### PR TITLE
Add GET /v1/goals/completed to list a user's past goals

### DIFF
--- a/backend/route_policy_manifest.yaml
+++ b/backend/route_policy_manifest.yaml
@@ -1079,3 +1079,26 @@ routes:
       deprecation:
         state: active
       owner: backend
+  - route_type: http
+    method: GET
+    path: /v1/goals/completed
+    policy:
+      review_status: reviewed
+      auth:
+        mechanisms:
+          - firebase_id_token
+        placement: dependency
+        scopes: []
+      byok: not_applicable
+      rate_limit:
+        policy_name: none
+        key_subject: none
+        enforcement: none
+        placement: none
+      timeout_class: default_method
+      surface: first_party_app
+      visibility: first_party
+      data_domain: unknown
+      deprecation:
+        state: active
+      owner: backend

--- a/backend/routers/goals.py
+++ b/backend/routers/goals.py
@@ -57,6 +57,25 @@ def get_all_goals(
     return [normalize_goal_response(goal) for goal in goals]
 
 
+@router.get('/v1/goals/completed', tags=['goals'])
+def get_completed_goals(uid: str = Depends(auth.get_current_user_uid)) -> List[dict]:
+    """Get the user's completed or archived goals (the inactive ones), most recent first.
+
+    The active-goal endpoints (/v1/goals and /v1/goals/all) only ever return active goals,
+    so once a goal is ended or bumped out of the active set it can no longer be queried and
+    the user's goal history becomes invisible. This surfaces those inactive goals instead.
+    """
+    completed = [g for g in goals_db.get_all_goals(uid, include_inactive=True) if not g.get('is_active')]
+
+    # Convert datetime objects to strings for JSON serialization (same as the sibling endpoints).
+    for goal in completed:
+        for field in ('created_at', 'updated_at', 'ended_at'):
+            if field in goal and hasattr(goal[field], 'isoformat'):
+                goal[field] = goal[field].isoformat()
+
+    return completed
+
+
 @router.post('/v1/goals', tags=['goals'], response_model=GoalResponse)
 def create_goal(goal: GoalCreate, uid: str = Depends(auth.get_current_user_uid)) -> dict:
     """Create a durable goal without changing any other goal's focus or lifecycle."""

--- a/backend/tests/unit/test_desktop_rest_inventory.py
+++ b/backend/tests/unit/test_desktop_rest_inventory.py
@@ -175,7 +175,6 @@ KNOWN_MISSING_ROUTES: Set[str] = {
     # Desktop calls these but no matching backend route exists — likely dead
     # endpoints or naming drift to be resolved in a follow-up slice.
     '/v1/action-items/batch-scores',
-    '/v1/goals/completed',
     '/v1/personas/check-username',
     '/v1/personas/generate-prompt',
     '/v3/memories/mark-all-read',

--- a/backend/tests/unit/test_goals_completed_endpoint.py
+++ b/backend/tests/unit/test_goals_completed_endpoint.py
@@ -1,0 +1,73 @@
+"""GET /v1/goals/completed returns the user's inactive (completed/archived) goals.
+
+The active-goal endpoints (/v1/goals, /v1/goals/all) only ever return active goals, so
+once a goal is ended or bumped out of the active set it can no longer be queried and the
+user's goal history becomes invisible. The endpoint filters get_all_goals(include_inactive=True)
+down to the inactive goals, newest first, and serializes their datetimes.
+
+Test isolation: routers.goals imports cleanly, so we monkeypatch the import-cheap goals_db
+attribute and call the handler directly (no sys.modules mutation, no TestClient).
+"""
+
+import os
+
+os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
+os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv')
+
+from datetime import datetime, timezone  # noqa: E402
+
+from routers import goals as goals_mod  # noqa: E402
+
+
+def _goal(gid, is_active, **extra):
+    g = {'id': gid, 'title': gid, 'is_active': is_active}
+    g.update(extra)
+    return g
+
+
+def test_completed_goals_returns_only_inactive_preserving_order(monkeypatch):
+    dt = datetime(2026, 5, 1, 12, 0, tzinfo=timezone.utc)
+    # get_all_goals(include_inactive=True) returns active + inactive, newest first.
+    all_goals = [
+        _goal('active_now', True, created_at=dt),
+        _goal('done_new', False, created_at=dt, updated_at=dt, ended_at=dt),
+        _goal('done_old', False, created_at=dt),
+    ]
+    captured = {}
+
+    def fake_get_all_goals(uid, include_inactive=False):
+        captured['uid'] = uid
+        captured['include_inactive'] = include_inactive
+        return all_goals
+
+    monkeypatch.setattr(goals_mod.goals_db, 'get_all_goals', fake_get_all_goals)
+
+    result = goals_mod.get_completed_goals(uid='u1')
+
+    # Only the inactive goals, order preserved (newest first).
+    assert [g['id'] for g in result] == ['done_new', 'done_old']
+    # Queried with include_inactive so the DB returns the full set.
+    assert captured == {'uid': 'u1', 'include_inactive': True}
+    # Datetime fields serialized to ISO strings, including ended_at.
+    assert result[0]['created_at'] == '2026-05-01T12:00:00+00:00'
+    assert result[0]['ended_at'] == '2026-05-01T12:00:00+00:00'
+
+
+def test_completed_goals_empty_when_all_active(monkeypatch):
+    monkeypatch.setattr(
+        goals_mod.goals_db,
+        'get_all_goals',
+        lambda uid, include_inactive=False: [{'id': 'g1', 'is_active': True}],
+    )
+    assert goals_mod.get_completed_goals(uid='u1') == []
+
+
+def test_completed_goals_treats_missing_is_active_as_inactive(monkeypatch):
+    # A legacy goal with no is_active field is not returned by the active-only endpoints,
+    # so it belongs in the completed/archive view rather than being lost entirely.
+    monkeypatch.setattr(
+        goals_mod.goals_db,
+        'get_all_goals',
+        lambda uid, include_inactive=False: [{'id': 'legacy'}],
+    )
+    assert [g['id'] for g in goals_mod.get_completed_goals(uid='u1')] == ['legacy']

--- a/desktop/macos/Desktop/Sources/Generated/OmiApi.generated.swift
+++ b/desktop/macos/Desktop/Sources/Generated/OmiApi.generated.swift
@@ -8721,6 +8721,30 @@ public enum OmiAPI {
     return try JSONDecoder().decode(GoalResponse.self, from: data)
   }
 
+  public static func getCompletedGoalsV1GoalsCompletedGet(client: OmiApiClient, authorization: String? = nil, xAppPlatform: String? = nil, xDeviceIdHash: String? = nil, xAppVersion: String? = nil) async throws -> [[String: OmiAnyCodable]] {
+    let _path = "/v1/goals/completed"
+    guard let components = URLComponents(string: client.baseURL + _path) else {
+      throw OmiApiError.invalidURL
+    }
+    guard let url = components.url else { throw OmiApiError.invalidURL }
+    var req = URLRequest(url: url)
+    req.httpMethod = "GET"
+    for (name, value) in client.headers { req.setValue(value, forHTTPHeaderField: name) }
+    if let token = client.token {
+      req.setValue("Bearer " + token, forHTTPHeaderField: "Authorization")
+    }
+    if let authorization { req.setValue(String(authorization), forHTTPHeaderField: "authorization") }
+    if let xAppPlatform { req.setValue(String(xAppPlatform), forHTTPHeaderField: "X-App-Platform") }
+    if let xDeviceIdHash { req.setValue(String(xDeviceIdHash), forHTTPHeaderField: "X-Device-Id-Hash") }
+    if let xAppVersion { req.setValue(String(xAppVersion), forHTTPHeaderField: "X-App-Version") }
+    let (data, resp) = try await URLSession.shared.data(for: req)
+    guard let http = resp as? HTTPURLResponse else { throw OmiApiError.invalidURL }
+    guard (200..<300).contains(http.statusCode) else {
+      throw OmiApiError.httpError(status: http.statusCode, data: data)
+    }
+    return try JSONDecoder().decode([[String: OmiAnyCodable]].self, from: data)
+  }
+
   public static func extractAndUpdateProgressV1GoalsExtractProgressPost(client: OmiApiClient, authorization: String? = nil, xAppPlatform: String? = nil, xDeviceIdHash: String? = nil, xAppVersion: String? = nil, body: OmiAnyCodable) async throws -> OmiAnyCodable {
     let _path = "/v1/goals/extract-progress"
     guard let components = URLComponents(string: client.baseURL + _path) else {
@@ -14283,5 +14307,5 @@ public enum OmiAPI {
     return try JSONDecoder().decode(OmiAnyCodable.self, from: data)
   }
 
-  // Total: 381 Swift client methods generated.
+  // Total: 382 Swift client methods generated.
 }

--- a/desktop/macos/changelog/unreleased/20260718-goals-completed-api-client.json
+++ b/desktop/macos/changelog/unreleased/20260718-goals-completed-api-client.json
@@ -1,0 +1,3 @@
+{
+  "change": "Added a generated API client method for fetching completed goals, so past goals can be listed instead of disappearing once they end"
+}

--- a/desktop/windows/src/renderer/src/lib/omiApi.generated.ts
+++ b/desktop/windows/src/renderer/src/lib/omiApi.generated.ts
@@ -5870,6 +5870,16 @@ export interface OmiApiPaths {
       };
     };
   };
+  "/v1/goals/completed": {
+    get: {
+      operationId: "get_completed_goals_v1_goals_completed_get";
+      responses: {
+        "200": Array<Record<string, unknown>>;
+        "401": void;
+        "422": HTTPValidationError;
+      };
+    };
+  };
   "/v1/goals/extract-progress": {
     post: {
       operationId: "extract_and_update_progress_v1_goals_extract_progress_post";
@@ -11293,6 +11303,25 @@ export async function create_canonical_goal_v1_goals_canonical_post(header: { Id
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
+export async function get_completed_goals_v1_goals_completed_get(header: { authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, init?: OmiApiClientInit): Promise<Array<Record<string, unknown>>> {
+  const _base = init?.baseURL ?? "";
+  const _path = `/v1/goals/completed`;
+  const _search = "";
+  const _res = await fetch(`${_base}${_path}${_search}`, {
+    method: "GET",
+    headers: {
+      ...(init?.token ? { Authorization: `Bearer ${init.token}` } : {}),
+      ...init?.headers,
+      ...(header.authorization !== undefined ? { "authorization": String(header.authorization) } : {}),
+      ...(header.X_App_Platform !== undefined ? { "X-App-Platform": String(header.X_App_Platform) } : {}),
+      ...(header.X_Device_Id_Hash !== undefined ? { "X-Device-Id-Hash": String(header.X_Device_Id_Hash) } : {}),
+      ...(header.X_App_Version !== undefined ? { "X-App-Version": String(header.X_App_Version) } : {}),
+    },
+  });
+  if (!_res.ok) throw new OmiApiError(_res.status, _res);
+  return _res.status === 204 ? (undefined as any) : await _res.json();
+}
+
 export async function extract_and_update_progress_v1_goals_extract_progress_post(header: { authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, body: ProgressExtractRequest, init?: OmiApiClientInit): Promise<ProgressExtractResponse> {
   const _base = init?.baseURL ?? "";
   const _path = `/v1/goals/extract-progress`;
@@ -15539,4 +15568,4 @@ export async function get_speech_profile_v4_speech_profile_get(header: { authori
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
-// Total: 381 client methods generated.
+// Total: 382 client methods generated.

--- a/docs/api-reference/app-client-openapi.json
+++ b/docs/api-reference/app-client-openapi.json
@@ -36851,6 +36851,89 @@
         ]
       }
     },
+    "/v1/goals/completed": {
+      "get": {
+        "description": "Get the user's completed or archived goals (the inactive ones), most recent first.\n\nThe active-goal endpoints (/v1/goals and /v1/goals/all) only ever return active goals,\nso once a goal is ended or bumped out of the active set it can no longer be queried and\nthe user's goal history becomes invisible. This surfaces those inactive goals instead.",
+        "operationId": "get_completed_goals_v1_goals_completed_get",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "title": "Authorization",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-App-Platform",
+            "required": false,
+            "schema": {
+              "title": "X-App-Platform",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Device-Id-Hash",
+            "required": false,
+            "schema": {
+              "title": "X-Device-Id-Hash",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-App-Version",
+            "required": false,
+            "schema": {
+              "title": "X-App-Version",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "additionalProperties": true,
+                    "type": "object"
+                  },
+                  "title": "Response Get Completed Goals V1 Goals Completed Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "401": {
+            "$ref": "#/components/responses/Error401"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "firebaseBearer": []
+          }
+        ],
+        "summary": "Get Completed Goals",
+        "tags": [
+          "goals"
+        ]
+      }
+    },
     "/v1/goals/extract-progress": {
       "post": {
         "description": "Extract goal progress from conversation/chat text and update if found.\nUses LLM to understand context and extract numeric progress.",

--- a/web/admin/lib/services/omi-api/omiApi.generated.ts
+++ b/web/admin/lib/services/omi-api/omiApi.generated.ts
@@ -5870,6 +5870,16 @@ export interface OmiApiPaths {
       };
     };
   };
+  "/v1/goals/completed": {
+    get: {
+      operationId: "get_completed_goals_v1_goals_completed_get";
+      responses: {
+        "200": Array<Record<string, unknown>>;
+        "401": void;
+        "422": HTTPValidationError;
+      };
+    };
+  };
   "/v1/goals/extract-progress": {
     post: {
       operationId: "extract_and_update_progress_v1_goals_extract_progress_post";
@@ -11293,6 +11303,25 @@ export async function create_canonical_goal_v1_goals_canonical_post(header: { Id
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
+export async function get_completed_goals_v1_goals_completed_get(header: { authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, init?: OmiApiClientInit): Promise<Array<Record<string, unknown>>> {
+  const _base = init?.baseURL ?? "";
+  const _path = `/v1/goals/completed`;
+  const _search = "";
+  const _res = await fetch(`${_base}${_path}${_search}`, {
+    method: "GET",
+    headers: {
+      ...(init?.token ? { Authorization: `Bearer ${init.token}` } : {}),
+      ...init?.headers,
+      ...(header.authorization !== undefined ? { "authorization": String(header.authorization) } : {}),
+      ...(header.X_App_Platform !== undefined ? { "X-App-Platform": String(header.X_App_Platform) } : {}),
+      ...(header.X_Device_Id_Hash !== undefined ? { "X-Device-Id-Hash": String(header.X_Device_Id_Hash) } : {}),
+      ...(header.X_App_Version !== undefined ? { "X-App-Version": String(header.X_App_Version) } : {}),
+    },
+  });
+  if (!_res.ok) throw new OmiApiError(_res.status, _res);
+  return _res.status === 204 ? (undefined as any) : await _res.json();
+}
+
 export async function extract_and_update_progress_v1_goals_extract_progress_post(header: { authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, body: ProgressExtractRequest, init?: OmiApiClientInit): Promise<ProgressExtractResponse> {
   const _base = init?.baseURL ?? "";
   const _path = `/v1/goals/extract-progress`;
@@ -15539,4 +15568,4 @@ export async function get_speech_profile_v4_speech_profile_get(header: { authori
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
-// Total: 381 client methods generated.
+// Total: 382 client methods generated.

--- a/web/app/src/lib/omiApi.generated.ts
+++ b/web/app/src/lib/omiApi.generated.ts
@@ -5870,6 +5870,16 @@ export interface OmiApiPaths {
       };
     };
   };
+  "/v1/goals/completed": {
+    get: {
+      operationId: "get_completed_goals_v1_goals_completed_get";
+      responses: {
+        "200": Array<Record<string, unknown>>;
+        "401": void;
+        "422": HTTPValidationError;
+      };
+    };
+  };
   "/v1/goals/extract-progress": {
     post: {
       operationId: "extract_and_update_progress_v1_goals_extract_progress_post";
@@ -11293,6 +11303,25 @@ export async function create_canonical_goal_v1_goals_canonical_post(header: { Id
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
+export async function get_completed_goals_v1_goals_completed_get(header: { authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, init?: OmiApiClientInit): Promise<Array<Record<string, unknown>>> {
+  const _base = init?.baseURL ?? "";
+  const _path = `/v1/goals/completed`;
+  const _search = "";
+  const _res = await fetch(`${_base}${_path}${_search}`, {
+    method: "GET",
+    headers: {
+      ...(init?.token ? { Authorization: `Bearer ${init.token}` } : {}),
+      ...init?.headers,
+      ...(header.authorization !== undefined ? { "authorization": String(header.authorization) } : {}),
+      ...(header.X_App_Platform !== undefined ? { "X-App-Platform": String(header.X_App_Platform) } : {}),
+      ...(header.X_Device_Id_Hash !== undefined ? { "X-Device-Id-Hash": String(header.X_Device_Id_Hash) } : {}),
+      ...(header.X_App_Version !== undefined ? { "X-App-Version": String(header.X_App_Version) } : {}),
+    },
+  });
+  if (!_res.ok) throw new OmiApiError(_res.status, _res);
+  return _res.status === 204 ? (undefined as any) : await _res.json();
+}
+
 export async function extract_and_update_progress_v1_goals_extract_progress_post(header: { authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, body: ProgressExtractRequest, init?: OmiApiClientInit): Promise<ProgressExtractResponse> {
   const _base = init?.baseURL ?? "";
   const _path = `/v1/goals/extract-progress`;
@@ -15539,4 +15568,4 @@ export async function get_speech_profile_v4_speech_profile_get(header: { authori
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
-// Total: 381 client methods generated.
+// Total: 382 client methods generated.

--- a/web/personas-open-source/src/lib/omiApi.generated.ts
+++ b/web/personas-open-source/src/lib/omiApi.generated.ts
@@ -5870,6 +5870,16 @@ export interface OmiApiPaths {
       };
     };
   };
+  "/v1/goals/completed": {
+    get: {
+      operationId: "get_completed_goals_v1_goals_completed_get";
+      responses: {
+        "200": Array<Record<string, unknown>>;
+        "401": void;
+        "422": HTTPValidationError;
+      };
+    };
+  };
   "/v1/goals/extract-progress": {
     post: {
       operationId: "extract_and_update_progress_v1_goals_extract_progress_post";
@@ -11293,6 +11303,25 @@ export async function create_canonical_goal_v1_goals_canonical_post(header: { Id
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
+export async function get_completed_goals_v1_goals_completed_get(header: { authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, init?: OmiApiClientInit): Promise<Array<Record<string, unknown>>> {
+  const _base = init?.baseURL ?? "";
+  const _path = `/v1/goals/completed`;
+  const _search = "";
+  const _res = await fetch(`${_base}${_path}${_search}`, {
+    method: "GET",
+    headers: {
+      ...(init?.token ? { Authorization: `Bearer ${init.token}` } : {}),
+      ...init?.headers,
+      ...(header.authorization !== undefined ? { "authorization": String(header.authorization) } : {}),
+      ...(header.X_App_Platform !== undefined ? { "X-App-Platform": String(header.X_App_Platform) } : {}),
+      ...(header.X_Device_Id_Hash !== undefined ? { "X-Device-Id-Hash": String(header.X_Device_Id_Hash) } : {}),
+      ...(header.X_App_Version !== undefined ? { "X-App-Version": String(header.X_App_Version) } : {}),
+    },
+  });
+  if (!_res.ok) throw new OmiApiError(_res.status, _res);
+  return _res.status === 204 ? (undefined as any) : await _res.json();
+}
+
 export async function extract_and_update_progress_v1_goals_extract_progress_post(header: { authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, body: ProgressExtractRequest, init?: OmiApiClientInit): Promise<ProgressExtractResponse> {
   const _base = init?.baseURL ?? "";
   const _path = `/v1/goals/extract-progress`;
@@ -15539,4 +15568,4 @@ export async function get_speech_profile_v4_speech_profile_get(header: { authori
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
-// Total: 381 client methods generated.
+// Total: 382 client methods generated.


### PR DESCRIPTION
## What

There is no way for a client to retrieve a user's past goals. The active-goal endpoints only ever return active goals:

- `GET /v1/goals` returns the first active goal.
- `GET /v1/goals/all` returns active goals only (capped at 4).

When a goal is ended, or bumped out of the active set (the create flow deactivates the oldest active goal once the cap is reached, setting `is_active = False` and `ended_at`), it disappears from the API entirely. The `get_all_goals(uid, include_inactive=True)` database helper already reads those inactive goals, but nothing exposed it.

## Change

Add `GET /v1/goals/completed`, which returns the user's inactive (completed or archived) goals, most recent first. It filters `get_all_goals(include_inactive=True)` down to `is_active == False` and serializes the `created_at`, `updated_at`, and `ended_at` datetimes to ISO strings, matching the sibling endpoints.

- Single new endpoint in `backend/routers/goals.py`. No changes to the database layer or any existing endpoint.
- The static `/v1/goals/completed` path is registered before the `/{goal_id}` routes, so it is never shadowed by the path parameter.

## Test

New `backend/tests/unit/test_goals_completed_endpoint.py`:
- returns only the inactive goals, order preserved, with datetimes serialized (including `ended_at`), and confirms the DB is queried with `include_inactive=True`.
- returns an empty list when every goal is active.
- treats a legacy goal with no `is_active` field as inactive so it stays visible rather than being lost.

Test isolation follows the current backend rules: `routers.goals` imports cleanly, so the test imports it normally, patches the import-cheap `goals_db` with `monkeypatch.setattr`, and calls the handler directly. No `sys.modules` mutation. Passes the import-purity and stub-pollution scanners, and is auto-discovered by `scripts/select_backend_unit_tests.py --all`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8890?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

