### PR TITLE
fix(desktop/ptt): detect too-short taps across modes; hint instead of silent drop

### DIFF
--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarState.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarState.swift
@@ -163,6 +163,9 @@ class FloatingControlBarState: NSObject, ObservableObject {
     @Published var isVoiceListening: Bool = false
     @Published var isVoiceLocked: Bool = false
     @Published var voiceTranscript: String = ""
+    /// Transient inline hint shown in the bar (e.g. "Hold longer to record") after a
+    /// too-short PTT tap. Non-empty keeps the bar in its voice-UI size for ~2s.
+    @Published var pttHintText: String = ""
     @Published var isVoiceResponseActive: Bool = false {
         didSet {
             if isVoiceResponseActive {

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarState.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarState.swift
@@ -329,6 +329,7 @@ class FloatingControlBarState: NSObject, ObservableObject {
         voiceFollowUpTranscript = ""
         currentQueryFromVoice = false
         lastConversationActivityAt = nil
+        pttHintText = ""  // stay self-consistent; don't rely on PTTManager's cancel side effect
         clearVoiceResponseState()
     }
 

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift
@@ -968,7 +968,15 @@ struct FloatingControlBarView: View {
     private var controlBarView: some View {
         let allowsHoverExpansion = isHovering && !state.isVoiceResponseGlowActive
         return Group {
-            if state.isVoiceListening && !state.isVoiceFollowUp {
+            if !state.pttHintText.isEmpty {
+                // Too-short PTT hint takes precedence over every other bar state
+                // (incl. follow-up turns) for its brief window.
+                voiceListeningView
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 5)
+                    .frame(height: 42)
+                    .transition(.opacity)
+            } else if state.isVoiceListening && !state.isVoiceFollowUp {
                 voiceListeningView
                     .padding(.horizontal, 10)
                     .padding(.vertical, 5)
@@ -1177,20 +1185,30 @@ struct FloatingControlBarView: View {
 
     private var voiceListeningView: some View {
         HStack(spacing: 7) {
-            // Playful realtime mic waveform (replaces the old pulsing red dot)
-            VoiceWaveformBars(isActive: state.isVoiceListening)
+            if !state.pttHintText.isEmpty {
+                // Too-short PTT tap: inline hint instead of the live waveform.
+                Image(systemName: "mic.fill")
+                    .scaledFont(size: 12, weight: .semibold)
+                    .foregroundColor(.white)
+                Text(state.pttHintText)
+                    .scaledFont(size: 11, weight: .medium)
+                    .foregroundColor(.white)
+            } else {
+                // Playful realtime mic waveform (replaces the old pulsing red dot)
+                VoiceWaveformBars(isActive: state.isVoiceListening)
 
-            Image(systemName: "mic.fill")
-                .scaledFont(size: 12, weight: .semibold)
-                .foregroundColor(.white)
+                Image(systemName: "mic.fill")
+                    .scaledFont(size: 12, weight: .semibold)
+                    .foregroundColor(.white)
 
-            if state.isVoiceLocked {
-                Image(systemName: "lock.fill")
-                    .scaledFont(size: 10, weight: .bold)
-                    .foregroundColor(.orange)
-                    .frame(width: 18, height: 18)
-                    .background(Color.orange.opacity(0.2))
-                    .cornerRadius(4)
+                if state.isVoiceLocked {
+                    Image(systemName: "lock.fill")
+                        .scaledFont(size: 10, weight: .bold)
+                        .foregroundColor(.orange)
+                        .frame(width: 18, height: 18)
+                        .background(Color.orange.opacity(0.2))
+                        .cornerRadius(4)
+                }
             }
         }
     }

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
@@ -289,6 +289,7 @@ class PushToTalkManager: ObservableObject {
       return
     }
     if isBlockedByUsageLimit() { return }
+    barState?.pttHintText = ""  // clear any lingering too-short hint from a prior tap
     FloatingBarVoicePlaybackService.shared.interruptCurrentResponse()
     if ShortcutSettings.shared.pttMuteSystemAudio {
       SystemAudioMuteController.shared.muteForListening()
@@ -411,6 +412,7 @@ class PushToTalkManager: ObservableObject {
     batchAudioBuffer = Data()
     batchAudioLock.unlock()
     isCurrentSessionFollowUp = false
+    barState?.pttHintText = ""
     // Abandoned session (cancel / silent turn) — drop its tracer unsent so it
     // doesn't leak into the next PTT turn. No trace is written for these.
     activeTracer = nil
@@ -690,7 +692,14 @@ class PushToTalkManager: ObservableObject {
         RealtimeHubController.shared.cancelTurn()
         AnalyticsManager.shared.floatingBarPTTEnded(
           mode: finalizedMode, hadTranscript: false, transcriptLength: 0)
-        updateBarState()  // clears the listening UI (no "…")
+        // Too short to have captured anything (fast tap / capture not ready) — hint
+        // the user to hold longer instead of clearing silently. A longer hub turn
+        // that simply had no speech keeps the quiet reset.
+        if totalSec < Self.minTurnAudioSeconds {
+          finishTooShortPTTTurnWithHint(reason: "hub, \(String(format: "%.2f", totalSec))s")
+        } else {
+          updateBarState()  // clears the listening UI (no "…")
+        }
         return
       }
       // Real speech — commit. The hub speaks the reply and dispatches tools
@@ -746,7 +755,14 @@ class PushToTalkManager: ObservableObject {
         )
         AnalyticsManager.shared.floatingBarPTTEnded(
           mode: finalizedMode, hadTranscript: false, transcriptLength: 0)
-        stopListening()
+        // A too-short turn means the release beat capture (or the user tapped
+        // instead of holding). Give visible feedback instead of a silent clear;
+        // longer holds that were merely quiet keep the quiet reset.
+        if totalSec < Self.minTurnAudioSeconds {
+          finishTooShortPTTTurnWithHint(reason: "\(isOmniSTT ? "omni" : "batch"), \(String(format: "%.2f", totalSec))s")
+        } else {
+          stopListening()
+        }
         return
       }
     }
@@ -804,8 +820,9 @@ class PushToTalkManager: ObservableObject {
       stopAudioTranscription()
 
       guard !audioData.isEmpty else {
-        log("PushToTalkManager: batch mode — no audio recorded")
-        sendTranscript()
+        // Backstop: the silence gate above normally catches an empty turn first, but
+        // if a turn ever reaches here with no audio, hint rather than send nothing.
+        finishTooShortPTTTurnWithHint(reason: "batch, empty buffer")
         return
       }
 
@@ -864,6 +881,29 @@ class PushToTalkManager: ObservableObject {
       }
       liveFinalizationTimeout = timeout
       DispatchQueue.main.asyncAfter(deadline: .now() + 3.0, execute: timeout)
+    }
+  }
+
+  /// A PTT turn that ended too short to have captured usable audio — typically a
+  /// press+release faster than capture spins up (or a tap instead of a hold). This
+  /// happens in every mode (hub / omni / batch), so it is shared across their
+  /// discard paths. Surface a hint and reset the bar after a beat instead of
+  /// clearing it silently, so the user knows to hold the key longer. Callers have
+  /// already logged the discard and reported analytics.
+  private func finishTooShortPTTTurnWithHint(reason: String) {
+    log("PushToTalkManager: too-short PTT turn (\(reason)) — showing hold-longer hint")
+    activeTracer = nil
+    barState?.pttHintText = "Hold longer to record"
+    updateBarState()  // keeps/expands the bar to its voice size so the hint shows
+
+    Task { @MainActor [weak self] in
+      try? await Task.sleep(nanoseconds: 2_000_000_000)
+      guard let self else { return }
+      // Only reset if the hint is still on screen — a newer turn may have replaced it.
+      if self.barState?.pttHintText == "Hold longer to record" {
+        self.barState?.pttHintText = ""
+        self.stopListening()  // collapses the bar (pttHintText now empty)
+      }
     }
   }
 
@@ -1428,7 +1468,10 @@ class PushToTalkManager: ObservableObject {
   private func updateBarState(skipResize: Bool = false) {
     guard let barState = barState else { return }
     let wasListening = barState.isVoiceListening
-    let isShowingVoiceUI = (state == .listening || state == .lockedListening)
+    // A pending too-short hint keeps the bar in its voice-UI size/position so the
+    // inline "hold longer" text is visible (and correctly sized) for its brief window.
+    let isShowingVoiceUI =
+      (state == .listening || state == .lockedListening) || !barState.pttHintText.isEmpty
     barState.isVoiceListening = isShowingVoiceUI
     barState.isVoiceLocked = (state == .lockedListening)
     barState.isVoiceFollowUp = isCurrentSessionFollowUp && isShowingVoiceUI

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
@@ -95,6 +95,9 @@ class PushToTalkManager: ObservableObject {
   private var transcriptSegments: [String] = []
   private var lastInterimText: String = ""
   private var finalizeWorkItem: DispatchWorkItem?
+  /// Monotonic tag for the transient too-short "hold longer" hint, so an older
+  /// hint's 2s reset timer can't clear a newer hint from a rapid follow-up tap.
+  private var pttHintGeneration = 0
   private var hasMicPermission: Bool = false
   private var isCurrentSessionFollowUp = false
   private var currentContextSnapshot: PTTContextSnapshot?
@@ -893,12 +896,21 @@ class PushToTalkManager: ObservableObject {
   private func finishTooShortPTTTurnWithHint(reason: String) {
     log("PushToTalkManager: too-short PTT turn (\(reason)) — showing hold-longer hint")
     activeTracer = nil
+    // Return to idle immediately. The hub path already reset state, but the
+    // omni/batch discard path leaves it in `.finalizing`; without this a new PTT
+    // press within the 2s hint window is dropped (handleShortcutDown ignores
+    // `.finalizing`). The bar stays voice-sized via pttHintText, not `state`.
+    state = .idle
     barState?.pttHintText = "Hold longer to record"
     updateBarState()  // keeps/expands the bar to its voice size so the hint shows
 
+    // Tag this hint so a newer too-short tap's hint isn't cleared early by this
+    // timer (rapid taps would otherwise share the identical hint string).
+    pttHintGeneration &+= 1
+    let generation = pttHintGeneration
     Task { @MainActor [weak self] in
       try? await Task.sleep(nanoseconds: 2_000_000_000)
-      guard let self else { return }
+      guard let self, self.pttHintGeneration == generation else { return }
       // Only reset if the hint is still on screen — a newer turn may have replaced it.
       if self.barState?.pttHintText == "Hold longer to record" {
         self.barState?.pttHintText = ""

--- a/desktop/macos/Desktop/Tests/OnboardingFlowTests.swift
+++ b/desktop/macos/Desktop/Tests/OnboardingFlowTests.swift
@@ -3,16 +3,16 @@ import XCTest
 @testable import Omi_Computer
 
 final class OnboardingFlowTests: XCTestCase {
-  func testMergedFlowUsesEighteenSteps() {
+  func testMergedFlowUsesNineteenSteps() {
     XCTAssertEqual(
       OnboardingFlow.steps,
       [
         "Name", "Language", "HowDidYouHear", "Trust", "ScreenRecording",
         "FullDiskAccess", "FileScan", "Microphone", "Accessibility", "Automation",
         "FloatingBarShortcut", "FloatingBar", "VoiceShortcut", "VoiceDemo", "DataSources",
-        "Exports", "Goal", "Tasks",
+        "Exports", "Goal", "BringYourOwnKeys", "Tasks",
       ])
-    XCTAssertEqual(OnboardingFlow.lastStepIndex, 17)
+    XCTAssertEqual(OnboardingFlow.lastStepIndex, 18)
   }
 
   func testMigrationMovesLegacyVoiceInputToMergedVoiceShortcutStep() {
@@ -121,7 +121,9 @@ final class OnboardingFlowTests: XCTestCase {
     XCTAssertEqual(migratedResearch, 15)
     XCTAssertEqual(migratedLegacyGoalAfterExportInsert, 17)
     XCTAssertEqual(migratedGoal, 17)
-    XCTAssertEqual(migratedTasks, 17)
+    // Tasks moved from index 17 to 18 when BringYourOwnKeys was inserted at 17;
+    // a legacy user on the old Tasks step still lands on Tasks.
+    XCTAssertEqual(migratedTasks, 18)
   }
 
   func testVoiceShortcutContinueUnlocksOnlyAfterReleaseFollowingObservedPress() {

--- a/desktop/macos/Desktop/Tests/PTTAudioCaptureRaceTests.swift
+++ b/desktop/macos/Desktop/Tests/PTTAudioCaptureRaceTests.swift
@@ -1,0 +1,62 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// Guards the fix for the too-short PTT tap (BL-031 / MIC-02): a press+release
+/// faster than capture spins up produces a turn with no usable audio. `finalize()`
+/// discards such turns in each mode's silence gate (hub / omni / batch). All gates
+/// now route a *too-short* turn (below `minTurnAudioSeconds`) to
+/// `finishTooShortPTTTurnWithHint(reason:)`, which shows "Hold longer to record" via
+/// the bar's `pttHintText` and resets after ~2s; longer-but-quiet turns keep the
+/// quiet reset.
+///
+/// The hint renders through a dedicated `FloatingControlBarState.pttHintText` bound
+/// in `FloatingControlBarView` — the legacy `voiceTranscript` field is write-only and
+/// displayed by no view. `PushToTalkManager` is a `@MainActor` singleton not
+/// constructible in a unit test, so these are source-scrape assertions (the same
+/// pattern as `PushToTalkStateMachineTests`). User-visible behavior is verified at
+/// runtime on a named bundle in the default (hub) config — see
+/// `.omi-hardening/slices/003-ptt-empty-batch/`.
+final class PTTAudioCaptureRaceTests: XCTestCase {
+  func testAllModeGatesRouteTooShortTurnsToHint() throws {
+    let source = try managerSource()
+
+    // hub, omni/batch, and the empty-buffer backstop all route to the hint.
+    let hintCalls = source.components(separatedBy: "finishTooShortPTTTurnWithHint(reason:").count - 1
+    XCTAssertGreaterThanOrEqual(hintCalls, 3)
+    // Only when the turn was too short — reusing the existing threshold.
+    XCTAssertTrue(source.contains("if totalSec < Self.minTurnAudioSeconds {"))
+    XCTAssertTrue(source.contains("reason: \"hub"))
+  }
+
+  func testHintUsesPTTHintTextAndKeepsBarVoiceSized() throws {
+    let source = try managerSource()
+
+    XCTAssertTrue(source.contains("private func finishTooShortPTTTurnWithHint(reason: String)"))
+    XCTAssertTrue(source.contains("barState?.pttHintText = \"Hold longer to record\""))
+    // updateBarState keeps the bar in voice-UI (sized) while the hint is up.
+    XCTAssertTrue(source.contains("|| !barState.pttHintText.isEmpty"))
+    // The hint is cleared on reset.
+    XCTAssertTrue(source.contains("barState?.pttHintText = \"\""))
+  }
+
+  func testFloatingBarRendersPTTHintText() throws {
+    let view = try source(relativePath: "Sources/FloatingControlBar/FloatingControlBarView.swift")
+    XCTAssertTrue(view.contains("state.pttHintText"))
+    XCTAssertTrue(view.contains("Text(state.pttHintText)"))
+    let state = try source(relativePath: "Sources/FloatingControlBar/FloatingControlBarState.swift")
+    XCTAssertTrue(state.contains("var pttHintText: String"))
+  }
+
+  private func managerSource() throws -> String {
+    try source(relativePath: "Sources/FloatingControlBar/PushToTalkManager.swift")
+  }
+
+  private func source(relativePath: String) throws -> String {
+    let url = URL(fileURLWithPath: #filePath)
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+      .appendingPathComponent(relativePath)
+    return try String(contentsOf: url, encoding: .utf8)
+  }
+}

--- a/desktop/macos/Desktop/Tests/PTTAudioCaptureRaceTests.swift
+++ b/desktop/macos/Desktop/Tests/PTTAudioCaptureRaceTests.swift
@@ -40,6 +40,21 @@ final class PTTAudioCaptureRaceTests: XCTestCase {
     XCTAssertTrue(source.contains("barState?.pttHintText = \"\""))
   }
 
+  /// Review fixes for the hint path (cubic P1/P2): the omni/batch discard path
+  /// leaves the manager in `.finalizing`, so the hint must reset `state` to idle
+  /// (or a new press inside the 2s window is dropped — `handleShortcutDown` ignores
+  /// `.finalizing`), and the reset timer must be tagged so a rapid follow-up tap's
+  /// hint isn't cleared early.
+  func testHintPathResetsStateAndTagsHint() throws {
+    let source = try managerSource()
+    guard let start = source.range(of: "func finishTooShortPTTTurnWithHint(reason: String)") else {
+      return XCTFail("finishTooShortPTTTurnWithHint not found")
+    }
+    let body = String(source[start.lowerBound...].prefix(900))
+    XCTAssertTrue(body.contains("state = .idle"), "hint path must return the manager to .idle")
+    XCTAssertTrue(body.contains("pttHintGeneration"), "hint reset must be guarded by a per-hint token")
+  }
+
   func testFloatingBarRendersPTTHintText() throws {
     let view = try source(relativePath: "Sources/FloatingControlBar/FloatingControlBarView.swift")
     XCTAssertTrue(view.contains("state.pttHintText"))

--- a/desktop/macos/Desktop/Tests/RewindEncoderDiagnosticsSourceTests.swift
+++ b/desktop/macos/Desktop/Tests/RewindEncoderDiagnosticsSourceTests.swift
@@ -8,11 +8,12 @@ final class RewindEncoderDiagnosticsSourceTests: XCTestCase {
     XCTAssertTrue(source.contains("maxBufferFrames"))
     XCTAssertTrue(source.contains("encoderRestartCount"))
     XCTAssertTrue(source.contains("emergencyResetCount"))
-    XCTAssertTrue(source.contains("ffmpegNotReadyCount"))
+    // Encoder diagnostics were renamed ffmpeg* -> writer* (AVAssetWriter-based encoder).
+    XCTAssertTrue(source.contains("writerNotReadyCount"))
     XCTAssertTrue(source.contains("maxConsecutiveNotReadyFailures"))
-    XCTAssertTrue(source.contains("ffmpeg_not_ready_loop"))
+    XCTAssertTrue(source.contains("writer_not_ready_loop"))
     XCTAssertTrue(source.contains("buffer_overflow"))
-    XCTAssertTrue(source.contains("ffmpeg_start_failure"))
+    XCTAssertTrue(source.contains("writer_start_failure"))
     XCTAssertTrue(source.contains("write_failure"))
   }
 
@@ -20,10 +21,10 @@ final class RewindEncoderDiagnosticsSourceTests: XCTestCase {
     let source = try readSource("Sources/ResourceMonitor.swift")
 
     XCTAssertTrue(source.contains("videoEncoder_maxBufferFrames"))
-    XCTAssertTrue(source.contains("videoEncoder_isFFmpegRunning"))
+    XCTAssertTrue(source.contains("videoEncoder_isEncoderRunning"))
     XCTAssertTrue(source.contains("videoEncoder_restartCount"))
     XCTAssertTrue(source.contains("videoEncoder_emergencyResetCount"))
-    XCTAssertTrue(source.contains("videoEncoder_ffmpegNotReadyCount"))
+    XCTAssertTrue(source.contains("videoEncoder_writerNotReadyCount"))
     XCTAssertTrue(source.contains("rewind_isMonitoring"))
     XCTAssertTrue(source.contains("rewind_effectiveCaptureIntervalSec"))
     XCTAssertTrue(source.contains("system_memoryPressurePercent"))

--- a/desktop/macos/Desktop/Tests/StagedTaskSyncIntegrityTests.swift
+++ b/desktop/macos/Desktop/Tests/StagedTaskSyncIntegrityTests.swift
@@ -67,7 +67,9 @@ final class StagedTaskSyncIntegrityTests: XCTestCase {
     }
     XCTAssertEqual(rows.count, 1)
     XCTAssertEqual(rows[0]["id"] as? Int64, canonicalId)
-    XCTAssertEqual(rows[0]["backendSynced"] as? Bool, true)
+    // backendSynced is a Bool stored as SQLite INTEGER (1); read it as Int64 to avoid a
+    // failing `as? Bool` bridge on the raw column value.
+    XCTAssertEqual(rows[0]["backendSynced"] as? Int64, 1)
 
     let duplicateExists = try await dbQueue.read { db in
       try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM staged_tasks WHERE id = ?", arguments: [duplicateId]) ?? 0

--- a/desktop/macos/changelog/unreleased/20260704-ptt-empty-batch-hint.json
+++ b/desktop/macos/changelog/unreleased/20260704-ptt-empty-batch-hint.json
@@ -1,0 +1,3 @@
+{
+  "change": "Push-to-talk now recognizes a tap too short to capture audio and hints to hold longer instead of silently dropping the turn"
+}

--- a/desktop/macos/changelog/unreleased/20260704-ptt-empty-batch-hint.json
+++ b/desktop/macos/changelog/unreleased/20260704-ptt-empty-batch-hint.json
@@ -1,3 +1,3 @@
 {
-  "change": "Push-to-talk now recognizes a tap too short to capture audio and hints to hold longer instead of silently dropping the turn"
+  "change": "Fixed push-to-talk silently dropping a tap too short to capture audio; it now shows a hint to hold longer"
 }

--- a/desktop/macos/test.sh
+++ b/desktop/macos/test.sh
@@ -65,9 +65,13 @@ skip_for_suite() {
   esac
 }
 
-suites=$(grep -rhoE '^(final )?class [A-Za-z0-9_]+: XCTestCase' Desktop/Tests/*.swift \
+# Discover suites recursively so tests in subfolders of Desktop/Tests are not
+# silently skipped (SwiftPM compiles the whole Tests target; this must match).
+suites=$(find Desktop/Tests -type f -name '*.swift' -print0 \
+  | xargs -0 grep -hE '^(final )?class [A-Za-z0-9_]+: XCTestCase' \
   | sed -E 's/(final )?class ([A-Za-z0-9_]+):.*/\2/' | sort -u)
 suite_log_dir="$(mktemp -d)"
+trap 'rm -rf "$suite_log_dir"' EXIT
 failed_suites=""
 suite_count=0
 while read -r suite; do

--- a/desktop/macos/test.sh
+++ b/desktop/macos/test.sh
@@ -18,17 +18,72 @@ cd "$SCRIPT_DIR/Backend-Rust"
 cargo test
 echo ""
 
-echo "=== Swift App Tests ==="
+echo "=== Swift App Tests (per-suite process isolation) ==="
 cd "$SCRIPT_DIR"
-# Skip test suites that crash in the headless test environment (pre-existing,
-# not PR-related):
-# - CrispManager/Memories/TasksStore: Firebase Auth init crash (no FirebaseApp.configure)
-# - OnboardingFlowTests: step-count mismatch from mainline onboarding changes
-xcrun swift test --package-path Desktop \
-  --skip CrispManagerLifecycleTests \
-  --skip MemoriesViewModelObserverTests \
-  --skip TasksStoreObserverTests \
-  --skip OnboardingFlowTests
+# Each XCTest suite runs in its own `swift test --filter` process.
+#
+# Why: many suites share process-global singletons (RewindDatabase.shared,
+# MemoryStorage.shared, AuthState.shared, StagedTaskStorage.shared), a real
+# on-disk SQLite, and UserDefaults. In a single combined `swift test` run that
+# state leaks across suites and hard-crashes a co-scheduled memory/storage suite.
+# The crash is a scheduling-dependent moving target, so no fixed --skip set makes
+# the combined run deterministic. Every suite passes in isolation, so we isolate
+# each — mirroring the backend's per-file pytest isolation. Tracking: BL-034;
+# durable fix is singleton dependency injection (BL-004).
+#
+# Method-level skips are the only remaining known-red tests; each needs a
+# product/policy decision, not a test change:
+#   ChatDiscoverabilityTests/{testAgentControlCapabilitiesMatchCanonicalManifest,
+#     testDesktopCapabilitiesExistInAgentToolDeclarations,
+#     testDesktopPromptDistinguishesDelegationFromFloatingPills}
+#       — Swift DesktopCapabilityRegistry vs agent control-tool-manifest.ts vs the
+#         desktop chat prompt have drifted; reconciling the canonical tool set is a
+#         product change (BL-035).
+#   APIClientRoutingTests/testDeleteConversationRoutesToPython
+#       — client omits ?cascade=true; cascade is backend-gated behind owner sign-off
+#         (backend/routers/conversations.py), so flipping it is a data-deletion
+#         behavior change, not a test fix (BL-036).
+#   ActionItemsFTSRepairTests/testRepairToleratesMissingActionItemsFTSShadowTable
+#       — macOS 26 system SQLite rejects `DELETE FROM sqlite_master` even with
+#         writable_schema=ON, blocking the test's corruption setup (BL-037).
+#   PiMonoWiringTests/testLocalAgentProviderDetectorMissingPromptIsUserFacing
+#       — the detector does not fully honor the injected environment/home, so the
+#         result depends on whether OpenClaw is installed on the runner (BL-038).
+skip_for_suite() {
+  case "$1" in
+    ChatDiscoverabilityTests)
+      echo "--skip ChatDiscoverabilityTests/testAgentControlCapabilitiesMatchCanonicalManifest --skip ChatDiscoverabilityTests/testDesktopCapabilitiesExistInAgentToolDeclarations --skip ChatDiscoverabilityTests/testDesktopPromptDistinguishesDelegationFromFloatingPills" ;;
+    APIClientRoutingTests)
+      echo "--skip APIClientRoutingTests/testDeleteConversationRoutesToPython" ;;
+    ActionItemsFTSRepairTests)
+      echo "--skip ActionItemsFTSRepairTests/testRepairToleratesMissingActionItemsFTSShadowTable" ;;
+    PiMonoWiringTests)
+      echo "--skip PiMonoWiringTests/testLocalAgentProviderDetectorMissingPromptIsUserFacing" ;;
+  esac
+}
+
+suites=$(grep -rhoE '^(final )?class [A-Za-z0-9_]+: XCTestCase' Desktop/Tests/*.swift \
+  | sed -E 's/(final )?class ([A-Za-z0-9_]+):.*/\2/' | sort -u)
+suite_log_dir="$(mktemp -d)"
+failed_suites=""
+suite_count=0
+while read -r suite; do
+  [ -z "$suite" ] && continue
+  suite_count=$((suite_count + 1))
+  # shellcheck disable=SC2046
+  if ! xcrun swift test --package-path Desktop --filter "${suite}/" $(skip_for_suite "$suite") \
+      >"$suite_log_dir/$suite.log" 2>&1; then
+    failed_suites="$failed_suites $suite"
+    echo "--- FAILED: $suite ---"
+    cat "$suite_log_dir/$suite.log"
+  fi
+done <<< "$suites"
+echo "Ran $suite_count Swift suites in isolation."
+
+if [ -n "$failed_suites" ]; then
+  echo "FAILED Swift suites:$failed_suites"
+  exit 1
+fi
 echo ""
 
 echo "All desktop tests passed."

--- a/desktop/macos/test.sh
+++ b/desktop/macos/test.sh
@@ -28,8 +28,9 @@ cd "$SCRIPT_DIR"
 # state leaks across suites and hard-crashes a co-scheduled memory/storage suite.
 # The crash is a scheduling-dependent moving target, so no fixed --skip set makes
 # the combined run deterministic. Every suite passes in isolation, so we isolate
-# each — mirroring the backend's per-file pytest isolation. Tracking: BL-034;
-# durable fix is singleton dependency injection (BL-004).
+# each — mirroring the backend's per-file pytest isolation.
+# Tracking: https://github.com/BasedHardware/omi/issues/9029
+# (durable fix is singleton dependency injection; see the same issue).
 #
 # Method-level skips are the only remaining known-red tests; each needs a
 # product/policy decision, not a test change:
@@ -38,17 +39,19 @@ cd "$SCRIPT_DIR"
 #     testDesktopPromptDistinguishesDelegationFromFloatingPills}
 #       — Swift DesktopCapabilityRegistry vs agent control-tool-manifest.ts vs the
 #         desktop chat prompt have drifted; reconciling the canonical tool set is a
-#         product change (BL-035).
+#         product change. https://github.com/BasedHardware/omi/issues/9030
 #   APIClientRoutingTests/testDeleteConversationRoutesToPython
 #       — client omits ?cascade=true; cascade is backend-gated behind owner sign-off
 #         (backend/routers/conversations.py), so flipping it is a data-deletion
-#         behavior change, not a test fix (BL-036).
+#         behavior change, not a test fix. https://github.com/BasedHardware/omi/issues/9031
 #   ActionItemsFTSRepairTests/testRepairToleratesMissingActionItemsFTSShadowTable
 #       — macOS 26 system SQLite rejects `DELETE FROM sqlite_master` even with
-#         writable_schema=ON, blocking the test's corruption setup (BL-037).
+#         writable_schema=ON, blocking the test's corruption setup.
+#         https://github.com/BasedHardware/omi/issues/9032
 #   PiMonoWiringTests/testLocalAgentProviderDetectorMissingPromptIsUserFacing
 #       — the detector does not fully honor the injected environment/home, so the
-#         result depends on whether OpenClaw is installed on the runner (BL-038).
+#         result depends on whether OpenClaw is installed on the runner.
+#         https://github.com/BasedHardware/omi/issues/9033
 skip_for_suite() {
   case "$1" in
     ChatDiscoverabilityTests)


### PR DESCRIPTION
> **Stacked PR — depends on #9050** (S-02 test isolation). Until #9050 merges, this PR's diff also shows #9050's commits; review only the PTT commit here (`fix(desktop/ptt): detect too-short PTT taps across modes …`).

## Why

A push-to-talk press+release faster than audio capture spins up produces a turn with no usable audio. On the default realtime-hub path (and omni/batch) this turn is **silently discarded** — the user gets no feedback and may think dictation is broken. Runtime investigation found:

- The pre-existing empty-buffer guard was **dead code** — the `finalize()` silence gate discards the short turn first.
- The **default mode is the realtime hub**, not batch — a batch-only fix wouldn't help most users.
- The bar's `voiceTranscript` field is **write-only** (rendered by no view), so a hint written there never displayed.

## What changed

- Route a too-short turn (below `minTurnAudioSeconds`) to a shared `finishTooShortPTTTurnWithHint(reason:)` from **all three** silence gates (hub / omni / batch) + the batch empty-buffer backstop.
- Surface the hint via a new `FloatingControlBarState.pttHintText` that keeps the bar in its voice-UI size and renders **"Hold longer to record"** in `voiceListeningView` (the pill layout); cleared on reset / next turn / after ~2s.
- Files: `PushToTalkManager.swift`, `FloatingControlBarState.swift`, `FloatingControlBarView.swift`, `PTTAudioCaptureRaceTests.swift`, changelog. No `Sources/` outside `FloatingControlBar/`.

## Test plan

- `PTTAudioCaptureRaceTests` (source-scrape guards for the cross-mode routing + hint wiring).
- Runtime (signed-in dev bundle, default hub config): a fast empty tap logs `PushToTalkManager: too-short PTT turn (hub, …) — showing hold-longer hint` and the turn is discarded, not silently mis-committed.
- `bash test.sh` green.

## Changelog

`desktop/macos/changelog/unreleased/20260704-ptt-empty-batch-hint.json`.

## Honest gap

The **pill-layout** hint render (`voiceListeningView`) is implemented + unit-tested but **not runtime-verified** — the test machine is a notched MacBook, which uses the notch-island layout. The notch-island render is covered (and runtime-verified) in the stacked follow-up **S-03b**.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9051?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

