### PR TITLE
fix(backend): pusher logs surfaced as ERROR severity — route by level (#9138)

### DIFF
--- a/backend/pusher/logging_config.py
+++ b/backend/pusher/logging_config.py
@@ -1,0 +1,26 @@
+"""Severity-aware logging setup for the pusher service.
+
+GKE/Cloud Run's logging agent infers Cloud Logging severity from the stream a
+line is written to: stdout -> INFO, stderr -> ERROR. Python's
+``logging.basicConfig()`` sends every record to stderr, so normal INFO request
+logs surface as ERROR severity and bury real errors in the noise (issue #9138).
+
+Split the streams by level so severity is reported correctly: INFO/WARNING go to
+stdout, ERROR/CRITICAL go to stderr.
+"""
+
+import logging
+import sys
+
+
+def configure_logging(level: int = logging.INFO) -> None:
+    """Configure root logging to route records to stdout/stderr by level.
+
+    Records below ERROR go to stdout; ERROR and above go to stderr, so the
+    Cloud Logging agent tags each line with the correct severity.
+    """
+    stdout_handler = logging.StreamHandler(sys.stdout)
+    stdout_handler.addFilter(lambda record: record.levelno < logging.ERROR)
+    stderr_handler = logging.StreamHandler(sys.stderr)
+    stderr_handler.setLevel(logging.ERROR)
+    logging.basicConfig(level=level, handlers=[stdout_handler, stderr_handler])

--- a/backend/pusher/main.py
+++ b/backend/pusher/main.py
@@ -4,7 +4,9 @@ import os
 from contextlib import asynccontextmanager
 from typing import Any, AsyncIterator
 
-logging.basicConfig(level=logging.INFO)
+from pusher.logging_config import configure_logging
+
+configure_logging(logging.INFO)
 
 import firebase_admin
 from fastapi import FastAPI

--- a/backend/tests/unit/test_pusher_log_severity.py
+++ b/backend/tests/unit/test_pusher_log_severity.py
@@ -1,0 +1,57 @@
+"""Regression test for issue #9138: pusher INFO logs surfaced as ERROR severity.
+
+``logging.basicConfig()`` sends every record to stderr, which the GKE/Cloud Run
+logging agent tags as ERROR. ``configure_logging`` must split records by level so
+INFO/WARNING go to stdout and ERROR/CRITICAL go to stderr.
+"""
+
+import logging
+import sys
+
+from pusher.logging_config import configure_logging
+
+
+def _reset_root_logging():
+    root = logging.getLogger()
+    saved = root.handlers[:]
+    saved_level = root.level
+    for handler in saved:
+        root.removeHandler(handler)
+    return saved, saved_level
+
+
+def _restore_root_logging(saved, saved_level):
+    root = logging.getLogger()
+    for handler in root.handlers[:]:
+        root.removeHandler(handler)
+    for handler in saved:
+        root.addHandler(handler)
+    root.setLevel(saved_level)
+
+
+def test_configure_logging_routes_by_severity():
+    saved, saved_level = _reset_root_logging()
+    try:
+        configure_logging(logging.INFO)
+        handlers = logging.getLogger().handlers
+        streams = {h.stream for h in handlers if isinstance(h, logging.StreamHandler)}
+        assert sys.stdout in streams
+        assert sys.stderr in streams
+
+        stdout_handler = next(h for h in handlers if getattr(h, "stream", None) is sys.stdout)
+        stderr_handler = next(h for h in handlers if getattr(h, "stream", None) is sys.stderr)
+
+        info = logging.LogRecord("t", logging.INFO, __file__, 1, "hi", None, None)
+        warning = logging.LogRecord("t", logging.WARNING, __file__, 1, "hi", None, None)
+        error = logging.LogRecord("t", logging.ERROR, __file__, 1, "boom", None, None)
+
+        # INFO/WARNING belong on stdout, never stderr.
+        assert stdout_handler.filter(info)
+        assert stdout_handler.filter(warning)
+        assert not stdout_handler.filter(error)
+
+        # ERROR belongs on stderr only.
+        assert error.levelno >= stderr_handler.level
+        assert info.levelno < stderr_handler.level
+    finally:
+        _restore_root_logging(saved, saved_level)


### PR DESCRIPTION
## Bug (#9138)
Prod monitoring is noisy: pusher emits normal **INFO request logs at ERROR severity** in Cloud Logging, drowning real errors and eroding trust in alerts.

## Root cause
`backend/pusher/main.py` configured logging with `logging.basicConfig(level=logging.INFO)`. `basicConfig`'s `StreamHandler` defaults to **stderr**, so *every* record — INFO, WARNING, ERROR — is written to stderr. GKE/Cloud Run's logging agent infers severity from the stream (stdout→INFO, stderr→ERROR), so all pusher logs get tagged `ERROR`.

## Fix
Add `pusher/logging_config.configure_logging()` that splits streams by level:
- INFO/WARNING → **stdout** (tagged INFO)
- ERROR/CRITICAL → **stderr** (tagged ERROR)

Wired into pusher startup in place of the bare `basicConfig`. Behavior otherwise unchanged (same level, same output, all lines still logged).

## Verification
- New hermetic regression test `tests/unit/test_pusher_log_severity.py` asserts the stdout handler accepts INFO/WARNING and rejects ERROR, and the stderr handler is ERROR-level. Passes locally.
- Runtime check: `logger.info(...)` lands on stdout, `logger.error(...)` on stderr:
  ```
  --- stdout ---
  INFO:pusher.demo:normal request line
  --- stderr ---
  ERROR:pusher.demo:real error line
  ```

Scoped to the service named in the issue; the broader alert-suppression / control-plane items in #9138 are separate infra work.

🤖 automated by hourly watchdog; opened for review, not merged.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9177?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

