### PR TITLE
desktop: remove obsolete Neo no-desktop-access upsell (freemium includes desktop)

### DIFF
--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingBarUsageLimiter.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingBarUsageLimiter.swift
@@ -13,11 +13,6 @@ final class FloatingBarUsageLimiter: ObservableObject {
 
     @Published private(set) var hasPaidPlan: Bool = false
 
-    /// True when the user is on Neo (unlimited) without desktop access — Neo is a
-    /// mobile/web plan, so on desktop we surface a banner nudging them to Operator.
-    /// Grandfathered Neo subscribers (desktopGrandfatherUntil set) are excluded.
-    @Published private(set) var neoNeedsDesktopUpgrade: Bool = false
-
     /// Server-reported quota snapshot, plus an optimistic local delta for queries
     /// sent since the last server sync.
     private(set) var serverQuota: APIClient.ChatUsageQuota?
@@ -34,15 +29,6 @@ final class FloatingBarUsageLimiter: ObservableObject {
         do {
             let response = try await APIClient.shared.getUserSubscription()
             applyPlan(plan: response.subscription.plan, status: response.subscription.status)
-            // Neo (unlimited) has no desktop entitlement; show the upgrade banner
-            // unless this subscriber is grandfathered for the current period or is
-            // BYOK-active (BYOK users pay their own LLM/STT bill and the backend
-            // grants them desktop access, so the "upgrade to Operator" nudge would
-            // be wrong for them).
-            neoNeedsDesktopUpgrade =
-                response.subscription.plan == .unlimited
-                && response.desktopGrandfatherUntil == nil
-                && !APIKeyService.isByokActive
         } catch {
             log("FloatingBarUsageLimiter: failed to fetch plan: \(error.localizedDescription)")
         }
@@ -77,7 +63,6 @@ final class FloatingBarUsageLimiter: ObservableObject {
         serverQuota = nil
         optimisticDelta = 0
         hasPaidPlan = false
-        neoNeedsDesktopUpgrade = false
         UserDefaults.standard.removeObject(forKey: Self.cachedPlanKey)
     }
 

--- a/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
@@ -21,7 +21,6 @@ struct DesktopHomeView: View {
   @StateObject private var viewModelContainer = ViewModelContainer()
   @ObservedObject private var authState = AuthState.shared
   @ObservedObject private var apiKeyService = APIKeyService.shared
-  @ObservedObject private var usageLimiter = FloatingBarUsageLimiter.shared
   @ObservedObject private var updatePolicyManager = DesktopUpdatePolicyManager.shared
   @State private var selectedIndex: Int = {
     if OMIApp.launchMode == .rewind { return SidebarNavItem.rewind.rawValue }
@@ -45,8 +44,6 @@ struct DesktopHomeView: View {
   @State private var proactiveMonitoringStartGate = RetryableDelayedStartGate()
   @State private var didScheduleConversationWarmup = false
   @State private var initialFileIndexingBackfill = DelayedFileIndexingBackfillState()
-  // Dismiss state for the Neo "no desktop access" banner (resets each launch).
-  @State private var neoDesktopBannerDismissed = false
 
   // Pre-loaded hero logo to avoid NSImage init crashes during SwiftUI body evaluation
   private static let heroLogoImage: NSImage? = {
@@ -908,24 +905,6 @@ struct DesktopHomeView: View {
       }
       .padding(14)
     }
-    .safeAreaInset(edge: .top, spacing: 0) {
-      if usageLimiter.neoNeedsDesktopUpgrade && !neoDesktopBannerDismissed {
-        NeoDesktopBanner(
-          onUpgrade: {
-            selectedSettingsSection = .planUsage
-            withAnimation(Self.pageNavigationAnimation) {
-              selectedIndex = SidebarNavItem.settings.rawValue
-            }
-          },
-          onDismiss: {
-            withAnimation(Self.pageNavigationAnimation) {
-              neoDesktopBannerDismissed = true
-            }
-          }
-        )
-        .transition(.move(edge: .top).combined(with: .opacity))
-      }
-    }
     .overlay {
       // Goal completion celebration overlay
       GoalCelebrationView()
@@ -1072,54 +1051,6 @@ private struct PageChromeButton: View {
     .onHover { isHovering = $0 }
     .help(title)
     .accessibilityLabel(title)
-  }
-}
-
-/// Dismissible top banner shown when a Neo (unlimited) user opens the desktop app.
-/// Neo is a mobile/web plan with no desktop access; the CTA routes to Settings →
-/// Plan & Usage where the existing Operator upgrade flow lives.
-private struct NeoDesktopBanner: View {
-  var onUpgrade: () -> Void
-  var onDismiss: () -> Void
-
-  var body: some View {
-    HStack(spacing: 12) {
-      Image(systemName: "exclamationmark.triangle.fill")
-        .scaledFont(size: 14, weight: .semibold)
-        .foregroundColor(OmiColors.warning)
-
-      Text("Neo doesn't include desktop access. Upgrade to Operator to use Omi on Mac.")
-        .scaledFont(size: 13, weight: .medium)
-        .foregroundColor(OmiColors.textPrimary)
-        .fixedSize(horizontal: false, vertical: true)
-
-      Spacer(minLength: 12)
-
-      Button(action: onUpgrade) {
-        Text("Upgrade to Operator")
-          .scaledFont(size: 13, weight: .semibold)
-          .foregroundColor(.white)
-          .padding(.horizontal, 14)
-          .padding(.vertical, 7)
-          .background(RoundedRectangle(cornerRadius: 8).fill(OmiColors.purplePrimary))
-      }
-      .buttonStyle(.plain)
-
-      Button(action: onDismiss) {
-        Image(systemName: "xmark")
-          .scaledFont(size: 12, weight: .semibold)
-          .foregroundColor(OmiColors.textSecondary)
-      }
-      .buttonStyle(.plain)
-    }
-    .padding(.horizontal, 18)
-    .padding(.vertical, 10)
-    .frame(maxWidth: .infinity)
-    .background(OmiColors.backgroundSecondary)
-    .overlay(
-      Rectangle().fill(OmiColors.border.opacity(0.4)).frame(height: 1),
-      alignment: .bottom
-    )
   }
 }
 

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+AccountBilling.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+AccountBilling.swift
@@ -171,20 +171,8 @@ extension SettingsContentView {
         }
       }
     } else if let trial = appState.trialMetadata,
-      trial.trialExpired,
-      // Suppress the trial-expired card entirely for grandfathered Neo users.
-      // The backend already returns trial_expired=false for them, but
-      // trialMetadata is polled on a 60s timer; defensive guard so a stale
-      // cached value during/after a backend deploy doesn't briefly stack the
-      // "Trial Ended" card on top of the grandfather notice. The grandfather
-      // notice is rendered separately via neoDesktopGrandfatherCard.
-      userSubscription?.desktopGrandfatherUntil == nil
+      trial.trialExpired
     {
-      // Neo subscribers who aren't grandfathered land on this card too because
-      // Neo doesn't grant desktop access (per #7496). The generic "Trial Ended"
-      // copy is confusing for them — they're on a paid plan, just not one that
-      // includes Mac. Detect that case and switch to plan-specific copy.
-      let isNeoWithoutDesktop = userSubscription?.subscription.plan == .unlimited
       settingsCard(settingId: "planusage.trial-expired") {
         VStack(alignment: .leading, spacing: 14) {
           HStack(spacing: 16) {
@@ -193,75 +181,13 @@ extension SettingsContentView {
               .foregroundColor(OmiColors.warning)
 
             VStack(alignment: .leading, spacing: 4) {
-              Text(isNeoWithoutDesktop ? "Desktop access not included" : "Trial Ended")
+              Text("Trial Ended")
                 .scaledFont(size: 16, weight: .semibold)
                 .foregroundColor(OmiColors.textPrimary)
 
-              Text(
-                isNeoWithoutDesktop
-                  ? "Neo is available on mobile and web. To use Omi on Mac, upgrade to Operator or Architect."
-                  : "Upgrade to keep unlimited access"
-              )
-              .scaledFont(size: 13)
-              .foregroundColor(OmiColors.textSecondary)
-            }
-
-            Spacer()
-          }
-
-          Divider().overlay(OmiColors.backgroundQuaternary)
-
-          Button(action: {
-            selectedPlanIdForCheckout = "operator"
-          }) {
-            Text("View Plans")
-              .scaledFont(size: 13, weight: .semibold)
-              .padding(.horizontal, 16)
-              .padding(.vertical, 8)
-          }
-          .buttonStyle(.borderedProminent)
-          .tint(OmiColors.purplePrimary)
-        }
-      }
-    }
-  }
-
-  // MARK: - Neo desktop grandfather notice
-  //
-  // Surfaced for Neo subscribers whose current billing period started before
-  // the #7496 policy change. They keep desktop access until their period
-  // ends — this card tells them when, so the change doesn't surprise them
-  // at the next renewal. Backend computes the date as
-  // `desktop_grandfather_until` on /v1/users/me/subscription (#7513).
-  @ViewBuilder
-  var neoDesktopGrandfatherCard: some View {
-    if let until = userSubscription?.desktopGrandfatherUntil,
-      userSubscription?.subscription.plan == .unlimited
-    {
-      let endsOn = Date(timeIntervalSince1970: TimeInterval(until))
-      let formatter: DateFormatter = {
-        let f = DateFormatter()
-        f.dateStyle = .long
-        f.timeStyle = .none
-        return f
-      }()
-      settingsCard(settingId: "planusage.neo-grandfather") {
-        VStack(alignment: .leading, spacing: 14) {
-          HStack(spacing: 16) {
-            Image(systemName: "info.circle.fill")
-              .scaledFont(size: 28)
-              .foregroundColor(OmiColors.purplePrimary)
-
-            VStack(alignment: .leading, spacing: 4) {
-              Text("Neo desktop access ends \(formatter.string(from: endsOn))")
-                .scaledFont(size: 16, weight: .semibold)
-                .foregroundColor(OmiColors.textPrimary)
-
-              Text(
-                "Your Neo plan continues to include desktop access through this billing period. After it ends, upgrade to Operator or Architect to keep using Omi on Mac."
-              )
-              .scaledFont(size: 13)
-              .foregroundColor(OmiColors.textSecondary)
+              Text("Upgrade to keep unlimited access")
+                .scaledFont(size: 13)
+                .foregroundColor(OmiColors.textSecondary)
             }
 
             Spacer()
@@ -331,7 +257,6 @@ extension SettingsContentView {
   var planUsageSection: some View {
     VStack(spacing: 20) {
       trialCountdownCard
-      neoDesktopGrandfatherCard
 
       settingsCard(settingId: "planusage.current") {
         VStack(alignment: .leading, spacing: 14) {

--- a/desktop/macos/changelog/unreleased/20260703-remove-neo-desktop-upsell.json
+++ b/desktop/macos/changelog/unreleased/20260703-remove-neo-desktop-upsell.json
@@ -1,0 +1,3 @@
+{
+  "change": "Removed the outdated \"Neo doesn't include desktop access\" banner and upgrade notices — Neo works on desktop with the freemium tier"
+}


### PR DESCRIPTION
## Why
Desktop went freemium (trial paywall off, Neo works on desktop), but the client still showed three stale upsell surfaces claiming Neo has no desktop access. A Neo user on Discord reported the home banner: *"Neo doesn't include desktop access. Upgrade to Operator to use Omi on Mac."* — confusing since the freemium announcement said Neo now works in Desktop.

## What
- Removed the home-screen `NeoDesktopBanner` and the `neoNeedsDesktopUpgrade` flag that drove it (`FloatingBarUsageLimiter`)
- Removed the Settings → Plan & Usage "Desktop access not included" trial-expired variant (falls back to the generic Trial Ended card, which never renders while `TRIAL_PAYWALL_ENABLED` is off)
- Removed the "Neo desktop access ends <date>" grandfather card
- Changelog fragment added

## Verification
- Built and ran named bundle `omi-neo-freemium-sign` against prod; Home and Plan & Usage render correctly with no banner/cards (screenshots verified)
- Clean release build (`swift build -c release --triple arm64-apple-macosx`) passes
- Zero dangling references to removed symbols; independent agent review approved
- Note: tester account is Operator, so the live Neo-plan path wasn't exercised — but the banner code is deleted entirely and cannot render for any plan

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8935?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

