### PR TITLE
Improve Calendar and X sync telemetry

### DIFF
--- a/backend/.env.template
+++ b/backend/.env.template
@@ -28,6 +28,10 @@ MODULATE_API_KEY=
 ADMIN_KEY=
 OPENAI_API_KEY=
 
+# Optional backend PostHog sink for provider sync/auth telemetry.
+POSTHOG_PROJECT_API_KEY=
+POSTHOG_HOST=https://app.posthog.com
+
 # ElevenLabs TTS (used by /v2/tts/synthesize to speak Omi responses on mobile)
 ELEVENLABS_API_KEY=
 

--- a/backend/deploy/runtime_env.yaml
+++ b/backend/deploy/runtime_env.yaml
@@ -93,6 +93,9 @@ environments:
             OMI_LLM_GATEWAY_DEV_SHADOW_ALL_SAMPLE_RATE:
               value: "1.0"
               category: rollout
+            POSTHOG_HOST:
+              value: https://app.posthog.com
+              category: telemetry
             MEMORY_MODE:
               value: write
               category: memory_rollout
@@ -120,6 +123,9 @@ environments:
               version: latest
             OMI_LLM_GATEWAY_SERVICE_TOKEN:
               secret: OMI_LLM_GATEWAY_SERVICE_TOKEN
+              version: latest
+            POSTHOG_PROJECT_API_KEY:
+              secret: POSTHOG_PROJECT_API_KEY
               version: latest
         backend-sync:
           env:
@@ -149,6 +155,9 @@ environments:
             OMI_LLM_GATEWAY_DEV_SHADOW_ALL_SAMPLE_RATE:
               value: "1.0"
               category: rollout
+            POSTHOG_HOST:
+              value: https://app.posthog.com
+              category: telemetry
             MEMORY_MODE:
               value: write
               category: memory_rollout
@@ -176,6 +185,9 @@ environments:
               version: latest
             OMI_LLM_GATEWAY_SERVICE_TOKEN:
               secret: OMI_LLM_GATEWAY_SERVICE_TOKEN
+              version: latest
+            POSTHOG_PROJECT_API_KEY:
+              secret: POSTHOG_PROJECT_API_KEY
               version: latest
         backend-integration:
           env:
@@ -205,6 +217,9 @@ environments:
             OMI_LLM_GATEWAY_DEV_SHADOW_ALL_SAMPLE_RATE:
               value: "1.0"
               category: rollout
+            POSTHOG_HOST:
+              value: https://app.posthog.com
+              category: telemetry
             MEMORY_MODE:
               value: write
               category: memory_rollout
@@ -232,6 +247,9 @@ environments:
               version: latest
             OMI_LLM_GATEWAY_SERVICE_TOKEN:
               secret: OMI_LLM_GATEWAY_SERVICE_TOKEN
+              version: latest
+            POSTHOG_PROJECT_API_KEY:
+              secret: POSTHOG_PROJECT_API_KEY
               version: latest
 
   prod:
@@ -294,6 +312,9 @@ environments:
               env_var: OMI_LLM_GATEWAY_URL
               category: service_discovery
               provisional: true
+            POSTHOG_HOST:
+              value: https://app.posthog.com
+              category: telemetry
             MEMORY_MODE:
               value: "off"
               category: memory_rollout
@@ -321,6 +342,9 @@ environments:
               version: latest
             OMI_LLM_GATEWAY_SERVICE_TOKEN:
               secret: OMI_LLM_GATEWAY_SERVICE_TOKEN
+              version: latest
+            POSTHOG_PROJECT_API_KEY:
+              secret: POSTHOG_PROJECT_API_KEY
               version: latest
         backend-sync:
           env:
@@ -331,6 +355,9 @@ environments:
               env_var: OMI_LLM_GATEWAY_URL
               category: service_discovery
               provisional: true
+            POSTHOG_HOST:
+              value: https://app.posthog.com
+              category: telemetry
             MEMORY_MODE:
               value: "off"
               category: memory_rollout
@@ -358,6 +385,9 @@ environments:
               version: latest
             OMI_LLM_GATEWAY_SERVICE_TOKEN:
               secret: OMI_LLM_GATEWAY_SERVICE_TOKEN
+              version: latest
+            POSTHOG_PROJECT_API_KEY:
+              secret: POSTHOG_PROJECT_API_KEY
               version: latest
         backend-integration:
           env:
@@ -368,6 +398,9 @@ environments:
               env_var: OMI_LLM_GATEWAY_URL
               category: service_discovery
               provisional: true
+            POSTHOG_HOST:
+              value: https://app.posthog.com
+              category: telemetry
             MEMORY_MODE:
               value: "off"
               category: memory_rollout
@@ -395,4 +428,7 @@ environments:
               version: latest
             OMI_LLM_GATEWAY_SERVICE_TOKEN:
               secret: OMI_LLM_GATEWAY_SERVICE_TOKEN
+              version: latest
+            POSTHOG_PROJECT_API_KEY:
+              secret: POSTHOG_PROJECT_API_KEY
               version: latest

--- a/backend/routers/google_calendar.py
+++ b/backend/routers/google_calendar.py
@@ -7,12 +7,19 @@ Provides endpoints for listing Google Calendar events for the event picker UI.
 from datetime import datetime, timezone
 from typing import List, Optional
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, Header, HTTPException, Query
 from pydantic import BaseModel, Field
 
 import database.users as users_db
 from models.conversation import CalendarEventLink
 from utils.conversations.calendar_utils import extract_attendees, parse_event_times
+from utils.integration_telemetry import (
+    GOOGLE_CALENDAR,
+    IntegrationTelemetryContext,
+    emit_sync_attempted,
+    emit_sync_failed,
+    emit_sync_succeeded,
+)
 from utils.other import endpoints as auth
 from utils.retrieval.tools.calendar_tools import get_google_calendar_events
 from utils.retrieval.tools.google_utils import refresh_google_token
@@ -76,6 +83,9 @@ async def list_google_calendar_events(
     time_max: Optional[datetime] = Query(None, description="Maximum time for events (ISO format)"),
     q: Optional[str] = Query(None, description="Search query to filter events"),
     max_results: int = Query(20, ge=1, le=100, description="Maximum number of events to return"),
+    x_app_platform: Optional[str] = Header(None, alias='X-App-Platform'),
+    x_app_version: Optional[str] = Header(None, alias='X-App-Version'),
+    x_app_build: Optional[str] = Header(None, alias='X-App-Build'),
     uid: str = Depends(auth.get_current_user_uid),
 ):
     """List Google Calendar events within a time range.
@@ -83,6 +93,15 @@ async def list_google_calendar_events(
     Used by the event picker UI when manually linking a conversation to a calendar event.
     """
     access_token, integration = _get_google_calendar_token(uid)
