### PR TITLE
fix(desktop/auth): don't sign out on launch when restored-session validation fails (regression from #9125)

### DIFF
--- a/desktop/macos/Desktop/Sources/AuthService.swift
+++ b/desktop/macos/Desktop/Sources/AuthService.swift
@@ -623,14 +623,16 @@ class AuthService {
                 NSLog("OMI AUTH: Restored UserDefaults session validated by forced token refresh")
                 APIKeyService.shared.startFetchingKeys()
                 Task { await FloatingBarUsageLimiter.shared.fetchPlan() }
-            } catch AuthError.notSignedIn {
-                NSLog("OMI AUTH: Restored UserDefaults session failed validation - signed out")
-                self.clearTokens()
-                self.isSignedIn = false
-                AuthState.shared.userEmail = nil
-                AuthState.shared.isRestoringAuth = false
-                self.saveAuthState(isSignedIn: false, email: nil, userId: nil)
             } catch {
+                // Do NOT tear down a restored session on a launch-time validation failure.
+                // A *definitive* auth failure (expired/revoked refresh token, USER_NOT_FOUND,
+                // USER_DISABLED, HTTP 400) is already handled inside refreshIdToken(): it
+                // clears tokens and flips isSignedIn before throwing. Every *other* reason
+                // getIdToken can throw notSignedIn on launch — the Firebase SDK user not yet
+                // restored (async race), a missing refresh token, or a transient network/5xx
+                // error — must NOT wipe the persisted session; on-demand refresh recovers it.
+                // Clearing here signed users out (and could block re-sign-in) on launch after
+                // v0.12.31 (regression from #9125).
                 NSLog("OMI AUTH: Restored UserDefaults session validation deferred: %@", error.localizedDescription)
             }
         }

--- a/desktop/macos/Desktop/Tests/ChatErrorStateTests.swift
+++ b/desktop/macos/Desktop/Tests/ChatErrorStateTests.swift
@@ -243,18 +243,22 @@ final class ChatErrorStateTests: XCTestCase {
     XCTAssertTrue(source.contains("validateRestoredUserDefaultsSession()"))
     XCTAssertTrue(source.contains("getIdToken(forceRefresh: true)"))
     XCTAssertTrue(source.contains("Restored UserDefaults session validated by forced token refresh"))
-    XCTAssertTrue(source.contains("Restored UserDefaults session failed validation - signed out"))
+    // A validation failure is now non-destructive (deferred) — see the regression test below.
+    XCTAssertTrue(source.contains("Restored UserDefaults session validation deferred"))
   }
 
