### PR TITLE
Bound TtsSynthesizeRequest.text length at the schema boundary

### DIFF
--- a/backend/models/tts.py
+++ b/backend/models/tts.py
@@ -23,7 +23,9 @@ class TtsSynthesizeRequest(BaseModel):
     # `model_id` collides with pydantic's `model_` protected namespace; disable.
     model_config = ConfigDict(protected_namespaces=())
 
-    text: str = Field(..., min_length=1)
+    # Upper bound mirrors _TTS_REQUEST_CHAR_LIMIT in routers/tts.py (and the Rust backend), so an
+    # oversized request is rejected at the schema/contract boundary rather than only at runtime.
+    text: str = Field(..., min_length=1, max_length=5000)
     voice_id: str = DEFAULT_VOICE_ID
     model_id: str = DEFAULT_MODEL_ID
     output_format: str = DEFAULT_OUTPUT_FORMAT

--- a/backend/tests/unit/test_tts_request_text_bound.py
+++ b/backend/tests/unit/test_tts_request_text_bound.py
@@ -1,0 +1,35 @@
+"""TtsSynthesizeRequest must bound the text length at the schema boundary.
+
+The TTS proxy enforces a 5000-character limit at runtime (_TTS_REQUEST_CHAR_LIMIT), but the
+shared request model only required min_length=1, so the schema/contract the mobile and desktop
+clients rely on did not express the upper bound and an oversized payload was fully parsed before
+the runtime check. Bounding text with max_length=5000 rejects it at request validation (422).
+
+Test isolation: models.tts is pure pydantic and imports cleanly, so the test exercises the
+model's validation directly (no router, no monkeypatch).
+"""
+
+import os
+
+os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
+os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv')
+
+import pytest  # noqa: E402
+from pydantic import ValidationError  # noqa: E402
+
+from models.tts import TtsSynthesizeRequest  # noqa: E402
+
+
+def test_accepts_text_at_the_limit():
+    req = TtsSynthesizeRequest(text='x' * 5000)
+    assert len(req.text) == 5000
+
+
+def test_rejects_empty_text():
+    with pytest.raises(ValidationError):
+        TtsSynthesizeRequest(text='')
+
+
+def test_rejects_text_over_the_limit():
+    with pytest.raises(ValidationError):
+        TtsSynthesizeRequest(text='x' * 5001)


### PR DESCRIPTION
## What

The TTS proxy (`POST /v2/tts/synthesize`) enforces a 5000-character request limit at runtime via `_TTS_REQUEST_CHAR_LIMIT`, but the shared request model `TtsSynthesizeRequest` only declared `text: str = Field(min_length=1)` with no upper bound. The model's docstring states it "mirrors the request shape of `tts.rs` so the mobile and desktop clients can share contract expectations," yet the schema did not express the size limit, and an oversized payload was fully parsed into the model before the runtime check rejected it.

## Change

Bound the field with `max_length=5000` (mirroring `_TTS_REQUEST_CHAR_LIMIT`), so an oversized request is rejected at request validation (422) rather than only at runtime, and the shared contract schema now expresses the limit. Single-field change in `backend/models/tts.py`; no behavior change for valid requests.

## Test

New `backend/tests/unit/test_tts_request_text_bound.py`: accepts text at the 5000 limit, rejects empty text, and rejects text over the limit. `models.tts` is pure pydantic, so the test exercises the model's validation directly (no router, no monkeypatch). Passes the import-purity and stub-pollution scanners.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8945?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

