### PR TITLE
Windows: memory provenance / audit surface (what Omi knows, where it learned it, selective forget)

### DIFF
--- a/desktop/windows/src/renderer/src/App.shell.test.ts
+++ b/desktop/windows/src/renderer/src/App.shell.test.ts
@@ -1,0 +1,60 @@
+// Full-shell module-eval smoke. Guards the "blank renderer" class: any throw
+// while evaluating the real App module graph (circular-import TDZ error,
+// rejected top-level await, module-scope throw such as a service init like
+// Firebase) aborts the whole renderer bundle and the window renders BLACK with
+// no UI error surface. Component-level tests never catch this because they
+// import leaf modules, not the shell. This test evaluates the exact graph
+// main.tsx bootstraps (App + its static imports, which include every page via
+// MainViews), so it goes red on any module-eval regression.
+//
+// Scope note (verified empirically): importing a NON-EXISTENT NAMED EXPORT is
+// a browser-ESM SyntaxError that also blanks the renderer, but Vitest's SSR
+// transform degrades it to `undefined`, so THIS test cannot see it. That class
+// is caught by `npm run typecheck:web` (tsc errors on missing exports). The
+// blank-renderer gate is therefore typecheck + this smoke together.
+//
+// 2026-07-02 incident: the app booted to a fully black window. Root cause was
+// an uncaught module-scope FirebaseError (auth/invalid-api-key) from
+// lib/firebase.ts when .env was absent (VITE_FIREBASE_API_KEY undefined).
+// This exact failure reproduces here when the env fallback below is removed
+// and no .env exists (red-proven during the incident fix).
+import { describe, expect, it, vi } from 'vitest'
+
+// Fallback Firebase env so the shell graph is evaluable on machines/CI without
+// a local .env (the app itself still needs a real .env; see .env.example).
+// Values are only presence-checked at init; no network call happens in tests.
+// Real .env values, when present, take precedence and are left untouched.
+if (!import.meta.env.VITE_FIREBASE_API_KEY) {
+  vi.stubEnv('VITE_FIREBASE_API_KEY', 'test-shell-smoke-api-key')
+  vi.stubEnv('VITE_FIREBASE_AUTH_DOMAIN', 'test.firebaseapp.com')
+  vi.stubEnv('VITE_FIREBASE_PROJECT_ID', 'test-project')
+}
+
+// Minimal stand-ins for browser globals the renderer genuinely has at runtime
+// (this suite runs in the node environment; jsdom is not a dependency of this
+// repo). Only add globals the real renderer provides -- never stub the preload
+// bridge objects themselves beyond existence, so accidental module-scope CALLS
+// into preload APIs still surface as failures.
+function memoryStorage(): Storage {
+  const map = new Map<string, string>()
+  return {
+    get length() {
+      return map.size
+    },
+    clear: () => map.clear(),
+    getItem: (k: string) => map.get(k) ?? null,
+    key: (i: number) => [...map.keys()][i] ?? null,
+    removeItem: (k: string) => void map.delete(k),
+    setItem: (k: string, v: string) => void map.set(k, String(v))
+  }
+}
+vi.stubGlobal('localStorage', memoryStorage())
+vi.stubGlobal('sessionStorage', memoryStorage())
+
+describe('renderer shell', () => {
+  it('evaluates the full App module graph without throwing', async () => {
+    // Dynamic import so the env fallback above is applied first.
+    const mod = await import('./App')
+    expect(typeof mod.default).toBe('function')
+  })
+})

