### PR TITLE
Add GET /v1/fair-use/violations for a user's own recent event counts

### DIFF
--- a/backend/routers/fair_use_admin.py
+++ b/backend/routers/fair_use_admin.py
@@ -211,6 +211,16 @@ def get_my_fair_use_status(uid: str = Depends(get_current_user_uid)):
     }
 
 
+@router.get('/v1/fair-use/violations', tags=['fair_use'])
+def get_my_fair_use_violations(uid: str = Depends(get_current_user_uid)):
+    """User-facing endpoint: a rolling count of your own fair-use events.
+
+    Complements /v1/fair-use/status (which reports the current stage and speech usage) with
+    how many fair-use events you have had in the last 7 and 30 days.
+    """
+    return fair_use_db.get_violation_counts(uid)
+
+
 def _user_facing_message(stage: str, case_ref: str = '') -> str:
     ref_note = f' Your case reference is {case_ref}.' if case_ref else ''
     messages = {

--- a/backend/tests/unit/test_fair_use_violations_endpoint.py
+++ b/backend/tests/unit/test_fair_use_violations_endpoint.py
@@ -1,0 +1,34 @@
+"""GET /v1/fair-use/violations returns the caller's rolling fair-use event counts.
+
+Complements /v1/fair-use/status with how many fair-use events the user has had in the
+last 7 and 30 days, reusing the existing get_violation_counts helper.
+
+Test isolation: routers.fair_use_admin imports cleanly, so the test imports it normally,
+patches the import-cheap fair_use_db helper with monkeypatch.setattr, and calls the
+handler directly (no sys.modules mutation, no TestClient).
+"""
+
+import os
+
+os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
+os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv')
+
+from routers import fair_use_admin as fu_mod  # noqa: E402
+
+
+def test_violations_returns_counts(monkeypatch):
+    counts = {'violation_count_7d': 2, 'violation_count_30d': 5}
+    monkeypatch.setattr(fu_mod.fair_use_db, 'get_violation_counts', lambda uid: counts)
+    assert fu_mod.get_my_fair_use_violations(uid='u1') == counts
+
+
+def test_violations_scopes_to_caller_uid(monkeypatch):
+    seen = {}
+
+    def fake(uid):
+        seen['uid'] = uid
+        return {'violation_count_7d': 0, 'violation_count_30d': 0}
+
+    monkeypatch.setattr(fu_mod.fair_use_db, 'get_violation_counts', fake)
+    fu_mod.get_my_fair_use_violations(uid='user-42')
+    assert seen['uid'] == 'user-42'


### PR DESCRIPTION
## What

`GET /v1/fair-use/status` already lets a user see their current fair-use stage, speech usage, and limits, but there is no way for a user to see how many fair-use events they have actually accrued. The `get_violation_counts(uid)` database helper already rolls those events up over the last 7 and 30 days, but it was not exposed to the user (only the admin detail endpoint reads a user's events).

## Change

Add `GET /v1/fair-use/violations`, authenticated as the current user, returning the caller's own rolling event counts:

```json
{ "violation_count_7d": 2, "violation_count_30d": 5 }
```

It is grouped with the existing user-facing `/v1/fair-use/status` endpoint and reuses the same `get_current_user_uid` dependency. Single new endpoint in `backend/routers/fair_use_admin.py`; no change to the database layer or any existing endpoint. The data is a rollup of the same per-user fair-use events, uid-scoped throughout.

## Test

New `backend/tests/unit/test_fair_use_violations_endpoint.py`:
- returns the counts from the helper.
- scopes the lookup to the caller's uid.

Test isolation follows the current backend rules: `routers.fair_use_admin` imports cleanly, so the test imports it normally, patches the import-cheap `fair_use_db` helper with `monkeypatch.setattr`, and calls the handler directly. No `sys.modules` mutation. Passes the import-purity and stub-pollution scanners and is auto-discovered by `scripts/select_backend_unit_tests.py --all`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8920?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

