### PR TITLE
fix(app): handle missing app reviews

### DIFF
--- a/app/lib/backend/schema/app.dart
+++ b/app/lib/backend/schema/app.dart
@@ -399,7 +399,7 @@ class App {
       capabilities: generated.capabilities.toSet(),
       chatPrompt: generated.chatPrompt,
       conversationPrompt: generated.memoryPrompt,
-      reviews: generated.reviews.map(AppReview.fromGenerated).toList(),
+      reviews: generated.reviews?.map(AppReview.fromGenerated).toList() ?? [],
       userReview: generated.userReview == null ? null : AppReview.fromGenerated(generated.userReview!),
       deleted: false,
       enabled: generated.enabled,

--- a/app/test/backend/app_schema_test.dart
+++ b/app/test/backend/app_schema_test.dart
@@ -1,0 +1,74 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:omi/backend/schema/app.dart';
+
+Map<String, dynamic> _appJson({Object? reviews = _missingReviews}) {
+  final json = <String, dynamic>{
+    'id': 'app-1',
+    'name': 'Review parser',
+    'author': 'Omi',
+    'description': 'Parses reviews',
+    'image': 'https://example.com/icon.png',
+    'category': 'productivity',
+    'capabilities': ['chat'],
+    'rating_count': 0,
+    'enabled': true,
+    'approved': true,
+    'private': false,
+  };
+
+  if (!identical(reviews, _missingReviews)) {
+    json['reviews'] = reviews;
+  }
+
+  return json;
+}
+
+const _missingReviews = Object();
+
+void main() {
+  group('App review parsing', () {
+    test('defaults missing reviews to an empty list', () {
+      final app = App.fromJson(_appJson());
+
+      expect(app.reviews, isEmpty);
+    });
+
+    test('defaults null reviews to an empty list', () {
+      final app = App.fromJson(_appJson(reviews: null));
+
+      expect(app.reviews, isEmpty);
+    });
+
+    test('keeps empty reviews as an empty list', () {
+      final app = App.fromJson(_appJson(reviews: []));
+
+      expect(app.reviews, isEmpty);
+    });
+
+    test('parses present reviews', () {
+      final app = App.fromJson(
+        _appJson(
+          reviews: [
+            {
+              'uid': 'review-1',
+              'rated_at': '2026-07-01T12:00:00.000Z',
+              'score': 5.0,
+              'review': 'Helpful',
+              'username': 'Reviewer',
+              'response': 'Thanks',
+              'responded_at': '2026-07-02T12:00:00.000Z',
+            },
+          ],
+        ),
+      );
+
+      expect(app.reviews, hasLength(1));
+      expect(app.reviews.single.uid, 'review-1');
+      expect(app.reviews.single.score, 5.0);
+      expect(app.reviews.single.review, 'Helpful');
+      expect(app.reviews.single.username, 'Reviewer');
+      expect(app.reviews.single.response, 'Thanks');
+      expect(app.reviews.single.respondedAt, isNotNull);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Restores the null-safe mapping from #9146 so generated app details with omitted/null reviews compile and default to an empty list.
- Adds a focused Flutter regression test for missing, null, empty, and present reviews in app schema parsing.

## Context
#8895 made generated app reviews nullable, while the adapter still called `.map` directly. #9147 reverted the prior one-line fix and restored the mobile Flutter compile failure.

## Test Plan
- [x] Git pre-commit Dart formatter ran while committing.
- [ ] Local Flutter test/build not run: `flutter` is not installed/available in this Hermes shell PATH.

References: #8895, #9146, #9147

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9182?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

