### PR TITLE
fix(backend): skip a malformed chat message instead of 500ing the whole send

### DIFF
--- a/backend/models/chat.py
+++ b/backend/models/chat.py
@@ -99,6 +99,20 @@ class Message(BaseModel):
                 data['app_id'] = plugin_id_val
         return data
 
+    @classmethod
+    def deserialize_many_safe(cls, records, on_error=None) -> List['Message']:
+        """Build Message objects from raw stored records, skipping any that fail
+        validation so one malformed or legacy chat message cannot 500 a whole history
+        load. on_error(record, exception), when provided, is called for each skip."""
+        parsed: List['Message'] = []
+        for record in records:
+            try:
+                parsed.append(cls(**record))
+            except Exception as exc:  # noqa: BLE001 - one bad record must not break the history
+                if on_error is not None:
+                    on_error(record, exc)
+        return parsed
+
     @staticmethod
     def get_messages_as_string(
         messages: List['Message'],

--- a/backend/routers/chat.py
+++ b/backend/routers/chat.py
@@ -286,7 +286,20 @@ def send_message(
 
     app_id_from_app = app.id if app else None
 
-    messages = list(reversed([Message(**msg) for msg in chat_db.get_messages(uid, limit=10, app_id=compat_app_id)]))
+    # Skip a malformed/legacy stored message rather than 500 the whole chat send.
+    messages = list(
+        reversed(
+            Message.deserialize_many_safe(
+                chat_db.get_messages(uid, limit=10, app_id=compat_app_id),
+                on_error=lambda record, exc: logger.warning(
+                    'Skipping malformed chat message %s for uid=%s: %s',
+                    record.get('id') if isinstance(record, dict) else None,
+                    uid,
+                    type(exc).__name__,
+                ),
+            )
+        )
+    )
 
     def process_message(response: str, callback_data: dict):
         memories = callback_data.get('memories_found', [])

--- a/backend/tests/unit/test_message_deserialize_safe.py
+++ b/backend/tests/unit/test_message_deserialize_safe.py
@@ -1,0 +1,37 @@
+"""Loading chat history must skip a malformed message instead of 500ing the send.
+
+The chat send path built [Message(**msg) for msg in chat_db.get_messages(...)], and
+Message has required fields (id, text, created_at, sender, type). One malformed or
+legacy stored message raised a ValidationError that took down the whole send.
+Message.deserialize_many_safe skips bad records, keeping the valid history.
+"""
+
+from datetime import datetime, timezone
+
+from models.chat import Message
+
+
+def _valid(mid):
+    return {'id': mid, 'text': 'hi', 'created_at': datetime.now(timezone.utc), 'sender': 'human', 'type': 'text'}
+
+
+def test_parses_valid_records():
+    out = Message.deserialize_many_safe([_valid('m1'), _valid('m2')])
+    assert [m.id for m in out] == ['m1', 'm2']
+
+
+def test_skips_malformed_without_losing_valid():
+    records = [_valid('good1'), {'id': 'bad', 'text': 'missing required fields'}, _valid('good2')]
+    skipped = []
+    out = Message.deserialize_many_safe(records, on_error=lambda record, exc: skipped.append(record))
+    assert [m.id for m in out] == ['good1', 'good2']
+    assert len(skipped) == 1
+
+
+def test_tolerates_missing_callback():
+    out = Message.deserialize_many_safe([{'id': 'bad'}, _valid('ok')])
+    assert [m.id for m in out] == ['ok']
+
+
+def test_empty():
+    assert Message.deserialize_many_safe([]) == []


### PR DESCRIPTION
## Summary

Fixes a poison-record bug on the chat send path: one malformed stored message made loading recent history 500, so the user could not send a chat message at all until the bad record was fixed.

## Root cause

The send path loads the last 10 messages for context with an unguarded comprehension:

```python
messages = list(reversed([Message(**msg) for msg in chat_db.get_messages(uid, limit=10, app_id=compat_app_id)]))
```

`Message` has required fields (`id`, `text`, `created_at`, `sender`, `type`). If any stored message is missing one of those or has a bad type, `Message(**msg)` raises a `ValidationError` that propagates out of the comprehension and 500s the whole send, so a single corrupt or legacy history record blocks chatting entirely.

## Fix

Add a `Message.deserialize_many_safe` classmethod that parses each record and skips the ones that fail validation, and use it for the history load. On a skip it logs a safe identifier (the message id) plus the exception class name only, not the `ValidationError` string, which would render user content.

## Testing

`tests/unit/test_message_deserialize_safe.py`: valid records are parsed, malformed records are skipped without losing the valid ones (and reported via the callback), a missing callback is tolerated, and empty input returns an empty list. The classmethod is pure, so the test needs no I/O.

## PR status

Mergeable, no conflicts. Additive resilience: valid history returns exactly as before; only a malformed record changes from 500-the-whole-send to skip-and-log.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8882?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

