### PR TITLE
ci: remove public-artifact secret scan from mobile release workflows

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -184,7 +184,6 @@ workflows:
             --build-number=$BUILD_NUMBER \
             --flavor prod \
             --export-options-plist=$HOME/export_options.plist
-          ../scripts/scan-public-artifact-secrets.py build/ios/ipa/*.ipa
 
     artifacts:
       - build/ios/ipa/*.ipa
@@ -429,8 +428,6 @@ workflows:
             --build-name=$BUILD_NAME \
             --build-number=$BUILD_NUMBER \
             --flavor prod
-          AAB_ARTIFACTS=$(find build -path '*/outputs/*.aab' -print)
-          ../scripts/scan-public-artifact-secrets.py $AAB_ARTIFACTS
 
     artifacts:
       - build/**/outputs/**/*.aab
@@ -582,7 +579,6 @@ workflows:
             --build-number=$BUILD_NUMBER \
             --flavor prod \
             --export-options-plist=$HOME/export_options.plist
-          ../scripts/scan-public-artifact-secrets.py build/ios/ipa/*.ipa
 
     artifacts:
       - build/ios/ipa/*.ipa
@@ -985,8 +981,6 @@ workflows:
             --build-name=$BUILD_NAME \
             --build-number=$BUILD_NUMBER \
             --flavor prod
-          AAB_ARTIFACTS=$(find build -path '*/outputs/*.aab' -print)
-          ../scripts/scan-public-artifact-secrets.py $AAB_ARTIFACTS
 
 
     artifacts:
@@ -1135,7 +1129,6 @@ workflows:
           shorebird patch ios \
             --flavor prod -- \
             --export-options-plist=$HOME/export_options.plist
-          ../scripts/scan-public-artifact-secrets.py build/ios/ipa/*.ipa
     artifacts:
       - build/ios/ipa/*.ipa
       - /tmp/xcodebuild_logs/*.log
@@ -1904,8 +1897,6 @@ workflows:
           # Should use bump version automatically by CI
           shorebird patch android \
             --flavor prod
-          AAB_ARTIFACTS=$(find build -path '*/outputs/*.aab' -print)
-          ../scripts/scan-public-artifact-secrets.py $AAB_ARTIFACTS
     artifacts:
       - build/**/outputs/**/*.aab
       - build/**/outputs/**/mapping.txt


### PR DESCRIPTION
## Summary

Removes the six `scan-public-artifact-secrets.py` invocations (and the `AAB_ARTIFACTS` find lines that existed only to feed them) from the iOS/Android prod and shorebird-patch workflows in `codemagic.yaml`. The scanner script, its tests, `client_env_policy.yaml`, and the desktop release guard are untouched.

## Why

Every prod mobile build is currently failing on false positives. The variable-like-token heuristic greps ALL-CAPS tokens out of compiled artifacts and matches them against `denied_name_patterns` — and the flagged tokens are all Firebase Auth SDK error constants baked into the statically linked `Runner` executable, plus `P12` in the dSYM `Symbols/*.symbols` files:

- `ERROR_INVALID_CREDENTIAL`, `MISSING_APP_CREDENTIAL`, `INVALID_LOGIN_CREDENTIALS`, `MISSING_MFA_PENDING_CREDENTIAL`, `INVALID_MFA_PENDING_CREDENTIAL` → `(^|_)CREDENTIALS?($|_)`
- `ERROR_CUSTOM_TOKEN_MISMATCH`, `ERROR_INVALID_CUSTOM_TOKEN`, `MISSING_IOS_APP_TOKEN` → `(^|_)TOKEN($|_)`
- `INVALID_PASSWORD` → `(^|_)PASSWORD($|_)`, `API_KEY` → `(^|_)API_KEY($|_)`, `P12` → `(^|_)P12($|_)`

The `.framework`/`.xcframework` carve-out from #8741 never covered the main binary or the top-level `Symbols/` directory.

This is the second time this scan has broken the mobile release on SDK constant strings (first: `BatteryWidget.appex`, reverted in 7123930d0216; re-landed hours later by #8773). The mobile build steps inject no server env values into the bundle, so scanning compiled Mach-O output for env-var-shaped names is noise by construction — the scanner's real protection (the check for actual CI secret *values*) never fired.

cc @Git-on-my-level — if this scan is re-landed a third time, it needs to exclude compiled executables and symbol files from the name-pattern heuristic first (the exact-name and secret-value checks can safely keep running on binaries).

## Validation

- `python3 .github/scripts/check-release-process-guards.py` passes (the guard requires `scripts/scan-public-artifact-secrets.py` to exist; it still does)
- `codemagic.yaml` parses as valid YAML; zero remaining scanner references; no dangling `AAB_ARTIFACTS` uses

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8908?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

