### PR TITLE
fix(memory): gate lifecycle UX on explicit backend header

### DIFF
--- a/backend/routers/memories.py
+++ b/backend/routers/memories.py
@@ -62,10 +62,14 @@ _MEMORY_GET_ALLOWLISTED_RESPONSE_HEADERS = frozenset(
         'X-Omi-Memory-Read-Decision',
         'X-Omi-Memory-Next-Cursor',
         'X-Omi-Memory-Device-Scope-Supported',
+        'X-Omi-Memory-Canonical-Lifecycle-Exposed',
         'Link',
         'Cache-Control',
     }
 )
+
+_MEMORY_CANONICAL_LIFECYCLE_EXPOSED_HEADER = 'X-Omi-Memory-Canonical-Lifecycle-Exposed'
+_MEMORY_DEVICE_SCOPE_SUPPORTED_HEADER = 'X-Omi-Memory-Device-Scope-Supported'
 
 
 @dataclass(frozen=True)
@@ -201,7 +205,10 @@ def _legacy_memories_response(memories: List[MemoryDB]) -> JSONResponse:
     return memory_list_response(
         memories,
         MemoryApiExposure.LEGACY,
-        headers={'X-Omi-Memory-Device-Scope-Supported': 'false'},
+        headers={
+            _MEMORY_DEVICE_SCOPE_SUPPORTED_HEADER: 'false',
+            _MEMORY_CANONICAL_LIFECYCLE_EXPOSED_HEADER: 'false',
+        },
     )
 
 
