### PR TITLE
Add import-job lifecycle: cancel in-progress and delete finished jobs

### DIFF
--- a/backend/models/import_job.py
+++ b/backend/models/import_job.py
@@ -10,6 +10,7 @@ class ImportJobStatus(str, Enum):
     processing = 'processing'
     completed = 'completed'
     failed = 'failed'
+    cancelled = 'cancelled'
 
 
 class ImportSourceType(str, Enum):

--- a/backend/routers/imports.py
+++ b/backend/routers/imports.py
@@ -169,6 +169,44 @@ def get_import_job_status(
     )
 
 
+@router.post('/v1/import/jobs/{job_id}/cancel', response_model=ImportJobResponse, tags=['import'])
+def cancel_import_job(job_id: str, uid: str = Depends(auth.get_current_user_uid)):
+    """Cancel a pending or processing import job."""
+    job = import_jobs_db.get_import_job(job_id)
+    if not job:
+        raise HTTPException(status_code=404, detail="Import job not found")
+    if job['uid'] != uid:
+        raise HTTPException(status_code=403, detail="Not authorized to modify this import job")
+    if job.get('status') not in (ImportJobStatus.pending.value, ImportJobStatus.processing.value):
+        raise HTTPException(status_code=409, detail="Only a pending or processing import can be cancelled")
+
+    import_jobs_db.update_import_job(job_id, {'status': ImportJobStatus.cancelled.value, 'error': 'Cancelled by user'})
+    return ImportJobResponse(
+        job_id=job['id'],
+        status=ImportJobStatus.cancelled,
+        total_files=job.get('total_files'),
+        processed_files=job.get('processed_files'),
+        conversations_created=job.get('conversations_created'),
+        created_at=job.get('created_at'),
+        error='Cancelled by user',
+    )
+
+
+@router.delete('/v1/import/jobs/{job_id}', tags=['import'])
+def delete_import_job(job_id: str, uid: str = Depends(auth.get_current_user_uid)):
+    """Delete a finished (completed, failed, or cancelled) import job."""
+    job = import_jobs_db.get_import_job(job_id)
+    if not job:
+        raise HTTPException(status_code=404, detail="Import job not found")
+    if job['uid'] != uid:
+        raise HTTPException(status_code=403, detail="Not authorized to modify this import job")
+    if job.get('status') in (ImportJobStatus.pending.value, ImportJobStatus.processing.value):
+        raise HTTPException(status_code=409, detail="Cancel the in-progress import before deleting it")
+
+    import_jobs_db.delete_import_job(job_id)
+    return {'status': 'ok', 'job_id': job_id}
+
+
 @router.delete(
     '/v1/import/limitless/conversations',
     tags=['import'],

--- a/backend/tests/routers/test_imports.py
+++ b/backend/tests/routers/test_imports.py
@@ -1,0 +1,106 @@
+"""Import-job lifecycle: POST /v1/import/jobs/{job_id}/cancel and DELETE /v1/import/jobs/{job_id}.
+
+A user can start, list, and get the status of import jobs, but there was no way to cancel a stuck
+or running import or remove a finished one. cancel handles the in-progress states (pending/
+processing -> cancelled); delete handles the terminal states (completed/failed/cancelled). Both
+mirror the existing ownership pattern (404 unknown, 403 wrong owner). The worker skips its final
+status write when the job was cancelled mid-run, so a cancel sticks.
+
+Test isolation: routers.imports imports cleanly (tests/conftest.py sets the env, stubs tiktoken,
+and blocks network), so the module is imported normally and the db helpers are patched.
+"""
+
+import os
+
+os.environ.setdefault("ENCRYPTION_SECRET", "omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv")
+os.environ.setdefault("OPENAI_API_KEY", "sk-test")
+
+from unittest.mock import patch
+
+import pytest
+from fastapi import HTTPException
+
+from routers import imports as imports_mod
+from models.import_job import ImportJobStatus
+
+UID = "u1"
+
+
+def _job(status, uid=UID, job_id="j1"):
+    return {
+        "id": job_id,
+        "uid": uid,
+        "status": status,
+        "total_files": 3,
+        "processed_files": 3,
+        "conversations_created": 2,
+        "created_at": "2026-01-01T00:00:00",
+        "error": None,
+    }
+
+
+class TestCancelImportJob:
+    @pytest.mark.parametrize("status", ["pending", "processing"])
+    def test_cancel_in_progress(self, status):
+        with patch.object(imports_mod.import_jobs_db, "get_import_job", return_value=_job(status)), patch.object(
+            imports_mod.import_jobs_db, "update_import_job"
+        ) as upd:
+            resp = imports_mod.cancel_import_job("j1", uid=UID)
+        assert resp.status == ImportJobStatus.cancelled
+        upd.assert_called_once()
+        assert upd.call_args.args[1]["status"] == ImportJobStatus.cancelled.value
+
+    @pytest.mark.parametrize("status", ["completed", "failed", "cancelled"])
+    def test_cancel_terminal_is_409(self, status):
+        with patch.object(imports_mod.import_jobs_db, "get_import_job", return_value=_job(status)), patch.object(
+            imports_mod.import_jobs_db, "update_import_job"
+        ) as upd:
+            with pytest.raises(HTTPException) as ei:
+                imports_mod.cancel_import_job("j1", uid=UID)
+        assert ei.value.status_code == 409
+        upd.assert_not_called()
+
+    def test_cancel_missing_is_404(self):
+        with patch.object(imports_mod.import_jobs_db, "get_import_job", return_value=None):
+            with pytest.raises(HTTPException) as ei:
+                imports_mod.cancel_import_job("j1", uid=UID)
+        assert ei.value.status_code == 404
+
+    def test_cancel_wrong_owner_is_403(self):
+        with patch.object(imports_mod.import_jobs_db, "get_import_job", return_value=_job("pending", uid="other")):
+            with pytest.raises(HTTPException) as ei:
+                imports_mod.cancel_import_job("j1", uid=UID)
+        assert ei.value.status_code == 403
+
+
+class TestDeleteImportJob:
+    @pytest.mark.parametrize("status", ["completed", "failed", "cancelled"])
+    def test_delete_terminal_ok(self, status):
+        with patch.object(imports_mod.import_jobs_db, "get_import_job", return_value=_job(status)), patch.object(
+            imports_mod.import_jobs_db, "delete_import_job"
+        ) as dele:
+            result = imports_mod.delete_import_job("j1", uid=UID)
+        assert result == {"status": "ok", "job_id": "j1"}
+        dele.assert_called_once_with("j1")
+
+    @pytest.mark.parametrize("status", ["pending", "processing"])
+    def test_delete_in_progress_is_409(self, status):
+        with patch.object(imports_mod.import_jobs_db, "get_import_job", return_value=_job(status)), patch.object(
+            imports_mod.import_jobs_db, "delete_import_job"
+        ) as dele:
+            with pytest.raises(HTTPException) as ei:
+                imports_mod.delete_import_job("j1", uid=UID)
+        assert ei.value.status_code == 409
+        dele.assert_not_called()
+
+    def test_delete_missing_is_404(self):
+        with patch.object(imports_mod.import_jobs_db, "get_import_job", return_value=None):
+            with pytest.raises(HTTPException) as ei:
+                imports_mod.delete_import_job("j1", uid=UID)
+        assert ei.value.status_code == 404
+
+    def test_delete_wrong_owner_is_403(self):
+        with patch.object(imports_mod.import_jobs_db, "get_import_job", return_value=_job("completed", uid="other")):
+            with pytest.raises(HTTPException) as ei:
+                imports_mod.delete_import_job("j1", uid=UID)
+        assert ei.value.status_code == 403

--- a/backend/utils/imports/limitless.py
+++ b/backend/utils/imports/limitless.py
@@ -359,6 +359,13 @@ def process_limitless_import(job_id: str, uid: str, zip_path: str, language_code
                     # Partial success
                     error_msg = f"{len(errors)} files failed to process"
 
+            # A user cancel during processing must stick: don't overwrite a cancelled job with the
+            # final completed/failed status.
+            current = import_jobs_db.get_import_job(job_id)
+            if current and current.get('status') == ImportJobStatus.cancelled.value:
+                logger.info(f"Import job {job_id} was cancelled; skipping final status write")
+                return
+
             import_jobs_db.update_import_job(
                 job_id,
                 {


### PR DESCRIPTION
## What

Users can start (`POST /v1/import/limitless`), list (`GET /v1/import/jobs`), and check the status of an import job, but there was no way to cancel a stuck or running import or remove a finished/failed one, so old jobs pile up in the list with no recourse. This adds the two missing lifecycle verbs. It sits in the actively-built ChatGPT/Claude/Limitless memory-bank import area (#4862, #8764), and it wires up the `delete_import_job` db helper that already shipped but was never called by any router.

Purely additive: no existing route or behavior changes.

## Changes

- `models/import_job.py` — add a `cancelled` status to `ImportJobStatus`.
- `routers/imports.py`
  - `POST /v1/import/jobs/{job_id}/cancel` — cancels a `pending` or `processing` job (sets `cancelled` + an error note); 409 if the job is already terminal.
  - `DELETE /v1/import/jobs/{job_id}` — deletes a terminal job (`completed`/`failed`/`cancelled`); 409 while it is still in progress (cancel first).
  - Both mirror the existing `get_import_job_status` ownership checks (404 unknown, 403 wrong owner). The two endpoints form a clean state machine (cancel for in-progress, delete for terminal), so the delete path never races the background worker.
- `utils/imports/limitless.py` — the worker re-reads the job right before its final status write and bails if it was cancelled, so a mid-run cancel is not overwritten by `completed`/`failed`.

## Tests

`tests/routers/test_imports.py` (14 cases): cancel of pending/processing sets `cancelled` and calls `update_import_job`; cancel of a terminal job is 409; delete of completed/failed/cancelled calls `delete_import_job`; delete of an in-progress job is 409; and both 404 on a missing job and 403 on a wrong-owner job. The module is imported normally and the db helpers are patched (no `sys.modules` mutation, no network).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8975?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

