### PR TITLE
Complete Google connector hardening follow-up

### DIFF
--- a/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
+++ b/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
@@ -695,6 +695,62 @@ final class DesktopAutomationActionRegistry {
     }
 
     register(
+      name: "gmail_read_probe",
+      summary: "Read Gmail through the real connector path and return classified status",
+      params: ["maxResults", "query"]
+    ) { params in
+      let requestedMaxResults = intParam(params["maxResults"], default: 1)
+      let maxResults = min(max(requestedMaxResults, 1), 500)
+      let rawQuery = params["query"]?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+      let query = rawQuery.isEmpty ? "newer_than:1d" : rawQuery
+
+      do {
+        let emails = try await GmailReaderService.shared.readRecentEmails(
+          maxResults: maxResults,
+          query: query
+        )
+        return [
+          "status": "connected",
+          "classification": "readable",
+          "emailCount": "\(emails.count)",
+          "maxResults": "\(maxResults)",
+          "query": query,
+        ]
+      } catch let error as GmailReaderError {
+        let classification: String
+        switch error {
+        case .noBrowserFound:
+          classification = "no_browser"
+        case .noGmailCookies, .notSignedIn:
+          classification = "not_signed_in"
+        case .sessionExpired, .authFailed:
+          classification = "session_expired"
+        case .cookieDecryptionFailed:
+          classification = "decrypt_failed"
+        case .networkError:
+          classification = "network"
+        case .pythonNotFound:
+          classification = "python_not_found"
+        }
+        return [
+          "status": "error",
+          "classification": classification,
+          "message": error.errorDescription ?? "\(error)",
+          "maxResults": "\(maxResults)",
+          "query": query,
+        ]
+      } catch {
+        return [
+          "status": "error",
+          "classification": "unknown",
+          "message": error.localizedDescription,
+          "maxResults": "\(maxResults)",
+          "query": query,
+        ]
+      }
+    }
+
+    register(
       name: "spatial_overlay_present_instruction",
       summary: "Present the Screen Recording fallback instruction card (dogfood/visual)"
     ) { params in

--- a/desktop/macos/changelog/unreleased/resolve-8809-google-probes.json
+++ b/desktop/macos/changelog/unreleased/resolve-8809-google-probes.json
@@ -1,0 +1,3 @@
+{
+  "change": "Added a semantic Gmail connector probe and updated the Google connector checklist to reflect the shared browser-session path."
+}

--- a/desktop/macos/docs/connector-checklist.md
+++ b/desktop/macos/docs/connector-checklist.md
@@ -80,8 +80,7 @@ Work top to bottom. Don't skip the probe or the fixture test.
 
 ---
 
-**Known follow-up:** Calendar and Gmail now both classify browser-cookie
-attempts instead of using last-writer-wins diagnostics. A shared
-`BrowserGoogleSession` helper (cookie discovery + decrypt + classify) would let
-both connectors share the hardened path — worth doing once the duplicated shape
-stabilizes.
+**Current Google connector baseline:** Calendar and Gmail share
+`BrowserGoogleSession` for browser/profile discovery, Safe Storage access, and
+Chromium cookie handling, and share `PipeProcessRunner` for deadlock-safe helper
+process execution. Keep new browser-cookie Google fixes on those shared paths.


### PR DESCRIPTION
## Summary
- add a semantic `gmail_read_probe` automation action that exercises the real Gmail connector path and returns stable classifications
- update the connector checklist to reflect the now-shared `BrowserGoogleSession` + `PipeProcessRunner` Google connector baseline
- add the required desktop changelog fragment

Recent merged PRs (#8805, #8806, #8810, #8814) landed the bulk of #8809: shared browser session discovery, shared process runner, classified Gmail/Calendar outcomes, functional probes, and fixture tests. This PR covers the remaining delta I found: Gmail lacked the semantic automation probe called for by the connector checklist, and the checklist still described `BrowserGoogleSession` as future work.

Closes #8809

## Testing
- `python3 -m json.tool desktop/macos/changelog/unreleased/resolve-8809-google-probes.json >/dev/null`
- `git diff --check`
- `xcrun swift test --package-path Desktop --filter GmailOutcomeParserTests` *(blocked in this environment: after installing `webp` and `pkg-config`, SwiftPM gets past `CWebP` but the installed Command Line Tools toolchain cannot load SwiftUI `PreviewsMacros` for existing unrelated `#Preview` declarations; no full Xcode.app is installed)*
- push pre-checks passed, including desktop changelog validation


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8823?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

