### PR TITLE
Route LLM gateway shadows through LangChain provider

### DIFF
--- a/backend/charts/backend-listen/dev_omi_backend_listen_values.yaml
+++ b/backend/charts/backend-listen/dev_omi_backend_listen_values.yaml
@@ -119,6 +119,10 @@ env:
     value: "true"
   - name: OMI_LLM_GATEWAY_CONVERSATION_ACTION_ITEMS_SHADOW_SAMPLE_RATE
     value: "1.0"
+  - name: OMI_LLM_GATEWAY_DEV_SHADOW_ALL_ENABLED
+    value: "true"
+  - name: OMI_LLM_GATEWAY_DEV_SHADOW_ALL_SAMPLE_RATE
+    value: "1.0"
   - name: OMI_LLM_GATEWAY_SERVICE_TOKEN
     valueFrom:
       secretKeyRef:

--- a/backend/charts/backend-listen/dev_omi_backend_listen_values.yaml
+++ b/backend/charts/backend-listen/dev_omi_backend_listen_values.yaml
@@ -111,6 +111,8 @@ env:
         key: OPENAI_API_KEY
   - name: OMI_LLM_GATEWAY_URL
     value: "http://dev-omi-llm-gateway.dev-omi-backend.svc.cluster.local:8080"
+  - name: OMI_ENV_STAGE
+    value: "dev"
   - name: OMI_LLM_GATEWAY_CONVERSATION_STRUCTURE_SHADOW_ENABLED
     value: "true"
   - name: OMI_LLM_GATEWAY_CONVERSATION_STRUCTURE_SHADOW_SAMPLE_RATE

--- a/backend/charts/backend-listen/prod_omi_backend_listen_values.yaml
+++ b/backend/charts/backend-listen/prod_omi_backend_listen_values.yaml
@@ -103,6 +103,8 @@ env:
         key: OPENAI_API_KEY
   - name: OMI_LLM_GATEWAY_URL
     value: "http://prod-omi-llm-gateway.prod-omi-backend.svc.cluster.local:8080"
+  - name: OMI_ENV_STAGE
+    value: "prod"
   - name: OMI_LLM_GATEWAY_SERVICE_TOKEN
     valueFrom:
       secretKeyRef:

--- a/backend/deploy/runtime_env.yaml
+++ b/backend/deploy/runtime_env.yaml
@@ -24,6 +24,12 @@ environments:
           OMI_LLM_GATEWAY_CONVERSATION_ACTION_ITEMS_SHADOW_SAMPLE_RATE:
             value: "1.0"
             category: rollout
+          OMI_LLM_GATEWAY_DEV_SHADOW_ALL_ENABLED:
+            value: "true"
+            category: rollout
+          OMI_LLM_GATEWAY_DEV_SHADOW_ALL_SAMPLE_RATE:
+            value: "1.0"
+            category: rollout
           OMI_LLM_GATEWAY_SERVICE_TOKEN:
             secret:
               name: dev-omi-backend-secrets
@@ -75,6 +81,12 @@ environments:
             OMI_LLM_GATEWAY_CONVERSATION_ACTION_ITEMS_SHADOW_SAMPLE_RATE:
               value: "1.0"
               category: rollout
+            OMI_LLM_GATEWAY_DEV_SHADOW_ALL_ENABLED:
+              value: "true"
+              category: rollout
+            OMI_LLM_GATEWAY_DEV_SHADOW_ALL_SAMPLE_RATE:
+              value: "1.0"
+              category: rollout
             MEMORY_MODE:
               value: write
               category: memory_rollout
@@ -122,6 +134,12 @@ environments:
             OMI_LLM_GATEWAY_CONVERSATION_ACTION_ITEMS_SHADOW_SAMPLE_RATE:
               value: "1.0"
               category: rollout
+            OMI_LLM_GATEWAY_DEV_SHADOW_ALL_ENABLED:
+              value: "true"
+              category: rollout
+            OMI_LLM_GATEWAY_DEV_SHADOW_ALL_SAMPLE_RATE:
+              value: "1.0"
+              category: rollout
             MEMORY_MODE:
               value: write
               category: memory_rollout
@@ -167,6 +185,12 @@ environments:
               value: "true"
               category: rollout
             OMI_LLM_GATEWAY_CONVERSATION_ACTION_ITEMS_SHADOW_SAMPLE_RATE:
+              value: "1.0"
+              category: rollout
+            OMI_LLM_GATEWAY_DEV_SHADOW_ALL_ENABLED:
+              value: "true"
+              category: rollout
+            OMI_LLM_GATEWAY_DEV_SHADOW_ALL_SAMPLE_RATE:
               value: "1.0"
               category: rollout
             MEMORY_MODE:

--- a/backend/deploy/runtime_env.yaml
+++ b/backend/deploy/runtime_env.yaml
@@ -12,6 +12,9 @@ environments:
           OMI_LLM_GATEWAY_URL:
             value: http://dev-omi-llm-gateway.dev-omi-backend.svc.cluster.local:8080
             category: service_discovery
+          OMI_ENV_STAGE:
+            value: dev
+            category: runtime_identity
           OMI_LLM_GATEWAY_CONVERSATION_STRUCTURE_SHADOW_ENABLED:
             value: "true"
             category: rollout
@@ -66,6 +69,9 @@ environments:
           env:
             GOOGLE_CLOUD_PROJECT:
               value: based-hardware
+            OMI_ENV_STAGE:
+              value: dev
+              category: runtime_identity
             OMI_LLM_GATEWAY_URL:
               value: http://172.16.63.232
               category: service_discovery
@@ -119,6 +125,9 @@ environments:
           env:
             GOOGLE_CLOUD_PROJECT:
               value: based-hardware
+            OMI_ENV_STAGE:
+              value: dev
+              category: runtime_identity
             OMI_LLM_GATEWAY_URL:
               value: http://172.16.63.232
               category: service_discovery
@@ -172,6 +181,9 @@ environments:
           env:
             GOOGLE_CLOUD_PROJECT:
               value: based-hardware
+            OMI_ENV_STAGE:
+              value: dev
+              category: runtime_identity
             OMI_LLM_GATEWAY_URL:
               value: http://172.16.63.232
               category: service_discovery
@@ -233,6 +245,9 @@ environments:
           OMI_LLM_GATEWAY_URL:
             value: http://prod-omi-llm-gateway.prod-omi-backend.svc.cluster.local:8080
             category: service_discovery
+          OMI_ENV_STAGE:
+            value: prod
+            category: runtime_identity
           OMI_LLM_GATEWAY_SERVICE_TOKEN:
             secret:
               name: prod-omi-backend-secrets
@@ -272,6 +287,9 @@ environments:
       services:
         backend:
           env:
+            OMI_ENV_STAGE:
+              value: prod
+              category: runtime_identity
             OMI_LLM_GATEWAY_URL:
               env_var: OMI_LLM_GATEWAY_URL
               category: service_discovery
@@ -306,6 +324,9 @@ environments:
               version: latest
         backend-sync:
           env:
+            OMI_ENV_STAGE:
+              value: prod
+              category: runtime_identity
             OMI_LLM_GATEWAY_URL:
               env_var: OMI_LLM_GATEWAY_URL
               category: service_discovery
@@ -340,6 +361,9 @@ environments:
               version: latest
         backend-integration:
           env:
+            OMI_ENV_STAGE:
+              value: prod
+              category: runtime_identity
             OMI_LLM_GATEWAY_URL:
               env_var: OMI_LLM_GATEWAY_URL
               category: service_discovery

--- a/backend/docs/llm/model_endpoint_inventory.yaml
+++ b/backend/docs/llm/model_endpoint_inventory.yaml
@@ -68,7 +68,7 @@ model_config_features:
     pinned:
       - fair_use
   gateway_capability_needed: OpenAI-compatible chat-completions lane with provider refs for openai, gemini, openrouter, perplexity, and anthropic.
-  migration_status: get_llm can centrally switch Omi-managed feature traffic to the generated gateway lanes with OMI_LLM_GATEWAY_FEATURE_MODE=gateway; BYOK remains direct user-key routing.
+  migration_status: get_llm can centrally switch Omi-managed feature traffic to the generated gateway lanes with OMI_LLM_GATEWAY_FEATURE_MODE=gateway; BYOK remains direct user-key routing outside the gateway flip and fails closed during the gateway flip unless explicitly acknowledged; direct exception surfaces fail closed during the gateway flip unless explicitly acknowledged.
   test_guardrail_coverage:
     - backend/tests/unit/test_llm_gateway_coverage_guardrails.py::test_every_model_config_feature_has_inventory_and_gateway_lane
     - backend/tests/unit/test_llm_gateway_client_config.py::test_get_llm_feature_gateway_mode_uses_generated_auto_lane
@@ -85,7 +85,7 @@ surfaces:
     current_provider_model: anthropic/chat_agent
     request_shape: streaming, native tool calling, server-side web search
     gateway_lane_capability_needed: anthropic provider adapter with tools enabled on omi:auto:chat-agent
-    migration_status: gateway_capability_implemented; legacy native stream remains serving until the dev gateway flip validates equivalent streaming behavior
+    migration_status: inventoried_explicit_direct_anthropic_stream_exception; blocked during OMI_LLM_GATEWAY_FEATURE_MODE=gateway unless explicitly acknowledged
     test_guardrail_coverage: backend/tests/unit/test_llm_gateway_coverage_guardrails.py
   - surface: perplexity_web_search_tool
     code_path: backend/utils/retrieval/tools/perplexity_tools.py:perplexity_web_search_tool
@@ -106,21 +106,21 @@ surfaces:
     current_provider_model: openai/gpt-4.1
     request_shape: streaming vision chat completion
     gateway_lane_capability_needed: gateway-owned vision chat lane or file-chat replacement retrieval path
-    migration_status: inventoried_explicit_direct_file_lifecycle_exception; not silently missed during dev flip
+    migration_status: inventoried_explicit_direct_file_lifecycle_exception; blocked during OMI_LLM_GATEWAY_FEATURE_MODE=gateway unless explicitly acknowledged
     test_guardrail_coverage: backend/tests/unit/test_llm_gateway_coverage_guardrails.py
   - surface: file_chat_assistants
     code_path: backend/utils/other/chat_file.py:FileChatTool
     current_provider_model: openai/gpt-4.1 with Assistants, Threads, Files, File Search
     request_shape: file upload, assistants, file_search, streaming run deltas
     gateway_lane_capability_needed: gateway-owned file/assistant lifecycle or replacement retrieval path
-    migration_status: inventoried_explicit_direct_file_lifecycle_exception; not silently missed during dev flip
+    migration_status: inventoried_explicit_direct_file_lifecycle_exception; blocked during OMI_LLM_GATEWAY_FEATURE_MODE=gateway unless explicitly acknowledged
     test_guardrail_coverage: backend/tests/unit/test_llm_gateway_coverage_guardrails.py
   - surface: omni_realtime_relay
     code_path: backend/routers/omni_relay.py
     current_provider_model: openai realtime or gemini live selected by client query
     request_shape: realtime websocket relay
     gateway_lane_capability_needed: gateway-owned realtime websocket relay
-    migration_status: inventoried_explicit_realtime_exception; prod behavior unchanged
+    migration_status: inventoried_explicit_realtime_exception; blocked during OMI_LLM_GATEWAY_FEATURE_MODE=gateway unless explicitly acknowledged; prod behavior unchanged
     test_guardrail_coverage: backend/tests/unit/test_llm_gateway_coverage_guardrails.py
   - surface: fair_use_classifier
     code_path: backend/utils/llm/fair_use_classifier.py:classify_user_purpose

--- a/backend/docs/llm/model_endpoint_inventory.yaml
+++ b/backend/docs/llm/model_endpoint_inventory.yaml
@@ -1,0 +1,138 @@
+schema_version: llm_model_endpoint_inventory.v1
+scope:
+  in_scope: backend chat/completion/generation/model calls, including streaming, tool calling, image generation, file chat, realtime relay, and provider web search
+  out_of_scope: embeddings/vector APIs only
+out_of_scope_surfaces:
+  - surface: openai_embeddings
+    code_path: backend/utils/llm/clients.py:OpenAIEmbeddings,generate_embedding
+    provider_model: openai/text-embedding-3-large
+    request_shape: embedding
+    reason: Embeddings are explicitly out of scope for this phase.
+  - surface: gemini_screen_activity_query_embedding
+    code_path: backend/utils/llm/clients.py:gemini_embed_query
+    provider_model: gemini/embedding-001
+    request_shape: embedding
+    reason: Embeddings are explicitly out of scope for this phase.
+model_config_features:
+  status: gateway_lane_generated_from_model_config
+  source_of_truth: backend/utils/llm/model_config.py
+  gateway_lane: omi:auto:<feature-with-underscores-as-hyphens>
+  code_paths:
+    - backend/utils/llm/clients.py:get_llm
+    - backend/llm_gateway/gateway/config_loader.py:_generated_feature_route_items
+  request_shapes:
+    plain_chat:
+      - conv_action_items
+      - conv_app_result
+      - conv_discard
+      - conv_folder
+      - conv_structure
+      - daily_summary
+      - daily_summary_simple
+      - followup
+      - goals
+      - goals_advice
+      - knowledge_graph
+      - learnings
+      - memories
+      - memory_category
+      - memory_conflict
+      - memory_l1
+      - notifications
+      - onboarding
+      - openglass
+      - persona_chat
+      - persona_chat_premium
+      - persona_clone
+      - session_titles
+      - smart_glasses
+      - wrapped_analysis
+      - app_generator
+      - app_integration
+    structured_output:
+      - chat_extraction
+      - conv_app_select
+      - external_structure
+      - proactive_notification
+      - trends
+    streaming:
+      - chat_responses
+      - chat_graph
+      - persona_chat
+      - persona_chat_premium
+    tool_calling:
+      - chat_agent
+      - memory_l2
+    provider_search:
+      - web_search
+    pinned:
+      - fair_use
+  gateway_capability_needed: OpenAI-compatible chat-completions lane with provider refs for openai, gemini, openrouter, perplexity, and anthropic.
+  migration_status: get_llm can centrally switch Omi-managed feature traffic to the generated gateway lanes with OMI_LLM_GATEWAY_FEATURE_MODE=gateway; BYOK remains direct user-key routing.
+  test_guardrail_coverage:
+    - backend/tests/unit/test_llm_gateway_coverage_guardrails.py::test_every_model_config_feature_has_inventory_and_gateway_lane
+    - backend/tests/unit/test_llm_gateway_client_config.py::test_get_llm_feature_gateway_mode_uses_generated_auto_lane
+surfaces:
+  - surface: langchain_feature_routing
+    code_path: backend/utils/llm/clients.py:get_llm
+    current_provider_model: utils.llm.model_config feature profile
+    request_shape: plain chat, structured output, parser chain, streaming, tool calling via LangChain
+    gateway_lane_capability_needed: generated feature lanes
+    migration_status: gateway_capable_central_flip
+    test_guardrail_coverage: backend/tests/unit/test_llm_gateway_coverage_guardrails.py
+  - surface: anthropic_agentic_chat
+    code_path: backend/utils/retrieval/agentic.py:_run_anthropic_agent_stream
+    current_provider_model: anthropic/chat_agent
+    request_shape: streaming, native tool calling, server-side web search
+    gateway_lane_capability_needed: anthropic provider adapter with tools enabled on omi:auto:chat-agent
+    migration_status: gateway_capability_implemented; legacy native stream remains serving until the dev gateway flip validates equivalent streaming behavior
+    test_guardrail_coverage: backend/tests/unit/test_llm_gateway_coverage_guardrails.py
+  - surface: perplexity_web_search_tool
+    code_path: backend/utils/retrieval/tools/perplexity_tools.py:perplexity_web_search_tool
+    current_provider_model: perplexity/web_search
+    request_shape: provider search chat completion
+    gateway_lane_capability_needed: perplexity OpenAI-compatible provider adapter on omi:auto:web-search
+    migration_status: gateway_routed
+    test_guardrail_coverage: backend/tests/unit/test_llm_gateway_coverage_guardrails.py
+  - surface: app_icon_generation
+    code_path: backend/utils/llm/app_generator.py:generate_app_icon
+    current_provider_model: openai/dall-e-3
+    request_shape: image generation
+    gateway_lane_capability_needed: gateway-owned /v1/images/generations proxy
+    migration_status: gateway_routed
+    test_guardrail_coverage: backend/tests/unit/test_llm_gateway_coverage_guardrails.py
+  - surface: file_chat_vision
+    code_path: backend/utils/other/chat_file.py:_ask_vision_stream
+    current_provider_model: openai/gpt-4.1
+    request_shape: streaming vision chat completion
+    gateway_lane_capability_needed: gateway-owned vision chat lane or file-chat replacement retrieval path
+    migration_status: inventoried_explicit_direct_file_lifecycle_exception; not silently missed during dev flip
+    test_guardrail_coverage: backend/tests/unit/test_llm_gateway_coverage_guardrails.py
+  - surface: file_chat_assistants
+    code_path: backend/utils/other/chat_file.py:FileChatTool
+    current_provider_model: openai/gpt-4.1 with Assistants, Threads, Files, File Search
+    request_shape: file upload, assistants, file_search, streaming run deltas
+    gateway_lane_capability_needed: gateway-owned file/assistant lifecycle or replacement retrieval path
+    migration_status: inventoried_explicit_direct_file_lifecycle_exception; not silently missed during dev flip
+    test_guardrail_coverage: backend/tests/unit/test_llm_gateway_coverage_guardrails.py
+  - surface: omni_realtime_relay
+    code_path: backend/routers/omni_relay.py
+    current_provider_model: openai realtime or gemini live selected by client query
+    request_shape: realtime websocket relay
+    gateway_lane_capability_needed: gateway-owned realtime websocket relay
+    migration_status: inventoried_explicit_realtime_exception; prod behavior unchanged
+    test_guardrail_coverage: backend/tests/unit/test_llm_gateway_coverage_guardrails.py
+  - surface: fair_use_classifier
+    code_path: backend/utils/llm/fair_use_classifier.py:classify_user_purpose
+    current_provider_model: openai/fair_use pinned feature
+    request_shape: async plain chat JSON
+    gateway_lane_capability_needed: generated omi:auto:fair-use lane
+    migration_status: get_llm_routed
+    test_guardrail_coverage: backend/tests/unit/test_llm_gateway_coverage_guardrails.py
+  - surface: production_like_memory_ingestion
+    code_path: backend/utils/memory_ingestion/adapters/production_like_model.py:_memory_llm
+    current_provider_model: openai/memories feature
+    request_shape: parser chain
+    gateway_lane_capability_needed: generated omi:auto:memories lane
+    migration_status: get_llm_routed
+    test_guardrail_coverage: backend/tests/unit/test_llm_gateway_coverage_guardrails.py

--- a/backend/llm_gateway/config/route_artifacts.yaml
+++ b/backend/llm_gateway/config/route_artifacts.yaml
@@ -1,6 +1,6 @@
 route_artifacts:
   - route_artifact_id: route.chat_structured.2026_06_27.001
-    artifact_digest: sha256:d387bb7ebde0b4e79583b773111b32e4693808570f7c29470dec68527b595b6e
+    artifact_digest: sha256:271229622698025cd7f496f3d0cb3cb505306c2e7b5d6ce32a35d059b1908094
     lane_id: omi:auto:chat-structured
     surface: openai.chat_completions
     primary:
@@ -56,7 +56,7 @@ route_artifacts:
         - invalid_config
 
   - route_artifact_id: route.chat_structured.2026_06_20.001
-    artifact_digest: sha256:2d073c8787bbff26c9b79492c1eacd1357e2f7a2f6a07e8d603a3b860ea229ce
+    artifact_digest: sha256:70492be577ce8833273a58f04802aafa251d7981c0ad4c7a818a895fb5d1d9fc
     lane_id: omi:auto:chat-structured
     surface: openai.chat_completions
     # LKG primary must match the legacy `chat_extraction` model (gpt-4.1-mini) so

--- a/backend/llm_gateway/gateway/config_loader.py
+++ b/backend/llm_gateway/gateway/config_loader.py
@@ -8,6 +8,14 @@ import yaml
 from pydantic import BaseModel, ConfigDict
 
 from llm_gateway.gateway.schemas import FeatureBundle, LaneConfig, RouteArtifact
+from utils.llm.gateway_client import feature_auto_lane_id
+from utils.llm.model_config import (
+    get_all_configured_features,
+    get_model,
+    get_provider,
+    get_route_options,
+    is_structured_output_feature,
+)
 
 DEFAULT_CONFIG_DIR = Path(__file__).resolve().parents[1] / 'config'
 PROD_ENV_VAR = 'OMI_LLM_GATEWAY_PROD'
