### PR TITLE
fix(desktop): surface swallowed system shell-out errors + make floating-bar timing signal-driven

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -48,6 +48,9 @@ jobs:
           # UserDefaults key ratchet: run when desktop Swift sources, the ratchet
           # script, or this workflow change (so the gate dogfoods itself).
           echo "has_desktop_defaults_ratchet=$(echo "$FILES" | grep -qE '^desktop/macos/Desktop/Sources/.*\.swift$|^desktop/macos/scripts/check-userdefaults-key-ratchet\.py$|^\.github/workflows/lint\.yml$' && echo true || echo false)" >> $GITHUB_OUTPUT
+          # asyncAfter ratchet: run when floating-bar / PTT sources, the ratchet
+          # script, or this workflow change (so the gate dogfoods itself).
+          echo "has_desktop_async_after_ratchet=$(echo "$FILES" | grep -qE '^desktop/macos/Desktop/Sources/FloatingControlBar/.*\.swift$|^desktop/macos/scripts/check-async-after-ratchet\.py$|^\.github/workflows/lint\.yml$' && echo true || echo false)" >> $GITHUB_OUTPUT
 
       # -- Universal source hygiene --
       - name: Check merge conflict markers
@@ -103,6 +106,10 @@ jobs:
       - name: Check desktop UserDefaults key ratchet
         if: steps.changed.outputs.has_desktop_defaults_ratchet == 'true'
         run: python3 desktop/macos/scripts/check-userdefaults-key-ratchet.py
+
+      - name: Check desktop asyncAfter ratchet
+        if: steps.changed.outputs.has_desktop_async_after_ratchet == 'true'
+        run: python3 desktop/macos/scripts/check-async-after-ratchet.py
 
       - name: Check GitHub Actions workflows
         if: steps.changed.outputs.has_workflows == 'true'

