### PR TITLE
test: isolate unit sys.modules stubs

### DIFF
--- a/backend/tests/unit/test_action_item_date_validation.py
+++ b/backend/tests/unit/test_action_item_date_validation.py
@@ -52,8 +52,18 @@ def _stub_module(name):
 
 
 def _stub_package(name):
-    mod = _stub_module(name)
+    # Always replace package modules with fresh stubs after the sys.modules
+    # snapshot. Reusing an already-imported real package and mutating
+    # ``__path__`` would alter the snapshotted object itself, so restoring the
+    # sys.modules entry later would still leave the original package corrupted.
+    mod = types.ModuleType(name)
     mod.__path__ = []
+    sys.modules[name] = mod
+    if "." in name:
+        parent_name, attr_name = name.rsplit(".", 1)
+        parent = sys.modules.get(parent_name)
+        if parent is not None:
+            setattr(parent, attr_name, mod)
     return mod
 
 

--- a/backend/tests/unit/test_action_item_date_validation.py
+++ b/backend/tests/unit/test_action_item_date_validation.py
@@ -21,6 +21,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from tests.unit.memory_import_isolation import restore_sys_modules, snapshot_sys_modules
+
 # ---------------------------------------------------------------------------
 # Paths
 # ---------------------------------------------------------------------------
@@ -71,7 +73,58 @@ def _load_module_from_file(module_name, file_path):
 
 # ---------------------------------------------------------------------------
 # Stub heavy dependencies
+#
+# Snapshot touched modules first so the stubs installed below do not leak into
+# other test files during bulk ``pytest tests/unit/`` collection (issue #8661).
+# They are restored right after the modules under test are imported.
 # ---------------------------------------------------------------------------
