### PR TITLE
[codex] Split desktop recording analytics

### DIFF
--- a/desktop/macos/Desktop/Sources/AnalyticsManager.swift
+++ b/desktop/macos/Desktop/Sources/AnalyticsManager.swift
@@ -161,6 +161,28 @@ class AnalyticsManager {
     )
   }
 
+  func conversationReconciliationFailed(
+    error: String,
+    reason: String,
+    source: String?,
+    stage: String?,
+    retryCount: Int,
+    hasBackendId: Bool,
+    hasClientConversationId: Bool,
+    segmentCount: Int?
+  ) {
+    PostHogManager.shared.conversationReconciliationFailed(
+      error: error,
+      reason: reason,
+      source: source,
+      stage: stage,
+      retryCount: retryCount,
+      hasBackendId: hasBackendId,
+      hasClientConversationId: hasClientConversationId,
+      segmentCount: segmentCount
+    )
+  }
+
   // MARK: - Permission Events
 
   func permissionRequested(permission: String, extraProperties: [String: Any] = [:]) {

--- a/desktop/macos/Desktop/Sources/ConversationFinalizationService.swift
+++ b/desktop/macos/Desktop/Sources/ConversationFinalizationService.swift
@@ -395,12 +395,16 @@ actor ConversationFinalizationService {
       let session = try await TranscriptionStorage.shared.getSession(id: sessionId)
       let retryCount = (session?.retryCount ?? 0) + 1
       if retryCount >= maxRetries {
-        await AnalyticsManager.shared.recordingError(
+        let segmentCount = try? await TranscriptionStorage.shared.getSegmentCount(sessionId: sessionId)
+        await AnalyticsManager.shared.conversationReconciliationFailed(
           error: "session_reconciliation_failed",
           reason: "cloud_reconcile_exhausted",
           source: session?.source,
           stage: session?.finalizationStrategy?.rawValue,
-          retryCount: retryCount
+          retryCount: retryCount,
+          hasBackendId: session?.backendId?.isEmpty == false,
+          hasClientConversationId: session?.clientConversationId?.isEmpty == false,
+          segmentCount: segmentCount
         )
       }
       try await TranscriptionStorage.shared.incrementRetryCount(id: sessionId)

--- a/desktop/macos/Desktop/Sources/PostHogManager.swift
+++ b/desktop/macos/Desktop/Sources/PostHogManager.swift
@@ -230,11 +230,14 @@ extension PostHogManager {
     // MARK: - Recording Events
 
     func transcriptionStarted() {
-        track("Phone Mic Recording Started")
+        track("Desktop Recording Started", properties: [
+            "platform": "macos"
+        ])
     }
 
     func transcriptionStopped(wordCount: Int) {
-        track("Phone Mic Recording Stopped", properties: [
+        track("Desktop Recording Stopped", properties: [
+            "platform": "macos",
             "word_count": wordCount
         ])
     }
@@ -246,7 +249,10 @@ extension PostHogManager {
         stage: String? = nil,
         retryCount: Int? = nil
     ) {
-        var properties: [String: Any] = ["error": error]
+        var properties: [String: Any] = [
+            "platform": "macos",
+            "error": error
+        ]
         if let reason {
             properties["recording_error_reason"] = reason
         }
@@ -259,7 +265,38 @@ extension PostHogManager {
         if let retryCount {
             properties["retry_count"] = retryCount
         }
-        track("Phone Mic Recording Error", properties: properties)
+        track("Desktop Recording Error", properties: properties)
+    }
+
+    func conversationReconciliationFailed(
+        error: String,
+        reason: String,
+        source: String?,
+        stage: String?,
+        retryCount: Int,
+        hasBackendId: Bool,
+        hasClientConversationId: Bool,
+        segmentCount: Int?
+    ) {
+        var properties: [String: Any] = [
+            "platform": "macos",
+            "error": error,
+            "recording_error_reason": reason,
+            "retry_count": retryCount,
+            "has_backend_id": hasBackendId,
+            "has_client_conversation_id": hasClientConversationId
+        ]
+        if let source {
+            properties["recording_source"] = source
+        }
+        if let stage {
+            properties["recording_stage"] = stage
+        }
+        if let segmentCount {
+            properties["segment_count"] = segmentCount
+            properties["has_local_segments"] = segmentCount > 0
+        }
+        track("Desktop Conversation Reconciliation Failed", properties: properties)
     }
 
     // MARK: - Permission Events

--- a/desktop/macos/changelog/unreleased/20260703-desktop-recording-analytics-split.json
+++ b/desktop/macos/changelog/unreleased/20260703-desktop-recording-analytics-split.json
@@ -1,0 +1,5 @@
+{
+  "changes": [
+    "Split desktop recording and reconciliation failures into dedicated PostHog events so phone mic reports no longer include desktop finalization errors"
+  ]
+}


### PR DESCRIPTION
## Summary
- move macOS recording analytics off the misleading `Phone Mic Recording *` PostHog events
- add a dedicated `Desktop Conversation Reconciliation Failed` event for cloud reconciliation exhaustion
- include platform, source, stage, retry count, backend/client-id presence, and local segment count for future diagnosis

## Why
The production evidence on #5249 is dominated by macOS build numbers and reconciliation signatures, but those failures were still grouped under `Phone Mic Recording Error`. Splitting the desktop events keeps future phone-mic reports clean and gives desktop reconciliation its own diagnostic surface.

Closes #5249

## Validation
- `GITHUB_TOKEN=$(gh auth token) xcrun swift test --package-path Desktop --filter 'StopReconciliationTests|TranscriptionFinalizationStateMachineTests'`
- `xcrun swift build -c debug --package-path Desktop`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8957?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

