### PR TITLE
desktop: floating bar morphs into the notch island while active (thinking animation), any display

### DIFF
--- a/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
+++ b/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
@@ -435,6 +435,22 @@ final class DesktopAutomationActionRegistry {
       return ["sent": query]
     }
 
+    // Force the notch "thinking" indicator on/off so the spinning-Omi animation
+    // can be exercised without a mic. Same state a committed PTT turn sets in
+    // PushToTalkManager.finalize(); non-prod bridge only.
+    register(
+      name: "debug_thinking",
+      summary: "Force the floating-bar 'thinking' indicator on/off (visual verification)",
+      params: ["on"]
+    ) { params in
+      let on = boolParam(params["on"], default: true)
+      if on, !FloatingControlBarManager.shared.isVisible {
+        FloatingControlBarManager.shared.show()
+      }
+      FloatingControlBarManager.shared.barState?.isThinking = on
+      return ["isThinking": on ? "true" : "false"]
+    }
+
     // Send a message through the real main-window chat pipeline (ChatPage),
     // in-process via ViewModelContainer's ChatProvider — no synthetic mouse
     // or keyboard input, so it never touches the user's actual cursor.

--- a/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
+++ b/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
@@ -435,20 +435,22 @@ final class DesktopAutomationActionRegistry {
       return ["sent": query]
     }
 
