### PR TITLE
fix(desktop/auth): sign out instead of ghost when launch validation clears tokens internally (follow-up to #9161)

### DIFF
--- a/desktop/macos/Desktop/Sources/AuthService.swift
+++ b/desktop/macos/Desktop/Sources/AuthService.swift
@@ -632,7 +632,21 @@ class AuthService {
                 APIKeyService.shared.startFetchingKeys()
                 Task { await FloatingBarUsageLimiter.shared.fetchPlan() }
             } catch AuthError.notSignedIn {
-                if self.isSignedIn {
+                if self.storedIdToken == nil || self.storedRefreshToken == nil {
+                    // getIdToken() can clear tokens internally before surfacing notSignedIn —
+                    // e.g. a stored token/user mismatch after an account switch (it clears the
+                    // stale token, then the refresh path has no token). The entry guard proved
+                    // a cached ID token existed, so if it's gone now the session is genuinely
+                    // dead; preserving isSignedIn would leave a ghost signed-in UI with no
+                    // credentials. Sign out cleanly so the UI shows sign-in.
+                    NSLog("OMI AUTH: Restored UserDefaults session validation cleared tokens - signing out")
+                    self.isSignedIn = false
+                    AuthState.shared.userEmail = nil
+                    AuthState.shared.isRestoringAuth = false
+                    self.saveAuthState(isSignedIn: false, email: nil, userId: nil)
+                } else if self.isSignedIn {
+                    // Tokens survived — a transient/race failure (e.g. Firebase SDK user not
+                    // yet restored). Keep the restored session; on-demand refresh recovers it.
                     NSLog("OMI AUTH: Restored UserDefaults session validation deferred - preserving restored session")
                 } else {
                     NSLog("OMI AUTH: Restored UserDefaults session validation found signed-out state")

--- a/desktop/macos/Desktop/Tests/ChatErrorStateTests.swift
+++ b/desktop/macos/Desktop/Tests/ChatErrorStateTests.swift
@@ -260,12 +260,31 @@ final class ChatErrorStateTests: XCTestCase {
     XCTAssertTrue(source.contains("Definitive auth failure - clearing tokens and session"))
   }
 
+  func testRestoredSessionSignsOutWhenValidationClearedTokens() throws {
+    // Follow-up to #9161 (Copilot): getIdToken(forceRefresh: false) can clear tokens
+    // internally on a stored token/user mismatch and then surface notSignedIn. Preserving
+    // isSignedIn there would leave a ghost signed-in UI with no credentials, so the catch
+    // must sign out when the tokens are gone — gated on the tokens actually being cleared,
+    // so the transient/race case (tokens intact) is still preserved.
+    let source = try sourceFile("AuthService.swift")
+    let range = source.range(of: "Restored UserDefaults session validation cleared tokens - signing out")
+    XCTAssertNotNil(range)
+    let snippet = String(source[range!.lowerBound...]).prefix(320)
+    XCTAssertTrue(snippet.contains("self.isSignedIn = false"))
+    XCTAssertTrue(snippet.contains("saveAuthState(isSignedIn: false"))
+    // The sign-out branch is gated on the tokens actually being gone (not a blanket clear).
+    let methodStart = source.range(of: "private func validateRestoredUserDefaultsSession()")
+    XCTAssertNotNil(methodStart)
+    let method = String(source[methodStart!.lowerBound...]).prefix(1700)
+    XCTAssertTrue(method.contains("storedIdToken == nil") || method.contains("storedRefreshToken == nil"))
+  }
+
   func testRestoredSessionValidationClearsInMemoryEmailIfAlreadySignedOut() throws {
     let source = try sourceFile("AuthService.swift")
     let validationRange = source.range(of: "private func validateRestoredUserDefaultsSession()")
     XCTAssertNotNil(validationRange)
     let snippet = String(source[validationRange!.lowerBound...])
-      .prefix(1800)
+      .prefix(2600)
 
     XCTAssertTrue(snippet.contains("if self.isSignedIn"))
     XCTAssertTrue(snippet.contains("Restored UserDefaults session validation found signed-out state"))

--- a/desktop/macos/changelog/unreleased/20260706-auth-launch-ghost-signout.json
+++ b/desktop/macos/changelog/unreleased/20260706-auth-launch-ghost-signout.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed a rare case where a stale/mismatched saved session could leave the app showing signed-in with no working credentials, instead of returning you to sign-in"
+}


### PR DESCRIPTION
## What

Follow-up to #9161 — closes the unresolved Copilot thread on that PR (`AuthService.swift`, left unresolved at merge time, ~20:13Z).

## The gap

#9161 correctly made `validateRestoredUserDefaultsSession()` **preserve** the restored session on `AuthError.notSignedIn`, so a transient/race failure doesn't sign users out. But `getIdToken(forceRefresh: false)` can call `clearTokens()` **internally** — the "Stored token user mismatch" branch (account switch) clears the stale token, then the refresh path finds no token and throws `notSignedIn`. In that case #9161's `if isSignedIn { preserve }` left `isSignedIn = true` with the tokens gone: a **ghost signed-in UI with no usable credentials.**

## Fix

In the `catch AuthError.notSignedIn`, add a first branch: if the tokens are actually gone (`storedIdToken == nil || storedRefreshToken == nil` — the entry guard proved a cached ID token existed, so their absence means validation cleared them), **sign out cleanly** (`isSignedIn = false` + `saveAuthState(false)`) so the UI returns to sign-in. Otherwise preserve/defer when the tokens survive (the intended transient/race case), and keep #9161's early no-cached-token / expired-token guards.

## Verification

- `xcrun swift build -c debug --package-path Desktop` → exit 0.
- `ChatErrorStateTests` → **21/21** (the four #9161 tests still pass; +1 regression test `testRestoredSessionSignsOutWhenValidationClearedTokens`; one test's source-scan window bumped 1800→2600 since the method grew).
- **Independent review: no blockers.** Confirmed the `storedIdToken == nil` detector cannot false-positive — the `@MainActor` class serializes cache reads, the entry guard pre-loads a non-nil token cache, and the cache is only invalidated by a genuine clear — so it never signs out a valid user; and `saveAuthState(false)` persists the signed-out flag, so no re-ghost next launch.

Fresh branch off `upstream/main` (post-#9161). Auth code — please review before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9166?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

