### PR TITLE
feat(desktop-windows): follow foreground changes across displays

### DIFF
--- a/desktop/windows/src/main/index.ts
+++ b/desktop/windows/src/main/index.ts
@@ -122,6 +122,10 @@ import { startTaskPromotionService } from './assistants/tasks/promotionService'
 import { registerGoalGeneration } from './assistants/goals/register'
 import { startRendererServer, rendererBaseUrl } from './rendererServer'
 import { startRewindCapture } from './rewind/captureService'
+import {
+  startRewindForegroundCaptureTrigger,
+  stopRewindForegroundCaptureTrigger
+} from './rewind/foregroundCaptureTrigger'
 import { startRewindOcr } from './rewind/ocrService'
 import { startRewindEmbedding } from './rewind/embeddingService'
 import { startRewindRetention } from './rewind/retentionRunner'
@@ -1149,6 +1153,10 @@ app.whenReady().then(async () => {
         // fresh install, and any change the user makes in Settings survives restarts.
         // OCR/retention loops are cheap no-ops until frames exist.
         { name: 'rewindCapture', run: () => startRewindCapture() },
+        {
+          name: 'rewindForegroundCapture',
+          run: () => startRewindForegroundCaptureTrigger()
+        },
         { name: 'rewindOcr', run: () => startRewindOcr() },
         // Semantic-search indexer (Track 4). Starts its flush timer here; the queue
         // and the launch backfill only move once the renderer relays a Firebase
@@ -1497,6 +1505,7 @@ app.on('will-quit', () => {
   flushPerfMarks()
   automationBridge.dispose()
   stopAutomationTargetTracker()
+  stopRewindForegroundCaptureTrigger()
   // Kill the long-running OCR/window-info helper subprocess. Without this it
   // outlives the app on every quit, so orphaned omi-*-ocr-helper.exe processes
   // pile up across launches (no production dispose() call site before this).

--- a/desktop/windows/src/main/ipc/rewind.ts
+++ b/desktop/windows/src/main/ipc/rewind.ts
@@ -1,5 +1,9 @@
 import { ipcMain, BrowserWindow } from 'electron'
-import { getPrimarySourceId } from '../rewind/sourceId'
+import {
+  getPrimarySourceId,
+  getRewindCaptureSourceId,
+  isCurrentRewindCaptureSource
+} from '../rewind/sourceId'
 import {
   listRewindFrames,
   listRewindFramesSampled,
@@ -145,9 +149,17 @@ export function registerRewindHandlers(): void {
   // take several seconds on some machines, so it's prewarmed at startup; this
   // is an instant cache hit in the normal case.
   ipcMain.handle('rewind:primarySourceId', async () => getPrimarySourceId())
+  // Rewind follows the foreground window across displays while retaining one
+  // persistent stream. Source enumeration is cached; each lookup is cheap.
+  ipcMain.handle('rewind:captureSourceId', async () => getRewindCaptureSourceId())
   // Receive a sampled JPEG frame from the renderer capture host and store it
   // (after foreground-window metadata + idle/lock/dup gating).
-  ipcMain.handle('rewind:saveFrame', async (_e, data: Uint8Array) => {
+  ipcMain.handle('rewind:saveFrame', async (_e, data: Uint8Array, sourceId: string) => {
+    // Foreground focus can move again while getUserMedia opens a new display.
+    // Never attach the new window's metadata/privacy decision to stale pixels.
+    if (!(await isCurrentRewindCaptureSource(sourceId))) {
+      return { captured: false, reason: 'display-changed' }
+    }
     const result = await ingestRewindFrame(Buffer.from(data))
     // A stored frame bumps the all-time frame count. Tell open windows so the
     // Hub's "Screenshots" stat re-reads live instead of freezing at whatever it

--- a/desktop/windows/src/main/rewind/foregroundCaptureTrigger.test.ts
+++ b/desktop/windows/src/main/rewind/foregroundCaptureTrigger.test.ts
@@ -1,0 +1,129 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+type MockWindow = {
+  destroyed: boolean
+  isDestroyed: () => boolean
+  webContents: {
+    destroyed: boolean
+    isDestroyed: () => boolean
+    send: ReturnType<typeof vi.fn>
+  }
+}
+
+const windows: MockWindow[] = []
+const subscriptions: Array<() => void> = []
+const unsubscribes: Array<ReturnType<typeof vi.fn>> = []
+
+vi.mock('electron', () => ({
+  BrowserWindow: {
+    getAllWindows: () => windows
+  }
+}))
+
+vi.mock('../usage/nativeForeground', () => ({
+  subscribeForegroundChange: vi.fn((callback: () => void) => {
+    const unsubscribe = vi.fn()
+    subscriptions.push(callback)
+    unsubscribes.push(unsubscribe)
+    return unsubscribe
+  })
+}))
+
+import { subscribeForegroundChange } from '../usage/nativeForeground'
+import {
+  startRewindForegroundCaptureTrigger,
+  stopRewindForegroundCaptureTrigger
+} from './foregroundCaptureTrigger'
+
+const platformDescriptor = Object.getOwnPropertyDescriptor(process, 'platform')
+
+function makeWindow(destroyed = false, webContentsDestroyed = false): MockWindow {
+  return {
+    destroyed,
+    isDestroyed(): boolean {
+      return this.destroyed
+    },
+    webContents: {
+      destroyed: webContentsDestroyed,
+      isDestroyed(): boolean {
+        return this.destroyed
+      },
+      send: vi.fn()
+    }
+  }
+}
+
+function forcePlatform(platform: NodeJS.Platform): void {
+  Object.defineProperty(process, 'platform', { value: platform })
+}
+
+describe('rewind foreground capture trigger', () => {
+  beforeEach(() => {
+    stopRewindForegroundCaptureTrigger()
+    windows.length = 0
+    subscriptions.length = 0
+    unsubscribes.length = 0
+    vi.clearAllMocks()
+    vi.useFakeTimers()
+    vi.setSystemTime(1000)
+    forcePlatform('win32')
+  })
+
+  afterEach(() => {
+    stopRewindForegroundCaptureTrigger()
+    vi.useRealTimers()
+    if (platformDescriptor) Object.defineProperty(process, 'platform', platformDescriptor)
+  })
+
+  it('broadcasts capture requests to live windows only', () => {
+    const live = makeWindow()
+    const destroyed = makeWindow(true)
+    const destroyedWebContents = makeWindow(false, true)
+    windows.push(live, destroyed, destroyedWebContents)
+
+    startRewindForegroundCaptureTrigger()
+    subscriptions[0]()
+
+    expect(live.webContents.send).toHaveBeenCalledWith('rewind:capture-now')
+    expect(destroyed.webContents.send).not.toHaveBeenCalled()
+    expect(destroyedWebContents.webContents.send).not.toHaveBeenCalled()
+  })
+
+  it('subscribes once and throttles foreground-change bursts', () => {
+    const live = makeWindow()
+    windows.push(live)
+
+    startRewindForegroundCaptureTrigger()
+    startRewindForegroundCaptureTrigger()
+
+    expect(subscribeForegroundChange).toHaveBeenCalledTimes(1)
+    expect(subscriptions).toHaveLength(1)
+
+    subscriptions[0]()
+    expect(live.webContents.send).toHaveBeenCalledTimes(1)
+
+    vi.setSystemTime(1100)
+    subscriptions[0]()
+    expect(live.webContents.send).toHaveBeenCalledTimes(1)
+
+    vi.setSystemTime(1300)
+    subscriptions[0]()
+    expect(live.webContents.send).toHaveBeenCalledTimes(2)
+  })
+
+  it('unsubscribes on stop', () => {
+    startRewindForegroundCaptureTrigger()
+
+    stopRewindForegroundCaptureTrigger()
+
+    expect(unsubscribes[0]).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not subscribe off Windows', () => {
+    forcePlatform('darwin')
+
+    startRewindForegroundCaptureTrigger()
+
+    expect(subscribeForegroundChange).not.toHaveBeenCalled()
+  })
+})

--- a/desktop/windows/src/main/rewind/foregroundCaptureTrigger.ts
+++ b/desktop/windows/src/main/rewind/foregroundCaptureTrigger.ts
@@ -1,0 +1,33 @@
+import { BrowserWindow } from 'electron'
+import { subscribeForegroundChange } from '../usage/nativeForeground'
+
+const CAPTURE_NOW_CHANNEL = 'rewind:capture-now'
+const MIN_TRIGGER_GAP_MS = 250
+
+let unsubscribeForeground: (() => void) | null = null
+let lastTriggerAt = 0
+
+function notifyRewindCaptureNow(): void {
+  for (const window of BrowserWindow.getAllWindows()) {
+    if (!window.isDestroyed() && !window.webContents.isDestroyed()) {
+      window.webContents.send(CAPTURE_NOW_CHANNEL)
+    }
+  }
+}
+
+export function startRewindForegroundCaptureTrigger(): void {
+  if (unsubscribeForeground || process.platform !== 'win32') return
+
+  unsubscribeForeground = subscribeForegroundChange(() => {
+    const now = Date.now()
+    if (now - lastTriggerAt < MIN_TRIGGER_GAP_MS) return
+    lastTriggerAt = now
+    notifyRewindCaptureNow()
+  })
+}
+
+export function stopRewindForegroundCaptureTrigger(): void {
+  unsubscribeForeground?.()
+  unsubscribeForeground = null
+  lastTriggerAt = 0
+}

--- a/desktop/windows/src/main/rewind/sourceId.test.ts
+++ b/desktop/windows/src/main/rewind/sourceId.test.ts
@@ -2,14 +2,27 @@ import { describe, it, expect, beforeEach, vi } from 'vitest'
 
 const getSources = vi.fn()
 const getPrimaryDisplay = vi.fn()
+const getDisplayMatching = vi.fn()
+const screenToDipRect = vi.fn()
+const getCursorScreenPoint = vi.fn()
+const getDisplayNearestPoint = vi.fn()
+const getForegroundWindowRect = vi.fn()
 const on = vi.fn()
 
 vi.mock('electron', () => ({
   desktopCapturer: { getSources: (...args: unknown[]) => getSources(...args) },
   screen: {
     getPrimaryDisplay: () => getPrimaryDisplay(),
+    getDisplayMatching: (...args: unknown[]) => getDisplayMatching(...args),
+    screenToDipRect: (...args: unknown[]) => screenToDipRect(...args),
+    getCursorScreenPoint: () => getCursorScreenPoint(),
+    getDisplayNearestPoint: (...args: unknown[]) => getDisplayNearestPoint(...args),
     on: (...args: unknown[]) => on(...args)
   }
+}))
+
+vi.mock('../usage/nativeForeground', () => ({
+  getForegroundWindowRect: () => getForegroundWindowRect()
 }))
 
 // The module caches at module scope, so each test gets a fresh copy.
@@ -88,5 +101,85 @@ describe('prewarmPrimarySourceId', () => {
     invalidate?.()
 
     expect(await getPrimarySourceId()).toBe('screen:1:0')
+  })
+})
+
+describe('getRewindCaptureSourceId', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    getPrimaryDisplay.mockReturnValue({ id: 2 })
+    getForegroundWindowRect.mockReturnValue({
+      rect: null,
+      className: null,
+      exePath: null
+    })
+    getCursorScreenPoint.mockReturnValue({ x: 100, y: 100 })
+    getDisplayNearestPoint.mockReturnValue({ id: 2 })
+    screenToDipRect.mockImplementation((_window, rect) => rect)
+    getDisplayMatching.mockReturnValue({ id: 2 })
+  })
+
+  it('selects the source for the display containing the foreground window', async () => {
+    const physicalRect = { x: 3840, y: 0, width: 1920, height: 1080 }
+    const dipRect = { x: 2560, y: 0, width: 1280, height: 720 }
+    getForegroundWindowRect.mockReturnValue({
+      rect: physicalRect,
+      className: 'Chrome_WidgetWin_1',
+      exePath: 'C:\\Chrome\\chrome.exe'
+    })
+    screenToDipRect.mockReturnValue(dipRect)
+    getDisplayMatching.mockReturnValue({ id: 3 })
+    getSources.mockResolvedValue([source('screen:0:0', '2'), source('screen:1:0', '3')])
+
+    const { getRewindCaptureSourceId } = await loadModule()
+
+    expect(await getRewindCaptureSourceId()).toBe('screen:1:0')
+    expect(screenToDipRect).toHaveBeenCalledWith(null, physicalRect)
+    expect(getDisplayMatching).toHaveBeenCalledWith(dipRect)
+  })
+
+  it('uses the cursor display when foreground geometry is unavailable', async () => {
+    getDisplayNearestPoint.mockReturnValue({ id: 3 })
+    getSources.mockResolvedValue([source('screen:0:0', '2'), source('screen:1:0', '3')])
+
+    const { getRewindCaptureSourceId } = await loadModule()
+
+    expect(await getRewindCaptureSourceId()).toBe('screen:1:0')
+  })
+
+  it('reuses the source map while the foreground window moves between displays', async () => {
+    getForegroundWindowRect.mockReturnValue({
+      rect: { x: 0, y: 0, width: 100, height: 100 },
+      className: 'TestWindow',
+      exePath: 'C:\\test.exe'
+    })
+    getDisplayMatching.mockReturnValueOnce({ id: 2 }).mockReturnValueOnce({ id: 3 })
+    getSources.mockResolvedValue([source('screen:0:0', '2'), source('screen:1:0', '3')])
+
+    const { getRewindCaptureSourceId } = await loadModule()
+
+    expect(await getRewindCaptureSourceId()).toBe('screen:0:0')
+    expect(await getRewindCaptureSourceId()).toBe('screen:1:0')
+    expect(getSources).toHaveBeenCalledTimes(1)
+  })
+
+  it('falls back to the primary source when the target display has no source', async () => {
+    getDisplayNearestPoint.mockReturnValue({ id: 99 })
+    getSources.mockResolvedValue([source('screen:0:0', '2'), source('screen:1:0', '3')])
+
+    const { getRewindCaptureSourceId } = await loadModule()
+
+    expect(await getRewindCaptureSourceId()).toBe('screen:0:0')
+  })
+
+  it('rejects a frame captured from a display that is no longer foreground', async () => {
+    getDisplayNearestPoint.mockReturnValue({ id: 3 })
+    getSources.mockResolvedValue([source('screen:0:0', '2'), source('screen:1:0', '3')])
+
+    const { isCurrentRewindCaptureSource } = await loadModule()
+
+    expect(await isCurrentRewindCaptureSource('screen:0:0')).toBe(false)
+    expect(await isCurrentRewindCaptureSource('screen:1:0')).toBe(true)
+    expect(await isCurrentRewindCaptureSource('')).toBe(false)
   })
 })

--- a/desktop/windows/src/main/rewind/sourceId.ts
+++ b/desktop/windows/src/main/rewind/sourceId.ts
@@ -1,37 +1,33 @@
 import { desktopCapturer, screen } from 'electron'
+import { getForegroundWindowRect } from '../usage/nativeForeground'
 
 // desktopCapturer.getSources() is pathologically slow on some machines (multiple
-// seconds even with thumbnails disabled), and it's the dominant cost of enabling
-// Rewind capture. The primary screen's source id is stable for a session, so we
-// fetch it once, cache it, and reuse it. The cache is invalidated when the
-// display layout changes. A single-flight promise dedupes concurrent callers
-// (e.g. the startup prewarm racing the user's first enable).
+// seconds even with thumbnails disabled), and it is the dominant cost of enabling
+// Rewind capture. Screen source ids are stable for a display layout, so fetch the
+// id-to-display map once, cache it, and choose from it cheaply as focus moves
+// between monitors. The cache is invalidated when the layout changes. A
+// single-flight promise dedupes concurrent callers.
 
-let cached: string | null = null
-let inflight: Promise<string | null> | null = null
+type SourceIdentity = { id: string; displayId: string }
 
-async function fetchPrimarySourceId(): Promise<string | null> {
+let cached: SourceIdentity[] | null = null
+let inflight: Promise<SourceIdentity[]> | null = null
+
+async function fetchSourceIdentities(): Promise<SourceIdentity[]> {
   const sources = await desktopCapturer.getSources({
     types: ['screen'],
-    thumbnailSize: { width: 0, height: 0 } // ids only — no screen bitmap
+    thumbnailSize: { width: 0, height: 0 } // ids only - no screen bitmap
   })
-  // A source's `id` is a sequential screen number, and getSources() makes no
-  // ordering guarantee — so sources[0] is not necessarily the primary display.
-  // `display_id` is the documented link to the Screen API; match on it and only
-  // fall back to the first source when Electron doesn't report one.
-  const primaryDisplayId = String(screen.getPrimaryDisplay().id)
-  const primary = sources.find((s) => s.display_id === primaryDisplayId)
-  return primary?.id ?? sources[0]?.id ?? null
+  return sources.map((source) => ({ id: source.id, displayId: source.display_id }))
 }
 
-/** Cached primary-screen source id; computes it (slowly) once, then reuses it. */
-export async function getPrimarySourceId(): Promise<string | null> {
+async function getSourceIdentities(): Promise<SourceIdentity[]> {
   if (cached) return cached
   if (!inflight) {
-    inflight = fetchPrimarySourceId()
-      .then((id) => {
-        cached = id
-        return id
+    inflight = fetchSourceIdentities()
+      .then((sources) => {
+        cached = sources
+        return sources
       })
       .finally(() => {
         inflight = null
@@ -40,12 +36,63 @@ export async function getPrimarySourceId(): Promise<string | null> {
   return inflight
 }
 
+function sourceIdForDisplay(sources: SourceIdentity[], displayId: string): string | null {
+  return sources.find((source) => source.displayId === displayId)?.id ?? null
+}
+
+/** Cached primary-screen source id; computes the source map once, then reuses it. */
+export async function getPrimarySourceId(): Promise<string | null> {
+  const sources = await getSourceIdentities()
+  const primaryDisplayId = String(screen.getPrimaryDisplay().id)
+  return sourceIdForDisplay(sources, primaryDisplayId) ?? sources[0]?.id ?? null
+}
+
+function foregroundDisplayId(): string | null {
+  const { rect } = getForegroundWindowRect()
+  if (!rect || rect.width <= 0 || rect.height <= 0) return null
+  try {
+    // Win32 reports physical pixels while Electron's display geometry is DIP.
+    // Let Electron perform the per-monitor conversion before matching.
+    const dipRect = screen.screenToDipRect(null, rect)
+    return String(screen.getDisplayMatching(dipRect).id)
+  } catch {
+    return null
+  }
+}
+
+function cursorDisplayId(): string | null {
+  try {
+    return String(screen.getDisplayNearestPoint(screen.getCursorScreenPoint()).id)
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Source for the display containing the foreground window. Fall back to the
+ * cursor display when native foreground geometry is unavailable, then primary.
+ */
+export async function getRewindCaptureSourceId(): Promise<string | null> {
+  const sources = await getSourceIdentities()
+  const targetDisplayId = foregroundDisplayId() ?? cursorDisplayId()
+  if (targetDisplayId) {
+    const target = sourceIdForDisplay(sources, targetDisplayId)
+    if (target) return target
+  }
+  const primary = sourceIdForDisplay(sources, String(screen.getPrimaryDisplay().id))
+  return primary ?? sources[0]?.id ?? null
+}
+
+/** Reject a frame if foreground focus changed displays while it was encoded. */
+export async function isCurrentRewindCaptureSource(sourceId: string): Promise<boolean> {
+  return sourceId.length > 0 && sourceId === (await getRewindCaptureSourceId())
+}
+
 let invalidatorBound = false
 
 /**
  * Kick off the slow getSources() once at startup-idle so the cache is warm
- * before the user enables capture — turning the multi-second enable hitch into
- * an instant cache hit. Also binds display-change listeners that drop the cache.
+ * before the user enables capture. Also bind display-change cache invalidation.
  */
 export function prewarmPrimarySourceId(): void {
   if (!invalidatorBound) {

--- a/desktop/windows/src/preload/index.ts
+++ b/desktop/windows/src/preload/index.ts
@@ -484,6 +484,11 @@ const omi: OmiBridgeApi = {
   screenSynthSetState: (patch) => ipcRenderer.invoke('screenSynth:setState', patch),
   screenSynthAdvanceWatermark: (ts) => ipcRenderer.invoke('screenSynth:advanceWatermark', ts),
   screenSynthRecordRun: (run) => ipcRenderer.invoke('screenSynth:recordRun', run),
+  onRewindCaptureNow: (cb: () => void) => {
+    const listener = (): void => cb()
+    ipcRenderer.on('rewind:capture-now', listener)
+    return () => ipcRenderer.removeListener('rewind:capture-now', listener)
+  },
   onRewindSettings: (cb: (s: RewindSettings) => void) => {
     const listener = (_e: unknown, s: RewindSettings): void => cb(s)
     ipcRenderer.on('rewind:settings', listener)

--- a/desktop/windows/src/preload/index.ts
+++ b/desktop/windows/src/preload/index.ts
@@ -370,7 +370,9 @@ const omi: OmiBridgeApi = {
   rewindPruneNow: () => ipcRenderer.invoke('rewind:pruneNow'),
   rewindRebuildIndex: () => ipcRenderer.invoke('rewind:rebuildIndex'),
   rewindPrimarySourceId: () => ipcRenderer.invoke('rewind:primarySourceId'),
-  rewindSaveFrame: (data: Uint8Array) => ipcRenderer.invoke('rewind:saveFrame', data),
+  rewindCaptureSourceId: () => ipcRenderer.invoke('rewind:captureSourceId'),
+  rewindSaveFrame: (data: Uint8Array, sourceId: string) =>
+    ipcRenderer.invoke('rewind:saveFrame', data, sourceId),
   screenReadText: () => ipcRenderer.invoke('screen:readNow'),
   codingAgentList: (commandOverrides?: CodingAgentCommandOverrides) =>
     ipcRenderer.invoke('codingAgent:list', commandOverrides),

--- a/desktop/windows/src/renderer/src/components/rewind/RewindCaptureHost.test.tsx
+++ b/desktop/windows/src/renderer/src/components/rewind/RewindCaptureHost.test.tsx
@@ -33,10 +33,16 @@ function fakeStream(track: FakeTrack): MediaStream {
 let tracks: FakeTrack[] = []
 let getUserMedia: ReturnType<typeof vi.fn>
 let saveFrame: ReturnType<typeof vi.fn>
+let captureNowListener: (() => void) | null
+let unsubscribeCaptureNow: ReturnType<typeof vi.fn>
 
 beforeEach(() => {
   vi.useFakeTimers()
   tracks = []
+  captureNowListener = null
+  unsubscribeCaptureNow = vi.fn(() => {
+    captureNowListener = null
+  })
   saveFrame = vi.fn(async () => undefined)
   getUserMedia = vi.fn(async () => {
     const t = new FakeTrack()
@@ -50,7 +56,11 @@ beforeEach(() => {
     rewindGetCaptureDirective: async () => ({ paused: false, intervalMs: INTERVAL_MS }),
     onRewindCaptureDirective: () => () => undefined,
     rewindPrimarySourceId: async () => 'screen:0:0',
-    rewindSaveFrame: saveFrame
+    rewindSaveFrame: saveFrame,
+    onRewindCaptureNow: (cb: () => void) => {
+      captureNowListener = cb
+      return unsubscribeCaptureNow
+    }
   }
   // jsdom has no media pipeline or 2D canvas: give the host a video that reports
   // a frame size and a canvas that encodes, so the sampling path can run.
@@ -91,6 +101,13 @@ async function tick(ms: number): Promise<void> {
   })
 }
 
+async function requestCaptureNow(): Promise<void> {
+  await act(async () => {
+    captureNowListener?.()
+    await vi.advanceTimersByTimeAsync(0)
+  })
+}
+
 describe('RewindCaptureHost — dead capture track', () => {
   it('stops saving frames and reopens the stream when the capture track dies', async () => {
     render(<RewindCaptureHost />)
@@ -106,6 +123,7 @@ describe('RewindCaptureHost — dead capture track', () => {
     await act(async () => {
       tracks[0].die()
     })
+    await requestCaptureNow()
 
     // No blank frames from the dead <video> while the stream is down...
     await tick(INTERVAL_MS)
@@ -273,9 +291,77 @@ describe('RewindCaptureHost — unmount', () => {
     await settle()
     expect(getUserMedia).toHaveBeenCalledTimes(1)
 
+    const unsubscribeCount = unsubscribeCaptureNow.mock.calls.length
     view.unmount()
+    expect(unsubscribeCaptureNow).toHaveBeenCalledTimes(unsubscribeCount + 1)
+    expect(captureNowListener).toBeNull()
     await tick(RESTART_DELAY_MS + INTERVAL_MS)
     expect(getUserMedia).toHaveBeenCalledTimes(1)
     expect(saveFrame).not.toHaveBeenCalled()
+  })
+})
+
+describe('RewindCaptureHost — foreground capture', () => {
+  it('ignores foreground requests while capture is disabled', async () => {
+    const omi = (
+      window as unknown as {
+        omi: {
+          rewindGetSettings: () => Promise<{ captureEnabled: boolean; intervalMs: number }>
+        }
+      }
+    ).omi
+    omi.rewindGetSettings = async () => ({
+      captureEnabled: false,
+      intervalMs: INTERVAL_MS
+    })
+
+    render(<RewindCaptureHost />)
+    await settle()
+    await requestCaptureNow()
+
+    expect(getUserMedia).not.toHaveBeenCalled()
+    expect(saveFrame).not.toHaveBeenCalled()
+  })
+
+  it('captures immediately and restarts the periodic cadence', async () => {
+    render(<RewindCaptureHost />)
+    await settle()
+
+    await requestCaptureNow()
+    expect(saveFrame).toHaveBeenCalledTimes(1)
+
+    await tick(INTERVAL_MS - 1)
+    expect(saveFrame).toHaveBeenCalledTimes(1)
+    await tick(1)
+    expect(saveFrame).toHaveBeenCalledTimes(2)
+  })
+
+  it('coalesces foreground requests while a save is in flight', async () => {
+    let releaseSave: () => void = () => undefined
+    saveFrame.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          releaseSave = () => resolve()
+        })
+    )
+    render(<RewindCaptureHost />)
+    await settle()
+
+    await requestCaptureNow()
+    expect(saveFrame).toHaveBeenCalledTimes(1)
+
+    await requestCaptureNow()
+    await requestCaptureNow()
+    expect(saveFrame).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      releaseSave()
+      await vi.advanceTimersByTimeAsync(0)
+    })
+    expect(saveFrame).toHaveBeenCalledTimes(2)
+
+    saveFrame.mockClear()
+    await tick(INTERVAL_MS)
+    expect(saveFrame).toHaveBeenCalledTimes(1)
   })
 })

--- a/desktop/windows/src/renderer/src/components/rewind/RewindCaptureHost.test.tsx
+++ b/desktop/windows/src/renderer/src/components/rewind/RewindCaptureHost.test.tsx
@@ -35,10 +35,12 @@ let getUserMedia: ReturnType<typeof vi.fn>
 let saveFrame: ReturnType<typeof vi.fn>
 let captureNowListener: (() => void) | null
 let unsubscribeCaptureNow: ReturnType<typeof vi.fn>
+let captureSourceId: string
 
 beforeEach(() => {
   vi.useFakeTimers()
   tracks = []
+  captureSourceId = 'screen:0:0'
   captureNowListener = null
   unsubscribeCaptureNow = vi.fn(() => {
     captureNowListener = null
@@ -56,6 +58,7 @@ beforeEach(() => {
     rewindGetCaptureDirective: async () => ({ paused: false, intervalMs: INTERVAL_MS }),
     onRewindCaptureDirective: () => () => undefined,
     rewindPrimarySourceId: async () => 'screen:0:0',
+    rewindCaptureSourceId: async () => captureSourceId,
     rewindSaveFrame: saveFrame,
     onRewindCaptureNow: (cb: () => void) => {
       captureNowListener = cb
@@ -334,6 +337,37 @@ describe('RewindCaptureHost — foreground capture', () => {
     expect(saveFrame).toHaveBeenCalledTimes(1)
     await tick(1)
     expect(saveFrame).toHaveBeenCalledTimes(2)
+  })
+
+  it('reopens the stream on the foreground window display before capturing', async () => {
+    render(<RewindCaptureHost />)
+    await settle()
+    expect(getUserMedia).toHaveBeenCalledTimes(1)
+
+    captureSourceId = 'screen:1:0'
+    await requestCaptureNow()
+
+    expect(getUserMedia).toHaveBeenCalledTimes(2)
+    expect(
+      (
+        getUserMedia.mock.calls[1][0] as {
+          video: { mandatory: { chromeMediaSourceId: string } }
+        }
+      ).video.mandatory.chromeMediaSourceId
+    ).toBe('screen:1:0')
+    expect(tracks[0].readyState).toBe('ended')
+    expect(tracks[1].readyState).toBe('live')
+    expect(saveFrame).toHaveBeenCalledTimes(1)
+    expect(saveFrame).toHaveBeenCalledWith(expect.any(Uint8Array), 'screen:1:0')
+
+    // A queued 'ended' event from the replaced track must not tear down the new
+    // display stream.
+    await act(async () => {
+      tracks[0].die()
+    })
+    await tick(RESTART_DELAY_MS)
+    expect(getUserMedia).toHaveBeenCalledTimes(2)
+    expect(tracks[1].readyState).toBe('live')
   })
 
   it('coalesces foreground requests while a save is in flight', async () => {

--- a/desktop/windows/src/renderer/src/components/rewind/RewindCaptureHost.tsx
+++ b/desktop/windows/src/renderer/src/components/rewind/RewindCaptureHost.tsx
@@ -84,6 +84,7 @@ export function RewindCaptureHost(): React.JSX.Element {
     let generation = 0
     let captureRunning = false
     let queuedGeneration: number | null = null
+    let activeSourceId: string | null = null
 
     const stop = (): void => {
       generation++
@@ -94,6 +95,7 @@ export function RewindCaptureHost(): React.JSX.Element {
       }
       streamRef.current?.getTracks().forEach((t) => t.stop())
       streamRef.current = null
+      activeSourceId = null
       if (videoRef.current) videoRef.current.srcObject = null
     }
 
@@ -105,20 +107,69 @@ export function RewindCaptureHost(): React.JSX.Element {
     // sampler kept drawing a dead <video>, so the timeline filled with blank frames
     // and capture never came back. Re-open the stream instead. Our own teardown
     // uses track.stop(), which does not fire 'ended', so this can't self-trigger.
-    const onTrackEnded = (): void => {
-      if (cancelled) return
+    const onTrackEnded = (track: MediaStreamTrack): void => {
+      if (cancelled || !streamRef.current?.getVideoTracks().includes(track)) return
       console.warn('[rewind] capture track ended — reopening stream')
       stop()
       timerRef.current = setTimeout(() => void start(), RESTART_DELAY_MS)
     }
 
+    const replaceStream = async (sourceId: string, gen: number): Promise<boolean> => {
+      const stream = await (
+        navigator.mediaDevices as unknown as {
+          getUserMedia: (c: unknown) => Promise<MediaStream>
+        }
+      ).getUserMedia({
+        audio: false,
+        video: {
+          mandatory: {
+            chromeMediaSource: 'desktop',
+            chromeMediaSourceId: sourceId,
+            // Resolution follows the user's quality tier; every display stays
+            // at 1fps so following focus does not add another persistent stream.
+            maxWidth: tier.maxWidth,
+            maxHeight: tier.maxHeight,
+            maxFrameRate: 1
+          }
+        }
+      })
+      if (cancelled || gen !== generation) {
+        stream.getTracks().forEach((track) => track.stop())
+        return false
+      }
+
+      const previous = streamRef.current
+      previous?.getTracks().forEach((track) => track.stop())
+      streamRef.current = stream
+      activeSourceId = sourceId
+      stream
+        .getVideoTracks()
+        .forEach((track) => track.addEventListener('ended', () => onTrackEnded(track)))
+      const video = videoRef.current
+      if (video) {
+        video.srcObject = stream
+        await video.play().catch(() => undefined)
+      }
+      if (cancelled || gen !== generation) {
+        stream.getTracks().forEach((track) => track.stop())
+        return false
+      }
+      return true
+    }
+
     const captureOnce = async (gen: number): Promise<void> => {
       if (cancelled || gen !== generation) return
-      const v = videoRef.current
-      if (!v || !isLive() || !v.videoWidth || !v.videoHeight || savingRef.current) return
-
-      savingRef.current = true
       try {
+        const targetSourceId = await window.omi.rewindCaptureSourceId()
+        if (targetSourceId && targetSourceId !== activeSourceId) {
+          const replaced = await replaceStream(targetSourceId, gen)
+          if (!replaced) return
+        }
+
+        const v = videoRef.current
+        if (!v || !isLive() || !v.videoWidth || !v.videoHeight || savingRef.current) return
+
+        savingRef.current = true
         const scale = Math.min(1, tier.maxEdge / Math.max(v.videoWidth, v.videoHeight))
         const w = Math.round(v.videoWidth * scale)
         const h = Math.round(v.videoHeight * scale)
@@ -131,8 +182,11 @@ export function RewindCaptureHost(): React.JSX.Element {
           const blob = await new Promise<Blob | null>((r) =>
             canvas.toBlob(r, 'image/jpeg', tier.jpegQuality)
           )
-          if (blob && !cancelled && gen === generation) {
-            await window.omi.rewindSaveFrame(new Uint8Array(await blob.arrayBuffer()))
+          if (blob && activeSourceId && !cancelled && gen === generation) {
+            await window.omi.rewindSaveFrame(
+              new Uint8Array(await blob.arrayBuffer()),
+              activeSourceId
+            )
           }
         }
       } catch (e) {
@@ -185,43 +239,10 @@ export function RewindCaptureHost(): React.JSX.Element {
 
     const start = async (): Promise<void> => {
       try {
-        const sourceId = await window.omi.rewindPrimarySourceId()
+        const sourceId = await window.omi.rewindCaptureSourceId()
         if (!sourceId || cancelled) return
-        const stream = await (
-          navigator.mediaDevices as unknown as {
-            getUserMedia: (c: unknown) => Promise<MediaStream>
-          }
-        ).getUserMedia({
-          audio: false,
-          video: {
-            mandatory: {
-              chromeMediaSource: 'desktop',
-              chromeMediaSourceId: sourceId,
-              // The live stream is decoded continuously in the renderer, so its
-              // resolution + frame rate set the steady-state cost of having
-              // capture on. Resolution follows the user's quality tier (720p by
-              // default); the frame rate stays at 1fps regardless — we sample
-              // every few seconds, and frame rate is what made this expensive
-              // before (1080p@30fps → froze; 1080p@2fps → laggy).
-              maxWidth: tier.maxWidth,
-              maxHeight: tier.maxHeight,
-              maxFrameRate: 1
-            }
-          }
-        })
-        if (cancelled) {
-          stream.getTracks().forEach((t) => t.stop())
-          return
-        }
-        streamRef.current = stream
-        stream.getVideoTracks().forEach((t) => t.addEventListener('ended', onTrackEnded))
         const gen = generation
-        const v = videoRef.current
-        if (v) {
-          v.srcObject = stream
-          await v.play().catch(() => undefined)
-        }
-        scheduleNext(gen)
+        if (await replaceStream(sourceId, gen)) scheduleNext(gen)
       } catch (e) {
         console.error('[rewind] failed to start capture:', (e as Error).message)
       }

--- a/desktop/windows/src/renderer/src/components/rewind/RewindCaptureHost.tsx
+++ b/desktop/windows/src/renderer/src/components/rewind/RewindCaptureHost.tsx
@@ -82,9 +82,12 @@ export function RewindCaptureHost(): React.JSX.Element {
     // round-trip) can't reschedule itself onto a stream that is already gone —
     // otherwise each recovery would leave an extra sampling loop running.
     let generation = 0
+    let captureRunning = false
+    let queuedGeneration: number | null = null
 
     const stop = (): void => {
       generation++
+      queuedGeneration = null
       if (timerRef.current) {
         clearTimeout(timerRef.current)
         timerRef.current = null
@@ -109,42 +112,75 @@ export function RewindCaptureHost(): React.JSX.Element {
       timerRef.current = setTimeout(() => void start(), RESTART_DELAY_MS)
     }
 
-    // Self-pacing: schedule the next grab only after the current one settles, so
-    // a slow save can never stack concurrent captures.
-    const grabAndSchedule = async (gen: number): Promise<void> => {
+    const captureOnce = async (gen: number): Promise<void> => {
       if (cancelled || gen !== generation) return
+      const v = videoRef.current
+      if (!v || !isLive() || !v.videoWidth || !v.videoHeight || savingRef.current) return
+
+      savingRef.current = true
       try {
-        const v = videoRef.current
-        if (v && isLive() && v.videoWidth && v.videoHeight && !savingRef.current) {
-          const scale = Math.min(1, tier.maxEdge / Math.max(v.videoWidth, v.videoHeight))
-          const w = Math.round(v.videoWidth * scale)
-          const h = Math.round(v.videoHeight * scale)
-          const canvas = canvasRef.current ?? (canvasRef.current = document.createElement('canvas'))
-          if (canvas.width !== w) canvas.width = w
-          if (canvas.height !== h) canvas.height = h
-          const ctx = canvas.getContext('2d')
-          if (ctx) {
-            ctx.drawImage(v, 0, 0, w, h)
-            const blob = await new Promise<Blob | null>((r) =>
-              canvas.toBlob(r, 'image/jpeg', tier.jpegQuality)
-            )
-            if (blob && !cancelled && gen === generation) {
-              savingRef.current = true
-              try {
-                await window.omi.rewindSaveFrame(new Uint8Array(await blob.arrayBuffer()))
-              } finally {
-                savingRef.current = false
-              }
-            }
+        const scale = Math.min(1, tier.maxEdge / Math.max(v.videoWidth, v.videoHeight))
+        const w = Math.round(v.videoWidth * scale)
+        const h = Math.round(v.videoHeight * scale)
+        const canvas = canvasRef.current ?? (canvasRef.current = document.createElement('canvas'))
+        if (canvas.width !== w) canvas.width = w
+        if (canvas.height !== h) canvas.height = h
+        const ctx = canvas.getContext('2d')
+        if (ctx) {
+          ctx.drawImage(v, 0, 0, w, h)
+          const blob = await new Promise<Blob | null>((r) =>
+            canvas.toBlob(r, 'image/jpeg', tier.jpegQuality)
+          )
+          if (blob && !cancelled && gen === generation) {
+            await window.omi.rewindSaveFrame(new Uint8Array(await blob.arrayBuffer()))
           }
         }
       } catch (e) {
         console.error('[rewind] sample failed:', (e as Error).message)
       } finally {
-        if (!cancelled && gen === generation) {
-          timerRef.current = setTimeout(() => void grabAndSchedule(gen), intervalMs)
-        }
+        savingRef.current = false
       }
+    }
+
+    // Periodic and foreground-triggered requests share one serial drain. Bursts
+    // coalesce to one pending sample, while the next periodic timer is armed only
+    // after all requested work settles.
+    function scheduleNext(gen: number): void {
+      if (cancelled || gen !== generation || !isLive()) return
+      if (timerRef.current) clearTimeout(timerRef.current)
+      timerRef.current = setTimeout(() => {
+        timerRef.current = null
+        requestCapture(gen)
+      }, intervalMs)
+    }
+
+    function requestCapture(gen: number): void {
+      if (cancelled || gen !== generation || !isLive()) return
+      if (captureRunning) {
+        queuedGeneration = gen
+        return
+      }
+
+      captureRunning = true
+      void (async () => {
+        let nextGeneration: number | null = gen
+        let processedGeneration: number | null = null
+        try {
+          while (nextGeneration !== null && !cancelled) {
+            const requestedGeneration = nextGeneration
+            queuedGeneration = null
+            await captureOnce(requestedGeneration)
+            processedGeneration = requestedGeneration
+            nextGeneration = queuedGeneration
+          }
+        } finally {
+          captureRunning = false
+          queuedGeneration = null
+          if (!cancelled && processedGeneration === generation && isLive()) {
+            scheduleNext(generation)
+          }
+        }
+      })()
     }
 
     const start = async (): Promise<void> => {
@@ -185,17 +221,28 @@ export function RewindCaptureHost(): React.JSX.Element {
           v.srcObject = stream
           await v.play().catch(() => undefined)
         }
-        timerRef.current = setTimeout(() => void grabAndSchedule(gen), intervalMs)
+        scheduleNext(gen)
       } catch (e) {
         console.error('[rewind] failed to start capture:', (e as Error).message)
       }
     }
+
+    const captureNow = (): void => {
+      if (!enabled || cancelled || !isLive()) return
+      if (timerRef.current) {
+        clearTimeout(timerRef.current)
+        timerRef.current = null
+      }
+      requestCapture(generation)
+    }
+    const offCaptureNow = window.omi.onRewindCaptureNow(captureNow)
 
     if (enabled) void start()
     else stop()
 
     return () => {
       cancelled = true
+      offCaptureNow()
       stop()
     }
     // `quality` is a stream constraint, so changing it re-opens the stream —

--- a/desktop/windows/src/shared/types.ts
+++ b/desktop/windows/src/shared/types.ts
@@ -1015,6 +1015,7 @@ export type OmiBridgeApi = {
   rewindRebuildIndex: () => Promise<number>
   rewindPrimarySourceId: () => Promise<string | null>
   rewindSaveFrame: (data: Uint8Array) => Promise<{ captured: boolean; reason?: string }>
+  onRewindCaptureNow: (cb: () => void) => () => void
   onRewindSettings: (cb: (s: RewindSettings) => void) => () => void
   /** Runtime capture directive (pause + effective cadence) the main process derives
    *  from OS power/lock state; the capture host prefers it over the base interval. */

--- a/desktop/windows/src/shared/types.ts
+++ b/desktop/windows/src/shared/types.ts
@@ -1014,7 +1014,12 @@ export type OmiBridgeApi = {
    *  deletes, idempotent). Resolves to the number of rows rebuilt. */
   rewindRebuildIndex: () => Promise<number>
   rewindPrimarySourceId: () => Promise<string | null>
-  rewindSaveFrame: (data: Uint8Array) => Promise<{ captured: boolean; reason?: string }>
+  /** Display source containing the foreground window, with cursor/primary fallbacks. */
+  rewindCaptureSourceId: () => Promise<string | null>
+  rewindSaveFrame: (
+    data: Uint8Array,
+    sourceId: string
+  ) => Promise<{ captured: boolean; reason?: string }>
   onRewindCaptureNow: (cb: () => void) => () => void
   onRewindSettings: (cb: (s: RewindSettings) => void) => () => void
   /** Runtime capture directive (pause + effective cadence) the main process derives


### PR DESCRIPTION
## What changed and why

Closes #8498. Closes #10488.

Windows Rewind now reacts to foreground-window changes and follows that window across displays without keeping multiple capture streams alive.

- The existing WinEvent hook requests an immediate sample on a foreground change.
- Screen sources are cached as an ID-to-display map instead of caching only the primary source.
- The foreground window's physical Win32 rectangle is converted to Electron DIP coordinates and matched to its display, with cursor and primary fallbacks.
- The renderer replaces its single persistent 1 fps stream only when the target display changes, preserving the current quality tier and capture cadence.
- Each save includes its capture source ID. The main process revalidates that source before ingestion and drops stale frames when focus moved displays during stream setup or JPEG encoding.
- The stream replacement path retains the `ended`/`mute` recovery merged in #10829, including initial-muted rejection and generation-fenced late-event handling.

Capture-disabled, lock/idle, excluded-app, sensitive-title, size, and duplicate-frame guards remain authoritative in the existing `ingestRewindFrame` path.

## Product invariants affected

none

## How it was verified

- Synced with current `origin/main` (`df314540b`) at head `c92147266`.
- `npm run build` passed with the final code, including main/preload and renderer typechecks, bytecode verification, extension bundling, and the production renderer bundle.
- A detached Windows integration used #10825 solely as the path-safe preflight runner; the committed 44-file composition passed all 70 selected checks in 188.34s. This PR's own diff remains 10 files.
- Targeted ESLint and Prettier passed for the two conflict-resolved capture-host files.
- `git diff --check` passed.
- A native Windows Electron smoke probe previously exercised `SetWinEventHook -> foregroundCaptureTrigger -> BrowserWindow IPC`; two programmatic foreground-window changes produced `events=2`.
- The current Windows host exposes one physical display, so a real dual-monitor switch was not hardware-tested here. Multi-display source selection, per-monitor DPI conversion, stream replacement, stale-source rejection, and muted/dead-track recovery are covered by tests.

## Tests

- `vitest run src/main/rewind/sourceId.test.ts src/main/rewind/foregroundCaptureTrigger.test.ts src/renderer/src/components/rewind/RewindCaptureHost.test.tsx` passed: 3 files, 29 tests.
- Coverage includes source-map caching and invalidation, foreground/cursor/primary display selection, physical-to-DIP conversion, source switching, late old-track events, stale-source rejection, burst coalescing, muted/dead-track recovery, and disabled/unmounted capture.
- A full Windows Vitest run on the prior head reached one unrelated `Apps.errorToast.test.tsx` timeout under full-suite load; that untouched file passed 2/2 immediately on an isolated rerun. All Rewind tests remained green.

## Failure class (fixes)

Failure-Class: none
