### PR TITLE
fix(desktop): redact Basic-auth and bare sk- keys in diagnostics export

### DIFF
--- a/desktop/macos/Desktop/Sources/DesktopDiagnosticsManager.swift
+++ b/desktop/macos/Desktop/Sources/DesktopDiagnosticsManager.swift
@@ -320,6 +320,10 @@ final class DesktopDiagnosticsManager {
       ("eyJ[A-Za-z0-9_-]+\\.[A-Za-z0-9_-]+\\.[A-Za-z0-9_-]+", "[redacted-jwt]"),
       // Authorization: Bearer <token>
       ("(?i)(bearer)\\s+[A-Za-z0-9._~+/=-]{8,}", "$1 [redacted]"),
+      // Authorization: Basic <base64 credentials>
+      ("(?i)(basic)\\s+[A-Za-z0-9+/=]{8,}", "$1 [redacted]"),
+      // Bare OpenAI-style API keys.
+      ("sk-[A-Za-z0-9_-]{20,}", "sk-[redacted]"),
       // key=..., token: ..., password="..." in query strings, JSON, or kv logs.
       (
         "(?i)(api[_-]?key|access[_-]?token|refresh[_-]?token|id[_-]?token|token|password|passwd|secret|client[_-]?secret|authorization)([\"']?\\s*[=:]\\s*[\"']?)[A-Za-z0-9._~+/=-]{6,}",

--- a/desktop/macos/Desktop/Sources/DesktopDiagnosticsManager.swift
+++ b/desktop/macos/Desktop/Sources/DesktopDiagnosticsManager.swift
@@ -320,8 +320,9 @@ final class DesktopDiagnosticsManager {
       ("eyJ[A-Za-z0-9_-]+\\.[A-Za-z0-9_-]+\\.[A-Za-z0-9_-]+", "[redacted-jwt]"),
       // Authorization: Bearer <token>
       ("(?i)(bearer)\\s+[A-Za-z0-9._~+/=-]{8,}", "$1 [redacted]"),
-      // Authorization: Basic <base64 credentials>
-      ("(?i)(basic)\\s+[A-Za-z0-9+/=]{8,}", "$1 [redacted]"),
+      // Authorization: Basic <base64 credentials>. Anchored to the header prefix
+      // so benign phrases like "basic settings" aren't over-redacted.
+      ("(?i)(authorization:\\s*basic)\\s+[A-Za-z0-9+/=]{8,}", "$1 [redacted]"),
       // Bare OpenAI-style API keys.
       ("sk-[A-Za-z0-9_-]{20,}", "sk-[redacted]"),
       // key=..., token: ..., password="..." in query strings, JSON, or kv logs.

--- a/desktop/macos/Desktop/Tests/DiagnosticsExportTests.swift
+++ b/desktop/macos/Desktop/Tests/DiagnosticsExportTests.swift
@@ -30,6 +30,9 @@ final class DiagnosticsExportTests: XCTestCase {
       "[10:00:01.000] [app] GET /v1/things?api_key=SUPERSECRETKEY123 status=200",
       "[10:00:02.000] [app] Authorization: Bearer BEARERTOKENabc123def456",
       "[10:00:03.000] [app] idToken=\(jwt)",
+      "[10:00:03.500] [app] Authorization: Basic dXNlcjpwYXNzd29yZA==",
+      "[10:00:03.750] [app] openai_key=sk-proj-1234567890abcdef1234567890abcdef",
+      "[10:00:03.900] [app] raw key sk-1234567890abcdef1234567890abcdef",
       "[10:00:04.000] [app] user tapped Report Issue",
     ].joined(separator: "\n")
     try logContents.write(toFile: logPath, atomically: true, encoding: .utf8)
@@ -40,6 +43,9 @@ final class DiagnosticsExportTests: XCTestCase {
     XCTAssertFalse(text.contains("SUPERSECRETKEY123"), "api_key value leaked")
     XCTAssertFalse(text.contains("BEARERTOKENabc123def456"), "bearer token leaked")
     XCTAssertFalse(text.contains(jwt), "JWT leaked")
+    XCTAssertFalse(text.contains("dXNlcjpwYXNzd29yZA=="), "basic auth leaked")
+    XCTAssertFalse(text.contains("sk-proj-1234567890abcdef1234567890abcdef"), "OpenAI key leaked")
+    XCTAssertFalse(text.contains("sk-1234567890abcdef1234567890abcdef"), "bare OpenAI key leaked")
     XCTAssertTrue(text.contains("[redacted"), "expected redaction markers")
 
     // Benign operational lines survive so the report stays useful.

--- a/desktop/macos/Desktop/Tests/DiagnosticsExportTests.swift
+++ b/desktop/macos/Desktop/Tests/DiagnosticsExportTests.swift
@@ -33,6 +33,7 @@ final class DiagnosticsExportTests: XCTestCase {
       "[10:00:03.500] [app] Authorization: Basic dXNlcjpwYXNzd29yZA==",
       "[10:00:03.750] [app] openai_key=sk-proj-1234567890abcdef1234567890abcdef",
       "[10:00:03.900] [app] raw key sk-1234567890abcdef1234567890abcdef",
+      "[10:00:03.950] [app] applied basic settings for the user",
       "[10:00:04.000] [app] user tapped Report Issue",
     ].joined(separator: "\n")
     try logContents.write(toFile: logPath, atomically: true, encoding: .utf8)
@@ -48,9 +49,11 @@ final class DiagnosticsExportTests: XCTestCase {
     XCTAssertFalse(text.contains("sk-1234567890abcdef1234567890abcdef"), "bare OpenAI key leaked")
     XCTAssertTrue(text.contains("[redacted"), "expected redaction markers")
 
-    // Benign operational lines survive so the report stays useful.
+    // Benign operational lines survive so the report stays useful — including
+    // "basic settings", which the Basic-auth pattern must not over-redact.
     XCTAssertTrue(text.contains("launched cleanly"))
     XCTAssertTrue(text.contains("user tapped Report Issue"))
+    XCTAssertTrue(text.contains("applied basic settings for the user"), "over-redacted benign 'basic'")
 
     // Metadata header is present and offline-safe.
     XCTAssertTrue(text.contains("# Omi Desktop Diagnostics"))

--- a/desktop/macos/changelog/unreleased/20260706-diagnostics-redaction-followup.json
+++ b/desktop/macos/changelog/unreleased/20260706-diagnostics-redaction-followup.json
@@ -1,0 +1,3 @@
+{
+  "change": "Local diagnostics export now also redacts bare OpenAI-style keys and Authorization Basic headers"
+}


### PR DESCRIPTION
## What

Extend the local diagnostics-export redactor to catch secret shapes it previously missed (follow-up to the redaction gap noted during the diagnostics-export work in #9106).

Adds redaction patterns for:
- `Authorization: Basic <base64>` credentials → `Basic [redacted]`
- Bare OpenAI-style API keys (`sk-…`) → `sk-[redacted]`

## Why

The offline "Save Diagnostics…" bundle is meant to be safe to share manually, but the redactor only masked JWTs, `Bearer` tokens, and `key=`/`token:` kv pairs — a bare `sk-` key or a `Basic` auth header would have survived into an exported bundle.

## Testing

`DiagnosticsExportTests` extended to assert the new shapes are masked; `bash test.sh` (desktop suite) green.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9130?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

