### PR TITLE
feat(desktop): restore web search in chat + main-chat Response Context icon

### DIFF
--- a/desktop/macos/Backend-Rust/src/models/chat_completions.rs
+++ b/desktop/macos/Backend-Rust/src/models/chat_completions.rs
@@ -182,9 +182,20 @@ pub struct AnthropicRequest {
     pub temperature: Option<f64>,
     pub stream: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub tools: Option<Vec<AnthropicTool>>,
+    pub tools: Option<Vec<AnthropicToolDef>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tool_choice: Option<serde_json::Value>,
+}
+
+/// A tool definition in an Anthropic request: either a client-executed custom
+/// tool (translated from the OpenAI request) or an Anthropic server-side tool
+/// (e.g. web_search) that Anthropic executes during generation without any
+/// client round-trip.
+#[derive(Debug, Clone, Serialize)]
+#[serde(untagged)]
+pub enum AnthropicToolDef {
+    Custom(AnthropicTool),
+    Server(serde_json::Value),
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -252,6 +263,14 @@ pub enum AnthropicContentBlock {
         name: String,
         input: serde_json::Value,
     },
+    /// Server-side tool invocation (e.g. web_search) — executed by Anthropic
+    /// during generation. Never surfaced to the OpenAI client.
+    #[serde(rename = "server_tool_use")]
+    ServerToolUse { id: String, name: String },
+    /// Result of a server-side web search — consumed by the model upstream.
+    /// Never surfaced to the OpenAI client.
+    #[serde(rename = "web_search_tool_result")]
+    WebSearchToolResult {},
 }
 
 #[derive(Debug, Clone, Deserialize, Default)]
