### PR TITLE
Rate-limit the Developer API read routes (#8713)

### DIFF
--- a/backend/routers/developer.py
+++ b/backend/routers/developer.py
@@ -894,7 +894,7 @@ class BatchActionItemsResponse(BaseModel):
     operation_id="listActionItems",
 )
 def get_action_items(
-    uid: str = Depends(get_uid_with_action_items_read),
+    uid: str = Depends(with_rate_limit(get_uid_with_action_items_read, "dev:action_items_read")),
     conversation_id: Optional[str] = None,
     completed: Optional[bool] = None,
     start_date: Optional[datetime] = None,
@@ -1305,7 +1305,7 @@ class DeveloperFolder(BaseModel):
 
 
 @router.get("/v1/dev/user/folders", response_model=List[DeveloperFolder], tags=["Folders"], operation_id="listFolders")
-def get_user_folders(uid: str = Depends(get_uid_with_conversations_read)):
+def get_user_folders(uid: str = Depends(with_rate_limit(get_uid_with_conversations_read, "dev:conversations_read"))):
     """
     Get all folders for the authenticated user.
 
@@ -1992,7 +1992,7 @@ def _serialize_goal_datetimes(goal: dict) -> dict:
 
 @router.get("/v1/dev/user/goals", tags=["Goals"], response_model=List[GoalResponse], operation_id="listGoals")
 def get_goals(
-    uid: str = Depends(get_uid_with_goals_read),
+    uid: str = Depends(with_rate_limit(get_uid_with_goals_read, "dev:goals_read")),
     limit: int = 10,
     include_inactive: bool = False,
 ):
@@ -2013,7 +2013,7 @@ def get_goals(
 @router.get("/v1/dev/user/goals/{goal_id}", tags=["Goals"], response_model=GoalResponse, operation_id="getGoal")
 def get_goal(
     goal_id: str,
-    uid: str = Depends(get_uid_with_goals_read),
+    uid: str = Depends(with_rate_limit(get_uid_with_goals_read, "dev:goals_read")),
 ):
     """
     Get a single goal by ID.
@@ -2125,7 +2125,7 @@ def update_goal_progress(
 def get_goal_history(
     goal_id: str,
     days: HistoryDays = 30,
-    uid: str = Depends(get_uid_with_goals_read),
+    uid: str = Depends(with_rate_limit(get_uid_with_goals_read, "dev:goals_read")),
 ) -> List[dict]:
     """
     Get progress history for a goal.

--- a/backend/tests/unit/test_dev_api_folder_filters.py
+++ b/backend/tests/unit/test_dev_api_folder_filters.py
@@ -88,6 +88,13 @@ sys.modules['firebase_admin.auth'].RevokedIdTokenError = type('RevokedIdTokenErr
 sys.modules['firebase_admin.auth'].CertificateFetchError = type('CertificateFetchError', (Exception,), {})
 sys.modules['firebase_admin.auth'].UserNotFoundError = type('UserNotFoundError', (Exception,), {})
 
+# utils.other.endpoints is stubbed above, so with_rate_limit would be a MagicMock and the
+# rate-limited dev read routes would depend on a MagicMock instead of their real scope
+# dependency. Make it a transparent pass-through so the routes resolve to the underlying
+# scope dependency (which these tests override); the rate-limit wiring itself is covered by
+# test_dev_read_rate_limits.py.
+sys.modules['utils.other.endpoints'].with_rate_limit = lambda auth_dependency, policy_name: auth_dependency
+
 # ---- Mock populate_folder_names / populate_speaker_names ----
 # We patch these directly on routers.developer in each test class's setup_method,
 # so that the real utils.conversations.render module is never polluted regardless

--- a/backend/tests/unit/test_dev_read_rate_limits.py
+++ b/backend/tests/unit/test_dev_read_rate_limits.py
@@ -1,0 +1,32 @@
+"""Every Developer API read GET route must enforce a per-key read rate limit (issue #8713).
+
+The dev read policies (dev:conversations_read, dev:action_items_read, dev:goals_read) already
+exist in rate_limit_config, but the GET routes were declared with a bare scope dependency and
+no rate limit, so a single API key could poll them unbounded. This guards that each read
+dependency is wrapped with with_rate_limit and its intended policy.
+
+routers.developer builds a typesense client at import, so it cannot be imported in a bare unit
+test; this reads the source and asserts the wiring, matching the issue's acceptance criterion.
+"""
+
+from pathlib import Path
+
+_DEV = Path(__file__).resolve().parents[2] / 'routers' / 'developer.py'
+
+
+def _developer_source() -> str:
+    return _DEV.read_text(encoding='utf-8')
+
+
+def test_dev_read_routes_are_rate_limited():
+    src = _developer_source()
+    # No read GET route may use the bare scope dependency; each must be rate-limited.
+    for dep in ('get_uid_with_conversations_read', 'get_uid_with_action_items_read', 'get_uid_with_goals_read'):
+        assert f'Depends({dep})' not in src, f'{dep} is used as a dependency without a rate limit'
+
+
+def test_dev_read_routes_use_intended_policies():
+    src = _developer_source()
+    assert 'with_rate_limit(get_uid_with_conversations_read, "dev:conversations_read")' in src
+    assert 'with_rate_limit(get_uid_with_action_items_read, "dev:action_items_read")' in src
+    assert 'with_rate_limit(get_uid_with_goals_read, "dev:goals_read")' in src


### PR DESCRIPTION
Closes part of #8713.

## What

The Developer API read routes (`GET /v1/dev/user/...` for conversations, folders, action items, and goals) are scope-gated but not rate-limited. As the issue reports, a single API key polled `GET /v1/dev/user/conversations` roughly 1,300 times per hour for days with no throttle. The per-key read policies already exist in `utils/rate_limit_config.py` (`dev:conversations_read`, `dev:action_items_read`, `dev:goals_read`); they were simply never wired to the routes, so the runtime enforcement was silently absent.

## Change

Wrap each read route's scope dependency with `with_rate_limit(..., "dev:<area>_read")`, matching the pattern already used on the write route in the same file:

- `get_uid_with_conversations_read` → `dev:conversations_read` (conversations list, folders, and the conversation detail routes)
- `get_uid_with_action_items_read` → `dev:action_items_read`
- `get_uid_with_goals_read` → `dev:goals_read` (goals list, goal detail, goal history)

No route paths, parameters, or response models change, so the public OpenAPI contract is unchanged. This is the self-contained read-rate-limit slice of the issue; the broader `app_id:key_id` auth-context keying and audit-logging items are intentionally out of scope here.

## Test

New `backend/tests/unit/test_dev_read_rate_limits.py` guards the wiring: no read GET route may use the bare scope dependency, and each read dependency must be wrapped with its intended policy. `routers.developer` constructs a typesense client at import so it cannot be imported in a bare unit test; the test reads the source and asserts the wiring, which is exactly the acceptance check the issue asks for. Auto-discovered by `scripts/select_backend_unit_tests.py --all`; passes the import-purity and stub-pollution scanners.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8923?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

