### PR TITLE
desktop: redesigned Home — inline chat, Connect tray, suggested questions

### DIFF
--- a/desktop/macos/Desktop/Sources/AppState.swift
+++ b/desktop/macos/Desktop/Sources/AppState.swift
@@ -665,6 +665,14 @@ extension Notification.Name {
   static let screenCaptureKitBroken = Notification.Name("screenCaptureKitBroken")
   /// Posted to show the "Try asking" popup centered over the full window
   static let showTryAskingPopup = Notification.Name("showTryAskingPopup")
+  /// Posted (automation bridge) to open the inline chat on the redesigned Home
+  static let homeStageOpenChat = Notification.Name("homeStageOpenChat")
+  /// Posted (automation bridge) to toggle the Connect tray on the redesigned Home
+  static let homeStageToggleConnect = Notification.Name("homeStageToggleConnect")
+  /// Posted (automation bridge) to collapse the redesigned Home back to the hub
+  static let homeStageClose = Notification.Name("homeStageClose")
+  /// Posted (automation bridge) to send a query through the Home ask bar. userInfo["query"] = text.
+  static let homeStageAsk = Notification.Name("homeStageAsk")
   /// Posted to show the over-usage-limit popup. userInfo["reason"] = "transcription" | "chat" | "floating_bar".
   static let showUsageLimitPopup = Notification.Name("showUsageLimitPopup")
   /// Posted to navigate to Rewind settings

--- a/desktop/macos/Desktop/Sources/AppState.swift
+++ b/desktop/macos/Desktop/Sources/AppState.swift
@@ -673,6 +673,8 @@ extension Notification.Name {
   static let homeStageClose = Notification.Name("homeStageClose")
   /// Posted (automation bridge) to send a query through the Home ask bar. userInfo["query"] = text.
   static let homeStageAsk = Notification.Name("homeStageAsk")
+  /// Posted (automation bridge) to stage a file in the Home ask bar. userInfo["path"] = file path.
+  static let homeStageAttach = Notification.Name("homeStageAttach")
   /// Posted to show the over-usage-limit popup. userInfo["reason"] = "transcription" | "chat" | "floating_bar".
   static let showUsageLimitPopup = Notification.Name("showUsageLimitPopup")
   /// Posted to navigate to Rewind settings

--- a/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
+++ b/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
@@ -639,6 +639,45 @@ final class DesktopAutomationActionRegistry {
       return await FloatingControlBarManager.shared.closeAskOmiForAutomation(wait: wait)
     }
 
+    // Drive the redesigned Home stage (inline chat / connect tray) without the
+    // cursor. Each posts the notification DashboardPage observes, which calls
+    // the exact functions the on-screen controls call.
+    register(
+      name: "home_open_chat",
+      summary: "Open the inline chat on Home (same path as clicking the ask bar)"
+    ) { _ in
+      NotificationCenter.default.post(name: .homeStageOpenChat, object: nil)
+      return nil
+    }
+
+    register(
+      name: "home_connect_toggle",
+      summary: "Toggle the Connect tray on Home (same path as the ask-bar Connect button)"
+    ) { _ in
+      NotificationCenter.default.post(name: .homeStageToggleConnect, object: nil)
+      return nil
+    }
+
+    register(
+      name: "home_close_panel",
+      summary: "Collapse Home back to the hub (same as Esc / the close buttons)"
+    ) { _ in
+      NotificationCenter.default.post(name: .homeStageClose, object: nil)
+      return nil
+    }
+
+    register(
+      name: "home_ask",
+      summary: "Send a query through the Home ask bar (opens the inline chat and sends)",
+      params: ["query"]
+    ) { params in
+      let query = (params["query"] ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+      guard !query.isEmpty else { return ["error": "missing 'query'"] }
+      NotificationCenter.default.post(
+        name: .homeStageAsk, object: nil, userInfo: ["query": query])
+      return ["sent": query]
+    }
+
     register(
       name: "ask",
       summary: "Send a query to the floating-bar AI (typed path); exercises the full chat pipeline",

--- a/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
+++ b/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
@@ -679,6 +679,20 @@ final class DesktopAutomationActionRegistry {
     }
 
     register(
+      name: "home_attach",
+      summary: "Stage a file in the Home ask bar (same wiring as the paperclip/drag-drop)",
+      params: ["path"]
+    ) { params in
+      let path = (params["path"] ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+      guard !path.isEmpty, FileManager.default.fileExists(atPath: path) else {
+        return ["error": "missing or nonexistent 'path'"]
+      }
+      NotificationCenter.default.post(
+        name: .homeStageAttach, object: nil, userInfo: ["path": path])
+      return ["staged": path]
+    }
+
+    register(
       name: "ask",
       summary: "Send a query to the floating-bar AI (typed path); exercises the full chat pipeline",
       params: ["query"]

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
@@ -251,6 +251,8 @@ struct DashboardPage: View {
     @AppStorage("systemAudioCaptureMode") private var systemAudioCaptureModeRaw =
         AssistantSettings.SystemAudioCaptureMode.onlyDuringMeetings.rawValue
     @AppStorage("useLegacyHomeDesign") private var useLegacyHomeDesign = false
+    @State private var homeMode: HomeStageMode = .hub
+    @FocusState private var homeAskFieldFocused: Bool
 
     private var selectedApp: OmiApp? {
         guard let appId = chatProvider.selectedAppId else { return nil }
@@ -291,6 +293,9 @@ struct DashboardPage: View {
     private static let omiDeviceHistoryDefaultsKey = "home-omi-device-account-history"
     private static let homeStageMaxWidth: CGFloat = 1120
     private static let homeStageHorizontalPadding: CGFloat = 34
+    private static let homeAskBarMaxWidth: CGFloat = 640
+    private static let homeStagePanelMaxWidth: CGFloat = 780
+    private static let homeStageAnimation = Animation.spring(response: 0.46, dampingFraction: 0.86)
     private static let appsPopupMaxWidth: CGFloat = 1040
     private static let appsPopupMaxHeight: CGFloat = 600
     private static let appsPopupMinWidth: CGFloat = 360
@@ -443,6 +448,33 @@ struct DashboardPage: View {
         .onReceive(NotificationCenter.default.publisher(for: .screenCaptureKitBroken)) { _ in
             syncCaptureState()
         }
+        // Clicking into the ask bar reveals the inline chat; the same is true
+        // when focus lands there via keyboard (Tab / Full Keyboard Access).
+        .onChange(of: homeAskFieldFocused) { _, focused in
+            if focused && !useLegacyHomeDesign && homeMode != .chat {
+                openHomeChat()
+            }
+        }
+        // Automation-bridge entry points (home_open_chat / home_connect_toggle /
+        // home_close_panel / home_ask) — they call the exact functions the
+        // on-screen controls call.
+        .onReceive(NotificationCenter.default.publisher(for: .homeStageOpenChat)) { _ in
+            guard !useLegacyHomeDesign else { return }
+            openHomeChat()
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .homeStageToggleConnect)) { _ in
+            guard !useLegacyHomeDesign else { return }
+            toggleHomeConnectPanel()
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .homeStageClose)) { _ in
+            guard !useLegacyHomeDesign else { return }
+            closeHomeStagePanel()
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .homeStageAsk)) { note in
+            guard !useLegacyHomeDesign,
+                  let query = note.userInfo?["query"] as? String else { return }
+            askHomeSuggestion(query)
+        }
     }
 
     private var legacyHome: some View {
@@ -534,12 +566,8 @@ struct DashboardPage: View {
             ZStack(alignment: .topTrailing) {
                 HomeCanvasBackground()
 
-                homeRoutingStage
-                    .frame(maxWidth: Self.homeStageMaxWidth)
-                    .padding(.horizontal, Self.homeStageHorizontalPadding)
-                    .frame(width: proxy.size.width)
-                    .frame(height: panelHeight)
-                    .position(x: proxy.size.width / 2, y: panelTop + panelHeight / 2)
+                homeStage
+                    .frame(width: proxy.size.width, height: proxy.size.height)
                     // The popup/sheet overlays are modal: while one is up, the
                     // stage underneath must not be reachable by VoiceOver /
                     // Full Keyboard Access.
@@ -563,10 +591,315 @@ struct DashboardPage: View {
                     panelHeight: panelHeight,
                     panelTop: panelTop
                 )
+
+                // Esc collapses the inline chat / connect tray back to the hub —
+                // but only while no modal overlay owns the key.
+                if homeMode != .hub && !isHomeModalPresented {
+                    OverlayModalEscapeCatcher {
+                        closeHomeStagePanel()
+                    }
+                }
             }
             .animation(.easeOut(duration: 0.2), value: isShowingAppsPopup)
             .animation(.easeOut(duration: 0.2), value: homeConnectSheetIsPresented)
+            .animation(Self.homeStageAnimation, value: homeMode)
         }
+    }
+
+    /// Vertical stage: mode content on top (hub metrics, inline chat, or the
+    /// connect tray), the persistent ask bar anchored beneath it, and the
+    /// suggested questions under the bar while the hub is showing.
+    private var homeStage: some View {
+        VStack(spacing: 0) {
+            ZStack {
+                switch homeMode {
+                case .hub:
+                    homeHubCenterpiece
+                        .transition(.homeHubFade)
+                case .chat:
+                    homeChatPanel
+                        .transition(.homeDropFromTop)
+                case .connect:
+                    homeConnectPanel
+                        .transition(.homeDropFromTop)
+                }
+            }
+            // Hub: the centerpiece sits directly above the ask bar; the chat /
+            // connect panels fill the whole area instead.
+            .frame(
+                maxWidth: .infinity,
+                maxHeight: .infinity,
+                alignment: homeMode == .hub ? .bottom : .center
+            )
+
+            homeAskBar
+                .frame(maxWidth: Self.homeAskBarMaxWidth)
+                .padding(.horizontal, Self.homeStageHorizontalPadding)
+                .padding(.top, homeMode == .hub ? 26 : 16)
+
+            if homeMode == .hub {
+                homeSuggestionList
+                    .frame(maxWidth: Self.homeAskBarMaxWidth)
+                    .padding(.horizontal, Self.homeStageHorizontalPadding)
+                    .padding(.top, 12)
+                    .transition(.homeSuggestionsFade)
+            }
+
+            // Lifts the hub cluster toward the optical center; collapses while
+            // a panel is up so the ask bar anchors at the bottom.
+            Spacer(minLength: 0)
+                .frame(height: homeMode == .hub ? 64 : 0)
+        }
+        .padding(.top, 74)
+        .padding(.bottom, 26)
+    }
+
+    // MARK: Hub centerpiece
+
+    private var homeHubCenterpiece: some View {
+        VStack(spacing: 22) {
+            VStack(spacing: 4) {
+                Text("omi.")
+                    .font(.system(size: 52, weight: .bold, design: .rounded))
+                    .foregroundStyle(HomePalette.ink)
+                    .lineLimit(1)
+                    .shadow(color: HomePalette.glow.opacity(0.45), radius: 24)
+
+                Text("What omi knows")
+                    .font(.system(size: 16, weight: .medium, design: .serif))
+                    .foregroundStyle(HomePalette.secondary)
+                    .lineLimit(1)
+            }
+
+            VStack(spacing: 8) {
+                HStack(spacing: 8) {
+                    HomeCenterMetricTile(
+                        title: "Conversations",
+                        value: conversationMetricValue,
+                        systemImage: "text.bubble.fill",
+                        action: { navigate(to: .conversations) }
+                    )
+                    HomeCenterMetricTile(
+                        title: "Tasks",
+                        value: taskMetricValue,
+                        systemImage: "checklist",
+                        action: { navigate(to: .tasks) }
+                    )
+                }
+
+                HStack(spacing: 8) {
+                    HomeCenterMetricTile(
+                        title: "Memories",
+                        value: memoryMetricValue,
+                        systemImage: "brain",
+                        action: { navigate(to: .memories) }
+                    )
+                    HomeCenterMetricTile(
+                        title: "Screenshots",
+                        value: screenshotMetricValue,
+                        systemImage: "photo.on.rectangle.angled",
+                        action: { navigate(to: .rewind) }
+                    )
+                }
+            }
+            .frame(width: 336)
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    // MARK: Inline chat panel
+
+    private var homeChatPanel: some View {
+        VStack(spacing: 0) {
+            HStack {
+                Text("Ask omi")
+                    .font(.system(size: 19, weight: .medium, design: .serif))
+                    .foregroundStyle(HomePalette.ink)
+
+                Spacer()
+
+                HomeIconActionButton(title: "Close chat", systemImage: "chevron.down") {
+                    closeHomeStagePanel()
+                }
+            }
+            .padding(.bottom, 2)
+
+            ChatMessagesView(
+                messages: chatProvider.messages,
+                isSending: chatProvider.isSending,
+                hasMoreMessages: chatProvider.hasMoreMessages,
+                isLoadingMoreMessages: chatProvider.isLoadingMoreMessages,
+                isLoadingInitial: (chatProvider.isLoading || chatProvider.isLoadingSessions)
+                    && !chatProvider.isClearing,
+                app: selectedApp,
+                onLoadMore: { await chatProvider.loadMoreMessages() },
+                onRate: { messageId, rating in
+                    Task { await chatProvider.rateMessage(messageId, rating: rating) }
+                },
+                onCitationTap: { citation in
+                    handleCitationTap(citation)
+                },
+                sessionsLoadError: chatProvider.sessionsLoadError,
+                onRetry: { Task { await chatProvider.retryLoad() } },
+                localSendToken: chatProvider.localSendToken,
+                onCancelTurn: { chatProvider.stopAgent(owner: .mainChat) },
+                welcomeContent: { dashboardChatWelcome }
+            )
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .mask(
+                LinearGradient(
+                    stops: [
+                        .init(color: .clear, location: 0.0),
+                        .init(color: .black, location: 0.05),
+                        .init(color: .black, location: 0.97),
+                        .init(color: .clear, location: 1.0),
+                    ],
+                    startPoint: .top,
+                    endPoint: .bottom
+                )
+            )
+        }
+        .frame(maxWidth: Self.homeStagePanelMaxWidth)
+        .padding(.horizontal, Self.homeStageHorizontalPadding)
+    }
+
+    // MARK: Connect tray
+
+    private var homeConnectPanel: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            HStack(alignment: .top) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Connect")
+                        .font(.system(size: 24, weight: .medium, design: .serif))
+                        .foregroundStyle(HomePalette.ink)
+
+                    Text("Feed omi new context — and take its memory everywhere.")
+                        .scaledFont(size: 12, weight: .medium)
+                        .foregroundStyle(HomePalette.muted)
+                }
+
+                Spacer()
+
+                HomeIconActionButton(title: "Close connect", systemImage: "xmark") {
+                    closeHomeStagePanel()
+                }
+            }
+
+            ScrollView(showsIndicators: false) {
+                HStack(alignment: .top, spacing: 24) {
+                    VStack(alignment: .leading, spacing: 12) {
+                        sourceColumnHeader
+                        sourceConstellation
+                    }
+                    .frame(maxWidth: .infinity)
+
+                    destinationStack
+                        .frame(maxWidth: .infinity)
+                }
+                .padding(.bottom, 4)
+            }
+        }
+        .padding(24)
+        .background(
+            RoundedRectangle(cornerRadius: 28, style: .continuous)
+                .fill(HomePalette.panel.opacity(0.94))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 28, style: .continuous)
+                .stroke(HomePalette.hairline.opacity(0.9), lineWidth: 1)
+        )
+        .shadow(color: .black.opacity(0.4), radius: 30, y: 16)
+        .frame(maxWidth: Self.homeStagePanelMaxWidth)
+        .padding(.horizontal, Self.homeStageHorizontalPadding)
+    }
+
+    // MARK: Ask bar + suggestions
+
+    private var homeAskBar: some View {
+        HomeAskBar(
+            text: $chatProvider.draftText,
+            isSending: chatProvider.isSending,
+            isStopping: chatProvider.isStopping,
+            isConnectActive: homeMode == .connect,
+            focus: $homeAskFieldFocused,
+            onSend: sendFromHomeAskBar,
+            onStop: { chatProvider.stopAgent(owner: .mainChat) },
+            onConnect: toggleHomeConnectPanel,
+            onActivate: openHomeChat
+        )
+    }
+
+    private var homeSuggestedQuestions: [String] {
+        let saved = PostOnboardingPromptSuggestions.suggestions()
+        let fallback = [
+            "What should I focus on today to achieve my goals?",
+            "What did I spend my time on this week?",
+            "What's the highest-leverage thing I can do next?",
+        ]
+        return Array((saved.isEmpty ? fallback : saved).prefix(3))
+    }
+
+    private var homeSuggestionList: some View {
+        VStack(spacing: 8) {
+            ForEach(homeSuggestedQuestions, id: \.self) { question in
+                HomeSuggestionRow(text: question) {
+                    askHomeSuggestion(question)
+                }
+            }
+        }
+    }
+
+    // MARK: Stage actions
+
+    private func openHomeChat() {
+        guard homeMode != .chat else { return }
+        withAnimation(Self.homeStageAnimation) {
+            homeMode = .chat
+        }
+    }
+
+    private func toggleHomeConnectPanel() {
+        let target: HomeStageMode = homeMode == .connect ? .hub : .connect
+        if target == .connect {
+            homeAskFieldFocused = false
+        }
+        withAnimation(Self.homeStageAnimation) {
+            homeMode = target
+        }
+    }
+
+    private func closeHomeStagePanel() {
+        homeAskFieldFocused = false
+        withAnimation(Self.homeStageAnimation) {
+            homeMode = .hub
+        }
+    }
+
+    private func sendFromHomeAskBar() {
+        let text = chatProvider.draftText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !text.isEmpty else { return }
+        chatProvider.draftText = ""
+        openHomeChat()
+        AnalyticsManager.shared.chatMessageSent(
+            messageLength: text.count,
+            hasContext: selectedApp != nil,
+            source: "home_ask_bar"
+        )
+        if chatProvider.isSending {
+            Task { await chatProvider.sendFollowUp(text) }
+        } else {
+            Task { await chatProvider.sendMessage(text) }
+        }
+    }
+
+    private func askHomeSuggestion(_ suggestion: String) {
+        openHomeChat()
+        AnalyticsManager.shared.chatMessageSent(
+            messageLength: suggestion.count,
+            hasContext: selectedApp != nil,
+            source: "home_suggested_question"
+        )
+        Task { await chatProvider.sendMessage(suggestion) }
     }
 
     @ViewBuilder
@@ -777,48 +1110,6 @@ struct DashboardPage: View {
         .frame(height: 36)
     }
 
-    private var homeRoutingStage: some View {
-        ZStack {
-            RoundedRectangle(cornerRadius: 30, style: .continuous)
-                .fill(HomePalette.panel)
-                .overlay(
-                    RoundedRectangle(cornerRadius: 30, style: .continuous)
-                        .stroke(HomePalette.hairline.opacity(0.86), lineWidth: 1)
-                )
-                .shadow(color: .black.opacity(0.42), radius: 34, y: 18)
-
-            HomeMemoryBridgeBackdrop()
-                .clipShape(RoundedRectangle(cornerRadius: 30, style: .continuous))
-
-            HStack(alignment: .top, spacing: 28) {
-                VStack(alignment: .leading, spacing: 12) {
-                    sourceColumnHeader
-                    sourceConstellation
-                }
-                .frame(width: 320)
-
-                centerMemoryColumn
-
-                destinationStack
-                    .frame(width: 300)
-            }
-            .padding(26)
-        }
-    }
-
-    private var centerMemoryColumn: some View {
-        HomeCenterMemoryColumn(
-            conversationValue: conversationMetricValue,
-            taskValue: taskMetricValue,
-            memoryValue: memoryMetricValue,
-            screenshotValue: screenshotMetricValue,
-            onConversations: { navigate(to: .conversations) },
-            onTasks: { navigate(to: .tasks) },
-            onMemories: { navigate(to: .memories) },
-            onScreenshots: { navigate(to: .rewind) }
-        )
-    }
-
     private var sourceColumnHeader: some View {
         VStack(alignment: .leading, spacing: 4) {
             Text("Connect data")
@@ -831,23 +1122,6 @@ struct DashboardPage: View {
                 .lineLimit(1)
         }
         .frame(height: 62, alignment: .bottomLeading)
-    }
-
-    private var centerMemoryHeader: some View {
-        VStack(spacing: 2) {
-            Text("omi.")
-                .font(.system(size: 42, weight: .bold, design: .rounded))
-                .foregroundStyle(HomePalette.ink)
-                .lineLimit(1)
-                .shadow(color: HomePalette.glow.opacity(0.42), radius: 20)
-
-            Text("What omi knows")
-                .font(.system(size: 15, weight: .medium, design: .serif))
-                .foregroundStyle(HomePalette.secondary)
-                .multilineTextAlignment(.center)
-                .lineLimit(1)
-        }
-        .frame(height: 62, alignment: .bottom)
     }
 
     private var sourceConstellation: some View {
@@ -888,7 +1162,7 @@ struct DashboardPage: View {
             .frame(height: 62, alignment: .bottomLeading)
 
             HomeAIChoiceButton(title: "Ask Omi", usesOmiMark: true) {
-                navigate(to: .chat)
+                openHomeChat()
             }
             HomeAIChoiceButton(title: "Claude / Claude Code", brand: .claude, isConnected: isMCPDestinationConnected(.claude)) {
                 openExportDestination(.claudeCode)
@@ -1478,8 +1752,6 @@ private enum HomePalette {
     // cleanups (e.g. 317424f57), so we put the purple on the name those reverts converge to.
     // Do NOT change this back to red/rose.
     static let glow = Color(red: 0.48, green: 0.30, blue: 0.95)      // purple
-    static let glowSoft = Color(red: 0.28, green: 0.17, blue: 0.57)  // purpleSoft
-    static let flowPink = Color(red: 1.0, green: 0.16, blue: 0.44)
 }
 
 private enum HomeRowStatus {
@@ -1493,149 +1765,275 @@ private enum HomeDestinationProminence {
     case quiet
 }
 
+private enum HomeStageMode: Equatable {
+    case hub
+    case chat
+    case connect
+}
+
+/// Shared "drop from the top" motion for stage panels: a short slide with a
+/// slight top-anchored scale and fade — deliberate, not a full-height fly-in.
+private struct HomeStageDropModifier: ViewModifier {
+    let offsetY: CGFloat
+    let scale: CGFloat
+    let opacity: Double
+
+    func body(content: Content) -> some View {
+        content
+            .offset(y: offsetY)
+            .scaleEffect(scale, anchor: .top)
+            .opacity(opacity)
+    }
+}
+
+extension AnyTransition {
+    fileprivate static var homeDropFromTop: AnyTransition {
+        .modifier(
+            active: HomeStageDropModifier(offsetY: -46, scale: 0.97, opacity: 0),
+            identity: HomeStageDropModifier(offsetY: 0, scale: 1, opacity: 1)
+        )
+    }
+
+    fileprivate static var homeHubFade: AnyTransition {
+        .modifier(
+            active: HomeStageDropModifier(offsetY: 18, scale: 0.985, opacity: 0),
+            identity: HomeStageDropModifier(offsetY: 0, scale: 1, opacity: 1)
+        )
+    }
+
+    fileprivate static var homeSuggestionsFade: AnyTransition {
+        .modifier(
+            active: HomeStageDropModifier(offsetY: 10, scale: 1, opacity: 0),
+            identity: HomeStageDropModifier(offsetY: 0, scale: 1, opacity: 1)
+        )
+    }
+}
+
+/// The persistent home ask bar: a pill-shaped chat input with a send/stop
+/// action and the Connect toggle living inside the pill.
+private struct HomeAskBar: View {
+    @Binding var text: String
+    let isSending: Bool
+    let isStopping: Bool
+    let isConnectActive: Bool
+    var focus: FocusState<Bool>.Binding
+    let onSend: () -> Void
+    let onStop: () -> Void
+    let onConnect: () -> Void
+    let onActivate: () -> Void
+
+    @State private var isHovering = false
+
+    private var hasText: Bool {
+        !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    private var isFocused: Bool { focus.wrappedValue }
+
+    var body: some View {
+        HStack(spacing: 10) {
+            Image(systemName: "sparkles")
+                .scaledFont(size: 14, weight: .semibold)
+                .foregroundStyle(isFocused ? HomePalette.ink : HomePalette.muted)
+
+            TextField(
+                "",
+                text: $text,
+                prompt: Text("Ask omi anything").foregroundColor(HomePalette.muted)
+            )
+            .textFieldStyle(.plain)
+            .font(.system(size: 15))
+            .foregroundStyle(HomePalette.ink)
+            .focused(focus)
+            .onSubmit(onSend)
+
+            if isSending && !hasText {
+                stopButton
+            } else if hasText {
+                sendButton
+            }
+
+            connectButton
+        }
+        .padding(.leading, 18)
+        .padding(.trailing, 8)
+        .frame(height: 58)
+        .background(
+            RoundedRectangle(cornerRadius: 29, style: .continuous)
+                .fill(HomePalette.tile.opacity(isHovering || isFocused ? 1 : 0.92))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 29, style: .continuous)
+                .stroke(
+                    isFocused
+                        ? Color.white.opacity(0.30)
+                        : HomePalette.hairline.opacity(isHovering ? 1 : 0.9),
+                    lineWidth: 1
+                )
+        )
+        .shadow(color: .black.opacity(isFocused ? 0.45 : 0.34), radius: 24, y: 10)
+        .contentShape(.rect(cornerRadius: 29))
+        .onTapGesture {
+            onActivate()
+            focus.wrappedValue = true
+        }
+        .onHover { isHovering = $0 }
+        .animation(.easeOut(duration: 0.16), value: isFocused)
+        .animation(.easeOut(duration: 0.16), value: hasText)
+    }
+
+    private var sendButton: some View {
+        Button(action: onSend) {
+            ZStack {
+                Circle()
+                    .fill(Color.white)
+
+                Image(systemName: "arrow.up")
+                    .scaledFont(size: 13, weight: .bold)
+                    .foregroundStyle(Color.black)
+            }
+            .frame(width: 34, height: 34)
+            .contentShape(Circle())
+        }
+        .buttonStyle(.plain)
+        .help("Send")
+        .accessibilityLabel("Send message")
+    }
+
+    private var stopButton: some View {
+        Button(action: onStop) {
+            ZStack {
+                Circle()
+                    .fill(Color.white.opacity(0.14))
+
+                if isStopping {
+                    ProgressView()
+                        .controlSize(.small)
+                        .scaleEffect(0.6)
+                } else {
+                    Image(systemName: "square.fill")
+                        .scaledFont(size: 10, weight: .bold)
+                        .foregroundStyle(HomePalette.ink)
+                }
+            }
+            .frame(width: 34, height: 34)
+            .contentShape(Circle())
+        }
+        .buttonStyle(.plain)
+        .disabled(isStopping)
+        .help("Stop")
+        .accessibilityLabel("Stop response")
+    }
+
+    private var connectButton: some View {
+        HomeAskBarConnectButton(isActive: isConnectActive, action: onConnect)
+    }
+}
+
+private struct HomeAskBarConnectButton: View {
+    let isActive: Bool
+    let action: () -> Void
+
+    @State private var isHovering = false
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 6) {
+                Image(systemName: "link")
+                    .scaledFont(size: 11, weight: .semibold)
+
+                Text("Connect")
+                    .scaledFont(size: 12, weight: .semibold)
+            }
+            .foregroundStyle(isActive ? Color.black : HomePalette.ink)
+            .padding(.horizontal, 13)
+            .frame(height: 34)
+            .background(
+                Capsule(style: .continuous)
+                    .fill(isActive ? Color.white : Color.white.opacity(isHovering ? 0.14 : 0.07))
+            )
+            .overlay(
+                Capsule(style: .continuous)
+                    .stroke(isActive ? Color.clear : HomePalette.hairline, lineWidth: 1)
+            )
+            .contentShape(Capsule())
+        }
+        .buttonStyle(.plain)
+        .onHover { isHovering = $0 }
+        .help("Connect data & use omi anywhere")
+        .accessibilityLabel(isActive ? "Close connect" : "Connect")
+    }
+}
+
+private struct HomeSuggestionRow: View {
+    let text: String
+    let action: () -> Void
+
+    @State private var isHovering = false
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 10) {
+                Image(systemName: "sparkles")
+                    .scaledFont(size: 11, weight: .semibold)
+                    .foregroundStyle(isHovering ? Color(hex: 0xE3BF63) : HomePalette.muted)
+
+                Text(text)
+                    .scaledFont(size: 13, weight: .medium)
+                    .foregroundStyle(isHovering ? HomePalette.ink : HomePalette.secondary)
+                    .lineLimit(1)
+
+                Spacer(minLength: 8)
+
+                Image(systemName: "arrow.up.right")
+                    .scaledFont(size: 10, weight: .bold)
+                    .foregroundStyle(isHovering ? HomePalette.ink : HomePalette.faint)
+            }
+            .padding(.horizontal, 16)
+            .frame(height: 42)
+            .frame(maxWidth: .infinity)
+            .background(
+                RoundedRectangle(cornerRadius: 21, style: .continuous)
+                    .fill(isHovering ? HomePalette.tileHover : HomePalette.tile.opacity(0.55))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 21, style: .continuous)
+                    .stroke(HomePalette.hairline.opacity(isHovering ? 1 : 0.55), lineWidth: 1)
+            )
+            .contentShape(.rect(cornerRadius: 21))
+        }
+        .buttonStyle(.plain)
+        .onHover { isHovering = $0 }
+        .accessibilityLabel(text)
+    }
+}
+
 private struct HomeCanvasBackground: View {
     var body: some View {
         ZStack {
             HomePalette.paper
 
+            // One barely-there key light high behind the wordmark, and a faint
+            // horizon lift near the ask bar. Deliberately subtle — the old
+            // mid-screen glow blobs read as splotches on large displays.
             RadialGradient(
-                colors: [
-                    HomePalette.glow.opacity(0.16),
-                    HomePalette.glow.opacity(0.035),
-                    .clear,
-                ],
-                center: .center,
-                startRadius: 30,
-                endRadius: 520
+                colors: [Color.white.opacity(0.045), .clear],
+                center: UnitPoint(x: 0.5, y: 0.16),
+                startRadius: 0,
+                endRadius: 560
             )
-            .blur(radius: 12)
+
+            LinearGradient(
+                stops: [
+                    .init(color: .clear, location: 0.62),
+                    .init(color: Color.white.opacity(0.02), location: 0.86),
+                    .init(color: .clear, location: 1.0),
+                ],
+                startPoint: .top,
+                endPoint: .bottom
+            )
         }
         .ignoresSafeArea()
-    }
-}
-
-private struct HomeMemoryBridgeBackdrop: View {
-    @State private var isAppActive = NSApp.isActive
-
-    var body: some View {
-        Group {
-            if isAppActive {
-                TimelineView(.periodic(from: .now, by: 1.0 / 10.0)) { timeline in
-                    HomeMemoryBridgeBackdropContent(
-                        progress: Self.progress(for: timeline.date)
-                    )
-                }
-            } else {
-                HomeMemoryBridgeBackdropContent(progress: 0.18)
-            }
-        }
-        .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
-            isAppActive = true
-        }
-        .onReceive(NotificationCenter.default.publisher(for: NSApplication.didResignActiveNotification)) { _ in
-            isAppActive = false
-        }
-        .allowsHitTesting(false)
-        .accessibilityHidden(true)
-    }
-
-    private static func progress(for date: Date) -> CGFloat {
-        CGFloat(date.timeIntervalSinceReferenceDate.truncatingRemainder(dividingBy: 7.0) / 7.0)
-    }
-}
-
-private struct HomeMemoryBridgeBackdropContent: View {
-    let progress: CGFloat
-
-    var body: some View {
-        GeometryReader { proxy in
-            let width = proxy.size.width
-            let height = proxy.size.height
-
-            ZStack {
-                ForEach(0..<5, id: \.self) { index in
-                    HomeFlowCloud(index: index, progress: progress, width: width, height: height)
-                }
-
-                ForEach(0..<14, id: \.self) { index in
-                    HomeFlowParticle(index: index, progress: progress, width: width, height: height)
-                }
-            }
-        }
-    }
-}
-private struct HomeFlowCloud: View {
-    let index: Int
-    let progress: CGFloat
-    let width: CGFloat
-    let height: CGFloat
-
-    var body: some View {
-        let baseX = CGFloat(0.13 + Double(index) * 0.19)
-        let wave = CGFloat(sin(Double(progress) * Double.pi * 2 + Double(index) * 0.82))
-        let drift = CGFloat(cos(Double(progress) * Double.pi * 2 + Double(index) * 0.55))
-        let cloudWidth = width * (index == 2 ? 0.46 : 0.34)
-        let cloudHeight = height * (index == 2 ? 0.42 : 0.32)
-        let opacity = index == 2 ? 0.18 : 0.12
-
-        Ellipse()
-            .fill(
-                RadialGradient(
-                    colors: [
-                        (index % 2 == 0 ? HomePalette.glow : HomePalette.flowPink).opacity(opacity),
-                        HomePalette.glowSoft.opacity(opacity * 0.58),
-                        .clear,
-                    ],
-                    center: .center,
-                    startRadius: 0,
-                    endRadius: cloudWidth * 0.46
-                )
-            )
-            .frame(width: cloudWidth, height: cloudHeight)
-            .position(
-                x: width * baseX + drift * width * 0.020,
-                y: height * (0.47 + wave * 0.052)
-            )
-            .blur(radius: 36)
-            .blendMode(.screen)
-    }
-}
-
-private struct HomeFlowParticle: View {
-    let index: Int
-    let progress: CGFloat
-    let width: CGFloat
-    let height: CGFloat
-
-    var body: some View {
-        let base = CGFloat(index) / 14.0
-        let wrapped = (base + progress).truncatingRemainder(dividingBy: 1)
-        let wave = CGFloat(sin(Double(wrapped) * Double.pi * 2 + Double(index) * 0.72))
-        let fade = min(max((wrapped < 0.5 ? wrapped : 1 - wrapped) * 2.4, 0), 1)
-        let lane = CGFloat((index % 5) - 2) * 0.018
-        let x = width * (-0.06 + wrapped * 1.12)
-        let y = height * (0.49 + lane + wave * 0.052)
-        let size = CGFloat(26 + (index % 4) * 9)
-        let opacity = 0.04 + fade * 0.16
-
-        Ellipse()
-            .fill(
-                RadialGradient(
-                    colors: [
-                        (index % 3 == 0 ? HomePalette.flowPink : HomePalette.glow).opacity(opacity),
-                        HomePalette.glowSoft.opacity(opacity * 0.46),
-                        .clear,
-                    ],
-                    center: .center,
-                    startRadius: 2,
-                    endRadius: size
-                )
-            )
-            .frame(width: size * 2.3, height: size * 1.12)
-            .position(x: x, y: y)
-            .rotationEffect(.degrees(Double(wave) * 9))
-            .blur(radius: 15)
-            .blendMode(.screen)
     }
 }
 
