### PR TITLE
Add desktop update policy banner

### DIFF
--- a/backend/database/desktop_update_policy.py
+++ b/backend/database/desktop_update_policy.py
@@ -1,0 +1,109 @@
+from typing import Any, Optional
+
+from database._client import get_firestore_client
+
+DEFAULT_DESKTOP_DOWNLOAD_URL = "https://api.omi.me/v2/desktop/download/latest?channel=stable"
+VALID_DESKTOP_UPDATE_SEVERITIES = {"none", "banner", "required"}
+
+
+def _as_int(value: Any) -> Optional[int]:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        try:
+            return int(value)
+        except ValueError:
+            return None
+    return None
+
+
+def _as_bool(value: Any, default: bool = False) -> bool:
+    if isinstance(value, bool):
+        return value
+    return default
+
+
+def _as_string(value: Any) -> Optional[str]:
+    if isinstance(value, str):
+        trimmed = value.strip()
+        return trimmed or None
+    return None
+
+
+def _as_string_list(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [item.strip() for item in value if isinstance(item, str) and item.strip()]
+
+
+def _default_policy() -> dict[str, Any]:
+    return {
+        "id": "current",
+        "active": False,
+        "severity": "none",
+        "maximum_build_number": None,
+        "latest_build_number": None,
+        "title": None,
+        "message": None,
+        "cta_text": "Download latest",
+        "download_url": DEFAULT_DESKTOP_DOWNLOAD_URL,
+        "can_dismiss": True,
+    }
+
+
+def _normalize_policy(data: dict[str, Any]) -> dict[str, Any]:
+    policy = _default_policy()
+
+    severity = _as_string(data.get("severity")) or "none"
+    if severity not in VALID_DESKTOP_UPDATE_SEVERITIES:
+        severity = "none"
+    maximum_build_number = _as_int(data.get("maximum_build_number"))
+    if maximum_build_number is None:
+        maximum_build_number = _as_int(data.get("minimum_build_number"))
+
+    policy.update(
+        {
+            "id": _as_string(data.get("id")) or policy["id"],
+            "active": _as_bool(data.get("active")),
+            "severity": severity,
+            "maximum_build_number": maximum_build_number,
+            "latest_build_number": _as_int(data.get("latest_build_number")),
+            "title": _as_string(data.get("title")),
+            "message": _as_string(data.get("message")),
+            "cta_text": _as_string(data.get("cta_text")) or policy["cta_text"],
+            "download_url": _as_string(data.get("download_url")) or policy["download_url"],
+            "can_dismiss": _as_bool(data.get("can_dismiss"), default=True),
+            "platforms": _as_string_list(data.get("platforms")),
+        }
+    )
+    return policy
+
+
+def _applies_to_platform(policy: dict[str, Any], platform: str) -> bool:
+    platforms = policy.get("platforms") or []
+    return not platforms or platform in platforms
+
+
+def get_desktop_update_policy(
+    current_build: Optional[int], platform: str = "macos", *, firestore_client: Any = None
+) -> dict[str, Any]:
+    client = firestore_client if firestore_client is not None else get_firestore_client()
+    doc = client.collection("desktop_update_policy").document("current").get()
+    if not getattr(doc, "exists", False):
+        return _default_policy()
+
+    raw = doc.to_dict() or {}
+    policy = _normalize_policy(raw)
+    if not _applies_to_platform(policy, platform):
+        return _default_policy()
+
+    maximum_build = policy.get("maximum_build_number")
+    if current_build is not None and maximum_build is not None and current_build > maximum_build:
+        return _default_policy()
+
+    if not policy["active"]:
+        return _default_policy()
+
+    return policy

--- a/backend/routers/updates.py
+++ b/backend/routers/updates.py
@@ -6,6 +6,7 @@ from xml.sax.saxutils import escape as xml_escape
 from fastapi import APIRouter, HTTPException, Header, Query
 from fastapi.responses import RedirectResponse, Response, HTMLResponse
 
+from database.desktop_update_policy import get_desktop_update_policy
 from database.redis_db import delete_generic_cache
 from utils.github_releases import get_omi_github_releases, extract_key_value_pairs
 
@@ -461,6 +462,21 @@ async def download_beta_desktop_release(
     Convenience endpoint for macos.omi.me/beta (URL map can't add query params).
     """
     return await download_latest_desktop_release(platform=platform, channel="beta")
+
+
+@router.get("/v2/desktop/update-policy")
+def get_desktop_update_policy_endpoint(
+    platform: str = Query(default="macos", pattern="^(macos|windows|linux)$"),
+    current_build: Optional[int] = Query(default=None, ge=0),
+):
+    """
+    Server-controlled desktop update banner policy.
+
+    Defaults to inactive when the Firestore document is missing. Configure
+    ``desktop_update_policy/current`` to show a dismissible banner or a required
+    manual-update prompt to future desktop clients.
+    """
+    return get_desktop_update_policy(current_build=current_build, platform=platform)
 
 
 @router.post("/v2/desktop/clear-cache")

--- a/backend/tests/unit/test_desktop_updates.py
+++ b/backend/tests/unit/test_desktop_updates.py
@@ -36,6 +36,7 @@ from routers.updates import (
     _xml_attr,
     router as updates_router,
 )
+from database.desktop_update_policy import get_desktop_update_policy
 
 # Minimal test app mounting only the updates router
 _test_app = FastAPI()
@@ -603,3 +604,101 @@ class TestClearCacheEndpoint:
         async with AsyncClient(transport=ASGITransport(app=_test_app), base_url="http://test") as client:
             resp = await client.post("/v2/desktop/clear-cache")
         assert resp.status_code == 422
+
+
+# --- Update policy endpoint ---
+
+
+class TestDesktopUpdatePolicyEndpoint:
+    @pytest.mark.asyncio
+    async def test_returns_policy_for_current_build(self):
+        policy = {
+            "id": "force-legacy-4xx",
+            "active": True,
+            "severity": "required",
+            "maximum_build_number": 11507,
+            "latest_build_number": 11590,
+            "title": "Update required",
+            "message": "Install the latest Omi desktop app.",
+            "cta_text": "Download latest",
+            "download_url": "https://example.com/Omi.dmg",
+            "can_dismiss": False,
+        }
+        with patch("routers.updates.get_desktop_update_policy", return_value=policy) as mock_policy:
+            async with AsyncClient(transport=ASGITransport(app=_test_app), base_url="http://test") as client:
+                resp = await client.get("/v2/desktop/update-policy?platform=macos&current_build=11400")
+
+        assert resp.status_code == 200
+        assert resp.json()["id"] == "force-legacy-4xx"
+        mock_policy.assert_called_once_with(current_build=11400, platform="macos")
+
+    @pytest.mark.asyncio
+    async def test_rejects_invalid_platform(self):
+        async with AsyncClient(transport=ASGITransport(app=_test_app), base_url="http://test") as client:
+            resp = await client.get("/v2/desktop/update-policy?platform=ios")
+        assert resp.status_code == 422
+
+
+class TestDesktopUpdatePolicyDatabase:
+    def _mock_doc(self, exists=True, data=None):
+        doc = MagicMock()
+        doc.exists = exists
+        doc.to_dict.return_value = data or {}
+        return doc
+
+    def test_missing_doc_returns_inactive_default(self):
+        doc = self._mock_doc(exists=False)
+        mock_db = MagicMock()
+        mock_db.collection.return_value.document.return_value.get.return_value = doc
+        policy = get_desktop_update_policy(current_build=11400, firestore_client=mock_db)
+
+        assert policy["active"] is False
+        assert policy["severity"] == "none"
+        assert policy["download_url"].endswith("/v2/desktop/download/latest?channel=stable")
+
+    def test_required_policy_applies_through_maximum_build(self):
+        doc = self._mock_doc(
+            data={
+                "id": "force-old-desktop",
+                "active": True,
+                "severity": "required",
+                "maximum_build_number": 11507,
+                "title": "Update required",
+                "can_dismiss": False,
+            }
+        )
+        mock_db = MagicMock()
+        mock_db.collection.return_value.document.return_value.get.return_value = doc
+        policy = get_desktop_update_policy(current_build=11507, firestore_client=mock_db)
+
+        assert policy["id"] == "force-old-desktop"
+        assert policy["active"] is True
+        assert policy["severity"] == "required"
+        assert policy["can_dismiss"] is False
+
+    def test_policy_suppressed_above_maximum_build(self):
+        doc = self._mock_doc(data={"active": True, "severity": "required", "maximum_build_number": 11507})
+        mock_db = MagicMock()
+        mock_db.collection.return_value.document.return_value.get.return_value = doc
+        policy = get_desktop_update_policy(current_build=11508, firestore_client=mock_db)
+
+        assert policy["active"] is False
+        assert policy["severity"] == "none"
+
+    def test_policy_accepts_legacy_minimum_build_alias(self):
+        doc = self._mock_doc(data={"active": True, "severity": "required", "minimum_build_number": 11507})
+        mock_db = MagicMock()
+        mock_db.collection.return_value.document.return_value.get.return_value = doc
+        policy = get_desktop_update_policy(current_build=11507, firestore_client=mock_db)
+
+        assert policy["active"] is True
+        assert policy["maximum_build_number"] == 11507
+        assert "minimum_build_number" not in policy
+
+    def test_policy_suppressed_for_other_platforms(self):
+        doc = self._mock_doc(data={"active": True, "severity": "banner", "platforms": ["windows"]})
+        mock_db = MagicMock()
+        mock_db.collection.return_value.document.return_value.get.return_value = doc
+        policy = get_desktop_update_policy(current_build=11400, platform="macos", firestore_client=mock_db)
+
+        assert policy["active"] is False

--- a/desktop/macos/Desktop/Sources/APIClient.swift
+++ b/desktop/macos/Desktop/Sources/APIClient.swift
@@ -84,6 +84,8 @@ actor APIClient {
     var headers: [String: String] = [
       "Content-Type": "application/json",
       "X-App-Platform": "macos",
+      "X-App-Version": Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "unknown",
+      "X-App-Build": Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "unknown",
       "X-Device-Id-Hash": ClientDeviceService.shared.deviceIdHash,
       "X-Request-Start-Time": String(Date().timeIntervalSince1970),
       "X-Desktop-Request-ID": UUID().uuidString,
@@ -126,13 +128,14 @@ actor APIClient {
   func get<T: Decodable>(
     _ endpoint: String,
     requireAuth: Bool = true,
-    customBaseURL: String? = nil
+    customBaseURL: String? = nil,
+    includeBYOK: Bool = true
   ) async throws -> T {
     let base = customBaseURL ?? baseURL
     let url = URL(string: base + endpoint)!
     var request = URLRequest(url: url)
     request.httpMethod = "GET"
-    request.allHTTPHeaderFields = try await buildHeaders(requireAuth: requireAuth)
+    request.allHTTPHeaderFields = try await buildHeaders(requireAuth: requireAuth, includeBYOK: includeBYOK)
 
     return try await performRequest(request)
   }
@@ -4117,6 +4120,15 @@ extension APIClient {
     return try await patch("v1/users/assistant-settings", body: settings)
   }
 
+  /// Fetches server-controlled desktop update/banner policy.
+  func getDesktopUpdatePolicy(currentBuild: Int?) async throws -> DesktopUpdatePolicyResponse {
+    var endpoint = "v2/desktop/update-policy?platform=macos"
+    if let currentBuild {
+      endpoint += "&current_build=\(currentBuild)"
+    }
+    return try await get(endpoint, requireAuth: false, includeBYOK: false)
+  }
+
   // MARK: - Knowledge Graph API
 
   /// Get the full knowledge graph (nodes and edges)
@@ -4595,6 +4607,40 @@ struct UserProfileResponse: Codable {
     useCase = try container.decodeIfPresent(String.self, forKey: .useCase)
     job = try container.decodeIfPresent(String.self, forKey: .job)
     company = try container.decodeIfPresent(String.self, forKey: .company)
+  }
+}
+
+// MARK: - Desktop Update Policy Models
+
+struct DesktopUpdatePolicyResponse: Codable, Equatable {
+  enum Severity: String, Codable {
+    case none
+    case banner
+    case required
+  }
+
+  let id: String
+  let active: Bool
+  let severity: Severity
+  let maximumBuildNumber: Int?
+  let latestBuildNumber: Int?
+  let title: String?
+  let message: String?
+  let ctaText: String
+  let downloadURL: String
+  let canDismiss: Bool
+
+  enum CodingKeys: String, CodingKey {
+    case id, active, severity, title, message
+    case maximumBuildNumber = "maximum_build_number"
+    case latestBuildNumber = "latest_build_number"
+    case ctaText = "cta_text"
+    case downloadURL = "download_url"
+    case canDismiss = "can_dismiss"
+  }
+
+  var isRequired: Bool {
+    active && severity == .required
   }
 }
 

--- a/desktop/macos/Desktop/Sources/DesktopUpdatePolicyManager.swift
+++ b/desktop/macos/Desktop/Sources/DesktopUpdatePolicyManager.swift
@@ -1,0 +1,177 @@
+import AppKit
+import Foundation
+import SwiftUI
+
+@MainActor
+final class DesktopUpdatePolicyManager: ObservableObject {
+  static let shared = DesktopUpdatePolicyManager()
+
+  @Published private(set) var policy: DesktopUpdatePolicyResponse?
+
+  private var lastCheckAt = Date.distantPast
+  private let minimumCheckInterval: TimeInterval = 5 * 60
+  private let dismissedPrefix = "desktopUpdatePolicyDismissed."
+
+  private init() {}
+
+  var visiblePolicy: DesktopUpdatePolicyResponse? {
+    guard let policy, policy.active, policy.severity != .none else { return nil }
+    if policy.isRequired { return policy }
+    return isDismissed(policy) ? nil : policy
+  }
+
+  func refresh(force: Bool = false) {
+    let now = Date()
+    guard force || now.timeIntervalSince(lastCheckAt) >= minimumCheckInterval else { return }
+    lastCheckAt = now
+
+    Task {
+      do {
+        let fetched = try await APIClient.shared.getDesktopUpdatePolicy(currentBuild: currentBuildNumber)
+        await MainActor.run {
+          self.policy = fetched.active ? fetched : nil
+        }
+      } catch {
+        log("DesktopUpdatePolicy: failed to fetch policy: \(error.localizedDescription)")
+      }
+    }
+  }
+
+  func dismiss(_ policy: DesktopUpdatePolicyResponse) {
+    guard policy.canDismiss, !policy.isRequired else { return }
+    UserDefaults.standard.set(true, forKey: dismissedKey(for: policy))
+    if self.policy?.id == policy.id {
+      self.policy = nil
+    }
+  }
+
+  func openDownload(_ policy: DesktopUpdatePolicyResponse) {
+    guard let url = URL(string: policy.downloadURL),
+      let scheme = url.scheme?.lowercased(),
+      ["http", "https"].contains(scheme)
+    else {
+      log("DesktopUpdatePolicy: ignored invalid download URL")
+      return
+    }
+    NSWorkspace.shared.open(url)
+  }
+
+  private var currentBuildNumber: Int? {
+    guard let raw = Bundle.main.infoDictionary?["CFBundleVersion"] as? String else { return nil }
+    return Int(raw)
+  }
+
+  private func isDismissed(_ policy: DesktopUpdatePolicyResponse) -> Bool {
+    UserDefaults.standard.bool(forKey: dismissedKey(for: policy))
+  }
+
+  private func dismissedKey(for policy: DesktopUpdatePolicyResponse) -> String {
+    dismissedPrefix + policy.id
+  }
+}
+
+struct DesktopUpdatePolicyBanner: View {
+  let policy: DesktopUpdatePolicyResponse
+  let onDownload: () -> Void
+  let onDismiss: () -> Void
+
+  var body: some View {
+    HStack(alignment: .center, spacing: 12) {
+      Image(systemName: "arrow.down.circle.fill")
+        .scaledFont(size: 16)
+        .foregroundColor(.white)
+        .frame(width: 22)
+
+      VStack(alignment: .leading, spacing: 3) {
+        Text(policy.title ?? "Update Omi")
+          .scaledFont(size: 13, weight: .semibold)
+          .foregroundColor(.white)
+          .lineLimit(1)
+        if let message = policy.message {
+          Text(message)
+            .scaledFont(size: 12)
+            .foregroundColor(.white.opacity(0.82))
+            .lineLimit(2)
+            .truncationMode(.tail)
+            .fixedSize(horizontal: false, vertical: true)
+        }
+      }
+      .frame(maxWidth: 400, alignment: .leading)
+      .layoutPriority(1)
+
+      Button(policy.ctaText) {
+        onDownload()
+      }
+      .buttonStyle(.plain)
+      .scaledFont(size: 12, weight: .semibold)
+      .foregroundColor(Color(red: 0.08, green: 0.09, blue: 0.10))
+      .padding(.horizontal, 14)
+      .frame(height: 32)
+      .background(Color.white.opacity(0.94))
+      .clipShape(RoundedRectangle(cornerRadius: 7))
+      .fixedSize(horizontal: true, vertical: false)
+      .layoutPriority(2)
+
+      if policy.canDismiss {
+        Button {
+          onDismiss()
+        } label: {
+          Image(systemName: "xmark")
+            .scaledFont(size: 11, weight: .semibold)
+        }
+        .buttonStyle(.plain)
+        .foregroundColor(.white.opacity(0.72))
+        .frame(width: 24, height: 24)
+        .help("Dismiss")
+      }
+    }
+    .padding(.horizontal, 14)
+    .padding(.vertical, 12)
+    .background(Color(red: 0.10, green: 0.12, blue: 0.14).opacity(0.98))
+    .overlay(
+      RoundedRectangle(cornerRadius: 8)
+        .stroke(Color.white.opacity(0.12), lineWidth: 1)
+    )
+    .clipShape(RoundedRectangle(cornerRadius: 8))
+    .shadow(color: Color.black.opacity(0.28), radius: 18, x: 0, y: 8)
+  }
+}
+
+struct DesktopRequiredUpdatePrompt: View {
+  let policy: DesktopUpdatePolicyResponse
+  let onDownload: () -> Void
+
+  var body: some View {
+    VStack(spacing: 16) {
+      Image(systemName: "arrow.down.circle.fill")
+        .scaledFont(size: 30)
+        .foregroundColor(.white)
+
+      VStack(spacing: 8) {
+        Text(policy.title ?? "Update Required")
+          .scaledFont(size: 20, weight: .semibold)
+          .foregroundColor(.white)
+        Text(policy.message ?? "Please install the latest Omi desktop app to continue.")
+          .scaledFont(size: 13)
+          .foregroundColor(.white.opacity(0.72))
+          .multilineTextAlignment(.center)
+          .fixedSize(horizontal: false, vertical: true)
+      }
+
+      Button(policy.ctaText) {
+        onDownload()
+      }
+      .buttonStyle(.borderedProminent)
+      .controlSize(.large)
+    }
+    .frame(width: 420)
+    .padding(28)
+    .background(Color(red: 0.08, green: 0.09, blue: 0.10))
+    .overlay(
+      RoundedRectangle(cornerRadius: 10)
+        .stroke(Color.white.opacity(0.14), lineWidth: 1)
+    )
+    .clipShape(RoundedRectangle(cornerRadius: 10))
+    .shadow(color: Color.black.opacity(0.36), radius: 24, x: 0, y: 14)
+  }
+}

--- a/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
@@ -22,6 +22,7 @@ struct DesktopHomeView: View {
   @ObservedObject private var authState = AuthState.shared
   @ObservedObject private var apiKeyService = APIKeyService.shared
   @ObservedObject private var usageLimiter = FloatingBarUsageLimiter.shared
+  @ObservedObject private var updatePolicyManager = DesktopUpdatePolicyManager.shared
   @State private var selectedIndex: Int = {
     if OMIApp.launchMode == .rewind { return SidebarNavItem.rewind.rawValue }
     let tier = UserDefaults.standard.integer(forKey: "currentTierLevel")
@@ -139,12 +140,25 @@ struct DesktopHomeView: View {
                 )
               }
             }
+            .overlay(alignment: .top) {
+              if let policy = updatePolicyManager.visiblePolicy, !policy.isRequired {
+                DesktopUpdatePolicyBanner(
+                  policy: policy,
+                  onDownload: { updatePolicyManager.openDownload(policy) },
+                  onDismiss: { updatePolicyManager.dismiss(policy) }
+                )
+                .padding(.top, 12)
+                .padding(.horizontal, 20)
+                .transition(.move(edge: .top).combined(with: .opacity))
+              }
+            }
             .onReceive(NotificationCenter.default.publisher(for: .showUsageLimitPopup)) { notification in
               let reason = notification.userInfo?["reason"] as? String ?? ""
               appState.triggerUsageLimitPopup(reason: reason)
             }
             .onAppear {
               log("DesktopHomeView: Showing mainContent (signed in and onboarded)")
+              updatePolicyManager.refresh(force: true)
               // Check all permissions on launch
               appState.checkAllPermissions()
 
@@ -236,6 +250,7 @@ struct DesktopHomeView: View {
                 lastActivationRefresh = now
                 Task { await appState.refreshConversations() }
               }
+              updatePolicyManager.refresh()
               // Auto-start monitoring when returning to app if screen analysis is enabled
               // but monitoring is not running. Handles the case where the user granted
               // screen recording permission in System Settings and switched back.
@@ -364,6 +379,17 @@ struct DesktopHomeView: View {
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .background(OmiColors.backgroundPrimary)
             .transition(.opacity.animation(.easeOut(duration: 0.3)))
+          }
+
+          if let policy = updatePolicyManager.visiblePolicy, policy.isRequired {
+            Color.black.opacity(0.62)
+              .ignoresSafeArea()
+              .zIndex(20)
+            DesktopRequiredUpdatePrompt(
+              policy: policy,
+              onDownload: { updatePolicyManager.openDownload(policy) }
+            )
+            .zIndex(21)
           }
         }
       }

--- a/desktop/macos/changelog/unreleased/20260702-desktop-update-policy-banner.json
+++ b/desktop/macos/changelog/unreleased/20260702-desktop-update-policy-banner.json
@@ -1,0 +1,3 @@
+{
+  "change": "Prompt to update to the latest Omi when running an older desktop version"
+}

--- a/docs/runbooks/desktop-update-policy.md
+++ b/docs/runbooks/desktop-update-policy.md
@@ -1,0 +1,42 @@
+# Desktop Update Policy
+
+Use this when macOS desktop users need an extra update prompt beyond Sparkle.
+
+## Firestore Config
+
+Create or update `desktop_update_policy/current`:
+
+```json
+{
+  "active": true,
+  "severity": "required",
+  "maximum_build_number": 11507,
+  "latest_build_number": 11590,
+  "title": "Update required",
+  "message": "Your Omi desktop app has an older updater issue. Please install the latest version manually.",
+  "cta_text": "Download latest",
+  "download_url": "https://api.omi.me/v2/desktop/download/latest?channel=stable",
+  "can_dismiss": false,
+  "platforms": ["macos"]
+}
+```
+
+## Fields
+
+- `active`: `true` enables the policy.
+- `severity`: `banner` shows a dismissible top banner; `required` shows a blocking prompt; `none` disables it.
+- `maximum_build_number`: highest client build that should see the policy. Clients above this build do not see it.
+- `latest_build_number`: informational for clients and analytics.
+- `title`, `message`, `cta_text`: user-facing copy.
+- `download_url`: manual installer URL.
+- `can_dismiss`: only applies to `banner`; required prompts cannot be dismissed.
+- `platforms`: optional allowlist. Omit or use `["macos"]` for macOS.
+
+## Verification
+
+```bash
+curl 'https://api.omi.me/v2/desktop/update-policy?platform=macos&current_build=11400'
+curl 'https://api.omi.me/v2/desktop/appcast.xml?platform=macos' | grep criticalUpdate
+```
+
+Disable the policy by setting `active` to `false`.


### PR DESCRIPTION
## Summary
- Add a server-controlled desktop update policy endpoint backed by Firestore so we can show future macOS update banners or required-update prompts.
- Add a macOS client policy manager with dismissible banner support, blocking required-update prompt support, and app version/build request headers.
- Add a desktop update policy runbook and backend tests.
- Marked the latest stable macOS GitHub release as mandatory so the live stable appcast emits a Sparkle critical update for the current stable build.

## Review Fixes
- Use `get_firestore_client()` inside the update-policy helper with a keyword-only `firestore_client` override for tests.
- Disable BYOK headers on the unauthenticated update-policy GET request.
- Restrict update CTA URLs to `http`/`https` before opening them.
- Rename the operator-facing build ceiling to `maximum_build_number`; the backend still accepts the old `minimum_build_number` alias for compatibility.
- Rewrite the changelog fragment from the user's perspective.

## Current Recovery Notes
- Stable `v0.11.507+11507-macos` now has `mandatory: true` in release metadata, and the live stable appcast includes `<sparkle:criticalUpdate />` for `0.11.507+11507`.
- Sampled old 4xx macOS tags (`v0.11.400+11400-macos`, `v0.11.450+11450-macos`, `v0.11.480+11480-macos`, `v0.11.507+11507-macos`) include `CrispManager`, backend `/v1/crisp/unread`, and `DesktopHomeView` startup of Crisp, so Crisp support-message prompts should be available for signed-in/running clients.
- This PR does not send the Crisp message itself; that still needs to be sent via Crisp/support ops if we want the extra manual-install prompt for affected users.

## Tests
- `cd backend && uv run --with pytest --with pytest-asyncio --with httpx --with fastapi pytest tests/unit/test_desktop_updates.py tests/unit/test_announcement_malformed_type.py`
- `cd backend && uv run python -m py_compile database/desktop_update_policy.py routers/updates.py`
- `git diff --check HEAD`
- Pre-push hook passed, including selected backend update tests and OpenAPI contract check.

## Local Desktop Build Note
- Attempted `cd desktop/macos && xcrun swift build -c debug --package-path Desktop`, but this local toolchain is blocked by existing `#Preview` macro / `PreviewsMacros.SwiftUIView` plugin errors across unrelated desktop files before a full desktop build can complete.
