### PR TITLE
Add GET /v3/memories/review-queue/{review_id} to fetch one review conflict

### DIFF
--- a/backend/routers/memories.py
+++ b/backend/routers/memories.py
@@ -605,6 +605,23 @@ def list_memory_review_queue(
     return review_queue.list_review_conflicts(uid, status=status, limit=limit)
 
 
+@router.get('/v3/memories/review-queue/{review_id}', tags=['memories'])
+def get_memory_review_item(
+    review_id: str,
+    uid: str = Depends(auth.with_rate_limit(auth.get_current_user_uid, "memories:review")),
+):
+    """Fetch a single memory review conflict by id.
+
+    The list endpoint only returns conflicts in the 'pending' status, so once a conflict is
+    resolved it can no longer be retrieved. This fetches any of the user's review conflicts
+    by id regardless of status, returning 404 if it does not exist.
+    """
+    conflict = review_queue.get_review_conflict(uid, review_id)
+    if conflict is None:
+        raise HTTPException(status_code=404, detail='Review item not found')
+    return conflict
+
+
 @router.post('/v3/memories/review-queue/{review_id}/resolve', tags=['memories'])
 def resolve_memory_review_item(
     review_id: str,

--- a/backend/tests/unit/test_memories_create.py
+++ b/backend/tests/unit/test_memories_create.py
@@ -99,7 +99,7 @@ class TestMemoriesRateLimitWiring:
 
     def test_review_endpoint_has_rate_limit(self):
         matches = _grep_router(r"with_rate_limit.*memories:review")
-        assert len(matches) == 2, f"Review queue endpoints must have memories:review, found: {matches}"
+        assert len(matches) == 3, f"Review queue endpoints must have memories:review, found: {matches}"
 
     def test_modify_endpoints_have_rate_limit(self):
         matches = _grep_router(r"with_rate_limit.*memories:modify")
@@ -108,9 +108,9 @@ class TestMemoriesRateLimitWiring:
     def test_all_write_endpoints_rate_limited(self):
         """Every write endpoint in memories.py must use with_rate_limit."""
         matches = _grep_router(r"with_rate_limit.*memories:")
-        # create, batch, review queue list/resolve, delete, delete_all,
-        # modify(review), modify(edit), modify(visibility) = 9
-        assert len(matches) == 9, f"Expected 9 rate-limited endpoints, got {len(matches)}: {matches}"
+        # create, batch, review queue list/get/resolve, delete, delete_all,
+        # modify(review), modify(edit), modify(visibility) = 10
+        assert len(matches) == 10, f"Expected 10 rate-limited endpoints, got {len(matches)}: {matches}"
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/unit/test_memories_review_item_endpoint.py
+++ b/backend/tests/unit/test_memories_review_item_endpoint.py
@@ -1,0 +1,45 @@
+"""GET /v3/memories/review-queue/{review_id} fetches a single memory review conflict.
+
+The list endpoint only returns conflicts with status 'pending', so once a conflict is
+resolved it can no longer be retrieved. This endpoint fetches any of the user's review
+conflicts by id (404 if missing), reusing the existing get_review_conflict helper.
+
+Test isolation: routers.memories imports cleanly, so the test imports it normally, patches
+the import-cheap review_queue helper with monkeypatch.setattr, and calls the handler
+directly (no sys.modules mutation, no TestClient).
+"""
+
+import os
+
+os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
+os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv')
+
+import pytest  # noqa: E402
+from fastapi import HTTPException  # noqa: E402
+
+from routers import memories as mem_mod  # noqa: E402
+
+
+def test_get_review_item_returns_conflict(monkeypatch):
+    conflict = {'review_id': 'r1', 'status': 'resolved', 'conflict': {}}
+    monkeypatch.setattr(mem_mod.review_queue, 'get_review_conflict', lambda uid, review_id: conflict)
+    assert mem_mod.get_memory_review_item(review_id='r1', uid='u1') == conflict
+
+
+def test_get_review_item_404_when_missing(monkeypatch):
+    monkeypatch.setattr(mem_mod.review_queue, 'get_review_conflict', lambda uid, review_id: None)
+    with pytest.raises(HTTPException) as ei:
+        mem_mod.get_memory_review_item(review_id='nope', uid='u1')
+    assert ei.value.status_code == 404
+
+
+def test_get_review_item_scopes_to_caller_uid(monkeypatch):
+    seen = {}
+
+    def fake(uid, review_id):
+        seen['args'] = (uid, review_id)
+        return {'review_id': review_id}
+
+    monkeypatch.setattr(mem_mod.review_queue, 'get_review_conflict', fake)
+    mem_mod.get_memory_review_item(review_id='r9', uid='user-7')
+    assert seen['args'] == ('user-7', 'r9')

--- a/backend/tests/unit/test_rate_limiting.py
+++ b/backend/tests/unit/test_rate_limiting.py
@@ -557,8 +557,8 @@ class TestRouterWiring(unittest.TestCase):
 
     def test_memories_router_has_rate_limits(self):
         matches = self._grep_file("routers/memories.py", r"with_rate_limit.*memories:")
-        # create, batch, 2 review, delete, delete_all, 3 modify endpoints = 9
-        self.assertEqual(len(matches), 9, f"memories.py expected 9 rate limits, got {len(matches)}")
+        # create, batch, 3 review (list/get/resolve), delete, delete_all, 3 modify endpoints = 10
+        self.assertEqual(len(matches), 10, f"memories.py expected 10 rate limits, got {len(matches)}")
 
     def test_memories_create_endpoint_rate_limited(self):
         matches = self._grep_file("routers/memories.py", r"with_rate_limit.*memories:create")


### PR DESCRIPTION
## What

The memory review queue has a list endpoint (`GET /v3/memories/review-queue`) and a resolve endpoint (`POST /v3/memories/review-queue/{review_id}/resolve`), but no way to fetch a single review conflict by id. The list endpoint only returns conflicts with `status='pending'` (its default), so once a conflict is resolved it can no longer be retrieved through the API. The `get_review_conflict(uid, review_id)` database helper already fetches any conflict by id regardless of status, but nothing exposed it.

## Change

Add `GET /v3/memories/review-queue/{review_id}`, authenticated as the current user (same `memories:review` rate-limit dependency as the sibling endpoints), returning the conflict or 404 if it does not exist.

- Single new endpoint in `backend/routers/memories.py`, grouped between the existing list and resolve endpoints. No change to the database layer or any existing endpoint.
- Registered so it does not collide with any existing route (verified route registration).

## Test

New `backend/tests/unit/test_memories_review_item_endpoint.py`:
- returns the conflict from the helper.
- raises 404 when the helper returns nothing.
- scopes the lookup to the caller's uid.

Test isolation follows the current backend rules: `routers.memories` imports cleanly, so the test imports it normally, patches the import-cheap `review_queue` helper with `monkeypatch.setattr`, and calls the handler directly. No `sys.modules` mutation. Passes the import-purity and stub-pollution scanners and is auto-discovered by `scripts/select_backend_unit_tests.py --all`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8921?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

