### PR TITLE
[codex] Support Enter on onboarding continue actions

### DIFF
--- a/desktop/macos/Desktop/Sources/OnboardingBYOKStepView.swift
+++ b/desktop/macos/Desktop/Sources/OnboardingBYOKStepView.swift
@@ -50,10 +50,10 @@ struct OnboardingBYOKStepView: View {
 
         HStack(spacing: 12) {
           Button("Skip for now") {
-            AnalyticsManager.shared.onboardingStepCompleted(step: stepIndex, stepName: "BYOK_Skipped")
-            onSkip()
+            skipForNow()
           }
           .buttonStyle(OnboardingCardButtonStyle(isPrimary: true))
+          .keyboardShortcut(.defaultAction)
           .disabled(isActivating)
 
           Button(isActivating ? "Saving…" : "Save keys") {
@@ -75,6 +75,11 @@ struct OnboardingBYOKStepView: View {
     [openaiKey, anthropicKey, geminiKey, deepgramKey].allSatisfy {
       !$0.trimmingCharacters(in: .whitespaces).isEmpty
     }
+  }
+
+  private func skipForNow() {
+    AnalyticsManager.shared.onboardingStepCompleted(step: stepIndex, stepName: "BYOK_Skipped")
+    onSkip()
   }
 
   private func keyField(provider: BYOKProvider, binding: Binding<String>, help: String)
@@ -104,6 +109,10 @@ struct OnboardingBYOKStepView: View {
             )
         )
         .foregroundColor(OmiColors.textPrimary)
+        .onSubmit {
+          guard allKeysProvided, !isActivating else { return }
+          Task { await activate() }
+        }
       if case .failed(let msg) = keyStatuses[provider] ?? .notChecked {
         Text(msg)
           .font(.system(size: 11))

--- a/desktop/macos/Desktop/Sources/OnboardingDataSourcesStepView.swift
+++ b/desktop/macos/Desktop/Sources/OnboardingDataSourcesStepView.swift
@@ -40,6 +40,7 @@ struct OnboardingDataSourcesStepView: View {
             onContinue()
           }
           .buttonStyle(OnboardingCardButtonStyle(isPrimary: true))
+          .keyboardShortcut(.defaultAction)
           .transition(.opacity.combined(with: .scale(scale: 0.95)))
         } else {
           HStack(spacing: 8) {

--- a/desktop/macos/Desktop/Sources/OnboardingExportsStepView.swift
+++ b/desktop/macos/Desktop/Sources/OnboardingExportsStepView.swift
@@ -36,6 +36,7 @@ struct OnboardingExportsStepView: View {
           onContinue()
         }
         .buttonStyle(OnboardingCardButtonStyle(isPrimary: true))
+        .keyboardShortcut(.defaultAction)
       }
       .frame(maxWidth: .infinity, alignment: .leading)
       .task {

--- a/desktop/macos/Desktop/Sources/OnboardingFileScanStepView.swift
+++ b/desktop/macos/Desktop/Sources/OnboardingFileScanStepView.swift
@@ -59,6 +59,7 @@ struct OnboardingFileScanStepView: View {
             onContinue()
           }
           .buttonStyle(OnboardingCardButtonStyle(isPrimary: true))
+          .keyboardShortcut(.defaultAction)
         } else {
           Text("Scanning your workspace…")
             .font(.system(size: 13))

--- a/desktop/macos/Desktop/Sources/OnboardingFloatingBarDemoView.swift
+++ b/desktop/macos/Desktop/Sources/OnboardingFloatingBarDemoView.swift
@@ -104,6 +104,7 @@ struct OnboardingFloatingBarDemoView: View {
                         .cornerRadius(12)
                 }
                 .buttonStyle(.plain)
+                .keyboardShortcut(.defaultAction)
                 .padding(.bottom, 32)
                 .transition(.move(edge: .bottom).combined(with: .opacity))
             }

--- a/desktop/macos/Desktop/Sources/OnboardingFloatingBarShortcutStepView.swift
+++ b/desktop/macos/Desktop/Sources/OnboardingFloatingBarShortcutStepView.swift
@@ -87,6 +87,7 @@ struct OnboardingFloatingBarShortcutStepView: View {
                             )
                     }
                     .buttonStyle(.plain)
+                    .keyboardShortcut(.defaultAction)
                     .transition(.move(edge: .bottom).combined(with: .opacity))
                 }
             }

