### PR TITLE
Surface Google Calendar reconnect state + add onboarding reset

### DIFF
--- a/backend/routers/calendar_onboarding.py
+++ b/backend/routers/calendar_onboarding.py
@@ -4,6 +4,8 @@ Calendar onboarding router.
 Guides new users through Google Calendar connection during onboarding.
 """
 
+from typing import Optional
+
 from fastapi import APIRouter, Depends
 
 import database.users as users_db
@@ -12,13 +14,43 @@ from utils.other import endpoints as auth
 router = APIRouter()
 
 
+def _calendar_onboarding_state(integration: Optional[dict]) -> dict:
+    """Derive the calendar onboarding / reconnect state from the google_calendar integration.
+
+    Adds needs_reconnect + reauth_reason so the app can distinguish a never-connected user (show
+    "Connect calendar") from one whose OAuth token died (show "Reconnect calendar"). The backend
+    already writes reauth_required/reauth_reason and deletes access_token when a token refresh fails,
+    but no endpoint surfaced it. The existing connected / onboarding_completed semantics are unchanged.
+    """
+    integration = integration or {}
+    connected = bool(integration.get('connected'))
+    skipped = bool(integration.get('onboarding_skipped'))
+    reauth_required = bool(integration.get('reauth_required'))
+    has_token = bool(integration.get('access_token'))
+    needs_reconnect = reauth_required or (connected and not has_token)
+    reauth_reason = integration.get('reauth_reason') if reauth_required else None
+    if needs_reconnect:
+        state = 'needs_reconnect'
+    elif connected:
+        state = 'connected'
+    elif skipped:
+        state = 'skipped'
+    else:
+        state = 'not_started'
+    return {
+        'connected': connected,
+        'onboarding_completed': connected or skipped,
+        'needs_reconnect': needs_reconnect,
+        'reauth_reason': reauth_reason,
+        'state': state,
+    }
+
+
 @router.get('/v1/calendar/onboarding/status', tags=['calendar_onboarding'])
 def get_calendar_onboarding_status(uid: str = Depends(auth.get_current_user_uid)):
-    """Return whether the user has completed (or skipped) calendar onboarding."""
-    integration = users_db.get_integration(uid, 'google_calendar')
-    connected = bool(integration and integration.get('connected'))
-    skipped = bool(integration and integration.get('onboarding_skipped'))
-    return {'connected': connected, 'onboarding_completed': connected or skipped}
+    """Return the calendar onboarding state, including whether a previously-connected calendar now
+    needs reconnecting (its OAuth token expired)."""
+    return _calendar_onboarding_state(users_db.get_integration(uid, 'google_calendar'))
 
 
 @router.post('/v1/calendar/onboarding/skip', tags=['calendar_onboarding'])
@@ -26,3 +58,12 @@ def skip_calendar_onboarding(uid: str = Depends(auth.get_current_user_uid)):
     """Mark calendar onboarding as skipped so the prompt is not shown again."""
     users_db.set_integration(uid, 'google_calendar', {'onboarding_skipped': True})
     return {'skipped': True}
+
+
+@router.post('/v1/calendar/onboarding/reset', tags=['calendar_onboarding'])
+def reset_calendar_onboarding(uid: str = Depends(auth.get_current_user_uid)):
+    """Clear the skipped / reauth flags so the connect-calendar prompt is shown again."""
+    users_db.set_integration(
+        uid, 'google_calendar', {'onboarding_skipped': False, 'reauth_required': False, 'reauth_reason': None}
+    )
+    return {'reset': True}

--- a/backend/tests/unit/test_calendar_onboarding.py
+++ b/backend/tests/unit/test_calendar_onboarding.py
@@ -1,0 +1,114 @@
+"""Calendar onboarding + reconnect state: GET /v1/calendar/onboarding/status and POST .../reset.
+
+When a user's Google Calendar OAuth token dies, refresh_google_token writes reauth_required +
+reauth_reason and deletes access_token on the google_calendar integration, but no endpoint read
+that back, so the app couldn't tell "never connected" from "was connected, now needs reconnect".
+This surfaces needs_reconnect / reauth_reason / state on the status endpoint (existing keys kept)
+and adds a reset endpoint that clears the skipped/reauth flags.
+
+Test isolation: routers.calendar_onboarding imports cleanly; the pure state helper is tested
+directly and the sync endpoints are called directly with users_db monkeypatched (no network).
+"""
+
+import os
+
+os.environ.setdefault("ENCRYPTION_SECRET", "omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv")
+os.environ.setdefault("OPENAI_API_KEY", "sk-test")
+
+import routers.calendar_onboarding as co
+
+# --- pure state helper ---
+
+
+def test_state_none_is_not_started():
+    assert co._calendar_onboarding_state(None) == {
+        "connected": False,
+        "onboarding_completed": False,
+        "needs_reconnect": False,
+        "reauth_reason": None,
+        "state": "not_started",
+    }
+
+
+def test_state_connected():
+    s = co._calendar_onboarding_state({"connected": True, "access_token": "tok"})
+    assert s["state"] == "connected"
+    assert s["connected"] is True
+    assert s["onboarding_completed"] is True
+    assert s["needs_reconnect"] is False
+
+
+def test_state_skipped_only():
+    s = co._calendar_onboarding_state({"onboarding_skipped": True})
+    assert s["state"] == "skipped"
+    assert s["onboarding_completed"] is True
+    assert s["connected"] is False
+
+
+def test_state_needs_reconnect_invalid_grant():
+    # Exact post-refresh-failure shape: reauth flags set, access_token deleted.
+    s = co._calendar_onboarding_state({"connected": True, "reauth_required": True, "reauth_reason": "invalid_grant"})
+    assert s["needs_reconnect"] is True
+    assert s["reauth_reason"] == "invalid_grant"
+    assert s["state"] == "needs_reconnect"
+
+
+def test_state_needs_reconnect_missing_refresh_token():
+    s = co._calendar_onboarding_state(
+        {"connected": True, "reauth_required": True, "reauth_reason": "missing_refresh_token"}
+    )
+    assert s["reauth_reason"] == "missing_refresh_token"
+    assert s["state"] == "needs_reconnect"
+
+
+def test_connected_without_token_needs_reconnect():
+    # Defensive: connected but access_token gone (deleted on refresh failure) even if the flag is absent.
+    s = co._calendar_onboarding_state({"connected": True})
+    assert s["needs_reconnect"] is True
+    assert s["state"] == "needs_reconnect"
+
+
+def test_reauth_reason_suppressed_when_not_required():
+    s = co._calendar_onboarding_state({"connected": True, "access_token": "t", "reauth_reason": "stale"})
+    assert s["needs_reconnect"] is False
+    assert s["reauth_reason"] is None
+    assert s["state"] == "connected"
+
+
+def test_connected_and_skipped_prefers_connected():
+    s = co._calendar_onboarding_state({"connected": True, "access_token": "t", "onboarding_skipped": True})
+    assert s["state"] == "connected"
+
+
+# --- endpoints ---
+
+
+def test_status_endpoint_surfaces_needs_reconnect(monkeypatch):
+    monkeypatch.setattr(
+        co.users_db,
+        "get_integration",
+        lambda uid, key: {"connected": True, "reauth_required": True, "reauth_reason": "invalid_grant"},
+    )
+    result = co.get_calendar_onboarding_status(uid="u1")
+    assert result["needs_reconnect"] is True
+    assert result["reauth_reason"] == "invalid_grant"
+    assert result["state"] == "needs_reconnect"
+
+
+def test_status_endpoint_backward_compatible_keys(monkeypatch):
+    monkeypatch.setattr(co.users_db, "get_integration", lambda uid, key: {"connected": True, "access_token": "t"})
+    result = co.get_calendar_onboarding_status(uid="u1")
+    assert result["connected"] is True
+    assert result["onboarding_completed"] is True
+
+
+def test_reset_endpoint_clears_flags(monkeypatch):
+    calls = {}
+    monkeypatch.setattr(
+        co.users_db, "set_integration", lambda uid, key, data: calls.update(uid=uid, key=key, data=data)
+    )
+    result = co.reset_calendar_onboarding(uid="u1")
+    assert result == {"reset": True}
+    assert calls["uid"] == "u1"
+    assert calls["key"] == "google_calendar"
+    assert calls["data"] == {"onboarding_skipped": False, "reauth_required": False, "reauth_reason": None}


### PR DESCRIPTION
## What

When a user's Google Calendar OAuth token dies, `refresh_google_token` (in `utils/retrieval/tools/google_utils.py`) writes `reauth_required: true` + `reauth_reason` and deletes `access_token` on the `google_calendar` integration. But no endpoint ever read that back, so `GET /v1/calendar/onboarding/status` (which returned only `{connected, onboarding_completed}`) could not distinguish a never-connected user from one who was connected and now needs to reconnect. The app therefore showed a generic prompt instead of "Reconnect calendar."

This surfaces that already-produced (and unit-tested) signal, and adds a reset endpoint. Additive and backward-compatible: the existing keys are unchanged.

## Changes

- `routers/calendar_onboarding.py`
  - `GET /v1/calendar/onboarding/status` now also returns `needs_reconnect`, `reauth_reason`, and a `state` field (`not_started` / `connected` / `skipped` / `needs_reconnect`), computed by a pure `_calendar_onboarding_state` helper. `needs_reconnect` is true when `reauth_required` is set, or when the integration is connected but its `access_token` was deleted. `reauth_reason` is only surfaced when a reauth is actually required. The existing `connected` / `onboarding_completed` keys and semantics are unchanged.
  - `POST /v1/calendar/onboarding/reset` clears the `onboarding_skipped` / `reauth_required` / `reauth_reason` flags so the connect-calendar prompt is shown again.
  - It reuses the pre-existing `users_db.get_integration` / `set_integration` helpers; no database change.

## Tests

`tests/unit/test_calendar_onboarding.py` (11 cases): the pure state helper for none / connected / skipped / needs-reconnect (both `invalid_grant` and `missing_refresh_token`) / connected-without-token / reason-suppressed-when-not-required / connected-and-skipped, plus the status endpoint surfacing `needs_reconnect` and staying backward-compatible, and the reset endpoint writing exactly the cleared flags. The module is imported normally and `users_db` is monkeypatched, so there is no network.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8984?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

