### PR TITLE
fix(desktop): local diagnostics export + owner-only (0600) log file

### DIFF
--- a/desktop/macos/Desktop/Sources/DesktopDiagnosticsManager.swift
+++ b/desktop/macos/Desktop/Sources/DesktopDiagnosticsManager.swift
@@ -228,6 +228,103 @@ final class DesktopDiagnosticsManager {
     }
   }
 
+  // MARK: - Local (offline) diagnostics export
+
+  /// Build a redacted, offline diagnostics bundle and write it to `url`.
+  ///
+  /// Unlike the Sentry path, this works with no network and without a crash
+  /// reporter — it backs the local "Save Diagnostics…" export so users can share
+  /// a report manually (BL-023 / SET-03). The bundle carries app/version/OS
+  /// metadata, the already-sanitized health snapshots, and a redacted tail of the
+  /// local log. Returns `true` on success.
+  @discardableResult
+  func writeLocalDiagnosticsBundle(
+    to url: URL,
+    logPath: String = omiLogFilePath(),
+    maxLogLines: Int = 500
+  ) -> Bool {
+    let text = buildLocalDiagnosticsText(logPath: logPath, maxLogLines: maxLogLines)
+    guard let data = text.data(using: .utf8) else { return false }
+    do {
+      try data.write(to: url, options: .atomic)
+      return true
+    } catch {
+      log("DesktopDiagnostics: failed to write local diagnostics bundle")
+      return false
+    }
+  }
+
+  /// Render the redacted diagnostics bundle as plain text (metadata header,
+  /// sanitized health snapshots, redacted recent log tail). Exposed for testing
+  /// the redaction guarantee without disk I/O.
+  func buildLocalDiagnosticsText(logPath: String, maxLogLines: Int = 500) -> String {
+    var sections: [String] = []
+
+    let meta = commonProperties()
+    var header = ["# Omi Desktop Diagnostics"]
+    header.append("generated_at: \(ISO8601DateFormatter.desktopDiagnostics.string(from: Date()))")
+    header.append("privacy: redacted_local_export")
+    for key in ["build", "build_number", "os_version", "device_model", "system_audio_mode"] {
+      if let value = meta[key] {
+        header.append("\(key): \(value)")
+      }
+    }
+    sections.append(header.joined(separator: "\n"))
+
+    let snapshots = currentSnapshotsForSentry()
+    if JSONSerialization.isValidJSONObject(snapshots),
+      let data = try? JSONSerialization.data(withJSONObject: snapshots, options: [.prettyPrinted]),
+      let json = String(data: data, encoding: .utf8)
+    {
+      sections.append("## Health snapshots\n\(json)")
+    }
+
+    let tail = redactedLogTail(logPath: logPath, maxLines: maxLogLines)
+    sections.append("## Recent log (redacted, last \(maxLogLines) lines)\n\(tail)")
+
+    return sections.joined(separator: "\n\n") + "\n"
+  }
+
+  /// Read up to `maxLines` from the end of the log file, redacting anything that
+  /// looks like a secret (tokens, JWTs, credential kv pairs) line by line.
+  private func redactedLogTail(logPath: String, maxLines: Int) -> String {
+    guard let content = try? String(contentsOfFile: logPath, encoding: .utf8) else {
+      return "(no readable log file at \(logPath))"
+    }
+    let lines = content.split(separator: "\n", omittingEmptySubsequences: false)
+    let tail = lines.suffix(max(0, maxLines))
+    return tail.map { redactSensitive(String($0)) }.joined(separator: "\n")
+  }
+
+  /// Defensive best-effort redaction. The desktop log is not expected to contain
+  /// raw credentials, but a manually-shared export must never leak one, so we
+  /// mask common token shapes before including any log text.
+  private static let redactionPatterns: [(NSRegularExpression, String)] = {
+    let specs: [(String, String)] = [
+      // JWT: three base64url segments starting with a typical header.
+      ("eyJ[A-Za-z0-9_-]+\\.[A-Za-z0-9_-]+\\.[A-Za-z0-9_-]+", "[redacted-jwt]"),
+      // Authorization: Bearer <token>
+      ("(?i)(bearer)\\s+[A-Za-z0-9._~+/=-]{8,}", "$1 [redacted]"),
+      // key=..., token: ..., password="..." in query strings, JSON, or kv logs.
+      (
+        "(?i)(api[_-]?key|access[_-]?token|refresh[_-]?token|id[_-]?token|token|password|passwd|secret|client[_-]?secret|authorization)([\"']?\\s*[=:]\\s*[\"']?)[A-Za-z0-9._~+/=-]{6,}",
+        "$1$2[redacted]"
+      ),
+    ]
+    return specs.compactMap { pattern, template in
+      (try? NSRegularExpression(pattern: pattern)).map { ($0, template) }
+    }
+  }()
+
+  private func redactSensitive(_ line: String) -> String {
+    var result = line
+    for (regex, template) in DesktopDiagnosticsManager.redactionPatterns {
+      let range = NSRange(result.startIndex..., in: result)
+      result = regex.stringByReplacingMatches(in: result, range: range, withTemplate: template)
+    }
+    return result
+  }
+
   #if DEBUG
   func resetForTests() {
     lock.lock()

--- a/desktop/macos/Desktop/Sources/DesktopDiagnosticsManager.swift
+++ b/desktop/macos/Desktop/Sources/DesktopDiagnosticsManager.swift
@@ -288,8 +288,23 @@ final class DesktopDiagnosticsManager {
   /// Read up to `maxLines` from the end of the log file, redacting anything that
   /// looks like a secret (tokens, JWTs, credential kv pairs) line by line.
   private func redactedLogTail(logPath: String, maxLines: Int) -> String {
-    guard let content = try? String(contentsOfFile: logPath, encoding: .utf8) else {
+    guard let handle = FileHandle(forReadingAtPath: logPath) else {
       return "(no readable log file at \(logPath))"
+    }
+    defer { handle.closeFile() }
+    // Read only a bounded tail from the end rather than loading the whole log
+    // into memory, so export latency and memory stay predictable on large logs.
+    // 512 KB comfortably covers maxLines (default 500) of log text.
+    let maxTailBytes: UInt64 = 512 * 1024
+    let fileSize = handle.seekToEndOfFile()
+    let start = fileSize > maxTailBytes ? fileSize - maxTailBytes : 0
+    handle.seek(toFileOffset: start)
+    let data = handle.readDataToEndOfFile()
+    // Lenient decode: a byte-offset seek can split a multibyte character, so
+    // substitute rather than fail; the possibly-partial first line is dropped.
+    var content = String(decoding: data, as: UTF8.self)
+    if start > 0, let newline = content.firstIndex(of: "\n") {
+      content = String(content[content.index(after: newline)...])
     }
     let lines = content.split(separator: "\n", omittingEmptySubsequences: false)
     let tail = lines.suffix(max(0, maxLines))

--- a/desktop/macos/Desktop/Sources/FeedbackView.swift
+++ b/desktop/macos/Desktop/Sources/FeedbackView.swift
@@ -1,5 +1,6 @@
 import Sentry
 import SwiftUI
+import UniformTypeIdentifiers
 
 /// Window controller for the feedback dialog
 @MainActor
@@ -80,9 +81,11 @@ struct FeedbackView: View {
         Text("Report an Issue")
           .font(.headline)
 
-        Text("App logs will be included automatically. Optionally describe what went wrong.")
-          .font(.caption)
-          .foregroundColor(.secondary)
+        Text(
+          "App logs will be included automatically. Optionally describe what went wrong, or save a redacted diagnostics file to share manually."
+        )
+        .font(.caption)
+        .foregroundColor(.secondary)
 
         TextEditor(text: $feedbackText)
           .font(.body)
@@ -113,6 +116,11 @@ struct FeedbackView: View {
           }
           .keyboardShortcut(.cancelAction)
 
+          Button("Save Diagnostics…") {
+            saveDiagnosticsLocally()
+          }
+          .help("Save a redacted diagnostics report locally — works offline, nothing is uploaded.")
+
           Spacer()
 
           Button("Send Report") {
@@ -140,9 +148,8 @@ struct FeedbackView: View {
 
     // Capture event with log file attached via scope
     let eventId = SentrySDK.capture(message: sentryMessage) { scope in
-      let isDev = AppBuild.isNonProduction
-      let logPath = isDev ? "/tmp/omi-dev.log" : "/tmp/omi.log"
-      let logFilename = isDev ? "omi-dev.log" : "omi.log"
+      let logPath = omiLogFilePath()
+      let logFilename = (logPath as NSString).lastPathComponent
       if FileManager.default.fileExists(atPath: logPath) {
         let attachment = Attachment(path: logPath, filename: logFilename, contentType: "text/plain")
         scope.addAttachment(attachment)
@@ -176,5 +183,32 @@ struct FeedbackView: View {
       showSuccess = true
       isSubmitting = false
     }
+  }
+
+  /// Save a redacted diagnostics bundle to a user-chosen location and reveal it
+  /// in Finder. Fully offline — no Sentry, no network — so users on named/dev
+  /// bundles or without connectivity can still capture a report (BL-023 / SET-03).
+  private func saveDiagnosticsLocally() {
+    let panel = NSSavePanel()
+    panel.title = "Save Diagnostics"
+    panel.message = "Save a redacted diagnostics report you can share manually."
+    panel.nameFieldStringValue = "omi-diagnostics-\(Self.exportTimestamp()).txt"
+    panel.allowedContentTypes = [.plainText]
+    panel.canCreateDirectories = true
+
+    guard panel.runModal() == .OK, let url = panel.url else { return }
+
+    if DesktopDiagnosticsManager.shared.writeLocalDiagnosticsBundle(to: url) {
+      NSWorkspace.shared.activateFileViewerSelecting([url])
+      log("Saved local diagnostics bundle to a user-chosen location")
+    } else {
+      log("Failed to save local diagnostics bundle")
+    }
+  }
+
+  private static func exportTimestamp() -> String {
+    let formatter = DateFormatter()
+    formatter.dateFormat = "yyyyMMdd-HHmmss"
+    return formatter.string(from: Date())
   }
 }

--- a/desktop/macos/Desktop/Sources/FeedbackView.swift
+++ b/desktop/macos/Desktop/Sources/FeedbackView.swift
@@ -198,11 +198,19 @@ struct FeedbackView: View {
 
     guard panel.runModal() == .OK, let url = panel.url else { return }
 
-    if DesktopDiagnosticsManager.shared.writeLocalDiagnosticsBundle(to: url) {
-      NSWorkspace.shared.activateFileViewerSelecting([url])
-      log("Saved local diagnostics bundle to a user-chosen location")
-    } else {
-      log("Failed to save local diagnostics bundle")
+    // Building the bundle reads the log, serializes snapshots, and writes the
+    // file — keep it off the main thread so a large log can't hang the UI. The
+    // panel already returned; reveal in Finder back on main.
+    DispatchQueue.global(qos: .userInitiated).async {
+      let saved = DesktopDiagnosticsManager.shared.writeLocalDiagnosticsBundle(to: url)
+      DispatchQueue.main.async {
+        if saved {
+          NSWorkspace.shared.activateFileViewerSelecting([url])
+          log("Saved local diagnostics bundle to a user-chosen location")
+        } else {
+          log("Failed to save local diagnostics bundle")
+        }
+      }
     }
   }
 

--- a/desktop/macos/Desktop/Sources/Logger.swift
+++ b/desktop/macos/Desktop/Sources/Logger.swift
@@ -5,6 +5,11 @@ private let logFile: String = {
   let isDev = AppBuild.isNonProduction
   return isDev ? "/tmp/omi-dev.log" : "/tmp/omi.log"
 }()
+/// The on-disk app-log path for the current build. Single source of truth for
+/// the log location so callers (feedback export, diagnostics bundle) don't
+/// re-derive it. Owner-only permissions are enforced by `ensureLogFileOwnerOnly`.
+func omiLogFilePath() -> String { logFile }
+
 private let logQueue = DispatchQueue(label: "me.omi.logger", qos: .utility)
 private let dateFormatter: DateFormatter = {
   let formatter = DateFormatter()
@@ -29,8 +34,32 @@ private func appendToLogFileSync(_ line: String) {
   }
 }
 
+/// Create the file at `path` (if missing) or tighten an existing file so it is
+/// readable and writable only by its owner (0600).
+///
+/// The log lives in the shared, world-readable `/tmp` directory and can contain
+/// UIDs, request context, and operational detail, so other local users must not
+/// be able to read it (BL-024 / SET-06). Idempotent and safe to call repeatedly.
+@discardableResult
+func ensureLogFileOwnerOnly(atPath path: String) -> Bool {
+  let fileManager = FileManager.default
+  if fileManager.fileExists(atPath: path) {
+    // Tighten files created by older builds (or a create without attributes).
+    return (try? fileManager.setAttributes([.posixPermissions: 0o600], ofItemAtPath: path)) != nil
+  }
+  return fileManager.createFile(atPath: path, contents: nil, attributes: [.posixPermissions: 0o600])
+}
+
+/// Guards the one-time permission normalization. Mutated only on the serial
+/// `logQueue` (every writer hops through it), so it needs no extra locking.
+private var didEnsureLogFilePermissions = false
+
 /// Shared file-write implementation (must be called on logQueue)
 private func writeToLogFile(_ data: Data) {
+  if !didEnsureLogFilePermissions {
+    didEnsureLogFilePermissions = true
+    ensureLogFileOwnerOnly(atPath: logFile)
+  }
   if FileManager.default.fileExists(atPath: logFile) {
     if let handle = FileHandle(forWritingAtPath: logFile) {
       handle.seekToEndOfFile()
@@ -38,7 +67,9 @@ private func writeToLogFile(_ data: Data) {
       handle.closeFile()
     }
   } else {
-    FileManager.default.createFile(atPath: logFile, contents: data)
+    // Recreate owner-only if the file was removed mid-session.
+    FileManager.default.createFile(
+      atPath: logFile, contents: data, attributes: [.posixPermissions: 0o600])
   }
 }
 

--- a/desktop/macos/Desktop/Sources/Logger.swift
+++ b/desktop/macos/Desktop/Sources/Logger.swift
@@ -37,15 +37,30 @@ private func appendToLogFileSync(_ line: String) {
 /// Create the file at `path` (if missing) or tighten an existing file so it is
 /// readable and writable only by its owner (0600).
 ///
-/// The log lives in the shared, world-readable `/tmp` directory and can contain
+/// The log lives in the shared, world-*writable* `/tmp` directory and can contain
 /// UIDs, request context, and operational detail, so other local users must not
-/// be able to read it (BL-024 / SET-06). Idempotent and safe to call repeatedly.
+/// be able to read it (BL-024 / SET-06). Because any local user can pre-create
+/// the path, we refuse to adopt anything that isn't a regular file owned by the
+/// current user: a symlink, a non-regular node, or someone else's file is removed
+/// and recreated owner-only, so we never chmod a symlink target or hand our logs
+/// to a file we don't control. Uses `lstat` (not `stat`) so a symlink is judged
+/// on its own, not its target. Idempotent and safe to call repeatedly. Returns
+/// whether the path is now a regular, owner-only file under our control.
 @discardableResult
 func ensureLogFileOwnerOnly(atPath path: String) -> Bool {
   let fileManager = FileManager.default
-  if fileManager.fileExists(atPath: path) {
-    // Tighten files created by older builds (or a create without attributes).
-    return (try? fileManager.setAttributes([.posixPermissions: 0o600], ofItemAtPath: path)) != nil
+  var info = stat()
+  if lstat(path, &info) == 0 {
+    let isRegularFile = (info.st_mode & mode_t(S_IFMT)) == mode_t(S_IFREG)
+    let isOwnedByUs = info.st_uid == getuid()
+    if isRegularFile && isOwnedByUs {
+      // Tighten files created by older builds (or a create without attributes).
+      return (try? fileManager.setAttributes([.posixPermissions: 0o600], ofItemAtPath: path)) != nil
+    }
+    // Symlink, non-regular node, or another user's file — never adopt it. In
+    // sticky `/tmp` we may be unable to remove an attacker-owned file; then we
+    // report failure (the caller keeps retrying) rather than trusting it.
+    guard (try? fileManager.removeItem(atPath: path)) != nil else { return false }
   }
   return fileManager.createFile(atPath: path, contents: nil, attributes: [.posixPermissions: 0o600])
 }
@@ -57,8 +72,10 @@ private var didEnsureLogFilePermissions = false
 /// Shared file-write implementation (must be called on logQueue)
 private func writeToLogFile(_ data: Data) {
   if !didEnsureLogFilePermissions {
-    didEnsureLogFilePermissions = true
-    ensureLogFileOwnerOnly(atPath: logFile)
+    // Latch only when normalization actually succeeds, so a transient failure
+    // (e.g. a racing create) is retried on the next write instead of leaving
+    // the log permanently world-readable.
+    didEnsureLogFilePermissions = ensureLogFileOwnerOnly(atPath: logFile)
   }
   if FileManager.default.fileExists(atPath: logFile) {
     if let handle = FileHandle(forWritingAtPath: logFile) {

--- a/desktop/macos/Desktop/Tests/DiagnosticsExportTests.swift
+++ b/desktop/macos/Desktop/Tests/DiagnosticsExportTests.swift
@@ -92,4 +92,28 @@ final class DiagnosticsExportTests: XCTestCase {
     let text = DesktopDiagnosticsManager.shared.buildLocalDiagnosticsText(logPath: missing)
     XCTAssertTrue(text.contains("no readable log file"))
   }
+
+  func testLogTailReadsBoundedEndOfLargeLogFile() throws {
+    let logPath = tempDir.appendingPathComponent("omi-dev.log").path
+    // A log larger than the 512 KB bounded-read window: the head line falls
+    // outside both the byte window and the requested line tail and must be
+    // excluded, while the tail marker survives. Exercises the end-of-file seek
+    // plus partial-first-line trim in redactedLogTail.
+    var lines = ["[00:00:00.000] [app] HEAD_MARKER_beyond_window"]
+    for i in 1...15000 {
+      lines.append("[00:00:00.000] [app] filler operational line number \(i)")
+    }
+    lines.append("[23:59:59.999] [app] TAIL_MARKER_at_end")
+    let body = lines.joined(separator: "\n")
+    XCTAssertGreaterThan(
+      body.utf8.count, 512 * 1024, "test log must exceed the bounded-read window")
+    try body.write(toFile: logPath, atomically: true, encoding: .utf8)
+
+    let text = DesktopDiagnosticsManager.shared.buildLocalDiagnosticsText(
+      logPath: logPath, maxLogLines: 50)
+
+    XCTAssertTrue(text.contains("TAIL_MARKER_at_end"), "tail line missing from export")
+    XCTAssertFalse(
+      text.contains("HEAD_MARKER_beyond_window"), "head line should be outside the bounded tail")
+  }
 }

--- a/desktop/macos/Desktop/Tests/DiagnosticsExportTests.swift
+++ b/desktop/macos/Desktop/Tests/DiagnosticsExportTests.swift
@@ -1,0 +1,95 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// BL-023 / SET-03: the local (offline) diagnostics export must produce a file
+/// with app/OS metadata and a *redacted* log tail — no raw tokens.
+final class DiagnosticsExportTests: XCTestCase {
+  private var tempDir: URL!
+
+  override func setUpWithError() throws {
+    try super.setUpWithError()
+    DesktopDiagnosticsManager.shared.resetForTests()
+    tempDir = FileManager.default.temporaryDirectory
+      .appendingPathComponent("diagnostics-export-\(UUID().uuidString)")
+    try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+  }
+
+  override func tearDownWithError() throws {
+    DesktopDiagnosticsManager.shared.resetForTests()
+    if let tempDir { try? FileManager.default.removeItem(at: tempDir) }
+    try super.tearDownWithError()
+  }
+
+  func testLocalBundleRedactsSecretsFromLogTailButKeepsBenignLines() throws {
+    let logPath = tempDir.appendingPathComponent("omi-dev.log").path
+    let jwt =
+      "eyJhbGciOiJIUzI1NiJ9.eyJ1aWQiOiJhYmMifQ.s3cr3tSignatureValue_do_not_leak"
+    let logContents = [
+      "[10:00:00.000] [app] launched cleanly",
+      "[10:00:01.000] [app] GET /v1/things?api_key=SUPERSECRETKEY123 status=200",
+      "[10:00:02.000] [app] Authorization: Bearer BEARERTOKENabc123def456",
+      "[10:00:03.000] [app] idToken=\(jwt)",
+      "[10:00:04.000] [app] user tapped Report Issue",
+    ].joined(separator: "\n")
+    try logContents.write(toFile: logPath, atomically: true, encoding: .utf8)
+
+    let text = DesktopDiagnosticsManager.shared.buildLocalDiagnosticsText(logPath: logPath)
+
+    // Secrets are gone.
+    XCTAssertFalse(text.contains("SUPERSECRETKEY123"), "api_key value leaked")
+    XCTAssertFalse(text.contains("BEARERTOKENabc123def456"), "bearer token leaked")
+    XCTAssertFalse(text.contains(jwt), "JWT leaked")
+    XCTAssertTrue(text.contains("[redacted"), "expected redaction markers")
+
+    // Benign operational lines survive so the report stays useful.
+    XCTAssertTrue(text.contains("launched cleanly"))
+    XCTAssertTrue(text.contains("user tapped Report Issue"))
+
+    // Metadata header is present and offline-safe.
+    XCTAssertTrue(text.contains("# Omi Desktop Diagnostics"))
+    XCTAssertTrue(text.contains("os_version:"))
+    XCTAssertTrue(text.contains("privacy: redacted_local_export"))
+  }
+
+  func testWriteLocalDiagnosticsBundleCreatesFileOffline() throws {
+    let logPath = tempDir.appendingPathComponent("omi-dev.log").path
+    try "[10:00:00.000] [app] hello\n".write(toFile: logPath, atomically: true, encoding: .utf8)
+
+    let outURL = tempDir.appendingPathComponent("omi-diagnostics.txt")
+    XCTAssertTrue(
+      DesktopDiagnosticsManager.shared.writeLocalDiagnosticsBundle(to: outURL, logPath: logPath))
+
+    XCTAssertTrue(FileManager.default.fileExists(atPath: outURL.path))
+    let written = try String(contentsOf: outURL, encoding: .utf8)
+    XCTAssertTrue(written.contains("# Omi Desktop Diagnostics"))
+    XCTAssertTrue(written.contains("hello"))
+  }
+
+  func testBundleIncludesSanitizedHealthSnapshots() throws {
+    DesktopDiagnosticsManager.shared.recordPTTSilentTurn(
+      source: "hub",
+      mode: "hold",
+      audioSeconds: 2.14,
+      voicedSeconds: nil,
+      peak: 0,
+      rms: 0,
+      deviceDescription: "built-in id=123 Alice private microphone",
+      micPermissionGranted: true,
+      hubActive: true)
+
+    let logPath = tempDir.appendingPathComponent("omi-dev.log").path
+    let text = DesktopDiagnosticsManager.shared.buildLocalDiagnosticsText(logPath: logPath)
+
+    XCTAssertTrue(text.contains("ptt_audio_capture_silent_turn"))
+    // The device-description PII must not survive into the snapshot section.
+    XCTAssertFalse(text.contains("Alice"))
+    XCTAssertFalse(text.contains("private microphone"))
+  }
+
+  func testMissingLogFileIsReportedNotCrashed() throws {
+    let missing = tempDir.appendingPathComponent("does-not-exist.log").path
+    let text = DesktopDiagnosticsManager.shared.buildLocalDiagnosticsText(logPath: missing)
+    XCTAssertTrue(text.contains("no readable log file"))
+  }
+}

--- a/desktop/macos/Desktop/Tests/LoggerPermissionsTests.swift
+++ b/desktop/macos/Desktop/Tests/LoggerPermissionsTests.swift
@@ -45,6 +45,30 @@ final class LoggerPermissionsTests: XCTestCase {
     XCTAssertEqual(try String(contentsOfFile: path, encoding: .utf8), "prior line\n")
   }
 
+  func testEnsureLogFileOwnerOnlyRejectsSymlinkAndDoesNotTouchTarget() throws {
+    // An attacker in world-writable /tmp pre-creates the log path as a symlink to
+    // a victim file. We must not chmod the victim or write through the link.
+    let victim = tempDir.appendingPathComponent("victim.txt").path
+    XCTAssertTrue(
+      FileManager.default.createFile(
+        atPath: victim, contents: Data("victim content\n".utf8),
+        attributes: [.posixPermissions: 0o644]))
+
+    let path = tempDir.appendingPathComponent("omi-symlinked.log").path
+    try FileManager.default.createSymbolicLink(atPath: path, withDestinationPath: victim)
+
+    XCTAssertTrue(ensureLogFileOwnerOnly(atPath: path))
+
+    // The symlink was replaced by a real owner-only file — the path is no longer
+    // a link (destinationOfSymbolicLink throws once it isn't one).
+    XCTAssertThrowsError(try FileManager.default.destinationOfSymbolicLink(atPath: path))
+    XCTAssertEqual(try posixPermissions(of: path), 0o600)
+
+    // The victim was neither tightened to 0600 nor overwritten through the link.
+    XCTAssertEqual(try posixPermissions(of: victim), 0o644)
+    XCTAssertEqual(try String(contentsOfFile: victim, encoding: .utf8), "victim content\n")
+  }
+
   private func posixPermissions(of path: String) throws -> Int {
     let attributes = try FileManager.default.attributesOfItem(atPath: path)
     let number = try XCTUnwrap(attributes[.posixPermissions] as? NSNumber)

--- a/desktop/macos/Desktop/Tests/LoggerPermissionsTests.swift
+++ b/desktop/macos/Desktop/Tests/LoggerPermissionsTests.swift
@@ -1,0 +1,53 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// BL-024 / SET-06: the app log must not be world-readable. These tests pin the
+/// permission-normalization helper the logger uses on every first write.
+final class LoggerPermissionsTests: XCTestCase {
+  private var tempDir: URL!
+
+  override func setUpWithError() throws {
+    try super.setUpWithError()
+    tempDir = FileManager.default.temporaryDirectory
+      .appendingPathComponent("logger-perms-\(UUID().uuidString)")
+    try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+  }
+
+  override func tearDownWithError() throws {
+    if let tempDir { try? FileManager.default.removeItem(at: tempDir) }
+    try super.tearDownWithError()
+  }
+
+  func testEnsureLogFileOwnerOnlyCreatesFileWith0600() throws {
+    let path = tempDir.appendingPathComponent("omi-new.log").path
+    XCTAssertFalse(FileManager.default.fileExists(atPath: path))
+
+    XCTAssertTrue(ensureLogFileOwnerOnly(atPath: path))
+
+    XCTAssertTrue(FileManager.default.fileExists(atPath: path))
+    XCTAssertEqual(try posixPermissions(of: path), 0o600)
+  }
+
+  func testEnsureLogFileOwnerOnlyTightensExistingWorldReadableFile() throws {
+    let path = tempDir.appendingPathComponent("omi-existing.log").path
+    // Simulate a log created by an older build with default (world-readable) perms.
+    XCTAssertTrue(
+      FileManager.default.createFile(
+        atPath: path, contents: Data("prior line\n".utf8),
+        attributes: [.posixPermissions: 0o644]))
+    XCTAssertEqual(try posixPermissions(of: path), 0o644)
+
+    XCTAssertTrue(ensureLogFileOwnerOnly(atPath: path))
+
+    XCTAssertEqual(try posixPermissions(of: path), 0o600)
+    // Existing content is preserved — only the mode changes.
+    XCTAssertEqual(try String(contentsOfFile: path, encoding: .utf8), "prior line\n")
+  }
+
+  private func posixPermissions(of path: String) throws -> Int {
+    let attributes = try FileManager.default.attributesOfItem(atPath: path)
+    let number = try XCTUnwrap(attributes[.posixPermissions] as? NSNumber)
+    return number.intValue
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260705-diagnostics-export-log-hygiene.json
+++ b/desktop/macos/changelog/unreleased/20260705-diagnostics-export-log-hygiene.json
@@ -1,0 +1,3 @@
+{
+  "change": "Added a \"Save Diagnostics…\" option to Report Issue that saves a redacted diagnostics report locally (works offline, nothing is uploaded), and the app log file is now created owner-only so it is no longer readable by other users on the machine"
+}


### PR DESCRIPTION
## Summary

Two desktop diagnostics/log-hygiene fixes (macOS hardening):

- **Log file world-readable (BL-024 / SET-06):** the app log in shared `/tmp` (`/tmp/omi-dev.log` / `/tmp/omi.log`) was created with default (world-readable) permissions. It's now created `0600` (owner-only), and any pre-existing looser log is tightened once on first write. The tighten flag is mutated only on the serial logging queue (no lock needed); the path is unchanged so documented readers (AGENTS.md, Sentry attachment, dev scripts) still work; first-write ordering preserves content.
- **No local diagnostics export (BL-023 / SET-03):** "Report Issue" was Sentry-only. Adds an offline **"Save Diagnostics…"** action that writes a **redacted** bundle (app/OS metadata + already-sanitized health snapshots + a redacted log tail) to a user-chosen location via `NSSavePanel` and reveals it in Finder — no network, no Sentry.

## Tests

- New `LoggerPermissionsTests` (2/2: create-`0600`, tighten-existing with content preserved) + `DiagnosticsExportTests` (4/4: real offline writer, token/JWT/Bearer redaction, PII-bucketed snapshots, missing-log handled).
- `bash test.sh` → **293 Rust + 131 Swift suites**, all green (independently re-run by a verifier pass).

## Honest scope

- **SET-06: PASS** (unit-verified). **SET-03: writer PASS (offline, unit-verified)**; the `NSSavePanel` chooser + reveal-in-Finder is GUI-**BLOCKED** (system modal, not driven headlessly).

## Follow-up (noted, not in this PR)

The export's log-tail redaction is defensive best-effort on a log not expected to hold raw credentials (the app already masks secrets at emit time). It reliably masks JWT (`eyJ…`), `Bearer <tok>`, and `key=/:<value>` shapes, but **misses**: bare high-entropy tokens with no keyword (`sk-proj-…`), space-separated values, plain `key:` (no `api` prefix), and `Authorization: Basic <base64>`. A fast follow can broaden value detection. No concrete unredacted-secret log line exists today.

## Changelog

`desktop/macos/changelog/unreleased/20260705-diagnostics-export-log-hygiene.json`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9106?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

