### PR TITLE
fix(backend): prevent /v2/chat-sessions 500 (ResponseValidationError) (#9099)

### DIFF
--- a/backend/database/chat.py
+++ b/backend/database/chat.py
@@ -469,7 +469,7 @@ def get_chat_session_by_id(uid: str, chat_session_id: str):
     session_doc = session_ref.get()
 
     if session_doc.exists:
-        return session_doc.to_dict()
+        return _normalize_chat_session(session_doc.to_dict())
 
     return None
 
@@ -593,6 +593,30 @@ def migrate_chats_level_batch(uid: str, message_doc_ids: List[str], target_level
 # ============================================================================
 
 
+def _normalize_chat_session(data: Optional[dict]) -> Optional[dict]:
+    """Guarantee a v2 chat-session dict satisfies ``ChatSessionResponse``.
+
+    Firestore holds sessions written by several code paths (Python v2, the Rust
+    desktop backend, legacy docs). Some rows are missing fields the response
+    model requires (``title``, ``created_at``, ``message_count``, ``starred``),
+    which makes FastAPI raise ``ResponseValidationError`` (HTTP 500). Fill safe
+    defaults so listing/reading sessions never 500 on an incomplete doc.
+    """
+    if data is None:
+        return None
+    data.setdefault('title', 'New Chat')
+    data.setdefault('preview', None)
+    data.setdefault('message_count', 0)
+    data.setdefault('starred', False)
+    # created_at/updated_at are required datetimes; fall back to each other when
+    # one is missing (the list query orders by updated_at, so it is present there).
+    if data.get('created_at') is None:
+        data['created_at'] = data.get('updated_at')
+    if data.get('updated_at') is None:
+        data['updated_at'] = data.get('created_at')
+    return data
+
+
 def create_chat_session(uid: str, title: str = None, app_id: str = None) -> dict:
     session_id = str(uuid.uuid4())
     now = datetime.now(timezone.utc)
@@ -645,7 +669,7 @@ def get_chat_sessions(
     for doc in query.stream():
         data = doc.to_dict()
         data['id'] = doc.id
-        items.append(data)
+        items.append(_normalize_chat_session(data))
     return items
 
 
@@ -661,7 +685,7 @@ def update_chat_session(uid: str, session_id: str, title: str = None, starred: b
     ref.update(updates)
     result = ref.get().to_dict()
     result['id'] = session_id
-    return result
+    return _normalize_chat_session(result)
 
 
 # ============================================================================

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -109,6 +109,7 @@ pytest tests/unit/test_default_read_rollout_decision.py -v
 pytest tests/unit/test_rollout_schema_readiness.py -v
 pytest tests/unit/test_chat_memory_adapter.py -v
 pytest tests/unit/test_chat_memory_tool_caller.py -v
+pytest tests/unit/test_chat_session_normalize.py -v
 pytest tests/unit/test_tools_agent_route_response_shape.py -v
 pytest tests/unit/test_tools_rest_memory_runtime_adapter.py -v
 pytest tests/unit/test_p1_5_tools_fastapi_testclient_readiness.py -v

--- a/backend/tests/unit/test_chat_session_normalize.py
+++ b/backend/tests/unit/test_chat_session_normalize.py
@@ -1,0 +1,56 @@
+"""Regression test for GET /v2/chat-sessions ResponseValidationError (issue #9099).
+
+Commit e22938ac7 added a strict ``response_model=list[ChatSessionResponse]`` to
+the previously-untyped list endpoint. Firestore holds session docs written by
+several code paths (Python v2, Rust desktop backend, legacy), and some rows lack
+fields the model marks required (``title``, ``created_at``, ``message_count``,
+``starred``) — which made FastAPI raise ResponseValidationError (HTTP 500).
+
+``_normalize_chat_session`` fills safe defaults so those rows validate.
+"""
+
+from datetime import datetime, timezone
+
+from database.chat import _normalize_chat_session
+from models.chat_session import ChatSessionResponse
+
+
+def test_normalize_none_passthrough():
+    assert _normalize_chat_session(None) is None
+
+
+def test_normalize_fills_missing_required_fields_and_validates():
+    # A doc as returned by the list query: only id + updated_at + plugin_id are
+    # guaranteed present; title/created_at/message_count/starred are missing.
+    now = datetime.now(timezone.utc)
+    raw = {'id': 'sess-1', 'updated_at': now, 'plugin_id': None}
+
+    normalized = _normalize_chat_session(raw)
+
+    assert normalized['title'] == 'New Chat'
+    assert normalized['message_count'] == 0
+    assert normalized['starred'] is False
+    assert normalized['created_at'] == now  # falls back to updated_at
+
+    # The previously-failing step: strict response_model validation must pass.
+    ChatSessionResponse.model_validate(normalized)
+
+
+def test_normalize_preserves_existing_values():
+    now = datetime.now(timezone.utc)
+    raw = {
+        'id': 'sess-2',
+        'title': 'My chat',
+        'preview': 'hello',
+        'created_at': now,
+        'updated_at': now,
+        'message_count': 7,
+        'starred': True,
+    }
+
+    normalized = _normalize_chat_session(raw)
+
+    assert normalized['title'] == 'My chat'
+    assert normalized['message_count'] == 7
+    assert normalized['starred'] is True
+    ChatSessionResponse.model_validate(normalized)


### PR DESCRIPTION
## Bug (#9099)
After the schema-SSOT deploy, `GET /v2/chat-sessions?limit=50&offset=0` returns **500** with `fastapi.exceptions.ResponseValidationError: 2 validation errors`. Health/liveness stays green, so it's a response-schema regression, not an outage.

## Root cause
`e22938ac7` (Backfill response_model, part of the schema-SSOT plan `81d28b0`) added a strict `response_model=list[ChatSessionResponse]` to the previously-**untyped** `GET /v2/chat-sessions`. `ChatSessionResponse` marks `title`, `created_at`, `updated_at`, `message_count`, `starred` as **required**.

`database.chat.get_chat_sessions()` returns **raw Firestore dicts**. The listing query only guarantees `updated_at` + `plugin_id` are present. Session docs written by other code paths (the Rust desktop backend, legacy v1 rows) can be missing `title`, `created_at`, `message_count`, or `starred` — so FastAPI validation fails and returns 500. Reproduced locally: validating such a dict against `ChatSessionResponse` raises exactly this `ResponseValidationError`.

## Fix
Add `_normalize_chat_session()` in `database/chat.py` that fills safe defaults (`title='New Chat'`, `message_count=0`, `starred=False`, `preview=None`, and `created_at`/`updated_at` falling back to each other). Applied on the three read paths that feed `ChatSessionResponse`: list, get-by-id, and update. Surgical (~28 lines), no schema/contract change.

## Tests
- New `backend/tests/unit/test_chat_session_normalize.py` (registered in `test.sh`): asserts an incomplete session dict is normalized and passes `ChatSessionResponse.model_validate` — the previously-failing step. 3/3 pass on Python 3.11.

## Scope / risk
Backend null-guard style fix, low risk. Reported on dev; the offending commit is already on `main`, so prod listing is likely affected for any user with an incomplete session doc — but prod impact was not directly observed, so opening as **PR for review, not auto-merged**.

🤖 automated by hourly watchdog; opened for review, not merged.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9110?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

