### PR TITLE
Add Windows Web Speech reply playback

### DIFF
--- a/desktop/windows/src/renderer/src/components/overlay/OverlayApp.tsx
+++ b/desktop/windows/src/renderer/src/components/overlay/OverlayApp.tsx
@@ -1,6 +1,6 @@
 // src/renderer/src/components/overlay/OverlayApp.tsx
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
-import { useChat } from '../../hooks/useChat'
+import { useChat, type SendOptions } from '../../hooks/useChat'
 import { useAuth } from '../../hooks/useAuth'
 import { usePushToTalk } from '../../hooks/usePushToTalk'
 import { auth } from '../../lib/firebase'
@@ -33,14 +33,17 @@ function OverlayPanel({ replayEnter }: { replayEnter: () => void }): React.JSX.E
   // reply is still streaming (which `useChat.send` would no-op). Each send is
   // chained after the prior one resolves and dispatched through the latest `send`.
   const sendRef = useRef(send)
-  // eslint-disable-next-line react-hooks/refs -- intentional latest-ref / lazy-init (reads newest value in once-registered listeners & imperative loops, avoids stale closures)
-  sendRef.current = send
+  useEffect(() => {
+    sendRef.current = send
+  }, [send])
   const sendChainRef = useRef<Promise<void>>(Promise.resolve())
