### PR TITLE
Add CI for the Windows desktop app and fix failing tests

### DIFF
--- a/.github/workflows/desktop-windows-ci.yml
+++ b/.github/workflows/desktop-windows-ci.yml
@@ -1,0 +1,88 @@
+name: Desktop Windows CI
+
+# The Windows desktop app had no CI: its typecheck and ~550-test suite never ran
+# on a PR. This workflow gates every change under desktop/windows/.
+#
+# - `checks` runs on ubuntu (fast; the vitest electron stub lets the suite run
+#   without the electron binary) and BLOCKS merge on typecheck/test failures.
+# - `build-windows` proves the app still packages on a real Windows runner,
+#   exercising the native paths (better-sqlite3 rebuild, OCR/automation helpers)
+#   that ubuntu cannot.
+#
+# Lint is intentionally not wired here yet — the existing lint errors are cleared
+# in a follow-up, which then adds the lint step as a blocking check.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'desktop/windows/**'
+      - '.github/workflows/desktop-windows-ci.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'desktop/windows/**'
+      - '.github/workflows/desktop-windows-ci.yml'
+
+defaults:
+  run:
+    working-directory: desktop/windows
+
+jobs:
+  checks:
+    name: Typecheck · Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      # The app is pnpm-managed (pnpm-lock.yaml, lockfileVersion 9).
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: desktop/windows/pnpm-lock.yaml
+      # Checks need no native modules; --ignore-scripts skips the electron-rebuild
+      # / OCR-helper postinstall. The vitest electron stub (test/electronStub.ts)
+      # lets the suite run without the electron binary.
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --ignore-scripts
+      - name: Typecheck
+        run: pnpm run typecheck
+      - name: Test
+        run: pnpm test
+
+  build-windows:
+    name: Windows build smoke
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: desktop/windows/pnpm-lock.yaml
+      # OCR + UI-automation helpers are .NET projects built during install/build.
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+      - name: Provision .env (ships public Firebase/PostHog config)
+        shell: pwsh
+        run: Copy-Item .env.example .env
+      # Full install: runs postinstall (electron-builder install-app-deps,
+      # electron-rebuild better-sqlite3, ensure-ocr-helper).
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Build unpacked app
+        run: pnpm run build:unpack
+      - name: Upload unpacked build
+        uses: actions/upload-artifact@v4
+        with:
+          name: omi-windows-unpacked
+          path: desktop/windows/dist/win-unpacked
+          if-no-files-found: warn
+          retention-days: 7

--- a/desktop/windows/src/main/automation/foregroundTargetLogic.ts
+++ b/desktop/windows/src/main/automation/foregroundTargetLogic.ts
@@ -1,4 +1,11 @@
-import { basename } from 'path'
+import { win32 } from 'path'
+
+// Always parse Windows exe paths with the win32 semantics, regardless of the
+// host OS this runs under. Node's default `basename` is POSIX on Linux/macOS
+// and does not split on '\', so `D:\a\OMI.EXE` would not reduce to `OMI.EXE`
+// there — breaking self-detection and making this module's unit tests
+// host-dependent (green on Windows, red in Linux CI).
+const basename = win32.basename
 
 // Pure target-selection logic, split out from foregroundTarget.ts (which pulls
 // in electron + native koffi) so it can be unit-tested under node Vitest.

--- a/desktop/windows/test/electronStub.ts
+++ b/desktop/windows/test/electronStub.ts
@@ -1,0 +1,112 @@
+// Test-only stub for the `electron` module.
+//
+// Node-side Vitest suites import main-process modules (e.g. overlay/shortcut,
+// automation/bridge) whose module graph pulls in `electron`. The real package's
+// entry resolves a native binary path and throws under a headless
+// `npm install --ignore-scripts`. This stub is aliased in for `electron` in
+// vitest.config.ts so those suites can exercise pure logic without the binary.
+//
+// It is intentionally minimal and inert: methods are no-ops with sensible
+// return shapes. If a test needs specific Electron behaviour, mock it locally
+// with `vi.mock('electron', ...)` in that suite instead of expanding this stub.
+
+const noop = (): void => {}
+
+export const app = {
+  getPath: (): string => '/tmp',
+  getAppPath: (): string => '/tmp/app',
+  getName: (): string => 'omi-windows',
+  getVersion: (): string => '0.0.0-test',
+  isPackaged: false,
+  on: noop,
+  once: noop,
+  whenReady: (): Promise<void> => Promise.resolve(),
+  quit: noop,
+  setLoginItemSettings: noop,
+  requestSingleInstanceLock: (): boolean => true
+}
+
+export const globalShortcut = {
+  register: (): boolean => true,
+  unregister: noop,
+  unregisterAll: noop,
+  isRegistered: (): boolean => false
+}
+
+export const ipcMain = { on: noop, once: noop, handle: noop, removeHandler: noop, removeAllListeners: noop }
+export const ipcRenderer = { on: noop, once: noop, invoke: (): Promise<undefined> => Promise.resolve(undefined), send: noop }
+export const contextBridge = { exposeInMainWorld: noop }
+export const shell = { openExternal: (): Promise<void> => Promise.resolve(), openPath: (): Promise<string> => Promise.resolve('') }
+export const dialog = {
+  showMessageBox: (): Promise<{ response: number }> => Promise.resolve({ response: 0 }),
+  showOpenDialog: (): Promise<{ canceled: boolean; filePaths: string[] }> =>
+    Promise.resolve({ canceled: true, filePaths: [] })
+}
+export const screen = {
+  getPrimaryDisplay: (): { bounds: { x: number; y: number; width: number; height: number }; workAreaSize: { width: number; height: number }; scaleFactor: number } => ({
+    bounds: { x: 0, y: 0, width: 1920, height: 1080 },
+    workAreaSize: { width: 1920, height: 1040 },
+    scaleFactor: 1
+  }),
+  getAllDisplays: (): unknown[] => [],
+  on: noop
+}
+export const powerMonitor = { on: noop, getSystemIdleTime: (): number => 0 }
+export const safeStorage = {
+  isEncryptionAvailable: (): boolean => false,
+  encryptString: (s: string): Buffer => Buffer.from(s),
+  decryptString: (b: Buffer): string => b.toString()
+}
+export const session = { defaultSession: { webRequest: { onBeforeSendHeaders: noop } } }
+export const net = { request: noop, isOnline: (): boolean => true }
+export const desktopCapturer = { getSources: (): Promise<unknown[]> => Promise.resolve([]) }
+export const nativeImage = { createEmpty: (): Record<string, never> => ({}), createFromPath: (): Record<string, never> => ({}) }
+
+export class BrowserWindow {
+  static getAllWindows(): BrowserWindow[] {
+    return []
+  }
+  webContents = { send: noop, on: noop, executeJavaScript: (): Promise<undefined> => Promise.resolve(undefined) }
+  on = noop
+  loadURL = (): Promise<void> => Promise.resolve()
+  show = noop
+  hide = noop
+  close = noop
+  destroy = noop
+  isDestroyed = (): boolean => false
+  setBounds = noop
+  getBounds = (): { x: number; y: number; width: number; height: number } => ({ x: 0, y: 0, width: 0, height: 0 })
+}
+
+export class Notification {
+  static isSupported(): boolean {
+    return false
+  }
+  on = noop
+  show = noop
+}
+
+// Type-only exports referenced by main code; runtime values are never used.
+export type WebContents = unknown
+export type IpcMainInvokeEvent = unknown
+export const webContents = { getAllWebContents: (): unknown[] => [] }
+
+export default {
+  app,
+  globalShortcut,
+  ipcMain,
+  ipcRenderer,
+  contextBridge,
+  shell,
+  dialog,
+  screen,
+  powerMonitor,
+  safeStorage,
+  session,
+  net,
+  desktopCapturer,
+  nativeImage,
+  BrowserWindow,
+  Notification,
+  webContents
+}

--- a/desktop/windows/vitest.config.ts
+++ b/desktop/windows/vitest.config.ts
@@ -1,6 +1,14 @@
 import { defineConfig } from 'vitest/config'
+import { resolve } from 'path'
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      // Node-side suites import main-process modules whose graph pulls in
+      // `electron`, whose real entry needs the native binary. Alias to a stub.
+      electron: resolve(__dirname, 'test/electronStub.ts')
+    }
+  },
   test: {
     environment: 'node',
     include: ['src/**/*.test.ts', 'scripts/**/*.test.mjs']


