### PR TITLE
test(backend/updates): pin desktop appcast 2-component tag parsing (regression for #5285)

### DIFF
--- a/backend/tests/unit/test_desktop_updates.py
+++ b/backend/tests/unit/test_desktop_updates.py
@@ -77,6 +77,45 @@ class TestParseDesktopVersion:
         assert result["version"] == "11.3.0+11003"
         assert result["build"] == "11003"
 
+    # --- Regression anchor for issue #5285 ---
+    #
+    # https://github.com/BasedHardware/omi/issues/5285 — the appcast endpoint
+    # silently dropped newer 2-component release tags (e.g. ``v11.0+11000-macos``)
+    # because the patch group was mandatory, breaking desktop auto-updates. The
+    # fix made the patch component optional (defaulting to "0"). These cases pin
+    # that behavior so the regex can never regress to requiring a patch component
+    # while still accepting the legacy 3-component form.
+    @pytest.mark.parametrize(
+        "tag, expected_version, expected_patch",
+        [
+            # The exact 2-component tags called out in issue #5285 (patch omitted).
+            ("v11.0+11000-macos", "11.0.0+11000", "0"),
+            ("v11.3+11003-macos", "11.3.0+11003", "0"),
+            # The legacy 3-component form must keep parsing (guard vs. over-correction).
+            ("v1.0.77+464-desktop-cm", "1.0.77+464", "77"),
+        ],
+    )
+    def test_issue_5285_supported_tags_parse(self, tag, expected_version, expected_patch):
+        result = _parse_desktop_version(tag)
+        assert result is not None, f"expected {tag!r} to parse (issue #5285)"
+        assert result["version"] == expected_version
+        assert result["patch"] == expected_patch
+
+    @pytest.mark.parametrize(
+        "tag",
+        [
+            "v11+11000-macos",  # missing minor component
+            "v11.0-macos",  # missing +build component
+            "v11.0+11000",  # missing platform suffix
+            "v11.0+11000-ios",  # unsupported platform
+            "not-a-version",
+            "",
+        ],
+    )
+    def test_issue_5285_malformed_tags_return_none(self, tag):
+        # Making patch optional must not loosen the rest of the grammar.
+        assert _parse_desktop_version(tag) is None
+
 
 # --- _parse_changelog_to_changes ---
 


### PR DESCRIPTION
## Summary

Adds an **issue-anchored regression test** locking the desktop appcast version-parse grammar (`_parse_desktop_version` in `backend/routers/updates.py`) so it can never silently drop newer 2-component release tags again (issue #5285).

The underlying fix is **already on `main`** — the regex makes the patch component optional (`^v?(\d+)\.(\d+)(?:\.(\d+))?\+(\d+)-(?:desktop|macos|windows|linux)(?:-(?:cm|auto))?$`, docstring cites `v11.0+11000-macos`). This PR is **test-only, no product change**.

## What

- Parametrized test for the exact 2-component tags called out in #5285 (`v11.0+11000-macos` → `11.0.0+11000`, patch `"0"`; the `-cm` variant) and a 3-component control.
- Malformed-grammar guards (missing `+build`, missing platform suffix, unsupported platform) → `None`.

## Verification

- `test_desktop_updates.py` → **73 passed** (+9 new); `TestParseDesktopVersion` 17/17.
- **Negative control:** temporarily reverting `updates.py` to the old mandatory-patch regex makes the two 2-component cases FAIL (3-component still passes), then restored — proving the anchor catches the exact #5285 regression, not a vacuous pass.

## Recommendation

Close **#5285** as already-resolved once this lands.

_No changelog fragment (backend, not desktop user-facing)._


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9092?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

