### PR TITLE
[codex] Remove stale Cloud Run pusher references

### DIFF
--- a/.github/workflows/gcp_backend_pusher.yml
+++ b/.github/workflows/gcp_backend_pusher.yml
@@ -117,14 +117,6 @@ jobs:
           fi
           docker push gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}:${GITHUB_SHA::7}
 
-      # - name: Deploy to Cloud Run
-      #   id: deploy
-      #   uses: google-github-actions/deploy-cloudrun@v2
-      #   with:
-      #     service: ${{ env.SERVICE }}
-      #     region: ${{ env.REGION }}
-      #     image: gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}
-
       - name: Get GKE credentials
         uses: google-github-actions/get-gke-credentials@v2
         with:

--- a/backend/charts/monitoring/dashboards/general/backend-api-monitoring-v2.json
+++ b/backend/charts/monitoring/dashboards/general/backend-api-monitoring-v2.json
@@ -738,7 +738,7 @@
       "targets": [
         {
           "projectId": "based-hardware",
-          "queryText": "resource.type=\"cloud_run_revision\"\nresource.labels.service_name=~\"backend|backend-integration|backend-sync|frontend|plugins|pusher\"\nhttpRequest.status>=400",
+          "queryText": "resource.type=\"cloud_run_revision\"\nresource.labels.service_name=~\"backend|backend-integration|backend-sync|frontend|plugins\"\nhttpRequest.status>=400",
           "refId": "A"
         }
       ],
@@ -808,7 +808,7 @@
       "targets": [
         {
           "projectId": "based-hardware",
-          "queryText": "resource.type=\"cloud_run_revision\"\nresource.labels.service_name=~\"backend|backend-integration|backend-sync|frontend|plugins|pusher\"\nseverity>=ERROR",
+          "queryText": "resource.type=\"cloud_run_revision\"\nresource.labels.service_name=~\"backend|backend-integration|backend-sync|frontend|plugins\"\nseverity>=ERROR",
           "refId": "A"
         }
       ],


### PR DESCRIPTION
## Summary

- remove the dead commented Cloud Run deploy block from the pusher workflow
- remove `pusher` from Cloud Run error panels in the backend monitoring dashboard

## Why

Pusher is deployed and monitored through GKE today. The stale Cloud Run pusher service in dev has a broken latest revision and is not the authoritative deploy path, so keeping it in Cloud Run deploy/monitoring surfaces creates false operational noise.

## Validation

- `python3 -m json.tool backend/charts/monitoring/dashboards/general/backend-api-monitoring-v2.json`
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9126?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

