### PR TITLE
Ground text-memory calendar extraction in the current date

### DIFF
--- a/backend/tests/unit/test_experience_summary_date_grounding.py
+++ b/backend/tests/unit/test_experience_summary_date_grounding.py
@@ -15,10 +15,13 @@ os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7
 from datetime import datetime, timezone  # noqa: E402
 from unittest.mock import MagicMock, patch  # noqa: E402
 
+import pytz  # noqa: E402
+
 import utils.llm.external_integrations as ext  # noqa: E402
 
 
-def test_summarize_experience_grounds_prompt_in_current_date():
+def _capture_prompt(text, **kwargs):
+    """Call summarize_experience_text with a mocked LLM and return the prompt it built."""
     captured = {}
     fake_response = MagicMock()
     fake_response.action_items = []
@@ -29,8 +32,26 @@ def test_summarize_experience_grounds_prompt_in_current_date():
     llm.with_structured_output.return_value = chain
 
     with patch.object(ext, 'get_llm', return_value=llm):
-        ext.summarize_experience_text('I have a dentist appointment tomorrow')
+        ext.summarize_experience_text(text, **kwargs)
+    return captured['prompt']
 
-    prompt = captured['prompt']
+
+def test_summarize_experience_grounds_prompt_in_current_date():
+    prompt = _capture_prompt('I have a dentist appointment tomorrow')
     assert 'today is' in prompt.lower()
+    # No timezone passed -> anchor to today's UTC date, labeled UTC.
     assert datetime.now(timezone.utc).strftime('%Y-%m-%d') in prompt
+    assert '(UTC)' in prompt
+
+
+def test_summarize_experience_uses_provided_timezone():
+    prompt = _capture_prompt('dentist tomorrow', tz='Asia/Tokyo')
+    # The anchor date is computed in the user's timezone, which can differ from UTC near midnight.
+    assert datetime.now(pytz.timezone('Asia/Tokyo')).strftime('%Y-%m-%d') in prompt
+    assert 'Asia/Tokyo' in prompt
+
+
+def test_summarize_experience_falls_back_to_utc_on_invalid_timezone():
+    prompt = _capture_prompt('dentist tomorrow', tz='Not/ARealZone')
+    assert datetime.now(timezone.utc).strftime('%Y-%m-%d') in prompt
+    assert '(UTC)' in prompt

--- a/backend/tests/unit/test_experience_summary_date_grounding.py
+++ b/backend/tests/unit/test_experience_summary_date_grounding.py
@@ -1,0 +1,36 @@
+"""summarize_experience_text must give the model a current-date reference.
+
+When extracting Calendar Events from a text memory, the model needs to know what
+"today" is to resolve relative dates ("tomorrow", "next week"); without it, extracted
+event dates anchor to the model's training cutoff. The sibling get_message_structure
+already grounds this via the message's started_at. This test asserts the current date
+reaches the prompt sent to the LLM.
+"""
+
+import os
+
+os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
+os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv')
+
+from datetime import datetime, timezone  # noqa: E402
+from unittest.mock import MagicMock, patch  # noqa: E402
+
+import utils.llm.external_integrations as ext  # noqa: E402
+
+
+def test_summarize_experience_grounds_prompt_in_current_date():
+    captured = {}
+    fake_response = MagicMock()
+    fake_response.action_items = []
+
+    chain = MagicMock()
+    chain.invoke.side_effect = lambda prompt: captured.__setitem__('prompt', prompt) or fake_response
+    llm = MagicMock()
+    llm.with_structured_output.return_value = chain
+
+    with patch.object(ext, 'get_llm', return_value=llm):
+        ext.summarize_experience_text('I have a dentist appointment tomorrow')
+
+    prompt = captured['prompt']
+    assert 'today is' in prompt.lower()
+    assert datetime.now(timezone.utc).strftime('%Y-%m-%d') in prompt

