### PR TITLE
perf(desktop): batch Gmail import feed fetches

### DIFF
--- a/desktop/macos/Desktop/Sources/GmailReaderService.swift
+++ b/desktop/macos/Desktop/Sources/GmailReaderService.swift
@@ -135,10 +135,85 @@ enum GmailOutcomeParser {
   }
 }
 
+struct GmailAtomBatchResponse {
+  let requestID: String
+  let browser: String
+  let source: String
+  let emails: [[String: Any]]
+}
+
+enum GmailAtomBatchOutcome {
+  case success([GmailAtomBatchResponse])
+  case failure(GmailFailureClass, summary: String, attempts: [GmailAttempt])
+}
+
+enum GmailAtomBatchParser {
+  static func parse(_ json: [String: Any]) -> GmailAtomBatchOutcome {
+    if json["ok"] as? Bool == true {
+      // The helper always emits a `responses` array on success (possibly empty).
+      // Its absence means the payload didn't come from this script's contract.
+      guard let responses = json["responses"] as? [[String: Any]] else {
+        return .failure(.unknown, summary: "Gmail batch response missing responses", attempts: [])
+      }
+      let fallbackBrowser = json["browser"] as? String ?? "unknown"
+      let fallbackSource = json["source"] as? String ?? "unknown"
+      return .success(
+        responses.map { response in
+          GmailAtomBatchResponse(
+            requestID: response["id"] as? String ?? "unknown",
+            browser: response["browser"] as? String ?? fallbackBrowser,
+            source: response["source"] as? String ?? fallbackSource,
+            emails: response["emails"] as? [[String: Any]] ?? []
+          )
+        }
+      )
+    }
+
+    if case let .failure(cls, summary, attempts) = GmailOutcomeParser.parse(json) {
+      return .failure(cls, summary: summary, attempts: attempts)
+    }
+
+    return .failure(.unknown, summary: "unexpected Gmail batch response", attempts: [])
+  }
+}
+
+private struct GmailAtomBatchRequest {
+  let id: String
+  let maxResults: Int
+  let query: String
+  let feedPath: String?
+  let useBootstrap: Bool
+
+  var jsonObject: [String: Any] {
+    [
+      "id": id,
+      "max_results": maxResults,
+      "query": query,
+      "feed_path": feedPath ?? "",
+      "use_bootstrap": useBootstrap,
+    ]
+  }
+}
+
 // MARK: - GmailReaderService
 
 actor GmailReaderService {
   static let shared = GmailReaderService()
+  private static let labelFeedPaths = [
+    "atom/all",
+    "atom/inbox",
+    "atom/sent",
+    "atom/starred",
+    "atom/important",
+    "atom/trash",
+    "atom/spam",
+    "atom/unread",
+    "atom/social",
+    "atom/promotions",
+    "atom/updates",
+    "atom/forums",
+    "atom/personal",
+  ]
 
   /// Read emails using browser cookies + Gmail Atom feed.
   /// - Parameters:
@@ -149,15 +224,12 @@ actor GmailReaderService {
   {
     let emails: [GmailEmail]
     if let days = Self.parseNewerThanDays(query), days > 20 {
-      let queryEmails = try fetchGmailViaAtomFeedSingle(
+      let fetched = try fetchGmailViaCombinedAtomFeeds(
         maxResults: maxResults,
-        query: query,
-        feedPath: nil,
-        allowBootstrap: false
+        query: query
       )
-      let labelEmails = try fetchGmailViaLabelFeeds(maxResults: maxResults, query: query)
       var merged: [String: GmailEmail] = [:]
-      for email in queryEmails + labelEmails {
+      for email in fetched.queryEmails + fetched.labelEmails {
         let existing = merged[email.id]
         if existing == nil || existing!.date < email.date {
           merged[email.id] = email
@@ -412,31 +484,144 @@ actor GmailReaderService {
     let shouldUseBootstrapPage =
       allowBootstrap ?? (feedPath == nil && Self.parseNewerThanDays(query) != nil)
 
-    let browserConfigs = BrowserGoogleSession.configsForPython(logPrefix: "GmailReaderService")
+    let request = GmailAtomBatchRequest(
+      id: "single",
+      maxResults: maxResults,
+      query: query,
+      feedPath: feedPath,
+      useBootstrap: shouldUseBootstrapPage
+    )
+    let responses = try fetchGmailViaAtomFeedBatch(
+      requests: [request],
+      maxConcurrentRequests: 1
+    )
+    guard let response = responses[request.id] else {
+      throw GmailReaderError.networkError("Gmail helper did not return response")
+    }
+    log(
+      "GmailReaderService: Got \(response.emails.count) emails from \(response.browser) via \(response.source)"
+    )
+    return response.emails
+  }
 
+  private func fetchGmailViaCombinedAtomFeeds(maxResults: Int, query: String) throws -> (
+    queryEmails: [GmailEmail], labelEmails: [GmailEmail]
+  ) {
+    guard maxResults > 0 else { return ([], []) }
+
+    var requests = [
+      GmailAtomBatchRequest(
+        id: "query",
+        maxResults: maxResults,
+        query: query,
+        feedPath: nil,
+        useBootstrap: false
+      )
+    ]
+    requests.append(
+      contentsOf: Self.labelFeedPaths.map { feedPath in
+        GmailAtomBatchRequest(
+          id: "label:\(feedPath)",
+          maxResults: min(20, maxResults),
+          query: query,
+          feedPath: feedPath,
+          useBootstrap: false
+        )
+      }
+    )
+
+    let responses = try fetchGmailViaAtomFeedBatch(
+      requests: requests,
+      maxConcurrentRequests: 4
+    )
+    guard let queryResponse = responses["query"] else {
+      throw GmailReaderError.networkError("Gmail batch helper did not return query response")
+    }
+
+    log(
+      "GmailReaderService: Got \(queryResponse.emails.count) emails from \(queryResponse.browser) via \(queryResponse.source)"
+    )
+
+    var labelMerged: [String: GmailEmail] = [:]
+    for feedPath in Self.labelFeedPaths {
+      guard let response = responses["label:\(feedPath)"] else {
+        throw GmailReaderError.networkError("Gmail batch helper did not return \(feedPath) response")
+      }
+      for email in response.emails {
+        let existing = labelMerged[email.id]
+        if existing == nil || existing!.date < email.date {
+          labelMerged[email.id] = email
+        }
+      }
+    }
+
+    log(
+      "GmailReaderService: Collected \(labelMerged.count) unique emails across \(Self.labelFeedPaths.count) label feeds"
+    )
+
+    let labelEmails = Array(labelMerged.values)
+      .sorted { $0.date > $1.date }
+      .prefix(maxResults)
+      .map(\.self)
+
+    return (queryResponse.emails, labelEmails)
+  }
+
+  /// Overall fetch budget: one serial probe wave plus however many parallel
+  /// waves the remaining requests need at the given width. Keeps worst-case
+  /// time-to-error a designed number instead of `requests.count * 60`.
+  static func batchBudgetSeconds(requestCount: Int, maxConcurrentRequests: Int) -> Int {
+    guard requestCount > 1 else { return 60 }
+    let workers = max(1, maxConcurrentRequests)
+    let remaining = requestCount - 1
+    let parallelWaves = (remaining + workers - 1) / workers
+    return 60 * (1 + parallelWaves)
+  }
+
+  private func fetchGmailViaAtomFeedBatch(
+    requests: [GmailAtomBatchRequest],
+    maxConcurrentRequests: Int
+  ) throws -> [String: (emails: [GmailEmail], browser: String, source: String)] {
+    guard !requests.isEmpty else { return [:] }
+
+    let browserConfigs = BrowserGoogleSession.configsForPython(logPrefix: "GmailReaderService")
     guard !browserConfigs.isEmpty else {
       throw GmailReaderError.noBrowserFound
     }
 
-    let configJSON: String
+    let budgetSeconds = Self.batchBudgetSeconds(
+      requestCount: requests.count,
+      maxConcurrentRequests: maxConcurrentRequests
+    )
+
+    let payloadJSON: String
     do {
-      let data = try JSONSerialization.data(withJSONObject: browserConfigs)
-      configJSON = String(data: data, encoding: .utf8) ?? "[]"
+      let payload: [String: Any] = [
+        "browsers": browserConfigs,
+        "requests": requests.map(\.jsonObject),
+        "max_workers": max(1, maxConcurrentRequests),
+        "deadline_seconds": budgetSeconds,
+      ]
+      let data = try JSONSerialization.data(withJSONObject: payload)
+      payloadJSON = String(data: data, encoding: .utf8) ?? "{}"
     } catch {
       throw GmailReaderError.networkError("Failed to serialize browser configs")
     }
 
     let pythonScript = """
       \(BrowserGoogleSession.chromiumCookiePythonSupport)
+      import shutil
+      import tempfile
       import xml.etree.ElementTree as ET
+      from concurrent.futures import ThreadPoolExecutor, as_completed
       from urllib.parse import quote
       from urllib.request import Request, build_opener, HTTPCookieProcessor
 
-      browsers = json.loads(sys.stdin.read())
-      max_results = int(sys.argv[1]) if len(sys.argv) > 1 else 50
-      query = sys.argv[2] if len(sys.argv) > 2 else 'newer_than:1d'
-      use_bootstrap = (sys.argv[3] if len(sys.argv) > 3 else '1') == '1'
-      feed_path = sys.argv[4] if len(sys.argv) > 4 else ''
+      payload = json.loads(sys.stdin.read())
+      browsers = payload.get('browsers', [])
+      requests = payload.get('requests', [])
+      max_workers = max(1, int(payload.get('max_workers', 4)))
+      deadline = time.monotonic() + float(payload.get('deadline_seconds', 300))
 
       def fetch_home_page(jar):
           opener = build_opener(HTTPCookieProcessor(jar))
@@ -555,8 +740,10 @@ actor GmailReaderService {
 
           return emails[:max_results], None
 
-      def fetch_atom_feed(jar):
+      def fetch_atom_feed(jar, request):
           opener = build_opener(HTTPCookieProcessor(jar))
+          query = request.get('query') or ''
+          feed_path = request.get('feed_path') or ''
           if feed_path:
               url = f'https://mail.google.com/mail/feed/{feed_path.lstrip("/")}'
               if query:
@@ -630,8 +817,6 @@ actor GmailReaderService {
               })
           return emails, None
 
-      attempts = []
-
       def classify(attempts):
           if not attempts:
               return 'no_browser', 'No supported browser with a readable Gmail session was found.'
@@ -644,47 +829,217 @@ actor GmailReaderService {
               return 'not_signed_in', 'No browser is signed into Gmail. Sign into mail.google.com and try again.'
           return 'decrypt_failed', 'Your browser session could not be read.'
 
-      # Try each browser/profile and keep every non-sensitive attempt.
-      for browser in browsers:
-          cookies, err = decrypt_google_cookies(browser['db_path'], browser['password'], include_gmail_hosts=True)
-          if err or not cookies:
-              attempts.append({'browser': browser['name'], 'stage': 'decrypt',
-                               'reason': (err or 'no cookies'), 'had_auth': False})
-              continue
+      def decrypt_cookies_from_copy(db_path, password):
+          # Copy the live browser DB into a private temp dir before reading it.
+          # This avoids contending on the locks the browser holds while writing.
+          # Chromium's Cookies DB uses a rollback journal (journal_mode=delete),
+          # so we copy any -journal/-wal/-shm sidecars alongside the main file
+          # under the same basename; if the copy caught a write mid-flight,
+          # SQLite recovers a consistent view from the copied journal.
+          copy_dir = None
+          try:
+              copy_dir = tempfile.mkdtemp(prefix='omi_gmail_cookies_')
+              base = os.path.basename(db_path)
+              copy_path = os.path.join(copy_dir, base)
+              shutil.copyfile(db_path, copy_path)
+              # Sidecars are best-effort: the browser deletes -journal on every
+              # commit, so it can vanish between a check and the copy. A missing
+              # sidecar just means we proceed without it (no worse than the
+              # main-file-only copy), so never fail the browser over one.
+              for suffix in ('-journal', '-wal', '-shm'):
+                  try:
+                      shutil.copyfile(db_path + suffix, copy_path + suffix)
+                  except OSError:
+                      pass
+          except Exception as e:
+              if copy_dir is not None:
+                  shutil.rmtree(copy_dir, ignore_errors=True)
+              return None, f'cookie db copy failed: {e}'
+          try:
+              return decrypt_google_cookies(copy_path, password, include_gmail_hosts=True)
+          finally:
+              shutil.rmtree(copy_dir, ignore_errors=True)
 
-          found_auth = [c for c in cookies if c['name'] in GOOGLE_AUTH_COOKIE_NAMES]
-          if not found_auth:
-              attempts.append({'browser': browser['name'], 'stage': 'auth',
-                               'reason': 'no Google auth cookies', 'had_auth': False})
-              continue
+      def load_sessions():
+          # Decrypt each browser's cookies exactly once, up front, on the main
+          # thread. Workers only ever read the resulting session list.
+          sessions = []
+          attempts = []
+          for browser in browsers:
+              cookies, err = decrypt_cookies_from_copy(browser['db_path'], browser['password'])
+              if err or not cookies:
+                  attempts.append({'browser': browser['name'], 'stage': 'decrypt',
+                                   'reason': (err or 'no cookies'), 'had_auth': False})
+                  continue
+              if not any(c['name'] in GOOGLE_AUTH_COOKIE_NAMES for c in cookies):
+                  attempts.append({'browser': browser['name'], 'stage': 'auth',
+                                   'reason': 'no Google auth cookies', 'had_auth': False})
+                  continue
+              sessions.append({'name': browser['name'], 'cookies': cookies})
+          return sessions, attempts
 
-          jar = make_cookie_jar(cookies)
-          status, body = fetch_home_page(jar)
-          if use_bootstrap and status == 200:
-              emails, parse_err = parse_bootstrap_page(body, max_results)
-              if not parse_err and emails:
-                  attempts.append({'browser': browser['name'], 'stage': 'ok', 'reason': 'ok', 'had_auth': True})
-                  write_json_result('omi_gmail_', {'ok': True, 'browser': browser['name'], 'source': 'bootstrap',
-                                                   'emails': emails, 'count': len(emails), 'attempts': attempts})
-                  sys.exit(0)
+      def jar_cookie_list(jar):
+          return [{'domain': c.domain, 'name': c.name, 'value': c.value,
+                   'path': c.path, 'secure': bool(c.secure)} for c in jar]
 
-          status, body = fetch_atom_feed(jar)
-          if status == 200:
-              emails, parse_err = parse_atom(body, max_results)
-              if not parse_err and emails is not None:
-                  attempts.append({'browser': browser['name'], 'stage': 'ok', 'reason': 'ok', 'had_auth': True})
-                  write_json_result('omi_gmail_', {'ok': True, 'browser': browser['name'], 'source': 'atom',
-                                                   'emails': emails, 'count': len(emails), 'attempts': attempts})
-                  sys.exit(0)
+      def request_limits(request):
+          request_id = request.get('id') or 'unknown'
+          max_results_value = request.get('max_results')
+          max_results = int(max_results_value) if max_results_value is not None else 50
+          return request_id, max_results
 
-          reason = f'HTTP {status}' if status else str(body)
-          attempts.append({'browser': browser['name'], 'stage': 'fetch',
-                           'reason': reason or 'unknown fetch error',
-                           'had_auth': True, 'http': status})
+      def failure_result(request_id, attempts):
+          error_class, summary = classify(attempts)
+          return {'ok': False, 'id': request_id, 'error_class': error_class, 'summary': summary,
+                  'attempts': attempts}
 
-      error_class, summary = classify(attempts)
-      write_json_result('omi_gmail_', {'ok': False, 'error_class': error_class, 'summary': summary,
-                                       'attempts': attempts})
+      def run_probe(request, sessions, session_attempts):
+          # Serial first request: the only place the Gmail home page is fetched.
+          # It doubles as session warm-up — any Set-Cookie refreshes are folded
+          # back into the winning session so workers reuse the warmed cookies.
+          attempts = list(session_attempts)
+          request_id, max_results = request_limits(request)
+          use_bootstrap = bool(request.get('use_bootstrap'))
+          try:
+              for session in sessions:
+                  if time.monotonic() > deadline:
+                      attempts.append({'browser': session['name'], 'stage': 'fetch',
+                                       'reason': 'deadline exceeded', 'had_auth': True})
+                      break
+                  jar = make_cookie_jar(session['cookies'])
+                  status, body = fetch_home_page(jar)
+                  if use_bootstrap and status == 200:
+                      emails, parse_err = parse_bootstrap_page(body, max_results)
+                      if not parse_err and emails:
+                          session['cookies'] = jar_cookie_list(jar)
+                          return ({'ok': True, 'id': request_id, 'browser': session['name'], 'source': 'bootstrap',
+                                   'emails': emails, 'count': len(emails), 'attempts': attempts}, session)
+
+                  status, body = fetch_atom_feed(jar, request)
+                  if status == 200:
+                      emails, parse_err = parse_atom(body, max_results)
+                      if not parse_err and emails is not None:
+                          session['cookies'] = jar_cookie_list(jar)
+                          return ({'ok': True, 'id': request_id, 'browser': session['name'], 'source': 'atom',
+                                   'emails': emails, 'count': len(emails), 'attempts': attempts}, session)
+
+                  reason = f'HTTP {status}' if status else str(body)
+                  attempts.append({'browser': session['name'], 'stage': 'fetch',
+                                   'reason': reason or 'unknown fetch error',
+                                   'had_auth': True, 'http': status})
+          except Exception as e:
+              attempts.append({'browser': 'helper', 'stage': 'fetch', 'reason': str(e), 'had_auth': False})
+          return (failure_result(request_id, attempts), None)
+
+      def run_worker(request, sessions):
+          # Parallel label-feed request: atom fetch only, no home page, no
+          # decryption — sessions were prepared once before the pool started.
+          attempts = []
+          request_id, max_results = request_limits(request)
+          try:
+              for session in sessions:
+                  if time.monotonic() > deadline:
+                      attempts.append({'browser': session['name'], 'stage': 'fetch',
+                                       'reason': 'deadline exceeded', 'had_auth': True})
+                      break
+                  jar = make_cookie_jar(session['cookies'])
+                  status, body = fetch_atom_feed(jar, request)
+                  if status == 200:
+                      emails, parse_err = parse_atom(body, max_results)
+                      if not parse_err and emails is not None:
+                          return {'ok': True, 'id': request_id, 'browser': session['name'], 'source': 'atom',
+                                  'emails': emails, 'count': len(emails), 'attempts': attempts}
+                  reason = f'HTTP {status}' if status else str(body)
+                  attempts.append({'browser': session['name'], 'stage': 'fetch',
+                                   'reason': reason or 'unknown fetch error',
+                                   'had_auth': True, 'http': status})
+          except Exception as e:
+              attempts.append({'browser': 'helper', 'stage': 'fetch', 'reason': str(e), 'had_auth': False})
+          return failure_result(request_id, attempts)
+
+      if not requests:
+          write_json_result('omi_gmail_', {'ok': True, 'browser': 'none', 'source': 'batch',
+                                           'responses': []})
+          sys.exit(0)
+
+      sessions, session_attempts = load_sessions()
+      if not sessions:
+          first_id, _ = request_limits(requests[0])
+          write_json_result('omi_gmail_', failure_result(first_id, session_attempts))
+          sys.exit(0)
+
+      first_result, working_session = run_probe(requests[0], sessions, session_attempts)
+      if not first_result.get('ok'):
+          write_json_result('omi_gmail_', first_result)
+          sys.exit(0)
+
+      # Workers try the probe-validated session first, then the rest in order.
+      worker_sessions = [working_session] + [s for s in sessions if s is not working_session]
+
+      ordered_results = [first_result]
+      remaining = requests[1:]
+      if remaining:
+          parallel_results = [None] * len(remaining)
+          first_failure = None
+          workers = min(max_workers, len(remaining))
+          executor = ThreadPoolExecutor(max_workers=workers)
+          try:
+              future_to_index = {
+                  executor.submit(run_worker, request, worker_sessions): index
+                  for index, request in enumerate(remaining)
+              }
+              for future in as_completed(future_to_index):
+                  index = future_to_index[future]
+                  try:
+                      result = future.result()
+                  except Exception as e:
+                      request_id = remaining[index].get('id') or 'unknown'
+                      result = {
+                          'ok': False,
+                          'id': request_id,
+                          'error_class': 'unknown',
+                          'summary': str(e),
+                          'attempts': [{'browser': 'helper', 'stage': 'fetch', 'reason': str(e), 'had_auth': False}],
+                      }
+                  parallel_results[index] = result
+                  if not result.get('ok'):
+                      first_failure = result
+                      break
+          finally:
+              # Drop queued work now; never block on in-flight fetches.
+              # cancel_futures is Python 3.9+, and the runner may pick an older
+              # interpreter, so fall back gracefully. The os._exit below still
+              # tears down any queued/in-flight work on the fail path regardless.
+              if sys.version_info >= (3, 9):
+                  executor.shutdown(wait=False, cancel_futures=True)
+              else:
+                  executor.shutdown(wait=False)
+
+          if first_failure is not None:
+              # Surface the first failure immediately. os._exit skips the
+              # concurrent.futures atexit hook (and sys.exit's own join) that
+              # would otherwise wait for in-flight worker threads to drain.
+              write_json_result('omi_gmail_', first_failure)
+              sys.stdout.flush()
+              os._exit(0)
+          ordered_results.extend(parallel_results)
+
+      responses = [
+          {
+              'id': result.get('id') or 'unknown',
+              'browser': result.get('browser') or 'unknown',
+              'source': result.get('source') or 'unknown',
+              'emails': result.get('emails') or [],
+              'count': result.get('count') or 0,
+          }
+          for result in ordered_results
+      ]
+      write_json_result('omi_gmail_', {
+          'ok': True,
+          'browser': responses[0]['browser'] if responses else 'unknown',
+          'source': 'batch',
+          'responses': responses,
+      })
       sys.exit(0)
       """
 
@@ -692,12 +1047,11 @@ actor GmailReaderService {
     do {
       result = try BrowserPythonRunner.run(
         script: pythonScript,
-        arguments: [
-          String(maxResults), query,
-          shouldUseBootstrapPage ? "1" : "0",
-          feedPath ?? "",
-        ],
-        stdinData: Data(configJSON.utf8)
+        arguments: [],
+        stdinData: Data(payloadJSON.utf8),
+        // Margin past the in-script deadline so one last in-flight fetch can
+        // time out (30s) and the classified failure still gets written.
+        timeoutSeconds: budgetSeconds + 30
       )
     } catch BrowserPythonRunnerError.pythonNotFound {
       throw GmailReaderError.pythonNotFound
@@ -725,20 +1079,27 @@ actor GmailReaderService {
       throw GmailReaderError.networkError("Python returned invalid JSON: \(raw.prefix(200))")
     }
 
-    let outcome = GmailOutcomeParser.parse(json)
-    let emailDicts: [[String: Any]]
-    switch outcome {
+    switch GmailAtomBatchParser.parse(json) {
     case let .failure(cls, summary, attempts):
       log(
         "GmailReaderService: fetch failed [\(cls.rawValue)] — \(summary) | "
           + "attempts: \(GmailOutcomeParser.diagnosticsLine(attempts))")
       throw cls.asError(summary: summary)
-    case let .success(emails, browserName, sourceName):
-      log("GmailReaderService: Got \(emails.count) emails from \(browserName) via \(sourceName)")
-      emailDicts = emails
+    case let .success(responses):
+      var parsed: [String: (emails: [GmailEmail], browser: String, source: String)] = [:]
+      for response in responses {
+        parsed[response.requestID] = (
+          emails: gmailEmails(from: response.emails),
+          browser: response.browser,
+          source: response.source
+        )
+      }
+      return parsed
     }
+  }
 
-    return emailDicts.compactMap { dict -> GmailEmail? in
+  private func gmailEmails(from emailDicts: [[String: Any]]) -> [GmailEmail] {
+    emailDicts.compactMap { dict -> GmailEmail? in
       guard let id = dict["id"] as? String,
         let from = dict["from"] as? String,
         let subject = dict["subject"] as? String
@@ -757,51 +1118,6 @@ actor GmailReaderService {
         isUnread: isUnread
       )
     }
-  }
-
-  private func fetchGmailViaLabelFeeds(maxResults: Int, query: String) throws -> [GmailEmail] {
-    guard maxResults > 0 else { return [] }
-
-    let feedPaths = [
-      "atom/all",
-      "atom/inbox",
-      "atom/sent",
-      "atom/starred",
-      "atom/important",
-      "atom/trash",
-      "atom/spam",
-      "atom/unread",
-      "atom/social",
-      "atom/promotions",
-      "atom/updates",
-      "atom/forums",
-      "atom/personal",
-    ]
-
-    var merged: [String: GmailEmail] = [:]
-    for feedPath in feedPaths {
-      let feedEmails = try fetchGmailViaAtomFeedSingle(
-        maxResults: min(20, maxResults),
-        query: query,
-        feedPath: feedPath,
-        allowBootstrap: false
-      )
-      for email in feedEmails {
-        let existing = merged[email.id]
-        if existing == nil || existing!.date < email.date {
-          merged[email.id] = email
-        }
-      }
-    }
-
-    log(
-      "GmailReaderService: Collected \(merged.count) unique emails across \(feedPaths.count) label feeds"
-    )
-
-    return Array(merged.values)
-      .sorted { $0.date > $1.date }
-      .prefix(maxResults)
-      .map(\.self)
   }
 
   private func fetchGmailViaDateWindows(daysBack: Int, maxResults: Int) throws -> [GmailEmail] {

--- a/desktop/macos/Desktop/Tests/GmailBatchBudgetTests.swift
+++ b/desktop/macos/Desktop/Tests/GmailBatchBudgetTests.swift
@@ -1,0 +1,32 @@
+import XCTest
+
+@testable import Omi_Computer
+
+final class GmailBatchBudgetTests: XCTestCase {
+
+  func testSingleRequestKeepsOriginalSixtySecondBudget() {
+    XCTAssertEqual(
+      GmailReaderService.batchBudgetSeconds(requestCount: 1, maxConcurrentRequests: 1), 60)
+    XCTAssertEqual(
+      GmailReaderService.batchBudgetSeconds(requestCount: 1, maxConcurrentRequests: 4), 60)
+  }
+
+  func testCombinedFetchBudgetIsWaveBasedNotPerRequest() {
+    // 1 probe wave + ceil(13/4) = 4 parallel waves → 300s, not 14 × 60 = 840s.
+    XCTAssertEqual(
+      GmailReaderService.batchBudgetSeconds(requestCount: 14, maxConcurrentRequests: 4), 300)
+  }
+
+  func testSequentialWidthDegradesToPerRequestBudget() {
+    // Width 1 means every request is its own wave — matches the old serial cap.
+    XCTAssertEqual(
+      GmailReaderService.batchBudgetSeconds(requestCount: 3, maxConcurrentRequests: 1), 180)
+  }
+
+  func testDefensiveInputsClampToMinimumBudget() {
+    XCTAssertEqual(
+      GmailReaderService.batchBudgetSeconds(requestCount: 0, maxConcurrentRequests: 4), 60)
+    XCTAssertEqual(
+      GmailReaderService.batchBudgetSeconds(requestCount: 2, maxConcurrentRequests: 0), 120)
+  }
+}

--- a/desktop/macos/Desktop/Tests/GmailOutcomeParserTests.swift
+++ b/desktop/macos/Desktop/Tests/GmailOutcomeParserTests.swift
@@ -103,6 +103,77 @@ final class GmailOutcomeParserTests: XCTestCase {
     XCTAssertEqual(GmailOutcomeParser.diagnosticsLine(attempts), "Arc[auth:no Google auth cookies]")
   }
 
+  func testBatchSuccessParsesResponsesInOrder() {
+    let json: [String: Any] = [
+      "ok": true,
+      "browser": "Chrome",
+      "source": "batch",
+      "responses": [
+        [
+          "id": "query",
+          "browser": "Chrome",
+          "source": "atom",
+          "emails": [["id": "q1", "subject": "Query result"]],
+        ],
+        [
+          "id": "label:atom/inbox",
+          "browser": "Chrome",
+          "source": "atom",
+          "emails": [["id": "l1", "subject": "Inbox result"]],
+        ],
+      ],
+    ]
+
+    guard case let .success(responses) = GmailAtomBatchParser.parse(json) else {
+      return XCTFail("expected batch success")
+    }
+
+    XCTAssertEqual(responses.map(\.requestID), ["query", "label:atom/inbox"])
+    XCTAssertEqual(responses[0].browser, "Chrome")
+    XCTAssertEqual(responses[0].source, "atom")
+    XCTAssertEqual(responses[0].emails.count, 1)
+  }
+
+  func testBatchSuccessWithEmptyResponsesIsSuccessNotFailure() {
+    let json: [String: Any] = ["ok": true, "browser": "none", "source": "batch", "responses": []]
+
+    guard case let .success(responses) = GmailAtomBatchParser.parse(json) else {
+      return XCTFail("expected batch success for empty responses")
+    }
+    XCTAssertTrue(responses.isEmpty)
+  }
+
+  func testBatchOkWithoutResponsesIsTreatedAsContractFailure() {
+    // The helper always emits `responses` on success; its absence is a
+    // contract violation, not a single-response payload to synthesize.
+    let json: [String: Any] = ["ok": true, "browser": "Chrome", "emails": [["id": "x"]]]
+
+    guard case let .failure(cls, summary, _) = GmailAtomBatchParser.parse(json) else {
+      return XCTFail("expected contract failure when responses is missing")
+    }
+    XCTAssertEqual(cls, .unknown)
+    XCTAssertEqual(summary, "Gmail batch response missing responses")
+  }
+
+  func testBatchFailureUsesExistingFailureClassification() {
+    let json: [String: Any] = [
+      "ok": false,
+      "error_class": "network",
+      "summary": "Could not reach Gmail (HTTP 500).",
+      "attempts": [
+        ["browser": "Chrome", "stage": "fetch", "reason": "HTTP 500", "had_auth": true, "http": 500]
+      ],
+    ]
+
+    guard case let .failure(cls, summary, attempts) = GmailAtomBatchParser.parse(json) else {
+      return XCTFail("expected batch failure")
+    }
+
+    XCTAssertEqual(cls, .network)
+    XCTAssertEqual(summary, "Could not reach Gmail (HTTP 500).")
+    XCTAssertEqual(attempts.count, 1)
+  }
+
   func testConnectionStatusIsConnectedHelper() {
     XCTAssertTrue(GmailConnectionStatus.connected(verifiedAt: Date()).isConnected)
     XCTAssertFalse(GmailConnectionStatus.needsSignIn(message: "x").isConnected)

--- a/desktop/macos/changelog/unreleased/gmail-import-fetch-batching.json
+++ b/desktop/macos/changelog/unreleased/gmail-import-fetch-batching.json
@@ -1,0 +1,5 @@
+{
+    "changes": [
+        "Made Gmail history import faster and more reliable by fetching its feeds in one batched pass that shares a single browser session and stops early on failure"
+    ]
+}

--- a/desktop/macos/scripts/test-gmail-batch-helper.py
+++ b/desktop/macos/scripts/test-gmail-batch-helper.py
@@ -1,0 +1,300 @@
+#!/usr/bin/env python3
+"""Hermetic failure-path tests for the embedded Gmail batch helper.
+
+The Gmail Atom batch fetch runs as a Python script embedded as a Swift string
+literal in Desktop/Sources/GmailReaderService.swift (with shared cookie-decrypt
+support from BrowserGoogleSession.swift). Swift unit tests cover the parser and
+budget math, but not the generated script's own failure classification.
+
+This harness reconstructs the exact script the app runs — reproducing Swift's
+multiline-literal indentation stripping and the one string interpolation — then
+drives it as a subprocess with synthetic payloads. No network, no real cookies:
+it asserts only on the JSON result contract (error_class, deadline handling,
+empty/no-browser cases). Run before changing the embedded helper.
+
+Usage: python3 scripts/test-gmail-batch-helper.py
+Exit code 0 = all pass, 1 = a failure, 2 = sources not found.
+"""
+import json
+import os
+import shutil
+import sqlite3
+import subprocess
+import sys
+import tempfile
+import time
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+SOURCES = os.path.normpath(os.path.join(HERE, "..", "Desktop", "Sources"))
+SUPPORT_SWIFT = os.path.join(SOURCES, "BrowserGoogleSession.swift")
+GMAIL_SWIFT = os.path.join(SOURCES, "GmailReaderService.swift")
+SUPPORT_INTERPOLATION = r"\(BrowserGoogleSession.chromiumCookiePythonSupport)"
+
+
+def extract_multiline_literal(path, assignment_marker):
+    """Return the Swift multiline string literal that follows an assignment.
+
+    Swift strips indentation up to the column of the closing delimiter, so we
+    detect that column from the closing-delimiter line and strip it per line.
+    """
+    lines = open(path).read().splitlines()
+    start = None
+    for i, line in enumerate(lines):
+        if assignment_marker in line and line.rstrip().endswith('"""'):
+            start = i + 1
+            break
+    if start is None:
+        raise SystemExit(f"marker not found in {path}: {assignment_marker}")
+
+    end = None
+    for j in range(start, len(lines)):
+        if lines[j].strip() == '"""':
+            end = j
+            break
+    if end is None:
+        raise SystemExit(f"closing delimiter not found in {path} after {assignment_marker}")
+
+    strip = len(lines[end]) - len(lines[end].lstrip())
+    body = []
+    for line in lines[start:end]:
+        body.append(line[strip:] if line[:strip].strip() == "" else line.lstrip())
+    return "\n".join(body)
+
+
+def build_script():
+    if not (os.path.exists(SUPPORT_SWIFT) and os.path.exists(GMAIL_SWIFT)):
+        print("Gmail helper sources not found; skipping", file=sys.stderr)
+        sys.exit(2)
+    support = extract_multiline_literal(SUPPORT_SWIFT, "static let chromiumCookiePythonSupport = ")
+    gmail = extract_multiline_literal(GMAIL_SWIFT, "let pythonScript = ")
+    if SUPPORT_INTERPOLATION not in gmail:
+        raise SystemExit("support interpolation placeholder missing from gmail script")
+    return gmail.replace(SUPPORT_INTERPOLATION, support, 1)
+
+
+SCRIPT = build_script()
+_fd, SCRIPT_PATH = tempfile.mkstemp(suffix=".py", prefix="omi_gmail_helper_")
+with os.fdopen(_fd, "w") as _f:
+    _f.write(SCRIPT + "\n")
+
+# Fail loudly if the reconstructed script is not even valid Python.
+subprocess.run([sys.executable, "-m", "py_compile", SCRIPT_PATH], check=True)
+
+
+def run_script(payload):
+    proc = subprocess.run(
+        [sys.executable, SCRIPT_PATH],
+        input=json.dumps(payload).encode(),
+        capture_output=True,
+        timeout=60,
+    )
+    return read_result(proc)
+
+
+def read_result(proc):
+    out_path = proc.stdout.decode().strip()
+    assert out_path and os.path.exists(
+        out_path
+    ), f"no output file; stdout={proc.stdout!r} stderr={proc.stderr.decode()[:500]!r}"
+    with open(out_path) as f:
+        result = json.load(f)
+    os.remove(out_path)
+    return result
+
+
+# Test-only override, activated by OMI_GMAIL_TEST_FAKE, that replaces just the
+# two network leaf functions so the real orchestration (probe → warm session →
+# parallel workers → fail-fast os._exit) runs offline. The production script has
+# no such env check, so this never affects shipped behavior. Injected before the
+# orchestration block, after the real defs, so late-bound calls hit the fakes.
+FAKE_FETCH_INJECTION = (
+    "if os.environ.get('OMI_GMAIL_TEST_FAKE'):\n"
+    "    _FAKE_ATOM = b'<?xml version=\"1.0\"?><feed xmlns=\"http://purl.org/atom/ns#\">"
+    "<entry><title>t</title><summary>s</summary>"
+    "<author><name>A</name><email>a@b.com</email></author>"
+    "<issued>2026-01-01T00:00:00Z</issued></entry></feed>'\n"
+    "    def fetch_home_page(jar):\n"
+    "        return 200, b'<html>fake</html>'\n"
+    "    def fetch_atom_feed(jar, request):\n"
+    "        rid = request.get('id')\n"
+    "        if rid == 'label:atom/fail':\n"
+    "            return 500, b'boom'\n"
+    "        if rid == 'label:atom/slow':\n"
+    "            time.sleep(10)\n"
+    "        return 200, _FAKE_ATOM\n"
+)
+
+
+def run_script_faked(payload, timeout=20):
+    anchor = "if not requests:"
+    assert SCRIPT.count(anchor) == 1, "fake-injection anchor is not unique"
+    faked = SCRIPT.replace(anchor, FAKE_FETCH_INJECTION + anchor, 1)
+    fd, path = tempfile.mkstemp(suffix=".py", prefix="omi_gmail_helper_fake_")
+    with os.fdopen(fd, "w") as f:
+        f.write(faked + "\n")
+    try:
+        proc = subprocess.run(
+            [sys.executable, path],
+            input=json.dumps(payload).encode(),
+            capture_output=True,
+            timeout=timeout,
+            env=dict(os.environ, OMI_GMAIL_TEST_FAKE="1"),
+        )
+        return read_result(proc)
+    finally:
+        os.remove(path)
+
+
+# Temp cookie-DB dirs created during the run; removed in the final cleanup.
+_COOKIE_DB_DIRS = []
+
+
+def make_cookie_db(rows, with_journal=False):
+    d = tempfile.mkdtemp(prefix="omi_gmail_cookiedb_")
+    _COOKIE_DB_DIRS.append(d)
+    path = os.path.join(d, "Cookies")
+    conn = sqlite3.connect(path)
+    conn.execute("CREATE TABLE meta (key TEXT, value TEXT)")
+    conn.execute("INSERT INTO meta VALUES ('version', '13')")
+    conn.execute(
+        "CREATE TABLE cookies (host_key TEXT, name TEXT, encrypted_value BLOB,"
+        " path TEXT, is_secure INTEGER, expires_utc INTEGER)"
+    )
+    for host, name, value in rows:
+        conn.execute("INSERT INTO cookies VALUES (?, ?, ?, '/', 1, 0)", (host, name, value.encode()))
+    conn.commit()
+    conn.close()
+    if with_journal:
+        # A hot-journal sidecar the copy step must pick up alongside the DB.
+        open(path + "-journal", "wb").close()
+    return path
+
+
+REQS = [{"id": "query", "max_results": 5, "query": "newer_than:365d", "feed_path": "", "use_bootstrap": False}] + [
+    {
+        "id": f"label:atom/{n}",
+        "max_results": 5,
+        "query": "newer_than:365d",
+        "feed_path": f"atom/{n}",
+        "use_bootstrap": False,
+    }
+    for n in ("inbox", "sent")
+]
+
+failures = 0
+
+
+def check(name, cond, detail=""):
+    global failures
+    if not cond:
+        failures += 1
+    print(f"{'PASS' if cond else 'FAIL'}: {name} {detail}")
+
+
+def main():
+    # 1. Missing cookie DB → copy fails → decrypt attempt → decrypt_failed.
+    r = run_script(
+        {
+            "browsers": [{"name": "Fake", "db_path": "/nonexistent/Cookies", "password": "x"}],
+            "requests": REQS,
+            "max_workers": 4,
+            "deadline_seconds": 30,
+        }
+    )
+    check(
+        "missing DB → decrypt_failed",
+        r.get("ok") is False and r.get("error_class") == "decrypt_failed",
+        f"got {r.get('error_class')}",
+    )
+
+    # 2. DB with a hot-journal sidecar but no Google auth cookies → not_signed_in.
+    #    Also exercises the sidecar-aware copy path (#1 fix).
+    db = make_cookie_db([(".google.com", "NID", "plain")], with_journal=True)
+    r = run_script(
+        {
+            "browsers": [{"name": "Fake", "db_path": db, "password": "x"}],
+            "requests": REQS,
+            "max_workers": 4,
+            "deadline_seconds": 30,
+        }
+    )
+    check(
+        "no auth cookies (with journal sidecar) → not_signed_in",
+        r.get("ok") is False and r.get("error_class") == "not_signed_in",
+        f"got {r.get('error_class')}",
+    )
+
+    # 3. Auth cookies present but deadline already exhausted → probe stops
+    #    before any network fetch (deadline fix, #3).
+    db = make_cookie_db([(".google.com", "SID", "s"), (".google.com", "HSID", "h")])
+    r = run_script(
+        {
+            "browsers": [{"name": "Fake", "db_path": db, "password": "x"}],
+            "requests": REQS,
+            "max_workers": 4,
+            "deadline_seconds": 0,
+        }
+    )
+    reasons = [a.get("reason") for a in r.get("attempts", [])]
+    check(
+        "exhausted deadline stops probe pre-network",
+        r.get("ok") is False and "deadline exceeded" in reasons,
+        f"reasons={reasons}",
+    )
+
+    # 4. Empty request list → ok with empty responses, no top-level emails.
+    r = run_script({"browsers": [], "requests": [], "max_workers": 4, "deadline_seconds": 30})
+    check(
+        "empty requests → ok, empty responses",
+        r.get("ok") is True and r.get("responses") == [] and "emails" not in r,
+        f"got {r}",
+    )
+
+    # 5. No browsers at all → no_browser.
+    r = run_script({"browsers": [], "requests": REQS, "max_workers": 4, "deadline_seconds": 30})
+    check(
+        "no browsers → no_browser",
+        r.get("ok") is False and r.get("error_class") == "no_browser",
+        f"got {r.get('error_class')}",
+    )
+
+    # 6. Fail-fast (#2 fix): probe succeeds, one worker fails immediately while
+    #    another hangs for 10s. The helper must write a classified failure and
+    #    exit promptly via os._exit — not join the in-flight hang.
+    db = make_cookie_db([(".google.com", "SID", "s"), (".google.com", "HSID", "h")])
+    reqs = [
+        {"id": "query", "max_results": 5, "query": "q", "feed_path": "", "use_bootstrap": False},
+        {"id": "label:atom/fail", "max_results": 5, "query": "q", "feed_path": "atom/fail", "use_bootstrap": False},
+        {"id": "label:atom/slow", "max_results": 5, "query": "q", "feed_path": "atom/slow", "use_bootstrap": False},
+    ]
+    start = time.monotonic()
+    r = run_script_faked(
+        {
+            "browsers": [{"name": "Fake", "db_path": db, "password": "x"}],
+            "requests": reqs,
+            "max_workers": 4,
+            "deadline_seconds": 30,
+        }
+    )
+    elapsed = time.monotonic() - start
+    check(
+        "worker fail-fast writes a classified failure",
+        r.get("ok") is False and r.get("error_class") in ("network", "session_expired", "unknown"),
+        f"got {r.get('error_class')}",
+    )
+    check("worker fail-fast exits without joining the 10s hang", elapsed < 5.0, f"elapsed={elapsed:.2f}s")
+
+    print(f"\n{'ALL PASS' if failures == 0 else f'{failures} FAILURE(S)'}")
+    return 1 if failures else 0
+
+
+try:
+    code = main()
+finally:
+    try:
+        os.remove(SCRIPT_PATH)
+    except OSError:
+        pass
+    for _dir in _COOKIE_DB_DIRS:
+        shutil.rmtree(_dir, ignore_errors=True)
+sys.exit(code)


### PR DESCRIPTION
## Summary
- batch Gmail query and label Atom feed reads into one helper subprocess
- reuse one decrypted browser session across fetch workers
- fetch the Gmail home page once during the serial probe instead of once per feed
- add wave-based timeout budgeting and fail-fast worker failure handling
- measured local provider-fetch time at roughly 2x faster, with output parity checked
- add Swift parser/budget tests, a hermetic Python helper harness, and a desktop changelog fragment

## Validation
- `git diff --check upstream/main...HEAD`
- `jq . desktop/macos/changelog/unreleased/gmail-import-fetch-batching.json`
- `python3 scripts/test-gmail-batch-helper.py`
- `xcrun swift test --package-path Desktop --filter Gmail --jobs 2 --disable-keychain --disable-netrc`
- `xcrun swift build -c debug --package-path Desktop`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9046?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

