### PR TITLE
fix: allow prod backend deploy without LLM gateway

### DIFF
--- a/backend/charts/backend-listen/prod_omi_backend_listen_values.yaml
+++ b/backend/charts/backend-listen/prod_omi_backend_listen_values.yaml
@@ -101,15 +101,8 @@ env:
       secretKeyRef:
         name: prod-omi-backend-secrets
         key: OPENAI_API_KEY
-  - name: OMI_LLM_GATEWAY_URL
-    value: "http://prod-omi-llm-gateway.prod-omi-backend.svc.cluster.local:8080"
   - name: OMI_ENV_STAGE
     value: "prod"
-  - name: OMI_LLM_GATEWAY_SERVICE_TOKEN
-    valueFrom:
-      secretKeyRef:
-        name: prod-omi-backend-secrets
-        key: OMI_LLM_GATEWAY_SERVICE_TOKEN
   - name: MEMORY_MODE
     value: "off"
   - name: MEMORY_ENABLED_USERS

--- a/backend/charts/backend-secrets/prod_omi_backend_secrets_values.yaml
+++ b/backend/charts/backend-secrets/prod_omi_backend_secrets_values.yaml
@@ -20,8 +20,6 @@ externalSecret:
       remoteKey: GITHUB_TOKEN
     - secretKey: OPENAI_API_KEY
       remoteKey: OPENAI_API_KEY
-    - secretKey: OMI_LLM_GATEWAY_SERVICE_TOKEN
-      remoteKey: OMI_LLM_GATEWAY_SERVICE_TOKEN
     - secretKey: FAL_KEY
       remoteKey: FAL_KEY
     - secretKey: GROQ_API_KEY

--- a/backend/deploy/runtime_env.yaml
+++ b/backend/deploy/runtime_env.yaml
@@ -278,16 +278,9 @@ environments:
       backend-listen:
         values_file: backend/charts/backend-listen/prod_omi_backend_listen_values.yaml
         env:
-          OMI_LLM_GATEWAY_URL:
-            value: http://prod-omi-llm-gateway.prod-omi-backend.svc.cluster.local:8080
-            category: service_discovery
           OMI_ENV_STAGE:
             value: prod
             category: runtime_identity
-          OMI_LLM_GATEWAY_SERVICE_TOKEN:
-            secret:
-              name: prod-omi-backend-secrets
-              key: OMI_LLM_GATEWAY_SERVICE_TOKEN
           SERVICE_ACCOUNT_JSON:
             secret:
               name: prod-omi-backend-secrets
@@ -326,10 +319,6 @@ environments:
             OMI_ENV_STAGE:
               value: prod
               category: runtime_identity
-            OMI_LLM_GATEWAY_URL:
-              env_var: OMI_LLM_GATEWAY_URL
-              category: service_discovery
-              provisional: true
             POSTHOG_HOST:
               value: https://app.posthog.com
               category: telemetry
@@ -363,9 +352,6 @@ environments:
               version: latest
             GOOGLE_CLIENT_SECRET:
               secret: GOOGLE_CLIENT_SECRET
-              version: latest
-            OMI_LLM_GATEWAY_SERVICE_TOKEN:
-              secret: OMI_LLM_GATEWAY_SERVICE_TOKEN
               version: latest
             POSTHOG_PROJECT_API_KEY:
               secret: POSTHOG_PROJECT_API_KEY
@@ -375,10 +361,6 @@ environments:
             OMI_ENV_STAGE:
               value: prod
               category: runtime_identity
-            OMI_LLM_GATEWAY_URL:
-              env_var: OMI_LLM_GATEWAY_URL
-              category: service_discovery
-              provisional: true
             POSTHOG_HOST:
               value: https://app.posthog.com
               category: telemetry
@@ -412,9 +394,6 @@ environments:
               version: latest
             GOOGLE_CLIENT_SECRET:
               secret: GOOGLE_CLIENT_SECRET
-              version: latest
-            OMI_LLM_GATEWAY_SERVICE_TOKEN:
-              secret: OMI_LLM_GATEWAY_SERVICE_TOKEN
               version: latest
             POSTHOG_PROJECT_API_KEY:
               secret: POSTHOG_PROJECT_API_KEY
@@ -424,10 +403,6 @@ environments:
             OMI_ENV_STAGE:
               value: prod
               category: runtime_identity
-            OMI_LLM_GATEWAY_URL:
-              env_var: OMI_LLM_GATEWAY_URL
-              category: service_discovery
-              provisional: true
             POSTHOG_HOST:
               value: https://app.posthog.com
               category: telemetry
@@ -461,9 +436,6 @@ environments:
               version: latest
             GOOGLE_CLIENT_SECRET:
               secret: GOOGLE_CLIENT_SECRET
-              version: latest
-            OMI_LLM_GATEWAY_SERVICE_TOKEN:
-              secret: OMI_LLM_GATEWAY_SERVICE_TOKEN
               version: latest
             POSTHOG_PROJECT_API_KEY:
               secret: POSTHOG_PROJECT_API_KEY


### PR DESCRIPTION
## Summary
- Remove prod `OMI_LLM_GATEWAY_URL` from backend runtime manifest and backend-listen Helm values.
- Remove prod `OMI_LLM_GATEWAY_SERVICE_TOKEN` bindings from Cloud Run/GKE runtime config.
- Keep dev LLM gateway runtime config unchanged.

## Why
Prod LLM gateway is not deployed/enabled yet, so prod backend deploys should not require `OMI_LLM_GATEWAY_URL` or the gateway service token. The current prod workflow fails during runtime env rendering when `OMI_LLM_GATEWAY_URL` is absent from the prod GitHub environment.

## Test plan
- `python3 backend/scripts/validate-backend-runtime-env.py --env prod --check-workflows`
- `python3 backend/scripts/validate-backend-runtime-env.py --env dev --check-workflows`
- `CLOUD_RUN_VPC_NETWORK=omi-prod-vpc-1 CLOUD_RUN_VPC_SUBNET=omi-us-central1-prod-vpc-1-subnet-1 python3 backend/scripts/render-backend-runtime-env.py --env prod`
- `python3 -m pytest backend/tests/unit/test_backend_runtime_env_validator.py -q`

All passed locally.

## Notes
This does not deploy prod and does not remove any already-existing Cloud Run env vars from live services. It only stops the checked-in prod deploy path from requiring/injecting the not-yet-live LLM gateway config.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8995?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

