### PR TITLE
[codex] Fix meeting-ended conversation finalization

### DIFF
--- a/desktop/macos/Desktop/Sources/AppState.swift
+++ b/desktop/macos/Desktop/Sources/AppState.swift
@@ -274,6 +274,7 @@ class AppState: ObservableObject {
   var captureGateInFlight = false
   var captureReconcilePending = false
   var pendingCoreAudioCaptureRecoveryReason: String?
+  var meetingEndFinalizationInProgress = false
   @Published var isAwaitingMeeting = false
 
   var effectiveSystemAudioMode: AssistantSettings.SystemAudioCaptureMode {

--- a/desktop/macos/Desktop/Sources/AppState/AppState+Transcription.swift
+++ b/desktop/macos/Desktop/Sources/AppState/AppState+Transcription.swift
@@ -21,6 +21,7 @@ extension AppState {
       sttCloudFallbackTried = false
       forceLocalSTTForSession = false
     }
+    meetingEndFinalizationInProgress = false
 
     // Paywall hard-stop: every code path that enables the mic + WS streaming
     // funnels through here, including auto-restart from sleep and toggle
@@ -505,6 +506,22 @@ extension AppState {
       }
     }
 
+    if !meetingEndFinalizationInProgress,
+      MeetingConversationBoundaryPolicy.shouldFinishConversation(
+        mode: mode,
+        shouldCapture: shouldCapture,
+        segmentCount: totalSegmentCount,
+        hasSpeakerSegments: !speakerSegments.isEmpty
+      )
+    {
+      meetingEndFinalizationInProgress = true
+      log("Transcription: Meeting ended — finishing conversation and waiting for the next meeting")
+      Task { @MainActor in
+        defer { self.meetingEndFinalizationInProgress = false }
+        _ = await self.finishConversation(finalizationReason: .meetingEnded)
+      }
+    }
+
     captureGateInFlight = false
     if let recoveryReason = pendingCoreAudioCaptureRecoveryReason {
       pendingCoreAudioCaptureRecoveryReason = nil
@@ -801,13 +818,15 @@ extension AppState {
 
   /// Finish the current conversation and keep recording for a new one.
   /// Disconnects the WebSocket (triggers backend conversation processing) then reconnects.
-  func finishConversation() async -> FinishConversationResult {
+  func finishConversation(
+    finalizationReason: TranscriptionFinalizationReason = .finishAndContinue
+  ) async -> FinishConversationResult {
     guard totalSegmentCount > 0 || !speakerSegments.isEmpty else {
       log("Transcription: No segments to finish")
       return .discarded
     }
 
-    log("Transcription: Finishing conversation — disconnecting WebSocket to trigger backend processing")
+    log("Transcription: Finishing conversation — reason=\(finalizationReason.rawValue)")
 
     // Capture state before rotation — memory_created event for this conversation
     // may arrive on the new WebSocket after currentSessionId and recordingStartTime have changed.
@@ -834,7 +853,7 @@ extension AppState {
     // (backend will process it; memory_created event may arrive on the new session's WebSocket)
     if let sessionId = sessionToFinalize {
       do {
-        try await TranscriptionStorage.shared.finishSession(id: sessionId, reason: .finishAndContinue)
+        try await TranscriptionStorage.shared.finishSession(id: sessionId, reason: finalizationReason)
         log("Transcription: Finished DB session \(sessionId) before reconnect")
       } catch {
         logError("Transcription: Failed to finish DB session \(sessionId)", error: error)
@@ -871,7 +890,7 @@ extension AppState {
       Task {
         await ConversationFinalizationService.shared.finalizeSession(
           id: sessionId,
-          reason: .finishAndContinue,
+          reason: finalizationReason,
           allowCloudForceProcess: !finishedUsesLocalSTT
         )
       }
@@ -1040,6 +1059,7 @@ extension AppState {
     captureReconcilePending = false
     pendingCoreAudioCaptureRecoveryReason = nil
     isAwaitingMeeting = false
+    meetingEndFinalizationInProgress = false
 
     // Stop system audio capture first (if available)
     if #available(macOS 14.4, *) {
@@ -1114,6 +1134,7 @@ extension AppState {
     LiveNotesMonitor.shared.clear()
     recordingStartTime = nil
     currentSessionId = nil
+    meetingEndFinalizationInProgress = false
 
     // Track transcription stopped
     AnalyticsManager.shared.transcriptionStopped(wordCount: totalWordCount)

--- a/desktop/macos/Desktop/Sources/AppState/AppState+Transcription.swift
+++ b/desktop/macos/Desktop/Sources/AppState/AppState+Transcription.swift
@@ -450,9 +450,14 @@ extension AppState {
     // The meeting detector runs only in "Only during meetings" mode.
     if mode == .onlyDuringMeetings {
       if meetingDetector == nil {
-        let detector = MeetingDetector(onChange: { [weak self] _ in
-          Task { @MainActor in await self?.reconcileCapture() }
-        })
+        let detector = MeetingDetector(
+          onInitialStateObserved: { [weak self] in
+            Task { @MainActor in await self?.reconcileCapture() }
+          },
+          onChange: { [weak self] _ in
+            Task { @MainActor in await self?.reconcileCapture() }
+          }
+        )
         meetingDetector = detector
         detector.start()
       }
@@ -461,11 +466,17 @@ extension AppState {
       meetingDetector = nil
     }
 
+    let meetingStateReady = mode != .onlyDuringMeetings || meetingDetector?.hasObservedState == true
     let meetingActive = meetingDetector?.isMeetingActive ?? false
     // Only during meetings → capture (mic + system) only while in a call. Always/Never → the mic
     // runs continuously (system audio still respects the mode below).
     let shouldCapture = mode != .onlyDuringMeetings || meetingActive
     isAwaitingMeeting = mode == .onlyDuringMeetings && !meetingActive
+
+    guard meetingStateReady else {
+      log("Transcription: waiting for meeting detector before changing capture state")
+      return
+    }
 
     captureGateInFlight = true
 
@@ -509,6 +520,7 @@ extension AppState {
     if !meetingEndFinalizationInProgress,
       MeetingConversationBoundaryPolicy.shouldFinishConversation(
         mode: mode,
+        meetingStateReady: meetingStateReady,
         shouldCapture: shouldCapture,
         segmentCount: totalSegmentCount,
         hasSpeakerSegments: !speakerSegments.isEmpty
@@ -518,6 +530,16 @@ extension AppState {
       log("Transcription: Meeting ended — finishing conversation and waiting for the next meeting")
       Task { @MainActor in
         defer { self.meetingEndFinalizationInProgress = false }
+        guard MeetingConversationBoundaryPolicy.shouldFinishConversation(
+          mode: self.effectiveSystemAudioMode,
+          meetingStateReady: self.meetingDetector?.hasObservedState == true,
+          shouldCapture: self.meetingDetector?.isMeetingActive == true,
+          segmentCount: self.totalSegmentCount,
+          hasSpeakerSegments: !self.speakerSegments.isEmpty
+        ) else {
+          log("Transcription: skipped meeting-ended finalization because meeting state changed")
+          return
+        }
         _ = await self.finishConversation(finalizationReason: .meetingEnded)
       }
     }

--- a/desktop/macos/Desktop/Sources/AppState/MeetingConversationBoundaryPolicy.swift
+++ b/desktop/macos/Desktop/Sources/AppState/MeetingConversationBoundaryPolicy.swift
@@ -3,11 +3,13 @@ import Foundation
 enum MeetingConversationBoundaryPolicy {
   static func shouldFinishConversation(
     mode: AssistantSettings.SystemAudioCaptureMode,
+    meetingStateReady: Bool,
     shouldCapture: Bool,
     segmentCount: Int,
     hasSpeakerSegments: Bool
   ) -> Bool {
     mode == .onlyDuringMeetings
+      && meetingStateReady
       && !shouldCapture
       && (segmentCount > 0 || hasSpeakerSegments)
   }

--- a/desktop/macos/Desktop/Sources/AppState/MeetingConversationBoundaryPolicy.swift
+++ b/desktop/macos/Desktop/Sources/AppState/MeetingConversationBoundaryPolicy.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+enum MeetingConversationBoundaryPolicy {
+  static func shouldFinishConversation(
+    mode: AssistantSettings.SystemAudioCaptureMode,
+    shouldCapture: Bool,
+    segmentCount: Int,
+    hasSpeakerSegments: Bool
+  ) -> Bool {
+    mode == .onlyDuringMeetings
+      && !shouldCapture
+      && (segmentCount > 0 || hasSpeakerSegments)
+  }
+}

--- a/desktop/macos/Desktop/Sources/MeetingDetector.swift
+++ b/desktop/macos/Desktop/Sources/MeetingDetector.swift
@@ -15,11 +15,15 @@ final class MeetingDetector {
 
     /// Current meeting state. Updated on the main actor by `applyDetected(_:)`.
     private(set) var isMeetingActive: Bool = false
+    /// True after at least one async probe has reported. Until then, `isMeetingActive == false`
+    /// means "unknown", not "no meeting".
+    private(set) var hasObservedState: Bool = false
 
     private let pollInterval: TimeInterval
     private let offGracePeriod: TimeInterval
     private let isMeetingNow: () -> Bool
     private let now: () -> Date
+    private let onInitialStateObserved: () -> Void
     private let onChange: (Bool) -> Void
 
     private var timer: Timer?
@@ -35,6 +39,7 @@ final class MeetingDetector {
     ///   - isMeetingNow: conferencing-call probe (injectable for tests). Default: a native or browser
     ///     app using the mic (macOS 14.4+), or a browser call window (window-title fallback).
     ///   - now: clock (injectable for tests).
+    ///   - onInitialStateObserved: called on the main actor once the first async probe completes.
     ///   - onChange: called on the main actor whenever `isMeetingActive` flips.
     init(
         pollInterval: TimeInterval = 4.0,
@@ -44,12 +49,14 @@ final class MeetingDetector {
             return ConferencingApps.browserCallWindowPresent()
         },
         now: @escaping () -> Date = { Date() },
+        onInitialStateObserved: @escaping () -> Void = {},
         onChange: @escaping (Bool) -> Void
     ) {
         self.pollInterval = pollInterval
         self.offGracePeriod = offGracePeriod
         self.isMeetingNow = isMeetingNow
         self.now = now
+        self.onInitialStateObserved = onInitialStateObserved
         self.onChange = onChange
     }
 
@@ -113,6 +120,9 @@ final class MeetingDetector {
     /// Apply a boolean detection result, honoring the off-hysteresis. Exposed for tests; normally
     /// driven by the poll timer and workspace notifications via `tick()`.
     func applyDetected(_ detected: Bool) {
+        let hadObservedState = hasObservedState
+        hasObservedState = true
+
         if detected {
             // Meeting present: cancel any pending-off and ensure we're active.
             pendingOffDeadline = nil
@@ -130,6 +140,10 @@ final class MeetingDetector {
         } else {
             // Already inactive and still no meeting.
             pendingOffDeadline = nil
+        }
+
+        if !hadObservedState {
+            onInitialStateObserved()
         }
     }
 

--- a/desktop/macos/Desktop/Sources/Rewind/Core/TranscriptionModels.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/TranscriptionModels.swift
@@ -20,6 +20,7 @@ enum TranscriptionFinalizationStrategy: String, Codable, CaseIterable {
 enum TranscriptionFinalizationReason: String, Codable, CaseIterable {
     case userStop = "user_stop"
     case finishAndContinue = "finish_and_continue"
+    case meetingEnded = "meeting_ended"
     case maxDurationRotation = "max_duration_rotation"
     case crashRecovery = "crash_recovery"
     case retry = "retry"

--- a/desktop/macos/Desktop/Tests/MeetingGatedSystemAudioTests.swift
+++ b/desktop/macos/Desktop/Tests/MeetingGatedSystemAudioTests.swift
@@ -165,3 +165,71 @@ final class SystemAudioCaptureModeSettingsTests: XCTestCase {
         XCTAssertEqual(AssistantSettings.shared.systemAudioCaptureMode, .onlyDuringMeetings)
     }
 }
+
+// MARK: - Meeting conversation boundary
+
+final class MeetingConversationBoundaryPolicyTests: XCTestCase {
+
+    func testMeetingGateClosingWithSegmentsFinishesConversation() {
+        XCTAssertTrue(
+            MeetingConversationBoundaryPolicy.shouldFinishConversation(
+                mode: .onlyDuringMeetings,
+                shouldCapture: false,
+                segmentCount: 12,
+                hasSpeakerSegments: false
+            )
+        )
+    }
+
+    func testMeetingGateClosingWithOnlyInMemorySegmentsFinishesConversation() {
+        XCTAssertTrue(
+            MeetingConversationBoundaryPolicy.shouldFinishConversation(
+                mode: .onlyDuringMeetings,
+                shouldCapture: false,
+                segmentCount: 0,
+                hasSpeakerSegments: true
+            )
+        )
+    }
+
+    func testWaitingForFirstMeetingDoesNotFinishEmptySession() {
+        XCTAssertFalse(
+            MeetingConversationBoundaryPolicy.shouldFinishConversation(
+                mode: .onlyDuringMeetings,
+                shouldCapture: false,
+                segmentCount: 0,
+                hasSpeakerSegments: false
+            )
+        )
+    }
+
+    func testNonMeetingModesDoNotUseMeetingEndBoundary() {
+        XCTAssertFalse(
+            MeetingConversationBoundaryPolicy.shouldFinishConversation(
+                mode: .always,
+                shouldCapture: false,
+                segmentCount: 12,
+                hasSpeakerSegments: true
+            )
+        )
+        XCTAssertFalse(
+            MeetingConversationBoundaryPolicy.shouldFinishConversation(
+                mode: .never,
+                shouldCapture: false,
+                segmentCount: 12,
+                hasSpeakerSegments: true
+            )
+        )
+    }
+
+    func testActiveMeetingDoesNotFinishConversation() {
+        XCTAssertFalse(
+            MeetingConversationBoundaryPolicy.shouldFinishConversation(
+                mode: .onlyDuringMeetings,
+                shouldCapture: true,
+                segmentCount: 12,
+                hasSpeakerSegments: true
+            )
+        )
+    }
+}

--- a/desktop/macos/Desktop/Tests/MeetingGatedSystemAudioTests.swift
+++ b/desktop/macos/Desktop/Tests/MeetingGatedSystemAudioTests.swift
@@ -74,10 +74,32 @@ final class MeetingDetectorTests: XCTestCase {
         var changes = [Bool]()
         let detector = makeDetector(onChange: { changes.append($0) })
 
+        XCTAssertFalse(detector.hasObservedState)
         detector.applyDetected(true)
 
+        XCTAssertTrue(detector.hasObservedState)
         XCTAssertTrue(detector.isMeetingActive)
         XCTAssertEqual(changes, [true])
+    }
+
+    func testInitialInactiveProbeMarksStateObservedWithoutMeetingChange() {
+        var initialObservedCount = 0
+        var changes = [Bool]()
+        let detector = MeetingDetector(
+            pollInterval: 4.0,
+            offGracePeriod: 8.0,
+            now: { [weak self] in self?.now ?? Date(timeIntervalSince1970: 0) },
+            onInitialStateObserved: { initialObservedCount += 1 },
+            onChange: { changes.append($0) }
+        )
+
+        detector.applyDetected(false)
+        detector.applyDetected(false)
+
+        XCTAssertTrue(detector.hasObservedState)
+        XCTAssertFalse(detector.isMeetingActive)
+        XCTAssertEqual(initialObservedCount, 1)
+        XCTAssertEqual(changes, [], "initial inactive readiness is not a meeting state change")
     }
 
     func testTurningOffRequiresSustainedGracePeriod() {
@@ -174,6 +196,7 @@ final class MeetingConversationBoundaryPolicyTests: XCTestCase {
         XCTAssertTrue(
             MeetingConversationBoundaryPolicy.shouldFinishConversation(
                 mode: .onlyDuringMeetings,
+                meetingStateReady: true,
                 shouldCapture: false,
                 segmentCount: 12,
                 hasSpeakerSegments: false
@@ -185,6 +208,7 @@ final class MeetingConversationBoundaryPolicyTests: XCTestCase {
         XCTAssertTrue(
             MeetingConversationBoundaryPolicy.shouldFinishConversation(
                 mode: .onlyDuringMeetings,
+                meetingStateReady: true,
                 shouldCapture: false,
                 segmentCount: 0,
                 hasSpeakerSegments: true
@@ -196,6 +220,7 @@ final class MeetingConversationBoundaryPolicyTests: XCTestCase {
         XCTAssertFalse(
             MeetingConversationBoundaryPolicy.shouldFinishConversation(
                 mode: .onlyDuringMeetings,
+                meetingStateReady: true,
                 shouldCapture: false,
                 segmentCount: 0,
                 hasSpeakerSegments: false
@@ -207,6 +232,7 @@ final class MeetingConversationBoundaryPolicyTests: XCTestCase {
         XCTAssertFalse(
             MeetingConversationBoundaryPolicy.shouldFinishConversation(
                 mode: .always,
+                meetingStateReady: true,
                 shouldCapture: false,
                 segmentCount: 12,
                 hasSpeakerSegments: true
@@ -215,6 +241,7 @@ final class MeetingConversationBoundaryPolicyTests: XCTestCase {
         XCTAssertFalse(
             MeetingConversationBoundaryPolicy.shouldFinishConversation(
                 mode: .never,
+                meetingStateReady: true,
                 shouldCapture: false,
                 segmentCount: 12,
                 hasSpeakerSegments: true
@@ -226,7 +253,20 @@ final class MeetingConversationBoundaryPolicyTests: XCTestCase {
         XCTAssertFalse(
             MeetingConversationBoundaryPolicy.shouldFinishConversation(
                 mode: .onlyDuringMeetings,
+                meetingStateReady: true,
                 shouldCapture: true,
+                segmentCount: 12,
+                hasSpeakerSegments: true
+            )
+        )
+    }
+
+    func testUnreadyMeetingStateDoesNotFinishExistingConversation() {
+        XCTAssertFalse(
+            MeetingConversationBoundaryPolicy.shouldFinishConversation(
+                mode: .onlyDuringMeetings,
+                meetingStateReady: false,
+                shouldCapture: false,
                 segmentCount: 12,
                 hasSpeakerSegments: true
             )

--- a/desktop/macos/Desktop/Tests/TranscriptionFinalizationStateMachineTests.swift
+++ b/desktop/macos/Desktop/Tests/TranscriptionFinalizationStateMachineTests.swift
@@ -207,6 +207,24 @@ final class TranscriptionFinalizationStateMachineTests: XCTestCase {
         XCTAssertNil(session.finalizationCompletedAt)
     }
 
+    func testMeetingEndedFinalizationReasonPersists() async throws {
+        let sessionId = try await TranscriptionStorage.shared.startSession(
+            source: "desktop",
+            finalizationStrategy: .localSegments
+        )
+
+        try await TranscriptionStorage.shared.finishSession(
+            id: sessionId,
+            reason: .meetingEnded
+        )
+
+        let storedSession = try await TranscriptionStorage.shared.getSession(id: sessionId)
+        let session = try XCTUnwrap(storedSession)
+        XCTAssertEqual(session.status, .pendingUpload)
+        XCTAssertEqual(session.finalizationStrategy, .localSegments)
+        XCTAssertEqual(session.finalizationReason, .meetingEnded)
+    }
+
     func testSessionsNeedingFinalizationIncludesRetryableWorkOnly() async throws {
         let recordingId = try await TranscriptionStorage.shared.startSession(source: "desktop")
 

--- a/desktop/macos/changelog/unreleased/20260706-meeting-ended-finalization.json
+++ b/desktop/macos/changelog/unreleased/20260706-meeting-ended-finalization.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed meeting-only listening so ended calls are saved as full conversations instead of staying stuck locally"
+}


### PR DESCRIPTION
## Summary
- finish and finalize meeting-only recordings when the meeting detector flips inactive after transcript segments exist
- preserve listening-on behavior by rotating into a fresh waiting session for the next meeting
- add `meeting_ended` finalization state, regression tests, and a desktop changelog fragment

## Root cause
In meetings-only mode the detector only paused mic/system capture on meeting end. The active transcription session stayed in `recording` with no `finishedAt` or backend id, so the full call remained local while only an earlier crash-recovered short session appeared in the conversation list.

## Verification
- `xcrun swift test --package-path desktop/macos/Desktop --filter MeetingConversationBoundaryPolicyTests`
- `xcrun swift test --package-path desktop/macos/Desktop --filter TranscriptionFinalizationStateMachineTests/testMeetingEndedFinalizationReasonPersists`
- `python3 desktop/macos/scripts/check-sources-root-layout.py`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9179?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

