### PR TITLE
Add action-item completion streak (GET /v1/scores/streak)

### DIFF
--- a/backend/database/action_items.py
+++ b/backend/database/action_items.py
@@ -4,6 +4,7 @@ from typing import Optional, List
 from google.api_core.exceptions import NotFound
 from google.cloud import firestore
 from google.cloud.firestore_v1 import FieldFilter
+import pytz
 
 from ._client import db
 import logging
@@ -833,4 +834,73 @@ def get_scores(uid: str, date: str = None) -> dict:
         'overall': overall,
         'default_tab': default_tab,
         'date': day.strftime('%Y-%m-%d'),
+    }
+
+
+def get_completion_streak(
+    uid: str,
+    *,
+    tz: str = 'UTC',
+    today: Optional[str] = None,
+    max_days: int = 366,
+    firestore_client=None,
+) -> dict:
+    """Consecutive-day action-item completion streak, an engagement metric.
+
+    A day counts toward the streak when at least one non-deleted action item was completed that
+    day, bucketed by ``completed_at`` in the caller's IANA time zone ``tz``. The current streak is
+    the run of consecutive completed days ending today, or ending yesterday when nothing has been
+    completed yet today, so a still-live streak is not reported as broken before the day is over.
+
+    Args:
+        uid: User ID.
+        tz: IANA time zone used to bucket ``completed_at`` into local days.
+        today: Local ``YYYY-MM-DD`` anchoring "today" (defaults to the current local date).
+        max_days: How far back to look; caps the single range query.
+        firestore_client: Optional injected client (tests); defaults to the shared client.
+
+    Returns:
+        {'current_streak': int, 'longest_streak': int, 'completed_today': bool,
+         'last_completed_date': 'YYYY-MM-DD' | None}
+    """
+    client = firestore_client if firestore_client is not None else db
+    zone = pytz.timezone(tz)
+    today_date = datetime.strptime(today, '%Y-%m-%d').date() if today else datetime.now(zone).date()
+    window_start = datetime.now(timezone.utc) - timedelta(days=max_days)
+
+    col = client.collection('users').document(uid).collection(action_items_collection)
+    completed_days = set()
+    for doc in col.where(filter=FieldFilter('completed_at', '>=', window_start)).stream():
+        data = doc.to_dict()
+        if data.get('deleted') or not data.get('completed'):
+            continue
+        completed_at = data.get('completed_at')
+        if completed_at is not None:
+            completed_days.add(completed_at.astimezone(zone).date())
+
+    if not completed_days:
+        return {'current_streak': 0, 'longest_streak': 0, 'completed_today': False, 'last_completed_date': None}
+
+    completed_today = today_date in completed_days
+
+    # Current streak: consecutive days ending today, or yesterday if today is not done yet.
+    current_streak = 0
+    cursor = today_date if completed_today else today_date - timedelta(days=1)
+    while cursor in completed_days:
+        current_streak += 1
+        cursor -= timedelta(days=1)
+
+    # Longest streak anywhere in the window.
+    longest_streak = current_run = 0
+    prev = None
+    for day in sorted(completed_days):
+        current_run = current_run + 1 if prev is not None and day - prev == timedelta(days=1) else 1
+        longest_streak = max(longest_streak, current_run)
+        prev = day
+
+    return {
+        'current_streak': current_streak,
+        'longest_streak': longest_streak,
+        'completed_today': completed_today,
+        'last_completed_date': max(completed_days).isoformat(),
     }

--- a/backend/routers/scores.py
+++ b/backend/routers/scores.py
@@ -1,6 +1,7 @@
 """Scores — daily, weekly, and overall productivity scores computed from action items."""
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
+import pytz
 
 import database.action_items as action_items_db
 from utils.other import endpoints as auth
@@ -25,3 +26,13 @@ def get_scores(
 ):
     date = validate_calendar_date(date)
     return action_items_db.get_scores(uid, date=date)
