### PR TITLE
Fix desktop updater diagnostics

### DIFF
--- a/desktop/macos/Desktop/Sources/AnalyticsManager.swift
+++ b/desktop/macos/Desktop/Sources/AnalyticsManager.swift
@@ -663,12 +663,20 @@ class AnalyticsManager {
 
   // MARK: - Update Events
 
-  func updateAvailable(version: String) {
-    PostHogManager.shared.updateAvailable(version: version)
+  func updateAvailable(
+    version: String,
+    context: UpdateAnalyticsContext,
+    item: UpdateItemAnalytics
+  ) {
+    PostHogManager.shared.updateAvailable(version: version, context: context, item: item)
   }
 
-  func updateInstalled(version: String) {
-    PostHogManager.shared.updateInstalled(version: version)
+  func updateInstalled(
+    version: String,
+    context: UpdateAnalyticsContext,
+    item: UpdateItemAnalytics
+  ) {
+    PostHogManager.shared.updateInstalled(version: version, context: context, item: item)
   }
 
   func updateCheckFailed(diagnostics: UpdateFailureDiagnostics) {

--- a/desktop/macos/Desktop/Sources/PostHogManager.swift
+++ b/desktop/macos/Desktop/Sources/PostHogManager.swift
@@ -615,20 +615,27 @@ extension PostHogManager {
 
     // MARK: - Update Events
 
-    func updateAvailable(version: String) {
-        track("Update Available", properties: [
-            "version": version
-        ])
+    func updateAvailable(version: String, context: UpdateAnalyticsContext, item: UpdateItemAnalytics) {
+        track("Update Available", properties: updateProperties(version: version, context: context, item: item))
     }
 
-    func updateInstalled(version: String) {
-        track("Update Installed", properties: [
-            "version": version
-        ])
+    func updateInstalled(version: String, context: UpdateAnalyticsContext, item: UpdateItemAnalytics) {
+        track("Update Installed", properties: updateProperties(version: version, context: context, item: item))
     }
 
     func updateCheckFailed(diagnostics: UpdateFailureDiagnostics) {
         track("Update Check Failed", properties: diagnostics.analyticsProperties)
+    }
+
+    private func updateProperties(
+        version: String,
+        context: UpdateAnalyticsContext,
+        item: UpdateItemAnalytics
+    ) -> [String: Any] {
+        var properties = context.properties
+        properties.merge(item.properties) { _, new in new }
+        properties["version"] = version
+        return properties
     }
 
     // MARK: - Notification Events

--- a/desktop/macos/Desktop/Sources/UpdaterViewModel.swift
+++ b/desktop/macos/Desktop/Sources/UpdaterViewModel.swift
@@ -56,8 +56,17 @@ struct UpdateFailureDiagnostics: Equatable {
   let code: Int
   let underlyingDomain: String?
   let underlyingCode: Int?
+  let errorChainDomains: [String]
+  let errorChainCodes: [Int]
+  let nsurlErrorCode: Int?
+  let failingURLHost: String?
+  let failingURLPath: String?
   let updateChannel: String
   let launchLocationBucket: String
+  let sourceAppVersion: String
+  let sourceAppBuild: String
+  let appcastURLHost: String?
+  let appcastURLPath: String?
 
   var isRecoverableLaunchLocation: Bool {
     switch reason {
@@ -107,6 +116,10 @@ struct UpdateFailureDiagnostics: Equatable {
       "update_failure_code": code,
       "update_channel": updateChannel,
       "launch_location_bucket": launchLocationBucket,
+      "source_app_version": sourceAppVersion,
+      "source_app_build": sourceAppBuild,
+      "error_chain_domains": errorChainDomains,
+      "error_chain_codes": errorChainCodes,
     ]
 
     if let underlyingDomain {
@@ -115,6 +128,21 @@ struct UpdateFailureDiagnostics: Equatable {
     if let underlyingCode {
       properties["underlying_code"] = underlyingCode
     }
+    if let nsurlErrorCode {
+      properties["nsurl_error_code"] = nsurlErrorCode
+    }
+    if let failingURLHost {
+      properties["failing_url_host"] = failingURLHost
+    }
+    if let failingURLPath {
+      properties["failing_url_path"] = failingURLPath
+    }
+    if let appcastURLHost {
+      properties["appcast_url_host"] = appcastURLHost
+    }
+    if let appcastURLPath {
+      properties["appcast_url_path"] = appcastURLPath
+    }
 
     return properties
   }
@@ -122,16 +150,24 @@ struct UpdateFailureDiagnostics: Equatable {
   static func classify(
     error: NSError,
     updateChannel: String,
-    bundlePath: String = Bundle.main.bundlePath
+    bundlePath: String = Bundle.main.bundlePath,
+    sourceAppVersion: String = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
+      ?? "unknown",
+    sourceAppBuild: String = Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? "unknown",
+    appcastURL: URL? = Bundle.main.object(forInfoDictionaryKey: "SUFeedURL")
+      .flatMap({ ($0 as? String).flatMap(URL.init(string:)) })
   ) -> UpdateFailureDiagnostics {
     let underlying = error.userInfo[NSUnderlyingErrorKey] as? NSError
+    let chain = errorChain(from: error)
+    let nsurlError = chain.first { $0.domain == NSURLErrorDomain }
+    let failingURL = failingURL(in: chain)
     let message = error.localizedDescription
     let bucket = launchLocationBucket(for: bundlePath)
 
     return UpdateFailureDiagnostics(
       reason: reason(
         for: error,
-        underlying: underlying,
+        errorChain: chain,
         message: message.lowercased(),
         bucket: bucket
       ),
@@ -140,8 +176,17 @@ struct UpdateFailureDiagnostics: Equatable {
       code: error.code,
       underlyingDomain: underlying?.domain,
       underlyingCode: underlying?.code,
+      errorChainDomains: chain.map(\.domain),
+      errorChainCodes: chain.map(\.code),
+      nsurlErrorCode: nsurlError?.code,
+      failingURLHost: failingURL?.host,
+      failingURLPath: failingURL?.path,
       updateChannel: updateChannel,
-      launchLocationBucket: bucket
+      launchLocationBucket: bucket,
+      sourceAppVersion: sourceAppVersion,
+      sourceAppBuild: sourceAppBuild,
+      appcastURLHost: appcastURL?.host,
+      appcastURLPath: appcastURL?.path
     )
   }
 
@@ -171,7 +216,7 @@ struct UpdateFailureDiagnostics: Equatable {
 
   private static func reason(
     for error: NSError,
-    underlying: NSError?,
+    errorChain: [NSError],
     message: String,
     bucket: String
   ) -> UpdateFailureReason {
@@ -192,6 +237,9 @@ struct UpdateFailureDiagnostics: Equatable {
     if error.domain == SUSparkleErrorDomain && error.code == 4005 {
       return .installerLaunch
     }
+    if errorChain.contains(where: { $0.domain == NSURLErrorDomain }) {
+      return .network
+    }
     if message.contains("retrieving update information") || message.contains("appcast") {
       return .appcastRetrieval
     }
@@ -201,11 +249,98 @@ struct UpdateFailureDiagnostics: Equatable {
     if message.contains("signature") || message.contains("verify") || message.contains("ed25519") {
       return .signature
     }
-    if error.domain == NSURLErrorDomain || underlying?.domain == NSURLErrorDomain {
-      return .network
-    }
 
     return .unknown
+  }
+
+  private static func errorChain(from error: NSError) -> [NSError] {
+    var chain: [NSError] = []
+    var current: NSError? = error
+    var seen = Set<ObjectIdentifier>()
+
+    while let error = current {
+      let identifier = ObjectIdentifier(error)
+      guard !seen.contains(identifier) else { break }
+      seen.insert(identifier)
+      chain.append(error)
+      current = error.userInfo[NSUnderlyingErrorKey] as? NSError
+    }
+
+    return chain
+  }
+
+  private static func failingURL(in errorChain: [NSError]) -> URL? {
+    for error in errorChain {
+      if let url = error.userInfo[NSURLErrorFailingURLErrorKey] as? URL {
+        return url
+      }
+      if let urlString = error.userInfo[NSURLErrorFailingURLStringErrorKey] as? String,
+        let url = URL(string: urlString)
+      {
+        return url
+      }
+    }
+    return nil
+  }
+}
+
+struct UpdateAnalyticsContext {
+  let sourceAppVersion: String
+  let sourceAppBuild: String
+  let updateChannel: String
+  let appcastURLHost: String?
+  let appcastURLPath: String?
+
+  var properties: [String: Any] {
+    var properties: [String: Any] = [
+      "source_app_version": sourceAppVersion,
+      "source_app_build": sourceAppBuild,
+      "update_channel": updateChannel,
+    ]
+    if let appcastURLHost {
+      properties["appcast_url_host"] = appcastURLHost
+    }
+    if let appcastURLPath {
+      properties["appcast_url_path"] = appcastURLPath
+    }
+    return properties
+  }
+
+  static func current(updateChannel: String) -> UpdateAnalyticsContext {
+    let appcastURL = Bundle.main.object(forInfoDictionaryKey: "SUFeedURL")
+      .flatMap { ($0 as? String).flatMap(URL.init(string:)) }
+
+    return UpdateAnalyticsContext(
+      sourceAppVersion: Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString")
+        as? String ?? "unknown",
+      sourceAppBuild: Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String
+        ?? "unknown",
+      updateChannel: updateChannel,
+      appcastURLHost: appcastURL?.host,
+      appcastURLPath: appcastURL?.path
+    )
+  }
+}
+
+struct UpdateItemAnalytics {
+  let targetVersion: String
+  let targetBuild: String
+  let itemChannel: String
+
+  var properties: [String: Any] {
+    [
+      "target_version": targetVersion,
+      "target_build": targetBuild,
+      "item_channel": itemChannel,
+    ]
+  }
+
+  static func from(item: SUAppcastItem) -> UpdateItemAnalytics {
+    UpdateItemAnalytics(
+      targetVersion: item.displayVersionString,
+      targetBuild: item.versionString,
+      itemChannel: (item.channel?.isEmpty == false) ? item.channel! : "stable"
+    )
   }
 }
 
@@ -251,9 +386,17 @@ final class UpdaterDelegate: NSObject, SPUUpdaterDelegate {
   /// Called when Sparkle finds a valid update
   func updater(_ updater: SPUUpdater, didFindValidUpdate item: SUAppcastItem) {
     let version = item.displayVersionString
+    let context = UpdateAnalyticsContext.current(
+      updateChannel: UserDefaults.standard.string(forKey: kUpdateChannelKey) ?? "stable"
+    )
+    let itemAnalytics = UpdateItemAnalytics.from(item: item)
     logSync("Sparkle: Found update v\(version)")
     Task { @MainActor in
-      AnalyticsManager.shared.updateAvailable(version: version)
+      AnalyticsManager.shared.updateAvailable(
+        version: version,
+        context: context,
+        item: itemAnalytics
+      )
       self.viewModel?.updateAvailable = true
       self.viewModel?.availableVersion = version
       self.viewModel?.lastUpdateFailure = nil
@@ -366,6 +509,10 @@ final class UpdaterDelegate: NSObject, SPUUpdaterDelegate {
   /// Called when an update will be installed (app may terminate immediately after)
   func updater(_ updater: SPUUpdater, willInstallUpdate item: SUAppcastItem) {
     let version = item.displayVersionString
+    let context = UpdateAnalyticsContext.current(
+      updateChannel: UserDefaults.standard.string(forKey: kUpdateChannelKey) ?? "stable"
+    )
+    let itemAnalytics = UpdateItemAnalytics.from(item: item)
     logSync("Sparkle: Installing update v\(version)")
     let restoreMainWindow = AppDelegate.shouldRestoreMainWindowAfterUpdateRelaunch()
     UpdateRelaunchWindowPolicy.markPendingRelaunch(restoreMainWindow: restoreMainWindow)
@@ -373,7 +520,11 @@ final class UpdaterDelegate: NSObject, SPUUpdaterDelegate {
       "Sparkle: Next launch will \(restoreMainWindow ? "restore" : "suppress") the main window after update"
     )
     Task { @MainActor in
-      AnalyticsManager.shared.updateInstalled(version: version)
+      AnalyticsManager.shared.updateInstalled(
+        version: version,
+        context: context,
+        item: itemAnalytics
+      )
       self.viewModel?.updateAvailable = false
     }
   }

--- a/desktop/macos/Desktop/Tests/UpdateFailureDiagnosticsTests.swift
+++ b/desktop/macos/Desktop/Tests/UpdateFailureDiagnosticsTests.swift
@@ -108,6 +108,59 @@ final class UpdateFailureDiagnosticsTests: XCTestCase {
     XCTAssertEqual(diagnostics.underlyingCode, NSURLErrorTimedOut)
   }
 
+  func testClassifiesDeeplyWrappedSparkleDownloadFailureAsNetwork() {
+    let url = URL(string: "https://api.omi.me/v2/desktop/appcast.xml")!
+    let network = NSError(
+      domain: NSURLErrorDomain,
+      code: NSURLErrorTimedOut,
+      userInfo: [
+        NSURLErrorFailingURLErrorKey: url
+      ]
+    )
+    let innerSparkle = NSError(
+      domain: "SUSparkleErrorDomain",
+      code: 2001,
+      userInfo: [
+        NSLocalizedDescriptionKey: "An error occurred in retrieving update information.",
+        NSUnderlyingErrorKey: network,
+      ]
+    )
+    let outerSparkle = NSError(
+      domain: "SUSparkleErrorDomain",
+      code: 2001,
+      userInfo: [
+        NSLocalizedDescriptionKey: "An error occurred in retrieving update information.",
+        NSUnderlyingErrorKey: innerSparkle,
+      ]
+    )
+
+    let diagnostics = UpdateFailureDiagnostics.classify(
+      error: outerSparkle,
+      updateChannel: "stable",
+      bundlePath: "/Applications/Omi.app",
+      sourceAppVersion: "0.12.0",
+      sourceAppBuild: "12000",
+      appcastURL: url
+    )
+
+    XCTAssertEqual(diagnostics.reason, .network)
+    XCTAssertEqual(diagnostics.nsurlErrorCode, NSURLErrorTimedOut)
+    XCTAssertEqual(
+      diagnostics.errorChainDomains,
+      ["SUSparkleErrorDomain", "SUSparkleErrorDomain", NSURLErrorDomain]
+    )
+    XCTAssertEqual(diagnostics.errorChainCodes, [2001, 2001, NSURLErrorTimedOut])
+
+    let properties = diagnostics.analyticsProperties
+    XCTAssertEqual(properties["update_failure_reason"] as? String, "network")
+    XCTAssertEqual(properties["nsurl_error_code"] as? Int, NSURLErrorTimedOut)
+    XCTAssertEqual(properties["failing_url_host"] as? String, "api.omi.me")
+    XCTAssertEqual(properties["failing_url_path"] as? String, "/v2/desktop/appcast.xml")
+    XCTAssertEqual(properties["source_app_version"] as? String, "0.12.0")
+    XCTAssertEqual(properties["source_app_build"] as? String, "12000")
+    XCTAssertEqual(properties["appcast_url_host"] as? String, "api.omi.me")
+  }
+
   func testAnalyticsPropertiesOmitRawPath() {
     let error = NSError(
       domain: "SUSparkleErrorDomain",

--- a/desktop/macos/changelog/unreleased/issue-8941-updater-diagnostics.json
+++ b/desktop/macos/changelog/unreleased/issue-8941-updater-diagnostics.json
@@ -1,0 +1,3 @@
+{
+  "change": "Improved macOS updater failure diagnostics so nested Sparkle network errors are classified correctly."
+}


### PR DESCRIPTION
## Summary
- classify nested Sparkle-wrapped `NSURLErrorDomain` failures as network failures instead of generic appcast retrieval failures
- add source app version/build, appcast host/path, nested error chain, NSURL code, and failing URL host/path to `Update Check Failed` telemetry
- add target version/build and item channel metadata to `Update Available` and `Update Installed` events
- add a focused regression test and desktop changelog fragment

## Root cause
Sparkle wraps appcast retrieval/download failures in `SUSparkleErrorDomain` / `2001`, sometimes nesting another Sparkle wrapper before the real `NSURLErrorDomain`. The app classified by the top-level localized message before walking nested errors, so transient network failures from current clients were reported as `appcast_retrieval`. The available/installed analytics also only emitted `version`, which made source-vs-target release interpretation require person-level sequence inference.

Fixes #8941

## Validation
- `xcrun swift test --package-path desktop/macos/Desktop --filter UpdateFailureDiagnosticsTests`
- `cd desktop/macos && xcrun swift build -c debug --package-path Desktop`
- pre-push hook: desktop changelog validation, desktop Swift compile, and related fast checks passed

Notes: the Swift commands still emit existing unrelated warnings, including FluidAudio resource warning, libwebp macOS version linker warning, and existing Swift concurrency/deprecation warnings.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8954?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

