### PR TITLE
Clarify pre-push async blocker output

### DIFF
--- a/backend/scripts/scan_async_blockers.py
+++ b/backend/scripts/scan_async_blockers.py
@@ -481,6 +481,46 @@ def print_report(results):
         print()
 
 
+def _finding_calls(finding):
+    if "calls" in finding:
+        return finding["calls"]
+    return (
+        finding.get("network_io", [])
+        + finding.get("file_io", [])
+        + finding.get("sleeps", [])
+        + finding.get("db_calls", [])
+        + finding.get("all_blocking", [])
+    )
+
+
+def print_selected_report(results, failures, fail_on, diff_base, full_report):
+    s = results["summary"]
+    scope_label = (
+        f"changed function/decorator ranges and import-changed files since {diff_base}"
+        if diff_base
+        else "all scanned functions"
+    )
+
+    print("=== FastAPI Async Blocker Gate ===")
+    print(f"Endpoints scanned: {s['total_def_endpoints']} def + {s['total_async_endpoints']} async def")
+    print(f"Fail-on policy: {', '.join(fail_on) if fail_on else '(none)'}")
+    print(f"Fail-on scope: {scope_label}")
+    print(f"Selected blocking findings: {len(failures)}")
+
+    if failures:
+        print()
+        print("--- Blocking findings selected for this push ---")
+        for category, finding in failures:
+            label = finding.get("endpoint") or finding.get("function") or "async def"
+            calls = ", ".join(f"{c['call']}:{c['line']}" for c in _finding_calls(finding))
+            detail = f" | {calls}" if calls else ""
+            print(f"  {category}: {finding['file']}:{finding['line']} | {label}{detail}")
+    elif not full_report:
+        total_known = sum(s[category] for category in FAIL_ON_CATEGORIES if category in s)
+        print(f"Known findings outside this push's fail scope: {total_known}")
+        print("Full audit suppressed; rerun with --full-report or PRE_PUSH_VERBOSE=1 for legacy findings.")
+
+
 def main():
     parser = argparse.ArgumentParser(description="Scan FastAPI routers for async blocking patterns")
     parser.add_argument(
@@ -505,8 +545,13 @@ def main():
         "--diff-base",
         help=(
             "Only fail findings whose function/decorator line range intersects lines changed since this git ref, "
-            "or findings in files with changed imports. The full report is still printed."
+            "or findings in files with changed imports."
         ),
+    )
+    parser.add_argument(
+        "--full-report",
+        action="store_true",
+        help="Print every finding from the full async audit, including legacy findings outside the fail scope.",
     )
     args = parser.parse_args()
     if args.dirs == ["backend/routers", "backend/utils"] and not os.path.isdir("backend/routers"):
@@ -526,18 +571,10 @@ def main():
         json.dump(results, sys.stdout, indent=2)
         print()
     else:
-        print_report(results)
-        scope_label = (
-            f"changed function/decorator ranges and import-changed files since {args.diff_base}"
-            if args.diff_base
-            else "all scanned functions"
-        )
-        print(f"Fail-on policy: {', '.join(fail_on) if fail_on else '(none)'}")
-        print(f"Fail-on scope: {scope_label}")
-        print(f"Selected blocking findings: {len(failures)}")
-        for category, finding in failures:
-            label = finding.get("endpoint") or finding.get("function") or "async def"
-            print(f"  {category}: {finding['file']}:{finding['line']} | {label}")
+        print_selected_report(results, failures, fail_on, args.diff_base, args.full_report)
+        if args.full_report:
+            print()
+            print_report(results)
 
     sys.exit(1 if failures else 0)
 

--- a/scripts/pre-push
+++ b/scripts/pre-push
@@ -22,6 +22,7 @@ CURRENT_BRANCH=$(git symbolic-ref --short -q HEAD || true)
 ZERO_SHA="0000000000000000000000000000000000000000"
 
 declare -a PUSH_UPDATES=()
+declare -a DIFF_SUMMARIES=()
 while read -r local_ref local_oid remote_ref remote_oid; do
   [ -n "${local_ref:-}" ] || continue
   [ "${local_oid:-$ZERO_SHA}" != "$ZERO_SHA" ] || continue
@@ -29,7 +30,7 @@ while read -r local_ref local_oid remote_ref remote_oid; do
 done
 
 if [ "${#PUSH_UPDATES[@]}" -gt 0 ]; then
-  echo "Running fast pre-push checks for ${#PUSH_UPDATES[@]} pushed ref(s)."
+  echo "Running fast pre-push checks for ${#PUSH_UPDATES[@]} pushed ref(s) against ${BASE_REMOTE_REF#refs/remotes/}."
 else
   echo "Running fast pre-push checks against ${BASE_REMOTE_REF#refs/remotes/} (merge-base ${BASE_REF:0:12})"
 fi
