### PR TITLE
Stop onboarding file-scan memory spam (desktop + backend)

### DIFF
--- a/backend/routers/memories.py
+++ b/backend/routers/memories.py
@@ -30,7 +30,11 @@ from utils.memory.canonical_memory_adapter import (
 )
 from utils.memory.memory_service import MemoryService, fetch_memory_dict
 from utils.memory.required_promotion import required_promotion_payload
-from utils.memory.import_write_guard import import_write_block_mode, import_write_violation
+from utils.memory.import_write_guard import (
+    import_write_block_mode,
+    import_write_violation,
+    is_per_file_local_import_tags,
+)
 from utils.memory.memory_api_contract import (
     MemoryApiExposure,
     memory_write_payload,
@@ -307,6 +311,14 @@ async def create_memory(
     manually_added = memory.category == MemoryCategory.manual
     memory_db = MemoryDB.from_memory(memory, uid, None, manually_added)
 
+    # Old desktop builds fan out one create per indexed local file during
+    # onboarding (up to 2800 path facts). Acknowledge without persisting:
+    # a 4xx would make those clients surface/retry a failure for traffic we
+    # simply do not want stored.
+    if is_per_file_local_import_tags(memory.tags):
+        logger.info("memory_import.per_file_item_dropped endpoint=/v3/memories uid=%s", uid)
+        return _legacy_memory_response(memory_db)
+
     # Build payload outside try so serialization bugs aren't misreported as
     # transient 503s — only the Firestore write should be retryable.
     payload = memory_db.model_dump()
@@ -387,13 +399,29 @@ async def create_memories_batch(
     if not request.memories:
         return BatchMemoriesResponse(memories=[], created_count=0)
 
+    # Drop per-file local-file import items (one memory per indexed file, up
+    # to 2800 per onboarding scan) regardless of block mode: they buried real
+    # memories for every user who ran the scan and old desktop builds in the
+    # wild still send them. Aggregate local_files facts pass through.
+    accepted_memories = [m for m in request.memories if not is_per_file_local_import_tags(m.tags)]
+    dropped_count = len(request.memories) - len(accepted_memories)
+    if dropped_count:
+        logger.info(
+            "memory_import.per_file_items_dropped endpoint=/v3/memories/batch uid=%s dropped=%d kept=%d",
+            uid,
+            dropped_count,
+            len(accepted_memories),
+        )
+    if not accepted_memories:
+        return BatchMemoriesResponse(memories=[], created_count=0)
+
     # Honor each item's category (defaults to `interesting` per the Memory
     # model). Desktop import/extraction paths send `system`/`interesting` so
     # they land under "About You"/"Insights"; only user-typed memories send
     # `manual`. Derive manually_added from the category instead of forcing it.
     memory_dbs: List[MemoryDB] = []
     has_public = False
-    for memory in request.memories:
+    for memory in accepted_memories:
         manually_added = memory.category == MemoryCategory.manual
         memory_db = MemoryDB.from_memory(memory, uid, None, manually_added)
         memory_dbs.append(memory_db)

--- a/backend/routers/memories.py
+++ b/backend/routers/memories.py
@@ -32,7 +32,7 @@ from utils.memory.memory_service import MemoryService, fetch_memory_dict
 from utils.memory.required_promotion import required_promotion_payload
 from utils.memory.import_write_guard import (
     import_write_block_mode,
-    import_write_violation,
+    import_write_violation_for_guard,
     is_per_file_local_import_tags,
 )
 from utils.memory.memory_api_contract import (
@@ -138,7 +138,11 @@ async def _guard_import_memory_write(request: Request, *, endpoint: str, uid: st
     for payload in payloads:
         if not isinstance(payload, dict):
             continue
-        violation = import_write_violation(payload)
+        # Per-file local-file items are exempt: the endpoints below
+        # acknowledge-and-drop them without persisting, and a 409 here
+        # (enforce mode) would fail an old desktop build's whole batch
+        # before that drop can happen.
+        violation = import_write_violation_for_guard(payload)
         if not violation:
             continue
         logger.warning(

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -340,6 +340,7 @@ pytest tests/unit/test_rate_limiting.py -v
 pytest tests/unit/test_rate_limit_json_failopen.py -v
 pytest tests/unit/test_memories_batch.py -v
 pytest tests/unit/test_memories_create.py -v
+pytest tests/unit/test_per_file_import_guard.py -v
 pytest tests/unit/test_memories_pagination_clamp.py -v
 pytest tests/unit/test_sync_v2.py -v
 pytest tests/unit/test_sync_file_paths_filename_none.py -v

--- a/backend/tests/unit/test_per_file_import_guard.py
+++ b/backend/tests/unit/test_per_file_import_guard.py
@@ -1,0 +1,46 @@
+"""
+Tests for the per-file local-file import guard.
+
+Regression goal: the desktop onboarding scan historically emitted one memory
+per indexed file (up to 2800 "The user's local projects include <path>"
+entries per scan). Those buried users' real memories and were bulk-purged in
+July 2026. `is_per_file_local_import_tags` is the server-side backstop that
+keeps clients released before the fix from recreating the spam, while letting
+the aggregate local_files facts (profile/project/technology) through.
+"""
+
+from utils.memory.import_write_guard import is_per_file_local_import_tags
+
+
+class TestIsPerFileLocalImportTags:
+    def test_per_file_folder_variants_are_dropped(self):
+        for folder in ("projects", "documents", "downloads"):
+            assert is_per_file_local_import_tags(["local_files", "onboarding", folder, "py"]) is True
+
+    def test_recent_file_variant_is_dropped(self):
+        assert is_per_file_local_import_tags(["local_files", "onboarding", "recent_file"]) is True
+
+    def test_aggregate_local_file_facts_pass(self):
+        for aggregate in ("profile", "project", "technology"):
+            assert is_per_file_local_import_tags(["local_files", "onboarding", aggregate]) is False
+
+    def test_requires_both_import_markers(self):
+        # "projects" alone (e.g. a conversation memory about the user's
+        # projects) must not be treated as a file-import item.
+        assert is_per_file_local_import_tags(["projects", "py"]) is False
+        assert is_per_file_local_import_tags(["local_files", "projects"]) is False
+        assert is_per_file_local_import_tags(["onboarding", "projects"]) is False
+
+    def test_other_import_sources_pass(self):
+        assert is_per_file_local_import_tags(["gmail", "onboarding", "profile"]) is False
+        assert is_per_file_local_import_tags(["calendar", "onboarding", "profile"]) is False
+
+    def test_normalization_of_case_and_separators(self):
+        assert is_per_file_local_import_tags(["Local_Files", "Onboarding", "Recent-File"]) is True
+        assert is_per_file_local_import_tags([" local_files ", "onboarding", "Projects", "PY"]) is True
+
+    def test_non_list_and_empty_inputs_pass(self):
+        assert is_per_file_local_import_tags(None) is False
+        assert is_per_file_local_import_tags("local_files") is False
+        assert is_per_file_local_import_tags([]) is False
+        assert is_per_file_local_import_tags([None, 42]) is False

--- a/backend/tests/unit/test_per_file_import_guard.py
+++ b/backend/tests/unit/test_per_file_import_guard.py
@@ -7,9 +7,45 @@ entries per scan). Those buried users' real memories and were bulk-purged in
 July 2026. `is_per_file_local_import_tags` is the server-side backstop that
 keeps clients released before the fix from recreating the spam, while letting
 the aggregate local_files facts (profile/project/technology) through.
+
+The backstop must hold in every MEMORY_IMPORT_WRITE_BLOCK_MODE: the import
+write guard consumes `import_write_violation_for_guard`, which exempts
+per-file items so enforce mode cannot 409 an old desktop build's batch before
+the endpoints acknowledge-and-drop those items. Endpoint wiring is asserted
+source-level (the memories router import chain needs production env vars —
+same pattern as test_memories_create.py).
 """
 
-from utils.memory.import_write_guard import is_per_file_local_import_tags
+import os
+import re
+
+from utils.memory.import_write_guard import (
+    import_write_block_mode,
+    import_write_violation,
+    import_write_violation_for_guard,
+    is_per_file_local_import_tags,
+)
+
+ROUTER_PATH = os.path.join(os.path.dirname(__file__), '..', '..', 'routers', 'memories.py')
+
+
+def _read_router() -> str:
+    with open(ROUTER_PATH, encoding='utf-8') as f:
+        return f.read()
+
+
+PER_FILE_PAYLOAD = {
+    "content": "The user's local projects include ~/projects/foo/main.py (py).",
+    "tags": ["local_files", "onboarding", "projects", "py"],
+    "source": "local_files",
+    "category": "system",
+}
+AGGREGATE_IMPORT_PAYLOAD = {
+    "content": "The user works on a local project named foo.",
+    "tags": ["local_files", "onboarding", "project"],
+    "source": "local_files",
+    "category": "system",
+}
 
 
 class TestIsPerFileLocalImportTags:
@@ -44,3 +80,64 @@ class TestIsPerFileLocalImportTags:
         assert is_per_file_local_import_tags("local_files") is False
         assert is_per_file_local_import_tags([]) is False
         assert is_per_file_local_import_tags([None, 42]) is False
+
+
+class TestGuardExemptionUnderEnforce:
+    """Per-file items must never reach the 409 path, in any block mode."""
+
+    def test_per_file_payload_is_exempt_from_guard(self):
+        # Would be a violation via source AND tags — but per-file items are
+        # acknowledged-and-dropped by the endpoints, never persisted, so the
+        # guard must not see them.
+        assert import_write_violation(PER_FILE_PAYLOAD) is not None
+        assert import_write_violation_for_guard(PER_FILE_PAYLOAD) is None
+
+    def test_aggregate_import_payload_still_hits_guard(self):
+        # Non-per-file import writes keep the existing guard semantics
+        # (logged today, 409 once enforce mode is enabled).
+        assert import_write_violation_for_guard(AGGREGATE_IMPORT_PAYLOAD) == import_write_violation(
+            AGGREGATE_IMPORT_PAYLOAD
+        )
+        assert import_write_violation_for_guard(AGGREGATE_IMPORT_PAYLOAD) is not None
+
+    def test_non_import_payload_unaffected(self):
+        payload = {"content": "GUARD-TEST: the user enjoys hiking.", "tags": [], "category": "interesting"}
+        assert import_write_violation_for_guard(payload) is None
+
+    def test_enforce_mode_env_is_honored(self, monkeypatch):
+        monkeypatch.setenv("MEMORY_IMPORT_WRITE_BLOCK_MODE", "enforce")
+        assert import_write_block_mode() == "enforce"
+        # Even in enforce mode the guard input for a per-file item is "no
+        # violation" — the mode can only 409 what the guard actually flags.
+        assert import_write_violation_for_guard(PER_FILE_PAYLOAD) is None
+
+
+class TestRouterWiring:
+    """Source-level assertions on routers/memories.py (its import chain needs
+    production env vars, so behavior is pinned the same way as
+    test_memories_create.py)."""
+
+    def test_guard_uses_exempting_violation_helper(self):
+        src = _read_router()
+        guard_body = src.split("async def _guard_import_memory_write", 1)[1].split("\nasync def", 1)[0]
+        assert "import_write_violation_for_guard(payload)" in guard_body
+        # The unexempted helper must not be called anywhere in the router —
+        # otherwise enforce mode could 409 per-file items on some path.
+        assert re.search(r"[^_]import_write_violation\(", src) is None
+
+    def test_single_create_acknowledges_and_drops_per_file(self):
+        src = _read_router()
+        create_body = src.split("async def create_memory(", 1)[1].split("\nasync def", 1)[0]
+        drop_idx = create_body.find("is_per_file_local_import_tags(memory.tags)")
+        assert drop_idx != -1
+        # The drop returns the ghost response before any persistence call.
+        persist_idx = create_body.find("create_memory,")
+        assert persist_idx == -1 or drop_idx < persist_idx
+        assert "_legacy_memory_response(memory_db)" in create_body[drop_idx:]
+
+    def test_batch_filters_per_file_before_building_writes(self):
+        src = _read_router()
+        batch_body = src.split("async def create_memories_batch(", 1)[1].split("\nasync def", 1)[0]
+        filter_idx = batch_body.find("is_per_file_local_import_tags(m.tags)")
+        build_idx = batch_body.find("for memory in accepted_memories")
+        assert filter_idx != -1 and build_idx != -1 and filter_idx < build_idx

--- a/backend/utils/memory/import_write_guard.py
+++ b/backend/utils/memory/import_write_guard.py
@@ -90,6 +90,19 @@ def import_write_violation(payload: Dict[str, Any]) -> Optional[Dict[str, Any]]:
     return None
 
 
+def import_write_violation_for_guard(payload: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    """`import_write_violation`, except per-file local-file items are exempt.
+
+    The memory endpoints acknowledge-and-drop per-file items without
+    persisting them; letting the guard see them would 409 an old desktop
+    build's whole onboarding batch in enforce mode before the drop can
+    happen, defeating the backstop.
+    """
+    if is_per_file_local_import_tags(payload.get("tags")):
+        return None
+    return import_write_violation(payload)
+
+
 def import_write_block_mode() -> str:
     mode = (os.getenv(IMPORT_WRITE_BLOCK_MODE_ENV) or "log").strip().lower()
     return mode if mode in {"off", "log", "enforce"} else "log"

--- a/backend/utils/memory/import_write_guard.py
+++ b/backend/utils/memory/import_write_guard.py
@@ -42,11 +42,35 @@ IMPORT_METADATA_KEYS = frozenset(
 )
 
 
+# Tags that mark one-memory-per-indexed-file items from the desktop local-file
+# onboarding scan: the folder tag the scanner attached (projects/documents/
+# downloads) or the per-file "recently modified" variant. Aggregate local_files
+# facts use profile/project/technology tags instead and are not matched.
+PER_FILE_LOCAL_IMPORT_TAGS = frozenset({"projects", "documents", "downloads", "recent_file"})
+
+
 def normalized_import_marker(value: Any) -> Optional[str]:
     if not isinstance(value, str):
         return None
     marker = "_".join(value.strip().lower().replace("-", "_").split())
     return marker or None
+
+
+def is_per_file_local_import_tags(tags: Any) -> bool:
+    """True for per-file local_files import items (one memory per indexed file).
+
+    These carry no durable signal — up to 2800 path facts per onboarding scan —
+    and historically buried users' real memories (bulk-purged server-side in
+    July 2026). They are dropped unconditionally, independent of
+    MEMORY_IMPORT_WRITE_BLOCK_MODE, so desktop clients released before the
+    scanner stopped emitting them cannot recreate the spam.
+    """
+    if not isinstance(tags, list):
+        return False
+    normalized = {normalized_import_marker(tag) for tag in tags} - {None}
+    if not {"local_files", "onboarding"} <= normalized:
+        return False
+    return bool(normalized & PER_FILE_LOCAL_IMPORT_TAGS)
 
 
 def import_write_violation(payload: Dict[str, Any]) -> Optional[Dict[str, Any]]:

--- a/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
+++ b/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
@@ -382,6 +382,22 @@ final class DesktopAutomationActionRegistry {
       return await harness.run(timeoutSeconds: timeout)
     }
 
+    // Run the post-scan local-file memory import exactly as onboarding does
+    // (indexed-files snapshot → aggregate drafts → import evidence service
+    // with legacy batch fallback). Lets agents verify the import pipeline
+    // without driving the onboarding UI or the cursor.
+    register(
+      name: "onboarding_local_file_import",
+      summary: "Run the post-scan local-file memory import from the indexed snapshot; returns saved count"
+    ) { _ in
+      let coordinator = OnboardingPagedIntroCoordinator()
+      await coordinator.refreshSnapshotIfAvailable()
+      return [
+        "saved": String(coordinator.localFileMemoriesSaved),
+        "file_count": String(coordinator.scanSnapshot?.fileCount ?? 0),
+      ]
+    }
+
     // Send a typed query through the real floating-bar AI path
     // (openAIInputWithQuery → routeQuery → sendAIQuery → ChatProvider → bridge).
     // Used to drive cache/latency benchmarks without a mic or the cursor.

--- a/desktop/macos/Desktop/Sources/OnboardingImportEvidenceService.swift
+++ b/desktop/macos/Desktop/Sources/OnboardingImportEvidenceService.swift
@@ -144,7 +144,10 @@ enum OnboardingImportEvidenceService {
 
   private static func isLegacyMemorySystemError(_ error: Error) -> Bool {
     guard case let APIError.httpError(statusCode, detail) = error else { return false }
-    return statusCode == 403 && detail == "memory_import_requires_canonical"
+    if statusCode == 403 && detail == "memory_import_requires_canonical" { return true }
+    // Deployments without the canonical import router (prod today) 404 this
+    // endpoint; without falling back the whole scan context is silently lost.
+    return statusCode == 404
   }
 
   private static func newImportRunId(sourceType: String) -> String {

--- a/desktop/macos/Desktop/Sources/OnboardingPagedIntroCoordinator.swift
+++ b/desktop/macos/Desktop/Sources/OnboardingPagedIntroCoordinator.swift
@@ -1394,70 +1394,12 @@ final class OnboardingPagedIntroCoordinator: ObservableObject {
       )
     }
 
-    for fileName in snapshot.recentFiles.prefix(8) {
-      drafts.append(
-        MemoryDraft(
-          content: "A recently modified local file is named \(fileName).",
-          tags: ["local_files", "onboarding", "recent_file"],
-          source: "local_files",
-          headline: fileName
-        )
-      )
-    }
-
-    if let dbQueue = await RewindDatabase.shared.getDatabaseQueue() {
-      do {
-        let projectDrafts = try await dbQueue.read { db -> [MemoryDraft] in
-          let sql = """
-            SELECT path, filename, fileExtension, folder
-            FROM indexed_files
-            WHERE folder IN ('Projects', 'Documents', 'Downloads')
-              AND filename NOT LIKE 'CleanShot %'
-              AND filename NOT LIKE '.DS_Store'
-              AND path NOT LIKE '%/node_modules/%'
-              AND path NOT LIKE '%/.git/%'
-              AND path NOT LIKE '%/.build/%'
-              AND path NOT LIKE '%/build/%'
-              AND path NOT LIKE '%/DerivedData/%'
-              AND path NOT LIKE '%/Pods/%'
-              AND (
-                fileExtension IN ('swift','dart','py','ts','tsx','js','jsx','md','mdx','json',
-                                  'yaml','yml','toml','sh','txt','html','css','scss','sql',
-                                  'go','rs','kt','java','cpp','c','h','hpp','ipynb','pdf')
-                OR fileExtension IS NULL
-              )
-            ORDER BY modifiedAt DESC
-            LIMIT 2800
-            """
-
-          let rows = try Row.fetchAll(db, sql: sql)
-          return rows.compactMap { row in
-            guard let path: String = row["path"], let filename: String = row["filename"] else {
-              return nil
-            }
-
-            let folder: String = row["folder"] ?? "Files"
-            let fileExtension: String = row["fileExtension"] ?? ""
-            let normalizedPath = Self.normalizedLocalFilePath(path)
-            let extensionSuffix = fileExtension.isEmpty ? "" : " (\(fileExtension))"
-
-            return MemoryDraft(
-              content:
-                "The user's local \(folder.lowercased()) include \(normalizedPath)\(extensionSuffix).",
-              tags: [
-                "local_files", "onboarding", folder.lowercased(), Self.sanitizedTag(fileExtension),
-              ],
-              source: "local_files",
-              headline: filename
-            )
-          }
-        }
-        drafts.append(contentsOf: projectDrafts)
-      } catch {
-        log(
-          "OnboardingPagedIntroCoordinator: Failed to build detailed local file memories: \(error)")
-      }
-    }
+    // Deliberately no per-file drafts here. An earlier version emitted one
+    // memory per indexed file (up to 2800 "The user's local projects include
+    // <path>" entries, plus per-file "recently modified" facts); those
+    // drowned out real memories for every user who ran the scan and were
+    // bulk-purged server-side. Only aggregate facts (count, project names,
+    // technologies) carry durable signal.
 
     var seen = Set<MemoryDraft>()
     return drafts.filter { seen.insert($0).inserted }
@@ -1471,11 +1413,6 @@ final class OnboardingPagedIntroCoordinator: ObservableObject {
       return "~/" + path.dropFirst(home.count + 1)
     }
     return path
-  }
-
-  nonisolated private static func sanitizedTag(_ tag: String) -> String {
-    let trimmed = tag.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-    return trimmed.isEmpty ? "unknown" : trimmed.replacingOccurrences(of: " ", with: "_")
   }
 
   private func heuristicGoalTitle(_ text: String) -> String {

--- a/desktop/macos/Desktop/Tests/APIClientMemoryBulkSafetyTests.swift
+++ b/desktop/macos/Desktop/Tests/APIClientMemoryBulkSafetyTests.swift
@@ -434,6 +434,46 @@ final class APIClientMemoryBulkSafetyTests: XCTestCase {
         XCTAssertEqual(legacyContents, [legacyMemory.content])
     }
 
+    func testOnboardingImportEvidenceFallsBackToLegacyBatchWhenEndpointMissing() async {
+        // Deployments without the canonical import router (prod today) 404
+        // /v3/memory-imports/batch; the scan context must still reach the
+        // legacy batch path instead of being silently dropped.
+        let item = ImportEvidenceBatchItem(
+            title: "Missing Endpoint",
+            snippet: "The user works on a local project named foo.",
+            content: "The user works on a local project named foo.",
+            metadata: ["import_kind": "local_file_profile"]
+        )
+        let legacyMemory = MemoryBatchItem(
+            content: "The user works on a local project named foo.",
+            tags: ["local_files", "onboarding", "project"],
+            headline: "foo",
+            source: "local_files"
+        )
+        let api = FakeImportEvidenceAPI(
+            outcomes: [
+                .failure(APIError.httpError(statusCode: 404, detail: "Not Found")),
+            ])
+        let legacyApi = FakeMemoryBatchAPI()
+
+        let result = await OnboardingImportEvidenceService.save(
+            [item],
+            sourceType: "local_files",
+            logPrefix: "test",
+            importRunId: "test-run-missing-endpoint",
+            sourceAccountHash: nil,
+            legacyMemories: [legacyMemory],
+            apiClient: api,
+            legacyApiClient: legacyApi,
+            sleep: { _ in }
+        )
+
+        XCTAssertEqual(result.saved, 1)
+        XCTAssertEqual(result.failed, 0)
+        let legacyCallCount = await legacyApi.callCount()
+        XCTAssertEqual(legacyCallCount, 1)
+    }
+
     func testOnboardingImportEvidenceDoesNotFallbackWhenCanonicalNotReady() async {
         let item = ImportEvidenceBatchItem(
             title: "Canonical Not Ready",

--- a/desktop/macos/changelog/unreleased/20260702-no-per-file-onboarding-memories.json
+++ b/desktop/macos/changelog/unreleased/20260702-no-per-file-onboarding-memories.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed onboarding file scan flooding your memories with one entry per local file — it now saves only a few aggregate facts about your projects and technologies"
+}


### PR DESCRIPTION
## Problem

The desktop onboarding file scan wrote **one memory per indexed local file** — up to 2,800 "The user's local projects include ~/path/file.py" entries per scan, plus per-file "recently modified" facts. With no dedup on the legacy `/v3/memories/batch` path, every re-onboarding re-wrote the whole scan.

Impact was severe: on the worst-hit account, 57% of all memory docs were this spam and it was 77% of the *visible* list, burying real memories. Across all users it was **~4.75M docs (48% of the entire memories database)**.

## Changes

**Desktop** (`OnboardingPagedIntroCoordinator.swift`)
- Stop emitting per-file / recently-modified memories. Keep only the aggregate facts (file count, project names, technologies) — ~18 items instead of thousands.

**Desktop** (`OnboardingImportEvidenceService.swift`)
- Fall back to the legacy memory batch path when `/v3/memory-imports/batch` returns **404** (prod has no canonical import router), instead of silently dropping the entire scan context.

**Desktop** (`DesktopAutomationBridge.swift`)
- Add an `onboarding_local_file_import` automation action so the import pipeline can be verified in-process (no cursor).

**Backend** (`import_write_guard.py`, `routers/memories.py`)
- Server-side backstop: drop per-file local-file import items on both `POST /v3/memories` and `/v3/memories/batch` (logged; ghost-200 on single create so old clients don't retry). Protects against **old desktop builds still in the wild**.
- `import_write_violation_for_guard` exempts per-file items so `MEMORY_IMPORT_WRITE_BLOCK_MODE=enforce` can't 409 an old client's batch before the endpoints acknowledge-and-drop it.
- Aggregate `local_files` facts (profile/project/technology) pass through unchanged.

## Verification

- **Backend:** 54 unit tests pass (incl. new `test_per_file_import_guard.py` covering the helper, enforce-mode exemption, and router wiring). Exercised the real endpoints on a local backend: batch of 4 (2 per-file + 1 aggregate + 1 plain) → 2 persisted, per-file dropped; single per-file create → ghost 200, not persisted.
- **Desktop:** built a named bundle against prod, ran the real onboarding scan of **97,156 files → 18 aggregate memories** (Firestore-confirmed, zero per-file). 404→legacy fallback exercised. 12/12 desktop tests pass.
- **Data cleanup (separate, already executed):** deleted ~4.77M existing per-file spam docs across 9,203 users (Firestore + Pinecone) with a managed export restore point; 0 per-file spam remain, aggregate facts kept.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9009?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

