### PR TITLE
test(desktop): make settings-seed test hermetic (isolated HOME)

### DIFF
--- a/desktop/macos/tests/test-settings-seed.sh
+++ b/desktop/macos/tests/test-settings-seed.sh
@@ -26,10 +26,15 @@ assert_unset() {
 }
 
 cleanup_domains=()
+prefs_home="$(mktemp -d "${TMPDIR:-/tmp}/omi-settings-seed-home.XXXXXX")"
+mkdir -p "$prefs_home/Library/Preferences"
+export HOME="$prefs_home"
+export CFFIXED_USER_HOME="$prefs_home"
 cleanup() {
   for domain in "${cleanup_domains[@]}"; do
     defaults delete "$domain" >/dev/null 2>&1 || true
   done
+  rm -rf "$prefs_home"
 }
 trap cleanup EXIT
 
@@ -45,7 +50,7 @@ defaults write "$source_domain" shortcut_askOmiEnabled -bool true
 # Set the hidden kill switch in the source to verify it is NOT copied to targets.
 defaults write "$source_domain" disableSystemAudioCapture -bool true
 
-"$MACOS_DIR/scripts/omi-settings-seed.sh" "$quiet_target" "$source_domain" >/tmp/omi-settings-seed-quiet.out
+"$MACOS_DIR/scripts/omi-settings-seed.sh" "$quiet_target" "$source_domain" >"$prefs_home/omi-settings-seed-quiet.out"
 assert_defaults "$quiet_target" screenAnalysisEnabled 0
 assert_defaults "$quiet_target" transcriptionEnabled 0
 assert_defaults "$quiet_target" systemAudioCaptureMode never
@@ -55,7 +60,7 @@ assert_unset "$quiet_target" disableSystemAudioCapture
 assert_defaults "$quiet_target" shortcut_askOmiEnabled 1
 assert_unset "$quiet_target" hasCompletedFileIndexing
 
-OMI_DEV_EAGER_PERMISSIONS=1 "$MACOS_DIR/scripts/omi-settings-seed.sh" "$eager_target" "$source_domain" >/tmp/omi-settings-seed-eager.out
+OMI_DEV_EAGER_PERMISSIONS=1 "$MACOS_DIR/scripts/omi-settings-seed.sh" "$eager_target" "$source_domain" >"$prefs_home/omi-settings-seed-eager.out"
 assert_defaults "$eager_target" screenAnalysisEnabled 1
 assert_defaults "$eager_target" transcriptionEnabled 1
 assert_defaults "$eager_target" devLazyPermissionsEnabled 0
@@ -63,7 +68,7 @@ assert_unset "$eager_target" disableSystemAudioCapture
 assert_defaults "$eager_target" systemAudioCaptureMode always
 assert_unset "$eager_target" screenAnalysisAutoStartFixed_v2
 
-"$MACOS_DIR/scripts/omi-settings-seed.sh" "$missing_target" "com.omi.missing-source-$$" >/tmp/omi-settings-seed-missing.out
+"$MACOS_DIR/scripts/omi-settings-seed.sh" "$missing_target" "com.omi.missing-source-$$" >"$prefs_home/omi-settings-seed-missing.out"
 assert_defaults "$missing_target" screenAnalysisEnabled 0
 assert_defaults "$missing_target" transcriptionEnabled 0
 assert_defaults "$missing_target" devLazyPermissionsEnabled 1


### PR DESCRIPTION
## What

Make `test-settings-seed.sh` hermetic so it no longer reads or writes the developer's real macOS `defaults` (BL-029).

The test now runs against a throwaway `HOME` (`mktemp -d` + `export HOME`/`CFFIXED_USER_HOME`) and exercises the quiet, eager (`OMI_DEV_EAGER_PERMISSIONS=1`), and missing-source cases in isolation, cleaning up the temp home on exit.

## Why

The prior test touched the real user `defaults` domain, so it was non-hermetic — it could mutate developer state and behave differently depending on the machine's existing preferences.

## Testing

`bash desktop/macos/tests/test-settings-seed.sh` passes against the isolated home.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9131?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

