### PR TITLE
ci: allow explicit desktop release versions

### DIFF
--- a/.github/scripts/plan-desktop-release.py
+++ b/.github/scripts/plan-desktop-release.py
@@ -142,14 +142,17 @@ def main() -> int:
     changes = releasable_desktop_changes_since(latest_tag)
     set_output("latest_tag", latest_tag or "")
 
-    if not changes:
+    if not changes and args.mode == "force_release":
+        print("No releasable desktop app changes since the latest desktop tag, but force_release was requested.")
+    elif not changes:
         set_output("should_release", "false")
         set_output("reason", "No releasable desktop app changes since the latest desktop tag.")
         return 0
 
-    print("Releasable desktop app changes since latest tag:")
-    for path in changes:
-        print(f"  - {path}")
+    if changes:
+        print("Releasable desktop app changes since latest tag:")
+        for path in changes:
+            print(f"  - {path}")
 
     if args.mode != "force_release":
         active_reason = active_release_reason(args.repository, latest_tag)

--- a/.github/workflows/desktop_auto_release.yml
+++ b/.github/workflows/desktop_auto_release.yml
@@ -20,6 +20,10 @@ on:
         options:
           - release_now
           - force_release
+      next_version:
+        description: 'Optional explicit desktop version to tag (for example, 0.12.0)'
+        required: false
+        type: string
 
 permissions:
   contents: write
@@ -102,11 +106,22 @@ jobs:
       - name: Compute next version and consolidate changelog
         if: steps.recheck.outputs.should_release == 'true'
         id: version
+        env:
+          NEXT_VERSION: ${{ github.event.inputs.next_version || '' }}
         run: |
           # Get latest desktop release tag
           LATEST=$(git tag -l 'v*-macos' | sort -V | tail -1)
 
-          if [ -z "$LATEST" ]; then
+          if [ -n "$NEXT_VERSION" ]; then
+            if ! [[ "$NEXT_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo "next_version must be a semantic version like 0.12.0" >&2
+              exit 1
+            fi
+            VERSION="$NEXT_VERSION"
+            if [ -n "$LATEST" ]; then
+              python3 -c 'import sys; latest=sys.argv[1].removeprefix("v").split("+", 1)[0]; candidate=sys.argv[2]; parse=lambda v: tuple(int(p) for p in v.split(".")); sys.exit(0 if parse(candidate) > parse(latest) else f"next_version {candidate} must be greater than latest desktop version {latest}")' "$LATEST" "$VERSION"
+            fi
+          elif [ -z "$LATEST" ]; then
             VERSION="0.0.1"
           else
             # Strip v prefix and +build-macos suffix  e.g. v0.11.11+11011-macos -> 0.11.11


### PR DESCRIPTION
## Summary
- Adds an optional `next_version` input to the desktop auto-release workflow so a minor-version candidate like `0.12.0` can be tagged through the normal release path.
- Allows `force_release` to create a tag even when a previous tag already consumed the current desktop diff, which makes one-shot version rollovers deterministic.

## Test Plan
- `python3 .github/scripts/plan-desktop-release.py --repository BasedHardware/omi --mode release_now`
- `python3 .github/scripts/plan-desktop-release.py --repository BasedHardware/omi --mode force_release`
- `python3 .github/scripts/desktop-changelog.py validate`
- Simulated `next_version=0.12.0` build-number calculation -> `v0.12.0+12000-macos`
- Simulated rejection when `next_version` is not greater than latest
- `actionlint .github/workflows/desktop_auto_release.yml`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8897?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

