### PR TITLE
Fix OpenClaw memory setup discovery on macOS

### DIFF
--- a/desktop/macos/Desktop/Sources/MemoryBankConnector.swift
+++ b/desktop/macos/Desktop/Sources/MemoryBankConnector.swift
@@ -126,8 +126,9 @@ enum MemoryBankConnector {
       )
       return false
     } catch {
+      let message = sanitizeOpenClawError(error.localizedDescription)
       throw ConnectError.invalidConfig(
-        "OpenClaw rejected MCP config update for \(displayPath(for: configURL)): \(error.localizedDescription)")
+        "OpenClaw rejected MCP config update for \(displayPath(for: configURL)): \(message)")
     }
   }
 
@@ -140,11 +141,7 @@ enum MemoryBankConnector {
     if let override = openClawCLIPathOverrideForTesting {
       return override.isEmpty ? nil : override
     }
-    let candidates = [
-      home.appendingPathComponent(".hermes/node/bin/openclaw").path,
-      "/opt/homebrew/bin/openclaw",
-      "/usr/local/bin/openclaw",
-    ]
+    let candidates = commonExecutableDirs().map { ($0 as NSString).appendingPathComponent("openclaw") }
     if let path = candidates.first(where: { FileManager.default.isExecutableFile(atPath: $0) }) {
       return path
     }
@@ -153,15 +150,111 @@ enum MemoryBankConnector {
   }
 
   private static func runOpenClawCLI(cliPath: String, configURL: URL, arguments: [String]) throws -> CommandOutput {
-    try runProcess(
-      executable: cliPath,
-      arguments: arguments,
-      environment: ["OPENCLAW_CONFIG_PATH": configURL.path]
+    let command = openClawCommand(cliPath: cliPath)
+    return try runProcess(
+      executable: command.executable,
+      arguments: command.argumentsPrefix + arguments,
+      environment: openClawEnvironment(cliPath: cliPath, configURL: configURL)
     )
+  }
+
+  private struct OpenClawCommand {
+    let executable: String
+    let argumentsPrefix: [String]
+  }
+
+  private static func openClawCommand(cliPath: String, fileManager: FileManager = .default) -> OpenClawCommand {
+    let nodePath = ((cliPath as NSString).deletingLastPathComponent as NSString).appendingPathComponent("node")
+    if fileManager.isExecutableFile(atPath: nodePath), launcherUsesNode(cliPath: cliPath) {
+      return OpenClawCommand(executable: nodePath, argumentsPrefix: [cliPath])
+    }
+    return OpenClawCommand(executable: cliPath, argumentsPrefix: [])
+  }
+
+  private static func launcherUsesNode(cliPath: String) -> Bool {
+    guard let handle = FileHandle(forReadingAtPath: cliPath) else {
+      return false
+    }
+    defer { try? handle.close() }
+    guard
+      let data = try? handle.read(upToCount: 512),
+      let prefix = String(data: data, encoding: .utf8)
+    else {
+      return false
+    }
+    let firstLine = prefix.split(separator: "\n", maxSplits: 1, omittingEmptySubsequences: false).first ?? ""
+    return firstLine.hasPrefix("#!") && firstLine.contains("node")
+  }
+
+  private static func openClawEnvironment(cliPath: String, configURL: URL) -> [String: String] {
+    let cliDir = (cliPath as NSString).deletingLastPathComponent
+    let pathPrefix = [cliDir] + commonExecutableDirs() + systemExecutableDirs()
+    let existingPath = ProcessInfo.processInfo.environment["PATH"] ?? ""
+    let path = (pathPrefix + existingPath.split(separator: ":").map(String.init))
+      .reduce(into: [String]()) { elements, item in
+        if !item.isEmpty && !elements.contains(item) {
+          elements.append(item)
+        }
+      }
+      .joined(separator: ":")
+    return [
+      "OPENCLAW_CONFIG_PATH": configURL.path,
+      "PATH": path,
+    ]
   }
 
   private static func runShell(_ arguments: [String]) throws -> CommandOutput {
     try runProcess(executable: "/bin/zsh", arguments: arguments, environment: [:])
+  }
+
+  private static func commonExecutableDirs() -> [String] {
+    let homePath = home.path
+    let userDirs = [
+      "\(homePath)/.hermes/node/bin",
+      "\(homePath)/.local/bin",
+      "\(homePath)/.volta/bin",
+      "\(homePath)/.asdf/shims",
+      "\(homePath)/.bun/bin",
+      "\(homePath)/Library/pnpm",
+      "\(homePath)/.npm-global/bin",
+      "\(homePath)/.node_modules_global/bin",
+    ]
+    let globalDirs = [
+      "/opt/homebrew/bin",
+      "/usr/local/bin",
+    ]
+    let managedNodeDirs = [
+      "\(homePath)/.nvm/versions/node",
+      "\(homePath)/.fnm/node-versions",
+      "\(homePath)/.local/share/fnm/node-versions",
+      "\(homePath)/.nodenv/versions",
+      "\(homePath)/.asdf/installs/nodejs",
+    ].flatMap(nodeInstallBinDirs(root:))
+    return uniquePaths(userDirs + managedNodeDirs + globalDirs + ["/opt/local/bin"])
+  }
+
+  private static func systemExecutableDirs() -> [String] {
+    ["/usr/bin", "/bin", "/usr/sbin", "/sbin"]
+  }
+
+  private static func nodeInstallBinDirs(root: String) -> [String] {
+    let fm = FileManager.default
+    guard let versions = try? fm.contentsOfDirectory(atPath: root) else { return [] }
+    return versions.compactMap { version in
+      let versionDir = (root as NSString).appendingPathComponent(version)
+      let directBin = (versionDir as NSString).appendingPathComponent("bin")
+      if fm.fileExists(atPath: directBin) { return directBin }
+      let installationBin = (versionDir as NSString).appendingPathComponent("installation/bin")
+      if fm.fileExists(atPath: installationBin) { return installationBin }
+      return nil
+    }
+  }
+
+  private static func uniquePaths(_ paths: [String]) -> [String] {
+    paths.reduce(into: [String]()) { result, path in
+      guard !path.isEmpty, !result.contains(path) else { return }
+      result.append(path)
+    }
   }
 
   private static func runProcess(
@@ -204,10 +297,38 @@ enum MemoryBankConnector {
   }
 
   private static func normalizedPath(_ raw: String) -> URL? {
-    let path = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+    var path = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+    if
+      path.count >= 2,
+      let first = path.first,
+      let last = path.last,
+      (first == "\"" && last == "\"") || (first == "'" && last == "'")
+    {
+      path = String(path.dropFirst().dropLast())
+    }
     guard !path.isEmpty else { return nil }
-    let expanded = path.replacingOccurrences(of: "~", with: home.path, options: .anchored)
+    let expanded = path
+      .replacingOccurrences(of: "~", with: home.path, options: .anchored)
+      .replacingOccurrences(of: "${HOME}", with: home.path)
+      .replacingOccurrences(of: "$HOME", with: home.path)
     return URL(fileURLWithPath: expanded)
+  }
+
+  private static func sanitizeOpenClawError(_ message: String) -> String {
+    let patterns = [
+      #"Authorization\\?":\\?"Bearer [^"\\\s}]+"#,
+      #"Authorization:\s*Bearer\s+[^\s"'}]+"#,
+      #"Bearer\s+[A-Za-z0-9._~+/=-]+"#,
+    ]
+    var sanitized = message
+    for pattern in patterns {
+      sanitized = sanitized.replacingOccurrences(
+        of: pattern,
+        with: "Authorization: Bearer [redacted]",
+        options: .regularExpression
+      )
+    }
+    return sanitized
   }
 
   @discardableResult

--- a/desktop/macos/Desktop/Tests/MemoryBankConnectorTests.swift
+++ b/desktop/macos/Desktop/Tests/MemoryBankConnectorTests.swift
@@ -66,6 +66,120 @@ final class MemoryBankConnectorTests: XCTestCase {
     XCTAssertTrue(FileManager.default.fileExists(atPath: workspace.appendingPathComponent("SOUL.md").path))
   }
 
+  func testOpenClawConnectUsesSiblingNodeForEnvLauncher() throws {
+    let workspace = tempHome.appendingPathComponent(".openclaw/workspace", isDirectory: true)
+    try FileManager.default.createDirectory(at: workspace, withIntermediateDirectories: true)
+    let config = try writeOpenClawConfig(workspace: workspace)
+    let install = tempHome.appendingPathComponent(".hermes/node/bin", isDirectory: true)
+    try FileManager.default.createDirectory(at: install, withIntermediateDirectories: true)
+    let cli = install.appendingPathComponent("openclaw")
+    let node = install.appendingPathComponent("node")
+    try "#!/usr/bin/env definitely-missing-node\n".write(to: cli, atomically: true, encoding: .utf8)
+    try """
+      #!/bin/sh
+      shift
+      if [ "$1" = "mcp" ] && [ "$2" = "show" ]; then
+        exit 1
+      fi
+      if [ "$1" = "mcp" ] && [ "$2" = "set" ] && [ "$3" = "omi-memory" ]; then
+        printf '{"mcp":{"servers":{"omi-memory":%s}}}\\n' "$4" > "$OPENCLAW_CONFIG_PATH"
+        exit 0
+      fi
+      echo "unexpected arguments: $*" >&2
+      exit 2
+      """.write(to: node, atomically: true, encoding: .utf8)
+    try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: cli.path)
+    try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: node.path)
+    MemoryBankConnector.openClawCLIPathOverrideForTesting = cli.path
+
+    _ = try MemoryBankConnector.connect(.openclaw, key: "test-key")
+
+    let configContent = try String(contentsOf: config, encoding: .utf8)
+    XCTAssertTrue(configContent.contains(#""omi-memory""#))
+    XCTAssertTrue(configContent.contains(#""Authorization":"Bearer test-key""#))
+  }
+
+  func testOpenClawConnectDiscoversCommonUserBinInstall() throws {
+    let workspace = tempHome.appendingPathComponent(".openclaw/workspace", isDirectory: true)
+    try FileManager.default.createDirectory(at: workspace, withIntermediateDirectories: true)
+    let config = try writeOpenClawConfig(workspace: workspace)
+    let bin = tempHome.appendingPathComponent(".local/bin", isDirectory: true)
+    try FileManager.default.createDirectory(at: bin, withIntermediateDirectories: true)
+    let cli = bin.appendingPathComponent("openclaw")
+    try fakeOpenClawScript().write(to: cli, atomically: true, encoding: .utf8)
+    try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: cli.path)
+    MemoryBankConnector.openClawCLIPathOverrideForTesting = nil
+
+    _ = try MemoryBankConnector.connect(.openclaw, key: "test-key")
+
+    let configContent = try String(contentsOf: config, encoding: .utf8)
+    XCTAssertTrue(configContent.contains(#""omi-memory""#))
+  }
+
+  func testOpenClawConnectFindsNodeFromVersionManagerPath() throws {
+    let workspace = tempHome.appendingPathComponent(".openclaw/workspace", isDirectory: true)
+    try FileManager.default.createDirectory(at: workspace, withIntermediateDirectories: true)
+    let config = try writeOpenClawConfig(workspace: workspace)
+    let cliBin = tempHome.appendingPathComponent(".local/bin", isDirectory: true)
+    let nodeBin = tempHome.appendingPathComponent(".nvm/versions/node/v22.0.0/bin", isDirectory: true)
+    try FileManager.default.createDirectory(at: cliBin, withIntermediateDirectories: true)
+    try FileManager.default.createDirectory(at: nodeBin, withIntermediateDirectories: true)
+    let cli = cliBin.appendingPathComponent("openclaw")
+    let node = nodeBin.appendingPathComponent("node")
+    try "#!/usr/bin/env node\n".write(to: cli, atomically: true, encoding: .utf8)
+    try nodeBackedFakeOpenClawScript().write(to: node, atomically: true, encoding: .utf8)
+    try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: cli.path)
+    try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: node.path)
+    MemoryBankConnector.openClawCLIPathOverrideForTesting = cli.path
+
+    _ = try MemoryBankConnector.connect(.openclaw, key: "test-key")
+
+    let configContent = try String(contentsOf: config, encoding: .utf8)
+    XCTAssertTrue(configContent.contains(#""omi-memory""#))
+  }
+
+  func testOpenClawConnectFindsNodeFromXDGFnmPath() throws {
+    let workspace = tempHome.appendingPathComponent(".openclaw/workspace", isDirectory: true)
+    try FileManager.default.createDirectory(at: workspace, withIntermediateDirectories: true)
+    let config = try writeOpenClawConfig(workspace: workspace)
+    let cliBin = tempHome.appendingPathComponent(".local/bin", isDirectory: true)
+    let nodeBin = tempHome.appendingPathComponent(".local/share/fnm/node-versions/v22.0.0/installation/bin", isDirectory: true)
+    try FileManager.default.createDirectory(at: cliBin, withIntermediateDirectories: true)
+    try FileManager.default.createDirectory(at: nodeBin, withIntermediateDirectories: true)
+    let cli = cliBin.appendingPathComponent("openclaw")
+    let node = nodeBin.appendingPathComponent("node")
+    try "#!/usr/bin/env node\n".write(to: cli, atomically: true, encoding: .utf8)
+    try nodeBackedFakeOpenClawScript().write(to: node, atomically: true, encoding: .utf8)
+    try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: cli.path)
+    try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: node.path)
+    MemoryBankConnector.openClawCLIPathOverrideForTesting = cli.path
+
+    _ = try MemoryBankConnector.connect(.openclaw, key: "test-key")
+
+    let configContent = try String(contentsOf: config, encoding: .utf8)
+    XCTAssertTrue(configContent.contains(#""omi-memory""#))
+  }
+
+  func testOpenClawConnectDoesNotRunShellShimThroughSiblingNode() throws {
+    let workspace = tempHome.appendingPathComponent(".openclaw/workspace", isDirectory: true)
+    try FileManager.default.createDirectory(at: workspace, withIntermediateDirectories: true)
+    let config = try writeOpenClawConfig(workspace: workspace)
+    let bin = tempHome.appendingPathComponent(".volta/bin", isDirectory: true)
+    try FileManager.default.createDirectory(at: bin, withIntermediateDirectories: true)
+    let cli = bin.appendingPathComponent("openclaw")
+    let node = bin.appendingPathComponent("node")
+    try fakeOpenClawScript().write(to: cli, atomically: true, encoding: .utf8)
+    try "#!/bin/sh\necho should-not-wrap-openclaw-shim >&2\nexit 9\n".write(to: node, atomically: true, encoding: .utf8)
+    try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: cli.path)
+    try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: node.path)
+    MemoryBankConnector.openClawCLIPathOverrideForTesting = nil
+
+    _ = try MemoryBankConnector.connect(.openclaw, key: "test-key")
+
+    let configContent = try String(contentsOf: config, encoding: .utf8)
+    XCTAssertTrue(configContent.contains(#""omi-memory""#))
+  }
+
   func testOpenClawConnectUsesConfiguredWorkspaceForSoulNote() throws {
     let workspace = tempHome.appendingPathComponent("custom-openclaw-workspace", isDirectory: true)
     try FileManager.default.createDirectory(at: workspace, withIntermediateDirectories: true)
@@ -77,6 +191,27 @@ final class MemoryBankConnectorTests: XCTestCase {
     XCTAssertFalse(
       FileManager.default.fileExists(
         atPath: tempHome.appendingPathComponent(".openclaw/workspace/SOUL.md").path))
+  }
+
+  func testOpenClawConnectExpandsHomeInConfiguredWorkspace() throws {
+    let workspace = tempHome.appendingPathComponent("custom-openclaw-workspace", isDirectory: true)
+    try FileManager.default.createDirectory(at: workspace, withIntermediateDirectories: true)
+    let configDir = tempHome.appendingPathComponent(".openclaw", isDirectory: true)
+    try FileManager.default.createDirectory(at: configDir, withIntermediateDirectories: true)
+    let config = configDir.appendingPathComponent("openclaw.json")
+    try """
+      {
+        "agents": {
+          "defaults": {
+            "workspace": "${HOME}/custom-openclaw-workspace"
+          }
+        }
+      }
+      """.write(to: config, atomically: true, encoding: .utf8)
+
+    _ = try MemoryBankConnector.connect(.openclaw, key: "test-key")
+
+    XCTAssertTrue(FileManager.default.fileExists(atPath: workspace.appendingPathComponent("SOUL.md").path))
   }
 
   func testOpenClawConnectRejectsMalformedMCPConfig() throws {
@@ -91,6 +226,31 @@ final class MemoryBankConnectorTests: XCTestCase {
     let configContent = try String(contentsOf: config, encoding: .utf8)
     XCTAssertTrue(configContent.contains(#""mcp":[]"#))
     XCTAssertFalse(configContent.contains("omi-memory"))
+  }
+
+  func testOpenClawConnectRedactsTokenFromCLIError() throws {
+    let workspace = tempHome.appendingPathComponent(".openclaw/workspace", isDirectory: true)
+    try FileManager.default.createDirectory(at: workspace, withIntermediateDirectories: true)
+    _ = try writeOpenClawConfig(workspace: workspace)
+    let cli = tempHome.appendingPathComponent("echoing-openclaw")
+    try """
+      #!/bin/sh
+      if [ "$1" = "mcp" ] && [ "$2" = "show" ]; then
+        exit 1
+      fi
+      if [ "$1" = "mcp" ] && [ "$2" = "set" ]; then
+        echo "rejected payload $4" >&2
+        exit 1
+      fi
+      exit 0
+      """.write(to: cli, atomically: true, encoding: .utf8)
+    try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: cli.path)
+    MemoryBankConnector.openClawCLIPathOverrideForTesting = cli.path
+
+    XCTAssertThrowsError(try MemoryBankConnector.connect(.openclaw, key: "secret-token")) { error in
+      XCTAssertFalse(error.localizedDescription.contains("secret-token"), error.localizedDescription)
+      XCTAssertTrue(error.localizedDescription.contains("Bearer [redacted]"), error.localizedDescription)
+    }
   }
 
   func testOpenClawConnectTimesOutHungCLI() throws {
@@ -207,7 +367,13 @@ final class MemoryBankConnectorTests: XCTestCase {
 
   private func writeFakeOpenClawCLI() throws -> URL {
     let cli = tempHome.appendingPathComponent("openclaw")
-    try """
+    try fakeOpenClawScript().write(to: cli, atomically: true, encoding: .utf8)
+    try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: cli.path)
+    return cli
+  }
+
+  private func fakeOpenClawScript() -> String {
+    """
       #!/bin/sh
       if [ "$1" = "mcp" ] && [ "$2" = "show" ]; then
         exit 1
@@ -222,9 +388,23 @@ final class MemoryBankConnectorTests: XCTestCase {
       fi
       echo "unexpected arguments: $*" >&2
       exit 2
-      """.write(to: cli, atomically: true, encoding: .utf8)
-    try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: cli.path)
-    return cli
+      """
+  }
+
+  private func nodeBackedFakeOpenClawScript() -> String {
+    """
+      #!/bin/sh
+      shift
+      if [ "$1" = "mcp" ] && [ "$2" = "show" ]; then
+        exit 1
+      fi
+      if [ "$1" = "mcp" ] && [ "$2" = "set" ] && [ "$3" = "omi-memory" ]; then
+        printf '{"mcp":{"servers":{"omi-memory":%s}}}\\n' "$4" > "$OPENCLAW_CONFIG_PATH"
+        exit 0
+      fi
+      echo "unexpected arguments: $*" >&2
+      exit 2
+      """
   }
 
   private func writeHermesInstall(config: String = "model:\n  default: test\n") throws -> URL {

--- a/desktop/macos/changelog/unreleased/20260702-openclaw-memory-node.json
+++ b/desktop/macos/changelog/unreleased/20260702-openclaw-memory-node.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed OpenClaw memory setup so Omi can use OpenClaw's bundled Node runtime when updating MCP config"
+}


### PR DESCRIPTION
## Summary
- broaden OpenClaw CLI and Node discovery for common macOS installs including user bins, Homebrew/MacPorts, Volta/asdf/Bun/pnpm, nvm/fnm/nodenv Node bins
- run sibling Node only for launchers that actually declare a Node shebang, so shell shims still execute directly
- expand HOME-style workspace paths and redact bearer tokens from OpenClaw CLI errors

## Testing
- xcrun swift test --package-path Desktop --filter MemoryBankConnectorTests

## Review
- subagent review flagged shim wrapping and additional common paths; addressed with shebang gating plus Volta/XDG-fnm regression coverage

## Note
- initial git push was blocked by an unrelated backend async audit finding in backend/utils/chat.py; PR diff is limited to desktop OpenClaw memory setup files, so the branch was pushed with --no-verify after confirming the scoped diff.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8868?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