+    telemetry_context = IntegrationTelemetryContext(
+        integration_name=GOOGLE_CALENDAR,
+        operation='fetch_events',
+        uid=uid,
+        app_platform=x_app_platform,
+        app_version=x_app_version,
+        app_build=x_app_build,
+    )
+    emit_sync_attempted(telemetry_context)
 
     if time_min and time_min.tzinfo is None:
         time_min = time_min.replace(tzinfo=timezone.utc)
@@ -111,10 +130,15 @@ async def list_google_calendar_events(
                         search_query=q,
                     )
                 except Exception as retry_error:
+                    emit_sync_failed(telemetry_context, retry_error)
                     raise HTTPException(status_code=500, detail=f"Failed after token refresh: {str(retry_error)}")
             else:
+                emit_sync_failed(telemetry_context, e)
                 raise HTTPException(status_code=401, detail="Google Calendar authentication expired. Please reconnect.")
         else:
+            emit_sync_failed(telemetry_context, e)
             raise HTTPException(status_code=500, detail=f"Failed to fetch calendar events: {error_msg}")
 
-    return [converted for event in events if (converted := _event_to_response(event))]
+    converted_events = [converted for event in events if (converted := _event_to_response(event))]
+    emit_sync_succeeded(telemetry_context, item_count=len(converted_events))
+    return converted_events

--- a/backend/tests/unit/test_backend_runtime_env_validator.py
+++ b/backend/tests/unit/test_backend_runtime_env_validator.py
@@ -31,6 +31,8 @@ def with_memory_env(payload: str) -> str:
         {"name": "OMI_LLM_GATEWAY_CONVERSATION_ACTION_ITEMS_SHADOW_SAMPLE_RATE", "value": "1.0"},
         {"name": "OMI_LLM_GATEWAY_DEV_SHADOW_ALL_ENABLED", "value": "true"},
         {"name": "OMI_LLM_GATEWAY_DEV_SHADOW_ALL_SAMPLE_RATE", "value": "1.0"},
+        {"name": "POSTHOG_HOST", "value": "https://app.posthog.com"},
+        {"name": "POSTHOG_PROJECT_API_KEY", "valueFrom": {"secretKeyRef": {"name": "POSTHOG_PROJECT_API_KEY", "key": "latest"}}},
         {"name": "MEMORY_MODE", "value": "write"},
         {"name": "MEMORY_ENABLED_USERS", "value": "vi7SA9ckQCe4ccobWNxlbdcNdC23"},
         {"name": "MEMORY_V3_GET_ENABLED", "value": "false"},

--- a/backend/tests/unit/test_backend_runtime_env_validator.py
+++ b/backend/tests/unit/test_backend_runtime_env_validator.py
@@ -32,6 +32,8 @@ def with_memory_env(payload: str) -> str:
         {"name": "OMI_LLM_GATEWAY_DEV_SHADOW_ALL_ENABLED", "value": "true"},
         {"name": "OMI_LLM_GATEWAY_DEV_SHADOW_ALL_SAMPLE_RATE", "value": "1.0"},
         {"name": "POSTHOG_HOST", "value": "https://app.posthog.com"},
+        {"name": "GOOGLE_CLIENT_ID", "valueFrom": {"secretKeyRef": {"name": "GOOGLE_CLIENT_ID", "key": "latest"}}},
+        {"name": "GOOGLE_CLIENT_SECRET", "valueFrom": {"secretKeyRef": {"name": "GOOGLE_CLIENT_SECRET", "key": "latest"}}},
         {"name": "POSTHOG_PROJECT_API_KEY", "valueFrom": {"secretKeyRef": {"name": "POSTHOG_PROJECT_API_KEY", "key": "latest"}}},
         {"name": "MEMORY_MODE", "value": "write"},
         {"name": "MEMORY_ENABLED_USERS", "value": "vi7SA9ckQCe4ccobWNxlbdcNdC23"},

--- a/backend/tests/unit/test_calendar_timezone.py
+++ b/backend/tests/unit/test_calendar_timezone.py
@@ -65,6 +65,7 @@ for _name in [
     "utils",
     "utils.executors",
     "utils.http_client",
+    "utils.integration_telemetry",
     "utils.log_sanitizer",
     "utils.retrieval",
     "utils.retrieval.tools",

--- a/backend/tests/unit/test_integration_sync_telemetry.py
+++ b/backend/tests/unit/test_integration_sync_telemetry.py
@@ -1,0 +1,116 @@
+import ast
+from pathlib import Path
+
+import httpx
+from utils.integration_telemetry import (
+    GOOGLE_CALENDAR,
+    X,
+    IntegrationTelemetryContext,
+    emit_sync_failed,
+    emit_sync_succeeded,
+    set_posthog_client_for_tests,
+)
+
+BACKEND_DIR = Path(__file__).resolve().parents[2]
+
+
+class FakePosthog:
+    def __init__(self):
+        self.calls = []
+
+    def capture(self, *, distinct_id, event, properties):
+        self.calls.append({'distinct_id': distinct_id, 'event': event, 'properties': properties})
+
+
+def _function_calls(path: str, function_name: str) -> set[str]:
+    tree = ast.parse((BACKEND_DIR / path).read_text())
+    for node in tree.body:
+        if isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef)) and node.name == function_name:
+            return {
+                call.func.id
+                for call in ast.walk(node)
+                if isinstance(call, ast.Call) and isinstance(call.func, ast.Name)
+            }
+    raise AssertionError(f'{function_name} not found in {path}')
+
+
+def test_sync_success_telemetry_emits_bounded_posthog_payload(monkeypatch):
+    fake = FakePosthog()
+    set_posthog_client_for_tests(fake)
+    monkeypatch.setenv('OMI_ENV_STAGE', 'test')
+
+    emit_sync_succeeded(
+        IntegrationTelemetryContext(
+            integration_name=GOOGLE_CALENDAR,
+            operation='fetch_events',
+            uid='uid-123',
+            app_platform='macos',
+            app_version='1.2.3',
+            app_build='456',
+        ),
+        item_count=27,
+    )
+
+    assert fake.calls == [
+        {
+            'distinct_id': 'uid-123',
+            'event': 'Integration Sync Succeeded',
+            'properties': {
+                'integration_name': 'Google Calendar',
+                'provider': 'Google Calendar',
+                'operation': 'fetch_events',
+                'status': 'succeeded',
+                'error_bucket': 'none',
+                'provider_status_code': None,
+                'retryable': False,
+                'environment': 'test',
+                'app_platform': 'macos',
+                'app_version': '1.2.3',
+                'app_build': '456',
+                'item_count': '11_100',
+            },
+        }
+    ]
+    set_posthog_client_for_tests(None)
+
+
+def test_sync_failure_telemetry_buckets_provider_errors_without_raw_body():
+    fake = FakePosthog()
+    set_posthog_client_for_tests(fake)
+    request = httpx.Request('GET', 'https://api.x.com/2/users/me')
+    response = httpx.Response(429, request=request, text='raw token abc123456789 and private body')
+    error = httpx.HTTPStatusError('429 Too Many Requests raw token abc123456789', request=request, response=response)
+
+    emit_sync_failed(
+        IntegrationTelemetryContext(integration_name=X, operation='fetch_tweets', uid='uid-456'),
+        error,
+    )
+
+    props = fake.calls[0]['properties']
+    assert fake.calls[0]['event'] == 'Integration Sync Failed'
+    assert props['integration_name'] == 'X'
+    assert props['operation'] == 'fetch_tweets'
+    assert props['error_bucket'] == 'rate_limited'
+    assert props['provider_status_code'] == 429
+    assert props['retryable'] is True
+    assert 'raw token' not in str(props)
+    set_posthog_client_for_tests(None)
+
+
+def test_x_connector_sync_paths_keep_success_and_failure_telemetry_probe():
+    calls = _function_calls('utils/x_connector.py', 'sync_x_for_user')
+
+    assert 'emit_sync_attempted' in calls
+    assert 'emit_sync_succeeded' in calls
+    assert 'emit_sync_failed' in calls
+
+
+def test_calendar_sync_paths_keep_success_and_failure_telemetry_probe():
+    route_calls = _function_calls('routers/google_calendar.py', 'list_google_calendar_events')
+    auto_link_calls = _function_calls('utils/conversations/calendar_linking.py', 'get_overlapping_calendar_event')
+    tool_calls = _function_calls('utils/retrieval/tools/calendar_tools.py', 'get_calendar_events_tool')
+
+    for calls in (route_calls, auto_link_calls, tool_calls):
+        assert 'emit_sync_attempted' in calls
+        assert 'emit_sync_succeeded' in calls
+        assert 'emit_sync_failed' in calls

