### PR TITLE
ci(desktop): build and test Swift app in PRs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -329,7 +329,7 @@ jobs:
 
   desktop-swift:
     name: Desktop Swift Build & Tests
-    runs-on: macos-14
+    runs-on: macos-15
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -344,7 +344,7 @@ jobs:
           else
             DIFF_BASE="HEAD~1"
           fi
-          FILES=$(git diff --name-only --diff-filter=ACM "$DIFF_BASE"...HEAD)
+          FILES=$(git diff --name-only --diff-filter=ACMRD "$DIFF_BASE"...HEAD)
           echo "$FILES"
           if echo "$FILES" | grep -qE '^desktop/macos/Desktop/|^desktop/macos/test\.sh$|^desktop/macos/scripts/swift-test-suites\.sh$|^\.github/workflows/lint\.yml$'; then
             echo "should_run=true" >> "$GITHUB_OUTPUT"
@@ -359,9 +359,13 @@ jobs:
           path: |
             ~/Library/Caches/org.swift.swiftpm
             desktop/macos/Desktop/.build
-          key: ${{ runner.os }}-desktop-swift-${{ hashFiles('desktop/macos/Desktop/Package.resolved') }}
+          key: ${{ runner.os }}-desktop-swift-${{ hashFiles('desktop/macos/Desktop/Package.swift') }}
           restore-keys: |
             ${{ runner.os }}-desktop-swift-
+
+      - name: Install Swift system dependencies
+        if: steps.changed.outputs.should_run == 'true'
+        run: brew install pkg-config webp
 
       - name: Build desktop Swift app
         if: steps.changed.outputs.should_run == 'true'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -326,3 +326,49 @@ jobs:
         run: |
           npm ci
           npm run build
