### PR TITLE
fix(desktop): reject non-system-linked local node in agent runtime staging (#8835)

### DIFF
--- a/desktop/macos/scripts/prepare-agent-runtime.sh
+++ b/desktop/macos/scripts/prepare-agent-runtime.sh
@@ -136,6 +136,22 @@ stage_local_node() {
     stage_universal_node
     return
   fi
+
+  # A local node can pass --version here yet still link non-system dylibs (e.g.
+  # Homebrew's /opt/homebrew/opt/libuv/lib/libuv.1.dylib), which load fine on the
+  # dev machine but are rejected by hardened-runtime library validation once the
+  # app is signed (different Team ID) — killing every bundled AgentRuntimeProcess
+  # task with processExited. Only official builds link solely system libraries, so
+  # reject any staged node with non-system dependencies and fall back to universal.
+  local nonsystem_libs
+  nonsystem_libs="$(otool -L "$NODE_RESOURCE" 2>/dev/null | tail -n +2 | awk '{print $1}' | grep -Ev '^(/usr/lib/|/System/)' || true)"
+  if [ -n "$nonsystem_libs" ]; then
+    log "Local Node at $node_bin links non-system libraries (rejected by hardened-runtime library validation once signed): $(echo "$nonsystem_libs" | tr '\n' ' ')"
+    log "Falling back to self-contained official Node $NODE_VERSION download"
+    rm -f "$NODE_RESOURCE"
+    stage_universal_node
+    return
+  fi
   log "Staged local Node $staged_version from $node_bin"
 }
 


### PR DESCRIPTION
## Bug (#8835)

On macOS desktop, the Gmail reader's **synthesis** step and other features that spawn the bundled Node agent runtime (`AgentRuntimeProcess`) fail with `processExited`. Gmail auth/fetch/memory-save succeed — the failure is downstream: the bundled `node` cannot launch because it is dynamically linked to a Homebrew copy of `libuv` (`/opt/homebrew/opt/libuv/lib/libuv.1.dylib`) that macOS **library validation rejects** under hardened runtime (different Team ID → code signature not valid). `node` exits with code 6 and every agent-runtime task (Gmail synthesis, onboarding Claude import, iMessage autoreply) reports `processExited`.

## Root cause

`prepare-agent-runtime.sh` → `stage_local_node` copies the developer's `node` into the app resources. It only falls back to the official self-contained build when the copied binary **cannot run at all** (`--version` fails, e.g. the `@rpath/libnode.dylib` Homebrew stub). But a Homebrew node that links `libuv` (and friends) via an **absolute `/opt/homebrew` path** runs fine on the dev machine (the dylibs are present) — so `--version` passes and the broken binary gets bundled. Once the app is signed, hardened-runtime library validation rejects the differently-signed Homebrew dylib and `node` never starts.

Release builds use `--universal-node` (checksum-verified official download, system-linked) and are unaffected — this is a **dev/named-bundle** correctness bug.

## Fix

After the existing `--version` self-contained check, run `otool -L` on the staged node: if it links **any** dylib outside `/usr/lib` or `/System`, it is not portable under hardened runtime → remove it and fall back to `stage_universal_node` (official darwin builds link only system libraries). Mirrors the existing self-contained fallback pattern; 16-line addition, no behavior change for a genuinely self-contained local node.

## Verification

Verified the detection pipeline directly against real binaries:
- system-only binary (`/bin/ls`) → no non-system libs → accepted (unchanged path)
- local Homebrew `node` (the exact failure signature from the issue: `/opt/homebrew/opt/libuv/lib/libuv.1.dylib`) → non-system libs detected → falls back to universal

Not exercised end-to-end (full bundle build downloads Node + runs `npm ci`); the change is a shell fallback mirroring existing verified logic.

🤖 automated by hourly watchdog; opened for review, not merged (dev-only bug, not live on prod).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8839?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

