### PR TITLE
fix: hide memory tier fields from legacy responses

### DIFF
--- a/backend/models/memories.py
+++ b/backend/models/memories.py
@@ -543,15 +543,16 @@ class MemoryDB(Memory):
     kg_extracted: bool = False
     evidence: List[Evidence] = Field(default_factory=list)
 
-    # memory tiering. Pre-memory docs lack this field and read back as long_term, so
-    # the existing UI is unchanged; newly produced memories are tiered at birth
-    # (decide_initial_memory_tier) and may be promoted on corroboration.
-    memory_tier: MemoryTier = MemoryTier.long_term
+    # Canonical memory tiering. Legacy API/service boundaries set this to None
+    # so non-cohort users cannot receive Short-term/Long-term rollout state.
+    memory_tier: Optional[MemoryTier] = None
 
     @computed_field  # type: ignore[prop-decorator]
     @property
-    def layer(self) -> str:
+    def layer(self) -> Optional[str]:
         """Canonical product lifecycle layer (Q6/WS-K); derived from memory_tier at serialization only."""
+        if self.memory_tier is None:
+            return None
         return tier_to_layer(self.memory_tier).value
 
     # Temporal lifecycle — the "constantly updated brain". All optional, so existing

--- a/backend/routers/mcp_sse.py
+++ b/backend/routers/mcp_sse.py
@@ -50,6 +50,7 @@ from utils.memory.memory_service import (
     raise_if_legacy_write_blocked,
     resolve_external_memory_write_context,
 )