-    // Force the notch "thinking" indicator on/off so the spinning-Omi animation
-    // can be exercised without a mic. Same state a committed PTT turn sets in
-    // PushToTalkManager.finalize(); non-prod bridge only.
+    // Force the floating-bar active state so the pill↔notch-island morph and the
+    // "thinking" animation can be exercised without a mic. Same flags a real PTT
+    // turn sets; non-prod bridge only. state = idle|listening|thinking|answering.
     register(
-      name: "debug_thinking",
-      summary: "Force the floating-bar 'thinking' indicator on/off (visual verification)",
-      params: ["on"]
+      name: "debug_bar_state",
+      summary: "Force floating-bar state: idle|listening|thinking|answering (visual verification)",
+      params: ["state"]
     ) { params in
-      let on = boolParam(params["on"], default: true)
-      if on, !FloatingControlBarManager.shared.isVisible {
-        FloatingControlBarManager.shared.show()
-      }
-      FloatingControlBarManager.shared.barState?.isThinking = on
-      return ["isThinking": on ? "true" : "false"]
+      let s = (params["state"] ?? "thinking").lowercased()
+      let mgr = FloatingControlBarManager.shared
+      guard let bar = mgr.barState else { return ["error": "no bar state"] }
+      if s != "idle", !mgr.isVisible { mgr.show() }
+      bar.isVoiceResponseActive = (s == "answering")
+      bar.isVoiceListening = (s == "listening")
+      bar.isThinking = (s == "thinking")
+      return ["state": s, "usesNotchIsland": bar.usesNotchIsland ? "true" : "false"]
     }
 
     // Send a message through the real main-window chat pipeline (ChatPage),

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarState.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarState.swift
@@ -91,6 +91,9 @@ struct FloatingBarNotification: Identifiable, Equatable {
 class FloatingControlBarState: NSObject, ObservableObject {
     static let visibleConversationReuseInterval: TimeInterval = 10 * 60
     static var voiceResponseWatchdogDelay: TimeInterval = 30
+    /// Safety cap: the "thinking" indicator self-clears after this long even if
+    /// no explicit response-start/teardown signal arrives, so it can never stick.
+    static var thinkingWatchdogDelay: TimeInterval = 25
 
     @Published var isRecording: Bool = false
     @Published var duration: Int = 0
@@ -166,10 +169,18 @@ class FloatingControlBarState: NSObject, ObservableObject {
                 isVoiceResponseWaiting = false
             }
             updateVoiceResponseWatchdog()
+            // A live voice response supersedes the "thinking" indicator.
+            if isVoiceResponseActive { isThinking = false }
         }
     }
     @Published var isVoiceResponseWaiting: Bool = false {
         didSet { updateVoiceResponseWatchdog() }
+    }
+    /// True while a committed Push-to-Talk query is being processed and no
+    /// response output (voice glow or conversation surface) has surfaced yet.
+    /// Drives the notch/pill "thinking" animation. Auto-clears via a watchdog.
+    @Published var isThinking: Bool = false {
+        didSet { updateThinkingWatchdog() }
     }
     var isVoiceResponseGlowActive: Bool {
         isVoiceResponseActive || isVoiceResponseWaiting
@@ -188,6 +199,7 @@ class FloatingControlBarState: NSObject, ObservableObject {
     @Published var currentQueryFromVoice: Bool = false
 
     private var voiceResponseWatchdogWorkItem: DispatchWorkItem?
+    private var thinkingWatchdogWorkItem: DispatchWorkItem?
 
     // Model selection
     @Published var selectedModel: String = ModelQoS.Claude.defaultSelection
@@ -222,6 +234,9 @@ class FloatingControlBarState: NSObject, ObservableObject {
         showingAIConversation = surface.isOpen
         showingAIResponse = surface.isResponseLike
         markConversationActivity()
+        // The conversation surface owns its own loading header once it opens, so
+        // hand the "thinking" indicator off to it (avoids showing both).
+        if surface.isOpen { isThinking = false }
     }
 
     func leaveAgentSurface() {
@@ -247,6 +262,7 @@ class FloatingControlBarState: NSObject, ObservableObject {
         showingAIConversation = false
         showingAIResponse = false
         isAILoading = false
+        isThinking = false
         isVoiceFollowUp = false
         voiceFollowUpTranscript = ""
         markConversationActivity()
@@ -305,6 +321,7 @@ class FloatingControlBarState: NSObject, ObservableObject {
         showingAIConversation = false
         showingAIResponse = false
         isAILoading = false
+        isThinking = false
         isVoiceFollowUp = false
         voiceFollowUpTranscript = ""
         currentQueryFromVoice = false
@@ -334,6 +351,22 @@ class FloatingControlBarState: NSObject, ObservableObject {
         voiceResponseWatchdogWorkItem = workItem
         DispatchQueue.main.asyncAfter(
             deadline: .now() + Self.voiceResponseWatchdogDelay,
+            execute: workItem
+        )
+    }
+
+    private func updateThinkingWatchdog() {
+        thinkingWatchdogWorkItem?.cancel()
+        thinkingWatchdogWorkItem = nil
+        guard isThinking else { return }
+
+        let workItem = DispatchWorkItem { [weak self] in
+            guard let self, self.isThinking else { return }
+            self.isThinking = false
+        }
+        thinkingWatchdogWorkItem = workItem
+        DispatchQueue.main.asyncAfter(
+            deadline: .now() + Self.thinkingWatchdogDelay,
             execute: workItem
         )
     }

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift
@@ -50,6 +50,9 @@ struct FloatingControlBarView: View {
                 ? FloatingControlBarWindow.notchCompactSideWidth
                 : FloatingControlBarWindow.notchActiveSideWidth
         }
+        if showingNotchThinking {
+            return FloatingControlBarWindow.notchThinkingSideWidth
+        }
         if agentPills.pills.isEmpty && !state.isVoiceListening {
             return FloatingControlBarWindow.notchCompactSideWidth
         }
@@ -129,6 +132,13 @@ struct FloatingControlBarView: View {
 
     private var showingNotchWaveform: Bool {
         state.isVoiceListening && !state.isVoiceFollowUp && !state.showingAIConversation
+    }
+
+    /// The notch "thinking" state: a PTT query is committed and being processed,
+    /// with no live listening or open conversation surface. Shows the spinning
+    /// Omi mark + "Thinking" in the notch lobes.
+    private var showingNotchThinking: Bool {
+        state.isThinking && !state.showingAIConversation && !state.isVoiceListening
     }
 
     private var shouldUseOmiChatOverlayHitTarget: Bool {
@@ -302,6 +312,10 @@ struct FloatingControlBarView: View {
                 (window as? FloatingControlBarWindow)?.setPillAgentListVisible(false)
             }
         }
+        .onChange(of: state.isThinking) { _, thinking in
+            guard state.usesNotchIsland else { return }
+            (window as? FloatingControlBarWindow)?.resizeForThinking(active: thinking)
+        }
         .onDisappear { state.setNotchHoverMenuOpen(false) }
     }
 
@@ -331,6 +345,11 @@ struct FloatingControlBarView: View {
                     .scaleEffect(0.72)
                     .frame(width: 28, height: 15)
                     .frame(width: 38, height: 27)
+            } else if showingNotchThinking {
+                NotchThinkingMark()
+                    .frame(width: 24, height: 24)
+                    .frame(width: notchSideWidth, height: notchChromeHeight, alignment: .trailing)
+                    .padding(.trailing, 2)
             } else {
                 ZStack(alignment: .trailing) {
                     NotchAgentPillsRowView(manager: agentPills, barWindow: window)
@@ -387,14 +406,22 @@ struct FloatingControlBarView: View {
             }
             .buttonStyle(.plain)
 
-            if notchSettingsHovering {
+            if showingNotchThinking {
+                Text("Thinking")
+                    .scaledFont(size: 11, weight: .medium)
+                    .foregroundStyle(.white.opacity(0.92))
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.75)
+                    .allowsHitTesting(false)
+                    .transition(.opacity)
+            } else if notchSettingsHovering {
                 notchSettingsButton
                     .zIndex(1)
                     .transition(.scale.combined(with: .opacity))
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
-        .padding(.leading, 5)
+        .padding(.leading, 6)
         .accessibilityElement(children: .contain)
     }
 
@@ -1454,6 +1481,29 @@ private struct NotchOmiMark: View {
         }
         .drawingGroup(opaque: false, colorMode: .linear)
         .accessibilityHidden(true)
+    }
+}
+
+/// The Omi mark rendered as a spinning "thinking" indicator. The ring's dots
+/// carry a brightness trail (bright head → faint tail) so the continuous
+/// rotation reads as a sweeping comet rather than a static ring of dots.
+private struct NotchThinkingMark: View {
+    @State private var angle: Double = 0
+
+    private static let trail: [Color] = (0..<8).map { index in
+        Color.white.opacity(1.0 - Double(index) * 0.1)
+    }
+
+    var body: some View {
+        NotchOmiMark(dotColors: Self.trail)
+            .rotationEffect(.degrees(angle))
+            .onAppear {
+                angle = 0
+                withAnimation(.linear(duration: 0.9).repeatForever(autoreverses: false)) {
+                    angle = 360
+                }
+            }
+            .accessibilityLabel("Thinking")
     }
 }
 

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift
@@ -109,6 +109,17 @@ struct FloatingControlBarView: View {
         )
         .background(Color.clear)
         .animation(.spring(response: 0.35, dampingFraction: 0.82), value: state.currentNotification?.id)
+        // Placed on the always-mounted root (not inside unifiedFloatingSurface) so
+        // the pill→island morph still fires when transitioning out of the idle pill.
+        .onChange(of: activeLifecycleKey) { _, _ in
+            (window as? FloatingControlBarWindow)?.syncActiveIsland()
+        }
+    }
+
+    /// Composite key for the active PTT lifecycle — any change drives the
+    /// pill ↔ notch-island morph (see FloatingControlBarWindow.syncActiveIsland).
+    private var activeLifecycleKey: String {
+        "\(state.isVoiceListening)-\(state.isThinking)-\(state.isVoiceResponseActive)"
     }
 
     /// Whether the bar chrome should stretch to fill the window width
@@ -311,10 +322,6 @@ struct FloatingControlBarView: View {
                 notchLogoHovering = false
                 (window as? FloatingControlBarWindow)?.setPillAgentListVisible(false)
             }
-        }
-        .onChange(of: state.isThinking) { _, thinking in
-            guard state.usesNotchIsland else { return }
-            (window as? FloatingControlBarWindow)?.resizeForThinking(active: thinking)
         }
         .onDisappear { state.setNotchHoverMenuOpen(false) }
     }

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
@@ -69,6 +69,9 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
     }
     static let notchCompactSideWidth: CGFloat = 30
     static let notchActiveSideWidth: CGFloat = 42
+    /// Wider lobes while "thinking" so the right lobe fits the word alongside the
+    /// spinning Omi mark on the left.
+    static let notchThinkingSideWidth: CGFloat = 62
     static let defaultNotchChromeHeight: CGFloat = 34
     static var notchChromeHeight: CGFloat { defaultNotchChromeHeight }
     static let notchActivationHeight: CGFloat = 17
@@ -356,6 +359,10 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
         // hardware so the fallback surface can be exercised locally. getenv so
         // values loaded from the bundle .env (BundleEnvironment) are seen too.
         if let forced = getenv("OMI_FORCE_NO_NOTCH"), String(cString: forced) == "1" { return false }
+        // Testing hook: force the notch-island presentation on non-notch hardware
+        // (external display / dev machine) so notch-only UI can be exercised
+        // locally. Mirror of OMI_FORCE_NO_NOTCH; NO_NOTCH wins if both are set.
+        if let forced = getenv("OMI_FORCE_NOTCH"), String(cString: forced) == "1" { return true }
         guard let screen else { return false }
         if #available(macOS 12.0, *) {
             if let leftArea = screen.auxiliaryTopLeftArea,
@@ -1645,6 +1652,40 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
         resizeToFrame(targetFrame, makeResizable: false, animated: true, animationDuration: 0.18)
     }
 
