### PR TITLE
desktop: Home ask bar requires text to send (attachment-only was a silent no-op)

### DIFF
--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
@@ -920,8 +920,9 @@ struct DashboardPage: View {
 
     private func sendFromHomeAskBar() {
         let text = chatProvider.draftText.trimmingCharacters(in: .whitespacesAndNewlines)
-        // Attachments without text are sendable, matching the chat page.
-        guard !text.isEmpty || !chatProvider.pendingAttachments.isEmpty else { return }
+        // Text is required — ChatProvider.sendMessage no-ops on empty text, so
+        // an attachment-only "send" would silently drop the turn.
+        guard !text.isEmpty else { return }
         chatProvider.draftText = ""
         openHomeChat()
         AnalyticsManager.shared.chatMessageSent(
@@ -1833,9 +1834,11 @@ private struct HomeAskBar: View {
         !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
 
-    /// Matches ChatInputView: attachments without text are sendable.
+    /// Requires text: ChatProvider.sendMessage drops empty-text sends, so
+    /// presenting attachment-only as sendable would silently do nothing.
+    /// Staged files ride along with the typed message instead.
     private var canSend: Bool {
-        hasText || !attachments.isEmpty
+        hasText
     }
 
     private var isFocused: Bool { focus.wrappedValue }

--- a/desktop/macos/changelog/unreleased/20260707-home-askbar-attachment-send.json
+++ b/desktop/macos/changelog/unreleased/20260707-home-askbar-attachment-send.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed the Home ask bar showing a send button for attachment-only input that silently did nothing"
+}


### PR DESCRIPTION
Follow-up to #9195, from cross-review: `ChatProvider.sendMessage` drops empty-text sends, so the Home ask bar presented attachment-only input as sendable but silently did nothing. The send button now requires text; staged files ride along with the typed message.

Verified in the omi-home-chat bundle: staging a file alone shows no send button; adding text sends and the agent read the file and quoted its exact content inline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9197?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

