### PR TITLE
Fix Windows Memories graph idle GPU work

### DIFF
--- a/desktop/windows/src/renderer/src/components/graph/BrainGraph.tsx
+++ b/desktop/windows/src/renderer/src/components/graph/BrainGraph.tsx
@@ -24,6 +24,9 @@ export type BrainGraphProps = {
   // when shown. Use for the Memories tab. Leave false (default) for onboarding,
   // where the map is deliberately kept mounted across steps and must not blank.
   pauseWhenHidden?: boolean
+  // Use demand for idle-heavy surfaces such as Memories so the WebGL canvas
+  // stops rendering once layout/easing has settled.
+  frameLoop?: 'always' | 'demand'
 }
 
 // Must match GraphSimulation.nodeRadius so the spheres and the collision force
@@ -46,7 +49,8 @@ function GraphNodeMesh({
   node,
   centerNodeId,
   reduced,
-  posMap
+  posMap,
+  frameLoop
 }: {
   sim: GraphSimulation
   node: NodePosition
@@ -55,6 +59,7 @@ function GraphNodeMesh({
   // Shared map (owned by GraphScene, recreated on mount) where each node writes
   // its eased on-screen position so the edges can connect to it.
   posMap: Map<string, THREE.Vector3>
+  frameLoop: 'always' | 'demand'
 }): React.JSX.Element {
   const groupRef = useRef<THREE.Group>(null)
   const coreMat = useRef<THREE.MeshStandardMaterial>(null)
@@ -67,6 +72,7 @@ function GraphNodeMesh({
   // The center ("you") label gets a bit bigger than the proportional size.
   const labelSize = labelFontSize(node.sizeScale) * (isFixed ? 1.35 : 1)
   const phase = useMemo(() => hashPhase(node.id), [node.id])
+  const invalidate = useThree((state) => state.invalidate)
 
   // Read the live simulation position each frame (no React state in the loop)
   // and ease toward it so motion stays smooth. New nodes fly out from the
@@ -77,6 +83,7 @@ function GraphNodeMesh({
     const live = sim.liveNode(node.id)
     if (live) target.current.set(live.x ?? 0, live.y ?? 0, live.z ?? 0)
 
+    let shouldContinue = false
     if (reduced) {
       g.position.copy(target.current)
       g.scale.setScalar(1)
@@ -84,7 +91,9 @@ function GraphNodeMesh({
       // Low lerp factor = slow, smooth glide toward the target (used both for
       // the initial reveal and for the gentle reshuffle drift between screens).
       g.position.lerp(target.current, 0.045)
+      if (g.position.distanceToSquared(target.current) < 0.01) g.position.copy(target.current)
       if (g.scale.x < 1) g.scale.setScalar(Math.min(1, g.scale.x + 0.05))
+      shouldContinue = g.position.distanceToSquared(target.current) > 0.01 || g.scale.x < 1
     }
     // Record the eased on-screen position so the connecting lines follow the
     // sphere exactly (instead of snapping to the raw sim position). The map is
@@ -106,6 +115,7 @@ function GraphNodeMesh({
     if (coreMat.current) coreMat.current.emissiveIntensity = (0.85 + 0.45 * pulse) * flare
     if (glowMat.current) glowMat.current.opacity = (0.12 + 0.14 * pulse) * flare
     if (glowMesh.current) glowMesh.current.scale.setScalar(1 + 0.18 * pulse)
+    if (frameLoop === 'demand' && shouldContinue) invalidate()
   })
 
   return (
@@ -263,9 +273,11 @@ function GraphScene({
   graph,
   centerNodeId,
   interactive,
-  shuffleKey
+  shuffleKey,
+  frameLoop = 'always'
 }: BrainGraphProps): React.JSX.Element {
   const { sim, nodes, reduced } = useGraphSimulation(graph, centerNodeId)
+  const invalidate = useThree((state) => state.invalidate)
 
   // Eased on-screen position of each node, written by the meshes and read by the
   // edges so the lines stay glued to the spheres. Owned here (not on the sim) and
@@ -284,13 +296,20 @@ function GraphScene({
       firstShuffle.current = false
       return
     }
-    if (!reduced) sim.reshuffle?.()
-  }, [shuffleKey, sim, reduced])
+    if (!reduced) {
+      sim.reshuffle?.()
+      if (frameLoop === 'demand') invalidate()
+    }
+  }, [shuffleKey, sim, reduced, frameLoop, invalidate])
+
+  useEffect(() => {
+    if (frameLoop === 'demand') invalidate()
+  }, [graph, frameLoop, invalidate])
 
   // Advance the physics in the render loop (only while warm). Nothing here
   // touches React state, so the scene never re-renders frame to frame.
   useFrame(() => {
-    if (!reduced) sim.settleFrame()
+    if (!reduced && sim.settleFrame() && frameLoop === 'demand') invalidate()
   })
 
   return (
@@ -306,6 +325,7 @@ function GraphScene({
           centerNodeId={centerNodeId}
           reduced={reduced}
           posMap={posMap}
+          frameLoop={frameLoop}
         />
       ))}
       {interactive ? (
@@ -331,7 +351,8 @@ export function BrainGraph({
   centerNodeId,
   interactive = true,
   shuffleKey,
-  pauseWhenHidden = false
+  pauseWhenHidden = false,
+  frameLoop = 'always'
 }: BrainGraphProps): React.JSX.Element {
   const hostRef = useRef<HTMLDivElement>(null)
   const [visible, setVisible] = useState(true)
@@ -365,7 +386,7 @@ export function BrainGraph({
         // its distance from the FOV, so the framing/zoom is unchanged.
         camera={{ position: [0, 0, 700], fov: 28, near: 1, far: 20000 }}
         dpr={[1, 2]}
-        frameloop="always"
+        frameloop={frameLoop}
         gl={{ antialias: true, alpha: true }}
       >
         <GraphScene
@@ -373,6 +394,7 @@ export function BrainGraph({
           centerNodeId={centerNodeId}
           interactive={interactive}
           shuffleKey={shuffleKey}
+          frameLoop={frameLoop}
         />
       </Canvas>
       )}

--- a/desktop/windows/src/renderer/src/lib/useGraphSimulation.test.ts
+++ b/desktop/windows/src/renderer/src/lib/useGraphSimulation.test.ts
@@ -47,4 +47,15 @@ describe('GraphSimulation', () => {
     expect(sim.consumeNewlyAdded()).toEqual(['language_en'])
     expect(sim.consumeNewlyAdded()).toEqual([]) // consumed
   })
+
+  it('reports whether frame-by-frame settling still needs rendering', () => {
+    const sim = new GraphSimulation('user')
+    sim.setGraph(g2)
+
+    expect(sim.settleFrame()).toBe(true)
+
+    sim.settle(300)
+
+    expect(sim.settleFrame()).toBe(false)
+  })
 })

--- a/desktop/windows/src/renderer/src/lib/useGraphSimulation.ts
+++ b/desktop/windows/src/renderer/src/lib/useGraphSimulation.ts
@@ -253,11 +253,13 @@ export class GraphSimulation {
 
   // Advance one tick per render frame, but only while the layout is still warm.
   // Once alpha decays the layout is settled and ticking stops (no idle CPU).
-  settleFrame(): void {
+  settleFrame(): boolean {
     if (this.sim.alpha() > 0.01) {
       this.sim.tick(1)
       this.clampPositions()
+      return this.sim.alpha() > 0.01
     }
+    return false
   }
 
   // Live simulation node (positions mutate in place each tick). The renderer

--- a/desktop/windows/src/renderer/src/pages/Memories.performance.test.ts
+++ b/desktop/windows/src/renderer/src/pages/Memories.performance.test.ts
@@ -1,0 +1,22 @@
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const source = readFileSync(join(here, 'Memories.tsx'), 'utf8')
+
+describe('Memories WebGL performance guards', () => {
+  it('keeps the BrainGraph canvas out of blurred glass surfaces', () => {
+    const brainGraphPane = source.match(
+      /<div className="mx-auto mb-6 max-w-4xl">[\s\S]*?<BrainGraph[\s\S]*?<\/div>\s*<\/div>/
+    )
+
+    expect(brainGraphPane?.[0]).toContain('bg-black/40')
+    expect(brainGraphPane?.[0]).not.toMatch(/className="[^"]*(?:surface-card|glass)/)
+  })
+
+  it('renders the Memories BrainGraph on demand instead of every frame', () => {
+    expect(source).toContain('frameLoop="demand"')
+  })
+})

--- a/desktop/windows/src/renderer/src/pages/Memories.tsx
+++ b/desktop/windows/src/renderer/src/pages/Memories.tsx
@@ -210,7 +210,13 @@ export function Memories(): React.JSX.Element {
                 the graph on every unrelated UI repaint, pinning GPU at 50-60%.
                 Keeps the card look via a solid tint + hairline border. */}
             <div className="relative h-80 overflow-hidden rounded-2xl border border-white/[0.08] bg-black/40 p-0">
-              <BrainGraph graph={brainGraph} centerNodeId={centerNodeId} interactive={false} pauseWhenHidden />
+              <BrainGraph
+                graph={brainGraph}
+                centerNodeId={centerNodeId}
+                interactive={false}
+                pauseWhenHidden
+                frameLoop="demand"
+              />
             </div>
           </div>
         )}


### PR DESCRIPTION
Fixes #8438.

## Summary
- render the Memories BrainGraph on React Three Fiber's demand frameloop so it stops drawing after graph layout and node easing settle
- keep the default BrainGraph behavior as `always`, so onboarding and other animated graph surfaces are unchanged
- keep the Memories graph out of the blurred glass wrapper to avoid the expensive WebGL + backdrop-filter composition path on Windows
- add regression guards for the demand frameloop and non-blurred Memories graph container

## Refresh
- Rebased on `main` at `0384a5578bb479e15583d2f6785796cfd2c32d38`.
- Current head: `d4f5b3aeaeefe5bfc635b1727fe9cb65937f9667`.
- GitHub currently reports this PR as mergeable.

## Testing
- `pnpm exec vitest run src/renderer/src/lib/useGraphSimulation.test.ts src/renderer/src/pages/Memories.performance.test.ts` -> 2 files, 6 tests passed
- `pnpm run typecheck` -> passed
- `pnpm run build` -> passed; existing Vite dynamic/static import chunk warning only
- `git diff --check origin/main...HEAD` -> passed
- `git diff --check` -> passed
- `PYTHONUTF8=1 bash scripts/pre-push` -> passed; existing `Memories` long-function advisory only

Note: local targeted `pnpm exec eslint ... --quiet` still reports existing repo-wide/R3F lint noise in these files (for example `react/no-unknown-property` on Three.js JSX properties and existing React compiler ref warnings), so it is not listed as a passing validation for this refresh.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8910?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

