### PR TITLE
fix(desktop): single-instance guard to prevent a second copy racing shared state

### DIFF
--- a/desktop/macos/Desktop/Sources/OmiApp.swift
+++ b/desktop/macos/Desktop/Sources/OmiApp.swift
@@ -240,6 +240,17 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
   private var didScheduleInitialSettingsSync = false
   private var initialSettingsSyncTask: Task<Void, Never>?
 
+  func applicationWillFinishLaunching(_ notification: Notification) {
+    // Single-instance guard: a second live copy of the same bundle id + launch mode
+    // would race the first against the shared Rewind SQLite DB
+    // (~/Library/Application Support/Omi/…) and the bundle-id UserDefaults domain,
+    // corrupting state. Enforce here — the earliest delegate callback — so a duplicate
+    // exits before any DB open or UserDefaults write in applicationDidFinishLaunching.
+    SingleInstanceGuard.enforceSingleInstanceOrExit(
+      launchMode: OMIApp.launchMode,
+      isExporting: ViewExporter.shouldExport())
+  }
+
   func applicationDidFinishLaunching(_ notification: Notification) {
     if ViewExporter.shouldExport() {
       ViewExporter.run()

--- a/desktop/macos/Desktop/Sources/SingleInstanceGuard.swift
+++ b/desktop/macos/Desktop/Sources/SingleInstanceGuard.swift
@@ -1,0 +1,186 @@
+import AppKit
+import Darwin
+import Foundation
+
+/// Prevents a second live copy of the app (same bundle id + launch mode) from
+/// running concurrently against the same on-disk state.
+///
+/// Why this matters: two live instances share `~/Library/Application Support/Omi/`
+/// (the Rewind SQLite DB and its `.omi_running` crash flag) and the `UserDefaults`
+/// domain keyed by the bundle id. A second instance racing the first can corrupt the
+/// database, clobber `lastSessionCleanExit` / auth state, and double-register global
+/// shortcuts. LaunchServices usually coalesces a double-click into the running app,
+/// but `open -n`, a launch from a second bundle path, a Sparkle relaunch race, or a
+/// stale Dock item can each spawn a true duplicate — this guard is the backstop.
+///
+/// Mechanism: a per-`(bundle id, launch mode)` advisory `flock`. The OS releases the
+/// lock automatically when the process dies, so a crashed instance never leaves a
+/// stale lock behind (unlike a PID file). Keying on the bundle id keeps parallel
+/// *named* dev/test bundles (`com.omi.omi-*`, `com.omi.desktop-dev`) independent of
+/// each other and of production. Keying on the launch mode keeps rewind-only mode
+/// (`--mode=rewind`) and the full app — which the rewind window intentionally spawns
+/// via `open -n` — from evicting one another.
+enum SingleInstanceGuard {
+  /// Held for the whole process lifetime once acquired; intentionally never closed.
+  /// The OS drops the `flock` when the process exits.
+  private static var lockFileDescriptor: Int32 = -1
+
+  /// If another instance for this `(bundle id, launch mode)` already holds the lock,
+  /// foreground it and exit **without** running the normal termination path.
+  ///
+  /// Call as early as possible in launch — before any database open or `UserDefaults`
+  /// write. On conflict this uses `exit(0)` rather than `NSApp.terminate(_:)` on
+  /// purpose: `applicationWillTerminate(_:)` writes the shared `lastSessionCleanExit`
+  /// flag and tears down the *live* instance's global hotkeys / push-to-talk, so a
+  /// duplicate must never run it.
+  ///
+  /// - Parameters:
+  ///   - launchMode: this process's launch mode (full vs rewind-only).
+  ///   - isExporting: whether this is a headless view-export run; such runs spawn
+  ///     short-lived same-bundle subprocesses on purpose and must be exempt.
+  static func enforceSingleInstanceOrExit(launchMode: LaunchMode, isExporting: Bool) {
+    guard !isExporting else { return }
+
+    let bundleID = AppBuild.bundleIdentifier
+    let path = lockFilePath(bundleID: bundleID, launchMode: launchMode)
+
+    switch acquireExclusiveLock(at: path) {
+    case .acquired(let descriptor):
+      lockFileDescriptor = descriptor  // hold for the process lifetime
+
+    case .heldByAnotherInstance:
+      log(
+        "SingleInstanceGuard: another \(bundleID) (\(launchMode.rawValue)) instance is already "
+          + "running — foregrounding it and exiting")
+      activateExistingInstance(
+        bundleID: bundleID,
+        ownerProcessIdentifier: lockOwnerProcessIdentifier(at: path))
+      exit(0)
+
+    case .failed(let code):
+      // Never block launch on a lock-infrastructure failure — fail open, just record it.
+      log(
+        "SingleInstanceGuard: could not acquire lock at \(path) (errno \(code)); "
+          + "continuing without the single-instance guard")
+    }
+  }
+
+  // MARK: - Pure helpers (unit-tested)
+
+  /// Deterministic lock-file path, unique per `(bundle id, launch mode)`.
+  ///
+  /// Placed in the per-user temporary directory: it is stable within a login session
+  /// and, unlike the app-support data dir, does not depend on the signed-in user id
+  /// (which is not yet known this early in launch).
+  static func lockFilePath(
+    bundleID: String,
+    launchMode: LaunchMode,
+    directory: String = NSTemporaryDirectory()
+  ) -> String {
+    let name = "omi-single-instance-\(sanitizeForFilename(bundleID))-\(launchMode.rawValue).lock"
+    return (directory as NSString).appendingPathComponent(name)
+  }
+
+  /// Collapse anything that is not a safe filename character to `_` so an unusual
+  /// bundle id can never escape the intended directory or break the path.
+  static func sanitizeForFilename(_ value: String) -> String {
+    let allowed = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: ".-_"))
+    let scalars = value.unicodeScalars.map { allowed.contains($0) ? Character($0) : "_" }
+    return String(scalars)
+  }
+
+  /// Result of attempting to take the single-instance lock.
+  enum LockResult: Equatable {
+    /// Lock acquired; the descriptor must be kept open for the process lifetime.
+    case acquired(fileDescriptor: Int32)
+    /// Another live instance already holds the lock.
+    case heldByAnotherInstance
+    /// The lock could not be evaluated (open/flock syscall failed); carries `errno`.
+    case failed(errno: Int32)
+  }
+
+  /// Try to take an exclusive, non-blocking advisory lock on `path`.
+  ///
+  /// Returns the open file descriptor on success (the caller keeps it alive),
+  /// `.heldByAnotherInstance` when another live process holds it, or `.failed` on any
+  /// other syscall error. Exposed for tests.
+  static func acquireExclusiveLock(at path: String) -> LockResult {
+    let descriptor = path.withCString { open($0, O_CREAT | O_RDWR, 0o600) }
+    guard descriptor >= 0 else { return .failed(errno: errno) }
+
+    guard setCloseOnExec(on: descriptor) else {
+      let flagErrno = errno
+      close(descriptor)
+      return .failed(errno: flagErrno)
+    }
+
+    if flock(descriptor, LOCK_EX | LOCK_NB) == 0 {
+      writeLockOwnerProcessIdentifier(ProcessInfo.processInfo.processIdentifier, to: descriptor)
+      return .acquired(fileDescriptor: descriptor)
+    }
+
+    let lockErrno = errno
+    close(descriptor)
+    if lockErrno == EWOULDBLOCK {
+      return .heldByAnotherInstance
+    }
+    return .failed(errno: lockErrno)
+  }
+
+  static func descriptorHasCloseOnExec(_ descriptor: Int32) -> Bool {
+    let flags = fcntl(descriptor, F_GETFD)
+    return flags >= 0 && (flags & FD_CLOEXEC) != 0
+  }
+
+  private static func setCloseOnExec(on descriptor: Int32) -> Bool {
+    let flags = fcntl(descriptor, F_GETFD)
+    guard flags >= 0 else { return false }
+    return fcntl(descriptor, F_SETFD, flags | FD_CLOEXEC) == 0
+  }
+
+  /// Read the PID written by the lock holder. The lock path is already scoped by
+  /// launch mode, so this identifies the same-mode process to foreground.
+  static func lockOwnerProcessIdentifier(at path: String) -> pid_t? {
+    guard
+      let contents = try? String(contentsOfFile: path, encoding: .utf8),
+      let firstLine = contents.split(whereSeparator: \.isNewline).first,
+      let pid = pid_t(String(firstLine))
+    else {
+      return nil
+    }
+    return pid
+  }
+
+  private static func writeLockOwnerProcessIdentifier(_ processIdentifier: pid_t, to descriptor: Int32) {
+    let contents = "\(processIdentifier)\n"
+    contents.withCString { pointer in
+      _ = ftruncate(descriptor, 0)
+      _ = lseek(descriptor, 0, SEEK_SET)
+      _ = Darwin.write(descriptor, pointer, strlen(pointer))
+    }
+  }
+
+  /// Release a held lock (test helper). Production keeps the descriptor open until the
+  /// process exits, at which point the OS releases the lock.
+  static func releaseLock(_ descriptor: Int32) {
+    guard descriptor >= 0 else { return }
+    flock(descriptor, LOCK_UN)
+    close(descriptor)
+  }
+
+  // MARK: - Effect
+
+  /// Best-effort: bring the lock-owning same-mode instance to the foreground.
+  private static func activateExistingInstance(bundleID: String, ownerProcessIdentifier: pid_t?) {
+    let myPID = ProcessInfo.processInfo.processIdentifier
+    let applications = NSRunningApplication.runningApplications(withBundleIdentifier: bundleID)
+    let existing =
+      ownerProcessIdentifier.flatMap { ownerPID in
+        applications.first {
+          $0.processIdentifier == ownerPID && $0.processIdentifier != myPID && !$0.isTerminated
+        }
+      }
+      ?? applications.first { $0.processIdentifier != myPID && !$0.isTerminated }
+    existing?.activate(options: [.activateAllWindows])
+  }
+}

