### PR TITLE
Reduce macOS desktop bundle size

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -2344,7 +2344,11 @@ workflows:
             mkdir -p "$APP_BUNDLE/Contents/Resources/agent"
             cp -Rf agent/dist        "$APP_BUNDLE/Contents/Resources/agent/"
             cp -f  agent/package.json "$APP_BUNDLE/Contents/Resources/agent/"
-            cp -Rf agent/node_modules "$APP_BUNDLE/Contents/Resources/agent/"
+            if [ ! -d ".harness/agent-runtime/agent-node_modules" ]; then
+              echo "ERROR: packaged agent dependencies missing"
+              exit 1
+            fi
+            cp -Rf .harness/agent-runtime/agent-node_modules "$APP_BUNDLE/Contents/Resources/agent/node_modules"
             mkdir -p "$APP_BUNDLE/Contents/Resources/agent/src/runtime"
             cp -f agent/src/runtime/control-tool-manifest.js "$APP_BUNDLE/Contents/Resources/agent/src/runtime/"
             cp -f agent/src/runtime/control-tool-manifest.ts "$APP_BUNDLE/Contents/Resources/agent/src/runtime/"
@@ -2363,7 +2367,11 @@ workflows:
             cp -f pi-mono-extension/index.ts    "$APP_BUNDLE/Contents/Resources/pi-mono-extension/"
             cp -f pi-mono-extension/package.json "$APP_BUNDLE/Contents/Resources/pi-mono-extension/"
             cp -f pi-mono-extension/package-lock.json "$APP_BUNDLE/Contents/Resources/pi-mono-extension/"
-            cp -Rf pi-mono-extension/node_modules "$APP_BUNDLE/Contents/Resources/pi-mono-extension/"
+            if [ ! -d ".harness/agent-runtime/pi-mono-extension-node_modules" ]; then
+              echo "ERROR: packaged pi-mono-extension dependencies missing"
+              exit 1
+            fi
+            cp -Rf .harness/agent-runtime/pi-mono-extension-node_modules "$APP_BUNDLE/Contents/Resources/pi-mono-extension/node_modules"
           else
             echo "ERROR: pi-mono-extension directory not found"
             exit 1

--- a/desktop/macos/Desktop/Sources/Rewind/Core/RewindStorage.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/RewindStorage.swift
@@ -1,5 +1,6 @@
 import AppKit
 import AVFoundation
+import CoreImage
 import Foundation
 import Sentry
 
@@ -234,43 +235,74 @@ actor RewindStorage {
             throw RewindError.storageError("AVFoundation found no video track")
         }
 