@@ -47,11 +48,15 @@ if [ "${#PUSH_UPDATES[@]}" -gt 0 ]; then
     else
       DIFF_BASE=$(git merge-base "$BASE_REMOTE_REF" "$local_oid")
     fi
+    changed_count=$(git diff --name-only --diff-filter=ACM "$DIFF_BASE" "$local_oid" | wc -l | tr -d ' ')
+    DIFF_SUMMARIES+=("${remote_ref:-$local_oid}: ${changed_count} changed file(s) since ${DIFF_BASE:0:12}")
     while IFS= read -r file; do
       [ -n "$file" ] && CHANGED_FILES+=("$file")
     done < <(git diff --name-only --diff-filter=ACM "$DIFF_BASE" "$local_oid")
   done
 else
+  changed_count=$(git diff --name-only --diff-filter=ACM "$BASE_REF" HEAD | wc -l | tr -d ' ')
+  DIFF_SUMMARIES+=("HEAD: ${changed_count} changed file(s) since ${BASE_REF:0:12}")
   while IFS= read -r file; do
     [ -n "$file" ] && CHANGED_FILES+=("$file")
   done < <(git diff --name-only --diff-filter=ACM "$BASE_REF" HEAD)
@@ -63,6 +68,15 @@ if [ "${#CHANGED_FILES[@]}" -gt 0 ]; then
     [ -n "$file" ] && UNIQUE_CHANGED_FILES+=("$file")
   done < <(printf '%s\n' "${CHANGED_FILES[@]}" | sort -u)
   CHANGED_FILES=("${UNIQUE_CHANGED_FILES[@]}")
+fi
+
+echo "Pre-push diff summary:"
+for summary in "${DIFF_SUMMARIES[@]}"; do
+  echo "  ${summary}"
+done
+echo "Unique changed files considered by hooks: ${#CHANGED_FILES[@]}"
+if [ "${PRE_PUSH_DEBUG:-}" = "1" ] && [ "${#CHANGED_FILES[@]}" -gt 0 ]; then
+  printf '  %s\n' "${CHANGED_FILES[@]}"
 fi
 
 CHANGED_FILES_LIST=$(mktemp "${TMPDIR:-/tmp}/omi-pre-push-changed-files.XXXXXX")
@@ -225,19 +239,27 @@ check_backend_runtime_env_if_needed() {
 }
 
 check_backend_async_blockers_if_needed() {
+  local -a scanner_args=()
+
   if [ "${PRE_PUSH_SKIP_BACKEND_ASYNC_BLOCKERS:-}" = "1" ]; then
     echo "Skipping backend async blocker scan because PRE_PUSH_SKIP_BACKEND_ASYNC_BLOCKERS=1."
     return
   fi
 
   if ! changed_matches 'backend/*.py' 'backend/**/*.py' '.github/workflows/lint.yml'; then
+    echo "Skipping backend async blocker scan; no backend Python files changed."
     return
+  fi
+
+  if [ "${PRE_PUSH_VERBOSE:-}" = "1" ]; then
+    scanner_args+=(--full-report)
   fi
 
   python3 backend/scripts/scan_async_blockers.py \
     --dirs backend/routers backend/utils \
     --diff-base "$BASE_REF" \
-    --fail-on high_network_io,async_helpers_with_blocking,time_sleep,mixed_await_sync_db,no_await_should_be_def
+    --fail-on high_network_io,async_helpers_with_blocking,time_sleep,mixed_await_sync_db,no_await_should_be_def \
+    "${scanner_args[@]}"
 }
 
 check_module_stub_pollution_if_needed() {
@@ -388,7 +410,7 @@ check_openapi_contract_if_needed() {
 
   (
     cd backend
-    python3 scripts/export_openapi.py --check ../docs/api-reference/openapi.json
+    scripts/openapi_runner.sh scripts/export_openapi.py --check ../docs/api-reference/openapi.json
   )
 }
 


### PR DESCRIPTION
## Summary
- Print pre-push diff base and changed-file summaries so agents can see exactly what the hook is checking.
- Make the async blocker scanner lead with selected blocking findings and suppress legacy findings by default.
- Run the OpenAPI contract check through the pinned openapi_runner.sh environment instead of the ambient Python environment.

## Verification
- python3 -m py_compile backend/scripts/scan_async_blockers.py
- black --check --line-length 120 --skip-string-normalization backend/scripts/scan_async_blockers.py
- python3 backend/scripts/scan_async_blockers.py --dirs backend/routers backend/utils --diff-base origin/main --fail-on high_network_io,async_helpers_with_blocking,time_sleep,mixed_await_sync_db,no_await_should_be_def
- backend/scripts/openapi_runner.sh scripts/export_openapi.py --help
- scripts/pre-push
- git push -u origin codex/pre-push-clearer-agent-output (pre-push hook passed)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9010?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

