### PR TITLE
[codex] Fix desktop connector connected status

### DIFF
--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/AppsPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/AppsPage.swift
@@ -657,6 +657,7 @@ final class ImportConnectorStatusStore: ObservableObject {
     private let lastSyncedAtKeyPrefix = "appsImportConnectorLastSyncedAt."
     private let lastDeltaCountKeyPrefix = "appsImportConnectorLastDeltaCount."
     private let hasLastDeltaKeyPrefix = "appsImportConnectorHasLastDelta."
+    private let availabilityTextKeyPrefix = "appsImportConnectorAvailabilityText."
     private let manualConnectorIDs: Set<String> = ["chatgpt", "claude"]
     private let onboardingChatGPTImportedMemoriesKey = "onboardingChatGPTImportedMemoriesCount"
     private let onboardingClaudeImportedMemoriesKey = "onboardingClaudeImportedMemoriesCount"
@@ -716,6 +717,7 @@ final class ImportConnectorStatusStore: ObservableObject {
         }
         if let availabilityText {
             metrics.availabilityText = availabilityText
+            defaults.set(availabilityText, forKey: availabilityTextKeyPrefix + connectorID)
         }
         metricsByID[connectorID] = metrics
     }
@@ -726,6 +728,7 @@ final class ImportConnectorStatusStore: ObservableObject {
         defaults.removeObject(forKey: lastSyncedAtKeyPrefix + connectorID)
         defaults.removeObject(forKey: lastDeltaCountKeyPrefix + connectorID)
         defaults.removeObject(forKey: hasLastDeltaKeyPrefix + connectorID)
+        defaults.removeObject(forKey: availabilityTextKeyPrefix + connectorID)
         metricsByID[connectorID] = ConnectorMetrics()
     }
 
@@ -753,6 +756,7 @@ final class ImportConnectorStatusStore: ObservableObject {
             if defaults.bool(forKey: hasLastDeltaKeyPrefix + connector.id) {
                 metrics.lastDeltaCount = defaults.integer(forKey: lastDeltaCountKeyPrefix + connector.id)
             }
+            metrics.availabilityText = defaults.string(forKey: availabilityTextKeyPrefix + connector.id)
 
             metricsByID[connector.id] = metrics
         }
