### PR TITLE
Fix required promotion memory follow-ups

### DIFF
--- a/backend/tests/unit/test_developer_memory_adapter.py
+++ b/backend/tests/unit/test_developer_memory_adapter.py
@@ -88,9 +88,7 @@ def test_developer_route_wires_adapter_before_legacy_memory_reads():
 
 
 def test_developer_vector_route_wires_app_key_scope_grant_before_memory_vector_reads():
-    developer_py = Path(__file__).resolve().parents[2] / 'routers' / 'developer.py'
-    contents = developer_py.read_text(encoding='utf-8')
-    route = '@router.get("/v1/dev/user/memories/vector/search", tags=["developer"])'
+    route_source = _function_source_for_route('/v1/dev/user/memories/vector/search', 'get')
     auth_context_dependency = (
         'auth_context: ProductAuthorizationContext = Depends(get_developer_memory_default_memory_read_context)'
     )
@@ -100,23 +98,17 @@ def test_developer_vector_route_wires_app_key_scope_grant_before_memory_vector_r
     rollout_call = "read_default_read_rollout(uid=uid, db_client=db, consumer='developer_api')"
     vector_adapter_call = 'search_memory_default_developer_memories_vector('
     vector_side_effect = 'fetch_default_vector_memory_search('
-    assert route in contents
-    assert auth_context_dependency in contents
-    assert app_key_grant_call in contents
-    assert vector_adapter_call in contents
+    assert auth_context_dependency in route_source
+    assert app_key_grant_call in route_source
+    assert vector_adapter_call in route_source
+    assert vector_side_effect not in route_source[: route_source.index(vector_adapter_call)]
     assert (
-        vector_side_effect
-        not in contents[contents.index(route) : contents.index(vector_adapter_call, contents.index(route))]
-    )
-    route_index = contents.index(route)
-    assert (
-        route_index
-        < contents.index(auth_context_dependency, route_index)
-        < contents.index(uid_from_context, route_index)
-        < contents.index(app_key_grant_call, route_index)
-        < contents.index(app_key_deny_check, route_index)
-        < contents.index(rollout_call, route_index)
-        < contents.index(vector_adapter_call, route_index)
+        route_source.index(auth_context_dependency)
+        < route_source.index(uid_from_context)
+        < route_source.index(app_key_grant_call)
+        < route_source.index(app_key_deny_check)
+        < route_source.index(rollout_call)
+        < route_source.index(vector_adapter_call)
     )
 
 
