### PR TITLE
Add GET /v1/folders/by-category/{category_mapping}: resolve a category to its folder

### DIFF
--- a/backend/routers/folders.py
+++ b/backend/routers/folders.py
@@ -63,6 +63,21 @@ def get_folder(folder_id: str, uid: str = Depends(auth.get_current_user_uid)):
     return folder
 
 
+@router.get('/v1/folders/by-category/{category_mapping}', response_model=Folder, tags=['folders'])
+def get_folder_by_category(category_mapping: str, uid: str = Depends(auth.get_current_user_uid)):
+    """Get the folder mapped to a given conversation category (404 if none is mapped).
+
+    Categories are auto-routed into folders via `category_mapping`, but the reverse
+    lookup (which folder does this category go to) had no HTTP surface. Registered
+    before `/v1/folders/{folder_id}/conversations` so the literal `by-category`
+    segment is not shadowed.
+    """
+    folder = folders_db.get_folder_by_category_mapping(uid, category_mapping)
+    if not folder:
+        raise HTTPException(status_code=404, detail="Folder not found")
+    return folder
+
+
 @router.patch('/v1/folders/{folder_id}', response_model=Folder, tags=['folders'])
 def update_folder(folder_id: str, request: UpdateFolderRequest, uid: str = Depends(auth.get_current_user_uid)):
     """Update folder metadata (name, description, color, icon, order)."""

--- a/backend/tests/unit/test_folder_by_category.py
+++ b/backend/tests/unit/test_folder_by_category.py
@@ -1,0 +1,62 @@
+"""Unit tests for GET /v1/folders/by-category/{category_mapping} and its db helper.
+
+routers.folders and database.folders import cleanly, so both the endpoint and the
+helper are tested directly with patch.object (no sys.modules mutation).
+"""
+
+import os
+
+os.environ.setdefault(
+    "ENCRYPTION_SECRET",
+    "omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv",
+)
+os.environ.setdefault("OPENAI_API_KEY", "test-openai-key-not-real")
+
+from unittest.mock import patch
+
+import pytest
+from fastapi import HTTPException
+
+import database.folders as folders_db
+from routers import folders as folders_router
+
+
+# ---------------------------------------------------------------------------
+# db helper: get_folder_by_category_mapping
+# ---------------------------------------------------------------------------
+def test_helper_finds_matching_category():
+    folders = [
+        {"id": "1", "category_mapping": "food"},
+        {"id": "2", "category_mapping": "work"},
+    ]
+    with patch.object(folders_db, "get_folders", return_value=folders):
+        result = folders_db.get_folder_by_category_mapping("u1", "work")
+    assert result["id"] == "2"
+
+
+def test_helper_returns_none_when_no_match():
+    with patch.object(folders_db, "get_folders", return_value=[{"id": "1", "category_mapping": "food"}]):
+        assert folders_db.get_folder_by_category_mapping("u1", "missing") is None
+
+
+def test_helper_returns_none_on_empty():
+    with patch.object(folders_db, "get_folders", return_value=[]):
+        assert folders_db.get_folder_by_category_mapping("u1", "any") is None
+
+
+# ---------------------------------------------------------------------------
+# endpoint: get_folder_by_category
+# ---------------------------------------------------------------------------
+def test_endpoint_returns_folder():
+    folder = {"id": "1", "name": "Food", "category_mapping": "food"}
+    with patch.object(folders_db, "get_folder_by_category_mapping", return_value=folder) as m:
+        result = folders_router.get_folder_by_category(category_mapping="food", uid="u1")
+    assert result == folder
+    m.assert_called_once_with("u1", "food")
+
+
+def test_endpoint_404_when_absent():
+    with patch.object(folders_db, "get_folder_by_category_mapping", return_value=None):
+        with pytest.raises(HTTPException) as exc:
+            folders_router.get_folder_by_category(category_mapping="none", uid="u1")
+    assert exc.value.status_code == 404


### PR DESCRIPTION
## What
Adds `GET /v1/folders/by-category/{category_mapping}`, which returns the folder a given conversation category is mapped to.

## Why
Conversations are auto-routed into folders by their `category_mapping`, and `get_folder_by_category_mapping` already exists in the database layer, but there was no HTTP surface for the reverse lookup (given a category, which folder does it go to). A client that wants to jump to the folder for a category had no way to resolve it.

## Details
- Returns the mapped `Folder`, or 404 when no folder maps to that category.
- Reuses the existing `get_folder_by_category_mapping` helper (no new database code) and the same `db` seam and auth dependency as the sibling folder routes.
- Registered before `/v1/folders/{folder_id}/conversations` so the literal `by-category` segment is not shadowed for the edge case of a category named "conversations".

## Test
`backend/tests/unit/test_folder_by_category.py`: the helper finds the matching folder, returns None when no category matches, and handles an empty list; the endpoint returns the folder and raises 404 when absent. 5 passed locally.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9058?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