+
+  desktop-swift:
+    name: Desktop Swift Build & Tests
+    runs-on: macos-14
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check changed files
+        id: changed
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            DIFF_BASE="origin/${{ github.base_ref }}"
+          else
+            DIFF_BASE="HEAD~1"
+          fi
+          FILES=$(git diff --name-only --diff-filter=ACM "$DIFF_BASE"...HEAD)
+          echo "$FILES"
+          if echo "$FILES" | grep -qE '^desktop/macos/Desktop/|^desktop/macos/test\.sh$|^desktop/macos/scripts/swift-test-suites\.sh$|^\.github/workflows/lint\.yml$'; then
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Cache SwiftPM build products
+        if: steps.changed.outputs.should_run == 'true'
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/Library/Caches/org.swift.swiftpm
+            desktop/macos/Desktop/.build
+          key: ${{ runner.os }}-desktop-swift-${{ hashFiles('desktop/macos/Desktop/Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-desktop-swift-
+
+      - name: Build desktop Swift app
+        if: steps.changed.outputs.should_run == 'true'
+        working-directory: desktop/macos
+        run: xcrun swift build -c release --package-path Desktop --triple arm64-apple-macosx
+
+      - name: Test desktop Swift app
+        if: steps.changed.outputs.should_run == 'true'
+        working-directory: desktop/macos
+        run: ./scripts/swift-test-suites.sh

--- a/desktop/macos/Desktop/Tests/MemoryBankConnectorTests.swift
+++ b/desktop/macos/Desktop/Tests/MemoryBankConnectorTests.swift
@@ -15,7 +15,7 @@ final class MemoryBankConnectorTests: XCTestCase {
     MemoryBankConnector.claudeCLIPathOverrideForTesting = ""
     MemoryBankConnector.codexCLIPathOverrideForTesting = ""
     MemoryBankConnector.openClawCLIPathOverrideForTesting = try writeFakeOpenClawCLI().path
-    MemoryBankConnector.processTimeoutSecondsForTesting = 2
+    MemoryBankConnector.processTimeoutSecondsForTesting = 5
   }
 
   override func tearDownWithError() throws {

--- a/desktop/macos/Desktop/Tests/QueryTracerTests.swift
+++ b/desktop/macos/Desktop/Tests/QueryTracerTests.swift
@@ -61,18 +61,20 @@ final class QueryTracerTests: XCTestCase {
 
     // MARK: - 4. TTFT marking
 
-    func testTTFTMarking() {
+    func testTTFTMarking() throws {
         let tracer = QueryTracer(query: "ttft", inputMode: .text)
         Thread.sleep(forTimeInterval: 0.01)
         tracer.markTTFT()
-        // Second call should be ignored
+        let firstTrace = tracer.buildTrace(tokenCount: 10, model: "gpt-4")
+        let firstTTFT = try XCTUnwrap(firstTrace.ttft_ms)
+
+        // Second call should be ignored.
         Thread.sleep(forTimeInterval: 0.05)
         tracer.markTTFT()
 
         let trace = tracer.buildTrace(tokenCount: 10, model: "gpt-4")
-        XCTAssertNotNil(trace.ttft_ms)
-        // First mark was ~10ms after origin, so ttft should be < 50ms (not second mark)
-        XCTAssertLessThan(trace.ttft_ms!, 50)
+        XCTAssertEqual(trace.ttft_ms, firstTTFT)
+        XCTAssertGreaterThan(trace.total_ms, firstTTFT)
     }
 
     // MARK: - 5. Metadata passthrough

--- a/desktop/macos/scripts/swift-test-suites.sh
+++ b/desktop/macos/scripts/swift-test-suites.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# Runs Swift XCTest suites in isolated processes.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+MACOS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+skip_for_suite() {
+  case "$1" in
+    ChatDiscoverabilityTests)
+      echo "--skip ChatDiscoverabilityTests/testAgentControlCapabilitiesMatchCanonicalManifest --skip ChatDiscoverabilityTests/testDesktopCapabilitiesExistInAgentToolDeclarations --skip ChatDiscoverabilityTests/testDesktopPromptDistinguishesDelegationFromFloatingPills" ;;
+    APIClientRoutingTests)
+      echo "--skip APIClientRoutingTests/testDeleteConversationRoutesToPython" ;;
+    ActionItemsFTSRepairTests)
+      echo "--skip ActionItemsFTSRepairTests/testRepairToleratesMissingActionItemsFTSShadowTable" ;;
+    PiMonoWiringTests)
+      echo "--skip PiMonoWiringTests/testLocalAgentProviderDetectorMissingPromptIsUserFacing" ;;
+  esac
+}
+
+cd "$MACOS_DIR"
+
+# Discover suites recursively so tests in subfolders of Desktop/Tests are not
+# silently skipped (SwiftPM compiles the whole Tests target; this must match).
+suites=$(find Desktop/Tests -type f -name '*.swift' -print0 \
+  | xargs -0 grep -hE '^(final )?class [A-Za-z0-9_]+: XCTestCase' \
+  | sed -E 's/(final )?class ([A-Za-z0-9_]+):.*/\2/' | sort -u)
+suite_log_dir="$(mktemp -d)"
+trap 'rm -rf "$suite_log_dir"' EXIT
+failed_suites=""
+suite_count=0
+while read -r suite; do
+  [ -z "$suite" ] && continue
+  suite_count=$((suite_count + 1))
+  # shellcheck disable=SC2046
+  if ! xcrun swift test --package-path Desktop --filter "${suite}/" $(skip_for_suite "$suite") \
+      >"$suite_log_dir/$suite.log" 2>&1; then
+    failed_suites="$failed_suites $suite"
+    echo "--- FAILED: $suite ---"
+    cat "$suite_log_dir/$suite.log"
+  fi
+done <<< "$suites"
+echo "Ran $suite_count Swift suites in isolation."
+
+if [ -n "$failed_suites" ]; then
+  echo "FAILED Swift suites:$failed_suites"
+  exit 1
+fi

--- a/desktop/macos/scripts/swift-test-suites.sh
+++ b/desktop/macos/scripts/swift-test-suites.sh
@@ -23,8 +23,9 @@ cd "$MACOS_DIR"
 # Discover suites recursively so tests in subfolders of Desktop/Tests are not
 # silently skipped (SwiftPM compiles the whole Tests target; this must match).
 suites=$(find Desktop/Tests -type f -name '*.swift' -print0 \
-  | xargs -0 grep -hE '^(final )?class [A-Za-z0-9_]+: XCTestCase' \
-  | sed -E 's/(final )?class ([A-Za-z0-9_]+):.*/\2/' | sort -u)
+  | xargs -0 grep -hE '^[[:space:]]*(@[A-Za-z0-9_]+[[:space:]]+)*(public |internal |private |fileprivate |open )?(final )?(class|extension) [A-Za-z0-9_]+:.*XCTestCase' \
+  | sed -E 's/^[[:space:]]*(@[A-Za-z0-9_]+[[:space:]]+)*(public |internal |private |fileprivate |open )?(final )?(class|extension) ([A-Za-z0-9_]+):.*/\5/' \
+  | sort -u)
 suite_log_dir="$(mktemp -d)"
 trap 'rm -rf "$suite_log_dir"' EXIT
 failed_suites=""

--- a/desktop/macos/test.sh
+++ b/desktop/macos/test.sh
@@ -32,8 +32,8 @@ cd "$SCRIPT_DIR"
 # Tracking: https://github.com/BasedHardware/omi/issues/9029
 # (durable fix is singleton dependency injection; see the same issue).
 #
