### PR TITLE
Fix packaging metadata and document signing/auto-update gaps for Windows

### DIFF
--- a/desktop/windows/electron-builder.yml
+++ b/desktop/windows/electron-builder.yml
@@ -77,7 +77,7 @@ npmRebuild: false
 # dependency, there is no `autoUpdater` wiring in src/main, and no `publish`
 # target. Shipped users cannot receive fixes without a manual re-download.
 # To enable (do this deliberately, then test on a real release channel):
-#   1. npm i electron-updater
+#   1. pnpm add electron-updater
 #   2. wire autoUpdater.checkForUpdatesAndNotify() in src/main (guarded to
 #      packaged builds), with a NSIS differential-update-friendly flow.
 #   3. uncomment and point this at your release host:

--- a/desktop/windows/electron-builder.yml
+++ b/desktop/windows/electron-builder.yml
@@ -66,7 +66,7 @@ linux:
     - AppImage
     - snap
     - deb
-  maintainer: Based Hardware
+  maintainer: Based Hardware <team@basedhardware.com>
   category: Utility
 appImage:
   artifactName: ${name}-${version}.${ext}

--- a/desktop/windows/electron-builder.yml
+++ b/desktop/windows/electron-builder.yml
@@ -27,6 +27,22 @@ win:
   target:
     - target: nsis
       arch: [x64]
+  # --- CODE SIGNING (unsigned today → Windows SmartScreen warns "unknown publisher") ---
+  # Signing requires a certificate that must be procured separately; until one is
+  # wired in, leave this commented so unsigned builds still succeed. Recommended:
+  # Azure Trusted Signing (no hardware token, CI-friendly). Once you have an
+  # account, uncomment and set the values (store secrets in CI, never here):
+  #
+  # azureSignOptions:
+  #   publisherName: "Based Hardware"
+  #   endpoint: "https://<region>.codesigning.azure.net/"
+  #   certificateProfileName: "<profile>"
+  #   codeSigningAccountName: "<account>"
+  #
+  # Traditional OV/EV cert alternative:
+  # signtoolOptions:
+  #   certificateSubjectName: "Based Hardware"   # EV cert in the machine store
+  #   # or: certificateFile / certificatePassword via CSC_LINK / CSC_KEY_PASSWORD env
 nsis:
   oneClick: false
   perMachine: false
@@ -50,8 +66,22 @@ linux:
     - AppImage
     - snap
     - deb
-  maintainer: electronjs.org
+  maintainer: Based Hardware
   category: Utility
 appImage:
   artifactName: ${name}-${version}.${ext}
 npmRebuild: false
+
+# --- AUTO-UPDATE (NOT configured today) ---
+# Finding: the Windows app has no updater — `electron-updater` is not a
+# dependency, there is no `autoUpdater` wiring in src/main, and no `publish`
+# target. Shipped users cannot receive fixes without a manual re-download.
+# To enable (do this deliberately, then test on a real release channel):
+#   1. npm i electron-updater
+#   2. wire autoUpdater.checkForUpdatesAndNotify() in src/main (guarded to
+#      packaged builds), with a NSIS differential-update-friendly flow.
+#   3. uncomment and point this at your release host:
+# publish:
+#   - provider: github
+#     owner: BasedHardware
+#     repo: omi

--- a/desktop/windows/package.json
+++ b/desktop/windows/package.json
@@ -3,8 +3,8 @@
   "version": "1.0.0",
   "description": "An Electron application with React and TypeScript",
   "main": "./out/main/index.js",
-  "author": "example.com",
-  "homepage": "https://electron-vite.org",
+  "author": "Based Hardware",
+  "homepage": "https://github.com/BasedHardware/omi",
   "scripts": {
     "format": "prettier --write .",
     "lint": "eslint --cache .",


### PR DESCRIPTION
> **Stacked on #9069** — merge that first. The CI/test-fix commits shown here are #9069's; this PR's own change is one packaging commit. Independent of the lint and hardening PRs — mergeable in any order after #9069.

## What

- Replaces electron-vite scaffold placeholders in the packaged app's metadata with real values: `author` (was `example.com`), `homepage` (was `electron-vite.org`), and the Linux `maintainer` (was `electronjs.org`). These ship in the installer today.
- Adds a commented **code-signing scaffold** (Azure Trusted Signing + classic OV/EV paths) to `electron-builder.yml`. Unsigned builds still succeed exactly as before; the comments document what procurement has to provide to remove the SmartScreen warning.
- Documents the **absent auto-update path** with a commented `publish` block and the steps needed to wire it (Windows currently has no update mechanism at all).

## Why

Shipping installers that say `example.com` erodes trust, and the signing/auto-update gaps are invisible until someone hits them — this makes both the current state and the path forward explicit in the config where the next person will look.

## Testing

From `desktop/windows/` (pnpm, frozen lockfile): typecheck clean; `pnpm test` → 547 passed | 3 skipped. Config/metadata only — no runtime code changes; the `build-windows` CI job from #9069 exercises the packaging path with these values.

Out of scope, on purpose: actually procuring a certificate and wiring auto-update — both need infrastructure decisions, not code.

## AI Disclosure

- Tools used: Claude (fix authoring), Claude Code (verification and submission)
- Verified by running typecheck/tests locally with the exact commands CI uses, stacked on #9069.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9074?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