@@ -200,9 +192,8 @@ def test_developer_routes_only_reach_legacy_after_explicit_legacy_safe_decision(
     assert legacy_safe_check in contents
     assert legacy_call in contents
     assert contents.index(denied_check) < contents.index(legacy_safe_check) < contents.index(legacy_call)
-    route = '@router.get("/v1/dev/user/memories/vector/search", tags=["developer"])'
-    route_index = contents.index(route)
-    assert contents.index(denied_check, route_index) < contents.index(legacy_safe_check, route_index)
+    vector_route_source = _function_source_for_route('/v1/dev/user/memories/vector/search', 'get')
+    assert vector_route_source.index(denied_check) < vector_route_source.index(legacy_safe_check)
 
 
 def test_developer_category_filters_do_not_force_legacy_when_memory_can_decide_safely():

--- a/backend/tests/unit/test_ws_b_short_term_lifecycle.py
+++ b/backend/tests/unit/test_ws_b_short_term_lifecycle.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 import sys
+import importlib
 from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock
 
@@ -22,35 +23,89 @@ from tests.unit.memory_import_isolation import (
     snapshot_sys_modules,
 )
 
+read_canonical_memories = None
+write_canonical_extraction_memory = None
+required_promotion_payload = None
+MemorySystem = None
+resolve_memory_system = None
+CanonicalKgPromotionResult = None
+DEFAULT_PROMOTION_BATCH_THRESHOLD = None
+promotion_batch_threshold = None
+promotion_trigger_reason = None
+run_canonical_short_term_promotion = None
+run_canonical_short_term_ttl_lifecycle = None
+
+
+def _load_ws_b_runtime_modules() -> None:
+    if write_canonical_extraction_memory is not None:
+        return
+    ensure_utils_memory_packages_importable()
+    canonical_adapter = importlib.import_module("utils.memory.canonical_memory_adapter")
+    short_term_promotion = importlib.import_module("utils.memory.short_term_promotion")
+    required_promotion = importlib.import_module("utils.memory.required_promotion")
+    memory_system = importlib.import_module("utils.memory.memory_system")
+    canonical_kg_promotion = importlib.import_module("utils.memory.canonical_kg_promotion")
+
+    g = globals()
+    g["read_canonical_memories"] = canonical_adapter.read_canonical_memories
+    g["write_canonical_extraction_memory"] = canonical_adapter.write_canonical_extraction_memory
+    g["required_promotion_payload"] = required_promotion.required_promotion_payload
+    g["MemorySystem"] = memory_system.MemorySystem
+    g["resolve_memory_system"] = memory_system.resolve_memory_system
+    g["CanonicalKgPromotionResult"] = canonical_kg_promotion.CanonicalKgPromotionResult
+    g["DEFAULT_PROMOTION_BATCH_THRESHOLD"] = short_term_promotion.DEFAULT_PROMOTION_BATCH_THRESHOLD
+    g["promotion_batch_threshold"] = short_term_promotion.promotion_batch_threshold
+    g["promotion_trigger_reason"] = short_term_promotion.promotion_trigger_reason
+    g["run_canonical_short_term_promotion"] = short_term_promotion.run_canonical_short_term_promotion
+    g["run_canonical_short_term_ttl_lifecycle"] = short_term_promotion.run_canonical_short_term_ttl_lifecycle
+
+
+def _clear_ws_b_runtime_modules() -> None:
+    g = globals()
+    for name in (
+        "read_canonical_memories",
+        "write_canonical_extraction_memory",
+        "required_promotion_payload",
+        "MemorySystem",
+        "resolve_memory_system",
+        "CanonicalKgPromotionResult",
+        "DEFAULT_PROMOTION_BATCH_THRESHOLD",
+        "promotion_batch_threshold",
+        "promotion_trigger_reason",
+        "run_canonical_short_term_promotion",
+        "run_canonical_short_term_ttl_lifecycle",
+    ):
+        g[name] = None
+
 
 @pytest.fixture(scope="module", autouse=True)
 def _ws_b_import_isolation():
     saved = snapshot_sys_modules(WS_B_STUB_MODULE_NAMES)
     touched = install_ws_b_import_stubs()
     saved.update(snapshot_sys_modules(touched))
+    ensure_utils_memory_packages_importable()
+
+    for stale_module in (
+        "database.memory_apply_store",
+        "utils.memory.canonical_memory_adapter",
+        "utils.memory.short_term_promotion",
+        "utils.memory.required_promotion",
+        "utils.memory.memory_system",
+        "utils.memory.canonical_kg_promotion",
+    ):
+        sys.modules.pop(stale_module, None)
+
+    _load_ws_b_runtime_modules()
+
     yield
     restore_sys_modules(saved)
+    _clear_ws_b_runtime_modules()
 
 
-ensure_utils_memory_packages_importable()
 from models.memory_domain import MemoryLayer, MemoryProcessingState, MemoryRecordStatus
 from models.memory_evidence import ArtifactPreservationState, MemoryEvidence, SourceState
 from models.memory_apply import MemoryControlState
 from models.product_memory import MemoryItemStatus, MemoryTier, ProcessingState, MemoryItem
-from utils.memory.canonical_memory_adapter import (
-    read_canonical_memories,
-    write_canonical_extraction_memory,
-)
-from utils.memory.required_promotion import required_promotion_payload
-from utils.memory.memory_system import MemorySystem, resolve_memory_system
-from utils.memory.canonical_kg_promotion import CanonicalKgPromotionResult
-from utils.memory.short_term_promotion import (
-    DEFAULT_PROMOTION_BATCH_THRESHOLD,
-    promotion_batch_threshold,
-    promotion_trigger_reason,
-    run_canonical_short_term_promotion,
-    run_canonical_short_term_ttl_lifecycle,
-)
 from tests.unit.test_ws_i_write_convergence import (
     _FakeDb,
     _sample_memory_payload,
@@ -180,6 +235,7 @@ def _seed_canonical_short_term(
     content: str,
     monkeypatch,
 ) -> str:
+    _load_ws_b_runtime_modules()
     evidence_id = f"ev_{conversation_id}"
     db.docs[f"users/{uid}/memory_evidence/{evidence_id}"] = MemoryEvidence(
         evidence_id=evidence_id,
@@ -514,6 +570,8 @@ def test_required_promotion_merges_exact_existing_long_term(monkeypatch):
         source_surface="mcp",
     )
     short_id = write_canonical_extraction_memory(uid, required_payload, db_client=db)
+    initial_existing_commit = db.docs[f"users/{uid}/memory_items/{existing_id}"]["ledger_commit_id"]
+    initial_short_commit = db.docs[f"users/{uid}/memory_items/{short_id}"]["ledger_commit_id"]
 
     report = run_canonical_short_term_promotion(uid, db_client=db, now=NOW, run_id="promo-required-merge")
     existing_stored = db.docs[f"users/{uid}/memory_items/{existing_id}"]
@@ -523,9 +581,11 @@ def test_required_promotion_merges_exact_existing_long_term(monkeypatch):
     assert report.promoted_memory_ids == [existing_id]
     assert existing_stored["tier"] == MemoryTier.long_term.value
     assert existing_stored["corroboration_count"] == 1
+    assert existing_stored["ledger_commit_id"] != initial_existing_commit
     assert short_stored["tier"] == MemoryTier.short_term.value
     assert short_stored["status"] == MemoryItemStatus.superseded.value
     assert short_stored["superseded_by"] == existing_id
+    assert short_stored["ledger_commit_id"] != initial_short_commit
     assert short_stored["promotion"]["status"] == "merged"
     assert short_stored["promotion"]["target_memory_id"] == existing_id
 

--- a/backend/tests/unit/test_ws_b_short_term_lifecycle.py
+++ b/backend/tests/unit/test_ws_b_short_term_lifecycle.py
@@ -6,7 +6,7 @@ import os
 import sys
 import importlib
 from datetime import datetime, timedelta, timezone
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -588,6 +588,121 @@ def test_required_promotion_merges_exact_existing_long_term(monkeypatch):
     assert short_stored["ledger_commit_id"] != initial_short_commit
     assert short_stored["promotion"]["status"] == "merged"
     assert short_stored["promotion"]["target_memory_id"] == existing_id
+
+
+def test_required_promotion_merges_multiple_sources_in_same_run(monkeypatch):
+    uid = "uid-canonical-required-merge-multiple"
+    _set_canonical_cohort(monkeypatch, uid)
+    db = _canonical_db_with_control(uid)
+    monkeypatch.setattr(
+        "utils.memory.canonical_memory_adapter.read_memory_v3_trusted_account_generation",
+        lambda **_: _trusted_account_generation(),
+    )
+    monkeypatch.setattr("utils.memory.short_term_promotion.sync_canonical_memory_vector", lambda *_, **__: None)
+
+    existing_id = write_canonical_extraction_memory(
+        uid,
+        {
+            "id": "existing-long-term-multi",
+            "content": "User prefers launch checklists",
+            "memory_tier": MemoryTier.long_term.value,
+        },
+        db_client=db,
+    )
+    short_ids = []
+    for source_id in ["manual-required-multi-a", "manual-required-multi-b"]:
+        payload = required_promotion_payload(
+            {
+                "id": source_id,
+                "content": "User prefers launch checklists",
+                "manually_added": True,
+            },
+            source_surface="mcp",
+        )
+        short_ids.append(write_canonical_extraction_memory(uid, payload, db_client=db))
+
+    report = run_canonical_short_term_promotion(uid, db_client=db, now=NOW, run_id="promo-required-multi")
+    existing_stored = db.docs[f"users/{uid}/memory_items/{existing_id}"]
+
+    assert report.trigger_reason == "required_promotion"
+    assert report.promoted_memory_ids == [existing_id, existing_id]
+    assert existing_stored["corroboration_count"] == 2
+    for short_id in short_ids:
+        short_stored = db.docs[f"users/{uid}/memory_items/{short_id}"]
+        assert short_stored["status"] == MemoryItemStatus.superseded.value
+        assert short_stored["promotion"]["status"] == "merged"
+        assert short_stored["promotion"]["target_memory_id"] == existing_id
+
+
+def test_required_promotion_retry_after_supersede_failure_is_idempotent_across_run_ids(monkeypatch):
+    uid = "uid-canonical-required-merge-retry"
+    _set_canonical_cohort(monkeypatch, uid)
+    db = _canonical_db_with_control(uid)
+    monkeypatch.setattr(
+        "utils.memory.canonical_memory_adapter.read_memory_v3_trusted_account_generation",
+        lambda **_: _trusted_account_generation(),
+    )
+    monkeypatch.setattr("utils.memory.short_term_promotion.sync_canonical_memory_vector", lambda *_, **__: None)
+
+    existing_id = write_canonical_extraction_memory(
+        uid,
+        {
+            "id": "existing-long-term-retry",
+            "content": "User prefers launch checklists",
+            "memory_tier": MemoryTier.long_term.value,
+        },
+        db_client=db,
+    )
+    required_payload = required_promotion_payload(
+        {
+            "id": "manual-required-retry",
+            "content": "User prefers launch checklists",
+            "manually_added": True,
+        },
+        source_surface="mcp",
+    )
+    short_id = write_canonical_extraction_memory(uid, required_payload, db_client=db)
+
+    import utils.memory.short_term_promotion as short_term_promotion_mod
+
+    real_apply = short_term_promotion_mod.apply_long_term_patch_firestore
+    failed_once = False
+
+    def flaky_apply(**kwargs):
+        nonlocal failed_once
+        patch_payload = kwargs.get("patch_payload") or {}
+        if (
+            not failed_once
+            and patch_payload.get("target_memory_id") == short_id
+            and patch_payload.get("result_status") == "superseded"
+        ):
+            failed_once = True
+            raise RuntimeError("injected supersede failure")
+        return real_apply(**kwargs)
+
+    with patch("utils.memory.short_term_promotion.apply_long_term_patch_firestore", side_effect=flaky_apply):
+        with pytest.raises(RuntimeError, match="injected supersede failure"):
+            run_canonical_short_term_promotion(uid, db_client=db, now=NOW, run_id="promo-required-retry-1")
+
+    existing_after_failure = db.docs[f"users/{uid}/memory_items/{existing_id}"]
+    short_after_failure = db.docs[f"users/{uid}/memory_items/{short_id}"]
+    assert existing_after_failure["corroboration_count"] == 1
+    assert short_after_failure["status"] == MemoryItemStatus.active.value
+
+    retry = run_canonical_short_term_promotion(
+        uid,
+        db_client=db,
+        now=NOW + timedelta(hours=1),
+        run_id="promo-required-retry-2",
+    )
+    existing_after_retry = db.docs[f"users/{uid}/memory_items/{existing_id}"]
+    short_after_retry = db.docs[f"users/{uid}/memory_items/{short_id}"]
+
+    assert retry.promoted_memory_ids == [existing_id]
+    assert existing_after_retry["corroboration_count"] == 1
+    assert existing_after_retry["ledger_commit_id"] == existing_after_failure["ledger_commit_id"]
+    assert short_after_retry["status"] == MemoryItemStatus.superseded.value
+    assert short_after_retry["promotion"]["status"] == "merged"
 
 
 def test_promotion_daily_cadence_applies_after_first_successful_run(monkeypatch):

--- a/backend/utils/memory/short_term_promotion.py
+++ b/backend/utils/memory/short_term_promotion.py
@@ -163,22 +163,70 @@ def _merge_required_promotion_duplicate(
     item: MemoryItem,
     existing: MemoryItem,
     *,
+    control: MemoryControlState,
+    run_id: str,
     trigger_reason: str,
     now: datetime,
     db_client,
 ) -> tuple[MemoryItem, bool]:
-    collections = MemoryCollections(uid=uid)
     evidence_by_id = {evidence.evidence_id: evidence for evidence in existing.evidence}
     for evidence in item.evidence:
         evidence_by_id.setdefault(evidence.evidence_id, evidence)
-    merged_existing = existing.model_copy(
-        update={
-            "evidence": list(evidence_by_id.values()),
-            "corroboration_count": existing.corroboration_count + 1,
-            "last_corroborated_at": now,
-            "updated_at": now,
-        }
+    merged_evidence_ids = [evidence.evidence_id for evidence in evidence_by_id.values()]
+    merge_operation = _ensure_required_promotion_update_operation(
+        uid=uid,
+        target_memory_id=existing.memory_id,
+        evidence_ids=merged_evidence_ids,
+        logical_payload={
+            "decision": DurablePatchDecision.update.value,
+            "target_memory_id": existing.memory_id,
+            "memory_text": existing.content,
+            "result_status": LifecycleState.active.value,
+        },
+        control=control,
+        source_packet_id=f"promotion_merge_{run_id}",
+        db_client=db_client,
     )
+    merge_idempotency_key = deterministic_contract_id(
+        "canonical-required-promotion-duplicate-merge",
+        {"uid": uid, "source_memory_id": item.memory_id, "target_memory_id": existing.memory_id},
+    )
+    merge_result = apply_long_term_patch_firestore(
+        uid=uid,
+        operation_id=merge_operation.operation_id,
+        patch_payload={
+            "patch_id": f"patch_req_merge_{merge_idempotency_key[:24]}",
+            "packet_id": f"promotion_{run_id}",
+            "run_id": run_id,
+            "observed_head_commit_id": control.head_commit_id,
+            "idempotency_key": merge_idempotency_key,
+            "decision": DurablePatchDecision.update.value,
+            "result_status": LifecycleState.active.value,
+            "target_memory_id": existing.memory_id,
+            "memory_text": existing.content,
+            "evidence_ids": merged_evidence_ids,
+            "corroboration_count": existing.corroboration_count + 1,
+            "last_corroborated_at": now.isoformat(),
+        },
+        db_client=db_client,
+    )
+    if merge_result.status not in {ApplyStatus.committed, ApplyStatus.idempotent_skip}:
+        raise RuntimeError(
+            f"required-promotion duplicate merge failed for {item.memory_id}: "
+            f"{merge_result.status} ({merge_result.reason})"
+        )
+    merged_existing = (
+        merge_result.memory_items[0]
+        if merge_result.memory_items
+        else _read_memory_item(
+            uid,
+            existing.memory_id,
+            db_client=db_client,
+        )
+    )
+    if merged_existing is None:
+        raise RuntimeError(f"required-promotion duplicate merge lost target {existing.memory_id}")
+
     source_promotion = dict(item.promotion or {})
     source_promotion.update(
         {
@@ -188,18 +236,85 @@ def _merge_required_promotion_duplicate(
             "trigger_reason": trigger_reason,
         }
     )
-    superseded_source = item.model_copy(
-        update={
-            "status": MemoryItemStatus.superseded,
-            "promotion": source_promotion,
-            "superseded_by": existing.memory_id,
-            "updated_at": now,
-        }
+    supersede_control = _read_control_state(uid, db_client=db_client)
+    supersede_operation = _ensure_required_promotion_update_operation(
+        uid=uid,
+        target_memory_id=item.memory_id,
+        evidence_ids=[],
+        logical_payload={
+            "decision": DurablePatchDecision.update.value,
+            "target_memory_id": item.memory_id,
+            "result_status": LifecycleState.superseded.value,
+        },
+        control=supersede_control,
+        source_packet_id=f"promotion_merge_supersede_{run_id}",
+        db_client=db_client,
     )
-    db_client.document(f"{collections.memory_items}/{existing.memory_id}").set(merged_existing.model_dump(mode="json"))
-    db_client.document(f"{collections.memory_items}/{item.memory_id}").set(superseded_source.model_dump(mode="json"))
+    supersede_idempotency_key = deterministic_contract_id(
+        "canonical-required-promotion-duplicate-supersede",
+        {"uid": uid, "source_memory_id": item.memory_id, "target_memory_id": existing.memory_id},
+    )
+    supersede_result = apply_long_term_patch_firestore(
+        uid=uid,
+        operation_id=supersede_operation.operation_id,
+        patch_payload={
+            "patch_id": f"patch_req_sup_{supersede_idempotency_key[:24]}",
+            "packet_id": f"promotion_{run_id}",
+            "run_id": run_id,
+            "observed_head_commit_id": supersede_control.head_commit_id,
+            "idempotency_key": supersede_idempotency_key,
+            "decision": DurablePatchDecision.update.value,
+            "result_status": LifecycleState.superseded.value,
+            "target_memory_id": item.memory_id,
+            "memory_text": None,
+            "evidence_ids": [],
+            "promotion_audit": source_promotion,
+            "superseded_by": existing.memory_id,
+        },
+        db_client=db_client,
+    )
+    if supersede_result.status not in {ApplyStatus.committed, ApplyStatus.idempotent_skip}:
+        raise RuntimeError(
+            f"required-promotion duplicate supersede failed for {item.memory_id}: "
+            f"{supersede_result.status} ({supersede_result.reason})"
+        )
     keyword_sync_succeeded = sync_atom_keyword_index_for_item(merged_existing, db_client=db_client)
     return merged_existing, keyword_sync_succeeded
+
+
+def _ensure_required_promotion_update_operation(
+    *,
+    uid: str,
+    target_memory_id: str,
+    evidence_ids: List[str],
+    logical_payload: Dict,
+    control: MemoryControlState,
+    source_packet_id: str,
+    db_client,
+) -> MemoryOperation:
+    operation = MemoryOperation.new(
+        uid=uid,
+        operation_type=MemoryOperationType.long_term_apply,
+        source_packet_id=source_packet_id,
+        target_memory_id=target_memory_id,
+        evidence_ids=evidence_ids,
+        logical_payload=logical_payload,
+        account_generation=control.account_generation,
+        source_generation=control.source_generation,
+        observed_head_commit_id=control.head_commit_id,
+    )
+    op_path = f"{MemoryCollections(uid=uid).memory_operations}/{operation.operation_id}"
+    op_ref = db_client.document(op_path)
+    if not op_ref.get().exists:
+        op_ref.set(operation.model_dump(mode="json"))
+    return operation
+
+
+def _read_memory_item(uid: str, memory_id: str, *, db_client) -> Optional[MemoryItem]:
+    snapshot = db_client.document(f"{MemoryCollections(uid=uid).memory_items}/{memory_id}").get()
+    if not getattr(snapshot, "exists", False):
+        return None
+    return MemoryItem(**(snapshot.to_dict() or {}))
 
 
 def list_fast_track_promotable_items(
@@ -326,6 +441,8 @@ def promote_short_term_item_via_apply(
                 uid,
                 item,
                 existing_duplicate,
+                control=control,
+                run_id=run_id,
                 trigger_reason=trigger_reason,
                 now=current_time,
                 db_client=client,

--- a/backend/utils/memory/short_term_promotion.py
+++ b/backend/utils/memory/short_term_promotion.py
@@ -173,6 +173,10 @@ def _merge_required_promotion_duplicate(
     for evidence in item.evidence:
         evidence_by_id.setdefault(evidence.evidence_id, evidence)
     merged_evidence_ids = [evidence.evidence_id for evidence in evidence_by_id.values()]
+    merge_idempotency_key = deterministic_contract_id(
+        "canonical-required-promotion-duplicate-merge",
+        {"uid": uid, "source_memory_id": item.memory_id, "target_memory_id": existing.memory_id},
+    )
     merge_operation = _ensure_required_promotion_update_operation(
         uid=uid,
         target_memory_id=existing.memory_id,
@@ -184,12 +188,8 @@ def _merge_required_promotion_duplicate(
             "result_status": LifecycleState.active.value,
         },
         control=control,
-        source_packet_id=f"promotion_merge_{run_id}",
+        source_packet_id=f"promotion_merge_{merge_idempotency_key}",
         db_client=db_client,
-    )
-    merge_idempotency_key = deterministic_contract_id(
-        "canonical-required-promotion-duplicate-merge",
-        {"uid": uid, "source_memory_id": item.memory_id, "target_memory_id": existing.memory_id},
     )
     merge_result = apply_long_term_patch_firestore(
         uid=uid,
@@ -237,6 +237,10 @@ def _merge_required_promotion_duplicate(
         }
     )
     supersede_control = _read_control_state(uid, db_client=db_client)
+    supersede_idempotency_key = deterministic_contract_id(
+        "canonical-required-promotion-duplicate-supersede",
+        {"uid": uid, "source_memory_id": item.memory_id, "target_memory_id": existing.memory_id},
+    )
     supersede_operation = _ensure_required_promotion_update_operation(
         uid=uid,
         target_memory_id=item.memory_id,
@@ -247,12 +251,8 @@ def _merge_required_promotion_duplicate(
             "result_status": LifecycleState.superseded.value,
         },
         control=supersede_control,
-        source_packet_id=f"promotion_merge_supersede_{run_id}",
+        source_packet_id=f"promotion_merge_supersede_{supersede_idempotency_key}",
         db_client=db_client,
-    )
-    supersede_idempotency_key = deterministic_contract_id(
-        "canonical-required-promotion-duplicate-supersede",
-        {"uid": uid, "source_memory_id": item.memory_id, "target_memory_id": existing.memory_id},
     )
     supersede_result = apply_long_term_patch_firestore(
         uid=uid,


### PR DESCRIPTION
## Summary
- Route exact required-promotion duplicate merges through canonical apply ledger commits for both the survivor update and superseded source.
- Make WS-B lifecycle imports hermetic so unit collection does not touch external clients.
- Make developer memory adapter route assertions independent of exact decorator text.

Fixes #8677

## Testing
- PYTHON=.venv/bin/python bash test-preflight.sh
- PYTHON=.venv/bin/python .venv/bin/python -m pytest tests/unit/test_ws_b_short_term_lifecycle.py tests/unit/test_developer_memory_adapter.py tests/unit/test_atomic_apply.py tests/unit/test_canonical_consolidation_apply.py -q
- PYTHON=.venv/bin/python .venv/bin/python -m pytest tests/unit/test_ws_c_backfill.py -q
- PYTHON=.venv/bin/python .venv/bin/python scripts/scan_async_blockers.py --dirs routers utils
- PYTHON=.venv/bin/python BACKEND_PYTEST_XDIST=8 BACKEND_PYTEST_WORKERS=8 bash test.sh

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8813?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

