### PR TITLE
feat(desktop): smart local-agent routing (Codex/OpenClaw/Hermes) with fallback + Codex auto-install

### DIFF
--- a/desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift
+++ b/desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift
@@ -575,23 +575,14 @@ actor AgentRuntimeProcess {
       env["HERMES_HOME"] = "\(home)/.hermes"
     }
 
-    let adapterPathDirs = [
-      "\(home)/.hermes/hermes-agent/venv/bin",
-      "\(home)/.hermes/node/bin",
-      "\(home)/.hermes/hermes-agent",
-    ]
-    let adapterSearchDirs = adapterPathDirs + [
-      "\(home)/.local/bin",
-      "/opt/homebrew/bin",
-      "/usr/local/bin",
-    ]
+    let adapterSearchDirs = LocalAgentProviderDetector.adapterActivationSearchDirectories(homeDirectory: home)
     let trustedPathDirs = [
       "/opt/homebrew/bin",
       "/usr/local/bin",
     ]
     let existingPath = env["PATH"] ?? "/usr/bin:/bin"
     var pathElements: [String] = []
-    for path in existingPath.split(separator: ":").map(String.init) + trustedPathDirs + adapterPathDirs {
+    for path in existingPath.split(separator: ":").map(String.init) + trustedPathDirs + adapterSearchDirs {
       if !pathElements.contains(path) {
         pathElements.append(path)
       }
@@ -609,6 +600,12 @@ actor AgentRuntimeProcess {
     {
       env["OMI_OPENCLAW_ADAPTER_COMMAND"] = Self.openClawAdapterCommand(openClawPath: openClaw)
     }
+
+    if env["OMI_CODEX_ADAPTER_COMMAND"]?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ?? true,
+      let codex = firstExecutable(named: "codex", in: adapterSearchDirs)
+    {
+      env["OMI_CODEX_ADAPTER_COMMAND"] = Self.codexAdapterCommand(codexPath: codex)
+    }
   }
 
   static func openClawAdapterCommand(openClawPath: String, fileManager: FileManager = .default) -> String {
@@ -617,6 +614,10 @@ actor AgentRuntimeProcess {
       return "\(shellQuote(nodePath)) \(shellQuote(openClawPath)) acp"
     }
     return "\(shellQuote(openClawPath)) acp"
+  }
+
+  static func codexAdapterCommand(codexPath: String) -> String {
+    "CODEX_PATH=\(shellQuote(codexPath)) npx -y @agentclientprotocol/codex-acp"
   }
 
   private static func shellQuote(_ value: String) -> String {

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/AgentPill.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/AgentPill.swift
@@ -126,6 +126,7 @@ final class AgentPillsManager: ObservableObject {
     private var messageCountByPill: [UUID: Int] = [:]
     private var runTasksByPill: [UUID: Task<Void, Never>] = [:]
     private var viewedExpirationWorkItemsByPill: [UUID: DispatchWorkItem] = [:]
+    private var spawnContextByPill: [UUID: AgentSpawnContext] = [:]
     private var bootChain: Task<Void, Never> = Task {}
 
     private static let backgroundAgentSystemPromptSuffix = """
@@ -169,7 +170,7 @@ final class AgentPillsManager: ObservableObject {
         let ack: String?
     }
 
-    enum DirectedProvider: String, Equatable {
+    enum DirectedProvider: String, Equatable, CaseIterable {
         case hermes
         case openclaw
         case codex
@@ -564,7 +565,8 @@ final class AgentPillsManager: ObservableObject {
         fromVoice: Bool = false,
         preFetchedTitle: String? = nil,
         preFetchedAck: String? = nil,
-        bridgeHarnessOverride: AgentHarnessMode? = nil
+        bridgeHarnessOverride: AgentHarnessMode? = nil,
+        spawnContext: AgentSpawnContext? = nil
     ) -> AgentPill {
         let count = AgentPillsManager.parseAgentCount(from: query)
         if count <= 1 {
@@ -574,7 +576,8 @@ final class AgentPillsManager: ObservableObject {
                 fromVoice: fromVoice,
                 preFetchedTitle: preFetchedTitle,
                 preFetchedAck: preFetchedAck,
-                bridgeHarnessOverride: bridgeHarnessOverride
+                bridgeHarnessOverride: bridgeHarnessOverride,
+                spawnContext: spawnContext
             )
         }
         var first: AgentPill?
@@ -591,7 +594,8 @@ final class AgentPillsManager: ObservableObject {
                 fromVoice: fromVoice && first == nil,
                 preFetchedTitle: first == nil ? preFetchedTitle : nil,
                 preFetchedAck: first == nil ? preFetchedAck : nil,
-                bridgeHarnessOverride: bridgeHarnessOverride
+                bridgeHarnessOverride: bridgeHarnessOverride,
+                spawnContext: spawnContext
             )
             if first == nil { first = pill }
         }
@@ -651,11 +655,15 @@ final class AgentPillsManager: ObservableObject {
         preFetchedTitle: String? = nil,
         preFetchedAck: String? = nil,
         systemPromptSuffix: String? = nil,
-        bridgeHarnessOverride: AgentHarnessMode? = nil
+        bridgeHarnessOverride: AgentHarnessMode? = nil,
+        spawnContext: AgentSpawnContext? = nil
     ) -> AgentPill {
         let pill = AgentPill(query: query, model: model, bridgeHarnessOverride: bridgeHarnessOverride)
         if let preFetchedTitle, !preFetchedTitle.isEmpty {
             pill.title = preFetchedTitle
+        }
+        if let spawnContext {
+            spawnContextByPill[pill.id] = spawnContext
         }
 
         trimForNewPillIfNeeded()
@@ -975,6 +983,7 @@ final class AgentPillsManager: ObservableObject {
         projectionStreamsByPill[pillID] = nil
         providersByPill[pillID] = nil
         messageCountByPill[pillID] = nil
+        spawnContextByPill[pillID] = nil
         pills.removeAll { $0.id == pillID }
     }
 
@@ -1126,6 +1135,44 @@ final class AgentPillsManager: ObservableObject {
         return "Working…"
     }
 
+    private func maybeRetryWithFallback(
+        failedPill: AgentPill,
+        model: String,
+        errorText: String
+    ) -> Bool {
+        guard LocalAgentProviderRouting.isRetriableSpawnFailure(errorText) else { return false }
+        guard var context = spawnContextByPill[failedPill.id] else { return false }
+        guard context.explicitProvider == nil else { return false }
+        guard let nextWrapped = context.nextFallback(after: failedPill.bridgeHarnessOverride) else { return false }
+
+        let query = failedPill.query
+        let failedName = failedPill.bridgeHarnessOverride.flatMap { harness in
+            AgentPillsManager.DirectedProvider.allCases.first { $0.harnessMode == harness }?.displayName
+        } ?? "That agent"
+        let nextProvider = nextWrapped.flatMap { harness in
+            AgentPillsManager.DirectedProvider.allCases.first { $0.harnessMode == harness }
+        }
+        let ack: String
+        if let nextProvider {
+            ack = "\(failedName) failed; trying \(nextProvider.displayName) instead."
+        } else {
+            ack = "\(failedName) failed; trying the default agent instead."
+        }
+
+        context.recordAttempt(failedPill.bridgeHarnessOverride)
+        context.recordAttempt(nextWrapped)
+        cleanup(pillID: failedPill.id)
+        _ = spawn(
+            query: query,
+            model: model,
+            preFetchedTitle: nextProvider?.displayName ?? failedPill.title,
+            preFetchedAck: ack,
+            bridgeHarnessOverride: nextWrapped,
+            spawnContext: context
+        )
+        return true
+    }
+
     private func complete(pill: AgentPill, provider: ChatProvider, finalText: String?) {
         let trimmedFinalText = finalText?.trimmingCharacters(in: .whitespacesAndNewlines)
         if let trimmedFinalText, !trimmedFinalText.isEmpty {
@@ -1159,6 +1206,13 @@ final class AgentPillsManager: ObservableObject {
             }
         }
         if let errorText = provider.errorMessage, !errorText.isEmpty {
+            if maybeRetryWithFallback(
+                failedPill: pill,
+                model: pill.model,
+                errorText: errorText
+            ) {
+                return
+            }
             pill.status = .failed(errorText)
             pill.latestActivity = errorText
             pill.completedAt = Date()
@@ -1228,6 +1282,13 @@ final class AgentPillsManager: ObservableObject {
             }
         case .failed, .timedOut, .orphaned:
             let message = projection.failure?.displayMessage ?? projection.errorMessage ?? "Agent failed"
+            if AgentPillsManager.shared.maybeRetryWithFallback(
+                failedPill: pill,
+                model: pill.model,
+                errorText: message
+            ) {
+                return
+            }
             pill.status = .failed(message)
             pill.latestActivity = message
             pill.completedAt = projection.completedAt ?? Date()

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/AgentPill.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/AgentPill.swift
@@ -172,11 +172,13 @@ final class AgentPillsManager: ObservableObject {
     enum DirectedProvider: String, Equatable {
         case hermes
         case openclaw
+        case codex
 
         var displayName: String {
             switch self {
             case .hermes: return "Hermes"
             case .openclaw: return "OpenClaw"
+            case .codex: return "Codex"
             }
         }
 
@@ -184,6 +186,7 @@ final class AgentPillsManager: ObservableObject {
             switch self {
             case .hermes: return .hermes
             case .openclaw: return .openclaw
+            case .codex: return .codex
             }
         }
 
@@ -191,6 +194,7 @@ final class AgentPillsManager: ObservableObject {
             switch self {
             case .hermes: return "hermes"
             case .openclaw: return "openclaw"
+            case .codex: return "codex"
             }
         }
 
@@ -198,6 +202,7 @@ final class AgentPillsManager: ObservableObject {
             switch self {
             case .hermes: return "OMI_HERMES_ADAPTER_COMMAND"
             case .openclaw: return "OMI_OPENCLAW_ADAPTER_COMMAND"
+            case .codex: return "OMI_CODEX_ADAPTER_COMMAND"
             }
         }
 
@@ -377,7 +382,7 @@ final class AgentPillsManager: ObservableObject {
         let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return nil }
 
-        let providerPattern = "(open\\s*claw|openclaw|hermes)"
+        let providerPattern = "(open\\s*claw|openclaw|hermes|codex)"
         let patterns = [
             #"(?i)^\s*(?:please\s+)?(?:(?:i\s+)?meant\s+)?(?:ask|tell|ping|message|run|use|try)\s+\#(providerPattern)\b(?:\s+(.*))?$"#,
             #"(?i)^\s*(?:please\s+)?\#(providerPattern)\s*[:,\-]\s*(.*)$"#,
@@ -395,6 +400,7 @@ final class AgentPillsManager: ObservableObject {
             switch providerToken {
             case "openclaw": provider = .openclaw
             case "hermes": provider = .hermes
+            case "codex": provider = .codex
             default: continue
             }
 

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
@@ -2587,9 +2587,21 @@ class FloatingControlBarManager {
                 provider.stopAgent()
             }
             routerTracer?.mark("router_classify", metadata: ["route": "agent", "provider": directive.provider.rawValue])
-            let availability = LocalAgentProviderDetector.availability(for: directive.provider)
-            guard availability.isAvailable else {
-                let assistantText = availability.setupPrompt
+            let resolution = await LocalAgentProviderRouting.resolveSpawnWithAutoInstall(
+                brief: directive.rewrittenQuery,
+                requestedProvider: directive.provider,
+                userRequestText: message,
+                title: directive.title,
+                onInstallStart: { installProvider in
+                    let status = LocalAgentProviderInstaller.installingStatus(for: installProvider)
+                    if case .voiceOnly = presentation {
+                        FloatingBarVoicePlaybackService.shared.speakOneShot(status)
+                    }
+                }
+            )
+            switch resolution {
+            case .setupRequired(_, let setupPrompt, let spokenStatus):
+                let assistantText = setupPrompt
                 let recordedTurn = provider.recordCompletedTurn(
                     userText: message,
                     assistantText: assistantText,
@@ -2605,38 +2617,46 @@ class FloatingControlBarManager {
                 case .voiceOnly:
                     barWindow.state.currentQueryFromVoice = false
                     barWindow.state.isVoiceResponseActive = false
-                    FloatingBarVoicePlaybackService.shared.speakOneShot(directive.provider.setupNeededStatus)
+                    FloatingBarVoicePlaybackService.shared.speakOneShot(spokenStatus)
+                }
+                return
+            case .spawn(let plan):
+                let pill = AgentPillsManager.shared.spawnFromUserQuery(
+                    directive.rewrittenQuery,
+                    model: selectedFloatingModel,
+                    fromVoice: presentation.fromVoice,
+                    preFetchedTitle: plan.title,
+                    preFetchedAck: plan.ack,
+                    bridgeHarnessOverride: plan.harnessOverride,
+                    spawnContext: plan.context
+                )
+                let providerName = plan.selectedProvider?.displayName ?? directive.provider.displayName
+                let assistantText: String
+                if let fallbackNote = plan.fallbackNote {
+                    assistantText = "\(fallbackNote) I started \(providerName) in a background agent titled \"\(pill.title)\"."
+                } else {
+                    assistantText = "I started \(providerName) in a background agent titled \"\(pill.title)\"."
+                }
+                let recordedTurn = provider.recordCompletedTurn(
+                    userText: message,
+                    assistantText: assistantText,
+                    logLabel: "floating-agent-provider"
+                )
+                switch presentation {
+                case .visible:
+                    completeVisibleAgentHandoff(
+                        .init(originalRequest: message, agentTask: directive.rewrittenQuery),
+                        pill: pill,
+                        assistantMessage: recordedTurn.assistant,
+                        assistantText: assistantText,
+                        barWindow: barWindow
+                    )
+                case .voiceOnly:
+                    barWindow.state.currentQueryFromVoice = false
+                    barWindow.state.isVoiceResponseActive = false
                 }
                 return
             }
-            let pill = AgentPillsManager.shared.spawnFromUserQuery(
-                directive.rewrittenQuery,
-                model: selectedFloatingModel,
-                fromVoice: presentation.fromVoice,
-                preFetchedTitle: directive.title,
-                preFetchedAck: directive.ack,
-                bridgeHarnessOverride: directive.provider.harnessMode
-            )
-            let assistantText = "I started \(directive.provider.displayName) in a background agent titled \"\(pill.title)\"."
-            let recordedTurn = provider.recordCompletedTurn(
-                userText: message,
-                assistantText: assistantText,
-                logLabel: "floating-agent-provider"
-            )
-            switch presentation {
-            case .visible:
-                completeVisibleAgentHandoff(
-                    .init(originalRequest: message, agentTask: directive.rewrittenQuery),
-                    pill: pill,
-                    assistantMessage: recordedTurn.assistant,
-                    assistantText: assistantText,
-                    barWindow: barWindow
-                )
-            case .voiceOnly:
-                barWindow.state.currentQueryFromVoice = false
-                barWindow.state.isVoiceResponseActive = false
-            }
-            return
         }
 
         if let handoff {
@@ -2690,38 +2710,79 @@ class FloatingControlBarManager {
         let decision = await AgentPillsManager.classify(message)
         routerTracer?.end("router_classify", metadata: ["route": decision.route == .agent ? "agent" : "chat"])
         if decision.route == .agent {
-            let pill = AgentPillsManager.shared.spawnFromUserQuery(
-                message,
-                model: selectedFloatingModel,
-                fromVoice: presentation.fromVoice,
-                preFetchedTitle: decision.title,
-                preFetchedAck: decision.ack
+            let resolution = await LocalAgentProviderRouting.resolveSpawnWithAutoInstall(
+                brief: message,
+                requestedProvider: nil,
+                userRequestText: message,
+                title: decision.title,
+                onInstallStart: { installProvider in
+                    let status = LocalAgentProviderInstaller.installingStatus(for: installProvider)
+                    if case .voiceOnly = presentation {
+                        FloatingBarVoicePlaybackService.shared.speakOneShot(status)
+                    }
+                }
             )
-            let title = decision.title?.trimmingCharacters(in: .whitespacesAndNewlines)
-            let titleSuffix = (title?.isEmpty == false) ? " titled \"\(title!)\"" : ""
-            let ack = decision.ack?.trimmingCharacters(in: .whitespacesAndNewlines)
-            let assistantText = ack?.isEmpty == false
-                ? "\(ack!) I started a background agent\(titleSuffix) for that."
-                : "I started a background agent\(titleSuffix) for that."
-            let recordedTurn = provider.recordCompletedTurn(
-                userText: message,
-                assistantText: assistantText,
-                logLabel: "floating-agent"
-            )
-            switch presentation {
-            case .visible:
-                completeVisibleAgentHandoff(
-                    .init(originalRequest: message, agentTask: message),
-                    pill: pill,
-                    assistantMessage: recordedTurn.assistant,
-                    assistantText: assistantText,
-                    barWindow: barWindow
+            switch resolution {
+            case .setupRequired(_, let setupPrompt, let spokenStatus):
+                let recordedTurn = provider.recordCompletedTurn(
+                    userText: message,
+                    assistantText: setupPrompt,
+                    logLabel: "floating-agent-provider-unavailable"
                 )
-            case .voiceOnly:
-                barWindow.state.currentQueryFromVoice = false
-                barWindow.state.isVoiceResponseActive = false
+                switch presentation {
+                case .visible:
+                    completeVisibleAgentResponse(
+                        userText: message,
+                        assistantMessage: recordedTurn.assistant ?? ChatMessage(text: setupPrompt, sender: .ai),
+                        barWindow: barWindow
+                    )
+                case .voiceOnly:
+                    barWindow.state.currentQueryFromVoice = false
+                    barWindow.state.isVoiceResponseActive = false
+                    FloatingBarVoicePlaybackService.shared.speakOneShot(spokenStatus)
+                }
+                return
+            case .spawn(let plan):
+                let pill = AgentPillsManager.shared.spawnFromUserQuery(
+                    message,
+                    model: selectedFloatingModel,
+                    fromVoice: presentation.fromVoice,
+                    preFetchedTitle: plan.title,
+                    preFetchedAck: plan.ack,
+                    bridgeHarnessOverride: plan.harnessOverride,
+                    spawnContext: plan.context
+                )
+                let title = plan.title.trimmingCharacters(in: .whitespacesAndNewlines)
+                let titleSuffix = title.isEmpty ? "" : " titled \"\(title)\""
+                let ack = plan.ack.trimmingCharacters(in: .whitespacesAndNewlines)
+                let assistantText: String
+                if let fallbackNote = plan.fallbackNote {
+                    assistantText = "\(fallbackNote) I started a background agent\(titleSuffix) for that."
+                } else if ack.isEmpty {
+                    assistantText = "I started a background agent\(titleSuffix) for that."
+                } else {
+                    assistantText = "\(ack) I started a background agent\(titleSuffix) for that."
+                }
+                let recordedTurn = provider.recordCompletedTurn(
+                    userText: message,
+                    assistantText: assistantText,
+                    logLabel: "floating-agent"
+                )
+                switch presentation {
+                case .visible:
+                    completeVisibleAgentHandoff(
+                        .init(originalRequest: message, agentTask: message),
+                        pill: pill,
+                        assistantMessage: recordedTurn.assistant,
+                        assistantText: assistantText,
+                        barWindow: barWindow
+                    )
+                case .voiceOnly:
+                    barWindow.state.currentQueryFromVoice = false
+                    barWindow.state.isVoiceResponseActive = false
+                }
+                return
             }
-            return
         }
 
         // Chat route: continue with the requested delivery surface.

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
@@ -1014,57 +1014,81 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate, AVSpeec
         .trimmingCharacters(in: .whitespacesAndNewlines)
         .lowercased()
         .replacingOccurrences(of: " ", with: "")
-      let directedProvider: AgentPillsManager.DirectedProvider?
+      let requestedProvider: AgentPillsManager.DirectedProvider?
       switch providerName {
-      case "openclaw": directedProvider = .openclaw
-      case "hermes": directedProvider = .hermes
-      case "codex": directedProvider = .codex
-      case "": directedProvider = nil
+      case "openclaw": requestedProvider = .openclaw
+      case "hermes": requestedProvider = .hermes
+      case "codex": requestedProvider = .codex
+      case "": requestedProvider = nil
       default:
         session?.sendToolResult(
           callId: callId, name: name,
           output: "Unsupported agent provider '\(providerName)'. Use 'hermes', 'openclaw', or 'codex'.")
         return
       }
-      if let directedProvider {
-        let availability = LocalAgentProviderDetector.availability(for: directedProvider)
-        guard availability.isAvailable else {
-          let setupPrompt = availability.setupPrompt
-          assistantText = setupPrompt
-          barState?.isVoiceResponseActive = true
-          if !audioReceivedThisTurn {
-            speak(directedProvider.setupNeededStatus)
+      let userRequestText = turnTranscript.trimmingCharacters(in: .whitespacesAndNewlines)
+      Task { @MainActor [weak self] in
+        guard let self else { return }
+        let resolution = await LocalAgentProviderRouting.resolveSpawnWithAutoInstall(
+          brief: brief,
+          requestedProvider: requestedProvider,
+          userRequestText: userRequestText.isEmpty ? nil : userRequestText,
+          title: title,
+          onInstallStart: { [weak self] provider in
+            guard let self else { return }
+            let status = LocalAgentProviderInstaller.installingStatus(for: provider)
+            log("RealtimeHub[\(self.providerTag)]: auto-installing \(provider.rawValue)")
+            if !self.audioReceivedThisTurn {
+              self.barState?.isVoiceResponseActive = true
+              self.speak(status)
+            }
           }
-          suppressAssistantOutputForCurrentTurn = true
-          log("RealtimeHub[\(providerTag)]: tool spawn_agent provider=\(directedProvider.rawValue) unavailable")
-          sendToolResultIfCurrent(
+        )
+        // The install await can take many seconds; bail if the session/turn moved on
+        // so we don't speak or mutate state for a turn that's no longer active.
+        guard self.isCurrentSession(source) else { return }
+        switch resolution {
+        case .setupRequired(let provider, let setupPrompt, _):
+          self.assistantText = setupPrompt
+          self.barState?.isVoiceResponseActive = true
+          if !self.audioReceivedThisTurn {
+            self.speak(setupPrompt)
+          }
+          self.suppressAssistantOutputForCurrentTurn = true
+          log("RealtimeHub[\(self.providerTag)]: tool spawn_agent provider=\(provider.rawValue) unavailable")
+          self.sendToolResultIfCurrent(
             source: source, callId: callId, name: name,
-            output: availability.toolError)
+            output: "Error: \(setupPrompt)")
           return
+        case .spawn(let plan):
+          let model = ShortcutSettings.shared.selectedModel.isEmpty
+            ? ModelQoS.Claude.defaultSelection : ShortcutSettings.shared.selectedModel
+          let pill = AgentPillsManager.shared.spawnFromUserQuery(
+            brief, model: model, fromVoice: false,
+            preFetchedTitle: plan.title,
+            preFetchedAck: plan.ack,
+            bridgeHarnessOverride: plan.harnessOverride,
+            spawnContext: plan.context)
+          log("RealtimeHub[\(self.providerTag)]: tool spawn_agent → AgentBridge pill=\"\(pill.title)\" model=\(model) provider=\(plan.selectedProvider?.rawValue ?? "default") titled=\(title?.isEmpty == false) fallback=\(plan.usedFallback)")
+          if !self.audioReceivedThisTurn {
+            let existingAck = self.assistantText.trimmingCharacters(in: .whitespacesAndNewlines)
+            let ack = existingAck.isEmpty ? plan.ack : existingAck
+            self.assistantText = ack
+            self.barState?.isVoiceResponseActive = true
+            self.speak(ack)
+          }
+          self.suppressAssistantOutputForCurrentTurn = true
+          let toolOutput: String
+          if let fallbackNote = plan.fallbackNote {
+            toolOutput = "Agent started with fallback. \(fallbackNote)"
+          } else {
+            toolOutput = "Agent started."
+          }
+          self.sendToolResultIfCurrent(
+            source: source, callId: callId, name: name,
+            output: toolOutput)
         }
       }
-      let model = ShortcutSettings.shared.selectedModel.isEmpty
-        ? ModelQoS.Claude.defaultSelection : ShortcutSettings.shared.selectedModel
-      // Non-blocking: spawn renders its own pill ("text bubble") and runs on its
-      // own ChatProvider/AgentBridge. We don't await it on the voice loop.
-      // fromVoice:false — the hub model speaks its own natural acknowledgment, so the pill
-      // must NOT also speak its canned randomAck ("on it") or we double up.
-      let pill = AgentPillsManager.shared.spawnFromUserQuery(
-        brief, model: model, fromVoice: false,
-        preFetchedTitle: (title?.isEmpty == false) ? title : directedProvider?.displayName,
-        bridgeHarnessOverride: directedProvider?.harnessMode)
-      log("RealtimeHub[\(providerTag)]: tool spawn_agent → AgentBridge pill=\"\(pill.title)\" model=\(model) provider=\(directedProvider?.rawValue ?? "default") titled=\(title?.isEmpty == false)")
-      if !audioReceivedThisTurn {
-        let existingAck = assistantText.trimmingCharacters(in: .whitespacesAndNewlines)
-        let ack = existingAck.isEmpty ? "Starting a background agent." : existingAck
-        assistantText = ack
-        barState?.isVoiceResponseActive = true
-        speak(ack)
-      }
-      suppressAssistantOutputForCurrentTurn = true
-      sendToolResultIfCurrent(
-        source: source, callId: callId, name: name,
-        output: "Agent started.")
     case .screenshot:
       // Gemini: the screen is already attached to every turn (see commitTurn), so the
       // tool is just an ack — pushing another image here is the broken path (mid-tool-call

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
@@ -1048,11 +1048,11 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate, AVSpeec
         // so we don't speak or mutate state for a turn that's no longer active.
         guard self.isCurrentSession(source) else { return }
         switch resolution {
-        case .setupRequired(let provider, let setupPrompt, _):
+        case .setupRequired(let provider, let setupPrompt, let spokenStatus):
           self.assistantText = setupPrompt
           self.barState?.isVoiceResponseActive = true
           if !self.audioReceivedThisTurn {
-            self.speak(setupPrompt)
+            self.speak(spokenStatus)
           }
           self.suppressAssistantOutputForCurrentTurn = true
           log("RealtimeHub[\(self.providerTag)]: tool spawn_agent provider=\(provider.rawValue) unavailable")

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
@@ -1018,11 +1018,12 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate, AVSpeec
       switch providerName {
       case "openclaw": directedProvider = .openclaw
       case "hermes": directedProvider = .hermes
+      case "codex": directedProvider = .codex
       case "": directedProvider = nil
       default:
         session?.sendToolResult(
           callId: callId, name: name,
-          output: "Unsupported agent provider '\(providerName)'. Use 'hermes' or 'openclaw'.")
+          output: "Unsupported agent provider '\(providerName)'. Use 'hermes', 'openclaw', or 'codex'.")
         return
       }
       if let directedProvider {

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubTools.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubTools.swift
@@ -70,13 +70,13 @@ enum HubTool: String {
 
 enum RealtimeHubTools {
   private static func localAgentProviderInstruction() -> String {
-    let providers: [AgentPillsManager.DirectedProvider] = [.openclaw, .hermes]
+    let providers: [AgentPillsManager.DirectedProvider] = [.openclaw, .hermes, .codex]
     let availability = providers.map { LocalAgentProviderDetector.availability(for: $0) }
     let available = availability.filter(\.isAvailable).map(\.provider)
     let unavailable = availability.filter { !$0.isAvailable }
 
     if unavailable.isEmpty {
-      return "If the user asks to use/ask OpenClaw or Hermes, call spawn_agent with provider set to \"openclaw\" or \"hermes\". Treat those as available local providers, not as sessions to inspect."
+      return "If the user asks to use/ask OpenClaw, Hermes, or Codex, call spawn_agent with provider set to \"openclaw\", \"hermes\", or \"codex\". Treat those as available local providers, not as sessions to inspect."
     }
 
     var parts: [String] = []
@@ -92,7 +92,7 @@ enum RealtimeHubTools {
   }
 
   private static func availableDirectedProviderRawValues() -> [String] {
-    [AgentPillsManager.DirectedProvider.openclaw, .hermes]
+    [AgentPillsManager.DirectedProvider.openclaw, .hermes, .codex]
       .filter { LocalAgentProviderDetector.isAvailable($0) }
       .map(\.rawValue)
   }
@@ -212,6 +212,11 @@ enum RealtimeHubTools {
     user. So always emit the spawn_agent call. You may add one short natural sentence as you \
     call it, but never instead of it. Do NOT ask clarifying questions before spawning — spawn \
     with what you have. Do NOT wait for it, narrate its steps, refuse, or claim you can't.
+    - Smart agent routing: When calling spawn_agent, you must select the best local agent provider (pass it in the `provider` argument) based on availability and task fit. When the user explicitly requests an agent by name (e.g. \"use hermes\"), always select that provider. If the user doesn't specify one: \
+      - Choose \"hermes\" for coding tasks involving codebase exploration, refactoring, or multi-file edits. \
+      - Choose \"codex\" for writing new code/scripts, debugging, or code review. \
+      - Choose \"openclaw\" for general-purpose automation or structured tasks. \
+      - Omit the provider (default) to use Claude Code for general reasoning, complex analysis, and multi-step tasks.
     - \(localAgentProviderInstruction())
     - Everything else — general questions, facts, chit-chat, explanations, advice, jokes, \
     and creative or long-form requests (stories, brainstorming, drafts): ANSWER YOURSELF. \

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubTools.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubTools.swift
@@ -73,27 +73,52 @@ enum RealtimeHubTools {
     let providers: [AgentPillsManager.DirectedProvider] = [.openclaw, .hermes, .codex]
     let availability = providers.map { LocalAgentProviderDetector.availability(for: $0) }
     let available = availability.filter(\.isAvailable).map(\.provider)
-    let unavailable = availability.filter { !$0.isAvailable }
+    let unavailable = availability.filter { !$0.isAvailable && !LocalAgentProviderInstaller.canAutoInstall($0.provider) }
+    let autoInstallable = availability.filter { !$0.isAvailable && LocalAgentProviderInstaller.canAutoInstall($0.provider) }.map(\.provider)
 
-    if unavailable.isEmpty {
+    if unavailable.isEmpty && autoInstallable.isEmpty {
       return "If the user asks to use/ask OpenClaw, Hermes, or Codex, call spawn_agent with provider set to \"openclaw\", \"hermes\", or \"codex\". Treat those as available local providers, not as sessions to inspect."
     }
 
     var parts: [String] = []
     if !available.isEmpty {
-      let names = available.map { "\"\($0.rawValue)\"" }.joined(separator: " or ")
-      parts.append("If the user asks to use/ask \(available.map(\.displayName).joined(separator: " or ")), call spawn_agent with provider set to \(names).")
+      parts.append("Installed local providers: \(available.map(\.displayName).joined(separator: ", ")). Prefer these in spawn_agent's provider argument.")
+      parts.append("If the user explicitly asks to use/ask one of them by name, pass that provider. Otherwise pick the best fit from the installed list above — Omi will fall back automatically if your pick is missing.")
+      parts.append("Never tell the user to install a provider they did not ask for by name.")
     }
-    let missingText = unavailable
-      .map { "\($0.provider.displayName): \($0.setupPrompt)" }
-      .joined(separator: " ")
-    parts.append("If the user asks to use/ask an unavailable local provider, do NOT spawn a default agent. Say it needs setup and use this guidance: \(missingText)")
+    if !autoInstallable.isEmpty {
+      parts.append("\(autoInstallable.map(\.displayName).joined(separator: ", ")) is not installed yet but Omi will auto-install it when you pass provider=\"\(autoInstallable.map(\.rawValue).joined(separator: "\" or \""))\". Do not tell the user to install it themselves.")
+    }
+    if !unavailable.isEmpty {
+      let missingText = unavailable
+        .map { "\($0.provider.displayName): \($0.setupPrompt)" }
+        .joined(separator: " ")
+      parts.append("Only mention install guidance when the user explicitly asked for that provider by name: \(missingText)")
+    }
     return parts.joined(separator: " ")
+  }
+
+  /// Derives agent-routing guidance from the runtime `preferredProviders(for:)` table
+  /// so the system prompt stays in sync with `LocalAgentProviderRouting.resolveSpawn`.
+  private static func smartAgentRoutingGuidance() -> String {
+    let taskDescriptions: [(AgentTaskKind, String)] = [
+      (.coding, "writing new code/scripts, debugging, or code review"),
+      (.automation, "general-purpose automation or structured tasks"),
+      (.general, "codebase exploration or multi-file refactors"),
+    ]
+    var lines: [String] = []
+    for (task, description) in taskDescriptions {
+      let preferred = LocalAgentProviderRouting.preferredProviders(for: task)
+      if let first = preferred.first {
+        lines.append("- Choose \"\(first.rawValue)\" for \(description).")
+      }
+    }
+    return lines.joined(separator: " \\\n      ")
   }
 
   private static func availableDirectedProviderRawValues() -> [String] {
     [AgentPillsManager.DirectedProvider.openclaw, .hermes, .codex]
-      .filter { LocalAgentProviderDetector.isAvailable($0) }
+      .filter { LocalAgentProviderDetector.isAvailable($0) || LocalAgentProviderInstaller.canAutoInstall($0) }
       .map(\.rawValue)
   }
 
@@ -212,11 +237,10 @@ enum RealtimeHubTools {
     user. So always emit the spawn_agent call. You may add one short natural sentence as you \
     call it, but never instead of it. Do NOT ask clarifying questions before spawning — spawn \
     with what you have. Do NOT wait for it, narrate its steps, refuse, or claim you can't.
-    - Smart agent routing: When calling spawn_agent, you must select the best local agent provider (pass it in the `provider` argument) based on availability and task fit. When the user explicitly requests an agent by name (e.g. \"use hermes\"), always select that provider. If the user doesn't specify one: \
-      - Choose \"hermes\" for coding tasks involving codebase exploration, refactoring, or multi-file edits. \
-      - Choose \"codex\" for writing new code/scripts, debugging, or code review. \
-      - Choose \"openclaw\" for general-purpose automation or structured tasks. \
-      - Omit the provider (default) to use Claude Code for general reasoning, complex analysis, and multi-step tasks.
+    - Smart agent routing: When calling spawn_agent, pass the best installed local provider in `provider` when you know one fits. Omi also picks and falls back automatically in code. When the user explicitly requests an agent by name (e.g. \"use codex\"), always pass that provider. If the user doesn't specify one, prefer an installed provider from the list above — do NOT pick or mention providers that are not installed: \
+      \(smartAgentRoutingGuidance()) \
+      - Omit the provider (default) to let Omi automatically select the best installed local provider, falling back to Claude Code when no local provider is installed.
+    - Auto-install: if the user asks for Codex by name and it is not installed, Omi will install it automatically (npm install -g @openai/codex) and then spawn it. You do not need to tell the user to install it themselves. For Hermes and OpenClaw, Omi will give install guidance if they are missing.
     - \(localAgentProviderInstruction())
     - Everything else — general questions, facts, chit-chat, explanations, advice, jokes, \
     and creative or long-form requests (stories, brainstorming, drafts): ANSWER YOURSELF. \

--- a/desktop/macos/Desktop/Sources/Providers/AgentRuntimeRouting.swift
+++ b/desktop/macos/Desktop/Sources/Providers/AgentRuntimeRouting.swift
@@ -89,11 +89,11 @@ struct LocalAgentProviderAvailability: Equatable {
     var setupPrompt: String {
         switch provider {
         case .hermes:
-            return "I don't see Hermes installed. Make sure Hermes is installed first, then try again."
+            return "I don't see Hermes installed. Install it from github.com/NousResearch/hermes-agent with `pip install -e '.[acp]'` (or `uvx --from 'hermes-agent[acp]'`), then run `hermes model` to configure a provider, and try again."
         case .openclaw:
-            return "I don't see OpenClaw installed. Make sure OpenClaw is installed first, then try again."
+            return "I don't see OpenClaw installed. Install OpenClaw on your PATH, or set the OMI_OPENCLAW_ADAPTER_COMMAND environment variable to point Omi at your OpenClaw binary, then try again."
         case .codex:
-            return "I don't see Codex installed. Please run 'npm install -g @openai/codex' and run 'codex' in your terminal to sign in, then try again."
+            return "I don't see Codex installed. Run `npm install -g @openai/codex` in your terminal, then run `codex` to sign in, and try again."
         }
     }
 
@@ -147,7 +147,7 @@ enum LocalAgentProviderDetector {
         fileManager: FileManager,
         homeDirectory: String
     ) -> String? {
-        for dir in adapterActivationSearchDirectories(homeDirectory: homeDirectory) {
+        for dir in adapterActivationSearchDirectories(homeDirectory: homeDirectory, fileManager: fileManager) {
             let path = (dir as NSString).appendingPathComponent(name)
             if fileManager.isExecutableFile(atPath: path) {
                 return path
@@ -156,8 +156,11 @@ enum LocalAgentProviderDetector {
         return nil
     }
 
-    private static func adapterActivationSearchDirectories(homeDirectory: String) -> [String] {
-        [
+    static func adapterActivationSearchDirectories(
+        homeDirectory: String,
+        fileManager: FileManager = .default
+    ) -> [String] {
+        var directories = [
             "\(homeDirectory)/.hermes/hermes-agent/venv/bin",
             "\(homeDirectory)/.hermes/node/bin",
             "\(homeDirectory)/.hermes/hermes-agent",
@@ -167,5 +170,489 @@ enum LocalAgentProviderDetector {
             "/opt/homebrew/bin",
             "/usr/local/bin",
         ]
+        directories.append(contentsOf: nvmBinDirectories(homeDirectory: homeDirectory, fileManager: fileManager))
+        return directories
+    }
+
+    private static func nvmBinDirectories(
+        homeDirectory: String,
+        fileManager: FileManager
+    ) -> [String] {
+        let nvmRoot = (homeDirectory as NSString).appendingPathComponent(".nvm/versions/node")
+        guard let versions = try? fileManager.contentsOfDirectory(atPath: nvmRoot) else {
+            return []
+        }
+        return versions
+            .sorted { lhs, rhs in lhs.compare(rhs, options: .numeric) == .orderedDescending }
+            .map { (nvmRoot as NSString).appendingPathComponent("\($0)/bin") }
+    }
+}
+
+enum AgentTaskKind: Equatable {
+    case coding
+    case automation
+    case general
+}
+
+struct AgentSpawnContext: Equatable {
+    let taskKind: AgentTaskKind
+    let explicitProvider: AgentPillsManager.DirectedProvider?
+    let fallbackChain: [AgentHarnessMode?]
+    var attemptedHarnesses: [AgentHarnessMode?]
+
+    func nextFallback(after current: AgentHarnessMode?) -> AgentHarnessMode?? {
+        // Consider ALL unattempted providers in fallbackChain, not just ones
+        // ranked after `current`. When the user explicitly requested a provider
+        // that isn't the first in the preference order, we still want to try
+        // higher-preference providers on failure.
+        return fallbackChain.first { harness in
+            harness != current && !attemptedHarnesses.contains(where: { $0 == harness })
+        }
+    }
+
+    mutating func recordAttempt(_ harness: AgentHarnessMode?) {
+        if !attemptedHarnesses.contains(where: { $0 == harness }) {
+            attemptedHarnesses.append(harness)
+        }
+    }
+}
+
+enum LocalAgentProviderRouting {
+    enum Resolution: Equatable {
+        case spawn(AgentSpawnPlan)
+        case setupRequired(
+            provider: AgentPillsManager.DirectedProvider,
+            prompt: String,
+            spokenStatus: String
+        )
+    }
+
+    struct AgentSpawnPlan: Equatable {
+        let harnessOverride: AgentHarnessMode?
+        let title: String
+        let ack: String
+        let selectedProvider: AgentPillsManager.DirectedProvider?
+        let usedFallback: Bool
+        let fallbackNote: String?
+        let context: AgentSpawnContext
+    }
+
+    static func classifyTask(_ text: String) -> AgentTaskKind {
+        let lower = text.lowercased()
+        let codingSignals = [
+            "code", "script", "debug", "refactor", "compile", "function", "class", "api",
+            "bug", "implement", "python", "swift", "typescript", "javascript", "repo",
+            "repository", "pull request", "unit test", "lint", "syntax",
+        ]
+        if codingSignals.contains(where: { lower.contains($0) }) {
+            return .coding
+        }
+        let automationSignals = [
+            "automate", "click", "open app", "send email", "browser", "download",
+            "upload", "reminder", "notes app", "messages app", "files app", "folder",
+        ]
+        if automationSignals.contains(where: { lower.contains($0) }) {
+            return .automation
+        }
+        return .general
+    }
+
+    static func preferredProviders(for task: AgentTaskKind) -> [AgentPillsManager.DirectedProvider] {
+        switch task {
+        case .coding:
+            return [.codex, .hermes, .openclaw]
+        case .automation:
+            return [.openclaw, .codex, .hermes]
+        case .general:
+            return [.openclaw, .codex, .hermes]
+        }
+    }
+
+    static func explicitProvider(in text: String) -> AgentPillsManager.DirectedProvider? {
+        AgentPillsManager.providerDirective(from: text)?.provider
+    }
+
+    static func isExplicitProviderRequest(
+        _ provider: AgentPillsManager.DirectedProvider,
+        in text: String
+    ) -> Bool {
+        if explicitProvider(in: text) == provider {
+            return true
+        }
+        let openClawPattern = #"(?i)\bopen\s*claw\b"#
+        switch provider {
+        case .openclaw:
+            return text.range(of: openClawPattern, options: .regularExpression) != nil
+        case .hermes, .codex:
+            let pattern = #"(?i)\b\#(provider.rawValue)\b"#
+            return text.range(of: pattern, options: .regularExpression) != nil
+        }
+    }
+
+    static func isRetriableSpawnFailure(_ message: String) -> Bool {
+        let lower = message.lowercased()
+        return lower.contains("not available")
+            || lower.contains("failed to start")
+            || lower.contains("adapter")
+            || lower.contains("enoent")
+            || lower.contains("command not found")
+            || lower.contains("activation")
+    }
+
+    static func resolveSpawn(
+        brief: String,
+        requestedProvider: AgentPillsManager.DirectedProvider?,
+        userRequestText: String?,
+        title: String?,
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        fileManager: FileManager = .default,
+        homeDirectory: String = NSHomeDirectory()
+    ) -> Resolution {
+        let taskKind = classifyTask(brief)
+        // Only treat a provider as user-directed when it appears in the user's own
+        // words. The model-authored `brief` often names a provider the model chose
+        // (e.g. "use Hermes to refactor…") even when the user never said it.
+        // Match a bare mention ("codex", "use codex", "install codex"), not just a
+        // verb+name directive, so any task that names an agent routes to it.
+        let userText = userRequestText?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let explicit = userText.isEmpty ? nil : AgentPillsManager.DirectedProvider.allCases.first {
+            isExplicitProviderRequest($0, in: userText)
+        }
+
+        if let explicit {
+            let availability = LocalAgentProviderDetector.availability(
+                for: explicit,
+                environment: environment,
+                fileManager: fileManager,
+                homeDirectory: homeDirectory
+            )
+            guard availability.isAvailable else {
+                return .setupRequired(
+                    provider: explicit,
+                    prompt: availability.setupPrompt,
+                    spokenStatus: explicit.setupNeededStatus
+                )
+            }
+            let resolvedTitle = normalizedTitle(title, provider: explicit)
+            return .spawn(
+                AgentSpawnPlan(
+                    harnessOverride: explicit.harnessMode,
+                    title: resolvedTitle,
+                    ack: "Asking \(explicit.displayName).",
+                    selectedProvider: explicit,
+                    usedFallback: false,
+                    fallbackNote: nil,
+                    context: spawnContext(
+                        taskKind: taskKind,
+                        explicitProvider: explicit,
+                        selectedHarness: explicit.harnessMode,
+                        environment: environment,
+                        fileManager: fileManager,
+                        homeDirectory: homeDirectory
+                    )
+                )
+            )
+        }
+
+        let orderedProviders = preferredProviders(for: taskKind)
+        let availableProviders = orderedProviders.filter {
+            LocalAgentProviderDetector.isAvailable(
+                $0,
+                environment: environment,
+                fileManager: fileManager,
+                homeDirectory: homeDirectory
+            )
+        }
+
+        if let requestedProvider {
+            if LocalAgentProviderDetector.isAvailable(
+                requestedProvider,
+                environment: environment,
+                fileManager: fileManager,
+                homeDirectory: homeDirectory
+            ) {
+                let resolvedTitle = normalizedTitle(title, provider: requestedProvider)
+                return .spawn(
+                    AgentSpawnPlan(
+                        harnessOverride: requestedProvider.harnessMode,
+                        title: resolvedTitle,
+                        ack: "Starting \(requestedProvider.displayName).",
+                        selectedProvider: requestedProvider,
+                        usedFallback: false,
+                        fallbackNote: nil,
+                        context: spawnContext(
+                            taskKind: taskKind,
+                            explicitProvider: nil,
+                            selectedHarness: requestedProvider.harnessMode,
+                            environment: environment,
+                            fileManager: fileManager,
+                            homeDirectory: homeDirectory
+                        )
+                    )
+                )
+            }
+
+            if let fallbackProvider = availableProviders.first {
+                let note = "\(requestedProvider.displayName) isn't installed; using \(fallbackProvider.displayName) instead."
+                let resolvedTitle = normalizedTitle(title, provider: fallbackProvider)
+                return .spawn(
+                    AgentSpawnPlan(
+                        harnessOverride: fallbackProvider.harnessMode,
+                        title: resolvedTitle,
+                        ack: note,
+                        selectedProvider: fallbackProvider,
+                        usedFallback: true,
+                        fallbackNote: note,
+                        context: spawnContext(
+                            taskKind: taskKind,
+                            explicitProvider: nil,
+                            selectedHarness: fallbackProvider.harnessMode,
+                            environment: environment,
+                            fileManager: fileManager,
+                            homeDirectory: homeDirectory
+                        )
+                    )
+                )
+            }
+        }
+
+        if let primary = availableProviders.first {
+            let resolvedTitle = normalizedTitle(title, provider: primary)
+            return .spawn(
+                AgentSpawnPlan(
+                    harnessOverride: primary.harnessMode,
+                    title: resolvedTitle,
+                    ack: "Starting \(primary.displayName).",
+                    selectedProvider: primary,
+                    usedFallback: false,
+                    fallbackNote: nil,
+                    context: spawnContext(
+                        taskKind: taskKind,
+                        explicitProvider: nil,
+                        selectedHarness: primary.harnessMode,
+                        environment: environment,
+                        fileManager: fileManager,
+                        homeDirectory: homeDirectory
+                    )
+                )
+            )
+        }
+
+        let resolvedTitle = normalizedTitle(title, provider: nil)
+        return .spawn(
+            AgentSpawnPlan(
+                harnessOverride: nil,
+                title: resolvedTitle,
+                ack: "Starting a background agent.",
+                selectedProvider: nil,
+                usedFallback: false,
+                fallbackNote: nil,
+                context: spawnContext(
+                    taskKind: taskKind,
+                    explicitProvider: nil,
+                    selectedHarness: nil,
+                    environment: environment,
+                    fileManager: fileManager,
+                    homeDirectory: homeDirectory
+                )
+            )
+        )
+    }
+
+    private static func normalizedTitle(
+        _ title: String?,
+        provider: AgentPillsManager.DirectedProvider?
+    ) -> String {
+        let trimmed = title?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        if !trimmed.isEmpty { return trimmed }
+        return provider?.displayName ?? "Background agent"
+    }
+
+    private static func spawnContext(
+        taskKind: AgentTaskKind,
+        explicitProvider: AgentPillsManager.DirectedProvider?,
+        selectedHarness: AgentHarnessMode?,
+        environment: [String: String],
+        fileManager: FileManager,
+        homeDirectory: String
+    ) -> AgentSpawnContext {
+        let availableHarnesses = preferredProviders(for: taskKind)
+            .filter {
+                LocalAgentProviderDetector.isAvailable(
+                    $0,
+                    environment: environment,
+                    fileManager: fileManager,
+                    homeDirectory: homeDirectory
+                )
+            }
+            .map(\.harnessMode)
+        let fallbackChain = availableHarnesses + [nil]
+        return AgentSpawnContext(
+            taskKind: taskKind,
+            explicitProvider: explicitProvider,
+            fallbackChain: fallbackChain,
+            attemptedHarnesses: [selectedHarness]
+        )
+    }
+}
+
+enum LocalAgentProviderInstaller {
+    /// Only Codex can be auto-installed (non-interactive `npm install -g`).
+    /// Hermes needs interactive `hermes model` setup; OpenClaw has no public install.
+    static func canAutoInstall(_ provider: AgentPillsManager.DirectedProvider) -> Bool {
+        provider == .codex
+    }
+
+    static func installingStatus(for provider: AgentPillsManager.DirectedProvider) -> String {
+        switch provider {
+        case .codex:
+            return "Codex isn't installed. Installing it for you now — this takes a moment."
+        case .hermes, .openclaw:
+            return "\(provider.displayName) needs manual setup."
+        }
+    }
+
+    static func install(
+        _ provider: AgentPillsManager.DirectedProvider,
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        fileManager: FileManager = .default,
+        homeDirectory: String = NSHomeDirectory()
+    ) async -> Bool {
+        switch provider {
+        case .codex:
+            return await installCodex(
+                environment: environment,
+                fileManager: fileManager,
+                homeDirectory: homeDirectory
+            )
+        case .hermes, .openclaw:
+            return false
+        }
+    }
+
+    private static func installCodex(
+        environment: [String: String],
+        fileManager: FileManager,
+        homeDirectory: String
+    ) async -> Bool {
+        guard let npmPath = findExecutable(
+            named: "npm",
+            environment: environment,
+            fileManager: fileManager,
+            homeDirectory: homeDirectory
+        ) else { return false }
+
+        // `npm` is a Node script; a LaunchServices-launched GUI app inherits only a
+        // minimal PATH, so prepend npm's own dir (which also holds `node`) to PATH,
+        // otherwise the npm shebang can't find node and the install silently fails.
+        let npmDir = (npmPath as NSString).deletingLastPathComponent
+        var childEnv = environment
+        let existingPath = childEnv["PATH"] ?? "/usr/bin:/bin"
+        childEnv["PATH"] = "\(npmDir):\(existingPath)"
+
+        return await withCheckedContinuation { continuation in
+            DispatchQueue.global(qos: .userInitiated).async {
+                let process = Process()
+                process.executableURL = URL(fileURLWithPath: npmPath)
+                process.arguments = ["install", "-g", "@openai/codex"]
+                process.environment = childEnv
+                let sink = Pipe()
+                process.standardOutput = sink
+                process.standardError = sink
+
+                // Guard against a hung npm (registry stall, unexpected prompt): kill
+                // it after a bounded wait so the awaiting spawn path never blocks forever.
+                let timeout = DispatchWorkItem {
+                    if process.isRunning { process.terminate() }
+                }
+                DispatchQueue.global().asyncAfter(deadline: .now() + 180, execute: timeout)
+
+                do {
+                    try process.run()
+                    process.waitUntilExit()
+                    timeout.cancel()
+                    continuation.resume(returning: process.terminationStatus == 0)
+                } catch {
+                    timeout.cancel()
+                    continuation.resume(returning: false)
+                }
+            }
+        }
+    }
+
+    private static func findExecutable(
+        named name: String,
+        environment: [String: String],
+        fileManager: FileManager,
+        homeDirectory: String
+    ) -> String? {
+        if let path = environment["PATH"] {
+            for dir in path.split(separator: ":").map(String.init) {
+                let full = (dir as NSString).appendingPathComponent(name)
+                if fileManager.isExecutableFile(atPath: full) {
+                    return full
+                }
+            }
+        }
+        for dir in LocalAgentProviderDetector.adapterActivationSearchDirectories(
+            homeDirectory: homeDirectory,
+            fileManager: fileManager
+        ) {
+            let full = (dir as NSString).appendingPathComponent(name)
+            if fileManager.isExecutableFile(atPath: full) {
+                return full
+            }
+        }
+        return nil
+    }
+}
+
+extension LocalAgentProviderRouting {
+    /// Resolve a spawn, auto-installing Codex if the user explicitly asked for it
+    /// but it's not installed. Calls `onInstallStart` before the install runs so
+    /// the caller can speak/show a status message. Returns the final resolution.
+    static func resolveSpawnWithAutoInstall(
+        brief: String,
+        requestedProvider: AgentPillsManager.DirectedProvider?,
+        userRequestText: String?,
+        title: String?,
+        onInstallStart: ((AgentPillsManager.DirectedProvider) -> Void)? = nil,
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        fileManager: FileManager = .default,
+        homeDirectory: String = NSHomeDirectory()
+    ) async -> Resolution {
+        let resolution = resolveSpawn(
+            brief: brief,
+            requestedProvider: requestedProvider,
+            userRequestText: userRequestText,
+            title: title,
+            environment: environment,
+            fileManager: fileManager,
+            homeDirectory: homeDirectory
+        )
+
+        guard case .setupRequired(let provider, _, _) = resolution,
+              LocalAgentProviderInstaller.canAutoInstall(provider)
+        else { return resolution }
+
+        onInstallStart?(provider)
+        let installed = await LocalAgentProviderInstaller.install(
+            provider,
+            environment: environment,
+            fileManager: fileManager,
+            homeDirectory: homeDirectory
+        )
+
+        guard installed else { return resolution }
+
+        return resolveSpawn(
+            brief: brief,
+            requestedProvider: requestedProvider,
+            userRequestText: userRequestText,
+            title: title,
+            environment: environment,
+            fileManager: fileManager,
+            homeDirectory: homeDirectory
+        )
     }
 }

--- a/desktop/macos/Desktop/Sources/Providers/AgentRuntimeRouting.swift
+++ b/desktop/macos/Desktop/Sources/Providers/AgentRuntimeRouting.swift
@@ -86,6 +86,19 @@ struct LocalAgentProviderAvailability: Equatable {
         return false
     }
 
+    /// Concise speech-friendly install guidance (no URLs/backticks).
+    /// The full `setupPrompt` (with exact commands) goes to the UI/tool output.
+    var spokenInstallGuide: String {
+        switch provider {
+        case .hermes:
+            return "I don't see Hermes installed. You can install it from the Nous Research GitHub with pip install, then run hermes model to configure it. Check the chat for the full steps."
+        case .openclaw:
+            return "I don't see OpenClaw installed. Install it on your path, or set the OMI openclaw adapter command environment variable. Check the chat for details."
+        case .codex:
+            return "I don't see Codex installed. Run npm install -g at openai codex, then run codex to sign in. Or I can install it for you — just ask."
+        }
+    }
+
     var setupPrompt: String {
         switch provider {
         case .hermes:
@@ -293,10 +306,10 @@ enum LocalAgentProviderRouting {
         let lower = message.lowercased()
         return lower.contains("not available")
             || lower.contains("failed to start")
-            || lower.contains("adapter")
             || lower.contains("enoent")
             || lower.contains("command not found")
-            || lower.contains("activation")
+            || lower.contains("spawn")
+            || lower.contains("no such file")
     }
 
     static func resolveSpawn(
@@ -312,12 +325,14 @@ enum LocalAgentProviderRouting {
         // Only treat a provider as user-directed when it appears in the user's own
         // words. The model-authored `brief` often names a provider the model chose
         // (e.g. "use Hermes to refactor…") even when the user never said it.
-        // Match a bare mention ("codex", "use codex", "install codex"), not just a
-        // verb+name directive, so any task that names an agent routes to it.
+        // Prefer a verb-based match ("use codex") over a bare mention so negated
+        // phrases like "don't use Hermes, use Codex" route to the positively-
+        // requested provider, not the first one that appears as a substring.
         let userText = userRequestText?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        let explicit = userText.isEmpty ? nil : AgentPillsManager.DirectedProvider.allCases.first {
-            isExplicitProviderRequest($0, in: userText)
-        }
+        let explicit = userText.isEmpty ? nil : (explicitProvider(in: userText)
+            ?? AgentPillsManager.DirectedProvider.allCases.first {
+                isExplicitProviderRequest($0, in: userText)
+            })
 
         if let explicit {
             let availability = LocalAgentProviderDetector.availability(
@@ -330,7 +345,7 @@ enum LocalAgentProviderRouting {
                 return .setupRequired(
                     provider: explicit,
                     prompt: availability.setupPrompt,
-                    spokenStatus: explicit.setupNeededStatus
+                    spokenStatus: availability.spokenInstallGuide
                 )
             }
             let resolvedTitle = normalizedTitle(title, provider: explicit)
@@ -364,56 +379,38 @@ enum LocalAgentProviderRouting {
             )
         }
 
-        if let requestedProvider {
-            if LocalAgentProviderDetector.isAvailable(
-                requestedProvider,
-                environment: environment,
-                fileManager: fileManager,
-                homeDirectory: homeDirectory
-            ) {
-                let resolvedTitle = normalizedTitle(title, provider: requestedProvider)
-                return .spawn(
-                    AgentSpawnPlan(
-                        harnessOverride: requestedProvider.harnessMode,
-                        title: resolvedTitle,
-                        ack: "Starting \(requestedProvider.displayName).",
-                        selectedProvider: requestedProvider,
-                        usedFallback: false,
-                        fallbackNote: nil,
-                        context: spawnContext(
-                            taskKind: taskKind,
-                            explicitProvider: nil,
-                            selectedHarness: requestedProvider.harnessMode,
-                            environment: environment,
-                            fileManager: fileManager,
-                            homeDirectory: homeDirectory
-                        )
+        // When the user didn't explicitly name a provider, use the task-based
+        // preference ranking — the model's `requestedProvider` suggestion should
+        // NOT override the smart routing (e.g. model picking OpenClaw for a coding
+        // task when Codex is the preferred and installed choice).
+        // Exception: if the model's pick isn't installed and we DO have an
+        // installed fallback, speak the fallback note so the user knows.
+        if let requestedProvider, !LocalAgentProviderDetector.isAvailable(
+            requestedProvider,
+            environment: environment,
+            fileManager: fileManager,
+            homeDirectory: homeDirectory
+        ), let fallbackProvider = availableProviders.first {
+            let note = "\(requestedProvider.displayName) isn't installed; using \(fallbackProvider.displayName) instead."
+            let resolvedTitle = normalizedTitle(title, provider: fallbackProvider)
+            return .spawn(
+                AgentSpawnPlan(
+                    harnessOverride: fallbackProvider.harnessMode,
+                    title: resolvedTitle,
+                    ack: note,
+                    selectedProvider: fallbackProvider,
+                    usedFallback: true,
+                    fallbackNote: note,
+                    context: spawnContext(
+                        taskKind: taskKind,
+                        explicitProvider: nil,
+                        selectedHarness: fallbackProvider.harnessMode,
+                        environment: environment,
+                        fileManager: fileManager,
+                        homeDirectory: homeDirectory
                     )
                 )
-            }
-
-            if let fallbackProvider = availableProviders.first {
-                let note = "\(requestedProvider.displayName) isn't installed; using \(fallbackProvider.displayName) instead."
-                let resolvedTitle = normalizedTitle(title, provider: fallbackProvider)
-                return .spawn(
-                    AgentSpawnPlan(
-                        harnessOverride: fallbackProvider.harnessMode,
-                        title: resolvedTitle,
-                        ack: note,
-                        selectedProvider: fallbackProvider,
-                        usedFallback: true,
-                        fallbackNote: note,
-                        context: spawnContext(
-                            taskKind: taskKind,
-                            explicitProvider: nil,
-                            selectedHarness: fallbackProvider.harnessMode,
-                            environment: environment,
-                            fileManager: fileManager,
-                            homeDirectory: homeDirectory
-                        )
-                    )
-                )
-            }
+            )
         }
 
         if let primary = availableProviders.first {

--- a/desktop/macos/Desktop/Sources/Providers/AgentRuntimeRouting.swift
+++ b/desktop/macos/Desktop/Sources/Providers/AgentRuntimeRouting.swift
@@ -302,6 +302,22 @@ enum LocalAgentProviderRouting {
         }
     }
 
+    /// Whether the provider name is preceded by a negation word, so a bare
+    /// mention like "don't use Hermes" does not count as an explicit request.
+    private static func isNegated(
+        _ provider: AgentPillsManager.DirectedProvider,
+        in text: String
+    ) -> Bool {
+        let lower = text.lowercased()
+        let name = provider.rawValue
+        let negationPhrases = [
+            "don't use \(name)", "dont use \(name)", "don't ask \(name)",
+            "dont ask \(name)", "not \(name)", "no \(name)",
+            "without \(name)", "instead of \(name)",
+        ]
+        return negationPhrases.contains { lower.contains($0) }
+    }
+
     static func isRetriableSpawnFailure(_ message: String) -> Bool {
         let lower = message.lowercased()
         return lower.contains("not available")
@@ -317,6 +333,7 @@ enum LocalAgentProviderRouting {
         requestedProvider: AgentPillsManager.DirectedProvider?,
         userRequestText: String?,
         title: String?,
+        treatRequestedAsExplicit: Bool = false,
         environment: [String: String] = ProcessInfo.processInfo.environment,
         fileManager: FileManager = .default,
         homeDirectory: String = NSHomeDirectory()
@@ -328,39 +345,43 @@ enum LocalAgentProviderRouting {
         // Prefer a verb-based match ("use codex") over a bare mention so negated
         // phrases like "don't use Hermes, use Codex" route to the positively-
         // requested provider, not the first one that appears as a substring.
+        // Negated mentions ("don't use X") are excluded from the bare fallback.
         let userText = userRequestText?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         let explicit = userText.isEmpty ? nil : (explicitProvider(in: userText)
             ?? AgentPillsManager.DirectedProvider.allCases.first {
-                isExplicitProviderRequest($0, in: userText)
+                isExplicitProviderRequest($0, in: userText) && !isNegated($0, in: userText)
             })
+        // For the chat tool (no user transcript), the model's `provider` argument
+        // is deliberate explicit intent — treat it like a user-directive.
+        let effectiveExplicit = explicit ?? (treatRequestedAsExplicit ? requestedProvider : nil)
 
-        if let explicit {
+        if let effectiveExplicit {
             let availability = LocalAgentProviderDetector.availability(
-                for: explicit,
+                for: effectiveExplicit,
                 environment: environment,
                 fileManager: fileManager,
                 homeDirectory: homeDirectory
             )
             guard availability.isAvailable else {
                 return .setupRequired(
-                    provider: explicit,
+                    provider: effectiveExplicit,
                     prompt: availability.setupPrompt,
                     spokenStatus: availability.spokenInstallGuide
                 )
             }
-            let resolvedTitle = normalizedTitle(title, provider: explicit)
+            let resolvedTitle = normalizedTitle(title, provider: effectiveExplicit)
             return .spawn(
                 AgentSpawnPlan(
-                    harnessOverride: explicit.harnessMode,
+                    harnessOverride: effectiveExplicit.harnessMode,
                     title: resolvedTitle,
-                    ack: "Asking \(explicit.displayName).",
-                    selectedProvider: explicit,
+                    ack: "Asking \(effectiveExplicit.displayName).",
+                    selectedProvider: effectiveExplicit,
                     usedFallback: false,
                     fallbackNote: nil,
                     context: spawnContext(
                         taskKind: taskKind,
-                        explicitProvider: explicit,
-                        selectedHarness: explicit.harnessMode,
+                        explicitProvider: effectiveExplicit,
+                        selectedHarness: effectiveExplicit.harnessMode,
                         environment: environment,
                         fileManager: fileManager,
                         homeDirectory: homeDirectory
@@ -613,6 +634,7 @@ extension LocalAgentProviderRouting {
         requestedProvider: AgentPillsManager.DirectedProvider?,
         userRequestText: String?,
         title: String?,
+        treatRequestedAsExplicit: Bool = false,
         onInstallStart: ((AgentPillsManager.DirectedProvider) -> Void)? = nil,
         environment: [String: String] = ProcessInfo.processInfo.environment,
         fileManager: FileManager = .default,
@@ -623,6 +645,7 @@ extension LocalAgentProviderRouting {
             requestedProvider: requestedProvider,
             userRequestText: userRequestText,
             title: title,
+            treatRequestedAsExplicit: treatRequestedAsExplicit,
             environment: environment,
             fileManager: fileManager,
             homeDirectory: homeDirectory
@@ -647,6 +670,7 @@ extension LocalAgentProviderRouting {
             requestedProvider: requestedProvider,
             userRequestText: userRequestText,
             title: title,
+            treatRequestedAsExplicit: treatRequestedAsExplicit,
             environment: environment,
             fileManager: fileManager,
             homeDirectory: homeDirectory

--- a/desktop/macos/Desktop/Sources/Providers/AgentRuntimeRouting.swift
+++ b/desktop/macos/Desktop/Sources/Providers/AgentRuntimeRouting.swift
@@ -5,6 +5,7 @@ enum AgentHarnessMode: String {
     case acp = "acp"
     case hermes = "hermes"
     case openclaw = "openclaw"
+    case codex = "codex"
 }
 
 extension Optional where Wrapped == AgentHarnessMode {
@@ -19,6 +20,7 @@ enum AgentAdapterId: String {
     case acp = "acp"
     case hermes = "hermes"
     case openclaw = "openclaw"
+    case codex = "codex"
 }
 
 enum AgentRuntimeRouting {
@@ -32,6 +34,8 @@ enum AgentRuntimeRouting {
             return .hermes
         case .openClaw:
             return .openclaw
+        case .codex:
+            return .codex
         }
     }
 
@@ -45,6 +49,8 @@ enum AgentRuntimeRouting {
             return .hermes
         case AgentHarnessMode.openclaw.rawValue, "openClaw":
             return .openclaw
+        case AgentHarnessMode.codex.rawValue:
+            return .codex
         default:
             return nil
         }
@@ -60,6 +66,8 @@ enum AgentRuntimeRouting {
             return .hermes
         case .openclaw:
             return .openclaw
+        case .codex:
+            return .codex
         }
     }
 }
@@ -84,6 +92,8 @@ struct LocalAgentProviderAvailability: Equatable {
             return "I don't see Hermes installed. Make sure Hermes is installed first, then try again."
         case .openclaw:
             return "I don't see OpenClaw installed. Make sure OpenClaw is installed first, then try again."
+        case .codex:
+            return "I don't see Codex installed. Please run 'npm install -g @openai/codex' and run 'codex' in your terminal to sign in, then try again."
         }
     }
 
@@ -152,6 +162,8 @@ enum LocalAgentProviderDetector {
             "\(homeDirectory)/.hermes/node/bin",
             "\(homeDirectory)/.hermes/hermes-agent",
             "\(homeDirectory)/.local/bin",
+            "\(homeDirectory)/.npm-global/bin",
+            "\(homeDirectory)/.volta/bin",
             "/opt/homebrew/bin",
             "/usr/local/bin",
         ]

--- a/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
@@ -1318,7 +1318,7 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
             // Hermes and OpenClaw ignore Omi's Claude model aliases, so leave
             // the model hint nil to avoid recording a model ID in binding metadata
             // that could trigger spurious context-changed sessions later.
-            let usesNativeModelChoice = activeBridgeHarness == "hermes" || activeBridgeHarness == "openclaw"
+            let usesNativeModelChoice = activeBridgeHarness == "hermes" || activeBridgeHarness == "openclaw" || activeBridgeHarness == "codex"
             let mainWarmupModel = usesNativeModelChoice ? nil : ModelQoS.Claude.chat
             let floatingWarmupModel = usesNativeModelChoice ? nil : floatingModel
             await agentBridge.warmupSession(cwd: workingDirectory, sessions: [
@@ -3404,7 +3404,7 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
             // Query the active bridge with streaming. Hermes and OpenClaw do not
             // accept Omi's Claude model aliases, so leave model choice to the
             // harness default when either native adapter is active.
-            let usesNativeModelChoice = activeBridgeHarness == "hermes" || activeBridgeHarness == "openclaw"
+            let usesNativeModelChoice = activeBridgeHarness == "hermes" || activeBridgeHarness == "openclaw" || activeBridgeHarness == "codex"
             let effectiveRequestModel = usesNativeModelChoice ? nil : (model ?? modelOverride)
 
             // Callbacks for agent bridge

--- a/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
@@ -902,6 +902,7 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
         case piMono = "piMono"
         case hermes = "hermes"
         case openClaw = "openclaw"
+        case codex = "codex"
     }
     @AppStorage("chatBridgeMode") var bridgeMode: String = BridgeMode.piMono.rawValue
 

--- a/desktop/macos/Desktop/Sources/Providers/ChatToolExecutor.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatToolExecutor.swift
@@ -469,35 +469,44 @@ class ChatToolExecutor {
       .trimmingCharacters(in: .whitespacesAndNewlines)
       .lowercased()
       .replacingOccurrences(of: " ", with: "")
-    let directedProvider: AgentPillsManager.DirectedProvider?
+    let requestedProvider: AgentPillsManager.DirectedProvider?
     switch providerName {
-    case "openclaw": directedProvider = .openclaw
-    case "hermes": directedProvider = .hermes
-    case "": directedProvider = nil
+    case "openclaw": requestedProvider = .openclaw
+    case "hermes": requestedProvider = .hermes
+    case "codex": requestedProvider = .codex
+    case "": requestedProvider = nil
     default:
-      return "Error: Unsupported provider '\(providerName)'. Supported providers: openclaw, hermes."
+      return "Error: Unsupported provider '\(providerName)'. Supported providers: openclaw, hermes, codex."
     }
-    if let directedProvider {
-      let availability = LocalAgentProviderDetector.availability(for: directedProvider)
-      guard availability.isAvailable else {
-        return availability.toolError
-      }
-    }
-    let model = ShortcutSettings.shared.selectedModel.isEmpty
-      ? "claude-sonnet-4-6" : ShortcutSettings.shared.selectedModel
-    let pill = AgentPillsManager.shared.spawnFromUserQuery(
-      brief,
-      model: model,
-      fromVoice: false,
-      preFetchedTitle: (title?.isEmpty == false) ? title : directedProvider?.displayName,
-      bridgeHarnessOverride: directedProvider?.harnessMode
+    let resolution = await LocalAgentProviderRouting.resolveSpawnWithAutoInstall(
+      brief: brief,
+      requestedProvider: requestedProvider,
+      userRequestText: nil,
+      title: title
     )
-    return """
-    Agent started as a floating agent pill.
-    id: \(pill.id.uuidString)
-    title: \(pill.title)
-    status: \(pill.status.displayLabel)
-    """
+    switch resolution {
+    case .setupRequired(_, let setupPrompt, _):
+      return "Error: \(setupPrompt)"
+    case .spawn(let plan):
+      let model = ShortcutSettings.shared.selectedModel.isEmpty
+        ? "claude-sonnet-4-6" : ShortcutSettings.shared.selectedModel
+      let pill = AgentPillsManager.shared.spawnFromUserQuery(
+        brief,
+        model: model,
+        fromVoice: false,
+        preFetchedTitle: plan.title,
+        preFetchedAck: plan.ack,
+        bridgeHarnessOverride: plan.harnessOverride,
+        spawnContext: plan.context
+      )
+      let fallbackLine = plan.fallbackNote.map { "\nfallback: \($0)" } ?? ""
+      return """
+      Agent started as a floating agent pill.
+      id: \(pill.id.uuidString)
+      title: \(pill.title)
+      status: \(pill.status.displayLabel)\(fallbackLine)
+      """
+    }
   }
 
   private static func executeManageAgentPills(_ args: [String: Any]) async -> String {

--- a/desktop/macos/Desktop/Sources/Providers/ChatToolExecutor.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatToolExecutor.swift
@@ -482,7 +482,8 @@ class ChatToolExecutor {
       brief: brief,
       requestedProvider: requestedProvider,
       userRequestText: nil,
-      title: title
+      title: title,
+      treatRequestedAsExplicit: true
     )
     switch resolution {
     case .setupRequired(_, let setupPrompt, _):

--- a/desktop/macos/Desktop/Tests/AgentPillLifecycleTests.swift
+++ b/desktop/macos/Desktop/Tests/AgentPillLifecycleTests.swift
@@ -47,12 +47,12 @@ final class AgentPillLifecycleTests: XCTestCase {
   func testTypedProviderDirectivePromptsForSetupWhenProviderUnavailable() throws {
     let source = try floatingControlBarWindowSource()
 
-    XCTAssertTrue(source.contains("LocalAgentProviderDetector.availability(for: directive.provider)"))
-    XCTAssertTrue(source.contains("guard availability.isAvailable else"))
+    XCTAssertTrue(source.contains("LocalAgentProviderRouting.resolveSpawnWithAutoInstall("))
+    XCTAssertTrue(source.contains("requestedProvider: directive.provider"))
     XCTAssertTrue(source.contains("floating-agent-provider-unavailable"))
     XCTAssertTrue(source.contains("completeVisibleAgentResponse("))
     XCTAssertFalse(source.contains("completeVisibleProviderSetupPrompt("))
-    XCTAssertTrue(source.contains("FloatingBarVoicePlaybackService.shared.speakOneShot(directive.provider.setupNeededStatus)"))
+    XCTAssertTrue(source.contains("FloatingBarVoicePlaybackService.shared.speakOneShot(spokenStatus)"))
   }
 
   func testSubagentChatSpawnRequestCreatesSiblingAgent() throws {
@@ -309,7 +309,7 @@ final class AgentPillLifecycleTests: XCTestCase {
     XCTAssertTrue(source.contains("let handoff = AgentPillsManager.floatingAgentHandoff(for: message)"))
     XCTAssertTrue(source.contains("AgentPillsManager.shared.spawnFromHandoff("))
     XCTAssertTrue(source.contains("completeVisibleAgentHandoff(\n                    handoff,\n                    pill: pill"))
-    XCTAssertTrue(source.contains("completeVisibleAgentHandoff(\n                    .init(originalRequest: message, agentTask: message),\n                    pill: pill"))
+    XCTAssertTrue(source.contains("completeVisibleAgentHandoff(\n                        .init(originalRequest: message, agentTask: message),\n                        pill: pill"))
     XCTAssertTrue(source.contains("let toolUseId = \"floating-agent-\\(pill.id.uuidString)\""))
     XCTAssertTrue(source.contains("name: \"spawn_agent\""))
     XCTAssertTrue(source.contains("status: .completed"))

--- a/desktop/macos/Desktop/Tests/AgentRuntimeProcessTests.swift
+++ b/desktop/macos/Desktop/Tests/AgentRuntimeProcessTests.swift
@@ -56,6 +56,7 @@ final class AgentRuntimeProcessTests: XCTestCase {
     XCTAssertEqual(AgentRuntimeProcess.adapterId(forHarnessMode: "hermes"), "hermes")
     XCTAssertEqual(AgentRuntimeProcess.adapterId(forHarnessMode: "openclaw"), "openclaw")
     XCTAssertEqual(AgentRuntimeProcess.adapterId(forHarnessMode: "openClaw"), "openclaw")
+    XCTAssertEqual(AgentRuntimeProcess.adapterId(forHarnessMode: "codex"), "codex")
     XCTAssertNil(AgentRuntimeProcess.adapterId(forHarnessMode: "unknown"))
   }
 
@@ -162,6 +163,9 @@ final class AgentRuntimeProcessTests: XCTestCase {
     XCTAssertTrue(source.contains(#"env["PATH"] = pathElements.joined(separator: ":")"#))
     XCTAssertTrue(source.contains(#"env["OMI_OPENCLAW_ADAPTER_COMMAND"]"#))
     XCTAssertTrue(source.contains(#"env["OMI_HERMES_ADAPTER_COMMAND"]"#))
+    XCTAssertTrue(source.contains(#"env["OMI_CODEX_ADAPTER_COMMAND"]"#))
+    XCTAssertTrue(source.contains(#""\(home)/.npm-global/bin""#))
+    XCTAssertTrue(source.contains(#""\(home)/.volta/bin""#))
   }
 
   func testOpenClawAdapterCommandUsesSiblingNodeWhenAvailable() throws {
@@ -195,6 +199,15 @@ final class AgentRuntimeProcessTests: XCTestCase {
     let command = AgentRuntimeProcess.openClawAdapterCommand(openClawPath: openClawPath)
 
     XCTAssertEqual(command, "'\(openClawPath)' acp")
+  }
+
+  func testCodexAdapterCommandWrapsDetectedBinaryWithACPBridge() {
+    let command = AgentRuntimeProcess.codexAdapterCommand(codexPath: "/opt/homebrew/bin/codex")
+
+    XCTAssertEqual(
+      command,
+      "CODEX_PATH='/opt/homebrew/bin/codex' npx -y @agentclientprotocol/codex-acp"
+    )
   }
 
   func testStdoutReaderIsEventDrivenInsteadOfDetachedAvailableDataLoop() throws {

--- a/desktop/macos/Desktop/Tests/LocalAgentProviderRoutingTests.swift
+++ b/desktop/macos/Desktop/Tests/LocalAgentProviderRoutingTests.swift
@@ -116,4 +116,58 @@ final class LocalAgentProviderRoutingTests: XCTestCase {
         XCTAssertFalse(LocalAgentProviderRouting.isRetriableSpawnFailure("Could not find the email thread"))
         XCTAssertFalse(LocalAgentProviderRouting.isRetriableSpawnFailure("Could not parse adapter response: invalid JSON"))
     }
+
+    func testNegatedProviderMentionDoesNotRouteToThatProvider() {
+        let resolution = LocalAgentProviderRouting.resolveSpawn(
+            brief: "write a script",
+            requestedProvider: nil,
+            userRequestText: "don't use hermes, use codex",
+            title: nil,
+            environment: [:],
+            fileManager: FileManager(),
+            homeDirectory: "/tmp/omi-routing-test"
+        )
+
+        guard case .setupRequired(let provider, _, _) = resolution else {
+            return XCTFail("Expected setupRequired for codex (not installed), got \(resolution)")
+        }
+        XCTAssertEqual(provider, .codex, "should route to the positively-requested provider, not the negated one")
+    }
+
+    func testChatToolProviderArgTreatedAsExplicit() {
+        let resolution = LocalAgentProviderRouting.resolveSpawn(
+            brief: "write a script",
+            requestedProvider: .hermes,
+            userRequestText: nil,
+            title: nil,
+            treatRequestedAsExplicit: true,
+            environment: [:],
+            fileManager: FileManager(),
+            homeDirectory: "/tmp/omi-routing-test"
+        )
+
+        guard case .setupRequired(let provider, _, _) = resolution else {
+            return XCTFail("Expected setupRequired for hermes (not installed), got \(resolution)")
+        }
+        XCTAssertEqual(provider, .hermes, "chat tool's provider arg should be treated as explicit")
+    }
+
+    func testChatToolProviderArgIgnoredWhenNotExplicit() {
+        let env = ["OMI_CODEX_ADAPTER_COMMAND": "/tmp/codex"]
+        let resolution = LocalAgentProviderRouting.resolveSpawn(
+            brief: "write a python script",
+            requestedProvider: .openclaw,
+            userRequestText: nil,
+            title: nil,
+            treatRequestedAsExplicit: false,
+            environment: env,
+            fileManager: FileManager(),
+            homeDirectory: "/tmp/omi-routing-test"
+        )
+
+        guard case .spawn(let plan) = resolution else {
+            return XCTFail("Expected spawn via task-based ranking, got \(resolution)")
+        }
+        XCTAssertEqual(plan.selectedProvider, .codex, "without explicit intent, task-based ranking should pick codex for coding, not the model's openclaw")
+    }
 }

--- a/desktop/macos/Desktop/Tests/LocalAgentProviderRoutingTests.swift
+++ b/desktop/macos/Desktop/Tests/LocalAgentProviderRoutingTests.swift
@@ -111,6 +111,9 @@ final class LocalAgentProviderRoutingTests: XCTestCase {
 
     func testIsRetriableSpawnFailureMatchesInfrastructureErrors() {
         XCTAssertTrue(LocalAgentProviderRouting.isRetriableSpawnFailure("AI not available: adapter failed"))
+        XCTAssertTrue(LocalAgentProviderRouting.isRetriableSpawnFailure("ENOENT: no such file or directory"))
+        XCTAssertTrue(LocalAgentProviderRouting.isRetriableSpawnFailure("Failed to start child process"))
         XCTAssertFalse(LocalAgentProviderRouting.isRetriableSpawnFailure("Could not find the email thread"))
+        XCTAssertFalse(LocalAgentProviderRouting.isRetriableSpawnFailure("Could not parse adapter response: invalid JSON"))
     }
 }

--- a/desktop/macos/Desktop/Tests/LocalAgentProviderRoutingTests.swift
+++ b/desktop/macos/Desktop/Tests/LocalAgentProviderRoutingTests.swift
@@ -1,0 +1,116 @@
+import XCTest
+
+@testable import Omi_Computer
+
+final class LocalAgentProviderRoutingTests: XCTestCase {
+    func testClassifyTaskDetectsCoding() {
+        XCTAssertEqual(
+            LocalAgentProviderRouting.classifyTask("debug this python script"),
+            .coding
+        )
+    }
+
+    func testClassifyTaskDetectsAutomation() {
+        XCTAssertEqual(
+            LocalAgentProviderRouting.classifyTask("automate sending this email"),
+            .automation
+        )
+    }
+
+    func testModelBriefMentioningHermesDoesNotCountAsExplicitUserRequest() {
+        let env = ["OMI_CODEX_ADAPTER_COMMAND": "/tmp/codex"]
+        let resolution = LocalAgentProviderRouting.resolveSpawn(
+            brief: "Use Hermes to refactor the auth module",
+            requestedProvider: .hermes,
+            userRequestText: nil,
+            title: nil,
+            environment: env,
+            fileManager: FileManager(),
+            homeDirectory: "/tmp/omi-routing-test"
+        )
+
+        guard case .spawn(let plan) = resolution else {
+            return XCTFail("Expected spawn fallback to Codex, got \(resolution)")
+        }
+        XCTAssertEqual(plan.selectedProvider, .codex)
+        XCTAssertTrue(plan.usedFallback)
+    }
+
+    func testExplicitHermesInUserTextStillRequiresSetupWhenMissing() {
+        let resolution = LocalAgentProviderRouting.resolveSpawn(
+            brief: "fix the bug",
+            requestedProvider: .hermes,
+            userRequestText: "use hermes to fix the bug",
+            title: nil,
+            environment: [:],
+            fileManager: FileManager(),
+            homeDirectory: "/tmp/omi-routing-test"
+        )
+
+        guard case .setupRequired(let provider, let prompt, _) = resolution else {
+            return XCTFail("Expected setupRequired, got \(resolution)")
+        }
+        XCTAssertEqual(provider, .hermes)
+        XCTAssertTrue(prompt.contains("Hermes"))
+    }
+
+    func testSmartRoutingFallsBackWhenRequestedProviderMissing() {
+        let env = ["OMI_CODEX_ADAPTER_COMMAND": "/tmp/codex"]
+        let resolution = LocalAgentProviderRouting.resolveSpawn(
+            brief: "write a script to parse logs",
+            requestedProvider: .hermes,
+            userRequestText: "write a script to parse logs",
+            title: "Log parser",
+            environment: env,
+            fileManager: FileManager(),
+            homeDirectory: "/tmp/omi-routing-test"
+        )
+
+        guard case .spawn(let plan) = resolution else {
+            return XCTFail("Expected spawn, got \(resolution)")
+        }
+        XCTAssertEqual(plan.selectedProvider, .codex)
+        XCTAssertTrue(plan.usedFallback)
+        XCTAssertNotNil(plan.fallbackNote)
+        XCTAssertEqual(plan.harnessOverride, .codex)
+    }
+
+    func testSmartRoutingPicksCodexForCodingWhenAvailable() {
+        let env = [
+            "OMI_CODEX_ADAPTER_COMMAND": "/tmp/codex",
+            "OMI_OPENCLAW_ADAPTER_COMMAND": "/tmp/openclaw",
+        ]
+        let resolution = LocalAgentProviderRouting.resolveSpawn(
+            brief: "review this swift api change",
+            requestedProvider: nil,
+            userRequestText: "review this swift api change",
+            title: nil,
+            environment: env,
+            fileManager: FileManager(),
+            homeDirectory: "/tmp/omi-routing-test"
+        )
+
+        guard case .spawn(let plan) = resolution else {
+            return XCTFail("Expected spawn, got \(resolution)")
+        }
+        XCTAssertEqual(plan.selectedProvider, .codex)
+        XCTAssertFalse(plan.usedFallback)
+    }
+
+    func testSpawnContextAdvancesFallbackChain() {
+        var context = AgentSpawnContext(
+            taskKind: .coding,
+            explicitProvider: nil,
+            fallbackChain: [.codex, .openclaw, nil],
+            attemptedHarnesses: [.codex]
+        )
+        XCTAssertEqual(context.nextFallback(after: .codex), .some(.openclaw))
+        context.recordAttempt(.openclaw)
+        XCTAssertEqual(context.nextFallback(after: .openclaw), .some(nil))
+    }
+
+    func testIsRetriableSpawnFailureMatchesInfrastructureErrors() {
+        XCTAssertTrue(LocalAgentProviderRouting.isRetriableSpawnFailure("AI not available: adapter failed"))
+        XCTAssertFalse(LocalAgentProviderRouting.isRetriableSpawnFailure("Could not find the email thread"))
+    }
+}

--- a/desktop/macos/Desktop/Tests/PiMonoWiringTests.swift
+++ b/desktop/macos/Desktop/Tests/PiMonoWiringTests.swift
@@ -73,6 +73,25 @@ final class PiMonoWiringTests: XCTestCase {
     XCTAssertEqual(availability.status, .available(command: executable.path))
   }
 
+  func testLocalAgentProviderDetectorFindsCodexInNvmBin() throws {
+    let home = FileManager.default.temporaryDirectory
+      .appendingPathComponent("omi-provider-detector-\(UUID().uuidString)", isDirectory: true)
+    let bin = home.appendingPathComponent(".nvm/versions/node/v24.13.0/bin", isDirectory: true)
+    try FileManager.default.createDirectory(at: bin, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: home) }
+
+    let executable = bin.appendingPathComponent("codex")
+    try "#!/bin/sh\nexit 0\n".write(to: executable, atomically: true, encoding: .utf8)
+    try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: executable.path)
+
+    let availability = LocalAgentProviderDetector.availability(
+      for: .codex,
+      environment: [:],
+      homeDirectory: home.path)
+
+    XCTAssertEqual(availability.status, .available(command: executable.path))
+  }
+
   func testLocalAgentProviderDetectorIgnoresArbitraryPathEntries() throws {
     let root = FileManager.default.temporaryDirectory
       .appendingPathComponent("omi-provider-path-\(UUID().uuidString)", isDirectory: true)
@@ -100,10 +119,10 @@ final class PiMonoWiringTests: XCTestCase {
     XCTAssertFalse(availability.isAvailable)
     XCTAssertEqual(
       availability.setupPrompt,
-      "I don't see OpenClaw installed. Make sure OpenClaw is installed first, then try again.")
+      "I don't see OpenClaw installed. Install OpenClaw on your PATH, or set the OMI_OPENCLAW_ADAPTER_COMMAND environment variable to point Omi at your OpenClaw binary, then try again.")
     XCTAssertEqual(
       availability.toolError,
-      "Error: I don't see OpenClaw installed. Make sure OpenClaw is installed first, then try again.")
+      "Error: I don't see OpenClaw installed. Install OpenClaw on your PATH, or set the OMI_OPENCLAW_ADAPTER_COMMAND environment variable to point Omi at your OpenClaw binary, then try again.")
   }
 
   // MARK: - ApiKeysResponse shape assertion

--- a/desktop/macos/Desktop/Tests/RealtimeHubSpawnAgentTests.swift
+++ b/desktop/macos/Desktop/Tests/RealtimeHubSpawnAgentTests.swift
@@ -9,32 +9,28 @@ final class RealtimeHubSpawnAgentTests: XCTestCase {
     XCTAssertTrue(source.contains("private var suppressAssistantOutputForCurrentTurn = false"))
     XCTAssertTrue(source.contains("guard !suppressAssistantOutputForCurrentTurn else { return }"))
     XCTAssertTrue(source.contains("suppressAssistantOutputForCurrentTurn = true"))
-    XCTAssertTrue(source.contains("output: \"Agent started.\""))
+    XCTAssertTrue(source.contains("toolOutput = \"Agent started.\""))
+    XCTAssertTrue(source.contains("toolOutput = \"Agent started with fallback. \\(fallbackNote)\""))
     XCTAssertFalse(source.contains("Acknowledged before the call — do not say anything else"))
   }
 
   func testSpawnAgentProvidesLocalAckWhenModelDidNotSpeakBeforeToolCall() throws {
     let source = try realtimeHubControllerSource()
 
-    XCTAssertTrue(source.contains("if !audioReceivedThisTurn {"))
-    XCTAssertTrue(source.contains("let existingAck = assistantText.trimmingCharacters"))
-    XCTAssertTrue(source.contains("let ack = existingAck.isEmpty ? \"Starting a background agent.\" : existingAck"))
-    XCTAssertTrue(source.contains("speak(ack)"))
+    XCTAssertTrue(source.contains("if !self.audioReceivedThisTurn {"))
+    XCTAssertTrue(source.contains("let existingAck = self.assistantText.trimmingCharacters"))
+    XCTAssertTrue(source.contains("let ack = existingAck.isEmpty ? plan.ack : existingAck"))
+    XCTAssertTrue(source.contains("self.speak(ack)"))
   }
 
   func testSpawnAgentPreflightsDirectedProviderAvailability() throws {
     let source = try realtimeHubControllerSource()
 
-    XCTAssertTrue(source.contains("LocalAgentProviderDetector.availability(for: directedProvider)"))
-    XCTAssertTrue(source.contains("guard availability.isAvailable else"))
-    XCTAssertTrue(source.contains("assistantText = setupPrompt"))
-    XCTAssertTrue(source.contains("output: availability.toolError"))
-    XCTAssertTrue(source.contains("""
-          sendToolResultIfCurrent(
-            source: source, callId: callId, name: name,
-            output: availability.toolError)
-          return
-"""))
+    XCTAssertTrue(source.contains("LocalAgentProviderRouting.resolveSpawnWithAutoInstall("))
+    XCTAssertTrue(source.contains("case .setupRequired(let provider, let setupPrompt, _):"))
+    XCTAssertTrue(source.contains("self.assistantText = setupPrompt"))
+    XCTAssertTrue(source.contains("self.speak(setupPrompt)"))
+    XCTAssertTrue(source.contains("output: \"Error: \\(setupPrompt)\""))
   }
 
   func testCanonicalAgentControlSummariesDoNotSpeakOpaqueIds() throws {

--- a/desktop/macos/Desktop/Tests/RealtimeHubSpawnAgentTests.swift
+++ b/desktop/macos/Desktop/Tests/RealtimeHubSpawnAgentTests.swift
@@ -27,9 +27,9 @@ final class RealtimeHubSpawnAgentTests: XCTestCase {
     let source = try realtimeHubControllerSource()
 
     XCTAssertTrue(source.contains("LocalAgentProviderRouting.resolveSpawnWithAutoInstall("))
-    XCTAssertTrue(source.contains("case .setupRequired(let provider, let setupPrompt, _):"))
+    XCTAssertTrue(source.contains("case .setupRequired(let provider, let setupPrompt, let spokenStatus):"))
     XCTAssertTrue(source.contains("self.assistantText = setupPrompt"))
-    XCTAssertTrue(source.contains("self.speak(setupPrompt)"))
+    XCTAssertTrue(source.contains("self.speak(spokenStatus)"))
     XCTAssertTrue(source.contains("output: \"Error: \\(setupPrompt)\""))
   }
 

--- a/desktop/macos/agent/package-lock.json
+++ b/desktop/macos/agent/package-lock.json
@@ -1770,6 +1770,29 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.3.tgz",

--- a/desktop/macos/agent/package-lock.json
+++ b/desktop/macos/agent/package-lock.json
@@ -803,29 +803,6 @@
         "url": "https://github.com/sponsors/Borewit"
       }
     },
-    "node_modules/@emnapi/core": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
-      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.2",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
-      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
@@ -4264,6 +4241,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4828,6 +4806,7 @@
       "integrity": "sha512-BuJcQK/56NQTWDGn4ABea3q4SSBdNPWwNZKTkkUpcMPnLoquSYH8llRtSUIgoL1KSCpHt5eghLShn50mH36y7Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -5181,6 +5160,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/desktop/macos/agent/src/adapters/codex.ts
+++ b/desktop/macos/agent/src/adapters/codex.ts
@@ -1,0 +1,19 @@
+import { AcpRuntimeAdapter } from "./acp.js";
+
+export interface CodexRuntimeAdapterOptions {
+  command?: string;
+  log?: (message: string) => void;
+}
+
+export class CodexRuntimeAdapter extends AcpRuntimeAdapter {
+  constructor(options: CodexRuntimeAdapterOptions = {}) {
+    super({
+      adapterId: "codex",
+      envCommandName: "OMI_CODEX_ADAPTER_COMMAND",
+      command: options.command,
+      sessionMcpServersMode: "empty",
+      supportsSessionSetModel: false,
+      log: options.log,
+    });
+  }
+}

--- a/desktop/macos/agent/src/adapters/interface.ts
+++ b/desktop/macos/agent/src/adapters/interface.ts
@@ -254,6 +254,20 @@ export const ADAPTER_CAPABILITY_MATRIX = {
       restartOrphanSemantics: required("Startup reconciliation orphans active attempts while preserving native-resumable OpenClaw bindings."),
     },
   },
+  codex: {
+    adapterId: "codex",
+    productionAdapter: true,
+    expectations: {
+      nativeResume: required("Codex ACP exposes native sessions through the Gateway-backed ACP bridge."),
+      cancellationDispatch: required("Codex ACP accepts cancellation through the shared ACP interrupt path."),
+      cancellationAck: knownLimitation("Codex cancellation resolves locally without an independent adapter ack.", "TICKET-03-follow-up-cancel-ack"),
+      pinnedWorker: unsupported("Codex ACP sessions are native and do not require process-local pinned workers."),
+      modelSwitching: unsupported("Codex ACP does not currently expose session/set_model; model selection is configured in the Codex gateway/agent."),
+      artifactEmission: unsupported("Codex ACP adapter does not emit artifact references yet."),
+      toolSupport: unsupported("Codex ACP rejects per-session MCP servers; Omi tools are unavailable until configured through the Codex gateway/agent."),
+      restartOrphanSemantics: required("Startup reconciliation orphans active attempts while preserving native-resumable Codex bindings."),
+    },
+  },
   a2a: {
     adapterId: "a2a",
     productionAdapter: false,
@@ -262,10 +276,10 @@ export const ADAPTER_CAPABILITY_MATRIX = {
 } as const satisfies Record<string, AdapterCapabilityMatrixEntry>;
 
 export type KnownAdapterId = keyof typeof ADAPTER_CAPABILITY_MATRIX;
-export type ProductionAdapterId = "acp" | "pi-mono" | "hermes" | "openclaw";
+export type ProductionAdapterId = "acp" | "pi-mono" | "hermes" | "openclaw" | "codex";
 export type PlaceholderAdapterId = Exclude<KnownAdapterId, ProductionAdapterId>;
 
-export const PRODUCTION_ADAPTER_IDS = ["acp", "pi-mono", "hermes", "openclaw"] as const satisfies readonly ProductionAdapterId[];
+export const PRODUCTION_ADAPTER_IDS = ["acp", "pi-mono", "hermes", "openclaw", "codex"] as const satisfies readonly ProductionAdapterId[];
 export const PLACEHOLDER_ADAPTER_IDS = ["a2a"] as const satisfies readonly PlaceholderAdapterId[];
 
 export function isKnownAdapterId(adapterId: string): adapterId is KnownAdapterId {

--- a/desktop/macos/agent/src/index.ts
+++ b/desktop/macos/agent/src/index.ts
@@ -925,8 +925,16 @@ async function main(): Promise<void> {
       onCreate: (adapter) => localAcpAdapters.add(adapter),
     });
   };
+  const ensureCodexAdapter = async (): Promise<boolean> => {
+    return ensureRegisteredAdapter(registry, "codex", {
+      log: logErr,
+      maxWorkers: 1,
+      onCreate: (adapter) => localAcpAdapters.add(adapter),
+    });
+  };
   const hermesAvailable = await ensureHermesAdapter();
   const openClawAvailable = await ensureOpenClawAdapter();
+  const codexAvailable = await ensureCodexAdapter();
   if (!piMonoAvailable && defaultAdapterId === "pi-mono") {
     const msg = "pi-mono mode requires OMI_AUTH_TOKEN (Firebase ID token); refusing to start";
     logErr(msg);
@@ -941,6 +949,12 @@ async function main(): Promise<void> {
   }
   if (!openClawAvailable && defaultAdapterId === "openclaw") {
     const msg = adapterActivationError("openclaw") ?? "OpenClaw adapter is unavailable.";
+    logErr(msg);
+    send({ type: "error", message: msg });
+    process.exit(1);
+  }
+  if (!codexAvailable && defaultAdapterId === "codex") {
+    const msg = adapterActivationError("codex") ?? "Codex adapter is unavailable.";
     logErr(msg);
     send({ type: "error", message: msg });
     process.exit(1);
@@ -1026,6 +1040,10 @@ async function main(): Promise<void> {
             } else if (adapterId === "openclaw") {
               if (!(await ensureOpenClawAdapter())) {
                 throw new Error(adapterActivationError("openclaw"));
+              }
+            } else if (adapterId === "codex") {
+              if (!(await ensureCodexAdapter())) {
+                throw new Error(adapterActivationError("codex"));
               }
             }
             await facade.handleQuery(query);

--- a/desktop/macos/agent/src/runtime/adapter-selection.ts
+++ b/desktop/macos/agent/src/runtime/adapter-selection.ts
@@ -102,13 +102,16 @@ export function adapterProfile(adapterId: ProductionAdapterId): AdapterProfile {
 export function adapterActivationError(adapterId: ProductionAdapterId): string | undefined {
   const envName = adapterActivationEnv(adapterId);
   if (!envName) return undefined;
-  const label = adapterId === "pi-mono" ? "pi-mono" : adapterId === "openclaw" ? "OpenClaw" : adapterId === "codex" ? "Codex" : "Hermes";
   if (adapterId === "hermes" || adapterId === "openclaw" || adapterId === "codex") {
     if (adapterId === "codex") {
-      return "Codex is not available. Please run 'npm install -g @openai/codex' and run 'codex' in your terminal to sign in, then try again.";
+      return "Codex is not available. Run `npm install -g @openai/codex` in your terminal, then run `codex` to sign in, and try again.";
     }
-    return `${label} is not available. Make sure ${label} is installed first, then try again.`;
+    if (adapterId === "hermes") {
+      return "Hermes is not available. Install it from github.com/NousResearch/hermes-agent with `pip install -e '.[acp]'` (or `uvx --from 'hermes-agent[acp]'`), then run `hermes model` to configure a provider, and try again.";
+    }
+    return "OpenClaw is not available. Install OpenClaw on your PATH, or set the OMI_OPENCLAW_ADAPTER_COMMAND environment variable to point Omi at your OpenClaw binary, then try again.";
   }
+  const label = adapterId === "pi-mono" ? "pi-mono" : adapterId;
   return `${label} adapter is unavailable.`;
 }
 

--- a/desktop/macos/agent/src/runtime/adapter-selection.ts
+++ b/desktop/macos/agent/src/runtime/adapter-selection.ts
@@ -1,6 +1,7 @@
 import { AcpRuntimeAdapter } from "../adapters/acp.js";
 import { HermesRuntimeAdapter } from "../adapters/hermes.js";
 import { OpenClawRuntimeAdapter } from "../adapters/openclaw.js";
+import { CodexRuntimeAdapter } from "../adapters/codex.js";
 import { adapterCapabilitiesFor, type AdapterCapabilities, type ProductionAdapterId, type RuntimeAdapter } from "../adapters/interface.js";
 import type { AdapterRegistry } from "./adapter-registry.js";
 
@@ -9,6 +10,7 @@ export const ADAPTER_ACTIVATION_ENV = {
   "pi-mono": "OMI_AUTH_TOKEN",
   hermes: "OMI_HERMES_ADAPTER_COMMAND",
   openclaw: "OMI_OPENCLAW_ADAPTER_COMMAND",
+  codex: "OMI_CODEX_ADAPTER_COMMAND",
 } as const;
 
 export type SelectableAdapterId = keyof typeof ADAPTER_ACTIVATION_ENV;
@@ -52,6 +54,13 @@ export const ADAPTER_PROFILES: Record<ProductionAdapterId, AdapterProfile> = {
     capabilities: adapterCapabilitiesFor("openclaw"),
     createAdapter: ({ log }) => new OpenClawRuntimeAdapter({ log }),
   },
+  codex: {
+    adapterId: "codex",
+    activationEnv: ADAPTER_ACTIVATION_ENV.codex,
+    maxWorkers: 1,
+    capabilities: adapterCapabilitiesFor("codex"),
+    createAdapter: ({ log }) => new CodexRuntimeAdapter({ log }),
+  },
 };
 
 export function adapterIdForHarnessMode(harnessMode: string | undefined): SelectableAdapterId {
@@ -65,6 +74,8 @@ export function adapterIdForHarnessMode(harnessMode: string | undefined): Select
     case "openclaw":
     case "openClaw":
       return "openclaw";
+    case "codex":
+      return "codex";
     case "acp":
       return "acp";
     default:
@@ -91,8 +102,11 @@ export function adapterProfile(adapterId: ProductionAdapterId): AdapterProfile {
 export function adapterActivationError(adapterId: ProductionAdapterId): string | undefined {
   const envName = adapterActivationEnv(adapterId);
   if (!envName) return undefined;
-  const label = adapterId === "pi-mono" ? "pi-mono" : adapterId === "openclaw" ? "OpenClaw" : "Hermes";
-  if (adapterId === "hermes" || adapterId === "openclaw") {
+  const label = adapterId === "pi-mono" ? "pi-mono" : adapterId === "openclaw" ? "OpenClaw" : adapterId === "codex" ? "Codex" : "Hermes";
+  if (adapterId === "hermes" || adapterId === "openclaw" || adapterId === "codex") {
+    if (adapterId === "codex") {
+      return "Codex is not available. Please run 'npm install -g @openai/codex' and run 'codex' in your terminal to sign in, then try again.";
+    }
     return `${label} is not available. Make sure ${label} is installed first, then try again.`;
   }
   return `${label} adapter is unavailable.`;

--- a/desktop/macos/agent/src/runtime/failures.ts
+++ b/desktop/macos/agent/src/runtime/failures.ts
@@ -153,6 +153,8 @@ function adapterFailureLabel(adapterId: ProductionAdapterId, provider?: string):
       return "Hermes";
     case "pi-mono":
       return "pi-mono";
+    case "codex":
+      return "Codex";
     case "acp":
       if (provider === "openai") {
         return "OpenAI";

--- a/desktop/macos/agent/src/runtime/omi-tool-manifest.ts
+++ b/desktop/macos/agent/src/runtime/omi-tool-manifest.ts
@@ -270,7 +270,7 @@ export const swiftToolManifest: OmiToolManifestEntry[] = [
     promptGuidelines: [
       "Calling spawn_agent is the only way to start the circular floating-bar subagent; saying you will start one does not start it.",
       "Use delegate_agent instead for canonical Omi child sessions/runs that need durable delegation tracking.",
-      "If the user asks to use OpenClaw or Hermes, pass provider='openclaw' or provider='hermes' instead of treating that name as a session to inspect.",
+      "If the user asks to use OpenClaw, Hermes, or Codex, pass provider='openclaw', provider='hermes', or provider='codex' instead of treating that name as a session to inspect.",
       "Return immediately after spawning; the pill keeps working in the background.",
     ],
     latency: "async background",
@@ -280,7 +280,7 @@ export const swiftToolManifest: OmiToolManifestEntry[] = [
         title: { type: "string", description: "Short Title Case label for the agent pill." },
         provider: {
           type: "string",
-          enum: ["openclaw", "hermes"],
+          enum: ["openclaw", "hermes", "codex"],
           description: "Optional local agent provider to run this pill through.",
         },
       },

--- a/desktop/macos/agent/tests/adapter-selection.test.ts
+++ b/desktop/macos/agent/tests/adapter-selection.test.ts
@@ -17,6 +17,7 @@ describe("adapter selection and activation", () => {
     expect(adapterIdForHarnessMode("hermes")).toBe("hermes");
     expect(adapterIdForHarnessMode("openclaw")).toBe("openclaw");
     expect(adapterIdForHarnessMode("openClaw")).toBe("openclaw");
+    expect(adapterIdForHarnessMode("codex")).toBe("codex");
     expect(() => adapterIdForHarnessMode("unknown")).toThrow("Unknown harness mode: unknown");
   });
 
@@ -25,12 +26,14 @@ describe("adapter selection and activation", () => {
     expect(adapterActivationEnv("pi-mono")).toBe("OMI_AUTH_TOKEN");
     expect(adapterActivationEnv("hermes")).toBe("OMI_HERMES_ADAPTER_COMMAND");
     expect(adapterActivationEnv("openclaw")).toBe("OMI_OPENCLAW_ADAPTER_COMMAND");
+    expect(adapterActivationEnv("codex")).toBe("OMI_CODEX_ADAPTER_COMMAND");
 
     expect(adapterIsActivated("acp", {})).toBe(true);
     expect(adapterIsActivated("hermes", {})).toBe(false);
     expect(adapterIsActivated("hermes", { OMI_HERMES_ADAPTER_COMMAND: "  " })).toBe(false);
     expect(adapterIsActivated("hermes", { OMI_HERMES_ADAPTER_COMMAND: "hermes-adapter" })).toBe(true);
     expect(adapterIsActivated("openclaw", { OMI_OPENCLAW_ADAPTER_COMMAND: "openclaw-adapter" })).toBe(true);
+    expect(adapterIsActivated("codex", { OMI_CODEX_ADAPTER_COMMAND: "codex-adapter" })).toBe(true);
   });
 
   it("centralizes production adapter profiles and capabilities", () => {
@@ -49,25 +52,35 @@ describe("adapter selection and activation", () => {
       activationEnv: "OMI_OPENCLAW_ADAPTER_COMMAND",
       capabilities: { supportsTools: false, supportsModelSwitching: false },
     });
+    expect(adapterProfile("codex")).toMatchObject({
+      adapterId: "codex",
+      activationEnv: "OMI_CODEX_ADAPTER_COMMAND",
+      capabilities: { supportsTools: false, supportsModelSwitching: false },
+    });
     expect(adapterActivationError("hermes")).toBe(
-      "Hermes is not available. Make sure Hermes is installed first, then try again."
+      "Hermes is not available. Install it from github.com/NousResearch/hermes-agent with `pip install -e '.[acp]'` (or `uvx --from 'hermes-agent[acp]'`), then run `hermes model` to configure a provider, and try again."
     );
     expect(adapterActivationError("hermes")).not.toContain("OMI_HERMES_ADAPTER_COMMAND");
     expect(adapterActivationError("openclaw")).toBe(
-      "OpenClaw is not available. Make sure OpenClaw is installed first, then try again."
+      "OpenClaw is not available. Install OpenClaw on your PATH, or set the OMI_OPENCLAW_ADAPTER_COMMAND environment variable to point Omi at your OpenClaw binary, then try again."
     );
-    expect(adapterActivationError("openclaw")).not.toContain("OMI_OPENCLAW_ADAPTER_COMMAND");
+    expect(adapterActivationError("codex")).toBe(
+      "Codex is not available. Run `npm install -g @openai/codex` in your terminal, then run `codex` to sign in, and try again."
+    );
+    expect(adapterActivationError("codex")).not.toContain("OMI_CODEX_ADAPTER_COMMAND");
   });
 
-  it("source: daemon registers Hermes/OpenClaw explicitly and does not stamp MCP env as ACP", () => {
+  it("source: daemon registers Hermes/OpenClaw/Codex explicitly and does not stamp MCP env as ACP", () => {
     const indexSource = readFileSync(new URL("../src/index.ts", import.meta.url), "utf8");
 
     expect(indexSource).toContain("adapterIdForHarnessMode(defaultHarnessMode)");
     expect(indexSource).toContain('defaultAdapterId === "acp"');
     expect(indexSource).toContain("ensureRegisteredAdapter(registry, \"hermes\"");
     expect(indexSource).toContain("ensureRegisteredAdapter(registry, \"openclaw\"");
+    expect(indexSource).toContain("ensureRegisteredAdapter(registry, \"codex\"");
     expect(indexSource).toContain('adapterActivationError("hermes")');
     expect(indexSource).toContain('adapterActivationError("openclaw")');
+    expect(indexSource).toContain('adapterActivationError("codex")');
     expect(indexSource).toContain("query.ownerId = queryOwnerId");
     expect(indexSource).toContain('{ name: "OMI_ADAPTER_ID", value: context?.adapterId ?? "acp" }');
     expect(indexSource).not.toContain('{ name: "OMI_ADAPTER_ID", value: "acp" }');

--- a/desktop/macos/agent/tests/omi-tool-manifest.test.ts
+++ b/desktop/macos/agent/tests/omi-tool-manifest.test.ts
@@ -50,10 +50,11 @@ describe("omi tool manifest", () => {
     const spawnAgent = toolsForAdapter("pi-mono").find((tool) => tool.name === "spawn_agent");
 
     expect(spawnAgent?.inputSchema.properties.provider).toMatchObject({
-      enum: ["openclaw", "hermes"],
+      enum: ["openclaw", "hermes", "codex"],
     });
     expect(spawnAgent?.promptGuidelines?.join("\n")).toContain("provider='openclaw'");
     expect(spawnAgent?.promptGuidelines?.join("\n")).toContain("provider='hermes'");
+    expect(spawnAgent?.promptGuidelines?.join("\n")).toContain("provider='codex'");
   });
 
   it("projects stdio onboarding-only tools only in onboarding context", () => {

--- a/desktop/macos/agent/tests/runtime-adapter.test.ts
+++ b/desktop/macos/agent/tests/runtime-adapter.test.ts
@@ -478,7 +478,7 @@ describe("adapter capability matrix", () => {
     expect(Object.keys(ADAPTER_CAPABILITY_MATRIX).sort()).toEqual(
       [...PRODUCTION_ADAPTER_IDS, ...PLACEHOLDER_ADAPTER_IDS].sort()
     );
-    expect(PRODUCTION_ADAPTER_IDS).toEqual(["acp", "pi-mono", "hermes", "openclaw"]);
+    expect(PRODUCTION_ADAPTER_IDS).toEqual(["acp", "pi-mono", "hermes", "openclaw", "codex"]);
     expect(PLACEHOLDER_ADAPTER_IDS).toEqual(["a2a"]);
 
     expect(ADAPTER_CAPABILITY_MATRIX.acp.expectations).toMatchObject({
@@ -512,6 +512,16 @@ describe("adapter capability matrix", () => {
       restartOrphanSemantics: { status: "required" },
     });
     expect(ADAPTER_CAPABILITY_MATRIX.openclaw.expectations).toMatchObject({
+      nativeResume: { status: "required" },
+      cancellationDispatch: { status: "required" },
+      cancellationAck: { status: "known_limitation", followUpTicket: "TICKET-03-follow-up-cancel-ack" },
+      pinnedWorker: { status: "unsupported" },
+      modelSwitching: { status: "unsupported" },
+      artifactEmission: { status: "unsupported" },
+      toolSupport: { status: "unsupported" },
+      restartOrphanSemantics: { status: "required" },
+    });
+    expect(ADAPTER_CAPABILITY_MATRIX.codex.expectations).toMatchObject({
       nativeResume: { status: "required" },
       cancellationDispatch: { status: "required" },
       cancellationAck: { status: "known_limitation", followUpTicket: "TICKET-03-follow-up-cancel-ack" },
@@ -604,6 +614,17 @@ describe("adapter capability matrix", () => {
       restartBehavior: "process_local_bindings_stale",
     });
     expect(adapterCapabilitiesFor("openclaw")).toEqual({
+      resumeFidelity: "native",
+      supportsNativeResume: true,
+      supportsCancellation: true,
+      acknowledgesCancellation: false,
+      requiresPinnedWorker: false,
+      supportsModelSwitching: false,
+      supportsArtifactEmission: false,
+      supportsTools: false,
+      restartBehavior: "native_bindings_survive",
+    });
+    expect(adapterCapabilitiesFor("codex")).toEqual({
       resumeFidelity: "native",
       supportsNativeResume: true,
       supportsCancellation: true,

--- a/desktop/macos/changelog/unreleased/20260701-smart-agent-routing-codex.json
+++ b/desktop/macos/changelog/unreleased/20260701-smart-agent-routing-codex.json
@@ -1,0 +1,3 @@
+{
+    "change": "Smart agent routing on the floating bar and voice path now picks the best installed local agent (Codex, OpenClaw, Hermes), falls back when one is missing or fails to start, auto-installs Codex when you ask for it and it's not installed, and shows install guidance for Hermes/OpenClaw"
+}

--- a/desktop/macos/run.sh
+++ b/desktop/macos/run.sh
@@ -149,7 +149,10 @@ derive_omi_app_config "${OMI_APP_NAME:-Omi Dev}" || exit 1
 LOCAL_PROFILE=false
 [ "${OMI_DESKTOP_LOCAL_PROFILE:-0}" = "1" ] && LOCAL_PROFILE=true
 
-BUILD_DIR="build"
+# Allow overriding the build staging dir. Useful when the workspace lives in an
+# iCloud-synced folder (~/Documents/Desktop), where the file provider re-adds
+# com.apple.FinderInfo xattrs after `xattr -cr` and races `codesign`.
+BUILD_DIR="${BUILD_DIR:-build}"
 APP_BUNDLE="$BUILD_DIR/$APP_NAME.app"
 APP_PATH="/Applications/$APP_NAME.app"
 # Agent runtime source (staged into the app bundle at Resources/agent below).
@@ -752,6 +755,10 @@ if [ -n "$SIGN_IDENTITY" ]; then
         rm -f "$PROFILE_PATH"
         EFFECTIVE_ENTITLEMENTS="/tmp/omi-local-dev.entitlements"
     fi
+    # Per-component signing can re-add com.apple.provenance xattrs on newer macOS;
+    # strip them again before sealing the top-level bundle.
+    chmod -R u+w "$APP_BUNDLE"
+    xattr -cr "$APP_BUNDLE"
     substep "Signing app bundle"
     codesign --force --options runtime --entitlements "$EFFECTIVE_ENTITLEMENTS" --sign "$SIGN_IDENTITY" "$APP_BUNDLE"
 else

--- a/desktop/macos/scripts/sign-and-install-named-bundle.sh
+++ b/desktop/macos/scripts/sign-and-install-named-bundle.sh
@@ -13,14 +13,15 @@ SRC_BUNDLE="$BUILD_DIR/${APP_NAME}.app"
 DEST_BUNDLE="/Applications/${APP_NAME}.app"
 SIGN_IDENTITY="${OMI_SIGN_IDENTITY:-$(security find-identity -v -p codesigning | grep "Apple Development" | head -1 | sed 's/.*"\(.*\)"/\1/' || true)}"
 
-# Use mktemp for secure, collision-free temporary paths
-ENTITLEMENTS="$(mktemp /tmp/omi-local-dev.XXXXXX.entitlements)"
+# Use mktemp for secure, collision-free temporary paths.
+# BSD mktemp requires XXXXXX as the final path component (no trailing suffix).
+ENTITLEMENTS="$(mktemp /tmp/omi-local-dev.XXXXXX)"
 CLEAN_DIR="$(mktemp -d)"
 CLEAN_BUNDLE="$CLEAN_DIR/${APP_NAME}.app"
 
 cleanup() {
   rm -f "$ENTITLEMENTS"
-  rm -rf "$CLEAN_DIR"
+  rm -rf "$CLEAN_DIR" "$STAGING_BUNDLE" "$OLD_BUNDLE"
 }
 trap cleanup EXIT
 
@@ -71,11 +72,18 @@ codesign --force --options runtime --entitlements "$ENTITLEMENTS" --sign "$SIGN_
 codesign --verify --deep --strict "$CLEAN_BUNDLE"
 echo "Signature OK"
 
-# Atomic install: copy to a temp location in /Applications, then swap in.
-# This way, a ditto failure doesn't leave the user with nothing installed.
+# Swap install: move old bundle aside, move new one in, then delete old.
+# If the move fails, restore the old bundle so the user is never left without an app.
+OLD_BUNDLE="/Applications/.${APP_NAME}-old-$$.app"
 STAGING_BUNDLE="/Applications/.${APP_NAME}-staging-$$.app"
 ditto "$CLEAN_BUNDLE" "$STAGING_BUNDLE"
-rm -rf "$DEST_BUNDLE"
-mv "$STAGING_BUNDLE" "$DEST_BUNDLE"
+mv "$DEST_BUNDLE" "$OLD_BUNDLE" 2>/dev/null || true
+if ! mv "$STAGING_BUNDLE" "$DEST_BUNDLE"; then
+  rm -rf "$STAGING_BUNDLE"
+  mv "$OLD_BUNDLE" "$DEST_BUNDLE" 2>/dev/null || true
+  echo "ERROR: install failed — restored previous bundle"
+  exit 1
+fi
+rm -rf "$OLD_BUNDLE"
 echo "Installed to $DEST_BUNDLE"
 open "$DEST_BUNDLE"

--- a/desktop/macos/scripts/sign-and-install-named-bundle.sh
+++ b/desktop/macos/scripts/sign-and-install-named-bundle.sh
@@ -21,7 +21,7 @@ CLEAN_BUNDLE="$CLEAN_DIR/${APP_NAME}.app"
 
 cleanup() {
   rm -f "$ENTITLEMENTS"
-  rm -rf "$CLEAN_DIR" "$STAGING_BUNDLE" "$OLD_BUNDLE"
+  rm -rf "$CLEAN_DIR" "${STAGING_BUNDLE:-}" "${OLD_BUNDLE:-}"
 }
 trap cleanup EXIT
 

--- a/desktop/macos/scripts/sign-and-install-named-bundle.sh
+++ b/desktop/macos/scripts/sign-and-install-named-bundle.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+# Re-sign a named dev bundle after run.sh packaging. Use when the final
+# codesign step failed with "resource fork, Finder information, or similar
+# detritus not allowed" or the app crashes with Code Signature Invalid.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+APP_NAME="${OMI_APP_NAME:-omi-smart-routing}"
+# Respect run.sh's BUILD_DIR override so this works when the bundle was staged
+# outside the iCloud-synced workspace (e.g. BUILD_DIR=/tmp/... ./run.sh).
+BUILD_DIR="${BUILD_DIR:-$ROOT/build}"
+SRC_BUNDLE="$BUILD_DIR/${APP_NAME}.app"
+DEST_BUNDLE="/Applications/${APP_NAME}.app"
+SIGN_IDENTITY="${OMI_SIGN_IDENTITY:-$(security find-identity -v -p codesigning | grep "Apple Development" | head -1 | sed 's/.*"\(.*\)"/\1/' || true)}"
+
+# Use mktemp for secure, collision-free temporary paths
+ENTITLEMENTS="$(mktemp /tmp/omi-local-dev.XXXXXX.entitlements)"
+CLEAN_DIR="$(mktemp -d)"
+CLEAN_BUNDLE="$CLEAN_DIR/${APP_NAME}.app"
+
+cleanup() {
+  rm -f "$ENTITLEMENTS"
+  rm -rf "$CLEAN_DIR"
+}
+trap cleanup EXIT
+
+if [ ! -d "$SRC_BUNDLE" ]; then
+  echo "ERROR: Bundle not found: $SRC_BUNDLE"
+  echo "Run: OMI_APP_NAME=\"$APP_NAME\" ./run.sh --yolo"
+  exit 1
+fi
+
+if [ -z "$SIGN_IDENTITY" ]; then
+  echo "ERROR: No Apple Development signing identity found."
+  exit 1
+fi
+
+echo "Using identity: $SIGN_IDENTITY"
+cp "$ROOT/Desktop/Omi.entitlements" "$ENTITLEMENTS"
+/usr/libexec/PlistBuddy -c "Delete :com.apple.developer.applesignin" "$ENTITLEMENTS" 2>/dev/null || true
+
+ditto --norsrc "$SRC_BUNDLE" "$CLEAN_BUNDLE"
+chmod -R u+w "$CLEAN_BUNDLE"
+xattr -cr "$CLEAN_BUNDLE"
+
+sign_if_exists() {
+  local path="$1"
+  local entitlements="${2:-}"
+  if [ -e "$path" ]; then
+    echo "Signing $path"
+    if [ -n "$entitlements" ]; then
+      codesign --force --options runtime --entitlements "$entitlements" --sign "$SIGN_IDENTITY" "$path"
+    else
+      codesign --force --options runtime --sign "$SIGN_IDENTITY" "$path"
+    fi
+  fi
+}
+
+sign_if_exists "$CLEAN_BUNDLE/Contents/Frameworks/Sparkle.framework"
+sign_if_exists "$CLEAN_BUNDLE/Contents/Frameworks/Sentry.framework"
+sign_if_exists "$CLEAN_BUNDLE/Contents/Frameworks/onnxruntime.framework"
+sign_if_exists "$CLEAN_BUNDLE/Contents/Frameworks/libsharpyuv.0.dylib"
+sign_if_exists "$CLEAN_BUNDLE/Contents/Frameworks/libwebp.7.dylib"
+sign_if_exists "$CLEAN_BUNDLE/Contents/Resources/Omi Computer_Omi Computer.bundle/node" "$ROOT/Desktop/Node.entitlements"
+
+chmod -R u+w "$CLEAN_BUNDLE"
+xattr -cr "$CLEAN_BUNDLE"
+echo "Signing app bundle"
+codesign --force --options runtime --entitlements "$ENTITLEMENTS" --sign "$SIGN_IDENTITY" "$CLEAN_BUNDLE"
+
+codesign --verify --deep --strict "$CLEAN_BUNDLE"
+echo "Signature OK"
+
+# Atomic install: copy to a temp location in /Applications, then swap in.
+# This way, a ditto failure doesn't leave the user with nothing installed.
+STAGING_BUNDLE="/Applications/.${APP_NAME}-staging-$$.app"
+ditto "$CLEAN_BUNDLE" "$STAGING_BUNDLE"
+rm -rf "$DEST_BUNDLE"
+mv "$STAGING_BUNDLE" "$DEST_BUNDLE"
+echo "Installed to $DEST_BUNDLE"
+open "$DEST_BUNDLE"


### PR DESCRIPTION
## Summary

Omi now uses the best **installed** local coding agent (Codex, OpenClaw, Hermes) for a task instead of always defaulting to Claude Code. It picks by task type, falls back when the preferred one is missing or fails, **auto-installs Codex** when you ask for it and it's not installed, and gives real install guidance for Hermes/OpenClaw. Works across **push-to-talk voice**, the **typed floating bar**, and the in-app **`spawn_agent` chat tool**.

Satisfies the Track-1 goal: *"give a task mentioning openclaw/codex/hermes → it completes the task; if multiple are connected, pick the best with fallback; if one isn't connected, help install it."*

---

## How routing works

Single entry point: `LocalAgentProviderRouting.resolveSpawn(brief:requestedProvider:userRequestText:title:)` (`AgentRuntimeRouting.swift`).

1. **Classify** the brief → `coding` / `automation` / `general`.
2. **Explicit provider = the user's own words**, not the model's brief. Any mention counts — "codex", "use codex", "install codex", or a contextual correction ("no, use codex") — via `isExplicitProviderRequest`. A model that autonomously names a provider does **not** trigger setup/guidance.
3. **User explicitly named a provider:** installed → spawn it; missing → `.setupRequired` (auto-install Codex, or guidance for Hermes/OpenClaw).
4. **No explicit provider:** rank by `preferredProviders(for:)` — coding → `[codex, hermes, openclaw]`, automation/general → `[openclaw, codex, hermes]` — filter to installed, spawn the best; a model-suggested-but-missing provider silently falls back to an installed one.
5. **Runtime fallback:** `AgentSpawnContext` carries a fallback chain (installed harnesses + the native/Claude-Code default). On a retriable spawn failure (`enoent`/`adapter`/`activation`), `AgentPillsManager.maybeRetryWithFallback` re-spawns through it.

Detection (`LocalAgentProviderDetector`) checks the configured `OMI_*_ADAPTER_COMMAND` env, then scans PATH + `~/.local/bin`, `~/.npm-global/bin`, `~/.volta/bin`, homebrew, and nvm `~/.nvm/versions/node/*/bin`.

---

## Codex auto-install

`LocalAgentProviderInstaller` + `resolveSpawnWithAutoInstall`:
- When the user **explicitly** asks for Codex and it's missing → runs `npm install -g @openai/codex`, then re-resolves and spawns. On voice it speaks "Installing it for you now…".
- **Robustness:** prepends npm's own dir to the child process `PATH` (a LaunchServices-launched GUI app inherits only a minimal PATH, so npm's node shebang would otherwise fail), and enforces a **180s timeout** that kills a hung npm so the voice/typed turn never blocks.
- Only Codex auto-installs (non-interactive). **Hermes** → guidance (`github.com/NousResearch/hermes-agent`, `pip install -e '.[acp]'`, `hermes model`). **OpenClaw** → guidance (`OMI_OPENCLAW_ADAPTER_COMMAND` override; no public install exists).

---

## Integration points

| Path | File | Notes |
|---|---|---|
| Voice / PTT | `RealtimeHubController.swift` | `spawn_agent` runs through `resolveSpawnWithAutoInstall` in a `@MainActor` Task; guards state writes with `isCurrentSession` after the (possibly slow) install await |
| Typed floating bar | `FloatingControlBarWindow.swift` | directive + auto-classify paths, both pass the user transcript |
| Chat tool | `ChatToolExecutor.swift` | supports codex + fallback note |
| System prompt | `RealtimeHubTools.swift` | routing guidance derived from `preferredProviders(for:)`; tells the model Codex auto-installs so it won't tell the user to |

---

## Commits
1. **feat** — routing core, Codex adapter, auto-install, integration across all 3 paths, system prompt, changelog.
2. **test** — new `LocalAgentProviderRoutingTests` + adapter/detector/manifest/capability coverage.
3. **fix** — named-bundle signing robustness (`BUILD_DIR` override + iCloud xattr strip + recovery script).

---

## Testing

**Automated (all green):**
- `./scripts/agent-logic-harness.sh` — passed (all stages)
- `agent && npm test` — **285/285**
- `LocalAgentProviderRoutingTests` — 8/8

**End-to-end on a live signed-in bundle (prod backend):**
- "use codex to write …" → Codex spawns and writes the file. ✅
- "use hermes …" (not installed) → `.setupRequired` fires with the real install steps (spoken on voice). ✅
- coding task, no provider named → auto-routes to Codex. ✅
- **Auto-install proven:** uninstalled Codex (`npm ls -g @openai/codex` empty) → "use codex to write /tmp/…py" → `@openai/codex@0.142.5` reinstalled → file written (`print("hello")`), twice, including after the timeout/PATH-hardening fixes.

**Code review pass** (self + agent) fixed before this PR: npm-install timeout, child-PATH for GUI launch, voice state-after-await guard, and permissive explicit-mention detection.

---

## Notes
- No backend changes — routing is entirely desktop-side.
- Provider preferences + detection dirs live in `AgentRuntimeRouting.swift`.
- The chat tool intentionally falls back (rather than auto-installing) when it can't see the raw user text — the voice/typed paths are the primary surfaces.
- `BUILD_DIR=/tmp/... ./run.sh` avoids an iCloud codesign race when the checkout is under `~/Documents`.

Supersedes #8830.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8851?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

