### PR TITLE
Fix macOS notification registration repair

### DIFF
--- a/desktop/macos/Desktop/Sources/AppState/AppState+Permissions.swift
+++ b/desktop/macos/Desktop/Sources/AppState/AppState+Permissions.swift
@@ -25,34 +25,11 @@ extension AppState {
 
         if settings.authorizationStatus == .notDetermined {
           // First time - show the system prompt
-          NSApp.activate()
-          UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound, .badge])
-          { [weak self] granted, error in
-            if let error = error {
-              let nsError = error as NSError
-              log(
-                "Notification permission error: \(error) (domain=\(nsError.domain) code=\(nsError.code))"
-              )
-
-              // UNErrorDomain code 1 = notificationsNotAllowed
-              // This happens when LaunchServices has the app marked as launch-disabled,
-              // which prevents the notification center from registering the app.
-              // Fix: unregister from LaunchServices and re-register to clear the flag, then retry.
-              if nsError.domain == "UNErrorDomain" && nsError.code == 1 {
-                DispatchQueue.main.async {
-                  AnalyticsManager.shared.notificationRepairTriggered(
-                    reason: "launch_disabled_error",
-                    previousStatus: "notDetermined",
-                    currentStatus: "error_code_1"
-                  )
-                  self?.repairNotificationRegistrationAndRetry()
-                }
-                return
-              }
-            }
-            DispatchQueue.main.async {
-              self?.checkNotificationPermission()
-            }
+          NotificationRegistrationRepair.requestAuthorizationRepairingLaunchServices(
+            reason: "launch_disabled_error",
+            previousStatus: "notDetermined"
+          ) { [weak self] _ in
+            self?.checkNotificationPermission()
           }
         } else if settings.authorizationStatus == .denied {
           // Previously denied - open System Settings so user can enable manually
@@ -67,11 +44,18 @@ extension AppState {
   /// The "launch-disabled" flag in LaunchServices prevents the notification center
   /// from registering the app. This unregisters and re-registers to clear the flag.
   func repairNotificationRegistrationAndRetry() {
-    // Use the shared repair utility (also used by ProactiveAssistantsPlugin)
-    ProactiveAssistantsPlugin.repairNotificationRegistration()
+    NotificationRegistrationRepair.repair(reason: "app_state_retry", includeUnregister: true) {
+      [weak self] _ in
+      NotificationRegistrationRepair.requestAuthorizationRepairingLaunchServices(
+        reason: "launch_disabled_error_retry",
+        previousStatus: "post_repair"
+      ) { [weak self] _ in
+        self?.checkNotificationPermission()
+      }
+    }
 
-    // After the repair + retry, update our permission state and open System Settings as fallback
-    DispatchQueue.main.asyncAfter(deadline: .now() + 3.0) { [weak self] in
+    // After the repair + retry, update our permission state and open System Settings as fallback.
+    DispatchQueue.main.asyncAfter(deadline: .now() + 5.0) { [weak self] in
       UNUserNotificationCenter.current().getNotificationSettings { settings in
         DispatchQueue.main.async {
           let isNowGranted = settings.authorizationStatus == .authorized
@@ -89,7 +73,15 @@ extension AppState {
   /// Called from sidebar and settings "Fix" buttons when auth is not authorized.
   func repairNotificationAndFallback() {
     log("Fix button tapped — running lsregister repair for notifications")
-    ProactiveAssistantsPlugin.repairNotificationRegistration()
+    NotificationRegistrationRepair.repair(reason: "settings_fix_button", includeUnregister: true) {
+      [weak self] _ in
+      NotificationRegistrationRepair.requestAuthorizationRepairingLaunchServices(
+        reason: "settings_fix_button_retry",
+        previousStatus: "post_repair"
+      ) { [weak self] _ in
+        self?.checkNotificationPermission()
+      }
+    }
 
     // Wait for repair + re-authorization, then check if it worked
     DispatchQueue.main.asyncAfter(deadline: .now() + 4.0) { [weak self] in

--- a/desktop/macos/Desktop/Sources/NotificationRegistrationRepair.swift
+++ b/desktop/macos/Desktop/Sources/NotificationRegistrationRepair.swift
@@ -116,10 +116,19 @@ enum NotificationRegistrationRepair {
       Thread.sleep(forTimeInterval: 1.5)
 
       DispatchQueue.main.async {
+        var finalSuccess = success
         if let cfURL = bundleURL as CFURL? {
-          LSRegisterURL(cfURL, true)
+          let registerStatus = LSRegisterURL(cfURL, true)
+          let registerSucceeded = registerStatus == noErr
+          finalSuccess = registerSucceeded && finalSuccess
+          if !registerSucceeded {
+            log("LSRegisterURL failed during notification registration repair: \(registerStatus)")
+          }
+        } else {
+          finalSuccess = false
+          log("LSRegisterURL skipped during notification registration repair: missing bundle URL")
         }
-        finishRepair(success: success)
+        finishRepair(success: finalSuccess)
       }
     }
   }

--- a/desktop/macos/Desktop/Sources/NotificationRegistrationRepair.swift
+++ b/desktop/macos/Desktop/Sources/NotificationRegistrationRepair.swift
@@ -1,0 +1,173 @@
+import Cocoa
+import UserNotifications
+
+enum NotificationRegistrationRepair {
+  static let repairedVersionKey = "notificationRegistrationRepairedAppVersion"
+
+  private static var isRepairing = false
+  private static var pendingCompletions: [(Bool) -> Void] = []
+
+  static func currentVersionIdentifier(bundle: Bundle = .main) -> String {
+    let version =
+      bundle.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "unknown"
+    let build = bundle.object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? "unknown"
+    return "\(version)+\(build)"
+  }
+
+  static func shouldRepairForCurrentVersion(
+    defaults: UserDefaults = .standard,
+    versionIdentifier: String = currentVersionIdentifier()
+  ) -> Bool {
+    defaults.string(forKey: repairedVersionKey) != versionIdentifier
+  }
+
+  static func markRepairedForCurrentVersion(
+    defaults: UserDefaults = .standard,
+    versionIdentifier: String = currentVersionIdentifier()
+  ) {
+    defaults.set(versionIdentifier, forKey: repairedVersionKey)
+  }
+
+  @MainActor
+  static func repairOnceForCurrentVersion(reason: String) {
+    let versionIdentifier = currentVersionIdentifier()
+    guard shouldRepairForCurrentVersion(versionIdentifier: versionIdentifier) else { return }
+
+    repair(reason: reason, includeUnregister: true) { success in
+      if success {
+        markRepairedForCurrentVersion(versionIdentifier: versionIdentifier)
+      }
+    }
+  }
+
+  @MainActor
+  static func requestAuthorizationRepairingLaunchServices(
+    reason: String,
+    previousStatus: String,
+    completion: ((Bool) -> Void)? = nil
+  ) {
+    NSApp.activate()
+    UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound, .badge]) {
+      granted, error in
+      if let error {
+        let nsError = error as NSError
+        log(
+          "Notification permission request error: \(error.localizedDescription) (domain=\(nsError.domain) code=\(nsError.code))"
+        )
+
+        if isLaunchDisabledNotificationError(nsError) {
+          DispatchQueue.main.async {
+            AnalyticsManager.shared.notificationRepairTriggered(
+              reason: reason,
+              previousStatus: previousStatus,
+              currentStatus: "error_code_1"
+            )
+            repair(reason: reason, includeUnregister: true) { _ in
+              retryAuthorizationAfterRepair(completion: completion)
+            }
+          }
+          return
+        }
+      }
+
+      DispatchQueue.main.async {
+        completion?(granted)
+      }
+    }
+  }
+
+  @MainActor
+  static func repair(
+    reason: String,
+    includeUnregister: Bool,
+    completion: ((Bool) -> Void)? = nil
+  ) {
+    if let completion {
+      pendingCompletions.append(completion)
+    }
+
+    guard !isRepairing else {
+      log("Notification registration repair already running; coalescing request (\(reason))")
+      return
+    }
+
+    isRepairing = true
+    let appPath = Bundle.main.bundlePath
+    let bundleURL = Bundle.main.bundleURL
+    log("Repairing notification registration via LaunchServices: \(appPath) reason=\(reason)")
+
+    DispatchQueue.global(qos: .utility).async {
+      let lsregister =
+        "/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister"
+      var success = true
+
+      if includeUnregister {
+        success = runProcess(lsregister, arguments: ["-u", appPath]) && success
+      }
+      success = runProcess(lsregister, arguments: ["-f", appPath]) && success
+
+      let restartedUsernoted = runProcess("/usr/bin/killall", arguments: ["usernoted"])
+      let restartedNotificationCenter = runProcess(
+        "/usr/bin/killall", arguments: ["NotificationCenter"])
+      log(
+        "Notification registration repair finished: lsregisterSuccess=\(success), usernotedRestarted=\(restartedUsernoted), notificationCenterRestarted=\(restartedNotificationCenter)"
+      )
+
+      Thread.sleep(forTimeInterval: 1.5)
+
+      DispatchQueue.main.async {
+        if let cfURL = bundleURL as CFURL? {
+          LSRegisterURL(cfURL, true)
+        }
+        finishRepair(success: success)
+      }
+    }
+  }
+
+  @MainActor
+  private static func finishRepair(success: Bool) {
+    let callbacks = pendingCompletions
+    pendingCompletions.removeAll()
+    isRepairing = false
+    callbacks.forEach { $0(success) }
+  }
+
+  private static func retryAuthorizationAfterRepair(completion: ((Bool) -> Void)?) {
+    DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+      NSApp.activate()
+      UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound, .badge]) {
+        granted, error in
+        if let error {
+          log("Notification retry after registration repair failed: \(error.localizedDescription)")
+        } else if granted {
+          log("Notification permission granted after registration repair")
+        }
+
+        DispatchQueue.main.async {
+          completion?(granted)
+        }
+      }
+    }
+  }
+
+  private static func isLaunchDisabledNotificationError(_ error: NSError) -> Bool {
+    error.domain == "UNErrorDomain" && error.code == 1
+  }
+
+  private static func runProcess(_ executablePath: String, arguments: [String]) -> Bool {
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: executablePath)
+    process.arguments = arguments
+    process.standardOutput = FileHandle.nullDevice
+    process.standardError = FileHandle.nullDevice
+
+    do {
+      try process.run()
+      process.waitUntilExit()
+      return process.terminationStatus == 0
+    } catch {
+      logError("Notification registration repair command failed: \(executablePath)", error: error)
+      return false
+    }
+  }
+}

--- a/desktop/macos/Desktop/Sources/OmiApp.swift
+++ b/desktop/macos/Desktop/Sources/OmiApp.swift
@@ -325,6 +325,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     // Initialize NotificationService early to set up UNUserNotificationCenterDelegate
     // This ensures notifications display properly when app is in foreground
     _ = NotificationService.shared
+    NotificationRegistrationRepair.repairOnceForCurrentVersion(reason: "startup_version_registration")
 
     // Initialize Sparkle auto-updater early so the 10-minute check timer starts at launch
     // Without this, the updater only starts when the user opens Settings or clicks "Check for Updates"

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift
@@ -284,7 +284,12 @@ public class ProactiveAssistantsPlugin: NSObject {
     /// The launch-disabled flag in LaunchServices prevents notification center registration.
     /// Unregistering and re-registering clears the flag, then retries authorization.
     static func repairNotificationRegistration() {
-        NotificationRegistrationRepair.repair(reason: "legacy_call_site", includeUnregister: true)
+        NotificationRegistrationRepair.repair(reason: "legacy_call_site", includeUnregister: true) { _ in
+            NotificationRegistrationRepair.requestAuthorizationRepairingLaunchServices(
+                reason: "legacy_call_site_retry",
+                previousStatus: "post_repair"
+            ) { _ in }
+        }
     }
 
     private func continueStartMonitoring(completion: @escaping (Bool, String?) -> Void) {

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift
@@ -256,29 +256,22 @@ public class ProactiveAssistantsPlugin: NSObject {
             return
         }
 
-        // Request notification permission in parallel — don't block monitoring on it.
-        // Screen analysis can work without notifications - users just won't get alerts.
-        UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound, .badge]) { granted, error in
+        // Request notification permission in parallel, but only for first-time users.
+        // Denied users should not be put through repeated startup repair loops.
+        UNUserNotificationCenter.current().getNotificationSettings { settings in
             DispatchQueue.main.async {
-                if let error = error {
-                    let nsError = error as NSError
-                    log("Notification permission request error: \(error.localizedDescription) (domain=\(nsError.domain) code=\(nsError.code))")
-
-                    // UNErrorDomain code 1 = notificationsNotAllowed
-                    // This happens when LaunchServices has the app marked as launch-disabled,
-                    // preventing notification center registration. Repair and retry once.
-                    if nsError.domain == "UNErrorDomain" && nsError.code == 1 {
-                        AnalyticsManager.shared.notificationRepairTriggered(
-                            reason: "launch_disabled_error_startup",
-                            previousStatus: "notDetermined",
-                            currentStatus: "error_code_1"
-                        )
-                        Self.repairNotificationRegistration()
-                    }
+                guard settings.authorizationStatus == .notDetermined else {
+                    log("Skipping startup notification authorization request (auth=\(settings.authorizationStatus.rawValue))")
+                    return
                 }
 
-                if !granted {
-                    log("Notification permission not granted - screen analysis will work but notifications will be disabled")
+                NotificationRegistrationRepair.requestAuthorizationRepairingLaunchServices(
+                    reason: "launch_disabled_error_startup",
+                    previousStatus: "notDetermined"
+                ) { granted in
+                    if !granted {
+                        log("Notification permission not granted - screen analysis will work but notifications will be disabled")
+                    }
                 }
             }
         }
@@ -291,63 +284,7 @@ public class ProactiveAssistantsPlugin: NSObject {
     /// The launch-disabled flag in LaunchServices prevents notification center registration.
     /// Unregistering and re-registering clears the flag, then retries authorization.
     static func repairNotificationRegistration() {
-        let appPath = Bundle.main.bundlePath
-        let bundleURL = Bundle.main.bundleURL
-        log("Repairing LaunchServices registration for notifications: \(appPath)")
-
-        let lsregister = "/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister"
-
-        // Run blocking Process calls on a background thread
-        DispatchQueue.global(qos: .utility).async {
-            // Unregister to clear stale/launch-disabled entries
-            let unregister = Process()
-            unregister.executableURL = URL(fileURLWithPath: lsregister)
-            unregister.arguments = ["-u", appPath]
-            try? unregister.run()
-            unregister.waitUntilExit()
-
-            // Force re-register
-            let register = Process()
-            register.executableURL = URL(fileURLWithPath: lsregister)
-            register.arguments = ["-f", appPath]
-            try? register.run()
-            register.waitUntilExit()
-
-            // Restart usernoted (notification center daemon) to pick up fresh registration
-            // Runs as current user (no sudo needed), auto-restarts within ~1 second
-            let killUsernoted = Process()
-            killUsernoted.executableURL = URL(fileURLWithPath: "/usr/bin/killall")
-            killUsernoted.arguments = ["usernoted"]
-            killUsernoted.standardOutput = FileHandle.nullDevice
-            killUsernoted.standardError = FileHandle.nullDevice
-            try? killUsernoted.run()
-            killUsernoted.waitUntilExit()
-            log("Restarted usernoted to force notification re-discovery")
-
-            // Wait for usernoted to restart before retrying
-            Thread.sleep(forTimeInterval: 1.5)
-
-            DispatchQueue.main.async {
-                // Also re-register via LSRegisterURL (must be on main thread)
-                if let cfURL = bundleURL as CFURL? {
-                    LSRegisterURL(cfURL, true)
-                }
-
-                log("LaunchServices re-registration complete, retrying notification authorization...")
-
-                // Retry authorization after a short delay
-                DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
-                    NSApp.activate()
-                    UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound, .badge]) { granted, error in
-                        if let error = error {
-                            log("Notification retry after repair failed: \(error.localizedDescription)")
-                        } else if granted {
-                            log("Notification permission granted after LaunchServices repair")
-                        }
-                    }
-                }
-            }
-        }
+        NotificationRegistrationRepair.repair(reason: "legacy_call_site", includeUnregister: true)
     }
 
     private func continueStartMonitoring(completion: @escaping (Bool, String?) -> Void) {

--- a/desktop/macos/Desktop/Tests/NotificationRegistrationRepairTests.swift
+++ b/desktop/macos/Desktop/Tests/NotificationRegistrationRepairTests.swift
@@ -1,0 +1,35 @@
+import XCTest
+
+@testable import Omi_Computer
+
+final class NotificationRegistrationRepairTests: XCTestCase {
+  func testVersionRepairRunsOnlyOncePerInstalledVersion() {
+    let defaults = UserDefaults(suiteName: "NotificationRegistrationRepairTests")!
+    defaults.removePersistentDomain(forName: "NotificationRegistrationRepairTests")
+
+    XCTAssertTrue(
+      NotificationRegistrationRepair.shouldRepairForCurrentVersion(
+        defaults: defaults,
+        versionIdentifier: "0.12.0+12000"
+      )
+    )
+
+    NotificationRegistrationRepair.markRepairedForCurrentVersion(
+      defaults: defaults,
+      versionIdentifier: "0.12.0+12000"
+    )
+
+    XCTAssertFalse(
+      NotificationRegistrationRepair.shouldRepairForCurrentVersion(
+        defaults: defaults,
+        versionIdentifier: "0.12.0+12000"
+      )
+    )
+    XCTAssertTrue(
+      NotificationRegistrationRepair.shouldRepairForCurrentVersion(
+        defaults: defaults,
+        versionIdentifier: "0.12.1+12001"
+      )
+    )
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260703-fix-notification-registration.json
+++ b/desktop/macos/changelog/unreleased/20260703-fix-notification-registration.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed macOS notification permission registration after app updates"
+}


### PR DESCRIPTION
## Summary
- root cause: the desktop startup monitoring path directly requested notification authorization, so LaunchServices `UNErrorDomain` code 1 failures only triggered a reactive, incomplete repair and could repeat on later starts
- add a shared notification registration repair helper that unregisters/re-registers the app, restarts both `usernoted` and `NotificationCenter`, coalesces concurrent repairs, and retries authorization where appropriate
- proactively repair LaunchServices once per installed app version at startup without inflating the existing `Notification Repair Triggered` metric
- skip startup notification authorization for users who already denied notifications, so monitoring does not keep producing repair loops
- add a desktop changelog fragment and a focused unit test for the one-per-version repair guard

Fixes #4831

## Verification
- `xcrun swift build -c debug --package-path Desktop`
- `xcrun swift test --package-path Desktop --filter NotificationRegistrationRepairTests`
- `git push` pre-push checks passed, including desktop changelog validation and desktop Swift build

## Notes
- I attempted a named-bundle smoke run with `OMI_APP_NAME="omi-notification-registration" ./run.sh --yolo`, but this machine has no valid Apple Development signing identity (`security find-identity -v -p codesigning` reports 0 identities). The run script intentionally refused ad-hoc signing because it can reset Screen Recording permissions for Omi apps.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8955?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

