### PR TITLE
fix(desktop/automation): tolerant settings-section matching for omi-ctl navigate (SET-01)

### DIFF
--- a/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
@@ -620,10 +620,15 @@ struct DesktopHomeView: View {
       }
     }
 
-    if let sectionRaw = settingsSectionRaw,
-      let section = SettingsContentView.SettingsSection(rawValue: sectionRaw)
-    {
-      selectedSettingsSection = section
+    if let sectionRaw = settingsSectionRaw {
+      // Tolerant match (SET-01): omi-ctl sends the caller's casing verbatim (docs use
+      // lowercase, raw values are Title Case), so a strict rawValue init silently left
+      // navigation on General for every sub-section command.
+      if let section = SettingsContentView.SettingsSection.automationMatch(sectionRaw) {
+        selectedSettingsSection = section
+      } else {
+        log("AutomationNavigation: unknown settings section '\(sectionRaw)'")
+      }
     }
     highlightedSettingId = settingId
 

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
@@ -330,6 +330,30 @@ struct SettingsContentView: View {
     case shortcuts = "Shortcuts"
     case advanced = "Advanced"
     case about = "About"
+
+    /// Resolve an automation-supplied section name tolerantly (SET-01). The raw values
+    /// are Title Case with spaces ("Plan and Usage"), but `omi-ctl navigate settings
+    /// <section>` sends whatever the caller typed — the documented examples are
+    /// lowercase (`settings rewind`), so a strict `init(rawValue:)` never matched and
+    /// navigation silently stayed on General. Accepts the exact raw value, any
+    /// case/spacing/hyphen/underscore variant of it, or the Swift case name
+    /// (`planUsage`, `floating_bar`, "plan-and-usage", …).
+    nonisolated static func automationMatch(_ raw: String) -> SettingsSection? {
+      if let exact = SettingsSection(rawValue: raw) { return exact }
+      let key = normalizedAutomationKey(raw)
+      guard !key.isEmpty else { return nil }
+      return allCases.first { section in
+        normalizedAutomationKey(section.rawValue) == key
+          || normalizedAutomationKey(String(describing: section)) == key
+      }
+    }
+
+    /// Lowercase and strip everything but letters/digits, so "Plan and Usage",
+    /// "plan_usage", "plan-and-usage", and "planUsage" can meet in one keyspace.
+    private nonisolated static func normalizedAutomationKey(_ value: String) -> String {
+      String(value.unicodeScalars.filter { CharacterSet.alphanumerics.contains($0) })
+        .lowercased()
+    }
   }
 
   enum AdvancedSubsection: String, CaseIterable {

--- a/desktop/macos/Desktop/Tests/AutomationSettingsSectionTests.swift
+++ b/desktop/macos/Desktop/Tests/AutomationSettingsSectionTests.swift
@@ -82,7 +82,10 @@ final class AutomationSettingsSectionTests: XCTestCase {
       .deletingLastPathComponent()
       .appendingPathComponent("Sources/MainWindow/DesktopHomeView.swift")
     let source = try String(contentsOf: sourceURL, encoding: .utf8)
-    XCTAssertTrue(source.contains("SettingsContentView.SettingsSection.automationMatch(sectionRaw)"))
-    XCTAssertFalse(source.contains("SettingsContentView.SettingsSection(rawValue: sectionRaw)"))
+    // Identifier-independent: assert the handler resolves via the tolerant matcher and
+    // never via the strict rawValue init (renaming a local or reformatting must not
+    // break or bypass this invariant).
+    XCTAssertTrue(source.contains("SettingsSection.automationMatch("))
+    XCTAssertFalse(source.contains("SettingsSection(rawValue:"))
   }
 }

--- a/desktop/macos/Desktop/Tests/AutomationSettingsSectionTests.swift
+++ b/desktop/macos/Desktop/Tests/AutomationSettingsSectionTests.swift
@@ -1,0 +1,88 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// SET-01: `omi-ctl navigate settings <section>` sends the caller's string verbatim
+/// (the documented examples are lowercase, e.g. `settings rewind`), but
+/// `SettingsSection` raw values are Title Case with spaces — so the old strict
+/// `init(rawValue:)` never matched and navigation silently stayed on General.
+/// `automationMatch` must accept the exact raw value plus reasonable variants.
+final class AutomationSettingsSectionTests: XCTestCase {
+  typealias Section = SettingsContentView.SettingsSection
+
+  func testExactRawValuesStillMatch() {
+    for section in Section.allCases {
+      XCTAssertEqual(Section.automationMatch(section.rawValue), section)
+    }
+  }
+
+  func testLowercaseSingleWordSectionsMatch() {
+    XCTAssertEqual(Section.automationMatch("rewind"), .rewind)
+    XCTAssertEqual(Section.automationMatch("general"), .general)
+    XCTAssertEqual(Section.automationMatch("advanced"), .advanced)
+    XCTAssertEqual(Section.automationMatch("shortcuts"), .shortcuts)
+    XCTAssertEqual(Section.automationMatch("about"), .about)
+  }
+
+  func testMultiWordVariantsMatch() {
+    // Case-name style
+    XCTAssertEqual(Section.automationMatch("planUsage"), .planUsage)
+    XCTAssertEqual(Section.automationMatch("plan_usage"), .planUsage)
+    XCTAssertEqual(Section.automationMatch("plan-usage"), .planUsage)
+    // Raw-value style
+    XCTAssertEqual(Section.automationMatch("plan and usage"), .planUsage)
+    XCTAssertEqual(Section.automationMatch("plan-and-usage"), .planUsage)
+    XCTAssertEqual(Section.automationMatch("aichat"), .aiChat)
+    XCTAssertEqual(Section.automationMatch("ai_chat"), .aiChat)
+    XCTAssertEqual(Section.automationMatch("AI Chat"), .aiChat)
+    XCTAssertEqual(Section.automationMatch("floating-bar"), .floatingBar)
+    XCTAssertEqual(Section.automationMatch("floatingBar"), .floatingBar)
+    XCTAssertEqual(Section.automationMatch("FLOATING BAR"), .floatingBar)
+  }
+
+  func testUnknownAndEmptyReturnNil() {
+    XCTAssertNil(Section.automationMatch("nonsense-section"))
+    XCTAssertNil(Section.automationMatch(""))
+    XCTAssertNil(Section.automationMatch("---"))
+  }
+
+  func testEveryCaseReachableFromItsCaseName() {
+    for section in Section.allCases {
+      XCTAssertEqual(
+        Section.automationMatch(String(describing: section)), section,
+        "case name '\(String(describing: section))' must resolve to its own section")
+    }
+  }
+
+  func testNormalizedKeysAreUnambiguousAcrossSections() {
+    // Future-proofing: if a new case's normalized rawValue or case name ever collides
+    // with an existing section's keys, automationMatch would silently pick the
+    // declaration-order winner. Fail loud here instead.
+    var owner: [String: Section] = [:]
+    for section in Section.allCases {
+      let keys = Set(
+        [section.rawValue, String(describing: section)].map { raw in
+          String(raw.unicodeScalars.filter { CharacterSet.alphanumerics.contains($0) })
+            .lowercased()
+        })
+      for key in keys {
+        if let existing = owner[key], existing != section {
+          XCTFail("normalized key '\(key)' is claimed by both \(existing) and \(section)")
+        }
+        owner[key] = section
+      }
+    }
+  }
+
+  func testNavigationHandlerUsesTolerantMatch() throws {
+    // Source invariant: the automation navigation handler must go through
+    // automationMatch, not the strict rawValue init that caused SET-01.
+    let sourceURL = URL(fileURLWithPath: #filePath)
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+      .appendingPathComponent("Sources/MainWindow/DesktopHomeView.swift")
+    let source = try String(contentsOf: sourceURL, encoding: .utf8)
+    XCTAssertTrue(source.contains("SettingsContentView.SettingsSection.automationMatch(sectionRaw)"))
+    XCTAssertFalse(source.contains("SettingsContentView.SettingsSection(rawValue: sectionRaw)"))
+  }
+}


### PR DESCRIPTION
## Problem

`./scripts/omi-ctl navigate settings <section>` silently stays on **General** for every sub-section command. The documented examples send lowercase (`omi-ctl navigate settings rewind` — in `e2e/SKILL.md` and the omi-ctl help), the bridge forwards the string verbatim, but `DesktopHomeView.handleAutomationNavigation` matched it with a strict `SettingsSection(rawValue:)` against **Title-Case-with-spaces** raw values (`"Rewind"`, `"Plan and Usage"`) — so the init always returned nil and the section never changed. Found as SET-01 in runtime verification (every bridge sub-section command left `selectedSettingsSection=General`).

## Fix

- `SettingsContentView.SettingsSection.automationMatch(_:)` — resolves an automation-supplied name tolerantly: exact raw value, any case/spacing/hyphen/underscore variant of it, or the Swift case name (`rewind`, `plan-usage`, `plan_and_usage`, `planUsage`, `floating_bar`, …). Internally normalizes to a lowercase alphanumeric key.
- `handleAutomationNavigation` uses it; an **unknown** section now logs `AutomationNavigation: unknown settings section '…'` and leaves the selection unchanged (no more silent no-op ambiguity).

Automation-only surface: the handler is guarded by `DesktopAutomationLaunchOptions.isEnabled` (never on production bundles). This makes the already-documented lowercase examples work as written — no doc changes needed. **No changelog** (internal dev/test tooling) → `no-changelog-needed`.

## Verification

- **Unit:** new `AutomationSettingsSectionTests` — **7/7**: exact raw values, lowercase single-word, multi-word variants (`plan-usage`/`planUsage`/`plan and usage`/`ai_chat`/`floating-bar`/`FLOATING BAR`), every case reachable from its case name, unknown/empty → nil, a **normalized-key uniqueness guard** (fails loud if a future section collides), and a source-invariant that the handler uses the tolerant match.
- **Runtime (named bundle `com.omi.omi-set01`):** `rewind→Rewind`, `plan-usage→Plan and Usage`, `floating_bar→Floating Bar`, `transcription→Transcription`, exact `Advanced→Advanced`; `nonsense-section` → selection unchanged + logged. (`aiChat→Advanced` is the app's own deliberate redirect of the deprecated AI Chat section — `SettingsPage.swift` `.onAppear`/`.onChange` — the resolver returns `.aiChat` and the app redirects exactly as it does for a human click.)
- Build exit 0; rebased onto current `upstream/main` and re-smoked (build + suite) post-rebase.
- **Independent review: approve, no blockers** — confirmed no normalized-key ambiguity among current sections (all 24 keys enumerated), no Turkish-I/locale trap (`lowercased()` without a locale uses locale-independent Unicode mapping), `nonisolated` annotations are forward-safe for Swift-6 isolation, and the bridge snapshot (`selectedSettingsSection.rawValue`) is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9174?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

