### PR TITLE
Fix desktop search response contracts

### DIFF
--- a/app/lib/backend/schema/gen/apps_wire.g.dart
+++ b/app/lib/backend/schema/gen/apps_wire.g.dart
@@ -770,6 +770,86 @@ class GeneratedAppBaseModel {
   }
 }
 
+class GeneratedAppCatalogItem {
+  final bool approved;
+  final String author;
+  final List<String>? capabilities;
+  final String category;
+  final String description;
+  final bool enabled;
+  final GeneratedExternalIntegration? externalIntegration;
+  final String id;
+  final String image;
+  final int installs;
+  final bool? isPaid;
+  final String name;
+  final double? price;
+  final bool private;
+  final double? ratingAvg;
+  final int ratingCount;
+
+  const GeneratedAppCatalogItem({
+    this.approved = false,
+    this.author = "",
+    this.capabilities,
+    this.category = "other",
+    this.description = "",
+    this.enabled = false,
+    this.externalIntegration,
+    required this.id,
+    this.image = "",
+    this.installs = 0,
+    this.isPaid = false,
+    this.name = "",
+    this.price,
+    this.private = false,
+    this.ratingAvg,
+    this.ratingCount = 0,
+  });
+
+  factory GeneratedAppCatalogItem.fromJson(Map<String, dynamic> json) {
+    return GeneratedAppCatalogItem(
+      approved: _required(_readFieldValue<bool>(_readField(json, const ["approved"]), "approved", _readBool, requiredField: false, nullable: false, defaultValue: false), "approved"),
+      author: _required(_readFieldValue<String>(_readField(json, const ["author"]), "author", _readString, requiredField: false, nullable: false, defaultValue: ""), "author"),
+      capabilities: _readFieldValue<List<String>>(_readField(json, const ["capabilities"]), "capabilities", _readStringList, requiredField: false, nullable: true),
+      category: _required(_readFieldValue<String>(_readField(json, const ["category"]), "category", _readString, requiredField: false, nullable: false, defaultValue: "other"), "category"),
+      description: _required(_readFieldValue<String>(_readField(json, const ["description"]), "description", _readString, requiredField: false, nullable: false, defaultValue: ""), "description"),
+      enabled: _required(_readFieldValue<bool>(_readField(json, const ["enabled"]), "enabled", _readBool, requiredField: false, nullable: false, defaultValue: false), "enabled"),
+      externalIntegration: _readFieldValue<GeneratedExternalIntegration>(_readField(json, const ["external_integration"]), "external_integration", (value) => _readObject(value, GeneratedExternalIntegration.fromJson), requiredField: false, nullable: true),
+      id: _required(_readFieldValue<String>(_readField(json, const ["id"]), "id", _readString, requiredField: true, nullable: false), "id"),
+      image: _required(_readFieldValue<String>(_readField(json, const ["image"]), "image", _readString, requiredField: false, nullable: false, defaultValue: ""), "image"),
+      installs: _required(_readFieldValue<int>(_readField(json, const ["installs"]), "installs", _readInt, requiredField: false, nullable: false, defaultValue: 0), "installs"),
+      isPaid: _readFieldValue<bool>(_readField(json, const ["is_paid"]), "is_paid", _readBool, requiredField: false, nullable: true, defaultValue: false),
+      name: _required(_readFieldValue<String>(_readField(json, const ["name"]), "name", _readString, requiredField: false, nullable: false, defaultValue: ""), "name"),
+      price: _readFieldValue<double>(_readField(json, const ["price"]), "price", _readDouble, requiredField: false, nullable: true),
+      private: _required(_readFieldValue<bool>(_readField(json, const ["private"]), "private", _readBool, requiredField: false, nullable: false, defaultValue: false), "private"),
+      ratingAvg: _readFieldValue<double>(_readField(json, const ["rating_avg"]), "rating_avg", _readDouble, requiredField: false, nullable: true),
+      ratingCount: _required(_readFieldValue<int>(_readField(json, const ["rating_count"]), "rating_count", _readInt, requiredField: false, nullable: false, defaultValue: 0), "rating_count"),
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'approved': approved,
+      'author': author,
+      'capabilities': capabilities,
+      'category': category,
+      'description': description,
+      'enabled': enabled,
+      'external_integration': externalIntegration?.toJson(),
+      'id': id,
+      'image': image,
+      'installs': installs,
+      'is_paid': isPaid,
+      'name': name,
+      'price': price,
+      'private': private,
+      'rating_avg': ratingAvg,
+      'rating_count': ratingCount,
+    };
+  }
+}
+
 class GeneratedApp {
   final bool approved;
   final String author;
@@ -1050,7 +1130,7 @@ class GeneratedAppCatalogGroup {
   final GeneratedAppSelectOption? capability;
   final GeneratedAppSelectOption? category;
   final int? count;
-  final List<GeneratedAppBaseModel>? data;
+  final List<GeneratedAppCatalogItem>? data;
   final GeneratedAppPagination? pagination;
 
   const GeneratedAppCatalogGroup({
@@ -1066,7 +1146,7 @@ class GeneratedAppCatalogGroup {
       capability: _readFieldValue<GeneratedAppSelectOption>(_readField(json, const ["capability"]), "capability", (value) => _readObject(value, GeneratedAppSelectOption.fromJson), requiredField: false, nullable: true),
       category: _readFieldValue<GeneratedAppSelectOption>(_readField(json, const ["category"]), "category", (value) => _readObject(value, GeneratedAppSelectOption.fromJson), requiredField: false, nullable: true),
       count: _readFieldValue<int>(_readField(json, const ["count"]), "count", _readInt, requiredField: false, nullable: true),
-      data: _readFieldValue<List<GeneratedAppBaseModel>>(_readField(json, const ["data"]), "data", (value) => _readObjectList(value, GeneratedAppBaseModel.fromJson), requiredField: false, nullable: true),
+      data: _readFieldValue<List<GeneratedAppCatalogItem>>(_readField(json, const ["data"]), "data", (value) => _readObjectList(value, GeneratedAppCatalogItem.fromJson), requiredField: false, nullable: true),
       pagination: _readFieldValue<GeneratedAppPagination>(_readField(json, const ["pagination"]), "pagination", (value) => _readObject(value, GeneratedAppPagination.fromJson), requiredField: false, nullable: true),
     );
   }
@@ -1121,7 +1201,7 @@ class GeneratedAppCatalogMeta {
 class GeneratedAppCatalogResponse {
   final GeneratedAppSelectOption? capability;
   final GeneratedAppSelectOption? category;
-  final List<GeneratedAppBaseModel>? data;
+  final List<GeneratedAppCatalogItem>? data;
   final List<GeneratedAppCatalogGroup>? groups;
   final GeneratedAppCatalogMeta? meta;
   final GeneratedAppPagination? pagination;
@@ -1139,7 +1219,7 @@ class GeneratedAppCatalogResponse {
     return GeneratedAppCatalogResponse(
       capability: _readFieldValue<GeneratedAppSelectOption>(_readField(json, const ["capability"]), "capability", (value) => _readObject(value, GeneratedAppSelectOption.fromJson), requiredField: false, nullable: true),
       category: _readFieldValue<GeneratedAppSelectOption>(_readField(json, const ["category"]), "category", (value) => _readObject(value, GeneratedAppSelectOption.fromJson), requiredField: false, nullable: true),
-      data: _readFieldValue<List<GeneratedAppBaseModel>>(_readField(json, const ["data"]), "data", (value) => _readObjectList(value, GeneratedAppBaseModel.fromJson), requiredField: false, nullable: true),
+      data: _readFieldValue<List<GeneratedAppCatalogItem>>(_readField(json, const ["data"]), "data", (value) => _readObjectList(value, GeneratedAppCatalogItem.fromJson), requiredField: false, nullable: true),
       groups: _readFieldValue<List<GeneratedAppCatalogGroup>>(_readField(json, const ["groups"]), "groups", (value) => _readObjectList(value, GeneratedAppCatalogGroup.fromJson), requiredField: false, nullable: true),
       meta: _readFieldValue<GeneratedAppCatalogMeta>(_readField(json, const ["meta"]), "meta", (value) => _readObject(value, GeneratedAppCatalogMeta.fromJson), requiredField: false, nullable: true),
       pagination: _readFieldValue<GeneratedAppPagination>(_readField(json, const ["pagination"]), "pagination", (value) => _readObject(value, GeneratedAppPagination.fromJson), requiredField: false, nullable: true),
@@ -1203,7 +1283,7 @@ class GeneratedAppSearchFilters {
 }
 
 class GeneratedAppSearchResponse {
-  final List<GeneratedAppBaseModel>? data;
+  final List<GeneratedAppCatalogItem>? data;
   final GeneratedAppSearchFilters filters;
   final GeneratedAppPagination pagination;
 
@@ -1215,7 +1295,7 @@ class GeneratedAppSearchResponse {
 
   factory GeneratedAppSearchResponse.fromJson(Map<String, dynamic> json) {
     return GeneratedAppSearchResponse(
-      data: _readFieldValue<List<GeneratedAppBaseModel>>(_readField(json, const ["data"]), "data", (value) => _readObjectList(value, GeneratedAppBaseModel.fromJson), requiredField: false, nullable: true),
+      data: _readFieldValue<List<GeneratedAppCatalogItem>>(_readField(json, const ["data"]), "data", (value) => _readObjectList(value, GeneratedAppCatalogItem.fromJson), requiredField: false, nullable: true),
       filters: _required(_readFieldValue<GeneratedAppSearchFilters>(_readField(json, const ["filters"]), "filters", (value) => _readObject(value, GeneratedAppSearchFilters.fromJson), requiredField: true, nullable: false), "filters"),
       pagination: _required(_readFieldValue<GeneratedAppPagination>(_readField(json, const ["pagination"]), "pagination", (value) => _readObject(value, GeneratedAppPagination.fromJson), requiredField: true, nullable: false), "pagination"),
     );

--- a/app/lib/backend/schema/gen/conversation_wire.g.dart
+++ b/app/lib/backend/schema/gen/conversation_wire.g.dart
@@ -616,7 +616,7 @@ class GeneratedMergeConversationsResponse {
 
 class GeneratedSearchConversationsResponse {
   final int currentPage;
-  final List<Map<String, dynamic>> items;
+  final List<GeneratedConversation> items;
   final int perPage;
   final int totalPages;
 
@@ -630,7 +630,7 @@ class GeneratedSearchConversationsResponse {
   factory GeneratedSearchConversationsResponse.fromJson(Map<String, dynamic> json) {
     return GeneratedSearchConversationsResponse(
       currentPage: _required(_readFieldValue<int>(_readField(json, const ["current_page"]), "current_page", _readInt, requiredField: true, nullable: false), "current_page"),
-      items: _required(_readFieldValue<List<Map<String, dynamic>>>(_readField(json, const ["items"]), "items", _readMapList, requiredField: true, nullable: false), "items"),
+      items: _required(_readFieldValue<List<GeneratedConversation>>(_readField(json, const ["items"]), "items", (value) => _readObjectList(value, GeneratedConversation.fromJson), requiredField: true, nullable: false), "items"),
       perPage: _required(_readFieldValue<int>(_readField(json, const ["per_page"]), "per_page", _readInt, requiredField: true, nullable: false), "per_page"),
       totalPages: _required(_readFieldValue<int>(_readField(json, const ["total_pages"]), "total_pages", _readInt, requiredField: true, nullable: false), "total_pages"),
     );
@@ -639,7 +639,7 @@ class GeneratedSearchConversationsResponse {
   Map<String, dynamic> toJson() {
     return {
       'current_page': currentPage,
-      'items': items,
+      'items': items.map((value) => value.toJson()).toList(),
       'per_page': perPage,
       'total_pages': totalPages,
     };

--- a/app/lib/backend/schema/gen/privacy_wire.g.dart
+++ b/app/lib/backend/schema/gen/privacy_wire.g.dart
@@ -115,25 +115,61 @@ class GeneratedMigrationRequestsResponse {
 }
 
 class GeneratedUserProfileResponse {
+  final String? company;
+  final DateTime? createdAt;
   final String? dataProtectionLevel;
+  final String? email;
+  final String? job;
   final Map<String, dynamic>? migrationStatus;
+  final String? motivation;
+  final String? name;
+  final String? timeZone;
+  final String uid;
+  final String? useCase;
 
   const GeneratedUserProfileResponse({
+    this.company,
+    this.createdAt,
     this.dataProtectionLevel,
+    this.email,
+    this.job,
     this.migrationStatus,
+    this.motivation,
+    this.name,
+    this.timeZone,
+    required this.uid,
+    this.useCase,
   });
 
   factory GeneratedUserProfileResponse.fromJson(Map<String, dynamic> json) {
     return GeneratedUserProfileResponse(
+      company: _readFieldValue<String>(_readField(json, const ["company"]), "company", _readString, requiredField: false, nullable: true),
+      createdAt: _readFieldValue<DateTime>(_readField(json, const ["created_at"]), "created_at", _readDateTime, requiredField: false, nullable: true),
       dataProtectionLevel: _readFieldValue<String>(_readField(json, const ["data_protection_level"]), "data_protection_level", _readString, requiredField: false, nullable: true),
+      email: _readFieldValue<String>(_readField(json, const ["email"]), "email", _readString, requiredField: false, nullable: true),
+      job: _readFieldValue<String>(_readField(json, const ["job"]), "job", _readString, requiredField: false, nullable: true),
       migrationStatus: _readFieldValue<Map<String, dynamic>>(_readField(json, const ["migration_status"]), "migration_status", _readMap, requiredField: false, nullable: true),
+      motivation: _readFieldValue<String>(_readField(json, const ["motivation"]), "motivation", _readString, requiredField: false, nullable: true),
+      name: _readFieldValue<String>(_readField(json, const ["name"]), "name", _readString, requiredField: false, nullable: true),
+      timeZone: _readFieldValue<String>(_readField(json, const ["time_zone"]), "time_zone", _readString, requiredField: false, nullable: true),
+      uid: _required(_readFieldValue<String>(_readField(json, const ["uid"]), "uid", _readString, requiredField: true, nullable: false), "uid"),
+      useCase: _readFieldValue<String>(_readField(json, const ["use_case"]), "use_case", _readString, requiredField: false, nullable: true),
     );
   }
 
   Map<String, dynamic> toJson() {
     return {
+      'company': company,
+      'created_at': createdAt?.toUtc().toIso8601String(),
       'data_protection_level': dataProtectionLevel,
+      'email': email,
+      'job': job,
       'migration_status': migrationStatus,
+      'motivation': motivation,
+      'name': name,
+      'time_zone': timeZone,
+      'uid': uid,
+      'use_case': useCase,
     };
   }
 }

--- a/backend/database/conversations.py
+++ b/backend/database/conversations.py
@@ -619,7 +619,8 @@ def _get_conversations_by_id(uid, conversation_ids, include_discarded: bool = Fa
             data = doc.to_dict()
             if data.get('discarded') and not include_discarded:
                 continue
-            conversations_by_id[str(data.get('id', doc.id))] = data
+            data.setdefault('id', doc.id)
+            conversations_by_id[str(data['id'])] = data
 
     return [
         conversations_by_id[str(conversation_id)]

--- a/backend/database/conversations.py
+++ b/backend/database/conversations.py
@@ -597,22 +597,35 @@ def delete_conversation(uid, conversation_id):
 
 @prepare_for_read(decrypt_func=_prepare_conversation_for_read)
 @with_photos(get_conversation_photos)
-def get_conversations_by_id(uid, conversation_ids):
+def get_conversations_by_id(uid, conversation_ids, include_discarded: bool = False):
+    return _get_conversations_by_id(uid, conversation_ids, include_discarded=include_discarded)
+
+
+@prepare_for_read(decrypt_func=_prepare_conversation_for_read)
+def get_conversations_by_id_without_photos(uid, conversation_ids, include_discarded: bool = False):
+    return _get_conversations_by_id(uid, conversation_ids, include_discarded=include_discarded)
+
+
+def _get_conversations_by_id(uid, conversation_ids, include_discarded: bool = False):
     user_ref = db.collection('users').document(uid)
     conversations_ref = user_ref.collection(conversations_collection)
 
     doc_refs = [conversations_ref.document(str(conversation_id)) for conversation_id in conversation_ids]
     docs = db.get_all(doc_refs)
 
-    conversations = []
+    conversations_by_id = {}
     for doc in docs:
         if doc.exists:
             data = doc.to_dict()
-            if data.get('discarded'):
+            if data.get('discarded') and not include_discarded:
                 continue
-            conversations.append(data)
+            conversations_by_id[str(data.get('id', doc.id))] = data
 
-    return conversations
+    return [
+        conversations_by_id[str(conversation_id)]
+        for conversation_id in conversation_ids
+        if str(conversation_id) in conversations_by_id
+    ]
 
 
 # **************************************

--- a/backend/models/app.py
+++ b/backend/models/app.py
@@ -166,6 +166,26 @@ class AppBaseModel(BaseModel):
     disabled_reason: Optional[str] = None
 
 
+class AppCatalogItem(BaseModel):
+    """Desktop app catalog response item for list/search views."""
+
+    id: str
+    name: str = ''
+    description: str = ''
+    image: str = ''
+    category: str = 'other'
+    author: str = ''
+    capabilities: List[str] = Field(default_factory=list)
+    approved: bool = False
+    private: bool = False
+    installs: int = 0
+    rating_avg: Optional[float] = None
+    rating_count: int = 0
+    is_paid: bool = False
+    price: Optional[float] = None
+    enabled: bool = False
+
+
 class App(AppBaseModel):
     """Full App model - includes large/internal fields for detail views."""
 

--- a/backend/models/app.py
+++ b/backend/models/app.py
@@ -181,7 +181,8 @@ class AppCatalogItem(BaseModel):
     installs: int = 0
     rating_avg: Optional[float] = None
     rating_count: int = 0
-    is_paid: bool = False
+    external_integration: Optional[ExternalIntegration] = None
+    is_paid: Optional[bool] = False
     price: Optional[float] = None
     enabled: bool = False
 

--- a/backend/routers/apps.py
+++ b/backend/routers/apps.py
@@ -122,7 +122,15 @@ from utils.request_validation import (
     normalize_required_webhook_url,
     parse_form_json,
 )
-from models.app import App, ActionType, AppCreate, AppUpdate, AppBaseModel, AppReview
+from models.app import (
+    App,
+    ActionType,
+    AppCreate,
+    AppUpdate,
+    AppBaseModel,
+    AppReview,
+    AppCatalogItem,
+)
 from utils.other.storage import upload_app_logo, delete_app_logo, upload_app_thumbnail, get_app_thumbnail_url
 from utils.social import (
     get_twitter_profile,
@@ -262,7 +270,7 @@ class AppPagination(PydanticBaseModel):
 class AppCatalogGroup(PydanticBaseModel):
     capability: Optional[AppSelectOption] = None
     category: Optional[AppSelectOption] = None
-    data: List[AppBaseModel] = Field(default_factory=list)
+    data: List[AppCatalogItem] = Field(default_factory=list)
     pagination: Optional[AppPagination] = None
     count: Optional[int] = None
 
@@ -276,7 +284,7 @@ class AppCatalogMeta(PydanticBaseModel):
 
 
 class AppCatalogResponse(PydanticBaseModel):
-    data: List[AppBaseModel] = Field(default_factory=list)
+    data: List[AppCatalogItem] = Field(default_factory=list)
     pagination: Optional[AppPagination] = None
     capability: Optional[AppSelectOption] = None
     category: Optional[AppSelectOption] = None
@@ -295,7 +303,7 @@ class AppSearchFilters(PydanticBaseModel):
 
 
 class AppSearchResponse(PydanticBaseModel):
-    data: List[AppBaseModel] = Field(default_factory=list)
+    data: List[AppCatalogItem] = Field(default_factory=list)
     pagination: AppPagination
     filters: AppSearchFilters
 

--- a/backend/routers/conversations.py
+++ b/backend/routers/conversations.py
@@ -120,7 +120,7 @@ class ProcessConversationRequest(BaseModel):
 
 
 class SearchConversationsResponse(BaseModel):
-    items: List[Dict[str, Any]]
+    items: List[Conversation]
     total_pages: int
     current_page: int
     per_page: int
@@ -1074,7 +1074,7 @@ def search_conversations_endpoint(
         except ValueError:
             raise HTTPException(status_code=400, detail="Invalid end_date; expected an ISO 8601 datetime string")
 
-    return search_conversations(
+    search_results = search_conversations(
         query=search_request.query,
         page=search_request.page,
         per_page=search_request.per_page,
@@ -1084,6 +1084,18 @@ def search_conversations_endpoint(
         end_date=end_timestamp,
         speaker_id=search_request.speaker_id,
     )
+    conversation_ids = [item.get('id') for item in search_results.get('items', []) if item.get('id')]
+    conversations = conversations_db.get_conversations_by_id_without_photos(
+        uid,
+        conversation_ids,
+        include_discarded=bool(search_request.include_discarded),
+    )
+    # Typesense filters locked hits, but the index can lag Firestore. Re-check after hydration
+    # so search never leaks that a locked conversation matched a query.
+    conversations = [conversation for conversation in conversations if not conversation.get('is_locked')]
+    redact_conversations_for_list(conversations)
+    search_results['items'] = conversations
+    return search_results
 
 
 @router.get(

--- a/backend/routers/conversations.py
+++ b/backend/routers/conversations.py
@@ -1095,6 +1095,9 @@ def search_conversations_endpoint(
     conversations = [conversation for conversation in conversations if not conversation.get('is_locked')]
     redact_conversations_for_list(conversations)
     search_results['items'] = conversations
+    search_results['total_pages'] = (
+        search_request.page + 1 if len(conversations) >= search_request.per_page else search_request.page
+    )
     return search_results
 
 

--- a/backend/routers/users.py
+++ b/backend/routers/users.py
@@ -150,6 +150,15 @@ class UserStatusResponse(BaseModel):
 class UserProfileResponse(BaseModel):
     model_config = ConfigDict(extra='allow')
 
+    uid: str
+    email: Optional[str] = None
+    name: Optional[str] = None
+    time_zone: Optional[str] = None
+    created_at: Optional[Union[datetime, str]] = None
+    motivation: Optional[str] = None
+    use_case: Optional[str] = None
+    job: Optional[str] = None
+    company: Optional[str] = None
     data_protection_level: Optional[str] = None
     migration_status: Optional[Dict[str, Any]] = None
 
@@ -282,6 +291,7 @@ def get_user_profile_endpoint(uid: str = Depends(auth.get_current_user_uid)):
     profile = get_user_profile(uid)
     if not profile:
         raise HTTPException(status_code=410, detail="User not found")
+    profile.setdefault('uid', uid)
     return profile
 
 

--- a/backend/routers/users.py
+++ b/backend/routers/users.py
@@ -154,7 +154,7 @@ class UserProfileResponse(BaseModel):
     email: Optional[str] = None
     name: Optional[str] = None
     time_zone: Optional[str] = None
-    created_at: Optional[Union[datetime, str]] = None
+    created_at: Optional[datetime] = None
     motivation: Optional[str] = None
     use_case: Optional[str] = None
     job: Optional[str] = None

--- a/backend/scripts/generate_dart_models.py
+++ b/backend/scripts/generate_dart_models.py
@@ -180,6 +180,7 @@ SCHEMA_GROUPS = {
             'ProactiveNotification',
             'ChatTool',
             'AppBaseModel',
+            'AppCatalogItem',
             'App',
             'AppPaginationLinks',
             'AppPagination',

--- a/backend/tests/unit/test_app_catalog_detail_response_contract.py
+++ b/backend/tests/unit/test_app_catalog_detail_response_contract.py
@@ -26,6 +26,7 @@ def _app_payload():
         'is_paid': False,
         'price': 0,
         'enabled': True,
+        'external_integration': {'auth_steps': [{'name': 'Connect', 'url': 'https://example.com/oauth'}]},
         'twitter': {'handle': 'legacy-object'},
         'reviews': [{'uid': 'u1', 'rated_at': '2026-07-06T10:00:00Z', 'score': 5, 'review': 'nice'}],
         'chat_tools': [
@@ -66,6 +67,7 @@ def test_v2_apps_catalog_response_uses_desktop_safe_app_items():
         'chat',
     ]
     assert app['rating_avg'] == 4.0
+    assert app['external_integration']['auth_steps'][0]['name'] == 'Connect'
     assert 'twitter' not in app
     assert 'reviews' not in app
     assert 'chat_tools' not in app
@@ -83,8 +85,22 @@ def test_v2_apps_search_response_uses_same_desktop_safe_app_items():
 
     app = response.model_dump()['data'][0]
     assert app['id'] == 'app1'
+    assert app['external_integration']['auth_steps'][0]['name'] == 'Connect'
     assert 'twitter' not in app
     assert 'reviews' not in app
+
+
+def test_v2_apps_catalog_response_tolerates_legacy_null_is_paid():
+    payload = _app_payload()
+    payload['is_paid'] = None
+    response = AppCatalogResponse.model_validate(
+        {
+            'data': [payload],
+            'pagination': {'total': 1, 'count': 1, 'offset': 0, 'limit': 20, 'hasNext': False, 'hasPrevious': False},
+        }
+    )
+
+    assert response.model_dump()['data'][0]['is_paid'] is None
 
 
 def test_v1_app_detail_response_preserves_shared_client_fields():
@@ -99,7 +115,6 @@ def test_v1_app_detail_response_preserves_shared_client_fields():
             'payment_plan': None,
             'username': 'owner',
             'created_at': '2026-07-06T10:00:00Z',
-            'external_integration': {'auth_steps': [{'name': 'Connect', 'url': 'https://example.com/oauth'}]},
         }
     )
 

--- a/backend/tests/unit/test_app_catalog_detail_response_contract.py
+++ b/backend/tests/unit/test_app_catalog_detail_response_contract.py
@@ -1,0 +1,111 @@
+"""App catalog/detail routes expose desktop-safe app response shapes."""
+
+import os
+
+os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
+os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv')
+
+from models.app import App  # noqa: E402
+from routers.apps import AppCatalogResponse, AppSearchResponse  # noqa: E402
+
+
+def _app_payload():
+    return {
+        'id': 'app1',
+        'name': 'Catalog App',
+        'description': 'Does things',
+        'image': 'https://example.com/icon.png',
+        'category': 'productivity',
+        'author': 'Someone',
+        'capabilities': {'chat', 'external_integration'},
+        'approved': True,
+        'private': False,
+        'installs': 12,
+        'rating_avg': 4,
+        'rating_count': 2,
+        'is_paid': False,
+        'price': 0,
+        'enabled': True,
+        'twitter': {'handle': 'legacy-object'},
+        'reviews': [{'uid': 'u1', 'rated_at': '2026-07-06T10:00:00Z', 'score': 5, 'review': 'nice'}],
+        'chat_tools': [
+            {
+                'name': 'tool',
+                'description': 'Runs a tool',
+                'endpoint': 'https://example.com/tool',
+            }
+        ],
+        'payment_product_id': 'prod_123',
+    }
+
+
+def test_v2_apps_catalog_response_uses_desktop_safe_app_items():
+    response = AppCatalogResponse.model_validate(
+        {
+            'groups': [
+                {
+                    'capability': {'id': 'chat', 'title': 'Chat'},
+                    'data': [_app_payload()],
+                    'pagination': {
+                        'total': 1,
+                        'count': 1,
+                        'offset': 0,
+                        'limit': 20,
+                        'hasNext': False,
+                        'hasPrevious': False,
+                    },
+                }
+            ],
+            'meta': {'capabilities': [], 'groupCount': 1, 'limit': 20, 'offset': 0},
+        }
+    )
+
+    app = response.model_dump()['groups'][0]['data'][0]
+    assert app['capabilities'] == ['chat', 'external_integration'] or app['capabilities'] == [
+        'external_integration',
+        'chat',
+    ]
+    assert app['rating_avg'] == 4.0
+    assert 'twitter' not in app
+    assert 'reviews' not in app
+    assert 'chat_tools' not in app
+    assert 'payment_product_id' not in app
+
+
+def test_v2_apps_search_response_uses_same_desktop_safe_app_items():
+    response = AppSearchResponse.model_validate(
+        {
+            'data': [_app_payload()],
+            'pagination': {'total': 1, 'count': 1, 'offset': 0, 'limit': 20, 'hasNext': False, 'hasPrevious': False},
+            'filters': {'sort': 'name'},
+        }
+    )
+
+    app = response.model_dump()['data'][0]
+    assert app['id'] == 'app1'
+    assert 'twitter' not in app
+    assert 'reviews' not in app
+
+
+def test_v1_app_detail_response_preserves_shared_client_fields():
+    response = App.model_validate(
+        {
+            **_app_payload(),
+            'uid': 'owner1',
+            'status': 'approved',
+            'chat_prompt': 'chat',
+            'memory_prompt': 'memory',
+            'persona_prompt': None,
+            'payment_plan': None,
+            'username': 'owner',
+            'created_at': '2026-07-06T10:00:00Z',
+            'external_integration': {'auth_steps': [{'name': 'Connect', 'url': 'https://example.com/oauth'}]},
+        }
+    )
+
+    app = response.model_dump()
+    assert app['id'] == 'app1'
+    assert app['external_integration']['auth_steps'][0]['name'] == 'Connect'
+    assert app['reviews'][0]['uid'] == 'u1'
+    assert app['chat_tools'][0]['name'] == 'tool'
+    assert app['payment_product_id'] == 'prod_123'

--- a/backend/tests/unit/test_app_client_dart_generator.py
+++ b/backend/tests/unit/test_app_client_dart_generator.py
@@ -46,7 +46,7 @@ def test_conversation_wire_dart_is_generated_from_app_client_openapi():
     assert GENERATED_DART_PATH.read_text() == generated
     for schema_name in generate_dart_models.SCHEMA_GROUPS['conversation']['schemas']:
         assert f'class Generated{schema_name}' in generated
-    assert 'items: _required(_readFieldValue<List<Map<String, dynamic>>>' in generated
+    assert 'items: _required(_readFieldValue<List<GeneratedConversation>>' in generated
     assert 'class GeneratedSyncJobStartResponse' in generated
     assert 'class GeneratedSyncJobStatusResponse' in generated
     assert 'result: _readFieldValue<GeneratedSyncLocalFilesResultResponse>' in generated
@@ -265,7 +265,7 @@ def test_apps_wire_dart_is_generated_from_app_client_openapi():
     assert 'id: _required(_readFieldValue<String>' in generated
     assert 'app: _required(_readFieldValue<GeneratedAppDraftGenerationResponse>' in generated
     assert 'requiresOauth: _required(_readFieldValue<bool>' in generated
-    assert 'data: _readFieldValue<List<GeneratedAppBaseModel>>' in generated
+    assert 'data: _readFieldValue<List<GeneratedAppCatalogItem>>' in generated
     assert 'createdAt: _readFieldValue<DateTime>' in generated
 
 

--- a/backend/tests/unit/test_assistant_settings_response_models.py
+++ b/backend/tests/unit/test_assistant_settings_response_models.py
@@ -1,0 +1,40 @@
+import json
+from pathlib import Path
+
+from routers.users import AssistantSettingsResponse
+
+ROOT_DIR = Path(__file__).resolve().parents[3]
+SPEC_PATH = ROOT_DIR / 'docs' / 'api-reference' / 'app-client-openapi.json'
+
+
+def test_assistant_settings_response_keeps_forward_compatible_sections():
+    response = AssistantSettingsResponse.model_validate(
+        {
+            'focus': {'enabled': True},
+            'update_channel': 'beta',
+            'future_section': {'enabled': False, 'threshold': 3},
+        }
+    )
+
+    assert response.model_dump()['future_section'] == {'enabled': False, 'threshold': 3}
+
+
+def test_assistant_settings_model_schema_exposes_known_fields_and_allows_future_sections():
+    schema = AssistantSettingsResponse.model_json_schema()
+
+    assert schema['title'] == 'AssistantSettingsResponse'
+    assert schema.get('additionalProperties') is True
+    assert {'shared', 'focus', 'task', 'advice', 'memory', 'floating_bar', 'update_channel'} <= set(
+        schema['properties']
+    )
+
+
+def test_app_client_openapi_assistant_settings_response_exposes_known_fields_and_allows_future_sections():
+    spec = json.loads(SPEC_PATH.read_text())
+    schema = spec['components']['schemas']['AssistantSettingsResponse']
+
+    assert schema['title'] == 'AssistantSettingsResponse'
+    assert schema.get('additionalProperties') is True
+    assert {'shared', 'focus', 'task', 'advice', 'memory', 'floating_bar', 'update_channel'} <= set(
+        schema['properties']
+    )

--- a/backend/tests/unit/test_desktop_rest_inventory.py
+++ b/backend/tests/unit/test_desktop_rest_inventory.py
@@ -20,13 +20,14 @@ from __future__ import annotations
 
 import re
 from pathlib import Path
-from typing import Set
+from typing import Any, Set
 
 import pytest
 
 ROOT_DIR = Path(__file__).resolve().parents[3]
 SPEC_PATH = ROOT_DIR / 'docs' / 'api-reference' / 'app-client-openapi.json'
 APICLIENT_SWIFT = ROOT_DIR / 'desktop' / 'macos' / 'Desktop' / 'Sources' / 'APIClient.swift'
+CONVERSATIONS_ROUTER = ROOT_DIR / 'backend' / 'routers' / 'conversations.py'
 
 # Route prefixes that belong to other service boundaries / protocols and are
 # explicitly out of scope for the Python-backend REST SSoT rollout.
@@ -84,6 +85,12 @@ def _load_spec_paths() -> Set[str]:
     return set(spec.get('paths', {}).keys())
 
 
+def _load_spec() -> dict[str, Any]:
+    import json
+
+    return json.loads(SPEC_PATH.read_text())
+
+
 def _normalize_for_match(path: str) -> str:
     """Normalize both Swift-extracted and spec paths so they compare equal.
 
@@ -92,6 +99,33 @@ def _normalize_for_match(path: str) -> str:
     sides reduce to a `__param__` placeholder.
     """
     return re.sub(r'\{[^}]+\}', '{param}', path)
+
+
+DESKTOP_NAMED_MODEL_RESPONSE_CONTRACTS = {
+    ('post', '/v1/conversations/search'): {
+        'response_schema': 'SearchConversationsResponse',
+        'array_properties': {'items': 'Conversation'},
+        'desktop_decode': 'ConversationSearchResult.items -> [ServerConversation] -> OmiAPI.Conversation',
+    },
+}
+
+
+def _resolve_ref(spec: dict[str, Any], schema: dict[str, Any]) -> dict[str, Any]:
+    ref = schema.get('$ref')
+    if not ref:
+        return schema
+    prefix = '#/components/schemas/'
+    assert ref.startswith(prefix), f'Unsupported schema ref: {ref}'
+    return spec['components']['schemas'][ref[len(prefix) :]]
+
+
+def _success_json_schema(spec: dict[str, Any], method: str, path: str) -> dict[str, Any]:
+    operation = spec['paths'][path][method]
+    return operation['responses']['200']['content']['application/json']['schema']
+
+
+def _is_free_form_object_schema(schema: dict[str, Any]) -> bool:
+    return schema.get('type') == 'object' and schema.get('additionalProperties') is True
 
 
 def test_apiclient_swift_exists():
@@ -182,6 +216,57 @@ def test_known_missing_routes_do_not_drift():
     assert not stale, 'These KNOWN_MISSING_ROUTES are now in the app-client spec — remove ' 'them from the set: ' + str(
         stale
     )
+
+
+def test_desktop_named_model_response_items_are_not_free_form_objects():
+    """Desktop strict model decoders need matching app-client response schemas."""
+    spec = _load_spec()
+    failures = []
+
+    for (method, path), contract in DESKTOP_NAMED_MODEL_RESPONSE_CONTRACTS.items():
+        response_schema = _resolve_ref(spec, _success_json_schema(spec, method, path))
+        expected_response_schema = contract['response_schema']
+        if response_schema.get('title') != expected_response_schema:
+            failures.append(
+                f'{method.upper()} {path} expected response schema {expected_response_schema}, '
+                f'got {response_schema.get("title")}'
+            )
+            continue
+
+        properties = response_schema.get('properties', {})
+        for property_name, expected_item_schema in contract['array_properties'].items():
+            array_schema = properties.get(property_name)
+            item_schema = (array_schema or {}).get('items', {})
+            resolved_item_schema = _resolve_ref(spec, item_schema)
+            if _is_free_form_object_schema(item_schema):
+                failures.append(
+                    f'{method.upper()} {path} {expected_response_schema}.{property_name} is '
+                    f'array<object additionalProperties=true>, but desktop decodes '
+                    f'{contract["desktop_decode"]}. Model items as array[$ref {expected_item_schema}] instead.'
+                )
+                continue
+            if resolved_item_schema.get('title') != expected_item_schema:
+                failures.append(
+                    f'{method.upper()} {path} {expected_response_schema}.{property_name} expected '
+                    f'array[{expected_item_schema}], got {resolved_item_schema.get("title") or item_schema}'
+                )
+
+    assert not failures, '\n'.join(failures)
+
+
+def test_conversations_search_hydrates_index_hits_before_returning_app_client_rows():
+    source = CONVERSATIONS_ROUTER.read_text()
+    endpoint_start = source.index('def search_conversations_endpoint(')
+    endpoint_end = source.index(
+        '@router.get(\n    "/v1/conversations/{conversation_id}/suggested-apps"', endpoint_start
+    )
+    endpoint_source = source[endpoint_start:endpoint_end]
+
+    assert 'search_results = search_conversations(' in endpoint_source
+    assert 'get_conversations_by_id_without_photos(' in endpoint_source
+    assert "if not conversation.get('is_locked')" in endpoint_source
+    assert "search_results['items'] = conversations" in endpoint_source
+    assert 'return search_conversations(' not in endpoint_source
 
 
 def test_desktop_rest_inventory_is_nonempty():

--- a/backend/tests/unit/test_desktop_rest_inventory.py
+++ b/backend/tests/unit/test_desktop_rest_inventory.py
@@ -28,6 +28,7 @@ ROOT_DIR = Path(__file__).resolve().parents[3]
 SPEC_PATH = ROOT_DIR / 'docs' / 'api-reference' / 'app-client-openapi.json'
 APICLIENT_SWIFT = ROOT_DIR / 'desktop' / 'macos' / 'Desktop' / 'Sources' / 'APIClient.swift'
 CONVERSATIONS_ROUTER = ROOT_DIR / 'backend' / 'routers' / 'conversations.py'
+CONVERSATIONS_DB = ROOT_DIR / 'backend' / 'database' / 'conversations.py'
 
 # Route prefixes that belong to other service boundaries / protocols and are
 # explicitly out of scope for the Python-backend REST SSoT rollout.
@@ -266,7 +267,18 @@ def test_conversations_search_hydrates_index_hits_before_returning_app_client_ro
     assert 'get_conversations_by_id_without_photos(' in endpoint_source
     assert "if not conversation.get('is_locked')" in endpoint_source
     assert "search_results['items'] = conversations" in endpoint_source
+    assert "search_results['total_pages'] =" in endpoint_source
     assert 'return search_conversations(' not in endpoint_source
+
+
+def test_conversation_id_hydration_backfills_legacy_missing_ids():
+    source = CONVERSATIONS_DB.read_text()
+    helper_start = source.index('def _get_conversations_by_id(')
+    helper_end = source.index('# **************************************', helper_start)
+    helper_source = source[helper_start:helper_end]
+
+    assert "data.setdefault('id', doc.id)" in helper_source
+    assert "conversations_by_id[str(data['id'])] = data" in helper_source
 
 
 def test_desktop_rest_inventory_is_nonempty():

--- a/backend/tests/unit/test_user_profile_people_response_models.py
+++ b/backend/tests/unit/test_user_profile_people_response_models.py
@@ -1,0 +1,54 @@
+from models.other import Person
+from routers import users as users_router
+from routers.users import UserProfileResponse
+
+
+def test_user_profile_response_schema_models_desktop_fields():
+    schema = UserProfileResponse.model_json_schema()
+    properties = schema['properties']
+
+    assert schema['title'] == 'UserProfileResponse'
+    assert schema['required'] == ['uid']
+    assert properties['uid']['type'] == 'string'
+    assert properties['email']['anyOf'][0]['type'] == 'string'
+    assert properties['name']['anyOf'][0]['type'] == 'string'
+    assert properties['time_zone']['anyOf'][0]['type'] == 'string'
+    assert properties['created_at']['anyOf'][0]['format'] == 'date-time'
+    assert properties['motivation']['anyOf'][0]['type'] == 'string'
+    assert properties['use_case']['anyOf'][0]['type'] == 'string'
+    assert properties['job']['anyOf'][0]['type'] == 'string'
+    assert properties['company']['anyOf'][0]['type'] == 'string'
+
+
+def test_user_profile_response_requires_uid_and_keeps_extra_profile_fields():
+    response = UserProfileResponse.model_validate(
+        {
+            'uid': 'user-123',
+            'name': 'Desktop User',
+            'future_profile_field': {'enabled': True},
+        }
+    )
+
+    assert response.uid == 'user-123'
+    assert response.name == 'Desktop User'
+    assert response.model_dump()['future_profile_field'] == {'enabled': True}
+
+
+def test_user_profile_endpoint_injects_uid_for_legacy_profile_docs(monkeypatch):
+    monkeypatch.setattr(users_router, 'get_user_profile', lambda uid: {'name': 'Legacy User'})
+
+    response = users_router.get_user_profile_endpoint(uid='user-123')
+
+    assert response == {'name': 'Legacy User', 'uid': 'user-123'}
+
+
+def test_person_response_model_keeps_people_timestamps_optional():
+    person = Person.model_validate({'id': 'person-123', 'name': 'Alice'})
+
+    assert person.id == 'person-123'
+    assert person.name == 'Alice'
+    assert person.created_at is None
+    assert person.updated_at is None
+    assert person.speech_samples == []
+    assert person.speech_sample_transcripts is None
+    assert person.speech_samples_version == 3

--- a/desktop/macos/Desktop/Sources/APIClient.swift
+++ b/desktop/macos/Desktop/Sources/APIClient.swift
@@ -3835,7 +3835,7 @@ struct OmiAppDetails: Codable, Identifiable {
     price = try container.decodeIfPresent(Double.self, forKey: .price)
     paymentPlan = try container.decodeIfPresent(String.self, forKey: .paymentPlan)
     username = try container.decodeIfPresent(String.self, forKey: .username)
-    twitter = try container.decodeIfPresent(String.self, forKey: .twitter)
+    twitter = (try? container.decodeIfPresent(String.self, forKey: .twitter)) ?? nil
     createdAt = try container.decodeIfPresent(Date.self, forKey: .createdAt)
     enabled = try container.decodeIfPresent(Bool.self, forKey: .enabled) ?? false
     externalIntegration = try container.decodeIfPresent(
@@ -5079,9 +5079,63 @@ struct MemorySettingsResponse: Codable {
 
 struct FloatingBarSettingsResponse: Codable {
   var voiceAnswersEnabled: Bool?
+  var elevenlabsVoiceId: String?
 
   enum CodingKeys: String, CodingKey {
     case voiceAnswersEnabled = "voice_answers_enabled"
+    case elevenlabsVoiceId = "elevenlabs_voice_id"
+  }
+}
+
+enum AssistantSettingsJSONValue: Codable, Equatable {
+  case null
+  case bool(Bool)
+  case int(Int)
+  case double(Double)
+  case string(String)
+  case array([AssistantSettingsJSONValue])
+  case object([String: AssistantSettingsJSONValue])
+
+  init(from decoder: Decoder) throws {
+    let container = try decoder.singleValueContainer()
+    if container.decodeNil() {
+      self = .null
+    } else if let value = try? container.decode(Bool.self) {
+      self = .bool(value)
+    } else if let value = try? container.decode(Int.self) {
+      self = .int(value)
+    } else if let value = try? container.decode(Double.self) {
+      self = .double(value)
+    } else if let value = try? container.decode(String.self) {
+      self = .string(value)
+    } else if let value = try? container.decode([AssistantSettingsJSONValue].self) {
+      self = .array(value)
+    } else if let value = try? container.decode([String: AssistantSettingsJSONValue].self) {
+      self = .object(value)
+    } else {
+      throw DecodingError.dataCorruptedError(
+        in: container, debugDescription: "Unsupported assistant settings JSON value")
+    }
+  }
+
+  func encode(to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+    switch self {
+    case .null:
+      try container.encodeNil()
+    case .bool(let value):
+      try container.encode(value)
+    case .int(let value):
+      try container.encode(value)
+    case .double(let value):
+      try container.encode(value)
+    case .string(let value):
+      try container.encode(value)
+    case .array(let value):
+      try container.encode(value)
+    case .object(let value):
+      try container.encode(value)
+    }
   }
 }
 
@@ -5093,13 +5147,99 @@ struct AssistantSettingsResponse: Codable {
   var memory: MemorySettingsResponse?
   var floatingBar: FloatingBarSettingsResponse?
   var updateChannel: String?
+  var unknownSections: [String: AssistantSettingsJSONValue]
 
-  enum CodingKeys: String, CodingKey {
+  enum CodingKeys: String, CodingKey, CaseIterable {
     case shared, focus, task
     case insight = "advice"
     case memory
     case floatingBar = "floating_bar"
     case updateChannel = "update_channel"
+  }
+
+  init(
+    shared: SharedAssistantSettingsResponse? = nil,
+    focus: FocusSettingsResponse? = nil,
+    task: TaskSettingsResponse? = nil,
+    insight: InsightSettingsResponse? = nil,
+    memory: MemorySettingsResponse? = nil,
+    floatingBar: FloatingBarSettingsResponse? = nil,
+    updateChannel: String? = nil,
+    unknownSections: [String: AssistantSettingsJSONValue] = [:]
+  ) {
+    self.shared = shared
+    self.focus = focus
+    self.task = task
+    self.insight = insight
+    self.memory = memory
+    self.floatingBar = floatingBar
+    self.updateChannel = updateChannel
+    self.unknownSections = unknownSections
+  }
+
+  init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    shared = Self.decodeLossy(SharedAssistantSettingsResponse.self, from: container, forKey: .shared)
+    focus = Self.decodeLossy(FocusSettingsResponse.self, from: container, forKey: .focus)
+    task = Self.decodeLossy(TaskSettingsResponse.self, from: container, forKey: .task)
+    insight = Self.decodeLossy(InsightSettingsResponse.self, from: container, forKey: .insight)
+    memory = Self.decodeLossy(MemorySettingsResponse.self, from: container, forKey: .memory)
+    floatingBar = Self.decodeLossy(
+      FloatingBarSettingsResponse.self, from: container, forKey: .floatingBar)
+    updateChannel = Self.decodeLossy(String.self, from: container, forKey: .updateChannel)
+
+    let rawContainer = try decoder.container(keyedBy: AssistantSettingsDynamicCodingKey.self)
+    let knownKeys = Set(CodingKeys.allCases.map(\.rawValue))
+    unknownSections = rawContainer.allKeys.reduce(into: [:]) { result, key in
+      guard !knownKeys.contains(key.stringValue),
+        let value = try? rawContainer.decode(AssistantSettingsJSONValue.self, forKey: key)
+      else { return }
+      result[key.stringValue] = value
+    }
+  }
+
+  func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    try container.encodeIfPresent(shared, forKey: .shared)
+    try container.encodeIfPresent(focus, forKey: .focus)
+    try container.encodeIfPresent(task, forKey: .task)
+    try container.encodeIfPresent(insight, forKey: .insight)
+    try container.encodeIfPresent(memory, forKey: .memory)
+    try container.encodeIfPresent(floatingBar, forKey: .floatingBar)
+    try container.encodeIfPresent(updateChannel, forKey: .updateChannel)
+
+    var rawContainer = encoder.container(keyedBy: AssistantSettingsDynamicCodingKey.self)
+    let knownKeys = Set(CodingKeys.allCases.map(\.rawValue))
+    for (key, value) in unknownSections where !knownKeys.contains(key) {
+      try rawContainer.encode(value, forKey: AssistantSettingsDynamicCodingKey(stringValue: key))
+    }
+  }
+
+  private static func decodeLossy<T: Decodable>(
+    _ type: T.Type,
+    from container: KeyedDecodingContainer<CodingKeys>,
+    forKey key: CodingKeys
+  ) -> T? {
+    do {
+      return try container.decodeIfPresent(type, forKey: key)
+    } catch {
+      return nil
+    }
+  }
+}
+
+struct AssistantSettingsDynamicCodingKey: CodingKey {
+  let stringValue: String
+  let intValue: Int?
+
+  init(stringValue: String) {
+    self.stringValue = stringValue
+    intValue = nil
+  }
+
+  init(intValue: Int) {
+    stringValue = String(intValue)
+    self.intValue = intValue
   }
 }
 
@@ -5577,13 +5717,49 @@ extension APIClient {
 struct Person: Codable, Identifiable {
   let id: String
   let name: String
-  let createdAt: Date
-  let updatedAt: Date
+  let createdAt: Date?
+  let updatedAt: Date?
+  let speechSamples: [String]
+  let speechSampleTranscripts: [String]?
+  let speechSamplesVersion: Int
 
   enum CodingKeys: String, CodingKey {
     case id, name
     case createdAt = "created_at"
     case updatedAt = "updated_at"
+    case speechSamples = "speech_samples"
+    case speechSampleTranscripts = "speech_sample_transcripts"
+    case speechSamplesVersion = "speech_samples_version"
+  }
+
+  init(
+    id: String,
+    name: String,
+    createdAt: Date? = nil,
+    updatedAt: Date? = nil,
+    speechSamples: [String] = [],
+    speechSampleTranscripts: [String]? = nil,
+    speechSamplesVersion: Int = 3
+  ) {
+    self.id = id
+    self.name = name
+    self.createdAt = createdAt
+    self.updatedAt = updatedAt
+    self.speechSamples = speechSamples
+    self.speechSampleTranscripts = speechSampleTranscripts
+    self.speechSamplesVersion = speechSamplesVersion
+  }
+
+  init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    id = try container.decode(String.self, forKey: .id)
+    name = try container.decode(String.self, forKey: .name)
+    createdAt = try container.decodeIfPresent(Date.self, forKey: .createdAt)
+    updatedAt = try container.decodeIfPresent(Date.self, forKey: .updatedAt)
+    speechSamples = try container.decodeIfPresent([String].self, forKey: .speechSamples) ?? []
+    speechSampleTranscripts = try container.decodeIfPresent(
+      [String].self, forKey: .speechSampleTranscripts)
+    speechSamplesVersion = try container.decodeIfPresent(Int.self, forKey: .speechSamplesVersion) ?? 3
   }
 }
 

--- a/desktop/macos/Desktop/Tests/APIClientAssistantSettingsTests.swift
+++ b/desktop/macos/Desktop/Tests/APIClientAssistantSettingsTests.swift
@@ -1,0 +1,65 @@
+import XCTest
+
+@testable import Omi_Computer
+
+final class APIClientAssistantSettingsTests: XCTestCase {
+
+  func testAssistantSettingsDecodesValidSiblingsWhenOneKnownSectionIsMalformed() throws {
+    let data = """
+      {
+        "focus": "not-yet-a-focus-object",
+        "task": {
+          "enabled": true,
+          "min_confidence": 0.72
+        },
+        "floating_bar": {
+          "voice_answers_enabled": true,
+          "elevenlabs_voice_id": "voice-123"
+        },
+        "update_channel": "beta"
+      }
+      """.data(using: .utf8)!
+
+    let response = try JSONDecoder().decode(AssistantSettingsResponse.self, from: data)
+
+    XCTAssertNil(response.focus)
+    XCTAssertEqual(response.task?.enabled, true)
+    XCTAssertEqual(response.task?.minConfidence, 0.72)
+    XCTAssertEqual(response.floatingBar?.voiceAnswersEnabled, true)
+    XCTAssertEqual(response.floatingBar?.elevenlabsVoiceId, "voice-123")
+    XCTAssertEqual(response.updateChannel, "beta")
+  }
+
+  func testAssistantSettingsPreservesUnknownFutureSectionsWhenReEncoding() throws {
+    let data = """
+      {
+        "focus": {
+          "enabled": false
+        },
+        "future_section": {
+          "enabled": true,
+          "threshold": 3,
+          "labels": ["alpha", "beta"]
+        }
+      }
+      """.data(using: .utf8)!
+
+    let response = try JSONDecoder().decode(AssistantSettingsResponse.self, from: data)
+    XCTAssertEqual(
+      response.unknownSections["future_section"],
+      .object([
+        "enabled": .bool(true),
+        "threshold": .int(3),
+        "labels": .array([.string("alpha"), .string("beta")]),
+      ])
+    )
+
+    let encoded = try JSONEncoder().encode(response)
+    let object = try XCTUnwrap(JSONSerialization.jsonObject(with: encoded) as? [String: Any])
+    let futureSection = try XCTUnwrap(object["future_section"] as? [String: Any])
+
+    XCTAssertEqual(futureSection["enabled"] as? Bool, true)
+    XCTAssertEqual(futureSection["threshold"] as? Int, 3)
+    XCTAssertEqual(futureSection["labels"] as? [String], ["alpha", "beta"])
+  }
+}

--- a/desktop/macos/Desktop/Tests/APIClientUserProfilePeopleDecodingTests.swift
+++ b/desktop/macos/Desktop/Tests/APIClientUserProfilePeopleDecodingTests.swift
@@ -1,0 +1,98 @@
+import XCTest
+
+@testable import Omi_Computer
+
+final class APIClientUserProfilePeopleDecodingTests: XCTestCase {
+  private func makeDecoder() -> JSONDecoder {
+    let decoder = JSONDecoder()
+    decoder.dateDecodingStrategy = .custom { decoder in
+      let container = try decoder.singleValueContainer()
+      let value = try container.decode(String.self)
+
+      let isoWithFractional = ISO8601DateFormatter()
+      isoWithFractional.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+      if let date = isoWithFractional.date(from: value) {
+        return date
+      }
+
+      let iso = ISO8601DateFormatter()
+      if let date = iso.date(from: value) {
+        return date
+      }
+
+      throw DecodingError.dataCorruptedError(
+        in: container, debugDescription: "Invalid ISO8601 date: \(value)")
+    }
+    return decoder
+  }
+
+  func testUserProfileRequiresUidButToleratesOptionalProfileFields() throws {
+    let json = """
+      {
+        "uid": "user-123",
+        "name": "Desktop User",
+        "unexpected_profile_field": "ignored"
+      }
+      """.data(using: .utf8)!
+
+    let profile = try makeDecoder().decode(UserProfileResponse.self, from: json)
+
+    XCTAssertEqual(profile.uid, "user-123")
+    XCTAssertEqual(profile.name, "Desktop User")
+    XCTAssertNil(profile.email)
+    XCTAssertNil(profile.timeZone)
+  }
+
+  func testUserProfileStillFailsWithoutUid() {
+    let json = """
+      {
+        "name": "Legacy User"
+      }
+      """.data(using: .utf8)!
+
+    XCTAssertThrowsError(try makeDecoder().decode(UserProfileResponse.self, from: json))
+  }
+
+  func testPersonToleratesLegacyMissingOptionalFields() throws {
+    let json = """
+      {
+        "id": "person-123",
+        "name": "Alice"
+      }
+      """.data(using: .utf8)!
+
+    let person = try makeDecoder().decode(Person.self, from: json)
+
+    XCTAssertEqual(person.id, "person-123")
+    XCTAssertEqual(person.name, "Alice")
+    XCTAssertNil(person.createdAt)
+    XCTAssertNil(person.updatedAt)
+    XCTAssertEqual(person.speechSamples, [])
+    XCTAssertNil(person.speechSampleTranscripts)
+    XCTAssertEqual(person.speechSamplesVersion, 3)
+  }
+
+  func testPersonDecodesFullPeoplePayload() throws {
+    let json = """
+      {
+        "id": "person-456",
+        "name": "Bob",
+        "created_at": "2026-07-06T12:30:00.123Z",
+        "updated_at": "2026-07-06T12:45:00Z",
+        "speech_samples": ["https://example.test/sample.wav"],
+        "speech_sample_transcripts": ["hello"],
+        "speech_samples_version": 4
+      }
+      """.data(using: .utf8)!
+
+    let person = try makeDecoder().decode(Person.self, from: json)
+
+    XCTAssertEqual(person.id, "person-456")
+    XCTAssertEqual(person.name, "Bob")
+    XCTAssertNotNil(person.createdAt)
+    XCTAssertNotNil(person.updatedAt)
+    XCTAssertEqual(person.speechSamples, ["https://example.test/sample.wav"])
+    XCTAssertEqual(person.speechSampleTranscripts, ["hello"])
+    XCTAssertEqual(person.speechSamplesVersion, 4)
+  }
+}

--- a/desktop/macos/Desktop/Tests/ServerAppCatalogDecodingTests.swift
+++ b/desktop/macos/Desktop/Tests/ServerAppCatalogDecodingTests.swift
@@ -1,0 +1,79 @@
+import XCTest
+
+@testable import Omi_Computer
+
+final class ServerAppCatalogDecodingTests: XCTestCase {
+  func testAppDetailsIgnoresLegacyTwitterObject() throws {
+    let json = """
+      {
+        "id": "app1",
+        "name": "Catalog App",
+        "description": "Does things",
+        "image": "https://example.com/icon.png",
+        "category": "productivity",
+        "author": "Someone",
+        "email": "author@example.com",
+        "capabilities": ["chat"],
+        "uid": "owner1",
+        "approved": true,
+        "private": false,
+        "status": "approved",
+        "installs": 12,
+        "rating_avg": 4.5,
+        "rating_count": 2,
+        "is_paid": false,
+        "price": 0,
+        "username": "owner",
+        "twitter": {"handle": "legacy-object"},
+        "enabled": true,
+        "external_integration": {
+          "auth_steps": [{"name": "Connect", "url": "https://example.com/oauth"}]
+        }
+      }
+      """.data(using: .utf8)!
+
+    let app = try JSONDecoder().decode(OmiAppDetails.self, from: json)
+
+    XCTAssertEqual(app.id, "app1")
+    XCTAssertNil(app.twitter)
+    XCTAssertEqual(app.externalIntegration?.authSteps.first?.name, "Connect")
+  }
+
+  func testV2AppsResponseDecodesCatalogItems() throws {
+    let json = """
+      {
+        "groups": [
+          {
+            "capability": {"id": "chat", "title": "Chat"},
+            "data": [
+              {
+                "id": "app1",
+                "name": "Catalog App",
+                "description": "Does things",
+                "image": "https://example.com/icon.png",
+                "category": "productivity",
+                "author": "Someone",
+                "capabilities": ["chat"],
+                "approved": true,
+                "private": false,
+                "installs": 12,
+                "rating_avg": 4.5,
+                "rating_count": 2,
+                "is_paid": false,
+                "price": 0,
+                "enabled": true
+              }
+            ],
+            "pagination": {"total": 1, "count": 1, "offset": 0, "limit": 20}
+          }
+        ],
+        "meta": {"capabilities": [{"id": "chat", "title": "Chat"}], "groupCount": 1, "limit": 20, "offset": 0}
+      }
+      """.data(using: .utf8)!
+
+    let response = try JSONDecoder().decode(OmiAppsV2Response.self, from: json)
+
+    XCTAssertEqual(response.groups.first?.data.first?.id, "app1")
+    XCTAssertEqual(response.groups.first?.data.first?.ratingAvg, 4.5)
+  }
+}

--- a/desktop/macos/Desktop/Tests/ServerConversationDecodingTests.swift
+++ b/desktop/macos/Desktop/Tests/ServerConversationDecodingTests.swift
@@ -31,6 +31,40 @@ final class ServerConversationDecodingTests: XCTestCase {
         return try decoder.decode(ServerConversation.self, from: Data(json.utf8))
     }
 
+    private func decodeSearchResult(_ itemFields: String) throws -> ConversationSearchResult {
+        let json = """
+        {
+          "items": [
+            {
+              "id": "conversation-1",
+              "created_at": "2026-06-25T10:00:00+00:00",
+              "started_at": null,
+              "finished_at": null,
+              "structured": {
+                "title": "Search hit",
+                "overview": "Overview",
+                "emoji": "💬",
+                "category": "other",
+                "action_items": [],
+                "events": []
+              },
+              "status": "completed",
+              "discarded": false,
+              "starred": false,
+              "deferred": false
+              \(itemFields)
+            }
+          ],
+          "current_page": 1,
+          "total_pages": 1,
+          "per_page": 50
+        }
+        """
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return try decoder.decode(ConversationSearchResult.self, from: Data(json.utf8))
+    }
+
     func testOmittedTranscriptSegmentsAreMarkedOmitted() throws {
         let conversation = try decodeConversation("")
 
@@ -85,6 +119,24 @@ final class ServerConversationDecodingTests: XCTestCase {
         XCTAssertTrue(conversation.transcriptSegments.isEmpty)
         XCTAssertEqual(conversation.transcriptPresenceState, .includedEmpty)
         XCTAssertFalse(conversation.shouldFetchDetailForTranscript)
+    }
+
+    func testConversationSearchResultDecodesCanonicalListRowWithOmittedTranscript() throws {
+        let result = try decodeSearchResult("")
+
+        XCTAssertEqual(result.items.count, 1)
+        XCTAssertEqual(result.items[0].title, "Search hit")
+        XCTAssertFalse(result.items[0].transcriptSegmentsIncluded)
+        XCTAssertEqual(result.items[0].transcriptPresenceState, .omittedFromResponse)
+        XCTAssertTrue(result.items[0].shouldFetchDetailForTranscript)
+    }
+
+    func testConversationSearchResultRejectsRawPartialTypesenseTranscriptShape() throws {
+        XCTAssertThrowsError(
+            try decodeSearchResult(
+                ",\n\"transcript_segments\": [{\"person_id\": \"person-1\"}]"
+            )
+        )
     }
 
     func testLockStateParticipatesInConversationEquality() throws {

--- a/desktop/macos/changelog/unreleased/20260706-fix-conversation-search-contract.json
+++ b/desktop/macos/changelog/unreleased/20260706-fix-conversation-search-contract.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed conversation search failing when backend search results used the search index shape instead of the normal conversation row shape"
+}

--- a/desktop/windows/src/renderer/src/lib/omiApi.generated.ts
+++ b/desktop/windows/src/renderer/src/lib/omiApi.generated.ts
@@ -243,8 +243,27 @@ export interface AppCatalogGroup {
   capability?: AppSelectOption | null;
   category?: AppSelectOption | null;
   count?: number | null;
-  data?: Array<AppBaseModel>;
+  data?: Array<AppCatalogItem>;
   pagination?: AppPagination | null;
+}
+
+export interface AppCatalogItem {
+  approved?: boolean;
+  author?: string;
+  capabilities?: Array<string>;
+  category?: string;
+  description?: string;
+  enabled?: boolean;
+  external_integration?: ExternalIntegration | null;
+  id: string;
+  image?: string;
+  installs?: number;
+  is_paid?: boolean | null;
+  name?: string;
+  price?: number | null;
+  private?: boolean;
+  rating_avg?: number | null;
+  rating_count?: number;
 }
 
 export interface AppCatalogMeta {
@@ -258,7 +277,7 @@ export interface AppCatalogMeta {
 export interface AppCatalogResponse {
   capability?: AppSelectOption | null;
   category?: AppSelectOption | null;
-  data?: Array<AppBaseModel>;
+  data?: Array<AppCatalogItem>;
   groups?: Array<AppCatalogGroup>;
   meta?: AppCatalogMeta | null;
   pagination?: AppPagination | null;
@@ -357,7 +376,7 @@ export interface AppSearchFilters {
 }
 
 export interface AppSearchResponse {
-  data?: Array<AppBaseModel>;
+  data?: Array<AppCatalogItem>;
   filters: AppSearchFilters;
   pagination: AppPagination;
 }
@@ -2116,7 +2135,7 @@ export interface SavePayPalPaymentDetailsRequest {
 
 export interface SearchConversationsResponse {
   current_page: number;
-  items: Array<Record<string, unknown>>;
+  items: Array<Conversation>;
   per_page: number;
   total_pages: number;
 }
@@ -2729,8 +2748,17 @@ export interface UserProfile {
 }
 
 export interface UserProfileResponse {
+  company?: string | null;
+  created_at?: string | null;
   data_protection_level?: string | null;
+  email?: string | null;
+  job?: string | null;
   migration_status?: Record<string, unknown> | null;
+  motivation?: string | null;
+  name?: string | null;
+  time_zone?: string | null;
+  uid: string;
+  use_case?: string | null;
   [key: string]: unknown;
 }
 
@@ -2872,6 +2900,7 @@ export interface OmiApiSchemas {
   "AppCapabilityAction": AppCapabilityAction;
   "AppCapabilityResponse": AppCapabilityResponse;
   "AppCatalogGroup": AppCatalogGroup;
+  "AppCatalogItem": AppCatalogItem;
   "AppCatalogMeta": AppCatalogMeta;
   "AppCatalogResponse": AppCatalogResponse;
   "AppCreateResponse": AppCreateResponse;

--- a/docs/api-reference/app-client-openapi.json
+++ b/docs/api-reference/app-client-openapi.json
@@ -1744,6 +1744,16 @@
             "title": "Enabled",
             "type": "boolean"
           },
+          "external_integration": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ExternalIntegration"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "id": {
             "title": "Id",
             "type": "string"
@@ -1759,9 +1769,16 @@
             "type": "integer"
           },
           "is_paid": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "default": false,
-            "title": "Is Paid",
-            "type": "boolean"
+            "title": "Is Paid"
           },
           "name": {
             "default": "",
@@ -16154,9 +16171,6 @@
             "anyOf": [
               {
                 "format": "date-time",
-                "type": "string"
-              },
-              {
                 "type": "string"
               },
               {

--- a/docs/api-reference/app-client-openapi.json
+++ b/docs/api-reference/app-client-openapi.json
@@ -1690,7 +1690,7 @@
           },
           "data": {
             "items": {
-              "$ref": "#/components/schemas/AppBaseModel"
+              "$ref": "#/components/schemas/AppCatalogItem"
             },
             "title": "Data",
             "type": "array"
@@ -1707,6 +1707,104 @@
           }
         },
         "title": "AppCatalogGroup",
+        "type": "object"
+      },
+      "AppCatalogItem": {
+        "description": "Desktop app catalog response item for list/search views.",
+        "properties": {
+          "approved": {
+            "default": false,
+            "title": "Approved",
+            "type": "boolean"
+          },
+          "author": {
+            "default": "",
+            "title": "Author",
+            "type": "string"
+          },
+          "capabilities": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Capabilities",
+            "type": "array"
+          },
+          "category": {
+            "default": "other",
+            "title": "Category",
+            "type": "string"
+          },
+          "description": {
+            "default": "",
+            "title": "Description",
+            "type": "string"
+          },
+          "enabled": {
+            "default": false,
+            "title": "Enabled",
+            "type": "boolean"
+          },
+          "id": {
+            "title": "Id",
+            "type": "string"
+          },
+          "image": {
+            "default": "",
+            "title": "Image",
+            "type": "string"
+          },
+          "installs": {
+            "default": 0,
+            "title": "Installs",
+            "type": "integer"
+          },
+          "is_paid": {
+            "default": false,
+            "title": "Is Paid",
+            "type": "boolean"
+          },
+          "name": {
+            "default": "",
+            "title": "Name",
+            "type": "string"
+          },
+          "price": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Price"
+          },
+          "private": {
+            "default": false,
+            "title": "Private",
+            "type": "boolean"
+          },
+          "rating_avg": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Rating Avg"
+          },
+          "rating_count": {
+            "default": 0,
+            "title": "Rating Count",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "id"
+        ],
+        "title": "AppCatalogItem",
         "type": "object"
       },
       "AppCatalogMeta": {
@@ -1784,7 +1882,7 @@
           },
           "data": {
             "items": {
-              "$ref": "#/components/schemas/AppBaseModel"
+              "$ref": "#/components/schemas/AppCatalogItem"
             },
             "title": "Data",
             "type": "array"
@@ -2274,7 +2372,7 @@
         "properties": {
           "data": {
             "items": {
-              "$ref": "#/components/schemas/AppBaseModel"
+              "$ref": "#/components/schemas/AppCatalogItem"
             },
             "title": "Data",
             "type": "array"
@@ -12264,8 +12362,7 @@
           },
           "items": {
             "items": {
-              "additionalProperties": true,
-              "type": "object"
+              "$ref": "#/components/schemas/Conversation"
             },
             "title": "Items",
             "type": "array"
@@ -16042,6 +16139,32 @@
       "UserProfileResponse": {
         "additionalProperties": true,
         "properties": {
+          "company": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Company"
+          },
+          "created_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Created At"
+          },
           "data_protection_level": {
             "anyOf": [
               {
@@ -16052,6 +16175,28 @@
               }
             ],
             "title": "Data Protection Level"
+          },
+          "email": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Email"
+          },
+          "job": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Job"
           },
           "migration_status": {
             "anyOf": [
@@ -16064,8 +16209,59 @@
               }
             ],
             "title": "Migration Status"
+          },
+          "motivation": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Motivation"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "time_zone": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Time Zone"
+          },
+          "uid": {
+            "title": "Uid",
+            "type": "string"
+          },
+          "use_case": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Use Case"
           }
         },
+        "required": [
+          "uid"
+        ],
         "title": "UserProfileResponse",
         "type": "object"
       },

--- a/scripts/pre-push
+++ b/scripts/pre-push
@@ -438,6 +438,17 @@ check_openapi_contract_if_needed() {
   if ! changed_matches \
     'backend/**' \
     'docs/api-reference/openapi.json' \
+    'docs/api-reference/app-client-openapi.json' \
+    'docs/api-reference/integration-public-openapi.json' \
+    'app/lib/backend/http/api/**' \
+    'app/lib/backend/schema/**' \
+    'app/lib/models/announcement.dart' \
+    'app/lib/models/subscription.dart' \
+    'app/lib/models/user_usage.dart' \
+    'desktop/windows/src/renderer/src/lib/omiApi.generated.ts' \
+    'web/app/src/lib/omiApi.generated.ts' \
+    'web/admin/lib/services/omi-api/omiApi.generated.ts' \
+    'web/personas-open-source/src/lib/omiApi.generated.ts' \
     'docs/docs.json' \
     '.github/workflows/openapi-contract.yml' \
     'scripts/pre-push'
@@ -448,7 +459,13 @@ check_openapi_contract_if_needed() {
   (
     cd backend
     scripts/openapi_runner.sh scripts/export_openapi.py --check ../docs/api-reference/openapi.json
+    scripts/openapi_runner.sh scripts/export_openapi.py --surface app-client --check ../docs/api-reference/app-client-openapi.json
+    scripts/openapi_runner.sh scripts/export_openapi.py --surface integration-public --check ../docs/api-reference/integration-public-openapi.json
   )
+
+  "$BACKEND_PYTHON" backend/scripts/generate_dart_models.py --all --check
+  "$BACKEND_PYTHON" backend/scripts/generate_ts_openapi_types.py --check
+  "$BACKEND_PYTHON" backend/scripts/generate_swift_openapi_types.py --check
 }
 
 check_workflows_if_needed() {

--- a/web/admin/lib/services/omi-api/omiApi.generated.ts
+++ b/web/admin/lib/services/omi-api/omiApi.generated.ts
@@ -243,8 +243,27 @@ export interface AppCatalogGroup {
   capability?: AppSelectOption | null;
   category?: AppSelectOption | null;
   count?: number | null;
-  data?: Array<AppBaseModel>;
+  data?: Array<AppCatalogItem>;
   pagination?: AppPagination | null;
+}
+
+export interface AppCatalogItem {
+  approved?: boolean;
+  author?: string;
+  capabilities?: Array<string>;
+  category?: string;
+  description?: string;
+  enabled?: boolean;
+  external_integration?: ExternalIntegration | null;
+  id: string;
+  image?: string;
+  installs?: number;
+  is_paid?: boolean | null;
+  name?: string;
+  price?: number | null;
+  private?: boolean;
+  rating_avg?: number | null;
+  rating_count?: number;
 }
 
 export interface AppCatalogMeta {
@@ -258,7 +277,7 @@ export interface AppCatalogMeta {
 export interface AppCatalogResponse {
   capability?: AppSelectOption | null;
   category?: AppSelectOption | null;
-  data?: Array<AppBaseModel>;
+  data?: Array<AppCatalogItem>;
   groups?: Array<AppCatalogGroup>;
   meta?: AppCatalogMeta | null;
   pagination?: AppPagination | null;
@@ -357,7 +376,7 @@ export interface AppSearchFilters {
 }
 
 export interface AppSearchResponse {
-  data?: Array<AppBaseModel>;
+  data?: Array<AppCatalogItem>;
   filters: AppSearchFilters;
   pagination: AppPagination;
 }
@@ -2116,7 +2135,7 @@ export interface SavePayPalPaymentDetailsRequest {
 
 export interface SearchConversationsResponse {
   current_page: number;
-  items: Array<Record<string, unknown>>;
+  items: Array<Conversation>;
   per_page: number;
   total_pages: number;
 }
@@ -2729,8 +2748,17 @@ export interface UserProfile {
 }
 
 export interface UserProfileResponse {
+  company?: string | null;
+  created_at?: string | null;
   data_protection_level?: string | null;
+  email?: string | null;
+  job?: string | null;
   migration_status?: Record<string, unknown> | null;
+  motivation?: string | null;
+  name?: string | null;
+  time_zone?: string | null;
+  uid: string;
+  use_case?: string | null;
   [key: string]: unknown;
 }
 
@@ -2872,6 +2900,7 @@ export interface OmiApiSchemas {
   "AppCapabilityAction": AppCapabilityAction;
   "AppCapabilityResponse": AppCapabilityResponse;
   "AppCatalogGroup": AppCatalogGroup;
+  "AppCatalogItem": AppCatalogItem;
   "AppCatalogMeta": AppCatalogMeta;
   "AppCatalogResponse": AppCatalogResponse;
   "AppCreateResponse": AppCreateResponse;

--- a/web/app/src/lib/omiApi.generated.ts
+++ b/web/app/src/lib/omiApi.generated.ts
@@ -243,8 +243,27 @@ export interface AppCatalogGroup {
   capability?: AppSelectOption | null;
   category?: AppSelectOption | null;
   count?: number | null;
-  data?: Array<AppBaseModel>;
+  data?: Array<AppCatalogItem>;
   pagination?: AppPagination | null;
+}
+
+export interface AppCatalogItem {
+  approved?: boolean;
+  author?: string;
+  capabilities?: Array<string>;
+  category?: string;
+  description?: string;
+  enabled?: boolean;
+  external_integration?: ExternalIntegration | null;
+  id: string;
+  image?: string;
+  installs?: number;
+  is_paid?: boolean | null;
+  name?: string;
+  price?: number | null;
+  private?: boolean;
+  rating_avg?: number | null;
+  rating_count?: number;
 }
 
 export interface AppCatalogMeta {
@@ -258,7 +277,7 @@ export interface AppCatalogMeta {
 export interface AppCatalogResponse {
   capability?: AppSelectOption | null;
   category?: AppSelectOption | null;
-  data?: Array<AppBaseModel>;
+  data?: Array<AppCatalogItem>;
   groups?: Array<AppCatalogGroup>;
   meta?: AppCatalogMeta | null;
   pagination?: AppPagination | null;
@@ -357,7 +376,7 @@ export interface AppSearchFilters {
 }
 
 export interface AppSearchResponse {
-  data?: Array<AppBaseModel>;
+  data?: Array<AppCatalogItem>;
   filters: AppSearchFilters;
   pagination: AppPagination;
 }
@@ -2116,7 +2135,7 @@ export interface SavePayPalPaymentDetailsRequest {
 
 export interface SearchConversationsResponse {
   current_page: number;
-  items: Array<Record<string, unknown>>;
+  items: Array<Conversation>;
   per_page: number;
   total_pages: number;
 }
@@ -2729,8 +2748,17 @@ export interface UserProfile {
 }
 
 export interface UserProfileResponse {
+  company?: string | null;
+  created_at?: string | null;
   data_protection_level?: string | null;
+  email?: string | null;
+  job?: string | null;
   migration_status?: Record<string, unknown> | null;
+  motivation?: string | null;
+  name?: string | null;
+  time_zone?: string | null;
+  uid: string;
+  use_case?: string | null;
   [key: string]: unknown;
 }
 
@@ -2872,6 +2900,7 @@ export interface OmiApiSchemas {
   "AppCapabilityAction": AppCapabilityAction;
   "AppCapabilityResponse": AppCapabilityResponse;
   "AppCatalogGroup": AppCatalogGroup;
+  "AppCatalogItem": AppCatalogItem;
   "AppCatalogMeta": AppCatalogMeta;
   "AppCatalogResponse": AppCatalogResponse;
   "AppCreateResponse": AppCreateResponse;

--- a/web/personas-open-source/src/lib/omiApi.generated.ts
+++ b/web/personas-open-source/src/lib/omiApi.generated.ts
@@ -243,8 +243,27 @@ export interface AppCatalogGroup {
   capability?: AppSelectOption | null;
   category?: AppSelectOption | null;
   count?: number | null;
-  data?: Array<AppBaseModel>;
+  data?: Array<AppCatalogItem>;
   pagination?: AppPagination | null;
+}
+
+export interface AppCatalogItem {
+  approved?: boolean;
+  author?: string;
+  capabilities?: Array<string>;
+  category?: string;
+  description?: string;
+  enabled?: boolean;
+  external_integration?: ExternalIntegration | null;
+  id: string;
+  image?: string;
+  installs?: number;
+  is_paid?: boolean | null;
+  name?: string;
+  price?: number | null;
+  private?: boolean;
+  rating_avg?: number | null;
+  rating_count?: number;
 }
 
 export interface AppCatalogMeta {
@@ -258,7 +277,7 @@ export interface AppCatalogMeta {
 export interface AppCatalogResponse {
   capability?: AppSelectOption | null;
   category?: AppSelectOption | null;
-  data?: Array<AppBaseModel>;
+  data?: Array<AppCatalogItem>;
   groups?: Array<AppCatalogGroup>;
   meta?: AppCatalogMeta | null;
   pagination?: AppPagination | null;
@@ -357,7 +376,7 @@ export interface AppSearchFilters {
 }
 
 export interface AppSearchResponse {
-  data?: Array<AppBaseModel>;
+  data?: Array<AppCatalogItem>;
   filters: AppSearchFilters;
   pagination: AppPagination;
 }
@@ -2116,7 +2135,7 @@ export interface SavePayPalPaymentDetailsRequest {
 
 export interface SearchConversationsResponse {
   current_page: number;
-  items: Array<Record<string, unknown>>;
+  items: Array<Conversation>;
   per_page: number;
   total_pages: number;
 }
@@ -2729,8 +2748,17 @@ export interface UserProfile {
 }
 
 export interface UserProfileResponse {
+  company?: string | null;
+  created_at?: string | null;
   data_protection_level?: string | null;
+  email?: string | null;
+  job?: string | null;
   migration_status?: Record<string, unknown> | null;
+  motivation?: string | null;
+  name?: string | null;
+  time_zone?: string | null;
+  uid: string;
+  use_case?: string | null;
   [key: string]: unknown;
 }
 
@@ -2872,6 +2900,7 @@ export interface OmiApiSchemas {
   "AppCapabilityAction": AppCapabilityAction;
   "AppCapabilityResponse": AppCapabilityResponse;
   "AppCatalogGroup": AppCatalogGroup;
+  "AppCatalogItem": AppCatalogItem;
   "AppCatalogMeta": AppCatalogMeta;
   "AppCatalogResponse": AppCatalogResponse;
   "AppCreateResponse": AppCreateResponse;


### PR DESCRIPTION
## Summary
- Hydrate `/v1/conversations/search` index hits into canonical `Conversation` rows before returning them to desktop, and re-filter hydrated locked rows to preserve the search privacy invariant when Typesense lags Firestore.
- Tighten app-client contracts for sibling desktop decode risks: user profile now models/injects `uid`, people timestamps remain optional, assistant settings decode lossy per known section while preserving future sections, and app catalog/search list routes use a desktop-safe DTO without narrowing shared app detail responses.
- Regenerated the app-client OpenAPI and added backend/Swift regression coverage plus a desktop route contract guard against free-form response items.

## Root Cause
Desktop search decoded `ConversationSearchResult.items` as canonical `ServerConversation` rows, but the backend OpenAPI and endpoint returned raw Typesense documents shaped as partial search-index records. In particular, indexed transcript segment objects could omit required canonical fields, causing the Swift decoder error shown in the UI.

## Verification
- `cd backend && uv run --with pytest --with pytest-asyncio --with-requirements requirements.txt python -m pytest tests/unit/test_desktop_rest_inventory.py tests/unit/test_conversation_hybrid_search.py tests/unit/test_app_catalog_detail_response_contract.py tests/unit/test_assistant_settings_response_models.py tests/unit/test_user_profile_people_response_models.py tests/unit/test_app_client_response_models.py -q` -> 37 passed
- `cd desktop/macos && xcrun swift test --package-path Desktop --filter ServerConversationDecodingTests --filter APIClientAssistantSettingsTests --filter APIClientUserProfilePeopleDecodingTests --filter ServerAppCatalogDecodingTests` -> 17 passed
- `cd backend && ./scripts/openapi_runner.sh scripts/generate_swift_openapi_types.py --check`
- `git diff --check`
- Pre-push hook passed, including backend typecheck/unit hooks, OpenAPI contract check, desktop changelog validation, and desktop Swift build.

## Review
- Subagents implemented sibling-risk slices for profile/people, assistant settings, and app catalog/search.
- Review agents found and I fixed two P1s before opening: preserving full `/v1/apps/{app_id}` shared-client fields, and re-filtering locked conversations after search hydration.
- Final review pass reported no remaining P0/P1 findings.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9175?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

