### PR TITLE
fix(desktop): stop startup notification repair loop (#9082)

### DIFF
--- a/desktop/macos/Desktop/Sources/NotificationRegistrationRepair.swift
+++ b/desktop/macos/Desktop/Sources/NotificationRegistrationRepair.swift
@@ -3,6 +3,7 @@ import UserNotifications
 
 enum NotificationRegistrationRepair {
   static let repairedVersionKey = "notificationRegistrationRepairedAppVersion"
+  static let startupRepairAttemptedVersionKey = "notificationStartupRepairAttemptedAppVersion"
 
   private static var isRepairing = false
   private static var pendingCompletions: [(Bool) -> Void] = []
@@ -26,6 +27,24 @@ enum NotificationRegistrationRepair {
     versionIdentifier: String = currentVersionIdentifier()
   ) {
     defaults.set(versionIdentifier, forKey: repairedVersionKey)
+  }
+
+  /// Whether the non-user-initiated startup path may attempt a launch-services
+  /// notification repair. Users stuck in the launch-disabled + notDetermined state
+  /// would otherwise re-run lsregister + killall usernoted/NotificationCenter on
+  /// every launch/wake; gate that attempt to once per installed app version.
+  static func shouldAttemptStartupRepair(
+    defaults: UserDefaults = .standard,
+    versionIdentifier: String = currentVersionIdentifier()
+  ) -> Bool {
+    defaults.string(forKey: startupRepairAttemptedVersionKey) != versionIdentifier
+  }
+
+  static func markStartupRepairAttempted(
+    defaults: UserDefaults = .standard,
+    versionIdentifier: String = currentVersionIdentifier()
+  ) {
+    defaults.set(versionIdentifier, forKey: startupRepairAttemptedVersionKey)
   }
 
   @MainActor

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift
@@ -265,6 +265,17 @@ public class ProactiveAssistantsPlugin: NSObject {
                     return
                 }
 
+                // Only attempt the launch-services repair-capable authorization once per
+                // app version on this non-user-initiated path. Otherwise users stuck in the
+                // launch-disabled + notDetermined state re-run lsregister + killall
+                // usernoted/NotificationCenter on every launch/wake (issue #9082). The
+                // user-initiated "Fix" flows and onboarding prompt remain unaffected.
+                guard NotificationRegistrationRepair.shouldAttemptStartupRepair() else {
+                    log("Skipping startup notification repair — already attempted for this app version")
+                    return
+                }
+                NotificationRegistrationRepair.markStartupRepairAttempted()
+
                 NotificationRegistrationRepair.requestAuthorizationRepairingLaunchServices(
                     reason: "launch_disabled_error_startup",
                     previousStatus: "notDetermined"

--- a/desktop/macos/Desktop/Tests/NotificationRegistrationRepairTests.swift
+++ b/desktop/macos/Desktop/Tests/NotificationRegistrationRepairTests.swift
@@ -32,4 +32,51 @@ final class NotificationRegistrationRepairTests: XCTestCase {
       )
     )
   }
+
+  func testStartupRepairAttemptedOnlyOncePerInstalledVersion() {
+    let defaults = UserDefaults(suiteName: "NotificationRegistrationRepairTests")!
+    defaults.removePersistentDomain(forName: "NotificationRegistrationRepairTests")
+
+    XCTAssertTrue(
+      NotificationRegistrationRepair.shouldAttemptStartupRepair(
+        defaults: defaults,
+        versionIdentifier: "0.12.0+12000"
+      )
+    )
+
+    NotificationRegistrationRepair.markStartupRepairAttempted(
+      defaults: defaults,
+      versionIdentifier: "0.12.0+12000"
+    )
+
+    XCTAssertFalse(
+      NotificationRegistrationRepair.shouldAttemptStartupRepair(
+        defaults: defaults,
+        versionIdentifier: "0.12.0+12000"
+      )
+    )
+    XCTAssertTrue(
+      NotificationRegistrationRepair.shouldAttemptStartupRepair(
+        defaults: defaults,
+        versionIdentifier: "0.12.1+12001"
+      )
+    )
+  }
+
+  func testStartupRepairGuardIsIndependentOfVersionRepairGuard() {
+    let defaults = UserDefaults(suiteName: "NotificationRegistrationRepairTests")!
+    defaults.removePersistentDomain(forName: "NotificationRegistrationRepairTests")
+
+    // Marking the startup attempt must not consume the version-repair guard, and vice versa.
+    NotificationRegistrationRepair.markStartupRepairAttempted(
+      defaults: defaults,
+      versionIdentifier: "0.12.0+12000"
+    )
+    XCTAssertTrue(
+      NotificationRegistrationRepair.shouldRepairForCurrentVersion(
+        defaults: defaults,
+        versionIdentifier: "0.12.0+12000"
+      )
+    )
+  }
 }

--- a/desktop/macos/changelog/unreleased/20260705-notification-repair-loop.json
+++ b/desktop/macos/changelog/unreleased/20260705-notification-repair-loop.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed a startup notification-permission repair that could re-run on every launch, repeatedly restarting macOS Notification Center"
+}


### PR DESCRIPTION
## Bug (#9082)

macOS telemetry shows hundreds of users repeatedly hitting `Notification Repair Triggered` with reason `launch_disabled_error_startup` across launches:

- `0.11.507`: **705 events / 366 users**
- `0.12.0`: **583 events / 341 users**

Event count far exceeds user count → the same users trigger it over and over.

## Root cause

`ProactiveAssistantsPlugin.startMonitoring` (a non-user-initiated path that runs on launch, app re-activation, key load, and wake) calls `NotificationRegistrationRepair.requestAuthorizationRepairingLaunchServices(reason: "launch_disabled_error_startup", …)` whenever notification auth is `.notDetermined`, with **no once-per-version guard**.

For a user stuck in the launch-disabled + `notDetermined` state, the authorization request returns `UNErrorDomain` code 1, which triggers the heavy repair every single time: `lsregister -u`/`-f`, `killall usernoted`, and `killall NotificationCenter`. That repeats on every launch/wake — the loop in the telemetry, and it churns the user's Notification Center repeatedly.

Other repair call sites are either user-initiated ("Fix" buttons, onboarding `requestNotificationPermission`) or one-shot (`OmiApp` startup already uses `repairOnceForCurrentVersion`); only this startup path was unguarded.

## Fix

Gate the startup repair attempt to **once per installed app version**, using a dedicated `shouldAttemptStartupRepair` / `markStartupRepairAttempted` guard that mirrors the existing `repairOnceForCurrentVersion` pattern. The guard uses its own UserDefaults key so it's independent of the `OmiApp` startup repair guard.

Unchanged: user-initiated "Fix" flows, the onboarding permission prompt, and the `auth_regression` auto-repair — those should still run on demand.

- `NotificationRegistrationRepair.swift`: add the startup-repair guard + key
- `ProactiveAssistantsPlugin.swift`: guard the startup call, skip + log if already attempted this version
- `NotificationRegistrationRepairTests.swift`: tests for the new guard + independence from the version-repair guard

Compile-checked (`xcrun swift build -c debug`, clean). Could not reproduce the live `UNErrorDomain` code-1 state locally, so the behavior change is verified by the added unit tests and the mirrored existing pattern.

🤖 automated by hourly watchdog; opened for review, not merged.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9095?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

