### PR TITLE
[codex] Fix Google Calendar auth recovery

### DIFF
--- a/backend/deploy/runtime_env.yaml
+++ b/backend/deploy/runtime_env.yaml
@@ -118,6 +118,12 @@ environments:
             ENCRYPTION_SECRET:
               secret: ENCRYPTION_SECRET
               version: latest
+            GOOGLE_CLIENT_ID:
+              secret: GOOGLE_CLIENT_ID
+              version: latest
+            GOOGLE_CLIENT_SECRET:
+              secret: GOOGLE_CLIENT_SECRET
+              version: latest
             OMI_LLM_GATEWAY_SERVICE_TOKEN:
               secret: OMI_LLM_GATEWAY_SERVICE_TOKEN
               version: latest
@@ -174,6 +180,12 @@ environments:
             ENCRYPTION_SECRET:
               secret: ENCRYPTION_SECRET
               version: latest
+            GOOGLE_CLIENT_ID:
+              secret: GOOGLE_CLIENT_ID
+              version: latest
+            GOOGLE_CLIENT_SECRET:
+              secret: GOOGLE_CLIENT_SECRET
+              version: latest
             OMI_LLM_GATEWAY_SERVICE_TOKEN:
               secret: OMI_LLM_GATEWAY_SERVICE_TOKEN
               version: latest
@@ -229,6 +241,12 @@ environments:
               version: latest
             ENCRYPTION_SECRET:
               secret: ENCRYPTION_SECRET
+              version: latest
+            GOOGLE_CLIENT_ID:
+              secret: GOOGLE_CLIENT_ID
+              version: latest
+            GOOGLE_CLIENT_SECRET:
+              secret: GOOGLE_CLIENT_SECRET
               version: latest
             OMI_LLM_GATEWAY_SERVICE_TOKEN:
               secret: OMI_LLM_GATEWAY_SERVICE_TOKEN
@@ -319,6 +337,12 @@ environments:
             ENCRYPTION_SECRET:
               secret: ENCRYPTION_SECRET
               version: latest
+            GOOGLE_CLIENT_ID:
+              secret: GOOGLE_CLIENT_ID
+              version: latest
+            GOOGLE_CLIENT_SECRET:
+              secret: GOOGLE_CLIENT_SECRET
+              version: latest
             OMI_LLM_GATEWAY_SERVICE_TOKEN:
               secret: OMI_LLM_GATEWAY_SERVICE_TOKEN
               version: latest
@@ -356,6 +380,12 @@ environments:
             ENCRYPTION_SECRET:
               secret: ENCRYPTION_SECRET
               version: latest
+            GOOGLE_CLIENT_ID:
+              secret: GOOGLE_CLIENT_ID
+              version: latest
+            GOOGLE_CLIENT_SECRET:
+              secret: GOOGLE_CLIENT_SECRET
+              version: latest
             OMI_LLM_GATEWAY_SERVICE_TOKEN:
               secret: OMI_LLM_GATEWAY_SERVICE_TOKEN
               version: latest
@@ -392,6 +422,12 @@ environments:
               version: latest
             ENCRYPTION_SECRET:
               secret: ENCRYPTION_SECRET
+              version: latest
+            GOOGLE_CLIENT_ID:
+              secret: GOOGLE_CLIENT_ID
+              version: latest
+            GOOGLE_CLIENT_SECRET:
+              secret: GOOGLE_CLIENT_SECRET
               version: latest
             OMI_LLM_GATEWAY_SERVICE_TOKEN:
               secret: OMI_LLM_GATEWAY_SERVICE_TOKEN

