### PR TITLE
Fix ChatGPT MCP OAuth review config

### DIFF
--- a/backend/database/mcp_oauth.py
+++ b/backend/database/mcp_oauth.py
@@ -15,7 +15,7 @@ from google.cloud import firestore
 from database._client import db
 
 MCP_RESOURCE_URL = os.getenv("MCP_RESOURCE_URL", "https://api.omi.me/v1/mcp/sse")
-DEFAULT_CLIENT_ID = os.getenv("MCP_OAUTH_CHATGPT_CLIENT_ID", "omi")
+DEFAULT_CLIENT_ID = os.getenv("MCP_OAUTH_CHATGPT_CLIENT_ID", "omi-chatgpt-prod")
 DEFAULT_CLIENT_NAME = os.getenv("MCP_OAUTH_CHATGPT_CLIENT_NAME", "ChatGPT")
 DEFAULT_CLAUDE_CLIENT_ID = os.getenv("MCP_OAUTH_CLAUDE_CLIENT_ID", "omi-claude-prod")
 DEFAULT_CLAUDE_CLIENT_NAME = os.getenv("MCP_OAUTH_CLAUDE_CLIENT_NAME", "Claude")

--- a/backend/scripts/validate_mcp_oauth_review_config.py
+++ b/backend/scripts/validate_mcp_oauth_review_config.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""Validate ChatGPT MCP OAuth review/submission config without printing secrets."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+APPROVED_CLIENT_AUTH_METHODS = {
+    "omi-chatgpt-prod": "none",
+    "omi-mcp-public": "none",
+}
+REJECTED_CLIENT_IDS = {"omi"}
+SECRET_FIELD_NAMES = {
+    "access_token",
+    "client_secret",
+    "firebase_id_token",
+    "id_token",
+    "password",
+    "refresh_token",
+}
+
+
+class ValidationError(Exception):
+    pass
+
+
+def _load_json(path: Path) -> Any:
+    if not path.exists():
+        raise ValidationError(f"{path}: file does not exist")
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ValidationError(f"{path}: invalid JSON: {exc}") from exc
+
+
+def _find_dicts_with_key(value: Any, key: str) -> list[dict[str, Any]]:
+    matches: list[dict[str, Any]] = []
+    if isinstance(value, dict):
+        if key in value:
+            matches.append(value)
+        for child in value.values():
+            matches.extend(_find_dicts_with_key(child, key))
+    elif isinstance(value, list):
+        for child in value:
+            matches.extend(_find_dicts_with_key(child, key))
+    return matches
+
+
+def _find_secret_paths(value: Any, prefix: str = "$") -> list[str]:
+    paths: list[str] = []
+    if isinstance(value, dict):
+        for key, child in value.items():
+            child_path = f"{prefix}.{key}"
+            if key.lower() in SECRET_FIELD_NAMES and child not in (None, ""):
+                paths.append(child_path)
+            paths.extend(_find_secret_paths(child, child_path))
+    elif isinstance(value, list):
+        for index, child in enumerate(value):
+            paths.extend(_find_secret_paths(child, f"{prefix}[{index}]"))
+    return paths
+
+
+def _extract_oauth_clients(payload: Any) -> list[dict[str, Any] | None]:
+    clients: list[dict[str, Any] | None] = []
+    for owner in _find_dicts_with_key(payload, "oauth_client"):
+        oauth_client = owner.get("oauth_client")
+        flow_requires_oauth = bool(
+            owner.get("requires_oauth")
+            or owner.get("oauth_required")
+            or owner.get("authentication") == "oauth"
+            or owner.get("auth_type") == "oauth"
+            or owner.get("type") == "oauth"
+            or owner.get("server_url")
+        )
+        if oauth_client is None and flow_requires_oauth:
+            clients.append(None)
+        elif isinstance(oauth_client, dict):
+            clients.append(oauth_client)
+        elif oauth_client is not None:
+            raise ValidationError("oauth_client must be an object when present")
+    return clients
+
+
+def validate_submission_config(payload: Any) -> list[str]:
+    errors: list[str] = []
+    oauth_clients = _extract_oauth_clients(payload)
+    if not oauth_clients:
+        errors.append("missing oauth_client object for MCP OAuth review config")
+
+    for index, oauth_client in enumerate(oauth_clients, start=1):
+        label = f"oauth_client[{index}]"
+        if oauth_client is None:
+            errors.append(f"{label} is null for a flow that requires OAuth")
+            continue
+        client_id = str(oauth_client.get("client_id") or "").strip()
+        token_auth_method = str(oauth_client.get("token_endpoint_auth_method") or "").strip()
+        if not client_id:
+            errors.append(f"{label}.client_id is required")
+        elif client_id in REJECTED_CLIENT_IDS:
+            errors.append(f"{label}.client_id={client_id!r} is rejected; use omi-chatgpt-prod or omi-mcp-public")
+        elif client_id not in APPROVED_CLIENT_AUTH_METHODS:
+            errors.append(f"{label}.client_id={client_id!r} is not in the approved review client registry")
+        expected_method = APPROVED_CLIENT_AUTH_METHODS.get(client_id)
+        if not token_auth_method:
+            errors.append(f"{label}.token_endpoint_auth_method is required")
+        elif expected_method and token_auth_method != expected_method:
+            errors.append(
+                f"{label}.token_endpoint_auth_method={token_auth_method!r} does not match {client_id!r}: {expected_method!r}"
+            )
+
+    secret_paths = _find_secret_paths(payload)
+    if secret_paths:
+        errors.append("submission config contains raw secret fields: " + ", ".join(secret_paths))
+    return errors
+
+
+def _tool_names(value: Any) -> set[str]:
+    names: set[str] = set()
+
+    if isinstance(value, list):
+        for tool in value:
+            if isinstance(tool, dict) and tool.get("name"):
+                names.add(str(tool["name"]))
+
+    def visit(node: Any) -> None:
+        if isinstance(node, dict):
+            tools = node.get("tools")
+            if isinstance(tools, list):
+                for tool in tools:
+                    if isinstance(tool, dict) and tool.get("name"):
+                        names.add(str(tool["name"]))
+            for child in node.values():
+                visit(child)
+        elif isinstance(node, list):
+            for child in node:
+                visit(child)
+
+    visit(value)
+    return names
+
+
+def validate_tool_metadata(submission_payload: Any, live_tools_payload: Any) -> list[str]:
+    exported = _tool_names(submission_payload)
+    live = _tool_names(live_tools_payload)
+    errors: list[str] = []
+    if not exported:
+        errors.append("submission config does not include tool metadata to compare")
+    if not live:
+        errors.append("live tools/list payload does not include tools")
+    missing = sorted(live - exported)
+    stale = sorted(exported - live)
+    if missing:
+        errors.append("submission tool metadata is missing live tools: " + ", ".join(missing))
+    if stale:
+        errors.append("submission tool metadata includes stale tools: " + ", ".join(stale))
+    return errors
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("submission_json", type=Path, help="Generated ChatGPT review/submission JSON")
+    parser.add_argument("--live-tools-json", type=Path, help="Captured MCP tools/list JSON for the selected scopes")
+    args = parser.parse_args(argv)
+
+    try:
+        submission_payload = _load_json(args.submission_json)
+        errors = validate_submission_config(submission_payload)
+        if args.live_tools_json:
+            errors.extend(validate_tool_metadata(submission_payload, _load_json(args.live_tools_json)))
+    except ValidationError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    if errors:
+        for error in errors:
+            print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+    print("MCP OAuth review config OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/tests/unit/test_mcp_data_endpoints.py
+++ b/backend/tests/unit/test_mcp_data_endpoints.py
@@ -285,6 +285,49 @@ def test_authorize_redirect_builder_preserves_existing_query():
     assert redirect_uri == 'https://chatgpt.com/connector_platform_oauth_redirect?client=chatgpt&code=code-1&state=s1'
 
 
+def test_authorize_request_accepts_chatgpt_public_client():
+    client = {
+        'id': 'omi-chatgpt-prod',
+        'allowed_redirect_uris': ['https://chatgpt.com/connector_platform_oauth_redirect'],
+        'allowed_resources': [sse.MCP_RESOURCE_URL],
+        'allowed_scopes': ['memories.read'],
+        'token_endpoint_auth_method': 'none',
+    }
+    with (
+        patch('routers.mcp_sse.mcp_oauth_db.get_client', return_value=client),
+        patch('routers.mcp_sse.mcp_oauth_db.validate_redirect_uri', return_value=True),
+        patch('routers.mcp_sse.mcp_oauth_db.validate_resource', return_value=True),
+        patch('routers.mcp_sse.mcp_oauth_db.validate_pkce_challenge', return_value=True),
+        patch('routers.mcp_sse.mcp_oauth_db.normalize_scopes', return_value=['memories.read']),
+    ):
+        validated_client, scopes = sse._validate_authorize_request(
+            'code',
+            'omi-chatgpt-prod',
+            'https://chatgpt.com/connector_platform_oauth_redirect',
+            sse.MCP_RESOURCE_URL,
+            'memories.read',
+            'a' * 64,
+            'S256',
+        )
+
+    assert validated_client == client
+    assert scopes == ['memories.read']
+
+
+def test_authorize_request_rejects_legacy_omi_client_id():
+    with patch('routers.mcp_sse.mcp_oauth_db.get_client', return_value=None):
+        with pytest.raises(ValueError, match='Unknown OAuth client'):
+            sse._validate_authorize_request(
+                'code',
+                'omi',
+                'https://chatgpt.com/connector_platform_oauth_redirect',
+                sse.MCP_RESOURCE_URL,
+                'memories.read',
+                'a' * 64,
+                'S256',
+            )
+
+
 def test_legacy_api_key_helper_rejects_oauth_tokens():
     with patch('routers.mcp_sse.mcp_oauth_db.validate_access_token') as validate_access_token:
         validate_access_token.return_value = {

--- a/backend/tests/unit/test_mcp_oauth.py
+++ b/backend/tests/unit/test_mcp_oauth.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock
 
 os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
 os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv')
+os.environ['MCP_OAUTH_CHATGPT_CLIENT_ID'] = 'omi-chatgpt-prod'
 os.environ['MCP_OAUTH_CHATGPT_CLIENT_SECRET'] = 'client-secret'
 os.environ['MCP_OAUTH_CHATGPT_REDIRECT_URIS'] = 'https://chatgpt.com/connector_platform_oauth_redirect'
 os.environ['MCP_OAUTH_PUBLIC_REDIRECT_URIS'] = 'https://chatgpt.com/connector_platform_oauth_redirect'
@@ -108,18 +109,19 @@ from database import mcp_oauth
 
 
 def test_authorization_code_exchange_issues_scoped_tokens_and_rejects_reuse():
-    client = mcp_oauth.get_client('omi')
-    assert mcp_oauth.verify_client_secret(client, 'client-secret')
-    assert mcp_oauth.verify_client_auth(client, 'client-secret')
+    client = mcp_oauth.get_client('omi-chatgpt-prod')
+    assert client['token_endpoint_auth_method'] == 'none'
+    assert mcp_oauth.verify_client_auth(client, None)
+    assert not mcp_oauth.verify_client_auth(client, 'client-secret')
     assert mcp_oauth.validate_redirect_uri(client, 'https://chatgpt.com/connector_platform_oauth_redirect')
 
     scopes = mcp_oauth.normalize_scopes('memories.read conversations.read', client)
     verifier = 'a' * 64
-    grant = mcp_oauth.create_or_update_grant('user-1', 'omi', mcp_oauth.MCP_RESOURCE_URL, scopes)
+    grant = mcp_oauth.create_or_update_grant('user-1', 'omi-chatgpt-prod', mcp_oauth.MCP_RESOURCE_URL, scopes)
     code = mcp_oauth.issue_authorization_code(
         'user-1',
         grant['id'],
-        'omi',
+        'omi-chatgpt-prod',
         'https://chatgpt.com/connector_platform_oauth_redirect',
         mcp_oauth.MCP_RESOURCE_URL,
         scopes,
@@ -127,12 +129,20 @@ def test_authorization_code_exchange_issues_scoped_tokens_and_rejects_reuse():
     )
 
     token_pair = mcp_oauth.exchange_authorization_code_for_tokens(
-        code, 'omi', 'https://chatgpt.com/connector_platform_oauth_redirect', mcp_oauth.MCP_RESOURCE_URL, verifier
+        code,
+        'omi-chatgpt-prod',
+        'https://chatgpt.com/connector_platform_oauth_redirect',
+        mcp_oauth.MCP_RESOURCE_URL,
+        verifier,
     )
     assert token_pair['access_token'].startswith('omi_oat_')
     assert (
         mcp_oauth.exchange_authorization_code_for_tokens(
-            code, 'omi', 'https://chatgpt.com/connector_platform_oauth_redirect', mcp_oauth.MCP_RESOURCE_URL, verifier
+            code,
+            'omi-chatgpt-prod',
+            'https://chatgpt.com/connector_platform_oauth_redirect',
+            mcp_oauth.MCP_RESOURCE_URL,
+            verifier,
         )
         is None
     )
@@ -385,32 +395,46 @@ def test_default_clients_can_request_all_supported_tool_scopes():
         ]
     )
 
