### PR TITLE
[codex] Fix Apple Notes connector status

### DIFF
--- a/desktop/macos/Desktop/Sources/AppleNotesReaderService.swift
+++ b/desktop/macos/Desktop/Sources/AppleNotesReaderService.swift
@@ -44,6 +44,48 @@ enum AppleNotesReaderError: LocalizedError {
       return "store_read_failed"
     }
   }
+
+  var shouldPromptForFolderSelection: Bool {
+    switch self {
+    case .storeNotFound, .authorizationDenied, .invalidSelectedFolder:
+      return true
+    case .schemaUnavailable, .storeReadFailed:
+      return false
+    }
+  }
+}
+
+enum AppleNotesConnectionStatus: Equatable {
+  case connected(noteCount: Int, verifiedAt: Date)
+  case needsAccess(message: String, reasonCode: String)
+  case error(message: String, reasonCode: String)
+
+  var isConnected: Bool {
+    if case .connected = self { return true }
+    return false
+  }
+}
+
+enum AppleNotesReadOutcome: Equatable {
+  case readable(noteCount: Int)
+  case needsAccess(message: String, reasonCode: String)
+  case error(message: String, reasonCode: String)
+
+  static func classify(noteCount: Int?, error: AppleNotesReaderError?) -> AppleNotesReadOutcome {
+    if let noteCount {
+      return .readable(noteCount: noteCount)
+    }
+
+    guard let error else {
+      return .error(message: "Apple Notes data store could not be read.", reasonCode: "unknown")
+    }
+
+    let message = error.localizedDescription
+    if error.shouldPromptForFolderSelection {
+      return .needsAccess(message: message, reasonCode: error.reasonCode)
+    }
+    return .error(message: message, reasonCode: error.reasonCode)
+  }
 }
 
 actor AppleNotesReaderService {
@@ -73,6 +115,26 @@ actor AppleNotesReaderService {
       let classified = Self.classifyReadError(error, path: storeURL.path)
       log("AppleNotesReaderService: Notes read failed code=\(classified.reasonCode) path=\(storeURL.path): \(error)")
       throw classified
+    }
+  }
+
+  func connectionStatus(maxResults: Int = 1, selectedFolderPath: String? = nil) async -> AppleNotesConnectionStatus {
+    do {
+      let notes = try await readRecentNotes(maxResults: maxResults, selectedFolderPath: selectedFolderPath)
+      return .connected(noteCount: notes.count, verifiedAt: Date())
+    } catch let error as AppleNotesReaderError {
+      let outcome = Self.classifyReadOutcome(noteCount: nil, error: error)
+      switch outcome {
+      case .readable(let noteCount):
+        return .connected(noteCount: noteCount, verifiedAt: Date())
+      case .needsAccess(let message, let reasonCode):
+        return .needsAccess(message: message, reasonCode: reasonCode)
+      case .error(let message, let reasonCode):
+        return .error(message: message, reasonCode: reasonCode)
+      }
+    } catch {
+      let classified = Self.classifyReadError(error, path: selectedFolderPath ?? "")
+      return .error(message: classified.localizedDescription, reasonCode: classified.reasonCode)
     }
   }
 
@@ -155,6 +217,10 @@ actor AppleNotesReaderService {
     }
 
     return .storeReadFailed(path: path, reason: localized)
