### PR TITLE
Prevent Firebase Google OAuth secret drift

### DIFF
--- a/backend/scripts/sync_firebase_google_provider_secret.py
+++ b/backend/scripts/sync_firebase_google_provider_secret.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""Sync Firebase Auth's Google provider secret from Secret Manager.
+
+Firebase Auth stores a separate copy of the Google OAuth client secret used by
+the hosted `__/auth/handler` flow. Rotating GOOGLE_CLIENT_SECRET in Secret
+Manager is not enough; this script patches the Firebase provider copy too.
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from typing import Any, Optional, Sequence
+
+IDENTITY_TOOLKIT_BASE_URL = "https://identitytoolkit.googleapis.com/admin/v2"
+GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token"
+DEFAULT_PROVIDER_ID = "google.com"
+DEFAULT_CLIENT_ID_SECRET = "GOOGLE_CLIENT_ID"
+DEFAULT_CLIENT_SECRET_SECRET = "GOOGLE_CLIENT_SECRET"
+
+
+@dataclass(frozen=True)
+class SyncConfig:
+    project: str
+    quota_project: str
+    provider_id: str
+    client_id_secret: str
+    client_secret_secret: str
+    apply: bool
+    validate_google_secret: bool
+
+
+def redact_value(value: str, *, visible_prefix: int = 8, visible_suffix: int = 8) -> str:
+    if not value:
+        return ""
+    if len(value) <= visible_prefix + visible_suffix:
+        return "***"
+    return f"{value[:visible_prefix]}...{value[-visible_suffix:]}"
+
+
+def provider_url(project: str, provider_id: str) -> str:
+    quoted_provider = urllib.parse.quote(provider_id, safe="")
+    return f"{IDENTITY_TOOLKIT_BASE_URL}/projects/{project}/defaultSupportedIdpConfigs/{quoted_provider}"
+
+
+def provider_resource_name(project: str, provider_id: str) -> str:
+    return f"projects/{project}/defaultSupportedIdpConfigs/{provider_id}"
+
+
+def build_provider_patch(project: str, provider_id: str, client_id: str, client_secret: str) -> dict[str, Any]:
+    return {
+        "name": provider_resource_name(project, provider_id),
+        "enabled": True,
+        "clientId": client_id,
+        "clientSecret": client_secret,
+    }
+
+
+def run_command(args: Sequence[str]) -> str:
+    completed = subprocess.run(args, check=True, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    return completed.stdout.strip()
+
+
+def access_secret(project: str, secret_name: str) -> str:
+    return run_command(
+        [
+            "gcloud",
+            "secrets",
+            "versions",
+            "access",
+            "latest",
+            f"--secret={secret_name}",
+            f"--project={project}",
+        ]
+    )
+
+
+def access_token() -> str:
+    try:
+        return run_command(["gcloud", "auth", "application-default", "print-access-token"])
+    except subprocess.CalledProcessError:
+        return run_command(["gcloud", "auth", "print-access-token"])
+
+
+def identity_toolkit_request(
+    method: str,
+    url: str,
+    token: str,
+    quota_project: str,
+    body: Optional[dict[str, Any]] = None,
+) -> dict[str, Any]:
+    data = None
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "x-goog-user-project": quota_project,
+    }
+    if body is not None:
+        data = json.dumps(body, separators=(",", ":")).encode("utf-8")
+        headers["Content-Type"] = "application/json"
+    request = urllib.request.Request(url, data=data, headers=headers, method=method)
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            return json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as error:
+        error_body = error.read().decode("utf-8", errors="replace")
+        raise RuntimeError(f"Identity Toolkit {method} failed status={error.code} body={error_body}") from error
+
+
+def validate_google_secret(client_id: str, client_secret: str) -> None:
+    body = urllib.parse.urlencode(
+        {
+            "code": "bogus-code-for-secret-validation",
+            "client_id": client_id,
+            "client_secret": client_secret,
+            "redirect_uri": "https://based-hardware.firebaseapp.com/__/auth/handler",
+            "grant_type": "authorization_code",
+        }
+    ).encode("utf-8")
+    request = urllib.request.Request(GOOGLE_TOKEN_URL, data=body, method="POST")
+    try:
+        with urllib.request.urlopen(request, timeout=30):
+            raise RuntimeError("Unexpected Google token success with bogus code")
+    except urllib.error.HTTPError as error:
+        payload = json.loads(error.read().decode("utf-8"))
+    if payload.get("error") == "invalid_client":
+        raise RuntimeError("GOOGLE_CLIENT_SECRET is invalid for GOOGLE_CLIENT_ID")
+    if payload.get("error") != "invalid_grant":
+        raise RuntimeError(f"Unexpected Google token response: {payload.get('error')}")
+
+
+def sync(config: SyncConfig) -> int:
+    client_id = access_secret(config.project, config.client_id_secret)
+    client_secret = access_secret(config.project, config.client_secret_secret)
+    if not client_id or not client_secret:
+        raise RuntimeError("Client ID and client secret must both be non-empty")
+
+    if config.validate_google_secret:
+        validate_google_secret(client_id, client_secret)
+        print("google_secret=valid")
+
+    token = access_token()
+    url = provider_url(config.project, config.provider_id)
+    provider = identity_toolkit_request("GET", url, token, config.quota_project)
+    existing_client_id = provider.get("clientId") or ""
+    print(f"provider={config.provider_id}")
+    print(f"project={config.project}")
+    print(f"provider_enabled={provider.get('enabled') is True}")
+    print(f"provider_client_id={redact_value(existing_client_id)}")
+    print(f"secret_client_id={redact_value(client_id)}")
+
+    if existing_client_id and existing_client_id != client_id:
+        raise RuntimeError(
+            f"Firebase provider client ID differs from {config.client_id_secret}; "
+            "fix the client ID before syncing the secret"
+        )
+
+    if not config.apply:
+        print("status=dry_run")
+        print("client_secret_readback=unavailable")
+        print("next=rerun with --apply after rotating GOOGLE_CLIENT_SECRET")
+        return 0
+
+    patch = build_provider_patch(config.project, config.provider_id, client_id, client_secret)
+    patched = identity_toolkit_request(
+        "PATCH",
+        f"{url}?updateMask=clientSecret,clientId,enabled",
+        token,
+        config.quota_project,
+        body=patch,
+    )
+    print("status=applied")
+    print(f"patched_enabled={patched.get('enabled') is True}")
+    print(f"patched_client_id={redact_value(patched.get('clientId') or '')}")
+    return 0
+
+
+def parse_args(argv: Optional[Sequence[str]] = None) -> SyncConfig:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--project", default="based-hardware", help="GCP/Firebase project ID")
+    parser.add_argument("--quota-project", help="Quota project for Identity Toolkit Admin API")
+    parser.add_argument("--provider-id", default=DEFAULT_PROVIDER_ID)
+    parser.add_argument("--client-id-secret", default=DEFAULT_CLIENT_ID_SECRET)
+    parser.add_argument("--client-secret-secret", default=DEFAULT_CLIENT_SECRET_SECRET)
+    parser.add_argument("--apply", action="store_true", help="Patch Firebase Auth provider. Default is dry-run.")
+    parser.add_argument(
+        "--skip-google-secret-validation",
+        action="store_true",
+        help="Skip token-endpoint validation of the Secret Manager client secret.",
+    )
+    args = parser.parse_args(argv)
+    quota_project = args.quota_project or args.project
+    return SyncConfig(
+        project=args.project,
+        quota_project=quota_project,
+        provider_id=args.provider_id,
+        client_id_secret=args.client_id_secret,
+        client_secret_secret=args.client_secret_secret,
+        apply=args.apply,
+        validate_google_secret=not args.skip_google_secret_validation,
+    )
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    try:
+        return sync(parse_args(argv))
+    except Exception as error:
+        print(f"error={error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/scripts/sync_firebase_google_provider_secret.py
+++ b/backend/scripts/sync_firebase_google_provider_secret.py
@@ -8,6 +8,7 @@ Manager is not enough; this script patches the Firebase provider copy too.
 
 import argparse
 import json
+import re
 import subprocess
 import sys
 import urllib.error
@@ -21,6 +22,9 @@ GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token"
 DEFAULT_PROVIDER_ID = "google.com"
 DEFAULT_CLIENT_ID_SECRET = "GOOGLE_CLIENT_ID"
 DEFAULT_CLIENT_SECRET_SECRET = "GOOGLE_CLIENT_SECRET"
+SENSITIVE_ERROR_RE = re.compile(
+    r"(?i)(client[_-]?secret|secret|access[_-]?token|refresh[_-]?token|id[_-]?token)(['\"\s:=]+)([^,\s}\"']+)"
+)
 
 
 @dataclass(frozen=True)
@@ -32,6 +36,7 @@ class SyncConfig:
     client_secret_secret: str
     apply: bool
     validate_google_secret: bool
+    auth_domain: Optional[str]
 
 
 def redact_value(value: str, *, visible_prefix: int = 8, visible_suffix: int = 8) -> str:
@@ -54,10 +59,41 @@ def provider_resource_name(project: str, provider_id: str) -> str:
 def build_provider_patch(project: str, provider_id: str, client_id: str, client_secret: str) -> dict[str, Any]:
     return {
         "name": provider_resource_name(project, provider_id),
-        "enabled": True,
         "clientId": client_id,
         "clientSecret": client_secret,
     }
+
+
+def project_config_url(project: str) -> str:
+    return f"{IDENTITY_TOOLKIT_BASE_URL}/projects/{project}/config"
+
+
+def safe_http_error_message(error_body: str) -> str:
+    try:
+        payload = json.loads(error_body)
+    except json.JSONDecodeError:
+        return "<unparseable>"
+
+    error = payload.get("error")
+    if isinstance(error, dict):
+        message = str(error.get("message") or error.get("status") or "<no message>")
+    elif error:
+        message = str(error)
+    else:
+        message = "<no message>"
+
+    redacted = SENSITIVE_ERROR_RE.sub(r"\1\2***", message)
+    return redacted[:300]
+
+
+def firebase_auth_redirect_uri(project: str, project_config: dict[str, Any], auth_domain: Optional[str] = None) -> str:
+    if auth_domain:
+        domain = auth_domain.removeprefix("https://").removeprefix("http://").rstrip("/")
+    else:
+        client = project_config.get("client") if isinstance(project_config.get("client"), dict) else {}
+        subdomain = str(client.get("firebaseSubdomain") or project).strip()
+        domain = f"{subdomain}.firebaseapp.com"
+    return f"https://{domain}/__/auth/handler"
 
 
 def run_command(args: Sequence[str]) -> str:
@@ -107,16 +143,17 @@ def identity_toolkit_request(
             return json.loads(response.read().decode("utf-8"))
     except urllib.error.HTTPError as error:
         error_body = error.read().decode("utf-8", errors="replace")
-        raise RuntimeError(f"Identity Toolkit {method} failed status={error.code} body={error_body}") from error
+        safe_message = safe_http_error_message(error_body)
+        raise RuntimeError(f"Identity Toolkit {method} failed status={error.code} message={safe_message}") from error
 
 
-def validate_google_secret(client_id: str, client_secret: str) -> None:
+def validate_google_secret(client_id: str, client_secret: str, redirect_uri: str) -> None:
     body = urllib.parse.urlencode(
         {
             "code": "bogus-code-for-secret-validation",
             "client_id": client_id,
             "client_secret": client_secret,
-            "redirect_uri": "https://based-hardware.firebaseapp.com/__/auth/handler",
+            "redirect_uri": redirect_uri,
             "grant_type": "authorization_code",
         }
     ).encode("utf-8")
@@ -138,11 +175,14 @@ def sync(config: SyncConfig) -> int:
     if not client_id or not client_secret:
         raise RuntimeError("Client ID and client secret must both be non-empty")
 
-    if config.validate_google_secret:
-        validate_google_secret(client_id, client_secret)
-        print("google_secret=valid")
-
     token = access_token()
+    project_config = identity_toolkit_request("GET", project_config_url(config.project), token, config.quota_project)
+    redirect_uri = firebase_auth_redirect_uri(config.project, project_config, config.auth_domain)
+    if config.validate_google_secret:
+        validate_google_secret(client_id, client_secret, redirect_uri)
+        print("google_secret=valid")
+        print(f"google_redirect_uri={redirect_uri}")
+
     url = provider_url(config.project, config.provider_id)
     provider = identity_toolkit_request("GET", url, token, config.quota_project)
     existing_client_id = provider.get("clientId") or ""
@@ -167,7 +207,7 @@ def sync(config: SyncConfig) -> int:
     patch = build_provider_patch(config.project, config.provider_id, client_id, client_secret)
     patched = identity_toolkit_request(
         "PATCH",
-        f"{url}?updateMask=clientSecret,clientId,enabled",
+        f"{url}?updateMask=clientSecret,clientId",
         token,
         config.quota_project,
         body=patch,
@@ -185,6 +225,10 @@ def parse_args(argv: Optional[Sequence[str]] = None) -> SyncConfig:
     parser.add_argument("--provider-id", default=DEFAULT_PROVIDER_ID)
     parser.add_argument("--client-id-secret", default=DEFAULT_CLIENT_ID_SECRET)
     parser.add_argument("--client-secret-secret", default=DEFAULT_CLIENT_SECRET_SECRET)
+    parser.add_argument(
+        "--auth-domain",
+        help="Firebase Auth domain for Google token validation. Defaults to the project's Firebase subdomain.",
+    )
     parser.add_argument("--apply", action="store_true", help="Patch Firebase Auth provider. Default is dry-run.")
     parser.add_argument(
         "--skip-google-secret-validation",
@@ -201,6 +245,7 @@ def parse_args(argv: Optional[Sequence[str]] = None) -> SyncConfig:
         client_secret_secret=args.client_secret_secret,
         apply=args.apply,
         validate_google_secret=not args.skip_google_secret_validation,
+        auth_domain=args.auth_domain,
     )
 
 

--- a/backend/templates/mcp_oauth_authorize.html
+++ b/backend/templates/mcp_oauth_authorize.html
@@ -92,6 +92,8 @@
                 </section>
 
                 <div class="oauth-actions">
+                    <div id="firebaseui-auth-container"></div>
+                    <div class="oauth-divider" id="social-sign-in-divider">or sign in with email</div>
                     <form class="email-sign-in-form" id="email-sign-in-form" novalidate>
                         <div class="oauth-field">
                             <label for="email-input">Email</label>
@@ -108,8 +110,6 @@
                             Sign in &amp; allow access
                         </button>
                     </form>
-                    <div class="oauth-divider" id="social-sign-in-divider">or continue with</div>
-                    <div id="firebaseui-auth-container"></div>
 
                     <div class="consent-retry" id="consent-retry" hidden>
                         <div class="signed-in-chip" id="signed-in-chip">

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -122,6 +122,8 @@ pytest tests/unit/test_developer_auth_context_static.py -v
 pytest tests/unit/test_mcp_auth_context_static.py -v
 pytest tests/unit/test_mcp_api_key_auth_context.py -v
 pytest tests/unit/test_mcp_api_key_scope_readiness.py -v
+pytest tests/unit/test_mcp_oauth_template.py -v
+pytest tests/unit/test_sync_firebase_google_provider_secret.py -v
 pytest tests/unit/test_short_term_lifecycle_worker.py -v
 pytest tests/unit/test_short_term_lifecycle_firestore_store.py -v
 pytest tests/unit/test_memory_contracts.py -v

--- a/backend/tests/unit/test_mcp_oauth_template.py
+++ b/backend/tests/unit/test_mcp_oauth_template.py
@@ -85,6 +85,13 @@ def test_mcp_oauth_template_still_renders_permissions_and_social_sign_in():
     assert "firebaseui-auth-container" in html
 
 
+def test_mcp_oauth_template_places_email_sign_in_below_social_options():
+    html = _render_mcp_template()
+
+    assert "or sign in with email" in html
+    assert html.index('id="firebaseui-auth-container"') < html.index('id="email-sign-in-form"')
+
+
 def test_mcp_oauth_template_uses_client_display_name():
     html = _render_mcp_template_for_client("Claude")
 

--- a/backend/tests/unit/test_sync_firebase_google_provider_secret.py
+++ b/backend/tests/unit/test_sync_firebase_google_provider_secret.py
@@ -1,0 +1,46 @@
+from scripts.sync_firebase_google_provider_secret import (
+    build_provider_patch,
+    parse_args,
+    provider_resource_name,
+    provider_url,
+    redact_value,
+)
+
+
+def test_redact_value_keeps_prefix_and_suffix_only():
+    redacted = redact_value("208440318997-secret-value.apps.googleusercontent.com")
+
+    assert redacted.startswith("20844031...")
+    assert redacted.endswith("tent.com")
+    assert "secret-value" not in redacted
+
+
+def test_build_provider_patch_includes_secret_without_logging_contract_fields():
+    patch = build_provider_patch("based-hardware", "google.com", "client-id", "client-secret")
+
+    assert patch == {
+        "name": "projects/based-hardware/defaultSupportedIdpConfigs/google.com",
+        "enabled": True,
+        "clientId": "client-id",
+        "clientSecret": "client-secret",
+    }
+
+
+def test_provider_helpers_encode_provider_for_url_but_not_resource_name():
+    assert provider_resource_name("based-hardware", "google.com") == (
+        "projects/based-hardware/defaultSupportedIdpConfigs/google.com"
+    )
+    assert provider_url("based-hardware", "google.com").endswith(
+        "/projects/based-hardware/defaultSupportedIdpConfigs/google.com"
+    )
+
+
+def test_cli_defaults_to_dry_run_and_secret_validation():
+    config = parse_args(["--project", "based-hardware"])
+
+    assert config.project == "based-hardware"
+    assert config.quota_project == "based-hardware"
+    assert config.apply is False
+    assert config.validate_google_secret is True
+    assert config.client_id_secret == "GOOGLE_CLIENT_ID"
+    assert config.client_secret_secret == "GOOGLE_CLIENT_SECRET"

--- a/backend/tests/unit/test_sync_firebase_google_provider_secret.py
+++ b/backend/tests/unit/test_sync_firebase_google_provider_secret.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from scripts.sync_firebase_google_provider_secret import (
     build_provider_patch,
     firebase_auth_redirect_uri,
@@ -7,6 +9,10 @@ from scripts.sync_firebase_google_provider_secret import (
     redact_value,
     safe_http_error_message,
 )
+
+BACKEND_DIR = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = BACKEND_DIR / "scripts" / "sync_firebase_google_provider_secret.py"
+TEST_SH_PATH = BACKEND_DIR / "test.sh"
 
 
 def test_redact_value_keeps_prefix_and_suffix_only():
@@ -83,3 +89,19 @@ def test_safe_http_error_message_does_not_echo_secret_values():
     assert "raw-secret-value" not in message
     assert "raw-token" not in message
     assert "client_secret=***" in message
+
+
+def test_static_review_guards_cover_secret_sync_regressions():
+    source = SCRIPT_PATH.read_text()
+
+    assert "body={error_body}" not in source
+    assert "failed status={error.code} body=" not in source
+    assert "updateMask=clientSecret,clientId,enabled" not in source
+    assert '"redirect_uri": "https://based-hardware.firebaseapp.com/__/auth/handler"' not in source
+
+
+def test_secret_sync_tests_are_registered_in_backend_test_sh():
+    test_sh = TEST_SH_PATH.read_text()
+
+    assert "pytest tests/unit/test_mcp_oauth_template.py -v" in test_sh
+    assert "pytest tests/unit/test_sync_firebase_google_provider_secret.py -v" in test_sh

--- a/backend/tests/unit/test_sync_firebase_google_provider_secret.py
+++ b/backend/tests/unit/test_sync_firebase_google_provider_secret.py
@@ -1,9 +1,11 @@
 from scripts.sync_firebase_google_provider_secret import (
     build_provider_patch,
+    firebase_auth_redirect_uri,
     parse_args,
     provider_resource_name,
     provider_url,
     redact_value,
+    safe_http_error_message,
 )
 
 
@@ -15,15 +17,15 @@ def test_redact_value_keeps_prefix_and_suffix_only():
     assert "secret-value" not in redacted
 
 
-def test_build_provider_patch_includes_secret_without_logging_contract_fields():
+def test_build_provider_patch_does_not_change_enabled_state():
     patch = build_provider_patch("based-hardware", "google.com", "client-id", "client-secret")
 
     assert patch == {
         "name": "projects/based-hardware/defaultSupportedIdpConfigs/google.com",
-        "enabled": True,
         "clientId": "client-id",
         "clientSecret": "client-secret",
     }
+    assert "enabled" not in patch
 
 
 def test_provider_helpers_encode_provider_for_url_but_not_resource_name():
@@ -44,3 +46,40 @@ def test_cli_defaults_to_dry_run_and_secret_validation():
     assert config.validate_google_secret is True
     assert config.client_id_secret == "GOOGLE_CLIENT_ID"
     assert config.client_secret_secret == "GOOGLE_CLIENT_SECRET"
+    assert config.auth_domain is None
+
+
+def test_cli_accepts_explicit_auth_domain_for_non_default_projects():
+    config = parse_args(["--project", "staging-project", "--auth-domain", "auth.example.com"])
+
+    assert config.project == "staging-project"
+    assert config.auth_domain == "auth.example.com"
+
+
+def test_firebase_auth_redirect_uri_uses_project_config_subdomain():
+    redirect_uri = firebase_auth_redirect_uri(
+        "fallback-project",
+        {"client": {"firebaseSubdomain": "based-hardware"}},
+    )
+
+    assert redirect_uri == "https://based-hardware.firebaseapp.com/__/auth/handler"
+
+
+def test_firebase_auth_redirect_uri_allows_explicit_auth_domain():
+    redirect_uri = firebase_auth_redirect_uri(
+        "fallback-project",
+        {"client": {"firebaseSubdomain": "based-hardware"}},
+        "https://auth.example.com/",
+    )
+
+    assert redirect_uri == "https://auth.example.com/__/auth/handler"
+
+
+def test_safe_http_error_message_does_not_echo_secret_values():
+    message = safe_http_error_message(
+        '{"error":{"message":"bad client_secret=raw-secret-value and refresh_token:raw-token"}}'
+    )
+
+    assert "raw-secret-value" not in message
+    assert "raw-token" not in message
+    assert "client_secret=***" in message

--- a/docs/runbooks/mcp-oauth-review-validator.md
+++ b/docs/runbooks/mcp-oauth-review-validator.md
@@ -7,6 +7,24 @@ cd backend
 python scripts/validate_mcp_oauth_review_config.py /path/to/submission.json
 ```
 
+## Google OAuth Secret Rotation
+
+Rotating `GOOGLE_CLIENT_SECRET` in Secret Manager does not update Firebase
+Auth's Google provider copy. After adding a new Secret Manager version, sync the
+Firebase provider before disabling the old version:
+
+```bash
+cd backend
+python scripts/sync_firebase_google_provider_secret.py --project based-hardware
+python scripts/sync_firebase_google_provider_secret.py --project based-hardware --apply
+```
+
+The first command is a dry run. The apply command patches
+`defaultSupportedIdpConfigs/google.com` using `GOOGLE_CLIENT_ID` and
+`GOOGLE_CLIENT_SECRET` from Secret Manager without printing secrets. If the
+provider copy drifts, FirebaseUI sign-in on the MCP OAuth consent page fails
+with `invalid_client` even when backend Google OAuth still works.
+
 If you captured a live `tools/list` response for the same scope set, compare it too:
 
 ```bash


### PR DESCRIPTION
## Summary
- add a dry-run-by-default sync script for Firebase Auth Google provider secret drift after `GOOGLE_CLIENT_SECRET` rotation
- document the required Secret Manager -> Firebase provider sync step in the MCP OAuth review runbook
- move MCP OAuth email/password login below Google/Apple and cover the ordering with a template test

## Live config context
- prod Firebase Auth `google.com` provider was patched outside this PR to use the current Secret Manager `GOOGLE_CLIENT_SECRET`
- audit trail showed `GOOGLE_CLIENT_SECRET` version 2 was added on 2026-07-01 by `david@scalingforever.com`, while Firebase provider config had not been updated until the manual patch
- no backend redeploy was performed

## Verification
- `backend/scripts/sync_firebase_google_provider_secret.py --project based-hardware`
- `cd backend && python3 -m pytest tests/unit/test_mcp_oauth_template.py tests/unit/test_mcp_oauth.py tests/unit/test_sync_firebase_google_provider_secret.py -q`
- pre-push passed with `PRE_PUSH_SKIP_BACKEND_UNIT_TESTS=1 PRE_PUSH_SKIP_OPENAPI_CONTRACT=1`; backend unit hook was skipped because local `python3` is 3.11.15 while `.python-version` expects 3.11.14, and OpenAPI was skipped because DNS resolution for `openaipublic.blob.core.windows.net` failed. The focused tests above passed manually.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8996?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

