### PR TITLE
Fix chat session response validation for legacy records

### DIFF
--- a/backend/models/chat_session.py
+++ b/backend/models/chat_session.py
@@ -14,9 +14,9 @@ Collection: users/{uid}/chat_sessions and users/{uid}/messages.
 """
 
 from datetime import datetime
-from typing import Optional
+from typing import Any, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 
 class ChatSessionResponse(BaseModel):
@@ -31,6 +31,32 @@ class ChatSessionResponse(BaseModel):
     plugin_id: Optional[str] = Field(default=None, description='Mirrors app_id for cross-platform query compatibility.')
     message_count: int = Field(description='Number of messages in the session.')
     starred: bool = Field(description='Whether the user starred the session.')
+
+    @model_validator(mode='before')
+    @classmethod
+    def _repair_legacy_session_shape(cls, data: Any) -> Any:
+        if not isinstance(data, dict):
+            return data
+
+        app_id_val = data.get('app_id')
+        plugin_id_val = data.get('plugin_id')
+        if app_id_val is not None:
+            data['plugin_id'] = app_id_val
+        elif plugin_id_val is not None:
+            data['app_id'] = plugin_id_val
+
+        if not data.get('title'):
+            data['title'] = 'New Chat'
+        if 'preview' not in data:
+            data['preview'] = None
+        if data.get('updated_at') is None and data.get('created_at') is not None:
+            data['updated_at'] = data['created_at']
+        if data.get('message_count') is None:
+            data['message_count'] = len(data.get('message_ids') or [])
+        if data.get('starred') is None:
+            data['starred'] = False
+
+        return data
 
 
 class SaveMessageResponse(BaseModel):

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -109,6 +109,7 @@ pytest tests/unit/test_default_read_rollout_decision.py -v
 pytest tests/unit/test_rollout_schema_readiness.py -v
 pytest tests/unit/test_chat_memory_adapter.py -v
 pytest tests/unit/test_chat_memory_tool_caller.py -v
+pytest tests/unit/test_chat_session_response_model.py -v
 pytest tests/unit/test_tools_agent_route_response_shape.py -v
 pytest tests/unit/test_tools_rest_memory_runtime_adapter.py -v
 pytest tests/unit/test_p1_5_tools_fastapi_testclient_readiness.py -v

--- a/backend/tests/unit/test_chat_session_response_model.py
+++ b/backend/tests/unit/test_chat_session_response_model.py
@@ -1,0 +1,50 @@
+from datetime import datetime, timezone
+
+from pydantic import TypeAdapter
+
+from models.chat_session import ChatSessionResponse
+
+
+def test_chat_session_response_repairs_legacy_none_fields():
+    created_at = datetime(2026, 7, 5, tzinfo=timezone.utc)
+
+    response = ChatSessionResponse.model_validate(
+        {
+            'id': 'session-1',
+            'title': None,
+            'preview': None,
+            'created_at': created_at,
+            'updated_at': created_at,
+            'app_id': None,
+            'plugin_id': None,
+            'message_count': None,
+            'starred': None,
+            'message_ids': ['message-1', 'message-2'],
+        }
+    )
+
+    assert response.title == 'New Chat'
+    assert response.message_count == 2
+    assert response.starred is False
+
+
+def test_chat_session_response_list_accepts_legacy_missing_updated_at():
+    created_at = datetime(2026, 7, 5, tzinfo=timezone.utc)
+
+    responses = TypeAdapter(list[ChatSessionResponse]).validate_python(
+        [
+            {
+                'id': 'session-1',
+                'created_at': created_at,
+                'plugin_id': 'app-1',
+                'message_ids': ['message-1'],
+            }
+        ]
+    )
+
+    assert responses[0].title == 'New Chat'
+    assert responses[0].updated_at == created_at
+    assert responses[0].app_id == 'app-1'
+    assert responses[0].plugin_id == 'app-1'
+    assert responses[0].message_count == 1
+    assert responses[0].starred is False


### PR DESCRIPTION
## Summary
- repair legacy/partial chat session records before `ChatSessionResponse` validation
- derive defaults for missing/null `title`, `updated_at`, `message_count`, and `starred`
- add regression coverage for list response validation and wire it into backend/test.sh

Fixes #9099

## Tests
- `.venv/bin/python -m pytest tests/unit/test_chat_session_response_model.py tests/unit/test_desktop_migration.py::TestGetChatSessionsQuery -q`
- `PYTHON=.venv/bin/python bash test-preflight.sh`
- `BACKEND_UNIT_TEST_FILE_LIST=/tmp/omi-issue-9099-tests.txt PYTHON=.venv/bin/python bash test.sh`
- `.venv/bin/python scripts/check_module_stub_pollution.py`
- `.venv/bin/python scripts/scan_async_blockers.py --dirs routers utils`
- `.venv/bin/python scripts/scan_import_time_side_effects.py`
- pre-push hook: backend guards, selected unit test, OpenAPI contract, black --check


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9109?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

