### PR TITLE
refactor(desktop): typed UserDefaults keys + raw-key count ratchet (auth keys migrated)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -45,6 +45,9 @@ jobs:
           # Also run the Rust check when this workflow changes so CI PRs dogfood
           # the new guard instead of only validating YAML syntax.
           echo "has_desktop_rust=$(echo "$FILES" | grep -qE '^desktop/macos/Backend-Rust/|^\.github/workflows/lint\.yml$' && echo true || echo false)" >> $GITHUB_OUTPUT
+          # UserDefaults key ratchet: run when desktop Swift sources, the ratchet
+          # script, or this workflow change (so the gate dogfoods itself).
+          echo "has_desktop_defaults_ratchet=$(echo "$FILES" | grep -qE '^desktop/macos/Desktop/Sources/.*\.swift$|^desktop/macos/scripts/check-userdefaults-key-ratchet\.py$|^\.github/workflows/lint\.yml$' && echo true || echo false)" >> $GITHUB_OUTPUT
 
       # -- Universal source hygiene --
       - name: Check merge conflict markers
@@ -96,6 +99,10 @@ jobs:
       - name: Summarize deferred-work markers
         continue-on-error: true
         run: python3 .github/scripts/deferred-work-marker-count.py --format github-summary >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Check desktop UserDefaults key ratchet
+        if: steps.changed.outputs.has_desktop_defaults_ratchet == 'true'
+        run: python3 desktop/macos/scripts/check-userdefaults-key-ratchet.py
 
       - name: Check GitHub Actions workflows
         if: steps.changed.outputs.has_workflows == 'true'

--- a/desktop/macos/Desktop/Sources/AuthService.swift
+++ b/desktop/macos/Desktop/Sources/AuthService.swift
@@ -354,16 +354,9 @@ class AuthService {
         let callbackTransport: String
     }
 
-    // UserDefaults keys for auth persistence (dev builds with ad-hoc signing)
-    private let kAuthIsSignedIn = "auth_isSignedIn"
-    private let kAuthUserEmail = "auth_userEmail"
-    private let kAuthUserId = "auth_userId"
-    private let kAuthGivenName = "auth_givenName"
-    private let kAuthFamilyName = "auth_familyName"
-    private let kAuthIdToken = "auth_idToken"
-    private let kAuthRefreshToken = "auth_refreshToken"
-    private let kAuthTokenExpiry = "auth_tokenExpiry"
-    private let kAuthTokenUserId = "auth_tokenUserId"  // User ID that owns the stored token
+    // UserDefaults keys for auth persistence (dev builds with ad-hoc signing).
+    // Keys are defined once in `DefaultsKey` and read/written through the typed
+    // `UserDefaults` accessors so a typo is a compile error, not a silent nil.
 
     // Firebase Web API key — fetched from backend via APIKeyService, set as env var.
     // No hardcoded fallback — if the key isn't available, auth operations will fail