-  const enqueueSend = useCallback((text: string): void => {
+  const enqueueSend = useCallback((text: string, options?: SendOptions): void => {
     // Single send choke-point (typed Enter + voice commit) — tell onboarding the
     // user asked something in the bar.
     window.omiOverlay.notifyAsked()
-    sendChainRef.current = sendChainRef.current.then(() => sendRef.current(text)).catch(() => {})
+    sendChainRef.current = sendChainRef.current
+      .then(() => sendRef.current(text, options))
+      .catch(() => {})
   }, [])
 
   // Hold-Space-to-talk: a quick Space tap types a space; holding past the threshold
@@ -48,14 +51,15 @@ function OverlayPanel({ replayEnter }: { replayEnter: () => void }): React.JSX.E
   // auto-sends it (queued behind any in-flight reply).
   // Latest draft, read by the window-level (textarea-unfocused) push-to-talk path.
   const draftRef = useRef(draft)
-  // eslint-disable-next-line react-hooks/refs -- intentional latest-ref / lazy-init (reads newest value in once-registered listeners & imperative loops, avoids stale closures)
-  draftRef.current = draft
+  useLayoutEffect(() => {
+    draftRef.current = draft
+  }, [draft])
 
   const ptt = usePushToTalk({
     onTranscript: (text) => setDraft(text),
     onCommit: (text) => {
       setDraft('')
-      enqueueSend(text)
+      enqueueSend(text, { speakReply: true })
     },
     // Fires on every completed hold-Space capture, even when transcription was
     // unavailable (quota/1008) or silent. Drives the onboarding voice step so a

--- a/desktop/windows/src/renderer/src/hooks/useChat.ts
+++ b/desktop/windows/src/renderer/src/hooks/useChat.ts
@@ -8,8 +8,11 @@ import { callAgentLLM } from '../lib/agentLLM'
 import type { AutomationPlan } from '../../../shared/types'
 import { getPreferences } from '../lib/preferences'
 import { resolveChatId, mergeChatMessages } from '../lib/chatConversation'
+import { createWebSpeechReplyPlayer, findReplySpeechBoundary } from '../lib/replySpeech'
 
 export type ChatMsg = { id?: string; role: 'user' | 'assistant'; content: string }
+// Replies are spoken by default; callers can opt out for silent sends.
+export type SendOptions = { speakReply?: boolean }
 
 const OMI_BASE = import.meta.env.VITE_OMI_API_BASE as string
 
@@ -25,7 +28,7 @@ export type UseChat = {
   // voice transcript. When it classifies a message as an action and builds a valid
   // plan, approval + execution happen via a NATIVE Windows dialog (main process),
   // so it works identically from the main window and the floating overlay.
-  send: (text: string) => Promise<void>
+  send: (text: string, options?: SendOptions) => Promise<void>
   /** Clear the thread to a fresh conversation (used by the overlay's Esc). */
   reset: () => void
 }
@@ -70,6 +73,13 @@ export function useChat(opts?: { surface?: 'main' | 'overlay' }): UseChat {
   // message firing right as a previous reply finishes), which would wrongly drop
   // the new send; the ref is always current.
   const sendingRef = useRef(false)
+  const speechRef = useRef(createWebSpeechReplyPlayer())
+
+  useEffect(() => {
+    return () => {
+      speechRef.current.cancel()
+    }
+  }, [])
 
   // In infinite mode the MAIN window shows the ongoing thread, so load it once on
   // mount (and backfill ids on any legacy id-less messages so the merge can match
@@ -184,9 +194,10 @@ export function useChat(opts?: { surface?: 'main' | 'overlay' }): UseChat {
     }
   }
 
-  const send = async (text: string): Promise<void> => {
+  const send = async (text: string, options?: SendOptions): Promise<void> => {
     // Re-entrancy latch (sendingRef is the always-current mirror of `sending`).
     if (!text.trim() || sendingRef.current) return
+    const speech = options?.speakReply === false ? null : speechRef.current
     sendingRef.current = true
     const userMsg: ChatMsg = { id: crypto.randomUUID(), role: 'user', content: text }
     const baseHistory = history
@@ -194,6 +205,28 @@ export function useChat(opts?: { surface?: 'main' | 'overlay' }): UseChat {
     // planner snapshot+LLM round-trip, so the chat never appears to hang. The
     // planner then decides: park a plan, surface an error, or fall through to chat.
     setHistory((h) => [...h, userMsg])
+    speech?.startFiller()
+
+    let speechBuffer = ''
+    let firstSpeechChunk = true
+    const queueSpeech = (chunk: string, final = false): void => {
+      if (!speech) return
+      speechBuffer += chunk
+      while (true) {
+        const boundary = findReplySpeechBoundary(speechBuffer, {
+          final,
+          first: firstSpeechChunk
+        })
+        if (boundary === null) break
+        const next = speechBuffer.slice(0, boundary)
+        speechBuffer = speechBuffer.slice(boundary).replace(/^\s+/, '')
+        if (speech.speak(next)) firstSpeechChunk = false
+        if (!speechBuffer.trim()) {
+          speechBuffer = ''
+          break
+        }
+      }
+    }
 
     const verdict = await tryPlan(text)
     if (verdict.kind === 'planned') {
@@ -211,6 +244,7 @@ export function useChat(opts?: { surface?: 'main' | 'overlay' }): UseChat {
             : `I couldn't finish that: ${r.message ?? 'a step failed'}`
       }
       setHistory((h) => [...h, outMsg])
+      speech?.speak(outMsg.content)
       void persistChat([...baseHistory, userMsg, outMsg])
       sendingRef.current = false
       return
@@ -223,6 +257,7 @@ export function useChat(opts?: { surface?: 'main' | 'overlay' }): UseChat {
           "I couldn't turn that into an action I could run safely, so I didn't do anything. Try rephrasing it, or try again in a moment."
       }
       setHistory((h) => [...h, errMsg])
+      speech?.speak(errMsg.content)
       void persistChat([...baseHistory, userMsg, errMsg])
       sendingRef.current = false
       return
@@ -295,6 +330,7 @@ export function useChat(opts?: { surface?: 'main' | 'overlay' }): UseChat {
           const chunk = parseChunk(line)
           if (chunk === null) continue
           assistantText += chunk
+          queueSpeech(chunk)
           setHistory((h) => {
             const next = [...h]
             next[next.length - 1] = { id: assistantId, role: 'assistant', content: assistantText }
@@ -309,6 +345,7 @@ export function useChat(opts?: { surface?: 'main' | 'overlay' }): UseChat {
       const tail = parseChunk(buffer)
       if (tail !== null) {
         assistantText += tail
+        queueSpeech(tail)
         setHistory((h) => {
           const next = [...h]
           next[next.length - 1] = { id: assistantId, role: 'assistant', content: assistantText }
@@ -319,16 +356,24 @@ export function useChat(opts?: { surface?: 'main' | 'overlay' }): UseChat {
       // with raw plan JSON (when it reached chat WITHOUT our planner — e.g. a
       // keyword-less follow-up like "again"). Don't render that raw in the thread.
       if (looksLikeRawPlan(assistantText)) {
+        speechBuffer = ''
+        speech?.cancel()
         assistantText =
           "It looks like you want me to do something in an app. Phrase it as a direct command (e.g. \"type report in the search box\") with that app focused, and I'll show you a plan to approve."
+        speech?.speak(assistantText)
         setHistory((h) => {
           const next = [...h]
           next[next.length - 1] = { id: assistantId, role: 'assistant', content: assistantText }
           return next
         })
+      } else {
+        queueSpeech('', true)
       }
     } catch (e) {
       assistantText = `Error: ${(e as Error).message}`
+      speechBuffer = ''
+      speech?.cancel()
+      speech?.speak(assistantText)
       setHistory((h) => {
         const next = [...h]
         next[next.length - 1] = { id: assistantId, role: 'assistant', content: assistantText }
@@ -349,6 +394,7 @@ export function useChat(opts?: { surface?: 'main' | 'overlay' }): UseChat {
     setHistory([])
     setSending(false)
     sendingRef.current = false
+    speechRef.current.cancel()
     // Per-launch: forget the id so the next send creates a NEW conversation.
     // Infinite: keep the shared id — reset is only a fresh on-screen view of the
     // same ongoing thread, not a new conversation.

--- a/desktop/windows/src/renderer/src/lib/replySpeech.test.ts
+++ b/desktop/windows/src/renderer/src/lib/replySpeech.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createWebSpeechReplyPlayer, findReplySpeechBoundary } from './replySpeech'
+
+describe('findReplySpeechBoundary', () => {
+  it('waits until the first reply chunk is large enough', () => {
+    expect(findReplySpeechBoundary('Too short.', { first: true })).toBeNull()
+  })
+
+  it('uses an early sentence boundary once the first chunk reaches the minimum', () => {
+    const text = 'This is enough text to start speaking naturally now. More text follows'
+    expect(findReplySpeechBoundary(text, { first: true })).toBe(52)
+  })
+
+  it('waits for preferred length before using clause boundaries', () => {
+    const text = `${'a'.repeat(50)}, ${'b'.repeat(67)}`
+    expect(findReplySpeechBoundary(text, { first: true })).toBeNull()
+    expect(findReplySpeechBoundary(`${text} c`, { first: true })).toBe(51)
+  })
+
+  it('hard-cuts the first chunk at the emergency limit', () => {
+    const text = 'a'.repeat(205)
+    expect(findReplySpeechBoundary(text, { first: true })).toBe(200)
+  })
+
+  it('uses larger limits after the first spoken chunk', () => {
+    expect(findReplySpeechBoundary(`${'a'.repeat(318)}.`, { first: false })).toBeNull()
+    expect(findReplySpeechBoundary(`${'a'.repeat(320)}.`, { first: false })).toBe(321)
+  })
+
+  it('flushes any final leftover text', () => {
+    expect(findReplySpeechBoundary('short final', { final: true, first: false })).toBe(11)
+  })
+})
+
+describe('createWebSpeechReplyPlayer', () => {
+  it('speaks a filler and replaces it with the first real reply chunk', () => {
+    const speak = vi.fn()
+    const cancel = vi.fn()
+    class Utterance {
+      text: string
+
+      constructor(text: string) {
+        this.text = text
+      }
+    }
+
+    const player = createWebSpeechReplyPlayer({
+      getWindow: () =>
+        ({
+          speechSynthesis: { speak, cancel },
+          SpeechSynthesisUtterance: Utterance
+        }) as unknown as Window,
+      fillerText: 'Checking.'
+    })
+
+    player.startFiller()
+    expect(speak.mock.calls[0][0].text).toBe('Checking.')
+
+    expect(player.speak('  Hello\nworld.  ')).toBe(true)
+    expect(cancel).toHaveBeenCalledTimes(2)
+    expect(speak.mock.calls[1][0].text).toBe('Hello world.')
+  })
+
+  it('no-ops when Web Speech is unavailable', () => {
+    const player = createWebSpeechReplyPlayer({ getWindow: () => undefined })
+    expect(player.speak('Hello')).toBe(false)
+    expect(() => player.startFiller()).not.toThrow()
+    expect(() => player.cancel()).not.toThrow()
+  })
+})

--- a/desktop/windows/src/renderer/src/lib/replySpeech.ts
+++ b/desktop/windows/src/renderer/src/lib/replySpeech.ts
@@ -1,0 +1,118 @@
+type SpeechWindow = {
+  speechSynthesis?: SpeechSynthesis
+  SpeechSynthesisUtterance?: new (text: string) => SpeechSynthesisUtterance
+}
+
+type BoundaryLimits = {
+  min: number
+  preferred: number
+  emergency: number
+}
+
+const FIRST_CHUNK: BoundaryLimits = { min: 40, preferred: 120, emergency: 200 }
+const FOLLOWUP_CHUNK: BoundaryLimits = { min: 320, preferred: 520, emergency: 800 }
+
+const SENTENCE_END = new Set(['.', '!', '?', '\n', '\r'])
+const CLAUSE_END = new Set([',', ';', ':'])
+
+export type ReplySpeechPlayer = {
+  startFiller: () => void
+  speak: (text: string) => boolean
+  cancel: () => void
+}
+
+export type ReplySpeechOptions = {
+  getWindow?: () => SpeechWindow | undefined
+  fillerText?: string
+}
+
+export function findReplySpeechBoundary(
+  text: string,
+  opts: { final?: boolean; first?: boolean } = {}
+): number | null {
+  if (!text.trim()) return null
+  if (opts.final) return text.length
+
+  const limits = opts.first === false ? FOLLOWUP_CHUNK : FIRST_CHUNK
+  if (text.length < limits.min) return null
+
+  const sentence = findLastBoundary(text, limits.min, text.length, (ch) => SENTENCE_END.has(ch))
+  if (sentence !== null) return sentence
+
+  if (text.length >= limits.preferred) {
+    const clause = findLastBoundary(text, limits.min, text.length, (ch) => CLAUSE_END.has(ch))
+    if (clause !== null) return clause
+
+    const whitespace = findLastBoundary(text, limits.min, text.length, (ch) => /\s/.test(ch))
+    if (whitespace !== null) return whitespace
+  }
+
+  if (text.length >= limits.emergency) {
+    const cut = Math.min(text.length, limits.emergency)
+    const whitespace = findLastBoundary(text, limits.min, cut, (ch) => /\s/.test(ch))
+    return whitespace ?? cut
+  }
+
+  return null
+}
+
+export function createWebSpeechReplyPlayer(opts: ReplySpeechOptions = {}): ReplySpeechPlayer {
+  const getWindow = opts.getWindow ?? (() => (typeof window === 'undefined' ? undefined : window))
+  const fillerText = opts.fillerText ?? 'One moment.'
+  let fillerActive = false
+
+  const resolve = (): {
+    synth: SpeechSynthesis
+    Utterance: new (text: string) => SpeechSynthesisUtterance
+  } | null => {
+    const w = getWindow()
+    if (!w?.speechSynthesis || !w.SpeechSynthesisUtterance) return null
+    return { synth: w.speechSynthesis, Utterance: w.SpeechSynthesisUtterance }
+  }
+
+  const speak = (text: string): boolean => {
+    const clean = normalizeSpeechText(text)
+    if (!clean) return false
+    const speech = resolve()
+    if (!speech) return false
+    if (fillerActive) {
+      speech.synth.cancel()
+      fillerActive = false
+    }
+    speech.synth.speak(new speech.Utterance(clean))
+    return true
+  }
+
+  return {
+    startFiller: () => {
+      const speech = resolve()
+      if (!speech) return
+      speech.synth.cancel()
+      fillerActive = true
+      speech.synth.speak(new speech.Utterance(fillerText))
+    },
+    speak,
+    cancel: () => {
+      const speech = resolve()
+      if (speech) speech.synth.cancel()
+      fillerActive = false
+    }
+  }
+}
+
+function findLastBoundary(
+  text: string,
+  min: number,
+  max: number,
+  matches: (ch: string) => boolean
+): number | null {
+  const end = Math.min(max, text.length)
+  for (let i = end - 1; i >= min - 1; i--) {
+    if (matches(text[i])) return i + 1
+  }
+  return null
+}
+
+function normalizeSpeechText(text: string): string {
+  return text.replace(/\s+/g, ' ').trim()
+}


### PR DESCRIPTION
## Summary

- add a Web Speech reply player for Windows chat replies with a short filler utterance
- chunk streamed SSE replies on sentence/clause/length boundaries before speaking
- wire shared `useChat` replies so both the main window and overlay can speak without adding dependencies
- cancel queued speech when chat is reset or the hook unmounts

Part of #8912. This covers the zero-dependency Web Speech TTS path; AudioWorklet streaming and client-side VAD interruption remain follow-up work.

## Refresh

- Re-applied onto the post-rewrite `main` line at `d6cb66f320f5217590671315cb95c312bf78ea52` after GitHub reported the old branch as diverged from current `main`.
- Current head: `e51b2533b0438c8a55a3fcad3fc9dab03de9d852`.
- GitHub currently reports this PR as mergeable.

## Validation

- `pnpm install --frozen-lockfile --ignore-scripts --offline --config.confirmModulesPurge=false` -> passed
- `pnpm exec vitest run src/renderer/src/lib/replySpeech.test.ts src/renderer/src/components/overlay/pushToTalk.test.ts` -> 2 files, 28 tests passed
- `pnpm run typecheck` -> passed
- `npm test` -> 81 files, 555 tests passed; 1 e2e file skipped by existing config
- `npm run build` -> passed; existing Vite dynamic/static import chunk warning only
- `./node_modules/.bin/eslint.cmd src/renderer/src/lib/replySpeech.ts src/renderer/src/lib/replySpeech.test.ts src/renderer/src/hooks/useChat.ts src/renderer/src/components/overlay/OverlayApp.tsx --quiet` -> no errors
- `PYTHONUTF8=1 bash scripts/pre-push` -> passed; existing long-function advisories for `OverlayPanel` and `useChat` only

Note: this Windows machine does not have the .NET SDK, so postinstall logs the existing non-fatal OCR helper build warning; the app and checks still completed.