### PR TITLE
test(desktop): rename warmup tests to match ProactiveAssistants terminology

### DIFF
--- a/desktop/macos/Desktop/Tests/StartupWarmupPolicyTests.swift
+++ b/desktop/macos/Desktop/Tests/StartupWarmupPolicyTests.swift
@@ -38,14 +38,14 @@ final class StartupWarmupPolicyTests: XCTestCase {
         )
     }
 
-    func testProactiveMonitoringRemainingDelayIsFullAtLaunch() {
+    func testProactiveAssistantsRemainingDelayIsFullAtLaunch() {
         XCTAssertEqual(
             StartupWarmupPolicy.remainingProactiveAssistantsStartDelay(elapsedSinceLaunch: 0),
             StartupWarmupPolicy.proactiveAssistantsStartDelay
         )
     }
 
-    func testProactiveMonitoringRemainingDelayCountsDownFromLaunch() {
+    func testProactiveAssistantsRemainingDelayCountsDownFromLaunch() {
         XCTAssertEqual(
             StartupWarmupPolicy.remainingProactiveAssistantsStartDelay(elapsedSinceLaunch: 2.0),
             StartupWarmupPolicy.proactiveAssistantsStartDelay - 2.0,
@@ -53,7 +53,7 @@ final class StartupWarmupPolicyTests: XCTestCase {
         )
     }
 
-    func testProactiveMonitoringRemainingDelayIsZeroOnceWindowHasElapsed() {
+    func testProactiveAssistantsRemainingDelayIsZeroOnceWindowHasElapsed() {
         XCTAssertEqual(
             StartupWarmupPolicy.remainingProactiveAssistantsStartDelay(
                 elapsedSinceLaunch: StartupWarmupPolicy.proactiveAssistantsStartDelay + 60),
@@ -61,7 +61,7 @@ final class StartupWarmupPolicyTests: XCTestCase {
         )
     }
 
-    func testProactiveMonitoringRemainingDelayClampsNegativeElapsedToFullDelay() {
+    func testProactiveAssistantsRemainingDelayClampsNegativeElapsedToFullDelay() {
         XCTAssertEqual(
             StartupWarmupPolicy.remainingProactiveAssistantsStartDelay(elapsedSinceLaunch: -5),
             StartupWarmupPolicy.proactiveAssistantsStartDelay


### PR DESCRIPTION
## Summary

Addresses the post-merge Copilot/cubic review feedback on #9021: the four anchored-delay tests were named `testProactiveMonitoringRemainingDelay…` while the API they exercise is `StartupWarmupPolicy.remainingProactiveAssistantsStartDelay` and the rest of the suite uses the ProactiveAssistants terminology. Rename-only — no behavior change.

## Testing

`xcrun swift test --package-path Desktop --filter StartupWarmupPolicy` → 40 tests, 0 failures (all four renamed tests pass).

## AI Disclosure

Authored and verified with Claude Code; ran the filtered suite locally after the rename.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9077?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

