### PR TITLE
Harden memory exposure boundaries

### DIFF
--- a/backend/routers/memories.py
+++ b/backend/routers/memories.py
@@ -6,7 +6,6 @@ import database._client as db_client_module
 from utils.executors import db_executor, postprocess_executor, run_blocking, submit_with_context
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Query, Request, Response
-from fastapi.encoders import jsonable_encoder
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field, ValidationError
 
@@ -34,10 +33,9 @@ from utils.memory.required_promotion import required_promotion_payload
 from utils.memory.import_write_guard import import_write_block_mode, import_write_violation
 from utils.memory.memory_api_contract import (
     MemoryApiExposure,
-    memory_api_payload,
-    memory_api_payloads,
     memory_write_payload,
 )
+from utils.memory.memory_api_response import memory_batch_response, memory_item_response, memory_list_response
 from utils.memory.memory_system import MemorySystem
 from utils.client_device import DeviceScopeRequest, DeviceScopeValidationError, resolve_client_device
 from utils.memory.device_scope_filter import device_scope_validation_error
@@ -192,26 +190,19 @@ def _legacy_memories_response(memories: List[MemoryDB]) -> JSONResponse:
     legacy response takes the same field contract.
     """
 
-    body = jsonable_encoder(memory_api_payloads(memories, MemoryApiExposure.LEGACY))
-    return JSONResponse(
-        content=body,
+    return memory_list_response(
+        memories,
+        MemoryApiExposure.LEGACY,
         headers={'X-Omi-Memory-Device-Scope-Supported': 'false'},
     )
 
 
 def _legacy_memory_response(memory: MemoryDB) -> JSONResponse:
-    return JSONResponse(content=jsonable_encoder(memory_api_payload(memory, MemoryApiExposure.LEGACY)))
+    return memory_item_response(memory, MemoryApiExposure.LEGACY)
 
 
 def _legacy_batch_memories_response(memories: List[MemoryDB]) -> JSONResponse:
-    return JSONResponse(
-        content=jsonable_encoder(
-            {
-                'memories': memory_api_payloads(memories, MemoryApiExposure.LEGACY),
-                'created_count': len(memories),
-            }
-        )
-    )
+    return memory_batch_response(memories, MemoryApiExposure.LEGACY, created_count=len(memories))
 
 
 def _apply_memory_response_headers(http_response: Response, memory_response: V3ComposedResponse) -> None:
@@ -602,10 +593,7 @@ def get_memories(
         _raise_memory_http_exception(memory_response)
     headers = _memory_allowlisted_headers(memory_response)
     headers['Cache-Control'] = 'no-store'
-    return JSONResponse(
-        content=jsonable_encoder(memory_api_payloads(memory_response.body or [], MemoryApiExposure.CANONICAL)),
-        headers=headers,
-    )
+    return memory_list_response(memory_response.body or [], MemoryApiExposure.CANONICAL, headers=headers)
 
 
 @router.get('/v3/memories/review-queue', tags=['memories'])

--- a/backend/testing/e2e/test_v3_memories_route.py
+++ b/backend/testing/e2e/test_v3_memories_route.py
@@ -95,8 +95,14 @@ def test_enrolled_memory_fake_success_maps_body_cursor_and_allowlisted_headers(c
         from utils.memory.v3_composed_get_service import V3ComposedResponse
 
         captured.append(params)
+        composed_body = {
+            **memory_body,
+            "memory_tier": "short_term",
+            "layer": "short_term",
+            "memory_only": "internal-default",
+        }
         response = V3ComposedResponse.success(
-            body=[memory_body],
+            body=[composed_body],
             next_cursor="cursor-next-1",
             source="memory_compatibility_projection",
             read_count=1,
@@ -111,7 +117,9 @@ def test_enrolled_memory_fake_success_maps_body_cursor_and_allowlisted_headers(c
         resp = client.get("/v3/memories?limit=2&offset=0&cursor=cursor-start", headers=auth_headers)
 
     assert resp.status_code == 200, resp.text
-    assert resp.json() == [memory_body]
+    assert resp.json()[0] == {**memory_body, "memory_tier": "short_term", "layer": "short_term"}
+    assert resp.json()[0]["layer"] == "short_term"
+    assert "memory_only" not in resp.json()[0]
     assert len(captured) == 1
     assert captured[0].limit == 2
     assert captured[0].offset == 0

--- a/backend/tests/unit/test_memory_api_contract.py
+++ b/backend/tests/unit/test_memory_api_contract.py
@@ -3,6 +3,7 @@ from datetime import datetime, timezone
 from models.memories import MemoryDB
 from models.product_memory import MemoryTier
 from utils.memory.memory_api_contract import MemoryApiExposure, memory_api_payload, memory_write_payload
+from utils.memory.memory_api_response import memory_batch_response, memory_item_response, memory_list_response
 
 
 def _memory(memory_tier=MemoryTier.short_term):
@@ -19,11 +20,15 @@ def _memory(memory_tier=MemoryTier.short_term):
 
 
 def test_legacy_api_payload_strips_canonical_lifecycle_fields():
-    payload = memory_api_payload(_memory(), MemoryApiExposure.LEGACY)
+    memory = _memory()
+    payload = memory_api_payload(
+        {**memory.model_dump(), "expires_at": "2026-07-03T00:00:00Z"}, MemoryApiExposure.LEGACY
+    )
 
     assert "memory_tier" not in payload
     assert "layer" not in payload
     assert "tier" not in payload
+    assert "expires_at" not in payload
     assert payload["content"] == "User is testing memory rollout"
 
 
@@ -49,13 +54,37 @@ def test_api_payload_strips_internal_memory_fields_for_all_exposures():
                 "id": "m1",
                 "content": "User is testing memory rollout",
                 "memory_only": "strip-me",
+                "memory_default_memory": True,
                 "memory_source": "compatibility_projection",
+                "archive_default_visible": True,
                 "read_decision": "internal",
             },
             exposure,
         )
 
         assert "memory_only" not in payload
+        assert "memory_default_memory" not in payload
         assert "memory_source" not in payload
+        assert "archive_default_visible" not in payload
         assert "read_decision" not in payload
         assert payload["content"] == "User is testing memory rollout"
+
+
+def test_memory_response_builders_apply_public_projection():
+    value = {
+        "id": "m1",
+        "content": "User is testing memory rollout",
+        "memory_tier": "short_term",
+        "memory_only": "strip-me",
+    }
+
+    item = memory_item_response(value, MemoryApiExposure.LEGACY)
+    listed = memory_list_response([value], MemoryApiExposure.LEGACY, headers={"X-Test": "yes"})
+    batch = memory_batch_response([value], MemoryApiExposure.LEGACY, created_count=1)
+
+    assert b"memory_tier" not in item.body
+    assert b"memory_only" not in item.body
+    assert listed.headers["x-test"] == "yes"
+    assert b"memory_tier" not in listed.body
+    assert b"memory_only" not in batch.body
+    assert b"created_count" in batch.body

--- a/backend/tests/unit/test_memory_api_egress_contract.py
+++ b/backend/tests/unit/test_memory_api_egress_contract.py
@@ -1,0 +1,38 @@
+from pathlib import Path
+
+BACKEND_DIR = Path(__file__).resolve().parents[2]
+
+
+def _read(path: str) -> str:
+    return (BACKEND_DIR / path).read_text(encoding='utf-8')
+
+
+def test_v3_memories_route_uses_memory_response_builders_for_public_egress():
+    source = _read('routers/memories.py')
+
+    assert (
+        'from utils.memory.memory_api_response import memory_batch_response, memory_item_response, memory_list_response'
+        in source
+    )
+    assert 'jsonable_encoder(' not in source
+    assert 'memory_list_response(memory_response.body or [], MemoryApiExposure.CANONICAL' in source
+    assert 'memory_list_response(\n        memories,\n        MemoryApiExposure.LEGACY' in source
+    assert 'memory_item_response(memory, MemoryApiExposure.LEGACY)' in source
+    assert 'memory_batch_response(memories, MemoryApiExposure.LEGACY' in source
+
+
+def test_external_memory_surfaces_use_exposure_aware_projection_before_returning_memory_objects():
+    mcp_sse_source = _read('routers/mcp_sse.py')
+    memory_service_source = _read('utils/memory/memory_service.py')
+
+    create_tool = mcp_sse_source[
+        mcp_sse_source.index('elif tool_name == "create_memory":') : mcp_sse_source.index(
+            'elif tool_name == "delete_memory":'
+        )
+    ]
+    assert 'exposure = (' in create_tool
+    assert 'MemoryApiExposure.CANONICAL' in create_tool
+    assert 'MemoryApiExposure.LEGACY' in create_tool
+    assert 'return {"success": True, "memory": memory_api_payload(memory_db, exposure)}' in create_tool
+    assert 'memory_write_payload(memory_db, MemoryApiExposure.LEGACY)' in memory_service_source
+    assert '[memory_write_payload(memory, MemoryApiExposure.LEGACY) for memory in memory_dbs]' in memory_service_source

--- a/backend/utils/memory/memory_api_contract.py
+++ b/backend/utils/memory/memory_api_contract.py
@@ -17,10 +17,11 @@ class MemoryApiExposure(str, Enum):
     CANONICAL = "canonical"
 
 
-CANONICAL_LIFECYCLE_FIELDS = frozenset({"memory_tier", "layer", "tier"})
+CANONICAL_LIFECYCLE_FIELDS = frozenset({"memory_tier", "layer", "tier", "expires_at"})
 MEMORY_INTERNAL_FIELDS = frozenset(
     {
         "memory_only",
+        "memory_default_memory",
         "memory_source",
         "memory_policy",
         "source",
@@ -30,6 +31,7 @@ MEMORY_INTERNAL_FIELDS = frozenset(
         "read_decision",
         "source_policy",
         "archive_default_available",
+        "archive_default_visible",
         "stale_short_term_default_visible",
     }
 )

--- a/backend/utils/memory/memory_api_response.py
+++ b/backend/utils/memory/memory_api_response.py
@@ -1,0 +1,42 @@
+"""HTTP response builders for public memory API payloads."""
+
+from collections.abc import Mapping
+from typing import Any, Iterable
+
+from fastapi.encoders import jsonable_encoder
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
+
+from utils.memory.memory_api_contract import MemoryApiExposure, memory_api_payload, memory_api_payloads
+
+
+def memory_item_response(
+    value: BaseModel | dict[str, Any],
+    exposure: MemoryApiExposure,
+    *,
+    headers: Mapping[str, str] | None = None,
+) -> JSONResponse:
+    return JSONResponse(content=jsonable_encoder(memory_api_payload(value, exposure)), headers=dict(headers or {}))
+
+
+def memory_list_response(
+    values: Iterable[BaseModel | dict[str, Any]],
+    exposure: MemoryApiExposure,
+    *,
+    headers: Mapping[str, str] | None = None,
+) -> JSONResponse:
+    return JSONResponse(content=jsonable_encoder(memory_api_payloads(values, exposure)), headers=dict(headers or {}))
+
+
+def memory_batch_response(
+    values: Iterable[BaseModel | dict[str, Any]],
+    exposure: MemoryApiExposure,
+    *,
+    created_count: int,
+    headers: Mapping[str, str] | None = None,
+) -> JSONResponse:
+    content = {
+        'memories': memory_api_payloads(values, exposure),
+        'created_count': created_count,
+    }
+    return JSONResponse(content=jsonable_encoder(content), headers=dict(headers or {}))

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoriesPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoriesPage.swift
@@ -292,8 +292,33 @@ class MemoriesViewModel: ObservableObject {
     displayMemories(values, lifecycleExposed: canonicalLifecycleExposed)
   }
 
+  private func displayCacheMemories(_ values: [ServerMemory], for token: MemoryScopeToken) -> [ServerMemory] {
+    displayMemories(values, for: token)
+  }
+
   private func displayMemories(_ values: [ServerMemory], lifecycleExposed: Bool) -> [ServerMemory] {
     lifecycleExposed ? values : values.map { $0.hidingLifecycleExposure() }
+  }
+
+  private struct MemoryPageFetchResult {
+    let page: APIClient.MemoryListPage
+    let deviceScopeSupportedOverride: Bool?
+  }
+
+  @discardableResult
+  private func commitMemoryPageCapabilities(
+    _ page: APIClient.MemoryListPage,
+    for token: MemoryScopeToken,
+    expectedOffset: Int? = nil,
+    deviceScopeSupportedOverride: Bool? = nil
+  ) -> Bool {
+    guard isCurrentScope(token) else { return false }
+    if let expectedOffset, currentOffset != expectedOffset { return false }
+    canonicalLifecycleExposed = page.canonicalLifecycleExposed
+    if let deviceScopeCapability = deviceScopeSupportedOverride ?? page.deviceScopeSupported {
+      deviceScopeSupported = deviceScopeCapability
+    }
+    return isCurrentScope(token)
   }
 
   private func layerAllowed(_ memory: ServerMemory, for token: MemoryScopeToken) -> Bool {
@@ -315,7 +340,7 @@ class MemoriesViewModel: ObservableObject {
         let loaded = try await MemoryStorage.shared.getLocalMemories(
           limit: pageSize, offset: 0, tiers: layers(for: token))
         guard isCurrentScope(token) else { return }
-        memories = displayMemories(loaded, for: token)
+        memories = displayCacheMemories(loaded, for: token)
         currentOffset = loaded.count
         hasMoreMemories = loaded.count >= pageSize
         recomputeFilteredMemories()
@@ -421,8 +446,9 @@ class MemoriesViewModel: ObservableObject {
       guard isCurrentScope(token) else { return }
       if let fetchedLifecycleExposure {
         canonicalLifecycleExposed = fetchedLifecycleExposure
+        guard isCurrentScope(token) else { return }
       }
-      memories = displayMemories(mergedMemories, for: token)
+      memories = displayCacheMemories(mergedMemories, for: token)
       currentOffset = mergedMemories.count
       hasMoreMemories = mergedMemories.count >= reloadLimit
       recomputeFilteredMemories()
@@ -494,8 +520,7 @@ class MemoriesViewModel: ObservableObject {
       let reloadLimit = max(pageSize, memories.count)
       let page = try await APIClient.shared.getMemoriesPage(limit: reloadLimit, offset: 0)
       let apiMemories = page.memories
-      guard isCurrentScope(token) else { return }
-      canonicalLifecycleExposed = page.canonicalLifecycleExposed
+      guard commitMemoryPageCapabilities(page, for: token) else { return }
 
       // Sync API results to local cache
       try await MemoryStorage.shared.syncServerMemories(apiMemories)
@@ -510,7 +535,7 @@ class MemoriesViewModel: ObservableObject {
       log(
         "MemoriesViewModel: Auto-refresh showing \(mergedMemories.count) memories (API had \(apiMemories.count))"
       )
-      memories = displayMemories(mergedMemories, for: token)
+      memories = displayCacheMemories(mergedMemories, for: token)
       currentOffset = mergedMemories.count
       rawBackendOffset = apiMemories.count
       hasMoreMemories = mergedMemories.count >= reloadLimit
@@ -590,7 +615,7 @@ class MemoriesViewModel: ObservableObject {
         token.selectedTags.contains { tag in tag.matches(memory) }
       }
 
-      filteredFromDatabase = displayMemories(filteredResults, for: token)
+      filteredFromDatabase = displayCacheMemories(filteredResults, for: token)
       log(
         "MemoriesViewModel: Loaded \(filteredResults.count) filtered memories from SQLite (raw: \(results.count))"
       )
@@ -689,7 +714,7 @@ class MemoriesViewModel: ObservableObject {
         tiers: layers(for: token)
       )
       guard isCurrentScope(token) else { return }
-      searchResults = displayMemories(results, for: token)
+      searchResults = displayCacheMemories(results, for: token)
       log("MemoriesViewModel: Search for '\(query)' found \(results.count) results")
     } catch {
       guard isCurrentScope(token) else { return }
@@ -709,18 +734,19 @@ class MemoriesViewModel: ObservableObject {
 
   /// Fetch memories from the API, honoring the device-scope filter only when
   /// the backend supports it for this user. Legacy (non-canonical) memory users
-  /// get a 400 from device_scope=current; on that we clear deviceScopeSupported
-  /// and retry without the scope so the page still loads. Client-side device
+  /// get a 400 from device_scope=current; on that we retry without the scope
+  /// and return the capability update to the guarded page commit. Client-side device
   /// filtering (recomputeFilteredMemories) preserves the "This Mac" UX.
-  private func fetchMemoriesPageDeviceScopeAware(limit: Int, offset: Int) async throws -> APIClient.MemoryListPage {
+  private func fetchMemoriesPageDeviceScopeAware(limit: Int, offset: Int) async throws -> MemoryPageFetchResult {
     let scope = (filterThisDeviceOnly && deviceScopeSupported) ? "current" : nil
     do {
-      return try await APIClient.shared.getMemoriesPage(limit: limit, offset: offset, deviceScope: scope)
+      let page = try await APIClient.shared.getMemoriesPage(limit: limit, offset: offset, deviceScope: scope)
+      return MemoryPageFetchResult(page: page, deviceScopeSupportedOverride: nil)
     } catch APIError.httpError(let statusCode, _) where statusCode == 400 && scope != nil {
       // Backend rejected device_scope for a non-canonical user — retry unscoped.
-      deviceScopeSupported = false
       log("MemoriesViewModel: device_scope unsupported by backend, retrying unscoped")
-      return try await APIClient.shared.getMemoriesPage(limit: limit, offset: offset, deviceScope: nil)
+      let page = try await APIClient.shared.getMemoriesPage(limit: limit, offset: offset, deviceScope: nil)
+      return MemoryPageFetchResult(page: page, deviceScopeSupportedOverride: false)
     }
   }
 
@@ -760,7 +786,7 @@ class MemoriesViewModel: ObservableObject {
       }
 
       if !cachedMemories.isEmpty, isCurrentScope(token) {
-        memories = displayMemories(cachedMemories, for: token)
+        memories = displayCacheMemories(cachedMemories, for: token)
         currentOffset = cachedMemories.count
         hasMoreMemories = cachedMemories.count >= pageSize
         isLoading = false  // Show cached data immediately
@@ -773,10 +799,11 @@ class MemoriesViewModel: ObservableObject {
 
     // Step 2: Fetch from API in background and sync to local cache
     do {
-      let page = try await fetchMemoriesPageDeviceScopeAware(
+      let fetchResult = try await fetchMemoriesPageDeviceScopeAware(
         limit: pageSize,
         offset: 0
       )
+      let page = fetchResult.page
       let fetchedMemories = page.memories
       guard isCurrentScope(token) else {
         // Scope changed mid-load; reset loading state so the replacement load
@@ -784,9 +811,13 @@ class MemoriesViewModel: ObservableObject {
         isLoading = false
         return
       }
-      canonicalLifecycleExposed = page.canonicalLifecycleExposed
-      if let deviceScopeCapability = page.deviceScopeSupported {
-        deviceScopeSupported = deviceScopeCapability
+      guard commitMemoryPageCapabilities(
+        page,
+        for: token,
+        deviceScopeSupportedOverride: fetchResult.deviceScopeSupportedOverride
+      ) else {
+        isLoading = false
+        return
       }
       hasLoadedInitially = true
       log("MemoriesViewModel: Fetched \(fetchedMemories.count) memories from API")
@@ -802,8 +833,9 @@ class MemoriesViewModel: ObservableObject {
         // Reloading from the unscoped SQLite cache can surface other devices'
         // newer memories that recomputeFilteredMemories() then strips, leaving
         // an empty/short initial page that cannot paginate. Display the fetched
-        // page directly instead. (If device_scope 400'd, deviceScopeSupported is
-        // now false so we take the merged-cache path with client-side filtering.)
+        // page directly instead. (If device_scope 400'd, the committed
+        // capability override is false so we take the merged-cache path with
+        // client-side filtering.)
         let wasDeviceScoped = filterThisDeviceOnly && deviceScopeSupported
         let displayMemories: [ServerMemory]
         if wasDeviceScoped {
@@ -822,7 +854,7 @@ class MemoriesViewModel: ObservableObject {
           isLoading = false
           return
         }
-        let visibleMemories = self.displayMemories(displayMemories, for: token)
+        let visibleMemories = self.displayCacheMemories(displayMemories, for: token)
         memories = visibleMemories
         currentOffset = visibleMemories.count
         // Track the raw backend cursor for subsequent loadMore() fetches.
@@ -887,7 +919,6 @@ class MemoriesViewModel: ObservableObject {
     do {
       while true {
         let page = try await APIClient.shared.getMemoriesPage(limit: batchSize, offset: offset)
-        canonicalLifecycleExposed = page.canonicalLifecycleExposed
         let batch = page.memories
         if batch.isEmpty { break }
 
@@ -940,7 +971,6 @@ class MemoriesViewModel: ObservableObject {
     do {
       while true {
         let page = try await APIClient.shared.getMemoriesPage(limit: batchSize, offset: offset)
-        canonicalLifecycleExposed = page.canonicalLifecycleExposed
         let batch = page.memories
         if batch.isEmpty { break }
 
@@ -1021,7 +1051,7 @@ class MemoriesViewModel: ObservableObject {
 
       guard isCurrentScope(token), currentOffset == requestedOffset else { return }
       if !moreFromCache.isEmpty {
-        let visibleMemories = displayMemories(moreFromCache, for: token)
+        let visibleMemories = displayCacheMemories(moreFromCache, for: token)
         memories.append(contentsOf: visibleMemories)
         currentOffset += visibleMemories.count
         hasMoreMemories = visibleMemories.count >= pageSize
@@ -1040,16 +1070,18 @@ class MemoriesViewModel: ObservableObject {
     // Use the raw backend offset (not the visible/SQLite offset) so that layer
     // filtering does not cause overlapping pages or duplicate appends.
     do {
-      let page = try await fetchMemoriesPageDeviceScopeAware(
+      let fetchResult = try await fetchMemoriesPageDeviceScopeAware(
         limit: pageSize,
         offset: requestedRawOffset
       )
+      let page = fetchResult.page
       let newMemories = page.memories
-      guard isCurrentScope(token), currentOffset == requestedOffset else { return }
-      canonicalLifecycleExposed = page.canonicalLifecycleExposed
-      if let deviceScopeCapability = page.deviceScopeSupported {
-        deviceScopeSupported = deviceScopeCapability
-      }
+      guard commitMemoryPageCapabilities(
+        page,
+        for: token,
+        expectedOffset: requestedOffset,
+        deviceScopeSupportedOverride: fetchResult.deviceScopeSupportedOverride
+      ) else { return }
 
       // Sync to local cache first
       try await MemoryStorage.shared.syncServerMemories(newMemories)

--- a/desktop/macos/Desktop/Tests/MemoryLayerFilterTests.swift
+++ b/desktop/macos/Desktop/Tests/MemoryLayerFilterTests.swift
@@ -102,6 +102,50 @@ final class MemoryLayerFilterTests: XCTestCase {
         XCTAssertEqual(hidden.tier, .longTerm)
         XCTAssertFalse(hidden.tierIsExplicit)
     }
+
+    func testMemoriesPageCommitsPageCapabilitiesThroughSingleFreshnessHelper() throws {
+        let source = try memoriesPageSource()
+
+        XCTAssertTrue(source.contains("private func commitMemoryPageCapabilities("))
+        XCTAssertTrue(source.contains("private struct MemoryPageFetchResult"))
+        XCTAssertEqual(
+            source.components(separatedBy: "canonicalLifecycleExposed = page.canonicalLifecycleExposed").count - 1,
+            1,
+            "Page capability metadata should only be assigned inside commitMemoryPageCapabilities()."
+        )
+        XCTAssertEqual(
+            source.components(separatedBy: "deviceScopeSupported = false").count - 1,
+            0,
+            "Device-scope fallback metadata should be returned to commitMemoryPageCapabilities(), not assigned in fetch retry code."
+        )
+        XCTAssertTrue(source.contains("guard commitMemoryPageCapabilities(page, for: token) else"))
+        XCTAssertTrue(source.contains("let fetchResult = try await fetchMemoriesPageDeviceScopeAware("))
+        XCTAssertTrue(source.contains("let page = fetchResult.page"))
+        XCTAssertTrue(source.contains("deviceScopeSupportedOverride: fetchResult.deviceScopeSupportedOverride"))
+    }
+
+    func testMemoriesPageProjectsCacheReadsBeforeDisplay() throws {
+        let source = try memoriesPageSource()
+
+        XCTAssertTrue(source.contains("private func displayCacheMemories("))
+        XCTAssertFalse(source.contains("memories.append(contentsOf: moreFromCache)"))
+        XCTAssertFalse(source.contains("memories = displayMemories(cachedMemories, for: token)"))
+        XCTAssertFalse(source.contains("memories = displayMemories(mergedMemories, for: token)"))
+        XCTAssertTrue(source.contains("memories.append(contentsOf: visibleMemories)"))
+        XCTAssertTrue(source.contains("memories = displayCacheMemories(cachedMemories, for: token)"))
+        XCTAssertTrue(source.contains("memories = displayCacheMemories(mergedMemories, for: token)"))
+    }
+
+    private func memoriesPageSource() throws -> String {
+        let testsDirectory = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
+        let packageDirectory = testsDirectory.deletingLastPathComponent()
+        let sourceURL = packageDirectory
+            .appendingPathComponent("Sources")
+            .appendingPathComponent("MainWindow")
+            .appendingPathComponent("Pages")
+            .appendingPathComponent("MemoriesPage.swift")
+        return try String(contentsOf: sourceURL, encoding: .utf8)
+    }
 }
 
 /// Reversible alias during WS-G client rename (Wave 36).

--- a/desktop/macos/changelog/unreleased/memory-exposure-hardening.json
+++ b/desktop/macos/changelog/unreleased/memory-exposure-hardening.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed memory labels appearing incorrectly after stale fetches or local cache updates"
+}


### PR DESCRIPTION
## Summary
- centralize public memory HTTP egress through exposure-aware response builders
- keep composed /v3/memories reads legacy-projected unless canonical read is explicitly active
- harden desktop memory cache display and page capability commits so stale/local data cannot expose lifecycle labels to legacy users
- add backend route/contract tests and Swift source guardrail tests

## Validation
- cd backend && PYTHON=.venv/bin/python .venv/bin/python -m pytest tests/unit/test_memory_api_contract.py tests/unit/test_memory_api_egress_contract.py tests/unit/test_ws_i_write_convergence.py tests/unit/test_developer_memory_adapter.py tests/unit/test_mcp_memory_adapter.py -q
- cd backend && PYTHON=.venv/bin/python .venv/bin/python -m pytest tests/unit/test_v3_real_router_default_off_f4.py -q
- cd backend && PYTHON=.venv/bin/python .venv/bin/python -m pytest testing/e2e/test_v3_memories_route.py -q
- cd desktop/macos && xcrun swift test --package-path Desktop --filter MemoryLayerFilterTests
- cd backend && scripts/openapi_runner.sh scripts/export_openapi.py --check ../docs/api-reference/openapi.json
- cd desktop/macos && xcrun swift build -c debug --package-path Desktop
- PYTHON=/Users/dazheng/.codex/worktrees/2efd/omi-upstream/backend/.venv/bin/python git push -u origin codex/memory-exposure-hardening (pre-push checks passed)

## Notes
- Oracle plan recorded locally in .coordination/memory-exposure-hardening-oracle-plan.md (gitignored).
- This PR does not change rollout eligibility, legacy import behavior, GCP services, Firestore data, or deployment workflows.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8880?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

