### PR TITLE
Fix Apple Notes permission flow

### DIFF
--- a/desktop/macos/Desktop/Sources/AppleNotesReaderService.swift
+++ b/desktop/macos/Desktop/Sources/AppleNotesReaderService.swift
@@ -10,14 +10,38 @@ struct AppleNoteRecord: Identifiable, Sendable {
 
 enum AppleNotesReaderError: LocalizedError {
   case storeNotFound
-  case storeUnavailable
+  case authorizationDenied(path: String)
+  case invalidSelectedFolder(path: String)
+  case schemaUnavailable(path: String)
+  case storeReadFailed(path: String, reason: String)
 
   var errorDescription: String? {
     switch self {
     case .storeNotFound:
       return "Apple Notes data store not found."
-    case .storeUnavailable:
-      return "Apple Notes data store is unavailable."
+    case .authorizationDenied:
+      return "Omi needs permission to read Apple Notes. Select the Apple Notes folder or grant Full Disk Access, then try again."
+    case .invalidSelectedFolder:
+      return "Choose the Apple Notes folder named group.com.apple.notes."
+    case .schemaUnavailable:
+      return "Apple Notes data store could not be read because its database format was not recognized."
+    case .storeReadFailed(_, let reason):
+      return "Apple Notes data store could not be read: \(reason)"
+    }
+  }
+
+  var reasonCode: String {
+    switch self {
+    case .storeNotFound:
+      return "store_not_found"
+    case .authorizationDenied:
+      return "authorization_denied"
+    case .invalidSelectedFolder:
+      return "invalid_selected_folder"
+    case .schemaUnavailable:
+      return "schema_unavailable"
+    case .storeReadFailed:
+      return "store_read_failed"
     }
   }
 }
@@ -35,20 +59,115 @@ actor AppleNotesReaderService {
 
   private let selectedFolderDefaultsKey = "onboardingAppleNotesFolderPath"
 
-  func readRecentNotes(maxResults: Int = 40) async throws -> [AppleNoteRecord] {
-    guard let storeURL = locateNotesStoreURL() else {
-      throw AppleNotesReaderError.storeNotFound
-    }
-
-    var configuration = Configuration()
-    configuration.readonly = true
+  func readRecentNotes(maxResults: Int = 40, selectedFolderPath: String? = nil) async throws -> [AppleNoteRecord] {
+    let boundedMaxResults = min(max(maxResults, 0), 1_000)
+    let storeURL = try locateNotesStoreURL(selectedFolderPath: selectedFolderPath)
 
     do {
-      let dbQueue = try DatabaseQueue(path: storeURL.path, configuration: configuration)
-      return try await dbQueue.read { db in
-        let rows = try Row.fetchAll(
-          db,
-          sql: """
+      let dbQueue = try openReadOnlyStore(at: storeURL)
+      return try await fetchRecentNotes(from: dbQueue, maxResults: boundedMaxResults)
+    } catch let error as AppleNotesReaderError {
+      log("AppleNotesReaderService: Notes read failed code=\(error.reasonCode) path=\(storeURL.path)")
+      throw error
+    } catch {
+      let classified = Self.classifyReadError(error, path: storeURL.path)
+      log("AppleNotesReaderService: Notes read failed code=\(classified.reasonCode) path=\(storeURL.path): \(error)")
+      throw classified
+    }
+  }
+
+  func validateSelectedFolder(path: String, remember: Bool = true) async throws -> URL {
+    let folderURL = URL(fileURLWithPath: path)
+    let resolvedFolder = try Self.resolveSelectedFolder(folderURL)
+    let storeURL = try locateNotesStoreURL(selectedFolderPath: resolvedFolder.path)
+
+    do {
+      let dbQueue = try openReadOnlyStore(at: storeURL)
+      _ = try await countReadableNotes(from: dbQueue)
+      if remember {
+        rememberSelectedFolder(path: resolvedFolder.path)
+      }
+      log("AppleNotesReaderService: Validated selected Notes folder at \(resolvedFolder.path)")
+      return resolvedFolder
+    } catch let error as AppleNotesReaderError {
+      log("AppleNotesReaderService: Selected folder validation failed code=\(error.reasonCode) path=\(storeURL.path)")
+      throw error
+    } catch {
+      let classified = Self.classifyReadError(error, path: storeURL.path)
+      log("AppleNotesReaderService: Selected folder validation failed code=\(classified.reasonCode) path=\(storeURL.path): \(error)")
+      throw classified
+    }
+  }
+
+  nonisolated static func resolveSelectedFolder(
+    _ selectedURL: URL,
+    fileManager: FileManager = .default,
+    homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser
+  ) throws -> URL {
+    let groupContainersURL = homeDirectory
+      .appendingPathComponent("Library/Group Containers", isDirectory: true)
+
+    if selectedURL.path == groupContainersURL.path {
+      let inferredURL = groupContainersURL.appendingPathComponent("group.com.apple.notes", isDirectory: true)
+      guard fileManager.fileExists(atPath: inferredURL.path) else {
+        throw AppleNotesReaderError.invalidSelectedFolder(path: selectedURL.path)
+      }
+      return inferredURL
+    }
+
+    if selectedURL.lastPathComponent == "group.com.apple.notes" {
+      guard fileManager.fileExists(atPath: selectedURL.path) else {
+        throw AppleNotesReaderError.invalidSelectedFolder(path: selectedURL.path)
+      }
+      return selectedURL
+    }
+
+    let nestedURL = selectedURL.appendingPathComponent("group.com.apple.notes", isDirectory: true)
+    guard fileManager.fileExists(atPath: nestedURL.path) else {
+      throw AppleNotesReaderError.invalidSelectedFolder(path: selectedURL.path)
+    }
+    return nestedURL
+  }
+
+  nonisolated static func classifyReadError(_ error: Error, path: String) -> AppleNotesReaderError {
+    if let notesError = error as? AppleNotesReaderError {
+      return notesError
+    }
+
+    let message = String(describing: error)
+    let localized = error.localizedDescription
+    let combined = "\(message) \(localized)".lowercased()
+
+    if combined.contains("sqlite error 23")
+      || combined.contains("authorization denied")
+      || combined.contains("not authorized")
+      || combined.contains("operation not permitted")
+      || combined.contains("permission denied")
+    {
+      return .authorizationDenied(path: path)
+    }
+
+    if combined.contains("no such table")
+      || combined.contains("no such column")
+      || combined.contains("database disk image is malformed")
+    {
+      return .schemaUnavailable(path: path)
+    }
+
+    return .storeReadFailed(path: path, reason: localized)
+  }
+
+  private func openReadOnlyStore(at storeURL: URL) throws -> DatabaseQueue {
+    var configuration = Configuration()
+    configuration.readonly = true
+    return try DatabaseQueue(path: storeURL.path, configuration: configuration)
+  }
+
+  private func fetchRecentNotes(from dbQueue: DatabaseQueue, maxResults: Int) async throws -> [AppleNoteRecord] {
+    try await dbQueue.read { db in
+      let rows = try Row.fetchAll(
+        db,
+        sql: """
               SELECT
                 Z_PK,
                 ZTITLE,
@@ -61,39 +180,50 @@ actor AppleNotesReaderService {
               ORDER BY ZMODIFICATIONDATE DESC
               LIMIT ?
             """,
-          arguments: [maxResults * 3]
-        )
+        arguments: [maxResults * 3]
+      )
 
-        let notes = rows.compactMap { row -> AppleNoteRecord? in
-          guard let rawTitle = row["ZTITLE"] as? String else {
-            return nil
-          }
-
-          let id = (row["Z_PK"] as? Int64) ?? Int64(row["Z_PK"] as? Int ?? 0)
-          let modifiedAtValue =
-            (row["ZMODIFICATIONDATE"] as? Double)
-            ?? Double(row["ZMODIFICATIONDATE"] as? Int64 ?? 0)
-
-          let title = Self.normalizeNoteField(rawTitle)
-          let summary = Self.normalizeNoteField(row["ZSUMMARY"] as? String ?? "")
-
-          guard !title.isEmpty, !Self.isLikelyAttachment(title: title, summary: summary) else {
-            return nil
-          }
-
-          return AppleNoteRecord(
-            id: id,
-            title: title,
-            summary: summary,
-            modifiedAt: Date(timeIntervalSinceReferenceDate: modifiedAtValue)
-          )
+      let notes = rows.compactMap { row -> AppleNoteRecord? in
+        guard let rawTitle = row["ZTITLE"] as? String else {
+          return nil
         }
 
-        return Array(notes.prefix(maxResults))
+        let id = (row["Z_PK"] as? Int64) ?? Int64(row["Z_PK"] as? Int ?? 0)
+        let modifiedAtValue =
+          (row["ZMODIFICATIONDATE"] as? Double)
+          ?? Double(row["ZMODIFICATIONDATE"] as? Int64 ?? 0)
+
+        let title = Self.normalizeNoteField(rawTitle)
+        let summary = Self.normalizeNoteField(row["ZSUMMARY"] as? String ?? "")
+
+        guard !title.isEmpty, !Self.isLikelyAttachment(title: title, summary: summary) else {
+          return nil
+        }
+
+        return AppleNoteRecord(
+          id: id,
+          title: title,
+          summary: summary,
+          modifiedAt: Date(timeIntervalSinceReferenceDate: modifiedAtValue)
+        )
       }
-    } catch {
-      log("AppleNotesReaderService: Failed reading Notes store at \(storeURL.path): \(error)")
-      throw AppleNotesReaderError.storeUnavailable
+
+      return Array(notes.prefix(maxResults))
+    }
+  }
+
+  private func countReadableNotes(from dbQueue: DatabaseQueue) async throws -> Int {
+    try await dbQueue.read { db in
+      try Int.fetchOne(
+        db,
+        sql: """
+          SELECT COUNT(*)
+          FROM ZICCLOUDSYNCINGOBJECT
+          WHERE ZNOTE IS NOT NULL
+            AND ZMARKEDFORDELETION = 0
+            AND ZTITLE IS NOT NULL
+        """
+      ) ?? 0
     }
   }
 
@@ -234,13 +364,13 @@ actor AppleNotesReaderService {
     UserDefaults.standard.set(path, forKey: selectedFolderDefaultsKey)
   }
 
-  private func locateNotesStoreURL() -> URL? {
+  private func locateNotesStoreURL(selectedFolderPath: String? = nil) throws -> URL {
     let fm = FileManager.default
     let home = fm.homeDirectoryForCurrentUser
 
     var candidates: [URL] = []
 
-    if let selectedFolderPath = UserDefaults.standard.string(forKey: selectedFolderDefaultsKey),
+    if let selectedFolderPath = selectedFolderPath ?? UserDefaults.standard.string(forKey: selectedFolderDefaultsKey),
       !selectedFolderPath.isEmpty
     {
       let selectedFolderURL = URL(fileURLWithPath: selectedFolderPath)
@@ -262,6 +392,11 @@ actor AppleNotesReaderService {
           .appendingPathComponent("LocalAccount", isDirectory: true)
           .appendingPathComponent("NoteStore.sqlite", isDirectory: false)
       )
+
+      guard let storeURL = candidates.first(where: { fm.fileExists(atPath: $0.path) }) else {
+        throw AppleNotesReaderError.invalidSelectedFolder(path: selectedFolderPath)
+      }
+      return storeURL
     }
 
     candidates.append(
@@ -281,7 +416,10 @@ actor AppleNotesReaderService {
         .appendingPathComponent("NoteStore.sqlite", isDirectory: false)
     )
 
-    return candidates.first(where: { fm.fileExists(atPath: $0.path) })
+    guard let storeURL = candidates.first(where: { fm.fileExists(atPath: $0.path) }) else {
+      throw AppleNotesReaderError.storeNotFound
+    }
+    return storeURL
   }
 
   private static func normalizeNoteField(_ value: String) -> String {

--- a/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
+++ b/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
@@ -448,6 +448,53 @@ final class DesktopAutomationActionRegistry {
     }
 
     register(
+      name: "apple_notes_read_probe",
+      summary: "Probe Apple Notes access without importing or saving memories",
+      params: ["folderPath", "maxResults", "remember"]
+    ) { params in
+      let maxResults = min(max(intParam(params["maxResults"], default: 20), 1), 250)
+      let folderPath = params["folderPath"]?.trimmingCharacters(in: .whitespacesAndNewlines)
+      let remember = boolParam(params["remember"], default: false)
+
+      do {
+        let selectedFolderPath: String?
+        if let folderPath, !folderPath.isEmpty {
+          let resolved = try await AppleNotesReaderService.shared.validateSelectedFolder(
+            path: folderPath,
+            remember: remember
+          )
+          selectedFolderPath = resolved.path
+        } else {
+          selectedFolderPath = nil
+        }
+
+        let notes = try await AppleNotesReaderService.shared.readRecentNotes(
+          maxResults: maxResults,
+          selectedFolderPath: selectedFolderPath
+        )
+        return [
+          "ok": "true",
+          "classification": "readable",
+          "noteCount": "\(notes.count)",
+          "selectedFolderPath": selectedFolderPath ?? "",
+          "firstTitle": notes.first?.title ?? "",
+        ]
+      } catch let error as AppleNotesReaderError {
+        return [
+          "ok": "false",
+          "classification": error.reasonCode,
+          "message": error.localizedDescription,
+        ]
+      } catch {
+        return [
+          "ok": "false",
+          "classification": "unknown_error",
+          "message": error.localizedDescription,
+        ]
+      }
+    }
+
+    register(
       name: "delete_conversation",
       summary: "Delete conversation with cascade (API + conversationDeleted notification)",
       params: ["id"]

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/AppsPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/AppsPage.swift
@@ -658,7 +658,6 @@ final class ImportConnectorStatusStore: ObservableObject {
     private let lastDeltaCountKeyPrefix = "appsImportConnectorLastDeltaCount."
     private let hasLastDeltaKeyPrefix = "appsImportConnectorHasLastDelta."
     private let manualConnectorIDs: Set<String> = ["chatgpt", "claude"]
-    private let appleNotesFolderDefaultsKey = "onboardingAppleNotesFolderPath"
     private let onboardingChatGPTImportedMemoriesKey = "onboardingChatGPTImportedMemoriesCount"
     private let onboardingClaudeImportedMemoriesKey = "onboardingClaudeImportedMemoriesCount"
 
@@ -751,11 +750,8 @@ final class ImportConnectorStatusStore: ObservableObject {
 
         hydrateLegacyManualImports()
 
-        if let folderPath = defaults.string(forKey: appleNotesFolderDefaultsKey), !folderPath.isEmpty {
-            var metrics = metricsByID["apple-notes"] ?? ConnectorMetrics()
-            metrics.availabilityText = "Folder granted"
-            metricsByID["apple-notes"] = metrics
-        }
+        // A remembered path is not enough to call Apple Notes connected. The
+        // status becomes connected only after the reader proves the store is readable.
     }
 
     private func hydrateLegacyManualImports() {
@@ -808,18 +804,14 @@ final class ImportConnectorStatusStore: ObservableObject {
     private func refreshAppleNotesMetrics() async {
         do {
             let notes = try await AppleNotesReaderService.shared.readRecentNotes(maxResults: 250)
-            guard !notes.isEmpty else { return }
 
             var metrics = metricsByID["apple-notes"] ?? ConnectorMetrics()
             metrics.sourceCount = notes.count
             metrics.availabilityText = "Private notes accessible"
             metricsByID["apple-notes"] = metrics
         } catch {
-            let folderPath = defaults.string(forKey: appleNotesFolderDefaultsKey) ?? ""
-            guard !folderPath.isEmpty else { return }
-            var metrics = metricsByID["apple-notes"] ?? ConnectorMetrics()
-            metrics.availabilityText = "Folder granted"
-            metricsByID["apple-notes"] = metrics
+            let reason = (error as? AppleNotesReaderError)?.reasonCode ?? "unknown"
+            log("ImportConnectorStatusStore: Apple Notes refresh unavailable code=\(reason)")
         }
     }
 
@@ -1269,7 +1261,7 @@ private final class ImportConnectorSheetModel: ObservableObject {
             return try await runAppleNotesImport()
         } catch let error as AppleNotesReaderError {
             switch error {
-            case .storeNotFound, .storeUnavailable:
+            case .storeNotFound, .authorizationDenied, .invalidSelectedFolder, .schemaUnavailable, .storeReadFailed:
                 break
             }
             let granted = await selectAppleNotesFolder()
@@ -1357,29 +1349,17 @@ private final class ImportConnectorSheetModel: ObservableObject {
             return false
         }
 
-        let resolvedURL: URL
-        if selectedURL.path == groupContainersURL.path {
-            let inferredURL = groupContainersURL.appendingPathComponent("group.com.apple.notes", isDirectory: true)
-            guard fileManager.fileExists(atPath: inferredURL.path) else {
-                errorMessage = "Choose the Apple Notes folder inside Group Containers."
-                return false
-            }
-            resolvedURL = inferredURL
-        } else if selectedURL.lastPathComponent == "group.com.apple.notes" {
-            resolvedURL = selectedURL
-        } else {
-            let nestedURL = selectedURL.appendingPathComponent("group.com.apple.notes", isDirectory: true)
-            if fileManager.fileExists(atPath: nestedURL.path) {
-                resolvedURL = nestedURL
-            } else {
-                errorMessage = "Choose the Apple Notes folder named group.com.apple.notes."
-                return false
-            }
+        do {
+            _ = try await AppleNotesReaderService.shared.validateSelectedFolder(path: selectedURL.path)
+            errorMessage = nil
+            return true
+        } catch let error as AppleNotesReaderError {
+            errorMessage = error.localizedDescription
+            return false
+        } catch {
+            errorMessage = error.localizedDescription
+            return false
         }
-
-        errorMessage = nil
-        await AppleNotesReaderService.shared.rememberSelectedFolder(path: resolvedURL.path)
-        return true
     }
 
     private func currentIndexedFileCount() async -> Int {

--- a/desktop/macos/Desktop/Tests/AppleNotesReaderServiceTests.swift
+++ b/desktop/macos/Desktop/Tests/AppleNotesReaderServiceTests.swift
@@ -1,0 +1,141 @@
+import GRDB
+import XCTest
+
+@testable import Omi_Computer
+
+final class AppleNotesReaderServiceTests: XCTestCase {
+  func testClassifiesSqliteAuthorizationDeniedAsPermissionError() {
+    let error = NSError(
+      domain: "GRDB",
+      code: 23,
+      userInfo: [NSLocalizedDescriptionKey: "SQLite error 23: authorization denied"]
+    )
+
+    guard case .authorizationDenied(let path) = AppleNotesReaderService.classifyReadError(error, path: "/notes/NoteStore.sqlite") else {
+      return XCTFail("Expected authorizationDenied classification")
+    }
+    XCTAssertEqual(path, "/notes/NoteStore.sqlite")
+  }
+
+  func testResolveSelectedFolderAcceptsAndInfersNotesContainer() throws {
+    let root = try makeTemporaryDirectory()
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    let home = root.appendingPathComponent("home", isDirectory: true)
+    let groupContainers = home.appendingPathComponent("Library/Group Containers", isDirectory: true)
+    let notesContainer = groupContainers.appendingPathComponent("group.com.apple.notes", isDirectory: true)
+    try FileManager.default.createDirectory(at: notesContainer, withIntermediateDirectories: true)
+
+    XCTAssertEqual(
+      try AppleNotesReaderService.resolveSelectedFolder(groupContainers, homeDirectory: home).path,
+      notesContainer.path
+    )
+    XCTAssertEqual(
+      try AppleNotesReaderService.resolveSelectedFolder(notesContainer, homeDirectory: home).path,
+      notesContainer.path
+    )
+  }
+
+  func testResolveSelectedFolderRejectsUnrelatedFolder() throws {
+    let root = try makeTemporaryDirectory()
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    let unrelated = root.appendingPathComponent("Documents", isDirectory: true)
+    try FileManager.default.createDirectory(at: unrelated, withIntermediateDirectories: true)
+
+    XCTAssertThrowsError(try AppleNotesReaderService.resolveSelectedFolder(unrelated, homeDirectory: root)) { error in
+      guard case .invalidSelectedFolder(let path) = error as? AppleNotesReaderError else {
+        return XCTFail("Expected invalidSelectedFolder, got \(error)")
+      }
+      XCTAssertEqual(path, unrelated.path)
+    }
+  }
+
+  func testReadRecentNotesFromSelectedFolderFixture() async throws {
+    let root = try makeTemporaryDirectory()
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    let notesContainer = try makeNotesContainerFixture(in: root, withSchema: true)
+    let store = notesContainer.appendingPathComponent("NoteStore.sqlite")
+    let dbQueue = try DatabaseQueue(path: store.path)
+    try await dbQueue.write { db in
+      try db.execute(
+        sql: """
+          INSERT INTO ZICCLOUDSYNCINGOBJECT
+            (Z_PK, ZTITLE, ZSUMMARY, ZMODIFICATIONDATE, ZNOTE, ZMARKEDFORDELETION)
+          VALUES (?, ?, ?, ?, ?, ?)
+        """,
+        arguments: [1, "Launch checklist", "Ship Notes connector", 42.0, 1, 0]
+      )
+    }
+
+    let notes = try await AppleNotesReaderService.shared.readRecentNotes(
+      maxResults: 10,
+      selectedFolderPath: notesContainer.path
+    )
+
+    XCTAssertEqual(notes.count, 1)
+    XCTAssertEqual(notes.first?.title, "Launch checklist")
+    XCTAssertEqual(notes.first?.summary, "Ship Notes connector")
+  }
+
+  func testReadRecentNotesClampsNegativeLimit() async throws {
+    let root = try makeTemporaryDirectory()
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    let notesContainer = try makeNotesContainerFixture(in: root, withSchema: true)
+
+    let notes = try await AppleNotesReaderService.shared.readRecentNotes(
+      maxResults: -1,
+      selectedFolderPath: notesContainer.path
+    )
+
+    XCTAssertTrue(notes.isEmpty)
+  }
+
+  func testValidateSelectedFolderClassifiesSchemaFailure() async throws {
+    let root = try makeTemporaryDirectory()
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    let notesContainer = try makeNotesContainerFixture(in: root, withSchema: false)
+    _ = try DatabaseQueue(path: notesContainer.appendingPathComponent("NoteStore.sqlite").path)
+
+    do {
+      _ = try await AppleNotesReaderService.shared.validateSelectedFolder(path: notesContainer.path, remember: false)
+      XCTFail("Expected schema validation to fail")
+    } catch let error as AppleNotesReaderError {
+      XCTAssertEqual(error.reasonCode, "schema_unavailable")
+    }
+  }
+
+  private func makeNotesContainerFixture(in root: URL, withSchema: Bool) throws -> URL {
+    let notesContainer = root.appendingPathComponent("group.com.apple.notes", isDirectory: true)
+    try FileManager.default.createDirectory(at: notesContainer, withIntermediateDirectories: true)
+    let store = notesContainer.appendingPathComponent("NoteStore.sqlite")
+    let dbQueue = try DatabaseQueue(path: store.path)
+    if withSchema {
+      try dbQueue.write { db in
+        try db.execute(
+          sql: """
+            CREATE TABLE ZICCLOUDSYNCINGOBJECT (
+              Z_PK INTEGER PRIMARY KEY,
+              ZTITLE TEXT,
+              ZSUMMARY TEXT,
+              ZMODIFICATIONDATE REAL,
+              ZNOTE INTEGER,
+              ZMARKEDFORDELETION INTEGER
+            )
+          """
+        )
+      }
+    }
+    return notesContainer
+  }
+
+  private func makeTemporaryDirectory() throws -> URL {
+    let url = FileManager.default.temporaryDirectory
+      .appendingPathComponent("AppleNotesReaderServiceTests-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+    return url
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260701-apple-notes-permission-flow.json
+++ b/desktop/macos/changelog/unreleased/20260701-apple-notes-permission-flow.json
@@ -1,0 +1,3 @@
+{
+  "change": "Apple Notes import now reports actionable permission and folder errors instead of a generic unavailable state"
+}


### PR DESCRIPTION
## Summary
- classify Apple Notes store access failures into actionable states and validate selected folders before saving them
- stop treating a remembered Apple Notes folder path as connected until readability is proven
- add an `apple_notes_read_probe` automation action plus focused reader tests for selected folders, permission errors, schema errors, and limit clamping

## Verification
- `xcrun swift test --package-path desktop/macos/Desktop --filter AppleNotesReaderServiceTests`
- named bundle `/Applications/omi-apple-notes-auth.app` (`com.omi.omi-apple-notes-auth`) on automation port 47998:
  - fixture probe returned `classification=readable`, `noteCount=1`, `firstTitle=Agent verification note`
  - negative `maxResults=-7` probe returned readable via clamped limit
  - invalid folder `/tmp` returned `classification=invalid_selected_folder`
- subagent review approved with no blockers after the zero-note status and negative-limit findings were fixed


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8807?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