@@ -2449,85 +2847,6 @@ private struct HomeSourceTile: View {
     }
 }
 
-private struct HomeCenterMemoryColumn: View {
-    let conversationValue: String
-    let taskValue: String
-    let memoryValue: String
-    let screenshotValue: String
-    let onConversations: () -> Void
-    let onTasks: () -> Void
-    let onMemories: () -> Void
-    let onScreenshots: () -> Void
-
-    var body: some View {
-        content
-    }
-
-    private var content: AnyView {
-        let stack = VStack(spacing: 18) {
-            header
-            metrics
-        }
-        // Group the title directly above the cards and center the unit in a
-        // column the same height as the side lists.
-        let columnHeight = CGFloat(422)
-        let framed = stack.frame(width: CGFloat(340), height: columnHeight, alignment: Alignment.center)
-        return AnyView(framed)
-    }
-
-    private var header: AnyView {
-        AnyView(VStack(spacing: 2) {
-            Text("omi.")
-                .font(.system(size: 42, weight: .bold, design: .rounded))
-                .foregroundStyle(HomePalette.ink)
-                .lineLimit(1)
-                .shadow(color: HomePalette.glow.opacity(0.42), radius: 20)
-
-            Text("What omi knows")
-                .font(.system(size: 15, weight: .medium, design: .serif))
-                .foregroundStyle(HomePalette.secondary)
-                .multilineTextAlignment(.center)
-                .lineLimit(1)
-        }
-        .frame(height: 62, alignment: .bottom))
-    }
-
-    private var metrics: AnyView {
-        AnyView(VStack(spacing: 8) {
-            HStack(spacing: 8) {
-                HomeCenterMetricTile(
-                    title: "Conversations",
-                    value: conversationValue,
-                    systemImage: "text.bubble.fill",
-                    action: onConversations
-                )
-                HomeCenterMetricTile(
-                    title: "Tasks",
-                    value: taskValue,
-                    systemImage: "checklist",
-                    action: onTasks
-                )
-            }
-
-            HStack(spacing: 8) {
-                HomeCenterMetricTile(
-                    title: "Memories",
-                    value: memoryValue,
-                    systemImage: "brain",
-                    action: onMemories
-                )
-                HomeCenterMetricTile(
-                    title: "Screenshots",
-                    value: screenshotValue,
-                    systemImage: "photo.on.rectangle.angled",
-                    action: onScreenshots
-                )
-            }
-        }
-        .frame(maxWidth: .infinity))
-    }
-}
-
 private struct HomeCenterMetricTile: View {
     let title: String
     let value: String
@@ -2538,42 +2857,44 @@ private struct HomeCenterMetricTile: View {
 
     var body: some View {
         Button(action: action) {
-            VStack(alignment: .leading, spacing: 6) {
+            VStack(alignment: .leading, spacing: 3) {
                 HStack {
                     Image(systemName: systemImage)
-                        .scaledFont(size: 12, weight: .semibold)
+                        .scaledFont(size: 11, weight: .semibold)
                         .foregroundStyle(HomePalette.ink)
 
                     Spacer(minLength: 8)
 
                     Image(systemName: "arrow.up.right")
-                        .scaledFont(size: 9, weight: .bold)
-                        .foregroundStyle(isHovering ? HomePalette.flowPink : HomePalette.faint)
+                        .scaledFont(size: 8, weight: .bold)
+                        .foregroundStyle(isHovering ? HomePalette.ink : HomePalette.faint)
                 }
 
+                Spacer(minLength: 0)
+
                 Text(value)
-                    .font(.system(size: 20, weight: .medium, design: .serif))
+                    .font(.system(size: 17, weight: .medium, design: .serif))
                     .foregroundStyle(HomePalette.ink)
                     .lineLimit(1)
                     .minimumScaleFactor(0.75)
 
                 Text(title)
-                    .scaledFont(size: 11, weight: .medium)
+                    .scaledFont(size: 10, weight: .medium)
                     .foregroundStyle(HomePalette.muted)
                     .lineLimit(1)
                     .minimumScaleFactor(0.82)
             }
-            .padding(10)
-            .frame(maxWidth: .infinity, minHeight: 82, maxHeight: 82, alignment: .topLeading)
+            .padding(9)
+            .frame(maxWidth: .infinity, minHeight: 66, maxHeight: 66, alignment: .topLeading)
             .background(
-                RoundedRectangle(cornerRadius: 15, style: .continuous)
+                RoundedRectangle(cornerRadius: 13, style: .continuous)
                     .fill(isHovering ? HomePalette.tileHover : HomePalette.tile.opacity(0.92))
             )
             .overlay(
-                RoundedRectangle(cornerRadius: 15, style: .continuous)
-                    .stroke(isHovering ? HomePalette.flowPink.opacity(0.5) : HomePalette.hairline.opacity(0.82), lineWidth: 1)
+                RoundedRectangle(cornerRadius: 13, style: .continuous)
+                    .stroke(isHovering ? HomePalette.hairline : HomePalette.hairline.opacity(0.82), lineWidth: 1)
             )
-            .contentShape(.rect(cornerRadius: 15))
+            .contentShape(.rect(cornerRadius: 13))
         }
         .buttonStyle(.plain)
         .onHover { isHovering = $0 }

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
@@ -1,6 +1,7 @@
 import Combine
 import SwiftUI
 import AppKit
+import UniformTypeIdentifiers
 import OmiTheme
 
 // MARK: - Dashboard View Model
@@ -475,6 +476,15 @@ struct DashboardPage: View {
                   let query = note.userInfo?["query"] as? String else { return }
             askHomeSuggestion(query)
         }
+        .onReceive(NotificationCenter.default.publisher(for: .homeStageAttach)) { note in
+            guard !useLegacyHomeDesign,
+                  let path = note.userInfo?["path"] as? String else { return }
+            // Same wiring the ask bar's paperclip/drag-drop runs after the
+            // OS hands back file URLs.
+            if let attachment = ChatAttachment.from(url: URL(fileURLWithPath: path)) {
+                chatProvider.addAttachments([attachment])
+            }
+        }
     }
 
     private var legacyHome: some View {
@@ -658,18 +668,11 @@ struct DashboardPage: View {
 
     private var homeHubCenterpiece: some View {
         VStack(spacing: 22) {
-            VStack(spacing: 4) {
-                Text("omi.")
-                    .font(.system(size: 52, weight: .bold, design: .rounded))
-                    .foregroundStyle(HomePalette.ink)
-                    .lineLimit(1)
-                    .shadow(color: HomePalette.glow.opacity(0.45), radius: 24)
-
-                Text("What omi knows")
-                    .font(.system(size: 16, weight: .medium, design: .serif))
-                    .foregroundStyle(HomePalette.secondary)
-                    .lineLimit(1)
-            }
+            Text("omi.")
+                .font(.system(size: 52, weight: .bold, design: .rounded))
+                .foregroundStyle(HomePalette.ink)
+                .lineLimit(1)
+                .shadow(color: HomePalette.glow.opacity(0.45), radius: 24)
 
             VStack(spacing: 8) {
                 HStack(spacing: 8) {
@@ -767,19 +770,31 @@ struct DashboardPage: View {
 
     private var homeConnectPanel: some View {
         ScrollView(showsIndicators: false) {
-            HStack(alignment: .top, spacing: 24) {
-                VStack(alignment: .leading, spacing: 12) {
-                    sourceColumnHeader
-                    sourceConstellation
+            // Sources feed omi; omi's memory flows out to the AI destinations —
+            // the chevron between the two cards reads that direction.
+            HStack(alignment: .center, spacing: 12) {
+                homeConnectColumnCard {
+                    VStack(alignment: .leading, spacing: 12) {
+                        sourceColumnHeader
+                        sourceConstellation
+                    }
                 }
-                .frame(maxWidth: .infinity)
 
-                destinationStack
-                    .frame(maxWidth: .infinity)
+                Image(systemName: "chevron.right")
+                    .scaledFont(size: 13, weight: .bold)
+                    .foregroundStyle(HomePalette.secondary)
+                    .frame(width: 30, height: 30)
+                    .background(Circle().fill(HomePalette.tile))
+                    .overlay(Circle().stroke(HomePalette.hairline, lineWidth: 1))
+                    .accessibilityHidden(true)
+
+                homeConnectColumnCard {
+                    destinationStack
+                }
             }
             .padding(.bottom, 4)
         }
-        .padding(24)
+        .padding(18)
         .background(
             RoundedRectangle(cornerRadius: 28, style: .continuous)
                 .fill(HomePalette.panel.opacity(0.94))
@@ -799,6 +814,20 @@ struct DashboardPage: View {
         .padding(.horizontal, Self.homeStageHorizontalPadding)
     }
 
+    private func homeConnectColumnCard<Content: View>(@ViewBuilder content: () -> Content) -> some View {
+        content()
+            .padding(16)
+            .frame(maxWidth: .infinity, alignment: .topLeading)
+            .background(
+                RoundedRectangle(cornerRadius: 22, style: .continuous)
+                    .fill(Color.white.opacity(0.025))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 22, style: .continuous)
+                    .stroke(HomePalette.hairline.opacity(0.55), lineWidth: 1)
+            )
+    }
+
     // MARK: Ask bar + suggestions
 
     private var homeAskBar: some View {
@@ -808,6 +837,14 @@ struct DashboardPage: View {
             isStopping: chatProvider.isStopping,
             isConnectActive: homeMode == .connect,
             focus: $homeAskFieldFocused,
+            attachments: $chatProvider.pendingAttachments,
+            onAttachmentsAdded: { urls in
+                let toAdd = urls.compactMap { ChatAttachment.from(url: $0) }
+                chatProvider.addAttachments(toAdd)
+            },
+            onAttachmentRemoved: { id in
+                chatProvider.removePendingAttachment(id: id)
+            },
             onSend: sendFromHomeAskBar,
             onStop: { chatProvider.stopAgent(owner: .mainChat) },
             onConnect: toggleHomeConnectPanel,
@@ -863,7 +900,8 @@ struct DashboardPage: View {
 
     private func sendFromHomeAskBar() {
         let text = chatProvider.draftText.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !text.isEmpty else { return }
+        // Attachments without text are sendable, matching the chat page.
+        guard !text.isEmpty || !chatProvider.pendingAttachments.isEmpty else { return }
         chatProvider.draftText = ""
         openHomeChat()
         AnalyticsManager.shared.chatMessageSent(
@@ -1107,7 +1145,6 @@ struct DashboardPage: View {
                 .foregroundStyle(HomePalette.muted)
                 .lineLimit(1)
         }
-        .frame(height: 62, alignment: .bottomLeading)
     }
 
     private var sourceConstellation: some View {
@@ -1135,9 +1172,9 @@ struct DashboardPage: View {
 
     private var destinationStack: some View {
         VStack(alignment: .leading, spacing: 12) {
-            VStack(alignment: .leading, spacing: 5) {
+            VStack(alignment: .leading, spacing: 4) {
                 Text("Use omi memory anywhere")
-                    .font(.system(size: 22, weight: .medium, design: .serif))
+                    .font(.system(size: 20, weight: .medium, design: .serif))
                     .foregroundStyle(HomePalette.ink)
 
                 Text("Bring your memories to the apps you use")
@@ -1145,7 +1182,6 @@ struct DashboardPage: View {
                     .foregroundStyle(HomePalette.muted)
                     .fixedSize(horizontal: false, vertical: true)
             }
-            .frame(height: 62, alignment: .bottomLeading)
 
             HomeAIChoiceButton(title: "Ask Omi", usesOmiMark: true) {
                 openHomeChat()
@@ -1753,55 +1789,83 @@ extension AnyTransition {
     }
 }
 
-/// The persistent home ask bar: a pill-shaped chat input with a send/stop
-/// action and the Connect toggle living inside the pill.
+/// The persistent home ask bar: a pill-shaped chat input with attachments
+/// (paperclip + drag-drop, same limits as the chat page), a send/stop action,
+/// and the Connect toggle living inside the pill.
 private struct HomeAskBar: View {
     @Binding var text: String
     let isSending: Bool
     let isStopping: Bool
     let isConnectActive: Bool
     var focus: FocusState<Bool>.Binding
+    @Binding var attachments: [ChatAttachment]
+    let onAttachmentsAdded: ([URL]) -> Void
+    let onAttachmentRemoved: (String) -> Void
     let onSend: () -> Void
     let onStop: () -> Void
     let onConnect: () -> Void
     let onActivate: () -> Void
 
     @State private var isHovering = false
+    @State private var isDropTargeted = false
 
     private var hasText: Bool {
         !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
 
+    /// Matches ChatInputView: attachments without text are sendable.
+    private var canSend: Bool {
+        hasText || !attachments.isEmpty
+    }
+
     private var isFocused: Bool { focus.wrappedValue }
 
     var body: some View {
-        HStack(spacing: 10) {
-            Image(systemName: "sparkles")
-                .scaledFont(size: 14, weight: .semibold)
-                .foregroundStyle(isFocused ? HomePalette.ink : HomePalette.muted)
-
-            TextField(
-                "",
-                text: $text,
-                prompt: Text("Ask omi anything").foregroundColor(HomePalette.muted)
-            )
-            .textFieldStyle(.plain)
-            .font(.system(size: 15))
-            .foregroundStyle(HomePalette.ink)
-            .focused(focus)
-            .onSubmit(onSend)
-
-            if isSending && !hasText {
-                stopButton
-            } else if hasText {
-                sendButton
+        VStack(spacing: 8) {
+            if !attachments.isEmpty {
+                AttachmentPreviewRow(
+                    attachments: attachments,
+                    onRemove: onAttachmentRemoved
+                )
+                .padding(.top, 10)
+                .padding(.horizontal, 12)
             }
 
-            connectButton
+            HStack(spacing: 10) {
+                Button(action: pickFiles) {
+                    Image(systemName: "paperclip")
+                        .scaledFont(size: 15, weight: .medium)
+                        .foregroundStyle(isFocused ? HomePalette.secondary : HomePalette.muted)
+                        .frame(width: 24, height: 24)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .disabled(attachments.count >= kMaxChatAttachments)
+                .help("Attach files")
+
+                TextField(
+                    "",
+                    text: $text,
+                    prompt: Text("Ask omi anything").foregroundColor(HomePalette.muted)
+                )
+                .textFieldStyle(.plain)
+                .font(.system(size: 15))
+                .foregroundStyle(HomePalette.ink)
+                .focused(focus)
+                .onSubmit(onSend)
+
+                if isSending && !hasText {
+                    stopButton
+                } else if canSend {
+                    sendButton
+                }
+
+                connectButton
+            }
+            .padding(.leading, 16)
+            .padding(.trailing, 8)
+            .frame(height: 58)
         }
-        .padding(.leading, 18)
-        .padding(.trailing, 8)
-        .frame(height: 58)
         .background(
             RoundedRectangle(cornerRadius: 29, style: .continuous)
                 .fill(HomePalette.tile.opacity(isHovering || isFocused ? 1 : 0.92))
@@ -1809,9 +1873,11 @@ private struct HomeAskBar: View {
         .overlay(
             RoundedRectangle(cornerRadius: 29, style: .continuous)
                 .stroke(
-                    isFocused
-                        ? Color.white.opacity(0.30)
-                        : HomePalette.hairline.opacity(isHovering ? 1 : 0.9),
+                    isDropTargeted
+                        ? Color.white.opacity(0.55)
+                        : (isFocused
+                            ? Color.white.opacity(0.30)
+                            : HomePalette.hairline.opacity(isHovering ? 1 : 0.9)),
                     lineWidth: 1
                 )
         )
@@ -1822,8 +1888,40 @@ private struct HomeAskBar: View {
             focus.wrappedValue = true
         }
         .onHover { isHovering = $0 }
+        .onDrop(of: [UTType.fileURL], isTargeted: $isDropTargeted, perform: handleDrop)
         .animation(.easeOut(duration: 0.16), value: isFocused)
-        .animation(.easeOut(duration: 0.16), value: hasText)
+        .animation(.easeOut(duration: 0.16), value: canSend)
+        .animation(.easeOut(duration: 0.16), value: attachments.count)
+    }
+
+    private func pickFiles() {
+        let panel = NSOpenPanel()
+        panel.canChooseFiles = true
+        panel.canChooseDirectories = false
+        panel.allowsMultipleSelection = true
+        panel.allowedContentTypes = [
+            .image, .jpeg, .png, .gif, .heic, .heif, .webP, .tiff, .bmp,
+            .pdf, .plainText, .json, .commaSeparatedText, .html,
+            .text, .content,
+        ]
+        if panel.runModal() == .OK {
+            let remaining = max(0, kMaxChatAttachments - attachments.count)
+            let urls = Array(panel.urls.prefix(remaining))
+            if !urls.isEmpty {
+                onAttachmentsAdded(urls)
+            }
+        }
+    }
+
+    private func handleDrop(providers: [NSItemProvider]) -> Bool {
+        ChatAttachmentDropHandler.collectURLs(from: providers) { [attachments] urls in
+            guard !urls.isEmpty else { return }
+            let remaining = max(0, kMaxChatAttachments - attachments.count)
+            let allowed = Array(urls.prefix(remaining))
+            if !allowed.isEmpty {
+                onAttachmentsAdded(allowed)
+            }
+        }
     }
 
     private var sendButton: some View {
@@ -1967,6 +2065,15 @@ private struct HomeCanvasBackground: View {
                 endRadius: 560
             )
 
+            RadialGradient(
+                colors: [HomePalette.glow.opacity(0.05), .clear],
+                center: UnitPoint(x: 0.5, y: 0.20),
+                startRadius: 0,
+                endRadius: 720
+            )
+
+            HomeMemoryDustField()
+
             LinearGradient(
                 stops: [
                     .init(color: .clear, location: 0.62),
@@ -1978,6 +2085,67 @@ private struct HomeCanvasBackground: View {
             )
         }
         .ignoresSafeArea()
+    }
+}
+
+/// Sparse, slowly drifting points of light — memories surfacing. Quiet enough
+/// to sit behind text, alive enough that the canvas doesn't feel dead.
+/// Freezes while the app is inactive so it costs nothing in the background.
+private struct HomeMemoryDustField: View {
+    @State private var isAppActive = NSApp.isActive
+
+    var body: some View {
+        Group {
+            if isAppActive {
+                TimelineView(.periodic(from: .now, by: 1.0 / 15.0)) { timeline in
+                    HomeMemoryDustCanvas(
+                        time: timeline.date.timeIntervalSinceReferenceDate)
+                }
+            } else {
+                HomeMemoryDustCanvas(time: 1200)
+            }
+        }
+        .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
+            isAppActive = true
+        }
+        .onReceive(NotificationCenter.default.publisher(for: NSApplication.didResignActiveNotification)) { _ in
+            isAppActive = false
+        }
+        .allowsHitTesting(false)
+        .accessibilityHidden(true)
+    }
+}
+
+private struct HomeMemoryDustCanvas: View {
+    let time: TimeInterval
+
+    var body: some View {
+        Canvas { context, size in
+            for index in 0..<56 {
+                let fi = Double(index)
+                // Deterministic per-index pseudo-randoms (no RNG — resume-safe
+                // and stable across frames).
+                let seedX = abs((sin(fi * 12.9898) * 43758.5453).truncatingRemainder(dividingBy: 1))
+                let seedY = abs((sin(fi * 78.233) * 12543.123).truncatingRemainder(dividingBy: 1))
+                let seedP = abs((sin(fi * 3.7) * 951.135).truncatingRemainder(dividingBy: 1))
+
+                // Slow upward drift with a gentle horizontal sway.
+                let rawY = (seedY * size.height - time * (3.0 + seedP * 5.0))
+                    .truncatingRemainder(dividingBy: size.height)
+                let y = rawY < 0 ? rawY + size.height : rawY
+                let x = seedX * size.width + sin(time * 0.22 + fi * 1.3) * 7
+
+                let twinkle = 0.5 + 0.5 * sin(time * (0.5 + seedP * 0.8) + fi * 1.7)
+                let alpha = 0.03 + twinkle * (0.04 + seedP * 0.08)
+                let radius = 0.8 + seedP * 1.5
+
+                let rect = CGRect(x: x - radius, y: y - radius, width: radius * 2, height: radius * 2)
+                let color = index % 6 == 0
+                    ? HomePalette.glow.opacity(alpha * 1.4)
+                    : Color.white.opacity(alpha)
+                context.fill(Path(ellipseIn: rect), with: .color(color))
+            }
+        }
     }
 }
 

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
@@ -726,17 +726,6 @@ struct DashboardPage: View {
 
     private var homeChatPanel: some View {
         VStack(spacing: 0) {
-            HStack {
-                Text("Ask omi")
-                    .font(.system(size: 19, weight: .medium, design: .serif))
-                    .foregroundStyle(HomePalette.ink)
-
-                Spacer()
-            }
-            .padding(.horizontal, 20)
-            .padding(.top, 16)
-            .padding(.bottom, 2)
-
             ChatMessagesView(
                 messages: chatProvider.messages,
                 isSending: chatProvider.isSending,
@@ -772,17 +761,28 @@ struct DashboardPage: View {
                 )
             )
             .padding(.horizontal, 8)
-            .padding(.bottom, 6)
+            .padding(.vertical, 6)
         }
         // Barely-there card so the chat reads as a bounded surface — making it
         // obvious the canvas around it is clickable (and closes the chat).
+        // The stroke is a soft gradient that dissolves toward the bottom.
         .background(
             RoundedRectangle(cornerRadius: 26, style: .continuous)
-                .fill(Color.white.opacity(0.016))
+                .fill(Color.white.opacity(0.012))
         )
         .overlay(
             RoundedRectangle(cornerRadius: 26, style: .continuous)
-                .stroke(HomePalette.hairline.opacity(0.55), lineWidth: 1)
+                .stroke(
+                    LinearGradient(
+                        colors: [
+                            HomePalette.hairline.opacity(0.45),
+                            HomePalette.hairline.opacity(0.10),
+                        ],
+                        startPoint: .top,
+                        endPoint: .bottom
+                    ),
+                    lineWidth: 1
+                )
         )
         .frame(maxWidth: Self.homeStagePanelMaxWidth)
         .padding(.horizontal, Self.homeStageHorizontalPadding)

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
@@ -791,30 +791,28 @@ struct DashboardPage: View {
     // MARK: Connect tray
 
     private var homeConnectPanel: some View {
-        ScrollView(showsIndicators: false) {
-            // Sources feed omi; omi's memory flows out to the AI destinations —
-            // the chevron between the two cards reads that direction.
-            HStack(alignment: .center, spacing: 12) {
-                homeConnectColumnCard {
-                    VStack(alignment: .leading, spacing: 12) {
-                        sourceColumnHeader
-                        sourceConstellation
-                    }
-                }
-
-                Image(systemName: "chevron.right")
-                    .scaledFont(size: 13, weight: .bold)
-                    .foregroundStyle(HomePalette.secondary)
-                    .frame(width: 30, height: 30)
-                    .background(Circle().fill(HomePalette.tile))
-                    .overlay(Circle().stroke(HomePalette.hairline, lineWidth: 1))
-                    .accessibilityHidden(true)
-
-                homeConnectColumnCard {
-                    destinationStack
+        // Sources feed omi; omi's memory flows out to the AI destinations —
+        // the chevron between the two cards reads that direction. The tray
+        // hugs its content: no scroll filler below the columns.
+        HStack(alignment: .center, spacing: 12) {
+            homeConnectColumnCard {
+                VStack(alignment: .leading, spacing: 12) {
+                    sourceColumnHeader
+                    sourceConstellation
                 }
             }
-            .padding(.bottom, 4)
+
+            Image(systemName: "chevron.right")
+                .scaledFont(size: 13, weight: .bold)
+                .foregroundStyle(HomePalette.secondary)
+                .frame(width: 30, height: 30)
+                .background(Circle().fill(HomePalette.tile))
+                .overlay(Circle().stroke(HomePalette.hairline, lineWidth: 1))
+                .accessibilityHidden(true)
+
+            homeConnectColumnCard {
+                destinationStack
+            }
         }
         .padding(18)
         .background(

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
@@ -576,6 +576,18 @@ struct DashboardPage: View {
             ZStack(alignment: .topTrailing) {
                 HomeCanvasBackground()
 
+                // Clicking anywhere outside the chat / connect panel collapses
+                // back to the hub (panels and the ask bar consume their own
+                // clicks above this catcher).
+                if homeMode != .hub {
+                    Color.black.opacity(0.001)
+                        .ignoresSafeArea()
+                        .contentShape(Rectangle())
+                        .onTapGesture {
+                            closeHomeStagePanel()
+                        }
+                }
+
                 homeStage
                     .frame(width: proxy.size.width, height: proxy.size.height)
                     // The popup/sheet overlays are modal: while one is up, the
@@ -720,10 +732,6 @@ struct DashboardPage: View {
                     .foregroundStyle(HomePalette.ink)
 
                 Spacer()
-
-                HomeIconActionButton(title: "Close chat", systemImage: "chevron.down") {
-                    closeHomeStagePanel()
-                }
             }
             .padding(.bottom, 2)
 
@@ -2072,8 +2080,6 @@ private struct HomeCanvasBackground: View {
                 endRadius: 720
             )
 
-            HomeMemoryDustField()
-
             LinearGradient(
                 stops: [
                     .init(color: .clear, location: 0.62),
@@ -2085,67 +2091,6 @@ private struct HomeCanvasBackground: View {
             )
         }
         .ignoresSafeArea()
-    }
-}
-
-/// Sparse, slowly drifting points of light — memories surfacing. Quiet enough
-/// to sit behind text, alive enough that the canvas doesn't feel dead.
-/// Freezes while the app is inactive so it costs nothing in the background.
-private struct HomeMemoryDustField: View {
-    @State private var isAppActive = NSApp.isActive
-
-    var body: some View {
-        Group {
-            if isAppActive {
-                TimelineView(.periodic(from: .now, by: 1.0 / 15.0)) { timeline in
-                    HomeMemoryDustCanvas(
-                        time: timeline.date.timeIntervalSinceReferenceDate)
-                }
-            } else {
-                HomeMemoryDustCanvas(time: 1200)
-            }
-        }
-        .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
-            isAppActive = true
-        }
-        .onReceive(NotificationCenter.default.publisher(for: NSApplication.didResignActiveNotification)) { _ in
-            isAppActive = false
-        }
-        .allowsHitTesting(false)
-        .accessibilityHidden(true)
-    }
-}
-
-private struct HomeMemoryDustCanvas: View {
-    let time: TimeInterval
-
-    var body: some View {
-        Canvas { context, size in
-            for index in 0..<56 {
-                let fi = Double(index)
-                // Deterministic per-index pseudo-randoms (no RNG — resume-safe
-                // and stable across frames).
-                let seedX = abs((sin(fi * 12.9898) * 43758.5453).truncatingRemainder(dividingBy: 1))
-                let seedY = abs((sin(fi * 78.233) * 12543.123).truncatingRemainder(dividingBy: 1))
-                let seedP = abs((sin(fi * 3.7) * 951.135).truncatingRemainder(dividingBy: 1))
-
-                // Slow upward drift with a gentle horizontal sway.
-                let rawY = (seedY * size.height - time * (3.0 + seedP * 5.0))
-                    .truncatingRemainder(dividingBy: size.height)
-                let y = rawY < 0 ? rawY + size.height : rawY
-                let x = seedX * size.width + sin(time * 0.22 + fi * 1.3) * 7
-
-                let twinkle = 0.5 + 0.5 * sin(time * (0.5 + seedP * 0.8) + fi * 1.7)
-                let alpha = 0.03 + twinkle * (0.04 + seedP * 0.08)
-                let radius = 0.8 + seedP * 1.5
-
-                let rect = CGRect(x: x - radius, y: y - radius, width: radius * 2, height: radius * 2)
-                let color = index % 6 == 0
-                    ? HomePalette.glow.opacity(alpha * 1.4)
-                    : Color.white.opacity(alpha)
-                context.fill(Path(ellipseIn: rect), with: .color(color))
-            }
-        }
     }
 }
 

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
@@ -611,11 +611,17 @@ struct DashboardPage: View {
     /// suggested questions under the bar while the hub is showing.
     private var homeStage: some View {
         VStack(spacing: 0) {
+            // Constant container alignment — each mode positions itself inside
+            // the flexible area. Animating the container's own alignment made
+            // the hub snap instead of gliding when the chat opened.
             ZStack {
                 switch homeMode {
                 case .hub:
-                    homeHubCenterpiece
-                        .transition(.homeHubFade)
+                    VStack(spacing: 0) {
+                        Spacer(minLength: 0)
+                        homeHubCenterpiece
+                    }
+                    .transition(.homeHubFade)
                 case .chat:
                     homeChatPanel
                         .transition(.homeDropFromTop)
@@ -624,18 +630,12 @@ struct DashboardPage: View {
                         .transition(.homeDropFromTop)
                 }
             }
-            // Hub: the centerpiece sits directly above the ask bar; the chat /
-            // connect panels fill the whole area instead.
-            .frame(
-                maxWidth: .infinity,
-                maxHeight: .infinity,
-                alignment: homeMode == .hub ? .bottom : .center
-            )
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
 
             homeAskBar
                 .frame(maxWidth: Self.homeAskBarMaxWidth)
                 .padding(.horizontal, Self.homeStageHorizontalPadding)
-                .padding(.top, homeMode == .hub ? 26 : 16)
+                .padding(.top, 22)
 
             if homeMode == .hub {
                 homeSuggestionList
@@ -702,7 +702,7 @@ struct DashboardPage: View {
                     )
                 }
             }
-            .frame(width: 336)
+            .frame(width: 304)
         }
         .frame(maxWidth: .infinity)
     }
@@ -766,38 +766,18 @@ struct DashboardPage: View {
     // MARK: Connect tray
 
     private var homeConnectPanel: some View {
-        VStack(alignment: .leading, spacing: 16) {
-            HStack(alignment: .top) {
-                VStack(alignment: .leading, spacing: 4) {
-                    Text("Connect")
-                        .font(.system(size: 24, weight: .medium, design: .serif))
-                        .foregroundStyle(HomePalette.ink)
-
-                    Text("Feed omi new context — and take its memory everywhere.")
-                        .scaledFont(size: 12, weight: .medium)
-                        .foregroundStyle(HomePalette.muted)
+        ScrollView(showsIndicators: false) {
+            HStack(alignment: .top, spacing: 24) {
+                VStack(alignment: .leading, spacing: 12) {
+                    sourceColumnHeader
+                    sourceConstellation
                 }
+                .frame(maxWidth: .infinity)
 
-                Spacer()
-
-                HomeIconActionButton(title: "Close connect", systemImage: "xmark") {
-                    closeHomeStagePanel()
-                }
-            }
-
-            ScrollView(showsIndicators: false) {
-                HStack(alignment: .top, spacing: 24) {
-                    VStack(alignment: .leading, spacing: 12) {
-                        sourceColumnHeader
-                        sourceConstellation
-                    }
+                destinationStack
                     .frame(maxWidth: .infinity)
-
-                    destinationStack
-                        .frame(maxWidth: .infinity)
-                }
-                .padding(.bottom, 4)
             }
+            .padding(.bottom, 4)
         }
         .padding(24)
         .background(
@@ -808,6 +788,12 @@ struct DashboardPage: View {
             RoundedRectangle(cornerRadius: 28, style: .continuous)
                 .stroke(HomePalette.hairline.opacity(0.9), lineWidth: 1)
         )
+        .overlay(alignment: .topTrailing) {
+            HomeIconActionButton(title: "Close connect", systemImage: "xmark") {
+                closeHomeStagePanel()
+            }
+            .padding(14)
+        }
         .shadow(color: .black.opacity(0.4), radius: 30, y: 16)
         .frame(maxWidth: Self.homeStagePanelMaxWidth)
         .padding(.horizontal, Self.homeStageHorizontalPadding)
@@ -1754,7 +1740,7 @@ extension AnyTransition {
 
     fileprivate static var homeHubFade: AnyTransition {
         .modifier(
-            active: HomeStageDropModifier(offsetY: 18, scale: 0.985, opacity: 0),
+            active: HomeStageDropModifier(offsetY: 14, scale: 1, opacity: 0),
             identity: HomeStageDropModifier(offsetY: 0, scale: 1, opacity: 1)
         )
     }
@@ -2815,44 +2801,42 @@ private struct HomeCenterMetricTile: View {
 
     var body: some View {
         Button(action: action) {
-            VStack(alignment: .leading, spacing: 3) {
+            VStack(alignment: .leading, spacing: 6) {
                 HStack {
                     Image(systemName: systemImage)
-                        .scaledFont(size: 11, weight: .semibold)
+                        .scaledFont(size: 12, weight: .semibold)
                         .foregroundStyle(HomePalette.ink)
 
                     Spacer(minLength: 8)
 
                     Image(systemName: "arrow.up.right")
-                        .scaledFont(size: 8, weight: .bold)
+                        .scaledFont(size: 9, weight: .bold)
                         .foregroundStyle(isHovering ? HomePalette.ink : HomePalette.faint)
                 }
 
-                Spacer(minLength: 0)
-
                 Text(value)
-                    .font(.system(size: 17, weight: .medium, design: .serif))
+                    .font(.system(size: 20, weight: .medium, design: .serif))
                     .foregroundStyle(HomePalette.ink)
                     .lineLimit(1)
                     .minimumScaleFactor(0.75)
 
                 Text(title)
-                    .scaledFont(size: 10, weight: .medium)
+                    .scaledFont(size: 11, weight: .medium)
                     .foregroundStyle(HomePalette.muted)
                     .lineLimit(1)
                     .minimumScaleFactor(0.82)
             }
-            .padding(9)
-            .frame(maxWidth: .infinity, minHeight: 66, maxHeight: 66, alignment: .topLeading)
+            .padding(10)
+            .frame(maxWidth: .infinity, minHeight: 82, maxHeight: 82, alignment: .topLeading)
             .background(
-                RoundedRectangle(cornerRadius: 13, style: .continuous)
+                RoundedRectangle(cornerRadius: 15, style: .continuous)
                     .fill(isHovering ? HomePalette.tileHover : HomePalette.tile.opacity(0.92))
             )
             .overlay(
-                RoundedRectangle(cornerRadius: 13, style: .continuous)
+                RoundedRectangle(cornerRadius: 15, style: .continuous)
                     .stroke(isHovering ? HomePalette.hairline : HomePalette.hairline.opacity(0.82), lineWidth: 1)
             )
-            .contentShape(.rect(cornerRadius: 13))
+            .contentShape(.rect(cornerRadius: 15))
         }
         .buttonStyle(.plain)
         .onHover { isHovering = $0 }

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
@@ -1182,48 +1182,6 @@ struct DashboardPage: View {
         }
     }
 
-    private var homeMetricsStrip: some View {
-        VStack(spacing: 8) {
-            homeMetricTopRow
-            homeMetricBottomRow
-        }
-        .frame(maxWidth: .infinity)
-    }
-
-    private var homeMetricTopRow: some View {
-        HStack(spacing: 8) {
-            HomeCenterMetricTile(
-                title: "Conversations",
-                value: conversationMetricValue,
-                systemImage: "text.bubble.fill",
-                action: { navigate(to: .conversations) }
-            )
-            HomeCenterMetricTile(
-                title: "Tasks",
-                value: taskMetricValue,
-                systemImage: "checklist",
-                action: { navigate(to: .tasks) }
-            )
-        }
-    }
-
-    private var homeMetricBottomRow: some View {
-        HStack(spacing: 8) {
-            HomeCenterMetricTile(
-                title: "Memories",
-                value: memoryMetricValue,
-                systemImage: "brain",
-                action: { navigate(to: .memories) }
-            )
-            HomeCenterMetricTile(
-                title: "Screenshots",
-                value: screenshotMetricValue,
-                systemImage: "photo.on.rectangle.angled",
-                action: { navigate(to: .rewind) }
-            )
-        }
-    }
-
     private var conversationMetricValue: String {
         formattedCount(conversationCount ?? appState.totalConversationsCount ?? appState.conversations.count)
     }

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
@@ -733,6 +733,8 @@ struct DashboardPage: View {
 
                 Spacer()
             }
+            .padding(.horizontal, 20)
+            .padding(.top, 16)
             .padding(.bottom, 2)
 
             ChatMessagesView(
@@ -769,7 +771,19 @@ struct DashboardPage: View {
                     endPoint: .bottom
                 )
             )
+            .padding(.horizontal, 8)
+            .padding(.bottom, 6)
         }
+        // Barely-there card so the chat reads as a bounded surface — making it
+        // obvious the canvas around it is clickable (and closes the chat).
+        .background(
+            RoundedRectangle(cornerRadius: 26, style: .continuous)
+                .fill(Color.white.opacity(0.016))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 26, style: .continuous)
+                .stroke(HomePalette.hairline.opacity(0.55), lineWidth: 1)
+        )
         .frame(maxWidth: Self.homeStagePanelMaxWidth)
         .padding(.horizontal, Self.homeStageHorizontalPadding)
     }

--- a/desktop/macos/changelog/unreleased/20260707-home-chat-redesign.json
+++ b/desktop/macos/changelog/unreleased/20260707-home-chat-redesign.json
@@ -1,0 +1,3 @@
+{
+  "change": "Redesigned Home: ask omi directly from a new chat bar (chat slides in on the same page), suggested questions under the bar, and data connections tucked behind a Connect button"
+}


### PR DESCRIPTION
## What

Redesigns the macOS Home into a single centered stage:

- **Ask bar** (persistent, bottom): real chat input with paperclip/drag-drop attachments (same limits as the chat page), send/stop, and a **Connect** button inside the pill.
- **Inline chat**: clicking/focusing the bar (or sending, or a suggestion) reveals the chat on the same page with a drop-from-top spring animation, inside a barely-there bordered card; clicking anywhere outside (or Esc) collapses back to the hub.
- **Connect tray**: the Connect button reveals the "Connect data" and "Use omi memory anywhere" groups (moved off the always-visible dashboard) as two sub-cards with a flow chevron between them.
- **Top-3 suggested questions** (post-onboarding suggestions with fallbacks) under the bar.
- **Canvas**: the old routing-panel rectangle and ambient flow blobs are gone — clean near-black background with a soft key light; hub shows the omi wordmark + knowledge tiles right above the bar.
- Automation bridge: `home_open_chat` / `home_connect_toggle` / `home_close_panel` / `home_ask` / `home_attach` actions for cursor-free testing.

## Verification

Exercised live in the `omi-home-chat` named bundle against prod backend across 7 feedback rounds with Nik testing in parallel:
- Real questions sent through the ask bar streamed real agent replies inline (tool steps included).
- Attachment staged via the paperclip wiring; agent read the file and quoted its exact content.
- Tab-focus opens the chat with a real key event; Esc closes; Connect tray round-trips.
- 8-frame capture burst during open shows a clean glide (no snap).
- Clean release build: `rm -rf .build && xcrun swift build -c release --triple arm64-apple-macosx` → Build complete (412s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9195?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