@@ -264,6 +283,16 @@ pub struct AnthropicUsage {
     pub cache_creation_input_tokens: i64,
     #[serde(default)]
     pub cache_read_input_tokens: i64,
+    /// Server-side tool usage (web search request count) — billed per request,
+    /// so it must survive into cost computation.
+    #[serde(default)]
+    pub server_tool_use: Option<AnthropicServerToolUsage>,
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct AnthropicServerToolUsage {
+    #[serde(default)]
+    pub web_search_requests: i64,
 }
 
 // ── Anthropic streaming event types ─────────────────────────────────────────
@@ -310,6 +339,10 @@ pub enum AnthropicDelta {
     TextDelta { text: String },
     #[serde(rename = "input_json_delta")]
     InputJsonDelta { partial_json: String },
+    /// Citation metadata attached to text generated from web search results.
+    /// Dropped in translation — the OpenAI chunk format has no citation slot.
+    #[serde(rename = "citations_delta")]
+    CitationsDelta {},
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/desktop/macos/Backend-Rust/src/models/chat_completions.rs
+++ b/desktop/macos/Backend-Rust/src/models/chat_completions.rs
@@ -432,8 +432,40 @@ pub fn map_stop_reason(anthropic_reason: Option<&str>) -> Option<String> {
         "max_tokens" => "length".to_string(),
         "tool_use" => "tool_calls".to_string(),
         "stop_sequence" => "stop".to_string(),
+        // Long-running server tools (web search) can pause the turn. The proxy
+        // cannot resume it — the OpenAI client never saw the server tool blocks
+        // — so terminate cleanly instead of leaking an unknown finish_reason.
+        "pause_turn" => "stop".to_string(),
         other => other.to_string(),
     })
+}
+
+/// Merge stream usage: message_start carries the input/cache token counts,
+/// but on server-tool turns (web search) the final message_delta usage is
+/// cumulative across search iterations — prefer its nonzero fields so cost
+/// doesn't undercount searched turns. output and server_tool_use are only
+/// authoritative in the final usage.
+pub fn merge_stream_usage(
+    initial: Option<&AnthropicUsage>,
+    final_usage: &AnthropicUsage,
+) -> AnthropicUsage {
+    let pick = |final_v: i64, initial_v: i64| if final_v > 0 { final_v } else { initial_v };
+    AnthropicUsage {
+        input_tokens: pick(
+            final_usage.input_tokens,
+            initial.map_or(0, |u| u.input_tokens),
+        ),
+        output_tokens: final_usage.output_tokens,
+        cache_creation_input_tokens: pick(
+            final_usage.cache_creation_input_tokens,
+            initial.map_or(0, |u| u.cache_creation_input_tokens),
+        ),
+        cache_read_input_tokens: pick(
+            final_usage.cache_read_input_tokens,
+            initial.map_or(0, |u| u.cache_read_input_tokens),
+        ),
+        server_tool_use: final_usage.server_tool_use.clone(),
+    }
 }
 
 pub fn anthropic_usage_to_openai(usage: &AnthropicUsage) -> Usage {

--- a/desktop/macos/Backend-Rust/src/routes/chat_completions.rs
+++ b/desktop/macos/Backend-Rust/src/routes/chat_completions.rs
@@ -49,6 +49,31 @@ const ANTHROPIC_API_URL: &str = "https://api.anthropic.com/v1/messages";
 /// Anthropic API version header.
 const ANTHROPIC_API_VERSION: &str = "2023-06-01";
 
+/// Anthropic server-side web search tool type (same version the Python
+/// backend's agentic chat uses). Executed entirely upstream by Anthropic —
+/// the OpenAI-side client never sees or executes it.
+const WEB_SEARCH_TOOL_TYPE: &str = "web_search_20260209";
+
+/// Max web searches per request (matches the Python backend's agentic chat).
+const WEB_SEARCH_MAX_USES: u32 = 5;
+
+/// Anthropic web search pricing: $10 per 1,000 searches.
+const WEB_SEARCH_COST_PER_REQUEST: f64 = 10.0 / 1_000.0;
+
+fn web_search_tool_def() -> AnthropicToolDef {
+    AnthropicToolDef::Server(json!({
+        "type": WEB_SEARCH_TOOL_TYPE,
+        "name": "web_search",
+        "max_uses": WEB_SEARCH_MAX_USES,
+    }))
+}
+
+/// Kill switch: set OMI_DESKTOP_WEB_SEARCH_DISABLED=1 to stop injecting the
+/// server-side web_search tool without shipping a new desktop build.
+fn web_search_enabled() -> bool {
+    std::env::var("OMI_DESKTOP_WEB_SEARCH_DISABLED").map_or(true, |v| v != "1")
+}
+
 /// Per-token costs for Anthropic models (USD per token).
 /// Updated for Claude 4 / Sonnet 4 pricing.
 struct ModelCost {
@@ -89,10 +114,15 @@ fn model_cost(upstream_model: &str) -> ModelCost {
 
 fn compute_cost(usage: &AnthropicUsage, upstream_model: &str) -> f64 {
     let c = model_cost(upstream_model);
+    let web_search_requests = usage
+        .server_tool_use
+        .as_ref()
+        .map_or(0, |s| s.web_search_requests);
     (usage.input_tokens as f64 * c.input_per_token)
         + (usage.output_tokens as f64 * c.output_per_token)
         + (usage.cache_read_input_tokens as f64 * c.cache_read_per_token)
         + (usage.cache_creation_input_tokens as f64 * c.cache_write_per_token)
+        + (web_search_requests as f64 * WEB_SEARCH_COST_PER_REQUEST)
 }
 
 // ── OpenAI → Anthropic request translation ──────────────────────────────────
@@ -100,6 +130,14 @@ fn compute_cost(usage: &AnthropicUsage, upstream_model: &str) -> f64 {
 fn translate_request(
     req: &ChatCompletionRequest,
     upstream_model: &str,
+) -> Result<AnthropicRequest, String> {
+    translate_request_inner(req, upstream_model, web_search_enabled())
+}
+
+fn translate_request_inner(
+    req: &ChatCompletionRequest,
+    upstream_model: &str,
+    enable_web_search: bool,
 ) -> Result<AnthropicRequest, String> {
     let mut system_prompt: Option<String> = None;
     let mut anthropic_messages: Vec<AnthropicMessage> = Vec::new();
@@ -182,11 +220,20 @@ fn translate_request(
         }
     }
 
-    // Translate tools
+    // Translate tools. Agentic requests (which carry client tools) also get
+    // Anthropic's server-side web_search tool injected ahead of them —
+    // restoring the web access desktop chat lost when the default harness
+    // moved off Claude Code (whose built-in WebSearch it inherited). Bare
+    // completions like the pill router classifier stay tool-free. Prepending
+    // keeps the tools array byte-stable for the prompt-cache prefix.
+    let inject_web_search = enable_web_search;
     let anthropic_tools = req.tools.as_ref().map(|tools| {
-        tools
-            .iter()
-            .map(|t| AnthropicTool {
+        let mut defs: Vec<AnthropicToolDef> = Vec::with_capacity(tools.len() + 1);
+        if inject_web_search && !tools.is_empty() {
+            defs.push(web_search_tool_def());
+        }
+        defs.extend(tools.iter().map(|t| {
+            AnthropicToolDef::Custom(AnthropicTool {
                 name: t.function.name.clone(),
                 description: t.function.description.clone(),
                 input_schema: t
@@ -195,7 +242,8 @@ fn translate_request(
                     .clone()
                     .unwrap_or(json!({"type": "object", "properties": {}})),
             })
-            .collect()
+        }));
+        defs
     });
 
     let max_tokens = req
@@ -480,6 +528,11 @@ fn translate_response(resp: &AnthropicResponse, public_model: &str) -> ChatCompl
                     },
                 });
                 tool_index += 1;
+            }
+            AnthropicContentBlock::ServerToolUse { .. }
+            | AnthropicContentBlock::WebSearchToolResult {} => {
+                // Server-side tool blocks are consumed upstream — only the
+                // text they produced is surfaced to the client.
             }
         }
     }
@@ -908,6 +961,18 @@ async fn handle_streaming(
                             AnthropicContentBlock::Text { .. } => {
                                 // text_start — no chunk needed, text comes via deltas
                             }
+                            AnthropicContentBlock::ServerToolUse { name, .. } => {
+                                // Executed upstream by Anthropic — no OpenAI tool_call
+                                // is emitted, so the client never tries to run it.
+                                // Info-level: each invocation is a billable event.
+                                tracing::info!(
+                                    "chat_completions: server tool '{}' running upstream",
+                                    name
+                                );
+                            }
+                            AnthropicContentBlock::WebSearchToolResult {} => {
+                                // Consumed by the model upstream — nothing to forward.
+                            }
                         }
                     }
 
