### PR TITLE
Harden the Windows desktop app: crash handling, helper fast-fail, retention

### DIFF
--- a/desktop/windows/src/main/automation/bridge.ts
+++ b/desktop/windows/src/main/automation/bridge.ts
@@ -14,9 +14,14 @@ class AutomationBridge {
   private child: ChildProcessWithoutNullStreams | null = null
   private readonly queue: Pending[] = []
   private backoff = 500
+  // Set once the helper binary is confirmed missing (spawn ENOENT). Without it,
+  // every snapshot/step request re-spawns the missing exe — failing forever,
+  // flooding the log and stalling the planner. Once unavailable, fail fast.
+  // (Mirrors the OCR HelperProcess.) A rebuild + app restart clears it.
+  private unavailable = false
 
   private ensureStarted(): void {
-    if (this.child) return
+    if (this.child || this.unavailable) return
     const exe = resolveHelperPath()
     const child = spawn(exe, [], { stdio: ['pipe', 'pipe', 'pipe'] })
     this.child = child
@@ -36,7 +41,18 @@ class AutomationBridge {
       this.handleExit()
     })
     child.on('error', (e) => {
-      console.error('[win-automation-helper] spawn error:', e.message)
+      if ((e as NodeJS.ErrnoException).code === 'ENOENT') {
+        if (!this.unavailable) {
+          console.error(
+            '[win-automation-helper] binary not found — UI automation is DISABLED. ' +
+              'Build it once with: pwsh scripts/build-automation-helper.ps1  (needs .NET SDK). ' +
+              `(${e.message})`
+          )
+        }
+        this.unavailable = true
+      } else {
+        console.error('[win-automation-helper] spawn error:', e.message)
+      }
       this.handleExit()
     })
     setTimeout(() => {
@@ -86,6 +102,7 @@ class AutomationBridge {
   }
 
   private request(opcode: number, payloadJson: string): Promise<string> {
+    if (this.unavailable) return Promise.reject(new Error('helper unavailable (binary missing)'))
     this.ensureStarted()
     const child = this.child
     if (!child) return Promise.reject(new Error('helper not available'))

--- a/desktop/windows/src/main/index.ts
+++ b/desktop/windows/src/main/index.ts
@@ -1,5 +1,6 @@
 import { app, shell, BrowserWindow, ipcMain, session, nativeImage, desktopCapturer } from 'electron'
 import { join } from 'path'
+import { appendFileSync } from 'fs'
 import { electronApp, optimizer, is } from '@electron-toolkit/utils'
 import iconPath from '../../resources/icon.png?asset'
 import { listCaptureSources } from './ipc/capture'
@@ -46,6 +47,41 @@ if (!process.env.OMI_PERF_LOG) {
   process.env.OMI_PERF_LOG = join(app.getPath('userData'), 'perf.jsonl')
 }
 perfMark('app:start')
+
+// --- Global crash observability --------------------------------------------
+// The main process previously had no top-level error handling: an unhandled
+// exception or rejection could terminate (or silently wedge) the app with
+// nothing recorded, and renderer/GPU/utility crashes went unnoticed. Record
+// fatal events to a crash log under userData so field failures are diagnosable,
+// and keep the app usable on a renderer crash by reloading rather than leaving
+// a blank window. Handlers are best-effort and must never throw themselves.
+const crashLogPath = join(app.getPath('userData'), 'crash.log')
+function logFatal(kind: string, detail: unknown): void {
+  const body = detail instanceof Error ? (detail.stack ?? detail.message) : String(detail)
+  try {
+    appendFileSync(crashLogPath, `${new Date().toISOString()} [${kind}] ${body}\n`)
+  } catch {
+    /* best-effort; never throw from a crash handler */
+  }
+  console.error(`[fatal] ${kind}:`, detail)
+}
+process.on('uncaughtException', (err) => logFatal('uncaughtException', err))
+process.on('unhandledRejection', (reason) => logFatal('unhandledRejection', reason))
+app.on('render-process-gone', (_e, wc, details) => {
+  logFatal('render-process-gone', `reason=${details.reason} exitCode=${details.exitCode}`)
+  // Reload the crashed renderer instead of leaving a white window — unless it
+  // exited cleanly (intentional teardown).
+  if (details.reason !== 'clean-exit' && !wc.isDestroyed()) {
+    try {
+      wc.reload()
+    } catch {
+      /* window may be mid-teardown */
+    }
+  }
+})
+app.on('child-process-gone', (_e, details) =>
+  logFatal('child-process-gone', `type=${details.type} reason=${details.reason}`)
+)
 
 // Opt-in sandbox isolation. By default Electron derives userData from the
 // product name ("omi-windows"), which is the real user's data + signed-in

--- a/desktop/windows/src/main/index.ts
+++ b/desktop/windows/src/main/index.ts
@@ -74,24 +74,30 @@ process.on('uncaughtException', (err) => logFatal('uncaughtException', err))
 process.on('unhandledRejection', (reason) => logFatal('unhandledRejection', reason))
 // Reload a crashed renderer instead of leaving a white window — but cap rapid
 // retries: a persistent startup failure would otherwise loop crash → reload →
-// crash forever, flashing the window and flooding crash.log.
+// crash forever, flashing the window and flooding crash.log. The budget is
+// tracked PER WebContents (WeakMap, so destroyed windows drop out): a
+// crash-looping toast/overlay must not exhaust the main window's retries.
 const RENDERER_RELOAD_WINDOW_MS = 60_000
 const RENDERER_RELOAD_MAX = 3
-let rendererReloadTimes: number[] = []
+const rendererReloadTimes = new WeakMap<Electron.WebContents, number[]>()
 app.on('render-process-gone', (_e, wc, details) => {
   logFatal('render-process-gone', `reason=${details.reason} exitCode=${details.exitCode}`)
   // Skip clean exits (intentional teardown) and destroyed windows.
   if (details.reason === 'clean-exit' || wc.isDestroyed()) return
   const now = Date.now()
-  rendererReloadTimes = rendererReloadTimes.filter((t) => now - t < RENDERER_RELOAD_WINDOW_MS)
-  if (rendererReloadTimes.length >= RENDERER_RELOAD_MAX) {
+  const recent = (rendererReloadTimes.get(wc) ?? []).filter(
+    (t) => now - t < RENDERER_RELOAD_WINDOW_MS
+  )
+  if (recent.length >= RENDERER_RELOAD_MAX) {
+    rendererReloadTimes.set(wc, recent)
     logFatal(
       'render-process-gone',
-      `reload suppressed — renderer crashed ${RENDERER_RELOAD_MAX}+ times in ${RENDERER_RELOAD_WINDOW_MS / 1000}s; leaving window for manual reload`
+      `reload suppressed — renderer (webContents ${wc.id}) crashed ${RENDERER_RELOAD_MAX}+ times in ${RENDERER_RELOAD_WINDOW_MS / 1000}s; leaving window for manual reload`
     )
     return
   }
-  rendererReloadTimes.push(now)
+  recent.push(now)
+  rendererReloadTimes.set(wc, recent)
   try {
     wc.reload()
   } catch {

--- a/desktop/windows/src/main/index.ts
+++ b/desktop/windows/src/main/index.ts
@@ -55,11 +55,16 @@ perfMark('app:start')
 // fatal events to a crash log under userData so field failures are diagnosable,
 // and keep the app usable on a renderer crash by reloading rather than leaving
 // a blank window. Handlers are best-effort and must never throw themselves.
-const crashLogPath = join(app.getPath('userData'), 'crash.log')
 function logFatal(kind: string, detail: unknown): void {
   const body = detail instanceof Error ? (detail.stack ?? detail.message) : String(detail)
   try {
-    appendFileSync(crashLogPath, `${new Date().toISOString()} [${kind}] ${body}\n`)
+    // Resolve the path at call time, not module load: the sandbox block below
+    // re-pins userData, and a path captured at import would send sandbox-mode
+    // crash logs to the production profile.
+    appendFileSync(
+      join(app.getPath('userData'), 'crash.log'),
+      `${new Date().toISOString()} [${kind}] ${body}\n`
+    )
   } catch {
     /* best-effort; never throw from a crash handler */
   }
@@ -67,16 +72,30 @@ function logFatal(kind: string, detail: unknown): void {
 }
 process.on('uncaughtException', (err) => logFatal('uncaughtException', err))
 process.on('unhandledRejection', (reason) => logFatal('unhandledRejection', reason))
+// Reload a crashed renderer instead of leaving a white window — but cap rapid
+// retries: a persistent startup failure would otherwise loop crash → reload →
+// crash forever, flashing the window and flooding crash.log.
+const RENDERER_RELOAD_WINDOW_MS = 60_000
+const RENDERER_RELOAD_MAX = 3
+let rendererReloadTimes: number[] = []
 app.on('render-process-gone', (_e, wc, details) => {
   logFatal('render-process-gone', `reason=${details.reason} exitCode=${details.exitCode}`)
-  // Reload the crashed renderer instead of leaving a white window — unless it
-  // exited cleanly (intentional teardown).
-  if (details.reason !== 'clean-exit' && !wc.isDestroyed()) {
-    try {
-      wc.reload()
-    } catch {
-      /* window may be mid-teardown */
-    }
+  // Skip clean exits (intentional teardown) and destroyed windows.
+  if (details.reason === 'clean-exit' || wc.isDestroyed()) return
+  const now = Date.now()
+  rendererReloadTimes = rendererReloadTimes.filter((t) => now - t < RENDERER_RELOAD_WINDOW_MS)
+  if (rendererReloadTimes.length >= RENDERER_RELOAD_MAX) {
+    logFatal(
+      'render-process-gone',
+      `reload suppressed — renderer crashed ${RENDERER_RELOAD_MAX}+ times in ${RENDERER_RELOAD_WINDOW_MS / 1000}s; leaving window for manual reload`
+    )
+    return
+  }
+  rendererReloadTimes.push(now)
+  try {
+    wc.reload()
+  } catch {
+    /* window may be mid-teardown */
   }
 })
 app.on('child-process-gone', (_e, details) =>

--- a/desktop/windows/src/main/rewind/retentionRunner.ts
+++ b/desktop/windows/src/main/rewind/retentionRunner.ts
@@ -16,5 +16,10 @@ export async function pruneRewindOnce(): Promise<number> {
 }
 
 export function startRewindRetention(): void {
-  setInterval(() => void pruneRewindOnce(), PRUNE_INTERVAL_MS)
+  // Prune once on launch so a restart enforces retention promptly (not only
+  // after the first hourly tick), and surface failures instead of dropping them.
+  void pruneRewindOnce().catch((e) => console.warn('[rewind] initial prune failed:', e))
+  setInterval(() => {
+    void pruneRewindOnce().catch((e) => console.warn('[rewind] prune failed:', e))
+  }, PRUNE_INTERVAL_MS)
 }


### PR DESCRIPTION
> **Stacked on #9069** — merge that first. The CI/test-fix commits shown here are #9069's; this PR's own change is one hardening commit (3 files, +61/−3). Independent of the lint PR — mergeable in any order after #9069.

## What

Three reliability fixes for failure modes that currently degrade silently:

- **Global crash observability** (`src/main/index.ts`): the main process had no top-level error handling. Adds `uncaughtException` / `unhandledRejection` / `render-process-gone` / `child-process-gone` handlers that append to `crash.log` under `userData`, and reloads a crashed renderer instead of leaving a white window.
- **Automation-helper fast-fail** (`src/main/automation/bridge.ts`): ports the OCR helper's `unavailable` ENOENT guard. A missing automation binary previously re-spawned on every request forever, flooding logs and stalling the planner; now it fails fast once and marks the helper unavailable.
- **Rewind retention** (`src/main/rewind/retentionRunner.ts`): prune once at startup (previously only on the interval timer, so long-idle installs never pruned) and log prune failures instead of swallowing them.

## Why

A crash today produces a white window and no artifact to debug from; a missing helper binary produces an infinite spawn loop. Both are cheap to fix and make field reports actionable.

## Testing

From `desktop/windows/` (pnpm, frozen lockfile): typecheck clean; `pnpm test` → 547 passed | 3 skipped (includes `bridge.test.ts` covering the fast-fail); eslint on the three touched files → 0 errors.

Out of scope, on purpose: DB-corruption recovery (a corrupt `omi.db` still takes down every DB feature) — the fix is destructive and wants a real Windows test; tracked separately rather than shipped blind.

## AI Disclosure

- Tools used: Claude (fix authoring), Claude Code (verification and submission)
- Verified by running typecheck/tests locally with the exact commands CI uses, stacked on #9069.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9073?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

