### PR TITLE
[codex] Harden calendar key readiness

### DIFF
--- a/.github/workflows/desktop_backend_auto_dev.yml
+++ b/.github/workflows/desktop_backend_auto_dev.yml
@@ -11,6 +11,10 @@ env:
   SERVICE: desktop-backend
   REGION: us-central1
 
+concurrency:
+  group: desktop-backend-auto-dev
+  cancel-in-progress: true
+
 jobs:
   deploy:
     environment: development
@@ -51,6 +55,24 @@ jobs:
             exit 1
           fi
 
+      - name: Validate desktop Calendar API key secret
+        env:
+          PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
+        run: |
+          set -euo pipefail
+          gcloud secrets versions access latest \
+            --project="$PROJECT_ID" \
+            --secret=DESKTOP_GOOGLE_CALENDAR_API_KEY > /tmp/desktop-google-calendar-api-key
+          python3 - <<'PY'
+          from pathlib import Path
+
+          value = Path("/tmp/desktop-google-calendar-api-key").read_bytes()
+          if value.endswith(b"\n"):
+              raise SystemExit("DESKTOP_GOOGLE_CALENDAR_API_KEY must not include a trailing newline")
+          if len(value) != 39 or not value.startswith(b"AIza"):
+              raise SystemExit("DESKTOP_GOOGLE_CALENDAR_API_KEY does not look like a Google API key")
+          PY
+
       - name: Build and Push Docker image
         uses: docker/build-push-action@v6
         with:
@@ -86,6 +108,44 @@ jobs:
             ANTHROPIC_API_KEY=DESKTOP_ANTHROPIC_API_KEY:latest
             DESKTOP_LEGACY_ANTHROPIC_KEY=DESKTOP_LEGACY_ANTHROPIC_KEY:latest
             GOOGLE_CALENDAR_API_KEY=DESKTOP_GOOGLE_CALENDAR_API_KEY:latest
+
+      - name: Route traffic to deployed desktop-backend revision
+        env:
+          PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
+        run: |
+          set -euo pipefail
+          REVISION="$(gcloud run services describe "$SERVICE" \
+            --project="$PROJECT_ID" \
+            --region="$REGION" \
+            --format='value(status.latestCreatedRevisionName)')"
+          if [ -z "$REVISION" ]; then
+            echo "Could not determine latest desktop-backend revision" >&2
+            exit 1
+          fi
+          gcloud run services update-traffic "$SERVICE" \
+            --project="$PROJECT_ID" \
+            --region="$REGION" \
+            --to-revisions="$REVISION=100" \
+            --quiet
+          TRAFFIC_JSON="$(gcloud run services describe "$SERVICE" \
+            --project="$PROJECT_ID" \
+            --region="$REGION" \
+            --format=json)"
+          SERVING_REVISION="$(TRAFFIC_JSON="$TRAFFIC_JSON" python3 - <<'PY'
+          import json
+          import os
+
+          service = json.loads(os.environ["TRAFFIC_JSON"])
+          for target in service.get("status", {}).get("traffic", []):
+              if target.get("percent") == 100:
+                  print(target.get("revisionName", ""))
+                  break
+          PY
+          )"
+          if [ "$SERVING_REVISION" != "$REVISION" ]; then
+            echo "desktop-backend traffic is serving $SERVING_REVISION, expected $REVISION" >&2
+            exit 1
+          fi
 
       - name: Show Output
         run: echo "Desktop backend deployed to development environment"

--- a/.github/workflows/desktop_promote_prod.yml
+++ b/.github/workflows/desktop_promote_prod.yml
@@ -281,6 +281,25 @@ jobs:
             exit 1
           fi
 
+      - name: Validate desktop Calendar API key secret
+        if: steps.current.outputs.deploy_needed == 'true'
+        env:
+          PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
+        run: |
+          set -euo pipefail
+          gcloud secrets versions access latest \
+            --project="$PROJECT_ID" \
+            --secret=DESKTOP_GOOGLE_CALENDAR_API_KEY > /tmp/desktop-google-calendar-api-key
+          python3 - <<'PY'
+          from pathlib import Path
+
+          value = Path("/tmp/desktop-google-calendar-api-key").read_bytes()
+          if value.endswith(b"\n"):
+              raise SystemExit("DESKTOP_GOOGLE_CALENDAR_API_KEY must not include a trailing newline")
+          if len(value) != 39 or not value.startswith(b"AIza"):
+              raise SystemExit("DESKTOP_GOOGLE_CALENDAR_API_KEY does not look like a Google API key")
+          PY
+
       - name: Build and Push Desktop Backend Image
         if: steps.current.outputs.deploy_needed == 'true'
         uses: docker/build-push-action@v6
