### PR TITLE
Return 404 for a malformed calendar meeting instead of 500 on the single-item GET

### DIFF
--- a/backend/routers/calendar_meetings.py
+++ b/backend/routers/calendar_meetings.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from typing import List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ValidationError
 
 import database.calendar_meetings as calendar_db
 from models.calendar_context import CalendarMeetingContext, MeetingParticipant
@@ -92,7 +92,20 @@ def get_calendar_meeting(
     if not meeting:
         raise HTTPException(status_code=404, detail="Meeting not found")
 
-    return CalendarMeetingContext(**meeting)
+    try:
+        return CalendarMeetingContext(**meeting)
+    except ValidationError as exc:
+        # A malformed/legacy stored meeting cannot be rendered; treat it as unavailable
+        # (the list endpoint already skips such records) rather than 500 the request. Log a
+        # safe id plus the exception type only: a ValidationError's str() renders sensitive
+        # field input like the meeting title, participant emails, link, or notes.
+        logger.warning(
+            'Malformed calendar meeting for uid=%s event_id=%s: %s',
+            uid,
+            meeting.get('calendar_event_id'),
+            type(exc).__name__,
+        )
+        raise HTTPException(status_code=404, detail="Meeting not found")
 
 
 @router.get('/v1/calendar/meetings', response_model=List[CalendarMeetingContext], tags=['calendar'])

--- a/backend/tests/unit/test_calendar_meeting_item_guard.py
+++ b/backend/tests/unit/test_calendar_meeting_item_guard.py
@@ -1,0 +1,55 @@
+"""GET /v1/calendar/meetings/{id} must not 500 on a malformed stored meeting.
+
+The single-item endpoint built CalendarMeetingContext(**meeting) unguarded, so a legacy or
+malformed stored meeting 500'd the request. The list endpoint already skips such records; the
+single-item path now treats a malformed meeting as unavailable (404), consistent with the list,
+and logs only a safe id + the exception type (a ValidationError's str() would leak the meeting
+title / participant emails / link / notes).
+
+Test isolation: routers.calendar_meetings imports cleanly, so the test imports it normally,
+patches the import-cheap db helper with monkeypatch.setattr, and calls the handler directly.
+"""
+
+import os
+
+os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
+os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv')
+
+from datetime import datetime, timezone  # noqa: E402
+
+import pytest  # noqa: E402
+from fastapi import HTTPException  # noqa: E402
+
+from routers import calendar_meetings as cm_mod  # noqa: E402
+from models.calendar_context import CalendarMeetingContext  # noqa: E402
+
+
+def _valid_meeting():
+    return {
+        'calendar_event_id': 'e1',
+        'title': 'Standup',
+        'start_time': datetime(2026, 7, 3, 9, 0, tzinfo=timezone.utc),
+        'duration_minutes': 30,
+    }
+
+
+def test_get_meeting_returns_context(monkeypatch):
+    monkeypatch.setattr(cm_mod.calendar_db, 'get_meeting', lambda uid, mid: _valid_meeting())
+    result = cm_mod.get_calendar_meeting(meeting_id='e1', uid='u1')
+    assert isinstance(result, CalendarMeetingContext)
+    assert result.calendar_event_id == 'e1'
+
+
+def test_get_meeting_malformed_returns_404_not_500(monkeypatch):
+    # Missing required fields (title/start_time/duration_minutes) -> 404, not an unhandled 500.
+    monkeypatch.setattr(cm_mod.calendar_db, 'get_meeting', lambda uid, mid: {'calendar_event_id': 'e2'})
+    with pytest.raises(HTTPException) as ei:
+        cm_mod.get_calendar_meeting(meeting_id='e2', uid='u1')
+    assert ei.value.status_code == 404
+
+
+def test_get_meeting_missing_returns_404(monkeypatch):
+    monkeypatch.setattr(cm_mod.calendar_db, 'get_meeting', lambda uid, mid: None)
+    with pytest.raises(HTTPException) as ei:
+        cm_mod.get_calendar_meeting(meeting_id='nope', uid='u1')
+    assert ei.value.status_code == 404


### PR DESCRIPTION
## What

`GET /v1/calendar/meetings/{meeting_id}` built `CalendarMeetingContext(**meeting)` with no guard, so a legacy or malformed stored meeting (missing a required field like `title`, `start_time`, or `duration_minutes`) raised `ValidationError` and 500'd the request. The list endpoint already skips such records, so the two paths behaved inconsistently.

## Change

Wrap the single-item build in `try/except ValidationError`: treat a malformed meeting as unavailable and return 404 (the same response as a missing meeting, and consistent with the list endpoint dropping malformed records) instead of an unhandled 500. Following the logging-security rule established on the list endpoint, log only a safe id and the exception type: a `ValidationError`'s `str()` renders the offending field input, which for a meeting can be sensitive (title, participant emails, link, notes). Single-file change in `backend/routers/calendar_meetings.py`.

## Test

New `backend/tests/unit/test_calendar_meeting_item_guard.py`: a valid meeting returns the context; a malformed meeting returns 404 (not 500); a missing meeting returns 404. Imports the router normally, patches the db helper with `monkeypatch.setattr`, and calls the handler directly.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8934?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

