### PR TITLE
fix(desktop): recover recordings from local segments when finalization errors out (#9083)

### DIFF
--- a/desktop/macos/Desktop/Sources/ConversationFinalizationService.swift
+++ b/desktop/macos/Desktop/Sources/ConversationFinalizationService.swift
@@ -395,6 +395,17 @@ actor ConversationFinalizationService {
       let session = try await TranscriptionStorage.shared.getSession(id: sessionId)
       let retryCount = (session?.retryCount ?? 0) + 1
       if retryCount >= maxRetries {
+        // Retries are exhausted. The in-line reconciliation fallback (resolveExhaustedCloudReconciliation)
+        // only runs when the final attempt returns cleanly with no match; when it fails by *throwing*
+        // (backend/network error), we land here instead and would abandon the session, dropping any
+        // recorded audio/transcript we still hold locally (#9083). Try to finalize from saved local
+        // segments first so the recording is not lost.
+        if let session,
+           let recovered = try? await resolveExhaustedCloudReconciliation(session: session, sessionId: sessionId),
+           recovered {
+          log("ConversationFinalization: Recovered exhausted session \(sessionId) from local data after finalize error")
+          return
+        }
         let segmentCount = try? await TranscriptionStorage.shared.getSegmentCount(sessionId: sessionId)
         await AnalyticsManager.shared.conversationReconciliationFailed(
           error: "session_reconciliation_failed",

--- a/desktop/macos/changelog/unreleased/20260705-recover-recordings-on-finalize-error.json
+++ b/desktop/macos/changelog/unreleased/20260705-recover-recordings-on-finalize-error.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed recordings being lost when conversation finalization repeatedly failed with a network/backend error — the app now recovers the conversation from saved local transcript segments instead of dropping it"
+}


### PR DESCRIPTION
## Bug
macOS conversation finalization intermittently loses recordings: audio was captured / a live transcript existed, but no conversation is created. Telemetry signature `session_reconciliation_failed` / `"Session N could not be reconciled after 5 attempts"` — 146 events / 39 users on `0.12.0` (last seen 2026-07-05). (#9083)

## Root cause
In `ConversationFinalizationService`, the local-segments fallback (`resolveExhaustedCloudReconciliation`) is only reached inside `finalizeCloudSession` on the **non-throwing** path — when the final reconcile attempt returns cleanly with no backend match (`ConversationFinalizationService.swift:263`).

When the final attempt instead **throws** (backend/network error — exactly what produces the repeated "could not be reconciled" failures), control unwinds to `finalizeSession`'s `catch` → `markRetryableFailure`, which emits `session_reconciliation_failed` and marks the session failed. The saved local transcript segments are **never uploaded**, so the recording is abandoned even though we still hold the data locally.

## Fix
`markRetryableFailure` now, at retry exhaustion, routes through the same already-tested `resolveExhaustedCloudReconciliation` helper before giving up. If saved local segments exist they are uploaded and the conversation is finalized (`.uploadLocalSegments`); empty desktop sessions are discarded as before; anything it can't resolve falls through to the existing analytics + failed-marking. Uses `try?` so a fallback error can't regress the previous behavior.

- Reuses existing, tested exhaustion logic (`cloudReconciliationExhaustionAction` / `resolveExhaustedCloudReconciliation`) — no new reconciliation branch.
- Scoped to the exhaustion moment (`retryCount >= maxRetries`); the internal guard `retryCount >= maxRetries - 1` prevents premature action.

## Test / verification
`xcrun swift build -c debug` passes. The recovery decision paths are already covered by `TranscriptionFinalizationStateMachineTests`. The error-path → recovery-upload branch requires a live backend failure + a real recording to reproduce, so it is **not** runtime-verified here.

🤖 automated by hourly watchdog; opened for review, not merged.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9120?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

