### PR TITLE
Shorten home memory export subtitle to one line

### DIFF
--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
@@ -575,7 +575,7 @@ struct DashboardPage: View {
                     .font(.system(size: 22, weight: .medium, design: .serif))
                     .foregroundStyle(HomePalette.ink)
 
-                Text("Bring your memories and tasks into the apps you already use")
+                Text("Bring your memories to the apps you use")
                     .scaledFont(size: 12, weight: .medium)
                     .foregroundStyle(HomePalette.muted)
                     .fixedSize(horizontal: false, vertical: true)

--- a/desktop/macos/changelog/unreleased/20260702-home-subtitle-one-line.json
+++ b/desktop/macos/changelog/unreleased/20260702-home-subtitle-one-line.json
@@ -1,0 +1,3 @@
+{
+    "change": "Home: shortened the memory export subtitle so it fits on one line"
+}


### PR DESCRIPTION
"Bring your memories and tasks into the apps you already use" wrapped to two lines; per Nik's request it is now "Bring your memories to the apps you use" which renders on one line (verified in a local omi-subtitle named bundle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8871?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