-    assert mcp_oauth.normalize_scopes(requested_scopes, mcp_oauth.get_client('omi')) == sorted(requested_scopes.split())
+    assert mcp_oauth.normalize_scopes(requested_scopes, mcp_oauth.get_client('omi-chatgpt-prod')) == sorted(
+        requested_scopes.split()
+    )
     assert mcp_oauth.normalize_scopes(requested_scopes, mcp_oauth.get_client('omi-mcp-public')) == sorted(
         requested_scopes.split()
     )
 
 
+def test_legacy_omi_client_id_is_not_registered_by_default():
+    assert mcp_oauth.get_client('omi') is None
+
+
 def test_refresh_token_rotates_and_old_refresh_reuse_revokes_grant():
     scopes = ['memories.read']
-    grant = mcp_oauth.create_or_update_grant('user-2', 'omi', mcp_oauth.MCP_RESOURCE_URL, scopes)
+    grant = mcp_oauth.create_or_update_grant('user-2', 'omi-chatgpt-prod', mcp_oauth.MCP_RESOURCE_URL, scopes)
     first_pair = mcp_oauth.issue_token_pair(grant, scopes=scopes)
 
-    second_pair = mcp_oauth.rotate_refresh_token(first_pair['refresh_token'], 'omi', mcp_oauth.MCP_RESOURCE_URL)
+    second_pair = mcp_oauth.rotate_refresh_token(
+        first_pair['refresh_token'], 'omi-chatgpt-prod', mcp_oauth.MCP_RESOURCE_URL
+    )
     assert second_pair['refresh_token'] != first_pair['refresh_token']
     assert mcp_oauth.validate_access_token(second_pair['access_token'], mcp_oauth.MCP_RESOURCE_URL)['uid'] == 'user-2'
 
