### PR TITLE
fix(backend): skip malformed action items instead of 500ing the whole list

### DIFF
--- a/backend/routers/action_items.py
+++ b/backend/routers/action_items.py
@@ -93,6 +93,20 @@ class ActionItemResponse(BaseModel):
     indent_level: int = 0
 
 
+def _safe_action_item_responses(items, *, uid: str = '', context: str = '') -> List[ActionItemResponse]:
+    """Build ActionItemResponse objects from raw records, skipping any that fail
+    validation so one malformed or legacy item cannot 500 a whole list endpoint."""
+    responses: List[ActionItemResponse] = []
+    for item in items:
+        try:
+            responses.append(ActionItemResponse(**item))
+        except ValidationError:
+            item_id = item.get('id') if isinstance(item, dict) else None
+            suffix = f', {context}' if context else ''
+            logger.warning('Skipping malformed action item %s (uid=%s%s)', item_id, uid, suffix)
+    return responses
+
+
 def _get_valid_action_item(uid: str, action_item_id: str) -> dict:
     action_item = action_items_db.get_action_item(uid, action_item_id)
     if not action_item:
@@ -155,8 +169,8 @@ def get_pending_sync_items(
     pending_export = [item for item in result["pending_export"] if not item.get('is_locked', False)]
     synced_items = [item for item in result["synced_items"] if not item.get('is_locked', False)]
     return {
-        "pending_export": [ActionItemResponse(**item) for item in pending_export],
-        "synced_items": [ActionItemResponse(**item) for item in synced_items],
+        "pending_export": _safe_action_item_responses(pending_export, uid=uid, context='pending_export'),
+        "synced_items": _safe_action_item_responses(synced_items, uid=uid, context='synced_items'),
     }
 
 
@@ -320,7 +334,7 @@ def get_action_items(
             description = item.get('description', '')
             item['description'] = (description[:70] + '...') if len(description) > 70 else description
 
-    response_items = [ActionItemResponse(**item) for item in action_items]
+    response_items = _safe_action_item_responses(action_items, uid=uid)
 
     has_more = len(action_items) == limit
     if has_more:
@@ -353,7 +367,7 @@ def search_action_items(
 
     action_items = action_items_db.get_action_items_by_ids(uid, action_item_ids)
     action_items = [item for item in action_items if not item.get('is_locked', False)]
-    return {"action_items": [ActionItemResponse(**item) for item in action_items]}
+    return {"action_items": _safe_action_item_responses(action_items, uid=uid)}
 
 
 @router.get("/v1/action-items/{action_item_id}", response_model=ActionItemResponse, tags=['action-items'])
@@ -532,15 +546,7 @@ def get_conversation_action_items(conversation_id: str, uid: str = Depends(auth.
     if conversation.get('is_locked', False):
         raise HTTPException(status_code=402, detail="A paid plan is required to access this conversation.")
     action_items = action_items_db.get_action_items_by_conversation(uid, conversation_id)
-    response_items = []
-    for item in action_items:
-        try:
-            response_items.append(ActionItemResponse(**item))
-        except ValidationError:
-            logger.warning(
-                f"Skipping malformed action item {item.get('id')} for conversation {conversation_id}, uid {uid}"
-            )
-            continue
+    response_items = _safe_action_item_responses(action_items, uid=uid, context=f'conversation {conversation_id}')
 
     return {"action_items": response_items, "conversation_id": conversation_id}
 

--- a/backend/tests/unit/test_action_items_conversation_list_malformed.py
+++ b/backend/tests/unit/test_action_items_conversation_list_malformed.py
@@ -1,8 +1,10 @@
-"""GET /v1/conversations/{id}/action-items must skip a malformed action item instead of 500ing the page.
+"""The action-items list endpoints must skip a malformed item instead of 500ing the whole list.
 
-The endpoint built ActionItemResponse(**item) per item, so one malformed/legacy item (missing a required
-field like 'completed') raised ValidationError and failed the whole page. routers/action_items.py has a
-heavy import graph, so we import it under a stub finder, then call the endpoint directly.
+Each built ActionItemResponse(**item) per item, so one malformed/legacy item (missing a required field
+like 'completed') raised ValidationError and failed the whole response. A shared _safe_action_item_responses
+helper now skips bad records. This covers the conversation list, the main list (GET /v1/action-items), and
+search. routers/action_items.py has a heavy import graph, so we import it under a stub finder, then call the
+endpoints directly.
 """
 
 import importlib.abc
@@ -120,4 +122,33 @@ def test_conversation_list_skips_malformed_not_500():
         ai_mod.conversations_db, 'get_conversation', return_value={'id': 'c1', 'is_locked': False}
     ), patch.object(ai_mod.action_items_db, 'get_action_items_by_conversation', return_value=page):
         resp = ai_mod.get_conversation_action_items(conversation_id='c1', uid='uid1')
+    assert [i.id for i in resp['action_items']] == ['a1']
+
+
+def test_main_list_skips_malformed_not_500():
+    bad = {'id': 'a2', 'description': 'missing completed'}  # missing required 'completed' -> ValidationError
+    page = [_valid('a1'), bad]
+    with patch.object(ai_mod.action_items_db, 'get_action_items', return_value=page):
+        # Pass params explicitly: calling the handler directly leaves Query() defaults unresolved.
+        resp = ai_mod.get_action_items(
+            limit=50,
+            offset=0,
+            completed=None,
+            conversation_id=None,
+            start_date=None,
+            end_date=None,
+            due_start_date=None,
+            due_end_date=None,
+            uid='uid1',
+        )
+    assert [i.id for i in resp['action_items']] == ['a1']
+
+
+def test_search_skips_malformed_not_500():
+    bad = {'id': 'a2', 'description': 'missing completed'}
+    page = [_valid('a1'), bad]
+    with patch.object(ai_mod, 'search_action_items_by_vector', return_value=['a1', 'a2']), patch.object(
+        ai_mod.action_items_db, 'get_action_items_by_ids', return_value=page
+    ):
+        resp = ai_mod.search_action_items(query='meeting', limit=10, uid='uid1')
     assert [i.id for i in resp['action_items']] == ['a1']


### PR DESCRIPTION
## Summary

Fixes a poison-record bug on the action-items list endpoints: one malformed stored action item made the whole list 500, hiding every task the user has.

## Root cause

`GET /v1/action-items`, `/v1/action-items/search`, and `/v1/action-items/pending-sync` each built their response with an unguarded list comprehension:

```python
[ActionItemResponse(**item) for item in action_items]
```

`ActionItemResponse` has required fields (`id`, `description`, `completed`). If any stored item is missing one of those or has a bad type, `ActionItemResponse(**item)` raises a `ValidationError` that propagates out of the comprehension and 500s the whole request, so a single corrupt or legacy record hides every action item, not just itself. The per-conversation list (`GET /v1/conversations/{id}/action-items`) already guarded this; these three did not.

## Fix

Add a shared `_safe_action_item_responses` helper that parses each record and skips the ones that fail validation (logging them), and use it at all four sites. The already-guarded per-conversation list now shares the same helper, so there is one consistent path.

## Testing

Extends the existing malformed-item test to cover the main list and the search endpoint: a page containing one valid and one malformed item returns only the valid one instead of 500ing. The per-conversation test still passes against the shared helper.

## PR status

Mergeable, no conflicts. Additive resilience: valid items return exactly as before; only malformed records change from 500-the-whole-list to skip-and-log.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8867?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

