### PR TITLE
Revert "fix(app): null-safe reviews mapping (#9146)"

### DIFF
--- a/app/lib/backend/schema/app.dart
+++ b/app/lib/backend/schema/app.dart
@@ -399,7 +399,7 @@ class App {
       capabilities: generated.capabilities.toSet(),
       chatPrompt: generated.chatPrompt,
       conversationPrompt: generated.memoryPrompt,
-      reviews: generated.reviews?.map(AppReview.fromGenerated).toList() ?? [],
+      reviews: generated.reviews.map(AppReview.fromGenerated).toList(),
       userReview: generated.userReview == null ? null : AppReview.fromGenerated(generated.userReview!),
       deleted: false,
       enabled: generated.enabled,


### PR DESCRIPTION
Reverts #9146 per manager request — the underlying issue (PR #8895) needs to be reworked by the original author with proper testing before we release.

_by AI for @beastoin_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9147?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

