### PR TITLE
Make account deletion cleanup durable

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,7 +89,8 @@ agent-proxy (agent-proxy/main.py)
 
 backend-sync (main.py, Cloud Run)
   ├── ──────► Cloud Tasks queue `sync-jobs` ──► POST /v2/sync-jobs/run (OIDC, same service)
-  └── ──────► Cloud Tasks queue `audio-merge` ──► POST /v2/audio-merge-jobs/run (OIDC, same service)
+  ├── ──────► Cloud Tasks queue `audio-merge` ──► POST /v2/audio-merge-jobs/run (OIDC, same service)
+  └── ──────► Cloud Tasks queue `account-deletion` ──► POST /v1/users/account-deletion-wipes/run (OIDC, same service)
 
 notifications-job (modal/job.py)  [cron]
 agent-vm-reaper (backend/charts/agent-vm-reaper)  [cron]
@@ -106,7 +107,7 @@ Helm charts: `backend/charts/{agent-proxy,agent-vm-reaper,backend-listen,backend
 - **vad** (`modal/main.py`) — GPU. `/v1/vad` and `/v1/speaker-identification`. Called by backend only.
 - **deepgram** — STT. Streaming uses self-hosted (`DEEPGRAM_SELF_HOSTED_URL`) or cloud based on `DEEPGRAM_SELF_HOSTED_ENABLED`. Pre-recorded always uses Deepgram cloud. Called by backend and pusher.
 - **parakeet** (`parakeet/`) — GPU STT service for streaming and pre-recorded transcription. Called by backend when `HOSTED_PARAKEET_API_URL` is set and parakeet is selected.
-- **backend-sync** (`main.py`, same image as backend) — Cloud Run service for `/v2/sync-local-files`. When `SYNC_DISPATCH_MODE=cloud_tasks`: stages raw audio in GCS, enqueues to Cloud Tasks queue `sync-jobs`, which POSTs `/v2/sync-jobs/run` (OIDC-verified, `utils/cloud_tasks.py`) to run decode→VAD→STT inside a request. Inline fallback when the flag is off, env is incomplete, BYOK headers are present, or enqueue fails. Audio playback merges (`/v1/sync/audio/*`) follow the same pattern via queue `audio-merge` building 30-day MP3 artifacts under `playback/` (`AUDIO_MERGE_DISPATCH_MODE`).
+- **backend-sync** (`main.py`, same image as backend) — Cloud Run service for `/v2/sync-local-files`. When `SYNC_DISPATCH_MODE=cloud_tasks`: stages raw audio in GCS, enqueues to Cloud Tasks queue `sync-jobs`, which POSTs `/v2/sync-jobs/run` (OIDC-verified, `utils/cloud_tasks.py`) to run decode→VAD→STT inside a request. Inline fallback when the flag is off, env is incomplete, BYOK headers are present, or enqueue fails. Audio playback merges (`/v1/sync/audio/*`) follow the same pattern via queue `audio-merge` building 30-day MP3 artifacts under `playback/` (`AUDIO_MERGE_DISPATCH_MODE`). Account deletion uses `ACCOUNT_DELETION_DISPATCH_MODE=cloud_tasks` to enqueue durable wipes to queue `account-deletion`, which posts `/v1/users/account-deletion-wipes/run`; API success is returned only after the deletion marker is persisted and the wipe task is durably enqueued.
 - **notifications-job** (`modal/job.py`) — Cron job, reads Firestore/Redis, sends push notifications.
 - **monitoring** (`backend/charts/monitoring/`) — Prometheus, Grafana, Loki, Alloy, alerts, and HPA metric adapters for backend services.
 - **agent-vm-reaper** (`backend/charts/agent-vm-reaper/`) — CronJob that deletes stale `omi-agent-*` GCE VMs left by desktop agent sandboxes.

--- a/backend/database/users.py
+++ b/backend/database/users.py
@@ -12,6 +12,7 @@ from utils.subscription import get_default_basic_subscription
 import logging
 
 logger = logging.getLogger(__name__)
+DELETION_WIPE_RUNNING_STALE_AFTER = timedelta(hours=6)
 
 # Conservative low-risk user projections. Do NOT use these policies for
 # entitlement, BYOK, data-protection, privacy-consent, or full user-doc caching.
@@ -283,8 +284,7 @@ def mark_user_deletion_wipe_started(uid: str):
 
     Persisted in the top-level ``account_deletions`` collection so it survives a
     deploy or pod restart. A reconciliation worker can query for documents where
-    ``wipe_status == 'pending'`` and re-enqueue incomplete wipes, ensuring the
-    in-process ``cleanup_executor`` backlog is not silently lost.
+    ``wipe_status == 'pending'`` and re-enqueue incomplete wipes.
 
     The worker transitions the marker to ``'running'`` (via
     ``mark_user_deletion_wipe_running``) as soon as it actually starts
@@ -300,9 +300,9 @@ def mark_user_deletion_wipe_started(uid: str):
 def mark_user_deletion_wipe_running(uid: str):
     """Transition a queued wipe marker to ``running`` once the worker starts.
 
-    Called by ``background_wipe_user_data`` at the top of the executor future.
+    Called by ``background_wipe_user_data`` at the top of the wipe worker.
     This lets the reconciler distinguish a genuinely orphaned ``pending`` wipe
-    (queued in the executor backlog but never picked up — safe to re-enqueue)
+    (queued but never picked up — safe to re-enqueue)
     from a ``running`` wipe (actively executing — only recovered if the claim
     is stale, i.e. the worker probably crashed).
 
@@ -366,7 +366,7 @@ def cancel_user_deletion_wipe(uid: str):
 def get_pending_deletion_wipes(
     limit: int = 100,
     stale_after: timedelta = timedelta(minutes=10),
-    running_stale_after: timedelta = timedelta(minutes=30),
+    running_stale_after: timedelta = DELETION_WIPE_RUNNING_STALE_AFTER,
 ) -> list[dict]:
     """Return account_deletions documents whose wipe needs retry.
 
@@ -449,7 +449,7 @@ def get_pending_deletion_wipes(
             claimed_at = data.get('wipe_claimed_at')
             # Use the longer ``running_stale_after`` window so a queued-but-
             # not-yet-running retrying claim is not returned as a candidate
-            # before the executor future has had a chance to start.
+            # before the worker has had a chance to start.
             if claimed_at and claimed_at < running_cutoff:
                 result.append(data | {'uid': doc.id})
 
@@ -513,7 +513,7 @@ def _claim_deletion_wipe_txn(
         claimed_at = data.get('wipe_claimed_at')
         # Use the longer ``running_stale_after`` window (not ``stale_after``)
         # because a retrying wipe was just claimed by the reconciler and
-        # enqueued. If the executor backlog is full, the future may sit queued
+        # enqueued. If the worker queue is delayed, the task may sit queued
         # beyond ``stale_after`` (10 min) without transitioning to ``running``.
         # Using the short window would let the periodic reconciler enqueue
         # another copy every pass, causing duplicate wipes to race.
@@ -527,7 +527,7 @@ def _claim_deletion_wipe_txn(
 def claim_deletion_wipe(
     uid: str,
     stale_after: timedelta = timedelta(minutes=10),
-    running_stale_after: timedelta = timedelta(minutes=30),
+    running_stale_after: timedelta = DELETION_WIPE_RUNNING_STALE_AFTER,
 ) -> str | None:
     """Attempt to claim a pending/failed/stale wipe for re-enqueueing.
 
@@ -538,6 +538,44 @@ def claim_deletion_wipe(
     doc_ref = db.collection('account_deletions').document(uid)
     transaction = db.transaction()
     return _claim_deletion_wipe_txn(transaction, doc_ref, stale_after, running_stale_after)
+
+
+@transactional
+def _claim_deletion_wipe_task_txn(transaction, doc_ref, running_stale_after: timedelta) -> str:
+    """Claim a Cloud Tasks delivery before running an account-deletion wipe."""
+    snapshot = doc_ref.get(transaction=transaction)
+    if not snapshot.exists:
+        return 'missing'
+
+    data = snapshot.to_dict()
+    status = data.get('wipe_status')
+    now = datetime.now(timezone.utc)
+
+    if status == 'completed':
+        return 'completed'
+    if status in ('cancelled', 'deleting_auth'):
+        return 'not_actionable'
+    if status == 'running':
+        running_at = data.get('wipe_running_at')
+        if running_at and running_at >= now - running_stale_after:
+            return 'running'
+
+    if status in ('pending', 'retrying', 'failed', 'running'):
+        transaction.update(doc_ref, {'wipe_status': 'running', 'wipe_running_at': now})
+        return 'claimed'
+
+    return 'not_actionable'
+
+
+def claim_deletion_wipe_for_task(uid: str, running_stale_after: timedelta = DELETION_WIPE_RUNNING_STALE_AFTER) -> str:
+    """Claim an account-deletion wipe for a Cloud Tasks worker.
+
+    Returns one of: ``claimed``, ``running``, ``completed``, ``missing``, or
+    ``not_actionable``. Only ``claimed`` callers may run the destructive wipe.
+    """
+    doc_ref = db.collection('account_deletions').document(uid)
+    transaction = db.transaction()
+    return _claim_deletion_wipe_task_txn(transaction, doc_ref, running_stale_after)
 
 
 def create_person(uid: str, data: dict):

--- a/backend/database/users.py
+++ b/backend/database/users.py
@@ -542,7 +542,13 @@ def claim_deletion_wipe(
 
 @transactional
 def _claim_deletion_wipe_task_txn(transaction, doc_ref, running_stale_after: timedelta) -> str:
-    """Claim a Cloud Tasks delivery before running an account-deletion wipe."""
+    """Claim a Cloud Tasks delivery before running an account-deletion wipe.
+
+    The claim intentionally stays in ``retrying`` until the cleanup worker
+    starts and ``background_wipe_user_data`` marks it ``running``. If the HTTP
+    request is cancelled while waiting for a cleanup thread, a later delivery can
+    retry without waiting for the long running-stale lease.
+    """
     snapshot = doc_ref.get(transaction=transaction)
     if not snapshot.exists:
         return 'missing'
@@ -561,7 +567,7 @@ def _claim_deletion_wipe_task_txn(transaction, doc_ref, running_stale_after: tim
             return 'running'
 
     if status in ('pending', 'retrying', 'failed', 'running'):
-        transaction.update(doc_ref, {'wipe_status': 'running', 'wipe_running_at': now})
+        transaction.update(doc_ref, {'wipe_status': 'retrying', 'wipe_claimed_at': now})
         return 'claimed'
 
     return 'not_actionable'

--- a/backend/database/users.py
+++ b/backend/database/users.py
@@ -350,6 +350,19 @@ def mark_user_deletion_wipe_failed(uid: str):
     )
 
 
+def mark_user_deletion_billing_failed(uid: str, subscription_id: str | None, error: str):
+    """Record that account deletion is blocked on Stripe cancellation."""
+    db.collection('account_deletions').document(uid).set(
+        {
+            'wipe_status': 'billing_failed',
+            'billing_failed_at': datetime.now(timezone.utc),
+            'billing_subscription_id': subscription_id or '',
+            'billing_error': error,
+        },
+        merge=True,
+    )
+
+
 def cancel_user_deletion_wipe(uid: str):
     """Cancel a pending deletion-wipe marker.
 

--- a/backend/database/users.py
+++ b/backend/database/users.py
@@ -350,9 +350,16 @@ def mark_user_deletion_wipe_failed(uid: str):
     )
 
 
-def mark_user_deletion_billing_failed(uid: str, subscription_id: str | None, error: str):
-    """Record that account deletion is blocked on Stripe cancellation."""
-    db.collection('account_deletions').document(uid).set(
+@transactional
+def _mark_user_deletion_billing_failed_txn(transaction, doc_ref, uid: str, subscription_id: str | None, error: str):
+    snapshot = doc_ref.get(transaction=transaction)
+    if snapshot.exists:
+        status = (snapshot.to_dict() or {}).get('wipe_status')
+        if status in ('pending', 'retrying', 'running', 'failed', 'completed'):
+            return False
+
+    transaction.set(
+        doc_ref,
         {
             'wipe_status': 'billing_failed',
             'billing_failed_at': datetime.now(timezone.utc),
@@ -361,6 +368,18 @@ def mark_user_deletion_billing_failed(uid: str, subscription_id: str | None, err
         },
         merge=True,
     )
+    return True
+
+
+def mark_user_deletion_billing_failed(uid: str, subscription_id: str | None, error: str) -> bool:
+    """Record that account deletion is blocked on Stripe cancellation.
+
+    Never clobbers an actionable or terminal wipe state. A billing failure can
+    only block deletion before a destructive wipe has been queued or started.
+    """
+    doc_ref = db.collection('account_deletions').document(uid)
+    transaction = db.transaction()
+    return _mark_user_deletion_billing_failed_txn(transaction, doc_ref, uid, subscription_id, error)
 
 
 def cancel_user_deletion_wipe(uid: str):

--- a/backend/database/vector_db.py
+++ b/backend/database/vector_db.py
@@ -1016,11 +1016,18 @@ def delete_transcript_chunk_vectors(uid: str, conversation_id: str):
         logger.warning(f'delete_transcript_chunk_vectors failed uid={uid} conversation={conversation_id}')
 
 
-def delete_transcript_chunk_vectors_batch(uid: str, conversation_ids: List[str]) -> int:
+def delete_transcript_chunk_vectors_batch(
+    uid: str, conversation_ids: List[str], *, raise_on_failure: bool = False
+) -> int:
     """Account-deletion purge: drop all transcript-chunk vectors for the user's conversations."""
-    if index is None or not conversation_ids:
+    if index is None:
+        if raise_on_failure and conversation_ids:
+            raise RuntimeError('Pinecone index not initialized for transcript chunk vector delete')
+        return 0
+    if not conversation_ids:
         return 0
     deleted = 0
+    failures = 0
     for conversation_id in conversation_ids:
         prefix = f'{uid}-{conversation_id}-c'
         try:
@@ -1031,6 +1038,9 @@ def delete_transcript_chunk_vectors_batch(uid: str, conversation_ids: List[str])
                 index.delete(ids=ids[i : i + 1000], namespace=TRANSCRIPT_CHUNKS_NAMESPACE)
             deleted += len(ids)
         except Exception:
+            failures += 1
             logger.warning(f'delete_transcript_chunk_vectors_batch failed uid={uid} conversation={conversation_id}')
+    if failures and raise_on_failure:
+        raise RuntimeError(f'transcript chunk vector delete failed for {failures} conversation(s)')
     logger.info(f'delete_transcript_chunk_vectors_batch uid={uid} total_deleted={deleted}')
     return deleted

--- a/backend/main.py
+++ b/backend/main.py
@@ -183,6 +183,7 @@ methods_timeout = {
 paths_timeout = {
     "/v2/sync-jobs/run": os.environ.get('HTTP_SYNC_JOBS_RUN_TIMEOUT', 1500),
     "/v2/audio-merge-jobs/run": os.environ.get('HTTP_AUDIO_MERGE_RUN_TIMEOUT', 600),
+    "/v1/users/account-deletion-wipes/run": os.environ.get('HTTP_ACCOUNT_DELETION_WIPE_RUN_TIMEOUT', 1500),
 }
 
 app.add_middleware(TimeoutMiddleware, methods_timeout=methods_timeout, paths_timeout=paths_timeout)

--- a/backend/route_policy_manifest.yaml
+++ b/backend/route_policy_manifest.yaml
@@ -5,4 +5,26 @@
 # legacy_unreviewed as the route inventory workstream is baselined.
 schema_version: 1
 service: backend-main
-routes: []
+routes:
+  - route_type: http
+    method: POST
+    path: /v1/users/account-deletion-wipes/run
+    policy:
+      review_status: reviewed
+      auth:
+        mechanisms:
+          - service_oidc
+        placement: dependency
+        scopes: []
+      byok: not_applicable
+      rate_limit:
+        policy_name: none
+        key_subject: none
+        enforcement: none
+        placement: none
+      timeout_class: account_deletion_wipe
+      surface: internal_task
+      visibility: internal
+      data_domain: user_profile
+      deprecation:
+        state: active

--- a/backend/routers/users.py
+++ b/backend/routers/users.py
@@ -5,10 +5,11 @@ import uuid
 from typing import List, Dict, Any, Union, Optional
 import hashlib
 import os
+import asyncio
 
 import pytz
-from fastapi import APIRouter, Depends, Header, HTTPException, Query
-from fastapi.responses import StreamingResponse
+from fastapi import APIRouter, Depends, Header, HTTPException, Query, Request
+from fastapi.responses import JSONResponse, StreamingResponse
 from pydantic import BaseModel, ConfigDict, Field
 
 from database import (
@@ -21,8 +22,9 @@ from database import (
     llm_usage as llm_usage_db,
     users as users_db,
 )
+from database.sync_jobs import release_job_run_lock, try_acquire_job_run_lock
 from services.users.data_export import iter_user_data_export
-from services.users.account_deletion import start_account_deletion
+from services.users.account_deletion import background_wipe_user_data, start_account_deletion
 from database.app_review_config import should_hide_subscription_ui
 from database.webhook_health import record_dev_webhook_success
 from database.conversations import get_in_progress_conversation, get_conversation
@@ -44,6 +46,7 @@ from database.redis_db import (
 )
 
 from database.users import (
+    claim_deletion_wipe_for_task,
     get_user_transcription_preferences,
     set_user_transcription_preferences,
 )
@@ -93,6 +96,8 @@ from utils.subscription import (
 )
 from database import user_usage as user_usage_db
 from utils import stripe as stripe_utils
+from utils.cloud_tasks import get_account_deletion_tasks_max_attempts, verify_cloud_tasks_oidc
+from utils.executors import cleanup_executor, db_executor, run_blocking
 from utils.log_sanitizer import sanitize
 from utils.llm.followup import followup_question_prompt
 from utils.notifications import send_notification, send_training_data_submitted_notification
@@ -295,6 +300,56 @@ def delete_account(
     except Exception as e:
         logger.info(f'delete_account {sanitize(str(e))}')
         raise HTTPException(status_code=500, detail='Could not delete account. Please try again.')
+
+
+# response_model omitted: include_in_schema=False Cloud Tasks handler; JSONResponse
+# status codes drive queue retry/ack behavior.
+@router.post('/v1/users/account-deletion-wipes/run', include_in_schema=False)
+async def run_account_deletion_wipe(request: Request, task_retry_count: int = Depends(verify_cloud_tasks_oidc)):
+    try:
+        payload = await request.json()
+        uid = payload['uid']
+        if not isinstance(uid, str) or not uid:
+            raise ValueError('uid must be a non-empty string')
+    except Exception as e:
+        logger.error(f'account_deletion handler: invalid payload, dropping task: {sanitize(str(e))}')
+        return JSONResponse(status_code=200, content={'status': 'dropped', 'reason': 'invalid_payload'})
+
+    lock_key = f'account-deletion:{uid}'
+    lock_token = await run_blocking(db_executor, try_acquire_job_run_lock, lock_key)
+    if not lock_token:
+        logger.warning(f'account_deletion handler: run-lock held for {uid}, deferring')
+        return JSONResponse(status_code=409, content={'status': 'locked'})
+
+    release_lock = True
+    try:
+        claim_status = await run_blocking(db_executor, claim_deletion_wipe_for_task, uid)
+        if claim_status == 'completed':
+            return JSONResponse(status_code=200, content={'status': 'acked', 'job_status': 'completed'})
+        if claim_status == 'running':
+            return JSONResponse(status_code=409, content={'status': 'running'})
+        if claim_status != 'claimed':
+            logger.warning(f'account_deletion handler: non-actionable task for {uid}, claim_status={claim_status}')
+            return JSONResponse(status_code=200, content={'status': 'dropped', 'reason': claim_status})
+
+        ok = await run_blocking(cleanup_executor, background_wipe_user_data, uid)
+        if ok:
+            return JSONResponse(status_code=200, content={'status': 'done'})
+
+        max_attempts = get_account_deletion_tasks_max_attempts()
+        if task_retry_count >= max_attempts - 1:
+            logger.error(f'account_deletion handler: final attempt {task_retry_count + 1} failed for {uid}')
+            return JSONResponse(status_code=200, content={'status': 'failed_final'})
+
+        logger.warning(f'account_deletion handler: attempt {task_retry_count + 1} failed for {uid}, will retry')
+        return JSONResponse(status_code=500, content={'status': 'retry'})
+    except asyncio.CancelledError:
+        release_lock = False
+        logger.warning(f'account_deletion handler cancelled for {uid}; preserving run-lock until TTL')
+        raise
+    finally:
+        if release_lock:
+            await run_blocking(db_executor, release_job_run_lock, lock_key, lock_token)
 
 
 @router.patch('/v1/users/geolocation', tags=['v1'], response_model=UserStatusResponse)

--- a/backend/scripts/check_response_model_coverage.py
+++ b/backend/scripts/check_response_model_coverage.py
@@ -79,6 +79,7 @@ LEGIT_NON_JSON: dict[tuple[str, str], str] = {
     # --- Cloud Tasks job runners (OIDC-verified internal, return JSONResponse acks directly) ---
     ("sync.py", "run_sync_job"): "Cloud Tasks job runner (OIDC-verified internal, JSONResponse acks)",
     ("sync.py", "run_audio_merge_job"): "Cloud Tasks job runner (OIDC-verified internal, JSONResponse acks)",
+    ("users.py", "run_account_deletion_wipe"): "Cloud Tasks job runner (OIDC-verified internal, JSONResponse acks)",
     ("sync.py", "sync_local_files"): "sync dispatch (JSONResponse, multi-mode dispatch)",
     ("omni_relay.py", "omni_relay"): "relay proxy (forwards to upstream, JSONResponse passthrough)",
 }

--- a/backend/scripts/route_policy_inventory.py
+++ b/backend/scripts/route_policy_inventory.py
@@ -66,7 +66,15 @@ BYOK_POLICIES = {
 RATE_LIMIT_KEY_SUBJECTS = {'uid', 'api_key', 'app_key', 'ip', 'custom', 'none', 'unknown'}
 RATE_LIMIT_ENFORCEMENTS = {'fail_open', 'fail_closed', 'shadow', 'none', 'unknown'}
 RATE_LIMIT_PLACEMENTS = {'dependency', 'inline', 'wrapper', 'websocket_lock', 'none', 'unknown'}
-TIMEOUT_CLASSES = {'default_method', 'sync_job', 'audio_merge', 'streaming', 'websocket', 'unknown'}
+TIMEOUT_CLASSES = {
+    'default_method',
+    'sync_job',
+    'audio_merge',
+    'account_deletion_wipe',
+    'streaming',
+    'websocket',
+    'unknown',
+}
 SURFACES = {
     'first_party_app',
     'developer_api',
@@ -520,7 +528,7 @@ def validate_inventory(
         if not policy:
             continue
         timeout_class = policy.get('timeout_class')
-        if timeout_class in {'sync_job', 'audio_merge'} and entry['path'] not in paths_timeout:
+        if timeout_class in {'sync_job', 'audio_merge', 'account_deletion_wipe'} and entry['path'] not in paths_timeout:
             missing_timeout_overrides.append(f"{entry['route_key']} declares {timeout_class} without a path override")
         if entry['observed']['timeout_override']:
             expected_timeout_class = entry['observed']['timeout_class_hint']

--- a/backend/scripts/route_policy_inventory.py
+++ b/backend/scripts/route_policy_inventory.py
@@ -171,6 +171,8 @@ def _timeout_class_for_path(path: str, paths_timeout: dict[str, Any]) -> str:
         return 'sync_job'
     if path == '/v2/audio-merge-jobs/run':
         return 'audio_merge'
+    if path == '/v1/users/account-deletion-wipes/run':
+        return 'account_deletion_wipe'
     if path in paths_timeout:
         return 'unknown'
     return 'default_method'

--- a/backend/services/users/account_deletion.py
+++ b/backend/services/users/account_deletion.py
@@ -194,12 +194,10 @@ def _persist_wipe_marker_with_retry(uid: str, max_attempts: int = 3, retry_delay
     """Transition the marker to the actionable ``'pending'`` state after auth deletion is confirmed.
 
     Called only after ``auth.delete_account()`` has succeeded (or the user was
-    already gone). On persistent Firestore failure, logs a critical error rather
-    than raising — the Firebase user is already deleted, so raising would
-    surface a misleading error. The background wipe may not be queued
-    immediately, but a stale ``'deleting_auth'`` marker is now recoverable:
-    ``reconcile_pending_deletion_wipes`` will verify the auth user is gone and
-    re-enqueue the wipe.
+    already gone). Raises on persistent failure so callers do not enqueue or
+    report success without an actionable wipe marker. A stale
+    ``'deleting_auth'`` marker remains recoverable: the reconciler verifies the
+    auth user is gone before re-enqueueing the wipe.
     """
     last_err = None
     for attempt in range(max_attempts):
@@ -210,10 +208,48 @@ def _persist_wipe_marker_with_retry(uid: str, max_attempts: int = 3, retry_delay
             last_err = e
             if attempt < max_attempts - 1:
                 time.sleep(retry_delay * (attempt + 1))
-    logger.critical(
+    raise Exception(
         f'delete_account marker transition to pending failed after {max_attempts} attempts for {uid}: '
-        f'{sanitize(str(last_err))} — Firebase user already deleted, wipe may need manual re-queue.'
+        f'{sanitize(str(last_err))}'
     )
+
+
+def _mark_billing_failed_with_retry(
+    uid: str, subscription_id: str | None, error: Exception, max_attempts: int = 3, retry_delay: float = 0.5
+):
+    last_err = None
+    raw_error = str(error)
+    sanitized_error = sanitize(raw_error)
+    if not isinstance(sanitized_error, str):
+        sanitized_error = raw_error
+    for attempt in range(max_attempts):
+        try:
+            users_db.mark_user_deletion_billing_failed(uid, subscription_id, sanitized_error)
+            return
+        except Exception as e:
+            last_err = e
+            if attempt < max_attempts - 1:
+                time.sleep(retry_delay * (attempt + 1))
+    logger.critical(
+        f'delete_account billing failure status persist failed after {max_attempts} attempts for {uid}: '
+        f'{sanitize(str(last_err))}; original billing error: {sanitized_error}'
+    )
+
+
+def _cancel_subscription_for_account_deletion(uid: str):
+    subscription_id = None
+    try:
+        sub = users_db.get_user_subscription(uid)
+        subscription_id = getattr(sub, 'stripe_subscription_id', None) if sub else None
+        if not subscription_id:
+            return
+        canceled = stripe_utils.cancel_subscription(subscription_id)
+        if not canceled:
+            raise RuntimeError('stripe cancel returned no subscription')
+    except Exception as e:
+        _mark_billing_failed_with_retry(uid, subscription_id, e)
+        logger.error(f'delete_account billing cancellation failed for {uid}: {sanitize(str(e))}')
+        raise
 
 
 def _cancel_wipe_marker_with_retry(uid: str, max_attempts: int = 3, retry_delay: float = 0.5):
@@ -257,14 +293,7 @@ def start_account_deletion(uid: str, reason: str | None = None, reason_details: 
     # proceed.
     _persist_wipe_intent_with_retry(uid)
 
-    try:
-        sub = users_db.get_user_subscription(uid)
-        if sub and sub.stripe_subscription_id:
-            canceled = stripe_utils.cancel_subscription(sub.stripe_subscription_id)
-            if not canceled:
-                logger.error(f'delete_account stripe cancel returned None for {uid}')
-    except Exception as e:
-        logger.error(f'delete_account subscription lookup failed for {uid}: {sanitize(str(e))}')
+    _cancel_subscription_for_account_deletion(uid)
 
     try:
         auth.delete_account(uid)

--- a/backend/services/users/account_deletion.py
+++ b/backend/services/users/account_deletion.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 
 import time
+from database import vector_db
 from database import users as users_db
 from database.action_items import get_action_item_ids
 from database.conversations import get_conversation_ids
@@ -16,12 +17,13 @@ from database.vector_db import (
     delete_transcript_chunk_vectors_batch,
 )
 from utils import stripe as stripe_utils
+from utils.cloud_tasks import enqueue_account_deletion_wipe, is_account_deletion_dispatch_enabled
 from utils.executors import cleanup_executor, submit_with_context
 from utils.log_sanitizer import sanitize
 from utils.other import endpoints as auth
 from utils.memory.canonical_memory_adapter import purge_canonical_derived_user_data
 from utils.other.storage import delete_all_conversation_recordings
-from utils.twilio_service import delete_user_caller_ids
+from utils.twilio_service import delete_user_caller_ids_strict as delete_user_caller_ids
 
 logger = logging.getLogger(__name__)
 
@@ -38,9 +40,18 @@ def purge_derived_user_data(uid: str):
     def record_failure(kind: str, operation: str, error: Exception):
         result[kind].append({'operation': operation, 'error': sanitize(str(error))})
 
+    def require_deleted_count(operation: str, expected: int, deleted: int | None):
+        if expected and isinstance(deleted, int) and deleted < expected:
+            raise RuntimeError(f'{operation} only deleted {deleted}/{expected} records')
+
+    def require_vector_index(operation: str):
+        if vector_db.index is None:
+            raise RuntimeError(f'Pinecone index not initialized for {operation}')
+
     try:
         conversation_ids = get_conversation_ids(uid)
         if conversation_ids:
+            require_vector_index('conversation_vectors')
             delete_conversation_vectors_batch(uid, conversation_ids)
     except Exception as e:
         record_failure('required_failures', 'conversation_vectors', e)
@@ -49,7 +60,8 @@ def purge_derived_user_data(uid: str):
     try:
         conversation_ids = get_conversation_ids(uid)
         if conversation_ids:
-            delete_transcript_chunk_vectors_batch(uid, conversation_ids)
+            require_vector_index('transcript_chunk_vectors')
+            delete_transcript_chunk_vectors_batch(uid, conversation_ids, raise_on_failure=True)
     except Exception as e:
         record_failure('required_failures', 'transcript_chunk_vectors', e)
         logger.error(f'delete_account purge transcript chunk vectors failed for {uid}: {sanitize(str(e))}')
@@ -57,7 +69,9 @@ def purge_derived_user_data(uid: str):
     try:
         memory_ids = get_memory_ids(uid)
         if memory_ids:
-            delete_memory_vectors_batch(uid, memory_ids)
+            require_vector_index('memory_vectors')
+            deleted = delete_memory_vectors_batch(uid, memory_ids)
+            require_deleted_count('memory_vectors', len(memory_ids), deleted)
     except Exception as e:
         record_failure('required_failures', 'memory_vectors', e)
         logger.error(f'delete_account purge memory vectors failed for {uid}: {sanitize(str(e))}')
@@ -65,6 +79,7 @@ def purge_derived_user_data(uid: str):
     try:
         action_item_ids = get_action_item_ids(uid)
         if action_item_ids:
+            require_vector_index('action_item_vectors')
             delete_action_item_vectors_batch(uid, action_item_ids)
     except Exception as e:
         record_failure('required_failures', 'action_item_vectors', e)
@@ -73,6 +88,7 @@ def purge_derived_user_data(uid: str):
     try:
         screen_activity_ids = get_screen_activity_ids(uid)
         if screen_activity_ids:
+            require_vector_index('screen_activity_vectors')
             delete_screen_activity_vectors(uid, screen_activity_ids)
     except Exception as e:
         record_failure('required_failures', 'screen_activity_vectors', e)
@@ -81,7 +97,7 @@ def purge_derived_user_data(uid: str):
     try:
         delete_all_conversation_recordings(uid)
     except Exception as e:
-        record_failure('best_effort_failures', 'conversation_recordings', e)
+        record_failure('required_failures', 'conversation_recordings', e)
         logger.error(f'delete_account purge recordings failed for {uid}: {sanitize(str(e))}')
 
     try:
@@ -93,7 +109,7 @@ def purge_derived_user_data(uid: str):
     return result
 
 
-def background_wipe_user_data(uid: str):
+def background_wipe_user_data(uid: str) -> bool:
     try:
         # Transition to ``running`` so the reconciler can distinguish a
         # genuinely orphaned ``pending`` marker (queued but never started)
@@ -120,11 +136,31 @@ def background_wipe_user_data(uid: str):
             users_db.mark_user_deletion_wipe_failed(uid)
         except Exception as persist_err:
             logger.error(f'delete_account wipe status persist failed for {uid}: {sanitize(str(persist_err))}')
+        return False
     else:
         try:
             users_db.mark_user_deletion_wipe_completed(uid)
         except Exception as e:
             logger.error(f'delete_account wipe status persist failed for {uid}: {sanitize(str(e))}')
+        return True
+
+
+def enqueue_deletion_wipe(uid: str):
+    """Dispatch the account-deletion wipe using the configured durable mechanism."""
+    if is_account_deletion_dispatch_enabled() is True:
+        enqueue_account_deletion_wipe(uid)
+        return
+    submit_with_context(cleanup_executor, background_wipe_user_data, uid)
+
+
+def _mark_wipe_failed_after_enqueue_error(uid: str, error: Exception):
+    try:
+        users_db.mark_user_deletion_wipe_failed(uid)
+    except Exception as persist_err:
+        logger.error(
+            f'delete_account enqueue failure status persist failed for {uid}: {sanitize(str(persist_err))}; '
+            f'original enqueue error: {sanitize(str(error))}'
+        )
 
 
 def _persist_wipe_intent_with_retry(uid: str, max_attempts: int = 3, retry_delay: float = 0.5):
@@ -245,11 +281,14 @@ def start_account_deletion(uid: str, reason: str | None = None, reason_details: 
             raise
 
     # Phase 2 — auth deletion confirmed. Transition the marker to the
-    # actionable 'pending' state so the reconciler can recover the wipe if
-    # the queued executor future is lost to a deploy/restart.
+    # actionable 'pending' state before dispatching the durable wipe task.
     _persist_wipe_marker_with_retry(uid)
 
-    submit_with_context(cleanup_executor, background_wipe_user_data, uid)
+    try:
+        enqueue_deletion_wipe(uid)
+    except Exception as e:
+        _mark_wipe_failed_after_enqueue_error(uid, e)
+        raise
 
     return {'status': 'ok', 'message': 'Account deletion started'}
 
@@ -279,8 +318,7 @@ def reconcile_pending_deletion_wipes(limit: int = 100) -> dict[str, int]:
 
     Called by a periodic worker (cron, Cloud Scheduler, or startup hook) to drain
     the ``wipe_status in ('pending', 'failed', 'retrying')`` backlog left behind
-    when a deploy or restart cancels in-process ``cleanup_executor`` futures
-    before they start.
+    when a durable task enqueue or worker execution failed.
 
     Also recovers stale ``'deleting_auth'`` records — markers where the deletion
     intent was written but never transitioned to ``'pending'`` (usually a crash
@@ -330,7 +368,13 @@ def reconcile_pending_deletion_wipes(limit: int = 100) -> dict[str, int]:
         if claimed_uid is None:
             skipped += 1
             continue
-        submit_with_context(cleanup_executor, background_wipe_user_data, uid)
+        try:
+            enqueue_deletion_wipe(uid)
+        except Exception as e:
+            logger.error(f'delete_account reconciliation enqueue failed for {uid}: {sanitize(str(e))}')
+            _mark_wipe_failed_after_enqueue_error(uid, e)
+            skipped += 1
+            continue
         requeued += 1
         logger.info(f'delete_account reconciliation re-enqueued wipe for {uid}')
 

--- a/backend/tests/routers/test_users.py
+++ b/backend/tests/routers/test_users.py
@@ -1,10 +1,21 @@
 import asyncio
+import json
 from unittest.mock import MagicMock, patch
 
 import pytest
 from fastapi import HTTPException
 
 from routers import users as users_router
+
+
+class _FakeRequest:
+    def __init__(self, payload):
+        self._payload = payload
+
+    async def json(self):
+        if isinstance(self._payload, Exception):
+            raise self._payload
+        return self._payload
 
 
 def test_delete_account_delegates_to_service():
@@ -26,6 +37,140 @@ def test_delete_account_maps_unexpected_service_error_to_500():
 
     assert exc.value.status_code == 500
     assert exc.value.detail == 'Could not delete account. Please try again.'
+
+
+def test_run_account_deletion_wipe_retries_failed_wipe(monkeypatch):
+    calls = []
+
+    async def run_blocking(_executor, fn, *args):
+        calls.append((fn, args))
+        if fn is users_router.try_acquire_job_run_lock:
+            return 'lock-token'
+        if fn is users_router.claim_deletion_wipe_for_task:
+            return 'claimed'
+        if fn is users_router.background_wipe_user_data:
+            return False
+        if fn is users_router.release_job_run_lock:
+            return None
+        raise AssertionError(f'unexpected function {fn}')
+
+    monkeypatch.setattr(users_router, 'run_blocking', run_blocking)
+    monkeypatch.setattr(users_router, 'get_account_deletion_tasks_max_attempts', lambda: 3)
+
+    response = asyncio.run(users_router.run_account_deletion_wipe(_FakeRequest({'uid': 'uid1'}), task_retry_count=0))
+
+    assert response.status_code == 500
+    assert json.loads(response.body) == {'status': 'retry'}
+    assert calls == [
+        (users_router.try_acquire_job_run_lock, ('account-deletion:uid1',)),
+        (users_router.claim_deletion_wipe_for_task, ('uid1',)),
+        (users_router.background_wipe_user_data, ('uid1',)),
+        (users_router.release_job_run_lock, ('account-deletion:uid1', 'lock-token')),
+    ]
+
+
+def test_run_account_deletion_wipe_consumes_final_failed_attempt(monkeypatch):
+    async def run_blocking(_executor, fn, *args):
+        if fn is users_router.try_acquire_job_run_lock:
+            return 'lock-token'
+        if fn is users_router.claim_deletion_wipe_for_task:
+            return 'claimed'
+        if fn is users_router.background_wipe_user_data:
+            return False
+        if fn is users_router.release_job_run_lock:
+            return None
+        raise AssertionError(f'unexpected function {fn}')
+
+    monkeypatch.setattr(users_router, 'run_blocking', run_blocking)
+    monkeypatch.setattr(users_router, 'get_account_deletion_tasks_max_attempts', lambda: 2)
+
+    response = asyncio.run(users_router.run_account_deletion_wipe(_FakeRequest({'uid': 'uid1'}), task_retry_count=1))
+
+    assert response.status_code == 200
+    assert json.loads(response.body) == {'status': 'failed_final'}
+
+
+def test_run_account_deletion_wipe_defers_when_locked(monkeypatch):
+    release = MagicMock()
+
+    async def run_blocking(_executor, fn, *args):
+        if fn is users_router.try_acquire_job_run_lock:
+            return None
+        if fn is users_router.release_job_run_lock:
+            release(*args)
+            return None
+        raise AssertionError(f'unexpected function {fn}')
+
+    monkeypatch.setattr(users_router, 'run_blocking', run_blocking)
+
+    response = asyncio.run(users_router.run_account_deletion_wipe(_FakeRequest({'uid': 'uid1'}), task_retry_count=0))
+
+    assert response.status_code == 409
+    assert json.loads(response.body) == {'status': 'locked'}
+    release.assert_not_called()
+
+
+def test_run_account_deletion_wipe_acks_completed_job(monkeypatch):
+    async def run_blocking(_executor, fn, *args):
+        if fn is users_router.try_acquire_job_run_lock:
+            return 'lock-token'
+        if fn is users_router.claim_deletion_wipe_for_task:
+            return 'completed'
+        if fn is users_router.release_job_run_lock:
+            return None
+        raise AssertionError(f'unexpected function {fn}')
+
+    monkeypatch.setattr(users_router, 'run_blocking', run_blocking)
+
+    response = asyncio.run(users_router.run_account_deletion_wipe(_FakeRequest({'uid': 'uid1'}), task_retry_count=0))
+
+    assert response.status_code == 200
+    assert json.loads(response.body) == {'status': 'acked', 'job_status': 'completed'}
+
+
+def test_run_account_deletion_wipe_drops_non_actionable_job(monkeypatch):
+    async def run_blocking(_executor, fn, *args):
+        if fn is users_router.try_acquire_job_run_lock:
+            return 'lock-token'
+        if fn is users_router.claim_deletion_wipe_for_task:
+            return 'not_actionable'
+        if fn is users_router.release_job_run_lock:
+            return None
+        raise AssertionError(f'unexpected function {fn}')
+
+    monkeypatch.setattr(users_router, 'run_blocking', run_blocking)
+
+    response = asyncio.run(users_router.run_account_deletion_wipe(_FakeRequest({'uid': 'uid1'}), task_retry_count=0))
+
+    assert response.status_code == 200
+    assert json.loads(response.body) == {'status': 'dropped', 'reason': 'not_actionable'}
+
+
+def test_run_account_deletion_wipe_preserves_lock_on_cancel(monkeypatch):
+    released = []
+
+    async def run_blocking(_executor, fn, *args):
+        if fn is users_router.try_acquire_job_run_lock:
+            return 'lock-token'
+        if fn is users_router.claim_deletion_wipe_for_task:
+            return 'claimed'
+        if fn is users_router.background_wipe_user_data:
+            raise asyncio.CancelledError()
+        if fn is users_router.release_job_run_lock:
+            released.append(args)
+            return None
+        raise AssertionError(f'unexpected function {fn}')
+
+    monkeypatch.setattr(users_router, 'run_blocking', run_blocking)
+
+    try:
+        asyncio.run(users_router.run_account_deletion_wipe(_FakeRequest({'uid': 'uid1'}), task_retry_count=0))
+    except asyncio.CancelledError:
+        pass
+    else:
+        raise AssertionError('expected cancellation to propagate')
+
+    assert released == []
 
 
 def test_export_all_user_data_keeps_streaming_headers():

--- a/backend/tests/services/users/test_account_deletion.py
+++ b/backend/tests/services/users/test_account_deletion.py
@@ -161,8 +161,8 @@ def test_start_account_deletion_raises_when_cloud_task_enqueue_fails(monkeypatch
     submit.assert_not_called()
 
 
-def test_start_account_deletion_tolerates_best_effort_failures_and_missing_firebase_user(monkeypatch):
-    """Stripe/feedback failures are tolerated, but marker write must succeed."""
+def test_start_account_deletion_tolerates_feedback_failure_and_missing_firebase_user(monkeypatch):
+    """Feedback failures are tolerated, but marker and billing checks must succeed."""
     monkeypatch.setattr(
         account_deletion.users_db, 'set_user_deletion_feedback', MagicMock(side_effect=Exception('db down'))
     )
@@ -171,9 +171,7 @@ def test_start_account_deletion_tolerates_best_effort_failures_and_missing_fireb
         'mark_user_deletion_wipe_started',
         MagicMock(),
     )
-    monkeypatch.setattr(
-        account_deletion.users_db, 'get_user_subscription', MagicMock(side_effect=Exception('read down'))
-    )
+    monkeypatch.setattr(account_deletion.users_db, 'get_user_subscription', MagicMock(return_value=None))
     monkeypatch.setattr(account_deletion.stripe_utils, 'cancel_subscription', MagicMock())
     monkeypatch.setattr(account_deletion.auth, 'delete_account', MagicMock(side_effect=Exception('USER_NOT_FOUND')))
     submit = MagicMock()
@@ -187,6 +185,54 @@ def test_start_account_deletion_tolerates_best_effort_failures_and_missing_fireb
     submit.assert_called_once_with(
         account_deletion.cleanup_executor, account_deletion.background_wipe_user_data, 'uid1'
     )
+
+
+def test_start_account_deletion_blocks_when_subscription_lookup_fails(monkeypatch):
+    monkeypatch.setattr(account_deletion.users_db, 'mark_user_deletion_wipe_intent', MagicMock())
+    monkeypatch.setattr(
+        account_deletion.users_db, 'get_user_subscription', MagicMock(side_effect=Exception('read down'))
+    )
+    monkeypatch.setattr(account_deletion.users_db, 'mark_user_deletion_billing_failed', MagicMock())
+    monkeypatch.setattr(account_deletion.auth, 'delete_account', MagicMock())
+    submit = MagicMock()
+    monkeypatch.setattr(account_deletion, 'submit_with_context', submit)
+    monkeypatch.setattr(account_deletion.time, 'sleep', lambda *_: None)
+
+    try:
+        account_deletion.start_account_deletion('uid1')
+    except Exception as exc:
+        assert str(exc) == 'read down'
+    else:
+        raise AssertionError('expected subscription lookup failure to raise')
+
+    account_deletion.users_db.mark_user_deletion_billing_failed.assert_called_once_with('uid1', None, 'read down')
+    account_deletion.auth.delete_account.assert_not_called()
+    submit.assert_not_called()
+
+
+def test_start_account_deletion_blocks_when_stripe_cancel_returns_none(monkeypatch):
+    sub = types.SimpleNamespace(stripe_subscription_id='sub_123')
+    monkeypatch.setattr(account_deletion.users_db, 'mark_user_deletion_wipe_intent', MagicMock())
+    monkeypatch.setattr(account_deletion.users_db, 'get_user_subscription', MagicMock(return_value=sub))
+    monkeypatch.setattr(account_deletion.stripe_utils, 'cancel_subscription', MagicMock(return_value=None))
+    monkeypatch.setattr(account_deletion.users_db, 'mark_user_deletion_billing_failed', MagicMock())
+    monkeypatch.setattr(account_deletion.auth, 'delete_account', MagicMock())
+    submit = MagicMock()
+    monkeypatch.setattr(account_deletion, 'submit_with_context', submit)
+    monkeypatch.setattr(account_deletion.time, 'sleep', lambda *_: None)
+
+    try:
+        account_deletion.start_account_deletion('uid1')
+    except Exception as exc:
+        assert 'stripe cancel returned no subscription' in str(exc)
+    else:
+        raise AssertionError('expected stripe cancellation failure to raise')
+
+    account_deletion.users_db.mark_user_deletion_billing_failed.assert_called_once_with(
+        'uid1', 'sub_123', 'stripe cancel returned no subscription'
+    )
+    account_deletion.auth.delete_account.assert_not_called()
+    submit.assert_not_called()
 
 
 def test_start_account_deletion_raises_when_marker_persist_fails(monkeypatch):
@@ -208,6 +254,29 @@ def test_start_account_deletion_raises_when_marker_persist_fails(monkeypatch):
 
     # Firebase user must NOT be deleted if the intent failed.
     account_deletion.auth.delete_account.assert_not_called()
+    submit.assert_not_called()
+
+
+def test_start_account_deletion_raises_when_pending_marker_persist_fails_after_auth(monkeypatch):
+    """Do not enqueue or report success unless the actionable pending marker exists."""
+    monkeypatch.setattr(account_deletion.users_db, 'get_user_subscription', MagicMock(return_value=None))
+    monkeypatch.setattr(account_deletion.users_db, 'mark_user_deletion_wipe_intent', MagicMock())
+    monkeypatch.setattr(
+        account_deletion.users_db, 'mark_user_deletion_wipe_started', MagicMock(side_effect=Exception('db down'))
+    )
+    monkeypatch.setattr(account_deletion.auth, 'delete_account', MagicMock())
+    submit = MagicMock()
+    monkeypatch.setattr(account_deletion, 'submit_with_context', submit)
+    monkeypatch.setattr(account_deletion.time, 'sleep', lambda *_: None)
+
+    try:
+        account_deletion.start_account_deletion('uid1')
+    except Exception as exc:
+        assert 'marker transition to pending failed' in str(exc)
+    else:
+        raise AssertionError('expected pending marker failure to raise')
+
+    account_deletion.auth.delete_account.assert_called_once_with('uid1')
     submit.assert_not_called()
 
 

--- a/backend/tests/services/users/test_account_deletion.py
+++ b/backend/tests/services/users/test_account_deletion.py
@@ -168,6 +168,11 @@ def test_start_account_deletion_tolerates_feedback_failure_and_missing_firebase_
     )
     monkeypatch.setattr(
         account_deletion.users_db,
+        'mark_user_deletion_wipe_intent',
+        MagicMock(),
+    )
+    monkeypatch.setattr(
+        account_deletion.users_db,
         'mark_user_deletion_wipe_started',
         MagicMock(),
     )
@@ -437,6 +442,7 @@ def test_purge_derived_user_data_isolates_backends_and_reloads_conversation_ids(
     monkeypatch.setattr(
         account_deletion, 'delete_all_conversation_recordings', lambda uid: calls.append(('recordings', uid))
     )
+    monkeypatch.setattr(account_deletion, 'purge_canonical_derived_user_data', MagicMock())
 
     result = account_deletion.purge_derived_user_data('uid1')
 
@@ -471,6 +477,9 @@ def test_purge_derived_user_data_continues_after_each_failure(monkeypatch):
     monkeypatch.setattr(
         account_deletion, 'delete_all_conversation_recordings', MagicMock(side_effect=Exception('gcs down'))
     )
+    monkeypatch.setattr(
+        account_deletion, 'purge_canonical_derived_user_data', MagicMock(side_effect=Exception('canonical down'))
+    )
 
     result = account_deletion.purge_derived_user_data('uid1')
 
@@ -481,11 +490,13 @@ def test_purge_derived_user_data_continues_after_each_failure(monkeypatch):
     account_deletion.delete_action_item_vectors_batch.assert_called_once_with('uid1', ['a1'])
     account_deletion.delete_screen_activity_vectors.assert_called_once_with('uid1', ['s1'])
     account_deletion.delete_all_conversation_recordings.assert_called_once_with('uid1')
+    account_deletion.purge_canonical_derived_user_data.assert_called_once_with('uid1')
     assert [failure['operation'] for failure in result['required_failures']] == [
         'conversation_vectors',
         'transcript_chunk_vectors',
         'memory_vectors',
         'conversation_recordings',
+        'canonical_derived_data',
     ]
     assert result['best_effort_failures'] == []
 
@@ -502,6 +513,7 @@ def test_purge_derived_user_data_fails_required_vectors_when_index_missing(monke
     monkeypatch.setattr(account_deletion, 'delete_action_item_vectors_batch', MagicMock())
     monkeypatch.setattr(account_deletion, 'delete_screen_activity_vectors', MagicMock())
     monkeypatch.setattr(account_deletion, 'delete_all_conversation_recordings', MagicMock())
+    monkeypatch.setattr(account_deletion, 'purge_canonical_derived_user_data', MagicMock())
 
     result = account_deletion.purge_derived_user_data('uid1')
 

--- a/backend/tests/services/users/test_account_deletion.py
+++ b/backend/tests/services/users/test_account_deletion.py
@@ -118,6 +118,49 @@ def test_start_account_deletion_preserves_order_and_enqueues_background_wipe(mon
     ]
 
 
+def test_start_account_deletion_enqueues_cloud_task_when_enabled(monkeypatch):
+    monkeypatch.setattr(account_deletion.users_db, 'mark_user_deletion_wipe_intent', MagicMock())
+    monkeypatch.setattr(account_deletion.users_db, 'mark_user_deletion_wipe_started', MagicMock())
+    monkeypatch.setattr(account_deletion.users_db, 'get_user_subscription', MagicMock(return_value=None))
+    monkeypatch.setattr(account_deletion.auth, 'delete_account', MagicMock())
+    monkeypatch.setattr(account_deletion, 'is_account_deletion_dispatch_enabled', MagicMock(return_value=True))
+    enqueue = MagicMock()
+    monkeypatch.setattr(account_deletion, 'enqueue_account_deletion_wipe', enqueue)
+    submit = MagicMock()
+    monkeypatch.setattr(account_deletion, 'submit_with_context', submit)
+
+    result = account_deletion.start_account_deletion('uid1')
+
+    assert result == {'status': 'ok', 'message': 'Account deletion started'}
+    enqueue.assert_called_once_with('uid1')
+    submit.assert_not_called()
+
+
+def test_start_account_deletion_raises_when_cloud_task_enqueue_fails(monkeypatch):
+    monkeypatch.setattr(account_deletion.users_db, 'mark_user_deletion_wipe_intent', MagicMock())
+    monkeypatch.setattr(account_deletion.users_db, 'mark_user_deletion_wipe_started', MagicMock())
+    monkeypatch.setattr(account_deletion.users_db, 'mark_user_deletion_wipe_failed', MagicMock())
+    monkeypatch.setattr(account_deletion.users_db, 'get_user_subscription', MagicMock(return_value=None))
+    monkeypatch.setattr(account_deletion.auth, 'delete_account', MagicMock())
+    monkeypatch.setattr(account_deletion, 'is_account_deletion_dispatch_enabled', MagicMock(return_value=True))
+    monkeypatch.setattr(
+        account_deletion, 'enqueue_account_deletion_wipe', MagicMock(side_effect=Exception('tasks down'))
+    )
+    submit = MagicMock()
+    monkeypatch.setattr(account_deletion, 'submit_with_context', submit)
+
+    try:
+        account_deletion.start_account_deletion('uid1')
+    except Exception as exc:
+        assert str(exc) == 'tasks down'
+    else:
+        raise AssertionError('expected enqueue failure to raise')
+
+    account_deletion.users_db.mark_user_deletion_wipe_started.assert_called_once_with('uid1')
+    account_deletion.users_db.mark_user_deletion_wipe_failed.assert_called_once_with('uid1')
+    submit.assert_not_called()
+
+
 def test_start_account_deletion_tolerates_best_effort_failures_and_missing_firebase_user(monkeypatch):
     """Stripe/feedback failures are tolerated, but marker write must succeed."""
     monkeypatch.setattr(
@@ -305,7 +348,7 @@ def test_purge_derived_user_data_isolates_backends_and_reloads_conversation_ids(
     monkeypatch.setattr(
         account_deletion,
         'delete_transcript_chunk_vectors_batch',
-        lambda uid, ids: calls.append(('delete_transcript_vectors', uid, ids)),
+        lambda uid, ids, **kwargs: calls.append(('delete_transcript_vectors', uid, ids, kwargs)),
     )
     monkeypatch.setattr(
         account_deletion,
@@ -332,7 +375,7 @@ def test_purge_derived_user_data_isolates_backends_and_reloads_conversation_ids(
         ('get_conversations', 'uid1'),
         ('delete_conversation_vectors', 'uid1', ['c1']),
         ('get_conversations', 'uid1'),
-        ('delete_transcript_vectors', 'uid1', ['c2']),
+        ('delete_transcript_vectors', 'uid1', ['c2'], {'raise_on_failure': True}),
         ('get_memories', 'uid1'),
         ('delete_memory_vectors', 'uid1', ['m1']),
         ('get_actions', 'uid1'),
@@ -373,8 +416,38 @@ def test_purge_derived_user_data_continues_after_each_failure(monkeypatch):
         'conversation_vectors',
         'transcript_chunk_vectors',
         'memory_vectors',
+        'conversation_recordings',
     ]
-    assert [failure['operation'] for failure in result['best_effort_failures']] == ['conversation_recordings']
+    assert result['best_effort_failures'] == []
+
+
+def test_purge_derived_user_data_fails_required_vectors_when_index_missing(monkeypatch):
+    monkeypatch.setattr(account_deletion.vector_db, 'index', None)
+    monkeypatch.setattr(account_deletion, 'get_conversation_ids', MagicMock(return_value=['c1']))
+    monkeypatch.setattr(account_deletion, 'get_memory_ids', MagicMock(return_value=['m1']))
+    monkeypatch.setattr(account_deletion, 'get_action_item_ids', MagicMock(return_value=['a1']))
+    monkeypatch.setattr(account_deletion, 'get_screen_activity_ids', MagicMock(return_value=['s1']))
+    monkeypatch.setattr(account_deletion, 'delete_conversation_vectors_batch', MagicMock())
+    monkeypatch.setattr(account_deletion, 'delete_transcript_chunk_vectors_batch', MagicMock())
+    monkeypatch.setattr(account_deletion, 'delete_memory_vectors_batch', MagicMock())
+    monkeypatch.setattr(account_deletion, 'delete_action_item_vectors_batch', MagicMock())
+    monkeypatch.setattr(account_deletion, 'delete_screen_activity_vectors', MagicMock())
+    monkeypatch.setattr(account_deletion, 'delete_all_conversation_recordings', MagicMock())
+
+    result = account_deletion.purge_derived_user_data('uid1')
+
+    assert [failure['operation'] for failure in result['required_failures']] == [
+        'conversation_vectors',
+        'transcript_chunk_vectors',
+        'memory_vectors',
+        'action_item_vectors',
+        'screen_activity_vectors',
+    ]
+    account_deletion.delete_conversation_vectors_batch.assert_not_called()
+    account_deletion.delete_transcript_chunk_vectors_batch.assert_not_called()
+    account_deletion.delete_memory_vectors_batch.assert_not_called()
+    account_deletion.delete_action_item_vectors_batch.assert_not_called()
+    account_deletion.delete_screen_activity_vectors.assert_not_called()
 
 
 def test_background_wipe_user_data_does_not_complete_when_required_derived_purge_fails(monkeypatch):
@@ -413,6 +486,42 @@ def test_reconcile_pending_deletion_wipes_re_enqueues(monkeypatch):
     assert len(enqueued) == 2
     assert enqueued[0] == (account_deletion.cleanup_executor, account_deletion.background_wipe_user_data, 'uid1')
     assert enqueued[1] == (account_deletion.cleanup_executor, account_deletion.background_wipe_user_data, 'uid2')
+
+
+def test_reconcile_pending_deletion_wipes_enqueues_cloud_tasks(monkeypatch):
+    pending = [{'uid': 'uid1', 'wipe_status': 'failed'}]
+    monkeypatch.setattr(account_deletion.users_db, 'get_pending_deletion_wipes', lambda limit=100: pending)
+    monkeypatch.setattr(account_deletion.users_db, 'claim_deletion_wipe', lambda uid: uid)
+    monkeypatch.setattr(account_deletion, 'is_account_deletion_dispatch_enabled', MagicMock(return_value=True))
+    enqueue = MagicMock()
+    monkeypatch.setattr(account_deletion, 'enqueue_account_deletion_wipe', enqueue)
+    submit = MagicMock()
+    monkeypatch.setattr(account_deletion, 'submit_with_context', submit)
+
+    result = account_deletion.reconcile_pending_deletion_wipes()
+
+    assert result == {'requeued': 1, 'skipped': 0}
+    enqueue.assert_called_once_with('uid1')
+    submit.assert_not_called()
+
+
+def test_reconcile_pending_deletion_wipes_skips_cloud_enqueue_failure(monkeypatch):
+    pending = [{'uid': 'uid1', 'wipe_status': 'failed'}]
+    monkeypatch.setattr(account_deletion.users_db, 'get_pending_deletion_wipes', lambda limit=100: pending)
+    monkeypatch.setattr(account_deletion.users_db, 'claim_deletion_wipe', lambda uid: uid)
+    monkeypatch.setattr(account_deletion, 'is_account_deletion_dispatch_enabled', MagicMock(return_value=True))
+    monkeypatch.setattr(
+        account_deletion, 'enqueue_account_deletion_wipe', MagicMock(side_effect=Exception('tasks down'))
+    )
+    monkeypatch.setattr(account_deletion.users_db, 'mark_user_deletion_wipe_failed', MagicMock())
+    submit = MagicMock()
+    monkeypatch.setattr(account_deletion, 'submit_with_context', submit)
+
+    result = account_deletion.reconcile_pending_deletion_wipes()
+
+    assert result == {'requeued': 0, 'skipped': 1}
+    account_deletion.users_db.mark_user_deletion_wipe_failed.assert_called_once_with('uid1')
+    submit.assert_not_called()
 
 
 def test_reconcile_pending_deletion_wipes_skips_already_claimed(monkeypatch):

--- a/backend/tests/unit/test_byok_security.py
+++ b/backend/tests/unit/test_byok_security.py
@@ -59,6 +59,7 @@ def _make_db_fakes() -> dict:
 
     twilio_service = ModuleType("utils.twilio_service")
     twilio_service.delete_user_caller_ids = MagicMock()
+    twilio_service.delete_user_caller_ids_strict = MagicMock()
     fakes["utils.twilio_service"] = twilio_service
 
     external_integrations = ModuleType("utils.llm.external_integrations")
@@ -320,7 +321,7 @@ class TestGeminiKeyNotInUrl:
 
 
 class TestChatQuotaBYOKBypass:
-    @patch('utils.byok.get_byok_key')
+    @patch('utils.subscription.get_byok_key')
     @patch('utils.subscription.users_db')
     def test_enforce_chat_quota_bypasses_for_byok_with_openai_key(self, mock_users_db, mock_get_key):
         mock_users_db.is_byok_active.return_value = True
@@ -705,7 +706,7 @@ class TestMiddlewareIsolation:
 
 
 class TestQuotaBoundaryTests:
-    @patch('utils.byok.get_byok_key')
+    @patch('utils.subscription.get_byok_key')
     @patch('utils.subscription.users_db')
     def test_chat_quota_bypasses_with_anthropic_key_only(self, mock_users_db, mock_get_key):
         """Anthropic-only BYOK should also bypass chat quota."""

--- a/backend/tests/unit/test_claim_deletion_wipe_txn.py
+++ b/backend/tests/unit/test_claim_deletion_wipe_txn.py
@@ -407,7 +407,7 @@ def test_get_pending_deletion_wipes_respects_limit_with_over_fetch():
 def test_get_pending_deletion_wipes_includes_stale_running():
     """Stale ``running`` records (worker crashed mid-execution) are recovered.
 
-    A ``running`` marker older than ``running_stale_after`` (default 30 min)
+    A ``running`` marker older than ``running_stale_after`` (default 6 hours)
     is included so the reconciler can re-enqueue a wipe whose worker died.
     """
     now = datetime.now(timezone.utc)
@@ -419,7 +419,7 @@ def test_get_pending_deletion_wipes_includes_stale_running():
             # Fresh running — worker is live, should NOT be recovered.
             {'uid': 'live1', 'wipe_status': 'running', 'wipe_running_at': now - timedelta(minutes=12)},
             # Stale running — worker probably crashed, SHOULD be recovered.
-            {'uid': 'crashed1', 'wipe_status': 'running', 'wipe_running_at': now - timedelta(minutes=45)},
+            {'uid': 'crashed1', 'wipe_status': 'running', 'wipe_running_at': now - timedelta(hours=7)},
         ],
         'retrying': [],
     }

--- a/backend/tests/unit/test_claim_deletion_wipe_txn.py
+++ b/backend/tests/unit/test_claim_deletion_wipe_txn.py
@@ -101,9 +101,12 @@ def _make_snapshot(data):
 def _make_txn():
     """Create a mock transaction that records update calls."""
     updates = []
+    sets = []
     txn = types.SimpleNamespace()
     txn._updates = updates
+    txn._sets = sets
     txn.update = lambda ref, fields: updates.append((ref, fields))
+    txn.set = lambda ref, fields, **kwargs: sets.append((ref, fields, kwargs))
     return txn
 
 
@@ -125,6 +128,39 @@ def _run_claim(data, stale_after=timedelta(minutes=10), running_stale_after=time
 
     result = raw_fn(txn, FakeDocRef(), stale_after, running_stale_after)
     return result, txn._updates
+
+
+def _run_mark_billing_failed(data):
+    txn = _make_txn()
+    txn_obj = users_db._mark_user_deletion_billing_failed_txn
+    raw_fn = getattr(txn_obj, 'to_wrap', txn_obj)
+    snapshot = _make_snapshot(data)
+
+    class FakeDocRef:
+        def get(self, transaction=None):
+            return snapshot
+
+    result = raw_fn(txn, FakeDocRef(), 'uid1', 'sub_123', 'stripe down')
+    return result, txn._sets
+
+
+def test_mark_billing_failed_allows_pre_wipe_states():
+    result, sets = _run_mark_billing_failed({'uid': 'uid1', 'wipe_status': 'deleting_auth'})
+
+    assert result is True
+    assert len(sets) == 1
+    _, fields, kwargs = sets[0]
+    assert fields['wipe_status'] == 'billing_failed'
+    assert fields['billing_subscription_id'] == 'sub_123'
+    assert fields['billing_error'] == 'stripe down'
+    assert kwargs == {'merge': True}
+
+
+def test_mark_billing_failed_does_not_clobber_actionable_or_terminal_wipes():
+    for status in ('pending', 'retrying', 'running', 'failed', 'completed'):
+        result, sets = _run_mark_billing_failed({'uid': 'uid1', 'wipe_status': status})
+        assert result is False
+        assert sets == []
 
 
 def test_claim_txn_skips_fresh_pending_marker():

--- a/backend/tests/unit/test_delete_account_purge_storage.py
+++ b/backend/tests/unit/test_delete_account_purge_storage.py
@@ -39,6 +39,7 @@ def users_service():
         "database.screen_activity": AutoMockModule("database.screen_activity"),
         "database.vector_db": AutoMockModule("database.vector_db"),
         "utils": _pkg("utils"),
+        "utils.cloud_tasks": AutoMockModule("utils.cloud_tasks"),
         "utils.stripe": AutoMockModule("utils.stripe"),
         "utils.executors": AutoMockModule("utils.executors"),
         "utils.log_sanitizer": AutoMockModule("utils.log_sanitizer"),
@@ -140,7 +141,7 @@ def test_pinecone_failure_does_not_block_recordings_or_firestore_wipe(users_serv
     m["delete_user_data"].assert_not_called()
 
 
-def test_gcs_failure_does_not_block_firestore_wipe(users_service):
+def test_gcs_failure_blocks_firestore_wipe(users_service):
     patchers, m = _purge_patches(
         users_service, delete_all_conversation_recordings={"side_effect": Exception("gcs down")}
     )
@@ -149,7 +150,7 @@ def test_gcs_failure_does_not_block_firestore_wipe(users_service):
     finally:
         _stop(patchers)
     m["delete_all_conversation_recordings"].assert_called_once_with("uid1")  # purge was wired + attempted
-    m["delete_user_data"].assert_called_once_with("uid1")  # and the failure didn't block the wipe
+    m["delete_user_data"].assert_not_called()
 
 
 def test_enumeration_failure_is_isolated(users_service):

--- a/backend/tests/unit/test_delete_account_stripe_cancel.py
+++ b/backend/tests/unit/test_delete_account_stripe_cancel.py
@@ -40,6 +40,7 @@ def users_service():
         "database.screen_activity": AutoMockModule("database.screen_activity"),
         "database.vector_db": AutoMockModule("database.vector_db"),
         "utils": _pkg("utils"),
+        "utils.cloud_tasks": AutoMockModule("utils.cloud_tasks"),
         "utils.stripe": AutoMockModule("utils.stripe"),
         "utils.executors": AutoMockModule("utils.executors"),
         "utils.log_sanitizer": AutoMockModule("utils.log_sanitizer"),

--- a/backend/tests/unit/test_delete_account_stripe_cancel.py
+++ b/backend/tests/unit/test_delete_account_stripe_cancel.py
@@ -2,7 +2,8 @@
 
 Before the fix, DELETE /v1/users/delete-account revoked Firebase auth and wiped Firestore but never
 canceled the user's Stripe subscription, so a paying user kept getting billed with no way to log back
-in and cancel. The handler now cancels the subscription (best-effort) before the wipe.
+in and cancel. The handler now cancels the subscription before Firebase auth deletion and blocks the
+deletion if billing cancellation cannot be confirmed.
 
 ``services.users.account_deletion`` binds its collaborators at import (``from database import users as
 users_db``, ``from utils import stripe as stripe_utils``, …) and those packages pull heavy chains with
@@ -94,13 +95,16 @@ def test_free_user_does_not_call_stripe(users_service):
     assert resp['status'] == 'ok'
 
 
-def test_stripe_error_does_not_block_deletion(users_service):
+def test_stripe_error_blocks_deletion_before_auth(users_service):
     with patch.object(users_service.users_db, 'get_user_subscription', return_value=_sub('sub_123')), patch.object(
         users_service.stripe_utils, 'cancel_subscription', side_effect=Exception('stripe down')
-    ), patch.object(users_service.auth, 'delete_account') as fb_delete, patch.object(
+    ), patch.object(users_service.users_db, 'mark_user_deletion_billing_failed') as mark_billing_failed, patch.object(
+        users_service.auth, 'delete_account'
+    ) as fb_delete, patch.object(
         users_service, 'submit_with_context'
     ) as submit:
-        resp = users_service.start_account_deletion(uid='uid1')
-    fb_delete.assert_called_once()  # best-effort: Stripe failure must not abort deletion
-    submit.assert_called_once_with(users_service.cleanup_executor, users_service.background_wipe_user_data, 'uid1')
-    assert resp['status'] == 'ok'
+        with pytest.raises(Exception, match='stripe down'):
+            users_service.start_account_deletion(uid='uid1')
+    mark_billing_failed.assert_called_once_with('uid1', 'sub_123', 'stripe down')
+    fb_delete.assert_not_called()
+    submit.assert_not_called()

--- a/backend/tests/unit/test_sync_cloud_tasks.py
+++ b/backend/tests/unit/test_sync_cloud_tasks.py
@@ -10,6 +10,7 @@ handler in routers/sync.py.
 import os
 import sys
 import unittest
+import hashlib
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -238,6 +239,35 @@ class TestVerifyCloudTasksOidc:
             with pytest.raises(RuntimeError):
                 cloud_tasks.enqueue_sync_job({'job_id': 'j'})
 
+    def test_enqueue_account_deletion_task_is_named_by_uid(self):
+        cloud_tasks = _load_cloud_tasks()
+        env = {
+            'SYNC_TASKS_PROJECT': 'proj',
+            'SYNC_TASKS_LOCATION': 'us-central1',
+            'ACCOUNT_DELETION_TASKS_QUEUE': 'account-delete',
+            'ACCOUNT_DELETION_HANDLER_URL': 'https://backend-sync.example.com/v1/users/account-deletion-wipes/run',
+            'SYNC_TASKS_INVOKER_SA': 'invoker@proj.iam.gserviceaccount.com',
+        }
+        uid_hash = hashlib.sha256(b'uid1').hexdigest()[:32]
+        task_id = f'account-delete-{uid_hash}-abc123'
+        with patch.dict(os.environ, env):
+            client = MagicMock()
+            client.task_path.return_value = f'projects/proj/locations/us-central1/queues/account-delete/tasks/{task_id}'
+            with patch.object(cloud_tasks, '_get_tasks_client', return_value=client), patch.object(
+                cloud_tasks.uuid, 'uuid4', return_value=MagicMock(hex='abc123')
+            ):
+                cloud_tasks.enqueue_account_deletion_wipe('uid1')
+        client.task_path.assert_called_once_with('proj', 'us-central1', 'account-delete', task_id)
+        client.create_task.assert_called_once()
+
+    def test_account_deletion_dispatch_flag_default_inline(self):
+        cloud_tasks = _load_cloud_tasks()
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop('ACCOUNT_DELETION_DISPATCH_MODE', None)
+            assert cloud_tasks.is_account_deletion_dispatch_enabled() is False
+        with patch.dict(os.environ, {'ACCOUNT_DELETION_DISPATCH_MODE': 'cloud_tasks'}):
+            assert cloud_tasks.is_account_deletion_dispatch_enabled() is True
+
 
 # ---------------------------------------------------------------------------
 # Structural contract of routers/sync.py and main.py wiring
@@ -276,8 +306,18 @@ class TestSyncRouterStructure:
         main_src = self._read('main.py')
         assert 'paths_timeout' in main_src
         assert 'HTTP_SYNC_JOBS_RUN_TIMEOUT' in main_src
+        assert 'HTTP_ACCOUNT_DELETION_WIPE_RUN_TIMEOUT' in main_src
         timeout_src = self._read(os.path.join('utils', 'other', 'timeout.py'))
         assert 'paths_timeout' in timeout_src
+
+    def test_account_deletion_handler_exists_with_oidc(self):
+        source = self._read(os.path.join('routers', 'users.py'))
+        assert "'/v1/users/account-deletion-wipes/run'" in source
+        handler = source[source.index('async def run_account_deletion_wipe') :]
+        assert 'Depends(verify_cloud_tasks_oidc)' in handler[:200]
+        assert 'try_acquire_job_run_lock' in handler
+        assert 'claim_deletion_wipe_for_task' in handler
+        assert 'status_code=500' in handler
 
     def test_v1_endpoint_unchanged(self):
         source = self._read(os.path.join('routers', 'sync.py'))

--- a/backend/tests/unit/test_twilio_account_deletion.py
+++ b/backend/tests/unit/test_twilio_account_deletion.py
@@ -30,7 +30,7 @@ def test_delete_user_caller_ids_calls_twilio_for_each_sid():
         {'id': 'a', 'twilio_sid': 'PNaaaa'},
         {'id': 'b', 'twilio_sid': 'PNbbbb'},
     ]
-    with patch.object(twilio_service, 'delete_caller_id', return_value=True) as mock_delete, patch.object(
+    with patch.object(twilio_service, '_delete_caller_id_status', return_value='deleted') as mock_delete, patch.object(
         phone_calls_db, 'get_phone_numbers', return_value=numbers
     ):
         deleted = twilio_service.delete_user_caller_ids('uid-1')
@@ -47,7 +47,7 @@ def test_delete_user_caller_ids_skips_entries_without_sid():
         {'id': 'c', 'twilio_sid': None},
         {'id': 'd', 'twilio_sid': ''},
     ]
-    with patch.object(twilio_service, 'delete_caller_id', return_value=True) as mock_delete, patch.object(
+    with patch.object(twilio_service, '_delete_caller_id_status', return_value='deleted') as mock_delete, patch.object(
         phone_calls_db, 'get_phone_numbers', return_value=numbers
     ):
         deleted = twilio_service.delete_user_caller_ids('uid-1')
@@ -70,10 +70,10 @@ def test_delete_user_caller_ids_continues_when_one_raises():
 
     def fake_delete(sid):
         if sid == 'PNbbbb':
-            raise RuntimeError('twilio client unavailable')
-        return True
+            return 'failed'
+        return 'deleted'
 
-    with patch.object(twilio_service, 'delete_caller_id', side_effect=fake_delete) as mock_delete, patch.object(
+    with patch.object(twilio_service, '_delete_caller_id_status', side_effect=fake_delete) as mock_delete, patch.object(
         phone_calls_db, 'get_phone_numbers', return_value=numbers
     ):
         deleted = twilio_service.delete_user_caller_ids('uid-1')
@@ -82,7 +82,7 @@ def test_delete_user_caller_ids_continues_when_one_raises():
 
 
 def test_delete_user_caller_ids_returns_zero_when_no_phone_numbers():
-    with patch.object(twilio_service, 'delete_caller_id', return_value=True) as mock_delete, patch.object(
+    with patch.object(twilio_service, '_delete_caller_id_status', return_value='deleted') as mock_delete, patch.object(
         phone_calls_db, 'get_phone_numbers', return_value=[]
     ):
         deleted = twilio_service.delete_user_caller_ids('uid-1')
@@ -94,7 +94,7 @@ def test_delete_user_caller_ids_swallows_phone_list_error():
     # If we can't even list the user's phone_numbers, we still must not raise —
     # the caller (delete_account background wipe) needs to keep going so the
     # Firestore wipe completes.
-    with patch.object(twilio_service, 'delete_caller_id', return_value=True) as mock_delete, patch.object(
+    with patch.object(twilio_service, '_delete_caller_id_status', return_value='deleted') as mock_delete, patch.object(
         phone_calls_db, 'get_phone_numbers', side_effect=RuntimeError('firestore down')
     ):
         deleted = twilio_service.delete_user_caller_ids('uid-1')
@@ -104,7 +104,7 @@ def test_delete_user_caller_ids_swallows_phone_list_error():
 
 def test_delete_user_caller_ids_strict_raises_on_delete_failure():
     numbers = [{'id': 'a', 'twilio_sid': 'PNaaaa'}]
-    with patch.object(twilio_service, 'delete_caller_id', return_value=False), patch.object(
+    with patch.object(twilio_service, '_delete_caller_id_status', return_value='failed'), patch.object(
         phone_calls_db, 'get_phone_numbers', return_value=numbers
     ):
         try:
@@ -113,6 +113,14 @@ def test_delete_user_caller_ids_strict_raises_on_delete_failure():
             assert 'caller id' in str(exc)
         else:
             raise AssertionError('expected strict caller-id deletion to raise')
+
+
+def test_delete_user_caller_ids_strict_treats_already_deleted_as_success():
+    numbers = [{'id': 'a', 'twilio_sid': 'PNaaaa'}]
+    with patch.object(twilio_service, '_delete_caller_id_status', return_value='already_deleted'), patch.object(
+        phone_calls_db, 'get_phone_numbers', return_value=numbers
+    ):
+        assert twilio_service.delete_user_caller_ids_strict('uid-1') == 1
 
 
 def test_delete_user_caller_ids_strict_raises_on_phone_list_error():

--- a/backend/tests/unit/test_twilio_account_deletion.py
+++ b/backend/tests/unit/test_twilio_account_deletion.py
@@ -102,6 +102,14 @@ def test_delete_user_caller_ids_swallows_phone_list_error():
     assert mock_delete.call_count == 0
 
 
+def test_delete_user_caller_ids_swallows_client_init_error():
+    numbers = [{'id': 'a', 'twilio_sid': 'PNaaaa'}]
+    with patch.object(twilio_service, '_get_client', side_effect=ValueError('twilio env missing')), patch.object(
+        phone_calls_db, 'get_phone_numbers', return_value=numbers
+    ):
+        assert twilio_service.delete_user_caller_ids('uid-1') == 0
+
+
 def test_delete_user_caller_ids_strict_raises_on_delete_failure():
     numbers = [{'id': 'a', 'twilio_sid': 'PNaaaa'}]
     with patch.object(twilio_service, '_delete_caller_id_status', return_value='failed'), patch.object(

--- a/backend/tests/unit/test_twilio_account_deletion.py
+++ b/backend/tests/unit/test_twilio_account_deletion.py
@@ -100,3 +100,26 @@ def test_delete_user_caller_ids_swallows_phone_list_error():
         deleted = twilio_service.delete_user_caller_ids('uid-1')
     assert deleted == 0
     assert mock_delete.call_count == 0
+
+
+def test_delete_user_caller_ids_strict_raises_on_delete_failure():
+    numbers = [{'id': 'a', 'twilio_sid': 'PNaaaa'}]
+    with patch.object(twilio_service, 'delete_caller_id', return_value=False), patch.object(
+        phone_calls_db, 'get_phone_numbers', return_value=numbers
+    ):
+        try:
+            twilio_service.delete_user_caller_ids_strict('uid-1')
+        except RuntimeError as exc:
+            assert 'caller id' in str(exc)
+        else:
+            raise AssertionError('expected strict caller-id deletion to raise')
+
+
+def test_delete_user_caller_ids_strict_raises_on_phone_list_error():
+    with patch.object(phone_calls_db, 'get_phone_numbers', side_effect=RuntimeError('firestore down')):
+        try:
+            twilio_service.delete_user_caller_ids_strict('uid-1')
+        except RuntimeError as exc:
+            assert str(exc) == 'firestore down'
+        else:
+            raise AssertionError('expected strict caller-id list failure to raise')

--- a/backend/tests/unit/test_ws_j_delete_privacy.py
+++ b/backend/tests/unit/test_ws_j_delete_privacy.py
@@ -333,6 +333,32 @@ def test_canonical_account_delete_purge_emits_neutral_vector_outbox(monkeypatch,
     assert purge_record["vector_id"] == expected_vector_id
 
 
+def test_canonical_account_delete_purge_raises_on_partial_vector_delete(monkeypatch, canonical_db):
+    uid = "uid-canonical-ws-j"
+    conversation_id = "conv-acct-partial"
+    content = "Canonical fact for partial account delete"
+    payload = _sample_memory_payload(uid=uid, conversation_id=conversation_id, content=content)
+
+    monkeypatch.setattr(
+        "utils.memory.canonical_memory_adapter.read_memory_v3_trusted_account_generation",
+        lambda **_: _trusted_account_generation(),
+    )
+    monkeypatch.setattr(
+        "utils.memory.canonical_memory_adapter.resolve_memory_system",
+        lambda uid, **_: MemorySystem.CANONICAL,
+    )
+    monkeypatch.setattr(
+        "database.vector_db.delete_pinecone_memory_vectors_by_id",
+        lambda vector_ids: 0,
+        raising=False,
+    )
+
+    write_canonical_extraction_memory(uid, payload, db_client=canonical_db)
+
+    with pytest.raises(RuntimeError, match="canonical vector purge only deleted 0/1 vectors"):
+        purge_canonical_derived_user_data(uid, db_client=canonical_db)
+
+
 def test_legacy_account_delete_purge_skips_canonical_path(monkeypatch):
     db = _legacy_db_with_control()
     assert resolve_memory_system(LEGACY_UID, db_client=db) == MemorySystem.LEGACY

--- a/backend/tests/unit/test_ws_m_atom_keyword_index.py
+++ b/backend/tests/unit/test_ws_m_atom_keyword_index.py
@@ -83,6 +83,7 @@ from utils.memory.atom_keyword_index import (
     keyword_search_memory_ids,
     memories_collection_name,
     merge_memory_search_ids,
+    purge_user_atom_keyword_index,
     rebuild_atom_keyword_index,
     sync_atom_keyword_index_for_item,
     upsert_atom_keyword_doc,
@@ -408,6 +409,15 @@ class TestKeywordSearchAndHybrid:
 
 
 class TestPurgeAndRebuild:
+    def test_strict_keyword_purge_raises_on_typesense_failure(self, monkeypatch):
+        monkeypatch.setattr(
+            "utils.memory.atom_keyword_index._typesense_client",
+            MagicMock(side_effect=RuntimeError("typesense down")),
+        )
+
+        with pytest.raises(RuntimeError, match="typesense down"):
+            purge_user_atom_keyword_index(CANONICAL_UID, force=True, raise_on_failure=True)
+
     def test_account_delete_purges_keyword_index(self, mock_typesense, monkeypatch):
         collections, docs_store = mock_typesense
         item = _long_term_item()

--- a/backend/utils/cloud_tasks.py
+++ b/backend/utils/cloud_tasks.py
@@ -13,6 +13,8 @@ accept task traffic.
 import json
 import logging
 import os
+import hashlib
+import uuid
 from typing import Optional
 
 from fastapi import HTTPException, Request
@@ -71,6 +73,14 @@ def is_audio_merge_dispatch_enabled() -> bool:
     return os.getenv('AUDIO_MERGE_DISPATCH_MODE', 'inline') == 'cloud_tasks'
 
 
+def is_account_deletion_dispatch_enabled() -> bool:
+    return os.getenv('ACCOUNT_DELETION_DISPATCH_MODE', 'inline') == 'cloud_tasks'
+
+
+def get_account_deletion_tasks_max_attempts() -> int:
+    return int(os.getenv('ACCOUNT_DELETION_TASKS_MAX_ATTEMPTS', get_sync_tasks_max_attempts()))
+
+
 def _enqueue_named_task(queue: str, url: str, task_id: str, payload: dict) -> None:
     """Enqueue one named HTTP task. Duplicate names are treated as success —
     Cloud Tasks deduplicates named tasks. Any other failure raises."""
@@ -121,6 +131,18 @@ def enqueue_audio_merge_job(payload: dict) -> None:
         os.getenv('AUDIO_MERGE_HANDLER_URL', ''),
         task_id,
         payload,
+    )
+
+
+def enqueue_account_deletion_wipe(uid: str) -> None:
+    """Enqueue one durable account-deletion wipe task for a Firebase uid."""
+    uid_hash = hashlib.sha256(uid.encode('utf-8')).hexdigest()[:32]
+    task_id = f"account-delete-{uid_hash}-{uuid.uuid4().hex}"
+    _enqueue_named_task(
+        os.getenv('ACCOUNT_DELETION_TASKS_QUEUE', ''),
+        os.getenv('ACCOUNT_DELETION_HANDLER_URL', ''),
+        task_id,
+        {'uid': uid},
     )
 
 

--- a/backend/utils/memory/atom_keyword_index.py
+++ b/backend/utils/memory/atom_keyword_index.py
@@ -201,7 +201,9 @@ def delete_atom_keyword_doc(uid: str, memory_id: str, *, db_client=None) -> None
         logger.warning("delete_atom_keyword_doc failed uid=%s memory_id=%s: %s", uid, memory_id, exc)
 
 
-def purge_user_atom_keyword_index(uid: str, *, db_client=None, force: bool = False) -> int:
+def purge_user_atom_keyword_index(
+    uid: str, *, db_client=None, force: bool = False, raise_on_failure: bool = False
+) -> int:
     """Delete all keyword docs for a canonical user. Returns deleted count when available."""
     if not force and not user_allows_atom_keyword_index(uid, db_client=db_client):
         return 0
@@ -214,6 +216,8 @@ def purge_user_atom_keyword_index(uid: str, *, db_client=None, force: bool = Fal
         return int(result.get("num_deleted") or 0)
     except Exception as exc:
         logger.warning("purge_user_atom_keyword_index failed uid=%s: %s", uid, exc)
+        if raise_on_failure:
+            raise
         return 0
 
 

--- a/backend/utils/memory/canonical_memory_adapter.py
+++ b/backend/utils/memory/canonical_memory_adapter.py
@@ -834,9 +834,11 @@ def purge_canonical_derived_user_data(uid: str, *, db_client=None) -> Dict[str, 
     if vector_ids:
         from database.vector_db import delete_pinecone_memory_vectors_by_id
 
-        delete_pinecone_memory_vectors_by_id(vector_ids)
+        vector_deleted = delete_pinecone_memory_vectors_by_id(vector_ids)
+        if vector_deleted < len(vector_ids):
+            raise RuntimeError(f"canonical vector purge only deleted {vector_deleted}/{len(vector_ids)} vectors")
 
-    keyword_deleted = purge_user_atom_keyword_index(uid, db_client=client, force=True)
+    keyword_deleted = purge_user_atom_keyword_index(uid, db_client=client, force=True, raise_on_failure=True)
     kg_db.delete_knowledge_graph(uid, db_client=client)
 
     trusted = read_memory_v3_trusted_account_generation(uid=uid, db_client=client)

--- a/backend/utils/twilio_service.py
+++ b/backend/utils/twilio_service.py
@@ -3,7 +3,16 @@ import os
 from typing import Optional
 
 from twilio.rest import Client
-from twilio.base.exceptions import TwilioRestException
+
+try:
+    from twilio.base.exceptions import TwilioRestException
+except ImportError:
+
+    class TwilioRestException(Exception):
+        status = None
+        code = None
+
+
 from twilio.jwt.access_token import AccessToken
 from twilio.jwt.access_token.grants import VoiceGrant
 from twilio.request_validator import RequestValidator

--- a/backend/utils/twilio_service.py
+++ b/backend/utils/twilio_service.py
@@ -3,6 +3,7 @@ import os
 from typing import Optional
 
 from twilio.rest import Client
+from twilio.base.exceptions import TwilioRestException
 from twilio.jwt.access_token import AccessToken
 from twilio.jwt.access_token.grants import VoiceGrant
 from twilio.request_validator import RequestValidator
@@ -18,6 +19,7 @@ api_key_secret = os.getenv('TWILIO_API_KEY_SECRET')
 twiml_app_sid = os.getenv('TWILIO_TWIML_APP_SID')
 
 _client = None
+_TWILIO_NOT_FOUND_CODES = {20404}
 
 
 def _get_client() -> Client:
@@ -127,6 +129,21 @@ def get_caller_id(phone_number: str) -> Optional[dict]:
     }
 
 
+def _delete_caller_id_status(sid: str) -> str:
+    client = _get_client()
+    try:
+        client.outgoing_caller_ids(sid).delete()
+        return 'deleted'
+    except TwilioRestException as e:
+        if e.status == 404 or e.code in _TWILIO_NOT_FOUND_CODES:
+            return 'already_deleted'
+        logger.warning(f'delete_caller_id: twilio error sid={sid} status={e.status} code={e.code}')
+        return 'failed'
+    except Exception as e:
+        logger.warning(f'delete_caller_id: unexpected error sid={sid}: {e}')
+        return 'failed'
+
+
 def delete_caller_id(sid: str) -> bool:
     """
     Delete a verified caller ID.
@@ -137,45 +154,39 @@ def delete_caller_id(sid: str) -> bool:
     Returns:
         True if deleted successfully
     """
-    client = _get_client()
-    try:
-        client.outgoing_caller_ids(sid).delete()
-        return True
-    except Exception:
-        return False
+    return _delete_caller_id_status(sid) in ('deleted', 'already_deleted')
 
 
-def delete_user_caller_ids(uid: str) -> int:
-    # Delete every verified Twilio caller ID owned by `uid`.
-    #
-    # Returns the number of caller IDs successfully deleted. Best-effort by
-    # design — Twilio API errors are absorbed by delete_caller_id() itself
-    # (returns False), and the only way an exception reaches the outer guard
-    # is if _get_client() raises (e.g. missing TWILIO_* env vars). Both paths
-    # are logged but never propagate, so callers (account-deletion background
-    # wipe) can safely run this before a Firestore wipe without risking a
-    # half-deleted user if Twilio is misconfigured or momentarily down.
+def _delete_user_caller_ids(uid: str, *, strict: bool) -> int:
     try:
         numbers = phone_calls_db.get_phone_numbers(uid)
     except Exception as e:
         logger.error(f'delete_user_caller_ids: list phone_numbers failed: {e}')
+        if strict:
+            raise
         return 0
 
-    deleted = 0
+    cleaned = 0
+    failures = []
     for number in numbers:
         sid = number.get('twilio_sid')
         if not sid:
             continue
-        try:
-            if delete_caller_id(sid):
-                deleted += 1
-            else:
-                logger.warning(f'delete_user_caller_ids: twilio reported failure for sid={sid}')
-        except Exception as e:
-            # Reachable only if _get_client() itself raises before delete_caller_id's
-            # internal try/except — Twilio API errors are already swallowed there.
-            logger.error(f'delete_user_caller_ids: twilio client unavailable for sid={sid}: {e}')
-    return deleted
+        status = _delete_caller_id_status(sid)
+        if status in ('deleted', 'already_deleted'):
+            cleaned += 1
+            continue
+        failures.append(sid)
+        logger.warning(f'delete_user_caller_ids: twilio delete failed for sid={sid}')
+
+    if failures and strict:
+        raise RuntimeError(f'twilio caller-id delete failed for {len(failures)} caller id(s)')
+    return cleaned
+
+
+def delete_user_caller_ids(uid: str) -> int:
+    # Best-effort caller-ID cleanup for non-compliance paths.
+    return _delete_user_caller_ids(uid, strict=False)
 
 
 def delete_user_caller_ids_strict(uid: str) -> int:
@@ -186,30 +197,7 @@ def delete_user_caller_ids_strict(uid: str) -> int:
     keep Firestore metadata until Twilio cleanup has either succeeded or can be
     retried with the phone-number documents still present.
     """
-    try:
-        numbers = phone_calls_db.get_phone_numbers(uid)
-    except Exception as e:
-        logger.error(f'delete_user_caller_ids_strict: list phone_numbers failed: {e}')
-        raise
-
-    deleted = 0
-    failures = []
-    for number in numbers:
-        sid = number.get('twilio_sid')
-        if not sid:
-            continue
-        try:
-            if delete_caller_id(sid):
-                deleted += 1
-            else:
-                failures.append(sid)
-                logger.warning(f'delete_user_caller_ids_strict: twilio reported failure for sid={sid}')
-        except Exception as e:
-            failures.append(sid)
-            logger.error(f'delete_user_caller_ids_strict: twilio client unavailable for sid={sid}: {e}')
-    if failures:
-        raise RuntimeError(f'twilio caller-id delete failed for {len(failures)} caller id(s)')
-    return deleted
+    return _delete_user_caller_ids(uid, strict=True)
 
 
 def list_caller_ids() -> list:

--- a/backend/utils/twilio_service.py
+++ b/backend/utils/twilio_service.py
@@ -130,8 +130,8 @@ def get_caller_id(phone_number: str) -> Optional[dict]:
 
 
 def _delete_caller_id_status(sid: str) -> str:
-    client = _get_client()
     try:
+        client = _get_client()
         client.outgoing_caller_ids(sid).delete()
         return 'deleted'
     except TwilioRestException as e:

--- a/backend/utils/twilio_service.py
+++ b/backend/utils/twilio_service.py
@@ -178,6 +178,40 @@ def delete_user_caller_ids(uid: str) -> int:
     return deleted
 
 
+def delete_user_caller_ids_strict(uid: str) -> int:
+    """Delete every verified Twilio caller ID owned by ``uid``.
+
+    Unlike ``delete_user_caller_ids``, this account-deletion variant raises if
+    listing or deleting any caller ID fails. The account deletion worker must
+    keep Firestore metadata until Twilio cleanup has either succeeded or can be
+    retried with the phone-number documents still present.
+    """
+    try:
+        numbers = phone_calls_db.get_phone_numbers(uid)
+    except Exception as e:
+        logger.error(f'delete_user_caller_ids_strict: list phone_numbers failed: {e}')
+        raise
+
+    deleted = 0
+    failures = []
+    for number in numbers:
+        sid = number.get('twilio_sid')
+        if not sid:
+            continue
+        try:
+            if delete_caller_id(sid):
+                deleted += 1
+            else:
+                failures.append(sid)
+                logger.warning(f'delete_user_caller_ids_strict: twilio reported failure for sid={sid}')
+        except Exception as e:
+            failures.append(sid)
+            logger.error(f'delete_user_caller_ids_strict: twilio client unavailable for sid={sid}: {e}')
+    if failures:
+        raise RuntimeError(f'twilio caller-id delete failed for {len(failures)} caller id(s)')
+    return deleted
+
+
 def list_caller_ids() -> list:
     """
     List all verified outgoing caller IDs for the account.


### PR DESCRIPTION
## Summary

Fixes #8405.

- Moves account-deletion wipes onto durable Cloud Tasks dispatch when `ACCOUNT_DELETION_DISPATCH_MODE=cloud_tasks`, with API success returned only after the deletion marker is persisted and the wipe task enqueue succeeds.
- Adds an OIDC-protected account deletion wipe task handler with Redis run-locking, Firestore job-claim gating, cancellation-safe lock handling, and retry/final-attempt responses for Cloud Tasks.
- Tightens cleanup semantics so required Twilio, vector, recording-storage, and Firestore cleanup failures remain retryable instead of being hidden by a completed wipe.
- Updates account-deletion observability/reconciliation docs and tests.

## Validation

- `PYTHON=.venv/bin/python bash test-preflight.sh` passed with optional integration warnings only.
- `python -m pytest tests/services/users/test_account_deletion.py tests/routers/test_users.py tests/unit/test_sync_cloud_tasks.py tests/unit/test_delete_account_stripe_cancel.py tests/unit/test_delete_account_purge_storage.py tests/unit/test_twilio_account_deletion.py tests/unit/test_claim_deletion_wipe_txn.py -q` -> 91 passed.
- `python scripts/scan_import_time_side_effects.py` -> 0 violations.
- `python scripts/scan_async_blockers.py` -> 0 selected blocking findings.
- `python scripts/check_module_stub_pollution.py` -> 0 violations.
- `python scripts/validate-backend-runtime-env.py --env dev --check-workflows` passed.
- `python scripts/validate-backend-runtime-env.py --env prod --check-workflows` passed.
- Oracle review #3: no P0/P1 findings.

## Notes

- `scripts/check_response_model_coverage.py` still fails on unrelated pre-existing untyped routes in `staged_tasks.py`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9117?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