@@ -33,9 +41,11 @@ def load_gateway_config(config_dir: str | Path | None = None, *, prod_mode: bool
     artifact_items = _load_config_list(resolved_config_dir / 'route_artifacts.yaml', 'route_artifacts')
     bundle_items = _load_config_list(resolved_config_dir / 'feature_bundles.yaml', 'feature_bundles')
 
-    lanes = _parse_lanes(lane_items)
-    route_artifacts = _parse_route_artifacts(artifact_items, prod_mode=resolved_prod_mode)
-    feature_bundles = _parse_feature_bundles(bundle_items)
+    generated_lane_items, generated_artifact_items, generated_bundle_items = _generated_feature_route_items()
+
+    lanes = _parse_lanes([*generated_lane_items, *lane_items])
+    route_artifacts = _parse_route_artifacts([*generated_artifact_items, *artifact_items], prod_mode=resolved_prod_mode)
+    feature_bundles = _parse_feature_bundles([*generated_bundle_items, *bundle_items])
 
     _validate_lane_routes(lanes, route_artifacts)
     _validate_feature_bundles(feature_bundles, lanes)
@@ -148,3 +158,113 @@ def _validate_feature_bundles(feature_bundles: dict[str, FeatureBundle], lanes: 
     for bundle in feature_bundles.values():
         if bundle.lane_id not in lanes:
             raise ConfigValidationError(f'feature bundle {bundle.feature} references unknown lane: {bundle.lane_id}')
+
+
+def feature_lane_id(feature: str) -> str:
+    return feature_auto_lane_id(feature)
+
+
+def _generated_feature_route_items() -> tuple[list[dict[str, Any]], list[dict[str, Any]], list[dict[str, Any]]]:
+    lanes: list[dict[str, Any]] = []
+    artifacts: list[dict[str, Any]] = []
+    bundles: list[dict[str, Any]] = []
+    for feature in sorted(get_all_configured_features()):
+        model = get_model(feature)
+        provider = get_provider(feature)
+        lane_id = feature_lane_id(feature)
+        route_id = f"route.{feature}.model_config.001"
+        capabilities = _capabilities_for_feature(feature)
+        credential_policy = _credential_policy()
+
+        lanes.append(
+            {
+                'lane_id': lane_id,
+                'surface': 'openai.chat_completions',
+                'capabilities': capabilities,
+                'objective': {'quality': 0.6, 'latency': 0.2, 'cost': 0.2},
+                'credential_policy': credential_policy,
+                'active_route': route_id,
+                'last_known_good': route_id,
+            }
+        )
+        primary = {'provider': provider, 'model': _provider_model_name(provider, model)}
+        artifacts.append(
+            {
+                'route_artifact_id': route_id,
+                'lane_id': lane_id,
+                'surface': 'openai.chat_completions',
+                'primary': primary,
+                'fallbacks': [],
+                'timeouts': {'request_ms': 120000 if capabilities['streaming'] else 30000},
+                'retry': {'max_attempts': 1},
+                'capabilities': capabilities,
+                'evidence': {
+                    'benchmark_snapshot': 'model_config.source_of_truth',
+                    'eval_report': f'{feature}.gateway_coverage',
+                    'benchmark_source': 'omi_eval',
+                    'dev_only': False,
+                },
+                'rollout': {'stage': 'active', 'percent': 100},
+                'credential_policy': credential_policy,
+                'fallback_policy': {
+                    'fallback_on': ['timeout_before_output', 'provider_429_omi_paid', 'provider_5xx_omi_paid'],
+                    'never_fallback_on': [
+                        'byok_auth',
+                        'byok_quota',
+                        'byok_rate_limit',
+                        'byok_unsupported_provider',
+                        'missing_byok_key',
+                        'capability_mismatch',
+                        'invalid_config',
+                    ],
+                },
+            }
+        )
+        bundles.append(
+            {
+                'feature': feature,
+                'lane_id': lane_id,
+                'prompt_version': f'{feature}.model_config',
+                'parser_version': 'callsite',
+                'eval_suite': f'{feature}.gateway_coverage',
+                'promotion_gates': {'inventory_status': 'gateway_managed'},
+            }
+        )
+    return lanes, artifacts, bundles
+
+
+def _capabilities_for_feature(feature: str) -> dict[str, Any]:
+    structured_output = 'json_schema' if is_structured_output_feature(feature) else 'none'
+    return {
+        'text_input': True,
+        'streaming': True,
+        'structured_output': structured_output,
+        'tools': feature in {'chat_agent', 'memory_l2'},
+    }
+
+
+def _credential_policy() -> dict[str, Any]:
+    return {
+        'mode': 'omi_paid',
+        'allow_byok_to_omi_paid_fallback': False,
+        'fallback_eligible_failure_classes': [
+            'timeout_before_output',
+            'provider_429_omi_paid',
+            'provider_5xx_omi_paid',
+        ],
+        'never_fallback_failure_classes': [
+            'byok_auth',
+            'byok_quota',
+            'byok_rate_limit',
+            'byok_unsupported_provider',
+            'missing_byok_key',
+            'capability_mismatch',
+            'invalid_config',
+        ],
+    }
+
+
+def _provider_model_name(provider: str, model: str) -> str:
+    if provider == 'openrouter' and model.startswith('gemini'):
+        return f'google/{model}'
+    return model

--- a/backend/llm_gateway/gateway/config_loader.py
+++ b/backend/llm_gateway/gateway/config_loader.py
@@ -188,6 +188,7 @@ def _generated_feature_route_items() -> tuple[list[dict[str, Any]], list[dict[st
             }
         )
         primary = {'provider': provider, 'model': _provider_model_name(provider, model)}
+        provider_options = get_route_options(feature, model, provider)
         artifacts.append(
             {
                 'route_artifact_id': route_id,
@@ -195,6 +196,7 @@ def _generated_feature_route_items() -> tuple[list[dict[str, Any]], list[dict[st
                 'surface': 'openai.chat_completions',
                 'primary': primary,
                 'fallbacks': [],
+                'provider_options': provider_options,
                 'timeouts': {'request_ms': 120000 if capabilities['streaming'] else 30000},
                 'retry': {'max_attempts': 1},
                 'capabilities': capabilities,
@@ -235,11 +237,12 @@ def _generated_feature_route_items() -> tuple[list[dict[str, Any]], list[dict[st
 
 def _capabilities_for_feature(feature: str) -> dict[str, Any]:
     structured_output = 'json_schema' if is_structured_output_feature(feature) else 'none'
+    provider = get_provider(feature)
     return {
         'text_input': True,
-        'streaming': True,
+        'streaming': provider in {'openai', 'openrouter', 'perplexity', 'gemini'},
         'structured_output': structured_output,
-        'tools': feature in {'chat_agent', 'memory_l2'},
+        'tools': feature == 'memory_l2',
     }
 
 

--- a/backend/llm_gateway/gateway/executor.py
+++ b/backend/llm_gateway/gateway/executor.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import json
+import logging
 import os
 from collections.abc import Mapping
 from dataclasses import dataclass
@@ -26,6 +28,8 @@ from llm_gateway.gateway.schemas import CredentialMode, FailureClass, ProviderRe
 from llm_gateway.gateway.validator import ValidatedChatCompletionRequest
 from utils.log_sanitizer import sanitize
 
+logger = logging.getLogger(__name__)
+
 
 @dataclass(frozen=True)
 class ExecutorResult:
@@ -47,10 +51,23 @@ class ProviderRegistry:
         return self._providers.get(provider.strip().lower())
 
     async def aclose(self) -> None:
-        for provider in self._providers.values():
-            close = getattr(provider, 'aclose', None)
-            if close is not None:
-                await close()
+        cleanup_tasks = [
+            _close_provider(provider_name, provider)
+            for provider_name, provider in self._providers.items()
+            if getattr(provider, 'aclose', None) is not None
+        ]
+        if cleanup_tasks:
+            await asyncio.gather(*cleanup_tasks)
+
+
+async def _close_provider(provider_name: str, provider: ChatCompletionProvider) -> None:
+    close = getattr(provider, 'aclose', None)
+    if close is None:
+        return
+    try:
+        await close()
+    except Exception:
+        logger.exception('LLM gateway provider cleanup failed: %s', provider_name)
 
 
 async def execute_chat_completion(

--- a/backend/llm_gateway/gateway/executor.py
+++ b/backend/llm_gateway/gateway/executor.py
@@ -247,7 +247,7 @@ async def _attempt_provider(
     for _attempt in range(max_attempts):
         try:
             response = await provider.create_chat_completion(
-                _provider_request(resolved_route, provider_ref),
+                _provider_request(resolved_route, provider_ref, route=route),
                 provider_ref=provider_ref,
                 credentials=credential_context,
                 timeout_ms=route.timeouts.request_ms,
@@ -260,8 +260,13 @@ async def _attempt_provider(
     return None, error
 
 
-def _provider_request(resolved_route: ResolvedRoute, provider_ref: ProviderRef) -> dict[str, Any]:
-    route = selected_serving_route(resolved_route)
+def _provider_request(
+    resolved_route: ResolvedRoute,
+    provider_ref: ProviderRef,
+    *,
+    route: RouteArtifact | None = None,
+) -> dict[str, Any]:
+    route = route or selected_serving_route(resolved_route)
     provider_request = {
         'model': provider_ref.model,
         'messages': list(resolved_route.validated_request.messages),

--- a/backend/llm_gateway/gateway/executor.py
+++ b/backend/llm_gateway/gateway/executor.py
@@ -127,6 +127,14 @@ def selected_serving_route_artifact_id(resolved_route: ResolvedRoute) -> str:
     return _select_serving_route(resolved_route).route_artifact_id
 
 
+def selected_serving_route(resolved_route: ResolvedRoute) -> RouteArtifact:
+    return _select_serving_route(resolved_route)
+
+
+def provider_request_for(resolved_route: ResolvedRoute, provider_ref: ProviderRef) -> dict[str, Any]:
+    return _provider_request(resolved_route, provider_ref)
+
+
 def _is_route_eligible_to_serve(route: RouteArtifact, validated_request: ValidatedChatCompletionRequest) -> bool:
     """Whether a route should receive live traffic based on rollout stage and percent."""
     if route.rollout.stage in (RolloutStage.SHADOW, RolloutStage.DISABLED):

--- a/backend/llm_gateway/gateway/executor.py
+++ b/backend/llm_gateway/gateway/executor.py
@@ -261,15 +261,26 @@ async def _attempt_provider(
 
 
 def _provider_request(resolved_route: ResolvedRoute, provider_ref: ProviderRef) -> dict[str, Any]:
+    route = selected_serving_route(resolved_route)
     provider_request = {
         'model': provider_ref.model,
         'messages': list(resolved_route.validated_request.messages),
         'stream': False,
     }
+    _apply_provider_options(provider_request, route.provider_options)
     if resolved_route.validated_request.response_format is not None:
         provider_request['response_format'] = dict(resolved_route.validated_request.response_format)
     provider_request.update(dict(resolved_route.validated_request.forwarded_params))
     return provider_request
+
+
+def _apply_provider_options(provider_request: dict[str, Any], provider_options: Mapping[str, Any]) -> None:
+    extra_body = provider_options.get('extra_body')
+    if isinstance(extra_body, Mapping):
+        provider_request.update(dict(extra_body))
+    for key, value in provider_options.items():
+        if key != 'extra_body':
+            provider_request[key] = value
 
 
 def _executor_result(

--- a/backend/llm_gateway/gateway/executor.py
+++ b/backend/llm_gateway/gateway/executor.py
@@ -301,8 +301,35 @@ def _apply_provider_options(provider_request: dict[str, Any], provider_options: 
     if isinstance(extra_body, Mapping):
         provider_request.update(dict(extra_body))
     for key, value in provider_options.items():
-        if key != 'extra_body':
-            provider_request[key] = value
+        if key == 'extra_body':
+            continue
+        if key == 'thinking_budget':
+            _apply_gemini_thinking_budget(provider_request, value)
+            continue
+        provider_request[key] = value
+
+
+def _apply_gemini_thinking_budget(provider_request: dict[str, Any], thinking_budget: Any) -> None:
+    if thinking_budget == 0:
+        provider_request['reasoning_effort'] = 'none'
+        return
+
+    extra_body = provider_request.get('extra_body')
+    if not isinstance(extra_body, dict):
+        extra_body = {}
+        provider_request['extra_body'] = extra_body
+
+    google_options = extra_body.get('google')
+    if not isinstance(google_options, dict):
+        google_options = {}
+        extra_body['google'] = google_options
+
+    thinking_config = google_options.get('thinking_config')
+    if not isinstance(thinking_config, dict):
+        thinking_config = {}
+        google_options['thinking_config'] = thinking_config
+
+    thinking_config['thinking_budget'] = thinking_budget
 
 
 def _executor_result(

--- a/backend/llm_gateway/gateway/executor.py
+++ b/backend/llm_gateway/gateway/executor.py
@@ -256,9 +256,10 @@ def _provider_request(resolved_route: ResolvedRoute, provider_ref: ProviderRef) 
     provider_request = {
         'model': provider_ref.model,
         'messages': list(resolved_route.validated_request.messages),
-        'response_format': dict(resolved_route.validated_request.response_format),
         'stream': False,
     }
+    if resolved_route.validated_request.response_format is not None:
+        provider_request['response_format'] = dict(resolved_route.validated_request.response_format)
     provider_request.update(dict(resolved_route.validated_request.forwarded_params))
     return provider_request
 

--- a/backend/llm_gateway/gateway/providers.py
+++ b/backend/llm_gateway/gateway/providers.py
@@ -49,10 +49,12 @@ class OpenAICompatibleChatCompletionProvider:
         *,
         api_key_env: str = OPENAI_API_KEY_ENV_VAR,
         base_url: str | None = None,
+        default_headers: Mapping[str, str] | None = None,
         http_client: httpx.AsyncClient | None = None,
     ) -> None:
         self._api_key_env = api_key_env
         self._base_url = (base_url or os.getenv(OPENAI_BASE_URL_ENV_VAR, DEFAULT_OPENAI_BASE_URL)).rstrip('/')
+        self._default_headers = dict(default_headers or {})
         self._http_client = http_client or httpx.AsyncClient()
         self._owns_http_client = http_client is None
 
@@ -79,6 +81,7 @@ class OpenAICompatibleChatCompletionProvider:
                 headers={
                     'Authorization': f'Bearer {api_key}',
                     'Content-Type': 'application/json',
+                    **self._default_headers,
                 },
                 timeout=timeout_ms / 1000.0,
             ) as response:
@@ -101,9 +104,174 @@ class OpenAICompatibleChatCompletionProvider:
         _validate_chat_completion_response_shape(parsed)
         return parsed
 
+    async def stream_chat_completion(
+        self,
+        request: Mapping[str, Any],
+        *,
+        provider_ref: ProviderRef,
+        credentials: CredentialContext,
+        timeout_ms: int,
+    ):
+        if credentials.mode == CredentialMode.BYOK:
+            raise ProviderFailure(FailureClass.BYOK_UNSUPPORTED_PROVIDER)
+
+        api_key = os.getenv(self._api_key_env, '').strip()
+        if not api_key:
+            raise ProviderFailure(FailureClass.INVALID_CONFIG)
+
+        try:
+            async with self._http_client.stream(
+                'POST',
+                f'{self._base_url}/chat/completions',
+                json=dict(request),
+                headers={
+                    'Authorization': f'Bearer {api_key}',
+                    'Content-Type': 'application/json',
+                    **self._default_headers,
+                },
+                timeout=timeout_ms / 1000.0,
+            ) as response:
+                if response.status_code >= 400:
+                    error_preview = await _read_bounded_preview(response, max_bytes=PROVIDER_ERROR_DETAIL_BYTES)
+                    _raise_for_status(response.status_code, error_preview)
+                async for chunk in response.aiter_bytes():
+                    if chunk:
+                        yield chunk
+        except httpx.TimeoutException as exc:
+            raise ProviderFailure(FailureClass.TIMEOUT_BEFORE_OUTPUT) from exc
+        except httpx.HTTPError as exc:
+            raise ProviderFailure(FailureClass.PROVIDER_5XX_OMI_PAID) from exc
+
     async def aclose(self) -> None:
         if self._owns_http_client:
             await self._http_client.aclose()
+
+
+class AnthropicMessagesProvider:
+    """Minimal Anthropic Messages adapter behind the gateway route boundary."""
+
+    def __init__(
+        self,
+        *,
+        api_key_env: str = 'ANTHROPIC_API_KEY',
+        base_url: str = 'https://api.anthropic.com/v1',
+        http_client: httpx.AsyncClient | None = None,
+    ) -> None:
+        self._api_key_env = api_key_env
+        self._base_url = base_url.rstrip('/')
+        self._http_client = http_client or httpx.AsyncClient()
+        self._owns_http_client = http_client is None
+
+    async def create_chat_completion(
+        self,
+        request: Mapping[str, Any],
+        *,
+        provider_ref: ProviderRef,
+        credentials: CredentialContext,
+        timeout_ms: int,
+    ) -> Mapping[str, Any]:
+        if credentials.mode == CredentialMode.BYOK:
+            raise ProviderFailure(FailureClass.BYOK_UNSUPPORTED_PROVIDER)
+
+        api_key = os.getenv(self._api_key_env, '').strip()
+        if not api_key:
+            raise ProviderFailure(FailureClass.INVALID_CONFIG)
+
+        anthropic_request = _anthropic_request(request, provider_ref)
+        try:
+            response = await self._http_client.post(
+                f'{self._base_url}/messages',
+                json=anthropic_request,
+                headers={
+                    'x-api-key': api_key,
+                    'anthropic-version': '2023-06-01',
+                    'anthropic-beta': 'token-efficient-tools-2025-02-19',
+                    'Content-Type': 'application/json',
+                },
+                timeout=timeout_ms / 1000.0,
+            )
+            if response.status_code >= 400:
+                _raise_for_status(response.status_code, response.content[:PROVIDER_ERROR_DETAIL_BYTES])
+            parsed = response.json()
+        except httpx.TimeoutException as exc:
+            raise ProviderFailure(FailureClass.TIMEOUT_BEFORE_OUTPUT) from exc
+        except httpx.HTTPError as exc:
+            raise ProviderFailure(FailureClass.PROVIDER_5XX_OMI_PAID) from exc
+        except ValueError as exc:
+            raise ProviderFailure(FailureClass.PROVIDER_5XX_OMI_PAID) from exc
+
+        return _anthropic_to_openai_response(parsed, requested_model=str(request.get('model') or provider_ref.model))
+
+    async def aclose(self) -> None:
+        if self._owns_http_client:
+            await self._http_client.aclose()
+
+
+def _anthropic_request(request: Mapping[str, Any], provider_ref: ProviderRef) -> dict[str, Any]:
+    system_blocks: list[Any] = []
+    messages: list[Mapping[str, Any]] = []
+    for message in request.get('messages') or []:
+        if not isinstance(message, Mapping):
+            continue
+        if message.get('role') == 'system':
+            system_blocks.append(message.get('content') or '')
+        else:
+            messages.append(message)
+
+    payload: dict[str, Any] = {
+        'model': provider_ref.model,
+        'messages': messages,
+        'max_tokens': int(request.get('max_tokens') or request.get('max_completion_tokens') or 4096),
+    }
+    if system_blocks:
+        payload['system'] = '\n\n'.join(str(block) for block in system_blocks if block is not None)
+    if 'temperature' in request:
+        payload['temperature'] = request['temperature']
+    if 'tools' in request:
+        payload['tools'] = request['tools']
+    if 'tool_choice' in request and request.get('tool_choice') not in (None, 'none'):
+        payload['tool_choice'] = request['tool_choice']
+    return payload
+
+
+def _anthropic_to_openai_response(response: Mapping[str, Any], *, requested_model: str) -> dict[str, Any]:
+    content_blocks = response.get('content')
+    text_parts: list[str] = []
+    tool_calls: list[dict[str, Any]] = []
+    if isinstance(content_blocks, list):
+        for block in content_blocks:
+            if not isinstance(block, Mapping):
+                continue
+            if block.get('type') == 'text' and isinstance(block.get('text'), str):
+                text_parts.append(block['text'])
+            elif block.get('type') == 'tool_use':
+                tool_calls.append(
+                    {
+                        'id': block.get('id') or '',
+                        'type': 'function',
+                        'function': {
+                            'name': block.get('name') or '',
+                            'arguments': json.dumps(block.get('input') or {}, separators=(',', ':')),
+                        },
+                    }
+                )
+
+    message: dict[str, Any] = {'role': 'assistant', 'content': ''.join(text_parts)}
+    if tool_calls:
+        message['tool_calls'] = tool_calls
+    return {
+        'id': str(response.get('id') or 'anthropic_gateway'),
+        'object': 'chat.completion',
+        'created': 1782522000,
+        'model': requested_model,
+        'choices': [
+            {
+                'index': 0,
+                'message': message,
+                'finish_reason': 'tool_calls' if tool_calls else response.get('stop_reason') or 'stop',
+            }
+        ],
+    }
 
 
 class FakeChatCompletionProvider:

--- a/backend/llm_gateway/gateway/providers.py
+++ b/backend/llm_gateway/gateway/providers.py
@@ -214,7 +214,9 @@ def _anthropic_request(request: Mapping[str, Any], provider_ref: ProviderRef) ->
         if not isinstance(message, Mapping):
             continue
         if message.get('role') == 'system':
-            system_blocks.append(message.get('content') or '')
+            system_text = _text_content(message.get('content'))
+            if system_text:
+                system_blocks.append(system_text)
         else:
             messages.append(message)
 
@@ -268,10 +270,32 @@ def _anthropic_to_openai_response(response: Mapping[str, Any], *, requested_mode
             {
                 'index': 0,
                 'message': message,
-                'finish_reason': 'tool_calls' if tool_calls else response.get('stop_reason') or 'stop',
+                'finish_reason': 'tool_calls' if tool_calls else _openai_finish_reason(response.get('stop_reason')),
             }
         ],
     }
+
+
+def _text_content(content: Any) -> str:
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for part in content:
+            if isinstance(part, Mapping) and part.get('type') == 'text' and isinstance(part.get('text'), str):
+                parts.append(part['text'])
+        return '\n'.join(parts)
+    return ''
+
+
+def _openai_finish_reason(stop_reason: Any) -> str:
+    if stop_reason in {'end_turn', 'stop_sequence'}:
+        return 'stop'
+    if stop_reason == 'max_tokens':
+        return 'length'
+    if stop_reason == 'tool_use':
+        return 'tool_calls'
+    return 'stop'
 
 
 class FakeChatCompletionProvider:

--- a/backend/llm_gateway/gateway/resolver.py
+++ b/backend/llm_gateway/gateway/resolver.py
@@ -15,7 +15,6 @@ from llm_gateway.gateway.errors import (
 from llm_gateway.gateway.schemas import FailureClass, LaneConfig, RouteArtifact, Surface
 from llm_gateway.gateway.validator import ValidatedChatCompletionRequest, validate_chat_completion_request
 
-SUPPORTED_AUTO_LANE_IDS = frozenset({'omi:auto:chat-structured'})
 AUTO_LANE_PREFIX = 'omi:auto:'
 NEVER_LKG_FAILURE_CLASSES = frozenset(
     {
@@ -72,12 +71,9 @@ def resolve_lane(config: GatewayConfig, model: str) -> LaneConfig:
             f'provider model names are not direct routes in gateway v1: {model}',
         )
 
-    if model not in SUPPORTED_AUTO_LANE_IDS:
-        raise GatewayModelNotFoundError(f'auto lane not found: {model}')
-
     lane = config.lanes.get(model)
     if lane is None:
-        raise GatewayModelNotFoundError(f'auto lane not configured: {model}')
+        raise GatewayModelNotFoundError(f'auto lane not found: {model}')
     if lane.surface != Surface.OPENAI_CHAT_COMPLETIONS:
         raise GatewayCapabilityMismatchError(f'unsupported lane surface: {lane.surface.value}', param='model')
     return lane

--- a/backend/llm_gateway/gateway/schemas.py
+++ b/backend/llm_gateway/gateway/schemas.py
@@ -161,6 +161,7 @@ class RouteArtifact(StrictBaseModel):
     surface: Surface
     primary: ProviderRef
     fallbacks: list[ProviderRef] = Field(default_factory=list)
+    provider_options: dict[str, Any] = Field(default_factory=dict)
     timeouts: TimeoutPolicy
     retry: RetryPolicy
     capabilities: Capabilities
@@ -194,7 +195,12 @@ class FeatureBundle(StrictBaseModel):
 
 def compute_route_artifact_digest(artifact: RouteArtifact | dict[str, Any]) -> str:
     if isinstance(artifact, RouteArtifact):
-        payload = artifact.model_dump(mode='json', exclude={'artifact_digest', 'content_digest'}, exclude_none=True)
+        payload = artifact.model_dump(
+            mode='json',
+            exclude={'artifact_digest', 'content_digest'},
+            exclude_none=True,
+            exclude_defaults=True,
+        )
     else:
         payload = dict(artifact)
         payload.pop('artifact_digest', None)

--- a/backend/llm_gateway/gateway/validator.py
+++ b/backend/llm_gateway/gateway/validator.py
@@ -48,11 +48,11 @@ def validate_chat_completion_request(
     if not isinstance(model, str) or not model.strip():
         raise GatewayInvalidRequestError('model is required', param='model')
 
-    if request.get('stream') is True:
+    if request.get('stream') is True and not lane.capabilities.streaming:
         raise GatewayCapabilityMismatchError('streaming is not supported for this lane', param='stream')
-    if 'tools' in request:
+    if 'tools' in request and not lane.capabilities.tools:
         raise GatewayCapabilityMismatchError('tools are not supported for this lane', param='tools')
-    if 'tool_choice' in request and request.get('tool_choice') not in (None, 'none'):
+    if 'tool_choice' in request and request.get('tool_choice') not in (None, 'none') and not lane.capabilities.tools:
         raise GatewayCapabilityMismatchError('tool_choice is not supported for this lane', param='tool_choice')
 
     messages = _validate_messages(request.get('messages'))
@@ -146,4 +146,8 @@ def _validate_forwarded_params(request: Mapping[str, Any]) -> Mapping[str, Any]:
             f'unsupported chat completion parameter: {unsupported[0]}',
             param=unsupported[0],
         )
-    return {key: request[key] for key in FORWARDED_CHAT_COMPLETION_PARAMS if key in request}
+    forwarded = {key: request[key] for key in FORWARDED_CHAT_COMPLETION_PARAMS if key in request}
+    for key in ('tools', 'tool_choice', 'stream'):
+        if key in request:
+            forwarded[key] = request[key]
+    return forwarded

--- a/backend/llm_gateway/gateway/validator.py
+++ b/backend/llm_gateway/gateway/validator.py
@@ -11,7 +11,7 @@ from llm_gateway.gateway.schemas import LaneConfig, StructuredOutputMode
 class ValidatedChatCompletionRequest:
     model: str
     messages: tuple[Mapping[str, Any], ...]
-    response_format: Mapping[str, Any]
+    response_format: Mapping[str, Any] | None
     forwarded_params: Mapping[str, Any]
 
 
@@ -26,6 +26,7 @@ FORWARDED_CHAT_COMPLETION_PARAMS = frozenset(
         'max_tokens',
         'n',
         'presence_penalty',
+        'prompt_cache_key',
         'seed',
         'stop',
         'temperature',
@@ -99,7 +100,10 @@ def _is_text_content_part(part: Any) -> bool:
     return isinstance(part, Mapping) and part.get('type') == 'text' and isinstance(part.get('text'), str)
 
 
-def _validate_response_format(value: Any, lane: LaneConfig) -> Mapping[str, Any]:
+def _validate_response_format(value: Any, lane: LaneConfig) -> Mapping[str, Any] | None:
+    if value is None:
+        return None
+
     if not isinstance(value, Mapping):
         raise GatewayInvalidRequestError('response_format with json_schema is required', param='response_format')
 

--- a/backend/llm_gateway/main.py
+++ b/backend/llm_gateway/main.py
@@ -1,4 +1,4 @@
-from contextlib import asynccontextmanager
+from contextlib import asynccontextmanager, suppress
 
 from fastapi import FastAPI
 
@@ -11,8 +11,10 @@ async def lifespan(app: FastAPI):
     try:
         yield
     finally:
-        await openai_compatible.close_image_generation_client()
-        await close_provider_registry()
+        with suppress(Exception):
+            await openai_compatible.close_image_generation_client()
+        with suppress(Exception):
+            await close_provider_registry()
 
 
 app = FastAPI(title='Omi LLM Gateway', lifespan=lifespan)

--- a/backend/llm_gateway/main.py
+++ b/backend/llm_gateway/main.py
@@ -1,9 +1,14 @@
-from contextlib import asynccontextmanager, suppress
+import asyncio
+import logging
+from collections.abc import Awaitable, Callable
+from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
 
 from llm_gateway.routers import health, metrics, openai_compatible
 from llm_gateway.routers.dependencies import close_provider_registry
+
+logger = logging.getLogger(__name__)
 
 
 @asynccontextmanager
@@ -11,10 +16,17 @@ async def lifespan(app: FastAPI):
     try:
         yield
     finally:
-        with suppress(Exception):
-            await openai_compatible.close_image_generation_client()
-        with suppress(Exception):
-            await close_provider_registry()
+        await asyncio.gather(
+            _run_shutdown_cleanup('image_generation_client', openai_compatible.close_image_generation_client),
+            _run_shutdown_cleanup('provider_registry', close_provider_registry),
+        )
+
+
+async def _run_shutdown_cleanup(name: str, cleanup: Callable[[], Awaitable[None]]) -> None:
+    try:
+        await cleanup()
+    except Exception:
+        logger.exception('LLM gateway shutdown cleanup failed: %s', name)
 
 
 app = FastAPI(title='Omi LLM Gateway', lifespan=lifespan)

--- a/backend/llm_gateway/main.py
+++ b/backend/llm_gateway/main.py
@@ -2,8 +2,8 @@ from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
 
-from llm_gateway.routers.dependencies import close_provider_registry
 from llm_gateway.routers import health, metrics, openai_compatible
+from llm_gateway.routers.dependencies import close_provider_registry
 
 
 @asynccontextmanager
@@ -11,6 +11,7 @@ async def lifespan(app: FastAPI):
     try:
         yield
     finally:
+        await openai_compatible.close_image_generation_client()
         await close_provider_registry()
 
 

--- a/backend/llm_gateway/routers/dependencies.py
+++ b/backend/llm_gateway/routers/dependencies.py
@@ -4,7 +4,7 @@ from functools import lru_cache
 
 from llm_gateway.gateway.config_loader import GatewayConfig, load_gateway_config
 from llm_gateway.gateway.executor import ProviderRegistry
-from llm_gateway.gateway.providers import OpenAICompatibleChatCompletionProvider
+from llm_gateway.gateway.providers import AnthropicMessagesProvider, OpenAICompatibleChatCompletionProvider
 
 
 @lru_cache(maxsize=1)
@@ -14,7 +14,25 @@ def get_gateway_config() -> GatewayConfig:
 
 @lru_cache(maxsize=1)
 def get_provider_registry() -> ProviderRegistry:
-    return ProviderRegistry({'openai': OpenAICompatibleChatCompletionProvider()})
+    return ProviderRegistry(
+        {
+            'openai': OpenAICompatibleChatCompletionProvider(),
+            'openrouter': OpenAICompatibleChatCompletionProvider(
+                api_key_env='OPENROUTER_API_KEY',
+                base_url='https://openrouter.ai/api/v1',
+                default_headers={'X-Title': 'Omi Chat'},
+            ),
+            'perplexity': OpenAICompatibleChatCompletionProvider(
+                api_key_env='PERPLEXITY_API_KEY',
+                base_url='https://api.perplexity.ai',
+            ),
+            'gemini': OpenAICompatibleChatCompletionProvider(
+                api_key_env='GEMINI_API_KEY',
+                base_url='https://generativelanguage.googleapis.com/v1beta/openai',
+            ),
+            'anthropic': AnthropicMessagesProvider(),
+        }
+    )
 
 
 async def close_provider_registry() -> None:

--- a/backend/llm_gateway/routers/openai_compatible.py
+++ b/backend/llm_gateway/routers/openai_compatible.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 from typing import Any
 
 from fastapi import APIRouter, Depends, Request
-from fastapi.responses import JSONResponse
+import httpx
+import os
+from fastapi.responses import JSONResponse, StreamingResponse
 
 from llm_gateway.gateway.auth import ServiceAuthDependency
 from llm_gateway.gateway.config_loader import GatewayConfig
@@ -13,7 +15,13 @@ from llm_gateway.gateway.errors import (
     GatewayErrorCode,
     GatewayInvalidRequestError,
 )
-from llm_gateway.gateway.executor import ProviderRegistry, execute_chat_completion, selected_serving_route_artifact_id
+from llm_gateway.gateway.executor import (
+    ProviderRegistry,
+    execute_chat_completion,
+    provider_request_for,
+    selected_serving_route,
+    selected_serving_route_artifact_id,
+)
 from llm_gateway.gateway.metrics import observe_error, observe_success, time_request
 from llm_gateway.gateway.resolver import resolve_chat_completion_route
 from llm_gateway.routers.dependencies import get_gateway_config, get_provider_registry
@@ -34,6 +42,8 @@ async def create_chat_completion(
         request_body = await _request_json(request)
         resolved_route = resolve_chat_completion_route(config, request_body)
         credentials = build_omi_managed_credential_context(caller)
+        if resolved_route.validated_request.forwarded_params.get('stream') is True:
+            return _streaming_response(resolved_route, credentials, provider_registry)
         result = await execute_chat_completion(resolved_route, credentials, provider_registry)
         _safe_observe(lambda: observe_success(started_at, result))
         return JSONResponse(content=result.response)
@@ -117,3 +127,47 @@ def _status_code_for_error(exc: GatewayError) -> int:
     if exc.code == GatewayErrorCode.PROVIDER_FAILURE:
         return 502
     return 500
+
+
+@router.post('/v1/images/generations')
+async def create_image_generation(request: Request, caller: ServiceAuthDependency):
+    request_body = await _request_json(request)
+    api_key = os.getenv('OPENAI_API_KEY', '').strip()
+    if not api_key:
+        return JSONResponse(
+            status_code=503,
+            content={'error': {'message': 'provider request failed: invalid_config', 'type': 'api_error'}},
+        )
+    try:
+        async with httpx.AsyncClient(timeout=120.0) as client:
+            response = await client.post(
+                'https://api.openai.com/v1/images/generations',
+                headers={'Authorization': f'Bearer {api_key}', 'Content-Type': 'application/json'},
+                json=request_body,
+            )
+        return JSONResponse(status_code=response.status_code, content=response.json())
+    except (httpx.HTTPError, ValueError):
+        return JSONResponse(
+            status_code=502,
+            content={'error': {'message': 'provider request failed', 'type': 'api_error'}},
+        )
+
+
+def _streaming_response(resolved_route, credentials, provider_registry: ProviderRegistry) -> StreamingResponse:
+    route = selected_serving_route(resolved_route)
+    provider_ref = route.primary
+    provider = provider_registry.provider_for(provider_ref.provider)
+    stream_chat_completion = getattr(provider, 'stream_chat_completion', None)
+    if stream_chat_completion is None:
+        raise GatewayInvalidRequestError('streaming provider adapter is not configured', param='stream')
+
+    async def event_stream():
+        async for chunk in stream_chat_completion(
+            provider_request_for(resolved_route, provider_ref),
+            provider_ref=provider_ref,
+            credentials=credentials,
+            timeout_ms=route.timeouts.request_ms,
+        ):
+            yield chunk
+
+    return StreamingResponse(event_stream(), media_type='text/event-stream')

--- a/backend/llm_gateway/routers/openai_compatible.py
+++ b/backend/llm_gateway/routers/openai_compatible.py
@@ -161,6 +161,13 @@ def _get_image_generation_client() -> httpx.AsyncClient:
     return _image_generation_client
 
 
+async def close_image_generation_client() -> None:
+    global _image_generation_client
+    if _image_generation_client is not None:
+        await _image_generation_client.aclose()
+        _image_generation_client = None
+
+
 def _streaming_response(resolved_route, credentials, provider_registry: ProviderRegistry) -> StreamingResponse:
     route = selected_serving_route(resolved_route)
 

--- a/backend/llm_gateway/routers/openai_compatible.py
+++ b/backend/llm_gateway/routers/openai_compatible.py
@@ -23,10 +23,12 @@ from llm_gateway.gateway.executor import (
     selected_serving_route_artifact_id,
 )
 from llm_gateway.gateway.metrics import observe_error, observe_success, time_request
-from llm_gateway.gateway.resolver import resolve_chat_completion_route
+from llm_gateway.gateway.providers import ProviderFailure
+from llm_gateway.gateway.resolver import is_lkg_eligible, resolve_chat_completion_route
 from llm_gateway.routers.dependencies import get_gateway_config, get_provider_registry
 
 router = APIRouter()
+_image_generation_client: httpx.AsyncClient | None = None
 
 
 @router.post('/v1/chat/completions')
@@ -139,12 +141,11 @@ async def create_image_generation(request: Request, caller: ServiceAuthDependenc
             content={'error': {'message': 'provider request failed: invalid_config', 'type': 'api_error'}},
         )
     try:
-        async with httpx.AsyncClient(timeout=120.0) as client:
-            response = await client.post(
-                'https://api.openai.com/v1/images/generations',
-                headers={'Authorization': f'Bearer {api_key}', 'Content-Type': 'application/json'},
-                json=request_body,
-            )
+        response = await _get_image_generation_client().post(
+            'https://api.openai.com/v1/images/generations',
+            headers={'Authorization': f'Bearer {api_key}', 'Content-Type': 'application/json'},
+            json=request_body,
+        )
         return JSONResponse(status_code=response.status_code, content=response.json())
     except (httpx.HTTPError, ValueError):
         return JSONResponse(
@@ -153,21 +154,38 @@ async def create_image_generation(request: Request, caller: ServiceAuthDependenc
         )
 
 
+def _get_image_generation_client() -> httpx.AsyncClient:
+    global _image_generation_client
+    if _image_generation_client is None:
+        _image_generation_client = httpx.AsyncClient(timeout=120.0)
+    return _image_generation_client
+
+
 def _streaming_response(resolved_route, credentials, provider_registry: ProviderRegistry) -> StreamingResponse:
     route = selected_serving_route(resolved_route)
-    provider_ref = route.primary
-    provider = provider_registry.provider_for(provider_ref.provider)
-    stream_chat_completion = getattr(provider, 'stream_chat_completion', None)
-    if stream_chat_completion is None:
-        raise GatewayInvalidRequestError('streaming provider adapter is not configured', param='stream')
 
     async def event_stream():
-        async for chunk in stream_chat_completion(
-            provider_request_for(resolved_route, provider_ref),
-            provider_ref=provider_ref,
-            credentials=credentials,
-            timeout_ms=route.timeouts.request_ms,
-        ):
-            yield chunk
+        last_error: ProviderFailure | None = None
+        for provider_ref in [route.primary, *route.fallbacks]:
+            provider = provider_registry.provider_for(provider_ref.provider)
+            stream_chat_completion = getattr(provider, 'stream_chat_completion', None)
+            if stream_chat_completion is None:
+                continue
+            try:
+                async for chunk in stream_chat_completion(
+                    provider_request_for(resolved_route, provider_ref),
+                    provider_ref=provider_ref,
+                    credentials=credentials,
+                    timeout_ms=route.timeouts.request_ms,
+                ):
+                    yield chunk
+                return
+            except ProviderFailure as exc:
+                last_error = exc
+                if not is_lkg_eligible(route, exc.failure_class):
+                    raise
+        if last_error is not None:
+            raise last_error
+        raise GatewayInvalidRequestError('streaming provider adapter is not configured', param='stream')
 
     return StreamingResponse(event_stream(), media_type='text/event-stream')

--- a/backend/llm_gateway/routers/openai_compatible.py
+++ b/backend/llm_gateway/routers/openai_compatible.py
@@ -13,11 +13,13 @@ from llm_gateway.gateway.credentials import build_omi_managed_credential_context
 from llm_gateway.gateway.errors import (
     GatewayError,
     GatewayErrorCode,
+    GatewayInvalidRouteConfigError,
     GatewayInvalidRequestError,
 )
 from llm_gateway.gateway.executor import (
     ProviderRegistry,
     execute_chat_completion,
+    _map_provider_failure,
     provider_request_for,
     selected_serving_route,
     selected_serving_route_artifact_id,
@@ -45,7 +47,7 @@ async def create_chat_completion(
         resolved_route = resolve_chat_completion_route(config, request_body)
         credentials = build_omi_managed_credential_context(caller)
         if resolved_route.validated_request.forwarded_params.get('stream') is True:
-            return _streaming_response(resolved_route, credentials, provider_registry)
+            return await _streaming_response(resolved_route, credentials, provider_registry)
         result = await execute_chat_completion(resolved_route, credentials, provider_registry)
         _safe_observe(lambda: observe_success(started_at, result))
         return JSONResponse(content=result.response)
@@ -168,31 +170,50 @@ async def close_image_generation_client() -> None:
         _image_generation_client = None
 
 
-def _streaming_response(resolved_route, credentials, provider_registry: ProviderRegistry) -> StreamingResponse:
+async def _streaming_response(resolved_route, credentials, provider_registry: ProviderRegistry) -> StreamingResponse:
     route = selected_serving_route(resolved_route)
 
-    async def event_stream():
-        last_error: ProviderFailure | None = None
-        for provider_ref in [route.primary, *route.fallbacks]:
-            provider = provider_registry.provider_for(provider_ref.provider)
-            stream_chat_completion = getattr(provider, 'stream_chat_completion', None)
-            if stream_chat_completion is None:
-                continue
-            try:
-                async for chunk in stream_chat_completion(
-                    provider_request_for(resolved_route, provider_ref),
-                    provider_ref=provider_ref,
-                    credentials=credentials,
-                    timeout_ms=route.timeouts.request_ms,
-                ):
-                    yield chunk
-                return
-            except ProviderFailure as exc:
-                last_error = exc
-                if not is_lkg_eligible(route, exc.failure_class):
-                    raise
-        if last_error is not None:
-            raise last_error
-        raise GatewayInvalidRequestError('streaming provider adapter is not configured', param='stream')
+    async_iterator = await _prepared_streaming_iterator(resolved_route, credentials, provider_registry, route)
 
-    return StreamingResponse(event_stream(), media_type='text/event-stream')
+    return StreamingResponse(async_iterator, media_type='text/event-stream')
+
+
+async def _prepared_streaming_iterator(resolved_route, credentials, provider_registry: ProviderRegistry, route):
+    last_error: GatewayError | None = None
+    for provider_ref in [route.primary, *route.fallbacks]:
+        provider = provider_registry.provider_for(provider_ref.provider)
+        if provider is None:
+            raise GatewayInvalidRouteConfigError(f'provider is not supported for this route: {provider_ref.provider}')
+        stream_chat_completion = getattr(provider, 'stream_chat_completion', None)
+        if stream_chat_completion is None:
+            continue
+        stream = stream_chat_completion(
+            provider_request_for(resolved_route, provider_ref),
+            provider_ref=provider_ref,
+            credentials=credentials,
+            timeout_ms=route.timeouts.request_ms,
+        )
+        try:
+            first_chunk = await anext(stream)
+        except StopAsyncIteration:
+            return _empty_stream()
+        except ProviderFailure as exc:
+            last_error = _map_provider_failure(exc, credentials)
+            if not is_lkg_eligible(route, exc.failure_class):
+                raise last_error
+            continue
+        return _stream_with_first_chunk(first_chunk, stream)
+    if last_error is not None:
+        raise last_error
+    raise GatewayInvalidRequestError('streaming provider adapter is not configured', param='stream')
+
+
+async def _stream_with_first_chunk(first_chunk: bytes, stream):
+    yield first_chunk
+    async for chunk in stream:
+        yield chunk
+
+
+async def _empty_stream():
+    if False:
+        yield b''

--- a/backend/routers/omni_relay.py
+++ b/backend/routers/omni_relay.py
@@ -14,6 +14,7 @@ from utils.byok import (
     validate_byok_websocket,
 )
 from utils.executors import critical_executor, run_blocking
+from utils.llm.gateway_client import raise_if_gateway_feature_mode_blocks_direct_model_surface
 from utils.other.endpoints import _verify_ws_auth
 from utils.subscription import is_trial_paywalled
 
@@ -64,6 +65,12 @@ def _upstream(provider: str, model: str | None):
 
 @router.websocket("/v1/omni/relay")
 async def omni_relay(websocket: WebSocket):
+    try:
+        raise_if_gateway_feature_mode_blocks_direct_model_surface('omni_realtime.provider_websocket')
+    except RuntimeError as exc:
+        await websocket.close(code=1013, reason=str(exc)[:120])
+        return
+
     # Manual auth (read the header directly so we control logging and avoid any
     # WS header-DI surprises). Token first, then BYOK validate, then the gate.
     authz = websocket.headers.get("authorization")

--- a/backend/scripts/smoke-llm-gateway-openai-schemas.py
+++ b/backend/scripts/smoke-llm-gateway-openai-schemas.py
@@ -15,10 +15,12 @@ from llm_gateway.gateway.credentials import build_omi_managed_credential_context
 from llm_gateway.gateway.providers import OpenAICompatibleChatCompletionProvider
 from llm_gateway.gateway.schemas import ProviderRef
 from models.structured_extraction import ActionItemsExtraction, ConversationStructureExtraction
+from utils.llm.chat import RequiresContext
 from utils.llm.gateway_client import _chat_structured_payload
 
 PROVIDER_REF = ProviderRef(provider='openai', model='gpt-4.1-mini')
 SMOKE_FEATURES = (
+    ('chat_extraction.requires_context', RequiresContext),
     ('conversation_structure.extract.shadow', ConversationStructureExtraction),
     ('conversation_action_items.extract.shadow', ActionItemsExtraction),
 )

--- a/backend/scripts/smoke-llm-gateway.py
+++ b/backend/scripts/smoke-llm-gateway.py
@@ -117,13 +117,13 @@ def main() -> int:
                 'strict': True,
                 'schema': {
                     'type': 'object',
-                    'properties': {'requires_context': {'type': 'boolean'}},
-                    'required': ['requires_context'],
+                    'properties': {'value': {'type': 'boolean'}},
+                    'required': ['value'],
                     'additionalProperties': False,
                 },
             },
         },
-        'metadata': {'omi_feature': 'chat_extraction.requires_context.smoke'},
+        'metadata': {'omi_feature': 'chat_extraction.requires_context'},
     }
 
     with httpx.Client(timeout=20.0) as client:
@@ -147,8 +147,8 @@ def main() -> int:
     except ValueError:
         print('ERROR: response content was not JSON')
         return 1
-    if not isinstance(decoded.get('requires_context'), bool):
-        print('ERROR: response JSON did not contain boolean requires_context')
+    if not isinstance(decoded.get('value'), bool):
+        print('ERROR: response JSON did not contain boolean value')
         return 1
     print('LLM gateway smoke passed')
     return 0

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -211,6 +211,7 @@ pytest tests/unit/test_llm_gateway_client_config.py -v
 pytest tests/unit/test_llm_gateway_route_refs.py -v
 pytest tests/unit/test_llm_gateway_dependencies.py -v
 pytest tests/unit/test_llm_gateway_chat_extraction_pilot.py -v
+pytest tests/unit/test_llm_gateway_coverage_guardrails.py -v
 pytest tests/unit/test_backend_runtime_env_validator.py -v
 pytest tests/unit/test_google_credentials.py -v
 pytest tests/unit/test_llm_usage_tracker.py -v

--- a/backend/tests/unit/test_action_item_date_validation.py
+++ b/backend/tests/unit/test_action_item_date_validation.py
@@ -214,6 +214,7 @@ llm_clients_stub.parser = MagicMock()
 llm_clients_stub.llm_high = MagicMock()
 llm_clients_stub.llm_medium_experiment = MagicMock()
 llm_clients_stub.get_llm = MagicMock(return_value=MagicMock())
+llm_clients_stub.get_llm_gateway_chat_structured = MagicMock(return_value=MagicMock())
 
 # Stub utils.llm.conversation_folder (conversation_processing imports from it after a recent refactor)
 conv_folder_stub = _stub_module("utils.llm.conversation_folder")

--- a/backend/tests/unit/test_backend_runtime_env_validator.py
+++ b/backend/tests/unit/test_backend_runtime_env_validator.py
@@ -26,8 +26,11 @@ def write_yaml(path: Path, payload: dict) -> None:
 
 def with_memory_env(payload: str) -> str:
     memory_env = '''\
+        {"name": "OMI_ENV_STAGE", "value": "dev"},
         {"name": "OMI_LLM_GATEWAY_CONVERSATION_ACTION_ITEMS_SHADOW_ENABLED", "value": "true"},
         {"name": "OMI_LLM_GATEWAY_CONVERSATION_ACTION_ITEMS_SHADOW_SAMPLE_RATE", "value": "1.0"},
+        {"name": "OMI_LLM_GATEWAY_DEV_SHADOW_ALL_ENABLED", "value": "true"},
+        {"name": "OMI_LLM_GATEWAY_DEV_SHADOW_ALL_SAMPLE_RATE", "value": "1.0"},
         {"name": "MEMORY_MODE", "value": "write"},
         {"name": "MEMORY_ENABLED_USERS", "value": "vi7SA9ckQCe4ccobWNxlbdcNdC23"},
         {"name": "MEMORY_V3_GET_ENABLED", "value": "false"},
@@ -258,7 +261,10 @@ def test_cloud_run_workflow_validation_uses_custom_manifest_for_runtime_env_outp
                             'backend': {
                                 'env': {
                                     'GOOGLE_CLOUD_PROJECT': {'value': 'based-hardware'},
+                                    'OMI_ENV_STAGE': {'value': 'dev'},
                                     'OMI_LLM_GATEWAY_URL': {'value': 'http://custom-manifest-gateway'},
+                                    'OMI_LLM_GATEWAY_DEV_SHADOW_ALL_ENABLED': {'value': 'true'},
+                                    'OMI_LLM_GATEWAY_DEV_SHADOW_ALL_SAMPLE_RATE': {'value': '1.0'},
                                     'CUSTOM_MANIFEST_ONLY_MARKER': {'value': 'present'},
                                 },
                                 'secrets': {},

--- a/backend/tests/unit/test_conversation_structure_timezone.py
+++ b/backend/tests/unit/test_conversation_structure_timezone.py
@@ -89,6 +89,7 @@ _stub_package("utils")
 _stub_package("utils.llm")
 llm_clients_stub = _stub_module("utils.llm.clients")
 llm_clients_stub.get_llm = MagicMock(return_value=MagicMock())
+llm_clients_stub.get_llm_gateway_chat_structured = MagicMock(return_value=MagicMock())
 llm_clients_stub.parser = MagicMock()
 conversation_folder_stub = _stub_module("utils.llm.conversation_folder")
 conversation_folder_stub.FolderAssignment = MagicMock

--- a/backend/tests/unit/test_llm_gateway_chat_extraction_pilot.py
+++ b/backend/tests/unit/test_llm_gateway_chat_extraction_pilot.py
@@ -104,65 +104,20 @@ _UNEXPECTED_RESPONSE = FakeGatewayResponse({'choices': [{'message': {'content': 
 _UNEXPECTED_STRUCTURE_RESPONSE = FakeGatewayResponse({'choices': [{'message': {'content': '{"answer": "ok"}'}}]})
 
 
-def test_requires_context_gateway_success_returns_parsed_result(monkeypatch):
-    monkeypatch.setattr(
-        chat,
-        'get_llm',
-        lambda feature: pytest.fail('existing path should not be called after gateway success'),
-    )
-    monkeypatch.setattr(
-        chat,
-        'invoke_chat_structured_gateway',
-        lambda prompt, output_model, *, feature: output_model(value=True),
-    )
+def test_requires_context_uses_legacy_llm_provider(monkeypatch):
+    existing_calls = []
+    monkeypatch.setattr(chat, 'get_llm', lambda feature: FakeLLM(chat.RequiresContext(value=True), existing_calls))
 
     assert chat.requires_context('what did I discuss yesterday?') is True
-
-
-def test_requires_context_gateway_failure_falls_back(monkeypatch):
-    existing_calls = []
-    monkeypatch.setattr(chat, 'get_llm', lambda feature: FakeLLM(chat.RequiresContext(value=False), existing_calls))
-    monkeypatch.setattr(chat, 'invoke_chat_structured_gateway', lambda *args, **kwargs: None)
-
-    assert chat.requires_context('what did I discuss yesterday?') is False
     assert existing_calls == [chat.RequiresContext]
 
 
-def test_requires_context_byok_context_skips_gateway(monkeypatch):
+def test_requires_context_byok_context_uses_same_legacy_llm_provider(monkeypatch):
     byok.set_byok_keys({'openai': 'secret'})
     existing_calls = []
-    counter = FakeCounter()
-    monkeypatch.setattr(
-        chat, 'record_chat_extraction_gateway_result', gateway_client.record_chat_extraction_gateway_result
-    )
-    monkeypatch.setattr(gateway_observability, 'LLM_GATEWAY_CHAT_EXTRACTION_REQUESTS', counter)
     monkeypatch.setattr(chat, 'get_llm', lambda feature: FakeLLM(chat.RequiresContext(value=True), existing_calls))
-    monkeypatch.setattr(
-        chat,
-        'invoke_chat_structured_gateway',
-        lambda *args, **kwargs: pytest.fail('gateway should not be called for BYOK requests'),
-    )
 
     assert chat.requires_context('what did I discuss yesterday?') is True
-    assert existing_calls == [chat.RequiresContext]
-    assert counter.calls == [
-        (
-            {
-                'feature': 'chat_extraction.requires_context',
-                'outcome': 'skipped',
-                'reason': 'byok',
-            },
-            1,
-        )
-    ]
-
-
-def test_requires_context_invalid_gateway_content_falls_back(monkeypatch):
-    existing_calls = []
-    monkeypatch.setattr(chat, 'get_llm', lambda feature: FakeLLM(chat.RequiresContext(value=False), existing_calls))
-    _mock_gateway_client(monkeypatch, lambda *args, **kwargs: _UNEXPECTED_RESPONSE)
-
-    assert chat.requires_context('what did I discuss yesterday?') is False
     assert existing_calls == [chat.RequiresContext]
 
 
@@ -408,30 +363,38 @@ def test_chat_structured_gateway_failure_does_not_log_raw_prompt_or_response(mon
     assert 'raw provider body should not be logged' not in caplog.text
 
 
-def test_conversation_discard_gateway_success_returns_without_legacy_llm(monkeypatch):
-    captured = {}
+def test_conversation_discard_uses_legacy_llm_provider(monkeypatch):
+    class FakeParser:
+        def __init__(self, pydantic_object):
+            self.pydantic_object = pydantic_object
 
-    def fake_gateway(prompt, output_model, *, feature, timeout_seconds):
-        captured.update(
-            {'prompt': prompt, 'output_model': output_model, 'feature': feature, 'timeout_seconds': timeout_seconds}
-        )
-        return output_model(discard=True)
+        def get_format_instructions(self):
+            return 'return structured output'
 
-    monkeypatch.setattr(conversation_processing, 'invoke_chat_structured_gateway', fake_gateway)
+    class FakePrompt:
+        def __or__(self, other):
+            return FakeChain()
+
+    class FakeChain:
+        def __or__(self, other):
+            return self
+
+        def invoke(self, values):
+            assert 'hello there' in values['full_context']
+            return conversation_processing.DiscardConversation(discard=True)
+
+    legacy_features = []
+    monkeypatch.setattr(conversation_processing, 'PydanticOutputParser', FakeParser)
+    monkeypatch.setattr(conversation_processing.ChatPromptTemplate, 'from_messages', lambda messages: FakePrompt())
     monkeypatch.setattr(
-        conversation_processing,
-        'get_llm',
-        lambda feature, **kwargs: pytest.fail('legacy discard path should not be called after gateway success'),
+        conversation_processing, 'get_llm', lambda feature, **kwargs: legacy_features.append(feature) or object()
     )
 
     assert conversation_processing.should_discard_conversation('hello there', duration_seconds=15) is True
-    assert captured['output_model'] is conversation_processing.DiscardConversation
-    assert captured['feature'] == 'conversation_discard.should_discard'
-    assert captured['timeout_seconds'] == gateway_client.BACKGROUND_CHAT_EXTRACTION_TIMEOUT_SECONDS
-    assert 'hello there' in captured['prompt']
+    assert legacy_features == ['conv_discard']
 
 
-def test_conversation_discard_byok_skips_gateway_and_uses_legacy_llm(monkeypatch):
+def test_conversation_discard_byok_uses_same_legacy_llm_provider(monkeypatch):
     class FakeParser:
         def __init__(self, pydantic_object):
             self.pydantic_object = pydantic_object
@@ -452,64 +415,14 @@ def test_conversation_discard_byok_skips_gateway_and_uses_legacy_llm(monkeypatch
             return conversation_processing.DiscardConversation(discard=False)
 
     byok.set_byok_keys({'openai': 'secret'})
-    counter = FakeCounter()
-    monkeypatch.setattr(gateway_observability, 'LLM_GATEWAY_CHAT_EXTRACTION_REQUESTS', counter)
-    monkeypatch.setattr(
-        conversation_processing,
-        'invoke_chat_structured_gateway',
-        lambda *args, **kwargs: pytest.fail('gateway should not be called for BYOK requests'),
-    )
     monkeypatch.setattr(conversation_processing, 'PydanticOutputParser', FakeParser)
     monkeypatch.setattr(conversation_processing.ChatPromptTemplate, 'from_messages', lambda messages: FakePrompt())
-    monkeypatch.setattr(conversation_processing, 'get_llm', lambda feature, **kwargs: object())
-
-    assert conversation_processing.should_discard_conversation('hello there', duration_seconds=15) is False
-    assert counter.calls == [
-        (
-            {
-                'feature': 'conversation_discard.should_discard',
-                'outcome': 'skipped',
-                'reason': 'byok',
-            },
-            1,
-        )
-    ]
-
-
-def test_conversation_discard_gateway_failure_falls_back_to_legacy_llm(monkeypatch):
-    class FakeParser:
-        def __init__(self, pydantic_object):
-            self.pydantic_object = pydantic_object
-
-        def get_format_instructions(self):
-            return 'return structured output'
-
-    class FakePrompt:
-        def __or__(self, other):
-            return FakeChain()
-
-    class FakeChain:
-        def __or__(self, other):
-            return self
-
-        def invoke(self, values):
-            assert 'hello there' in values['full_context']
-            return conversation_processing.DiscardConversation(discard=False)
-
-    monkeypatch.setattr(conversation_processing, 'invoke_chat_structured_gateway', lambda *args, **kwargs: None)
-    monkeypatch.setattr(conversation_processing, 'PydanticOutputParser', FakeParser)
-    monkeypatch.setattr(
-        conversation_processing.ChatPromptTemplate,
-        'from_messages',
-        lambda messages: FakePrompt(),
-    )
     monkeypatch.setattr(conversation_processing, 'get_llm', lambda feature, **kwargs: object())
 
     assert conversation_processing.should_discard_conversation('hello there', duration_seconds=15) is False
 
 
 def test_action_items_gateway_shadow_keeps_legacy_result_and_records_comparison(monkeypatch, caplog):
-    captured = {}
     counter = FakeCounter()
     call_order = []
 
@@ -522,27 +435,27 @@ def test_action_items_gateway_shadow_keeps_legacy_result_and_records_comparison(
 
     class FakePrompt:
         def __or__(self, other):
-            return FakeChain()
+            return FakeChain(other)
 
     class FakeChain:
+        def __init__(self, llm):
+            self.llm = llm
+
         def __or__(self, other):
             return self
 
         def invoke(self, values):
             assert 'submit report by Friday' in values['conversation_context']
-            call_order.append('legacy')
+            call_order.append(self.llm)
+            if self.llm == 'gateway':
+                return conversation_processing.ActionItemsExtraction(
+                    action_items=[{'description': 'Submit the report', 'due_at': datetime(2026, 7, 3, 17, 0)}]
+                )
             return conversation_processing.ActionItemsExtraction(
                 action_items=[
                     {'description': 'Submit report', 'due_at': datetime(2026, 7, 3, 17, 0, tzinfo=timezone.utc)}
                 ]
             )
-
-    def fake_gateway(prompt, output_model, *, feature, timeout_seconds):
-        call_order.append('gateway')
-        captured.update(
-            {'prompt': prompt, 'output_model': output_model, 'feature': feature, 'timeout_seconds': timeout_seconds}
-        )
-        return output_model(action_items=[{'description': 'Submit the report', 'due_at': datetime(2026, 7, 3, 17, 0)}])
 
     class ImmediateFuture:
         def result(self):
@@ -559,8 +472,8 @@ def test_action_items_gateway_shadow_keeps_legacy_result_and_records_comparison(
     monkeypatch.setenv(conversation_processing.CONVERSATION_ACTION_ITEMS_SHADOW_SAMPLE_RATE_ENV, '1.0')
     monkeypatch.setattr(conversation_processing, 'PydanticOutputParser', FakeParser)
     monkeypatch.setattr(conversation_processing.ChatPromptTemplate, 'from_messages', lambda messages: FakePrompt())
-    monkeypatch.setattr(conversation_processing, 'get_llm', lambda feature, **kwargs: object())
-    monkeypatch.setattr(conversation_processing, 'invoke_chat_structured_gateway', fake_gateway)
+    monkeypatch.setattr(conversation_processing, 'get_llm', lambda feature, **kwargs: 'legacy')
+    monkeypatch.setattr(conversation_processing, 'get_llm_gateway_chat_structured', lambda **kwargs: 'gateway')
     monkeypatch.setattr(conversation_processing, '_submit_llm_background', immediate_submit)
     monkeypatch.setattr(gateway_observability, 'LLM_GATEWAY_CHAT_EXTRACTION_COMPARISONS', counter)
 
@@ -574,14 +487,6 @@ def test_action_items_gateway_shadow_keeps_legacy_result_and_records_comparison(
 
     assert [item.description for item in result] == ['Submit report']
     assert call_order == ['legacy', 'gateway']
-    assert captured['output_model'] is conversation_processing.ActionItemsExtraction
-    assert captured['feature'] == conversation_processing.CONVERSATION_ACTION_ITEMS_SHADOW_FEATURE
-    assert captured['timeout_seconds'] == gateway_client.BACKGROUND_CHAT_EXTRACTION_TIMEOUT_SECONDS
-    assert 'submit report by Friday' in captured['prompt']
-    assert '{started_at_local}' not in captured['prompt']
-    assert '{current_time_local}' not in captured['prompt']
-    assert '{format_instructions}' not in captured['prompt']
-    assert 'return structured output' in captured['prompt']
     comparison_labels = [labels for labels, _amount in counter.calls]
     assert {
         'feature': 'conversation_action_items.extract.shadow',
@@ -642,7 +547,7 @@ def test_action_items_gateway_shadow_disabled_skips_submit(monkeypatch):
     monkeypatch.setattr(conversation_processing, 'PydanticOutputParser', FakeParser)
     monkeypatch.setattr(conversation_processing.ChatPromptTemplate, 'from_messages', lambda messages: FakePrompt())
     monkeypatch.setattr(conversation_processing, 'get_llm', lambda feature, **kwargs: object())
-    monkeypatch.setattr(conversation_processing, 'invoke_chat_structured_gateway', fake_gateway)
+    monkeypatch.setattr(conversation_processing, 'get_llm_gateway_chat_structured', fake_gateway)
     monkeypatch.setattr(conversation_processing, '_submit_llm_background', fake_submit)
     monkeypatch.setattr(gateway_observability, 'LLM_GATEWAY_CHAT_EXTRACTION_REQUESTS', counter)
 
@@ -666,7 +571,6 @@ def test_action_items_gateway_shadow_disabled_skips_submit(monkeypatch):
 
 
 def test_conversation_structure_gateway_shadow_keeps_legacy_result_and_records_comparison(monkeypatch, caplog):
-    captured = {}
     counter = FakeCounter()
     call_order = []
 
@@ -675,42 +579,33 @@ def test_conversation_structure_gateway_shadow_keeps_legacy_result_and_records_c
         def get_format_instructions():
             return 'return legacy structure'
 
-    class FakeParser:
-        def __init__(self, pydantic_object):
-            self.pydantic_object = pydantic_object
-
-        def get_format_instructions(self):
-            return 'return shadow structure'
-
     class FakePrompt:
         def __or__(self, other):
-            return FakeChain()
+            return FakeChain(other)
 
     class FakeChain:
+        def __init__(self, llm):
+            self.llm = llm
+
         def __or__(self, other):
             return self
 
         def invoke(self, values):
             assert values['format_instructions'] == 'return legacy structure'
-            call_order.append('legacy')
+            call_order.append(self.llm)
+            if self.llm == 'gateway':
+                return Structured(
+                    title='Weekly Plan',
+                    overview='Discussed launch tasks for the project.',
+                    emoji='📋',
+                    category=CategoryEnum.work,
+                )
             return Structured(
                 title='Weekly Planning',
                 overview='Discussed project launch tasks.',
                 emoji='📋',
                 category=CategoryEnum.work,
             )
-
-    def fake_gateway(prompt, output_model, *, feature, timeout_seconds):
-        call_order.append('gateway')
-        captured.update(
-            {'prompt': prompt, 'output_model': output_model, 'feature': feature, 'timeout_seconds': timeout_seconds}
-        )
-        return output_model(
-            title='Weekly Plan',
-            overview='Discussed launch tasks for the project.',
-            emoji='📋',
-            category=CategoryEnum.work,
-        )
 
     class ImmediateFuture:
         def result(self):
@@ -726,10 +621,9 @@ def test_conversation_structure_gateway_shadow_keeps_legacy_result_and_records_c
     monkeypatch.setenv(conversation_processing.CONVERSATION_STRUCTURE_SHADOW_ENABLED_ENV, 'true')
     monkeypatch.setenv(conversation_processing.CONVERSATION_STRUCTURE_SHADOW_SAMPLE_RATE_ENV, '1.0')
     monkeypatch.setattr(conversation_processing, 'parser', LegacyParser())
-    monkeypatch.setattr(conversation_processing, 'PydanticOutputParser', FakeParser)
     monkeypatch.setattr(conversation_processing.ChatPromptTemplate, 'from_messages', lambda messages: FakePrompt())
-    monkeypatch.setattr(conversation_processing, 'get_llm', lambda feature, **kwargs: object())
-    monkeypatch.setattr(conversation_processing, 'invoke_chat_structured_gateway', fake_gateway)
+    monkeypatch.setattr(conversation_processing, 'get_llm', lambda feature, **kwargs: 'legacy')
+    monkeypatch.setattr(conversation_processing, 'get_llm_gateway_chat_structured', lambda **kwargs: 'gateway')
     monkeypatch.setattr(conversation_processing, '_submit_llm_background', immediate_submit)
     monkeypatch.setattr(gateway_observability, 'LLM_GATEWAY_CHAT_EXTRACTION_COMPARISONS', counter)
 
@@ -745,10 +639,6 @@ def test_conversation_structure_gateway_shadow_keeps_legacy_result_and_records_c
     assert result.title == 'Weekly Planning'
     assert result.overview == 'Discussed project launch tasks.'
     assert call_order == ['legacy', 'gateway']
-    assert captured['output_model'] is ConversationStructureExtraction
-    assert captured['feature'] == 'conversation_structure.extract.shadow'
-    assert captured['timeout_seconds'] == gateway_client.BACKGROUND_CHAT_EXTRACTION_TIMEOUT_SECONDS
-    assert 'return shadow structure' in captured['prompt']
     comparison_labels = [labels for labels, _amount in counter.calls]
     assert {
         'feature': 'conversation_structure.extract.shadow',
@@ -800,7 +690,7 @@ def test_conversation_structure_shadow_disabled_skips_gateway(monkeypatch):
     monkeypatch.setattr(conversation_processing, 'parser', LegacyParser())
     monkeypatch.setattr(conversation_processing.ChatPromptTemplate, 'from_messages', lambda messages: FakePrompt())
     monkeypatch.setattr(conversation_processing, 'get_llm', lambda feature, **kwargs: object())
-    monkeypatch.setattr(conversation_processing, 'invoke_chat_structured_gateway', fake_gateway)
+    monkeypatch.setattr(conversation_processing, 'get_llm_gateway_chat_structured', fake_gateway)
     monkeypatch.setattr(conversation_processing, '_submit_llm_background', fake_submit)
     monkeypatch.setattr(gateway_observability, 'LLM_GATEWAY_CHAT_EXTRACTION_REQUESTS', counter)
 

--- a/backend/tests/unit/test_llm_gateway_client_config.py
+++ b/backend/tests/unit/test_llm_gateway_client_config.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import importlib.util
+from pathlib import Path
 from typing import Any
 
 from langchain_core.callbacks.manager import CallbackManagerForLLMRun
@@ -7,6 +9,7 @@ from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import AIMessage, BaseMessage
 from langchain_core.outputs import ChatGeneration, ChatResult
 from langchain_core.runnables import Runnable
+import pytest
 
 from utils.llm import clients, gateway_shadow
 from utils.llm import providers
@@ -252,3 +255,41 @@ def test_gateway_feature_mode_allows_acknowledged_direct_exception(monkeypatch):
     monkeypatch.delenv('K_SERVICE', raising=False)
 
     raise_if_gateway_feature_mode_blocks_direct_model_surface('file_chat.openai_files')
+
+
+@pytest.mark.asyncio
+async def test_app_icon_generation_uses_legacy_provider_when_gateway_feature_mode_off(monkeypatch):
+    from utils.llm import app_generator
+
+    monkeypatch.setattr(app_generator, 'should_route_features_through_gateway', lambda: False)
+    monkeypatch.setattr(app_generator, '_generate_app_icon_via_openai', lambda _prompt: b'legacy-image')
+
+    def fail_gateway(**_kwargs):
+        raise AssertionError('gateway image generation should not run with feature mode off')
+
+    monkeypatch.setattr(app_generator, 'generate_image_via_gateway', fail_gateway)
+
+    assert await app_generator.generate_app_icon('Name', 'Description', 'other') == b'legacy-image'
+
+
+@pytest.mark.asyncio
+async def test_perplexity_tool_uses_legacy_provider_when_gateway_feature_mode_off(monkeypatch):
+    module_path = Path(__file__).parents[2] / 'utils' / 'retrieval' / 'tools' / 'perplexity_tools.py'
+    spec = importlib.util.spec_from_file_location('perplexity_tools_under_test', module_path)
+    assert spec is not None and spec.loader is not None
+    perplexity_tools = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(perplexity_tools)
+
+    monkeypatch.setattr(perplexity_tools, 'should_route_features_through_gateway', lambda: False)
+    monkeypatch.setattr(perplexity_tools, '_perplexity_legacy_search', lambda _query: _async_return('legacy-search'))
+    monkeypatch.setattr(perplexity_tools, '_perplexity_gateway_search', lambda _query: _raise_gateway_called())
+
+    assert await perplexity_tools.perplexity_web_search_tool.coroutine('query') == 'legacy-search'
+
+
+async def _async_return(value):
+    return value
+
+
+async def _raise_gateway_called():
+    raise AssertionError('gateway web search should not run with feature mode off')

--- a/backend/tests/unit/test_llm_gateway_client_config.py
+++ b/backend/tests/unit/test_llm_gateway_client_config.py
@@ -77,15 +77,21 @@ def test_gateway_langchain_client_uses_internal_gateway_base_url_and_auth(monkey
     monkeypatch.setenv('OMI_LLM_GATEWAY_URL', 'http://gateway.internal:8080/')
     monkeypatch.setenv('OMI_LLM_GATEWAY_SERVICE_TOKEN', 'service-token')
     monkeypatch.setattr(providers, 'ChatOpenAI', FakeChatOpenAI)
+    original_cache = dict(providers._llm_cache)
     providers._llm_cache.clear()
 
-    result = get_llm_gateway_chat_structured()
+    try:
+        result = get_llm_gateway_chat_structured()
 
-    assert isinstance(result, FakeChatOpenAI)
-    assert captured['model'] == 'omi:auto:chat-structured'
-    assert captured['base_url'] == 'http://gateway.internal:8080/v1'
-    assert captured['default_headers']['X-Omi-Service-Caller'] == 'backend'
-    assert captured['default_headers']['Authorization'] == 'Bearer service-token'
+        assert isinstance(result, FakeChatOpenAI)
+        assert captured['model'] == 'omi:auto:chat-structured'
+        assert captured['base_url'] == 'http://gateway.internal:8080/v1'
+        assert captured['request_timeout'] == 35.0
+        assert captured['default_headers']['X-Omi-Service-Caller'] == 'backend'
+        assert captured['default_headers']['Authorization'] == 'Bearer service-token'
+    finally:
+        providers._llm_cache.clear()
+        providers._llm_cache.update(original_cache)
 
 
 def test_get_llm_dev_shadow_wraps_legacy_and_submits_gateway(monkeypatch):
@@ -191,6 +197,19 @@ def test_gateway_feature_mode_is_blocked_in_prod_without_explicit_allow(monkeypa
         assert LLM_GATEWAY_ALLOW_PROD_FEATURE_MODE_ENV_VAR in str(exc)
     else:
         raise AssertionError('expected prod gateway feature mode to require explicit allow env')
+
+
+def test_gateway_feature_mode_is_blocked_in_non_dev_cloud_stage_without_explicit_allow(monkeypatch):
+    monkeypatch.setenv(LLM_GATEWAY_FEATURE_MODE_ENV_VAR, 'gateway')
+    monkeypatch.setenv('OMI_ENV_STAGE', 'staging')
+    monkeypatch.delenv(LLM_GATEWAY_ALLOW_PROD_FEATURE_MODE_ENV_VAR, raising=False)
+
+    try:
+        should_route_features_through_gateway()
+    except RuntimeError as exc:
+        assert LLM_GATEWAY_ALLOW_PROD_FEATURE_MODE_ENV_VAR in str(exc)
+    else:
+        raise AssertionError('expected non-dev gateway feature mode to require explicit allow env')
 
 
 def test_gateway_feature_mode_in_prod_requires_gateway_url(monkeypatch):

--- a/backend/tests/unit/test_llm_gateway_client_config.py
+++ b/backend/tests/unit/test_llm_gateway_client_config.py
@@ -11,7 +11,15 @@ from langchain_core.runnables import Runnable
 from utils.llm import clients, gateway_shadow
 from utils.llm import providers
 from utils.llm.gateway_client import DEFAULT_LLM_GATEWAY_URL, get_llm_gateway_base_url
-from utils.llm.gateway_client import LLM_GATEWAY_FEATURE_MODE_ENV_VAR, feature_auto_lane_id
+from utils.llm.gateway_client import (
+    LLM_GATEWAY_ALLOW_DIRECT_EXCEPTION_ENV_VAR,
+    LLM_GATEWAY_ALLOW_PROD_FEATURE_MODE_ENV_VAR,
+    LLM_GATEWAY_FEATURE_MODE_ENV_VAR,
+    LLM_GATEWAY_URL_ENV_VAR,
+    feature_auto_lane_id,
+    raise_if_gateway_feature_mode_blocks_direct_model_surface,
+    should_route_features_through_gateway,
+)
 from utils.llm.clients import get_llm_gateway_chat_structured
 
 
@@ -156,3 +164,65 @@ def test_get_llm_feature_gateway_mode_uses_generated_auto_lane(monkeypatch):
 
     assert result.content == 'gateway response'
     assert captured == {'lane_id': feature_auto_lane_id('conv_discard'), 'streaming': True}
+
+
+def test_get_llm_feature_gateway_mode_blocks_byok_direct_bypass(monkeypatch):
+    monkeypatch.setenv(LLM_GATEWAY_FEATURE_MODE_ENV_VAR, 'gateway')
+    monkeypatch.delenv(LLM_GATEWAY_ALLOW_DIRECT_EXCEPTION_ENV_VAR, raising=False)
+    monkeypatch.delenv('K_SERVICE', raising=False)
+    monkeypatch.setattr(clients, 'get_byok_key', lambda provider: 'sk-test-byok' if provider == 'openai' else None)
+
+    try:
+        clients.get_llm('conv_discard')
+    except RuntimeError as exc:
+        assert 'get_llm.conv_discard.byok' in str(exc)
+    else:
+        raise AssertionError('expected gateway mode to block BYOK direct bypass')
+
+
+def test_gateway_feature_mode_is_blocked_in_prod_without_explicit_allow(monkeypatch):
+    monkeypatch.setenv(LLM_GATEWAY_FEATURE_MODE_ENV_VAR, 'gateway')
+    monkeypatch.setenv('K_SERVICE', 'omi-backend')
+    monkeypatch.delenv(LLM_GATEWAY_ALLOW_PROD_FEATURE_MODE_ENV_VAR, raising=False)
+
+    try:
+        should_route_features_through_gateway()
+    except RuntimeError as exc:
+        assert LLM_GATEWAY_ALLOW_PROD_FEATURE_MODE_ENV_VAR in str(exc)
+    else:
+        raise AssertionError('expected prod gateway feature mode to require explicit allow env')
+
+
+def test_gateway_feature_mode_in_prod_requires_gateway_url(monkeypatch):
+    monkeypatch.setenv(LLM_GATEWAY_FEATURE_MODE_ENV_VAR, 'gateway')
+    monkeypatch.setenv(LLM_GATEWAY_ALLOW_PROD_FEATURE_MODE_ENV_VAR, 'true')
+    monkeypatch.setenv('K_SERVICE', 'omi-backend')
+    monkeypatch.delenv(LLM_GATEWAY_URL_ENV_VAR, raising=False)
+
+    try:
+        should_route_features_through_gateway()
+    except RuntimeError as exc:
+        assert LLM_GATEWAY_URL_ENV_VAR in str(exc)
+    else:
+        raise AssertionError('expected prod gateway feature mode to require gateway url')
+
+
+def test_gateway_feature_mode_blocks_direct_exception_surfaces(monkeypatch):
+    monkeypatch.setenv(LLM_GATEWAY_FEATURE_MODE_ENV_VAR, 'gateway')
+    monkeypatch.delenv(LLM_GATEWAY_ALLOW_DIRECT_EXCEPTION_ENV_VAR, raising=False)
+    monkeypatch.delenv('K_SERVICE', raising=False)
+
+    try:
+        raise_if_gateway_feature_mode_blocks_direct_model_surface('file_chat.openai_files')
+    except RuntimeError as exc:
+        assert 'file_chat.openai_files' in str(exc)
+    else:
+        raise AssertionError('expected direct model surface to be blocked')
+
+
+def test_gateway_feature_mode_allows_acknowledged_direct_exception(monkeypatch):
+    monkeypatch.setenv(LLM_GATEWAY_FEATURE_MODE_ENV_VAR, 'gateway')
+    monkeypatch.setenv(LLM_GATEWAY_ALLOW_DIRECT_EXCEPTION_ENV_VAR, 'true')
+    monkeypatch.delenv('K_SERVICE', raising=False)
+
+    raise_if_gateway_feature_mode_blocks_direct_model_surface('file_chat.openai_files')

--- a/backend/tests/unit/test_llm_gateway_client_config.py
+++ b/backend/tests/unit/test_llm_gateway_client_config.py
@@ -11,6 +11,7 @@ from langchain_core.runnables import Runnable
 from utils.llm import clients, gateway_shadow
 from utils.llm import providers
 from utils.llm.gateway_client import DEFAULT_LLM_GATEWAY_URL, get_llm_gateway_base_url
+from utils.llm.gateway_client import LLM_GATEWAY_FEATURE_MODE_ENV_VAR, feature_auto_lane_id
 from utils.llm.clients import get_llm_gateway_chat_structured
 
 
@@ -137,3 +138,21 @@ def test_get_llm_dev_shadow_is_disabled_for_prod_like_runtime(monkeypatch):
     result = clients.get_llm('conv_discard')
 
     assert result is legacy
+
+
+def test_get_llm_feature_gateway_mode_uses_generated_auto_lane(monkeypatch):
+    captured = {}
+    gateway = FakeChatModel(name='gateway', calls=[])
+
+    def fake_gateway(lane_id, streaming=False, options=None):
+        captured['lane_id'] = lane_id
+        captured['streaming'] = streaming
+        return gateway
+
+    monkeypatch.setenv(LLM_GATEWAY_FEATURE_MODE_ENV_VAR, 'gateway')
+    monkeypatch.setattr(clients, 'get_or_create_omi_gateway_llm', fake_gateway)
+
+    result = clients.get_llm('conv_discard', streaming=True).invoke('hello')
+
+    assert result.content == 'gateway response'
+    assert captured == {'lane_id': feature_auto_lane_id('conv_discard'), 'streaming': True}

--- a/backend/tests/unit/test_llm_gateway_client_config.py
+++ b/backend/tests/unit/test_llm_gateway_client_config.py
@@ -96,6 +96,7 @@ def test_gateway_langchain_client_uses_internal_gateway_base_url_and_auth(monkey
 
 def test_get_llm_dev_shadow_wraps_legacy_and_submits_gateway(monkeypatch):
     submitted = []
+    captured_gateway_options = {}
     legacy = FakeChatModel(name='legacy', calls=[])
     gateway = FakeChatModel(name='gateway', calls=[])
 
@@ -107,7 +108,12 @@ def test_get_llm_dev_shadow_wraps_legacy_and_submits_gateway(monkeypatch):
     monkeypatch.delenv('OMI_ENV_STAGE', raising=False)
     monkeypatch.delenv('K_SERVICE', raising=False)
     monkeypatch.setattr(clients, 'get_default_client', lambda *args, **kwargs: legacy)
-    monkeypatch.setattr(gateway_shadow, 'get_or_create_omi_gateway_llm', lambda *args, **kwargs: gateway)
+
+    def fake_gateway(*args, **kwargs):
+        captured_gateway_options.update(kwargs.get('options') or {})
+        return gateway
+
+    monkeypatch.setattr(gateway_shadow, 'get_or_create_omi_gateway_llm', fake_gateway)
     monkeypatch.setattr(gateway_shadow, 'submit_with_context', immediate_submit)
 
     result = clients.get_llm('conv_discard').invoke('hello')
@@ -115,6 +121,7 @@ def test_get_llm_dev_shadow_wraps_legacy_and_submits_gateway(monkeypatch):
     assert result.content == 'legacy response'
     assert len(legacy.calls) == 1
     assert len(gateway.calls) == 1
+    assert captured_gateway_options['request_timeout'] == 35.0
     assert submitted == ['_run_sync_shadow']
 
 

--- a/backend/tests/unit/test_llm_gateway_client_config.py
+++ b/backend/tests/unit/test_llm_gateway_client_config.py
@@ -1,8 +1,49 @@
 from __future__ import annotations
 
+from typing import Any
+
+from langchain_core.callbacks.manager import CallbackManagerForLLMRun
+from langchain_core.language_models import BaseChatModel
+from langchain_core.messages import AIMessage, BaseMessage
+from langchain_core.outputs import ChatGeneration, ChatResult
+from langchain_core.runnables import Runnable
+
+from utils.llm import clients, gateway_shadow
 from utils.llm import providers
 from utils.llm.gateway_client import DEFAULT_LLM_GATEWAY_URL, get_llm_gateway_base_url
 from utils.llm.clients import get_llm_gateway_chat_structured
+
+
+class FakeChatModel(BaseChatModel):
+    name: str
+    calls: list
+
+    @property
+    def _llm_type(self) -> str:
+        return f'fake-{self.name}'
+
+    def _generate(
+        self,
+        messages: list[BaseMessage],
+        stop: list[str] | None = None,
+        run_manager: CallbackManagerForLLMRun | None = None,
+        **kwargs: Any,
+    ) -> ChatResult:
+        self.calls.append({'messages': messages, 'kwargs': kwargs})
+        return ChatResult(generations=[ChatGeneration(message=AIMessage(content=f'{self.name} response'))])
+
+    def with_structured_output(self, schema, *, include_raw: bool = False, **kwargs: Any):
+        return FakeStructuredRunnable(self.name, self.calls)
+
+
+class FakeStructuredRunnable(Runnable):
+    def __init__(self, name: str, calls: list):
+        self.name = name
+        self.calls = calls
+
+    def invoke(self, input: Any, config=None, **kwargs: Any) -> dict[str, str]:
+        self.calls.append({'input': input, 'kwargs': kwargs})
+        return {'result': self.name}
 
 
 def test_llm_gateway_base_url_defaults_to_local_service(monkeypatch):
@@ -36,3 +77,63 @@ def test_gateway_langchain_client_uses_internal_gateway_base_url_and_auth(monkey
     assert captured['base_url'] == 'http://gateway.internal:8080/v1'
     assert captured['default_headers']['X-Omi-Service-Caller'] == 'backend'
     assert captured['default_headers']['Authorization'] == 'Bearer service-token'
+
+
+def test_get_llm_dev_shadow_wraps_legacy_and_submits_gateway(monkeypatch):
+    submitted = []
+    legacy = FakeChatModel(name='legacy', calls=[])
+    gateway = FakeChatModel(name='gateway', calls=[])
+
+    def immediate_submit(_executor, fn, *args, **kwargs):
+        submitted.append(fn.__name__)
+        fn(*args, **kwargs)
+
+    monkeypatch.setenv(gateway_shadow.DEV_SHADOW_ALL_ENABLED_ENV, 'true')
+    monkeypatch.delenv('OMI_ENV_STAGE', raising=False)
+    monkeypatch.delenv('K_SERVICE', raising=False)
+    monkeypatch.setattr(clients, 'get_default_client', lambda *args, **kwargs: legacy)
+    monkeypatch.setattr(gateway_shadow, 'get_or_create_omi_gateway_llm', lambda *args, **kwargs: gateway)
+    monkeypatch.setattr(gateway_shadow, 'submit_with_context', immediate_submit)
+
+    result = clients.get_llm('conv_discard').invoke('hello')
+
+    assert result.content == 'legacy response'
+    assert len(legacy.calls) == 1
+    assert len(gateway.calls) == 1
+    assert submitted == ['_run_sync_shadow']
+
+
+def test_get_llm_dev_shadow_wraps_structured_output(monkeypatch):
+    submitted = []
+    legacy = FakeChatModel(name='legacy', calls=[])
+    gateway = FakeChatModel(name='gateway', calls=[])
+
+    def immediate_submit(_executor, fn, *args, **kwargs):
+        submitted.append(fn.__name__)
+        fn(*args, **kwargs)
+
+    monkeypatch.setenv(gateway_shadow.DEV_SHADOW_ALL_ENABLED_ENV, 'true')
+    monkeypatch.delenv('OMI_ENV_STAGE', raising=False)
+    monkeypatch.delenv('K_SERVICE', raising=False)
+    monkeypatch.setattr(clients, 'get_default_client', lambda *args, **kwargs: legacy)
+    monkeypatch.setattr(gateway_shadow, 'get_or_create_omi_gateway_llm', lambda *args, **kwargs: gateway)
+    monkeypatch.setattr(gateway_shadow, 'submit_with_context', immediate_submit)
+
+    result = clients.get_llm('chat_extraction').with_structured_output(dict).invoke('hello')
+
+    assert result == {'result': 'legacy'}
+    assert legacy.calls == [{'input': 'hello', 'kwargs': {}}]
+    assert gateway.calls == [{'input': 'hello', 'kwargs': {}}]
+    assert submitted == ['_run_sync_shadow']
+
+
+def test_get_llm_dev_shadow_is_disabled_for_prod_like_runtime(monkeypatch):
+    legacy = FakeChatModel(name='legacy', calls=[])
+
+    monkeypatch.setenv(gateway_shadow.DEV_SHADOW_ALL_ENABLED_ENV, 'true')
+    monkeypatch.setenv('K_SERVICE', 'prod-omi-backend')
+    monkeypatch.setattr(clients, 'get_default_client', lambda *args, **kwargs: legacy)
+
+    result = clients.get_llm('conv_discard')
+
+    assert result is legacy

--- a/backend/tests/unit/test_llm_gateway_client_config.py
+++ b/backend/tests/unit/test_llm_gateway_client_config.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+from utils.llm import providers
 from utils.llm.gateway_client import DEFAULT_LLM_GATEWAY_URL, get_llm_gateway_base_url
+from utils.llm.clients import get_llm_gateway_chat_structured
 
 
 def test_llm_gateway_base_url_defaults_to_local_service(monkeypatch):
@@ -13,3 +15,24 @@ def test_llm_gateway_base_url_uses_repo_local_env_config(monkeypatch):
     monkeypatch.setenv('OMI_LLM_GATEWAY_URL', ' http://llm-gateway.internal:8080/ ')
 
     assert get_llm_gateway_base_url() == 'http://llm-gateway.internal:8080'
+
+
+def test_gateway_langchain_client_uses_internal_gateway_base_url_and_auth(monkeypatch):
+    captured = {}
+
+    class FakeChatOpenAI:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setenv('OMI_LLM_GATEWAY_URL', 'http://gateway.internal:8080/')
+    monkeypatch.setenv('OMI_LLM_GATEWAY_SERVICE_TOKEN', 'service-token')
+    monkeypatch.setattr(providers, 'ChatOpenAI', FakeChatOpenAI)
+    providers._llm_cache.clear()
+
+    result = get_llm_gateway_chat_structured()
+
+    assert isinstance(result, FakeChatOpenAI)
+    assert captured['model'] == 'omi:auto:chat-structured'
+    assert captured['base_url'] == 'http://gateway.internal:8080/v1'
+    assert captured['default_headers']['X-Omi-Service-Caller'] == 'backend'
+    assert captured['default_headers']['Authorization'] == 'Bearer service-token'

--- a/backend/tests/unit/test_llm_gateway_client_config.py
+++ b/backend/tests/unit/test_llm_gateway_client_config.py
@@ -222,6 +222,32 @@ def test_gateway_feature_mode_is_blocked_in_non_dev_cloud_stage_without_explicit
         raise AssertionError('expected non-dev gateway feature mode to require explicit allow env')
 
 
+def test_gateway_feature_mode_is_blocked_in_kubernetes_without_explicit_dev_stage(monkeypatch):
+    monkeypatch.setenv(LLM_GATEWAY_FEATURE_MODE_ENV_VAR, 'gateway')
+    monkeypatch.setenv('KUBERNETES_SERVICE_HOST', '10.0.0.1')
+    monkeypatch.delenv(LLM_GATEWAY_ALLOW_PROD_FEATURE_MODE_ENV_VAR, raising=False)
+    monkeypatch.delenv('OMI_ENV_STAGE', raising=False)
+    monkeypatch.delenv('ENVIRONMENT', raising=False)
+    monkeypatch.delenv('APP_ENV', raising=False)
+    monkeypatch.delenv('K_SERVICE', raising=False)
+
+    try:
+        should_route_features_through_gateway()
+    except RuntimeError as exc:
+        assert LLM_GATEWAY_ALLOW_PROD_FEATURE_MODE_ENV_VAR in str(exc)
+    else:
+        raise AssertionError('expected unstaged Kubernetes gateway feature mode to require explicit allow env')
+
+
+def test_gateway_feature_mode_allows_kubernetes_with_explicit_dev_stage(monkeypatch):
+    monkeypatch.setenv(LLM_GATEWAY_FEATURE_MODE_ENV_VAR, 'gateway')
+    monkeypatch.setenv('KUBERNETES_SERVICE_HOST', '10.0.0.1')
+    monkeypatch.setenv('OMI_ENV_STAGE', 'dev')
+    monkeypatch.delenv(LLM_GATEWAY_ALLOW_PROD_FEATURE_MODE_ENV_VAR, raising=False)
+
+    assert should_route_features_through_gateway() is True
+
+
 def test_gateway_feature_mode_in_prod_requires_gateway_url(monkeypatch):
     monkeypatch.setenv(LLM_GATEWAY_FEATURE_MODE_ENV_VAR, 'gateway')
     monkeypatch.setenv(LLM_GATEWAY_ALLOW_PROD_FEATURE_MODE_ENV_VAR, 'true')
@@ -274,17 +300,37 @@ async def test_app_icon_generation_uses_legacy_provider_when_gateway_feature_mod
 
 @pytest.mark.asyncio
 async def test_perplexity_tool_uses_legacy_provider_when_gateway_feature_mode_off(monkeypatch):
-    module_path = Path(__file__).parents[2] / 'utils' / 'retrieval' / 'tools' / 'perplexity_tools.py'
-    spec = importlib.util.spec_from_file_location('perplexity_tools_under_test', module_path)
-    assert spec is not None and spec.loader is not None
-    perplexity_tools = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(perplexity_tools)
+    perplexity_tools = _load_perplexity_tools()
 
     monkeypatch.setattr(perplexity_tools, 'should_route_features_through_gateway', lambda: False)
     monkeypatch.setattr(perplexity_tools, '_perplexity_legacy_search', lambda _query: _async_return('legacy-search'))
     monkeypatch.setattr(perplexity_tools, '_perplexity_gateway_search', lambda _query: _raise_gateway_called())
 
     assert await perplexity_tools.perplexity_web_search_tool.coroutine('query') == 'legacy-search'
+
+
+def test_perplexity_gateway_response_preserves_top_level_citations():
+    perplexity_tools = _load_perplexity_tools()
+
+    formatted = perplexity_tools._format_perplexity_response(
+        {
+            'choices': [{'message': {'content': 'answer'}}],
+            'citations': [{'title': 'Source title', 'url': 'https://example.com/source'}],
+        }
+    )
+
+    assert 'answer' in formatted
+    assert 'Source title' in formatted
+    assert 'https://example.com/source' in formatted
+
+
+def _load_perplexity_tools():
+    module_path = Path(__file__).parents[2] / 'utils' / 'retrieval' / 'tools' / 'perplexity_tools.py'
+    spec = importlib.util.spec_from_file_location('perplexity_tools_under_test', module_path)
+    assert spec is not None and spec.loader is not None
+    perplexity_tools = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(perplexity_tools)
+    return perplexity_tools
 
 
 async def _async_return(value):

--- a/backend/tests/unit/test_llm_gateway_config.py
+++ b/backend/tests/unit/test_llm_gateway_config.py
@@ -6,6 +6,7 @@ import pytest
 import yaml
 
 from llm_gateway.gateway.config_loader import ConfigValidationError, load_gateway_config
+from utils.llm.model_config import get_all_configured_features
 
 LANE_ID = 'omi:auto:chat-structured'
 ACTIVE_ROUTE = 'route.chat_structured.2026_06_27.001'
@@ -15,7 +16,8 @@ LKG_ROUTE = 'route.chat_structured.2026_06_20.001'
 def test_loads_default_gateway_config():
     config = load_gateway_config(prod_mode=True)
 
-    assert set(config.lanes) == {LANE_ID}
+    assert LANE_ID in config.lanes
+    assert len(config.lanes) >= len(get_all_configured_features())
     lane = config.lanes[LANE_ID]
     assert lane.active_route == ACTIVE_ROUTE
     assert lane.last_known_good == LKG_ROUTE

--- a/backend/tests/unit/test_llm_gateway_coverage_guardrails.py
+++ b/backend/tests/unit/test_llm_gateway_coverage_guardrails.py
@@ -165,6 +165,7 @@ def _is_skipped_path(rel: str) -> bool:
             'testing/',
             'pusher/',
             '.venv/',
+            '.openapi-venv/',
         )
     )
 

--- a/backend/tests/unit/test_llm_gateway_coverage_guardrails.py
+++ b/backend/tests/unit/test_llm_gateway_coverage_guardrails.py
@@ -94,6 +94,15 @@ def test_generated_gateway_lanes_preserve_model_config_route_options():
         assert route.provider_options == get_route_options(feature, model, provider)
 
 
+def test_anthropic_generated_lanes_do_not_advertise_streaming_without_adapter_support():
+    config = load_gateway_config(prod_mode=True)
+
+    for feature in get_all_configured_features():
+        if get_provider(feature) == 'anthropic':
+            lane = config.lanes[feature_lane_id(feature)]
+            assert lane.capabilities.streaming is False
+
+
 def test_inventory_surfaces_have_status_guardrails_and_resolvable_code_paths():
     inventory = _load_inventory()
 

--- a/backend/tests/unit/test_llm_gateway_coverage_guardrails.py
+++ b/backend/tests/unit/test_llm_gateway_coverage_guardrails.py
@@ -47,6 +47,7 @@ class DirectUse:
 
 DIRECT_PROVIDER_ALLOWLIST = {
     DirectUse('llm_gateway/routers/openai_compatible.py', 'OPENAI_API_KEY'),
+    DirectUse('utils/llm/app_generator.py', 'OpenAI'),
     DirectUse('utils/llm/providers.py', 'ChatGoogleGenerativeAI'),
     DirectUse('utils/llm/providers.py', 'ChatOpenAI'),
     DirectUse('utils/llm/providers.py', 'GEMINI_API_KEY'),
@@ -59,6 +60,7 @@ DIRECT_PROVIDER_ALLOWLIST = {
     DirectUse('utils/other/chat_file.py', 'openai.beta'),
     DirectUse('utils/other/chat_file.py', 'openai.files'),
     DirectUse('utils/retrieval/agentic.py', 'anthropic_client.messages'),
+    DirectUse('utils/retrieval/tools/perplexity_tools.py', 'PERPLEXITY_API_KEY'),
     DirectUse('routers/omni_relay.py', 'GEMINI_API_KEY'),
     DirectUse('routers/omni_relay.py', 'OPENAI_API_KEY'),
 }

--- a/backend/tests/unit/test_llm_gateway_coverage_guardrails.py
+++ b/backend/tests/unit/test_llm_gateway_coverage_guardrails.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import yaml
+
+from llm_gateway.gateway.config_loader import feature_lane_id, load_gateway_config
+from utils.llm.model_config import get_all_configured_features
+
+BACKEND_DIR = Path(__file__).resolve().parents[2]
+INVENTORY_PATH = BACKEND_DIR / 'docs' / 'llm' / 'model_endpoint_inventory.yaml'
+
+DIRECT_PROVIDER_PATTERNS = {
+    ('openai', 'OpenAI'),
+    ('openai', 'AsyncOpenAI'),
+    ('anthropic', 'AsyncAnthropic'),
+    ('langchain_openai', 'ChatOpenAI'),
+    ('langchain_google_genai', 'ChatGoogleGenerativeAI'),
+}
+
+DIRECT_CALL_ALLOWLIST = {
+    # Gateway/client construction boundary.
+    'llm_gateway/gateway/providers.py',
+    'utils/llm/providers.py',
+    'utils/llm/clients.py',
+    # Explicitly out-of-scope embeddings and memory-ingestion tests patch this seam.
+    'utils/memory_ingestion/adapters/production_like_model.py',
+    # Inventoried direct provider lifecycle surfaces that cannot be silently missed.
+    'utils/other/chat_file.py',
+    'routers/omni_relay.py',
+    'utils/retrieval/agentic.py',
+}
+
+
+def test_every_model_config_feature_has_inventory_and_gateway_lane():
+    inventory = _load_inventory()
+    configured_features = get_all_configured_features()
+    listed_features = set()
+    for values in inventory['model_config_features']['request_shapes'].values():
+        listed_features.update(values)
+
+    assert configured_features <= listed_features
+
+    config = load_gateway_config(prod_mode=True)
+    missing_lanes = [feature for feature in configured_features if feature_lane_id(feature) not in config.lanes]
+    assert missing_lanes == []
+
+
+def test_inventory_surfaces_have_status_and_guardrails():
+    inventory = _load_inventory()
+
+    assert inventory['schema_version'] == 'llm_model_endpoint_inventory.v1'
+    assert inventory['out_of_scope_surfaces']
+    for surface in inventory['surfaces']:
+        assert surface['surface']
+        assert surface['code_path']
+        assert surface['current_provider_model']
+        assert surface['request_shape']
+        assert surface['gateway_lane_capability_needed']
+        assert surface['migration_status']
+        assert surface['test_guardrail_coverage']
+
+
+def test_direct_provider_construction_stays_inside_approved_boundaries():
+    violations: list[str] = []
+    for path in BACKEND_DIR.rglob('*.py'):
+        rel = path.relative_to(BACKEND_DIR).as_posix()
+        if _is_skipped_path(rel):
+            continue
+        if rel in DIRECT_CALL_ALLOWLIST:
+            continue
+        source = path.read_text(encoding='utf-8')
+        try:
+            tree = ast.parse(source, filename=str(path))
+        except SyntaxError:
+            continue
+        imported_names = _direct_provider_imports(tree)
+        if not imported_names:
+            continue
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id in imported_names:
+                violations.append(f'{rel}:{node.lineno} constructs {node.func.id}')
+
+    assert violations == []
+
+
+def _load_inventory() -> dict:
+    with INVENTORY_PATH.open('r', encoding='utf-8') as handle:
+        loaded = yaml.safe_load(handle)
+    assert isinstance(loaded, dict)
+    return loaded
+
+
+def _is_skipped_path(rel: str) -> bool:
+    return rel.startswith(
+        (
+            'tests/',
+            'scripts/',
+            'migrations/',
+            'testing/',
+            'pusher/',
+            '.venv/',
+        )
+    )
+
+
+def _direct_provider_imports(tree: ast.AST) -> set[str]:
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ImportFrom) or node.module is None:
+            continue
+        for module_name, class_name in DIRECT_PROVIDER_PATTERNS:
+            if node.module == module_name:
+                for alias in node.names:
+                    if alias.name == class_name:
+                        names.add(alias.asname or alias.name)
+    return names

--- a/backend/tests/unit/test_llm_gateway_coverage_guardrails.py
+++ b/backend/tests/unit/test_llm_gateway_coverage_guardrails.py
@@ -1,35 +1,71 @@
 from __future__ import annotations
 
 import ast
+from dataclasses import dataclass
 from pathlib import Path
 
 import yaml
 
 from llm_gateway.gateway.config_loader import feature_lane_id, load_gateway_config
-from utils.llm.model_config import get_all_configured_features
+from utils.llm.model_config import get_all_configured_features, get_route_options, get_model, get_provider
 
 BACKEND_DIR = Path(__file__).resolve().parents[2]
 INVENTORY_PATH = BACKEND_DIR / 'docs' / 'llm' / 'model_endpoint_inventory.yaml'
 
-DIRECT_PROVIDER_PATTERNS = {
-    ('openai', 'OpenAI'),
-    ('openai', 'AsyncOpenAI'),
-    ('anthropic', 'AsyncAnthropic'),
-    ('langchain_openai', 'ChatOpenAI'),
-    ('langchain_google_genai', 'ChatGoogleGenerativeAI'),
+DIRECT_CONSTRUCTOR_NAMES = {
+    'openai.OpenAI',
+    'openai.AsyncOpenAI',
+    'anthropic.Anthropic',
+    'anthropic.AsyncAnthropic',
+    'langchain_openai.ChatOpenAI',
+    'langchain_openai.OpenAIEmbeddings',
+    'langchain_anthropic.ChatAnthropic',
+    'langchain_google_genai.ChatGoogleGenerativeAI',
+    'google.genai.Client',
+    'genai.Client',
+}
+DIRECT_PROVIDER_CALL_PREFIXES = {
+    'openai.beta',
+    'openai.chat.completions',
+    'openai.files',
+    'anthropic_client.messages',
+}
+DIRECT_PROVIDER_ENV_VARS = {
+    'OPENAI_API_KEY',
+    'OPENROUTER_API_KEY',
+    'ANTHROPIC_API_KEY',
+    'PERPLEXITY_API_KEY',
+    'GEMINI_API_KEY',
 }
 
-DIRECT_CALL_ALLOWLIST = {
-    # Gateway/client construction boundary.
-    'llm_gateway/gateway/providers.py',
-    'utils/llm/providers.py',
-    'utils/llm/clients.py',
-    # Explicitly out-of-scope embeddings and memory-ingestion tests patch this seam.
-    'utils/memory_ingestion/adapters/production_like_model.py',
-    # Inventoried direct provider lifecycle surfaces that cannot be silently missed.
+
+@dataclass(frozen=True)
+class DirectUse:
+    rel_path: str
+    symbol: str
+
+
+DIRECT_PROVIDER_ALLOWLIST = {
+    DirectUse('llm_gateway/routers/openai_compatible.py', 'OPENAI_API_KEY'),
+    DirectUse('utils/llm/providers.py', 'ChatGoogleGenerativeAI'),
+    DirectUse('utils/llm/providers.py', 'ChatOpenAI'),
+    DirectUse('utils/llm/providers.py', 'GEMINI_API_KEY'),
+    DirectUse('utils/llm/clients.py', 'AsyncAnthropic'),
+    DirectUse('utils/llm/clients.py', 'ChatOpenAI'),
+    DirectUse('utils/llm/clients.py', 'GEMINI_API_KEY'),
+    DirectUse('utils/llm/clients.py', 'OpenAIEmbeddings'),
+    DirectUse('utils/memory_ingestion/export_runner.py', 'OPENAI_API_KEY'),
+    DirectUse('utils/other/chat_file.py', 'AsyncOpenAI'),
+    DirectUse('utils/other/chat_file.py', 'openai.beta'),
+    DirectUse('utils/other/chat_file.py', 'openai.files'),
+    DirectUse('utils/retrieval/agentic.py', 'anthropic_client.messages'),
+    DirectUse('routers/omni_relay.py', 'GEMINI_API_KEY'),
+    DirectUse('routers/omni_relay.py', 'OPENAI_API_KEY'),
+}
+INVENTORIED_DIRECT_EXCEPTION_FILES = {
     'utils/other/chat_file.py',
-    'routers/omni_relay.py',
     'utils/retrieval/agentic.py',
+    'routers/omni_relay.py',
 }
 
 
@@ -47,7 +83,18 @@ def test_every_model_config_feature_has_inventory_and_gateway_lane():
     assert missing_lanes == []
 
 
-def test_inventory_surfaces_have_status_and_guardrails():
+def test_generated_gateway_lanes_preserve_model_config_route_options():
+    config = load_gateway_config(prod_mode=True)
+
+    for feature in get_all_configured_features():
+        model = get_model(feature)
+        provider = get_provider(feature)
+        route = config.route_artifacts[f'route.{feature}.model_config.001']
+
+        assert route.provider_options == get_route_options(feature, model, provider)
+
+
+def test_inventory_surfaces_have_status_guardrails_and_resolvable_code_paths():
     inventory = _load_inventory()
 
     assert inventory['schema_version'] == 'llm_model_endpoint_inventory.v1'
@@ -60,29 +107,37 @@ def test_inventory_surfaces_have_status_and_guardrails():
         assert surface['gateway_lane_capability_needed']
         assert surface['migration_status']
         assert surface['test_guardrail_coverage']
+        assert _inventory_file_exists(surface['code_path']), surface['code_path']
 
 
-def test_direct_provider_construction_stays_inside_approved_boundaries():
-    violations: list[str] = []
+def test_direct_provider_usage_stays_inside_approved_boundaries():
+    detected = set()
     for path in BACKEND_DIR.rglob('*.py'):
         rel = path.relative_to(BACKEND_DIR).as_posix()
         if _is_skipped_path(rel):
-            continue
-        if rel in DIRECT_CALL_ALLOWLIST:
             continue
         source = path.read_text(encoding='utf-8')
         try:
             tree = ast.parse(source, filename=str(path))
         except SyntaxError:
             continue
-        imported_names = _direct_provider_imports(tree)
-        if not imported_names:
-            continue
-        for node in ast.walk(tree):
-            if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id in imported_names:
-                violations.append(f'{rel}:{node.lineno} constructs {node.func.id}')
+        detected.update(_direct_provider_uses(rel, tree))
+
+    violations = sorted(detected - DIRECT_PROVIDER_ALLOWLIST, key=lambda item: (item.rel_path, item.symbol))
+    stale_allowlist = sorted(DIRECT_PROVIDER_ALLOWLIST - detected, key=lambda item: (item.rel_path, item.symbol))
 
     assert violations == []
+    assert stale_allowlist == []
+
+
+def test_direct_exception_files_are_inventoried_and_fail_closed_for_gateway_flip():
+    inventory = _load_inventory()
+    inventory_paths = {_code_path_file(surface['code_path']) for surface in inventory['surfaces']}
+
+    assert INVENTORIED_DIRECT_EXCEPTION_FILES <= inventory_paths
+    for rel_path in INVENTORIED_DIRECT_EXCEPTION_FILES:
+        source = (BACKEND_DIR / rel_path).read_text(encoding='utf-8')
+        assert 'raise_if_gateway_feature_mode_blocks_direct_model_surface' in source
 
 
 def _load_inventory() -> dict:
@@ -105,14 +160,82 @@ def _is_skipped_path(rel: str) -> bool:
     )
 
 
-def _direct_provider_imports(tree: ast.AST) -> set[str]:
-    names: set[str] = set()
+def _direct_provider_uses(rel: str, tree: ast.AST) -> set[DirectUse]:
+    aliases = _import_aliases(tree)
+    uses: set[DirectUse] = set()
     for node in ast.walk(tree):
-        if not isinstance(node, ast.ImportFrom) or node.module is None:
-            continue
-        for module_name, class_name in DIRECT_PROVIDER_PATTERNS:
-            if node.module == module_name:
-                for alias in node.names:
-                    if alias.name == class_name:
-                        names.add(alias.asname or alias.name)
-    return names
+        if isinstance(node, ast.Call):
+            call_name = _expanded_name(_dotted_name(node.func), aliases)
+            matched = _direct_symbol(call_name)
+            if matched is not None:
+                uses.add(DirectUse(rel, matched))
+            env_var = _provider_env_var_from_call(node)
+            if env_var is not None:
+                uses.add(DirectUse(rel, env_var))
+    return uses
+
+
+def _import_aliases(tree: ast.AST) -> dict[str, str]:
+    aliases: dict[str, str] = {}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                aliases[alias.asname or alias.name.split('.')[0]] = alias.name
+        elif isinstance(node, ast.ImportFrom) and node.module is not None:
+            for alias in node.names:
+                aliases[alias.asname or alias.name] = f'{node.module}.{alias.name}'
+    return aliases
+
+
+def _dotted_name(node: ast.AST) -> str | None:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        parent = _dotted_name(node.value)
+        return f'{parent}.{node.attr}' if parent else node.attr
+    return None
+
+
+def _expanded_name(name: str | None, aliases: dict[str, str]) -> str | None:
+    if name is None:
+        return None
+    head, _, tail = name.partition('.')
+    expanded_head = aliases.get(head, head)
+    return f'{expanded_head}.{tail}' if tail else expanded_head
+
+
+def _direct_symbol(call_name: str | None) -> str | None:
+    if call_name is None:
+        return None
+    for constructor in DIRECT_CONSTRUCTOR_NAMES:
+        if call_name == constructor:
+            return constructor.split('.')[-1]
+    for prefix in DIRECT_PROVIDER_CALL_PREFIXES:
+        if (
+            call_name == prefix
+            or call_name.startswith(f'{prefix}.')
+            or call_name.endswith(f'.{prefix}')
+            or f'.{prefix}.' in call_name
+        ):
+            return prefix
+    return None
+
+
+def _provider_env_var_from_call(node: ast.Call) -> str | None:
+    call_name = _dotted_name(node.func)
+    if call_name not in {'os.getenv', 'os.environ.get'}:
+        return None
+    if not node.args or not isinstance(node.args[0], ast.Constant):
+        return None
+    value = node.args[0].value
+    return value if isinstance(value, str) and value in DIRECT_PROVIDER_ENV_VARS else None
+
+
+def _inventory_file_exists(code_path: str) -> bool:
+    rel = _code_path_file(code_path)
+    return bool(rel) and (BACKEND_DIR / rel).exists()
+
+
+def _code_path_file(code_path: str) -> str:
+    normalized = code_path.removeprefix('backend/')
+    return normalized.split(':', 1)[0]

--- a/backend/tests/unit/test_llm_gateway_dependencies.py
+++ b/backend/tests/unit/test_llm_gateway_dependencies.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import pytest
 
+from llm_gateway.gateway.executor import ProviderRegistry
 from llm_gateway.routers.dependencies import close_provider_registry, get_provider_registry
 
 
@@ -17,3 +18,29 @@ async def test_provider_registry_is_cached_and_closed():
 
     assert get_provider_registry() is not first
     await close_provider_registry()
+
+
+@pytest.mark.asyncio
+async def test_provider_registry_closes_all_providers_when_one_close_fails():
+    calls = []
+
+    class Provider:
+        def __init__(self, name: str, should_fail: bool = False):
+            self.name = name
+            self.should_fail = should_fail
+
+        async def aclose(self):
+            calls.append(self.name)
+            if self.should_fail:
+                raise RuntimeError(f'{self.name} failed')
+
+    registry = ProviderRegistry(
+        {
+            'first': Provider('first', should_fail=True),
+            'second': Provider('second'),
+        }
+    )
+
+    await registry.aclose()
+
+    assert sorted(calls) == ['first', 'second']

--- a/backend/tests/unit/test_llm_gateway_executor.py
+++ b/backend/tests/unit/test_llm_gateway_executor.py
@@ -65,7 +65,7 @@ async def test_executor_forwards_prompt_parser_request_without_response_format()
 
 
 @pytest.mark.asyncio
-async def test_executor_uses_executing_route_provider_options_for_lkg_fallback():
+async def test_executor_uses_lkg_route_provider_options_when_active_is_shadow():
     active_route = active_route_with_fallbacks([]).model_copy(
         update={
             'provider_options': {'temperature': 0.9},

--- a/backend/tests/unit/test_llm_gateway_executor.py
+++ b/backend/tests/unit/test_llm_gateway_executor.py
@@ -65,6 +65,32 @@ async def test_executor_forwards_prompt_parser_request_without_response_format()
 
 
 @pytest.mark.asyncio
+async def test_executor_uses_executing_route_provider_options_for_lkg_fallback():
+    active_route = active_route_with_fallbacks([]).model_copy(
+        update={
+            'provider_options': {'temperature': 0.9},
+            'rollout': RolloutPolicy(stage=RolloutStage.SHADOW, percent=0),
+        }
+    )
+    lkg_route = (
+        load_gateway_config(prod_mode=True)
+        .route_artifacts[LKG_ROUTE]
+        .model_copy(update={'provider_options': {'temperature': 0.1}})
+    )
+    config = config_with_routes(active_route, lkg_route)
+    resolved = resolve_chat_completion_route(config, valid_request())
+    provider = FakeChatCompletionProvider([fake_success_response(resolved.last_known_good_route.primary)])
+
+    await execute_chat_completion(
+        resolved,
+        omi_credentials(),
+        ProviderRegistry({'openai': provider}),
+    )
+
+    assert provider.calls[0].request['temperature'] == 0.1
+
+
+@pytest.mark.asyncio
 async def test_executor_retries_provider_up_to_max_attempts_before_fallback():
     fallback_ref = ProviderRef(provider='openai', model='gpt-4o-mini')
     config = config_with_active_route(active_route_with_fallbacks([fallback_ref]))

--- a/backend/tests/unit/test_llm_gateway_executor.py
+++ b/backend/tests/unit/test_llm_gateway_executor.py
@@ -91,6 +91,23 @@ async def test_executor_uses_lkg_route_provider_options_when_active_is_shadow():
 
 
 @pytest.mark.asyncio
+async def test_executor_maps_gemini_thinking_budget_before_provider_call():
+    active_route = active_route_with_fallbacks([]).model_copy(update={'provider_options': {'thinking_budget': 0}})
+    config = config_with_active_route(active_route)
+    resolved = resolve_chat_completion_route(config, valid_request())
+    provider = FakeChatCompletionProvider([fake_success_response(resolved.active_route.primary)])
+
+    await execute_chat_completion(
+        resolved,
+        omi_credentials(),
+        ProviderRegistry({'openai': provider}),
+    )
+
+    assert provider.calls[0].request['reasoning_effort'] == 'none'
+    assert 'thinking_budget' not in provider.calls[0].request
+
+
+@pytest.mark.asyncio
 async def test_executor_retries_provider_up_to_max_attempts_before_fallback():
     fallback_ref = ProviderRef(provider='openai', model='gpt-4o-mini')
     config = config_with_active_route(active_route_with_fallbacks([fallback_ref]))

--- a/backend/tests/unit/test_llm_gateway_executor.py
+++ b/backend/tests/unit/test_llm_gateway_executor.py
@@ -46,6 +46,25 @@ async def test_executor_success_uses_active_primary_and_exposes_lane_model():
 
 
 @pytest.mark.asyncio
+async def test_executor_forwards_prompt_parser_request_without_response_format():
+    config = config_with_active_route(active_route_with_fallbacks([]))
+    request = valid_request()
+    request.pop('response_format')
+    resolved = resolve_chat_completion_route(config, request)
+    active_primary = resolved.active_route.primary
+    provider = FakeChatCompletionProvider([fake_success_response(active_primary, content='{"answer":"primary"}')])
+
+    await execute_chat_completion(
+        resolved,
+        omi_credentials(),
+        ProviderRegistry({'openai': provider}),
+    )
+
+    assert provider.calls[0].request['model'] == 'gpt-4.1-mini'
+    assert 'response_format' not in provider.calls[0].request
+
+
+@pytest.mark.asyncio
 async def test_executor_retries_provider_up_to_max_attempts_before_fallback():
     fallback_ref = ProviderRef(provider='openai', model='gpt-4o-mini')
     config = config_with_active_route(active_route_with_fallbacks([fallback_ref]))

--- a/backend/tests/unit/test_llm_gateway_openai_compatible.py
+++ b/backend/tests/unit/test_llm_gateway_openai_compatible.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 from fastapi.testclient import TestClient
 
+from llm_gateway.gateway.config_loader import load_gateway_config
 from llm_gateway.gateway.executor import ProviderRegistry
-from llm_gateway.gateway.providers import FakeChatCompletionProvider
+from llm_gateway.gateway.providers import FakeChatCompletionProvider, ProviderFailure
+from llm_gateway.gateway.schemas import FailureClass
 from llm_gateway.main import app
 from llm_gateway.routers import dependencies
 from models.structured_extraction import ActionItemsExtraction, ConversationStructureExtraction
@@ -161,6 +163,41 @@ def test_chat_completions_fails_closed_when_openai_key_is_not_configured(monkeyp
 
     assert response.status_code == 503
     assert response.json()['error']['code'] == 'invalid_route_config'
+
+
+def test_streaming_provider_setup_failure_returns_json_error_before_streaming(monkeypatch):
+    monkeypatch.setenv('LLM_GATEWAY_SERVICE_TOKEN', 'shared-secret')
+    app.dependency_overrides[dependencies.get_gateway_config] = _streaming_enabled_gateway_config
+    app.dependency_overrides[dependencies.get_provider_registry] = lambda: ProviderRegistry(
+        {'openai': FailingStreamProvider()}
+    )
+    try:
+        response = TestClient(app).post('/v1/chat/completions', json=valid_request(stream=True), headers=auth_headers())
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 503
+    assert response.headers['content-type'].startswith('application/json')
+    assert response.json()['error']['code'] == 'invalid_route_config'
+
+
+class FailingStreamProvider(FakeChatCompletionProvider):
+    async def stream_chat_completion(self, *_args, **_kwargs):
+        raise ProviderFailure(FailureClass.INVALID_CONFIG)
+        yield b''
+
+
+def _streaming_enabled_gateway_config():
+    config = load_gateway_config(prod_mode=True)
+    lane = config.lanes[LANE_ID]
+    capabilities = lane.capabilities.model_copy(update={'streaming': True})
+    lane = lane.model_copy(update={'capabilities': capabilities})
+    route_artifacts = dict(config.route_artifacts)
+    for route_id in (lane.active_route, lane.last_known_good):
+        route_artifacts[route_id] = route_artifacts[route_id].model_copy(update={'capabilities': capabilities})
+    lanes = dict(config.lanes)
+    lanes[LANE_ID] = lane
+    return config.model_copy(update={'lanes': lanes, 'route_artifacts': route_artifacts})
 
 
 def auth_headers() -> dict[str, str]:

--- a/backend/tests/unit/test_llm_gateway_openai_provider.py
+++ b/backend/tests/unit/test_llm_gateway_openai_provider.py
@@ -47,6 +47,38 @@ async def test_openai_compatible_provider_posts_chat_completion(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_openai_compatible_provider_streams_chat_completion_bytes(monkeypatch):
+    monkeypatch.setenv('OPENAI_API_KEY', 'test-key')
+    seen_requests = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen_requests.append(request)
+        return httpx.Response(
+            200,
+            content=b'data: {"choices":[{"delta":{"content":"hi"}}]}\n\ndata: [DONE]\n\n',
+            headers={'content-type': 'text/event-stream'},
+        )
+
+    provider = OpenAICompatibleChatCompletionProvider(
+        http_client=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+    )
+
+    chunks = [
+        chunk
+        async for chunk in provider.stream_chat_completion(
+            {'model': 'gpt-4.1-mini', 'messages': [], 'stream': True},
+            provider_ref=ProviderRef(provider='openai', model='gpt-4.1-mini'),
+            credentials=build_omi_managed_credential_context(ServiceCaller(name='backend')),
+            timeout_ms=8000,
+        )
+    ]
+
+    assert b''.join(chunks).startswith(b'data:')
+    assert seen_requests[0].url == 'https://api.openai.com/v1/chat/completions'
+    assert seen_requests[0].headers['authorization'] == 'Bearer test-key'
+
+
+@pytest.mark.asyncio
 async def test_openai_compatible_provider_closes_owned_http_client():
     provider = OpenAICompatibleChatCompletionProvider()
 

--- a/backend/tests/unit/test_llm_gateway_openai_provider.py
+++ b/backend/tests/unit/test_llm_gateway_openai_provider.py
@@ -6,6 +6,7 @@ import pytest
 from llm_gateway.gateway.auth import ServiceCaller
 from llm_gateway.gateway.credentials import build_byok_credential_context, build_omi_managed_credential_context
 from llm_gateway.gateway.providers import (
+    AnthropicMessagesProvider,
     MAX_RESPONSE_BYTES_ENV_VAR,
     OpenAICompatibleChatCompletionProvider,
     ProviderFailure,
@@ -76,6 +77,43 @@ async def test_openai_compatible_provider_streams_chat_completion_bytes(monkeypa
     assert b''.join(chunks).startswith(b'data:')
     assert seen_requests[0].url == 'https://api.openai.com/v1/chat/completions'
     assert seen_requests[0].headers['authorization'] == 'Bearer test-key'
+
+
+@pytest.mark.asyncio
+async def test_anthropic_provider_flattens_system_text_parts_and_normalizes_finish_reason(monkeypatch):
+    monkeypatch.setenv('ANTHROPIC_API_KEY', 'test-key')
+    seen_requests = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen_requests.append(request)
+        return httpx.Response(
+            200,
+            json={
+                'id': 'msg_test',
+                'content': [{'type': 'text', 'text': 'ok'}],
+                'stop_reason': 'end_turn',
+            },
+        )
+
+    provider = AnthropicMessagesProvider(
+        http_client=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+    )
+
+    response = await provider.create_chat_completion(
+        {
+            'model': 'claude-sonnet-4-6',
+            'messages': [
+                {'role': 'system', 'content': [{'type': 'text', 'text': 'A'}, {'type': 'text', 'text': 'B'}]},
+                {'role': 'user', 'content': 'hello'},
+            ],
+        },
+        provider_ref=ProviderRef(provider='anthropic', model='claude-sonnet-4-6'),
+        credentials=build_omi_managed_credential_context(ServiceCaller(name='backend')),
+        timeout_ms=8000,
+    )
+
+    assert b'"system":"A\\nB"' in seen_requests[0].content
+    assert response['choices'][0]['finish_reason'] == 'stop'
 
 
 @pytest.mark.asyncio

--- a/backend/tests/unit/test_llm_gateway_readiness.py
+++ b/backend/tests/unit/test_llm_gateway_readiness.py
@@ -6,6 +6,7 @@ from llm_gateway.gateway.config_loader import ConfigValidationError
 from llm_gateway.gateway.schemas import LaneConfig
 from llm_gateway.main import app
 from llm_gateway.routers import health
+from utils.llm.model_config import get_all_configured_features
 
 
 def test_ready_requires_service_auth(monkeypatch):
@@ -24,8 +25,9 @@ def test_ready_validates_gateway_config(monkeypatch):
 
     assert response.status_code == 200
     assert response.json()['status'] == 'ready'
-    assert response.json()['lanes'] == ['omi:auto:chat-structured']
-    assert response.json()['route_artifact_count'] == 2
+    assert 'omi:auto:chat-structured' in response.json()['lanes']
+    assert len(response.json()['lanes']) >= len(get_all_configured_features())
+    assert response.json()['route_artifact_count'] >= len(get_all_configured_features()) + 2
 
 
 def test_ready_fails_closed_on_invalid_gateway_config(monkeypatch):

--- a/backend/tests/unit/test_llm_gateway_service.py
+++ b/backend/tests/unit/test_llm_gateway_service.py
@@ -1,9 +1,8 @@
-from fastapi.testclient import TestClient
 import pytest
+from fastapi.testclient import TestClient
 
 from llm_gateway import main
-from llm_gateway.main import app, lifespan
-from llm_gateway.routers import openai_compatible
+from llm_gateway.main import app
 
 
 def test_llm_gateway_app_imports_and_health_is_public():
@@ -26,10 +25,10 @@ async def test_lifespan_runs_registry_cleanup_when_image_cleanup_fails(monkeypat
     async def close_registry():
         calls.append('registry')
 
-    monkeypatch.setattr(openai_compatible, 'close_image_generation_client', fail_image_cleanup)
+    monkeypatch.setattr(main.openai_compatible, 'close_image_generation_client', fail_image_cleanup)
     monkeypatch.setattr(main, 'close_provider_registry', close_registry)
 
-    async with lifespan(app):
+    async with main.lifespan(app):
         pass
 
     assert calls == ['image', 'registry']

--- a/backend/tests/unit/test_llm_gateway_service.py
+++ b/backend/tests/unit/test_llm_gateway_service.py
@@ -1,6 +1,9 @@
 from fastapi.testclient import TestClient
+import pytest
 
-from llm_gateway.main import app
+from llm_gateway import main
+from llm_gateway.main import app, lifespan
+from llm_gateway.routers import openai_compatible
 
 
 def test_llm_gateway_app_imports_and_health_is_public():
@@ -10,3 +13,23 @@ def test_llm_gateway_app_imports_and_health_is_public():
 
     assert response.status_code == 200
     assert response.json() == {'status': 'healthy'}
+
+
+@pytest.mark.asyncio
+async def test_lifespan_runs_registry_cleanup_when_image_cleanup_fails(monkeypatch):
+    calls = []
+
+    async def fail_image_cleanup():
+        calls.append('image')
+        raise RuntimeError('image cleanup failed')
+
+    async def close_registry():
+        calls.append('registry')
+
+    monkeypatch.setattr(openai_compatible, 'close_image_generation_client', fail_image_cleanup)
+    monkeypatch.setattr(main, 'close_provider_registry', close_registry)
+
+    async with lifespan(app):
+        pass
+
+    assert calls == ['image', 'registry']

--- a/backend/tests/unit/test_llm_gateway_validator.py
+++ b/backend/tests/unit/test_llm_gateway_validator.py
@@ -19,6 +19,27 @@ def test_accepts_non_streaming_text_messages_with_json_schema_output():
     assert validated.response_format['type'] == 'json_schema'
 
 
+def test_accepts_prompt_parser_style_request_without_response_format():
+    lane = load_gateway_config(prod_mode=True).lanes[LANE_ID]
+    request = valid_request()
+    request.pop('response_format')
+
+    validated = validate_chat_completion_request(request, lane)
+
+    assert validated.model == LANE_ID
+    assert len(validated.messages) == 2
+    assert validated.response_format is None
+
+
+def test_forwards_prompt_cache_key():
+    lane = load_gateway_config(prod_mode=True).lanes[LANE_ID]
+    request = valid_request(prompt_cache_key='omi-extract-actions')
+
+    validated = validate_chat_completion_request(request, lane)
+
+    assert validated.forwarded_params['prompt_cache_key'] == 'omi-extract-actions'
+
+
 def test_rejects_streaming():
     lane = load_gateway_config(prod_mode=True).lanes[LANE_ID]
     request = valid_request(stream=True)

--- a/backend/tests/unit/test_prompt_cache_integration.py
+++ b/backend/tests/unit/test_prompt_cache_integration.py
@@ -127,6 +127,10 @@ gateway_mod = _stub_module("utils.llm.gateway_client")
 gateway_mod.invoke_chat_structured_gateway = MagicMock(return_value=None)
 gateway_mod.is_auto_lane_id = lambda value: isinstance(value, str) and value.startswith('omi:auto:')
 gateway_mod.record_chat_extraction_gateway_result = MagicMock()
+gateway_mod.raise_if_gateway_feature_mode_blocks_direct_model_surface = MagicMock()
+
+gateway_shadow_mod = _stub_module("utils.llm.gateway_shadow")
+gateway_shadow_mod.maybe_wrap_dev_gateway_shadow = MagicMock(side_effect=lambda legacy_model, **_kwargs: legacy_model)
 
 # --- langchain core stubs ---
 langchain_core_mod = _stub_module("langchain_core")

--- a/backend/tests/unit/test_sync_v2.py
+++ b/backend/tests/unit/test_sync_v2.py
@@ -2375,6 +2375,12 @@ class TestTimeoutConfiguration:
         with open(path, encoding='utf-8') as f:
             return f.read()
 
+    @staticmethod
+    def _read_llm_providers_source():
+        path = os.path.join(os.path.dirname(__file__), '..', '..', 'utils', 'llm', 'providers.py')
+        with open(path, encoding='utf-8') as f:
+            return f.read()
+
     def test_llm_mini_has_timeout(self):
         source = self._read_clients_source()
         llm_mini_line = [l for l in source.split('\n') if 'llm_mini' in l and 'ChatOpenAI' in l][0]
@@ -2404,12 +2410,12 @@ class TestTimeoutConfiguration:
         assert "'max_retries': 1" in func_body
 
     def test_classifier_llm_has_timeout(self):
-        source = self._read_classifier_source()
-        start = source.index('_classifier_llm')
-        end = source.index('\n', source.index(')', start))
-        constructor_call = source[start:end]
-        assert 'request_timeout=120' in constructor_call
-        assert 'max_retries=1' in constructor_call
+        classifier_source = self._read_classifier_source()
+        providers_source = self._read_llm_providers_source()
+
+        assert "get_llm('fair_use')" in classifier_source
+        assert "'request_timeout': options.get('request_timeout', 120)" in providers_source
+        assert "'max_retries': options.get('max_retries', 1)" in providers_source
 
     def test_dg_timeout_read_within_budget(self):
         """DG read timeout must be <= 150s so 2 attempts fit within 300s segment budget."""

--- a/backend/utils/llm/app_generator.py
+++ b/backend/utils/llm/app_generator.py
@@ -8,10 +8,10 @@ import base64
 import httpx
 from typing import Optional
 from pydantic import BaseModel
-from openai import OpenAI
 
 from langchain_core.messages import SystemMessage, HumanMessage
 from utils.llm.clients import get_llm
+from utils.llm.gateway_client import generate_image_via_gateway
 
 # App categories available in the system
 APP_CATEGORIES = [
@@ -153,8 +153,6 @@ async def generate_app_icon(app_name: str, app_description: str, category: str) 
     Returns:
         PNG image bytes of the generated icon
     """
-    client = OpenAI()
-
     # Create a prompt for icon generation
     icon_prompt = f"""Create a modern, minimal app icon for an AI app called "{app_name}".
 
@@ -171,12 +169,12 @@ Design requirements:
 - Vibrant but not overwhelming colors
 - Style: Similar to modern iOS/Android app icons"""
 
-    response = client.images.generate(
+    response = generate_image_via_gateway(
         model="dall-e-3", prompt=icon_prompt, size="1024x1024", quality="standard", n=1, response_format="b64_json"
     )
 
     # Get the base64 image data and decode it
-    image_data = response.data[0].b64_json
+    image_data = response["data"][0]["b64_json"]
     return base64.b64decode(image_data)
 
 

--- a/backend/utils/llm/app_generator.py
+++ b/backend/utils/llm/app_generator.py
@@ -5,14 +5,16 @@ Generates app configuration from a natural language prompt using LLM
 
 import json
 import base64
+import re
 import httpx
 from typing import Optional
 from pydantic import BaseModel
+from openai import OpenAI
 
 from langchain_core.messages import SystemMessage, HumanMessage
 from utils.executors import llm_executor, run_blocking
 from utils.llm.clients import get_llm
-from utils.llm.gateway_client import generate_image_via_gateway
+from utils.llm.gateway_client import generate_image_via_gateway, should_route_features_through_gateway
 
 # App categories available in the system
 APP_CATEGORIES = [
@@ -123,8 +125,6 @@ async def generate_app_from_prompt(user_prompt: str) -> GeneratedAppData:
         app_data = json.loads(content)
     except json.JSONDecodeError:
         # Try to extract JSON from the response
-        import re
-
         json_match = re.search(r'\{[\s\S]*\}', content)
         if json_match:
             app_data = json.loads(json_match.group())
@@ -166,9 +166,16 @@ Design requirements:
 - Simple geometric shapes or abstract representation
 - Professional and polished look
 - Should work well at small sizes (app icon)
-- No text or letters in the icon
-- Vibrant but not overwhelming colors
-- Style: Similar to modern iOS/Android app icons"""
+    - No text or letters in the icon
+    - Vibrant but not overwhelming colors
+    - Style: Similar to modern iOS/Android app icons"""
+
+    if not should_route_features_through_gateway():
+        return await run_blocking(
+            llm_executor,
+            _generate_app_icon_via_openai,
+            icon_prompt,
+        )
 
     response = await run_blocking(
         llm_executor,
@@ -183,6 +190,15 @@ Design requirements:
 
     # Get the base64 image data and decode it
     image_data = response["data"][0]["b64_json"]
+    return base64.b64decode(image_data)
+
+
+def _generate_app_icon_via_openai(icon_prompt: str) -> bytes:
+    client = OpenAI()
+    response = client.images.generate(
+        model="dall-e-3", prompt=icon_prompt, size="1024x1024", quality="standard", n=1, response_format="b64_json"
+    )
+    image_data = response.data[0].b64_json
     return base64.b64decode(image_data)
 
 

--- a/backend/utils/llm/app_generator.py
+++ b/backend/utils/llm/app_generator.py
@@ -10,6 +10,7 @@ from typing import Optional
 from pydantic import BaseModel
 
 from langchain_core.messages import SystemMessage, HumanMessage
+from utils.executors import llm_executor, run_blocking
 from utils.llm.clients import get_llm
 from utils.llm.gateway_client import generate_image_via_gateway
 
@@ -169,8 +170,15 @@ Design requirements:
 - Vibrant but not overwhelming colors
 - Style: Similar to modern iOS/Android app icons"""
 
-    response = generate_image_via_gateway(
-        model="dall-e-3", prompt=icon_prompt, size="1024x1024", quality="standard", n=1, response_format="b64_json"
+    response = await run_blocking(
+        llm_executor,
+        generate_image_via_gateway,
+        model="dall-e-3",
+        prompt=icon_prompt,
+        size="1024x1024",
+        quality="standard",
+        n=1,
+        response_format="b64_json",
     )
 
     # Get the base64 image data and decode it

--- a/backend/utils/llm/chat.py
+++ b/backend/utils/llm/chat.py
@@ -20,8 +20,6 @@ from models.conversation_photo import ConversationPhoto
 from models.structured import ActionItem, Event
 from models.other import Person
 from models.transcript_segment import TranscriptSegment
-from utils.byok import has_byok_keys
-from utils.llm.gateway_client import invoke_chat_structured_gateway, record_chat_extraction_gateway_result
 from utils.llms.memory import get_prompt_memories
 from utils.llm.usage_tracker import track_usage, Features
 
@@ -103,7 +101,6 @@ class DatesContext(BaseModel):
 
 
 def requires_context(question: str) -> bool:
-    feature = 'chat_extraction.requires_context'
     prompt = f'''
     Based on the current question your task is to determine whether the user is asking a question that requires context outside the conversation to be answered.
     Take as example: if the user is saying "Hi", "Hello", "How are you?", "Good morning", etc, the answer is False.
@@ -111,13 +108,6 @@ def requires_context(question: str) -> bool:
     User's Question:
     {question}
     '''
-    if not has_byok_keys():
-        gateway_response = invoke_chat_structured_gateway(prompt, RequiresContext, feature=feature)
-        if gateway_response is not None:
-            return gateway_response.value
-    else:
-        record_chat_extraction_gateway_result(feature=feature, outcome='skipped', reason='byok')
-
     with_parser = get_llm('chat_extraction').with_structured_output(RequiresContext)
     response: RequiresContext = with_parser.invoke(prompt)
     try:

--- a/backend/utils/llm/clients.py
+++ b/backend/utils/llm/clients.py
@@ -46,12 +46,42 @@ from utils.llm.providers import (
     GEMINI_OPENAI_BASE_URL,
     get_default_client,
     get_or_create_gemini_llm as _get_or_create_gemini_llm,
-    get_or_create_omi_gateway_llm,
     get_or_create_openai_compatible_llm,
     _llm_cache,
 )
-from utils.llm.gateway_client import CHAT_STRUCTURED_AUTO_LANE_ID
-from utils.llm.gateway_shadow import maybe_wrap_dev_gateway_shadow
+
+try:
+    from utils.llm.providers import get_or_create_omi_gateway_llm
+except ImportError:
+
+    def get_or_create_omi_gateway_llm(*_args, **_kwargs):
+        raise RuntimeError('Omi gateway LangChain client is unavailable')
+
+
+try:
+    from utils.llm.gateway_client import (
+        CHAT_STRUCTURED_AUTO_LANE_ID,
+        feature_auto_lane_id,
+        should_route_features_through_gateway,
+    )
+except ImportError:
+    CHAT_STRUCTURED_AUTO_LANE_ID = 'omi:auto:chat-structured'
+
+    def feature_auto_lane_id(feature: str) -> str:
+        return f"omi:auto:{feature.replace('_', '-')}"
+
+    def should_route_features_through_gateway() -> bool:
+        return False
+
+
+try:
+    from utils.llm.gateway_shadow import maybe_wrap_dev_gateway_shadow
+except ImportError:
+
+    def maybe_wrap_dev_gateway_shadow(*, legacy_model, **_kwargs):
+        return legacy_model
+
+
 from utils.llm.usage_tracker import get_usage_callback
 
 logger = logging.getLogger(__name__)
@@ -273,22 +303,24 @@ def get_llm(feature: str, streaming: bool = False, cache_key: Optional[str] = No
     providers. Returns a BaseChatModel. For Anthropic/Perplexity, use
     get_model(feature) to get the model string and the provider-specific client.
     """
-    if is_anthropic_only_feature(feature):
+    gateway_feature_mode = should_route_features_through_gateway()
+
+    if is_anthropic_only_feature(feature) and not gateway_feature_mode:
         raise ValueError(
             f"Feature '{feature}' is Anthropic — use get_model('{feature}') with anthropic_client instead of get_llm()"
         )
-    if is_perplexity_only_feature(feature):
+    if is_perplexity_only_feature(feature) and not gateway_feature_mode:
         raise ValueError(
             f"Feature '{feature}' is Perplexity — use get_model('{feature}') with the Perplexity HTTP client instead of get_llm()"
         )
 
     model, provider = _get_model_config(feature)
 
-    if provider == 'anthropic':
+    if provider == 'anthropic' and not gateway_feature_mode:
         raise ValueError(
             f"Feature '{feature}' resolved to Anthropic model '{model}' — use get_model() with anthropic_client"
         )
-    if provider == 'perplexity':
+    if provider == 'perplexity' and not gateway_feature_mode:
         raise ValueError(
             f"Feature '{feature}' resolved to Perplexity model '{model}' — use get_model() with Perplexity HTTP client"
         )
@@ -321,6 +353,8 @@ def get_llm(feature: str, streaming: bool = False, cache_key: Optional[str] = No
             if byok_client is not None
             else get_default_client(model, provider, streaming, get_route_options(feature, model, provider))
         )
+    elif gateway_feature_mode:
+        result = get_or_create_omi_gateway_llm(feature_auto_lane_id(feature), streaming)
     else:
         result = get_default_client(model, provider, streaming, get_route_options(feature, model, provider))
 

--- a/backend/utils/llm/clients.py
+++ b/backend/utils/llm/clients.py
@@ -62,6 +62,7 @@ try:
     from utils.llm.gateway_client import (
         CHAT_STRUCTURED_AUTO_LANE_ID,
         feature_auto_lane_id,
+        raise_if_gateway_feature_mode_blocks_direct_model_surface,
         should_route_features_through_gateway,
     )
 except ImportError:
@@ -72,6 +73,9 @@ except ImportError:
 
     def should_route_features_through_gateway() -> bool:
         return False
+
+    def raise_if_gateway_feature_mode_blocks_direct_model_surface(_surface: str) -> None:
+        return None
 
 
 try:
@@ -345,6 +349,9 @@ def get_llm(feature: str, streaming: bool = False, cache_key: Optional[str] = No
             logger.debug('BYOK QoS upgrade: feature=%s %s/%s→%s/%s', feature, model, provider, byok_model, byok_prov)
             model, provider = byok_model, byok_prov
             byok_key = byok_key_for_profile
+
+    if byok_key and gateway_feature_mode:
+        raise_if_gateway_feature_mode_blocks_direct_model_surface(f'get_llm.{feature}.byok')
 
     if byok_key:
         byok_client = _create_byok_client(model, provider, byok_key, streaming, feature)

--- a/backend/utils/llm/clients.py
+++ b/backend/utils/llm/clients.py
@@ -403,7 +403,11 @@ def get_llm_gateway_chat_structured(
     result = get_or_create_omi_gateway_llm(
         CHAT_STRUCTURED_AUTO_LANE_ID,
         streaming,
-        options={'request_timeout': request_timeout or BACKGROUND_CHAT_EXTRACTION_TIMEOUT_SECONDS},
+        options={
+            'request_timeout': (
+                request_timeout if request_timeout is not None else BACKGROUND_CHAT_EXTRACTION_TIMEOUT_SECONDS
+            )
+        },
     )
     if cache_key:
         return result.bind(prompt_cache_key=cache_key)

--- a/backend/utils/llm/clients.py
+++ b/backend/utils/llm/clients.py
@@ -52,7 +52,9 @@ from utils.llm.providers import (
 
 try:
     from utils.llm.providers import get_or_create_omi_gateway_llm
-except ImportError:
+except ImportError as exc:
+    if exc.name != 'utils.llm.providers' and 'get_or_create_omi_gateway_llm' not in str(exc):
+        raise
 
     def get_or_create_omi_gateway_llm(*_args, **_kwargs):
         raise RuntimeError('Omi gateway LangChain client is unavailable')
@@ -60,12 +62,17 @@ except ImportError:
 
 try:
     from utils.llm.gateway_client import (
+        BACKGROUND_CHAT_EXTRACTION_TIMEOUT_SECONDS,
         CHAT_STRUCTURED_AUTO_LANE_ID,
         feature_auto_lane_id,
         raise_if_gateway_feature_mode_blocks_direct_model_surface,
         should_route_features_through_gateway,
     )
-except ImportError:
+except ImportError as exc:
+    if exc.name != 'utils.llm.gateway_client':
+        raise
+
+    BACKGROUND_CHAT_EXTRACTION_TIMEOUT_SECONDS = 35.0
     CHAT_STRUCTURED_AUTO_LANE_ID = 'omi:auto:chat-structured'
 
     def feature_auto_lane_id(feature: str) -> str:
@@ -80,7 +87,9 @@ except ImportError:
 
 try:
     from utils.llm.gateway_shadow import maybe_wrap_dev_gateway_shadow
-except ImportError:
+except ImportError as exc:
+    if exc.name != 'utils.llm.gateway_shadow':
+        raise
 
     def maybe_wrap_dev_gateway_shadow(*, legacy_model, **_kwargs):
         return legacy_model
@@ -378,7 +387,11 @@ def get_llm(feature: str, streaming: bool = False, cache_key: Optional[str] = No
     return result
 
 
-def get_llm_gateway_chat_structured(streaming: bool = False, cache_key: Optional[str] = None) -> BaseChatModel:
+def get_llm_gateway_chat_structured(
+    streaming: bool = False,
+    cache_key: Optional[str] = None,
+    request_timeout: float | None = None,
+) -> BaseChatModel:
     """Return the gateway chat-structured lane as a LangChain chat model.
 
     Use this for shadow/eval comparisons that must preserve the existing
@@ -387,7 +400,11 @@ def get_llm_gateway_chat_structured(streaming: bool = False, cache_key: Optional
     gateway provider for that feature.
     """
 
-    result = get_or_create_omi_gateway_llm(CHAT_STRUCTURED_AUTO_LANE_ID, streaming)
+    result = get_or_create_omi_gateway_llm(
+        CHAT_STRUCTURED_AUTO_LANE_ID,
+        streaming,
+        options={'request_timeout': request_timeout or BACKGROUND_CHAT_EXTRACTION_TIMEOUT_SECONDS},
+    )
     if cache_key:
         return result.bind(prompt_cache_key=cache_key)
     return result

--- a/backend/utils/llm/clients.py
+++ b/backend/utils/llm/clients.py
@@ -51,6 +51,7 @@ from utils.llm.providers import (
     _llm_cache,
 )
 from utils.llm.gateway_client import CHAT_STRUCTURED_AUTO_LANE_ID
+from utils.llm.gateway_shadow import maybe_wrap_dev_gateway_shadow
 from utils.llm.usage_tracker import get_usage_callback
 
 logger = logging.getLogger(__name__)
@@ -322,6 +323,14 @@ def get_llm(feature: str, streaming: bool = False, cache_key: Optional[str] = No
         )
     else:
         result = get_default_client(model, provider, streaming, get_route_options(feature, model, provider))
+
+    result = maybe_wrap_dev_gateway_shadow(
+        feature=feature,
+        model=model,
+        provider=provider,
+        streaming=streaming,
+        legacy_model=result,
+    )
 
     if cache_key and supports_prompt_cache(model):
         return result.bind(prompt_cache_key=cache_key)

--- a/backend/utils/llm/clients.py
+++ b/backend/utils/llm/clients.py
@@ -46,9 +46,11 @@ from utils.llm.providers import (
     GEMINI_OPENAI_BASE_URL,
     get_default_client,
     get_or_create_gemini_llm as _get_or_create_gemini_llm,
+    get_or_create_omi_gateway_llm,
     get_or_create_openai_compatible_llm,
     _llm_cache,
 )
+from utils.llm.gateway_client import CHAT_STRUCTURED_AUTO_LANE_ID
 from utils.llm.usage_tracker import get_usage_callback
 
 logger = logging.getLogger(__name__)
@@ -322,6 +324,21 @@ def get_llm(feature: str, streaming: bool = False, cache_key: Optional[str] = No
         result = get_default_client(model, provider, streaming, get_route_options(feature, model, provider))
 
     if cache_key and supports_prompt_cache(model):
+        return result.bind(prompt_cache_key=cache_key)
+    return result
+
+
+def get_llm_gateway_chat_structured(streaming: bool = False, cache_key: Optional[str] = None) -> BaseChatModel:
+    """Return the gateway chat-structured lane as a LangChain chat model.
+
+    Use this for shadow/eval comparisons that must preserve the existing
+    LangChain prompt and parser chain shape. Live feature routing should still
+    go through ``get_llm(feature)`` until an explicit rollout promotes the
+    gateway provider for that feature.
+    """
+
+    result = get_or_create_omi_gateway_llm(CHAT_STRUCTURED_AUTO_LANE_ID, streaming)
+    if cache_key:
         return result.bind(prompt_cache_key=cache_key)
     return result
 

--- a/backend/utils/llm/conversation_processing.py
+++ b/backend/utils/llm/conversation_processing.py
@@ -15,14 +15,10 @@ from models.calendar_context import CalendarMeetingContext
 from models.conversation import Conversation
 from models.conversation_photo import ConversationPhoto
 from models.structured import ActionItem, Event, Structured
-from models.structured_extraction import ActionItemsExtraction, ConversationStructureExtraction, StructuredExtraction
-from .clients import get_llm, parser
+from models.structured_extraction import ActionItemsExtraction, StructuredExtraction
+from .clients import get_llm, get_llm_gateway_chat_structured, parser
 from utils.byok import has_byok_keys
-from utils.llm.gateway_client import (
-    BACKGROUND_CHAT_EXTRACTION_TIMEOUT_SECONDS,
-    invoke_chat_structured_gateway,
-    record_chat_extraction_gateway_result,
-)
+from utils.llm.gateway_client import record_chat_extraction_gateway_result
 from utils.llm.conversation_folder import FolderAssignment, assign_conversation_to_folder, build_folders_context
 from utils.llm.gateway_observability import record_gateway_shadow_comparison
 import logging
@@ -50,17 +46,17 @@ class SpeakerIdMatch(BaseModel):
     speaker_id: int = Field(description="The speaker id assigned to the segment")
 
 
-def _invoke_gateway_unless_byok(
-    prompt: str,
-    output_model: type[BaseModel],
-    *,
-    feature: str,
-    timeout_seconds: float = BACKGROUND_CHAT_EXTRACTION_TIMEOUT_SECONDS,
-) -> BaseModel | None:
+def _invoke_gateway_shadow_chain(chain, values: dict, *, feature: str) -> BaseModel | None:
     if has_byok_keys():
         record_chat_extraction_gateway_result(feature=feature, outcome='skipped', reason='byok')
         return None
-    return invoke_chat_structured_gateway(prompt, output_model, feature=feature, timeout_seconds=timeout_seconds)
+    try:
+        response = chain.invoke(values)
+    except Exception:
+        record_chat_extraction_gateway_result(feature=feature, outcome='fallback', reason='unexpected_error')
+        return None
+    record_chat_extraction_gateway_result(feature=feature, outcome='success', reason='ok')
+    return response
 
 
 def _word_count(text: str) -> int:
@@ -248,7 +244,7 @@ def _length_ratio_bucket(left: object, right: object) -> str:
 
 
 def _record_conversation_structure_shadow_comparison(
-    gateway_response: ConversationStructureExtraction | None,
+    gateway_response: Structured | None,
     legacy_response: Structured,
 ) -> None:
     if gateway_response is None:
@@ -373,21 +369,27 @@ def _record_conversation_action_items_shadow_comparison(
     )
 
 
-def _run_conversation_structure_shadow(prompt: str, legacy_response: Structured) -> None:
-    gateway_response = _invoke_gateway_unless_byok(
-        prompt,
-        ConversationStructureExtraction,
+def _run_conversation_structure_shadow(prompt, prompt_values: dict, legacy_response: Structured) -> None:
+    gateway_chain = prompt | get_llm_gateway_chat_structured(cache_key='omi-transcript-structure') | parser
+    gateway_response = _invoke_gateway_shadow_chain(
+        gateway_chain,
+        prompt_values,
         feature=CONVERSATION_STRUCTURE_SHADOW_FEATURE,
     )
-    _record_conversation_structure_shadow_comparison(gateway_response, legacy_response)
+    _record_conversation_structure_shadow_comparison(_coerce_structured(gateway_response), legacy_response)
 
 
 def _run_conversation_action_items_shadow(
-    prompt: str, legacy_response: List[ActionItem], user_tz, now: datetime
+    prompt, prompt_values: dict, legacy_response: List[ActionItem], user_tz, now: datetime
 ) -> None:
-    gateway_response = _invoke_gateway_unless_byok(
-        prompt,
-        ActionItemsExtraction,
+    gateway_chain = (
+        prompt
+        | get_llm_gateway_chat_structured(cache_key='omi-extract-actions')
+        | PydanticOutputParser(pydantic_object=ActionItemsExtraction)
+    )
+    gateway_response = _invoke_gateway_shadow_chain(
+        gateway_chain,
+        prompt_values,
         feature=CONVERSATION_ACTION_ITEMS_SHADOW_FEATURE,
     )
     _record_conversation_action_items_shadow_comparison(gateway_response, legacy_response, user_tz=user_tz, now=now)
@@ -424,24 +426,26 @@ def _submit_gateway_shadow(
     future.add_done_callback(_log_shadow_failure)
 
 
-def _submit_conversation_structure_shadow(prompt: str, legacy_response: Structured) -> None:
+def _submit_conversation_structure_shadow(prompt, prompt_values: dict, legacy_response: Structured) -> None:
     _submit_gateway_shadow(
         _run_conversation_structure_shadow,
         CONVERSATION_STRUCTURE_SHADOW_FEATURE,
         'conversation_structure',
         prompt,
+        prompt_values,
         legacy_response,
     )
 
 
 def _submit_conversation_action_items_shadow(
-    prompt: str, legacy_response: List[ActionItem], user_tz, now: datetime
+    prompt, prompt_values: dict, legacy_response: List[ActionItem], user_tz, now: datetime
 ) -> None:
     _submit_gateway_shadow(
         _run_conversation_action_items_shadow,
         CONVERSATION_ACTION_ITEMS_SHADOW_FEATURE,
         'conversation_action_items',
         prompt,
+        prompt_values,
         legacy_response,
         user_tz,
         now,
@@ -521,14 +525,6 @@ Content:
         'duration_context': duration_context,
         'format_instructions': custom_parser.get_format_instructions(),
     }
-
-    gateway_response = _invoke_gateway_unless_byok(
-        prompt_template.format(**prompt_values),
-        DiscardConversation,
-        feature='conversation_discard.should_discard',
-    )
-    if gateway_response is not None:
-        return gateway_response.discard
 
     prompt = ChatPromptTemplate.from_messages([prompt_template])
     chain = prompt | get_llm('conv_discard') | custom_parser
@@ -855,8 +851,6 @@ def extract_action_items(
         'existing_items_context': existing_items_context,
     }
 
-    shadow_prompt = f'{instructions_text.format(**prompt_values)}\n\n{context_message.format(**prompt_values)}'
-
     try:
         response = chain.invoke(prompt_values)
         action_items = _coerce_action_items(response)
@@ -871,7 +865,7 @@ def extract_action_items(
         _normalize_action_item_due_dates(action_items, user_tz=user_tz, now=now, log_past_due_clears=True)
 
         if _should_run_conversation_action_items_shadow('conversation_action_items', started_at, conversation_context):
-            _submit_conversation_action_items_shadow(shadow_prompt, action_items, user_tz, now)
+            _submit_conversation_action_items_shadow(prompt, prompt_values, action_items, user_tz, now)
 
         return action_items
 
@@ -972,13 +966,9 @@ def get_transcript_structure(
 
     response = _coerce_structured(chain.invoke(legacy_prompt_values))
     if _should_run_conversation_structure_shadow(uid, started_at, conversation_context):
-        structure_shadow_parser = PydanticOutputParser(pydantic_object=ConversationStructureExtraction)
-        shadow_prompt_values = {
-            **legacy_prompt_values,
-            'format_instructions': structure_shadow_parser.get_format_instructions(),
-        }
         _submit_conversation_structure_shadow(
-            f'{instructions_text.format(**shadow_prompt_values)}\n\n{context_message.format(**shadow_prompt_values)}',
+            prompt,
+            legacy_prompt_values,
             response,
         )
 

--- a/backend/utils/llm/fair_use_classifier.py
+++ b/backend/utils/llm/fair_use_classifier.py
@@ -12,18 +12,15 @@ from datetime import datetime, timedelta
 from typing import Optional
 
 import database.conversations as conversations_db
-from langchain_openai import ChatOpenAI
 from utils.executors import db_executor, run_blocking
-from utils.llm.usage_tracker import get_usage_callback
+from utils.llm.clients import get_llm
 
 logger = logging.getLogger(__name__)
 
 CLASSIFIER_MODEL = os.getenv('FAIR_USE_CLASSIFIER_MODEL', 'gpt-5.1')
-_classifier_llm = ChatOpenAI(
-    model=CLASSIFIER_MODEL, callbacks=[get_usage_callback()], request_timeout=120, max_retries=1
-)
 CLASSIFIER_LOOKBACK_DAYS = int(os.getenv('FAIR_USE_CLASSIFIER_LOOKBACK_DAYS', '7'))
 CLASSIFIER_MAX_CONVERSATIONS = 30
+_classifier_llm = None
 
 # ---------------------------------------------------------------------------
 # Prompt recipes for different non-personal usage scenarios
@@ -228,7 +225,8 @@ CONVERSATIONS:
 
 Respond with ONLY the JSON output, no other text."""
 
-        response = await _classifier_llm.ainvoke(
+        classifier_llm = _classifier_llm or get_llm('fair_use')
+        response = await classifier_llm.ainvoke(
             [
                 {"role": "system", "content": SYSTEM_PROMPT},
                 {"role": "user", "content": user_message},

--- a/backend/utils/llm/fair_use_classifier.py
+++ b/backend/utils/llm/fair_use_classifier.py
@@ -14,10 +14,11 @@ from typing import Optional
 import database.conversations as conversations_db
 from utils.executors import db_executor, run_blocking
 from utils.llm.clients import get_llm
+from utils.llm.model_config import get_model, get_provider
 
 logger = logging.getLogger(__name__)
 
-CLASSIFIER_MODEL = os.getenv('FAIR_USE_CLASSIFIER_MODEL', 'gpt-5.1')
+CLASSIFIER_ROUTE = f"{get_provider('fair_use')}/{get_model('fair_use')}"
 CLASSIFIER_LOOKBACK_DAYS = int(os.getenv('FAIR_USE_CLASSIFIER_LOOKBACK_DAYS', '7'))
 CLASSIFIER_MAX_CONVERSATIONS = 30
 _classifier_llm = None
@@ -204,7 +205,7 @@ async def classify_user_purpose(uid: str) -> dict:
         'usage_type': 'none',
         'confidence': 0.0,
         'evidence': [],
-        'model': CLASSIFIER_MODEL,
+        'model': CLASSIFIER_ROUTE,
         'prompt_version': 'v2',
     }
 
@@ -249,7 +250,7 @@ Respond with ONLY the JSON output, no other text."""
         result['confidence'] = max(0.0, min(1.0, float(result.get('confidence', 0.0))))
         result['usage_type'] = result.get('usage_type', 'none')
         result['evidence'] = result.get('evidence', [])[:10]  # Cap evidence entries
-        result['model'] = CLASSIFIER_MODEL
+        result['model'] = CLASSIFIER_ROUTE
         result['prompt_version'] = 'v2'
 
         return result

--- a/backend/utils/llm/gateway_client.py
+++ b/backend/utils/llm/gateway_client.py
@@ -20,6 +20,8 @@ DEFAULT_LLM_GATEWAY_URL = 'http://127.0.0.1:9080'
 LLM_GATEWAY_AUTO_LANE_PREFIX = 'omi:auto:'
 CHAT_STRUCTURED_AUTO_LANE_ID = 'omi:auto:chat-structured'
 LLM_GATEWAY_FEATURE_MODE_ENV_VAR = 'OMI_LLM_GATEWAY_FEATURE_MODE'
+LLM_GATEWAY_ALLOW_PROD_FEATURE_MODE_ENV_VAR = 'OMI_LLM_GATEWAY_ALLOW_PROD_FEATURE_MODE'
+LLM_GATEWAY_ALLOW_DIRECT_EXCEPTION_ENV_VAR = 'OMI_LLM_GATEWAY_ALLOW_DIRECT_MODEL_EXCEPTION'
 LLM_GATEWAY_CALLER = 'backend'
 CHAT_EXTRACTION_TIMEOUT_SECONDS = 10.0
 BACKGROUND_CHAT_EXTRACTION_TIMEOUT_SECONDS = 35.0
@@ -49,7 +51,42 @@ def feature_auto_lane_id(feature: str) -> str:
 
 
 def should_route_features_through_gateway() -> bool:
-    return os.getenv(LLM_GATEWAY_FEATURE_MODE_ENV_VAR, '').strip().lower() in {'1', 'true', 'yes', 'gateway'}
+    enabled = os.getenv(LLM_GATEWAY_FEATURE_MODE_ENV_VAR, '').strip().lower() in {'1', 'true', 'yes', 'gateway'}
+    if not enabled:
+        return False
+    if _is_local_or_dev_runtime():
+        return True
+    if os.getenv(LLM_GATEWAY_ALLOW_PROD_FEATURE_MODE_ENV_VAR, '').strip().lower() not in {'1', 'true', 'yes'}:
+        raise RuntimeError(
+            f'{LLM_GATEWAY_FEATURE_MODE_ENV_VAR}=gateway is blocked outside dev/local unless '
+            f'{LLM_GATEWAY_ALLOW_PROD_FEATURE_MODE_ENV_VAR}=true is set'
+        )
+    if not os.getenv(LLM_GATEWAY_URL_ENV_VAR, '').strip():
+        raise RuntimeError(
+            f'{LLM_GATEWAY_FEATURE_MODE_ENV_VAR}=gateway outside dev/local requires {LLM_GATEWAY_URL_ENV_VAR}'
+        )
+    return True
+
+
+def raise_if_gateway_feature_mode_blocks_direct_model_surface(surface: str) -> None:
+    if not should_route_features_through_gateway():
+        return
+    if os.getenv(LLM_GATEWAY_ALLOW_DIRECT_EXCEPTION_ENV_VAR, '').strip().lower() in {'1', 'true', 'yes'}:
+        return
+    raise RuntimeError(
+        f'{surface} is a direct provider LLM surface and is blocked while '
+        f'{LLM_GATEWAY_FEATURE_MODE_ENV_VAR}=gateway. Route it through the LLM gateway or set '
+        f'{LLM_GATEWAY_ALLOW_DIRECT_EXCEPTION_ENV_VAR}=true for an explicitly acknowledged exception.'
+    )
+
+
+def _is_local_or_dev_runtime() -> bool:
+    explicit_stage = os.getenv('OMI_ENV_STAGE') or os.getenv('ENVIRONMENT') or os.getenv('APP_ENV')
+    if explicit_stage and explicit_stage.strip().lower() in {'prod', 'production'}:
+        return False
+    if os.getenv('K_SERVICE') and not explicit_stage:
+        return False
+    return True
 
 
 def invoke_chat_structured_gateway(

--- a/backend/utils/llm/gateway_client.py
+++ b/backend/utils/llm/gateway_client.py
@@ -82,8 +82,8 @@ def raise_if_gateway_feature_mode_blocks_direct_model_surface(surface: str) -> N
 
 def _is_local_or_dev_runtime() -> bool:
     explicit_stage = os.getenv('OMI_ENV_STAGE') or os.getenv('ENVIRONMENT') or os.getenv('APP_ENV')
-    if explicit_stage and explicit_stage.strip().lower() in {'prod', 'production'}:
-        return False
+    if explicit_stage:
+        return explicit_stage.strip().lower() in {'dev', 'development', 'local', 'test'}
     if os.getenv('K_SERVICE') and not explicit_stage:
         return False
     return True

--- a/backend/utils/llm/gateway_client.py
+++ b/backend/utils/llm/gateway_client.py
@@ -19,6 +19,7 @@ LLM_GATEWAY_URL_ENV_VAR = 'OMI_LLM_GATEWAY_URL'
 DEFAULT_LLM_GATEWAY_URL = 'http://127.0.0.1:9080'
 LLM_GATEWAY_AUTO_LANE_PREFIX = 'omi:auto:'
 CHAT_STRUCTURED_AUTO_LANE_ID = 'omi:auto:chat-structured'
+LLM_GATEWAY_FEATURE_MODE_ENV_VAR = 'OMI_LLM_GATEWAY_FEATURE_MODE'
 LLM_GATEWAY_CALLER = 'backend'
 CHAT_EXTRACTION_TIMEOUT_SECONDS = 10.0
 BACKGROUND_CHAT_EXTRACTION_TIMEOUT_SECONDS = 35.0
@@ -41,6 +42,14 @@ def get_llm_gateway_service_token() -> str | None:
 
 def is_auto_lane_id(model_or_lane: object) -> bool:
     return isinstance(model_or_lane, str) and model_or_lane.startswith(LLM_GATEWAY_AUTO_LANE_PREFIX)
+
+
+def feature_auto_lane_id(feature: str) -> str:
+    return f"{LLM_GATEWAY_AUTO_LANE_PREFIX}{feature.replace('_', '-')}"
+
+
+def should_route_features_through_gateway() -> bool:
+    return os.getenv(LLM_GATEWAY_FEATURE_MODE_ENV_VAR, '').strip().lower() in {'1', 'true', 'yes', 'gateway'}
 
 
 def invoke_chat_structured_gateway(
@@ -237,3 +246,35 @@ def _validate_output_model(
 ) -> StructuredOutput:
     validate_json_schema(instance=decoded, schema=_strict_model_json_schema(output_model))
     return output_model.model_validate(decoded)
+
+
+def generate_image_via_gateway(
+    *,
+    model: str,
+    prompt: str,
+    size: str,
+    quality: str,
+    n: int,
+    response_format: str,
+    timeout_seconds: float = 120.0,
+) -> Mapping[str, object]:
+    """Call the gateway-owned image generation surface."""
+
+    with httpx.Client(timeout=timeout_seconds) as client:
+        response = client.post(
+            f'{get_llm_gateway_base_url()}/v1/images/generations',
+            headers=_gateway_headers(),
+            json={
+                'model': model,
+                'prompt': prompt,
+                'size': size,
+                'quality': quality,
+                'n': n,
+                'response_format': response_format,
+            },
+        )
+        response.raise_for_status()
+        body = response.json()
+    if not isinstance(body, Mapping):
+        raise ValueError('gateway image response must be an object')
+    return body

--- a/backend/utils/llm/gateway_client.py
+++ b/backend/utils/llm/gateway_client.py
@@ -84,7 +84,7 @@ def _is_local_or_dev_runtime() -> bool:
     explicit_stage = os.getenv('OMI_ENV_STAGE') or os.getenv('ENVIRONMENT') or os.getenv('APP_ENV')
     if explicit_stage:
         return explicit_stage.strip().lower() in {'dev', 'development', 'local', 'test'}
-    if os.getenv('K_SERVICE') and not explicit_stage:
+    if os.getenv('K_SERVICE') or os.getenv('KUBERNETES_SERVICE_HOST'):
         return False
     return True
 
@@ -159,6 +159,10 @@ def _gateway_headers() -> dict[str, str]:
     if service_token is not None:
         headers['Authorization'] = f'Bearer {service_token}'
     return headers
+
+
+def llm_gateway_headers() -> dict[str, str]:
+    return _gateway_headers()
 
 
 def _chat_structured_payload(prompt: str, output_model: type[BaseModel], *, feature: str) -> dict:

--- a/backend/utils/llm/gateway_shadow.py
+++ b/backend/utils/llm/gateway_shadow.py
@@ -4,14 +4,43 @@ import os
 import random
 from typing import Any
 
-from langchain_core.callbacks.manager import AsyncCallbackManagerForLLMRun, CallbackManagerForLLMRun
+try:
+    from langchain_core.callbacks.manager import AsyncCallbackManagerForLLMRun, CallbackManagerForLLMRun
+except ImportError:
+    try:
+        from langchain_core.callbacks import BaseCallbackHandler as CallbackManagerForLLMRun
+    except ImportError:
+        CallbackManagerForLLMRun = Any
+
+    AsyncCallbackManagerForLLMRun = CallbackManagerForLLMRun
 from langchain_core.language_models import BaseChatModel
-from langchain_core.messages import BaseMessage
-from langchain_core.outputs import ChatResult
-from langchain_core.runnables import Runnable
+
+try:
+    from langchain_core.messages import BaseMessage
+except ImportError:
+    BaseMessage = Any
+try:
+    from langchain_core.outputs import ChatResult
+except ImportError:
+    ChatResult = Any
+try:
+    from langchain_core.runnables import Runnable
+except ImportError:
+
+    class Runnable:
+        pass
+
+
 from pydantic import ConfigDict
 
-from utils.byok import has_byok_keys
+try:
+    from utils.byok import has_byok_keys
+except ImportError:
+
+    def has_byok_keys() -> bool:
+        return False
+
+
 from utils.executors import llm_executor, start_background_task, submit_with_context
 from utils.llm.gateway_client import CHAT_STRUCTURED_AUTO_LANE_ID
 from utils.llm.gateway_observability import record_gateway_request_result, record_gateway_shadow_comparison

--- a/backend/utils/llm/gateway_shadow.py
+++ b/backend/utils/llm/gateway_shadow.py
@@ -18,7 +18,7 @@ from langchain_core.language_models import BaseChatModel
 try:
     from langchain_core.messages import BaseMessage
 except ImportError:
-    BaseMessage = Any
+    BaseMessage = None
 try:
     from langchain_core.outputs import ChatResult
 except ImportError:
@@ -227,7 +227,7 @@ def _comparison_value(value: Any) -> Any:
         value = value.get('parsed')
     if hasattr(value, 'model_dump'):
         return value.model_dump(mode='json')
-    if isinstance(value, BaseMessage):
+    if BaseMessage is not None and isinstance(value, BaseMessage):
         return {'type': value.type, 'content': value.content}
     return value
 

--- a/backend/utils/llm/gateway_shadow.py
+++ b/backend/utils/llm/gateway_shadow.py
@@ -1,0 +1,207 @@
+from __future__ import annotations
+
+import os
+import random
+from typing import Any
+
+from langchain_core.callbacks.manager import AsyncCallbackManagerForLLMRun, CallbackManagerForLLMRun
+from langchain_core.language_models import BaseChatModel
+from langchain_core.messages import BaseMessage
+from langchain_core.outputs import ChatResult
+from langchain_core.runnables import Runnable
+from pydantic import ConfigDict
+
+from utils.byok import has_byok_keys
+from utils.executors import llm_executor, start_background_task, submit_with_context
+from utils.llm.gateway_client import CHAT_STRUCTURED_AUTO_LANE_ID
+from utils.llm.gateway_observability import record_gateway_request_result, record_gateway_shadow_comparison
+from utils.llm.providers import get_or_create_omi_gateway_llm
+
+DEV_SHADOW_ALL_ENABLED_ENV = 'OMI_LLM_GATEWAY_DEV_SHADOW_ALL_ENABLED'
+DEV_SHADOW_ALL_SAMPLE_RATE_ENV = 'OMI_LLM_GATEWAY_DEV_SHADOW_ALL_SAMPLE_RATE'
+
+_PROD_STAGE_VALUES = {'prod', 'production'}
+
+
+def maybe_wrap_dev_gateway_shadow(
+    *,
+    feature: str,
+    model: str,
+    provider: str,
+    streaming: bool,
+    legacy_model: BaseChatModel,
+) -> BaseChatModel:
+    if not _dev_shadow_enabled(provider=provider, streaming=streaming):
+        return legacy_model
+
+    gateway_model = get_or_create_omi_gateway_llm(CHAT_STRUCTURED_AUTO_LANE_ID, streaming=False)
+    return GatewayShadowChatModel(
+        feature=feature,
+        model_name=model,
+        provider=provider,
+        legacy_model=legacy_model,
+        gateway_model=gateway_model,
+    )
+
+
+def _dev_shadow_enabled(*, provider: str, streaming: bool) -> bool:
+    if streaming:
+        return False
+    if has_byok_keys():
+        return False
+    if _is_prod_like_runtime():
+        return False
+    if provider in {'anthropic', 'perplexity'}:
+        return False
+    if os.getenv(DEV_SHADOW_ALL_ENABLED_ENV, '').strip().casefold() not in {'1', 'true', 'yes', 'on'}:
+        return False
+    sample_rate = _sample_rate()
+    return sample_rate >= 1.0 or random.random() < sample_rate
+
+
+def _sample_rate() -> float:
+    value = os.getenv(DEV_SHADOW_ALL_SAMPLE_RATE_ENV, '1.0')
+    try:
+        return max(0.0, min(1.0, float(value)))
+    except ValueError:
+        return 0.0
+
+
+def _is_prod_like_runtime() -> bool:
+    stage = os.getenv('OMI_ENV_STAGE', '').strip().casefold()
+    if stage in _PROD_STAGE_VALUES:
+        return True
+    service = (os.getenv('K_SERVICE') or os.getenv('APP_NAME') or '').strip().casefold()
+    return service.startswith('prod-') or service.startswith('prod_') or service in _PROD_STAGE_VALUES
+
+
+class GatewayShadowChatModel(BaseChatModel):
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    feature: str
+    model_name: str
+    provider: str
+    legacy_model: BaseChatModel
+    gateway_model: BaseChatModel
+
+    @property
+    def _llm_type(self) -> str:
+        return f'{getattr(self.legacy_model, "_llm_type", "chat")}-omi-gateway-shadow'
+
+    def _generate(
+        self,
+        messages: list[BaseMessage],
+        stop: list[str] | None = None,
+        run_manager: CallbackManagerForLLMRun | None = None,
+        **kwargs: Any,
+    ) -> ChatResult:
+        result = self.legacy_model._generate(messages, stop=stop, run_manager=run_manager, **kwargs)
+        _submit_sync_shadow(
+            self.gateway_model._generate,
+            messages,
+            stop=stop,
+            feature=_shadow_feature(self.feature),
+            **kwargs,
+        )
+        return result
+
+    async def _agenerate(
+        self,
+        messages: list[BaseMessage],
+        stop: list[str] | None = None,
+        run_manager: AsyncCallbackManagerForLLMRun | None = None,
+        **kwargs: Any,
+    ) -> ChatResult:
+        result = await self.legacy_model._agenerate(messages, stop=stop, run_manager=run_manager, **kwargs)
+        start_background_task(
+            _run_async_shadow(
+                self.gateway_model._agenerate, messages, stop=stop, feature=_shadow_feature(self.feature), **kwargs
+            ),
+            name=f'llm-gateway-shadow:{self.feature}',
+        )
+        return result
+
+    def with_structured_output(self, schema: dict[str, Any] | type, *, include_raw: bool = False, **kwargs: Any):
+        legacy = self.legacy_model.with_structured_output(schema, include_raw=include_raw, **kwargs)
+        gateway = self.gateway_model.with_structured_output(schema, include_raw=include_raw, **kwargs)
+        return GatewayShadowRunnable(feature=_shadow_feature(self.feature), legacy=legacy, gateway=gateway)
+
+
+class GatewayShadowRunnable(Runnable):
+    def __init__(self, *, feature: str, legacy: Runnable, gateway: Runnable):
+        self._feature = feature
+        self._legacy = legacy
+        self._gateway = gateway
+
+    def invoke(self, input: Any, config=None, **kwargs: Any) -> Any:
+        result = self._legacy.invoke(input, config=config, **kwargs)
+        _submit_sync_shadow(
+            self._gateway.invoke, input, config=config, feature=self._feature, legacy_result=result, **kwargs
+        )
+        return result
+
+    async def ainvoke(self, input: Any, config=None, **kwargs: Any) -> Any:
+        result = await self._legacy.ainvoke(input, config=config, **kwargs)
+        start_background_task(
+            _run_async_shadow(
+                self._gateway.ainvoke,
+                input,
+                config=config,
+                feature=self._feature,
+                legacy_result=result,
+                **kwargs,
+            ),
+            name=f'llm-gateway-shadow:{self._feature}',
+        )
+        return result
+
+
+def _submit_sync_shadow(fn, *args, feature: str, legacy_result: Any = None, **kwargs: Any) -> None:
+    try:
+        submit_with_context(llm_executor, _run_sync_shadow, fn, args, kwargs, feature, legacy_result)
+    except Exception:
+        record_gateway_request_result(feature=feature, outcome='fallback', reason='submit_failed')
+
+
+def _run_sync_shadow(fn, args: tuple[Any, ...], kwargs: dict[str, Any], feature: str, legacy_result: Any) -> None:
+    try:
+        gateway_result = fn(*args, **kwargs)
+    except Exception:
+        record_gateway_request_result(feature=feature, outcome='fallback', reason='unexpected_error')
+        return
+    record_gateway_request_result(feature=feature, outcome='success', reason='ok')
+    _record_shadow_result_comparison(feature=feature, legacy_result=legacy_result, gateway_result=gateway_result)
+
+
+async def _run_async_shadow(fn, *args, feature: str, legacy_result: Any = None, **kwargs: Any) -> None:
+    try:
+        gateway_result = await fn(*args, **kwargs)
+    except Exception:
+        record_gateway_request_result(feature=feature, outcome='fallback', reason='unexpected_error')
+        return
+    record_gateway_request_result(feature=feature, outcome='success', reason='ok')
+    _record_shadow_result_comparison(feature=feature, legacy_result=legacy_result, gateway_result=gateway_result)
+
+
+def _record_shadow_result_comparison(*, feature: str, legacy_result: Any, gateway_result: Any) -> None:
+    if legacy_result is None:
+        return
+    record_gateway_shadow_comparison(
+        feature=feature,
+        field='parsed_result',
+        outcome='exact_match' if _comparison_value(legacy_result) == _comparison_value(gateway_result) else 'mismatch',
+    )
+
+
+def _comparison_value(value: Any) -> Any:
+    if isinstance(value, dict) and {'raw', 'parsed', 'parsing_error'} <= set(value):
+        value = value.get('parsed')
+    if hasattr(value, 'model_dump'):
+        return value.model_dump(mode='json')
+    if isinstance(value, BaseMessage):
+        return {'type': value.type, 'content': value.content}
+    return value
+
+
+def _shadow_feature(feature: str) -> str:
+    return f'{feature}.shadow'

--- a/backend/utils/llm/gateway_shadow.py
+++ b/backend/utils/llm/gateway_shadow.py
@@ -42,7 +42,7 @@ except ImportError:
 
 
 from utils.executors import llm_executor, start_background_task, submit_with_context
-from utils.llm.gateway_client import CHAT_STRUCTURED_AUTO_LANE_ID
+from utils.llm.gateway_client import BACKGROUND_CHAT_EXTRACTION_TIMEOUT_SECONDS, CHAT_STRUCTURED_AUTO_LANE_ID
 from utils.llm.gateway_observability import record_gateway_request_result, record_gateway_shadow_comparison
 from utils.llm.providers import get_or_create_omi_gateway_llm
 
@@ -63,7 +63,11 @@ def maybe_wrap_dev_gateway_shadow(
     if not _dev_shadow_enabled(provider=provider, streaming=streaming):
         return legacy_model
 
-    gateway_model = get_or_create_omi_gateway_llm(CHAT_STRUCTURED_AUTO_LANE_ID, streaming=False)
+    gateway_model = get_or_create_omi_gateway_llm(
+        CHAT_STRUCTURED_AUTO_LANE_ID,
+        streaming=False,
+        options={'request_timeout': BACKGROUND_CHAT_EXTRACTION_TIMEOUT_SECONDS},
+    )
     return GatewayShadowChatModel(
         feature=feature,
         model_name=model,

--- a/backend/utils/llm/model_config.py
+++ b/backend/utils/llm/model_config.py
@@ -211,7 +211,7 @@ MODEL_QOS_PROFILES: Dict[str, Dict[str, Tuple[str, str]]] = {
 
 # Pinned features — (model, provider) fixed regardless of profile or env override.
 _PINNED_FEATURES: Dict[str, Tuple[str, str]] = {
-    'fair_use': ('gpt-5.1', 'openai'),
+    'fair_use': (os.getenv('FAIR_USE_CLASSIFIER_MODEL', 'gpt-5.1').strip() or 'gpt-5.1', 'openai'),
 }
 
 # Resolve active profile once at startup.

--- a/backend/utils/llm/model_config.py
+++ b/backend/utils/llm/model_config.py
@@ -74,6 +74,8 @@ MODEL_QOS_PROFILES: Dict[str, Dict[str, Tuple[str, str]]] = {
         'memory_conflict': ('gpt-4.1-mini', 'openai'),
         'memory_category': ('gpt-4.1-nano', 'openai'),
         'knowledge_graph': ('gpt-4.1-mini', 'openai'),
+        'memory_l1': ('gpt-4.1-mini', 'openai'),
+        'memory_l2': ('gpt-4.1-mini', 'openai'),
         # OpenAI — chat
         'chat_responses': ('gpt-5.4-mini', 'openai'),
         'chat_extraction': ('gpt-4.1-mini', 'openai'),
@@ -124,6 +126,8 @@ MODEL_QOS_PROFILES: Dict[str, Dict[str, Tuple[str, str]]] = {
         'memory_conflict': ('gpt-4.1-mini', 'openai'),
         'memory_category': ('gpt-4.1-mini', 'openai'),
         'knowledge_graph': ('gpt-4.1-mini', 'openai'),
+        'memory_l1': ('gpt-4.1-mini', 'openai'),
+        'memory_l2': ('gpt-4.1-mini', 'openai'),
         # OpenAI — chat
         'chat_responses': ('gpt-5.4', 'openai'),
         'chat_extraction': ('gpt-4.1-mini', 'openai'),
@@ -173,6 +177,8 @@ MODEL_QOS_PROFILES: Dict[str, Dict[str, Tuple[str, str]]] = {
         'memory_conflict': ('gpt-4.1-mini', 'openai'),
         'memory_category': ('gpt-4.1-mini', 'openai'),
         'knowledge_graph': ('gpt-4.1-mini', 'openai'),
+        'memory_l1': ('gpt-4.1-mini', 'openai'),
+        'memory_l2': ('gpt-4.1-mini', 'openai'),
         # OpenAI — chat
         'chat_responses': ('gpt-5.4', 'openai'),
         'chat_extraction': ('gpt-4.1-mini', 'openai'),

--- a/backend/utils/llm/providers.py
+++ b/backend/utils/llm/providers.py
@@ -8,6 +8,7 @@ configuration decide which provider/model to use.
 
 import logging
 import os
+import hashlib
 from dataclasses import dataclass, field
 from typing import Any, Dict, Optional
 
@@ -16,6 +17,7 @@ from langchain_google_genai import ChatGoogleGenerativeAI
 from langchain_openai import ChatOpenAI
 from pydantic import SecretStr
 
+from utils.llm.gateway_client import get_llm_gateway_base_url, get_llm_gateway_service_token
 from utils.llm.usage_tracker import get_usage_callback
 
 logger = logging.getLogger(__name__)
@@ -111,6 +113,48 @@ def get_or_create_openai_compatible_llm(
             kwargs['stream_options'] = {"include_usage": True}
 
         _llm_cache[key] = ChatOpenAI(model=_api_model_name(provider_config, model_name), **kwargs)
+    return _llm_cache[key]
+
+
+def get_or_create_omi_gateway_llm(
+    lane_id: str,
+    streaming: bool = False,
+    options: Optional[Dict[str, Any]] = None,
+) -> ChatOpenAI:
+    """Get or create a cached LangChain chat model backed by the Omi LLM gateway."""
+
+    options = options or {}
+    base_url = f'{get_llm_gateway_base_url()}/v1'
+    service_token = get_llm_gateway_service_token()
+    default_headers = {'X-Omi-Service-Caller': 'backend'}
+    if service_token:
+        default_headers['Authorization'] = f'Bearer {service_token}'
+    service_token_cache_key = hashlib.sha256(service_token.encode()).hexdigest() if service_token else 'none'
+
+    key = _cache_key(
+        'omi_gateway',
+        lane_id,
+        streaming,
+        {
+            'base_url': base_url,
+            'service_token': service_token_cache_key,
+            'request_timeout': options.get('request_timeout', 120),
+            'max_retries': options.get('max_retries', 1),
+        },
+    )
+    if key not in _llm_cache:
+        kwargs: Dict[str, Any] = {
+            'api_key': SecretStr('omi-gateway'),
+            'base_url': base_url,
+            'callbacks': [_usage_callback],
+            'default_headers': default_headers,
+            'request_timeout': options.get('request_timeout', 120),
+            'max_retries': options.get('max_retries', 1),
+        }
+        if streaming:
+            kwargs['streaming'] = True
+            kwargs['stream_options'] = {"include_usage": True}
+        _llm_cache[key] = ChatOpenAI(model=lane_id, **kwargs)
     return _llm_cache[key]
 
 

--- a/backend/utils/memory_ingestion/adapters/production_like_model.py
+++ b/backend/utils/memory_ingestion/adapters/production_like_model.py
@@ -8,9 +8,9 @@ import re
 from typing import Iterable, Literal, Any, Callable
 
 from langchain_core.output_parsers import PydanticOutputParser
-from langchain_openai import ChatOpenAI
 from models.transcript_segment import TranscriptSegment
 from pydantic import BaseModel, Field
+from utils.llm.clients import get_llm
 from utils.prompts import extract_memories_prompt
 from utils.memory_ingestion.adapters.typed_extraction_prompt import (
     TYPED_PREDICATES,
@@ -773,10 +773,9 @@ def _memory_llm(temperature: float = 0.0):
         url_preview = base_url or "(default OpenAI)"
         print(f"[pipeline-llm] model={model}  base_url={url_preview}")
         _memory_llm_logged = True
-    kwargs: dict = dict(model=model, temperature=temperature, request_timeout=120, max_retries=1)
-    if base_url:
-        kwargs["base_url"] = base_url
-    return ChatOpenAI(**kwargs)
+    if temperature:
+        return get_llm("memories").bind(temperature=temperature)
+    return get_llm("memories")
 
 
 def _language_instruction(language: str | None) -> str:

--- a/backend/utils/memory_ingestion/adapters/production_like_model.py
+++ b/backend/utils/memory_ingestion/adapters/production_like_model.py
@@ -11,6 +11,7 @@ from langchain_core.output_parsers import PydanticOutputParser
 from models.transcript_segment import TranscriptSegment
 from pydantic import BaseModel, Field
 from utils.llm.clients import get_llm
+from utils.llm.model_config import get_model, get_provider
 from utils.prompts import extract_memories_prompt
 from utils.memory_ingestion.adapters.typed_extraction_prompt import (
     TYPED_PREDICATES,
@@ -766,14 +767,11 @@ _memory_llm_logged = False  # module-level flag: has the LLM endpoint been logge
 
 def _memory_llm(temperature: float = 0.0):
     global _memory_llm_logged
-    model = os.environ.get("OMI_MEMORY_PIPELINE_MODEL", "gpt-4.1-mini")
-    base_url = os.environ.get("OPENAI_BASE_URL", "")
     # Log resolved endpoint once for debuggability — catches credential mismatches early
     if not _memory_llm_logged:
-        url_preview = base_url or "(default OpenAI)"
-        print(f"[pipeline-llm] model={model}  base_url={url_preview}")
+        print(f"[pipeline-llm] feature=memories route={get_provider('memories')}/{get_model('memories')}")
         _memory_llm_logged = True
-    if temperature:
+    if temperature is not None:
         return get_llm("memories").bind(temperature=temperature)
     return get_llm("memories")
 

--- a/backend/utils/other/chat_file.py
+++ b/backend/utils/other/chat_file.py
@@ -12,11 +12,23 @@ from PIL import Image
 import database.chat as chat_db
 from models.chat import ChatSession, FileChat
 from utils.executors import db_executor, run_blocking
+from utils.llm.gateway_client import raise_if_gateway_feature_mode_blocks_direct_model_surface
 import logging
 
 logger = logging.getLogger(__name__)
 
-_async_openai = AsyncOpenAI()
+_async_openai: AsyncOpenAI | None = None
+
+
+def _get_async_openai() -> AsyncOpenAI:
+    global _async_openai
+    if _async_openai is None:
+        _async_openai = AsyncOpenAI()
+    return _async_openai
+
+
+def _assert_direct_file_chat_allowed() -> None:
+    raise_if_gateway_feature_mode_blocks_direct_model_surface('file_chat.openai_files_assistants_vision')
 
 
 class File:
@@ -75,6 +87,7 @@ class FileChatTool:
 
     @staticmethod
     def upload(file_path) -> dict:
+        _assert_direct_file_chat_allowed()
         result = {}
         file = File(file_path)
         file.get_mime_type()
@@ -100,12 +113,14 @@ class FileChatTool:
 
     def process_chat_with_file(self, question, file_ids: List[str]):
         """Process chat with file attachments"""
+        _assert_direct_file_chat_allowed()
         self._ensure_thread_and_assistant()
         answer = self.ask(self.uid, question, file_ids, self.thread_id, self.assistant_id)
         return answer
 
     async def process_chat_with_file_stream(self, question, file_ids: List[str], callback=None):
         """Process chat with file attachments (streaming)"""
+        _assert_direct_file_chat_allowed()
         # Offloaded: the Firestore read is sync and blocks the event loop in this async path.
         # If this pre-stream setup fails, signal the streaming callback's end before propagating
         # (mirrors the _ensure_thread_and_assistant failure path below) so it is not left dangling.
@@ -140,8 +155,9 @@ class FileChatTool:
         output_list = []
         try:
             contents = [{"type": "text", "text": question}]
+            openai_client = _get_async_openai()
             for file in files:
-                file_content = await _async_openai.files.content(file.openai_file_id)
+                file_content = await openai_client.files.content(file.openai_file_id)
                 b64 = base64.b64encode(file_content.read()).decode('utf-8')
                 mime = file.mime_type or 'image/png'
                 contents.append(
@@ -151,7 +167,7 @@ class FileChatTool:
                     }
                 )
 
-            stream = await _async_openai.chat.completions.create(
+            stream = await openai_client.chat.completions.create(
                 model="gpt-4.1",
                 messages=[{"role": "user", "content": contents}],
                 stream=True,
@@ -300,6 +316,7 @@ class FileChatTool:
 
     def cleanup(self):
         """Cleanup chat session files, thread, and assistant"""
+        _assert_direct_file_chat_allowed()
         logger.info("start cleanup thread chat with file")
         files = chat_db.get_chat_files(self.uid)
         # delete file in db

--- a/backend/utils/other/chat_file.py
+++ b/backend/utils/other/chat_file.py
@@ -316,7 +316,6 @@ class FileChatTool:
 
     def cleanup(self):
         """Cleanup chat session files, thread, and assistant"""
-        _assert_direct_file_chat_allowed()
         logger.info("start cleanup thread chat with file")
         files = chat_db.get_chat_files(self.uid)
         # delete file in db

--- a/backend/utils/retrieval/agentic.py
+++ b/backend/utils/retrieval/agentic.py
@@ -51,6 +51,7 @@ from utils.retrieval.tools.app_tools import load_app_tools, get_tool_status_mess
 from utils.retrieval.tool_result_boundaries import preserve_chat_memory_tool_result_boundary
 from utils.retrieval.safety import AgentSafetyGuard, SafetyGuardError
 from utils.llm.clients import anthropic_client, ANTHROPIC_AGENT_MODEL
+from utils.llm.gateway_client import raise_if_gateway_feature_mode_blocks_direct_model_surface
 from utils.llm.chat import _get_agentic_qa_prompt, get_current_datetime_block, get_user_timezone
 from utils.other.endpoints import timeit
 from utils.observability.langsmith import is_langsmith_enabled
@@ -392,6 +393,8 @@ async def _run_anthropic_agent_stream(
     while loop that calls Anthropic's messages API, executes any tool calls,
     and feeds results back until the model stops requesting tools.
     """
+    raise_if_gateway_feature_mode_blocks_direct_model_surface('chat_agent.anthropic_stream')
+
     # System prompt with cache_control for Anthropic prompt caching
     # TTL=1h: Anthropic changed default from 1h→5m on 2026-03-06; interactive chat
     # sessions have gaps >5min between turns, so the 5-min default kills cache hit rate.

--- a/backend/utils/retrieval/agentic.py
+++ b/backend/utils/retrieval/agentic.py
@@ -393,8 +393,6 @@ async def _run_anthropic_agent_stream(
     while loop that calls Anthropic's messages API, executes any tool calls,
     and feeds results back until the model stops requesting tools.
     """
-    raise_if_gateway_feature_mode_blocks_direct_model_surface('chat_agent.anthropic_stream')
-
     # System prompt with cache_control for Anthropic prompt caching
     # TTL=1h: Anthropic changed default from 1h→5m on 2026-03-06; interactive chat
     # sessions have gaps >5min between turns, so the 5-min default kills cache hit rate.
@@ -619,6 +617,8 @@ You have fetch_url_tool available. When the user shares any URL (starting with h
     # turn (not the system prompt) so the cache_control system prefix stays byte-stable.
     anthropic_messages = _messages_to_anthropic(messages)
     anthropic_messages = _inject_current_datetime(anthropic_messages, get_current_datetime_block(uid, tz=tz))
+
+    raise_if_gateway_feature_mode_blocks_direct_model_surface('chat_agent.anthropic_stream')
 
     callback = AsyncStreamingCallback()
 

--- a/backend/utils/retrieval/tools/perplexity_tools.py
+++ b/backend/utils/retrieval/tools/perplexity_tools.py
@@ -4,6 +4,7 @@ Tools for performing web searches using Perplexity AI.
 
 import httpx
 from langchain_core.tools import tool
+from openai import APIConnectionError, APIStatusError, APITimeoutError
 from utils.llm.gateway_client import feature_auto_lane_id
 from utils.llm.providers import get_or_create_omi_gateway_llm
 import logging
@@ -48,7 +49,7 @@ async def perplexity_web_search_tool(
 
     try:
         response = await get_or_create_omi_gateway_llm(feature_auto_lane_id('web_search')).ainvoke(
-            query, config={'max_tokens': 1000, 'temperature': 0.2}
+            query, max_tokens=1000, temperature=0.2
         )
         content = response.content if hasattr(response, 'content') else str(response)
         if content:
@@ -59,6 +60,15 @@ async def perplexity_web_search_tool(
     except ValueError as e:
         logger.error(f"❌ perplexity_web_search_tool - Gateway routing unavailable: {e}")
         return "Error: Perplexity gateway route not configured"
+    except APIStatusError as e:
+        logger.error(f"❌ perplexity_web_search_tool - API error: {e.status_code}")
+        return f"Error: Perplexity API returned status {e.status_code}. Please try again later."
+    except APITimeoutError:
+        logger.warning("❌ perplexity_web_search_tool - Request timeout")
+        return "Error: Request to Perplexity API timed out. Please try again later."
+    except APIConnectionError as e:
+        logger.error(f"❌ perplexity_web_search_tool - Request error: {e}")
+        return f"Error: Failed to connect to Perplexity API. {str(e)}"
     except httpx.HTTPStatusError as e:
         logger.error(f"❌ perplexity_web_search_tool - API error: {e.response.status_code}")
         return f"Error: Perplexity API returned status {e.response.status_code}. Please try again later."

--- a/backend/utils/retrieval/tools/perplexity_tools.py
+++ b/backend/utils/retrieval/tools/perplexity_tools.py
@@ -2,16 +2,16 @@
 Tools for performing web searches using Perplexity AI.
 """
 
-import os
-
 import httpx
 from langchain_core.tools import tool
-from utils.http_client import get_webhook_client
-from utils.llm.clients import get_model
-from utils.log_sanitizer import sanitize
+from utils.llm.gateway_client import feature_auto_lane_id
+from utils.llm.providers import get_or_create_omi_gateway_llm
 import logging
 
 logger = logging.getLogger(__name__)
+
+# Legacy QoS coverage anchor: web search still maps to get_model('web_search') in model_config,
+# while this tool now invokes the generated gateway lane directly.
 
 
 @tool
@@ -46,61 +46,25 @@ async def perplexity_web_search_tool(
     """
     logger.info(f"🔍 perplexity_web_search_tool called - query: {query}")
 
-    api_key = os.getenv('PERPLEXITY_API_KEY')
-    if not api_key:
-        logger.warning("❌ perplexity_web_search_tool - PERPLEXITY_API_KEY not found in environment")
-        return "Error: Perplexity API key not configured"
-
     try:
-        url = "https://api.perplexity.ai/chat/completions"
-
-        headers = {"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"}
-
-        payload = {
-            "model": get_model('web_search'),
-            "messages": [{"role": "user", "content": query}],
-            "temperature": 0.2,
-            "max_tokens": 1000,
-        }
-
-        client = get_webhook_client()
-        response = await client.post(url, json=payload, headers=headers, timeout=30.0)
-
-        if response.status_code != 200:
-            logger.error(
-                f"❌ perplexity_web_search_tool - API error: {response.status_code} - {sanitize(response.text[:200])}"
-            )
-            return f"Error: Perplexity API returned status {response.status_code}. Please try again later."
-
-        result = response.json()
-
-        if 'choices' in result and len(result['choices']) > 0:
-            content = result['choices'][0]['message']['content']
-
-            citations = []
-            if 'citations' in result:
-                citations = result['citations']
-            elif 'citations' in result.get('choices', [{}])[0].get('message', {}):
-                citations = result['choices'][0]['message'].get('citations', [])
-
-            formatted_result = f"Web Search Results:\n\n{content}\n\n"
-
-            if citations:
-                formatted_result += "\nSources:\n"
-                for i, citation in enumerate(citations[:10], 1):
-                    if isinstance(citation, dict):
-                        url = citation.get('url', citation.get('citation', ''))
-                        title = citation.get('title', '')
-                        if url:
-                            formatted_result += f"{i}. {title}\n   {url}\n"
-                    elif isinstance(citation, str):
-                        formatted_result += f"{i}. {citation}\n"
-
-            logger.info(f"✅ perplexity_web_search_tool - Successfully retrieved search results")
-            return formatted_result.strip()
-        else:
-            logger.error(f"⚠️ perplexity_web_search_tool - Unexpected response format: {result}")
-            return "Error: Unexpected response format from Perplexity API"
+        response = await get_or_create_omi_gateway_llm(feature_auto_lane_id('web_search')).ainvoke(
+            query, config={'max_tokens': 1000, 'temperature': 0.2}
+        )
+        content = response.content if hasattr(response, 'content') else str(response)
+        if content:
+            logger.info("✅ perplexity_web_search_tool - Successfully retrieved search results")
+            return f"Web Search Results:\n\n{content}".strip()
+        logger.error("⚠️ perplexity_web_search_tool - Empty response")
+        return "Error: Unexpected response format from Perplexity API"
+    except ValueError as e:
+        logger.error(f"❌ perplexity_web_search_tool - Gateway routing unavailable: {e}")
+        return "Error: Perplexity gateway route not configured"
+    except httpx.HTTPStatusError as e:
+        logger.error(f"❌ perplexity_web_search_tool - API error: {e.response.status_code}")
+        return f"Error: Perplexity API returned status {e.response.status_code}. Please try again later."
+    except (IndexError, KeyError, TypeError):
+        logger.error("⚠️ perplexity_web_search_tool - Unexpected response format")
+        return "Error: Unexpected response format from Perplexity API"
 
     except httpx.TimeoutException:
         logger.warning("❌ perplexity_web_search_tool - Request timeout")

--- a/backend/utils/retrieval/tools/perplexity_tools.py
+++ b/backend/utils/retrieval/tools/perplexity_tools.py
@@ -2,16 +2,21 @@
 Tools for performing web searches using Perplexity AI.
 """
 
+import logging
+import os
+
+import httpx
 from langchain_core.tools import tool
 from openai import APIConnectionError, APIStatusError, APITimeoutError
-from utils.llm.gateway_client import feature_auto_lane_id
+from utils.http_client import get_webhook_client
+from utils.llm.clients import get_model
+from utils.llm.gateway_client import feature_auto_lane_id, should_route_features_through_gateway
 from utils.llm.providers import get_or_create_omi_gateway_llm
-import logging
+from utils.log_sanitizer import sanitize
 
 logger = logging.getLogger(__name__)
 
-# Legacy QoS coverage anchor: web search still maps to get_model('web_search') in model_config,
-# while this tool now invokes the generated gateway lane directly.
+# Legacy QoS coverage anchor: web search maps to get_model('web_search') in model_config.
 
 
 @tool
@@ -46,6 +51,12 @@ async def perplexity_web_search_tool(
     """
     logger.info(f"🔍 perplexity_web_search_tool called - query: {query}")
 
+    if should_route_features_through_gateway():
+        return await _perplexity_gateway_search(query)
+    return await _perplexity_legacy_search(query)
+
+
+async def _perplexity_gateway_search(query: str) -> str:
     try:
         response = await get_or_create_omi_gateway_llm(feature_auto_lane_id('web_search')).ainvoke(
             query, max_tokens=1000, temperature=0.2
@@ -72,6 +83,66 @@ async def perplexity_web_search_tool(
         logger.error("⚠️ perplexity_web_search_tool - Unexpected response format")
         return "Error: Unexpected response format from Perplexity API"
 
+    except Exception as e:
+        logger.error(f"❌ perplexity_web_search_tool - Unexpected error: {e}")
+        return f"Error: An unexpected error occurred while searching: {str(e)}"
+
+
+async def _perplexity_legacy_search(query: str) -> str:
+    api_key = os.getenv('PERPLEXITY_API_KEY')
+    if not api_key:
+        logger.warning("❌ perplexity_web_search_tool - PERPLEXITY_API_KEY not found in environment")
+        return "Error: Perplexity API key not configured"
+
+    try:
+        response = await get_webhook_client().post(
+            "https://api.perplexity.ai/chat/completions",
+            json={
+                "model": get_model('web_search'),
+                "messages": [{"role": "user", "content": query}],
+                "temperature": 0.2,
+                "max_tokens": 1000,
+            },
+            headers={"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"},
+            timeout=30.0,
+        )
+
+        if response.status_code != 200:
+            logger.error(
+                f"❌ perplexity_web_search_tool - API error: {response.status_code} - {sanitize(response.text[:200])}"
+            )
+            return f"Error: Perplexity API returned status {response.status_code}. Please try again later."
+
+        result = response.json()
+        if 'choices' in result and len(result['choices']) > 0:
+            content = result['choices'][0]['message']['content']
+            formatted_result = f"Web Search Results:\n\n{content}\n\n"
+
+            citations = result.get('citations') or result.get('choices', [{}])[0].get('message', {}).get(
+                'citations', []
+            )
+            if citations:
+                formatted_result += "\nSources:\n"
+                for i, citation in enumerate(citations[:10], 1):
+                    if isinstance(citation, dict):
+                        url = citation.get('url', citation.get('citation', ''))
+                        title = citation.get('title', '')
+                        if url:
+                            formatted_result += f"{i}. {title}\n   {url}\n"
+                    elif isinstance(citation, str):
+                        formatted_result += f"{i}. {citation}\n"
+
+            logger.info("✅ perplexity_web_search_tool - Successfully retrieved search results")
+            return formatted_result.strip()
+
+        logger.error(f"⚠️ perplexity_web_search_tool - Unexpected response format: {sanitize(str(result)[:200])}")
+        return "Error: Unexpected response format from Perplexity API"
+    except httpx.TimeoutException:
+        logger.warning("❌ perplexity_web_search_tool - Request timeout")
+        return "Error: Request to Perplexity API timed out. Please try again later."
+    except httpx.HTTPError as e:
+        logger.error(f"❌ perplexity_web_search_tool - Request error: {e}")
+        return f"Error: Failed to connect to Perplexity API. {str(e)}"
     except Exception as e:
         logger.error(f"❌ perplexity_web_search_tool - Unexpected error: {e}")
         return f"Error: An unexpected error occurred while searching: {str(e)}"

--- a/backend/utils/retrieval/tools/perplexity_tools.py
+++ b/backend/utils/retrieval/tools/perplexity_tools.py
@@ -2,7 +2,6 @@
 Tools for performing web searches using Perplexity AI.
 """
 
-import httpx
 from langchain_core.tools import tool
 from openai import APIConnectionError, APIStatusError, APITimeoutError
 from utils.llm.gateway_client import feature_auto_lane_id
@@ -69,19 +68,10 @@ async def perplexity_web_search_tool(
     except APIConnectionError as e:
         logger.error(f"❌ perplexity_web_search_tool - Request error: {e}")
         return f"Error: Failed to connect to Perplexity API. {str(e)}"
-    except httpx.HTTPStatusError as e:
-        logger.error(f"❌ perplexity_web_search_tool - API error: {e.response.status_code}")
-        return f"Error: Perplexity API returned status {e.response.status_code}. Please try again later."
     except (IndexError, KeyError, TypeError):
         logger.error("⚠️ perplexity_web_search_tool - Unexpected response format")
         return "Error: Unexpected response format from Perplexity API"
 
-    except httpx.TimeoutException:
-        logger.warning("❌ perplexity_web_search_tool - Request timeout")
-        return "Error: Request to Perplexity API timed out. Please try again later."
-    except httpx.HTTPError as e:
-        logger.error(f"❌ perplexity_web_search_tool - Request error: {e}")
-        return f"Error: Failed to connect to Perplexity API. {str(e)}"
     except Exception as e:
         logger.error(f"❌ perplexity_web_search_tool - Unexpected error: {e}")
         return f"Error: An unexpected error occurred while searching: {str(e)}"

--- a/backend/utils/retrieval/tools/perplexity_tools.py
+++ b/backend/utils/retrieval/tools/perplexity_tools.py
@@ -7,11 +7,10 @@ import os
 
 import httpx
 from langchain_core.tools import tool
-from openai import APIConnectionError, APIStatusError, APITimeoutError
 from utils.http_client import get_webhook_client
 from utils.llm.clients import get_model
-from utils.llm.gateway_client import feature_auto_lane_id, should_route_features_through_gateway
-from utils.llm.providers import get_or_create_omi_gateway_llm
+from utils.llm.gateway_client import feature_auto_lane_id, get_llm_gateway_base_url, llm_gateway_headers
+from utils.llm.gateway_client import should_route_features_through_gateway
 from utils.log_sanitizer import sanitize
 
 logger = logging.getLogger(__name__)
@@ -58,31 +57,35 @@ async def perplexity_web_search_tool(
 
 async def _perplexity_gateway_search(query: str) -> str:
     try:
-        response = await get_or_create_omi_gateway_llm(feature_auto_lane_id('web_search')).ainvoke(
-            query, max_tokens=1000, temperature=0.2
+        response = await get_webhook_client().post(
+            f'{get_llm_gateway_base_url()}/v1/chat/completions',
+            json={
+                "model": feature_auto_lane_id('web_search'),
+                "messages": [{"role": "user", "content": query}],
+                "temperature": 0.2,
+                "max_tokens": 1000,
+            },
+            headers=llm_gateway_headers(),
+            timeout=30.0,
         )
-        content = response.content if hasattr(response, 'content') else str(response)
-        if content:
-            logger.info("✅ perplexity_web_search_tool - Successfully retrieved search results")
-            return f"Web Search Results:\n\n{content}".strip()
-        logger.error("⚠️ perplexity_web_search_tool - Empty response")
-        return "Error: Unexpected response format from Perplexity API"
-    except ValueError as e:
-        logger.error(f"❌ perplexity_web_search_tool - Gateway routing unavailable: {e}")
-        return "Error: Perplexity gateway route not configured"
-    except APIStatusError as e:
-        logger.error(f"❌ perplexity_web_search_tool - API error: {e.status_code}")
-        return f"Error: Perplexity API returned status {e.status_code}. Please try again later."
-    except APITimeoutError:
+
+        if response.status_code != 200:
+            logger.error(
+                f"❌ perplexity_web_search_tool - Gateway API error: {response.status_code} - "
+                f"{sanitize(response.text[:200])}"
+            )
+            return f"Error: Perplexity API returned status {response.status_code}. Please try again later."
+
+        return _format_perplexity_response(response.json())
+    except httpx.TimeoutException:
         logger.warning("❌ perplexity_web_search_tool - Request timeout")
         return "Error: Request to Perplexity API timed out. Please try again later."
-    except APIConnectionError as e:
+    except httpx.HTTPError as e:
         logger.error(f"❌ perplexity_web_search_tool - Request error: {e}")
         return f"Error: Failed to connect to Perplexity API. {str(e)}"
-    except (IndexError, KeyError, TypeError):
+    except (ValueError, IndexError, KeyError, TypeError):
         logger.error("⚠️ perplexity_web_search_tool - Unexpected response format")
         return "Error: Unexpected response format from Perplexity API"
-
     except Exception as e:
         logger.error(f"❌ perplexity_web_search_tool - Unexpected error: {e}")
         return f"Error: An unexpected error occurred while searching: {str(e)}"
@@ -113,29 +116,9 @@ async def _perplexity_legacy_search(query: str) -> str:
             )
             return f"Error: Perplexity API returned status {response.status_code}. Please try again later."
 
-        result = response.json()
-        if 'choices' in result and len(result['choices']) > 0:
-            content = result['choices'][0]['message']['content']
-            formatted_result = f"Web Search Results:\n\n{content}\n\n"
-
-            citations = result.get('citations') or result.get('choices', [{}])[0].get('message', {}).get(
-                'citations', []
-            )
-            if citations:
-                formatted_result += "\nSources:\n"
-                for i, citation in enumerate(citations[:10], 1):
-                    if isinstance(citation, dict):
-                        url = citation.get('url', citation.get('citation', ''))
-                        title = citation.get('title', '')
-                        if url:
-                            formatted_result += f"{i}. {title}\n   {url}\n"
-                    elif isinstance(citation, str):
-                        formatted_result += f"{i}. {citation}\n"
-
-            logger.info("✅ perplexity_web_search_tool - Successfully retrieved search results")
-            return formatted_result.strip()
-
-        logger.error(f"⚠️ perplexity_web_search_tool - Unexpected response format: {sanitize(str(result)[:200])}")
+        return _format_perplexity_response(response.json())
+    except ValueError:
+        logger.error("⚠️ perplexity_web_search_tool - Unexpected response format")
         return "Error: Unexpected response format from Perplexity API"
     except httpx.TimeoutException:
         logger.warning("❌ perplexity_web_search_tool - Request timeout")
@@ -146,3 +129,34 @@ async def _perplexity_legacy_search(query: str) -> str:
     except Exception as e:
         logger.error(f"❌ perplexity_web_search_tool - Unexpected error: {e}")
         return f"Error: An unexpected error occurred while searching: {str(e)}"
+
+
+def _format_perplexity_response(result: dict) -> str:
+    if 'choices' in result and len(result['choices']) > 0:
+        content = result['choices'][0]['message']['content']
+        formatted_result = f"Web Search Results:\n\n{content}\n\n"
+
+        citations = _extract_citations(result)
+        if citations:
+            formatted_result += "\nSources:\n"
+            for i, citation in enumerate(citations[:10], 1):
+                if isinstance(citation, dict):
+                    url = citation.get('url', citation.get('citation', ''))
+                    title = citation.get('title', '')
+                    if url:
+                        formatted_result += f"{i}. {title}\n   {url}\n"
+                elif isinstance(citation, str):
+                    formatted_result += f"{i}. {citation}\n"
+
+        logger.info("✅ perplexity_web_search_tool - Successfully retrieved search results")
+        return formatted_result.strip()
+
+    logger.error(f"⚠️ perplexity_web_search_tool - Unexpected response format: {sanitize(str(result)[:200])}")
+    return "Error: Unexpected response format from Perplexity API"
+
+
+def _extract_citations(result: dict) -> list:
+    citations = result.get('citations') or result.get('search_results')
+    if citations:
+        return citations
+    return result.get('choices', [{}])[0].get('message', {}).get('citations', [])


### PR DESCRIPTION
## Summary
- route gateway shadow comparisons through a LangChain ChatOpenAI-compatible gateway client so prompts/parsers stay aligned with legacy behavior
- keep live requires-context and discard decisions on the legacy provider path while shadows remain sampled and env-gated
- allow prompt-parser style gateway requests without response_format and forward prompt_cache_key for LangChain parity
- update gateway smoke/schema coverage for current structured payload contracts

## Verification
- cd backend && black --line-length 120 --skip-string-normalization --check llm_gateway/gateway/validator.py llm_gateway/gateway/executor.py utils/llm/providers.py utils/llm/clients.py utils/llm/chat.py utils/llm/conversation_processing.py tests/unit/test_llm_gateway_chat_extraction_pilot.py tests/unit/test_llm_gateway_client_config.py tests/unit/test_llm_gateway_validator.py tests/unit/test_llm_gateway_executor.py
- cd backend && pytest tests/unit/test_llm_gateway_client_config.py tests/unit/test_llm_gateway_chat_extraction_pilot.py tests/unit/test_llm_gateway_route_refs.py tests/unit/test_llm_gateway_validator.py tests/unit/test_llm_gateway_executor.py tests/unit/test_llm_gateway_openai_compatible.py -q
- cd backend && python scripts/scan_async_blockers.py
- pre-push selected backend checks passed; skipped only PRE_PUSH_SKIP_OPENAPI_CONTRACT=1 because this branch does not change API route/schema output and the hook reported existing generated OpenAPI drift


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8888?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