-    assert mcp_oauth.rotate_refresh_token(first_pair['refresh_token'], 'omi', mcp_oauth.MCP_RESOURCE_URL) is None
+    assert (
+        mcp_oauth.rotate_refresh_token(first_pair['refresh_token'], 'omi-chatgpt-prod', mcp_oauth.MCP_RESOURCE_URL)
+        is None
+    )
     assert mcp_oauth.validate_access_token(second_pair['access_token'], mcp_oauth.MCP_RESOURCE_URL) is None
 
-    new_grant = mcp_oauth.create_or_update_grant('user-2', 'omi', mcp_oauth.MCP_RESOURCE_URL, scopes)
+    new_grant = mcp_oauth.create_or_update_grant('user-2', 'omi-chatgpt-prod', mcp_oauth.MCP_RESOURCE_URL, scopes)
     assert new_grant['id'] != grant['id']
-    assert mcp_oauth.rotate_refresh_token(second_pair['refresh_token'], 'omi', mcp_oauth.MCP_RESOURCE_URL) is None
+    assert (
+        mcp_oauth.rotate_refresh_token(second_pair['refresh_token'], 'omi-chatgpt-prod', mcp_oauth.MCP_RESOURCE_URL)
+        is None
+    )
 
 
 def test_revoke_user_grant_invalidates_tokens():
     scopes = ['memories.read']