--- a/desktop/windows/src/renderer/src/components/memories/ForgetPanels.tsx
+++ b/desktop/windows/src/renderer/src/components/memories/ForgetPanels.tsx
@@ -1,0 +1,148 @@
+// Selective-forget panels: the consequence preview shown before any delete
+// happens (replaces window.confirm) and the honest progress panel shown while
+// the existing paced delete runs.
+import { Clock, Loader2, Trash2 } from 'lucide-react'
+import type { Memory } from '../../hooks/useMemories'
+import {
+  SOURCE_LABELS,
+  categoryLabel,
+  describeFilters,
+  estimateForgetSeconds,
+  forgetPreview,
+  formatDuration,
+  type MemoryFilters
+} from '../../lib/memoryProvenance'
+
+const MAX_BAR_ROWS = 4
+
+function BarRows(props: { rows: { label: string; count: number }[] }): React.JSX.Element {
+  const rows = props.rows.slice(0, MAX_BAR_ROWS)
+  const max = rows[0]?.count ?? 1
+  return (
+    <div className="space-y-1.5">
+      {rows.map(({ label, count }) => (
+        <div key={label} className="flex items-center gap-2 text-xs">
+          <span className="w-24 shrink-0 truncate text-white/60">{label}</span>
+          <span className="h-1 flex-1 overflow-hidden rounded-full bg-white/10">
+            <span
+              className="block h-full rounded-full bg-white/45"
+              style={{ width: `${Math.max(4, Math.round((count / max) * 100))}%` }}
+            />
+          </span>
+          <span className="w-8 shrink-0 text-right text-white/40">{count}</span>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+// Consequence preview: exact count, where the selected memories came from and
+// what they are about, the plain-language outcome, and the honest pacing
+// estimate — all before anything is deleted.
+export function ForgetPreviewPanel(props: {
+  selected: Memory[]
+  filters: MemoryFilters
+  onCancel: () => void
+  onConfirm: () => void
+}): React.JSX.Element {
+  const { selected, filters, onCancel, onConfirm } = props
+  const preview = forgetPreview(selected)
+  const scope = describeFilters(filters)
+  const eta = formatDuration(estimateForgetSeconds(preview.count))
+
+  return (
+    <div className="surface-card mx-auto mb-5 max-w-4xl animate-fade-in p-5">
+      <div className="font-display text-lg font-bold text-white">
+        Forget {preview.count} memor{preview.count === 1 ? 'y' : 'ies'}?{' '}
+        {scope && <span className="font-body text-sm font-normal text-white/50">{scope}</span>}
+      </div>
+      <div className="mt-4 grid grid-cols-1 gap-5 sm:grid-cols-2">
+        <div>
+          <div className="section-label mb-2">Where they came from</div>
+          <BarRows
+            rows={preview.bySource.map(({ kind, count }) => ({
+              label: SOURCE_LABELS[kind],
+              count
+            }))}
+          />
+        </div>
+        <div>
+          <div className="section-label mb-2">What they are about</div>
+          <BarRows
+            rows={preview.byCategory.map(({ category, count }) => ({
+              label: categoryLabel(category),
+              count
+            }))}
+          />
+        </div>
+      </div>
+      <p className="mt-4 text-sm leading-relaxed text-white/70">
+        {preview.count === 1 ? 'This memory' : `These ${preview.count} memories`} will be
+        permanently removed from your account and from everything Omi says from now on. The
+        recordings and conversations they came from are not touched. This cannot be undone.
+      </p>
+      <p className="mt-2 flex items-start gap-2 text-xs leading-relaxed text-white/45">
+        <Clock className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+        The server allows about 60 deletions per hour, so this will take {eta}. You can stop
+        anytime and resume later; memories already forgotten stay forgotten.
+      </p>
+      <div className="mt-4 flex items-center justify-end gap-2">
+        <button onClick={onCancel} className="btn-ghost px-3 py-2">
+          Cancel
+        </button>
+        <button onClick={onConfirm} className="btn-primary px-4 py-2">
+          <Trash2 className="h-4 w-4" />
+          Forget {preview.count} memor{preview.count === 1 ? 'y' : 'ies'}
+        </button>
+      </div>
+    </div>
+  )
+}
+
+// Progress panel while the paced delete runs: live tally, remaining-time
+// estimate, visible rate-limit pauses, and Stop.
+export function ForgetProgressPanel(props: {
+  deleted: number
+  failed: number
+  total: number
+  waitSeconds: number
+  onStop: () => void
+}): React.JSX.Element {
+  const { deleted, failed, total, waitSeconds, onStop } = props
+  const done = deleted + failed
+  const remaining = Math.max(0, total - done)
+  const pct = total > 0 ? Math.round((done / total) * 100) : 0
+
+  return (
+    <div className="surface-card mx-auto mb-5 max-w-4xl animate-fade-in p-5">
+      <div className="flex flex-wrap items-center gap-3">
+        <Loader2 className="h-4 w-4 animate-spin text-white/70" />
+        <span className="font-display text-base font-bold text-white">
+          Forgetting {Math.min(done + 1, total)} of {total}…
+        </span>
+        <span className="text-xs text-white/45">
+          {deleted} forgotten, {failed} failed
+        </span>
+        <button onClick={onStop} className="btn-ghost ml-auto px-3 py-1.5 text-sm">
+          Stop
+        </button>
+      </div>
+      <div className="mt-3 h-1 overflow-hidden rounded-full bg-white/10">
+        <div
+          className="h-full rounded-full bg-white/60 transition-all duration-500"
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+      <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-white/40">
+        {remaining > 0 && (
+          // Never show an estimate shorter than a pause we know we're in.
+          <span>{formatDuration(Math.max(estimateForgetSeconds(remaining), waitSeconds))} left</span>
+        )}
+        {waitSeconds > 0 && (
+          <span>Paused by the server rate limit — resuming in about {waitSeconds}s</span>
+        )}
+        <span>Memories already forgotten stay forgotten if you stop.</span>
+      </div>
+    </div>
+  )
+}

--- a/desktop/windows/src/renderer/src/components/memories/KnowsBand.tsx
+++ b/desktop/windows/src/renderer/src/components/memories/KnowsBand.tsx
@@ -1,0 +1,65 @@
+// "What Omi knows about you" — grouped category and source counts over the
+// loaded memory set. Clicking a source count applies that source filter;
+// clicking a category chip applies a text filter is intentionally NOT done
+// (category chips are read-only context, categories aren't a filter axis here).
+import type { Memory } from '../../hooks/useMemories'
+import {
+  SOURCE_LABELS,
+  categoryCounts,
+  categoryLabel,
+  sourceCounts,
+  type MemorySourceKind
+} from '../../lib/memoryProvenance'
+import { SOURCE_ICONS } from './sourceIcons'
+
+export function KnowsBand(props: {
+  memories: Memory[]
+  activeSource: MemorySourceKind | 'all'
+  onPickSource: (kind: MemorySourceKind | 'all') => void
+}): React.JSX.Element | null {
+  const { memories, activeSource, onPickSource } = props
+  if (memories.length === 0) return null
+  const bySource = sourceCounts(memories)
+  const byCategory = categoryCounts(memories)
+
+  return (
+    <div className="mx-auto mb-5 max-w-4xl">
+      <div className="surface-card px-5 py-4">
+        <div className="flex flex-wrap items-baseline justify-between gap-2">
+          <span className="section-label">What Omi knows about you</span>
+          <span className="text-xs text-white/35">
+            {memories.length} memor{memories.length === 1 ? 'y' : 'ies'} from {bySource.length}{' '}
+            source{bySource.length === 1 ? '' : 's'}
+          </span>
+        </div>
+        <div className="mt-3 flex flex-wrap items-center gap-2">
+          {byCategory.map(({ category, count }) => (
+            <span key={category} className="badge">
+              {categoryLabel(category)} <span className="ml-1 font-normal text-white/35">{count}</span>
+            </span>
+          ))}
+        </div>
+        <div className="mt-3 flex flex-wrap items-center gap-x-3 gap-y-2 text-[13px]">
+          <span className="text-xs text-white/35">Learned from</span>
+          {bySource.map(({ kind, count }) => {
+            const Icon = SOURCE_ICONS[kind]
+            const active = activeSource === kind
+            return (
+              <button
+                key={kind}
+                onClick={() => onPickSource(active ? 'all' : kind)}
+                className={`inline-flex items-center gap-1.5 font-medium transition-colors ${
+                  active ? 'text-white' : 'text-white/55 hover:text-white'
+                }`}
+                title={`Show only memories from ${SOURCE_LABELS[kind].toLowerCase()}`}
+              >
+                <Icon className="h-3.5 w-3.5" />
+                {SOURCE_LABELS[kind]} {count}
+              </button>
+            )
+          })}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/desktop/windows/src/renderer/src/components/memories/MemoryAuditDetail.tsx
+++ b/desktop/windows/src/renderer/src/components/memories/MemoryAuditDetail.tsx
@@ -1,0 +1,230 @@
+// Audit detail for a single memory: the full text with its provenance line,
+// the provenance chain (capture, linked conversation, extraction,
+// corroboration — only the steps whose backing fields exist), related memories
+// from the same conversation, and the forget actions (this memory / all from
+// this conversation / everything from this source).
+import { useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import {
+  Brain,
+  Check,
+  ChevronRight,
+  Loader2,
+  MessageSquareText,
+  Trash2
+} from 'lucide-react'
+import { omiApi } from '../../lib/apiClient'
+import { toast } from '../../lib/toast'
+import type { Memory } from '../../hooks/useMemories'
+import {
+  SOURCE_LABELS,
+  memorySource,
+  provenanceChain,
+  relatedMemories,
+  type ChainStep,
+  type MemorySourceKind
+} from '../../lib/memoryProvenance'
+import { PageHeader } from '../layout/PageHeader'
+import { ProvenanceLine, SourceTag } from './provenanceUi'
+import { SOURCE_ICONS } from './sourceIcons'
+
+function stepIcon(step: ChainStep, source: MemorySourceKind): React.JSX.Element {
+  const cls = 'h-4 w-4'
+  if (step.kind === 'capture') {
+    const Icon = SOURCE_ICONS[source]
+    return <Icon className={cls} />
+  }
+  if (step.kind === 'conversation') return <MessageSquareText className={cls} />
+  if (step.kind === 'extraction') return <Brain className={cls} />
+  return <Check className={cls} />
+}
+
+export function MemoryAuditDetail(props: {
+  memory: Memory
+  all: Memory[]
+  onBack: () => void
+  onOpenMemory: (memory: Memory) => void
+  onForgotten: (id: string) => void
+  onForgetConversation: (ids: string[]) => void
+  onForgetSource: (kind: MemorySourceKind) => void
+}): React.JSX.Element {
+  const { memory, all, onBack, onOpenMemory, onForgotten, onForgetConversation, onForgetSource } =
+    props
+  const navigate = useNavigate()
+  const source = memorySource(memory)
+  const chain = provenanceChain(memory)
+  const related = relatedMemories(all, memory)
+  // The parent keys this component by memory id, so all local state (confirm
+  // step, resolved conversation title) resets naturally when another memory
+  // opens — no state juggling inside the effect.
+  const [confirming, setConfirming] = useState(false)
+  const [deleting, setDeleting] = useState(false)
+  // Resolved lazily so the chain can show the conversation's real title; the
+  // step renders without it (id-linked) until the fetch lands.
+  const [conversationTitle, setConversationTitle] = useState<string | null>(null)
+
+  useEffect(() => {
+    const id = memory.conversation_id
+    if (!id) return
+    let cancelled = false
+    ;(async () => {
+      try {
+        const r = await omiApi.get(`/v1/conversations/${id}`)
+        const c = r.data as { title?: string | null; structured?: { title?: string | null } | null }
+        const title = c.structured?.title || c.title
+        if (!cancelled && title) setConversationTitle(title)
+      } catch {
+        /* keep the generic step title */
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [memory.id, memory.conversation_id])
+
+  const forgetThis = async (): Promise<void> => {
+    if (deleting) return
+    setDeleting(true)
+    try {
+      await omiApi.delete(`/v3/memories/${memory.id}`)
+      toast('Memory forgotten', { tone: 'info' })
+      onForgotten(memory.id)
+    } catch (e) {
+      toast('Could not forget memory', { tone: 'error', body: (e as Error).message })
+      setDeleting(false)
+    }
+  }
+
+  return (
+    <div className="flex h-full flex-col">
+      <PageHeader
+        title={memory.headline || memory.content.slice(0, 80)}
+        subtitle={`${memory.category ?? 'memory'} · first learned ${new Date(
+          memory.created_at
+        ).toLocaleDateString()}`}
+        onBack={onBack}
+        actions={
+          confirming ? (
+            <div className="flex items-center gap-2">
+              <button onClick={() => setConfirming(false)} className="btn-ghost px-3 py-2" disabled={deleting}>
+                Cancel
+              </button>
+              <button onClick={forgetThis} className="btn-danger px-4 py-2" disabled={deleting}>
+                {deleting ? <Loader2 className="h-4 w-4 animate-spin" /> : <Trash2 className="h-4 w-4" />}
+                Forget permanently
+              </button>
+            </div>
+          ) : (
+            <button onClick={() => setConfirming(true)} className="btn-danger px-4 py-2">
+              <Trash2 className="h-4 w-4" />
+              Forget this memory
+            </button>
+          )
+        }
+      />
+
+      <div className="flex-1 overflow-y-auto px-6 py-6 lg:px-10 lg:py-8">
+        <div className="mx-auto max-w-3xl space-y-4">
+          {confirming && (
+            <div className="glass-subtle animate-fade-in px-4 py-3 text-sm text-white/70">
+              This memory will be permanently removed from your account and from everything Omi
+              says from now on. The recordings and conversations it came from are not touched.
+              This cannot be undone.
+            </div>
+          )}
+
+          <div className="surface-card p-6">
+            <p className="text-sm leading-relaxed text-white/85">{memory.content}</p>
+            <ProvenanceLine memory={memory} />
+            {memory.user_review == null && !memory.manually_added && (
+              <div className="mt-2 text-xs text-white/40">Not yet reviewed by you.</div>
+            )}
+          </div>
+
+          <div className="surface-card p-6">
+            <h2 className="section-label mb-4">Where this came from</h2>
+            <ul className="space-y-4">
+              {chain.map((step, i) => (
+                <li key={i} className="flex items-start gap-3">
+                  <span className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-xl border border-white/10 bg-black/20 text-white/65">
+                    {stepIcon(step, source)}
+                  </span>
+                  <div className="min-w-0 flex-1">
+                    <div className="flex flex-wrap items-center gap-2 text-sm font-medium text-white/90">
+                      {step.kind === 'conversation' && step.conversationId
+                        ? `Linked conversation${conversationTitle ? `: ${conversationTitle}` : ''}`
+                        : step.title}
+                      {step.kind === 'conversation' && step.conversationId && (
+                        <button
+                          onClick={() => navigate(`/conversations/${step.conversationId}`)}
+                          className="badge transition-colors hover:border-white/25 hover:text-white"
+                          title="Open the source conversation"
+                        >
+                          Open
+                          <ChevronRight className="h-3 w-3" />
+                        </button>
+                      )}
+                    </div>
+                    {step.sub && <p className="mt-0.5 text-xs text-white/45">{step.sub}</p>}
+                  </div>
+                  {step.at && (
+                    <time className="shrink-0 text-xs text-white/35">
+                      {new Date(step.at).toLocaleString()}
+                    </time>
+                  )}
+                </li>
+              ))}
+            </ul>
+          </div>
+
+          {related.length > 0 && (
+            <div className="surface-card p-6">
+              <h2 className="section-label mb-3">From the same conversation ({related.length})</h2>
+              <ul>
+                {related.map((r) => (
+                  <li key={r.id}>
+                    <button
+                      onClick={() => onOpenMemory(r)}
+                      className="flex w-full items-center gap-3 border-b border-white/5 py-2.5 text-left last:border-b-0"
+                    >
+                      <span className="min-w-0 flex-1 truncate text-sm text-white/85">
+                        {r.headline || r.content}
+                      </span>
+                      <span className="flex shrink-0 items-center gap-2 text-xs text-text-quaternary">
+                        <SourceTag kind={memorySource(r)} />
+                        <time>{new Date(r.created_at).toLocaleDateString()}</time>
+                        <ChevronRight className="h-3.5 w-3.5 text-white/30" />
+                      </span>
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          <div className="surface-card p-6">
+            <p className="text-xs leading-relaxed text-white/45">
+              Forgetting removes a memory from your account and from Omi&apos;s answers. It cannot
+              be undone.
+            </p>
+            <div className="mt-3 flex flex-wrap items-center gap-2">
+              {related.length > 0 && (
+                <button
+                  onClick={() =>
+                    onForgetConversation([memory.id, ...related.map((r) => r.id)])
+                  }
+                  className="btn-ghost px-3 py-2 text-sm"
+                >
+                  Forget all {related.length + 1} from this conversation
+                </button>
+              )}
+              <button onClick={() => onForgetSource(source)} className="btn-ghost px-3 py-2 text-sm">
+                Forget everything from {SOURCE_LABELS[source].toLowerCase()}…
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/desktop/windows/src/renderer/src/components/memories/provenanceUi.tsx
+++ b/desktop/windows/src/renderer/src/components/memories/provenanceUi.tsx
@@ -1,0 +1,80 @@
+// Small shared pieces for the Memories audit surface: the provenance meta line
+// rendered on every memory card and the filter chip used by the source/date
+// toolbars and the "What Omi knows" band.
+import { Info, type LucideIcon } from 'lucide-react'
+import type { Memory } from '../../hooks/useMemories'
+import {
+  SOURCE_LABELS,
+  isSeenOnce,
+  memorySource,
+  type MemorySourceKind
+} from '../../lib/memoryProvenance'
+import { SOURCE_ICONS } from './sourceIcons'
+
+export function SourceTag({ kind }: { kind: MemorySourceKind }): React.JSX.Element {
+  const Icon = SOURCE_ICONS[kind]
+  return (
+    <span className="inline-flex items-center gap-1.5 font-medium text-white/55">
+      <Icon className="h-3.5 w-3.5" />
+      {SOURCE_LABELS[kind]}
+    </span>
+  )
+}
+
+function Dot(): React.JSX.Element {
+  return <span className="h-[3px] w-[3px] shrink-0 rounded-full bg-white/25" />
+}
+
+// The provenance meta line on a memory card: source (icon + label), capture
+// time, category badge, and the low-evidence "seen once" marker when the server
+// flagged the memory as single-source. Fields that are missing simply don't
+// render — nothing is faked.
+export function ProvenanceLine({ memory }: { memory: Memory }): React.JSX.Element {
+  return (
+    <div className="mt-4 flex flex-wrap items-center gap-2 text-xs text-text-quaternary">
+      <SourceTag kind={memorySource(memory)} />
+      <Dot />
+      <time>{new Date(memory.created_at).toLocaleString()}</time>
+      {memory.category && <span className="badge text-text-tertiary">{memory.category}</span>}
+      {isSeenOnce(memory) && (
+        <span
+          className="badge border-dashed text-white/50"
+          title="Backed by a single source so far — independent confirmations raise Omi's confidence."
+        >
+          <Info className="mr-1 h-3 w-3" />
+          seen once
+        </span>
+      )}
+    </div>
+  )
+}
+
+export function FilterChip(props: {
+  label: string
+  count?: number
+  active: boolean
+  onClick: () => void
+  icon?: LucideIcon
+  disabled?: boolean
+}): React.JSX.Element {
+  const { label, count, active, onClick, icon: Icon, disabled } = props
+  return (
+    <button
+      onClick={onClick}
+      disabled={disabled}
+      className={`inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-xs font-medium transition-colors disabled:opacity-40 ${
+        active
+          ? 'border-white/30 bg-white/15 text-white'
+          : 'border-white/10 bg-black/20 text-white/65 hover:border-white/20 hover:text-white'
+      }`}
+    >
+      {Icon && <Icon className="h-3 w-3" />}
+      {label}
+      {count !== undefined && (
+        <span className={active ? 'font-normal text-white/60' : 'font-normal text-white/35'}>
+          {count}
+        </span>
+      )}
+    </button>
+  )
+}

--- a/desktop/windows/src/renderer/src/components/memories/sourceIcons.ts
+++ b/desktop/windows/src/renderer/src/components/memories/sourceIcons.ts
@@ -1,0 +1,29 @@
+// Icon per memory source kind. Lives apart from the components so component
+// files export only components (react-refresh constraint).
+import {
+  Files,
+  HelpCircle,
+  LayoutGrid,
+  Mail,
+  MessageSquare,
+  Mic,
+  Monitor,
+  Pencil,
+  Plug,
+  StickyNote,
+  type LucideIcon
+} from 'lucide-react'
+import type { MemorySourceKind } from '../../lib/memoryProvenance'
+
+export const SOURCE_ICONS: Record<MemorySourceKind, LucideIcon> = {
+  screen: Monitor,
+  conversation: Mic,
+  chat: MessageSquare,
+  manual: Pencil,
+  gmail: Mail,
+  'sticky-notes': StickyNote,
+  'file-index': Files,
+  integration: Plug,
+  app: LayoutGrid,
+  unknown: HelpCircle
+}

--- a/desktop/windows/src/renderer/src/hooks/useMemories.test.ts
+++ b/desktop/windows/src/renderer/src/hooks/useMemories.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi } from 'vitest'
+import { createMemoryBody, type Memory } from './useMemories'
+import { memorySource } from '../lib/memoryProvenance'
+
+vi.mock('../lib/apiClient', () => ({
+  omiApi: {
+    get: vi.fn(),
+    post: vi.fn()
+  }
+}))
+
+// What the server stores for a given POST /v3/memories body — mirrored from
+// backend/routers/memories.py create_memory + models/memories.py
+// MemoryDB.from_memory: `category` defaults to 'interesting' (Memory model),
+// `manually_added` is DERIVED from category === 'manual', and the evidence
+// record gets source_signal 'manual' when manually_added else 'transcription'
+// (source_type 'developer_api' since there is no conversation). If the backend
+// contract changes, update this mirror alongside it.
+function storedByBackend(body: { content: string; category?: string; tags?: string[] }): Memory {
+  const category = body.category ?? 'interesting'
+  const manually_added = category === 'manual'
+  return {
+    id: 'm-created',
+    uid: 'u',
+    content: body.content,
+    category,
+    manually_added,
+    tags: body.tags,
+    created_at: '2026-07-01T10:00:00Z',
+    updated_at: '2026-07-01T10:00:00Z',
+    evidence: [
+      {
+        evidence_id: 'e1',
+        source_id: 'external:m-created',
+        source_type: 'developer_api',
+        source_signal: manually_added ? 'manual' : 'transcription',
+        extractor_id: 'memory_extractor',
+        extractor_version: 'v1',
+        redaction_status: 'active',
+        created_at: '2026-07-01T10:00:00Z'
+      }
+    ]
+  }
+}
+
+describe('createMemoryBody (page create flow)', () => {
+  it('stamps category manual so a memory typed on the Memories page classifies as Manual', () => {
+    // Without the stamp the backend derives manually_added=false and emits
+    // source_signal 'transcription' — and our own provenance UI would then
+    // label the user's typed memory "Heard in a conversation".
+    const body = createMemoryBody('I prefer window seats')
+    expect(body.category).toBe('manual')
+    expect(memorySource(storedByBackend(body))).toBe('manual')
+  })
+
+  it('lets an importer override the category and keep its provenance tags', () => {
+    const body = createMemoryBody('note text', {
+      category: 'interesting',
+      tags: ['gmail/import/note']
+    })
+    expect(body.category).toBe('interesting')
+    expect(body.tags).toEqual(['gmail/import/note'])
+    expect(memorySource(storedByBackend(body))).toBe('gmail')
+  })
+})

--- a/desktop/windows/src/renderer/src/hooks/useMemories.ts
+++ b/desktop/windows/src/renderer/src/hooks/useMemories.ts
@@ -63,9 +63,24 @@ function extractList(data: unknown): Memory[] {
 }
 
 // Optional extra fields for a created memory. `tags` carries provenance (e.g.
-// 'omi-app-index'); `category` is sent best-effort — the server may ignore or
-// reassign it, so UI coloring must not depend on it.
+// 'omi-app-index'); `category` carries provenance too — see createMemoryBody.
 export type CreateMemoryExtra = { category?: string; tags?: string[] }
+
+// The POST /v3/memories body for a memory created through this hook. The
+// category defaults to 'manual', and that default is load-bearing provenance:
+// the backend honors a client-supplied category and DERIVES manually_added
+// from category === 'manual'; without it the record stores category
+// 'interesting', manually_added false, and an evidence source_signal of
+// 'transcription' (backend/routers/memories.py create_memory +
+// models/memories.py MemoryDB.from_memory) — which would make the provenance
+// UI label a user-typed memory "Heard in a conversation". Importers creating
+// non-manual memories pass their own category in `extra`.
+export function createMemoryBody(
+  content: string,
+  extra?: CreateMemoryExtra
+): { content: string } & CreateMemoryExtra {
+  return { content, ...extra, category: extra?.category ?? 'manual' }
+}
 
 // Match the server KG's build budget (it's built from up to 500 memories), so
 // the brain map can scope itself to roughly the same memory set the graph was
@@ -136,7 +151,7 @@ export function useMemories(): {
   const createMemory = async (content: string, extra?: CreateMemoryExtra): Promise<void> => {
     const text = content.trim()
     if (!text) return
-    await omiApi.post('/v3/memories', { content: text, ...extra })
+    await omiApi.post('/v3/memories', createMemoryBody(text, extra))
     publish(await fetchMemories())
   }
 

--- a/desktop/windows/src/renderer/src/hooks/useMemories.ts
+++ b/desktop/windows/src/renderer/src/hooks/useMemories.ts
@@ -1,6 +1,24 @@
 import { useEffect, useState } from 'react'
 import { omiApi } from '../lib/apiClient'
 
+// One provenance record on a memory. Written by the backend's Evidence model
+// (models/memories.py); every field below survives the legacy GET serializer
+// (memory_api_contract strips only internal + canonical-lifecycle fields).
+// Older Firestore docs predate evidence entirely, so everything is optional.
+export type MemoryEvidence = {
+  evidence_id?: string
+  source_id?: string | null
+  source_type?: string
+  source_signal?: string
+  extractor_id?: string
+  extractor_version?: string
+  capture_confidence?: number | null
+  independence_group?: string | null
+  redaction_status?: string
+  created_at?: string
+  client_device_id?: string | null
+}
+
 export type Memory = {
   id: string
   uid: string
@@ -12,6 +30,15 @@ export type Memory = {
   created_at: string
   updated_at: string
   conversation_id?: string | null
+  // Provenance fields (all served by GET /v3/memories today; optional because
+  // memories created before the evidence pipeline lack them).
+  manually_added?: boolean
+  app_id?: string | null
+  reviewed?: boolean
+  user_review?: boolean | null
+  capture_confidence?: number | null
+  uncertainty_reasons?: string[]
+  evidence?: MemoryEvidence[]
 }
 
 const cache = {

--- a/desktop/windows/src/renderer/src/lib/memoriesBulk.test.ts
+++ b/desktop/windows/src/renderer/src/lib/memoriesBulk.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { fetchAllMemories, deleteMemoriesPaced } from './memoriesBulk'
+import { omiApi } from './apiClient'
+import type { Memory } from '../hooks/useMemories'
+
+vi.mock('./apiClient', () => ({
+  omiApi: {
+    get: vi.fn(),
+    delete: vi.fn()
+  }
+}))
+
+const mockedGet = vi.mocked(omiApi.get)
+const mockedDelete = vi.mocked(omiApi.delete)
+
+function mem(id: string): Memory {
+  return { id, uid: 'u', content: `memory ${id}`, created_at: '', updated_at: '' } as Memory
+}
+
+// Mirror of the backend's pagination semantics (backend/routers/memories.py
+// _legacy_get_memories): offset=0 EXPANDS the limit to 5000 regardless of the
+// requested page size; any other offset serves the clamped requested limit.
+function serveFrom(rows: Memory[]): void {
+  mockedGet.mockImplementation(
+    async (_url: string, config?: { params?: { limit?: number; offset?: number } }) => {
+      const limit = config?.params?.limit ?? 100
+      const offset = config?.params?.offset ?? 0
+      const effectiveLimit = offset === 0 ? 5000 : Math.max(1, Math.min(limit, 5000))
+      return { data: rows.slice(offset, offset + effectiveLimit) }
+    }
+  )
+}
+
+beforeEach(() => {
+  mockedGet.mockReset()
+  mockedDelete.mockReset()
+})
+
+describe('fetchAllMemories', () => {
+  it('fetches an account larger than the 5000-row first page completely, without duplicates', async () => {
+    const total = 5200
+    serveFrom(Array.from({ length: total }, (_, i) => mem(`m${i}`)))
+    const out = await fetchAllMemories()
+    expect(out).toHaveLength(total)
+    expect(new Set(out.map((m) => m.id)).size).toBe(total)
+  })
+
+  it('handles a small account in one short page', async () => {
+    serveFrom(Array.from({ length: 150 }, (_, i) => mem(`m${i}`)))
+    const out = await fetchAllMemories()
+    expect(out).toHaveLength(150)
+    expect(mockedGet).toHaveBeenCalledTimes(1)
+  })
+
+  it('handles exactly one expanded first page (no phantom extra rows)', async () => {
+    serveFrom(Array.from({ length: 5000 }, (_, i) => mem(`m${i}`)))
+    const out = await fetchAllMemories()
+    expect(out).toHaveLength(5000)
+  })
+
+  it('terminates against a server that ignores offset (dedupe guard)', async () => {
+    const rows = Array.from({ length: 5000 }, (_, i) => mem(`m${i}`))
+    mockedGet.mockImplementation(async () => ({ data: rows }))
+    const out = await fetchAllMemories()
+    expect(out).toHaveLength(5000)
+    expect(mockedGet.mock.calls.length).toBeLessThan(5)
+  })
+})
+
+describe('deleteMemoriesPaced', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('does not delete another memory when Stop arrives during a rate-limit wait', async () => {
+    let stop = false
+    mockedDelete.mockRejectedValue({
+      response: { status: 429, headers: { 'retry-after': '30' } }
+    })
+    const done = deleteMemoriesPaced(
+      ['a', 'b'],
+      () => {},
+      () => stop
+    )
+    // First delete fires immediately, gets a 429, and the 30s wait begins.
+    await vi.advanceTimersByTimeAsync(1000)
+    expect(mockedDelete).toHaveBeenCalledTimes(1)
+    // User presses Stop mid-wait. No further delete may go out — neither a
+    // retry of 'a' nor a first attempt at 'b'.
+    stop = true
+    await vi.advanceTimersByTimeAsync(1_200_000)
+    const res = await done
+    expect(mockedDelete).toHaveBeenCalledTimes(1)
+    expect(res.deleted).toBe(0)
+    expect(res.failed).toBe(0)
+  })
+
+  it('retries through a 429 and completes when not stopped', async () => {
+    const waits: number[] = []
+    mockedDelete
+      .mockRejectedValueOnce({ response: { status: 429, headers: { 'retry-after': '2' } } })
+      .mockResolvedValue({ data: {} })
+    const done = deleteMemoriesPaced(
+      ['a', 'b'],
+      () => {},
+      undefined,
+      (s) => waits.push(s)
+    )
+    await vi.advanceTimersByTimeAsync(60_000)
+    const res = await done
+    expect(res).toMatchObject({ deleted: 2, failed: 0 })
+    expect(mockedDelete).toHaveBeenCalledTimes(3) // a (429), a (ok), b (ok)
+    expect(waits).toEqual([2, 0]) // pause reported, then cleared
+  })
+
+  it('honors Stop between ids (pre-existing behavior)', async () => {
+    let stop = false
+    mockedDelete.mockResolvedValue({ data: {} })
+    const done = deleteMemoriesPaced(
+      ['a', 'b', 'c'],
+      (_id, _ok, t) => {
+        if (t.deleted === 1) stop = true
+      },
+      () => stop
+    )
+    await vi.advanceTimersByTimeAsync(60_000)
+    const res = await done
+    expect(res.deleted).toBe(1)
+    expect(mockedDelete).toHaveBeenCalledTimes(1)
+  })
+
+  it('treats 404 as already gone and keeps going', async () => {
+    mockedDelete
+      .mockRejectedValueOnce({ response: { status: 404 } })
+      .mockResolvedValue({ data: {} })
+    const done = deleteMemoriesPaced(['a', 'b'], () => {})
+    await vi.advanceTimersByTimeAsync(60_000)
+    const res = await done
+    expect(res).toMatchObject({ deleted: 2, failed: 0 })
+  })
+})

--- a/desktop/windows/src/renderer/src/lib/memoriesBulk.ts
+++ b/desktop/windows/src/renderer/src/lib/memoriesBulk.ts
@@ -3,12 +3,31 @@ import type { Memory } from '../hooks/useMemories'
 
 const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms))
 
-// Page through every memory (server caps a page at 200). Dedupes by id and stops
-// if a page adds nothing new — guards against a server that ignores `offset`.
+// Sleep in short slices, returning early once shouldStop() flips — a Stop
+// pressed during a long Retry-After pause takes effect within a slice
+// (~250ms) instead of after the full wait.
+async function waitInterruptible(ms: number, shouldStop?: () => boolean): Promise<void> {
+  const SLICE_MS = 250
+  for (let waited = 0; waited < ms; waited += SLICE_MS) {
+    if (shouldStop?.()) return
+    await sleep(Math.min(SLICE_MS, ms - waited))
+  }
+}
+
+// Page through every memory. The backend expands the FIRST page (offset=0) to
+// 5000 rows regardless of the requested limit, then serves later offsets at
+// the clamped limit (backend/routers/memories.py _legacy_get_memories) — so
+// the offset must advance by the number of rows actually RETURNED, never by
+// the requested page size, or accounts past 5000 memories get duplicate pages
+// and a premature stop. Dedupes by id and stops when a page adds nothing new
+// (guards a server that ignores `offset`) or comes back shorter than asked
+// (the end of the list).
 export async function fetchAllMemories(): Promise<Memory[]> {
+  const PAGE_LIMIT = 200
   const byId = new Map<string, Memory>()
-  for (let offset = 0; offset < 100_000; offset += 200) {
-    const r = await omiApi.get('/v3/memories', { params: { limit: 200, offset } })
+  let offset = 0
+  while (offset < 100_000) {
+    const r = await omiApi.get('/v3/memories', { params: { limit: PAGE_LIMIT, offset } })
     const page = (Array.isArray(r.data) ? r.data : (r.data?.memories ?? [])) as Memory[]
     let added = 0
     for (const m of page) {
@@ -17,7 +36,9 @@ export async function fetchAllMemories(): Promise<Memory[]> {
         added++
       }
     }
-    if (page.length < 200 || added === 0) break
+    if (page.length === 0 || added === 0) break
+    offset += page.length
+    if (page.length < PAGE_LIMIT) break
   }
   return [...byId.values()]
 }
@@ -28,8 +49,11 @@ export type BulkDeleteTally = { deleted: number; failed: number; firstError?: st
 // a time at ~1.1s, waiting out 429s (honoring Retry-After) and retrying the same
 // id rather than failing. 404 = already gone (idempotent). `onResult` fires after
 // each id so the UI can drop the row and show progress. `shouldStop` lets the
-// caller cancel between ids. `onWait` reports rate-limit pauses (seconds until
-// the next retry; 0 when the pause ends) so progress UI can show them honestly.
+// caller cancel; it is rechecked after EVERY wait (rate-limit pauses included,
+// which also end early), so a Stop pressed mid-pause never lets one more delete
+// out. An id cancelled mid-retry counts as neither deleted nor failed. `onWait`
+// reports rate-limit pauses (seconds until the next retry; 0 when the pause
+// ends) so progress UI can show them honestly.
 export async function deleteMemoriesPaced(
   ids: string[],
   onResult: (id: string, ok: boolean, tally: { deleted: number; failed: number }) => void,
@@ -42,6 +66,7 @@ export async function deleteMemoriesPaced(
   for (const id of ids) {
     if (shouldStop?.()) break
     let ok = false
+    let stopped = false
     for (let attempt = 0; attempt < 30; attempt++) {
       try {
         // __noRetry: this loop owns 429 handling, so the axios interceptor's
@@ -50,7 +75,8 @@ export async function deleteMemoriesPaced(
         ok = true
         break
       } catch (e) {
-        const resp = (e as { response?: { status?: number; headers?: Record<string, string> } }).response
+        const resp = (e as { response?: { status?: number; headers?: Record<string, string> } })
+          .response
         const status = resp?.status
         if (status === 404) {
           ok = true // already gone
@@ -61,18 +87,25 @@ export async function deleteMemoriesPaced(
           const waitMs =
             Number.isFinite(ra) && ra > 0 ? ra * 1000 : Math.min(3000 * 1.6 ** attempt, 60_000)
           onWait?.(Math.round(waitMs / 1000))
-          await sleep(waitMs)
+          await waitInterruptible(waitMs, shouldStop)
           onWait?.(0)
+          // Recheck after the wait: without this, a Stop pressed during the
+          // pause still let the retry delete one more memory.
+          if (shouldStop?.()) {
+            stopped = true
+            break
+          }
           continue
         }
         if (!firstError) firstError = status ? `HTTP ${status}` : (e as Error).message
         break
       }
     }
+    if (stopped) break // cancelled mid-retry: this id was neither deleted nor failed
     if (ok) deleted++
     else failed++
     onResult(id, ok, { deleted, failed })
-    await sleep(1100) // stay under ~60/hour
+    await waitInterruptible(1100, shouldStop) // stay under ~60/hour; Stop skips the tail
   }
   return { deleted, failed, firstError }
 }

--- a/desktop/windows/src/renderer/src/lib/memoriesBulk.ts
+++ b/desktop/windows/src/renderer/src/lib/memoriesBulk.ts
@@ -28,11 +28,13 @@ export type BulkDeleteTally = { deleted: number; failed: number; firstError?: st
 // a time at ~1.1s, waiting out 429s (honoring Retry-After) and retrying the same
 // id rather than failing. 404 = already gone (idempotent). `onResult` fires after
 // each id so the UI can drop the row and show progress. `shouldStop` lets the
-// caller cancel between ids.
+// caller cancel between ids. `onWait` reports rate-limit pauses (seconds until
+// the next retry; 0 when the pause ends) so progress UI can show them honestly.
 export async function deleteMemoriesPaced(
   ids: string[],
   onResult: (id: string, ok: boolean, tally: { deleted: number; failed: number }) => void,
-  shouldStop?: () => boolean
+  shouldStop?: () => boolean,
+  onWait?: (seconds: number) => void
 ): Promise<BulkDeleteTally> {
   let deleted = 0
   let failed = 0
@@ -56,7 +58,11 @@ export async function deleteMemoriesPaced(
         }
         if (status === 429) {
           const ra = Number(resp?.headers?.['retry-after'])
-          await sleep(Number.isFinite(ra) && ra > 0 ? ra * 1000 : Math.min(3000 * 1.6 ** attempt, 60_000))
+          const waitMs =
+            Number.isFinite(ra) && ra > 0 ? ra * 1000 : Math.min(3000 * 1.6 ** attempt, 60_000)
+          onWait?.(Math.round(waitMs / 1000))
+          await sleep(waitMs)
+          onWait?.(0)
           continue
         }
         if (!firstError) firstError = status ? `HTTP ${status}` : (e as Error).message

--- a/desktop/windows/src/renderer/src/lib/memoryProvenance.test.ts
+++ b/desktop/windows/src/renderer/src/lib/memoryProvenance.test.ts
@@ -87,6 +87,17 @@ describe('memorySource', () => {
       )
     ).toBe('manual')
   })
+  it('classifies from the active evidence, skipping a tombstoned first record', () => {
+    // A tombstoned evidence[0] must not drive the card's source: the active
+    // record classifies, matching what provenanceChain shows in the detail.
+    const m = mem('1', {
+      evidence: [
+        ev({ source_type: 'chat_exchange', source_signal: 'direct_user', redaction_status: 'tombstoned' }),
+        ev({ evidence_id: 'e2', source_type: 'conversation', source_signal: 'transcription' })
+      ]
+    })
+    expect(memorySource(m)).toBe('conversation')
+  })
 })
 
 describe('withinDateRange', () => {
@@ -240,6 +251,19 @@ describe('provenanceChain', () => {
       evidence: [ev(), ev({ evidence_id: 'e2', redaction_status: 'tombstoned' })]
     })
     expect(provenanceChain(m).some((s) => s.kind === 'corroboration')).toBe(false)
+  })
+  it('picks the chronologically latest corroboration timestamp, not the lexicographically last', () => {
+    // created_at values can carry timezone offsets, so a raw string sort can
+    // pick an earlier instant. Sort by parsed time so the true latest wins:
+    // 08:00Z is later than 09:00+05:00 (04:00Z) yet sorts earlier as a string.
+    const m = mem('1', {
+      evidence: [
+        ev({ created_at: '2026-07-01T08:00:00Z' }),
+        ev({ evidence_id: 'e2', created_at: '2026-07-01T09:00:00+05:00' })
+      ]
+    })
+    const step = provenanceChain(m).find((s) => s.kind === 'corroboration')
+    expect(step?.at).toBe('2026-07-01T08:00:00Z')
   })
 })
 

--- a/desktop/windows/src/renderer/src/lib/memoryProvenance.test.ts
+++ b/desktop/windows/src/renderer/src/lib/memoryProvenance.test.ts
@@ -71,6 +71,22 @@ describe('memorySource', () => {
   it('prefers a tag over a conflicting evidence record', () => {
     expect(memorySource(mem('1', { tags: [SCREEN_TAG], evidence: [ev()] }))).toBe('screen')
   })
+  it('prefers manually_added / category=manual over a conflicting transcription signal', () => {
+    // Defense in depth for the create flow: even if the evidence record says
+    // 'transcription', an explicit manual marker on the record wins — a
+    // user-typed memory must never be labeled "Heard in a conversation".
+    expect(memorySource(mem('1', { manually_added: true, evidence: [ev()] }))).toBe('manual')
+    expect(memorySource(mem('2', { category: 'manual', evidence: [ev()] }))).toBe('manual')
+    expect(
+      memorySource(
+        mem('3', {
+          manually_added: true,
+          conversation_id: 'c1',
+          evidence: [ev({ source_type: 'conversation', source_signal: 'transcription' })]
+        })
+      )
+    ).toBe('manual')
+  })
 })
 
 describe('withinDateRange', () => {

--- a/desktop/windows/src/renderer/src/lib/memoryProvenance.test.ts
+++ b/desktop/windows/src/renderer/src/lib/memoryProvenance.test.ts
@@ -1,0 +1,243 @@
+import { describe, it, expect } from 'vitest'
+import {
+  categoryCounts,
+  categoryLabel,
+  describeFilters,
+  estimateForgetSeconds,
+  filterMemories,
+  forgetPreview,
+  formatDuration,
+  hasActiveFilter,
+  isSeenOnce,
+  memorySource,
+  provenanceChain,
+  relatedMemories,
+  sourceCounts,
+  withinDateRange
+} from './memoryProvenance'
+import { SCREEN_TAG } from './screenTag'
+import { APP_INDEX_TAG } from './memoryCleanup'
+import type { Memory, MemoryEvidence } from '../hooks/useMemories'
+
+function mem(id: string, over: Partial<Memory> = {}): Memory {
+  return {
+    id,
+    uid: 'u',
+    content: `memory ${id}`,
+    created_at: '2026-06-30T12:00:00Z',
+    updated_at: '2026-06-30T12:00:00Z',
+    ...over
+  }
+}
+
+function ev(over: Partial<MemoryEvidence> = {}): MemoryEvidence {
+  return {
+    evidence_id: 'e1',
+    source_id: 'conv-1',
+    source_type: 'conversation',
+    source_signal: 'transcription',
+    extractor_id: 'memory_extractor',
+    extractor_version: 'v1',
+    capture_confidence: 0.8,
+    independence_group: 'conv-1',
+    redaction_status: 'active',
+    created_at: '2026-06-30T11:58:00Z',
+    ...over
+  }
+}
+
+describe('memorySource', () => {
+  it('classifies by the desktop provenance tags first', () => {
+    expect(memorySource(mem('1', { tags: [SCREEN_TAG] }))).toBe('screen')
+    expect(memorySource(mem('2', { tags: [APP_INDEX_TAG] }))).toBe('file-index')
+    expect(memorySource(mem('3', { tags: ['gmail/import/note'] }))).toBe('gmail')
+    expect(memorySource(mem('4', { tags: ['sticky_notes/import/profile'] }))).toBe('sticky-notes')
+  })
+  it('classifies manual via manually_added, category, or evidence signal', () => {
+    expect(memorySource(mem('1', { manually_added: true }))).toBe('manual')
+    expect(memorySource(mem('2', { category: 'manual' }))).toBe('manual')
+    expect(memorySource(mem('3', { evidence: [ev({ source_signal: 'manual' })] }))).toBe('manual')
+  })
+  it('classifies chat, integration, and conversation from the evidence record', () => {
+    expect(memorySource(mem('1', { evidence: [ev({ source_type: 'chat_exchange', source_signal: 'direct_user' })] }))).toBe('chat')
+    expect(memorySource(mem('2', { evidence: [ev({ source_type: 'integration:x', source_signal: 'integration' })] }))).toBe('integration')
+    expect(memorySource(mem('3', { evidence: [ev()] }))).toBe('conversation')
+  })
+  it('falls back to conversation_id, then app_id, then unknown', () => {
+    expect(memorySource(mem('1', { conversation_id: 'c1' }))).toBe('conversation')
+    expect(memorySource(mem('2', { app_id: 'some-app' }))).toBe('app')
+    expect(memorySource(mem('3'))).toBe('unknown')
+  })
+  it('prefers a tag over a conflicting evidence record', () => {
+    expect(memorySource(mem('1', { tags: [SCREEN_TAG], evidence: [ev()] }))).toBe('screen')
+  })
+})
+
+describe('withinDateRange', () => {
+  const now = new Date('2026-06-30T18:00:00Z')
+  it('always matches "any"', () => {
+    expect(withinDateRange('2001-01-01T00:00:00Z', 'any', now)).toBe(true)
+  })
+  it('matches today only for the same local day', () => {
+    expect(withinDateRange(new Date(now.getTime() - 3600_000).toISOString(), 'today', now)).toBe(true)
+    expect(withinDateRange(new Date(now.getTime() - 2 * 86_400_000).toISOString(), 'today', now)).toBe(false)
+  })
+  it('bounds 7 and 30 day windows', () => {
+    expect(withinDateRange(new Date(now.getTime() - 6 * 86_400_000).toISOString(), '7d', now)).toBe(true)
+    expect(withinDateRange(new Date(now.getTime() - 8 * 86_400_000).toISOString(), '7d', now)).toBe(false)
+    expect(withinDateRange(new Date(now.getTime() - 29 * 86_400_000).toISOString(), '30d', now)).toBe(true)
+    expect(withinDateRange(new Date(now.getTime() - 31 * 86_400_000).toISOString(), '30d', now)).toBe(false)
+  })
+  it('rejects an unparseable timestamp instead of matching it', () => {
+    expect(withinDateRange('not-a-date', '7d', now)).toBe(false)
+  })
+})
+
+describe('filterMemories', () => {
+  const now = new Date('2026-06-30T18:00:00Z')
+  const list = [
+    mem('screen-old', { tags: [SCREEN_TAG], content: 'compared CAD tools', created_at: '2026-05-01T10:00:00Z' }),
+    mem('screen-new', { tags: [SCREEN_TAG], content: 'compared flight prices', created_at: '2026-06-29T10:00:00Z' }),
+    mem('manual-new', { manually_added: true, content: 'allergic to peanuts', created_at: '2026-06-30T08:00:00Z' })
+  ]
+  it('composes text, source, and date filters (AND)', () => {
+    expect(filterMemories(list, { text: 'compared' }, now).map((m) => m.id)).toEqual(['screen-old', 'screen-new'])
+    expect(filterMemories(list, { text: 'compared', range: '7d' }, now).map((m) => m.id)).toEqual(['screen-new'])
+    expect(filterMemories(list, { source: 'screen', range: '7d' }, now).map((m) => m.id)).toEqual(['screen-new'])
+    expect(filterMemories(list, { source: 'manual', text: 'compared' }, now)).toEqual([])
+  })
+  it('passes everything through with no active filter', () => {
+    expect(filterMemories(list, { text: ' ', source: 'all', range: 'any' }, now)).toHaveLength(3)
+  })
+  it('reports whether any filter is active', () => {
+    expect(hasActiveFilter({ text: ' ', source: 'all', range: 'any' })).toBe(false)
+    expect(hasActiveFilter({ text: 'x' })).toBe(true)
+    expect(hasActiveFilter({ source: 'screen' })).toBe(true)
+    expect(hasActiveFilter({ range: '7d' })).toBe(true)
+  })
+})
+
+describe('describeFilters', () => {
+  it('summarizes the active scope in plain language', () => {
+    expect(describeFilters({ source: 'screen', range: '7d' })).toBe(
+      'Everything from screen capture, last 7 days'
+    )
+    expect(describeFilters({ text: 'standup' })).toBe('Everything matching "standup"')
+  })
+  it('is null when nothing is filtered', () => {
+    expect(describeFilters({ source: 'all', range: 'any', text: '' })).toBeNull()
+  })
+})
+
+describe('counts and preview', () => {
+  const list = [
+    mem('1', { tags: [SCREEN_TAG], category: 'work' }),
+    mem('2', { tags: [SCREEN_TAG], category: 'work' }),
+    mem('3', { manually_added: true, category: 'core' }),
+    mem('4', { conversation_id: 'c1' }) // no category -> 'other'
+  ]
+  it('groups source counts descending', () => {
+    expect(sourceCounts(list)).toEqual([
+      { kind: 'screen', count: 2 },
+      { kind: 'manual', count: 1 },
+      { kind: 'conversation', count: 1 }
+    ])
+  })
+  it('groups category counts descending with a fallback bucket', () => {
+    expect(categoryCounts(list)).toEqual([
+      { category: 'work', count: 2 },
+      { category: 'core', count: 1 },
+      { category: 'other', count: 1 }
+    ])
+    expect(categoryLabel('work')).toBe('Work')
+  })
+  it('builds the consequence preview from the selection only', () => {
+    const preview = forgetPreview(list.slice(0, 3))
+    expect(preview.count).toBe(3)
+    expect(preview.bySource[0]).toEqual({ kind: 'screen', count: 2 })
+    expect(preview.byCategory[0]).toEqual({ category: 'work', count: 2 })
+  })
+})
+
+describe('estimateForgetSeconds / formatDuration', () => {
+  it('paces small batches at ~1.1s each', () => {
+    expect(estimateForgetSeconds(0)).toBe(0)
+    expect(estimateForgetSeconds(10)).toBeCloseTo(11)
+    expect(estimateForgetSeconds(60)).toBeCloseTo(66)
+  })
+  it('paces past the hourly cap at ~1/minute', () => {
+    expect(estimateForgetSeconds(61)).toBeCloseTo(126)
+    expect(estimateForgetSeconds(120)).toBeCloseTo(66 + 60 * 60)
+  })
+  it('formats durations honestly', () => {
+    expect(formatDuration(30)).toBe('under a minute')
+    expect(formatDuration(300)).toBe('about 5 minutes')
+    expect(formatDuration(3600)).toBe('about 1 hour')
+    expect(formatDuration(5400)).toBe('about 1 h 30 min')
+  })
+})
+
+describe('isSeenOnce', () => {
+  it('is true only when the server flagged single_source', () => {
+    expect(isSeenOnce(mem('1', { uncertainty_reasons: ['single_source'] }))).toBe(true)
+    expect(isSeenOnce(mem('2', { uncertainty_reasons: ['stale'] }))).toBe(false)
+    expect(isSeenOnce(mem('3'))).toBe(false) // field absent -> no marker, never guessed
+  })
+})
+
+describe('provenanceChain', () => {
+  it('renders the shortest honest chain for a bare legacy memory', () => {
+    const steps = provenanceChain(mem('1'))
+    expect(steps).toHaveLength(1)
+    expect(steps[0]).toMatchObject({ kind: 'capture', title: 'Origin not recorded', at: '2026-06-30T12:00:00Z' })
+    expect(steps[0].sub).toBeUndefined()
+  })
+  it('adds conversation, extraction, and corroboration steps only when backed by data', () => {
+    const m = mem('1', {
+      conversation_id: 'c1',
+      capture_confidence: 0.8,
+      evidence: [
+        ev({ client_device_id: 'LAPTOP-A9' }),
+        ev({ evidence_id: 'e2', independence_group: 'conv-2', created_at: '2026-07-01T09:20:00Z' })
+      ]
+    })
+    const steps = provenanceChain(m)
+    expect(steps.map((s) => s.kind)).toEqual(['capture', 'conversation', 'extraction', 'corroboration'])
+    expect(steps[0].sub).toBe('Device: LAPTOP-A9')
+    expect(steps[1].conversationId).toBe('c1')
+    expect(steps[2].sub).toBe('memory_extractor v1 · capture confidence 0.80')
+    expect(steps[3].title).toBe('Confirmed 1 more time')
+    expect(steps[3].sub).toContain('2 independent sources')
+    expect(steps[3].at).toBe('2026-07-01T09:20:00Z')
+  })
+  it('omits the extraction step when the extractor is unknown', () => {
+    const m = mem('1', { evidence: [ev({ extractor_id: 'unknown', extractor_version: 'unknown' })] })
+    expect(provenanceChain(m).map((s) => s.kind)).toEqual(['capture'])
+  })
+  it('omits capture confidence when the field is missing', () => {
+    const m = mem('1', { evidence: [ev()] })
+    const extraction = provenanceChain(m).find((s) => s.kind === 'extraction')
+    expect(extraction?.sub).toBe('memory_extractor v1')
+  })
+  it('ignores tombstoned evidence for corroboration', () => {
+    const m = mem('1', {
+      evidence: [ev(), ev({ evidence_id: 'e2', redaction_status: 'tombstoned' })]
+    })
+    expect(provenanceChain(m).some((s) => s.kind === 'corroboration')).toBe(false)
+  })
+})
+
+describe('relatedMemories', () => {
+  const list = [
+    mem('a', { conversation_id: 'c1' }),
+    mem('b', { conversation_id: 'c1' }),
+    mem('c', { conversation_id: 'c2' }),
+    mem('d')
+  ]
+  it('returns other memories from the same conversation', () => {
+    expect(relatedMemories(list, list[0]).map((m) => m.id)).toEqual(['b'])
+  })
+  it('is empty when the memory has no conversation', () => {
+    expect(relatedMemories(list, list[3])).toEqual([])
+  })
+})

--- a/desktop/windows/src/renderer/src/lib/memoryProvenance.ts
+++ b/desktop/windows/src/renderer/src/lib/memoryProvenance.ts
@@ -1,0 +1,292 @@
+// Pure provenance/audit logic for the Memories page: classify where each memory
+// came from, compose the audit filters (text + source + date), aggregate the
+// "What Omi knows" counts, build the consequence preview for selective forget,
+// and derive the provenance chain shown in the audit detail. Everything here is
+// computed from fields the server already returns on GET /v3/memories — nothing
+// is invented client-side, and every derivation degrades gracefully when a
+// field is missing (memories created before the evidence pipeline lack most of
+// them).
+import type { Memory, MemoryEvidence } from '../hooks/useMemories'
+import { APP_INDEX_TAG } from './memoryCleanup'
+import { SCREEN_TAG } from './screenTag'
+
+// Import tags stamped by the Settings integrations (IntegrationsTab/googleSync).
+// Matched by prefix so note/profile variants group together.
+const GMAIL_TAG_PREFIX = 'gmail/'
+const STICKY_TAG_PREFIX = 'sticky_notes/'
+
+export type MemorySourceKind =
+  | 'screen'
+  | 'conversation'
+  | 'chat'
+  | 'manual'
+  | 'gmail'
+  | 'sticky-notes'
+  | 'file-index'
+  | 'integration'
+  | 'app'
+  | 'unknown'
+
+export const SOURCE_LABELS: Record<MemorySourceKind, string> = {
+  screen: 'Screen capture',
+  conversation: 'Conversation',
+  chat: 'Omi chat',
+  manual: 'Added by you',
+  gmail: 'Gmail import',
+  'sticky-notes': 'Sticky Notes',
+  'file-index': 'File index',
+  integration: 'Integration',
+  app: 'App',
+  unknown: 'Unknown source'
+}
+
+// Where did this memory come from? Resolution order: the desktop's own
+// provenance tags (stamped at creation, most specific), then explicit record
+// fields (manually_added / category), then the server evidence record, then
+// weaker hints (conversation_id, app_id). A memory with none of these is
+// honestly 'unknown' — never guessed.
+export function memorySource(m: Memory): MemorySourceKind {
+  const tags = m.tags ?? []
+  if (tags.includes(SCREEN_TAG)) return 'screen'
+  if (tags.includes(APP_INDEX_TAG)) return 'file-index'
+  if (tags.some((t) => t.startsWith(GMAIL_TAG_PREFIX))) return 'gmail'
+  if (tags.some((t) => t.startsWith(STICKY_TAG_PREFIX))) return 'sticky-notes'
+  if (m.manually_added || m.category === 'manual') return 'manual'
+  const ev = m.evidence?.[0]
+  if (ev) {
+    if (ev.source_signal === 'manual') return 'manual'
+    if (ev.source_type === 'chat_exchange' || ev.source_signal === 'direct_user') return 'chat'
+    if (ev.source_signal === 'integration' || ev.source_type?.startsWith('integration'))
+      return 'integration'
+    if (ev.source_type === 'conversation' || ev.source_signal === 'transcription')
+      return 'conversation'
+  }
+  if (m.conversation_id) return 'conversation'
+  if (m.app_id) return 'app'
+  return 'unknown'
+}
+
+export type DateRange = 'any' | 'today' | '7d' | '30d'
+
+export const DATE_RANGE_LABELS: Record<DateRange, string> = {
+  any: 'Any time',
+  today: 'Today',
+  '7d': 'Last 7 days',
+  '30d': 'Last 30 days'
+}
+
+export function withinDateRange(createdAt: string, range: DateRange, now = new Date()): boolean {
+  if (range === 'any') return true
+  const t = new Date(createdAt).getTime()
+  if (!Number.isFinite(t)) return false
+  if (range === 'today') {
+    const start = new Date(now)
+    start.setHours(0, 0, 0, 0)
+    return t >= start.getTime() && t <= now.getTime()
+  }
+  const days = range === '7d' ? 7 : 30
+  return t >= now.getTime() - days * 86_400_000 && t <= now.getTime()
+}
+
+export type MemoryFilters = {
+  text?: string
+  source?: MemorySourceKind | 'all'
+  range?: DateRange
+}
+
+export function hasActiveFilter(f: MemoryFilters): boolean {
+  return !!f.text?.trim() || (!!f.source && f.source !== 'all') || (!!f.range && f.range !== 'any')
+}
+
+// Text, source, and date filters compose (AND). Text matching mirrors the
+// page's original behavior: case-insensitive substring over content.
+export function filterMemories(memories: Memory[], f: MemoryFilters, now = new Date()): Memory[] {
+  const q = f.text?.trim().toLowerCase() ?? ''
+  return memories.filter((m) => {
+    if (q && !m.content?.toLowerCase().includes(q)) return false
+    if (f.source && f.source !== 'all' && memorySource(m) !== f.source) return false
+    if (f.range && f.range !== 'any' && !withinDateRange(m.created_at, f.range, now)) return false
+    return true
+  })
+}
+
+// Human summary of the active filters for the consequence preview, e.g.
+// "Everything from screen capture, last 7 days". Null when nothing is filtered.
+export function describeFilters(f: MemoryFilters): string | null {
+  const parts: string[] = []
+  if (f.source && f.source !== 'all') parts.push(`from ${SOURCE_LABELS[f.source].toLowerCase()}`)
+  if (f.range && f.range !== 'any') parts.push(DATE_RANGE_LABELS[f.range].toLowerCase())
+  const text = f.text?.trim()
+  if (text) parts.push(`matching "${text}"`)
+  if (parts.length === 0) return null
+  return `Everything ${parts.join(', ')}`
+}
+
+export type SourceCount = { kind: MemorySourceKind; count: number }
+export type CategoryCount = { category: string; count: number }
+
+export function sourceCounts(memories: Memory[]): SourceCount[] {
+  const counts = new Map<MemorySourceKind, number>()
+  for (const m of memories) {
+    const kind = memorySource(m)
+    counts.set(kind, (counts.get(kind) ?? 0) + 1)
+  }
+  return [...counts.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .map(([kind, count]) => ({ kind, count }))
+}
+
+export function categoryCounts(memories: Memory[]): CategoryCount[] {
+  const counts = new Map<string, number>()
+  for (const m of memories) {
+    const c = m.category || 'other'
+    counts.set(c, (counts.get(c) ?? 0) + 1)
+  }
+  return [...counts.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .map(([category, count]) => ({ category, count }))
+}
+
+export function categoryLabel(category: string): string {
+  return category.charAt(0).toUpperCase() + category.slice(1)
+}
+
+// The server flags a memory backed by a single independent evidence group as
+// uncertain (uncertainty_reasons: 'single_source'). Absence of the field means
+// we don't know — no marker, never a guessed one.
+export function isSeenOnce(m: Memory): boolean {
+  return (m.uncertainty_reasons ?? []).includes('single_source')
+}
+
+// --- Selective forget -------------------------------------------------------
+
+export type ForgetPreview = {
+  count: number
+  bySource: SourceCount[]
+  byCategory: CategoryCount[]
+}
+
+export function forgetPreview(selected: Memory[]): ForgetPreview {
+  return {
+    count: selected.length,
+    bySource: sourceCounts(selected),
+    byCategory: categoryCounts(selected)
+  }
+}
+
+// Honest time estimate for a paced bulk delete. deleteMemoriesPaced runs one
+// delete per ~1.1s until the server's ~60/hour cap kicks in, after which 429s
+// pace the rest at roughly one per minute.
+export function estimateForgetSeconds(count: number): number {
+  const PACE_SECONDS = 1.1
+  const HOURLY_CAP = 60
+  if (count <= 0) return 0
+  if (count <= HOURLY_CAP) return count * PACE_SECONDS
+  return HOURLY_CAP * PACE_SECONDS + (count - HOURLY_CAP) * 60
+}
+
+export function formatDuration(seconds: number): string {
+  if (seconds < 60) return 'under a minute'
+  const minutes = Math.round(seconds / 60)
+  if (minutes < 60) return `about ${minutes} minute${minutes === 1 ? '' : 's'}`
+  const h = Math.floor(minutes / 60)
+  const m = minutes % 60
+  return m === 0 ? `about ${h} hour${h === 1 ? '' : 's'}` : `about ${h} h ${m} min`
+}
+
+// --- Audit detail -----------------------------------------------------------
+
+export type ChainStep = {
+  kind: 'capture' | 'conversation' | 'extraction' | 'corroboration'
+  title: string
+  sub?: string
+  at?: string
+  conversationId?: string
+}
+
+const CAPTURE_TITLES: Record<MemorySourceKind, string> = {
+  screen: 'Captured from your screen',
+  conversation: 'Heard in a conversation',
+  chat: 'From a chat with Omi',
+  manual: 'Added by you',
+  gmail: 'Imported from Gmail',
+  'sticky-notes': 'Imported from Sticky Notes',
+  'file-index': 'Synthesized from your local file index',
+  integration: 'From a connected integration',
+  app: 'Created by an app',
+  unknown: 'Origin not recorded'
+}
+
+function activeEvidence(m: Memory): MemoryEvidence[] {
+  return (m.evidence ?? []).filter((e) => e.redaction_status !== 'tombstoned')
+}
+
+// The provenance chain rendered in the audit detail. Every step is derived
+// from a real field on the record; steps whose backing fields are missing are
+// omitted rather than faked, so the shortest honest chain is a single capture
+// step timestamped by created_at.
+export function provenanceChain(m: Memory): ChainStep[] {
+  const steps: ChainStep[] = []
+  const evidence = activeEvidence(m)
+  const first = evidence[0]
+
+  const capture: ChainStep = {
+    kind: 'capture',
+    title: CAPTURE_TITLES[memorySource(m)],
+    at: first?.created_at ?? m.created_at
+  }
+  if (first?.client_device_id) capture.sub = `Device: ${first.client_device_id}`
+  steps.push(capture)
+
+  if (m.conversation_id) {
+    steps.push({
+      kind: 'conversation',
+      title: 'Linked conversation',
+      sub: 'The full conversation this memory was distilled from.',
+      conversationId: m.conversation_id
+    })
+  }
+
+  if (first?.extractor_id && first.extractor_id !== 'unknown') {
+    const version =
+      first.extractor_version && first.extractor_version !== 'unknown'
+        ? ` ${first.extractor_version}`
+        : ''
+    const confidence =
+      typeof m.capture_confidence === 'number'
+        ? ` · capture confidence ${m.capture_confidence.toFixed(2)}`
+        : ''
+    steps.push({
+      kind: 'extraction',
+      title: 'Memory extracted',
+      sub: `${first.extractor_id}${version}${confidence}`,
+      at: m.created_at
+    })
+  }
+
+  if (evidence.length > 1) {
+    const groups = new Set(
+      evidence.map((e) => e.independence_group || e.source_id).filter(Boolean)
+    )
+    const times = evidence
+      .map((e) => e.created_at)
+      .filter((t): t is string => !!t)
+      .sort()
+    steps.push({
+      kind: 'corroboration',
+      title: `Confirmed ${evidence.length - 1} more time${evidence.length > 2 ? 's' : ''}`,
+      sub:
+        groups.size > 1
+          ? `Backed by ${evidence.length} evidence records from ${groups.size} independent sources.`
+          : `Backed by ${evidence.length} evidence records.`,
+      at: times[times.length - 1]
+    })
+  }
+
+  return steps
+}
+
+export function relatedMemories(all: Memory[], m: Memory): Memory[] {
+  if (!m.conversation_id) return []
+  return all.filter((o) => o.id !== m.id && o.conversation_id === m.conversation_id)
+}

--- a/desktop/windows/src/renderer/src/lib/memoryProvenance.ts
+++ b/desktop/windows/src/renderer/src/lib/memoryProvenance.ts
@@ -52,7 +52,7 @@ export function memorySource(m: Memory): MemorySourceKind {
   if (tags.some((t) => t.startsWith(GMAIL_TAG_PREFIX))) return 'gmail'
   if (tags.some((t) => t.startsWith(STICKY_TAG_PREFIX))) return 'sticky-notes'
   if (m.manually_added || m.category === 'manual') return 'manual'
-  const ev = m.evidence?.[0]
+  const ev = activeEvidence(m)[0]
   if (ev) {
     if (ev.source_signal === 'manual') return 'manual'
     if (ev.source_type === 'chat_exchange' || ev.source_signal === 'direct_user') return 'chat'
@@ -271,7 +271,8 @@ export function provenanceChain(m: Memory): ChainStep[] {
     const times = evidence
       .map((e) => e.created_at)
       .filter((t): t is string => !!t)
-      .sort()
+      .filter((t) => Number.isFinite(new Date(t).getTime()))
+      .sort((a, b) => new Date(a).getTime() - new Date(b).getTime())
     steps.push({
       kind: 'corroboration',
       title: `Confirmed ${evidence.length - 1} more time${evidence.length > 2 ? 's' : ''}`,

--- a/desktop/windows/src/renderer/src/pages/Memories.tsx
+++ b/desktop/windows/src/renderer/src/pages/Memories.tsx
@@ -8,10 +8,26 @@ import { useMemoryGraph } from '../hooks/useMemoryGraph'
 import { toast } from '../lib/toast'
 import { fetchAllMemories, deleteMemoriesPaced } from '../lib/memoriesBulk'
 import { isAppIndexMemory } from '../lib/memoryCleanup'
+import {
+  DATE_RANGE_LABELS,
+  SOURCE_LABELS,
+  filterMemories,
+  hasActiveFilter,
+  sourceCounts,
+  type DateRange,
+  type MemorySourceKind
+} from '../lib/memoryProvenance'
+import { FilterChip, ProvenanceLine } from '../components/memories/provenanceUi'
+import { SOURCE_ICONS } from '../components/memories/sourceIcons'
+import { KnowsBand } from '../components/memories/KnowsBand'
+import { ForgetPreviewPanel, ForgetProgressPanel } from '../components/memories/ForgetPanels'
+import { MemoryAuditDetail } from '../components/memories/MemoryAuditDetail'
 
 // Cap how many cards render at once so a multi-thousand list stays responsive;
 // selection still operates on the full (filtered) set, not just what's rendered.
 const RENDER_CAP = 400
+
+const DATE_RANGES: DateRange[] = ['any', 'today', '7d', '30d']
 
 export function Memories(): React.JSX.Element {
   const { memories, loading, error, createMemory, refresh } = useMemories()
@@ -23,13 +39,24 @@ export function Memories(): React.JSX.Element {
   const [draft, setDraft] = useState('')
   const [saving, setSaving] = useState(false)
 
+  // Audit filters: text, source, and date compose (lib/memoryProvenance) and
+  // apply in both the audit view and manage mode.
+  const [filter, setFilter] = useState('')
+  const [srcFilter, setSrcFilter] = useState<MemorySourceKind | 'all'>('all')
+  const [dateFilter, setDateFilter] = useState<DateRange>('any')
+
+  // Audit detail: a memory opened from a card (in-page, like a detail route).
+  const [detail, setDetail] = useState<Memory | null>(null)
+
   // Manage mode: load ALL memories, multi-select, and delete the selection.
   const [manage, setManage] = useState(false)
   const [all, setAll] = useState<Memory[] | null>(null) // full set, owned locally so deletes can drop rows
   const [loadingAll, setLoadingAll] = useState(false)
-  const [filter, setFilter] = useState('')
   const [selected, setSelected] = useState<Set<string>>(new Set())
+  const [confirming, setConfirming] = useState(false) // consequence preview open
   const [deleting, setDeleting] = useState(false)
+  const [deleteTotal, setDeleteTotal] = useState(0)
+  const [waitSeconds, setWaitSeconds] = useState(0) // active rate-limit pause
   const [tally, setTally] = useState({ deleted: 0, failed: 0 })
   const stopRef = useState({ stop: false })[0]
 
@@ -53,30 +80,40 @@ export function Memories(): React.JSX.Element {
     }
   }
 
-  const enterManage = async (): Promise<void> => {
+  const enterManage = async (): Promise<Memory[]> => {
     setManage(true)
-    if (all === null) {
-      setLoadingAll(true)
-      try {
-        setAll(await fetchAllMemories())
-      } catch (e) {
-        toast('Could not load all memories', { tone: 'error', body: (e as Error).message })
-      } finally {
-        setLoadingAll(false)
-      }
+    if (all !== null) return all
+    setLoadingAll(true)
+    try {
+      const list = await fetchAllMemories()
+      setAll(list)
+      return list
+    } catch (e) {
+      toast('Could not load all memories', { tone: 'error', body: (e as Error).message })
+      return []
+    } finally {
+      setLoadingAll(false)
     }
   }
 
   const exitManage = (): void => {
     setManage(false)
     setSelected(new Set())
+    setConfirming(false)
     setFilter('')
+    setSrcFilter('all')
+    setDateFilter('any')
   }
 
   const source = manage ? (all ?? []) : memories
-  const q = filter.trim().toLowerCase()
-  const filtered = q ? source.filter((m) => m.content?.toLowerCase().includes(q)) : source
+  const filters = { text: filter, source: srcFilter, range: dateFilter }
+  const filtered = filterMemories(source, filters)
   const rendered = filtered.slice(0, RENDER_CAP)
+  const filterActive = hasActiveFilter(filters)
+  // Source chip counts reflect what clicking each chip would show (text + date
+  // filters applied, source not).
+  const chipCounts = sourceCounts(filterMemories(source, { text: filter, range: dateFilter }))
+  const selectedMemories = source.filter((m) => selected.has(m.id))
 
   const toggle = (id: string): void =>
     setSelected((s) => {
@@ -89,17 +126,16 @@ export function Memories(): React.JSX.Element {
   const selectJunk = (): void => setSelected(new Set(source.filter(isAppIndexMemory).map((m) => m.id)))
   const clearSel = (): void => setSelected(new Set())
 
+  // Runs after the consequence preview is confirmed — the preview replaced the
+  // old window.confirm, the paced delete machinery is unchanged.
   const deleteSelected = async (): Promise<void> => {
     const ids = [...selected]
     if (ids.length === 0 || deleting) return
-    if (
-      !window.confirm(
-        `Delete ${ids.length} selected memories? The server allows ~60 deletes/hour, so this pauses when the limit is hit (you can stop and resume anytime). This cannot be undone.`
-      )
-    )
-      return
+    setConfirming(false)
     setDeleting(true)
     stopRef.stop = false
+    setDeleteTotal(ids.length)
+    setWaitSeconds(0)
     setTally({ deleted: 0, failed: 0 })
     const res = await deleteMemoriesPaced(
       ids,
@@ -114,23 +150,68 @@ export function Memories(): React.JSX.Element {
           })
         }
       },
-      () => stopRef.stop
+      () => stopRef.stop,
+      (seconds) => setWaitSeconds(seconds)
     )
     setDeleting(false)
-    toast(`Deleted ${res.deleted} of ${ids.length}`, {
+    setWaitSeconds(0)
+    toast(`Forgot ${res.deleted} of ${ids.length}`, {
       tone: res.failed ? 'warn' : 'success',
       body: res.failed ? `${res.failed} failed${res.firstError ? ` — ${res.firstError}` : ''}.` : undefined
     })
     await refresh()
   }
 
+  // Scope escalators from the audit detail: enter manage mode with the scope
+  // pre-applied (filter-as-selection), then let the consequence preview gate
+  // the actual delete.
+  const forgetConversation = async (ids: string[]): Promise<void> => {
+    setDetail(null)
+    const list = await enterManage()
+    const known = new Set(list.map((m) => m.id))
+    setSelected(new Set(ids.filter((id) => known.has(id))))
+    setConfirming(true)
+  }
+
+  const forgetSource = async (kind: MemorySourceKind): Promise<void> => {
+    setDetail(null)
+    setSrcFilter(kind)
+    const list = await enterManage()
+    setSelected(new Set(filterMemories(list, { source: kind }).map((m) => m.id)))
+  }
+
+  const forgottenFromDetail = (id: string): void => {
+    setDetail(null)
+    setAll((prev) => (prev ? prev.filter((m) => m.id !== id) : prev))
+    void refresh()
+  }
+
+  if (detail) {
+    return (
+      <MemoryAuditDetail
+        key={detail.id}
+        memory={detail}
+        all={source}
+        onBack={() => setDetail(null)}
+        onOpenMemory={setDetail}
+        onForgotten={forgottenFromDetail}
+        onForgetConversation={(ids) => void forgetConversation(ids)}
+        onForgetSource={(kind) => void forgetSource(kind)}
+      />
+    )
+  }
+
   const headerCount = manage
     ? loadingAll
       ? 'Loading all…'
-      : `${filtered.length} shown${selected.size ? ` · ${selected.size} selected` : ''}`
+      : `Forget mode · ${filtered.length} of ${source.length} match${
+          selected.size ? ` · ${selected.size} selected` : ''
+        }`
     : loading
       ? 'Loading…'
-      : `${memories.length} memor${memories.length === 1 ? 'y' : 'ies'}`
+      : `${memories.length} memor${memories.length === 1 ? 'y' : 'ies'}${
+          filterActive ? ` · ${filtered.length} match your filter` : ''
+        }`
 
   return (
     <div className="flex h-full flex-col">
@@ -145,7 +226,7 @@ export function Memories(): React.JSX.Element {
             </button>
           ) : (
             <div className="flex items-center gap-2">
-              <button onClick={enterManage} className="btn-ghost px-3 py-2" title="Select & delete memories">
+              <button onClick={() => void enterManage()} className="btn-ghost px-3 py-2" title="Select & forget memories">
                 <CheckSquare className="h-4 w-4" />
                 Select
               </button>
@@ -158,41 +239,63 @@ export function Memories(): React.JSX.Element {
         }
       />
 
+      <div className="flex flex-wrap items-center gap-2 border-b border-white/5 px-6 py-3 lg:px-10">
+        <input
+          value={filter}
+          onChange={(e) => setFilter(e.target.value)}
+          placeholder="Filter by text…"
+          className="input-field max-w-xs flex-1 py-1.5 text-sm"
+        />
+        <span className="ml-1 text-[11px] font-medium tracking-wide text-white/35">SOURCE</span>
+        <FilterChip
+          label="All"
+          count={filterMemories(source, { text: filter, range: dateFilter }).length}
+          active={srcFilter === 'all'}
+          onClick={() => setSrcFilter('all')}
+          disabled={deleting}
+        />
+        {chipCounts.map(({ kind, count }) => (
+          <FilterChip
+            key={kind}
+            label={SOURCE_LABELS[kind]}
+            icon={SOURCE_ICONS[kind]}
+            count={count}
+            active={srcFilter === kind}
+            onClick={() => setSrcFilter(srcFilter === kind ? 'all' : kind)}
+            disabled={deleting}
+          />
+        ))}
+        <span className="ml-1 text-[11px] font-medium tracking-wide text-white/35">WHEN</span>
+        {DATE_RANGES.map((range) => (
+          <FilterChip
+            key={range}
+            label={DATE_RANGE_LABELS[range]}
+            active={dateFilter === range}
+            onClick={() => setDateFilter(range)}
+            disabled={deleting}
+          />
+        ))}
+      </div>
+
       {manage && (
         <div className="flex flex-wrap items-center gap-2 border-b border-white/5 px-6 py-3 lg:px-10">
-          <input
-            value={filter}
-            onChange={(e) => setFilter(e.target.value)}
-            placeholder="Filter by text (e.g. local projects include)…"
-            className="input-field max-w-xs flex-1 py-1.5 text-sm"
-          />
           <button onClick={selectJunk} className="btn-ghost px-3 py-1.5 text-sm" disabled={deleting}>
             Select file-index junk
           </button>
           <button onClick={selectAllFiltered} className="btn-ghost px-3 py-1.5 text-sm" disabled={deleting}>
-            Select all {q ? 'matching' : ''} ({filtered.length})
+            Select all {filterActive ? 'matching' : ''} ({filtered.length})
           </button>
           <button onClick={clearSel} className="btn-ghost px-3 py-1.5 text-sm" disabled={deleting || !selected.size}>
             Clear
           </button>
           <div className="ml-auto flex items-center gap-2">
-            {deleting && (
-              <>
-                <span className="text-sm text-text-tertiary">
-                  Deleting {tally.deleted}/{selected.size + tally.deleted}…
-                </span>
-                <button onClick={() => (stopRef.stop = true)} className="btn-ghost px-3 py-1.5 text-sm">
-                  Stop
-                </button>
-              </>
-            )}
             <button
-              onClick={deleteSelected}
+              onClick={() => setConfirming(true)}
               disabled={deleting || selected.size === 0}
               className="btn-primary px-4 py-1.5 text-sm disabled:opacity-40"
             >
               {deleting ? <Loader2 className="h-4 w-4 animate-spin" /> : <Trash2 className="h-4 w-4" />}
-              Delete selected ({selected.size})
+              Forget selected ({selected.size})
             </button>
           </div>
         </div>
@@ -203,12 +306,35 @@ export function Memories(): React.JSX.Element {
           <div className="glass-subtle mb-5 px-4 py-3 text-sm text-white/60">Failed to load memories: {error}</div>
         )}
 
-        {!manage && brainGraph.nodes.length > 0 && (
+        {!manage && !filterActive && brainGraph.nodes.length > 0 && (
           <div className="mx-auto mb-6 max-w-4xl">
             <div className="surface-card relative h-80 overflow-hidden p-0">
               <BrainGraph graph={brainGraph} centerNodeId={centerNodeId} interactive={false} pauseWhenHidden />
             </div>
           </div>
+        )}
+
+        {!manage && !loading && (
+          <KnowsBand memories={memories} activeSource={srcFilter} onPickSource={setSrcFilter} />
+        )}
+
+        {manage && confirming && !deleting && !loadingAll && (
+          <ForgetPreviewPanel
+            selected={selectedMemories}
+            filters={filters}
+            onCancel={() => setConfirming(false)}
+            onConfirm={() => void deleteSelected()}
+          />
+        )}
+
+        {manage && deleting && (
+          <ForgetProgressPanel
+            deleted={tally.deleted}
+            failed={tally.failed}
+            total={deleteTotal}
+            waitSeconds={waitSeconds}
+            onStop={() => (stopRef.stop = true)}
+          />
         )}
 
         {composing && (
@@ -257,10 +383,9 @@ export function Memories(): React.JSX.Element {
             return (
               <li
                 key={m.id}
-                onClick={manage ? () => toggle(m.id) : undefined}
-                className={`surface-card-interactive p-5 ${manage ? 'cursor-pointer' : ''} ${
-                  isSel ? 'ring-2 ring-white/40' : ''
-                }`}
+                onClick={manage ? () => toggle(m.id) : () => setDetail(m)}
+                title={manage ? undefined : 'See where this memory came from'}
+                className={`surface-card-interactive cursor-pointer p-5 ${isSel ? 'ring-2 ring-white/40' : ''}`}
               >
                 <div className="flex items-start gap-3">
                   {manage && (
@@ -279,13 +404,7 @@ export function Memories(): React.JSX.Element {
                     {m.headline && (
                       <p className="mt-2.5 line-clamp-3 text-sm leading-relaxed text-text-tertiary">{m.content}</p>
                     )}
-                    <div className="mt-4 flex flex-wrap items-center gap-2 text-xs text-text-quaternary">
-                      <time>{new Date(m.created_at).toLocaleString()}</time>
-                      {m.category && <span className="badge text-text-tertiary">{m.category}</span>}
-                      {m.tags && m.tags.length > 0 && (
-                        <span className="truncate text-text-quaternary">{m.tags.join(' · ')}</span>
-                      )}
-                    </div>
+                    <ProvenanceLine memory={m} />
                   </div>
                 </div>
               </li>
@@ -294,8 +413,8 @@ export function Memories(): React.JSX.Element {
         </ul>
         {manage && filtered.length > RENDER_CAP && (
           <p className="mx-auto mt-4 max-w-4xl text-center text-sm text-text-tertiary">
-            Showing first {RENDER_CAP} of {filtered.length}. Selection and delete still apply to all{' '}
-            {q ? 'matching' : ''} {filtered.length}.
+            Showing first {RENDER_CAP} of {filtered.length}. Selection and forget still apply to all{' '}
+            {filterActive ? 'matching' : ''} {filtered.length}.
           </p>
         )}
       </div>

--- a/desktop/windows/src/renderer/src/pages/Memories.tsx
+++ b/desktop/windows/src/renderer/src/pages/Memories.tsx
@@ -70,7 +70,10 @@ export function Memories(): React.JSX.Element {
     if (!text || saving) return
     setSaving(true)
     try {
-      await createMemory(text)
+      // category 'manual' is the provenance stamp: the backend derives
+      // manually_added from it (createMemoryBody defaults it too — explicit
+      // here because this compose box is exactly the user-typed path).
+      await createMemory(text, { category: 'manual' })
       toast('Memory created', { tone: 'info' })
       closeCompose()
     } catch (e) {


### PR DESCRIPTION
# PR: Memory provenance / audit surface for the Windows desktop Memories page

## What

Every memory now shows where it came from, and forgetting is scoped,
previewed, and honest about pacing.

- **Provenance on every card**: source (screen capture / conversation / Omi
  chat / added by you / Gmail import / Sticky Notes / integrations), capture
  time, category, and a dashed "seen once" marker when the server flagged the
  memory `single_source`.
- **Typed memories are provenance-true**: creating a memory on the page now
  sends `category: 'manual'`, which the backend uses to derive
  `manually_added` - so a memory the user typed shows "Added by you" instead
  of inheriting the backend's `transcription` default and being mislabeled
  "Heard in a conversation". The classifier also prefers an explicit
  `manually_added`/`category=manual` marker over a conflicting evidence
  `source_signal`.
- **"What Omi knows" band**: category and source counts at a glance; clicking
  a source filters the list.
- **Source + date filter chips** with live counts, composing with the existing
  text filter in both the normal view and manage mode.
- **Selective forget**: "Forget selected (N)" opens a consequence preview -
  exact count, where-they-came-from / what-they-are-about breakdowns, plain
  language about what is (and is not) removed, and a time estimate derived
  from the real ~60/hour delete cap - replacing the old `window.confirm`.
  While the paced delete runs, a progress panel shows the live tally,
  remaining time, visible rate-limit pauses, and Stop - and Stop is honored
  immediately, even in the middle of a rate-limit pause (the pause is rechecked
  and ends early; no further delete goes out after Stop).
- **Audit detail** (click any card): full text, a provenance chain built from
  the memory's evidence records (capture + device, linked conversation with a
  jump to the existing conversation detail, extraction, corroborations),
  related memories from the same conversation, "Forget this memory", and
  scope escalators that open the forget flow prefiltered.

## Why

Omi asks users to trust it with a memory of their life. That trust needs two
things the page didn't have: the ability to audit *why Omi believes something*
(source, conversation, how often it was confirmed), and the ability to forget
precisely ("everything from screen capture last week") while seeing exactly
what will be removed before anything happens.

## How

- **No backend changes.** All fields used (evidence records,
  capture_confidence, uncertainty_reasons, conversation_id, manually_added,
  app_id, user_review, tags) already flow through GET /v3/memories; grouping
  and filtering are computed client-side from the existing fetch paths.
- New pure lib `lib/memoryProvenance.ts` does source classification, filter
  composition, count aggregation, forget preview, ETA, and chain derivation.
  Everything degrades gracefully: memories that predate the evidence pipeline
  render the shortest honest chain, and no marker/step is ever shown without a
  backing field.
- Reuses existing machinery throughout: `fetchAllMemories` +
  `deleteMemoriesPaced` for bulk forget, manage-mode selection,
  `PageHeader`/badge/chip anatomy, the ConversationDetail route. Both bulk
  helpers were hardened in review rework:
  - `fetchAllMemories` now pages by the backend's actual semantics (offset=0
    returns a 5000-row first page regardless of the requested limit, per
    `_legacy_get_memories`), advancing the offset by the rows actually
    returned - accounts past 5000 memories previously got duplicate pages and
    a premature stop at 5000.
  - `deleteMemoriesPaced` rechecks `shouldStop` after every wait and runs
    waits in interruptible slices, so Stop can no longer let one more delete
    out mid-pause. The pacing rate itself (~1.1s/delete, Retry-After honored)
    is unchanged; an optional `onWait` callback lets the UI show 429 pauses.

## Screenshots

(from the component harness, 1440x900: audit view, forget preview + progress,
audit detail - attach `screenshots/audit.png`, `screenshots/forget.png`,
`screenshots/progress.png`, `screenshots/detail.png`)

## How to test

1. `cd desktop/windows && npm install && npm test` - full vitest suite
   (571 passed | 3 pre-existing skips); the new logic is covered in
   `src/renderer/src/lib/memoryProvenance.test.ts` (29 tests: classification
   incl. missing-field fallbacks and manual-vs-signal conflicts, filter
   composition, preview counts, ETA, chain derivation),
   `src/renderer/src/lib/memoriesBulk.test.ts` (8 tests: pagination past the
   5000-row first page, dedupe guard, stop-during-rate-limit-wait, 429 retry,
   404 idempotency), and `src/renderer/src/hooks/useMemories.test.ts` (2
   tests: the manual-category stamp classifies as Manual under the backend's
   create contract; importer override). A new
   `src/renderer/src/App.shell.test.ts` evaluates the full App module graph
   and fails on any module-scope throw - the class that otherwise blanks the
   renderer with no visible error (e.g. Firebase init when `.env` is absent).
2. Copy `.env.example` to `.env` (Firebase init throws at module load without
   it and the window renders black), then `npm run dev`, sign in, open
   Memories (shortcut 4):
   - every card shows a provenance line; cards with a single evidence source
     show "seen once";
   - New -> type a memory -> Save: its card and audit detail say "Added by
     you" (not "Heard in a conversation");
   - chip filters + text filter compose and update the header count;
   - click a card -> audit detail; "Open" on the linked conversation jumps to
     the conversation; "Forget everything from <source>..." lands in manage
     mode preselected;
   - Select -> pick a filter -> "Select all matching" -> "Forget selected" ->
     consequence preview shows count + breakdowns; confirm -> progress panel
     ticks and cards drop one by one; Stop halts the run immediately, even
     while a rate-limit pause is counting down.
3. Memories without evidence records (older accounts) still render: chain
   collapses to a single capture step, no invented fields.

> Note on local sign-in from a fork: `npm run dev` renders to the login screen,
> but completing Google sign-in needs the desktop OAuth client secret
> (`MAIN_VITE_GOOGLE_CLIENT_SECRET`), which isn't in the public repo - a fork
> build returns `invalid_client`. This surface was therefore built and verified
> via the component harness (the real components on fixture data) plus the full
> vitest suite; maintainers with the project credentials can exercise the
> signed-in flow end-to-end.



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8952?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

