### PR TITLE
Fix desktop memory lifecycle visibility gate

### DIFF
--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoriesPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoriesPage.swift
@@ -288,6 +288,10 @@ class MemoriesViewModel: ObservableObject {
     canonicalLifecycleExposed ? token.layerFilter.allowedLayers : nil
   }
 
+  private func includeExplicitLifecycleRows(for token: MemoryScopeToken) -> Bool {
+    canonicalLifecycleExposed
+  }
+
   private func displayMemories(_ values: [ServerMemory], for token: MemoryScopeToken) -> [ServerMemory] {
     displayMemories(values, lifecycleExposed: canonicalLifecycleExposed)
   }
@@ -297,7 +301,7 @@ class MemoriesViewModel: ObservableObject {
   }
 
   private func displayMemories(_ values: [ServerMemory], lifecycleExposed: Bool) -> [ServerMemory] {
-    lifecycleExposed ? values : values.map { $0.hidingLifecycleExposure() }
+    lifecycleExposed ? values : values.filter { !$0.tierIsExplicit }
   }
 
   private struct MemoryPageFetchResult {
@@ -338,7 +342,11 @@ class MemoriesViewModel: ObservableObject {
     } else {
       do {
         let loaded = try await MemoryStorage.shared.getLocalMemories(
-          limit: pageSize, offset: 0, tiers: layers(for: token))
+          limit: pageSize,
+          offset: 0,
+          tiers: layers(for: token),
+          includeExplicitLifecycleRows: includeExplicitLifecycleRows(for: token)
+        )
         guard isCurrentScope(token) else { return }
         memories = displayCacheMemories(loaded, for: token)
         currentOffset = loaded.count
@@ -441,7 +449,8 @@ class MemoriesViewModel: ObservableObject {
       let mergedMemories = try await MemoryStorage.shared.getLocalMemories(
         limit: reloadLimit,
         offset: 0,
-        tiers: layers(for: token)
+        tiers: layers(for: token),
+        includeExplicitLifecycleRows: includeExplicitLifecycleRows(for: token)
       )
       guard isCurrentScope(token) else { return }
       if let fetchedLifecycleExposure {
@@ -529,7 +538,8 @@ class MemoriesViewModel: ObservableObject {
       let mergedMemories = try await MemoryStorage.shared.getLocalMemories(
         limit: reloadLimit,
         offset: 0,
-        tiers: layers(for: token)
+        tiers: layers(for: token),
+        includeExplicitLifecycleRows: includeExplicitLifecycleRows(for: token)
       )
       guard isCurrentScope(token) else { return }
       log(
@@ -566,12 +576,20 @@ class MemoriesViewModel: ObservableObject {
       var counts: [MemoryTag: Int] = [:]
 
       // Get total count (no filters) and store for "All" badge
-      let totalCount = try await MemoryStorage.shared.getLocalMemoriesCount(tiers: activeLayerFilter)
+      let includeExplicitLifecycleRows = canonicalLifecycleExposed
+      let totalCount = try await MemoryStorage.shared.getLocalMemoriesCount(
+        tiers: activeLayerFilter,
+        includeExplicitLifecycleRows: includeExplicitLifecycleRows
+      )
       totalMemoriesCount = totalCount
 
       // One count per backend category (mirrors mobile).
       for tag in MemoryTag.allCases {
-        counts[tag] = try await MemoryStorage.shared.getLocalMemoriesCount(category: tag.rawValue, tiers: activeLayerFilter)
+        counts[tag] = try await MemoryStorage.shared.getLocalMemoriesCount(
+          category: tag.rawValue,
+          tiers: activeLayerFilter,
+          includeExplicitLifecycleRows: includeExplicitLifecycleRows
+        )
       }
 
       tagCounts = counts
@@ -607,7 +625,8 @@ class MemoriesViewModel: ObservableObject {
         limit: 10000,
         matchAnyTag: nil,
         matchAnyCategory: matchAnyCategory.isEmpty ? nil : matchAnyCategory,
-        tiers: layers(for: token)
+        tiers: layers(for: token),
+        includeExplicitLifecycleRows: includeExplicitLifecycleRows(for: token)
       )
 
       guard isCurrentScope(token) else { return }
@@ -711,7 +730,8 @@ class MemoriesViewModel: ObservableObject {
       let results = try await MemoryStorage.shared.searchLocalMemories(
         query: query,
         limit: 10000,
-        tiers: layers(for: token)
+        tiers: layers(for: token),
+        includeExplicitLifecycleRows: includeExplicitLifecycleRows(for: token)
       )
       guard isCurrentScope(token) else { return }
       searchResults = displayCacheMemories(results, for: token)
@@ -773,7 +793,8 @@ class MemoriesViewModel: ObservableObject {
           try await MemoryStorage.shared.getLocalMemories(
             limit: self.pageSize,
             offset: 0,
-            tiers: tokenTiers
+            tiers: tokenTiers,
+            includeExplicitLifecycleRows: self.includeExplicitLifecycleRows(for: token)
           )
         }
         group.addTask {
@@ -845,7 +866,8 @@ class MemoriesViewModel: ObservableObject {
           displayMemories = try await MemoryStorage.shared.getLocalMemories(
             limit: pageSize,
             offset: 0,
-            tiers: layers(for: token)
+            tiers: layers(for: token),
+            includeExplicitLifecycleRows: includeExplicitLifecycleRows(for: token)
           )
         }
         guard isCurrentScope(token) else {
@@ -1046,7 +1068,8 @@ class MemoriesViewModel: ObservableObject {
       let moreFromCache = try await MemoryStorage.shared.getLocalMemories(
         limit: pageSize,
         offset: requestedOffset,
-        tiers: layers(for: token)
+        tiers: layers(for: token),
+        includeExplicitLifecycleRows: includeExplicitLifecycleRows(for: token)
       )
 
       guard isCurrentScope(token), currentOffset == requestedOffset else { return }

--- a/desktop/macos/Desktop/Sources/Rewind/Core/MemoryStorage.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/MemoryStorage.swift
@@ -45,6 +45,13 @@ actor MemoryStorage {
         return query.filter(tiers.map { $0.rawValue }.contains(Column("tier")))
     }
 
+    private static func applyLifecycleExposureFilter(
+        _ query: QueryInterfaceRequest<MemoryRecord>,
+        includeExplicitLifecycleRows: Bool
+    ) -> QueryInterfaceRequest<MemoryRecord> {
+        includeExplicitLifecycleRows ? query : query.filter(Column("tierIsExplicit") == false)
+    }
+
     private static func appendTierCondition(_ conditions: inout [String], _ arguments: inout [DatabaseValue], tiers: [MemoryLayer]?) {
         guard let tiers = tiers, !tiers.isEmpty else { return }
         let placeholders = tiers.map { _ in "?" }.joined(separator: ", ")
@@ -66,6 +73,7 @@ actor MemoryStorage {
         category: String? = nil,
         tags: [String]? = nil,
         tiers: [MemoryLayer]? = [.shortTerm, .longTerm],
+        includeExplicitLifecycleRows: Bool = true,
         includeDismissed: Bool = false
     ) async throws -> [ServerMemory] {
         let db = try await ensureInitialized()
@@ -84,6 +92,10 @@ actor MemoryStorage {
             }
 
             query = Self.applyTierFilter(query, tiers: tiers)
+            query = Self.applyLifecycleExposureFilter(
+                query,
+                includeExplicitLifecycleRows: includeExplicitLifecycleRows
+            )
 
             // Tag filtering using JSON
             if let tags = tags, !tags.isEmpty {
@@ -107,6 +119,7 @@ actor MemoryStorage {
         category: String? = nil,
         tags: [String]? = nil,
         tiers: [MemoryLayer]? = [.shortTerm, .longTerm],
+        includeExplicitLifecycleRows: Bool = true,
         includeDismissed: Bool = false
     ) async throws -> Int {
         let db = try await ensureInitialized()
@@ -125,6 +138,10 @@ actor MemoryStorage {
             }
 
             query = Self.applyTierFilter(query, tiers: tiers)
+            query = Self.applyLifecycleExposureFilter(
+                query,
+                includeExplicitLifecycleRows: includeExplicitLifecycleRows
+            )
 
             if let tags = tags, !tags.isEmpty {
                 for tag in tags {
@@ -145,6 +162,7 @@ actor MemoryStorage {
         matchAnyCategory: [String]? = nil, // OR logic: matches any of these categories
         excludeTags: [String]? = nil,      // Exclude memories containing these tags
         tiers: [MemoryLayer]? = [.shortTerm, .longTerm],
+        includeExplicitLifecycleRows: Bool = true,
         includeDismissed: Bool = false
     ) async throws -> [ServerMemory] {
         let db = try await ensureInitialized()
@@ -159,6 +177,9 @@ actor MemoryStorage {
             }
 
             Self.appendTierCondition(&conditions, &arguments, tiers: tiers)
+            if !includeExplicitLifecycleRows {
+                conditions.append("tierIsExplicit = 0")
+            }
 
             // Tag OR conditions
             if let tags = matchAnyTag, !tags.isEmpty {
@@ -219,6 +240,7 @@ actor MemoryStorage {
         category: String? = nil,
         tags: [String]? = nil,
         tiers: [MemoryLayer]? = [.shortTerm, .longTerm],
+        includeExplicitLifecycleRows: Bool = true,
         includeDismissed: Bool = false
     ) async throws -> [ServerMemory] {
         let db = try await ensureInitialized()
@@ -241,6 +263,10 @@ actor MemoryStorage {
             }
 
             query = Self.applyTierFilter(query, tiers: tiers)
+            query = Self.applyLifecycleExposureFilter(
+                query,
+                includeExplicitLifecycleRows: includeExplicitLifecycleRows
+            )
 
             if let tags = tags, !tags.isEmpty {
                 for tag in tags {

--- a/desktop/macos/Desktop/Tests/MemoryAuthoritativeTierSyncTests.swift
+++ b/desktop/macos/Desktop/Tests/MemoryAuthoritativeTierSyncTests.swift
@@ -109,6 +109,57 @@ final class MemoryAuthoritativeTierSyncTests: XCTestCase {
         XCTAssertEqual(record?.tierIsExplicit, false)
     }
 
+    func testLocalReadsCanExcludeCanonicalLifecycleRowsWhenServerDoesNotExposeLifecycle() async throws {
+        let legacy = makeMemory(
+            id: "legacy-visible",
+            tier: .longTerm,
+            tierIsExplicit: false,
+            updatedAt: Date(timeIntervalSince1970: 1_000)
+        )
+        let shortTerm = makeMemory(
+            id: "canonical-short-hidden",
+            tier: .shortTerm,
+            tierIsExplicit: true,
+            updatedAt: Date(timeIntervalSince1970: 1_100)
+        )
+        let longTerm = makeMemory(
+            id: "canonical-long-hidden",
+            tier: .longTerm,
+            tierIsExplicit: true,
+            updatedAt: Date(timeIntervalSince1970: 1_200)
+        )
+        try await MemoryStorage.shared.syncServerMemories([legacy, shortTerm, longTerm])
+
+        let local = try await MemoryStorage.shared.getLocalMemories(
+            limit: 10,
+            tiers: nil,
+            includeExplicitLifecycleRows: false
+        )
+        XCTAssertEqual(local.map(\.id), ["legacy-visible"])
+
+        let count = try await MemoryStorage.shared.getLocalMemoriesCount(
+            tiers: nil,
+            includeExplicitLifecycleRows: false
+        )
+        XCTAssertEqual(count, 1)
+
+        let filtered = try await MemoryStorage.shared.getFilteredMemories(
+            limit: 10,
+            matchAnyCategory: ["system"],
+            tiers: nil,
+            includeExplicitLifecycleRows: false
+        )
+        XCTAssertEqual(filtered.map(\.id), ["legacy-visible"])
+
+        let search = try await MemoryStorage.shared.searchLocalMemories(
+            query: "Memory",
+            limit: 10,
+            tiers: nil,
+            includeExplicitLifecycleRows: false
+        )
+        XCTAssertEqual(search.map(\.id), ["legacy-visible"])
+    }
+
     private func corruptLocalTier(
         backendId: String,
         tier: String,

--- a/desktop/macos/Desktop/Tests/MemoryLayerFilterTests.swift
+++ b/desktop/macos/Desktop/Tests/MemoryLayerFilterTests.swift
@@ -103,6 +103,14 @@ final class MemoryLayerFilterTests: XCTestCase {
         XCTAssertFalse(hidden.tierIsExplicit)
     }
 
+    func testNonCanonicalDisplayExcludesLifecycleExplicitRows() throws {
+        let source = try memoriesPageSource()
+
+        XCTAssertTrue(source.contains("includeExplicitLifecycleRows(for: token)"))
+        XCTAssertTrue(source.contains("lifecycleExposed ? values : values.filter { !$0.tierIsExplicit }"))
+        XCTAssertFalse(source.contains("lifecycleExposed ? values : values.map { $0.hidingLifecycleExposure() }"))
+    }
+
     func testMemoriesPageCommitsPageCapabilitiesThroughSingleFreshnessHelper() throws {
         let source = try memoriesPageSource()
 

--- a/desktop/macos/changelog/unreleased/fix-memory-lifecycle-whitelist-leak.json
+++ b/desktop/macos/changelog/unreleased/fix-memory-lifecycle-whitelist-leak.json
@@ -1,0 +1,5 @@
+{
+  "changes": [
+    "Fixed cached short-term memories appearing in the desktop Memories UI before the account is enabled for the new memory lifecycle."
+  ]
+}


### PR DESCRIPTION
## Summary
- Fix desktop Memories cache reads so lifecycle-explicit cached rows are hidden unless the backend exposes canonical lifecycle for the current user.
- Apply the same gate to local cache display, pagination, counts, tag filters, and search.
- Add SQLite-backed coverage for excluding cached canonical rows when the server does not expose lifecycle.

## Root cause
The backend correctly sends `X-Omi-Memory-Canonical-Lifecycle-Exposed: false` for users outside the canonical memory whitelist, but the desktop Memories page loaded local SQLite before/around the API capability update. Cached short-term rows had `tierIsExplicit = true`; the UI only stripped the lifecycle badge by mapping them to legacy-looking long-term rows, so the content still appeared.

## Verification
- `cd desktop/macos && xcrun swift test --package-path Desktop --filter MemoryLayerFilterTests --filter APIClientMemoryLifecycleHeaderTests --filter MemoryAuthoritativeTierSyncTests`
- Pre-push hook against `origin/main` passed, including desktop changelog validation and desktop Swift build.

## Notes
- Initial push to `fork` was blocked because `fork/main` is stale and the hook compared against unrelated backend changes; the branch was pushed to `origin` so pre-push used the actual PR base.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9090?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

