### PR TITLE
Right-size import connector sheets

### DIFF
--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/AppsPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/AppsPage.swift
@@ -307,7 +307,7 @@ struct AppsPage: View {
                 onDismiss: {
                 selectedConnector = nil
             })
-            .frame(width: 520, height: 620)
+            .frame(width: connector.sheetPreferredSize.width, height: connector.sheetPreferredSize.height)
         }
         .dismissableSheet(item: $selectedExportDestination) { destination in
             ConnectDestinationSheet(
@@ -638,6 +638,15 @@ struct ImportConnector: Identifiable {
     let metricText: String?
     let actionTitle: String
     let isConnected: Bool
+
+    var sheetPreferredSize: CGSize {
+        switch id {
+        case "chatgpt", "claude":
+            return CGSize(width: 520, height: 620)
+        default:
+            return CGSize(width: 520, height: 360)
+        }
+    }
 
     static let all: [ImportConnector] = [
         ImportConnector(

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/AppsPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/AppsPage.swift
@@ -629,6 +629,8 @@ struct AppsPage: View {
 // MARK: - Imports Section
 
 struct ImportConnector: Identifiable {
+    private static let manualMemoryImportIDs: Set<String> = ["chatgpt", "claude"]
+
     let id: String
     let title: String
     let subtitle: String
@@ -639,13 +641,12 @@ struct ImportConnector: Identifiable {
     let actionTitle: String
     let isConnected: Bool
 
+    var isManualMemoryImport: Bool {
+        Self.manualMemoryImportIDs.contains(id)
+    }
+
     var sheetPreferredSize: CGSize {
-        switch id {
-        case "chatgpt", "claude":
-            return CGSize(width: 520, height: 620)
-        default:
-            return CGSize(width: 520, height: 360)
-        }
+        isManualMemoryImport ? CGSize(width: 520, height: 620) : CGSize(width: 520, height: 360)
     }
 
     static let all: [ImportConnector] = [
@@ -755,7 +756,6 @@ final class ImportConnectorStatusStore: ObservableObject {
     private let lastDeltaCountKeyPrefix = "appsImportConnectorLastDeltaCount."
     private let hasLastDeltaKeyPrefix = "appsImportConnectorHasLastDelta."
     private let availabilityTextKeyPrefix = "appsImportConnectorAvailabilityText."
-    private let manualConnectorIDs: Set<String> = ["chatgpt", "claude"]
     private let onboardingChatGPTImportedMemoriesKey = "onboardingChatGPTImportedMemoriesCount"
     private let onboardingClaudeImportedMemoriesKey = "onboardingClaudeImportedMemoriesCount"
 
@@ -772,7 +772,7 @@ final class ImportConnectorStatusStore: ObservableObject {
             || metrics.availabilityText != nil
             || connector.id == "local-files"
         let actionTitle: String
-        if manualConnectorIDs.contains(connector.id) {
+        if connector.isManualMemoryImport {
             actionTitle = isConnected ? "Update" : "Connect"
         } else {
             actionTitle = isConnected ? "Sync now" : "Connect"
@@ -974,7 +974,7 @@ final class ImportConnectorStatusStore: ObservableObject {
             return metricText
         }
 
-        return manualConnectorIDs.contains(connector.id) && isConnected ? "Imported earlier" : nil
+        return connector.isManualMemoryImport && isConnected ? "Imported earlier" : nil
     }
 
     private func sourceLabel(for connector: ImportConnector, count: Int) -> String {

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
@@ -303,7 +303,6 @@ struct DashboardPage: View {
     private static let homeConnectSheetMinHeight: CGFloat = 360
     private static let homeConnectSheetCornerRadius: CGFloat = 24
     private static let appDetailSheetPreferredSize = CGSize(width: 500, height: 600)
-    private static let importConnectorSheetPreferredSize = CGSize(width: 520, height: 500)
     private static let exportDestinationSheetPreferredSize = CGSize(width: 520, height: 560)
 
     private var homeConnectSheetIsPresented: Bool {
@@ -392,7 +391,7 @@ struct DashboardPage: View {
                     selectedImportConnector = nil
                 }
             )
-            .frame(width: 520, height: 620)
+            .frame(width: connector.sheetPreferredSize.width, height: connector.sheetPreferredSize.height)
         }
         .dismissableSheet(item: legacySelectedExportDestination) { destination in
             ConnectDestinationSheet(
@@ -560,6 +559,7 @@ struct DashboardPage: View {
                     contentWidth: proxy.size.width,
                     panelWidth: panelWidth,
                     panelHeight: panelHeight,
+                    availableHeight: proxy.size.height,
                     panelTop: panelTop
                 )
             }
@@ -638,6 +638,7 @@ struct DashboardPage: View {
         contentWidth: CGFloat,
         panelWidth: CGFloat,
         panelHeight: CGFloat,
+        availableHeight: CGFloat,
         panelTop: CGFloat
     ) -> some View {
         ZStack {
@@ -651,7 +652,7 @@ struct DashboardPage: View {
                     .transition(.opacity)
                     .zIndex(4)
 
-                let sheetSize = homeConnectSheetSize(panelWidth: panelWidth, panelHeight: panelHeight)
+                let sheetSize = homeConnectSheetSize(panelWidth: panelWidth, availableHeight: availableHeight)
 
                 homeConnectSheetContent()
                     .frame(width: sheetSize.width, height: sheetSize.height)
@@ -679,7 +680,7 @@ struct DashboardPage: View {
         .zIndex(4)
     }
 
-    private func homeConnectSheetSize(panelWidth: CGFloat, panelHeight: CGFloat) -> CGSize {
+    private func homeConnectSheetSize(panelWidth: CGFloat, availableHeight: CGFloat) -> CGSize {
         let preferred = homeConnectSheetPreferredSize
         return CGSize(
             width: min(
@@ -688,7 +689,7 @@ struct DashboardPage: View {
             ),
             height: min(
                 preferred.height,
-                max(Self.homeConnectSheetMinHeight, panelHeight - (Self.homeConnectSheetVerticalMargin * 2))
+                max(Self.homeConnectSheetMinHeight, availableHeight - (Self.homeConnectSheetVerticalMargin * 2))
             )
         )
     }
@@ -697,8 +698,8 @@ struct DashboardPage: View {
         if selectedCatalogApp != nil {
             return Self.appDetailSheetPreferredSize
         }
-        if selectedImportConnector != nil {
-            return Self.importConnectorSheetPreferredSize
+        if let connector = selectedImportConnector {
+            return connector.sheetPreferredSize
         }
         return Self.exportDestinationSheetPreferredSize
     }

--- a/desktop/macos/Desktop/Tests/ImportConnectorSheetSizingTests.swift
+++ b/desktop/macos/Desktop/Tests/ImportConnectorSheetSizingTests.swift
@@ -5,17 +5,18 @@ import XCTest
 
 final class ImportConnectorSheetSizingTests: XCTestCase {
     func testSimpleImportConnectorsUseCompactSheetSize() {
-        let memoryImportIDs: Set<String> = ["chatgpt", "claude"]
-
-        for connector in ImportConnector.all where !memoryImportIDs.contains(connector.id) {
+        for connector in ImportConnector.all where !connector.isManualMemoryImport {
             XCTAssertEqual(connector.sheetPreferredSize, CGSize(width: 520, height: 360), connector.id)
         }
     }
 
     func testMemoryImportConnectorsKeepEditorSheetSize() throws {
-        for connectorID in ["chatgpt", "claude"] {
-            let connector = try XCTUnwrap(ImportConnector.all.first { $0.id == connectorID })
-            XCTAssertEqual(connector.sheetPreferredSize, CGSize(width: 520, height: 620), connectorID)
+        let memoryImportConnectors = ImportConnector.all.filter(\.isManualMemoryImport)
+
+        XCTAssertFalse(memoryImportConnectors.isEmpty)
+
+        for connector in memoryImportConnectors {
+            XCTAssertEqual(connector.sheetPreferredSize, CGSize(width: 520, height: 620), connector.id)
         }
     }
 }

--- a/desktop/macos/Desktop/Tests/ImportConnectorSheetSizingTests.swift
+++ b/desktop/macos/Desktop/Tests/ImportConnectorSheetSizingTests.swift
@@ -1,0 +1,21 @@
+import CoreGraphics
+import XCTest
+
+@testable import Omi_Computer
+
+final class ImportConnectorSheetSizingTests: XCTestCase {
+    func testSimpleImportConnectorsUseCompactSheetSize() {
+        let memoryImportIDs: Set<String> = ["chatgpt", "claude"]
+
+        for connector in ImportConnector.all where !memoryImportIDs.contains(connector.id) {
+            XCTAssertEqual(connector.sheetPreferredSize, CGSize(width: 520, height: 360), connector.id)
+        }
+    }
+
+    func testMemoryImportConnectorsKeepEditorSheetSize() throws {
+        for connectorID in ["chatgpt", "claude"] {
+            let connector = try XCTUnwrap(ImportConnector.all.first { $0.id == connectorID })
+            XCTAssertEqual(connector.sheetPreferredSize, CGSize(width: 520, height: 620), connectorID)
+        }
+    }
+}

--- a/desktop/macos/Desktop/Tests/ImportConnectorSheetSizingTests.swift
+++ b/desktop/macos/Desktop/Tests/ImportConnectorSheetSizingTests.swift
@@ -5,7 +5,11 @@ import XCTest
 
 final class ImportConnectorSheetSizingTests: XCTestCase {
     func testSimpleImportConnectorsUseCompactSheetSize() {
-        for connector in ImportConnector.all where !connector.isManualMemoryImport {
+        let simpleImportConnectors = ImportConnector.all.filter { !$0.isManualMemoryImport }
+
+        XCTAssertFalse(simpleImportConnectors.isEmpty)
+
+        for connector in simpleImportConnectors {
             XCTAssertEqual(connector.sheetPreferredSize, CGSize(width: 520, height: 360), connector.id)
         }
     }

--- a/desktop/macos/changelog/unreleased/20260704-right-size-import-sheets.json
+++ b/desktop/macos/changelog/unreleased/20260704-right-size-import-sheets.json
@@ -1,0 +1,3 @@
+{
+  "change": "Right-sized import connector setup sheets"
+}


### PR DESCRIPTION
## Summary
- Give import connectors preferred sheet sizes instead of one fixed height for every connector.
- Keep memory-import sheets tall enough for the text editor while using compact sheets for simple source connectors.
- Cover both Home and Apps presentation paths with the same sizing contract.

## Why
Simple connector sheets were visually oversized, leaving large dead space and making the modal feel less intentional.

## Validation
- `xcrun swift test -c debug --package-path Desktop --disable-keychain --disable-index-store --filter ImportConnectorSheetSizingTests`
- Pre-push desktop Swift compile passed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9043?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

