### PR TITLE
fix(backend): offload the blocking Firestore calls in speaker-sample migrations

### DIFF
--- a/backend/tests/unit/test_speaker_sample_migration_async.py
+++ b/backend/tests/unit/test_speaker_sample_migration_async.py
@@ -1,0 +1,97 @@
+"""Structural test: the speaker-sample migrations offload their blocking Firestore calls.
+
+migrate_person_samples_v1_to_v2 and migrate_person_samples_v2_to_v3 in
+utils/speaker_sample_migration.py are async helpers. They already offload their storage and embedding
+work to run_blocking, but the person-record reads and writes still went through the synchronous
+users_db.get_person / clear_person_speaker_embedding / update_person_speech_samples_version /
+update_person_speech_samples_after_migration (Firestore calls in database/users.py) directly on the
+event loop. A sync Firestore call on the loop blocks it for the duration of the call, stalling health
+checks and every other connection sharing the loop. This test parses the source (no import) and asserts
+each of those calls is routed through an awaited run_blocking(db_executor, ...) and never called
+directly. The await check guards against a dangling coroutine (offloaded but not awaited).
+"""
+
+import ast
+from pathlib import Path
+
+BACKEND_DIR = Path(__file__).resolve().parents[2]
+MIGRATION = BACKEND_DIR / 'utils' / 'speaker_sample_migration.py'
+
+_USERS_DB_CALLS = (
+    'get_person',
+    'clear_person_speaker_embedding',
+    'update_person_speech_samples_version',
+    'update_person_speech_samples_after_migration',
+)
+TARGETS = {
+    'migrate_person_samples_v1_to_v2': _USERS_DB_CALLS,
+    'migrate_person_samples_v2_to_v3': _USERS_DB_CALLS,
+}
+
+
+def _load_function(name):
+    tree = ast.parse(MIGRATION.read_text(encoding='utf-8'))
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef)) and node.name == name:
+            return node
+    raise AssertionError(f'{name} not found in {MIGRATION}')
+
+
+def _ref_name(node):
+    """Name for an ast.Name (.id) or ast.Attribute (.attr); None otherwise."""
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        return node.attr
+    return None
+
+
+def _direct_calls(fn_node, callee):
+    return [n for n in ast.walk(fn_node) if isinstance(n, ast.Call) and _ref_name(n.func) == callee]
+
+
+def _awaited_run_blocking_offloads(fn_node):
+    """Yield (executor_name, target_name) for each AWAITED run_blocking(executor, target, ...) call.
+
+    Only awaited calls count: a bare run_blocking(...) without await is a dangling coroutine that
+    never runs, so the offload would silently do nothing.
+    """
+    for node in ast.walk(fn_node):
+        if not isinstance(node, ast.Await):
+            continue
+        call = node.value
+        if not isinstance(call, ast.Call) or _ref_name(call.func) != 'run_blocking':
+            continue
+        if len(call.args) >= 2:
+            yield _ref_name(call.args[0]), _ref_name(call.args[1])
+
+
+def test_users_db_calls_are_not_called_directly():
+    for fn_name, blocking in TARGETS.items():
+        fn = _load_function(fn_name)
+        for callee in blocking:
+            assert (
+                _direct_calls(fn, callee) == []
+            ), f'{callee} is called directly in {fn_name}; it must be offloaded via run_blocking'
+
+
+def test_users_db_calls_are_offloaded_and_awaited():
+    for fn_name, blocking in TARGETS.items():
+        fn = _load_function(fn_name)
+        targets = [target for _executor, target in _awaited_run_blocking_offloads(fn)]
+        for callee in blocking:
+            assert callee in targets, (
+                f'{callee} must be offloaded via an AWAITED run_blocking(db_executor, {callee}, ...) '
+                f'in {fn_name}; awaited run_blocking targets found: {targets}'
+            )
+
+
+def test_offloads_use_db_executor():
+    for fn_name in TARGETS:
+        fn = _load_function(fn_name)
+        for executor, target in _awaited_run_blocking_offloads(fn):
+            if target in _USERS_DB_CALLS:
+                assert executor == 'db_executor', (
+                    f'{target} is a Firestore call and must be offloaded on db_executor (Firestore/Redis '
+                    f'CRUD pool); found executor {executor} in {fn_name}'
+                )

--- a/backend/utils/speaker_sample_migration.py
+++ b/backend/utils/speaker_sample_migration.py
@@ -19,7 +19,7 @@ from utils.speaker_sample import (
     download_sample_audio,
     verify_and_transcribe_sample,
 )
-from utils.executors import storage_executor, sync_executor, run_blocking
+from utils.executors import db_executor, storage_executor, sync_executor, run_blocking
 from utils.stt.speaker_embedding import extract_embedding_from_bytes
 import logging
 
@@ -66,16 +66,16 @@ async def migrate_person_samples_v1_to_v2(uid: str, person: dict) -> dict:
 
     async with lock:
         # Re-check version inside lock (another call may have migrated)
