### PR TITLE
Add GET /v1/screen-activity/ids to list a user's screen-activity IDs

### DIFF
--- a/backend/routers/focus_sessions.py
+++ b/backend/routers/focus_sessions.py
@@ -4,6 +4,7 @@ from fastapi import APIRouter, Depends, Query
 from pydantic import BaseModel, Field
 
 import database.focus_sessions as focus_sessions_db
+import database.screen_activity as screen_activity_db
 from utils.other import endpoints as auth
 from utils.request_validation import validate_calendar_date
 
@@ -70,3 +71,13 @@ def get_focus_stats(
 ):
     date = validate_calendar_date(date)
     return focus_sessions_db.get_focus_stats(uid, date=date)
+
+
+@router.get('/v1/screen-activity/ids', tags=['screen-activity'])
+def list_screen_activity_ids(uid: str = Depends(auth.get_current_user_uid)):
+    """Return all of the user's screen-activity document IDs (IDs only, no field reads).
+
+    A lightweight way for a client to reconcile which captured rows exist (for sync or bulk
+    operations) without paging the full activity list.
+    """
+    return {'ids': screen_activity_db.get_screen_activity_ids(uid)}

--- a/backend/tests/unit/test_screen_activity_ids_endpoint.py
+++ b/backend/tests/unit/test_screen_activity_ids_endpoint.py
@@ -1,0 +1,38 @@
+"""GET /v1/screen-activity/ids returns the user's screen-activity document IDs.
+
+The full list endpoint returns every field for every captured row; there was no cheap way to
+fetch just the set of IDs for sync/reconciliation. This reuses the IDs-only
+get_screen_activity_ids helper.
+
+Test isolation: routers.focus_sessions imports cleanly, so the test imports it normally, patches
+the import-cheap db helper with monkeypatch.setattr, and calls the handler directly.
+"""
+
+import os
+
+os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
+os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv')
+
+from routers import focus_sessions as fs_mod  # noqa: E402
+
+
+def test_ids_returns_wrapped_list(monkeypatch):
+    monkeypatch.setattr(fs_mod.screen_activity_db, 'get_screen_activity_ids', lambda uid: ['s1', 's2', 's3'])
+    assert fs_mod.list_screen_activity_ids(uid='u1') == {'ids': ['s1', 's2', 's3']}
+
+
+def test_ids_empty(monkeypatch):
+    monkeypatch.setattr(fs_mod.screen_activity_db, 'get_screen_activity_ids', lambda uid: [])
+    assert fs_mod.list_screen_activity_ids(uid='u1') == {'ids': []}
+
+
+def test_ids_scopes_to_caller(monkeypatch):
+    seen = {}
+
+    def fake(uid):
+        seen['uid'] = uid
+        return []
+
+    monkeypatch.setattr(fs_mod.screen_activity_db, 'get_screen_activity_ids', fake)
+    fs_mod.list_screen_activity_ids(uid='user-7')
+    assert seen['uid'] == 'user-7'


### PR DESCRIPTION
## What

`GET /v1/screen-activity` returns every field for every captured row, so a client that only needs to know which rows exist (for sync or bulk operations like reconciling against a local cache) has to page the whole list. The `get_screen_activity_ids(uid)` database helper does an IDs-only Firestore projection (`.select([]).stream()`, no field reads), but nothing exposed it (it is used only internally, e.g. for account-deletion cleanup).

## Change

Add `GET /v1/screen-activity/ids`, authenticated as the current user, returning `{ "ids": [...] }`. Single new endpoint in `backend/routers/focus_sessions.py` (the same clean host as the other screen-activity read endpoints), reusing the existing helper. No change to the database layer.

## Test

New `backend/tests/unit/test_screen_activity_ids_endpoint.py`: returns the ids wrapped, returns an empty list, and scopes the lookup to the caller's uid. Imports the router normally, patches the db helper with `monkeypatch.setattr`, and calls the handler directly. Passes the import-purity and stub-pollution scanners.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8944?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