+    /// Size the notch to fit the "thinking" indicator (active width) while a PTT
+    /// query is being processed, then collapse it back once the response takes
+    /// over. Voice listening and the open conversation surface own sizing while
+    /// they are active, so this defers to them.
+    func resizeForThinking(active: Bool) {
+        guard notchModeEnabled, !state.showingAIConversation, state.currentNotification == nil else { return }
+        if active {
+            // No isVoiceListening guard here: entering "thinking" always follows a
+            // just-committed turn where listening is ending in the same tick.
+            resizeAnchored(
+                to: notchSize(sideWidth: Self.notchThinkingSideWidth),
+                makeResizable: false,
+                animated: true,
+                animationDuration: Self.askOmiAnimationDuration,
+                anchorTop: true
+            )
+        } else {
+            // A new listening turn (which clears isThinking) owns sizing — don't
+            // collapse out from under it.
+            guard !state.isVoiceListening else { return }
+            resizeForPTTState(expanded: false)
+        }
+    }
+
+    /// Pop the notch in from a near-zero scale the first time it is revealed via
+    /// Push-to-Talk (it stays hidden at launch on notched displays).
+    func playNotchRevealAnimation() {
+        guard notchModeEnabled else { return }
+        state.notchRevealProgress = 0.01
+        withAnimation(.easeOut(duration: 0.24)) {
+            state.notchRevealProgress = 1
+        }
+    }
+
     func showNotification(_ notification: FloatingBarNotification, animated: Bool = true) {
         guard !state.showingAIConversation else { return }
         state.currentNotification = notification
@@ -1981,6 +2022,10 @@ class FloatingControlBarManager {
     }
 
     private var window: FloatingControlBarWindow?
+    /// On notched displays the notch is not shown at launch — it reveals only
+    /// after the user's first Push-to-Talk press. Tracks whether that reveal has
+    /// happened this session so `showInitial()` can gate the launch presentation.
+    private var hasRevealedNotchThisSession = false
     private var snoozeTimer: Timer?
     private var recordingCancellable: AnyCancellable?
     private var durationCancellable: AnyCancellable?
@@ -2421,6 +2466,18 @@ class FloatingControlBarManager {
         }
     }
 
