### PR TITLE
fix(desktop): fail loud on missing Firebase key + report real system-audio permission

### DIFF
--- a/desktop/macos/Desktop/Sources/AppState/AppState+SystemActions.swift
+++ b/desktop/macos/Desktop/Sources/AppState/AppState+SystemActions.swift
@@ -363,11 +363,23 @@ extension AppState {
     }
   }
 
-  /// Check system audio permission status
-  /// This checks if the test capture was successful (set by triggerSystemAudioPermission)
+  /// Check system audio permission status and update `hasSystemAudioPermission`.
+  ///
+  /// Core Audio process taps (macOS 14.4+) have no dedicated preflight API, but a
+  /// *global* tap that captures other apps' output is gated behind the same Screen
+  /// Recording TCC grant the rest of the app already checks — which is why a failed
+  /// test capture in `triggerSystemAudioPermission()` deep-links the user to
+  /// Privacy → Screen Recording. Previously this was a no-op (BL-020) that left the
+  /// flag reflecting only a prior successful test capture, so a revoked grant (or a
+  /// user who never ran onboarding's test) was never reflected. Mirror
+  /// `checkScreenRecordingPermission()` so the reported state tracks real TCC state.
   func checkSystemAudioPermission() {
-    // Permission is set by triggerSystemAudioPermission after successful test
-    // No-op here - we rely on the test result
+    guard #available(macOS 14.4, *) else {
+      hasSystemAudioPermission = false
+      return
+    }
+    hasSystemAudioPermission = ScreenRecordingPermissionPolicy.uiPermissionGranted(
+      tccGranted: ScreenCaptureService.checkPermission())
   }
 
   /// Trigger system audio permission by actually testing capture

--- a/desktop/macos/Desktop/Sources/AuthService.swift
+++ b/desktop/macos/Desktop/Sources/AuthService.swift
@@ -376,6 +376,24 @@ class AuthService {
         return ""
     }
 
+    /// Resolve the Firebase Web API key or fail loudly (BL-019).
+    ///
+    /// The key is provisioned asynchronously (APIKeyService fetches it from the
+    /// backend and `setenv`s it), so it can legitimately be absent right after a
+    /// cold launch — failing at launch would false-positive. Instead, fail at the
+    /// point of use: every identitytoolkit/securetoken request must resolve the key
+    /// through this helper so a missing/empty key surfaces as a clear, user-visible
+    /// `AuthError` instead of being interpolated into `?key=` and returning an
+    /// opaque HTTP 400 ("API key not valid") that looks like a generic auth failure.
+    private func requireFirebaseApiKey() throws -> String {
+        let key = firebaseApiKey
+        guard !key.isEmpty else {
+            log("AuthService: refusing to build an auth request without FIREBASE_API_KEY")
+            throw AuthError.missingFirebaseApiKey
+        }
+        return key
+    }
+
     // MARK: - User Name Properties
 
     /// Get the user's given name (first name)
