### PR TITLE
[codex] Fix desktop realtime health telemetry

### DIFF
--- a/desktop/macos/Backend-Rust/src/routes/realtime.rs
+++ b/desktop/macos/Backend-Rust/src/routes/realtime.rs
@@ -231,15 +231,7 @@ async fn mint_gemini(state: &AppState, uid: &str) -> Result<MintResponse, MintEr
         .format("%Y-%m-%dT%H:%M:%SZ")
         .to_string();
 
-    // Single use + short windows bound the cost. NOTE: only the bare token form is
-    // verified to connect to the BidiGenerateContentConstrained endpoint; locking the
-    // model/config via `liveConnectConstraints` is a follow-up that needs its own
-    // spike (the constraint shape wasn't verified) — see Phase 2 spike notes.
-    let body = serde_json::json!({
-        "uses": 1,
-        "expireTime": expire,
-        "newSessionExpireTime": new_session_expire,
-    });
+    let body = gemini_auth_token_body(&new_session_expire, &expire);
     let req = http_client()
         .post(GEMINI_AUTH_TOKENS_URL)
         .query(&[("key", key)])
@@ -265,6 +257,18 @@ async fn mint_gemini(state: &AppState, uid: &str) -> Result<MintResponse, MintEr
         provider: "gemini".to_string(),
         token,
         expires_at: Some(expire),
+    })
+}
+
+fn gemini_auth_token_body(new_session_expire: &str, expire: &str) -> serde_json::Value {
+    // Google's CreateAuthTokenRequest wraps token settings under `authToken`.
+    // Top-level `uses`/`expireTime` fields are ignored/rejected by the v1alpha API.
+    serde_json::json!({
+        "authToken": {
+            "uses": 1,
+            "expireTime": expire,
+            "newSessionExpireTime": new_session_expire,
+        }
     })
 }
 
@@ -398,4 +402,24 @@ pub fn realtime_routes() -> Router<AppState> {
     Router::new()
         .route("/v2/realtime/session", post(mint_session))
         .route("/v2/realtime/usage", post(report_usage))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn gemini_auth_token_body_wraps_settings_under_auth_token() {
+        let body = gemini_auth_token_body("2026-07-03T18:40:00Z", "2026-07-03T19:08:00Z");
+
+        assert_eq!(body["authToken"]["uses"], 1);
+        assert_eq!(
+            body["authToken"]["newSessionExpireTime"],
+            "2026-07-03T18:40:00Z"
+        );
+        assert_eq!(body["authToken"]["expireTime"], "2026-07-03T19:08:00Z");
+        assert!(body.get("uses").is_none());
+        assert!(body.get("expireTime").is_none());
+        assert!(body.get("newSessionExpireTime").is_none());
+    }
 }

--- a/desktop/macos/Desktop/Sources/CredentialHealthManager.swift
+++ b/desktop/macos/Desktop/Sources/CredentialHealthManager.swift
@@ -40,6 +40,15 @@ enum CredentialFailureClass: Equatable {
     case .unknown: return "unknown"
     }
   }
+
+  var httpStatusCode: Int? {
+    switch self {
+    case .backendTransient(let statusCode):
+      return statusCode
+    default:
+      return nil
+    }
+  }
 }
 
 struct CredentialRecoveryIssue: Equatable {

--- a/desktop/macos/Desktop/Sources/DesktopDiagnosticsManager.swift
+++ b/desktop/macos/Desktop/Sources/DesktopDiagnosticsManager.swift
@@ -9,6 +9,7 @@ enum DesktopHealthEventName: String {
   case pttAudioCaptureDeviceRouteChanged = "ptt_audio_capture_device_route_changed"
   case pttCommitted = "ptt_committed"
   case realtimeTokenMintFailed = "realtime_token_mint_failed"
+  case realtimeProviderExpectedIdleTeardown = "realtime_provider_expected_idle_teardown"
   case realtimeProviderPolicyClose = "realtime_provider_policy_close"
   case realtimeProviderSessionError = "realtime_provider_session_error"
 }
@@ -124,28 +125,62 @@ final class DesktopDiagnosticsManager {
       ])
   }
 
-  func recordRealtimeTokenMintFailed(provider: String, reason: String, phase: String) {
+  func recordRealtimeTokenMintFailed(
+    provider: String,
+    reason: String,
+    phase: String,
+    httpStatusCode: Int? = nil
+  ) {
+    var properties: [String: Any] = [
+      "provider": safeProvider(provider),
+      "reason": reason,
+      "phase": phase,
+    ]
+    if let httpStatusCode {
+      properties["http_status_code"] = httpStatusCode
+    }
     record(
       .realtimeTokenMintFailed,
-      properties: [
-        "provider": safeProvider(provider),
-        "reason": reason,
-        "phase": phase,
-      ])
+      properties: properties)
   }
 