+    /// Launch-time presentation. On notched displays the notch stays hidden until
+    /// the user's first Push-to-Talk press (which calls `show()`); on other
+    /// displays it behaves exactly like `show()`.
+    func showInitial() {
+        if window?.usesNotchIslandForCurrentScreen == true, !hasRevealedNotchThisSession {
+            isEnabled = true
+            log("FloatingControlBarManager: showInitial() — notch hidden until first Push-to-Talk")
+            return
+        }
+        show()
+    }
+
     /// Show the floating bar and persist the preference.
     func show() {
         log("FloatingControlBarManager: show() called, window=\(window != nil), isVisible=\(window?.isVisible ?? false)")
@@ -2429,8 +2486,13 @@ class FloatingControlBarManager {
             log("FloatingControlBarManager: show() suppressed because bar is snoozed until \(snoozedUntil?.description ?? "?")")
             return
         }
+        let isFirstNotchReveal = window?.usesNotchIslandForCurrentScreen == true && !hasRevealedNotchThisSession
+        hasRevealedNotchThisSession = true
         window?.normalizeForTemporaryShow()
         window?.makeKeyAndOrderFront(nil)
+        if isFirstNotchReveal {
+            window?.playNotchRevealAnimation()
+        }
         log("FloatingControlBarManager: show() done, frame=\(window?.frame ?? .zero)")
 
         // Auto-focus input if AI conversation is open

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
@@ -162,14 +162,27 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
     /// Used by savePreChatCenterIfNeeded() to snap to the correct pill position
     /// if a new PTT query fires while the restore animation is still running.
     private var pendingRestoreOrigin: NSPoint?
+    /// The idle pill frame captured just before morphing into the active island
+    /// on a non-notch display, so the pill returns to the exact same spot.
+    private var savedPillFrame: NSRect?
     private var frameAnimationToken: Int = 0
     private var pendingFrameAnimationTarget: NSRect?
     private var startupDisplayRevalidationWorkItems: [DispatchWorkItem] = []
 
+    /// The bar adopts the notch-island presentation whenever it is actively
+    /// engaged — PTT listening, thinking, or speaking a reply — on ANY display,
+    /// so external monitors morph from the idle pill into the island too.
+    private var barWantsActiveIsland: Bool {
+        state.isVoiceListening || state.isThinking || state.isVoiceResponseGlowActive
+    }
     private var notchModeEnabled: Bool {
+        Self.screenHasCameraHousing(screenForPlacement) || barWantsActiveIsland
+    }
+    /// Hardware-only notch detection (ignores the transient active-island state) —
+    /// "does this display physically have a camera housing".
+    var usesNotchIslandForCurrentScreen: Bool {
         Self.screenHasCameraHousing(screenForPlacement)
     }
-    var usesNotchIslandForCurrentScreen: Bool { notchModeEnabled }
     private var screenForPlacement: NSScreen? {
         self.screen ?? NSApp.keyWindow?.screen ?? NSScreen.main ?? NSScreen.screens.first
     }
@@ -424,6 +437,13 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
 
     private func updateNotchIslandState() {
         let usesNotch = notchModeEnabled
+        // Leaving the idle pill for the active island on a non-notch display —
+        // remember the pill's exact spot so we can restore it when we return
+        // (otherwise the pill drifts to a recomputed top-center each cycle).
+        if usesNotch, !state.usesNotchIsland, !Self.screenHasCameraHousing(screenForPlacement),
+           !state.showingAIConversation, state.currentNotification == nil {
+            savedPillFrame = frame
+        }
         if state.usesNotchIsland != usesNotch {
             state.usesNotchIsland = usesNotch
         }
@@ -1656,24 +1676,63 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
     /// query is being processed, then collapse it back once the response takes
     /// over. Voice listening and the open conversation surface own sizing while
     /// they are active, so this defers to them.
-    func resizeForThinking(active: Bool) {
-        guard notchModeEnabled, !state.showingAIConversation, state.currentNotification == nil else { return }
-        if active {
-            // No isVoiceListening guard here: entering "thinking" always follows a
-            // just-committed turn where listening is ending in the same tick.
-            resizeAnchored(
-                to: notchSize(sideWidth: Self.notchThinkingSideWidth),
-                makeResizable: false,
-                animated: true,
-                animationDuration: Self.askOmiAnimationDuration,
-                anchorTop: true
-            )
+    /// Single authority for the pill ↔ notch-island morph across the active PTT
+    /// lifecycle (idle pill → listening → thinking → answering → idle pill).
+    /// Called whenever any active flag changes. Because notchModeEnabled is
+    /// active-aware, this engages the island on external monitors too.
+    func syncActiveIsland() {
+        // The chat panel and notifications own their own geometry.
+        guard !state.showingAIConversation, state.currentNotification == nil else { return }
+        guard let screen = screenForPlacement else { return }
+
+        let wasIsland = state.usesNotchIsland
+        updateNotchIslandState()  // sets state.usesNotchIsland + level from notchModeEnabled
+        let island = state.usesNotchIsland
+        let target = activeIslandTargetFrame(on: screen, island: island)
+
+        if wasIsland != island && island {
+            // Idle pill → active island: grow with the reveal pop.
+            styleMask.remove(.resizable)
+            animateGrowOutFromNotch(to: target)
+        } else if wasIsland != island && !island {
+            // Active island → idle pill: shrink back to the resting pill at the
+            // exact spot it left from (fall back to the computed top-center).
+            state.notchRevealProgress = 1
+            let pillFrame: NSRect
+            if let saved = savedPillFrame {
+                pillFrame = NSRect(origin: saved.origin, size: target.size)
+                savedPillFrame = nil
+            } else {
+                pillFrame = target
+            }
+            resizeToFrame(pillFrame, makeResizable: false, animated: true, animationDuration: 0.16)
         } else {
-            // A new listening turn (which clears isThinking) owns sizing — don't
-            // collapse out from under it.
-            guard !state.isVoiceListening else { return }
-            resizeForPTTState(expanded: false)
+            // Same mode, different sub-state (e.g. listening → thinking).
+            resizeToFrame(target, makeResizable: false, animated: true, animationDuration: Self.askOmiAnimationDuration)
         }
+    }
+
+    /// The window frame for the current active sub-state, in the given mode.
+    private func activeIslandTargetFrame(on screen: NSScreen, island: Bool) -> NSRect {
+        let size: NSSize
+        if island {
+            let base: NSSize
+            if state.isVoiceListening {
+                base = notchSize(sideWidth: Self.notchActiveSideWidth, for: screen)
+            } else if state.isThinking {
+                base = notchSize(sideWidth: Self.notchThinkingSideWidth, for: screen)
+            } else {
+                // Answering (voice-response glow) or a brief transient — collapsed island.
+                base = notchCollapsedSize(for: screen)
+            }
+            size = responseGlowWindowSize(forSurfaceSize: base, usesNotchIsland: true)
+        } else {
+            size = state.isVoiceListening ? Self.voiceBarSize : Self.minBarSize
+        }
+        return NSRect(
+            origin: topCenteredOrigin(for: size, on: screen, usesNotchIsland: island),
+            size: size
+        )
     }
 
     /// Pop the notch in from a near-zero scale the first time it is revealed via

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
@@ -294,6 +294,7 @@ class PushToTalkManager: ObservableObject {
       SystemAudioMuteController.shared.muteForListening()
     }
     state = .listening
+    barState?.isThinking = false
     startActiveTracer()
     isCurrentSessionFollowUp = barState?.showingAIResponse == true
     transcriptSegments = []
@@ -402,6 +403,7 @@ class PushToTalkManager: ObservableObject {
     }
     stopAudioTranscription()
     state = .idle
+    barState?.isThinking = false
     transcriptSegments = []
     lastInterimText = ""
     currentContextSnapshot = nil
@@ -705,8 +707,10 @@ class PushToTalkManager: ObservableObject {
       silentMicRecoveryPolicy.recordSuccessfulHubTurn()
       DesktopDiagnosticsManager.shared.recordPTTCommitted(mode: finalizedMode, hubActive: true)
       barState?.beginVoiceResponseWaiting()
-      // Collapse the bar on release — the hub speaks its reply as audio (no inline
-      // status UI), the same as the legacy voice path.
+      // Show the "thinking" indicator in the notch during the release→first-audio
+      // gap. It clears when the hub's spoken reply starts (isVoiceResponseActive),
+      // so the glow takes over.
+      barState?.isThinking = true
       updateBarState()
       AnalyticsManager.shared.floatingBarPTTEnded(
         mode: finalizedMode, hadTranscript: true, transcriptLength: 0)
@@ -747,6 +751,11 @@ class PushToTalkManager: ObservableObject {
       }
     }
 
+    // Past the silence gate — a real turn will be transcribed and answered. Show
+    // the "thinking" indicator through the transcription/first-token gap; it hands
+    // off to the conversation surface (or voice glow) the moment output arrives.
+    barState?.isThinking = true
+    updateBarState()
 
     // Realtime omni: commit the turn and wait for the final transcript.
     if isOmniSTT {
@@ -1437,7 +1446,10 @@ class PushToTalkManager: ObservableObject {
     guard !skipResize && !barState.isVoiceFollowUp && !barState.showingAIConversation && !isOnboarding else { return }
     if barState.isVoiceListening && !wasListening {
       FloatingControlBarManager.shared.resizeForPTT(expanded: true)
-    } else if !barState.isVoiceListening && wasListening {
+    } else if !barState.isVoiceListening && wasListening && !(barState.isThinking && barState.usesNotchIsland) {
+      // Keep the notch expanded while "thinking" so the indicator has room; the
+      // view's isThinking observer collapses it when the response arrives. The
+      // pill (non-notch) display has no thinking indicator, so it collapses now.
       FloatingControlBarManager.shared.resizeForPTT(expanded: false)
     }
   }

--- a/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
@@ -223,7 +223,7 @@ struct DesktopHomeView: View {
               FloatingControlBarManager.shared.setup(
                 appState: appState, chatProvider: viewModelContainer.chatProvider)
               if FloatingControlBarManager.shared.isEnabled {
-                FloatingControlBarManager.shared.show()
+                FloatingControlBarManager.shared.showInitial()
               }
 
               // Set up push-to-talk voice input

--- a/desktop/macos/changelog/unreleased/20260704-ptt-thinking-indicator.json
+++ b/desktop/macos/changelog/unreleased/20260704-ptt-thinking-indicator.json
@@ -1,3 +1,3 @@
 {
-    "change": "Added a spinning Omi \"Thinking\" animation in the notch while a Push-to-Talk question is being processed"
+    "change": "The floating bar now grows into the notch island while Omi is listening, thinking (spinning Omi mark + \"Thinking\"), or answering — on external monitors too — and collapses back to the compact pill when idle"
 }

--- a/desktop/macos/changelog/unreleased/20260704-ptt-thinking-indicator.json
+++ b/desktop/macos/changelog/unreleased/20260704-ptt-thinking-indicator.json
@@ -1,0 +1,3 @@
+{
+    "change": "Added a spinning Omi \"Thinking\" animation in the notch while a Push-to-Talk question is being processed"
+}


### PR DESCRIPTION
## What
The desktop floating bar is a compact grey pill when idle and now **morphs into the notch island** whenever Omi is actively engaged — Push-to-Talk **listening, thinking, or answering** — on **any display, including external monitors**. During the processing gap it shows a spinning Omi mark + "Thinking". It collapses back to the pill when idle.

Previously the island was tied to physical-notch hardware, so on an external monitor the active states only showed the little pill.

## How
- `notchModeEnabled` is now active-aware (`screenHasCameraHousing || barWantsActiveIsland`).
- `syncActiveIsland()` is the single authority for the pill↔island morph, driven by a composite `onChange` on the always-mounted view root.
- New `FloatingControlBarState.isThinking` flag set at the PTT commit points, cleared on response-start / new-turn / teardown, with a watchdog so it can't stick.
- `savedPillFrame` restores the exact idle pill spot (no per-cycle drift).
- Non-prod `debug_bar_state` automation action + `OMI_FORCE_NOTCH` test hook for mic-less verification.

## Verification
Built + ran locally against the prod backend; drove idle/listening/thinking/answering via the automation bridge on an external monitor and confirmed the pill↔island morph, the spinning "Thinking" indicator, and a stable pill position. Nik tested the real path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9020?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

