### PR TITLE
fix(desktop): make LocalAgentProviderDetector hermetic (#9033)

### DIFF
--- a/desktop/macos/Desktop/Sources/Providers/AgentRuntimeRouting.swift
+++ b/desktop/macos/Desktop/Sources/Providers/AgentRuntimeRouting.swift
@@ -146,14 +146,16 @@ enum LocalAgentProviderDetector {
         return nil
     }
 
+    // Detection is intentionally hermetic: only home-relative activation directories
+    // (plus the explicit OMI_*_ADAPTER_COMMAND env) are trusted, never arbitrary $PATH
+    // or absolute system bin dirs. Consulting /opt/homebrew/bin or /usr/local/bin made
+    // availability depend on the host machine's global installs (see #9033).
     private static func adapterActivationSearchDirectories(homeDirectory: String) -> [String] {
         [
             "\(homeDirectory)/.hermes/hermes-agent/venv/bin",
             "\(homeDirectory)/.hermes/node/bin",
             "\(homeDirectory)/.hermes/hermes-agent",
             "\(homeDirectory)/.local/bin",
-            "/opt/homebrew/bin",
-            "/usr/local/bin",
         ]
     }
 }


### PR DESCRIPTION
## Bug
`LocalAgentProviderDetector.availability` is meant to detect whether a local agent runtime (Hermes / OpenClaw) is installed, using only the injected `homeDirectory` + `environment` so it is deterministic across machines and CI runners (issue #9033).

But `adapterActivationSearchDirectories` hard-coded two absolute system dirs:

```swift
"/opt/homebrew/bin",
"/usr/local/bin",
```

These are outside the injected environment, so on any machine where `openclaw`/`hermes` are installed in a system bin dir, `testLocalAgentProviderDetectorMissingPromptIsUserFacing` (injects a missing `PATH` + `/tmp/missing-home`, expects **unavailable**) reports `isAvailable == true`. Detection leaks the host's global installs.

## Root cause
Filesystem search included absolute system paths that ignore the injected environment/home. The committed test contract already establishes the intended design: `testLocalAgentProviderDetectorIgnoresArbitraryPathEntries` deliberately does **not** trust arbitrary `$PATH`; only home-relative activation dirs and the explicit `OMI_*_ADAPTER_COMMAND` env are trusted.

## Fix
Drop `/opt/homebrew/bin` and `/usr/local/bin` from `adapterActivationSearchDirectories`, so detection consults only home-relative activation directories plus the explicit command env. Detection is now hermetic w.r.t. the injected `homeDirectory`/`environment`.

`availability` is used only as an availability **gate** (`RealtimeHubController` line ~1496); the resolved command path is not used to spawn the agent, so the actual launch path is unchanged.

## Verification
`xcrun swift test --filter PiMonoWiringTests/testLocalAgentProviderDetector` — all 4 detector tests pass (0 failures); clean debug compile.

🤖 automated by hourly watchdog; opened for review, not merged.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9047?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

