### PR TITLE
Add desktop Swift pre-push guard

### DIFF
--- a/desktop/macos/Desktop/Sources/MainWindow/Components/ChatMessagesView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Components/ChatMessagesView.swift
@@ -485,7 +485,7 @@ struct ChatMessagesView<WelcomeContent: View>: View {
                 userScrollEndWorkItem = endWork
                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.3, execute: endWork)
             } onScrollSettledAtBottom: {
-                guard scrollMode == .freeScrolling || scrollMode == .anchoringTurn else { return }
+                guard scrollMode == .freeScrolling else { return }
                 cancelAllPendingScrolls()
                 userIsScrolling = false
                 scrollMode = .followingBottom

--- a/desktop/macos/changelog/unreleased/issue-8946-desktop-chat-build.json
+++ b/desktop/macos/changelog/unreleased/issue-8946-desktop-chat-build.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed a desktop chat build failure."
+}

--- a/scripts/pre-push
+++ b/scripts/pre-push
@@ -426,6 +426,34 @@ check_workflows_if_needed() {
   "${actionlint_cmd[@]}" -shellcheck "" "${workflow_files[@]}"
 }
 
+check_desktop_swift_if_needed() {
+  if [ "${PRE_PUSH_SKIP_DESKTOP_SWIFT:-}" = "1" ]; then
+    echo "Skipping desktop Swift compile because PRE_PUSH_SKIP_DESKTOP_SWIFT=1."
+    return
+  fi
+
+  if ! changed_matches \
+    'desktop/macos/Desktop/*.swift' \
+    'desktop/macos/Desktop/**/*.swift' \
+    'desktop/macos/Desktop/Package.swift' \
+    'desktop/macos/Desktop/Package.resolved' \
+    'scripts/pre-push'
+  then
+    return
+  fi
+
+  if ! command -v xcrun >/dev/null 2>&1; then
+    echo "FAIL: xcrun is required to compile the desktop Swift package for changed desktop files." >&2
+    echo "Push from macOS with Xcode command line tools installed, or deliberately skip with PRE_PUSH_SKIP_DESKTOP_SWIFT=1 git push." >&2
+    return 1
+  fi
+
+  (
+    cd desktop/macos
+    xcrun swift build -c debug --package-path Desktop
+  )
+}
+
 check_desktop_rust_if_needed() {
   local -a rust_files=()
   local file
@@ -513,6 +541,7 @@ run_step check_import_time_side_effects_if_needed
 run_step check_backend_unit_tests_if_needed
 run_step check_openapi_contract_if_needed
 run_step check_workflows_if_needed
+run_step check_desktop_swift_if_needed
 run_step check_desktop_rust_if_needed
 run_step check_desktop_launcher_tests_if_needed
 run_step check_desktop_tool_surfaces_if_needed


### PR DESCRIPTION
## Summary
- Add a pre-push desktop Swift compile guard for desktop Swift/package changes and scripts/pre-push.
- Add PRE_PUSH_SKIP_DESKTOP_SWIFT=1 as an explicit escape hatch.
- Fix the stale ChatScrollMode.anchoringTurn reference that the guard catches.
- Add an unreleased desktop changelog fragment.

Fixes #8946

## Verification
- cd desktop/macos && xcrun swift build -c debug --package-path Desktop
- PRE_PUSH_SKIP_OPENAPI_CONTRACT=1 ./scripts/pre-push
- PRE_PUSH_SKIP_OPENAPI_CONTRACT=1 git push -u origin codex/pre-push-desktop-swift-guard

Note: full ./scripts/pre-push without skips reached the existing OpenAPI check and failed locally because fastapi is not installed in this shell. The OpenAPI check is unrelated to this desktop-only change.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8949?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

