### PR TITLE
fix(desktop/tasks): keep reorder sortOrder inside category bands and scope drag-end reset

### DIFF
--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/TasksPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/TasksPage.swift
@@ -877,17 +877,29 @@ class TasksViewModel: ObservableObject {
     /// base. Here the spacing is derived from the item count as
     /// `bandWidth / (count + 1)`, capped at the historical 1000 so small
     /// categories keep the familiar sparse spacing (room for future in-place
-    /// inserts). Because the largest value is
-    /// `count * spacing <= count/(count+1) * bandWidth < bandWidth`, the last
-    /// item never reaches the next band's base for any realistic category size
-    /// (up to ~99,999 items, past which the integer spacing floors to 1 — far
-    /// beyond any real task list). Both reorder sites (`moveTask`,
+    /// inserts). While `count < bandWidth` the integer spacing is >= 1 and the
+    /// largest value is `count * spacing <= count/(count+1) * bandWidth < bandWidth`,
+    /// so the last item never reaches the next band's base — true for any realistic
+    /// category size (values are byte-identical to the old scheme for count <= 99).
+    /// Only when `count >= bandWidth` (~100k+ items in one section, not reachable
+    /// in practice) does the integer spacing floor to 0; that degenerate case is
+    /// handled separately by distributing items evenly so the result still stays
+    /// strictly inside the band. Both reorder sites (`moveTask`,
     /// `collectSortOrderUpdates`) call this single helper so their optimistic and
     /// persisted orders agree.
     nonisolated static func sortOrder(categoryIndex: Int, itemIndex: Int, itemCount: Int) -> Int {
         let band = sortOrderBandWidth
-        let spacing = max(1, min(1000, band / (itemCount + 1)))
-        return categoryIndex * band + (itemIndex + 1) * spacing
+        let base = categoryIndex * band
+        let rawSpacing = band / (itemCount + 1)
+        guard rawSpacing >= 1 else {
+            // Degenerate: itemCount >= bandWidth leaves no integer room for unique
+            // spacing. Spread items evenly across [base, base+band) so the result
+            // never leaves the band; ordering is preserved even if exact spacing
+            // is not. Unreachable for any real task section.
+            return base + min(band - 1, (itemIndex * (band - 1)) / max(1, itemCount - 1))
+        }
+        let spacing = min(1000, rawSpacing)
+        return base + (itemIndex + 1) * spacing
     }
 
     /// Move a task within a category

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/TasksPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/TasksPage.swift
@@ -861,6 +861,35 @@ class TasksViewModel: ObservableObject {
         }
     }
 
