### PR TITLE
fix(web): guard app-detail image + capabilities on h.omi.me frontend (#7237)

### DIFF
--- a/web/frontend/src/app/apps/[id]/page.tsx
+++ b/web/frontend/src/app/apps/[id]/page.tsx
@@ -156,8 +156,8 @@ function getPlatformLink(userAgent: string) {
   return isAndroid
     ? 'https://play.google.com/store/apps/details?id=com.friend.ios'
     : isIOS
-    ? 'https://apps.apple.com/us/app/friend-ai-wearable/id6502156163'
-    : 'https://omi.me';
+      ? 'https://apps.apple.com/us/app/friend-ai-wearable/id6502156163'
+      : 'https://omi.me';
 }
 
 // Helper function to format date
@@ -213,7 +213,7 @@ export default async function PluginDetailView(props: {
             <div className="lg:col-span-2">
               <div className="relative aspect-square overflow-hidden rounded-[1rem] bg-[#1A1F2E]">
                 <Image
-                  src={plugin.image}
+                  src={plugin.image || '/logo.webp'}
                   alt={plugin.name}
                   className="h-full w-full object-cover transition-transform duration-300 hover:scale-105"
                   width={500}
@@ -346,7 +346,7 @@ export default async function PluginDetailView(props: {
                   <div className="text-sm font-medium text-gray-400">Capabilities</div>
                 </div>
                 <div className="mt-2 flex flex-wrap gap-2 pl-7">
-                  {Array.from(plugin.capabilities).map((cap) => (
+                  {Array.from(plugin.capabilities ?? []).map((cap) => (
                     <span
                       key={cap}
                       className="rounded-full bg-[#1A1F2E] px-3 py-1 text-sm text-white"


### PR DESCRIPTION
## Bug (#7237)

App detail pages on **h.omi.me** crash with:

> Application error: a server-side exception has occurred (see the server logs for more information).

Repro: https://h.omi.me/apps/ → click any app → white error screen.

## Root cause

`web/frontend/src/app/apps/[id]/page.tsx` renders two fields with no fallback:

- **Line 216** `<Image src={plugin.image}>` — `next/image` throws during SSR when `src` is empty/falsy.
- **Line 349** `Array.from(plugin.capabilities)` — `Array.from(undefined)` throws `undefined is not iterable` when an app has no `capabilities`.

`getAppById` returns raw `JSON.parse(...)` data with no defaults, so both fields can be missing. This file's sibling components already guard them (`plugin.image || 'https://via.placeholder.com/...'` in the plugin cards; `Array.isArray(plugin.capabilities)` in `getAppsByCategory`), but the detail page's hero image and capabilities list were not.

**Why it wasn't already fixed:** PR #7730 fixed this exact bug but only in `web/app/src/app/(public)/apps/[id]/page.tsx`. The page actually serving `h.omi.me` is the `web/frontend` Cloud Run service (`.github/workflows/gcp_frontend.yml` builds/deploys `web/frontend`), which was still unguarded.

## Fix

Mirror the accepted #7730 guard in `web/frontend`:
- `src={plugin.image || '/logo.webp'}` — local asset (exists in `web/frontend/public/`) so the fallback itself can't fail.
- `Array.from(plugin.capabilities ?? [])`.

Two null guards, no behavior change for valid data. Type-safe under `strict` (`string || string → string`, `string[] ?? [] → string[]`).

## Verification

- Reproduced the mechanism: `Array.from(undefined)` → `undefined is not iterable`; `Array.from(undefined ?? [])` → `[]`. Image fallback yields a non-empty src while preserving real image URLs.
- Diff is 2 substantive lines (+ one pre-existing ternary re-indented by the repo Prettier pre-commit hook).
- Could not run `next build` locally (no `node_modules` in the worktree); CI runs the real frontend build + lint.

🤖 automated by hourly watchdog. This is a live prod bug (h.omi.me app-detail pages crash for any app missing an image or capabilities); opened under the prod auto-merge gate — merging deploys the `frontend` Cloud Run service.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9185?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