@@ -804,6 +808,7 @@ final class ImportConnectorStatusStore: ObservableObject {
             metrics.sourceCount = result.count
             metrics.lastSyncedAt = result.lastIndexedAt
             metrics.availabilityText = "On-device index"
+            defaults.set("On-device index", forKey: availabilityTextKeyPrefix + "local-files")
             metricsByID["local-files"] = metrics
         } catch {
             log("ImportConnectorStatusStore: Failed to refresh local files metrics: \(error)")
@@ -817,6 +822,7 @@ final class ImportConnectorStatusStore: ObservableObject {
             var metrics = metricsByID["apple-notes"] ?? ConnectorMetrics()
             metrics.sourceCount = noteCount
             metrics.availabilityText = "Private notes accessible"
+            defaults.set("Private notes accessible", forKey: availabilityTextKeyPrefix + "apple-notes")
             metricsByID["apple-notes"] = metrics
         case .needsAccess(_, let reasonCode), .error(_, let reasonCode):
             log("ImportConnectorStatusStore: Apple Notes refresh unavailable code=\(reasonCode)")

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
@@ -318,6 +318,7 @@ struct DashboardPage: View {
                 NotificationCenter.default.post(name: .showTryAskingPopup, object: nil)
             }
             syncCaptureState()
+            Task { await importConnectorStatusStore.refresh() }
             Task { await loadScreenshotCount() }
             Task { await loadKnowledgeCounts() }
             Task { await loadMemoryExportStatuses() }
@@ -326,6 +327,7 @@ struct DashboardPage: View {
             viewModel.refreshGoals()
             appState.checkAllPermissions()
             syncCaptureState()
+            Task { await importConnectorStatusStore.refresh() }
             Task { await loadScreenshotCount() }
             Task { await loadKnowledgeCounts() }
             Task { await loadMemoryExportStatuses() }

--- a/desktop/macos/Desktop/Sources/MemoryExportConnectionDetector.swift
+++ b/desktop/macos/Desktop/Sources/MemoryExportConnectionDetector.swift
@@ -1,0 +1,139 @@
+import Foundation
+
+enum MemoryExportConnectionDetector {
+  static var homeOverrideForTesting: URL?
+
+  private static var home: URL {
+    homeOverrideForTesting ?? FileManager.default.homeDirectoryForCurrentUser
+  }
+
+  static func hasExistingConnection(for destination: MemoryExportDestination) -> Bool {
+    switch destination {
+    case .codex:
+      return codexConfigHasOmiMCP(home.appendingPathComponent(".codex/config.toml"))
+    case .claude:
+      return jsonConfigHasOmiMCP(
+        home.appendingPathComponent("Library/Application Support/Claude/claude_desktop_config.json"),
+        serverPath: ["mcpServers", "omi-memory"])
+    case .claudeCode:
+      return [
+        home.appendingPathComponent(".claude.json"),
+        home.appendingPathComponent(".claude/settings.json"),
+      ].contains { jsonConfigHasOmiMCP($0, serverPath: ["mcpServers", "omi-memory"]) }
+    case .hermes:
+      return hermesConfigHasOmiMCP(home.appendingPathComponent(".hermes/config.yaml"))
+    case .openclaw:
+      return jsonConfigHasOmiMCP(
+        home.appendingPathComponent(".openclaw/openclaw.json"),
+        serverPath: ["mcp", "servers", "omi-memory"])
+    case .notion, .obsidian, .chatgpt, .gemini, .agents:
+      return false
+    }
+  }
+
+  private static func codexConfigHasOmiMCP(_ url: URL) -> Bool {
+    guard let content = try? String(contentsOf: url, encoding: .utf8) else { return false }
+
+    var inOmiServer = false
+    var body = ""
+    for rawLine in content.components(separatedBy: .newlines) {
+      let line = stripInlineComment(rawLine, comment: "#").trimmingCharacters(in: .whitespaces)
+      guard !line.isEmpty else { continue }
+      if line.hasPrefix("[") && line.hasSuffix("]") {
+        inOmiServer = line == "[mcp_servers.omi-memory]"
+        continue
+      }
+      if inOmiServer {
+        body += "\n" + line
+      }
+    }
+    return bodyContainsOmiEndpoint(body)
+  }
+
+  private static func hermesConfigHasOmiMCP(_ url: URL) -> Bool {
+    guard let content = try? String(contentsOf: url, encoding: .utf8) else { return false }
+
+    var inMCPServers = false
+    var inOmiServer = false
+    var body = ""
+    for rawLine in content.components(separatedBy: .newlines) {
+      let line = stripInlineComment(rawLine, comment: "#")
+      let trimmed = line.trimmingCharacters(in: .whitespaces)
+      guard !trimmed.isEmpty else { continue }
+
+      if !line.hasPrefix(" "), !line.hasPrefix("\t") {
+        inMCPServers = trimmed == "mcp_servers:"
+        inOmiServer = false
+        continue
+      }
+      guard inMCPServers else { continue }
+
+      if line.hasPrefix("  "), !line.hasPrefix("    "), trimmed.hasSuffix(":") {
+        inOmiServer = trimmed == "omi-memory:"
+        continue
+      }
+      if inOmiServer {
+        body += "\n" + trimmed
+      }
+    }
+    return bodyContainsOmiEndpoint(body)
+  }
+
+  private static func jsonConfigHasOmiMCP(_ url: URL, serverPath: [String]) -> Bool {
+    guard
+      let data = try? Data(contentsOf: url),
+      let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+      let server = value(in: json, at: serverPath) as? [String: Any],
+      server["disabled"] as? Bool != true,
+      server["enabled"] as? Bool != false
+    else {
+      return false
+    }
+    return bodyContainsOmiEndpoint(stringValues(in: server).joined(separator: "\n"))
+  }
+
+  private static func value(in dictionary: [String: Any], at path: [String]) -> Any? {
+    var current: Any? = dictionary
+    for key in path {
+      current = (current as? [String: Any])?[key]
+    }
+    return current
+  }
+
+  private static func stringValues(in value: Any) -> [String] {
+    if let string = value as? String {
+      return [string]
+    }
+    if let array = value as? [Any] {
+      return array.flatMap(stringValues)
+    }
+    if let dictionary = value as? [String: Any] {
+      return dictionary.values.flatMap(stringValues)
+    }
+    return []
+  }
+
+  private static func bodyContainsOmiEndpoint(_ body: String) -> Bool {
+    let lower = body.lowercased()
+    return lower.contains("api.omi") && lower.contains("/v1/mcp/sse")
+  }
+
+  private static func stripInlineComment(_ line: String, comment: Character) -> String {
+    var result = ""
+    var isInSingleQuote = false
+    var isInDoubleQuote = false
+    var previous: Character?
+    for character in line {
+      if character == "'", !isInDoubleQuote {
+        isInSingleQuote.toggle()
+      } else if character == "\"", !isInSingleQuote, previous != "\\" {
+        isInDoubleQuote.toggle()
+      } else if character == comment, !isInSingleQuote, !isInDoubleQuote {
+        break
+      }
+      result.append(character)
+      previous = character
+    }
+    return result
+  }
+}

--- a/desktop/macos/Desktop/Sources/MemoryExportService.swift
+++ b/desktop/macos/Desktop/Sources/MemoryExportService.swift
@@ -509,13 +509,16 @@ enum MemoryExportDestination: String, CaseIterable, Identifiable, Sendable {
     guard let setup = mcpSetup(key: key) else { return nil }
     switch self {
     case .claude:
+      // Public OAuth client: match the manual setup copy and native automation.
+      // Claude may render a secret field, but the backend expects it to stay blank.
       return [
         CloudConnectorCopyField(id: "name", label: "Name", value: "Omi Memory"),
         CloudConnectorCopyField(
           id: "server_url", label: "Remote MCP server URL", value: setup.serverURL),
-        CloudConnectorCopyField(id: "oauth_client_id", label: "OAuth Client ID", value: "omi"),
         CloudConnectorCopyField(
-          id: "oauth_client_secret", label: "OAuth Client Secret", value: key, masksValue: true),
+          id: "oauth_client_id", label: "OAuth Client ID", value: cloudOAuthClientID ?? ""),
+        CloudConnectorCopyField(
+          id: "oauth_client_secret", label: "OAuth Client Secret", value: "", masksValue: false),
       ]
     case .chatgpt:
       // Public PKCE client: the backend rejects token requests that carry a
@@ -649,7 +652,10 @@ actor MemoryExportService {
     }
 
     let detailText = defaults.string(forKey: destination.detailKey)
-    let hasConnection = exportedCount > 0 || defaults.double(forKey: destination.connectedAtKey) > 0
+    let hasConnection =
+      exportedCount > 0
+      || defaults.double(forKey: destination.connectedAtKey) > 0
+      || MemoryExportConnectionDetector.hasExistingConnection(for: destination)
     let isConfigured: Bool
     switch destination {
     case .obsidian:
@@ -660,7 +666,9 @@ actor MemoryExportService {
         && LocalAgentAPISettings.storedToken() != nil
     case .claudeCode, .codex, .openclaw, .hermes:
       isConfigured = hasStoredMCPKey
-    case .notion, .chatgpt, .claude, .gemini:
+    case .chatgpt, .claude:
+      isConfigured = hasConnection
+    case .notion, .gemini:
       isConfigured = exportedCount > 0
     }
 

--- a/desktop/macos/Desktop/Tests/BrowserAutomationTargetTests.swift
+++ b/desktop/macos/Desktop/Tests/BrowserAutomationTargetTests.swift
@@ -48,10 +48,16 @@ final class BrowserAutomationTargetTests: XCTestCase {
     XCTAssertEqual(
       MemoryExportDestination.chatgpt.assistedSetupFields(key: "k")?
         .first(where: { $0.label == "OAuth Client Secret" })?.masksValue, false)
-    // Claude secret must be masked on screen.
+    // Claude cloud uses a public OAuth client too — the secret row must stay blank.
     XCTAssertEqual(
       MemoryExportDestination.claude.assistedSetupFields(key: "secret-key")?
-        .first(where: { $0.label == "OAuth Client Secret" })?.masksValue, true)
+        .first(where: { $0.label == "OAuth Client ID" })?.value, "omi-claude-prod")
+    XCTAssertEqual(
+      MemoryExportDestination.claude.assistedSetupFields(key: "secret-key")?
+        .first(where: { $0.label == "OAuth Client Secret" })?.value, "")
+    XCTAssertEqual(
+      MemoryExportDestination.claude.assistedSetupFields(key: "secret-key")?
+        .first(where: { $0.label == "OAuth Client Secret" })?.masksValue, false)
     // Stable ids — never label-derived (duplicate labels would crash ForEach).
     let chatgptIDs = MemoryExportDestination.chatgpt.assistedSetupFields(key: "k")?.map(\.id) ?? []
     XCTAssertEqual(Set(chatgptIDs).count, chatgptIDs.count)

--- a/desktop/macos/Desktop/Tests/ImportConnectorStatusStoreTests.swift
+++ b/desktop/macos/Desktop/Tests/ImportConnectorStatusStoreTests.swift
@@ -1,0 +1,52 @@
+import XCTest
+
+@testable import Omi_Computer
+
+@MainActor
+final class ImportConnectorStatusStoreTests: XCTestCase {
+  override func setUp() {
+    super.setUp()
+    resetImportConnectorDefaults()
+  }
+
+  override func tearDown() {
+    resetImportConnectorDefaults()
+    super.tearDown()
+  }
+
+  func testAvailabilityTextMarksZeroCountConnectorConnectedAcrossStoreReloads() {
+    let connector = ImportConnector.all.first { $0.id == "apple-notes" }!
+    let store = ImportConnectorStatusStore()
+
+    store.markSynced(
+      connectorID: "apple-notes",
+      sourceCount: 0,
+      memoryCount: 0,
+      lastDeltaCount: 0,
+      availabilityText: "Private notes accessible")
+
+    let immediate = store.snapshot(for: connector)
+    let reloaded = ImportConnectorStatusStore().snapshot(for: connector)
+
+    XCTAssertTrue(immediate.isConnected)
+    XCTAssertEqual(immediate.actionTitle, "Sync now")
+    XCTAssertTrue(reloaded.isConnected)
+    XCTAssertEqual(reloaded.primaryText, "Private notes accessible")
+  }
+
+  private func resetImportConnectorDefaults() {
+    let prefixes = [
+      "appsImportConnectorSourceCount.",
+      "appsImportConnectorMemoryCount.",
+      "appsImportConnectorLastSyncedAt.",
+      "appsImportConnectorLastDeltaCount.",
+      "appsImportConnectorHasLastDelta.",
+      "appsImportConnectorAvailabilityText.",
+    ]
+    for connector in ImportConnector.all {
+      for prefix in prefixes {
+        UserDefaults.standard.removeObject(forKey: prefix + connector.id)
+      }
+    }
+  }
+}

--- a/desktop/macos/Desktop/Tests/MemoryExportStatusTests.swift
+++ b/desktop/macos/Desktop/Tests/MemoryExportStatusTests.swift
@@ -3,13 +3,23 @@ import XCTest
 @testable import Omi_Computer
 
 final class MemoryExportStatusTests: XCTestCase {
+  private var tempHome: URL!
+
   override func setUp() {
     super.setUp()
     resetMemoryExportDefaults()
+    tempHome = FileManager.default.temporaryDirectory
+      .appendingPathComponent("memory-export-status-\(UUID().uuidString)", isDirectory: true)
+    try? FileManager.default.createDirectory(at: tempHome, withIntermediateDirectories: true)
+    MemoryExportConnectionDetector.homeOverrideForTesting = tempHome
   }
 
   override func tearDown() {
     resetMemoryExportDefaults()
+    MemoryExportConnectionDetector.homeOverrideForTesting = nil
+    if let tempHome {
+      try? FileManager.default.removeItem(at: tempHome)
+    }
     super.tearDown()
   }
 
@@ -43,6 +53,137 @@ final class MemoryExportStatusTests: XCTestCase {
     let status = await MemoryExportService.shared.status(for: .claude)
 
     XCTAssertTrue(status.isConfigured)
+    XCTAssertTrue(status.hasConnection)
+  }
+
+  func testExistingCodexMCPConfigMarksCodexConnected() async throws {
+    UserDefaults.standard.set("test-key", forKey: "memoryExportMCPApiKey")
+    let codex = tempHome.appendingPathComponent(".codex", isDirectory: true)
+    try FileManager.default.createDirectory(at: codex, withIntermediateDirectories: true)
+    try """
+      [mcp_servers.omi-memory]
+      command = "npx"
+      args = ["-y", "mcp-remote", "https://api.omi.me/v1/mcp/sse", "--header", "Authorization: Bearer test-key"]
+      """.write(to: codex.appendingPathComponent("config.toml"), atomically: true, encoding: .utf8)
+
+    let codexStatus = await MemoryExportService.shared.status(for: .codex)
+    let chatGPTStatus = await MemoryExportService.shared.status(for: .chatgpt)
+
+    XCTAssertTrue(codexStatus.isConfigured)
+    XCTAssertTrue(codexStatus.hasConnection)
+    XCTAssertFalse(chatGPTStatus.hasConnection)
+  }
+
+  func testCommentedCodexMCPConfigDoesNotMarkCodexConnected() async throws {
+    UserDefaults.standard.set("test-key", forKey: "memoryExportMCPApiKey")
+    let codex = tempHome.appendingPathComponent(".codex", isDirectory: true)
+    try FileManager.default.createDirectory(at: codex, withIntermediateDirectories: true)
+    try """
+      # [mcp_servers.omi-memory]
+      # command = "npx"
+      # args = ["-y", "mcp-remote", "https://api.omi.me/v1/mcp/sse", "--header", "Authorization: Bearer test-key"]
+      """.write(to: codex.appendingPathComponent("config.toml"), atomically: true, encoding: .utf8)
+
+    let status = await MemoryExportService.shared.status(for: .codex)
+
+    XCTAssertFalse(status.hasConnection)
+  }
+
+  func testExistingClaudeMCPConfigMarksClaudeCodeConnected() async throws {
+    UserDefaults.standard.set("test-key", forKey: "memoryExportMCPApiKey")
+    try """
+      {
+        "mcpServers": {
+          "omi-memory": {
+            "type": "http",
+            "url": "https://api.omiapi.com/v1/mcp/sse"
+          }
+        }
+      }
+      """.write(to: tempHome.appendingPathComponent(".claude.json"), atomically: true, encoding: .utf8)
+
+    let status = await MemoryExportService.shared.status(for: .claudeCode)
+
+    XCTAssertTrue(status.isConfigured)
+    XCTAssertTrue(status.hasConnection)
+  }
+
+  func testClaudeDesktopConfigMarksClaudeNotClaudeCodeConnected() async throws {
+    UserDefaults.standard.set("test-key", forKey: "memoryExportMCPApiKey")
+    let claudeDesktop = tempHome.appendingPathComponent(
+      "Library/Application Support/Claude", isDirectory: true)
+    try FileManager.default.createDirectory(at: claudeDesktop, withIntermediateDirectories: true)
+    try """
+      {
+        "mcpServers": {
+          "omi-memory": {
+            "type": "http",
+            "url": "https://api.omi.me/v1/mcp/sse"
+          }
+        }
+      }
+      """.write(to: claudeDesktop.appendingPathComponent("claude_desktop_config.json"), atomically: true, encoding: .utf8)
+
+    let claudeStatus = await MemoryExportService.shared.status(for: .claude)
+    let claudeCodeStatus = await MemoryExportService.shared.status(for: .claudeCode)
+
+    XCTAssertTrue(claudeStatus.isConfigured)
+    XCTAssertTrue(claudeStatus.hasConnection)
+    XCTAssertTrue(claudeCodeStatus.isConfigured)
+    XCTAssertFalse(claudeCodeStatus.hasConnection)
+  }
+
+  func testDisabledOpenClawMCPConfigDoesNotMarkOpenClawConnected() async throws {
+    UserDefaults.standard.set("test-key", forKey: "memoryExportMCPApiKey")
+    let openClaw = tempHome.appendingPathComponent(".openclaw", isDirectory: true)
+    try FileManager.default.createDirectory(at: openClaw, withIntermediateDirectories: true)
+    try """
+      {
+        "mcp": {
+          "servers": {
+            "omi-memory": {
+              "enabled": false,
+              "url": "https://api.omi.me/v1/mcp/sse"
+            }
+          }
+        }
+      }
+      """.write(to: openClaw.appendingPathComponent("openclaw.json"), atomically: true, encoding: .utf8)
+
+    let status = await MemoryExportService.shared.status(for: .openclaw)
+
+    XCTAssertFalse(status.hasConnection)
+  }
+
+  func testCommentedHermesMCPConfigDoesNotMarkHermesConnected() async throws {
+    UserDefaults.standard.set("test-key", forKey: "memoryExportMCPApiKey")
+    let hermes = tempHome.appendingPathComponent(".hermes", isDirectory: true)
+    try FileManager.default.createDirectory(at: hermes, withIntermediateDirectories: true)
+    try """
+      mcp_servers:
+      #  omi-memory:
+      #    command: npx
+      #    args: ["-y", "mcp-remote", "https://api.omi.me/v1/mcp/sse", "--header", "Authorization: Bearer test-key"]
+      """.write(to: hermes.appendingPathComponent("config.yaml"), atomically: true, encoding: .utf8)
+
+    let status = await MemoryExportService.shared.status(for: .hermes)
+
+    XCTAssertFalse(status.hasConnection)
+  }
+
+  func testExistingHermesMCPConfigMarksHermesConnected() async throws {
+    UserDefaults.standard.set("test-key", forKey: "memoryExportMCPApiKey")
+    let hermes = tempHome.appendingPathComponent(".hermes", isDirectory: true)
+    try FileManager.default.createDirectory(at: hermes, withIntermediateDirectories: true)
+    try """
+      mcp_servers:
+        omi-memory:
+          command: npx
+          args: ["-y", "mcp-remote", "https://api.omi.me/v1/mcp/sse", "--header", "Authorization: Bearer test-key"]
+      """.write(to: hermes.appendingPathComponent("config.yaml"), atomically: true, encoding: .utf8)
+
+    let status = await MemoryExportService.shared.status(for: .hermes)
+
     XCTAssertTrue(status.hasConnection)
   }
 

--- a/desktop/macos/changelog/unreleased/20260702-connector-status-detection.json
+++ b/desktop/macos/changelog/unreleased/20260702-connector-status-detection.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed connector rows showing disconnected when Notes or local MCP clients are already set up"
+}


### PR DESCRIPTION
## Summary

Fixes desktop Dashboard connector rows that could stay visually disconnected even when the local app or MCP client is already configured.

- Detect existing active local Omi MCP config for Codex, Claude Desktop, Claude Code, Hermes, and OpenClaw.
- Keep Claude Desktop config mapped to the Claude side of the row, not Claude Code.
- Parse active config structure instead of raw substring matches, so commented TOML/YAML blocks and disabled OpenClaw JSON entries do not show false `Connected` indicators.
- Refresh import connector status from the Dashboard lifecycle, not only from the Apps page.
- Persist connector availability text so accessible zero-count sources such as Apple Notes still count as connected after reload.
- Correct Claude cloud setup copy to use the public OAuth client ID and leave the client secret blank.

## Root Cause

The Dashboard used stored export/import counters and explicit `markConnected` timestamps, but it did not inspect existing local MCP config files. Import connector availability text was also not persisted, so a source could be accessible without producing a stable connected label.

The first implementation checked for raw Omi MCP substrings, which could count inactive/commented config. It also treated Claude Desktop config as Claude Code config. This revision checks destination-specific active config locations and disabled flags.

## Validation

- `xcrun swift test --package-path Desktop --filter 'MemoryExportStatusTests|ImportConnectorStatusStoreTests|BrowserAutomationTargetTests/testDestinationModesSeparateCloudBrowserAndLocalSetup'` — 12 tests, 0 failures
- `xcrun swift build -c debug --package-path Desktop`
- `git diff --check`
- Launched `/Applications/omi-connector-status.app` and captured the Dashboard through the in-process automation bridge; Claude/Claude Code, ChatGPT/Codex, and Hermes show `Connected`; OpenClaw stays disconnected without an active config.

Note: `git push` pre-push checks fail locally when comparing this branch against stale `fork/main`, selecting an unrelated existing backend async-blocker finding in `backend/utils/chat.py`. The branch is based on current `origin/main`, and the desktop-specific checks above passed.