-    grant = mcp_oauth.create_or_update_grant('user-3', 'omi', mcp_oauth.MCP_RESOURCE_URL, scopes)
+    grant = mcp_oauth.create_or_update_grant('user-3', 'omi-chatgpt-prod', mcp_oauth.MCP_RESOURCE_URL, scopes)
     token_pair = mcp_oauth.issue_token_pair(grant, scopes=scopes)
 
     assert len(mcp_oauth.list_user_grants('user-3')) == 1

--- a/backend/tests/unit/test_mcp_oauth_review_validator.py
+++ b/backend/tests/unit/test_mcp_oauth_review_validator.py
@@ -1,0 +1,74 @@
+from scripts.validate_mcp_oauth_review_config import validate_submission_config, validate_tool_metadata
+
+
+def test_validator_accepts_structured_public_chatgpt_client():
+    errors = validate_submission_config(
+        {
+            "server_url": "https://api.omi.me/v1/mcp/sse",
+            "authentication": "oauth",
+            "oauth_client": {
+                "client_id": "omi-chatgpt-prod",
+                "token_endpoint_auth_method": "none",
+            },
+        }
+    )
+
+    assert errors == []
+
+
+def test_validator_rejects_null_oauth_client_for_oauth_flow():
+    errors = validate_submission_config(
+        {
+            "server_url": "https://api.omi.me/v1/mcp/sse",
+            "authentication": "oauth",
+            "oauth_client": None,
+        }
+    )
+
+    assert any("oauth_client[1] is null" in error for error in errors)
+
+
+def test_validator_rejects_legacy_client_id_and_auth_method_mismatch():
+    errors = validate_submission_config(
+        {
+            "oauth_client": {
+                "client_id": "omi",
+                "token_endpoint_auth_method": "client_secret_post",
+            }
+        }
+    )
+
+    assert any("client_id='omi' is rejected" in error for error in errors)
+
+
+def test_validator_rejects_chatgpt_secret_post_mismatch_without_printing_secret_value():
+    errors = validate_submission_config(
+        {
+            "oauth_client": {
+                "client_id": "omi-chatgpt-prod",
+                "token_endpoint_auth_method": "client_secret_post",
+                "client_secret": "should-not-appear",
+            }
+        }
+    )
+
+    encoded = "\n".join(errors)
+    assert "client_secret_post" in encoded
+    assert "raw secret fields" in encoded
+    assert "should-not-appear" not in encoded
+
+
+def test_validator_detects_tool_metadata_drift():
+    errors = validate_tool_metadata({"tools": [{"name": "search_memories"}]}, {"tools": [{"name": "create_memory"}]})
+
+    assert any("missing live tools: create_memory" in error for error in errors)
+    assert any("stale tools: search_memories" in error for error in errors)
+
+
+def test_validator_reads_jsonrpc_tools_list_envelopes():
+    errors = validate_tool_metadata(
+        {"result": {"tools": [{"name": "search_memories"}]}},
+        {"jsonrpc": "2.0", "id": 1, "result": {"tools": [{"name": "search_memories"}]}},
+    )
+
+    assert errors == []