+
+
+@router.get('/v1/scores/streak', tags=['scores'])
+def get_streak(
+    tz: str = Query('UTC'),
+    uid: str = Depends(auth.get_current_user_uid),
+):
+    if tz not in pytz.all_timezones_set:
+        raise HTTPException(status_code=400, detail='Invalid timezone')
+    return action_items_db.get_completion_streak(uid, tz=tz)

--- a/backend/tests/unit/test_scores_streak.py
+++ b/backend/tests/unit/test_scores_streak.py
@@ -1,0 +1,149 @@
+"""Action-item completion streak: database.get_completion_streak and GET /v1/scores/streak.
+
+The streak is a consecutive-day engagement metric over action-item completions, bucketed by
+``completed_at`` in the caller's IANA time zone. A day counts when at least one non-deleted item
+was completed that day. The current streak stays alive through today until the day ends (it anchors
+on yesterday when nothing has been completed yet today), while the longest streak scans the window.
+
+These tests drive the pure day-bucketing/counting logic through an injected fake Firestore client
+(the ``firestore_client=`` seam), plus the endpoint's timezone validation. No Redis/Firestore/network.
+"""
+
+import os
+
+os.environ.setdefault(
+    "ENCRYPTION_SECRET",
+    "omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv",
+)
+os.environ.setdefault("OPENAI_API_KEY", "sk-test")
+
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+import pytest
+from fastapi import HTTPException
+
+import database.action_items as action_items_db
+import routers.scores as scores
+
+
+def _utc(year, month, day, hour=12):
+    return datetime(year, month, day, hour, 0, tzinfo=timezone.utc)
+
+
+class _FakeDoc:
+    def __init__(self, data):
+        self._data = data
+
+    def to_dict(self):
+        return self._data
+
+
+class _FakeActionItems:
+    """Minimal Firestore stand-in for collection().document().collection().where().stream().
+
+    The test seeds only in-window docs, so the range filter is a no-op here.
+    """
+
+    def __init__(self, docs):
+        self._docs = [_FakeDoc(d) for d in docs]
+
+    def collection(self, _name):
+        return self
+
+    def document(self, _uid):
+        return self
+
+    def where(self, filter=None):
+        return self
+
+    def stream(self):
+        return iter(self._docs)
+
+
+def _item(completed_at, *, completed=True, deleted=False):
+    return {'completed': completed, 'deleted': deleted, 'completed_at': completed_at}
+
+
+def _streak(docs, *, tz='UTC', today='2026-06-15'):
+    return action_items_db.get_completion_streak('u', tz=tz, today=today, firestore_client=_FakeActionItems(docs))
+
+
+class TestCompletionStreak:
+    def test_no_completed_items(self):
+        assert _streak([]) == {
+            'current_streak': 0,
+            'longest_streak': 0,
+            'completed_today': False,
+            'last_completed_date': None,
+        }
+
+    def test_completed_today_and_prior_two_days(self):
+        result = _streak([_item(_utc(2026, 6, 15)), _item(_utc(2026, 6, 14)), _item(_utc(2026, 6, 13))])
+        assert result['current_streak'] == 3
+        assert result['completed_today'] is True
+        assert result['longest_streak'] == 3
+        assert result['last_completed_date'] == '2026-06-15'
+
+    def test_streak_alive_through_yesterday_when_today_empty(self):
+        # Completed yesterday and the day before, nothing yet today -> still a live streak of 2.
+        result = _streak([_item(_utc(2026, 6, 14)), _item(_utc(2026, 6, 13))])
+        assert result['current_streak'] == 2
+        assert result['completed_today'] is False
+        assert result['last_completed_date'] == '2026-06-14'
+
+    def test_gap_resets_current_but_longest_tracks_best(self):
+        # 14,13 give current=2 (through yesterday); gap at 12; 11,10,9 give a longest run of 3.
+        docs = [
+            _item(_utc(2026, 6, 14)),
+            _item(_utc(2026, 6, 13)),
+            _item(_utc(2026, 6, 11)),
+            _item(_utc(2026, 6, 10)),
+            _item(_utc(2026, 6, 9)),
+        ]
+        result = _streak(docs)
+        assert result['current_streak'] == 2
+        assert result['longest_streak'] == 3
+
+    def test_multiple_completions_same_day_count_once(self):
+        docs = [_item(_utc(2026, 6, 15, 9)), _item(_utc(2026, 6, 15, 17)), _item(_utc(2026, 6, 14))]
+        assert _streak(docs)['current_streak'] == 2
+
+    def test_deleted_and_incomplete_items_ignored(self):
+        docs = [
+            _item(_utc(2026, 6, 15)),
+            _item(_utc(2026, 6, 14), deleted=True),
+            _item(_utc(2026, 6, 13), completed=False),
+        ]
+        result = _streak(docs)
+        assert result['current_streak'] == 1
+        assert result['completed_today'] is True
+
+    def test_timezone_buckets_completed_at_to_local_day(self):
+        # 2026-01-02T02:00Z is 2026-01-01 21:00 in America/New_York -> local day 2026-01-01.
+        docs = [_item(datetime(2026, 1, 2, 2, 0, tzinfo=timezone.utc))]
+        ny = _streak(docs, tz='America/New_York', today='2026-01-01')
+        assert ny['completed_today'] is True
+        assert ny['last_completed_date'] == '2026-01-01'
+        # The same instant is 2026-01-02 in UTC.
+        utc = _streak(docs, tz='UTC', today='2026-01-02')
+        assert utc['last_completed_date'] == '2026-01-02'
+
+
+class TestStreakEndpoint:
+    def test_invalid_timezone_is_400(self):
+        with pytest.raises(HTTPException) as ei:
+            scores.get_streak(tz='Not/AZone', uid='u')
+        assert ei.value.status_code == 400
+
+    def test_endpoint_returns_helper_result(self):
+        payload = {
+            'current_streak': 4,
+            'longest_streak': 9,
+            'completed_today': True,
+            'last_completed_date': '2026-06-15',
+        }
+        with patch.object(scores.action_items_db, 'get_completion_streak', return_value=payload) as helper:
+            result = scores.get_streak(tz='America/Los_Angeles', uid='u1')
+        assert result == payload
+        helper.assert_called_once_with('u1', tz='America/Los_Angeles')


