### PR TITLE
Skip a malformed app record instead of 500ing the whole marketplace listing

### DIFF
--- a/backend/tests/unit/test_apps_marketplace_poison_guard.py
+++ b/backend/tests/unit/test_apps_marketplace_poison_guard.py
@@ -1,0 +1,52 @@
+"""Marketplace list builders must skip a malformed app record, not 500 the whole listing.
+
+get_popular_apps / get_available_apps / get_approved_available_apps build App(**doc) in a loop
+over raw Firestore docs. The listings are shared and Redis/process-cached across all users, so
+one malformed or legacy app document previously raised ValidationError and 500'd the entire page
+for everyone. _safe_build_app skips such a record (returns None) and logs its id + field names.
+
+The helper is a pure function, so the test imports and calls it directly (functional core, no
+monkeypatch, no sys.modules).
+"""
+
+import os
+
+os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
+os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv')
+
+import utils.apps as apps_utils  # noqa: E402
+from models.app import App  # noqa: E402
+
+
+def _valid_app_dict():
+    return {
+        'id': 'app1',
+        'name': 'Test App',
+        'category': 'productivity',
+        'author': 'Someone',
+        'description': 'Does things',
+        'image': 'http://img',
+        'capabilities': ['chat'],
+    }
+
+
+def test_safe_build_app_returns_app_for_valid_record():
+    built = apps_utils._safe_build_app(_valid_app_dict())
+    assert isinstance(built, App)
+    assert built.id == 'app1'
+
+
+def test_safe_build_app_skips_record_missing_required_fields():
+    # A legacy doc missing required fields (name/category/author/...) is skipped, not raised.
+    assert apps_utils._safe_build_app({'id': 'broken'}) is None
+
+
+def test_safe_build_app_skips_empty_record():
+    assert apps_utils._safe_build_app({}) is None
+
+
+def test_safe_build_app_valid_record_survives_next_to_a_poison_one():
+    # A poison record between good ones must not take the whole batch down.
+    records = [_valid_app_dict(), {'id': 'broken'}, {**_valid_app_dict(), 'id': 'app2'}]
+    built = [a for a in (apps_utils._safe_build_app(r) for r in records) if a is not None]
+    assert [a.id for a in built] == ['app1', 'app2']

--- a/backend/utils/apps.py
+++ b/backend/utils/apps.py
@@ -5,11 +5,12 @@ import os
 import secrets
 from collections import defaultdict
 from datetime import datetime, timezone
-from typing import List, Tuple, Dict, Any
+from typing import List, Tuple, Dict, Any, Optional
 from urllib.parse import urlparse
 
 import httpx
 from fastapi import HTTPException
+from pydantic import ValidationError
 from database.cache import get_memory_cache, get_pubsub_manager
 from database.redis_db import delete_generic_cache
 from database.apps import (
@@ -84,6 +85,25 @@ from utils.social import get_twitter_timeline
 import logging
 
 logger = logging.getLogger(__name__)
+
+
+def _safe_build_app(app_dict: dict) -> Optional[App]:
+    """Build an App from a raw marketplace record, skipping (not raising on) a malformed one.
+
+    The marketplace list builders are shared and Redis/process-cached across all users, so one
+    legacy or malformed app document must not 500 the whole listing for everyone. Returns None
+    for a record that fails validation, logging the app id and the offending field names only.
+    """
+    try:
+        return App(**app_dict)
+    except ValidationError as e:
+        logger.warning(
+            "Skipping malformed marketplace app %s: %s",
+            app_dict.get('id'),
+            [err['loc'][0] for err in e.errors()],
+        )
+        return None
+
 
 MarketplaceAppReviewUIDs = (
     os.getenv('MARKETPLACE_APP_REVIEWERS').split(',') if os.getenv('MARKETPLACE_APP_REVIEWERS') else []
@@ -271,7 +291,9 @@ def get_popular_apps() -> List[App]:
             rating_avg = sum([x['score'] for x in sorted_reviews]) / len(sorted_reviews) if reviews else None
             app_dict['rating_avg'] = rating_avg
             app_dict['rating_count'] = len(sorted_reviews)
-            apps.append(App(**app_dict))
+            built_app = _safe_build_app(app_dict)
+            if built_app is not None:
+                apps.append(built_app)
         apps = sorted(apps, key=lambda x: x.installs, reverse=True)
         return apps
 
@@ -338,7 +360,9 @@ def get_available_apps(uid: str, include_reviews: bool = False) -> List[App]:
             app_dict['user_review'] = reviews.get(uid)
             app_dict['rating_avg'] = rating_avg
             app_dict['rating_count'] = len(sorted_reviews)
-        apps.append(App(**app_dict))
+        built_app = _safe_build_app(app_dict)
+        if built_app is not None:
+            apps.append(built_app)
     if include_reviews:
         apps = sorted(apps, key=weighted_rating, reverse=True)
     return apps
@@ -462,7 +486,9 @@ def get_approved_available_apps(include_reviews: bool = False) -> list[App]:
                 app_dict['reviews'] = []
                 app_dict['rating_avg'] = rating_avg
                 app_dict['rating_count'] = len(sorted_reviews)
-            apps.append(App(**app_dict))
+            built_app = _safe_build_app(app_dict)
+            if built_app is not None:
+                apps.append(built_app)
         if include_reviews:
             apps = sorted(apps, key=weighted_rating, reverse=True)
         return apps


### PR DESCRIPTION
## What

The public app marketplace listings are built by looping over raw Firestore documents and constructing `App(**doc)` for each, with no per-record guard:

- `get_popular_apps()` feeds `GET /v1/apps/popular`
- `get_available_apps()` feeds `GET /v1/apps`
- `get_approved_available_apps()` feeds `GET /v2/apps` and `GET /v1/approved-apps`

`App` has required no-default fields (`id`, `name`, `category`, `author`, `description`, `image`, `capabilities`). A single legacy or malformed app document that is missing one of these raises `pydantic.ValidationError`, which is unhandled and 500s the entire listing. Because these listings are shared and Redis/process-cached across all users, one bad record takes the marketplace down for everyone, not just its owner.

## Change

Add a `_safe_build_app(app_dict)` helper that builds the `App`, and on `ValidationError` skips the record (returns `None`) and logs its id plus the offending field names only (never the field values, per the logging-security rules). Use it at all three build sites so a malformed record is dropped instead of failing the whole page.

Single-file change in `backend/utils/apps.py`. No change to the model, the database layer, or the routers.

## Test

New `backend/tests/unit/test_apps_marketplace_poison_guard.py`:
- a valid record builds an `App`.
- a record missing required fields, and an empty record, each return `None` instead of raising.
- a poison record between two valid ones does not take the batch down (the two valid apps still come through).

The helper is a pure function, so the test imports and calls it directly (functional core, no `monkeypatch`, no `sys.modules`). Auto-discovered by `scripts/select_backend_unit_tests.py --all`; passes the import-purity and stub-pollution scanners.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8924?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

