### PR TITLE
Fix subagent stop control and tool-call rendering

### DIFF
--- a/desktop/macos/Desktop/Sources/FloatingControlBar/AgentPill.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/AgentPill.swift
@@ -12,6 +12,7 @@ final class AgentPill: ObservableObject, Identifiable {
         case starting
         case running
         case done
+        case stopped
         case failed(String)
 
         var displayLabel: String {
@@ -19,6 +20,7 @@ final class AgentPill: ObservableObject, Identifiable {
             case .queued: return "Queued"
             case .starting, .running: return "Running"
             case .done: return "Done"
+            case .stopped: return "Stopped"
             case .failed: return "Failed"
             }
         }
@@ -28,6 +30,7 @@ final class AgentPill: ObservableObject, Identifiable {
             case .queued: return Color(red: 0.20, green: 0.86, blue: 1.0)
             case .starting, .running: return Color(red: 1.0, green: 0.80, blue: 0.40)
             case .done: return Color(red: 0.27, green: 0.92, blue: 0.46)
+            case .stopped: return Color(red: 0.64, green: 0.66, blue: 0.70)
             case .failed: return Color(red: 1.0, green: 0.42, blue: 0.42)
             }
         }
@@ -38,13 +41,14 @@ final class AgentPill: ObservableObject, Identifiable {
             case .starting: return "starting"
             case .running: return "running"
             case .done: return "done"
+            case .stopped: return "stopped"
             case .failed: return "failed"
             }
         }
 
         var isFinished: Bool {
             switch self {
-            case .done, .failed: return true
+            case .done, .stopped, .failed: return true
             default: return false
             }
         }
@@ -841,6 +845,30 @@ final class AgentPillsManager: ObservableObject {
         if pinnedPillID == pillID { pinnedPillID = nil }
     }
 
