### PR TITLE
desktop: show PTT/voice questions in chat instantly, before the reply

### DIFF
--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
@@ -3248,15 +3248,28 @@ class FloatingControlBarManager {
         mostRecentNotificationID = notification.id
     }
 
+    /// Show the user's spoken question in the main chat history the instant its
+    /// transcript is known — before the reply is generated — so a voice/PTT question
+    /// appears on the home-page chat immediately, the same as a typed message. Returns
+    /// the bubble's id; the caller keeps it for THIS turn and passes it back to
+    /// `recordVoiceTurn`/`recordVoiceAgentHandoff` for reconciliation. Nil if not set up.
+    func beginVoiceUserMessage(userText: String) -> String? {
+        historyChatProvider?.beginVoiceUserMessage(userText: userText)?.id
+    }
+
     /// Record a completed realtime-hub voice turn into the main chat history (+ backend
     /// sync) via the shared history provider — the same provider notifications use. The
     /// hub plays its own audio and never routes through the query path, so this is the
     /// only way voice turns reach chat history. No-op if the bar isn't set up yet.
-    func recordVoiceTurn(userText: String, assistantText: String) {
-        historyChatProvider?.recordVoiceTurn(userText: userText, assistantText: assistantText)
+    /// `earlyUserMessageId` reconciles this turn's early bubble (see beginVoiceUserMessage).
+    func recordVoiceTurn(userText: String, assistantText: String, earlyUserMessageId: String? = nil) {
+        historyChatProvider?.recordVoiceTurn(
+            userText: userText, assistantText: assistantText, earlyUserMessageId: earlyUserMessageId)
     }
 
-    func recordVoiceAgentHandoff(userText: String, agentTitle: String, agentBrief: String) {
+    func recordVoiceAgentHandoff(
+        userText: String, agentTitle: String, agentBrief: String, earlyUserMessageId: String? = nil
+    ) {
         let title = agentTitle.trimmingCharacters(in: .whitespacesAndNewlines)
         let brief = agentBrief.trimmingCharacters(in: .whitespacesAndNewlines)
         let assistantText = "Started background agent\(title.isEmpty ? "" : " \"\(title)\"")\(brief.isEmpty ? "." : " for: \(brief)")"
@@ -3264,7 +3277,8 @@ class FloatingControlBarManager {
             userText: userText,
             assistantText: assistantText,
             logLabel: "voice_agent_handoff",
-            messageSource: "realtime_voice"
+            messageSource: "realtime_voice",
+            earlyUserMessageId: earlyUserMessageId
         )
     }
 

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
@@ -157,6 +157,13 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate {
   /// Guards against recording the same turn to chat history twice (a delegate that
   /// fires turn-done more than once on reconnect/barge-in edges). Reset per turn.
   private var turnRecorded = false
+  /// Guards the one-time early append of the user's spoken question to chat history
+  /// (shown the instant the transcript is known, before the reply). Reset per turn.
+  private var earlyUserMessageShown = false
+  /// Chat id of THIS turn's early user bubble (from beginVoiceUserMessage). Captured
+  /// into the completion so recordVoiceTurn reconciles the right bubble even if the
+  /// async completion lands after the next turn has already begun. Reset per turn.
+  private var earlyUserMessageId: String?
 
   // Per-turn language identification (multi-language PTT).
   /// Local copy of this turn's mic audio (16 kHz s16le mono) for on-device language ID.
@@ -742,6 +749,8 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate {
     let screenshotTurnGeneration = turnGeneration
     suppressAssistantOutputForCurrentTurn = false
     turnRecorded = false
+    earlyUserMessageShown = false
+    earlyUserMessageId = nil
     turnEpoch += 1
     turnAudio16k.removeAll(keepingCapacity: true)
     earlyLIDTask = nil
@@ -815,7 +824,10 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate {
     }
     turnRecorded = true
     rememberVoiceContinuityTurn(userText: heard, assistantText: interruptedReply, interrupted: true)
-    FloatingControlBarManager.shared.recordVoiceTurn(userText: heard, assistantText: interruptedReply)
+    // Runs synchronously in beginTurn before earlyUserMessageId is reset, so this is
+    // still the interrupted turn's bubble id.
+    FloatingControlBarManager.shared.recordVoiceTurn(
+      userText: heard, assistantText: interruptedReply, earlyUserMessageId: earlyUserMessageId)
   }
 
   /// Mic chunk (16 kHz PCM16 mono) → resample to the provider's rate → session.
@@ -986,6 +998,9 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate {
     guard isCurrentSession(source) else { return }
     if isFinal {
       if !text.isEmpty { turnTranscript = text }
+      // OpenAI marks the input transcript final before/as the model starts replying —
+      // surface the question in chat now instead of waiting for the whole turn.
+      showUserQuestionEarly()
     } else {
       turnTranscript += text
     }
@@ -1003,6 +1018,42 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate {
     }
   }
 
+  /// Surface the user's spoken question on the main chat page the instant we can —
+  /// the same immediacy as a typed message — instead of only when the whole voice turn
+  /// (reply + audio playback) finishes. Fires at most once per turn.
+  ///
+  /// Trigger timing differs by provider: OpenAI emits a final input transcript
+  /// (`hubDidReceiveInputTranscript` isFinal), while Gemini streams input transcription
+  /// only as partials and never marks one final — so for Gemini this is driven by the
+  /// first reply chunk (`hubDidReceiveAudio` / `hubDidEmitText`), by which point
+  /// `turnTranscript` holds the full question and the model is already answering it.
+  /// The completed reply is appended later by `recordVoiceTurn`, which reconciles
+  /// against this bubble (correcting its text if the language guard swapped it).
+  private func showUserQuestionEarly() {
+    guard !earlyUserMessageShown else { return }
+    let heard = turnTranscript.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !heard.isEmpty else { return }
+    earlyUserMessageShown = true  // decided this turn, whether we show or skip
+
+    // Don't surface a likely language-misdetect early. When the user has picked voice
+    // languages and this provider transcript classifies as none of them (e.g. Gemini —
+    // which ignores the language hint — transcribing English as Japanese), skip the
+    // instant show. The completed turn runs the on-device language-ID correction
+    // (see hubDidFinishTurn) and appends the corrected text, so we show the right
+    // language a beat later instead of flashing a wrong-language bubble.
+    let candidates = AssistantSettings.shared.voiceBaseLanguages
+    if !candidates.isEmpty,
+      let lang = PTTLanguageIdentifier.dominantLanguage(of: heard, hints: []),
+      !candidates.contains(lang) {
+      log(
+        "RealtimeHub: skipping early show — transcript language \(lang) not in user languages "
+          + "\(candidates) (likely provider misdetect); corrected text will appear at turn end")
+      return
+    }
+
+    earlyUserMessageId = FloatingControlBarManager.shared.beginVoiceUserMessage(userText: heard)
+  }
+
   func hubDidReceiveAudio(_ pcm24k: Data, source: RealtimeHubSession) {
     guard isCurrentSession(source) else { return }
     guard !suppressAssistantOutputForCurrentTurn else { return }
@@ -1017,12 +1068,19 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate {
     realtimePlaybackActive = true
     realtimePlaybackEpoch = pcmPlayer.playbackEpoch
     responseGlowGate.markPlaybackActive()
+    // Reply audio started → the question is fully transcribed; surface it now (covers
+    // Gemini, which never marks its input transcript final).
+    showUserQuestionEarly()
   }
 
   func hubDidEmitText(_ text: String, isFinal: Bool, source: RealtimeHubSession) {
     guard isCurrentSession(source) else { return }
     guard !suppressAssistantOutputForCurrentTurn else { return }
-    if !text.isEmpty { assistantText += text }
+    if !text.isEmpty {
+      assistantText += text
+      // Reply text started → surface the question now (covers Gemini / audio-less turns).
+      showUserQuestionEarly()
+    }
     if isFinal {
       let reply = assistantText.trimmingCharacters(in: .whitespacesAndNewlines)
       // Fallback only: if the model produced text but no native audio this turn,
@@ -1522,11 +1580,17 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate {
         FloatingControlBarManager.shared.recordVoiceAgentHandoff(
           userText: heard,
           agentTitle: handoff.title,
-          agentBrief: handoff.brief)
+          agentBrief: handoff.brief,
+          earlyUserMessageId: earlyUserMessageId)
       } else {
       let candidates = AssistantSettings.shared.voiceBaseLanguages
       let fullTask = fullLIDTask
       let provider = providerTag
+      // Capture THIS turn's early bubble id NOW: the task below awaits language-ID (up to
+      // ~1.5s), by which point the next PTT turn may have reset/replaced the controller's
+      // earlyUserMessageId. Reconciling against the captured id keeps a late completion
+      // from rewriting a newer turn's bubble.
+      let capturedEarlyId = earlyUserMessageId
       Task { @MainActor [weak self] in
         var userText = heard
         var providerLang: String?
@@ -1566,7 +1630,8 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate {
         // Continuity memory + persistence use the CORRECTED text, so a swapped
         // bubble and the model's follow-up context stay consistent.
         self?.rememberVoiceContinuityTurn(userText: userText, assistantText: reply, interrupted: false)
-        FloatingControlBarManager.shared.recordVoiceTurn(userText: userText, assistantText: reply)
+        FloatingControlBarManager.shared.recordVoiceTurn(
+          userText: userText, assistantText: reply, earlyUserMessageId: capturedEarlyId)
         self?.lastTurnDiagnostics = [
           "provider": provider,
           "provider_transcript": heard,

--- a/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
@@ -3323,21 +3323,51 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
         return aiMessage
     }
 
+    /// Local ID of a voice/PTT user message shown optimistically the instant its
+    /// transcript is known — before the assistant reply exists — via
+    /// `beginVoiceUserMessage`. `recordCompletedTurn` reconciles the completed turn
+    /// against this bubble (updating its text if the transcript was corrected) instead
+    /// Show the user's spoken question on the main chat page the moment its transcript
+    /// is known, before the assistant reply is generated — so a voice/PTT question
+    /// appears instantly, matching how a typed message shows up immediately. Returns the
+    /// created message; the caller keeps its `id` for THIS turn and hands it back to
+    /// `recordCompletedTurn(earlyUserMessageId:)` so the completed turn reconciles against
+    /// its own bubble. Keyed per-turn (not a shared field) on purpose: voice completions
+    /// run from async tasks and can arrive out of order relative to the next turn's start,
+    /// so a shared id would let an old completion rewrite a newer turn's bubble.
+    /// UI-only: persistence happens once, at turn completion, with the final text.
+    @discardableResult
+    func beginVoiceUserMessage(userText: String) -> ChatMessage? {
+        let text = userText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !text.isEmpty else { return nil }
+        let message = ChatMessage(text: text, sender: .user)
+        messages.append(message)
+        log("ChatProvider: showing voice user message early (\(text.count) chars)")
+        return message
+    }
+
     /// Record a completed turn that did not stream through `sendMessage`.
     /// Appends both messages to the in-memory provider session immediately, then
     /// persists them sequentially in the background so later follow-ups retain context.
+    /// - Parameter earlyUserMessageId: id of the bubble `beginVoiceUserMessage` created
+    ///   for THIS turn (nil if none). Reconciled in place instead of appending a
+    ///   duplicate. Passed explicitly per turn so an out-of-order async completion can
+    ///   never touch a different turn's bubble.
     @discardableResult
     func recordCompletedTurn(
         userText: String,
         assistantText: String,
         logLabel: String = "completed",
-        messageSource: String = "desktop_chat"
+        messageSource: String = "desktop_chat",
+        earlyUserMessageId: String? = nil
     ) -> (
         user: ChatMessage?, assistant: ChatMessage?
     ) {
         let user = userText.trimmingCharacters(in: .whitespacesAndNewlines)
         let assistant = assistantText.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !user.isEmpty || !assistant.isEmpty else { return (nil, nil) }
+        guard !user.isEmpty || !assistant.isEmpty else {
+            return (nil, nil)
+        }
 
         let capturedSessionId = isInDefaultChat ? nil : currentSessionId
         let capturedAppId = overrideAppId ?? selectedAppId
@@ -3345,9 +3375,18 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
         var userMessage: ChatMessage?
         var aiMessage: ChatMessage?
         if !user.isEmpty {
-            let m = ChatMessage(text: user, sender: .user)
-            messages.append(m)
-            userMessage = m
+            if let earlyId = earlyUserMessageId,
+                let idx = messages.firstIndex(where: { $0.id == earlyId }) {
+                // This turn's early bubble (shown by beginVoiceUserMessage): reconcile its
+                // text (in case the final transcript was language-corrected) and reuse it —
+                // persisted once, below — instead of appending a duplicate.
+                if messages[idx].text != user { messages[idx].text = user }
+                userMessage = messages[idx]
+            } else {
+                let m = ChatMessage(text: user, sender: .user)
+                messages.append(m)
+                userMessage = m
+            }
         }
         if !assistant.isEmpty {
             let m = ChatMessage(text: assistant, sender: .ai)
@@ -3382,12 +3421,13 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
     /// normal query path, so without this the turn would never appear in chat history
     /// or sync to the backend. Empty sides are skipped (a tool-only turn with no
     /// spoken reply still records the user's request).
-    func recordVoiceTurn(userText: String, assistantText: String) {
+    func recordVoiceTurn(userText: String, assistantText: String, earlyUserMessageId: String? = nil) {
         recordCompletedTurn(
             userText: userText,
             assistantText: assistantText,
             logLabel: "voice",
-            messageSource: "realtime_voice"
+            messageSource: "realtime_voice",
+            earlyUserMessageId: earlyUserMessageId
         )
     }
 

--- a/desktop/macos/Desktop/Tests/DesktopCoordinatorServiceTests.swift
+++ b/desktop/macos/Desktop/Tests/DesktopCoordinatorServiceTests.swift
@@ -300,8 +300,15 @@ final class DesktopCoordinatorServiceTests: XCTestCase {
     let hubSource = try sourceFile("FloatingControlBar/RealtimeHubController.swift")
     let pillSource = try sourceFile("FloatingControlBar/AgentPill.swift")
 
-    XCTAssertTrue(chatSource.contains("func recordVoiceTurn(userText: String, assistantText: String)"))
-    XCTAssertTrue(hubSource.contains("FloatingControlBarManager.shared.recordVoiceTurn(userText: userText, assistantText: reply)"))
+    XCTAssertTrue(
+      chatSource.contains(
+        "func recordVoiceTurn(userText: String, assistantText: String, earlyUserMessageId: String? = nil)"
+      ))
+    // Completed turn is recorded via the manager with the (corrected) user text, the
+    // reply, and the early-bubble id captured for THIS turn (see instant-show feature).
+    XCTAssertTrue(hubSource.contains("FloatingControlBarManager.shared.recordVoiceTurn("))
+    XCTAssertTrue(
+      hubSource.contains("userText: userText, assistantText: reply, earlyUserMessageId: capturedEarlyId)"))
     XCTAssertTrue(hubSource.contains("escalateToHigherModel"))
     XCTAssertTrue(hubSource.contains("AgentDelegationResolver.shared.resolve"))
     XCTAssertTrue(hubSource.contains("AgentDelegationExecutor.shared.spawnResolvedDelegation"))
@@ -357,7 +364,10 @@ final class DesktopCoordinatorServiceTests: XCTestCase {
     let managerSource = try sourceFile("FloatingControlBar/FloatingControlBarWindow.swift")
     let hubSource = try sourceFile("FloatingControlBar/RealtimeHubController.swift")
 
-    XCTAssertTrue(managerSource.contains("recordVoiceAgentHandoff(userText: String, agentTitle: String, agentBrief: String)"))
+    XCTAssertTrue(managerSource.contains("func recordVoiceAgentHandoff("))
+    XCTAssertTrue(
+      managerSource.contains(
+        "userText: String, agentTitle: String, agentBrief: String, earlyUserMessageId: String? = nil"))
     XCTAssertTrue(managerSource.contains("Started background agent"))
     XCTAssertTrue(managerSource.contains("logLabel: \"voice_agent_handoff\""))
     XCTAssertTrue(hubSource.contains("FloatingControlBarManager.shared.recordVoiceAgentHandoff("))

--- a/desktop/macos/Desktop/Tests/PTTVoiceUserMessageEarlyTests.swift
+++ b/desktop/macos/Desktop/Tests/PTTVoiceUserMessageEarlyTests.swift
@@ -1,0 +1,115 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// Voice/PTT questions must appear in chat the instant they're transcribed — via
+/// `beginVoiceUserMessage` — and the completed turn must reconcile against THAT turn's
+/// bubble (by explicit id, never a shared global) so an out-of-order async completion
+/// can't rewrite a different turn's bubble. These exercise the synchronous message-array
+/// mutations of the real `ChatProvider`; the backend save fired by `recordCompletedTurn`
+/// is a fire-and-forget Task that runs after the assertions and is irrelevant here.
+@MainActor
+final class PTTVoiceUserMessageEarlyTests: XCTestCase {
+
+  private func userTexts(_ p: ChatProvider) -> [String] {
+    p.messages.filter { $0.sender == .user }.map(\.text)
+  }
+  private func aiTexts(_ p: ChatProvider) -> [String] {
+    p.messages.filter { $0.sender == .ai }.map(\.text)
+  }
+
+  /// The question bubble shows immediately, before any reply exists.
+  func testBeginShowsUserQuestionImmediately() {
+    let p = ChatProvider()
+    p.beginVoiceUserMessage(userText: "what is the capital of France")
+    XCTAssertEqual(userTexts(p), ["what is the capital of France"])
+    XCTAssertTrue(aiTexts(p).isEmpty, "reply must not exist yet")
+  }
+
+  /// Completing the turn appends the reply and reuses the early bubble (matched by id) —
+  /// exactly one user message, not two.
+  func testCompletionReusesEarlyBubbleNoDuplicate() {
+    let p = ChatProvider()
+    let early = p.beginVoiceUserMessage(userText: "hi there")
+    let (user, ai) = p.recordCompletedTurn(
+      userText: "hi there", assistantText: "hello!", earlyUserMessageId: early?.id)
+    XCTAssertEqual(userTexts(p), ["hi there"], "must not duplicate the user bubble")
+    XCTAssertEqual(aiTexts(p), ["hello!"])
+    XCTAssertEqual(p.messages.count, 2)
+    XCTAssertEqual(user?.id, early?.id, "reused the same bubble")
+    XCTAssertNotNil(ai)
+  }
+
+  /// If the final transcript was language-corrected after the early show, the existing
+  /// bubble's text is updated in place — still a single user message.
+  func testCompletionReconcilesCorrectedText() {
+    let p = ChatProvider()
+    let early = p.beginVoiceUserMessage(userText: "provider misdetect")  // early, uncorrected
+    p.recordCompletedTurn(
+      userText: "corrected question", assistantText: "reply", earlyUserMessageId: early?.id)
+    XCTAssertEqual(userTexts(p), ["corrected question"])
+    XCTAssertEqual(p.messages.filter { $0.sender == .user }.count, 1)
+  }
+
+  /// Without an early show (e.g. a provider that never fires the trigger), the
+  /// completed turn still appends both messages — unchanged legacy behavior.
+  func testCompletionWithoutEarlyShowAppendsBoth() {
+    let p = ChatProvider()
+    let (user, ai) = p.recordCompletedTurn(userText: "typed-like", assistantText: "answer")
+    XCTAssertEqual(userTexts(p), ["typed-like"])
+    XCTAssertEqual(aiTexts(p), ["answer"])
+    XCTAssertNotNil(user)
+    XCTAssertNotNil(ai)
+  }
+
+  /// An empty/whitespace transcript shows nothing (no blank bubble).
+  func testEmptyTranscriptShowsNothing() {
+    let p = ChatProvider()
+    XCTAssertNil(p.beginVoiceUserMessage(userText: "   "))
+    XCTAssertTrue(p.messages.isEmpty)
+  }
+
+  /// Two voice turns in a row each produce exactly one user bubble.
+  func testConsecutiveTurnsEachGetOwnBubble() {
+    let p = ChatProvider()
+    let e1 = p.beginVoiceUserMessage(userText: "first question")
+    p.recordCompletedTurn(
+      userText: "first question", assistantText: "first reply", earlyUserMessageId: e1?.id)
+    let e2 = p.beginVoiceUserMessage(userText: "second question")
+    p.recordCompletedTurn(
+      userText: "second question", assistantText: "second reply", earlyUserMessageId: e2?.id)
+    XCTAssertEqual(userTexts(p), ["first question", "second question"])
+    XCTAssertEqual(aiTexts(p), ["first reply", "second reply"])
+  }
+
+  /// Race guard: turn 2 begins before turn 1's (async) completion runs. Each completion
+  /// must reconcile ITS OWN bubble by id — a shared global id would let turn 1's late
+  /// completion overwrite turn 2's bubble and corrupt history.
+  func testInterleavedTurnsDoNotCorruptEachOther() {
+    let p = ChatProvider()
+    let e1 = p.beginVoiceUserMessage(userText: "Q1")   // turn 1 shows
+    let e2 = p.beginVoiceUserMessage(userText: "Q2")   // turn 2 shows before turn 1 completes
+    XCTAssertNotEqual(e1?.id, e2?.id)
+    // completions arrive (turn 1 then turn 2), each carrying its own captured id
+    p.recordCompletedTurn(userText: "Q1", assistantText: "R1", earlyUserMessageId: e1?.id)
+    p.recordCompletedTurn(userText: "Q2", assistantText: "R2", earlyUserMessageId: e2?.id)
+    XCTAssertEqual(userTexts(p), ["Q1", "Q2"], "each bubble kept its own text")
+    XCTAssertEqual(aiTexts(p), ["R1", "R2"])
+    XCTAssertEqual(p.messages.filter { $0.sender == .user }.count, 2, "no duplicate/lost bubble")
+  }
+
+  /// Same race but completions arrive OUT OF ORDER (turn 2 completes first). Still no
+  /// cross-turn corruption — the id, not arrival order, decides which bubble is reused.
+  func testOutOfOrderCompletionsReconcileCorrectBubble() {
+    let p = ChatProvider()
+    let e1 = p.beginVoiceUserMessage(userText: "Q1")
+    let e2 = p.beginVoiceUserMessage(userText: "Q2")
+    p.recordCompletedTurn(userText: "Q2", assistantText: "R2", earlyUserMessageId: e2?.id)
+    p.recordCompletedTurn(userText: "Q1", assistantText: "R1", earlyUserMessageId: e1?.id)
+    // Q1 and Q2 bubbles both retain their original text (neither overwrote the other).
+    let users = p.messages.filter { $0.sender == .user }
+    XCTAssertEqual(users.count, 2)
+    XCTAssertEqual(users.first(where: { $0.id == e1?.id })?.text, "Q1")
+    XCTAssertEqual(users.first(where: { $0.id == e2?.id })?.text, "Q2")
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260704-ptt-question-instant-chat.json
+++ b/desktop/macos/changelog/unreleased/20260704-ptt-question-instant-chat.json
@@ -1,0 +1,3 @@
+{
+  "change": "Voice and push-to-talk questions now appear in the chat instantly, as soon as they're transcribed, instead of only after the assistant finishes replying"
+}


### PR DESCRIPTION
## What
Voice/PTT questions now appear in the main chat page the instant they're transcribed — the same immediacy as a typed message — instead of only after the assistant finishes replying.

## Why
Typed messages append optimistically and show immediately; voice turns were recorded to chat only at turn end (`recordVoiceTurn` → `recordCompletedTurn`), appended together with the finished reply, so the question stayed invisible until the model answered.

## How
- **`ChatProvider.beginVoiceUserMessage`** — optimistically append the transcribed question the instant it's known (UI-only, no persist), returning the bubble.
- **`recordCompletedTurn(earlyUserMessageId:)`** — reconcile against THIS turn's bubble by explicit per-turn id (update text if the transcript was language-corrected) instead of appending a duplicate. Per-turn id, not a shared global: voice completions run from async tasks and can land out of order vs the next turn's start, so a shared id would corrupt a newer turn's bubble.
- **`RealtimeHubController`** — fire the early append at the earliest reliable per-provider signal (OpenAI's final input transcript; Gemini's first reply chunk, since it never marks its input transcript final), capturing the bubble id synchronously before the language-ID task. Skip the early show when the provider transcript classifies as a language the user didn't pick (likely a Gemini misdetect) — the completed turn's on-device correction shows the right text instead of flashing a wrong-language bubble.

## Tests
- 8 new unit tests on the real `ChatProvider` (instant-show, no-duplicate, corrected-text reconcile, unchanged legacy path, empty guard, consecutive turns, and two interleaved/out-of-order race cases).
- Updated two `DesktopCoordinatorService` contract-string tests to the new `recordVoiceTurn`/`recordVoiceAgentHandoff` signatures (more specific, not weakened).

## Verification
Exercised the real hub path via `ptt_test_turn` (real turn, PCM audio + forced provider transcript) with English selected: forced provider transcript `イヤホン を つけて` (ja) → saved chat bubble corrected to "What is the capital of France?" (`used_local_transcript: true`). The instant-show and the misdetect gate both confirmed live.

## Follow-up (separate)
The misdetect correction only runs when a voice language is *explicitly* selected. Users who see "English ✓" via the settings fallback but never saved it get no correction — a migration to persist that fallback is tracked as follow-up work in the languages workstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9016?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

