### PR TITLE
fix(desktop): report notification permission during onboarding

### DIFF
--- a/desktop/macos/Desktop/Sources/Providers/ChatToolExecutor.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatToolExecutor.swift
@@ -31,6 +31,37 @@ class ChatToolExecutor {
   private static var fileScanFileCount = 0
   private static var followupContinuation: CheckedContinuation<String, Never>?
 
+  nonisolated static let onboardingPermissionTypes = [
+    "screen_recording",
+    "microphone",
+    "notifications",
+    "accessibility",
+    "automation",
+    "full_disk_access",
+  ]
+
+  nonisolated static var onboardingPermissionTypesDescription: String {
+    onboardingPermissionTypes.joined(separator: ", ")
+  }
+
+  nonisolated static func onboardingPermissionStatusPayload(
+    screenRecording: Bool,
+    microphone: Bool,
+    notifications: Bool,
+    accessibility: Bool,
+    automation: Bool,
+    fullDiskAccess: Bool
+  ) -> [String: String] {
+    [
+      "screen_recording": screenRecording ? "granted" : "not_granted",
+      "microphone": microphone ? "granted" : "not_granted",
+      "notifications": notifications ? "granted" : "not_granted",
+      "accessibility": accessibility ? "granted" : "not_granted",
+      "automation": automation ? "granted" : "not_granted",
+      "full_disk_access": fullDiskAccess ? "granted" : "not_granted",
+    ]
+  }
+
   static func resumeFollowup(with reply: String) {
     followupContinuation?.resume(returning: reply)
     followupContinuation = nil
@@ -1095,7 +1126,7 @@ class ChatToolExecutor {
   private static func executeRequestPermission(_ args: [String: Any]) async -> String {
     guard let type = args["type"] as? String else {
       return
-        "Error: 'type' parameter is required (screen_recording, microphone, accessibility, automation)"
+        "Error: 'type' parameter is required (\(onboardingPermissionTypesDescription))"
     }
 
     guard let appState = onboardingAppState else {
@@ -1130,6 +1161,17 @@ class ChatToolExecutor {
         return "granted"
       } else {
         return "pending - user needs to allow microphone access in the system dialog"
+      }
+
+    case "notifications":
+      appState.requestNotificationPermission()
+      try? await Task.sleep(nanoseconds: 3_000_000_000)
+      appState.checkNotificationPermission()
+      try? await Task.sleep(nanoseconds: 500_000_000)
+      if appState.hasNotificationPermission {
+        return "granted"
+      } else {
+        return "pending - user needs to allow notifications in the system dialog or enable omi in System Settings > Notifications"
       }
 
     case "accessibility":
@@ -1173,7 +1215,7 @@ class ChatToolExecutor {
 
     default:
       return
-        "Error: unknown permission type '\(type)'. Valid types: screen_recording, microphone, accessibility, automation, full_disk_access"
+        "Error: unknown permission type '\(type)'. Valid types: \(onboardingPermissionTypesDescription)"
     }
   }
 
@@ -1186,13 +1228,14 @@ class ChatToolExecutor {
     appState.checkAllPermissions()
     try? await Task.sleep(nanoseconds: 500_000_000)
 
-    let statuses: [String: String] = [
-      "screen_recording": appState.hasScreenRecordingPermission ? "granted" : "not_granted",
-      "microphone": appState.hasMicrophonePermission ? "granted" : "not_granted",
-      "accessibility": appState.hasAccessibilityPermission ? "granted" : "not_granted",
-      "automation": appState.hasAutomationPermission ? "granted" : "not_granted",
-      "full_disk_access": appState.hasFullDiskAccess ? "granted" : "not_granted",
-    ]
+    let statuses = onboardingPermissionStatusPayload(
+      screenRecording: appState.hasScreenRecordingPermission,
+      microphone: appState.hasMicrophonePermission,
+      notifications: appState.hasNotificationPermission,
+      accessibility: appState.hasAccessibilityPermission,
+      automation: appState.hasAutomationPermission,
+      fullDiskAccess: appState.hasFullDiskAccess
+    )
 
     if let data = try? JSONSerialization.data(withJSONObject: statuses, options: .prettyPrinted),
       let json = String(data: data, encoding: .utf8)

--- a/desktop/macos/Desktop/Tests/OnboardingPermissionToolTests.swift
+++ b/desktop/macos/Desktop/Tests/OnboardingPermissionToolTests.swift
@@ -1,0 +1,35 @@
+import XCTest
+
+@testable import Omi_Computer
+
+final class OnboardingPermissionToolTests: XCTestCase {
+  func testPermissionStatusPayloadIncludesEveryPermissionAdvertisedToOnboardingAgent() {
+    let statuses = ChatToolExecutor.onboardingPermissionStatusPayload(
+      screenRecording: false,
+      microphone: false,
+      notifications: false,
+      accessibility: false,
+      automation: false,
+      fullDiskAccess: false
+    )
+
+    XCTAssertEqual(
+      Set(statuses.keys),
+      Set(ChatToolExecutor.onboardingPermissionTypes)
+    )
+    XCTAssertTrue(statuses.keys.contains("notifications"))
+  }
+
+  func testSupportedPermissionTypesIncludeNotifications() {
+    XCTAssertEqual(
+      ChatToolExecutor.onboardingPermissionTypes,
+      [
+        "screen_recording",
+        "microphone",
+        "notifications",
+        "accessibility",
+        "automation",
+        "full_disk_access",
+      ])
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260705-onboarding-notification-permission.json
+++ b/desktop/macos/changelog/unreleased/20260705-onboarding-notification-permission.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed onboarding permission checks so notification permission is reported and can be requested correctly"
+}


### PR DESCRIPTION
## Summary

Fixes a macOS onboarding permission-tool mismatch where the onboarding agent was told it could check and request `notifications`, but the actual tool executor omitted notification permission from `check_permission_status` and rejected `request_permission(type: "notifications")` as unsupported.

## Bug

During onboarding, `ChatPrompts.swift` advertises six supported permissions for the onboarding tools:

- `screen_recording`
- `microphone`
- `notifications`
- `accessibility`
- `automation`
- `full_disk_access`

Before this PR, `ChatToolExecutor` only reported/requested five of them. That meant the onboarding agent could not reliably see or fix notification permission state, even though its prompt contract said it could.

## Root Cause

`executeCheckPermissionStatus` manually built its permission JSON and left out `notifications`. `executeRequestPermission` also had no `notifications` switch case, so the advertised tool argument was treated as invalid.

## Fix

- Adds notification permission status to the onboarding permission payload.
- Adds a `request_permission(type: "notifications")` path using the existing `AppState.requestNotificationPermission()` / `checkNotificationPermission()` behavior.
- Centralizes the supported onboarding permission type list so status, request validation, and tests stay aligned.
- Adds focused tests for the advertised permission contract.

## Reproduction Evidence Before Fix

Verified in a real named macOS test bundle with a temporary local-only automation probe calling the same onboarding tool executor path.

Bundle: `/Applications/omi-onboarding-permission-probe.app`  
Bundle id: `com.omi.omi-onboarding-permission-probe`  
Automation port: `47844`

Command:

```bash
OMI_AUTOMATION_PORT=47844 ./scripts/omi-ctl action debug_onboarding_permission_status_probe
```

Before-fix output omitted `notifications`:

```json
{
  "full_disk_access": "not_granted",
  "microphone": "not_granted",
  "accessibility": "not_granted",
  "screen_recording": "not_granted",
  "automation": "not_granted"
}
```

## Verification After Fix

Rebuilt the same named bundle and ran the same local-only probe. After the fix, the real app returned all six permissions, including `notifications`:

```json
{
  "microphone": "not_granted",
  "screen_recording": "not_granted",
  "notifications": "not_granted",
  "accessibility": "not_granted",
  "automation": "not_granted",
  "full_disk_access": "not_granted"
}
```

Focused test command:

```bash
xcrun swift test --package-path desktop/macos/Desktop --filter OnboardingPermissionToolTests
```

Result: passed, 2 tests, 0 failures.

Additional checks:

```bash
git diff --check
make setup
test -x "$(git rev-parse --git-path hooks)/pre-commit" && echo OK
```

All passed.

## Visual Proof

This bug is not a visible layout defect; it is the JSON contract exposed to the onboarding agent. I did capture a post-fix app screenshot locally, but the meaningful before/after proof is the real named-bundle tool output above.

## Risk

Low. The change only aligns the executor with the permission types already advertised to the onboarding agent and reuses existing notification-permission AppState methods.

## Rollback

Revert this commit. No migrations or persisted data changes.

## AI Disclosure

Implemented with Codex assistance and locally verified in a named macOS test bundle plus focused Swift tests.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9039?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

