### PR TITLE
Add GET /v1/calendar/current-meetings: meetings in progress now

### DIFF
--- a/backend/routers/calendar_meetings.py
+++ b/backend/routers/calendar_meetings.py
@@ -1,5 +1,5 @@
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException
@@ -121,6 +121,35 @@ def list_calendar_meetings(
     # record cannot hide every other meeting the user has. Log a safe identifier plus
     # the exception class only: a ValidationError's str() renders the field input_value,
     # which for a meeting can be sensitive (title, participant emails, link, notes).
+    return CalendarMeetingContext.from_records(
+        meetings,
+        on_error=lambda record, exc: logger.warning(
+            'Skipping malformed calendar meeting for uid=%s event_id=%s: %s',
+            uid,
+            record.get('calendar_event_id'),
+            type(exc).__name__,
+        ),
+    )
+
+
+@router.get('/v1/calendar/current-meetings', response_model=List[CalendarMeetingContext], tags=['calendar'])
+def get_current_meetings(
+    uid: str = Depends(auth.get_current_user_uid),
+    at: Optional[datetime] = None,
+):
+    """List calendar meetings in progress at a given instant (default: now).
+
+    Returns the meeting(s) whose [start_time, end_time] window contains `at`, i.e. the
+    meeting the user is currently in. Reuses the same overlap query the desktop
+    transcription pipeline uses to auto-attach a conversation to a meeting; there was
+    no HTTP surface for it before.
+    """
+    moment = at or datetime.now(timezone.utc)
+    if moment.tzinfo is None:
+        # Treat a naive instant as UTC, consistent with how meeting times are stored.
+        moment = moment.replace(tzinfo=timezone.utc)
+
+    meetings = calendar_db.get_meetings_in_time_range(uid, moment, moment)
     return CalendarMeetingContext.from_records(
         meetings,
         on_error=lambda record, exc: logger.warning(

--- a/backend/tests/unit/test_calendar_current_meetings.py
+++ b/backend/tests/unit/test_calendar_current_meetings.py
@@ -1,0 +1,68 @@
+"""Unit tests for GET /v1/calendar/current-meetings (meetings in progress now).
+
+routers.calendar_meetings imports cleanly, so the endpoint is tested directly with
+patch.object on the calendar_db seam (no sys.modules mutation).
+"""
+
+import os
+
+os.environ.setdefault(
+    "ENCRYPTION_SECRET",
+    "omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv",
+)
+os.environ.setdefault("OPENAI_API_KEY", "test-openai-key-not-real")
+
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+import database.calendar_meetings as calendar_db
+from routers import calendar_meetings as cal_router
+
+
+def _valid_record(event_id="evt1"):
+    return {
+        "calendar_event_id": event_id,
+        "title": "Standup",
+        "start_time": datetime(2026, 7, 5, 12, 0, tzinfo=timezone.utc),
+        "duration_minutes": 30,
+    }
+
+
+def test_empty_returns_empty_and_uses_zero_width_window():
+    with patch.object(calendar_db, "get_meetings_in_time_range", return_value=[]) as m:
+        result = cal_router.get_current_meetings(uid="u1", at=None)
+    assert result == []
+    args = m.call_args[0]
+    assert args[0] == "u1"
+    assert args[1] == args[2]  # start == end (a zero-width "now" window)
+    assert args[1].tzinfo == timezone.utc
+
+
+def test_naive_at_is_treated_as_utc():
+    naive = datetime(2026, 7, 5, 9, 30, 0)
+    with patch.object(calendar_db, "get_meetings_in_time_range", return_value=[]) as m:
+        cal_router.get_current_meetings(uid="u1", at=naive)
+    passed = m.call_args[0][1]
+    assert passed == naive.replace(tzinfo=timezone.utc)
+    assert m.call_args[0][1] == m.call_args[0][2]
+
+
+def test_aware_at_passes_through():
+    aware = datetime(2026, 7, 5, 9, 30, 0, tzinfo=timezone.utc)
+    with patch.object(calendar_db, "get_meetings_in_time_range", return_value=[]) as m:
+        cal_router.get_current_meetings(uid="u1", at=aware)
+    assert m.call_args[0][1] == aware
+
+
+def test_valid_records_mapped_to_context():
+    recs = [_valid_record("a"), _valid_record("b")]
+    with patch.object(calendar_db, "get_meetings_in_time_range", return_value=recs):
+        result = cal_router.get_current_meetings(uid="u1", at=None)
+    assert [m.calendar_event_id for m in result] == ["a", "b"]
+
+
+def test_malformed_record_is_skipped():
+    recs = [_valid_record("ok"), {"title": "missing required fields"}]
+    with patch.object(calendar_db, "get_meetings_in_time_range", return_value=recs):
+        result = cal_router.get_current_meetings(uid="u1", at=None)
+    assert [m.calendar_event_id for m in result] == ["ok"]


### PR DESCRIPTION
## What
Adds `GET /v1/calendar/current-meetings`, which returns the calendar meeting(s) a user is currently in.

## Why
The overlap query `get_meetings_in_time_range` already powers the desktop transcription pipeline (it auto-attaches a new conversation to the meeting in progress), but it has no HTTP surface. A client that wants to show "you are currently in this meeting" had no way to ask. This exposes that per-user view.

## Details
- Returns the meeting(s) whose `[start_time, end_time]` window contains a given instant, defaulting to now. An optional `at` query param checks a specific moment; a naive `at` is treated as UTC to match how meeting times are stored.
- Reuses the existing overlap helper and the same skip-malformed `from_records` pattern as the list endpoint, so one bad stored record cannot 500 the whole response. Malformed records are logged by a safe id and exception type only.
- No new database code and no route collision (all sibling `/v1/calendar/*` routes are literal or nested under `/meetings/`).

## Test
`backend/tests/unit/test_calendar_current_meetings.py`: empty result uses a zero-width now-window, a naive `at` is coerced to UTC, an aware `at` passes through, valid records map to context objects, and a malformed record is skipped. 5 passed locally.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9057?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