@@ -324,6 +343,26 @@ jobs:
             DESKTOP_LEGACY_ANTHROPIC_KEY=DESKTOP_LEGACY_ANTHROPIC_KEY:latest
             GOOGLE_CALENDAR_API_KEY=DESKTOP_GOOGLE_CALENDAR_API_KEY:latest
             RELEASE_SECRET=RELEASE_SECRET:latest
+
+      - name: Route traffic to deployed desktop-backend revision
+        if: steps.current.outputs.deploy_needed == 'true'
+        env:
+          PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
+        run: |
+          set -euo pipefail
+          REVISION="$(gcloud run services describe "$SERVICE" \
+            --project="$PROJECT_ID" \
+            --region="$REGION" \
+            --format='value(status.latestCreatedRevisionName)')"
+          if [ -z "$REVISION" ]; then
+            echo "Could not determine latest desktop-backend revision" >&2
+            exit 1
+          fi
+          gcloud run services update-traffic "$SERVICE" \
+            --project="$PROJECT_ID" \
+            --region="$REGION" \
+            --to-revisions="$REVISION=100" \
+            --quiet
 
       - name: Verify prod backend release identity
         env:

--- a/desktop/macos/Desktop/Sources/APIKeyService.swift
+++ b/desktop/macos/Desktop/Sources/APIKeyService.swift
@@ -64,11 +64,14 @@ final class APIKeyService: ObservableObject {
 
     /// Start fetching keys in the background. Callers can await via waitForKeys().
     func startFetchingKeys() {
+        guard !isLoaded else { return }
+        guard fetchTask == nil else { return }
         fetchTask = Task { await self.fetchKeys() }
     }
 
     /// Wait for keys to be loaded. Returns immediately if already loaded.
     /// If no fetch is in-flight, starts one (handles app-restart-while-signed-in case).
+    /// A previously failed fetch clears fetchTask, so Calendar/Chat callers can retry without restarting.
     func waitForKeys() async {
         if isLoaded { return }
         if fetchTask == nil {
@@ -76,6 +79,12 @@ final class APIKeyService: ObservableObject {
             fetchTask = Task { await fetchKeys() }
         }
         await fetchTask?.value
+        if isLoaded { return }
+        if fetchTask == nil {
+            log("APIKeyService: key fetch completed without loaded keys, retrying once")
+            fetchTask = Task { await fetchKeys() }
+            await fetchTask?.value
+        }
     }
 
     var effectiveGeminiKey: String? {
@@ -119,6 +128,7 @@ final class APIKeyService: ObservableObject {
 
         loadError = "Failed to fetch API keys from backend"
         log("APIKeyService: All fetch attempts failed — features requiring API keys will be unavailable")
+        fetchTask = nil
 
         // Still apply env vars from developer overrides if set
         applyToEnvironment()

--- a/desktop/macos/Desktop/Sources/CalendarReaderService.swift
+++ b/desktop/macos/Desktop/Sources/CalendarReaderService.swift
@@ -46,6 +46,7 @@ enum CalendarReaderError: LocalizedError, Equatable {
   case sessionExpired
   case cookieDecryptionFailed(String)
   case networkError(String)
+  case configurationError(String)
   case pythonNotFound
 
   var errorDescription: String? {
@@ -60,6 +61,8 @@ enum CalendarReaderError: LocalizedError, Equatable {
       return "Couldn't read your browser session: \(msg)"
     case .networkError(let msg):
       return "Couldn't reach Google Calendar: \(msg)"
+    case .configurationError(let msg):
+      return "Couldn't use Google Calendar: \(msg)"
     case .pythonNotFound:
       return "Python 3 not found. Install it via Homebrew: brew install python3"
     }
@@ -105,6 +108,7 @@ enum CalendarFailureClass: String, Equatable {
   case notSignedIn = "not_signed_in"
   case sessionExpired = "session_expired"
   case decryptFailed = "decrypt_failed"
+  case configuration = "configuration"
   case network = "network"
   case unknown = "unknown"
 
@@ -118,6 +122,8 @@ enum CalendarFailureClass: String, Equatable {
       return "Your Google session expired. Reload calendar.google.com to refresh it."
     case .decryptFailed:
       return "browser session could not be decrypted"
+    case .configuration:
+      return "Calendar API key is invalid or unavailable"
     case .network:
       return "please check your connection and try again"
     case .unknown:
@@ -149,12 +155,12 @@ enum CalendarFailureClass: String, Equatable {
       return raw
     case .noBrowser, .notSignedIn, .sessionExpired:
       return nil
-    case .unknown:
+    case .configuration, .unknown:
       return raw
     }
   }
 
-  func asError(summary: String?) -> CalendarReaderError {
+  func asError(summary: String? = nil) -> CalendarReaderError {
     func detailOr(_ fallback: String) -> String {
       detailFragment(from: summary) ?? fallback
     }
@@ -165,6 +171,8 @@ enum CalendarFailureClass: String, Equatable {
     case .sessionExpired: return .sessionExpired
     case .decryptFailed:
       return .cookieDecryptionFailed(detailOr("browser session could not be decrypted"))
+    case .configuration:
+      return .configurationError(detailOr("Calendar API key is invalid or unavailable"))
     case .network:
       return .networkError(detailOr("please check your connection and try again"))
     case .unknown:
@@ -219,6 +227,7 @@ actor CalendarReaderService {
   func readEvents(daysBack: Int = 90, daysForward: Int = 14, maxResults: Int = 200) async throws
     -> [CalendarEvent]
   {
+    await APIKeyService.shared.waitForKeys()
     let events = try fetchCalendarViaCookies(
       daysBack: daysBack, daysForward: daysForward, maxResults: maxResults)
     return events.sorted { $0.startTime > $1.startTime }
@@ -233,6 +242,7 @@ actor CalendarReaderService {
   /// green result guarantees the whole chain (cookies → auth → API) works.
   func verifyConnection() async -> CalendarConnectionStatus {
     do {
+      await APIKeyService.shared.waitForKeys()
       _ = try fetchCalendarViaCookies(daysBack: 1, daysForward: 1, maxResults: 1)
       return .connected(verifiedAt: Date())
     } catch let error as CalendarReaderError {
@@ -460,6 +470,11 @@ actor CalendarReaderService {
       daysForward: daysForward,
       maxResults: maxResults
     )
+    guard let calendarKey = getenv("GOOGLE_CALENDAR_API_KEY").flatMap({ String(validatingUTF8: $0) }),
+      !calendarKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    else {
+      throw CalendarReaderError.configurationError("Calendar API key is unavailable; try again after startup finishes.")
+    }
 
     // Build browser configs as JSON for Python
     // Pass the ORIGINAL db path — Python opens it read-only to avoid WAL/journal corruption from file copy
@@ -494,6 +509,22 @@ actor CalendarReaderService {
           raw = timestamp + " " + sapisid + " " + origin
           hash_val = hashlib.sha1(raw.encode('utf-8')).hexdigest()
           return "SAPISIDHASH " + timestamp + "_" + hash_val
+
+      def google_error_detail(raw_body):
+          try:
+              payload = json.loads(raw_body.decode('utf-8', errors='replace'))
+              error = payload.get('error', {})
+              message = error.get('message') or ''
+              status = error.get('status') or ''
+              reasons = [
+                  e.get('reason', '')
+                  for e in error.get('errors', [])
+                  if isinstance(e, dict)
+              ]
+              parts = [p for p in [status, message, ','.join([r for r in reasons if r])] if p]
+              return ': '.join(parts) if parts else None
+          except Exception:
+              return None
 
       def fetch_calendar_events(jar, cookies_list, days_back, days_forward, max_results):
           # Returns (events, error, http_status). http_status lets the caller
@@ -551,7 +582,8 @@ actor CalendarReaderService {
                       return None, f"HTTP {status}", status
                   data = json.loads(body)
               except urllib.error.HTTPError as e:
-                  return None, f"HTTP {e.code}", e.code
+                  detail = google_error_detail(e.read())
+                  return None, f"HTTP {e.code}" + (f": {detail}" if detail else ""), e.code
               except Exception as e:
                   return None, str(e), None
 
@@ -572,6 +604,19 @@ actor CalendarReaderService {
           # No browser produced any readable cookies at all.
           if not attempts:
               return 'no_browser', 'No supported browser with a readable session was found.'
+          # API-key/config failures are not user sign-in problems. Google uses
+          # 400 for invalid keys and 403 for missing/unregistered callers.
+          config_markers = (
+              'API key not valid',
+              'API key expired',
+              'API key is invalid',
+              'unregistered callers',
+              'API key',
+          )
+          for a in attempts:
+              reason = a.get('reason') or ''
+              if a['stage'] == 'fetch' and any(marker in reason for marker in config_markers):
+                  return 'configuration', 'Calendar API key is invalid or unavailable.'
           # Session expired beats "not signed in": if any profile HAD auth
           # cookies but Google rejected them, telling the user to re-login is the
           # actionable next step.

--- a/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
+++ b/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
@@ -676,6 +676,8 @@ final class DesktopAutomationActionRegistry {
           classification = "session_expired"
         case .cookieDecryptionFailed:
           classification = "decrypt_failed"
+        case .configurationError:
+          classification = "configuration"
         case .networkError:
           classification = "network"
         case .pythonNotFound:

--- a/desktop/macos/Desktop/Tests/CalendarOutcomeParserTests.swift
+++ b/desktop/macos/Desktop/Tests/CalendarOutcomeParserTests.swift
@@ -56,7 +56,7 @@ final class CalendarOutcomeParserTests: XCTestCase {
       return XCTFail("expected failure")
     }
     XCTAssertEqual(cls, .notSignedIn)
-    XCTAssertEqual(cls.asError, .notSignedIn)
+    XCTAssertEqual(cls.asError(), .notSignedIn)
     // Every attempt is retained — not just the last one (no last-writer-wins).
     XCTAssertEqual(attempts.count, 2)
   }
@@ -74,7 +74,56 @@ final class CalendarOutcomeParserTests: XCTestCase {
       return XCTFail("expected failure")
     }
     XCTAssertEqual(cls, .sessionExpired)
-    XCTAssertEqual(cls.asError, .sessionExpired)
+    XCTAssertEqual(cls.asError(), .sessionExpired)
+  }
+
+  func testInvalidCalendarAPIKeyMapsToConfigurationError() {
+    let json: [String: Any] = [
+      "ok": false,
+      "error_class": "configuration",
+      "summary": "Calendar API key is invalid or unavailable.",
+      "attempts": [
+        [
+          "browser": "Chrome",
+          "stage": "fetch",
+          "reason": "HTTP 400: INVALID_ARGUMENT: API key not valid. Please pass a valid API key.: badRequest",
+          "had_auth": true,
+          "http": 400,
+        ]
+      ],
+    ]
+    guard case let .failure(cls, summary, _) = CalendarOutcomeParser.parse(json) else {
+      return XCTFail("expected failure")
+    }
+    XCTAssertEqual(cls, .configuration)
+    XCTAssertEqual(cls.asError(summary: summary), .configurationError("Calendar API key is invalid or unavailable."))
+  }
+
+  func testMissingCalendarAPIKeyMapsToConfigurationError() {
+    let json: [String: Any] = [
+      "ok": false,
+      "error_class": "configuration",
+      "summary": "Calendar API key is invalid or unavailable.",
+      "attempts": [
+        [
+          "browser": "Chrome",
+          "stage": "fetch",
+          "reason": "HTTP 403: PERMISSION_DENIED: Method doesn't allow unregistered callers.",
+          "had_auth": true,
+          "http": 403,
+        ]
+      ],
+    ]
+    guard case let .failure(cls, summary, _) = CalendarOutcomeParser.parse(json) else {
+      return XCTFail("expected failure")
+    }
+    XCTAssertEqual(cls, .configuration)
+    XCTAssertEqual(cls.asError(summary: summary).errorDescription, "Couldn't use Google Calendar: Calendar API key is invalid or unavailable.")
+  }
+
+  func testNetworkSummaryAvoidsDoublePrefix() {
+    let error = CalendarFailureClass.network.asError(summary: "Could not reach Google Calendar (HTTP 500).")
+    XCTAssertEqual(error.errorDescription, "Couldn't reach Google Calendar: (HTTP 500).")
   }
 
   func testNoBrowserWhenNothingScanned() {
@@ -184,6 +233,27 @@ final class CalendarOutcomeParserTests: XCTestCase {
     XCTAssertEqual(
       CalendarFetchParameters.normalized(daysBack: 9999, daysForward: 9999, maxResults: 9999),
       CalendarFetchParameters(daysBack: 3650, daysForward: 3650, maxResults: 2500)
+    )
+  }
+
+  func testCalendarReadsWaitForBackendServedAPIKeys() throws {
+    let testsURL = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
+    let sourceURL = testsURL
+      .deletingLastPathComponent()
+      .appendingPathComponent("Sources/CalendarReaderService.swift")
+    let source = try String(contentsOf: sourceURL, encoding: .utf8)
+
+    guard let readRange = source.range(of: "func readEvents("),
+      let keyWaitRange = source.range(of: "await APIKeyService.shared.waitForKeys()", range: readRange.upperBound..<source.endIndex),
+      let fetchRange = source.range(of: "fetchCalendarViaCookies(", range: readRange.upperBound..<source.endIndex)
+    else {
+      return XCTFail("Calendar reads must wait for backend-served API keys before fetching")
+    }
+
+    XCTAssertLessThan(
+      keyWaitRange.lowerBound,
+      fetchRange.lowerBound,
+      "Calendar reads must not hit Google before GOOGLE_CALENDAR_API_KEY has loaded"
     )
   }
 }

--- a/desktop/macos/Desktop/Tests/StartupWarmupPolicyTests.swift
+++ b/desktop/macos/Desktop/Tests/StartupWarmupPolicyTests.swift
@@ -117,6 +117,23 @@ final class StartupWarmupPolicyTests: XCTestCase {
         )
     }
 
+    func testAPIKeyFetchFailureDoesNotBlockFutureWaiters() throws {
+        let testsURL = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
+        let serviceURL = testsURL
+            .deletingLastPathComponent()
+            .appendingPathComponent("Sources/APIKeyService.swift")
+        let source = try String(contentsOf: serviceURL, encoding: .utf8)
+
+        XCTAssertTrue(
+            source.contains("fetchTask = nil"),
+            "A failed API key fetch must clear fetchTask so later Calendar waits can retry"
+        )
+        XCTAssertTrue(
+            source.contains("key fetch completed without loaded keys, retrying once"),
+            "waitForKeys() must retry after awaiting a failed completed fetch"
+        )
+    }
+
     func testChatPromptContextWarmupWaitsUntilAfterDeferredWarmupStarts() {
         XCTAssertGreaterThan(
             StartupWarmupPolicy.chatPromptContextWarmupDelay,

--- a/desktop/macos/changelog/unreleased/20260701-calendar-key-readiness.json
+++ b/desktop/macos/changelog/unreleased/20260701-calendar-key-readiness.json
@@ -1,0 +1,3 @@
+{
+    "change": "Google Calendar imports now wait for desktop API keys to load before checking your browser session"
+}


### PR DESCRIPTION
## Summary
- make Google Calendar reads wait for backend-served API keys before launching the cookie/Python fetch path
- classify invalid or missing Calendar API keys as configuration failures instead of session-expired browser-cookie failures
- validate the desktop Calendar API key secret shape in dev/prod desktop-backend deploy workflows and explicitly route Cloud Run traffic to the newly deployed revision

## Root Cause
Omi Beta can route to the dev desktop-backend and fetch `GOOGLE_CALENDAR_API_KEY` asynchronously after launch. A Calendar import could run before that key was loaded, causing Google to return a 403 that the connector classified as an expired Google browser session. Separately, the dev Secret Manager value had been a placeholder, and Cloud Run traffic was pinned to an older revision until explicitly shifted.

## Validation
- `xcrun swift test --package-path desktop/macos/Desktop --filter CalendarOutcomeParserTests` (11 tests, 0 failures)
- `python3 .github/scripts/desktop-changelog.py validate`
- `git diff --check`
- parsed `.github/workflows/desktop_backend_auto_dev.yml` and `.github/workflows/desktop_promote_prod.yml` with PyYAML
- verified `DESKTOP_GOOGLE_CALENDAR_API_KEY` latest secret shape in both `based-hardware-dev` and `based-hardware`
- verified live dev desktop-backend now serves a 39-byte Google-shaped Calendar key and a real Calendar fetch returns HTTP 200

## Notes
- SwiftPM emitted existing Swift concurrency warnings in CalendarReaderService pipe handlers and AppState listen code; they did not fail the focused test run.
- Pre-push guardrails passed, with the existing advisory that `CalendarReaderService.swift` is over 800 lines.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8817?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

