### PR TITLE
fix(desktop): emit error message on Update Check Failed telemetry (#9079)

### DIFF
--- a/desktop/macos/Desktop/Sources/UpdaterViewModel.swift
+++ b/desktop/macos/Desktop/Sources/UpdaterViewModel.swift
@@ -110,11 +110,14 @@ struct UpdateFailureDiagnostics: Equatable {
   }
 
   var analyticsProperties: [String: Any] {
+    let telemetryMessage = message.isEmpty ? "\(domain) \(code)" : message
     var properties: [String: Any] = [
       // Emit the human-readable message under "error" so the daily report's
       // error_or_message column is populated (previously blank on Update Check Failed).
-      "error": message.isEmpty ? "\(domain) \(code)" : message,
-      "update_failure_message": message,
+      "error": telemetryMessage,
+      "phase": reason.rawValue,
+      "update_failure_message": telemetryMessage,
+      "update_failure_phase": reason.rawValue,
       "update_failure_reason": reason.rawValue,
       "update_failure_domain": domain,
       "update_failure_code": code,

--- a/desktop/macos/Desktop/Sources/UpdaterViewModel.swift
+++ b/desktop/macos/Desktop/Sources/UpdaterViewModel.swift
@@ -111,6 +111,10 @@ struct UpdateFailureDiagnostics: Equatable {
 
   var analyticsProperties: [String: Any] {
     var properties: [String: Any] = [
+      // Emit the human-readable message under "error" so the daily report's
+      // error_or_message column is populated (previously blank on Update Check Failed).
+      "error": message.isEmpty ? "\(domain) \(code)" : message,
+      "update_failure_message": message,
       "update_failure_reason": reason.rawValue,
       "update_failure_domain": domain,
       "update_failure_code": code,

--- a/desktop/macos/Desktop/Tests/UpdateFailureDiagnosticsTests.swift
+++ b/desktop/macos/Desktop/Tests/UpdateFailureDiagnosticsTests.swift
@@ -152,6 +152,8 @@ final class UpdateFailureDiagnosticsTests: XCTestCase {
     XCTAssertEqual(diagnostics.errorChainCodes, [2001, 2001, NSURLErrorTimedOut])
 
     let properties = diagnostics.analyticsProperties
+    XCTAssertEqual(properties["phase"] as? String, "network")
+    XCTAssertEqual(properties["update_failure_phase"] as? String, "network")
     XCTAssertEqual(properties["update_failure_reason"] as? String, "network")
     XCTAssertEqual(properties["nsurl_error_code"] as? Int, NSURLErrorTimedOut)
     XCTAssertEqual(properties["failing_url_host"] as? String, "api.omi.me")
@@ -188,5 +190,33 @@ final class UpdateFailureDiagnosticsTests: XCTestCase {
     XCTAssertEqual(properties["update_failure_reason"] as? String, "downloads_location")
     XCTAssertEqual(properties["launch_location_bucket"] as? String, "downloads_folder")
     XCTAssertNil(properties["bundle_path"])
+  }
+
+  func testAnalyticsPropertiesFallbackMessageIsNonEmpty() {
+    let diagnostics = UpdateFailureDiagnostics(
+      reason: .unknown,
+      message: "",
+      domain: "SUSparkleErrorDomain",
+      code: 2001,
+      underlyingDomain: nil,
+      underlyingCode: nil,
+      errorChainDomains: ["SUSparkleErrorDomain"],
+      errorChainCodes: [2001],
+      nsurlErrorCode: nil,
+      failingURLHost: nil,
+      failingURLPath: nil,
+      updateChannel: "stable",
+      launchLocationBucket: "applications_system",
+      sourceAppVersion: "0.12.0",
+      sourceAppBuild: "12000",
+      appcastURLHost: "api.omi.me",
+      appcastURLPath: "/v2/desktop/appcast.xml"
+    )
+
+    let properties = diagnostics.analyticsProperties
+    XCTAssertEqual(properties["error"] as? String, "SUSparkleErrorDomain 2001")
+    XCTAssertEqual(properties["phase"] as? String, "unknown")
+    XCTAssertEqual(properties["update_failure_message"] as? String, "SUSparkleErrorDomain 2001")
+    XCTAssertEqual(properties["update_failure_phase"] as? String, "unknown")
   }
 }

--- a/desktop/macos/Desktop/Tests/UpdateFailureDiagnosticsTests.swift
+++ b/desktop/macos/Desktop/Tests/UpdateFailureDiagnosticsTests.swift
@@ -159,6 +159,13 @@ final class UpdateFailureDiagnosticsTests: XCTestCase {
     XCTAssertEqual(properties["source_app_version"] as? String, "0.12.0")
     XCTAssertEqual(properties["source_app_build"] as? String, "12000")
     XCTAssertEqual(properties["appcast_url_host"] as? String, "api.omi.me")
+    // Regression: Update Check Failed must carry a non-empty error message so the
+    // daily report's error_or_message column is populated (was blank on 0.12.0).
+    XCTAssertEqual(
+      properties["error"] as? String, "An error occurred in retrieving update information.")
+    XCTAssertEqual(
+      properties["update_failure_message"] as? String,
+      "An error occurred in retrieving update information.")
   }
 
   func testAnalyticsPropertiesOmitRawPath() {


### PR DESCRIPTION
## Bug
Issue #9079: `Update Check Failed` spiked on macOS 0.12.0 (build 12000) — **283 users / 1,587 events** in 14d — but the daily report's `error_or_message` column is **blank**, so the updater regression is undiagnosable.

## Root cause
`UpdateFailureDiagnostics` (`UpdaterViewModel.swift`) captures the failure `message` (`error.localizedDescription`) into the struct, but `analyticsProperties` — the dict sent with the `Update Check Failed` PostHog event — emits `update_failure_reason` / `update_failure_domain` / `update_failure_code` etc. and **never the message**. Every other desktop error event (e.g. `Sign In Failed`) emits its message under `"error"`, which is what the report's `error_or_message` column coalesces on. Update failures emit neither → blank column.

## Fix
Add the captured message to `analyticsProperties`:
- `"error"` — the human-readable `localizedDescription` (matches sibling error events; populates the report column). Falls back to `"<domain> <code>"` on the rare empty message so the field is never blank.
- `"update_failure_message"` — structured field consistent with the existing `update_failure_*` family.

Directly satisfies acceptance criterion #1 ("Update failure event includes non-empty phase and error fields; blank `error_or_message` cannot happen"). Instrumentation-only — no behavior change, no user-facing surface (no changelog fragment).

## Verification
- `xcrun swift build -c debug` — green.
- `xcrun swift test --filter UpdateFailureDiagnosticsTests` — 9/9 pass, including a new regression assertion that `error` and `update_failure_message` are populated.

🤖 automated by hourly watchdog; opened for review, not merged.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9085?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

