### PR TITLE
fix(desktop): resume screen capture when a mid-session paywall clears

### DIFF
--- a/desktop/macos/Desktop/Sources/AppState/AppState+TrialPaywall.swift
+++ b/desktop/macos/Desktop/Sources/AppState/AppState+TrialPaywall.swift
@@ -26,6 +26,22 @@ extension AppState {
     !APIKeyService.isByokActive && UserDefaults.standard.bool(forKey: "desktop_isPaywalled")
   }
 
+  /// Decision for the resume-on-paywall-clear hook in `fetchTrialMetadata()`.
+  /// Pure so it is unit-testable: resume screen-analysis monitoring only when
+  /// this fetch actually cleared the paywall (set → clear transition), the
+  /// user still has screen analysis enabled, nothing is already running, and
+  /// API keys are loaded (mirrors the launch gate; the key-load retry path
+  /// covers the not-yet-loaded case).
+  nonisolated static func shouldResumeMonitoringAfterPaywallClear(
+    wasPaywalled: Bool,
+    isPaywalledNow: Bool,
+    screenAnalysisEnabled: Bool,
+    isMonitoring: Bool,
+    keysAvailable: Bool
+  ) -> Bool {
+    wasPaywalled && !isPaywalledNow && screenAnalysisEnabled && !isMonitoring && keysAvailable
+  }
+
   @discardableResult
   func blockIfPaywalled(reason: String = "trial_expired") -> Bool {
     // BYOK users are never paywalled. If the user has all four BYOK keys
@@ -58,6 +74,11 @@ extension AppState {
       do {
         let metadata = try await APIClient.shared.getTrialMetadata()
         self.trialMetadata = metadata
+        // Snapshot the paywall state observed AFTER the network await resolves
+        // (intentionally not before): if two fetches are in flight, whichever
+        // resolves first clears the flag, so the second sees false here and
+        // the resume hook below fires exactly once instead of double-starting.
+        let wasPaywalled = self.isPaywalled
         // Local BYOK always wins — never re-block a user who has all four keys
         // configured, regardless of what the (possibly heartbeat-lagged)
         // backend trial state says.
@@ -67,6 +88,26 @@ extension AppState {
           self.isPaywalled = true
         } else if !metadata.trialExpired && self.isPaywalled {
           self.isPaywalled = false
+        }
+        // A mid-session `freemium_threshold_reached` event stops capture and
+        // sets the sticky flag; nothing else observes the flag clearing, so
+        // without this hook capture stays off after the paywall lifts until
+        // the next incidental startMonitoring trigger (e.g. app
+        // re-activation) — indefinitely for a user who leaves the window in
+        // the background.
+        if AppState.shouldResumeMonitoringAfterPaywallClear(
+          wasPaywalled: wasPaywalled,
+          isPaywalledNow: self.isPaywalled,
+          screenAnalysisEnabled: AssistantSettings.shared.screenAnalysisEnabled,
+          isMonitoring: ProactiveAssistantsPlugin.shared.isMonitoring,
+          keysAvailable: APIKeyService.keysAvailable
+        ) {
+          log("AppState: paywall lifted — resuming screen analysis monitoring")
+          ProactiveAssistantsPlugin.shared.startMonitoring { success, error in
+            if !success {
+              log("AppState: paywall-lifted monitoring restart failed: \(error ?? "unknown")")
+            }
+          }
         }
       } catch {
         log("AppState: failed to fetch trial metadata: \(error.localizedDescription)")

--- a/desktop/macos/Desktop/Sources/AppState/AppState+TrialPaywall.swift
+++ b/desktop/macos/Desktop/Sources/AppState/AppState+TrialPaywall.swift
@@ -104,8 +104,8 @@ extension AppState {
         ) {
           log("AppState: paywall lifted — resuming screen analysis monitoring")
           ProactiveAssistantsPlugin.shared.startMonitoring { success, error in
-            if !success {
-              log("AppState: paywall-lifted monitoring restart failed: \(error ?? "unknown")")
+            if !success, let error, !error.isEmpty {
+              log("AppState: paywall-lifted monitoring restart failed: \(error)")
             }
           }
         }

--- a/desktop/macos/Desktop/Tests/PaywallClearResumeTests.swift
+++ b/desktop/macos/Desktop/Tests/PaywallClearResumeTests.swift
@@ -1,0 +1,67 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// Verifies the resume-on-paywall-clear decision used by
+/// `AppState.fetchTrialMetadata()`: screen-analysis monitoring restarts
+/// exactly when a trial fetch transitions the paywall from set to clear and
+/// the user still wants (and can run) screen analysis.
+final class PaywallClearResumeTests: XCTestCase {
+
+    func testResumesWhenFetchClearsPaywallAndAllConditionsHold() {
+        XCTAssertTrue(
+            AppState.shouldResumeMonitoringAfterPaywallClear(
+                wasPaywalled: true, isPaywalledNow: false,
+                screenAnalysisEnabled: true, isMonitoring: false, keysAvailable: true
+            )
+        )
+    }
+
+    func testDoesNotResumeWhenPaywallWasNeverSet() {
+        // Ordinary fetch on a healthy account — no transition, no restart.
+        XCTAssertFalse(
+            AppState.shouldResumeMonitoringAfterPaywallClear(
+                wasPaywalled: false, isPaywalledNow: false,
+                screenAnalysisEnabled: true, isMonitoring: false, keysAvailable: true
+            )
+        )
+    }
+
+    func testDoesNotResumeWhileStillPaywalled() {
+        // Genuinely expired account: flag stays set, capture stays stopped.
+        XCTAssertFalse(
+            AppState.shouldResumeMonitoringAfterPaywallClear(
+                wasPaywalled: true, isPaywalledNow: true,
+                screenAnalysisEnabled: true, isMonitoring: false, keysAvailable: true
+            )
+        )
+    }
+
+    func testDoesNotResumeWhenScreenAnalysisDisabled() {
+        XCTAssertFalse(
+            AppState.shouldResumeMonitoringAfterPaywallClear(
+                wasPaywalled: true, isPaywalledNow: false,
+                screenAnalysisEnabled: false, isMonitoring: false, keysAvailable: true
+            )
+        )
+    }
+
+    func testDoesNotResumeWhenAlreadyMonitoring() {
+        XCTAssertFalse(
+            AppState.shouldResumeMonitoringAfterPaywallClear(
+                wasPaywalled: true, isPaywalledNow: false,
+                screenAnalysisEnabled: true, isMonitoring: true, keysAvailable: true
+            )
+        )
+    }
+
+    func testDoesNotResumeBeforeAPIKeysLoad() {
+        // The key-load retry path in DesktopHomeView covers this case instead.
+        XCTAssertFalse(
+            AppState.shouldResumeMonitoringAfterPaywallClear(
+                wasPaywalled: true, isPaywalledNow: false,
+                screenAnalysisEnabled: true, isMonitoring: false, keysAvailable: false
+            )
+        )
+    }
+}

--- a/desktop/macos/changelog/unreleased/20260704-paywall-clear-capture-resume.json
+++ b/desktop/macos/changelog/unreleased/20260704-paywall-clear-capture-resume.json
@@ -1,0 +1,3 @@
+{
+  "change": "Screen capture now resumes automatically when a temporary usage-limit paywall clears instead of staying paused until you switch back to the app"
+}


### PR DESCRIPTION
## Summary

- Problem: when a `freemium_threshold_reached` event stops screen capture mid-session and sets the sticky `desktop_isPaywalled` flag, **nothing resumes capture after the paywall clears**. `fetchTrialMetadata()` clears the flag on its next poll (e.g. lag-noise event on an active account, or the user reactivates), but no code observes that transition — capture stays off until an incidental `startMonitoring` trigger like app re-activation, which never comes for a user who leaves Omi in the background.
- What changed: `fetchTrialMetadata()` now detects the paywall set → clear transition and immediately resumes screen-analysis monitoring, gated on the setting still being enabled, monitoring not already running, and API keys loaded. The decision is a pure, unit-tested function (`AppState.shouldResumeMonitoringAfterPaywallClear`).
- What did NOT change (scope boundary): paywall **enforcement** is untouched — a genuinely expired account keeps `trialExpired=true`, the flag stays set, and the hook never fires (covered by a test). Transcription resume-after-clear is intentionally out of scope: auto-reactivating the mic has privacy-perception weight that deserves its own decision, whereas the screen-capture pill visibly reflects state.

## Linked Issue / Bounty

- N/A — independent contribution (companion to the launch-time fix in ce6a1c64c)

## Root Cause (bug fixes only)

- Root cause: the paywall lifecycle is asymmetric. Setting the flag has an enforcement action attached (`stopMonitoring()` in the `freemium_threshold_reached` handler), but clearing it (`AppState+TrialPaywall.swift` fetch handler) only flips state — the only consumers of the cleared flag are gates on *future* start attempts, and none of the automatic start triggers fire on flag transitions.
- Why it wasn't caught before: ce6a1c64c fixed the *launch* half of this bug (stale flag restored from UserDefaults) by clearing the flag in `AppState.init()`; the mid-session half needs a running session that receives a threshold event and then has it clear, which no automated test exercised.

## How It Works

`fetchTrialMetadata()` snapshots `isPaywalled` after the network await resolves (intentionally not before: with two fetches in flight, whichever resolves first clears the flag, so the second observes `false` and the hook fires exactly once). After the existing flag-update chain, `shouldResumeMonitoringAfterPaywallClear(wasPaywalled:isPaywalledNow:screenAnalysisEnabled:isMonitoring:keysAvailable:)` decides the restart; on true it calls `ProactiveAssistantsPlugin.startMonitoring` (which has its own re-entrancy and permission guards). Worst-case recovery latency is one trial-poll interval (60s) after the backend state changes, versus indefinite today.

## Change Type

- [x] Bug fix

## Scope

- [x] Desktop app (Swift/macOS)

## Security Impact

- New permissions or capabilities introduced? No
- Auth or token handling changed? No
- Data access scope changed (screen data, OCR, user data)? No — capture resumes only for users who had it enabled and running before the paywall event; the same `startMonitoring` permission/paywall guards still apply
- New or changed network calls? No
- Plugin or tool execution surface changed? No

## Testing

- [x] Built locally — `xcrun swift build -c debug --package-path Desktop`, clean (macOS 26.5.1, arm64)
- [x] Manual verification: full mid-session expire → stop → clear → auto-resume cycle on a named bundle (see Human Verification)
- [x] Existing tests pass — `BYOKPaywallTests` (paywall gating semantics)
- [x] New tests added — `PaywallClearResumeTests`, 6 cases: resumes on set→clear with all conditions; no resume when never paywalled / still paywalled (enforcement intact) / setting disabled / already monitoring / keys not loaded

## Human Verification

Verified on a dedicated named bundle signed into a real account (macOS 26.5.1), using the DEBUG `realtime` trial mode to stage a mid-session expiry:

- Verified scenarios:
  1. **Mid-session set → clear → auto-resume**: with the app running, capture off, and the paywall flag set mid-session (staged via the DEBUG realtime trial expiry), switching the trial back to the real backend cleared the flag on the next poll and the hook resumed monitoring **3 seconds later** — `AppState: paywall lifted — resuming screen analysis monitoring` followed 23ms later by `ProactiveAssistantsPlugin: Capture timer set to 9.0s (monitoring start)`, with macOS registering active screen-capture usage seconds after.
  2. **No double-start**: an earlier round where monitoring was still running when the flag cleared produced the flag transition with no restart attempt (the `isMonitoring` guard held live).
  3. **Enforcement unchanged**: while the flag was set, no start occurred and the flag persisted across polls until the backend genuinely reported not-expired.
- Edge cases checked: hook does not fire on ordinary fetches (no set→clear transition); startMonitoring's own guards prevent double-starts.
- What was **not** verified: a real `freemium_threshold_reached` WS event (requires backend-side usage exhaustion); the stop side of that handler is pre-existing and unchanged.

## Evidence

- [x] Log output

```
20:41:42            app launch (AppState.init clears the flag)
20:41:50            trial tick sets desktop_isPaywalled=1 mid-session; capture off
20:41:50            debug trial mode removed — next poll is a real backend fetch
[20:41:53.143] AppState: paywall lifted — resuming screen analysis monitoring
[20:41:53.166] ProactiveAssistantsPlugin: Capture timer set to 9.0s (monitoring start)
                    desktop_isPaywalled=0; ScreenCaptureApprovals LastUsed advances at 20:42:02
```

## Docs

- [x] N/A — no docs impact (changelog fragment added)

## Performance, Privacy, and Reliability

No new network calls or timers — the hook piggybacks on the existing trial poll. Privacy: capture resumes only to the state the user had already enabled; a genuinely paywalled user stays stopped.

## Migration / Backward Compatibility

- Backward compatible? Yes
- Migration needed? No

## Risks and Mitigations

- Risk: resuming capture the user believed was off.
  - Mitigation: the hook only fires when `screenAnalysisEnabled` is still true — i.e. the user never turned capture off; the paywall event did. Any explicit user disable clears that setting and blocks the hook (tested).
- Risk: double-start if a start is already in flight when the flag clears.
  - Mitigation: `startMonitoring` guards on `isMonitoring`/`isStartingMonitoring`; the after-await snapshot additionally makes concurrent fetches fire the hook at most once.

## AI Disclosure

- Tools used: Claude Code
- AI-assisted portions: fix implementation, tests, and this PR body
- How you verified correctness: staged the full mid-session cycle on a locally built named bundle (debug realtime trial expiry → capture stopped while paywalled → flag cleared by a real trial fetch → auto-resume observed in logs) and ran the paywall test suites.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9027?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

