### PR TITLE
fix(desktop): honor stop during chat preflight

### DIFF
--- a/desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift
+++ b/desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift
@@ -136,6 +136,7 @@ actor AgentRuntimeProcess {
   private var receivedInit = false
   private var advertisedAgentControlTools: Set<String> = []
   private var isRestarting = false
+  private var expectedCancelledRequests: Set<RuntimeMessage.RequestKey> = []
 
   var isAlive: Bool { isRunning }
 
@@ -313,7 +314,14 @@ actor AgentRuntimeProcess {
     if let ownerId = currentOwnerId() {
       dict["ownerId"] = ownerId
     }
-    sendJson(dict)
+    guard sendJson(dict) else {
+      activeRequests.removeValue(forKey: requestKey)
+      request.continuation.resume(throwing: BridgeError.stopped)
+      return
+    }
+    activeRequests.removeValue(forKey: requestKey)
+    expectedCancelledRequests.insert(requestKey)
+    request.continuation.resume(throwing: BridgeError.stopped)
   }
 
   func query(
@@ -907,11 +915,18 @@ actor AgentRuntimeProcess {
   }
 
   private func completeRequest(_ message: RuntimeMessage) {
-    guard let requestKey = message.requestKey, let request = activeRequests.removeValue(forKey: requestKey) else {
+    let terminalStatus = message.payload["terminalStatus"] as? String
+    guard let requestKey = message.requestKey else {
       log("AgentRuntimeProcess: dropping unroutable result")
       return
     }
-    let terminalStatus = message.payload["terminalStatus"] as? String
+    guard let request = activeRequests.removeValue(forKey: requestKey) else {
+      if terminalStatus == "cancelled", expectedCancelledRequests.remove(requestKey) != nil {
+        return
+      }
+      log("AgentRuntimeProcess: dropping unroutable result")
+      return
+    }
     if terminalStatus == "cancelled" {
       request.continuation.resume(throwing: BridgeError.stopped)
       return

--- a/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
@@ -891,12 +891,14 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
     /// action can re-issue the user's last prompt. Cleared after a
     /// successful re-send or on dismiss to avoid stale retries.
     private var lastFailedPrompt: String?
+    private var pendingErrorRecoveryPrompt: String?
 
     /// Monotonically-incremented id for each sendMessage / stopAgent cycle.
     /// Watchdog tasks capture their gen and only reset state if it still
     /// matches — so a watchdog fired by a stuck send #N won't cancel a
     /// later, healthy send #N+1. See sendMessage() and stopAgent().
     private var sendGeneration: Int = 0
+    private var activeBridgeSendGeneration: Int?
 
     /// Set to true during onboarding so the ACP session ID is persisted for restart recovery.
     var isOnboarding = false
@@ -3166,16 +3168,25 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
             return false
         }
         isStopping = true
+        let stoppedGen = sendGeneration
+        sendGeneration += 1
         let myGen = sendGeneration
         Task {
-            await agentBridge.interrupt()
-            // Normal path: interrupt → bridge emits final result or .stopped →
-            // sendMessage's do/catch resets isSending via its finally (line 2631).
-            // Fallback: if the bridge drops the turn_end as "stray" (known
-            // sleep/wake flake — see PR where this watchdog was added), the
-            // for-await in sendMessage hangs forever and isSending stays true.
-            // After a short grace, force-release so the user's next query isn't
-            // silently swallowed by the guard at sendMessage:start.
+            let shouldInterruptBridge = await MainActor.run { () -> Bool in
+                guard self.isSending,
+                      self.sendGeneration == myGen,
+                      self.activeBridgeSendGeneration == stoppedGen else {
+                    return false
+                }
+                self.activeBridgeSendGeneration = nil
+                return true
+            }
+            if shouldInterruptBridge {
+                await agentBridge.interrupt()
+            }
+            // Normal path: interrupt → bridge emits final result or .stopped.
+            // Fallback: if the bridge drops the turn_end as "stray", force-release
+            // after a short grace so the user's next query is not silently swallowed.
             try? await Task.sleep(nanoseconds: 3_000_000_000)
             await MainActor.run {
                 if self.isSending && self.sendGeneration == myGen {
@@ -3674,6 +3685,7 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
         let tracer = QueryTracerContext.current
 
         isSending = true
+        isStopping = false
         activeTurnOwner = turnOwner
         errorMessage = nil
         currentError = nil
@@ -3704,6 +3716,11 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
             return nil
         }
         tracer?.end("bridge_ensure", metadata: ["status": "ok"])
+        guard sendGeneration == sendGen else {
+            tracer?.finalize(tokenCount: 0, model: model ?? modelOverride)
+            clearSendLockState()
+            return nil
+        }
 
         // Show upgrade prompt if over threshold but don't block the message.
         // Never for paid/BYOK users — they aren't subject to the free Omi spend cap.
@@ -3729,6 +3746,11 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
             }
             sessionId = sid
         }
+        guard sendGeneration == sendGen else {
+            tracer?.finalize(tokenCount: 0, model: model ?? modelOverride)
+            clearSendLockState()
+            return nil
+        }
 
         // Safety-net watchdog: if this specific send is still "in flight"
         // 3 minutes from now, something in the bridge / stream pipeline has
@@ -3738,11 +3760,22 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
         // by the "already sending" guard. The generation check means the
         // watchdog only fires if no later send has replaced this one.
         Task { [weak self] in
-            try? await Task.sleep(nanoseconds: 180_000_000_000)
-            await MainActor.run {
-                guard let self = self, self.isSending, self.sendGeneration == sendGen else { return }
+            do {
+                try await Task.sleep(nanoseconds: 180_000_000_000)
+            } catch {
+                return
+            }
+            guard let self else { return }
+            let stillStuck = await MainActor.run { () -> Bool in
+                guard self.isSending, self.sendGeneration == sendGen else { return false }
                 log("ChatProvider: send watchdog fired at 180s — bridge is stuck; force-resetting")
-                self.releaseSendLock(sendGeneration: sendGen)
+                return true
+            }
+            guard stillStuck else { return }
+            await self.agentBridge.interrupt()
+            await MainActor.run {
+                guard self.isSending, self.sendGeneration == sendGen else { return }
+                _ = self.releaseSendLock(sendGeneration: sendGen)
                 self.errorMessage = "Response took too long. Try again."
             }
         }
@@ -3754,6 +3787,11 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
         var attachmentsForMessage: [ChatAttachment] = []
         if !pendingAttachments.isEmpty {
             let ok = await awaitPendingUploads()
+            guard sendGeneration == sendGen else {
+                tracer?.finalize(tokenCount: 0, model: model ?? modelOverride)
+                clearSendLockState()
+                return nil
+            }
             if !ok {
                 releaseSendLock(sendGeneration: sendGen)
                 errorMessage = "Some attachments failed to upload. Remove them and try again."
@@ -3892,6 +3930,7 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
             startedAtMs: turnStartMs
         )
 
+        var stoppedByUser = false
         do {
             // Use the system prompt built at warmup. The agent bridge applies it only
             // at session/new; for the normal reused-session path it is ignored.
@@ -4171,6 +4210,7 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
                 ? basePromptForBridge
                 : "\(bridgePromptContexts.joined(separator: "\n\n"))\n\n\(basePromptForBridge)"
 
+            activeBridgeSendGeneration = sendGen
             let queryResult = try await agentBridge.query(
                 prompt: promptForBridge,
                 systemPrompt: systemPrompt,
@@ -4204,6 +4244,7 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
                     }
                 }
             )
+            activeBridgeSendGeneration = nil
             if let coordinatorCompletionDeltaContext {
                 // Acknowledge against the exact surface the delta was peeked from,
                 // so main chat and notch stay independent consumers.
@@ -4420,6 +4461,7 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
             }
             completedResponseText = messageText
         } catch {
+            activeBridgeSendGeneration = nil
             // QueryTracer: error path — close spans and write the (partial) trace
             // so failed/timed-out queries still show up in benchmarks.
             tracer?.end("ttft")
@@ -4511,6 +4553,7 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
             // Both surfaces coexist — only one is active at a time per
             // turn.
             if let bridgeError = error as? BridgeError, case .stopped = bridgeError {
+                stoppedByUser = true
                 // User stopped — no error to show, but the card system
                 // still surfaces .interrupted so users can resume.
                 if let card = ChatErrorState.from(bridgeError) {
@@ -4529,7 +4572,13 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
             }
         }
 
-        let releasedCurrentGeneration = releaseSendLock(sendGeneration: sendGen)
+        let releasedCurrentGeneration: Bool
+        if stoppedByUser, isStopping, sendGeneration != sendGen {
+            clearSendLockState()
+            releasedCurrentGeneration = false
+        } else {
+            releasedCurrentGeneration = releaseSendLock(sendGeneration: sendGen)
+        }
 
         // If follow-ups were queued while we were running, chain the oldest as a new full query.
         // Each chained query drains one item; this preserves user barge-in order without
@@ -4557,11 +4606,22 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
     @discardableResult
     private func releaseSendLock(sendGeneration generation: Int) -> Bool {
         guard sendGeneration == generation else { return false }
+        clearSendLockState()
+        return true
+    }
+
+    private func clearSendLockState() {
         isSending = false
         isStopping = false
+        activeBridgeSendGeneration = nil
         activeTurnOwner = nil
         activeFollowUpContext = nil
-        return true
+        if let prompt = pendingErrorRecoveryPrompt {
+            pendingErrorRecoveryPrompt = nil
+            Task { [weak self] in
+                await self?.sendMessage(prompt)
+            }
+        }
     }
 
     /// Generate a title for the session using LLM
@@ -5058,6 +5118,15 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
         switch action {
         case .retry:
             if let prompt = promptToRetry, !prompt.isEmpty {
+                if isSending {
+                    if isStopping {
+                        pendingErrorRecoveryPrompt = prompt
+                        return
+                    }
+                    currentError = error
+                    lastFailedPrompt = prompt
+                    return
+                }
                 await sendMessage(prompt)
             }
         case .dismiss:


### PR DESCRIPTION
## Summary

- Problem: moving `isSending = true` earlier made the chat Stop button tappable during pre-flight work, but the send path did not honor a Stop until the bridge query started.
- What changed: Stop now bumps the send generation, pre-flight awaits abort when that generation changes, the 180s watchdog interrupts the bridge before releasing UI state, and accepted runtime interrupts retire their active request continuation.
- What changed: interrupted retry recovery now queues a Resume tap made while Stop cleanup is still unwinding, then replays it after the send lock releases instead of dropping it on the `isSending` guard.
- What did NOT change (scope boundary): no chat UX redesign, no model/provider behavior change, no desktop changelog entry because this is internal correctness hardening for an existing user-facing flow.

## Linked Issue / Bounty

- Closes N/A
- Related N/A — follow-up to review feedback on the instant-loading-feedback branch.

## Root Cause (bug fixes only)

- Root cause: after `isSending` was hoisted above bridge/session/upload pre-flight awaits, `stopAgent()` could mutate Stop state and `sendGeneration` while `sendMessage()` continued with the stale generation and still appended/query-started the turn.
- Root cause: the watchdog only released UI state after 180s and did not interrupt the bridge/runtime request first, leaving a possible live continuation behind.
- Root cause: runtime interrupt could be acknowledged while the runtime later emitted an abort result as a stray message; Swift kept the active request continuation until that late result path.
- Why it wasn't caught before: the original change targeted instant loading feedback and did not exercise Stop during cold-start/pre-flight awaits or Resume during the short Stop cleanup window.

## How It Works

`sendMessage()` captures `sendGen` after it marks the turn as sending. After each pre-flight await (`ensureBridgeStarted()`, session selection/creation, and pending uploads), it aborts if `sendGeneration` changed, which indicates Stop was tapped before the bridge query started.

`stopAgent()` increments `sendGeneration` before interrupting so stale in-flight sends cannot continue as current work. The runtime interrupt path marks the active request interrupted, sends the interrupt message, removes the active request, and resumes the continuation with `.stopped` once the interrupt command is accepted.

The send watchdog now checks that the same generation is still stuck, interrupts the bridge, rechecks, and only then releases the send lock and shows the timeout message.

For the interrupted error card, Resume still replays the last prompt as before. If Resume is tapped while Stop cleanup is still holding `isSending`, the prompt is queued and replayed from `releaseSendLock()` as soon as the stopped turn actually unlocks.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Chore / infra

## Scope

- [ ] Mobile app (Flutter)
- [x] Desktop app (Swift/macOS)
- [ ] Backend (Python API)
- [ ] Firmware / hardware
- [ ] Plugins / integrations
- [ ] SDKs (Expo / React Native / Python / Swift)
- [ ] MCP server
- [ ] Web frontend
- [ ] Docs
- [ ] CI / build / infra

## Security Impact

- New permissions or capabilities introduced? No
- Auth or token handling changed? No
- Data access scope changed (screen data, OCR, user data)? No
- New or changed network calls? No
- Plugin or tool execution surface changed? No
- If any `Yes` — risk and mitigation: N/A

## Testing

- [x] Built locally
- [x] Manual verification:
  - macOS named dev bundle: `/Applications/omi-pr34-stop-cold.app` (`com.omi.omi-pr34-stop-cold`)
  - Send a chat message, tap Stop immediately, verify the response stops and the input unlocks.
  - Tap Resume after Stop cleanup completes, verify the prompt replays and receives a response.
  - Tap Resume before Stop cleanup finishes, verify the prompt is queued and replays after Stop releases the send lock.
- [ ] Existing tests pass
- [ ] New tests added (if applicable)

## Human Verification

- Verified scenarios:
  - Stop during an active query produces the interrupted card instead of saving an AI response.
  - Resume after the interrupted card works.
  - Resume tapped during the Stop cleanup/spinner window no longer gets dropped by the `isSending` guard.
  - Branch rebased onto latest `upstream/main` before push.
- Edge cases checked:
  - Pre-flight generation guards after bridge startup, session creation, and pending uploads.
  - Watchdog path interrupts bridge before force-unlocking UI state.
- What you did **not** verify (and why): full Swift test suite was not run; this desktop slice was compile-checked and manually verified in the named macOS bundle.

## Evidence

- [ ] Screenshot or recording
- [x] Log output (before/after)
  - Local logs showed Stop interrupt accepted, `.stopped` surfaced, and Resume replay saved a new user message after Stop cleanup instead of being dropped.
- [x] Test output
  - `xcrun swift build -c debug --package-path desktop/macos/Desktop` passed.
- [ ] N/A — change is not user-visible

## Docs

- [ ] Updated docs in [`docs/`](https://github.com/BasedHardware/omi/tree/main/docs) (if user-facing change)
- [x] N/A — no docs impact

## Performance, Privacy, and Reliability

Reliability improvement for chat cancellation and retry recovery. No privacy, permission, or network-scope changes. The queued recovery prompt is in-memory only and is cleared when consumed.

## Migration / Backward Compatibility

- Backward compatible? Yes
- Migration needed? No
- If yes, upgrade steps: N/A

## Risks and Mitigations

- Risk: Stop/Resume behavior is timing-sensitive around bridge/runtime interruption.
  - Mitigation: generation guards make stale sends abort before query start; runtime interrupt retires the active continuation; Resume during stop cleanup is queued until `releaseSendLock()` clears the current turn.

## AI Disclosure

- Tools used: Codex
- AI-assisted portions: implementation, review-feedback triage, PR body drafting, and local verification orchestration.
- How you verified correctness: local debug build, named-bundle install/run, and manual Stop/Resume verification on macOS.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9026?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

