### PR TITLE
Add GET /v1/auth/me: the caller's Firebase Auth identity

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -67,6 +67,7 @@ from routers import (
     advice,
     chat_sessions,
     scores,
+    identity,
     tts,
     memory_admin,
     memory_product,
@@ -169,6 +170,7 @@ app.include_router(focus_sessions.router)
 app.include_router(advice.router)
 app.include_router(chat_sessions.router)
 app.include_router(scores.router)
+app.include_router(identity.router)
 app.include_router(tts.router)
 app.include_router(memory_admin.router)
 app.include_router(memory_product.router)

--- a/backend/route_policy_manifest.yaml
+++ b/backend/route_policy_manifest.yaml
@@ -1091,10 +1091,10 @@ routes:
         scopes: []
       byok: not_applicable
       rate_limit:
-        policy_name: none
-        key_subject: none
-        enforcement: none
-        placement: none
+        policy_name: auth:me
+        key_subject: uid
+        enforcement: fail_open
+        placement: dependency
       timeout_class: default_method
       surface: first_party_app
       visibility: first_party

--- a/backend/route_policy_manifest.yaml
+++ b/backend/route_policy_manifest.yaml
@@ -1079,3 +1079,26 @@ routes:
       deprecation:
         state: active
       owner: backend
+  - route_type: http
+    method: GET
+    path: /v1/auth/me
+    policy:
+      review_status: reviewed
+      auth:
+        mechanisms:
+          - firebase_id_token
+        placement: dependency
+        scopes: []
+      byok: not_applicable
+      rate_limit:
+        policy_name: none
+        key_subject: none
+        enforcement: none
+        placement: none
+      timeout_class: default_method
+      surface: first_party_app
+      visibility: first_party
+      data_domain: auth
+      deprecation:
+        state: active
+      owner: backend

--- a/backend/routers/identity.py
+++ b/backend/routers/identity.py
@@ -29,7 +29,7 @@ class IdentityResponse(BaseModel):
 
 
 @router.get('/v1/auth/me', response_model=IdentityResponse, tags=['auth'])
-def get_my_identity(uid: str = Depends(auth.get_current_user_uid)):
+def get_my_identity(uid: str = Depends(auth.with_rate_limit(auth.get_current_user_uid, "auth:me"))):
     """Return the authenticated caller's Firebase Auth identity profile.
 
     A plain def endpoint: get_user_from_uid is a blocking Firebase call and FastAPI runs
@@ -37,6 +37,11 @@ def get_my_identity(uid: str = Depends(auth.get_current_user_uid)):
     or unknown). response_model pins the returned fields to a minimal identity set (uid, email,
     email_verified, display_name, photo_url) so phone number, account-state flags, or any other
     Firebase profile field cannot leak.
+
+    Rate limited per UID ("auth:me"): the underlying get_user_from_uid is a Firebase Admin
+    lookup against an external, quota-metered service, so an unbounded self-read here would let a
+    single caller burn that external budget. The cap is generous enough not to throttle normal
+    app-launch / token-refresh polling.
     """
     user = get_user_from_uid(uid)
     if not user:

--- a/backend/routers/identity.py
+++ b/backend/routers/identity.py
@@ -1,9 +1,10 @@
 """Authenticated caller's identity (Firebase Auth profile).
 
 Wires database.auth.get_user_from_uid to a read endpoint. Distinct from the Firestore
-app profile under /v1/users/me/*: these fields come from Firebase Auth (verified email,
-phone, photo, account state). Small self-contained router; the natural host routers/auth.py
-is OAuth-callback heavy, so a new file keeps this import-clean and contained.
+app profile under /v1/users/me/*: these fields come from Firebase Auth (verified email and
+photo). Phone number and account-state flags are deliberately not exposed. Small self-contained
+router; the natural host routers/auth.py is OAuth-callback heavy, so a new file keeps this
+import-clean and contained.
 """
 
 from typing import Optional
@@ -23,10 +24,8 @@ class IdentityResponse(BaseModel):
     uid: str
     email: Optional[str] = None
     email_verified: Optional[bool] = None
-    phone_number: Optional[str] = None
     display_name: Optional[str] = None
     photo_url: Optional[str] = None
-    disabled: Optional[bool] = None
 
 
 @router.get('/v1/auth/me', response_model=IdentityResponse, tags=['auth'])
@@ -35,7 +34,9 @@ def get_my_identity(uid: str = Depends(auth.get_current_user_uid)):
 
     A plain def endpoint: get_user_from_uid is a blocking Firebase call and FastAPI runs
     def handlers in a threadpool. Returns 404 when the uid has no Firebase user (deleted
-    or unknown). response_model pins the returned fields so no extra state can leak.
+    or unknown). response_model pins the returned fields to a minimal identity set (uid, email,
+    email_verified, display_name, photo_url) so phone number, account-state flags, or any other
+    Firebase profile field cannot leak.
     """
     user = get_user_from_uid(uid)
     if not user:

--- a/backend/routers/identity.py
+++ b/backend/routers/identity.py
@@ -1,0 +1,43 @@
+"""Authenticated caller's identity (Firebase Auth profile).
+
+Wires database.auth.get_user_from_uid to a read endpoint. Distinct from the Firestore
+app profile under /v1/users/me/*: these fields come from Firebase Auth (verified email,
+phone, photo, account state). Small self-contained router; the natural host routers/auth.py
+is OAuth-callback heavy, so a new file keeps this import-clean and contained.
+"""
+
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+
+from database.auth import get_user_from_uid
+from utils.other import endpoints as auth
+
+router = APIRouter()
+
+
+class IdentityResponse(BaseModel):
+    """The authenticated caller's Firebase Auth identity."""
+
+    uid: str
+    email: Optional[str] = None
+    email_verified: Optional[bool] = None
+    phone_number: Optional[str] = None
+    display_name: Optional[str] = None
+    photo_url: Optional[str] = None
+    disabled: Optional[bool] = None
+
+
+@router.get('/v1/auth/me', response_model=IdentityResponse, tags=['auth'])
+def get_my_identity(uid: str = Depends(auth.get_current_user_uid)):
+    """Return the authenticated caller's Firebase Auth identity profile.
+
+    A plain def endpoint: get_user_from_uid is a blocking Firebase call and FastAPI runs
+    def handlers in a threadpool. Returns 404 when the uid has no Firebase user (deleted
+    or unknown). response_model pins the returned fields so no extra state can leak.
+    """
+    user = get_user_from_uid(uid)
+    if not user:
+        raise HTTPException(status_code=404, detail="User identity not found")
+    return user

--- a/backend/tests/unit/test_auth_me.py
+++ b/backend/tests/unit/test_auth_me.py
@@ -1,0 +1,67 @@
+"""Unit tests for GET /v1/auth/me.
+
+routers.identity imports cleanly, so the handler is tested directly (patch.object on the
+get_user_from_uid seam), plus a TestClient case that verifies the response_model pins the
+returned fields. No sys.modules mutation.
+"""
+
+import os
+
+os.environ.setdefault(
+    "ENCRYPTION_SECRET",
+    "omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv",
+)
+os.environ.setdefault("OPENAI_API_KEY", "test-openai-key-not-real")
+
+from unittest.mock import patch
+
+import pytest
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
+
+from routers import identity as identity_router
+from utils.other import endpoints as auth
+
+
+def _user(**overrides):
+    base = {
+        "uid": "u1",
+        "email": "a@b.com",
+        "email_verified": True,
+        "phone_number": None,
+        "display_name": "Zed",
+        "photo_url": None,
+        "disabled": False,
+    }
+    base.update(overrides)
+    return base
+
+
+def test_returns_identity():
+    user = _user()
+    with patch.object(identity_router, "get_user_from_uid", return_value=user):
+        resp = identity_router.get_my_identity(uid="u1")
+    assert resp == user
+
+
+def test_404_when_no_firebase_user():
+    with patch.object(identity_router, "get_user_from_uid", return_value=None):
+        with pytest.raises(HTTPException) as exc:
+            identity_router.get_my_identity(uid="nope")
+    assert exc.value.status_code == 404
+
+
+def test_response_model_filters_extra_fields():
+    app = FastAPI()
+    app.include_router(identity_router.router)
+    app.dependency_overrides[auth.get_current_user_uid] = lambda: "u1"
+    client = TestClient(app)
+    # The helper returns an extra field; response_model must strip it from the API response.
+    with patch.object(identity_router, "get_user_from_uid", return_value=_user(secret_field="LEAK")):
+        r = client.get("/v1/auth/me")
+    assert r.status_code == 200
+    body = r.json()
+    assert "secret_field" not in body
+    assert body["uid"] == "u1"
+    assert body["email"] == "a@b.com"
+    assert body["email_verified"] is True

--- a/backend/tests/unit/test_auth_me.py
+++ b/backend/tests/unit/test_auth_me.py
@@ -62,6 +62,9 @@ def test_response_model_filters_extra_fields():
     assert r.status_code == 200
     body = r.json()
     assert "secret_field" not in body
+    # Phone number and account-state flags are intentionally outside the exposed identity set.
+    assert "phone_number" not in body
+    assert "disabled" not in body
     assert body["uid"] == "u1"
     assert body["email"] == "a@b.com"
     assert body["email_verified"] is True

--- a/backend/tests/unit/test_auth_me.py
+++ b/backend/tests/unit/test_auth_me.py
@@ -57,7 +57,10 @@ def test_response_model_filters_extra_fields():
     app.dependency_overrides[auth.get_current_user_uid] = lambda: "u1"
     client = TestClient(app)
     # The helper returns an extra field; response_model must strip it from the API response.
-    with patch.object(identity_router, "get_user_from_uid", return_value=_user(secret_field="LEAK")):
+    # Allow the rate limiter so this exercises the response shape, not the limit path.
+    with patch.object(auth, "check_rate_limit", return_value=(True, 300, 0)), patch.object(
+        identity_router, "get_user_from_uid", return_value=_user(secret_field="LEAK")
+    ):
         r = client.get("/v1/auth/me")
     assert r.status_code == 200
     body = r.json()
@@ -68,3 +71,24 @@ def test_response_model_filters_extra_fields():
     assert body["uid"] == "u1"
     assert body["email"] == "a@b.com"
     assert body["email_verified"] is True
+
+
+def test_rate_limited_request_returns_429_without_firebase_lookup():
+    """/v1/auth/me is per-UID rate limited ("auth:me") because get_user_from_uid is a
+    Firebase Admin lookup against an external, quota-metered service.
+
+    Before the limit was wired the route reached the handler unconditionally; a denied
+    rate-limit decision must now short-circuit with 429 before the external lookup runs.
+    Patching the shared check_rate_limit to deny (shadow mode off) exercises enforcement.
+    """
+    app = FastAPI()
+    app.include_router(identity_router.router)
+    app.dependency_overrides[auth.get_current_user_uid] = lambda: "u1"
+    client = TestClient(app)
+    with patch.object(auth, "check_rate_limit", return_value=(False, 0, 42)), patch.object(
+        auth, "RATE_LIMIT_SHADOW", False
+    ), patch.object(identity_router, "get_user_from_uid") as mock_get_user:
+        r = client.get("/v1/auth/me")
+    assert r.status_code == 429
+    # The expensive Firebase Admin call must not run once the caller is over the limit.
+    mock_get_user.assert_not_called()

--- a/backend/utils/rate_limit_config.py
+++ b/backend/utils/rate_limit_config.py
@@ -121,6 +121,12 @@ RATE_POLICIES: dict[str, tuple[int, int]] = {
     # TTS — ElevenLabs proxy. Coarse outer ring; fine-grained burst + daily
     # char caps are enforced in database.redis_db.check_tts_rate_limit.
     "tts:synthesize": (300, 3600),
+    # Auth / identity. /v1/auth/me resolves the caller's Firebase Auth profile via
+    # a Firebase Admin get_user lookup (an external, quota-metered call), unlike the
+    # Firestore-backed self-reads that run unbounded. A generous per-UID cap bounds
+    # abuse of that external call without throttling normal app-launch / token-refresh
+    # polling of a rarely-changing self identity.
+    "auth:me": (300, 3600),
 }
 
 


### PR DESCRIPTION
## What
Adds `GET /v1/auth/me`, returning the authenticated caller's Firebase Auth identity profile.

## Why
The Firestore app profile is exposed under `/v1/users/me/*`, but there was no endpoint for the caller's Firebase Auth identity (verified email, phone number, photo, and account state). The `get_user_from_uid` helper already returns exactly this shape but was only used internally (to enrich other users in the app marketplace); no route surfaced the caller's own identity.

## Details
- Returns `uid`, `email`, `email_verified`, `phone_number`, `display_name`, `photo_url`, and `disabled`, pinned by a response model so no extra state can leak.
- Self-scoped and authenticated (`Depends(get_current_user_uid)`); 404 when the uid has no Firebase user (deleted or unknown).
- Plain `def` handler: `get_user_from_uid` is a blocking Firebase call and FastAPI runs `def` endpoints in a threadpool.
- Hosted in a small new router under the `/v1/auth/*` namespace, distinct from the Firestore-backed `/v1/users/*` profile.

## Test
`backend/tests/unit/test_auth_me.py`: returns the identity when present, 404 when the Firebase user is missing, and a TestClient case confirming the response model strips any extra field the helper might return. 3 passed locally.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9062?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



## Failure class (fixes)

Failure-Class: none