-        fresh_person = users_db.get_person(uid, person_id)
+        fresh_person = await run_blocking(db_executor, users_db.get_person, uid, person_id)
         if fresh_person and fresh_person.get('speech_samples_version', 1) >= 2:
             return fresh_person
 
         samples = person.get('speech_samples', [])
         if not samples:
             if person.get('speaker_embedding'):
-                users_db.clear_person_speaker_embedding(uid, person_id)
+                await run_blocking(db_executor, users_db.clear_person_speaker_embedding, uid, person_id)
                 logger.info(f"v1→v2 migration: cleared stale embedding for person with no samples {uid} {person_id}")
-            users_db.update_person_speech_samples_version(uid, person_id, 2)
+            await run_blocking(db_executor, users_db.update_person_speech_samples_version, uid, person_id, 2)
             person['speech_samples_version'] = 2
             person['speech_sample_transcripts'] = []
             person['speaker_embedding'] = None
@@ -137,7 +137,9 @@ async def migrate_person_samples_v1_to_v2(uid: str, person: dict) -> dict:
             except Exception as e:
                 logger.error(f"Error extracting speaker embedding: {e} {uid} {person_id}")
 
-        users_db.update_person_speech_samples_after_migration(
+        await run_blocking(
+            db_executor,
+            users_db.update_person_speech_samples_after_migration,
             uid,
             person_id,
             samples=valid_samples,
@@ -185,7 +187,7 @@ async def migrate_person_samples_v2_to_v3(uid: str, person: dict) -> dict:
 
     async with lock:
         # Re-check version inside lock (another call may have migrated)
-        fresh_person = users_db.get_person(uid, person_id)
+        fresh_person = await run_blocking(db_executor, users_db.get_person, uid, person_id)
         if fresh_person and fresh_person.get('speech_samples_version', 1) >= 3:
             return fresh_person
 
@@ -195,9 +197,9 @@ async def migrate_person_samples_v2_to_v3(uid: str, person: dict) -> dict:
             # first, then bump version (order matters: avoids race where a concurrent
             # sample add writes a valid embedding that we'd then delete)
             if person.get('speaker_embedding'):
-                users_db.clear_person_speaker_embedding(uid, person_id)
+                await run_blocking(db_executor, users_db.clear_person_speaker_embedding, uid, person_id)
                 logger.info(f"v2→v3 migration: cleared stale embedding for person with no samples {uid} {person_id}")
-            users_db.update_person_speech_samples_version(uid, person_id, 3)
+            await run_blocking(db_executor, users_db.update_person_speech_samples_version, uid, person_id, 3)
             person['speech_samples_version'] = 3
             person['speaker_embedding'] = None
             return person
@@ -220,7 +222,9 @@ async def migrate_person_samples_v2_to_v3(uid: str, person: dict) -> dict:
             return person
 
         # Update version and embedding
-        users_db.update_person_speech_samples_after_migration(
+        await run_blocking(
+            db_executor,
+            users_db.update_person_speech_samples_after_migration,
             uid,
             person_id,
             samples=person.get('speech_samples', []),


### PR DESCRIPTION
## What

`migrate_person_samples_v1_to_v2` and `migrate_person_samples_v2_to_v3` in `utils/speaker_sample_migration.py` are async helpers. They already offload their storage downloads and embedding extraction to `run_blocking`, but the person-record reads and writes still went through the synchronous `users_db.get_person`, `clear_person_speaker_embedding`, `update_person_speech_samples_version`, and `update_person_speech_samples_after_migration` (Firestore calls in `database/users.py`) directly on the event loop:

```python
fresh_person = users_db.get_person(uid, person_id)
...
users_db.update_person_speech_samples_after_migration(uid, person_id, samples=..., version=2, speaker_embedding=...)
```

A synchronous Firestore call on the event loop blocks it for the duration of the call, stalling health checks and every other connection sharing the loop.

## Fix

Route those calls through `db_executor`, matching the storage and embedding offloads already in the same functions:

```python
fresh_person = await run_blocking(db_executor, users_db.get_person, uid, person_id)
...
await run_blocking(db_executor, users_db.update_person_speech_samples_after_migration, uid, person_id, samples=..., version=2, speaker_embedding=...)
```

`db_executor` is the correct pool for a Firestore call (Firestore/Redis CRUD per the backend async guidance). `run_blocking` was already imported; `db_executor` is added to the existing `utils.executors` import. The composite `migrate_person_samples_v1_to_v3` and `maybe_migrate_person_samples` only delegate to these two async functions and hold no direct blocking calls.

After the change, `python scripts/scan_async_blockers.py --dirs routers utils --diff-base origin/main` reports 0 selected findings for the changed range (the whole file, since the import changed).

## Test

Adds `tests/unit/test_speaker_sample_migration_async.py`, an AST-structural test that parses the source (no import) and asserts, for both migrations:

- `get_person`, `clear_person_speaker_embedding`, `update_person_speech_samples_version`, and `update_person_speech_samples_after_migration` are never called directly.
- each is routed through an awaited `run_blocking(db_executor, ...)`.
- the executor used is `db_executor`.

The await check matters: a bare `run_blocking(...)` without `await` is a dangling coroutine that never runs, so the offload would silently do nothing. The test fails if any offload, the await, or the pool choice is dropped.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8853?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

