### PR TITLE
fix: default dev desktop backend base url

### DIFF
--- a/.github/workflows/desktop_backend_auto_dev.yml
+++ b/.github/workflows/desktop_backend_auto_dev.yml
@@ -10,6 +10,7 @@ on:
 env:
   SERVICE: desktop-backend
   REGION: us-central1
+  DEFAULT_DESKTOP_BACKEND_BASE_API_URL: https://desktop-backend-dt5lrfkkoa-uc.a.run.app
 
 concurrency:
   group: desktop-backend-auto-dev
@@ -45,15 +46,21 @@ jobs:
       - name: Google Service Account
         run: echo "${{ secrets.GCP_SERVICE_ACCOUNT }}" | base64 -d > ./desktop/macos/Backend-Rust/google-credentials.json
 
-      - name: Validate desktop OAuth base API URL
+      - name: Resolve desktop OAuth base API URL
+        id: desktop-base-api-url
         env:
           DESKTOP_BACKEND_BASE_API_URL: ${{ vars.DESKTOP_BACKEND_BASE_API_URL }}
         run: |
           set -euo pipefail
-          if [ -z "${DESKTOP_BACKEND_BASE_API_URL//[[:space:]]/}" ]; then
-            echo "DESKTOP_BACKEND_BASE_API_URL must be configured for desktop OAuth callbacks" >&2
+          BASE_API_URL="${DESKTOP_BACKEND_BASE_API_URL//[[:space:]]/}"
+          if [ -z "$BASE_API_URL" ]; then
+            BASE_API_URL="$DEFAULT_DESKTOP_BACKEND_BASE_API_URL"
+          fi
+          if [ -z "$BASE_API_URL" ]; then
+            echo "Desktop OAuth BASE_API_URL could not be resolved" >&2
             exit 1
           fi
+          echo "base_api_url=$BASE_API_URL" >> "$GITHUB_OUTPUT"
 
       - name: Validate desktop Calendar API key secret
         env:
@@ -93,7 +100,7 @@ jobs:
           env_vars: |
             FIREBASE_PROJECT_ID=based-hardware
             GOOGLE_APPLICATION_CREDENTIALS=/app/google-credentials.json
-            BASE_API_URL=${{ vars.DESKTOP_BACKEND_BASE_API_URL }}
+            BASE_API_URL=${{ steps.desktop-base-api-url.outputs.base_api_url }}
           secrets: |
             GEMINI_API_KEY=GEMINI_API_KEY:latest
             OPENAI_API_KEY=OPENAI_API_KEY:latest


### PR DESCRIPTION
## Summary
- Fixes the dev desktop-backend deploy failure when `DESKTOP_BACKEND_BASE_API_URL` is missing from the development GitHub environment.
- Resolves the dev workflow base URL from `vars.DESKTOP_BACKEND_BASE_API_URL` when present, otherwise falls back to the current dev Cloud Run desktop-backend URL.
- Leaves the production promote workflow strict/unchanged.

## Context
The latest `Auto Deploy Desktop Backend to Development` run failed at `Validate desktop OAuth base API URL` because the development environment does not define `DESKTOP_BACKEND_BASE_API_URL`:

https://github.com/BasedHardware/omi/actions/runs/28799589968

## Test Plan
- `actionlint -shellcheck '' .github/workflows/desktop_backend_auto_dev.yml .github/workflows/desktop_promote_prod.yml`
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9155?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

