### PR TITLE
Shadow eligible dev LLM traffic through gateway

### DIFF
--- a/backend/charts/backend-listen/dev_omi_backend_listen_values.yaml
+++ b/backend/charts/backend-listen/dev_omi_backend_listen_values.yaml
@@ -119,6 +119,10 @@ env:
     value: "true"
   - name: OMI_LLM_GATEWAY_CONVERSATION_ACTION_ITEMS_SHADOW_SAMPLE_RATE
     value: "1.0"
+  - name: OMI_LLM_GATEWAY_DEV_SHADOW_ALL_ENABLED
+    value: "true"
+  - name: OMI_LLM_GATEWAY_DEV_SHADOW_ALL_SAMPLE_RATE
+    value: "1.0"
   - name: OMI_LLM_GATEWAY_SERVICE_TOKEN
     valueFrom:
       secretKeyRef:

--- a/backend/deploy/runtime_env.yaml
+++ b/backend/deploy/runtime_env.yaml
@@ -24,6 +24,12 @@ environments:
           OMI_LLM_GATEWAY_CONVERSATION_ACTION_ITEMS_SHADOW_SAMPLE_RATE:
             value: "1.0"
             category: rollout
+          OMI_LLM_GATEWAY_DEV_SHADOW_ALL_ENABLED:
+            value: "true"
+            category: rollout
+          OMI_LLM_GATEWAY_DEV_SHADOW_ALL_SAMPLE_RATE:
+            value: "1.0"
+            category: rollout
           OMI_LLM_GATEWAY_SERVICE_TOKEN:
             secret:
               name: dev-omi-backend-secrets
@@ -75,6 +81,12 @@ environments:
             OMI_LLM_GATEWAY_CONVERSATION_ACTION_ITEMS_SHADOW_SAMPLE_RATE:
               value: "1.0"
               category: rollout
+            OMI_LLM_GATEWAY_DEV_SHADOW_ALL_ENABLED:
+              value: "true"
+              category: rollout
+            OMI_LLM_GATEWAY_DEV_SHADOW_ALL_SAMPLE_RATE:
+              value: "1.0"
+              category: rollout
             MEMORY_MODE:
               value: write
               category: memory_rollout
@@ -122,6 +134,12 @@ environments:
             OMI_LLM_GATEWAY_CONVERSATION_ACTION_ITEMS_SHADOW_SAMPLE_RATE:
               value: "1.0"
               category: rollout
+            OMI_LLM_GATEWAY_DEV_SHADOW_ALL_ENABLED:
+              value: "true"
+              category: rollout
+            OMI_LLM_GATEWAY_DEV_SHADOW_ALL_SAMPLE_RATE:
+              value: "1.0"
+              category: rollout
             MEMORY_MODE:
               value: write
               category: memory_rollout
@@ -167,6 +185,12 @@ environments:
               value: "true"
               category: rollout
             OMI_LLM_GATEWAY_CONVERSATION_ACTION_ITEMS_SHADOW_SAMPLE_RATE:
+              value: "1.0"
+              category: rollout
+            OMI_LLM_GATEWAY_DEV_SHADOW_ALL_ENABLED:
+              value: "true"
+              category: rollout
+            OMI_LLM_GATEWAY_DEV_SHADOW_ALL_SAMPLE_RATE:
               value: "1.0"
               category: rollout
             MEMORY_MODE:

--- a/backend/tests/unit/test_llm_gateway_client_config.py
+++ b/backend/tests/unit/test_llm_gateway_client_config.py
@@ -1,8 +1,49 @@
 from __future__ import annotations
 
+from typing import Any
+
+from langchain_core.callbacks.manager import CallbackManagerForLLMRun
+from langchain_core.language_models import BaseChatModel
+from langchain_core.messages import AIMessage, BaseMessage
+from langchain_core.outputs import ChatGeneration, ChatResult
+from langchain_core.runnables import Runnable
+
+from utils.llm import clients, gateway_shadow
 from utils.llm import providers
 from utils.llm.gateway_client import DEFAULT_LLM_GATEWAY_URL, get_llm_gateway_base_url
 from utils.llm.clients import get_llm_gateway_chat_structured
