### PR TITLE
feat(desktop): smart agent routing — pick best local provider (Codex/OpenClaw/Hermes) with fallback + install guidance

### DIFF
--- a/desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift
+++ b/desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift
@@ -575,23 +575,14 @@ actor AgentRuntimeProcess {
       env["HERMES_HOME"] = "\(home)/.hermes"
     }
 
-    let adapterPathDirs = [
-      "\(home)/.hermes/hermes-agent/venv/bin",
-      "\(home)/.hermes/node/bin",
-      "\(home)/.hermes/hermes-agent",
-    ]
-    let adapterSearchDirs = adapterPathDirs + [
-      "\(home)/.local/bin",
-      "/opt/homebrew/bin",
-      "/usr/local/bin",
-    ]
+    let adapterSearchDirs = LocalAgentProviderDetector.adapterActivationSearchDirectories(homeDirectory: home)
     let trustedPathDirs = [
       "/opt/homebrew/bin",
       "/usr/local/bin",
     ]
     let existingPath = env["PATH"] ?? "/usr/bin:/bin"
     var pathElements: [String] = []
-    for path in existingPath.split(separator: ":").map(String.init) + trustedPathDirs + adapterPathDirs {
+    for path in existingPath.split(separator: ":").map(String.init) + trustedPathDirs + adapterSearchDirs {
       if !pathElements.contains(path) {
         pathElements.append(path)
       }
@@ -609,6 +600,12 @@ actor AgentRuntimeProcess {
     {
       env["OMI_OPENCLAW_ADAPTER_COMMAND"] = Self.openClawAdapterCommand(openClawPath: openClaw)
     }
+
+    if env["OMI_CODEX_ADAPTER_COMMAND"]?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ?? true,
+      let codex = firstExecutable(named: "codex", in: adapterSearchDirs)
+    {
+      env["OMI_CODEX_ADAPTER_COMMAND"] = Self.codexAdapterCommand(codexPath: codex)
+    }
   }
 
   static func openClawAdapterCommand(openClawPath: String, fileManager: FileManager = .default) -> String {
@@ -617,6 +614,10 @@ actor AgentRuntimeProcess {
       return "\(shellQuote(nodePath)) \(shellQuote(openClawPath)) acp"
     }
     return "\(shellQuote(openClawPath)) acp"
+  }
+
+  static func codexAdapterCommand(codexPath: String) -> String {
+    "CODEX_PATH=\(shellQuote(codexPath)) npx -y @agentclientprotocol/codex-acp"
   }
 
   private static func shellQuote(_ value: String) -> String {

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/AgentPill.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/AgentPill.swift
@@ -172,11 +172,13 @@ final class AgentPillsManager: ObservableObject {
     enum DirectedProvider: String, Equatable {
         case hermes
         case openclaw
+        case codex
 
         var displayName: String {
             switch self {
             case .hermes: return "Hermes"
             case .openclaw: return "OpenClaw"
+            case .codex: return "Codex"
             }
         }
 
@@ -184,6 +186,7 @@ final class AgentPillsManager: ObservableObject {
             switch self {
             case .hermes: return .hermes
             case .openclaw: return .openclaw
+            case .codex: return .codex
             }
         }
 
@@ -191,6 +194,7 @@ final class AgentPillsManager: ObservableObject {
             switch self {
             case .hermes: return "hermes"
             case .openclaw: return "openclaw"
+            case .codex: return "codex"
             }
         }
 
@@ -198,6 +202,7 @@ final class AgentPillsManager: ObservableObject {
             switch self {
             case .hermes: return "OMI_HERMES_ADAPTER_COMMAND"
             case .openclaw: return "OMI_OPENCLAW_ADAPTER_COMMAND"
+            case .codex: return "OMI_CODEX_ADAPTER_COMMAND"
             }
         }
 
@@ -377,7 +382,7 @@ final class AgentPillsManager: ObservableObject {
         let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return nil }
 
-        let providerPattern = "(open\\s*claw|openclaw|hermes)"
+        let providerPattern = "(open\\s*claw|openclaw|hermes|codex)"
         let patterns = [
             #"(?i)^\s*(?:please\s+)?(?:(?:i\s+)?meant\s+)?(?:ask|tell|ping|message|run|use|try)\s+\#(providerPattern)\b(?:\s+(.*))?$"#,
             #"(?i)^\s*(?:please\s+)?\#(providerPattern)\s*[:,\-]\s*(.*)$"#,
@@ -395,6 +400,7 @@ final class AgentPillsManager: ObservableObject {
             switch providerToken {
             case "openclaw": provider = .openclaw
             case "hermes": provider = .hermes
+            case "codex": provider = .codex
             default: continue
             }
 

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/AgentPill.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/AgentPill.swift
@@ -126,6 +126,7 @@ final class AgentPillsManager: ObservableObject {
     private var messageCountByPill: [UUID: Int] = [:]
     private var runTasksByPill: [UUID: Task<Void, Never>] = [:]
     private var viewedExpirationWorkItemsByPill: [UUID: DispatchWorkItem] = [:]
+    private var spawnContextByPill: [UUID: AgentSpawnContext] = [:]
     private var bootChain: Task<Void, Never> = Task {}
 
     private static let backgroundAgentSystemPromptSuffix = """
@@ -169,7 +170,7 @@ final class AgentPillsManager: ObservableObject {
         let ack: String?
     }
 
-    enum DirectedProvider: String, Equatable {
+    enum DirectedProvider: String, Equatable, CaseIterable {
         case hermes
         case openclaw
         case codex
@@ -564,7 +565,8 @@ final class AgentPillsManager: ObservableObject {
         fromVoice: Bool = false,
         preFetchedTitle: String? = nil,
         preFetchedAck: String? = nil,
-        bridgeHarnessOverride: AgentHarnessMode? = nil
+        bridgeHarnessOverride: AgentHarnessMode? = nil,
+        spawnContext: AgentSpawnContext? = nil
     ) -> AgentPill {
         let count = AgentPillsManager.parseAgentCount(from: query)
         if count <= 1 {
@@ -574,7 +576,8 @@ final class AgentPillsManager: ObservableObject {
                 fromVoice: fromVoice,
                 preFetchedTitle: preFetchedTitle,
                 preFetchedAck: preFetchedAck,
-                bridgeHarnessOverride: bridgeHarnessOverride
+                bridgeHarnessOverride: bridgeHarnessOverride,
+                spawnContext: spawnContext
             )
         }
         var first: AgentPill?
@@ -651,11 +654,15 @@ final class AgentPillsManager: ObservableObject {
         preFetchedTitle: String? = nil,
         preFetchedAck: String? = nil,
         systemPromptSuffix: String? = nil,
-        bridgeHarnessOverride: AgentHarnessMode? = nil
+        bridgeHarnessOverride: AgentHarnessMode? = nil,
+        spawnContext: AgentSpawnContext? = nil
     ) -> AgentPill {
         let pill = AgentPill(query: query, model: model, bridgeHarnessOverride: bridgeHarnessOverride)
         if let preFetchedTitle, !preFetchedTitle.isEmpty {
             pill.title = preFetchedTitle
+        }
+        if let spawnContext {
+            spawnContextByPill[pill.id] = spawnContext
         }
 
         trimForNewPillIfNeeded()
@@ -975,6 +982,7 @@ final class AgentPillsManager: ObservableObject {
         projectionStreamsByPill[pillID] = nil
         providersByPill[pillID] = nil
         messageCountByPill[pillID] = nil
+        spawnContextByPill[pillID] = nil
         pills.removeAll { $0.id == pillID }
     }
 
@@ -1126,6 +1134,44 @@ final class AgentPillsManager: ObservableObject {
         return "Working…"
     }
 
+    private func maybeRetryWithFallback(
+        failedPill: AgentPill,
+        model: String,
+        errorText: String
+    ) -> Bool {
+        guard LocalAgentProviderRouting.isRetriableSpawnFailure(errorText) else { return false }
+        guard var context = spawnContextByPill[failedPill.id] else { return false }
+        guard context.explicitProvider == nil else { return false }
+        guard let nextWrapped = context.nextFallback(after: failedPill.bridgeHarnessOverride) else { return false }
+
+        let query = failedPill.query
+        let failedName = failedPill.bridgeHarnessOverride.flatMap { harness in
+            AgentPillsManager.DirectedProvider.allCases.first { $0.harnessMode == harness }?.displayName
+        } ?? "That agent"
+        let nextProvider = nextWrapped.flatMap { harness in
+            AgentPillsManager.DirectedProvider.allCases.first { $0.harnessMode == harness }
+        }
+        let ack: String
+        if let nextProvider {
+            ack = "\(failedName) failed; trying \(nextProvider.displayName) instead."
+        } else {
+            ack = "\(failedName) failed; trying the default agent instead."
+        }
+
+        context.recordAttempt(failedPill.bridgeHarnessOverride)
+        context.recordAttempt(nextWrapped)
+        cleanup(pillID: failedPill.id)
+        _ = spawn(
+            query: query,
+            model: model,
+            preFetchedTitle: nextProvider?.displayName ?? failedPill.title,
+            preFetchedAck: ack,
+            bridgeHarnessOverride: nextWrapped,
+            spawnContext: context
+        )
+        return true
+    }
+
     private func complete(pill: AgentPill, provider: ChatProvider, finalText: String?) {
         let trimmedFinalText = finalText?.trimmingCharacters(in: .whitespacesAndNewlines)
         if let trimmedFinalText, !trimmedFinalText.isEmpty {
@@ -1159,6 +1205,13 @@ final class AgentPillsManager: ObservableObject {
             }
         }
         if let errorText = provider.errorMessage, !errorText.isEmpty {
+            if maybeRetryWithFallback(
+                failedPill: pill,
+                model: pill.model,
+                errorText: errorText
+            ) {
+                return
+            }
             pill.status = .failed(errorText)
             pill.latestActivity = errorText
             pill.completedAt = Date()
@@ -1228,6 +1281,13 @@ final class AgentPillsManager: ObservableObject {
             }
         case .failed, .timedOut, .orphaned:
             let message = projection.failure?.displayMessage ?? projection.errorMessage ?? "Agent failed"
+            if AgentPillsManager.shared.maybeRetryWithFallback(
+                failedPill: pill,
+                model: pill.model,
+                errorText: message
+            ) {
+                return
+            }
             pill.status = .failed(message)
             pill.latestActivity = message
             pill.completedAt = projection.completedAt ?? Date()

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
@@ -2587,9 +2587,15 @@ class FloatingControlBarManager {
                 provider.stopAgent()
             }
             routerTracer?.mark("router_classify", metadata: ["route": "agent", "provider": directive.provider.rawValue])
-            let availability = LocalAgentProviderDetector.availability(for: directive.provider)
-            guard availability.isAvailable else {
-                let assistantText = availability.setupPrompt
+            let resolution = LocalAgentProviderRouting.resolveSpawn(
+                brief: directive.rewrittenQuery,
+                requestedProvider: directive.provider,
+                userRequestText: message,
+                title: directive.title
+            )
+            switch resolution {
+            case .setupRequired(_, let setupPrompt, let spokenStatus):
+                let assistantText = setupPrompt
                 let recordedTurn = provider.recordCompletedTurn(
                     userText: message,
                     assistantText: assistantText,
@@ -2605,38 +2611,46 @@ class FloatingControlBarManager {
                 case .voiceOnly:
                     barWindow.state.currentQueryFromVoice = false
                     barWindow.state.isVoiceResponseActive = false
-                    FloatingBarVoicePlaybackService.shared.speakOneShot(directive.provider.setupNeededStatus)
+                    FloatingBarVoicePlaybackService.shared.speakOneShot(spokenStatus)
+                }
+                return
+            case .spawn(let plan):
+                let pill = AgentPillsManager.shared.spawnFromUserQuery(
+                    directive.rewrittenQuery,
+                    model: selectedFloatingModel,
+                    fromVoice: presentation.fromVoice,
+                    preFetchedTitle: plan.title,
+                    preFetchedAck: plan.ack,
+                    bridgeHarnessOverride: plan.harnessOverride,
+                    spawnContext: plan.context
+                )
+                let providerName = plan.selectedProvider?.displayName ?? directive.provider.displayName
+                let assistantText: String
+                if let fallbackNote = plan.fallbackNote {
+                    assistantText = "\(fallbackNote) I started \(providerName) in a background agent titled \"\(pill.title)\"."
+                } else {
+                    assistantText = "I started \(providerName) in a background agent titled \"\(pill.title)\"."
+                }
+                let recordedTurn = provider.recordCompletedTurn(
+                    userText: message,
+                    assistantText: assistantText,
+                    logLabel: "floating-agent-provider"
+                )
+                switch presentation {
+                case .visible:
+                    completeVisibleAgentHandoff(
+                        .init(originalRequest: message, agentTask: directive.rewrittenQuery),
+                        pill: pill,
+                        assistantMessage: recordedTurn.assistant,
+                        assistantText: assistantText,
+                        barWindow: barWindow
+                    )
+                case .voiceOnly:
+                    barWindow.state.currentQueryFromVoice = false
+                    barWindow.state.isVoiceResponseActive = false
                 }
                 return
             }
-            let pill = AgentPillsManager.shared.spawnFromUserQuery(
-                directive.rewrittenQuery,
-                model: selectedFloatingModel,
-                fromVoice: presentation.fromVoice,
-                preFetchedTitle: directive.title,
-                preFetchedAck: directive.ack,
-                bridgeHarnessOverride: directive.provider.harnessMode
-            )
-            let assistantText = "I started \(directive.provider.displayName) in a background agent titled \"\(pill.title)\"."
-            let recordedTurn = provider.recordCompletedTurn(
-                userText: message,
-                assistantText: assistantText,
-                logLabel: "floating-agent-provider"
-            )
-            switch presentation {
-            case .visible:
-                completeVisibleAgentHandoff(
-                    .init(originalRequest: message, agentTask: directive.rewrittenQuery),
-                    pill: pill,
-                    assistantMessage: recordedTurn.assistant,
-                    assistantText: assistantText,
-                    barWindow: barWindow
-                )
-            case .voiceOnly:
-                barWindow.state.currentQueryFromVoice = false
-                barWindow.state.isVoiceResponseActive = false
-            }
-            return
         }
 
         if let handoff {
@@ -2690,38 +2704,72 @@ class FloatingControlBarManager {
         let decision = await AgentPillsManager.classify(message)
         routerTracer?.end("router_classify", metadata: ["route": decision.route == .agent ? "agent" : "chat"])
         if decision.route == .agent {
-            let pill = AgentPillsManager.shared.spawnFromUserQuery(
-                message,
-                model: selectedFloatingModel,
-                fromVoice: presentation.fromVoice,
-                preFetchedTitle: decision.title,
-                preFetchedAck: decision.ack
+            let resolution = LocalAgentProviderRouting.resolveSpawn(
+                brief: message,
+                requestedProvider: nil,
+                userRequestText: message,
+                title: decision.title
             )
-            let title = decision.title?.trimmingCharacters(in: .whitespacesAndNewlines)
-            let titleSuffix = (title?.isEmpty == false) ? " titled \"\(title!)\"" : ""
-            let ack = decision.ack?.trimmingCharacters(in: .whitespacesAndNewlines)
-            let assistantText = ack?.isEmpty == false
-                ? "\(ack!) I started a background agent\(titleSuffix) for that."
-                : "I started a background agent\(titleSuffix) for that."
-            let recordedTurn = provider.recordCompletedTurn(
-                userText: message,
-                assistantText: assistantText,
-                logLabel: "floating-agent"
-            )
-            switch presentation {
-            case .visible:
-                completeVisibleAgentHandoff(
-                    .init(originalRequest: message, agentTask: message),
-                    pill: pill,
-                    assistantMessage: recordedTurn.assistant,
-                    assistantText: assistantText,
-                    barWindow: barWindow
+            switch resolution {
+            case .setupRequired(_, let setupPrompt, _):
+                let recordedTurn = provider.recordCompletedTurn(
+                    userText: message,
+                    assistantText: setupPrompt,
+                    logLabel: "floating-agent-provider-unavailable"
                 )
-            case .voiceOnly:
-                barWindow.state.currentQueryFromVoice = false
-                barWindow.state.isVoiceResponseActive = false
+                switch presentation {
+                case .visible:
+                    completeVisibleAgentResponse(
+                        userText: message,
+                        assistantMessage: recordedTurn.assistant ?? ChatMessage(text: setupPrompt, sender: .ai),
+                        barWindow: barWindow
+                    )
+                case .voiceOnly:
+                    barWindow.state.currentQueryFromVoice = false
+                    barWindow.state.isVoiceResponseActive = false
+                }
+                return
+            case .spawn(let plan):
+                let pill = AgentPillsManager.shared.spawnFromUserQuery(
+                    message,
+                    model: selectedFloatingModel,
+                    fromVoice: presentation.fromVoice,
+                    preFetchedTitle: plan.title,
+                    preFetchedAck: plan.ack,
+                    bridgeHarnessOverride: plan.harnessOverride,
+                    spawnContext: plan.context
+                )
+                let title = plan.title.trimmingCharacters(in: .whitespacesAndNewlines)
+                let titleSuffix = title.isEmpty ? "" : " titled \"\(title)\""
+                let ack = plan.ack.trimmingCharacters(in: .whitespacesAndNewlines)
+                let assistantText: String
+                if let fallbackNote = plan.fallbackNote {
+                    assistantText = "\(fallbackNote) I started a background agent\(titleSuffix) for that."
+                } else if ack.isEmpty {
+                    assistantText = "I started a background agent\(titleSuffix) for that."
+                } else {
+                    assistantText = "\(ack) I started a background agent\(titleSuffix) for that."
+                }
+                let recordedTurn = provider.recordCompletedTurn(
+                    userText: message,
+                    assistantText: assistantText,
+                    logLabel: "floating-agent"
+                )
+                switch presentation {
+                case .visible:
+                    completeVisibleAgentHandoff(
+                        .init(originalRequest: message, agentTask: message),
+                        pill: pill,
+                        assistantMessage: recordedTurn.assistant,
+                        assistantText: assistantText,
+                        barWindow: barWindow
+                    )
+                case .voiceOnly:
+                    barWindow.state.currentQueryFromVoice = false
+                    barWindow.state.isVoiceResponseActive = false
+                }
+                return
             }
-            return
         }
 
         // Chat route: continue with the requested delivery surface.

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
@@ -1018,11 +1018,12 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate, AVSpeec
       switch providerName {
       case "openclaw": directedProvider = .openclaw
       case "hermes": directedProvider = .hermes
+      case "codex": directedProvider = .codex
       case "": directedProvider = nil
       default:
         session?.sendToolResult(
           callId: callId, name: name,
-          output: "Unsupported agent provider '\(providerName)'. Use 'hermes' or 'openclaw'.")
+          output: "Unsupported agent provider '\(providerName)'. Use 'hermes', 'openclaw', or 'codex'.")
         return
       }
       if let directedProvider {

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
@@ -1014,57 +1014,66 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate, AVSpeec
         .trimmingCharacters(in: .whitespacesAndNewlines)
         .lowercased()
         .replacingOccurrences(of: " ", with: "")
-      let directedProvider: AgentPillsManager.DirectedProvider?
+      let requestedProvider: AgentPillsManager.DirectedProvider?
       switch providerName {
-      case "openclaw": directedProvider = .openclaw
-      case "hermes": directedProvider = .hermes
-      case "codex": directedProvider = .codex
-      case "": directedProvider = nil
+      case "openclaw": requestedProvider = .openclaw
+      case "hermes": requestedProvider = .hermes
+      case "codex": requestedProvider = .codex
+      case "": requestedProvider = nil
       default:
         session?.sendToolResult(
           callId: callId, name: name,
           output: "Unsupported agent provider '\(providerName)'. Use 'hermes', 'openclaw', or 'codex'.")
         return
       }
-      if let directedProvider {
-        let availability = LocalAgentProviderDetector.availability(for: directedProvider)
-        guard availability.isAvailable else {
-          let setupPrompt = availability.setupPrompt
-          assistantText = setupPrompt
-          barState?.isVoiceResponseActive = true
-          if !audioReceivedThisTurn {
-            speak(directedProvider.setupNeededStatus)
-          }
-          suppressAssistantOutputForCurrentTurn = true
-          log("RealtimeHub[\(providerTag)]: tool spawn_agent provider=\(directedProvider.rawValue) unavailable")
-          sendToolResultIfCurrent(
-            source: source, callId: callId, name: name,
-            output: availability.toolError)
-          return
-        }
-      }
-      let model = ShortcutSettings.shared.selectedModel.isEmpty
-        ? ModelQoS.Claude.defaultSelection : ShortcutSettings.shared.selectedModel
-      // Non-blocking: spawn renders its own pill ("text bubble") and runs on its
-      // own ChatProvider/AgentBridge. We don't await it on the voice loop.
-      // fromVoice:false — the hub model speaks its own natural acknowledgment, so the pill
-      // must NOT also speak its canned randomAck ("on it") or we double up.
-      let pill = AgentPillsManager.shared.spawnFromUserQuery(
-        brief, model: model, fromVoice: false,
-        preFetchedTitle: (title?.isEmpty == false) ? title : directedProvider?.displayName,
-        bridgeHarnessOverride: directedProvider?.harnessMode)
-      log("RealtimeHub[\(providerTag)]: tool spawn_agent → AgentBridge pill=\"\(pill.title)\" model=\(model) provider=\(directedProvider?.rawValue ?? "default") titled=\(title?.isEmpty == false)")
-      if !audioReceivedThisTurn {
-        let existingAck = assistantText.trimmingCharacters(in: .whitespacesAndNewlines)
-        let ack = existingAck.isEmpty ? "Starting a background agent." : existingAck
-        assistantText = ack
+      let userRequestText = turnTranscript.trimmingCharacters(in: .whitespacesAndNewlines)
+      let resolution = LocalAgentProviderRouting.resolveSpawn(
+        brief: brief,
+        requestedProvider: requestedProvider,
+        userRequestText: userRequestText.isEmpty ? nil : userRequestText,
+        title: title
+      )
+      switch resolution {
+      case .setupRequired(let provider, let setupPrompt, let spokenStatus):
+        assistantText = setupPrompt
         barState?.isVoiceResponseActive = true
-        speak(ack)
+        if !audioReceivedThisTurn {
+          speak(spokenStatus)
+        }
+        suppressAssistantOutputForCurrentTurn = true
+        log("RealtimeHub[\(providerTag)]: tool spawn_agent provider=\(provider.rawValue) unavailable")
+        sendToolResultIfCurrent(
+          source: source, callId: callId, name: name,
+          output: "Error: \(setupPrompt)")
+        return
+      case .spawn(let plan):
+        let model = ShortcutSettings.shared.selectedModel.isEmpty
+          ? ModelQoS.Claude.defaultSelection : ShortcutSettings.shared.selectedModel
+        let pill = AgentPillsManager.shared.spawnFromUserQuery(
+          brief, model: model, fromVoice: false,
+          preFetchedTitle: plan.title,
+          preFetchedAck: plan.ack,
+          bridgeHarnessOverride: plan.harnessOverride,
+          spawnContext: plan.context)
+        log("RealtimeHub[\(providerTag)]: tool spawn_agent → AgentBridge pill=\"\(pill.title)\" model=\(model) provider=\(plan.selectedProvider?.rawValue ?? "default") titled=\(title?.isEmpty == false) fallback=\(plan.usedFallback)")
+        if !audioReceivedThisTurn {
+          let existingAck = assistantText.trimmingCharacters(in: .whitespacesAndNewlines)
+          let ack = existingAck.isEmpty ? plan.ack : existingAck
+          assistantText = ack
+          barState?.isVoiceResponseActive = true
+          speak(ack)
+        }
+        suppressAssistantOutputForCurrentTurn = true
+        let toolOutput: String
+        if let fallbackNote = plan.fallbackNote {
+          toolOutput = "Agent started with fallback. \(fallbackNote)"
+        } else {
+          toolOutput = "Agent started."
+        }
+        sendToolResultIfCurrent(
+          source: source, callId: callId, name: name,
+          output: toolOutput)
       }
-      suppressAssistantOutputForCurrentTurn = true
-      sendToolResultIfCurrent(
-        source: source, callId: callId, name: name,
-        output: "Agent started.")
     case .screenshot:
       // Gemini: the screen is already attached to every turn (see commitTurn), so the
       // tool is just an ack — pushing another image here is the broken path (mid-tool-call

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubTools.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubTools.swift
@@ -70,13 +70,13 @@ enum HubTool: String {
 
 enum RealtimeHubTools {
   private static func localAgentProviderInstruction() -> String {
-    let providers: [AgentPillsManager.DirectedProvider] = [.openclaw, .hermes]
+    let providers: [AgentPillsManager.DirectedProvider] = [.openclaw, .hermes, .codex]
     let availability = providers.map { LocalAgentProviderDetector.availability(for: $0) }
     let available = availability.filter(\.isAvailable).map(\.provider)
     let unavailable = availability.filter { !$0.isAvailable }
 
     if unavailable.isEmpty {
-      return "If the user asks to use/ask OpenClaw or Hermes, call spawn_agent with provider set to \"openclaw\" or \"hermes\". Treat those as available local providers, not as sessions to inspect."
+      return "If the user asks to use/ask OpenClaw, Hermes, or Codex, call spawn_agent with provider set to \"openclaw\", \"hermes\", or \"codex\". Treat those as available local providers, not as sessions to inspect."
     }
 
     var parts: [String] = []
@@ -92,7 +92,7 @@ enum RealtimeHubTools {
   }
 
   private static func availableDirectedProviderRawValues() -> [String] {
-    [AgentPillsManager.DirectedProvider.openclaw, .hermes]
+    [AgentPillsManager.DirectedProvider.openclaw, .hermes, .codex]
       .filter { LocalAgentProviderDetector.isAvailable($0) }
       .map(\.rawValue)
   }
@@ -212,6 +212,11 @@ enum RealtimeHubTools {
     user. So always emit the spawn_agent call. You may add one short natural sentence as you \
     call it, but never instead of it. Do NOT ask clarifying questions before spawning — spawn \
     with what you have. Do NOT wait for it, narrate its steps, refuse, or claim you can't.
+    - Smart agent routing: When calling spawn_agent, you must select the best local agent provider (pass it in the `provider` argument) based on availability and task fit. When the user explicitly requests an agent by name (e.g. \"use hermes\"), always select that provider. If the user doesn't specify one: \
+      - Choose \"hermes\" for coding tasks involving codebase exploration, refactoring, or multi-file edits. \
+      - Choose \"codex\" for writing new code/scripts, debugging, or code review. \
+      - Choose \"openclaw\" for general-purpose automation or structured tasks. \
+      - Omit the provider (default) to use Claude Code for general reasoning, complex analysis, and multi-step tasks.
     - \(localAgentProviderInstruction())
     - Everything else — general questions, facts, chit-chat, explanations, advice, jokes, \
     and creative or long-form requests (stories, brainstorming, drafts): ANSWER YOURSELF. \

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubTools.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubTools.swift
@@ -82,12 +82,16 @@ enum RealtimeHubTools {
     var parts: [String] = []
     if !available.isEmpty {
       let names = available.map { "\"\($0.rawValue)\"" }.joined(separator: " or ")
-      parts.append("If the user asks to use/ask \(available.map(\.displayName).joined(separator: " or ")), call spawn_agent with provider set to \(names).")
+      parts.append("Installed local providers: \(available.map(\.displayName).joined(separator: ", ")). Prefer these in spawn_agent's provider argument.")
+      parts.append("If the user explicitly asks to use/ask one of them by name, pass that provider. Otherwise pick the best fit from the installed list above — Omi will fall back automatically if your pick is missing.")
+      parts.append("Never tell the user to install a provider they did not ask for by name.")
     }
-    let missingText = unavailable
-      .map { "\($0.provider.displayName): \($0.setupPrompt)" }
-      .joined(separator: " ")
-    parts.append("If the user asks to use/ask an unavailable local provider, do NOT spawn a default agent. Say it needs setup and use this guidance: \(missingText)")
+    if !unavailable.isEmpty {
+      let missingText = unavailable
+        .map { "\($0.provider.displayName): \($0.setupPrompt)" }
+        .joined(separator: " ")
+      parts.append("Only mention install guidance when the user explicitly asked for that provider by name: \(missingText)")
+    }
     return parts.joined(separator: " ")
   }
 
@@ -212,10 +216,10 @@ enum RealtimeHubTools {
     user. So always emit the spawn_agent call. You may add one short natural sentence as you \
     call it, but never instead of it. Do NOT ask clarifying questions before spawning — spawn \
     with what you have. Do NOT wait for it, narrate its steps, refuse, or claim you can't.
-    - Smart agent routing: When calling spawn_agent, you must select the best local agent provider (pass it in the `provider` argument) based on availability and task fit. When the user explicitly requests an agent by name (e.g. \"use hermes\"), always select that provider. If the user doesn't specify one: \
-      - Choose \"hermes\" for coding tasks involving codebase exploration, refactoring, or multi-file edits. \
+    - Smart agent routing: When calling spawn_agent, pass the best installed local provider in `provider` when you know one fits. Omi also picks and falls back automatically in code. When the user explicitly requests an agent by name (e.g. \"use codex\"), always pass that provider. If the user doesn't specify one, prefer an installed provider from the list above — do NOT pick or mention providers that are not installed: \
       - Choose \"codex\" for writing new code/scripts, debugging, or code review. \
       - Choose \"openclaw\" for general-purpose automation or structured tasks. \
+      - Choose \"hermes\" only when it is installed and the task needs codebase exploration or multi-file refactors. \
       - Omit the provider (default) to use Claude Code for general reasoning, complex analysis, and multi-step tasks.
     - \(localAgentProviderInstruction())
     - Everything else — general questions, facts, chit-chat, explanations, advice, jokes, \

--- a/desktop/macos/Desktop/Sources/Providers/AgentRuntimeRouting.swift
+++ b/desktop/macos/Desktop/Sources/Providers/AgentRuntimeRouting.swift
@@ -5,6 +5,7 @@ enum AgentHarnessMode: String {
     case acp = "acp"
     case hermes = "hermes"
     case openclaw = "openclaw"
+    case codex = "codex"
 }
 
 extension Optional where Wrapped == AgentHarnessMode {
@@ -19,6 +20,7 @@ enum AgentAdapterId: String {
     case acp = "acp"
     case hermes = "hermes"
     case openclaw = "openclaw"
+    case codex = "codex"
 }
 
 enum AgentRuntimeRouting {
@@ -32,6 +34,8 @@ enum AgentRuntimeRouting {
             return .hermes
         case .openClaw:
             return .openclaw
+        case .codex:
+            return .codex
         }
     }
 
@@ -45,6 +49,8 @@ enum AgentRuntimeRouting {
             return .hermes
         case AgentHarnessMode.openclaw.rawValue, "openClaw":
             return .openclaw
+        case AgentHarnessMode.codex.rawValue:
+            return .codex
         default:
             return nil
         }
@@ -60,6 +66,8 @@ enum AgentRuntimeRouting {
             return .hermes
         case .openclaw:
             return .openclaw
+        case .codex:
+            return .codex
         }
     }
 }
@@ -84,6 +92,8 @@ struct LocalAgentProviderAvailability: Equatable {
             return "I don't see Hermes installed. Make sure Hermes is installed first, then try again."
         case .openclaw:
             return "I don't see OpenClaw installed. Make sure OpenClaw is installed first, then try again."
+        case .codex:
+            return "I don't see Codex installed. Please run 'npm install -g @openai/codex' and run 'codex' in your terminal to sign in, then try again."
         }
     }
 
@@ -152,6 +162,8 @@ enum LocalAgentProviderDetector {
             "\(homeDirectory)/.hermes/node/bin",
             "\(homeDirectory)/.hermes/hermes-agent",
             "\(homeDirectory)/.local/bin",
+            "\(homeDirectory)/.npm-global/bin",
+            "\(homeDirectory)/.volta/bin",
             "/opt/homebrew/bin",
             "/usr/local/bin",
         ]

--- a/desktop/macos/Desktop/Sources/Providers/AgentRuntimeRouting.swift
+++ b/desktop/macos/Desktop/Sources/Providers/AgentRuntimeRouting.swift
@@ -147,7 +147,7 @@ enum LocalAgentProviderDetector {
         fileManager: FileManager,
         homeDirectory: String
     ) -> String? {
-        for dir in adapterActivationSearchDirectories(homeDirectory: homeDirectory) {
+        for dir in adapterActivationSearchDirectories(homeDirectory: homeDirectory, fileManager: fileManager) {
             let path = (dir as NSString).appendingPathComponent(name)
             if fileManager.isExecutableFile(atPath: path) {
                 return path
@@ -156,8 +156,11 @@ enum LocalAgentProviderDetector {
         return nil
     }
 
-    private static func adapterActivationSearchDirectories(homeDirectory: String) -> [String] {
-        [
+    static func adapterActivationSearchDirectories(
+        homeDirectory: String,
+        fileManager: FileManager = .default
+    ) -> [String] {
+        var directories = [
             "\(homeDirectory)/.hermes/hermes-agent/venv/bin",
             "\(homeDirectory)/.hermes/node/bin",
             "\(homeDirectory)/.hermes/hermes-agent",
@@ -167,5 +170,330 @@ enum LocalAgentProviderDetector {
             "/opt/homebrew/bin",
             "/usr/local/bin",
         ]
+        directories.append(contentsOf: nvmBinDirectories(homeDirectory: homeDirectory, fileManager: fileManager))
+        return directories
+    }
+
+    private static func nvmBinDirectories(
+        homeDirectory: String,
+        fileManager: FileManager
+    ) -> [String] {
+        let nvmRoot = (homeDirectory as NSString).appendingPathComponent(".nvm/versions/node")
+        guard let versions = try? fileManager.contentsOfDirectory(atPath: nvmRoot) else {
+            return []
+        }
+        return versions
+            .sorted { lhs, rhs in lhs.compare(rhs, options: .numeric) == .orderedDescending }
+            .map { (nvmRoot as NSString).appendingPathComponent("\($0)/bin") }
+    }
+}
+
+enum AgentTaskKind: Equatable {
+    case coding
+    case automation
+    case general
+}
+
+struct AgentSpawnContext: Equatable {
+    let taskKind: AgentTaskKind
+    let explicitProvider: AgentPillsManager.DirectedProvider?
+    let fallbackChain: [AgentHarnessMode?]
+    var attemptedHarnesses: [AgentHarnessMode?]
+
+    func nextFallback(after current: AgentHarnessMode?) -> AgentHarnessMode?? {
+        guard let currentIndex = fallbackChain.firstIndex(where: { $0 == current }) else {
+            return fallbackChain.first { harness in
+                !attemptedHarnesses.contains(where: { $0 == harness })
+            }
+        }
+        for harness in fallbackChain.dropFirst(currentIndex + 1) {
+            if !attemptedHarnesses.contains(where: { $0 == harness }) {
+                return harness
+            }
+        }
+        return nil
+    }
+
+    mutating func recordAttempt(_ harness: AgentHarnessMode?) {
+        if !attemptedHarnesses.contains(where: { $0 == harness }) {
+            attemptedHarnesses.append(harness)
+        }
+    }
+}
+
+enum LocalAgentProviderRouting {
+    enum Resolution: Equatable {
+        case spawn(AgentSpawnPlan)
+        case setupRequired(
+            provider: AgentPillsManager.DirectedProvider,
+            prompt: String,
+            spokenStatus: String
+        )
+    }
+
+    struct AgentSpawnPlan: Equatable {
+        let harnessOverride: AgentHarnessMode?
+        let title: String
+        let ack: String
+        let selectedProvider: AgentPillsManager.DirectedProvider?
+        let usedFallback: Bool
+        let fallbackNote: String?
+        let context: AgentSpawnContext
+    }
+
+    static func classifyTask(_ text: String) -> AgentTaskKind {
+        let lower = text.lowercased()
+        let codingSignals = [
+            "code", "script", "debug", "refactor", "compile", "function", "class", "api",
+            "bug", "implement", "python", "swift", "typescript", "javascript", "repo",
+            "repository", "pull request", "unit test", "lint", "syntax",
+        ]
+        if codingSignals.contains(where: { lower.contains($0) }) {
+            return .coding
+        }
+        let automationSignals = [
+            "automate", "click", "open app", "send email", "browser", "download",
+            "upload", "reminder", "notes app", "messages app", "files app", "folder",
+        ]
+        if automationSignals.contains(where: { lower.contains($0) }) {
+            return .automation
+        }
+        return .general
+    }
+
+    static func preferredProviders(for task: AgentTaskKind) -> [AgentPillsManager.DirectedProvider] {
+        switch task {
+        case .coding:
+            return [.codex, .hermes, .openclaw]
+        case .automation:
+            return [.openclaw, .codex, .hermes]
+        case .general:
+            return [.openclaw, .codex, .hermes]
+        }
+    }
+
+    static func explicitProvider(in text: String) -> AgentPillsManager.DirectedProvider? {
+        AgentPillsManager.providerDirective(from: text)?.provider
+    }
+
+    static func isExplicitProviderRequest(
+        _ provider: AgentPillsManager.DirectedProvider,
+        in text: String
+    ) -> Bool {
+        if explicitProvider(in: text) == provider {
+            return true
+        }
+        let openClawPattern = #"(?i)\bopen\s*claw\b"#
+        switch provider {
+        case .openclaw:
+            return text.range(of: openClawPattern, options: .regularExpression) != nil
+        case .hermes, .codex:
+            let pattern = #"(?i)\b\#(provider.rawValue)\b"#
+            return text.range(of: pattern, options: .regularExpression) != nil
+        }
+    }
+
+    static func isRetriableSpawnFailure(_ message: String) -> Bool {
+        let lower = message.lowercased()
+        return lower.contains("not available")
+            || lower.contains("failed to start")
+            || lower.contains("adapter")
+            || lower.contains("enoent")
+            || lower.contains("command not found")
+            || lower.contains("activation")
+    }
+
+    static func resolveSpawn(
+        brief: String,
+        requestedProvider: AgentPillsManager.DirectedProvider?,
+        userRequestText: String?,
+        title: String?,
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        fileManager: FileManager = .default,
+        homeDirectory: String = NSHomeDirectory()
+    ) -> Resolution {
+        let taskKind = classifyTask(brief)
+        // Only treat a provider as user-directed when it appears in the user's own
+        // words. The model-authored `brief` often names a provider the model chose
+        // (e.g. "use Hermes to refactor…") even when the user never said it.
+        let userText = userRequestText?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let explicit = userText.isEmpty ? nil : AgentPillsManager.DirectedProvider.allCases.first {
+            isExplicitProviderRequest($0, in: userText)
+        }
+
+        if let explicit {
+            let availability = LocalAgentProviderDetector.availability(
+                for: explicit,
+                environment: environment,
+                fileManager: fileManager,
+                homeDirectory: homeDirectory
+            )
+            guard availability.isAvailable else {
+                return .setupRequired(
+                    provider: explicit,
+                    prompt: availability.setupPrompt,
+                    spokenStatus: explicit.setupNeededStatus
+                )
+            }
+            let resolvedTitle = normalizedTitle(title, provider: explicit)
+            return .spawn(
+                AgentSpawnPlan(
+                    harnessOverride: explicit.harnessMode,
+                    title: resolvedTitle,
+                    ack: "Asking \(explicit.displayName).",
+                    selectedProvider: explicit,
+                    usedFallback: false,
+                    fallbackNote: nil,
+                    context: spawnContext(
+                        taskKind: taskKind,
+                        explicitProvider: explicit,
+                        selectedHarness: explicit.harnessMode,
+                        environment: environment,
+                        fileManager: fileManager,
+                        homeDirectory: homeDirectory
+                    )
+                )
+            )
+        }
+
+        let orderedProviders = preferredProviders(for: taskKind)
+        let availableProviders = orderedProviders.filter {
+            LocalAgentProviderDetector.isAvailable(
+                $0,
+                environment: environment,
+                fileManager: fileManager,
+                homeDirectory: homeDirectory
+            )
+        }
+
+        if let requestedProvider {
+            if LocalAgentProviderDetector.isAvailable(
+                requestedProvider,
+                environment: environment,
+                fileManager: fileManager,
+                homeDirectory: homeDirectory
+            ) {
+                let resolvedTitle = normalizedTitle(title, provider: requestedProvider)
+                return .spawn(
+                    AgentSpawnPlan(
+                        harnessOverride: requestedProvider.harnessMode,
+                        title: resolvedTitle,
+                        ack: "Starting \(requestedProvider.displayName).",
+                        selectedProvider: requestedProvider,
+                        usedFallback: false,
+                        fallbackNote: nil,
+                        context: spawnContext(
+                            taskKind: taskKind,
+                            explicitProvider: nil,
+                            selectedHarness: requestedProvider.harnessMode,
+                            environment: environment,
+                            fileManager: fileManager,
+                            homeDirectory: homeDirectory
+                        )
+                    )
+                )
+            }
+
+            if let fallbackProvider = availableProviders.first {
+                let note = "\(requestedProvider.displayName) isn't installed; using \(fallbackProvider.displayName) instead."
+                let resolvedTitle = normalizedTitle(title, provider: fallbackProvider)
+                return .spawn(
+                    AgentSpawnPlan(
+                        harnessOverride: fallbackProvider.harnessMode,
+                        title: resolvedTitle,
+                        ack: note,
+                        selectedProvider: fallbackProvider,
+                        usedFallback: true,
+                        fallbackNote: note,
+                        context: spawnContext(
+                            taskKind: taskKind,
+                            explicitProvider: nil,
+                            selectedHarness: fallbackProvider.harnessMode,
+                            environment: environment,
+                            fileManager: fileManager,
+                            homeDirectory: homeDirectory
+                        )
+                    )
+                )
+            }
+        }
+
+        if let primary = availableProviders.first {
+            let resolvedTitle = normalizedTitle(title, provider: primary)
+            return .spawn(
+                AgentSpawnPlan(
+                    harnessOverride: primary.harnessMode,
+                    title: resolvedTitle,
+                    ack: "Starting \(primary.displayName).",
+                    selectedProvider: primary,
+                    usedFallback: false,
+                    fallbackNote: nil,
+                    context: spawnContext(
+                        taskKind: taskKind,
+                        explicitProvider: nil,
+                        selectedHarness: primary.harnessMode,
+                        environment: environment,
+                        fileManager: fileManager,
+                        homeDirectory: homeDirectory
+                    )
+                )
+            )
+        }
+
+        let resolvedTitle = normalizedTitle(title, provider: nil)
+        return .spawn(
+            AgentSpawnPlan(
+                harnessOverride: nil,
+                title: resolvedTitle,
+                ack: "Starting a background agent.",
+                selectedProvider: nil,
+                usedFallback: false,
+                fallbackNote: nil,
+                context: spawnContext(
+                    taskKind: taskKind,
+                    explicitProvider: nil,
+                    selectedHarness: nil,
+                    environment: environment,
+                    fileManager: fileManager,
+                    homeDirectory: homeDirectory
+                )
+            )
+        )
+    }
+
+    private static func normalizedTitle(
+        _ title: String?,
+        provider: AgentPillsManager.DirectedProvider?
+    ) -> String {
+        let trimmed = title?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        if !trimmed.isEmpty { return trimmed }
+        return provider?.displayName ?? "Background agent"
+    }
+
+    private static func spawnContext(
+        taskKind: AgentTaskKind,
+        explicitProvider: AgentPillsManager.DirectedProvider?,
+        selectedHarness: AgentHarnessMode?,
+        environment: [String: String],
+        fileManager: FileManager,
+        homeDirectory: String
+    ) -> AgentSpawnContext {
+        let availableHarnesses = preferredProviders(for: taskKind)
+            .filter {
+                LocalAgentProviderDetector.isAvailable(
+                    $0,
+                    environment: environment,
+                    fileManager: fileManager,
+                    homeDirectory: homeDirectory
+                )
+            }
+            .map(\.harnessMode)
+        let fallbackChain = availableHarnesses + [nil]
+        return AgentSpawnContext(
+            taskKind: taskKind,
+            explicitProvider: explicitProvider,
+            fallbackChain: fallbackChain,
+            attemptedHarnesses: [selectedHarness]
+        )
     }
 }

--- a/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
@@ -902,6 +902,7 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
         case piMono = "piMono"
         case hermes = "hermes"
         case openClaw = "openclaw"
+        case codex = "codex"
     }
     @AppStorage("chatBridgeMode") var bridgeMode: String = BridgeMode.piMono.rawValue
 

--- a/desktop/macos/Desktop/Sources/Providers/ChatToolExecutor.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatToolExecutor.swift
@@ -469,35 +469,44 @@ class ChatToolExecutor {
       .trimmingCharacters(in: .whitespacesAndNewlines)
       .lowercased()
       .replacingOccurrences(of: " ", with: "")
-    let directedProvider: AgentPillsManager.DirectedProvider?
+    let requestedProvider: AgentPillsManager.DirectedProvider?
     switch providerName {
-    case "openclaw": directedProvider = .openclaw
-    case "hermes": directedProvider = .hermes
-    case "": directedProvider = nil
+    case "openclaw": requestedProvider = .openclaw
+    case "hermes": requestedProvider = .hermes
+    case "codex": requestedProvider = .codex
+    case "": requestedProvider = nil
     default:
-      return "Error: Unsupported provider '\(providerName)'. Supported providers: openclaw, hermes."
+      return "Error: Unsupported provider '\(providerName)'. Supported providers: openclaw, hermes, codex."
     }
-    if let directedProvider {
-      let availability = LocalAgentProviderDetector.availability(for: directedProvider)
-      guard availability.isAvailable else {
-        return availability.toolError
-      }
-    }
-    let model = ShortcutSettings.shared.selectedModel.isEmpty
-      ? "claude-sonnet-4-6" : ShortcutSettings.shared.selectedModel
-    let pill = AgentPillsManager.shared.spawnFromUserQuery(
-      brief,
-      model: model,
-      fromVoice: false,
-      preFetchedTitle: (title?.isEmpty == false) ? title : directedProvider?.displayName,
-      bridgeHarnessOverride: directedProvider?.harnessMode
+    let resolution = LocalAgentProviderRouting.resolveSpawn(
+      brief: brief,
+      requestedProvider: requestedProvider,
+      userRequestText: nil,
+      title: title
     )
-    return """
-    Agent started as a floating agent pill.
-    id: \(pill.id.uuidString)
-    title: \(pill.title)
-    status: \(pill.status.displayLabel)
-    """
+    switch resolution {
+    case .setupRequired(_, let setupPrompt, _):
+      return "Error: \(setupPrompt)"
+    case .spawn(let plan):
+      let model = ShortcutSettings.shared.selectedModel.isEmpty
+        ? "claude-sonnet-4-6" : ShortcutSettings.shared.selectedModel
+      let pill = AgentPillsManager.shared.spawnFromUserQuery(
+        brief,
+        model: model,
+        fromVoice: false,
+        preFetchedTitle: plan.title,
+        preFetchedAck: plan.ack,
+        bridgeHarnessOverride: plan.harnessOverride,
+        spawnContext: plan.context
+      )
+      let fallbackLine = plan.fallbackNote.map { "\nfallback: \($0)" } ?? ""
+      return """
+      Agent started as a floating agent pill.
+      id: \(pill.id.uuidString)
+      title: \(pill.title)
+      status: \(pill.status.displayLabel)\(fallbackLine)
+      """
+    }
   }
 
   private static func executeManageAgentPills(_ args: [String: Any]) async -> String {

--- a/desktop/macos/Desktop/Tests/AgentPillLifecycleTests.swift
+++ b/desktop/macos/Desktop/Tests/AgentPillLifecycleTests.swift
@@ -47,12 +47,12 @@ final class AgentPillLifecycleTests: XCTestCase {
   func testTypedProviderDirectivePromptsForSetupWhenProviderUnavailable() throws {
     let source = try floatingControlBarWindowSource()
 
-    XCTAssertTrue(source.contains("LocalAgentProviderDetector.availability(for: directive.provider)"))
-    XCTAssertTrue(source.contains("guard availability.isAvailable else"))
+    XCTAssertTrue(source.contains("LocalAgentProviderRouting.resolveSpawn("))
+    XCTAssertTrue(source.contains("requestedProvider: directive.provider"))
     XCTAssertTrue(source.contains("floating-agent-provider-unavailable"))
     XCTAssertTrue(source.contains("completeVisibleAgentResponse("))
     XCTAssertFalse(source.contains("completeVisibleProviderSetupPrompt("))
-    XCTAssertTrue(source.contains("FloatingBarVoicePlaybackService.shared.speakOneShot(directive.provider.setupNeededStatus)"))
+    XCTAssertTrue(source.contains("FloatingBarVoicePlaybackService.shared.speakOneShot(spokenStatus)"))
   }
 
   func testSubagentChatSpawnRequestCreatesSiblingAgent() throws {
@@ -309,7 +309,7 @@ final class AgentPillLifecycleTests: XCTestCase {
     XCTAssertTrue(source.contains("let handoff = AgentPillsManager.floatingAgentHandoff(for: message)"))
     XCTAssertTrue(source.contains("AgentPillsManager.shared.spawnFromHandoff("))
     XCTAssertTrue(source.contains("completeVisibleAgentHandoff(\n                    handoff,\n                    pill: pill"))
-    XCTAssertTrue(source.contains("completeVisibleAgentHandoff(\n                    .init(originalRequest: message, agentTask: message),\n                    pill: pill"))
+    XCTAssertTrue(source.contains("completeVisibleAgentHandoff(\n                        .init(originalRequest: message, agentTask: message),\n                        pill: pill"))
     XCTAssertTrue(source.contains("let toolUseId = \"floating-agent-\\(pill.id.uuidString)\""))
     XCTAssertTrue(source.contains("name: \"spawn_agent\""))
     XCTAssertTrue(source.contains("status: .completed"))

--- a/desktop/macos/Desktop/Tests/AgentRuntimeProcessTests.swift
+++ b/desktop/macos/Desktop/Tests/AgentRuntimeProcessTests.swift
@@ -56,6 +56,7 @@ final class AgentRuntimeProcessTests: XCTestCase {
     XCTAssertEqual(AgentRuntimeProcess.adapterId(forHarnessMode: "hermes"), "hermes")
     XCTAssertEqual(AgentRuntimeProcess.adapterId(forHarnessMode: "openclaw"), "openclaw")
     XCTAssertEqual(AgentRuntimeProcess.adapterId(forHarnessMode: "openClaw"), "openclaw")
+    XCTAssertEqual(AgentRuntimeProcess.adapterId(forHarnessMode: "codex"), "codex")
     XCTAssertNil(AgentRuntimeProcess.adapterId(forHarnessMode: "unknown"))
   }
 
@@ -162,6 +163,9 @@ final class AgentRuntimeProcessTests: XCTestCase {
     XCTAssertTrue(source.contains(#"env["PATH"] = pathElements.joined(separator: ":")"#))
     XCTAssertTrue(source.contains(#"env["OMI_OPENCLAW_ADAPTER_COMMAND"]"#))
     XCTAssertTrue(source.contains(#"env["OMI_HERMES_ADAPTER_COMMAND"]"#))
+    XCTAssertTrue(source.contains(#"env["OMI_CODEX_ADAPTER_COMMAND"]"#))
+    XCTAssertTrue(source.contains(#""\(home)/.npm-global/bin""#))
+    XCTAssertTrue(source.contains(#""\(home)/.volta/bin""#))
   }
 
   func testOpenClawAdapterCommandUsesSiblingNodeWhenAvailable() throws {
@@ -195,6 +199,15 @@ final class AgentRuntimeProcessTests: XCTestCase {
     let command = AgentRuntimeProcess.openClawAdapterCommand(openClawPath: openClawPath)
 
     XCTAssertEqual(command, "'\(openClawPath)' acp")
+  }
+
+  func testCodexAdapterCommandWrapsDetectedBinaryWithACPBridge() {
+    let command = AgentRuntimeProcess.codexAdapterCommand(codexPath: "/opt/homebrew/bin/codex")
+
+    XCTAssertEqual(
+      command,
+      "CODEX_PATH='/opt/homebrew/bin/codex' npx -y @agentclientprotocol/codex-acp"
+    )
   }
 
   func testStdoutReaderIsEventDrivenInsteadOfDetachedAvailableDataLoop() throws {

--- a/desktop/macos/Desktop/Tests/LocalAgentProviderRoutingTests.swift
+++ b/desktop/macos/Desktop/Tests/LocalAgentProviderRoutingTests.swift
@@ -1,0 +1,116 @@
+import XCTest
+
+@testable import Omi_Computer
+
+final class LocalAgentProviderRoutingTests: XCTestCase {
+    func testClassifyTaskDetectsCoding() {
+        XCTAssertEqual(
+            LocalAgentProviderRouting.classifyTask("debug this python script"),
+            .coding
+        )
+    }
+
+    func testClassifyTaskDetectsAutomation() {
+        XCTAssertEqual(
+            LocalAgentProviderRouting.classifyTask("automate sending this email"),
+            .automation
+        )
+    }
+
+    func testModelBriefMentioningHermesDoesNotCountAsExplicitUserRequest() {
+        let env = ["OMI_CODEX_ADAPTER_COMMAND": "/tmp/codex"]
+        let resolution = LocalAgentProviderRouting.resolveSpawn(
+            brief: "Use Hermes to refactor the auth module",
+            requestedProvider: .hermes,
+            userRequestText: nil,
+            title: nil,
+            environment: env,
+            fileManager: FileManager(),
+            homeDirectory: "/tmp/omi-routing-test"
+        )
+
+        guard case .spawn(let plan) = resolution else {
+            return XCTFail("Expected spawn fallback to Codex, got \(resolution)")
+        }
+        XCTAssertEqual(plan.selectedProvider, .codex)
+        XCTAssertTrue(plan.usedFallback)
+    }
+
+    func testExplicitHermesInUserTextStillRequiresSetupWhenMissing() {
+        let resolution = LocalAgentProviderRouting.resolveSpawn(
+            brief: "fix the bug",
+            requestedProvider: .hermes,
+            userRequestText: "use hermes to fix the bug",
+            title: nil,
+            environment: [:],
+            fileManager: FileManager(),
+            homeDirectory: "/tmp/omi-routing-test"
+        )
+
+        guard case .setupRequired(let provider, let prompt, _) = resolution else {
+            return XCTFail("Expected setupRequired, got \(resolution)")
+        }
+        XCTAssertEqual(provider, .hermes)
+        XCTAssertTrue(prompt.contains("Hermes"))
+    }
+
+    func testSmartRoutingFallsBackWhenRequestedProviderMissing() {
+        let env = ["OMI_CODEX_ADAPTER_COMMAND": "/tmp/codex"]
+        let resolution = LocalAgentProviderRouting.resolveSpawn(
+            brief: "write a script to parse logs",
+            requestedProvider: .hermes,
+            userRequestText: "write a script to parse logs",
+            title: "Log parser",
+            environment: env,
+            fileManager: FileManager(),
+            homeDirectory: "/tmp/omi-routing-test"
+        )
+
+        guard case .spawn(let plan) = resolution else {
+            return XCTFail("Expected spawn, got \(resolution)")
+        }
+        XCTAssertEqual(plan.selectedProvider, .codex)
+        XCTAssertTrue(plan.usedFallback)
+        XCTAssertNotNil(plan.fallbackNote)
+        XCTAssertEqual(plan.harnessOverride, .codex)
+    }
+
+    func testSmartRoutingPicksCodexForCodingWhenAvailable() {
+        let env = [
+            "OMI_CODEX_ADAPTER_COMMAND": "/tmp/codex",
+            "OMI_OPENCLAW_ADAPTER_COMMAND": "/tmp/openclaw",
+        ]
+        let resolution = LocalAgentProviderRouting.resolveSpawn(
+            brief: "review this swift api change",
+            requestedProvider: nil,
+            userRequestText: "review this swift api change",
+            title: nil,
+            environment: env,
+            fileManager: FileManager(),
+            homeDirectory: "/tmp/omi-routing-test"
+        )
+
+        guard case .spawn(let plan) = resolution else {
+            return XCTFail("Expected spawn, got \(resolution)")
+        }
+        XCTAssertEqual(plan.selectedProvider, .codex)
+        XCTAssertFalse(plan.usedFallback)
+    }
+
+    func testSpawnContextAdvancesFallbackChain() {
+        var context = AgentSpawnContext(
+            taskKind: .coding,
+            explicitProvider: nil,
+            fallbackChain: [.codex, .openclaw, nil],
+            attemptedHarnesses: [.codex]
+        )
+        XCTAssertEqual(context.nextFallback(after: .codex), .some(.openclaw))
+        context.recordAttempt(.openclaw)
+        XCTAssertEqual(context.nextFallback(after: .openclaw), .some(nil))
+    }
+
+    func testIsRetriableSpawnFailureMatchesInfrastructureErrors() {
+        XCTAssertTrue(LocalAgentProviderRouting.isRetriableSpawnFailure("AI not available: adapter failed"))
+        XCTAssertFalse(LocalAgentProviderRouting.isRetriableSpawnFailure("Could not find the email thread"))
+    }
+}

--- a/desktop/macos/Desktop/Tests/PiMonoWiringTests.swift
+++ b/desktop/macos/Desktop/Tests/PiMonoWiringTests.swift
@@ -73,6 +73,25 @@ final class PiMonoWiringTests: XCTestCase {
     XCTAssertEqual(availability.status, .available(command: executable.path))
   }
 
+  func testLocalAgentProviderDetectorFindsCodexInNvmBin() throws {
+    let home = FileManager.default.temporaryDirectory
+      .appendingPathComponent("omi-provider-detector-\(UUID().uuidString)", isDirectory: true)
+    let bin = home.appendingPathComponent(".nvm/versions/node/v24.13.0/bin", isDirectory: true)
+    try FileManager.default.createDirectory(at: bin, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: home) }
+
+    let executable = bin.appendingPathComponent("codex")
+    try "#!/bin/sh\nexit 0\n".write(to: executable, atomically: true, encoding: .utf8)
+    try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: executable.path)
+
+    let availability = LocalAgentProviderDetector.availability(
+      for: .codex,
+      environment: [:],
+      homeDirectory: home.path)
+
+    XCTAssertEqual(availability.status, .available(command: executable.path))
+  }
+
   func testLocalAgentProviderDetectorIgnoresArbitraryPathEntries() throws {
     let root = FileManager.default.temporaryDirectory
       .appendingPathComponent("omi-provider-path-\(UUID().uuidString)", isDirectory: true)

--- a/desktop/macos/Desktop/Tests/RealtimeHubSpawnAgentTests.swift
+++ b/desktop/macos/Desktop/Tests/RealtimeHubSpawnAgentTests.swift
@@ -9,7 +9,8 @@ final class RealtimeHubSpawnAgentTests: XCTestCase {
     XCTAssertTrue(source.contains("private var suppressAssistantOutputForCurrentTurn = false"))
     XCTAssertTrue(source.contains("guard !suppressAssistantOutputForCurrentTurn else { return }"))
     XCTAssertTrue(source.contains("suppressAssistantOutputForCurrentTurn = true"))
-    XCTAssertTrue(source.contains("output: \"Agent started.\""))
+    XCTAssertTrue(source.contains("toolOutput = \"Agent started.\""))
+    XCTAssertTrue(source.contains("toolOutput = \"Agent started with fallback. \\(fallbackNote)\""))
     XCTAssertFalse(source.contains("Acknowledged before the call — do not say anything else"))
   }
 
@@ -18,23 +19,18 @@ final class RealtimeHubSpawnAgentTests: XCTestCase {
 
     XCTAssertTrue(source.contains("if !audioReceivedThisTurn {"))
     XCTAssertTrue(source.contains("let existingAck = assistantText.trimmingCharacters"))
-    XCTAssertTrue(source.contains("let ack = existingAck.isEmpty ? \"Starting a background agent.\" : existingAck"))
+    XCTAssertTrue(source.contains("let ack = existingAck.isEmpty ? plan.ack : existingAck"))
     XCTAssertTrue(source.contains("speak(ack)"))
   }
 
   func testSpawnAgentPreflightsDirectedProviderAvailability() throws {
     let source = try realtimeHubControllerSource()
 
-    XCTAssertTrue(source.contains("LocalAgentProviderDetector.availability(for: directedProvider)"))
-    XCTAssertTrue(source.contains("guard availability.isAvailable else"))
+    XCTAssertTrue(source.contains("LocalAgentProviderRouting.resolveSpawn("))
+    XCTAssertTrue(source.contains("case .setupRequired(let provider, let setupPrompt, let spokenStatus):"))
     XCTAssertTrue(source.contains("assistantText = setupPrompt"))
-    XCTAssertTrue(source.contains("output: availability.toolError"))
-    XCTAssertTrue(source.contains("""
-          sendToolResultIfCurrent(
-            source: source, callId: callId, name: name,
-            output: availability.toolError)
-          return
-"""))
+    XCTAssertTrue(source.contains("speak(spokenStatus)"))
+    XCTAssertTrue(source.contains("output: \"Error: \\(setupPrompt)\""))
   }
 
   func testCanonicalAgentControlSummariesDoNotSpeakOpaqueIds() throws {

--- a/desktop/macos/agent/package-lock.json
+++ b/desktop/macos/agent/package-lock.json
@@ -803,29 +803,6 @@
         "url": "https://github.com/sponsors/Borewit"
       }
     },
-    "node_modules/@emnapi/core": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
-      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.2",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
-      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
@@ -4264,6 +4241,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4828,6 +4806,7 @@
       "integrity": "sha512-BuJcQK/56NQTWDGn4ABea3q4SSBdNPWwNZKTkkUpcMPnLoquSYH8llRtSUIgoL1KSCpHt5eghLShn50mH36y7Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -5181,6 +5160,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/desktop/macos/agent/src/adapters/codex.ts
+++ b/desktop/macos/agent/src/adapters/codex.ts
@@ -1,0 +1,19 @@
+import { AcpRuntimeAdapter } from "./acp.js";
+
+export interface CodexRuntimeAdapterOptions {
+  command?: string;
+  log?: (message: string) => void;
+}
+
+export class CodexRuntimeAdapter extends AcpRuntimeAdapter {
+  constructor(options: CodexRuntimeAdapterOptions = {}) {
+    super({
+      adapterId: "codex",
+      envCommandName: "OMI_CODEX_ADAPTER_COMMAND",
+      command: options.command,
+      sessionMcpServersMode: "empty",
+      supportsSessionSetModel: false,
+      log: options.log,
+    });
+  }
+}

--- a/desktop/macos/agent/src/adapters/interface.ts
+++ b/desktop/macos/agent/src/adapters/interface.ts
@@ -254,6 +254,20 @@ export const ADAPTER_CAPABILITY_MATRIX = {
       restartOrphanSemantics: required("Startup reconciliation orphans active attempts while preserving native-resumable OpenClaw bindings."),
     },
   },
+  codex: {
+    adapterId: "codex",
+    productionAdapter: true,
+    expectations: {
+      nativeResume: required("Codex ACP exposes native sessions through the Gateway-backed ACP bridge."),
+      cancellationDispatch: required("Codex ACP accepts cancellation through the shared ACP interrupt path."),
+      cancellationAck: knownLimitation("Codex cancellation resolves locally without an independent adapter ack.", "TICKET-03-follow-up-cancel-ack"),
+      pinnedWorker: unsupported("Codex ACP sessions are native and do not require process-local pinned workers."),
+      modelSwitching: unsupported("Codex ACP does not currently expose session/set_model; model selection is configured in the Codex gateway/agent."),
+      artifactEmission: unsupported("Codex ACP adapter does not emit artifact references yet."),
+      toolSupport: unsupported("Codex ACP rejects per-session MCP servers; Omi tools are unavailable until configured through the Codex gateway/agent."),
+      restartOrphanSemantics: required("Startup reconciliation orphans active attempts while preserving native-resumable Codex bindings."),
+    },
+  },
   a2a: {
     adapterId: "a2a",
     productionAdapter: false,
@@ -262,10 +276,10 @@ export const ADAPTER_CAPABILITY_MATRIX = {
 } as const satisfies Record<string, AdapterCapabilityMatrixEntry>;
 
 export type KnownAdapterId = keyof typeof ADAPTER_CAPABILITY_MATRIX;
-export type ProductionAdapterId = "acp" | "pi-mono" | "hermes" | "openclaw";
+export type ProductionAdapterId = "acp" | "pi-mono" | "hermes" | "openclaw" | "codex";
 export type PlaceholderAdapterId = Exclude<KnownAdapterId, ProductionAdapterId>;
 
-export const PRODUCTION_ADAPTER_IDS = ["acp", "pi-mono", "hermes", "openclaw"] as const satisfies readonly ProductionAdapterId[];
+export const PRODUCTION_ADAPTER_IDS = ["acp", "pi-mono", "hermes", "openclaw", "codex"] as const satisfies readonly ProductionAdapterId[];
 export const PLACEHOLDER_ADAPTER_IDS = ["a2a"] as const satisfies readonly PlaceholderAdapterId[];
 
 export function isKnownAdapterId(adapterId: string): adapterId is KnownAdapterId {

--- a/desktop/macos/agent/src/index.ts
+++ b/desktop/macos/agent/src/index.ts
@@ -925,8 +925,16 @@ async function main(): Promise<void> {
       onCreate: (adapter) => localAcpAdapters.add(adapter),
     });
   };
+  const ensureCodexAdapter = async (): Promise<boolean> => {
+    return ensureRegisteredAdapter(registry, "codex", {
+      log: logErr,
+      maxWorkers: 1,
+      onCreate: (adapter) => localAcpAdapters.add(adapter),
+    });
+  };
   const hermesAvailable = await ensureHermesAdapter();
   const openClawAvailable = await ensureOpenClawAdapter();
+  const codexAvailable = await ensureCodexAdapter();
   if (!piMonoAvailable && defaultAdapterId === "pi-mono") {
     const msg = "pi-mono mode requires OMI_AUTH_TOKEN (Firebase ID token); refusing to start";
     logErr(msg);
@@ -941,6 +949,12 @@ async function main(): Promise<void> {
   }
   if (!openClawAvailable && defaultAdapterId === "openclaw") {
     const msg = adapterActivationError("openclaw") ?? "OpenClaw adapter is unavailable.";
+    logErr(msg);
+    send({ type: "error", message: msg });
+    process.exit(1);
+  }
+  if (!codexAvailable && defaultAdapterId === "codex") {
+    const msg = adapterActivationError("codex") ?? "Codex adapter is unavailable.";
     logErr(msg);
     send({ type: "error", message: msg });
     process.exit(1);
@@ -1026,6 +1040,10 @@ async function main(): Promise<void> {
             } else if (adapterId === "openclaw") {
               if (!(await ensureOpenClawAdapter())) {
                 throw new Error(adapterActivationError("openclaw"));
+              }
+            } else if (adapterId === "codex") {
+              if (!(await ensureCodexAdapter())) {
+                throw new Error(adapterActivationError("codex"));
               }
             }
             await facade.handleQuery(query);

--- a/desktop/macos/agent/src/runtime/adapter-selection.ts
+++ b/desktop/macos/agent/src/runtime/adapter-selection.ts
@@ -1,6 +1,7 @@
 import { AcpRuntimeAdapter } from "../adapters/acp.js";
 import { HermesRuntimeAdapter } from "../adapters/hermes.js";
 import { OpenClawRuntimeAdapter } from "../adapters/openclaw.js";
+import { CodexRuntimeAdapter } from "../adapters/codex.js";
 import { adapterCapabilitiesFor, type AdapterCapabilities, type ProductionAdapterId, type RuntimeAdapter } from "../adapters/interface.js";
 import type { AdapterRegistry } from "./adapter-registry.js";
 
@@ -9,6 +10,7 @@ export const ADAPTER_ACTIVATION_ENV = {
   "pi-mono": "OMI_AUTH_TOKEN",
   hermes: "OMI_HERMES_ADAPTER_COMMAND",
   openclaw: "OMI_OPENCLAW_ADAPTER_COMMAND",
+  codex: "OMI_CODEX_ADAPTER_COMMAND",
 } as const;
 
 export type SelectableAdapterId = keyof typeof ADAPTER_ACTIVATION_ENV;
@@ -52,6 +54,13 @@ export const ADAPTER_PROFILES: Record<ProductionAdapterId, AdapterProfile> = {
     capabilities: adapterCapabilitiesFor("openclaw"),
     createAdapter: ({ log }) => new OpenClawRuntimeAdapter({ log }),
   },
+  codex: {
+    adapterId: "codex",
+    activationEnv: ADAPTER_ACTIVATION_ENV.codex,
+    maxWorkers: 1,
+    capabilities: adapterCapabilitiesFor("codex"),
+    createAdapter: ({ log }) => new CodexRuntimeAdapter({ log }),
+  },
 };
 
 export function adapterIdForHarnessMode(harnessMode: string | undefined): SelectableAdapterId {
@@ -65,6 +74,8 @@ export function adapterIdForHarnessMode(harnessMode: string | undefined): Select
     case "openclaw":
     case "openClaw":
       return "openclaw";
+    case "codex":
+      return "codex";
     case "acp":
       return "acp";
     default:
@@ -91,8 +102,11 @@ export function adapterProfile(adapterId: ProductionAdapterId): AdapterProfile {
 export function adapterActivationError(adapterId: ProductionAdapterId): string | undefined {
   const envName = adapterActivationEnv(adapterId);
   if (!envName) return undefined;
-  const label = adapterId === "pi-mono" ? "pi-mono" : adapterId === "openclaw" ? "OpenClaw" : "Hermes";
-  if (adapterId === "hermes" || adapterId === "openclaw") {
+  const label = adapterId === "pi-mono" ? "pi-mono" : adapterId === "openclaw" ? "OpenClaw" : adapterId === "codex" ? "Codex" : "Hermes";
+  if (adapterId === "hermes" || adapterId === "openclaw" || adapterId === "codex") {
+    if (adapterId === "codex") {
+      return "Codex is not available. Please run 'npm install -g @openai/codex' and run 'codex' in your terminal to sign in, then try again.";
+    }
     return `${label} is not available. Make sure ${label} is installed first, then try again.`;
   }
   return `${label} adapter is unavailable.`;

--- a/desktop/macos/agent/src/runtime/failures.ts
+++ b/desktop/macos/agent/src/runtime/failures.ts
@@ -153,6 +153,8 @@ function adapterFailureLabel(adapterId: ProductionAdapterId, provider?: string):
       return "Hermes";
     case "pi-mono":
       return "pi-mono";
+    case "codex":
+      return "Codex";
     case "acp":
       if (provider === "openai") {
         return "OpenAI";

--- a/desktop/macos/agent/src/runtime/omi-tool-manifest.ts
+++ b/desktop/macos/agent/src/runtime/omi-tool-manifest.ts
@@ -270,7 +270,7 @@ export const swiftToolManifest: OmiToolManifestEntry[] = [
     promptGuidelines: [
       "Calling spawn_agent is the only way to start the circular floating-bar subagent; saying you will start one does not start it.",
       "Use delegate_agent instead for canonical Omi child sessions/runs that need durable delegation tracking.",
-      "If the user asks to use OpenClaw or Hermes, pass provider='openclaw' or provider='hermes' instead of treating that name as a session to inspect.",
+      "If the user asks to use OpenClaw, Hermes, or Codex, pass provider='openclaw', provider='hermes', or provider='codex' instead of treating that name as a session to inspect.",
       "Return immediately after spawning; the pill keeps working in the background.",
     ],
     latency: "async background",
@@ -280,7 +280,7 @@ export const swiftToolManifest: OmiToolManifestEntry[] = [
         title: { type: "string", description: "Short Title Case label for the agent pill." },
         provider: {
           type: "string",
-          enum: ["openclaw", "hermes"],
+          enum: ["openclaw", "hermes", "codex"],
           description: "Optional local agent provider to run this pill through.",
         },
       },

--- a/desktop/macos/agent/tests/adapter-selection.test.ts
+++ b/desktop/macos/agent/tests/adapter-selection.test.ts
@@ -17,6 +17,7 @@ describe("adapter selection and activation", () => {
     expect(adapterIdForHarnessMode("hermes")).toBe("hermes");
     expect(adapterIdForHarnessMode("openclaw")).toBe("openclaw");
     expect(adapterIdForHarnessMode("openClaw")).toBe("openclaw");
+    expect(adapterIdForHarnessMode("codex")).toBe("codex");
     expect(() => adapterIdForHarnessMode("unknown")).toThrow("Unknown harness mode: unknown");
   });
 
@@ -25,12 +26,14 @@ describe("adapter selection and activation", () => {
     expect(adapterActivationEnv("pi-mono")).toBe("OMI_AUTH_TOKEN");
     expect(adapterActivationEnv("hermes")).toBe("OMI_HERMES_ADAPTER_COMMAND");
     expect(adapterActivationEnv("openclaw")).toBe("OMI_OPENCLAW_ADAPTER_COMMAND");
+    expect(adapterActivationEnv("codex")).toBe("OMI_CODEX_ADAPTER_COMMAND");
 
     expect(adapterIsActivated("acp", {})).toBe(true);
     expect(adapterIsActivated("hermes", {})).toBe(false);
     expect(adapterIsActivated("hermes", { OMI_HERMES_ADAPTER_COMMAND: "  " })).toBe(false);
     expect(adapterIsActivated("hermes", { OMI_HERMES_ADAPTER_COMMAND: "hermes-adapter" })).toBe(true);
     expect(adapterIsActivated("openclaw", { OMI_OPENCLAW_ADAPTER_COMMAND: "openclaw-adapter" })).toBe(true);
+    expect(adapterIsActivated("codex", { OMI_CODEX_ADAPTER_COMMAND: "codex-adapter" })).toBe(true);
   });
 
   it("centralizes production adapter profiles and capabilities", () => {
@@ -49,6 +52,11 @@ describe("adapter selection and activation", () => {
       activationEnv: "OMI_OPENCLAW_ADAPTER_COMMAND",
       capabilities: { supportsTools: false, supportsModelSwitching: false },
     });
+    expect(adapterProfile("codex")).toMatchObject({
+      adapterId: "codex",
+      activationEnv: "OMI_CODEX_ADAPTER_COMMAND",
+      capabilities: { supportsTools: false, supportsModelSwitching: false },
+    });
     expect(adapterActivationError("hermes")).toBe(
       "Hermes is not available. Make sure Hermes is installed first, then try again."
     );
@@ -57,17 +65,23 @@ describe("adapter selection and activation", () => {
       "OpenClaw is not available. Make sure OpenClaw is installed first, then try again."
     );
     expect(adapterActivationError("openclaw")).not.toContain("OMI_OPENCLAW_ADAPTER_COMMAND");
+    expect(adapterActivationError("codex")).toBe(
+      "Codex is not available. Please run 'npm install -g @openai/codex' and run 'codex' in your terminal to sign in, then try again."
+    );
+    expect(adapterActivationError("codex")).not.toContain("OMI_CODEX_ADAPTER_COMMAND");
   });
 
-  it("source: daemon registers Hermes/OpenClaw explicitly and does not stamp MCP env as ACP", () => {
+  it("source: daemon registers Hermes/OpenClaw/Codex explicitly and does not stamp MCP env as ACP", () => {
     const indexSource = readFileSync(new URL("../src/index.ts", import.meta.url), "utf8");
 
     expect(indexSource).toContain("adapterIdForHarnessMode(defaultHarnessMode)");
     expect(indexSource).toContain('defaultAdapterId === "acp"');
     expect(indexSource).toContain("ensureRegisteredAdapter(registry, \"hermes\"");
     expect(indexSource).toContain("ensureRegisteredAdapter(registry, \"openclaw\"");
+    expect(indexSource).toContain("ensureRegisteredAdapter(registry, \"codex\"");
     expect(indexSource).toContain('adapterActivationError("hermes")');
     expect(indexSource).toContain('adapterActivationError("openclaw")');
+    expect(indexSource).toContain('adapterActivationError("codex")');
     expect(indexSource).toContain("query.ownerId = queryOwnerId");
     expect(indexSource).toContain('{ name: "OMI_ADAPTER_ID", value: context?.adapterId ?? "acp" }');
     expect(indexSource).not.toContain('{ name: "OMI_ADAPTER_ID", value: "acp" }');

--- a/desktop/macos/agent/tests/omi-tool-manifest.test.ts
+++ b/desktop/macos/agent/tests/omi-tool-manifest.test.ts
@@ -50,10 +50,11 @@ describe("omi tool manifest", () => {
     const spawnAgent = toolsForAdapter("pi-mono").find((tool) => tool.name === "spawn_agent");
 
     expect(spawnAgent?.inputSchema.properties.provider).toMatchObject({
-      enum: ["openclaw", "hermes"],
+      enum: ["openclaw", "hermes", "codex"],
     });
     expect(spawnAgent?.promptGuidelines?.join("\n")).toContain("provider='openclaw'");
     expect(spawnAgent?.promptGuidelines?.join("\n")).toContain("provider='hermes'");
+    expect(spawnAgent?.promptGuidelines?.join("\n")).toContain("provider='codex'");
   });
 
   it("projects stdio onboarding-only tools only in onboarding context", () => {

--- a/desktop/macos/agent/tests/runtime-adapter.test.ts
+++ b/desktop/macos/agent/tests/runtime-adapter.test.ts
@@ -478,7 +478,7 @@ describe("adapter capability matrix", () => {
     expect(Object.keys(ADAPTER_CAPABILITY_MATRIX).sort()).toEqual(
       [...PRODUCTION_ADAPTER_IDS, ...PLACEHOLDER_ADAPTER_IDS].sort()
     );
-    expect(PRODUCTION_ADAPTER_IDS).toEqual(["acp", "pi-mono", "hermes", "openclaw"]);
+    expect(PRODUCTION_ADAPTER_IDS).toEqual(["acp", "pi-mono", "hermes", "openclaw", "codex"]);
     expect(PLACEHOLDER_ADAPTER_IDS).toEqual(["a2a"]);
 
     expect(ADAPTER_CAPABILITY_MATRIX.acp.expectations).toMatchObject({
@@ -512,6 +512,16 @@ describe("adapter capability matrix", () => {
       restartOrphanSemantics: { status: "required" },
     });
     expect(ADAPTER_CAPABILITY_MATRIX.openclaw.expectations).toMatchObject({
+      nativeResume: { status: "required" },
+      cancellationDispatch: { status: "required" },
+      cancellationAck: { status: "known_limitation", followUpTicket: "TICKET-03-follow-up-cancel-ack" },
+      pinnedWorker: { status: "unsupported" },
+      modelSwitching: { status: "unsupported" },
+      artifactEmission: { status: "unsupported" },
+      toolSupport: { status: "unsupported" },
+      restartOrphanSemantics: { status: "required" },
+    });
+    expect(ADAPTER_CAPABILITY_MATRIX.codex.expectations).toMatchObject({
       nativeResume: { status: "required" },
       cancellationDispatch: { status: "required" },
       cancellationAck: { status: "known_limitation", followUpTicket: "TICKET-03-follow-up-cancel-ack" },

--- a/desktop/macos/changelog/unreleased/20260701-smart-agent-routing-codex.json
+++ b/desktop/macos/changelog/unreleased/20260701-smart-agent-routing-codex.json
@@ -1,0 +1,3 @@
+{
+  "change": "Smart agent routing on the floating bar and voice path now picks the best installed local agent (Codex, OpenClaw, Hermes), falls back when one is missing or fails to start, and shows install guidance when you explicitly ask for an agent that is not installed"
+}

--- a/desktop/macos/run.sh
+++ b/desktop/macos/run.sh
@@ -149,7 +149,10 @@ derive_omi_app_config "${OMI_APP_NAME:-Omi Dev}" || exit 1
 LOCAL_PROFILE=false
 [ "${OMI_DESKTOP_LOCAL_PROFILE:-0}" = "1" ] && LOCAL_PROFILE=true
 
-BUILD_DIR="build"
+# Allow overriding the build staging dir. Useful when the workspace lives in an
+# iCloud-synced folder (~/Documents/Desktop), where the file provider re-adds
+# com.apple.FinderInfo xattrs after `xattr -cr` and races `codesign`.
+BUILD_DIR="${BUILD_DIR:-build}"
 APP_BUNDLE="$BUILD_DIR/$APP_NAME.app"
 APP_PATH="/Applications/$APP_NAME.app"
 # Agent runtime source (staged into the app bundle at Resources/agent below).
@@ -752,6 +755,10 @@ if [ -n "$SIGN_IDENTITY" ]; then
         rm -f "$PROFILE_PATH"
         EFFECTIVE_ENTITLEMENTS="/tmp/omi-local-dev.entitlements"
     fi
+    # Per-component signing can re-add com.apple.provenance xattrs on newer macOS;
+    # strip them again before sealing the top-level bundle.
+    chmod -R u+w "$APP_BUNDLE"
+    xattr -cr "$APP_BUNDLE"
     substep "Signing app bundle"
     codesign --force --options runtime --entitlements "$EFFECTIVE_ENTITLEMENTS" --sign "$SIGN_IDENTITY" "$APP_BUNDLE"
 else

--- a/desktop/macos/scripts/sign-and-install-named-bundle.sh
+++ b/desktop/macos/scripts/sign-and-install-named-bundle.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+# Re-sign a named dev bundle after run.sh packaging. Use when the final
+# codesign step failed with "resource fork, Finder information, or similar
+# detritus not allowed" or the app crashes with Code Signature Invalid.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+APP_NAME="${OMI_APP_NAME:-omi-smart-routing}"
+# Respect run.sh's BUILD_DIR override so this works when the bundle was staged
+# outside the iCloud-synced workspace (e.g. BUILD_DIR=/tmp/... ./run.sh).
+BUILD_DIR="${BUILD_DIR:-$ROOT/build}"
+SRC_BUNDLE="$BUILD_DIR/${APP_NAME}.app"
+DEST_BUNDLE="/Applications/${APP_NAME}.app"
+SIGN_IDENTITY="${OMI_SIGN_IDENTITY:-$(security find-identity -v -p codesigning | grep "Apple Development" | head -1 | sed 's/.*"\(.*\)"/\1/')}"
+ENTITLEMENTS="/tmp/omi-local-dev.entitlements"
+CLEAN_BUNDLE="${TMPDIR:-/tmp}/omi-sign-${APP_NAME}.app"
+
+if [ ! -d "$SRC_BUNDLE" ]; then
+  echo "ERROR: Bundle not found: $SRC_BUNDLE"
+  echo "Run: OMI_APP_NAME=\"$APP_NAME\" ./run.sh --yolo"
+  exit 1
+fi
+
+if [ -z "$SIGN_IDENTITY" ]; then
+  echo "ERROR: No Apple Development signing identity found."
+  exit 1
+fi
+
+echo "Using identity: $SIGN_IDENTITY"
+cp "$ROOT/Desktop/Omi.entitlements" "$ENTITLEMENTS"
+/usr/libexec/PlistBuddy -c "Delete :com.apple.developer.applesignin" "$ENTITLEMENTS" 2>/dev/null || true
+
+rm -rf "$CLEAN_BUNDLE"
+ditto --norsrc "$SRC_BUNDLE" "$CLEAN_BUNDLE"
+chmod -R u+w "$CLEAN_BUNDLE"
+xattr -cr "$CLEAN_BUNDLE"
+
+sign_if_exists() {
+  local path="$1"
+  local entitlements="${2:-}"
+  if [ -e "$path" ]; then
+    echo "Signing $path"
+    if [ -n "$entitlements" ]; then
+      codesign --force --options runtime --entitlements "$entitlements" --sign "$SIGN_IDENTITY" "$path"
+    else
+      codesign --force --options runtime --sign "$SIGN_IDENTITY" "$path"
+    fi
+  fi
+}
+
+sign_if_exists "$CLEAN_BUNDLE/Contents/Frameworks/Sparkle.framework"
+sign_if_exists "$CLEAN_BUNDLE/Contents/Frameworks/Sentry.framework"
+sign_if_exists "$CLEAN_BUNDLE/Contents/Frameworks/onnxruntime.framework"
+sign_if_exists "$CLEAN_BUNDLE/Contents/Frameworks/libsharpyuv.0.dylib"
+sign_if_exists "$CLEAN_BUNDLE/Contents/Frameworks/libwebp.7.dylib"
+sign_if_exists "$CLEAN_BUNDLE/Contents/Resources/Omi Computer_Omi Computer.bundle/node" "$ROOT/Desktop/Node.entitlements"
+
+chmod -R u+w "$CLEAN_BUNDLE"
+xattr -cr "$CLEAN_BUNDLE"
+echo "Signing app bundle"
+codesign --force --options runtime --entitlements "$ENTITLEMENTS" --sign "$SIGN_IDENTITY" "$CLEAN_BUNDLE"
+
+codesign --verify --deep --strict "$CLEAN_BUNDLE"
+echo "Signature OK"
+
+rm -rf "$DEST_BUNDLE"
+ditto "$CLEAN_BUNDLE" "$DEST_BUNDLE"
+echo "Installed to $DEST_BUNDLE"
+open "$DEST_BUNDLE"


### PR DESCRIPTION
## Summary

Omi now uses the best **installed** local coding agent (Codex, OpenClaw, or Hermes) for a given task instead of always defaulting to Claude Code. It picks the best fit by task type, falls back automatically when the preferred one is missing or fails to start, and gives install guidance when you explicitly ask for an agent that isn't connected.

This works across all three spawn entry points: **push-to-talk voice**, the **typed floating bar**, and the in-app **`spawn_agent` chat tool**.

---

## Background / Problem

Previously every background agent spawned through Claude Code. Omi *could* connect to OpenClaw/Hermes but only when the user (or model) explicitly directed a provider, and:
- there was no "pick the best one" logic — if the requested provider was missing, it just bailed with a setup prompt;
- Codex wasn't wired as a first-class provider at all;
- a model-authored brief that *mentioned* a provider (e.g. "use Hermes to refactor…") would falsely trigger a setup prompt even though the user never said "Hermes";
- there was no runtime fallback if a provider failed to start.

---

## How routing works

The single entry point is `LocalAgentProviderRouting.resolveSpawn(brief:requestedProvider:userRequestText:title:)` (`AgentRuntimeRouting.swift`):

1. **Classify** the brief → `coding` / `automation` / `general` (keyword signals).
2. **Resolve an explicit provider from the *user's* transcript text** (`userRequestText`), not the model's brief — so a model naming a provider no longer triggers setup. `isExplicitProviderRequest` matches "codex", "hermes", and "openclaw"/"open claw".
3. **If the user explicitly named a provider:**
   - if installed → spawn it;
   - if missing → return `.setupRequired(provider, prompt, spokenStatus)` with install guidance (e.g. `npm install -g @openai/codex`).
4. **Otherwise** rank by `preferredProviders(for:)`:
   - coding → `[codex, hermes, openclaw]`
   - automation / general → `[openclaw, codex, hermes]`
   - filter to *installed* providers and spawn the first; if the model passed a `requestedProvider` that's missing, fall back to the first available with a spoken fallback note.
5. **Runtime fallback:** the `AgentSpawnContext` carries a fallback chain (available harnesses + the nil/Claude-Code default). On a retriable spawn failure (`enoent` / `adapter` / `activation`), `AgentPillsManager.maybeRetryWithFallback` re-spawns through the chain.

Provider availability (`LocalAgentProviderDetector`) checks the configured `OMI_*_ADAPTER_COMMAND` env first, then scans activation dirs including `~/.local/bin`, `~/.npm-global/bin`, `~/.volta/bin`, homebrew, and **nvm** `~/.nvm/versions/node/*/bin`.

---

## Codex adapter wiring

- `DirectedProvider.codex` added (displayName, harnessMode, executableName=`codex`, commandEnvironmentName=`OMI_CODEX_ADAPTER_COMMAND`).
- `AgentRuntimeProcess.envSetup` sets `OMI_CODEX_ADAPTER_COMMAND` via `codexAdapterCommand(codexPath:)`:
  ```
  CODEX_PATH='<detected codex binary>' npx -y @agentclientprotocol/codex-acp
  ```
- Node agent (`agent/src/index.ts`) registers the codex adapter (`ensureCodexAdapter`) and refuses to start when `defaultAdapterId=codex` but the adapter is unavailable — matching the Hermes/OpenClaw contract.
- Tool manifest (`omi-tool-manifest.ts`) adds `codex` to the `spawn_agent` provider enum + prompt guidance.

---

## Integration across all spawn paths

| Path | File | Change |
|---|---|---|
| Voice / PTT | `RealtimeHubController.swift` | `spawn_agent` tool calls `resolveSpawn`, speaks the plan ack, returns `Agent started.` or the fallback note |
| Typed floating bar (explicit directive) | `FloatingControlBarWindow.swift` | directive path calls `resolveSpawn` with the user transcript |
| Typed floating bar (auto-classify) | `FloatingControlBarWindow.swift` | Haiku-router agent route calls `resolveSpawn` |
| In-app chat tool | `ChatToolExecutor.swift` | `spawn_agent` supports `codex` + returns fallback note |
| System prompt | `RealtimeHubTools.swift` | tells the model to pass the best *installed* provider, never mention install for a provider the user didn't name, prefer codex for writing/debugging and openclaw for automation |
| Pill lifecycle | `AgentPill.swift` | `maybeRetryWithFallback` re-spawns through the fallback chain on retriable failures |

---

## Commits

1. **`feat(desktop): smart agent routing picks best local provider with fallback`** — routing core, codex adapter wiring, integration across voice/floating-bar/chat, system-prompt guidance, changelog.
2. **`test(desktop): cover smart agent routing and codex adapter`** — new `LocalAgentProviderRoutingTests` (8 cases) + updated `AgentRuntimeProcessTests`, `PiMonoWiringTests`, and node `adapter-selection`/`omi-tool-manifest`/`runtime-adapter` tests; refreshed stale source-grep contracts in `RealtimeHubSpawnAgentTests`/`AgentPillLifecycleTests`.
3. **`fix(desktop): make named-bundle signing robust against iCloud xattr race`** — `run.sh` `BUILD_DIR` override + pre-seal xattr strip; new `scripts/sign-and-install-named-bundle.sh` recovery tool.

---

## Testing

### Unit / focused
- `./scripts/agent-logic-harness.sh` — **passed** (all 4 stages: failure-propagation self-check, swift focused lifecycle/state, agent runtime focused, pi-mono-extension package).
- `cd desktop/macos/agent && npm test` — **285/285 passed**.
- New `LocalAgentProviderRoutingTests` — 8/8: task classification, explicit-by-name from user text vs model brief, setupRequired when named provider missing, fallback to next installed, spawn-context chain advancement, retriable-failure matching.

### End-to-end (live named bundle)
Built `OMI_APP_NAME=omi-smart-routing BUILD_DIR=/tmp/... ./run.sh --yolo` (signed into prod backend) and drove the typed floating-bar path — which shares the exact `resolveSpawn` routing the voice path uses. App logs confirm all three user requirements:

| Scenario | Log evidence | Result |
|---|---|---|
| "use codex to write a python script…" (Codex installed) | `Default harness mode: codex` → `Adapter registered id=codex` → `Starting codex ACP subprocess: CODEX_PATH='~/.local/bin/codex' npx -y @agentclientprotocol/codex-acp` | ✅ spawns Codex |
| "use hermes to review my swift code" (Hermes not installed) | `Saved floating-agent-provider-unavailable` (the `.setupRequired` path) | ✅ install guidance |
| "write and run a python script…" (no provider named) | `router decided route=agent` → auto path → reused Codex bridge | ✅ smart-picks best installed |

> The voice/PTT `spawn_agent` tool calls the same `resolveSpawn`; the Gemini Live session was connected during testing. Autonomous mic-driven PTT wasn't exercised, but the routing code is shared and verified.

---

## How to test locally

```bash
cd desktop/macos
# codex must be installed: npm install -g @openai/codex && codex  (to sign in)
BUILD_DIR=/tmp/omi-build OMI_APP_NAME="omi-smart-routing" ./run.sh --yolo
```
Then press PTT (or type in the floating bar) and try:
- "use codex to write a hello world python script" → spawns Codex
- "use hermes to fix a bug" → "I don't see Hermes installed…" install guidance
- "write a python script to parse logs" → auto-routes to the best installed provider (Codex on a codex-only machine)

> `BUILD_DIR=/tmp/...` avoids an iCloud xattr signing race when the workspace is in a synced `~/Documents` (see commit 3).

---

## Notes
- Provider preference table and detection dirs live in `AgentRuntimeRouting.swift`; update there when adding a new provider.
- The system prompt now explicitly tells the model **not** to volunteer install guidance for providers the user didn't name by name (prevents "you should install Hermes" spam).
- No backend changes — routing is entirely desktop-side. The agent VM / backend spawn flow is untouched.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8830?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