@@ -398,14 +391,14 @@ class AuthService {
 
     /// Get the user's given name (first name)
     var givenName: String {
-        get { UserDefaults.standard.string(forKey: kAuthGivenName) ?? "" }
-        set { UserDefaults.standard.set(newValue, forKey: kAuthGivenName) }
+        get { UserDefaults.standard.string(forKey: .authGivenName) ?? "" }
+        set { UserDefaults.standard.set(newValue, forKey: .authGivenName) }
     }
 
     /// Get the user's family name (last name)
     var familyName: String {
-        get { UserDefaults.standard.string(forKey: kAuthFamilyName) ?? "" }
-        set { UserDefaults.standard.set(newValue, forKey: kAuthFamilyName) }
+        get { UserDefaults.standard.string(forKey: .authFamilyName) ?? "" }
+        set { UserDefaults.standard.set(newValue, forKey: .authFamilyName) }
     }
 
     /// Get the user's full display name
@@ -452,7 +445,7 @@ class AuthService {
             return
         }
 
-        if let savedEmail = UserDefaults.standard.string(forKey: kAuthUserEmail),
+        if let savedEmail = UserDefaults.standard.string(forKey: .authUserEmail),
            !savedEmail.isEmpty, savedEmail != email {
             clearPersistedAuthState()
             clearTokens()
@@ -541,27 +534,27 @@ class AuthService {
     // MARK: - Auth Persistence (UserDefaults for dev builds)
 
     private func saveAuthState(isSignedIn: Bool, email: String?, userId: String?) {
-        UserDefaults.standard.set(isSignedIn, forKey: kAuthIsSignedIn)
-        UserDefaults.standard.set(email, forKey: kAuthUserEmail)
-        UserDefaults.standard.set(userId, forKey: kAuthUserId)
+        UserDefaults.standard.set(isSignedIn, forKey: .authIsSignedIn)
+        UserDefaults.standard.set(email, forKey: .authUserEmail)
+        UserDefaults.standard.set(userId, forKey: .authUserId)
         UserDefaults.standard.synchronize()  // Force flush before process can be killed
         NSLog("OMI AUTH: Saved auth state - signedIn: %@, email: %@", isSignedIn ? "true" : "false", email ?? "nil")
     }
 
     private func clearPersistedAuthState() {
-        UserDefaults.standard.removeObject(forKey: kAuthIsSignedIn)
-        UserDefaults.standard.removeObject(forKey: kAuthUserEmail)
-        UserDefaults.standard.removeObject(forKey: kAuthUserId)
-        UserDefaults.standard.removeObject(forKey: kAuthIdToken)
-        UserDefaults.standard.removeObject(forKey: kAuthRefreshToken)
-        UserDefaults.standard.removeObject(forKey: kAuthTokenExpiry)
-        UserDefaults.standard.removeObject(forKey: kAuthTokenUserId)
+        UserDefaults.standard.removeObject(forKey: .authIsSignedIn)
+        UserDefaults.standard.removeObject(forKey: .authUserEmail)
+        UserDefaults.standard.removeObject(forKey: .authUserId)
+        UserDefaults.standard.removeObject(forKey: .authIdToken)
+        UserDefaults.standard.removeObject(forKey: .authRefreshToken)
+        UserDefaults.standard.removeObject(forKey: .authTokenExpiry)
+        UserDefaults.standard.removeObject(forKey: .authTokenUserId)
     }
 
     private func restoreAuthState() {
         // Check if we have a saved auth state
-        let savedSignedIn = UserDefaults.standard.bool(forKey: kAuthIsSignedIn)
-        let savedEmail = UserDefaults.standard.string(forKey: kAuthUserEmail)
+        let savedSignedIn = UserDefaults.standard.bool(forKey: .authIsSignedIn)
+        let savedEmail = UserDefaults.standard.string(forKey: .authUserEmail)
 
         NSLog("OMI AUTH: Checking saved auth state - savedSignedIn: %@, savedEmail: %@",
               savedSignedIn ? "true" : "false", savedEmail ?? "nil")
@@ -584,12 +577,12 @@ class AuthService {
                 NSLog("OMI AUTH: Restored auth state from UserDefaults (Firebase session expired)")
 
                 // Migration: Fix empty userId by extracting from stored idToken
-                let savedUserId = UserDefaults.standard.string(forKey: kAuthUserId) ?? ""
+                let savedUserId = UserDefaults.standard.string(forKey: .authUserId) ?? ""
                 if savedUserId.isEmpty, let storedToken = storedIdToken {
                     if let payload = decodeJWT(storedToken),
                        let userId = payload["user_id"] as? String ?? payload["sub"] as? String {
                         NSLog("OMI AUTH: Migrating empty userId - extracted from JWT: %@", userId)
-                        UserDefaults.standard.set(userId, forKey: kAuthUserId)
+                        UserDefaults.standard.set(userId, forKey: .authUserId)
                     }
                 }
 
@@ -627,7 +620,7 @@ class AuthService {
                     Task { await SettingsSyncManager.shared.syncFromServer() }
                 } else {
                     // Firebase has no user - check if we have a saved session (for dev builds where Keychain doesn't persist)
-                    let savedSignedIn = UserDefaults.standard.bool(forKey: self?.kAuthIsSignedIn ?? "")
+                    let savedSignedIn = UserDefaults.standard.bool(forKey: .authIsSignedIn)
                     log("AUTH_LISTENER: Firebase user nil, savedSignedIn=\(savedSignedIn), currentIsSignedIn=\(self?.isSignedIn ?? false)")
                     if !savedSignedIn {
                         // No saved session either - user is truly signed out
@@ -1541,7 +1534,7 @@ class AuthService {
 
         // Try to update Firebase profile (best effort)
         // Skip during impersonation to avoid overwriting the target user's display name
-        let isImpersonating = UserDefaults.standard.bool(forKey: "auth_isImpersonating")
+        let isImpersonating = UserDefaults.standard.bool(forKey: .authIsImpersonating)
         if isImpersonating {
             NSLog("OMI AUTH: Skipping Firebase displayName update (impersonation mode)")
         } else if let user = Auth.auth().currentUser {
@@ -1614,38 +1607,38 @@ class AuthService {
     // MARK: - Token Storage
 
     private func saveTokens(idToken: String, refreshToken: String, expiresIn: Int, userId: String) {
-        UserDefaults.standard.set(idToken, forKey: kAuthIdToken)
-        UserDefaults.standard.set(refreshToken, forKey: kAuthRefreshToken)
+        UserDefaults.standard.set(idToken, forKey: .authIdToken)
+        UserDefaults.standard.set(refreshToken, forKey: .authRefreshToken)
         // Store expiry time (current time + expiresIn seconds, minus 5 min buffer)
         let expiryTime = Date().addingTimeInterval(TimeInterval(expiresIn - 300))
-        UserDefaults.standard.set(expiryTime.timeIntervalSince1970, forKey: kAuthTokenExpiry)
+        UserDefaults.standard.set(expiryTime.timeIntervalSince1970, forKey: .authTokenExpiry)
         // Store the user ID that owns these tokens (for validation on retrieval)
-        UserDefaults.standard.set(userId, forKey: kAuthTokenUserId)
+        UserDefaults.standard.set(userId, forKey: .authTokenUserId)
         NSLog("OMI AUTH: Saved tokens for user %@, expires at %@", userId, expiryTime.description)
     }
 
     private func clearTokens() {
-        UserDefaults.standard.removeObject(forKey: kAuthIdToken)
-        UserDefaults.standard.removeObject(forKey: kAuthRefreshToken)
-        UserDefaults.standard.removeObject(forKey: kAuthTokenExpiry)
-        UserDefaults.standard.removeObject(forKey: kAuthTokenUserId)
+        UserDefaults.standard.removeObject(forKey: .authIdToken)
+        UserDefaults.standard.removeObject(forKey: .authRefreshToken)
+        UserDefaults.standard.removeObject(forKey: .authTokenExpiry)
+        UserDefaults.standard.removeObject(forKey: .authTokenUserId)
         NSLog("OMI AUTH: Cleared all tokens")
     }
 
     private var storedIdToken: String? {
-        UserDefaults.standard.string(forKey: kAuthIdToken)
+        UserDefaults.standard.string(forKey: .authIdToken)
     }
 
     private var storedRefreshToken: String? {
-        UserDefaults.standard.string(forKey: kAuthRefreshToken)
+        UserDefaults.standard.string(forKey: .authRefreshToken)
     }
 
     private var storedTokenUserId: String? {
-        UserDefaults.standard.string(forKey: kAuthTokenUserId)
+        UserDefaults.standard.string(forKey: .authTokenUserId)
     }
 
     private var isTokenExpired: Bool {
-        let expiryTime = UserDefaults.standard.double(forKey: kAuthTokenExpiry)
+        let expiryTime = UserDefaults.standard.double(forKey: .authTokenExpiry)
         guard expiryTime > 0 else { return true }
         return Date().timeIntervalSince1970 > expiryTime
     }
@@ -1788,7 +1781,7 @@ class AuthService {
 
     func getIdToken(forceRefresh: Bool = false) async throws -> String {
         // Get the expected user ID (the currently signed-in user)
-        let expectedUserId = UserDefaults.standard.string(forKey: kAuthUserId)
+        let expectedUserId = UserDefaults.standard.string(forKey: .authUserId)
 
         // First try: Use stored token if valid AND belongs to the current user
         if !forceRefresh, let token = storedIdToken, !isTokenExpired {
@@ -1799,7 +1792,7 @@ class AuthService {
                     // expectedUserId missing (migration gap, crash recovery) - trust the token
                     // and backfill the userId so future calls don't hit this path
                     NSLog("OMI AUTH: expectedUserId is nil but token has userId %@ - backfilling", tokenUserId)
-                    UserDefaults.standard.set(tokenUserId, forKey: kAuthUserId)
+                    UserDefaults.standard.set(tokenUserId, forKey: .authUserId)
                     return token
                 } else if tokenUserId == expectedUserId {
                     return token
@@ -1838,7 +1831,7 @@ class AuthService {
                 if expectedUserId == nil {
                     // Backfill the missing userId
                     NSLog("OMI AUTH: expectedUserId is nil, backfilling from Firebase SDK user %@", user.uid)
-                    UserDefaults.standard.set(user.uid, forKey: kAuthUserId)
+                    UserDefaults.standard.set(user.uid, forKey: .authUserId)
                 }
                 let tokenResult = try await user.getIDTokenResult(forcingRefresh: forceRefresh)
                 return tokenResult.token

--- a/desktop/macos/Desktop/Sources/DefaultsKey.swift
+++ b/desktop/macos/Desktop/Sources/DefaultsKey.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+/// Compile-checked `UserDefaults` keys (S-13, BL-004 partial).
+///
+/// The defect: `UserDefaults` keys were raw inline string literals scattered
+/// across the app — `"auth_userId"` alone appeared inline ~18 times. A single
+/// typo (`"auth_userld"`) silently reads `nil` with no error, so auth /
+/// onboarding state fails to restore and the failure is invisible.
+///
+/// Routing keys through this enum turns a typo from a silent `nil` into a
+/// compile error, and gives the app one source of truth for each key's string.
+///
+/// This is the auth slice of the migration. New keys should be added here and
+/// read/written through the typed `UserDefaults` accessors below rather than as
+/// inline literals. `scripts/check-userdefaults-key-ratchet.py` is a CI/pre-push
+/// gate that prevents new raw inline `forKey:` string literals from being
+/// introduced elsewhere (the count may only shrink).
+enum DefaultsKey: String {
+    case authIsSignedIn = "auth_isSignedIn"
+    case authUserEmail = "auth_userEmail"
+    case authUserId = "auth_userId"
+    case authGivenName = "auth_givenName"
+    case authFamilyName = "auth_familyName"
+    case authIdToken = "auth_idToken"
+    case authRefreshToken = "auth_refreshToken"
+    case authTokenExpiry = "auth_tokenExpiry"
+    case authTokenUserId = "auth_tokenUserId"  // User ID that owns the stored token
+    case authIsImpersonating = "auth_isImpersonating"
+}
+
+/// Typed accessors that take a `DefaultsKey` instead of a `String`.
+///
+/// Each forwards to the stdlib `String`-keyed method via `key.rawValue`, so
+/// overload resolution picks the stdlib method (no recursion). Call sites read
+/// as `UserDefaults.standard.string(forKey: .authUserId)` — the key is now
+/// compiler-checked.
+extension UserDefaults {
+    func string(forKey key: DefaultsKey) -> String? { string(forKey: key.rawValue) }
+    func bool(forKey key: DefaultsKey) -> Bool { bool(forKey: key.rawValue) }
+    func integer(forKey key: DefaultsKey) -> Int { integer(forKey: key.rawValue) }
+    func double(forKey key: DefaultsKey) -> Double { double(forKey: key.rawValue) }
+
+    func set(_ value: Any?, forKey key: DefaultsKey) { set(value, forKey: key.rawValue) }
+    func removeObject(forKey key: DefaultsKey) { removeObject(forKey: key.rawValue) }
+}

--- a/desktop/macos/Desktop/Sources/DefaultsKey.swift
+++ b/desktop/macos/Desktop/Sources/DefaultsKey.swift
@@ -12,8 +12,8 @@ import Foundation
 ///
 /// This is the auth slice of the migration. New keys should be added here and
 /// read/written through the typed `UserDefaults` accessors below rather than as
-/// inline literals. `scripts/check-userdefaults-key-ratchet.py` is a CI/pre-push
-/// gate that prevents new raw inline `forKey:` string literals from being
+/// inline literals. `desktop/macos/scripts/check-userdefaults-key-ratchet.py` is
+/// a CI/pre-push gate that prevents new raw inline `forKey:` string literals from being
 /// introduced elsewhere (the count may only shrink).
 enum DefaultsKey: String {
     case authIsSignedIn = "auth_isSignedIn"

--- a/desktop/macos/Desktop/Tests/DefaultsKeyTests.swift
+++ b/desktop/macos/Desktop/Tests/DefaultsKeyTests.swift
@@ -1,0 +1,110 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// S-13 — typed UserDefaults keys (BL-004, partial).
+///
+/// Guards the anti-typo foundation: the typed `DefaultsKey` accessors must read
+/// and write the exact same underlying string keys the app has always used (so
+/// migrated call sites see previously-persisted auth state), the key strings are
+/// pinned against silent drift, and `AuthService` reads through the typed keys
+/// rather than raw inline literals.
+final class DefaultsKeyTests: XCTestCase {
+
+  private var defaults: UserDefaults!
+  private let suiteName = "DefaultsKeyTests.\(UUID().uuidString)"
+
+  override func setUp() {
+    super.setUp()
+    defaults = UserDefaults(suiteName: suiteName)
+  }
+
+  override func tearDown() {
+    defaults.removePersistentDomain(forName: suiteName)
+    defaults = nil
+    super.tearDown()
+  }
+
+  // MARK: Key-string stability
+
+  /// The rawValue of each case is the on-disk key. Renaming any of these
+  /// silently orphans previously-persisted auth state (the user gets logged
+  /// out with no error). Pin them so such a change fails loudly in review.
+  func testRawValuesMatchLegacyKeyStrings() {
+    XCTAssertEqual(DefaultsKey.authIsSignedIn.rawValue, "auth_isSignedIn")
+    XCTAssertEqual(DefaultsKey.authUserEmail.rawValue, "auth_userEmail")
+    XCTAssertEqual(DefaultsKey.authUserId.rawValue, "auth_userId")
+    XCTAssertEqual(DefaultsKey.authGivenName.rawValue, "auth_givenName")
+    XCTAssertEqual(DefaultsKey.authFamilyName.rawValue, "auth_familyName")
+    XCTAssertEqual(DefaultsKey.authIdToken.rawValue, "auth_idToken")
+    XCTAssertEqual(DefaultsKey.authRefreshToken.rawValue, "auth_refreshToken")
+    XCTAssertEqual(DefaultsKey.authTokenExpiry.rawValue, "auth_tokenExpiry")
+    XCTAssertEqual(DefaultsKey.authTokenUserId.rawValue, "auth_tokenUserId")
+    XCTAssertEqual(DefaultsKey.authIsImpersonating.rawValue, "auth_isImpersonating")
+  }
+
+  // MARK: Typed accessors round-trip through the same underlying key
+
+  /// A value written with the typed setter must be readable with the raw
+  /// `String` key (and vice versa) — i.e. the typed accessor is a pure alias for
+  /// `forKey: key.rawValue`, so migrated code and any not-yet-migrated raw call
+  /// site still agree on the same slot.
+  func testTypedStringAccessorAliasesRawKey() {
+    defaults.set("user-123", forKey: .authUserId)
+    XCTAssertEqual(defaults.string(forKey: "auth_userId"), "user-123")
+    XCTAssertEqual(defaults.string(forKey: .authUserId), "user-123")
+
+    defaults.set("alt-456", forKey: "auth_userId")
+    XCTAssertEqual(defaults.string(forKey: .authUserId), "alt-456")
+  }
+
+  func testTypedBoolAccessorAliasesRawKey() {
+    XCTAssertFalse(defaults.bool(forKey: .authIsSignedIn))  // default
+    defaults.set(true, forKey: .authIsSignedIn)
+    XCTAssertTrue(defaults.bool(forKey: "auth_isSignedIn"))
+    XCTAssertTrue(defaults.bool(forKey: .authIsSignedIn))
+  }
+
+  func testTypedNumericAccessorsAliasRawKey() {
+    XCTAssertEqual(defaults.integer(forKey: .authTokenExpiry), 0)  // default
+    defaults.set(1_700_000_000.5, forKey: .authTokenExpiry)
+    XCTAssertEqual(defaults.double(forKey: .authTokenExpiry), 1_700_000_000.5, accuracy: 0.0001)
+    XCTAssertEqual(defaults.double(forKey: "auth_tokenExpiry"), 1_700_000_000.5, accuracy: 0.0001)
+  }
+
+  func testRemoveObjectClearsTypedKey() {
+    defaults.set("gone", forKey: .authIdToken)
+    XCTAssertNotNil(defaults.string(forKey: .authIdToken))
+    defaults.removeObject(forKey: .authIdToken)
+    XCTAssertNil(defaults.string(forKey: .authIdToken))
+    XCTAssertNil(defaults.string(forKey: "auth_idToken"))
+  }
+
+  // MARK: AuthService migration (regression guard)
+
+  /// AuthService must read its auth keys through the typed enum, not through the
+  /// old private `kAuth*` constants or raw inline literals.
+  func testAuthServiceUsesTypedKeys() throws {
+    let src = try source(relativePath: "Sources/AuthService.swift")
+
+    XCTAssertTrue(
+      src.contains("forKey: .authUserId"),
+      "AuthService must read/write auth_userId through the typed DefaultsKey")
+    XCTAssertFalse(
+      src.contains("private let kAuthUserId"),
+      "the duplicated private key constants must be gone (single source is DefaultsKey)")
+    XCTAssertFalse(
+      src.contains("forKey: \"auth_isImpersonating\""),
+      "the raw impersonation literal must be migrated to .authIsImpersonating")
+  }
+
+  // MARK: Helper
+
+  private func source(relativePath: String) throws -> String {
+    let url = URL(fileURLWithPath: #filePath)
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+      .appendingPathComponent(relativePath)
+    return try String(contentsOf: url, encoding: .utf8)
+  }
+}

--- a/desktop/macos/scripts/check-userdefaults-key-ratchet.py
+++ b/desktop/macos/scripts/check-userdefaults-key-ratchet.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Ratchet on raw inline UserDefaults string keys in the desktop Swift app.
+
+BL-004 / S-13: `UserDefaults` keys were raw inline string literals scattered
+across the app (`"auth_userId"` alone appeared inline ~18 times). A typo in one
+silently reads `nil` with no error, breaking auth/onboarding state restore
+invisibly. The durable fix is to route keys through the compile-checked
+`DefaultsKey` enum (see `Desktop/Sources/DefaultsKey.swift`).
+
+That migration is incremental, so this is an anti-regression ratchet, not a
+full sweep: it counts the raw inline `forKey: "literal"` occurrences that remain
+in production Swift sources and FAILS if that count rises above the pinned
+baseline. The baseline may only shrink — every new UserDefaults key must go
+through `DefaultsKey`, and every migrated call site lowers the ceiling.
+
+What counts as a raw inline key: an occurrence of `forKey:` immediately followed
+by a double-quoted string literal, in a `.swift` file under the scanned Sources
+root, EXCLUDING:
+  - `DefaultsKey.swift` (the allowlisted single source of truth), and
+  - non-UserDefaults `forKey:` forms — Dictionary `removeValue(forKey:)` and KVC
+    `setValue(_:forKey:)` — which are not defaults keys.
+
+Wiring (see also `scripts/pre-push` and `.github/workflows/lint.yml`):
+  - Pre-push: run automatically for pushes that touch desktop Swift sources.
+  - CI: a gated step in the Lint workflow.
+  - Manually:  python3 desktop/macos/scripts/check-userdefaults-key-ratchet.py
+  - Show the count / offenders:  ... --print
+
+Lowering the baseline: after migrating call sites, run with --print, then set
+BASELINE to the new (lower) number in the same commit.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+# Pinned baseline — the number of raw inline UserDefaults string keys remaining
+# in the scanned sources. MAY ONLY DECREASE. Raising it is a regression and must
+# not be done to make the gate pass; migrate the call site to `DefaultsKey`
+# instead.
+BASELINE = 184
+
+# Sources root, relative to the repo root.
+SOURCES_ROOT = "desktop/macos/Desktop/Sources"
+
+# Files whose inline `forKey: "..."` occurrences are exempt (the typed-key
+# definitions themselves may legitimately spell key strings).
+ALLOWLISTED_FILES = {
+    "desktop/macos/Desktop/Sources/DefaultsKey.swift",
+}
+
+# `forKey:` immediately followed by a double-quoted string literal.
+FORKEY_LITERAL_RE = re.compile(r'forKey:\s*"[^"]*"')
+
+# Non-UserDefaults `forKey:` forms to skip (Dictionary.removeValue, KVC setValue).
+NON_USERDEFAULTS_RE = re.compile(r'removeValue\(forKey:|\.setValue\(')
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument(
+        "--root",
+        default=None,
+        help="Repository root (default: inferred from this script's location).",
+    )
+    parser.add_argument(
+        "--print",
+        dest="print_offenders",
+        action="store_true",
+        help="Print the current count and every offending file:line, then exit 0.",
+    )
+    return parser.parse_args()
+
+
+def repo_root(explicit: str | None) -> Path:
+    if explicit:
+        return Path(explicit).resolve()
+    # scripts/ -> desktop/macos -> desktop -> repo root
+    return Path(__file__).resolve().parents[3]
+
+
+def scan(root: Path) -> list[tuple[str, int, str]]:
+    """Return (relative_path, line_number, line_text) for each raw inline key."""
+    sources = root / SOURCES_ROOT
+    offenders: list[tuple[str, int, str]] = []
+    for path in sorted(sources.rglob("*.swift")):
+        relative = path.relative_to(root).as_posix()
+        if relative in ALLOWLISTED_FILES:
+            continue
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        for lineno, line in enumerate(text.splitlines(), start=1):
+            if NON_USERDEFAULTS_RE.search(line):
+                continue
+            for _ in FORKEY_LITERAL_RE.finditer(line):
+                offenders.append((relative, lineno, line.strip()))
+    return offenders
+
+
+def main() -> int:
+    args = parse_args()
+    root = repo_root(args.root)
+    offenders = scan(root)
+    count = len(offenders)
+
+    if args.print_offenders:
+        for relative, lineno, line in offenders:
+            print(f"{relative}:{lineno}: {line}")
+        print(f"\nraw inline UserDefaults keys: {count} (baseline {BASELINE})")
+        return 0
+
+    if count > BASELINE:
+        print(
+            f"FAIL: raw inline UserDefaults string keys rose to {count} " f"(baseline {BASELINE}).",
+            file=sys.stderr,
+        )
+        print(
+            "Route new keys through DefaultsKey (desktop/macos/Desktop/Sources/"
+            "DefaultsKey.swift) and read/write via the typed UserDefaults "
+            "accessors instead of an inline forKey: \"...\" literal.",
+            file=sys.stderr,
+        )
+        print(
+            "See offenders with: python3 desktop/macos/scripts/" "check-userdefaults-key-ratchet.py --print",
+            file=sys.stderr,
+        )
+        return 1
+
+    if count < BASELINE:
+        print(
+            f"NOTE: raw inline UserDefaults keys dropped to {count} "
+            f"(baseline {BASELINE}). Lower BASELINE to {count} in "
+            "check-userdefaults-key-ratchet.py to ratchet the gain."
+        )
+        return 0
+
+    print(f"OK: raw inline UserDefaults keys at baseline ({count}).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/pre-push
+++ b/scripts/pre-push
@@ -486,6 +486,26 @@ check_desktop_swift_if_needed() {
   )
 }
 
+check_desktop_userdefaults_ratchet_if_needed() {
+  # BL-004 / S-13: fail if new raw inline UserDefaults string keys are added to
+  # the desktop Swift sources. Pure grep-count ratchet (no toolchain needed).
+  if [ "${PRE_PUSH_SKIP_DESKTOP_DEFAULTS_RATCHET:-}" = "1" ]; then
+    echo "Skipping desktop UserDefaults key ratchet because PRE_PUSH_SKIP_DESKTOP_DEFAULTS_RATCHET=1."
+    return
+  fi
+
+  if ! changed_matches \
+    'desktop/macos/Desktop/Sources/*.swift' \
+    'desktop/macos/Desktop/Sources/**/*.swift' \
+    'desktop/macos/scripts/check-userdefaults-key-ratchet.py' \
+    'scripts/pre-push'
+  then
+    return
+  fi
+
+  python3 desktop/macos/scripts/check-userdefaults-key-ratchet.py
+}
+
 check_desktop_rust_if_needed() {
   local -a rust_files=()
   local file
@@ -574,6 +594,7 @@ run_step check_backend_unit_tests_if_needed
 run_step check_openapi_contract_if_needed
 run_step check_workflows_if_needed
 run_step check_desktop_swift_if_needed
+run_step check_desktop_userdefaults_ratchet_if_needed
 run_step check_desktop_rust_if_needed
 run_step check_desktop_launcher_tests_if_needed
 run_step check_desktop_tool_surfaces_if_needed


### PR DESCRIPTION
## Summary

Starts closing the raw-`UserDefaults`-key foot-gun (BL-004, partial): keys were scattered inline string literals (`"auth_userId"` typed inline ~18×), where a single typo **silently reads nil** and breaks auth/onboarding restore with no error.

## What changed (smallest correct foundation — not a 476-key sweep)

- **`DefaultsKey.swift`** — a compile-checked `enum DefaultsKey: String` + typed `UserDefaults` accessors. A typo is now a **build error**, not a silent nil.
- **`AuthService.swift`** — migrated the ~10 auth keys to the typed accessor and deleted the 9 duplicated `kAuth*` constants + a raw literal. Pure aliasing: every `DefaultsKey` raw value equals the original key string exactly → **no persisted-state migration**, no behavior change.
- **`scripts/check-userdefaults-key-ratchet.py`** — a grep-count ratchet pinned at the current **baseline 184** raw inline keys; it only shrinks. Wired into `scripts/pre-push` and Lint CI (mirroring the repo's existing count-ratchet convention), so **no new raw key can land** while the remaining scattered sites are migrated incrementally.

## Tests

- New `DefaultsKeyTests` (6): typo-safety (compile-checked cases + pinned raw strings) + round-trip aliasing (typed setter ↔ raw key) + a guard that the old constants/literals are gone.
- Ratchet: **PASS at 184**; **FAILS (exit 1) at 185** when a raw key is added (demonstrated), passes again on removal.
- `bash test.sh` → **293 Rust + 130 Swift suites**, all green (independently re-run + reviewed by a verifier pass).

## Scope

Partial S-13 by design: the anti-regression foundation (enum + accessors + ratchet) lands now and freezes the raw-key count; the remaining scattered read sites are migrated in follow-ups. No user-visible behavior change (no changelog fragment).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9115?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

