### PR TITLE
fix(backend): attribute app push notifications via plugin_id, not the dropped app_id

### DIFF
--- a/backend/tests/unit/test_app_notification_plugin_id.py
+++ b/backend/tests/unit/test_app_notification_plugin_id.py
@@ -1,0 +1,46 @@
+"""send_app_notification must attribute a plugin push via plugin_id.
+
+NotificationMessage has a `plugin_id` field but no `app_id`, and pydantic silently
+drops unknown kwargs, so building the message with `app_id=...` left plugin_id at its
+None default; get_message_as_dict then deletes the None plugin_id, so the FCM data
+payload carried no app attribution at all (the client reads `plugin_id` into the
+message's app id). The sibling send_chat_message_notification builds the same message
+with plugin_id correctly. These tests guard the caller against regressing to the wrong
+key and document why the wrong key drops the attribution.
+"""
+
+from pathlib import Path
+
+import models.notification_message as nm
+
+_APP_INTEGRATIONS = Path(__file__).resolve().parents[2] / 'utils' / 'app_integrations.py'
+
+
+def _send_app_notification_source() -> str:
+    source = _APP_INTEGRATIONS.read_text(encoding='utf-8')
+    body = source.split('def send_app_notification(', 1)[1]
+    return body.split('\ndef ', 1)[0]
+
+
+def test_send_app_notification_attributes_via_plugin_id():
+    body = _send_app_notification_source()
+    assert 'plugin_id=app_id' in body
+    assert 'app_id=app_id' not in body
+
+
+def test_plugin_id_survives_payload_but_unknown_app_id_is_dropped():
+    kept = nm.NotificationMessage.get_message_as_dict(
+        nm.NotificationMessage(
+            text='hi', plugin_id='app123', from_integration='true', type='text', notification_type='plugin'
+        )
+    )
+    assert kept.get('plugin_id') == 'app123'
+
+    # The old wrong key is silently ignored by pydantic, so plugin_id stays None and
+    # get_message_as_dict strips it, leaving no app attribution for the client.
+    dropped = nm.NotificationMessage.get_message_as_dict(
+        nm.NotificationMessage(
+            text='hi', app_id='app123', from_integration='true', type='text', notification_type='plugin'
+        )
+    )
+    assert 'plugin_id' not in dropped

--- a/backend/utils/app_integrations.py
+++ b/backend/utils/app_integrations.py
@@ -805,7 +805,7 @@ def send_app_notification(user_id: str, app_name: str, app_id: str, message: str
     navigate_to = '/chat/omi' if target == 'main' else f'/chat/{app_id}'
     ai_message = NotificationMessage(
         text=message,
-        app_id=app_id,
+        plugin_id=app_id,
         from_integration='true',
         type='text',
         notification_type='plugin',


### PR DESCRIPTION
## Summary

Fixes a latent wrong-key bug: app-attributed push notifications lost their app id in the FCM data payload, so the client could not associate them with the app that sent them.

## Root cause

`send_app_notification` (`utils/app_integrations.py`) built its `NotificationMessage` with `app_id=app_id`, but `NotificationMessage` (`models/notification_message.py`) has a `plugin_id` field and no `app_id`. Pydantic silently drops the unknown `app_id`, so `plugin_id` stayed at its `None` default. `get_message_as_dict` then removes a `None` `plugin_id`, so the payload ended up with neither key. The Flutter client reads `plugin_id` into the message's app id, so these notifications arrived with no app attribution.

The sibling `send_chat_message_notification` (`utils/chat.py`) builds the same message (same `from_integration='true'`, `notification_type='plugin'`, `navigate_to=/chat/{app_id}`) but correctly uses `plugin_id=app_id`. The other `NotificationMessage` call sites are `from_integration='false'` system notifications that correctly omit `plugin_id`, so `send_app_notification` was the only one with the wrong key.

## Impact

Every push that routes through `send_app_notification`: the mentor proactive notification, the realtime integration-app notifications, and the developer `POST /v1/integrations/notification` endpoint.

## Fix

Build the message with `plugin_id=app_id`, matching the model and the sibling path. One line.

## Testing

`tests/unit/test_app_notification_plugin_id.py`: guards the caller against regressing to the wrong key, and shows the mechanism (a plugin_id-built payload keeps the attribution, while the old `app_id` kwarg is silently dropped so `get_message_as_dict` strips it).

## PR status

Mergeable, no conflicts. One-line behavior fix plus a regression test.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8864?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

