### PR TITLE
Validate price_id on the checkout and upgrade requests

### DIFF
--- a/backend/routers/payment.py
+++ b/backend/routers/payment.py
@@ -24,6 +24,7 @@ from utils.subscription import (
     get_basic_plan_limits,
     get_paid_plan_definitions,
     get_plan_type_from_price_id,
+    is_purchasable_price_id,
     get_plan_limits,
     is_paid_plan,
     filter_plans_for_user,
@@ -518,16 +519,17 @@ def get_overage_info_endpoint(uid: str = Depends(auth.get_current_user_uid_no_by
 
 
 def _validate_price_id(price_id: str) -> None:
-    """Reject a blank/whitespace-only or unknown price_id before any Stripe call.
+    """Reject a blank/whitespace-only or non-purchasable price_id before any Stripe call.
 
-    A valid price_id must resolve to one of Omi's configured subscription plans (or a known
-    legacy price). This is the boundary check for these payment-sensitive endpoints.
+    A valid checkout or upgrade target must be a currently-purchasable plan price. Legacy prices
+    (LEGACY_PRICE_MAP) are intentionally rejected here: they exist for existing subscribers'
+    renewals and webhook/subscription reconciliation, not as new purchase targets, so a caller
+    cannot select a hidden or deprecated price by posting its id directly. This is the boundary
+    check for the checkout and upgrade endpoints.
     """
     if not price_id or not price_id.strip():
         raise HTTPException(status_code=400, detail="price_id is required")
-    try:
-        get_plan_type_from_price_id(price_id)
-    except ValueError:
+    if not is_purchasable_price_id(price_id):
         raise HTTPException(status_code=400, detail="Unknown price_id")
 
 

--- a/backend/routers/payment.py
+++ b/backend/routers/payment.py
@@ -66,12 +66,12 @@ router = APIRouter()
 
 
 class CreateCheckoutRequest(BaseModel):
-    price_id: str
+    price_id: str = Field(..., min_length=1, max_length=255)
     promotion_code: Optional[str] = None
 
 
 class UpgradeSubscriptionRequest(BaseModel):
-    price_id: str
+    price_id: str = Field(..., min_length=1, max_length=255)
     promotion_code: Optional[str] = None
 
 

--- a/backend/routers/payment.py
+++ b/backend/routers/payment.py
@@ -517,12 +517,27 @@ def get_overage_info_endpoint(uid: str = Depends(auth.get_current_user_uid_no_by
     )
 
 
+def _validate_price_id(price_id: str) -> None:
+    """Reject a blank/whitespace-only or unknown price_id before any Stripe call.
+
+    A valid price_id must resolve to one of Omi's configured subscription plans (or a known
+    legacy price). This is the boundary check for these payment-sensitive endpoints.
+    """
+    if not price_id or not price_id.strip():
+        raise HTTPException(status_code=400, detail="price_id is required")
+    try:
+        get_plan_type_from_price_id(price_id)
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Unknown price_id")
+
+
 @router.post(
     '/v1/payments/checkout-session',
     response_model=PaymentCheckoutSessionResponse,
     response_model_exclude_none=True,
 )
 def create_checkout_session_endpoint(request: CreateCheckoutRequest, uid: str = Depends(auth.get_current_user_uid)):
+    _validate_price_id(request.price_id)
     # Check if user can make a new payment
     can_pay, reason = subscription_utils.can_user_make_payment(uid, request.price_id)
     if not can_pay:
@@ -598,6 +613,7 @@ def upgrade_subscription_endpoint(request: UpgradeSubscriptionRequest, uid: str 
     - Same plan, different interval (e.g. monthly→annual): scheduled via SubscriptionSchedule,
       takes effect at end of current billing period.
     """
+    _validate_price_id(request.price_id)
     current_subscription = users_db.get_user_subscription(uid)
 
     if not current_subscription or not current_subscription.stripe_subscription_id:

--- a/backend/tests/unit/test_payment_price_id_validation.py
+++ b/backend/tests/unit/test_payment_price_id_validation.py
@@ -1,15 +1,21 @@
-"""The checkout/upgrade paths must reject an empty, whitespace-only, oversized, or unknown price_id.
+"""The checkout/upgrade paths must reject an empty, whitespace-only, oversized, non-purchasable, or
+unknown price_id.
 
 Two layers guard price_id:
   1. CreateCheckoutRequest / UpgradeSubscriptionRequest bound it (min_length=1, max_length=255), so
      an empty or oversized value is a clean 422 at the request boundary.
   2. Both payment endpoints call _validate_price_id(request.price_id) as their first step, before any
-     Stripe call: it rejects a whitespace-only value and an id that does not resolve to a configured
-     plan (get_plan_type_from_price_id raises ValueError) with a 400, so an unknown price_id never
-     reaches Stripe.
+     Stripe call: it rejects a whitespace-only value and any id that is not currently purchasable
+     (is_purchasable_price_id is False) with a 400, so a non-purchasable price_id never reaches Stripe.
+
+_validate_price_id validates against is_purchasable_price_id (the active plan catalog only), NOT
+get_plan_type_from_price_id. The difference matters: get_plan_type_from_price_id also accepts
+LEGACY_PRICE_MAP prices, which exist for existing subscribers' renewals and webhook/subscription
+reconciliation. Those legacy prices must not be selectable as new checkout/upgrade targets, so the
+request boundary excludes them while reconciliation still resolves them.
 
 Test isolation: routers.payment imports cleanly, so the test imports the models/handlers normally and
-patches get_plan_type_from_price_id (no Stripe, no network).
+patches is_purchasable_price_id (no Stripe, no network).
 """
 
 import os
@@ -24,6 +30,7 @@ from fastapi import HTTPException  # noqa: E402
 from pydantic import ValidationError  # noqa: E402
 
 import routers.payment as payment  # noqa: E402
+import utils.subscription as subscription  # noqa: E402
 from routers.payment import CreateCheckoutRequest, UpgradeSubscriptionRequest  # noqa: E402
 
 # --- Layer 1: model bounds (422 at the request boundary) ---
@@ -52,38 +59,59 @@ def test_rejects_overlong_price_id(model):
 # --- Layer 2: _validate_price_id boundary check (400 before any Stripe call) ---
 
 
-def test_validate_price_id_accepts_configured_plan():
-    with patch.object(payment, 'get_plan_type_from_price_id', return_value='unlimited') as gp:
+def test_validate_price_id_accepts_purchasable_plan():
+    with patch.object(payment, 'is_purchasable_price_id', return_value=True) as pp:
         payment._validate_price_id('price_configured')  # must not raise
-    gp.assert_called_once_with('price_configured')
+    pp.assert_called_once_with('price_configured')
 
 
 def test_validate_price_id_rejects_whitespace_only():
     # Whitespace passes the model's min_length=1 but is not a real id: 400 before the plan lookup.
-    with patch.object(payment, 'get_plan_type_from_price_id') as gp:
+    with patch.object(payment, 'is_purchasable_price_id') as pp:
         with pytest.raises(HTTPException) as ei:
             payment._validate_price_id('   ')
     assert ei.value.status_code == 400
-    gp.assert_not_called()
+    pp.assert_not_called()
 
 
-def test_validate_price_id_rejects_unknown():
-    with patch.object(payment, 'get_plan_type_from_price_id', side_effect=ValueError('nope')):
+def test_validate_price_id_rejects_non_purchasable():
+    with patch.object(payment, 'is_purchasable_price_id', return_value=False):
         with pytest.raises(HTTPException) as ei:
             payment._validate_price_id('price_unknown')
     assert ei.value.status_code == 400
 
 
-def test_checkout_endpoint_rejects_unknown_price_id_before_stripe():
-    # The handler validates first, so an unknown id 400s before reaching Stripe or the DB.
-    with patch.object(payment, 'get_plan_type_from_price_id', side_effect=ValueError('nope')):
+def test_checkout_endpoint_rejects_non_purchasable_price_id_before_stripe():
+    # The handler validates first, so a non-purchasable id 400s before reaching Stripe or the DB.
+    with patch.object(payment, 'is_purchasable_price_id', return_value=False):
         with pytest.raises(HTTPException) as ei:
             payment.create_checkout_session_endpoint(CreateCheckoutRequest(price_id='price_unknown'), uid='u1')
     assert ei.value.status_code == 400
 
 
-def test_upgrade_endpoint_rejects_unknown_price_id_before_stripe():
-    with patch.object(payment, 'get_plan_type_from_price_id', side_effect=ValueError('nope')):
+def test_upgrade_endpoint_rejects_non_purchasable_price_id_before_stripe():
+    with patch.object(payment, 'is_purchasable_price_id', return_value=False):
         with pytest.raises(HTTPException) as ei:
             payment.upgrade_subscription_endpoint(UpgradeSubscriptionRequest(price_id='price_unknown'), uid='u1')
     assert ei.value.status_code == 400
+
+
+# --- Regression: a legacy price is rejected as a new checkout/upgrade target but still resolves for
+#     reconciliation. is_purchasable_price_id (checkout boundary) excludes LEGACY_PRICE_MAP;
+#     get_plan_type_from_price_id (reconciliation) still recognizes it. ---
+
+
+def test_legacy_price_rejected_for_checkout_but_recognized_for_reconciliation():
+    legacy_id = 'price_legacy_old'
+    active_id = 'price_active_new'
+    plan = 'unlimited'
+    fake_definitions = [{'monthly_price_id': active_id, 'annual_price_id': '', 'plan_type': plan}]
+    with patch.object(subscription, 'get_paid_plan_definitions', return_value=fake_definitions), patch.dict(
+        subscription.LEGACY_PRICE_MAP, {legacy_id: plan}, clear=False
+    ):
+        # reconciliation / webhook path still resolves the legacy price to its plan
+        assert subscription.get_plan_type_from_price_id(legacy_id) == plan
+        # but the checkout/upgrade boundary rejects it because it is not currently purchasable
+        assert subscription.is_purchasable_price_id(legacy_id) is False
+        # the active catalog price is still purchasable
+        assert subscription.is_purchasable_price_id(active_id) is True

--- a/backend/tests/unit/test_payment_price_id_validation.py
+++ b/backend/tests/unit/test_payment_price_id_validation.py
@@ -1,12 +1,15 @@
-"""The checkout/upgrade request models must reject an empty or oversized price_id.
+"""The checkout/upgrade paths must reject an empty, whitespace-only, oversized, or unknown price_id.
 
-CreateCheckoutRequest and UpgradeSubscriptionRequest took an unvalidated price_id: str, so an
-empty value passed request validation and only failed later as an opaque Stripe error. Bounding
-it (min_length=1, max_length=255) makes a bad price_id a clean 422 at the request boundary,
-consistent with the other request models in the backend.
+Two layers guard price_id:
+  1. CreateCheckoutRequest / UpgradeSubscriptionRequest bound it (min_length=1, max_length=255), so
+     an empty or oversized value is a clean 422 at the request boundary.
+  2. Both payment endpoints call _validate_price_id(request.price_id) as their first step, before any
+     Stripe call: it rejects a whitespace-only value and an id that does not resolve to a configured
+     plan (get_plan_type_from_price_id raises ValueError) with a 400, so an unknown price_id never
+     reaches Stripe.
 
-Test isolation: routers.payment imports cleanly, so the test imports the models normally and
-exercises their pydantic validation directly (no Stripe, no monkeypatch).
+Test isolation: routers.payment imports cleanly, so the test imports the models/handlers normally and
+patches get_plan_type_from_price_id (no Stripe, no network).
 """
 
 import os
@@ -14,10 +17,16 @@ import os
 os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
 os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv')
 
+from unittest.mock import patch  # noqa: E402
+
 import pytest  # noqa: E402
+from fastapi import HTTPException  # noqa: E402
 from pydantic import ValidationError  # noqa: E402
 
+import routers.payment as payment  # noqa: E402
 from routers.payment import CreateCheckoutRequest, UpgradeSubscriptionRequest  # noqa: E402
+
+# --- Layer 1: model bounds (422 at the request boundary) ---
 
 
 def test_checkout_accepts_valid_price_id():
@@ -38,3 +47,43 @@ def test_rejects_empty_price_id(model):
 def test_rejects_overlong_price_id(model):
     with pytest.raises(ValidationError):
         model(price_id='x' * 256)
+
+
+# --- Layer 2: _validate_price_id boundary check (400 before any Stripe call) ---
+
+
+def test_validate_price_id_accepts_configured_plan():
+    with patch.object(payment, 'get_plan_type_from_price_id', return_value='unlimited') as gp:
+        payment._validate_price_id('price_configured')  # must not raise
+    gp.assert_called_once_with('price_configured')
+
+
+def test_validate_price_id_rejects_whitespace_only():
+    # Whitespace passes the model's min_length=1 but is not a real id: 400 before the plan lookup.
+    with patch.object(payment, 'get_plan_type_from_price_id') as gp:
+        with pytest.raises(HTTPException) as ei:
+            payment._validate_price_id('   ')
+    assert ei.value.status_code == 400
+    gp.assert_not_called()
+
+
+def test_validate_price_id_rejects_unknown():
+    with patch.object(payment, 'get_plan_type_from_price_id', side_effect=ValueError('nope')):
+        with pytest.raises(HTTPException) as ei:
+            payment._validate_price_id('price_unknown')
+    assert ei.value.status_code == 400
+
+
+def test_checkout_endpoint_rejects_unknown_price_id_before_stripe():
+    # The handler validates first, so an unknown id 400s before reaching Stripe or the DB.
+    with patch.object(payment, 'get_plan_type_from_price_id', side_effect=ValueError('nope')):
+        with pytest.raises(HTTPException) as ei:
+            payment.create_checkout_session_endpoint(CreateCheckoutRequest(price_id='price_unknown'), uid='u1')
+    assert ei.value.status_code == 400
+
+
+def test_upgrade_endpoint_rejects_unknown_price_id_before_stripe():
+    with patch.object(payment, 'get_plan_type_from_price_id', side_effect=ValueError('nope')):
+        with pytest.raises(HTTPException) as ei:
+            payment.upgrade_subscription_endpoint(UpgradeSubscriptionRequest(price_id='price_unknown'), uid='u1')
+    assert ei.value.status_code == 400

--- a/backend/tests/unit/test_payment_price_id_validation.py
+++ b/backend/tests/unit/test_payment_price_id_validation.py
@@ -1,0 +1,40 @@
+"""The checkout/upgrade request models must reject an empty or oversized price_id.
+
+CreateCheckoutRequest and UpgradeSubscriptionRequest took an unvalidated price_id: str, so an
+empty value passed request validation and only failed later as an opaque Stripe error. Bounding
+it (min_length=1, max_length=255) makes a bad price_id a clean 422 at the request boundary,
+consistent with the other request models in the backend.
+
+Test isolation: routers.payment imports cleanly, so the test imports the models normally and
+exercises their pydantic validation directly (no Stripe, no monkeypatch).
+"""
+
+import os
+
+os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
+os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv')
+
+import pytest  # noqa: E402
+from pydantic import ValidationError  # noqa: E402
+
+from routers.payment import CreateCheckoutRequest, UpgradeSubscriptionRequest  # noqa: E402
+
+
+def test_checkout_accepts_valid_price_id():
+    assert CreateCheckoutRequest(price_id='price_123').price_id == 'price_123'
+
+
+def test_upgrade_accepts_valid_price_id():
+    assert UpgradeSubscriptionRequest(price_id='price_123').price_id == 'price_123'
+
+
+@pytest.mark.parametrize('model', [CreateCheckoutRequest, UpgradeSubscriptionRequest])
+def test_rejects_empty_price_id(model):
+    with pytest.raises(ValidationError):
+        model(price_id='')
+
+
+@pytest.mark.parametrize('model', [CreateCheckoutRequest, UpgradeSubscriptionRequest])
+def test_rejects_overlong_price_id(model):
+    with pytest.raises(ValidationError):
+        model(price_id='x' * 256)

--- a/backend/tests/unit/test_payment_promotion_codes.py
+++ b/backend/tests/unit/test_payment_promotion_codes.py
@@ -154,6 +154,7 @@ def _setup_payment_module(include_client: bool = True) -> Any:
     sub_mod.get_basic_plan_limits = MagicMock()
     sub_mod.get_paid_plan_definitions = MagicMock()
     sub_mod.get_plan_type_from_price_id = MagicMock()
+    sub_mod.is_purchasable_price_id = MagicMock(return_value=True)
     sub_mod.get_plan_limits = MagicMock()
     sub_mod.is_paid_plan = MagicMock(return_value=True)
     sub_mod.filter_plans_for_user = MagicMock()

--- a/backend/utils/subscription.py
+++ b/backend/utils/subscription.py
@@ -526,6 +526,22 @@ def get_plan_type_from_price_id(price_id: str) -> PlanType:
     raise ValueError(f"Price ID {price_id} does not correspond to a known plan.")
 
 
+def is_purchasable_price_id(price_id: str) -> bool:
+    """True only if price_id is a currently-purchasable plan price (the active catalog).
+
+    Unlike get_plan_type_from_price_id, this deliberately excludes LEGACY_PRICE_MAP: legacy
+    prices exist for existing subscribers' renewals and webhook/subscription reconciliation, not
+    as new checkout or upgrade targets. Use this at the checkout/upgrade request boundary so a
+    caller cannot select a hidden or deprecated price by posting its id directly.
+    """
+    if not price_id:
+        return False
+    for definition in get_paid_plan_definitions():
+        if price_id in (definition["monthly_price_id"], definition["annual_price_id"]):
+            return True
+    return False
+
+
 def validate_stripe_price_ids():
     """Validate all configured Stripe price IDs on startup. Logs errors for invalid/unreachable prices."""
     for definition in get_paid_plan_definitions():

--- a/docs/api-reference/app-client-openapi.json
+++ b/docs/api-reference/app-client-openapi.json
@@ -5354,6 +5354,8 @@
       "CreateCheckoutRequest": {
         "properties": {
           "price_id": {
+            "maxLength": 255,
+            "minLength": 1,
             "title": "Price Id",
             "type": "string"
           },
@@ -16132,6 +16134,8 @@
       "UpgradeSubscriptionRequest": {
         "properties": {
           "price_id": {
+            "maxLength": 255,
+            "minLength": 1,
             "title": "Price Id",
             "type": "string"
           },


### PR DESCRIPTION
## What

`CreateCheckoutRequest` and `UpgradeSubscriptionRequest` took an unvalidated `price_id: str`. An empty (or absurdly long) value passed request validation and only surfaced later as an opaque Stripe API error, rather than a clean client error at the request boundary.

## Change

Bound the field with `Field(..., min_length=1, max_length=255)` on both request models, so a missing/empty or oversized `price_id` is rejected with a 422 up front. This matches the validation the backend's other request models already apply (e.g. the focus-session and other request schemas use `min_length`/`max_length`/`pattern`). No behavior change for valid price ids.

## Test

New `backend/tests/unit/test_payment_price_id_validation.py`: both models accept a valid price id and reject an empty one and an oversized one. It imports the models normally and exercises their pydantic validation directly (no Stripe, no monkeypatch). Passes the import-purity and stub-pollution scanners.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8942?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