+
+
+class FakeChatModel(BaseChatModel):
+    name: str
+    calls: list
+
+    @property
+    def _llm_type(self) -> str:
+        return f'fake-{self.name}'
+
+    def _generate(
+        self,
+        messages: list[BaseMessage],
+        stop: list[str] | None = None,
+        run_manager: CallbackManagerForLLMRun | None = None,
+        **kwargs: Any,
+    ) -> ChatResult:
+        self.calls.append({'messages': messages, 'kwargs': kwargs})
+        return ChatResult(generations=[ChatGeneration(message=AIMessage(content=f'{self.name} response'))])
+
+    def with_structured_output(self, schema, *, include_raw: bool = False, **kwargs: Any):
+        return FakeStructuredRunnable(self.name, self.calls)
+
+
+class FakeStructuredRunnable(Runnable):
+    def __init__(self, name: str, calls: list):
+        self.name = name
+        self.calls = calls
+
+    def invoke(self, input: Any, config=None, **kwargs: Any) -> dict[str, str]:
+        self.calls.append({'input': input, 'kwargs': kwargs})
+        return {'result': self.name}
 
 
 def test_llm_gateway_base_url_defaults_to_local_service(monkeypatch):
@@ -36,3 +77,63 @@ def test_gateway_langchain_client_uses_internal_gateway_base_url_and_auth(monkey
     assert captured['base_url'] == 'http://gateway.internal:8080/v1'
     assert captured['default_headers']['X-Omi-Service-Caller'] == 'backend'
     assert captured['default_headers']['Authorization'] == 'Bearer service-token'
+
+
+def test_get_llm_dev_shadow_wraps_legacy_and_submits_gateway(monkeypatch):
+    submitted = []
+    legacy = FakeChatModel(name='legacy', calls=[])
+    gateway = FakeChatModel(name='gateway', calls=[])
+
+    def immediate_submit(_executor, fn, *args, **kwargs):
+        submitted.append(fn.__name__)
+        fn(*args, **kwargs)
+
+    monkeypatch.setenv(gateway_shadow.DEV_SHADOW_ALL_ENABLED_ENV, 'true')
+    monkeypatch.delenv('OMI_ENV_STAGE', raising=False)
+    monkeypatch.delenv('K_SERVICE', raising=False)
+    monkeypatch.setattr(clients, 'get_default_client', lambda *args, **kwargs: legacy)
+    monkeypatch.setattr(gateway_shadow, 'get_or_create_omi_gateway_llm', lambda *args, **kwargs: gateway)
+    monkeypatch.setattr(gateway_shadow, 'submit_with_context', immediate_submit)
+
+    result = clients.get_llm('conv_discard').invoke('hello')
+
+    assert result.content == 'legacy response'
+    assert len(legacy.calls) == 1
+    assert len(gateway.calls) == 1
+    assert submitted == ['_run_sync_shadow']
+
+
+def test_get_llm_dev_shadow_wraps_structured_output(monkeypatch):
+    submitted = []
+    legacy = FakeChatModel(name='legacy', calls=[])
+    gateway = FakeChatModel(name='gateway', calls=[])
+
+    def immediate_submit(_executor, fn, *args, **kwargs):
+        submitted.append(fn.__name__)
+        fn(*args, **kwargs)
+
+    monkeypatch.setenv(gateway_shadow.DEV_SHADOW_ALL_ENABLED_ENV, 'true')
+    monkeypatch.delenv('OMI_ENV_STAGE', raising=False)
+    monkeypatch.delenv('K_SERVICE', raising=False)
+    monkeypatch.setattr(clients, 'get_default_client', lambda *args, **kwargs: legacy)
+    monkeypatch.setattr(gateway_shadow, 'get_or_create_omi_gateway_llm', lambda *args, **kwargs: gateway)
+    monkeypatch.setattr(gateway_shadow, 'submit_with_context', immediate_submit)
+
+    result = clients.get_llm('chat_extraction').with_structured_output(dict).invoke('hello')
+
+    assert result == {'result': 'legacy'}
+    assert legacy.calls == [{'input': 'hello', 'kwargs': {}}]
+    assert gateway.calls == [{'input': 'hello', 'kwargs': {}}]
+    assert submitted == ['_run_sync_shadow']
+
+
+def test_get_llm_dev_shadow_is_disabled_for_prod_like_runtime(monkeypatch):
+    legacy = FakeChatModel(name='legacy', calls=[])
+
+    monkeypatch.setenv(gateway_shadow.DEV_SHADOW_ALL_ENABLED_ENV, 'true')
+    monkeypatch.setenv('K_SERVICE', 'prod-omi-backend')
+    monkeypatch.setattr(clients, 'get_default_client', lambda *args, **kwargs: legacy)
+
+    result = clients.get_llm('conv_discard')
+
+    assert result is legacy

--- a/backend/utils/llm/clients.py
+++ b/backend/utils/llm/clients.py
@@ -51,6 +51,7 @@ from utils.llm.providers import (
     _llm_cache,
 )
 from utils.llm.gateway_client import CHAT_STRUCTURED_AUTO_LANE_ID
+from utils.llm.gateway_shadow import maybe_wrap_dev_gateway_shadow
 from utils.llm.usage_tracker import get_usage_callback
 
 logger = logging.getLogger(__name__)
@@ -322,6 +323,14 @@ def get_llm(feature: str, streaming: bool = False, cache_key: Optional[str] = No
         )
     else:
         result = get_default_client(model, provider, streaming, get_route_options(feature, model, provider))
+
+    result = maybe_wrap_dev_gateway_shadow(
+        feature=feature,
+        model=model,
+        provider=provider,
+        streaming=streaming,
+        legacy_model=result,
+    )
 
     if cache_key and supports_prompt_cache(model):
         return result.bind(prompt_cache_key=cache_key)

--- a/backend/utils/llm/gateway_shadow.py
+++ b/backend/utils/llm/gateway_shadow.py
@@ -1,0 +1,207 @@
+from __future__ import annotations
+
+import os
+import random
+from typing import Any
+
+from langchain_core.callbacks.manager import AsyncCallbackManagerForLLMRun, CallbackManagerForLLMRun
+from langchain_core.language_models import BaseChatModel
+from langchain_core.messages import BaseMessage
+from langchain_core.outputs import ChatResult
+from langchain_core.runnables import Runnable
+from pydantic import ConfigDict
+
+from utils.byok import has_byok_keys
+from utils.executors import llm_executor, start_background_task, submit_with_context
+from utils.llm.gateway_client import CHAT_STRUCTURED_AUTO_LANE_ID
+from utils.llm.gateway_observability import record_gateway_request_result, record_gateway_shadow_comparison
+from utils.llm.providers import get_or_create_omi_gateway_llm
+
+DEV_SHADOW_ALL_ENABLED_ENV = 'OMI_LLM_GATEWAY_DEV_SHADOW_ALL_ENABLED'
+DEV_SHADOW_ALL_SAMPLE_RATE_ENV = 'OMI_LLM_GATEWAY_DEV_SHADOW_ALL_SAMPLE_RATE'
+
+_PROD_STAGE_VALUES = {'prod', 'production'}
+
+
+def maybe_wrap_dev_gateway_shadow(
+    *,
+    feature: str,
+    model: str,
+    provider: str,
+    streaming: bool,
+    legacy_model: BaseChatModel,
+) -> BaseChatModel:
+    if not _dev_shadow_enabled(provider=provider, streaming=streaming):
+        return legacy_model
+
+    gateway_model = get_or_create_omi_gateway_llm(CHAT_STRUCTURED_AUTO_LANE_ID, streaming=False)
+    return GatewayShadowChatModel(
+        feature=feature,
+        model_name=model,
+        provider=provider,
+        legacy_model=legacy_model,
+        gateway_model=gateway_model,
+    )
+
+
+def _dev_shadow_enabled(*, provider: str, streaming: bool) -> bool:
+    if streaming:
+        return False
+    if has_byok_keys():
+        return False
+    if _is_prod_like_runtime():
+        return False
+    if provider in {'anthropic', 'perplexity'}:
+        return False
+    if os.getenv(DEV_SHADOW_ALL_ENABLED_ENV, '').strip().casefold() not in {'1', 'true', 'yes', 'on'}:
+        return False
+    sample_rate = _sample_rate()
+    return sample_rate >= 1.0 or random.random() < sample_rate
+
+
+def _sample_rate() -> float:
+    value = os.getenv(DEV_SHADOW_ALL_SAMPLE_RATE_ENV, '1.0')
+    try:
+        return max(0.0, min(1.0, float(value)))
+    except ValueError:
+        return 0.0
+
+
+def _is_prod_like_runtime() -> bool:
+    stage = os.getenv('OMI_ENV_STAGE', '').strip().casefold()
+    if stage in _PROD_STAGE_VALUES:
+        return True
+    service = (os.getenv('K_SERVICE') or os.getenv('APP_NAME') or '').strip().casefold()
+    return service.startswith('prod-') or service.startswith('prod_') or service in _PROD_STAGE_VALUES
+
+
+class GatewayShadowChatModel(BaseChatModel):
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    feature: str
+    model_name: str
+    provider: str
+    legacy_model: BaseChatModel
+    gateway_model: BaseChatModel
+
+    @property
+    def _llm_type(self) -> str:
+        return f'{getattr(self.legacy_model, "_llm_type", "chat")}-omi-gateway-shadow'
+
+    def _generate(
+        self,
+        messages: list[BaseMessage],
+        stop: list[str] | None = None,
+        run_manager: CallbackManagerForLLMRun | None = None,
+        **kwargs: Any,
+    ) -> ChatResult:
+        result = self.legacy_model._generate(messages, stop=stop, run_manager=run_manager, **kwargs)
+        _submit_sync_shadow(
+            self.gateway_model._generate,
+            messages,
+            stop=stop,
+            feature=_shadow_feature(self.feature),
+            **kwargs,
+        )
+        return result
+
+    async def _agenerate(
+        self,
+        messages: list[BaseMessage],
+        stop: list[str] | None = None,
+        run_manager: AsyncCallbackManagerForLLMRun | None = None,
+        **kwargs: Any,
+    ) -> ChatResult:
+        result = await self.legacy_model._agenerate(messages, stop=stop, run_manager=run_manager, **kwargs)
+        start_background_task(
+            _run_async_shadow(
+                self.gateway_model._agenerate, messages, stop=stop, feature=_shadow_feature(self.feature), **kwargs
+            ),
+            name=f'llm-gateway-shadow:{self.feature}',
+        )
+        return result
+
+    def with_structured_output(self, schema: dict[str, Any] | type, *, include_raw: bool = False, **kwargs: Any):
+        legacy = self.legacy_model.with_structured_output(schema, include_raw=include_raw, **kwargs)
+        gateway = self.gateway_model.with_structured_output(schema, include_raw=include_raw, **kwargs)
+        return GatewayShadowRunnable(feature=_shadow_feature(self.feature), legacy=legacy, gateway=gateway)
+
+
+class GatewayShadowRunnable(Runnable):
+    def __init__(self, *, feature: str, legacy: Runnable, gateway: Runnable):
+        self._feature = feature
+        self._legacy = legacy
+        self._gateway = gateway
+
+    def invoke(self, input: Any, config=None, **kwargs: Any) -> Any:
+        result = self._legacy.invoke(input, config=config, **kwargs)
+        _submit_sync_shadow(
+            self._gateway.invoke, input, config=config, feature=self._feature, legacy_result=result, **kwargs
+        )
+        return result
+
+    async def ainvoke(self, input: Any, config=None, **kwargs: Any) -> Any:
+        result = await self._legacy.ainvoke(input, config=config, **kwargs)
+        start_background_task(
+            _run_async_shadow(
+                self._gateway.ainvoke,
+                input,
+                config=config,
+                feature=self._feature,
+                legacy_result=result,
+                **kwargs,
+            ),
+            name=f'llm-gateway-shadow:{self._feature}',
+        )
+        return result
+
+
+def _submit_sync_shadow(fn, *args, feature: str, legacy_result: Any = None, **kwargs: Any) -> None:
+    try:
+        submit_with_context(llm_executor, _run_sync_shadow, fn, args, kwargs, feature, legacy_result)
+    except Exception:
+        record_gateway_request_result(feature=feature, outcome='fallback', reason='submit_failed')
+
+
+def _run_sync_shadow(fn, args: tuple[Any, ...], kwargs: dict[str, Any], feature: str, legacy_result: Any) -> None:
+    try:
+        gateway_result = fn(*args, **kwargs)
+    except Exception:
+        record_gateway_request_result(feature=feature, outcome='fallback', reason='unexpected_error')
+        return
+    record_gateway_request_result(feature=feature, outcome='success', reason='ok')
+    _record_shadow_result_comparison(feature=feature, legacy_result=legacy_result, gateway_result=gateway_result)
+
+
+async def _run_async_shadow(fn, *args, feature: str, legacy_result: Any = None, **kwargs: Any) -> None:
+    try:
+        gateway_result = await fn(*args, **kwargs)
+    except Exception:
+        record_gateway_request_result(feature=feature, outcome='fallback', reason='unexpected_error')
+        return
+    record_gateway_request_result(feature=feature, outcome='success', reason='ok')
+    _record_shadow_result_comparison(feature=feature, legacy_result=legacy_result, gateway_result=gateway_result)
+
+
+def _record_shadow_result_comparison(*, feature: str, legacy_result: Any, gateway_result: Any) -> None:
+    if legacy_result is None:
+        return
+    record_gateway_shadow_comparison(
+        feature=feature,
+        field='parsed_result',
+        outcome='exact_match' if _comparison_value(legacy_result) == _comparison_value(gateway_result) else 'mismatch',
+    )
+
+
+def _comparison_value(value: Any) -> Any:
+    if isinstance(value, dict) and {'raw', 'parsed', 'parsing_error'} <= set(value):
+        value = value.get('parsed')
+    if hasattr(value, 'model_dump'):
+        return value.model_dump(mode='json')
+    if isinstance(value, BaseMessage):
+        return {'type': value.type, 'content': value.content}
+    return value
+
+
+def _shadow_feature(feature: str) -> str:
+    return f'{feature}.shadow'


### PR DESCRIPTION
## Summary
- add a dev-only get_llm shadow wrapper that returns the legacy result and submits an Omi gateway shadow call for eligible non-streaming chat traffic
- cover raw chat model invocations and with_structured_output callers from the same get_llm integration point, instead of adding a separate expected-call counter
- wire OMI_LLM_GATEWAY_DEV_SHADOW_ALL_ENABLED and sample rate to dev backend/listen + Cloud Run runtime env only; prod runtime remains disabled and wrapper also fails closed for prod-like service names

## Scope
- Shadows get_llm-based, non-BYOK, non-streaming chat traffic through omi:auto:chat-structured.
- Does not claim coverage for direct provider APIs outside get_llm: Anthropic agent streams, Perplexity search, file/image APIs, or embeddings. Those need separate gateway lanes/capabilities.
- Stacked on #8888 because it depends on the LangChain gateway client cleanup.

## Verification
- cd backend && pytest tests/unit/test_llm_gateway_client_config.py tests/unit/test_llm_gateway_chat_extraction_pilot.py tests/unit/test_llm_gateway_route_refs.py tests/unit/test_llm_gateway_validator.py tests/unit/test_llm_gateway_executor.py tests/unit/test_llm_gateway_openai_compatible.py -q
- cd backend && python scripts/validate-backend-runtime-env.py --env dev
- cd backend && python scripts/validate-backend-runtime-env.py --env prod
- cd backend && python scripts/scan_async_blockers.py
- pre-push checks passed with PRE_PUSH_SKIP_OPENAPI_CONTRACT=1; OpenAPI export drift is unrelated to this backend LLM runtime change


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8889?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

