### PR TITLE
fix(desktop): screen capture starts seconds after launch instead of 30-60s (launch-anchored warmup)

### DIFF
--- a/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
@@ -42,6 +42,10 @@ struct DesktopHomeView: View {
   @State private var lastActivationRefresh = Date.distantPast
   @State private var didScheduleAgentVMProvisioning = false
   @State private var proactiveMonitoringStartGate = RetryableDelayedStartGate()
+  // Anchor for the proactive-monitoring warmup budget. Captured at view
+  // creation (≈ launch) so the delay is spent once per session, not once per
+  // trigger — see StartupWarmupPolicy.remainingProactiveAssistantsStartDelay.
+  @State private var proactiveMonitoringWarmupAnchor = Date()
   @State private var didScheduleConversationWarmup = false
   @State private var initialFileIndexingBackfill = DelayedFileIndexingBackfillState()
 
@@ -767,9 +771,14 @@ struct DesktopHomeView: View {
   private func scheduleProactiveMonitoringStart(reason: String) {
     guard proactiveMonitoringStartGate.reserve() else { return }
 
+    let delay = StartupWarmupPolicy.remainingProactiveAssistantsStartDelay(
+      elapsedSinceLaunch: Date().timeIntervalSince(proactiveMonitoringWarmupAnchor))
+    log(
+      "DesktopHomeView: Scheduling screen analysis start in \(String(format: "%.1f", delay))s (\(reason))"
+    )
     let scheduled = viewModelContainer.scheduleSessionWarmup(
       id: .proactiveAssistantsStart,
-      delay: StartupWarmupPolicy.proactiveAssistantsStartDelay,
+      delay: delay,
       onCancel: { proactiveMonitoringStartGate.finishAttempt() }
     ) {
       let plugin = ProactiveAssistantsPlugin.shared

--- a/desktop/macos/Desktop/Sources/StartupWarmupPolicy.swift
+++ b/desktop/macos/Desktop/Sources/StartupWarmupPolicy.swift
@@ -103,9 +103,20 @@ enum StartupWarmupPolicy {
     static let floatingBarPlanFetchDelay: TimeInterval = 0.0
     static let crispInitialPollDelay: TimeInterval = 15.0
     static let agentVMProvisioningDelay: TimeInterval = 20.0
-    static let proactiveAssistantsStartDelay: TimeInterval = 30.0
+    static let proactiveAssistantsStartDelay: TimeInterval = 6.0
     static let conversationWarmupDelay: TimeInterval = 6.0
     static let transcriptionRetryRecoveryDelay: TimeInterval = 8.0
     static let recurringTaskSchedulerInitialDelay: TimeInterval = 12.0
     static let initialFileIndexingDelay: TimeInterval = 45.0
+
+    /// Remaining delay before proactive monitoring may start, measured from a
+    /// launch anchor rather than from the triggering event. The warmup delay
+    /// exists to keep capture out of the busy launch window, so late triggers
+    /// (API-key load, app re-activation) must not re-pay the full delay —
+    /// that compounding is what made the Capture pill sit "paused" for
+    /// 30-60+ seconds after launch. Negative elapsed values (clock changes)
+    /// clamp to the full delay.
+    static func remainingProactiveAssistantsStartDelay(elapsedSinceLaunch: TimeInterval) -> TimeInterval {
+        max(0, proactiveAssistantsStartDelay - max(0, elapsedSinceLaunch))
+    }
 }

--- a/desktop/macos/Desktop/Tests/StartupWarmupPolicyTests.swift
+++ b/desktop/macos/Desktop/Tests/StartupWarmupPolicyTests.swift
@@ -38,6 +38,36 @@ final class StartupWarmupPolicyTests: XCTestCase {
         )
     }
 
+    func testProactiveMonitoringRemainingDelayIsFullAtLaunch() {
+        XCTAssertEqual(
+            StartupWarmupPolicy.remainingProactiveAssistantsStartDelay(elapsedSinceLaunch: 0),
+            StartupWarmupPolicy.proactiveAssistantsStartDelay
+        )
+    }
+
+    func testProactiveMonitoringRemainingDelayCountsDownFromLaunch() {
+        XCTAssertEqual(
+            StartupWarmupPolicy.remainingProactiveAssistantsStartDelay(elapsedSinceLaunch: 2.0),
+            StartupWarmupPolicy.proactiveAssistantsStartDelay - 2.0,
+            accuracy: 0.0001
+        )
+    }
+
+    func testProactiveMonitoringRemainingDelayIsZeroOnceWindowHasElapsed() {
+        XCTAssertEqual(
+            StartupWarmupPolicy.remainingProactiveAssistantsStartDelay(
+                elapsedSinceLaunch: StartupWarmupPolicy.proactiveAssistantsStartDelay + 60),
+            0
+        )
+    }
+
+    func testProactiveMonitoringRemainingDelayClampsNegativeElapsedToFullDelay() {
+        XCTAssertEqual(
+            StartupWarmupPolicy.remainingProactiveAssistantsStartDelay(elapsedSinceLaunch: -5),
+            StartupWarmupPolicy.proactiveAssistantsStartDelay
+        )
+    }
+
     func testConversationWarmupWaitsUntilAfterDeferredWarmupStarts() {
         XCTAssertGreaterThan(
             StartupWarmupPolicy.conversationWarmupDelay,

--- a/desktop/macos/changelog/unreleased/20260704-capture-startup-delay.json
+++ b/desktop/macos/changelog/unreleased/20260704-capture-startup-delay.json
@@ -1,0 +1,3 @@
+{
+  "change": "Screen capture now starts within seconds of launch instead of staying paused for 30-60 seconds"
+}


### PR DESCRIPTION
## Summary

- Problem: since #8013, the home-screen "Capture" pill stays **paused for 30–60+ seconds after every launch** before screen capture starts. `StartupWarmupPolicy.proactiveAssistantsStartDelay` (30s) is applied as a fixed delay **from whatever event triggers scheduling**, not from launch — so a launch with cached keys waits 30s, a launch whose API keys load late waits key-load + 30s (~40–60s), and re-activating the app (`reason: "app active"`, e.g. right after granting Screen Recording) waits a fresh 30s even minutes after launch. For a product whose core feature is capturing your screen, the first half-minute of every session is silently lost.
- What changed: the warmup delay is now a **launch-anchored budget** — `remainingProactiveAssistantsStartDelay(elapsedSinceLaunch:)` returns `max(0, delay − elapsed)`, so the delay is paid once per session, not once per trigger — and the budget is reduced from 30s to **6s**. A `Scheduling screen analysis start in Xs (reason)` log line makes the effective delay observable.
- What did NOT change (scope boundary): the staged-warmup ordering from #8013 is preserved — capture still starts strictly after `initialSettingsSyncDelay` (5s) so a remote `screenAnalysisEnabled=false` lands before monitoring starts, and still after `deferredWarmupDelay` (2s). Both existing ordering tests pass unchanged. No other warmup delays are touched.

## Linked Issue / Bounty

- N/A — independent contribution (behavioral regression introduced by #8013)

## Root Cause (bug fixes only)

- Root cause: #8013 introduced `proactiveAssistantsStartDelay = 30.0` and `scheduleProactiveMonitoringStart()` passes it verbatim to `scheduleSessionWarmup` on every trigger (`launch`, `key load`, `app active`). The delay's purpose is to keep capture out of the busy launch window, but measuring it from the trigger instead of from launch makes late triggers re-pay the full 30s.
- Why it wasn't caught before: #8013 was validated with policy unit tests and build checks ("without changing product behavior"); the pill-stays-paused effect only shows up when running the app and watching the first minute. Verified on production v0.12.0 (which contains both #8013 and the later paywall launch fix): capture consistently starts ~30s after window appear.

## How It Works

`StartupWarmupPolicy.remainingProactiveAssistantsStartDelay(elapsedSinceLaunch:)` computes the remaining launch-anchored budget (clamping negative elapsed to the full delay). `DesktopHomeView` captures a `proactiveMonitoringWarmupAnchor = Date()` when the view is created (≈ launch) and passes the computed remainder to `scheduleSessionWarmup`. Behavior by scenario:

| Scenario | Before | After |
|---|---|---|
| Launch, keys cached | 30s | 6s |
| Launch, keys load at +9s | ~39s | 9s (budget already elapsed → starts at key load) |
| Slow key fetch (e.g. +30s) | ~60s | at key load |
| App re-activation (e.g. after permission grant) | +30s | immediate |

## Change Type

- [x] Bug fix

## Scope

- [x] Desktop app (Swift/macOS)

## Security Impact

- New permissions or capabilities introduced? No
- Auth or token handling changed? No
- Data access scope changed (screen data, OCR, user data)? No — capture still requires the same permission and enabled setting; it just starts sooner
- New or changed network calls? No
- Plugin or tool execution surface changed? No

## Testing

- [x] Built locally — `xcrun swift build -c debug --package-path Desktop`, clean (macOS 26.5.1, arm64)
- [x] Manual verification: launch/key-load/app-active timing on a named bundle (see Human Verification)
- [x] Existing tests pass — `StartupWarmupPolicyTests` (including the two ordering invariants that pin capture after settings sync and deferred warmup)
- [x] New tests added — 4 cases covering the anchored-budget helper: full delay at elapsed 0, countdown mid-window, zero after the window, negative-elapsed clamp

## Human Verification

Verified on a dedicated named bundle (`com.omi.omi-verify-capture`) built from this branch, signed in, macOS 26.5.1:

- Verified scenarios:
  1. **Launch with permission granted**: capture running **5.5s after the main window appeared** (`Scheduling screen analysis start in 5.2s (launch)` → `Screen analysis started (launch, delayed)`), versus +30.4s measured on production v0.12.0.
  2. **Launch-anchoring**: the scheduled delay is the launch budget minus elapsed time (logged `5.2s`/`5.4s` across launches depending on view-appear latency), and the start attempt consistently fired at launch+6s.
  3. **Permission still gates correctly**: with Screen Recording not yet granted, the launch+6s attempt entered the existing dialog-free retry loop and left the setting enabled; after granting in System Settings, the next launch started capture at +5.5s and macOS registered active capture usage for the bundle (`ScreenCaptureApprovals.plist` LastUsed).
- Edge cases checked: trigger arriving after the window has fully elapsed (app-active → 0.0s delay); re-launch repeats the 6s budget per session.
- What was **not** verified: Intel macs; the `key load` trigger with a genuinely slow network fetch (exercised the code path via the anchored computation instead).

## Evidence

- [x] Log output (before/after)

Production v0.12.0 (before — fixed 30s from window appear):

```
[13:33:09.220] DesktopHomeView: Showing mainContent (signed in and onboarded)
[13:33:18.221] DesktopHomeView: API keys loaded — retrying deferred services
[13:33:39.612] DesktopHomeView: Screen analysis started (launch, delayed)   ← +30.4s
```

This branch (after):

```
[19:06:38.366] DesktopHomeView: Showing mainContent (signed in and onboarded)
[19:06:38.410] DesktopHomeView: Scheduling screen analysis start in 5.2s (launch)
[19:06:43.830] DesktopHomeView: Screen analysis started (launch, delayed)      ← +5.5s
```

Permission-missing launch on the same build (retry loop intact, timing unchanged):

```
[18:56:41.588] DesktopHomeView: Scheduling screen analysis start in 5.4s (launch)
[18:56:47.320] Screen recording permission not yet granted, retrying in 2.0s (attempt 1/3)
```

## Docs

- [x] N/A — no docs impact (changelog fragment added)

## Performance, Privacy, and Reliability

Launch performance: capture-start work now runs at +6s instead of +30s. This sits after the first-window render and the 5s settings sync; the heavier startup warmups (`crispInitialPoll` 15s, `agentVMProvisioning` 20s, `initialFileIndexing` 45s) remain untouched, so launch responsiveness — the goal of #8013 — is preserved. If capture start measurably contends at +6s, the constant is a single knob to tune; the launch-anchoring fix stands on its own regardless of the chosen value.

## Migration / Backward Compatibility

- Backward compatible? Yes
- Migration needed? No

## Risks and Mitigations

- Risk: starting capture at +6s could contend with remaining launch work on slow machines.
  - Mitigation: still strictly after settings sync (5s) and deferred warmup (2s); ordering tests enforce this. The 30s value predates any measured contention data for capture specifically.
- Risk: remote `screenAnalysisEnabled=false` arriving after capture starts (settings sync slower than 6s on a slow network) would leave monitoring running this session.
  - Mitigation: pre-existing behavior — nothing stops a running monitor on remote-sync disable today, at 30s or 6s; the 5s-before-6s ordering keeps the common case correct. A remote-sync stop hook would be a separable follow-up.

## AI Disclosure

- Tools used: Claude Code
- AI-assisted portions: diagnosis (production log timeline analysis), fix implementation, tests, and this PR body
- How you verified correctness: measured the regression on production v0.12.0 logs; built and ran a named bundle from this branch and measured launch→capture-start and app-active→start timings from app logs; ran the warmup-policy test suite.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9021?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