--- a/backend/utils/conversations/process_conversation.py
+++ b/backend/utils/conversations/process_conversation.py
@@ -193,7 +193,7 @@ def _get_structured(
 
             if conversation.text_source == ExternalIntegrationConversationSource.other:
                 with track_usage(uid, Features.CONVERSATION_STRUCTURE):
-                    structured = summarize_experience_text(conversation.text, conversation.text_source_spec)
+                    structured = summarize_experience_text(conversation.text, conversation.text_source_spec, tz=tz)
                 return structured, False
 
             # not supported conversation source

--- a/backend/utils/llm/external_integrations.py
+++ b/backend/utils/llm/external_integrations.py
@@ -111,15 +111,20 @@ def get_message_structure(
     return response
 
 
-def summarize_experience_text(text: str, text_source_spec: str = None) -> Structured:
+def summarize_experience_text(text: str, text_source_spec: str = None, tz: str = None) -> Structured:
     source_context = f"Source: {text_source_spec}" if text_source_spec else "their own experiences or thoughts"
-    current_date = datetime.now(timezone.utc).strftime('%Y-%m-%d')
+    tz = tz or 'UTC'
+    try:
+        current_date = datetime.now(pytz.timezone(tz)).strftime('%Y-%m-%d')
+    except Exception:  # unknown/invalid timezone -> anchor to UTC
+        tz = 'UTC'
+        current_date = datetime.now(timezone.utc).strftime('%Y-%m-%d')
     prompt = f'''The user sent a text of {source_context}, and wants to create a memory from it.
       For the title, use the main topic of the experience or thought.
       For the overview, condense the descriptions into a brief summary with the main topics discussed, make sure to capture the key points and important details.
       For the category, classify the scenes into one of the available categories.
       For the action items, include any tasks or actions that need to be taken based on the content.
-      For Calendar Events, include any events or meetings mentioned in the content. For date context, today is {current_date} (UTC); resolve any relative dates like "tomorrow" or "next week" against it.
+      For Calendar Events, include any events or meetings mentioned in the content. For date context, today is {current_date} in the user's timezone ({tz}); resolve any relative dates like "tomorrow" or "next week" against it.
 
       Text: ```{text}```
       '''.replace('    ', '').strip()

--- a/backend/utils/llm/external_integrations.py
+++ b/backend/utils/llm/external_integrations.py
@@ -113,12 +113,13 @@ def get_message_structure(
 
 def summarize_experience_text(text: str, text_source_spec: str = None) -> Structured:
     source_context = f"Source: {text_source_spec}" if text_source_spec else "their own experiences or thoughts"
+    current_date = datetime.now(timezone.utc).strftime('%Y-%m-%d')
     prompt = f'''The user sent a text of {source_context}, and wants to create a memory from it.
       For the title, use the main topic of the experience or thought.
       For the overview, condense the descriptions into a brief summary with the main topics discussed, make sure to capture the key points and important details.
       For the category, classify the scenes into one of the available categories.
       For the action items, include any tasks or actions that need to be taken based on the content.
-      For Calendar Events, include any events or meetings mentioned in the content.
+      For Calendar Events, include any events or meetings mentioned in the content. For date context, today is {current_date} (UTC); resolve any relative dates like "tomorrow" or "next week" against it.
 
       Text: ```{text}```
       '''.replace('    ', '').strip()


### PR DESCRIPTION
## What

`summarize_experience_text` (used when a user turns a text note into a memory) asks the model to extract Calendar Events from the text, but the prompt gives the model no reference for the current date. Relative dates in the note ("tomorrow", "next Tuesday", "next week") have nothing to anchor against, so extracted event datetimes drift toward the model's training cutoff instead of the user's actual today.

The sibling extractor `get_message_structure` already grounds its prompt with the message `started_at` and timezone. This brings `summarize_experience_text` in line.

## Change

- Compute the current UTC date once and add a date-context line to the extraction prompt, instructing the model to resolve relative dates against it.
- Single-file change in `backend/utils/llm/external_integrations.py`. No signature or caller changes.

## Test

- New `backend/tests/unit/test_experience_summary_date_grounding.py` mocks the LLM, calls `summarize_experience_text`, and asserts the current date reaches the prompt sent for extraction.
- Passes locally and is auto-discovered by `scripts/select_backend_unit_tests.py --all`.

Follows the same date-grounding approach already used by the message and conversation extractors.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8885?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