+    func stop(pillID: UUID) {
+        guard let pill = pills.first(where: { $0.id == pillID }), !pill.status.isFinished else { return }
+        log("AgentPills: stopping pill \(pill.title)")
+        if recordingPillID == pillID {
+            recordingPillID = nil
+            PushToTalkManager.shared.cancelPillFollowUp(for: pillID)
+        }
+        providersByPill[pillID]?.stopAgent()
+        runTasksByPill[pillID]?.cancel()
+        runTasksByPill[pillID] = nil
+        pill.status = .stopped
+        pill.latestActivity = "Stopped by user"
+        pill.completedAt = Date()
+        pill.suggestedFollowUps = AgentPillsManager.deriveFollowUps(for: pill)
+        pill.markContentChanged()
+        if pill.viewedAt != nil {
+            scheduleViewedExpiration(for: pill)
+        }
+        AgentRuntimeStatusStore.shared.recordLocalCancellation(
+            surface: .floatingPill(pillId: pillID),
+            message: "Stopped by user"
+        )
+    }
+
     func markViewed(pillID: UUID) {
         guard let pill = pills.first(where: { $0.id == pillID }) else { return }
         pill.viewedAt = Date()
@@ -1228,7 +1256,7 @@ final class AgentPillsManager: ObservableObject {
             ensureFailureMessage(message, for: pill)
             pill.markContentChanged()
         case .cancelled:
-            pill.status = .failed("Stopped by user")
+            pill.status = .stopped
             pill.latestActivity = "Stopped by user"
             pill.completedAt = projection.completedAt ?? Date()
             pill.markContentChanged()

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/AgentPill.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/AgentPill.swift
@@ -1228,6 +1228,10 @@ final class AgentPillsManager: ObservableObject {
     }
 
     private static func apply(projection: AgentRunProjection, to pill: AgentPill) {
+        if pill.status == .stopped && projection.status != .cancelled {
+            return
+        }
+
         switch projection.status {
         case .queued:
             pill.status = .queued

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/AgentPillsView.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/AgentPillsView.swift
@@ -165,7 +165,7 @@ struct AgentPillView: View {
             return false
         }
         switch pill.status {
-        case .done, .failed: return true
+        case .done, .stopped, .failed: return true
         default: return false
         }
     }
@@ -304,7 +304,7 @@ struct AgentPillPopover: View {
 
     private var isFinished: Bool {
         switch pill.status {
-        case .done, .failed: return true
+        case .done, .stopped, .failed: return true
         default: return false
         }
     }
@@ -358,6 +358,7 @@ struct AgentPillPopover: View {
         case .queued: return Color(red: 0.0, green: 0.0, blue: 0.0)
         case .starting, .running: return Color(red: 0.18, green: 0.10, blue: 0.0)
         case .done: return Color(red: 0.07, green: 0.18, blue: 0.10)
+        case .stopped: return Color(red: 0.08, green: 0.09, blue: 0.10)
         case .failed: return .white
         }
     }
@@ -367,6 +368,7 @@ struct AgentPillPopover: View {
         case .queued: return Color(red: 0.85, green: 0.85, blue: 0.85)
         case .starting, .running: return Color(red: 1.0, green: 0.78, blue: 0.30)
         case .done: return Color(red: 0.45, green: 0.92, blue: 0.55)
+        case .stopped: return Color(red: 0.64, green: 0.66, blue: 0.70)
         case .failed: return Color(red: 0.78, green: 0.32, blue: 0.32)
         }
     }

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/AgentPillsWindow.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/AgentPillsWindow.swift
@@ -162,7 +162,7 @@ final class AgentPillsWindow: NSPanel, NSWindowDelegate {
       let pill = manager.pills.first(where: { $0.id == id })
     else { return 0 }
     switch pill.status {
-    case .done, .failed: return 170
+    case .done, .stopped, .failed: return 170
     default: return 110
     }
   }

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift
@@ -1359,7 +1359,7 @@ private struct AgentMainChatView: View {
         switch pill.status {
         case .queued, .starting, .running:
             return true
-        case .done, .failed:
+        case .done, .stopped, .failed:
             return false
         }
     }
@@ -1465,20 +1465,42 @@ private struct AgentMainChatView: View {
     }
 
     private var statusBadge: some View {
-        Group {
-            if pill.status == .done {
-                Button {
-                    manager.dismiss(pillID: pill.id)
-                    onBackToAgentRows()
-                } label: {
+        HStack(spacing: 6) {
+            Group {
+                if pill.status == .done {
+                    Button {
+                        manager.dismiss(pillID: pill.id)
+                        onBackToAgentRows()
+                    } label: {
+                        statusBadgeLabel
+                    }
+                    .buttonStyle(.plain)
+                    .help("Dismiss completed agent")
+                } else {
                     statusBadgeLabel
                 }
-                .buttonStyle(.plain)
-                .help("Dismiss completed agent")
-            } else {
-                statusBadgeLabel
+            }
+
+            if isRunning {
+                stopButton
             }
         }
+    }
+
+    private var stopButton: some View {
+        Button {
+            manager.stop(pillID: pill.id)
+        } label: {
+            Image(systemName: "stop.fill")
+                .scaledFont(size: 8, weight: .bold)
+                .foregroundColor(.black.opacity(0.82))
+                .frame(width: 22, height: 22)
+                .background(pill.status.tintColor)
+                .clipShape(Circle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Stop subagent")
+        .help("Stop subagent")
     }
 
     private var statusBadgeLabel: some View {
@@ -1495,6 +1517,8 @@ private struct AgentMainChatView: View {
         switch pill.status {
         case .queued, .starting, .running, .done:
             return .black.opacity(0.86)
+        case .stopped:
+            return .black.opacity(0.78)
         case .failed:
             return .white
         }
@@ -1502,7 +1526,7 @@ private struct AgentMainChatView: View {
 
     private var statusBackgroundOpacity: Double {
         switch pill.status {
-        case .queued, .starting, .running, .done:
+        case .queued, .starting, .running, .done, .stopped:
             return 1
         case .failed:
             return 0.75
@@ -1582,7 +1606,7 @@ private struct AgentMainChatView: View {
     private func agentAssistantContent(_ message: ChatMessage) -> some View {
         if !message.contentBlocks.isEmpty {
             VStack(alignment: .leading, spacing: 8) {
-                ForEach(ContentBlockGroup.group(message.contentBlocks)) { group in
+                ForEach(groupedContentBlocks(for: message)) { group in
                     switch group {
                     case .text(_, let text):
                         if !text.isEmpty {
@@ -1610,6 +1634,32 @@ private struct AgentMainChatView: View {
                     .textSelection(.enabled)
                     .fixedSize(horizontal: false, vertical: true)
                     .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        }
+    }
+
+    private func groupedContentBlocks(for message: ChatMessage) -> [ContentBlockGroup] {
+        let grouped = ContentBlockGroup.group(message.contentBlocks)
+
+        return grouped.filter { group in
+            switch group {
+            case .text, .discoveryCard:
+                return true
+            case .toolCalls(_, let calls):
+                if calls.contains(where: { $0.spawnedAgentID != nil }) {
+                    return true
+                }
+                if message.isStreaming {
+                    return calls.contains { block in
+                        if case .toolCall(_, _, let status, _, _, _) = block {
+                            return status.isInFlight
+                        }
+                        return false
+                    }
+                }
+                return false
+            case .thinking:
+                return message.isStreaming
             }
         }
     }
@@ -2058,6 +2108,8 @@ private struct NotchAgentListRow: View {
             return "sparkles"
         case .done:
             return "checkmark"
+        case .stopped:
+            return "stop.fill"
         case .failed:
             return "exclamationmark"
         }
@@ -2068,6 +2120,7 @@ private enum NotchAgentStatusGroup: String, Identifiable {
     case running
     case queued
     case failed
+    case stopped
     case done
 
     var id: String { rawValue }
@@ -2080,6 +2133,8 @@ private enum NotchAgentStatusGroup: String, Identifiable {
             self = .queued
         case .failed:
             self = .failed
+        case .stopped:
+            self = .stopped
         case .done:
             self = .done
         }
@@ -2090,6 +2145,7 @@ private enum NotchAgentStatusGroup: String, Identifiable {
         case .running: return "Running"
         case .queued: return "Queued"
         case .failed: return "Failed"
+        case .stopped: return "Stopped"
         case .done: return "Done"
         }
     }
@@ -2099,6 +2155,7 @@ private enum NotchAgentStatusGroup: String, Identifiable {
         case .running: return Color(red: 1.0, green: 0.80, blue: 0.40)
         case .queued: return Color(red: 0.20, green: 0.86, blue: 1.0)
         case .failed: return Color(red: 1.0, green: 0.42, blue: 0.42)
+        case .stopped: return Color(red: 0.64, green: 0.66, blue: 0.70)
         case .done: return Color(red: 0.27, green: 0.92, blue: 0.46)
         }
     }
@@ -2108,6 +2165,7 @@ private enum NotchAgentStatusGroup: String, Identifiable {
         case .running: return Color(red: 1.0, green: 0.62, blue: 0.20)
         case .queued: return Color(red: 0.08, green: 0.52, blue: 1.0)
         case .failed: return Color(red: 1.0, green: 0.46, blue: 0.12)
+        case .stopped: return Color(red: 0.42, green: 0.44, blue: 0.48)
         case .done: return Color(red: 0.08, green: 0.78, blue: 0.62)
         }
     }
@@ -2117,6 +2175,7 @@ private enum NotchAgentStatusGroup: String, Identifiable {
         case .running: return Color(red: 0.72, green: 0.36, blue: 0.04)
         case .queued: return Color(red: 0.00, green: 0.44, blue: 0.95)
         case .failed: return Color(red: 0.78, green: 0.08, blue: 0.18)
+        case .stopped: return Color(red: 0.24, green: 0.25, blue: 0.28)
         case .done: return Color(red: 0.02, green: 0.50, blue: 0.24)
         }
     }
@@ -2126,7 +2185,8 @@ private enum NotchAgentStatusGroup: String, Identifiable {
         case .running: return 0
         case .queued: return 1
         case .failed: return 2
-        case .done: return 3
+        case .stopped: return 3
+        case .done: return 4
         }
     }
 

--- a/desktop/macos/Desktop/Tests/AgentPillLifecycleTests.swift
+++ b/desktop/macos/Desktop/Tests/AgentPillLifecycleTests.swift
@@ -76,7 +76,8 @@ final class AgentPillLifecycleTests: XCTestCase {
     XCTAssertTrue(source.contains("ForEach(displayedMessages) { message in"))
     XCTAssertTrue(source.contains("agentMessageBubble(message)"))
     XCTAssertTrue(source.contains("agentAssistantContent(message)"))
-    XCTAssertTrue(source.contains("ForEach(ContentBlockGroup.group(message.contentBlocks))"))
+    XCTAssertTrue(source.contains("ForEach(groupedContentBlocks(for: message))"))
+    XCTAssertTrue(source.contains("private func groupedContentBlocks(for message: ChatMessage) -> [ContentBlockGroup]"))
     XCTAssertTrue(source.contains("ToolCallsGroup(calls: calls, compact: true)"))
     XCTAssertTrue(source.contains("ThinkingBlock(text: text)"))
     XCTAssertTrue(source.contains("Markdown(trimmed)"))
@@ -773,6 +774,20 @@ final class AgentPillLifecycleTests: XCTestCase {
     XCTAssertTrue(source.contains("AgentRuntimeStatusStore.shared.recordLocalSuccess("))
     XCTAssertTrue(statusStoreSource.contains("func recordLocalSuccess(surface: AgentSurfaceReference, statusText: String? = nil)"))
     XCTAssertTrue(statusStoreSource.contains("if !terminal, projectionsBySurface[surface.key]?.status.isTerminal == true {\n      return\n    }"))
+  }
+
+  func testStoppedPillIgnoresLateNonCancellationProjection() throws {
+    let source = try agentPillSource()
+
+    XCTAssertTrue(
+      source.contains(
+        """
+        if pill.status == .stopped && projection.status != .cancelled {
+                    return
+                }
+
+                switch projection.status {
+        """))
   }
 
   func testDirectedProviderPillsDoNotForwardClaudeModelOverrides() throws {

--- a/desktop/macos/changelog/unreleased/20260702-subagent-stop-and-tool-rendering.json
+++ b/desktop/macos/changelog/unreleased/20260702-subagent-stop-and-tool-rendering.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed floating subagent chats so stale completed tool calls do not duplicate around text, and added a Stop control for running subagents."
+}

--- a/desktop/macos/changelog/unreleased/20260702-subagent-stop-and-tool-rendering.json
+++ b/desktop/macos/changelog/unreleased/20260702-subagent-stop-and-tool-rendering.json
@@ -1,3 +1,3 @@
 {
-  "change": "Fixed floating subagent chats so stale completed tool calls do not duplicate around text, and added a Stop control for running subagents."
+  "change": "Fixed floating subagent chats so stale completed tool calls do not duplicate around text, and added a Stop control for running subagents"
 }


### PR DESCRIPTION
## Summary
- filter stale completed tool-call groups from floating subagent chats so text is not sandwiched by duplicate tool cards
- add a right-side Stop control next to the Running badge for active floating subagents
- mark user-stopped subagents as Stopped instead of Failed and update pill/notch presentation states

## Review
- Subagent review found one P3: Stop icon was left of Running. Fixed before commit.

## Verification
- xcrun swift build -c debug --package-path Desktop
- OMI_APP_NAME="omi-subagent-stop" ./run.sh --yolo
- OMI_AUTOMATION_PORT=47919 ./scripts/omi-ctl action seed_subagents count=3
- OMI_AUTOMATION_PORT=47919 ./scripts/omi-ctl action open_seeded_subagent index=1 wait=true
- agent-swift verified Stop subagent button on the right side of the status area, pressed it, and observed Sleep Subagent Stopped / Stopped
- git diff --check
- pre-push checks passed, including desktop changelog validation, selected backend tests, OpenAPI check, and black --check


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8820?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

