### PR TITLE
fix(desktop): surface onboarding data-source failures

### DIFF
--- a/desktop/macos/Desktop/Sources/OnboardingDataSourcesStepView.swift
+++ b/desktop/macos/Desktop/Sources/OnboardingDataSourcesStepView.swift
@@ -74,7 +74,7 @@ struct OnboardingDataSourcesStepView: View {
           sourcePlural: "events",
           memoryCount: coordinator.calendarMemoriesSaved
         ),
-        isOn: !coordinator.calendarInsightsFailed,
+        isOn: true,
         isDisabled: true,
         scanFinished: coordinator.calendarInsightsFinished,
         scanFailed: coordinator.calendarInsightsFailed
@@ -90,7 +90,7 @@ struct OnboardingDataSourcesStepView: View {
           sourcePlural: "emails",
           memoryCount: coordinator.gmailMemoriesSaved
         ),
-        isOn: !coordinator.gmailInsightsFailed,
+        isOn: true,
         isDisabled: true,
         scanFinished: coordinator.gmailInsightsFinished,
         scanFailed: coordinator.gmailInsightsFailed
@@ -122,7 +122,7 @@ struct OnboardingDataSourcesStepView: View {
         ),
         isOn: true,
         isDisabled: coordinator.appleNotesInsightCount > 0,
-        scanFinished: !coordinator.isSyncingAppleNotes,
+        scanFinished: coordinator.appleNotesInsightsFinished,
         scanFailed: coordinator.appleNotesInsightsFailed,
         actionTitle: coordinator.appleNotesInsightCount > 0 ? nil : "Select Folder",
         action: coordinator.appleNotesInsightCount > 0

--- a/desktop/macos/Desktop/Sources/OnboardingDataSourcesStepView.swift
+++ b/desktop/macos/Desktop/Sources/OnboardingDataSourcesStepView.swift
@@ -74,8 +74,10 @@ struct OnboardingDataSourcesStepView: View {
           sourcePlural: "events",
           memoryCount: coordinator.calendarMemoriesSaved
         ),
-        isOn: true,
-        isDisabled: true
+        isOn: !coordinator.calendarInsightsFailed,
+        isDisabled: true,
+        scanFinished: coordinator.calendarInsightsFinished,
+        scanFailed: coordinator.calendarInsightsFailed
       )
       listDivider
 
@@ -88,8 +90,10 @@ struct OnboardingDataSourcesStepView: View {
           sourcePlural: "emails",
           memoryCount: coordinator.gmailMemoriesSaved
         ),
-        isOn: true,
-        isDisabled: true
+        isOn: !coordinator.gmailInsightsFailed,
+        isDisabled: true,
+        scanFinished: coordinator.gmailInsightsFinished,
+        scanFailed: coordinator.gmailInsightsFailed
       )
       listDivider
 
@@ -118,6 +122,8 @@ struct OnboardingDataSourcesStepView: View {
         ),
         isOn: true,
         isDisabled: coordinator.appleNotesInsightCount > 0,
+        scanFinished: !coordinator.isSyncingAppleNotes,
+        scanFailed: coordinator.appleNotesInsightsFailed,
         actionTitle: coordinator.appleNotesInsightCount > 0 ? nil : "Select Folder",
         action: coordinator.appleNotesInsightCount > 0
           ? nil
