### PR TITLE
fix(desktop): add CatchPanicLayer + convert prod-path unwraps in Rust backend (#8847)

### DIFF
--- a/desktop/macos/Backend-Rust/Cargo.lock
+++ b/desktop/macos/Backend-Rust/Cargo.lock
@@ -2486,6 +2486,7 @@ checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
 dependencies = [
  "bitflags 2.11.1",
  "bytes",
+ "futures-util",
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",

--- a/desktop/macos/Backend-Rust/Cargo.toml
+++ b/desktop/macos/Backend-Rust/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 # Web framework
 axum = "0.7"
 tokio = { version = "1", features = ["full"] }
-tower-http = { version = "0.5", features = ["cors", "trace"] }
+tower-http = { version = "0.5", features = ["cors", "trace", "catch-panic"] }
 
 # Serialization
 serde = { version = "1", features = ["derive"] }

--- a/desktop/macos/Backend-Rust/src/main.rs
+++ b/desktop/macos/Backend-Rust/src/main.rs
@@ -5,6 +5,7 @@ use axum::Router;
 use std::fs::OpenOptions;
 use std::io::LineWriter;
 use std::sync::Arc;
+use tower_http::catch_panic::CatchPanicLayer;
 use tower_http::cors::{Any, CorsLayer};
 use tower_http::trace::TraceLayer;
 use tracing_subscriber::fmt::format::Writer;
@@ -355,7 +356,10 @@ async fn main() {
         .layer(paywall_checker_extension(paywall_checker))
         .layer(byok_cache_extension(byok_cache))
         .layer(cors)
-        .layer(TraceLayer::new_for_http());
+        .layer(TraceLayer::new_for_http())
+        // Outermost layer: turn any handler/middleware panic into a 500 + logged
+        // error instead of a dropped connection with no response or structured log.
+        .layer(CatchPanicLayer::new());
 
     // Start server
     let addr = format!("0.0.0.0:{}", config.port);

--- a/desktop/macos/Backend-Rust/src/routes/proxy.rs
+++ b/desktop/macos/Backend-Rust/src/routes/proxy.rs
@@ -235,7 +235,13 @@ async fn gemini_proxy(
     // Vertex AI requires our service account — can't mix with user's API key.
     // Skip Vertex-specific transforms (embedContent→predict) since AI Studio
     // handles embedContent natively.
-    let byok_key = byok_gemini_key.unwrap();
+    // `is_byok` guarantees this is `Some`, but return 500 instead of panicking if
+    // the invariant ever breaks (e.g. under refactor) so a request can't drop the
+    // connection with no response.
+    let Some(byok_key) = byok_gemini_key else {
+        tracing::error!("gemini_proxy: BYOK key unexpectedly missing on BYOK path");
+        return Err(ProxyError::Status(StatusCode::INTERNAL_SERVER_ERROR));
+    };
     tracing::info!("gemini_proxy: using BYOK Gemini key for uid={}", user.uid);
 
     let url = build_gemini_url(&path, byok_key);
@@ -515,7 +521,12 @@ async fn gemini_stream_proxy(
     }
 
     // BYOK path: always use AI Studio with user's key, skip Vertex AI.
-    let byok_key = byok_gemini_key.unwrap();
+    // `is_byok` guarantees this is `Some`; return 500 rather than panic if the
+    // invariant ever breaks under refactor.
+    let Some(byok_key) = byok_gemini_key else {
+        tracing::error!("gemini_stream_proxy: BYOK key unexpectedly missing on BYOK path");
+        return Err(ProxyError::Status(StatusCode::INTERNAL_SERVER_ERROR));
+    };
     tracing::info!(
         "gemini_stream_proxy: using BYOK Gemini key for uid={}",
         user.uid

--- a/desktop/macos/Backend-Rust/src/routes/screen_activity.rs
+++ b/desktop/macos/Backend-Rust/src/routes/screen_activity.rs
@@ -44,15 +44,16 @@ async fn sync_screen_activity(
         .upsert_screen_activity(&user.uid, &request.rows)
         .await;
 
-    if let Err(e) = &firestore_result {
-        tracing::error!("Screen activity Firestore write failed: {}", e);
-        return Err((
-            StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Firestore write failed: {}", e),
-        ));
-    }
-
-    let written = firestore_result.unwrap();
+    let written = match firestore_result {
+        Ok(written) => written,
+        Err(e) => {
+            tracing::error!("Screen activity Firestore write failed: {}", e);
+            return Err((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Firestore write failed: {}", e),
+            ));
+        }
+    };
 
     // Upsert embeddings to Pinecone ns3 (fire-and-forget in background)
     let rows_with_embeddings: Vec<_> = request

--- a/desktop/macos/changelog/unreleased/20260706-rust-backend-panic-hardening.json
+++ b/desktop/macos/changelog/unreleased/20260706-rust-backend-panic-hardening.json
@@ -1,0 +1,3 @@
+{
+  "change": "Improved reliability of AI and screen-activity features when backend errors occur"
+}


### PR DESCRIPTION
## Bug
Issue #8847 — the desktop Rust backend (`desktop/macos/Backend-Rust`) serves real user traffic (auth, LLM proxy, Firestore) but has **no panic-catch layer**. `src/main.rs` layers auth/paywall/BYOK/CORS/trace, but nothing catches a handler panic — a panic drops the connection with **no 500 response and no structured log**. Compounding this, several prod-path `unwrap()`s are guarded only by a *positional* invariant that will break under refactor.

## Root cause
1. No `CatchPanicLayer` on the router, so any `unwrap()`/`panic!` in a handler unwinds into a dropped connection.
2. `proxy.rs` `byok_gemini_key.unwrap()` (×2) and `screen_activity.rs` `firestore_result.unwrap()` rely on an earlier `is_byok`/`if let Err` check positioned above them — correct today, but a latent panic if the code moves.

## Fix (surgical, `desktop/` only)
- Add `tower_http::catch_panic::CatchPanicLayer::new()` as the **outermost** layer. Its default handler logs the panic via `tracing::error!` and returns a 500 instead of dropping the connection.
- Convert the three concrete prod-path unwraps to `let Some(..) else` / `match` that return a logged 500 — removing the positional invariants.

Left out of scope (per watchdog policy — no CI/workflow edits): the issue's `.github/workflows/lint.yml` clippy/`cargo test` additions and the `[lints]` `Cargo.toml` section.

## Verification
- `cargo build` clean (only pre-existing dead-code warnings).
- `cargo test proxy` → 78 passed, 0 failed.
- `rustfmt` applied.

🤖 automated by hourly watchdog; opened for review, not merged (latent/hardening fix, not a live-prod crasher, so does not meet the auto-merge+deploy gate).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8850?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

