### PR TITLE
ci: read CODEMAGIC_API_TOKEN from the prod environment

### DIFF
--- a/.github/workflows/mobile_internal_auto.yml
+++ b/.github/workflows/mobile_internal_auto.yml
@@ -13,6 +13,7 @@ permissions:
 jobs:
   trigger-codemagic:
     runs-on: ubuntu-latest
+    environment: prod
     concurrency:
       group: mobile-internal-auto-${{ matrix.workflow_id }}-${{ github.ref }}
       cancel-in-progress: true


### PR DESCRIPTION
## Problem
`mobile_internal_auto.yml` (the GitHub-side dispatcher for the `ios-internal-auto` / `android-internal-auto` Codemagic workflows, added in 5d6686917e) has failed on every run — the July 3 and July 4 `app/**` merges never shipped internal builds.

Cause: `CODEMAGIC_API_TOKEN` is stored as a secret in the **prod** GitHub environment, but the `trigger-codemagic` job doesn't declare an environment, so `secrets.CODEMAGIC_API_TOKEN` resolves empty and the validate step exits 1.

## Fix
Bind the job to the `prod` environment (one line) so the environment secret is visible. `prod` has no protection rules, so this adds no approval gate to auto-deploys.

## After merge
Backfill the missed deploys with:
```
gh workflow run mobile_internal_auto.yml --repo BasedHardware/omi
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9002?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

