### PR TITLE
feat(desktop): pin Gemini realtime hub voice to Charon

### DIFF
--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubSession.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubSession.swift
@@ -448,6 +448,12 @@ final class RealtimeHubSession: NSObject {
           "generationConfig": [
             "responseModalities": ["AUDIO"], "temperature": 0.3,
             "mediaResolution": "MEDIA_RESOLUTION_HIGH",
+            // Pin the spoken voice — with no speechConfig Gemini picks its own default,
+            // which differs from the OpenAI hub voice (marin) and can change across
+            // model revisions. Charon: deep, calm, "informative" — closest match to marin.
+            "speechConfig": [
+              "voiceConfig": ["prebuiltVoiceConfig": ["voiceName": "Charon"]]
+            ],
           ],
           "systemInstruction": ["parts": [["text": instructions]]],
           "tools": [["functionDeclarations": RealtimeHubTools.geminiFunctionDeclarations]],

--- a/desktop/macos/changelog/unreleased/20260703-gemini-hub-default-voice.json
+++ b/desktop/macos/changelog/unreleased/20260703-gemini-hub-default-voice.json
@@ -1,0 +1,3 @@
+{
+  "change": "Voice answers powered by Gemini now always use the same voice (Charon) instead of a provider default that could vary"
+}


### PR DESCRIPTION
## Why

The Gemini hub session sent no `speechConfig`, so PTT voice replies used whatever default voice Google ships — different from the OpenAI hub voice (marin) and changeable across model revisions. One of the sources of inconsistent PTT voices.

## What

Pin `speechConfig.voiceConfig.prebuiltVoiceConfig.voiceName = "Charon"` in the Gemini branch of `RealtimeHubSession.sendSessionSetup()`. Charon: deep, calm, "informative" — closest match to marin, picked by Nik from generated samples of 7 candidate voices.

## Verification

- Local named bundle `omi-charon-voice` built and run; three live Gemini hub turns via the repo E2E harness (`omi-ctl action hub_test_turn provider=gemini`, ephemeral auth = managed-user path over the v1alpha Constrained endpoint): connected, correct STT transcript, spoken reply ~120KB PCM each, no errors — endpoint accepts the pinned voice.
- `provider=openai` regression turn clean (marin path untouched).
- `agent-logic-harness.sh` passed (36s).
- Voice identity confirmed by direct-WS sampling of the same model+setup (audibly Charon).
- Cross-review (Codex) approved after evidence rework.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8937?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

