### PR TITLE
fix(desktop): handle disk-full file indexing failures

### DIFF
--- a/desktop/macos/Desktop/Sources/DefaultsKey.swift
+++ b/desktop/macos/Desktop/Sources/DefaultsKey.swift
@@ -28,6 +28,7 @@ enum DefaultsKey: String {
     case authIsImpersonating = "auth_isImpersonating"
     case chatBridgeMode = "chatBridgeMode"
     case onboardingStep = "onboardingStep"
+    case hasCompletedFileIndexing = "hasCompletedFileIndexing"
 }
 
 /// Typed accessors that take a `DefaultsKey` instead of a `String`.

--- a/desktop/macos/Desktop/Sources/FileIndexing/FileIndexerService.swift
+++ b/desktop/macos/Desktop/Sources/FileIndexing/FileIndexerService.swift
@@ -1,3 +1,4 @@
+import Darwin
 import Foundation
 import GRDB
 
@@ -77,7 +78,13 @@ actor FileIndexerService {
         let foldersToScan = scanPolicy.standardScanRoots(homeURL: home)
 
         // 1. Scan files
-        let totalFiles = await scanFolders(foldersToScan)
+        let scanResult = await scanFolders(foldersToScan)
+        if let failure = scanResult.failure {
+            log("FileIndexer: Onboarding scan failed after \(scanResult.indexedCount) files: \(failure.logMessage)")
+            return
+        }
+
+        let totalFiles = scanResult.indexedCount
         guard totalFiles > 0 else {
             log("FileIndexer: No files found, skipping")
             await MainActor.run {
@@ -125,22 +132,26 @@ actor FileIndexerService {
         let home = FileManager.default.homeDirectoryForCurrentUser
         let folders = scanPolicy.standardScanRoots(homeURL: home)
 
-        let count = await scanFolders(folders, incremental: true)
-        log("FileIndexer: Background rescan complete, \(count) files indexed")
+        let scanResult = await scanFolders(folders, incremental: true)
+        if let failure = scanResult.failure {
+            log("FileIndexer: Background rescan failed after \(scanResult.indexedCount) files: \(failure.logMessage)")
+            return
+        }
+        log("FileIndexer: Background rescan complete, \(scanResult.indexedCount) files indexed")
     }
 
     // MARK: - File Scanning
 
     /// Scan folders and store file metadata in indexed_files table
-    /// Returns total number of files indexed
+    /// Returns the number of files indexed, plus a failure when the local index could not be saved.
     @discardableResult
-    func scanFolders(_ folders: [URL], incremental: Bool = false) async -> Int {
+    func scanFolders(_ folders: [URL], incremental: Bool = false) async -> FileIndexingScanResult {
         let db: DatabasePool
         do {
             db = try await ensureDB()
         } catch {
             log("FileIndexer: DB init failed: \(error.localizedDescription)")
-            return 0
+            return FileIndexingScanResult(indexedCount: 0, failure: FileIndexingFailure.classify(error))
         }
 
         // For incremental scans, load existing index for O(1) lookup
@@ -167,7 +178,7 @@ actor FileIndexerService {
             let folderName = folder.lastPathComponent
             log("FileIndexer: Scanning ~/\(folderName)")
 
-            scanDirectory(
+            if let failure = scanDirectory(
                 url: folder,
                 folderName: folderName,
                 homePath: home,
@@ -179,20 +190,32 @@ actor FileIndexerService {
                 db: db,
                 existingIndex: existingIndex,
                 scannedPaths: &scannedPaths
-            )
+            ) {
+                return FileIndexingScanResult(indexedCount: totalFiles, failure: failure)
+            }
         }
 
         // Flush remaining batch
         if !batch.isEmpty {
-            insertBatch(batch, into: db)
+            let insertedCount = batch.count
+            if let failure = insertBatch(batch, into: db) {
+                return FileIndexingScanResult(indexedCount: totalFiles, failure: failure)
+            }
+            totalFiles += insertedCount
         }
 
         // For incremental scans, remove files that no longer exist on disk
         if incremental && !existingIndex.isEmpty {
-            deleteRemovedFiles(scannedPaths: scannedPaths, existingPaths: Set(existingIndex.keys), db: db)
+            if let failure = deleteRemovedFiles(
+                scannedPaths: scannedPaths,
+                existingPaths: Set(existingIndex.keys),
+                db: db
+            ) {
+                return FileIndexingScanResult(indexedCount: totalFiles, failure: failure)
+            }
         }
 
-        return totalFiles
+        return FileIndexingScanResult(indexedCount: totalFiles)
     }
 
     private func scanDirectory(
@@ -207,8 +230,8 @@ actor FileIndexerService {
         db: DatabasePool,
         existingIndex: [String: Date?],
         scannedPaths: inout Set<String>
-    ) {
-        guard scanPolicy.shouldScanDirectory(atDepth: depth) else { return }
+    ) -> FileIndexingFailure? {
+        guard scanPolicy.shouldScanDirectory(atDepth: depth) else { return nil }
 
         let contents: [URL]
         do {
@@ -219,7 +242,7 @@ actor FileIndexerService {
             )
         } catch {
             log("FileIndexer: Cannot read \(url.lastPathComponent): \(error.localizedDescription)")
-            return
+            return nil
         }
 
         for item in contents {
@@ -251,14 +274,17 @@ actor FileIndexerService {
                         continue
                     }
                     batch.append(record)
-                    totalFiles += 1
                     if batch.count >= batchSize {
-                        insertBatch(batch, into: db)
+                        let insertedCount = batch.count
+                        if let failure = insertBatch(batch, into: db) {
+                            return failure
+                        }
+                        totalFiles += insertedCount
                         batch.removeAll(keepingCapacity: true)
                     }
                     continue
                 case .descend:
-                    scanDirectory(
+                    if let failure = scanDirectory(
                         url: item,
                         folderName: folderName,
                         homePath: homePath,
@@ -270,7 +296,9 @@ actor FileIndexerService {
                         db: db,
                         existingIndex: existingIndex,
                         scannedPaths: &scannedPaths
-                    )
+                    ) {
+                        return failure
+                    }
                     continue
                 }
             }
@@ -299,16 +327,21 @@ actor FileIndexerService {
             }
 
             batch.append(record)
-            totalFiles += 1
 
             if batch.count >= batchSize {
-                insertBatch(batch, into: db)
+                let insertedCount = batch.count
+                if let failure = insertBatch(batch, into: db) {
+                    return failure
+                }
+                totalFiles += insertedCount
                 batch.removeAll(keepingCapacity: true)
             }
         }
+
+        return nil
     }
 
-    private func insertBatch(_ records: [IndexedFileRecord], into db: DatabasePool) {
+    private func insertBatch(_ records: [IndexedFileRecord], into db: DatabasePool) -> FileIndexingFailure? {
         do {
             try db.write { database in
                 for record in records {
@@ -330,8 +363,11 @@ actor FileIndexerService {
                     )
                 }
             }
+            return nil
         } catch {
-            log("FileIndexer: Batch insert error: \(error.localizedDescription)")
+            let failure = FileIndexingFailure.classify(error)
+            log("FileIndexer: Batch insert error (\(failure.logMessage)): \(error.localizedDescription)")
+            return failure
         }
     }
 
@@ -357,9 +393,13 @@ actor FileIndexerService {
     }
 
     /// Delete files from the index that no longer exist on disk
-    private func deleteRemovedFiles(scannedPaths: Set<String>, existingPaths: Set<String>, db: DatabasePool) {
+    private func deleteRemovedFiles(
+        scannedPaths: Set<String>,
+        existingPaths: Set<String>,
+        db: DatabasePool
+    ) -> FileIndexingFailure? {
         let removed = existingPaths.subtracting(scannedPaths)
-        guard !removed.isEmpty else { return }
+        guard !removed.isEmpty else { return nil }
 
         log("FileIndexer: Removing \(removed.count) deleted files from index")
 
@@ -377,10 +417,13 @@ actor FileIndexerService {
                     )
                 }
             } catch {
-                log("FileIndexer: Batch delete error: \(error.localizedDescription)")
+                let failure = FileIndexingFailure.classify(error)
+                log("FileIndexer: Batch delete error (\(failure.logMessage)): \(error.localizedDescription)")
+                return failure
             }
             offset = end
         }
+        return nil
     }
 
     // MARK: - Summary Generation
@@ -534,6 +577,69 @@ actor FileIndexerService {
 }
 
 // MARK: - Errors
+
+struct FileIndexingScanResult: Equatable {
+    let indexedCount: Int
+    let failure: FileIndexingFailure?
+
+    init(indexedCount: Int, failure: FileIndexingFailure? = nil) {
+        self.indexedCount = indexedCount
+        self.failure = failure
+    }
+}
+
+enum FileIndexingFailure: Error, Equatable, LocalizedError {
+    case diskFull
+    case localWriteFailed
+
+    static func classify(_ error: Error) -> FileIndexingFailure {
+        if isDiskFull(error) {
+            return .diskFull
+        }
+        return .localWriteFailed
+    }
+
+    var userMessage: String {
+        switch self {
+        case .diskFull:
+            return "Mac storage is full. Free up space and try again."
+        case .localWriteFailed:
+            return "Omi couldn't save the file index. Try again."
+        }
+    }
+
+    var toolErrorMessage: String {
+        "Error: \(userMessage)"
+    }
+
+    var logMessage: String {
+        switch self {
+        case .diskFull:
+            return "disk full"
+        case .localWriteFailed:
+            return "local file index write failed"
+        }
+    }
+
+    var errorDescription: String? {
+        userMessage
+    }
+
+    private static func isDiskFull(_ error: Error) -> Bool {
+        if let dbError = error as? DatabaseError {
+            return dbError.resultCode == .SQLITE_FULL
+        }
+
+        let nsError = error as NSError
+        if nsError.domain == NSPOSIXErrorDomain && nsError.code == Int(ENOSPC) {
+            return true
+        }
+        if let underlying = nsError.userInfo[NSUnderlyingErrorKey] as? Error {
+            return isDiskFull(underlying)
+        }
+        return false
+    }
+}
 
 enum FileIndexerError: LocalizedError {
     case databaseNotInitialized

--- a/desktop/macos/Desktop/Sources/FileIndexing/FileIndexerService.swift
+++ b/desktop/macos/Desktop/Sources/FileIndexing/FileIndexerService.swift
@@ -118,10 +118,11 @@ actor FileIndexerService {
 
     /// Incremental background re-scan of all standard folders.
     /// Updates metadata for existing files and adds new ones.
-    func backgroundRescan() async {
+    @discardableResult
+    func backgroundRescan() async -> FileIndexingScanResult? {
         guard !isScanning else {
             log("FileIndexer: Scan already in progress, skipping background rescan")
-            return
+            return nil
         }
 
         isScanning = true
@@ -135,9 +136,10 @@ actor FileIndexerService {
         let scanResult = await scanFolders(folders, incremental: true)
         if let failure = scanResult.failure {
             log("FileIndexer: Background rescan failed after \(scanResult.indexedCount) files: \(failure.logMessage)")
-            return
+            return scanResult
         }
         log("FileIndexer: Background rescan complete, \(scanResult.indexedCount) files indexed")
+        return scanResult
     }
 
     // MARK: - File Scanning

--- a/desktop/macos/Desktop/Sources/FileIndexing/FileIndexerService.swift
+++ b/desktop/macos/Desktop/Sources/FileIndexing/FileIndexerService.swift
@@ -153,7 +153,7 @@ actor FileIndexerService {
             db = try await ensureDB()
         } catch {
             log("FileIndexer: DB init failed: \(error.localizedDescription)")
-            return FileIndexingScanResult(indexedCount: 0, failure: FileIndexingFailure.classify(error))
+            return FileIndexingScanResult(indexedCount: 0, failure: FileIndexingFailure.classifyInitializationFailure(error))
         }
 
         // For incremental scans, load existing index for O(1) lookup
@@ -592,6 +592,7 @@ struct FileIndexingScanResult: Equatable {
 
 enum FileIndexingFailure: Error, Equatable, LocalizedError {
     case diskFull
+    case localIndexUnavailable
     case localWriteFailed
 
     static func classify(_ error: Error) -> FileIndexingFailure {
@@ -601,10 +602,19 @@ enum FileIndexingFailure: Error, Equatable, LocalizedError {
         return .localWriteFailed
     }
 
+    static func classifyInitializationFailure(_ error: Error) -> FileIndexingFailure {
+        if isDiskFull(error) {
+            return .diskFull
+        }
+        return .localIndexUnavailable
+    }
+
     var userMessage: String {
         switch self {
         case .diskFull:
             return "Mac storage is full. Free up space and try again."
+        case .localIndexUnavailable:
+            return "Omi couldn't open the file index. Try again."
         case .localWriteFailed:
             return "Omi couldn't save the file index. Try again."
         }
@@ -618,6 +628,8 @@ enum FileIndexingFailure: Error, Equatable, LocalizedError {
         switch self {
         case .diskFull:
             return "disk full"
+        case .localIndexUnavailable:
+            return "local file index unavailable"
         case .localWriteFailed:
             return "local file index write failed"
         }

--- a/desktop/macos/Desktop/Sources/FileIndexing/FileIndexingView.swift
+++ b/desktop/macos/Desktop/Sources/FileIndexing/FileIndexingView.swift
@@ -18,6 +18,7 @@ struct FileIndexingView: View {
     @State private var chatMessages: [String] = []
     @State private var pipelineStarted = false
     @State private var scanFailed = false
+    @State private var pipelineTask: Task<Void, Never>?
 
     @StateObject private var graphViewModel = MemoryGraphViewModel()
 
@@ -269,6 +270,7 @@ struct FileIndexingView: View {
     // MARK: - Pipeline
 
     private func startLoadingPipeline() {
+        pipelineTask?.cancel()
         totalFilesScanned = 0
         progress = 0.0
         scanFailed = false
@@ -277,21 +279,25 @@ struct FileIndexingView: View {
         // when onboarding completes mid-pipeline
         UserDefaults.standard.set(true, forKey: "hasCompletedFileIndexing")
 
-        Task {
+        pipelineTask = Task {
             // Stage 1: File Scanning (0% → 60%)
             let scanSucceeded = await runFileScanning()
+            guard !Task.isCancelled else { return }
             guard scanSucceeded else {
                 await MainActor.run {
                     UserDefaults.standard.set(false, forKey: "hasCompletedFileIndexing")
+                    pipelineTask = nil
                 }
                 return
             }
 
             // Stage 2: AI Exploration (60% → 90%)
             await runAIExploration()
+            guard !Task.isCancelled else { return }
 
             // Stage 3: Knowledge Graph Build (90% → 100%)
             await runKnowledgeGraphBuild()
+            guard !Task.isCancelled else { return }
 
             // Transition to brain map
             await MainActor.run {
@@ -299,6 +305,7 @@ struct FileIndexingView: View {
                     phase = .brainMap
                     isBrainMapPhase?.wrappedValue = true
                 }
+                pipelineTask = nil
             }
         }
     }
@@ -307,6 +314,7 @@ struct FileIndexingView: View {
     private func runFileScanning() async -> Bool {
         // Check if files were already indexed (e.g., during onboarding chat via scan_files tool)
         let existingCount = await FileIndexerService.shared.getIndexedFileCount()
+        guard !Task.isCancelled else { return false }
         if existingCount > 0 {
             log("FileIndexingView: Skipping file scan — \(existingCount) files already indexed")
             await MainActor.run {
@@ -344,6 +352,7 @@ struct FileIndexingView: View {
                 scanningFolder = name
             }
             let scanResult = await FileIndexerService.shared.scanFolders([url])
+            guard !Task.isCancelled else { return false }
             if let failure = scanResult.failure {
                 await showScanFailure(failure)
                 return false
@@ -357,6 +366,7 @@ struct FileIndexingView: View {
 
         // Also index installed app names from /Applications
         let appScanResult = await scanApplicationNames()
+        guard !Task.isCancelled else { return false }
         if let failure = appScanResult.failure {
             await showScanFailure(failure)
             return false
@@ -498,6 +508,9 @@ struct FileIndexingView: View {
         var count = 0
         for dir in appDirs {
             let scanResult = await FileIndexerService.shared.scanFolders([dir])
+            guard !Task.isCancelled else {
+                return FileIndexingScanResult(indexedCount: count + scanResult.indexedCount)
+            }
             if let failure = scanResult.failure {
                 return FileIndexingScanResult(
                     indexedCount: count + scanResult.indexedCount,
@@ -626,6 +639,8 @@ struct FileIndexingView: View {
 
     private func skip() {
         log("FileIndexingView: User skipped file indexing")
+        pipelineTask?.cancel()
+        pipelineTask = nil
         UserDefaults.standard.set(true, forKey: "hasCompletedFileIndexing")
         onComplete(0)
     }

--- a/desktop/macos/Desktop/Sources/FileIndexing/FileIndexingView.swift
+++ b/desktop/macos/Desktop/Sources/FileIndexing/FileIndexingView.swift
@@ -285,7 +285,7 @@ struct FileIndexingView: View {
             guard !Task.isCancelled else { return }
             guard scanSucceeded else {
                 await MainActor.run {
-                    UserDefaults.standard.set(false, forKey: "hasCompletedFileIndexing")
+                    UserDefaults.standard.set(false, forKey: .hasCompletedFileIndexing)
                     pipelineTask = nil
                 }
                 return

--- a/desktop/macos/Desktop/Sources/FileIndexing/FileIndexingView.swift
+++ b/desktop/macos/Desktop/Sources/FileIndexing/FileIndexingView.swift
@@ -17,6 +17,7 @@ struct FileIndexingView: View {
     @State private var showInfoPopover: Bool = false
     @State private var chatMessages: [String] = []
     @State private var pipelineStarted = false
+    @State private var scanFailed = false
 
     @StateObject private var graphViewModel = MemoryGraphViewModel()
 
@@ -63,7 +64,9 @@ struct FileIndexingView: View {
                 .padding(.bottom, 6)
 
             // Subtitle — folder being scanned or general message
-            if !scanningFolder.isEmpty {
+            if scanFailed {
+                EmptyView()
+            } else if !scanningFolder.isEmpty {
                 Text("Scanning ~/\(scanningFolder)" + (totalFilesScanned > 0 ? " · \(totalFilesScanned.formatted()) files found" : ""))
                     .scaledFont(size: 13)
                     .foregroundColor(OmiColors.textTertiary)
@@ -268,6 +271,7 @@ struct FileIndexingView: View {
     private func startLoadingPipeline() {
         totalFilesScanned = 0
         progress = 0.0
+        scanFailed = false
 
         // Set flag immediately so DesktopHomeView won't spawn a duplicate sheet
         // when onboarding completes mid-pipeline
@@ -275,7 +279,13 @@ struct FileIndexingView: View {
 
         Task {
             // Stage 1: File Scanning (0% → 60%)
-            await runFileScanning()
+            let scanSucceeded = await runFileScanning()
+            guard scanSucceeded else {
+                await MainActor.run {
+                    UserDefaults.standard.set(false, forKey: "hasCompletedFileIndexing")
+                }
+                return
+            }
 
             // Stage 2: AI Exploration (60% → 90%)
             await runAIExploration()
@@ -294,7 +304,7 @@ struct FileIndexingView: View {
     }
 
     /// Stage 1: Scan folders, progress 0% → 60%
-    private func runFileScanning() async {
+    private func runFileScanning() async -> Bool {
         // Check if files were already indexed (e.g., during onboarding chat via scan_files tool)
         let existingCount = await FileIndexerService.shared.getIndexedFileCount()
         if existingCount > 0 {
@@ -304,7 +314,7 @@ struct FileIndexingView: View {
                 progress = 0.6
                 statusText = "Analyzing your files..."
             }
-            return
+            return true
         }
 
         await MainActor.run {
@@ -333,21 +343,30 @@ struct FileIndexingView: View {
             await MainActor.run {
                 scanningFolder = name
             }
-            let count = await FileIndexerService.shared.scanFolders([url])
+            let scanResult = await FileIndexerService.shared.scanFolders([url])
+            if let failure = scanResult.failure {
+                await showScanFailure(failure)
+                return false
+            }
             completedFolders += 1
             await MainActor.run {
-                totalFilesScanned += count
+                totalFilesScanned += scanResult.indexedCount
                 progress = Double(completedFolders) / Double(folderCount) * 0.6
             }
         }
 
         // Also index installed app names from /Applications
-        let appCount = await scanApplicationNames()
+        let appScanResult = await scanApplicationNames()
+        if let failure = appScanResult.failure {
+            await showScanFailure(failure)
+            return false
+        }
         await MainActor.run {
-            totalFilesScanned += appCount
+            totalFilesScanned += appScanResult.indexedCount
             progress = 0.6
             scanningFolder = ""
         }
+        return true
     }
 
     /// Stage 2: AI exploration chat in background, progress 60% → 90%
@@ -465,7 +484,7 @@ struct FileIndexingView: View {
     // MARK: - Helpers
 
     /// Scan /Applications and ~/Applications for app names
-    private func scanApplicationNames() async -> Int {
+    private func scanApplicationNames() async -> FileIndexingScanResult {
         await MainActor.run {
             scanningFolder = "Applications"
         }
@@ -478,10 +497,25 @@ struct FileIndexingView: View {
 
         var count = 0
         for dir in appDirs {
-            let scanned = await FileIndexerService.shared.scanFolders([dir])
-            count += scanned
+            let scanResult = await FileIndexerService.shared.scanFolders([dir])
+            if let failure = scanResult.failure {
+                return FileIndexingScanResult(
+                    indexedCount: count + scanResult.indexedCount,
+                    failure: failure
+                )
+            }
+            count += scanResult.indexedCount
         }
-        return count
+        return FileIndexingScanResult(indexedCount: count)
+    }
+
+    private func showScanFailure(_ failure: FileIndexingFailure) async {
+        log("FileIndexingView: File scan failed: \(failure.logMessage)")
+        await MainActor.run {
+            scanFailed = true
+            statusText = failure.userMessage
+            scanningFolder = ""
+        }
     }
 
     /// Send the exploration prompt to the chat

--- a/desktop/macos/Desktop/Sources/Logger.swift
+++ b/desktop/macos/Desktop/Sources/Logger.swift
@@ -117,6 +117,8 @@ private func writeToStandardError(_ message: String) {
 
 enum LocalLogFileWriteError: Error, Equatable, CustomStringConvertible {
   case openFailed(errno: Int32)
+  case statFailed(errno: Int32)
+  case unsafeFile
   case writeFailed(errno: Int32)
   case closeFailed(errno: Int32)
 
@@ -124,6 +126,10 @@ enum LocalLogFileWriteError: Error, Equatable, CustomStringConvertible {
     switch self {
     case .openFailed(let code):
       return "open failed: \(Self.message(for: code))"
+    case .statFailed(let code):
+      return "stat failed: \(Self.message(for: code))"
+    case .unsafeFile:
+      return "unsafe log file"
     case .writeFailed(let code):
       return "write failed: \(Self.message(for: code))"
     case .closeFailed(let code):
@@ -138,9 +144,15 @@ enum LocalLogFileWriteError: Error, Equatable, CustomStringConvertible {
 
 enum LocalLogFileWriter {
   static func append(_ data: Data, to path: String) -> Result<Void, LocalLogFileWriteError> {
-    let fd = open(path, O_WRONLY | O_CREAT | O_APPEND | O_CLOEXEC, S_IRUSR | S_IWUSR)
+    let flags = O_WRONLY | O_CREAT | O_APPEND | O_CLOEXEC | O_NOFOLLOW | O_NONBLOCK
+    let fd = open(path, flags, S_IRUSR | S_IWUSR)
     guard fd >= 0 else {
       return .failure(.openFailed(errno: errno))
+    }
+
+    if let validationFailure = validateOpenedFile(fd) {
+      close(fd)
+      return .failure(validationFailure)
     }
 
     let writeFailure = data.withUnsafeBytes { rawBuffer -> LocalLogFileWriteError? in
@@ -170,6 +182,21 @@ enum LocalLogFileWriter {
       return .failure(.closeFailed(errno: errno))
     }
     return .success(())
+  }
+
+  private static func validateOpenedFile(_ fd: Int32) -> LocalLogFileWriteError? {
+    var fileStat = stat()
+    guard fstat(fd, &fileStat) == 0 else {
+      return .statFailed(errno: errno)
+    }
+
+    let isRegularFile = (fileStat.st_mode & S_IFMT) == S_IFREG
+    let isOwnedByCurrentUser = fileStat.st_uid == geteuid()
+    let hasSingleLink = fileStat.st_nlink == 1
+    guard isRegularFile, isOwnedByCurrentUser, hasSingleLink else {
+      return .unsafeFile
+    }
+    return nil
   }
 }
 

--- a/desktop/macos/Desktop/Sources/Logger.swift
+++ b/desktop/macos/Desktop/Sources/Logger.swift
@@ -1,3 +1,4 @@
+import Darwin
 import Foundation
 import Sentry
 
@@ -11,6 +12,8 @@ private let logFile: String = {
 func omiLogFilePath() -> String { logFile }
 
 private let logQueue = DispatchQueue(label: "me.omi.logger", qos: .utility)
+private let logFileFailureCooldown: TimeInterval = 60
+private var lastLogFileFailure: Date?
 private let dateFormatter: DateFormatter = {
   let formatter = DateFormatter()
   formatter.dateFormat = "HH:mm:ss.SSS"  // Added milliseconds for perf tracking
@@ -77,16 +80,96 @@ private func writeToLogFile(_ data: Data) {
     // the log permanently world-readable.
     didEnsureLogFilePermissions = ensureLogFileOwnerOnly(atPath: logFile)
   }
-  if FileManager.default.fileExists(atPath: logFile) {
-    if let handle = FileHandle(forWritingAtPath: logFile) {
-      handle.seekToEndOfFile()
-      handle.write(data)
-      handle.closeFile()
+  switch LocalLogFileWriter.append(data, to: logFile) {
+  case .success:
+    return
+  case .failure(let error):
+    reportLogFileFailure(error)
+  }
+}
+
+private func reportLogFileFailure(_ error: LocalLogFileWriteError) {
+  let now = Date()
+  if let lastLogFileFailure, now.timeIntervalSince(lastLogFileFailure) < logFileFailureCooldown {
+    return
+  }
+  lastLogFileFailure = now
+  writeToStandardError("[logger] failed to append \(logFile): \(error.description)\n")
+}
+
+private func writeToStandardError(_ message: String) {
+  message.withCString { buffer in
+    var remaining = strlen(buffer)
+    var pointer = UnsafeRawPointer(buffer)
+    while remaining > 0 {
+      let written = Darwin.write(STDERR_FILENO, pointer, remaining)
+      if written > 0 {
+        pointer = pointer.advanced(by: written)
+        remaining -= written
+      } else if written == -1 && errno == EINTR {
+        continue
+      } else {
+        return
+      }
     }
-  } else {
-    // Recreate owner-only if the file was removed mid-session.
-    FileManager.default.createFile(
-      atPath: logFile, contents: data, attributes: [.posixPermissions: 0o600])
+  }
+}
+
+enum LocalLogFileWriteError: Error, Equatable, CustomStringConvertible {
+  case openFailed(errno: Int32)
+  case writeFailed(errno: Int32)
+  case closeFailed(errno: Int32)
+
+  var description: String {
+    switch self {
+    case .openFailed(let code):
+      return "open failed: \(Self.message(for: code))"
+    case .writeFailed(let code):
+      return "write failed: \(Self.message(for: code))"
+    case .closeFailed(let code):
+      return "close failed: \(Self.message(for: code))"
+    }
+  }
+
+  private static func message(for code: Int32) -> String {
+    String(cString: strerror(code))
+  }
+}
+
+enum LocalLogFileWriter {
+  static func append(_ data: Data, to path: String) -> Result<Void, LocalLogFileWriteError> {
+    let fd = open(path, O_WRONLY | O_CREAT | O_APPEND | O_CLOEXEC, S_IRUSR | S_IWUSR)
+    guard fd >= 0 else {
+      return .failure(.openFailed(errno: errno))
+    }
+
+    let writeFailure = data.withUnsafeBytes { rawBuffer -> LocalLogFileWriteError? in
+      guard let baseAddress = rawBuffer.baseAddress else { return nil }
+      var pointer = baseAddress
+      var remaining = rawBuffer.count
+
+      while remaining > 0 {
+        let written = Darwin.write(fd, pointer, remaining)
+        if written > 0 {
+          pointer = pointer.advanced(by: written)
+          remaining -= written
+        } else if written == -1 && errno == EINTR {
+          continue
+        } else {
+          return .writeFailed(errno: errno)
+        }
+      }
+      return nil
+    }
+
+    let closeStatus = close(fd)
+    if let writeFailure {
+      return .failure(writeFailure)
+    }
+    guard closeStatus == 0 else {
+      return .failure(.closeFailed(errno: errno))
+    }
+    return .success(())
   }
 }
 

--- a/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
@@ -754,7 +754,7 @@ struct DesktopHomeView: View {
       onCancel: { initialFileIndexingBackfill.releaseReservation() }
     ) {
       log("DesktopHomeView: Running delayed background file scan for existing user")
-      await FileIndexerService.shared.backgroundRescan()
+      let scanResult = await FileIndexerService.shared.backgroundRescan()
       guard !Task.isCancelled,
             sessionScope.matches(
               currentUserId: UserDefaults.standard.string(forKey: "auth_userId"),
@@ -763,11 +763,16 @@ struct DesktopHomeView: View {
         initialFileIndexingBackfill.releaseReservation()
         return
       }
-      initialFileIndexingBackfill.markScanCompleted()
+      let scanSucceeded = scanResult.map { $0.failure == nil } ?? false
+      initialFileIndexingBackfill.finishScan(succeeded: scanSucceeded)
       if initialFileIndexingBackfill.shouldMarkComplete {
         UserDefaults.standard.set(true, forKey: "hasCompletedFileIndexing")
         log(
           "DesktopHomeView: Marked existing-user file indexing backfill complete after background scan returned"
+        )
+      } else {
+        log(
+          "DesktopHomeView: Existing-user file indexing backfill did not complete successfully; leaving completion flag unset"
         )
       }
     }

--- a/desktop/macos/Desktop/Sources/Providers/ChatToolExecutor.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatToolExecutor.swift
@@ -1232,7 +1232,9 @@ class ChatToolExecutor {
   private static func executeScanFiles(_: [String: Any]) async -> String {
     let outcome = await scanLocalFiles()
     fileScanFileCount = outcome.indexedFileCount
-    onScanFilesCompleted?(outcome.indexedFileCount)
+    if outcome.didCompleteSuccessfully {
+      onScanFilesCompleted?(outcome.indexedFileCount)
+    }
     return outcome.summaryText
   }
 
@@ -1305,7 +1307,20 @@ class ChatToolExecutor {
     }
 
     // Actually scan accessible folders (blocking)
-    let count = await FileIndexerService.shared.scanFolders(accessibleFolders)
+    let scanResult = await FileIndexerService.shared.scanFolders(accessibleFolders)
+    if let failure = scanResult.failure {
+      log(
+        "Onboarding file scan failed after \(scanResult.indexedCount) files indexed, \(deniedFolders.count) folders denied: \(failure.logMessage)"
+      )
+      return LocalFileScanOutcome(
+        hasReadableUserFileTarget: readableUserFileTargetCount > 0,
+        didCompleteSuccessfully: false,
+        indexedFileCount: scanResult.indexedCount,
+        summaryText: failure.toolErrorMessage
+      )
+    }
+
+    let count = scanResult.indexedCount
     log(
       "Onboarding file scan completed: \(count) files indexed, \(deniedFolders.count) folders denied"
     )

--- a/desktop/macos/Desktop/Sources/Startup/StartupWarmupPolicy.swift
+++ b/desktop/macos/Desktop/Sources/Startup/StartupWarmupPolicy.swift
@@ -72,9 +72,9 @@ struct DelayedFileIndexingBackfillState {
         return true
     }
 
-    mutating func markScanCompleted() {
+    mutating func finishScan(succeeded: Bool) {
         isScheduled = false
-        shouldMarkComplete = true
+        shouldMarkComplete = succeeded
     }
 
     mutating func releaseReservation() {

--- a/desktop/macos/Desktop/Tests/FileIndexerServiceTests.swift
+++ b/desktop/macos/Desktop/Tests/FileIndexerServiceTests.swift
@@ -70,9 +70,10 @@ final class FileIndexerServiceTests: XCTestCase {
     let policy = FileIndexScanPolicy(maxDepth: 1, maxFileSize: 12)
     let service = FileIndexerService(databasePool: databasePool, scanPolicy: policy, batchSize: 2)
 
-    let firstCount = await service.scanFolders([root])
+    let firstScanResult = await service.scanFolders([root])
 
-    XCTAssertEqual(firstCount, 4)
+    XCTAssertEqual(firstScanResult.indexedCount, 4)
+    XCTAssertNil(firstScanResult.failure)
     var records = try fetchIndexedRecords()
     XCTAssertEqual(records.map(\.filename).sorted(), ["Example.app", "main.py", "remove.txt", "root.md"])
     XCTAssertEqual(records.first(where: { $0.filename == "Example.app" })?.fileType, "application")
@@ -91,9 +92,10 @@ final class FileIndexerServiceTests: XCTestCase {
     try FileManager.default.removeItem(at: deletedLater)
     _ = try writeFile("new", at: root.appendingPathComponent("new.csv"))
 
-    let secondCount = await service.scanFolders([root], incremental: true)
+    let secondScanResult = await service.scanFolders([root], incremental: true)
 
-    XCTAssertEqual(secondCount, 1)
+    XCTAssertEqual(secondScanResult.indexedCount, 1)
+    XCTAssertNil(secondScanResult.failure)
     records = try fetchIndexedRecords()
     XCTAssertEqual(records.map(\.filename).sorted(), ["Example.app", "main.py", "new.csv", "root.md"])
     XCTAssertNil(records.first { $0.filename == deletedFilename })

--- a/desktop/macos/Desktop/Tests/FileIndexingFailureTests.swift
+++ b/desktop/macos/Desktop/Tests/FileIndexingFailureTests.swift
@@ -29,10 +29,31 @@ final class FileIndexingFailureTests: XCTestCase {
         XCTAssertEqual(FileIndexingFailure.classify(error), .localWriteFailed)
     }
 
+    func testClassifiesInitializationFailureSeparatelyFromWriteFailure() {
+        XCTAssertEqual(
+            FileIndexingFailure.classifyInitializationFailure(FileIndexerError.databaseNotInitialized),
+            .localIndexUnavailable
+        )
+    }
+
+    func testClassifiesInitializationDiskFullAsDiskFull() {
+        let error = NSError(
+            domain: NSCocoaErrorDomain,
+            code: NSFileWriteUnknownError,
+            userInfo: [NSUnderlyingErrorKey: NSError(domain: NSPOSIXErrorDomain, code: Int(ENOSPC))]
+        )
+
+        XCTAssertEqual(FileIndexingFailure.classifyInitializationFailure(error), .diskFull)
+    }
+
     func testUserFacingMessagesAreShortAndActionable() {
         XCTAssertEqual(
             FileIndexingFailure.diskFull.toolErrorMessage,
             "Error: Mac storage is full. Free up space and try again."
+        )
+        XCTAssertEqual(
+            FileIndexingFailure.localIndexUnavailable.toolErrorMessage,
+            "Error: Omi couldn't open the file index. Try again."
         )
         XCTAssertEqual(
             FileIndexingFailure.localWriteFailed.toolErrorMessage,

--- a/desktop/macos/Desktop/Tests/FileIndexingFailureTests.swift
+++ b/desktop/macos/Desktop/Tests/FileIndexingFailureTests.swift
@@ -1,0 +1,42 @@
+import Darwin
+import GRDB
+import XCTest
+
+@testable import Omi_Computer
+
+final class FileIndexingFailureTests: XCTestCase {
+    func testClassifiesSQLiteFullAsDiskFull() {
+        let error = DatabaseError(resultCode: .SQLITE_FULL, message: "database or disk is full")
+
+        XCTAssertEqual(FileIndexingFailure.classify(error), .diskFull)
+    }
+
+    func testClassifiesPOSIXNoSpaceAsDiskFull() {
+        let error = NSError(domain: NSPOSIXErrorDomain, code: Int(ENOSPC))
+
+        XCTAssertEqual(FileIndexingFailure.classify(error), .diskFull)
+    }
+
+    func testDoesNotClassifyGenericSQLiteIOAsDiskFull() {
+        let error = DatabaseError(resultCode: .SQLITE_IOERR, message: "disk I/O error")
+
+        XCTAssertEqual(FileIndexingFailure.classify(error), .localWriteFailed)
+    }
+
+    func testDoesNotClassifyGenericPOSIXIOAsDiskFull() {
+        let error = NSError(domain: NSPOSIXErrorDomain, code: Int(EIO))
+
+        XCTAssertEqual(FileIndexingFailure.classify(error), .localWriteFailed)
+    }
+
+    func testUserFacingMessagesAreShortAndActionable() {
+        XCTAssertEqual(
+            FileIndexingFailure.diskFull.toolErrorMessage,
+            "Error: Mac storage is full. Free up space and try again."
+        )
+        XCTAssertEqual(
+            FileIndexingFailure.localWriteFailed.toolErrorMessage,
+            "Error: Omi couldn't save the file index. Try again."
+        )
+    }
+}

--- a/desktop/macos/Desktop/Tests/FileIndexingViewPipelineTests.swift
+++ b/desktop/macos/Desktop/Tests/FileIndexingViewPipelineTests.swift
@@ -30,7 +30,7 @@ final class FileIndexingViewPipelineTests: XCTestCase {
                 of: "guard !Task.isCancelled else { return }",
                 range: scanRange.lowerBound..<source.endIndex),
             let resetRange = source.range(
-                of: "UserDefaults.standard.set(false, forKey: \"hasCompletedFileIndexing\")",
+                of: "UserDefaults.standard.set(false, forKey: .hasCompletedFileIndexing)",
                 range: scanRange.lowerBound..<source.endIndex)
         else {
             return XCTFail("Failed scans must not reset completion after pipeline cancellation")

--- a/desktop/macos/Desktop/Tests/FileIndexingViewPipelineTests.swift
+++ b/desktop/macos/Desktop/Tests/FileIndexingViewPipelineTests.swift
@@ -1,0 +1,49 @@
+import XCTest
+
+final class FileIndexingViewPipelineTests: XCTestCase {
+    func testSkipCancelsPipelineBeforeMarkingFileIndexingComplete() throws {
+        let source = try fileIndexingViewSource()
+        guard let skipRange = source.range(of: "private func skip()") else {
+            return XCTFail("FileIndexingView.skip() must exist")
+        }
+        guard
+            let cancelRange = source.range(
+                of: "pipelineTask?.cancel()",
+                range: skipRange.lowerBound..<source.endIndex),
+            let markCompleteRange = source.range(
+                of: "UserDefaults.standard.set(true, forKey: \"hasCompletedFileIndexing\")",
+                range: skipRange.lowerBound..<source.endIndex)
+        else {
+            return XCTFail("Skip must cancel the pipeline and preserve the completion flag")
+        }
+
+        XCTAssertLessThan(cancelRange.lowerBound, markCompleteRange.lowerBound)
+    }
+
+    func testFileScanFailureResetIgnoresCancelledPipeline() throws {
+        let source = try fileIndexingViewSource()
+        guard let scanRange = source.range(of: "let scanSucceeded = await runFileScanning()") else {
+            return XCTFail("FileIndexingView must await the file scan result")
+        }
+        guard
+            let cancellationGuardRange = source.range(
+                of: "guard !Task.isCancelled else { return }",
+                range: scanRange.lowerBound..<source.endIndex),
+            let resetRange = source.range(
+                of: "UserDefaults.standard.set(false, forKey: \"hasCompletedFileIndexing\")",
+                range: scanRange.lowerBound..<source.endIndex)
+        else {
+            return XCTFail("Failed scans must not reset completion after pipeline cancellation")
+        }
+
+        XCTAssertLessThan(cancellationGuardRange.lowerBound, resetRange.lowerBound)
+    }
+
+    private func fileIndexingViewSource() throws -> String {
+        let testsURL = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
+        let sourceURL = testsURL
+            .deletingLastPathComponent()
+            .appendingPathComponent("Sources/FileIndexing/FileIndexingView.swift")
+        return try String(contentsOf: sourceURL, encoding: .utf8)
+    }
+}

--- a/desktop/macos/Desktop/Tests/LocalLogFileWriterTests.swift
+++ b/desktop/macos/Desktop/Tests/LocalLogFileWriterTests.swift
@@ -1,3 +1,4 @@
+import Darwin
 import XCTest
 
 @testable import Omi_Computer
@@ -19,6 +20,7 @@ final class LocalLogFileWriterTests: XCTestCase {
 
     let contents = try String(contentsOf: logFile, encoding: .utf8)
     XCTAssertEqual(contents, "first\nsecond\n")
+    XCTAssertEqual(try posixPermissions(of: logFile.path), 0o600)
   }
 
   func testAppendFailureReturnsErrorInsteadOfRaisingException() throws {
@@ -32,6 +34,38 @@ final class LocalLogFileWriterTests: XCTestCase {
       return XCTFail("Appending to a directory should fail")
     }
 
-    XCTAssertTrue(error.description.contains("failed"))
+    guard case .openFailed = error else {
+      return XCTFail("Expected open failure, got \(error)")
+    }
+  }
+
+  func testAppendRejectsSymlinkDestination() throws {
+    let directory = FileManager.default.temporaryDirectory
+      .appendingPathComponent("omi-log-writer-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: directory) }
+
+    let target = directory.appendingPathComponent("target.log")
+    try "original\n".write(to: target, atomically: true, encoding: .utf8)
+
+    let symlink = directory.appendingPathComponent("omi.log")
+    try FileManager.default.createSymbolicLink(at: symlink, withDestinationURL: target)
+
+    let result = LocalLogFileWriter.append(Data("line\n".utf8), to: symlink.path)
+    guard case .failure(let error) = result else {
+      return XCTFail("Appending to a symlink should fail")
+    }
+
+    guard case .openFailed(let code) = error else {
+      return XCTFail("Expected open failure, got \(error)")
+    }
+    XCTAssertEqual(code, ELOOP)
+    XCTAssertEqual(try String(contentsOf: target, encoding: .utf8), "original\n")
+  }
+
+  private func posixPermissions(of path: String) throws -> Int {
+    let attributes = try FileManager.default.attributesOfItem(atPath: path)
+    let number = try XCTUnwrap(attributes[.posixPermissions] as? NSNumber)
+    return number.intValue
   }
 }

--- a/desktop/macos/Desktop/Tests/LocalLogFileWriterTests.swift
+++ b/desktop/macos/Desktop/Tests/LocalLogFileWriterTests.swift
@@ -1,0 +1,37 @@
+import XCTest
+
+@testable import Omi_Computer
+
+final class LocalLogFileWriterTests: XCTestCase {
+  func testAppendCreatesAndAppendsToFile() throws {
+    let directory = FileManager.default.temporaryDirectory
+      .appendingPathComponent("omi-log-writer-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: directory) }
+
+    let logFile = directory.appendingPathComponent("omi.log")
+    guard case .success = LocalLogFileWriter.append(Data("first\n".utf8), to: logFile.path) else {
+      return XCTFail("Expected first append to succeed")
+    }
+    guard case .success = LocalLogFileWriter.append(Data("second\n".utf8), to: logFile.path) else {
+      return XCTFail("Expected second append to succeed")
+    }
+
+    let contents = try String(contentsOf: logFile, encoding: .utf8)
+    XCTAssertEqual(contents, "first\nsecond\n")
+  }
+
+  func testAppendFailureReturnsErrorInsteadOfRaisingException() throws {
+    let directory = FileManager.default.temporaryDirectory
+      .appendingPathComponent("omi-log-writer-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: directory) }
+
+    let result = LocalLogFileWriter.append(Data("line\n".utf8), to: directory.path)
+    guard case .failure(let error) = result else {
+      return XCTFail("Appending to a directory should fail")
+    }
+
+    XCTAssertTrue(error.description.contains("failed"))
+  }
+}

--- a/desktop/macos/Desktop/Tests/StartupWarmupPolicyTests.swift
+++ b/desktop/macos/Desktop/Tests/StartupWarmupPolicyTests.swift
@@ -238,16 +238,27 @@ final class StartupWarmupPolicyTests: XCTestCase {
         XCTAssertTrue(gate.reserve())
     }
 
-    func testFileIndexingBackfillMarksCompleteOnlyAfterScanCompletes() {
+    func testFileIndexingBackfillMarksCompleteOnlyAfterSuccessfulScan() {
         var backfill = DelayedFileIndexingBackfillState()
 
         XCTAssertTrue(backfill.reserveIfNeeded(hasCompletedBackfill: false))
         XCTAssertFalse(backfill.shouldMarkComplete)
 
-        backfill.markScanCompleted()
+        backfill.finishScan(succeeded: true)
 
         XCTAssertTrue(backfill.shouldMarkComplete)
         XCTAssertFalse(backfill.reserveIfNeeded(hasCompletedBackfill: true))
+    }
+
+    func testFileIndexingBackfillDoesNotMarkCompleteAfterFailedScan() {
+        var backfill = DelayedFileIndexingBackfillState()
+
+        XCTAssertTrue(backfill.reserveIfNeeded(hasCompletedBackfill: false))
+
+        backfill.finishScan(succeeded: false)
+
+        XCTAssertFalse(backfill.shouldMarkComplete)
+        XCTAssertTrue(backfill.reserveIfNeeded(hasCompletedBackfill: false))
     }
 
     func testFileIndexingBackfillCanRescheduleAfterReservationRelease() {
@@ -260,6 +271,25 @@ final class StartupWarmupPolicyTests: XCTestCase {
 
         XCTAssertFalse(backfill.shouldMarkComplete)
         XCTAssertTrue(backfill.reserveIfNeeded(hasCompletedBackfill: false))
+    }
+
+    func testInitialFileIndexingBackfillUsesBackgroundScanResultBeforeMarkingComplete() throws {
+        let testsURL = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
+        let homeViewURL = testsURL
+            .deletingLastPathComponent()
+            .appendingPathComponent("Sources/MainWindow/DesktopHomeView.swift")
+        let source = try String(contentsOf: homeViewURL, encoding: .utf8)
+
+        guard
+            let scanRange = source.range(of: "let scanResult = await FileIndexerService.shared.backgroundRescan()"),
+            let successRange = source.range(of: "let scanSucceeded = scanResult.map { $0.failure == nil } ?? false"),
+            let finishRange = source.range(of: "initialFileIndexingBackfill.finishScan(succeeded: scanSucceeded)")
+        else {
+            return XCTFail("Initial file indexing backfill must gate completion on the background scan result")
+        }
+
+        XCTAssertLessThan(scanRange.lowerBound, successRange.lowerBound)
+        XCTAssertLessThan(successRange.lowerBound, finishRange.lowerBound)
     }
 
     func testSessionScopeRejectsSignedOutAndMismatchedUsers() {

--- a/desktop/macos/changelog/unreleased/20260705-file-indexing-storage-full.json
+++ b/desktop/macos/changelog/unreleased/20260705-file-indexing-storage-full.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed local file scans crashing or appearing complete when Mac storage is full"
+}

--- a/desktop/macos/e2e/flows/file-indexing.yaml
+++ b/desktop/macos/e2e/flows/file-indexing.yaml
@@ -1,0 +1,36 @@
+version: 2
+name: file-indexing
+tier: 1
+description: File indexing startup and onboarding flow — verify the desktop home surface can run file-indexing backfill without crashing or leaving stale pipeline state
+app: non-prod
+covers:
+  - desktop/macos/Desktop/Sources/DefaultsKey.swift
+  - desktop/macos/Desktop/Sources/FileIndexing/FileIndexerService.swift
+  - desktop/macos/Desktop/Sources/FileIndexing/FileIndexingView.swift
+  - desktop/macos/Desktop/Sources/Logger.swift
+  - desktop/macos/Desktop/Sources/Providers/ChatToolExecutor.swift
+  - desktop/macos/Desktop/Sources/Startup/StartupWarmupPolicy.swift
+preconditions:
+  - automation_bridge_ready
+
+steps:
+  - id: S1
+    name: Navigate to Dashboard
+    bridge.navigate:
+      target: dashboard
+      activateApp: false
+    wait:
+      state.selectedTabIndex: 0
+
+  - id: S2
+    name: Assert Dashboard State
+    state.expect:
+      state.selectedTabIndex: 0
+
+  - id: S3
+    name: Assert File Indexing Logs Are Clean
+    log.expect:
+      absent:
+        - "FileIndexer: Batch insert error"
+        - "FileIndexer: Batch delete error"
+        - "FileIndexingView: File scan failed"


### PR DESCRIPTION
## Summary
- Replace crash-prone log file writes with a low-level append path that returns errors instead of raising Objective-C exceptions.
- Surface file-index storage failures as explicit scan failures, including a specific disk-full message for SQLite `SQLITE_FULL` and POSIX `ENOSPC`.
- Keep onboarding/background file-indexing follow-up work gated on successful scans so failed writes do not mark file indexing complete or start downstream exploration.

## Why
When local storage is full, file indexing and log appends can fail while the desktop app is scanning local files. The previous paths either relied on APIs that can raise during file writes or treated failed indexing as if it completed, which could crash the app or leave stale completion state.

## Testing
- `git diff --check upstream/main...HEAD`
- `xcrun swift test --package-path Desktop --filter 'FileIndexingFailureTests|LocalLogFileWriterTests|StartupWarmupPolicyTests'`
- `rm -rf Desktop/.build && xcrun swift build -c release --package-path Desktop --triple arm64-apple-macosx`
- pre-push hook: desktop changelog validation, desktop Swift build, and fast guardrail checks passed


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9091?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

