### PR TITLE
Improve desktop confidence tooling

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -354,7 +354,7 @@ jobs:
           fi
           FILES=$(git diff --name-only --diff-filter=ACMRD "$DIFF_BASE"...HEAD)
           echo "$FILES"
-          if echo "$FILES" | grep -qE '^desktop/macos/Desktop/|^desktop/macos/test\.sh$|^desktop/macos/scripts/swift-test-suites\.sh$|^\.github/workflows/lint\.yml$'; then
+          if echo "$FILES" | grep -qE '^desktop/macos/Desktop/|^desktop/macos/test\.sh$|^desktop/macos/scripts/|^desktop/macos/tests/|^desktop/macos/e2e/flows/|^\.github/workflows/lint\.yml$'; then
             echo "should_run=true" >> "$GITHUB_OUTPUT"
           else
             echo "should_run=false" >> "$GITHUB_OUTPUT"
@@ -374,6 +374,16 @@ jobs:
       - name: Install Swift system dependencies
         if: steps.changed.outputs.should_run == 'true'
         run: brew install pkg-config webp
+
+      - name: Check desktop e2e flow coverage
+        if: steps.changed.outputs.should_run == 'true'
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            DIFF_BASE="origin/${{ github.base_ref }}"
+          else
+            DIFF_BASE="HEAD~1"
+          fi
+          python3 desktop/macos/scripts/check-e2e-flow-coverage.py --strict --base "$DIFF_BASE"
 
       - name: Build desktop Swift app
         if: steps.changed.outputs.should_run == 'true'

--- a/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
+++ b/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
@@ -160,6 +160,142 @@ struct DesktopAutomationActionDescriptor: Codable {
   let summary: String
   /// Names of params the handler reads (hints for the caller; not enforced).
   let params: [String]
+  /// Coarse grouping for scanners and harness UIs.
+  let category: String
+  /// Screens or app surfaces this action is meant to replace AX interaction on.
+  let surfaces: [String]
+  /// Agent-facing risk label; the bridge is still non-production only.
+  let safety: String
+  /// Plain-language effects so callers can prefer read-only probes before clicks.
+  let sideEffects: [String]
+  /// Copy-pasteable examples for `scripts/omi-ctl action ...`.
+  let examples: [String]
+  /// Semantic bridge actions should be preferred over `agent-swift` clicks when covered.
+  let preferSemantic: Bool
+
+  init(
+    name: String,
+    summary: String,
+    params: [String] = [],
+    category: String? = nil,
+    surfaces: [String]? = nil,
+    safety: String? = nil,
+    sideEffects: [String]? = nil,
+    examples: [String] = [],
+    preferSemantic: Bool = true
+  ) {
+    self.name = name
+    self.summary = summary
+    self.params = params
+    self.category = category ?? Self.inferCategory(name)
+    self.surfaces = surfaces ?? Self.inferSurfaces(name)
+    self.safety = safety ?? Self.inferSafety(name)
+    self.sideEffects = sideEffects ?? Self.inferSideEffects(name)
+    self.examples = examples.isEmpty ? [Self.commandExample(name: name, params: params)] : examples
+    self.preferSemantic = preferSemantic
+  }
+
+  private static func inferCategory(_ name: String) -> String {
+    if name.contains("snapshot") || name.contains("probe") || name.contains("state")
+      || name.contains("tail") || name.contains("evidence") || name.contains("qa_export")
+    {
+      return "read"
+    }
+    if name.hasPrefix("capture") {
+      return "capture"
+    }
+    if name.contains("coordinator") {
+      return "coordinator"
+    }
+    if name.contains("ask") || name.contains("chat") || name.contains("omni") {
+      return "chat"
+    }
+    if name.contains("spatial_overlay") || name.contains("debug_bar") || name.contains("subagent") {
+      return "visual"
+    }
+    if name.contains("transcription") || name.contains("refresh") {
+      return "app_control"
+    }
+    return "general"
+  }
+
+  private static func inferSurfaces(_ name: String) -> [String] {
+    if name.hasPrefix("capture_main_window") {
+      return ["main_window"]
+    }
+    if name.hasPrefix("capture_floating_bar") || name.contains("debug_bar") {
+      return ["floating_bar"]
+    }
+    if name.contains("main_chat") {
+      return ["main_chat"]
+    }
+    if name.contains("ask_omi") || name == "ask" || name.contains("floating") || name.contains("subagent") {
+      return ["floating_bar", "ask_omi"]
+    }
+    if name.contains("coordinator") {
+      return ["coordinator"]
+    }
+    if name.contains("spatial_overlay") || name.contains("cloud_connector") {
+      return ["cloud_connector_guidance"]
+    }
+    if name.contains("calendar") {
+      return ["calendar_connector"]
+    }
+    if name.contains("gmail") {
+      return ["gmail_connector"]
+    }
+    if name.contains("apple_notes") || name.contains("local_file") {
+      return ["import_connectors"]
+    }
+    return ["app"]
+  }
+
+  private static func inferSafety(_ name: String) -> String {
+    if name.contains("delete") {
+      return "remote_write"
+    }
+    if name.contains("snapshot") || name.contains("probe") || name.contains("state")
+      || name.contains("tail") || name.contains("evidence") || name.contains("qa_export")
+    {
+      return "read_only"
+    }
+    if name.hasPrefix("capture") {
+      return "local_artifact"
+    }
+    if name.contains("ask") || name.contains("omni") || name.contains("import") {
+      return "network_or_model"
+    }
+    return "local_ui_state"
+  }
+
+  private static func inferSideEffects(_ name: String) -> [String] {
+    if name.contains("delete") {
+      return ["may mutate remote user data"]
+    }
+    if name.hasPrefix("capture") {
+      return ["writes local artifact file"]
+    }
+    if name.contains("ask") || name.contains("omni") {
+      return ["may call model/backend services"]
+    }
+    if name.contains("import") {
+      return ["may read local connector data", "may save imported memory data"]
+    }
+    if name.contains("toggle") || name.contains("debug") || name.contains("open") || name.contains("close")
+      || name.contains("seed") || name.contains("swap") || name.contains("clear")
+    {
+      return ["mutates non-production app state"]
+    }
+    return []
+  }
+
+  private static func commandExample(name: String, params: [String]) -> String {
+    var pieces = ["./scripts/omi-ctl", "action", name]
+    for param in params {
+      pieces.append("\(param)=<value>")
+    }
+    return pieces.joined(separator: " ")
+  }
 }
 
 /// Returned by `POST /action`: what ran, any handler detail, and the resulting state.
