### PR TITLE
Add optional sources filter to conversations count endpoint

### DIFF
--- a/backend/database/conversations.py
+++ b/backend/database/conversations.py
@@ -255,10 +255,13 @@ def get_conversations_count(
     categories: Optional[List[str]] = None,
     folder_id: Optional[str] = None,
     starred: Optional[bool] = None,
+    sources: Optional[List[str]] = None,
 ):
     conversations_ref = db.collection('users').document(uid).collection(conversations_collection)
     if not include_discarded:
         conversations_ref = conversations_ref.where(filter=FieldFilter('discarded', '==', False))
+    if sources:
+        conversations_ref = conversations_ref.where(filter=FieldFilter('source', 'in', sources))
     if statuses:
         conversations_ref = conversations_ref.where(filter=FieldFilter('status', 'in', statuses))
     if categories:

--- a/backend/routers/conversations.py
+++ b/backend/routers/conversations.py
@@ -289,11 +289,16 @@ def get_conversations_count(
     end_date: Optional[datetime] = Query(None, description="Filter by end date (inclusive)"),
     folder_id: Optional[str] = Query(None, description="Filter by folder ID"),
     starred: Optional[bool] = Query(None, description="Filter by starred status"),
+    sources: Optional[str] = Query(None, description="Comma-separated source filter (e.g. friend,omi)"),
     uid: str = Depends(auth.get_current_user_uid),
 ):
     if start_date is not None and end_date is not None and _ensure_aware(start_date) > _ensure_aware(end_date):
         raise HTTPException(status_code=400, detail="start_date must be earlier than or equal to end_date")
     status_list = [s.strip() for s in statuses.split(',') if s.strip()] if statuses else []
+    source_list = [s.strip() for s in sources.split(',') if s.strip()] if sources else []
+    if status_list and source_list:
+        # Firestore allows a single `in` filter per query.
+        raise HTTPException(status_code=400, detail="statuses and sources filters cannot be combined")
     count = conversations_db.get_conversations_count(
         uid,
         include_discarded=include_discarded,
@@ -302,7 +307,12 @@ def get_conversations_count(
         end_date=end_date,
         folder_id=folder_id,
         starred=starred,
+        sources=source_list,
     )
+    if source_list:
+        # Echo the filter so clients can tell this backend applied it (older
+        # backends ignore the unknown param and return the unfiltered total).
+        return {'count': count, 'sources': source_list}
     return {'count': count}
 
 

--- a/backend/routers/conversations.py
+++ b/backend/routers/conversations.py
@@ -297,7 +297,7 @@ def get_conversations_count(
     status_list = [s.strip() for s in statuses.split(',') if s.strip()] if statuses else []
     source_list = [s.strip() for s in sources.split(',') if s.strip()] if sources else []
     if status_list and source_list:
-        # Firestore allows a single `in` filter per query.
+        # Combining status+source `in` filters would need a composite index; keep them exclusive.
         raise HTTPException(status_code=400, detail="statuses and sources filters cannot be combined")
     count = conversations_db.get_conversations_count(
         uid,

--- a/backend/tests/unit/test_conversations_count.py
+++ b/backend/tests/unit/test_conversations_count.py
@@ -79,11 +79,14 @@ def get_conversations_count(
     categories=None,
     folder_id=None,
     starred=None,
+    sources=None,
 ):
     """Mirrors database.conversations.get_conversations_count."""
     conversations_ref = mock_db.collection('users').document(uid).collection('conversations')
     if not include_discarded:
         conversations_ref = conversations_ref.where(filter=FieldFilter('discarded', '==', False))
+    if sources:
+        conversations_ref = conversations_ref.where(filter=FieldFilter('source', 'in', sources))
     if statuses:
         conversations_ref = conversations_ref.where(filter=FieldFilter('status', 'in', statuses))
     if categories:
@@ -116,6 +119,7 @@ class TestConversationsCount:
             source = f.read()
         assert 'def get_conversations_count(' in source
         assert "FieldFilter('discarded', '==', False)" in source
+        assert "FieldFilter('source', 'in', sources)" in source
         assert "FieldFilter('status', 'in', statuses)" in source
         assert "FieldFilter('folder_id', '==', folder_id)" in source
         assert "FieldFilter('starred', '==', starred)" in source
@@ -305,6 +309,26 @@ class TestConversationsCountRouteSource:
         with open(source_path, encoding='utf-8') as f:
             source = f.read()
         assert "{'count': count}" in source or "{'count':count}" in source
+
+    def test_route_forwards_sources_as_list(self):
+        source_path = os.path.join(os.path.dirname(__file__), '..', '..', 'routers', 'conversations.py')
+        with open(source_path, encoding='utf-8') as f:
+            source = f.read()
+        assert 'sources=source_list' in source
+
+    def test_route_rejects_statuses_combined_with_sources(self):
+        source_path = os.path.join(os.path.dirname(__file__), '..', '..', 'routers', 'conversations.py')
+        with open(source_path, encoding='utf-8') as f:
+            source = f.read()
+        assert 'statuses and sources filters cannot be combined' in source
+
+    def test_route_echoes_sources_when_filtered(self):
+        # Clients rely on the echo to distinguish a filtered count from an
+        # older backend that ignored the unknown sources param.
+        source_path = os.path.join(os.path.dirname(__file__), '..', '..', 'routers', 'conversations.py')
+        with open(source_path, encoding='utf-8') as f:
+            source = f.read()
+        assert "{'count': count, 'sources': source_list}" in source
 
 
 class TestAppsV2LimitBoundary:

--- a/backend/tests/unit/test_conversations_date_range_validation.py
+++ b/backend/tests/unit/test_conversations_date_range_validation.py
@@ -238,6 +238,7 @@ def _call_count(**overrides):
         end_date=None,
         folder_id=None,
         starred=None,
+        sources=None,
         uid='u1',
     )
     kwargs.update(overrides)


### PR DESCRIPTION
Backend half of the home-page "Omi Device → Connected" feature (desktop half follows separately).

- `GET /v1/conversations/count?sources=friend,omi` counts conversations from the given capture sources (single Firestore `in` filter; cannot combine with `statuses`, 400 if both).
- When `sources` is applied, the response echoes it (`{count, sources}`) so clients can tell a filtered count from an older backend ignoring the unknown param — prevents false positives during rollout.
- Legacy response shape unchanged when the param is absent.

Verified over HTTP against real accounts (local backend, prod Firestore): 9,531 for a wearable account, 0 for one without, no composite-index issues with combined equality filters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8873?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

