### PR TITLE
Add GET /v2/firmware/version: OTA metadata for a specific firmware version

### DIFF
--- a/backend/routers/firmware.py
+++ b/backend/routers/firmware.py
@@ -152,6 +152,21 @@ def _find_candidate_releases(
     return candidates
 
 
+def _find_release_by_version(
+    releases: List[Dict], release_prefix: str, target_firmware_tuple: Tuple[int, ...]
+) -> Optional[Dict]:
+    """Return the release whose release_firmware_version equals the target, or None.
+
+    Reuses _find_candidate_releases (current=None) so the same draft/prerelease/tag/parseable
+    validation applies, then matches the exact requested version.
+    """
+    for release in _find_candidate_releases(releases, release_prefix):
+        kv = extract_key_value_pairs(release.get("body"))
+        if _parse_firmware_version(kv.get("release_firmware_version")) == target_firmware_tuple:
+            return release
+    return None
+
+
 def _extract_firmware_response(device: DeviceModel, release: Dict) -> Dict:
     """Extract firmware details and download asset from a GitHub release."""
     kv = extract_key_value_pairs(release.get("body"))
@@ -251,3 +266,29 @@ async def get_stable_version(device_model: str):
 
     candidates.sort(key=lambda r: r.get("published_at", ""), reverse=True)
     return _extract_firmware_response(device, candidates[0])
+
+
+@router.get("/v2/firmware/version")
+async def get_firmware_version(device_model: str, version: str):
+    """Return the OTA metadata for a specific published firmware version of a device.
+
+    Complements /v2/firmware/stable by making any individual published build addressable, e.g. to pin
+    or roll a device back to a known-good earlier version, or for QA/support to flash a named build.
+    """
+    device = _get_device_by_model_number(device_model)
+    if not device:
+        raise HTTPException(status_code=404, detail="Device not found")
+
+    target = _parse_firmware_version(version)
+    if target is None:
+        raise HTTPException(status_code=400, detail="Could not parse requested firmware version")
+
+    releases = await get_omi_github_releases("github_releases_omi", tag_filter=FIRMWARE_TAG_PATTERN)
+    if not releases:
+        raise HTTPException(status_code=404, detail="No releases found for the repository")
+
+    match = _find_release_by_version(releases, _get_release_prefix(device), target)
+    if not match:
+        raise HTTPException(status_code=404, detail="Requested firmware version not found for your device.")
+
+    return _extract_firmware_response(device, match)

--- a/backend/routers/firmware.py
+++ b/backend/routers/firmware.py
@@ -157,10 +157,14 @@ def _find_release_by_version(
 ) -> Optional[Dict]:
     """Return the release whose release_firmware_version equals the target, or None.
 
-    Reuses _find_candidate_releases (current=None) so the same draft/prerelease/tag/parseable
-    validation applies, then matches the exact requested version.
+    Reuses _find_candidate_releases (current=None) for the device-prefix / draft / prerelease / tag
+    filtering, sorts newest-published first (matching get_stable/get_latest) so the result is
+    deterministic if two releases ever advertise the same version, then matches the exact target. An
+    unparseable stored version simply won't equal the (already-validated) target, so it is skipped.
     """
-    for release in _find_candidate_releases(releases, release_prefix):
+    candidates = _find_candidate_releases(releases, release_prefix)
+    candidates.sort(key=lambda r: r.get("published_at", ""), reverse=True)
+    for release in candidates:
         kv = extract_key_value_pairs(release.get("body"))
         if _parse_firmware_version(kv.get("release_firmware_version")) == target_firmware_tuple:
             return release

--- a/backend/tests/unit/test_firmware_specific_version.py
+++ b/backend/tests/unit/test_firmware_specific_version.py
@@ -1,0 +1,135 @@
+"""GET /v2/firmware/version: OTA metadata for one specific published firmware version of a device.
+
+/v2/firmware/stable only returns the latest stable build, so there was no way to address an exact
+earlier version. This adds that, so a device can be pinned or rolled back to a known-good build, or
+QA/support can flash a named version. It reuses the existing hardened helpers (_find_candidate_releases
+applies the same draft/prerelease/tag/parseable validation) and mirrors get_stable_version.
+
+Test isolation: routers.firmware imports cleanly; the async handler is driven via asyncio.run with
+get_omi_github_releases patched (no network), and extract_key_value_pairs stays real to parse fixtures.
+"""
+
+import os
+
+os.environ.setdefault("ENCRYPTION_SECRET", "omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv")
+os.environ.setdefault("OPENAI_API_KEY", "sk-test")
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+import routers.firmware as fw
+
+
+def _release(tag, version, assets, draft=False, prerelease=False, published_at="2026-01-01T00:00:00Z"):
+    body = f"<!-- KEY_VALUE_START\nrelease_firmware_version: {version}\nKEY_VALUE_END -->"
+    return {
+        "tag_name": tag,
+        "body": body,
+        "assets": assets,
+        "draft": draft,
+        "prerelease": prerelease,
+        "published_at": published_at,
+    }
+
+
+def _ota(version="3.0.15"):
+    return [{"name": f"Omi_CV1_OTA_v{version}.zip", "browser_download_url": "https://x/ota.zip"}]
+
+
+def _bin(version="2.3.2"):
+    return [{"name": f"omiglass_v{version}.bin", "browser_download_url": "https://x/fw.bin"}]
+
+
+def _call(**kw):
+    params = {"device_model": "Omi CV 1", "version": "3.0.15"}
+    params.update(kw)
+    return asyncio.run(fw.get_firmware_version(**params))
+
+
+def test_exact_match_non_glass_returns_ota_zip():
+    releases = [_release("Omi_CV1_v3.0.15", "3.0.15", _ota("3.0.15"))]
+    with patch.object(fw, "get_omi_github_releases", AsyncMock(return_value=releases)):
+        result = _call(version="3.0.15")
+    assert result["version"] == "3.0.15"
+    assert result["zip_url"] == "https://x/ota.zip"
+
+
+def test_exact_match_glass_returns_bin():
+    releases = [_release("OmiGlass_v2.3.2", "2.3.2", _bin("2.3.2"))]
+    with patch.object(fw, "get_omi_github_releases", AsyncMock(return_value=releases)):
+        result = _call(device_model="OmiGlass", version="2.3.2")
+    assert result["version"] == "2.3.2"
+    assert result["zip_url"] == "https://x/fw.bin"
+
+
+def test_version_normalization_accepts_v_prefix():
+    releases = [_release("Omi_CV1_v3.0.15", "3.0.15", _ota("3.0.15"))]
+    with patch.object(fw, "get_omi_github_releases", AsyncMock(return_value=releases)):
+        assert _call(version="v3.0.15")["version"] == "3.0.15"
+        assert _call(version="3.0.15")["version"] == "3.0.15"
+
+
+def test_picks_the_requested_version_not_the_newest():
+    releases = [
+        _release("Omi_CV1_v3.0.15", "3.0.15", _ota("3.0.15"), published_at="2026-03-01T00:00:00Z"),
+        _release("Omi_CV1_v3.0.10", "3.0.10", _ota("3.0.10"), published_at="2026-01-01T00:00:00Z"),
+    ]
+    with patch.object(fw, "get_omi_github_releases", AsyncMock(return_value=releases)):
+        assert _call(version="3.0.10")["version"] == "3.0.10"
+
+
+def test_not_found_is_404():
+    releases = [_release("Omi_CV1_v3.0.15", "3.0.15", _ota("3.0.15"))]
+    with patch.object(fw, "get_omi_github_releases", AsyncMock(return_value=releases)):
+        with pytest.raises(HTTPException) as ei:
+            _call(version="9.9.9")
+    assert ei.value.status_code == 404
+
+
+def test_unparseable_version_is_400_before_fetch():
+    m = AsyncMock(return_value=[])
+    with patch.object(fw, "get_omi_github_releases", m):
+        with pytest.raises(HTTPException) as ei:
+            _call(version="abc")
+    assert ei.value.status_code == 400
+    m.assert_not_called()  # 400 short-circuits before any release fetch
+
+
+def test_unknown_device_is_404_before_fetch():
+    m = AsyncMock(return_value=[])
+    with patch.object(fw, "get_omi_github_releases", m):
+        with pytest.raises(HTTPException) as ei:
+            _call(device_model="Nonexistent", version="3.0.15")
+    assert ei.value.status_code == 404
+    m.assert_not_called()
+
+
+def test_empty_releases_is_404():
+    with patch.object(fw, "get_omi_github_releases", AsyncMock(return_value=[])):
+        with pytest.raises(HTTPException) as ei:
+            _call(version="3.0.15")
+    assert ei.value.status_code == 404
+
+
+def test_draft_and_prerelease_excluded():
+    releases = [
+        _release("Omi_CV1_v3.0.15", "3.0.15", _ota("3.0.15"), draft=True),
+        _release("Omi_CV1_v3.0.16", "3.0.16", _ota("3.0.16"), prerelease=True),
+    ]
+    with patch.object(fw, "get_omi_github_releases", AsyncMock(return_value=releases)):
+        for v in ("3.0.15", "3.0.16"):
+            with pytest.raises(HTTPException) as ei:
+                _call(version=v)
+            assert ei.value.status_code == 404
+
+
+def test_helper_finds_exact_match():
+    releases = [
+        _release("Omi_CV1_v3.0.15", "3.0.15", _ota("3.0.15")),
+        _release("Omi_CV1_v3.0.10", "3.0.10", _ota("3.0.10")),
+    ]
+    assert fw._find_release_by_version(releases, "Omi_CV1", (3, 0, 10))["tag_name"] == "Omi_CV1_v3.0.10"
+    assert fw._find_release_by_version(releases, "Omi_CV1", (9, 9, 9)) is None

--- a/backend/tests/unit/test_firmware_specific_version.py
+++ b/backend/tests/unit/test_firmware_specific_version.py
@@ -133,3 +133,21 @@ def test_helper_finds_exact_match():
     ]
     assert fw._find_release_by_version(releases, "Omi_CV1", (3, 0, 10))["tag_name"] == "Omi_CV1_v3.0.10"
     assert fw._find_release_by_version(releases, "Omi_CV1", (9, 9, 9)) is None