--- a/desktop/macos/Desktop/Sources/AppState/AppState+Permissions.swift
+++ b/desktop/macos/Desktop/Sources/AppState/AppState+Permissions.swift
@@ -667,25 +667,16 @@ extension AppState {
     let bundleId = Bundle.main.bundleIdentifier ?? "com.omi.computer-macos"
     log("Resetting accessibility permission for \(bundleId) via tccutil...")
 
-    let process = Process()
-    process.executableURL = URL(fileURLWithPath: "/usr/bin/tccutil")
-    process.arguments = ["reset", "Accessibility", bundleId]
+    let success = SystemCommand.runLogging(
+      "tccutil reset Accessibility (\(bundleId))",
+      executable: "/usr/bin/tccutil",
+      arguments: ["reset", "Accessibility", bundleId])
 
-    do {
-      try process.run()
-      process.waitUntilExit()
-      let success = process.terminationStatus == 0
-      log("tccutil reset completed with exit code: \(process.terminationStatus)")
-
-      if success && shouldRestart {
-        restartApp()
-      }
-
-      return success
-    } catch {
-      log("Failed to run tccutil: \(error)")
-      return false
+    if success && shouldRestart {
+      restartApp()
     }
+
+    return success
   }
 
   /// Reset accessibility permission via tccutil and restart the app.

--- a/desktop/macos/Desktop/Sources/AppState/AppState+SystemActions.swift
+++ b/desktop/macos/Desktop/Sources/AppState/AppState+SystemActions.swift
@@ -245,20 +245,10 @@ extension AppState {
   nonisolated func resetLaunchServicesDatabase() {
     let lsregisterPath =
       "/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister"
-
-    let process = Process()
-    process.executableURL = URL(fileURLWithPath: lsregisterPath)
-    process.arguments = ["-kill", "-r", "-domain", "local", "-domain", "user"]
-    process.standardOutput = FileHandle.nullDevice
-    process.standardError = FileHandle.nullDevice
-
-    do {
-      try process.run()
-      process.waitUntilExit()
-      log("Launch Services database reset (exit code: \(process.terminationStatus))")
-    } catch {
-      log("Failed to reset Launch Services: \(error.localizedDescription)")
-    }
+    SystemCommand.runLogging(
+      "Reset Launch Services database",
+      executable: lsregisterPath,
+      arguments: ["-kill", "-r", "-domain", "local", "-domain", "user"])
   }
 
   /// Clean user TCC database entries for Omi apps
@@ -266,43 +256,19 @@ extension AppState {
     let homeDir = FileManager.default.homeDirectoryForCurrentUser.path
     let tccDbPath = "\(homeDir)/Library/Application Support/com.apple.TCC/TCC.db"
 
-    let process = Process()
-    process.executableURL = URL(fileURLWithPath: "/usr/bin/sqlite3")
-    process.arguments = [
-      tccDbPath, "DELETE FROM access WHERE client LIKE '%com.omi.computer-macos%';",
-    ]
-    process.standardOutput = FileHandle.nullDevice
-    process.standardError = FileHandle.nullDevice
-
-    do {
-      try process.run()
-      process.waitUntilExit()
-      log("User TCC database cleaned (exit code: \(process.terminationStatus))")
-    } catch {
-      log("Failed to clean user TCC database: \(error.localizedDescription)")
-    }
+    SystemCommand.runLogging(
+      "Clean user TCC database (production bundle)",
+      executable: "/usr/bin/sqlite3",
+      arguments: [tccDbPath, "DELETE FROM access WHERE client LIKE '%com.omi.computer-macos%';"])
 
     // Also clean entries for non-production Omi bundles (for example com.omi.desktop-dev, com.omi.1233).
-    let process2 = Process()
-    process2.executableURL = URL(fileURLWithPath: "/usr/bin/sqlite3")
-    process2.arguments = [
-      tccDbPath,
-      "DELETE FROM access WHERE client LIKE 'com.omi.%' AND client != 'com.omi.computer-macos';",
-    ]
-    process2.standardOutput = FileHandle.nullDevice
-    process2.standardError = FileHandle.nullDevice
-
-    do {
-      try process2.run()
-      process2.waitUntilExit()
-      log(
-        "User TCC database cleaned for non-production bundles (exit code: \(process2.terminationStatus))"
-      )
-    } catch {
-      log(
-        "Failed to clean user TCC database for non-production bundles: \(error.localizedDescription)"
-      )
-    }
+    SystemCommand.runLogging(
+      "Clean user TCC database (non-production bundles)",
+      executable: "/usr/bin/sqlite3",
+      arguments: [
+        tccDbPath,
+        "DELETE FROM access WHERE client LIKE 'com.omi.%' AND client != 'com.omi.computer-macos';",
+      ])
   }
 
   /// Reset microphone permission using tccutil (Option 1: Direct)
@@ -312,25 +278,16 @@ extension AppState {
     let bundleId = Bundle.main.bundleIdentifier ?? "com.omi.computer-macos"
     log("Resetting microphone permission for \(bundleId) via tccutil...")
 
-    let process = Process()
-    process.executableURL = URL(fileURLWithPath: "/usr/bin/tccutil")
-    process.arguments = ["reset", "Microphone", bundleId]
+    let success = SystemCommand.runLogging(
+      "tccutil reset Microphone (\(bundleId))",
+      executable: "/usr/bin/tccutil",
+      arguments: ["reset", "Microphone", bundleId])
 
-    do {
-      try process.run()
-      process.waitUntilExit()
-      let success = process.terminationStatus == 0
-      log("tccutil reset completed with exit code: \(process.terminationStatus)")
-
-      if success && shouldRestart {
-        restartApp()
-      }
-
-      return success
-    } catch {
-      log("Failed to run tccutil: \(error)")
-      return false
+    if success && shouldRestart {
+      restartApp()
     }
+
+    return success
   }
 
   /// Reset microphone permission via Terminal (Option 2: Visible to user)
@@ -433,4 +390,116 @@ extension AppState {
 
 extension Notification.Name {
   /// Posted when the current app instance should fully clear its own onboarding state.
+}
+
+// MARK: - Privileged system command runner (BL-022)
+
+/// Structured outcome of a system / privileged shell-out (`tccutil`,
+/// `lsregister`, `sqlite3` on `TCC.db`, `xattr`, …).
+///
+/// These call sites previously used `try? process.run()`, which dropped *both*
+/// launch failures and non-zero exits silently — a failed provenance strip broke
+/// future Sparkle updates, and a failed `tccutil`/`sqlite3` reset looked
+/// identical to success (BL-022). Making the outcome explicit lets callers log it
+/// with context and, where a UI surface exists, reflect it — without ever
+/// crashing.
+enum SystemCommandOutcome: Equatable {
+  /// Process ran and exited 0.
+  case succeeded
+  /// Process could not be started (missing binary, sandbox denial, …).
+  case failedToLaunch(String)
+  /// Process ran but exited non-zero; carries a bounded, sanitized stderr snippet.
+  case exitedNonZero(code: Int32, stderr: String)
+
+  var isSuccess: Bool {
+    if case .succeeded = self { return true }
+    return false
+  }
+
+  /// Short, log-safe one-liner describing the outcome.
+  var summary: String {
+    switch self {
+    case .succeeded:
+      return "ok"
+    case .failedToLaunch(let detail):
+      return "failed to launch\(detail.isEmpty ? "" : " — \(detail)")"
+    case .exitedNonZero(let code, let stderr):
+      return "exit \(code)\(stderr.isEmpty ? "" : " — \(stderr)")"
+    }
+  }
+
+  /// Emit a single structured log line. Success is `log`; any failure is
+  /// `logError` so it surfaces in error triage instead of vanishing. Use for
+  /// commands that are expected to succeed (permission resets, provenance strip);
+  /// for best-effort tools whose non-zero exit is benign, log `summary` directly.
+  func logResult(_ label: String) {
+    switch self {
+    case .succeeded:
+      log("\(label): ok")
+    case .failedToLaunch, .exitedNonZero:
+      logError("\(label): \(summary)")
+    }
+  }
+}
+
+/// Runs system/privileged shell-outs and returns a structured outcome instead of
+/// throwing or silently swallowing. stderr is captured (bounded + sanitized) so
+/// failures are diagnosable; stdout is discarded. Blocking — call off the main
+/// thread for slow tools.
+enum SystemCommand {
+  @discardableResult
+  static func run(
+    executable: String,
+    arguments: [String],
+    maxStderrLength: Int = 200
+  ) -> SystemCommandOutcome {
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: executable)
+    process.arguments = arguments
+    let stderrPipe = Pipe()
+    process.standardOutput = FileHandle.nullDevice
+    process.standardError = stderrPipe
+
+    do {
+      try process.run()
+    } catch {
+      return .failedToLaunch(
+        sanitizedCommandOutput(error.localizedDescription, maxLength: maxStderrLength))
+    }
+
+    // Drain stderr before waitUntilExit so a chatty tool can't deadlock on a full
+    // pipe buffer; readDataToEndOfFile returns once the child closes the pipe.
+    let stderrData = stderrPipe.fileHandleForReading.readDataToEndOfFile()
+    process.waitUntilExit()
+
+    if process.terminationStatus == 0 {
+      return .succeeded
+    }
+    let snippet = sanitizedCommandOutput(
+      String(decoding: stderrData, as: UTF8.self), maxLength: maxStderrLength)
+    return .exitedNonZero(code: process.terminationStatus, stderr: snippet)
+  }
+
+  /// Run a should-succeed command, log its outcome under `label` (failure →
+  /// `logError`), and return whether it succeeded so callers can branch.
+  @discardableResult
+  static func runLogging(_ label: String, executable: String, arguments: [String]) -> Bool {
+    let outcome = run(executable: executable, arguments: arguments)
+    outcome.logResult(label)
+    return outcome.isSuccess
+  }
+}
+
+/// Collapse captured command output to a single, control-char-free, length-
+/// bounded snippet safe to log. The privileged system tools used here don't emit
+/// user secrets, so this bounds noise rather than scrubbing PII.
+func sanitizedCommandOutput(_ raw: String, maxLength: Int = 200) -> String {
+  let collapsed =
+    raw
+    .replacingOccurrences(of: "\r", with: " ")
+    .replacingOccurrences(of: "\n", with: " ")
+    .replacingOccurrences(of: "\t", with: " ")
+    .trimmingCharacters(in: .whitespacesAndNewlines)
+  if collapsed.count <= maxLength { return collapsed }
+  return String(collapsed.prefix(maxLength)) + "…"
 }

--- a/desktop/macos/Desktop/Sources/AppState/AppState+SystemActions.swift
+++ b/desktop/macos/Desktop/Sources/AppState/AppState+SystemActions.swift
@@ -494,11 +494,12 @@ enum SystemCommand {
 /// bounded snippet safe to log. The privileged system tools used here don't emit
 /// user secrets, so this bounds noise rather than scrubbing PII.
 func sanitizedCommandOutput(_ raw: String, maxLength: Int = 200) -> String {
+  // Replace every control character (not just \r\n\t) with a space so a tool's
+  // stderr can't inject terminal/log escape sequences into our logs or Sentry.
   let collapsed =
-    raw
-    .replacingOccurrences(of: "\r", with: " ")
-    .replacingOccurrences(of: "\n", with: " ")
-    .replacingOccurrences(of: "\t", with: " ")
+    raw.unicodeScalars
+    .map { CharacterSet.controlCharacters.contains($0) ? " " : String($0) }
+    .joined()
     .trimmingCharacters(in: .whitespacesAndNewlines)
   if collapsed.count <= maxLength { return collapsed }
   return String(collapsed.prefix(maxLength)) + "…"

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift
@@ -986,21 +986,30 @@ struct FloatingControlBarView: View {
     /// create/activate the window (BL-005); the window-key event is the real signal.
     private func runWhenMainAppWindowKey(_ action: @escaping () -> Void) {
         if let key = NSApp.keyWindow, Self.isRealMainAppWindow(key) {
-            action()
+            // One runloop hop, same as the observer path below, so a freshly-keyed
+            // window's content (e.g. the navigate receiver) is mounted before we act.
+            DispatchQueue.main.async { action() }
             return
         }
         var token: NSObjectProtocol?
+        let removeObserver = {
+            if let token { NotificationCenter.default.removeObserver(token) }
+        }
         token = NotificationCenter.default.addObserver(
             forName: NSWindow.didBecomeKeyNotification, object: nil, queue: .main
         ) { note in
             guard let window = note.object as? NSWindow, Self.isRealMainAppWindow(window) else {
                 return
             }
-            if let token { NotificationCenter.default.removeObserver(token) }
+            removeObserver()
             // One runloop hop so SwiftUI can mount the freshly-opened window's
             // content (e.g. the navigate receiver) before we act.
             DispatchQueue.main.async { action() }
         }
+        // Safety net: if no real main window ever becomes key (e.g. openMainWindow
+        // was nil, or the view went away), drop the observer after a bounded delay
+        // so it can't linger on the default center indefinitely.
+        Timer.scheduledTimer(withTimeInterval: 10, repeats: false) { _ in removeObserver() }
     }
 
     @discardableResult

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift
@@ -949,7 +949,10 @@ struct FloatingControlBarView: View {
 
     private func openFloatingBarSettings() {
         activateMainAppWindow()
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.12) {
+        // Post the navigate request once the main window is key (its
+        // `navigateToFloatingBarSettings` receiver is mounted by then) rather than
+        // guessing a fixed delay for the window to appear (BL-005).
+        runWhenMainAppWindowKey {
             NotificationCenter.default.post(name: .navigateToFloatingBarSettings, object: nil)
         }
     }
@@ -957,12 +960,46 @@ struct FloatingControlBarView: View {
     private func activateMainAppWindow() {
         NSApp.activate()
 
-        if !revealMainAppWindow() {
-            AppDelegate.openMainWindow?()
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
-                NSApp.activate()
-                _ = revealMainAppWindow()
+        if revealMainAppWindow() { return }
+
+        // No existing window — open one and reveal it the moment it becomes key,
+        // instead of guessing a fixed delay for openWindow(id:) to create it (BL-005).
+        AppDelegate.openMainWindow?()
+        runWhenMainAppWindowKey {
+            NSApp.activate()
+            _ = revealMainAppWindow()
+        }
+    }
+
+    /// True for the app's real main window (not the floating panel or the
+    /// menu-bar popover).
+    private static func isRealMainAppWindow(_ window: NSWindow) -> Bool {
+        !(window is NSPanel)
+            && window.frame.width > 300
+            && window.frame.height > 200
+            && !window.title.hasPrefix("Item-")
+    }
+
+    /// Run `action` once the app's main window is key — immediately if one already
+    /// is, otherwise on the next `didBecomeKeyNotification` for a real main window.
+    /// Replaces fixed `asyncAfter` guesses that waited for `openWindow(id:)` to
+    /// create/activate the window (BL-005); the window-key event is the real signal.
+    private func runWhenMainAppWindowKey(_ action: @escaping () -> Void) {
+        if let key = NSApp.keyWindow, Self.isRealMainAppWindow(key) {
+            action()
+            return
+        }
+        var token: NSObjectProtocol?
+        token = NotificationCenter.default.addObserver(
+            forName: NSWindow.didBecomeKeyNotification, object: nil, queue: .main
+        ) { note in
+            guard let window = note.object as? NSWindow, Self.isRealMainAppWindow(window) else {
+                return
             }
+            if let token { NotificationCenter.default.removeObserver(token) }
+            // One runloop hop so SwiftUI can mount the freshly-opened window's
+            // content (e.g. the navigate receiver) before we act.
+            DispatchQueue.main.async { action() }
         }
     }
 
@@ -1664,9 +1701,11 @@ private struct AgentMainChatView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .onAppear {
             manager.markViewed(pillID: pill.id)
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.12) {
-                isFollowUpFocused = true
-            }
+        }
+        .task {
+            // Focus the follow-up field once the view is on screen (view-lifecycle
+            // signal) instead of guessing a fixed delay for it to mount (BL-005).
+            isFollowUpFocused = true
         }
         .onExitCommand {
             onEscape()

--- a/desktop/macos/Desktop/Sources/OmiApp.swift
+++ b/desktop/macos/Desktop/Sources/OmiApp.swift
@@ -716,16 +716,11 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
   private func stripProvenanceXattrs() {
     let bundlePath = Bundle.main.bundlePath
     DispatchQueue.global(qos: .utility).async {
-      let process = Process()
-      process.launchPath = "/usr/bin/xattr"
-      process.arguments = ["-cr", bundlePath]
-      process.standardOutput = nil
-      process.standardError = nil
-      try? process.run()
-      process.waitUntilExit()
-      if process.terminationStatus == 0 {
-        log("AppDelegate: Stripped provenance xattrs from bundle")
-      }
+      // A silent failure here breaks the code-signature seal and causes future
+      // Sparkle updates to fail, so surface it (BL-022) instead of dropping it.
+      SystemCommand.runLogging(
+        "AppDelegate: strip provenance xattrs",
+        executable: "/usr/bin/xattr", arguments: ["-cr", bundlePath])
     }
   }
 
@@ -743,54 +738,34 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
       "/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister"
 
     DispatchQueue.global(qos: .utility).async {
-      // Unregister to clear stale icon entries
-      let unregister = Process()
-      unregister.executableURL = URL(fileURLWithPath: lsregister)
-      unregister.arguments = ["-u", appPath]
-      unregister.standardOutput = FileHandle.nullDevice
-      unregister.standardError = FileHandle.nullDevice
-      try? unregister.run()
-      unregister.waitUntilExit()
-
-      // Force re-register with updated icon
-      let register = Process()
-      register.executableURL = URL(fileURLWithPath: lsregister)
-      register.arguments = ["-f", appPath]
-      register.standardOutput = FileHandle.nullDevice
-      register.standardError = FileHandle.nullDevice
-      try? register.run()
-      register.waitUntilExit()
-
-      // Kill iconservicesagent to flush the icon cache (auto-restarts in <1s)
-      let killIcons = Process()
-      killIcons.executableURL = URL(fileURLWithPath: "/usr/bin/killall")
-      killIcons.arguments = ["iconservicesagent"]
-      killIcons.standardOutput = FileHandle.nullDevice
-      killIcons.standardError = FileHandle.nullDevice
-      try? killIcons.run()
-      killIcons.waitUntilExit()
+      // Best-effort cosmetic maintenance. Capture each step's outcome instead of
+      // dropping it with `try?`, but keep it at info level — some steps exit
+      // non-zero benignly (e.g. killall when the agent isn't running), so this is
+      // not routed through the failure path (BL-022).
+      log(
+        "Icon cache: lsregister unregister \(SystemCommand.run(executable: lsregister, arguments: ["-u", appPath]).summary)"
+      )
+      log(
+        "Icon cache: lsregister register \(SystemCommand.run(executable: lsregister, arguments: ["-f", appPath]).summary)"
+      )
+      log(
+        "Icon cache: kill iconservicesagent \(SystemCommand.run(executable: "/usr/bin/killall", arguments: ["iconservicesagent"]).summary)"
+      )
 
       // Safety net: verify the Dock is still running after 2 seconds.
-      // iconservicesagent restart can occasionally crash the Dock.
+      // iconservicesagent restart can occasionally crash the Dock. pgrep exits
+      // non-zero when Dock isn't found, which is the signal we branch on.
       Thread.sleep(forTimeInterval: 2.0)
-      let dockCheck = Process()
-      dockCheck.executableURL = URL(fileURLWithPath: "/usr/bin/pgrep")
-      dockCheck.arguments = ["-x", "Dock"]
-      dockCheck.standardOutput = FileHandle.nullDevice
-      dockCheck.standardError = FileHandle.nullDevice
-      try? dockCheck.run()
-      dockCheck.waitUntilExit()
+      let dockRunning = SystemCommand.run(
+        executable: "/usr/bin/pgrep", arguments: ["-x", "Dock"]
+      ).isSuccess
 
-      if dockCheck.terminationStatus != 0 {
+      if !dockRunning {
         // Dock is not running — restart it
         log("AppDelegate: Dock not running after icon cache reset, restarting")
-        let restartDock = Process()
-        restartDock.executableURL = URL(fileURLWithPath: "/usr/bin/open")
-        restartDock.arguments = ["-a", "Dock"]
-        restartDock.standardOutput = FileHandle.nullDevice
-        restartDock.standardError = FileHandle.nullDevice
-        try? restartDock.run()
-        restartDock.waitUntilExit()
+        log(
+          "Icon cache: restart Dock \(SystemCommand.run(executable: "/usr/bin/open", arguments: ["-a", "Dock"]).summary)"
+        )
       }
 
       log("AppDelegate: Icon cache reset complete")

--- a/desktop/macos/Desktop/Tests/FloatingBarTimingSignalTests.swift
+++ b/desktop/macos/Desktop/Tests/FloatingBarTimingSignalTests.swift
@@ -1,0 +1,69 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// BL-005 / S-14b: guards the signal-driven conversions in the floating bar so
+/// they aren't silently reverted to fixed-delay `asyncAfter` timing, and pins the
+/// `.asyncAfter(` call-site count under `FloatingControlBar/` to the ratchet
+/// baseline (mirrors `scripts/check-async-after-ratchet.py` inside the test suite
+/// that `test.sh` runs).
+final class FloatingBarTimingSignalTests: XCTestCase {
+  /// Keep in sync with `BASELINE` in `scripts/check-async-after-ratchet.py`.
+  private static let asyncAfterBaseline = 27
+
+  private func floatingControlBarDir() -> URL {
+    URL(fileURLWithPath: #filePath)
+      .deletingLastPathComponent()  // Tests/
+      .deletingLastPathComponent()  // Desktop/
+      .appendingPathComponent("Sources/FloatingControlBar")
+  }
+
+  private func floatingBarViewSource() throws -> String {
+    try String(
+      contentsOf: floatingControlBarDir().appendingPathComponent("FloatingControlBarView.swift"))
+  }
+
+  func testWindowActivationKeysOffWindowSignalNotFixedDelay() throws {
+    let source = try floatingBarViewSource()
+    XCTAssertTrue(
+      source.contains("func runWhenMainAppWindowKey"),
+      "window activation should route through the window-key signal helper")
+    XCTAssertTrue(
+      source.contains("NSWindow.didBecomeKeyNotification"),
+      "the transition should key off didBecomeKey, not a fixed delay")
+  }
+
+  func testFollowUpFocusUsesViewLifecycle() throws {
+    let source = try floatingBarViewSource()
+    XCTAssertTrue(
+      source.contains(".task {"),
+      "follow-up focus should be driven by the view lifecycle (.task), not asyncAfter")
+    XCTAssertTrue(
+      source.contains("isFollowUpFocused = true"), "the field must still be focused on appear")
+  }
+
+  /// Anti-regression: no new fixed-delay `asyncAfter` may be added under
+  /// `FloatingControlBar/` above the pinned baseline. Recurses the directory the
+  /// same way the Python ratchet does; comment mentions of the word are excluded
+  /// because the match requires the leading dot and open paren.
+  func testAsyncAfterCallSitesAtOrBelowBaseline() throws {
+    let fm = FileManager.default
+    let dir = floatingControlBarDir()
+    var count = 0
+    let enumerator = fm.enumerator(at: dir, includingPropertiesForKeys: nil)
+    while let url = enumerator?.nextObject() as? URL {
+      guard url.pathExtension == "swift" else { continue }
+      let source = try String(contentsOf: url)
+      count += source.components(separatedBy: ".asyncAfter(").count - 1
+    }
+    XCTAssertLessThanOrEqual(
+      count, Self.asyncAfterBaseline,
+      """
+      new fixed-delay .asyncAfter( added under FloatingControlBar/ \
+      (count \(count) > baseline \(Self.asyncAfterBaseline)). Key the transition off a \
+      signal (window didBecomeKey, view lifecycle, state change) or, if the delay is \
+      genuinely required, lower/raise the baseline deliberately in both this test and \
+      scripts/check-async-after-ratchet.py.
+      """)
+  }
+}

--- a/desktop/macos/Desktop/Tests/SystemCommandTests.swift
+++ b/desktop/macos/Desktop/Tests/SystemCommandTests.swift
@@ -54,4 +54,14 @@ final class SystemCommandTests: XCTestCase {
     XCTAssertEqual(bounded.count, 201)  // 200 chars + the single ellipsis
     XCTAssertTrue(bounded.hasSuffix("…"))
   }
+
+  func testSanitizerStripsAllControlCharactersNotJustWhitespace() {
+    // ESC (0x1B) + a bell (0x07) + a NUL — none may survive into a log line.
+    let injected = "ok\u{1B}[31mred\u{07}\u{00}done"
+    let cleaned = sanitizedCommandOutput(injected)
+    XCTAssertFalse(cleaned.unicodeScalars.contains { CharacterSet.controlCharacters.contains($0) })
+    XCTAssertTrue(cleaned.contains("ok"))
+    XCTAssertTrue(cleaned.contains("done"))
+    XCTAssertFalse(cleaned.contains("\u{1B}"))
+  }
 }

--- a/desktop/macos/Desktop/Tests/SystemCommandTests.swift
+++ b/desktop/macos/Desktop/Tests/SystemCommandTests.swift
@@ -1,0 +1,57 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// BL-022 / S-14b: the privileged shell-out runner must report launch failures
+/// and non-zero exits as structured outcomes (never silently swallow them like
+/// the previous `try? process.run()`), and must bound + sanitize captured stderr.
+/// Exercised hermetically via `/bin/sh` and a nonexistent path — no privileged
+/// tools, no side effects.
+final class SystemCommandTests: XCTestCase {
+  func testSucceededOnZeroExit() {
+    let outcome = SystemCommand.run(executable: "/bin/sh", arguments: ["-c", "exit 0"])
+    XCTAssertEqual(outcome, .succeeded)
+    XCTAssertTrue(outcome.isSuccess)
+    XCTAssertEqual(outcome.summary, "ok")
+  }
+
+  func testExitedNonZeroCapturesCodeAndStderr() {
+    let outcome = SystemCommand.run(
+      executable: "/bin/sh", arguments: ["-c", "echo boom 1>&2; exit 3"])
+    guard case let .exitedNonZero(code, stderr) = outcome else {
+      return XCTFail("expected exitedNonZero, got \(outcome)")
+    }
+    XCTAssertEqual(code, 3)
+    XCTAssertTrue(stderr.contains("boom"), "stderr snippet should carry the tool's message")
+    XCTAssertFalse(outcome.isSuccess)
+    XCTAssertTrue(outcome.summary.contains("exit 3"))
+  }
+
+  func testFailedToLaunchOnMissingExecutable() {
+    let outcome = SystemCommand.run(
+      executable: "/no/such/binary-\(UUID().uuidString)", arguments: [])
+    guard case .failedToLaunch = outcome else {
+      return XCTFail("expected failedToLaunch, got \(outcome)")
+    }
+    XCTAssertFalse(outcome.isSuccess)
+    XCTAssertTrue(outcome.summary.hasPrefix("failed to launch"))
+  }
+
+  func testRunLoggingReturnsSuccessOnlyForZeroExit() {
+    XCTAssertTrue(
+      SystemCommand.runLogging("test ok", executable: "/bin/sh", arguments: ["-c", "exit 0"]))
+    XCTAssertFalse(
+      SystemCommand.runLogging("test fail", executable: "/bin/sh", arguments: ["-c", "exit 1"]))
+  }
+
+  func testSanitizerCollapsesWhitespaceAndTrims() {
+    XCTAssertEqual(sanitizedCommandOutput("  hello\nworld\t!  "), "hello world !")
+  }
+
+  func testSanitizerBoundsLength() {
+    let long = String(repeating: "x", count: 500)
+    let bounded = sanitizedCommandOutput(long, maxLength: 200)
+    XCTAssertEqual(bounded.count, 201)  // 200 chars + the single ellipsis
+    XCTAssertTrue(bounded.hasSuffix("…"))
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260706-timing-shell-outs.json
+++ b/desktop/macos/changelog/unreleased/20260706-timing-shell-outs.json
@@ -1,0 +1,3 @@
+{
+  "change": "Made opening settings from the floating bar and focusing the follow-up input more reliable"
+}

--- a/desktop/macos/scripts/check-async-after-ratchet.py
+++ b/desktop/macos/scripts/check-async-after-ratchet.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Ratchet on `DispatchQueue.*.asyncAfter` calls in the floating-bar / PTT sources.
+
+BL-005 / S-14b: the floating control bar and push-to-talk manager coordinate UI
+and capture state through a large number of fixed-delay `asyncAfter(...)` calls.
+Fixed delays are fragile — they race the very transitions they try to sequence
+(a window that hasn't opened yet, a view that hasn't mounted, an animation still
+running), so they surface as intermittent "sometimes the field isn't focused" /
+"the switcher didn't reopen" bugs. Where a real signal exists (a window becoming
+key, a view lifecycle event, a state change) the transition should key off that
+signal instead.
+
+That migration is incremental and some `asyncAfter` uses are legitimate
+(cancellable watchdogs, reconnect backoffs, deliberate gesture/debounce windows),
+so this is an anti-regression ratchet, not a full sweep: it counts the
+`.asyncAfter(` call sites under the scanned root and FAILS if that count rises
+above the pinned baseline. The baseline may only shrink — every new timing-based
+transition must justify itself, and every conversion to a signal lowers the
+ceiling.
+
+What counts: an occurrence of `.asyncAfter(` in a `.swift` file under the scanned
+root. The leading dot + open paren deliberately excludes prose mentions of the
+word `asyncAfter` (e.g. in doc comments).
+
+Wiring (see also `scripts/pre-push` and `.github/workflows/lint.yml`):
+  - Pre-push: run automatically for pushes that touch the floating-bar sources.
+  - CI: a gated step in the Lint workflow.
+  - Manually:  python3 desktop/macos/scripts/check-async-after-ratchet.py
+  - Show the count / offenders:  ... --print
+
+Lowering the baseline: after converting call sites to signal-driven transitions,
+run with --print, then set BASELINE to the new (lower) number in the same commit.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+# Pinned baseline — the number of `.asyncAfter(` call sites remaining in the
+# scanned sources. MAY ONLY DECREASE. Raising it is a regression and must not be
+# done to make the gate pass; key the new transition off a real signal (a window
+# becoming key, a view lifecycle event, a state change) instead.
+BASELINE = 27
+
+# Scanned root, relative to the repo root. Covers the floating control bar and the
+# push-to-talk manager (which lives under FloatingControlBar/).
+SCAN_ROOT = "desktop/macos/Desktop/Sources/FloatingControlBar"
+
+# `.asyncAfter(` call site. The leading dot + open paren excludes prose mentions
+# of the word in comments (e.g. a backtick-quoted `asyncAfter`).
+ASYNC_AFTER_RE = re.compile(r"\.asyncAfter\(")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument(
+        "--root",
+        default=None,
+        help="Repository root (default: inferred from this script's location).",
+    )
+    parser.add_argument(
+        "--print",
+        dest="print_offenders",
+        action="store_true",
+        help="Print the current count and every offending file:line, then exit 0.",
+    )
+    return parser.parse_args()
+
+
+def repo_root(explicit: str | None) -> Path:
+    if explicit:
+        return Path(explicit).resolve()
+    # scripts/ -> desktop/macos -> desktop -> repo root
+    return Path(__file__).resolve().parents[3]
+
+
+def scan(root: Path) -> list[tuple[str, int, str]]:
+    """Return (relative_path, line_number, line_text) for each asyncAfter call."""
+    sources = root / SCAN_ROOT
+    offenders: list[tuple[str, int, str]] = []
+    for path in sorted(sources.rglob("*.swift")):
+        relative = path.relative_to(root).as_posix()
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        for lineno, line in enumerate(text.splitlines(), start=1):
+            for _ in ASYNC_AFTER_RE.finditer(line):
+                offenders.append((relative, lineno, line.strip()))
+    return offenders
+
+
+def main() -> int:
+    args = parse_args()
+    root = repo_root(args.root)
+    offenders = scan(root)
+    count = len(offenders)
+
+    if args.print_offenders:
+        for relative, lineno, line in offenders:
+            print(f"{relative}:{lineno}: {line}")
+        print(f"\n.asyncAfter( call sites: {count} (baseline {BASELINE})")
+        return 0
+
+    if count > BASELINE:
+        print(
+            f"FAIL: .asyncAfter( call sites rose to {count} (baseline {BASELINE}).",
+            file=sys.stderr,
+        )
+        print(
+            "Key the new transition off a real signal (window didBecomeKey, a "
+            "view lifecycle event, a state change / onChange) instead of a fixed "
+            "delay. If a delay is genuinely required (cancellable watchdog, "
+            "reconnect backoff, gesture/debounce window), discuss it in review.",
+            file=sys.stderr,
+        )
+        print(
+            "See offenders with: python3 desktop/macos/scripts/check-async-after-ratchet.py --print",
+            file=sys.stderr,
+        )
+        return 1
+
+    if count < BASELINE:
+        print(
+            f"NOTE: .asyncAfter( call sites dropped to {count} (baseline "
+            f"{BASELINE}). Lower BASELINE to {count} in "
+            "check-async-after-ratchet.py to ratchet the gain."
+        )
+        return 0
+
+    print(f"OK: .asyncAfter( call sites at baseline ({count}).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/desktop/macos/scripts/check-async-after-ratchet.py
+++ b/desktop/macos/scripts/check-async-after-ratchet.py
@@ -80,6 +80,14 @@ def repo_root(explicit: str | None) -> Path:
 def scan(root: Path) -> list[tuple[str, int, str]]:
     """Return (relative_path, line_number, line_text) for each asyncAfter call."""
     sources = root / SCAN_ROOT
+    if not sources.is_dir():
+        # Fail loud: a missing scan root (renamed/moved/wrong path) would make
+        # rglob return zero matches, drop the count below baseline, and pass —
+        # silently disabling the ratchet. Refuse to run instead.
+        raise SystemExit(
+            f"FAIL: scan root not found: {sources}. Fix SCAN_ROOT in "
+            "check-async-after-ratchet.py or the repository layout."
+        )
     offenders: list[tuple[str, int, str]] = []
     for path in sorted(sources.rglob("*.swift")):
         relative = path.relative_to(root).as_posix()

--- a/scripts/pre-push
+++ b/scripts/pre-push
@@ -506,6 +506,26 @@ check_desktop_userdefaults_ratchet_if_needed() {
   python3 desktop/macos/scripts/check-userdefaults-key-ratchet.py
 }
 
+check_desktop_async_after_ratchet_if_needed() {
+  # BL-005 / S-14b: fail if new fixed-delay asyncAfter calls are added to the
+  # floating-bar / PTT sources. Pure grep-count ratchet (no toolchain needed).
+  if [ "${PRE_PUSH_SKIP_DESKTOP_ASYNC_AFTER_RATCHET:-}" = "1" ]; then
+    echo "Skipping desktop asyncAfter ratchet because PRE_PUSH_SKIP_DESKTOP_ASYNC_AFTER_RATCHET=1."
+    return
+  fi
+
+  if ! changed_matches \
+    'desktop/macos/Desktop/Sources/FloatingControlBar/*.swift' \
+    'desktop/macos/Desktop/Sources/FloatingControlBar/**/*.swift' \
+    'desktop/macos/scripts/check-async-after-ratchet.py' \
+    'scripts/pre-push'
+  then
+    return
+  fi
+
+  python3 desktop/macos/scripts/check-async-after-ratchet.py
+}
+
 check_desktop_rust_if_needed() {
   local -a rust_files=()
   local file
@@ -595,6 +615,7 @@ run_step check_openapi_contract_if_needed
 run_step check_workflows_if_needed
 run_step check_desktop_swift_if_needed
 run_step check_desktop_userdefaults_ratchet_if_needed
+run_step check_desktop_async_after_ratchet_if_needed
 run_step check_desktop_rust_if_needed
 run_step check_desktop_launcher_tests_if_needed
 run_step check_desktop_tool_surfaces_if_needed


### PR DESCRIPTION
## BL-022 — surface swallowed privileged shell-out errors

Replace `try? process.run()` on privileged/system shell-outs (`tccutil`, `lsregister`, `sqlite3`-on-`TCC.db`, `xattr`) with a tested `SystemCommand` runner returning a structured outcome (`succeeded` / `failedToLaunch` / `exitedNonZero(code, stderr)`) and logging failures with context instead of dropping them — a silent provenance-strip failure previously broke future Sparkle updates invisibly. 6 call sites migrated across `OmiApp` + `AppState`. stderr is captured bounded + sanitized; permission-reset callers keep their existing `Bool` return (no new failure banner — none exists today, deferred).

## BL-005 — targeted timing determinism

Convert 3 fragile fixed-delay `asyncAfter` UI sequences in the floating bar to signal-driven transitions:
- `openFloatingBarSettings` + `activateMainAppWindow` fallback → key off `NSWindow.didBecomeKeyNotification` (synchronous fast-path when a main window is already key; one runloop hop so SwiftUI mounts the navigate receiver first).
- Follow-up input focus → view-lifecycle `.task`.

Intentional timing is kept (cancellable watchdogs, PTT finalization timeouts, reconnect backoff, gesture/debounce windows). Adds `check-async-after-ratchet.py` (baseline 27, scope `FloatingControlBar/`) wired into pre-push + the Lint workflow so new fixed delays can't creep in.

## Testing

- `SystemCommandTests` (6, hermetic via `/bin/sh` + a missing path), `FloatingBarTimingSignalTests` (3, source-scrape + in-suite ratchet mirror).
- `xcrun swift build -c debug` clean; `bash test.sh` green (297 Rust + 136 Swift suites).
- **Runtime:** BL-022 verified on a named bundle (structured shell-out logs at launch, no hang). BL-005 timing is compile/unit/logic-verified; a UI click-through smoke is recommended before relying on it (low-severity reliability change).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9129?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