--- a/desktop/macos/Desktop/Tests/SingleInstanceGuardTests.swift
+++ b/desktop/macos/Desktop/Tests/SingleInstanceGuardTests.swift
@@ -1,0 +1,173 @@
+import XCTest
+
+@testable import Omi_Computer
+
+final class SingleInstanceGuardTests: XCTestCase {
+  private var tempDir: String!
+
+  override func setUpWithError() throws {
+    try super.setUpWithError()
+    tempDir = NSTemporaryDirectory().appending("omi-single-instance-tests-\(UUID().uuidString)/")
+    try FileManager.default.createDirectory(
+      atPath: tempDir, withIntermediateDirectories: true)
+  }
+
+  override func tearDownWithError() throws {
+    if let tempDir {
+      try? FileManager.default.removeItem(atPath: tempDir)
+    }
+    try super.tearDownWithError()
+  }
+
+  // MARK: - Lock path derivation
+
+  func testLockPathIsDeterministicForSameInputs() {
+    let first = SingleInstanceGuard.lockFilePath(
+      bundleID: "com.omi.computer-macos", launchMode: .full, directory: tempDir)
+    let second = SingleInstanceGuard.lockFilePath(
+      bundleID: "com.omi.computer-macos", launchMode: .full, directory: tempDir)
+    XCTAssertEqual(first, second)
+  }
+
+  func testLockPathDiffersByBundleID() {
+    // Parallel named dev/test bundles must not contend with each other or production.
+    let prod = SingleInstanceGuard.lockFilePath(
+      bundleID: "com.omi.computer-macos", launchMode: .full, directory: tempDir)
+    let dev = SingleInstanceGuard.lockFilePath(
+      bundleID: "com.omi.desktop-dev", launchMode: .full, directory: tempDir)
+    let named = SingleInstanceGuard.lockFilePath(
+      bundleID: "com.omi.omi-fix-rewind", launchMode: .full, directory: tempDir)
+    XCTAssertNotEqual(prod, dev)
+    XCTAssertNotEqual(prod, named)
+    XCTAssertNotEqual(dev, named)
+  }
+
+  func testLockPathDiffersByLaunchMode() {
+    // Rewind-only mode and the full app it spawns via `open -n` must not evict each other.
+    let full = SingleInstanceGuard.lockFilePath(
+      bundleID: "com.omi.computer-macos", launchMode: .full, directory: tempDir)
+    let rewind = SingleInstanceGuard.lockFilePath(
+      bundleID: "com.omi.computer-macos", launchMode: .rewind, directory: tempDir)
+    XCTAssertNotEqual(full, rewind)
+  }
+
+  func testLockPathSanitizesUnsafeCharacters() {
+    let path = SingleInstanceGuard.lockFilePath(
+      bundleID: "com.omi/../evil id", launchMode: .full, directory: tempDir)
+    let filename = (path as NSString).lastPathComponent
+    // No path separators or spaces survive into the filename, so an unusual bundle id
+    // can neither escape the directory nor break the path.
+    XCTAssertFalse(filename.contains("/"))
+    XCTAssertFalse(filename.contains(" "))
+    // The lock stays inside the requested directory.
+    XCTAssertEqual(
+      (path as NSString).deletingLastPathComponent, (tempDir as NSString).standardizingPath)
+  }
+
+  // MARK: - Lock acquisition mechanism
+
+  func testFirstAcquirerWinsSecondSeesConflict() {
+    let path = SingleInstanceGuard.lockFilePath(
+      bundleID: "com.omi.test", launchMode: .full, directory: tempDir)
+
+    // First instance takes the lock.
+    guard case .acquired(let descriptor) = SingleInstanceGuard.acquireExclusiveLock(at: path) else {
+      return XCTFail("first acquirer should win the lock")
+    }
+    XCTAssertGreaterThanOrEqual(descriptor, 0)
+
+    // A concurrent second instance (separate file description on the same path) is rejected.
+    XCTAssertEqual(
+      SingleInstanceGuard.acquireExclusiveLock(at: path),
+      .heldByAnotherInstance)
+
+    SingleInstanceGuard.releaseLock(descriptor)
+  }
+
+  func testAcquiredLockRecordsOwnerProcessIdentifier() {
+    let path = SingleInstanceGuard.lockFilePath(
+      bundleID: "com.omi.test", launchMode: .full, directory: tempDir)
+
+    guard case .acquired(let descriptor) = SingleInstanceGuard.acquireExclusiveLock(at: path) else {
+      return XCTFail("lock should be acquirable")
+    }
+    defer { SingleInstanceGuard.releaseLock(descriptor) }
+
+    XCTAssertEqual(
+      SingleInstanceGuard.lockOwnerProcessIdentifier(at: path),
+      ProcessInfo.processInfo.processIdentifier)
+  }
+
+  func testAcquiredLockDescriptorIsCloseOnExec() {
+    let path = SingleInstanceGuard.lockFilePath(
+      bundleID: "com.omi.test", launchMode: .full, directory: tempDir)
+
+    guard case .acquired(let descriptor) = SingleInstanceGuard.acquireExclusiveLock(at: path) else {
+      return XCTFail("lock should be acquirable")
+    }
+    defer { SingleInstanceGuard.releaseLock(descriptor) }
+
+    XCTAssertTrue(
+      SingleInstanceGuard.descriptorHasCloseOnExec(descriptor),
+      "Child processes must not inherit the app-lifetime lock descriptor")
+  }
+
+  func testLockOwnerProcessIdentifierIsModeScopedByLockPath() {
+    let full = SingleInstanceGuard.lockFilePath(
+      bundleID: "com.omi.test", launchMode: .full, directory: tempDir)
+    let rewind = SingleInstanceGuard.lockFilePath(
+      bundleID: "com.omi.test", launchMode: .rewind, directory: tempDir)
+
+    guard case .acquired(let fullDescriptor) = SingleInstanceGuard.acquireExclusiveLock(at: full)
+    else {
+      return XCTFail("full-mode lock should be acquirable")
+    }
+    defer { SingleInstanceGuard.releaseLock(fullDescriptor) }
+
+    XCTAssertNotNil(SingleInstanceGuard.lockOwnerProcessIdentifier(at: full))
+    XCTAssertNil(
+      SingleInstanceGuard.lockOwnerProcessIdentifier(at: rewind),
+      "Reading owner PID from the same lock path used for contention keeps activation scoped to launch mode")
+  }
+
+  func testLockIsReacquirableAfterRelease() {
+    let path = SingleInstanceGuard.lockFilePath(
+      bundleID: "com.omi.test", launchMode: .full, directory: tempDir)
+
+    guard case .acquired(let firstDescriptor) = SingleInstanceGuard.acquireExclusiveLock(at: path)
+    else {
+      return XCTFail("first acquire should succeed")
+    }
+    SingleInstanceGuard.releaseLock(firstDescriptor)
+
+    // Once the holder releases (mirrors process exit dropping the flock), the next
+    // launch may take the lock again.
+    guard case .acquired(let secondDescriptor) = SingleInstanceGuard.acquireExclusiveLock(at: path)
+    else {
+      return XCTFail("lock should be re-acquirable after release")
+    }
+    SingleInstanceGuard.releaseLock(secondDescriptor)
+  }
+
+  func testDifferentModesDoNotContend() {
+    let full = SingleInstanceGuard.lockFilePath(
+      bundleID: "com.omi.test", launchMode: .full, directory: tempDir)
+    let rewind = SingleInstanceGuard.lockFilePath(
+      bundleID: "com.omi.test", launchMode: .rewind, directory: tempDir)
+
+    guard case .acquired(let fullDescriptor) = SingleInstanceGuard.acquireExclusiveLock(at: full)
+    else {
+      return XCTFail("full-mode lock should be acquirable")
+    }
+    // A rewind-mode instance uses a distinct lock file, so it can run alongside full.
+    guard
+      case .acquired(let rewindDescriptor) = SingleInstanceGuard.acquireExclusiveLock(at: rewind)
+    else {
+      SingleInstanceGuard.releaseLock(fullDescriptor)
+      return XCTFail("rewind-mode lock should be acquirable while full mode holds its own lock")
+    }
+
+    SingleInstanceGuard.releaseLock(rewindDescriptor)
+    SingleInstanceGuard.releaseLock(fullDescriptor)
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260705-single-instance-guard.json
+++ b/desktop/macos/changelog/unreleased/20260705-single-instance-guard.json
@@ -1,0 +1,3 @@
+{
+  "change": "Launching a second copy of Omi now brings the existing window to the front instead of starting a duplicate that could corrupt your data"
+}


### PR DESCRIPTION
## Summary

Adds a single-instance guard (BL-018 / LNCH-02) so launching a second copy of the same app **foregrounds the existing window and exits** instead of racing a second process against the shared Rewind SQLite DB and `UserDefaults`.

## What

- New `SingleInstanceGuard.enforceSingleInstanceOrExit(launchMode:isExporting:)`, called from `applicationWillFinishLaunching` — **before** any DB open or `UserDefaults` write in `applicationDidFinishLaunching`.
- Mechanism: a per-**(bundle id, launch mode)** advisory `flock(LOCK_EX | LOCK_NB)`.
  - **Crash-safe:** the OS drops the lock on process death — no stale-PID reaping.
  - **`exit(0)`** on conflict (not `NSApp.terminate`) so a duplicate never runs `applicationWillTerminate`, which writes the shared `lastSessionCleanExit` flag and tears down the live instance's global hotkeys/PTT.
  - Keyed on `AppBuild.bundleIdentifier` → parallel named dev bundles stay independent, and prod is untouched.
  - **Launch-mode aware** → preserves the intentional rewind-only → full-app `open -n` transition.
  - **View-export subprocesses exempt**; **fails open** on any lock-infra syscall error (never blocks a legitimate launch).

## Design note

A raw `NSRunningApplication` count can't distinguish rewind-only vs full mode without reading the other process's argv, which would break the rewind→full transition — the mode-keyed flock gets that for free and is crash-safe.

## Tests

- New `SingleInstanceGuardTests` (7) + `swift build -c debug` exit 0.
- Cross-process proof (evidence `crossprocess-flock.log`): a duplicate defers+exits; after the holder dies, a fresh launch acquires the lock (crash-safe).
- `bash test.sh` → **293 Rust + 127 Swift suites**, all green (independently re-run).

## Honest scope — LNCH-02 full-app runtime BLOCKED

The two-real-app-instances test needs `./run.sh` + `open -n`, but the shared per-user **build lock** was contended by ~8–11 concurrent `run.sh` processes and couldn't be disturbed (hard boundary; bypassing risks build-tree corruption, and the bare `.build` binary has no bundle id → falls back to the **prod** id). The guard's core mechanism is proven cross-process and proven wired at the earliest launch hook via the build; the two-instance + DB-non-contention observation is the only remaining item — recipe to reproduce is in the branch's `PR-DRAFT.md`.

## Changelog

`desktop/macos/changelog/unreleased/20260705-single-instance-guard.json`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9097?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

