### PR TITLE
fix(desktop): mark transcription connected on websocket open

### DIFF
--- a/desktop/macos/Desktop/Sources/TranscriptionService.swift
+++ b/desktop/macos/Desktop/Sources/TranscriptionService.swift
@@ -80,6 +80,7 @@ class TranscriptionService {
     private let apiKey: String
     private var webSocketTask: URLSessionWebSocketTask?
     private var urlSession: URLSession?
+    private var webSocketDelegate: WebSocketConnectionDelegate?
     // Internal for @testable import access in unit tests
     var isConnected = false
     var shouldReconnect = false
@@ -401,31 +402,32 @@ class TranscriptionService {
         let configuration = URLSessionConfiguration.default
         configuration.timeoutIntervalForRequest = 30
         configuration.timeoutIntervalForResource = 0  // No resource timeout for long-lived WebSocket
-        urlSession = URLSession(configuration: configuration)
-        webSocketTask = urlSession?.webSocketTask(with: request)
+        let delegate = WebSocketConnectionDelegate()
+        let session = URLSession(configuration: configuration, delegate: delegate, delegateQueue: nil)
+        let task = session.webSocketTask(with: request)
+        webSocketDelegate = delegate
+        urlSession = session
+        webSocketTask = task
+
+        delegate.onOpen = { [weak self, weak task] in
+            guard let self, let task, self.webSocketTask === task else { return }
+            self.handleWebSocketOpen()
+        }
+        delegate.onClose = { [weak self, weak task] closeCode in
+            guard let self, let task, self.webSocketTask === task else { return }
+            log("TranscriptionService: WebSocket closed with code \(closeCode.rawValue)")
+            if self.isConnected {
+                self.handleDisconnection()
+            } else if self.shouldReconnect {
+                self.cleanupAndReconnect()
+            }
+        }
 
         // Start the connection
-        webSocketTask?.resume()
+        task.resume()
 
         // Start receiving messages
         receiveMessage()
-
-        // Mark as connected after a brief delay to allow WebSocket handshake.
-        // Also set a connect timeout — if the handshake hasn't completed in 10s, trigger reconnect.
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
-            guard let self = self else { return }
-            guard self.webSocketTask?.state == .running else {
-                log("TranscriptionService: WebSocket not running after handshake — triggering reconnect")
-                self.cleanupAndReconnect()
-                return
-            }
-            self.isConnected = true
-            self.reconnectAttempts = 0
-            self.lastDataReceivedAt = Date()
-            log("TranscriptionService: Connected to Python backend")
-            self.startWatchdog()
-            self.onConnected?()
-        }
 
         // Connect timeout: if still not connected after 10s, force reconnect
         Task { [weak self] in
@@ -434,6 +436,16 @@ class TranscriptionService {
             log("TranscriptionService: Connect timeout (10s) — forcing reconnect")
             self.cleanupAndReconnect()
         }
+    }
+
+    private func handleWebSocketOpen() {
+        guard !isConnected else { return }
+        isConnected = true
+        reconnectAttempts = 0
+        lastDataReceivedAt = Date()
+        log("TranscriptionService: WebSocket opened (handshake complete)")
+        startWatchdog()
+        onConnected?()
     }
 
     /// Start watchdog to detect stale connections (WebSocket dies silently)
@@ -461,6 +473,7 @@ class TranscriptionService {
         webSocketTask = nil
         urlSession?.invalidateAndCancel()
         urlSession = nil
+        webSocketDelegate = nil
         log("TranscriptionService: Disconnected")
         onDisconnected?()
     }
@@ -474,6 +487,7 @@ class TranscriptionService {
         webSocketTask = nil
         urlSession?.invalidateAndCancel()
         urlSession = nil
+        webSocketDelegate = nil
         onDisconnected?()
 
         // Attempt reconnection if enabled
@@ -496,10 +510,12 @@ class TranscriptionService {
     /// Cleanup a failed/pending connection and schedule reconnect.
     /// Unlike handleDisconnection(), this works even when isConnected is false (pre-handshake failures).
     func cleanupAndReconnect() {
+        isConnected = false
         webSocketTask?.cancel(with: .abnormalClosure, reason: nil)
         webSocketTask = nil
         urlSession?.invalidateAndCancel()
         urlSession = nil
+        webSocketDelegate = nil
 
         guard shouldReconnect, reconnectAttempts < maxReconnectAttempts else {
             if reconnectAttempts >= maxReconnectAttempts {
@@ -586,6 +602,28 @@ class TranscriptionService {
         } catch {
             logError("TranscriptionService: Parse error", error: error)
         }
+    }
+}
+
+final class WebSocketConnectionDelegate: NSObject, URLSessionWebSocketDelegate {
+    var onOpen: (() -> Void)?
+    var onClose: ((URLSessionWebSocketTask.CloseCode) -> Void)?
+
+    func urlSession(
+        _ session: URLSession,
+        webSocketTask: URLSessionWebSocketTask,
+        didOpenWithProtocol protocol: String?
+    ) {
+        onOpen?()
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        webSocketTask: URLSessionWebSocketTask,
+        didCloseWith closeCode: URLSessionWebSocketTask.CloseCode,
+        reason: Data?
+    ) {
+        onClose?(closeCode)
     }
 }
 

--- a/desktop/macos/Desktop/Sources/TranscriptionService.swift
+++ b/desktop/macos/Desktop/Sources/TranscriptionService.swift
@@ -430,9 +430,9 @@ class TranscriptionService {
         receiveMessage()
 
         // Connect timeout: if still not connected after 10s, force reconnect
-        Task { [weak self] in
+        Task { [weak self, weak task] in
             try? await Task.sleep(nanoseconds: 10_000_000_000)
-            guard let self = self, !self.isConnected, self.shouldReconnect else { return }
+            guard let self, let task, self.webSocketTask === task, !self.isConnected, self.shouldReconnect else { return }
             log("TranscriptionService: Connect timeout (10s) — forcing reconnect")
             self.cleanupAndReconnect()
         }

--- a/desktop/macos/Desktop/Sources/TranscriptionService.swift
+++ b/desktop/macos/Desktop/Sources/TranscriptionService.swift
@@ -410,11 +410,20 @@ class TranscriptionService {
         webSocketTask = task
 
         delegate.onOpen = { [weak self, weak task] in
-            guard let self, let task, self.webSocketTask === task else { return }
-            self.handleWebSocketOpen()
+            guard let self,
+                  WebSocketConnectionAttempt.matches(task, current: self.webSocketTask)
+            else { return }
+            DispatchQueue.main.async { [weak self, weak task] in
+                guard let self,
+                      WebSocketConnectionAttempt.matches(task, current: self.webSocketTask)
+                else { return }
+                self.handleWebSocketOpen()
+            }
         }
         delegate.onClose = { [weak self, weak task] closeCode in
-            guard let self, let task, self.webSocketTask === task else { return }
+            guard let self,
+                  WebSocketConnectionAttempt.matches(task, current: self.webSocketTask)
+            else { return }
             log("TranscriptionService: WebSocket closed with code \(closeCode.rawValue)")
             if self.isConnected {
                 self.handleDisconnection()
@@ -432,7 +441,11 @@ class TranscriptionService {
         // Connect timeout: if still not connected after 10s, force reconnect
         Task { [weak self, weak task] in
             try? await Task.sleep(nanoseconds: 10_000_000_000)
-            guard let self, let task, self.webSocketTask === task, !self.isConnected, self.shouldReconnect else { return }
+            guard let self,
+                  WebSocketConnectionAttempt.matches(task, current: self.webSocketTask),
+                  !self.isConnected,
+                  self.shouldReconnect
+            else { return }
             log("TranscriptionService: Connect timeout (10s) — forcing reconnect")
             self.cleanupAndReconnect()
         }
@@ -624,6 +637,13 @@ final class WebSocketConnectionDelegate: NSObject, URLSessionWebSocketDelegate {
         reason: Data?
     ) {
         onClose?(closeCode)
+    }
+}
+
+enum WebSocketConnectionAttempt {
+    static func matches(_ candidate: URLSessionWebSocketTask?, current: URLSessionWebSocketTask?) -> Bool {
+        guard let candidate, let current else { return false }
+        return candidate === current
     }
 }
 

--- a/desktop/macos/Desktop/Tests/TranscriptionConnectionStateTests.swift
+++ b/desktop/macos/Desktop/Tests/TranscriptionConnectionStateTests.swift
@@ -1,0 +1,52 @@
+import Foundation
+import XCTest
+@testable import Omi_Computer
+
+final class TranscriptionConnectionStateTests: XCTestCase {
+  func testStreamingConnectionStateIsDrivenByWebSocketOpenEvent() throws {
+    let source = try transcriptionServiceSource()
+
+    XCTAssertFalse(
+      source.contains("asyncAfter(deadline: .now() + 0.5)"),
+      "TranscriptionService must not mark the WebSocket connected from a fixed timer"
+    )
+    XCTAssertTrue(
+      source.contains("URLSession(configuration: configuration, delegate:"),
+      "TranscriptionService should install a URLSessionWebSocketDelegate"
+    )
+    XCTAssertTrue(
+      source.contains("didOpenWithProtocol"),
+      "TranscriptionService should mark connected from URLSessionWebSocketDelegate.didOpenWithProtocol"
+    )
+  }
+
+  func testWebSocketConnectionDelegateForwardsOpenAndClose() {
+    let delegate = WebSocketConnectionDelegate()
+    var didOpen = false
+    var closeCode: URLSessionWebSocketTask.CloseCode?
+
+    delegate.onOpen = {
+      didOpen = true
+    }
+    delegate.onClose = { code in
+      closeCode = code
+    }
+
+    let session = URLSession(configuration: .default)
+    let task = session.webSocketTask(with: URL(string: "wss://example.com/listen")!)
+    delegate.urlSession(session, webSocketTask: task, didOpenWithProtocol: nil)
+    delegate.urlSession(session, webSocketTask: task, didCloseWith: .goingAway, reason: nil)
+    session.invalidateAndCancel()
+
+    XCTAssertTrue(didOpen)
+    XCTAssertEqual(closeCode, .goingAway)
+  }
+
+  private func transcriptionServiceSource() throws -> String {
+    let url = URL(fileURLWithPath: #filePath)
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+      .appendingPathComponent("Sources/TranscriptionService.swift")
+    return try String(contentsOf: url, encoding: .utf8)
+  }
+}

--- a/desktop/macos/Desktop/Tests/TranscriptionConnectionStateTests.swift
+++ b/desktop/macos/Desktop/Tests/TranscriptionConnectionStateTests.swift
@@ -18,6 +18,14 @@ final class TranscriptionConnectionStateTests: XCTestCase {
       source.contains("didOpenWithProtocol"),
       "TranscriptionService should mark connected from URLSessionWebSocketDelegate.didOpenWithProtocol"
     )
+    XCTAssertTrue(
+      source.contains("Task { [weak self, weak task] in"),
+      "TranscriptionService should scope the connect timeout to the WebSocket attempt"
+    )
+    XCTAssertTrue(
+      source.contains("guard let self, let task, self.webSocketTask === task, !self.isConnected, self.shouldReconnect else { return }"),
+      "TranscriptionService should ignore stale connect timeouts from prior WebSocket attempts"
+    )
   }
 
   func testWebSocketConnectionDelegateForwardsOpenAndClose() {

--- a/desktop/macos/Desktop/Tests/TranscriptionConnectionStateTests.swift
+++ b/desktop/macos/Desktop/Tests/TranscriptionConnectionStateTests.swift
@@ -3,31 +3,6 @@ import XCTest
 @testable import Omi_Computer
 
 final class TranscriptionConnectionStateTests: XCTestCase {
-  func testStreamingConnectionStateIsDrivenByWebSocketOpenEvent() throws {
-    let source = try transcriptionServiceSource()
-
-    XCTAssertFalse(
-      source.contains("asyncAfter(deadline: .now() + 0.5)"),
-      "TranscriptionService must not mark the WebSocket connected from a fixed timer"
-    )
-    XCTAssertTrue(
-      source.contains("URLSession(configuration: configuration, delegate:"),
-      "TranscriptionService should install a URLSessionWebSocketDelegate"
-    )
-    XCTAssertTrue(
-      source.contains("didOpenWithProtocol"),
-      "TranscriptionService should mark connected from URLSessionWebSocketDelegate.didOpenWithProtocol"
-    )
-    XCTAssertTrue(
-      source.contains("Task { [weak self, weak task] in"),
-      "TranscriptionService should scope the connect timeout to the WebSocket attempt"
-    )
-    XCTAssertTrue(
-      source.contains("guard let self, let task, self.webSocketTask === task, !self.isConnected, self.shouldReconnect else { return }"),
-      "TranscriptionService should ignore stale connect timeouts from prior WebSocket attempts"
-    )
-  }
-
   func testWebSocketConnectionDelegateForwardsOpenAndClose() {
     let delegate = WebSocketConnectionDelegate()
     var didOpen = false
@@ -50,11 +25,15 @@ final class TranscriptionConnectionStateTests: XCTestCase {
     XCTAssertEqual(closeCode, .goingAway)
   }
 
-  private func transcriptionServiceSource() throws -> String {
-    let url = URL(fileURLWithPath: #filePath)
-      .deletingLastPathComponent()
-      .deletingLastPathComponent()
-      .appendingPathComponent("Sources/TranscriptionService.swift")
-    return try String(contentsOf: url, encoding: .utf8)
+  func testWebSocketConnectionAttemptMatchesOnlyCurrentTaskIdentity() {
+    let session = URLSession(configuration: .default)
+    let currentTask = session.webSocketTask(with: URL(string: "wss://example.com/listen")!)
+    let staleTask = session.webSocketTask(with: URL(string: "wss://example.com/listen")!)
+    session.invalidateAndCancel()
+
+    XCTAssertTrue(WebSocketConnectionAttempt.matches(currentTask, current: currentTask))
+    XCTAssertFalse(WebSocketConnectionAttempt.matches(staleTask, current: currentTask))
+    XCTAssertFalse(WebSocketConnectionAttempt.matches(nil, current: currentTask))
+    XCTAssertFalse(WebSocketConnectionAttempt.matches(currentTask, current: nil))
   }
 }

--- a/desktop/macos/changelog/unreleased/20260705-transcription-connect-state.json
+++ b/desktop/macos/changelog/unreleased/20260705-transcription-connect-state.json
@@ -1,0 +1,3 @@
+{
+  "change": "Made transcription connection status wait for the WebSocket to actually open"
+}

--- a/desktop/macos/changelog/unreleased/20260705-transcription-connect-state.json
+++ b/desktop/macos/changelog/unreleased/20260705-transcription-connect-state.json
@@ -1,3 +1,3 @@
 {
-  "change": "Made transcription connection status wait for the WebSocket to actually open"
+  "change": "Fixed transcription connection status to wait for the WebSocket to actually open"
 }


### PR DESCRIPTION
## Summary
Fixes a desktop transcription connection-state bug where `TranscriptionService` marked the WebSocket as connected from a fixed 0.5s timer after `resume()`, rather than from the WebSocket handshake/open event.

## Bug
When cloud transcription starts, the app could briefly treat the stream as connected before the WebSocket had actually opened. That could allow audio send/connected callbacks to run against a task that was only in the pre-handshake phase.

## Root Cause
`TranscriptionService.connectToBackend` created a plain `URLSession`, called `webSocketTask.resume()`, then set `isConnected = true` from `DispatchQueue.main.asyncAfter(deadline: .now() + 0.5)` if the task state looked running. `URLSessionWebSocketTask.State.running` is not the same as the server-side WebSocket open event.

## Fix
- Install a small `URLSessionWebSocketDelegate` for the transcription WebSocket session.
- Move the `isConnected = true`, reconnect-attempt reset, watchdog start, and `onConnected` callback into the delegate `didOpenWithProtocol` path.
- Route delegate close events through the existing connected/pre-handshake reconnect paths.
- Ignore stale delegate callbacks by checking that the callback still belongs to the current `webSocketTask`.
- Scope the 10s pre-handshake timeout to the same `webSocketTask`, so a stale timeout from an older attempt cannot interrupt a newer reconnect attempt.

## Testing
Before fix:
- Added focused regression test and confirmed it failed on current upstream behavior:
  - `TranscriptionService must not mark the WebSocket connected from a fixed timer`
  - `TranscriptionService should install a URLSessionWebSocketDelegate`
  - `TranscriptionService should mark connected from URLSessionWebSocketDelegate.didOpenWithProtocol`

After fix:
- `xcrun swift test --filter TranscriptionConnectionStateTests --package-path Desktop` passed: 2 tests, 0 failures
- `python3 .github/scripts/desktop-changelog.py validate` passed
- `git diff --check` passed
- `xcrun swift build -c debug --package-path Desktop` passed
- `./scripts/agent-logic-harness.sh` passed all sections:
  - harness failure propagation self-check
  - swift focused lifecycle/state tests
  - agent runtime focused tests
  - pi-mono-extension exact package tests
- Push pre-push hooks passed, including desktop changelog validation and desktop Swift build

Review follow-up after Cubic comments:
- Scoped the 10s connect timeout to the current WebSocket task.
- Updated the focused regression test to assert stale connect timeouts are ignored.
- Updated the changelog fragment to start with `Fixed`.
- Re-ran `xcrun swift test --filter TranscriptionConnectionStateTests --package-path Desktop`: passed, 2 tests, 0 failures.
- Re-ran `python3 .github/scripts/desktop-changelog.py validate`: passed.
- Re-ran `git diff --check`: passed.
- Re-ran `xcrun swift build -c debug --package-path Desktop`: passed.
- Re-ran `./scripts/agent-logic-harness.sh`: passed.
- Re-push pre-push hooks passed, including desktop Swift build.

Second review follow-up after Copilot comments:
- Kept the WebSocket open transition on the main queue before connected state and `onConnected` run, preserving the previous callback queue behavior.
- Replaced raw source-substring assertions with behavior-level tests for delegate forwarding and WebSocket task identity matching.
- Re-ran `xcrun swift test --filter TranscriptionConnectionStateTests --package-path Desktop`: passed, 2 tests, 0 failures.
- Re-ran `python3 .github/scripts/desktop-changelog.py validate`: passed.
- Re-ran `git diff --check`: passed.
- Re-ran `xcrun swift build -c debug --package-path Desktop`: passed.
- Re-ran `./scripts/agent-logic-harness.sh`: passed.
- Re-push pre-push hooks passed, including desktop Swift build.

## Visual Proof
No useful screenshot for this one: the bug is an internal transport-state race before/around the WebSocket handshake. The strongest evidence is the failing-before/passing-after focused regression plus debug build and desktop harness output.

## Risk
Low. The change keeps existing reconnect methods and only changes the source of truth for the initial connected transition from a timer to the system WebSocket open callback.

## Rollback
Revert this commit to restore the previous timer-based connection behavior.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9071?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



