### PR TITLE
Add GET /v1/action-items/ids to list a user's action-item IDs

### DIFF
--- a/backend/routers/action_items.py
+++ b/backend/routers/action_items.py
@@ -370,6 +370,17 @@ def search_action_items(
     return {"action_items": _safe_action_item_responses(action_items, uid=uid)}
 
 
+@router.get("/v1/action-items/ids", tags=['action-items'])
+def list_action_item_ids(uid: str = Depends(auth.get_current_user_uid)):
+    """Return all of the user's action-item IDs (IDs only, no field reads).
+
+    A lightweight way for a client to reconcile which tasks it has without paging the full
+    list. Declared before /v1/action-items/{action_item_id} so the static path is not
+    captured as an action item id.
+    """
+    return {"ids": action_items_db.get_action_item_ids(uid)}
+
+
 @router.get("/v1/action-items/{action_item_id}", response_model=ActionItemResponse, tags=['action-items'])
 def get_action_item(action_item_id: str, uid: str = Depends(auth.get_current_user_uid)):
     """Get a specific action item by ID."""

--- a/backend/tests/unit/test_action_item_ids_endpoint.py
+++ b/backend/tests/unit/test_action_item_ids_endpoint.py
@@ -1,0 +1,37 @@
+"""GET /v1/action-items/ids returns the user's action-item IDs (lightweight reconciliation).
+
+The full list endpoint returns every field for every task; there was no cheap way to fetch
+just the set of IDs a user has. This reuses the IDs-only get_action_item_ids helper.
+
+Test isolation: routers.action_items imports cleanly, so the test imports it normally,
+patches the import-cheap db helper with monkeypatch.setattr, and calls the handler directly.
+"""
+
+import os
+
+os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
+os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv')
+
+from routers import action_items as ai_mod  # noqa: E402
+
+
+def test_list_action_item_ids_returns_ids(monkeypatch):
+    monkeypatch.setattr(ai_mod.action_items_db, 'get_action_item_ids', lambda uid: ['a1', 'a2', 'a3'])
+    assert ai_mod.list_action_item_ids(uid='u1') == {'ids': ['a1', 'a2', 'a3']}
+
+
+def test_list_action_item_ids_empty(monkeypatch):
+    monkeypatch.setattr(ai_mod.action_items_db, 'get_action_item_ids', lambda uid: [])
+    assert ai_mod.list_action_item_ids(uid='u1') == {'ids': []}
+
+
+def test_list_action_item_ids_scopes_to_caller(monkeypatch):
+    seen = {}
+
+    def fake(uid):
+        seen['uid'] = uid
+        return []
+
+    monkeypatch.setattr(ai_mod.action_items_db, 'get_action_item_ids', fake)
+    ai_mod.list_action_item_ids(uid='user-9')
+    assert seen['uid'] == 'user-9'


### PR DESCRIPTION
## What

`GET /v1/action-items` returns every field for every task, so a client that only needs to know which tasks exist (for lightweight sync or reconciliation) has to page the whole list. The `get_action_item_ids(uid)` database helper does an IDs-only Firestore projection (`.select([]).stream()`, no field reads), but nothing exposed it.

## Change

Add `GET /v1/action-items/ids`, authenticated as the current user, returning `{ "ids": [...] }`. It is declared before `GET /v1/action-items/{action_item_id}` so the static path is not captured as an action-item id (verified route registration order). Single new endpoint in `backend/routers/action_items.py`, reusing the existing helper. No change to the database layer or any existing endpoint.

## Test

New `backend/tests/unit/test_action_item_ids_endpoint.py`: returns the ids, returns an empty list, and scopes the lookup to the caller's uid. Imports the router normally, patches the import-cheap db helper with `monkeypatch.setattr`, and calls the handler directly. Auto-discovered; passes the import-purity and stub-pollution scanners.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8932?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