@@ -351,10 +487,29 @@ final class DesktopAutomationActionRegistry {
   private var didRegisterBuiltins = false
 
   func register(
-    name: String, summary: String, params: [String] = [], handler: @escaping Handler
+    name: String,
+    summary: String,
+    params: [String] = [],
+    category: String? = nil,
+    surfaces: [String]? = nil,
+    safety: String? = nil,
+    sideEffects: [String]? = nil,
+    examples: [String] = [],
+    preferSemantic: Bool = true,
+    handler: @escaping Handler
   ) {
     entries[name] = Entry(
-      descriptor: DesktopAutomationActionDescriptor(name: name, summary: summary, params: params),
+      descriptor: DesktopAutomationActionDescriptor(
+        name: name,
+        summary: summary,
+        params: params,
+        category: category,
+        surfaces: surfaces,
+        safety: safety,
+        sideEffects: sideEffects,
+        examples: examples,
+        preferSemantic: preferSemantic
+      ),
       run: handler)
   }
 
@@ -1385,7 +1540,7 @@ final class DesktopAutomationBridge {
     case ("GET", "/capabilities"):
       let descriptors = await DesktopAutomationActionRegistry.shared.descriptors()
       let capabilities = DesktopAutomationCapabilities(
-        schemaVersion: 1,
+        schemaVersion: 2,
         routes: [
           "GET /health",
           "GET /state",

--- a/desktop/macos/Desktop/Tests/AgentContinuityGauntletTests.swift
+++ b/desktop/macos/Desktop/Tests/AgentContinuityGauntletTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+@testable import Omi_Computer
 
 final class AgentContinuityGauntletTests: XCTestCase {
   func testGauntletRunnerFilesExist() throws {
@@ -53,5 +54,56 @@ final class AgentContinuityGauntletTests: XCTestCase {
     XCTAssertTrue(providerSource.contains("automationSwapTestOwner"))
     XCTAssertTrue(providerSource.contains("automationKernelTurnTail"))
     XCTAssertTrue(providerSource.contains("automationClearOwnerSurfaceState"))
+  }
+
+  @MainActor
+  func testAutomationActionDescriptorsExposeDiscoveryMetadata() throws {
+    let registry = DesktopAutomationActionRegistry.shared
+    registry.register(
+      name: "__metadata_contract_test__",
+      summary: "Read test-only metadata",
+      params: ["limit"],
+      category: "read",
+      surfaces: ["test_surface"],
+      safety: "read_only",
+      sideEffects: [],
+      examples: ["./scripts/omi-ctl action __metadata_contract_test__ limit=1"]
+    ) { _ in
+      ["ok": "true"]
+    }
+    defer { registry.unregister("__metadata_contract_test__") }
+
+    let descriptor = try XCTUnwrap(
+      registry.descriptors().first { $0.name == "__metadata_contract_test__" }
+    )
+    XCTAssertEqual(descriptor.summary, "Read test-only metadata")
+    XCTAssertEqual(descriptor.params, ["limit"])
+    XCTAssertEqual(descriptor.category, "read")
+    XCTAssertEqual(descriptor.surfaces, ["test_surface"])
+    XCTAssertEqual(descriptor.safety, "read_only")
+    XCTAssertEqual(descriptor.examples, ["./scripts/omi-ctl action __metadata_contract_test__ limit=1"])
+    XCTAssertTrue(descriptor.preferSemantic)
+  }
+
+  func testAutomationActionDescriptorInfersUsefulMetadataForBuiltins() throws {
+    let snapshot = DesktopAutomationActionDescriptor(
+      name: "main_chat_snapshot",
+      summary: "Export main-chat state",
+      params: ["limit"]
+    )
+    XCTAssertEqual(snapshot.category, "read")
+    XCTAssertEqual(snapshot.surfaces, ["main_chat"])
+    XCTAssertEqual(snapshot.safety, "read_only")
+    XCTAssertEqual(snapshot.examples, ["./scripts/omi-ctl action main_chat_snapshot limit=<value>"])
+
+    let capture = DesktopAutomationActionDescriptor(
+      name: "capture_floating_bar_png",
+      summary: "Capture the floating bar",
+      params: ["path"]
+    )
+    XCTAssertEqual(capture.category, "capture")
+    XCTAssertEqual(capture.surfaces, ["floating_bar"])
+    XCTAssertEqual(capture.safety, "local_artifact")
+    XCTAssertEqual(capture.sideEffects, ["writes local artifact file"])
   }
 }

--- a/desktop/macos/changelog/unreleased/20260707-desktop-confidence-tooling.json
+++ b/desktop/macos/changelog/unreleased/20260707-desktop-confidence-tooling.json
@@ -1,0 +1,3 @@
+{
+  "change": "Improved desktop test and verification tooling"
+}

--- a/desktop/macos/e2e/SKILL.md
+++ b/desktop/macos/e2e/SKILL.md
@@ -43,6 +43,10 @@ deterministic equivalent of the Flutter app's Marionette driver). Prefer these o
 ./scripts/omi-ctl action refresh_all_data          # same as Cmd+R
 ./scripts/omi-ctl action toggle_transcription enabled=false
 ```
+`omi-ctl actions` returns descriptors with `category`, `surfaces`, `safety`,
+`sideEffects`, `examples`, and `preferSemantic`. Scan those fields before using
+`agent-swift`: prefer actions whose `surfaces` match the screen and whose
+`safety` is `read_only`, `local_artifact`, or `local_ui_state` for routine checks.
 Add new actions in `DesktopAutomationActionRegistry` (`registerBuiltins()` for global
 ones, or `register(name:summary:params:handler:)` from a view model for screen-scoped
 ones). `GET /actions` lists them; `POST /action {name, params}` runs one and returns

--- a/desktop/macos/e2e/flows/harness-smoke.yaml
+++ b/desktop/macos/e2e/flows/harness-smoke.yaml
@@ -2,6 +2,8 @@ version: 1
 name: harness-smoke
 description: Cursor-free smoke flow for the Omi desktop experience harness.
 app: non-prod
+covers:
+  - desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
 preconditions:
   - automation_bridge_ready
 

--- a/desktop/macos/e2e/harness.md
+++ b/desktop/macos/e2e/harness.md
@@ -79,6 +79,11 @@ traces, logs, timing, and AX text. The harness does not score screenshot quality
 the agent should open the PNGs listed in `summary.md` and judge layout, polish,
 clipping, empty states, and visual regressions directly.
 
+Before adding an AX step, inspect `./scripts/omi-ctl actions`. Action descriptors
+include `surfaces`, `safety`, `sideEffects`, and `examples`; use a matching semantic
+`bridge.action` first when `preferSemantic` is true, especially for read-only probes,
+local captures, and deterministic visual fixtures.
+
 Bridge routes return as soon as the app has accepted the command. Prefer `wait:`
 for readiness checks so benchmark timing separates command latency from UI settle
 latency. If a flow genuinely needs a fixed pause, pass `settleMs:` on

--- a/desktop/macos/scripts/check-e2e-flow-coverage.py
+++ b/desktop/macos/scripts/check-e2e-flow-coverage.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+"""Report desktop Swift changes that do or do not have e2e flow coverage."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+
+DESKTOP_SWIFT_ROOT = Path("desktop/macos/Desktop/Sources")
+DEFAULT_FLOWS_DIR = Path("desktop/macos/e2e/flows")
+
+
+@dataclass(frozen=True)
+class FlowCoverage:
+    flow_path: Path
+    flow_name: str
+    covered_paths: tuple[str, ...]
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument(
+        "changed_files",
+        nargs="*",
+        help="Changed files to check. If omitted, files come from git diff.",
+    )
+    parser.add_argument("--root", default=None, help="Repository root. Defaults to the git top-level.")
+    parser.add_argument("--base", default=None, help="Git base ref when no paths are provided.")
+    parser.add_argument("--staged", action="store_true", help="Use staged changes when no paths are provided.")
+    parser.add_argument("--flows-dir", default=str(DEFAULT_FLOWS_DIR), help="Flow directory.")
+    parser.add_argument("--strict", action="store_true", help="Fail when any changed Swift source file is uncovered.")
+    return parser.parse_args()
+
+
+def repo_root(explicit: str | None) -> Path:
+    if explicit:
+        return Path(explicit).resolve()
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+        )
+        return Path(result.stdout.strip()).resolve()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return Path(__file__).resolve().parents[3]
+
+
+def run_git(root: Path, args: list[str]) -> list[str]:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=root,
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        text=True,
+    )
+    if result.returncode != 0:
+        return []
+    return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+
+
+def default_base(root: Path) -> str | None:
+    for candidate in ("origin/main", "main"):
+        result = subprocess.run(
+            ["git", "merge-base", candidate, "HEAD"],
+            cwd=root,
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            return result.stdout.strip()
+    return None
+
+
+def changed_files_from_git(root: Path, base: str | None, staged: bool) -> list[str]:
+    if staged:
+        return run_git(root, ["diff", "--cached", "--name-only", "--diff-filter=ACMR"])
+    files: list[str] = []
+    resolved_base = base or default_base(root)
+    if resolved_base:
+        files.extend(run_git(root, ["diff", "--name-only", "--diff-filter=ACMR", f"{resolved_base}...HEAD"]))
+    else:
+        files.extend(run_git(root, ["diff", "--name-only", "--diff-filter=ACMR", "HEAD"]))
+    files.extend(run_git(root, ["diff", "--name-only", "--diff-filter=ACMR", "HEAD"]))
+    files.extend(run_git(root, ["ls-files", "--others", "--exclude-standard", str(DESKTOP_SWIFT_ROOT)]))
+    return sorted(dict.fromkeys(files))
+
+
+def canonical_path(value: str | Path) -> str:
+    text = Path(value).as_posix().lstrip("./")
+    if text.startswith("desktop/Desktop/"):
+        return "desktop/macos/" + text[len("desktop/") :]
+    return text
+
+
+def coverage_aliases(value: str | Path) -> set[str]:
+    canonical = canonical_path(value)
+    aliases = {canonical}
+    if canonical.startswith("desktop/macos/"):
+        aliases.add("desktop/" + canonical[len("desktop/macos/") :])
+    return aliases
+
+
+def is_desktop_swift_source(path: str) -> bool:
+    canonical = canonical_path(path)
+    return canonical.startswith(DESKTOP_SWIFT_ROOT.as_posix() + "/") and canonical.endswith(".swift")
+
+
+def read_yaml(path: Path) -> dict:
+    try:
+        import yaml
+    except ImportError:
+        data: dict[str, object] = {}
+        covers: list[str] = []
+        in_covers = False
+        for raw_line in path.read_text(encoding="utf-8").splitlines():
+            stripped = raw_line.strip()
+            if not stripped or stripped.startswith("#"):
+                continue
+            if stripped.startswith("name:"):
+                data["name"] = stripped.split(":", 1)[1].strip().strip("'\"")
+                in_covers = False
+                continue
+            if stripped == "covers:":
+                in_covers = True
+                continue
+            if in_covers and stripped.startswith("- "):
+                covers.append(stripped[2:].strip().strip("'\""))
+                continue
+            if not raw_line.startswith((" ", "\t")):
+                in_covers = False
+        if covers:
+            data["covers"] = covers
+        return data
+    with path.open("r", encoding="utf-8") as handle:
+        data = yaml.safe_load(handle) or {}
+    return data if isinstance(data, dict) else {}
+
+
+def load_flows(root: Path, flows_dir: Path) -> list[FlowCoverage]:
+    directory = flows_dir if flows_dir.is_absolute() else root / flows_dir
+    flows: list[FlowCoverage] = []
+    for path in sorted(directory.glob("*.yaml")):
+        data = read_yaml(path)
+        covers = data.get("covers") or []
+        if not isinstance(covers, list):
+            covers = []
+        covered_paths = tuple(str(item) for item in covers if isinstance(item, str))
+        flow_name = str(data.get("name") or path.stem)
+        flows.append(FlowCoverage(path, flow_name, covered_paths))
+    return flows
+
+
+def flow_matches(flows: Iterable[FlowCoverage], changed_file: str) -> list[FlowCoverage]:
+    changed_aliases = coverage_aliases(changed_file)
+    matches: list[FlowCoverage] = []
+    for flow in flows:
+        covered_aliases: set[str] = set()
+        for item in flow.covered_paths:
+            covered_aliases.update(coverage_aliases(item))
+        if changed_aliases & covered_aliases:
+            matches.append(flow)
+    return matches
+
+
+def harness_command(root: Path, flow: FlowCoverage) -> str:
+    try:
+        rel = flow.flow_path.relative_to(root / "desktop/macos").as_posix()
+    except ValueError:
+        rel = flow.flow_path.as_posix()
+    return f"cd desktop/macos && OMI_APP_NAME=omi-e2e ./scripts/omi-harness run {rel}"
+
+
+def print_report(root: Path, flows: list[FlowCoverage], changed: list[str], strict: bool) -> int:
+    desktop_swift = sorted(dict.fromkeys(canonical_path(path) for path in changed if is_desktop_swift_source(path)))
+    print("Desktop e2e flow coverage check")
+    if not desktop_swift:
+        print("No changed desktop Swift source files found.")
+        return 0
+
+    covered: list[tuple[str, list[FlowCoverage]]] = []
+    uncovered: list[str] = []
+    for path in desktop_swift:
+        matches = flow_matches(flows, path)
+        if matches:
+            covered.append((path, matches))
+        else:
+            uncovered.append(path)
+
+    print(f"Changed desktop Swift files: {len(desktop_swift)}")
+    print(f"Covered: {len(covered)}")
+    for path, matches in covered:
+        names = ", ".join(f"{flow.flow_name} ({flow.flow_path.name})" for flow in matches)
+        print(f"  COVERED   {path} -> {names}")
+
+    print(f"Uncovered: {len(uncovered)}")
+    for path in uncovered:
+        print(f"  UNCOVERED {path}")
+
+    recommended: list[str] = []
+    seen: set[Path] = set()
+    for _, matches in covered:
+        for flow in matches:
+            if flow.flow_path not in seen:
+                seen.add(flow.flow_path)
+                recommended.append(harness_command(root, flow))
+
+    if recommended:
+        print("Recommended harness commands:")
+        for command in recommended:
+            print(f"  {command}")
+    else:
+        print("Recommended harness commands: add or update a flow covers: entry, then run the relevant flow.")
+
+    if uncovered and strict:
+        print(
+            "FAIL: uncovered changed desktop Swift files found. Add e2e/flows/*.yaml covers: entries "
+            "or rerun without --strict.",
+            file=sys.stderr,
+        )
+        return 1
+    if uncovered:
+        print("NOTE: uncovered files are advisory unless --strict is passed.")
+    return 0
+
+
+def main() -> int:
+    args = parse_args()
+    root = repo_root(args.root)
+    changed = args.changed_files or changed_files_from_git(root, args.base, args.staged)
+    flows = load_flows(root, Path(args.flows_dir))
+    return print_report(root, flows, changed, args.strict)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/desktop/macos/scripts/desktop-doctor-preflight.py
+++ b/desktop/macos/scripts/desktop-doctor-preflight.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+"""Check local prerequisites for Omi desktop agent verification."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+
+
+DEFAULT_PORT = 47777
+
+
+@dataclass
+class CheckResult:
+    name: str
+    status: str
+    detail: str
+    required: bool = True
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--root", default=None, help="Repository root. Defaults to this script's inferred root.")
+    parser.add_argument("--require-bridge", action="store_true", help="Require the automation bridge to answer /state.")
+    parser.add_argument("--port", default=os.environ.get("OMI_AUTOMATION_PORT", str(DEFAULT_PORT)))
+    parser.add_argument("--require-auth-seed", action="store_true", help="Require a dumped dev auth seed file.")
+    parser.add_argument(
+        "--auth-file",
+        default=None,
+        help="Auth seed file. Defaults to desktop/macos/tmp/desktop-auth.json.",
+    )
+    parser.add_argument("--skip-agent-swift", action="store_true", help="Skip the agent-swift availability check.")
+    parser.add_argument("--skip-node", action="store_true", help="Skip Node/npm checks.")
+    return parser.parse_args()
+
+
+def repo_root(explicit: str | None) -> Path:
+    if explicit:
+        return Path(explicit).resolve()
+    return Path(__file__).resolve().parents[3]
+
+
+def command_output(command: list[str], timeout: float = 10.0) -> tuple[bool, str]:
+    try:
+        result = subprocess.run(
+            command,
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            timeout=timeout,
+        )
+    except FileNotFoundError:
+        return False, "not found"
+    except subprocess.TimeoutExpired:
+        return False, "timed out"
+    output = result.stdout.strip().splitlines()
+    detail = output[0] if output else f"exit {result.returncode}"
+    return result.returncode == 0, detail
+
+
+def check_tool(name: str, command: list[str], required: bool = True) -> CheckResult:
+    if shutil.which(command[0]) is None:
+        return CheckResult(name, "FAIL" if required else "SKIP", f"{command[0]} not found on PATH", required)
+    ok, detail = command_output(command)
+    return CheckResult(name, "PASS" if ok else "FAIL", detail, required)
+
+
+def check_pyyaml() -> CheckResult:
+    ok, detail = command_output([sys.executable, "-c", "import yaml; print(yaml.__version__)"])
+    if ok:
+        return CheckResult("PyYAML", "PASS", detail)
+    return CheckResult(
+        "PyYAML",
+        "SKIP",
+        "optional; install with `python3 -m pip install PyYAML` for YAML-backed helper scripts",
+        required=False,
+    )
+
+
+def node_is_relevant(root: Path) -> bool:
+    return any(
+        path.exists()
+        for path in (
+            root / "desktop/macos/agent/package.json",
+            root / "desktop/macos/pi-mono-extension/package.json",
+            root / "desktop/macos/agent-cloud/package.json",
+        )
+    )
+
+
+def parse_port(raw_port: str) -> int | None:
+    try:
+        port = int(raw_port)
+    except (TypeError, ValueError):
+        return None
+    if port < 1 or port > 65535:
+        return None
+    return port
+
+
+def automation_token(port: int) -> str | None:
+    token = os.environ.get("OMI_AUTOMATION_TOKEN", "").strip()
+    if token:
+        return token
+    token_file = Path(
+        os.environ.get("OMI_AUTOMATION_TOKEN_FILE")
+        or os.path.join(os.environ.get("TMPDIR", "/tmp"), f"omi-automation-{port}.token")
+    )
+    try:
+        token = token_file.read_text(encoding="utf-8").strip()
+    except FileNotFoundError:
+        return None
+    return token or None
+
+
+def check_bridge(raw_port: str, required: bool) -> CheckResult:
+    if not required:
+        return CheckResult("automation bridge", "SKIP", "pass --require-bridge to check reachability", required=False)
+    port = parse_port(raw_port)
+    if port is None:
+        return CheckResult("automation bridge", "FAIL", f"invalid automation port: {raw_port!r}")
+    token = automation_token(port)
+    if not token:
+        return CheckResult(
+            "automation bridge",
+            "FAIL",
+            f"missing automation token for port {port}; launch a non-prod bundle or set OMI_AUTOMATION_TOKEN",
+        )
+    request = urllib.request.Request(
+        f"http://127.0.0.1:{port}/state",
+        headers={"Authorization": f"Bearer {token}", "Accept": "application/json"},
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=3) as response:
+            payload = response.read().decode("utf-8", errors="replace")
+    except urllib.error.URLError as exc:
+        return CheckResult("automation bridge", "FAIL", f"port {port} not reachable: {exc.reason}")
+    except TimeoutError:
+        return CheckResult("automation bridge", "FAIL", f"port {port} timed out")
+    result = bridge_payload_result(payload, port)
+    if result is not None:
+        return result
+    return CheckResult("automation bridge", "PASS", f"reachable on 127.0.0.1:{port}")
+
+
+def bridge_payload_result(payload: str, port: int) -> CheckResult | None:
+    try:
+        data = json.loads(payload)
+    except json.JSONDecodeError:
+        return CheckResult("automation bridge", "FAIL", "bridge returned non-JSON response")
+    if data.get("ok") is not True:
+        return CheckResult(
+            "automation bridge",
+            "FAIL",
+            f"bridge did not return ok=true: {data.get('error', 'unknown error')}",
+        )
+    return None
+
+
+def default_auth_file(root: Path) -> Path:
+    return root / "desktop/macos/tmp/desktop-auth.json"
+
+
+def auth_value(data: dict, key: str):
+    value = data.get(key)
+    if isinstance(value, dict) and "value" in value:
+        return value.get("value")
+    return value
+
+
+def check_auth_seed(path: Path, required: bool) -> CheckResult:
+    if not required:
+        return CheckResult("auth seed", "SKIP", "pass --require-auth-seed to require desktop auth seed", required=False)
+    if not path.exists():
+        return CheckResult("auth seed", "FAIL", f"missing {path}; run `cd desktop/macos && ./scripts/omi-auth-dump.sh`")
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        return CheckResult("auth seed", "FAIL", f"could not parse {path}: {exc}")
+    signed_in = str(auth_value(data, "auth_isSignedIn")).lower() in {"1", "true", "yes"}
+    has_token = bool(auth_value(data, "auth_idToken"))
+    if not signed_in or not has_token:
+        return CheckResult("auth seed", "FAIL", f"{path} does not contain signed-in auth_idToken data")
+    email = auth_value(data, "auth_userEmail") or "unknown email"
+    return CheckResult("auth seed", "PASS", f"{path} signed in as {email}")
+
+
+def collect_checks(args: argparse.Namespace, root: Path) -> list[CheckResult]:
+    checks = [
+        check_tool("xcrun SwiftPM", ["xcrun", "swift", "--version"]),
+        check_tool("cargo", ["cargo", "--version"]),
+        check_pyyaml(),
+    ]
+    if args.skip_node:
+        checks.append(CheckResult("node", "SKIP", "--skip-node was passed", required=False))
+        checks.append(CheckResult("npm", "SKIP", "--skip-node was passed", required=False))
+    elif node_is_relevant(root):
+        checks.append(check_tool("node", ["node", "--version"]))
+        checks.append(check_tool("npm", ["npm", "--version"]))
+    else:
+        checks.append(CheckResult("node/npm", "SKIP", "no desktop Node package.json found", required=False))
+
+    if args.skip_agent_swift:
+        checks.append(CheckResult("agent-swift", "SKIP", "--skip-agent-swift was passed", required=False))
+    else:
+        checks.append(check_tool("agent-swift", ["agent-swift", "--version"]))
+
+    auth_file = Path(args.auth_file).expanduser() if args.auth_file else default_auth_file(root)
+    checks.append(check_bridge(args.port, args.require_bridge))
+    checks.append(check_auth_seed(auth_file, args.require_auth_seed))
+    return checks
+
+
+def print_results(checks: list[CheckResult]) -> int:
+    for check in checks:
+        print(f"{check.status:4} {check.name}: {check.detail}")
+    failures = [check for check in checks if check.status == "FAIL" and check.required]
+    if failures:
+        print(f"FAIL: {len(failures)} required desktop verification prerequisite(s) failed.", file=sys.stderr)
+        return 1
+    print("OK: desktop verification preflight passed.")
+    return 0
+
+
+def main() -> int:
+    args = parse_args()
+    root = repo_root(args.root)
+    return print_results(collect_checks(args, root))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/desktop/macos/scripts/swift-test-skip-ratchet.py
+++ b/desktop/macos/scripts/swift-test-skip-ratchet.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""Validate and expose the known-red Swift XCTest method skip list.
+
+The skip list is intentionally machine-readable and ratcheted: adding a skipped
+method without also making an explicit baseline change fails this check. The
+ratchet stores both the current count and the exact allowed skipped test IDs so
+same-count swaps do not silently introduce a new known-red test.
+Removing skips is allowed and should be followed by lowering max_skip_count.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+DEFAULT_SKIP_FILE = Path(__file__).with_name("swift-test-skips.json")
+DEFAULT_TESTS_ROOT = Path(__file__).resolve().parents[1] / "Desktop" / "Tests"
+TEST_ID_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*/test[A-Za-z0-9_]+$")
+METHOD_RE_TEMPLATE = r"\bfunc\s+{method}\s*\("
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--skip-file", default=str(DEFAULT_SKIP_FILE), help="Path to swift-test-skips.json.")
+    parser.add_argument(
+        "--tests-root",
+        default=str(DEFAULT_TESTS_ROOT),
+        help="Desktop Swift tests root used to verify skipped methods still exist.",
+    )
+    parser.add_argument("--check", action="store_true", help="Validate the ratchet file and skipped test existence.")
+    parser.add_argument("--args-for-suite", metavar="SUITE", help="Print SwiftPM --skip arguments for one suite.")
+    parser.add_argument("--list", action="store_true", help="Print skipped test identifiers, one per line.")
+    return parser.parse_args()
+
+
+def load_skip_file(path: Path) -> dict[str, Any]:
+    try:
+        with path.open(encoding="utf-8") as handle:
+            data = json.load(handle)
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError(f"could not read {path}: {exc}") from exc
+    if not isinstance(data, dict):
+        raise ValueError("skip file must contain a JSON object")
+    return data
+
+
+def normalized_skips(data: dict[str, Any]) -> list[dict[str, str]]:
+    raw_skips = data.get("skips")
+    if not isinstance(raw_skips, list):
+        raise ValueError("skip file must contain a skips array")
+
+    skips: list[dict[str, str]] = []
+    seen: set[str] = set()
+    for index, raw_skip in enumerate(raw_skips):
+        if not isinstance(raw_skip, dict):
+            raise ValueError(f"skips[{index}] must be an object")
+        skip = {}
+        for key in ("test", "issue", "reason"):
+            value = raw_skip.get(key)
+            if not isinstance(value, str) or not value.strip():
+                raise ValueError(f"skips[{index}].{key} must be a non-empty string")
+            skip[key] = value.strip()
+        if not TEST_ID_RE.match(skip["test"]):
+            raise ValueError(f"skips[{index}].test must look like SuiteName/testMethodName")
+        if skip["test"] in seen:
+            raise ValueError(f"duplicate skipped test: {skip['test']}")
+        seen.add(skip["test"])
+        skips.append(skip)
+    return skips
+
+
+def validate_ratchet(data: dict[str, Any], skips: list[dict[str, str]]) -> list[str]:
+    errors: list[str] = []
+    max_skip_count = data.get("max_skip_count")
+    if not isinstance(max_skip_count, int) or max_skip_count < 0:
+        errors.append("max_skip_count must be a non-negative integer")
+    elif len(skips) > max_skip_count:
+        errors.append(f"skip count rose to {len(skips)} (max_skip_count {max_skip_count})")
+
+    raw_allowed = data.get("allowed_tests")
+    if not isinstance(raw_allowed, list):
+        errors.append("allowed_tests must list the exact ratcheted skipped test IDs")
+        return errors
+    allowed: list[str] = []
+    seen: set[str] = set()
+    for index, value in enumerate(raw_allowed):
+        if not isinstance(value, str) or not TEST_ID_RE.match(value):
+            errors.append(f"allowed_tests[{index}] must look like SuiteName/testMethodName")
+            continue
+        if value in seen:
+            errors.append(f"duplicate allowed skipped test: {value}")
+        seen.add(value)
+        allowed.append(value)
+    skip_ids = [skip["test"] for skip in skips]
+    new_skips = sorted(set(skip_ids) - set(allowed))
+    stale_allowed = sorted(set(allowed) - set(skip_ids))
+    if new_skips:
+        errors.append(
+            "new skipped test IDs are not in the ratcheted baseline: " + ", ".join(new_skips)
+        )
+    if stale_allowed:
+        errors.append(
+            "allowed_tests contains IDs not present in skips; remove them to ratchet the gain: "
+            + ", ".join(stale_allowed)
+        )
+    return errors
+
+
+def validate_skipped_methods_exist(tests_root: Path, skips: list[dict[str, str]]) -> list[str]:
+    errors: list[str] = []
+    files_by_suite: dict[str, list[Path]] = {}
+    if not tests_root.exists():
+        errors.append(f"tests root does not exist: {tests_root}")
+        return errors
+
+    for path in sorted(tests_root.rglob("*.swift")):
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        for suite in {skip["test"].split("/", 1)[0] for skip in skips}:
+            if re.search(rf"\b(class|extension)\s+{re.escape(suite)}\b", text):
+                files_by_suite.setdefault(suite, []).append(path)
+
+    for skip in skips:
+        suite, method = skip["test"].split("/", 1)
+        files = files_by_suite.get(suite, [])
+        method_re = re.compile(METHOD_RE_TEMPLATE.format(method=re.escape(method)))
+        if not files:
+            errors.append(f"skipped suite no longer exists: {suite}")
+            continue
+        if not any(method_re.search(path.read_text(encoding="utf-8")) for path in files):
+            errors.append(f"skipped method no longer exists: {skip['test']}")
+    return errors
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        data = load_skip_file(Path(args.skip_file))
+        skips = normalized_skips(data)
+    except ValueError as exc:
+        print(f"FAIL: {exc}", file=sys.stderr)
+        return 1
+
+    if args.args_for_suite:
+        suite = args.args_for_suite
+        for skip in skips:
+            if skip["test"].split("/", 1)[0] == suite:
+                print("--skip")
+                print(skip["test"])
+        return 0
+
+    if args.list:
+        for skip in skips:
+            print(skip["test"])
+        return 0
+
+    errors = validate_ratchet(data, skips)
+    errors.extend(validate_skipped_methods_exist(Path(args.tests_root), skips))
+    if errors:
+        for error in errors:
+            print(f"FAIL: {error}", file=sys.stderr)
+        print(
+            "Swift XCTest method skips are ratcheted in "
+            "desktop/macos/scripts/swift-test-skips.json; fix the test or make "
+            "an explicit ratchet change with an issue and reason.",
+            file=sys.stderr,
+        )
+        return 1
+
+    max_skip_count = data["max_skip_count"]
+    if len(skips) < max_skip_count:
+        print(
+            f"NOTE: Swift XCTest method skips dropped to {len(skips)} "
+            f"(max_skip_count {max_skip_count}). Lower max_skip_count to ratchet the gain."
+        )
+    else:
+        print(f"OK: Swift XCTest method skips at ratchet ({len(skips)}).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/desktop/macos/scripts/swift-test-skips.json
+++ b/desktop/macos/scripts/swift-test-skips.json
@@ -1,0 +1,37 @@
+{
+  "max_skip_count": 5,
+  "allowed_tests": [
+    "ChatDiscoverabilityTests/testAgentControlCapabilitiesMatchCanonicalManifest",
+    "ChatDiscoverabilityTests/testDesktopCapabilitiesExistInAgentToolDeclarations",
+    "APIClientRoutingTests/testDeleteConversationRoutesToPython",
+    "ActionItemsFTSRepairTests/testRepairToleratesMissingActionItemsFTSShadowTable",
+    "PiMonoWiringTests/testLocalAgentProviderDetectorMissingPromptIsUserFacing"
+  ],
+  "skips": [
+    {
+      "test": "ChatDiscoverabilityTests/testAgentControlCapabilitiesMatchCanonicalManifest",
+      "issue": "https://github.com/BasedHardware/omi/issues/9030",
+      "reason": "Swift DesktopCapabilityRegistry, agent control-tool-manifest.ts, and the desktop chat prompt have drifted; reconciling the canonical tool set is a product decision."
+    },
+    {
+      "test": "ChatDiscoverabilityTests/testDesktopCapabilitiesExistInAgentToolDeclarations",
+      "issue": "https://github.com/BasedHardware/omi/issues/9030",
+      "reason": "Swift DesktopCapabilityRegistry, agent control-tool-manifest.ts, and the desktop chat prompt have drifted; reconciling the canonical tool set is a product decision."
+    },
+    {
+      "test": "APIClientRoutingTests/testDeleteConversationRoutesToPython",
+      "issue": "https://github.com/BasedHardware/omi/issues/9031",
+      "reason": "The client omits ?cascade=true; cascade is backend-gated behind owner sign-off, so flipping it is a data-deletion behavior change."
+    },
+    {
+      "test": "ActionItemsFTSRepairTests/testRepairToleratesMissingActionItemsFTSShadowTable",
+      "issue": "https://github.com/BasedHardware/omi/issues/9032",
+      "reason": "macOS 26 system SQLite rejects DELETE FROM sqlite_master even with writable_schema=ON, blocking the test corruption setup."
+    },
+    {
+      "test": "PiMonoWiringTests/testLocalAgentProviderDetectorMissingPromptIsUserFacing",
+      "issue": "https://github.com/BasedHardware/omi/issues/9033",
+      "reason": "The detector does not fully honor the injected environment/home, so the result depends on whether OpenClaw is installed on the runner."
+    }
+  ]
+}

--- a/desktop/macos/scripts/swift-test-suites.sh
+++ b/desktop/macos/scripts/swift-test-suites.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Runs Swift XCTest suites in isolated, parallel processes.
+# Runs Swift XCTest suites in isolated processes, with opt-in parallelism.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -8,7 +8,7 @@ MACOS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 SKIP_RATCHET="$SCRIPT_DIR/swift-test-skip-ratchet.py"
 TESTS_ROOT="${OMI_SWIFT_TEST_DISCOVERY_ROOT:-$MACOS_DIR/Desktop/Tests}"
 PACKAGE_PATH="${OMI_SWIFT_TEST_PACKAGE_PATH:-Desktop}"
-WORKERS="${OMI_SWIFT_TEST_SUITE_WORKERS:-${SWIFT_TEST_SUITE_WORKERS:-2}}"
+WORKERS="${OMI_SWIFT_TEST_SUITE_WORKERS:-${SWIFT_TEST_SUITE_WORKERS:-1}}"
 PREBUILD="${OMI_SWIFT_TEST_PREBUILD:-1}"
 
 fail() {

--- a/desktop/macos/scripts/swift-test-suites.sh
+++ b/desktop/macos/scripts/swift-test-suites.sh
@@ -1,47 +1,103 @@
-#!/bin/bash
-# Runs Swift XCTest suites in isolated processes.
+#!/usr/bin/env bash
+# Runs Swift XCTest suites in isolated, parallel processes.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT_PATH="$SCRIPT_DIR/$(basename "$0")"
 MACOS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+SKIP_RATCHET="$SCRIPT_DIR/swift-test-skip-ratchet.py"
+TESTS_ROOT="${OMI_SWIFT_TEST_DISCOVERY_ROOT:-$MACOS_DIR/Desktop/Tests}"
+PACKAGE_PATH="${OMI_SWIFT_TEST_PACKAGE_PATH:-Desktop}"
+WORKERS="${OMI_SWIFT_TEST_SUITE_WORKERS:-${SWIFT_TEST_SUITE_WORKERS:-2}}"
+PREBUILD="${OMI_SWIFT_TEST_PREBUILD:-1}"
 
-skip_for_suite() {
-  case "$1" in
-    ChatDiscoverabilityTests)
-      echo "--skip ChatDiscoverabilityTests/testAgentControlCapabilitiesMatchCanonicalManifest --skip ChatDiscoverabilityTests/testDesktopCapabilitiesExistInAgentToolDeclarations --skip ChatDiscoverabilityTests/testDesktopPromptDistinguishesDelegationFromFloatingPills" ;;
-    APIClientRoutingTests)
-      echo "--skip APIClientRoutingTests/testDeleteConversationRoutesToPython" ;;
-    ActionItemsFTSRepairTests)
-      echo "--skip ActionItemsFTSRepairTests/testRepairToleratesMissingActionItemsFTSShadowTable" ;;
-    PiMonoWiringTests)
-      echo "--skip PiMonoWiringTests/testLocalAgentProviderDetectorMissingPromptIsUserFacing" ;;
-  esac
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
 }
 
-cd "$MACOS_DIR"
+run_suite() {
+  local log_dir="$1"
+  local suite="$2"
+  local log_path="$log_dir/$suite.log"
+  local status_path="$log_dir/$suite.status"
+  local -a skip_args=()
+
+  while IFS= read -r skip_arg; do
+    skip_args+=("$skip_arg")
+  done < <("$SKIP_RATCHET" --args-for-suite "$suite")
+  local -a build_args=()
+  if [ "$PREBUILD" = "1" ]; then
+    build_args+=("--skip-build")
+  fi
+  local -a command=(xcrun swift test --package-path "$PACKAGE_PATH" "${build_args[@]}" --filter "${suite}/")
+  if [ "${#skip_args[@]}" -gt 0 ]; then
+    command+=("${skip_args[@]}")
+  fi
+  set +e
+  "${command[@]}" >"$log_path" 2>&1
+  local status=$?
+  set -e
+  echo "$status" >"$status_path"
+  exit "$status"
+}
+
+if [ "${1:-}" = "__run_suite" ]; then
+  run_suite "$2" "$3"
+fi
+
+[[ "$WORKERS" =~ ^[0-9]+$ ]] || fail "worker count must be a positive integer, got '$WORKERS'"
+if [ "$WORKERS" -lt 1 ]; then
+  fail "worker count must be at least 1"
+fi
+if [ "$PREBUILD" != "0" ] && [ "$PREBUILD" != "1" ]; then
+  fail "OMI_SWIFT_TEST_PREBUILD must be 0 or 1, got '$PREBUILD'"
+fi
 
 # Discover suites recursively so tests in subfolders of Desktop/Tests are not
 # silently skipped (SwiftPM compiles the whole Tests target; this must match).
-suites=$(find Desktop/Tests -type f -name '*.swift' -print0 \
+declare -a suites=()
+while IFS= read -r suite; do
+  suites+=("$suite")
+done < <(find "$TESTS_ROOT" -type f -name '*.swift' -print0 \
   | xargs -0 grep -hE '^[[:space:]]*(@[A-Za-z0-9_]+[[:space:]]+)*(public |internal |private |fileprivate |open )?(final )?(class|extension) [A-Za-z0-9_]+:.*XCTestCase' \
   | sed -E 's/^[[:space:]]*(@[A-Za-z0-9_]+[[:space:]]+)*(public |internal |private |fileprivate |open )?(final )?(class|extension) ([A-Za-z0-9_]+):.*/\5/' \
   | sort -u)
+
+"$SKIP_RATCHET" --check --tests-root "$TESTS_ROOT"
+
+cd "$MACOS_DIR"
 suite_log_dir="$(mktemp -d)"
 trap 'rm -rf "$suite_log_dir"' EXIT
 failed_suites=""
-suite_count=0
-while read -r suite; do
-  [ -z "$suite" ] && continue
-  suite_count=$((suite_count + 1))
-  # shellcheck disable=SC2046
-  if ! xcrun swift test --package-path Desktop --filter "${suite}/" $(skip_for_suite "$suite") \
-      >"$suite_log_dir/$suite.log" 2>&1; then
+suite_count="${#suites[@]}"
+
+if [ "$PREBUILD" = "1" ] && [ "$suite_count" -gt 0 ]; then
+  echo "Prebuilding Swift test bundle before parallel suite execution..."
+  xcrun swift build --package-path "$PACKAGE_PATH" --build-tests
+fi
+
+if [ "$suite_count" -gt 0 ]; then
+  printf '%s\0' "${suites[@]}" \
+    | xargs -0 -n1 -P "$WORKERS" "$SCRIPT_PATH" __run_suite "$suite_log_dir" || true
+fi
+
+for suite in "${suites[@]}"; do
+  status_path="$suite_log_dir/$suite.status"
+  if [ ! -f "$status_path" ]; then
+    failed_suites="$failed_suites $suite"
+    echo "--- FAILED: $suite ---"
+    echo "suite did not produce a status file"
+    continue
+  fi
+  if [ "$(cat "$status_path")" != "0" ]; then
     failed_suites="$failed_suites $suite"
     echo "--- FAILED: $suite ---"
     cat "$suite_log_dir/$suite.log"
   fi
-done <<< "$suites"
-echo "Ran $suite_count Swift suites in isolation."
+done
+
+echo "Ran $suite_count Swift suites in isolation with $WORKERS worker(s)."
 
 if [ -n "$failed_suites" ]; then
   echo "FAILED Swift suites:$failed_suites"

--- a/desktop/macos/test.sh
+++ b/desktop/macos/test.sh
@@ -12,6 +12,11 @@ bash tests/test-settings-seed.sh
 bash tests/test-cleanup-omi-tcc.sh
 bash tests/test-omi-harness.sh
 bash tests/test-signed-artifact-smoke.sh
+bash tests/test-e2e-flow-coverage.sh
+bash tests/test-desktop-doctor-preflight.sh
+bash tests/test-swift-test-skip-ratchet.sh
+bash tests/test-swift-test-suites.sh
+python3 scripts/check-e2e-flow-coverage.py --strict
 echo ""
 
 echo "=== Rust Backend Tests ==="
@@ -19,7 +24,7 @@ cd "$SCRIPT_DIR/Backend-Rust"
 cargo test
 echo ""
 
-echo "=== Swift App Tests (per-suite process isolation) ==="
+echo "=== Swift App Tests (parallel per-suite process isolation) ==="
 cd "$SCRIPT_DIR"
 # Each XCTest suite runs in its own `swift test --filter` process.
 #
@@ -33,26 +38,8 @@ cd "$SCRIPT_DIR"
 # Tracking: https://github.com/BasedHardware/omi/issues/9029
 # (durable fix is singleton dependency injection; see the same issue).
 #
-# Method-level skips in scripts/swift-test-suites.sh are the only remaining
-# known-red tests; each needs a product/policy decision, not a test change:
-#   ChatDiscoverabilityTests/{testAgentControlCapabilitiesMatchCanonicalManifest,
-#     testDesktopCapabilitiesExistInAgentToolDeclarations,
-#     testDesktopPromptDistinguishesDelegationFromFloatingPills}
-#       — Swift DesktopCapabilityRegistry vs agent control-tool-manifest.ts vs the
-#         desktop chat prompt have drifted; reconciling the canonical tool set is a
-#         product change. https://github.com/BasedHardware/omi/issues/9030
-#   APIClientRoutingTests/testDeleteConversationRoutesToPython
-#       — client omits ?cascade=true; cascade is backend-gated behind owner sign-off
-#         (backend/routers/conversations.py), so flipping it is a data-deletion
-#         behavior change, not a test fix. https://github.com/BasedHardware/omi/issues/9031
-#   ActionItemsFTSRepairTests/testRepairToleratesMissingActionItemsFTSShadowTable
-#       — macOS 26 system SQLite rejects `DELETE FROM sqlite_master` even with
-#         writable_schema=ON, blocking the test's corruption setup.
-#         https://github.com/BasedHardware/omi/issues/9032
-#   PiMonoWiringTests/testLocalAgentProviderDetectorMissingPromptIsUserFacing
-#       — the detector does not fully honor the injected environment/home, so the
-#         result depends on whether OpenClaw is installed on the runner.
-#         https://github.com/BasedHardware/omi/issues/9033
+# Method-level skips are ratcheted in scripts/swift-test-skips.json so new
+# known-red tests require an explicit issue, reason, and skip-count change.
 "$SCRIPT_DIR/scripts/swift-test-suites.sh"
 echo ""
 

--- a/desktop/macos/tests/test-desktop-doctor-preflight.sh
+++ b/desktop/macos/tests/test-desktop-doctor-preflight.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MACOS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+SCRIPT="$MACOS_DIR/scripts/desktop-doctor-preflight.py"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+TMPDIR="$(mktemp -d)"
+cleanup() {
+  rm -rf "$TMPDIR"
+}
+trap cleanup EXIT
+
+mkdir -p "$TMPDIR/bin" "$TMPDIR/desktop/macos/pi-mono-extension" "$TMPDIR/desktop/macos/tmp"
+touch "$TMPDIR/desktop/macos/pi-mono-extension/package.json"
+
+cat >"$TMPDIR/bin/xcrun" <<'SH'
+#!/usr/bin/env bash
+echo "swift-driver version test"
+SH
+cat >"$TMPDIR/bin/cargo" <<'SH'
+#!/usr/bin/env bash
+echo "cargo 1.0.0"
+SH
+cat >"$TMPDIR/bin/node" <<'SH'
+#!/usr/bin/env bash
+echo "v20.0.0"
+SH
+cat >"$TMPDIR/bin/npm" <<'SH'
+#!/usr/bin/env bash
+echo "10.0.0"
+SH
+cat >"$TMPDIR/bin/agent-swift" <<'SH'
+#!/usr/bin/env bash
+echo "agent-swift test"
+SH
+chmod +x "$TMPDIR/bin/"*
+
+cat >"$TMPDIR/desktop/macos/tmp/desktop-auth.json" <<'JSON'
+{
+  "auth_isSignedIn": {"value": true},
+  "auth_idToken": {"value": "token"},
+  "auth_userEmail": {"value": "dev@example.com"}
+}
+JSON
+
+PATH="$TMPDIR/bin:$PATH" "$SCRIPT" --root "$TMPDIR" --require-auth-seed >"$TMPDIR/pass.out" 2>"$TMPDIR/pass.err" || \
+  fail "doctor preflight unexpectedly failed with fake prerequisites"
+grep -q "PASS xcrun SwiftPM" "$TMPDIR/pass.out" || fail "xcrun check missing"
+grep -q "PASS auth seed" "$TMPDIR/pass.out" || fail "auth seed check missing"
+grep -q "SKIP automation bridge" "$TMPDIR/pass.out" || fail "bridge skip missing"
+
+rm "$TMPDIR/desktop/macos/tmp/desktop-auth.json"
+if PATH="$TMPDIR/bin:$PATH" "$SCRIPT" --root "$TMPDIR" --require-auth-seed >"$TMPDIR/fail.out" 2>"$TMPDIR/fail.err"; then
+  fail "doctor preflight unexpectedly passed without required auth seed"
+fi
+grep -q "FAIL auth seed" "$TMPDIR/fail.out" || fail "missing auth seed was not reported"
+grep -q "required desktop verification prerequisite" "$TMPDIR/fail.err" || fail "failure summary missing"
+
+if OMI_AUTOMATION_PORT=not-a-port PATH="$TMPDIR/bin:$PATH" "$SCRIPT" --root "$TMPDIR" --require-bridge \
+    >"$TMPDIR/bad-port.out" 2>"$TMPDIR/bad-port.err"; then
+  fail "doctor preflight unexpectedly passed with an invalid automation port"
+fi
+grep -q "FAIL automation bridge: invalid automation port: 'not-a-port'" "$TMPDIR/bad-port.out" || \
+  fail "invalid automation port was not reported as a normal check failure"
+
+python3 - "$SCRIPT" <<'PY'
+import importlib.util
+import sys
+
+spec = importlib.util.spec_from_file_location("doctor", sys.argv[1])
+doctor = importlib.util.module_from_spec(spec)
+sys.modules["doctor"] = doctor
+spec.loader.exec_module(doctor)
+
+failure = doctor.bridge_payload_result('{"state":"not an automation response"}', 47777)
+assert failure is not None
+assert failure.status == "FAIL"
+assert "ok=true" in failure.detail
+
+success = doctor.bridge_payload_result('{"ok": true, "result": {}}', 47777)
+assert success is None
+PY
+
+echo "desktop doctor preflight tests passed"

--- a/desktop/macos/tests/test-e2e-flow-coverage.sh
+++ b/desktop/macos/tests/test-e2e-flow-coverage.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MACOS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+SCRIPT="$MACOS_DIR/scripts/check-e2e-flow-coverage.py"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+TMPDIR="$(mktemp -d)"
+cleanup() {
+  rm -rf "$TMPDIR"
+}
+trap cleanup EXIT
+
+mkdir -p "$TMPDIR/desktop/macos/e2e/flows"
+cat >"$TMPDIR/desktop/macos/e2e/flows/chat.yaml" <<'YAML'
+version: 2
+name: chat
+covers:
+  - desktop/Desktop/Sources/MainWindow/Pages/ChatPage.swift
+YAML
+
+covered="desktop/macos/Desktop/Sources/MainWindow/Pages/ChatPage.swift"
+uncovered="desktop/macos/Desktop/Sources/MainWindow/Pages/UncoveredPage.swift"
+
+if ! "$SCRIPT" --root "$TMPDIR" "$covered" "$uncovered" >"$TMPDIR/report.out" 2>"$TMPDIR/report.err"; then
+  fail "advisory coverage check unexpectedly failed"
+fi
+grep -q "COVERED   $covered -> chat (chat.yaml)" "$TMPDIR/report.out" || fail "covered file was not reported"
+grep -q "UNCOVERED $uncovered" "$TMPDIR/report.out" || fail "uncovered file was not reported"
+grep -q "OMI_APP_NAME=omi-e2e ./scripts/omi-harness run e2e/flows/chat.yaml" "$TMPDIR/report.out" || \
+  fail "recommended harness command missing"
+
+if "$SCRIPT" --root "$TMPDIR" --strict "$covered" "$uncovered" >"$TMPDIR/strict.out" 2>"$TMPDIR/strict.err"; then
+  fail "strict coverage check unexpectedly passed with an uncovered file"
+fi
+grep -q "FAIL: uncovered changed desktop Swift files found" "$TMPDIR/strict.err" || fail "strict failure was not explained"
+
+echo "e2e flow coverage tests passed"

--- a/desktop/macos/tests/test-swift-test-skip-ratchet.sh
+++ b/desktop/macos/tests/test-swift-test-skip-ratchet.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MACOS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+RATCHET="$MACOS_DIR/scripts/swift-test-skip-ratchet.py"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+TMPDIR="$(mktemp -d)"
+cleanup() {
+  rm -rf "$TMPDIR"
+}
+trap cleanup EXIT
+
+mkdir -p "$TMPDIR/tests"
+cat >"$TMPDIR/tests/ExampleTests.swift" <<'SWIFT'
+import XCTest
+final class ExampleTests: XCTestCase {
+    func testKnownRed() {}
+}
+SWIFT
+
+cat >"$TMPDIR/ok.json" <<'JSON'
+{
+  "max_skip_count": 1,
+  "allowed_tests": ["ExampleTests/testKnownRed"],
+  "skips": [
+    {
+      "test": "ExampleTests/testKnownRed",
+      "issue": "https://github.com/BasedHardware/omi/issues/1",
+      "reason": "Fixture known-red test."
+    }
+  ]
+}
+JSON
+
+if ! "$RATCHET" --check --skip-file "$TMPDIR/ok.json" --tests-root "$TMPDIR/tests" >"$TMPDIR/ok.out"; then
+  fail "valid ratchet file failed"
+fi
+if ! grep -q "OK: Swift XCTest method skips at ratchet (1)." "$TMPDIR/ok.out"; then
+  fail "valid ratchet output did not report the count"
+fi
+
+args="$("$RATCHET" --skip-file "$TMPDIR/ok.json" --args-for-suite ExampleTests)"
+expected=$'--skip\nExampleTests/testKnownRed'
+if [ "$args" != "$expected" ]; then
+  fail "args-for-suite output was '$args'"
+fi
+
+cat >"$TMPDIR/too-many.json" <<'JSON'
+{
+  "max_skip_count": 0,
+  "allowed_tests": ["ExampleTests/testKnownRed"],
+  "skips": [
+    {
+      "test": "ExampleTests/testKnownRed",
+      "issue": "https://github.com/BasedHardware/omi/issues/1",
+      "reason": "Fixture known-red test."
+    }
+  ]
+}
+JSON
+if "$RATCHET" --check --skip-file "$TMPDIR/too-many.json" --tests-root "$TMPDIR/tests" \
+    >"$TMPDIR/too-many.out" 2>"$TMPDIR/too-many.err"; then
+  fail "ratchet unexpectedly allowed a skip-count increase"
+fi
+if ! grep -q "skip count rose to 1 (max_skip_count 0)" "$TMPDIR/too-many.err"; then
+  fail "ratchet failure did not explain the skip-count increase"
+fi
+
+cat >"$TMPDIR/stale.json" <<'JSON'
+{
+  "max_skip_count": 1,
+  "allowed_tests": ["ExampleTests/testMissing"],
+  "skips": [
+    {
+      "test": "ExampleTests/testMissing",
+      "issue": "https://github.com/BasedHardware/omi/issues/1",
+      "reason": "Fixture known-red test."
+    }
+  ]
+}
+JSON
+if "$RATCHET" --check --skip-file "$TMPDIR/stale.json" --tests-root "$TMPDIR/tests" \
+    >"$TMPDIR/stale.out" 2>"$TMPDIR/stale.err"; then
+  fail "ratchet unexpectedly allowed a stale skipped method"
+fi
+if ! grep -q "skipped method no longer exists: ExampleTests/testMissing" "$TMPDIR/stale.err"; then
+  fail "stale skip failure did not identify the missing method"
+fi
+
+cat >"$TMPDIR/tests/SwapTests.swift" <<'SWIFT'
+import XCTest
+final class SwapTests: XCTestCase {
+    func testNewKnownRed() {}
+}
+SWIFT
+cat >"$TMPDIR/swapped.json" <<'JSON'
+{
+  "max_skip_count": 1,
+  "allowed_tests": ["ExampleTests/testKnownRed"],
+  "skips": [
+    {
+      "test": "SwapTests/testNewKnownRed",
+      "issue": "https://github.com/BasedHardware/omi/issues/2",
+      "reason": "Fixture same-count swap."
+    }
+  ]
+}
+JSON
+if "$RATCHET" --check --skip-file "$TMPDIR/swapped.json" --tests-root "$TMPDIR/tests" \
+    >"$TMPDIR/swapped.out" 2>"$TMPDIR/swapped.err"; then
+  fail "ratchet unexpectedly allowed a same-count skipped-test swap"
+fi
+if ! grep -q "new skipped test IDs are not in the ratcheted baseline: SwapTests/testNewKnownRed" \
+    "$TMPDIR/swapped.err"; then
+  fail "same-count swap failure did not identify the new skipped test"
+fi
+
+echo "swift-test-skip-ratchet tests passed"

--- a/desktop/macos/tests/test-swift-test-suites.sh
+++ b/desktop/macos/tests/test-swift-test-suites.sh
@@ -74,7 +74,7 @@ suite="${filter%/}"
 
 case "$suite" in
   AlphaTests|BetaTests)
-    sleep 2
+    sleep 3
     ;;
 esac
 
@@ -99,7 +99,7 @@ if "$RUNNER" >"$TMPDIR/runner.out" 2>"$TMPDIR/runner.err"; then
 fi
 elapsed=$(( $(date +%s) - start ))
 
-if [ "$elapsed" -ge 4 ]; then
+if [ "$elapsed" -ge 6 ]; then
   fail "runner did not execute AlphaTests and BetaTests in parallel; elapsed=${elapsed}s"
 fi
 if ! grep -q -- "--- FAILED: AlphaTests ---" "$TMPDIR/runner.out"; then

--- a/desktop/macos/tests/test-swift-test-suites.sh
+++ b/desktop/macos/tests/test-swift-test-suites.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MACOS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+RUNNER="$MACOS_DIR/scripts/swift-test-suites.sh"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+TMPDIR="$(mktemp -d)"
+cleanup() {
+  rm -rf "$TMPDIR"
+}
+trap cleanup EXIT
+
+mkdir -p "$TMPDIR/tests" "$TMPDIR/bin"
+cat >"$TMPDIR/tests/AlphaTests.swift" <<'SWIFT'
+import XCTest
+final class AlphaTests: XCTestCase {
+    func testOne() {}
+}
+SWIFT
+cat >"$TMPDIR/tests/BetaTests.swift" <<'SWIFT'
+import XCTest
+final class BetaTests: XCTestCase {
+    func testOne() {}
+}
+SWIFT
+cat >"$TMPDIR/tests/ChatDiscoverabilityTests.swift" <<'SWIFT'
+import XCTest
+final class ChatDiscoverabilityTests: XCTestCase {
+    func testAgentControlCapabilitiesMatchCanonicalManifest() {}
+    func testDesktopCapabilitiesExistInAgentToolDeclarations() {}
+    func testDesktopPromptDistinguishesDelegationFromFloatingPills() {}
+}
+SWIFT
+cat >"$TMPDIR/tests/APIClientRoutingTests.swift" <<'SWIFT'
+import XCTest
+final class APIClientRoutingTests: XCTestCase {
+    func testDeleteConversationRoutesToPython() {}
+}
+SWIFT
+cat >"$TMPDIR/tests/ActionItemsFTSRepairTests.swift" <<'SWIFT'
+import XCTest
+final class ActionItemsFTSRepairTests: XCTestCase {
+    func testRepairToleratesMissingActionItemsFTSShadowTable() {}
+}
+SWIFT
+cat >"$TMPDIR/tests/PiMonoWiringTests.swift" <<'SWIFT'
+import XCTest
+final class PiMonoWiringTests: XCTestCase {
+    func testLocalAgentProviderDetectorMissingPromptIsUserFacing() {}
+}
+SWIFT
+
+cat >"$TMPDIR/bin/xcrun" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "$*" >>"$FAKE_XCRUN_LOG"
+filter=""
+previous=""
+for arg in "$@"; do
+  if [ "$previous" = "--filter" ]; then
+    filter="$arg"
+    break
+  fi
+  previous="$arg"
+done
+suite="${filter%/}"
+
+case "$suite" in
+  AlphaTests|BetaTests)
+    sleep 2
+    ;;
+esac
+
+if [ "$suite" = "AlphaTests" ]; then
+  echo "alpha failed"
+  exit 42
+fi
+
+echo "$suite passed"
+SH
+chmod +x "$TMPDIR/bin/xcrun"
+
+export PATH="$TMPDIR/bin:$PATH"
+export FAKE_XCRUN_LOG="$TMPDIR/xcrun.log"
+export OMI_SWIFT_TEST_DISCOVERY_ROOT="$TMPDIR/tests"
+export OMI_SWIFT_TEST_PACKAGE_PATH="$TMPDIR/package"
+export OMI_SWIFT_TEST_SUITE_WORKERS=2
+
+start=$(date +%s)
+if "$RUNNER" >"$TMPDIR/runner.out" 2>"$TMPDIR/runner.err"; then
+  fail "runner unexpectedly succeeded despite AlphaTests failure"
+fi
+elapsed=$(( $(date +%s) - start ))
+
+if [ "$elapsed" -ge 4 ]; then
+  fail "runner did not execute AlphaTests and BetaTests in parallel; elapsed=${elapsed}s"
+fi
+if ! grep -q -- "--- FAILED: AlphaTests ---" "$TMPDIR/runner.out"; then
+  fail "runner did not print the failed suite heading"
+fi
+if ! grep -q "alpha failed" "$TMPDIR/runner.out"; then
+  fail "runner did not preserve the failed suite log"
+fi
+if ! grep -q "Ran 6 Swift suites in isolation with 2 worker(s)." "$TMPDIR/runner.out"; then
+  fail "runner did not report suite count and worker count"
+fi
+if ! grep -q -- "--skip ChatDiscoverabilityTests/testAgentControlCapabilitiesMatchCanonicalManifest" "$FAKE_XCRUN_LOG"; then
+  fail "runner did not pass ratcheted skips to SwiftPM"
+fi
+
+echo "swift-test-suites tests passed"


### PR DESCRIPTION
## Summary
- parallelize isolated desktop Swift XCTest suite execution with a prebuild step and configurable worker count
- add an exact-identity ratchet for known-red Swift test skips, plus focused guard tests
- add strict changed Swift file -> desktop e2e flow coverage checking and wire it into local `test.sh` plus CI
- add a desktop verification doctor preflight for local agent workflows
- enrich automation bridge action descriptors so agents can prefer semantic bridge actions before AX clicks

## Verification
- `bash tests/test-app-config.sh && bash tests/test-settings-seed.sh && bash tests/test-cleanup-omi-tcc.sh && bash tests/test-omi-harness.sh && bash tests/test-e2e-flow-coverage.sh && bash tests/test-desktop-doctor-preflight.sh && bash tests/test-swift-test-skip-ratchet.sh && bash tests/test-swift-test-suites.sh && python3 scripts/check-e2e-flow-coverage.py --strict`
- `python3 -m py_compile desktop/macos/scripts/check-e2e-flow-coverage.py desktop/macos/scripts/desktop-doctor-preflight.py desktop/macos/scripts/swift-test-skip-ratchet.py`
- `desktop/macos/scripts/swift-test-skip-ratchet.py --check`
- `desktop/macos/scripts/desktop-doctor-preflight.py`
- `xcrun swiftc -parse Desktop/Sources/DesktopAutomationBridge.swift Desktop/Tests/AgentContinuityGauntletTests.swift`
- no-PyYAML fallback smoke for `check-e2e-flow-coverage.py`
- independent P0/P1 review pass: no findings
- pre-push checks passed with `PRE_PUSH_SKIP_DESKTOP_SWIFT=1`; the skipped desktop Swift compile is currently blocked by an unrelated existing `Desktop/Sources/Chat/AgentBridge.swift` call to `AgentRuntimeProcess.query` with stale arguments

## Known blocker outside this PR
`xcrun swift build -c debug --package-path Desktop` and `xcrun swift test --package-path Desktop --filter AgentContinuityGauntletTests` currently fail before reaching this patch's tests because `Desktop/Sources/Chat/AgentBridge.swift` references stale query arguments (`sessionKey`, `omiSessionId`, `surfaceKind`, etc.) and misses `attachmentMetadataJson` / `surfaceContextJson`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9172?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

