### PR TITLE
desktop: keep the notch island in sync during voice-reply warm-up

### DIFF
--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift
@@ -119,7 +119,7 @@ struct FloatingControlBarView: View {
     /// Composite key for the active PTT lifecycle — any change drives the
     /// pill ↔ notch-island morph (see FloatingControlBarWindow.syncActiveIsland).
     private var activeLifecycleKey: String {
-        "\(state.isVoiceListening)-\(state.isThinking)-\(state.isVoiceResponseActive)"
+        "\(state.isVoiceListening)-\(state.isThinking)-\(state.isVoiceResponseGlowActive)"
     }
 
     /// Whether the bar chrome should stretch to fill the window width
@@ -149,7 +149,8 @@ struct FloatingControlBarView: View {
     /// with no live listening or open conversation surface. Shows the spinning
     /// Omi mark + "Thinking" in the notch lobes.
     private var showingNotchThinking: Bool {
-        state.isThinking && !state.showingAIConversation && !state.isVoiceListening
+        (state.isThinking || state.isVoiceResponseWaiting)
+            && !state.showingAIConversation && !state.isVoiceListening
     }
 
     private var shouldUseOmiChatOverlayHitTarget: Bool {

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
@@ -1719,7 +1719,7 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
             let base: NSSize
             if state.isVoiceListening {
                 base = notchSize(sideWidth: Self.notchActiveSideWidth, for: screen)
-            } else if state.isThinking {
+            } else if state.isThinking || state.isVoiceResponseWaiting {
                 base = notchSize(sideWidth: Self.notchThinkingSideWidth, for: screen)
             } else {
                 // Answering (voice-response glow) or a brief transient — collapsed island.

--- a/desktop/macos/changelog/unreleased/20260704-notch-island-waiting-sync.json
+++ b/desktop/macos/changelog/unreleased/20260704-notch-island-waiting-sync.json
@@ -1,0 +1,3 @@
+{
+    "change": "The floating bar's notch island now stays in sync while a voice reply is warming up, so it no longer briefly flickers back to the pill during that gap"
+}


### PR DESCRIPTION
Follow-up to #9020. `#9008`'s `isVoiceResponseWaiting` (hub warm-up) could toggle without changing `isThinking` / `isVoiceResponseActive`, so the active-island morph and the "thinking" indicator briefly desynced from the window frame during the warm-up gap.

- `showingNotchThinking` and the island target width now also react to `isVoiceResponseWaiting`, so the spinner + island stay up through warm-up.
- `activeLifecycleKey` observes `isVoiceResponseGlowActive` (active OR waiting), so the pill↔island morph fires across the full lifecycle including warm-up start/end.

## Verification
Built + ran locally (named bundle, prod backend); drove idle/thinking/answering via the automation bridge on an external monitor — pill (40×14) ↔ island (314–378px) morph, spinning "Thinking", stable pill return. Compiles clean; base (merged #9020) already builds + released.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9022?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

