### PR TITLE
Add GET /v1/task-integrations/{app_key}: fetch one task integration status

### DIFF
--- a/backend/routers/task_integrations.py
+++ b/backend/routers/task_integrations.py
@@ -236,6 +236,60 @@ def delete_task_integration(app_key: str, uid: str = Depends(auth.get_current_us
     return {"status": "ok"}
 
 
+class TaskIntegrationStatusResponse(BaseModel):
+    """Non-secret connection status for a single task integration."""
+
+    app_key: str = Field(description="Task integration app key")
+    connected: bool = Field(default=False, description="Whether the integration is connected")
+    expired: bool = Field(default=False, description="Whether the stored OAuth token has expired")
+    expires_at: Optional[str] = Field(default=None, description="ISO timestamp the token expires, if known")
+    is_default: bool = Field(default=False, description="Whether this is the user's default task integration")
+    workspace_name: Optional[str] = None
+    project_name: Optional[str] = None
+    default_list_title: Optional[str] = None
+    team_name: Optional[str] = None
+    space_name: Optional[str] = None
+    list_name: Optional[str] = None
+
+
+@router.get("/v1/task-integrations/{app_key}", response_model=TaskIntegrationStatusResponse, tags=['task-integrations'])
+def get_task_integration_status(app_key: str, uid: str = Depends(auth.get_current_user_uid)):
+    """Get connection status for one task integration by app key.
+
+    Secrets (access_token / refresh_token) are intentionally omitted; the client only needs
+    connection health to render its UI. Token expiry is derived from the stored expires_at,
+    no OAuth refresh or network call is made.
+    """
+    integration = users_db.get_task_integration(uid, app_key)
+    if not integration:
+        raise HTTPException(status_code=404, detail="Task integration not found")
+
+    expired = False
+    expires_at = integration.get('expires_at')
+    if expires_at:
+        try:
+            exp = datetime.fromisoformat(str(expires_at).replace('Z', '+00:00'))
+            expired = datetime.now(timezone.utc) >= exp
+        except (ValueError, TypeError):
+            expired = False
+
+    default_app = users_db.get_default_task_integration(uid)
+
+    return TaskIntegrationStatusResponse(
+        app_key=app_key,
+        connected=bool(integration.get('connected', False)),
+        expired=expired,
+        expires_at=expires_at if isinstance(expires_at, str) else None,
+        is_default=(default_app == app_key),
+        workspace_name=integration.get('workspace_name'),
+        project_name=integration.get('project_name'),
+        default_list_title=integration.get('default_list_title'),
+        team_name=integration.get('team_name'),
+        space_name=integration.get('space_name'),
+        list_name=integration.get('list_name'),
+    )
+
+
 # *****************************
 # ****** OAuth Initiation *****
 # *****************************

--- a/backend/tests/unit/test_task_integration_status.py
+++ b/backend/tests/unit/test_task_integration_status.py
@@ -1,0 +1,81 @@
+"""Unit tests for GET /v1/task-integrations/{app_key} (fetch one integration's status).
+
+routers.task_integrations imports cleanly (no heavy deps), so the endpoint is tested
+directly with patch.object on the users_db seam (no sys.modules mutation).
+"""
+
+import os
+
+os.environ.setdefault(
+    "ENCRYPTION_SECRET",
+    "omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv",
+)
+os.environ.setdefault("OPENAI_API_KEY", "test-openai-key-not-real")
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+
+import pytest
+from fastapi import HTTPException
+
+import database.users as users_db
+from routers import task_integrations as ti_router
+
+
+def test_404_when_absent():
+    with patch.object(users_db, "get_task_integration", return_value=None):
+        with pytest.raises(HTTPException) as exc:
+            ti_router.get_task_integration_status(app_key="todoist", uid="u1")
+    assert exc.value.status_code == 404
+
+
+def test_status_maps_and_redacts_secrets():
+    integration = {
+        "connected": True,
+        "access_token": "SECRET",
+        "refresh_token": "SECRET2",
+        "workspace_name": "Acme",
+        "list_name": "Inbox",
+    }
+    with patch.object(users_db, "get_task_integration", return_value=integration), patch.object(
+        users_db, "get_default_task_integration", return_value="todoist"
+    ):
+        resp = ti_router.get_task_integration_status(app_key="todoist", uid="u1")
+    assert resp.app_key == "todoist"
+    assert resp.connected is True
+    assert resp.is_default is True
+    assert resp.workspace_name == "Acme"
+    assert resp.list_name == "Inbox"
+    # The secret fields are not even on the response model, so they cannot leak.
+    dumped = str(resp.model_dump())
+    assert "SECRET" not in dumped
+    assert "access_token" not in dumped
+    assert "refresh_token" not in dumped
+
+
+def test_expired_true_for_past_token():
+    past = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()
+    with patch.object(
+        users_db, "get_task_integration", return_value={"connected": True, "expires_at": past}
+    ), patch.object(users_db, "get_default_task_integration", return_value=None):
+        resp = ti_router.get_task_integration_status(app_key="asana", uid="u1")
+    assert resp.expired is True
+    assert resp.is_default is False
+
+
+def test_expired_false_for_future_token():
+    future = (datetime.now(timezone.utc) + timedelta(hours=1)).isoformat()
+    with patch.object(
+        users_db, "get_task_integration", return_value={"connected": True, "expires_at": future}
+    ), patch.object(users_db, "get_default_task_integration", return_value=None):
+        resp = ti_router.get_task_integration_status(app_key="asana", uid="u1")
+    assert resp.expired is False
+
+
+def test_malformed_expires_at_does_not_crash():
+    with patch.object(
+        users_db, "get_task_integration", return_value={"connected": True, "expires_at": "not-a-date"}
+    ), patch.object(users_db, "get_default_task_integration", return_value=None):
+        resp = ti_router.get_task_integration_status(app_key="asana", uid="u1")
+    assert resp.expired is False
+    assert resp.expires_at == "not-a-date"


### PR DESCRIPTION
## What
Adds `GET /v1/task-integrations/{app_key}`, which fetches a single task integration's connection status by app key.

## Why
Task integrations can be saved (`PUT /v1/task-integrations/{app_key}`), listed (`GET /v1/task-integrations`), and deleted (`DELETE /v1/task-integrations/{app_key}`), but there was no way to fetch one by app key. A client that wants to render a single integration's detail or health had no read path.

## Details
- Returns `connected`, a computed `expired` flag (derived from the stored `expires_at`, with no OAuth refresh or network call), `is_default`, and non-secret provider metadata (workspace_name, project_name, list_name, and similar).
- Access and refresh tokens are intentionally omitted from the response model, so no secrets leak.
- Returns 404 when the integration does not exist, matching the sibling delete handler.
- Registered after `GET /v1/task-integrations/default` so a request to `/default` is never captured as an `app_key`.

## Test
`backend/tests/unit/test_task_integration_status.py`: 404 when absent, field mapping with secret redaction, expired True/False for past/future tokens, and a malformed expires_at that does not crash. 5 passed locally.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9056?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