+    /// Width of each category's numeric sortOrder band. Category N owns the
+    /// half-open range `[N*bandWidth, (N+1)*bandWidth)`. Kept at 100_000 so
+    /// orders already persisted under the previous fixed scheme keep the same
+    /// band assignment.
+    nonisolated static let sortOrderBandWidth = 100_000
+
+    /// Compute a task's sortOrder so every item in a category stays strictly
+    /// inside that category's band — even when the category holds enough items
+    /// that the previous fixed 1000-spacing would overflow into the next
+    /// category's band and corrupt cross-category ordering (BL-016).
+    ///
+    /// The old scheme (`categoryIndex*100_000 + (itemIndex+1)*1000`) had a hard
+    /// ceiling of ~100 items per category: item 100 landed on the next band's
+    /// base. Here the spacing is derived from the item count as
+    /// `bandWidth / (count + 1)`, capped at the historical 1000 so small
+    /// categories keep the familiar sparse spacing (room for future in-place
+    /// inserts). Because the largest value is
+    /// `count * spacing <= count/(count+1) * bandWidth < bandWidth`, the last
+    /// item never reaches the next band's base for any realistic category size
+    /// (up to ~99,999 items, past which the integer spacing floors to 1 — far
+    /// beyond any real task list). Both reorder sites (`moveTask`,
+    /// `collectSortOrderUpdates`) call this single helper so their optimistic and
+    /// persisted orders agree.
+    nonisolated static func sortOrder(categoryIndex: Int, itemIndex: Int, itemCount: Int) -> Int {
+        let band = sortOrderBandWidth
+        let spacing = max(1, min(1000, band / (itemCount + 1)))
+        return categoryIndex * band + (itemIndex + 1) * spacing
+    }
+
     /// Move a task within a category
     func moveTask(_ task: TaskActionItem, toIndex targetIndex: Int, inCategory category: TaskCategory) {
         log("REORDER: moveTask(\(task.id), toIndex: \(targetIndex), inCategory: \(category.rawValue))")
@@ -881,11 +910,12 @@ class TasksViewModel: ObservableObject {
         // write to only one of them misses when filters/search are active. Each
         // reassignment fires its own @Published; recomputeAllCaches at the end folds
         // them all into categorizedTasks.
-        let categoryOffset = (TaskCategory.allCases.firstIndex(of: category) ?? 0) * 100_000
+        let categoryIndex = TaskCategory.allCases.firstIndex(of: category) ?? 0
+        let itemCount = order.count
 
         func applyOrder(to array: inout [TaskActionItem]) {
             for (index, taskId) in order.enumerated() {
-                let newSortOrder = categoryOffset + (index + 1) * 1000
+                let newSortOrder = Self.sortOrder(categoryIndex: categoryIndex, itemIndex: index, itemCount: itemCount)
                 if let i = array.firstIndex(where: { $0.id == taskId }) {
                     array[i].sortOrder = newSortOrder
                 }
@@ -1163,12 +1193,14 @@ class TasksViewModel: ObservableObject {
 
         for category in TaskCategory.allCases {
             let orderedTasks = getOrderedTasks(for: category)
-            // Category offset: today=0, tomorrow=100_000, later=200_000, noDeadline=300_000
-            let categoryOffset = (TaskCategory.allCases.firstIndex(of: category) ?? 0) * 100_000
+            // Category bands: today=[0,100k), tomorrow=[100k,200k), later=[200k,300k),
+            // noDeadline=[300k,400k). Spacing is derived from the per-category count so a
+            // large category never overflows its band (BL-016); see TasksViewModel.sortOrder.
+            let categoryIndex = TaskCategory.allCases.firstIndex(of: category) ?? 0
 
             for (index, task) in orderedTasks.enumerated() {
                 guard !task.id.hasPrefix("local_"), !task.id.hasPrefix("staged_") else { continue }
-                let sortOrder = categoryOffset + (index + 1) * 1000
+                let sortOrder = Self.sortOrder(categoryIndex: categoryIndex, itemIndex: index, itemCount: orderedTasks.count)
                 let indent = indentLevels[task.id] ?? task.indentLevel ?? 0
                 updates.append((id: task.id, sortOrder: sortOrder, indentLevel: indent))
             }
@@ -3318,14 +3350,16 @@ struct TasksPage: View {
                                     draggedTaskId: viewModel.draggedTaskId,
                                     findTaskGlobal: { viewModel.findTask($0) },
                                     onDragStarted: { viewModel.draggedTaskId = $0 },
-                                    onDragEnded: {
-                                        // Idempotent: TaskDragItemProvider.deinit fires onDragEnded
-                                        // a second time after the synchronous drop handler. Without
-                                        // this guard, the duplicate dispatch would no-op redundantly
-                                        // in the common case but could clobber state during a rapid
-                                        // re-drag (deinit dispatch is one main.async hop, sub-ms).
-                                        // Keep the guard so the design is strictly idempotent.
-                                        guard viewModel.draggedTaskId != nil else { return }
+                                    onDragEnded: { endedId in
+                                        // Drag-end is task-scoped. Both the drop handler and
+                                        // TaskDragItemProvider.deinit route here; deinit hops one
+                                        // main.async and can land *after* the user has already
+                                        // started a new drag. A late deinit from a prior drag
+                                        // carries that prior task's id, so guarding on
+                                        // draggedTaskId == endedId stops it clobbering the new
+                                        // drag's dim state (BL-030). Same-id re-fires are idempotent
+                                        // (second call sees a nil/other draggedTaskId and no-ops).
+                                        guard viewModel.draggedTaskId == endedId else { return }
                                         viewModel.draggedTaskId = nil
                                         viewModel.dropTargetTaskId = nil
                                     },
@@ -3551,7 +3585,10 @@ struct TaskCategorySection: View {
     // Non-optional with no-op defaults: this callback is load-bearing for the
     // dim-while-dragging effect, and a silent nil here was the original bug.
     var onDragStarted: (String) -> Void = { _ in }
-    var onDragEnded: () -> Void = {}
+    // Carries the id of the task whose drag ended, so the receiver can scope the
+    // dim/drag-state reset to that exact task and ignore a stale late end from a
+    // prior drag (BL-030).
+    var onDragEnded: (String) -> Void = { _ in }
     var onDragHoverChanged: ((String, Bool) -> Void)?
 
     // Edit mode support
@@ -3750,7 +3787,9 @@ struct TaskDragDropModifier: ViewModifier {
     var findTask: ((String) -> TaskActionItem?)?
     var findTargetIndex: (() -> Int?)?
     var onMoveTask: ((TaskActionItem, Int) -> Void)?
-    var onDragEnded: (() -> Void)?
+    /// Called with the id of the dragged task when a drop lands, so the drag-end
+    /// reset stays scoped to that task (BL-030).
+    var onDragEnded: ((String) -> Void)?
     var onHoverChanged: ((String, Bool) -> Void)?
 
     func body(content: Content) -> some View {
@@ -3776,9 +3815,10 @@ struct TaskDragDropModifier: ViewModifier {
                     }
                 )) { providers in
                     log("DROP: Received drop on task \(taskId), providers=\(providers.count)")
-                    onDragEnded?()
                     guard let provider = providers.first else {
                         log("DROP: No providers")
+                        // No payload to identify the dragged task; the provider's
+                        // deinit is the catch-all that fires the id-scoped reset.
                         return false
                     }
                     provider.loadItem(forTypeIdentifier: "public.plain-text", options: nil) { data, error in
@@ -3789,6 +3829,11 @@ struct TaskDragDropModifier: ViewModifier {
                             return
                         }
                         DispatchQueue.main.async {
+                            // End the drag scoped to the task that was actually dragged
+                            // (droppedId), before applying the move. The provider's deinit
+                            // fires the same scoped reset as the catch-all; both are
+                            // idempotent via the draggedTaskId == endedId guard (BL-030).
+                            onDragEnded?(droppedId)
                             guard let targetIndex = findTargetIndex?() else {
                                 log("DROP: findTargetIndex returned nil")
                                 return
@@ -3816,9 +3861,11 @@ struct TaskDragDropModifier: ViewModifier {
 /// NSEvent.addLocalMonitor/addGlobalMonitor approach that didn't fire from
 /// inside the AppKit drag modal loop, leaving the dragged row stuck dimmed.
 final class TaskDragItemProvider: NSItemProvider {
-    private let onEnd: () -> Void
+    private let taskId: String
+    private let onEnd: (String) -> Void
 
-    init(taskId: String, onEnd: @escaping () -> Void) {
+    init(taskId: String, onEnd: @escaping (String) -> Void) {
+        self.taskId = taskId
         self.onEnd = onEnd
         super.init()
         registerObject(taskId as NSString, visibility: .all)
@@ -3826,9 +3873,12 @@ final class TaskDragItemProvider: NSItemProvider {
 
     deinit {
         // deinit may run off-main when AppKit releases its reference. Hop to
-        // main before mutating @Published state.
+        // main before mutating @Published state. Pass this drag's own taskId so
+        // a late deinit from a *prior* drag can't clear a newer drag's dim
+        // state (BL-030): the receiver clears only when draggedTaskId == this id.
         let cb = onEnd
-        DispatchQueue.main.async { cb() }
+        let endedId = taskId
+        DispatchQueue.main.async { cb(endedId) }
     }
 }
 
@@ -3958,9 +4008,11 @@ struct TaskRow: View {
     /// Non-optional with no-op default: load-bearing for the dim effect, and a
     /// silent-nil here was the original bug we're fixing.
     var onDragStarted: (String) -> Void = { _ in }
-    /// Fires when the drag actually ends (mouseUp), regardless of drop outcome.
-    /// Required so the dimmed row is restored even if the drop misses every target.
-    var onDragEnded: () -> Void = {}
+    /// Fires when the drag actually ends (mouseUp), regardless of drop outcome,
+    /// carrying the id of the task whose drag ended. Required so the dimmed row is
+    /// restored even if the drop misses every target — and so a late end from a
+    /// prior drag doesn't clear a newer drag's dim (BL-030).
+    var onDragEnded: (String) -> Void = { _ in }
     /// True iff this row is the one currently being dragged. Drives the dim effect.
     var isBeingDragged: Bool = false
     var isChatActive: Bool = false

--- a/desktop/macos/Desktop/Tests/TasksSortOrderBandingTests.swift
+++ b/desktop/macos/Desktop/Tests/TasksSortOrderBandingTests.swift
@@ -71,6 +71,31 @@ final class TasksSortOrderBandingTests: XCTestCase {
             newValue, band, "new scheme must keep the 101st item inside its band (BL-016)")
     }
 
+    /// Copilot boundary review: once `itemCount >= bandWidth` the derived integer
+    /// spacing floors to 0, so a naive `(itemIndex+1)*max(1,spacing)` would land the
+    /// last item on the next band's base. The degenerate branch must keep every item
+    /// strictly inside its band (ordering non-decreasing) even at that unreachable scale.
+    func testDegenerateOversizedCategoryStaysInsideBand() {
+        let band = TasksViewModel.sortOrderBandWidth
+        let categoryIndex = 2
+        let base = categoryIndex * band
+        for count in [band, band + 1, band + 5000] {
+            var previous = Int.min
+            for itemIndex in [0, 1, count / 2, count - 2, count - 1] {
+                let value = TasksViewModel.sortOrder(
+                    categoryIndex: categoryIndex, itemIndex: itemIndex, itemCount: count)
+                XCTAssertGreaterThanOrEqual(
+                    value, base, "count \(count) item \(itemIndex) underflowed its band")
+                XCTAssertLessThan(
+                    value, base + band,
+                    "count \(count) item \(itemIndex) overflowed its band (degenerate boundary)")
+                XCTAssertGreaterThanOrEqual(
+                    value, previous, "degenerate ordering must stay non-decreasing")
+                previous = value
+            }
+        }
+    }
+
     /// Backward compatibility: small categories keep the historical sparse 1000
     /// spacing, so orders already persisted under the old scheme are unchanged.
     func testSmallCategoryKeepsHistoricalSparseSpacing() {

--- a/desktop/macos/Desktop/Tests/TasksSortOrderBandingTests.swift
+++ b/desktop/macos/Desktop/Tests/TasksSortOrderBandingTests.swift
@@ -1,0 +1,148 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// Covers the two remaining tasks-integrity defects fixed in this slice:
+///   - BL-016: the sortOrder scheme must keep every item inside its category's
+///     numeric band, even for large categories that overflowed the old fixed
+///     1000-spacing (hard ceiling ~100 items → cross-band collision).
+///   - BL-030: end-of-drag reset must be task-id-scoped so a late deinit from a
+///     prior drag can't clear a newer drag's dim state.
+final class TasksSortOrderBandingTests: XCTestCase {
+
+    // MARK: - BL-016: band containment (logic)
+
+    private var categoryCount: Int { TaskCategory.allCases.count }
+
+    /// A category with far more than the old ~100-item ceiling must keep every
+    /// order strictly inside its own band and strictly increasing.
+    func testLargeCategoryStaysInsideItsBandAndIsMonotonic() {
+        let band = TasksViewModel.sortOrderBandWidth
+        let count = 150  // TASK-04 exercises 150 reorders; comfortably past the old ceiling
+
+        for categoryIndex in 0..<categoryCount {
+            let lower = categoryIndex * band
+            let upper = (categoryIndex + 1) * band
+            var previous = Int.min
+            for itemIndex in 0..<count {
+                let value = TasksViewModel.sortOrder(
+                    categoryIndex: categoryIndex, itemIndex: itemIndex, itemCount: count)
+                XCTAssertGreaterThanOrEqual(
+                    value, lower, "item \(itemIndex) fell below category \(categoryIndex)'s band")
+                XCTAssertLessThan(
+                    value, upper,
+                    "item \(itemIndex) of \(count) overflowed category \(categoryIndex)'s band (BL-016)")
+                XCTAssertGreaterThan(
+                    value, previous, "sortOrder must be strictly increasing within a category")
+                previous = value
+            }
+        }
+    }
+
+    /// The direct cross-band collision from BL-016: at scale, the last item of one
+    /// category must stay below the first item of the next category's band.
+    func testAdjacentCategoriesDoNotCollideAtScale() {
+        let count = 150
+        for categoryIndex in 0..<(categoryCount - 1) {
+            let lastOfThis = TasksViewModel.sortOrder(
+                categoryIndex: categoryIndex, itemIndex: count - 1, itemCount: count)
+            let firstOfNext = TasksViewModel.sortOrder(
+                categoryIndex: categoryIndex + 1, itemIndex: 0, itemCount: count)
+            XCTAssertLessThan(
+                lastOfThis, firstOfNext,
+                "category \(categoryIndex)'s last item collided into category \(categoryIndex + 1)'s band (BL-016)")
+        }
+    }
+
+    /// Regression: the old fixed scheme (`categoryIndex*band + (itemIndex+1)*1000`)
+    /// overflowed the band at ~100 items; the new scheme must not.
+    func testOldFixedSchemeOverflowedButNewSchemeDoesNot() {
+        let band = TasksViewModel.sortOrderBandWidth
+        let count = 150
+        let overflowIndex = 100  // the 101st item — old value = 101 * 1000 = 101_000 ≥ band
+
+        let oldValue = 0 * band + (overflowIndex + 1) * 1000
+        XCTAssertGreaterThanOrEqual(
+            oldValue, band, "sanity: the old fixed scheme is expected to overflow here")
+
+        let newValue = TasksViewModel.sortOrder(
+            categoryIndex: 0, itemIndex: overflowIndex, itemCount: count)
+        XCTAssertLessThan(
+            newValue, band, "new scheme must keep the 101st item inside its band (BL-016)")
+    }
+
+    /// Backward compatibility: small categories keep the historical sparse 1000
+    /// spacing, so orders already persisted under the old scheme are unchanged.
+    func testSmallCategoryKeepsHistoricalSparseSpacing() {
+        let band = TasksViewModel.sortOrderBandWidth
+        let count = 5
+        for categoryIndex in 0..<categoryCount {
+            for itemIndex in 0..<count {
+                let value = TasksViewModel.sortOrder(
+                    categoryIndex: categoryIndex, itemIndex: itemIndex, itemCount: count)
+                let legacy = categoryIndex * band + (itemIndex + 1) * 1000
+                XCTAssertEqual(
+                    value, legacy,
+                    "small category spacing must match the legacy 1000 scheme for compatibility")
+            }
+        }
+    }
+
+    // MARK: - BL-016 + BL-030: source-scrape guards against regression
+
+    private func tasksPageSource() throws -> String {
+        let sourceURL = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("Sources/MainWindow/Pages/TasksPage.swift")
+        return try String(contentsOf: sourceURL)
+    }
+
+    /// Both reorder sites must route through the shared helper, and the fixed
+    /// `(index + 1) * 1000` / `(index + 1) * 1000` literals must be gone.
+    func testBothSortSitesUseSharedHelper() throws {
+        let source = try tasksPageSource()
+
+        XCTAssertTrue(
+            source.contains("static func sortOrder(categoryIndex: Int, itemIndex: Int, itemCount: Int) -> Int"),
+            "the shared sortOrder helper must exist so both sort sites agree (BL-016)")
+
+        // moveTask + collectSortOrderUpdates → two call sites.
+        let callSites = source.components(separatedBy: "Self.sortOrder(categoryIndex:").count - 1
+        XCTAssertGreaterThanOrEqual(
+            callSites, 2,
+            "both moveTask and collectSortOrderUpdates must call the shared helper (BL-016)")
+
+        XCTAssertFalse(
+            source.contains("categoryOffset + (index + 1) * 1000"),
+            "the fixed-spacing scheme with a hard ~100-item ceiling must be gone (BL-016)")
+    }
+
+    /// The end-of-drag reset must be task-id-scoped, not merely non-nil-gated.
+    func testDragEndResetIsTaskIdScoped() throws {
+        let source = try tasksPageSource()
+
+        XCTAssertTrue(
+            source.contains("guard viewModel.draggedTaskId == endedId else { return }"),
+            "drag-end must clear only when the ending task is still the dragged one (BL-030)")
+        XCTAssertFalse(
+            source.contains("guard viewModel.draggedTaskId != nil else { return }"),
+            "the non-scoped drag-end guard let a stale prior-drag deinit clobber a new drag (BL-030)")
+    }
+
+    /// The provider must carry its own task id and pass it through deinit so a
+    /// late release from a prior drag identifies itself.
+    func testDragItemProviderPassesItsOwnTaskId() throws {
+        let source = try tasksPageSource()
+
+        XCTAssertTrue(
+            source.contains("private let taskId: String"),
+            "TaskDragItemProvider must retain the dragged task's id (BL-030)")
+        XCTAssertTrue(
+            source.contains("let onEnd: (String) -> Void"),
+            "TaskDragItemProvider must fire an id-carrying end callback (BL-030)")
+        XCTAssertTrue(
+            source.contains("DispatchQueue.main.async { cb(endedId) }"),
+            "deinit must forward its own task id to the id-scoped end handler (BL-030)")
+    }
+}

--- a/desktop/macos/changelog/unreleased/20260705-task-reorder-large-lists.json
+++ b/desktop/macos/changelog/unreleased/20260705-task-reorder-large-lists.json
@@ -1,0 +1,3 @@
+{
+  "change": "Reordering tasks now stays correct in large lists (100+ items in a section no longer scramble order), and rapid re-drags no longer leave a row stuck dimmed"
+}


### PR DESCRIPTION
## What

Two focused fixes to task reordering in the desktop app:

1. **sortOrder stays inside its category band (large lists).** Reorder previously assigned `sortOrder = categoryIndex*100_000 + (itemIndex+1)*1000`. The fixed `1000` spacing inside a fixed `100_000` band caps a section at ~100 items — the 101st item's sortOrder overflowed into the *next* category's band, scrambling cross-section order. Both sort sites now derive spacing from the item count via a single shared helper:

   ```swift
   nonisolated static func sortOrder(categoryIndex: Int, itemIndex: Int, itemCount: Int) -> Int {
       let band = 100_000
       let spacing = max(1, min(1000, band / (itemCount + 1)))
       return categoryIndex * band + (itemIndex + 1) * spacing
   }
   ```

   Sections under 100 items keep the historical `1000` spacing exactly (byte-identical sortOrders — no data migration). Larger sections shrink spacing to stay strictly in-band and strictly monotonic (verified in-band + collision-free up to ~99,999 items/section, far beyond any real task list).

2. **Drag-end reset is scoped to the dragged row.** The end-of-drag dim-clear could be triggered by a *previous* drag's `NSItemProvider.deinit` firing late, clearing the dim of a **new** in-flight drag. `onDragEnded` now carries the ended task id; the receiver clears the dim only when `draggedTaskId == endedId`, so a stale prior-drag deinit can't disturb a newer drag.

## Why

Both are silent-corruption / stuck-UI fragilities on the task reorder hot path — order scrambles past 100 items per section, and rapid re-drags can leave a row visually stuck dimmed.

## Testing

- New `TasksSortOrderBandingTests` (7 tests): in-band + monotonic for large counts, small-section spacing unchanged, both sort sites use the shared helper (source-scrape guard), legacy literal removed.
- `xcrun swift build -c debug` — clean.
- `bash test.sh` (per-suite isolation harness) — Rust 293 passed, Swift 130 suites passed.

Band math independently boundary-checked for 150 / 500 / 1000 items per section (item 0 above band base, last item below next band base, step ≥ 1 so no ties).

Runtime verification of a 150-item reorder surviving an app restart is not included (needs a seeded signed-in bundle with ~150 persisted tasks); the fix is unit- and arithmetic-verified.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9121?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

