### PR TITLE
fix(desktop/ptt): bound PTT audio buffer + deadlock-safe capture teardown

### DIFF
--- a/desktop/macos/Desktop/Sources/AudioCaptureService.swift
+++ b/desktop/macos/Desktop/Sources/AudioCaptureService.swift
@@ -934,11 +934,15 @@ class AudioCaptureService: @unchecked Sendable {
         if isCapturing {
             removePropertyListeners()
             if let procID = ioProcID, deviceID != kAudioObjectUnknown {
-                // Use sync in deinit to ensure cleanup completes before deallocation
-                audioQueue.sync {
-                    AudioDeviceStop(deviceID, procID)
-                    AudioDeviceDestroyIOProcID(deviceID, procID)
-                }
+                // Call the HAL teardown directly — do NOT `audioQueue.sync` here.
+                // deinit can run *on* audioQueue (e.g. the last reference is released
+                // inside an audioQueue block), and dispatching sync to the current
+                // queue deadlocks. The object has no remaining references, so no
+                // concurrent audioQueue work can touch it; these HAL calls are
+                // thread-safe, so a direct call completes cleanup before deallocation
+                // (which `audioQueue.async` could not guarantee).
+                AudioDeviceStop(deviceID, procID)
+                AudioDeviceDestroyIOProcID(deviceID, procID)
             }
         }
     }

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
@@ -299,7 +299,11 @@ class PushToTalkManager: ObservableObject {
       return
     }
     if isBlockedByUsageLimit() { return }
