### PR TITLE
Fix realtime token mint failure diagnostics

### DIFF
--- a/desktop/macos/Backend-Rust/src/routes/realtime.rs
+++ b/desktop/macos/Backend-Rust/src/routes/realtime.rs
@@ -86,7 +86,7 @@ impl IntoResponse for MintError {
                 StatusCode::SERVICE_UNAVAILABLE,
                 "provider_not_configured",
                 format!("{} realtime is not configured", p),
-                None,
+                Some(p),
                 None,
                 None,
                 true,
@@ -189,10 +189,16 @@ fn parse_upstream_error(body: &str) -> (Option<String>, String) {
     let parsed = serde_json::from_str::<serde_json::Value>(body).ok();
     let error = parsed.as_ref().and_then(|v| v.get("error"));
     let code = error
-        .and_then(|e| e.get("code").or_else(|| e.get("status")))
-        .or_else(|| parsed.as_ref().and_then(|v| v.get("code")))
-        .and_then(|v| v.as_str())
-        .map(str::to_string);
+        .and_then(|e| {
+            value_as_string_code(e.get("code"))
+                .or_else(|| value_as_string_code(e.get("status")))
+                .or_else(|| value_as_numeric_code(e.get("code")))
+        })
+        .or_else(|| {
+            parsed.as_ref().and_then(|v| {
+                value_as_string_code(v.get("code")).or_else(|| value_as_numeric_code(v.get("code")))
+            })
+        });
     let message = error
         .and_then(|e| e.get("message"))
         .or_else(|| parsed.as_ref().and_then(|v| v.get("message")))
@@ -206,6 +212,20 @@ fn parse_upstream_error(body: &str) -> (Option<String>, String) {
             }
         });
     (code, message)
+}
+
+fn value_as_string_code(value: Option<&serde_json::Value>) -> Option<String> {
+    match value? {
+        serde_json::Value::String(s) if !s.is_empty() => Some(s.clone()),
+        _ => None,
+    }
+}
+
+fn value_as_numeric_code(value: Option<&serde_json::Value>) -> Option<String> {
+    match value? {
+        serde_json::Value::Number(n) => Some(n.to_string()),
+        _ => None,
+    }
 }
 
 fn http_client() -> reqwest::Client {
@@ -573,5 +593,30 @@ mod tests {
         assert_eq!(body["upstream_status_code"], 429);
         assert_eq!(body["code"], "RESOURCE_EXHAUSTED");
         assert_eq!(body["retryable"], true);
+    }
+
+    #[test]
+    fn missing_key_error_body_includes_provider() {
+        let (_status, body) = mint_error_body(
+            StatusCode::SERVICE_UNAVAILABLE,
+            "provider_not_configured",
+            "Gemini realtime is not configured".to_string(),
+            Some("Gemini"),
+            None,
+            None,
+            true,
+        );
+
+        assert_eq!(body["provider"], "Gemini");
+    }
+
+    #[test]
+    fn parse_upstream_error_preserves_status_when_code_is_numeric() {
+        let (code, message) = parse_upstream_error(
+            r#"{"error":{"code":429,"status":"RESOURCE_EXHAUSTED","message":"Quota exhausted"}}"#,
+        );
+
+        assert_eq!(code.as_deref(), Some("RESOURCE_EXHAUSTED"));
+        assert_eq!(message, "Quota exhausted");
     }
 }

