### PR TITLE
Add staged-task review controls: promote-by-id and clear-all

### DIFF
--- a/backend/database/staged_tasks.py
+++ b/backend/database/staged_tasks.py
@@ -119,12 +119,14 @@ def batch_update_staged_scores(uid: str, scores: List[dict]) -> None:
         batch.commit()
 
 
-def promote_staged_task(uid: str) -> Optional[dict]:
-    """Promote the top-scored staged task to an action_item.
+def promote_staged_task(uid: str, task_id: Optional[str] = None) -> Optional[dict]:
+    """Promote a staged task to an action_item.
 
-    Returns the new (or pre-existing) action_item dict, or None if no staged
-    tasks exist. Uses ``database.action_items.create_action_item()`` for
-    consistent field handling.
+    When ``task_id`` is given, promote that specific candidate; otherwise promote the
+    top-scored active staged task (the original behavior). Returns the new (or pre-existing)
+    action_item dict, or None if there is nothing to promote — no staged tasks exist, or the
+    given id does not exist or is already promoted/completed. Uses
+    ``database.action_items.create_action_item()`` for consistent field handling.
 
     Deduplicates against the live ``action_items`` collection: if a user
     already has an active (uncompleted, undeleted) action_item with the same
@@ -139,17 +141,26 @@ def promote_staged_task(uid: str) -> Optional[dict]:
     a few hours of activity.
     """
     col = _user_col(uid, 'staged_tasks')
-    query = (
-        col.where(filter=FieldFilter('completed', '==', False))
-        .order_by('relevance_score', direction=firestore.Query.ASCENDING)
-        .limit(1)
-    )
-    docs = list(query.stream())
-    if not docs:
-        return None
-
-    staged = docs[0].to_dict()
-    staged['id'] = docs[0].id
+    if task_id is not None:
+        snap = col.document(task_id).get()
+        if not snap.exists:
+            return None
+        staged = snap.to_dict() or {}
+        if staged.get('completed'):
+            # Already promoted/closed — nothing to do.
+            return None
+        staged['id'] = snap.id
+    else:
+        query = (
+            col.where(filter=FieldFilter('completed', '==', False))
+            .order_by('relevance_score', direction=firestore.Query.ASCENDING)
+            .limit(1)
+        )
+        docs = list(query.stream())
+        if not docs:
+            return None
+        staged = docs[0].to_dict()
+        staged['id'] = docs[0].id
 
     # Dedup: skip promotion if an active action_item with the same description
     # already exists. Close the staged task pointing at the existing item.
@@ -213,6 +224,27 @@ def promote_staged_task(uid: str) -> Optional[dict]:
 
     action_item = action_items_db.get_action_item(uid, action_id)
     return action_item
+
+
+def clear_staged_tasks(uid: str) -> int:
+    """Delete all active (uncompleted) staged tasks for a user in one call.
+
+    Returns the number deleted. Scoped to completed==False so promotion history
+    (completed/promoted staged tasks) is preserved.
+    """
+    col = _user_col(uid, 'staged_tasks')
+    active_query = col.where(filter=FieldFilter('completed', '==', False)).select([])
+    batch = db.batch()
+    count = 0
+    total = 0
+    for doc in active_query.stream():
+        batch.delete(col.document(doc.id))
+        count += 1
+        total += 1
+        batch, count = _commit_batch(batch, count)
+    if count > 0:
+        batch.commit()
+    return total
 
 
 def migrate_ai_tasks(uid: str) -> dict:

--- a/backend/routers/staged_tasks.py
+++ b/backend/routers/staged_tasks.py
@@ -1,6 +1,6 @@
 """Staged tasks — AI-generated tasks awaiting user promotion to action items."""
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
 from typing import List
 from datetime import datetime
 from pydantic import BaseModel, Field
@@ -71,6 +71,12 @@ def get_staged_tasks(
     return {'items': items, 'has_more': has_more}
 
 
+@router.delete('/v1/staged-tasks', tags=['staged-tasks'])
+def clear_staged_tasks(uid: str = Depends(auth.get_current_user_uid)):
+    count = staged_tasks_db.clear_staged_tasks(uid)
+    return {'status': 'ok', 'deleted_count': count}
+
+
 @router.delete('/v1/staged-tasks/{task_id}', tags=['staged-tasks'])
 def delete_staged_task(
     task_id: str,
@@ -94,6 +100,14 @@ def promote_staged_task(uid: str = Depends(auth.get_current_user_uid)):
     action_item = staged_tasks_db.promote_staged_task(uid)
     if action_item is None:
         return {'promoted': False, 'reason': 'No staged tasks available', 'promoted_task': None}
+    return {'promoted': True, 'reason': None, 'promoted_task': action_item}
+
+
+@router.post('/v1/staged-tasks/{task_id}/promote', tags=['staged-tasks'])
+def promote_staged_task_by_id(task_id: str, uid: str = Depends(auth.get_current_user_uid)):
+    action_item = staged_tasks_db.promote_staged_task(uid, task_id=task_id)
+    if action_item is None:
+        raise HTTPException(status_code=404, detail='Staged task not found or already promoted')
     return {'promoted': True, 'reason': None, 'promoted_task': action_item}
 
 

--- a/backend/tests/unit/test_staged_tasks_review_controls.py
+++ b/backend/tests/unit/test_staged_tasks_review_controls.py
@@ -1,0 +1,155 @@
+"""Staged-task review controls: promote-by-id and clear-all.
+
+Staged tasks are the buffer of AI-extracted task candidates a user reviews before they become
+action items (Nik's #5079 "Task Detection Is Too Aggressive"). This adds the two missing review
+verbs: promote a specific chosen candidate (POST /v1/staged-tasks/{task_id}/promote) and clear the
+whole active queue in one call (DELETE /v1/staged-tasks).
+
+- promote_staged_task now takes an optional task_id: when given it promotes that candidate through
+  the same dedup/merge/create tail as the top-scored path (default task_id=None is unchanged).
+- clear_staged_tasks batch-deletes only active (completed==False) staged tasks, preserving history.
+
+Test isolation: the modules import cleanly, so they are imported normally and the collection is
+faked via monkeypatch.setattr(staged_tasks_db, '_user_col'/'db') (no sys.modules mutation).
+"""
+
+import os
+
+os.environ.setdefault("ENCRYPTION_SECRET", "omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv")
+os.environ.setdefault("OPENAI_API_KEY", "sk-test")
+
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import HTTPException
+
+from database import action_items as action_items_db
+from database import staged_tasks as staged_tasks_db
+import routers.staged_tasks as r
+
+
+def _make_doc(doc_id, data):
+    doc = MagicMock()
+    doc.id = doc_id
+    doc.to_dict.return_value = data
+    return doc
+
+
+def _stub_staged_by_id(monkeypatch, task_id, data):
+    """Stub _user_col so document(task_id).get() returns a doc with `data` (exists=False if None)."""
+    snap = MagicMock()
+    snap.exists = data is not None
+    snap.id = task_id
+    snap.to_dict.return_value = data
+
+    update_calls = {}
+    ref = MagicMock()
+    ref.get.return_value = snap
+    ref.update.side_effect = lambda payload: update_calls.update(payload)
+
+    fake_col = MagicMock()
+    fake_col.document.return_value = ref
+    monkeypatch.setattr(staged_tasks_db, "_user_col", lambda uid, name: fake_col)
+    return fake_col, update_calls
+
+
+def _stub_clear(monkeypatch, doc_ids):
+    """Stub _user_col + db.batch for clear_staged_tasks."""
+    fake_query = MagicMock()
+    fake_query.select.return_value = fake_query
+    fake_query.stream.return_value = iter([_make_doc(d, {}) for d in doc_ids])
+
+    fake_col = MagicMock()
+    fake_col.where.return_value = fake_query
+
+    batch = MagicMock()
+    monkeypatch.setattr(staged_tasks_db, "_user_col", lambda uid, name: fake_col)
+    monkeypatch.setattr(staged_tasks_db, "db", MagicMock(batch=MagicMock(return_value=batch)))
+    return fake_col, fake_query, batch
+
+
+# --- promote_staged_task(task_id=...) ---
+
+
+class TestPromoteById:
+    def test_promotes_the_specified_candidate(self, monkeypatch):
+        fake_col, update_calls = _stub_staged_by_id(
+            monkeypatch, "staged-x", {"id": "staged-x", "description": "Unique task", "completed": False}
+        )
+        monkeypatch.setattr(action_items_db, "get_active_action_item_by_description", lambda uid, desc: None)
+        monkeypatch.setattr(action_items_db, "create_action_item", lambda uid, data: "fresh-1")
+        monkeypatch.setattr(
+            action_items_db, "get_action_item", lambda uid, aid: {"id": aid, "description": "Unique task"}
+        )
+
+        result = staged_tasks_db.promote_staged_task("uid", task_id="staged-x")
+
+        assert result == {"id": "fresh-1", "description": "Unique task"}
+        fake_col.document.assert_any_call("staged-x")  # promoted the chosen doc, not a scored query
+        assert update_calls.get("completed") is True
+
+    def test_dedup_tail_still_applies_when_promoting_by_id(self, monkeypatch):
+        _stub_staged_by_id(
+            monkeypatch, "staged-y", {"id": "staged-y", "description": "Follow up on Volt", "completed": False}
+        )
+        existing = {"id": "existing-1", "description": "Follow up on Volt", "completed": False}
+        monkeypatch.setattr(action_items_db, "get_active_action_item_by_description", lambda uid, desc: existing)
+        create_called = []
+        monkeypatch.setattr(
+            action_items_db, "create_action_item", lambda uid, data: create_called.append(data) or "nope"
+        )
+
+        result = staged_tasks_db.promote_staged_task("uid", task_id="staged-y")
+
+        assert result == existing
+        assert create_called == []  # dedup guard fired instead of creating a duplicate
+
+    def test_nonexistent_id_returns_none(self, monkeypatch):
+        _stub_staged_by_id(monkeypatch, "ghost", None)  # snap.exists = False
+        assert staged_tasks_db.promote_staged_task("uid", task_id="ghost") is None
+
+    def test_already_completed_returns_none(self, monkeypatch):
+        _stub_staged_by_id(monkeypatch, "done-1", {"id": "done-1", "description": "x", "completed": True})
+        assert staged_tasks_db.promote_staged_task("uid", task_id="done-1") is None
+
+
+# --- clear_staged_tasks ---
+
+
+class TestClearStagedTasks:
+    def test_deletes_active_and_returns_count(self, monkeypatch):
+        fake_col, fake_query, batch = _stub_clear(monkeypatch, ["a", "b", "c"])
+        count = staged_tasks_db.clear_staged_tasks("uid")
+        assert count == 3
+        assert batch.delete.call_count == 3
+        batch.commit.assert_called_once()
+        fake_col.where.assert_called_once()  # scoped, not an unfiltered wipe
+        fake_query.select.assert_called_once()  # IDs-only projection
+
+    def test_empty_queue_returns_zero_without_commit(self, monkeypatch):
+        _fake_col, _fake_query, batch = _stub_clear(monkeypatch, [])
+        assert staged_tasks_db.clear_staged_tasks("uid") == 0
+        batch.delete.assert_not_called()
+        batch.commit.assert_not_called()
+
+
+# --- router handlers (called directly) ---
+
+
+class TestRouterHandlers:
+    def test_promote_by_id_success_shape(self, monkeypatch):
+        monkeypatch.setattr(
+            r.staged_tasks_db, "promote_staged_task", lambda uid, task_id: {"id": "a1", "description": "x"}
+        )
+        result = r.promote_staged_task_by_id("a1", uid="u1")
+        assert result == {"promoted": True, "reason": None, "promoted_task": {"id": "a1", "description": "x"}}
+
+    def test_promote_by_id_404_when_missing(self, monkeypatch):
+        monkeypatch.setattr(r.staged_tasks_db, "promote_staged_task", lambda uid, task_id: None)
+        with pytest.raises(HTTPException) as ei:
+            r.promote_staged_task_by_id("ghost", uid="u1")
+        assert ei.value.status_code == 404
+
+    def test_clear_returns_deleted_count(self, monkeypatch):
+        monkeypatch.setattr(r.staged_tasks_db, "clear_staged_tasks", lambda uid: 5)
+        assert r.clear_staged_tasks(uid="u1") == {"status": "ok", "deleted_count": 5}


### PR DESCRIPTION
## What

Staged tasks are the buffer of AI-extracted task candidates a user reviews before they are promoted to real action items. Today the only controls are delete-one-by-id and auto-promote-the-single-top-scored-one, which is a poor fit for the complaint in #5079 "Task Detection Is Too Aggressive" (labels intelligence, maintainer, p2): when the AI mints a queue of mostly-junk candidates, a user wants to clear the whole queue in one action and cherry-pick the one good candidate rather than promote whatever the scorer ranked first.

This adds those two review verbs. It is purely additive: no existing route or signature changes behavior.

## Changes

- `database/staged_tasks.py`
  - `promote_staged_task(uid, task_id=None)`: when `task_id` is given, promote that specific candidate; otherwise promote the top-scored active staged task (the original behavior). The by-id path runs through the same dedup/merge/create tail, so promoting a chosen candidate still deduplicates against the live action_items and merges richer scheduling fields. A missing id, or one already promoted/completed, returns None. The default `task_id=None` keeps every existing caller unchanged.
  - `clear_staged_tasks(uid)`: batch-deletes only active (`completed == False`) staged tasks, so promotion history is preserved, and returns the number deleted.
- `routers/staged_tasks.py`
  - `POST /v1/staged-tasks/{task_id}/promote` — promote a chosen candidate; 404 when the id is missing or already promoted. Distinct from the existing static `POST /v1/staged-tasks/promote`.
  - `DELETE /v1/staged-tasks` — clear the active queue; returns `{status, deleted_count}`. Distinct from the existing `DELETE /v1/staged-tasks/{task_id}`.

## Tests

`tests/unit/test_staged_tasks_review_controls.py` (9 cases): promote-by-id promotes the chosen doc and still runs the dedup guard, a missing or already-completed id returns None, clear deletes only active tasks and returns the count (and no-ops on an empty queue), and the router handlers return the right shapes and 404. The existing top-scored `promote_staged_task` path and its dedup tests are unchanged (verified). The modules are imported normally and the collection is faked via `monkeypatch.setattr(_user_col/db)`, so there is no `sys.modules` mutation and no network.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8973?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