-    batchAudioOverflowSignaled = false  // fresh turn — allow the too-long warning again
+    // Reset the overflow flag under the buffer lock so it's atomic w.r.t. the
+    // audio thread's appendBatchAudioBounded (fresh turn → allow the warning again).
+    batchAudioLock.lock()
+    batchAudioOverflowSignaled = false
+    batchAudioLock.unlock()
     barState?.pttHintText = ""  // clear any lingering too-short/too-long hint from a prior tap
     FloatingBarVoicePlaybackService.shared.interruptCurrentResponse()
     if ShortcutSettings.shared.pttMuteSystemAudio {
@@ -933,22 +937,43 @@ class PushToTalkManager: ObservableObject {
   /// (~4.5 min) audio still transcribes normally when the turn is released.
   private func appendBatchAudioBounded(_ audioData: Data) {
     batchAudioLock.lock()
-    let atCap = batchAudioBuffer.count >= Self.maxBatchAudioBytes
-    if !atCap { batchAudioBuffer.append(audioData) }
+    // Append while under the cap (the chunk that reaches it is kept, so the warning
+    // fires exactly at the crossing). Set the once-flag atomically under the lock so
+    // the warning is enqueued exactly once, not on every subsequent chunk.
+    var justHitCap = false
+    if batchAudioBuffer.count < Self.maxBatchAudioBytes {
+      batchAudioBuffer.append(audioData)
+      if batchAudioBuffer.count >= Self.maxBatchAudioBytes && !batchAudioOverflowSignaled {
+        batchAudioOverflowSignaled = true
+        justHitCap = true
+      }
+    }
     batchAudioLock.unlock()
-    if atCap { signalBatchAudioOverflowOnce() }
+    if justHitCap { showBatchAudioOverflowWarning(turn: micCaptureGeneration) }
   }
 
-  /// Surface a one-time "recording too long" warning when the turn buffer is
+  /// Surface the one-time "recording too long" warning when the turn buffer is
   /// capped. Hops to main (called from the audio thread) and reuses the rendered
   /// `pttHintText` surface (the legacy `voiceTranscript` error field is unrendered).
-  private func signalBatchAudioOverflowOnce() {
+  /// `turn` guards against a stale warning painting a *newer* turn if this turn
+  /// ended before the block ran. Self-clears after a beat (like the too-short hint)
+  /// so it doesn't linger on the bar after the capped turn is submitted.
+  private func showBatchAudioOverflowWarning(turn: UInt64) {
     DispatchQueue.main.async { [weak self] in
-      guard let self, !self.batchAudioOverflowSignaled else { return }
-      self.batchAudioOverflowSignaled = true
+      guard let self, self.micCaptureGeneration == turn else { return }
       log("PushToTalkManager: turn audio hit \(Self.maxBatchAudioBytes)-byte cap — bounding buffer, warning user")
       self.barState?.pttHintText = "Recording too long — keep it under 5 min"
       self.updateBarState()
+      self.pttHintGeneration &+= 1
+      let generation = self.pttHintGeneration
+      Task { @MainActor [weak self] in
+        try? await Task.sleep(nanoseconds: 4_000_000_000)
+        guard let self, self.pttHintGeneration == generation else { return }
+        if self.barState?.pttHintText == "Recording too long — keep it under 5 min" {
+          self.barState?.pttHintText = ""
+          self.updateBarState()
+        }
+      }
     }
   }
 

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
@@ -935,7 +935,7 @@ class PushToTalkManager: ObservableObject {
   /// `maxBatchAudioBytes`. Called from the audio thread. Once the cap is hit the
   /// buffer stops growing (bounded RSS) and the user is warned once; the buffered
   /// (~4.5 min) audio still transcribes normally when the turn is released.
-  private func appendBatchAudioBounded(_ audioData: Data) {
+  private func appendBatchAudioBounded(_ audioData: Data, turn: UInt64) {
     batchAudioLock.lock()
     // Append while under the cap (the chunk that reaches it is kept, so the warning
     // fires exactly at the crossing). Set the once-flag atomically under the lock so
@@ -949,7 +949,7 @@ class PushToTalkManager: ObservableObject {
       }
     }
     batchAudioLock.unlock()
-    if justHitCap { showBatchAudioOverflowWarning(turn: micCaptureGeneration) }
+    if justHitCap { showBatchAudioOverflowWarning(turn: turn) }
   }
 
   /// Surface the one-time "recording too long" warning when the turn buffer is
@@ -1347,7 +1347,7 @@ class PushToTalkManager: ObservableObject {
               // Realtime hub owns this turn — stream mic PCM straight to it, and
               // retain it so finalize() can silence-gate the turn.
               RealtimeHubController.shared.feedAudio(audioData)
-              self.appendBatchAudioBounded(audioData)
+              self.appendBatchAudioBounded(audioData, turn: generation)
               return
             }
             if self.isOmniSTT {
@@ -1359,10 +1359,10 @@ class PushToTalkManager: ObservableObject {
                 self.omniPreconnectBuffer.append(audioData)
               }
               // Also retain the raw turn for a Deepgram fallback if omni fails.
-              self.appendBatchAudioBounded(audioData)
+              self.appendBatchAudioBounded(audioData, turn: generation)
             } else if batchMode {
               // Batch mode: accumulate audio in buffer
-              self.appendBatchAudioBounded(audioData)
+              self.appendBatchAudioBounded(audioData, turn: generation)
             } else {
               // Live mode: stream to Deepgram
               self.transcriptionService?.sendAudio(audioData)

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
@@ -106,6 +106,13 @@ class PushToTalkManager: ObservableObject {
   // Batch mode: accumulate raw audio for post-recording transcription
   private var batchAudioBuffer = Data()
   private let batchAudioLock = NSLock()
+  /// Hard cap on a single turn's buffered PCM (16 kHz mono int16) so a runaway
+  /// (>~4.5 min) dictation can't grow RSS without bound. Kept just under the
+  /// backend's ~5-min limit (HTTP 413) so we surface a client-side warning before
+  /// buffering forever and failing at submit. 4.5 min × 16000 Hz × 2 bytes.
+  nonisolated static let maxBatchAudioBytes = Int(4.5 * 60) * 16_000 * 2
+  /// Set once per turn when the buffer hits the cap, so the warning fires once.
+  private var batchAudioOverflowSignaled = false
 
   // Live mode: timeout for waiting on final transcript after CloseStream
   private var liveFinalizationTimeout: DispatchWorkItem?
@@ -292,7 +299,8 @@ class PushToTalkManager: ObservableObject {
       return
     }
     if isBlockedByUsageLimit() { return }
-    barState?.pttHintText = ""  // clear any lingering too-short hint from a prior tap
+    batchAudioOverflowSignaled = false  // fresh turn — allow the too-long warning again
+    barState?.pttHintText = ""  // clear any lingering too-short/too-long hint from a prior tap
     FloatingBarVoicePlaybackService.shared.interruptCurrentResponse()
     if ShortcutSettings.shared.pttMuteSystemAudio {
       SystemAudioMuteController.shared.muteForListening()
@@ -919,6 +927,31 @@ class PushToTalkManager: ObservableObject {
     }
   }
 
+  /// Append a mic chunk to the per-turn buffer under the lock, capped at
+  /// `maxBatchAudioBytes`. Called from the audio thread. Once the cap is hit the
+  /// buffer stops growing (bounded RSS) and the user is warned once; the buffered
+  /// (~4.5 min) audio still transcribes normally when the turn is released.
+  private func appendBatchAudioBounded(_ audioData: Data) {
+    batchAudioLock.lock()
+    let atCap = batchAudioBuffer.count >= Self.maxBatchAudioBytes
+    if !atCap { batchAudioBuffer.append(audioData) }
+    batchAudioLock.unlock()
+    if atCap { signalBatchAudioOverflowOnce() }
+  }
+
+  /// Surface a one-time "recording too long" warning when the turn buffer is
+  /// capped. Hops to main (called from the audio thread) and reuses the rendered
+  /// `pttHintText` surface (the legacy `voiceTranscript` error field is unrendered).
+  private func signalBatchAudioOverflowOnce() {
+    DispatchQueue.main.async { [weak self] in
+      guard let self, !self.batchAudioOverflowSignaled else { return }
+      self.batchAudioOverflowSignaled = true
+      log("PushToTalkManager: turn audio hit \(Self.maxBatchAudioBytes)-byte cap — bounding buffer, warning user")
+      self.barState?.pttHintText = "Recording too long — keep it under 5 min"
+      self.updateBarState()
+    }
+  }
+
   private func sendTranscript() {
     // QueryTracer: close the omni finalization span opened in finalize() (no-op on
     // the batch/live fallback paths, which never opened it).
@@ -1289,9 +1322,7 @@ class PushToTalkManager: ObservableObject {
               // Realtime hub owns this turn — stream mic PCM straight to it, and
               // retain it so finalize() can silence-gate the turn.
               RealtimeHubController.shared.feedAudio(audioData)
-              self.batchAudioLock.lock()
-              self.batchAudioBuffer.append(audioData)
-              self.batchAudioLock.unlock()
+              self.appendBatchAudioBounded(audioData)
               return
             }
             if self.isOmniSTT {
@@ -1303,14 +1334,10 @@ class PushToTalkManager: ObservableObject {
                 self.omniPreconnectBuffer.append(audioData)
               }
               // Also retain the raw turn for a Deepgram fallback if omni fails.
-              self.batchAudioLock.lock()
-              self.batchAudioBuffer.append(audioData)
-              self.batchAudioLock.unlock()
+              self.appendBatchAudioBounded(audioData)
             } else if batchMode {
               // Batch mode: accumulate audio in buffer
-              self.batchAudioLock.lock()
-              self.batchAudioBuffer.append(audioData)
-              self.batchAudioLock.unlock()
+              self.appendBatchAudioBounded(audioData)
             } else {
               // Live mode: stream to Deepgram
               self.transcriptionService?.sendAudio(audioData)

--- a/desktop/macos/Desktop/Tests/TranscriptionTransportTests.swift
+++ b/desktop/macos/Desktop/Tests/TranscriptionTransportTests.swift
@@ -68,6 +68,12 @@ final class TranscriptionTransportTests: XCTestCase {
     let src = try source(relativePath: "Sources/FloatingControlBar/PushToTalkManager.swift")
     XCTAssertTrue(src.contains("maxBatchAudioBytes"))
     XCTAssertTrue(src.contains("appendBatchAudioBounded"))
+    XCTAssertTrue(
+      src.contains("appendBatchAudioBounded(_ audioData: Data, turn: UInt64)"),
+      "bounded append should take the audio callback's stable turn id")
+    XCTAssertTrue(
+      src.contains("appendBatchAudioBounded(audioData, turn: generation)"),
+      "audio callbacks should pass their captured generation into the bounded append helper")
     // The raw unbounded appends are gone from the audio callback.
     XCTAssertFalse(
       src.contains("self.batchAudioBuffer.append(audioData)"),

--- a/desktop/macos/Desktop/Tests/TranscriptionTransportTests.swift
+++ b/desktop/macos/Desktop/Tests/TranscriptionTransportTests.swift
@@ -74,6 +74,14 @@ final class TranscriptionTransportTests: XCTestCase {
       "audio-thread appends must go through the bounded helper")
     // A user-visible warning surfaces via the rendered pttHintText channel.
     XCTAssertTrue(src.contains("Recording too long"))
+    // Review fixes: the overflow warning is turn-guarded (no stale warning painting a
+    // newer turn) and self-clears (doesn't linger after the capped turn is submitted).
+    guard let range = src.range(of: "func showBatchAudioOverflowWarning") else {
+      return XCTFail("showBatchAudioOverflowWarning not found")
+    }
+    let body = String(src[range.lowerBound...].prefix(700))
+    XCTAssertTrue(body.contains("micCaptureGeneration == turn"), "warning must be turn-guarded")
+    XCTAssertTrue(body.contains("pttHintGeneration"), "overflow hint must self-clear like the too-short hint")
   }
 
   // MARK: BL-014 — deinit must not deadlock

--- a/desktop/macos/Desktop/Tests/TranscriptionTransportTests.swift
+++ b/desktop/macos/Desktop/Tests/TranscriptionTransportTests.swift
@@ -1,0 +1,106 @@
+import Network
+import XCTest
+
+@testable import Omi_Computer
+
+/// S-04 — Transcription transport truthfulness (BL-011–014).
+/// Behavioral tests where the object is constructible; source-scrape guards
+/// (same pattern as `PTTAudioCaptureRaceTests`) for the hot-path / singleton
+/// changes that can't be driven without a backend or real audio device.
+final class TranscriptionTransportTests: XCTestCase {
+
+  // MARK: BL-011 — RawWebSocket port force-unwrap
+
+  /// A URL can carry an out-of-range port (URL.port is an Int; e.g. `:99999`).
+  /// `UInt16(url.port ?? 443)` / `NWEndpoint.Port(rawValue:)!` would trap. connect()
+  /// must report the error instead of crashing. (The guard itself landed upstream
+  /// in #9069 / 243bab529 — this regression test guards the port validation our
+  /// hub transport depends on; its message is "invalid WebSocket port <n>".)
+  func testConnectWithOutOfRangePortReportsErrorInsteadOfCrashing() {
+    let socket = RawWebSocket(
+      url: URL(string: "wss://example.com:99999/path")!,
+      queue: DispatchQueue(label: "test.rawws"))
+    let errored = expectation(description: "onError fires")
+    socket.onError = { message in
+      XCTAssertTrue(message.lowercased().contains("port"), "got: \(message)")
+      errored.fulfill()
+    }
+    socket.connect()  // pre-fix: traps in UInt16(99999)
+    wait(for: [errored], timeout: 2.0)
+  }
+
+  // MARK: BL-012 — isConnected reflects the real socket open
+
+  /// The delegate must forward the real WS handshake events so `isConnected`
+  /// is driven by `didOpenWithProtocol`, not a fixed timer.
+  func testWebSocketConnectionDelegateForwardsOpenAndClose() {
+    let delegate = WebSocketConnectionDelegate()
+    var opened = false
+    var closedCode: URLSessionWebSocketTask.CloseCode?
+    delegate.onOpen = { opened = true }
+    delegate.onClose = { closedCode = $0 }
+
+    let session = URLSession(configuration: .default)
+    let task = session.webSocketTask(with: URL(string: "wss://example.com/ws")!)
+    delegate.urlSession(session, webSocketTask: task, didOpenWithProtocol: nil)
+    delegate.urlSession(session, webSocketTask: task, didCloseWith: .goingAway, reason: nil)
+    session.invalidateAndCancel()
+
+    XCTAssertTrue(opened)
+    XCTAssertEqual(closedCode, .goingAway)
+  }
+
+  /// The 0.5s "assume connected" timer must be gone; isConnected is set on the
+  /// real open event and the session is created with the delegate.
+  func testConnectIsEventDrivenNotTimer() throws {
+    let src = try source(relativePath: "Sources/TranscriptionService.swift")
+    XCTAssertFalse(
+      src.contains("asyncAfter(deadline: .now() + 0.5)"),
+      "the fixed 0.5s connect timer must be replaced by the real open event")
+    XCTAssertTrue(src.contains("delegate.onOpen"))
+    XCTAssertTrue(src.contains("URLSession(configuration: configuration, delegate: delegate"))
+    XCTAssertTrue(src.contains("didOpenWithProtocol"))
+  }
+
+  // MARK: BL-013 — bounded per-turn audio buffer
+
+  func testBatchAudioBufferIsBounded() throws {
+    let src = try source(relativePath: "Sources/FloatingControlBar/PushToTalkManager.swift")
+    XCTAssertTrue(src.contains("maxBatchAudioBytes"))
+    XCTAssertTrue(src.contains("appendBatchAudioBounded"))
+    // The raw unbounded appends are gone from the audio callback.
+    XCTAssertFalse(
+      src.contains("self.batchAudioBuffer.append(audioData)"),
+      "audio-thread appends must go through the bounded helper")
+    // A user-visible warning surfaces via the rendered pttHintText channel.
+    XCTAssertTrue(src.contains("Recording too long"))
+  }
+
+  // MARK: BL-014 — deinit must not deadlock
+
+  func testAudioCaptureDeinitDoesNotSyncOnAudioQueue() throws {
+    let src = try source(relativePath: "Sources/AudioCaptureService.swift")
+    // The deadlock construct — a sync dispatch block onto audioQueue — must be gone
+    // entirely (the file otherwise only uses `audioQueue.async {`).
+    XCTAssertFalse(
+      src.contains("audioQueue.sync {"),
+      "deinit must call HAL teardown directly, not sync-dispatch to audioQueue (deadlock)")
+    // deinit still tears the HAL device down.
+    guard let deinitRange = src.range(of: "deinit {") else {
+      return XCTFail("deinit not found")
+    }
+    let deinitBody = String(src[deinitRange.lowerBound...].prefix(900))
+    XCTAssertTrue(deinitBody.contains("AudioDeviceStop"))
+    XCTAssertTrue(deinitBody.contains("AudioDeviceDestroyIOProcID"))
+  }
+
+  // MARK: Helper
+
+  private func source(relativePath: String) throws -> String {
+    let url = URL(fileURLWithPath: #filePath)
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+      .appendingPathComponent(relativePath)
+    return try String(contentsOf: url, encoding: .utf8)
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260705-transcription-transport.json
+++ b/desktop/macos/changelog/unreleased/20260705-transcription-transport.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed a rare hang during push-to-talk audio-device teardown, and now warns when a recording runs too long instead of only failing when you finish"
+}


### PR DESCRIPTION
## Summary

Two macOS push-to-talk transport-hardening fixes:

- **Bound the batch PTT audio buffer (~4.5 min)** with a user-visible "Recording too long — keep it under 5 min" hint (BL-013). The per-turn buffer was unbounded; the only cap was the backend's HTTP 413 at ~5 min, hit at submit time after RSS had already grown. `appendBatchAudioBounded(_:)` now caps it and warns once via the rendered `pttHintText` (the legacy `voiceTranscript` error field is rendered by no view).
- **Deadlock-safe `AudioCaptureService` teardown** (BL-014). `deinit` did `audioQueue.sync { AudioDeviceStop/Destroy }`, which deadlocks if deinit runs on `audioQueue`. It now calls the HAL teardown directly — safe because the object has no remaining references and the calls are thread-safe.

## Out of scope (fixed upstream while this was in flight)

- **BL-011** (RawWebSocket port force-unwrap crash) — already fixed in **#9069** (`243bab529`, superset host + range guard). Dropped from this branch during rebase.
- **BL-012** (transcription `isConnected` set from an optimistic 0.5s timer instead of the real socket open) — already fixed in `75d0a6e6a` / `90e20c51e` / `82637950e` (WebSocket-open delegate). Dropped from this branch during rebase.

This PR therefore no longer touches `RawWebSocket.swift` or `TranscriptionService.swift`.

## Tests

- `TranscriptionTransportTests` — 5/5. Two guard the BL-013/BL-014 fixes here; three are regression guards for the port/connect behavior now provided upstream (they pass against the merged code).
- `bash test.sh` — 293 Rust + 124 Swift suites (per-suite isolation harness).

## Runtime evidence

- **MIC-07 (teardown safety):** 50× rapid PTT start/stop → 46 balanced `AudioCapture Started`==`Stopped`, 0 hang/crash, app responsive (independently reproduced; implementer 20×→55 balanced).

## Review follow-up

Addressed the Cubic overflow race in `0e1949565`:

- `appendBatchAudioBounded` now receives the audio callback's captured `generation` instead of reading `micCaptureGeneration` after releasing `batchAudioLock`.
- The overflow warning remains guarded by that stable turn id, so stale audio callbacks cannot paint a later PTT turn.
- `TranscriptionTransportTests` now asserts the bounded append path takes and passes the stable turn id.

Re-verified after the follow-up:

- `xcrun swift test --filter TranscriptionTransportTests --package-path Desktop` — passed, 5 tests
- `python3 .github/scripts/desktop-changelog.py validate` — passed
- `git diff --check` — passed
- `xcrun swift build -c debug --package-path Desktop` — passed
- `./scripts/agent-logic-harness.sh` — passed
- Pre-push hooks — passed, including desktop Swift build

## Changelog

`desktop/macos/changelog/unreleased/20260705-transcription-transport.json`

## Test plan

- [ ] CI / local `bash test.sh` green
- [ ] Rapid PTT start/stop smoke on a named bundle (no hang)
- [ ] Review `PushToTalkManager` buffer cap (`appendBatchAudioBounded`) + `AudioCaptureService.deinit`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9078?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