-        let frameRate = try await track.load(.nominalFrameRate)
-        guard frameRate > 0 else {
-            throw RewindError.storageError("AVFoundation found invalid frame rate: \(frameRate)")
-        }
-
-        let requestedTime = CMTime(
-            seconds: Double(frameOffset) / Double(frameRate),
-            preferredTimescale: 600
+        let reader = try AVAssetReader(asset: asset)
+        let output = AVAssetReaderTrackOutput(
+            track: track,
+            outputSettings: [
+                kCVPixelBufferPixelFormatTypeKey as String: kCVPixelFormatType_32BGRA
+            ]
         )
-        let duration = try await asset.load(.duration)
-        guard CMTimeCompare(requestedTime, duration) < 0 else {
-            throw RewindError.screenshotNotFound
+        output.alwaysCopiesSampleData = false
+
+        guard reader.canAdd(output) else {
+            throw RewindError.storageError("AVFoundation cannot add video track output")
+        }
+        reader.add(output)
+
+        guard reader.startReading() else {
+            let message = reader.error?.localizedDescription ?? "unknown error"
+            throw RewindError.storageError("AVFoundation reader failed to start: \(message)")
         }
 
-        let imageGenerator = AVAssetImageGenerator(asset: asset)
-        imageGenerator.requestedTimeToleranceBefore = .zero
-        imageGenerator.requestedTimeToleranceAfter = .zero
+        var sampleIndex = 0
+        while let sampleBuffer = output.copyNextSampleBuffer() {
+            defer { CMSampleBufferInvalidate(sampleBuffer) }
 
-        let (cgImage, actualTime) = try await imageGenerator.image(at: requestedTime)
-        guard CMTimeCompare(actualTime, requestedTime) == 0 else {
-            throw RewindError.screenshotNotFound
+            guard sampleIndex == frameOffset else {
+                sampleIndex += 1
+                continue
+            }
+
+            guard let pixelBuffer = CMSampleBufferGetImageBuffer(sampleBuffer) else {
+                reader.cancelReading()
+                throw RewindError.storageError("AVFoundation sample had no image buffer")
+            }
+
+            let ciImage = CIImage(cvPixelBuffer: pixelBuffer)
+            let context = CIContext(options: [.useSoftwareRenderer: false])
+            let rect = CGRect(
+                x: 0,
+                y: 0,
+                width: CVPixelBufferGetWidth(pixelBuffer),
+                height: CVPixelBufferGetHeight(pixelBuffer)
+            )
+            guard let cgImage = context.createCGImage(ciImage, from: rect) else {
+                reader.cancelReading()
+                throw RewindError.storageError("AVFoundation failed to render decoded frame")
+            }
+
+            let image = NSImage(cgImage: cgImage, size: NSSize(width: cgImage.width, height: cgImage.height))
+
+            let breadcrumb = Breadcrumb(level: .info, category: "frame_extraction")
+            breadcrumb.message = "Extracted frame from video"
+            breadcrumb.data = [
+                "video_path": videoPath,
+                "frame_offset": frameOffset,
+                "image_width": cgImage.width,
+                "image_height": cgImage.height,
+                "decoder": "AVAssetReader"
+            ]
+            SentrySDK.addBreadcrumb(breadcrumb)
+
+            return image
         }
 
-        let image = NSImage(cgImage: cgImage, size: NSSize(width: cgImage.width, height: cgImage.height))
+        if reader.status == .failed {
+            let message = reader.error?.localizedDescription ?? "unknown error"
+            throw RewindError.storageError("AVFoundation reader failed: \(message)")
+        }
 
-        let breadcrumb = Breadcrumb(level: .info, category: "frame_extraction")
-        breadcrumb.message = "Extracted frame from video"
-        breadcrumb.data = [
-            "video_path": videoPath,
-            "frame_offset": frameOffset,
-            "image_width": cgImage.width,
-            "image_height": cgImage.height,
-            "decoder": "AVAssetImageGenerator"
-        ]
-        SentrySDK.addBreadcrumb(breadcrumb)
-
-        return image
+        throw RewindError.screenshotNotFound
     }
 
     /// Extract a frame from video using ffmpeg

--- a/desktop/macos/Desktop/Sources/Rewind/Core/RewindStorage.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/RewindStorage.swift
@@ -14,7 +14,7 @@ actor RewindStorage {
     // Frame extraction cache
     private var frameCache = NSCache<NSString, NSImage>()
 
-    // Track corrupted video chunks to avoid repeated FFmpeg calls
+    // Track corrupted video chunks to avoid repeated frame extraction attempts
     private var corruptedChunks = Set<String>()
 
     // MARK: - Initialization
@@ -141,7 +141,7 @@ actor RewindStorage {
 
     // MARK: - Video Frame Loading
 
-    /// Load a frame from a video chunk using ffmpeg (works with fragmented MP4)
+    /// Load a frame from a video chunk.
     func loadVideoFrame(videoPath: String, frameOffset: Int) async throws -> NSImage {
         guard let videosDirectory = videosDirectory else {
             throw RewindError.storageError("Videos directory not initialized")
@@ -164,9 +164,8 @@ actor RewindStorage {
             throw RewindError.screenshotNotFound
         }
 
-        // Use ffmpeg to extract frame (works with fragmented MP4)
         do {
-            let image = try await extractFrameWithFFmpeg(from: fullPath.path, frameOffset: frameOffset)
+            let image = try await extractFrame(from: fullPath.path, frameOffset: frameOffset)
 
             // Cache for reuse (estimate ~4MB per frame for cost)
             frameCache.setObject(image, forKey: cacheKey, cost: 4 * 1024 * 1024)
@@ -179,7 +178,7 @@ actor RewindStorage {
             }
             // Check error message for corruption indicators
             if case .storageError(let message) = error,
-               message.contains("moov atom not found") || message.contains("Invalid data found") {
+               isUnreadableVideoChunkError(message) {
                 // Don't mark the active chunk as corrupted — it's still being written
                 let activeChunk = await VideoChunkEncoder.shared.currentChunkPath
                 if videoPath == activeChunk {
@@ -192,6 +191,86 @@ actor RewindStorage {
             }
             throw error
         }
+    }
+
+    private func extractFrame(from fullPath: String, frameOffset: Int) async throws -> NSImage {
+        do {
+            return try await extractFrameWithAVFoundation(from: fullPath, frameOffset: frameOffset)
+        } catch let nativeError as RewindError {
+            if case .screenshotNotFound = nativeError {
+                throw nativeError
+            }
+
+            do {
+                return try await extractFrameWithFFmpeg(from: fullPath, frameOffset: frameOffset)
+            } catch {
+                if isFFmpegUnavailable(error) {
+                    throw nativeError
+                }
+                throw error
+            }
+        } catch {
+            let nativeError = error
+            do {
+                return try await extractFrameWithFFmpeg(from: fullPath, frameOffset: frameOffset)
+            } catch {
+                if isFFmpegUnavailable(error) {
+                    throw RewindError.storageError("AVFoundation failed: \(nativeError.localizedDescription)")
+                }
+                throw error
+            }
+        }
+    }
+
+    /// Extract a frame from finalized AVAssetWriter MP4 chunks using the system decoder.
+    private func extractFrameWithAVFoundation(from videoPath: String, frameOffset: Int) async throws -> NSImage {
+        guard frameOffset >= 0 else {
+            throw RewindError.screenshotNotFound
+        }
+
+        let asset = AVURLAsset(url: URL(fileURLWithPath: videoPath))
+        let tracks = try await asset.loadTracks(withMediaType: .video)
+        guard let track = tracks.first else {
+            throw RewindError.storageError("AVFoundation found no video track")
+        }
+
+        let frameRate = try await track.load(.nominalFrameRate)
+        guard frameRate > 0 else {
+            throw RewindError.storageError("AVFoundation found invalid frame rate: \(frameRate)")
+        }
+
+        let requestedTime = CMTime(
+            seconds: Double(frameOffset) / Double(frameRate),
+            preferredTimescale: 600
+        )
+        let duration = try await asset.load(.duration)
+        guard CMTimeCompare(requestedTime, duration) < 0 else {
+            throw RewindError.screenshotNotFound
+        }
+
+        let imageGenerator = AVAssetImageGenerator(asset: asset)
+        imageGenerator.requestedTimeToleranceBefore = .zero
+        imageGenerator.requestedTimeToleranceAfter = .zero
+
+        let (cgImage, actualTime) = try await imageGenerator.image(at: requestedTime)
+        guard CMTimeCompare(actualTime, requestedTime) == 0 else {
+            throw RewindError.screenshotNotFound
+        }
+
+        let image = NSImage(cgImage: cgImage, size: NSSize(width: cgImage.width, height: cgImage.height))
+
+        let breadcrumb = Breadcrumb(level: .info, category: "frame_extraction")
+        breadcrumb.message = "Extracted frame from video"
+        breadcrumb.data = [
+            "video_path": videoPath,
+            "frame_offset": frameOffset,
+            "image_width": cgImage.width,
+            "image_height": cgImage.height,
+            "decoder": "AVAssetImageGenerator"
+        ]
+        SentrySDK.addBreadcrumb(breadcrumb)
+
+        return image
     }
 
     /// Extract a frame from video using ffmpeg
@@ -274,16 +353,45 @@ actor RewindStorage {
         return image
     }
 
+    private func isFFmpegUnavailable(_ error: Error) -> Bool {
+        guard case RewindError.storageError(let message) = error else {
+            return false
+        }
+
+        return message.contains("Failed to run ffmpeg")
+    }
+
+    private func isUnreadableVideoChunkError(_ message: String) -> Bool {
+        message.contains("moov atom not found")
+            || message.contains("Invalid data found")
+            || message.contains("AVFoundation failed")
+            || message.contains("Cannot Open")
+            || message.contains("media may be damaged")
+    }
+
     /// Find ffmpeg executable path
     private func findFFmpegPath() -> String {
         // Bundled ffmpeg first for users without Homebrew
-        // Use Bundle.resourceBundle for SPM resources (they're in a nested bundle, not main bundle)
+        // SwiftPM resources are in a nested bundle, but avoid Bundle.resourceBundle
+        // here because that accessor fatal-errors in test contexts with no app bundle.
+        let bundleName = "Omi Computer_Omi Computer.bundle"
+        let resourceBundlePath = Bundle.main.bundleURL
+            .appendingPathComponent("Contents/Resources")
+            .appendingPathComponent(bundleName)
+            .appendingPathComponent("ffmpeg")
+            .path
+        let developmentBundlePath = Bundle.main.bundleURL
+            .appendingPathComponent(bundleName)
+            .appendingPathComponent("ffmpeg")
+            .path
+
         let possiblePaths = [
-            Bundle.resourceBundle.path(forResource: "ffmpeg", ofType: nil),
+            resourceBundlePath,
+            developmentBundlePath,
             "/opt/homebrew/bin/ffmpeg",
             "/usr/local/bin/ffmpeg",
             "/usr/bin/ffmpeg",
-        ].compactMap { $0 }
+        ]
 
         for path in possiblePaths {
             if FileManager.default.fileExists(atPath: path) {

--- a/desktop/macos/Desktop/Tests/RewindStorageVideoFrameExtractionTests.swift
+++ b/desktop/macos/Desktop/Tests/RewindStorageVideoFrameExtractionTests.swift
@@ -44,6 +44,19 @@ final class RewindStorageVideoFrameExtractionTests: XCTestCase {
     XCTAssertGreaterThan(center.green, center.blue)
   }
 
+  func testLoadVideoFrameUsesSampleOrdinalForLowCadenceChunks() async throws {
+    let relativePath = "2026-07-04/chunk_low_cadence_frame_selection.mp4"
+    let fullPath = try await createChunk(relativePath: relativePath, colors: [.red, .green, .blue], frameRate: 1.0 / 3.0)
+
+    XCTAssertTrue(FileManager.default.fileExists(atPath: fullPath.path), "precondition: MP4 chunk written")
+
+    let frame = try await RewindStorage.shared.loadVideoFrame(videoPath: relativePath, frameOffset: 1)
+    let center = try XCTUnwrap(centerPixel(in: frame))
+
+    XCTAssertGreaterThan(center.green, center.red)
+    XCTAssertGreaterThan(center.green, center.blue)
+  }
+
   func testLoadVideoFrameReturnsNotFoundWhenFrameOffsetIsPastEnd() async throws {
     let relativePath = "2026-07-04/chunk_missing_frame.mp4"
     _ = try await createChunk(relativePath: relativePath, colors: [.red, .green, .blue], frameRate: 2.0)

--- a/desktop/macos/Desktop/Tests/RewindStorageVideoFrameExtractionTests.swift
+++ b/desktop/macos/Desktop/Tests/RewindStorageVideoFrameExtractionTests.swift
@@ -1,0 +1,204 @@
+import AppKit
+import AVFoundation
+import XCTest
+
+@testable import Omi_Computer
+
+final class RewindStorageVideoFrameExtractionTests: XCTestCase {
+  private var testUserId: String!
+  private var userDir: URL!
+
+  override func setUp() async throws {
+    try await super.setUp()
+
+    testUserId = "video-frame-test-\(UUID().uuidString)"
+    RewindDatabase.currentUserId = testUserId
+    try await RewindStorage.shared.initialize()
+
+    let appSupport = FileManager.default
+      .urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+    userDir =
+      appSupport
+      .appendingPathComponent("Omi", isDirectory: true)
+      .appendingPathComponent("users", isDirectory: true)
+      .appendingPathComponent(testUserId, isDirectory: true)
+  }
+
+  override func tearDown() async throws {
+    if let userDir { try? FileManager.default.removeItem(at: userDir) }
+    RewindDatabase.currentUserId = nil
+    await RewindStorage.shared.reset()
+    try await super.tearDown()
+  }
+
+  func testLoadVideoFrameExtractsRequestedFrameOffsetFromMP4Chunk() async throws {
+    let relativePath = "2026-07-04/chunk_frame_selection.mp4"
+    let fullPath = try await createChunk(relativePath: relativePath, colors: [.red, .green, .blue], frameRate: 2.0)
+
+    XCTAssertTrue(FileManager.default.fileExists(atPath: fullPath.path), "precondition: MP4 chunk written")
+
+    let frame = try await RewindStorage.shared.loadVideoFrame(videoPath: relativePath, frameOffset: 1)
+    let center = try XCTUnwrap(centerPixel(in: frame))
+
+    XCTAssertGreaterThan(center.green, center.red)
+    XCTAssertGreaterThan(center.green, center.blue)
+  }
+
+  func testLoadVideoFrameReturnsNotFoundWhenFrameOffsetIsPastEnd() async throws {
+    let relativePath = "2026-07-04/chunk_missing_frame.mp4"
+    _ = try await createChunk(relativePath: relativePath, colors: [.red, .green, .blue], frameRate: 2.0)
+
+    do {
+      _ = try await RewindStorage.shared.loadVideoFrame(videoPath: relativePath, frameOffset: 99)
+      XCTFail("Expected missing frame offset to be reported as screenshotNotFound")
+    } catch RewindError.screenshotNotFound {
+      // Expected: mirrors ffmpeg select=eq(n,offset) producing no frame.
+    } catch {
+      XCTFail("Expected screenshotNotFound, got \(error)")
+    }
+  }
+
+  private func createChunk(relativePath: String, colors: [NSColor], frameRate: Double) async throws -> URL {
+    let maybeVideosDir = await RewindStorage.shared.getVideosDirectory()
+    let videosDir = try XCTUnwrap(maybeVideosDir)
+    let outputURL = videosDir.appendingPathComponent(relativePath)
+    try FileManager.default.createDirectory(
+      at: outputURL.deletingLastPathComponent(),
+      withIntermediateDirectories: true
+    )
+
+    let width = 96
+    let height = 64
+    let writer = try AVAssetWriter(outputURL: outputURL, fileType: .mp4)
+    writer.shouldOptimizeForNetworkUse = true
+
+    let input = AVAssetWriterInput(mediaType: .video, outputSettings: [
+      AVVideoCodecKey: AVVideoCodecType.hevc,
+      AVVideoWidthKey: width,
+      AVVideoHeightKey: height,
+      AVVideoCompressionPropertiesKey: [
+        AVVideoExpectedSourceFrameRateKey: max(1, Int(ceil(frameRate))),
+        AVVideoAllowFrameReorderingKey: false,
+      ],
+    ])
+    input.expectsMediaDataInRealTime = true
+
+    guard writer.canAdd(input) else {
+      throw XCTSkip("HEVC writer input is unavailable on this runner")
+    }
+    writer.add(input)
+
+    let adaptor = AVAssetWriterInputPixelBufferAdaptor(
+      assetWriterInput: input,
+      sourcePixelBufferAttributes: [
+        kCVPixelBufferPixelFormatTypeKey as String: kCVPixelFormatType_32BGRA,
+        kCVPixelBufferWidthKey as String: width,
+        kCVPixelBufferHeightKey as String: height,
+        kCVPixelBufferIOSurfacePropertiesKey as String: [:],
+      ]
+    )
+
+    guard writer.startWriting() else {
+      throw RewindError.storageError("Failed to start test writer: \(writer.error?.localizedDescription ?? "unknown")")
+    }
+    writer.startSession(atSourceTime: .zero)
+
+    for (index, color) in colors.enumerated() {
+      while !input.isReadyForMoreMediaData {
+        try await Task.sleep(nanoseconds: 10_000_000)
+      }
+
+      let pixelBuffer = try createPixelBuffer(
+        width: width,
+        height: height,
+        color: color,
+        adaptor: adaptor
+      )
+      let time = CMTime(seconds: Double(index) / frameRate, preferredTimescale: 600)
+      guard adaptor.append(pixelBuffer, withPresentationTime: time) else {
+        throw RewindError.storageError("Failed to append test frame: \(writer.error?.localizedDescription ?? "unknown")")
+      }
+    }
+
+    input.markAsFinished()
+    let writerBox = TestAssetWriterBox(writer)
+    try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+      writerBox.writer.finishWriting {
+        if writerBox.writer.status == .completed {
+          continuation.resume()
+        } else {
+          let error = writerBox.writer.error?.localizedDescription ?? "unknown"
+          continuation.resume(throwing: RewindError.storageError("Failed to finish test writer: \(error)"))
+        }
+      }
+    }
+
+    return outputURL
+  }
+
+  private func createPixelBuffer(
+    width: Int,
+    height: Int,
+    color: NSColor,
+    adaptor: AVAssetWriterInputPixelBufferAdaptor
+  ) throws -> CVPixelBuffer {
+    var pixelBuffer: CVPixelBuffer?
+    if let pool = adaptor.pixelBufferPool {
+      CVPixelBufferPoolCreatePixelBuffer(nil, pool, &pixelBuffer)
+    } else {
+      CVPixelBufferCreate(
+        nil,
+        width,
+        height,
+        kCVPixelFormatType_32BGRA,
+        [kCVPixelBufferIOSurfacePropertiesKey as String: [:]] as CFDictionary,
+        &pixelBuffer
+      )
+    }
+
+    let buffer = try XCTUnwrap(pixelBuffer)
+    CVPixelBufferLockBaseAddress(buffer, [])
+    defer { CVPixelBufferUnlockBaseAddress(buffer, []) }
+
+    let context = try XCTUnwrap(CGContext(
+      data: CVPixelBufferGetBaseAddress(buffer),
+      width: width,
+      height: height,
+      bitsPerComponent: 8,
+      bytesPerRow: CVPixelBufferGetBytesPerRow(buffer),
+      space: CGColorSpaceCreateDeviceRGB(),
+      bitmapInfo: CGImageAlphaInfo.premultipliedFirst.rawValue | CGBitmapInfo.byteOrder32Little.rawValue
+    ))
+
+    context.setFillColor(color.cgColor)
+    context.fill(CGRect(x: 0, y: 0, width: width, height: height))
+    return buffer
+  }
+
+  private func centerPixel(in image: NSImage) -> (red: Int, green: Int, blue: Int)? {
+    guard let cgImage = image.cgImage(forProposedRect: nil, context: nil, hints: nil) else {
+      return nil
+    }
+
+    let bitmap = NSBitmapImageRep(cgImage: cgImage)
+    let x = max(0, bitmap.pixelsWide / 2)
+    let y = max(0, bitmap.pixelsHigh / 2)
+    guard let color = bitmap.colorAt(x: x, y: y)?.usingColorSpace(.deviceRGB) else {
+      return nil
+    }
+
+    return (
+      red: Int(color.redComponent * 255),
+      green: Int(color.greenComponent * 255),
+      blue: Int(color.blueComponent * 255)
+    )
+  }
+}
+
+private final class TestAssetWriterBox: @unchecked Sendable {
+  let writer: AVAssetWriter
+
+  init(_ writer: AVAssetWriter) {
+    self.writer = writer
+  }
+}

--- a/desktop/macos/agent/tests/codemagic-pi-mono-extension-ci.test.ts
+++ b/desktop/macos/agent/tests/codemagic-pi-mono-extension-ci.test.ts
@@ -30,12 +30,39 @@ describe("macOS release CI", () => {
       );
     }
     expect(codemagic).toContain(
-      'cp -Rf pi-mono-extension/node_modules "$APP_BUNDLE/Contents/Resources/pi-mono-extension/"'
+      'cp -Rf .harness/agent-runtime/agent-node_modules "$APP_BUNDLE/Contents/Resources/agent/node_modules"'
+    );
+    expect(codemagic).toContain(
+      'cp -Rf .harness/agent-runtime/pi-mono-extension-node_modules "$APP_BUNDLE/Contents/Resources/pi-mono-extension/node_modules"'
     );
     expect(runScript).toContain('(cd "$PI_MONO_EXT_DIR" && npm ci --no-fund --no-audit)');
     expect(runScript).toContain(
-      'cp -Rf "$PI_MONO_EXT_DIR/node_modules" "$APP_BUNDLE/Contents/Resources/pi-mono-extension/"'
+      'macos_copy_tree "$AGENT_PACKAGED_NODE_MODULES" "$APP_BUNDLE/Contents/Resources/agent/node_modules"'
     );
+    expect(runScript).toContain(
+      'macos_copy_tree "$PI_MONO_PACKAGED_NODE_MODULES" "$APP_BUNDLE/Contents/Resources/pi-mono-extension/node_modules"'
+    );
+  });
+
+  it("prepares production-only Node dependencies for app packaging", () => {
+    const prepareRuntimeScript = readFileSync(
+      new URL("../../scripts/prepare-agent-runtime.sh", import.meta.url),
+      "utf8"
+    );
+
+    expect(prepareRuntimeScript).toContain("npm run build --silent");
+    expect(prepareRuntimeScript).toContain('stage_production_node_modules "$AGENT_DIR" "$AGENT_PACKAGED_NODE_MODULES"');
+    expect(prepareRuntimeScript).toContain(
+      'stage_production_node_modules "$PI_MONO_DIR" "$PI_MONO_PACKAGED_NODE_MODULES"'
+    );
+    expect(prepareRuntimeScript).toContain("dedupe_pi_mono_packaged_node_modules");
+    expect(prepareRuntimeScript).toContain("prune_packaged_node_modules");
+    expect(prepareRuntimeScript).toContain('["darwin_arm64", "darwin_x64"]');
+    expect(prepareRuntimeScript).toContain('["arm64-darwin", "x64-darwin"]');
+    expect(prepareRuntimeScript).toContain('return `../../agent/node_modules/${packageName}`');
+    expect(prepareRuntimeScript).toContain('return `../../../agent/node_modules/${packageName}`');
+    expect(prepareRuntimeScript).toContain("npm ci --omit=dev --no-fund --no-audit");
+    expect(prepareRuntimeScript).toContain('prune_non_macos_node_packages "$temp_dir"');
   });
 
   it("signs bundled pi-mono-extension native dependencies before app signing", () => {

--- a/desktop/macos/changelog/unreleased/20260704-smaller-macos-bundle.json
+++ b/desktop/macos/changelog/unreleased/20260704-smaller-macos-bundle.json
@@ -1,0 +1,3 @@
+{
+  "change": "Reduced the macOS app bundle footprint by trimming packaged agent runtimes and adding bundle-size checks for future releases."
+}

--- a/desktop/macos/docs/bundle-size-harness.md
+++ b/desktop/macos/docs/bundle-size-harness.md
@@ -22,10 +22,12 @@ Useful variants:
 OMI_BUNDLE_SIZE_APP_NAME=omi-size-probe ./scripts/bundle-size-harness.sh
 OMI_BUNDLE_SIZE_NO_ADHOC=1 ./scripts/bundle-size-harness.sh
 OMI_BUNDLE_SIZE_KEEP_APP=1 ./scripts/bundle-size-harness.sh
+OMI_BUNDLE_SIZE_BUILD_TIMEOUT_SECONDS=900 ./scripts/bundle-size-harness.sh
 ```
 
 The app name must start with `omi-`. Do not aim this harness at `Omi`,
-`Omi Beta`, or `Omi Dev`.
+`Omi Beta`, or `Omi Dev`. The build timeout covers the full `run.sh` build and
+launch wait; raise it on cold machines or when another bundle build is finishing.
 
 Before accepting a size reduction, compare `latest.json` before/after and keep
 the runtime smoke checks green. For Node dependency pruning, prefer edits in

--- a/desktop/macos/docs/bundle-size-harness.md
+++ b/desktop/macos/docs/bundle-size-harness.md
@@ -1,0 +1,33 @@
+# Bundle Size Harness
+
+Use this harness to hill-climb macOS app bundle size reductions without relying
+on manual Finder inspection.
+
+```bash
+cd desktop/macos
+./scripts/bundle-size-harness.sh
+```
+
+The harness builds a named throwaway bundle (`omi-bundle-size.app` by default),
+allows ad-hoc signing only for that named bundle, runs bundle-local Node runtime
+smoke checks, and writes:
+
+- `.harness/bundle-size/latest.txt` — human-readable size breakdown
+- `.harness/bundle-size/latest.json` — machine-readable byte counts
+- `.harness/bundle-size/run.log` — full `run.sh` output
+
+Useful variants:
+
+```bash
+OMI_BUNDLE_SIZE_APP_NAME=omi-size-probe ./scripts/bundle-size-harness.sh
+OMI_BUNDLE_SIZE_NO_ADHOC=1 ./scripts/bundle-size-harness.sh
+OMI_BUNDLE_SIZE_KEEP_APP=1 ./scripts/bundle-size-harness.sh
+```
+
+The app name must start with `omi-`. Do not aim this harness at `Omi`,
+`Omi Beta`, or `Omi Dev`.
+
+Before accepting a size reduction, compare `latest.json` before/after and keep
+the runtime smoke checks green. For Node dependency pruning, prefer edits in
+`scripts/prepare-agent-runtime.sh` so the developer `node_modules` trees remain
+untouched.

--- a/desktop/macos/run.sh
+++ b/desktop/macos/run.sh
@@ -156,6 +156,8 @@ APP_PATH="/Applications/$APP_NAME.app"
 # Without this, `[ -d "$AGENT_DIR/dist" ]` tests an empty path and the agent
 # copy is silently skipped → app shows "AI components missing".
 AGENT_DIR="$SCRIPT_DIR/agent"
+AGENT_PACKAGED_NODE_MODULES="$SCRIPT_DIR/.harness/agent-runtime/agent-node_modules"
+PI_MONO_PACKAGED_NODE_MODULES="$SCRIPT_DIR/.harness/agent-runtime/pi-mono-extension-node_modules"
 APP_DESKTOP_PATH="$HOME/Desktop/$APP_NAME.app"
 APP_DOWNLOADS_PATH="$HOME/Downloads/$APP_NAME.app"
 SIGN_IDENTITY="${OMI_SIGN_IDENTITY:-}"
@@ -565,7 +567,12 @@ if [ -d "$AGENT_DIR/dist" ]; then
     mkdir -p "$APP_BUNDLE/Contents/Resources/agent"
     macos_copy_tree "$AGENT_DIR/dist" "$APP_BUNDLE/Contents/Resources/agent/dist"
     cp -f "$AGENT_DIR/package.json" "$APP_BUNDLE/Contents/Resources/agent/"
-    macos_copy_tree "$AGENT_DIR/node_modules" "$APP_BUNDLE/Contents/Resources/agent/node_modules"
+    if [ ! -d "$AGENT_PACKAGED_NODE_MODULES" ]; then
+        echo "ERROR: packaged agent dependencies missing at $AGENT_PACKAGED_NODE_MODULES"
+        echo "       Run scripts/prepare-agent-runtime.sh before bundling."
+        exit 1
+    fi
+    macos_copy_tree "$AGENT_PACKAGED_NODE_MODULES" "$APP_BUNDLE/Contents/Resources/agent/node_modules"
     mkdir -p "$APP_BUNDLE/Contents/Resources/agent/src/runtime"
     cp -f "$AGENT_DIR/src/runtime/control-tool-manifest.js" "$APP_BUNDLE/Contents/Resources/agent/src/runtime/"
     cp -f "$AGENT_DIR/src/runtime/control-tool-manifest.ts" "$APP_BUNDLE/Contents/Resources/agent/src/runtime/"
@@ -584,7 +591,12 @@ if [ -d "$PI_MONO_EXT_DIR" ]; then
     cp -f "$PI_MONO_EXT_DIR/index.ts" "$APP_BUNDLE/Contents/Resources/pi-mono-extension/"
     cp -f "$PI_MONO_EXT_DIR/package.json" "$APP_BUNDLE/Contents/Resources/pi-mono-extension/"
     cp -f "$PI_MONO_EXT_DIR/package-lock.json" "$APP_BUNDLE/Contents/Resources/pi-mono-extension/"
-    cp -Rf "$PI_MONO_EXT_DIR/node_modules" "$APP_BUNDLE/Contents/Resources/pi-mono-extension/"
+    if [ ! -d "$PI_MONO_PACKAGED_NODE_MODULES" ]; then
+        echo "ERROR: packaged pi-mono-extension dependencies missing at $PI_MONO_PACKAGED_NODE_MODULES"
+        echo "       Run scripts/prepare-agent-runtime.sh before bundling."
+        exit 1
+    fi
+    macos_copy_tree "$PI_MONO_PACKAGED_NODE_MODULES" "$APP_BUNDLE/Contents/Resources/pi-mono-extension/node_modules"
 else
     echo "Warning: pi-mono-extension not found at $PI_MONO_EXT_DIR"
 fi
@@ -704,6 +716,10 @@ if [ -z "$SIGN_IDENTITY" ]; then
     if [ -z "$SIGN_IDENTITY" ]; then
         SIGN_IDENTITY=$(security find-identity -v -p codesigning | grep "Developer ID Application" | head -1 | sed 's/.*"\(.*\)"/\1/')
     fi
+    if [ -z "$SIGN_IDENTITY" ] && [ "${OMI_ALLOW_ADHOC_SIGN:-0}" = "1" ] && [ "$IS_NAMED_BUNDLE" = true ]; then
+        SIGN_IDENTITY="-"
+        substep "Using ad-hoc signing for named test bundle ($BUNDLE_ID)"
+    fi
 fi
 
 if [ -n "$SIGN_IDENTITY" ]; then
@@ -779,6 +795,9 @@ else
     echo "  Fix: Install an Apple Development certificate in Keychain Access,"
     echo "       or set OMI_SIGN_IDENTITY to a valid identity:"
     echo "       OMI_SIGN_IDENTITY=\"Apple Development: you@example.com\" ./run.sh"
+    echo ""
+    echo "       For named throwaway bundles only, tests may opt into ad-hoc signing:"
+    echo "       OMI_APP_NAME=\"omi-my-test\" OMI_ALLOW_ADHOC_SIGN=1 ./run.sh"
     echo ""
     exit 1
 fi

--- a/desktop/macos/scripts/bundle-size-harness.sh
+++ b/desktop/macos/scripts/bundle-size-harness.sh
@@ -1,0 +1,202 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MACOS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPO_ROOT="$(cd "$MACOS_DIR/../.." && pwd)"
+
+APP_NAME="${OMI_BUNDLE_SIZE_APP_NAME:-omi-bundle-size}"
+APP_PATH="/Applications/$APP_NAME.app"
+BUNDLE_PATH="$MACOS_DIR/build/$APP_NAME.app"
+HARNESS_DIR="$MACOS_DIR/.harness/bundle-size"
+REPORT_PATH="$HARNESS_DIR/latest.txt"
+JSON_PATH="$HARNESS_DIR/latest.json"
+LOG_PATH="$HARNESS_DIR/run.log"
+RUN_PID=""
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/bundle-size-harness.sh
+
+Builds a named macOS bundle, records size breakdowns, and runs bundle-local
+runtime smoke checks for the packaged Node agent and pi-mono extension.
+
+Environment:
+  OMI_BUNDLE_SIZE_APP_NAME   Named app bundle to build (default: omi-bundle-size)
+  OMI_BUNDLE_SIZE_NO_ADHOC   Set to 1 to require a real signing identity
+  OMI_BUNDLE_SIZE_KEEP_APP   Set to 1 to leave the launched named app running
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "ERROR: unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+  shift
+done
+
+if [[ "$APP_NAME" != omi-* ]]; then
+  echo "ERROR: OMI_BUNDLE_SIZE_APP_NAME must start with omi- (got: $APP_NAME)" >&2
+  exit 2
+fi
+
+mkdir -p "$HARNESS_DIR"
+: > "$LOG_PATH"
+
+cleanup() {
+  if [[ -n "$RUN_PID" ]] && kill -0 "$RUN_PID" 2>/dev/null; then
+    kill "$RUN_PID" 2>/dev/null || true
+    wait "$RUN_PID" 2>/dev/null || true
+  fi
+  if [[ "${OMI_BUNDLE_SIZE_KEEP_APP:-0}" != "1" ]]; then
+    pkill -f "/Applications/$APP_NAME.app/Contents/MacOS/Omi Computer" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT INT TERM
+
+run_bundle_build() {
+  local ad_hoc=1
+  if [[ "${OMI_BUNDLE_SIZE_NO_ADHOC:-0}" == "1" ]]; then
+    ad_hoc=0
+  fi
+
+  (
+    cd "$MACOS_DIR"
+    OMI_APP_NAME="$APP_NAME" \
+      OMI_ALLOW_ADHOC_SIGN="$ad_hoc" \
+      OMI_SKIP_AUTH_SEED="${OMI_SKIP_AUTH_SEED:-1}" \
+      OMI_SKIP_SETTINGS_SEED="${OMI_SKIP_SETTINGS_SEED:-1}" \
+      OMI_SKIP_STALE_BUNDLE_SCAN="${OMI_SKIP_STALE_BUNDLE_SCAN:-1}" \
+      ./run.sh --yolo
+  ) >"$LOG_PATH" 2>&1 &
+  RUN_PID="$!"
+
+  local deadline=$((SECONDS + 240))
+  while kill -0 "$RUN_PID" 2>/dev/null; do
+    if grep -q "Press Ctrl+C to stop all services" "$LOG_PATH"; then
+      return 0
+    fi
+    if grep -q "ERROR:" "$LOG_PATH"; then
+      tail -80 "$LOG_PATH" >&2
+      return 1
+    fi
+    if (( SECONDS > deadline )); then
+      tail -80 "$LOG_PATH" >&2
+      echo "ERROR: timed out waiting for bundle build" >&2
+      return 1
+    fi
+    sleep 2
+  done
+
+  wait "$RUN_PID"
+}
+
+bytes_for_path() {
+  local path="$1"
+  if [[ ! -e "$path" ]]; then
+    printf '0'
+    return
+  fi
+  du -sk "$path" | awk '{print $1 * 1024}'
+}
+
+human_size() {
+  local bytes="$1"
+  awk -v bytes="$bytes" 'BEGIN {
+    split("B KiB MiB GiB", units, " ")
+    value = bytes + 0
+    unit = 1
+    while (value >= 1024 && unit < 4) {
+      value = value / 1024
+      unit++
+    }
+    if (unit == 1) printf "%d %s", value, units[unit]
+    else printf "%.1f %s", value, units[unit]
+  }'
+}
+
+smoke_packaged_runtime() {
+  local app="$1"
+  local node="$app/Contents/Resources/Omi Computer_Omi Computer.bundle/node"
+  local pi_dir="$app/Contents/Resources/pi-mono-extension"
+
+  "$node" --version >/dev/null
+  (
+    cd "$pi_dir"
+    "$node" --experimental-strip-types -e "await import('./index.ts')"
+  )
+  (
+    cd "$app/Contents/Resources/agent"
+    "$node" -e "await import('./dist/adapters/pi-mono.js'); console.log('agent pi adapter import ok')" >/dev/null
+  )
+}
+
+write_report() {
+  local app="$1"
+  local total resources agent agent_node pi pi_node binary resource_bundle symlinks
+
+  total="$(bytes_for_path "$app")"
+  resources="$(bytes_for_path "$app/Contents/Resources")"
+  agent="$(bytes_for_path "$app/Contents/Resources/agent")"
+  agent_node="$(bytes_for_path "$app/Contents/Resources/agent/node_modules")"
+  pi="$(bytes_for_path "$app/Contents/Resources/pi-mono-extension")"
+  pi_node="$(bytes_for_path "$app/Contents/Resources/pi-mono-extension/node_modules")"
+  binary="$(bytes_for_path "$app/Contents/MacOS/Omi Computer")"
+  resource_bundle="$(bytes_for_path "$app/Contents/Resources/Omi Computer_Omi Computer.bundle")"
+  symlinks="$(find "$app/Contents/Resources/pi-mono-extension/node_modules" -type l 2>/dev/null | wc -l | tr -d ' ')"
+
+  {
+    echo "Bundle size harness report"
+    echo "app: $app"
+    echo "log: $LOG_PATH"
+    echo
+    printf "%-32s %12s\n" "total" "$(human_size "$total")"
+    printf "%-32s %12s\n" "resources" "$(human_size "$resources")"
+    printf "%-32s %12s\n" "agent" "$(human_size "$agent")"
+    printf "%-32s %12s\n" "agent/node_modules" "$(human_size "$agent_node")"
+    printf "%-32s %12s\n" "pi-mono-extension" "$(human_size "$pi")"
+    printf "%-32s %12s\n" "pi-mono/node_modules" "$(human_size "$pi_node")"
+    printf "%-32s %12s\n" "main executable" "$(human_size "$binary")"
+    printf "%-32s %12s\n" "SPM resource bundle" "$(human_size "$resource_bundle")"
+    printf "%-32s %12s\n" "pi symlinks" "$symlinks"
+  } | tee "$REPORT_PATH"
+
+  cat > "$JSON_PATH" <<JSON
+{
+  "app": "$app",
+  "log": "$LOG_PATH",
+  "sizes": {
+    "total": $total,
+    "resources": $resources,
+    "agent": $agent,
+    "agent_node_modules": $agent_node,
+    "pi_mono_extension": $pi,
+    "pi_mono_node_modules": $pi_node,
+    "main_executable": $binary,
+    "spm_resource_bundle": $resource_bundle
+  },
+  "pi_mono_symlinks": $symlinks
+}
+JSON
+}
+
+run_bundle_build
+
+if [[ ! -d "$BUNDLE_PATH" && -d "$APP_PATH" ]]; then
+  BUNDLE_PATH="$APP_PATH"
+fi
+if [[ ! -d "$BUNDLE_PATH" ]]; then
+  echo "ERROR: bundle not found at $BUNDLE_PATH or $APP_PATH" >&2
+  exit 1
+fi
+
+smoke_packaged_runtime "$BUNDLE_PATH"
+write_report "$BUNDLE_PATH"

--- a/desktop/macos/scripts/bundle-size-harness.sh
+++ b/desktop/macos/scripts/bundle-size-harness.sh
@@ -12,6 +12,7 @@ HARNESS_DIR="$MACOS_DIR/.harness/bundle-size"
 REPORT_PATH="$HARNESS_DIR/latest.txt"
 JSON_PATH="$HARNESS_DIR/latest.json"
 LOG_PATH="$HARNESS_DIR/run.log"
+BUILD_TIMEOUT_SECONDS="${OMI_BUNDLE_SIZE_BUILD_TIMEOUT_SECONDS:-600}"
 RUN_PID=""
 
 usage() {
@@ -25,6 +26,8 @@ Environment:
   OMI_BUNDLE_SIZE_APP_NAME   Named app bundle to build (default: omi-bundle-size)
   OMI_BUNDLE_SIZE_NO_ADHOC   Set to 1 to require a real signing identity
   OMI_BUNDLE_SIZE_KEEP_APP   Set to 1 to leave the launched named app running
+  OMI_BUNDLE_SIZE_BUILD_TIMEOUT_SECONDS
+                             Seconds to wait for build + launch (default: 600)
 USAGE
 }
 
@@ -47,6 +50,10 @@ if [[ "$APP_NAME" != omi-* ]]; then
   echo "ERROR: OMI_BUNDLE_SIZE_APP_NAME must start with omi- (got: $APP_NAME)" >&2
   exit 2
 fi
+if ! [[ "$BUILD_TIMEOUT_SECONDS" =~ ^[0-9]+$ ]] || ((BUILD_TIMEOUT_SECONDS < 60)); then
+  echo "ERROR: OMI_BUNDLE_SIZE_BUILD_TIMEOUT_SECONDS must be an integer >= 60 (got: $BUILD_TIMEOUT_SECONDS)" >&2
+  exit 2
+fi
 
 mkdir -p "$HARNESS_DIR"
 : > "$LOG_PATH"
@@ -56,11 +63,34 @@ cleanup() {
     kill "$RUN_PID" 2>/dev/null || true
     wait "$RUN_PID" 2>/dev/null || true
   fi
+  cleanup_stale_run_lock_if_safe
   if [[ "${OMI_BUNDLE_SIZE_KEEP_APP:-0}" != "1" ]]; then
-    pkill -f "/Applications/$APP_NAME.app/Contents/MacOS/Omi Computer" 2>/dev/null || true
+    local executable_path="/Applications/$APP_NAME.app/Contents/MacOS/Omi Computer"
+    while read -r pid command; do
+      if [[ "$pid" =~ ^[0-9]+$ && "$command" == *"$executable_path"* ]]; then
+        kill "$pid" 2>/dev/null || true
+      fi
+    done < <(ps -axo pid=,command=)
   fi
 }
 trap cleanup EXIT INT TERM
+
+cleanup_stale_run_lock_if_safe() {
+  local lock_dir="${TMPDIR:-/tmp}/omi-run-sh-${USER}.lock.d"
+  [[ -d "$lock_dir" ]] || return 0
+
+  local other_run_sh=0
+  while read -r pid command; do
+    if [[ "$pid" =~ ^[0-9]+$ && "$command" == *"./run.sh"* ]]; then
+      other_run_sh=1
+      break
+    fi
+  done < <(ps -axo pid=,command=)
+
+  if [[ "$other_run_sh" == "0" ]]; then
+    rmdir "$lock_dir" 2>/dev/null || true
+  fi
+}
 
 run_bundle_build() {
   local ad_hoc=1
@@ -79,7 +109,7 @@ run_bundle_build() {
   ) >"$LOG_PATH" 2>&1 &
   RUN_PID="$!"
 
-  local deadline=$((SECONDS + 240))
+  local deadline=$((SECONDS + BUILD_TIMEOUT_SECONDS))
   while kill -0 "$RUN_PID" 2>/dev/null; do
     if grep -q "Press Ctrl+C to stop all services" "$LOG_PATH"; then
       return 0
@@ -90,7 +120,7 @@ run_bundle_build() {
     fi
     if (( SECONDS > deadline )); then
       tail -80 "$LOG_PATH" >&2
-      echo "ERROR: timed out waiting for bundle build" >&2
+      echo "ERROR: timed out after ${BUILD_TIMEOUT_SECONDS}s waiting for bundle build" >&2
       return 1
     fi
     sleep 2

--- a/desktop/macos/scripts/prepare-agent-runtime.sh
+++ b/desktop/macos/scripts/prepare-agent-runtime.sh
@@ -6,6 +6,9 @@ DESKTOP_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 AGENT_DIR="$DESKTOP_DIR/agent"
 PI_MONO_DIR="$DESKTOP_DIR/pi-mono-extension"
 NODE_RESOURCE="$DESKTOP_DIR/Desktop/Sources/Resources/node"
+PACKAGED_RUNTIME_DIR="$DESKTOP_DIR/.harness/agent-runtime"
+AGENT_PACKAGED_NODE_MODULES="$PACKAGED_RUNTIME_DIR/agent-node_modules"
+PI_MONO_PACKAGED_NODE_MODULES="$PACKAGED_RUNTIME_DIR/pi-mono-extension-node_modules"
 
 NODE_VERSION="${OMI_AGENT_NODE_VERSION:-v22.14.0}"
 NODE_DARWIN_ARM64_SHA256="e9404633bc02a5162c5c573b1e2490f5fb44648345d64a958b17e325729a5e42"
@@ -21,6 +24,7 @@ Usage: scripts/prepare-agent-runtime.sh [--universal-node|--unsafe-local-node] [
 Prepares the desktop Ask Omi agent runtime:
   - installs agent npm dependencies with npm ci
   - compiles agent/dist
+  - stages production-only node_modules for app packaging
   - stages Desktop/Sources/Resources/node for SwiftPM resource bundling
   - validates bridge, piMono, and extension files that the app launches at runtime
 
@@ -107,6 +111,320 @@ install_agent_deps_and_build() {
     npm ci --no-fund --no-audit
     npm run build --silent
   )
+  stage_production_node_modules "$AGENT_DIR" "$AGENT_PACKAGED_NODE_MODULES"
+}
+
+install_pi_mono_deps() {
+  require_file "$PI_MONO_DIR/package-lock.json"
+  require_file "$PI_MONO_DIR/package.json"
+
+  if [ "$SKIP_NPM" = "1" ]; then
+    return
+  fi
+
+  log "Installing pi-mono-extension production dependencies for packaging"
+  (
+    cd "$PI_MONO_DIR"
+    npm ci --omit=dev --no-fund --no-audit
+  )
+  stage_production_node_modules "$PI_MONO_DIR" "$PI_MONO_PACKAGED_NODE_MODULES"
+  dedupe_pi_mono_packaged_node_modules
+}
+
+stage_production_node_modules() {
+  local package_dir="$1"
+  local output_dir="$2"
+  local temp_dir
+
+  require_file "$package_dir/package-lock.json"
+  require_file "$package_dir/package.json"
+
+  mkdir -p "$PACKAGED_RUNTIME_DIR"
+  temp_dir="$(mktemp -d "$PACKAGED_RUNTIME_DIR/$(basename "$package_dir").XXXXXX")"
+  cp -f "$package_dir/package.json" "$package_dir/package-lock.json" "$temp_dir/"
+
+  log "Staging $(basename "$package_dir") production dependencies for packaging"
+  (
+    cd "$temp_dir"
+    npm ci --omit=dev --no-fund --no-audit
+  )
+
+  prune_non_macos_node_packages "$temp_dir"
+  prune_packaged_node_modules "$temp_dir"
+  rm -rf "$output_dir"
+  mv "$temp_dir/node_modules" "$output_dir"
+  rm -rf "$temp_dir"
+}
+
+prune_non_macos_node_packages() {
+  local package_dir="$1"
+
+  node - "$package_dir" <<'NODE'
+const fs = require("node:fs");
+const path = require("node:path");
+
+const packageDir = process.argv[2];
+const lockPath = path.join(packageDir, "package-lock.json");
+const nodeModulesPath = path.join(packageDir, "node_modules");
+
+if (!fs.existsSync(lockPath) || !fs.existsSync(nodeModulesPath)) {
+  process.exit(0);
+}
+
+const lock = JSON.parse(fs.readFileSync(lockPath, "utf8"));
+const packages = lock.packages || {};
+let removedCount = 0;
+let removedBytes = 0;
+
+function directorySizeBytes(targetPath) {
+  let total = 0;
+  for (const entry of fs.readdirSync(targetPath, { withFileTypes: true })) {
+    const entryPath = path.join(targetPath, entry.name);
+    if (entry.isDirectory()) {
+      total += directorySizeBytes(entryPath);
+    } else if (entry.isFile()) {
+      total += fs.statSync(entryPath).size;
+    }
+  }
+  return total;
+}
+
+function excludesDarwin(packageMeta) {
+  return Array.isArray(packageMeta.os) && !packageMeta.os.includes("darwin");
+}
+
+for (const [lockPackagePath, packageMeta] of Object.entries(packages)) {
+  if (!lockPackagePath.startsWith("node_modules/") || !excludesDarwin(packageMeta)) {
+    continue;
+  }
+
+  const installedPath = path.join(packageDir, lockPackagePath);
+  if (!fs.existsSync(installedPath)) {
+    continue;
+  }
+
+  removedBytes += directorySizeBytes(installedPath);
+  fs.rmSync(installedPath, { recursive: true, force: true });
+  removedCount += 1;
+}
+
+if (removedCount > 0) {
+  const removedMiB = (removedBytes / 1024 / 1024).toFixed(1);
+  console.log(`[agent-runtime] Pruned ${removedCount} non-macOS package(s) from ${path.basename(packageDir)} (${removedMiB} MiB)`);
+}
+NODE
+}
+
+prune_packaged_node_modules() {
+  local package_dir="$1"
+
+  node - "$package_dir" <<'NODE'
+const fs = require("node:fs");
+const path = require("node:path");
+
+const packageDir = process.argv[2];
+const nodeModulesPath = path.join(packageDir, "node_modules");
+
+if (!fs.existsSync(nodeModulesPath)) {
+  process.exit(0);
+}
+
+let removedCount = 0;
+let removedBytes = 0;
+
+function removePath(targetPath) {
+  if (!fs.existsSync(targetPath)) {
+    return;
+  }
+  removedBytes += pathSizeBytes(targetPath);
+  fs.rmSync(targetPath, { recursive: true, force: true });
+  removedCount += 1;
+}
+
+function pathSizeBytes(targetPath) {
+  const stat = fs.lstatSync(targetPath);
+  if (stat.isSymbolicLink()) {
+    return 0;
+  }
+  if (stat.isFile()) {
+    return stat.size;
+  }
+  if (!stat.isDirectory()) {
+    return 0;
+  }
+
+  let total = 0;
+  for (const entry of fs.readdirSync(targetPath, { withFileTypes: true })) {
+    total += pathSizeBytes(path.join(targetPath, entry.name));
+  }
+  return total;
+}
+
+function walk(targetPath, visit) {
+  if (!fs.existsSync(targetPath)) {
+    return;
+  }
+  for (const entry of fs.readdirSync(targetPath, { withFileTypes: true })) {
+    const entryPath = path.join(targetPath, entry.name);
+    if (visit(entryPath, entry) === false) {
+      continue;
+    }
+    if (entry.isDirectory() && !entry.isSymbolicLink()) {
+      walk(entryPath, visit);
+    }
+  }
+}
+
+walk(nodeModulesPath, (entryPath, entry) => {
+  if (entry.isFile() && (entry.name.endsWith(".map") || entry.name.endsWith(".tsbuildinfo"))) {
+    removePath(entryPath);
+    return false;
+  }
+});
+
+removePath(path.join(nodeModulesPath, "@mariozechner", "pi-coding-agent", "docs"));
+
+for (const koffiDir of [
+  path.join(nodeModulesPath, "koffi", "build", "koffi"),
+]) {
+  if (!fs.existsSync(koffiDir)) {
+    continue;
+  }
+  for (const entry of fs.readdirSync(koffiDir, { withFileTypes: true })) {
+    if (!entry.isDirectory() || ["darwin_arm64", "darwin_x64"].includes(entry.name)) {
+      continue;
+    }
+    removePath(path.join(koffiDir, entry.name));
+  }
+}
+
+const ripgrepDir = path.join(
+  nodeModulesPath,
+  "@anthropic-ai",
+  "claude-agent-sdk",
+  "vendor",
+  "ripgrep"
+);
+if (fs.existsSync(ripgrepDir)) {
+  for (const entry of fs.readdirSync(ripgrepDir, { withFileTypes: true })) {
+    if (!entry.isDirectory() || ["arm64-darwin", "x64-darwin"].includes(entry.name)) {
+      continue;
+    }
+    removePath(path.join(ripgrepDir, entry.name));
+  }
+}
+
+if (removedCount > 0) {
+  const removedMiB = (removedBytes / 1024 / 1024).toFixed(1);
+  console.log(`[agent-runtime] Pruned ${removedCount} packaged-only file(s)/folder(s) from ${path.basename(packageDir)} (${removedMiB} MiB)`);
+}
+NODE
+}
+
+dedupe_pi_mono_packaged_node_modules() {
+  node - "$AGENT_PACKAGED_NODE_MODULES" "$PI_MONO_PACKAGED_NODE_MODULES" <<'NODE'
+const fs = require("node:fs");
+const path = require("node:path");
+
+const agentNodeModules = process.argv[2];
+const piNodeModules = process.argv[3];
+
+if (!fs.existsSync(agentNodeModules) || !fs.existsSync(piNodeModules)) {
+  process.exit(0);
+}
+
+let linkedCount = 0;
+let linkedBytes = 0;
+
+function directorySizeBytes(targetPath) {
+  const stat = fs.lstatSync(targetPath);
+  if (stat.isSymbolicLink()) {
+    return 0;
+  }
+  if (stat.isFile()) {
+    return stat.size;
+  }
+  if (!stat.isDirectory()) {
+    return 0;
+  }
+
+  let total = 0;
+  for (const entry of fs.readdirSync(targetPath, { withFileTypes: true })) {
+    total += directorySizeBytes(path.join(targetPath, entry.name));
+  }
+  return total;
+}
+
+function packageJson(packagePath) {
+  const jsonPath = path.join(packagePath, "package.json");
+  if (!fs.existsSync(jsonPath)) {
+    return undefined;
+  }
+  return JSON.parse(fs.readFileSync(jsonPath, "utf8"));
+}
+
+function samePackageVersion(piPackagePath, agentPackagePath) {
+  const piPackage = packageJson(piPackagePath);
+  const agentPackage = packageJson(agentPackagePath);
+  return Boolean(
+    piPackage &&
+      agentPackage &&
+      piPackage.name === agentPackage.name &&
+      piPackage.version === agentPackage.version
+  );
+}
+
+function finalBundleSymlinkTarget(packageName) {
+  if (packageName.startsWith("@")) {
+    return `../../../agent/node_modules/${packageName}`;
+  }
+  return `../../agent/node_modules/${packageName}`;
+}
+
+function linkPackage(piPackagePath, packageName) {
+  linkedBytes += directorySizeBytes(piPackagePath);
+  fs.rmSync(piPackagePath, { recursive: true, force: true });
+  fs.symlinkSync(finalBundleSymlinkTarget(packageName), piPackagePath, "dir");
+  linkedCount += 1;
+}
+
+for (const entry of fs.readdirSync(piNodeModules, { withFileTypes: true })) {
+  if (entry.name === ".bin" || entry.name === ".package-lock.json") {
+    continue;
+  }
+
+  const piEntryPath = path.join(piNodeModules, entry.name);
+  const agentEntryPath = path.join(agentNodeModules, entry.name);
+
+  if (entry.isDirectory() && entry.name.startsWith("@")) {
+    if (!fs.existsSync(agentEntryPath)) {
+      continue;
+    }
+    for (const scopedEntry of fs.readdirSync(piEntryPath, { withFileTypes: true })) {
+      if (!scopedEntry.isDirectory()) {
+        continue;
+      }
+      const piPackagePath = path.join(piEntryPath, scopedEntry.name);
+      const agentPackagePath = path.join(agentEntryPath, scopedEntry.name);
+      const packageName = `${entry.name}/${scopedEntry.name}`;
+      if (samePackageVersion(piPackagePath, agentPackagePath)) {
+        linkPackage(piPackagePath, packageName);
+      }
+    }
+    continue;
+  }
+
+  if (!entry.isDirectory() || !samePackageVersion(piEntryPath, agentEntryPath)) {
+    continue;
+  }
+  linkPackage(piEntryPath, entry.name);
+}
+
+if (linkedCount > 0) {
+  const linkedMiB = (linkedBytes / 1024 / 1024).toFixed(1);
+  console.log(`[agent-runtime] Deduped ${linkedCount} pi-mono package(s) via symlink (${linkedMiB} MiB)`);
+}
+NODE
 }
 
 stage_unsafe_local_node() {
@@ -188,15 +506,19 @@ validate_runtime_tree() {
   require_file "$AGENT_DIR/src/runtime/node-tools.ts"
   require_file "$AGENT_DIR/src/runtime/omi-tool-manifest.ts"
   require_file "$AGENT_DIR/node_modules/@mariozechner/pi-coding-agent/dist/cli.js"
+  require_file "$AGENT_PACKAGED_NODE_MODULES/@mariozechner/pi-coding-agent/dist/cli.js"
   require_file "$AGENT_DIR/node_modules/@zed-industries/claude-agent-acp/dist/acp-agent.js"
+  require_file "$AGENT_PACKAGED_NODE_MODULES/@zed-industries/claude-agent-acp/dist/acp-agent.js"
   require_file "$PI_MONO_DIR/index.ts"
   require_file "$PI_MONO_DIR/package.json"
+  require_file "$PI_MONO_PACKAGED_NODE_MODULES/@mariozechner/pi-coding-agent/dist/cli.js"
 
   "$NODE_RESOURCE" --version >/dev/null
   log "Runtime validated: node=$("$NODE_RESOURCE" --version), agent dist and piMono files present"
 }
 
 install_agent_deps_and_build
+install_pi_mono_deps
 case "$MODE" in
   local)
     stage_unsafe_local_node

--- a/desktop/macos/scripts/prepare-desktop-bundle-native-deps.sh
+++ b/desktop/macos/scripts/prepare-desktop-bundle-native-deps.sh
@@ -11,6 +11,7 @@ Usage: scripts/prepare-desktop-bundle-native-deps.sh /path/to/Omi.app
 Normalizes bundled native Node dependencies before signing:
   - rewrites host-machine LC_ID_DYLIB values in .node dylibs
   - vendors Homebrew pcre2 next to bundled ripgrep binaries that need it
+  - strips local symbols from the main app executable before codesign
 USAGE
 }
 
@@ -27,9 +28,113 @@ fi
 
 APP_BUNDLE="$(cd "$APP_BUNDLE" && pwd)"
 CONTENTS_DIR="$APP_BUNDLE/Contents"
+MACOS_DIR="$CONTENTS_DIR/MacOS"
+
+human_bytes() {
+  local bytes="$1"
+  awk -v bytes="$bytes" 'BEGIN {
+    split("B KiB MiB GiB", units, " ")
+    value = bytes + 0
+    unit = 1
+    while (value >= 1024 && unit < 4) {
+      value = value / 1024
+      unit++
+    }
+    if (unit == 1) {
+      printf "%d %s", value, units[unit]
+    } else {
+      printf "%.1f %s", value, units[unit]
+    }
+  }'
+}
+
+file_size_bytes() {
+  if stat -f%z "$1" >/dev/null 2>&1; then
+    stat -f%z "$1"
+  else
+    stat -c%s "$1"
+  fi
+}
+
+main_executable_name() {
+  local executable
+  local candidate
+
+  executable="$(/usr/libexec/PlistBuddy -c "Print :CFBundleExecutable" "$CONTENTS_DIR/Info.plist" 2>/dev/null || true)"
+  if [[ -n "$executable" && -f "$MACOS_DIR/$executable" ]]; then
+    printf '%s\n' "$executable"
+    return 0
+  fi
+
+  while IFS= read -r -d '' candidate; do
+    if [[ -f "$candidate" && -x "$candidate" ]]; then
+      basename "$candidate"
+      return 0
+    fi
+  done < <(find "$MACOS_DIR" -maxdepth 1 -type f -print0 2>/dev/null)
+}
 
 is_macho() {
   file "$1" 2>/dev/null | grep -q "Mach-O"
+}
+
+macho_arches() {
+  file "$1" 2>/dev/null | grep -oE 'arm64|x86_64' | sort -u | tr '\n' ' '
+}
+
+strip_main_executable() {
+  if [[ "${OMI_SKIP_MAIN_BINARY_STRIP:-0}" == "1" ]]; then
+    echo "Skipping main app executable strip (OMI_SKIP_MAIN_BINARY_STRIP=1)"
+    return 0
+  fi
+
+  if ! command -v strip >/dev/null 2>&1; then
+    echo "WARNING: strip not found; leaving main app executable unstripped" >&2
+    return 0
+  fi
+
+  local executable_name
+  local executable_path
+  local before_bytes
+  local after_bytes
+  local before_arches
+  local after_arches
+  local saved_bytes
+
+  executable_name="$(main_executable_name || true)"
+  if [[ -z "$executable_name" ]]; then
+    echo "WARNING: could not determine main app executable; skipping strip" >&2
+    return 0
+  fi
+
+  executable_path="$MACOS_DIR/$executable_name"
+  if [[ ! -f "$executable_path" ]]; then
+    echo "WARNING: main app executable missing at $executable_path; skipping strip" >&2
+    return 0
+  fi
+  if ! is_macho "$executable_path"; then
+    echo "WARNING: main app executable is not Mach-O: $executable_path; skipping strip" >&2
+    return 0
+  fi
+
+  before_bytes="$(file_size_bytes "$executable_path")"
+  before_arches="$(macho_arches "$executable_path")"
+  chmod u+w "$executable_path" 2>/dev/null || true
+  strip -x "$executable_path"
+  after_bytes="$(file_size_bytes "$executable_path")"
+  after_arches="$(macho_arches "$executable_path")"
+
+  if [[ "$before_arches" != "$after_arches" ]]; then
+    echo "ERROR: strip changed main executable architectures: before='$before_arches' after='$after_arches'" >&2
+    exit 1
+  fi
+  if [[ "$after_bytes" -gt "$before_bytes" ]]; then
+    echo "ERROR: strip increased main executable size: $(human_bytes "$before_bytes") -> $(human_bytes "$after_bytes")" >&2
+    exit 1
+  fi
+
+  saved_bytes=$((before_bytes - after_bytes))
+  echo "Stripped main app executable: $(human_bytes "$before_bytes") -> $(human_bytes "$after_bytes") (saved $(human_bytes "$saved_bytes"))"
 }
 
 host_local_id_names() {
@@ -123,5 +228,7 @@ while IFS= read -r -d '' rg; do
   chmod u+w "$rg" 2>/dev/null || true
   vendor_pcre2_for_ripgrep "$rg"
 done < <(find "$CONTENTS_DIR/Resources" -path '*/vendor/ripgrep/*-darwin/rg' -type f -print0 2>/dev/null)
+
+strip_main_executable
 
 echo "Prepared desktop bundle native dependencies"

--- a/desktop/macos/tests/test-prepare-desktop-bundle-native-deps.sh
+++ b/desktop/macos/tests/test-prepare-desktop-bundle-native-deps.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MACOS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/omi-prepare-native-deps-test.XXXXXX")"
+cleanup() {
+  rm -rf "$tmpdir"
+}
+trap cleanup EXIT
+
+fakebin="$tmpdir/bin"
+app_bundle="$tmpdir/Omi Test.app"
+main_binary="$app_bundle/Contents/MacOS/Omi Computer"
+mkdir -p "$fakebin" "$app_bundle/Contents/MacOS" "$app_bundle/Contents/Resources"
+
+cat > "$fakebin/file" <<'EOF'
+#!/usr/bin/env bash
+for arg in "$@"; do
+  case "$arg" in
+    *"/Contents/MacOS/Omi Computer")
+      echo "$arg: Mach-O universal binary with 2 architectures: [x86_64] [arm64]"
+      ;;
+    *)
+      echo "$arg: ASCII text"
+      ;;
+  esac
+done
+EOF
+chmod +x "$fakebin/file"
+
+cat > "$fakebin/strip" <<'EOF'
+#!/usr/bin/env bash
+target="${@: -1}"
+before="$(wc -c < "$target" | tr -d ' ')"
+after=$((before - 256))
+if [ "$after" -lt 1 ]; then
+  after=1
+fi
+perl -e 'truncate $ARGV[0], $ARGV[1] or die "truncate: $!"' "$target" "$after"
+EOF
+chmod +x "$fakebin/strip"
+
+head -c 4096 /dev/zero > "$main_binary"
+chmod +x "$main_binary"
+
+before="$(wc -c < "$main_binary" | tr -d ' ')"
+output="$(PATH="$fakebin:$PATH" "$MACOS_DIR/scripts/prepare-desktop-bundle-native-deps.sh" "$app_bundle")"
+after="$(wc -c < "$main_binary" | tr -d ' ')"
+
+if [ "$after" -ge "$before" ]; then
+  fail "main executable was not stripped: before=$before after=$after"
+fi
+if ! grep -q "Stripped main app executable:" <<< "$output"; then
+  fail "prepare script did not report main executable strip"
+fi
+if ! grep -q "Prepared desktop bundle native dependencies" <<< "$output"; then
+  fail "prepare script did not complete successfully"
+fi
+
+echo "prepare-desktop-bundle-native-deps tests passed"


### PR DESCRIPTION
## Summary
- stage production-only agent/pi-mono `node_modules` for macOS packaging and prune packaged-only ballast
- dedupe matching pi-mono packages to the agent dependency tree with bundle-local symlinks
- strip the main desktop executable before signing and add a bundle-size harness for future reductions
- move Rewind frame extraction to AVFoundation-first with the ffmpeg fallback retained

## Size / dogfood
- `./scripts/bundle-size-harness.sh` built and ad-hoc signed `omi-bundle-size.app`
- prepared bundle: 723.8 MiB
- agent/node_modules: 173.2 MiB
- pi-mono/node_modules: 78.1 MiB
- main executable: 90.8 MiB
- pi symlinks: 154

## Tests
- `./scripts/bundle-size-harness.sh`
- `./scripts/agent-logic-harness.sh --node-only --skip-install`
- `./scripts/test-tool-surfaces.sh`
- `cd desktop/macos/pi-mono-extension && npm test`
- `bash desktop/macos/tests/test-prepare-desktop-bundle-native-deps.sh`
- `cd desktop/macos/agent && npx vitest run tests/codemagic-pi-mono-extension-ci.test.ts`
- `xcrun swift test --package-path Desktop --scratch-path /tmp/omi-swiftpm-rewind-frame-3423-final --filter RewindStorageVideoFrameExtractionTests`
- pre-push hook: desktop changelog validation, Swift build, optional formatters


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9017?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