--- a/desktop/macos/Desktop/Sources/OnboardingGoalStepView.swift
+++ b/desktop/macos/Desktop/Sources/OnboardingGoalStepView.swift
@@ -59,6 +59,7 @@ struct OnboardingGoalStepView: View {
             )
             .foregroundColor(OmiColors.textPrimary)
             .frame(maxWidth: 560)
+            .onSubmit(saveGoalAndContinue)
         }
 
         if let error = coordinator.lastActionError {
@@ -69,17 +70,10 @@ struct OnboardingGoalStepView: View {
 
         if shouldShowContinue {
           Button(coordinator.isSavingGoal ? "Saving…" : "Continue") {
-            Task {
-              coordinator.goalSaved = false
-              await coordinator.saveGoalIfNeeded()
-              guard coordinator.goalSaved else { return }
-              let completed = await coordinator.completeIntro(appState: appState)
-              if completed {
-                onContinue()
-              }
-            }
+            saveGoalAndContinue()
           }
           .buttonStyle(OnboardingCardButtonStyle(isPrimary: true))
+          .keyboardShortcut(.defaultAction)
           .disabled(coordinator.isSavingGoal)
         }
       }
@@ -112,6 +106,19 @@ struct OnboardingGoalStepView: View {
 
   private var shouldShowContinue: Bool {
     !trimmedGoal.isEmpty
+  }
+
+  private func saveGoalAndContinue() {
+    guard shouldShowContinue, !coordinator.isSavingGoal else { return }
+    Task {
+      coordinator.goalSaved = false
+      await coordinator.saveGoalIfNeeded()
+      guard coordinator.goalSaved else { return }
+      let completed = await coordinator.completeIntro(appState: appState)
+      if completed {
+        onContinue()
+      }
+    }
   }
 }
 

--- a/desktop/macos/Desktop/Sources/OnboardingLanguageStepView.swift
+++ b/desktop/macos/Desktop/Sources/OnboardingLanguageStepView.swift
@@ -58,16 +58,13 @@ struct OnboardingLanguageStepView: View {
                   )
               )
               .foregroundColor(OmiColors.textPrimary)
+              .onSubmit(saveCustomLanguage)
 
             Button("Save language") {
-              Task {
-                await coordinator.setCustomLanguage()
-                if coordinator.lastActionError == nil {
-                  onContinue()
-                }
-              }
+              saveCustomLanguage()
             }
             .buttonStyle(OnboardingCardButtonStyle(isPrimary: true))
+            .keyboardShortcut(.defaultAction)
           }
         }
 
@@ -78,6 +75,15 @@ struct OnboardingLanguageStepView: View {
         }
       }
       .frame(maxWidth: .infinity, alignment: .leading)
+    }
+  }
+
+  private func saveCustomLanguage() {
+    Task {
+      await coordinator.setCustomLanguage()
+      if coordinator.lastActionError == nil {
+        onContinue()
+      }
     }
   }
 }

--- a/desktop/macos/Desktop/Sources/OnboardingNotificationStepView.swift
+++ b/desktop/macos/Desktop/Sources/OnboardingNotificationStepView.swift
@@ -110,6 +110,7 @@ struct OnboardingNotificationStepView: View {
                             .cornerRadius(12)
                     }
                     .buttonStyle(.plain)
+                    .keyboardShortcut(.defaultAction)
                 }
                 .padding(.bottom, 32)
                 .transition(.move(edge: .bottom).combined(with: .opacity))

--- a/desktop/macos/Desktop/Sources/OnboardingTasksStepView.swift
+++ b/desktop/macos/Desktop/Sources/OnboardingTasksStepView.swift
@@ -93,6 +93,7 @@ struct OnboardingTasksStepView: View {
                         .cornerRadius(12)
                 }
                 .buttonStyle(.plain)
+                .keyboardShortcut(.defaultAction)
 
             }
             .padding(.bottom, 32)

