### PR TITLE
feat(desktop): smooth streaming reveal for chat text

### DIFF
--- a/desktop/macos/Desktop/Sources/Chat/SmoothStreamReveal.swift
+++ b/desktop/macos/Desktop/Sources/Chat/SmoothStreamReveal.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+/// Pure core of the "visual stream" (smooth streaming, ref.
+/// upstash.com/blog/smooth-streaming): decouples the network cadence from
+/// the reading cadence. Deltas accumulate in `ChatProvider`'s streaming
+/// buffer as fast as they arrive; this decides how many characters each
+/// flush tick reveals so text "types" smoothly instead of jumping in
+/// whole-chunk bursts.
+///
+/// Adaptive rate: a steady base of ~200 characters per second, accelerating
+/// proportionally to the backlog so the visible text never trails the
+/// backend by more than a few ticks — fast models drain quickly, slow
+/// models still read as continuous typing.
+enum SmoothStreamReveal {
+  /// Base pace: ~5ms per character (~200 cps).
+  static let msPerCharacter: Double = 5
+
+  /// Backlog cap: with a large backlog, accelerate to drain it within at
+  /// most this many ticks. At the ~35ms flush cadence, 4 ticks ≈ 140ms of
+  /// maximum lag behind the backend.
+  static let catchUpTicks: Double = 4
+
+  /// How many characters to reveal on this tick.
+  /// - remaining: characters still buffered (not yet shown).
+  /// - elapsedMs: time since the previous tick.
+  static func step(remaining: Int, elapsedMs: Double) -> Int {
+    guard remaining > 0 else { return 0 }
+    let base = elapsedMs / msPerCharacter
+    let catchUp = Double(remaining) / catchUpTicks
+    let step = Int(max(base, catchUp).rounded(.up))
+    return min(remaining, max(1, step))
+  }
+}

--- a/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
@@ -1045,13 +1045,19 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
     private var refreshAllObserver: AnyCancellable?
 
     // MARK: - Streaming Buffer
-    /// Accumulates text deltas during streaming and flushes them to the published
-    /// messages array at most once per ~100ms, reducing SwiftUI re-render frequency.
+    /// Accumulates text deltas during streaming and reveals them into the published
+    /// messages array in metered steps every ~35ms (`SmoothStreamReveal`), so text
+    /// types smoothly instead of jumping in whole-chunk bursts. Also caps SwiftUI
+    /// re-render frequency to the flush cadence.
     private var streamingTextBuffer: String = ""
     private var streamingThinkingBuffer: String = ""
     private var streamingBufferMessageId: String?
     private var streamingFlushWorkItem: DispatchWorkItem?
     private let streamingFlushInterval: TimeInterval = 0.035
+    /// Monotonic timestamp of the previous reveal tick (or of scheduling, when the
+    /// loop starts from idle) — measures real elapsed time so a late tick reveals
+    /// proportionally more instead of falling behind.
+    private var streamingLastRevealTime: TimeInterval?
 
     // MARK: - Filtered Sessions
     var filteredSessions: [ChatSession] {
@@ -4258,7 +4264,7 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
             // Flush any remaining buffered streaming text before finalizing
             streamingFlushWorkItem?.cancel()
             streamingFlushWorkItem = nil
-            flushStreamingBuffer()
+            flushStreamingBuffer(revealAll: true)
 
             // Determine the final text to display and save
             let messageText: String
@@ -4478,7 +4484,7 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
             // Flush any remaining buffered streaming text before handling the error
             streamingFlushWorkItem?.cancel()
             streamingFlushWorkItem = nil
-            flushStreamingBuffer()
+            flushStreamingBuffer(revealAll: true)
 
             // Only remove the AI message if it's still empty (no streamed text yet).
             // If text was already streamed and visible, keep it and just stop streaming.
@@ -4690,25 +4696,36 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
         return normalized
     }
 