--- a/desktop/macos/Desktop/Sources/MemoryExportService.swift
+++ b/desktop/macos/Desktop/Sources/MemoryExportService.swift
@@ -435,7 +435,7 @@ enum MemoryExportDestination: String, CaseIterable, Identifiable, Sendable {
         ("auth_url", Self.mcpAuthorizeURL),
         ("token_url", Self.mcpTokenURL),
       ])
-    } else {
+    } else if !usesPublicCloudOAuthClient {
       nativeToolArgs.append(contentsOf: [
         ("oauth_client_id", "omi"),
         ("oauth_client_secret", key),

--- a/desktop/macos/changelog/unreleased/20260702-chatgpt-mcp-oauth.json
+++ b/desktop/macos/changelog/unreleased/20260702-chatgpt-mcp-oauth.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixes ChatGPT MCP connector setup to use the accepted public OAuth client"
+}

--- a/docs/runbooks/mcp-oauth-review-validator.md
+++ b/docs/runbooks/mcp-oauth-review-validator.md
@@ -1,0 +1,16 @@
+# MCP OAuth Review Validator
+
+Use this before submitting or exporting a ChatGPT MCP review package:
+
+```bash
+cd backend
+python scripts/validate_mcp_oauth_review_config.py /path/to/submission.json
+```
+
+If you captured a live `tools/list` response for the same scope set, compare it too:
+
+```bash
+python scripts/validate_mcp_oauth_review_config.py /path/to/submission.json --live-tools-json /path/to/tools-list.json
+```
+
+The validator fails on rejected legacy client IDs such as `omi`, token auth mismatches, null `oauth_client` blocks, raw secret fields, and optional tool metadata drift. It reports field paths only; it does not print secret values.


### PR DESCRIPTION
## Summary

Fixes #8828.

- switches the default ChatGPT MCP OAuth client from rejected legacy `omi` to `omi-chatgpt-prod`
- updates desktop ChatGPT connector setup/autofill instructions to use the public client and `token_endpoint_auth_method=none` without a client secret
- adds a checked-in MCP OAuth review config validator and docs for catching null `oauth_client`, rejected client IDs, token auth mismatches, raw secret fields, and optional tools/list drift
- adds backend and desktop regression tests for accepted/rejected authorize clients and generated ChatGPT OAuth setup values

## Validation

- `python -m pytest backend/tests/unit/test_mcp_data_endpoints.py -q`
- `python -m pytest backend/tests/unit/test_mcp_oauth.py -q`
- `python -m pytest backend/tests/unit/test_mcp_oauth_review_validator.py -q`
- `npm run build` in `desktop/macos/agent`
- `xcrun swift test --package-path desktop/macos/Desktop --filter BrowserAutomationTargetTests`
- pre-push checks passed, with `PRE_PUSH_SKIP_BACKEND_UNIT_TESTS=1` only because the hook selector includes `tests/unit/v3_router_probes/route_signature_integration.py`, which collects zero tests and fails pytest before completing despite the selected changed backend tests passing in isolated runs.

## Notes

- `npm ci` in `desktop/macos/agent` reports one existing high-severity audit finding; this PR does not change dependency versions.
- Existing architecture guardrail warnings remain for large/long pre-existing files touched by this flow.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8829?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

