### PR TITLE
fix(desktop): stop notification startup repair loop on every launch/wake (#9082)

### DIFF
--- a/desktop/macos/Desktop/Sources/NotificationRegistrationRepair.swift
+++ b/desktop/macos/Desktop/Sources/NotificationRegistrationRepair.swift
@@ -3,6 +3,8 @@ import UserNotifications
 
 enum NotificationRegistrationRepair {
   static let repairedVersionKey = "notificationRegistrationRepairedAppVersion"
+  static let startupAuthorizationAttemptedVersionKey =
+    "notificationStartupAuthorizationAttemptedAppVersion"
 
   private static var isRepairing = false
   private static var pendingCompletions: [(Bool) -> Void] = []
@@ -26,6 +28,26 @@ enum NotificationRegistrationRepair {
     versionIdentifier: String = currentVersionIdentifier()
   ) {
     defaults.set(versionIdentifier, forKey: repairedVersionKey)
+  }
+
+  /// Whether the automatic startup notification-authorization request (which can
+  /// trigger a LaunchServices repair) should run this app version. This path fires
+  /// on every launch/re-activation/wake, so without a guard a user stuck at
+  /// `.notDetermined` re-runs the repair loop indefinitely (issue #9082). Attempt at
+  /// most once per installed version; user-initiated "Enable"/"Fix" flows are not
+  /// gated by this and can still retry on demand.
+  static func shouldAttemptStartupAuthorizationForCurrentVersion(
+    defaults: UserDefaults = .standard,
+    versionIdentifier: String = currentVersionIdentifier()
+  ) -> Bool {
+    defaults.string(forKey: startupAuthorizationAttemptedVersionKey) != versionIdentifier
+  }
+
+  static func markStartupAuthorizationAttemptedForCurrentVersion(
+    defaults: UserDefaults = .standard,
+    versionIdentifier: String = currentVersionIdentifier()
+  ) {
+    defaults.set(versionIdentifier, forKey: startupAuthorizationAttemptedVersionKey)
   }
 
   @MainActor

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift
@@ -265,6 +265,17 @@ public class ProactiveAssistantsPlugin: NSObject {
                     return
                 }
 
+                // startMonitoring runs on launch, re-activation, key load, and wake.
+                // A user stuck at .notDetermined (launch-disabled error) would otherwise
+                // re-run the LaunchServices repair loop on every one of those (issue #9082),
+                // so attempt the startup authorization at most once per installed version.
+                // The in-app "Enable"/"Fix" buttons remain unguarded for on-demand retries.
+                guard NotificationRegistrationRepair.shouldAttemptStartupAuthorizationForCurrentVersion() else {
+                    log("Skipping startup notification authorization request (already attempted this app version)")
+                    return
+                }
+                NotificationRegistrationRepair.markStartupAuthorizationAttemptedForCurrentVersion()
+
                 NotificationRegistrationRepair.requestAuthorizationRepairingLaunchServices(
                     reason: "launch_disabled_error_startup",
                     previousStatus: "notDetermined"

--- a/desktop/macos/Desktop/Tests/NotificationRegistrationRepairTests.swift
+++ b/desktop/macos/Desktop/Tests/NotificationRegistrationRepairTests.swift
@@ -32,4 +32,40 @@ final class NotificationRegistrationRepairTests: XCTestCase {
       )
     )
   }
+
+  // Regression for #9082: the automatic startup notification-authorization request
+  // must run at most once per installed version so a user stuck at .notDetermined
+  // does not re-trigger the LaunchServices repair loop on every launch/wake.
+  func testStartupAuthorizationAttemptedOnlyOncePerInstalledVersion() {
+    let suite = "NotificationRegistrationRepairTests.startupAuth"
+    let defaults = UserDefaults(suiteName: suite)!
+    defaults.removePersistentDomain(forName: suite)
+
+    XCTAssertTrue(
+      NotificationRegistrationRepair.shouldAttemptStartupAuthorizationForCurrentVersion(
+        defaults: defaults,
+        versionIdentifier: "0.12.0+12000"
+      )
+    )
+
+    NotificationRegistrationRepair.markStartupAuthorizationAttemptedForCurrentVersion(
+      defaults: defaults,
+      versionIdentifier: "0.12.0+12000"
+    )
+
+    // Same version (re-activation / wake / relaunch) must not re-attempt.
+    XCTAssertFalse(
+      NotificationRegistrationRepair.shouldAttemptStartupAuthorizationForCurrentVersion(
+        defaults: defaults,
+        versionIdentifier: "0.12.0+12000"
+      )
+    )
+    // A new version resets the one-shot attempt.
+    XCTAssertTrue(
+      NotificationRegistrationRepair.shouldAttemptStartupAuthorizationForCurrentVersion(
+        defaults: defaults,
+        versionIdentifier: "0.12.1+12001"
+      )
+    )
+  }
 }

--- a/desktop/macos/changelog/unreleased/20260706-notification-startup-repair-loop.json
+++ b/desktop/macos/changelog/unreleased/20260706-notification-startup-repair-loop.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed macOS notification setup repeatedly re-running its repair step on every launch and wake"
+}


### PR DESCRIPTION
## Bug (#9082)

macOS telemetry shows hundreds of users repeatedly hitting `Notification Repair Triggered` with `launch_disabled_error_startup` across launches:

| build | events | users |
|---|---:|---:|
| 0.11.507 | 705 | 366 |
| 0.12.0 | 583 | 341 |

## Root cause

`ProactiveAssistantsPlugin.startMonitoring` runs on **launch, re-activation, key load, and wake**. It requests notification authorization whenever the user is at `.notDetermined`. When macOS returns the launch-disabled error (`UNErrorDomain` code 1), `requestAuthorizationRepairingLaunchServices` runs a full LaunchServices repair (`lsregister -u`/`-f` + `killall usernoted` + `killall NotificationCenter`). A user stuck at `.notDetermined` therefore re-runs the entire repair loop on every one of those events — indefinitely — which is exactly the telemetry signature.

## Fix

Gate the **automatic startup** notification-authorization request behind a once-per-installed-version guard, mirroring the existing `repairOnceForCurrentVersion` pattern already used at app startup. First launch of a version attempts once; subsequent launches/wakes on the same version skip it. User-initiated **"Enable"/"Fix"** buttons are intentionally **not** gated and can still retry on demand.

This directly satisfies the acceptance criterion: *"Users do not repeatedly trigger the same startup repair loop across launches."*

## Testing

- `xcrun swift build -c debug --package-path Desktop` — succeeds (exit 0).
- Added `testStartupAuthorizationAttemptedOnlyOncePerInstalledVersion` regression test covering the one-shot-per-version guard (same version → skip, new version → reset).

🤖 automated by hourly watchdog; opened for review, not merged.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9143?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

