### PR TITLE
Fix chat jump indicator at bottom

### DIFF
--- a/desktop/macos/Desktop/Sources/MainWindow/Components/ChatMessagesView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Components/ChatMessagesView.swift
@@ -499,6 +499,12 @@ struct ChatMessagesView<WelcomeContent: View>: View {
                 }
                 userScrollEndWorkItem = endWork
                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.3, execute: endWork)
+            } onScrollSettledAtBottom: {
+                guard scrollMode == .freeScrolling || scrollMode == .anchoringTurn else { return }
+                cancelAllPendingScrolls()
+                userIsScrolling = false
+                scrollMode = .followingBottom
+                hasActivityBelow = false
             }
         }
     }

--- a/desktop/macos/Desktop/Sources/MainWindow/Components/ChatScrollBehavior.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Components/ChatScrollBehavior.swift
@@ -86,6 +86,7 @@ struct ScrollPositionDetector: NSViewRepresentable {
 /// keyboard scroll-navigation on the enclosing NSScrollView.
 struct UserScrollDetector: NSViewRepresentable {
   let onUserScroll: () -> Void
+  var onScrollSettledAtBottom: () -> Void = {}
 
   func makeNSView(context: Context) -> NSView {
     let view = NSView()
@@ -98,11 +99,12 @@ struct UserScrollDetector: NSViewRepresentable {
   func updateNSView(_ nsView: NSView, context: Context) {}
 
   func makeCoordinator() -> Coordinator {
-    Coordinator(onUserScroll: onUserScroll)
+    Coordinator(onUserScroll: onUserScroll, onScrollSettledAtBottom: onScrollSettledAtBottom)
   }
 
   class Coordinator: NSObject {
     let onUserScroll: () -> Void
+    let onScrollSettledAtBottom: () -> Void
     private var monitor: Any?
 
     private static let scrollNavigationKeyCodes: Set<UInt16> = [
@@ -114,8 +116,9 @@ struct UserScrollDetector: NSViewRepresentable {
       119,  // End
     ]
 
-    init(onUserScroll: @escaping () -> Void) {
+    init(onUserScroll: @escaping () -> Void, onScrollSettledAtBottom: @escaping () -> Void) {
       self.onUserScroll = onUserScroll
+      self.onScrollSettledAtBottom = onScrollSettledAtBottom
     }
 
     func install(for view: NSView) {
@@ -151,6 +154,7 @@ struct UserScrollDetector: NSViewRepresentable {
             self.onUserScroll()
           }
         }
+        self.scheduleSettledBottomChecks(for: targetScrollView)
         return event
       }
     }
@@ -158,6 +162,24 @@ struct UserScrollDetector: NSViewRepresentable {
     private static func isScrollViewKeyboardTarget(in window: NSWindow?, scrollView: NSScrollView) -> Bool {
       guard let window, let firstResponderView = window.firstResponder as? NSView else { return false }
       return firstResponderView === scrollView || firstResponderView.isDescendant(of: scrollView)
+    }
+
+    private func scheduleSettledBottomChecks(for scrollView: NSScrollView) {
+      for delay in [0.12, 0.36] {
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self, weak scrollView] in
+          guard let self, let scrollView, Self.isAtBottom(scrollView) else { return }
+          self.onScrollSettledAtBottom()
+        }
+      }
+    }
+
+    private static func isAtBottom(_ scrollView: NSScrollView) -> Bool {
+      guard let documentView = scrollView.documentView else { return false }
+      let clipBounds = scrollView.contentView.bounds
+      let documentHeight = documentView.frame.height
+      let visibleMaxY = clipBounds.origin.y + clipBounds.height
+      let threshold: CGFloat = 100
+      return visibleMaxY >= documentHeight - threshold
     }
 
     deinit {
@@ -250,6 +272,12 @@ struct ChatScrollContainer<Content: View>: View {
         }
         userScrollEndWorkItem = endWork
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.3, execute: endWork)
+      } onScrollSettledAtBottom: {
+        guard scrollMode == .freeScrolling else { return }
+        cancelAllPendingScrolls()
+        userIsScrolling = false
+        scrollMode = .followingBottom
+        hasActivityBelow = false
       }
     }
   }

--- a/desktop/macos/Desktop/Tests/AgentPillLifecycleTests.swift
+++ b/desktop/macos/Desktop/Tests/AgentPillLifecycleTests.swift
@@ -190,6 +190,9 @@ final class AgentPillLifecycleTests: XCTestCase {
     XCTAssertFalse(viewSource.contains("proxy.scrollTo(\"agentBottom\", anchor: .bottom)"))
     XCTAssertTrue(scrollSource.contains("struct ChatScrollContainer<Content: View>: View"))
     XCTAssertTrue(scrollSource.contains("UserScrollDetector {"))
+    XCTAssertTrue(scrollSource.contains("onScrollSettledAtBottom"))
+    XCTAssertTrue(scrollSource.contains("scheduleSettledBottomChecks"))
+    XCTAssertTrue(scrollSource.contains("Self.isAtBottom(scrollView)"))
     XCTAssertTrue(scrollSource.contains("scrollMode = .freeScrolling"))
     XCTAssertTrue(scrollSource.contains("if scrollMode == .followingBottom"))
   }

--- a/desktop/macos/changelog/unreleased/20260703-chat-bottom-indicator.json
+++ b/desktop/macos/changelog/unreleased/20260703-chat-bottom-indicator.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed the chat jump-to-latest button so it disappears when scrolling reaches the latest message."
+}


### PR DESCRIPTION
## Summary
- Add a settled-bottom check after user scroll gestures so chat jump-to-latest buttons clear when the scroll view reaches the live edge.
- Apply the behavior to both the compact chat scroll container and the main chat messages view.
- Add a desktop changelog fragment and a source-level regression guard for the shared scroll policy.

## Verification
- `git diff --check`
- `xcrun swift test --package-path desktop/macos/Desktop --filter AgentPillLifecycleTests/testStreamingResponseGrowthIsSteppedAndNonAnimated`
- `OMI_APP_NAME="omi-chat-scroll" OMI_AUTOMATION_PORT=47923 ./run.sh --yolo`
- Runtime checked `/Applications/omi-chat-scroll.app` through the automation bridge: opened Ask Omi, sent a real chat prompt, observed completion in `/private/tmp/omi-dev.log`, and captured the completed floating chat at the latest message with no down-arrow jump button visible.

## Notes
- Pre-push checks passed. They reported the existing advisory that `desktop/macos/Desktop/Tests/AgentPillLifecycleTests.swift` is over the file-size threshold.