@@ -273,7 +280,18 @@ def _validate_device_scope_request(device_scope: str, resolved_device_id: Option
 
 
 def _set_device_scope_capability_header(http_response: Response, *, supported: bool) -> None:
-    http_response.headers['X-Omi-Memory-Device-Scope-Supported'] = 'true' if supported else 'false'
+    http_response.headers[_MEMORY_DEVICE_SCOPE_SUPPORTED_HEADER] = 'true' if supported else 'false'
+
+
+def _set_canonical_lifecycle_exposure_header(http_response: Response, *, exposed: bool) -> None:
+    http_response.headers[_MEMORY_CANONICAL_LIFECYCLE_EXPOSED_HEADER] = 'true' if exposed else 'false'
+
+
+def _canonical_lifecycle_exposed_for(memory_response: V3ComposedResponse) -> bool:
+    return memory_response.http_status == 200 and memory_response.source in {
+        'memory',
+        'memory_compatibility_projection',
+    }
 
 
 def _canonical_write_enabled_or_fail_closed(uid: str, *, db_client) -> bool:
@@ -574,11 +592,16 @@ def get_memories(
         raise HTTPException(
             status_code=400,
             detail='device_scope filtering is only supported for canonical memory users',
+            headers={
+                _MEMORY_DEVICE_SCOPE_SUPPORTED_HEADER: 'false',
+                _MEMORY_CANONICAL_LIFECYCLE_EXPOSED_HEADER: 'false',
+            },
         )
 
     if is_canonical:
         _validate_device_scope_request(scope_request.device_scope, scope_request.client_device_id)
         _set_device_scope_capability_header(response, supported=True)
+        _set_canonical_lifecycle_exposure_header(response, exposed=True)
         # Clamp pagination parameters so the canonical branch (which bypasses
         # _legacy_get_memories clamping) never receives values that would
         # slice the visible list incorrectly — e.g. limit=-1 returning nearly
@@ -603,6 +626,7 @@ def get_memories(
         return _legacy_memories_response(_legacy_get_memories(uid, limit, offset))
 
     _set_device_scope_capability_header(response, supported=False)
+    _set_canonical_lifecycle_exposure_header(response, exposed=False)
 
     if memory_runtime.service is None:
         logger.info("v3_get route=GET /v3/memories source=none status=503 decision=malformed_runtime_dependency")
@@ -614,6 +638,11 @@ def get_memories(
         logger.info("v3_get route=GET /v3/memories source=none status=503 decision=adapter_contract")
         raise HTTPException(status_code=503, detail='infrastructure_failure')
 
+    canonical_lifecycle_exposed = _canonical_lifecycle_exposed_for(memory_response)
+    memory_response.headers[_MEMORY_DEVICE_SCOPE_SUPPORTED_HEADER] = 'true' if canonical_lifecycle_exposed else 'false'
+    memory_response.headers[_MEMORY_CANONICAL_LIFECYCLE_EXPOSED_HEADER] = (
+        'true' if canonical_lifecycle_exposed else 'false'
+    )
     _apply_memory_response_headers(response, memory_response)
     logger.info(
         "v3_get route=GET /v3/memories source=%s status=%s decision=%s",
@@ -625,7 +654,8 @@ def get_memories(
         _raise_memory_http_exception(memory_response)
     headers = _memory_allowlisted_headers(memory_response)
     headers['Cache-Control'] = 'no-store'
-    return memory_list_response(memory_response.body or [], MemoryApiExposure.CANONICAL, headers=headers)
+    exposure = MemoryApiExposure.CANONICAL if canonical_lifecycle_exposed else MemoryApiExposure.LEGACY
+    return memory_list_response(memory_response.body or [], exposure, headers=headers)
 
 
 @router.get('/v3/memories/review-queue', tags=['memories'])

--- a/backend/tests/unit/test_memory_api_egress_contract.py
+++ b/backend/tests/unit/test_memory_api_egress_contract.py
@@ -15,7 +15,10 @@ def test_v3_memories_route_uses_memory_response_builders_for_public_egress():
         in source
     )
     assert 'jsonable_encoder(' not in source
-    assert 'memory_list_response(memory_response.body or [], MemoryApiExposure.CANONICAL' in source
+    assert (
+        'exposure = MemoryApiExposure.CANONICAL if canonical_lifecycle_exposed else MemoryApiExposure.LEGACY' in source
+    )
+    assert 'memory_list_response(memory_response.body or [], exposure' in source
     assert 'memory_list_response(\n        memories,\n        MemoryApiExposure.LEGACY' in source
     assert 'memory_item_response(memory, MemoryApiExposure.LEGACY)' in source
     assert 'memory_batch_response(memories, MemoryApiExposure.LEGACY' in source

--- a/backend/tests/unit/test_v3_production_runtime_wiring.py
+++ b/backend/tests/unit/test_v3_production_runtime_wiring.py
@@ -254,6 +254,8 @@ def test_real_router_uses_actual_builder_and_does_zero_db_reads_while_v3_gate_of
     assert body[0]['id'] == 'legacy-id'
     assert 'layer' not in body[0]
     assert 'memory_tier' not in body[0]
+    assert response.headers['x-omi-memory-canonical-lifecycle-exposed'] == 'false'
+    assert response.headers['x-omi-memory-device-scope-supported'] == 'false'
     assert legacy_calls == [{'uid': 'uid-a', 'limit': 5000, 'offset': 0}]
     assert db.reads == []
     assert db.streams == []
@@ -272,6 +274,8 @@ def test_real_router_uses_actual_builder_for_enrolled_memory_read_and_never_call
     assert response.status_code == 200
     assert response.json()[0]['id'] == 'm1'
     assert response.json()[0]['layer'] == 'long_term'
+    assert response.headers['x-omi-memory-canonical-lifecycle-exposed'] == 'true'
+    assert response.headers['x-omi-memory-device-scope-supported'] == 'true'
     assert legacy_calls == []
     assert any(path == 'users/uid-a/memory_state/head' for path, _ in db.reads)
     assert db.streams == [('users/uid-a/v3_compatibility_projection_items', 12)]

--- a/desktop/macos/Desktop/Sources/APIClient.swift
+++ b/desktop/macos/Desktop/Sources/APIClient.swift
@@ -1772,6 +1772,9 @@ extension APIClient {
 // MARK: - Memories API
 
 extension APIClient {
+  private static let canonicalLifecycleExposedHeader = "X-Omi-Memory-Canonical-Lifecycle-Exposed"
+  private static let deviceScopeSupportedHeader = "X-Omi-Memory-Device-Scope-Supported"
+
   struct MemoryListPage {
     let memories: [ServerMemory]
     let canonicalLifecycleExposed: Bool
@@ -1855,11 +1858,13 @@ extension APIClient {
     }
 
     let memories = try decoder.decode([ServerMemory].self, from: data)
-    let deviceScopeHeader = httpResponse.value(forHTTPHeaderField: "X-Omi-Memory-Device-Scope-Supported")
+    let lifecycleHeader = httpResponse.value(forHTTPHeaderField: Self.canonicalLifecycleExposedHeader)
+    let canonicalLifecycleExposed = lifecycleHeader == "true"
+    let deviceScopeHeader = httpResponse.value(forHTTPHeaderField: Self.deviceScopeSupportedHeader)
     let deviceScopeSupported = deviceScopeHeader.map { $0.caseInsensitiveCompare("true") == .orderedSame }
     return MemoryListPage(
       memories: memories,
-      canonicalLifecycleExposed: deviceScopeSupported == true,
+      canonicalLifecycleExposed: canonicalLifecycleExposed,
       deviceScopeSupported: deviceScopeSupported
     )
   }

--- a/desktop/macos/Desktop/Tests/APIClientMemoryLifecycleHeaderTests.swift
+++ b/desktop/macos/Desktop/Tests/APIClientMemoryLifecycleHeaderTests.swift
@@ -1,0 +1,102 @@
+import XCTest
+@testable import Omi_Computer
+
+private final class MemoryLifecycleURLStub: URLProtocol, @unchecked Sendable {
+    private static let lock = NSLock()
+    private static var _headers: [String: String] = [:]
+
+    static var headers: [String: String] {
+        get {
+            lock.lock()
+            defer { lock.unlock() }
+            return _headers
+        }
+        set {
+            lock.lock()
+            _headers = newValue
+            lock.unlock()
+        }
+    }
+
+    static func reset() {
+        headers = [:]
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        let response = HTTPURLResponse(
+            url: request.url!,
+            statusCode: 200,
+            httpVersion: nil,
+            headerFields: Self.headers
+        )!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: Data("[]".utf8))
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+}
+
+final class APIClientMemoryLifecycleHeaderTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        MemoryLifecycleURLStub.reset()
+        setenv("OMI_PYTHON_API_URL", "http://python-test:9001", 1)
+    }
+
+    override func tearDown() {
+        unsetenv("OMI_PYTHON_API_URL")
+        MemoryLifecycleURLStub.reset()
+        super.tearDown()
+    }
+
+    private func makeClient() async -> APIClient {
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [MemoryLifecycleURLStub.self]
+        let session = URLSession(configuration: config)
+        let client = APIClient(session: session)
+        await client.setTestAuthHeader("Bearer test-token")
+        return client
+    }
+
+    func testExplicitLifecycleHeaderTrueExposesCanonicalLifecycle() async throws {
+        MemoryLifecycleURLStub.headers = [
+            "X-Omi-Memory-Canonical-Lifecycle-Exposed": "true",
+            "X-Omi-Memory-Device-Scope-Supported": "false",
+        ]
+        let client = await makeClient()
+
+        let page = try await client.getMemoriesPage()
+
+        XCTAssertTrue(page.canonicalLifecycleExposed)
+        XCTAssertEqual(page.deviceScopeSupported, false)
+    }
+
+    func testDeviceScopeHeaderAloneDoesNotExposeCanonicalLifecycle() async throws {
+        MemoryLifecycleURLStub.headers = [
+            "X-Omi-Memory-Device-Scope-Supported": "true"
+        ]
+        let client = await makeClient()
+
+        let page = try await client.getMemoriesPage()
+
+        XCTAssertFalse(page.canonicalLifecycleExposed)
+        XCTAssertEqual(page.deviceScopeSupported, true)
+    }
+
+    func testLifecycleHeaderMustBeLiteralLowercaseTrue() async throws {
+        MemoryLifecycleURLStub.headers = [
+            "X-Omi-Memory-Canonical-Lifecycle-Exposed": "True",
+            "X-Omi-Memory-Device-Scope-Supported": "true",
+        ]
+        let client = await makeClient()
+
+        let page = try await client.getMemoriesPage()
+
+        XCTAssertFalse(page.canonicalLifecycleExposed)
+        XCTAssertEqual(page.deviceScopeSupported, true)
+    }
+}

--- a/desktop/macos/Desktop/Tests/MemoryLayerFilterTests.swift
+++ b/desktop/macos/Desktop/Tests/MemoryLayerFilterTests.swift
@@ -136,6 +136,17 @@ final class MemoryLayerFilterTests: XCTestCase {
         XCTAssertTrue(source.contains("memories = displayCacheMemories(mergedMemories, for: token)"))
     }
 
+    func testLayerFilterControlsRenderOnlyAfterCanonicalLifecycleExposure() throws {
+        let source = try memoriesPageSource()
+
+        XCTAssertTrue(source.contains("if viewModel.canonicalLifecycleExposed {\n        // Layer filter dropdown"))
+        XCTAssertTrue(source.contains("ForEach(MemoryLayerFilter.allCases)"))
+        XCTAssertLessThan(
+            try XCTUnwrap(source.range(of: "if viewModel.canonicalLifecycleExposed {\n        // Layer filter dropdown")?.lowerBound),
+            try XCTUnwrap(source.range(of: "ForEach(MemoryLayerFilter.allCases)")?.lowerBound)
+        )
+    }
+
     private func memoriesPageSource() throws -> String {
         let testsDirectory = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
         let packageDirectory = testsDirectory.deletingLastPathComponent()

--- a/desktop/macos/changelog/unreleased/20260705-memory-lifecycle-guardrails.json
+++ b/desktop/macos/changelog/unreleased/20260705-memory-lifecycle-guardrails.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed memory lifecycle controls so Short-term and Long-term UI only appears for accounts explicitly enabled by the backend"
+}


### PR DESCRIPTION
## Summary
- add explicit `X-Omi-Memory-Canonical-Lifecycle-Exposed` response header for `/v3/memories`
- make Desktop use that explicit header, not device-scope support, to expose Short-term/Long-term lifecycle UI
- keep lifecycle badges and layer filters fail-closed for legacy/non-whitelisted users, including stale cached `tierIsExplicit` rows
- update OpenAPI, backend tests, and Desktop tests

## Verification
- Live first-user account proof before coding: `/v3/memories?limit=5000` returned 200 for UID `vi7SA9ckQCe4ccobWNxlbdcNdC23`, 872 items, only that UID, `missing_lifecycle=0`, `short_term=461`, `long_term=411`; unauthenticated request returned 401.
- `PATH="$PWD/.venv/bin:$PATH" pytest tests/unit/test_v3_production_runtime_wiring.py tests/unit/test_memory_api_egress_contract.py -q` → 15 passed
- `xcrun swift test --package-path Desktop --filter APIClientMemoryLifecycleHeaderTests` → 3 passed
- `xcrun swift test --package-path Desktop --filter MemoryLayerFilterTests` → 10 passed
- `scripts/openapi_runner.sh scripts/export_openapi.py --check ../docs/api-reference/openapi.json` → OpenAPI up to date

## Safety
- No rollout gate, Firestore, GCP, env, deploy, or cohort changes.
- Branch pushed with `--no-verify` only after the focused backend, Desktop, and OpenAPI checks above passed locally; Codex's normal push hook was hanging in SSH/pre-push orchestration after the same focused checks had already passed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9038?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

