### PR TITLE
fix(desktop): re-arm the silent-mic watchdog so it recovers more than once per session

### DIFF
--- a/desktop/macos/Desktop/Sources/AudioCaptureService.swift
+++ b/desktop/macos/Desktop/Sources/AudioCaptureService.swift
@@ -567,6 +567,11 @@ class AudioCaptureService: @unchecked Sendable {
             // Clamp and convert to Int16 range (-32768 to 32767)
             let pcmSample = Int16(max(-32768, min(32767, sample * 32767)))
             pcmData.append(pcmSample)
+
+            // Accumulate the silent-mic peak while converting samples to avoid an
+            // extra pass on the audio callback hot path.
+            let absoluteSample = pcmSample == Int16.min ? Int16.max : Int16(pcmSample.magnitude)
+            if absoluteSample > watchdogWindowPeak { watchdogWindowPeak = absoluteSample }
         }
 
         // Convert to Data (little-endian, which is native on Apple platforms)
@@ -577,14 +582,9 @@ class AudioCaptureService: @unchecked Sendable {
         // Silent-mic watchdog: macOS can accept the IOProc but deliver only zero samples.
         // Bluetooth inputs recover by switching to the built-in mic; PTT can opt into
         // all-transport detection so a stale built-in/default route triggers a full rebuild.
-        // Accumulate this callback's peak, then classify once every ~1s window. Windows keep
-        // rolling after a fire (unlike a one-shot latch) so the watchdog observes recovery and
-        // can re-arm for a second episode — see `evaluateSilentMicWindow`.
-        for s in pcmData {
-            // Int16.min has magnitude 32768 which is out of Int16 range — clamp.
-            let a = s == Int16.min ? Int16.max : Int16(s.magnitude)
-            if a > watchdogWindowPeak { watchdogWindowPeak = a }
-        }
+        // Classify once every ~1s window. Windows keep rolling after a fire (unlike a
+        // one-shot latch) so the watchdog observes recovery and can re-arm for a second
+        // episode — see `evaluateSilentMicWindow`.
         let nowAbs = CFAbsoluteTimeGetCurrent()
         if watchdogWindowStart == 0 { watchdogWindowStart = nowAbs }
         if nowAbs - watchdogWindowStart >= 1.0 {

--- a/desktop/macos/Desktop/Sources/AudioCaptureService.swift
+++ b/desktop/macos/Desktop/Sources/AudioCaptureService.swift
@@ -83,11 +83,12 @@ class AudioCaptureService: @unchecked Sendable {
     private var onAudioChunk: AudioChunkHandler?
     private var onAudioLevel: AudioLevelHandler?
 
-    /// Called once when the mic has been alive-but-silent for `silentMicWindowThreshold`
-    /// seconds. By default this is limited to Bluetooth inputs, where macOS can feed
+    /// Called when the mic has been alive-but-silent for `silentMicWindowThreshold`
+    /// windows. By default this is limited to Bluetooth inputs, where macOS can feed
     /// zeros during A2DP/HFP profile conflicts. PTT enables all-transport detection so
     /// it can recover a stale HAL route that reports the built-in mic but still returns
-    /// silence. Fires at most once per capture session.
+    /// silence. The watchdog re-arms after each fire (see `evaluateSilentMicWindow`), so a
+    /// single capture session can recover from more than one silent episode.
     var onSilentMicDetected: ((SilentMicDetection) -> Void)?
     var detectSilentMicOnAnyTransport = false
 
@@ -98,10 +99,19 @@ class AudioCaptureService: @unchecked Sendable {
         return isBuiltIn ? "built-in id=\(deviceID)" : "id=\(deviceID)"
     }
 
-    // Silent-mic watchdog (fires once per session)
+    // Silent-mic watchdog. Re-arms after each fire so one session can recover from more
+    // than one silent episode; two guards keep it from spinning the recovery loop:
+    //   - `silentMicRecoveryCooldown`: suppress re-detection right after a fire so a freshly
+    //     rebuilt/switched capture has time to deliver real audio before we judge it again.
+    //   - `maxSilentMicFiresPerSession`: hard cap so an unrecoverable mic can't loop forever.
+    // `silentMicDetectedFired` now means "recently fired, awaiting re-arm" (not a permanent latch).
     private var consecutiveSilentWindows: Int = 0
     private var silentMicDetectedFired: Bool = false
+    private var silentMicFireCount: Int = 0
+    private var lastSilentMicFireTime: CFAbsoluteTime = 0
     private let silentMicWindowThreshold: Int = 2  // windows of ~1s each
+    private let silentMicRecoveryCooldown: CFAbsoluteTime = 3.0  // seconds to let recovery take effect
+    private let maxSilentMicFiresPerSession: Int = 3
 
     /// Target sample rate for DeepGram
     private let targetSampleRate: Double = 16000
@@ -135,8 +145,59 @@ class AudioCaptureService: @unchecked Sendable {
     func resetSilentMicWatchdog() {
         consecutiveSilentWindows = 0
         silentMicDetectedFired = false
+        silentMicFireCount = 0
+        lastSilentMicFireTime = 0
         watchdogWindowPeak = 0
         watchdogWindowStart = 0
+    }
+
+    /// Classify one closed ~1-second watchdog window and update re-arm bookkeeping.
+    ///
+    /// Returns a `SilentMicDetection` when the mic has been silent for
+    /// `silentMicWindowThreshold` consecutive windows and the watchdog is armed — the
+    /// caller then invokes `onSilentMicDetected`. Returns `nil` otherwise. After a fire the
+    /// watchdog suppresses re-detection until `silentMicRecoveryCooldown` has elapsed, then
+    /// re-arms, so a mic that recovered and later re-wedged (or a recovery that did not take)
+    /// is detected again — bounded by `maxSilentMicFiresPerSession` so an unrecoverable mic
+    /// cannot loop the recovery path forever.
+    ///
+    /// `internal` (not `private`) so the recover-more-than-once-per-session contract can be
+    /// unit-tested without driving real CoreAudio buffers.
+    func evaluateSilentMicWindow(peak: Int16, isBluetooth: Bool, now: CFAbsoluteTime) -> SilentMicDetection? {
+        // peak ≤ 5 (≈ -76 dBFS) is effectively silent compared to real speech.
+        if peak <= 5 {
+            consecutiveSilentWindows += 1
+        } else {
+            consecutiveSilentWindows = 0
+        }
+
+        // Re-arm once the post-fire cooldown has elapsed.
+        if silentMicDetectedFired, now - lastSilentMicFireTime >= silentMicRecoveryCooldown {
+            silentMicDetectedFired = false
+        }
+
+        guard !silentMicDetectedFired,
+              silentMicFireCount < maxSilentMicFiresPerSession,
+              consecutiveSilentWindows >= silentMicWindowThreshold,
+              isBluetooth || detectSilentMicOnAnyTransport
+        else {
+            return nil
+        }
+
+        let firedWindows = consecutiveSilentWindows
+        silentMicDetectedFired = true
+        silentMicFireCount += 1
+        lastSilentMicFireTime = now
+        // Require a fresh run of silent windows before the next fire so we never re-trigger
+        // on the very next window.
+        consecutiveSilentWindows = 0
+
+        return SilentMicDetection(
+            deviceID: deviceID,
+            deviceDescription: currentDeviceDescription,
+            consecutiveSilentWindows: firedWindows,
+            isBluetoothTransport: isBluetooth
+        )
     }
 
     /// Check if microphone permission is granted
@@ -516,44 +577,29 @@ class AudioCaptureService: @unchecked Sendable {
         // Silent-mic watchdog: macOS can accept the IOProc but deliver only zero samples.
         // Bluetooth inputs recover by switching to the built-in mic; PTT can opt into
         // all-transport detection so a stale built-in/default route triggers a full rebuild.
-        // Fires at most once per capture session.
-        if !silentMicDetectedFired {
-            for s in pcmData {
-                // Int16.min has magnitude 32768 which is out of Int16 range — clamp.
-                let a = s == Int16.min ? Int16.max : Int16(s.magnitude)
-                if a > watchdogWindowPeak { watchdogWindowPeak = a }
-            }
-            let nowAbs = CFAbsoluteTimeGetCurrent()
-            if watchdogWindowStart == 0 { watchdogWindowStart = nowAbs }
-            if nowAbs - watchdogWindowStart >= 1.0 {
-                // Window closed — classify and reset.
-                // peak ≤ 5 (≈ -76 dBFS) is effectively silent compared to real speech.
-                if watchdogWindowPeak <= 5 {
-                    consecutiveSilentWindows += 1
+        // Accumulate this callback's peak, then classify once every ~1s window. Windows keep
+        // rolling after a fire (unlike a one-shot latch) so the watchdog observes recovery and
+        // can re-arm for a second episode — see `evaluateSilentMicWindow`.
+        for s in pcmData {
+            // Int16.min has magnitude 32768 which is out of Int16 range — clamp.
+            let a = s == Int16.min ? Int16.max : Int16(s.magnitude)
+            if a > watchdogWindowPeak { watchdogWindowPeak = a }
+        }
+        let nowAbs = CFAbsoluteTimeGetCurrent()
+        if watchdogWindowStart == 0 { watchdogWindowStart = nowAbs }
+        if nowAbs - watchdogWindowStart >= 1.0 {
+            let isBluetooth = Self.isBluetoothTransport(deviceID: deviceID)
+            if let detection = evaluateSilentMicWindow(peak: watchdogWindowPeak, isBluetooth: isBluetooth, now: nowAbs) {
+                if isBluetooth {
+                    log("AudioCapture: Bluetooth mic returning silence for \(detection.consecutiveSilentWindows)s — falling back to built-in mic")
                 } else {
-                    consecutiveSilentWindows = 0
+                    log("AudioCapture: Input device returning silence for \(detection.consecutiveSilentWindows)s — rebuilding CoreAudio capture")
                 }
-                let isBluetooth = Self.isBluetoothTransport(deviceID: deviceID)
-                if consecutiveSilentWindows >= silentMicWindowThreshold,
-                   isBluetooth || detectSilentMicOnAnyTransport {
-                    silentMicDetectedFired = true
-                    let detection = SilentMicDetection(
-                        deviceID: deviceID,
-                        deviceDescription: currentDeviceDescription,
-                        consecutiveSilentWindows: consecutiveSilentWindows,
-                        isBluetoothTransport: isBluetooth
-                    )
-                    if isBluetooth {
-                        log("AudioCapture: Bluetooth mic returning silence for \(consecutiveSilentWindows)s — falling back to built-in mic")
-                    } else {
-                        log("AudioCapture: Input device returning silence for \(consecutiveSilentWindows)s — rebuilding CoreAudio capture")
-                    }
-                    let handler = onSilentMicDetected
-                    DispatchQueue.main.async { handler?(detection) }
-                }
-                watchdogWindowPeak = 0
-                watchdogWindowStart = nowAbs
+                let handler = onSilentMicDetected
+                DispatchQueue.main.async { handler?(detection) }
             }
+            watchdogWindowPeak = 0
+            watchdogWindowStart = nowAbs
         }
 
         // Calculate and report audio level (RMS normalized to 0.0 - 1.0)

--- a/desktop/macos/Desktop/Tests/SilentMicWatchdogRearmTests.swift
+++ b/desktop/macos/Desktop/Tests/SilentMicWatchdogRearmTests.swift
@@ -1,0 +1,94 @@
+import CoreFoundation
+import XCTest
+
+@testable import Omi_Computer
+
+/// BL-015 / MIC-05 — the silent-mic watchdog must detect and recover a silent mic more than
+/// once within a single capture session, not latch after the first episode. These tests drive
+/// `AudioCaptureService.evaluateSilentMicWindow` (the per-window decision extracted from the
+/// audio callback) so the fire-more-than-once contract is verified without real CoreAudio buffers.
+final class SilentMicWatchdogRearmTests: XCTestCase {
+
+  /// PTT opts every transport into detection; without this only Bluetooth inputs fire.
+  private func makeWatchdog(anyTransport: Bool = true) -> AudioCaptureService {
+    let svc = AudioCaptureService()
+    svc.detectSilentMicOnAnyTransport = anyTransport
+    svc.resetSilentMicWatchdog()
+    return svc
+  }
+
+  func testFiresAfterThresholdConsecutiveSilentWindows() {
+    let svc = makeWatchdog()
+    // One silent window is below the 2-window threshold — no detection yet.
+    XCTAssertNil(svc.evaluateSilentMicWindow(peak: 0, isBluetooth: false, now: 0))
+    // The second consecutive silent window crosses the threshold — fires.
+    XCTAssertNotNil(svc.evaluateSilentMicWindow(peak: 0, isBluetooth: false, now: 1))
+  }
+
+  func testNonSilentWindowResetsRunSoNoFire() {
+    let svc = makeWatchdog()
+    XCTAssertNil(svc.evaluateSilentMicWindow(peak: 0, isBluetooth: false, now: 0))
+    // A window with real audio resets the silent run.
+    XCTAssertNil(svc.evaluateSilentMicWindow(peak: 5000, isBluetooth: false, now: 1))
+    // A single silent window after recovery is again below threshold.
+    XCTAssertNil(svc.evaluateSilentMicWindow(peak: 0, isBluetooth: false, now: 2))
+  }
+
+  /// The core BL-015 regression: a second silent episode later in the SAME session must also
+  /// fire, after the recovery cooldown — not be swallowed by a permanent one-shot latch.
+  func testSecondEpisodeFiresAgainAfterCooldown() {
+    let svc = makeWatchdog()
+
+    // Episode 1 fires at t=1.
+    XCTAssertNil(svc.evaluateSilentMicWindow(peak: 0, isBluetooth: false, now: 0))
+    XCTAssertNotNil(svc.evaluateSilentMicWindow(peak: 0, isBluetooth: false, now: 1))
+
+    // Within the cooldown the watchdog is suppressed even while the mic is still silent —
+    // the freshly rebuilt/switched capture is given time to start delivering real audio.
+    XCTAssertNil(svc.evaluateSilentMicWindow(peak: 0, isBluetooth: false, now: 2))
+    XCTAssertNil(svc.evaluateSilentMicWindow(peak: 0, isBluetooth: false, now: 3))
+
+    // Mic recovers, then re-wedges after the cooldown has elapsed.
+    XCTAssertNil(svc.evaluateSilentMicWindow(peak: 8000, isBluetooth: false, now: 5))
+    XCTAssertNil(svc.evaluateSilentMicWindow(peak: 0, isBluetooth: false, now: 6))
+    // Episode 2 fires — proving detection more than once per session.
+    XCTAssertNotNil(svc.evaluateSilentMicWindow(peak: 0, isBluetooth: false, now: 7))
+  }
+
+  /// Tight-loop guard: an unrecoverable mic cannot fire endlessly — capped per session even
+  /// when every window is spaced past the cooldown so re-arm is never the limiter.
+  func testFireCountIsCappedPerSession() {
+    let svc = makeWatchdog()
+    var fires = 0
+    var t: CFAbsoluteTime = 0
+    for _ in 0..<40 {
+      if svc.evaluateSilentMicWindow(peak: 0, isBluetooth: false, now: t) != nil { fires += 1 }
+      t += 4  // > cooldown, so the per-session cap is what stops it
+    }
+    XCTAssertEqual(fires, 3, "watchdog must cap silent-mic recovery attempts per session")
+  }
+
+  /// A new capture session (start/stop calls `resetSilentMicWatchdog`) starts fresh even after
+  /// the previous session exhausted the per-session cap.
+  func testResetReArmsForANewSession() {
+    let svc = makeWatchdog()
+    var t: CFAbsoluteTime = 0
+    for _ in 0..<40 {
+      _ = svc.evaluateSilentMicWindow(peak: 0, isBluetooth: false, now: t)
+      t += 4
+    }
+
+    svc.resetSilentMicWatchdog()
+    XCTAssertNil(svc.evaluateSilentMicWindow(peak: 0, isBluetooth: false, now: t))
+    XCTAssertNotNil(svc.evaluateSilentMicWindow(peak: 0, isBluetooth: false, now: t + 1))
+  }
+
+  /// Non-Bluetooth silence only fires when the owner (PTT) opted into all-transport detection.
+  func testNonBluetoothSilenceRequiresAnyTransportOptIn() {
+    let svc = makeWatchdog(anyTransport: false)
+    XCTAssertNil(svc.evaluateSilentMicWindow(peak: 0, isBluetooth: false, now: 0))
+    XCTAssertNil(svc.evaluateSilentMicWindow(peak: 0, isBluetooth: false, now: 1))
+    // Same silence classified as Bluetooth still fires without the opt-in.
+    XCTAssertNotNil(svc.evaluateSilentMicWindow(peak: 0, isBluetooth: true, now: 2))
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260705-silent-mic-watchdog-rearm.json
+++ b/desktop/macos/changelog/unreleased/20260705-silent-mic-watchdog-rearm.json
@@ -1,0 +1,3 @@
+{
+  "change": "A microphone that goes silent mid-session (Bluetooth profile conflicts or a stale audio route) can now be auto-recovered more than once, instead of only the first time"
+}


### PR DESCRIPTION
## Summary

Fixes the silent-mic watchdog so it can recover from **more than one** silent-mic episode in a single capture session (BL-015 / MIC-05).

Previously the watchdog wrapped its whole peak-accumulation loop in `if !silentMicDetectedFired`, so after the first detection it **stopped observing entirely** — a mic that went silent, recovered, then re-wedged (e.g. Bluetooth A2DP/HFP profile conflict) within one session was never recovered again (permanent latch).

## What changed

- Remove the one-shot wrapper so detection windows keep rolling.
- Make the latch **re-armable**: after a fire, a **3s cooldown** must elapse before the next detection (gives a rebuilt/switched capture time to deliver real audio), and a **3-fire-per-session cap** hard-stops any runaway re-fire storm on a persistently-dead mic.
- Extract the per-window decision into `evaluateSilentMicWindow(...)` so the fire-twice contract is unit-testable without CoreAudio buffers.
- `resetSilentMicWatchdog()` zeroes all watchdog state on capture start/stop (no cross-session leak). `deinit` and the rest of `AudioCaptureService` are untouched.

## Tests

- New `SilentMicWatchdogRearmTests` (6): second-episode-fires-after-cooldown, cap-at-3 (40 windows → exactly 3 fires), reset-re-arms-for-new-session, transport-gating preserved.
- `bash test.sh` → **293 Rust + 130 Swift suites**, all green (independently re-run + adversarially reviewed by a verifier pass).

## Honest scope — MIC-05

Fire-twice + bounded-loop behavior is **unit-verified**. Full **runtime is BLOCKED** — inducing two real mic silences needs an actual silent / Bluetooth-A2DP-wedged mic, not driveable headlessly.

## Changelog

`desktop/macos/changelog/unreleased/20260705-silent-mic-watchdog-rearm.json`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9114?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