--- a/desktop/macos/Backend-Rust/src/routes/realtime.rs
+++ b/desktop/macos/Backend-Rust/src/routes/realtime.rs
@@ -59,33 +59,153 @@ struct MintResponse {
 enum MintError {
     BadProvider,
     MissingKey(&'static str),
-    Upstream(StatusCode, String),
+    Upstream {
+        provider: &'static str,
+        status: StatusCode,
+        reason: &'static str,
+        code: Option<String>,
+        message: String,
+        retryable: bool,
+    },
     BadGateway(String),
 }
 
 impl IntoResponse for MintError {
     fn into_response(self) -> Response {
-        let (status, message) = match self {
-            MintError::BadProvider => (
+        let (status, body) = match self {
+            MintError::BadProvider => mint_error_body(
                 StatusCode::BAD_REQUEST,
+                "bad_provider",
                 "provider must be \"openai\" or \"gemini\"".to_string(),
+                None,
+                None,
+                None,
+                false,
             ),
-            MintError::MissingKey(p) => (
+            MintError::MissingKey(p) => mint_error_body(
                 StatusCode::SERVICE_UNAVAILABLE,
+                "provider_not_configured",
                 format!("{} realtime is not configured", p),
+                None,
+                None,
+                None,
+                true,
             ),
-            MintError::Upstream(status, body) => {
-                let safe = if body.chars().count() > 500 {
-                    format!("{}...", body.chars().take(500).collect::<String>())
-                } else {
-                    body
-                };
-                (status, format!("token mint failed: {}", safe))
-            }
-            MintError::BadGateway(message) => (StatusCode::BAD_GATEWAY, message),
+            MintError::Upstream {
+                provider,
+                status,
+                reason,
+                code,
+                message,
+                retryable,
+            } => mint_error_body(
+                status,
+                reason,
+                message,
+                Some(provider),
+                code,
+                Some(status.as_u16()),
+                retryable,
+            ),
+            MintError::BadGateway(message) => mint_error_body(
+                StatusCode::BAD_GATEWAY,
+                "provider_mint_transport_error",
+                message,
+                None,
+                None,
+                None,
+                true,
+            ),
         };
-        (status, Json(serde_json::json!({ "error": message }))).into_response()
+        (status, Json(body)).into_response()
     }
+}
+
+fn mint_error_body(
+    status: StatusCode,
+    reason: &str,
+    message: String,
+    provider: Option<&str>,
+    code: Option<String>,
+    upstream_status_code: Option<u16>,
+    retryable: bool,
+) -> (StatusCode, serde_json::Value) {
+    let mut body = serde_json::json!({
+        "error": message,
+        "reason": reason,
+        "backend_route": "/v2/realtime/session",
+        "retryable": retryable,
+    });
+    if let Some(provider) = provider {
+        body["provider"] = serde_json::Value::String(provider.to_string());
+    }
+    if let Some(code) = code {
+        body["code"] = serde_json::Value::String(code);
+    }
+    if let Some(upstream_status_code) = upstream_status_code {
+        body["upstream_status_code"] = serde_json::Value::Number(upstream_status_code.into());
+    }
+    (status, body)
+}
+
+fn classify_upstream_mint_error(
+    provider: &'static str,
+    status: StatusCode,
+    body: &str,
+) -> MintError {
+    let (code, message) = parse_upstream_error(body);
+    let lower = format!(
+        "{} {}",
+        code.as_deref().unwrap_or_default(),
+        message.as_str()
+    )
+    .to_lowercase();
+    let reason = if status == StatusCode::TOO_MANY_REQUESTS || lower.contains("quota") {
+        "provider_quota_exceeded"
+    } else if status == StatusCode::UNAUTHORIZED
+        || status == StatusCode::FORBIDDEN
+        || lower.contains("invalid api key")
+        || lower.contains("api key not valid")
+        || lower.contains("authentication")
+        || lower.contains("permission denied")
+    {
+        "provider_auth_failed"
+    } else if status.is_server_error() {
+        "provider_mint_unavailable"
+    } else {
+        "provider_mint_rejected"
+    };
+    MintError::Upstream {
+        provider,
+        status,
+        reason,
+        code,
+        message,
+        retryable: status == StatusCode::TOO_MANY_REQUESTS || status.is_server_error(),
+    }
+}
+
+fn parse_upstream_error(body: &str) -> (Option<String>, String) {
+    let parsed = serde_json::from_str::<serde_json::Value>(body).ok();
+    let error = parsed.as_ref().and_then(|v| v.get("error"));
+    let code = error
+        .and_then(|e| e.get("code").or_else(|| e.get("status")))
+        .or_else(|| parsed.as_ref().and_then(|v| v.get("code")))
+        .and_then(|v| v.as_str())
+        .map(str::to_string);
+    let message = error
+        .and_then(|e| e.get("message"))
+        .or_else(|| parsed.as_ref().and_then(|v| v.get("message")))
+        .and_then(|v| v.as_str())
+        .map(str::to_string)
+        .unwrap_or_else(|| {
+            if body.chars().count() > 500 {
+                format!("{}...", body.chars().take(500).collect::<String>())
+            } else {
+                body.to_string()
+            }
+        });
+    (code, message)
 }
 
 fn http_client() -> reqwest::Client {
@@ -114,7 +234,7 @@ async fn mint_session(
 /// BadGateway and any non-2xx upstream to Upstream (so the client falls back).
 async fn send_and_parse(
     req: reqwest::RequestBuilder,
-    provider: &str,
+    provider: &'static str,
     uid: &str,
 ) -> Result<serde_json::Value, MintError> {
     let resp = req
@@ -134,7 +254,7 @@ async fn send_and_parse(
             uid,
             text
         );
-        return Err(MintError::Upstream(status, text));
+        return Err(classify_upstream_mint_error(provider, status, &text));
     }
     serde_json::from_str(&text).map_err(|e| MintError::BadGateway(e.to_string()))
 }
@@ -421,5 +541,37 @@ mod tests {
         assert!(body.get("uses").is_none());
         assert!(body.get("expireTime").is_none());
         assert!(body.get("newSessionExpireTime").is_none());
+    }
+
+    #[test]
+    fn classifies_upstream_auth_error_with_safe_structured_body() {
+        let error = classify_upstream_mint_error(
+            "openai",
+            StatusCode::UNAUTHORIZED,
+            r#"{"error":{"message":"Invalid authentication credentials","code":"invalid_api_key"}}"#,
+        );
+
+        let response = error.into_response();
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[test]
+    fn upstream_error_body_includes_actionable_fields() {
+        let (_status, body) = mint_error_body(
+            StatusCode::TOO_MANY_REQUESTS,
+            "provider_quota_exceeded",
+            "quota exhausted".to_string(),
+            Some("gemini"),
+            Some("RESOURCE_EXHAUSTED".to_string()),
+            Some(429),
+            true,
+        );
+
+        assert_eq!(body["provider"], "gemini");
+        assert_eq!(body["reason"], "provider_quota_exceeded");
+        assert_eq!(body["backend_route"], "/v2/realtime/session");
+        assert_eq!(body["upstream_status_code"], 429);
+        assert_eq!(body["code"], "RESOURCE_EXHAUSTED");
+        assert_eq!(body["retryable"], true);
     }
 }

--- a/desktop/macos/Desktop/Sources/APIClient.swift
+++ b/desktop/macos/Desktop/Sources/APIClient.swift
@@ -236,6 +236,8 @@ actor APIClient {
         let token = try await performRealtimeMintRequest(retry, provider: provider, retriedAuth: true)
         log("CredentialHealth: context=realtime_mint_auth_retry failure_class=retry_succeeded")
         return token
+      } catch let error as RealtimeTokenMintError {
+        throw error
       } catch let error as CredentialHealthError {
         throw error
       } catch {
@@ -447,7 +449,16 @@ struct RealtimeTokenMintError: LocalizedError {
   let payload: APIErrorPayload?
 
   var errorDescription: String? {
-    healthError.localizedDescription
+    var description = healthError.localizedDescription
+    description += " [status: \(statusCode)"
+    if let reason = payload?.reason {
+      description += ", reason: \(reason)"
+    }
+    if let code = payload?.code {
+      description += ", code: \(code)"
+    }
+    description += "]"
+    return description
   }
 }
 

--- a/desktop/macos/Desktop/Sources/APIClient.swift
+++ b/desktop/macos/Desktop/Sources/APIClient.swift
@@ -198,6 +198,9 @@ actor APIClient {
 
     do {
       return try await performRealtimeMintRequest(request, provider: providerType, retriedAuth: false)
+    } catch let error as RealtimeTokenMintError {
+      log("APIClient: realtime token mint failed for \(provider): \(error.localizedDescription)")
+      throw error
     } catch let error as CredentialHealthError {
       log("APIClient: realtime token mint failed for \(provider): \(error.localizedDescription)")
       throw error
@@ -242,10 +245,11 @@ actor APIClient {
 
     guard (200...299).contains(httpResponse.statusCode) else {
       let payload = Self.extractErrorPayload(from: data)
-      throw CredentialHealthManager.classifyHTTPFailure(
+      let healthError = CredentialHealthManager.classifyHTTPFailure(
         statusCode: httpResponse.statusCode,
         payload: payload,
         provider: provider)
+      throw RealtimeTokenMintError(statusCode: httpResponse.statusCode, healthError: healthError, payload: payload)
     }
 
     let resp = try decoder.decode(Resp.self, from: data)
@@ -434,6 +438,16 @@ enum APIError: LocalizedError {
     case .unsupportedTierScopedBulkMutation(let operation):
       return "Layer-scoped bulk memory \(operation) is not supported yet."
     }
+  }
+}
+
+struct RealtimeTokenMintError: LocalizedError {
+  let statusCode: Int
+  let healthError: CredentialHealthError
+  let payload: APIErrorPayload?
+
+  var errorDescription: String? {
+    healthError.localizedDescription
   }
 }
 

--- a/desktop/macos/Desktop/Sources/CredentialHealthManager.swift
+++ b/desktop/macos/Desktop/Sources/CredentialHealthManager.swift
@@ -275,6 +275,10 @@ struct APIErrorPayload: Decodable, Equatable {
   let message: String?
   let detail: String?
   let provider: String?
+  let reason: String?
+  let backendRoute: String?
+  let upstreamStatusCode: Int?
+  let retryable: Bool?
   let retryAfterSeconds: Int?
 
   enum CodingKeys: String, CodingKey {
@@ -283,6 +287,10 @@ struct APIErrorPayload: Decodable, Equatable {
     case message
     case detail
     case provider
+    case reason
+    case backendRoute = "backend_route"
+    case upstreamStatusCode = "upstream_status_code"
+    case retryable
     case retryAfterSeconds = "retry_after_seconds"
   }
 

--- a/desktop/macos/Desktop/Sources/DesktopDiagnosticsManager.swift
+++ b/desktop/macos/Desktop/Sources/DesktopDiagnosticsManager.swift
@@ -132,6 +132,7 @@ final class DesktopDiagnosticsManager {
     httpStatusCode: Int? = nil,
     backendRoute: String? = nil,
     upstreamStatusCode: Int? = nil,
+    providerCode: String? = nil,
     retryable: Bool? = nil
   ) {
     var properties: [String: Any] = [
@@ -147,6 +148,9 @@ final class DesktopDiagnosticsManager {
     }
     if let upstreamStatusCode {
       properties["upstream_status_code"] = upstreamStatusCode
+    }
+    if let providerCode {
+      properties["provider_code"] = providerCode
     }
     if let retryable {
       properties["retryable"] = retryable

--- a/desktop/macos/Desktop/Sources/DesktopDiagnosticsManager.swift
+++ b/desktop/macos/Desktop/Sources/DesktopDiagnosticsManager.swift
@@ -129,7 +129,10 @@ final class DesktopDiagnosticsManager {
     provider: String,
     reason: String,
     phase: String,
-    httpStatusCode: Int? = nil
+    httpStatusCode: Int? = nil,
+    backendRoute: String? = nil,
+    upstreamStatusCode: Int? = nil,
+    retryable: Bool? = nil
   ) {
     var properties: [String: Any] = [
       "provider": safeProvider(provider),
@@ -138,6 +141,15 @@ final class DesktopDiagnosticsManager {
     ]
     if let httpStatusCode {
       properties["http_status_code"] = httpStatusCode
+    }
+    if let backendRoute {
+      properties["backend_route"] = backendRoute
+    }
+    if let upstreamStatusCode {
+      properties["upstream_status_code"] = upstreamStatusCode
+    }
+    if let retryable {
+      properties["retryable"] = retryable
     }
     record(
       .realtimeTokenMintFailed,

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
@@ -307,6 +307,23 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate {
     }
   }
 
+  private func recordRealtimeMintFailure(
+    _ error: RealtimeTokenMintError,
+    provider providerParam: String,
+    phase: String,
+    context: String
+  ) {
+    CredentialHealthManager.shared.record(error.healthError, context: context)
+    DesktopDiagnosticsManager.shared.recordRealtimeTokenMintFailed(
+      provider: providerParam,
+      reason: error.payload?.reason ?? error.healthError.failureClass.logValue,
+      phase: phase,
+      httpStatusCode: error.statusCode,
+      backendRoute: error.payload?.backendRoute,
+      upstreamStatusCode: error.payload?.upstreamStatusCode,
+      retryable: error.payload?.retryable)
+  }
+
   /// True when the hub should drive this PTT turn. Read by PushToTalkManager at PTT
   /// start. The hub is the default voice path (no opt-in toggle).
   var isActive: Bool {
@@ -513,6 +530,15 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate {
       let token: String
       do {
         token = try await APIClient.shared.mintRealtimeToken(provider: providerParam)
+      } catch let error as RealtimeTokenMintError {
+        self.minting = false
+        self.recordRealtimeMintFailure(error, provider: providerParam, phase: "warm", context: "realtime_mint")
+        if error.healthError.failureClass.isAccountWide {
+          log("RealtimeHub: account credential failure during mint — staying on cascade")
+        } else if !self.failoverToAlternateProvider() {
+          log("⚠️ RealtimeHub: ephemeral mint failed on both providers — staying on cascade")
+        }
+        return
       } catch let error as CredentialHealthError {
         self.minting = false
         CredentialHealthManager.shared.record(error, context: "realtime_mint")
@@ -636,6 +662,20 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate {
       let token: String
       do {
         token = try await APIClient.shared.mintRealtimeToken(provider: providerParam)
+      } catch let error as RealtimeTokenMintError {
+        self.minting = false
+        self.recordRealtimeMintFailure(
+          error,
+          provider: providerParam,
+          phase: "barge_in_replacement",
+          context: "realtime_barge_in_mint")
+        self.failBargeInReplacement(provider: provider, reason: error.localizedDescription)
+        if self.shouldFailoverToAlternate(for: error.healthError.failureClass), self.failoverToAlternateProvider() {
+          return
+        } else if !error.healthError.failureClass.isAccountWide {
+          log("⚠️ RealtimeHub[\(provider.displayName)]: barge-in replacement token mint failed")
+        }
+        return
       } catch let error as CredentialHealthError {
         self.minting = false
         CredentialHealthManager.shared.record(error, context: "realtime_barge_in_mint")

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
@@ -321,6 +321,7 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate {
       httpStatusCode: error.statusCode,
       backendRoute: error.payload?.backendRoute,
       upstreamStatusCode: error.payload?.upstreamStatusCode,
+      providerCode: error.payload?.code,
       retryable: error.payload?.retryable)
   }
 

--- a/desktop/macos/Desktop/Tests/APIClientRoutingTests.swift
+++ b/desktop/macos/Desktop/Tests/APIClientRoutingTests.swift
@@ -310,6 +310,9 @@ final class APIClientRoutingTests: XCTestCase {
             XCTAssertEqual(error.payload?.upstreamStatusCode, 429)
             XCTAssertEqual(error.payload?.retryable, true)
             XCTAssertEqual(error.healthError.failureClass.logValue, "provider_quota_exceeded")
+            XCTAssertTrue(error.localizedDescription.contains("status: 429"))
+            XCTAssertTrue(error.localizedDescription.contains("reason: provider_quota_exceeded"))
+            XCTAssertTrue(error.localizedDescription.contains("code: insufficient_quota"))
         }
     }
 

--- a/desktop/macos/Desktop/Tests/APIClientRoutingTests.swift
+++ b/desktop/macos/Desktop/Tests/APIClientRoutingTests.swift
@@ -16,6 +16,8 @@ private struct CapturedRequest {
 private final class URLCapture: URLProtocol, @unchecked Sendable {
     private static let lock = NSLock()
     private static var _requests: [CapturedRequest] = []
+    private static var _statusCode = 403
+    private static var _responseBody = Data("{\"detail\":\"test\"}".utf8)
 
     static var capturedRequests: [CapturedRequest] {
         lock.lock()
@@ -26,6 +28,15 @@ private final class URLCapture: URLProtocol, @unchecked Sendable {
     static func reset() {
         lock.lock()
         _requests.removeAll()
+        _statusCode = 403
+        _responseBody = Data("{\"detail\":\"test\"}".utf8)
+        lock.unlock()
+    }
+
+    static func setResponse(statusCode: Int, body: Data) {
+        lock.lock()
+        _statusCode = statusCode
+        _responseBody = body
         lock.unlock()
     }
 
@@ -78,13 +89,20 @@ private final class URLCapture: URLProtocol, @unchecked Sendable {
                 body: Self.bodyData(from: request)
             ))
         }
-        let response = HTTPURLResponse(url: request.url!, statusCode: 403, httpVersion: nil, headerFields: nil)!
+        let (statusCode, body) = Self.response()
+        let response = HTTPURLResponse(url: request.url!, statusCode: statusCode, httpVersion: nil, headerFields: nil)!
         client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
-        client?.urlProtocol(self, didLoad: Data("{\"detail\":\"test\"}".utf8))
+        client?.urlProtocol(self, didLoad: body)
         client?.urlProtocolDidFinishLoading(self)
     }
 
     override func stopLoading() {}
+
+    private static func response() -> (Int, Data) {
+        lock.lock()
+        defer { lock.unlock() }
+        return (_statusCode, _responseBody)
+    }
 }
 
 // MARK: - Assertion helpers
@@ -264,6 +282,35 @@ final class APIClientRoutingTests: XCTestCase {
         XCTAssertEqual(base, "http://python:8080/")
         XCTAssertEqual(rust, "http://rust:8787/")
         XCTAssertNotEqual(base, rust)
+    }
+
+    func testRealtimeMintStructuredFailurePreservesDiagnostics() async throws {
+        let body = Data(
+            """
+            {
+              "error": "quota exhausted",
+              "reason": "provider_quota_exceeded",
+              "provider": "openai",
+              "backend_route": "/v2/realtime/session",
+              "upstream_status_code": 429,
+              "retryable": true,
+              "code": "insufficient_quota"
+            }
+            """.utf8)
+        URLCapture.setResponse(statusCode: 429, body: body)
+        let client = await makeTestClient()
+
+        do {
+            _ = try await client.mintRealtimeToken(provider: "openai")
+            XCTFail("Expected structured realtime mint failure")
+        } catch let error as RealtimeTokenMintError {
+            XCTAssertEqual(error.statusCode, 429)
+            XCTAssertEqual(error.payload?.reason, "provider_quota_exceeded")
+            XCTAssertEqual(error.payload?.backendRoute, "/v2/realtime/session")
+            XCTAssertEqual(error.payload?.upstreamStatusCode, 429)
+            XCTAssertEqual(error.payload?.retryable, true)
+            XCTAssertEqual(error.healthError.failureClass.logValue, "provider_quota_exceeded")
+        }
     }
 
     // MARK: - Routing behavior: Python-routed endpoints (default baseURL)

--- a/desktop/macos/Desktop/Tests/DesktopDiagnosticsManagerTests.swift
+++ b/desktop/macos/Desktop/Tests/DesktopDiagnosticsManagerTests.swift
@@ -114,6 +114,7 @@ final class DesktopDiagnosticsManagerTests: XCTestCase {
       httpStatusCode: 503,
       backendRoute: "/v2/realtime/session",
       upstreamStatusCode: 503,
+      providerCode: "UNAVAILABLE",
       retryable: true)
 
     let snapshot = try latestSnapshot()
@@ -125,6 +126,7 @@ final class DesktopDiagnosticsManagerTests: XCTestCase {
     XCTAssertEqual(snapshot["http_status_code"] as? Int, 503)
     XCTAssertEqual(snapshot["backend_route"] as? String, "/v2/realtime/session")
     XCTAssertEqual(snapshot["upstream_status_code"] as? Int, 503)
+    XCTAssertEqual(snapshot["provider_code"] as? String, "UNAVAILABLE")
     XCTAssertEqual(snapshot["retryable"] as? Bool, true)
   }
 

--- a/desktop/macos/Desktop/Tests/DesktopDiagnosticsManagerTests.swift
+++ b/desktop/macos/Desktop/Tests/DesktopDiagnosticsManagerTests.swift
@@ -111,7 +111,10 @@ final class DesktopDiagnosticsManagerTests: XCTestCase {
       provider: "gemini",
       reason: "backend_transient",
       phase: "warm",
-      httpStatusCode: 503)
+      httpStatusCode: 503,
+      backendRoute: "/v2/realtime/session",
+      upstreamStatusCode: 503,
+      retryable: true)
 
     let snapshot = try latestSnapshot()
 
@@ -120,6 +123,9 @@ final class DesktopDiagnosticsManagerTests: XCTestCase {
     XCTAssertEqual(snapshot["reason"] as? String, "backend_transient")
     XCTAssertEqual(snapshot["phase"] as? String, "warm")
     XCTAssertEqual(snapshot["http_status_code"] as? Int, 503)
+    XCTAssertEqual(snapshot["backend_route"] as? String, "/v2/realtime/session")
+    XCTAssertEqual(snapshot["upstream_status_code"] as? Int, 503)
+    XCTAssertEqual(snapshot["retryable"] as? Bool, true)
   }
 
   private func latestSnapshot() throws -> [String: Any] {

--- a/desktop/macos/changelog/unreleased/20260705-realtime-token-mint-diagnostics-9080.json
+++ b/desktop/macos/changelog/unreleased/20260705-realtime-token-mint-diagnostics-9080.json
@@ -1,0 +1,3 @@
+{
+  "change": "Improved realtime voice recovery diagnostics when managed Gemini or OpenAI token minting fails"
+}


### PR DESCRIPTION
## Summary

Fixes #9080 by preserving safe, actionable realtime token-mint failure reasons from the desktop Rust backend through the macOS health event.

Root cause:
- The 2026-07-05 telemetry spike came from managed realtime token minting, not expected idle websocket teardown.
- A recent main change already fixed one concrete Gemini mint cause: the Gemini `CreateAuthTokenRequest` body now wraps settings under `authToken`, matching Google Live API docs.
- The remaining problem was observability and recovery classification: non-2xx OpenAI/Gemini mint responses were mostly reduced client-side to `unknown` / generic transient failures, often without provider route, provider status, or retryability, so the July 5 failures could not be separated into provider auth/quota/outage/rejected-request/config cases.

What changed:
- Rust `/v2/realtime/session` now returns structured safe mint error JSON: `reason`, `backend_route`, `provider`, provider `code`, `upstream_status_code` when available, and `retryable`.
- macOS `APIClient.mintRealtimeToken` preserves those fields via `RealtimeTokenMintError` instead of erasing them in a generic catch.
- `RealtimeHubController` records structured mint diagnostics for warm and barge-in token mint phases while preserving existing failover/fallback behavior.
- `DesktopDiagnosticsManager` includes the new safe fields in `realtime_token_mint_failed` health snapshots.
- Added focused Rust and Swift tests plus a desktop changelog fragment.

## Verification

- `cargo fmt`
- `cargo test routes::realtime`
- `xcrun swift test -c debug --package-path Desktop --filter 'APIClientRoutingTests/testRealtimeMintStructuredFailurePreservesDiagnostics'`
- `xcrun swift test -c debug --package-path Desktop --filter 'DesktopDiagnosticsManagerTests/testTokenMintFailureIncludesHttpStatusWhenKnown'`
- Pre-push fast checks passed, including desktop Swift build and desktop Rust check.

Note: a broader filtered Swift run of `APIClientRoutingTests|DesktopDiagnosticsManagerTests` exposed an unrelated existing failure in `APIClientRoutingTests.testDeleteConversationRoutesToPython`: the test expects `?cascade=true`, while current `deleteConversation` sends `/v1/conversations/conv-456`. The new realtime mint test and diagnostics test both pass individually.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9102?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

