### PR TITLE
Fix macOS session reconciliation recovery

### DIFF
--- a/desktop/macos/Desktop/Sources/AnalyticsManager.swift
+++ b/desktop/macos/Desktop/Sources/AnalyticsManager.swift
@@ -169,7 +169,8 @@ class AnalyticsManager {
     retryCount: Int,
     hasBackendId: Bool,
     hasClientConversationId: Bool,
-    segmentCount: Int?
+    segmentCount: Int?,
+    diagnostics: ReconciliationFailureDiagnostics? = nil
   ) {
     PostHogManager.shared.conversationReconciliationFailed(
       error: error,
@@ -179,7 +180,8 @@ class AnalyticsManager {
       retryCount: retryCount,
       hasBackendId: hasBackendId,
       hasClientConversationId: hasClientConversationId,
-      segmentCount: segmentCount
+      segmentCount: segmentCount,
+      diagnostics: diagnostics
     )
   }
 

--- a/desktop/macos/Desktop/Sources/ConversationFinalizationService.swift
+++ b/desktop/macos/Desktop/Sources/ConversationFinalizationService.swift
@@ -5,8 +5,13 @@ actor ConversationFinalizationService {
 
   private let maxRetries = 5
   private let maxLocalFallbackRetries = 3
+  private var apiClient = APIClient.shared
 
   private init() {}
+
+  func setAPIClientForTesting(_ client: APIClient?) {
+    apiClient = client ?? APIClient.shared
+  }
 
   func finalizeSession(
     id sessionId: Int64,
@@ -41,7 +46,12 @@ actor ConversationFinalizationService {
           "ConversationFinalization: Recovering \(sessionsById.count) pending sessions (\(exhaustedLocalFallbackSessions.count) exhausted cloud sessions have local fallback data)"
         )
       }
+      let exhaustedLocalFallbackIds = Set(exhaustedLocalFallbackSessions.compactMap(\.id))
       for session in sessionsById where session.isReadyForRetry() || session.status != .failed || session.retryCount >= maxRetries {
+        if let sessionId = session.id, exhaustedLocalFallbackIds.contains(sessionId) {
+          await finalizeExhaustedCloudSessionFromLocalSegments(session)
+          continue
+        }
         await finalizeSession(
           session,
           reason: .retry,
@@ -50,6 +60,27 @@ actor ConversationFinalizationService {
       }
     } catch {
       logError("ConversationFinalization: Recovery failed", error: error)
+    }
+  }
+
+  private func finalizeExhaustedCloudSessionFromLocalSegments(_ session: TranscriptionSessionRecord) async {
+    guard let sessionId = session.id else { return }
+    guard session.status != .completed && !session.backendSynced else { return }
+
+    log("ConversationFinalization: Retrying exhausted cloud session \(sessionId) from saved local segments")
+
+    do {
+      guard try await TranscriptionStorage.shared.markSessionUploading(id: sessionId) else {
+        return
+      }
+      guard let latestSession = try await TranscriptionStorage.shared.getSession(id: sessionId) else {
+        throw TranscriptionStorageError.sessionNotFound
+      }
+      guard try await resolveExhaustedCloudReconciliation(session: latestSession, sessionId: sessionId) else {
+        throw TranscriptionStorageError.invalidState("Exhausted cloud session has no local fallback")
+      }
+    } catch {
+      await markRetryableFailure(sessionId: sessionId, error: error)
     }
   }
 
@@ -91,7 +122,7 @@ actor ConversationFinalizationService {
     return session.source == ConversationSource.desktop.rawValue ? .localSegments : .cloudReconcile
   }
 
-  private func uploadLocalSegments(sessionId: Int64) async throws {
+  private func uploadLocalSegments(sessionId: Int64, allowBackendIdOverride: Bool = false) async throws {
     guard let bundle = try await TranscriptionStorage.shared.getSessionWithSegments(id: sessionId) else {
       throw TranscriptionStorageError.sessionNotFound
     }
@@ -147,12 +178,13 @@ actor ConversationFinalizationService {
       language: bundle.session.language,
       client_conversation_id: Self.localClientConversationId(session: bundle.session, sessionId: sessionId)
     )
-    let response = try await APIClient.shared.createConversationFromSegments(request)
+    let response = try await apiClient.createConversationFromSegments(request)
     let status = LocalConversationStatus(rawValue: response.status) ?? .processing
     let completed = try await TranscriptionStorage.shared.markSessionCompleted(
       id: sessionId,
       backendId: response.id,
-      conversationStatus: status
+      conversationStatus: status,
+      allowBackendIdOverride: allowBackendIdOverride
     )
     if completed {
       log("ConversationFinalization: Uploaded local session \(sessionId) -> backend conversation \(response.id)")
@@ -203,9 +235,9 @@ actor ConversationFinalizationService {
     if let backendId = session.backendId, !backendId.isEmpty {
       let conversation: ServerConversation
       if allowForceProcess {
-        conversation = try await APIClient.shared.finalizeConversation(id: backendId)
+        conversation = try await apiClient.finalizeConversation(id: backendId)
       } else {
-        conversation = try await APIClient.shared.getConversation(id: backendId)
+        conversation = try await apiClient.getConversation(id: backendId)
       }
       if DesktopConversationMatchPolicy.canCompleteBoundBackendConversation(
         id: conversation.id,
@@ -235,7 +267,7 @@ actor ConversationFinalizationService {
       }
     }
 
-    if allowForceProcess, let conversation = try await APIClient.shared.forceProcessConversation() {
+    if allowForceProcess, let conversation = try await apiClient.forceProcessConversation() {
       if DesktopConversationMatchPolicy.matchesDesktopConversation(
         startedAt: conversation.startedAt,
         source: conversation.source,
@@ -253,7 +285,7 @@ actor ConversationFinalizationService {
     }
 
     let finishedAt = session.finishedAt ?? session.startedAt.addingTimeInterval(1)
-    let existing = try await APIClient.shared.getConversations(
+    let existing = try await apiClient.getConversations(
       limit: 5,
       statuses: DesktopConversationMatchPolicy.cloudReconciliationStatuses,
       includeDiscarded: true,
@@ -297,7 +329,7 @@ actor ConversationFinalizationService {
   ) async throws -> Bool {
     let conversation: ServerConversation
     if DesktopConversationMatchPolicy.shouldFinalizeTimestampMatchedConversation(status: match.status) {
-      conversation = try await APIClient.shared.finalizeConversation(id: match.id)
+      conversation = try await apiClient.finalizeConversation(id: match.id)
     } else {
       conversation = match
     }
@@ -332,7 +364,10 @@ actor ConversationFinalizationService {
       log(
         "ConversationFinalization: Cloud reconciliation exhausted for session \(sessionId); uploading \(segmentCount) saved local segments"
       )
-      try await uploadLocalSegments(sessionId: sessionId)
+      try await uploadLocalSegments(
+        sessionId: sessionId,
+        allowBackendIdOverride: session.backendId?.isEmpty == false
+      )
       return true
     case .discardEmptyDesktopSession:
       log("ConversationFinalization: Deleting empty unreconciled desktop session \(sessionId)")
@@ -375,9 +410,9 @@ actor ConversationFinalizationService {
     let conversation: ServerConversation
     do {
       if allowForceProcess {
-        conversation = try await APIClient.shared.finalizeConversation(id: conversationId)
+        conversation = try await apiClient.finalizeConversation(id: conversationId)
       } else {
-        conversation = try await APIClient.shared.getConversation(id: conversationId)
+        conversation = try await apiClient.getConversation(id: conversationId)
       }
     } catch APIError.httpError(let statusCode, _) where statusCode == 404 {
       return false

--- a/desktop/macos/Desktop/Sources/ConversationFinalizationService.swift
+++ b/desktop/macos/Desktop/Sources/ConversationFinalizationService.swift
@@ -4,6 +4,7 @@ actor ConversationFinalizationService {
   static let shared = ConversationFinalizationService()
 
   private let maxRetries = 5
+  private let maxLocalFallbackRetries = 3
 
   private init() {}
 
@@ -25,10 +26,22 @@ actor ConversationFinalizationService {
   func recoverPendingFinalizations() async {
     do {
       let sessions = try await TranscriptionStorage.shared.getSessionsNeedingFinalization(maxRetries: maxRetries)
-      if !sessions.isEmpty {
-      log("ConversationFinalization: Recovering \(sessions.count) pending sessions")
+      let exhaustedLocalFallbackSessions = try await TranscriptionStorage.shared
+        .getExhaustedCloudSessionsWithLocalSegments(
+          maxRetries: maxRetries,
+          maxLocalFallbackRetries: maxLocalFallbackRetries
+        )
+      let sessionsById = Dictionary(
+        grouping: sessions + exhaustedLocalFallbackSessions,
+        by: { $0.id ?? -1 }
+      ).compactMap { $0.value.first }
+
+      if !sessionsById.isEmpty {
+        log(
+          "ConversationFinalization: Recovering \(sessionsById.count) pending sessions (\(exhaustedLocalFallbackSessions.count) exhausted cloud sessions have local fallback data)"
+        )
       }
-      for session in sessions where session.isReadyForRetry() || session.status != .failed {
+      for session in sessionsById where session.isReadyForRetry() || session.status != .failed || session.retryCount >= maxRetries {
         await finalizeSession(
           session,
           reason: .retry,
@@ -396,6 +409,13 @@ actor ConversationFinalizationService {
       let retryCount = (session?.retryCount ?? 0) + 1
       if retryCount >= maxRetries {
         let segmentCount = try? await TranscriptionStorage.shared.getSegmentCount(sessionId: sessionId)
+        let diagnostics = ReconciliationFailureDiagnostics(
+          session: session,
+          segmentCount: segmentCount,
+          retryCount: retryCount,
+          maxRetries: maxRetries,
+          maxLocalFallbackRetries: maxLocalFallbackRetries
+        )
         await AnalyticsManager.shared.conversationReconciliationFailed(
           error: "session_reconciliation_failed",
           reason: "cloud_reconcile_exhausted",
@@ -404,7 +424,8 @@ actor ConversationFinalizationService {
           retryCount: retryCount,
           hasBackendId: session?.backendId?.isEmpty == false,
           hasClientConversationId: session?.clientConversationId?.isEmpty == false,
-          segmentCount: segmentCount
+          segmentCount: segmentCount,
+          diagnostics: diagnostics
         )
       }
       try await TranscriptionStorage.shared.incrementRetryCount(id: sessionId)
@@ -417,5 +438,50 @@ actor ConversationFinalizationService {
   static func localClientConversationId(session: TranscriptionSessionRecord, sessionId: Int64) -> String {
     let startedAtMs = Int64((session.startedAt.timeIntervalSince1970 * 1000).rounded())
     return session.clientConversationId ?? "macos-local-\(sessionId)-\(startedAtMs)"
+  }
+}
+
+struct ReconciliationFailureDiagnostics {
+  let sessionStatus: String?
+  let conversationStatus: String?
+  let finalizationReason: String?
+  let hasFinishedAt: Bool
+  let hasFinalizationStartedAt: Bool
+  let hasFinalizationCompletedAt: Bool
+  let hasInputDeviceName: Bool
+  let hasLocalSegments: Bool?
+  let sessionAgeSeconds: Int?
+  let sessionDurationSeconds: Int?
+  let localFallbackAvailable: Bool
+  let localFallbackRetriesRemaining: Int
+
+  init(
+    session: TranscriptionSessionRecord?,
+    segmentCount: Int?,
+    retryCount: Int,
+    maxRetries: Int,
+    maxLocalFallbackRetries: Int
+  ) {
+    let now = Date()
+    sessionStatus = session?.status.rawValue
+    conversationStatus = session?.conversationStatus.rawValue
+    finalizationReason = session?.finalizationReason?.rawValue
+    hasFinishedAt = session?.finishedAt != nil
+    hasFinalizationStartedAt = session?.finalizationStartedAt != nil
+    hasFinalizationCompletedAt = session?.finalizationCompletedAt != nil
+    hasInputDeviceName = session?.inputDeviceName?.isEmpty == false
+    hasLocalSegments = segmentCount.map { $0 > 0 }
+    sessionAgeSeconds = session.map { max(0, Int(now.timeIntervalSince($0.createdAt).rounded())) }
+    if let startedAt = session?.startedAt {
+      let finishedAt = session?.finishedAt ?? now
+      sessionDurationSeconds = max(0, Int(finishedAt.timeIntervalSince(startedAt).rounded()))
+    } else {
+      sessionDurationSeconds = nil
+    }
+    localFallbackAvailable =
+      session?.finalizationStrategy == .cloudReconcile
+      && (segmentCount ?? 0) > 0
+      && retryCount >= maxRetries
+    localFallbackRetriesRemaining = max(0, maxRetries + maxLocalFallbackRetries - retryCount)
   }
 }

--- a/desktop/macos/Desktop/Sources/PostHogManager.swift
+++ b/desktop/macos/Desktop/Sources/PostHogManager.swift
@@ -276,7 +276,8 @@ extension PostHogManager {
         retryCount: Int,
         hasBackendId: Bool,
         hasClientConversationId: Bool,
-        segmentCount: Int?
+        segmentCount: Int?,
+        diagnostics: ReconciliationFailureDiagnostics? = nil
     ) {
         var properties: [String: Any] = [
             "platform": "macos",
@@ -295,6 +296,32 @@ extension PostHogManager {
         if let segmentCount {
             properties["segment_count"] = segmentCount
             properties["has_local_segments"] = segmentCount > 0
+        }
+        if let diagnostics {
+            if let sessionStatus = diagnostics.sessionStatus {
+                properties["session_status"] = sessionStatus
+            }
+            if let conversationStatus = diagnostics.conversationStatus {
+                properties["conversation_status"] = conversationStatus
+            }
+            if let finalizationReason = diagnostics.finalizationReason {
+                properties["finalization_reason"] = finalizationReason
+            }
+            properties["has_finished_at"] = diagnostics.hasFinishedAt
+            properties["has_finalization_started_at"] = diagnostics.hasFinalizationStartedAt
+            properties["has_finalization_completed_at"] = diagnostics.hasFinalizationCompletedAt
+            properties["has_input_device_name"] = diagnostics.hasInputDeviceName
+            properties["local_fallback_available"] = diagnostics.localFallbackAvailable
+            properties["local_fallback_retries_remaining"] = diagnostics.localFallbackRetriesRemaining
+            if let hasLocalSegments = diagnostics.hasLocalSegments {
+                properties["has_local_segments"] = hasLocalSegments
+            }
+            if let sessionAgeSeconds = diagnostics.sessionAgeSeconds {
+                properties["session_age_seconds"] = sessionAgeSeconds
+            }
+            if let sessionDurationSeconds = diagnostics.sessionDurationSeconds {
+                properties["session_duration_seconds"] = sessionDurationSeconds
+            }
         }
         track("Desktop Conversation Reconciliation Failed", properties: properties)
     }

--- a/desktop/macos/Desktop/Sources/Rewind/Core/TranscriptionStorage.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/TranscriptionStorage.swift
@@ -183,7 +183,8 @@ actor TranscriptionStorage {
     func markSessionCompleted(
         id: Int64,
         backendId: String,
-        conversationStatus: LocalConversationStatus = .completed
+        conversationStatus: LocalConversationStatus = .completed,
+        allowBackendIdOverride: Bool = false
     ) async throws -> Bool {
         let db = try await ensureInitialized()
 
@@ -192,7 +193,7 @@ actor TranscriptionStorage {
                 throw TranscriptionStorageError.sessionNotFound
             }
 
-            guard record.canAcceptCompletion(backendId: backendId) else {
+            guard allowBackendIdOverride || record.canAcceptCompletion(backendId: backendId) else {
                 log("TranscriptionStorage: Skipping conflicting completion for session \(id) (existing: \(record.backendId ?? "nil"), incoming: \(backendId))")
                 return false
             }
@@ -662,7 +663,19 @@ actor TranscriptionStorage {
                 .filter(Column("status") == TranscriptionSessionStatus.failed.rawValue)
                 .filter(Column("retryCount") >= maxRetries)
                 .filter(Column("retryCount") < retryLimit)
-                .filter(Column("finalizationStrategy") == TranscriptionFinalizationStrategy.cloudReconcile.rawValue)
+                .filter(
+                    sql: """
+                        finalizationStrategy = ?
+                        OR (
+                            finalizationStrategy IS NULL
+                            AND ((backendId IS NOT NULL AND backendId != '') OR source != ?)
+                        )
+                        """,
+                    arguments: [
+                        TranscriptionFinalizationStrategy.cloudReconcile.rawValue,
+                        ConversationSource.desktop.rawValue,
+                    ]
+                )
                 .filter(
                     sql: """
                         EXISTS (

--- a/desktop/macos/Desktop/Sources/Rewind/Core/TranscriptionStorage.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/TranscriptionStorage.swift
@@ -647,6 +647,36 @@ actor TranscriptionStorage {
         }
     }
 
+    /// Get failed cloud-reconciliation sessions that exhausted normal retries but still have saved
+    /// local transcript segments. These can be recovered by uploading those segments directly.
+    func getExhaustedCloudSessionsWithLocalSegments(
+        maxRetries: Int = 5,
+        maxLocalFallbackRetries: Int = 3
+    ) async throws -> [TranscriptionSessionRecord] {
+        let db = try await ensureInitialized()
+        let retryLimit = maxRetries + maxLocalFallbackRetries
+
+        return try await db.read { database in
+            try TranscriptionSessionRecord
+                .filter(Column("backendSynced") == false)
+                .filter(Column("status") == TranscriptionSessionStatus.failed.rawValue)
+                .filter(Column("retryCount") >= maxRetries)
+                .filter(Column("retryCount") < retryLimit)
+                .filter(Column("finalizationStrategy") == TranscriptionFinalizationStrategy.cloudReconcile.rawValue)
+                .filter(
+                    sql: """
+                        EXISTS (
+                            SELECT 1
+                            FROM transcription_segments
+                            WHERE transcription_segments.sessionId = transcription_sessions.id
+                        )
+                        """
+                )
+                .order(Column("createdAt").asc)
+                .fetchAll(database)
+        }
+    }
+
     /// Get sessions that were left in "recording" status (crashed)
     func getCrashedSessions() async throws -> [TranscriptionSessionRecord] {
         let db = try await ensureInitialized()

--- a/desktop/macos/Desktop/Tests/TranscriptionFinalizationStateMachineTests.swift
+++ b/desktop/macos/Desktop/Tests/TranscriptionFinalizationStateMachineTests.swift
@@ -1,5 +1,93 @@
 import XCTest
+import GRDB
 @testable import Omi_Computer
+
+private struct FinalizationRecoveryRequest {
+    let url: URL
+    let method: String
+    let body: Data?
+}
+
+private final class FinalizationRecoveryURLStub: URLProtocol, @unchecked Sendable {
+    private static let lock = NSLock()
+    private static var _requests: [FinalizationRecoveryRequest] = []
+
+    static var requests: [FinalizationRecoveryRequest] {
+        lock.lock()
+        defer { lock.unlock() }
+        return _requests
+    }
+
+    static func reset() {
+        lock.lock()
+        _requests.removeAll()
+        lock.unlock()
+    }
+
+    private static func record(_ request: FinalizationRecoveryRequest) {
+        lock.lock()
+        _requests.append(request)
+        lock.unlock()
+    }
+
+    private static func bodyData(from request: URLRequest) -> Data? {
+        if let body = request.httpBody {
+            return body
+        }
+        guard let stream = request.httpBodyStream else {
+            return nil
+        }
+
+        stream.open()
+        defer { stream.close() }
+
+        var data = Data()
+        let bufferSize = 4096
+        let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: bufferSize)
+        defer { buffer.deallocate() }
+
+        while stream.hasBytesAvailable {
+            let readCount = stream.read(buffer, maxLength: bufferSize)
+            if readCount > 0 {
+                data.append(buffer, count: readCount)
+            } else {
+                break
+            }
+        }
+
+        return data.isEmpty ? nil : data
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        if let url = request.url {
+            Self.record(FinalizationRecoveryRequest(
+                url: url,
+                method: request.httpMethod ?? "GET",
+                body: Self.bodyData(from: request)
+            ))
+        }
+
+        let path = request.url?.path ?? ""
+        if path == "/v1/conversations/from-segments" {
+            let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(
+                self,
+                didLoad: Data(#"{"id":"local-fallback-conversation","status":"processing","discarded":false}"#.utf8)
+            )
+        } else {
+            let response = HTTPURLResponse(url: request.url!, statusCode: 404, httpVersion: nil, headerFields: nil)!
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: Data(#"{"detail":"not found"}"#.utf8))
+        }
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+}
 
 final class TranscriptionFinalizationStateMachineTests: XCTestCase {
     private var testUserId: String!
@@ -189,6 +277,38 @@ final class TranscriptionFinalizationStateMachineTests: XCTestCase {
             try await TranscriptionStorage.shared.incrementRetryCount(id: recoverableId)
         }
 
+        let legacyBackendBoundId = try await TranscriptionStorage.shared.startSession(
+            source: "desktop",
+            finalizationStrategy: .cloudReconcile
+        )
+        try await TranscriptionStorage.shared.bindBackendConversation(
+            id: legacyBackendBoundId,
+            backendId: "legacy-backend-id"
+        )
+        try await TranscriptionStorage.shared.finishSession(id: legacyBackendBoundId, reason: .userStop)
+        try await TranscriptionStorage.shared.appendSegment(
+            sessionId: legacyBackendBoundId,
+            speaker: 0,
+            text: "legacy saved transcript",
+            startTime: 0,
+            endTime: 1
+        )
+        try await TranscriptionStorage.shared.markSessionFailed(
+            id: legacyBackendBoundId,
+            error: "session_reconciliation_failed"
+        )
+        for _ in 0..<5 {
+            try await TranscriptionStorage.shared.incrementRetryCount(id: legacyBackendBoundId)
+        }
+        let dbQueue = await RewindDatabase.shared.getDatabaseQueue()
+        let db = try XCTUnwrap(dbQueue)
+        try await db.write { database in
+            try database.execute(
+                sql: "UPDATE transcription_sessions SET finalizationStrategy = NULL WHERE id = ?",
+                arguments: [legacyBackendBoundId]
+            )
+        }
+
         let emptyExhaustedId = try await TranscriptionStorage.shared.startSession(
             source: "desktop",
             finalizationStrategy: .cloudReconcile
@@ -223,8 +343,64 @@ final class TranscriptionFinalizationStateMachineTests: XCTestCase {
         let ids = Set(recoverable.compactMap(\.id))
 
         XCTAssertTrue(ids.contains(recoverableId))
+        XCTAssertTrue(ids.contains(legacyBackendBoundId))
         XCTAssertFalse(ids.contains(emptyExhaustedId))
         XCTAssertFalse(ids.contains(tooManyFallbackFailuresId))
+    }
+
+    func testRecoverPendingFinalizationsProcessesExhaustedBackendBoundLocalFallback() async throws {
+        FinalizationRecoveryURLStub.reset()
+        setenv("OMI_PYTHON_API_URL", "https://finalization-recovery.test/", 1)
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [FinalizationRecoveryURLStub.self]
+        let client = APIClient(session: URLSession(configuration: config))
+        await client.setTestAuthHeader("Bearer test-token")
+        await ConversationFinalizationService.shared.setAPIClientForTesting(client)
+        addTeardownBlock {
+            await ConversationFinalizationService.shared.setAPIClientForTesting(nil)
+        }
+        defer {
+            unsetenv("OMI_PYTHON_API_URL")
+            FinalizationRecoveryURLStub.reset()
+        }
+
+        let sessionId = try await TranscriptionStorage.shared.startSession(
+            source: "desktop",
+            clientConversationId: "client-fallback-id",
+            finalizationStrategy: .cloudReconcile
+        )
+        try await TranscriptionStorage.shared.bindBackendConversation(id: sessionId, backendId: "stale-backend-id")
+        try await TranscriptionStorage.shared.finishSession(id: sessionId, reason: .userStop)
+        try await TranscriptionStorage.shared.appendSegment(
+            sessionId: sessionId,
+            speaker: 0,
+            text: "saved transcript for recovery",
+            startTime: 0,
+            endTime: 1
+        )
+        try await TranscriptionStorage.shared.markSessionFailed(id: sessionId, error: "session_reconciliation_failed")
+        for _ in 0..<5 {
+            try await TranscriptionStorage.shared.incrementRetryCount(id: sessionId)
+        }
+
+        await ConversationFinalizationService.shared.recoverPendingFinalizations()
+
+        let storedSession = try await TranscriptionStorage.shared.getSession(id: sessionId)
+        let session = try XCTUnwrap(storedSession)
+        XCTAssertEqual(session.status, .completed)
+        XCTAssertEqual(session.backendId, "local-fallback-conversation")
+        XCTAssertTrue(session.backendSynced)
+
+        let requests = FinalizationRecoveryURLStub.requests
+        XCTAssertEqual(requests.count, 1)
+        XCTAssertEqual(requests.first?.method, "POST")
+        XCTAssertEqual(requests.first?.url.path, "/v1/conversations/from-segments")
+
+        let body = try XCTUnwrap(requests.first?.body)
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: body) as? [String: Any])
+        XCTAssertEqual(json["client_conversation_id"] as? String, "client-fallback-id")
+        let segments = try XCTUnwrap(json["transcript_segments"] as? [[String: Any]])
+        XCTAssertEqual(segments.first?["text"] as? String, "saved transcript for recovery")
     }
 
     func testFreshUploadingSessionWaitsForStaleRecoveryWindow() async throws {

--- a/desktop/macos/Desktop/Tests/TranscriptionFinalizationStateMachineTests.swift
+++ b/desktop/macos/Desktop/Tests/TranscriptionFinalizationStateMachineTests.swift
@@ -171,6 +171,62 @@ final class TranscriptionFinalizationStateMachineTests: XCTestCase {
         XCTAssertFalse(ids.contains(completedId))
     }
 
+    func testExhaustedCloudSessionsWithLocalSegmentsAreRecoverable() async throws {
+        let recoverableId = try await TranscriptionStorage.shared.startSession(
+            source: "desktop",
+            finalizationStrategy: .cloudReconcile
+        )
+        try await TranscriptionStorage.shared.finishSession(id: recoverableId, reason: .userStop)
+        try await TranscriptionStorage.shared.appendSegment(
+            sessionId: recoverableId,
+            speaker: 0,
+            text: "saved transcript",
+            startTime: 0,
+            endTime: 1
+        )
+        try await TranscriptionStorage.shared.markSessionFailed(id: recoverableId, error: "session_reconciliation_failed")
+        for _ in 0..<5 {
+            try await TranscriptionStorage.shared.incrementRetryCount(id: recoverableId)
+        }
+
+        let emptyExhaustedId = try await TranscriptionStorage.shared.startSession(
+            source: "desktop",
+            finalizationStrategy: .cloudReconcile
+        )
+        try await TranscriptionStorage.shared.finishSession(id: emptyExhaustedId, reason: .userStop)
+        try await TranscriptionStorage.shared.markSessionFailed(id: emptyExhaustedId, error: "session_reconciliation_failed")
+        for _ in 0..<5 {
+            try await TranscriptionStorage.shared.incrementRetryCount(id: emptyExhaustedId)
+        }
+
+        let tooManyFallbackFailuresId = try await TranscriptionStorage.shared.startSession(
+            source: "desktop",
+            finalizationStrategy: .cloudReconcile
+        )
+        try await TranscriptionStorage.shared.finishSession(id: tooManyFallbackFailuresId, reason: .userStop)
+        try await TranscriptionStorage.shared.appendSegment(
+            sessionId: tooManyFallbackFailuresId,
+            speaker: 0,
+            text: "already retried fallback",
+            startTime: 0,
+            endTime: 1
+        )
+        try await TranscriptionStorage.shared.markSessionFailed(
+            id: tooManyFallbackFailuresId,
+            error: "local fallback upload failed"
+        )
+        for _ in 0..<8 {
+            try await TranscriptionStorage.shared.incrementRetryCount(id: tooManyFallbackFailuresId)
+        }
+
+        let recoverable = try await TranscriptionStorage.shared.getExhaustedCloudSessionsWithLocalSegments()
+        let ids = Set(recoverable.compactMap(\.id))
+
+        XCTAssertTrue(ids.contains(recoverableId))
+        XCTAssertFalse(ids.contains(emptyExhaustedId))
+        XCTAssertFalse(ids.contains(tooManyFallbackFailuresId))
+    }
+
     func testFreshUploadingSessionWaitsForStaleRecoveryWindow() async throws {
         let sessionId = try await TranscriptionStorage.shared.startSession(source: "desktop")
         try await TranscriptionStorage.shared.finishSession(
@@ -349,6 +405,38 @@ final class TranscriptionFinalizationStateMachineTests: XCTestCase {
             ),
             .reportFailure
         )
+    }
+
+    func testReconciliationFailureDiagnosticsExposeRecoveryInputs() {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let session = TranscriptionSessionRecord(
+            startedAt: now.addingTimeInterval(-120),
+            finishedAt: now.addingTimeInterval(-60),
+            source: ConversationSource.desktop.rawValue,
+            inputDeviceName: "Built-in Microphone",
+            status: .failed,
+            retryCount: 5,
+            finalizationStrategy: .cloudReconcile,
+            finalizationReason: .userStop,
+            finalizationStartedAt: now.addingTimeInterval(-30)
+        )
+
+        let diagnostics = ReconciliationFailureDiagnostics(
+            session: session,
+            segmentCount: 2,
+            retryCount: 5,
+            maxRetries: 5,
+            maxLocalFallbackRetries: 3
+        )
+
+        XCTAssertEqual(diagnostics.sessionStatus, "failed")
+        XCTAssertEqual(diagnostics.finalizationReason, "user_stop")
+        XCTAssertTrue(diagnostics.hasFinishedAt)
+        XCTAssertTrue(diagnostics.hasInputDeviceName)
+        XCTAssertEqual(diagnostics.hasLocalSegments, true)
+        XCTAssertEqual(diagnostics.sessionDurationSeconds, 60)
+        XCTAssertTrue(diagnostics.localFallbackAvailable)
+        XCTAssertEqual(diagnostics.localFallbackRetriesRemaining, 3)
     }
 
     func testCompactsOversizedLocalUploadWithoutDroppingText() {

--- a/desktop/macos/changelog/unreleased/20260705-session-reconciliation-recovery.json
+++ b/desktop/macos/changelog/unreleased/20260705-session-reconciliation-recovery.json
@@ -1,0 +1,3 @@
+{
+  "change": "Improved desktop recording recovery so failed cloud reconciliation can retry from saved local transcript segments with clearer diagnostics"
+}


### PR DESCRIPTION
## Summary
- recover exhausted macOS cloud-reconciliation sessions that still have saved local transcript segments by retrying the existing local-segment finalization path
- add structured reconciliation-failure diagnostics for available inputs, timing, status, and local fallback availability
- add focused state-machine coverage and a desktop changelog fragment

Closes #9083.

Related: #8197 is a broader desktop conversations cache-authority project, and #4354 is mobile/offline-sync reprocessing, so this PR does not close those.

## Testing
- `xcrun swift test --package-path Desktop --filter TranscriptionFinalizationStateMachineTests`
- `xcrun swift build -c debug --package-path Desktop`
- pre-push fast checks, including desktop Swift build

Note: attempted to launch named bundle `omi-session-recovery`, but `run.sh` was blocked waiting on another active run lock, so I stopped my waiting process without disturbing the existing app session.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9103?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

