### PR TITLE
Gate export accessibility polling

### DIFF
--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/AgentConnectPickerSheet.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/AgentConnectPickerSheet.swift
@@ -124,7 +124,7 @@ private struct ConnectOptionCard: View {
   }
 
   var body: some View {
-    VStack(alignment: .leading, spacing: 12) {
+    let content = VStack(alignment: .leading, spacing: 12) {
       HStack(spacing: 12) {
         ConnectorBrandIcon(brand: destination.brand, size: 38, cornerRadius: 10)
         VStack(alignment: .leading, spacing: 2) {
@@ -189,12 +189,17 @@ private struct ConnectOptionCard: View {
       statuses[destination] = await MemoryExportService.shared.status(for: destination)
       await prepareMCPKeyIfNeeded()
     }
-    .onReceive(permissionRefreshTimer) { _ in
-      refreshPermissionStateIfNeeded()
-    }
     .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification))
     { _ in
       refreshPermissionStateIfNeeded()
+    }
+
+    if MemoryExportExecutor.accessibilityPreflightMissing(for: destination) {
+      content.onReceive(permissionRefreshTimer) { _ in
+        refreshPermissionStateIfNeeded()
+      }
+    } else {
+      content
     }
   }
 

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/AgentConnectPickerSheet.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/AgentConnectPickerSheet.swift
@@ -127,7 +127,7 @@ private struct ConnectOptionCard: View {
   }
 
   var body: some View {
-    VStack(alignment: .leading, spacing: OmiSpacing.md) {
+    let content = VStack(alignment: .leading, spacing: OmiSpacing.md) {
       HStack(spacing: OmiSpacing.md) {
         ConnectorBrandIcon(brand: destination.brand, size: 38, cornerRadius: SettingsGlassMetrics.cardRadius)
         VStack(alignment: .leading, spacing: OmiSpacing.hairline) {
@@ -212,12 +212,17 @@ private struct ConnectOptionCard: View {
       statuses[destination] = await MemoryExportService.shared.refreshCloudGrantConnectionStatus(for: destination)
       await prepareMCPKeyIfNeeded()
     }
-    .onReceive(permissionRefreshTimer) { _ in
-      refreshPermissionStateIfNeeded()
-    }
     .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
       refreshPermissionStateIfNeeded()
       refreshCloudGrantConnectionIfNeeded()
+    }
+
+    if MemoryExportExecutor.accessibilityPreflightMissing(for: destination) {
+      content.onReceive(permissionRefreshTimer) { _ in
+        refreshPermissionStateIfNeeded()
+      }
+    } else {
+      content
     }
   }
 

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryExportDestinationSheet.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryExportDestinationSheet.swift
@@ -442,7 +442,7 @@ struct MemoryExportDestinationSheet: View {
     .autoconnect()
 
   var body: some View {
-    VStack(alignment: .leading, spacing: 18) {
+    let sheet = VStack(alignment: .leading, spacing: 18) {
       HStack(alignment: .top, spacing: 14) {
         ConnectorBrandIcon(brand: destination.brand, size: 56, cornerRadius: 16)
 
@@ -496,12 +496,17 @@ struct MemoryExportDestinationSheet: View {
         await model.generateMCPKey()
       }
     }
-    .onReceive(permissionRefreshTimer) { _ in
-      refreshPermissionStateIfNeeded()
-    }
     .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification))
     { _ in
       refreshPermissionStateIfNeeded()
+    }
+
+    if MemoryExportExecutor.accessibilityPreflightMissing(for: destination) {
+      sheet.onReceive(permissionRefreshTimer) { _ in
+        refreshPermissionStateIfNeeded()
+      }
+    } else {
+      sheet
     }
   }
 

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryExportDestinationSheet.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryExportDestinationSheet.swift
@@ -499,7 +499,7 @@ struct MemoryExportDestinationSheet: View {
     .autoconnect()
 
   var body: some View {
-    VStack(alignment: .leading, spacing: OmiSpacing.lg) {
+    let sheet = VStack(alignment: .leading, spacing: OmiSpacing.lg) {
       HStack(alignment: .top, spacing: OmiSpacing.md) {
         ConnectorBrandIcon(brand: destination.brand, size: 56, cornerRadius: OmiChrome.controlRadius)
 
@@ -554,12 +554,17 @@ struct MemoryExportDestinationSheet: View {
         await model.generateMCPKey()
       }
     }
-    .onReceive(permissionRefreshTimer) { _ in
-      refreshPermissionStateIfNeeded()
-    }
     .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
       refreshPermissionStateIfNeeded()
       refreshCloudGrantConnectionIfNeeded()
+    }
+
+    if MemoryExportExecutor.accessibilityPreflightMissing(for: destination) {
+      sheet.onReceive(permissionRefreshTimer) { _ in
+        refreshPermissionStateIfNeeded()
+      }
+    } else {
+      sheet
     }
   }
 

--- a/desktop/macos/Desktop/Tests/BrowserAutomationTargetTests.swift
+++ b/desktop/macos/Desktop/Tests/BrowserAutomationTargetTests.swift
@@ -278,9 +278,9 @@ final class BrowserAutomationTargetTests: XCTestCase {
   func testClaudeNativeSetupWaitsForAccessibilityApprovalInsteadOfAgentFallback() {
     // Assisted-first Claude setup needs no Accessibility preflight; the check
     // only applies while a destination maps to .browserAutonomous.
-    XCTAssertFalse(MemoryExportExecutor.requiresAccessibilityPreflight(.claude))
-    XCTAssertFalse(MemoryExportExecutor.requiresAccessibilityPreflight(.chatgpt))
-    XCTAssertFalse(MemoryExportExecutor.requiresAccessibilityPreflight(.codex))
+    for destination in MemoryExportDestination.allCases {
+      XCTAssertFalse(MemoryExportExecutor.requiresAccessibilityPreflight(destination))
+    }
 
     XCTAssertTrue(
       MemoryExportExecutor.cloudFormFillRequiresAccessibilityApproval(
@@ -311,6 +311,28 @@ final class BrowserAutomationTargetTests: XCTestCase {
       MemoryExportExecutor.cloudFormFillNeedsManualClaudeAdd(
         "Error: Claude connector is added, but the Connect button is not exposed to Accessibility."
       )
+    )
+  }
+
+  func testExportConnectionSheetsPollAccessibilityOnlyWhilePreflightIsMissing() throws {
+    let pickerSource = try sourceFile("MainWindow/Pages/AgentConnectPickerSheet.swift")
+    let sheetSource = try sourceFile("MainWindow/Pages/MemoryExportDestinationSheet.swift")
+
+    XCTAssertTrue(
+      pickerSource.contains(
+        "if MemoryExportExecutor.accessibilityPreflightMissing(for: destination) {\n      content.onReceive(permissionRefreshTimer)"
+      )
+    )
+    XCTAssertTrue(
+      sheetSource.contains(
+        "if MemoryExportExecutor.accessibilityPreflightMissing(for: destination) {\n      sheet.onReceive(permissionRefreshTimer)"
+      )
+    )
+    XCTAssertTrue(
+      pickerSource.contains(".onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification))")
+    )
+    XCTAssertTrue(
+      sheetSource.contains(".onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification))")
     )
   }
 
@@ -864,4 +886,14 @@ extension Result {
     }
     return nil
   }
+}
+
+private func sourceFile(_ relativePath: String) throws -> String {
+  let testsURL = URL(fileURLWithPath: #filePath)
+    .deletingLastPathComponent()
+    .deletingLastPathComponent()
+  let sourceURL = testsURL
+    .appendingPathComponent("Sources")
+    .appendingPathComponent(relativePath)
+  return try String(contentsOf: sourceURL, encoding: .utf8)
 }

--- a/desktop/macos/Desktop/Tests/BrowserAutomationTargetTests.swift
+++ b/desktop/macos/Desktop/Tests/BrowserAutomationTargetTests.swift
@@ -337,10 +337,12 @@ import XCTest
       )
     )
     XCTAssertTrue(
-      pickerSource.contains(".onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification))")
+      pickerSource.contains(
+        ".onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification))")
     )
     XCTAssertTrue(
-      sheetSource.contains(".onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification))")
+      sheetSource.contains(
+        ".onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification))")
     )
   }
 
@@ -900,8 +902,10 @@ private func sourceFile(_ relativePath: String) throws -> String {
   let testsURL = URL(fileURLWithPath: #filePath)
     .deletingLastPathComponent()
     .deletingLastPathComponent()
-  let sourceURL = testsURL
+  let sourceURL =
+    testsURL
     .appendingPathComponent("Sources")
     .appendingPathComponent(relativePath)
+  // omi-test-quality: source-inspection -- static contract: pins that the export sheets subscribe the accessibility polling timer only while a preflight is missing
   return try String(contentsOf: sourceURL, encoding: .utf8)
 }

--- a/desktop/macos/Desktop/Tests/BrowserAutomationTargetTests.swift
+++ b/desktop/macos/Desktop/Tests/BrowserAutomationTargetTests.swift
@@ -286,9 +286,9 @@ import XCTest
   func testClaudeNativeSetupWaitsForAccessibilityApprovalInsteadOfAgentFallback() {
     // Assisted-first Claude setup needs no Accessibility preflight; the check
     // only applies while a destination maps to .browserAutonomous.
-    XCTAssertFalse(MemoryExportExecutor.requiresAccessibilityPreflight(.claude))
-    XCTAssertFalse(MemoryExportExecutor.requiresAccessibilityPreflight(.chatgpt))
-    XCTAssertFalse(MemoryExportExecutor.requiresAccessibilityPreflight(.codex))
+    for destination in MemoryExportDestination.allCases {
+      XCTAssertFalse(MemoryExportExecutor.requiresAccessibilityPreflight(destination))
+    }
 
     XCTAssertTrue(
       MemoryExportExecutor.cloudFormFillRequiresAccessibilityApproval(
@@ -319,6 +319,28 @@ import XCTest
       MemoryExportExecutor.cloudFormFillNeedsManualClaudeAdd(
         "Error: Claude connector is added, but the Connect button is not exposed to Accessibility."
       )
+    )
+  }
+
+  func testExportConnectionSheetsPollAccessibilityOnlyWhilePreflightIsMissing() throws {
+    let pickerSource = try sourceFile("MainWindow/Pages/AgentConnectPickerSheet.swift")
+    let sheetSource = try sourceFile("MainWindow/Pages/MemoryExportDestinationSheet.swift")
+
+    XCTAssertTrue(
+      pickerSource.contains(
+        "if MemoryExportExecutor.accessibilityPreflightMissing(for: destination) {\n      content.onReceive(permissionRefreshTimer)"
+      )
+    )
+    XCTAssertTrue(
+      sheetSource.contains(
+        "if MemoryExportExecutor.accessibilityPreflightMissing(for: destination) {\n      sheet.onReceive(permissionRefreshTimer)"
+      )
+    )
+    XCTAssertTrue(
+      pickerSource.contains(".onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification))")
+    )
+    XCTAssertTrue(
+      sheetSource.contains(".onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification))")
     )
   }
 
@@ -872,4 +894,14 @@ extension Result {
     }
     return nil
   }
+}
+
+private func sourceFile(_ relativePath: String) throws -> String {
+  let testsURL = URL(fileURLWithPath: #filePath)
+    .deletingLastPathComponent()
+    .deletingLastPathComponent()
+  let sourceURL = testsURL
+    .appendingPathComponent("Sources")
+    .appendingPathComponent(relativePath)
+  return try String(contentsOf: sourceURL, encoding: .utf8)
 }

--- a/desktop/macos/changelog/unreleased/20260705-export-accessibility-polling.json
+++ b/desktop/macos/changelog/unreleased/20260705-export-accessibility-polling.json
@@ -1,0 +1,3 @@
+{
+  "change": "Reduced background polling while setting up export connectors."
+}


### PR DESCRIPTION
## Summary
- Gate export connector accessibility polling so the 1-second timer is only subscribed while an accessibility preflight is actually missing.
- Apply the same gate to both export setup surfaces that had the timer.
- Keep the app-activation refresh path unchanged so future permission revocation/regrant flows still re-evaluate state.

## Why
The existing views installed an idle repeating timer even when no current export destination required accessibility preflight. This removes that background work without changing visible setup behavior.

## Validation
- `xcrun swift test -c debug --package-path Desktop --disable-keychain --disable-index-store --filter BrowserAutomationTargetTests`
- Pre-push desktop Swift compile passed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9041?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

## Product invariants affected

- INV-INT-1