### PR TITLE
Move Ask Omi to the top of the home export list

### DIFF
--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
@@ -589,6 +589,9 @@ struct DashboardPage: View {
             }
             .frame(height: 62, alignment: .bottomLeading)
 
+            HomeAIChoiceButton(title: "Ask Omi", usesOmiMark: true) {
+                navigate(to: .chat)
+            }
             HomeAIChoiceButton(title: "Claude / Claude Code", brand: .claude, isConnected: isMCPDestinationConnected(.claude)) {
                 openExportDestination(.claudeCode)
             }
@@ -600,9 +603,6 @@ struct DashboardPage: View {
             }
             HomeAIChoiceButton(title: "Hermes", brand: .hermes, isConnected: isMCPDestinationConnected(.hermes)) {
                 openExportDestination(.hermes)
-            }
-            HomeAIChoiceButton(title: "Ask Omi", usesOmiMark: true) {
-                navigate(to: .chat)
             }
             HomeAIChoiceButton(title: "More", systemImage: "plus") {
                 openAppsPage()

--- a/desktop/macos/changelog/unreleased/20260702-ask-omi-first.json
+++ b/desktop/macos/changelog/unreleased/20260702-ask-omi-first.json
@@ -1,0 +1,3 @@
+{
+    "change": "Home: moved Ask Omi to the top of the memory export list"
+}


### PR DESCRIPTION
Per Nik: Ask Omi now leads the "Use omi memory anywhere" column (above Claude/ChatGPT/OpenClaw/Hermes, More stays last). Verified in a local omi-askomi-top named bundle — screenshot in workspace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8881?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

