### PR TITLE
fix(desktop): PTT dead-mic recovery on all capture paths + accurate telemetry (#9081)

### DIFF
--- a/desktop/macos/Desktop/Sources/DesktopDiagnosticsManager.swift
+++ b/desktop/macos/Desktop/Sources/DesktopDiagnosticsManager.swift
@@ -69,7 +69,9 @@ final class DesktopDiagnosticsManager {
     rms: Int,
     deviceDescription: String?,
     micPermissionGranted: Bool,
-    hubActive: Bool
+    hubActive: Bool,
+    recoveryAction: String = "none",
+    recoveryResult: String = "not_attempted"
   ) {
     let nearZero = peak <= 5 && rms <= 5
     let watchdogEligible = audioSeconds >= pttWatchdogMinimumAudioSeconds
@@ -91,8 +93,8 @@ final class DesktopDiagnosticsManager {
       "consecutive_silent_turns": consecutiveNearZeroPTTTurns,
       "tcc_microphone_granted": micPermissionGranted,
       "input_device_class": classifyInputDevice(deviceDescription),
-      "recovery_action": "none",
-      "recovery_result": "not_attempted",
+      "recovery_action": recoveryAction,
+      "recovery_result": recoveryResult,
     ]
     if let voicedSeconds {
       properties["voiced_audio_seconds"] = rounded(voicedSeconds)

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
@@ -10,7 +10,7 @@ struct PTTSilentMicRecoveryPolicy {
 
   private(set) var consecutiveDeadMicTurns = 0
 
-  mutating func recordDiscardedHubTurn(totalSec: TimeInterval, peak: Int) -> Bool {
+  mutating func recordDiscardedTurn(totalSec: TimeInterval, peak: Int) -> Bool {
     if totalSec >= Self.minDeadTurnSeconds && peak <= Self.deadMicPeakThreshold {
       consecutiveDeadMicTurns += 1
     } else {
@@ -19,7 +19,7 @@ struct PTTSilentMicRecoveryPolicy {
     return consecutiveDeadMicTurns >= Self.consecutiveDeadTurnThreshold
   }
 
-  mutating func recordSuccessfulHubTurn() {
+  mutating func recordSuccessfulTurn() {
     consecutiveDeadMicTurns = 0
   }
 
@@ -674,7 +674,7 @@ class PushToTalkManager: ObservableObject {
       if !Self.hubTurnHasSpeech(pcm16k: turnAudio) {
         let (peak, rms) = Self.audioEnergy(pcm16k: turnAudio)
         let dev = audioCaptureService?.currentDeviceDescription ?? "?"
-        let attemptRecovery = silentMicRecoveryPolicy.recordDiscardedHubTurn(totalSec: totalSec, peak: peak)
+        let attemptRecovery = silentMicRecoveryPolicy.recordDiscardedTurn(totalSec: totalSec, peak: peak)
         DesktopDiagnosticsManager.shared.recordPTTSilentTurn(
           source: "hub",
           mode: finalizedMode,
@@ -719,7 +719,7 @@ class PushToTalkManager: ObservableObject {
         transcribeBufferedWarmWaitAudio()
         return
       }
-      silentMicRecoveryPolicy.recordSuccessfulHubTurn()
+      silentMicRecoveryPolicy.recordSuccessfulTurn()
       DesktopDiagnosticsManager.shared.recordPTTCommitted(mode: finalizedMode, hubActive: true)
       barState?.beginVoiceResponseWaiting()
       // Show the "thinking" indicator in the notch during the release→first-audio
@@ -749,7 +749,7 @@ class PushToTalkManager: ObservableObject {
         // A dead mic (peak≈0 for a real hold) leaves omni/batch users stuck on
         // repeated silent turns with no recovery. Mirror the hub path: rebuild the
         // CoreAudio capture after consecutive dead-mic turns.
-        let attemptRecovery = silentMicRecoveryPolicy.recordDiscardedHubTurn(totalSec: totalSec, peak: peak)
+        let attemptRecovery = silentMicRecoveryPolicy.recordDiscardedTurn(totalSec: totalSec, peak: peak)
         DesktopDiagnosticsManager.shared.recordPTTSilentTurn(
           source: isOmniSTT ? "omni_stt" : "batch_stt",
           mode: finalizedMode,
@@ -785,6 +785,7 @@ class PushToTalkManager: ObservableObject {
     // Past the silence gate — a real turn will be transcribed and answered. Show
     // the "thinking" indicator through the transcription/first-token gap; it hands
     // off to the conversation surface (or voice glow) the moment output arrives.
+    silentMicRecoveryPolicy.recordSuccessfulTurn()
     barState?.isThinking = true
     updateBarState()
 

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
@@ -674,6 +674,7 @@ class PushToTalkManager: ObservableObject {
       if !Self.hubTurnHasSpeech(pcm16k: turnAudio) {
         let (peak, rms) = Self.audioEnergy(pcm16k: turnAudio)
         let dev = audioCaptureService?.currentDeviceDescription ?? "?"
+        let attemptRecovery = silentMicRecoveryPolicy.recordDiscardedHubTurn(totalSec: totalSec, peak: peak)
         DesktopDiagnosticsManager.shared.recordPTTSilentTurn(
           source: "hub",
           mode: finalizedMode,
@@ -683,13 +684,15 @@ class PushToTalkManager: ObservableObject {
           rms: rms,
           deviceDescription: dev,
           micPermissionGranted: hasMicPermission,
-          hubActive: true)
+          hubActive: true,
+          recoveryAction: attemptRecovery ? "capture_rebuild" : "none",
+          recoveryResult: attemptRecovery ? "attempted" : "not_attempted")
         log(
           "PushToTalkManager: discarding hub turn — audio \(String(format: "%.2f", totalSec))s "
             + "peak=\(peak)/32767 rms=\(rms) device=[\(dev)] "
             + "(peak≈0 ⇒ dead mic; high peak ⇒ classifier misfire; low ⇒ quiet/far mic) — not committing"
         )
-        if silentMicRecoveryPolicy.recordDiscardedHubTurn(totalSec: totalSec, peak: peak) {
+        if attemptRecovery {
           requestCoreAudioCaptureRecovery(reason: "repeated dead-mic PTT turns", restartPTT: false, batchMode: false)
         }
         RealtimeHubController.shared.cancelTurn()
@@ -743,6 +746,10 @@ class PushToTalkManager: ObservableObject {
       let (totalSec, voicedSec) = Self.voicedAudioSeconds(pcm16k: turnAudio)
       if totalSec < Self.minTurnAudioSeconds || voicedSec < Self.minVoicedSeconds {
         let (peak, rms) = Self.audioEnergy(pcm16k: turnAudio)
+        // A dead mic (peak≈0 for a real hold) leaves omni/batch users stuck on
+        // repeated silent turns with no recovery. Mirror the hub path: rebuild the
+        // CoreAudio capture after consecutive dead-mic turns.
+        let attemptRecovery = silentMicRecoveryPolicy.recordDiscardedHubTurn(totalSec: totalSec, peak: peak)
         DesktopDiagnosticsManager.shared.recordPTTSilentTurn(
           source: isOmniSTT ? "omni_stt" : "batch_stt",
           mode: finalizedMode,
@@ -752,12 +759,17 @@ class PushToTalkManager: ObservableObject {
           rms: rms,
           deviceDescription: audioCaptureService?.currentDeviceDescription,
           micPermissionGranted: hasMicPermission,
-          hubActive: false)
+          hubActive: false,
+          recoveryAction: attemptRecovery ? "capture_rebuild" : "none",
+          recoveryResult: attemptRecovery ? "attempted" : "not_attempted")
         log(
           "PushToTalkManager: discarding silent turn (audio \(String(format: "%.2f", totalSec))s, voiced \(String(format: "%.2f", voicedSec))s) — not transcribing"
         )
         AnalyticsManager.shared.floatingBarPTTEnded(
           mode: finalizedMode, hadTranscript: false, transcriptLength: 0)
+        if attemptRecovery {
+          requestCoreAudioCaptureRecovery(reason: "repeated dead-mic PTT turns", restartPTT: false, batchMode: isBatch)
+        }
         // A too-short turn means the release beat capture (or the user tapped
         // instead of holding). Give visible feedback instead of a silent clear;
         // longer holds that were merely quiet keep the quiet reset.

--- a/desktop/macos/Desktop/Tests/DesktopDiagnosticsManagerTests.swift
+++ b/desktop/macos/Desktop/Tests/DesktopDiagnosticsManagerTests.swift
@@ -44,6 +44,56 @@ final class DesktopDiagnosticsManagerTests: XCTestCase {
     XCTAssertFalse(json.contains("id=123"))
   }
 
+  func testSilentTurnRecordsRecoveryActionAndResult() throws {
+    DesktopDiagnosticsManager.shared.recordPTTSilentTurn(
+      source: "omni_stt",
+      mode: "hold",
+      audioSeconds: 1.2,
+      voicedSeconds: 0,
+      peak: 0,
+      rms: 0,
+      deviceDescription: "built-in microphone",
+      micPermissionGranted: true,
+      hubActive: false,
+      recoveryAction: "capture_rebuild",
+      recoveryResult: "attempted")
+
+    let url = try XCTUnwrap(DesktopDiagnosticsManager.shared.writeDiagnosticsAttachment())
+    defer { try? FileManager.default.removeItem(at: url) }
+
+    let data = try Data(contentsOf: url)
+    let root = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+    let snapshots = try XCTUnwrap(root["snapshots"] as? [[String: Any]])
+    let snapshot = try XCTUnwrap(snapshots.last)
+
+    XCTAssertEqual(snapshot["recovery_action"] as? String, "capture_rebuild")
+    XCTAssertEqual(snapshot["recovery_result"] as? String, "attempted")
+  }
+
+  func testSilentTurnRecoveryFieldsDefaultToNone() throws {
+    DesktopDiagnosticsManager.shared.recordPTTSilentTurn(
+      source: "hub",
+      mode: "hold",
+      audioSeconds: 1.2,
+      voicedSeconds: nil,
+      peak: 0,
+      rms: 0,
+      deviceDescription: "built-in microphone",
+      micPermissionGranted: true,
+      hubActive: true)
+
+    let url = try XCTUnwrap(DesktopDiagnosticsManager.shared.writeDiagnosticsAttachment())
+    defer { try? FileManager.default.removeItem(at: url) }
+
+    let data = try Data(contentsOf: url)
+    let root = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+    let snapshots = try XCTUnwrap(root["snapshots"] as? [[String: Any]])
+    let snapshot = try XCTUnwrap(snapshots.last)
+
+    XCTAssertEqual(snapshot["recovery_action"] as? String, "none")
+    XCTAssertEqual(snapshot["recovery_result"] as? String, "not_attempted")
+  }
+
   func testShortSilentTurnsDoNotAdvanceWatchdogCounter() throws {
     for _ in 0..<3 {
       DesktopDiagnosticsManager.shared.recordPTTSilentTurn(

--- a/desktop/macos/Desktop/Tests/PTTSilentMicRecoveryPolicyTests.swift
+++ b/desktop/macos/Desktop/Tests/PTTSilentMicRecoveryPolicyTests.swift
@@ -6,34 +6,44 @@ final class PTTSilentMicRecoveryPolicyTests: XCTestCase {
   func testRepeatedDeadMicTurnsRequestRecovery() {
     var policy = PTTSilentMicRecoveryPolicy()
 
-    XCTAssertFalse(policy.recordDiscardedHubTurn(totalSec: 1.0, peak: 0))
+    XCTAssertFalse(policy.recordDiscardedTurn(totalSec: 1.0, peak: 0))
     XCTAssertEqual(policy.consecutiveDeadMicTurns, 1)
 
-    XCTAssertTrue(policy.recordDiscardedHubTurn(totalSec: 1.0, peak: 0))
+    XCTAssertTrue(policy.recordDiscardedTurn(totalSec: 1.0, peak: 0))
     XCTAssertEqual(policy.consecutiveDeadMicTurns, 2)
   }
 
   func testShortSilentTapDoesNotCountAsDeadMic() {
     var policy = PTTSilentMicRecoveryPolicy()
 
-    XCTAssertFalse(policy.recordDiscardedHubTurn(totalSec: 0.05, peak: 0))
+    XCTAssertFalse(policy.recordDiscardedTurn(totalSec: 0.05, peak: 0))
     XCTAssertEqual(policy.consecutiveDeadMicTurns, 0)
   }
 
   func testQuietButNonZeroTurnResetsDeadMicCounter() {
     var policy = PTTSilentMicRecoveryPolicy()
 
-    XCTAssertFalse(policy.recordDiscardedHubTurn(totalSec: 1.0, peak: 0))
-    XCTAssertFalse(policy.recordDiscardedHubTurn(totalSec: 1.0, peak: PTTSilentMicRecoveryPolicy.deadMicPeakThreshold + 1))
+    XCTAssertFalse(policy.recordDiscardedTurn(totalSec: 1.0, peak: 0))
+    XCTAssertFalse(policy.recordDiscardedTurn(totalSec: 1.0, peak: PTTSilentMicRecoveryPolicy.deadMicPeakThreshold + 1))
     XCTAssertEqual(policy.consecutiveDeadMicTurns, 0)
   }
 
   func testSuccessfulTurnResetsDeadMicCounter() {
     var policy = PTTSilentMicRecoveryPolicy()
 
-    XCTAssertFalse(policy.recordDiscardedHubTurn(totalSec: 1.0, peak: 0))
-    policy.recordSuccessfulHubTurn()
+    XCTAssertFalse(policy.recordDiscardedTurn(totalSec: 1.0, peak: 0))
+    policy.recordSuccessfulTurn()
 
     XCTAssertEqual(policy.consecutiveDeadMicTurns, 0)
+  }
+
+  func testSuccessfulTurnPreventsNonConsecutiveDeadMicRecovery() {
+    var policy = PTTSilentMicRecoveryPolicy()
+
+    XCTAssertFalse(policy.recordDiscardedTurn(totalSec: 1.0, peak: 0))
+    policy.recordSuccessfulTurn()
+
+    XCTAssertFalse(policy.recordDiscardedTurn(totalSec: 1.0, peak: 0))
+    XCTAssertEqual(policy.consecutiveDeadMicTurns, 1)
   }
 }

--- a/desktop/macos/changelog/unreleased/20260705-ptt-silent-turn-recovery.json
+++ b/desktop/macos/changelog/unreleased/20260705-ptt-silent-turn-recovery.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed push-to-talk dead-mic recovery not triggering (or being reported) outside the realtime path, so silent voice turns now attempt a mic-capture rebuild and are logged accurately"
+}


### PR DESCRIPTION
## Bug
Issue #9081: `ptt_audio_capture_silent_turn` fires for **169 users on macOS 0.12.0 hold mode** with `recovery_action=none`, `recovery_result=not_attempted` — PTT turns capture no audio and no recovery is attempted.

## Root cause
Two distinct defects in the silent-turn handling:

1. **Telemetry lied.** `DesktopDiagnosticsManager.recordPTTSilentTurn` hardcoded `recovery_action: "none"` / `recovery_result: "not_attempted"` on every event — even the realtime **hub** path, which *does* attempt a CoreAudio capture rebuild via `PTTSilentMicRecoveryPolicy`. So the daily report could never observe a recovery.
2. **Omni/batch STT paths never recovered.** Only the hub path fed `silentMicRecoveryPolicy` + called `requestCoreAudioCaptureRecovery`. A dead mic (peak≈0) in omni/batch mode → repeated silent turns → no recovery ever attempted, exactly `recovery_action=none`.

## Fix (surgical, mirrors the existing hub pattern)
- `recordPTTSilentTurn` gains `recoveryAction` / `recoveryResult` params (defaulting to `none`/`not_attempted`, so untouched paths are unchanged).
- Hub path evaluates the recovery decision *before* recording and reports what it actually did.
- Omni/batch path runs the same consecutive-dead-mic policy and rebuilds capture (`restartPTT:false`, additive to the existing UI reset), reporting the real action/result.

## Tests
- Added two `DesktopDiagnosticsManagerTests` cases (recovery fields threaded through; defaults to `none`).
- `xcrun swift build -c debug` ✅ · `DesktopDiagnosticsManagerTests` (7) ✅ · `PTTSilentMicRecoveryPolicyTests` (4) ✅.
- **UNVERIFIED end-to-end:** the dead-mic capture path can't be reproduced without physically faulty hardware; the recovery call reuses the exact code the hub path already ships in prod.

🤖 automated by hourly watchdog; opened for review, not merged.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9087?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

