### PR TITLE
Add GET /v1/trends/{category}: fetch a single trend category

### DIFF
--- a/backend/routers/trends.py
+++ b/backend/routers/trends.py
@@ -1,8 +1,9 @@
 from typing import List
 
-from fastapi import APIRouter
+from fastapi import APIRouter, HTTPException
 
 import database.trends as trends_db
+from models.trend import TrendEnum
 
 router = APIRouter()
 
@@ -10,3 +11,19 @@ router = APIRouter()
 @router.get("/v1/trends", response_model=List, tags=['trends'])
 def get_trends():
     return trends_db.get_trends_data()
+
+
+@router.get("/v1/trends/{category}", response_model=List, tags=['trends'])
+def get_trends_by_category(category: str):
+    """Return the trend entries for a single category (best and worst variants).
+
+    The only existing trends route returns every category at once, forcing a client to
+    pull the whole blob and filter locally. This exposes one category directly. Public,
+    matching the sibling GET /v1/trends (trends are global, not per-user).
+    """
+    if category not in {c.value for c in TrendEnum}:
+        raise HTTPException(status_code=404, detail="Unknown trend category")
+    entries = [row for row in trends_db.get_trends_data() if row.get('category') == category]
+    if not entries:
+        raise HTTPException(status_code=404, detail="No trends for this category yet")
+    return entries

--- a/backend/tests/unit/test_trends_by_category.py
+++ b/backend/tests/unit/test_trends_by_category.py
@@ -1,0 +1,49 @@
+"""Unit tests for GET /v1/trends/{category}.
+
+routers.trends imports cleanly (only database.trends), so the endpoint is tested
+directly with patch.object on the trends_db seam (no sys.modules mutation).
+"""
+
+import os
+
+os.environ.setdefault(
+    "ENCRYPTION_SECRET",
+    "omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv",
+)
+os.environ.setdefault("OPENAI_API_KEY", "test-openai-key-not-real")
+
+from unittest.mock import patch
+
+import pytest
+from fastapi import HTTPException
+
+import database.trends as trends_db
+from routers import trends as trends_router
+
+
+def test_filters_to_the_requested_category():
+    rows = [
+        {"category": "ceo", "type": "best", "topics": [{"topic": "x", "memories_count": 3}]},
+        {"category": "ceo", "type": "worst", "topics": []},
+        {"category": "company", "type": "best", "topics": []},
+    ]
+    with patch.object(trends_db, "get_trends_data", return_value=rows):
+        result = trends_router.get_trends_by_category(category="ceo")
+    assert [r["type"] for r in result] == ["best", "worst"]
+    assert all(r["category"] == "ceo" for r in result)
+
+
+def test_unknown_category_returns_404_without_db_call():
+    # The TrendEnum check runs before any DB access, so no patch is needed.
+    with pytest.raises(HTTPException) as exc:
+        trends_router.get_trends_by_category(category="not_a_category")
+    assert exc.value.status_code == 404
+
+
+def test_known_category_with_no_data_returns_404():
+    with patch.object(
+        trends_db, "get_trends_data", return_value=[{"category": "company", "type": "best", "topics": []}]
+    ):
+        with pytest.raises(HTTPException) as exc:
+            trends_router.get_trends_by_category(category="ceo")
+    assert exc.value.status_code == 404


### PR DESCRIPTION
## What
Adds `GET /v1/trends/{category}`, which returns the trend entries for a single category.

## Why
The only trends route, `GET /v1/trends`, returns every category at once, forcing a client to pull the whole aggregate and filter locally. This lets a client fetch just the category it wants (for example a CEO-trends view).

## Details
- Returns that category's entries (a category can appear as both a `best` and a `worst` variant, so this is a list). 404 when the category is not one of the known trend categories, or when there is no trend data for it yet.
- Reuses the existing `get_trends_data` helper (no new database code); the trends dataset is tiny (at most a handful of category docs).
- Public, matching the sibling `GET /v1/trends` (trends are global, not per-user).

## Test
`backend/tests/unit/test_trends_by_category.py`: filters to the requested category (best and worst variants), returns 404 for an unknown category without touching the database, and returns 404 for a known category with no data. 3 passed locally.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9059?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