-# Method-level skips are the only remaining known-red tests; each needs a
-# product/policy decision, not a test change:
+# Method-level skips in scripts/swift-test-suites.sh are the only remaining
+# known-red tests; each needs a product/policy decision, not a test change:
 #   ChatDiscoverabilityTests/{testAgentControlCapabilitiesMatchCanonicalManifest,
 #     testDesktopCapabilitiesExistInAgentToolDeclarations,
 #     testDesktopPromptDistinguishesDelegationFromFloatingPills}
@@ -52,45 +52,7 @@ cd "$SCRIPT_DIR"
 #       — the detector does not fully honor the injected environment/home, so the
 #         result depends on whether OpenClaw is installed on the runner.
 #         https://github.com/BasedHardware/omi/issues/9033
-skip_for_suite() {
-  case "$1" in
-    ChatDiscoverabilityTests)
-      echo "--skip ChatDiscoverabilityTests/testAgentControlCapabilitiesMatchCanonicalManifest --skip ChatDiscoverabilityTests/testDesktopCapabilitiesExistInAgentToolDeclarations --skip ChatDiscoverabilityTests/testDesktopPromptDistinguishesDelegationFromFloatingPills" ;;
-    APIClientRoutingTests)
-      echo "--skip APIClientRoutingTests/testDeleteConversationRoutesToPython" ;;
-    ActionItemsFTSRepairTests)
-      echo "--skip ActionItemsFTSRepairTests/testRepairToleratesMissingActionItemsFTSShadowTable" ;;
-    PiMonoWiringTests)
-      echo "--skip PiMonoWiringTests/testLocalAgentProviderDetectorMissingPromptIsUserFacing" ;;
-  esac
-}
-
-# Discover suites recursively so tests in subfolders of Desktop/Tests are not
-# silently skipped (SwiftPM compiles the whole Tests target; this must match).
-suites=$(find Desktop/Tests -type f -name '*.swift' -print0 \
-  | xargs -0 grep -hE '^(final )?class [A-Za-z0-9_]+: XCTestCase' \
-  | sed -E 's/(final )?class ([A-Za-z0-9_]+):.*/\2/' | sort -u)
-suite_log_dir="$(mktemp -d)"
-trap 'rm -rf "$suite_log_dir"' EXIT
-failed_suites=""
-suite_count=0
-while read -r suite; do
-  [ -z "$suite" ] && continue
-  suite_count=$((suite_count + 1))
-  # shellcheck disable=SC2046
-  if ! xcrun swift test --package-path Desktop --filter "${suite}/" $(skip_for_suite "$suite") \
-      >"$suite_log_dir/$suite.log" 2>&1; then
-    failed_suites="$failed_suites $suite"
-    echo "--- FAILED: $suite ---"
-    cat "$suite_log_dir/$suite.log"
-  fi
-done <<< "$suites"
-echo "Ran $suite_count Swift suites in isolation."
-
-if [ -n "$failed_suites" ]; then
-  echo "FAILED Swift suites:$failed_suites"
-  exit 1
-fi
+"$SCRIPT_DIR/scripts/swift-test-suites.sh"
 echo ""
 
 echo "All desktop tests passed."


### PR DESCRIPTION
## Summary
- add a path-filtered macOS CI job for desktop Swift changes
- run the release Swift build before merge: `xcrun swift build -c release --package-path Desktop --triple arm64-apple-macosx`
- run Swift XCTest suites through a shared per-suite isolation script used by both CI and `desktop/macos/test.sh`
- make the memory-bank connector process timeout test setup less brittle on loaded CI machines

Closes #8842.

## CI weight / timing
Measured locally on this Mac while developing the PR:
- release Swift build: 348s (5m48s), including SwiftPM dependency checkout/fetch from local cache
- isolated Swift suite runner before timeout hardening: 269s (4m29s), failed on a 2s helper timeout
- isolated Swift suite runner after timeout hardening: 208s (3m28s), 128 suites passed

Expected full desktop Swift job cost is roughly 9-10 minutes cold-ish for desktop Swift PRs, with SwiftPM cache expected to reduce subsequent runs. The job exits after the changed-file check for non-desktop-Swift PRs.

## Tests
- `xcrun swift build -c release --package-path Desktop --triple arm64-apple-macosx`
- `xcrun swift test --package-path Desktop --filter 'MemoryBankConnectorTests/testCodexConnectRedactsTokenFromCLIError'`
- `./scripts/swift-test-suites.sh`
- `/opt/homebrew/bin/actionlint -shellcheck "" .github/workflows/lint.yml`
- `bash -n desktop/macos/test.sh desktop/macos/scripts/swift-test-suites.sh`
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9111?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