@@ -927,6 +992,9 @@ async fn handle_streaming(
                                     None,
                                 );
                                 yield Ok(sse_line(&chunk_val));
+                            }
+                            AnthropicDelta::CitationsDelta {} => {
+                                // Web-search citation metadata — no OpenAI equivalent.
                             }
                             AnthropicDelta::InputJsonDelta { partial_json } => {
                                 if let Some(&ordinal) = tool_ordinals.get(&index) {
@@ -988,6 +1056,7 @@ async fn handle_streaming(
                                 output_tokens: fu.output_tokens,
                                 cache_creation_input_tokens: initial_usage.as_ref().map_or(0, |u| u.cache_creation_input_tokens),
                                 cache_read_input_tokens: initial_usage.as_ref().map_or(0, |u| u.cache_read_input_tokens),
+                                server_tool_use: fu.server_tool_use.clone(),
                             };
                             let openai_usage = anthropic_usage_to_openai(&merged);
                             let usage_chunk = ChatCompletionChunk {
@@ -1014,6 +1083,7 @@ async fn handle_streaming(
                                 output_tokens: fu.output_tokens,
                                 cache_creation_input_tokens: initial_usage.as_ref().map_or(0, |u| u.cache_creation_input_tokens),
                                 cache_read_input_tokens: initial_usage.as_ref().map_or(0, |u| u.cache_read_input_tokens),
+                                server_tool_use: fu.server_tool_use.clone(),
                             };
                             let cost = compute_cost(&merged, &upstream_model);
                             let uid_clone = uid.clone();
@@ -1230,6 +1300,7 @@ mod tests {
             output_tokens: 50,
             cache_creation_input_tokens: 10,
             cache_read_input_tokens: 20,
+            server_tool_use: None,
         };
         let openai = anthropic_usage_to_openai(&usage);
         assert_eq!(openai.prompt_tokens, 130); // 100 + 10 + 20
@@ -1244,11 +1315,125 @@ mod tests {
             output_tokens: 500,
             cache_creation_input_tokens: 0,
             cache_read_input_tokens: 0,
+            server_tool_use: None,
         };
         let cost = compute_cost(&usage, "claude-sonnet-4-6");
         // input: 1000 * 3/1M = 0.003, output: 500 * 15/1M = 0.0075
         let expected = 0.003 + 0.0075;
         assert!((cost - expected).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_compute_cost_includes_web_search_requests() {
+        let usage = AnthropicUsage {
+            input_tokens: 1000,
+            output_tokens: 500,
+            cache_creation_input_tokens: 0,
+            cache_read_input_tokens: 0,
+            server_tool_use: Some(AnthropicServerToolUsage {
+                web_search_requests: 3,
+            }),
+        };
+        let cost = compute_cost(&usage, "claude-sonnet-4-6");
+        // tokens: 0.003 + 0.0075, web search: 3 * $0.01
+        let expected = 0.003 + 0.0075 + 0.03;
+        assert!((cost - expected).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_stream_event_parses_server_tool_use_and_citations() {
+        // content_block_start for a server-side web search — must parse into
+        // ServerToolUse (not fail and not become a client ToolUse).
+        let start: AnthropicStreamEvent = serde_json::from_str(
+            r#"{"type":"content_block_start","index":1,"content_block":{"type":"server_tool_use","id":"srvtoolu_1","name":"web_search","input":{}}}"#,
+        )
+        .unwrap();
+        match start {
+            AnthropicStreamEvent::ContentBlockStart { content_block, .. } => {
+                assert!(matches!(
+                    content_block,
+                    AnthropicContentBlock::ServerToolUse { .. }
+                ));
+            }
+            other => panic!("unexpected event: {:?}", other),
+        }
+
+        // web_search_tool_result block start — extra fields must be tolerated.
+        let result: AnthropicStreamEvent = serde_json::from_str(
+            r#"{"type":"content_block_start","index":2,"content_block":{"type":"web_search_tool_result","tool_use_id":"srvtoolu_1","content":[{"type":"web_search_result","url":"https://example.com","title":"t"}]}}"#,
+        )
+        .unwrap();
+        match result {
+            AnthropicStreamEvent::ContentBlockStart { content_block, .. } => {
+                assert!(matches!(
+                    content_block,
+                    AnthropicContentBlock::WebSearchToolResult {}
+                ));
+            }
+            other => panic!("unexpected event: {:?}", other),
+        }
+
+        // citations_delta on a text block — must parse into CitationsDelta.
+        let citation: AnthropicStreamEvent = serde_json::from_str(
+            r#"{"type":"content_block_delta","index":3,"delta":{"type":"citations_delta","citation":{"type":"web_search_result_location","url":"https://example.com"}}}"#,
+        )
+        .unwrap();
+        match citation {
+            AnthropicStreamEvent::ContentBlockDelta { delta, .. } => {
+                assert!(matches!(delta, AnthropicDelta::CitationsDelta {}));
+            }
+            other => panic!("unexpected event: {:?}", other),
+        }
+
+        // message_delta usage carrying server_tool_use must round-trip the count.
+        let md: AnthropicStreamEvent = serde_json::from_str(
+            r#"{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":42,"server_tool_use":{"web_search_requests":2}}}"#,
+        )
+        .unwrap();
+        match md {
+            AnthropicStreamEvent::MessageDelta { usage, .. } => {
+                let u = usage.unwrap();
+                assert_eq!(u.server_tool_use.unwrap().web_search_requests, 2);
+            }
+            other => panic!("unexpected event: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_translate_response_skips_server_tool_blocks() {
+        let resp = AnthropicResponse {
+            id: "msg_ws".to_string(),
+            response_type: "message".to_string(),
+            model: "claude-sonnet-4-6".to_string(),
+            role: "assistant".to_string(),
+            content: vec![
+                AnthropicContentBlock::Text {
+                    text: "Checking. ".to_string(),
+                },
+                AnthropicContentBlock::ServerToolUse {
+                    id: "srvtoolu_1".to_string(),
+                    name: "web_search".to_string(),
+                },
+                AnthropicContentBlock::WebSearchToolResult {},
+                AnthropicContentBlock::Text {
+                    text: "It's 75F in NYC.".to_string(),
+                },
+            ],
+            stop_reason: Some("end_turn".to_string()),
+            usage: AnthropicUsage {
+                input_tokens: 10,
+                output_tokens: 5,
+                cache_creation_input_tokens: 0,
+                cache_read_input_tokens: 0,
+                server_tool_use: None,
+            },
+        };
+
+        let openai = translate_response(&resp, "omi-sonnet");
+        let msg = &openai.choices[0].message;
+        assert_eq!(msg.content.as_deref(), Some("Checking. It's 75F in NYC."));
+        // Server tool blocks must NOT surface as client tool_calls.
+        assert!(msg.tool_calls.is_none());
     }
 
     #[test]
@@ -1736,14 +1921,85 @@ mod tests {
             tool_choice: None,
         };
 
-        let result = translate_request(&req, "claude-sonnet-4-6").unwrap();
+        let result = translate_request_inner(&req, "claude-sonnet-4-6", true).unwrap();
+        let tools = result.tools.unwrap();
+        // Server-side web_search is injected ahead of the client tools.
+        assert_eq!(tools.len(), 2);
+        let ws = serde_json::to_value(&tools[0]).unwrap();
+        assert_eq!(ws["type"], WEB_SEARCH_TOOL_TYPE);
+        assert_eq!(ws["name"], "web_search");
+        assert_eq!(ws["max_uses"], WEB_SEARCH_MAX_USES);
+        let custom = serde_json::to_value(&tools[1]).unwrap();
+        assert_eq!(custom["name"], "get_weather");
+        assert_eq!(custom["description"], "Get weather for a location");
+        // Server tools carry no input_schema; custom tools must.
+        assert!(ws.get("input_schema").is_none());
+        assert!(custom.get("input_schema").is_some());
+    }
+
+    #[test]
+    fn test_translate_request_web_search_disabled() {
+        let req = ChatCompletionRequest {
+            model: "omi-sonnet".to_string(),
+            messages: vec![ChatMessage {
+                role: "user".to_string(),
+                content: Some(json!("Hi")),
+                name: None,
+                tool_calls: None,
+                tool_call_id: None,
+            }],
+            stream: false,
+            temperature: None,
+            max_tokens: None,
+            max_completion_tokens: None,
+            tools: Some(vec![ToolDefinition {
+                tool_type: "function".to_string(),
+                function: FunctionDefinition {
+                    name: "get_weather".to_string(),
+                    description: None,
+                    parameters: None,
+                },
+            }]),
+            tool_choice: None,
+        };
+
+        let result = translate_request_inner(&req, "claude-sonnet-4-6", false).unwrap();
         let tools = result.tools.unwrap();
         assert_eq!(tools.len(), 1);
-        assert_eq!(tools[0].name, "get_weather");
-        assert_eq!(
-            tools[0].description,
-            Some("Get weather for a location".to_string())
-        );
+        let only = serde_json::to_value(&tools[0]).unwrap();
+        assert_eq!(only["name"], "get_weather");
+    }
+
+    #[test]
+    fn test_translate_request_no_web_search_without_client_tools() {
+        // Tool-less requests (router classifier, summaries) must stay tool-free
+        // even with web search enabled.
+        let req = ChatCompletionRequest {
+            model: "omi-sonnet".to_string(),
+            messages: vec![ChatMessage {
+                role: "user".to_string(),
+                content: Some(json!("Hi")),
+                name: None,
+                tool_calls: None,
+                tool_call_id: None,
+            }],
+            stream: false,
+            temperature: None,
+            max_tokens: None,
+            max_completion_tokens: None,
+            tools: None,
+            tool_choice: None,
+        };
+        let result = translate_request_inner(&req, "claude-sonnet-4-6", true).unwrap();
+        assert!(result.tools.is_none());
+
+        // Same for an explicitly empty tools array.
+        let req_empty = ChatCompletionRequest {
+            tools: Some(vec![]),
+            ..req
+        };
+        let result = translate_request_inner(&req_empty, "claude-sonnet-4-6", true).unwrap();
+        assert_eq!(result.tools.unwrap().len(), 0);
     }
 
     #[test]
@@ -1762,6 +2018,7 @@ mod tests {
                 output_tokens: 5,
                 cache_creation_input_tokens: 0,
                 cache_read_input_tokens: 0,
+                server_tool_use: None,
             },
         };
 
@@ -1802,6 +2059,7 @@ mod tests {
                 output_tokens: 50,
                 cache_creation_input_tokens: 0,
                 cache_read_input_tokens: 0,
+                server_tool_use: None,
             },
         };
 

--- a/desktop/macos/Backend-Rust/src/routes/chat_completions.rs
+++ b/desktop/macos/Backend-Rust/src/routes/chat_completions.rs
@@ -226,7 +226,9 @@ fn translate_request_inner(
     // moved off Claude Code (whose built-in WebSearch it inherited). Bare
     // completions like the pill router classifier stay tool-free. Prepending
     // keeps the tools array byte-stable for the prompt-cache prefix.
-    let inject_web_search = enable_web_search;
+    // Haiku is excluded: web_search_20260209 is not supported there, and a
+    // tools-bearing haiku request would 400 with it attached.
+    let inject_web_search = enable_web_search && !upstream_model.starts_with("claude-haiku");
     let anthropic_tools = req.tools.as_ref().map(|tools| {
         let mut defs: Vec<AnthropicToolDef> = Vec::with_capacity(tools.len() + 1);
         if inject_web_search && !tools.is_empty() {
@@ -1033,6 +1035,13 @@ async fn handle_streaming(
                             final_usage = Some(u);
                         }
 
+                        if delta.stop_reason.as_deref() == Some("pause_turn") {
+                            // Mapped to "stop" — the proxy cannot resume a paused
+                            // server-tool turn, so the reply ends where it is.
+                            tracing::warn!(
+                                "chat_completions: pause_turn stop_reason — terminating turn"
+                            );
+                        }
                         let finish = map_stop_reason(delta.stop_reason.as_deref());
                         let chunk_val = make_chunk(
                             &stream_id,
@@ -1050,14 +1059,7 @@ async fn handle_streaming(
 
                         // Send usage chunk
                         if let Some(ref fu) = final_usage {
-                            // Merge initial + final usage
-                            let merged = AnthropicUsage {
-                                input_tokens: initial_usage.as_ref().map_or(0, |u| u.input_tokens),
-                                output_tokens: fu.output_tokens,
-                                cache_creation_input_tokens: initial_usage.as_ref().map_or(0, |u| u.cache_creation_input_tokens),
-                                cache_read_input_tokens: initial_usage.as_ref().map_or(0, |u| u.cache_read_input_tokens),
-                                server_tool_use: fu.server_tool_use.clone(),
-                            };
+                            let merged = merge_stream_usage(initial_usage.as_ref(), fu);
                             let openai_usage = anthropic_usage_to_openai(&merged);
                             let usage_chunk = ChatCompletionChunk {
                                 id: stream_id.clone(),
@@ -1078,13 +1080,7 @@ async fn handle_streaming(
                         // Log usage asynchronously — skip for BYOK (user pays own bill)
                         if !is_byok {
                         if let Some(ref fu) = final_usage {
-                            let merged = AnthropicUsage {
-                                input_tokens: initial_usage.as_ref().map_or(0, |u| u.input_tokens),
-                                output_tokens: fu.output_tokens,
-                                cache_creation_input_tokens: initial_usage.as_ref().map_or(0, |u| u.cache_creation_input_tokens),
-                                cache_read_input_tokens: initial_usage.as_ref().map_or(0, |u| u.cache_read_input_tokens),
-                                server_tool_use: fu.server_tool_use.clone(),
-                            };
+                            let merged = merge_stream_usage(initial_usage.as_ref(), fu);
                             let cost = compute_cost(&merged, &upstream_model);
                             let uid_clone = uid.clone();
                             let fs = firestore.clone();
@@ -1968,6 +1964,89 @@ mod tests {
         assert_eq!(tools.len(), 1);
         let only = serde_json::to_value(&tools[0]).unwrap();
         assert_eq!(only["name"], "get_weather");
+    }
+
+    #[test]
+    fn test_translate_request_no_web_search_on_haiku() {
+        // web_search_20260209 is unsupported on haiku — never inject there.
+        let req = ChatCompletionRequest {
+            model: "claude-haiku-4-5".to_string(),
+            messages: vec![ChatMessage {
+                role: "user".to_string(),
+                content: Some(json!("Hi")),
+                name: None,
+                tool_calls: None,
+                tool_call_id: None,
+            }],
+            stream: false,
+            temperature: None,
+            max_tokens: None,
+            max_completion_tokens: None,
+            tools: Some(vec![ToolDefinition {
+                tool_type: "function".to_string(),
+                function: FunctionDefinition {
+                    name: "some_tool".to_string(),
+                    description: None,
+                    parameters: None,
+                },
+            }]),
+            tool_choice: None,
+        };
+        let result = translate_request_inner(&req, "claude-haiku-4-5", true).unwrap();
+        let tools = result.tools.unwrap();
+        assert_eq!(tools.len(), 1);
+        assert_eq!(
+            serde_json::to_value(&tools[0]).unwrap()["name"],
+            "some_tool"
+        );
+    }
+
+    #[test]
+    fn test_map_stop_reason_pause_turn_terminates() {
+        assert_eq!(
+            map_stop_reason(Some("pause_turn")),
+            Some("stop".to_string())
+        );
+    }
+
+    #[test]
+    fn test_merge_stream_usage_prefers_final_nonzero() {
+        let initial = AnthropicUsage {
+            input_tokens: 100,
+            output_tokens: 0,
+            cache_creation_input_tokens: 50,
+            cache_read_input_tokens: 20,
+            server_tool_use: None,
+        };
+        // Web-search turn: final usage carries cumulative input + search count.
+        let fin = AnthropicUsage {
+            input_tokens: 5000,
+            output_tokens: 300,
+            cache_creation_input_tokens: 0,
+            cache_read_input_tokens: 0,
+            server_tool_use: Some(AnthropicServerToolUsage {
+                web_search_requests: 2,
+            }),
+        };
+        let merged = merge_stream_usage(Some(&initial), &fin);
+        assert_eq!(merged.input_tokens, 5000); // final wins when nonzero
+        assert_eq!(merged.output_tokens, 300);
+        assert_eq!(merged.cache_creation_input_tokens, 50); // fallback to initial
+        assert_eq!(merged.cache_read_input_tokens, 20); // fallback to initial
+        assert_eq!(merged.server_tool_use.unwrap().web_search_requests, 2);
+
+        // Plain turn: final has only output — initial fields survive.
+        let fin_plain = AnthropicUsage {
+            input_tokens: 0,
+            output_tokens: 40,
+            cache_creation_input_tokens: 0,
+            cache_read_input_tokens: 0,
+            server_tool_use: None,
+        };
+        let merged_plain = merge_stream_usage(Some(&initial), &fin_plain);
+        assert_eq!(merged_plain.input_tokens, 100);
+        assert_eq!(merged_plain.cache_read_input_tokens, 20);
+        assert!(merged_plain.server_tool_use.is_none());
     }
 
     #[test]

--- a/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
+++ b/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
@@ -419,6 +419,23 @@ final class DesktopAutomationActionRegistry {
       return ["sent": query]
     }
 
+    // Send a message through the real main-window chat pipeline (ChatPage),
+    // in-process via ViewModelContainer's ChatProvider — no synthetic mouse
+    // or keyboard input, so it never touches the user's actual cursor.
+    register(
+      name: "ask_main_chat",
+      summary: "Send a query to the main-window chat (typed path); exercises the full chat pipeline",
+      params: ["query"]
+    ) { params in
+      let query = (params["query"] ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+      guard !query.isEmpty else { return ["error": "missing 'query'"] }
+      guard let provider = ChatProvider.mainInstance else {
+        return ["error": "main ChatProvider not yet initialized"]
+      }
+      _ = await provider.sendMessage(query)
+      return ["sent": query]
+    }
+
     register(
       name: "memories_qa_export",
       summary: "Export memory counts by tier from the live API (local QA automation)",

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/ChatPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/ChatPage.swift
@@ -538,6 +538,7 @@ struct ChatBubble: View {
   @State private var isExpanded = false
   @State private var showCopied = false
   @State private var showRatingFeedback = false
+  @State private var showInfoPopover = false
   @State private var lastSubmittedRating: Int?
   /// Cached grouped content blocks — pre-computed on init to avoid recreating
   /// `[ContentBlockGroup]` on every SwiftUI layout pass.
@@ -767,6 +768,10 @@ struct ChatBubble: View {
         copyButton
       }
 
+      if includeCopyButton, message.metadata != nil {
+        infoButton
+      }
+
       Text(message.createdAt, format: .dateTime.hour().minute())
         .scaledFont(size: 10, weight: .medium)
         .foregroundColor(OmiColors.textTertiary)
@@ -848,6 +853,25 @@ struct ChatBubble: View {
     }
     .buttonStyle(.plain)
     .help("Copy message")
+  }
+
+  /// Response Context popover — same developer info the floating bar shows
+  /// (model, screenshot, prompt context counts, tools). Only fresh responses
+  /// carry metadata; it is in-memory only and not persisted across restarts.
+  @ViewBuilder
+  private var infoButton: some View {
+    Button(action: { showInfoPopover.toggle() }) {
+      Image(systemName: "info.circle")
+        .scaledFont(size: 11)
+        .foregroundColor(showInfoPopover ? OmiColors.textPrimary : OmiColors.textTertiary)
+    }
+    .buttonStyle(.plain)
+    .help("View response context")
+    .popover(isPresented: $showInfoPopover, arrowEdge: .bottom) {
+      if let metadata = message.metadata {
+        MessageMetadataPopover(metadata: metadata)
+      }
+    }
   }
 }
 

--- a/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
@@ -791,6 +791,12 @@ enum ChatSystemPromptStyle {
 @MainActor
 class ChatProvider: ObservableObject {
 
+    /// Weak reference to the app-root main-window instance (set by
+    /// ViewModelContainer.init()), so the local automation bridge can drive
+    /// the real main chat surface in-process — no synthetic mouse/keyboard
+    /// input, so it never touches the user's actual cursor.
+    static weak var mainInstance: ChatProvider?
+
     // MARK: - Floating Bar System Prompt Prefix
     /// Static prefix injected at the top of the system prompt for floating bar sessions.
     /// Defined here so it can be referenced both at warmup time and at query time.

--- a/desktop/macos/Desktop/Sources/ViewModelContainer.swift
+++ b/desktop/macos/Desktop/Sources/ViewModelContainer.swift
@@ -28,6 +28,7 @@ class ViewModelContainer: ObservableObject {
         let provider = ChatProvider()
         chatProvider = provider
         taskChatCoordinator = TaskChatCoordinator(chatProvider: provider)
+        ChatProvider.mainInstance = provider
     }
 
     // Loading state

--- a/desktop/macos/changelog/unreleased/20260703-restore-web-search.json
+++ b/desktop/macos/changelog/unreleased/20260703-restore-web-search.json
@@ -1,0 +1,3 @@
+{
+  "change": "Omi can search the web again in chat and the floating bar — live answers for things like weather, news, and product details"
+}

--- a/desktop/macos/run.sh
+++ b/desktop/macos/run.sh
@@ -441,13 +441,27 @@ else
     substep "Skipping backend (OMI_SKIP_BACKEND=1) — using OMI_DESKTOP_API_URL from .env"
 fi
 
-# Check if another SwiftPM instance is running (will block our build)
+# Wait only for SwiftPM instances building THIS checkout. Parallel worktrees
+# have their own .build scratch dirs and SwiftPM locks its shared caches, so
+# other worktrees' builds (including SourceKit-LSP indexing builds, which
+# respawn continuously and would starve a global wait forever) don't block us.
 while true; do
-    SWIFTPM_PIDS=$(pgrep -f "swift-build|swift-package" 2>/dev/null || true)
-    if [ -z "$SWIFTPM_PIDS" ]; then
+    SWIFTPM_BLOCKING=""
+    for _pid in $(pgrep -f "swift-build|swift-package" 2>/dev/null); do
+        # SourceKit-LSP indexing builds use their own scratch dir
+        # (.build/index-build) and respawn continuously — never wait on them.
+        if ps -p "$_pid" -o command= 2>/dev/null | grep -q "prepare-for-indexing\|index-build"; then
+            continue
+        fi
+        _pcwd=$(lsof -a -p "$_pid" -d cwd -Fn 2>/dev/null | sed -n 's/^n//p')
+        case "$_pcwd" in
+            "$SCRIPT_DIR"*) SWIFTPM_BLOCKING="$_pid"; break ;;
+        esac
+    done
+    if [ -z "$SWIFTPM_BLOCKING" ]; then
         break
     fi
-    step "Waiting for other SwiftPM instance(s) to finish..."
+    step "Waiting for this checkout's SwiftPM instance (pid $SWIFTPM_BLOCKING) to finish..."
     sleep 2
 done
 


### PR DESCRIPTION
## Summary

Desktop chat (floating bar, main chat, onboarding) lost web access on 2026-04-15 when the default harness moved from Claude Code — whose built-in WebSearch it inherited — to pi-mono (7b1c9450a7, #6633), whose Omi tool set has no web tool. Since then the assistant answers questions like "what's the weather" with *"I don't have internet access"*, while the floating-bar prompt and onboarding STEP 4 still instruct it to search the web.

This restores web search **server-side**: the Rust desktop-backend proxy injects Anthropic's server-side `web_search` tool (`web_search_20260209`, `max_uses: 5` — same as the Python backend's agentic chat) into `/v2/chat/completions` requests that carry client tools, i.e. agentic desktop chat sessions. Anthropic executes searches upstream within a single turn, so pi-mono and the Swift app need **no changes** — every installed desktop app picks this up on the next backend deploy.

## Implementation

- `web_search` is **prepended** to the translated tools array so the prompt-cache prefix stays byte-stable; tool-less utility calls (pill router classifier, summaries) remain tool-free; haiku models are excluded (tool version unsupported there)
- New serde variants translate/ignore `server_tool_use` + `web_search_tool_result` content blocks and `citations_delta` in both streaming and non-streaming paths (previously they were dropped only via parse-failure fallback); server tool blocks never surface as OpenAI `tool_calls`
- `pause_turn` stop_reason maps to `stop` (the proxy can't resume a paused server-tool turn)
- Cost: `usage.server_tool_use.web_search_requests` billed at $10/1k searches into per-request cost; streaming usage merge now prefers the final `message_delta` usage when nonzero so searched turns don't undercount input tokens
- Kill switch: `OMI_DESKTOP_WEB_SEARCH_DISABLED=1` (no client ship needed)

## Testing

- `cargo test`: 292 passed, 0 failed; `rustfmt --check` clean
- Independent agent code review: approved (its three minor findings — pause_turn mapping, usage-merge accuracy, haiku gating — are fixed in the second commit)
- E2E (real user path): built and ran the app as a named bundle (`omi-web-search`), local Rust backend from this branch; typed a weather question into the floating bar; verified the live answer in the UI and the backend log line `server tool 'web_search' running upstream`; negative check: chit-chat message triggers no search

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8994?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

