### PR TITLE
Fix OpenClaw and Hermes memory setup

### DIFF
--- a/desktop/macos/Desktop/Sources/MemoryBankConnector.swift
+++ b/desktop/macos/Desktop/Sources/MemoryBankConnector.swift
@@ -48,13 +48,18 @@ enum MemoryBankConnector {
       throw ConnectError.notInstalled(
         "OpenClaw not found locally (looked for ~/.openclaw/openclaw.json). Install OpenClaw, then try again.")
     }
-    let workspace = openClawConfiguredWorkspace(configURL: config) ?? home.appendingPathComponent(".openclaw/workspace")
+    guard let cliPath = openClawCLIPath() else {
+      throw ConnectError.notInstalled(
+        "OpenClaw CLI not found locally. Install OpenClaw or add the openclaw command to PATH, then try again.")
+    }
+    let workspace = openClawConfiguredWorkspace(configURL: config, cliPath: cliPath)
+      ?? home.appendingPathComponent(".openclaw/workspace")
     guard fm.fileExists(atPath: workspace.path) else {
       throw ConnectError.notInstalled(
         "OpenClaw workspace not found (looked for \(displayPath(for: workspace))). Run OpenClaw setup, then try again.")
     }
 
-    let alreadyWired = try ensureOpenClawMCPConfig(configURL: config, key: key)
+    let alreadyWired = try ensureOpenClawMCPConfig(configURL: config, key: key, cliPath: cliPath)
     let noteAdded = try ensureOpenClawSoulNote(workspace: workspace)
 
     if alreadyWired {
@@ -65,7 +70,18 @@ enum MemoryBankConnector {
     return "Connected OpenClaw — added the Omi MCP to openclaw.json and a 'search Omi first' note to SOUL.md."
   }
 
-  private static func openClawConfiguredWorkspace(configURL: URL) -> URL? {
+  private static func openClawConfiguredWorkspace(configURL: URL, cliPath: String) -> URL? {
+    if
+      let output = try? runOpenClawCLI(
+        cliPath: cliPath,
+        configURL: configURL,
+        arguments: ["config", "get", "agents.defaults.workspace"]
+      ),
+      let workspace = normalizedPath(output.stdout)
+    {
+      return workspace
+    }
+
     guard
       let data = try? Data(contentsOf: configURL),
       let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
@@ -76,20 +92,11 @@ enum MemoryBankConnector {
     else {
       return nil
     }
-    let expanded = workspace.replacingOccurrences(of: "~", with: home.path, options: .anchored)
-    return URL(fileURLWithPath: expanded)
+    return normalizedPath(workspace)
   }
 
   @discardableResult
-  private static func ensureOpenClawMCPConfig(configURL: URL, key: String) throws -> Bool {
-    if let cli = openClawCLIPath() {
-      return try ensureOpenClawMCPConfigWithCLI(configURL: configURL, key: key, cliPath: cli)
-    }
-    return try ensureOpenClawMCPConfigByStrictJSON(configURL: configURL, key: key)
-  }
-
-  @discardableResult
-  private static func ensureOpenClawMCPConfigWithCLI(configURL: URL, key: String, cliPath: String) throws -> Bool {
+  private static func ensureOpenClawMCPConfig(configURL: URL, key: String, cliPath: String) throws -> Bool {
     let server = openClawMCPServer(key: key)
     let existing = try? runOpenClawCLI(
       cliPath: cliPath,
@@ -120,46 +127,6 @@ enum MemoryBankConnector {
       throw ConnectError.invalidConfig(
         "OpenClaw rejected MCP config update for \(displayPath(for: configURL)): \(error.localizedDescription)")
     }
-  }
-
-  @discardableResult
-  private static func ensureOpenClawMCPConfigByStrictJSON(configURL: URL, key: String) throws -> Bool {
-    let data = try Data(contentsOf: configURL)
-    guard var json = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
-      throw ConnectError.invalidConfig(
-        "OpenClaw config is not strict JSON and the openclaw CLI was not found. Install the OpenClaw CLI, then try again.")
-    }
-
-    let server = openClawMCPServer(key: key)
-    var mcp: [String: Any]
-    if let existingMCP = json["mcp"] {
-      guard let existingMCP = existingMCP as? [String: Any] else {
-        throw ConnectError.invalidConfig("OpenClaw config has non-object mcp value in \(displayPath(for: configURL)).")
-      }
-      mcp = existingMCP
-    } else {
-      mcp = [:]
-    }
-    var servers: [String: Any]
-    if let existingServers = mcp["servers"] {
-      guard let existingServers = existingServers as? [String: Any] else {
-        throw ConnectError.invalidConfig("OpenClaw config has non-object mcp.servers value in \(displayPath(for: configURL)).")
-      }
-      servers = existingServers
-    } else {
-      servers = [:]
-    }
-    let existing = servers["omi-memory"] as? [String: Any]
-    if NSDictionary(dictionary: existing ?? [:]).isEqual(to: server) {
-      return true
-    }
-    servers["omi-memory"] = server
-    mcp["servers"] = servers
-    json["mcp"] = mcp
-
-    let output = try JSONSerialization.data(withJSONObject: json, options: [.prettyPrinted, .withoutEscapingSlashes])
-    try output.write(to: configURL, options: .atomic)
-    return false
   }
 
   private struct CommandOutput {
@@ -236,6 +203,13 @@ enum MemoryBankConnector {
         "Authorization": "Bearer \(key)"
       ],
     ]
+  }
+
+  private static func normalizedPath(_ raw: String) -> URL? {
+    let path = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !path.isEmpty else { return nil }
+    let expanded = path.replacingOccurrences(of: "~", with: home.path, options: .anchored)
+    return URL(fileURLWithPath: expanded)
   }
 
   @discardableResult

--- a/desktop/macos/Desktop/Sources/MemoryBankConnector.swift
+++ b/desktop/macos/Desktop/Sources/MemoryBankConnector.swift
@@ -1,11 +1,9 @@
 import Foundation
 
 /// Deterministic, local "Do it for me" for agent frameworks that store their
-/// memory/config as plain files (OpenClaw, Hermes). Unlike the cloud
-/// connectors, these don't have a CLI like `claude mcp add`, and delegating to
-/// the in-app agent proved unreliable (it doesn't reliably fire a file-write
-/// tool). So we write the Omi memory bank ourselves — idempotently — exactly
-/// the way Codex's config.toml block is written.
+/// memory/config locally (OpenClaw, Hermes). Delegating to the in-app agent
+/// proved unreliable (it doesn't reliably fire a file-write tool), so we wire
+/// the Omi memory bank ourselves using each agent's native durable surface.
 enum MemoryBankConnector {
   static let marker = "omi-memory-bank"
   private static var mcpURL: String { MemoryExportDestination.mcpServerURL }
@@ -38,6 +36,7 @@ enum MemoryBankConnector {
   }
 
   static var homeOverrideForTesting: URL?
+  static var openClawCLIPathOverrideForTesting: String?
   private static var home: URL { homeOverrideForTesting ?? FileManager.default.homeDirectoryForCurrentUser }
 
   // MARK: - OpenClaw (mcp.servers + workspace SOUL.md)
@@ -83,9 +82,52 @@ enum MemoryBankConnector {
 
   @discardableResult
   private static func ensureOpenClawMCPConfig(configURL: URL, key: String) throws -> Bool {
+    if let cli = openClawCLIPath() {
+      return try ensureOpenClawMCPConfigWithCLI(configURL: configURL, key: key, cliPath: cli)
+    }
+    return try ensureOpenClawMCPConfigByStrictJSON(configURL: configURL, key: key)
+  }
+
+  @discardableResult
+  private static func ensureOpenClawMCPConfigWithCLI(configURL: URL, key: String, cliPath: String) throws -> Bool {
+    let server = openClawMCPServer(key: key)
+    let existing = try? runOpenClawCLI(
+      cliPath: cliPath,
+      configURL: configURL,
+      arguments: ["mcp", "show", "omi-memory", "--json"]
+    )
+    if
+      let existing,
+      let data = existing.stdout.data(using: .utf8),
+      let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+      NSDictionary(dictionary: json).isEqual(to: server)
+    {
+      return true
+    }
+
+    let serverData = try JSONSerialization.data(withJSONObject: server, options: [.withoutEscapingSlashes])
+    guard let serverJSON = String(data: serverData, encoding: .utf8) else {
+      throw ConnectError.invalidConfig("Could not serialize OpenClaw MCP server config.")
+    }
+    do {
+      _ = try runOpenClawCLI(
+        cliPath: cliPath,
+        configURL: configURL,
+        arguments: ["mcp", "set", "omi-memory", serverJSON]
+      )
+      return false
+    } catch {
+      throw ConnectError.invalidConfig(
+        "OpenClaw rejected MCP config update for \(displayPath(for: configURL)): \(error.localizedDescription)")
+    }
+  }
+
+  @discardableResult
+  private static func ensureOpenClawMCPConfigByStrictJSON(configURL: URL, key: String) throws -> Bool {
     let data = try Data(contentsOf: configURL)
     guard var json = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
-      throw ConnectError.notInstalled("OpenClaw config is not a JSON object: \(displayPath(for: configURL)).")
+      throw ConnectError.invalidConfig(
+        "OpenClaw config is not strict JSON and the openclaw CLI was not found. Install the OpenClaw CLI, then try again.")
     }
 
     let server = openClawMCPServer(key: key)
@@ -118,6 +160,71 @@ enum MemoryBankConnector {
     let output = try JSONSerialization.data(withJSONObject: json, options: [.prettyPrinted, .withoutEscapingSlashes])
     try output.write(to: configURL, options: .atomic)
     return false
+  }
+
+  private struct CommandOutput {
+    let stdout: String
+    let stderr: String
+  }
+
+  private static func openClawCLIPath() -> String? {
+    if let override = openClawCLIPathOverrideForTesting {
+      return override.isEmpty ? nil : override
+    }
+    let candidates = [
+      home.appendingPathComponent(".hermes/node/bin/openclaw").path,
+      "/opt/homebrew/bin/openclaw",
+      "/usr/local/bin/openclaw",
+    ]
+    if let path = candidates.first(where: { FileManager.default.isExecutableFile(atPath: $0) }) {
+      return path
+    }
+    return try? runShell(["-lc", "command -v openclaw"]).stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+      .nilIfEmpty
+  }
+
+  private static func runOpenClawCLI(cliPath: String, configURL: URL, arguments: [String]) throws -> CommandOutput {
+    try runProcess(
+      executable: cliPath,
+      arguments: arguments,
+      environment: ["OPENCLAW_CONFIG_PATH": configURL.path]
+    )
+  }
+
+  private static func runShell(_ arguments: [String]) throws -> CommandOutput {
+    try runProcess(executable: "/bin/zsh", arguments: arguments, environment: [:])
+  }
+
+  private static func runProcess(
+    executable: String,
+    arguments: [String],
+    environment: [String: String]
+  ) throws -> CommandOutput {
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: executable)
+    process.arguments = arguments
+    var processEnvironment = ProcessInfo.processInfo.environment
+    for (key, value) in environment {
+      processEnvironment[key] = value
+    }
+    process.environment = processEnvironment
+
+    let stdout = Pipe()
+    let stderr = Pipe()
+    process.standardOutput = stdout
+    process.standardError = stderr
+    try process.run()
+    process.waitUntilExit()
+
+    let output = String(data: stdout.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+    let error = String(data: stderr.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+    guard process.terminationStatus == 0 else {
+      let message = error.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
+        ?? output.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
+        ?? "exit code \(process.terminationStatus)"
+      throw ConnectError.invalidConfig(message)
+    }
+    return CommandOutput(stdout: output, stderr: error)
   }
 
   private static func openClawMCPServer(key: String) -> [String: Any] {
@@ -265,7 +372,7 @@ enum MemoryBankConnector {
     var lines = content.components(separatedBy: "\n")
     let hadTrailingNewline = content.hasSuffix("\n")
 
-    if let sectionIndex = lines.firstIndex(where: { $0 == "mcp_servers:" }) {
+    if let sectionIndex = lines.firstIndex(where: { isTopLevelYAMLKey($0, named: "mcp_servers") }) {
       let nextTopLevelIndex =
         lines[(sectionIndex + 1)...]
         .firstIndex(where: { !$0.isEmpty && !$0.hasPrefix(" ") && !$0.hasPrefix("\t") }) ?? lines.endIndex
@@ -288,7 +395,7 @@ enum MemoryBankConnector {
       return updated
     }
 
-    if lines.contains(where: { $0.trimmingCharacters(in: .whitespaces) == "mcp_servers:" }) {
+    if lines.contains(where: { $0.trimmingCharacters(in: .whitespaces).hasPrefix("mcp_servers:") }) {
       throw ConnectError.invalidConfig(
         "Hermes config has an indented mcp_servers section; expected top-level mcp_servers in \(displayPath(for: configURL)).")
     }
@@ -298,5 +405,17 @@ enum MemoryBankConnector {
     updated += "\nmcp_servers:\n" + entry
     if hadTrailingNewline || content.isEmpty { updated += "\n" }
     return updated
+  }
+
+  private static func isTopLevelYAMLKey(_ line: String, named key: String) -> Bool {
+    guard !line.hasPrefix(" "), !line.hasPrefix("\t") else { return false }
+    let withoutComment = line.split(separator: "#", maxSplits: 1, omittingEmptySubsequences: false)[0]
+    return withoutComment.trimmingCharacters(in: .whitespaces) == "\(key):"
+  }
+}
+
+private extension String {
+  var nilIfEmpty: String? {
+    isEmpty ? nil : self
   }
 }

--- a/desktop/macos/Desktop/Sources/MemoryBankConnector.swift
+++ b/desktop/macos/Desktop/Sources/MemoryBankConnector.swift
@@ -12,9 +12,11 @@ enum MemoryBankConnector {
 
   enum ConnectError: LocalizedError {
     case notInstalled(String)
+    case invalidConfig(String)
     var errorDescription: String? {
       switch self {
       case .notInstalled(let msg): return msg
+      case .invalidConfig(let msg): return msg
       }
     }
   }
@@ -35,41 +37,127 @@ enum MemoryBankConnector {
     }
   }
 
-  private static var home: URL { FileManager.default.homeDirectoryForCurrentUser }
+  static var homeOverrideForTesting: URL?
+  private static var home: URL { homeOverrideForTesting ?? FileManager.default.homeDirectoryForCurrentUser }
 
-  // MARK: - OpenClaw (markdown memory bank)
+  // MARK: - OpenClaw (mcp.servers + workspace SOUL.md)
 
   private static func connectOpenClaw(key: String) throws -> String {
     let fm = FileManager.default
-    // OpenClaw keeps its core memory as markdown in its workspace; ~/clawd is
-    // the documented default, MEMORY.md the core file.
-    let candidates = ["clawd/MEMORY.md", ".openclaw/MEMORY.md", "clawd/AGENTS.md"]
-    guard
-      let rel = candidates.first(where: {
-        fm.fileExists(atPath: home.appendingPathComponent($0).path)
-      })
-    else {
+    let config = home.appendingPathComponent(".openclaw/openclaw.json")
+    guard fm.fileExists(atPath: config.path) else {
       throw ConnectError.notInstalled(
-        "OpenClaw not found locally (looked for ~/clawd/MEMORY.md). Install OpenClaw, then try again.")
+        "OpenClaw not found locally (looked for ~/.openclaw/openclaw.json). Install OpenClaw, then try again.")
     }
-    let url = home.appendingPathComponent(rel)
-    var content = (try? String(contentsOf: url, encoding: .utf8)) ?? ""
-    if content.contains(marker) {
-      return "OpenClaw already connected — Omi memory bank is in ~/\(rel)."
+    let workspace = openClawConfiguredWorkspace(configURL: config) ?? home.appendingPathComponent(".openclaw/workspace")
+    guard fm.fileExists(atPath: workspace.path) else {
+      throw ConnectError.notInstalled(
+        "OpenClaw workspace not found (looked for \(displayPath(for: workspace))). Run OpenClaw setup, then try again.")
     }
-    if !content.isEmpty && !content.hasSuffix("\n") { content += "\n" }
-    content += "\n" + openClawBlock(key: key) + "\n"
-    try content.write(to: url, atomically: true, encoding: .utf8)
-    return "Connected OpenClaw — added the Omi memory bank to ~/\(rel)."
+
+    let alreadyWired = try ensureOpenClawMCPConfig(configURL: config, key: key)
+    let noteAdded = try ensureOpenClawSoulNote(workspace: workspace)
+
+    if alreadyWired {
+      return noteAdded
+        ? "OpenClaw already had the Omi MCP — added the 'search Omi first' note to \(displayPath(for: workspace.appendingPathComponent("SOUL.md")))."
+        : "OpenClaw already connected — Omi MCP in openclaw.json, note in SOUL.md."
+    }
+    return "Connected OpenClaw — added the Omi MCP to openclaw.json and a 'search Omi first' note to SOUL.md."
   }
 
-  private static func openClawBlock(key: String) -> String {
+  private static func openClawConfiguredWorkspace(configURL: URL) -> URL? {
+    guard
+      let data = try? Data(contentsOf: configURL),
+      let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+      let agents = json["agents"] as? [String: Any],
+      let defaults = agents["defaults"] as? [String: Any],
+      let workspace = defaults["workspace"] as? String,
+      !workspace.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    else {
+      return nil
+    }
+    let expanded = workspace.replacingOccurrences(of: "~", with: home.path, options: .anchored)
+    return URL(fileURLWithPath: expanded)
+  }
+
+  @discardableResult
+  private static func ensureOpenClawMCPConfig(configURL: URL, key: String) throws -> Bool {
+    let data = try Data(contentsOf: configURL)
+    guard var json = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+      throw ConnectError.notInstalled("OpenClaw config is not a JSON object: \(displayPath(for: configURL)).")
+    }
+
+    let server = openClawMCPServer(key: key)
+    var mcp: [String: Any]
+    if let existingMCP = json["mcp"] {
+      guard let existingMCP = existingMCP as? [String: Any] else {
+        throw ConnectError.invalidConfig("OpenClaw config has non-object mcp value in \(displayPath(for: configURL)).")
+      }
+      mcp = existingMCP
+    } else {
+      mcp = [:]
+    }
+    var servers: [String: Any]
+    if let existingServers = mcp["servers"] {
+      guard let existingServers = existingServers as? [String: Any] else {
+        throw ConnectError.invalidConfig("OpenClaw config has non-object mcp.servers value in \(displayPath(for: configURL)).")
+      }
+      servers = existingServers
+    } else {
+      servers = [:]
+    }
+    let existing = servers["omi-memory"] as? [String: Any]
+    if NSDictionary(dictionary: existing ?? [:]).isEqual(to: server) {
+      return true
+    }
+    servers["omi-memory"] = server
+    mcp["servers"] = servers
+    json["mcp"] = mcp
+
+    let output = try JSONSerialization.data(withJSONObject: json, options: [.prettyPrinted, .withoutEscapingSlashes])
+    try output.write(to: configURL, options: .atomic)
+    return false
+  }
+
+  private static func openClawMCPServer(key: String) -> [String: Any] {
+    [
+      "enabled": true,
+      "url": mcpURL,
+      "transport": "sse",
+      "headers": [
+        "Authorization": "Bearer \(key)"
+      ],
+    ]
+  }
+
+  @discardableResult
+  private static func ensureOpenClawSoulNote(workspace: URL) throws -> Bool {
+    let url = workspace.appendingPathComponent("SOUL.md")
+    var soul = (try? String(contentsOf: url, encoding: .utf8)) ?? ""
+    if soul.contains(marker) { return false }
+    if !soul.isEmpty && !soul.hasSuffix("\n") { soul += "\n" }
+    soul += "\n" + openClawSoulBlock() + "\n"
+    let isSymlink = (try? FileManager.default.destinationOfSymbolicLink(atPath: url.path)) != nil
+    try soul.write(to: url, atomically: !isSymlink, encoding: .utf8)
+    return true
+  }
+
+  private static func displayPath(for url: URL) -> String {
+    let homePath = home.standardizedFileURL.path
+    let path = url.standardizedFileURL.path
+    if path == homePath { return "~" }
+    if path.hasPrefix(homePath + "/") {
+      return "~/" + String(path.dropFirst(homePath.count + 1))
+    }
+    return path
+  }
+
+  private static func openClawSoulBlock() -> String {
     """
     <!-- \(marker) -->
     ## OMI memory (search FIRST)
-    Omi is your memory bank. Before any task, **search Omi memory first** for context, then save durable new facts back to it.
-    - MCP: \(mcpURL)  (Authorization: Bearer \(key))
-    - Config-file MCP clients should connect through `mcp-remote` with this endpoint and Authorization header.
+    Omi is your memory bank. Before any task, search Omi memory first for context, then save durable new facts back to it. The `omi-memory` MCP server is configured for you — use it.
     <!-- /\(marker) -->
     """
   }
@@ -79,31 +167,24 @@ enum MemoryBankConnector {
   private static func connectHermes(key: String) throws -> String {
     let fm = FileManager.default
     let hermesDir = home.appendingPathComponent(".hermes")
-    guard fm.fileExists(atPath: hermesDir.path) else {
+    guard hermesInstallIsPresent(hermesDir: hermesDir, fileManager: fm) else {
       throw ConnectError.notInstalled(
-        "Hermes not found locally (~/.hermes). Install Hermes, then try again.")
+        "Hermes not found locally (looked for ~/.hermes/config.yaml and Hermes install files). Install Hermes, then try again.")
     }
 
     // 1. Wire the Omi memory MCP into config.yaml (idempotent).
     let cfg = hermesDir.appendingPathComponent("config.yaml")
     var content = (try? String(contentsOf: cfg, encoding: .utf8)) ?? ""
-    let alreadyWired = content.contains("omi-memory")
+    let alreadyWired = hermesEntryIsCurrent(content: content, key: key)
     if !alreadyWired {
-      let entry = hermesEntry(key: key)
-      if let range = content.range(of: "mcp_servers:") {
-        // Insert as the first child under the existing mcp_servers: key.
-        content.replaceSubrange(range, with: "mcp_servers:\n" + entry)
-      } else {
-        if !content.isEmpty && !content.hasSuffix("\n") { content += "\n" }
-        content += "\nmcp_servers:\n" + entry
-      }
+      content = try upsertHermesEntry(content: content, key: key, configURL: cfg)
       try content.write(to: cfg, atomically: true, encoding: .utf8)
     }
 
     // 2. Tell the agent to *use* it — append a "search Omi first" note to the
     //    Hermes system prompt (SOUL.md), matching OpenClaw's memory file. Having
     //    the tool isn't enough; this makes the agent prefer Omi memory.
-    let noteAdded = ensureHermesSoulNote(hermesDir: hermesDir)
+    let noteAdded = try ensureHermesSoulNote(hermesDir: hermesDir)
 
     if alreadyWired {
       return noteAdded
@@ -113,25 +194,48 @@ enum MemoryBankConnector {
     return "Connected Hermes — added the Omi MCP to config.yaml and a 'search Omi first' note to SOUL.md."
   }
 
+  private static func hermesInstallIsPresent(hermesDir: URL, fileManager fm: FileManager) -> Bool {
+    var isDirectory: ObjCBool = false
+    guard fm.fileExists(atPath: hermesDir.path, isDirectory: &isDirectory), isDirectory.boolValue else {
+      return false
+    }
+    guard fm.fileExists(atPath: hermesDir.appendingPathComponent("config.yaml").path) else {
+      return false
+    }
+    if hermesPackageLooksInstalled(hermesDir: hermesDir) { return true }
+    let evidence = [
+      ".install_method",
+      "hermes-agent/hermes",
+    ]
+    return evidence.contains { fm.fileExists(atPath: hermesDir.appendingPathComponent($0).path) }
+  }
+
+  private static func hermesPackageLooksInstalled(hermesDir: URL) -> Bool {
+    let package = hermesDir.appendingPathComponent("hermes-agent/package.json")
+    guard
+      let data = try? Data(contentsOf: package),
+      let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+      json["name"] as? String == "hermes-agent"
+    else {
+      return false
+    }
+    return true
+  }
+
   /// Appends the marked "search Omi first" block to the Hermes system prompt so
-  /// every user's agent is told to prefer Omi memory. Uses the first existing
-  /// prompt file, creating SOUL.md when none exists. Writes *through* a symlinked
+  /// every user's agent is told to prefer Omi memory. Writes SOUL.md, creating
+  /// it when needed. Writes *through* a symlinked
   /// prompt instead of replacing it. Idempotent; returns true only when it wrote.
   @discardableResult
-  private static func ensureHermesSoulNote(hermesDir: URL) -> Bool {
+  private static func ensureHermesSoulNote(hermesDir: URL) throws -> Bool {
     let fm = FileManager.default
-    let candidates = ["SOUL.md", "soul.md", "AGENTS.md", "system.md"]
-    let rel =
-      candidates.first(where: {
-        fm.fileExists(atPath: hermesDir.appendingPathComponent($0).path)
-      }) ?? "SOUL.md"
-    let url = hermesDir.appendingPathComponent(rel)
+    let url = hermesDir.appendingPathComponent("SOUL.md")
     var soul = (try? String(contentsOf: url, encoding: .utf8)) ?? ""
     if soul.contains(marker) { return false }
     if !soul.isEmpty && !soul.hasSuffix("\n") { soul += "\n" }
     soul += "\n" + hermesSoulBlock() + "\n"
     let isSymlink = (try? fm.destinationOfSymbolicLink(atPath: url.path)) != nil
-    try? soul.write(to: url, atomically: !isSymlink, encoding: .utf8)
+    try soul.write(to: url, atomically: !isSymlink, encoding: .utf8)
     return true
   }
 
@@ -150,5 +254,49 @@ enum MemoryBankConnector {
         command: npx
         args: ["-y", "mcp-remote", "\(mcpURL)", "--header", "Authorization: Bearer \(key)"]
     """
+  }
+
+  private static func hermesEntryIsCurrent(content: String, key: String) -> Bool {
+    content.contains(hermesEntry(key: key))
+  }
+
+  private static func upsertHermesEntry(content: String, key: String, configURL: URL) throws -> String {
+    let entry = hermesEntry(key: key)
+    var lines = content.components(separatedBy: "\n")
+    let hadTrailingNewline = content.hasSuffix("\n")
+
+    if let sectionIndex = lines.firstIndex(where: { $0 == "mcp_servers:" }) {
+      let nextTopLevelIndex =
+        lines[(sectionIndex + 1)...]
+        .firstIndex(where: { !$0.isEmpty && !$0.hasPrefix(" ") && !$0.hasPrefix("\t") }) ?? lines.endIndex
+      if let existingIndex = lines[(sectionIndex + 1)..<nextTopLevelIndex].firstIndex(where: { $0 == "  omi-memory:" }) {
+        var endIndex = existingIndex + 1
+        while endIndex < nextTopLevelIndex {
+          let line = lines[endIndex]
+          if line.hasPrefix("    ") || line.isEmpty {
+            endIndex += 1
+          } else {
+            break
+          }
+        }
+        lines.replaceSubrange(existingIndex..<endIndex, with: entry.components(separatedBy: "\n"))
+      } else {
+        lines.insert(contentsOf: entry.components(separatedBy: "\n"), at: sectionIndex + 1)
+      }
+      var updated = lines.joined(separator: "\n")
+      if hadTrailingNewline && !updated.hasSuffix("\n") { updated += "\n" }
+      return updated
+    }
+
+    if lines.contains(where: { $0.trimmingCharacters(in: .whitespaces) == "mcp_servers:" }) {
+      throw ConnectError.invalidConfig(
+        "Hermes config has an indented mcp_servers section; expected top-level mcp_servers in \(displayPath(for: configURL)).")
+    }
+
+    var updated = content
+    if !updated.isEmpty && !updated.hasSuffix("\n") { updated += "\n" }
+    updated += "\nmcp_servers:\n" + entry
+    if hadTrailingNewline || content.isEmpty { updated += "\n" }
+    return updated
   }
 }

--- a/desktop/macos/Desktop/Tests/MemoryBankConnectorTests.swift
+++ b/desktop/macos/Desktop/Tests/MemoryBankConnectorTests.swift
@@ -11,10 +11,12 @@ final class MemoryBankConnectorTests: XCTestCase {
       .appendingPathComponent("memory-bank-connector-\(UUID().uuidString)", isDirectory: true)
     try FileManager.default.createDirectory(at: tempHome, withIntermediateDirectories: true)
     MemoryBankConnector.homeOverrideForTesting = tempHome
+    MemoryBankConnector.openClawCLIPathOverrideForTesting = ""
   }
 
   override func tearDownWithError() throws {
     MemoryBankConnector.homeOverrideForTesting = nil
+    MemoryBankConnector.openClawCLIPathOverrideForTesting = nil
     if let tempHome {
       try? FileManager.default.removeItem(at: tempHome)
     }
@@ -40,6 +42,29 @@ final class MemoryBankConnectorTests: XCTestCase {
     XCTAssertTrue(configContent.contains(#""omi-memory""#))
     XCTAssertTrue(configContent.contains(#""transport" : "sse""#))
     XCTAssertTrue(configContent.contains(#""Authorization" : "Bearer test-key""#))
+  }
+
+  func testOpenClawConnectUsesCLIForJSON5Config() throws {
+    let workspace = tempHome.appendingPathComponent(".openclaw/workspace", isDirectory: true)
+    try FileManager.default.createDirectory(at: workspace, withIntermediateDirectories: true)
+    let configDir = tempHome.appendingPathComponent(".openclaw", isDirectory: true)
+    try FileManager.default.createDirectory(at: configDir, withIntermediateDirectories: true)
+    let config = configDir.appendingPathComponent("openclaw.json")
+    try """
+      {
+        agents: { defaults: { workspace: "\(workspace.path)" } },
+      }
+      """.write(to: config, atomically: true, encoding: .utf8)
+    let cli = try writeFakeOpenClawCLI()
+    MemoryBankConnector.openClawCLIPathOverrideForTesting = cli.path
+
+    _ = try MemoryBankConnector.connect(.openclaw, key: "test-key")
+
+    let configContent = try String(contentsOf: config, encoding: .utf8)
+    XCTAssertTrue(configContent.contains(#""omi-memory""#))
+    XCTAssertTrue(configContent.contains(#""transport":"sse""#))
+    XCTAssertTrue(configContent.contains(#""Authorization":"Bearer test-key""#))
+    XCTAssertTrue(FileManager.default.fileExists(atPath: workspace.appendingPathComponent("SOUL.md").path))
   }
 
   func testOpenClawConnectUsesConfiguredWorkspaceForSoulNote() throws {
@@ -114,6 +139,25 @@ final class MemoryBankConnectorTests: XCTestCase {
     XCTAssertFalse(config.contains("https://old.example"))
   }
 
+  func testHermesConnectRecognizesFormattedMCPServersKey() throws {
+    let hermes = try writeHermesInstall(
+      config: """
+        model:
+          default: test
+        mcp_servers:  # local tools
+          other-tool:
+            command: other
+        """
+    )
+
+    _ = try MemoryBankConnector.connect(.hermes, key: "test-key")
+
+    let config = try String(contentsOf: hermes.appendingPathComponent("config.yaml"), encoding: .utf8)
+    XCTAssertEqual(config.components(separatedBy: "mcp_servers:").count - 1, 1)
+    XCTAssertTrue(config.contains("Authorization: Bearer test-key"))
+    XCTAssertTrue(config.contains("other-tool:"))
+  }
+
   func testHermesConnectAlwaysWritesSoulNotAgentsFallback() throws {
     let hermes = try writeHermesInstall()
     try "legacy agents prompt".write(
@@ -144,6 +188,24 @@ final class MemoryBankConnectorTests: XCTestCase {
     let url = configDir.appendingPathComponent("openclaw.json")
     try config.write(to: url, atomically: true, encoding: .utf8)
     return url
+  }
+
+  private func writeFakeOpenClawCLI() throws -> URL {
+    let cli = tempHome.appendingPathComponent("openclaw")
+    try """
+      #!/bin/sh
+      if [ "$1" = "mcp" ] && [ "$2" = "show" ]; then
+        exit 1
+      fi
+      if [ "$1" = "mcp" ] && [ "$2" = "set" ] && [ "$3" = "omi-memory" ]; then
+        printf '{"mcp":{"servers":{"omi-memory":%s}}}\\n' "$4" > "$OPENCLAW_CONFIG_PATH"
+        exit 0
+      fi
+      echo "unexpected arguments: $*" >&2
+      exit 2
+      """.write(to: cli, atomically: true, encoding: .utf8)
+    try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: cli.path)
+    return cli
   }
 
   private func writeHermesInstall(config: String = "model:\n  default: test\n") throws -> URL {

--- a/desktop/macos/Desktop/Tests/MemoryBankConnectorTests.swift
+++ b/desktop/macos/Desktop/Tests/MemoryBankConnectorTests.swift
@@ -11,7 +11,7 @@ final class MemoryBankConnectorTests: XCTestCase {
       .appendingPathComponent("memory-bank-connector-\(UUID().uuidString)", isDirectory: true)
     try FileManager.default.createDirectory(at: tempHome, withIntermediateDirectories: true)
     MemoryBankConnector.homeOverrideForTesting = tempHome
-    MemoryBankConnector.openClawCLIPathOverrideForTesting = ""
+    MemoryBankConnector.openClawCLIPathOverrideForTesting = try writeFakeOpenClawCLI().path
   }
 
   override func tearDownWithError() throws {
@@ -40,8 +40,8 @@ final class MemoryBankConnectorTests: XCTestCase {
     XCTAssertTrue(soulContent.contains("The `omi-memory` MCP server is configured for you"))
     XCTAssertFalse(soulContent.contains("test-key"))
     XCTAssertTrue(configContent.contains(#""omi-memory""#))
-    XCTAssertTrue(configContent.contains(#""transport" : "sse""#))
-    XCTAssertTrue(configContent.contains(#""Authorization" : "Bearer test-key""#))
+    XCTAssertTrue(configContent.contains(#""transport":"sse""#))
+    XCTAssertTrue(configContent.contains(#""Authorization":"Bearer test-key""#))
   }
 
   func testOpenClawConnectUsesCLIForJSON5Config() throws {
@@ -55,9 +55,6 @@ final class MemoryBankConnectorTests: XCTestCase {
         agents: { defaults: { workspace: "\(workspace.path)" } },
       }
       """.write(to: config, atomically: true, encoding: .utf8)
-    let cli = try writeFakeOpenClawCLI()
-    MemoryBankConnector.openClawCLIPathOverrideForTesting = cli.path
-
     _ = try MemoryBankConnector.connect(.openclaw, key: "test-key")
 
     let configContent = try String(contentsOf: config, encoding: .utf8)
@@ -86,7 +83,8 @@ final class MemoryBankConnectorTests: XCTestCase {
     let config = try writeOpenClawConfig(workspace: workspace, extra: #","mcp":[]"#)
 
     XCTAssertThrowsError(try MemoryBankConnector.connect(.openclaw, key: "test-key")) { error in
-      XCTAssertTrue(error.localizedDescription.contains("non-object mcp value"))
+      XCTAssertTrue(error.localizedDescription.contains("OpenClaw rejected MCP config update"))
+      XCTAssertTrue(error.localizedDescription.contains("expected object"))
     }
     let configContent = try String(contentsOf: config, encoding: .utf8)
     XCTAssertTrue(configContent.contains(#""mcp":[]"#))
@@ -198,6 +196,10 @@ final class MemoryBankConnectorTests: XCTestCase {
         exit 1
       fi
       if [ "$1" = "mcp" ] && [ "$2" = "set" ] && [ "$3" = "omi-memory" ]; then
+        if grep -Fq '"mcp":[]' "$OPENCLAW_CONFIG_PATH"; then
+          echo "mcp: Invalid input: expected object, received array" >&2
+          exit 1
+        fi
         printf '{"mcp":{"servers":{"omi-memory":%s}}}\\n' "$4" > "$OPENCLAW_CONFIG_PATH"
         exit 0
       fi

--- a/desktop/macos/Desktop/Tests/MemoryBankConnectorTests.swift
+++ b/desktop/macos/Desktop/Tests/MemoryBankConnectorTests.swift
@@ -1,0 +1,164 @@
+import XCTest
+
+@testable import Omi_Computer
+
+final class MemoryBankConnectorTests: XCTestCase {
+  private var tempHome: URL!
+
+  override func setUpWithError() throws {
+    try super.setUpWithError()
+    tempHome = FileManager.default.temporaryDirectory
+      .appendingPathComponent("memory-bank-connector-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: tempHome, withIntermediateDirectories: true)
+    MemoryBankConnector.homeOverrideForTesting = tempHome
+  }
+
+  override func tearDownWithError() throws {
+    MemoryBankConnector.homeOverrideForTesting = nil
+    if let tempHome {
+      try? FileManager.default.removeItem(at: tempHome)
+    }
+    try super.tearDownWithError()
+  }
+
+  func testOpenClawConnectWritesMCPConfigAndSoulNote() throws {
+    let workspace = tempHome.appendingPathComponent(".openclaw/workspace", isDirectory: true)
+    try FileManager.default.createDirectory(at: workspace, withIntermediateDirectories: true)
+    let config = try writeOpenClawConfig(workspace: workspace)
+
+    let message = try MemoryBankConnector.connect(.openclaw, key: "test-key")
+
+    let soul = workspace.appendingPathComponent("SOUL.md")
+    let soulContent = try String(contentsOf: soul, encoding: .utf8)
+    let configContent = try String(contentsOf: config, encoding: .utf8)
+    XCTAssertEqual(
+      message,
+      "Connected OpenClaw — added the Omi MCP to openclaw.json and a 'search Omi first' note to SOUL.md.")
+    XCTAssertTrue(soulContent.contains(MemoryBankConnector.marker))
+    XCTAssertTrue(soulContent.contains("The `omi-memory` MCP server is configured for you"))
+    XCTAssertFalse(soulContent.contains("test-key"))
+    XCTAssertTrue(configContent.contains(#""omi-memory""#))
+    XCTAssertTrue(configContent.contains(#""transport" : "sse""#))
+    XCTAssertTrue(configContent.contains(#""Authorization" : "Bearer test-key""#))
+  }
+
+  func testOpenClawConnectUsesConfiguredWorkspaceForSoulNote() throws {
+    let workspace = tempHome.appendingPathComponent("custom-openclaw-workspace", isDirectory: true)
+    try FileManager.default.createDirectory(at: workspace, withIntermediateDirectories: true)
+    _ = try writeOpenClawConfig(workspace: workspace)
+
+    _ = try MemoryBankConnector.connect(.openclaw, key: "test-key")
+
+    XCTAssertTrue(FileManager.default.fileExists(atPath: workspace.appendingPathComponent("SOUL.md").path))
+    XCTAssertFalse(
+      FileManager.default.fileExists(
+        atPath: tempHome.appendingPathComponent(".openclaw/workspace/SOUL.md").path))
+  }
+
+  func testOpenClawConnectRejectsMalformedMCPConfig() throws {
+    let workspace = tempHome.appendingPathComponent(".openclaw/workspace", isDirectory: true)
+    try FileManager.default.createDirectory(at: workspace, withIntermediateDirectories: true)
+    let config = try writeOpenClawConfig(workspace: workspace, extra: #","mcp":[]"#)
+
+    XCTAssertThrowsError(try MemoryBankConnector.connect(.openclaw, key: "test-key")) { error in
+      XCTAssertTrue(error.localizedDescription.contains("non-object mcp value"))
+    }
+    let configContent = try String(contentsOf: config, encoding: .utf8)
+    XCTAssertTrue(configContent.contains(#""mcp":[]"#))
+    XCTAssertFalse(configContent.contains("omi-memory"))
+  }
+
+  func testHermesConnectRequiresRealInstallEvidence() throws {
+    let hermes = tempHome.appendingPathComponent(".hermes", isDirectory: true)
+    try FileManager.default.createDirectory(at: hermes, withIntermediateDirectories: true)
+
+    XCTAssertThrowsError(try MemoryBankConnector.connect(.hermes, key: "test-key")) { error in
+      XCTAssertTrue(error.localizedDescription.contains("Hermes not found locally"))
+    }
+    XCTAssertFalse(FileManager.default.fileExists(atPath: hermes.appendingPathComponent("config.yaml").path))
+    XCTAssertFalse(FileManager.default.fileExists(atPath: hermes.appendingPathComponent("SOUL.md").path))
+  }
+
+  func testHermesConnectWritesConfigAndSoulForInstalledHermes() throws {
+    let hermes = try writeHermesInstall()
+
+    let message = try MemoryBankConnector.connect(.hermes, key: "test-key")
+
+    let config = try String(contentsOf: hermes.appendingPathComponent("config.yaml"), encoding: .utf8)
+    let soul = try String(contentsOf: hermes.appendingPathComponent("SOUL.md"), encoding: .utf8)
+    XCTAssertEqual(message, "Connected Hermes — added the Omi MCP to config.yaml and a 'search Omi first' note to SOUL.md.")
+    XCTAssertTrue(config.contains("omi-memory:"))
+    XCTAssertTrue(config.contains("Authorization: Bearer test-key"))
+    XCTAssertTrue(soul.contains(MemoryBankConnector.marker))
+    XCTAssertTrue(soul.contains("The `omi-memory` MCP server is configured for you"))
+    XCTAssertFalse(soul.contains("test-key"))
+  }
+
+  func testHermesConnectReplacesStaleOmiMemoryEntry() throws {
+    let hermes = try writeHermesInstall(
+      config: """
+        model:
+          default: test
+        mcp_servers:
+          omi-memory:
+            command: npx
+            args: ["-y", "mcp-remote", "https://old.example/v1/mcp/sse", "--header", "Authorization: Bearer old-key"]
+        """
+    )
+
+    _ = try MemoryBankConnector.connect(.hermes, key: "new-key")
+
+    let config = try String(contentsOf: hermes.appendingPathComponent("config.yaml"), encoding: .utf8)
+    XCTAssertTrue(config.contains("Authorization: Bearer new-key"))
+    XCTAssertFalse(config.contains("old-key"))
+    XCTAssertFalse(config.contains("https://old.example"))
+  }
+
+  func testHermesConnectAlwaysWritesSoulNotAgentsFallback() throws {
+    let hermes = try writeHermesInstall()
+    try "legacy agents prompt".write(
+      to: hermes.appendingPathComponent("AGENTS.md"),
+      atomically: true,
+      encoding: .utf8)
+
+    _ = try MemoryBankConnector.connect(.hermes, key: "test-key")
+
+    let uppercaseSoul = try String(contentsOf: hermes.appendingPathComponent("SOUL.md"), encoding: .utf8)
+    let agents = try String(contentsOf: hermes.appendingPathComponent("AGENTS.md"), encoding: .utf8)
+    XCTAssertTrue(uppercaseSoul.contains(MemoryBankConnector.marker))
+    XCTAssertEqual(agents, "legacy agents prompt")
+  }
+
+  private func writeOpenClawConfig(workspace: URL, extra: String = "") throws -> URL {
+    let configDir = tempHome.appendingPathComponent(".openclaw", isDirectory: true)
+    try FileManager.default.createDirectory(at: configDir, withIntermediateDirectories: true)
+    let config = """
+      {
+        "agents": {
+          "defaults": {
+            "workspace": "\(workspace.path)"
+          }
+        }\(extra)
+      }
+      """
+    let url = configDir.appendingPathComponent("openclaw.json")
+    try config.write(to: url, atomically: true, encoding: .utf8)
+    return url
+  }
+
+  private func writeHermesInstall(config: String = "model:\n  default: test\n") throws -> URL {
+    let hermes = tempHome.appendingPathComponent(".hermes", isDirectory: true)
+    try FileManager.default.createDirectory(
+      at: hermes.appendingPathComponent("hermes-agent", isDirectory: true),
+      withIntermediateDirectories: true)
+    try config.write(
+      to: hermes.appendingPathComponent("config.yaml"),
+      atomically: true,
+      encoding: .utf8)
+    try #"{"name":"hermes-agent"}"#.write(
+      to: hermes.appendingPathComponent("hermes-agent/package.json"),
+      atomically: true,
+      encoding: .utf8)
+    return hermes
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260702-openclaw-memory-detection.json
+++ b/desktop/macos/changelog/unreleased/20260702-openclaw-memory-detection.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed OpenClaw and Hermes memory-bank setup so local installs are detected safely and Omi MCP wiring is updated deterministically."
+}

--- a/desktop/macos/changelog/unreleased/20260702-openclaw-memory-detection.json
+++ b/desktop/macos/changelog/unreleased/20260702-openclaw-memory-detection.json
@@ -1,3 +1,3 @@
 {
-  "change": "Fixed OpenClaw and Hermes memory-bank setup so local installs are detected safely and Omi MCP wiring is updated deterministically."
+  "change": "Fixed OpenClaw and Hermes memory-bank setup so local installs are detected safely and Omi MCP wiring is updated deterministically"
 }


### PR DESCRIPTION
## Summary
- wire OpenClaw Omi memory setup through `mcp.servers.omi-memory` in `openclaw.json` and put only the search-first nudge in workspace `SOUL.md`
- harden Hermes install detection and upsert stale `omi-memory` config entries deterministically
- add connector tests for OpenClaw config shape handling, Hermes install evidence, stale key replacement, and SOUL-only prompt notes

## Tests
- `xcrun swift test -c debug --package-path Desktop --filter MemoryBankConnectorTests`

## Review
- subagent review completed; initial findings addressed and follow-up re-review found no blockers

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8821?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

