### PR TITLE
Skip a malformed app record instead of 500ing the app search page

### DIFF
--- a/backend/routers/apps.py
+++ b/backend/routers/apps.py
@@ -403,7 +403,15 @@ def search_apps(
         app_dict['rating_avg'] = rating_avg
         app_dict['rating_count'] = len(sorted_reviews)
 
-        apps.append(App(**app_dict))
+        # Skip a malformed/legacy app document rather than 500 the whole search page.
+        try:
+            apps.append(App(**app_dict))
+        except ValidationError as e:
+            logger.warning(
+                "Skipping malformed app %s in search results: %s",
+                app_dict.get('id'),
+                [err['loc'][0] for err in e.errors() if err.get('loc')],
+            )
 
     # Always exclude persona type apps from results
     filtered_apps = [app for app in apps if not app.is_a_persona()]

--- a/backend/routers/apps.py
+++ b/backend/routers/apps.py
@@ -385,6 +385,15 @@ def search_apps(
 
     user_enabled = set(get_enabled_apps(uid))
 
+    # Drop any malformed record missing an id before enrichment: id drives the installs/reviews/
+    # enabled lookups below and the pre-loop app_ids list, so a missing id would KeyError before the
+    # per-record ValidationError guard can catch it.
+    valid_apps_data = [a for a in apps_data if a.get('id')]
+    skipped_no_id = len(apps_data) - len(valid_apps_data)
+    if skipped_no_id:
+        logger.warning("Skipping %d malformed app record(s) without an id in search results", skipped_no_id)
+    apps_data = valid_apps_data
+
     app_ids = [app['id'] for app in apps_data]
     apps_installs = get_apps_installs_count(app_ids)
     apps_reviews = get_apps_reviews(app_ids)

--- a/backend/tests/unit/test_apps_search_poison_guard.py
+++ b/backend/tests/unit/test_apps_search_poison_guard.py
@@ -1,0 +1,53 @@
+"""GET /v2/apps/search must skip a malformed app record, not 500 the whole search page.
+
+search_apps builds App(**app_dict) in a loop over raw Firestore app documents. One legacy or
+malformed app document (missing a required field like name/category/author) previously raised
+ValidationError and 500'd the entire search result for the user. The guard skips + logs it.
+
+Test isolation: routers.apps imports cleanly, so the test imports it normally, patches the
+import-cheap db helpers with monkeypatch.setattr, and calls the handler directly.
+"""
+
+import os
+
+os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
+os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv')
+
+from routers import apps as apps_mod  # noqa: E402
+
+
+def _valid_app_dict(app_id='a1'):
+    return {
+        'id': app_id,
+        'name': 'Good App',
+        'category': 'productivity',
+        'author': 'Someone',
+        'description': 'Does things',
+        'image': 'http://img',
+        'capabilities': ['chat'],
+    }
+
+
+def test_search_apps_skips_malformed_record(monkeypatch):
+    good = _valid_app_dict('a1')
+    bad = {'id': 'a2'}  # missing required fields -> ValidationError -> must be skipped, not 500
+    monkeypatch.setattr(apps_mod, 'search_apps_db', lambda **kw: [dict(good), dict(bad)])
+    monkeypatch.setattr(apps_mod, 'get_enabled_apps', lambda uid: set())
+    monkeypatch.setattr(apps_mod, 'get_apps_installs_count', lambda ids: {})
+    monkeypatch.setattr(apps_mod, 'get_apps_reviews', lambda ids: {})
+
+    result = apps_mod.search_apps(
+        q=None,
+        category=None,
+        rating=None,
+        capability=None,
+        sort=None,
+        my_apps=None,
+        installed_apps=None,
+        offset=0,
+        limit=20,
+        uid='u1',
+    )
+
+    # The malformed record is skipped; the valid app still comes through (no 500).
+    assert len(result['data']) == 1

--- a/backend/tests/unit/test_apps_search_poison_guard.py
+++ b/backend/tests/unit/test_apps_search_poison_guard.py
@@ -51,3 +51,29 @@ def test_search_apps_skips_malformed_record(monkeypatch):
 
     # The malformed record is skipped; the valid app still comes through (no 500).
     assert len(result['data']) == 1
+
+
+def test_search_apps_skips_record_without_id(monkeypatch):
+    # A record missing 'id' would KeyError in the app_ids list / installs / reviews lookups before
+    # the per-record ValidationError guard — it must be dropped up front, not 500.
+    good = _valid_app_dict('a1')
+    no_id = {'name': 'No Id App', 'category': 'productivity', 'author': 'Someone'}  # no 'id'
+    monkeypatch.setattr(apps_mod, 'search_apps_db', lambda **kw: [dict(no_id), dict(good)])
+    monkeypatch.setattr(apps_mod, 'get_enabled_apps', lambda uid: set())
+    monkeypatch.setattr(apps_mod, 'get_apps_installs_count', lambda ids: {})
+    monkeypatch.setattr(apps_mod, 'get_apps_reviews', lambda ids: {})
+
+    result = apps_mod.search_apps(
+        q=None,
+        category=None,
+        rating=None,
+        capability=None,
+        sort=None,
+        my_apps=None,
+        installed_apps=None,
+        offset=0,
+        limit=20,
+        uid='u1',
+    )
+
+    assert len(result['data']) == 1


### PR DESCRIPTION
## What

`GET /v2/apps/search` (`search_apps`) builds `App(**app_dict)` in a loop over raw Firestore app documents with no per-record guard. `App` has required no-default fields (`id`, `name`, `category`, `author`, `description`, `image`, `capabilities`), so one legacy or malformed app document raised `pydantic.ValidationError` and 500'd the entire search result for the user.

## Change

Wrap the per-record build in `try/except ValidationError`: skip the malformed record and log its id plus the offending field names (never the field values). This matches the recently merged marketplace-listing guard and the other per-record `ValidationError` guards already in this router. Single-file change in `backend/routers/apps.py`.

## Test

New `backend/tests/unit/test_apps_search_poison_guard.py`: a search returning one valid app and one malformed record (missing required fields) returns the valid app and skips the bad one instead of 500ing. Imports the router normally, patches the db helpers with `monkeypatch.setattr`, and calls the handler directly.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8933?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