--- a/desktop/macos/Desktop/Sources/OnboardingTrustStepView.swift
+++ b/desktop/macos/Desktop/Sources/OnboardingTrustStepView.swift
@@ -41,6 +41,7 @@ struct OnboardingTrustStepView: View {
             onContinue()
           }
           .buttonStyle(OnboardingCardButtonStyle(isPrimary: true))
+          .keyboardShortcut(.defaultAction)
 
           Button("Read the source code") {
             guard let url = URL(string: "https://github.com/BasedHardware/omi") else { return }

--- a/desktop/macos/Desktop/Sources/OnboardingVoiceDemoView.swift
+++ b/desktop/macos/Desktop/Sources/OnboardingVoiceDemoView.swift
@@ -96,6 +96,7 @@ struct OnboardingVoiceDemoView: View {
                         .cornerRadius(12)
                 }
                 .buttonStyle(.plain)
+                .keyboardShortcut(.defaultAction)
                 .padding(.bottom, 32)
                 .transition(.move(edge: .bottom).combined(with: .opacity))
             }

--- a/desktop/macos/Desktop/Sources/OnboardingVoiceShortcutStepView.swift
+++ b/desktop/macos/Desktop/Sources/OnboardingVoiceShortcutStepView.swift
@@ -85,6 +85,7 @@ struct OnboardingVoiceShortcutStepView: View {
                             )
                     }
                     .buttonStyle(.plain)
+                    .keyboardShortcut(.defaultAction)
                     .transition(.move(edge: .trailing).combined(with: .opacity))
                 }
             }

--- a/desktop/macos/Desktop/Sources/OnboardingWelcomeStepView.swift
+++ b/desktop/macos/Desktop/Sources/OnboardingWelcomeStepView.swift
@@ -34,6 +34,7 @@ struct OnboardingWelcomeStepView: View {
           )
           .foregroundColor(OmiColors.textPrimary)
           .frame(maxWidth: 320)
+          .onSubmit(confirmName)
 
         if let error = coordinator.lastActionError {
           Text(error)
@@ -43,14 +44,10 @@ struct OnboardingWelcomeStepView: View {
         }
 
         Button("Continue") {
-          Task {
-            await coordinator.confirmPreferredName()
-            if coordinator.lastActionError == nil {
-              onContinue()
-            }
-          }
+          confirmName()
         }
         .buttonStyle(OnboardingCardButtonStyle(isPrimary: true))
+        .keyboardShortcut(.defaultAction)
 
         // Dev-only shortcut to skip the whole onboarding flow — same as the
         // hidden logo long-press. Never shown on production builds.
@@ -67,6 +64,15 @@ struct OnboardingWelcomeStepView: View {
       .onAppear {
         coordinator.clearLastActionError()
         coordinator.draftName = coordinator.preferredName
+      }
+    }
+  }
+
+  private func confirmName() {
+    Task {
+      await coordinator.confirmPreferredName()
+      if coordinator.lastActionError == nil {
+        onContinue()
       }
     }
   }

--- a/desktop/macos/changelog/unreleased/20260702-onboarding-enter-continue.json
+++ b/desktop/macos/changelog/unreleased/20260702-onboarding-enter-continue.json
@@ -1,0 +1,3 @@
+{
+    "change": "Onboarding: pressing Enter now activates available Continue actions"
+}


### PR DESCRIPTION
## Summary
- Adds Return/Enter keyboard activation to available onboarding Continue-style actions.
- Adds text-field submit handling for name, custom language, custom goal, and BYOK key entry flows.
- Adds the required desktop changelog fragment.

## Validation
- Subagent review found the BYOK step missing an Enter path; patched before publishing.
- `git diff --check`
- `cd desktop/macos && xcrun swift build -c debug --package-path Desktop`
- Launched named bundle `/Applications/omi-onboarding-enter.app` via `OMI_APP_NAME="omi-onboarding-enter" ./run.sh --yolo`.
- Verified Enter advances Trust Continue from onboarding step 3 to 4.
- Verified Enter from focused name field advances onboarding step 0 to 1.
- Verified Enter on BYOK step activates `Skip for now` and advances onboarding step 17 to 18.
- Pre-push hooks passed.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8878?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

