### PR TITLE
Add GET /v1/x/posts to list a user's synced X posts

### DIFF
--- a/backend/routers/x_connector.py
+++ b/backend/routers/x_connector.py
@@ -16,10 +16,11 @@ themselves without the backend needing to know which is calling.
 import logging
 from typing import Optional
 
-from fastapi import APIRouter, Depends, Query, Request
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from fastapi.responses import HTMLResponse
 from pydantic import BaseModel
 
+import database.x_posts as x_posts_db
 from utils import x_connector
 from utils.executors import start_background_task
 from utils.other import endpoints as auth
@@ -28,6 +29,7 @@ router = APIRouter()
 logger = logging.getLogger(__name__)
 
 DEFAULT_DEEP_LINK = 'omi://x/callback'
+X_POST_KINDS = (x_posts_db.KIND_TWEET, x_posts_db.KIND_BOOKMARK, x_posts_db.KIND_LIKE)
 
 
 class OAuthUrlResponse(BaseModel):
@@ -106,6 +108,23 @@ async def x_oauth_callback(
 @router.get('/v1/x/connection-status', tags=['x'])
 def x_connection_status(uid: str = Depends(auth.get_current_user_uid)):
     return x_connector.connection_status(uid)
+
+
+@router.get('/v1/x/posts', tags=['x'])
+def list_x_posts(
+    kind: Optional[str] = Query(None, description="Filter by kind: 'tweet', 'bookmark', or 'like'"),
+    limit: int = Query(100, ge=1, le=500, description="Maximum number of posts to return"),
+    uid: str = Depends(auth.get_current_user_uid),
+):
+    """List the user's synced X posts, newest first.
+
+    The connector stores every synced post under the user's account and mines memories
+    from them, but there was no endpoint to read the raw posts back. Supports an optional
+    kind filter ('tweet', 'bookmark', 'like') and a bounded limit.
+    """
+    if kind is not None and kind not in X_POST_KINDS:
+        raise HTTPException(status_code=400, detail="kind must be one of: tweet, bookmark, like")
+    return {'posts': x_posts_db.get_x_posts(uid, limit=limit, kind=kind)}
 
 
 @router.post('/v1/x/sync', tags=['x'])

--- a/backend/tests/unit/test_x_posts_list_endpoint.py
+++ b/backend/tests/unit/test_x_posts_list_endpoint.py
@@ -14,10 +14,22 @@ import os
 os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
 os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv')
 
+import inspect  # noqa: E402
+
 import pytest  # noqa: E402
 from fastapi import HTTPException  # noqa: E402
 
 from routers import x_connector as x_mod  # noqa: E402
+
+
+def test_list_x_posts_limit_has_documented_bounds_and_default():
+    # The limit is declared Query(100, ge=1, le=500); FastAPI rejects out-of-range values
+    # (e.g. limit=0 or limit=501) with 422 based on this declaration, and defaults to 100.
+    param = inspect.signature(x_mod.list_x_posts).parameters['limit'].default
+    assert param.default == 100
+    bounds = {type(m).__name__: m for m in param.metadata}
+    assert bounds['Ge'].ge == 1
+    assert bounds['Le'].le == 500
 
 
 def test_list_x_posts_returns_posts_wrapped(monkeypatch):

--- a/backend/tests/unit/test_x_posts_list_endpoint.py
+++ b/backend/tests/unit/test_x_posts_list_endpoint.py
@@ -1,0 +1,52 @@
+"""GET /v1/x/posts lists the user's synced X posts.
+
+The X connector stores every synced post under the user's account and mines memories
+from them, but nothing let a client read the raw posts back. The endpoint returns them
+newest-first with an optional kind filter and a bounded limit.
+
+Test isolation: routers.x_connector imports cleanly, so the test imports it normally,
+patches the import-cheap x_posts_db helper with monkeypatch.setattr, and calls the
+handler directly (no sys.modules mutation, no TestClient).
+"""
+
+import os
+
+os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
+os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv')
+
+import pytest  # noqa: E402
+from fastapi import HTTPException  # noqa: E402
+
+from routers import x_connector as x_mod  # noqa: E402
+
+
+def test_list_x_posts_returns_posts_wrapped(monkeypatch):
+    posts = [{'id': '2', 'text': 'newer', 'kind': 'tweet'}, {'id': '1', 'text': 'older', 'kind': 'tweet'}]
+    monkeypatch.setattr(x_mod.x_posts_db, 'get_x_posts', lambda uid, limit=100, kind=None: posts)
+    assert x_mod.list_x_posts(kind=None, limit=100, uid='u1') == {'posts': posts}
+
+
+def test_list_x_posts_passes_kind_and_limit(monkeypatch):
+    captured = {}
+
+    def fake_get(uid, limit=100, kind=None):
+        captured['args'] = (uid, limit, kind)
+        return []
+
+    monkeypatch.setattr(x_mod.x_posts_db, 'get_x_posts', fake_get)
+    x_mod.list_x_posts(kind='bookmark', limit=25, uid='u1')
+    assert captured['args'] == ('u1', 25, 'bookmark')
+
+
+def test_list_x_posts_rejects_invalid_kind(monkeypatch):
+    called = {'hit': False}
+
+    def fake_get(uid, limit=100, kind=None):
+        called['hit'] = True
+        return []
+
+    monkeypatch.setattr(x_mod.x_posts_db, 'get_x_posts', fake_get)
+    with pytest.raises(HTTPException) as ei:
+        x_mod.list_x_posts(kind='retweet', limit=100, uid='u1')
+    assert ei.value.status_code == 400
+    assert called['hit'] is False  # rejected before touching the db


### PR DESCRIPTION
## What

The X connector stores every synced post as a first-class item under `users/{uid}/x_posts` and mines memories from them, but there is no endpoint to read the raw posts back. A client that connected X has no way to display or reconcile what was actually synced. The `get_x_posts(uid, limit, kind)` database helper already reads them newest-first with an optional kind filter, but nothing exposed it (it was only used internally by semantic search).

## Change

Add `GET /v1/x/posts`, authenticated as the current user:

- Returns the user's synced posts newest-first, wrapped as `{ "posts": [...] }`.
- Optional `kind` filter (`tweet`, `bookmark`, or `like`); an unrecognized kind is rejected with 400 before any database call.
- `limit` is bounded (1..500, default 100).

Single new endpoint in `backend/routers/x_connector.py`, reusing the existing `database/x_posts.py` helper. No change to the database layer or any existing endpoint.

## Test

New `backend/tests/unit/test_x_posts_list_endpoint.py`:
- returns the posts wrapped under `posts`.
- passes the `kind` and `limit` through to the helper.
- rejects an invalid `kind` with 400 without touching the database.

Test isolation follows the current backend rules: `routers.x_connector` imports cleanly, so the test imports it normally, patches the import-cheap `x_posts_db` helper with `monkeypatch.setattr`, and calls the handler directly. No `sys.modules` mutation. Passes the import-purity and stub-pollution scanners and is auto-discovered by `scripts/select_backend_unit_tests.py --all`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8916?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

