### PR TITLE
Add GET /v1/knowledge-graph/nodes/{node_id} to fetch one graph node

### DIFF
--- a/backend/routers/knowledge_graph.py
+++ b/backend/routers/knowledge_graph.py
@@ -48,6 +48,20 @@ def get_knowledge_graph(uid: str = Depends(auth.get_current_user_uid)):
     return KnowledgeGraphResponse(nodes=graph.get('nodes', []), edges=graph.get('edges', []))
 
 
+@router.get('/v1/knowledge-graph/nodes/{node_id}', tags=['knowledge_graph'])
+def get_knowledge_graph_node(node_id: str, uid: str = Depends(auth.get_current_user_uid)):
+    """Fetch a single knowledge-graph node by id.
+
+    The full-graph endpoint returns every node and edge; this fetches one node directly (for
+    example to expand or refresh a single node without reloading the whole graph), returning
+    404 if it does not exist.
+    """
+    node = kg_db.get_knowledge_node(uid, node_id)
+    if node is None:
+        raise HTTPException(status_code=404, detail='Node not found')
+    return node
+
+
 def _rebuild_graph_task(uid: str, user_name: str):
     memory_system = pin_memory_system(uid, db_client=firestore_db)
     if memory_system == MemorySystem.CANONICAL:

--- a/backend/tests/unit/test_kg_node_getter_endpoint.py
+++ b/backend/tests/unit/test_kg_node_getter_endpoint.py
@@ -1,0 +1,44 @@
+"""GET /v1/knowledge-graph/nodes/{node_id} fetches a single knowledge-graph node.
+
+The full-graph endpoint returns every node and edge; there was no way to fetch one node by
+id. This reuses the existing get_knowledge_node helper and returns 404 when it is missing.
+
+Test isolation: routers.knowledge_graph imports cleanly, so the test imports it normally,
+patches the import-cheap kg_db helper with monkeypatch.setattr, and calls the handler
+directly (no sys.modules mutation, no TestClient).
+"""
+
+import os
+
+os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
+os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv')
+
+import pytest  # noqa: E402
+from fastapi import HTTPException  # noqa: E402
+
+from routers import knowledge_graph as kg  # noqa: E402
+
+
+def test_get_node_returns_node(monkeypatch):
+    node = {'id': 'n1', 'label': 'Guitar', 'node_type': 'concept'}
+    monkeypatch.setattr(kg.kg_db, 'get_knowledge_node', lambda uid, node_id: node)
+    assert kg.get_knowledge_graph_node(node_id='n1', uid='u1') == node
+
+
+def test_get_node_404_when_missing(monkeypatch):
+    monkeypatch.setattr(kg.kg_db, 'get_knowledge_node', lambda uid, node_id: None)
+    with pytest.raises(HTTPException) as ei:
+        kg.get_knowledge_graph_node(node_id='nope', uid='u1')
+    assert ei.value.status_code == 404
+
+
+def test_get_node_scopes_to_caller_uid(monkeypatch):
+    seen = {}
+
+    def fake(uid, node_id):
+        seen['args'] = (uid, node_id)
+        return {'id': node_id}
+
+    monkeypatch.setattr(kg.kg_db, 'get_knowledge_node', fake)
+    kg.get_knowledge_graph_node(node_id='n9', uid='user-7')
+    assert seen['args'] == ('user-7', 'n9')


### PR DESCRIPTION
## What

The knowledge-graph API exposes the whole graph (`GET /v1/knowledge-graph` returns every node and edge) but has no way to fetch a single node by id. A client that wants to expand or refresh one node has to reload the entire graph. The `get_knowledge_node(uid, node_id)` database helper already fetches a single node, but nothing exposed it (it had zero router callers).

## Change

Add `GET /v1/knowledge-graph/nodes/{node_id}`, authenticated as the current user, returning the node or 404 if it does not exist. Single new endpoint in `backend/routers/knowledge_graph.py`, reusing the existing helper. No change to the database layer or any existing endpoint. The path is deeper and distinct from the existing `/v1/knowledge-graph` route, so there is no route-ordering hazard (verified route registration).

## Test

New `backend/tests/unit/test_kg_node_getter_endpoint.py`:
- returns the node from the helper.
- raises 404 when the helper returns nothing.
- scopes the lookup to the caller's uid.

Test isolation follows the current backend rules: `routers.knowledge_graph` imports cleanly, so the test imports it normally, patches the import-cheap `kg_db` helper with `monkeypatch.setattr`, and calls the handler directly. No `sys.modules` mutation. Passes the import-purity and stub-pollution scanners and is auto-discovered by `scripts/select_backend_unit_tests.py --all`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8926?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

