### PR TITLE
[codex] Harden macOS integration surfaces

### DIFF
--- a/desktop/macos/Desktop/Sources/BrowserGoogleSession.swift
+++ b/desktop/macos/Desktop/Sources/BrowserGoogleSession.swift
@@ -114,8 +114,12 @@ struct BrowserGoogleSession: Equatable {
       }
       let userDataPath = target.profileRoot(homeDirectory: homeDirectory).path
       return cookiePaths(in: userDataPath).map { cookiePath in
-        let profileName = URL(fileURLWithPath: cookiePath).deletingLastPathComponent()
-          .lastPathComponent
+        let cookieURL = URL(fileURLWithPath: cookiePath)
+        let profileURL =
+          cookieURL.deletingLastPathComponent().lastPathComponent == "Network"
+          ? cookieURL.deletingLastPathComponent().deletingLastPathComponent()
+          : cookieURL.deletingLastPathComponent()
+        let profileName = profileURL.lastPathComponent
         let browserName = profileName == "Default" ? target.name : "\(target.name) (\(profileName))"
         return BrowserGoogleSession(
           browserName: browserName,
@@ -141,29 +145,37 @@ struct BrowserGoogleSession: Equatable {
     }
   }
 
-  private static func cookiePaths(in userDataPath: String) -> [String] {
+  static func cookiePaths(in userDataPath: String) -> [String] {
     let fm = FileManager.default
     guard let entries = try? fm.contentsOfDirectory(atPath: userDataPath) else { return [] }
 
     return
       entries
-      .filter { entry in
+      .compactMap { entry -> (name: String, path: String)? in
         var isDirectory: ObjCBool = false
-        let path = "\(userDataPath)/\(entry)"
-        guard fm.fileExists(atPath: path, isDirectory: &isDirectory), isDirectory.boolValue else {
-          return false
+        let profilePath = "\(userDataPath)/\(entry)"
+        guard fm.fileExists(atPath: profilePath, isDirectory: &isDirectory), isDirectory.boolValue else {
+          return nil
         }
-        return fm.fileExists(atPath: "\(path)/Cookies")
+        let networkCookies = "\(profilePath)/Network/Cookies"
+        if fm.fileExists(atPath: networkCookies) {
+          return (entry, networkCookies)
+        }
+        let legacyCookies = "\(profilePath)/Cookies"
+        if fm.fileExists(atPath: legacyCookies) {
+          return (entry, legacyCookies)
+        }
+        return nil
       }
       .sorted { lhs, rhs in
-        if lhs == "Default" { return true }
-        if rhs == "Default" { return false }
-        let lhsIsProfile = lhs.hasPrefix("Profile ")
-        let rhsIsProfile = rhs.hasPrefix("Profile ")
+        if lhs.name == "Default" { return true }
+        if rhs.name == "Default" { return false }
+        let lhsIsProfile = lhs.name.hasPrefix("Profile ")
+        let rhsIsProfile = rhs.name.hasPrefix("Profile ")
         if lhsIsProfile != rhsIsProfile { return lhsIsProfile }
-        return lhs.localizedStandardCompare(rhs) == .orderedAscending
+        return lhs.name.localizedStandardCompare(rhs.name) == .orderedAscending
       }
-      .map { "\(userDataPath)/\($0)/Cookies" }
+      .map(\.path)
       .filter { fm.fileExists(atPath: $0) }
   }
 

--- a/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
+++ b/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
@@ -474,16 +474,11 @@ final class DesktopAutomationActionRegistry {
         )
         switch status {
         case .connected(let noteCount, _):
-          let notes = try await AppleNotesReaderService.shared.readRecentNotes(
-            maxResults: 1,
-            selectedFolderPath: selectedFolderPath
-          )
           return [
             "ok": "true",
             "classification": "readable",
             "noteCount": "\(noteCount)",
-            "selectedFolderPath": selectedFolderPath ?? "",
-            "firstTitle": notes.first?.title ?? "",
+            "folderSelected": selectedFolderPath == nil ? "false" : "true",
           ]
         case .needsAccess(let message, let reasonCode):
           return [
@@ -1105,42 +1100,21 @@ final class DesktopAutomationBridge {
           statusCode: 500)
       }
     case ("POST", "/gmail-read"):
-      do {
-        let emails = try await GmailReaderService.shared.readRecentEmails(maxResults: 50)
-        let result = await GmailReaderService.shared.saveAsMemories(emails: emails)
-        struct GmailReadResult: Codable {
-          let emailCount: Int
-          let memoriesSaved: Int
-          let memoriesFailed: Int
-          let emails: [GmailEmailSummary]
-        }
-        struct GmailEmailSummary: Codable {
-          let from: String
-          let subject: String
-          let snippet: String
-          let date: String
-          let isUnread: Bool
-        }
-        let formatter = ISO8601DateFormatter()
-        let summaries = emails.prefix(50).map { e in
-          GmailEmailSummary(
-            from: e.from, subject: e.subject, snippet: e.snippet,
-            date: formatter.string(from: e.date), isUnread: e.isUnread)
-        }
-        let gmailResult = GmailReadResult(
-          emailCount: emails.count,
-          memoriesSaved: result.saved,
-          memoriesFailed: result.failed,
-          emails: summaries
-        )
-        return jsonResponse(DesktopAutomationResponse(ok: true, result: gmailResult, error: nil))
-      } catch {
-        struct ErrorResult: Codable { let message: String }
-        return jsonResponse(
-          DesktopAutomationResponse(ok: false, result: ErrorResult(message: error.localizedDescription), error: error.localizedDescription),
-          statusCode: 500
-        )
+      struct RemovedRoute: Codable {
+        let message: String
+        let replacement: String
       }
+      return jsonResponse(
+        DesktopAutomationResponse(
+          ok: false,
+          result: RemovedRoute(
+            message: "The legacy Gmail import route was removed because automation responses must not expose email contents or trigger memory writes.",
+            replacement: "Use POST /action with gmail_read_probe for privacy-safe Gmail status checks."
+          ),
+          error: "gmail_read_removed"
+        ),
+        statusCode: 410
+      )
     default:
       return jsonResponse(
         DesktopAutomationResponse<DesktopAutomationSnapshot>(

--- a/desktop/macos/Desktop/Sources/GmailReaderService.swift
+++ b/desktop/macos/Desktop/Sources/GmailReaderService.swift
@@ -149,15 +149,15 @@ actor GmailReaderService {
   {
     let emails: [GmailEmail]
     if let days = Self.parseNewerThanDays(query), days > 20 {
-      let bootstrapEmails = try fetchGmailViaAtomFeedSingle(
+      let queryEmails = try fetchGmailViaAtomFeedSingle(
         maxResults: maxResults,
         query: query,
         feedPath: nil,
-        allowBootstrap: true
+        allowBootstrap: false
       )
-      let labelEmails = try fetchGmailViaLabelFeeds(maxResults: maxResults)
+      let labelEmails = try fetchGmailViaLabelFeeds(maxResults: maxResults, query: query)
       var merged: [String: GmailEmail] = [:]
-      for email in bootstrapEmails + labelEmails {
+      for email in queryEmails + labelEmails {
         let existing = merged[email.id]
         if existing == nil || existing!.date < email.date {
           merged[email.id] = email
@@ -532,6 +532,9 @@ actor GmailReaderService {
           opener = build_opener(HTTPCookieProcessor(jar))
           if feed_path:
               url = f'https://mail.google.com/mail/feed/{feed_path.lstrip("/")}'
+              if query:
+                  separator = '&' if '?' in url else '?'
+                  url = f'{url}{separator}q={quote(query)}'
           else:
               url = f'https://mail.google.com/mail/feed/atom?q={quote(query)}'
           req = Request(url)
@@ -729,7 +732,7 @@ actor GmailReaderService {
     }
   }
 
-  private func fetchGmailViaLabelFeeds(maxResults: Int) throws -> [GmailEmail] {
+  private func fetchGmailViaLabelFeeds(maxResults: Int, query: String) throws -> [GmailEmail] {
     guard maxResults > 0 else { return [] }
 
     let feedPaths = [
@@ -752,7 +755,7 @@ actor GmailReaderService {
     for feedPath in feedPaths {
       let feedEmails = try fetchGmailViaAtomFeedSingle(
         maxResults: min(20, maxResults),
-        query: "newer_than:1d",
+        query: query,
         feedPath: feedPath,
         allowBootstrap: false
       )

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/AppsPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/AppsPage.swift
@@ -720,6 +720,15 @@ final class ImportConnectorStatusStore: ObservableObject {
         metricsByID[connectorID] = metrics
     }
 
+    private func clearStoredMetrics(for connectorID: String) {
+        defaults.removeObject(forKey: sourceCountKeyPrefix + connectorID)
+        defaults.removeObject(forKey: memoryCountKeyPrefix + connectorID)
+        defaults.removeObject(forKey: lastSyncedAtKeyPrefix + connectorID)
+        defaults.removeObject(forKey: lastDeltaCountKeyPrefix + connectorID)
+        defaults.removeObject(forKey: hasLastDeltaKeyPrefix + connectorID)
+        metricsByID[connectorID] = ConnectorMetrics()
+    }
+
     func refresh() async {
         await refreshLocalFilesMetrics()
         await refreshAppleNotesMetrics()
@@ -811,6 +820,7 @@ final class ImportConnectorStatusStore: ObservableObject {
             metricsByID["apple-notes"] = metrics
         case .needsAccess(_, let reasonCode), .error(_, let reasonCode):
             log("ImportConnectorStatusStore: Apple Notes refresh unavailable code=\(reasonCode)")
+            clearStoredMetrics(for: "apple-notes")
         }
     }
 

--- a/desktop/macos/Desktop/Sources/MemoryBankConnector.swift
+++ b/desktop/macos/Desktop/Sources/MemoryBankConnector.swift
@@ -37,7 +37,9 @@ enum MemoryBankConnector {
 
   static var homeOverrideForTesting: URL?
   static var openClawCLIPathOverrideForTesting: String?
+  static var processTimeoutSecondsForTesting: TimeInterval?
   private static var home: URL { homeOverrideForTesting ?? FileManager.default.homeDirectoryForCurrentUser }
+  private static var processTimeoutSeconds: TimeInterval { processTimeoutSecondsForTesting ?? 20 }
 
   // MARK: - OpenClaw (mcp.servers + workspace SOUL.md)
 
@@ -167,28 +169,24 @@ enum MemoryBankConnector {
     arguments: [String],
     environment: [String: String]
   ) throws -> CommandOutput {
-    let process = Process()
-    process.executableURL = URL(fileURLWithPath: executable)
-    process.arguments = arguments
-    var processEnvironment = ProcessInfo.processInfo.environment
-    for (key, value) in environment {
-      processEnvironment[key] = value
+    let result: PipeProcessResult
+    do {
+      result = try PipeProcessRunner.run(
+        executableURL: URL(fileURLWithPath: executable),
+        arguments: arguments,
+        environment: environment,
+        timeoutSeconds: processTimeoutSeconds
+      )
+    } catch {
+      throw ConnectError.invalidConfig(error.localizedDescription)
     }
-    process.environment = processEnvironment
 
-    let stdout = Pipe()
-    let stderr = Pipe()
-    process.standardOutput = stdout
-    process.standardError = stderr
-    try process.run()
-    process.waitUntilExit()
-
-    let output = String(data: stdout.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
-    let error = String(data: stderr.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
-    guard process.terminationStatus == 0 else {
+    let output = String(data: result.stdout, encoding: .utf8) ?? ""
+    let error = String(data: result.stderr, encoding: .utf8) ?? ""
+    guard result.terminationStatus == 0 else {
       let message = error.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
         ?? output.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
-        ?? "exit code \(process.terminationStatus)"
+        ?? "exit code \(result.terminationStatus)"
       throw ConnectError.invalidConfig(message)
     }
     return CommandOutput(stdout: output, stderr: error)

--- a/desktop/macos/Desktop/Sources/MemoryExportService.swift
+++ b/desktop/macos/Desktop/Sources/MemoryExportService.swift
@@ -270,17 +270,17 @@ enum MemoryExportDestination: String, CaseIterable, Identifiable, Sendable {
         openTitle: nil
       )
     case .openclaw:
+      let serverJSON =
+        #"{"enabled":true,"url":"\#(url)","transport":"sse","headers":{"Authorization":"Bearer \#(key)"}}"#
       return MCPSetup(
         serverURL: url,
-        copyTitle: "Copy memory bank",
+        copyTitle: "Copy command",
         copyText: """
-          ## OMI memory (search FIRST)
-          - MCP: \(url)  (Authorization: Bearer \(key))
-          Before any task, search Omi memory for context; save durable new facts.
+          openclaw mcp set omi-memory \(Self.shellQuote(serverJSON))
           """,
         steps: [
-          "Paste the block below into your OpenClaw MEMORY.md (additive — don't replace it)",
-          "OpenClaw will search Omi memory first on every task",
+          "Run the command below to add the Omi MCP server to ~/.openclaw/openclaw.json",
+          "Add a SOUL.md note asking OpenClaw to search Omi memory first",
         ],
         openURL: nil,
         openTitle: nil
@@ -288,6 +288,10 @@ enum MemoryExportDestination: String, CaseIterable, Identifiable, Sendable {
     case .notion, .obsidian, .gemini, .agents:
       return nil
     }
+  }
+
+  private static func shellQuote(_ value: String) -> String {
+    "'\(value.replacingOccurrences(of: "'", with: "'\\''"))'"
   }
 
   /// Title + body for an Omi task that asks Omi to perform this connection

--- a/desktop/macos/Desktop/Sources/PipeProcessRunner.swift
+++ b/desktop/macos/Desktop/Sources/PipeProcessRunner.swift
@@ -31,6 +31,7 @@ enum PipeProcessRunner {
   static func run(
     executableURL: URL,
     arguments: [String],
+    environment: [String: String] = [:],
     stdinData: Data? = nil,
     timeoutSeconds: TimeInterval,
     killGraceSeconds: TimeInterval = 2
@@ -38,6 +39,13 @@ enum PipeProcessRunner {
     let process = Process()
     process.executableURL = executableURL
     process.arguments = arguments
+    if !environment.isEmpty {
+      var processEnvironment = ProcessInfo.processInfo.environment
+      for (key, value) in environment {
+        processEnvironment[key] = value
+      }
+      process.environment = processEnvironment
+    }
 
     let stdoutPipe = Pipe()
     let stderrPipe = Pipe()

--- a/desktop/macos/Desktop/Tests/BrowserGoogleSessionTests.swift
+++ b/desktop/macos/Desktop/Tests/BrowserGoogleSessionTests.swift
@@ -1,0 +1,40 @@
+import XCTest
+
+@testable import Omi_Computer
+
+final class BrowserGoogleSessionTests: XCTestCase {
+  private var tempRoot: URL!
+
+  override func setUpWithError() throws {
+    try super.setUpWithError()
+    tempRoot = FileManager.default.temporaryDirectory
+      .appendingPathComponent("browser-google-session-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
+  }
+
+  override func tearDownWithError() throws {
+    if let tempRoot {
+      try? FileManager.default.removeItem(at: tempRoot)
+    }
+    try super.tearDownWithError()
+  }
+
+  func testCookiePathsPreferChromiumNetworkCookieStore() throws {
+    let defaultProfile = tempRoot.appendingPathComponent("Default", isDirectory: true)
+    let networkDir = defaultProfile.appendingPathComponent("Network", isDirectory: true)
+    try FileManager.default.createDirectory(at: networkDir, withIntermediateDirectories: true)
+    try Data().write(to: defaultProfile.appendingPathComponent("Cookies"))
+    try Data().write(to: networkDir.appendingPathComponent("Cookies"))
+
+    let profile2 = tempRoot.appendingPathComponent("Profile 2", isDirectory: true)
+    try FileManager.default.createDirectory(at: profile2, withIntermediateDirectories: true)
+    try Data().write(to: profile2.appendingPathComponent("Cookies"))
+
+    XCTAssertEqual(
+      BrowserGoogleSession.cookiePaths(in: tempRoot.path),
+      [
+        networkDir.appendingPathComponent("Cookies").path,
+        profile2.appendingPathComponent("Cookies").path,
+      ])
+  }
+}

--- a/desktop/macos/Desktop/Tests/MemoryBankConnectorTests.swift
+++ b/desktop/macos/Desktop/Tests/MemoryBankConnectorTests.swift
@@ -12,11 +12,13 @@ final class MemoryBankConnectorTests: XCTestCase {
     try FileManager.default.createDirectory(at: tempHome, withIntermediateDirectories: true)
     MemoryBankConnector.homeOverrideForTesting = tempHome
     MemoryBankConnector.openClawCLIPathOverrideForTesting = try writeFakeOpenClawCLI().path
+    MemoryBankConnector.processTimeoutSecondsForTesting = 2
   }
 
   override func tearDownWithError() throws {
     MemoryBankConnector.homeOverrideForTesting = nil
     MemoryBankConnector.openClawCLIPathOverrideForTesting = nil
+    MemoryBankConnector.processTimeoutSecondsForTesting = nil
     if let tempHome {
       try? FileManager.default.removeItem(at: tempHome)
     }
@@ -89,6 +91,21 @@ final class MemoryBankConnectorTests: XCTestCase {
     let configContent = try String(contentsOf: config, encoding: .utf8)
     XCTAssertTrue(configContent.contains(#""mcp":[]"#))
     XCTAssertFalse(configContent.contains("omi-memory"))
+  }
+
+  func testOpenClawConnectTimesOutHungCLI() throws {
+    let workspace = tempHome.appendingPathComponent(".openclaw/workspace", isDirectory: true)
+    try FileManager.default.createDirectory(at: workspace, withIntermediateDirectories: true)
+    _ = try writeOpenClawConfig(workspace: workspace)
+    let cli = tempHome.appendingPathComponent("hung-openclaw")
+    try "#!/bin/sh\nsleep 5\n".write(to: cli, atomically: true, encoding: .utf8)
+    try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: cli.path)
+    MemoryBankConnector.openClawCLIPathOverrideForTesting = cli.path
+    MemoryBankConnector.processTimeoutSecondsForTesting = 0.2
+
+    XCTAssertThrowsError(try MemoryBankConnector.connect(.openclaw, key: "test-key")) { error in
+      XCTAssertTrue(error.localizedDescription.contains("timed out"), error.localizedDescription)
+    }
   }
 
   func testHermesConnectRequiresRealInstallEvidence() throws {

--- a/desktop/macos/Desktop/Tests/MemoryExportSetupTests.swift
+++ b/desktop/macos/Desktop/Tests/MemoryExportSetupTests.swift
@@ -1,0 +1,22 @@
+import XCTest
+
+@testable import Omi_Computer
+
+final class MemoryExportSetupTests: XCTestCase {
+  func testOpenClawManualSetupUsesMCPConfigNotMemoryPromptSecret() throws {
+    let setup = try XCTUnwrap(MemoryExportDestination.openclaw.mcpSetup(key: "test-key"))
+    let copyText = try XCTUnwrap(setup.copyText)
+
+    XCTAssertEqual(setup.copyTitle, "Copy command")
+    XCTAssertTrue(copyText.contains("openclaw mcp set omi-memory"))
+    XCTAssertTrue(copyText.contains("\"Authorization\":\"Bearer test-key\""))
+    XCTAssertFalse(copyText.contains("SOUL.md"))
+    XCTAssertFalse(copyText.contains("MEMORY.md"))
+    XCTAssertFalse(copyText.contains("MCP: https://"))
+    XCTAssertFalse(copyText.contains("\nAdd this note"))
+    XCTAssertFalse(copyText.contains("\n# Then add this note"))
+    XCTAssertEqual(copyText.split(separator: "\n").count, 1)
+    XCTAssertFalse(setup.steps.joined(separator: " ").contains("MEMORY.md"))
+    XCTAssertTrue(setup.steps.joined(separator: " ").contains("SOUL.md"))
+  }
+}

--- a/desktop/macos/Desktop/Tests/PipeProcessRunnerTests.swift
+++ b/desktop/macos/Desktop/Tests/PipeProcessRunnerTests.swift
@@ -61,4 +61,16 @@ final class PipeProcessRunnerTests: XCTestCase {
     XCTAssertEqual(result.terminationStatus, 0)
     XCTAssertEqual(String(data: result.stdout, encoding: .utf8), "BROWSER CONFIG")
   }
+
+  func testPassesEnvironmentOverrides() throws {
+    let result = try PipeProcessRunner.run(
+      executableURL: URL(fileURLWithPath: "/bin/sh"),
+      arguments: ["-c", "printf %s \"$OMI_PIPE_PROCESS_TEST\""],
+      environment: ["OMI_PIPE_PROCESS_TEST": "custom-env"],
+      timeoutSeconds: 5
+    )
+
+    XCTAssertEqual(result.terminationStatus, 0)
+    XCTAssertEqual(String(data: result.stdout, encoding: .utf8), "custom-env")
+  }
 }

--- a/desktop/macos/changelog/unreleased/20260702-integration-surface-followups.json
+++ b/desktop/macos/changelog/unreleased/20260702-integration-surface-followups.json
@@ -1,0 +1,3 @@
+{
+  "change": "Hardened macOS connector probes, browser cookie discovery, Gmail imports, and OpenClaw memory setup against stale status, privacy leaks, and hung helper processes"
+}


### PR DESCRIPTION
## Summary

- Fix Chromium-family Google session discovery to prefer `Network/Cookies` while falling back to legacy `Cookies` paths.
- Make Gmail long-range imports use query-specific Atom feeds instead of accepting an unfiltered bootstrap snapshot.
- Privacy-minimize local automation surfaces: Apple Notes probe returns status/count only, and legacy `/gmail-read` now returns an explicit 410 removal response instead of exposing email content or silently importing nothing.
- Harden OpenClaw setup by routing CLI calls through the timeout/pipe-draining process runner and replacing stale manual `MEMORY.md` bearer-token guidance with a command-only MCP setup snippet.
- Clear stale Apple Notes connector metrics when the live readability probe reports access/store failure.

## Root cause

Recent connector hardening fixed several specific integration bugs, but adjacent surfaces still had mismatched assumptions: newer Chromium cookie DB locations, Gmail bootstrap behavior bypassing search queries, legacy automation routes returning private content, OpenClaw subprocesses using blocking waits, and stored connector counts being treated as live Apple Notes availability.

## Verification

- Oracle review of recent merged macOS integration PRs with a split zip of tracked `desktop/macos` source.
- Fixed six first-pass P2 findings, then ran oracle follow-up reviews until the final response was `No findings`.
- `xcrun swift test --package-path desktop/macos/Desktop --filter BrowserGoogleSessionTests`
- `xcrun swift test --package-path desktop/macos/Desktop --filter PipeProcessRunnerTests`
- `xcrun swift test --package-path desktop/macos/Desktop --filter MemoryBankConnectorTests`
- `xcrun swift test --package-path desktop/macos/Desktop --filter MemoryExportSetupTests`
- `xcrun swift test --package-path desktop/macos/Desktop --filter GmailOutcomeParserTests`
- `python3 .github/scripts/desktop-changelog.py validate`
- `git diff --check`
- `xcrun swift build -c debug --package-path desktop/macos/Desktop`

## Notes

Attempted a named-bundle launch with `OMI_APP_NAME=omi-integration-followups ./run.sh --yolo`; build/install reached signing, then `run.sh` correctly refused to continue because this machine has no Apple Development/Developer ID signing identity. I did not bypass the repo safety guard against ad-hoc signing.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8831?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

