### PR TITLE
feat(desktop/automation): add PTT + task-CRUD bridge actions for headless MIC-01/TASK-01-03

### DIFF
--- a/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
+++ b/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
@@ -400,6 +400,25 @@ final class DesktopAutomationActionRegistry {
       return ["enabled": enabled ? "true" : "false"]
     }
 
+    // Drive the real push-to-talk state machine headlessly (MIC-01). ptt_start begins
+    // capture like the shortcut key-down; ptt_stop finalizes like a long-hold release.
+    // Releasing with no mic audio exercises the empty-batch release path — it must end
+    // the turn with a hint, not hang. Both hit the exact private startListening/finalize
+    // the shortcut handler calls, so no synthetic key events or cursor are involved.
+    register(
+      name: "ptt_start",
+      summary: "Begin a push-to-talk capture (mirrors the PTT shortcut key-down)"
+    ) { _ in
+      PushToTalkManager.shared.beginPushToTalkForAutomation()
+    }
+
+    register(
+      name: "ptt_stop",
+      summary: "Finalize the in-progress push-to-talk capture (mirrors a long-hold release)"
+    ) { _ in
+      PushToTalkManager.shared.endPushToTalkForAutomation()
+    }
+
     // Fake-voice end-to-end test: inject a raw PCM16/16kHz-mono file through the
     // real realtime omni STT path and return the transcript. No mic, no human.
     register(

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
@@ -473,6 +473,31 @@ class PushToTalkManager: ObservableObject {
     stopListening()
   }
 
+  // MARK: - Automation (headless PTT for the desktop bridge)
+
+  /// Begin a push-to-talk capture exactly as the shortcut key-down does
+  /// (`handleShortcutDown` → `startListening`), so the automation bridge can drive
+  /// MIC-01 without synthetic key events. `startListening()`'s own guard makes this a
+  /// no-op when PTT is busy; the returned state lets the caller confirm. Pairs with
+  /// `endPushToTalkForAutomation()`.
+  @discardableResult
+  func beginPushToTalkForAutomation() -> [String: String] {
+    startListening()
+    return ["state": "\(state)", "listening": state == .listening ? "true" : "false"]
+  }
+
+  /// Release an in-progress push-to-talk capture the same way a long-hold key-up does
+  /// (`handleShortcutUp` .listening branch → `finalize`), producing the final
+  /// transcript. Releasing with no captured audio exercises the empty-batch path,
+  /// which must end the turn with a hint rather than hang. No-op unless a capture is
+  /// active.
+  @discardableResult
+  func endPushToTalkForAutomation() -> [String: String] {
+    let wasActive = state == .listening || state == .lockedListening
+    if wasActive { finalize() }
+    return ["state": "\(state)", "finalized": wasActive ? "true" : "false"]
+  }
+
   private var finalizedMode: String = "hold"
 
   private func currentPTTMode() -> String {

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/TasksPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/TasksPage.swift
@@ -2132,7 +2132,7 @@ class TasksViewModel: ObservableObject {
 
         registry.register(
             name: "create_task",
-            summary: "Create a task through the genuine store path; returns its id",
+            summary: "Create a task through the genuine store path; waits for the backend id (see 'synced') and returns it",
             params: ["description", "priority"]
         ) { [weak self] params in
             guard let self else { return ["error": "tasks view model deallocated"] }
@@ -2142,26 +2142,43 @@ class TasksViewModel: ObservableObject {
                 description: desc, dueAt: nil, priority: params["priority"], tags: nil)
             else { return ["error": "create failed"] }
             self.recomputeAllCaches()
-            return ["id": created.id, "description": created.description]
+            // store.createTask is local-first: it returns a transient "local_<rowid>" id and
+            // syncs in the background. Hand back the stable backend id once the sync lands so
+            // follow-up-by-id and reorder persistence (which skips "local_" ids) both work.
+            let stableId = await self.resolveStableTaskIdsForAutomation([created.id], timeoutSeconds: 6).first ?? created.id
+            return [
+                "id": stableId,
+                "synced": stableId.hasPrefix("local_") ? "false" : "true",
+                "description": created.description,
+            ]
         }
 
         registry.register(
             name: "seed_tasks",
-            summary: "Create N tasks quickly for reorder/stress testing; returns the created ids",
+            summary: "Create N tasks for reorder/stress testing; waits for backend ids so they are reorder-persistable; returns synced count + ids",
             params: ["count", "prefix"]
         ) { [weak self] params in
             guard let self else { return ["error": "tasks view model deallocated"] }
             let count = max(0, min(Int(params["count"] ?? "") ?? 5, 300))
             let prefix = params["prefix"] ?? "Automation task"
-            var ids: [String] = []
+            var localIds: [String] = []
             for i in 0..<count {
                 if let created = await self.store.createTask(
                     description: "\(prefix) \(i + 1)", dueAt: nil, priority: nil, tags: nil) {
-                    ids.append(created.id)
+                    localIds.append(created.id)
                 }
             }
             self.recomputeAllCaches()
-            return ["created": String(ids.count), "ids": ids.joined(separator: ",")]
+            // Wait (bounded) for the background syncs so seeded tasks carry backend ids —
+            // reorder persistence skips "local_" ids, so unsynced seeds would not persist.
+            let ids = await self.resolveStableTaskIdsForAutomation(
+                localIds, timeoutSeconds: min(10 + Double(count) * 0.1, 30))
+            let syncedCount = ids.filter { !$0.hasPrefix("local_") }.count
+            return [
+                "created": String(ids.count),
+                "synced": String(syncedCount),
+                "ids": ids.joined(separator: ","),
+            ]
         }
 
         registry.register(
@@ -2197,7 +2214,9 @@ class TasksViewModel: ObservableObject {
             await self.ensureTasksLoadedForAutomation()
             guard let id = params["id"], let task = self.store.tasks.first(where: { $0.id == id })
             else { return ["error": "task not found: \(params["id"] ?? "")"] }
-            let index = Int(params["index"] ?? "") ?? 0
+            // moveTask only clamps the upper bound before Array.insert(at:), so a negative
+            // index would crash the bridge; clamp to >= 0 for deterministic behavior.
+            let index = max(0, Int(params["index"] ?? "") ?? 0)
             let category = Self.automationCategory(params["category"]) ?? .today
             self.moveTask(task, toIndex: index, inCategory: category)
             await self.flushSortOrderSyncForAutomation()
@@ -2214,13 +2233,15 @@ class TasksViewModel: ObservableObject {
             let limit = Int(params["limit"] ?? "") ?? 500
             let items: [TaskActionItem]
             do {
+                // Pass `category` into the SQLite query, which matches both the `category`
+                // column and serialized tags in `tagsJson` (an in-memory `== category`
+                // post-filter would miss tag-categorized items and over-fetch).
                 items = try await ActionItemStorage.shared.getLocalActionItems(
-                    limit: limit, completed: includeCompleted ? nil : false)
+                    limit: limit, completed: includeCompleted ? nil : false, category: params["category"])
             } catch {
                 return ["error": "sqlite read failed: \(error.localizedDescription)"]
             }
-            let filtered = params["category"].map { cat in items.filter { $0.category == cat } } ?? items
-            let sorted = filtered.sorted { ($0.sortOrder ?? Int.max) < ($1.sortOrder ?? Int.max) }
+            let sorted = items.sorted { ($0.sortOrder ?? Int.max) < ($1.sortOrder ?? Int.max) }
             let rows: [[String: Any]] = sorted.map { t in
                 [
                     "id": t.id,
@@ -2252,6 +2273,38 @@ class TasksViewModel: ObservableObject {
     private func flushSortOrderSyncForAutomation() async {
         sortOrderSyncTask?.cancel()
         await syncSortOrders()
+    }
+
+    /// Resolve automation-created tasks to their stable backend ids. `store.createTask`
+    /// is local-first: it returns a `"local_<rowid>"` id and syncs to the backend in the
+    /// background, which sets `backendId` on the same SQLite row (`markSynced`), so the
+    /// task's string id flips from `"local_<rowid>"` to the backend id. This polls each
+    /// stable rowid until its `backendId` lands (or a shared deadline elapses), returning
+    /// the backend id where synced and the original `"local_"` id otherwise. Ids that are
+    /// already backend ids pass through untouched.
+    private func resolveStableTaskIdsForAutomation(
+        _ ids: [String], timeoutSeconds: Double
+    ) async -> [String] {
+        let rowIds: [Int64?] = ids.map { id in
+            guard id.hasPrefix("local_") else { return nil }
+            return Int64(id.dropFirst("local_".count))
+        }
+        var resolved = ids
+        var pending = Set(rowIds.indices.filter { rowIds[$0] != nil })
+        let deadline = Date().addingTimeInterval(timeoutSeconds)
+        while !pending.isEmpty, Date() < deadline {
+            for i in Array(pending) {
+                guard let rowId = rowIds[i] else { continue }
+                if let record = try? await ActionItemStorage.shared.getActionItem(id: rowId),
+                    let backendId = record.backendId, !backendId.isEmpty {
+                    resolved[i] = backendId
+                    pending.remove(i)
+                }
+            }
+            if pending.isEmpty { break }
+            try? await Task.sleep(nanoseconds: 200_000_000)
+        }
+        return resolved
     }
 
     /// Map a friendly automation category key (today|tomorrow|later|nodeadline) to a

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/TasksPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/TasksPage.swift
@@ -2183,14 +2183,20 @@ class TasksViewModel: ObservableObject {
 
         registry.register(
             name: "toggle_task",
-            summary: "Toggle a task's completed state by id (mirrors the checkbox)",
+            summary: "Toggle a task's completed state by id (mirrors the checkbox); returns the actual post-toggle state",
             params: ["id"]
         ) { [weak self] params in
             guard let self else { return ["error": "tasks view model deallocated"] }
+            // Load from SQLite first so a headless caller (Tasks page never opened) resolves
+            // the task instead of getting a spurious "not found".
+            await self.ensureTasksLoadedForAutomation()
             guard let id = params["id"], let task = self.store.tasks.first(where: { $0.id == id })
             else { return ["error": "task not found: \(params["id"] ?? "")"] }
             await self.toggleTask(task)
-            return ["id": id, "completed": (!task.completed) ? "true" : "false"]
+            // Report the real post-toggle state read back from the store rather than the
+            // assumed negation — TasksStore leaves the prior state if the local write fails.
+            let completed = self.store.tasks.first(where: { $0.id == id })?.completed ?? !task.completed
+            return ["id": id, "completed": completed ? "true" : "false"]
         }
 
         registry.register(
@@ -2199,6 +2205,9 @@ class TasksViewModel: ObservableObject {
             params: ["id"]
         ) { [weak self] params in
             guard let self else { return ["error": "tasks view model deallocated"] }
+            // Load from SQLite first so a headless caller resolves the task instead of a
+            // spurious "not found" when the Tasks page was never opened.
+            await self.ensureTasksLoadedForAutomation()
             guard let id = params["id"], let task = self.store.tasks.first(where: { $0.id == id })
             else { return ["error": "task not found: \(params["id"] ?? "")"] }
             await self.deleteTask(task)
@@ -2226,18 +2235,19 @@ class TasksViewModel: ObservableObject {
 
         registry.register(
             name: "dump_tasks",
-            summary: "Snapshot tasks from SQLite (id, description, completed, sortOrder, category) sorted by sortOrder — proves reorder/CRUD persistence",
-            params: ["includeCompleted", "category", "limit"]
+            summary: "Snapshot tasks from SQLite (id, description, completed, sortOrder, category) sorted by sortOrder — proves reorder/CRUD persistence. Returns every task; filter client-side on the per-row category field",
+            params: ["includeCompleted", "limit"]
         ) { params in
             let includeCompleted = ["true", "1", "yes"].contains(params["includeCompleted"]?.lowercased() ?? "")
             let limit = Int(params["limit"] ?? "") ?? 500
             let items: [TaskActionItem]
             do {
-                // Pass `category` into the SQLite query, which matches both the `category`
-                // column and serialized tags in `tagsJson` (an in-memory `== category`
-                // post-filter would miss tag-categorized items and over-fetch).
+                // No category filter here: `category` means the due-date display bucket in
+                // reorder_task, but the stored classification/tags here — overloading one
+                // param name for two concepts is a footgun. Return all rows (each carries
+                // its own `category`) and let the caller filter.
                 items = try await ActionItemStorage.shared.getLocalActionItems(
-                    limit: limit, completed: includeCompleted ? nil : false, category: params["category"])
+                    limit: limit, completed: includeCompleted ? nil : false)
             } catch {
                 return ["error": "sqlite read failed: \(error.localizedDescription)"]
             }

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/TasksPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/TasksPage.swift
@@ -2114,6 +2114,158 @@ class TasksViewModel: ObservableObject {
         showingCreateTask = false
     }
 
+    // MARK: - Automation (headless task CRUD + reorder for the desktop bridge)
+
+    private var didRegisterAutomationActions = false
+
+    /// Register task actions on the desktop automation registry so omi-ctl can drive
+    /// TASK-01/02/03 headlessly against this genuine, long-lived view model (the one
+    /// `ViewModelContainer` owns). Each action routes through the same store / view-model
+    /// path the UI uses — create/toggle/delete via the store, reorder via `moveTask` plus
+    /// the debounced sortOrder sync (flushed here for a deterministic persistence check) —
+    /// and `dump_tasks` reads back from SQLite so callers can prove the write landed.
+    /// The caller gates this on `DesktopAutomationLaunchOptions.isEnabled` (never on prod).
+    func registerAutomationActions() {
+        guard !didRegisterAutomationActions else { return }
+        didRegisterAutomationActions = true
+        let registry = DesktopAutomationActionRegistry.shared
+
+        registry.register(
+            name: "create_task",
+            summary: "Create a task through the genuine store path; returns its id",
+            params: ["description", "priority"]
+        ) { [weak self] params in
+            guard let self else { return ["error": "tasks view model deallocated"] }
+            let trimmed = params["description"]?.trimmingCharacters(in: .whitespacesAndNewlines)
+            let desc = (trimmed?.isEmpty == false ? trimmed! : "Automation task")
+            guard let created = await self.store.createTask(
+                description: desc, dueAt: nil, priority: params["priority"], tags: nil)
+            else { return ["error": "create failed"] }
+            self.recomputeAllCaches()
+            return ["id": created.id, "description": created.description]
+        }
+
+        registry.register(
+            name: "seed_tasks",
+            summary: "Create N tasks quickly for reorder/stress testing; returns the created ids",
+            params: ["count", "prefix"]
+        ) { [weak self] params in
+            guard let self else { return ["error": "tasks view model deallocated"] }
+            let count = max(0, min(Int(params["count"] ?? "") ?? 5, 300))
+            let prefix = params["prefix"] ?? "Automation task"
+            var ids: [String] = []
+            for i in 0..<count {
+                if let created = await self.store.createTask(
+                    description: "\(prefix) \(i + 1)", dueAt: nil, priority: nil, tags: nil) {
+                    ids.append(created.id)
+                }
+            }
+            self.recomputeAllCaches()
+            return ["created": String(ids.count), "ids": ids.joined(separator: ",")]
+        }
+
+        registry.register(
+            name: "toggle_task",
+            summary: "Toggle a task's completed state by id (mirrors the checkbox)",
+            params: ["id"]
+        ) { [weak self] params in
+            guard let self else { return ["error": "tasks view model deallocated"] }
+            guard let id = params["id"], let task = self.store.tasks.first(where: { $0.id == id })
+            else { return ["error": "task not found: \(params["id"] ?? "")"] }
+            await self.toggleTask(task)
+            return ["id": id, "completed": (!task.completed) ? "true" : "false"]
+        }
+
+        registry.register(
+            name: "delete_task",
+            summary: "Delete a task by id (mirrors swipe / menu delete)",
+            params: ["id"]
+        ) { [weak self] params in
+            guard let self else { return ["error": "tasks view model deallocated"] }
+            guard let id = params["id"], let task = self.store.tasks.first(where: { $0.id == id })
+            else { return ["error": "task not found: \(params["id"] ?? "")"] }
+            await self.deleteTask(task)
+            return ["id": id, "deleted": "true"]
+        }
+
+        registry.register(
+            name: "reorder_task",
+            summary: "Move a task to a new index within a category (today|tomorrow|later|nodeadline) via the real drag path, flush the sortOrder sync to SQLite + backend, and return the resulting order",
+            params: ["id", "index", "category"]
+        ) { [weak self] params in
+            guard let self else { return ["error": "tasks view model deallocated"] }
+            await self.ensureTasksLoadedForAutomation()
+            guard let id = params["id"], let task = self.store.tasks.first(where: { $0.id == id })
+            else { return ["error": "task not found: \(params["id"] ?? "")"] }
+            let index = Int(params["index"] ?? "") ?? 0
+            let category = Self.automationCategory(params["category"]) ?? .today
+            self.moveTask(task, toIndex: index, inCategory: category)
+            await self.flushSortOrderSyncForAutomation()
+            let order = self.getOrderedTasks(for: category).map(\.id).joined(separator: ",")
+            return ["id": id, "category": category.rawValue, "order": order]
+        }
+
+        registry.register(
+            name: "dump_tasks",
+            summary: "Snapshot tasks from SQLite (id, description, completed, sortOrder, category) sorted by sortOrder — proves reorder/CRUD persistence",
+            params: ["includeCompleted", "category", "limit"]
+        ) { params in
+            let includeCompleted = ["true", "1", "yes"].contains(params["includeCompleted"]?.lowercased() ?? "")
+            let limit = Int(params["limit"] ?? "") ?? 500
+            let items: [TaskActionItem]
+            do {
+                items = try await ActionItemStorage.shared.getLocalActionItems(
+                    limit: limit, completed: includeCompleted ? nil : false)
+            } catch {
+                return ["error": "sqlite read failed: \(error.localizedDescription)"]
+            }
+            let filtered = params["category"].map { cat in items.filter { $0.category == cat } } ?? items
+            let sorted = filtered.sorted { ($0.sortOrder ?? Int.max) < ($1.sortOrder ?? Int.max) }
+            let rows: [[String: Any]] = sorted.map { t in
+                [
+                    "id": t.id,
+                    "description": t.description,
+                    "completed": t.completed,
+                    "sortOrder": t.sortOrder ?? -1,
+                    "category": t.category ?? "",
+                ]
+            }
+            let json = (try? JSONSerialization.data(withJSONObject: rows))
+                .flatMap { String(data: $0, encoding: .utf8) } ?? "[]"
+            return ["count": String(sorted.count), "tasks": json]
+        }
+    }
+
+    /// Ensure the store + category caches are populated before a headless reorder, so
+    /// `moveTask` operates on real ordering rather than an empty category. Cheap once
+    /// tasks are already loaded.
+    private func ensureTasksLoadedForAutomation() async {
+        if store.tasks.isEmpty {
+            await store.loadTasks()
+        }
+        recomputeAllCaches()
+    }
+
+    /// Cancel the debounced sortOrder sync and run it now, so an automation caller can
+    /// deterministically observe the SQLite + backend write instead of racing the 500ms
+    /// debounce window.
+    private func flushSortOrderSyncForAutomation() async {
+        sortOrderSyncTask?.cancel()
+        await syncSortOrders()
+    }
+
+    /// Map a friendly automation category key (today|tomorrow|later|nodeadline) to a
+    /// `TaskCategory`. Case-insensitive; nil for unknown input.
+    private static func automationCategory(_ raw: String?) -> TaskCategory? {
+        switch raw?.lowercased() {
+        case "today": return .today
+        case "tomorrow": return .tomorrow
+        case "later": return .later
+        case "nodeadline", "no_deadline", "none": return .noDeadline
+        default: return nil
+        }
+    }
+
     func updateTaskDetails(
         _ task: TaskActionItem,
         description: String? = nil,

--- a/desktop/macos/Desktop/Sources/ViewModelContainer.swift
+++ b/desktop/macos/Desktop/Sources/ViewModelContainer.swift
@@ -29,6 +29,14 @@ class ViewModelContainer: ObservableObject {
         chatProvider = provider
         taskChatCoordinator = TaskChatCoordinator(chatProvider: provider)
         ChatProvider.mainInstance = provider
+
+        // Bind the headless task automation actions (create/toggle/delete/reorder/dump)
+        // to this canonical, long-lived TasksViewModel so omi-ctl can drive TASK-01/02/03
+        // without the Tasks page being on screen. Gated to the automation bridge, which
+        // only runs on non-prod bundles.
+        if DesktopAutomationLaunchOptions.isEnabled {
+            tasksViewModel.registerAutomationActions()
+        }
     }
 
     // Loading state


### PR DESCRIPTION
## What

Adds discoverable `DesktopAutomationActionRegistry` actions so `omi-ctl` can drive the **push-to-talk** and **task-management** user journeys headlessly — no microphone, no cursor, no synthetic key events. This closes a testability gap that blocked runtime verification of **MIC-01** and **TASK-01/02/03** (the harness was hitting `unknown_action` for `ptt_start/stop`, `create_task`, `toggle_task`, `delete_task`, `reorder_task`, `dump_tasks`, `seed_tasks`).

## Actions added

**MIC-01 — PTT (builtins, always available when the bridge is on):**
- `ptt_start` — begins a capture through the exact private `startListening()` the PTT shortcut key-down calls.
- `ptt_stop` — finalizes through the exact `finalize()` a long-hold key-up calls. Releasing with no captured audio deterministically exercises the **empty-batch release path** (must end the turn with a hint, not hang).

Both route through two new public wrappers on `PushToTalkManager` (`beginPushToTalkForAutomation` / `endPushToTalkForAutomation`) — the state machine and STT path are the genuine ones, not a re-implementation.

**TASK-01/02/03 — task CRUD + reorder (bound to the canonical, long-lived `TasksViewModel` that `ViewModelContainer` owns, so they work without the Tasks page on screen):**
- `create_task` / `seed_tasks` — genuine `TasksStore` create path; return the new ids.
- `toggle_task` / `delete_task` — genuine view-model actions resolved by id.
- `reorder_task` — the real `moveTask()` drag path, then a **deterministic flush** of the debounced sortOrder sync to SQLite + backend (cancels the 500 ms debounce and awaits the write); returns the resulting order.
- `dump_tasks` — reads back from **SQLite** (`ActionItemStorage`) sorted by `sortOrder`, so a caller can prove the reorder/CRUD write actually persisted.

## Why genuine paths

Reorder persistence (TASK-02) and the 150-reorder sparse-band stress (TASK-03) live inside `moveTask` + `syncSortOrders`, so `reorder_task` drives those directly rather than a shortcut. `dump_tasks` reads SQLite (the source of truth) rather than in-memory state, so persistence claims are verifiable, not assumed.

## Safety / scope

- All registration is gated on `DesktopAutomationLaunchOptions.isEnabled`, which is `false` on production bundles (`AppBuild.isNonProduction` guard). **Prod never registers these actions** — they exist only on `Omi Dev` and `omi-*` named test bundles.
- No user-facing surface changes → **no changelog fragment** (internal dev/test tooling); labeled `no-changelog-needed`.
- Origin: **upstream** — this is a testability gap in the automation bridge, not a product defect.

## Verification

- `xcrun swift build -c debug --package-path Desktop` → **Build complete** (exit 0), no new warnings.
- Rust suite (`test.sh`) → **299/299 passed**.
- Swift suite (`test.sh`) → 139 suites in isolation; **the only failures are 4 pre-existing, upstream-origin suites — BL-041 (`CreateCalendarEventToolTests`), BL-042 (`HubSystemInstructionTests`), BL-043 (`AgentPillLifecycleTests` typed-provider), BL-044 (`DesktopCoordinatorServiceTests`)**. These are unrelated to this change: my diff touches only 4 files (`DesktopAutomationBridge.swift`, `PushToTalkManager.swift`, `TasksPage.swift`, `ViewModelContainer.swift`), while every failing assertion is a source-scrape / behavior check on *other* files (`ChatToolExecutor`, the hub instruction builder, `LocalAgentProviderDetector`, `AgentRuntimeProcess.swift` / `ChatProvider.swift` / `RealtimeHubController.swift`). A `.contains()` assertion on unmodified source text is invariant to this additive change, and none of the 4 failing test files reference any new symbol added here.

## Runtime verification — deferred (not exercised by implementer)

The new actions have **not** been driven against a running named bundle yet — `GET /actions` discoverability and the MIC-01 / TASK CRUD+reorder+persist roundtrips are **Wave 4c**, to be verified after merge (the host currently can't spare disk for a named-bundle `./run.sh`). This PR's gate is build + `test.sh`, as scoped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9156?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