+_SYS_MODULE_NAMES = [
+    "firebase_admin",
+    "firebase_admin.firestore",
+    "firebase_admin.auth",
+    "firebase_admin.messaging",
+    "firebase_admin.credentials",
+    "google.cloud.firestore",
+    "google.cloud.firestore_v1",
+    "google.cloud.firestore_v1.base_query",
+    "google.auth",
+    "google.auth.transport",
+    "google.auth.transport.requests",
+    "google.cloud.storage",
+    "opuslib",
+    "sentry_sdk",
+    "database",
+    "database._client",
+    "database.redis_db",
+    "database.auth",
+    "database.action_items",
+    "database.notifications",
+    "utils",
+    "utils.notifications",
+    "utils.byok",
+    "utils.llm",
+    "utils.llm.gateway_client",
+    "utils.llm.gateway_observability",
+    "utils.llm.clients",
+    "utils.llm.conversation_folder",
+    "utils.llm.conversation_processing",
+    "utils.retrieval",
+    "utils.retrieval.tools",
+    "utils.retrieval.tools.action_item_tools",
+    "utils.retrieval.agentic",
+    "utils.conversations",
+    "utils.conversations.render",
+    "langchain_core",
+    "langchain_core.tools",
+    "langchain_core.runnables",
+    "langchain_core.output_parsers",
+    "langchain_core.prompts",
+    "models",
+    "models.conversation",
+    "models.app",
+]
+_SYS_MODULES_SNAPSHOT = snapshot_sys_modules(_SYS_MODULE_NAMES)
+
 for importable_mod_name in [
     "google.auth",
     "google.auth.transport",
@@ -235,6 +288,16 @@ action_item_tools = _load_module_from_file(
 )
 create_action_item_tool = action_item_tools.create_action_item_tool
 update_action_item_tool = action_item_tools.update_action_item_tool
+
+conversation_processing = _load_module_from_file(
+    "utils.llm.conversation_processing",
+    BACKEND_DIR / "utils" / "llm" / "conversation_processing.py",
+)
+
+# Restore sys.modules now that the modules under test are imported and bound to
+# their stubbed dependencies. Tests below patch those module objects directly.
+restore_sys_modules(_SYS_MODULES_SNAPSHOT)
+del _SYS_MODULES_SNAPSHOT, _SYS_MODULE_NAMES
 
 
 def _make_config(uid="test-user-123"):
@@ -432,12 +495,7 @@ class TestExtractActionItemsPostValidation:
 
     def test_prompt_contains_current_time_and_staleness_rule(self):
         """The extraction prompt source should contain current_time and staleness logic."""
-        # Load conversation_processing to inspect source
-        conv_proc = _load_module_from_file(
-            "utils.llm.conversation_processing",
-            BACKEND_DIR / "utils" / "llm" / "conversation_processing.py",
-        )
-        source = inspect.getsource(conv_proc.extract_action_items)
+        source = inspect.getsource(conversation_processing.extract_action_items)
         assert 'current_time' in source, "extract_action_items must pass current_time"
         assert '7 days' in source or 'HISTORICAL' in source, "must contain staleness rule"
 
@@ -459,12 +517,7 @@ class TestExtractActionItemsPostValidation:
         mock_chain.invoke.return_value = mock_response
         mock_chain.__or__ = MagicMock(return_value=mock_chain)
 
-        conv_proc = sys.modules.get("utils.llm.conversation_processing")
-        if conv_proc is None:
-            conv_proc = _load_module_from_file(
-                "utils.llm.conversation_processing",
-                BACKEND_DIR / "utils" / "llm" / "conversation_processing.py",
-            )
+        conv_proc = conversation_processing
 
         mock_llm = MagicMock()
         mock_llm.bind.return_value = mock_llm
@@ -501,12 +554,7 @@ class TestExtractActionItemsPostValidation:
         mock_chain.invoke.return_value = mock_response
         mock_chain.__or__ = MagicMock(return_value=mock_chain)
 
-        conv_proc = sys.modules.get("utils.llm.conversation_processing")
-        if conv_proc is None:
-            conv_proc = _load_module_from_file(
-                "utils.llm.conversation_processing",
-                BACKEND_DIR / "utils" / "llm" / "conversation_processing.py",
-            )
+        conv_proc = conversation_processing
 
         mock_llm = MagicMock()
         mock_llm.bind.return_value = mock_llm
@@ -545,12 +593,7 @@ class TestExtractActionItemsPostValidation:
         mock_chain.invoke.return_value = mock_response
         mock_chain.__or__ = MagicMock(return_value=mock_chain)
 
-        conv_proc = sys.modules.get("utils.llm.conversation_processing")
-        if conv_proc is None:
-            conv_proc = _load_module_from_file(
-                "utils.llm.conversation_processing",
-                BACKEND_DIR / "utils" / "llm" / "conversation_processing.py",
-            )
+        conv_proc = conversation_processing
 
         mock_llm = MagicMock()
         mock_llm.bind.return_value = mock_llm
@@ -589,12 +632,7 @@ class TestExtractActionItemsPostValidation:
         mock_chain.invoke.return_value = mock_response
         mock_chain.__or__ = MagicMock(return_value=mock_chain)
 
-        conv_proc = sys.modules.get("utils.llm.conversation_processing")
-        if conv_proc is None:
-            conv_proc = _load_module_from_file(
-                "utils.llm.conversation_processing",
-                BACKEND_DIR / "utils" / "llm" / "conversation_processing.py",
-            )
+        conv_proc = conversation_processing
 
         mock_llm = MagicMock()
         mock_llm.bind.return_value = mock_llm
@@ -639,12 +677,7 @@ class TestActionItemTimezoneConversion:
         mock_chain.invoke.return_value = mock_response
         mock_chain.__or__ = MagicMock(return_value=mock_chain)
 
-        conv_proc = sys.modules.get("utils.llm.conversation_processing")
-        if conv_proc is None:
-            conv_proc = _load_module_from_file(
-                "utils.llm.conversation_processing",
-                BACKEND_DIR / "utils" / "llm" / "conversation_processing.py",
-            )
+        conv_proc = conversation_processing
 
         mock_llm = MagicMock()
         mock_llm.bind.return_value = mock_llm

--- a/backend/tests/unit/test_action_item_tool_result_bound.py
+++ b/backend/tests/unit/test_action_item_tool_result_bound.py
@@ -17,6 +17,8 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from tests.unit.memory_import_isolation import restore_sys_modules, snapshot_sys_modules
+
 BACKEND_DIR = Path(__file__).resolve().parent.parent.parent
 
 os.environ.setdefault(
@@ -52,6 +54,21 @@ def _load(module_name, rel_path):
 
 # Stub the heavy leaves action_item_tools imports; langchain_core is used for real (the @tool
 # decorator needs it). None of these are exercised by the pure helpers under test.
+_SYS_MODULE_NAMES = [
+    "database",
+    "database.action_items",
+    "database.notifications",
+    "utils",
+    "utils.notifications",
+    "utils.conversations",
+    "utils.conversations.render",
+    "utils.retrieval",
+    "utils.retrieval.agentic",
+    "utils.retrieval.tools",
+    "utils.retrieval.tools.action_item_tools",
+]
+_SYS_MODULES_SNAPSHOT = snapshot_sys_modules(_SYS_MODULE_NAMES)
+
 for _p in [
     "database",
     "utils",
@@ -77,6 +94,9 @@ for _name, _attrs in {
         setattr(_m, _a, MagicMock())
 
 ai = _load("utils.retrieval.tools.action_item_tools", "utils/retrieval/tools/action_item_tools.py")
+
+restore_sys_modules(_SYS_MODULES_SNAPSHOT)
+del _SYS_MODULES_SNAPSHOT, _SYS_MODULE_NAMES
 
 
 class TestCapActionItemsForLlm:

--- a/backend/tests/unit/test_action_item_tool_result_bound.py
+++ b/backend/tests/unit/test_action_item_tool_result_bound.py
@@ -28,11 +28,14 @@ os.environ.setdefault(
 
 
 def _pkg(name):
-    mod = sys.modules.get(name)
-    if mod is None or not hasattr(mod, "__path__"):
-        mod = types.ModuleType(name)
-        mod.__path__ = []
-        sys.modules[name] = mod
+    mod = types.ModuleType(name)
+    mod.__path__ = []
+    sys.modules[name] = mod
+    if "." in name:
+        parent_name, attr_name = name.rsplit(".", 1)
+        parent = sys.modules.get(parent_name)
+        if parent is not None:
+            setattr(parent, attr_name, mod)
     return mod
 
 

--- a/backend/tests/unit/test_tools_router.py
+++ b/backend/tests/unit/test_tools_router.py
@@ -21,6 +21,10 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from tests.unit.memory_import_isolation import restore_sys_modules, snapshot_sys_modules
 
 # ---------------------------------------------------------------------------
 # Paths
@@ -61,7 +65,69 @@ def _load_module_from_file(module_name, file_path):
 
 # ---------------------------------------------------------------------------
 # Stub heavy dependencies before importing anything from backend
+#
+# Snapshot touched modules first so the stubs installed below do not leak into
+# other test files during bulk ``pytest tests/unit/`` collection (issue #8661).
+# They are restored right after the modules under test are imported.
 # ---------------------------------------------------------------------------
+_SYS_MODULE_NAMES = [
+    "firebase_admin",
+    "firebase_admin.firestore",
+    "firebase_admin.auth",
+    "firebase_admin.messaging",
+    "firebase_admin.credentials",
+    "google.cloud.firestore",
+    "google.cloud.firestore_v1",
+    "google.cloud.firestore_v1.base_query",
+    "google.auth",
+    "google.auth.transport",
+    "google.auth.transport.requests",
+    "google.cloud.storage",
+    "opuslib",
+    "sentry_sdk",
+    "database",
+    "database._client",
+    "database.redis_db",
+    "database.auth",
+    "database.conversations",
+    "database.users",
+    "database.memories",
+    "database.vector_db",
+    "database.action_items",
+    "database.notifications",
+    "utils",
+    "utils.notifications",
+    "utils.conversations",
+    "utils.conversations.render",
+    "utils.conversations.factory",
+    "utils.conversations.search",
+    "utils.conversations.transcript_chunks",
+    "utils.retrieval",
+    "utils.retrieval.tools",
+    "utils.retrieval.tools.calendar_tools",
+    "utils.retrieval.tool_services",
+    "utils.retrieval.tool_services.conversations",
+    "utils.retrieval.tool_services.memories",
+    "utils.retrieval.tool_services.action_items",
+    "utils.retrieval.tool_result_boundaries",
+    "utils.other",
+    "utils.other.endpoints",
+    "utils.memory",
+    "utils.memory.chat_memory_adapter",
+    "utils.memory.default_read_rollout",
+    "utils.memory.memory_system",
+    "utils.memory.memory_service",
+    "utils.memory.surface_routing",
+    "utils.rate_limit_config",
+    "routers",
+    "routers.tools",
+    "models",
+    "models.conversation",
+    "models.other",
+    "models.memories",
+]
+_SYS_MODULES_SNAPSHOT = snapshot_sys_modules(_SYS_MODULE_NAMES)
+
 for mod_name in [
     "firebase_admin",
     "firebase_admin.firestore",
@@ -297,6 +363,19 @@ action_items_svc = _load_module_from_file(
     "utils.retrieval.tool_services.action_items",
     BACKEND_DIR / "utils" / "retrieval" / "tool_services" / "action_items.py",
 )
+router_mod = _load_module_from_file(
+    "routers.tools",
+    BACKEND_DIR / "routers" / "tools.py",
+)
+rate_limit_config_mod = _load_module_from_file(
+    "utils.rate_limit_config",
+    BACKEND_DIR / "utils" / "rate_limit_config.py",
+)
+
+# Restore sys.modules now that the modules under test are imported and bound to
+# their stubbed dependencies. Tests below patch those module objects directly.
+restore_sys_modules(_SYS_MODULES_SNAPSHOT)
+del _SYS_MODULES_SNAPSHOT, _SYS_MODULE_NAMES
 
 
 # ===========================================================================
@@ -653,18 +732,12 @@ class TestRouterEnvelope:
     """Test the _ok helper in the router module."""
 
     def test_ok_normal(self):
-        # Import the router module
-        router_mod = _load_module_from_file(
-            "routers.tools",
-            BACKEND_DIR / "routers" / "tools.py",
-        )
         result = router_mod._ok("test_tool", "All good")
         assert result["tool_name"] == "test_tool"
         assert result["result_text"] == "All good"
         assert result["is_error"] is False
 
     def test_ok_error(self):
-        router_mod = sys.modules["routers.tools"]
         result = router_mod._ok("test_tool", "Error: something went wrong")
         assert result["is_error"] is True
 
@@ -677,18 +750,12 @@ class TestRouterEndpoints:
 
     @pytest.fixture(autouse=True)
     def setup_app(self):
-        from fastapi import FastAPI
-        from fastapi.testclient import TestClient
-
         # Override auth dependency
-        router_mod = sys.modules["routers.tools"]
         app = FastAPI()
         app.include_router(router_mod.router)
 
         # Override auth deps to return a fixed uid
-        from utils.other.endpoints import get_current_user_uid
-
-        app.dependency_overrides[get_current_user_uid] = lambda: "test-uid"
+        app.dependency_overrides[endpoints_mod.get_current_user_uid] = lambda: "test-uid"
         # Override rate-limited deps too — with_rate_limit returns a new dependency
         # so we need to override whatever it returned
         for route in app.routes:
@@ -879,17 +946,14 @@ class TestRateLimitPolicies:
     """Verify rate limit policies exist and are wired correctly."""
 
     def test_tools_search_policy_exists(self):
-        rl_mod = _load_module_from_file(
-            "utils.rate_limit_config",
-            BACKEND_DIR / "utils" / "rate_limit_config.py",
-        )
+        rl_mod = rate_limit_config_mod
         assert "tools:search" in rl_mod.RATE_POLICIES
         max_req, window = rl_mod.RATE_POLICIES["tools:search"]
         assert max_req == 60
         assert window == 3600
 
     def test_tools_mutate_policy_exists(self):
-        rl_mod = sys.modules["utils.rate_limit_config"]
+        rl_mod = rate_limit_config_mod
         assert "tools:mutate" in rl_mod.RATE_POLICIES
         max_req, window = rl_mod.RATE_POLICIES["tools:mutate"]
         assert max_req == 60

--- a/backend/tests/unit/test_tools_router.py
+++ b/backend/tests/unit/test_tools_router.py
@@ -50,6 +50,11 @@ def _stub_package(name):
     mod = types.ModuleType(name)
     mod.__path__ = []
     sys.modules[name] = mod
+    if "." in name:
+        parent_name, attr_name = name.rsplit(".", 1)
+        parent = sys.modules.get(parent_name)
+        if parent is not None:
+            setattr(parent, attr_name, mod)
     return mod
 
 


### PR DESCRIPTION
## Summary
- stop `test_action_item_date_validation.py` and `test_tools_router.py` from leaking module-level stubs into later unit-test collection
- add the same cleanup to `test_action_item_tool_result_bound.py`, which reproduced the same `utils.request_validation` import failure pattern
- keep router/rate-limit module references directly in tests after restoring `sys.modules`

Fixes #8661

## Verification
- `PYTHON=.venv/bin/python bash test-preflight.sh`
- `.venv/bin/python -m pytest tests/unit/test_action_item_date_validation.py tests/unit/test_apps_create_app_json.py -q`
- `.venv/bin/python -m pytest tests/unit/test_tools_router.py tests/unit/test_apps_create_app_json.py -q`
- `.venv/bin/python -m pytest tests/unit/test_action_items_timezone.py tests/unit/test_apps_create_app_json.py -q`
- `.venv/bin/python -m pytest tests/unit/test_action_item_tool_result_bound.py tests/unit/test_apps_create_app_json.py -q`
- `.venv/bin/python -m pytest tests/unit/test_firestore_di_seam.py -q`
- pre-push hook passed, including module-stub pollution, import-time side-effect, selected backend unit tests, OpenAPI contract, and black checks

## Notes
- `fake-firestore` is already present in the checked-in backend pylocks and OpenAPI/e2e requirements on current `main`, and `test_firestore_di_seam.py` passes locally.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9113?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

