### PR TITLE
fix(backend): route pusher INFO logs to stdout so GKE stops tagging them ERROR (#9136)

### DIFF
--- a/backend/pusher/main.py
+++ b/backend/pusher/main.py
@@ -4,7 +4,11 @@ import os
 from contextlib import asynccontextmanager
 from typing import Any, AsyncIterator
 
-logging.basicConfig(level=logging.INFO)
+from utils.logging_config import configure_split_stream_logging
+
+# Route INFO/DEBUG to stdout and WARNING+ to stderr so GKE Cloud Logging does not
+# classify routine request logs as ERROR severity (issues #9136, #9138, #9135).
+configure_split_stream_logging(level=logging.INFO)
 
 import firebase_admin
 from fastapi import FastAPI

--- a/backend/tests/unit/test_logging_config.py
+++ b/backend/tests/unit/test_logging_config.py
@@ -1,0 +1,55 @@
+import io
+import logging
+
+import pytest
+
+from utils.logging_config import configure_split_stream_logging
+
+
+@pytest.fixture
+def restore_root_logging():
+    root = logging.getLogger()
+    saved_handlers = list(root.handlers)
+    saved_level = root.level
+    try:
+        yield
+    finally:
+        for handler in list(root.handlers):
+            root.removeHandler(handler)
+        for handler in saved_handlers:
+            root.addHandler(handler)
+        root.setLevel(saved_level)
+
+
+def test_info_goes_to_stdout_and_errors_to_stderr(restore_root_logging):
+    out, err = io.StringIO(), io.StringIO()
+    configure_split_stream_logging(stdout=out, stderr=err)
+
+    logger = logging.getLogger("pusher.test")
+    logger.info("routine request line")
+    logger.warning("something suspicious")
+    logger.error("real failure")
+
+    stdout_text = out.getvalue()
+    stderr_text = err.getvalue()
+
+    # INFO must NOT land on stderr (which GKE would tag as ERROR severity).
+    assert "routine request line" in stdout_text
+    assert "routine request line" not in stderr_text
+
+    # WARNING and ERROR must land on stderr and stay off stdout.
+    assert "something suspicious" in stderr_text
+    assert "real failure" in stderr_text
+    assert "something suspicious" not in stdout_text
+    assert "real failure" not in stdout_text
+
+
+def test_replaces_existing_root_handlers(restore_root_logging):
+    root = logging.getLogger()
+    sentinel = logging.NullHandler()
+    root.addHandler(sentinel)
+
+    configure_split_stream_logging(stdout=io.StringIO(), stderr=io.StringIO())
+
+    assert sentinel not in root.handlers
+    assert len(root.handlers) == 2

--- a/backend/utils/logging_config.py
+++ b/backend/utils/logging_config.py
@@ -1,0 +1,62 @@
+"""Severity-aware logging config for services running on GKE / Cloud Logging.
+
+On GKE the Cloud Logging agent classifies anything a container writes to
+**stderr** as ERROR severity, and stdout as INFO/DEFAULT. Python's default
+``logging.StreamHandler`` (and ``logging.basicConfig``) targets stderr, so
+routine INFO request logs were being ingested as ERROR — drowning out real
+failures and producing false-positive alert noise (issues #9136, #9138, #9135).
+
+``configure_split_stream_logging`` routes records below WARNING to stdout and
+WARNING/ERROR/CRITICAL to stderr so Cloud Logging severities map correctly,
+while preserving the default ``levelname:name:message`` format.
+"""
+
+import logging
+import sys
+from typing import Optional, TextIO
+
+
+class _MaxLevelFilter(logging.Filter):
+    """Only allow records strictly below ``level`` (keeps errors off stdout)."""
+
+    def __init__(self, level: int) -> None:
+        super().__init__()
+        self._level = level
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        return record.levelno < self._level
+
+
+def configure_split_stream_logging(
+    level: int = logging.INFO,
+    *,
+    stdout: Optional[TextIO] = None,
+    stderr: Optional[TextIO] = None,
+) -> None:
+    """Configure the root logger to split records across stdout/stderr by severity.
+
+    INFO/DEBUG go to stdout (Cloud Logging severity INFO); WARNING and above go
+    to stderr (severity ERROR). Replaces any existing root handlers so it is safe
+    to call in place of ``logging.basicConfig``.
+    """
+    out_stream = stdout if stdout is not None else sys.stdout
+    err_stream = stderr if stderr is not None else sys.stderr
+
+    root = logging.getLogger()
+    root.setLevel(level)
+    for handler in list(root.handlers):
+        root.removeHandler(handler)
+
+    formatter = logging.Formatter(logging.BASIC_FORMAT)
+
+    stdout_handler = logging.StreamHandler(out_stream)
+    stdout_handler.setLevel(level)
+    stdout_handler.addFilter(_MaxLevelFilter(logging.WARNING))
+    stdout_handler.setFormatter(formatter)
+
+    stderr_handler = logging.StreamHandler(err_stream)
+    stderr_handler.setLevel(logging.WARNING)
+    stderr_handler.setFormatter(formatter)
+
+    root.addHandler(stdout_handler)
+    root.addHandler(stderr_handler)


### PR DESCRIPTION
## Bug
Prod monitoring noise: pusher (and other backend services) emit routine INFO request lines that Cloud Logging ingests at **ERROR severity**, drowning out real failures and driving false-positive alerts. Reported across three issues:
- #9136 (pusher pods / log noise)
- #9138 (prod monitoring severity noise)
- #9135 (desktop-backend, same INFO-at-ERROR pattern)

## Root cause
On GKE the Cloud Logging agent classifies whatever a container writes to **stderr** as `ERROR` severity and **stdout** as `INFO`. Python's `logging.basicConfig(level=logging.INFO)` installs a `StreamHandler` that targets **stderr**, so *every* log line — including INFO — is tagged ERROR.

## Fix
- Add `backend/utils/logging_config.py` → `configure_split_stream_logging()`: routes `INFO`/`DEBUG` to **stdout** and `WARNING`/`ERROR`/`CRITICAL` to **stderr**, preserving the default `levelname:name:message` format. Pure module, no import-time side effects, reusable by other services.
- `pusher/main.py` uses it in place of `logging.basicConfig`. Real warnings/errors keep ERROR severity; routine INFO no longer does.

Scoped to the named service (pusher) to keep blast radius small; `backend/main.py`, `agent-proxy`, `diarizer`, and `parakeet` share the same defect and can adopt this helper in follow-ups.

## Verification
`python3 -m pytest tests/unit/test_logging_config.py` → **2 passed**. The regression test asserts INFO stays off stderr and WARNING/ERROR stay off stdout. `scan_import_time_side_effects.py` → 0 violations; black-clean.

Note: severity classification only manifests in the live GKE Cloud Logging pipeline, so the end-to-end severity relabel is **UNVERIFIED** outside prod — the unit test covers the stream-routing behavior that drives it.

🤖 automated by hourly watchdog; opened for review, not merged.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9154?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

