### PR TITLE
fix(desktop): respect master Notifications toggle for proactive notifications (#6778)

### DIFF
--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Components/SettingsContentView+BillingHelpers.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Components/SettingsContentView+BillingHelpers.swift
@@ -755,7 +755,9 @@ extension SettingsContentView {
           dailySummaryHour = dailySummary.hour
           notificationsEnabled = notifications.enabled
           notificationFrequency = notifications.frequency
-          // Mirror to UserDefaults so NotificationService can throttle without a backend roundtrip.
+          // Mirror to UserDefaults so NotificationService can gate/throttle without a backend roundtrip.
+          UserDefaults.standard.set(
+            notifications.enabled, forKey: NotificationService.masterEnabledDefaultsKey)
           UserDefaults.standard.set(notifications.frequency, forKey: NotificationService.frequencyDefaultsKey)
           userLanguage = language.language
           recordingPermissionEnabled = recording.enabled

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Components/SettingsContentView+SettingsUpdates.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Components/SettingsContentView+SettingsUpdates.swift
@@ -34,6 +34,11 @@ extension SettingsContentView {
   }
 
   func updateNotificationSettings(enabled: Bool? = nil, frequency: Int? = nil) {
+    if let enabled {
+      // Mirror locally so NotificationService suppresses/resumes proactive notifications
+      // immediately when the master toggle flips, even before the backend round-trip completes.
+      UserDefaults.standard.set(enabled, forKey: NotificationService.masterEnabledDefaultsKey)
+    }
     if let frequency {
       // Mirror locally so NotificationService picks up the new throttle level immediately,
       // even before the backend round-trip completes.

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/NotificationService.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/NotificationService.swift
@@ -80,6 +80,13 @@ class NotificationService: NSObject, UNUserNotificationCenterDelegate {
     /// has already run for this install, so we never re-disable a user who opted back in.
     static let offByDefaultMigrationKey = "notificationsOffByDefaultMigrationDone"
 
+    /// UserDefaults key mirroring the master `notifications_enabled` toggle from the backend.
+    /// The Settings page writes it on load and on toggle change; `sendNotification` reads it
+    /// synchronously so proactive notifications are suppressed the moment the user turns the
+    /// master Notifications switch off — without waiting for a backend round-trip. Defaults to
+    /// `true` when the key is absent (first run before the Settings page hydrates).
+    static let masterEnabledDefaultsKey = "notifications_enabled"
+
     /// Default level used when the key has never been written (e.g. first run before
     /// the Settings page has hydrated from the backend). Mirrors the backend default.
     /// Proactive notifications are OFF by default — users opt in via the Settings slider.
@@ -268,6 +275,16 @@ class NotificationService: NSObject, UNUserNotificationCenterDelegate {
             return
         }
 
+        // Proactive notifications honor the master Notifications toggle. When the user
+        // turns Notifications off in Settings, suppress the floating-bar popup and the
+        // native banner entirely (#6778). Functional notifications (Crisp support replies,
+        // screen-recording permission prompts, onboarding test) pass `respectFrequency: false`
+        // to bypass this, matching the frequency gate below.
+        if respectFrequency && !Self.areNotificationsEnabled() {
+            log("NotificationService: suppressing \(assistantId) notification because notifications are disabled")
+            return
+        }
+
         // Proactive notifications honor the user's frequency setting. Functional
         // notifications (Crisp support replies, screen-recording permission prompts,
         // onboarding test) pass `respectFrequency: false` to bypass the gate.
@@ -390,6 +407,16 @@ class NotificationService: NSObject, UNUserNotificationCenterDelegate {
                     "NotificationService: off-by-default migration backend push failed", error: error)
             }
         }
+    }
+
+    /// Whether the master Notifications toggle is on. Reads the mirrored UserDefaults key,
+    /// defaulting to `true` when absent so notifications are not accidentally suppressed
+    /// before the Settings page has hydrated from the backend.
+    static func areNotificationsEnabled() -> Bool {
+        guard UserDefaults.standard.object(forKey: Self.masterEnabledDefaultsKey) != nil else {
+            return true
+        }
+        return UserDefaults.standard.bool(forKey: Self.masterEnabledDefaultsKey)
     }
 
     /// Current frequency level from UserDefaults, clamped to [0, 5]. Falls back to

--- a/desktop/macos/changelog/unreleased/20260703-respect-master-notifications-toggle.json
+++ b/desktop/macos/changelog/unreleased/20260703-respect-master-notifications-toggle.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed proactive notifications (and the floating bar popup) still appearing after turning the master Notifications toggle off in Settings"
+}


### PR DESCRIPTION
## Bug
Reported in #6778 by two users (macOS 0.11.318 / 0.11.343): with **Settings → Notifications: Off**, proactive notifications still pop up the Floating Bar. Turning the Floating Bar toggle off doesn't help either — a proactive notification temporarily shows the bar for ~6s (intended, #6972), so the visible symptom is "disable not respected."

## Root cause
The master **Notifications** toggle handler (`updateNotificationSettings(enabled:)`) only pushed `enabled` to the backend. `NotificationService.sendNotification` gated proactive notifications on snooze, per-assistant enable flags, and the **frequency** slider (0=Off) — but never on the master toggle. So a user who flips the master switch off (while leaving frequency at e.g. Balanced) keeps receiving proactive notifications and their Floating Bar popup.

## Fix (surgical, ~30 lines, 3 files + changelog)
- `NotificationService`: add `masterEnabledDefaultsKey` + `areNotificationsEnabled()` (defaults true before hydration), and gate proactive sends on it — right beside the existing frequency gate. Functional notifications (Crisp support replies, screen-recording permission prompts) pass `respectFrequency: false` and bypass, exactly as they bypass the frequency gate.
- Mirror `notifications.enabled` to `UserDefaults` on settings load (`BillingHelpers`) and on toggle change (`SettingsUpdates`), matching the existing frequency-mirroring pattern so it takes effect without a backend round-trip.

Compile-checked with `xcrun swift build -c debug` (build complete, only pre-existing warnings).

🤖 automated by hourly watchdog; opened for review, not merged.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8904?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

