### PR TITLE
fix(desktop): structured upstream_result logging on Gemini proxy timeout/error (#8906)

### DIFF
--- a/desktop/macos/Backend-Rust/src/routes/proxy.rs
+++ b/desktop/macos/Backend-Rust/src/routes/proxy.rs
@@ -129,6 +129,17 @@ fn duration_bucket(elapsed: Duration) -> &'static str {
     }
 }
 
+/// Context for structured upstream_result logging on the error/timeout path,
+/// mirroring the fields the success path logs so sweeps can bucket timeouts and
+/// upstream failures by provider/model/action/payload (issue #8906).
+struct UpstreamLogCtx<'a> {
+    uid: &'a str,
+    provider: &'a str,
+    model: &'a str,
+    action: &'a str,
+    payload_bucket: &'a str,
+}
+
 fn map_upstream_error(error: reqwest::Error, operation: &str) -> ProxyError {
     let error = error.without_url();
     if error.is_timeout() {
@@ -136,6 +147,39 @@ fn map_upstream_error(error: reqwest::Error, operation: &str) -> ProxyError {
         ProxyError::UpstreamTimeout
     } else {
         tracing::error!("gemini_proxy: {} failed: {}", operation, error);
+        ProxyError::Status(StatusCode::BAD_GATEWAY)
+    }
+}
+
+/// Like `map_upstream_error` but also emits a structured `upstream_result` log
+/// line mirroring the success path, so observability sweeps can bucket timeouts
+/// and upstream failures by provider/model/action/payload (issue #8906).
+fn map_upstream_error_logged(
+    error: reqwest::Error,
+    operation: &str,
+    ctx: &UpstreamLogCtx,
+    started: Instant,
+) -> ProxyError {
+    let error = error.without_url();
+    let status_label = if error.is_timeout() {
+        "timeout"
+    } else {
+        "error"
+    };
+    tracing::warn!(
+        "gemini_proxy: upstream_result uid={} provider={} model={} action={} payload_bucket={} duration_bucket={} status={} operation={}",
+        ctx.uid,
+        ctx.provider,
+        ctx.model,
+        ctx.action,
+        ctx.payload_bucket,
+        duration_bucket(started.elapsed()),
+        status_label,
+        operation,
+    );
+    if error.is_timeout() {
+        ProxyError::UpstreamTimeout
+    } else {
         ProxyError::Status(StatusCode::BAD_GATEWAY)
     }
 }
@@ -240,6 +284,13 @@ async fn gemini_proxy(
 
     let url = build_gemini_url(&path, byok_key);
     let request_payload_bucket = payload_bucket(sanitized_body.len());
+    let log_ctx = UpstreamLogCtx {
+        uid: &user.uid,
+        provider: "ai_studio_byok",
+        model,
+        action,
+        payload_bucket: request_payload_bucket,
+    };
     let started = Instant::now();
     let upstream = state
         .gemini_client
@@ -248,14 +299,14 @@ async fn gemini_proxy(
         .body(sanitized_body)
         .send()
         .await
-        .map_err(|e| map_upstream_error(e, "BYOK upstream request"))?;
+        .map_err(|e| map_upstream_error_logged(e, "BYOK upstream request", &log_ctx, started))?;
 
     let status =
         StatusCode::from_u16(upstream.status().as_u16()).unwrap_or(StatusCode::BAD_GATEWAY);
     let bytes = upstream
         .bytes()
         .await
-        .map_err(|e| map_upstream_error(e, "BYOK upstream body read"))?;
+        .map_err(|e| map_upstream_error_logged(e, "BYOK upstream body read", &log_ctx, started))?;
     tracing::info!(
         "gemini_proxy: upstream_result uid={} provider=ai_studio_byok model={} action={} payload_bucket={} duration_bucket={} status={}",
         user.uid,
@@ -390,14 +441,22 @@ async fn gemini_proxy_server_key(
             .await
     };
 
-    let upstream = upstream.map_err(|e| map_upstream_error(e, "upstream request"))?;
+    let log_ctx = UpstreamLogCtx {
+        uid: &user.uid,
+        provider: upstream_provider,
+        model,
+        action,
+        payload_bucket: request_payload_bucket,
+    };
+    let upstream = upstream
+        .map_err(|e| map_upstream_error_logged(e, "upstream request", &log_ctx, started))?;
 
     let status =
         StatusCode::from_u16(upstream.status().as_u16()).unwrap_or(StatusCode::BAD_GATEWAY);
     let bytes = upstream
         .bytes()
         .await
-        .map_err(|e| map_upstream_error(e, "upstream body read"))?;
+        .map_err(|e| map_upstream_error_logged(e, "upstream body read", &log_ctx, started))?;
     tracing::info!(
         "gemini_proxy: upstream_result uid={} provider={} model={} action={} payload_bucket={} duration_bucket={} status={}",
         user.uid,


### PR DESCRIPTION
## Bug
Issue #8906 — production `desktop-backend` still returns high-volume 504s for the non-streaming Gemini proxy (`POST /v1/proxy/gemini/models/gemini-2.5-flash:generateContent`) after v0.12, with sampled latency ~120s.

## Root cause (of the observability gap this PR closes)
The non-streaming proxy already **owns** its 120s upstream deadline (`GEMINI_UPSTREAM_TIMEOUT`) and maps a timeout to a sanitized, retryable `504` — that part is working as intended. The problem for the sweep: on timeout/upstream error the handler returns early through `map_upstream_error`, which logs only a bare `warn!` with **no** provider/model/action/payload/duration buckets. The success path logs a rich `gemini_proxy: upstream_result …` line, but the failure path does not — so the post-v0.12 sweep can't attribute the 504s to a model/action/payload size, nor distinguish an upstream deadline from a proxy/internal error (acceptance criteria #2 and #3 in the issue).

## Fix
Add `map_upstream_error_logged`, which mirrors the success path's structured `upstream_result` log line (with `status=timeout|error`) on the error path, and route the four non-streaming call sites (BYOK + server-key, request-send + body-read) through it. No request behavior, timeout values, or response shape change — purely additive logging. Streaming path is untouched (it intentionally has no total-response deadline).

This closes the "distinguish timeout causes / observable with buckets" acceptance criteria so the next prod sweep can localize the remaining 504s; it does **not** by itself reduce the 504 volume (that needs the follow-up timeout/UX tuning the issue also describes).

## Verification
- `cargo check` — clean (only pre-existing dead-code warnings).
- `cargo test routes::proxy` — 77 passed, 0 failed.
- `rustfmt --edition 2021` applied.

Scope: 1 file, +63/-4.

🤖 automated by hourly watchdog; opened for review, not merged.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8913?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