-  func recordRealtimeProviderClose(provider: String, category: String?, aliveFor: TimeInterval, activeTurn: Bool) {
-    let event: DesktopHealthEventName = category == RealtimeHubCloseCategory.providerPolicyCloseFast.rawValue
-      ? .realtimeProviderPolicyClose
-      : .realtimeProviderSessionError
+  func recordRealtimeProviderClose(
+    provider: String,
+    category: String?,
+    aliveFor: TimeInterval,
+    activeTurn: Bool,
+    authMode: CredentialAuthMode?,
+    failureClass: CredentialFailureClass?
+  ) {
+    let normalizedCategory = category ?? failureClass?.logValue ?? "unclassified"
+    let event: DesktopHealthEventName
+    switch normalizedCategory {
+    case RealtimeHubCloseCategory.expectedIdleTeardown.rawValue:
+      event = .realtimeProviderExpectedIdleTeardown
+    case RealtimeHubCloseCategory.providerPolicyCloseFast.rawValue,
+      CredentialFailureClass.providerPolicyClose(provider: .openai).logValue:
+      event = .realtimeProviderPolicyClose
+    default:
+      event = .realtimeProviderSessionError
+    }
+    var properties: [String: Any] = [
+      "provider": safeProvider(provider),
+      "category": normalizedCategory,
+      "alive_for_seconds": Int(aliveFor),
+      "active_turn": activeTurn,
+    ]
+    if let authMode {
+      properties["auth_mode"] = authMode.rawValue
+    }
+    if let failureClass {
+      properties["failure_class"] = failureClass.logValue
+      if let httpStatusCode = failureClass.httpStatusCode {
+        properties["http_status_code"] = httpStatusCode
+      }
+    }
     record(
       event,
-      properties: [
-        "provider": safeProvider(provider),
-        "category": category ?? "unclassified",
-        "alive_for_seconds": Int(aliveFor),
-        "active_turn": activeTurn,
-      ])
+      properties: properties)
   }
 
   func currentSnapshotsForSentry() -> [[String: Any]] {

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
@@ -404,7 +404,8 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate {
         DesktopDiagnosticsManager.shared.recordRealtimeTokenMintFailed(
           provider: providerParam,
           reason: error.failureClass.logValue,
-          phase: "warm")
+          phase: "warm",
+          httpStatusCode: error.failureClass.httpStatusCode)
         if error.failureClass.isAccountWide {
           log("RealtimeHub: account credential failure during mint — staying on cascade")
         } else if !self.failoverToAlternateProvider() {
@@ -522,6 +523,11 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate {
       } catch let error as CredentialHealthError {
         self.minting = false
         CredentialHealthManager.shared.record(error, context: "realtime_barge_in_mint")
+        DesktopDiagnosticsManager.shared.recordRealtimeTokenMintFailed(
+          provider: providerParam,
+          reason: error.failureClass.logValue,
+          phase: "barge_in_replacement",
+          httpStatusCode: error.failureClass.httpStatusCode)
         self.failBargeInReplacement(provider: provider, reason: error.localizedDescription)
         if self.shouldFailoverToAlternate(for: error.failureClass), self.failoverToAlternateProvider() {
           return
@@ -531,6 +537,10 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate {
         return
       } catch {
         self.minting = false
+        DesktopDiagnosticsManager.shared.recordRealtimeTokenMintFailed(
+          provider: providerParam,
+          reason: "backend_transient",
+          phase: "barge_in_replacement")
         self.failBargeInReplacement(provider: provider, reason: error.localizedDescription)
         log("⚠️ RealtimeHub[\(provider.displayName)]: barge-in replacement token mint failed")
         return
@@ -1514,7 +1524,9 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate {
       provider: providerTag,
       category: closeCategory?.rawValue,
       aliveFor: aliveFor,
-      activeTurn: hasActiveTurn)
+      activeTurn: hasActiveTurn,
+      authMode: authMode,
+      failureClass: credentialFailureClass)
     if RealtimeHubCloseClassifier.shouldReportToSentry(closeCategory) {
       logError("RealtimeHub: session error —\(categoryText) provider=\(providerTag)\(safeMessage)")
     } else {

--- a/desktop/macos/Desktop/Tests/DesktopDiagnosticsManagerTests.swift
+++ b/desktop/macos/Desktop/Tests/DesktopDiagnosticsManagerTests.swift
@@ -70,4 +70,65 @@ final class DesktopDiagnosticsManagerTests: XCTestCase {
     XCTAssertTrue(snapshots.allSatisfy { $0["watchdog_eligible"] as? Bool == false })
     XCTAssertTrue(snapshots.allSatisfy { $0["consecutive_silent_turns"] as? Int == 0 })
   }
+
+  func testExpectedIdleTeardownUsesSeparateHealthEvent() throws {
+    DesktopDiagnosticsManager.shared.recordRealtimeProviderClose(
+      provider: "gemini",
+      category: RealtimeHubCloseCategory.expectedIdleTeardown.rawValue,
+      aliveFor: 180,
+      activeTurn: false,
+      authMode: .managed,
+      failureClass: nil)
+
+    let snapshot = try latestSnapshot()
+
+    XCTAssertEqual(snapshot["event"] as? String, "realtime_provider_expected_idle_teardown")
+    XCTAssertEqual(snapshot["provider"] as? String, "gemini")
+    XCTAssertEqual(snapshot["category"] as? String, "expected_idle_teardown")
+    XCTAssertEqual(snapshot["auth_mode"] as? String, "managed")
+    XCTAssertEqual(snapshot["active_turn"] as? Bool, false)
+  }
+
+  func testProviderCloseFallsBackToFailureClassInsteadOfUnclassified() throws {
+    DesktopDiagnosticsManager.shared.recordRealtimeProviderClose(
+      provider: "openai",
+      category: nil,
+      aliveFor: 7,
+      activeTurn: true,
+      authMode: .byok,
+      failureClass: .providerTransient(provider: .openai))
+
+    let snapshot = try latestSnapshot()
+
+    XCTAssertEqual(snapshot["event"] as? String, "realtime_provider_session_error")
+    XCTAssertEqual(snapshot["category"] as? String, "provider_transient")
+    XCTAssertEqual(snapshot["failure_class"] as? String, "provider_transient")
+    XCTAssertEqual(snapshot["auth_mode"] as? String, "byok")
+  }
+
+  func testTokenMintFailureIncludesHttpStatusWhenKnown() throws {
+    DesktopDiagnosticsManager.shared.recordRealtimeTokenMintFailed(
+      provider: "gemini",
+      reason: "backend_transient",
+      phase: "warm",
+      httpStatusCode: 503)
+
+    let snapshot = try latestSnapshot()
+
+    XCTAssertEqual(snapshot["event"] as? String, "realtime_token_mint_failed")
+    XCTAssertEqual(snapshot["provider"] as? String, "gemini")
+    XCTAssertEqual(snapshot["reason"] as? String, "backend_transient")
+    XCTAssertEqual(snapshot["phase"] as? String, "warm")
+    XCTAssertEqual(snapshot["http_status_code"] as? Int, 503)
+  }
+
+  private func latestSnapshot() throws -> [String: Any] {
+    let url = try XCTUnwrap(DesktopDiagnosticsManager.shared.writeDiagnosticsAttachment())
+    defer { try? FileManager.default.removeItem(at: url) }
+
+    let data = try Data(contentsOf: url)
+    let root = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+    let snapshots = try XCTUnwrap(root["snapshots"] as? [[String: Any]])
+    return try XCTUnwrap(snapshots.last)
+  }
 }

--- a/desktop/macos/changelog/unreleased/issue-8950-realtime-health.json
+++ b/desktop/macos/changelog/unreleased/issue-8950-realtime-health.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed Gemini realtime token minting and separated expected realtime idle closes from failure analytics."
+}


### PR DESCRIPTION
Closes #8950.

## Summary
- fix Gemini realtime ephemeral token minting by sending Google Live API's documented `authToken` request wrapper instead of top-level token fields
- move benign long-lived realtime idle teardown out of the failure-like `realtime_provider_session_error` bucket into `realtime_provider_expected_idle_teardown`
- add stable realtime diagnostics dimensions for auth mode, failure class, HTTP status, and barge-in replacement mint failures so the daily health report can separate actual provider/session failures from lifecycle noise
- add focused Swift and Rust regression coverage plus a desktop changelog fragment

## Recently merged coverage
- #8911 already addressed part of the broader July 3 Gemini picture by improving non-streaming Gemini proxy timeout observability and retryable timeout behavior.
- That did not cover this issue's realtime health stream or `/v2/realtime/session` Gemini ephemeral-token mint path, which are fixed here.

## Root cause
The Gemini realtime mint route posted `uses`, `expireTime`, and `newSessionExpireTime` at the top level. Google's current Live API `CreateAuthTokenRequest` requires those settings under `authToken`, so managed Gemini realtime users could fail before opening the provider session. Separately, expected Gemini idle closes were correctly classified locally but still emitted into the failure-like health event stream.

## Testing
- `git diff --check`
- `cargo test --manifest-path desktop/macos/Backend-Rust/Cargo.toml gemini_auth_token_body_wraps_settings_under_auth_token`
- `xcrun swift test --package-path desktop/macos/Desktop --filter 'DesktopDiagnosticsManagerTests|RealtimeHubCloseClassifierTests'`
- `scripts/pre-push`



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8953?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

