### PR TITLE
Fix desktop browser cookie value decoding

### DIFF
--- a/desktop/macos/Desktop/Sources/BrowserGoogleSession.swift
+++ b/desktop/macos/Desktop/Sources/BrowserGoogleSession.swift
@@ -51,6 +51,11 @@ struct BrowserGoogleSession: Equatable {
                 continue
             enc = bytes(enc) if not isinstance(enc, bytes) else enc
             value = None
+            # Cookie values are octet strings and are sent back verbatim in the
+            # Latin-1 HTTP Cookie header. Decode them as Latin-1 (a 1:1 byte<->char
+            # map, so value.encode('latin-1') reproduces the exact bytes). Using
+            # utf-8 with errors='replace' corrupted non-utf-8 values into U+FFFD,
+            # which then failed to encode into the Latin-1 request header.
             if enc[:3] in (b'v10', b'v11'):
                 ciphertext = enc[3:]
                 try:
@@ -64,12 +69,12 @@ struct BrowserGoogleSession: Equatable {
                         decrypted = decrypted[:-pad_len]
                     if db_version >= 24 and len(decrypted) > 32:
                         decrypted = decrypted[32:]
-                    value = decrypted.decode('utf-8', errors='replace')
+                    value = decrypted.decode('latin-1')
                 except Exception:
                     continue
             elif enc:
                 try:
-                    value = enc.decode('utf-8', errors='replace')
+                    value = enc.decode('latin-1')
                 except Exception:
                     continue
             if value:

--- a/desktop/macos/changelog/unreleased/gmail-calendar-cookie-latin1-decode.json
+++ b/desktop/macos/changelog/unreleased/gmail-calendar-cookie-latin1-decode.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed Gmail and Calendar import failing for some browser profiles by reading cookie values correctly"
+}


### PR DESCRIPTION
## Summary
- Decode Chromium cookie values as Latin-1 after decrypting browser cookies for Gmail and Calendar imports.
- Preserve the original cookie bytes when Python builds the HTTP `Cookie` header.
- Add a desktop changelog fragment for the Gmail/Calendar import fix.

## Root Cause
Cookie values are byte strings, but the previous helper decoded them as UTF-8 with replacement. Non-UTF-8 bytes became `U+FFFD`, and Python's HTTP header path could not encode that replacement character into the Latin-1 request header. That made some valid browser sessions fail before Gmail or Calendar could be reached.

## Validation
- `xcrun swift test -c debug --package-path Desktop --disable-index-store --filter BrowserGoogleSessionTests`
- Verified with a focused Python check that Latin-1 decoding round-trips the cookie byte into the header, while the old replacement-character path raises a Latin-1 header encoding error.

## Diff Size
- 2 files changed, 10 insertions, 2 deletions.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9122?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