@@ -470,10 +488,7 @@ class AuthService {
         guard let hostPort = DesktopLocalProfile.authEmulatorHost else {
             throw AuthError.invalidURL
         }
-        let apiKey = firebaseApiKey
-        guard !apiKey.isEmpty else {
-            throw AuthError.missingToken
-        }
+        let apiKey = try requireFirebaseApiKey()
         guard let url = URL(
             string: "http://\(hostPort)/identitytoolkit.googleapis.com/v1/accounts:signInWithPassword?key=\(apiKey)"
         ) else {
@@ -1196,6 +1211,7 @@ class AuthService {
         case .invalidCredential: return "invalid_credential"
         case .invalidNonce: return "invalid_nonce"
         case .missingToken: return "missing_token"
+        case .missingFirebaseApiKey: return "missing_firebase_api_key"
         case .notSignedIn: return "not_signed_in"
         case .invalidURL: return "invalid_url"
         case .stateMismatch: return "state_mismatch"
@@ -1645,7 +1661,8 @@ class AuthService {
 
     /// Exchange custom token for ID token using Firebase REST API
     private func exchangeCustomTokenForIdToken(customToken: String) async throws -> FirebaseTokenResult {
-        guard let url = URL(string: "https://identitytoolkit.googleapis.com/v1/accounts:signInWithCustomToken?key=\(firebaseApiKey)") else {
+        let apiKey = try requireFirebaseApiKey()
+        guard let url = URL(string: "https://identitytoolkit.googleapis.com/v1/accounts:signInWithCustomToken?key=\(apiKey)") else {
             throw AuthError.invalidURL
         }
 
@@ -1711,7 +1728,8 @@ class AuthService {
             throw AuthError.notSignedIn
         }
 
-        guard let url = URL(string: "https://securetoken.googleapis.com/v1/token?key=\(firebaseApiKey)") else {
+        let apiKey = try requireFirebaseApiKey()
+        guard let url = URL(string: "https://securetoken.googleapis.com/v1/token?key=\(apiKey)") else {
             throw AuthError.invalidURL
         }
 
@@ -2058,7 +2076,8 @@ class AuthService {
     /// Sign in with Firebase using an Apple identity token via REST API
     /// This bypasses the backend entirely - Firebase verifies the Apple JWT directly
     private func signInWithAppleIdentityToken(identityToken: String, nonce: String) async throws -> FirebaseTokenResult {
-        guard let url = URL(string: "https://identitytoolkit.googleapis.com/v1/accounts:signInWithIdp?key=\(firebaseApiKey)") else {
+        let apiKey = try requireFirebaseApiKey()
+        guard let url = URL(string: "https://identitytoolkit.googleapis.com/v1/accounts:signInWithIdp?key=\(apiKey)") else {
             throw AuthError.invalidURL
         }
 
@@ -2179,6 +2198,7 @@ enum AuthError: LocalizedError {
     case invalidCredential
     case invalidNonce
     case missingToken
+    case missingFirebaseApiKey
     case notSignedIn
     case invalidURL
     case stateMismatch
@@ -2199,6 +2219,8 @@ enum AuthError: LocalizedError {
             return "Invalid nonce - please try again"
         case .missingToken:
             return "Missing identity token from Apple"
+        case .missingFirebaseApiKey:
+            return "Sign-in is not ready yet (Firebase API key unavailable). Please check your connection and try again in a moment."
         case .notSignedIn:
             return "User is not signed in"
         case .invalidURL:

--- a/desktop/macos/Desktop/Tests/FailLoudConfigTests.swift
+++ b/desktop/macos/Desktop/Tests/FailLoudConfigTests.swift
@@ -1,0 +1,59 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// S-08 — Fail-loud config (BL-019, BL-020).
+/// Behavioral tests where the type is constructible; source-scrape guards
+/// (same pattern as `TranscriptionTransportTests`/`PTTAudioCaptureRaceTests`)
+/// for the private auth internals and the AppState permission path that can't
+/// be driven without a real signed-in session or a live TCC grant.
+final class FailLoudConfigTests: XCTestCase {
+
+  // MARK: BL-019 — empty firebaseApiKey must fail loud, not silently produce ""
+
+  /// A dedicated, user-visible error exists for the missing-key case (so the
+  /// failure surfaces as an actionable message instead of an opaque HTTP 400).
+  func testMissingFirebaseApiKeyErrorIsUserVisible() {
+    let message = AuthError.missingFirebaseApiKey.errorDescription
+    XCTAssertNotNil(message)
+    let lowered = (message ?? "").lowercased()
+    XCTAssertTrue(
+      lowered.contains("firebase") || lowered.contains("api key"),
+      "the missing-key error must name the cause; got: \(message ?? "nil")")
+  }
+
+  /// Every Firebase REST URL builder resolves the key through the throwing
+  /// `requireFirebaseApiKey()` helper — the raw `?key=\(firebaseApiKey)`
+  /// interpolation (which silently emits `?key=` when unset) must be gone.
+  func testFirebaseRequestsResolveKeyThroughThrowingHelper() throws {
+    let src = try source(relativePath: "Sources/AuthService.swift")
+
+    XCTAssertTrue(
+      src.contains("func requireFirebaseApiKey() throws -> String"),
+      "a throwing key accessor must exist")
+    XCTAssertTrue(
+      src.contains("throw AuthError.missingFirebaseApiKey"),
+      "the helper must fail loud on an empty/missing key")
+
+    // The silent path — interpolating the raw computed property straight into a
+    // request URL — must no longer exist at any call site.
+    XCTAssertFalse(
+      src.contains("?key=\\(firebaseApiKey)"),
+      "auth request URLs must use the guarded key (try requireFirebaseApiKey()), not the raw property")
+
+    // Each of the three Firebase endpoints must go through the helper.
+    XCTAssertTrue(src.contains("signInWithCustomToken?key=\\(apiKey)"))
+    XCTAssertTrue(src.contains("securetoken.googleapis.com/v1/token?key=\\(apiKey)"))
+    XCTAssertTrue(src.contains("signInWithIdp?key=\\(apiKey)"))
+  }
+
+  // MARK: Helper
+
+  private func source(relativePath: String) throws -> String {
+    let url = URL(fileURLWithPath: #filePath)
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+      .appendingPathComponent(relativePath)
+    return try String(contentsOf: url, encoding: .utf8)
+  }
+}

--- a/desktop/macos/Desktop/Tests/FailLoudConfigTests.swift
+++ b/desktop/macos/Desktop/Tests/FailLoudConfigTests.swift
@@ -47,6 +47,30 @@ final class FailLoudConfigTests: XCTestCase {
     XCTAssertTrue(src.contains("signInWithIdp?key=\\(apiKey)"))
   }
 
+  // MARK: BL-020 — checkSystemAudioPermission() must report the real state
+
+  /// The check is no longer a no-op: it must derive `hasSystemAudioPermission`
+  /// from the real screen-recording TCC preflight the rest of the app uses,
+  /// mirroring `checkScreenRecordingPermission()`.
+  func testCheckSystemAudioPermissionReadsRealTccState() throws {
+    let src = try source(relativePath: "Sources/AppState/AppState+SystemActions.swift")
+
+    guard let range = src.range(of: "func checkSystemAudioPermission() {") else {
+      return XCTFail("checkSystemAudioPermission not found")
+    }
+    let body = String(src[range.lowerBound...].prefix(600))
+
+    XCTAssertFalse(
+      body.contains("No-op"),
+      "checkSystemAudioPermission must no longer be a no-op")
+    XCTAssertTrue(
+      body.contains("hasSystemAudioPermission ="),
+      "it must actually assign the reported permission state")
+    XCTAssertTrue(
+      body.contains("ScreenCaptureService.checkPermission()"),
+      "it must query the real TCC preflight the rest of the app relies on")
+  }
+
   // MARK: Helper
 
   private func source(relativePath: String) throws -> String {

--- a/desktop/macos/changelog/unreleased/20260705-fail-loud-config.json
+++ b/desktop/macos/changelog/unreleased/20260705-fail-loud-config.json
@@ -1,0 +1,3 @@
+{
+  "change": "Sign-in now shows a clear, actionable message when Firebase configuration is briefly unavailable instead of failing opaquely, and the system-audio permission indicator now reflects your real macOS permission state"
+}


### PR DESCRIPTION
## Summary

Two desktop config paths failed silently; this makes both fail/report truthfully (smallest correct diff, no new UI, no launch-time failure):

- **Missing Firebase API key (BL-019 / AUTH-07):** `firebaseApiKey` fell back to `""`, so a missing key became a `?key=` request → opaque HTTP 400. Now a dedicated throwing `requireFirebaseApiKey()` guards it and throws a user-visible `AuthError.missingFirebaseApiKey` (telemetry code `missing_firebase_api_key`) at the point of use. All three Firebase REST call sites + the emulator path resolve the key through it. (Not a launch assert — the key is provisioned async post-launch, so a launch check would false-positive.)
- **System-audio permission no-op (BL-020 / PERM-05):** `checkSystemAudioPermission()` was a no-op echoing a prior value. It now derives `hasSystemAudioPermission` from the real Screen-Recording TCC state (`ScreenCaptureService.checkPermission()` → `CGPreflightScreenCaptureAccess`), macOS 14.4+ guarded — system-audio global taps are gated behind Screen Recording, mirroring the existing `checkScreenRecordingPermission()`.

## Tests

- New `FailLoudConfigTests` (3/3) + `xcrun swift build -c debug` exit 0.
- `bash test.sh` → **293 Rust + 127 Swift suites**, all green (independently re-run).

## Honest scope

- AUTH-07 / PERM-05: **PASS (static + unit)**. Full **runtime is BLOCKED** — end-to-end launch-with-key-unset and a live TCC grant/revoke cycle weren't exercised (no TCC mutation this session). These are the env/permission rows the acceptance matrix already flags for runtime.
- `hasSystemAudioPermission` has no gating readers today, so making it truthful can't regress runtime behavior.

## Changelog

`desktop/macos/changelog/unreleased/20260705-fail-loud-config.json`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9096?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

