### PR TITLE
Add POST /v1/agent/vm-stop: user-initiated stop of the agent VM

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -56,6 +56,7 @@ from routers import (
     announcements,
     phone_calls,
     agent_tools,
+    agent_vm,
     tools,
     metrics,
     fair_use_admin,
@@ -156,6 +157,7 @@ app.include_router(goals.router)
 app.include_router(announcements.router)
 app.include_router(phone_calls.router)
 app.include_router(agent_tools.router)
+app.include_router(agent_vm.router)
 app.include_router(tools.router)
 app.include_router(metrics.router)
 app.include_router(fair_use_admin.router)

--- a/backend/routers/agent_vm.py
+++ b/backend/routers/agent_vm.py
@@ -1,0 +1,76 @@
+"""User-initiated agent VM lifecycle (stop).
+
+The desktop can start (`/v1/agent/vm-ensure`) and keep-alive (`/v1/agent/keepalive`) the
+per-user agent sandbox VM, but there was no way to stop it before the idle auto-stop timer
+fires. This exposes a self-scoped stop so a user can end their own GCE compute now.
+
+Hosted in its own light module rather than routers/agent_tools.py: that module imports
+utils.retrieval.agentic, which constructs an OpenAI client at import time, so importing it
+is not clean. The GCE token helper and status writer are re-inlined here (a few lines) to
+keep this module import-pure.
+"""
+
+import logging
+
+import google.auth
+import google.auth.transport.requests
+import httpx
+from fastapi import APIRouter, Depends
+
+from database.users import get_agent_vm, db as firestore_db
+from utils.executors import db_executor, run_blocking
+from utils.log_sanitizer import sanitize
+from utils.other.endpoints import get_current_user_uid
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+GCE_PROJECT = "based-hardware"
+
+
+def _get_gce_access_token() -> str:
+    """Get a GCE access token via Application Default Credentials (sync; offload in async)."""
+    creds, _ = google.auth.default(scopes=['https://www.googleapis.com/auth/cloud-platform'])
+    creds.refresh(google.auth.transport.requests.Request())
+    return creds.token
+
+
+def _set_vm_status(uid: str, status: str) -> None:
+    firestore_db.collection('users').document(uid).update({"agentVm.status": status})
+
+
+@router.post("/v1/agent/vm-stop", tags=['agent'])
+async def stop_agent_vm(uid: str = Depends(get_current_user_uid)):
+    """Stop the caller's own agent VM to end GCE compute billing.
+
+    Self-scoped: reads only users/{uid}.agentVm, so a user can stop only their own VM.
+    Idempotent: an already-stopped (or absent) VM returns without calling GCE again.
+    """
+    vm = await run_blocking(db_executor, get_agent_vm, uid)
+    if not vm:
+        return {"ok": False, "reason": "no_vm"}
+
+    vm_name = vm.get("vmName")
+    zone = vm.get("zone", "us-central1-a")
+    if not vm_name:
+        return {"ok": False, "reason": "missing_vm_info"}
+
+    if vm.get("status") == "stopped":
+        return {"ok": True, "status": "stopped"}
+
+    token = await run_blocking(db_executor, _get_gce_access_token)
+    url = f"https://compute.googleapis.com/compute/v1/projects/{GCE_PROJECT}/zones/{zone}/instances/{vm_name}/stop"
+    try:
+        async with httpx.AsyncClient(timeout=30) as client:
+            resp = await client.post(url, headers={"Authorization": f"Bearer {token}"}, content=b"")
+    except httpx.HTTPError as e:
+        logger.error(f"[vm-stop] GCE stop request failed uid={uid}: {sanitize(str(e))}")
+        return {"ok": False, "reason": "unreachable"}
+
+    if resp.status_code not in (200, 204):
+        logger.error(f"[vm-stop] GCE stop failed uid={uid}: {resp.status_code} {sanitize(resp.text)}")
+        return {"ok": False, "reason": "stop_failed"}
+
+    await run_blocking(db_executor, _set_vm_status, uid, "stopped")
+    return {"ok": True, "status": "stopped"}

--- a/backend/tests/unit/test_agent_vm_stop.py
+++ b/backend/tests/unit/test_agent_vm_stop.py
@@ -1,0 +1,93 @@
+"""Unit tests for POST /v1/agent/vm-stop.
+
+routers.agent_vm imports cleanly, so the async handler is driven via asyncio.run with the
+GCE token, Firestore, and httpx calls mocked (no network). run_blocking is replaced with a
+passthrough so the offloaded sync helpers run inline. Uses monkeypatch (no sys.modules mutation).
+"""
+
+import os
+
+os.environ.setdefault(
+    "ENCRYPTION_SECRET",
+    "omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv",
+)
+os.environ.setdefault("OPENAI_API_KEY", "test-openai-key-not-real")
+
+import asyncio
+
+import httpx
+import pytest
+
+from routers import agent_vm
+
+
+async def _fake_run_blocking(executor, fn, *args):
+    return fn(*args)
+
+
+class _FakeResp:
+    def __init__(self, status_code, text=""):
+        self.status_code = status_code
+        self.text = text
+
+
+class _FakeAsyncClient:
+    def __init__(self, resp=None, exc=None):
+        self._resp = resp
+        self._exc = exc
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def post(self, *args, **kwargs):
+        if self._exc is not None:
+            raise self._exc
+        return self._resp
+
+
+def _wire(monkeypatch, vm, resp=None, exc=None):
+    """Wire the module seams; return the list of (uid, status) status writes."""
+    monkeypatch.setattr(agent_vm, "run_blocking", _fake_run_blocking)
+    monkeypatch.setattr(agent_vm, "get_agent_vm", lambda uid: vm)
+    monkeypatch.setattr(agent_vm, "_get_gce_access_token", lambda: "fake-token")
+    status_writes = []
+    monkeypatch.setattr(agent_vm, "_set_vm_status", lambda uid, status: status_writes.append((uid, status)))
+    if resp is not None or exc is not None:
+        monkeypatch.setattr(agent_vm.httpx, "AsyncClient", lambda *a, **k: _FakeAsyncClient(resp=resp, exc=exc))
+    return status_writes
+
+
+def test_no_vm(monkeypatch):
+    _wire(monkeypatch, vm=None)
+    assert asyncio.run(agent_vm.stop_agent_vm(uid="u1")) == {"ok": False, "reason": "no_vm"}
+
+
+def test_missing_vm_name(monkeypatch):
+    _wire(monkeypatch, vm={"zone": "us-central1-a", "status": "ready"})
+    assert asyncio.run(agent_vm.stop_agent_vm(uid="u1")) == {"ok": False, "reason": "missing_vm_info"}
+
+
+def test_already_stopped_is_idempotent(monkeypatch):
+    writes = _wire(monkeypatch, vm={"vmName": "vm1", "status": "stopped"})
+    assert asyncio.run(agent_vm.stop_agent_vm(uid="u1")) == {"ok": True, "status": "stopped"}
+    assert writes == []  # no GCE call, no extra status write
+
+
+def test_success_stops_and_records_status(monkeypatch):
+    writes = _wire(monkeypatch, vm={"vmName": "vm1", "zone": "z", "status": "ready"}, resp=_FakeResp(200))
+    assert asyncio.run(agent_vm.stop_agent_vm(uid="u1")) == {"ok": True, "status": "stopped"}
+    assert writes == [("u1", "stopped")]
+
+
+def test_gce_non_2xx_is_stop_failed_without_status_write(monkeypatch):
+    writes = _wire(monkeypatch, vm={"vmName": "vm1", "zone": "z", "status": "ready"}, resp=_FakeResp(500, "boom"))
+    assert asyncio.run(agent_vm.stop_agent_vm(uid="u1")) == {"ok": False, "reason": "stop_failed"}
+    assert writes == []
+
+
+def test_httpx_error_is_unreachable(monkeypatch):
+    _wire(monkeypatch, vm={"vmName": "vm1", "zone": "z", "status": "ready"}, exc=httpx.ConnectError("down"))
+    assert asyncio.run(agent_vm.stop_agent_vm(uid="u1")) == {"ok": False, "reason": "unreachable"}


### PR DESCRIPTION
## What
Adds `POST /v1/agent/vm-stop`, letting a user stop their own agent sandbox VM to end GCE compute billing.

## Why
The desktop can start the per-user agent VM (`POST /v1/agent/vm-ensure`) and keep it alive (`POST /v1/agent/keepalive`), but there was no way to stop it on demand; a user had to wait for the idle auto-stop timer. This adds a stop-now path so a user can end their GCE compute (for example a "Close agent" action) instead of paying for idle time.

## Details
- Self-scoped: reads only `users/{uid}.agentVm`, so a user can stop only their own VM.
- Idempotent: an absent VM returns `{ok: false, reason: no_vm}`, a VM missing its name returns `{ok: false, reason: missing_vm_info}`, and an already-stopped VM returns `{ok: true, status: stopped}` without calling GCE again.
- On success it calls the GCE instances stop API and records `agentVm.status=stopped` (a status already recognized by the existing state machine). Upstream failures map to `stop_failed` / `unreachable` rather than a 500.
- Async handler: the sync Firestore reads/writes and the credential refresh are offloaded via `run_blocking(db_executor, ...)`; the GCE call uses `httpx.AsyncClient`, matching the sibling agent-VM code.
- Hosted in a small new router rather than `routers/agent_tools.py`, which builds an OpenAI client at import (not import-clean). The short GCE token helper and status writer are re-inlined to keep this module import-pure.

## Test
`backend/tests/unit/test_agent_vm_stop.py`: no-VM, missing-name, already-stopped idempotency, successful stop with the status write, a non-2xx GCE response mapping to `stop_failed` without a status write, and an httpx error mapping to `unreachable`. 6 passed locally.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9060?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

