### PR TITLE
fix(desktop): report invalid realtime websocket ports

### DIFF
--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RawWebSocket.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RawWebSocket.swift
@@ -41,12 +41,23 @@ final class RawWebSocket {
   }
 
   func connect() {
-    let host = url.host ?? ""
-    let port = UInt16(url.port ?? 443)
+    guard let host = url.host, !host.isEmpty else {
+      fail("invalid WebSocket host")
+      return
+    }
+
+    let rawPort = url.port ?? 443
+    guard (1...65535).contains(rawPort),
+      let port = NWEndpoint.Port(rawValue: UInt16(rawPort))
+    else {
+      fail("invalid WebSocket port \(rawPort)")
+      return
+    }
+
     let tls = NWProtocolTLS.Options()
     sec_protocol_options_add_tls_application_protocol(tls.securityProtocolOptions, "http/1.1")
     let params = NWParameters(tls: tls)
-    let c = NWConnection(host: NWEndpoint.Host(host), port: NWEndpoint.Port(rawValue: port)!, using: params)
+    let c = NWConnection(host: NWEndpoint.Host(host), port: port, using: params)
     conn = c
     c.stateUpdateHandler = { [weak self] state in
       guard let self else { return }

--- a/desktop/macos/Desktop/Tests/RawWebSocketValidationTests.swift
+++ b/desktop/macos/Desktop/Tests/RawWebSocketValidationTests.swift
@@ -1,0 +1,26 @@
+import Foundation
+import XCTest
+
+@testable import Omi_Computer
+
+final class RawWebSocketValidationTests: XCTestCase {
+  func testInvalidPortReportsErrorInsteadOfCrashing() {
+    let errorExpectation = expectation(description: "invalid port error")
+    let webSocket = RawWebSocket(
+      url: URL(string: "wss://example.com:0/ws")!,
+      queue: DispatchQueue(label: "raw-websocket-validation-test")
+    )
+
+    webSocket.onError = { message in
+      XCTAssertTrue(
+        message.contains("invalid WebSocket port"),
+        "Unexpected error message: \(message)"
+      )
+      errorExpectation.fulfill()
+    }
+
+    webSocket.connect()
+
+    wait(for: [errorExpectation], timeout: 1.0)
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260705-realtime-websocket-invalid-port.json
+++ b/desktop/macos/changelog/unreleased/20260705-realtime-websocket-invalid-port.json
@@ -1,0 +1,3 @@
+{
+  "change": "Reported invalid realtime WebSocket URLs instead of leaving the connection stuck"
+}


### PR DESCRIPTION
## Summary
- Validate the realtime raw WebSocket host and port before creating the `NWConnection`.
- Report invalid URL input through the existing `onError` callback instead of leaving the socket stuck in Network.framework waiting state.
- Add a focused regression test and desktop changelog fragment.

## Bug
`RawWebSocket.connect()` accepted an invalid realtime WebSocket URL with port `0`, then created an `NWConnection` that entered `waiting POSIXErrorCode(rawValue: 22): Invalid argument`. The caller never received `onError`, so the realtime connection could remain stuck without a surfaced failure.

This is on the Gemini realtime hub path, where `RealtimeHubSession` wires `RawWebSocket.onError` to `hubDidError`.

## Root cause
`connect()` trusted `url.host`/`url.port` directly and force-built the Network.framework port. Port `0` is not useful for an outbound WebSocket, but it was allowed through to `NWConnection`, which only logged `.waiting` and did not trigger the app's error callback.

## Fix
- Guard missing/empty hosts.
- Guard ports outside `1...65535`.
- Reuse the existing `fail(...)` path so invalid URL input reaches `onError` and tears down cleanly.
- Replace the force unwrap with a validated `NWEndpoint.Port`.

## Reproduction before fix
Added the focused test first and ran it against unmodified product code:

```bash
xcrun swift test --filter RawWebSocketValidationTests --package-path Desktop
```

Before-fix output showed the connection stuck in Network.framework waiting and the test timed out waiting for `onError`:

```text
RawWebSocket: waiting POSIXErrorCode(rawValue: 22): Invalid argument
Asynchronous wait failed: Exceeded timeout of 1 seconds, with unfulfilled expectations: "invalid port error".
```

## Verification after fix
```bash
python3 .github/scripts/desktop-changelog.py validate
git diff --check
xcrun swift test --filter RawWebSocketValidationTests --package-path Desktop
xcrun swift build -c debug --package-path Desktop
./scripts/agent-logic-harness.sh
```

All passed on the rebased final SHA (`243bab529`). Push pre-checks also passed, including desktop changelog validation and the desktop Swift build.

## Evidence notes
No visual screenshot is applicable: this is a transport validation failure before UI rendering. The before/after evidence is the focused regression test output plus the realtime/agent harness.

## Risk
Low. Valid realtime URLs keep the same default port behavior and connection setup. Invalid host/port inputs now fail early through the existing error path.

## Rollback
Revert this commit to restore the prior raw WebSocket connection setup.

Generated with Codex.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9068?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

