### PR TITLE
fix(desktop/auth): use the file-based keychain so beta sign-in works (Could not securely store sign-in tokens)

### DIFF
--- a/desktop/macos/Desktop/Sources/DesktopKeychainStore.swift
+++ b/desktop/macos/Desktop/Sources/DesktopKeychainStore.swift
@@ -2,14 +2,20 @@ import Foundation
 import Security
 
 enum DesktopKeychainStore {
-  private static let useDataProtectionKeychain = kSecUseDataProtectionKeychain as String
-
   private static func baseQuery(service: String, account: String) -> [String: Any] {
+    // Use the file-based (login) keychain, NOT the iOS-style data-protection keychain.
+    // Opting into the data-protection keychain requires a `keychain-access-groups` entitlement
+    // this non-sandboxed Developer ID app does not have (see Omi-Release.entitlements:
+    // app-sandbox=false, no keychain-access-groups). On the signed/notarized build that made
+    // every SecItem write fail with errSecMissingEntitlement (-34018), so token storage failed
+    // ("Could not securely store sign-in tokens") and sign-in was blocked. The default
+    // file-based keychain works for a signed non-sandboxed app with no extra entitlement and
+    // still keeps tokens out of UserDefaults. (Dev builds don't hit this — they use
+    // UserDefaults, so it only ever failed on prod/beta.)
     [
       kSecClass as String: kSecClassGenericPassword,
       kSecAttrService as String: service,
       kSecAttrAccount as String: account,
-      useDataProtectionKeychain: true,
     ]
   }
 
@@ -39,6 +45,8 @@ enum DesktopKeychainStore {
     let query = baseQuery(service: service, account: account)
     let attributes: [String: Any] = [
       kSecValueData as String: data,
+      // Advisory on the file-based keychain (it's a data-protection-keychain attribute, so it's
+      // accepted but not cryptographically enforced here); kept for intent + parity with iOS.
       kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly,
     ]
 

--- a/desktop/macos/Desktop/Sources/DesktopKeychainStore.swift
+++ b/desktop/macos/Desktop/Sources/DesktopKeychainStore.swift
@@ -10,8 +10,11 @@ enum DesktopKeychainStore {
     // every SecItem write fail with errSecMissingEntitlement (-34018), so token storage failed
     // ("Could not securely store sign-in tokens") and sign-in was blocked. The default
     // file-based keychain works for a signed non-sandboxed app with no extra entitlement and
-    // still keeps tokens out of UserDefaults. (Dev builds don't hit this — they use
-    // UserDefaults, so it only ever failed on prod/beta.)
+    // still keeps tokens out of UserDefaults. (The *auth-token* path uses UserDefaults on
+    // non-production builds — usesKeychainTokenStorage = !AppBuild.isNonProduction — so the
+    // sign-in failure only surfaced on prod/beta. This store is also used by
+    // LocalAgentAPIServer on all builds, whose keychain writes hit the same failure and are
+    // fixed by the same change.)
     [
       kSecClass as String: kSecClassGenericPassword,
       kSecAttrService as String: service,

--- a/desktop/macos/Desktop/Tests/AuthTokenStorageTests.swift
+++ b/desktop/macos/Desktop/Tests/AuthTokenStorageTests.swift
@@ -116,6 +116,29 @@ final class AuthTokenStorageTests: XCTestCase {
     XCTAssertEqual(UserDefaults.standard.string(forKey: .authUserId), "user-keychain")
   }
 
+  /// Regression: the token Keychain store must NOT opt into the data-protection keychain
+  /// (`kSecUseDataProtectionKeychain`). That requires a `keychain-access-groups` entitlement
+  /// this non-sandboxed Developer ID app doesn't have, so on the signed/notarized build every
+  /// SecItem write failed with errSecMissingEntitlement and sign-in broke with "Could not
+  /// securely store sign-in tokens". Dev builds use UserDefaults, so this only ever failed on
+  /// prod/beta and is invisible to the behavioral tests — hence a source-level guard.
+  func testKeychainStoreDoesNotUseDataProtectionKeychain() throws {
+    let source = try sourceFile("DesktopKeychainStore.swift")
+    XCTAssertFalse(
+      source.contains("kSecUseDataProtectionKeychain"),
+      "DesktopKeychainStore must use the file-based login keychain (no keychain-access-groups "
+        + "entitlement); the data-protection keychain breaks sign-in on signed builds.")
+  }
+
+  private func sourceFile(_ relativePath: String) throws -> String {
+    let sourceURL = URL(fileURLWithPath: #filePath)
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+      .appendingPathComponent("Sources")
+      .appendingPathComponent(relativePath)
+    return try String(contentsOf: sourceURL, encoding: .utf8)
+  }
+
   private func clearAuthDefaults() {
     UserDefaults.standard.removeObject(forKey: .authIdToken)
     UserDefaults.standard.removeObject(forKey: .authRefreshToken)

--- a/desktop/macos/Desktop/Tests/FailLoudConfigTests.swift
+++ b/desktop/macos/Desktop/Tests/FailLoudConfigTests.swift
@@ -97,12 +97,10 @@ final class FailLoudConfigTests: XCTestCase {
     XCTAssertFalse(src.contains("UserDefaults.standard.set(token, forKey: tokenKey)"))
   }
 
-  func testDesktopKeychainStoreUsesDataProtectionKeychain() throws {
-    let src = try source(relativePath: "Sources/DesktopKeychainStore.swift")
-
-    XCTAssertTrue(src.contains("kSecUseDataProtectionKeychain"))
-    XCTAssertTrue(src.contains("useDataProtectionKeychain: true"))
-  }
+  // The data-protection keychain assertion was inverted by the file-based-keychain fix:
+  // a non-sandboxed Developer ID app has no keychain-access-groups entitlement, so the
+  // data-protection keychain failed with errSecMissingEntitlement and blocked sign-in.
+  // The correct invariant now lives in AuthTokenStorageTests.testKeychainStoreDoesNotUseDataProtectionKeychain.
 
   func testDesktopAutomationBridgeIsNonProductionAndAuthenticated() throws {
     let src = try source(relativePath: "Sources/DesktopAutomationBridge.swift")

--- a/desktop/macos/changelog/unreleased/20260706-fix-beta-keychain-signin.json
+++ b/desktop/macos/changelog/unreleased/20260706-fix-beta-keychain-signin.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed beta sign-in failing with \"Could not securely store sign-in tokens\" — credentials now save to the login keychain reliably on signed builds"
+}


### PR DESCRIPTION
## Problem

On the signed/notarized **beta**, sign-in fails with **"Could not securely store sign-in tokens. Please try again."** — you cannot log in (screenshot from v0.12.37).

## Root cause

`DesktopKeychainStore` opted into the **data-protection keychain** (`kSecUseDataProtectionKeychain: true`), which on macOS requires a `keychain-access-groups` entitlement. This app is a **non-sandboxed Developer ID** app with **no** such entitlement (`Omi-Release.entitlements`: `app-sandbox=false`, no keychain-access-groups). So on the signed build every `SecItemAdd`/`SecItemUpdate` returned **`errSecMissingEntitlement` (-34018)** → `saveTokens()` threw `keychainTokenStorageUnavailable` → sign-in blocked. Dev/named builds use UserDefaults (`usesKeychainTokenStorage = !AppBuild.isNonProduction`), which is why it only failed on prod/beta and slipped through CI.

## Fix

Drop `kSecUseDataProtectionKeychain` so the store uses the default **file-based (login) keychain** — a signed non-sandboxed app can read/write its own generic-password items there **without any keychain entitlement**, and tokens still stay out of UserDefaults. (`ClientDeviceService` already uses this exact pattern in the same app.) This **complements #9162's** UserDefaults fallback: with the keychain actually succeeding, the fallback becomes a rare safety net instead of the norm.

- `DesktopKeychainStore.swift`: remove the data-protection flag from the shared query.
- `AuthTokenStorageTests.swift`: source-guard against re-introducing the data-protection keychain (this regression is invisible to dev/CI since dev uses UserDefaults).
- `FailLoudConfigTests.swift`: remove the now-inverted `testDesktopKeychainStoreUsesDataProtectionKeychain` (its correct invariant now lives in the new guard).
- changelog.

## Verification

- **Runtime**: signed into a **local named bundle** with the keychain path forced on **and the UserDefaults fallback disabled**, so the outcome reflects the *real* keychain write — sign-in succeeded.
- **Standalone `SecItemAdd` probe**: data-protection keychain → `-34018`; file-based → `0`.
- Build exit 0; `AuthTokenStorageTests` 5/5, `FailLoudConfigTests` 6/6.
- **Independent review**: confirmed the file-based login keychain is an adequately secure store for a non-sandboxed Developer ID app (AES-encrypted at rest under the login key + per-item code-signature ACL — a big step up from UserDefaults, and #9108's goal is still met), and that no migration is needed (no signed build ever wrote a data-protection item).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9167?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