-  func testRestoredSessionFailureClearsPersistedTokens() throws {
-    // Regression: a failed restored-session validation must clear tokens, not just flip
-    // isSignedIn, otherwise the UI shows signed-out while API auth still succeeds.
+  func testRestoredSessionValidationFailureDoesNotClobberSession() throws {
+    // Regression (v0.12.31 / #9125): a launch-time restored-session validation failure must
+    // NOT clear tokens or force sign-out. Definitive auth failures (expired/revoked refresh
+    // token, USER_NOT_FOUND, USER_DISABLED, HTTP 400) are already handled inside
+    // refreshIdToken(); a transient/race failure here (e.g. the Firebase SDK user not yet
+    // restored) must leave the persisted session intact so on-demand refresh recovers it —
+    // otherwise users get signed out on launch.
     let source = try sourceFile("AuthService.swift")
-    let validationBlockRange = source.range(of: "Restored UserDefaults session failed validation - signed out")
-    XCTAssertNotNil(validationBlockRange)
-    let snippet = String(source[validationBlockRange!.lowerBound...])
-      .prefix(500)
-    XCTAssertTrue(snippet.contains("clearTokens()"))
+    // The destructive "signed out" branch (clearTokens + isSignedIn=false on validation
+    // failure) is gone; the failure path only defers.
+    XCTAssertFalse(source.contains("Restored UserDefaults session failed validation - signed out"))
+    XCTAssertTrue(source.contains("Restored UserDefaults session validation deferred"))
   }
 
   func testChatSignInRecoveryDoesNotDuplicatePlanRefresh() throws {

--- a/desktop/macos/changelog/unreleased/20260706-fix-launch-signout.json
+++ b/desktop/macos/changelog/unreleased/20260706-fix-launch-signout.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed the app signing you out on launch after a temporary connection hiccup or startup timing race, instead of keeping your session and retrying"
+}


### PR DESCRIPTION
## Problem

Beta users are getting **signed out on launch** (and can struggle to sign back in), starting in **v0.12.31**. Regression from #9125 "Fix desktop chat auth recovery."

## Root cause

#9125 added `AuthService.validateRestoredUserDefaultsSession()`, which runs on **every launch** after the session is restored from UserDefaults. It does a **forced token refresh** and, in the `catch AuthError.notSignedIn` branch, **hard-clears the persisted session** — `clearTokens()` + `isSignedIn = false` + `saveAuthState(isSignedIn: false, …)`.

The trap: `getIdToken(forceRefresh: true)` throws `AuthError.notSignedIn` not only for *definitive* auth failures, but also for **benign launch-time conditions** — most importantly when the Firebase SDK hasn't finished restoring its user yet (an async race on cold start), or when a refresh token is momentarily unavailable. In those cases the app wipes a perfectly valid session on launch, then re-auth can hit the same edge.

Crucially, definitive auth failures are **already** handled correctly inside `refreshAuthToken()`: it clears tokens + flips `isSignedIn` **only** for `TOKEN_EXPIRED` / `INVALID_REFRESH_TOKEN` / `USER_NOT_FOUND` / `USER_DISABLED` / HTTP 400, and throws `tokenExchangeFailed` (not `notSignedIn`) for transient network/5xx. So the launch-time clear in `validateRestored` is **redundant for real sign-outs and destructive for everything else.**

## Fix

Make `validateRestoredUserDefaultsSession()` **non-destructive**: on any validation failure it now logs and **defers** (the pre-existing generic `catch`), letting on-demand refresh recover the session. The destructive `notSignedIn` branch is removed. Genuinely-invalid sessions still get signed out — by `refreshAuthToken()`, which already owns that decision and does it correctly.

- `AuthService.swift` — remove the `clearTokens()` / `isSignedIn = false` / `saveAuthState(false)` on restored-session validation failure; fall through to the deferred log.
- `ChatErrorStateTests.swift` — two source-invariant tests updated to the corrected intent (validation failure defers, does not clobber).
- changelog fragment (user-facing).

## Verification

- `xcrun swift build -c debug --package-path Desktop` → exit 0.
- `ChatErrorStateTests` green with the updated invariants.
- Behavioral reasoning: definitive failures still sign out via `refreshAuthToken`; launch races / transient errors / momentarily-missing tokens no longer wipe the session.

## Known narrow edge (deliberately deferred)

Independent review flagged one narrow case: if `authIsSignedIn=true` persists in UserDefaults but there is **no** refresh token **and** no Firebase user (a genuinely unrecoverable session), the deferred path won't clear it *this* session, leaving a transient "signed-in" state with no usable token. I chose **not** to add a launch-time clear guard for it, because the guard risks re-introducing a false-positive sign-out and the reported regression is the common case. A revoked/expired session still self-heals into a real sign-out on the next on-demand refresh (401 retry → `refreshIdToken()` clears + signs out). The unrecoverable-ghost hardening can be a small separate follow-up if desired.

## Scope / safety

One theme: the launch-time session clobber. I intentionally did **not** touch #9125's `AgentBridge` `authMissing` mapping (that surfaces a sign-in CTA inside chat; it does not wipe tokens). If "can't sign in from a completely clean state" persists after this, that's a separate investigation. This is auth code — please give it a careful review before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9163?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

