### PR TITLE
Improve macOS core unit coverage

### DIFF
--- a/desktop/macos/Backend-Rust/src/services/firestore/chat_repository.rs
+++ b/desktop/macos/Backend-Rust/src/services/firestore/chat_repository.rs
@@ -1029,6 +1029,25 @@ mod tests {
     }
 
     #[test]
+    fn app_matching_accepts_legacy_main_shapes_and_requires_exact_plugin() {
+        let absent_fields = json!({});
+        let empty_fields = json!({
+            "plugin_id": {"stringValue": ""},
+            "app_id": {"stringValue": ""}
+        });
+        let plugin_fields = json!({
+            "plugin_id": {"stringValue": "plugin-a"},
+            "app_id": {"stringValue": "plugin-a"}
+        });
+
+        assert!(chat_session_matches_app(&absent_fields, None));
+        assert!(chat_session_matches_app(&empty_fields, None));
+        assert!(chat_session_matches_app(&plugin_fields, Some("plugin-a")));
+        assert!(!chat_session_matches_app(&plugin_fields, Some("plugin-b")));
+        assert!(!chat_session_matches_app(&plugin_fields, None));
+    }
+
+    #[test]
     fn create_chat_session_fields_preserve_main_nulls_and_plugin_fields() {
         let main_fields = build_create_chat_session_fields("session", None, None, timestamp());
         assert_eq!(main_fields["app_id"], json!({"nullValue": null}));

--- a/desktop/macos/Desktop/Sources/AuthService.swift
+++ b/desktop/macos/Desktop/Sources/AuthService.swift
@@ -552,27 +552,11 @@ class AuthService {
             throw AuthError.tokenExchangeFailed(httpResponse.statusCode)
         }
 
-        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-              let idToken = json["idToken"] as? String,
-              let refreshToken = json["refreshToken"] as? String else {
-            throw AuthError.invalidResponse
-        }
-        let expiresIn = Int(json["expiresIn"] as? String ?? "3600") ?? 3600
-        let localId = json["localId"] as? String ?? selectedLocalUserId(from: idToken) ?? ""
-        guard !localId.isEmpty else {
-            throw AuthError.invalidResponse
-        }
-        return FirebaseTokenResult(
-            idToken: idToken,
-            refreshToken: refreshToken,
-            expiresIn: expiresIn,
-            localId: localId
-        )
+        return try Self.decodeFirebaseTokenResult(from: data, requireLocalId: true)
     }
 
     private func selectedLocalUserId(from idToken: String) -> String? {
-        guard let payload = decodeJWT(idToken) else { return nil }
-        return payload["user_id"] as? String ?? payload["sub"] as? String
+        Self.localUserId(fromIDToken: idToken)
     }
 
     // MARK: - Auth Persistence (UserDefaults for dev builds)
@@ -1584,8 +1568,13 @@ class AuthService {
         return value.addingPercentEncoding(withAllowedCharacters: allowed) ?? ""
     }
 
+    nonisolated static func localUserId(fromIDToken idToken: String) -> String? {
+        guard let payload = decodeJWTPayload(idToken) else { return nil }
+        return payload["user_id"] as? String ?? payload["sub"] as? String
+    }
+
     /// Decode a JWT and return the payload as a dictionary
-    private func decodeJWT(_ jwt: String) -> [String: Any]? {
+    nonisolated static func decodeJWTPayload(_ jwt: String) -> [String: Any]? {
         let parts = jwt.split(separator: ".")
         guard parts.count >= 2 else { return nil }
 
@@ -1605,6 +1594,10 @@ class AuthService {
         }
 
         return json
+    }
+
+    private func decodeJWT(_ jwt: String) -> [String: Any]? {
+        Self.decodeJWTPayload(jwt)
     }
 
     // MARK: - User Name Management
@@ -1881,6 +1874,38 @@ class AuthService {
         let localId: String
     }
 
+    nonisolated static func decodeFirebaseTokenResult(
+        from data: Data,
+        requireLocalId: Bool = false
+    ) throws -> FirebaseTokenResult {
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let idToken = json["idToken"] as? String,
+              let refreshToken = json["refreshToken"] as? String else {
+            throw AuthError.invalidResponse
+        }
+
+        let expiresIn: Int
+        if let expiresInStr = json["expiresIn"] as? String {
+            expiresIn = Int(expiresInStr) ?? 3600
+        } else if let expiresInInt = json["expiresIn"] as? Int {
+            expiresIn = expiresInInt
+        } else {
+            expiresIn = 3600
+        }
+
+        let localId = json["localId"] as? String ?? localUserId(fromIDToken: idToken) ?? ""
+        if requireLocalId && localId.isEmpty {
+            throw AuthError.invalidResponse
+        }
+
+        return FirebaseTokenResult(
+            idToken: idToken,
+            refreshToken: refreshToken,
+            expiresIn: expiresIn,
+            localId: localId
+        )
+    }
+
     /// Exchange custom token for ID token using Firebase REST API
     private func exchangeCustomTokenForIdToken(customToken: String) async throws -> FirebaseTokenResult {
         let apiKey = try requireFirebaseApiKey()
@@ -1908,40 +1933,23 @@ class AuthService {
             throw AuthError.tokenExchangeFailed(httpResponse.statusCode)
         }
 
-        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-              let idToken = json["idToken"] as? String,
-              let refreshToken = json["refreshToken"] as? String else {
-            NSLog("OMI AUTH: Failed to parse Firebase response: %@", String(data: data, encoding: .utf8) ?? "nil")
-            throw AuthError.invalidResponse
-        }
-
-        // expiresIn can be String or Int
-        let expiresIn: Int
-        if let expiresInStr = json["expiresIn"] as? String {
-            expiresIn = Int(expiresInStr) ?? 3600
-        } else if let expiresInInt = json["expiresIn"] as? Int {
-            expiresIn = expiresInInt
-        } else {
-            expiresIn = 3600
-        }
-
-        // localId might be missing from REST API response - extract from JWT if needed
-        var localId = json["localId"] as? String ?? ""
-        if localId.isEmpty {
-            // Extract user_id from the JWT token payload
-            if let payload = decodeJWT(idToken),
-               let userId = payload["user_id"] as? String ?? payload["sub"] as? String {
-                localId = userId
-                NSLog("OMI AUTH: Extracted user_id from JWT: %@", localId)
+        do {
+            let tokens = try Self.decodeFirebaseTokenResult(from: data)
+            if !tokens.localId.isEmpty, jsonLocalIdMissing(in: data) {
+                NSLog("OMI AUTH: Extracted user_id from JWT: %@", tokens.localId)
             }
+            return tokens
+        } catch {
+            NSLog("OMI AUTH: Failed to parse Firebase response: %@", String(data: data, encoding: .utf8) ?? "nil")
+            throw error
         }
+    }
 
-        return FirebaseTokenResult(
-            idToken: idToken,
-            refreshToken: refreshToken,
-            expiresIn: expiresIn,
-            localId: localId
-        )
+    private func jsonLocalIdMissing(in data: Data) -> Bool {
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return false
+        }
+        return (json["localId"] as? String ?? "").isEmpty
     }
 
     /// Refresh the ID token using the refresh token
@@ -2329,29 +2337,11 @@ class AuthService {
             throw AuthError.tokenExchangeFailed(httpResponse.statusCode)
         }
 
-        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-              let idToken = json["idToken"] as? String,
-              let refreshToken = json["refreshToken"] as? String else {
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
             NSLog("OMI AUTH: Failed to parse Firebase signInWithIdp response")
             throw AuthError.invalidResponse
         }
-
-        let expiresIn: Int
-        if let expiresInStr = json["expiresIn"] as? String {
-            expiresIn = Int(expiresInStr) ?? 3600
-        } else if let expiresInInt = json["expiresIn"] as? Int {
-            expiresIn = expiresInInt
-        } else {
-            expiresIn = 3600
-        }
-
-        var localId = json["localId"] as? String ?? ""
-        if localId.isEmpty {
-            if let payload = decodeJWT(idToken),
-               let userId = payload["user_id"] as? String ?? payload["sub"] as? String {
-                localId = userId
-            }
-        }
+        let tokens = try Self.decodeFirebaseTokenResult(from: data)
 
         // Get email from response if not already set
         if AuthState.shared.userEmail == nil {
@@ -2360,12 +2350,7 @@ class AuthService {
             }
         }
 
-        return FirebaseTokenResult(
-            idToken: idToken,
-            refreshToken: refreshToken,
-            expiresIn: expiresIn,
-            localId: localId
-        )
+        return tokens
     }
 
     /// Generate a random nonce string for Apple Sign In

--- a/desktop/macos/Desktop/Sources/AuthService.swift
+++ b/desktop/macos/Desktop/Sources/AuthService.swift
@@ -2341,7 +2341,14 @@ class AuthService {
             NSLog("OMI AUTH: Failed to parse Firebase signInWithIdp response")
             throw AuthError.invalidResponse
         }
-        let tokens = try Self.decodeFirebaseTokenResult(from: data)
+
+        let tokens: FirebaseTokenResult
+        do {
+            tokens = try Self.decodeFirebaseTokenResult(from: data)
+        } catch {
+            NSLog("OMI AUTH: Failed to parse Firebase signInWithIdp response: %@", String(data: data, encoding: .utf8) ?? "nil")
+            throw error
+        }
 
         // Get email from response if not already set
         if AuthState.shared.userEmail == nil {

--- a/desktop/macos/Desktop/Sources/Bluetooth/BluetoothManager.swift
+++ b/desktop/macos/Desktop/Sources/Bluetooth/BluetoothManager.swift
@@ -11,6 +11,20 @@ extension Notification.Name {
     static let bleDeviceFailedToConnect = Notification.Name("bleDeviceFailedToConnect")
 }
 
+@MainActor
+protocol DeviceBluetoothManaging: AnyObject {
+    var currentBluetoothState: CBManagerState { get }
+    var currentIsScanning: Bool { get }
+    var currentDiscoveredDevices: [BtDevice] { get }
+    var bluetoothStatePublisher: AnyPublisher<CBManagerState, Never> { get }
+    var isScanningPublisher: AnyPublisher<Bool, Never> { get }
+    var discoveredDevicesPublisher: AnyPublisher<[BtDevice], Never> { get }
+
+    func prepareForStateUpdates()
+    func startScanning(timeout: TimeInterval)
+    func stopScanning()
+}
+
 /// Manages Bluetooth scanning and device discovery
 /// Ported from: omi/app/lib/services/devices.dart and bluetooth_discoverer.dart
 @MainActor
@@ -183,6 +197,25 @@ final class BluetoothManager: NSObject, ObservableObject {
         case .poweredOn: return "Powered On"
         @unknown default: return "Unknown"
         }
+    }
+}
+
+extension BluetoothManager: DeviceBluetoothManaging {
+    var currentBluetoothState: CBManagerState { bluetoothState }
+    var currentIsScanning: Bool { isScanning }
+    var currentDiscoveredDevices: [BtDevice] { discoveredDevices }
+    var bluetoothStatePublisher: AnyPublisher<CBManagerState, Never> {
+        $bluetoothState.eraseToAnyPublisher()
+    }
+    var isScanningPublisher: AnyPublisher<Bool, Never> {
+        $isScanning.eraseToAnyPublisher()
+    }
+    var discoveredDevicesPublisher: AnyPublisher<[BtDevice], Never> {
+        $discoveredDevices.eraseToAnyPublisher()
+    }
+
+    func prepareForStateUpdates() {
+        _ = centralManager
     }
 }
 

--- a/desktop/macos/Desktop/Sources/FileIndexing/FileIndexScanPolicy.swift
+++ b/desktop/macos/Desktop/Sources/FileIndexing/FileIndexScanPolicy.swift
@@ -1,0 +1,136 @@
+import Foundation
+
+struct FileIndexScanPolicy {
+    enum DirectoryEntryPlan: Equatable {
+        case skipSubtree
+        case descend
+        case indexPackage(fileExtension: String, fileType: String)
+    }
+
+    static let standard = FileIndexScanPolicy()
+
+    let skipFolders: Set<String>
+    let packageExtensions: Set<String>
+    let maxDepth: Int
+    let maxFileSize: Int64
+
+    init(
+        skipFolders: Set<String> = [
+            ".Trash", "node_modules", ".git", "__pycache__", ".venv", "venv",
+            ".cache", ".npm", ".yarn", "Pods", "DerivedData", ".build",
+            "build", "dist", ".next", ".nuxt", "target", "vendor",
+            "Library", ".local", ".cargo", ".rustup"
+        ],
+        packageExtensions: Set<String> = [
+            "app", "framework", "bundle", "plugin", "kext",
+            "xcodeproj", "xcworkspace", "playground"
+        ],
+        maxDepth: Int = 3,
+        maxFileSize: Int64 = 500 * 1024 * 1024
+    ) {
+        self.skipFolders = skipFolders
+        self.packageExtensions = packageExtensions
+        self.maxDepth = maxDepth
+        self.maxFileSize = maxFileSize
+    }
+
+    func standardScanRoots(
+        homeURL: URL,
+        applicationsURL: URL = URL(fileURLWithPath: "/Applications", isDirectory: true)
+    ) -> [URL] {
+        [
+            homeURL.appendingPathComponent("Downloads", isDirectory: true),
+            homeURL.appendingPathComponent("Documents", isDirectory: true),
+            homeURL.appendingPathComponent("Desktop", isDirectory: true),
+            homeURL.appendingPathComponent("Developer", isDirectory: true),
+            homeURL.appendingPathComponent("Projects", isDirectory: true),
+            homeURL.appendingPathComponent("Code", isDirectory: true),
+            homeURL.appendingPathComponent("src", isDirectory: true),
+            homeURL.appendingPathComponent("repos", isDirectory: true),
+            homeURL.appendingPathComponent("Sites", isDirectory: true),
+            applicationsURL,
+            homeURL.appendingPathComponent("Applications", isDirectory: true),
+        ]
+    }
+
+    func shouldScanDirectory(atDepth depth: Int) -> Bool {
+        depth <= maxDepth
+    }
+
+    func planDirectoryEntry(_ url: URL) -> DirectoryEntryPlan {
+        let name = url.lastPathComponent
+        if skipFolders.contains(name) {
+            return .skipSubtree
+        }
+
+        let ext = url.pathExtension.lowercased()
+        if packageExtensions.contains(ext) {
+            return .indexPackage(fileExtension: ext, fileType: ext == "app" ? "application" : "package")
+        }
+
+        return .descend
+    }
+
+    func makePackageRecord(
+        for url: URL,
+        folderName: String,
+        homePath: String,
+        depth: Int,
+        createdAt: Date?,
+        modifiedAt: Date?
+    ) -> IndexedFileRecord? {
+        guard case .indexPackage(let ext, let fileType) = planDirectoryEntry(url) else {
+            return nil
+        }
+
+        return IndexedFileRecord(
+            path: relativePath(for: url, homePath: homePath),
+            filename: url.lastPathComponent,
+            fileExtension: ext,
+            fileType: fileType,
+            sizeBytes: 0,
+            folder: folderName,
+            depth: depth,
+            createdAt: createdAt,
+            modifiedAt: modifiedAt
+        )
+    }
+
+    func makeFileRecord(
+        for url: URL,
+        folderName: String,
+        homePath: String,
+        depth: Int,
+        isRegularFile: Bool,
+        sizeBytes: Int64,
+        createdAt: Date?,
+        modifiedAt: Date?
+    ) -> IndexedFileRecord? {
+        guard isRegularFile, sizeBytes > 0, sizeBytes <= maxFileSize else {
+            return nil
+        }
+
+        let ext = url.pathExtension.isEmpty ? nil : url.pathExtension.lowercased()
+        let fileType = FileTypeCategory.from(extension: ext)
+
+        return IndexedFileRecord(
+            path: relativePath(for: url, homePath: homePath),
+            filename: url.lastPathComponent,
+            fileExtension: ext,
+            fileType: fileType.rawValue,
+            sizeBytes: sizeBytes,
+            folder: folderName,
+            depth: depth,
+            createdAt: createdAt,
+            modifiedAt: modifiedAt
+        )
+    }
+
+    func relativePath(for url: URL, homePath: String) -> String {
+        var path = url.path
+        if path.hasPrefix(homePath) {
+            path = "~" + path.dropFirst(homePath.count)
+        }
+        return path
+    }
+}

