### PR TITLE
Show Connected on home Omi Device row for account-level wearable history

### DIFF
--- a/desktop/macos/Desktop/Sources/APIClient.swift
+++ b/desktop/macos/Desktop/Sources/APIClient.swift
@@ -684,6 +684,22 @@ extension APIClient {
     return response.count
   }
 
+  /// True when this account has any conversations captured by an Omi wearable
+  /// (paired on any platform — usually the mobile app).
+  func hasOmiDeviceConversations() async throws -> Bool {
+    struct CountResponse: Decodable {
+      let count: Int
+      // Backends without the sources filter ignore the param and return the
+      // unfiltered total without this echo — decoding then fails, so we never
+      // read a false positive from an old backend.
+      let sources: [String]
+    }
+
+    let response: CountResponse = try await get(
+      "v1/conversations/count?include_discarded=true&sources=friend,omi")
+    return response.count > 0
+  }
+
   /// Gets the count of AI chat messages from PostHog
   func getChatMessageCount() async throws -> Int {
     struct CountResponse: Decodable {

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
@@ -227,6 +227,10 @@ struct DashboardPage: View {
     @State private var conversationCount: Int?
     @State private var memoryCount: Int?
     @State private var taskCount: Int?
+    // Wearable used on this account (any friend/omi-sourced conversation).
+    // Seeded from UserDefaults so the badge is instant on later launches.
+    @State private var accountHasOmiDeviceConversations = UserDefaults.standard.bool(
+        forKey: DashboardPage.omiDeviceHistoryDefaultsKey)
     @State private var memoryExportStatuses: [MemoryExportDestination: MemoryExportStatus] = [:]
     @State private var isCaptureMonitoring = false
     @State private var isTogglingCapture = false
@@ -257,8 +261,11 @@ struct DashboardPage: View {
         isCaptureMonitoring || ProactiveAssistantsPlugin.shared.isMonitoring
     }
 
+    private static let omiDeviceHistoryDefaultsKey = "home-omi-device-account-history"
+
     private var hasOmiDeviceHistory: Bool {
         deviceProvider.connectedDevice != nil || deviceProvider.pairedDevice != nil
+            || accountHasOmiDeviceConversations
     }
 
     /// Real persisted import-connector state (UserDefaults-backed via ImportConnectorStatusStore).
@@ -808,11 +815,18 @@ struct DashboardPage: View {
         // Open tasks only (matches the "Tasks" label and the old tile's intent —
         // the old value just under-counted, capping each bucket at a 7-day window).
         async let tasks = try? ActionItemStorage.shared.getLocalActionItemsCount(completed: false)
-        let (c, m, t) = await (convos, mems, tasks)
+        async let deviceHistory = try? APIClient.shared.hasOmiDeviceConversations()
+        let (c, m, t, d) = await (convos, mems, tasks, deviceHistory)
         await MainActor.run {
             if let c { conversationCount = c }
             if let m { memoryCount = m }
             if let t { taskCount = t }
+            // Sticky: device history never un-happens; keep the badge across
+            // launches and network failures once observed.
+            if d == true {
+                accountHasOmiDeviceConversations = true
+                UserDefaults.standard.set(true, forKey: Self.omiDeviceHistoryDefaultsKey)
+            }
         }
     }
 

--- a/desktop/macos/changelog/unreleased/20260702-omi-device-connected-account.json
+++ b/desktop/macos/changelog/unreleased/20260702-omi-device-connected-account.json
@@ -1,0 +1,3 @@
+{
+    "change": "Home: the Omi Device row now shows Connected when a wearable was used on this account (e.g. paired on mobile), not only when paired to this Mac"
+}


### PR DESCRIPTION
The home Omi Device row only reflected a device paired to this Mac via BLE — wearables usually pair on mobile, so desktop always showed it unconnected.

Now the row shows **Connected** when the account has any `friend`/`omi`-sourced conversations, via the new `sources` filter on `/v1/conversations/count` (#8873). The client strictly decodes the `{count, sources}` echo, so an older backend that ignores the param can never produce a false positive (verified fail-closed against prod). Result is sticky-cached in UserDefaults.

## Verification (local end-to-end)
- Local backend running the endpoint + local app build (`omi-subtitle` named bundle, real launch path): Omi Device row renders **Connected** for an account with a wearable conversation — screenshot in workspace.
- Fail-closed: same build against prod backend (no `sources` support) shows no badge.
- `swift build` clean; backend tests 36/36 on the paired PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8875?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