+  }
+
+  nonisolated static func classifyReadOutcome(noteCount: Int?, error: AppleNotesReaderError?) -> AppleNotesReadOutcome {
+    AppleNotesReadOutcome.classify(noteCount: noteCount, error: error)
   }
 
   private func openReadOnlyStore(at storeURL: URL) throws -> DatabaseQueue {
@@ -376,15 +442,19 @@ actor AppleNotesReaderService {
       let selectedFolderURL = URL(fileURLWithPath: selectedFolderPath)
       if selectedFolderURL.lastPathComponent == "NoteStore.sqlite" {
         candidates.append(selectedFolderURL)
+      } else if let resolvedFolder = try? Self.resolveSelectedFolder(selectedFolderURL, fileManager: fm, homeDirectory: home) {
+        candidates.append(
+          resolvedFolder.appendingPathComponent("NoteStore.sqlite", isDirectory: false)
+        )
+        candidates.append(
+          resolvedFolder
+            .appendingPathComponent("Accounts", isDirectory: true)
+            .appendingPathComponent("LocalAccount", isDirectory: true)
+            .appendingPathComponent("NoteStore.sqlite", isDirectory: false)
+        )
       }
       candidates.append(
         selectedFolderURL.appendingPathComponent("NoteStore.sqlite", isDirectory: false)
-      )
-      candidates.append(
-        selectedFolderURL.appendingPathComponent(
-          "NoteStore.sqlite-wal",
-          isDirectory: false
-        ).deletingLastPathComponent().appendingPathComponent("NoteStore.sqlite")
       )
       candidates.append(
         selectedFolderURL

--- a/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
+++ b/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
@@ -468,22 +468,44 @@ final class DesktopAutomationActionRegistry {
           selectedFolderPath = nil
         }
 
-        let notes = try await AppleNotesReaderService.shared.readRecentNotes(
+        let status = await AppleNotesReaderService.shared.connectionStatus(
           maxResults: maxResults,
           selectedFolderPath: selectedFolderPath
         )
-        return [
-          "ok": "true",
-          "classification": "readable",
-          "noteCount": "\(notes.count)",
-          "selectedFolderPath": selectedFolderPath ?? "",
-          "firstTitle": notes.first?.title ?? "",
-        ]
+        switch status {
+        case .connected(let noteCount, _):
+          let notes = try await AppleNotesReaderService.shared.readRecentNotes(
+            maxResults: 1,
+            selectedFolderPath: selectedFolderPath
+          )
+          return [
+            "ok": "true",
+            "classification": "readable",
+            "noteCount": "\(noteCount)",
+            "selectedFolderPath": selectedFolderPath ?? "",
+            "firstTitle": notes.first?.title ?? "",
+          ]
+        case .needsAccess(let message, let reasonCode):
+          return [
+            "ok": "false",
+            "classification": reasonCode,
+            "message": message,
+            "needsFolderSelection": "true",
+          ]
+        case .error(let message, let reasonCode):
+          return [
+            "ok": "false",
+            "classification": reasonCode,
+            "message": message,
+            "needsFolderSelection": "false",
+          ]
+        }
       } catch let error as AppleNotesReaderError {
         return [
           "ok": "false",
           "classification": error.reasonCode,
           "message": error.localizedDescription,
+          "needsFolderSelection": "\(error.shouldPromptForFolderSelection)",
         ]
       } catch {
         return [

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/AppsPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/AppsPage.swift
@@ -802,16 +802,15 @@ final class ImportConnectorStatusStore: ObservableObject {
     }
 
     private func refreshAppleNotesMetrics() async {
-        do {
-            let notes = try await AppleNotesReaderService.shared.readRecentNotes(maxResults: 250)
-
+        let status = await AppleNotesReaderService.shared.connectionStatus(maxResults: 250)
+        switch status {
+        case .connected(let noteCount, _):
             var metrics = metricsByID["apple-notes"] ?? ConnectorMetrics()
-            metrics.sourceCount = notes.count
+            metrics.sourceCount = noteCount
             metrics.availabilityText = "Private notes accessible"
             metricsByID["apple-notes"] = metrics
-        } catch {
-            let reason = (error as? AppleNotesReaderError)?.reasonCode ?? "unknown"
-            log("ImportConnectorStatusStore: Apple Notes refresh unavailable code=\(reason)")
+        case .needsAccess(_, let reasonCode), .error(_, let reasonCode):
+            log("ImportConnectorStatusStore: Apple Notes refresh unavailable code=\(reasonCode)")
         }
     }
 
@@ -1260,9 +1259,9 @@ private final class ImportConnectorSheetModel: ObservableObject {
         do {
             return try await runAppleNotesImport()
         } catch let error as AppleNotesReaderError {
-            switch error {
-            case .storeNotFound, .authorizationDenied, .invalidSelectedFolder, .schemaUnavailable, .storeReadFailed:
-                break
+            guard error.shouldPromptForFolderSelection else {
+                errorMessage = error.localizedDescription
+                return nil
             }
             let granted = await selectAppleNotesFolder()
             guard granted else {

--- a/desktop/macos/Desktop/Tests/AppleNotesReaderServiceTests.swift
+++ b/desktop/macos/Desktop/Tests/AppleNotesReaderServiceTests.swift
@@ -36,6 +36,34 @@ final class AppleNotesReaderServiceTests: XCTestCase {
     )
   }
 
+  func testReadRecentNotesResolvesLegacyGroupContainersSelection() async throws {
+    let root = try makeTemporaryDirectory()
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    let groupContainers = root.appendingPathComponent("Library/Group Containers", isDirectory: true)
+    let notesContainer = try makeNotesContainerFixture(in: groupContainers, withSchema: true)
+    let store = notesContainer.appendingPathComponent("NoteStore.sqlite")
+    let dbQueue = try DatabaseQueue(path: store.path)
+    try await dbQueue.write { db in
+      try db.execute(
+        sql: """
+          INSERT INTO ZICCLOUDSYNCINGOBJECT
+            (Z_PK, ZTITLE, ZSUMMARY, ZMODIFICATIONDATE, ZNOTE, ZMARKEDFORDELETION)
+          VALUES (?, ?, ?, ?, ?, ?)
+        """,
+        arguments: [1, "Legacy folder import", "Parent folder still works", 42.0, 1, 0]
+      )
+    }
+
+    let notes = try await AppleNotesReaderService.shared.readRecentNotes(
+      maxResults: 10,
+      selectedFolderPath: groupContainers.path
+    )
+
+    XCTAssertEqual(notes.count, 1)
+    XCTAssertEqual(notes.first?.title, "Legacy folder import")
+  }
+
   func testResolveSelectedFolderRejectsUnrelatedFolder() throws {
     let root = try makeTemporaryDirectory()
     defer { try? FileManager.default.removeItem(at: root) }
@@ -93,6 +121,23 @@ final class AppleNotesReaderServiceTests: XCTestCase {
     XCTAssertTrue(notes.isEmpty)
   }
 
+  func testConnectionStatusTreatsZeroNotesAsReadable() async throws {
+    let root = try makeTemporaryDirectory()
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    let notesContainer = try makeNotesContainerFixture(in: root, withSchema: true)
+    let status = await AppleNotesReaderService.shared.connectionStatus(
+      maxResults: 10,
+      selectedFolderPath: notesContainer.path
+    )
+
+    guard case .connected(let noteCount, _) = status else {
+      return XCTFail("Expected connected status, got \(status)")
+    }
+    XCTAssertEqual(noteCount, 0)
+    XCTAssertTrue(status.isConnected)
+  }
+
   func testValidateSelectedFolderClassifiesSchemaFailure() async throws {
     let root = try makeTemporaryDirectory()
     defer { try? FileManager.default.removeItem(at: root) }
@@ -106,6 +151,63 @@ final class AppleNotesReaderServiceTests: XCTestCase {
     } catch let error as AppleNotesReaderError {
       XCTAssertEqual(error.reasonCode, "schema_unavailable")
     }
+  }
+
+  func testReadOutcomeClassifiesPathFailuresAsNeedsAccess() {
+    let outcome = AppleNotesReaderService.classifyReadOutcome(
+      noteCount: nil,
+      error: .invalidSelectedFolder(path: "/tmp/wrong")
+    )
+
+    XCTAssertEqual(
+      outcome,
+      .needsAccess(
+        message: "Choose the Apple Notes folder named group.com.apple.notes.",
+        reasonCode: "invalid_selected_folder"
+      )
+    )
+  }
+
+  func testReadOutcomeClassifiesSchemaAndReadFailuresAsErrors() {
+    XCTAssertEqual(
+      AppleNotesReaderService.classifyReadOutcome(
+        noteCount: nil,
+        error: .schemaUnavailable(path: "/notes/NoteStore.sqlite")
+      ),
+      .error(
+        message: "Apple Notes data store could not be read because its database format was not recognized.",
+        reasonCode: "schema_unavailable"
+      )
+    )
+
+    XCTAssertEqual(
+      AppleNotesReaderService.classifyReadOutcome(
+        noteCount: nil,
+        error: .storeReadFailed(path: "/notes/NoteStore.sqlite", reason: "disk I/O error")
+      ),
+      .error(
+        message: "Apple Notes data store could not be read: disk I/O error",
+        reasonCode: "store_read_failed"
+      )
+    )
+  }
+
+  func testConnectionStatusSurfacesSchemaFailureAsError() async throws {
+    let root = try makeTemporaryDirectory()
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    let notesContainer = try makeNotesContainerFixture(in: root, withSchema: false)
+    _ = try DatabaseQueue(path: notesContainer.appendingPathComponent("NoteStore.sqlite").path)
+    let status = await AppleNotesReaderService.shared.connectionStatus(
+      maxResults: 10,
+      selectedFolderPath: notesContainer.path
+    )
+
+    guard case .error(let message, let reasonCode) = status else {
+      return XCTFail("Expected error status, got \(status)")
+    }
+    XCTAssertEqual(reasonCode, "schema_unavailable")
+    XCTAssertTrue(message.contains("database format was not recognized"))
   }
 
   private func makeNotesContainerFixture(in root: URL, withSchema: Bool) throws -> URL {

--- a/desktop/macos/changelog/unreleased/20260702-apple-notes-connection-status.json
+++ b/desktop/macos/changelog/unreleased/20260702-apple-notes-connection-status.json
@@ -1,0 +1,3 @@
+{
+  "change": "Improved Apple Notes connection checks so existing folder access keeps working and database read errors show the right recovery message"
+}

--- a/desktop/macos/docs/connector-checklist.md
+++ b/desktop/macos/docs/connector-checklist.md
@@ -49,6 +49,15 @@ Work top to bottom. Don't skip the probe or the fixture test.
       (philosophy §3, §4)
 - [ ] Drive UI status and any "Connected" badge off this probe, never off a
       stored one-time-success latch.
+- [ ] For file-backed local connectors such as Apple Notes, preserve legacy
+      selected parent folders by resolving them through the same canonical
+      folder logic used for new selections. Treat zero readable items as
+      connected, and keep path/access failures separate from schema/read
+      failures so the UI only reopens folder selection when a new folder can
+      actually fix the problem.
+- [ ] Expose a semantic automation probe (for example
+      `apple_notes_read_probe`) that returns the same stable classifications the
+      UI uses, including whether folder selection is an appropriate recovery.
 
 ## 6. Sanitized diagnostics for the corpus
 


### PR DESCRIPTION
## Summary
- add explicit Apple Notes connection status and pure read-outcome classification
- preserve legacy saved parent-folder selections by resolving them through the canonical Notes folder path
- keep schema/read failures out of the folder picker loop and return stable automation classifications
- add focused fixture tests, connector checklist guidance, and a desktop changelog fragment

Fixes #8811

## Verification
- xcrun swift test --package-path Desktop --filter AppleNotesReaderServiceTests
- attempted named bundle smoke: OMI_APP_NAME=omi-apple-notes-status OMI_AUTOMATION_PORT=47881 ./run.sh --yolo; build/bundle reached signing, but local machine has 0 valid codesigning identities, so the repo signing guard blocked launch to avoid ad-hoc permission resets

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8812?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

