### PR TITLE
Add GET /v1/integrations: list the user's integration connections

### DIFF
--- a/backend/database/users.py
+++ b/backend/database/users.py
@@ -1487,6 +1487,26 @@ def get_integration(uid: str, app_key: str) -> Optional[dict]:
     return None
 
 
+def get_integrations(uid: str) -> dict:
+    """
+    Get all integration connections for a user.
+
+    Args:
+        uid: User ID
+
+    Returns:
+        Dictionary with app_key as keys and connection details as values
+    """
+    user_ref = db.collection('users').document(uid)
+    integrations_ref = user_ref.collection('integrations')
+
+    integrations = {}
+    for doc in integrations_ref.stream():
+        integrations[doc.id] = doc.to_dict()
+
+    return integrations
+
+
 def set_integration(uid: str, app_key: str, data: dict) -> None:
     """
     Save or update an integration connection.

--- a/backend/routers/integrations.py
+++ b/backend/routers/integrations.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from fastapi.responses import HTMLResponse
 from fastapi.templating import Jinja2Templates
-from typing import Dict, Any, List, Optional
+from typing import Dict, Any, Optional
 from pydantic import BaseModel, Field
 import os
 import secrets
@@ -210,7 +210,19 @@ class IntegrationSummary(BaseModel):
 class IntegrationsListResponse(BaseModel):
     """All of the current user's integration connections."""
 
-    integrations: List[IntegrationSummary] = Field(default_factory=list)
+    integrations: list[IntegrationSummary] = Field(default_factory=list)
+
+
+def _coerce_connected(value) -> bool:
+    """Normalize a stored `connected` flag to a strict bool.
+
+    Firestore stores it as a real bool, but a legacy/string value must not be coerced
+    blindly: bool('false') is True, which would report a disconnected integration as
+    connected. Strings are compared explicitly; everything else falls back to truthiness.
+    """
+    if isinstance(value, str):
+        return value.strip().lower() == 'true'
+    return bool(value)
 
 
 @router.get("/v1/integrations", response_model=IntegrationsListResponse, tags=['integrations'])
@@ -226,7 +238,7 @@ def list_integrations(uid: str = Depends(auth.get_current_user_uid)):
         summaries.append(
             IntegrationSummary(
                 app_key=app_key,
-                connected=bool(data.get('connected')),
+                connected=_coerce_connected(data.get('connected')),
                 last_synced=last_synced,
             )
         )

--- a/backend/routers/integrations.py
+++ b/backend/routers/integrations.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from fastapi.responses import HTMLResponse
 from fastapi.templating import Jinja2Templates
-from typing import Dict, Any, Optional
+from typing import Dict, Any, List, Optional
 from pydantic import BaseModel, Field
 import os
 import secrets
@@ -197,6 +197,40 @@ class IntegrationResponse(BaseModel):
 # *****************************
 # ********** ROUTES ***********
 # *****************************
+
+
+class IntegrationSummary(BaseModel):
+    """One integration connection, status only (no secrets)."""
+
+    app_key: str = Field(description="Integration app key")
+    connected: bool = Field(description="Whether the integration is connected")
+    last_synced: Optional[str] = Field(default=None, description="ISO timestamp of the last sync, if recorded")
+
+
+class IntegrationsListResponse(BaseModel):
+    """All of the current user's integration connections."""
+
+    integrations: List[IntegrationSummary] = Field(default_factory=list)
+
+
+@router.get("/v1/integrations", response_model=IntegrationsListResponse, tags=['integrations'])
+def list_integrations(uid: str = Depends(auth.get_current_user_uid)):
+    """List all of the current user's integration connections (status only, no secrets)."""
+    raw = users_db.get_integrations(uid)
+    summaries = []
+    for app_key, data in raw.items():
+        data = data or {}
+        last_synced = data.get('last_synced')
+        if last_synced is not None and not isinstance(last_synced, str):
+            last_synced = last_synced.isoformat() if hasattr(last_synced, 'isoformat') else str(last_synced)
+        summaries.append(
+            IntegrationSummary(
+                app_key=app_key,
+                connected=bool(data.get('connected')),
+                last_synced=last_synced,
+            )
+        )
+    return IntegrationsListResponse(integrations=summaries)
 
 
 @router.get("/v1/integrations/{app_key}", response_model=IntegrationResponse, tags=['integrations'])

--- a/backend/tests/unit/test_integrations_list.py
+++ b/backend/tests/unit/test_integrations_list.py
@@ -63,6 +63,26 @@ def test_endpoint_tolerates_none_doc():
     assert resp.integrations[0].connected is False
 
 
+def test_endpoint_connected_coerces_strings_strictly():
+    # A stored string 'false' must not be reported as connected (bool('false') is True).
+    raw = {
+        'a': {'connected': 'false'},
+        'b': {'connected': 'true'},
+        'c': {'connected': True},
+        'd': {'connected': False},
+        'e': {'connected': None},
+    }
+    with patch.object(users_db, 'get_integrations', return_value=raw):
+        resp = integrations_router.list_integrations(uid='u1')
+    assert {s.app_key: s.connected for s in resp.integrations} == {
+        'a': False,
+        'b': True,
+        'c': True,
+        'd': False,
+        'e': False,
+    }
+
+
 # ---------------------------------------------------------------------------
 # DB helper: stream into an app_key-keyed dict
 # ---------------------------------------------------------------------------

