### PR TITLE
Fix hermetic network guard on Windows without AF_UNIX

### DIFF
--- a/backend/test.sh
+++ b/backend/test.sh
@@ -327,6 +327,8 @@ pytest tests/unit/test_pusher_circuit_breaker.py -v
 pytest tests/unit/test_pusher_ghost_connections.py -v
 pytest tests/unit/test_async_tasks.py -v
 pytest tests/unit/test_async_resource_correctness.py -v
+pytest tests/unit/test_hermetic_network.py -v
+pytest tests/unit/test_hermetic_network_collection_guard.py -v
 pytest tests/unit/test_lock_bypass_fixes.py -v
 pytest tests/unit/test_integration_malformed_records.py -v
 pytest tests/unit/test_oauth_callback_uid_guard.py -v

--- a/backend/testing/hermetic_network.py
+++ b/backend/testing/hermetic_network.py
@@ -37,6 +37,11 @@ def _host_from_address(address: object) -> object:
     return None
 
 
+def _is_unix_socket(sock: socket.socket) -> bool:
+    af_unix = getattr(socket, 'AF_UNIX', None)
+    return af_unix is not None and sock.family == af_unix
+
+
 @contextmanager
 def block_outbound_network() -> Iterator[None]:
     original_connect = socket.socket.connect
@@ -47,12 +52,12 @@ def block_outbound_network() -> Iterator[None]:
     original_gethostbyname_ex = socket.gethostbyname_ex
 
     def guarded_connect(sock: socket.socket, address: object):
-        if sock.family != socket.AF_UNIX and not is_local_address(_host_from_address(address)):
+        if not _is_unix_socket(sock) and not is_local_address(_host_from_address(address)):
             raise BlockedNetworkError(f'Blocked outbound network connection to {address!r}')
         return original_connect(sock, address)
 
     def guarded_connect_ex(sock: socket.socket, address: object):
-        if sock.family != socket.AF_UNIX and not is_local_address(_host_from_address(address)):
+        if not _is_unix_socket(sock) and not is_local_address(_host_from_address(address)):
             raise BlockedNetworkError(f'Blocked outbound network connection to {address!r}')
         return original_connect_ex(sock, address)
 

--- a/backend/tests/unit/test_hermetic_network.py
+++ b/backend/tests/unit/test_hermetic_network.py
@@ -20,6 +20,20 @@ def test_external_socket_connect_is_blocked():
         sock.close()
 
 
+def test_local_socket_connect_does_not_require_af_unix(monkeypatch):
+    monkeypatch.delattr(socket, 'AF_UNIX', raising=False)
+    server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    client = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        server.bind(('127.0.0.1', 0))
+        server.listen(1)
+
+        client.connect(server.getsockname())
+    finally:
+        client.close()
+        server.close()
+
+
 def test_external_dns_resolution_is_blocked():
     with pytest.raises(BlockedNetworkError):
         socket.getaddrinfo('example.com', 443)


### PR DESCRIPTION
## Summary
- Make the backend hermetic network guard tolerate Python builds/platforms without `socket.AF_UNIX`.
- Add a regression test that deletes `socket.AF_UNIX` and verifies localhost socket connections are still allowed.
- Add the existing hermetic network tests to `backend/test.sh` fallback coverage.

## Refresh
- Rebased on `main` at `b781d91767ac96a20f2305614eb50c7744a8a6c3`.
- Current head: `f08eaece6b6410cf466aafdf2da6d897f25c00a5`.
- GitHub currently reports this PR as mergeable.

## Testing
- `D:\codex-omi-work\.venvs\omi-backend-311\Scripts\python.exe -m pytest tests\unit\test_hermetic_network.py tests\unit\test_hermetic_network_collection_guard.py -q --tb=short` -> 7 passed
- `D:\codex-omi-work\.venvs\omi-backend-311\Scripts\python.exe -m py_compile testing\hermetic_network.py tests\unit\test_hermetic_network.py tests\unit\test_hermetic_network_collection_guard.py`
- `D:\codex-omi-work\.venvs\omi-backend-311\Scripts\python.exe -m black --line-length 120 --skip-string-normalization --check testing\hermetic_network.py tests\unit\test_hermetic_network.py tests\unit\test_hermetic_network_collection_guard.py` -> 3 files would be left unchanged
- `git diff --check origin/main...HEAD` -> passed
- `git diff --check` -> passed
- `scripts/pre-commit` with `PYTHONUTF8=1` -> passed
- `scripts/pre-push` with `PYTHONUTF8=1` -> passed