--- a/backend/tests/unit/test_google_calendar_auth_recovery.py
+++ b/backend/tests/unit/test_google_calendar_auth_recovery.py
@@ -1,0 +1,130 @@
+import asyncio
+import importlib.util
+import re
+from pathlib import Path
+
+BACKEND_DIR = Path(__file__).resolve().parents[2]
+PROCESS_CONVERSATION = BACKEND_DIR / 'utils' / 'conversations' / 'process_conversation.py'
+GOOGLE_UTILS = BACKEND_DIR / 'utils' / 'retrieval' / 'tools' / 'google_utils.py'
+
+
+class _TokenResponse:
+    def __init__(self, status_code: int, text: str = '', payload: dict | None = None):
+        self.status_code = status_code
+        self.text = text
+        self._payload = payload or {}
+
+    def json(self):
+        return self._payload
+
+
+class _AuthClient:
+    def __init__(self, response: _TokenResponse):
+        self.response = response
+
+    async def post(self, *args, **kwargs):
+        return self.response
+
+
+def _load_google_utils():
+    spec = importlib.util.spec_from_file_location('google_utils_under_test', GOOGLE_UTILS)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_conversation_processing_calendar_auto_link_is_opt_in():
+    source = PROCESS_CONVERSATION.read_text(encoding='utf-8')
+
+    assert 'GOOGLE_CALENDAR_AUTO_LINK_ENABLED' in source
+    assert 'def _calendar_auto_link_enabled()' in source
+    assert re.search(r'_calendar_auto_link_enabled\(\)\s+and\s+not\s+discarded', source)
+
+
+def test_refresh_google_token_marks_missing_refresh_token_reauth_required(monkeypatch):
+    google_utils = _load_google_utils()
+    writes = []
+
+    async def _run_blocking(_executor, fn, *args):
+        writes.append((fn, args))
+
+    monkeypatch.setattr(google_utils, 'run_blocking', _run_blocking)
+
+    result = asyncio.run(
+        google_utils.refresh_google_token(
+            'uid-calendar',
+            {'connected': True, 'access_token': 'old-token'},
+        )
+    )
+
+    assert result is None
+    assert writes[0][1][:2] == (
+        'uid-calendar',
+        'google_calendar',
+    )
+    assert writes[0][1][2] == {
+        'connected': False,
+        'reauth_required': True,
+        'reauth_reason': 'missing_refresh_token',
+        'access_token': google_utils.firestore.DELETE_FIELD,
+    }
+
+
+def test_refresh_google_token_marks_invalid_grant_reauth_required(monkeypatch):
+    google_utils = _load_google_utils()
+    writes = []
+
+    async def _run_blocking(_executor, fn, *args):
+        writes.append((fn, args))
+
+    monkeypatch.setenv('GOOGLE_CLIENT_ID', 'client-id')
+    monkeypatch.setenv('GOOGLE_CLIENT_SECRET', 'client-secret')
+    monkeypatch.setattr(google_utils, 'run_blocking', _run_blocking)
+    monkeypatch.setattr(
+        google_utils,
+        'get_auth_client',
+        lambda: _AuthClient(_TokenResponse(400, '{"error":"invalid_grant"}')),
+    )
+
+    result = asyncio.run(
+        google_utils.refresh_google_token(
+            'uid-calendar',
+            {'connected': True, 'access_token': 'old-token', 'refresh_token': 'refresh-token'},
+        )
+    )
+
+    assert result is None
+    assert writes[0][1][:2] == (
+        'uid-calendar',
+        'google_calendar',
+    )
+    assert writes[0][1][2] == {
+        'connected': False,
+        'refresh_token': 'refresh-token',
+        'reauth_required': True,
+        'reauth_reason': 'invalid_grant',
+        'access_token': google_utils.firestore.DELETE_FIELD,
+    }
+
+
+def test_refresh_google_token_does_not_demote_user_for_missing_runtime_config(monkeypatch):
+    google_utils = _load_google_utils()
+    writes = []
+
+    async def _run_blocking(_executor, fn, *args):
+        writes.append((fn, args))
+
+    monkeypatch.delenv('GOOGLE_CLIENT_ID', raising=False)
+    monkeypatch.delenv('GOOGLE_CLIENT_SECRET', raising=False)
+    monkeypatch.setattr(google_utils, 'run_blocking', _run_blocking)
+
+    result = asyncio.run(
+        google_utils.refresh_google_token(
+            'uid-calendar',
+            {'connected': True, 'access_token': 'old-token', 'refresh_token': 'refresh-token'},
+        )
+    )
+
+    assert result is None
+    assert writes == []

--- a/backend/utils/conversations/process_conversation.py
+++ b/backend/utils/conversations/process_conversation.py
@@ -97,6 +97,10 @@ from utils.other.storage import precache_conversation_audio
 logger = logging.getLogger(__name__)
 
 