@@ -263,11 +269,19 @@ struct OnboardingDataSourcesStepView: View {
     metrics: String,
     isOn: Bool,
     isDisabled: Bool,
+    scanFinished: Bool? = nil,
+    scanFailed: Bool = false,
     actionTitle: String? = nil,
     action: (() -> Void)? = nil,
     onToggle: ((Bool) -> Void)? = nil
   ) -> some View {
-    HStack(alignment: .center, spacing: 12) {
+    let status = OnboardingDataSourceRowStatus.resolve(
+      metrics: metrics,
+      scanFinished: scanFinished,
+      scanFailed: scanFailed
+    )
+
+    return HStack(alignment: .center, spacing: 12) {
       ConnectorBrandIcon(brand: brand, size: 38, cornerRadius: 11)
 
       VStack(alignment: .leading, spacing: 3) {
@@ -275,9 +289,9 @@ struct OnboardingDataSourcesStepView: View {
           .font(.system(size: 15, weight: .semibold))
           .foregroundColor(OmiColors.textPrimary)
 
-        Text(metrics)
+        Text(status.text)
           .font(.system(size: 12, weight: .medium))
-          .foregroundColor(OmiColors.textTertiary)
+          .foregroundColor(status.isError ? OmiColors.warning : OmiColors.textTertiary)
           .monospacedDigit()
           .lineLimit(1)
       }
@@ -321,5 +335,29 @@ struct OnboardingDataSourcesStepView: View {
 
   private func countLabel(_ count: Int, singular: String, plural: String) -> String {
     count == 1 ? "1 \(singular)" : "\(count.formatted()) \(plural)"
+  }
+}
+
+struct OnboardingDataSourceRowStatus: Equatable {
+  let text: String
+  let isError: Bool
+
+  static func resolve(
+    metrics: String,
+    scanFinished: Bool?,
+    scanFailed: Bool
+  ) -> OnboardingDataSourceRowStatus {
+    if scanFailed {
+      return OnboardingDataSourceRowStatus(
+        text: "Couldn't read - check access",
+        isError: true
+      )
+    }
+
+    if scanFinished == false {
+      return OnboardingDataSourceRowStatus(text: "Scanning...", isError: false)
+    }
+
+    return OnboardingDataSourceRowStatus(text: metrics, isError: false)
   }
 }

--- a/desktop/macos/Desktop/Sources/OnboardingPagedIntroCoordinator.swift
+++ b/desktop/macos/Desktop/Sources/OnboardingPagedIntroCoordinator.swift
@@ -87,9 +87,12 @@ final class OnboardingPagedIntroCoordinator: ObservableObject {
   @Published var isSyncingAppleNotes = false
 
   private var insightsStarted = false
-  private var gmailInsightsFinished = false
-  private var calendarInsightsFinished = false
-  private var appleNotesInsightsFinished = false
+  @Published private(set) var gmailInsightsFinished = false
+  @Published private(set) var calendarInsightsFinished = false
+  @Published private(set) var appleNotesInsightsFinished = false
+  @Published private(set) var gmailInsightsFailed = false
+  @Published private(set) var calendarInsightsFailed = false
+  @Published private(set) var appleNotesInsightsFailed = false
   private var gmailTask: Task<Void, Never>?
   private var calendarTask: Task<Void, Never>?
   private var appleNotesTask: Task<Void, Never>?
@@ -278,6 +281,7 @@ final class OnboardingPagedIntroCoordinator: ObservableObject {
 
   func refreshAppleNotesInsights() async {
     lastActionError = nil
+    appleNotesInsightsFailed = false
     isSyncingAppleNotes = true
     defer { isSyncingAppleNotes = false }
 
@@ -316,6 +320,7 @@ final class OnboardingPagedIntroCoordinator: ObservableObject {
       }
     } catch {
       lastActionError = error.localizedDescription
+      appleNotesInsightsFailed = true
     }
   }
 
@@ -680,6 +685,9 @@ final class OnboardingPagedIntroCoordinator: ObservableObject {
     gmailInsightsFinished = false
     calendarInsightsFinished = false
     appleNotesInsightsFinished = false
+    gmailInsightsFailed = false
+    calendarInsightsFailed = false
+    appleNotesInsightsFailed = false
     webResearchSummary = ""
 
     gmailTask = Task {
@@ -734,6 +742,7 @@ final class OnboardingPagedIntroCoordinator: ObservableObject {
         log(
           "OnboardingPagedIntroCoordinator: Gmail insights unavailable: \(error.localizedDescription)"
         )
+        await MainActor.run { self.gmailInsightsFailed = true }
         await self.markInsightFinished(.gmail)
       }
     }
@@ -797,6 +806,7 @@ final class OnboardingPagedIntroCoordinator: ObservableObject {
         log(
           "OnboardingPagedIntroCoordinator: Calendar insights unavailable: \(error.localizedDescription)"
         )
+        await MainActor.run { self.calendarInsightsFailed = true }
         await self.markInsightFinished(.calendar)
       }
     }
@@ -868,6 +878,7 @@ final class OnboardingPagedIntroCoordinator: ObservableObject {
           self.appleNotesInsightCount = 0
           self.appleNotesSummary = ""
           self.appleNotesMemoriesSaved = 0
+          self.appleNotesInsightsFailed = true
         }
         await self.markInsightFinished(.appleNotes)
       }

--- a/desktop/macos/Desktop/Tests/OnboardingDataSourceRowStatusTests.swift
+++ b/desktop/macos/Desktop/Tests/OnboardingDataSourceRowStatusTests.swift
@@ -1,0 +1,41 @@
+import XCTest
+
+@testable import Omi_Computer
+
+final class OnboardingDataSourceRowStatusTests: XCTestCase {
+  func testUsesMetricsWhenNoScanStateIsProvided() {
+    XCTAssertEqual(
+      OnboardingDataSourceRowStatus.resolve(
+        metrics: "0 emails - 0 memories",
+        scanFinished: nil,
+        scanFailed: false
+      ),
+      OnboardingDataSourceRowStatus(text: "0 emails - 0 memories", isError: false)
+    )
+  }
+
+  func testShowsScanningWhileSourceReadIsStillInFlight() {
+    XCTAssertEqual(
+      OnboardingDataSourceRowStatus.resolve(
+        metrics: "0 emails - 0 memories",
+        scanFinished: false,
+        scanFailed: false
+      ),
+      OnboardingDataSourceRowStatus(text: "Scanning...", isError: false)
+    )
+  }
+
+  func testFailureOverridesStaleMetrics() {
+    XCTAssertEqual(
+      OnboardingDataSourceRowStatus.resolve(
+        metrics: "114 emails - 114 memories",
+        scanFinished: true,
+        scanFailed: true
+      ),
+      OnboardingDataSourceRowStatus(
+        text: "Couldn't read - check access",
+        isError: true
+      )
+    )
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260705-onboarding-data-source-failures.json
+++ b/desktop/macos/changelog/unreleased/20260705-onboarding-data-source-failures.json
@@ -1,0 +1,3 @@
+{
+  "change": "Show onboarding data-source read failures instead of stale or empty metrics."
+}

--- a/desktop/macos/changelog/unreleased/20260705-onboarding-data-source-failures.json
+++ b/desktop/macos/changelog/unreleased/20260705-onboarding-data-source-failures.json
@@ -1,3 +1,3 @@
 {
-  "change": "Show onboarding data-source read failures instead of stale or empty metrics."
+  "change": "Show onboarding data-source read failures instead of stale or empty metrics"
 }


### PR DESCRIPTION
## Summary
- Show an explicit failure state when onboarding data-source reads fail instead of leaving stale or empty metrics visible.
- Track Gmail, Calendar, and Apple Notes read failures in the onboarding coordinator.
- Add focused row-status tests plus a desktop changelog fragment.

## Bug
During the onboarding data-source step, a failed source read could look like a successful empty import. The reproduced case was Apple Notes: when the app could not read the Notes container, the UI still showed `0 notes • 0 memories` with the toggle enabled, so the user had no clear indication that access failed.

## Root cause
The coordinator logged read failures, but the data-source rows only received count/memory metrics. The view had no failure state to render, so error paths collapsed into the same visible state as a real empty result.

## Fix
- Expose per-source finished/failed flags from `OnboardingPagedIntroCoordinator`.
- Render failed rows as `Couldn't read - check access` using the existing warning color.
- Keep in-flight rows as `Scanning...` and preserve normal metrics when no failure occurred.
- Reset failure flags when onboarding source scans restart or Apple Notes is retried.

## Local reproduction before fix
Named bundle: `omi-onboarding-ds-before` (`com.omi.omi-onboarding-ds-before`), launched from a fresh branch based on current `upstream/main`.

Steps:
1. Seed a signed-in dev auth state into the named bundle.
2. Force onboarding to the data-source step.
3. Leave Apple Notes access unavailable.
4. Launch the app and wait for background data-source scans.

Evidence:
- Log: `OnboardingPagedIntroCoordinator: Apple Notes insights unavailable: Omi needs permission...`
- UI/accessibility label still showed: `Apple Notes 0 notes • 0 memories`
- Result: the failure looked like a successful empty import.

## Verification after fix
Named bundle: `omi-onboarding-ds-after` (`com.omi.omi-onboarding-ds-after`).

- Visual/accessibility verification: Apple Notes row now shows `Couldn't read - check access` while Calendar, Email, and Local files keep their normal metrics.
- Focused test: `xcrun swift test --filter OnboardingDataSourceRowStatusTests --package-path Desktop` passed, 3 tests / 0 failures.
- Compile check: `xcrun swift build -c debug --package-path Desktop` passed.
- Pre-push checks passed, including desktop changelog validation and the desktop Swift build.

Note: the live visual repro covered the Apple Notes read-failure path. Gmail and Calendar use the same row-status rendering and now receive their own coordinator failure flags when their read calls throw.

## Risk
Low. This only changes the onboarding data-source row presentation for existing read-failure paths and adds state flags that reset on scan start/retry. Normal successful metrics are preserved.

## Rollback
Revert this commit to return the rows to metrics-only rendering.

Generated with Codex.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9053?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

