### PR TITLE
fix(desktop): make LocalAgentProviderDetector hermetic, re-enable skipped test (#9033)

### DIFF
--- a/desktop/macos/Desktop/Sources/Providers/AgentRuntimeRouting.swift
+++ b/desktop/macos/Desktop/Sources/Providers/AgentRuntimeRouting.swift
@@ -93,11 +93,21 @@ struct LocalAgentProviderAvailability: Equatable {
 }
 
 enum LocalAgentProviderDetector {
+    /// Well-known absolute install locations probed in production. GUI-launched
+    /// apps inherit a minimal `PATH`, so these are searched directly rather than
+    /// via `PATH`. Injected (not hardcoded into the search) so detection stays
+    /// hermetic w.r.t. its inputs — tests pass `[]` to prove the missing path.
+    static let defaultSystemSearchDirectories = [
+        "/opt/homebrew/bin",
+        "/usr/local/bin",
+    ]
+
     static func availability(
         for provider: AgentPillsManager.DirectedProvider,
         environment: [String: String] = ProcessInfo.processInfo.environment,
         fileManager: FileManager = .default,
-        homeDirectory: String = NSHomeDirectory()
+        homeDirectory: String = NSHomeDirectory(),
+        systemSearchDirectories: [String] = defaultSystemSearchDirectories
     ) -> LocalAgentProviderAvailability {
         if let command = configuredCommand(for: provider, environment: environment) {
             return LocalAgentProviderAvailability(provider: provider, status: .available(command: command))
@@ -106,7 +116,8 @@ enum LocalAgentProviderDetector {
         if let path = firstExecutable(
             named: provider.executableName,
             fileManager: fileManager,
-            homeDirectory: homeDirectory
+            homeDirectory: homeDirectory,
+            systemSearchDirectories: systemSearchDirectories
         ) {
             return LocalAgentProviderAvailability(provider: provider, status: .available(command: path))
         }
@@ -118,9 +129,16 @@ enum LocalAgentProviderDetector {
         _ provider: AgentPillsManager.DirectedProvider,
         environment: [String: String] = ProcessInfo.processInfo.environment,
         fileManager: FileManager = .default,
-        homeDirectory: String = NSHomeDirectory()
+        homeDirectory: String = NSHomeDirectory(),
+        systemSearchDirectories: [String] = defaultSystemSearchDirectories
     ) -> Bool {
-        availability(for: provider, environment: environment, fileManager: fileManager, homeDirectory: homeDirectory).isAvailable
+        availability(
+            for: provider,
+            environment: environment,
+            fileManager: fileManager,
+            homeDirectory: homeDirectory,
+            systemSearchDirectories: systemSearchDirectories
+        ).isAvailable
     }
 
     private static func configuredCommand(
@@ -135,9 +153,13 @@ enum LocalAgentProviderDetector {
     private static func firstExecutable(
         named name: String,
         fileManager: FileManager,
-        homeDirectory: String
+        homeDirectory: String,
+        systemSearchDirectories: [String]
     ) -> String? {
-        for dir in adapterActivationSearchDirectories(homeDirectory: homeDirectory) {
+        for dir in adapterActivationSearchDirectories(
+            homeDirectory: homeDirectory,
+            systemSearchDirectories: systemSearchDirectories
+        ) {
             let path = (dir as NSString).appendingPathComponent(name)
             if fileManager.isExecutableFile(atPath: path) {
                 return path
@@ -146,14 +168,15 @@ enum LocalAgentProviderDetector {
         return nil
     }
 
-    private static func adapterActivationSearchDirectories(homeDirectory: String) -> [String] {
+    private static func adapterActivationSearchDirectories(
+        homeDirectory: String,
+        systemSearchDirectories: [String]
+    ) -> [String] {
         [
             "\(homeDirectory)/.hermes/hermes-agent/venv/bin",
             "\(homeDirectory)/.hermes/node/bin",
             "\(homeDirectory)/.hermes/hermes-agent",
             "\(homeDirectory)/.local/bin",
-            "/opt/homebrew/bin",
-            "/usr/local/bin",
-        ]
+        ] + systemSearchDirectories
     }
 }

--- a/desktop/macos/Desktop/Tests/PiMonoWiringTests.swift
+++ b/desktop/macos/Desktop/Tests/PiMonoWiringTests.swift
@@ -83,19 +83,27 @@ final class PiMonoWiringTests: XCTestCase {
     try "#!/bin/sh\nexit 0\n".write(to: executable, atomically: true, encoding: .utf8)
     try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: executable.path)
 
+    // Hermetic: inject empty system dirs so the arbitrary PATH entry is the only
+    // possible discovery source — proving PATH is ignored regardless of whether the
+    // agent happens to be installed in a system dir on the runner (issue #9033).
     let availability = LocalAgentProviderDetector.availability(
       for: .hermes,
       environment: ["PATH": root.path],
-      homeDirectory: "/tmp/missing-home")
+      homeDirectory: "/tmp/missing-home",
+      systemSearchDirectories: [])
 
     XCTAssertFalse(availability.isAvailable)
   }
 
   func testLocalAgentProviderDetectorMissingPromptIsUserFacing() {
+    // Hermetic: every discovery input is injected (no configured command, a
+    // missing home, and no system dirs), so the result can't depend on whether
+    // OpenClaw happens to be installed on the runner (issue #9033).
     let availability = LocalAgentProviderDetector.availability(
       for: .openclaw,
       environment: ["PATH": "/tmp/definitely-missing-\(UUID().uuidString)"],
-      homeDirectory: "/tmp/missing-home")
+      homeDirectory: "/tmp/missing-home",
+      systemSearchDirectories: [])
 
     XCTAssertFalse(availability.isAvailable)
     XCTAssertEqual(

--- a/desktop/macos/scripts/swift-test-suites.sh
+++ b/desktop/macos/scripts/swift-test-suites.sh
@@ -13,8 +13,6 @@ skip_for_suite() {
       echo "--skip APIClientRoutingTests/testDeleteConversationRoutesToPython" ;;
     ActionItemsFTSRepairTests)
       echo "--skip ActionItemsFTSRepairTests/testRepairToleratesMissingActionItemsFTSShadowTable" ;;
-    PiMonoWiringTests)
-      echo "--skip PiMonoWiringTests/testLocalAgentProviderDetectorMissingPromptIsUserFacing" ;;
   esac
 }
 

--- a/desktop/macos/test.sh
+++ b/desktop/macos/test.sh
@@ -48,10 +48,6 @@ cd "$SCRIPT_DIR"
 #       — macOS 26 system SQLite rejects `DELETE FROM sqlite_master` even with
 #         writable_schema=ON, blocking the test's corruption setup.
 #         https://github.com/BasedHardware/omi/issues/9032
-#   PiMonoWiringTests/testLocalAgentProviderDetectorMissingPromptIsUserFacing
-#       — the detector does not fully honor the injected environment/home, so the
-#         result depends on whether OpenClaw is installed on the runner.
-#         https://github.com/BasedHardware/omi/issues/9033
 "$SCRIPT_DIR/scripts/swift-test-suites.sh"
 echo ""
 


### PR DESCRIPTION
## What

Make `LocalAgentProviderDetector` (desktop macOS) hermetic with respect to its injected inputs, and re-enable the regression test that was skipped for being machine-dependent.

## Why

Per #9033, `PiMonoWiringTests/testLocalAgentProviderDetectorMissingPromptIsUserFacing` was `--skip`-ped because the detector's result depended on whether OpenClaw happened to be installed on the runner:

> The test injects `PATH` → a missing dir and `homeDirectory: /tmp/missing-home`, expecting the local agent (OpenClaw) to be reported unavailable. On a machine where OpenClaw is installed/discoverable, the assertion fails: `isAvailable == true` … the detector reaches outside the injected environment.

Root cause: `adapterActivationSearchDirectories` **hardcoded** `/opt/homebrew/bin` and `/usr/local/bin` into the search path. Those dirs depend on neither the injected `homeDirectory` nor `environment`, so with a missing home the detector still found an agent installed in a system dir → non-hermetic.

## Fix

Turn the well-known absolute install locations into an **injected dependency** — `defaultSystemSearchDirectories` (the same two dirs, same ordering) is the production default, so production behavior is unchanged (GUI apps inherit a minimal `PATH`, so these still need to be probed directly). Tests pass `systemSearchDirectories: []` to fully control discovery, making the result depend only on inputs.

- Re-enabled `testLocalAgentProviderDetectorMissingPromptIsUserFacing` (removed the skip in `scripts/swift-test-suites.sh` + the rationale block in `test.sh`).
- Also hardened `testLocalAgentProviderDetectorIgnoresArbitraryPathEntries`, which had the identical latent flaw (it only passed on CI because the runner lacks `hermes` in a system dir).

## Verified

`swift test` end-to-end is currently blocked by an **unrelated pre-existing compile error** on `main` — `Desktop/Sources/Chat/AgentBridge.swift` calls `runtime.query(...)` with removed locals (`sessionKey`, `omiSessionId`, `surfaceKind`, …) that no longer match the `surface:`-based signature. Reproduced on a clean `origin/main` checkout (`xcrun swift build --package-path Desktop` → 18 errors, none in files this PR touches).

So I verified the change by extracting the detector source **verbatim** into a standalone `swiftc` harness and running all four `PiMonoWiringTests` scenarios. This machine has both `openclaw` and `hermes` symlinked in `/opt/homebrew/bin`, i.e. exactly the condition that made the test flaky:

```
PASS: testLocalAgentProviderDetectorUsesExplicitCommand
PASS: testLocalAgentProviderDetectorFindsExecutableInActivationPath
PASS: testLocalAgentProviderDetectorIgnoresArbitraryPathEntries
PASS: testLocalAgentProviderDetectorMissingPromptIsUserFacing/isAvailable==false
PASS: testLocalAgentProviderDetectorMissingPromptIsUserFacing/setupPrompt
PASS: testLocalAgentProviderDetectorMissingPromptIsUserFacing/toolError
INFO: openclaw present in system dirs on this machine: true; default-dirs availability = true (the flaky coupling #9033 describes)
ALL SCENARIOS PASSED
```

The INFO line shows the old default-dirs path reports `available=true` for a missing home (the bug); the hermetic test path reports missing (the fix). Production discovery still works — the "found in activation path" scenario and the INFO line both confirm system-dir lookup is intact.

> **Note for reviewers:** the pre-existing `AgentBridge.swift` compile break on `main` looks like a stale call site from an incomplete `surface:` refactor and blocks the desktop build for everyone — worth a separate fix, but out of scope here.

Auto-generated from issue feedback by the mini issues-improver. Review before merge.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9150?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