+def _calendar_auto_link_enabled() -> bool:
+    return os.getenv('GOOGLE_CALENDAR_AUTO_LINK_ENABLED', '').strip().lower() in {'1', 'true', 'yes', 'on'}
+
+
 def _fetch_dedup_candidates(uid: str, structured: Structured) -> List[dict]:
     """
     Fetch open action items semantically related to this conversation, active
@@ -946,8 +950,16 @@ def process_conversation(
     structured, discarded = _get_structured(uid, language_code, conversation, force_process, people=people)
     conversation = _get_conversation_obj(uid, structured, conversation)
 
-    # Check for overlapping calendar events and auto-write conversation link to the event description
-    if not discarded and conversation.started_at and conversation.finished_at and conversation.calendar_event is None:
+    # Calendar auto-linking calls and mutates a user's Google Calendar during generic
+    # conversation processing. Keep it opt-in so normal sync/reprocess jobs do not
+    # fan out provider traffic for every connected user.
+    if (
+        _calendar_auto_link_enabled()
+        and not discarded
+        and conversation.started_at
+        and conversation.finished_at
+        and conversation.calendar_event is None
+    ):
         try:
             calendar_event = asyncio.run(
                 get_overlapping_calendar_event(

--- a/backend/utils/retrieval/tools/google_utils.py
+++ b/backend/utils/retrieval/tools/google_utils.py
@@ -7,6 +7,7 @@ import os
 from typing import Optional
 
 import httpx
+from google.cloud import firestore
 
 import database.users as users_db
 from utils.executors import db_executor, run_blocking
@@ -48,6 +49,15 @@ class GoogleAPIError(Exception):
         return self.status_code in _RETRYABLE_STATUS_CODES
 
 
+async def _mark_google_calendar_reauth_required(uid: str, integration: dict, reason: str) -> None:
+    updated = dict(integration)
+    updated['connected'] = False
+    updated['reauth_required'] = True
+    updated['reauth_reason'] = reason
+    updated['access_token'] = firestore.DELETE_FIELD
+    await run_blocking(db_executor, users_db.set_integration, uid, 'google_calendar', updated)
+
+
 async def refresh_google_token(uid: str, integration: dict) -> Optional[str]:
     """
     Refresh Google access token using refresh token.
@@ -63,6 +73,7 @@ async def refresh_google_token(uid: str, integration: dict) -> Optional[str]:
     refresh_token = integration.get('refresh_token')
     if not refresh_token:
         logger.warning(f"🔄 No refresh_token stored for uid={uid}, cannot refresh")
+        await _mark_google_calendar_reauth_required(uid, integration, 'missing_refresh_token')
         return None
 
     client_id = os.getenv('GOOGLE_CLIENT_ID')
@@ -104,6 +115,7 @@ async def refresh_google_token(uid: str, integration: dict) -> Optional[str]:
                 f"🔄 Google refresh token revoked for uid={uid} (invalid_grant). "
                 f"User needs to reconnect. Response: {error_body}"
             )
+            await _mark_google_calendar_reauth_required(uid, integration, 'invalid_grant')
         else:
             logger.error(
                 f"🔄 Google token refresh failed for uid={uid}: " f"status={response.status_code}, body={error_body}"


### PR DESCRIPTION
## Summary
- make Google Calendar conversation auto-linking opt-in via `GOOGLE_CALENDAR_AUTO_LINK_ENABLED` so generic sync/reprocess jobs do not call or mutate Calendar for every connected user
- mark Google Calendar integrations as `reauth_required` and disconnected when refresh credentials are permanently unusable (`missing_refresh_token` or Google `invalid_grant`)
- declare Google OAuth client secrets for all backend Cloud Run services, including `backend-sync`, so token refresh config is preserved by runtime-env deploy rendering

## Root cause
Calendar auto-linking was running inside generic conversation processing for every non-discarded conversation with timestamps and `google_calendar.connected == true`. When access tokens expired, `backend-sync` and pusher repeatedly attempted refresh; `backend-sync` was missing Google OAuth client env, and permanently invalid user credentials stayed marked connected, so future jobs retried indefinitely.

## Validation
- `cd backend && pytest -q tests/unit/test_google_calendar_auth_recovery.py tests/unit/test_calendar_linking_helpers_async.py tests/unit/test_calendar_link_async.py tests/unit/test_google_credentials.py`
- `cd backend && python scripts/validate-backend-runtime-env.py --env prod && python scripts/validate-backend-runtime-env.py --env dev`
- `cd backend && python scripts/scan_import_time_side_effects.py`
- `cd backend && python scripts/scan_async_blockers.py`
- `git diff --check`
- `cd backend && CLOUD_RUN_VPC_NETWORK=dummy-net CLOUD_RUN_VPC_SUBNET=dummy-subnet OMI_LLM_GATEWAY_URL=http://dummy python scripts/render-backend-runtime-env.py --env prod | rg -n 'backend_sync_secrets|GOOGLE_CLIENT|backend_secrets|backend_integration_secrets'`\n\nCloses #8965

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8968?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

