### PR TITLE
Fix import connector connection state

### DIFF
--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/AppsPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/AppsPage.swift
@@ -1441,12 +1441,7 @@ private final class ImportConnectorSheetModel: ObservableObject {
         return SyncResult(sourceCount: notes.count, memoryCount: memoryCount, newItems: notes.count)
     }
 
-    func rescanLocalFiles(appState: AppState?) async -> SyncResult? {
-        guard let appState else {
-            errorMessage = "App state is unavailable right now."
-            return nil
-        }
-
+    func rescanLocalFiles() async -> SyncResult? {
         beginRun(
             title: "Indexing local files",
             detail: "Scanning your on-device files so Omi can use them in memory search."
@@ -1454,12 +1449,16 @@ private final class ImportConnectorSheetModel: ObservableObject {
         defer { finishRun() }
 
         let previousCount = await currentIndexedFileCount()
-        ChatToolExecutor.onboardingAppState = appState
         AnalyticsManager.shared.onboardingChatToolUsed(
             tool: "scan_files",
             properties: ["surface": "import_connector_sheet"]
         )
         let result = await ChatToolExecutor.scanLocalFiles()
+
+        if !result.didCompleteSuccessfully {
+            errorMessage = result.summaryText
+            return nil
+        }
 
         if !result.hasReadableUserFileTarget {
             errorMessage = result.summaryText
@@ -1624,7 +1623,7 @@ struct ImportConnectorSheet: View {
                             )
                         }
                     case "local-files":
-                        if let result = await model.rescanLocalFiles(appState: appState) {
+                        if let result = await model.rescanLocalFiles() {
                             statusStore.markSynced(
                                 connectorID: connector.id,
                                 sourceCount: result.sourceCount,

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/AppsPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/AppsPage.swift
@@ -668,10 +668,10 @@ struct ImportConnector: Identifiable {
             subtitle: "This Mac",
             description: "Index documents, code, and working folders.",
             brand: .localFiles,
-            statusText: "Connected",
-            metricText: "Available on this device",
-            actionTitle: "Connected",
-            isConnected: true
+            statusText: "Not connected",
+            metricText: nil,
+            actionTitle: "Connect",
+            isConnected: false
         ),
         ImportConnector(
             id: "apple-notes",
@@ -757,11 +757,7 @@ final class ImportConnectorStatusStore: ObservableObject {
 
     func snapshot(for connector: ImportConnector) -> Snapshot {
         let metrics = metricsByID[connector.id] ?? ConnectorMetrics()
-        let isConnected =
-            metrics.memoryCount.map { $0 > 0 } ?? false
-            || metrics.sourceCount.map { $0 > 0 } ?? false
-            || metrics.availabilityText != nil
-            || connector.id == "local-files"
+        let isConnected = isConnected(connector: connector, metrics: metrics)
         let actionTitle: String
         if manualConnectorIDs.contains(connector.id) {
             actionTitle = isConnected ? "Update" : "Connect"
@@ -894,9 +890,18 @@ final class ImportConnectorStatusStore: ObservableObject {
 
             var metrics = metricsByID["local-files"] ?? ConnectorMetrics()
             metrics.sourceCount = result.count
-            metrics.lastSyncedAt = result.lastIndexedAt
-            metrics.availabilityText = "On-device index"
-            defaults.set("On-device index", forKey: availabilityTextKeyPrefix + "local-files")
+            defaults.set(result.count, forKey: sourceCountKeyPrefix + "local-files")
+            if metrics.lastSyncedAt == nil, let lastIndexedAt = result.lastIndexedAt {
+                metrics.lastSyncedAt = lastIndexedAt
+                defaults.set(lastIndexedAt.timeIntervalSince1970, forKey: lastSyncedAtKeyPrefix + "local-files")
+            }
+            if metrics.lastSyncedAt != nil || result.count > 0 {
+                metrics.availabilityText = "On-device index"
+                defaults.set("On-device index", forKey: availabilityTextKeyPrefix + "local-files")
+            } else {
+                metrics.availabilityText = nil
+                defaults.removeObject(forKey: availabilityTextKeyPrefix + "local-files")
+            }
             metricsByID["local-files"] = metrics
         } catch {
             log("ImportConnectorStatusStore: Failed to refresh local files metrics: \(error)")
@@ -909,6 +914,12 @@ final class ImportConnectorStatusStore: ObservableObject {
         case .connected(let noteCount, _):
             var metrics = metricsByID["apple-notes"] ?? ConnectorMetrics()
             metrics.sourceCount = noteCount
+            defaults.set(noteCount, forKey: sourceCountKeyPrefix + "apple-notes")
+            if metrics.lastSyncedAt == nil {
+                let syncedAt = Date()
+                metrics.lastSyncedAt = syncedAt
+                defaults.set(syncedAt.timeIntervalSince1970, forKey: lastSyncedAtKeyPrefix + "apple-notes")
+            }
             metrics.availabilityText = "Private notes accessible"
             defaults.set("Private notes accessible", forKey: availabilityTextKeyPrefix + "apple-notes")
             metricsByID["apple-notes"] = metrics
@@ -916,6 +927,14 @@ final class ImportConnectorStatusStore: ObservableObject {
             log("ImportConnectorStatusStore: Apple Notes refresh unavailable code=\(reasonCode)")
             clearStoredMetrics(for: "apple-notes")
         }
+    }
+
+    private func isConnected(connector: ImportConnector, metrics: ConnectorMetrics) -> Bool {
+        if metrics.lastSyncedAt != nil {
+            return true
+        }
+
+        return manualConnectorIDs.contains(connector.id) && (metrics.memoryCount ?? 0) > 0
     }
 
     private func primaryText(
@@ -928,7 +947,7 @@ final class ImportConnectorStatusStore: ObservableObject {
                 return
                     "\(sourceCount.formatted()) \(sourceLabel(for: connector, count: sourceCount)) • \(memoryCount.formatted()) memories"
             }
-            if connector.id == "local-files" || sourceCount > 0 {
+            if isConnected || sourceCount > 0 {
                 return "\(sourceCount.formatted()) \(sourceLabel(for: connector, count: sourceCount))"
             }
         }
@@ -1436,15 +1455,17 @@ private final class ImportConnectorSheetModel: ObservableObject {
 
         let previousCount = await currentIndexedFileCount()
         ChatToolExecutor.onboardingAppState = appState
-        let result = await ChatToolExecutor.execute(
-            ToolCall(name: "scan_files", arguments: [:], thoughtSignature: nil)
+        AnalyticsManager.shared.onboardingChatToolUsed(
+            tool: "scan_files",
+            properties: ["surface": "import_connector_sheet"]
         )
+        let result = await ChatToolExecutor.scanLocalFiles()
 
-        if result.lowercased().hasPrefix("error") {
-            errorMessage = result
+        if !result.hasReadableUserFileTarget {
+            errorMessage = result.summaryText
             return nil
         } else {
-            statusMessage = result
+            statusMessage = result.summaryText
             let updatedCount = await currentIndexedFileCount()
             let newItems = max(updatedCount - previousCount, 0)
             return SyncResult(sourceCount: updatedCount, memoryCount: nil, newItems: newItems)
@@ -1707,7 +1728,7 @@ struct ImportConnectorSheet: View {
         case "x":
             return model.isRunning ? "Connecting…" : (snapshot.isConnected ? "Sync now" : "Connect X")
         case "local-files":
-            return model.isRunning ? "Reindexing…" : "Reindex Local Files"
+            return model.isRunning ? "Reindexing…" : (snapshot.isConnected ? "Reindex Local Files" : "Index Local Files")
         default:
             return model.isRunning ? "Working…" : connector.actionTitle
         }

--- a/desktop/macos/Desktop/Sources/Providers/ChatToolExecutor.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatToolExecutor.swift
@@ -62,6 +62,11 @@ class ChatToolExecutor {
     ]
   }
 
+  struct LocalFileScanOutcome {
+    let hasReadableUserFileTarget: Bool
+    let summaryText: String
+  }
+
   static func resumeFollowup(with reply: String) {
     followupContinuation?.resume(returning: reply)
     followupContinuation = nil
@@ -1247,36 +1252,42 @@ class ChatToolExecutor {
   }
 
   /// Scan files BLOCKING — triggers folder access dialogs, waits for scan, returns results
-  private static func executeScanFiles(_ args: [String: Any]) async -> String {
+  private static func executeScanFiles(_: [String: Any]) async -> String {
+    await scanLocalFiles().summaryText
+  }
+
+  static func scanLocalFiles() async -> LocalFileScanOutcome {
     let fm = FileManager.default
     let homeDir = fm.homeDirectoryForCurrentUser
-    let scanTargets: [(label: String, pathForUser: String, url: URL)] = {
-      var targets: [(String, String, URL)] = []
+    let scanTargets: [(label: String, pathForUser: String, url: URL, countsAsUserFileAccess: Bool)] = {
+      var targets: [(String, String, URL, Bool)] = []
 
       let homeFolders = ["Downloads", "Documents", "Desktop", "Developer", "Projects"]
       for folder in homeFolders {
         let url = homeDir.appendingPathComponent(folder)
         if fm.fileExists(atPath: url.path) {
-          targets.append((folder, "~/\(folder)", url))
+          targets.append((folder, "~/\(folder)", url, true))
         }
       }
 
       let applicationsURL = URL(fileURLWithPath: "/Applications")
       if fm.fileExists(atPath: applicationsURL.path) {
-        targets.append(("Applications", "/Applications", applicationsURL))
+        targets.append(("Applications", "/Applications", applicationsURL, false))
       }
 
       // Apple Notes local stores (container + group container)
-      let notesCandidates: [(String, String, URL)] = [
+      let notesCandidates: [(String, String, URL, Bool)] = [
         (
           "Apple Notes (Container)",
           "~/Library/Containers/com.apple.Notes/Data/Library/Notes",
-          homeDir.appendingPathComponent("Library/Containers/com.apple.Notes/Data/Library/Notes")
+          homeDir.appendingPathComponent("Library/Containers/com.apple.Notes/Data/Library/Notes"),
+          false
         ),
         (
           "Apple Notes (Group)",
           "~/Library/Group Containers/group.com.apple.notes",
-          homeDir.appendingPathComponent("Library/Group Containers/group.com.apple.notes")
+          homeDir.appendingPathComponent("Library/Group Containers/group.com.apple.notes"),
+          false
         ),
       ]
       for candidate in notesCandidates where fm.fileExists(atPath: candidate.2.path) {
@@ -1289,6 +1300,7 @@ class ChatToolExecutor {
     // Pre-check folder access — this triggers macOS TCC dialogs
     var deniedFolders: [String] = []
     var accessibleFolders: [URL] = []
+    var readableUserFileTargetCount = 0
     for target in scanTargets {
       do {
         _ = try fm.contentsOfDirectory(
@@ -1297,6 +1309,9 @@ class ChatToolExecutor {
           options: [.skipsHiddenFiles]
         )
         accessibleFolders.append(target.url)
+        if target.countsAsUserFileAccess {
+          readableUserFileTargetCount += 1
+        }
       } catch {
         let nsError = error as NSError
         if nsError.domain == NSCocoaErrorDomain && nsError.code == 257 {
@@ -1334,7 +1349,9 @@ class ChatToolExecutor {
     // Notify that scan completed — triggers parallel exploration
     onScanFilesCompleted?(count)
 
-    return out
+    return LocalFileScanOutcome(
+      hasReadableUserFileTarget: readableUserFileTargetCount > 0,
+      summaryText: out)
   }
 
   /// Get file scan results from the database

--- a/desktop/macos/Desktop/Sources/Providers/ChatToolExecutor.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatToolExecutor.swift
@@ -64,6 +64,8 @@ class ChatToolExecutor {
 
   struct LocalFileScanOutcome {
     let hasReadableUserFileTarget: Bool
+    let didCompleteSuccessfully: Bool
+    let indexedFileCount: Int
     let summaryText: String
   }
 
@@ -1253,7 +1255,10 @@ class ChatToolExecutor {
 
   /// Scan files BLOCKING — triggers folder access dialogs, waits for scan, returns results
   private static func executeScanFiles(_: [String: Any]) async -> String {
-    await scanLocalFiles().summaryText
+    let outcome = await scanLocalFiles()
+    fileScanFileCount = outcome.indexedFileCount
+    onScanFilesCompleted?(outcome.indexedFileCount)
+    return outcome.summaryText
   }
 
   static func scanLocalFiles() async -> LocalFileScanOutcome {
@@ -1326,7 +1331,6 @@ class ChatToolExecutor {
 
     // Actually scan accessible folders (blocking)
     let count = await FileIndexerService.shared.scanFolders(accessibleFolders)
-    fileScanFileCount = count
     log(
       "Onboarding file scan completed: \(count) files indexed, \(deniedFolders.count) folders denied"
     )
@@ -1346,11 +1350,10 @@ class ChatToolExecutor {
         "\nTell the user to click 'Allow' on the macOS dialogs, then call scan_files again to pick up those folders."
     }
 
-    // Notify that scan completed — triggers parallel exploration
-    onScanFilesCompleted?(count)
-
     return LocalFileScanOutcome(
       hasReadableUserFileTarget: readableUserFileTargetCount > 0,
+      didCompleteSuccessfully: !resultsStr.lowercased().hasPrefix("error"),
+      indexedFileCount: count,
       summaryText: out)
   }
 

--- a/desktop/macos/Desktop/Tests/ImportConnectorStatusStoreTests.swift
+++ b/desktop/macos/Desktop/Tests/ImportConnectorStatusStoreTests.swift
@@ -14,24 +14,90 @@ final class ImportConnectorStatusStoreTests: XCTestCase {
     super.tearDown()
   }
 
-  func testAvailabilityTextMarksZeroCountConnectorConnectedAcrossStoreReloads() {
-    let connector = ImportConnector.all.first { $0.id == "apple-notes" }!
+  func testSuccessfulZeroCountImportStaysConnectedAcrossStoreReloads() {
+    let connector = ImportConnector.all.first { $0.id == "email" }!
+    let syncedAt = Date(timeIntervalSince1970: 1_700_000_000)
     let store = ImportConnectorStatusStore()
 
     store.markSynced(
-      connectorID: "apple-notes",
+      connectorID: "email",
       sourceCount: 0,
       memoryCount: 0,
       lastDeltaCount: 0,
-      availabilityText: "Private notes accessible")
+      syncedAt: syncedAt)
 
     let immediate = store.snapshot(for: connector)
     let reloaded = ImportConnectorStatusStore().snapshot(for: connector)
 
     XCTAssertTrue(immediate.isConnected)
     XCTAssertEqual(immediate.actionTitle, "Sync now")
+    XCTAssertEqual(immediate.primaryText, "0 emails")
     XCTAssertTrue(reloaded.isConnected)
-    XCTAssertEqual(reloaded.primaryText, "Private notes accessible")
+    XCTAssertEqual(reloaded.primaryText, "0 emails")
+  }
+
+  func testLocalFilesStartNotConnectedWithoutSuccessfulScan() {
+    let connector = ImportConnector.all.first { $0.id == "local-files" }!
+    let snapshot = ImportConnectorStatusStore().snapshot(for: connector)
+
+    XCTAssertFalse(snapshot.isConnected)
+    XCTAssertEqual(snapshot.actionTitle, "Connect")
+    XCTAssertEqual(snapshot.primaryText, "Not connected")
+  }
+
+  func testSuccessfulZeroFileScanStaysConnectedAcrossStoreReloads() {
+    let connector = ImportConnector.all.first { $0.id == "local-files" }!
+    let syncedAt = Date(timeIntervalSince1970: 1_700_000_000)
+    let store = ImportConnectorStatusStore()
+
+    store.markSynced(
+      connectorID: "local-files",
+      sourceCount: 0,
+      memoryCount: nil,
+      lastDeltaCount: 0,
+      availabilityText: "On-device index",
+      syncedAt: syncedAt)
+
+    let immediate = store.snapshot(for: connector)
+    let reloaded = ImportConnectorStatusStore().snapshot(for: connector)
+
+    XCTAssertTrue(immediate.isConnected)
+    XCTAssertEqual(immediate.actionTitle, "Sync now")
+    XCTAssertEqual(immediate.primaryText, "0 files indexed")
+    XCTAssertTrue(reloaded.isConnected)
+    XCTAssertEqual(reloaded.primaryText, "0 files indexed")
+  }
+
+  func testAvailabilityTextAloneDoesNotMarkConnectorConnected() {
+    let connector = ImportConnector.all.first { $0.id == "apple-notes" }!
+    UserDefaults.standard.set("Private notes accessible", forKey: "appsImportConnectorAvailabilityText.apple-notes")
+
+    let store = ImportConnectorStatusStore()
+    let snapshot = store.snapshot(for: connector)
+    let reloaded = ImportConnectorStatusStore().snapshot(for: connector)
+
+    XCTAssertFalse(snapshot.isConnected)
+    XCTAssertFalse(reloaded.isConnected)
+  }
+
+  func testPositiveCountWithoutSuccessfulSyncDoesNotMarkConnectorConnected() {
+    let connector = ImportConnector.all.first { $0.id == "calendar" }!
+
+    UserDefaults.standard.set(3, forKey: "appsImportConnectorSourceCount.calendar")
+    let snapshot = ImportConnectorStatusStore().snapshot(for: connector)
+
+    XCTAssertFalse(snapshot.isConnected)
+    XCTAssertEqual(snapshot.actionTitle, "Connect")
+  }
+
+  func testLegacyManualImportCountStillMarksConnectorConnected() {
+    let connector = ImportConnector.all.first { $0.id == "chatgpt" }!
+
+    UserDefaults.standard.set(4, forKey: "onboardingChatGPTImportedMemoriesCount")
+    let snapshot = ImportConnectorStatusStore().snapshot(for: connector)
+
+    XCTAssertTrue(snapshot.isConnected)
+    XCTAssertEqual(snapshot.actionTitle, "Update")
   }
 
   private func resetImportConnectorDefaults() {
@@ -48,5 +114,7 @@ final class ImportConnectorStatusStoreTests: XCTestCase {
         UserDefaults.standard.removeObject(forKey: prefix + connector.id)
       }
     }
+    UserDefaults.standard.removeObject(forKey: "onboardingChatGPTImportedMemoriesCount")
+    UserDefaults.standard.removeObject(forKey: "onboardingClaudeImportedMemoriesCount")
   }
 }

--- a/desktop/macos/changelog/unreleased/20260705-import-connector-status.json
+++ b/desktop/macos/changelog/unreleased/20260705-import-connector-status.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed import connector status so sources no longer appear connected before setup and zero-item imports stay connected."
+}


### PR DESCRIPTION
## Summary
- Stop hardcoding local files as connected before setup.
- Treat successful source access/sync as the connector state marker, including successful zero-item imports.
- Preserve local-files scan analytics while using a structured scan result instead of parsing tool output strings.
- Keep legacy manual memory imports connected.

## Why
Connector rows should reflect whether Omi actually has source access, not whether a count or availability label happened to exist.

## Validation
- `xcrun swift test -c debug --package-path Desktop --disable-keychain --disable-index-store --filter ImportConnectorStatusStoreTests`
- Pre-push desktop Swift compile passed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9044?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