--- a/backend/tests/unit/test_integrations_list.py
+++ b/backend/tests/unit/test_integrations_list.py
@@ -1,0 +1,98 @@
+"""Unit tests for GET /v1/integrations (list the user's integration connections).
+
+Verifies the router endpoint's mapping and secret-stripping, and the db helper's
+stream-into-dict behavior, using the sanctioned seams (import the modules normally
+and patch.object on the singletons, no sys.modules mutation).
+"""
+
+import os
+
+os.environ.setdefault(
+    "ENCRYPTION_SECRET",
+    "omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv",
+)
+os.environ.setdefault("OPENAI_API_KEY", "test-openai-key-not-real")
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import database.users as users_db
+from routers import integrations as integrations_router
+
+
+# ---------------------------------------------------------------------------
+# Endpoint: mapping + secret stripping
+# ---------------------------------------------------------------------------
+def test_endpoint_maps_and_strips_secrets():
+    raw = {
+        'google_calendar': {'connected': True, 'access_token': 'SECRET', 'refresh_token': 'SECRET2'},
+        'apple_health': {'connected': True, 'last_synced': '2026-07-04T00:00:00+00:00'},
+        'whoop': {'connected': False, 'access_token': 'x'},
+    }
+    with patch.object(users_db, 'get_integrations', return_value=raw):
+        resp = integrations_router.list_integrations(uid='u1')
+    by_key = {s.app_key: s for s in resp.integrations}
+    assert by_key['google_calendar'].connected is True
+    assert by_key['google_calendar'].last_synced is None  # no last_synced recorded
+    assert by_key['apple_health'].last_synced == '2026-07-04T00:00:00+00:00'
+    assert by_key['whoop'].connected is False
+    # Secrets never leave the endpoint: the summary model has no token fields at all.
+    dumped = str(resp.model_dump())
+    assert 'access_token' not in dumped
+    assert 'refresh_token' not in dumped
+    assert 'SECRET' not in dumped
+
+
+def test_endpoint_empty_when_no_integrations():
+    with patch.object(users_db, 'get_integrations', return_value={}):
+        resp = integrations_router.list_integrations(uid='u1')
+    assert resp.integrations == []
+
+
+def test_endpoint_coerces_non_str_last_synced():
+    raw = {'apple_health': {'connected': True, 'last_synced': datetime(2026, 7, 4, tzinfo=timezone.utc)}}
+    with patch.object(users_db, 'get_integrations', return_value=raw):
+        resp = integrations_router.list_integrations(uid='u1')
+    assert resp.integrations[0].last_synced == '2026-07-04T00:00:00+00:00'
+
+
+def test_endpoint_tolerates_none_doc():
+    with patch.object(users_db, 'get_integrations', return_value={'weird': None}):
+        resp = integrations_router.list_integrations(uid='u1')
+    assert resp.integrations[0].app_key == 'weird'
+    assert resp.integrations[0].connected is False
+
+
+# ---------------------------------------------------------------------------
+# DB helper: stream into an app_key-keyed dict
+# ---------------------------------------------------------------------------
+def test_db_get_integrations_streams_into_dict():
+    doc1 = MagicMock()
+    doc1.id = 'google_calendar'
+    doc1.to_dict.return_value = {'connected': True}
+    doc2 = MagicMock()
+    doc2.id = 'whoop'
+    doc2.to_dict.return_value = {'connected': False}
+    col = MagicMock()
+    col.stream.return_value = [doc1, doc2]
+    user_ref = MagicMock()
+    user_ref.collection.return_value = col
+    # Pass an explicit mock: patch.object's default path introspects the lazy db
+    # proxy (hasattr __func__), which would construct a real Firestore client.
+    fake_db = MagicMock()
+    fake_db.collection.return_value.document.return_value = user_ref
+    with patch.object(users_db, 'db', fake_db):
+        out = users_db.get_integrations('u1')
+    assert out == {'google_calendar': {'connected': True}, 'whoop': {'connected': False}}
+    user_ref.collection.assert_called_once_with('integrations')
+
+
+def test_db_get_integrations_empty():
+    col = MagicMock()
+    col.stream.return_value = []
+    user_ref = MagicMock()
+    user_ref.collection.return_value = col
+    fake_db = MagicMock()
+    fake_db.collection.return_value.document.return_value = user_ref
+    with patch.object(users_db, 'db', fake_db):
+        assert users_db.get_integrations('u1') == {}


### PR DESCRIPTION
## What
Adds `GET /v1/integrations`, which lists all of the current user's integration connections.

## Why
The integrations router exposes a singular `GET /v1/integrations/{app_key}` but no way to list all of a user's connections at once, unlike task integrations which already have a list endpoint (`GET /v1/task-integrations`). A client that wants to render a connections screen otherwise has to know every app_key up front and probe each one.

## Details
- New db helper `get_integrations(uid)` mirrors `get_task_integrations`, using the same `db` seam and the `users/{uid}/integrations` subcollection.
- The response is status only: each entry is `{app_key, connected, last_synced}`. It never includes `access_token` or `refresh_token`, so no secrets leak (the summary model has no token fields at all).
- Coexists unambiguously with the existing `/v1/integrations/{app_key}` route.

## Test
`backend/tests/unit/test_integrations_list.py`: the endpoint maps fields and strips secrets, returns an empty list when there are no connections, coerces a non-string last_synced, and tolerates a null doc; the db helper streams into an app_key-keyed dict. 6 passed locally.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9054?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

