### PR TITLE
feat(desktop): add obvious Back button to onboarding (#8999)

### DIFF
--- a/desktop/macos/Desktop/Sources/AppState.swift
+++ b/desktop/macos/Desktop/Sources/AppState.swift
@@ -652,6 +652,8 @@ class AppState: ObservableObject {
 
 extension Notification.Name {
   static let resetOnboardingRequested = Notification.Name("resetOnboardingRequested")
+  /// Posted when the user taps the onboarding Back control to return to the previous step
+  static let onboardingBackRequested = Notification.Name("onboardingBackRequested")
   /// Posted when the system wakes from sleep
   static let systemDidWake = Notification.Name("systemDidWake")
   /// Posted when the screen is locked

--- a/desktop/macos/Desktop/Sources/OnboardingStepScaffold.swift
+++ b/desktop/macos/Desktop/Sources/OnboardingStepScaffold.swift
@@ -188,7 +188,36 @@ struct OnboardingStepScaffold<Content: View>: View {
 struct OnboardingLogoMark: View {
   let onForceComplete: (() -> Void)?
 
+  // Mirrors OnboardingView's step index so the Back control appears consistently in
+  // every step header without threading a closure through each step view.
+  @AppStorage("onboardingStep") private var currentStep = 0
+
   var body: some View {
+    HStack(spacing: 12) {
+      if currentStep > 0 {
+        Button {
+          NotificationCenter.default.post(name: .onboardingBackRequested, object: nil)
+        } label: {
+          Image(systemName: "chevron.left")
+            .font(.system(size: 14, weight: .semibold))
+            .foregroundColor(OmiColors.textSecondary)
+            .frame(width: 28, height: 28)
+            .background(
+              Circle().fill(OmiColors.backgroundTertiary)
+            )
+            .contentShape(Circle())
+        }
+        .buttonStyle(.plain)
+        .keyboardShortcut("[", modifiers: .command)
+        .help("Go back to the previous step")
+        .accessibilityLabel("Back")
+      }
+
+      logo
+    }
+  }
+
+  private var logo: some View {
     Group {
       if let logoImage = onboardingTextLogoImage() {
         Image(nsImage: logoImage)

--- a/desktop/macos/Desktop/Sources/OnboardingView.swift
+++ b/desktop/macos/Desktop/Sources/OnboardingView.swift
@@ -114,6 +114,11 @@ struct OnboardingView: View {
       log("OnboardingView: resetOnboardingRequested — returning to the first onboarding step")
       currentStep = 0
     }
+    .onReceive(NotificationCenter.default.publisher(for: .onboardingBackRequested)) { _ in
+      guard !isExportPreview, currentStep > 0 else { return }
+      log("OnboardingView: onboardingBackRequested — returning to the previous step")
+      currentStep -= 1
+    }
   }
 
   private var onboardingContent: some View {

--- a/desktop/macos/changelog/unreleased/20260705-onboarding-back-button.json
+++ b/desktop/macos/changelog/unreleased/20260705-onboarding-back-button.json
@@ -1,0 +1,3 @@
+{
+  "change": "Added an obvious Back button to onboarding so you can return to a previous step and revise earlier choices (also via Cmd+[)"
+}


### PR DESCRIPTION
## What

Adds an obvious, visible **Back** control (a chevron button) to the desktop onboarding header, shown on every step except the first. Clicking it returns to the previous step so users can revise an earlier choice without restarting onboarding. Also bound to the standard macOS **Cmd+[** shortcut as a secondary affordance.

## Why

From issue #8999 (reported by David via Telegram):

> The desktop app onboarding flow needs an obvious way to go back to the previous step. Right now users can get stuck or have to continue forward/restart if they want to revise an earlier onboarding choice.
> Clarification: this should not be just a keyboard shortcut — the UI needs an obvious button/control as well.

## How

- The control lives in `OnboardingLogoMark`, which every onboarding step (both scaffold-based and the interactive demo steps) already renders at the top-left of its header. Putting it there gives **consistent placement across all steps** with no per-step plumbing.
- It reads the same `@AppStorage("onboardingStep")` key that `OnboardingView` writes, so it is hidden on step 0 (`currentStep > 0`) — satisfying "disable/hide Back only on the first step".
- Tapping posts a new `.onboardingBackRequested` notification; `OnboardingView` observes it and does `currentStep -= 1`, mirroring the existing, production-proven `.resetOnboardingRequested` pattern in the same file.
- Every forward transition in the flow is `currentStep + 1`, so `- 1` is the exact inverse. Entered onboarding state (languages, goals, etc.) persists in `OnboardingPagedIntroCoordinator`/`AppStorage`, so going back preserves it.
- Uses white/neutral styling (no purple, per repo UI rules) and an accessible "Back" label.

## Acceptance criteria mapping
- ✅ Obvious on-screen control (not keyboard-only) — visible chevron button in every step header
- ✅ Consistently placed across all applicable steps (shared header component)
- ✅ Keyboard back works but isn't the only way (Cmd+[)
- ✅ Going back preserves previously-entered state
- ✅ Hidden on the first step

## Verified
- `xcrun swift build -c debug` — **clean build** (exit 0, "Build complete"), so the change compiles/links into the real app target.
- Logic reviewed against the full flow; reuses an existing production NotificationCenter pattern.

## Not verified (environment limitation)
- **Live GUI screenshot is UNVERIFIED.** This PR was prepared in a headless CI/cron context where the macOS console is locked (screen capture returns "could not create image from display") and Accessibility automation is unavailable over SSH, so the running onboarding UI could not be captured here. Please eyeball the Back button in a local `./run.sh` before merge.

Auto-generated from issue feedback by the mini issues-improver. Review before merge.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9064?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

