### PR TITLE
Harden Developer API conversation reads (#8713)

### DIFF
--- a/backend/dependencies.py
+++ b/backend/dependencies.py
@@ -1,12 +1,13 @@
 from typing import List, Optional
 
-from fastapi import Depends, HTTPException, Security
+from fastapi import Depends, HTTPException, Request, Security
 from fastapi.security import APIKeyHeader, HTTPAuthorizationCredentials, HTTPBearer
 from firebase_admin import auth
 
 import database.mcp_api_key as mcp_api_key_db
 import database.dev_api_key as dev_api_key_db
 from utils.scopes import Scopes, has_scope
+from utils.log_sanitizer import sanitize
 from utils.memory.product_authorization import ProductAuthorizationContext
 from utils.mcp_memories import (
     McpVerifiedAuth,
@@ -184,24 +185,88 @@ async def get_uid_from_dev_api_key(api_key: str = Security(api_key_header)) -> s
 
 
 # Scope-specific dependencies
-async def get_auth_with_conversations_read(auth: ApiKeyAuth = Depends(get_api_key_auth)) -> ApiKeyAuth:
+def _log_dev_api_rate_limit_failure(
+    *,
+    request: Optional[Request],
+    auth: ApiKeyAuth,
+    policy_name: str,
+    status_code: int,
+):
+    if request is None:
+        return
+    logger.warning(
+        "developer_api_rate_limit_failure policy=%s status=%s path=%s uid=%s app_id=%s key_id=%s remote_ip=%s user_agent=%s",
+        policy_name,
+        status_code,
+        request.url.path,
+        auth.uid,
+        auth.app_id or 'unknown_app',
+        auth.key_id or 'unknown_key',
+        request.client.host if request.client else None,
+        sanitize(request.headers.get('user-agent')),
+    )
+
+
+def _check_dev_api_key_rate_limit(
+    *,
+    request: Optional[Request],
+    auth: ApiKeyAuth,
+    policy_name: str,
+):
+    try:
+        check_api_key_rate_limit(
+            prefix="dev",
+            uid=auth.uid,
+            app_id=auth.app_id,
+            key_id=auth.key_id,
+            policy_name=policy_name,
+        )
+    except HTTPException as exc:
+        _log_dev_api_rate_limit_failure(
+            request=request,
+            auth=auth,
+            policy_name=policy_name,
+            status_code=exc.status_code,
+        )
+        raise
+
+
+def _require_conversations_read_scope(auth: ApiKeyAuth):
     if not has_scope(auth.scopes, Scopes.CONVERSATIONS_READ):
         raise HTTPException(
             status_code=403, detail=f"Insufficient permissions. Required scope: {Scopes.CONVERSATIONS_READ}"
         )
-    check_api_key_rate_limit(
-        prefix="dev",
-        uid=auth.uid,
-        app_id=auth.app_id,
-        key_id=auth.key_id,
-        policy_name="dev:conversations_read",
-    )
+
+
+async def get_auth_with_conversations_read(
+    auth: ApiKeyAuth = Depends(get_api_key_auth),
+    request: Request = None,
+) -> ApiKeyAuth:
+    _require_conversations_read_scope(auth)
+    _check_dev_api_key_rate_limit(request=request, auth=auth, policy_name="dev:conversations_read")
+    return auth
+
+
+async def get_auth_with_conversation_detail_read(
+    auth: ApiKeyAuth = Depends(get_api_key_auth),
+    request: Request = None,
+) -> ApiKeyAuth:
+    _require_conversations_read_scope(auth)
+    _check_dev_api_key_rate_limit(request=request, auth=auth, policy_name="dev:conversation_detail_read")
     return auth
 
 
 async def get_uid_with_conversations_read(auth: ApiKeyAuth = Depends(get_api_key_auth)) -> str:
     await get_auth_with_conversations_read(auth)
     return auth.uid
+
+
+def check_conversation_transcript_read_limit(
+    auth: ApiKeyAuth,
+    request: Optional[Request] = None,
+):
+    _require_conversations_read_scope(auth)
+    _check_dev_api_key_rate_limit(request=request, auth=auth, policy_name="dev:conversation_transcript_read")
 
 
 async def get_auth_with_conversations_write(auth: ApiKeyAuth = Depends(get_api_key_auth)) -> ApiKeyAuth:

--- a/backend/dependencies.py
+++ b/backend/dependencies.py
@@ -192,18 +192,19 @@ def _log_dev_api_rate_limit_failure(
     policy_name: str,
     status_code: int,
 ):
-    if request is None:
-        return
+    path = request.url.path if request else 'unknown_path'
+    remote_ip = request.client.host if request and request.client else None
+    user_agent = sanitize(request.headers.get('user-agent')) if request else None
     logger.warning(
         "developer_api_rate_limit_failure policy=%s status=%s path=%s uid=%s app_id=%s key_id=%s remote_ip=%s user_agent=%s",
         policy_name,
         status_code,
-        request.url.path,
+        path,
         auth.uid,
         auth.app_id or 'unknown_app',
         auth.key_id or 'unknown_key',
-        request.client.host if request.client else None,
-        sanitize(request.headers.get('user-agent')),
+        remote_ip,
+        user_agent,
     )
 
 

--- a/backend/routers/developer.py
+++ b/backend/routers/developer.py
@@ -37,7 +37,11 @@ from utils.conversations.render import populate_speaker_names, populate_folder_n
 from utils.dev_cache import invalidate_developer_cache
 from models.transcript_segment import TranscriptSegment
 from dependencies import (
+    ApiKeyAuth,
+    check_conversation_transcript_read_limit,
     get_current_user_id,
+    get_auth_with_conversation_detail_read,
+    get_auth_with_conversations_read,
     get_uid_with_conversations_read,
     get_uid_with_conversations_write,
     get_developer_memory_default_memory_batch_write_context,
@@ -49,6 +53,7 @@ from dependencies import (
     get_uid_with_goals_write,
 )
 from utils.apps import update_personas_async
+from utils.log_sanitizer import sanitize
 from utils.other.endpoints import with_rate_limit, get_current_user_uid
 from models.dev_api_key import DevApiKey, DevApiKeyCreate, DevApiKeyCreated
 from utils.scopes import AVAILABLE_SCOPES, validate_scopes
@@ -85,6 +90,46 @@ router = APIRouter()
 FROM_SEGMENTS_CLAIM_STALE_AFTER = timedelta(minutes=15)
 
 _FROM_SEGMENTS_CONVERSATION_NAMESPACE = uuid.UUID('fb2f1f36-3c84-47a4-9c62-b3f6fdb3fd13')
+
+
+def _developer_request_ip(request: Request) -> Optional[str]:
+    client = getattr(request, 'client', None)
+    if not client:
+        return None
+    return client.host
+
+
+def _audit_developer_read(
+    *,
+    request: Optional[Request],
+    auth: ApiKeyAuth,
+    operation: str,
+    status: int,
+    limit: Optional[int] = None,
+    offset: Optional[int] = None,
+    include_transcript: Optional[bool] = None,
+    returned_count: Optional[int] = None,
+    resource_id: Optional[str] = None,
+):
+    if request is None or not hasattr(request, 'url') or not hasattr(request, 'headers'):
+        return
+    logger.info(
+        "developer_api_read operation=%s path=%s status=%s uid=%s app_id=%s key_id=%s remote_ip=%s "
+        "user_agent=%s limit=%s offset=%s include_transcript=%s returned_count=%s resource_id=%s",
+        operation,
+        request.url.path,
+        status,
+        auth.uid,
+        auth.app_id or 'unknown_app',
+        auth.key_id or 'unknown_key',
+        _developer_request_ip(request),
+        sanitize(request.headers.get('user-agent')),
+        limit,
+        offset,
+        include_transcript,
+        returned_count,
+        sanitize(resource_id) if resource_id else None,
+    )
 
 
 # ******************************************************
@@ -1299,7 +1344,8 @@ def get_conversations(
     include_transcript: bool = False,
     folder_id: Optional[str] = Query(default=None, min_length=1),
     starred: Optional[bool] = None,
-    uid: str = Depends(get_uid_with_conversations_read),
+    uid: ApiKeyAuth = Depends(get_auth_with_conversations_read),
+    request: Request = None,
 ):
     """
     Get conversations with optional transcript inclusion.
@@ -1308,57 +1354,83 @@ def get_conversations(
     - **folder_id**: Filter by folder ID (must be a non-empty string if provided)
     - **starred**: Filter by starred status (true/false)
     """
-    # Clamp pagination so a negative value cannot reach Firestore (which raises -> HTTP 500) and an
-    # oversized limit cannot stream the whole collection. Mirrors the GET /v3/memories hardening.
-    offset = max(0, offset)
-    limit = max(1, min(limit, 25 if include_transcript else 100))
+    auth = uid
+    uid = auth.uid
+    status = 500
+    returned_count = None
     try:
-        category_list = [CategoryEnum(c.strip()) for c in categories.split(",") if c.strip()] if categories else []
-    except ValueError as e:
-        raise HTTPException(status_code=400, detail=f"Invalid category {str(e)}")
+        if include_transcript:
+            check_conversation_transcript_read_limit(auth, request=request)
 
-    conversations = conversations_db.get_conversations(
-        uid,
-        limit,
-        offset,
-        include_discarded=False,
-        statuses=["completed"],
-        start_date=start_date,
-        end_date=end_date,
-        categories=[c.value for c in category_list],
-        folder_id=folder_id,
-        starred=starred,
-    )
-
-    # Filter out locked conversations completely
-    unlocked_conversations = [conv for conv in conversations if not conv.get('is_locked', False)]
-
-    # Remove transcript_segments if not requested
-    if not include_transcript:
-        for conv in unlocked_conversations:
-            conv.pop('transcript_segments', None)
-    else:
-        populate_speaker_names(uid, unlocked_conversations)
-
-    populate_folder_names(uid, unlocked_conversations)
-
-    # Validate each record individually so a single malformed/legacy doc doesn't fail the whole page
-    # with a 500. Mirrors the hardening already applied to GET /v1/dev/user/memories.
-    valid_conversations = []
-    for conv in unlocked_conversations:
-        if not isinstance(conv, dict) or not conv.get('id'):
-            logger.warning('Skipping malformed conversation in Developer API conversation list')
-            continue
+        # Clamp pagination so a negative value cannot reach Firestore (which raises -> HTTP 500) and an
+        # oversized limit cannot stream the whole collection. Mirrors the GET /v3/memories hardening.
+        offset = max(0, offset)
+        limit = max(1, min(limit, 25 if include_transcript else 100))
         try:
-            valid_conversations.append(Conversation.model_validate(conv))
-        except ValidationError as e:
-            invalid_fields = [err['loc'][0] for err in e.errors() if err.get('loc')]
-            logger.warning(
-                f"Skipping invalid conversation doc {conv.get('id', 'unknown')} for uid {uid}: "
-                f"missing/invalid fields {invalid_fields}"
-            )
-            continue
-    return valid_conversations
+            category_list = [CategoryEnum(c.strip()) for c in categories.split(",") if c.strip()] if categories else []
+        except ValueError as e:
+            status = 400
+            raise HTTPException(status_code=400, detail=f"Invalid category {str(e)}")
+
+        conversations = conversations_db.get_conversations(
+            uid,
+            limit,
+            offset,
+            include_discarded=False,
+            statuses=["completed"],
+            start_date=start_date,
+            end_date=end_date,
+            categories=[c.value for c in category_list],
+            folder_id=folder_id,
+            starred=starred,
+        )
+
+        # Filter out locked conversations completely
+        unlocked_conversations = [conv for conv in conversations if not conv.get('is_locked', False)]
+
+        # Remove transcript_segments if not requested
+        if not include_transcript:
+            for conv in unlocked_conversations:
+                conv.pop('transcript_segments', None)
+        else:
+            populate_speaker_names(uid, unlocked_conversations)
+
+        populate_folder_names(uid, unlocked_conversations)
+
+        # Validate each record individually so a single malformed/legacy doc doesn't fail the whole page
+        # with a 500. Mirrors the hardening already applied to GET /v1/dev/user/memories.
+        valid_conversations = []
+        for conv in unlocked_conversations:
+            if not isinstance(conv, dict) or not conv.get('id'):
+                logger.warning('Skipping malformed conversation in Developer API conversation list')
+                continue
+            try:
+                valid_conversations.append(Conversation.model_validate(conv))
+            except ValidationError as e:
+                invalid_fields = [err['loc'][0] for err in e.errors() if err.get('loc')]
+                logger.warning(
+                    f"Skipping invalid conversation doc {conv.get('id', 'unknown')} for uid {uid}: "
+                    f"missing/invalid fields {invalid_fields}"
+                )
+                continue
+        status = 200
+        returned_count = len(valid_conversations)
+        return valid_conversations
+    except HTTPException as e:
+        status = e.status_code
+        returned_count = 0 if returned_count is None else returned_count
+        raise
+    finally:
+        _audit_developer_read(
+            request=request,
+            auth=auth,
+            operation='list_conversations',
+            status=status,
+            limit=limit,
+            offset=offset,
+            include_transcript=include_transcript,
+            returned_count=returned_count,
+        )
 
 
 @router.post(
@@ -1453,7 +1525,8 @@ def create_conversation(
 def get_conversation_endpoint(
     conversation_id: str,
     include_transcript: bool = False,
-    uid: str = Depends(get_uid_with_conversations_read),
+    uid: ApiKeyAuth = Depends(get_auth_with_conversation_detail_read),
+    request: Request = None,
 ):
     """
     Get a single conversation by ID.
@@ -1461,23 +1534,51 @@ def get_conversation_endpoint(
     - **conversation_id**: The ID of the conversation to retrieve
     - **include_transcript**: If True, includes full transcript_segments in the response
     """
-    conversation = conversations_db.get_conversation(uid, conversation_id)
-    if not conversation:
-        raise HTTPException(status_code=404, detail="Conversation not found")
+    auth = uid
+    uid = auth.uid
+    status = 500
+    returned_count = None
+    try:
+        if include_transcript:
+            check_conversation_transcript_read_limit(auth, request=request)
 
-    # Filter out locked conversations
-    if conversation.get('is_locked', False):
-        raise HTTPException(status_code=404, detail="Conversation not found")
+        conversation = conversations_db.get_conversation(uid, conversation_id)
+        if not conversation:
+            status = 404
+            returned_count = 0
+            raise HTTPException(status_code=404, detail="Conversation not found")
 
-    # Remove transcript_segments if not requested
-    if not include_transcript:
-        conversation.pop('transcript_segments', None)
-    else:
-        populate_speaker_names(uid, [conversation])
+        # Filter out locked conversations
+        if conversation.get('is_locked', False):
+            status = 404
+            returned_count = 0
+            raise HTTPException(status_code=404, detail="Conversation not found")
 
-    populate_folder_names(uid, [conversation])
+        # Remove transcript_segments if not requested
+        if not include_transcript:
+            conversation.pop('transcript_segments', None)
+        else:
+            populate_speaker_names(uid, [conversation])
 
-    return conversation
+        populate_folder_names(uid, [conversation])
+
+        status = 200
+        returned_count = 1
+        return conversation
+    except HTTPException as e:
+        status = e.status_code
+        returned_count = 0 if returned_count is None else returned_count
+        raise
+    finally:
+        _audit_developer_read(
+            request=request,
+            auth=auth,
+            operation='get_conversation',
+            status=status,
+            include_transcript=include_transcript,
+            returned_count=returned_count,
+            resource_id=conversation_id,
+        )
 
 
 def _from_segments_conversation_id(uid: str, client_session_id: str) -> str:

--- a/backend/tests/unit/test_dev_api_conversations_poison.py
+++ b/backend/tests/unit/test_dev_api_conversations_poison.py
@@ -151,10 +151,19 @@ from fastapi import FastAPI  # noqa: E402
 from fastapi.testclient import TestClient  # noqa: E402
 import routers.developer as developer_module  # noqa: E402
 from routers.developer import router as developer_router  # noqa: E402
-from dependencies import get_uid_with_conversations_read  # noqa: E402
+from dependencies import ApiKeyAuth, get_auth_with_conversations_read  # noqa: E402
 
 _NOW = datetime(2026, 1, 1, tzinfo=timezone.utc)
 _VALID_CATEGORY = next(iter(CategoryEnum)).value
+
+
+def _read_auth():
+    return ApiKeyAuth(
+        uid='uid1',
+        scopes=['conversations:read'],
+        app_id='test-app',
+        key_id='test-key',
+    )
 
 
 def _valid(cid):
@@ -170,7 +179,7 @@ def _valid(cid):
 def _build():
     app = FastAPI()
     app.include_router(developer_router)
-    app.dependency_overrides[get_uid_with_conversations_read] = lambda: 'uid1'
+    app.dependency_overrides[get_auth_with_conversations_read] = _read_auth
     return TestClient(app, raise_server_exceptions=False)
 
 
@@ -190,13 +199,13 @@ def test_pagination_is_clamped_before_firestore():
     # Out-of-range pagination is clamped before the Firestore query: a negative offset/limit
     # would otherwise raise (HTTP 500) and an oversized/zero limit would stream the whole
     # collection. Call the handler directly (the TestClient async path is flaky on Windows; the
-    # clamp is what matters). get_conversations(uid, limit, offset, ...) is positional.
+    # clamp is what matters).
     with patch.object(conversations_db, 'get_conversations', return_value=[]) as m, patch.object(
         developer_module, 'populate_folder_names', lambda *a, **k: None
     ), patch.object(developer_module, 'populate_speaker_names', lambda *a, **k: None):
-        developer_module.get_conversations(uid='uid1', limit=99999, offset=-1)
-        developer_module.get_conversations(uid='uid1', limit=99999, offset=0, include_transcript=True)
-        developer_module.get_conversations(uid='uid1', limit=0, offset=5)
+        developer_module.get_conversations(uid=_read_auth(), limit=99999, offset=-1)
+        developer_module.get_conversations(uid=_read_auth(), limit=99999, offset=0, include_transcript=True)
+        developer_module.get_conversations(uid=_read_auth(), limit=0, offset=5)
     high = m.call_args_list[0].args
     assert high[1] == 100 and high[2] == 0  # limit 99999 -> 100, offset -1 -> 0
     assert m.call_args_list[1].args[1] == 25  # transcript reads cap tighter

--- a/backend/tests/unit/test_dev_api_folder_filters.py
+++ b/backend/tests/unit/test_dev_api_folder_filters.py
@@ -99,6 +99,7 @@ _mock_populate_speaker_names = MagicMock()
 
 import database.conversations as conversations_db
 import database.folders as folders_db
+from dependencies import ApiKeyAuth, get_api_key_auth, get_auth_with_conversations_read, get_uid_with_conversations_read
 
 _mock_get_conversations = MagicMock(return_value=[])
 conversations_db.get_conversations = _mock_get_conversations
@@ -113,8 +114,6 @@ folders_db.initialize_system_folders = _mock_initialize_system_folders
 
 
 def _read_auth():
-    from dependencies import ApiKeyAuth
-
     return ApiKeyAuth(
         uid='uid1',
         scopes=['conversations:read'],
@@ -366,7 +365,6 @@ def _build_test_app():
     from fastapi import FastAPI
     from fastapi.testclient import TestClient
     from routers.developer import router as developer_router
-    from dependencies import get_auth_with_conversations_read, get_uid_with_conversations_read
 
     app = FastAPI()
     app.include_router(developer_router)
@@ -463,7 +461,6 @@ class TestDevApiHttpLayer:
         from fastapi import FastAPI
         from fastapi.testclient import TestClient
         from routers.developer import router as developer_router
-        from dependencies import get_api_key_auth, ApiKeyAuth
 
         app = FastAPI()
         app.include_router(developer_router)
@@ -484,7 +481,6 @@ class TestDevApiHttpLayer:
         from fastapi import FastAPI
         from fastapi.testclient import TestClient
         from routers.developer import router as developer_router
-        from dependencies import get_api_key_auth, ApiKeyAuth
 
         app = FastAPI()
         app.include_router(developer_router)

--- a/backend/tests/unit/test_dev_api_folder_filters.py
+++ b/backend/tests/unit/test_dev_api_folder_filters.py
@@ -112,6 +112,17 @@ folders_db.initialize_system_folders = _mock_initialize_system_folders
 # ---- Helper factories ----
 
 
+def _read_auth():
+    from dependencies import ApiKeyAuth
+
+    return ApiKeyAuth(
+        uid='uid1',
+        scopes=['conversations:read'],
+        app_id='test-app',
+        key_id='test-key',
+    )
+
+
 def _make_folder(folder_id='f1', name='Work'):
     now = datetime(2025, 1, 15, 10, 0, 0, tzinfo=timezone.utc)
     return {
@@ -230,7 +241,7 @@ class TestDevGetConversationsFolderFilters:
         from routers.developer import get_conversations
 
         get_conversations(
-            uid='uid1',
+            uid=_read_auth(),
             folder_id='f1',
             starred=None,
         )
@@ -244,7 +255,7 @@ class TestDevGetConversationsFolderFilters:
         from routers.developer import get_conversations
 
         get_conversations(
-            uid='uid1',
+            uid=_read_auth(),
             folder_id=None,
             starred=True,
         )
@@ -258,7 +269,7 @@ class TestDevGetConversationsFolderFilters:
         from routers.developer import get_conversations
 
         get_conversations(
-            uid='uid1',
+            uid=_read_auth(),
             folder_id=None,
             starred=False,
         )
@@ -272,7 +283,7 @@ class TestDevGetConversationsFolderFilters:
         from routers.developer import get_conversations
 
         get_conversations(
-            uid='uid1',
+            uid=_read_auth(),
             folder_id='f1',
             starred=True,
         )
@@ -303,7 +314,7 @@ class TestDevGetConversationsFolderFilters:
         end = datetime(2025, 1, 31, tzinfo=timezone.utc)
 
         get_conversations(
-            uid='uid1',
+            uid=_read_auth(),
             start_date=start,
             end_date=end,
             categories='work,personal',
@@ -340,7 +351,7 @@ class TestDevGetConversationsFolderFilters:
 
         from routers.developer import get_conversations
 
-        result = get_conversations(uid='uid1', folder_id='nonexistent-folder')
+        result = get_conversations(uid=_read_auth(), folder_id='nonexistent-folder')
 
         assert result == []
 
@@ -355,11 +366,12 @@ def _build_test_app():
     from fastapi import FastAPI
     from fastapi.testclient import TestClient
     from routers.developer import router as developer_router
-    from dependencies import get_uid_with_conversations_read
+    from dependencies import get_auth_with_conversations_read, get_uid_with_conversations_read
 
     app = FastAPI()
     app.include_router(developer_router)
     app.dependency_overrides[get_uid_with_conversations_read] = lambda: 'uid1'
+    app.dependency_overrides[get_auth_with_conversations_read] = _read_auth
     return app, TestClient(app)
 
 

--- a/backend/tests/unit/test_rate_limiting.py
+++ b/backend/tests/unit/test_rate_limiting.py
@@ -532,11 +532,36 @@ class TestRouterWiring(unittest.TestCase):
         self.assertIn("auth.app_id or 'unknown_app'", developer_source)
         self.assertIn("auth.key_id or 'unknown_key'", developer_source)
         self.assertIn("sanitize(request.headers.get('user-agent'))", developer_source)
-        self.assertIn("sanitize(request.headers.get('user-agent'))", dependencies_source)
         self.assertNotIn("request.headers.get('Authorization'", developer_source)
         self.assertNotIn('request.headers.get("Authorization"', developer_source)
         self.assertNotIn("request.headers.get('Authorization'", dependencies_source)
         self.assertNotIn('request.headers.get("Authorization"', dependencies_source)
+
+    def test_developer_rate_limit_failures_log_without_request(self):
+        dependencies = importlib.import_module("dependencies")
+        auth = dependencies.ApiKeyAuth(
+            uid="uid1",
+            scopes=["conversations:read"],
+            app_id="test-app",
+            key_id="test-key",
+        )
+
+        with patch.object(
+            dependencies,
+            "check_api_key_rate_limit",
+            side_effect=HTTPException(status_code=429, detail="Rate limit exceeded"),
+        ):
+            with self.assertLogs("dependencies", level="WARNING") as logs:
+                with self.assertRaises(HTTPException):
+                    dependencies.check_conversation_transcript_read_limit(auth)
+
+        log_output = "\n".join(logs.output)
+        self.assertIn("developer_api_rate_limit_failure policy=dev:conversation_transcript_read", log_output)
+        self.assertIn("path=unknown_path", log_output)
+        self.assertIn("uid=uid1", log_output)
+        self.assertIn("app_id=test-app", log_output)
+        self.assertIn("key_id=test-key", log_output)
+        self.assertNotIn("Authorization", log_output)
 
     def test_developer_read_routes_do_not_add_duplicate_uid_wrappers(self):
         developer_source = open("routers/developer.py", encoding='utf-8').read()

--- a/backend/tests/unit/test_rate_limiting.py
+++ b/backend/tests/unit/test_rate_limiting.py
@@ -438,6 +438,8 @@ class TestRouterPolicyMapping(unittest.TestCase):
             "goals:extract",
             "dev:conversations",
             "dev:conversations_read",
+            "dev:conversation_detail_read",
+            "dev:conversation_transcript_read",
             "dev:action_items_read",
             "dev:action_items_write",
             "dev:goals_read",
@@ -505,9 +507,43 @@ class TestRouterWiring(unittest.TestCase):
             "dev:memories_read",
             "dev:action_items_read",
             "dev:conversations_read",
+            "dev:conversation_detail_read",
+            "dev:conversation_transcript_read",
             "dev:goals_read",
         ]:
             self.assertIn(policy, source)
+
+    def test_developer_conversation_reads_split_detail_and_transcript_policies(self):
+        dependencies_source = open("dependencies.py", encoding='utf-8').read()
+        developer_source = open("routers/developer.py", encoding='utf-8').read()
+
+        self.assertIn('policy_name="dev:conversation_detail_read"', dependencies_source)
+        self.assertIn('policy_name="dev:conversation_transcript_read"', dependencies_source)
+        self.assertIn("get_auth_with_conversations_read", developer_source)
+        self.assertIn("get_auth_with_conversation_detail_read", developer_source)
+        self.assertIn("check_conversation_transcript_read_limit(auth, request=request)", developer_source)
+
+    def test_developer_conversation_reads_emit_sanitized_audit_logs(self):
+        developer_source = open("routers/developer.py", encoding='utf-8').read()
+        dependencies_source = open("dependencies.py", encoding='utf-8').read()
+
+        self.assertIn("developer_api_read operation=%s", developer_source)
+        self.assertIn("developer_api_rate_limit_failure policy=%s", dependencies_source)
+        self.assertIn("auth.app_id or 'unknown_app'", developer_source)
+        self.assertIn("auth.key_id or 'unknown_key'", developer_source)
+        self.assertIn("sanitize(request.headers.get('user-agent'))", developer_source)
+        self.assertIn("sanitize(request.headers.get('user-agent'))", dependencies_source)
+        self.assertNotIn("request.headers.get('Authorization'", developer_source)
+        self.assertNotIn('request.headers.get("Authorization"', developer_source)
+        self.assertNotIn("request.headers.get('Authorization'", dependencies_source)
+        self.assertNotIn('request.headers.get("Authorization"', dependencies_source)
+
+    def test_developer_read_routes_do_not_add_duplicate_uid_wrappers(self):
+        developer_source = open("routers/developer.py", encoding='utf-8').read()
+
+        self.assertNotIn('with_rate_limit(get_uid_with_conversations_read, "dev:conversations_read")', developer_source)
+        self.assertNotIn('with_rate_limit(get_uid_with_action_items_read, "dev:action_items_read")', developer_source)
+        self.assertNotIn('with_rate_limit(get_uid_with_goals_read, "dev:goals_read")', developer_source)
 
     def test_goals_router_has_rate_limits(self):
         matches = self._grep_file("routers/goals.py", r"with_rate_limit.*goals:")

--- a/backend/utils/rate_limit_config.py
+++ b/backend/utils/rate_limit_config.py
@@ -102,6 +102,8 @@ RATE_POLICIES: dict[str, tuple[int, int]] = {
     "dev:memories_read": (120, 3600),
     "dev:action_items_read": (120, 3600),
     "dev:conversations_read": (60, 3600),
+    "dev:conversation_detail_read": (60, 3600),
+    "dev:conversation_transcript_read": (25, 3600),
     "dev:goals_read": (120, 3600),
     "dev:conversations": (25, 3600),
     "dev:memories": (120, 3600),


### PR DESCRIPTION
## Summary
- Supersedes #8743 and #8923 with one consolidated implementation for #8713
- Keeps Developer API read enforcement keyed by app/key identity instead of adding duplicate UID route wrappers
- Adds separate conversation detail and transcript read policies, plus sanitized audit metadata for list/detail reads and rate-limit failures
- Preserves `ApiKeyAuth` in conversation read routes and updates the affected tests

## Credit
- Incorporates/cherry-picks work from #8743 by @RatnamOjha and #8923 by @ZachL111
- Commit trailers preserve the source commits and co-authorship

## Tests
- `cd backend && PYTHON=.venv/bin/python bash test-preflight.sh`
- `cd backend && PYTHON=.venv/bin/python .venv/bin/python -m pytest tests/unit/test_rate_limiting.py tests/unit/test_dev_api_conversations_poison.py tests/unit/test_dev_api_folder_filters.py -q`
- `cd backend && PYTHON=.venv/bin/python .venv/bin/python scripts/check_module_stub_pollution.py`
- `cd backend && PYTHON=.venv/bin/python .venv/bin/python scripts/scan_import_time_side_effects.py`
- `cd backend && PYTHON=.venv/bin/python .venv/bin/python scripts/scan_async_blockers.py`
- `cd backend && PATH="$PWD/.venv/bin:$PATH" bash test.sh`

Supersedes #8743.
Supersedes #8923.
Addresses #8713.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8958?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