+from utils.memory.memory_api_contract import MemoryApiExposure, memory_api_payload
 from utils.memory.memory_system import MemorySystem
 from utils.memory.product_authorization import (
     ProductAuthorizationContext,
@@ -900,7 +901,12 @@ def execute_tool(
         except HTTPException as exc:
             _raise_tool_error_from_http(exc)
 
-        return {"success": True, "memory": memory_db.model_dump()}
+        exposure = (
+            MemoryApiExposure.CANONICAL
+            if write_context.memory_system == MemorySystem.CANONICAL
+            else MemoryApiExposure.LEGACY
+        )
+        return {"success": True, "memory": memory_api_payload(memory_db, exposure)}
 
     elif tool_name == "delete_memory":
         memory_id = arguments.get("memory_id")

--- a/backend/routers/memories.py
+++ b/backend/routers/memories.py
@@ -600,7 +600,12 @@ def get_memories(
     )
     if memory_response.http_status != 200:
         _raise_memory_http_exception(memory_response)
-    return [MemoryDB.model_validate(item) for item in memory_response.body or []]
+    headers = _memory_allowlisted_headers(memory_response)
+    headers['Cache-Control'] = 'no-store'
+    return JSONResponse(
+        content=jsonable_encoder(memory_api_payloads(memory_response.body or [], MemoryApiExposure.CANONICAL)),
+        headers=headers,
+    )
 
 
 @router.get('/v3/memories/review-queue', tags=['memories'])

--- a/backend/routers/memories.py
+++ b/backend/routers/memories.py
@@ -32,6 +32,12 @@ from utils.memory.canonical_memory_adapter import (
 from utils.memory.memory_service import MemoryService, fetch_memory_dict
 from utils.memory.required_promotion import required_promotion_payload
 from utils.memory.import_write_guard import import_write_block_mode, import_write_violation
+from utils.memory.memory_api_contract import (
+    MemoryApiExposure,
+    memory_api_payload,
+    memory_api_payloads,
+    memory_write_payload,
+)
 from utils.memory.memory_system import MemorySystem
 from utils.client_device import DeviceScopeRequest, DeviceScopeValidationError, resolve_client_device
 from utils.memory.device_scope_filter import device_scope_validation_error
@@ -181,16 +187,30 @@ def _legacy_get_memories(uid: str, limit: int, offset: int) -> List[MemoryDB]:
 def _legacy_memories_response(memories: List[MemoryDB]) -> JSONResponse:
     """Serialize legacy memories without canonical lifecycle fields.
 
-    ``MemoryDB`` carries ``memory_tier`` plus a computed ``layer`` for canonical
-    memory responses. Returning those through the legacy `/v3/memories` path
-    makes non-cohort desktop clients think the canonical Short-term layer is
-    enabled. Keep the legacy shape intentionally badge-less.
+    The single source of truth for which fields are canonical-only lives in
+    ``utils.memory.memory_api_contract``. Keep this wrapper small so every
+    legacy response takes the same field contract.
     """
 
-    body = [jsonable_encoder(memory, exclude={'memory_tier', 'layer'}) for memory in memories]
+    body = jsonable_encoder(memory_api_payloads(memories, MemoryApiExposure.LEGACY))
     return JSONResponse(
         content=body,
         headers={'X-Omi-Memory-Device-Scope-Supported': 'false'},
+    )
+
+
+def _legacy_memory_response(memory: MemoryDB) -> JSONResponse:
+    return JSONResponse(content=jsonable_encoder(memory_api_payload(memory, MemoryApiExposure.LEGACY)))
+
+
+def _legacy_batch_memories_response(memories: List[MemoryDB]) -> JSONResponse:
+    return JSONResponse(
+        content=jsonable_encoder(
+            {
+                'memories': memory_api_payloads(memories, MemoryApiExposure.LEGACY),
+                'created_count': len(memories),
+            }
+        )
     )
 
 
@@ -298,7 +318,7 @@ async def create_memory(
 
     # Build payload outside try so serialization bugs aren't misreported as
     # transient 503s — only the Firestore write should be retryable.
-    payload = memory_db.dict()
+    payload = memory_db.model_dump()
 
     db_client = getattr(db_client_module, 'db', None)
     if _canonical_write_enabled_or_fail_closed(uid, db_client=db_client):
@@ -316,13 +336,21 @@ async def create_memory(
             )
             if item is not None:
                 return memory_item_to_memorydb(item)
-            return memory_db
+            logger.error(
+                "Canonical create_memory readback missing uid=%s memory_id=%s", uid, committed_id or memory_db.id
+            )
+            raise HTTPException(status_code=503, detail="Service temporarily unavailable")
         except Exception:
             logger.exception("Canonical create_memory failed uid=%s", uid)
             raise HTTPException(status_code=503, detail="Service temporarily unavailable")
 
     try:
-        await run_blocking(db_executor, memories_db.create_memory, uid, payload)
+        await run_blocking(
+            db_executor,
+            memories_db.create_memory,
+            uid,
+            memory_write_payload(memory_db, MemoryApiExposure.LEGACY),
+        )
     except Exception:
         logger.exception("Firestore create_memory failed uid=%s", uid)
         raise HTTPException(status_code=503, detail="Service temporarily unavailable")
@@ -340,7 +368,7 @@ async def create_memory(
     except Exception:
         logger.exception("Vector upsert failed uid=%s memory_id=%s (memory saved, vector missing)", uid, memory_db.id)
 
-    return memory_db
+    return _legacy_memory_response(memory_db)
 
 
 @router.post(
@@ -410,7 +438,8 @@ async def create_memories_batch(
             if item is not None:
                 server_memories.append(memory_item_to_memorydb(item))
             else:
-                server_memories.append(next(m for m in memory_dbs if m.id == memory_id))
+                logger.error("Canonical create_memories_batch readback missing uid=%s memory_id=%s", uid, memory_id)
+                raise HTTPException(status_code=503, detail="Service temporarily unavailable")
         return BatchMemoriesResponse(memories=server_memories, created_count=len(server_memories))
 
     # Persist to Firestore first — that write is the authoritative result.
@@ -419,7 +448,12 @@ async def create_memories_batch(
     # text-embedding-3-large access -> 403) can't 500 a request whose memories
     # were already saved, which would make the client retry and duplicate them.
     try:
-        await run_blocking(db_executor, memories_db.save_memories, uid, [m.dict() for m in memory_dbs])
+        await run_blocking(
+            db_executor,
+            memories_db.save_memories,
+            uid,
+            [memory_write_payload(m, MemoryApiExposure.LEGACY) for m in memory_dbs],
+        )
     except Exception:
         logger.exception("Firestore save_memories failed uid=%s count=%s", uid, len(memory_dbs))
         raise HTTPException(status_code=503, detail="Service temporarily unavailable")
@@ -447,7 +481,7 @@ async def create_memories_batch(
             "Batch vector upsert failed uid=%s count=%s (memories saved, vectors missing)", uid, len(memory_dbs)
         )
 
-    return BatchMemoriesResponse(memories=memory_dbs, created_count=len(memory_dbs))
+    return _legacy_batch_memories_response(memory_dbs)
 
 
 @router.post(

--- a/backend/routers/memories.py
+++ b/backend/routers/memories.py
@@ -6,6 +6,8 @@ import database._client as db_client_module
 from utils.executors import db_executor, postprocess_executor, run_blocking, submit_with_context
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Query, Request, Response
+from fastapi.encoders import jsonable_encoder
+from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field, ValidationError
 
 import database.memories as memories_db
@@ -174,6 +176,22 @@ def _legacy_get_memories(uid: str, limit: int, offset: int) -> List[MemoryDB]:
             )
             continue
     return valid_memories
+
+
+def _legacy_memories_response(memories: List[MemoryDB]) -> JSONResponse:
+    """Serialize legacy memories without canonical lifecycle fields.
+
+    ``MemoryDB`` carries ``memory_tier`` plus a computed ``layer`` for canonical
+    memory responses. Returning those through the legacy `/v3/memories` path
+    makes non-cohort desktop clients think the canonical Short-term layer is
+    enabled. Keep the legacy shape intentionally badge-less.
+    """
+
+    body = [jsonable_encoder(memory, exclude={'memory_tier', 'layer'}) for memory in memories]
+    return JSONResponse(
+        content=body,
+        headers={'X-Omi-Memory-Device-Scope-Supported': 'false'},
+    )
 
 
 def _apply_memory_response_headers(http_response: Response, memory_response: V3ComposedResponse) -> None:
@@ -524,10 +542,10 @@ def get_memories(
             device_scope_request=scope_request,
         )
 
-    _set_device_scope_capability_header(response, supported=False)
-
     if memory_runtime.source_decision != 'memory_read':
-        return _legacy_get_memories(uid, limit, offset)
+        return _legacy_memories_response(_legacy_get_memories(uid, limit, offset))
+
+    _set_device_scope_capability_header(response, supported=False)
 
     if memory_runtime.service is None:
         logger.info("v3_get route=GET /v3/memories source=none status=503 decision=malformed_runtime_dependency")

--- a/backend/tests/unit/test_developer_memory_adapter.py
+++ b/backend/tests/unit/test_developer_memory_adapter.py
@@ -133,7 +133,7 @@ def test_developer_batch_create_route_checks_split_brain_guard_before_categoriza
     categorization = 'identify_category_for_memory(mem_req.content.strip())'
     external_batch = '.create_external_memory_batch('
     guard_call = 'guard_legacy_memory_write('
-    legacy_write = 'memories_db.save_memories(uid, [memory.model_dump() for memory in memory_dbs])'
+    legacy_write = 'memory_write_payload(memory, MemoryApiExposure.LEGACY)'
     vector_write = 'upsert_memory_vectors_batch('
     assert pin_call in route_source
     assert categorization in route_source

--- a/backend/tests/unit/test_memory_api_contract.py
+++ b/backend/tests/unit/test_memory_api_contract.py
@@ -40,3 +40,22 @@ def test_canonical_api_payload_keeps_lifecycle_fields():
 
     assert payload["memory_tier"] == MemoryTier.long_term
     assert payload["layer"] == "long_term"
+
+
+def test_api_payload_strips_internal_memory_fields_for_all_exposures():
+    for exposure in (MemoryApiExposure.LEGACY, MemoryApiExposure.CANONICAL):
+        payload = memory_api_payload(
+            {
+                "id": "m1",
+                "content": "User is testing memory rollout",
+                "memory_only": "strip-me",
+                "memory_source": "compatibility_projection",
+                "read_decision": "internal",
+            },
+            exposure,
+        )
+
+        assert "memory_only" not in payload
+        assert "memory_source" not in payload
+        assert "read_decision" not in payload
+        assert payload["content"] == "User is testing memory rollout"

--- a/backend/tests/unit/test_memory_api_contract.py
+++ b/backend/tests/unit/test_memory_api_contract.py
@@ -1,0 +1,42 @@
+from datetime import datetime, timezone
+
+from models.memories import MemoryDB
+from models.product_memory import MemoryTier
+from utils.memory.memory_api_contract import MemoryApiExposure, memory_api_payload, memory_write_payload
+
+
+def _memory(memory_tier=MemoryTier.short_term):
+    now = datetime(2026, 7, 2, tzinfo=timezone.utc)
+    return MemoryDB(
+        id="m1",
+        uid="uid1",
+        content="User is testing memory rollout",
+        category="system",
+        created_at=now,
+        updated_at=now,
+        memory_tier=memory_tier,
+    )
+
+
+def test_legacy_api_payload_strips_canonical_lifecycle_fields():
+    payload = memory_api_payload(_memory(), MemoryApiExposure.LEGACY)
+
+    assert "memory_tier" not in payload
+    assert "layer" not in payload
+    assert "tier" not in payload
+    assert payload["content"] == "User is testing memory rollout"
+
+
+def test_legacy_write_payload_strips_canonical_lifecycle_fields():
+    payload = memory_write_payload(_memory(MemoryTier.long_term), MemoryApiExposure.LEGACY)
+
+    assert "memory_tier" not in payload
+    assert "layer" not in payload
+    assert "tier" not in payload
+
+
+def test_canonical_api_payload_keeps_lifecycle_fields():
+    payload = memory_api_payload(_memory(MemoryTier.long_term), MemoryApiExposure.CANONICAL)
+
+    assert payload["memory_tier"] == MemoryTier.long_term
+    assert payload["layer"] == "long_term"

--- a/backend/tests/unit/test_memory_service_parity.py
+++ b/backend/tests/unit/test_memory_service_parity.py
@@ -63,6 +63,12 @@ def _sample_memory_dict(memory_id: str = "mem-1", *, locked: bool = False) -> di
     }
 
 
+def _sample_tiered_memory_dict(memory_id: str = "mem-1") -> dict:
+    memory = _sample_memory_dict(memory_id)
+    memory.update({"memory_tier": "short_term", "layer": "short_term", "tier": "short_term"})
+    return memory
+
+
 def _purge_stub_memory_modules() -> None:
     import sys
 
@@ -290,15 +296,16 @@ class TestMemoryServiceParity:
         service = service_mod.MemoryService(db_client=_FirestoreFake())
         service._canonical.write = canonical_write
 
-        result = service.create_external_memory(
-            "uid-test",
-            memory_db,
-            memory_system=MemorySystem.CANONICAL,
-            consumer="mcp",
-            operation="mcp_tool_memory_create",
-        )
+        with pytest.raises(HTTPException) as exc:
+            service.create_external_memory(
+                "uid-test",
+                memory_db,
+                memory_system=MemorySystem.CANONICAL,
+                consumer="mcp",
+                operation="mcp_tool_memory_create",
+            )
 
-        assert result == memory_db
+        assert exc.value.status_code == 503
         canonical_write.assert_called_once()
         create_memory.assert_not_called()
 
@@ -382,6 +389,58 @@ class TestMemoryServiceParity:
 
         assert len(result) == 1
         assert result[0].id == "mem-1"
+
+    def test_legacy_backend_strips_canonical_lifecycle_fields_on_read(self, monkeypatch):
+        service_mod = _load_memory_service(monkeypatch)
+        memories = [_sample_tiered_memory_dict()]
+
+        with patch.object(service_mod.memories_db, "get_memories", return_value=memories):
+            result = service_mod.MemoryService(db_client=_FirestoreFake()).read("uid-test")
+
+        assert len(result) == 1
+        assert result[0].memory_tier is None
+        serialized = result[0].model_dump(mode="json")
+        assert serialized["memory_tier"] is None
+        assert serialized["layer"] is None
+        assert "short_term" not in serialized.values()
+
+    def test_legacy_backend_strips_canonical_lifecycle_fields_on_write(self, monkeypatch):
+        service_mod = _load_memory_service(monkeypatch)
+        create_memory = MagicMock()
+        monkeypatch.setattr(service_mod.memories_db, "create_memory", create_memory)
+
+        service_mod.MemoryService(db_client=_FirestoreFake()).write("uid-test", _sample_tiered_memory_dict())
+
+        payload = create_memory.call_args.args[1]
+        assert "memory_tier" not in payload
+        assert "layer" not in payload
+        assert "tier" not in payload
+
+    def test_external_legacy_create_strips_canonical_lifecycle_fields(self, monkeypatch):
+        service_mod = _load_memory_service(monkeypatch)
+        memory_db = service_mod.MemoryDB.model_validate(_sample_tiered_memory_dict())
+        create_memory = MagicMock()
+        monkeypatch.setattr(service_mod.memories_db, "create_memory", create_memory)
+        monkeypatch.setattr(
+            service_mod,
+            "guard_legacy_memory_write",
+            lambda *args, **kwargs: SimpleNamespace(allowed=True, status_code=200, detail=None),
+        )
+
+        result = service_mod.MemoryService(db_client=_FirestoreFake()).create_external_memory(
+            "uid-test",
+            memory_db,
+            memory_system=MemorySystem.LEGACY,
+            consumer="mcp",
+            operation="mcp_tool_memory_create",
+            upsert_vector=False,
+        )
+
+        payload = create_memory.call_args.args[1]
+        assert "memory_tier" not in payload
+        assert "layer" not in payload
+        assert "tier" not in payload
+        assert result.memory_tier is None
 
     def test_search_mcp_legacy_fetch_limit_filters_and_rrf(self, monkeypatch):
         service_mod = _load_memory_service(monkeypatch)

--- a/backend/tests/unit/test_v3_production_runtime_wiring.py
+++ b/backend/tests/unit/test_v3_production_runtime_wiring.py
@@ -227,6 +227,7 @@ def _route_client(monkeypatch, db, legacy_calls):
                 'edited': False,
                 'conversation_id': None,
                 'data_protection_level': 'standard',
+                'memory_tier': 'short_term',
             }
         ]
 
@@ -248,7 +249,10 @@ def test_real_router_uses_actual_builder_and_does_zero_db_reads_while_v3_gate_of
     response = client.get('/v3/memories?limit=3')
 
     assert response.status_code == 200
-    assert response.json()[0]['id'] == 'legacy-id'
+    body = response.json()
+    assert body[0]['id'] == 'legacy-id'
+    assert 'layer' not in body[0]
+    assert 'memory_tier' not in body[0]
     assert legacy_calls == [{'uid': 'uid-a', 'limit': 5000, 'offset': 0}]
     assert db.reads == []
     assert db.streams == []
@@ -266,6 +270,7 @@ def test_real_router_uses_actual_builder_for_enrolled_memory_read_and_never_call
 
     assert response.status_code == 200
     assert response.json()[0]['id'] == 'm1'
+    assert response.json()[0]['layer'] == 'long_term'
     assert legacy_calls == []
     assert any(path == 'users/uid-a/memory_state/head' for path, _ in db.reads)
     assert db.streams == [('users/uid-a/v3_compatibility_projection_items', 12)]

--- a/backend/tests/unit/test_v3_production_runtime_wiring.py
+++ b/backend/tests/unit/test_v3_production_runtime_wiring.py
@@ -164,6 +164,7 @@ def _projection_item(memory_id='m1'):
             'tags': [],
             'created_at': now,
             'updated_at': now,
+            'memory_tier': 'long_term',
             'reviewed': True,
             'user_review': None,
             'manually_added': False,

--- a/backend/tests/unit/test_ws_i_write_convergence.py
+++ b/backend/tests/unit/test_ws_i_write_convergence.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import ast
 import importlib
+import json
 import os
 import sys
 from datetime import datetime, timedelta, timezone
@@ -369,7 +370,10 @@ def test_legacy_extract_path_unchanged_for_non_canonical():
     legacy_fn_idx = source.index("def _extract_memories_legacy")
     assert canonical_fn_idx < legacy_fn_idx
     assert "deletion_result = memories_db.delete_memories_for_conversation" in source
-    assert "memories_db.save_memories(uid, [fact.dict() for fact in parsed_memories])" in source
+    assert (
+        "memories_db.save_memories(uid, [memory_write_payload(fact, MemoryApiExposure.LEGACY) "
+        "for fact in parsed_memories])"
+    ) in source
 
 
 def test_canonical_extract_uses_memory_service_not_legacy_save():
@@ -584,7 +588,13 @@ def test_v3_get_keeps_legacy_path_for_non_canonical(monkeypatch):
         x_device_id_hash=None,
     )
 
-    assert result == legacy_memories
+    body = json.loads(result.body)
+    assert body[0]["id"] == "mem-legacy"
+    assert body[0]["content"] == "legacy"
+    assert "memory_tier" not in body[0]
+    assert "layer" not in body[0]
+    assert "tier" not in body[0]
+    assert result.headers["x-omi-memory-device-scope-supported"] == "false"
     legacy_get.assert_called_once_with("uid-legacy", 10, 0)
     service_read.assert_not_called()
 

--- a/backend/tests/unit/test_ws_k_layer_field.py
+++ b/backend/tests/unit/test_ws_k_layer_field.py
@@ -73,21 +73,20 @@ def test_memorydb_serializes_layer_from_memory_tier(tier):
     assert serialized["memory_tier"] == tier.value
 
 
-def test_layer_always_present_for_default_long_term_legacy_row():
+def test_layer_absent_for_default_legacy_row():
     memory = MemoryDB(**_minimal_memorydb_payload())
     serialized = memory.model_dump(mode="json")
 
-    assert "layer" in serialized
-    assert serialized["layer"] == tier_to_layer(MemoryTier.long_term).value
-    assert serialized["memory_tier"] == MemoryTier.long_term.value
+    assert serialized["layer"] is None
+    assert serialized["memory_tier"] is None
 
 
-def test_legacy_firestore_dict_without_memory_tier_still_serializes_layer():
+def test_legacy_firestore_dict_without_memory_tier_stays_untiered():
     memory = MemoryDB.model_validate(_minimal_memorydb_payload())
     serialized = memory.model_dump(mode="json")
 
-    assert serialized["memory_tier"] == MemoryTier.long_term.value
-    assert serialized["layer"] == tier_to_layer(MemoryTier.long_term).value
+    assert serialized["memory_tier"] is None
+    assert serialized["layer"] is None
 
 
 def test_layer_uses_real_tier_to_layer_not_hardcoded_mapping():

--- a/backend/utils/conversations/memories.py
+++ b/backend/utils/conversations/memories.py
@@ -8,6 +8,7 @@ from models.memories import MemoryDB, Memory, MemoryCategory
 from models.integrations import ExternalIntegrationCreateMemory
 from utils.llm.memories import extract_memories_from_text
 from utils.memory.canonical_activation import canonical_write_enabled
+from utils.memory.memory_api_contract import MemoryApiExposure, memory_write_payload
 from utils.memory.memory_service import MemoryService
 from utils.memory.memory_system import MemorySystem, resolve_memory_system
 import logging
@@ -128,7 +129,10 @@ def process_external_integration_memory(
             for memory_db in saved_memories:
                 memory_service.write(uid, memory_db.dict())
         else:
-            memories_db.save_memories(uid, [fact_db.dict() for fact_db in saved_memories])
+            memories_db.save_memories(
+                uid,
+                [memory_write_payload(fact_db, MemoryApiExposure.LEGACY) for fact_db in saved_memories],
+            )
 
     return saved_memories
 
@@ -172,6 +176,9 @@ def process_twitter_memories(uid: str, tweets_text: str, persona_id: str) -> Lis
             for memory_db in saved_memories:
                 memory_service.write(uid, memory_db.dict())
         else:
-            memories_db.save_memories(uid, [memory_db.dict() for memory_db in saved_memories])
+            memories_db.save_memories(
+                uid,
+                [memory_write_payload(memory_db, MemoryApiExposure.LEGACY) for memory_db in saved_memories],
+            )
 
     return saved_memories

--- a/backend/utils/conversations/process_conversation.py
+++ b/backend/utils/conversations/process_conversation.py
@@ -47,6 +47,7 @@ from models.conversation_enums import ConversationSource, ConversationStatus, Ex
 from utils.conversations.factory import deserialize_conversation
 from utils.conversations.subjects import infer_subject_from_segments
 from utils.memory.canonical_activation import canonical_write_enabled
+from utils.memory.memory_api_contract import MemoryApiExposure, memory_write_payload
 from utils.memory.memory_service import MemoryService
 from utils.memory.memory_system import MemorySystem
 from utils.memory.memory_system_pin import memory_system_request_scope
@@ -636,7 +637,7 @@ def _extract_memories_legacy(uid: str, conversation: Conversation):
         return
 
     logger.info(f"Saving {len(parsed_memories)} memories for conversation {conversation.id}")
-    memories_db.save_memories(uid, [fact.dict() for fact in parsed_memories])
+    memories_db.save_memories(uid, [memory_write_payload(fact, MemoryApiExposure.LEGACY) for fact in parsed_memories])
 
     for memory_db_obj in parsed_memories:
         upsert_memory_vector(

--- a/backend/utils/memory/memory_api_contract.py
+++ b/backend/utils/memory/memory_api_contract.py
@@ -1,0 +1,46 @@
+"""Authoritative memory API field contract.
+
+Canonical lifecycle fields (`memory_tier` plus serialized `layer`) are only
+product-visible for users whose request is routed through canonical memory.
+Legacy users must stay untiered at API boundaries so desktop/mobile clients do
+not infer Short-term/Long-term rollout state from internal defaults.
+"""
+
+from enum import Enum
+from typing import Any, Dict, Iterable
+
+from pydantic import BaseModel
+
+
+class MemoryApiExposure(str, Enum):
+    LEGACY = "legacy"
+    CANONICAL = "canonical"
+
+
+CANONICAL_LIFECYCLE_FIELDS = frozenset({"memory_tier", "layer", "tier"})
+
+
+def _payload(value: BaseModel | Dict[str, Any]) -> Dict[str, Any]:
+    if isinstance(value, BaseModel):
+        return value.model_dump()
+    return dict(value)
+
+
+def memory_api_payload(value: BaseModel | Dict[str, Any], exposure: MemoryApiExposure) -> Dict[str, Any]:
+    """Serialize one memory for the requested API exposure."""
+    payload = _payload(value)
+    if exposure == MemoryApiExposure.LEGACY:
+        for field in CANONICAL_LIFECYCLE_FIELDS:
+            payload.pop(field, None)
+    return payload
+
+
+def memory_api_payloads(
+    values: Iterable[BaseModel | Dict[str, Any]], exposure: MemoryApiExposure
+) -> list[Dict[str, Any]]:
+    return [memory_api_payload(value, exposure) for value in values]
+
+
+def memory_write_payload(value: BaseModel | Dict[str, Any], exposure: MemoryApiExposure) -> Dict[str, Any]:
+    """Serialize one memory for persistence through the selected memory system."""
+    return memory_api_payload(value, exposure)

--- a/backend/utils/memory/memory_api_contract.py
+++ b/backend/utils/memory/memory_api_contract.py
@@ -32,6 +32,10 @@ def memory_api_payload(value: BaseModel | Dict[str, Any], exposure: MemoryApiExp
     if exposure == MemoryApiExposure.LEGACY:
         for field in CANONICAL_LIFECYCLE_FIELDS:
             payload.pop(field, None)
+    elif exposure == MemoryApiExposure.CANONICAL:
+        tier = payload.get("memory_tier") or payload.get("tier")
+        if tier is not None and payload.get("layer") is None:
+            payload["layer"] = tier
     return payload
 
 

--- a/backend/utils/memory/memory_api_contract.py
+++ b/backend/utils/memory/memory_api_contract.py
@@ -18,6 +18,21 @@ class MemoryApiExposure(str, Enum):
 
 
 CANONICAL_LIFECYCLE_FIELDS = frozenset({"memory_tier", "layer", "tier"})
+MEMORY_INTERNAL_FIELDS = frozenset(
+    {
+        "memory_only",
+        "memory_source",
+        "memory_policy",
+        "source",
+        "policy",
+        "cursor",
+        "read_source",
+        "read_decision",
+        "source_policy",
+        "archive_default_available",
+        "stale_short_term_default_visible",
+    }
+)
 
 
 def _payload(value: BaseModel | Dict[str, Any]) -> Dict[str, Any]:
@@ -29,6 +44,8 @@ def _payload(value: BaseModel | Dict[str, Any]) -> Dict[str, Any]:
 def memory_api_payload(value: BaseModel | Dict[str, Any], exposure: MemoryApiExposure) -> Dict[str, Any]:
     """Serialize one memory for the requested API exposure."""
     payload = _payload(value)
+    for field in MEMORY_INTERNAL_FIELDS:
+        payload.pop(field, None)
     if exposure == MemoryApiExposure.LEGACY:
         for field in CANONICAL_LIFECYCLE_FIELDS:
             payload.pop(field, None)

--- a/backend/utils/memory/memory_service.py
+++ b/backend/utils/memory/memory_service.py
@@ -33,6 +33,7 @@ from utils.memory.canonical_activation import canonical_read_enabled, canonical_
 from utils.memory.memory_system import MemorySystem
 from utils.memory.memory_system_pin import resolve_pinned_memory_system
 from utils.memory.default_read_rollout import guard_legacy_memory_write
+from utils.memory.memory_api_contract import MemoryApiExposure, memory_api_payload, memory_write_payload
 from utils.retrieval.hybrid import rrf_rerank
 
 logger = logging.getLogger(__name__)
@@ -107,6 +108,15 @@ def truncate_locked_memory_preview(memory: MemoryDB) -> MemoryDB:
     return memory.model_copy(update={"content": truncated})
 
 
+def _legacy_memorydb(value: MemoryDB | Dict[str, Any]) -> MemoryDB:
+    """Normalize one legacy memory object so direct route serialization stays untiered."""
+    if isinstance(value, MemoryDB):
+        return value.model_copy(update={"memory_tier": None})
+    payload = memory_api_payload(value, MemoryApiExposure.LEGACY)
+    memory = MemoryDB.model_validate(payload)
+    return memory.model_copy(update={"memory_tier": None})
+
+
 def fetch_memory_dict(uid: str, memory_id: str, *, db_client) -> dict:
     """Fetch one memory by id with canonical/legacy routing and locked-memory paywall."""
     if canonical_read_enabled(uid, db_client=db_client):
@@ -122,7 +132,7 @@ def fetch_memory_dict(uid: str, memory_id: str, *, db_client) -> dict:
     if memory.get('is_locked', False):
         raise HTTPException(status_code=402, detail="A paid plan is required to access this memory.")
 
-    return memory
+    return memory_api_payload(memory, MemoryApiExposure.LEGACY)
 
 
 def _reject_legacy_device_scope(device_scope_request: Optional[DeviceScopeRequest]) -> None:
@@ -140,12 +150,13 @@ class MemorySearchMatch:
 def _validate_memory_list(memories: List[dict]) -> List[MemoryDB]:
     valid_memories: List[MemoryDB] = []
     for memory in memories:
+        memory = memory_api_payload(memory, MemoryApiExposure.LEGACY)
         if memory.get("is_locked", False):
             content = memory.get("content", "")
             memory = dict(memory)
             memory["content"] = _truncate_locked_preview_text(content)
         try:
-            valid_memories.append(MemoryDB.model_validate(memory))
+            valid_memories.append(_legacy_memorydb(memory))
         except ValidationError as exc:
             missing_fields = [err["loc"][0] for err in exc.errors() if err.get("loc")]
             logger.warning(
@@ -174,13 +185,17 @@ def _legacy_search_memories(uid: str, query: str, *, limit: int = 5) -> List[Mem
         return []
 
     memories_data = memories_db.get_memories_by_ids(uid, memory_ids)
-    memories_data = [memory for memory in memories_data if not memory.get("is_locked", False)]
+    memories_data = [
+        memory_api_payload(memory, MemoryApiExposure.LEGACY)
+        for memory in memories_data
+        if not memory.get("is_locked", False)
+    ]
 
     results: List[MemorySearchMatch] = []
     for memory_data in memories_data:
         memory_id = memory_data.get("id")
         try:
-            memory_obj = MemoryDB.model_validate(memory_data)
+            memory_obj = _legacy_memorydb(memory_data)
         except ValidationError:
             continue
         results.append(MemorySearchMatch(memory=memory_obj, score=scores_by_id.get(memory_id, 0.0)))
@@ -271,7 +286,7 @@ class LegacyMemoryBackend:
         return _legacy_search_memories(uid, query, limit=limit)
 
     def write(self, uid: str, data: Dict[str, Any]) -> str:
-        memories_db.create_memory(uid, data)
+        memories_db.create_memory(uid, memory_write_payload(data, MemoryApiExposure.LEGACY))
         return str(data.get("id") or "")
 
     def review(self, uid: str, memory_id: str, value: bool) -> None:
@@ -292,17 +307,15 @@ class LegacyMemoryBackend:
             update_data["category"] = category
         if update_data:
             memories_db.update_memory_fields(uid, memory_id, update_data)
-        memory = memories_db.get_memory(uid, memory_id)
-        return MemoryDB.model_validate(memory)
+        return _legacy_memorydb(memories_db.get_memory(uid, memory_id))
 
     def write_batch(self, uid: str, items: List[Dict[str, Any]]) -> List[str]:
-        memories_db.save_memories(uid, items)
+        memories_db.save_memories(uid, [memory_write_payload(item, MemoryApiExposure.LEGACY) for item in items])
         return [str(item.get("id") or "") for item in items]
 
     def update_content(self, uid: str, memory_id: str, content: str) -> MemoryDB:
         memories_db.edit_memory(uid, memory_id, content)
-        memory = memories_db.get_memory(uid, memory_id)
-        return MemoryDB.model_validate(memory)
+        return _legacy_memorydb(memories_db.get_memory(uid, memory_id))
 
     def update_visibility(self, uid: str, memory_id: str, visibility: str) -> None:
         memories_db.change_memory_visibility(uid, memory_id, visibility)
@@ -530,10 +543,15 @@ class MemoryService:
             item = _read_canonical_memory_item(uid, committed_id or memory_db.id, db_client=self._db_client)
             if item is not None:
                 return memory_item_to_memorydb(item)
-            return memory_db
+            logger.error(
+                "canonical external memory readback missing uid=%s memory_id=%s",
+                uid,
+                committed_id or memory_db.id,
+            )
+            raise HTTPException(status_code=503, detail="Service temporarily unavailable")
 
         _require_legacy_write_guard(uid, self._db_client, consumer=consumer, operation=operation)
-        memories_db.create_memory(uid, memory_db.model_dump())
+        memories_db.create_memory(uid, memory_write_payload(memory_db, MemoryApiExposure.LEGACY))
         if upsert_vector:
             try:
                 upsert_memory_vector(
@@ -549,7 +567,7 @@ class MemoryService:
                     uid,
                     memory_db.id,
                 )
-        return memory_db
+        return _legacy_memorydb(memory_db)
 
     def create_external_memory_batch(
         self,
@@ -576,11 +594,15 @@ class MemoryService:
                 if item is not None:
                     results.append(memory_item_to_memorydb(item))
                 else:
-                    results.append(next(memory for memory in memory_dbs if memory.id == memory_id))
+                    logger.error("canonical external batch readback missing uid=%s memory_id=%s", uid, memory_id)
+                    raise HTTPException(status_code=503, detail="Service temporarily unavailable")
             return results
 
         _require_legacy_write_guard(uid, self._db_client, consumer=consumer, operation=operation)
-        memories_db.save_memories(uid, [memory.model_dump() for memory in memory_dbs])
+        memories_db.save_memories(
+            uid,
+            [memory_write_payload(memory, MemoryApiExposure.LEGACY) for memory in memory_dbs],
+        )
         if upsert_vectors:
             try:
                 upsert_memory_vectors_batch(
@@ -597,7 +619,7 @@ class MemoryService:
                 )
             except Exception:
                 logger.exception("Vector batch upsert failed uid=%s (memories saved, vectors missing)", uid)
-        return memory_dbs
+        return [_legacy_memorydb(memory) for memory in memory_dbs]
 
     def delete_external_memory(
         self,
@@ -674,4 +696,4 @@ class MemoryService:
                     uid,
                     memory_id,
                 )
-        return MemoryDB.model_validate(memories_db.get_memory(uid, memory_id))
+        return _legacy_memorydb(memories_db.get_memory(uid, memory_id))

--- a/backend/utils/x_connector.py
+++ b/backend/utils/x_connector.py
@@ -36,6 +36,7 @@ from database.vector_db import upsert_memory_vectors_batch, upsert_x_post_vector
 from models.memories import MemoryDB
 from utils.llm.memories import extract_memories_from_text
 from utils.memory.canonical_activation import canonical_write_enabled
+from utils.memory.memory_api_contract import MemoryApiExposure, memory_write_payload
 from utils.memory.memory_service import MemoryService
 from utils.memory.memory_system import MemorySystem, resolve_memory_system
 from utils.executors import db_executor, run_blocking
@@ -364,7 +365,7 @@ def _extract_and_index(uid: str, posts: List[Dict]) -> int:
             for mdb in memory_dbs:
                 memory_service.write(uid, mdb.dict())
         else:
-            memories_db.save_memories(uid, [m.dict() for m in memory_dbs])
+            memories_db.save_memories(uid, [memory_write_payload(m, MemoryApiExposure.LEGACY) for m in memory_dbs])
             upsert_memory_vectors_batch(
                 uid,
                 [

--- a/desktop/macos/Desktop/Sources/APIClient.swift
+++ b/desktop/macos/Desktop/Sources/APIClient.swift
@@ -1756,6 +1756,11 @@ extension APIClient {
 // MARK: - Memories API
 
 extension APIClient {
+  struct MemoryListPage {
+    let memories: [ServerMemory]
+    let canonicalLifecycleExposed: Bool
+    let deviceScopeSupported: Bool?
+  }
 
   /// Fetches memories from the API with optional filtering
   func getMemories(
@@ -1780,6 +1785,67 @@ extension APIClient {
       endpoint += "&device_scope=\(deviceScope)"
     }
     return try await get(endpoint)
+  }
+
+  /// Fetches memories plus server-authoritative capability headers.
+  func getMemoriesPage(
+    limit: Int = 100,
+    offset: Int = 0,
+    category: String? = nil,
+    tags: [String]? = nil,
+    includeDismissed: Bool = false,
+    deviceScope: String? = nil
+  ) async throws -> MemoryListPage {
+    var endpoint = "v3/memories?limit=\(limit)&offset=\(offset)"
+    if let category = category {
+      endpoint += "&category=\(category)"
+    }
+    if let tags = tags, !tags.isEmpty {
+      endpoint += "&tags=\(tags.joined(separator: ","))"
+    }
+    if includeDismissed {
+      endpoint += "&include_dismissed=true"
+    }
+    if let deviceScope = deviceScope {
+      endpoint += "&device_scope=\(deviceScope)"
+    }
+
+    let url = URL(string: baseURL + endpoint)!
+    var request = URLRequest(url: url)
+    request.httpMethod = "GET"
+    request.allHTTPHeaderFields = try await buildHeaders(requireAuth: true)
+    return try await performMemoryListRequest(request, retriedAuth: false)
+  }
+
+  private func performMemoryListRequest(_ request: URLRequest, retriedAuth: Bool) async throws -> MemoryListPage {
+    let (data, response) = try await session.data(for: request)
+    guard let httpResponse = response as? HTTPURLResponse else {
+      throw APIError.invalidResponse
+    }
+
+    if httpResponse.statusCode == 401, !retriedAuth {
+      let authService = await MainActor.run { AuthService.shared }
+      var retry = request
+      retry.setValue(try await authService.getAuthHeader(forceRefresh: true), forHTTPHeaderField: "Authorization")
+      return try await performMemoryListRequest(retry, retriedAuth: true)
+    }
+    if httpResponse.statusCode == 401 {
+      throw APIError.unauthorized
+    }
+
+    guard (200...299).contains(httpResponse.statusCode) else {
+      let detail = Self.extractErrorDetail(from: data)
+      throw APIError.httpError(statusCode: httpResponse.statusCode, detail: detail)
+    }
+
+    let memories = try decoder.decode([ServerMemory].self, from: data)
+    let deviceScopeHeader = httpResponse.value(forHTTPHeaderField: "X-Omi-Memory-Device-Scope-Supported")
+    let deviceScopeSupported = deviceScopeHeader.map { $0.caseInsensitiveCompare("true") == .orderedSame }
+    return MemoryListPage(
+      memories: memories,
+      canonicalLifecycleExposed: deviceScopeSupported == true,
+      deviceScopeSupported: deviceScopeSupported
+    )
   }
 
   /// Creates a new memory (manual or extracted)

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoriesPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoriesPage.swift
@@ -388,11 +388,12 @@ class MemoriesViewModel: ObservableObject {
     var offset = 0
     let batchSize = 500
     var allFetched: [ServerMemory] = []
+    var fetchedLifecycleExposure: Bool?
 
     do {
       while true {
         let page = try await APIClient.shared.getMemoriesPage(limit: batchSize, offset: offset)
-        canonicalLifecycleExposed = page.canonicalLifecycleExposed
+        fetchedLifecycleExposure = page.canonicalLifecycleExposed
         let batch = page.memories
         if batch.isEmpty { break }
         allFetched.append(contentsOf: batch)
@@ -418,6 +419,9 @@ class MemoriesViewModel: ObservableObject {
         tiers: layers(for: token)
       )
       guard isCurrentScope(token) else { return }
+      if let fetchedLifecycleExposure {
+        canonicalLifecycleExposed = fetchedLifecycleExposure
+      }
       memories = displayMemories(mergedMemories, for: token)
       currentOffset = mergedMemories.count
       hasMoreMemories = mergedMemories.count >= reloadLimit
@@ -489,9 +493,9 @@ class MemoriesViewModel: ObservableObject {
     do {
       let reloadLimit = max(pageSize, memories.count)
       let page = try await APIClient.shared.getMemoriesPage(limit: reloadLimit, offset: 0)
-      canonicalLifecycleExposed = page.canonicalLifecycleExposed
       let apiMemories = page.memories
       guard isCurrentScope(token) else { return }
+      canonicalLifecycleExposed = page.canonicalLifecycleExposed
 
       // Sync API results to local cache
       try await MemoryStorage.shared.syncServerMemories(apiMemories)
@@ -773,16 +777,16 @@ class MemoriesViewModel: ObservableObject {
         limit: pageSize,
         offset: 0
       )
-      canonicalLifecycleExposed = page.canonicalLifecycleExposed
-      if let deviceScopeCapability = page.deviceScopeSupported {
-        deviceScopeSupported = deviceScopeCapability
-      }
       let fetchedMemories = page.memories
       guard isCurrentScope(token) else {
         // Scope changed mid-load; reset loading state so the replacement load
         // (gated by `guard !isLoading`) is not permanently blocked.
         isLoading = false
         return
+      }
+      canonicalLifecycleExposed = page.canonicalLifecycleExposed
+      if let deviceScopeCapability = page.deviceScopeSupported {
+        deviceScopeSupported = deviceScopeCapability
       }
       hasLoadedInitially = true
       log("MemoriesViewModel: Fetched \(fetchedMemories.count) memories from API")
@@ -1017,11 +1021,12 @@ class MemoriesViewModel: ObservableObject {
 
       guard isCurrentScope(token), currentOffset == requestedOffset else { return }
       if !moreFromCache.isEmpty {
-        memories.append(contentsOf: moreFromCache)
-        currentOffset += moreFromCache.count
-        hasMoreMemories = moreFromCache.count >= pageSize
+        let visibleMemories = displayMemories(moreFromCache, for: token)
+        memories.append(contentsOf: visibleMemories)
+        currentOffset += visibleMemories.count
+        hasMoreMemories = visibleMemories.count >= pageSize
         log(
-          "MemoriesViewModel: Loaded \(moreFromCache.count) more from local cache (total: \(memories.count))"
+          "MemoriesViewModel: Loaded \(visibleMemories.count) more from local cache (total: \(memories.count))"
         )
         return
       }
@@ -1039,12 +1044,12 @@ class MemoriesViewModel: ObservableObject {
         limit: pageSize,
         offset: requestedRawOffset
       )
+      let newMemories = page.memories
+      guard isCurrentScope(token), currentOffset == requestedOffset else { return }
       canonicalLifecycleExposed = page.canonicalLifecycleExposed
       if let deviceScopeCapability = page.deviceScopeSupported {
         deviceScopeSupported = deviceScopeCapability
       }
-      let newMemories = page.memories
-      guard isCurrentScope(token), currentOffset == requestedOffset else { return }
 
       // Sync to local cache first
       try await MemoryStorage.shared.syncServerMemories(newMemories)

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoriesPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoriesPage.swift
@@ -123,6 +123,19 @@ class MemoriesViewModel: ObservableObject {
     }
   }
 
+  @Published private(set) var canonicalLifecycleExposed = false {
+    didSet {
+      guard oldValue != canonicalLifecycleExposed else { return }
+      if !canonicalLifecycleExposed, selectedLayerFilter != .defaultAccess {
+        selectedLayerFilter = .defaultAccess
+      }
+      memories = displayMemories(memories, lifecycleExposed: canonicalLifecycleExposed)
+      searchResults = displayMemories(searchResults, lifecycleExposed: canonicalLifecycleExposed)
+      filteredFromDatabase = displayMemories(filteredFromDatabase, lifecycleExposed: canonicalLifecycleExposed)
+      recomputeFilteredMemories()
+    }
+  }
+
   @Published var filterThisDeviceOnly = false {
     didSet {
       guard oldValue != filterThisDeviceOnly else { return }
@@ -251,7 +264,7 @@ class MemoriesViewModel: ObservableObject {
 
   private var scopeGeneration = 0
 
-  private var activeLayerFilter: [MemoryLayer] { selectedLayerFilter.allowedLayers }
+  private var activeLayerFilter: [MemoryLayer]? { canonicalLifecycleExposed ? selectedLayerFilter.allowedLayers : nil }
   private var activeLayerScope: MemoryLayerScope { selectedLayerFilter.layerScope }
 
   private var currentScopeToken: MemoryScopeToken {
@@ -271,8 +284,21 @@ class MemoriesViewModel: ObservableObject {
     token == currentScopeToken
   }
 
-  private func layers(for token: MemoryScopeToken) -> [MemoryLayer] {
-    token.layerFilter.allowedLayers
+  private func layers(for token: MemoryScopeToken) -> [MemoryLayer]? {
+    canonicalLifecycleExposed ? token.layerFilter.allowedLayers : nil
+  }
+
+  private func displayMemories(_ values: [ServerMemory], for token: MemoryScopeToken) -> [ServerMemory] {
+    displayMemories(values, lifecycleExposed: canonicalLifecycleExposed)
+  }
+
+  private func displayMemories(_ values: [ServerMemory], lifecycleExposed: Bool) -> [ServerMemory] {
+    lifecycleExposed ? values : values.map { $0.hidingLifecycleExposure() }
+  }
+
+  private func layerAllowed(_ memory: ServerMemory, for token: MemoryScopeToken) -> Bool {
+    guard let allowedLayers = layers(for: token) else { return true }
+    return Set(allowedLayers).contains(memory.tier)
   }
 
   private func reloadForCurrentLayerFilter() async {
@@ -289,7 +315,7 @@ class MemoriesViewModel: ObservableObject {
         let loaded = try await MemoryStorage.shared.getLocalMemories(
           limit: pageSize, offset: 0, tiers: layers(for: token))
         guard isCurrentScope(token) else { return }
-        memories = loaded
+        memories = displayMemories(loaded, for: token)
         currentOffset = loaded.count
         hasMoreMemories = loaded.count >= pageSize
         recomputeFilteredMemories()
@@ -365,7 +391,9 @@ class MemoriesViewModel: ObservableObject {
 
     do {
       while true {
-        let batch = try await APIClient.shared.getMemories(limit: batchSize, offset: offset)
+        let page = try await APIClient.shared.getMemoriesPage(limit: batchSize, offset: offset)
+        canonicalLifecycleExposed = page.canonicalLifecycleExposed
+        let batch = page.memories
         if batch.isEmpty { break }
         allFetched.append(contentsOf: batch)
         offset += batch.count
@@ -390,7 +418,7 @@ class MemoriesViewModel: ObservableObject {
         tiers: layers(for: token)
       )
       guard isCurrentScope(token) else { return }
-      memories = mergedMemories
+      memories = displayMemories(mergedMemories, for: token)
       currentOffset = mergedMemories.count
       hasMoreMemories = mergedMemories.count >= reloadLimit
       recomputeFilteredMemories()
@@ -412,6 +440,8 @@ class MemoriesViewModel: ObservableObject {
     searchText = ""
     isSearching = false
     searchResults = []
+    canonicalLifecycleExposed = false
+    selectedLayerFilter = .defaultAccess
     selectedTags = []
     filteredFromDatabase = []
     isLoadingFiltered = false
@@ -458,7 +488,9 @@ class MemoriesViewModel: ObservableObject {
     let token = currentScopeToken
     do {
       let reloadLimit = max(pageSize, memories.count)
-      let apiMemories = try await APIClient.shared.getMemories(limit: reloadLimit, offset: 0)
+      let page = try await APIClient.shared.getMemoriesPage(limit: reloadLimit, offset: 0)
+      canonicalLifecycleExposed = page.canonicalLifecycleExposed
+      let apiMemories = page.memories
       guard isCurrentScope(token) else { return }
 
       // Sync API results to local cache
@@ -474,7 +506,7 @@ class MemoriesViewModel: ObservableObject {
       log(
         "MemoriesViewModel: Auto-refresh showing \(mergedMemories.count) memories (API had \(apiMemories.count))"
       )
-      memories = mergedMemories
+      memories = displayMemories(mergedMemories, for: token)
       currentOffset = mergedMemories.count
       rawBackendOffset = apiMemories.count
       hasMoreMemories = mergedMemories.count >= reloadLimit
@@ -554,7 +586,7 @@ class MemoriesViewModel: ObservableObject {
         token.selectedTags.contains { tag in tag.matches(memory) }
       }
 
-      filteredFromDatabase = filteredResults
+      filteredFromDatabase = displayMemories(filteredResults, for: token)
       log(
         "MemoriesViewModel: Loaded \(filteredResults.count) filtered memories from SQLite (raw: \(results.count))"
       )
@@ -599,8 +631,10 @@ class MemoriesViewModel: ObservableObject {
     }
 
     // Guardrail: Archive is never part of the default list unless the user explicitly selects Archive.
-    let allowedTiers = Set(activeLayerFilter)
-    result = result.filter { allowedTiers.contains($0.tier) }
+    if let allowedLayers = activeLayerFilter {
+      let allowedTiers = Set(allowedLayers)
+      result = result.filter { allowedTiers.contains($0.tier) }
+    }
 
     if filterThisDeviceOnly {
       result = result.filter { ClientDeviceService.shared.memoryMatchesThisDevice($0) }
@@ -651,15 +685,14 @@ class MemoriesViewModel: ObservableObject {
         tiers: layers(for: token)
       )
       guard isCurrentScope(token) else { return }
-      searchResults = results
+      searchResults = displayMemories(results, for: token)
       log("MemoriesViewModel: Search for '\(query)' found \(results.count) results")
     } catch {
       guard isCurrentScope(token) else { return }
       logError("MemoriesViewModel: Search failed", error: error)
       // Fall back to in-memory filtering within the captured tier scope.
-      let allowedTiers = Set(layers(for: token))
       searchResults = memories.filter {
-        allowedTiers.contains($0.tier) && $0.content.localizedCaseInsensitiveContains(query)
+        layerAllowed($0, for: token) && $0.content.localizedCaseInsensitiveContains(query)
       }
     }
 
@@ -675,15 +708,15 @@ class MemoriesViewModel: ObservableObject {
   /// get a 400 from device_scope=current; on that we clear deviceScopeSupported
   /// and retry without the scope so the page still loads. Client-side device
   /// filtering (recomputeFilteredMemories) preserves the "This Mac" UX.
-  private func fetchMemoriesDeviceScopeAware(limit: Int, offset: Int) async throws -> [ServerMemory] {
+  private func fetchMemoriesPageDeviceScopeAware(limit: Int, offset: Int) async throws -> APIClient.MemoryListPage {
     let scope = (filterThisDeviceOnly && deviceScopeSupported) ? "current" : nil
     do {
-      return try await APIClient.shared.getMemories(limit: limit, offset: offset, deviceScope: scope)
+      return try await APIClient.shared.getMemoriesPage(limit: limit, offset: offset, deviceScope: scope)
     } catch APIError.httpError(let statusCode, _) where statusCode == 400 && scope != nil {
       // Backend rejected device_scope for a non-canonical user — retry unscoped.
       deviceScopeSupported = false
       log("MemoriesViewModel: device_scope unsupported by backend, retrying unscoped")
-      return try await APIClient.shared.getMemories(limit: limit, offset: offset, deviceScope: nil)
+      return try await APIClient.shared.getMemoriesPage(limit: limit, offset: offset, deviceScope: nil)
     }
   }
 
@@ -723,7 +756,7 @@ class MemoriesViewModel: ObservableObject {
       }
 
       if !cachedMemories.isEmpty, isCurrentScope(token) {
-        memories = cachedMemories
+        memories = displayMemories(cachedMemories, for: token)
         currentOffset = cachedMemories.count
         hasMoreMemories = cachedMemories.count >= pageSize
         isLoading = false  // Show cached data immediately
@@ -736,10 +769,15 @@ class MemoriesViewModel: ObservableObject {
 
     // Step 2: Fetch from API in background and sync to local cache
     do {
-      let fetchedMemories = try await fetchMemoriesDeviceScopeAware(
+      let page = try await fetchMemoriesPageDeviceScopeAware(
         limit: pageSize,
         offset: 0
       )
+      canonicalLifecycleExposed = page.canonicalLifecycleExposed
+      if let deviceScopeCapability = page.deviceScopeSupported {
+        deviceScopeSupported = deviceScopeCapability
+      }
+      let fetchedMemories = page.memories
       guard isCurrentScope(token) else {
         // Scope changed mid-load; reset loading state so the replacement load
         // (gated by `guard !isLoading`) is not permanently blocked.
@@ -765,8 +803,7 @@ class MemoriesViewModel: ObservableObject {
         let wasDeviceScoped = filterThisDeviceOnly && deviceScopeSupported
         let displayMemories: [ServerMemory]
         if wasDeviceScoped {
-          let allowedTiers = Set(layers(for: token))
-          displayMemories = fetchedMemories.filter { allowedTiers.contains($0.tier) }
+          displayMemories = fetchedMemories.filter { layerAllowed($0, for: token) }
         } else {
           // Reload from local cache to get merged data
           displayMemories = try await MemoryStorage.shared.getLocalMemories(
@@ -781,8 +818,9 @@ class MemoriesViewModel: ObservableObject {
           isLoading = false
           return
         }
-        memories = displayMemories
-        currentOffset = displayMemories.count
+        let visibleMemories = self.displayMemories(displayMemories, for: token)
+        memories = visibleMemories
+        currentOffset = visibleMemories.count
         // Track the raw backend cursor for subsequent loadMore() fetches.
         rawBackendOffset = fetchedMemories.count
         // Use the raw backend page count for pagination, not the tier-filtered
@@ -793,12 +831,11 @@ class MemoriesViewModel: ObservableObject {
         // permanently hide those memories. This matches the error-fallback path
         // below and the loadMore() API path.
         hasMoreMemories = fetchedMemories.count >= pageSize
-        log("MemoriesViewModel: Showing \(displayMemories.count) memories from \(wasDeviceScoped ? "device-scoped API" : "merged local cache")")
+        log("MemoriesViewModel: Showing \(visibleMemories.count) memories from \(wasDeviceScoped ? "device-scoped API" : "merged local cache")")
       } catch {
         logError("MemoriesViewModel: Failed to sync/reload from local cache", error: error)
         // Fall back to API data if sync fails, preserving the desktop default-access guardrail.
-        let allowedTiers = Set(layers(for: token))
-        memories = fetchedMemories.filter { allowedTiers.contains($0.tier) }
+        memories = displayMemories(fetchedMemories.filter { layerAllowed($0, for: token) }, for: token)
         currentOffset = memories.count
         rawBackendOffset = fetchedMemories.count
         hasMoreMemories = fetchedMemories.count >= pageSize
@@ -845,7 +882,9 @@ class MemoriesViewModel: ObservableObject {
 
     do {
       while true {
-        let batch = try await APIClient.shared.getMemories(limit: batchSize, offset: offset)
+        let page = try await APIClient.shared.getMemoriesPage(limit: batchSize, offset: offset)
+        canonicalLifecycleExposed = page.canonicalLifecycleExposed
+        let batch = page.memories
         if batch.isEmpty { break }
 
         try await MemoryStorage.shared.syncServerMemories(batch)
@@ -896,7 +935,9 @@ class MemoriesViewModel: ObservableObject {
 
     do {
       while true {
-        let batch = try await APIClient.shared.getMemories(limit: batchSize, offset: offset)
+        let page = try await APIClient.shared.getMemoriesPage(limit: batchSize, offset: offset)
+        canonicalLifecycleExposed = page.canonicalLifecycleExposed
+        let batch = page.memories
         if batch.isEmpty { break }
 
         try await MemoryStorage.shared.syncServerMemories(batch)
@@ -994,17 +1035,21 @@ class MemoriesViewModel: ObservableObject {
     // Use the raw backend offset (not the visible/SQLite offset) so that layer
     // filtering does not cause overlapping pages or duplicate appends.
     do {
-      let newMemories = try await fetchMemoriesDeviceScopeAware(
+      let page = try await fetchMemoriesPageDeviceScopeAware(
         limit: pageSize,
         offset: requestedRawOffset
       )
+      canonicalLifecycleExposed = page.canonicalLifecycleExposed
+      if let deviceScopeCapability = page.deviceScopeSupported {
+        deviceScopeSupported = deviceScopeCapability
+      }
+      let newMemories = page.memories
       guard isCurrentScope(token), currentOffset == requestedOffset else { return }
 
       // Sync to local cache first
       try await MemoryStorage.shared.syncServerMemories(newMemories)
 
-      let allowedTiers = Set(layers(for: token))
-      let visibleNewMemories = newMemories.filter { allowedTiers.contains($0.tier) }
+      let visibleNewMemories = displayMemories(newMemories.filter { layerAllowed($0, for: token) }, for: token)
 
       // Then append to display
       memories.append(contentsOf: visibleNewMemories)
@@ -1420,46 +1465,48 @@ struct MemoriesPage: View {
       .frame(minHeight: 46)
       .omiControlSurface(fill: OmiColors.backgroundTertiary, radius: 18)
 
-      // Layer filter dropdown. Default is product default access: Short-term + Long-term.
-      Menu {
-        ForEach(MemoryLayerFilter.allCases) { filter in
-          Button {
-            viewModel.selectedLayerFilter = filter
-          } label: {
-            HStack {
-              Text(filter.displayName)
-              if viewModel.selectedLayerFilter == filter {
-                Image(systemName: "checkmark")
+      if viewModel.canonicalLifecycleExposed {
+        // Layer filter dropdown. Default is product default access: Short-term + Long-term.
+        Menu {
+          ForEach(MemoryLayerFilter.allCases) { filter in
+            Button {
+              viewModel.selectedLayerFilter = filter
+            } label: {
+              HStack {
+                Text(filter.displayName)
+                if viewModel.selectedLayerFilter == filter {
+                  Image(systemName: "checkmark")
+                }
               }
             }
+            .help(filter.description)
           }
-          .help(filter.description)
+        } label: {
+          HStack(spacing: 6) {
+            Image(systemName: viewModel.selectedLayerFilter == .archive ? "archivebox" : "clock.badge.checkmark")
+              .scaledFont(size: 12)
+            Text(viewModel.selectedLayerFilter.displayName)
+              .scaledFont(size: 13, weight: viewModel.selectedLayerFilter == .defaultAccess ? .regular : .medium)
+            Image(systemName: "chevron.down")
+              .scaledFont(size: 10)
+          }
+          .foregroundColor(
+            viewModel.selectedLayerFilter == .defaultAccess ? OmiColors.textSecondary : OmiColors.textPrimary
+          )
+          .padding(.horizontal, 14)
+          .padding(.vertical, 12)
+          .frame(minHeight: 46)
+          .omiControlSurface(
+            fill: viewModel.selectedLayerFilter == .defaultAccess
+              ? OmiColors.backgroundTertiary : OmiColors.backgroundRaised,
+            radius: 18,
+            stroke: viewModel.selectedLayerFilter == .defaultAccess ? nil : OmiColors.border.opacity(0.6)
+          )
         }
-      } label: {
-        HStack(spacing: 6) {
-          Image(systemName: viewModel.selectedLayerFilter == .archive ? "archivebox" : "clock.badge.checkmark")
-            .scaledFont(size: 12)
-          Text(viewModel.selectedLayerFilter.displayName)
-            .scaledFont(size: 13, weight: viewModel.selectedLayerFilter == .defaultAccess ? .regular : .medium)
-          Image(systemName: "chevron.down")
-            .scaledFont(size: 10)
-        }
-        .foregroundColor(
-          viewModel.selectedLayerFilter == .defaultAccess ? OmiColors.textSecondary : OmiColors.textPrimary
-        )
-        .padding(.horizontal, 14)
-        .padding(.vertical, 12)
-        .frame(minHeight: 46)
-        .omiControlSurface(
-          fill: viewModel.selectedLayerFilter == .defaultAccess
-            ? OmiColors.backgroundTertiary : OmiColors.backgroundRaised,
-          radius: 18,
-          stroke: viewModel.selectedLayerFilter == .defaultAccess ? nil : OmiColors.border.opacity(0.6)
-        )
+        .menuStyle(.button)
+        .buttonStyle(.plain)
+        .help("Default shows Short-term + Long-term. Archive is explicit.")
       }
-      .menuStyle(.button)
-      .buttonStyle(.plain)
-      .help("Default shows Short-term + Long-term. Archive is explicit.")
 
       Button {
         viewModel.filterThisDeviceOnly.toggle()
@@ -1558,7 +1605,9 @@ struct MemoriesPage: View {
       }
     } message: {
       Text(
-        "This would delete Short-term and Long-term memories only. Archive is not included. Bulk deletion remains disabled until the backend supports layer-scoped mutation semantics."
+        viewModel.canonicalLifecycleExposed
+          ? "This would delete Short-term and Long-term memories only. Archive is not included. Bulk deletion remains disabled until the backend supports layer-scoped mutation semantics."
+          : "This would delete default memories. Bulk deletion remains disabled until the backend supports scoped mutation semantics."
       )
     }
   }
@@ -2284,9 +2333,11 @@ private struct MemoryDetailTooltip: View {
 
   var body: some View {
     VStack(alignment: .leading, spacing: 6) {
-      tooltipRow("Layer", memory.tierIsExplicit ? memory.tier.displayName : "Legacy (untiered)")
       if memory.tierIsExplicit, memory.tier == .shortTerm, let expiresAt = memory.expiresAt {
+        tooltipRow("Layer", memory.tier.displayName)
         tooltipRow("Expires", expiresAt.formatted(date: .abbreviated, time: .shortened))
+      } else if memory.tierIsExplicit {
+        tooltipRow("Layer", memory.tier.displayName)
       }
 
       // Category

--- a/desktop/macos/Desktop/Sources/Rewind/Core/MemoryModels.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/MemoryModels.swift
@@ -309,10 +309,18 @@ extension MemoryRecord {
     }
 
     /// Merge server-authoritative tier fields without overwriting newer local edits.
-    /// Legacy/untiered server rows (`tierIsExplicit == false`) are left unchanged.
+    /// Legacy/untiered server rows clear any previously cached canonical tier so
+    /// stale rollout metadata cannot keep Short-term/Long-term UI visible.
     @discardableResult
     mutating func mergeAuthoritativeTierFrom(_ memory: ServerMemory) -> Bool {
-        guard memory.tierIsExplicit else { return false }
+        guard memory.tierIsExplicit else {
+            let changed = tierIsExplicit || tier != MemoryLayer.longTerm.rawValue
+            if changed {
+                tier = MemoryLayer.longTerm.rawValue
+                tierIsExplicit = false
+            }
+            return changed
+        }
 
         let authoritativeTier = memory.tier.rawValue
         let changed = tier != authoritativeTier || !tierIsExplicit
@@ -374,6 +382,45 @@ extension MemoryRecord {
 // MARK: - ServerMemory Initializer Extension
 
 extension ServerMemory {
+    /// Return a display copy that hides canonical lifecycle state for legacy or
+    /// not-yet-confirmed users. The persisted cache may briefly contain stale
+    /// explicit tiers from earlier builds; UI must not render those until the
+    /// current server response confirms canonical lifecycle support.
+    func hidingLifecycleExposure() -> ServerMemory {
+        guard tierIsExplicit || tier != .longTerm else { return self }
+        return ServerMemory(
+            id: id,
+            content: content,
+            category: category,
+            tier: .longTerm,
+            tierIsExplicit: false,
+            createdAt: createdAt,
+            updatedAt: updatedAt,
+            capturedAt: capturedAt,
+            expiresAt: expiresAt,
+            conversationId: conversationId,
+            reviewed: reviewed,
+            userReview: userReview,
+            visibility: visibility,
+            manuallyAdded: manuallyAdded,
+            scoring: scoring,
+            source: source,
+            confidence: confidence,
+            sourceApp: sourceApp,
+            contextSummary: contextSummary,
+            isRead: isRead,
+            isDismissed: isDismissed,
+            tags: tags,
+            reasoning: reasoning,
+            currentActivity: currentActivity,
+            inputDeviceName: inputDeviceName,
+            windowTitle: windowTitle,
+            headline: headline,
+            primaryCaptureDevice: primaryCaptureDevice,
+            captureDeviceIds: captureDeviceIds
+        )
+    }
+
     /// Initialize from individual fields (for creating from MemoryRecord)
     init(
         id: String,

--- a/desktop/macos/Desktop/Tests/MemoryAuthoritativeTierSyncTests.swift
+++ b/desktop/macos/Desktop/Tests/MemoryAuthoritativeTierSyncTests.swift
@@ -57,7 +57,7 @@ final class MemoryAuthoritativeTierSyncTests: XCTestCase {
         XCTAssertEqual(record?.updatedAt, localUpdatedAt, "Tier merge must not bump updatedAt")
     }
 
-    func testSyncLeavesLegacyUntieredLocalRecordBadgeLess() async throws {
+    func testSyncClearsLegacyUntieredLocalRecordTierState() async throws {
         let backendId = "tier-sync-legacy-\(UUID().uuidString)"
         let serverUpdatedAt = Date(timeIntervalSince1970: 1_000)
         let localUpdatedAt = Date(timeIntervalSince1970: 2_000)
@@ -73,15 +73,16 @@ final class MemoryAuthoritativeTierSyncTests: XCTestCase {
         try await corruptLocalTier(
             backendId: backendId,
             tier: MemoryLayer.shortTerm.rawValue,
-            tierIsExplicit: false,
+            tierIsExplicit: true,
             updatedAt: localUpdatedAt
         )
 
         try await MemoryStorage.shared.syncServerMemories([legacyServerMemory])
 
         let record = try await MemoryStorage.shared.getMemoryByBackendId(backendId)
-        XCTAssertEqual(record?.tier, MemoryLayer.shortTerm.rawValue, "Local tier value is preserved")
-        XCTAssertEqual(record?.tierIsExplicit, false, "Legacy server rows must not force a badge")
+        XCTAssertEqual(record?.tier, MemoryLayer.longTerm.rawValue, "Legacy server rows clear stale tier filters")
+        XCTAssertEqual(record?.tierIsExplicit, false, "Legacy server rows clear stale tier badges")
+        XCTAssertEqual(record?.updatedAt, localUpdatedAt, "Tier cleanup must not bump updatedAt")
     }
 
     func testMarkSyncedDoesNotBumpUpdatedAt() async throws {

--- a/desktop/macos/Desktop/Tests/MemoryLayerFilterTests.swift
+++ b/desktop/macos/Desktop/Tests/MemoryLayerFilterTests.swift
@@ -67,6 +67,41 @@ final class MemoryLayerFilterTests: XCTestCase {
 
         XCTAssertNil(record.toServerMemory())
     }
+
+    func testHidingLifecycleExposureClearsStaleExplicitTierForLegacyDisplay() {
+        let memory = ServerMemory(
+            id: "mem-stale-tier",
+            content: "Cached stale tier",
+            category: .system,
+            tier: .shortTerm,
+            tierIsExplicit: true,
+            createdAt: Date(timeIntervalSince1970: 1),
+            updatedAt: Date(timeIntervalSince1970: 2),
+            conversationId: nil,
+            reviewed: false,
+            userReview: nil,
+            visibility: "private",
+            manuallyAdded: false,
+            scoring: nil,
+            source: nil,
+            confidence: nil,
+            sourceApp: nil,
+            contextSummary: nil,
+            isRead: false,
+            isDismissed: false,
+            tags: [],
+            reasoning: nil,
+            currentActivity: nil,
+            inputDeviceName: nil,
+            windowTitle: nil,
+            headline: nil
+        )
+
+        let hidden = memory.hidingLifecycleExposure()
+
+        XCTAssertEqual(hidden.tier, .longTerm)
+        XCTAssertFalse(hidden.tierIsExplicit)
+    }
 }
 
 /// Reversible alias during WS-G client rename (Wave 36).

--- a/desktop/macos/changelog/unreleased/20260702-memory-tier-cache-bleed.json
+++ b/desktop/macos/changelog/unreleased/20260702-memory-tier-cache-bleed.json
@@ -1,0 +1,3 @@
+{
+  "change": "Clear stale Short-term and Long-term memory labels from legacy memory accounts after backend sync"
+}


### PR DESCRIPTION
## Summary
- Strip canonical memory lifecycle fields from legacy /v3/memories responses
- Keep canonical memory-read responses returning layer for enrolled users
- Add regression coverage for non-enrolled legacy users with short-term memory_tier data

## Test Plan
- [x] cd backend && pytest tests/unit/test_v3_production_runtime_wiring.py -q

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8872?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