--- a/desktop/macos/Desktop/Sources/FileIndexing/FileIndexerService.swift
+++ b/desktop/macos/Desktop/Sources/FileIndexing/FileIndexerService.swift
@@ -8,29 +8,10 @@ actor FileIndexerService {
 
     private var _dbQueue: DatabasePool?
     private var isScanning = false
-
-    /// Folders to skip during recursive scan
-    private let skipFolders: Set<String> = [
-        ".Trash", "node_modules", ".git", "__pycache__", ".venv", "venv",
-        ".cache", ".npm", ".yarn", "Pods", "DerivedData", ".build",
-        "build", "dist", ".next", ".nuxt", "target", "vendor",
-        "Library", ".local", ".cargo", ".rustup"
-    ]
-
-    /// Max recursion depth (0 = root of scanned folder)
-    private let maxDepth = 3
-
-    /// Skip files larger than 500 MB
-    private let maxFileSize: Int64 = 500 * 1024 * 1024
+    private let scanPolicy = FileIndexScanPolicy.standard
 
     /// Batch insert size
     private let batchSize = 500
-
-    /// Package extensions to treat as leaf entries (don't recurse into)
-    private let packageExtensions: Set<String> = [
-        "app", "framework", "bundle", "plugin", "kext",
-        "xcodeproj", "xcworkspace", "playground"
-    ]
 
     private init() {}
 
@@ -84,19 +65,7 @@ actor FileIndexerService {
         log("FileIndexer: Starting onboarding pipeline")
 
         let home = FileManager.default.homeDirectoryForCurrentUser
-        let foldersToScan = [
-            home.appendingPathComponent("Downloads"),
-            home.appendingPathComponent("Documents"),
-            home.appendingPathComponent("Desktop"),
-            home.appendingPathComponent("Developer"),
-            home.appendingPathComponent("Projects"),
-            home.appendingPathComponent("Code"),
-            home.appendingPathComponent("src"),
-            home.appendingPathComponent("repos"),
-            home.appendingPathComponent("Sites"),
-            URL(fileURLWithPath: "/Applications"),
-            home.appendingPathComponent("Applications"),
-        ]
+        let foldersToScan = scanPolicy.standardScanRoots(homeURL: home)
 
         // 1. Scan files
         let totalFiles = await scanFolders(foldersToScan)
@@ -145,19 +114,7 @@ actor FileIndexerService {
         log("FileIndexer: Starting background rescan")
 
         let home = FileManager.default.homeDirectoryForCurrentUser
-        let folders = [
-            home.appendingPathComponent("Downloads"),
-            home.appendingPathComponent("Documents"),
-            home.appendingPathComponent("Desktop"),
-            home.appendingPathComponent("Developer"),
-            home.appendingPathComponent("Projects"),
-            home.appendingPathComponent("Code"),
-            home.appendingPathComponent("src"),
-            home.appendingPathComponent("repos"),
-            home.appendingPathComponent("Sites"),
-            URL(fileURLWithPath: "/Applications"),
-            home.appendingPathComponent("Applications"),
-        ]
+        let folders = scanPolicy.standardScanRoots(homeURL: home)
 
         let count = await scanFolders(folders, incremental: true)
         log("FileIndexer: Background rescan complete, \(count) files indexed")
@@ -242,7 +199,7 @@ actor FileIndexerService {
         existingIndex: [String: Date?],
         scannedPaths: inout Set<String>
     ) {
-        guard depth <= maxDepth else { return }
+        guard scanPolicy.shouldScanDirectory(atDepth: depth) else { return }
 
         let contents: [URL]
         do {
@@ -257,41 +214,33 @@ actor FileIndexerService {
         }
 
         for item in contents {
-            let name = item.lastPathComponent
-
             // Check directory
             let resourceValues = try? item.resourceValues(forKeys: Set(resourceKeys))
             let isDirectory = resourceValues?.isDirectory ?? false
 
             if isDirectory {
-                if skipFolders.contains(name) { continue }
-
-                // Treat macOS packages (.app, .framework, etc.) as leaf entries
-                let ext = item.pathExtension.lowercased()
-                if packageExtensions.contains(ext) {
-                    var relativePath = item.path
-                    if relativePath.hasPrefix(homePath) {
-                        relativePath = "~" + relativePath.dropFirst(homePath.count)
+                switch scanPolicy.planDirectoryEntry(item) {
+                case .skipSubtree:
+                    continue
+                case .indexPackage:
+                    guard let record = scanPolicy.makePackageRecord(
+                        for: item,
+                        folderName: folderName,
+                        homePath: homePath,
+                        depth: depth,
+                        createdAt: resourceValues?.creationDate,
+                        modifiedAt: resourceValues?.contentModificationDate
+                    ) else {
+                        continue
                     }
-                    scannedPaths.insert(relativePath)
+                    scannedPaths.insert(record.path)
                     // Skip unchanged files (incremental scan)
-                    if let existingModified = existingIndex[relativePath],
+                    if let existingModified = existingIndex[record.path],
                        let newModified = resourceValues?.contentModificationDate,
                        let existing = existingModified,
                        abs(existing.timeIntervalSince(newModified)) < 1.0 {
                         continue
                     }
-                    let record = IndexedFileRecord(
-                        path: relativePath,
-                        filename: name,
-                        fileExtension: ext,
-                        fileType: ext == "app" ? "application" : "package",
-                        sizeBytes: 0,
-                        folder: folderName,
-                        depth: depth,
-                        createdAt: resourceValues?.creationDate,
-                        modifiedAt: resourceValues?.contentModificationDate
-                    )
                     batch.append(record)
                     totalFiles += 1
                     if batch.count >= batchSize {
@@ -299,59 +248,46 @@ actor FileIndexerService {
                         batch.removeAll(keepingCapacity: true)
                     }
                     continue
+                case .descend:
+                    scanDirectory(
+                        url: item,
+                        folderName: folderName,
+                        homePath: homePath,
+                        depth: depth + 1,
+                        resourceKeys: resourceKeys,
+                        fm: fm,
+                        batch: &batch,
+                        totalFiles: &totalFiles,
+                        db: db,
+                        existingIndex: existingIndex,
+                        scannedPaths: &scannedPaths
+                    )
+                    continue
                 }
-
-                scanDirectory(
-                    url: item,
-                    folderName: folderName,
-                    homePath: homePath,
-                    depth: depth + 1,
-                    resourceKeys: resourceKeys,
-                    fm: fm,
-                    batch: &batch,
-                    totalFiles: &totalFiles,
-                    db: db,
-                    existingIndex: existingIndex,
-                    scannedPaths: &scannedPaths
-                )
-                continue
             }
 
             // Regular file
-            guard resourceValues?.isRegularFile == true else { continue }
-
-            let fileSize = Int64(resourceValues?.fileSize ?? 0)
-            guard fileSize > 0, fileSize <= maxFileSize else { continue }
-
-            let ext = item.pathExtension.isEmpty ? nil : item.pathExtension.lowercased()
-            let fileType = FileTypeCategory.from(extension: ext)
-
-            // Build relative path
-            var relativePath = item.path
-            if relativePath.hasPrefix(homePath) {
-                relativePath = "~" + relativePath.dropFirst(homePath.count)
+            guard let record = scanPolicy.makeFileRecord(
+                for: item,
+                folderName: folderName,
+                homePath: homePath,
+                depth: depth,
+                isRegularFile: resourceValues?.isRegularFile == true,
+                sizeBytes: Int64(resourceValues?.fileSize ?? 0),
+                createdAt: resourceValues?.creationDate,
+                modifiedAt: resourceValues?.contentModificationDate
+            ) else {
+                continue
             }
 
-            scannedPaths.insert(relativePath)
+            scannedPaths.insert(record.path)
             // Skip unchanged files (incremental scan)
-            if let existingModified = existingIndex[relativePath],
+            if let existingModified = existingIndex[record.path],
                let newModified = resourceValues?.contentModificationDate,
                let existing = existingModified,
                abs(existing.timeIntervalSince(newModified)) < 1.0 {
                 continue
             }
-
-            let record = IndexedFileRecord(
-                path: relativePath,
-                filename: name,
-                fileExtension: ext,
-                fileType: fileType.rawValue,
-                sizeBytes: fileSize,
-                folder: folderName,
-                depth: depth,
-                createdAt: resourceValues?.creationDate,
-                modifiedAt: resourceValues?.contentModificationDate
-            )
 
             batch.append(record)
             totalFiles += 1

--- a/desktop/macos/Desktop/Sources/FileIndexing/FileIndexerService.swift
+++ b/desktop/macos/Desktop/Sources/FileIndexing/FileIndexerService.swift
@@ -8,12 +8,21 @@ actor FileIndexerService {
 
     private var _dbQueue: DatabasePool?
     private var isScanning = false
-    private let scanPolicy = FileIndexScanPolicy.standard
+    private let scanPolicy: FileIndexScanPolicy
 
     /// Batch insert size
-    private let batchSize = 500
+    private let batchSize: Int
 
-    private init() {}
+    private init() {
+        scanPolicy = .standard
+        batchSize = 500
+    }
+
+    init(databasePool: DatabasePool, scanPolicy: FileIndexScanPolicy = .standard, batchSize: Int = 500) {
+        _dbQueue = databasePool
+        self.scanPolicy = scanPolicy
+        self.batchSize = batchSize
+    }
 
     // MARK: - Database Access
 

--- a/desktop/macos/Desktop/Sources/LiveNotes/LiveNotesAccumulator.swift
+++ b/desktop/macos/Desktop/Sources/LiveNotes/LiveNotesAccumulator.swift
@@ -46,6 +46,16 @@ struct LiveNotesAccumulator {
         trimExistingNotesContext()
     }
 
+    mutating func replaceExistingNote(oldText: String, newText: String) {
+        guard let index = existingNotesContext.firstIndex(of: oldText) else { return }
+        existingNotesContext[index] = newText
+    }
+
+    mutating func removeExistingNote(_ note: String) {
+        guard let index = existingNotesContext.firstIndex(of: note) else { return }
+        existingNotesContext.remove(at: index)
+    }
+
     mutating func handleSegmentsUpdate(
         _ segments: [SpeakerSegment],
         isGenerating: Bool

--- a/desktop/macos/Desktop/Sources/LiveNotes/LiveNotesAccumulator.swift
+++ b/desktop/macos/Desktop/Sources/LiveNotes/LiveNotesAccumulator.swift
@@ -1,0 +1,116 @@
+import Foundation
+
+struct LiveNotesGenerationRequest: Equatable {
+    let recentText: String
+    let existingNotesText: String
+    let segmentStartOrder: Int
+    let segmentEndOrder: Int
+}
+
+struct LiveNotesAccumulator {
+    let wordThreshold: Int
+    let maxWordBufferSize: Int
+    let maxExistingNotesContext: Int
+
+    private(set) var wordBuffer: [String] = []
+    private(set) var existingNotesContext: [String] = []
+    private(set) var currentSegmentOrder: Int = 0
+
+    private var lastProcessedSegmentEnd: Double?
+    private var wordsSinceLastGeneration = 0
+
+    init(
+        wordThreshold: Int = 50,
+        maxWordBufferSize: Int = 500,
+        maxExistingNotesContext: Int = 20
+    ) {
+        self.wordThreshold = wordThreshold
+        self.maxWordBufferSize = maxWordBufferSize
+        self.maxExistingNotesContext = maxExistingNotesContext
+    }
+
+    mutating func reset() {
+        wordBuffer = []
+        existingNotesContext = []
+        currentSegmentOrder = 0
+        lastProcessedSegmentEnd = nil
+        wordsSinceLastGeneration = 0
+    }
+
+    mutating func seedExistingNotes(_ notes: [String]) {
+        existingNotesContext = trimmedContext(notes)
+    }
+
+    mutating func appendExistingNote(_ note: String) {
+        existingNotesContext.append(note)
+        trimExistingNotesContext()
+    }
+
+    mutating func handleSegmentsUpdate(
+        _ segments: [SpeakerSegment],
+        isGenerating: Bool
+    ) -> LiveNotesGenerationRequest? {
+        currentSegmentOrder = segments.count
+
+        let newSegments: ArraySlice<SpeakerSegment>
+        if let lastProcessedSegmentEnd {
+            guard let startIndex = segments.firstIndex(where: { $0.end > lastProcessedSegmentEnd }) else {
+                return nil
+            }
+            newSegments = segments[startIndex...]
+        } else {
+            newSegments = segments[...]
+        }
+
+        let newWords = newSegments.flatMap { segment in
+            segment.text.split(separator: " ").map(String.init)
+        }
+        guard !newWords.isEmpty else { return nil }
+
+        if let lastSegment = segments.last {
+            lastProcessedSegmentEnd = lastSegment.end
+        }
+
+        wordBuffer.append(contentsOf: newWords)
+        wordsSinceLastGeneration += newWords.count
+        trimWordBuffer()
+
+        guard wordsSinceLastGeneration >= wordThreshold, !isGenerating else {
+            return nil
+        }
+
+        return LiveNotesGenerationRequest(
+            recentText: wordBuffer.suffix(wordThreshold).joined(separator: " "),
+            existingNotesText: existingNotesText(),
+            segmentStartOrder: max(0, currentSegmentOrder - 3),
+            segmentEndOrder: currentSegmentOrder
+        )
+    }
+
+    mutating func markGenerationSucceeded(noteText: String) {
+        wordsSinceLastGeneration = 0
+        appendExistingNote(noteText)
+    }
+
+    private mutating func trimWordBuffer() {
+        guard wordBuffer.count > maxWordBufferSize else { return }
+        wordBuffer.removeFirst(wordBuffer.count - maxWordBufferSize)
+    }
+
+    private mutating func trimExistingNotesContext() {
+        existingNotesContext = trimmedContext(existingNotesContext)
+    }
+
+    private func trimmedContext(_ notes: [String]) -> [String] {
+        guard notes.count > maxExistingNotesContext else { return notes }
+        return Array(notes.suffix(maxExistingNotesContext))
+    }
+
+    private func existingNotesText() -> String {
+        if existingNotesContext.isEmpty {
+            return "No existing notes yet."
+        }
+
+        return "Existing notes:\n" + existingNotesContext.map { "- \($0)" }.joined(separator: "\n")
+    }
+}

--- a/desktop/macos/Desktop/Sources/LiveNotes/LiveNotesAccumulator.swift
+++ b/desktop/macos/Desktop/Sources/LiveNotes/LiveNotesAccumulator.swift
@@ -16,7 +16,7 @@ struct LiveNotesAccumulator {
     private(set) var existingNotesContext: [String] = []
     private(set) var currentSegmentOrder: Int = 0
 
-    private var lastProcessedSegmentEnd: Double?
+    private var processedSegmentWordCounts: [String: Int] = [:]
     private var wordsSinceLastGeneration = 0
 
     init(
@@ -33,7 +33,7 @@ struct LiveNotesAccumulator {
         wordBuffer = []
         existingNotesContext = []
         currentSegmentOrder = 0
-        lastProcessedSegmentEnd = nil
+        processedSegmentWordCounts = [:]
         wordsSinceLastGeneration = 0
     }
 
@@ -46,40 +46,24 @@ struct LiveNotesAccumulator {
         trimExistingNotesContext()
     }
 
-    mutating func replaceExistingNote(oldText: String, newText: String) {
-        guard let index = existingNotesContext.firstIndex(of: oldText) else { return }
-        existingNotesContext[index] = newText
-    }
-
-    mutating func removeExistingNote(_ note: String) {
-        guard let index = existingNotesContext.firstIndex(of: note) else { return }
-        existingNotesContext.remove(at: index)
-    }
-
     mutating func handleSegmentsUpdate(
         _ segments: [SpeakerSegment],
         isGenerating: Bool
     ) -> LiveNotesGenerationRequest? {
         currentSegmentOrder = segments.count
 
-        let newSegments: ArraySlice<SpeakerSegment>
-        if let lastProcessedSegmentEnd {
-            guard let startIndex = segments.firstIndex(where: { $0.end > lastProcessedSegmentEnd }) else {
-                return nil
-            }
-            newSegments = segments[startIndex...]
-        } else {
-            newSegments = segments[...]
-        }
+        let currentSegmentIds = Set(segments.map(\.id))
+        processedSegmentWordCounts = processedSegmentWordCounts.filter { currentSegmentIds.contains($0.key) }
 
-        let newWords = newSegments.flatMap { segment in
-            segment.text.split(separator: " ").map(String.init)
+        let newWords = segments.flatMap { segment in
+            let words = segment.text.split(separator: " ").map(String.init)
+            let processedCount = processedSegmentWordCounts[segment.id] ?? 0
+            processedSegmentWordCounts[segment.id] = words.count
+
+            guard words.count > processedCount else { return [String]() }
+            return Array(words.dropFirst(processedCount))
         }
         guard !newWords.isEmpty else { return nil }
-
-        if let lastSegment = segments.last {
-            lastProcessedSegmentEnd = lastSegment.end
-        }
 
         wordBuffer.append(contentsOf: newWords)
         wordsSinceLastGeneration += newWords.count
@@ -98,7 +82,7 @@ struct LiveNotesAccumulator {
     }
 
     mutating func markGenerationSucceeded(noteText: String) {
-        wordsSinceLastGeneration = 0
+        wordsSinceLastGeneration = max(0, wordsSinceLastGeneration - wordThreshold)
         appendExistingNote(noteText)
     }
 

--- a/desktop/macos/Desktop/Sources/LiveNotes/LiveNotesMonitor.swift
+++ b/desktop/macos/Desktop/Sources/LiveNotes/LiveNotesMonitor.swift
@@ -21,29 +21,8 @@ class LiveNotesMonitor: ObservableObject {
     /// Current recording session ID
     private var currentSessionId: Int64?
 
-    /// Word buffer for tracking transcript content
-    private var wordBuffer: [String] = []
-
-    /// Segment order tracking for note context
-    private var lastProcessedSegmentOrder: Int = -1
-
-    /// Current segment order being processed
-    private var currentSegmentOrder: Int = 0
-
-    /// End time of the last segment we extracted words from (cursor for incremental processing)
-    private var lastProcessedSegmentEnd: Double?
-
-    /// Minimum words before triggering AI generation
-    private let wordThreshold = 50
-
-    /// Max words to keep in buffer (older words are trimmed)
-    private let maxWordBufferSize = 500
-
-    /// Max existing notes to keep for context (oldest trimmed)
-    private let maxExistingNotesContext = 20
-
-    /// Existing notes for context (to avoid repetition)
-    private var existingNotesContext: [String] = []
+    /// Pure transcript/note policy state for deciding when AI generation should run.
+    private var accumulator = LiveNotesAccumulator()
 
     /// GeminiClient for AI generation (lazily initialized)
     private var geminiClient: GeminiClient?
@@ -79,11 +58,7 @@ class LiveNotesMonitor: ObservableObject {
         log("LiveNotesMonitor: Starting session \(sessionId)")
         currentSessionId = sessionId
         notes = []
-        wordBuffer = []
-        lastProcessedSegmentOrder = -1
-        currentSegmentOrder = 0
-        lastProcessedSegmentEnd = nil
-        existingNotesContext = []
+        accumulator.reset()
 
         // Initialize Gemini client if not already done
         if geminiClient == nil {
@@ -106,20 +81,13 @@ class LiveNotesMonitor: ObservableObject {
     func endSession() {
         log("LiveNotesMonitor: Ending session \(currentSessionId ?? -1) with \(notes.count) notes")
         currentSessionId = nil
-        wordBuffer = []
-        lastProcessedSegmentOrder = -1
-        currentSegmentOrder = 0
-        lastProcessedSegmentEnd = nil
+        accumulator.reset()
     }
 
     /// Clear all notes (used when recording stops)
     func clear() {
         notes = []
-        wordBuffer = []
-        existingNotesContext = []
-        lastProcessedSegmentOrder = -1
-        currentSegmentOrder = 0
-        lastProcessedSegmentEnd = nil
+        accumulator.reset()
     }
 
     // MARK: - Note Operations
@@ -137,17 +105,13 @@ class LiveNotesMonitor: ObservableObject {
                     sessionId: sessionId,
                     text: text,
                     isAiGenerated: false,
-                    segmentStartOrder: currentSegmentOrder
+                    segmentStartOrder: accumulator.currentSegmentOrder
                 )
 
                 if let note = record.toLiveNote() {
                     await MainActor.run {
                         self.notes.append(note)
-                        self.existingNotesContext.append(text)
-                        // Trim context to prevent unbounded growth
-                        if self.existingNotesContext.count > self.maxExistingNotesContext {
-                            self.existingNotesContext.removeFirst(self.existingNotesContext.count - self.maxExistingNotesContext)
-                        }
+                        self.accumulator.appendExistingNote(text)
                     }
                 }
             } catch {
@@ -201,7 +165,7 @@ class LiveNotesMonitor: ObservableObject {
             let existingNotes = try await NoteStorage.shared.getLiveNotes(sessionId: sessionId)
             await MainActor.run {
                 self.notes = existingNotes
-                self.existingNotesContext = existingNotes.map { $0.text }
+                self.accumulator.seedExistingNotes(existingNotes.map { $0.text })
             }
             log("LiveNotesMonitor: Loaded \(existingNotes.count) existing notes from DB")
         } catch {
@@ -213,68 +177,24 @@ class LiveNotesMonitor: ObservableObject {
     private func handleSegmentsUpdate(_ segments: [SpeakerSegment]) {
         guard currentSessionId != nil, isAiEnabled else { return }
 
-        // Track segment order
-        currentSegmentOrder = segments.count
-
-        // Only extract words from segments we haven't processed yet.
-        // Use the last processed segment's end time as a cursor to find new content.
-        let newSegments: ArraySlice<SpeakerSegment>
-        if let lastEnd = lastProcessedSegmentEnd {
-            // Find segments that are new or were updated (end time > last processed)
-            if let startIdx = segments.firstIndex(where: { $0.end > lastEnd }) {
-                newSegments = segments[startIdx...]
-            } else {
-                return  // No new segments
-            }
-        } else {
-            newSegments = segments[...]
-        }
-
-        let newWords = newSegments.flatMap { $0.text.split(separator: " ").map(String.init) }
-        guard !newWords.isEmpty else { return }
-
-        // Update cursor to the end of the last segment we processed
-        if let lastSeg = segments.last {
-            lastProcessedSegmentEnd = lastSeg.end
-        }
-
-        wordBuffer.append(contentsOf: newWords)
-
-        // Trim word buffer to prevent unbounded growth (keep most recent words)
-        if wordBuffer.count > maxWordBufferSize {
-            wordBuffer.removeFirst(wordBuffer.count - maxWordBufferSize)
-        }
-
-        // Check if we have enough words to generate a note
-        let wordsSinceLastNote = wordBuffer.count - (lastProcessedSegmentOrder >= 0 ? lastProcessedSegmentOrder : 0)
-        if wordsSinceLastNote >= wordThreshold && !isGenerating {
-            generateNote(from: segments)
+        if let request = accumulator.handleSegmentsUpdate(segments, isGenerating: isGenerating) {
+            generateNote(for: request)
         }
     }
 
     /// Generate an AI note from recent transcript
-    private func generateNote(from segments: [SpeakerSegment]) {
+    private func generateNote(for request: LiveNotesGenerationRequest) {
         guard let sessionId = currentSessionId,
               let client = geminiClient,
               !isGenerating else { return }
 
         isGenerating = true
 
-        // Get recent transcript text (last ~50 words)
-        let recentText = wordBuffer.suffix(wordThreshold).joined(separator: " ")
-        let segmentStartOrder = max(0, currentSegmentOrder - 3)
-        let segmentEndOrder = currentSegmentOrder
-
-        // Build context from existing notes
-        let existingNotesText = existingNotesContext.isEmpty
-            ? "No existing notes yet."
-            : "Existing notes:\n" + existingNotesContext.map { "- \($0)" }.joined(separator: "\n")
-
         let prompt = """
             Transcript segment:
-            \(recentText)
+            \(request.recentText)
 
-            \(existingNotesText)
+            \(request.existingNotesText)
 
             \(noteGenerationPrompt)
             """
@@ -302,19 +222,14 @@ class LiveNotesMonitor: ObservableObject {
                     sessionId: sessionId,
                     text: noteText,
                     isAiGenerated: true,
-                    segmentStartOrder: segmentStartOrder,
-                    segmentEndOrder: segmentEndOrder
+                    segmentStartOrder: request.segmentStartOrder,
+                    segmentEndOrder: request.segmentEndOrder
                 )
 
                 if let note = record.toLiveNote() {
                     await MainActor.run {
                         self.notes.append(note)
-                        self.existingNotesContext.append(noteText)
-                        // Trim context to prevent unbounded growth (keep most recent notes)
-                        if self.existingNotesContext.count > self.maxExistingNotesContext {
-                            self.existingNotesContext.removeFirst(self.existingNotesContext.count - self.maxExistingNotesContext)
-                        }
-                        self.lastProcessedSegmentOrder = self.wordBuffer.count
+                        self.accumulator.markGenerationSucceeded(noteText: noteText)
                         self.isGenerating = false
                     }
                 } else {
@@ -351,8 +266,8 @@ class LiveNotesMonitor: ObservableObject {
     // MARK: - Diagnostics
 
     /// Word buffer size (for memory diagnostics)
-    var wordBufferCount: Int { wordBuffer.count }
+    var wordBufferCount: Int { accumulator.wordBuffer.count }
 
     /// Existing notes context size (for memory diagnostics)
-    var existingNotesContextCount: Int { existingNotesContext.count }
+    var existingNotesContextCount: Int { accumulator.existingNotesContext.count }
 }

--- a/desktop/macos/Desktop/Sources/LiveNotes/LiveNotesMonitor.swift
+++ b/desktop/macos/Desktop/Sources/LiveNotes/LiveNotesMonitor.swift
@@ -182,11 +182,10 @@ class LiveNotesMonitor: ObservableObject {
                 await MainActor.run {
                     if let index = self.notes.firstIndex(where: { $0.id == id }) {
                         var updatedNote = self.notes[index]
-                        let oldText = updatedNote.text
                         updatedNote.text = text
                         updatedNote.updatedAt = Date()
                         self.notes[index] = updatedNote
-                        self.accumulator.replaceExistingNote(oldText: oldText, newText: text)
+                        self.accumulator.seedExistingNotes(self.notes.map { $0.text })
                     }
                 }
             } catch {
@@ -203,8 +202,8 @@ class LiveNotesMonitor: ObservableObject {
 
                 await MainActor.run {
                     if let index = self.notes.firstIndex(where: { $0.id == id }) {
-                        let removedNote = self.notes.remove(at: index)
-                        self.accumulator.removeExistingNote(removedNote.text)
+                        self.notes.remove(at: index)
+                        self.accumulator.seedExistingNotes(self.notes.map { $0.text })
                     }
                 }
             } catch {

--- a/desktop/macos/Desktop/Sources/LiveNotes/LiveNotesMonitor.swift
+++ b/desktop/macos/Desktop/Sources/LiveNotes/LiveNotesMonitor.swift
@@ -2,6 +2,32 @@ import Foundation
 import Combine
 import GRDB
 
+protocol LiveNoteGenerating {
+    func generateNote(prompt: String, systemPrompt: String) async throws -> String
+}
+
+extension GeminiClient: LiveNoteGenerating {
+    func generateNote(prompt: String, systemPrompt: String) async throws -> String {
+        try await sendTextRequest(prompt: prompt, systemPrompt: systemPrompt)
+    }
+}
+
+protocol LiveNoteStoring {
+    func createNote(
+        sessionId: Int64,
+        text: String,
+        timestamp: Date,
+        isAiGenerated: Bool,
+        segmentStartOrder: Int?,
+        segmentEndOrder: Int?
+    ) async throws -> LiveNoteRecord
+    func updateNote(id: Int64, text: String) async throws
+    func deleteNote(id: Int64) async throws
+    func getLiveNotes(sessionId: Int64) async throws -> [LiveNote]
+}
+
+extension NoteStorage: LiveNoteStoring {}
+
 /// Dedicated monitor for live notes generation during recording sessions.
 /// Accumulates transcript words and triggers AI note generation at word thresholds.
 /// Only views that explicitly observe this class will update when notes change.
@@ -24,8 +50,12 @@ class LiveNotesMonitor: ObservableObject {
     /// Pure transcript/note policy state for deciding when AI generation should run.
     private var accumulator = LiveNotesAccumulator()
 
-    /// GeminiClient for AI generation (lazily initialized)
-    private var geminiClient: GeminiClient?
+    /// AI note generator (lazily initialized)
+    private var noteGenerator: LiveNoteGenerating?
+
+    private let noteGeneratorFactory: () throws -> LiveNoteGenerating
+
+    private let noteStorage: LiveNoteStoring
 
     /// Cancellables for subscriptions
     private var cancellables = Set<AnyCancellable>()
@@ -41,14 +71,31 @@ class LiveNotesMonitor: ObservableObject {
         avoid repeating information from existing notes.
         """
 
-    private init() {
-        // Subscribe to transcript changes
-        LiveTranscriptMonitor.shared.$segments
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] segments in
-                self?.handleSegmentsUpdate(segments)
-            }
-            .store(in: &cancellables)
+    private convenience init() {
+        self.init(
+            noteGeneratorFactory: { try GeminiClient() },
+            noteStorage: NoteStorage.shared,
+            subscribeToTranscript: true
+        )
+    }
+
+    init(
+        noteGeneratorFactory: @escaping () throws -> LiveNoteGenerating,
+        noteStorage: LiveNoteStoring,
+        subscribeToTranscript: Bool = false
+    ) {
+        self.noteGeneratorFactory = noteGeneratorFactory
+        self.noteStorage = noteStorage
+
+        if subscribeToTranscript {
+            // Subscribe to transcript changes
+            LiveTranscriptMonitor.shared.$segments
+                .receive(on: DispatchQueue.main)
+                .sink { [weak self] segments in
+                    self?.handleSegmentsUpdate(segments)
+                }
+                .store(in: &cancellables)
+        }
     }
 
     // MARK: - Session Lifecycle
@@ -58,13 +105,14 @@ class LiveNotesMonitor: ObservableObject {
         log("LiveNotesMonitor: Starting session \(sessionId)")
         currentSessionId = sessionId
         notes = []
+        isGenerating = false
         accumulator.reset()
 
-        // Initialize Gemini client if not already done
-        if geminiClient == nil {
+        // Initialize AI generator if not already done
+        if noteGenerator == nil {
             do {
                 // Use Gemini Flash for note generation (text-only, no tool loop — Flash-safe)
-                geminiClient = try GeminiClient()
+                noteGenerator = try noteGeneratorFactory()
                 log("LiveNotesMonitor: GeminiClient initialized with default model (Flash)")
             } catch {
                 logError("LiveNotesMonitor: Failed to initialize GeminiClient", error: error)
@@ -73,7 +121,7 @@ class LiveNotesMonitor: ObservableObject {
 
         // Load any existing notes from DB (for crash recovery)
         Task {
-            await loadExistingNotes()
+            await loadExistingNotes(for: sessionId)
         }
     }
 
@@ -81,12 +129,14 @@ class LiveNotesMonitor: ObservableObject {
     func endSession() {
         log("LiveNotesMonitor: Ending session \(currentSessionId ?? -1) with \(notes.count) notes")
         currentSessionId = nil
+        isGenerating = false
         accumulator.reset()
     }
 
     /// Clear all notes (used when recording stops)
     func clear() {
         notes = []
+        isGenerating = false
         accumulator.reset()
     }
 
@@ -101,15 +151,18 @@ class LiveNotesMonitor: ObservableObject {
 
         Task {
             do {
-                let record = try await NoteStorage.shared.createNote(
+                let record = try await noteStorage.createNote(
                     sessionId: sessionId,
                     text: text,
+                    timestamp: Date(),
                     isAiGenerated: false,
-                    segmentStartOrder: accumulator.currentSegmentOrder
+                    segmentStartOrder: accumulator.currentSegmentOrder,
+                    segmentEndOrder: nil
                 )
 
                 if let note = record.toLiveNote() {
                     await MainActor.run {
+                        guard self.currentSessionId == sessionId else { return }
                         self.notes.append(note)
                         self.accumulator.appendExistingNote(text)
                     }
@@ -124,14 +177,16 @@ class LiveNotesMonitor: ObservableObject {
     func updateNote(id: Int64, text: String) {
         Task {
             do {
-                try await NoteStorage.shared.updateNote(id: id, text: text)
+                try await noteStorage.updateNote(id: id, text: text)
 
                 await MainActor.run {
                     if let index = self.notes.firstIndex(where: { $0.id == id }) {
                         var updatedNote = self.notes[index]
+                        let oldText = updatedNote.text
                         updatedNote.text = text
                         updatedNote.updatedAt = Date()
                         self.notes[index] = updatedNote
+                        self.accumulator.replaceExistingNote(oldText: oldText, newText: text)
                     }
                 }
             } catch {
@@ -144,10 +199,13 @@ class LiveNotesMonitor: ObservableObject {
     func deleteNote(id: Int64) {
         Task {
             do {
-                try await NoteStorage.shared.deleteNote(id: id)
+                try await noteStorage.deleteNote(id: id)
 
                 await MainActor.run {
-                    self.notes.removeAll { $0.id == id }
+                    if let index = self.notes.firstIndex(where: { $0.id == id }) {
+                        let removedNote = self.notes.remove(at: index)
+                        self.accumulator.removeExistingNote(removedNote.text)
+                    }
                 }
             } catch {
                 logError("LiveNotesMonitor: Failed to delete note", error: error)
@@ -158,12 +216,11 @@ class LiveNotesMonitor: ObservableObject {
     // MARK: - Private Methods
 
     /// Load existing notes from DB (for crash recovery)
-    private func loadExistingNotes() async {
-        guard let sessionId = currentSessionId else { return }
-
+    private func loadExistingNotes(for sessionId: Int64) async {
         do {
-            let existingNotes = try await NoteStorage.shared.getLiveNotes(sessionId: sessionId)
+            let existingNotes = try await noteStorage.getLiveNotes(sessionId: sessionId)
             await MainActor.run {
+                guard self.currentSessionId == sessionId else { return }
                 self.notes = existingNotes
                 self.accumulator.seedExistingNotes(existingNotes.map { $0.text })
             }
@@ -174,7 +231,7 @@ class LiveNotesMonitor: ObservableObject {
     }
 
     /// Handle transcript segments update
-    private func handleSegmentsUpdate(_ segments: [SpeakerSegment]) {
+    func handleSegmentsUpdate(_ segments: [SpeakerSegment]) {
         guard currentSessionId != nil, isAiEnabled else { return }
 
         if let request = accumulator.handleSegmentsUpdate(segments, isGenerating: isGenerating) {
@@ -185,7 +242,7 @@ class LiveNotesMonitor: ObservableObject {
     /// Generate an AI note from recent transcript
     private func generateNote(for request: LiveNotesGenerationRequest) {
         guard let sessionId = currentSessionId,
-              let client = geminiClient,
+              let generator = noteGenerator,
               !isGenerating else { return }
 
         isGenerating = true
@@ -201,7 +258,7 @@ class LiveNotesMonitor: ObservableObject {
 
         Task {
             do {
-                let response = try await client.sendTextRequest(
+                let response = try await generator.generateNote(
                     prompt: prompt,
                     systemPrompt: "You are a concise note-taker. Generate a single short note (3-10 words) about the key point in the transcript. Do not use quotes. Be direct and specific."
                 )
@@ -213,14 +270,15 @@ class LiveNotesMonitor: ObservableObject {
                     .replacingOccurrences(of: "'", with: "")
 
                 guard !noteText.isEmpty else {
-                    await MainActor.run { self.isGenerating = false }
+                    await MainActor.run { self.finishGeneration(for: sessionId) }
                     return
                 }
 
                 // Save to DB
-                let record = try await NoteStorage.shared.createNote(
+                let record = try await noteStorage.createNote(
                     sessionId: sessionId,
                     text: noteText,
+                    timestamp: Date(),
                     isAiGenerated: true,
                     segmentStartOrder: request.segmentStartOrder,
                     segmentEndOrder: request.segmentEndOrder
@@ -228,22 +286,28 @@ class LiveNotesMonitor: ObservableObject {
 
                 if let note = record.toLiveNote() {
                     await MainActor.run {
+                        guard self.currentSessionId == sessionId else { return }
                         self.notes.append(note)
                         self.accumulator.markGenerationSucceeded(noteText: noteText)
                         self.isGenerating = false
                     }
                 } else {
-                    await MainActor.run { self.isGenerating = false }
+                    await MainActor.run { self.finishGeneration(for: sessionId) }
                 }
             } catch let dbError as DatabaseError where dbError.resultCode == .SQLITE_CONSTRAINT {
                 // Session was deleted during async AI generation — not an error
                 log("LiveNotesMonitor: Session \(sessionId) deleted during note generation, skipping")
-                await MainActor.run { self.isGenerating = false }
+                await MainActor.run { self.finishGeneration(for: sessionId) }
             } catch {
                 logError("LiveNotesMonitor: Failed to generate note", error: error)
-                await MainActor.run { self.isGenerating = false }
+                await MainActor.run { self.finishGeneration(for: sessionId) }
             }
         }
+    }
+
+    private func finishGeneration(for sessionId: Int64) {
+        guard currentSessionId == sessionId else { return }
+        isGenerating = false
     }
 
     // MARK: - Computed Properties

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ProactiveAssistantOrchestrationPolicy.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ProactiveAssistantOrchestrationPolicy.swift
@@ -130,6 +130,11 @@ struct ProactiveScreenshotCaptureGate {
 
         return decision
     }
+
+    mutating func reset() {
+        wasScreenshotAppFrontmost = false
+        backoffUntil = .distantPast
+    }
 }
 
 struct ProactiveVideoCallThrottleGate {

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ProactiveAssistantOrchestrationPolicy.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ProactiveAssistantOrchestrationPolicy.swift
@@ -1,0 +1,102 @@
+import Foundation
+
+enum ProactiveAssistantOrchestrationPolicy {
+    enum ScreenshotAppDecision: Equatable {
+        case pause(backoffUntil: Date)
+        case resumeIntoBackoff
+        case resumeAndCapture
+        case continueBackoff
+        case capture
+    }
+
+    enum VideoCallThrottleDecision: Equatable {
+        case capture(nextCounter: Int, didLeaveCall: Bool)
+        case skip(nextCounter: Int, didEnterCall: Bool)
+    }
+
+    enum DistributionDecision: Equatable {
+        case flushNow
+        case debounce
+        case skip
+    }
+
+    static func shouldRecheckPermission(
+        now: Date,
+        lastCheckTime: Date,
+        interval: TimeInterval
+    ) -> Bool {
+        now.timeIntervalSince(lastCheckTime) >= interval
+    }
+
+    static func screenshotAppDecision(
+        isScreenshotAppFrontmost: Bool,
+        wasScreenshotAppFrontmost: Bool,
+        backoffUntil: Date,
+        now: Date,
+        backoffDuration: TimeInterval
+    ) -> ScreenshotAppDecision {
+        if isScreenshotAppFrontmost {
+            return .pause(backoffUntil: now.addingTimeInterval(backoffDuration))
+        }
+
+        if wasScreenshotAppFrontmost {
+            return now < backoffUntil ? .resumeIntoBackoff : .resumeAndCapture
+        }
+
+        if now < backoffUntil {
+            return .continueBackoff
+        }
+
+        return .capture
+    }
+
+    static func videoCallThrottleDecision(
+        isVideoCall: Bool,
+        currentCounter: Int,
+        throttleFactor: Int
+    ) -> VideoCallThrottleDecision {
+        guard throttleFactor > 1 else {
+            return .capture(nextCounter: 0, didLeaveCall: !isVideoCall && currentCounter > 0)
+        }
+
+        if isVideoCall {
+            let nextCounter = currentCounter + 1
+            if nextCounter < throttleFactor {
+                return .skip(nextCounter: nextCounter, didEnterCall: nextCounter == 1)
+            }
+            return .capture(nextCounter: 0, didLeaveCall: false)
+        }
+
+        return .capture(nextCounter: 0, didLeaveCall: currentCounter > 0)
+    }
+
+    static func distributionDecision(
+        lastDistributedApp: String?,
+        lastDistributedWindowTitle: String?,
+        frameApp: String,
+        frameWindowTitle: String?,
+        lastDistributionTime: Date,
+        now: Date,
+        defaultFallbackInterval: TimeInterval,
+        messagingFallbackInterval: TimeInterval,
+        messagingFastPathApps: Set<String>
+    ) -> DistributionDecision {
+        guard lastDistributedApp != nil else {
+            return .flushNow
+        }
+
+        if ContextDetection.didContextChange(
+            fromApp: lastDistributedApp,
+            fromWindowTitle: lastDistributedWindowTitle,
+            toApp: frameApp,
+            toWindowTitle: frameWindowTitle
+        ) {
+            return .debounce
+        }
+
+        let fallbackInterval = messagingFastPathApps.contains(frameApp)
+            ? messagingFallbackInterval
+            : defaultFallbackInterval
+        return now.timeIntervalSince(lastDistributionTime) >= fallbackInterval ? .flushNow : .skip
+    }
+}

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ProactiveAssistantOrchestrationPolicy.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ProactiveAssistantOrchestrationPolicy.swift
@@ -100,3 +100,122 @@ enum ProactiveAssistantOrchestrationPolicy {
         return now.timeIntervalSince(lastDistributionTime) >= fallbackInterval ? .flushNow : .skip
     }
 }
+
+struct ProactiveScreenshotCaptureGate {
+    private(set) var wasScreenshotAppFrontmost = false
+    private(set) var backoffUntil: Date = .distantPast
+
+    mutating func nextDecision(
+        isScreenshotAppFrontmost: Bool,
+        now: Date,
+        backoffDuration: TimeInterval
+    ) -> ProactiveAssistantOrchestrationPolicy.ScreenshotAppDecision {
+        let decision = ProactiveAssistantOrchestrationPolicy.screenshotAppDecision(
+            isScreenshotAppFrontmost: isScreenshotAppFrontmost,
+            wasScreenshotAppFrontmost: wasScreenshotAppFrontmost,
+            backoffUntil: backoffUntil,
+            now: now,
+            backoffDuration: backoffDuration
+        )
+
+        switch decision {
+        case .pause(let nextBackoffUntil):
+            wasScreenshotAppFrontmost = true
+            backoffUntil = nextBackoffUntil
+        case .resumeIntoBackoff, .resumeAndCapture:
+            wasScreenshotAppFrontmost = false
+        case .continueBackoff, .capture:
+            break
+        }
+
+        return decision
+    }
+}
+
+struct ProactiveVideoCallThrottleGate {
+    private(set) var counter = 0
+
+    mutating func nextDecision(
+        isVideoCall: Bool,
+        throttleFactor: Int
+    ) -> ProactiveAssistantOrchestrationPolicy.VideoCallThrottleDecision {
+        let decision = ProactiveAssistantOrchestrationPolicy.videoCallThrottleDecision(
+            isVideoCall: isVideoCall,
+            currentCounter: counter,
+            throttleFactor: throttleFactor
+        )
+
+        switch decision {
+        case .capture(let nextCounter, _), .skip(let nextCounter, _):
+            counter = nextCounter
+        }
+
+        return decision
+    }
+
+    mutating func reset() {
+        counter = 0
+    }
+}
+
+struct ProactiveFrameDistributionGate {
+    enum Action: Equatable {
+        case flushNow
+        case scheduleDebounce
+        case skip
+    }
+
+    private(set) var lastDistributedApp: String?
+    private(set) var lastDistributedWindowTitle: String?
+    private(set) var lastDistributionTime: Date = .distantPast
+
+    mutating func reset() {
+        lastDistributedApp = nil
+        lastDistributedWindowTitle = nil
+        lastDistributionTime = .distantPast
+    }
+
+    mutating func nextAction(
+        frameApp: String,
+        frameWindowTitle: String?,
+        now: Date,
+        defaultFallbackInterval: TimeInterval,
+        messagingFallbackInterval: TimeInterval,
+        messagingFastPathApps: Set<String>
+    ) -> Action {
+        let decision = ProactiveAssistantOrchestrationPolicy.distributionDecision(
+            lastDistributedApp: lastDistributedApp,
+            lastDistributedWindowTitle: lastDistributedWindowTitle,
+            frameApp: frameApp,
+            frameWindowTitle: frameWindowTitle,
+            lastDistributionTime: lastDistributionTime,
+            now: now,
+            defaultFallbackInterval: defaultFallbackInterval,
+            messagingFallbackInterval: messagingFallbackInterval,
+            messagingFastPathApps: messagingFastPathApps
+        )
+
+        switch decision {
+        case .flushNow:
+            return .flushNow
+        case .debounce:
+            // Track the pending context immediately so repeated captures in that same
+            // context do not starve the debounce timer by rescheduling forever.
+            lastDistributedApp = frameApp
+            lastDistributedWindowTitle = frameWindowTitle
+            return .scheduleDebounce
+        case .skip:
+            return .skip
+        }
+    }
+
+    mutating func markFlushed(
+        frameApp: String,
+        frameWindowTitle: String?,
+        at time: Date
+    ) {
+        lastDistributedApp = frameApp
+        lastDistributedWindowTitle = frameWindowTitle
+        lastDistributionTime = time
+    }
+}

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift
@@ -455,6 +455,8 @@ public class ProactiveAssistantsPlugin: NSObject {
         distributionDebounceTimer?.invalidate()
         distributionDebounceTimer = nil
         isInDelayPeriod = false
+        screenshotCaptureGate.reset()
+        videoCallThrottleGate.reset()
         distributionGate.reset()
         latestCapturedFrame = nil
 

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift
@@ -63,6 +63,7 @@ public class ProactiveAssistantsPlugin: NSObject {
     // the user is trying to take a screenshot (CleanShot, Shottr, macOS screenshot, etc.).
     private var wasScreenshotAppFrontmost = false
     private var screenshotAppBackoffUntil: Date = .distantPast
+    private let screenshotAppBackoffDuration: TimeInterval = 10
 
     // Change-gated distribution: only distribute frames to assistants when context changes.
     // Eliminates continuous polling when the user stays on the same app/window.
@@ -614,7 +615,11 @@ public class ProactiveAssistantsPlugin: NSObject {
         // Detects when the user revokes permission via System Settings while monitoring is active,
         // and stops gracefully instead of silently failing on every capture.
         let now = Date()
-        if now.timeIntervalSince(lastPermissionCheckTime) >= permissionCheckInterval {
+        if ProactiveAssistantOrchestrationPolicy.shouldRecheckPermission(
+            now: now,
+            lastCheckTime: lastPermissionCheckTime,
+            interval: permissionCheckInterval
+        ) {
             lastPermissionCheckTime = now
             let permissionGranted = ScreenCaptureService.checkPermission()
             _hasScreenRecordingPermission = permissionGranted
@@ -636,22 +641,31 @@ public class ProactiveAssistantsPlugin: NSObject {
         // Skip capture while a screenshot / screen-recording app is frontmost.
         // Both apps using ScreenCaptureKit at the same time contend for WindowServer
         // locks, which can stall the user's capture UI for 20-60s. Yield to the user.
-        if isScreenshotAppFrontmost() {
+        switch ProactiveAssistantOrchestrationPolicy.screenshotAppDecision(
+            isScreenshotAppFrontmost: isScreenshotAppFrontmost(),
+            wasScreenshotAppFrontmost: wasScreenshotAppFrontmost,
+            backoffUntil: screenshotAppBackoffUntil,
+            now: now,
+            backoffDuration: screenshotAppBackoffDuration
+        ) {
+        case .pause(let backoffUntil):
             if !wasScreenshotAppFrontmost {
                 log("ProactiveAssistantsPlugin: Screenshot app frontmost — pausing capture to avoid WindowServer contention")
                 wasScreenshotAppFrontmost = true
             }
-            screenshotAppBackoffUntil = Date().addingTimeInterval(10)
+            screenshotAppBackoffUntil = backoffUntil
             return
-        } else if wasScreenshotAppFrontmost {
+        case .resumeIntoBackoff:
             log("ProactiveAssistantsPlugin: Screenshot app no longer frontmost, holding backoff for \(Int(max(0, screenshotAppBackoffUntil.timeIntervalSinceNow)))s")
             wasScreenshotAppFrontmost = false
-        }
-
-        // Continue honoring the backoff window after the screenshot app resigns so its
-        // post-capture editor UI (e.g. CleanShot's annotation window) isn't disturbed.
-        if Date() < screenshotAppBackoffUntil {
             return
+        case .resumeAndCapture:
+            log("ProactiveAssistantsPlugin: Screenshot app no longer frontmost, holding backoff for 0s")
+            wasScreenshotAppFrontmost = false
+        case .continueBackoff:
+            return
+        case .capture:
+            break
         }
 
         // Get current window info (use real app name, not cached)
@@ -662,19 +676,23 @@ public class ProactiveAssistantsPlugin: NSObject {
 
         // Throttle capture when a video call app is frontmost to reduce CPU contention.
         // Captures 1 out of every N frames (e.g., effective ~5s interval at default 1s capture rate).
-        if isVideoCallApp(appName: realAppName, windowTitle: windowTitle) {
-            videoCallFrameCounter += 1
-            if videoCallFrameCounter < videoCallThrottleFactor {
-                if videoCallFrameCounter == 1 {
-                    log("VideoCallThrottle: Detected call app '\(realAppName ?? "unknown")', throttling capture to 1/\(videoCallThrottleFactor) frames")
-                }
-                return  // Skip this frame
+        let videoCallDecision = ProactiveAssistantOrchestrationPolicy.videoCallThrottleDecision(
+            isVideoCall: isVideoCallApp(appName: realAppName, windowTitle: windowTitle),
+            currentCounter: videoCallFrameCounter,
+            throttleFactor: videoCallThrottleFactor
+        )
+        switch videoCallDecision {
+        case .skip(let nextCounter, let didEnterCall):
+            videoCallFrameCounter = nextCounter
+            if didEnterCall {
+                log("VideoCallThrottle: Detected call app '\(realAppName ?? "unknown")', throttling capture to 1/\(videoCallThrottleFactor) frames")
             }
-            // This frame will be captured — reset counter for next cycle
-            videoCallFrameCounter = 0
-        } else if videoCallFrameCounter > 0 {
-            log("VideoCallThrottle: Left call app, resuming normal capture")
-            videoCallFrameCounter = 0
+            return
+        case .capture(let nextCounter, let didLeaveCall):
+            videoCallFrameCounter = nextCounter
+            if didLeaveCall {
+                log("VideoCallThrottle: Left call app, resuming normal capture")
+            }
         }
 
         // Unified context switch detection (covers app changes, window ID changes, and title changes)
@@ -924,28 +942,22 @@ public class ProactiveAssistantsPlugin: NSObject {
     private func distributeFrameIfChanged(_ frame: CapturedFrame) {
         latestCapturedFrame = frame
 
-        // First frame after monitoring starts — distribute immediately, no debounce
-        if lastDistributedApp == nil {
+        let now = Date()
+        switch ProactiveAssistantOrchestrationPolicy.distributionDecision(
+            lastDistributedApp: lastDistributedApp,
+            lastDistributedWindowTitle: lastDistributedWindowTitle,
+            frameApp: frame.appName,
+            frameWindowTitle: frame.windowTitle,
+            lastDistributionTime: lastDistributionTime,
+            now: now,
+            defaultFallbackInterval: distributionFallbackInterval,
+            messagingFallbackInterval: messagingDistributionFallbackInterval,
+            messagingFastPathApps: Self.messagingFastPathApps
+        ) {
+        case .flushNow:
+            distributionDebounceTimer?.invalidate()
             flushDebouncedFrame()
-            return
-        }
-
-        let contextChanged = ContextDetection.didContextChange(
-            fromApp: lastDistributedApp,
-            fromWindowTitle: lastDistributedWindowTitle,
-            toApp: frame.appName,
-            toWindowTitle: frame.windowTitle
-        )
-
-        let timeSinceLastDistribution = Date().timeIntervalSince(lastDistributionTime)
-        // Messaging apps get a much shorter same-context fallback so a new chat message
-        // reaches the analyzer in ~15s, even when you stay in the app the whole time.
-        let activeFallbackInterval = Self.messagingFastPathApps.contains(frame.appName)
-            ? messagingDistributionFallbackInterval
-            : distributionFallbackInterval
-        let fallbackDue = timeSinceLastDistribution >= activeFallbackInterval
-
-        if contextChanged {
+        case .debounce:
             // Update tracking immediately so subsequent captures in the same new context
             // don't keep resetting the debounce timer (fixes starvation bug).
             lastDistributedApp = frame.appName
@@ -958,12 +970,9 @@ public class ProactiveAssistantsPlugin: NSObject {
                     self?.flushDebouncedFrame()
                 }
             }
-        } else if fallbackDue {
-            // Same context but fallback interval elapsed — distribute for periodic re-analysis
-            distributionDebounceTimer?.invalidate()
-            flushDebouncedFrame()
+        case .skip:
+            break
         }
-        // Otherwise: same context, within fallback interval — skip distribution
     }
 
     /// Flush the latest captured frame to all assistants (called when debounce timer fires or fallback is due).

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift
@@ -54,24 +54,21 @@ public class ProactiveAssistantsPlugin: NSObject {
 
     // Video call throttling: reduce capture frequency when a call app is frontmost
     // to avoid competing with the call app for CPU/GPU (ScreenCaptureKit, encoding, OCR).
-    private var videoCallFrameCounter = 0
+    private var videoCallThrottleGate = ProactiveVideoCallThrottleGate()
     private let videoCallThrottleFactor = 5  // Capture 1 out of every 5 frames (effective ~5s interval)
 
     // Screenshot-app yielding: pause capture entirely while another screenshot/recording
     // app is frontmost, and hold a short backoff after it resigns so its editor UI isn't
     // disturbed. Prevents Omi's 3s capture loop from locking WindowServer at the moment
     // the user is trying to take a screenshot (CleanShot, Shottr, macOS screenshot, etc.).
-    private var wasScreenshotAppFrontmost = false
-    private var screenshotAppBackoffUntil: Date = .distantPast
+    private var screenshotCaptureGate = ProactiveScreenshotCaptureGate()
     private let screenshotAppBackoffDuration: TimeInterval = 10
 
     // Change-gated distribution: only distribute frames to assistants when context changes.
     // Eliminates continuous polling when the user stays on the same app/window.
-    private var lastDistributedApp: String?
-    private var lastDistributedWindowTitle: String?
+    private var distributionGate = ProactiveFrameDistributionGate()
     private var distributionDebounceTimer: Timer?
     private var latestCapturedFrame: CapturedFrame?
-    private var lastDistributionTime: Date = .distantPast
     /// Fallback interval: re-distribute even without context change to catch visual-only updates.
     private let distributionFallbackInterval: TimeInterval = 60
     private let messagingDistributionFallbackInterval: TimeInterval = 15
@@ -458,10 +455,8 @@ public class ProactiveAssistantsPlugin: NSObject {
         distributionDebounceTimer?.invalidate()
         distributionDebounceTimer = nil
         isInDelayPeriod = false
-        lastDistributedApp = nil
-        lastDistributedWindowTitle = nil
+        distributionGate.reset()
         latestCapturedFrame = nil
-        lastDistributionTime = .distantPast
 
         windowMonitor?.stop()
         windowMonitor = nil
@@ -641,27 +636,22 @@ public class ProactiveAssistantsPlugin: NSObject {
         // Skip capture while a screenshot / screen-recording app is frontmost.
         // Both apps using ScreenCaptureKit at the same time contend for WindowServer
         // locks, which can stall the user's capture UI for 20-60s. Yield to the user.
-        switch ProactiveAssistantOrchestrationPolicy.screenshotAppDecision(
+        let wasScreenshotAppFrontmostBeforeDecision = screenshotCaptureGate.wasScreenshotAppFrontmost
+        switch screenshotCaptureGate.nextDecision(
             isScreenshotAppFrontmost: isScreenshotAppFrontmost(),
-            wasScreenshotAppFrontmost: wasScreenshotAppFrontmost,
-            backoffUntil: screenshotAppBackoffUntil,
             now: now,
             backoffDuration: screenshotAppBackoffDuration
         ) {
-        case .pause(let backoffUntil):
-            if !wasScreenshotAppFrontmost {
+        case .pause:
+            if !wasScreenshotAppFrontmostBeforeDecision {
                 log("ProactiveAssistantsPlugin: Screenshot app frontmost — pausing capture to avoid WindowServer contention")
-                wasScreenshotAppFrontmost = true
             }
-            screenshotAppBackoffUntil = backoffUntil
             return
         case .resumeIntoBackoff:
-            log("ProactiveAssistantsPlugin: Screenshot app no longer frontmost, holding backoff for \(Int(max(0, screenshotAppBackoffUntil.timeIntervalSinceNow)))s")
-            wasScreenshotAppFrontmost = false
+            log("ProactiveAssistantsPlugin: Screenshot app no longer frontmost, holding backoff for \(Int(max(0, screenshotCaptureGate.backoffUntil.timeIntervalSinceNow)))s")
             return
         case .resumeAndCapture:
             log("ProactiveAssistantsPlugin: Screenshot app no longer frontmost, holding backoff for 0s")
-            wasScreenshotAppFrontmost = false
         case .continueBackoff:
             return
         case .capture:
@@ -676,20 +666,17 @@ public class ProactiveAssistantsPlugin: NSObject {
 
         // Throttle capture when a video call app is frontmost to reduce CPU contention.
         // Captures 1 out of every N frames (e.g., effective ~5s interval at default 1s capture rate).
-        let videoCallDecision = ProactiveAssistantOrchestrationPolicy.videoCallThrottleDecision(
+        let videoCallDecision = videoCallThrottleGate.nextDecision(
             isVideoCall: isVideoCallApp(appName: realAppName, windowTitle: windowTitle),
-            currentCounter: videoCallFrameCounter,
             throttleFactor: videoCallThrottleFactor
         )
         switch videoCallDecision {
-        case .skip(let nextCounter, let didEnterCall):
-            videoCallFrameCounter = nextCounter
+        case .skip(_, let didEnterCall):
             if didEnterCall {
                 log("VideoCallThrottle: Detected call app '\(realAppName ?? "unknown")', throttling capture to 1/\(videoCallThrottleFactor) frames")
             }
             return
-        case .capture(let nextCounter, let didLeaveCall):
-            videoCallFrameCounter = nextCounter
+        case .capture(_, let didLeaveCall):
             if didLeaveCall {
                 log("VideoCallThrottle: Left call app, resuming normal capture")
             }
@@ -943,12 +930,9 @@ public class ProactiveAssistantsPlugin: NSObject {
         latestCapturedFrame = frame
 
         let now = Date()
-        switch ProactiveAssistantOrchestrationPolicy.distributionDecision(
-            lastDistributedApp: lastDistributedApp,
-            lastDistributedWindowTitle: lastDistributedWindowTitle,
+        switch distributionGate.nextAction(
             frameApp: frame.appName,
             frameWindowTitle: frame.windowTitle,
-            lastDistributionTime: lastDistributionTime,
             now: now,
             defaultFallbackInterval: distributionFallbackInterval,
             messagingFallbackInterval: messagingDistributionFallbackInterval,
@@ -957,12 +941,7 @@ public class ProactiveAssistantsPlugin: NSObject {
         case .flushNow:
             distributionDebounceTimer?.invalidate()
             flushDebouncedFrame()
-        case .debounce:
-            // Update tracking immediately so subsequent captures in the same new context
-            // don't keep resetting the debounce timer (fixes starvation bug).
-            lastDistributedApp = frame.appName
-            lastDistributedWindowTitle = frame.windowTitle
-
+        case .scheduleDebounce:
             // Restart the 3s debounce timer — fires 3s after the last context change
             distributionDebounceTimer?.invalidate()
             distributionDebounceTimer = Timer.scheduledTimer(withTimeInterval: 3.0, repeats: false) { [weak self] _ in
@@ -979,9 +958,11 @@ public class ProactiveAssistantsPlugin: NSObject {
     private func flushDebouncedFrame() {
         guard let frame = latestCapturedFrame else { return }
 
-        lastDistributedApp = frame.appName
-        lastDistributedWindowTitle = frame.windowTitle
-        lastDistributionTime = Date()
+        distributionGate.markFlushed(
+            frameApp: frame.appName,
+            frameWindowTitle: frame.windowTitle,
+            at: Date()
+        )
         distributionDebounceTimer = nil
 
         AssistantCoordinator.shared.distributeFrame(frame)

--- a/desktop/macos/Desktop/Sources/Providers/DeviceProvider.swift
+++ b/desktop/macos/Desktop/Sources/Providers/DeviceProvider.swift
@@ -21,6 +21,7 @@ final class DeviceProvider: ObservableObject {
 
     static let shared = DeviceProvider(bluetoothManager: BluetoothManager.shared)
     typealias ConnectionFactory = @MainActor (BtDevice) -> DeviceConnection?
+    typealias StorageDataChecker = @MainActor () async -> (totalBytes: Int, currentOffset: Int)?
 
     // MARK: - Published State
 
@@ -69,6 +70,7 @@ final class DeviceProvider: ObservableObject {
     private let userDefaults: UserDefaults
     private let notificationCenter: NotificationCenter
     private let connectionFactory: ConnectionFactory
+    private let storageDataChecker: StorageDataChecker
     private let autoReconnectEnabled: Bool
     /// The active device connection (internal for AudioSourceManager access)
     private(set) var activeConnection: DeviceConnection?
@@ -99,12 +101,14 @@ final class DeviceProvider: ObservableObject {
         userDefaults: UserDefaults = .standard,
         notificationCenter: NotificationCenter = .default,
         connectionFactory: @escaping ConnectionFactory = { DeviceConnectionFactory.create(device: $0) },
+        storageDataChecker: @escaping StorageDataChecker = { await StorageSyncService.shared.checkForStorageData() },
         autoReconnectEnabled: Bool = true
     ) {
         self.bluetoothManager = bluetoothManager
         self.userDefaults = userDefaults
         self.notificationCenter = notificationCenter
         self.connectionFactory = connectionFactory
+        self.storageDataChecker = storageDataChecker
         self.autoReconnectEnabled = autoReconnectEnabled
         setupNotificationBindings()
         loadPairedDevice()
@@ -482,7 +486,7 @@ final class DeviceProvider: ObservableObject {
 
     /// Check if device has pending storage data to sync
     private func checkPendingStorageSync() async {
-        guard let (totalBytes, currentOffset) = await StorageSyncService.shared.checkForStorageData() else {
+        guard let (totalBytes, currentOffset) = await storageDataChecker() else {
             return
         }
 

--- a/desktop/macos/Desktop/Sources/Providers/DeviceProvider.swift
+++ b/desktop/macos/Desktop/Sources/Providers/DeviceProvider.swift
@@ -19,7 +19,8 @@ final class DeviceProvider: ObservableObject {
 
     // MARK: - Singleton
 
-    static let shared = DeviceProvider()
+    static let shared = DeviceProvider(bluetoothManager: BluetoothManager.shared)
+    typealias ConnectionFactory = @MainActor (BtDevice) -> DeviceConnection?
 
     // MARK: - Published State
 
@@ -64,7 +65,11 @@ final class DeviceProvider: ObservableObject {
 
     // MARK: - Private Properties
 
-    private var bluetoothManager: BluetoothManager { BluetoothManager.shared }
+    private let bluetoothManager: DeviceBluetoothManaging
+    private let userDefaults: UserDefaults
+    private let notificationCenter: NotificationCenter
+    private let connectionFactory: ConnectionFactory
+    private let autoReconnectEnabled: Bool
     /// The active device connection (internal for AudioSourceManager access)
     private(set) var activeConnection: DeviceConnection?
     private var batterySubscription: Task<Void, Never>?
@@ -89,7 +94,18 @@ final class DeviceProvider: ObservableObject {
 
     private var hasSetupBluetoothBindings = false
 
-    private init() {
+    init(
+        bluetoothManager: DeviceBluetoothManaging,
+        userDefaults: UserDefaults = .standard,
+        notificationCenter: NotificationCenter = .default,
+        connectionFactory: @escaping ConnectionFactory = { DeviceConnectionFactory.create(device: $0) },
+        autoReconnectEnabled: Bool = true
+    ) {
+        self.bluetoothManager = bluetoothManager
+        self.userDefaults = userDefaults
+        self.notificationCenter = notificationCenter
+        self.connectionFactory = connectionFactory
+        self.autoReconnectEnabled = autoReconnectEnabled
         setupNotificationBindings()
         loadPairedDevice()
     }
@@ -100,12 +116,14 @@ final class DeviceProvider: ObservableObject {
         guard !hasSetupBluetoothBindings else { return }
         hasSetupBluetoothBindings = true
 
-        // Force CBCentralManager creation to start receiving state updates
-        // This triggers the Bluetooth permission dialog on first use
-        _ = bluetoothManager.centralManager
+        bluetoothManager.prepareForStateUpdates()
+
+        bluetoothState = bluetoothManager.currentBluetoothState
+        isScanning = bluetoothManager.currentIsScanning
+        discoveredDevices = bluetoothManager.currentDiscoveredDevices
 
         // Observe Bluetooth state changes
-        bluetoothManager.$bluetoothState
+        bluetoothManager.bluetoothStatePublisher
             .receive(on: DispatchQueue.main)
             .sink { [weak self] state in
                 self?.bluetoothState = state
@@ -113,7 +131,7 @@ final class DeviceProvider: ObservableObject {
             .store(in: &cancellables)
 
         // Observe scanning state
-        bluetoothManager.$isScanning
+        bluetoothManager.isScanningPublisher
             .receive(on: DispatchQueue.main)
             .sink { [weak self] scanning in
                 self?.isScanning = scanning
@@ -121,7 +139,7 @@ final class DeviceProvider: ObservableObject {
             .store(in: &cancellables)
 
         // Observe discovered devices
-        bluetoothManager.$discoveredDevices
+        bluetoothManager.discoveredDevicesPublisher
             .receive(on: DispatchQueue.main)
             .sink { [weak self] devices in
                 self?.discoveredDevices = devices
@@ -132,7 +150,7 @@ final class DeviceProvider: ObservableObject {
     private func setupNotificationBindings() {
 
         // Observe BLE connection events
-        NotificationCenter.default.publisher(for: .bleDeviceConnected)
+        notificationCenter.publisher(for: .bleDeviceConnected)
             .receive(on: DispatchQueue.main)
             .compactMap { $0.userInfo?["peripheralId"] as? UUID }
             .sink { [weak self] peripheralId in
@@ -140,7 +158,7 @@ final class DeviceProvider: ObservableObject {
             }
             .store(in: &cancellables)
 
-        NotificationCenter.default.publisher(for: .bleDeviceDisconnected)
+        notificationCenter.publisher(for: .bleDeviceDisconnected)
             .receive(on: DispatchQueue.main)
             .compactMap { $0.userInfo?["peripheralId"] as? UUID }
             .sink { [weak self] peripheralId in
@@ -152,13 +170,13 @@ final class DeviceProvider: ObservableObject {
     // MARK: - Persistence
 
     private func loadPairedDevice() {
-        guard let deviceId = UserDefaults.standard.string(forKey: UserDefaultsKeys.pairedDeviceId),
+        guard let deviceId = userDefaults.string(forKey: UserDefaultsKeys.pairedDeviceId),
               !deviceId.isEmpty else {
             return
         }
 
-        let deviceName = UserDefaults.standard.string(forKey: UserDefaultsKeys.pairedDeviceName) ?? "Unknown Device"
-        let deviceTypeRaw = UserDefaults.standard.string(forKey: UserDefaultsKeys.pairedDeviceType) ?? "omi"
+        let deviceName = userDefaults.string(forKey: UserDefaultsKeys.pairedDeviceName) ?? "Unknown Device"
+        let deviceTypeRaw = userDefaults.string(forKey: UserDefaultsKeys.pairedDeviceType) ?? "omi"
         let deviceType = DeviceType(rawValue: deviceTypeRaw) ?? .omi
 
         pairedDevice = BtDevice(
@@ -173,14 +191,14 @@ final class DeviceProvider: ObservableObject {
 
     private func savePairedDevice(_ device: BtDevice?) {
         if let device = device {
-            UserDefaults.standard.set(device.id, forKey: UserDefaultsKeys.pairedDeviceId)
-            UserDefaults.standard.set(device.name, forKey: UserDefaultsKeys.pairedDeviceName)
-            UserDefaults.standard.set(device.type.rawValue, forKey: UserDefaultsKeys.pairedDeviceType)
+            userDefaults.set(device.id, forKey: UserDefaultsKeys.pairedDeviceId)
+            userDefaults.set(device.name, forKey: UserDefaultsKeys.pairedDeviceName)
+            userDefaults.set(device.type.rawValue, forKey: UserDefaultsKeys.pairedDeviceType)
             logger.info("Saved paired device: \(device.displayName)")
         } else {
-            UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.pairedDeviceId)
-            UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.pairedDeviceName)
-            UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.pairedDeviceType)
+            userDefaults.removeObject(forKey: UserDefaultsKeys.pairedDeviceId)
+            userDefaults.removeObject(forKey: UserDefaultsKeys.pairedDeviceName)
+            userDefaults.removeObject(forKey: UserDefaultsKeys.pairedDeviceType)
             logger.info("Cleared paired device")
         }
     }
@@ -227,7 +245,7 @@ final class DeviceProvider: ObservableObject {
 
         do {
             // Create connection using factory
-            guard let connection = DeviceConnectionFactory.create(device: device) else {
+            guard let connection = connectionFactory(device) else {
                 throw DeviceConnectionError.connectionFailed("Failed to create connection")
             }
 
@@ -330,6 +348,7 @@ final class DeviceProvider: ObservableObject {
 
     /// Start periodic reconnection attempts
     func startReconnectionTimer() {
+        guard autoReconnectEnabled else { return }
         guard pairedDevice != nil else { return }
         guard reconnectionTimer == nil else { return }
 

--- a/desktop/macos/Desktop/Sources/Providers/DeviceProvider.swift
+++ b/desktop/macos/Desktop/Sources/Providers/DeviceProvider.swift
@@ -499,7 +499,7 @@ final class DeviceProvider: ObservableObject {
             logger.info("Device has \(String(format: "%.1f", mbToSync)) MB of audio data pending sync")
 
             // Post notification that storage sync is available
-            NotificationCenter.default.post(
+            notificationCenter.post(
                 name: .storageSyncAvailable,
                 object: nil,
                 userInfo: ["bytesToSync": bytesToSync]

--- a/desktop/macos/Desktop/Tests/AuthTokenDecodingTests.swift
+++ b/desktop/macos/Desktop/Tests/AuthTokenDecodingTests.swift
@@ -76,6 +76,20 @@ final class AuthTokenDecodingTests: XCTestCase {
     }
   }
 
+  func testSignInWithIdpLogsWellFormedMalformedTokenResponses() throws {
+    let source = try desktopSource(relativePath: "Sources/AuthService.swift")
+
+    XCTAssertTrue(source.contains("tokens = try Self.decodeFirebaseTokenResult(from: data)"))
+    XCTAssertTrue(source.contains("OMI AUTH: Failed to parse Firebase signInWithIdp response: %@"))
+  }
+
+  private func desktopSource(relativePath: String) throws -> String {
+    let testsURL = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
+    let desktopURL = testsURL.deletingLastPathComponent()
+    let sourceURL = desktopURL.appendingPathComponent(relativePath)
+    return try String(contentsOf: sourceURL, encoding: .utf8)
+  }
+
   private func firebaseTokenResponse(idToken: String, expiresIn: Any, localId: String?) throws -> Data {
     var json: [String: Any] = [
       "idToken": idToken,

--- a/desktop/macos/Desktop/Tests/AuthTokenDecodingTests.swift
+++ b/desktop/macos/Desktop/Tests/AuthTokenDecodingTests.swift
@@ -1,0 +1,105 @@
+import XCTest
+
+@testable import Omi_Computer
+
+final class AuthTokenDecodingTests: XCTestCase {
+  func testDecodeJWTPayloadHandlesBase64URLWithoutPadding() throws {
+    let jwt = makeJWT(payload: [
+      "email": "person@example.com",
+      "given_name": "Ada",
+      "family_name": "Lovelace",
+    ])
+
+    let payload = try XCTUnwrap(AuthService.decodeJWTPayload(jwt))
+
+    XCTAssertEqual(payload["email"] as? String, "person@example.com")
+    XCTAssertEqual(payload["given_name"] as? String, "Ada")
+    XCTAssertEqual(payload["family_name"] as? String, "Lovelace")
+  }
+
+  func testLocalUserIdPrefersUserIdThenFallsBackToSubject() {
+    XCTAssertEqual(
+      AuthService.localUserId(fromIDToken: makeJWT(payload: ["user_id": "firebase-user", "sub": "subject-user"])),
+      "firebase-user"
+    )
+    XCTAssertEqual(
+      AuthService.localUserId(fromIDToken: makeJWT(payload: ["sub": "subject-user"])),
+      "subject-user"
+    )
+    XCTAssertNil(AuthService.localUserId(fromIDToken: "not-a-jwt"))
+  }
+
+  func testDecodeFirebaseTokenResultAcceptsStringAndIntegerExpiresIn() throws {
+    let stringExpiryData = try firebaseTokenResponse(
+      idToken: makeJWT(payload: ["sub": "fallback-user"]),
+      expiresIn: "7200",
+      localId: "explicit-user"
+    )
+    let stringExpiry = try AuthService.decodeFirebaseTokenResult(from: stringExpiryData)
+    XCTAssertTrue(stringExpiry.idToken.hasSuffix("."))
+    XCTAssertEqual(stringExpiry.refreshToken, "refresh-token")
+    XCTAssertEqual(stringExpiry.expiresIn, 7200)
+    XCTAssertEqual(stringExpiry.localId, "explicit-user")
+
+    let integerExpiryData = try firebaseTokenResponse(
+      idToken: makeJWT(payload: ["sub": "fallback-user"]),
+      expiresIn: 1800,
+      localId: "explicit-user"
+    )
+    let integerExpiry = try AuthService.decodeFirebaseTokenResult(from: integerExpiryData)
+    XCTAssertEqual(integerExpiry.expiresIn, 1800)
+  }
+
+  func testDecodeFirebaseTokenResultFallsBackToJwtUserIdAndCanRequireIt() throws {
+    let data = try firebaseTokenResponse(
+      idToken: makeJWT(payload: ["user_id": "jwt-user"]),
+      expiresIn: "3600",
+      localId: nil
+    )
+
+    let token = try AuthService.decodeFirebaseTokenResult(from: data, requireLocalId: true)
+
+    XCTAssertEqual(token.localId, "jwt-user")
+  }
+
+  func testDecodeFirebaseTokenResultRejectsMissingRequiredLocalId() throws {
+    let data = try firebaseTokenResponse(
+      idToken: makeJWT(payload: ["email": "person@example.com"]),
+      expiresIn: "3600",
+      localId: nil
+    )
+
+    XCTAssertThrowsError(try AuthService.decodeFirebaseTokenResult(from: data, requireLocalId: true)) { error in
+      guard case AuthError.invalidResponse = error else {
+        return XCTFail("expected invalidResponse, got \(error)")
+      }
+    }
+  }
+
+  private func firebaseTokenResponse(idToken: String, expiresIn: Any, localId: String?) throws -> Data {
+    var json: [String: Any] = [
+      "idToken": idToken,
+      "refreshToken": "refresh-token",
+      "expiresIn": expiresIn,
+    ]
+    if let localId {
+      json["localId"] = localId
+    }
+    return try JSONSerialization.data(withJSONObject: json, options: [.sortedKeys])
+  }
+
+  private func makeJWT(payload: [String: Any]) -> String {
+    let header = base64URL(["alg": "none", "typ": "JWT"])
+    let payload = base64URL(payload)
+    return "\(header).\(payload)."
+  }
+
+  private func base64URL(_ json: [String: Any]) -> String {
+    let data = try! JSONSerialization.data(withJSONObject: json, options: [.sortedKeys])
+    return data
+      .base64EncodedString()
+      .replacingOccurrences(of: "+", with: "-")
+      .replacingOccurrences(of: "/", with: "_")
+      .replacingOccurrences(of: "=", with: "")
+  }
+}

--- a/desktop/macos/Desktop/Tests/DeviceProviderTests.swift
+++ b/desktop/macos/Desktop/Tests/DeviceProviderTests.swift
@@ -1,0 +1,283 @@
+import Combine
+import CoreBluetooth
+import XCTest
+
+@testable import Omi_Computer
+
+@MainActor
+final class DeviceProviderTests: XCTestCase {
+  func testLoadsPersistedPairedDeviceFromInjectedDefaults() {
+    let defaults = makeDefaults()
+    defaults.set(testDevice.id, forKey: "pairedDeviceId")
+    defaults.set(testDevice.name, forKey: "pairedDeviceName")
+    defaults.set(testDevice.type.rawValue, forKey: "pairedDeviceType")
+    defer { removeDefaults(defaults) }
+
+    let provider = makeProvider(defaults: defaults)
+
+    XCTAssertEqual(provider.pairedDevice, testDevice)
+  }
+
+  func testConnectPersistsPairedDeviceToInjectedDefaults() async {
+    let defaults = makeDefaults()
+    defer { removeDefaults(defaults) }
+    let provider = makeProvider(defaults: defaults)
+
+    await provider.connect(to: testDevice)
+
+    XCTAssertTrue(provider.isConnected)
+    XCTAssertEqual(provider.connectedDevice, testDevice)
+    XCTAssertEqual(provider.pairedDevice, testDevice)
+    XCTAssertEqual(defaults.string(forKey: "pairedDeviceId"), testDevice.id)
+    XCTAssertEqual(defaults.string(forKey: "pairedDeviceName"), testDevice.name)
+    XCTAssertEqual(defaults.string(forKey: "pairedDeviceType"), testDevice.type.rawValue)
+  }
+
+  func testStartDiscoveryDoesNotScanWhenBluetoothIsNotPoweredOn() {
+    let bluetooth = FakeDeviceBluetoothManager(state: .poweredOff)
+    let provider = makeProvider(bluetooth: bluetooth)
+
+    provider.startDiscovery(timeout: 1.0)
+
+    XCTAssertEqual(bluetooth.prepareForStateUpdatesCallCount, 1)
+    XCTAssertEqual(bluetooth.startScanningTimeouts, [])
+    XCTAssertFalse(provider.isScanning)
+    XCTAssertEqual(provider.errorMessage, "Bluetooth is not available")
+  }
+
+  func testStartDiscoveryScansWhenBluetoothIsPoweredOn() {
+    let bluetooth = FakeDeviceBluetoothManager(state: .poweredOn)
+    let provider = makeProvider(bluetooth: bluetooth)
+
+    provider.startDiscovery(timeout: 1.5)
+
+    XCTAssertEqual(bluetooth.prepareForStateUpdatesCallCount, 1)
+    XCTAssertEqual(bluetooth.startScanningTimeouts, [1.5])
+    XCTAssertNil(provider.errorMessage)
+  }
+
+  func testDisconnectNotificationClearsConnectedStateButKeepsPairing() async {
+    let notificationCenter = NotificationCenter()
+    let provider = makeProvider(notificationCenter: notificationCenter, autoReconnectEnabled: false)
+
+    await provider.connect(to: testDevice)
+    XCTAssertTrue(provider.isConnected)
+
+    notificationCenter.post(
+      name: .bleDeviceDisconnected,
+      object: nil,
+      userInfo: ["peripheralId": UUID(uuidString: testDevice.id)!]
+    )
+    await drainMainQueue()
+
+    XCTAssertFalse(provider.isConnected)
+    XCTAssertNil(provider.connectedDevice)
+    XCTAssertNil(provider.activeConnection)
+    XCTAssertEqual(provider.batteryLevel, -1)
+    XCTAssertFalse(provider.isDeviceStorageSupported)
+    XCTAssertEqual(provider.pairedDevice, testDevice)
+  }
+
+  func testUnpairDisconnectsAndClearsPersistedPairing() async {
+    let defaults = makeDefaults()
+    defer { removeDefaults(defaults) }
+    var connection: FakeDeviceConnection?
+    let provider = DeviceProvider(
+      bluetoothManager: FakeDeviceBluetoothManager(state: .poweredOn),
+      userDefaults: defaults,
+      notificationCenter: NotificationCenter(),
+      connectionFactory: { device in
+        let newConnection = FakeDeviceConnection(device: device)
+        connection = newConnection
+        return newConnection
+      },
+      autoReconnectEnabled: false
+    )
+
+    await provider.connect(to: testDevice)
+    await provider.unpair()
+
+    XCTAssertEqual(connection?.unpairCallCount, 1)
+    XCTAssertFalse(provider.isConnected)
+    XCTAssertNil(provider.connectedDevice)
+    XCTAssertNil(provider.pairedDevice)
+    XCTAssertNil(defaults.string(forKey: "pairedDeviceId"))
+    XCTAssertNil(defaults.string(forKey: "pairedDeviceName"))
+    XCTAssertNil(defaults.string(forKey: "pairedDeviceType"))
+  }
+
+  private var testDevice: BtDevice {
+    BtDevice(
+      id: "11111111-2222-3333-4444-555555555555",
+      name: "Test Omi",
+      type: .omi,
+      rssi: -45
+    )
+  }
+
+  private func makeProvider(
+    bluetooth: FakeDeviceBluetoothManager? = nil,
+    defaults: UserDefaults? = nil,
+    notificationCenter: NotificationCenter = NotificationCenter(),
+    autoReconnectEnabled: Bool = false
+  ) -> DeviceProvider {
+    DeviceProvider(
+      bluetoothManager: bluetooth ?? FakeDeviceBluetoothManager(state: .poweredOn),
+      userDefaults: defaults ?? makeDefaults(),
+      notificationCenter: notificationCenter,
+      connectionFactory: { FakeDeviceConnection(device: $0) },
+      autoReconnectEnabled: autoReconnectEnabled
+    )
+  }
+
+  private func makeDefaults() -> UserDefaults {
+    let suiteName = "DeviceProviderTests.\(UUID().uuidString)"
+    let defaults = UserDefaults(suiteName: suiteName)!
+    defaults.set(suiteName, forKey: "__testSuiteName")
+    return defaults
+  }
+
+  private func removeDefaults(_ defaults: UserDefaults) {
+    guard let suiteName = defaults.string(forKey: "__testSuiteName") else {
+      return
+    }
+    defaults.removePersistentDomain(forName: suiteName)
+  }
+
+  private func drainMainQueue() async {
+    await Task.yield()
+    await Task.yield()
+  }
+}
+
+@MainActor
+private final class FakeDeviceBluetoothManager: DeviceBluetoothManaging {
+  private let bluetoothStateSubject: CurrentValueSubject<CBManagerState, Never>
+  private let isScanningSubject: CurrentValueSubject<Bool, Never>
+  private let discoveredDevicesSubject: CurrentValueSubject<[BtDevice], Never>
+
+  var prepareForStateUpdatesCallCount = 0
+  var startScanningTimeouts: [TimeInterval] = []
+  var stopScanningCallCount = 0
+
+  init(
+    state: CBManagerState,
+    isScanning: Bool = false,
+    discoveredDevices: [BtDevice] = []
+  ) {
+    bluetoothStateSubject = CurrentValueSubject(state)
+    isScanningSubject = CurrentValueSubject(isScanning)
+    discoveredDevicesSubject = CurrentValueSubject(discoveredDevices)
+  }
+
+  var currentBluetoothState: CBManagerState { bluetoothStateSubject.value }
+  var currentIsScanning: Bool { isScanningSubject.value }
+  var currentDiscoveredDevices: [BtDevice] { discoveredDevicesSubject.value }
+  var bluetoothStatePublisher: AnyPublisher<CBManagerState, Never> {
+    bluetoothStateSubject.eraseToAnyPublisher()
+  }
+  var isScanningPublisher: AnyPublisher<Bool, Never> {
+    isScanningSubject.eraseToAnyPublisher()
+  }
+  var discoveredDevicesPublisher: AnyPublisher<[BtDevice], Never> {
+    discoveredDevicesSubject.eraseToAnyPublisher()
+  }
+
+  func prepareForStateUpdates() {
+    prepareForStateUpdatesCallCount += 1
+  }
+
+  func startScanning(timeout: TimeInterval) {
+    startScanningTimeouts.append(timeout)
+    isScanningSubject.send(true)
+  }
+
+  func stopScanning() {
+    stopScanningCallCount += 1
+    isScanningSubject.send(false)
+  }
+}
+
+private final class FakeDeviceConnection: BaseDeviceConnection {
+  var unpairCallCount = 0
+
+  init(device: BtDevice) {
+    super.init(device: device, transport: FakeDeviceTransport(deviceId: device.id))
+  }
+
+  override func unpair() async {
+    unpairCallCount += 1
+    await super.unpair()
+  }
+
+  override func getBatteryLevel() async -> Int {
+    82
+  }
+
+  override func getBatteryLevelStream() -> AsyncThrowingStream<Int, Error> {
+    AsyncThrowingStream { continuation in
+      continuation.finish()
+    }
+  }
+
+  override func getStorageList() async -> [Int32] {
+    []
+  }
+}
+
+private final class FakeDeviceTransport: DeviceTransport {
+  let deviceId: String
+  private(set) var state: DeviceTransportState = .disconnected
+  private let connectionStateSubject = PassthroughSubject<DeviceTransportState, Never>()
+
+  init(deviceId: String) {
+    self.deviceId = deviceId
+  }
+
+  var connectionStatePublisher: AnyPublisher<DeviceTransportState, Never> {
+    connectionStateSubject.eraseToAnyPublisher()
+  }
+
+  func connect() async throws {
+    state = .connected
+    connectionStateSubject.send(.connected)
+  }
+
+  func disconnect() async {
+    state = .disconnected
+    connectionStateSubject.send(.disconnected)
+  }
+
+  func isConnected() async -> Bool {
+    state == .connected
+  }
+
+  func ping() async -> Bool {
+    true
+  }
+
+  func getCharacteristicStream(
+    serviceUUID: CBUUID,
+    characteristicUUID: CBUUID
+  ) -> AsyncThrowingStream<Data, Error> {
+    AsyncThrowingStream { continuation in
+      continuation.finish()
+    }
+  }
+
+  func readCharacteristic(
+    serviceUUID: CBUUID,
+    characteristicUUID: CBUUID
+  ) async throws -> Data {
+    Data()
+  }
+
+  func writeCharacteristic(
+    data: Data,
+    serviceUUID: CBUUID,
+    characteristicUUID: CBUUID,
+    withResponse: Bool
+  ) async throws {}
+
+  func dispose() async {}
+}

--- a/desktop/macos/Desktop/Tests/DeviceProviderTests.swift
+++ b/desktop/macos/Desktop/Tests/DeviceProviderTests.swift
@@ -151,6 +151,34 @@ final class DeviceProviderTests: XCTestCase {
     XCTAssertTrue(provider.isDeviceStorageSupported)
   }
 
+  func testStorageSyncNotificationUsesInjectedNotificationCenter() async {
+    let defaults = makeDefaults()
+    defer { removeDefaults(defaults) }
+    let notificationCenter = NotificationCenter()
+    var observedBytesToSync: Int?
+    let observer = notificationCenter.addObserver(
+      forName: .storageSyncAvailable,
+      object: nil,
+      queue: nil
+    ) { notification in
+      observedBytesToSync = notification.userInfo?["bytesToSync"] as? Int
+    }
+    defer { notificationCenter.removeObserver(observer) }
+
+    let provider = DeviceProvider(
+      bluetoothManager: FakeDeviceBluetoothManager(state: .poweredOn),
+      userDefaults: defaults,
+      notificationCenter: notificationCenter,
+      connectionFactory: { FakeDeviceConnection(device: $0, batteryLevel: 25, storageList: [8_000]) },
+      storageDataChecker: { (2_000_000, 1_000_000) },
+      autoReconnectEnabled: false
+    )
+
+    await provider.connect(to: testDevice)
+
+    XCTAssertEqual(observedBytesToSync, 1_000_000)
+  }
+
   func testFirmwareUpdateInProgressStateCanBeToggled() {
     let provider = makeProvider(autoReconnectEnabled: false)
 

--- a/desktop/macos/Desktop/Tests/DeviceProviderTests.swift
+++ b/desktop/macos/Desktop/Tests/DeviceProviderTests.swift
@@ -6,6 +6,16 @@ import XCTest
 
 @MainActor
 final class DeviceProviderTests: XCTestCase {
+  private var defaultsToRemove: [UserDefaults] = []
+
+  override func tearDown() {
+    for defaults in defaultsToRemove {
+      removeDefaults(defaults)
+    }
+    defaultsToRemove = []
+    super.tearDown()
+  }
+
   func testLoadsPersistedPairedDeviceFromInjectedDefaults() {
     let defaults = makeDefaults()
     defaults.set(testDevice.id, forKey: "pairedDeviceId")
@@ -31,6 +41,29 @@ final class DeviceProviderTests: XCTestCase {
     XCTAssertEqual(defaults.string(forKey: "pairedDeviceId"), testDevice.id)
     XCTAssertEqual(defaults.string(forKey: "pairedDeviceName"), testDevice.name)
     XCTAssertEqual(defaults.string(forKey: "pairedDeviceType"), testDevice.type.rawValue)
+  }
+
+  func testFailedConnectionCleansUpTransientStateAndDoesNotPersistPairing() async {
+    let defaults = makeDefaults()
+    defer { removeDefaults(defaults) }
+    let provider = DeviceProvider(
+      bluetoothManager: FakeDeviceBluetoothManager(state: .poweredOn),
+      userDefaults: defaults,
+      notificationCenter: NotificationCenter(),
+      connectionFactory: { FakeDeviceConnection(device: $0, connectError: DeviceTransportError.connectionFailed("boom")) },
+      storageDataChecker: { nil },
+      autoReconnectEnabled: false
+    )
+
+    await provider.connect(to: testDevice)
+
+    XCTAssertFalse(provider.isConnecting)
+    XCTAssertFalse(provider.isConnected)
+    XCTAssertNil(provider.connectedDevice)
+    XCTAssertNil(provider.activeConnection)
+    XCTAssertNil(provider.pairedDevice)
+    XCTAssertNil(defaults.string(forKey: "pairedDeviceId"))
+    XCTAssertEqual(provider.errorMessage, "Failed to connect: Connection failed: boom")
   }
 
   func testStartDiscoveryDoesNotScanWhenBluetoothIsNotPoweredOn() {
@@ -78,6 +111,107 @@ final class DeviceProviderTests: XCTestCase {
     XCTAssertEqual(provider.pairedDevice, testDevice)
   }
 
+  func testDisconnectNotificationForDifferentPeripheralDoesNotClearCurrentDevice() async {
+    let notificationCenter = NotificationCenter()
+    let provider = makeProvider(notificationCenter: notificationCenter, autoReconnectEnabled: false)
+
+    await provider.connect(to: testDevice)
+    XCTAssertTrue(provider.isConnected)
+
+    notificationCenter.post(
+      name: .bleDeviceDisconnected,
+      object: nil,
+      userInfo: ["peripheralId": UUID(uuidString: "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE")!]
+    )
+    await drainMainQueue()
+
+    XCTAssertTrue(provider.isConnected)
+    XCTAssertEqual(provider.connectedDevice, testDevice)
+    XCTAssertNotNil(provider.activeConnection)
+    XCTAssertEqual(provider.pairedDevice, testDevice)
+    XCTAssertEqual(provider.batteryLevel, 82)
+  }
+
+  func testConnectReflectsBatteryAndStorageSupport() async {
+    let defaults = makeDefaults()
+    defer { removeDefaults(defaults) }
+    let provider = DeviceProvider(
+      bluetoothManager: FakeDeviceBluetoothManager(state: .poweredOn),
+      userDefaults: defaults,
+      notificationCenter: NotificationCenter(),
+      connectionFactory: { FakeDeviceConnection(device: $0, batteryLevel: 25, storageList: [8_000]) },
+      storageDataChecker: { nil },
+      autoReconnectEnabled: false
+    )
+
+    await provider.connect(to: testDevice)
+
+    XCTAssertTrue(provider.isConnected)
+    XCTAssertEqual(provider.batteryLevel, 25)
+    XCTAssertTrue(provider.isDeviceStorageSupported)
+  }
+
+  func testFirmwareUpdateInProgressStateCanBeToggled() {
+    let provider = makeProvider(autoReconnectEnabled: false)
+
+    provider.setFirmwareUpdateInProgress(true)
+    XCTAssertTrue(provider.isFirmwareUpdateInProgress)
+
+    provider.setFirmwareUpdateInProgress(false)
+    XCTAssertFalse(provider.isFirmwareUpdateInProgress)
+  }
+
+  func testStartReconnectionTimerAttemptsPersistedPairingImmediately() async {
+    let defaults = makeDefaults()
+    defaults.set(testDevice.id, forKey: "pairedDeviceId")
+    defaults.set(testDevice.name, forKey: "pairedDeviceName")
+    defaults.set(testDevice.type.rawValue, forKey: "pairedDeviceType")
+    defer { removeDefaults(defaults) }
+    var attemptedDevices: [BtDevice] = []
+    let provider = DeviceProvider(
+      bluetoothManager: FakeDeviceBluetoothManager(state: .poweredOn),
+      userDefaults: defaults,
+      notificationCenter: NotificationCenter(),
+      connectionFactory: { device in
+        attemptedDevices.append(device)
+        return FakeDeviceConnection(device: device)
+      },
+      storageDataChecker: { nil },
+      autoReconnectEnabled: true
+    )
+
+    provider.startReconnectionTimer()
+    await waitUntil { provider.isConnected }
+    provider.stopReconnectionTimer()
+
+    XCTAssertEqual(attemptedDevices, [testDevice])
+    XCTAssertTrue(provider.isConnected)
+    XCTAssertEqual(provider.connectedDevice, testDevice)
+  }
+
+  func testStartReconnectionTimerWithoutPairingDoesNotAttemptConnection() async {
+    let defaults = makeDefaults()
+    defer { removeDefaults(defaults) }
+    var connectionFactoryCallCount = 0
+    let provider = DeviceProvider(
+      bluetoothManager: FakeDeviceBluetoothManager(state: .poweredOn),
+      userDefaults: defaults,
+      notificationCenter: NotificationCenter(),
+      connectionFactory: { device in
+        connectionFactoryCallCount += 1
+        return FakeDeviceConnection(device: device)
+      },
+      storageDataChecker: { nil },
+      autoReconnectEnabled: true
+    )
+
+    provider.startReconnectionTimer()
+    await drainMainQueue()
+
+    XCTAssertEqual(connectionFactoryCallCount, 0)
+    XCTAssertFalse(provider.isConnected)
+  }
+
   func testUnpairDisconnectsAndClearsPersistedPairing() async {
     let defaults = makeDefaults()
     defer { removeDefaults(defaults) }
@@ -91,6 +225,7 @@ final class DeviceProviderTests: XCTestCase {
         connection = newConnection
         return newConnection
       },
+      storageDataChecker: { nil },
       autoReconnectEnabled: false
     )
 
@@ -126,6 +261,7 @@ final class DeviceProviderTests: XCTestCase {
       userDefaults: defaults ?? makeDefaults(),
       notificationCenter: notificationCenter,
       connectionFactory: { FakeDeviceConnection(device: $0) },
+      storageDataChecker: { nil },
       autoReconnectEnabled: autoReconnectEnabled
     )
   }
@@ -134,6 +270,7 @@ final class DeviceProviderTests: XCTestCase {
     let suiteName = "DeviceProviderTests.\(UUID().uuidString)"
     let defaults = UserDefaults(suiteName: suiteName)!
     defaults.set(suiteName, forKey: "__testSuiteName")
+    defaultsToRemove.append(defaults)
     return defaults
   }
 
@@ -147,6 +284,20 @@ final class DeviceProviderTests: XCTestCase {
   private func drainMainQueue() async {
     await Task.yield()
     await Task.yield()
+  }
+
+  private func waitUntil(
+    _ predicate: @MainActor () -> Bool,
+    file: StaticString = #filePath,
+    line: UInt = #line
+  ) async {
+    for _ in 0..<100 {
+      if predicate() {
+        return
+      }
+      await Task.yield()
+    }
+    XCTFail("Timed out waiting for condition", file: file, line: line)
   }
 }
 
@@ -199,10 +350,28 @@ private final class FakeDeviceBluetoothManager: DeviceBluetoothManaging {
 }
 
 private final class FakeDeviceConnection: BaseDeviceConnection {
+  private let connectError: Error?
+  private let batteryLevel: Int
+  private let storageList: [Int32]
   var unpairCallCount = 0
 
-  init(device: BtDevice) {
+  init(
+    device: BtDevice,
+    connectError: Error? = nil,
+    batteryLevel: Int = 82,
+    storageList: [Int32] = []
+  ) {
+    self.connectError = connectError
+    self.batteryLevel = batteryLevel
+    self.storageList = storageList
     super.init(device: device, transport: FakeDeviceTransport(deviceId: device.id))
+  }
+
+  override func connect() async throws {
+    if let connectError {
+      throw connectError
+    }
+    try await super.connect()
   }
 
   override func unpair() async {
@@ -211,7 +380,7 @@ private final class FakeDeviceConnection: BaseDeviceConnection {
   }
 
   override func getBatteryLevel() async -> Int {
-    82
+    batteryLevel
   }
 
   override func getBatteryLevelStream() -> AsyncThrowingStream<Int, Error> {
@@ -221,7 +390,7 @@ private final class FakeDeviceConnection: BaseDeviceConnection {
   }
 
   override func getStorageList() async -> [Int32] {
-    []
+    storageList
   }
 }
 

--- a/desktop/macos/Desktop/Tests/FileIndexScanPolicyTests.swift
+++ b/desktop/macos/Desktop/Tests/FileIndexScanPolicyTests.swift
@@ -1,0 +1,156 @@
+import XCTest
+
+@testable import Omi_Computer
+
+final class FileIndexScanPolicyTests: XCTestCase {
+  func testStandardScanRootsArePlannedFromSuppliedHomeURL() {
+    let policy = FileIndexScanPolicy.standard
+    let home = URL(fileURLWithPath: "/tmp/omi-test-home", isDirectory: true)
+    let applications = URL(fileURLWithPath: "/tmp/omi-test-applications", isDirectory: true)
+
+    let roots = policy.standardScanRoots(homeURL: home, applicationsURL: applications)
+
+    XCTAssertEqual(
+      roots.map(\.path),
+      [
+        "/tmp/omi-test-home/Downloads",
+        "/tmp/omi-test-home/Documents",
+        "/tmp/omi-test-home/Desktop",
+        "/tmp/omi-test-home/Developer",
+        "/tmp/omi-test-home/Projects",
+        "/tmp/omi-test-home/Code",
+        "/tmp/omi-test-home/src",
+        "/tmp/omi-test-home/repos",
+        "/tmp/omi-test-home/Sites",
+        "/tmp/omi-test-applications",
+        "/tmp/omi-test-home/Applications",
+      ]
+    )
+  }
+
+  func testSkipFoldersAreRejectedBeforeRecursiveDescent() {
+    let policy = FileIndexScanPolicy.standard
+
+    XCTAssertEqual(policy.planDirectoryEntry(directory(named: "node_modules")), .skipSubtree)
+    XCTAssertEqual(policy.planDirectoryEntry(directory(named: ".git")), .skipSubtree)
+    XCTAssertEqual(policy.planDirectoryEntry(directory(named: "Library")), .skipSubtree)
+    XCTAssertEqual(policy.planDirectoryEntry(directory(named: "Source")), .descend)
+  }
+
+  func testPackagesAreIndexedAsLeavesWithStableType() {
+    let policy = FileIndexScanPolicy.standard
+    let homePath = "/Users/tester"
+    let modified = Date(timeIntervalSince1970: 1_000)
+
+    let app = policy.makePackageRecord(
+      for: URL(fileURLWithPath: "\(homePath)/Applications/Omi.app", isDirectory: true),
+      folderName: "Applications",
+      homePath: homePath,
+      depth: 1,
+      createdAt: nil,
+      modifiedAt: modified
+    )
+    XCTAssertEqual(app?.path, "~/Applications/Omi.app")
+    XCTAssertEqual(app?.filename, "Omi.app")
+    XCTAssertEqual(app?.fileExtension, "app")
+    XCTAssertEqual(app?.fileType, "application")
+    XCTAssertEqual(app?.sizeBytes, 0)
+    XCTAssertEqual(app?.depth, 1)
+    XCTAssertEqual(app?.modifiedAt, modified)
+
+    let project = policy.makePackageRecord(
+      for: URL(fileURLWithPath: "\(homePath)/Developer/Omi.xcodeproj", isDirectory: true),
+      folderName: "Developer",
+      homePath: homePath,
+      depth: 0,
+      createdAt: nil,
+      modifiedAt: nil
+    )
+    XCTAssertEqual(project?.path, "~/Developer/Omi.xcodeproj")
+    XCTAssertEqual(project?.fileExtension, "xcodeproj")
+    XCTAssertEqual(project?.fileType, "package")
+
+    XCTAssertNil(
+      policy.makePackageRecord(
+        for: URL(fileURLWithPath: "\(homePath)/Developer/plain-folder", isDirectory: true),
+        folderName: "Developer",
+        homePath: homePath,
+        depth: 0,
+        createdAt: nil,
+        modifiedAt: nil
+      )
+    )
+  }
+
+  func testMaxDepthAllowsConfiguredDepthAndStopsBelowIt() {
+    let policy = FileIndexScanPolicy(maxDepth: 2)
+
+    XCTAssertTrue(policy.shouldScanDirectory(atDepth: 0))
+    XCTAssertTrue(policy.shouldScanDirectory(atDepth: 2))
+    XCTAssertFalse(policy.shouldScanDirectory(atDepth: 3))
+  }
+
+  func testFileRecordsRejectEmptyOversizedAndNonRegularFiles() {
+    let policy = FileIndexScanPolicy(maxFileSize: 10)
+    let homePath = "/Users/tester"
+    let url = URL(fileURLWithPath: "\(homePath)/Documents/report.pdf")
+
+    XCTAssertNil(
+      policy.makeFileRecord(
+        for: url,
+        folderName: "Documents",
+        homePath: homePath,
+        depth: 0,
+        isRegularFile: false,
+        sizeBytes: 5,
+        createdAt: nil,
+        modifiedAt: nil
+      )
+    )
+    XCTAssertNil(
+      policy.makeFileRecord(
+        for: url,
+        folderName: "Documents",
+        homePath: homePath,
+        depth: 0,
+        isRegularFile: true,
+        sizeBytes: 0,
+        createdAt: nil,
+        modifiedAt: nil
+      )
+    )
+    XCTAssertNil(
+      policy.makeFileRecord(
+        for: url,
+        folderName: "Documents",
+        homePath: homePath,
+        depth: 0,
+        isRegularFile: true,
+        sizeBytes: 11,
+        createdAt: nil,
+        modifiedAt: nil
+      )
+    )
+
+    let record = policy.makeFileRecord(
+      for: url,
+      folderName: "Documents",
+      homePath: homePath,
+      depth: 0,
+      isRegularFile: true,
+      sizeBytes: 10,
+      createdAt: nil,
+      modifiedAt: nil
+    )
+
+    XCTAssertEqual(record?.path, "~/Documents/report.pdf")
+    XCTAssertEqual(record?.filename, "report.pdf")
+    XCTAssertEqual(record?.fileExtension, "pdf")
+    XCTAssertEqual(record?.fileType, FileTypeCategory.document.rawValue)
+    XCTAssertEqual(record?.sizeBytes, 10)
+  }
+
+  private func directory(named name: String) -> URL {
+    URL(fileURLWithPath: "/tmp/omi-file-index-policy/\(name)", isDirectory: true)
+  }
+}

--- a/desktop/macos/Desktop/Tests/FileIndexerServiceTests.swift
+++ b/desktop/macos/Desktop/Tests/FileIndexerServiceTests.swift
@@ -1,0 +1,121 @@
+import GRDB
+import XCTest
+
+@testable import Omi_Computer
+
+final class FileIndexerServiceTests: XCTestCase {
+  private var temporaryRoot: URL!
+  private var databasePool: DatabasePool!
+
+  override func setUpWithError() throws {
+    try super.setUpWithError()
+
+    temporaryRoot = FileManager.default.temporaryDirectory
+      .appendingPathComponent("omi-file-indexer-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: temporaryRoot, withIntermediateDirectories: true)
+
+    let databaseURL = temporaryRoot.appendingPathComponent("index.sqlite")
+    databasePool = try DatabasePool(path: databaseURL.path)
+    try databasePool.write { db in
+      try db.create(table: "indexed_files") { t in
+        t.autoIncrementedPrimaryKey("id")
+        t.column("path", .text).notNull()
+        t.column("filename", .text).notNull()
+        t.column("fileExtension", .text)
+        t.column("fileType", .text).notNull()
+        t.column("sizeBytes", .integer).notNull()
+        t.column("folder", .text).notNull()
+        t.column("depth", .integer).notNull()
+        t.column("createdAt", .datetime)
+        t.column("modifiedAt", .datetime)
+        t.column("indexedAt", .datetime).notNull()
+      }
+      try db.create(index: "idx_indexed_files_path", on: "indexed_files", columns: ["path"], unique: true)
+    }
+  }
+
+  override func tearDownWithError() throws {
+    databasePool = nil
+    if let temporaryRoot {
+      try? FileManager.default.removeItem(at: temporaryRoot)
+    }
+    temporaryRoot = nil
+    try super.tearDownWithError()
+  }
+
+  func testScanFoldersIndexesRecursiveTreeAndIncrementalScanSkipsOrDeletes() async throws {
+    let root = temporaryRoot.appendingPathComponent("Documents", isDirectory: true)
+    try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+
+    let rootFile = try writeFile("hello", at: root.appendingPathComponent("root.md"))
+    let child = root.appendingPathComponent("Project", isDirectory: true)
+    let nested = child.appendingPathComponent("Nested", isDirectory: true)
+    try FileManager.default.createDirectory(at: nested, withIntermediateDirectories: true)
+    let childFile = try writeFile("print('hi')", at: child.appendingPathComponent("main.py"))
+    _ = try writeFile("too deep", at: nested.appendingPathComponent("deep.txt"))
+
+    let skippedFolder = root.appendingPathComponent("node_modules", isDirectory: true)
+    try FileManager.default.createDirectory(at: skippedFolder, withIntermediateDirectories: true)
+    _ = try writeFile("skip", at: skippedFolder.appendingPathComponent("package.json"))
+
+    let package = root.appendingPathComponent("Example.app", isDirectory: true)
+    try FileManager.default.createDirectory(
+      at: package.appendingPathComponent("Contents", isDirectory: true),
+      withIntermediateDirectories: true
+    )
+    _ = try writeFile("inside package", at: package.appendingPathComponent("Contents/Info.plist"))
+    _ = try writeFile("this file is over the test size limit", at: root.appendingPathComponent("big.bin"))
+    let deletedLater = try writeFile("delete me", at: root.appendingPathComponent("remove.txt"))
+
+    let policy = FileIndexScanPolicy(maxDepth: 1, maxFileSize: 12)
+    let service = FileIndexerService(databasePool: databasePool, scanPolicy: policy, batchSize: 2)
+
+    let firstCount = await service.scanFolders([root])
+
+    XCTAssertEqual(firstCount, 4)
+    var records = try fetchIndexedRecords()
+    XCTAssertEqual(records.map(\.filename).sorted(), ["Example.app", "main.py", "remove.txt", "root.md"])
+    XCTAssertEqual(records.first(where: { $0.filename == "Example.app" })?.fileType, "application")
+    XCTAssertEqual(records.first(where: { $0.filename == "Example.app" })?.depth, 0)
+    XCTAssertNil(records.first(where: { $0.filename == "Info.plist" }))
+    XCTAssertNil(records.first(where: { $0.filename == "package.json" }))
+    XCTAssertNil(records.first(where: { $0.filename == "deep.txt" }))
+    XCTAssertNil(records.first(where: { $0.filename == "big.bin" }))
+
+    let rootPath = try XCTUnwrap(records.first { $0.filename == rootFile.lastPathComponent }?.path)
+    let childPath = try XCTUnwrap(records.first { $0.filename == childFile.lastPathComponent }?.path)
+    let rootIndexedAt = try XCTUnwrap(records.first { $0.path == rootPath }?.indexedAt)
+    let childIndexedAt = try XCTUnwrap(records.first { $0.path == childPath }?.indexedAt)
+    let deletedFilename = deletedLater.lastPathComponent
+
+    try FileManager.default.removeItem(at: deletedLater)
+    _ = try writeFile("new", at: root.appendingPathComponent("new.csv"))
+
+    let secondCount = await service.scanFolders([root], incremental: true)
+
+    XCTAssertEqual(secondCount, 1)
+    records = try fetchIndexedRecords()
+    XCTAssertEqual(records.map(\.filename).sorted(), ["Example.app", "main.py", "new.csv", "root.md"])
+    XCTAssertNil(records.first { $0.filename == deletedFilename })
+    XCTAssertEqual(records.first { $0.path == rootPath }?.indexedAt, rootIndexedAt)
+    XCTAssertEqual(records.first { $0.path == childPath }?.indexedAt, childIndexedAt)
+    XCTAssertEqual(records.first { $0.filename == "new.csv" }?.fileType, FileTypeCategory.spreadsheet.rawValue)
+  }
+
+  private func writeFile(_ contents: String, at url: URL) throws -> URL {
+    try FileManager.default.createDirectory(
+      at: url.deletingLastPathComponent(),
+      withIntermediateDirectories: true
+    )
+    try contents.data(using: .utf8)?.write(to: url)
+    return url
+  }
+
+  private func fetchIndexedRecords() throws -> [IndexedFileRecord] {
+    try databasePool.read { db in
+      try IndexedFileRecord
+        .order(IndexedFileRecord.Columns.path)
+        .fetchAll(db)
+    }
+  }
+}

--- a/desktop/macos/Desktop/Tests/LiveNotesAccumulatorTests.swift
+++ b/desktop/macos/Desktop/Tests/LiveNotesAccumulatorTests.swift
@@ -1,0 +1,105 @@
+import XCTest
+@testable import Omi_Computer
+
+final class LiveNotesAccumulatorTests: XCTestCase {
+    func testBuildsGenerationRequestWhenWordThresholdIsReached() {
+        var accumulator = LiveNotesAccumulator(wordThreshold: 5, maxWordBufferSize: 20, maxExistingNotesContext: 3)
+
+        XCTAssertNil(accumulator.handleSegmentsUpdate([
+            segment(text: "one two", start: 0, end: 1),
+        ], isGenerating: false))
+        XCTAssertEqual(accumulator.wordBuffer, ["one", "two"])
+
+        let request = accumulator.handleSegmentsUpdate([
+            segment(text: "one two", start: 0, end: 1),
+            segment(text: "three four five", start: 1, end: 2),
+        ], isGenerating: false)
+
+        XCTAssertEqual(request?.recentText, "one two three four five")
+        XCTAssertEqual(request?.existingNotesText, "No existing notes yet.")
+        XCTAssertEqual(request?.segmentStartOrder, 0)
+        XCTAssertEqual(request?.segmentEndOrder, 2)
+    }
+
+    func testIgnoresAlreadyProcessedSegments() {
+        var accumulator = LiveNotesAccumulator(wordThreshold: 3, maxWordBufferSize: 20, maxExistingNotesContext: 3)
+        let segments = [
+            segment(text: "one two three", start: 0, end: 1),
+        ]
+
+        XCTAssertNotNil(accumulator.handleSegmentsUpdate(segments, isGenerating: false))
+        XCTAssertNil(accumulator.handleSegmentsUpdate(segments, isGenerating: false))
+        XCTAssertEqual(accumulator.wordBuffer, ["one", "two", "three"])
+    }
+
+    func testSuccessfulGenerationResetsThresholdAndTrimsExistingNotesContext() {
+        var accumulator = LiveNotesAccumulator(wordThreshold: 3, maxWordBufferSize: 20, maxExistingNotesContext: 2)
+        accumulator.seedExistingNotes(["old one", "old two", "old three"])
+
+        let firstRequest = accumulator.handleSegmentsUpdate([
+            segment(text: "alpha beta gamma", start: 0, end: 1),
+        ], isGenerating: false)
+
+        XCTAssertEqual(firstRequest?.existingNotesText, "Existing notes:\n- old two\n- old three")
+
+        accumulator.markGenerationSucceeded(noteText: "new note")
+        XCTAssertEqual(accumulator.existingNotesContext, ["old three", "new note"])
+
+        XCTAssertNil(accumulator.handleSegmentsUpdate([
+            segment(text: "alpha beta gamma", start: 0, end: 1),
+            segment(text: "delta epsilon", start: 1, end: 2),
+        ], isGenerating: false))
+
+        let secondRequest = accumulator.handleSegmentsUpdate([
+            segment(text: "alpha beta gamma", start: 0, end: 1),
+            segment(text: "delta epsilon", start: 1, end: 2),
+            segment(text: "zeta", start: 2, end: 3),
+        ], isGenerating: false)
+
+        XCTAssertEqual(secondRequest?.recentText, "delta epsilon zeta")
+        XCTAssertEqual(secondRequest?.existingNotesText, "Existing notes:\n- old three\n- new note")
+    }
+
+    func testWordBufferTrimsWithoutBlockingFutureGeneration() {
+        var accumulator = LiveNotesAccumulator(wordThreshold: 3, maxWordBufferSize: 5, maxExistingNotesContext: 3)
+
+        XCTAssertNotNil(accumulator.handleSegmentsUpdate([
+            segment(text: "one two three", start: 0, end: 1),
+        ], isGenerating: false))
+        accumulator.markGenerationSucceeded(noteText: "first note")
+
+        let request = accumulator.handleSegmentsUpdate([
+            segment(text: "one two three", start: 0, end: 1),
+            segment(text: "four five six seven eight", start: 1, end: 2),
+        ], isGenerating: false)
+
+        XCTAssertEqual(accumulator.wordBuffer, ["four", "five", "six", "seven", "eight"])
+        XCTAssertEqual(request?.recentText, "six seven eight")
+    }
+
+    func testGenerationInFlightSuppressesRequestButKeepsAccumulatingWords() {
+        var accumulator = LiveNotesAccumulator(wordThreshold: 3, maxWordBufferSize: 20, maxExistingNotesContext: 3)
+
+        XCTAssertNil(accumulator.handleSegmentsUpdate([
+            segment(text: "one two three", start: 0, end: 1),
+        ], isGenerating: true))
+        XCTAssertEqual(accumulator.wordBuffer, ["one", "two", "three"])
+
+        let request = accumulator.handleSegmentsUpdate([
+            segment(text: "one two three", start: 0, end: 1),
+            segment(text: "four", start: 1, end: 2),
+        ], isGenerating: false)
+
+        XCTAssertEqual(request?.recentText, "two three four")
+    }
+
+    private func segment(text: String, start: Double, end: Double) -> SpeakerSegment {
+        SpeakerSegment(
+            segmentId: nil,
+            speaker: 1,
+            text: text,
+            start: start,
+            end: end
+        )
+    }
+}

--- a/desktop/macos/Desktop/Tests/LiveNotesAccumulatorTests.swift
+++ b/desktop/macos/Desktop/Tests/LiveNotesAccumulatorTests.swift
@@ -60,6 +60,43 @@ final class LiveNotesAccumulatorTests: XCTestCase {
         XCTAssertEqual(secondRequest?.existingNotesText, "Existing notes:\n- old three\n- new note")
     }
 
+    func testSuccessfulGenerationPreservesOverflowWordsAccumulatedWhileInFlight() {
+        var accumulator = LiveNotesAccumulator(wordThreshold: 3, maxWordBufferSize: 20, maxExistingNotesContext: 3)
+
+        XCTAssertNotNil(accumulator.handleSegmentsUpdate([
+            segment(text: "one two three", start: 0, end: 1),
+        ], isGenerating: false))
+        XCTAssertNil(accumulator.handleSegmentsUpdate([
+            segment(text: "one two three", start: 0, end: 1),
+            segment(text: "four five", start: 1, end: 2),
+        ], isGenerating: true))
+
+        accumulator.markGenerationSucceeded(noteText: "first note")
+
+        let request = accumulator.handleSegmentsUpdate([
+            segment(text: "one two three", start: 0, end: 1),
+            segment(text: "four five", start: 1, end: 2),
+            segment(text: "six", start: 2, end: 3),
+        ], isGenerating: false)
+
+        XCTAssertEqual(request?.recentText, "four five six")
+    }
+
+    func testUpdatedSegmentOnlyAppendsNewWords() {
+        var accumulator = LiveNotesAccumulator(wordThreshold: 4, maxWordBufferSize: 20, maxExistingNotesContext: 3)
+
+        XCTAssertNil(accumulator.handleSegmentsUpdate([
+            segment(id: "backend-1", text: "one two", start: 0, end: 1),
+        ], isGenerating: false))
+
+        let request = accumulator.handleSegmentsUpdate([
+            segment(id: "backend-1", text: "one two three four", start: 0, end: 2),
+        ], isGenerating: false)
+
+        XCTAssertEqual(accumulator.wordBuffer, ["one", "two", "three", "four"])
+        XCTAssertEqual(request?.recentText, "one two three four")
+    }
+
     func testWordBufferTrimsWithoutBlockingFutureGeneration() {
         var accumulator = LiveNotesAccumulator(wordThreshold: 3, maxWordBufferSize: 5, maxExistingNotesContext: 3)
 
@@ -93,9 +130,9 @@ final class LiveNotesAccumulatorTests: XCTestCase {
         XCTAssertEqual(request?.recentText, "two three four")
     }
 
-    private func segment(text: String, start: Double, end: Double) -> SpeakerSegment {
+    private func segment(id: String? = nil, text: String, start: Double, end: Double) -> SpeakerSegment {
         SpeakerSegment(
-            segmentId: nil,
+            segmentId: id,
             speaker: 1,
             text: text,
             start: start,

--- a/desktop/macos/Desktop/Tests/LiveNotesMonitorTests.swift
+++ b/desktop/macos/Desktop/Tests/LiveNotesMonitorTests.swift
@@ -149,6 +149,58 @@ final class LiveNotesMonitorTests: XCTestCase {
         XCTAssertTrue(secondPrompt.contains("- AI kept project context"))
     }
 
+    func testUpdatingAndDeletingDuplicateNotesRebuildsGenerationContextByIdentity() async throws {
+        let generator = FakeLiveNoteGenerator(results: [
+            .success("AI after duplicate edit"),
+            .success("AI after duplicate delete"),
+        ])
+        let storage = FakeLiveNoteStorage(
+            existingNotes: [
+                liveNoteRecord(id: 1, sessionId: 42, text: "duplicate note"),
+                liveNoteRecord(id: 2, sessionId: 42, text: "duplicate note"),
+            ]
+        )
+        let monitor = LiveNotesMonitor(
+            noteGeneratorFactory: { generator },
+            noteStorage: storage
+        )
+        monitor.startSession(sessionId: 42)
+        await waitUntil("duplicate notes loaded") {
+            monitor.notes.map(\.id) == [1, 2]
+        }
+
+        monitor.updateNote(id: 2, text: "edited duplicate note")
+        await waitUntil("duplicate note updated") {
+            monitor.notes.map(\.text) == ["duplicate note", "edited duplicate note"]
+        }
+
+        monitor.handleSegmentsUpdate([segment(text: words(50, prefix: "first"), start: 0, end: 1)])
+        await waitUntil("first duplicate prompt generated") {
+            await generator.prompts().count == 1
+        }
+
+        let firstPrompt = await generator.prompts()[0]
+        XCTAssertTrue(firstPrompt.contains("Existing notes:\n- duplicate note\n- edited duplicate note"))
+
+        monitor.deleteNote(id: 2)
+        await waitUntil("edited duplicate deleted") {
+            monitor.notes.map(\.text) == ["duplicate note", "AI after duplicate edit"]
+        }
+
+        monitor.handleSegmentsUpdate([
+            segment(text: words(50, prefix: "first"), start: 0, end: 1),
+            segment(text: words(50, prefix: "second"), start: 1, end: 2),
+        ])
+        await waitUntil("second duplicate prompt generated") {
+            await generator.prompts().count == 2
+        }
+
+        let secondPrompt = await generator.prompts()[1]
+        XCTAssertTrue(secondPrompt.contains("- duplicate note"))
+        XCTAssertTrue(secondPrompt.contains("- AI after duplicate edit"))
+        XCTAssertFalse(secondPrompt.contains("edited duplicate note"))
+    }
+
     func testLateSessionLoadCannotOverwriteNewSessionNotes() async throws {
         let storage = FakeLiveNoteStorage(
             existingNotes: [
@@ -327,6 +379,7 @@ private actor FakeLiveNoteGenerator: LiveNoteGenerating {
 
 private actor FakeLiveNoteStorage: LiveNoteStoring {
     private var notes: [LiveNoteRecord]
+    private var createdRecords: [LiveNoteRecord] = []
     private var nextId: Int64
     private let createError: Error?
     private let suspendedLoadSessionId: Int64?
@@ -370,6 +423,7 @@ private actor FakeLiveNoteStorage: LiveNoteStoring {
         )
         nextId += 1
         notes.append(record)
+        createdRecords.append(record)
         return record
     }
 
@@ -398,7 +452,7 @@ private actor FakeLiveNoteStorage: LiveNoteStoring {
     }
 
     func createdNotes() -> [LiveNoteRecord] {
-        notes
+        createdRecords
     }
 
     func getLiveNotesCallCount() -> Int {

--- a/desktop/macos/Desktop/Tests/LiveNotesMonitorTests.swift
+++ b/desktop/macos/Desktop/Tests/LiveNotesMonitorTests.swift
@@ -1,0 +1,420 @@
+import GRDB
+import XCTest
+@testable import Omi_Computer
+
+@MainActor
+final class LiveNotesMonitorTests: XCTestCase {
+    func testAiGenerationSuccessPersistsAndAppendsNote() async throws {
+        let generator = FakeLiveNoteGenerator(results: [.success("\"Project timeline settled\"")])
+        let storage = FakeLiveNoteStorage()
+        let monitor = LiveNotesMonitor(
+            noteGeneratorFactory: { generator },
+            noteStorage: storage
+        )
+        monitor.startSession(sessionId: 42)
+        await waitForSessionLoad(storage)
+
+        monitor.handleSegmentsUpdate([segment(text: words(50), start: 0, end: 1)])
+
+        await waitUntil("AI generation persisted note") {
+            monitor.notes.count == 1 && !monitor.isGenerating
+        }
+
+        XCTAssertEqual(monitor.notes.map(\.text), ["Project timeline settled"])
+        XCTAssertEqual(monitor.notes.first?.sessionId, 42)
+        XCTAssertEqual(monitor.notes.first?.isAiGenerated, true)
+        XCTAssertEqual(monitor.notes.first?.segmentStartOrder, 0)
+        XCTAssertEqual(monitor.notes.first?.segmentEndOrder, 1)
+
+        let created = await storage.createdNotes()
+        XCTAssertEqual(created.map(\.text), ["Project timeline settled"])
+        XCTAssertEqual(created.first?.isAiGenerated, true)
+    }
+
+    func testAiEmptyResponseDoesNotWedgeGeneration() async throws {
+        let generator = FakeLiveNoteGenerator(results: [.success(" \n \"' ")])
+        let storage = FakeLiveNoteStorage()
+        let monitor = LiveNotesMonitor(
+            noteGeneratorFactory: { generator },
+            noteStorage: storage
+        )
+        monitor.startSession(sessionId: 42)
+        await waitForSessionLoad(storage)
+
+        monitor.handleSegmentsUpdate([segment(text: words(50), start: 0, end: 1)])
+
+        await waitUntil("empty AI response unwound generation") {
+            !monitor.isGenerating
+        }
+
+        XCTAssertTrue(monitor.notes.isEmpty)
+        let promptCount = await generator.prompts().count
+        XCTAssertEqual(promptCount, 1)
+        let created = await storage.createdNotes()
+        XCTAssertTrue(created.isEmpty)
+    }
+
+    func testAiFailureDoesNotWedgeGeneration() async throws {
+        let generator = FakeLiveNoteGenerator(results: [.failure(TestError.generationFailed)])
+        let storage = FakeLiveNoteStorage()
+        let monitor = LiveNotesMonitor(
+            noteGeneratorFactory: { generator },
+            noteStorage: storage
+        )
+        monitor.startSession(sessionId: 42)
+        await waitForSessionLoad(storage)
+
+        monitor.handleSegmentsUpdate([segment(text: words(50), start: 0, end: 1)])
+
+        await waitUntil("failed AI response unwound generation") {
+            !monitor.isGenerating
+        }
+
+        XCTAssertTrue(monitor.notes.isEmpty)
+        let promptCount = await generator.prompts().count
+        XCTAssertEqual(promptCount, 1)
+        let created = await storage.createdNotes()
+        XCTAssertTrue(created.isEmpty)
+    }
+
+    func testSessionDeletedConstraintDoesNotWedgeGeneration() async throws {
+        let generator = FakeLiveNoteGenerator(results: [.success("Follow up with design")])
+        let storage = FakeLiveNoteStorage(createError: DatabaseError(resultCode: .SQLITE_CONSTRAINT, message: "session deleted"))
+        let monitor = LiveNotesMonitor(
+            noteGeneratorFactory: { generator },
+            noteStorage: storage
+        )
+        monitor.startSession(sessionId: 42)
+        await waitForSessionLoad(storage)
+
+        monitor.handleSegmentsUpdate([segment(text: words(50), start: 0, end: 1)])
+
+        await waitUntil("constraint unwound generation") {
+            !monitor.isGenerating
+        }
+
+        XCTAssertTrue(monitor.notes.isEmpty)
+        let promptCount = await generator.prompts().count
+        XCTAssertEqual(promptCount, 1)
+    }
+
+    func testManualAddUpdateDeleteKeepsNotesAndGenerationContextCoherent() async throws {
+        let generator = FakeLiveNoteGenerator(results: [
+            .success("AI kept project context"),
+            .success("AI continued after cleanup"),
+        ])
+        let storage = FakeLiveNoteStorage()
+        let monitor = LiveNotesMonitor(
+            noteGeneratorFactory: { generator },
+            noteStorage: storage
+        )
+        monitor.startSession(sessionId: 42)
+        await waitForSessionLoad(storage)
+
+        monitor.addManualNote(text: "manual alpha")
+        await waitUntil("manual note appended") {
+            monitor.notes.map(\.text) == ["manual alpha"]
+        }
+
+        monitor.handleSegmentsUpdate([segment(text: words(50, prefix: "first"), start: 0, end: 1)])
+        await waitUntil("first AI note appended") {
+            monitor.notes.map(\.text) == ["manual alpha", "AI kept project context"]
+        }
+
+        let firstPrompt = await generator.prompts()[0]
+        XCTAssertTrue(firstPrompt.contains("- manual alpha"))
+
+        let manualId = try XCTUnwrap(monitor.notes.first?.id)
+        monitor.updateNote(id: manualId, text: "manual beta")
+        await waitUntil("manual note updated") {
+            monitor.notes.first?.text == "manual beta"
+        }
+
+        monitor.deleteNote(id: manualId)
+        await waitUntil("manual note deleted") {
+            monitor.notes.map(\.text) == ["AI kept project context"]
+        }
+
+        monitor.handleSegmentsUpdate([
+            segment(text: words(50, prefix: "first"), start: 0, end: 1),
+            segment(text: words(50, prefix: "second"), start: 1, end: 2),
+        ])
+        await waitUntil("second AI note appended") {
+            monitor.notes.map(\.text) == ["AI kept project context", "AI continued after cleanup"]
+        }
+
+        let secondPrompt = await generator.prompts()[1]
+        XCTAssertFalse(secondPrompt.contains("manual alpha"))
+        XCTAssertFalse(secondPrompt.contains("manual beta"))
+        XCTAssertTrue(secondPrompt.contains("- AI kept project context"))
+    }
+
+    func testLateSessionLoadCannotOverwriteNewSessionNotes() async throws {
+        let storage = FakeLiveNoteStorage(
+            existingNotes: [
+                liveNoteRecord(id: 11, sessionId: 1, text: "old session note"),
+                liveNoteRecord(id: 22, sessionId: 2, text: "current session note"),
+            ],
+            suspendedLoadSessionId: 1
+        )
+        let monitor = LiveNotesMonitor(
+            noteGeneratorFactory: { FakeLiveNoteGenerator(results: []) },
+            noteStorage: storage
+        )
+
+        monitor.startSession(sessionId: 1)
+        await waitUntil("first session load suspended") {
+            await storage.isLoadSuspended(sessionId: 1)
+        }
+
+        monitor.startSession(sessionId: 2)
+        await waitUntil("second session notes loaded") {
+            monitor.notes.map(\.text) == ["current session note"]
+        }
+
+        await storage.resumeLoad(sessionId: 1)
+        await waitForAsyncWorkToSettle()
+
+        XCTAssertEqual(monitor.notes.map(\.text), ["current session note"])
+        XCTAssertEqual(monitor.notes.map(\.sessionId), [2])
+    }
+
+    func testLateAiGenerationCannotAppendToNewSessionOrClearItsGenerationState() async throws {
+        let oldGenerator = FakeLiveNoteGenerator(
+            results: [.success("late old-session note"), .success("new session note")],
+            suspendedResponseLimit: 2
+        )
+        let storage = FakeLiveNoteStorage()
+        let monitor = LiveNotesMonitor(
+            noteGeneratorFactory: { oldGenerator },
+            noteStorage: storage
+        )
+
+        monitor.startSession(sessionId: 1)
+        await waitForSessionLoad(storage)
+        monitor.handleSegmentsUpdate([segment(text: words(50, prefix: "old"), start: 0, end: 1)])
+        await waitUntil("old session generation suspended") {
+            await oldGenerator.isResponseSuspended()
+        }
+
+        monitor.startSession(sessionId: 2)
+        await waitUntil("new session reset generation state") {
+            !monitor.isGenerating
+        }
+        monitor.handleSegmentsUpdate([segment(text: words(50, prefix: "new"), start: 0, end: 1)])
+        await waitUntil("new session generation suspended") {
+            let suspendedResponses = await oldGenerator.suspendedResponseCount()
+            return monitor.isGenerating && suspendedResponses == 2
+        }
+
+        await oldGenerator.resumeResponse()
+        await waitForAsyncWorkToSettle()
+
+        XCTAssertTrue(monitor.notes.isEmpty)
+        XCTAssertTrue(monitor.isGenerating)
+
+        await oldGenerator.resumeResponse()
+        await waitUntil("new session note appended") {
+            monitor.notes.map(\.text) == ["new session note"] && !monitor.isGenerating
+        }
+
+        XCTAssertEqual(monitor.notes.map(\.sessionId), [2])
+        let created = await storage.createdNotes()
+        XCTAssertEqual(created.map(\.text), ["late old-session note", "new session note"])
+    }
+
+    private func waitForSessionLoad(_ storage: FakeLiveNoteStorage) async {
+        await waitUntil("session load completed") {
+            await storage.getLiveNotesCallCount() > 0
+        }
+    }
+
+    private func waitUntil(
+        _ description: String,
+        file: StaticString = #filePath,
+        line: UInt = #line,
+        condition: () async -> Bool
+    ) async {
+        for _ in 0..<1_000 {
+            if await condition() {
+                return
+            }
+            await Task.yield()
+        }
+        XCTFail("Timed out waiting for \(description)", file: file, line: line)
+    }
+
+    private func waitForAsyncWorkToSettle() async {
+        for _ in 0..<10 {
+            await Task.yield()
+        }
+    }
+
+    private func words(_ count: Int, prefix: String = "word") -> String {
+        (0..<count).map { "\(prefix)\($0)" }.joined(separator: " ")
+    }
+
+    private func segment(text: String, start: Double, end: Double) -> SpeakerSegment {
+        SpeakerSegment(
+            segmentId: nil,
+            speaker: 1,
+            text: text,
+            start: start,
+            end: end
+        )
+    }
+
+    private func liveNoteRecord(id: Int64, sessionId: Int64, text: String) -> LiveNoteRecord {
+        LiveNoteRecord(
+            id: id,
+            sessionId: sessionId,
+            text: text,
+            timestamp: Date(),
+            isAiGenerated: false,
+            segmentStartOrder: nil,
+            segmentEndOrder: nil,
+            createdAt: Date(),
+            updatedAt: Date()
+        )
+    }
+}
+
+private actor FakeLiveNoteGenerator: LiveNoteGenerating {
+    private var results: [Result<String, Error>]
+    private var capturedPrompts: [String] = []
+    private var remainingSuspendedResponses: Int
+    private var responseContinuations: [CheckedContinuation<Void, Never>] = []
+
+    init(results: [Result<String, Error>], suspendFirstResponse: Bool = false, suspendedResponseLimit: Int? = nil) {
+        self.results = results
+        self.remainingSuspendedResponses = suspendedResponseLimit ?? (suspendFirstResponse ? 1 : 0)
+    }
+
+    func generateNote(prompt: String, systemPrompt: String) async throws -> String {
+        capturedPrompts.append(prompt)
+        let shouldSuspend = remainingSuspendedResponses > 0
+        if shouldSuspend {
+            remainingSuspendedResponses -= 1
+        }
+
+        if shouldSuspend {
+            await withCheckedContinuation { continuation in
+                responseContinuations.append(continuation)
+            }
+        }
+
+        guard !results.isEmpty else { throw TestError.missingResult }
+        return try results.removeFirst().get()
+    }
+
+    func prompts() -> [String] {
+        capturedPrompts
+    }
+
+    func isResponseSuspended() async -> Bool {
+        suspendedResponseCount() > 0
+    }
+
+    func suspendedResponseCount() -> Int {
+        responseContinuations.count
+    }
+
+    func resumeResponse() {
+        let continuation = responseContinuations.isEmpty ? nil : responseContinuations.removeFirst()
+        continuation?.resume()
+    }
+}
+
+private actor FakeLiveNoteStorage: LiveNoteStoring {
+    private var notes: [LiveNoteRecord]
+    private var nextId: Int64
+    private let createError: Error?
+    private let suspendedLoadSessionId: Int64?
+    private var loadContinuations: [Int64: CheckedContinuation<Void, Never>] = [:]
+    private var loadCallCount = 0
+
+    init(
+        existingNotes: [LiveNoteRecord] = [],
+        createError: Error? = nil,
+        suspendedLoadSessionId: Int64? = nil
+    ) {
+        self.notes = existingNotes
+        self.nextId = (existingNotes.compactMap(\.id).max() ?? 0) + 1
+        self.createError = createError
+        self.suspendedLoadSessionId = suspendedLoadSessionId
+    }
+
+    func createNote(
+        sessionId: Int64,
+        text: String,
+        timestamp: Date,
+        isAiGenerated: Bool,
+        segmentStartOrder: Int?,
+        segmentEndOrder: Int?
+    ) async throws -> LiveNoteRecord {
+        if let createError {
+            throw createError
+        }
+
+        let now = Date()
+        let record = LiveNoteRecord(
+            id: nextId,
+            sessionId: sessionId,
+            text: text,
+            timestamp: timestamp,
+            isAiGenerated: isAiGenerated,
+            segmentStartOrder: segmentStartOrder,
+            segmentEndOrder: segmentEndOrder,
+            createdAt: now,
+            updatedAt: now
+        )
+        nextId += 1
+        notes.append(record)
+        return record
+    }
+
+    func updateNote(id: Int64, text: String) async throws {
+        guard let index = notes.firstIndex(where: { $0.id == id }) else {
+            throw LiveNoteError.noteNotFound
+        }
+        notes[index].text = text
+        notes[index].updatedAt = Date()
+    }
+
+    func deleteNote(id: Int64) async throws {
+        notes.removeAll { $0.id == id }
+    }
+
+    func getLiveNotes(sessionId: Int64) async throws -> [LiveNote] {
+        loadCallCount += 1
+        if suspendedLoadSessionId == sessionId {
+            await withCheckedContinuation { continuation in
+                loadContinuations[sessionId] = continuation
+            }
+        }
+        return notes
+            .filter { $0.sessionId == sessionId }
+            .compactMap { $0.toLiveNote() }
+    }
+
+    func createdNotes() -> [LiveNoteRecord] {
+        notes
+    }
+
+    func getLiveNotesCallCount() -> Int {
+        loadCallCount
+    }
+
+    func isLoadSuspended(sessionId: Int64) -> Bool {
+        loadContinuations[sessionId] != nil
+    }
+
+    func resumeLoad(sessionId: Int64) {
+        loadContinuations.removeValue(forKey: sessionId)?.resume()
+    }
+}
+
+private enum TestError: Error {
+    case generationFailed
+    case missingResult
+}

--- a/desktop/macos/Desktop/Tests/ProactiveAssistantOrchestrationPolicyTests.swift
+++ b/desktop/macos/Desktop/Tests/ProactiveAssistantOrchestrationPolicyTests.swift
@@ -1,0 +1,184 @@
+import XCTest
+@testable import Omi_Computer
+
+final class ProactiveAssistantOrchestrationPolicyTests: XCTestCase {
+    func testPermissionRecheckUsesConfiguredInterval() {
+        let lastCheck = Date(timeIntervalSinceReferenceDate: 1_000)
+
+        XCTAssertFalse(ProactiveAssistantOrchestrationPolicy.shouldRecheckPermission(
+            now: lastCheck.addingTimeInterval(59.9),
+            lastCheckTime: lastCheck,
+            interval: 60
+        ))
+        XCTAssertTrue(ProactiveAssistantOrchestrationPolicy.shouldRecheckPermission(
+            now: lastCheck.addingTimeInterval(60),
+            lastCheckTime: lastCheck,
+            interval: 60
+        ))
+    }
+
+    func testScreenshotAppPausesAndExtendsBackoffWhileFrontmost() {
+        let now = Date(timeIntervalSinceReferenceDate: 2_000)
+
+        XCTAssertEqual(
+            ProactiveAssistantOrchestrationPolicy.screenshotAppDecision(
+                isScreenshotAppFrontmost: true,
+                wasScreenshotAppFrontmost: false,
+                backoffUntil: .distantPast,
+                now: now,
+                backoffDuration: 10
+            ),
+            .pause(backoffUntil: now.addingTimeInterval(10))
+        )
+    }
+
+    func testScreenshotAppTransitionContinuesBackoffThenCapturesAfterExpiry() {
+        let now = Date(timeIntervalSinceReferenceDate: 3_000)
+
+        XCTAssertEqual(
+            ProactiveAssistantOrchestrationPolicy.screenshotAppDecision(
+                isScreenshotAppFrontmost: false,
+                wasScreenshotAppFrontmost: true,
+                backoffUntil: now.addingTimeInterval(4),
+                now: now,
+                backoffDuration: 10
+            ),
+            .resumeIntoBackoff
+        )
+        XCTAssertEqual(
+            ProactiveAssistantOrchestrationPolicy.screenshotAppDecision(
+                isScreenshotAppFrontmost: false,
+                wasScreenshotAppFrontmost: false,
+                backoffUntil: now.addingTimeInterval(4),
+                now: now,
+                backoffDuration: 10
+            ),
+            .continueBackoff
+        )
+        XCTAssertEqual(
+            ProactiveAssistantOrchestrationPolicy.screenshotAppDecision(
+                isScreenshotAppFrontmost: false,
+                wasScreenshotAppFrontmost: false,
+                backoffUntil: now.addingTimeInterval(-0.1),
+                now: now,
+                backoffDuration: 10
+            ),
+            .capture
+        )
+    }
+
+    func testVideoCallThrottleCapturesOneOutOfEveryNFrames() {
+        let factor = 5
+
+        XCTAssertEqual(
+            ProactiveAssistantOrchestrationPolicy.videoCallThrottleDecision(
+                isVideoCall: true,
+                currentCounter: 0,
+                throttleFactor: factor
+            ),
+            .skip(nextCounter: 1, didEnterCall: true)
+        )
+        XCTAssertEqual(
+            ProactiveAssistantOrchestrationPolicy.videoCallThrottleDecision(
+                isVideoCall: true,
+                currentCounter: 4,
+                throttleFactor: factor
+            ),
+            .capture(nextCounter: 0, didLeaveCall: false)
+        )
+        XCTAssertEqual(
+            ProactiveAssistantOrchestrationPolicy.videoCallThrottleDecision(
+                isVideoCall: false,
+                currentCounter: 2,
+                throttleFactor: factor
+            ),
+            .capture(nextCounter: 0, didLeaveCall: true)
+        )
+    }
+
+    func testDistributionFlushesFirstFrameAndDebouncesContextChange() {
+        let now = Date(timeIntervalSinceReferenceDate: 4_000)
+
+        XCTAssertEqual(
+            distributionDecision(
+                lastApp: nil,
+                lastTitle: nil,
+                frameApp: "Xcode",
+                frameTitle: "Project",
+                lastDistributionTime: .distantPast,
+                now: now
+            ),
+            .flushNow
+        )
+        XCTAssertEqual(
+            distributionDecision(
+                lastApp: "Xcode",
+                lastTitle: "Project",
+                frameApp: "Safari",
+                frameTitle: "Docs",
+                lastDistributionTime: now,
+                now: now
+            ),
+            .debounce
+        )
+    }
+
+    func testDistributionFallbackUsesDefaultAndMessagingCadence() {
+        let now = Date(timeIntervalSinceReferenceDate: 5_000)
+
+        XCTAssertEqual(
+            distributionDecision(
+                lastApp: "Xcode",
+                lastTitle: "Project",
+                frameApp: "Xcode",
+                frameTitle: "Project",
+                lastDistributionTime: now.addingTimeInterval(-59),
+                now: now
+            ),
+            .skip
+        )
+        XCTAssertEqual(
+            distributionDecision(
+                lastApp: "Xcode",
+                lastTitle: "Project",
+                frameApp: "Xcode",
+                frameTitle: "Project",
+                lastDistributionTime: now.addingTimeInterval(-60),
+                now: now
+            ),
+            .flushNow
+        )
+        XCTAssertEqual(
+            distributionDecision(
+                lastApp: "Slack",
+                lastTitle: "Team",
+                frameApp: "Slack",
+                frameTitle: "Team",
+                lastDistributionTime: now.addingTimeInterval(-15),
+                now: now
+            ),
+            .flushNow
+        )
+    }
+
+    private func distributionDecision(
+        lastApp: String?,
+        lastTitle: String?,
+        frameApp: String,
+        frameTitle: String?,
+        lastDistributionTime: Date,
+        now: Date
+    ) -> ProactiveAssistantOrchestrationPolicy.DistributionDecision {
+        ProactiveAssistantOrchestrationPolicy.distributionDecision(
+            lastDistributedApp: lastApp,
+            lastDistributedWindowTitle: lastTitle,
+            frameApp: frameApp,
+            frameWindowTitle: frameTitle,
+            lastDistributionTime: lastDistributionTime,
+            now: now,
+            defaultFallbackInterval: 60,
+            messagingFallbackInterval: 15,
+            messagingFastPathApps: ["Slack", "Messages"]
+        )
+    }
+}

--- a/desktop/macos/Desktop/Tests/ProactiveAssistantOrchestrationPolicyTests.swift
+++ b/desktop/macos/Desktop/Tests/ProactiveAssistantOrchestrationPolicyTests.swift
@@ -67,6 +67,39 @@ final class ProactiveAssistantOrchestrationPolicyTests: XCTestCase {
         )
     }
 
+    func testScreenshotAppTransitionCapturesImmediatelyWhenBackoffExpired() {
+        let now = Date(timeIntervalSinceReferenceDate: 3_500)
+
+        XCTAssertEqual(
+            ProactiveAssistantOrchestrationPolicy.screenshotAppDecision(
+                isScreenshotAppFrontmost: false,
+                wasScreenshotAppFrontmost: true,
+                backoffUntil: now.addingTimeInterval(-0.1),
+                now: now,
+                backoffDuration: 10
+            ),
+            .resumeAndCapture
+        )
+    }
+
+    func testScreenshotAndVideoGatesResetStaleState() {
+        var screenshotGate = ProactiveScreenshotCaptureGate()
+        let now = Date(timeIntervalSinceReferenceDate: 3_750)
+        XCTAssertEqual(
+            screenshotGate.nextDecision(isScreenshotAppFrontmost: true, now: now, backoffDuration: 10),
+            .pause(backoffUntil: now.addingTimeInterval(10))
+        )
+
+        screenshotGate.reset()
+        XCTAssertFalse(screenshotGate.wasScreenshotAppFrontmost)
+        XCTAssertEqual(screenshotGate.backoffUntil, .distantPast)
+
+        var videoGate = ProactiveVideoCallThrottleGate()
+        XCTAssertEqual(videoGate.nextDecision(isVideoCall: true, throttleFactor: 5), .skip(nextCounter: 1, didEnterCall: true))
+        videoGate.reset()
+        XCTAssertEqual(videoGate.counter, 0)
+    }
+
     func testVideoCallThrottleCapturesOneOutOfEveryNFrames() {
         let factor = 5
 

--- a/desktop/macos/Desktop/Tests/ProactiveAssistantOrchestrationPolicyTests.swift
+++ b/desktop/macos/Desktop/Tests/ProactiveAssistantOrchestrationPolicyTests.swift
@@ -161,6 +161,103 @@ final class ProactiveAssistantOrchestrationPolicyTests: XCTestCase {
         )
     }
 
+    func testScreenshotGateMutatesBackoffStateAcrossPauseResumeAndExpiry() {
+        var gate = ProactiveScreenshotCaptureGate()
+        let now = Date(timeIntervalSinceReferenceDate: 6_000)
+
+        XCTAssertEqual(
+            gate.nextDecision(isScreenshotAppFrontmost: true, now: now, backoffDuration: 10),
+            .pause(backoffUntil: now.addingTimeInterval(10))
+        )
+        XCTAssertTrue(gate.wasScreenshotAppFrontmost)
+        XCTAssertEqual(gate.backoffUntil, now.addingTimeInterval(10))
+
+        XCTAssertEqual(
+            gate.nextDecision(isScreenshotAppFrontmost: false, now: now.addingTimeInterval(2), backoffDuration: 10),
+            .resumeIntoBackoff
+        )
+        XCTAssertFalse(gate.wasScreenshotAppFrontmost)
+        XCTAssertEqual(gate.backoffUntil, now.addingTimeInterval(10))
+
+        XCTAssertEqual(
+            gate.nextDecision(isScreenshotAppFrontmost: false, now: now.addingTimeInterval(9), backoffDuration: 10),
+            .continueBackoff
+        )
+        XCTAssertEqual(
+            gate.nextDecision(isScreenshotAppFrontmost: false, now: now.addingTimeInterval(10), backoffDuration: 10),
+            .capture
+        )
+    }
+
+    func testVideoCallThrottleGateCarriesCounterAndResetsWhenLeavingCall() {
+        var gate = ProactiveVideoCallThrottleGate()
+
+        XCTAssertEqual(gate.nextDecision(isVideoCall: true, throttleFactor: 3), .skip(nextCounter: 1, didEnterCall: true))
+        XCTAssertEqual(gate.counter, 1)
+        XCTAssertEqual(gate.nextDecision(isVideoCall: true, throttleFactor: 3), .skip(nextCounter: 2, didEnterCall: false))
+        XCTAssertEqual(gate.counter, 2)
+        XCTAssertEqual(gate.nextDecision(isVideoCall: true, throttleFactor: 3), .capture(nextCounter: 0, didLeaveCall: false))
+        XCTAssertEqual(gate.counter, 0)
+
+        XCTAssertEqual(gate.nextDecision(isVideoCall: true, throttleFactor: 3), .skip(nextCounter: 1, didEnterCall: true))
+        XCTAssertEqual(gate.nextDecision(isVideoCall: false, throttleFactor: 3), .capture(nextCounter: 0, didLeaveCall: true))
+        XCTAssertEqual(gate.counter, 0)
+    }
+
+    func testDistributionGateTracksPendingContextAndFlushTime() {
+        var gate = ProactiveFrameDistributionGate()
+        let now = Date(timeIntervalSinceReferenceDate: 7_000)
+
+        XCTAssertEqual(
+            gate.nextAction(
+                frameApp: "Xcode",
+                frameWindowTitle: "Project",
+                now: now,
+                defaultFallbackInterval: 60,
+                messagingFallbackInterval: 15,
+                messagingFastPathApps: ["Slack"]
+            ),
+            .flushNow
+        )
+        XCTAssertNil(gate.lastDistributedApp)
+
+        gate.markFlushed(frameApp: "Xcode", frameWindowTitle: "Project", at: now)
+        XCTAssertEqual(gate.lastDistributedApp, "Xcode")
+        XCTAssertEqual(gate.lastDistributedWindowTitle, "Project")
+        XCTAssertEqual(gate.lastDistributionTime, now)
+
+        XCTAssertEqual(
+            gate.nextAction(
+                frameApp: "Safari",
+                frameWindowTitle: "Docs",
+                now: now.addingTimeInterval(1),
+                defaultFallbackInterval: 60,
+                messagingFallbackInterval: 15,
+                messagingFastPathApps: ["Slack"]
+            ),
+            .scheduleDebounce
+        )
+        XCTAssertEqual(gate.lastDistributedApp, "Safari")
+        XCTAssertEqual(gate.lastDistributedWindowTitle, "Docs")
+        XCTAssertEqual(gate.lastDistributionTime, now)
+
+        XCTAssertEqual(
+            gate.nextAction(
+                frameApp: "Safari",
+                frameWindowTitle: "Docs",
+                now: now.addingTimeInterval(2),
+                defaultFallbackInterval: 60,
+                messagingFallbackInterval: 15,
+                messagingFastPathApps: ["Slack"]
+            ),
+            .skip
+        )
+
+        let flushTime = now.addingTimeInterval(4)
+        gate.markFlushed(frameApp: "Safari", frameWindowTitle: "Docs", at: flushTime)
+        XCTAssertEqual(gate.lastDistributionTime, flushTime)
+    }
+
     private func distributionDecision(
         lastApp: String?,
         lastTitle: String?,

--- a/desktop/macos/changelog/unreleased/20260707-core-coverage.json
+++ b/desktop/macos/changelog/unreleased/20260707-core-coverage.json
@@ -1,0 +1,3 @@
+{
+  "change": "Improved desktop reliability around live notes, file indexing, proactive capture, device reconnects, and sign-in recovery."
+}

--- a/desktop/macos/changelog/unreleased/20260707-core-coverage.json
+++ b/desktop/macos/changelog/unreleased/20260707-core-coverage.json
@@ -1,3 +1,3 @@
 {
-  "change": "Improved desktop reliability around live notes, file indexing, proactive capture, device reconnects, and sign-in recovery."
+  "change": "Improved desktop reliability around live notes, file indexing, proactive capture, device reconnects, and sign-in recovery"
 }


### PR DESCRIPTION
## Summary
- Add testable policy seams and workflow coverage for macOS desktop core areas: Live Notes, File Indexer, Proactive Assistants, DeviceProvider, auth token decoding, and Rust chat session matching.
- Add fake-backed Live Notes monitor tests that cover AI success/error paths, manual note context coherence, and stale async session races.
- Add hermetic FileIndexer temp-directory/SQLite workflow tests and stronger DeviceProvider/Proactive capture state-machine tests.
- Add an unreleased desktop changelog fragment for the reliability coverage work.

## Verification
- `git diff --check`
- `xcrun swift build -c debug --package-path Desktop`
- Focused coverage loop:
  - `xcrun swift test --package-path Desktop --filter LiveNotes`
  - `xcrun swift test --package-path Desktop --filter FileIndex`
  - `xcrun swift test --package-path Desktop --filter ProactiveAssistantOrchestrationPolicyTests`
  - `xcrun swift test --package-path Desktop --filter DeviceProviderTests`
  - `xcrun swift test --package-path Desktop --filter AuthTokenDecodingTests`
  - `cargo test --manifest-path Backend-Rust/Cargo.toml app_matching --quiet`
- `cd desktop/macos && bash test.sh`
  - launcher script tests passed
  - 300 Rust backend tests passed
  - 147 isolated Swift suites passed
- Pre-push hook passed, including desktop Swift build, desktop Rust check, changelog validation, launcher checks, and ratchets.

## Review
- Subagent review found no remaining P0/P1 after the Live Notes stale-session fix.
- The reviewer specifically validated that late session-load/manual-add/AI-generation completions no longer mutate the wrong session or clear the new session's `isGenerating` state.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9173?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