### PR DESCRIPTION
## What

The scores router already computes daily, weekly, and overall productivity scores from action items, but there was no streak, the standard consecutive-day engagement metric users expect from a productivity surface. This adds `GET /v1/scores/streak`.

It is purely additive (a new read endpoint over data already stored), so there is no behavior change for existing users.

## Changes

- `database/action_items.py`
  - `get_completion_streak(uid, tz='UTC', today=None, max_days=366)` returns `{current_streak, longest_streak, completed_today, last_completed_date}`.
  - A day counts toward the streak when at least one non-deleted action item was completed that day, bucketed by `completed_at` in the caller's IANA time zone.
  - The current streak is the run of consecutive completed days ending today, or ending yesterday when nothing has been completed yet today, so a live streak is not reported as broken before the day is over.
  - It uses a single range query on `completed_at` (mirroring `get_scores`), so no composite Firestore index is required. It takes an optional `firestore_client` for test injection, per the backend guide.
- `routers/scores.py`
  - `GET /v1/scores/streak?tz=` returns the streak. An unknown time zone returns a 400.

## Tests

`tests/unit/test_scores_streak.py` (9 cases): no completions, a live streak including today, a streak still alive through yesterday when today is empty, a mid-window gap that resets the current streak while the longest is tracked, multiple completions on one day counted once, deleted and not-completed items ignored, timezone bucketing across a day boundary, and the endpoint timezone validation plus pass-through. Uses normal imports plus an injected fake Firestore client, so there is no `sys.modules` mutation and no network.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8969?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

