### PR TITLE
fix(desktop): guard people-id dictionaries against duplicate keys (#6506)

### DIFF
--- a/desktop/macos/Desktop/Sources/AppState.swift
+++ b/desktop/macos/Desktop/Sources/AppState.swift
@@ -194,7 +194,9 @@ class AppState: ObservableObject {
   // People (speaker voice profiles)
   @Published var people: [Person] = []
   var peopleById: [String: Person] {
-    Dictionary(uniqueKeysWithValues: people.map { ($0.id, $0) })
+    // Last-write-wins: the API can return duplicate person ids; uniqueKeysWithValues
+    // would trap on a collision and crash the render path (same class as the fixed #6506).
+    Dictionary(people.map { ($0.id, $0) }, uniquingKeysWith: { _, latest in latest })
   }
 
   /// Maps live speaker IDs to person IDs during recording (cleared on finalize)

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/ConversationDetailView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/ConversationDetailView.swift
@@ -503,7 +503,7 @@ struct ConversationDetailView: View {
     private func copyTranscript() {
         guard canCopyTranscript else { return }
 
-        let peopleDict = Dictionary(uniqueKeysWithValues: people.map { ($0.id, $0) })
+        let peopleDict = Dictionary(people.map { ($0.id, $0) }, uniquingKeysWith: { _, latest in latest })
         let transcript: String = displayConversation.transcriptSegments.map { segment -> String in
             let speakerName: String
             if segment.isUser {
@@ -744,7 +744,7 @@ struct ConversationDetailView: View {
     /// Do NOT wrap this in another LazyVStack or VStack — it emits ForEach items directly.
     @ViewBuilder
     private var transcriptBubblesContent: some View {
-        let peopleDict = Dictionary(uniqueKeysWithValues: people.map { ($0.id, $0) })
+        let peopleDict = Dictionary(people.map { ($0.id, $0) }, uniquingKeysWith: { _, latest in latest })
         ForEach(displayConversation.transcriptSegments) { segment in
             SpeakerBubbleView(
                 segment: segment,

--- a/desktop/macos/changelog/unreleased/20260702-people-dict-crash.json
+++ b/desktop/macos/changelog/unreleased/20260702-people-dict-crash.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed a crash that could occur when loading conversations or copying a transcript if the account had duplicate speaker profiles"
+}


### PR DESCRIPTION
## Bug
`Dictionary(uniqueKeysWithValues:)` traps (crashes) when the source sequence contains duplicate keys. Three desktop sites build a `[personId: Person]` map this way over the API-fetched `people` array with no dedup guarantee:

- `AppState.peopleById` — a computed property on the hot SwiftUI render path
- `ConversationDetailView.copyTranscript()` (line ~506)
- `ConversationDetailView.transcriptBubblesContent` (line ~747)

If `GET /people` ever returns two profiles with the same id (e.g. a sync/merge race), any of these traps and the app crashes on conversation render or transcript copy.

## Root cause / precedent
This is the exact crash class confirmed on prod in **#6506** (`_NativeDictionary.merge` → `_assertionFailure` in the plan-catalog merge). That report was fixed by switching the settings merger to safe subscript assignment, but the identical unguarded pattern was left on the `people` array. The repo already uses the safe pattern elsewhere (`TasksPage.swift:815`).

## Fix
Switch the three lookups to last-write-wins deduplication:
```swift
Dictionary(people.map { ($0.id, $0) }, uniquingKeysWith: { _, latest in latest })
```
No behavior change for well-formed data (ids already unique); it only removes the crash on a duplicate. Clean `swift build -c debug` passes.

## Scope
3 lines changed across 2 files + a changelog fragment. No auth/signing/firmware/workflow surface.

🤖 automated by hourly watchdog; opened for review, not merged.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8861?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

