### PR TITLE
fix(backend): skip malformed calendar meetings instead of 500ing the whole list

### DIFF
--- a/backend/models/calendar_context.py
+++ b/backend/models/calendar_context.py
@@ -25,3 +25,18 @@ class CalendarMeetingContext(BaseModel):
     calendar_source: Optional[str] = Field(
         default='system_calendar', description="Calendar source (system_calendar, google, outlook, etc.)"
     )
+
+    @classmethod
+    def from_records(cls, records, on_error=None) -> List['CalendarMeetingContext']:
+        """Build a list of contexts from raw stored records, skipping any that fail
+        validation so a single malformed meeting cannot hide all of a user's meetings.
+        `on_error(record, exception)`, when provided, is called for each skipped record.
+        """
+        parsed: List['CalendarMeetingContext'] = []
+        for record in records:
+            try:
+                parsed.append(cls(**record))
+            except Exception as exc:  # noqa: BLE001 - one bad record must not break the whole list
+                if on_error is not None:
+                    on_error(record, exc)
+        return parsed

--- a/backend/routers/calendar_meetings.py
+++ b/backend/routers/calendar_meetings.py
@@ -1,3 +1,4 @@
+import logging
 from datetime import datetime
 from typing import List, Optional
 
@@ -8,6 +9,8 @@ import database.calendar_meetings as calendar_db
 from models.calendar_context import CalendarMeetingContext, MeetingParticipant
 from utils.other import endpoints as auth
 from utils.request_validation import CalendarMeetingsLimit
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
@@ -101,4 +104,9 @@ def list_calendar_meetings(
 ):
     """List calendar meetings within a date range"""
     meetings = calendar_db.list_meetings(uid, start_date=start_date, end_date=end_date, limit=limit)
-    return [CalendarMeetingContext(**m) for m in meetings]
+    # Skip any malformed stored meeting rather than 500 the whole list, so one bad
+    # record cannot hide every other meeting the user has.
+    return CalendarMeetingContext.from_records(
+        meetings,
+        on_error=lambda record, exc: logger.warning('Skipping malformed calendar meeting for uid=%s: %s', uid, exc),
+    )

--- a/backend/routers/calendar_meetings.py
+++ b/backend/routers/calendar_meetings.py
@@ -105,8 +105,15 @@ def list_calendar_meetings(
     """List calendar meetings within a date range"""
     meetings = calendar_db.list_meetings(uid, start_date=start_date, end_date=end_date, limit=limit)
     # Skip any malformed stored meeting rather than 500 the whole list, so one bad
-    # record cannot hide every other meeting the user has.
+    # record cannot hide every other meeting the user has. Log a safe identifier plus
+    # the exception class only: a ValidationError's str() renders the field input_value,
+    # which for a meeting can be sensitive (title, participant emails, link, notes).
     return CalendarMeetingContext.from_records(
         meetings,
-        on_error=lambda record, exc: logger.warning('Skipping malformed calendar meeting for uid=%s: %s', uid, exc),
+        on_error=lambda record, exc: logger.warning(
+            'Skipping malformed calendar meeting for uid=%s event_id=%s: %s',
+            uid,
+            record.get('calendar_event_id'),
+            type(exc).__name__,
+        ),
     )

--- a/backend/tests/unit/test_calendar_meeting_from_records.py
+++ b/backend/tests/unit/test_calendar_meeting_from_records.py
@@ -1,0 +1,54 @@
+"""GET /v1/calendar/meetings must not 500 the whole list on one malformed record.
+
+The endpoint built `[CalendarMeetingContext(**m) for m in meetings]`, and the model
+has required no-default fields (calendar_event_id, title, start_time, duration_minutes),
+so a single malformed stored meeting raised a ValidationError and hid every other
+meeting the user has. CalendarMeetingContext.from_records skips bad records (reporting
+them via on_error) and returns the valid ones.
+"""
+
+from datetime import datetime, timezone
+
+from models.calendar_context import CalendarMeetingContext
+
+
+def _valid(event_id='e1'):
+    return {
+        'calendar_event_id': event_id,
+        'title': 'Standup',
+        'start_time': datetime(2026, 1, 1, 9, 0, tzinfo=timezone.utc),
+        'duration_minutes': 30,
+    }
+
+
+def test_from_records_parses_valid_records():
+    out = CalendarMeetingContext.from_records([_valid('a'), _valid('b')])
+    assert [m.calendar_event_id for m in out] == ['a', 'b']
+
+
+def test_from_records_skips_malformed_without_losing_valid():
+    records = [
+        _valid('good1'),
+        {'title': 'missing required fields'},  # no calendar_event_id/start_time/duration_minutes
+        {  # bad start_time type
+            'calendar_event_id': 'x',
+            'title': 't',
+            'start_time': 'not-a-date',
+            'duration_minutes': 30,
+        },
+        _valid('good2'),
+    ]
+    skipped = []
+    out = CalendarMeetingContext.from_records(records, on_error=lambda record, exc: skipped.append(record))
+    assert [m.calendar_event_id for m in out] == ['good1', 'good2']
+    assert len(skipped) == 2
+
+
+def test_from_records_tolerates_missing_on_error():
+    # No on_error callback: malformed records are still skipped, not raised.
+    out = CalendarMeetingContext.from_records([{'title': 'bad'}, _valid('ok')])
+    assert [m.calendar_event_id for m in out] == ['ok']
+
+
+def test_from_records_empty():
+    assert CalendarMeetingContext.from_records([]) == []


### PR DESCRIPTION
## Summary

Fixes a poison-record bug: one malformed stored calendar meeting made `GET /v1/calendar/meetings` return 500, hiding every other meeting the user has.

## Root cause

The endpoint built the response with an unguarded list comprehension:

```python
return [CalendarMeetingContext(**m) for m in meetings]
```

`CalendarMeetingContext` has required no-default fields (`calendar_event_id`, `title`, `start_time`, `duration_minutes`). If any stored meeting record is missing one of those or has a bad type, `CalendarMeetingContext(**m)` raises a `ValidationError`, which propagates out of the comprehension and 500s the whole request. So a single corrupt record takes down the entire list, not just itself.

## Fix

Add a `CalendarMeetingContext.from_records` factory that parses each record and skips the ones that fail validation, reporting each skipped record through an `on_error` callback. The list endpoint uses it, logging and skipping a bad record instead of failing the request.

## Testing

`tests/unit/test_calendar_meeting_from_records.py`: valid records are parsed, malformed records are skipped without losing the valid ones (and are reported via `on_error`), a missing callback is tolerated, and empty input returns an empty list. The factory is pure, so the test needs no I/O.

## PR status

Mergeable, no conflicts. Additive resilience: valid records return exactly as before; only malformed records change from 500-the-whole-list to skip-and-log.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8865?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

