### PR TITLE
fix(app): null-safe reviews mapping — unblocks mobile release

### DIFF
--- a/app/lib/backend/schema/app.dart
+++ b/app/lib/backend/schema/app.dart
@@ -399,7 +399,7 @@ class App {
       capabilities: generated.capabilities.toSet(),
       chatPrompt: generated.chatPrompt,
       conversationPrompt: generated.memoryPrompt,
-      reviews: generated.reviews.map(AppReview.fromGenerated).toList(),
+      reviews: generated.reviews?.map(AppReview.fromGenerated).toList() ?? [],
       userReview: generated.userReview == null ? null : AppReview.fromGenerated(generated.userReview!),
       deleted: false,
       enabled: generated.enabled,


### PR DESCRIPTION
## Summary
- `generated.reviews` is `List<GeneratedAppReview>?` (nullable) but `App.fromGenerated()` called `.map()` without null-safe operator
- Causes compile error on Codemagic builds, blocking all mobile releases since PR #8895
- Fix: `generated.reviews?.map(...).toList() ?? []`

## Context
- All Codemagic builds (auto-deploy + tag-triggered) have been failing since this was introduced
- Last successful build: commit a52c4705f7 (Jul 6 02:44 UTC)
- Tag `v1.0.542+980-mobile-cm` is waiting — once this merges and auto-deploy succeeds, release continues

## Test plan
- [ ] `flutter analyze` passes (was passing before too — analyzer doesn't flag this with current settings)
- [ ] Codemagic auto-deploy succeeds after merge

_by AI for @beastoin_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9146?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