### PR DESCRIPTION
## What

The Windows desktop app (`desktop/windows/`) had no CI — its typecheck and ~550-test suite ran on no PR. This adds a CI workflow and fixes the test suite so it can be a required check.

- **CI** (`.github/workflows/desktop-windows-ci.yml`), gated on `desktop/windows/**`:
  - `checks` (ubuntu): pnpm install (frozen lockfile) → typecheck → test. Blocks merge.
  - `build-windows` (windows-latest, .NET 8): full install + `build:unpack`, uploads the unpacked build — exercises the native paths (better-sqlite3 rebuild, OCR/automation helpers) ubuntu can't.
  - Uses pnpm with `--frozen-lockfile` to match the app's `pnpm-lock.yaml` (lockfileVersion 9), so CI installs are reproducible against the lockfile the repo actually maintains (last synced in #7932).
- **Test fix:** `foregroundTargetLogic.ts` parsed Windows exe paths with POSIX `basename`, so self-detection only worked when the process ran on Windows and failed elsewhere (e.g. Linux CI). Switched to `win32.basename` (host-independent — the paths under comparison are always Windows paths).
- **Test infra:** added `test/electronStub.ts`, aliased `electron` → stub in `vitest.config.ts`. The suite's node-side tests transitively import `electron`, whose real entry needs the native binary; the stub lets them run headless.

## Why

Without CI, regressions in the Windows app merge unnoticed. This is the gate.

## Testing

From `desktop/windows/`:

```
pnpm install --frozen-lockfile --ignore-scripts
pnpm run typecheck   # clean
pnpm test            # 547 passed | 3 skipped (550) — previously 3 suites were red
```

Verified on macOS and Linux; the `build-windows` job in this PR exercises the Windows packaging path on a real Windows runner.

## Notes / out of scope, on purpose

- **Lint is intentionally not wired here** — the existing lint errors are cleared in a follow-up, which then adds the lint step as a blocking check.
- Native runtime paths (automation, OCR, capture, installer UX) still want a manual Windows smoke test; the `build-windows` job covers the packaging path.
- Code signing and auto-update remain absent on Windows — scaffolding/docs for those are a separate follow-up.

## AI Disclosure

- Tools used: Claude (analysis and patch preparation), Claude Code (verification and submission)
- AI-assisted portions: the fix, test stub, CI workflow, and this description
- Verified by running the full install/typecheck/test cycle locally with the exact commands CI uses


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9069?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

