### PR TITLE
fix(desktop): stop re-prompting Screen Recording permission on every launch

### DIFF
--- a/desktop/CHANGELOG.json
+++ b/desktop/CHANGELOG.json
@@ -1,6 +1,6 @@
 {
   "unreleased": [
-    "Fixed the macOS app popping up the Screen Recording permission dialog on every launch when permission hadn't been granted"
+    "Fixed the macOS app repeatedly requesting Screen Recording permission on launch when it has not been granted"
   ],
   "releases": [
     {

--- a/desktop/CHANGELOG.json
+++ b/desktop/CHANGELOG.json
@@ -1,7 +1,5 @@
 {
-  "unreleased": [
-    "Fixed the macOS app repeatedly requesting Screen Recording permission on launch when it has not been granted"
-  ],
+  "unreleased": [],
   "releases": [
     {
       "version": "0.11.423",

--- a/desktop/CHANGELOG.json
+++ b/desktop/CHANGELOG.json
@@ -1,5 +1,7 @@
 {
-  "unreleased": [],
+  "unreleased": [
+    "Fixed the macOS app popping up the Screen Recording permission dialog on every launch when permission hadn't been granted"
+  ],
   "releases": [
     {
       "version": "0.11.423",

--- a/desktop/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift
+++ b/desktop/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift
@@ -263,13 +263,15 @@ public class ProactiveAssistantsPlugin: NSObject {
             // Do NOT request the permission here. This method is invoked
             // automatically on launch, on API-key load, on app re-activation, and
             // after sleep/unlock (screen analysis is enabled by default), so
-            // requesting here popped the macOS Screen Recording dialog on every
-            // login when permission hadn't been granted. The permission is now
-            // surfaced only by explicit user-initiated enable flows (menu bar,
-            // Settings, Sidebar and Rewind toggles, and onboarding), each of which
-            // opens System Settings / requests permission before reaching this
-            // point. If the user grants access out-of-band, the retry loop below
-            // and the app-active/auto-restart paths pick it up without prompting.
+            // requesting here surfaced the macOS Screen Recording dialog on every
+            // login while permission was ungranted. The permission is now handled
+            // only by explicit user-initiated enable flows before they reach this
+            // point: the menu-bar and Settings toggles deep-link to System Settings
+            // via openScreenRecordingPreferences(), the Sidebar and Rewind toggles
+            // additionally call requestAllScreenCapturePermissions() to trigger the
+            // prompt, and onboarding uses its dedicated permission step. If the user
+            // grants access out-of-band, the retry loop below and the
+            // app-active/auto-restart paths pick it up without prompting.
             if retryCount < maxRetries {
                 let delay = retryDelays[retryCount]
                 log("Screen recording permission not yet granted, retrying in \(delay)s (attempt \(retryCount + 1)/\(maxRetries))")

--- a/desktop/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift
+++ b/desktop/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift
@@ -260,11 +260,16 @@ public class ProactiveAssistantsPlugin: NSObject {
         // Check screen recording permission (and update cache)
         refreshScreenRecordingPermission()
         guard hasScreenRecordingPermission else {
-            if retryCount == 0 {
-                // First attempt: request permissions and schedule retry
-                ScreenCaptureService.requestAllScreenCapturePermissions()
-            }
-
+            // Do NOT request the permission here. This method is invoked
+            // automatically on launch, on API-key load, on app re-activation, and
+            // after sleep/unlock (screen analysis is enabled by default), so
+            // requesting here popped the macOS Screen Recording dialog on every
+            // login when permission hadn't been granted. The permission is now
+            // surfaced only by explicit user-initiated enable flows (menu bar,
+            // Settings, Sidebar and Rewind toggles, and onboarding), each of which
+            // opens System Settings / requests permission before reaching this
+            // point. If the user grants access out-of-band, the retry loop below
+            // and the app-active/auto-restart paths pick it up without prompting.
             if retryCount < maxRetries {
                 let delay = retryDelays[retryCount]
                 log("Screen recording permission not yet granted, retrying in \(delay)s (attempt \(retryCount + 1)/\(maxRetries))")

--- a/desktop/macos/changelog/unreleased/20260704-screen-recording-permission-launch.json
+++ b/desktop/macos/changelog/unreleased/20260704-screen-recording-permission-launch.json
@@ -1,0 +1,3 @@
+{
+    "change": "Fixed the macOS app repeatedly requesting Screen Recording permission on launch when it has not been granted"
+}


### PR DESCRIPTION
## Summary

- Problem: the macOS desktop app pops the system **"wants to record your screen"** dialog on every launch (and on app re-activation / API-key load / wake-from-sleep) while Screen Recording permission is not granted. Screen analysis is enabled by default, so every automatic `startMonitoring()` attempt fired `CGRequestScreenCaptureAccess()` — an unsolicited permission prompt on every login until the user gives in.
- What changed: removed the automatic permission request from `ProactiveAssistantsPlugin.startMonitoring()`'s permission-missing branch. The dialog-free retry loop is retained, so monitoring still auto-starts once permission is granted out-of-band.
- What did NOT change (scope boundary): every **user-initiated** enable flow still surfaces the permission UI itself (menu-bar toggle, Settings toggle, Sidebar toggle, Rewind toggle, onboarding permission step). `SettingsSyncManager.applyRemoteSettings` overwriting `screenAnalysisEnabled` is a separate vector, intentionally untouched to keep this fix minimal.

## Linked Issue / Bounty

- N/A — independent contribution

## Root Cause (bug fixes only)

- Root cause: `screenAnalysisEnabled` defaults to `true`, so monitoring auto-starts from several automatic call sites (launch, API-key load, app re-activation, sleep/unlock). When Screen Recording permission was missing, `startMonitoring()` itself called `ScreenCaptureService.requestAllScreenCapturePermissions()` → `CGRequestScreenCaptureAccess()`, popping the system dialog from non-user-initiated paths.
- Why it wasn't caught before: users who grant permission during onboarding never see the path; it only manifests for users who decline or revoke permission, and each individual prompt looks like a legitimate one-off.

## How It Works

`startMonitoring()`'s permission-missing branch no longer requests the permission — it only schedules the existing retry loop (2s/4s/8s) and returns. All user-initiated enable paths already gate on permission **before** reaching `startMonitoring()` (menu-bar + Settings toggles deep-link to System Settings via `openScreenRecordingPreferences()`; Sidebar and Rewind toggles additionally call `requestAllScreenCapturePermissions()`; onboarding has a dedicated permission step), so the internal request only ever fired for automatic callers. If the user grants access out-of-band, the retry loop and the app-active/auto-restart handlers pick it up without prompting.

Note for maintainers: this branch was cut before the `desktop/` → `desktop/macos/` migration; git rename detection maps the change onto `desktop/macos/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift` and the merge against current `main` is clean (verified with `git merge-tree`). The changelog entry is a fragment under `desktop/macos/changelog/unreleased/` per the current convention.

## Change Type

- [x] Bug fix

## Scope

- [x] Desktop app (Swift/macOS)

## Security Impact

- New permissions or capabilities introduced? No — this removes an unsolicited permission request.
- Auth or token handling changed? No
- Data access scope changed (screen data, OCR, user data)? No
- New or changed network calls? No
- Plugin or tool execution surface changed? No

## Testing

- [x] Built locally — `xcrun swift build -c debug --package-path Desktop`, clean (macOS 26.5.1, arm64)
- [x] Manual verification: full permission matrix on macOS (see Human Verification)
- [x] Existing tests pass — `ScreenRecordingPermissionPolicyTests` 3/3, `ScreenCaptureWebPTests` 5/5, `CaptureScreenToolTests` 3/3. `OnboardingFlowTests` has 3 failures that are pre-existing on the branch base (reproduced identically on the same base without this diff — stale step-count expectations, unrelated to this change).
- [ ] New tests added — N/A: the removed call is an OS-level dialog side effect; the retained retry behavior is already covered by `ScreenRecordingPermissionPolicyTests`.

## Human Verification

Verified on a dedicated named bundle (`com.omi.omi-verify-perm`) installed via `./run.sh`, signed in, on macOS 26.5.1:

- Verified scenarios:
  1. **Launch with permission not granted** → no system dialog; log shows the dialog-free retry loop (`Screen recording permission not yet granted, retrying in 2.0s/4.0s/8.0s`) and no TCC screen-capture request is ever registered for the bundle.
  2. **Revoke (`tccutil reset ScreenCapture com.omi.omi-verify-perm`) → quit → relaunch** → still no dialog; after retries: `Screen recording permission not granted after 3 retries, giving up` and `Screen analysis failed to start: … — setting remains enabled for next launch`; `screenAnalysisEnabled` stays `true`.
  3. **User-initiated enable while unpermitted** (Settings/menu toggle) → System Settings opens at the Screen Recording pane (`Opened Screen Recording preferences via URL scheme` logged on each attempt) — user-initiated path unchanged.
  4. **Grant out-of-band in System Settings → relaunch** → `DesktopHomeView: Screen analysis started` immediately, capture active, no prompt.
- Edge cases checked: repeated relaunches while unpermitted (no prompt each time); permission granted between launches (auto-start without prompt).
- What was **not** verified: sleep/unlock re-activation path (same code path as app re-activation, which was exercised); Intel macs.

## Evidence

- [x] Log output (before/after)

```
# launch without permission — retry loop only, no request, no dialog
[16:23:38.468] Screen recording permission not yet granted, retrying in 2.0s (attempt 1/3)
[16:23:40.469] Screen recording permission not yet granted, retrying in 4.0s (attempt 2/3)
[16:23:44.471] Screen recording permission not yet granted, retrying in 8.0s (attempt 3/3)
[16:23:52.472] Screen recording permission not granted after 3 retries, giving up
[16:23:52.472] DesktopHomeView: Screen analysis failed to start: Screen recording permission not granted — setting remains enabled for next launch

# user-initiated toggle — permission UI still surfaces (unchanged path)
[17:08:33.212] Opened Screen Recording preferences via URL scheme

# after out-of-band grant — auto-start on next launch, no prompt
[16:18:08.952] DesktopHomeView: Screen analysis started
```

TCC state cross-check: no `kTCCServiceScreenCapture` request row is created for the bundle across launches (the request API is what registers it), confirming the app never invoked `CGRequestScreenCaptureAccess()` from automatic paths.

## Docs

- [x] N/A — no docs impact (changelog fragment added)

## Performance, Privacy, and Reliability

No performance impact. Privacy posture improves: the app no longer triggers an OS permission prompt without an explicit user action.

## Migration / Backward Compatibility

- Backward compatible? Yes
- Migration needed? No

## Risks and Mitigations

- Risk: a user who denied permission and never uses an explicit toggle might not discover how to enable screen capture.
  - Mitigation: onboarding has a dedicated permission step; the Settings/Sidebar/menu-bar/Rewind toggles all surface the permission UI; the Settings card shows "Screen recording permission required".
- Risk: monitoring not starting after an out-of-band grant.
  - Mitigation: retained retry loop + app-active/auto-restart handlers; verified scenario 4 above.

## AI Disclosure

- Tools used: Claude Code
- AI-assisted portions: fix implementation and this PR body
- How you verified correctness: built and ran the app locally on macOS 26.5.1 as a dedicated named bundle; exercised the full permission matrix (no-permission launch, revoke → relaunch, user-initiated enable, out-of-band grant) with app-log and TCC-state evidence captured for each step; ran the screen-capture/permission test suites.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9014?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

