### PR TITLE
Fix desktop PTT reliability and connection status polish

### DIFF
--- a/app/lib/pages/home/device.dart
+++ b/app/lib/pages/home/device.dart
@@ -225,9 +225,9 @@ class _ConnectedDeviceState extends State<ConnectedDevice> {
               icon: FontAwesomeIcons.graduationCap,
               title: context.l10n.deviceTutorial,
               onTap: () {
-                Navigator.of(
-                  context,
-                ).push(MaterialPageRoute(builder: (_) => const InteractiveDeviceOnboardingWrapper(allowExit: true)));
+                Navigator.of(context).push(
+                  MaterialPageRoute(builder: (_) => const InteractiveDeviceOnboardingWrapper(allowExit: true)),
+                );
               },
             ),
             const Divider(height: 1, color: Color(0xFF3C3C43)),
@@ -239,14 +239,13 @@ class _ConnectedDeviceState extends State<ConnectedDevice> {
             chipValue: provider.connectedDevice == null
                 ? context.l10n.offline
                 : provider.havingNewFirmware
-                ? context.l10n.available
-                : null,
+                    ? context.l10n.available
+                    : null,
             onTap: provider.connectedDevice != null
                 ? () {
                     // Route to OmiGlass OTA page for openglass devices
                     final deviceName = provider.connectedDevice!.name.toLowerCase();
-                    final isOpenGlass =
-                        provider.connectedDevice!.type == DeviceType.openglass ||
+                    final isOpenGlass = provider.connectedDevice!.type == DeviceType.openglass ||
                         deviceName.contains('openglass') ||
                         deviceName.contains('omiglass') ||
                         deviceName.contains('glass');
@@ -314,9 +313,8 @@ class _ConnectedDeviceState extends State<ConnectedDevice> {
               chipColor: pendingSeconds > 0 ? const Color(0xFF3D3520) : null,
               chipTextColor: pendingSeconds > 0 ? const Color(0xFFFFD060) : null,
               onTap: () {
-                final page = context.read<DeviceProvider>().supportsMultiFileSync
-                    ? const AutoSyncPage()
-                    : const SyncPage();
+                final page =
+                    context.read<DeviceProvider>().supportsMultiFileSync ? const AutoSyncPage() : const SyncPage();
                 Navigator.of(context).push(MaterialPageRoute(builder: (context) => page));
               },
             ),

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/AgentPill.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/AgentPill.swift
@@ -714,7 +714,7 @@ final class AgentPillsManager: ObservableObject {
                 pill.completedAt = nil
                 pill.suggestedFollowUps = []
                 pill.latestActivity = "Working…"
-                pill.conversationMessages = [ChatMessage(text: pill.query, sender: .user)]
+                Self.ensureStreamingAssistantMessage(for: pill)
                 pill.markContentChanged()
                 AgentRuntimeStatusStore.shared.recordAcceptedRun(
                     surface: surfaceRef,
@@ -774,6 +774,7 @@ final class AgentPillsManager: ObservableObject {
         pill.suggestedFollowUps = []
         pill.latestActivity = "Interrupting current run…"
         pill.conversationMessages.append(ChatMessage(text: text, sender: .user))
+        Self.ensureStreamingAssistantMessage(for: pill)
         pill.markContentChanged()
         let workingDirectory = FloatingControlBarManager.shared.sharedFloatingProvider?.workingDirectory
         let activeRunId = pill.canonicalRunId
@@ -804,6 +805,7 @@ final class AgentPillsManager: ObservableObject {
                     guard self.pills.contains(where: { $0.id == pill.id }) else { return }
                 }
                 pill.latestActivity = "Working on your follow-up…"
+                Self.ensureStreamingAssistantMessage(for: pill)
                 pill.markContentChanged()
                 let result = try await DesktopCoordinatorService.shared.continueAgent(
                     sessionId: sessionId,
@@ -879,6 +881,7 @@ final class AgentPillsManager: ObservableObject {
         pill.status = .stopped
         pill.latestActivity = "Stopped by user"
         pill.completedAt = Date()
+        Self.clearStreamingAssistantMessage(for: pill)
         pill.suggestedFollowUps = AgentPillsManager.deriveFollowUps(for: pill)
         pill.markContentChanged()
         if pill.viewedAt != nil {
@@ -997,7 +1000,7 @@ final class AgentPillsManager: ObservableObject {
             } else {
                 pill.status = .running
                 pill.latestActivity = "Working…"
-                pill.aiMessage = nil
+                Self.ensureStreamingAssistantMessage(for: pill)
                 pill.completedAt = nil
             }
             pill.markContentChanged()
@@ -1135,15 +1138,18 @@ final class AgentPillsManager: ObservableObject {
         case "queued", "starting":
             pill.status = .starting
             pill.latestActivity = "Starting…"
+            Self.ensureStreamingAssistantMessage(for: pill)
         case "running", "waiting_input", "waiting_approval", "cancelling":
             pill.status = .running
             pill.latestActivity = inspection.status == "cancelling" ? "Stopping…" : "Working…"
+            Self.ensureStreamingAssistantMessage(for: pill)
         case "succeeded", "completed":
             finish(pill: pill, finalText: inspection.finalText)
         case "cancelled":
             pill.status = .stopped
             pill.latestActivity = "Stopped by user"
             pill.completedAt = Date()
+            Self.clearStreamingAssistantMessage(for: pill)
             pill.suggestedFollowUps = AgentPillsManager.deriveFollowUps(for: pill)
         case "failed", "timed_out", "orphaned":
             fail(pill: pill, errorText: inspection.errorMessage ?? "Agent failed")
@@ -1161,18 +1167,23 @@ final class AgentPillsManager: ObservableObject {
     private func finish(pill: AgentPill, finalText: String?) {
         let trimmed = finalText?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         if !trimmed.isEmpty {
-            let finalMessage = ChatMessage(text: trimmed, sender: .ai)
+            var finalMessage = pill.aiMessage ?? ChatMessage(text: trimmed, sender: .ai)
+            finalMessage.text = trimmed
+            finalMessage.isStreaming = false
             pill.aiMessage = finalMessage
             if pill.conversationMessages.isEmpty {
                 pill.conversationMessages = [
                     ChatMessage(text: pill.query, sender: .user),
                     finalMessage,
                 ]
+            } else if let index = pill.conversationMessages.firstIndex(where: { $0.id == finalMessage.id }) {
+                pill.conversationMessages[index] = finalMessage
             } else if !pill.conversationMessages.contains(where: { $0.id == finalMessage.id }) {
                 pill.conversationMessages.append(finalMessage)
             }
             pill.latestActivity = String(trimmed.prefix(140))
         } else {
+            Self.clearStreamingAssistantMessage(for: pill)
             pill.latestActivity = "Done"
         }
         pill.status = .done
@@ -1185,9 +1196,52 @@ final class AgentPillsManager: ObservableObject {
         pill.status = .failed(errorText)
         pill.latestActivity = errorText
         pill.completedAt = Date()
+        Self.clearStreamingAssistantMessage(for: pill)
         Self.ensureFailureMessage(errorText, for: pill)
         pill.suggestedFollowUps = AgentPillsManager.deriveFollowUps(for: pill)
         pill.markContentChanged()
+    }
+
+    private static func ensureStreamingAssistantMessage(for pill: AgentPill) {
+        if let aiMessage = pill.aiMessage, aiMessage.isStreaming {
+            if !pill.conversationMessages.contains(where: { $0.id == aiMessage.id }) {
+                pill.conversationMessages.append(aiMessage)
+            }
+            return
+        }
+
+        if let index = pill.conversationMessages.lastIndex(where: { $0.sender == .ai && $0.isStreaming }) {
+            pill.aiMessage = pill.conversationMessages[index]
+            return
+        }
+
+        if pill.conversationMessages.isEmpty {
+            pill.conversationMessages = [ChatMessage(text: pill.query, sender: .user)]
+        }
+
+        var streamingMessage = ChatMessage(text: "", sender: .ai)
+        streamingMessage.isStreaming = true
+        pill.aiMessage = streamingMessage
+        pill.conversationMessages.append(streamingMessage)
+    }
+
+    private static func clearStreamingAssistantMessage(for pill: AgentPill) {
+        guard let aiMessage = pill.aiMessage, aiMessage.isStreaming else { return }
+        let hasVisibleContent =
+            !aiMessage.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            || !aiMessage.contentBlocks.isEmpty
+
+        if hasVisibleContent {
+            var completedMessage = aiMessage
+            completedMessage.isStreaming = false
+            pill.aiMessage = completedMessage
+            if let index = pill.conversationMessages.firstIndex(where: { $0.id == completedMessage.id }) {
+                pill.conversationMessages[index] = completedMessage
+            }
+        } else {
+            pill.aiMessage = nil
+            pill.conversationMessages.removeAll { $0.id == aiMessage.id }
+        }
     }
 
     private func handle(messages: [ChatMessage], since: Int, for pill: AgentPill) {
@@ -1334,12 +1388,15 @@ final class AgentPillsManager: ObservableObject {
         switch projection.status {
         case .queued:
             pill.status = .queued
+            ensureStreamingAssistantMessage(for: pill)
         case .starting, .running, .waitingInput, .waitingApproval, .cancelling:
             pill.status = .running
             pill.completedAt = nil
+            ensureStreamingAssistantMessage(for: pill)
         case .succeeded:
             pill.status = .done
             pill.completedAt = projection.completedAt ?? Date()
+            clearStreamingAssistantMessage(for: pill)
             if let statusText = projection.statusText?.trimmingCharacters(in: .whitespacesAndNewlines),
                !statusText.isEmpty {
                 pill.latestActivity = String(statusText.prefix(140))
@@ -1356,12 +1413,14 @@ final class AgentPillsManager: ObservableObject {
             pill.status = .failed(message)
             pill.latestActivity = message
             pill.completedAt = projection.completedAt ?? Date()
+            clearStreamingAssistantMessage(for: pill)
             ensureFailureMessage(message, for: pill)
             pill.markContentChanged()
         case .cancelled:
             pill.status = .stopped
             pill.latestActivity = "Stopped by user"
             pill.completedAt = projection.completedAt ?? Date()
+            clearStreamingAssistantMessage(for: pill)
             pill.markContentChanged()
         case .idle:
             break

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingBarVoicePlaybackService.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingBarVoicePlaybackService.swift
@@ -548,7 +548,11 @@ final class FloatingBarVoicePlaybackService: NSObject, AVAudioPlayerDelegate, AV
   }
 
   private func setFloatingPillResponseGlow(_ active: Bool) {
-    FloatingControlBarManager.shared.barState?.isVoiceResponseActive = active
+    if active {
+      FloatingControlBarManager.shared.barState?.isVoiceResponseActive = true
+    } else {
+      FloatingControlBarManager.shared.barState?.clearVoiceResponseState()
+    }
   }
 
   private func clearFloatingPillResponseGlowIfIdle() {

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarState.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarState.swift
@@ -161,7 +161,18 @@ class FloatingControlBarState: NSObject, ObservableObject {
     @Published var isVoiceLocked: Bool = false
     @Published var voiceTranscript: String = ""
     @Published var isVoiceResponseActive: Bool = false {
+        didSet {
+            if isVoiceResponseActive {
+                isVoiceResponseWaiting = false
+            }
+            updateVoiceResponseWatchdog()
+        }
+    }
+    @Published var isVoiceResponseWaiting: Bool = false {
         didSet { updateVoiceResponseWatchdog() }
+    }
+    var isVoiceResponseGlowActive: Bool {
+        isVoiceResponseActive || isVoiceResponseWaiting
     }
     /// True only when the notch-mode setting is enabled and the current display
     /// exposes a real camera housing safe area. External displays keep old pill UI.
@@ -298,16 +309,27 @@ class FloatingControlBarState: NSObject, ObservableObject {
         voiceFollowUpTranscript = ""
         currentQueryFromVoice = false
         lastConversationActivityAt = nil
+        clearVoiceResponseState()
+    }
+
+    func beginVoiceResponseWaiting() {
+        guard !isVoiceResponseActive else { return }
+        isVoiceResponseWaiting = true
+    }
+
+    func clearVoiceResponseState() {
+        isVoiceResponseWaiting = false
+        isVoiceResponseActive = false
     }
 
     private func updateVoiceResponseWatchdog() {
         voiceResponseWatchdogWorkItem?.cancel()
         voiceResponseWatchdogWorkItem = nil
-        guard isVoiceResponseActive else { return }
+        guard isVoiceResponseGlowActive else { return }
 
         let workItem = DispatchWorkItem { [weak self] in
-            guard let self, self.isVoiceResponseActive else { return }
-            self.isVoiceResponseActive = false
+            guard let self, self.isVoiceResponseGlowActive else { return }
+            self.clearVoiceResponseState()
         }
         voiceResponseWatchdogWorkItem = workItem
         DispatchQueue.main.asyncAfter(

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift
@@ -238,7 +238,7 @@ struct FloatingControlBarView: View {
                     .fill(Color.black)
                     .frame(width: surfaceWidth, height: surfaceHeight)
 
-                    if state.isVoiceResponseActive {
+                    if state.isVoiceResponseGlowActive {
                         NotchResponseGlowView(
                             bottomRadius: bottomRadius,
                             topRadius: state.usesNotchIsland ? 0 : 14,
@@ -930,7 +930,7 @@ struct FloatingControlBarView: View {
     }
 
     private var controlBarView: some View {
-        let allowsHoverExpansion = isHovering && !state.isVoiceResponseActive
+        let allowsHoverExpansion = isHovering && !state.isVoiceResponseGlowActive
         return Group {
             if state.isVoiceListening && !state.isVoiceFollowUp {
                 voiceListeningView
@@ -954,7 +954,7 @@ struct FloatingControlBarView: View {
                 .transition(.opacity)
             } else {
                 PillStatusObservingView(manager: agentPills) { pills in
-                    let agentGroup = state.isVoiceResponseActive
+                    let agentGroup = state.isVoiceResponseGlowActive
                         ? nil
                         : NotchAgentStatusGroup.aggregate(for: pills)
                     compactCircleView(agentGroup: agentGroup)
@@ -1031,19 +1031,19 @@ struct FloatingControlBarView: View {
             .fill(compactPillFill(agentGroup: agentGroup))
             .frame(width: 28, height: 6)
             .shadow(
-                color: state.isVoiceResponseActive ? Color.white.opacity(0.85) : .clear,
-                radius: state.isVoiceResponseActive ? 16 : 0,
+                color: state.isVoiceResponseGlowActive ? Color.white.opacity(0.85) : .clear,
+                radius: state.isVoiceResponseGlowActive ? 16 : 0,
                 x: 0,
                 y: 0
             )
             .shadow(
-                color: state.isVoiceResponseActive ? Color.white.opacity(0.45) : .clear,
-                radius: state.isVoiceResponseActive ? 28 : 0,
+                color: state.isVoiceResponseGlowActive ? Color.white.opacity(0.45) : .clear,
+                radius: state.isVoiceResponseGlowActive ? 28 : 0,
                 x: 0,
                 y: 0
             )
             .overlay {
-                if state.isVoiceResponseActive {
+                if state.isVoiceResponseGlowActive {
                     RoundedRectangle(cornerRadius: 3)
                         .stroke(
                             LinearGradient(
@@ -1061,11 +1061,11 @@ struct FloatingControlBarView: View {
                         .blur(radius: 0.25)
                 }
             }
-            .animation(.easeInOut(duration: 0.18), value: state.isVoiceResponseActive)
+            .animation(.easeInOut(duration: 0.18), value: state.isVoiceResponseGlowActive)
     }
 
     private func compactPillFill(agentGroup: NotchAgentStatusGroup?) -> LinearGradient {
-        if state.isVoiceResponseActive {
+        if state.isVoiceResponseGlowActive {
             return LinearGradient(
                 colors: [
                     Color.white.opacity(0.9),

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
@@ -210,7 +210,7 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
                 height: size.height + Self.notchGlowOutsetBottom
             )
         }
-        guard state.isVoiceResponseActive || collapsedPillAgentGlowActive else { return size }
+        guard state.isVoiceResponseGlowActive || collapsedPillAgentGlowActive else { return size }
         guard size.width <= Self.minBarSize.width + 0.5,
               size.height <= Self.minBarSize.height + 0.5
         else { return size }
@@ -805,7 +805,8 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
     }
 
     private func observeVoiceResponseGlow() {
-        voiceResponseGlowCancellable = state.$isVoiceResponseActive
+        voiceResponseGlowCancellable = Publishers.CombineLatest(state.$isVoiceResponseActive, state.$isVoiceResponseWaiting)
+            .map { $0 || $1 }
             .removeDuplicates()
             .receive(on: DispatchQueue.main)
             .sink { [weak self] isActive in
@@ -952,7 +953,7 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
         // streaming subscription must still be cancelled so late-arriving
         // chunks cannot re-present .mainResponse and pop the panel back open.
         // (Codex P2 — streaming reopens surface during playback.)
-        let keepVoiceResponseAlive = state.isVoiceResponseActive
+        let keepVoiceResponseAlive = state.isVoiceResponseGlowActive
         FloatingControlBarManager.shared.cancelChat(keepVoiceAlive: keepVoiceResponseAlive)
 
         // Cancel dynamic response-height observer and reset its state
@@ -1445,7 +1446,7 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
     /// force-grows the window with the origin pinned (a rightward drift).
     @discardableResult
     func resizeForHover(expanded: Bool) -> Bool {
-        guard !state.showingAIConversation, !state.isVoiceListening, !state.isVoiceResponseActive, !state.isShowingNotification, !suppressHoverResize else { return false }
+        guard !state.showingAIConversation, !state.isVoiceListening, !state.isVoiceResponseGlowActive, !state.isShowingNotification, !suppressHoverResize else { return false }
         // The pill agent list owns the window size while open; hover
         // exits must not collapse it out from under the list.
         guard notchModeEnabled || !state.isNotchHoverMenuVisible else { return false }
@@ -1471,7 +1472,7 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
             guard let self = self else { return }
             guard !self.state.showingAIConversation,
                   !self.state.isVoiceListening,
-                  !self.state.isVoiceResponseActive,
+                  !self.state.isVoiceResponseGlowActive,
                   !self.state.isShowingNotification,
                   !self.suppressHoverResize
             else { return }
@@ -1629,7 +1630,7 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
         // (e.g. realtime audio received this turn), collapse to the glow-adjusted
         // compact size so the white glow/stroke is not clipped until the idle
         // timer clears it.
-        let compactSize: NSSize = state.isVoiceResponseActive
+        let compactSize: NSSize = state.isVoiceResponseGlowActive
             ? responseGlowWindowSizeForCurrentScreen(forSurfaceSize: Self.minBarSize)
             : Self.minBarSize
         let targetFrame = FloatingControlBarGeometry.pushToTalkFrame(
@@ -2252,7 +2253,7 @@ class FloatingControlBarManager {
             isAskOmiFocused: focused,
             frame: NSStringFromRect(window.frame),
             isVoiceListening: window.state.isVoiceListening,
-            isVoiceResponseActive: window.state.isVoiceResponseActive,
+            isVoiceResponseActive: window.state.isVoiceResponseGlowActive,
             usesNotchIsland: window.state.usesNotchIsland
         )
     }
@@ -2872,7 +2873,7 @@ class FloatingControlBarManager {
                 )
             case .voiceOnly:
                 barWindow.state.currentQueryFromVoice = false
-                barWindow.state.isVoiceResponseActive = false
+                barWindow.state.clearVoiceResponseState()
                 FloatingBarVoicePlaybackService.shared.speakOneShot(assistantText)
             }
             return
@@ -2897,7 +2898,7 @@ class FloatingControlBarManager {
                     )
                 case .voiceOnly:
                     barWindow.state.currentQueryFromVoice = false
-                    barWindow.state.isVoiceResponseActive = false
+                    barWindow.state.clearVoiceResponseState()
                     FloatingBarVoicePlaybackService.shared.speakOneShot(resolvedProvider.setupNeededStatus)
                 }
                 return
@@ -2930,7 +2931,7 @@ class FloatingControlBarManager {
                 )
             case .voiceOnly:
                 barWindow.state.currentQueryFromVoice = false
-                barWindow.state.isVoiceResponseActive = false
+                barWindow.state.clearVoiceResponseState()
                 FloatingBarVoicePlaybackService.shared.speakOneShot(assistantText)
             }
             return
@@ -2958,7 +2959,7 @@ class FloatingControlBarManager {
             )
         case .voiceOnly:
             barWindow.state.currentQueryFromVoice = false
-            barWindow.state.isVoiceResponseActive = false
+            barWindow.state.clearVoiceResponseState()
         }
     }
 
@@ -3007,7 +3008,7 @@ class FloatingControlBarManager {
             barWindow.state.currentAIMessage = message
             barWindow.state.isAILoading = false
             barWindow.state.currentQueryFromVoice = false
-            barWindow.state.isVoiceResponseActive = false
+            barWindow.state.clearVoiceResponseState()
             barWindow.state.present(.mainResponse)
             barWindow.state.markConversationActivity()
             barWindow.resizeToResponseHeightPublic(animated: true)
@@ -3088,7 +3089,7 @@ class FloatingControlBarManager {
         barWindow.state.isAILoading = false
         barWindow.state.present(.mainResponse)
         barWindow.state.currentQueryFromVoice = false
-        barWindow.state.isVoiceResponseActive = false
+        barWindow.state.clearVoiceResponseState()
         barWindow.state.markConversationActivity()
         barWindow.resizeToResponseHeightPublic(animated: true)
     }
@@ -3700,7 +3701,7 @@ class FloatingControlBarManager {
             if limiter.isLimitReached {
                 currentTracer?.end("pre_llm", metadata: ["error": "usage_limit"])
                 barWindow.state.currentQueryFromVoice = false
-                barWindow.state.isVoiceResponseActive = false
+                barWindow.state.clearVoiceResponseState()
                 FloatingBarVoicePlaybackService.shared.speakOneShot(
                     "You've reached \(limiter.limitDescription). Upgrade to keep chatting without restrictions."
                 )

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
@@ -645,7 +645,7 @@ class PushToTalkManager: ObservableObject {
     activeTracer?.end("ptt_recording")
 
     if isWaitingForHub {
-      barState?.isVoiceResponseActive = true
+      barState?.beginVoiceResponseWaiting()
       updateBarState()
       log("PushToTalkManager: finalizing while realtime hub warms — holding buffered audio")
       return
@@ -704,6 +704,7 @@ class PushToTalkManager: ObservableObject {
       }
       silentMicRecoveryPolicy.recordSuccessfulHubTurn()
       DesktopDiagnosticsManager.shared.recordPTTCommitted(mode: finalizedMode, hubActive: true)
+      barState?.beginVoiceResponseWaiting()
       // Collapse the bar on release — the hub speaks its reply as audio (no inline
       // status UI), the same as the legacy voice path.
       updateBarState()
@@ -931,6 +932,7 @@ class PushToTalkManager: ObservableObject {
     // openAIInputWithQuery / sendFollowUpQuery inherits the bound value.
     let tracer = activeTracer
     activeTracer = nil
+    barState?.beginVoiceResponseWaiting()
     let dispatch = {
       if wasFollowUp {
         log("PushToTalkManager: sending follow-up query (\(query.count) chars): \(query)")
@@ -1131,6 +1133,7 @@ class PushToTalkManager: ObservableObject {
       return
     }
     DesktopDiagnosticsManager.shared.recordPTTCommitted(mode: finalizedMode, hubActive: true)
+    barState?.beginVoiceResponseWaiting()
     state = .idle
     updateBarState()
     AnalyticsManager.shared.floatingBarPTTEnded(
@@ -1421,7 +1424,7 @@ class PushToTalkManager: ObservableObject {
     barState.isVoiceLocked = (state == .lockedListening)
     barState.isVoiceFollowUp = isCurrentSessionFollowUp && isShowingVoiceUI
     if isShowingVoiceUI {
-      barState.isVoiceResponseActive = false
+      barState.clearVoiceResponseState()
     }
     if !isShowingVoiceUI {
       barState.voiceTranscript = ""

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
@@ -141,7 +141,11 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate {
   private var sessionAuth: HubAuth?
   private var pcmPlayer: StreamingPCMPlayer?
   private lazy var responseGlowGate = RealtimeResponseGlowGate { [weak self] active in
-    self?.barState?.isVoiceResponseActive = active
+    if active {
+      self?.barState?.isVoiceResponseActive = true
+    } else {
+      self?.barState?.clearVoiceResponseState()
+    }
   }
   private let agentControlService = AgentControlService()
 
@@ -885,17 +889,19 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate {
       }
     }
     guard let s = session else {
-      if pendingBargeInReplacement != nil {
-        log("RealtimeHub[\(providerTag)]: barge-in replacement not ready at commit — falling back to buffered transcription")
-        clearBargeInReplacementState()
-        responding = false
+      if var pending = pendingBargeInReplacement {
+        pending.pendingCommit = true
+        pendingBargeInReplacement = pending
+        log(
+          "RealtimeHub[\(providerTag)]: barge-in replacement not ready at commit — "
+            + "deferring commit (bufferedChunks=\(pending.audioBuffer.count))"
+        )
         ensureWarm()
-        return .rejectedNoSession
-      } else {
-        responding = false
-        exitVoiceUI(clearResponseGlow: true)
-        return .rejectedNoSession
+        return .deferredForReplacement
       }
+      responding = false
+      exitVoiceUI(clearResponseGlow: true)
+      return .rejectedNoSession
     }
     // Hint the provider's transcription with the identified language, entirely
     // synchronously: one configured language → hint it directly; several → whatever the
@@ -1527,6 +1533,12 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate {
       let candidates = AssistantSettings.shared.voiceBaseLanguages
       let fullTask = fullLIDTask
       let provider = providerTag
+      let provisionalHeard = heard
+      let provisionalReply = reply
+      rememberVoiceContinuityTurn(
+        userText: provisionalHeard,
+        assistantText: provisionalReply,
+        interrupted: false)
       Task { @MainActor [weak self] in
         var userText = heard
         var providerLang: String?
@@ -1565,7 +1577,14 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate {
         }
         // Continuity memory + persistence use the CORRECTED text, so a swapped
         // bubble and the model's follow-up context stay consistent.
-        self?.rememberVoiceContinuityTurn(userText: userText, assistantText: reply, interrupted: false)
+        if usedLocal {
+          self?.replaceVoiceContinuityTurn(
+            originalUserText: provisionalHeard,
+            originalAssistantText: provisionalReply,
+            correctedUserText: userText,
+            correctedAssistantText: reply,
+            interrupted: false)
+        }
         FloatingControlBarManager.shared.recordVoiceTurn(userText: userText, assistantText: reply)
         self?.lastTurnDiagnostics = [
           "provider": provider,
@@ -1590,6 +1609,39 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate {
       pendingCompletedAgentDeltaHighWaterMs = nil
     }
     exitVoiceUI()
+  }
+
+  private func replaceVoiceContinuityTurn(
+    originalUserText: String,
+    originalAssistantText: String,
+    correctedUserText: String,
+    correctedAssistantText: String,
+    interrupted: Bool
+  ) {
+    let originalUser = originalUserText.trimmingCharacters(in: .whitespacesAndNewlines)
+    let originalAssistant = originalAssistantText.trimmingCharacters(in: .whitespacesAndNewlines)
+    let correctedUser = correctedUserText.trimmingCharacters(in: .whitespacesAndNewlines)
+    let correctedAssistant = correctedAssistantText.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !correctedUser.isEmpty || !correctedAssistant.isEmpty else { return }
+
+    if let index = voiceContinuityTurns.lastIndex(where: {
+      $0.userText == originalUser
+        && $0.assistantText == originalAssistant
+        && $0.interrupted == interrupted
+    }) {
+      voiceContinuityTurns[index] = RealtimeVoiceContinuityTurn(
+        userText: correctedUser,
+        assistantText: correctedAssistant,
+        interrupted: interrupted,
+        recordedAt: voiceContinuityTurns[index].recordedAt
+      )
+      return
+    }
+
+    rememberVoiceContinuityTurn(
+      userText: correctedUser,
+      assistantText: correctedAssistant,
+      interrupted: interrupted)
   }
 
   private func rememberVoiceContinuityTurn(userText: String, assistantText: String, interrupted: Bool) {

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/AgentConnectPickerSheet.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/AgentConnectPickerSheet.swift
@@ -107,17 +107,15 @@ private struct ConnectOptionCard: View {
   }
 
   private var primaryLabel: String {
+    let presentation = MemoryExportConnectionPresentation.make(
+      destination: destination,
+      status: statuses[destination],
+      isRunning: isRunning,
+      accessibilityPreflightMissing: MemoryExportExecutor.accessibilityPreflightMissing(
+        for: destination)
+    )
     _ = permissionRefreshID
-    switch destination.mcpExecuteKind {
-    case .localAutonomous:
-      return "Do it for me"
-    case .browserAutonomous:
-      return MemoryExportExecutor.accessibilityPreflightMissing(for: destination)
-        ? "Grant Accessibility"
-        : "Do it for me"
-    case .assisted:
-      return destination.assistedOverlayHint != nil ? "Open & guide me" : "Open & copy key"
-    }
+    return presentation.primaryActionTitle ?? ""
   }
 
   var body: some View {
@@ -137,11 +135,22 @@ private struct ConnectOptionCard: View {
       }
 
       VStack(alignment: .leading, spacing: 8) {
-        // Primary action — the shared app pill (compact, white). Same style the
-        // single-destination sheet uses, so the connect flow is consistent.
-        Button(isRunning ? "Connecting…" : primaryLabel, action: run)
-          .buttonStyle(OnboardingCardButtonStyle(isPrimary: true))
-          .disabled(isRunning)
+        let presentation = MemoryExportConnectionPresentation.make(
+          destination: destination,
+          status: statuses[destination],
+          isRunning: isRunning,
+          accessibilityPreflightMissing: MemoryExportExecutor.accessibilityPreflightMissing(
+            for: destination)
+        )
+        if let completion = presentation.completion {
+          setupCompleteBlock(completion)
+        } else {
+          // Primary action — the shared app pill (compact, white). Same style the
+          // single-destination sheet uses, so the connect flow is consistent.
+          Button(presentation.primaryActionTitle ?? primaryLabel, action: run)
+            .buttonStyle(OnboardingCardButtonStyle(isPrimary: true))
+            .disabled(isRunning)
+        }
 
         // Secondary — full manual instructions in a quiet dropdown.
         if let setup = destination.mcpSetup(key: mcpKey ?? "YOUR_OMI_KEY") {
@@ -166,7 +175,7 @@ private struct ConnectOptionCard: View {
         }
       }
 
-      if let resultMessage {
+      if statuses[destination]?.hasConnection != true, let resultMessage {
         Text(resultMessage)
           .scaledFont(size: 11, weight: .medium)
           .foregroundColor(OmiColors.success)
@@ -189,16 +198,25 @@ private struct ConnectOptionCard: View {
     }
     .onReceive(permissionRefreshTimer) { _ in
       refreshPermissionStateIfNeeded()
+      refreshConnectionStatusIfNeeded()
     }
     .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification))
     { _ in
       refreshPermissionStateIfNeeded()
+      refreshConnectionStatusIfNeeded()
     }
   }
 
   private func refreshPermissionStateIfNeeded() {
     guard MemoryExportExecutor.requiresAccessibilityPreflight(destination) else { return }
     permissionRefreshID += 1
+  }
+
+  private func refreshConnectionStatusIfNeeded() {
+    guard destination.supportsMCP || destination.supportsAgentSetup else { return }
+    Task {
+      statuses[destination] = await MemoryExportService.shared.status(for: destination)
+    }
   }
 
   private func run() {
@@ -225,6 +243,33 @@ private struct ConnectOptionCard: View {
       }
       isRunning = false
     }
+  }
+
+  private func setupCompleteBlock(_ completion: MCPSetupCompletionSummary) -> some View {
+    HStack(alignment: .top, spacing: 10) {
+      Image(systemName: "checkmark.seal.fill")
+        .scaledFont(size: 15, weight: .semibold)
+        .foregroundColor(OmiColors.success)
+        .padding(.top, 1)
+      VStack(alignment: .leading, spacing: 4) {
+        Text(completion.title)
+          .scaledFont(size: 13, weight: .semibold)
+          .foregroundColor(OmiColors.textPrimary)
+        Text(completion.subtitle)
+          .scaledFont(size: 11)
+          .foregroundColor(OmiColors.textTertiary)
+          .fixedSize(horizontal: false, vertical: true)
+      }
+    }
+    .padding(10)
+    .frame(maxWidth: .infinity, alignment: .leading)
+    .background(
+      RoundedRectangle(cornerRadius: 10, style: .continuous)
+        .fill(OmiColors.backgroundTertiary)
+        .overlay(
+          RoundedRectangle(cornerRadius: 10, style: .continuous)
+            .stroke(OmiColors.success.opacity(0.22), lineWidth: 1))
+    )
   }
 
   private func manualText(for setup: MCPSetup) -> String {

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/AppsPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/AppsPage.swift
@@ -329,6 +329,12 @@ struct AppsPage: View {
             await connectorStatusStore.refresh()
             exportStatuses = await MemoryExportService.shared.allStatuses()
         }
+        .onChange(of: selectedExportDestination) { _, newValue in
+            guard newValue == nil else { return }
+            Task {
+                exportStatuses = await MemoryExportService.shared.allStatuses()
+            }
+        }
     }
 
     private var searchBar: some View {

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
@@ -238,6 +238,8 @@ struct DashboardPage: View {
     @AppStorage("dashboardWidgetsCollapsed") private var widgetsCollapsed = false
     @AppStorage("screenAnalysisEnabled") private var screenAnalysisEnabled = true
     @AppStorage("transcriptionEnabled") private var transcriptionEnabled = true
+    @AppStorage("systemAudioCaptureMode") private var systemAudioCaptureModeRaw =
+        AssistantSettings.SystemAudioCaptureMode.onlyDuringMeetings.rawValue
     @AppStorage("useLegacyHomeDesign") private var useLegacyHomeDesign = false
 
     private var selectedApp: OmiApp? {
@@ -259,6 +261,21 @@ struct DashboardPage: View {
 
     private var isCaptureLive: Bool {
         isCaptureMonitoring || ProactiveAssistantsPlugin.shared.isMonitoring
+    }
+
+    private var listeningCaptureMode: AssistantSettings.SystemAudioCaptureMode {
+        AssistantSettings.SystemAudioCaptureMode(rawValue: systemAudioCaptureModeRaw) ?? .onlyDuringMeetings
+    }
+
+    private var listeningModeTitle: String {
+        switch listeningCaptureMode {
+        case .always:
+            return "Always"
+        case .onlyDuringMeetings:
+            return appState.isAwaitingMeeting ? "Meetings only" : "In meeting"
+        case .never:
+            return "Mic only"
+        }
     }
 
     private static let omiDeviceHistoryDefaultsKey = "home-omi-device-account-history"
@@ -461,12 +478,15 @@ struct DashboardPage: View {
                     action: toggleCapture
                 )
 
-                HomeStatusButton(
+                HomeListeningStatusButton(
                     title: "Listening",
                     systemImage: appState.isTranscribing ? "waveform.circle.fill" : "mic.circle",
                     status: appState.isTranscribing ? .active : .inactive,
+                    modeTitle: listeningModeTitle,
+                    isMeetingsOnly: listeningCaptureMode == .onlyDuringMeetings,
                     isToggling: isTogglingListening,
-                    action: toggleListening
+                    action: toggleListening,
+                    modeAction: toggleListeningMode
                 )
 
                 HomeSettingsMenuButton(
@@ -740,6 +760,17 @@ struct DashboardPage: View {
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
             isTogglingListening = false
         }
+    }
+
+    private func toggleListeningMode() {
+        let nextMode: AssistantSettings.SystemAudioCaptureMode =
+            listeningCaptureMode == .onlyDuringMeetings ? .always : .onlyDuringMeetings
+        systemAudioCaptureModeRaw = nextMode.rawValue
+        AssistantSettings.shared.systemAudioCaptureMode = nextMode
+        AnalyticsManager.shared.settingToggled(
+            setting: "meetings_only_listening",
+            enabled: nextMode == .onlyDuringMeetings
+        )
     }
 
     private func toggleCapture() {
@@ -2770,6 +2801,110 @@ private struct HomeStatusButton: View {
             return status.indicator.opacity(isHovering ? 0.54 : 0.38)
         }
         return HomePalette.hairline.opacity(isHovering ? 0.8 : 0.58)
+    }
+}
+
+private struct HomeListeningStatusButton: View {
+    let title: String
+    let systemImage: String
+    let status: HomeStatusState
+    let modeTitle: String
+    let isMeetingsOnly: Bool
+    let isToggling: Bool
+    let action: () -> Void
+    let modeAction: () -> Void
+
+    @State private var isHoveringMain = false
+    @State private var isHoveringMode = false
+
+    var body: some View {
+        HStack(spacing: 0) {
+            Button(action: action) {
+                HStack(spacing: 8) {
+                    ZStack {
+                        if isToggling {
+                            ProgressView()
+                                .controlSize(.small)
+                                .scaleEffect(0.55)
+                        } else {
+                            Image(systemName: systemImage)
+                                .scaledFont(size: 13, weight: .semibold)
+                        }
+                    }
+                    .frame(width: 18, height: 18)
+
+                    VStack(alignment: .leading, spacing: 1) {
+                        Text(title)
+                            .scaledFont(size: 12, weight: .semibold)
+                            .lineLimit(1)
+
+                        Text(modeTitle)
+                            .scaledFont(size: 9, weight: .medium)
+                            .foregroundStyle(status.isActive ? HomePalette.secondary : HomePalette.muted)
+                            .lineLimit(1)
+                    }
+
+                    Circle()
+                        .fill(status.indicator)
+                        .frame(width: 6, height: 6)
+                }
+                .padding(.leading, 12)
+                .padding(.trailing, 9)
+                .padding(.vertical, 7)
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .disabled(isToggling)
+            .onHover { isHoveringMain = $0 }
+            .help("Listening: \(status.text), \(modeTitle)")
+            .accessibilityLabel("Listening \(status.text), \(modeTitle)")
+
+            Rectangle()
+                .fill(HomePalette.hairline.opacity(0.65))
+                .frame(width: 1, height: 22)
+
+            Button(action: modeAction) {
+                Image(systemName: isMeetingsOnly ? "person.2.fill" : "infinity")
+                    .scaledFont(size: 11, weight: .semibold)
+                    .foregroundStyle(isMeetingsOnly ? HomePalette.green : HomePalette.ink)
+                    .frame(width: 30, height: 32)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .onHover { isHoveringMode = $0 }
+            .help(isMeetingsOnly ? "Switch to always listening" : "Switch to meetings only")
+            .accessibilityLabel(isMeetingsOnly ? "Switch Listening to Always" : "Switch Listening to Meetings Only")
+        }
+        .foregroundStyle(status.isActive ? HomePalette.ink : (status.isBlocked ? status.indicator : HomePalette.muted))
+        .background(
+            Capsule(style: .continuous)
+                .fill(statusFill)
+        )
+        .overlay(
+            Capsule(style: .continuous)
+                .stroke(statusStroke, lineWidth: 1)
+        )
+        .contentShape(Capsule())
+    }
+
+    private var statusFill: Color {
+        if status.isActive {
+            return HomePalette.green.opacity(isHoveringMain || isHoveringMode ? 0.20 : 0.12)
+        }
+        if status.isBlocked {
+            return status.indicator.opacity(isHoveringMain || isHoveringMode ? 0.16 : 0.10)
+        }
+        return isHoveringMain || isHoveringMode ? HomePalette.tileHover : HomePalette.panel
+    }
+
+    private var statusStroke: Color {
+        if status.isActive {
+            return HomePalette.green.opacity(0.38)
+        }
+        if status.isBlocked {
+            return status.indicator.opacity(isHoveringMain || isHoveringMode ? 0.54 : 0.38)
+        }
+        return HomePalette.hairline.opacity(isHoveringMain || isHoveringMode ? 0.8 : 0.58)
     }
 }
 

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
@@ -3109,14 +3109,11 @@ private struct HomeStatusButton: View {
                 Text(title)
                     .scaledFont(size: 12, weight: .semibold)
                     .lineLimit(1)
-
-                Circle()
-                    .fill(status.indicator)
-                    .frame(width: 6, height: 6)
             }
             .foregroundStyle(status.isActive ? HomePalette.ink : (status.isBlocked ? status.indicator : HomePalette.muted))
             .padding(.horizontal, 12)
             .padding(.vertical, 8)
+            .frame(height: 34)
             .background(
                 Capsule(style: .continuous)
                     .fill(statusFill)
@@ -3190,18 +3187,14 @@ private struct HomeListeningStatusButton: View {
                             .lineLimit(1)
 
                         Text(modeTitle)
-                            .scaledFont(size: 9, weight: .medium)
+                            .scaledFont(size: 8, weight: .medium)
                             .foregroundStyle(status.isActive ? HomePalette.secondary : HomePalette.muted)
                             .lineLimit(1)
                     }
-
-                    Circle()
-                        .fill(status.indicator)
-                        .frame(width: 6, height: 6)
                 }
                 .padding(.leading, 12)
-                .padding(.trailing, 9)
-                .padding(.vertical, 7)
+                .padding(.trailing, 8)
+                .frame(height: 34)
                 .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
@@ -3212,13 +3205,13 @@ private struct HomeListeningStatusButton: View {
 
             Rectangle()
                 .fill(HomePalette.hairline.opacity(0.65))
-                .frame(width: 1, height: 22)
+                .frame(width: 1, height: 18)
 
             Button(action: modeAction) {
-                Image(systemName: isMeetingsOnly ? "person.2.fill" : "infinity")
+                Image(systemName: isMeetingsOnly ? "person.2.fill" : "person.fill")
                     .scaledFont(size: 11, weight: .semibold)
-                    .foregroundStyle(isMeetingsOnly ? HomePalette.green : HomePalette.ink)
-                    .frame(width: 30, height: 32)
+                    .foregroundStyle(modeIconColor)
+                    .frame(width: 30, height: 34)
                     .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
@@ -3236,6 +3229,11 @@ private struct HomeListeningStatusButton: View {
                 .stroke(statusStroke, lineWidth: 1)
         )
         .contentShape(Capsule())
+        .frame(height: 34)
+    }
+
+    private var modeIconColor: Color {
+        status.isActive ? HomePalette.green : HomePalette.muted
     }
 
     private var statusFill: Color {

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryExportDestinationSheet.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryExportDestinationSheet.swift
@@ -436,6 +436,10 @@ struct MemoryExportDestinationSheet: View {
   private let permissionRefreshTimer = Timer.publish(every: 1.0, on: .main, in: .common)
     .autoconnect()
 
+  private var currentStatus: MemoryExportStatus? {
+    statuses[destination]
+  }
+
   var body: some View {
     VStack(alignment: .leading, spacing: 18) {
       HStack(alignment: .top, spacing: 14) {
@@ -467,7 +471,7 @@ struct MemoryExportDestinationSheet: View {
         VStack(alignment: .leading, spacing: 18) {
           content
 
-          if let statusMessage = model.statusMessage {
+          if currentStatus?.hasConnection != true, let statusMessage = model.statusMessage {
             Text(statusMessage)
               .scaledFont(size: 12, weight: .medium)
               .foregroundColor(OmiColors.success)
@@ -492,16 +496,25 @@ struct MemoryExportDestinationSheet: View {
     }
     .onReceive(permissionRefreshTimer) { _ in
       refreshPermissionStateIfNeeded()
+      refreshConnectionStatusIfNeeded()
     }
     .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification))
     { _ in
       refreshPermissionStateIfNeeded()
+      refreshConnectionStatusIfNeeded()
     }
   }
 
   private func refreshPermissionStateIfNeeded() {
     guard MemoryExportExecutor.requiresAccessibilityPreflight(destination) else { return }
     permissionRefreshID += 1
+  }
+
+  private func refreshConnectionStatusIfNeeded() {
+    guard destination.supportsMCP || destination.supportsAgentSetup else { return }
+    Task {
+      statuses[destination] = await MemoryExportService.shared.status(for: destination)
+    }
   }
 
   @ViewBuilder
@@ -625,10 +638,10 @@ struct MemoryExportDestinationSheet: View {
           .foregroundColor(OmiColors.textPrimary)
         Text("MCP + CLI")
           .scaledFont(size: 9, weight: .bold)
-          .foregroundColor(OmiColors.purplePrimary)
+          .foregroundColor(OmiColors.info)
           .padding(.horizontal, 7)
           .padding(.vertical, 2)
-          .background(Capsule().fill(OmiColors.purplePrimary.opacity(0.15)))
+          .background(Capsule().fill(OmiColors.backgroundTertiary))
       }
       Text(
         "Copy one setup prompt for your agent. It connects Omi memories through MCP, turns on local Desktop access through the Omi CLI, and includes a short Omi guide the agent can keep."
@@ -643,7 +656,7 @@ struct MemoryExportDestinationSheet: View {
     HStack(alignment: .top, spacing: 8) {
       Image(systemName: "checkmark.circle.fill")
         .scaledFont(size: 12)
-        .foregroundColor(OmiColors.purplePrimary)
+        .foregroundColor(OmiColors.info)
         .padding(.top, 1)
       Text(text)
         .scaledFont(size: 12)
@@ -653,17 +666,15 @@ struct MemoryExportDestinationSheet: View {
   }
 
   private var executeButtonTitle: String {
+    let presentation = MemoryExportConnectionPresentation.make(
+      destination: destination,
+      status: currentStatus,
+      isRunning: model.isExecuting,
+      accessibilityPreflightMissing: MemoryExportExecutor.accessibilityPreflightMissing(
+        for: destination)
+    )
     _ = permissionRefreshID
-    switch destination.mcpExecuteKind {
-    case .localAutonomous:
-      return "Do it for me"
-    case .browserAutonomous:
-      return MemoryExportExecutor.accessibilityPreflightMissing(for: destination)
-        ? "Grant Accessibility"
-        : "Do it for me"
-    case .assisted:
-      return destination.assistedOverlayHint != nil ? "Open & guide me" : "Open & copy key"
-    }
+    return presentation.primaryActionTitle ?? ""
   }
 
   private var executeBlockSubtitle: String {
@@ -692,39 +703,77 @@ struct MemoryExportDestinationSheet: View {
   /// "Execute" — hands the whole setup to Omi to run as a task.
   private var executeBlock: some View {
     VStack(alignment: .leading, spacing: 8) {
-      HStack(spacing: 8) {
-        Image(systemName: "sparkles")
-          .scaledFont(size: 13, weight: .semibold)
-          .foregroundColor(OmiColors.purplePrimary)
-        Text("Let Omi do it")
-          .scaledFont(size: 15, weight: .semibold)
-          .foregroundColor(OmiColors.textPrimary)
-        Text("FASTEST")
-          .scaledFont(size: 9, weight: .bold)
-          .foregroundColor(OmiColors.purplePrimary)
-          .padding(.horizontal, 7)
-          .padding(.vertical, 2)
-          .background(Capsule().fill(OmiColors.purplePrimary.opacity(0.15)))
-      }
-      Text(executeBlockSubtitle)
-        .scaledFont(size: 12)
-        .foregroundColor(OmiColors.textTertiary)
-        .fixedSize(horizontal: false, vertical: true)
+      let presentation = MemoryExportConnectionPresentation.make(
+        destination: destination,
+        status: currentStatus,
+        isRunning: model.isExecuting,
+        accessibilityPreflightMissing: MemoryExportExecutor.accessibilityPreflightMissing(
+          for: destination)
+      )
+      if let completion = presentation.completion {
+        setupCompleteBlock(completion)
+      } else {
+        HStack(spacing: 8) {
+          Image(systemName: "sparkles")
+            .scaledFont(size: 13, weight: .semibold)
+            .foregroundColor(OmiColors.textSecondary)
+          Text("Let Omi do it")
+            .scaledFont(size: 15, weight: .semibold)
+            .foregroundColor(OmiColors.textPrimary)
+          Text("FASTEST")
+            .scaledFont(size: 9, weight: .bold)
+            .foregroundColor(OmiColors.textSecondary)
+            .padding(.horizontal, 7)
+            .padding(.vertical, 2)
+            .background(Capsule().fill(OmiColors.backgroundTertiary))
+        }
+        Text(executeBlockSubtitle)
+          .scaledFont(size: 12)
+          .foregroundColor(OmiColors.textTertiary)
+          .fixedSize(horizontal: false, vertical: true)
 
-      Button(model.isExecuting ? "Starting Omi…" : executeButtonTitle) {
-        Task {
-          await model.executeWithOmi(destination: destination)
-          statuses[destination] = await MemoryExportService.shared.status(for: destination)
-          // Assisted flow: the user pastes values by hand, so surface the
-          // field-by-field steps instead of leaving them collapsed.
-          if destination.mcpExecuteKind == .assisted, destination.assistedOverlayHint != nil {
-            showManualSetup = true
+        Button(presentation.primaryActionTitle ?? executeButtonTitle) {
+          Task {
+            await model.executeWithOmi(destination: destination)
+            statuses[destination] = await MemoryExportService.shared.status(for: destination)
+            // Assisted flow: the user pastes values by hand, so surface the
+            // field-by-field steps instead of leaving them collapsed.
+            if destination.mcpExecuteKind == .assisted, destination.assistedOverlayHint != nil {
+              showManualSetup = true
+            }
           }
         }
+        .buttonStyle(OnboardingCardButtonStyle(isPrimary: true))
+        .disabled(model.isExecuting)
       }
-      .buttonStyle(OnboardingCardButtonStyle(isPrimary: true))
-      .disabled(model.isExecuting)
     }
+  }
+
+  private func setupCompleteBlock(_ completion: MCPSetupCompletionSummary) -> some View {
+    HStack(alignment: .top, spacing: 10) {
+      Image(systemName: "checkmark.seal.fill")
+        .scaledFont(size: 16, weight: .semibold)
+        .foregroundColor(OmiColors.success)
+        .padding(.top, 1)
+      VStack(alignment: .leading, spacing: 4) {
+        Text(completion.title)
+          .scaledFont(size: 15, weight: .semibold)
+          .foregroundColor(OmiColors.textPrimary)
+        Text(completion.subtitle)
+          .scaledFont(size: 12)
+          .foregroundColor(OmiColors.textTertiary)
+          .fixedSize(horizontal: false, vertical: true)
+      }
+    }
+    .padding(12)
+    .frame(maxWidth: .infinity, alignment: .leading)
+    .background(
+      RoundedRectangle(cornerRadius: 12, style: .continuous)
+        .fill(OmiColors.backgroundSecondary)
+        .overlay(
+          RoundedRectangle(cornerRadius: 12, style: .continuous)
+            .stroke(OmiColors.success.opacity(0.22), lineWidth: 1))
+    )
   }
 
   /// Labeled header that makes the automatic (MCP) vs manual (pack) choice obvious.

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+General.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+General.swift
@@ -16,7 +16,7 @@ extension SettingsContentView {
 
           Image(systemName: "rectangle.dashed.badge.record")
             .scaledFont(size: 16)
-            .foregroundColor(OmiColors.purplePrimary)
+            .foregroundColor(OmiColors.info)
 
           VStack(alignment: .leading, spacing: 4) {
             Text("Screen Capture")
@@ -70,7 +70,7 @@ extension SettingsContentView {
 
           Image(systemName: "mic.fill")
             .scaledFont(size: 16)
-            .foregroundColor(OmiColors.purplePrimary)
+            .foregroundColor(OmiColors.info)
 
           VStack(alignment: .leading, spacing: 4) {
             Text("Audio Recording")
@@ -117,7 +117,7 @@ extension SettingsContentView {
             HStack(spacing: 16) {
               Image(systemName: "speaker.wave.2.fill")
                 .scaledFont(size: 16)
-                .foregroundColor(OmiColors.purplePrimary)
+                .foregroundColor(OmiColors.info)
 
               VStack(alignment: .leading, spacing: 4) {
                 Text("System Audio")
@@ -229,7 +229,7 @@ extension SettingsContentView {
                     RoundedRectangle(cornerRadius: 6)
                       .fill(
                         appState.isNotificationBannerDisabled
-                          ? OmiColors.warning : OmiColors.purplePrimary)
+                          ? OmiColors.warning : OmiColors.info)
                   )
               }
               .buttonStyle(.plain)
@@ -266,7 +266,7 @@ extension SettingsContentView {
           HStack(spacing: 16) {
             Image(systemName: "textformat.size")
               .scaledFont(size: 16, weight: .medium)
-              .foregroundColor(OmiColors.purplePrimary)
+              .foregroundColor(OmiColors.info)
               .frame(width: 12)
 
             VStack(alignment: .leading, spacing: 4) {
@@ -286,7 +286,7 @@ extension SettingsContentView {
                 fontScaleSettings.resetToDefault()
               }
               .scaledFont(size: 12, weight: .medium)
-              .foregroundColor(OmiColors.purplePrimary)
+              .foregroundColor(OmiColors.info)
               .buttonStyle(.plain)
             }
           }
@@ -297,7 +297,7 @@ extension SettingsContentView {
               .foregroundColor(OmiColors.textTertiary)
 
             Slider(value: $fontScaleSettings.scale, in: 0.5...2.0, step: 0.05)
-              .tint(OmiColors.purplePrimary)
+              .tint(OmiColors.info)
 
             Text("A")
               .scaledFont(size: 18, weight: .medium)

--- a/desktop/macos/Desktop/Sources/MemoryExportService.swift
+++ b/desktop/macos/Desktop/Sources/MemoryExportService.swift
@@ -340,6 +340,41 @@ enum MemoryExportDestination: String, CaseIterable, Identifiable, Sendable {
     }
   }
 
+  var mcpSetupCompletionSummary: MCPSetupCompletionSummary {
+    switch self {
+    case .codex:
+      return MCPSetupCompletionSummary(
+        title: "Setup complete",
+        subtitle: "Restart Codex to load Omi Memory."
+      )
+    case .claudeCode:
+      return MCPSetupCompletionSummary(
+        title: "Setup complete",
+        subtitle: "Restart Claude Code to load Omi Memory."
+      )
+    case .hermes:
+      return MCPSetupCompletionSummary(
+        title: "Setup complete",
+        subtitle: "Restart Hermes to load Omi Memory."
+      )
+    case .openclaw:
+      return MCPSetupCompletionSummary(
+        title: "Connected",
+        subtitle: "OpenClaw is ready to read Omi Memory."
+      )
+    case .chatgpt, .claude:
+      return MCPSetupCompletionSummary(
+        title: "Connected",
+        subtitle: "\(title) can read Omi Memory."
+      )
+    case .notion, .obsidian, .gemini, .agents:
+      return MCPSetupCompletionSummary(
+        title: "Setup complete",
+        subtitle: "\(title) is ready."
+      )
+    }
+  }
+
   private static func shellQuote(_ value: String) -> String {
     "'\(value.replacingOccurrences(of: "'", with: "'\\''"))'"
   }
@@ -583,6 +618,46 @@ struct MemoryExportStatus: Sendable {
   let detailText: String?
   let isConfigured: Bool
   let hasConnection: Bool
+}
+
+struct MCPSetupCompletionSummary: Equatable, Sendable {
+  let title: String
+  let subtitle: String
+}
+
+struct MemoryExportConnectionPresentation: Equatable {
+  let primaryActionTitle: String?
+  let completion: MCPSetupCompletionSummary?
+
+  static func make(
+    destination: MemoryExportDestination,
+    status: MemoryExportStatus?,
+    isRunning: Bool,
+    accessibilityPreflightMissing: Bool = false
+  ) -> MemoryExportConnectionPresentation {
+    if status?.hasConnection == true {
+      return MemoryExportConnectionPresentation(
+        primaryActionTitle: nil,
+        completion: destination.mcpSetupCompletionSummary
+      )
+    }
+
+    let title: String
+    if isRunning {
+      title = "Connecting…"
+    } else {
+      switch destination.mcpExecuteKind {
+      case .localAutonomous:
+        title = "Do it for me"
+      case .browserAutonomous:
+        title = accessibilityPreflightMissing ? "Grant Accessibility" : "Do it for me"
+      case .assisted:
+        title = destination.assistedOverlayHint != nil ? "Open & guide me" : "Open & copy key"
+      }
+    }
+
+    return MemoryExportConnectionPresentation(primaryActionTitle: title, completion: nil)
+  }
 }
 
 /// Rendered MCP connection instructions for a single client.

--- a/desktop/macos/Desktop/Tests/AgentPillLifecycleTests.swift
+++ b/desktop/macos/Desktop/Tests/AgentPillLifecycleTests.swift
@@ -4,6 +4,28 @@ import XCTest
 @testable import Omi_Computer
 
 final class AgentPillLifecycleTests: XCTestCase {
+  @MainActor
+  func testVoiceResponseWaitingDrivesGlowUntilPlaybackOrClear() {
+    let state = FloatingControlBarState()
+
+    XCTAssertFalse(state.isVoiceResponseGlowActive)
+
+    state.beginVoiceResponseWaiting()
+    XCTAssertTrue(state.isVoiceResponseWaiting)
+    XCTAssertFalse(state.isVoiceResponseActive)
+    XCTAssertTrue(state.isVoiceResponseGlowActive)
+
+    state.isVoiceResponseActive = true
+    XCTAssertFalse(state.isVoiceResponseWaiting)
+    XCTAssertTrue(state.isVoiceResponseActive)
+    XCTAssertTrue(state.isVoiceResponseGlowActive)
+
+    state.clearVoiceResponseState()
+    XCTAssertFalse(state.isVoiceResponseWaiting)
+    XCTAssertFalse(state.isVoiceResponseActive)
+    XCTAssertFalse(state.isVoiceResponseGlowActive)
+  }
+
   func testFloatingPillSpawnsCanonicalBackgroundAgentRun() throws {
     let source = try agentPillSource()
 
@@ -324,7 +346,7 @@ final class AgentPillLifecycleTests: XCTestCase {
     XCTAssertTrue(windowSource.contains("private static let askOmiSettleDelay: TimeInterval = 0.16"))
     XCTAssertTrue(windowSource.contains("let currentTopCenteredFrame = NSRect("))
     XCTAssertTrue(windowSource.contains("abs(frame.midX - targetFrame.midX) > 0.5"))
-    XCTAssertTrue(windowSource.contains("let keepVoiceResponseAlive = state.isVoiceResponseActive"))
+    XCTAssertTrue(windowSource.contains("let keepVoiceResponseAlive = state.isVoiceResponseGlowActive"))
     XCTAssertTrue(windowSource.contains("FloatingControlBarManager.shared.cancelChat(keepVoiceAlive: keepVoiceResponseAlive)"))
     XCTAssertTrue(windowSource.contains("static func notchAgentListHeight(agentCount: Int) -> CGFloat"))
     XCTAssertTrue(windowSource.contains("+ notchAgentListBottomMargin"))
@@ -455,6 +477,23 @@ final class AgentPillLifecycleTests: XCTestCase {
     XCTAssertTrue(viewSource.contains("message.text"))
     XCTAssertTrue(viewSource.contains("contentChangeToken: scrollContentToken"))
     XCTAssertTrue(viewSource.contains("state.reportContentHeight(height, for: .agent(pill.id))"))
+  }
+
+  func testFloatingSubagentWorkingStateUsesStreamingAssistantMessage() throws {
+    let agentSource = try agentPillSource()
+    let viewSource = try floatingControlBarViewSource()
+
+    XCTAssertTrue(agentSource.contains("Self.ensureStreamingAssistantMessage(for: pill)"))
+    XCTAssertTrue(agentSource.contains("private static func ensureStreamingAssistantMessage(for pill: AgentPill)"))
+    XCTAssertTrue(agentSource.contains("var streamingMessage = ChatMessage(text: \"\", sender: .ai)"))
+    XCTAssertTrue(agentSource.contains("streamingMessage.isStreaming = true"))
+    XCTAssertTrue(agentSource.contains("pill.conversationMessages.append(streamingMessage)"))
+    XCTAssertTrue(agentSource.contains("private static func clearStreamingAssistantMessage(for pill: AgentPill)"))
+    XCTAssertTrue(agentSource.contains("completedMessage.isStreaming = false"))
+    XCTAssertTrue(agentSource.contains("pill.conversationMessages.removeAll { $0.id == aiMessage.id }"))
+    XCTAssertTrue(agentSource.contains("pill.conversationMessages[index] = finalMessage"))
+    XCTAssertTrue(viewSource.contains("} else if trimmed.isEmpty && message.isStreaming {"))
+    XCTAssertTrue(viewSource.contains("TypingIndicator()"))
   }
 
   func testSharedChatMessagesOpenAndSendFollowLatest() throws {
@@ -599,8 +638,8 @@ final class AgentPillLifecycleTests: XCTestCase {
     // streaming reply, so barge-in must replace the session. Managed Gemini
     // tokens are single-use, so the replacement session remints before it
     // connects and holds early PTT audio during that remint gap. If the user
-    // releases before the replacement is ready, PushToTalk falls back to its
-    // buffered transcription path instead of dropping captured speech.
+    // releases before the replacement is ready, the commit is deferred onto the
+    // replacement session instead of dropping captured speech.
     XCTAssertTrue(sessionSource.contains("enum RealtimeHubBargeInStrategy"))
     XCTAssertTrue(sessionSource.contains("provider == .gemini ? .freshSession : .inSessionCancel"))
     XCTAssertTrue(hubSource.contains("private var sessionAuth: HubAuth?"))
@@ -614,15 +653,16 @@ final class AgentPillLifecycleTests: XCTestCase {
     XCTAssertTrue(hubSource.contains("barge-in replacement queued behind existing token mint"))
     XCTAssertTrue(hubSource.contains("finishBargeInReplacementAfterSessionStart(provider: provider)"))
     XCTAssertTrue(hubSource.contains("pendingBargeInReplacement?.audioBuffer.append(pcm16k)"))
-    XCTAssertTrue(hubSource.contains("barge-in replacement not ready at commit — falling back to buffered transcription"))
-    XCTAssertTrue(hubSource.contains("clearBargeInReplacementState()\n        responding = false\n        ensureWarm()\n        return .rejectedNoSession"))
+    XCTAssertTrue(hubSource.contains("barge-in replacement not ready at commit"))
+    XCTAssertTrue(hubSource.contains("pending.pendingCommit = true"))
+    XCTAssertTrue(hubSource.contains("return .deferredForReplacement"))
     XCTAssertTrue(hubSource.contains("return .rejectedNoSession"))
     XCTAssertTrue(hubSource.contains("failBargeInReplacement(provider: provider, reason: error.localizedDescription)"))
     XCTAssertTrue(hubSource.contains("if provider == .gemini, let speculativeScreenshot"))
     XCTAssertTrue(hubSource.contains("session?.sendVideoFrame(speculativeScreenshot, mime: \"image/jpeg\")"))
     XCTAssertTrue(hubSource.contains("responding = false\n    realtimePlaybackActive = false"))
     XCTAssertTrue(hubSource.contains("exitVoiceUI(clearResponseGlow: true)"))
-    XCTAssertTrue(hubSource.contains("} else {\n        responding = false\n        exitVoiceUI(clearResponseGlow: true)\n        return .rejectedNoSession\n      }"))
+    XCTAssertTrue(hubSource.contains("responding = false\n      exitVoiceUI(clearResponseGlow: true)\n      return .rejectedNoSession"))
     XCTAssertTrue(hubSource.contains("let providerResponseInFlight = responding"))
     XCTAssertTrue(hubSource.contains("private var turnGeneration: UInt64 = 0"))
     XCTAssertTrue(hubSource.contains("let screenshotTurnGeneration = turnGeneration"))
@@ -767,8 +807,8 @@ final class AgentPillLifecycleTests: XCTestCase {
     let source = try floatingControlBarWindowSource()
 
     // Legacy PTT collapse must use the glow-adjusted compact size when
-    // isVoiceResponseActive is still true.
-    XCTAssertTrue(source.contains("let compactSize: NSSize = state.isVoiceResponseActive"))
+    // either response playback or post-PTT waiting glow is still true.
+    XCTAssertTrue(source.contains("let compactSize: NSSize = state.isVoiceResponseGlowActive"))
     XCTAssertTrue(source.contains("responseGlowWindowSizeForCurrentScreen(forSurfaceSize: Self.minBarSize)"))
     XCTAssertTrue(source.contains("compactSize: compactSize"))
   }

--- a/desktop/macos/Desktop/Tests/DashboardCaptureStateTests.swift
+++ b/desktop/macos/Desktop/Tests/DashboardCaptureStateTests.swift
@@ -31,6 +31,18 @@ final class DashboardCaptureStateTests: XCTestCase {
         )
     }
 
+    func testListeningPillShowsAndTogglesCaptureMode() throws {
+        let source = try dashboardSource()
+
+        XCTAssertTrue(source.contains("@AppStorage(\"systemAudioCaptureMode\")"))
+        XCTAssertTrue(source.contains("private var listeningModeTitle: String"))
+        XCTAssertTrue(source.contains("return appState.isAwaitingMeeting ? \"Meetings only\" : \"In meeting\""))
+        XCTAssertTrue(source.contains("HomeListeningStatusButton("))
+        XCTAssertTrue(source.contains("modeAction: toggleListeningMode"))
+        XCTAssertTrue(source.contains("AssistantSettings.shared.systemAudioCaptureMode = nextMode"))
+        XCTAssertFalse(source.contains("OmiColors.purplePrimary"))
+    }
+
     private func dashboardSource() throws -> String {
         let testsURL = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
         let dashboardURL = testsURL

--- a/desktop/macos/Desktop/Tests/DashboardCaptureStateTests.swift
+++ b/desktop/macos/Desktop/Tests/DashboardCaptureStateTests.swift
@@ -40,6 +40,11 @@ final class DashboardCaptureStateTests: XCTestCase {
         XCTAssertTrue(source.contains("HomeListeningStatusButton("))
         XCTAssertTrue(source.contains("modeAction: toggleListeningMode"))
         XCTAssertTrue(source.contains("AssistantSettings.shared.systemAudioCaptureMode = nextMode"))
+        XCTAssertTrue(source.contains("Image(systemName: isMeetingsOnly ? \"person.2.fill\" : \"person.fill\")"))
+        XCTAssertTrue(source.contains("private var modeIconColor: Color"))
+        XCTAssertTrue(source.contains(".frame(height: 34)"))
+        XCTAssertFalse(source.contains("Image(systemName: isMeetingsOnly ? \"person.2.fill\" : \"infinity\")"))
+        XCTAssertFalse(source.contains("Circle()\n                    .fill(status.indicator)"))
         XCTAssertFalse(source.contains("OmiColors.purplePrimary"))
     }
 

--- a/desktop/macos/Desktop/Tests/MemoryExportStatusTests.swift
+++ b/desktop/macos/Desktop/Tests/MemoryExportStatusTests.swift
@@ -74,6 +74,46 @@ final class MemoryExportStatusTests: XCTestCase {
     XCTAssertFalse(chatGPTStatus.hasConnection)
   }
 
+  func testCodexSetupCompletionRefreshHidesPrimarySetupCTA() async throws {
+    UserDefaults.standard.set("test-key", forKey: "memoryExportMCPApiKey")
+
+    var statuses = await MemoryExportService.shared.allStatuses()
+    XCTAssertFalse(statuses[.codex]?.hasConnection == true)
+    XCTAssertEqual(
+      MemoryExportConnectionPresentation.make(
+        destination: .codex,
+        status: statuses[.codex],
+        isRunning: false
+      ).primaryActionTitle,
+      "Do it for me"
+    )
+
+    let codex = tempHome.appendingPathComponent(".codex", isDirectory: true)
+    try FileManager.default.createDirectory(at: codex, withIntermediateDirectories: true)
+    try """
+      [mcp_servers.omi-memory]
+      command = "npx"
+      args = ["-y", "mcp-remote", "https://api.omi.me/v1/mcp/sse", "--header", "Authorization: Bearer test-key"]
+      """.write(to: codex.appendingPathComponent("config.toml"), atomically: true, encoding: .utf8)
+
+    statuses = await MemoryExportService.shared.allStatuses()
+    let presentation = MemoryExportConnectionPresentation.make(
+      destination: .codex,
+      status: statuses[.codex],
+      isRunning: false
+    )
+
+    XCTAssertTrue(statuses[.codex]?.hasConnection == true)
+    XCTAssertNil(presentation.primaryActionTitle)
+    XCTAssertEqual(
+      presentation.completion,
+      MCPSetupCompletionSummary(
+        title: "Setup complete",
+        subtitle: "Restart Codex to load Omi Memory."
+      )
+    )
+  }
+
   func testCommentedCodexMCPConfigDoesNotMarkCodexConnected() async throws {
     UserDefaults.standard.set("test-key", forKey: "memoryExportMCPApiKey")
     let codex = tempHome.appendingPathComponent(".codex", isDirectory: true)

--- a/desktop/macos/Desktop/Tests/RealtimeHubSpawnAgentTests.swift
+++ b/desktop/macos/Desktop/Tests/RealtimeHubSpawnAgentTests.swift
@@ -79,6 +79,31 @@ final class RealtimeHubSpawnAgentTests: XCTestCase {
     XCTAssertTrue(source.contains("return expectedTurnEpoch == realtimeToolTurnEpoch && pendingRealtimeToolCallIds.contains(key)"))
   }
 
+  func testBargeInReplacementCommitIsDeferredInsteadOfRejected() throws {
+    let source = try realtimeHubControllerSource()
+
+    XCTAssertTrue(source.contains("case deferredForReplacement"))
+    XCTAssertTrue(source.contains("if var pending = pendingBargeInReplacement"))
+    XCTAssertTrue(source.contains("pending.pendingCommit = true"))
+    XCTAssertTrue(source.contains("pendingBargeInReplacement = pending"))
+    XCTAssertTrue(source.contains("barge-in replacement not ready at commit"))
+    XCTAssertTrue(source.contains("return .deferredForReplacement"))
+    XCTAssertFalse(
+      source.contains("barge-in replacement not ready at commit — falling back to buffered transcription"))
+  }
+
+  func testCompletedVoiceTurnContinuityIsRecordedBeforeAsyncCorrection() throws {
+    let source = try realtimeHubControllerSource()
+
+    XCTAssertTrue(source.contains("let provisionalHeard = heard"))
+    XCTAssertTrue(source.contains("let provisionalReply = reply"))
+    XCTAssertTrue(source.contains("userText: provisionalHeard"))
+    XCTAssertTrue(source.contains("assistantText: provisionalReply"))
+    XCTAssertTrue(source.contains("if usedLocal {"))
+    XCTAssertTrue(source.contains("replaceVoiceContinuityTurn("))
+    XCTAssertTrue(source.contains("recordedAt: voiceContinuityTurns[index].recordedAt"))
+  }
+
   func testSpawnAgentPreflightsDirectedProviderAvailability() throws {
     let source = try realtimeHubControllerSource()
 

--- a/desktop/macos/changelog/unreleased/20260704-codex-connection-complete.json
+++ b/desktop/macos/changelog/unreleased/20260704-codex-connection-complete.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed Codex connection cards to show setup complete and restart guidance after MCP setup finishes"
+}

--- a/desktop/macos/changelog/unreleased/20260704-ptt-rapid-followups.json
+++ b/desktop/macos/changelog/unreleased/20260704-ptt-rapid-followups.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed rapid push-to-talk follow-ups so they keep context and wait for realtime recovery instead of dropping the turn"
+}

--- a/desktop/macos/changelog/unreleased/20260704-subagent-typing-indicator.json
+++ b/desktop/macos/changelog/unreleased/20260704-subagent-typing-indicator.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed subagent chats sometimes missing the typing indicator while working"
+}

--- a/desktop/macos/changelog/unreleased/20260704-voice-listening-state.json
+++ b/desktop/macos/changelog/unreleased/20260704-voice-listening-state.json
@@ -1,0 +1,3 @@
+{
+  "change": "Improved desktop voice status so push-to-talk shows a waiting glow after release and the Listening pill shows and toggles meetings-only mode"
+}


### PR DESCRIPTION
## Summary
- Fix rapid desktop PTT follow-ups by deferring realtime barge-in commits until replacement sessions are ready and preserving local continuity context before async transcript correction
- Show the notch voice-response glow during the post-PTT waiting window and keep glow state cleanup centralized
- Show durable Codex/MCP setup completion state, refresh connector cards after setup, and remove the stale primary setup CTA
- Surface meetings-only vs always-listening mode in the Dashboard listening pill with a direct toggle
- Keep floating subagent chats showing a typing indicator while queued/starting/running/follow-up work is active

## Issues
Closes #9000
Closes #9001
Closes #9003
Closes #9004
Closes #9005
Closes #9006

## Verification
- Independent subagent review: no PR-blocking findings
- `git diff --check`
- `xcrun swift build -c debug --package-path Desktop`
- `xcrun swift test --package-path Desktop --filter 'MemoryExportStatusTests|RealtimeHubSpawnAgentTests|AgentPillLifecycleTests/testFloatingSubagentWorkingStateUsesStreamingAssistantMessage|FloatingControlBarStateTests|DashboardCaptureStateTests'`\n- `cd desktop/macos && ./scripts/agent-logic-harness.sh`\n- Pre-push fast checks passed, including desktop changelog validation and desktop Swift build\n- Local named-bundle launch verified with ad-hoc signing helper: `omi-9000-9006` launched, automation bridge responded, and screenshot captured at `/tmp/omi-9000-9006-main.png`\n\n## Notes\n- Local ad-hoc signing helpers were added outside the repo under `/Users/david/.codex/bin` and documented in `/Users/david/.codex/AGENTS.md`; nothing signing-related was committed.\n- Remaining risk: some regression coverage is source-string based, so it confirms wiring but not every realtime timing edge in live PTT.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9008?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