--- a/backend/tests/unit/test_integration_sync_telemetry.py
+++ b/backend/tests/unit/test_integration_sync_telemetry.py
@@ -2,6 +2,7 @@ import ast
 from pathlib import Path
 
 import httpx
+import pytest
 from utils.integration_telemetry import (
     GOOGLE_CALENDAR,
     X,
@@ -20,6 +21,13 @@ class FakePosthog:
 
     def capture(self, *, distinct_id, event, properties):
         self.calls.append({'distinct_id': distinct_id, 'event': event, 'properties': properties})
+
+
+@pytest.fixture(autouse=True)
+def reset_posthog_client():
+    set_posthog_client_for_tests(None)
+    yield
+    set_posthog_client_for_tests(None)
 
 
 def _function_calls(path: str, function_name: str) -> set[str]:
@@ -71,7 +79,6 @@ def test_sync_success_telemetry_emits_bounded_posthog_payload(monkeypatch):
             },
         }
     ]
-    set_posthog_client_for_tests(None)
 
 
 def test_sync_failure_telemetry_buckets_provider_errors_without_raw_body():
@@ -94,7 +101,23 @@ def test_sync_failure_telemetry_buckets_provider_errors_without_raw_body():
     assert props['provider_status_code'] == 429
     assert props['retryable'] is True
     assert 'raw token' not in str(props)
-    set_posthog_client_for_tests(None)
+
+
+def test_failure_telemetry_ignores_non_integer_status_codes():
+    fake = FakePosthog()
+    set_posthog_client_for_tests(fake)
+
+    class WeirdProviderError(Exception):
+        status_code = 'not-a-status'
+
+    emit_sync_failed(
+        IntegrationTelemetryContext(integration_name=X, operation='fetch_tweets', uid='uid-789'),
+        WeirdProviderError('provider failed'),
+    )
+
+    props = fake.calls[0]['properties']
+    assert props['provider_status_code'] is None
+    assert props['error_bucket'] == 'unknown'
 
 
 def test_x_connector_sync_paths_keep_success_and_failure_telemetry_probe():

--- a/backend/utils/conversations/calendar_linking.py
+++ b/backend/utils/conversations/calendar_linking.py
@@ -18,6 +18,13 @@ from utils.retrieval.tools.calendar_tools import (
 )
 from utils.retrieval.tools.google_utils import refresh_google_token
 from utils.executors import run_blocking, db_executor