-    /// Append text to a streaming message via a buffer that flushes at ~100ms intervals.
-    /// This reduces SwiftUI re-renders from once-per-token to ~10 times/second.
+    /// Append text to a streaming message via a buffer that reveals in metered
+    /// steps every ~35ms, smoothing chunky network deltas into steady typing.
     private func appendToMessage(id: String, text: String) {
         streamingBufferMessageId = id
         streamingTextBuffer += text
-
-        // Schedule a flush if one isn't already pending
-        if streamingFlushWorkItem == nil {
-            let workItem = DispatchWorkItem { [weak self] in
-                self?.flushStreamingBuffer()
-            }
-            streamingFlushWorkItem = workItem
-            DispatchQueue.main.asyncAfter(deadline: .now() + streamingFlushInterval, execute: workItem)
-        }
+        scheduleStreamingFlushIfNeeded()
     }
 
-    /// Flush accumulated text and thinking deltas to the published messages array.
-    private func flushStreamingBuffer() {
+    /// Start the reveal loop if it isn't already running. Resets the reveal
+    /// clock when starting from idle so time spent waiting (e.g. during a tool
+    /// call) doesn't count as elapsed typing time and dump the backlog at once.
+    private func scheduleStreamingFlushIfNeeded() {
+        guard streamingFlushWorkItem == nil else { return }
+        streamingLastRevealTime = ProcessInfo.processInfo.systemUptime
+        let workItem = DispatchWorkItem { [weak self] in
+            self?.flushStreamingBuffer()
+        }
+        streamingFlushWorkItem = workItem
+        DispatchQueue.main.asyncAfter(deadline: .now() + streamingFlushInterval, execute: workItem)
+    }
+
+    /// Reveal buffered text and thinking deltas into the published messages array.
+    /// Each tick reveals `SmoothStreamReveal.step` characters (adaptive typing
+    /// rate) and reschedules itself until the buffers drain; `revealAll` bypasses
+    /// the metering to drain everything at once (completion/error finalization).
+    private func flushStreamingBuffer(revealAll: Bool = false) {
         streamingFlushWorkItem = nil
+        let now = ProcessInfo.processInfo.systemUptime
+        let elapsedMs = (now - (streamingLastRevealTime ?? now - streamingFlushInterval)) * 1000
+        streamingLastRevealTime = now
 
         guard let id = streamingBufferMessageId,
               let index = messages.firstIndex(where: { $0.id == id }) else {
@@ -4717,10 +4734,13 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
             return
         }
 
-        // Flush text buffer
+        // Reveal from the text buffer
         if !streamingTextBuffer.isEmpty {
-            let buffered = streamingTextBuffer
-            streamingTextBuffer = ""
+            let step = revealAll
+                ? streamingTextBuffer.count
+                : SmoothStreamReveal.step(remaining: streamingTextBuffer.count, elapsedMs: elapsedMs)
+            let buffered = String(streamingTextBuffer.prefix(step))
+            streamingTextBuffer.removeFirst(step)
 
             messages[index].text += buffered
             if messages[index].sender == .ai {
@@ -4738,10 +4758,13 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
             }
         }
 
-        // Flush thinking buffer
+        // Reveal from the thinking buffer
         if !streamingThinkingBuffer.isEmpty {
-            let buffered = streamingThinkingBuffer
-            streamingThinkingBuffer = ""
+            let step = revealAll
+                ? streamingThinkingBuffer.count
+                : SmoothStreamReveal.step(remaining: streamingThinkingBuffer.count, elapsedMs: elapsedMs)
+            let buffered = String(streamingThinkingBuffer.prefix(step))
+            streamingThinkingBuffer.removeFirst(step)
 
             if let lastBlockIndex = messages[index].contentBlocks.indices.last,
                case .thinking(let thinkId, let existing) = messages[index].contentBlocks[lastBlockIndex] {
@@ -4749,6 +4772,12 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
             } else {
                 messages[index].contentBlocks.append(.thinking(id: UUID().uuidString, text: buffered))
             }
+        }
+
+        // Keep the reveal loop ticking until the buffers drain — network chunks
+        // may stop arriving while metered text is still typing out.
+        if !revealAll && (!streamingTextBuffer.isEmpty || !streamingThinkingBuffer.isEmpty) {
+            scheduleStreamingFlushIfNeeded()
         }
     }
 
@@ -4933,15 +4962,7 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
     private func appendThinking(messageId: String, text: String) {
         streamingBufferMessageId = messageId
         streamingThinkingBuffer += text
-
-        // Schedule a flush if one isn't already pending
-        if streamingFlushWorkItem == nil {
-            let workItem = DispatchWorkItem { [weak self] in
-                self?.flushStreamingBuffer()
-            }
-            streamingFlushWorkItem = workItem
-            DispatchQueue.main.asyncAfter(deadline: .now() + streamingFlushInterval, execute: workItem)
-        }
+        scheduleStreamingFlushIfNeeded()
     }
 
     /// Mark any remaining in-flight tool call blocks as terminal in a message.

--- a/desktop/macos/Desktop/Tests/SmoothStreamRevealTests.swift
+++ b/desktop/macos/Desktop/Tests/SmoothStreamRevealTests.swift
@@ -1,0 +1,66 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// `SmoothStreamReveal.step` is the pure core of the smooth-streaming reveal:
+/// given how much buffered text remains and how long since the previous flush
+/// tick, it decides how many characters to reveal this tick. Adaptive cadence:
+/// base ~5ms/char (~200 cps), accelerating with the backlog so the visible
+/// text never trails the backend by more than ~`catchUpTicks` ticks.
+final class SmoothStreamRevealTests: XCTestCase {
+
+  /// The nominal flush cadence in ChatProvider (streamingFlushInterval).
+  private let tickMs: Double = 35
+
+  func testRevealsNothingWhenNoTextRemains() {
+    XCTAssertEqual(SmoothStreamReveal.step(remaining: 0, elapsedMs: tickMs), 0)
+    XCTAssertEqual(SmoothStreamReveal.step(remaining: -3, elapsedMs: tickMs), 0)
+  }
+
+  func testKeepsSteadyBaseRateWithSmallBacklog() {
+    // base = 35/5 = 7; catchUp = 20/4 = 5 (doesn't dominate)
+    XCTAssertEqual(SmoothStreamReveal.step(remaining: 20, elapsedMs: tickMs), 7)
+  }
+
+  func testAcceleratesToDrainLargeBacklogWithinCatchUpTicks() {
+    // catchUp = 800/4 = 200 dominates over base 7
+    let step = SmoothStreamReveal.step(remaining: 800, elapsedMs: tickMs)
+    XCTAssertEqual(step, 200)
+    // At that pace the backlog empties in `catchUpTicks` ticks
+    XCTAssertEqual(Int((Double(800) / Double(step)).rounded(.up)), Int(SmoothStreamReveal.catchUpTicks))
+  }
+
+  func testNeverRevealsMoreThanRemaining() {
+    // base = 7 but only 3 characters are left
+    XCTAssertEqual(SmoothStreamReveal.step(remaining: 3, elapsedMs: tickMs), 3)
+  }
+
+  func testAlwaysProgressesAtLeastOneCharacterEvenWithZeroOrNegativeElapsed() {
+    XCTAssertGreaterThanOrEqual(SmoothStreamReveal.step(remaining: 5, elapsedMs: 0), 1)
+    XCTAssertGreaterThanOrEqual(SmoothStreamReveal.step(remaining: 5, elapsedMs: -50), 1)
+  }
+
+  func testLateTickRevealsProportionallyMore() {
+    // A tick delayed by main-thread congestion reveals more, not less:
+    // base = 140/5 = 28 vs the on-time 7 (catchUp = 100/4 = 25 doesn't dominate).
+    XCTAssertEqual(SmoothStreamReveal.step(remaining: 100, elapsedMs: 140), 28)
+  }
+
+  func testSimulatedRevealLoopAlwaysDrains() {
+    // Regardless of backlog size, the tick loop terminates with everything
+    // revealed and strictly monotonic progress.
+    for backlog in [1, 7, 42, 999, 10_000] {
+      var remaining = backlog
+      var ticks = 0
+      while remaining > 0 {
+        let step = SmoothStreamReveal.step(remaining: remaining, elapsedMs: tickMs)
+        XCTAssertGreaterThanOrEqual(step, 1)
+        XCTAssertLessThanOrEqual(step, remaining)
+        remaining -= step
+        ticks += 1
+        XCTAssertLessThan(ticks, 10_000, "reveal loop failed to converge for backlog \(backlog)")
+      }
+      XCTAssertEqual(remaining, 0)
+    }
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260705-smooth-streaming-chat-text.json
+++ b/desktop/macos/changelog/unreleased/20260705-smooth-streaming-chat-text.json
@@ -1,0 +1,3 @@
+{
+  "change": "Improved chat responses to type out smoothly while streaming instead of appearing in bursts"
+}

--- a/desktop/windows/src/renderer/src/components/chat/ChatMessages.tsx
+++ b/desktop/windows/src/renderer/src/components/chat/ChatMessages.tsx
@@ -1,13 +1,15 @@
 import { useEffect, useRef, useState } from 'react'
 import type { ChatMsg } from '../../hooks/useChat'
 import { Markdown } from '../Markdown'
+import { revealStep } from '../../lib/reveal'
 
 // Smooth text reveal, decoupled from SSE chunk sizes so a reply streams in evenly
-// instead of landing in bulky jumps. Rendered as markdown either way.
+// instead of landing in bulky jumps. Rendered as markdown either way. The pace
+// lives in `revealStep` (adaptive: steady base rate plus backlog catch-up); the
+// tick measures real elapsed time so late frames reveal proportionally more.
 const REVEAL_MS = 16
-const REVEAL_MIN_CHARS = 2
 
-function RevealMarkdown({
+export function RevealMarkdown({
   text,
   startRevealed
 }: {
@@ -18,17 +20,20 @@ function RevealMarkdown({
   const targetRef = useRef(text)
   // eslint-disable-next-line react-hooks/refs -- intentional latest-ref / lazy-init (reads newest value in once-registered listeners & imperative loops, avoids stale closures)
   targetRef.current = text
+  // Only tick while text is pending: the interval stops once caught up and
+  // restarts when more text arrives, instead of spinning for the bubble's life.
+  const pending = shown < text.length
   useEffect(() => {
+    if (!pending) return
+    let last = performance.now()
     const id = setInterval(() => {
-      setShown((prev) => {
-        const t = targetRef.current.length
-        if (prev >= t) return prev
-        const step = Math.max(REVEAL_MIN_CHARS, Math.ceil((t - prev) / 24))
-        return Math.min(t, prev + step)
-      })
+      const now = performance.now()
+      const elapsed = now - last
+      last = now
+      setShown((prev) => prev + revealStep(targetRef.current.length - prev, elapsed))
     }, REVEAL_MS)
     return () => clearInterval(id)
-  }, [])
+  }, [pending])
   return <Markdown text={text.slice(0, shown)} />
 }
 

--- a/desktop/windows/src/renderer/src/lib/reveal.test.ts
+++ b/desktop/windows/src/renderer/src/lib/reveal.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest'
+import { revealStep } from './reveal'
+
+// revealStep is the pure core of the smooth reveal: given how much text is
+// still hidden and how long since the previous frame, decide how many chars
+// to show this frame. Adaptive cadence: base ~5ms/char (~200 cps) but it
+// accelerates with the backlog so it never trails the stream by much.
+describe('revealStep', () => {
+  it('reveals nothing when no text remains', () => {
+    expect(revealStep(0, 16)).toBe(0)
+    expect(revealStep(-3, 16)).toBe(0)
+  })
+
+  it('keeps a steady base rate with a small backlog (~4 chars per 16ms frame)', () => {
+    // base = 16/5 = 3.2 -> ceil 4; catchUp = 10/8 = 1.25 (does not dominate)
+    expect(revealStep(10, 16)).toBe(4)
+  })
+
+  it('accelerates to drain a large backlog in ~8 frames', () => {
+    // catchUp = 800/8 = 100 dominates over the base rate
+    expect(revealStep(800, 16)).toBe(100)
+    // at that pace the backlog empties in CATCH_UP_FRAMES frames
+    expect(Math.ceil(800 / revealStep(800, 16))).toBe(8)
+  })
+
+  it('never reveals more than what remains', () => {
+    // base = 3.2 -> 4, but only 2 chars are left
+    expect(revealStep(2, 16)).toBe(2)
+  })
+
+  it('always progresses at least 1 char when text remains, even with zero or negative dt', () => {
+    expect(revealStep(5, 0)).toBeGreaterThanOrEqual(1)
+    expect(revealStep(5, -50)).toBeGreaterThanOrEqual(1)
+  })
+
+  it('a late frame reveals proportionally more, not less', () => {
+    // base = 140/5 = 28 vs the on-time 4 (catchUp = 100/8 = 12.5 does not dominate)
+    expect(revealStep(100, 140)).toBe(28)
+  })
+
+  it('the reveal loop always drains regardless of backlog size', () => {
+    for (const backlog of [1, 7, 42, 999, 10_000]) {
+      let remaining = backlog
+      let frames = 0
+      while (remaining > 0) {
+        const step = revealStep(remaining, 16)
+        expect(step).toBeGreaterThanOrEqual(1)
+        expect(step).toBeLessThanOrEqual(remaining)
+        remaining -= step
+        frames += 1
+        expect(frames).toBeLessThan(10_000)
+      }
+      expect(remaining).toBe(0)
+    }
+  })
+})

--- a/desktop/windows/src/renderer/src/lib/reveal.ts
+++ b/desktop/windows/src/renderer/src/lib/reveal.ts
@@ -1,0 +1,23 @@
+// Pure core of the smooth text reveal (ref. upstash.com/blog/smooth-streaming):
+// decouples the network cadence from the reading cadence. The chat hook
+// accumulates the full text as SSE deltas arrive; here we decide how many
+// characters to reveal each frame so the text "types" evenly instead of
+// landing in bulky jumps.
+
+// Base pace: ~5ms per character (~200 cps).
+const MS_PER_CHAR = 5
+// Backlog cap: with a large backlog, accelerate to drain it within at most
+// this many frames, so the visible text never trails the stream by more than
+// a few frames (fast models would otherwise fall seconds behind).
+const CATCH_UP_FRAMES = 8
+
+// How many characters to reveal on this frame.
+// - remaining: characters not yet shown (full length - already revealed).
+// - elapsedMs: time since the previous frame.
+export function revealStep(remaining: number, elapsedMs: number): number {
+  if (remaining <= 0) return 0
+  const base = elapsedMs / MS_PER_CHAR
+  const catchUp = remaining / CATCH_UP_FRAMES
+  const step = Math.ceil(Math.max(base, catchUp))
+  return Math.min(remaining, Math.max(1, step))
+}

--- a/desktop/windows/src/renderer/src/pages/Home.tsx
+++ b/desktop/windows/src/renderer/src/pages/Home.tsx
@@ -70,6 +70,7 @@ export function Home(): React.JSX.Element {
   const { chat } = useAppState()
   const [user, setUser] = useState<User | null>(auth.currentUser)
   const chatScrollRef = useRef<HTMLDivElement>(null)
+  const threadContentRef = useRef<HTMLDivElement>(null)
   const widgetsGridRef = useRef<HTMLDivElement>(null)
   const lastLenRef = useRef(0)
   const [scrollMode, setScrollModeState] = useState<ChatScrollMode>('followingBottom')
@@ -269,6 +270,39 @@ export function Home(): React.JSX.Element {
     setOverflowing(el.scrollHeight > el.clientHeight + 4)
   }, [chat.history, chat.sending, showThread, scrollToLatest, widgetsReady, widgetsH])
 
+  // The effect above fires on history/sending/layout deps, so it misses the
+  // smooth reveal ticks: RevealMarkdown grows the streaming bubble WITHOUT a
+  // new history reference, and a reader at the live edge would drift above the
+  // newest text (worst at end-of-message, when the last scroll ran before the
+  // metered tail finished typing). A ResizeObserver re-pins on every content
+  // height change while following the live edge.
+  //
+  // The pin runs SYNCHRONOUSLY here (not via scrollToLatest, which defers to
+  // rAF): ResizeObserver fires after layout but before paint, so scrolling in
+  // the callback lands the grown content already pinned. Deferring to the next
+  // frame instead paints the taller content at the old scrollTop first, then
+  // corrects — a per-tick vertical bounce during the reveal. Mirrors the
+  // overlay's pin-on-resize; re-binds when the thread mounts.
+  //
+  // No `isProgrammaticScrollRef` guard: the pin only ever scrolls to the
+  // bottom, so the scroll event it fires lands at distFromBottom≈0 — the
+  // resume-follow branch (a no-op while already following), never the release
+  // or paging branch. Setting the flag here would instead stay ~always true
+  // during the ~16ms reveal ticks and swallow a real scrollbar/keyboard
+  // scroll-up as "programmatic", trapping the reader at the live edge.
+  useEffect(() => {
+    const el = chatScrollRef.current
+    const content = threadContentRef.current
+    if (!el || !content) return
+    const ro = new ResizeObserver(() => {
+      if (scrollModeRef.current !== 'followingBottom') return
+      el.style.scrollBehavior = 'auto'
+      el.scrollTop = el.scrollHeight
+    })
+    ro.observe(content)
+    return () => ro.disconnect()
+  }, [showThread, started])
+
   // Reveal an older page when the user scrolls near the top, capturing the
   // current distance-from-bottom so the view can be pinned in place afterward.
   const onThreadScroll = (): void => {
@@ -357,7 +391,7 @@ export function Home(): React.JSX.Element {
           style={{ WebkitMaskImage: mask, maskImage: mask }}
         >
           <div className="mx-auto flex min-h-full w-full max-w-4xl flex-col">
-            <div className="mt-auto space-y-2 pb-2">
+            <div ref={threadContentRef} className="mt-auto space-y-2 pb-2">
               {started && showThread ? (
                 windowed.map((m, i) => {
                   const isUser = m.role === 'user'

--- a/desktop/windows/src/renderer/src/pages/Home.tsx
+++ b/desktop/windows/src/renderer/src/pages/Home.tsx
@@ -6,6 +6,7 @@ import { useAppState } from '../state/appState'
 import { QuickTaskWidget } from '../components/home/QuickTaskWidget'
 import { QuickGoalsWidget } from '../components/home/QuickGoalsWidget'
 import { Markdown } from '../components/Markdown'
+import { RevealMarkdown } from '../components/chat/ChatMessages'
 import { maybeBuildLocalGraph } from '../lib/kgSynthesis'
 import { cn } from '../lib/utils'
 import omiMark from '../assets/omi-logo.png'
@@ -406,8 +407,13 @@ export function Home(): React.JSX.Element {
                       >
                         {isUser ? (
                           <div className="whitespace-pre-wrap">{m.content}</div>
+                        ) : m.content ? (
+                          <RevealMarkdown
+                            text={m.content}
+                            startRevealed={!(isLast && chat.sending)}
+                          />
                         ) : (
-                          <Markdown text={m.content || (chat.sending && isLast ? '…' : '')} />
+                          <Markdown text={chat.sending && isLast ? '…' : ''} />
                         )}
                       </div>
                     </div>


### PR DESCRIPTION
## What

Streamed AI chat responses now type out smoothly, character by character, instead of appearing in chunky bursts sized by whatever the model produced between flushes. Applies to both desktop apps.

The reveal decouples the network cadence from the reading cadence (ref. [Upstash — smooth streaming](https://upstash.com/blog/smooth-streaming)): deltas accumulate as fast as they arrive, and a metered loop reveals a steady ~200 cps base that accelerates proportionally to the backlog, so visible text never trails the backend by more than ~130ms. Fast models drain quickly; slow models still read as continuous typing.

## Changes

**macOS (Swift)**
- `SmoothStreamReveal.swift` — pure, unit-tested reveal-step core (adaptive rate: base + backlog catch-up).
- `ChatProvider.swift` — the existing 35ms streaming-buffer flush now reveals in metered steps instead of dumping the whole batch; the loop keeps ticking after deltas stop until the buffer drains. Completion and error finalization bypass the metering (`revealAll`) so persistence still sees the full text immediately. Covers text and thinking deltas, and every surface fed by `ChatProvider.messages` (main chat, floating bar, task chat panel).

**Electron (`desktop/windows`)**
- `reveal.ts` — same pure `revealStep` core (+ tests).
- `ChatMessages.tsx` — `RevealMarkdown` now uses the shared adaptive pacing, measures real elapsed time per tick, and stops ticking once caught up (was spinning for the bubble's whole life).
- `Home.tsx` — the main window rendered assistant text with a bare `<Markdown>` (chunky), while only the overlay had the reveal; it now uses `RevealMarkdown` too, so both surfaces type in evenly.

## Testing

- macOS: `SmoothStreamRevealTests` (pacing edge cases + a loop-always-drains property test). Swift build/tests verified by CI (no local macOS toolchain).
- Electron: `reveal.test.ts` — 7/7 pass; `pnpm run typecheck` green. Verified live end-to-end by running the app and watching a streamed reply reveal smoothly.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9088?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