+
+
+def test_duplicate_version_returns_newest_published_deterministically():
+    older = _release(
+        "Omi_CV1_v3.0.15",
+        "3.0.15",
+        [{"name": "Omi_CV1_OTA_v3.0.15.zip", "browser_download_url": "https://x/OLD.zip"}],
+        published_at="2026-01-01T00:00:00Z",
+    )
+    newer = _release(
+        "Omi_CV1_v3.0.15",
+        "3.0.15",
+        [{"name": "Omi_CV1_OTA_v3.0.15.zip", "browser_download_url": "https://x/NEW.zip"}],
+        published_at="2026-03-01T00:00:00Z",
+    )
+    # Raw list order older-first; the newest-published must win regardless.
+    with patch.object(fw, "get_omi_github_releases", AsyncMock(return_value=[older, newer])):
+        assert _call(version="3.0.15")["zip_url"] == "https://x/NEW.zip"


### PR DESCRIPTION
## What

`GET /v2/firmware/stable` returns only the latest stable firmware for a device, and `GET /v2/firmware/latest` is the "is there something newer than my current build" update check. Neither lets a caller request the metadata for one specific, named version. This adds `GET /v2/firmware/version?device_model=&version=`, so any individual published build is addressable.

Firmware/OTA is core to a hardware company, and this completes an existing capability: it enables pinning or rolling a device back to a known-good earlier build when the latest regresses on specific hardware, and lets QA/support flash a named version. It is a direct sibling of the `/v2/firmware/stable` endpoint, reusing the same hardened helpers. Additive, unauthenticated (device-facing, like its siblings), no behavior change to existing routes.

## Changes

- `routers/firmware.py`
  - `GET /v2/firmware/version?device_model=&version=` returns `_extract_firmware_response` for the release whose `release_firmware_version` matches the requested version. 400 if the version string is unparseable (before any fetch), 404 for an unknown device, no releases, or a version not published for that device.
  - `_find_release_by_version` reuses `_find_candidate_releases` (so the same draft/prerelease/tag/parseable-version filtering applies) and then matches the exact version. The endpoint mirrors `get_stable_version`. No new dependency; firmware has no database.

## Tests

`tests/unit/test_firmware_specific_version.py` (10 cases): exact match for a non-glass device (returns the OTA zip) and a glass device (returns the `.bin`); version normalization (`v3.0.15` and `3.0.15` both match); it returns the requested version rather than the newest; 404 when the version is not published; 400 on an unparseable version (asserting no release fetch happens); 404 for an unknown device and for empty releases; draft/prerelease releases are excluded; and the helper matches the exact release. The async handler is driven via `asyncio.run` with `get_omi_github_releases` patched, so there is no network. The existing `test_firmware_pagination.py` still passes.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8982?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