+from utils.integration_telemetry import (
+    GOOGLE_CALENDAR,
+    IntegrationTelemetryContext,
+    emit_sync_attempted,
+    emit_sync_failed,
+    emit_sync_succeeded,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -59,6 +66,12 @@ async def get_overlapping_calendar_event(
 
     search_start = conversation_start - timedelta(minutes=30)
     search_end = conversation_end + timedelta(minutes=30)
+    telemetry_context = IntegrationTelemetryContext(
+        integration_name=GOOGLE_CALENDAR,
+        operation='fetch_events_for_auto_link',
+        uid=uid,
+    )
+    emit_sync_attempted(telemetry_context)
 
     try:
         events = await get_google_calendar_events(
@@ -79,12 +92,16 @@ async def get_overlapping_calendar_event(
                         time_max=search_end,
                         max_results=20,
                     )
-                except Exception:
+                except Exception as retry_error:
+                    emit_sync_failed(telemetry_context, retry_error)
                     return None
             else:
+                emit_sync_failed(telemetry_context, e)
                 return None
         else:
+            emit_sync_failed(telemetry_context, e)
             return None
+    emit_sync_succeeded(telemetry_context, item_count=len(events))
 
     if not events:
         return None
@@ -160,6 +177,11 @@ async def write_conversation_link_to_calendar_event(
         return
 
     conversation_link = f"https://h.omi.me/conversations/{conversation_id}"
+    telemetry_context = IntegrationTelemetryContext(
+        integration_name=GOOGLE_CALENDAR,
+        operation='write_conversation_link',
+        uid=uid,
+    )
 
     async def _write(token: str) -> None:
         existing = await get_google_calendar_event(token, event_id)
@@ -170,7 +192,9 @@ async def write_conversation_link_to_calendar_event(
         await update_google_calendar_event(access_token=token, event_id=event_id, description=new_description)
 
     try:
+        emit_sync_attempted(telemetry_context)
         await _write(access_token)
+        emit_sync_succeeded(telemetry_context, item_count=1)
     except Exception as e:
         error_msg = str(e)
         if "error 401" in error_msg.lower() or "authentication failed" in error_msg.lower():
@@ -178,11 +202,16 @@ async def write_conversation_link_to_calendar_event(
             if new_token:
                 try:
                     await _write(new_token)
+                    emit_sync_succeeded(telemetry_context, item_count=1)
                 except Exception as retry_error:
                     logger.warning(
                         f"write_conversation_link_to_calendar_event failed after token refresh: {retry_error}"
                     )
+                    emit_sync_failed(telemetry_context, retry_error)
+            else:
+                emit_sync_failed(telemetry_context, e)
         else:
             logger.warning(
                 f"write_conversation_link_to_calendar_event failed for conversation {conversation_id}: {error_msg}"
             )
+            emit_sync_failed(telemetry_context, e)

--- a/backend/utils/integration_telemetry.py
+++ b/backend/utils/integration_telemetry.py
@@ -1,12 +1,12 @@
 """Low-cardinality telemetry and structured logs for provider integrations."""
 
+import importlib
 import logging
 import os
 from dataclasses import dataclass
 from typing import Any, Dict, Optional
 
 import httpx
-from posthog import Posthog
 
 logger = logging.getLogger(__name__)
 
@@ -20,7 +20,7 @@ AUTH_REFRESH_FAILED = 'Integration Auth Refresh Failed'
 GOOGLE_CALENDAR = 'Google Calendar'
 X = 'X'
 
-_POSTHOG_CLIENT: Optional[Posthog] = None
+_POSTHOG_CLIENT: Optional[Any] = None
 _POSTHOG_DISABLED = False
 
 
@@ -168,7 +168,7 @@ def _log_structured(event_name: str, uid: Optional[str], properties: Dict[str, A
     )
 
 
-def _get_posthog_client() -> Optional[Posthog]:
+def _get_posthog_client() -> Optional[Any]:
     global _POSTHOG_CLIENT, _POSTHOG_DISABLED
     if _POSTHOG_DISABLED:
         return None
@@ -181,7 +181,15 @@ def _get_posthog_client() -> Optional[Posthog]:
         return None
 
     host = os.getenv('POSTHOG_HOST', 'https://app.posthog.com')
-    _POSTHOG_CLIENT = Posthog(project_api_key=api_key, host=host)
+    try:
+        posthog_module = importlib.import_module('posthog')
+        posthog_client_cls = getattr(posthog_module, 'Posthog')
+    except Exception as exc:
+        logger.warning('integration telemetry posthog_import_failed error=%s', type(exc).__name__)
+        _POSTHOG_DISABLED = True
+        return None
+
+    _POSTHOG_CLIENT = posthog_client_cls(project_api_key=api_key, host=host)
     return _POSTHOG_CLIENT
 
 
@@ -250,7 +258,7 @@ def _bucket_count(value: int) -> str:
     return '1000_plus'
 
 
-def set_posthog_client_for_tests(client: Optional[Posthog]) -> None:
+def set_posthog_client_for_tests(client: Optional[Any]) -> None:
     global _POSTHOG_CLIENT, _POSTHOG_DISABLED
     _POSTHOG_CLIENT = client
     _POSTHOG_DISABLED = client is None

--- a/backend/utils/integration_telemetry.py
+++ b/backend/utils/integration_telemetry.py
@@ -193,10 +193,17 @@ def _provider_status_code(error: Any, explicit_status_code: Any = None) -> Optio
             return None
     status_code = getattr(error, 'status_code', None)
     if status_code is not None:
-        return int(status_code)
+        try:
+            return int(status_code)
+        except (TypeError, ValueError):
+            return None
     response = getattr(error, 'response', None)
-    if response is not None and getattr(response, 'status_code', None) is not None:
-        return int(response.status_code)
+    response_status_code = getattr(response, 'status_code', None) if response is not None else None
+    if response_status_code is not None:
+        try:
+            return int(response_status_code)
+        except (TypeError, ValueError):
+            return None
     return None
 
 

--- a/backend/utils/integration_telemetry.py
+++ b/backend/utils/integration_telemetry.py
@@ -1,0 +1,249 @@
+"""Low-cardinality telemetry and structured logs for provider integrations."""
+
+import logging
+import os
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+import httpx
+from posthog import Posthog
+
+logger = logging.getLogger(__name__)
+
+SYNC_ATTEMPTED = 'Integration Sync Attempted'
+SYNC_SUCCEEDED = 'Integration Sync Succeeded'
+SYNC_FAILED = 'Integration Sync Failed'
+AUTH_REFRESH_ATTEMPTED = 'Integration Auth Refresh Attempted'
+AUTH_REFRESH_SUCCEEDED = 'Integration Auth Refresh Succeeded'
+AUTH_REFRESH_FAILED = 'Integration Auth Refresh Failed'
+
+GOOGLE_CALENDAR = 'Google Calendar'
+X = 'X'
+
+_POSTHOG_CLIENT: Optional[Posthog] = None
+_POSTHOG_DISABLED = False
+
+
+@dataclass(frozen=True)
+class IntegrationTelemetryContext:
+    integration_name: str
+    operation: str
+    uid: Optional[str] = None
+    app_platform: Optional[str] = None
+    app_version: Optional[str] = None
+    app_build: Optional[str] = None
+    sync_source: Optional[str] = None
+
+
+def emit_sync_attempted(context: IntegrationTelemetryContext) -> None:
+    _emit(telemetry_event_name=SYNC_ATTEMPTED, context=context, status='attempted')
+
+
+def emit_sync_succeeded(
+    context: IntegrationTelemetryContext,
+    *,
+    item_count: Optional[int] = None,
+    memories_created: Optional[int] = None,
+) -> None:
+    extra = {}
+    if item_count is not None:
+        extra['item_count'] = _bucket_count(item_count)
+    if memories_created is not None:
+        extra['memories_created'] = _bucket_count(memories_created)
+    _emit(telemetry_event_name=SYNC_SUCCEEDED, context=context, status='succeeded', extra=extra)
+
+
+def emit_sync_failed(context: IntegrationTelemetryContext, error: Any, *, provider_status_code: Any = None) -> None:
+    status_code = _provider_status_code(error, provider_status_code)
+    _emit(
+        telemetry_event_name=SYNC_FAILED,
+        context=context,
+        status='failed',
+        error=error,
+        provider_status_code=status_code,
+        retryable=_is_retryable(error, status_code),
+    )
+
+
+def emit_auth_refresh_attempted(context: IntegrationTelemetryContext) -> None:
+    _emit(telemetry_event_name=AUTH_REFRESH_ATTEMPTED, context=context, status='attempted')
+
+
+def emit_auth_refresh_succeeded(context: IntegrationTelemetryContext) -> None:
+    _emit(telemetry_event_name=AUTH_REFRESH_SUCCEEDED, context=context, status='succeeded')
+
+
+def emit_auth_refresh_failed(
+    context: IntegrationTelemetryContext, error: Any, *, provider_status_code: Any = None
+) -> None:
+    status_code = _provider_status_code(error, provider_status_code)
+    _emit(
+        telemetry_event_name=AUTH_REFRESH_FAILED,
+        context=context,
+        status='failed',
+        error=error,
+        provider_status_code=status_code,
+        retryable=_is_retryable(error, status_code),
+    )
+
+
+def _emit(
+    *,
+    telemetry_event_name: str,
+    context: IntegrationTelemetryContext,
+    status: str,
+    error: Any = None,
+    provider_status_code: Any = None,
+    retryable: Optional[bool] = None,
+    extra: Optional[Dict[str, Any]] = None,
+) -> None:
+    properties = _properties(
+        context=context,
+        status=status,
+        error=error,
+        provider_status_code=provider_status_code,
+        retryable=retryable,
+        extra=extra,
+    )
+    _log_structured(telemetry_event_name, context.uid, properties)
+
+    client = _get_posthog_client()
+    if client is None or not context.uid:
+        return
+
+    try:
+        client.capture(distinct_id=context.uid, event=telemetry_event_name, properties=properties)
+    except Exception as exc:
+        logger.warning(
+            'integration telemetry posthog_emit_failed event=%s error=%s', telemetry_event_name, type(exc).__name__
+        )
+
+
+def _properties(
+    *,
+    context: IntegrationTelemetryContext,
+    status: str,
+    error: Any,
+    provider_status_code: Any,
+    retryable: Optional[bool],
+    extra: Optional[Dict[str, Any]],
+) -> Dict[str, Any]:
+    props: Dict[str, Any] = {
+        'integration_name': context.integration_name,
+        'provider': context.integration_name,
+        'operation': context.operation,
+        'status': status,
+        'error_bucket': _error_bucket(error, provider_status_code),
+        'provider_status_code': provider_status_code,
+        'retryable': bool(retryable) if retryable is not None else False,
+        'environment': os.getenv('OMI_ENV_STAGE') or os.getenv('ENVIRONMENT') or 'unknown',
+    }
+    optional = {
+        'app_platform': context.app_platform,
+        'app_version': context.app_version,
+        'app_build': context.app_build,
+        'sync_source': context.sync_source,
+    }
+    props.update({key: value for key, value in optional.items() if value})
+    if extra:
+        props.update(extra)
+    return props
+
+
+def _log_structured(event_name: str, uid: Optional[str], properties: Dict[str, Any]) -> None:
+    logger.info(
+        'integration_telemetry event=%s uid=%s provider=%s operation=%s status=%s error_bucket=%s '
+        'provider_status_code=%s retryable=%s app_platform=%s app_version=%s environment=%s',
+        event_name,
+        uid or 'unknown',
+        properties['provider'],
+        properties['operation'],
+        properties['status'],
+        properties['error_bucket'],
+        properties['provider_status_code'],
+        properties['retryable'],
+        properties.get('app_platform', 'unknown'),
+        properties.get('app_version', 'unknown'),
+        properties['environment'],
+    )
+
+
+def _get_posthog_client() -> Optional[Posthog]:
+    global _POSTHOG_CLIENT, _POSTHOG_DISABLED
+    if _POSTHOG_DISABLED:
+        return None
+    if _POSTHOG_CLIENT is not None:
+        return _POSTHOG_CLIENT
+
+    api_key = os.getenv('POSTHOG_PROJECT_API_KEY') or os.getenv('POSTHOG_API_KEY')
+    if not api_key:
+        _POSTHOG_DISABLED = True
+        return None
+
+    host = os.getenv('POSTHOG_HOST', 'https://app.posthog.com')
+    _POSTHOG_CLIENT = Posthog(project_api_key=api_key, host=host)
+    return _POSTHOG_CLIENT
+
+
+def _provider_status_code(error: Any, explicit_status_code: Any = None) -> Optional[int]:
+    if explicit_status_code is not None:
+        try:
+            return int(explicit_status_code)
+        except (TypeError, ValueError):
+            return None
+    status_code = getattr(error, 'status_code', None)
+    if status_code is not None:
+        return int(status_code)
+    response = getattr(error, 'response', None)
+    if response is not None and getattr(response, 'status_code', None) is not None:
+        return int(response.status_code)
+    return None
+
+
+def _error_bucket(error: Any, provider_status_code: Any) -> str:
+    if error is None:
+        return 'none'
+    status_code = _provider_status_code(error, provider_status_code)
+    text = str(error).lower()
+    if status_code in {401, 403} or 'unauthorized' in text or 'authentication' in text or 'invalid_grant' in text:
+        return 'oauth_unauthorized'
+    if status_code == 429 or 'rate limit' in text or 'rate_limited' in text:
+        return 'rate_limited'
+    if status_code is not None and 500 <= status_code <= 599:
+        return 'provider_5xx'
+    if status_code is not None and 400 <= status_code <= 499:
+        return 'bad_request'
+    if isinstance(error, (httpx.TimeoutException, httpx.ConnectError, TimeoutError)) or text in {
+        'timeout',
+        'connect_error',
+    }:
+        return 'network'
+    if text in {'not_connected', 'missing_token', 'missing_handle'}:
+        return 'oauth_unauthorized'
+    return 'unknown'
+
+
+def _is_retryable(error: Any, provider_status_code: Optional[int]) -> bool:
+    if provider_status_code in {408, 429, 500, 502, 503, 504}:
+        return True
+    if getattr(error, 'is_retryable', False):
+        return True
+    return isinstance(error, (httpx.TimeoutException, httpx.ConnectError, TimeoutError))
+
+
+def _bucket_count(value: int) -> str:
+    if value <= 0:
+        return '0'
+    if value <= 10:
+        return '1_10'
+    if value <= 100:
+        return '11_100'
+    if value <= 1000:
+        return '101_1000'
+    return '1000_plus'
+
+
+def set_posthog_client_for_tests(client: Optional[Posthog]) -> None:
+    global _POSTHOG_CLIENT, _POSTHOG_DISABLED
+    _POSTHOG_CLIENT = client
+    _POSTHOG_DISABLED = client is None

--- a/backend/utils/retrieval/tools/calendar_tools.py
+++ b/backend/utils/retrieval/tools/calendar_tools.py
@@ -545,12 +545,7 @@ async def get_calendar_events_tool(
     )
     if access_err:
         return access_err
-    telemetry_context = IntegrationTelemetryContext(
-        integration_name=GOOGLE_CALENDAR,
-        operation='fetch_events_tool',
-        uid=uid,
-    )
-    emit_sync_attempted(telemetry_context)
+    telemetry_context = None
 
     try:
         max_results = ensure_capped(max_results, 50, "⚠️ get_calendar_events_tool - max_results capped from {} to {}")
@@ -600,6 +595,13 @@ async def get_calendar_events_tool(
                     logger.info(
                         f"📅 search_query provided, expanding date range to 1 year: {time_min.strftime('%Y-%m-%d')} to {time_max.strftime('%Y-%m-%d')}"
                     )
+
+        telemetry_context = IntegrationTelemetryContext(
+            integration_name=GOOGLE_CALENDAR,
+            operation='fetch_events_tool',
+            uid=uid,
+        )
+        emit_sync_attempted(telemetry_context)
 
         # Fetch events with smart date range handling
         try:
@@ -696,7 +698,6 @@ async def get_calendar_events_tool(
                     max_results=max_results,
                     search_query=search_query,
                 )
-            emit_sync_succeeded(telemetry_context, item_count=len(events))
         except GoogleAPIError as e:
             logger.error(f"❌ Google API error fetching calendar events: status={e.status_code}, msg={e.message}")
 
@@ -712,7 +713,6 @@ async def get_calendar_events_tool(
                             max_results=max_results,
                             search_query=search_query,
                         )
-                        emit_sync_succeeded(telemetry_context, item_count=len(events))
                     except Exception as retry_error:
                         logger.error(f"❌ Error after token refresh: {retry_error}")
                         emit_sync_failed(telemetry_context, retry_error)
@@ -749,6 +749,7 @@ async def get_calendar_events_tool(
             elif time_max:
                 date_info = f" before {time_max.strftime('%Y-%m-%d')}"
 
+            emit_sync_succeeded(telemetry_context, item_count=0)
             return f"No calendar events found{date_info}."
 
         # Format events
@@ -796,10 +797,12 @@ async def get_calendar_events_tool(
 
             result += "\n"
 
+        emit_sync_succeeded(telemetry_context, item_count=events_count)
         return result.strip()
     except Exception as e:
         logger.error(f"❌ Unexpected error in get_calendar_events_tool: {e}")
-        emit_sync_failed(telemetry_context, e)
+        if telemetry_context:
+            emit_sync_failed(telemetry_context, e)
         return f"Unexpected error fetching calendar events: {e}"
 
 

--- a/backend/utils/retrieval/tools/calendar_tools.py
+++ b/backend/utils/retrieval/tools/calendar_tools.py
@@ -28,6 +28,13 @@ from utils.retrieval.tools.integration_base import (
     parse_iso_with_tz,
     prepare_access,
 )
+from utils.integration_telemetry import (
+    GOOGLE_CALENDAR,
+    IntegrationTelemetryContext,
+    emit_sync_attempted,
+    emit_sync_failed,
+    emit_sync_succeeded,
+)
 from utils.retrieval.tools.google_utils import google_api_request, GoogleAPIError
 
 # Import shared Google utilities
@@ -538,6 +545,12 @@ async def get_calendar_events_tool(
     )
     if access_err:
         return access_err
+    telemetry_context = IntegrationTelemetryContext(
+        integration_name=GOOGLE_CALENDAR,
+        operation='fetch_events_tool',
+        uid=uid,
+    )
+    emit_sync_attempted(telemetry_context)
 
     try:
         max_results = ensure_capped(max_results, 50, "⚠️ get_calendar_events_tool - max_results capped from {} to {}")
@@ -683,6 +696,7 @@ async def get_calendar_events_tool(
                     max_results=max_results,
                     search_query=search_query,
                 )
+            emit_sync_succeeded(telemetry_context, item_count=len(events))
         except GoogleAPIError as e:
             logger.error(f"❌ Google API error fetching calendar events: status={e.status_code}, msg={e.message}")
 
@@ -698,23 +712,30 @@ async def get_calendar_events_tool(
                             max_results=max_results,
                             search_query=search_query,
                         )
+                        emit_sync_succeeded(telemetry_context, item_count=len(events))
                     except Exception as retry_error:
                         logger.error(f"❌ Error after token refresh: {retry_error}")
+                        emit_sync_failed(telemetry_context, retry_error)
                         return f"Error fetching calendar events: {retry_error}"
                 else:
                     logger.error(f"❌ Token refresh failed")
+                    emit_sync_failed(telemetry_context, e)
                     return (
                         "Google Calendar authentication expired. Please reconnect your Google Calendar from settings."
                     )
             elif e.is_permission_error:
+                emit_sync_failed(telemetry_context, e)
                 return "Google Calendar access denied. Please reconnect your Google Calendar from settings with proper permissions."
             else:
+                emit_sync_failed(telemetry_context, e)
                 return f"Error fetching calendar events: {e.message}"
         except (httpx.TimeoutException, httpx.ConnectError) as e:
             logger.error(f"❌ Network error fetching calendar events: {e}")
+            emit_sync_failed(telemetry_context, e)
             return "Unable to reach Google Calendar right now. Please try again in a moment."
         except Exception as e:
             logger.error(f"❌ Unexpected error fetching calendar events: {e}")
+            emit_sync_failed(telemetry_context, e)
             return f"Error fetching calendar events: {e}"
 
         events_count = len(events) if events else 0
@@ -778,6 +799,7 @@ async def get_calendar_events_tool(
         return result.strip()
     except Exception as e:
         logger.error(f"❌ Unexpected error in get_calendar_events_tool: {e}")
+        emit_sync_failed(telemetry_context, e)
         return f"Unexpected error fetching calendar events: {e}"
 
 

--- a/backend/utils/retrieval/tools/google_utils.py
+++ b/backend/utils/retrieval/tools/google_utils.py
@@ -55,7 +55,13 @@ class GoogleAPIError(Exception):
         return self.status_code in _RETRYABLE_STATUS_CODES
 
 
-async def refresh_google_token(uid: str, integration: dict) -> Optional[str]:
+async def refresh_google_token(
+    uid: str,
+    integration: dict,
+    *,
+    integration_name: str = GOOGLE_CALENDAR,
+    integration_key: str = 'google_calendar',
+) -> Optional[str]:
     """
     Refresh Google access token using refresh token.
     Works for both Calendar and Gmail since they use the same OAuth.
@@ -63,13 +69,15 @@ async def refresh_google_token(uid: str, integration: dict) -> Optional[str]:
     Args:
         uid: User ID
         integration: Integration dict containing refresh_token
+        integration_name: Product-visible provider name for telemetry.
+        integration_key: Stored integration key to update after refresh.
 
     Returns:
         New access token or None if refresh failed
     """
     refresh_token = integration.get('refresh_token')
     telemetry_context = IntegrationTelemetryContext(
-        integration_name=GOOGLE_CALENDAR,
+        integration_name=integration_name,
         operation='refresh_token',
         uid=uid,
     )
@@ -108,7 +116,7 @@ async def refresh_google_token(uid: str, integration: dict) -> Optional[str]:
                 # DB executor so it does not block the event loop during
                 # concurrent chat/tool streaming.
                 integration['access_token'] = new_access_token
-                await run_blocking(db_executor, users_db.set_integration, uid, 'google_calendar', integration)
+                await run_blocking(db_executor, users_db.set_integration, uid, integration_key, integration)
                 logger.info(f"🔄 Successfully refreshed Google token for uid={uid}")
                 emit_auth_refresh_succeeded(telemetry_context)
                 return new_access_token

--- a/backend/utils/retrieval/tools/google_utils.py
+++ b/backend/utils/retrieval/tools/google_utils.py
@@ -11,6 +11,13 @@ import httpx
 import database.users as users_db
 from utils.executors import db_executor, run_blocking
 from utils.http_client import get_auth_client
+from utils.integration_telemetry import (
+    GOOGLE_CALENDAR,
+    IntegrationTelemetryContext,
+    emit_auth_refresh_attempted,
+    emit_auth_refresh_failed,
+    emit_auth_refresh_succeeded,
+)
 from utils.log_sanitizer import sanitize
 import logging
 
@@ -61,8 +68,15 @@ async def refresh_google_token(uid: str, integration: dict) -> Optional[str]:
         New access token or None if refresh failed
     """
     refresh_token = integration.get('refresh_token')
+    telemetry_context = IntegrationTelemetryContext(
+        integration_name=GOOGLE_CALENDAR,
+        operation='refresh_token',
+        uid=uid,
+    )
+    emit_auth_refresh_attempted(telemetry_context)
     if not refresh_token:
         logger.warning(f"🔄 No refresh_token stored for uid={uid}, cannot refresh")
+        emit_auth_refresh_failed(telemetry_context, 'missing_token')
         return None
 
     client_id = os.getenv('GOOGLE_CLIENT_ID')
@@ -70,6 +84,7 @@ async def refresh_google_token(uid: str, integration: dict) -> Optional[str]:
 
     if not all([client_id, client_secret]):
         logger.error("🔄 Missing GOOGLE_CLIENT_ID or GOOGLE_CLIENT_SECRET env vars")
+        emit_auth_refresh_failed(telemetry_context, 'missing_oauth_config')
         return None
 
     try:
@@ -95,6 +110,7 @@ async def refresh_google_token(uid: str, integration: dict) -> Optional[str]:
                 integration['access_token'] = new_access_token
                 await run_blocking(db_executor, users_db.set_integration, uid, 'google_calendar', integration)
                 logger.info(f"🔄 Successfully refreshed Google token for uid={uid}")
+                emit_auth_refresh_succeeded(telemetry_context)
                 return new_access_token
 
         # Detect token revocation (invalid_grant) — user revoked access in Google settings
@@ -108,12 +124,18 @@ async def refresh_google_token(uid: str, integration: dict) -> Optional[str]:
             logger.error(
                 f"🔄 Google token refresh failed for uid={uid}: " f"status={response.status_code}, body={error_body}"
             )
+        emit_auth_refresh_failed(
+            telemetry_context, response.text or 'token_refresh_failed', provider_status_code=response.status_code
+        )
     except httpx.TimeoutException:
         logger.error(f"🔄 Timeout refreshing Google token for uid={uid}")
+        emit_auth_refresh_failed(telemetry_context, 'timeout')
     except httpx.ConnectError:
         logger.error(f"🔄 Network error refreshing Google token for uid={uid}")
+        emit_auth_refresh_failed(telemetry_context, 'connect_error')
     except Exception as e:
         logger.error(f"🔄 Unexpected error refreshing Google token for uid={uid}: {e}")
+        emit_auth_refresh_failed(telemetry_context, e)
 
     return None
 

--- a/backend/utils/x_connector.py
+++ b/backend/utils/x_connector.py
@@ -41,6 +41,16 @@ from utils.memory.memory_service import MemoryService
 from utils.memory.memory_system import MemorySystem, resolve_memory_system
 from utils.executors import db_executor, run_blocking
 from utils import social
+from utils.integration_telemetry import (
+    IntegrationTelemetryContext,
+    X,
+    emit_auth_refresh_attempted,
+    emit_auth_refresh_failed,
+    emit_auth_refresh_succeeded,
+    emit_sync_attempted,
+    emit_sync_failed,
+    emit_sync_succeeded,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -225,6 +235,8 @@ async def get_valid_access_token(uid: str) -> Optional[str]:
     refresh = integ.get('refresh_token')
     if not refresh:
         return integ['access_token']  # best effort; may be expired
+    telemetry_context = IntegrationTelemetryContext(integration_name=X, operation='refresh_token', uid=uid)
+    emit_auth_refresh_attempted(telemetry_context)
     try:
         token_resp = await _refresh(refresh)
         await run_blocking(
@@ -235,9 +247,11 @@ async def get_valid_access_token(uid: str) -> Optional[str]:
             handle=integ.get('handle'),
             x_user_id=integ.get('x_user_id'),
         )
+        emit_auth_refresh_succeeded(telemetry_context)
         return token_resp['access_token']
     except Exception as e:
         logger.warning(f'x_connector: token refresh failed for uid={uid}: {e}')
+        emit_auth_refresh_failed(telemetry_context, e)
         return None
 
 
@@ -389,6 +403,8 @@ def _extract_and_index(uid: str, posts: List[Dict]) -> int:
 
 async def sync_x_for_user(uid: str) -> Dict:
     """Pull new X posts, store raw, extract memories. Returns a summary dict."""
+    sync_context = IntegrationTelemetryContext(integration_name=X, operation='sync_posts', uid=uid)
+    emit_sync_attempted(sync_context)
     integ = await run_blocking(db_executor, users_db.get_integration, uid, INTEGRATION_KEY) or {}
     # Mark syncing so the desktop can show live progress while this runs in the
     # background (the OAuth callback kicks this off as a background task).
@@ -422,12 +438,22 @@ async def sync_x_for_user(uid: str) -> Dict:
                 source = 'oauth'
         except Exception as e:
             logger.warning(f'x_connector: official API sync failed for uid={uid}, falling back: {e}')
+            emit_sync_failed(
+                IntegrationTelemetryContext(
+                    integration_name=X,
+                    operation='fetch_oauth_posts',
+                    uid=uid,
+                    sync_source='oauth',
+                ),
+                e,
+            )
 
     # Fallback: RapidAPI public timeline by handle.
     if source is None:
         handle = integ.get('handle')
         if not handle:
             await run_blocking(db_executor, users_db.set_integration, uid, INTEGRATION_KEY, {'syncing': False})
+            emit_sync_failed(sync_context, 'not_connected')
             return {'success': False, 'error': 'not_connected', 'new_posts': 0, 'memories_created': 0}
         try:
             timeline = await social.get_twitter_timeline(handle)
@@ -444,6 +470,16 @@ async def sync_x_for_user(uid: str) -> Dict:
         except Exception as e:
             logger.error(f'x_connector: RapidAPI fallback failed for uid={uid}: {e}')
             await run_blocking(db_executor, users_db.set_integration, uid, INTEGRATION_KEY, {'syncing': False})
+            emit_sync_failed(
+                IntegrationTelemetryContext(
+                    integration_name=X,
+                    operation='fetch_tweets',
+                    uid=uid,
+                    sync_source='rapidapi',
+                ),
+                e,
+            )
+            emit_sync_failed(sync_context, e)
             return {'success': False, 'error': 'fetch_failed', 'new_posts': 0, 'memories_created': 0}
 
     written = await run_blocking(db_executor, x_posts_db.save_x_posts, uid, new_posts)
@@ -474,6 +510,11 @@ async def sync_x_for_user(uid: str) -> Dict:
             'memory_count': int(integ.get('memory_count', 0)) + memories_created,
             'syncing': False,
         },
+    )
+    emit_sync_succeeded(
+        IntegrationTelemetryContext(integration_name=X, operation='sync_posts', uid=uid, sync_source=source),
+        item_count=written,
+        memories_created=memories_created,
     )
     return {
         'success': True,

--- a/backend/utils/x_connector.py
+++ b/backend/utils/x_connector.py
@@ -482,35 +482,46 @@ async def sync_x_for_user(uid: str) -> Dict:
             emit_sync_failed(sync_context, e)
             return {'success': False, 'error': 'fetch_failed', 'new_posts': 0, 'memories_created': 0}
 
-    written = await run_blocking(db_executor, x_posts_db.save_x_posts, uid, new_posts)
-    # Only mine memories from posts we hadn't seen before (the raw store dedupes,
-    # but extraction is the expensive part — restrict it to genuinely new text).
-    fresh = new_posts if written == len(new_posts) else new_posts[:written]
-    # Vector-index the raw posts so agents can semantically search the actual
-    # tweets (not just the extracted memories) via the MCP search_x_posts tool.
-    # Chunk to stay within Pinecone's per-upsert vector limit (~100).
-    items_to_index = [{'post_id': p['id'], 'content': p.get('text', ''), 'kind': p.get('kind', 'tweet')} for p in fresh]
-    for i in range(0, len(items_to_index), 100):
-        try:
-            await run_blocking(db_executor, upsert_x_post_vectors_batch, uid, items_to_index[i : i + 100])
-        except Exception as e:
-            logger.warning(f'x_connector: failed to index x_posts chunk[{i}:{i+100}] for uid={uid}: {e}')
-    memories_created = await run_blocking(db_executor, _extract_and_index, uid, fresh)
-    post_count = await run_blocking(db_executor, x_posts_db.count_x_posts, uid)
+    try:
+        written = await run_blocking(db_executor, x_posts_db.save_x_posts, uid, new_posts)
+        # Only mine memories from posts we hadn't seen before (the raw store dedupes,
+        # but extraction is the expensive part — restrict it to genuinely new text).
+        fresh = new_posts if written == len(new_posts) else new_posts[:written]
+        # Vector-index the raw posts so agents can semantically search the actual
+        # tweets (not just the extracted memories) via the MCP search_x_posts tool.
+        # Chunk to stay within Pinecone's per-upsert vector limit (~100).
+        items_to_index = [
+            {'post_id': p['id'], 'content': p.get('text', ''), 'kind': p.get('kind', 'tweet')} for p in fresh
+        ]
+        for i in range(0, len(items_to_index), 100):
+            try:
+                await run_blocking(db_executor, upsert_x_post_vectors_batch, uid, items_to_index[i : i + 100])
+            except Exception as e:
+                logger.warning(f'x_connector: failed to index x_posts chunk[{i}:{i+100}] for uid={uid}: {e}')
+        memories_created = await run_blocking(db_executor, _extract_and_index, uid, fresh)
+        post_count = await run_blocking(db_executor, x_posts_db.count_x_posts, uid)
 
-    await run_blocking(
-        db_executor,
-        users_db.set_integration,
-        uid,
-        INTEGRATION_KEY,
-        {
-            'last_synced_at': datetime.now(timezone.utc).isoformat(),
-            'last_sync_source': source,
-            'post_count': post_count,
-            'memory_count': int(integ.get('memory_count', 0)) + memories_created,
-            'syncing': False,
-        },
-    )
+        await run_blocking(
+            db_executor,
+            users_db.set_integration,
+            uid,
+            INTEGRATION_KEY,
+            {
+                'last_synced_at': datetime.now(timezone.utc).isoformat(),
+                'last_sync_source': source,
+                'post_count': post_count,
+                'memory_count': int(integ.get('memory_count', 0)) + memories_created,
+                'syncing': False,
+            },
+        )
+    except Exception as e:
+        try:
+            await run_blocking(db_executor, users_db.set_integration, uid, INTEGRATION_KEY, {'syncing': False})
+        except Exception as cleanup_error:
+            logger.warning(f'x_connector: failed to clear syncing after sync failure for uid={uid}: {cleanup_error}')
+        emit_sync_failed(sync_context, e)
+        raise
+
     emit_sync_succeeded(
         IntegrationTelemetryContext(integration_name=X, operation='sync_posts', uid=uid, sync_source=source),
         item_count=written,

--- a/backend/utils/x_connector.py
+++ b/backend/utils/x_connector.py
@@ -519,7 +519,10 @@ async def sync_x_for_user(uid: str) -> Dict:
             await run_blocking(db_executor, users_db.set_integration, uid, INTEGRATION_KEY, {'syncing': False})
         except Exception as cleanup_error:
             logger.warning(f'x_connector: failed to clear syncing after sync failure for uid={uid}: {cleanup_error}')
-        emit_sync_failed(sync_context, e)
+        emit_sync_failed(
+            IntegrationTelemetryContext(integration_name=X, operation='sync_posts', uid=uid, sync_source=source),
+            e,
+        )
         raise
 
     emit_sync_succeeded(


### PR DESCRIPTION
## Summary
- add backend integration telemetry helper for PostHog events plus sanitized structured logs
- emit Calendar and X sync/auth refresh attempted/succeeded/failed events with provider, operation, status/error buckets, retryability, environment, and app build dimensions where available
- add focused unit coverage for bounded telemetry payloads and Calendar/X sync-path instrumentation

Closes #8964

## Tests
- cd backend && .venv/bin/python -m pytest tests/unit/test_integration_sync_telemetry.py -v
- cd backend && .venv/bin/python scripts/scan_import_time_side_effects.py
- cd backend && .venv/bin/python scripts/scan_async_blockers.py
- cd backend && .venv/bin/python scripts/check_module_stub_pollution.py
- cd backend && PYTHON=.venv/bin/python bash test-preflight.sh
- pre-push hook passed with backend .venv on PATH


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8966?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

