### PR TITLE
fix(android): guard BLE foreground service start against silent crash

### DIFF
--- a/app/android/app/src/main/kotlin/com/friend/ios/OmiBleForegroundService.kt
+++ b/app/android/app/src/main/kotlin/com/friend/ios/OmiBleForegroundService.kt
@@ -663,7 +663,17 @@ class OmiBleForegroundService : Service() {
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
-        startForeground(NOTIFICATION_ID, buildNotification("Connecting to Omi..."))
+        // On Android 12+ startForeground() throws ForegroundServiceStartNotAllowedException when the
+        // service is (re)started while the app is in the background — e.g. START_STICKY redelivery after
+        // a process kill with the screen locked, or a CompanionDeviceService callback. An uncaught throw
+        // silently kills the whole process ("app just disappears"). Stop cleanly instead of crashing.
+        try {
+            startForeground(NOTIFICATION_ID, buildNotification("Connecting to Omi..."))
+        } catch (e: Exception) {
+            Log.e(TAG, "startForeground failed; stopping service instead of crashing", e)
+            stopSelf()
+            return START_NOT_STICKY
+        }
 
         val backgroundMode = isBackgroundModeEnabled(this)
         val persistentMode = isPersistentModeEnabled(this)


### PR DESCRIPTION
What
----
Wraps the `startForeground()` call in `OmiBleForegroundService.onStartCommand()` in a try/catch. If it throws, the service logs the failure and calls `stopSelf()` (returning `START_NOT_STICKY`) instead of letting the exception kill the whole process.

Why
---
Issue #8860 reports:

> App crashes silently after 5-30 minutes of use on Android 16 ... No visible error — app just disappears ... especially when screen locks
>
> **Ask:** Please verify the foreground service notification shows persistently, and ensure `android:foregroundServiceType` is declared in AndroidManifest.xml per Android 16 requirements.

Investigation:
- The manifest is already correct — `OmiBleForegroundService` declares `android:foregroundServiceType="connectedDevice"`, and the required `BLUETOOTH_CONNECT` / `BLUETOOTH_SCAN` / `CHANGE_NETWORK_STATE` permissions are all present. So the fix is not a missing manifest declaration.
- The concrete crash vector is the **unguarded** `startForeground()` in `onStartCommand()`. On Android 12+ (API 31+), `startForeground()` throws `ForegroundServiceStartNotAllowedException` when the service is (re)started while the app is in the background — e.g. `START_STICKY` redelivery after the OS kills the process with the screen locked, or a `CompanionDeviceService` (`BleCompanionService`) BLE-appeared callback firing while backgrounded. An uncaught throw here silently terminates the entire process, which is exactly the "app just disappears" symptom.

Catching the failure and stopping the service cleanly turns a silent process kill into a graceful stop (capture pauses instead of the app vanishing, and the failure is logged for diagnostics).

Scope
-----
Single-file, minimal hardening of one known crash vector. It does not attempt to change the broader background-survival / battery-optimization behavior (that is opt-in background mode + battery-unrestricted, tracked separately). Uses only symbols already imported/used in the file (`Log`, `stopSelf()`, `START_NOT_STICKY`).

Verified
--------
- Change is self-contained Kotlin using pre-existing imports; matches the surrounding error-handling style (same `try/catch (e: Exception)` + `Log.e` pattern used elsewhere in this service, e.g. the companion `startService`/`stopService`).
- Could NOT run a Gradle/Kotlin compile: the build machine has no Android SDK installed (`flutter doctor` → "Unable to locate Android SDK"). Please let CI compile-verify.

Auto-generated from issue feedback by the mini issues-improver. Review before merge.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8990?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

