### PR TITLE
Gate backend prod deploys on blessing

### DIFF
--- a/.github/release-blessing-surfaces.json
+++ b/.github/release-blessing-surfaces.json
@@ -1,0 +1,31 @@
+{
+  "version": 1,
+  "surfaces": {
+    "python-backend": {
+      "display_name": "Python backend",
+      "blessing_tag_prefix": "python-backend-bless-",
+      "depends_on": [],
+      "promotion_workflows": [".github/workflows/gcp_backend.yml"]
+    },
+    "desktop-rust-backend": {
+      "display_name": "Desktop Rust backend",
+      "depends_on": ["python-backend"],
+      "promotion_workflows": [".github/workflows/desktop_promote_prod.yml"]
+    },
+    "desktop-macos": {
+      "display_name": "macOS Desktop app",
+      "depends_on": ["desktop-rust-backend", "python-backend"],
+      "promotion_workflows": [".github/workflows/desktop_promote_prod.yml"]
+    },
+    "flutter-ios": {
+      "display_name": "Flutter iOS app",
+      "depends_on": ["python-backend"],
+      "promotion_workflows": []
+    },
+    "flutter-android": {
+      "display_name": "Flutter Android app",
+      "depends_on": ["python-backend"],
+      "promotion_workflows": []
+    }
+  }
+}

--- a/.github/scripts/check-backend-prod-promotion-policy.py
+++ b/.github/scripts/check-backend-prod-promotion-policy.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Guard the Python backend prod blessing gate in gcp_backend.yml."""
+
+from pathlib import Path
+
+
+WORKFLOW = Path(".github/workflows/gcp_backend.yml")
+
+
+def fail(message: str) -> None:
+    raise SystemExit(f"FAIL: {message}")
+
+
+def require(needle: str, text: str, message: str) -> None:
+    if needle not in text:
+        fail(message)
+
+
+def require_order(text: str, first: str, second: str, message: str) -> None:
+    first_index = text.find(first)
+    second_index = text.find(second)
+    if first_index == -1 or second_index == -1 or first_index >= second_index:
+        fail(message)
+
+
+def job_block(text: str, job_name: str) -> str:
+    lines = text.splitlines()
+    start = None
+    for index, line in enumerate(lines):
+        if line == f"  {job_name}:":
+            start = index
+            break
+    if start is None:
+        fail(f"workflow is missing {job_name} job")
+
+    end = len(lines)
+    for index in range(start + 1, len(lines)):
+        line = lines[index]
+        if line.startswith("  ") and not line.startswith("    ") and line.endswith(":"):
+            end = index
+            break
+    return "\n".join(lines[start:end])
+
+
+def main() -> int:
+    text = WORKFLOW.read_text(encoding="utf-8")
+    deploy_text = job_block(text, "deploy")
+    repair_text = job_block(text, "repair-traffic")
+
+    require("override_unblessed:", text, "backend prod deploy must expose override_unblessed")
+    require("override_confirm:", text, "backend prod deploy must expose override_confirm")
+    require("I-ACCEPT-UNBLESSED-PROD-RISK", text, "backend prod deploy must require typed override confirmation")
+    if "Validate prod Python backend blessing" in repair_text:
+        fail("repair-traffic must not carry the prod blessing gate; it does not deploy new code")
+    require("Validate prod Python backend blessing", deploy_text, "deploy job must validate python-backend blessing")
+    require("if: ${{ github.event.inputs.environment == 'prod' }}", deploy_text, "blessing gate must only block prod")
+    require("check-python-backend-blessing.py", deploy_text, "deploy job must call the blessing validator")
+    require("python-backend-bless-${TARGET_SHA}", deploy_text, "deploy job must look up the target SHA blessing")
+    require("backend/scripts/bless-python-backend.sh", deploy_text, "deploy job must tell operators how to bless")
+    require("DEPLOY_SHA=\"$(git rev-parse HEAD)\"", deploy_text, "deploy identity must use the checked-out ref")
+    require("--tag-sha", deploy_text, "deploy job must verify the blessing tag points to the target SHA")
+    require("Google Auth", deploy_text, "workflow must authenticate to GCP only after the prod blessing gate")
+    require_order(
+        deploy_text,
+        "Validate prod Python backend blessing",
+        "Google Auth",
+        "prod blessing gate must run before GCP auth and deploy mutations",
+    )
+    require_order(
+        deploy_text,
+        "Validate prod Python backend blessing",
+        "Build and Push Docker image",
+        "prod blessing gate must run before image build/push",
+    )
+    require_order(
+        deploy_text,
+        "Validate prod Python backend blessing",
+        "Deploy ${{ env.SERVICE }} to Cloud Run",
+        "prod blessing gate must run before Cloud Run deploy",
+    )
+
+    print("backend prod promotion policy OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/check-python-backend-blessing.py
+++ b/.github/scripts/check-python-backend-blessing.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Validate a Python backend blessing release for prod deployment."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from desktop_release_metadata import fail, parse_metadata  # noqa: E402
+from release_blessing import require_surface_blessed, surface_blessing_from_metadata  # noqa: E402
+
+
+SURFACE_ID = "python-backend"
+CONFIRM_PHRASE = "I-ACCEPT-UNBLESSED-PROD-RISK"
+BLESS_TAG_PREFIX = "python-backend-bless-"
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+
+
+def write_github_output(path: str | None, values: dict[str, str]) -> None:
+    if not path:
+        return
+    with Path(path).open("a", encoding="utf-8") as f:
+        for key, value in values.items():
+            print(f"{key}={value}", file=f)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--release-json", required=True)
+    parser.add_argument("--target-sha", required=True)
+    parser.add_argument("--tag-sha")
+    parser.add_argument("--github-output")
+    parser.add_argument(
+        "--override-unblessed",
+        action="store_true",
+        help="DANGER: allow prod deployment without a blessed backend SHA",
+    )
+    parser.add_argument(
+        "--override-confirm",
+        default="",
+        help=f"Must be {CONFIRM_PHRASE} when --override-unblessed is set",
+    )
+    args = parser.parse_args()
+
+    override_unblessed = args.override_unblessed and args.override_confirm == CONFIRM_PHRASE
+    if args.override_unblessed and not override_unblessed:
+        fail(f"--override-unblessed requires --override-confirm {CONFIRM_PHRASE}")
+
+    target_sha = args.target_sha.strip()
+    if not SHA_RE.match(target_sha):
+        fail("--target-sha must be a full 40-char lowercase git SHA")
+    if args.tag_sha and args.tag_sha.strip() != target_sha:
+        if override_unblessed:
+            print(f"python backend blessing tag sha mismatch ignored by override: {args.tag_sha} != {target_sha}")
+        else:
+            fail(f"python backend blessing tag sha ({args.tag_sha}) does not match deploy target ({target_sha})")
+
+    expected_tag = f"{BLESS_TAG_PREFIX}{target_sha}"
+    release = json.loads(Path(args.release_json).read_text(encoding="utf-8"))
+    tag_name = release.get("tagName")
+    asset_names = {asset.get("name") for asset in release.get("assets", [])}
+    blessed_sha = ""
+
+    if tag_name != expected_tag:
+        if override_unblessed:
+            print(f"python backend blessing tag mismatch ignored by override: expected {expected_tag}, got {tag_name}")
+        else:
+            fail(f"python backend blessing tag mismatch: expected {expected_tag}, got {tag_name}")
+    else:
+        metadata = parse_metadata(release.get("body") or "")
+        blessing = surface_blessing_from_metadata(metadata, SURFACE_ID)
+        blessed_sha = blessing.sha
+        if not override_unblessed:
+            if release.get("isDraft"):
+                fail(f"{tag_name} is still a draft release")
+            require_surface_blessed(blessing)
+            if blessing.sha != target_sha:
+                fail(f"python backend blessed sha ({blessing.sha}) does not match deploy target ({target_sha})")
+            if blessing.evidence not in asset_names:
+                fail(f"{tag_name} is missing blessing evidence asset {blessing.evidence!r}")
+        elif blessing.sha and blessing.sha != target_sha:
+            print(
+                f"python backend blessed sha ({blessing.sha}) does not match deploy target ({target_sha}); "
+                "allowed by override"
+            )
+
+    write_github_output(
+        args.github_output,
+        {
+            "python_backend_blessed_sha": blessed_sha,
+            "python_backend_blessed_override": "true" if override_unblessed else "false",
+        },
+    )
+    print(f"python backend blessing check OK for {target_sha}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/release_blessing.py
+++ b/.github/scripts/release_blessing.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Shared release blessing metadata and dependency helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+from pathlib import Path
+
+from desktop_release_metadata import fail
+
+
+ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_REGISTRY_PATH = ROOT / ".github/release-blessing-surfaces.json"
+TRUE_VALUES = {"true", "1", "yes"}
+
+
+@dataclass(frozen=True)
+class BlessingSurface:
+    id: str
+    display_name: str
+    depends_on: tuple[str, ...]
+    promotion_workflows: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class SurfaceBlessing:
+    surface_id: str
+    blessed: bool
+    sha: str
+    blessed_at: str
+    tier: str
+    evidence: str
+
+
+def load_surface_registry(path: Path = DEFAULT_REGISTRY_PATH) -> dict[str, BlessingSurface]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    raw_surfaces = payload.get("surfaces")
+    if not isinstance(raw_surfaces, dict) or not raw_surfaces:
+        fail(f"{path} must contain a non-empty surfaces object")
+
+    surfaces: dict[str, BlessingSurface] = {}
+    for surface_id, config in raw_surfaces.items():
+        if not isinstance(config, dict):
+            fail(f"surface {surface_id!r} must be an object")
+        depends_on = tuple(config.get("depends_on") or ())
+        promotion_workflows = tuple(config.get("promotion_workflows") or ())
+        surfaces[surface_id] = BlessingSurface(
+            id=surface_id,
+            display_name=str(config.get("display_name") or surface_id),
+            depends_on=depends_on,
+            promotion_workflows=promotion_workflows,
+        )
+
+    for surface in surfaces.values():
+        for dependency in surface.depends_on:
+            if dependency not in surfaces:
+                fail(f"surface {surface.id!r} depends on unknown surface {dependency!r}")
+            if dependency == surface.id:
+                fail(f"surface {surface.id!r} cannot depend on itself")
+
+    return surfaces
+
+
+def namespaced_key(surface_id: str, field: str | None = None) -> str:
+    if field is None or field == "blessed":
+        return f"blessed.{surface_id}"
+    return f"blessed.{surface_id}.{field}"
+
+
+def parse_bool(value: str) -> bool:
+    return value.strip().lower() in TRUE_VALUES
+
+
+def surface_blessing_from_metadata(
+    metadata: dict[str, str],
+    surface_id: str,
+    *,
+    allow_legacy_desktop: bool = False,
+) -> SurfaceBlessing:
+    if (
+        allow_legacy_desktop
+        and surface_id == "desktop-macos"
+        and namespaced_key(surface_id) not in metadata
+        and "blessed" in metadata
+    ):
+        return SurfaceBlessing(
+            surface_id=surface_id,
+            blessed=parse_bool(metadata.get("blessed", "")),
+            sha=metadata.get("blessedSha", "").strip(),
+            blessed_at=metadata.get("blessedAt", "").strip(),
+            tier=metadata.get("blessedTier", "").strip(),
+            evidence=metadata.get("blessedEvidence", "").strip(),
+        )
+
+    return SurfaceBlessing(
+        surface_id=surface_id,
+        blessed=parse_bool(metadata.get(namespaced_key(surface_id), "")),
+        sha=metadata.get(namespaced_key(surface_id, "sha"), "").strip(),
+        blessed_at=metadata.get(namespaced_key(surface_id, "at"), "").strip(),
+        tier=metadata.get(namespaced_key(surface_id, "tier"), "").strip(),
+        evidence=metadata.get(namespaced_key(surface_id, "evidence"), "").strip(),
+    )
+
+
+def require_surface_blessed(blessing: SurfaceBlessing) -> None:
+    if not blessing.blessed:
+        fail(f"{blessing.surface_id} must be blessed before prod promotion")
+    if not blessing.sha:
+        fail(f"{blessing.surface_id} blessing is missing sha metadata")
+    if not blessing.blessed_at:
+        fail(f"{blessing.surface_id} blessing is missing at metadata")
+
+
+def dependency_closure(surface_id: str, surfaces: dict[str, BlessingSurface]) -> list[str]:
+    if surface_id not in surfaces:
+        fail(f"unknown blessing surface: {surface_id}")
+
+    ordered: list[str] = []
+    visiting: set[str] = set()
+    visited: set[str] = set()
+
+    def visit(current: str) -> None:
+        if current in visited:
+            return
+        if current in visiting:
+            fail(f"cycle detected in blessing surface dependencies at {current}")
+        visiting.add(current)
+        for dependency in surfaces[current].depends_on:
+            visit(dependency)
+        visiting.remove(current)
+        visited.add(current)
+        ordered.append(current)
+
+    visit(surface_id)
+    return ordered
+
+
+def require_blessed_closure(surface_id: str, blessings: dict[str, SurfaceBlessing]) -> None:
+    surfaces = load_surface_registry()
+    for required_surface in dependency_closure(surface_id, surfaces):
+        blessing = blessings.get(required_surface)
+        if blessing is None:
+            fail(f"{surface_id} promotion is missing blessing data for {required_surface}")
+        if blessing.surface_id != required_surface:
+            fail(f"{surface_id} promotion has {blessing.surface_id} blessing data for {required_surface}")
+        require_surface_blessed(blessing)

--- a/.github/scripts/test_check_python_backend_blessing.py
+++ b/.github/scripts/test_check_python_backend_blessing.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Tests for Python backend blessing gate."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / ".github/scripts/check-python-backend-blessing.py"
+
+
+def run_check(release: dict, sha: str, *extra: str) -> subprocess.CompletedProcess[str]:
+    release_path = Path("/tmp/python-backend-blessing-test.json")
+    release_path.write_text(json.dumps(release), encoding="utf-8")
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), "--release-json", str(release_path), "--target-sha", sha, *extra],
+        text=True,
+        capture_output=True,
+    )
+
+
+def blessing_release(sha: str, metadata: dict[str, str]) -> dict:
+    lines = ["KEY_VALUE_START", *[f"{key}: {value}" for key, value in metadata.items()], "KEY_VALUE_END"]
+    return {
+        "tagName": f"python-backend-bless-{sha}",
+        "isDraft": False,
+        "isPrerelease": False,
+        "body": "\n".join(lines),
+        "assets": [{"name": f"python-backend-bless-evidence-{sha}.json"}],
+    }
+
+
+def test_blessed_backend_passes() -> None:
+    sha = "a" * 40
+    release = blessing_release(
+        sha,
+        {
+            "blessed.python-backend": "true",
+            "blessed.python-backend.sha": sha,
+            "blessed.python-backend.at": "2026-07-07T00:00:00Z",
+            "blessed.python-backend.tier": "unit+workflow-contracts+openapi",
+            "blessed.python-backend.evidence": f"python-backend-bless-evidence-{sha}.json",
+        },
+    )
+    result = run_check(release, sha)
+    assert result.returncode == 0, result.stderr
+
+
+def test_unblessed_backend_fails() -> None:
+    sha = "b" * 40
+    release = blessing_release(
+        sha,
+        {
+            "blessed.python-backend.sha": sha,
+            "blessed.python-backend.at": "2026-07-07T00:00:00Z",
+        },
+    )
+    result = run_check(release, sha)
+    assert result.returncode != 0
+    assert "python-backend" in result.stderr
+
+
+def test_sha_mismatch_fails() -> None:
+    sha = "c" * 40
+    release = blessing_release(
+        sha,
+        {
+            "blessed.python-backend": "true",
+            "blessed.python-backend.sha": "d" * 40,
+            "blessed.python-backend.at": "2026-07-07T00:00:00Z",
+        },
+    )
+    result = run_check(release, sha)
+    assert result.returncode != 0
+    assert "does not match" in result.stderr
+
+
+def test_tag_sha_mismatch_fails() -> None:
+    sha = "f" * 40
+    release = blessing_release(
+        sha,
+        {
+            "blessed.python-backend": "true",
+            "blessed.python-backend.sha": sha,
+            "blessed.python-backend.at": "2026-07-07T00:00:00Z",
+            "blessed.python-backend.evidence": f"python-backend-bless-evidence-{sha}.json",
+        },
+    )
+    result = run_check(release, sha, "--tag-sha", "0" * 40)
+    assert result.returncode != 0
+    assert "tag sha" in result.stderr
+
+
+def test_override_requires_typed_confirm() -> None:
+    sha = "e" * 40
+    release = {"tagName": "wrong-tag", "body": ""}
+    result = run_check(release, sha, "--override-unblessed", "--override-confirm", "nope")
+    assert result.returncode != 0
+    override = run_check(
+        release,
+        sha,
+        "--override-unblessed",
+        "--override-confirm",
+        "I-ACCEPT-UNBLESSED-PROD-RISK",
+    )
+    assert override.returncode == 0, override.stderr
+
+
+if __name__ == "__main__":
+    test_blessed_backend_passes()
+    test_unblessed_backend_fails()
+    test_sha_mismatch_fails()
+    test_tag_sha_mismatch_fails()
+    test_override_requires_typed_confirm()
+    print("check-python-backend-blessing tests OK")

--- a/.github/scripts/test_release_blessing.py
+++ b/.github/scripts/test_release_blessing.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Tests for shared release blessing helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR))
+
+from release_blessing import (  # noqa: E402
+    SurfaceBlessing,
+    dependency_closure,
+    load_surface_registry,
+    require_blessed_closure,
+    surface_blessing_from_metadata,
+)
+
+
+def test_registry_loads_and_orders_dependencies() -> None:
+    surfaces = load_surface_registry()
+    assert "python-backend" in surfaces
+    assert dependency_closure("desktop-macos", surfaces) == [
+        "python-backend",
+        "desktop-rust-backend",
+        "desktop-macos",
+    ]
+
+
+def test_namespaced_python_backend_metadata() -> None:
+    blessing = surface_blessing_from_metadata(
+        {
+            "blessed.python-backend": "true",
+            "blessed.python-backend.sha": "abc123",
+            "blessed.python-backend.at": "2026-07-07T00:00:00Z",
+            "blessed.python-backend.tier": "unit+contracts",
+            "blessed.python-backend.evidence": "backend-evidence.json",
+        },
+        "python-backend",
+    )
+    assert blessing.blessed
+    assert blessing.sha == "abc123"
+    assert blessing.blessed_at == "2026-07-07T00:00:00Z"
+    assert blessing.tier == "unit+contracts"
+    assert blessing.evidence == "backend-evidence.json"
+
+
+def test_legacy_desktop_metadata_still_parses() -> None:
+    blessing = surface_blessing_from_metadata(
+        {
+            "blessed": "true",
+            "blessedSha": "desktop123",
+            "blessedAt": "2026-07-07T00:00:00Z",
+            "blessedTier": "2",
+        },
+        "desktop-macos",
+        allow_legacy_desktop=True,
+    )
+    assert blessing.blessed
+    assert blessing.sha == "desktop123"
+    assert blessing.blessed_at == "2026-07-07T00:00:00Z"
+    assert blessing.tier == "2"
+
+
+def test_namespaced_desktop_metadata_preferred_over_legacy() -> None:
+    blessing = surface_blessing_from_metadata(
+        {
+            "blessed": "true",
+            "blessedSha": "stale",
+            "blessedAt": "2026-07-06T00:00:00Z",
+            "blessed.desktop-macos": "false",
+            "blessed.desktop-macos.sha": "current",
+            "blessed.desktop-macos.at": "2026-07-07T00:00:00Z",
+        },
+        "desktop-macos",
+        allow_legacy_desktop=True,
+    )
+    assert not blessing.blessed
+    assert blessing.sha == "current"
+    assert blessing.blessed_at == "2026-07-07T00:00:00Z"
+
+
+def test_closure_requires_every_surface_blessed() -> None:
+    blessings = {
+        "python-backend": SurfaceBlessing("python-backend", True, "py123", "2026-07-07T00:00:00Z", "unit", ""),
+        "desktop-rust-backend": SurfaceBlessing(
+            "desktop-rust-backend",
+            True,
+            "rust123",
+            "2026-07-07T00:00:00Z",
+            "contracts",
+            "",
+        ),
+    }
+    try:
+        require_blessed_closure("desktop-macos", blessings)
+    except SystemExit as exc:
+        assert "desktop-macos" in str(exc)
+    else:
+        raise AssertionError("missing desktop-macos blessing should fail")
+
+
+def test_closure_rejects_mismatched_blessing_surface() -> None:
+    blessings = {
+        "python-backend": SurfaceBlessing("desktop-macos", True, "py123", "2026-07-07T00:00:00Z", "unit", ""),
+        "desktop-rust-backend": SurfaceBlessing(
+            "desktop-rust-backend",
+            True,
+            "rust123",
+            "2026-07-07T00:00:00Z",
+            "contracts",
+            "",
+        ),
+        "desktop-macos": SurfaceBlessing("desktop-macos", True, "desk123", "2026-07-07T00:00:00Z", "2", ""),
+    }
+    try:
+        require_blessed_closure("desktop-macos", blessings)
+    except SystemExit as exc:
+        assert "desktop-macos promotion has desktop-macos blessing data for python-backend" in str(exc)
+    else:
+        raise AssertionError("mismatched blessing surface should fail")
+
+
+if __name__ == "__main__":
+    test_registry_loads_and_orders_dependencies()
+    test_namespaced_python_backend_metadata()
+    test_legacy_desktop_metadata_still_parses()
+    test_namespaced_desktop_metadata_preferred_over_legacy()
+    test_closure_requires_every_surface_blessed()
+    test_closure_rejects_mismatched_blessing_surface()
+    print("release blessing tests OK")

--- a/.github/workflows/gcp_backend.yml
+++ b/.github/workflows/gcp_backend.yml
@@ -35,6 +35,15 @@ on:
         options:
           - all
           - cloud-run-only
+      override_unblessed:
+        description: 'DANGER: allow prod deploy without python-backend blessing'
+        required: false
+        default: false
+        type: boolean
+      override_confirm:
+        description: 'Type I-ACCEPT-UNBLESSED-PROD-RISK with override_unblessed'
+        required: false
+        default: ''
 
 env:
   SERVICE: backend
@@ -117,6 +126,48 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.inputs.branch }}
+          fetch-depth: 0
+
+      - name: Validate prod Python backend blessing
+        if: ${{ github.event.inputs.environment == 'prod' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          OVERRIDE_UNBLESSED: ${{ github.event.inputs.override_unblessed }}
+          OVERRIDE_CONFIRM: ${{ github.event.inputs.override_confirm }}
+        run: |
+          set -euo pipefail
+
+          TARGET_SHA="$(git rev-parse HEAD)"
+          BLESS_TAG="python-backend-bless-${TARGET_SHA}"
+          RELEASE_JSON="/tmp/python-backend-blessing.json"
+          git fetch --force --tags origin "+refs/tags/${BLESS_TAG}:refs/tags/${BLESS_TAG}" || true
+
+          if ! gh release view "$BLESS_TAG" --repo "$REPO" --json tagName,body,isDraft,isPrerelease,assets > "$RELEASE_JSON"; then
+            if [ "$OVERRIDE_UNBLESSED" = "true" ]; then
+              echo "::warning::No python-backend blessing release found for ${TARGET_SHA}; allowed by override_unblessed"
+              echo "::warning::No python-backend blessing release found for ${TARGET_SHA}; allowed by override_unblessed" >> "$GITHUB_STEP_SUMMARY"
+              printf '{"tagName":"missing-%s","body":""}\n' "$BLESS_TAG" > "$RELEASE_JSON"
+            else
+              echo "Missing python-backend blessing release: ${BLESS_TAG}" >&2
+              echo "Run backend/scripts/bless-python-backend.sh --ref ${TARGET_SHA} before prod deploy, or use the typed override." >&2
+              exit 1
+            fi
+          fi
+
+          OVERRIDE_ARGS=()
+          if [ "$OVERRIDE_UNBLESSED" = "true" ]; then
+            OVERRIDE_ARGS=(--override-unblessed --override-confirm "$OVERRIDE_CONFIRM")
+            echo "::warning::Python backend prod deploy override_unblessed enabled for ${TARGET_SHA}"
+            echo "::warning::Python backend prod deploy override_unblessed enabled for ${TARGET_SHA}" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+          python3 .github/scripts/check-python-backend-blessing.py \
+            --release-json "$RELEASE_JSON" \
+            --target-sha "$TARGET_SHA" \
+            --tag-sha "$(git rev-list -n1 "$BLESS_TAG" 2>/dev/null || true)" \
+            --github-output "$GITHUB_OUTPUT" \
+            "${OVERRIDE_ARGS[@]}"
 
       - name: Google Auth
         id: auth
@@ -133,11 +184,13 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Compute short SHA
+      - name: Compute deploy identity
         id: image-tag
         run: |
-          echo "short_sha=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
-          echo "revision_suffix=${GITHUB_SHA::7}-${GITHUB_RUN_ATTEMPT}" >> "$GITHUB_OUTPUT"
+          DEPLOY_SHA="$(git rev-parse HEAD)"
+          echo "deploy_sha=$DEPLOY_SHA" >> "$GITHUB_OUTPUT"
+          echo "short_sha=${DEPLOY_SHA::7}" >> "$GITHUB_OUTPUT"
+          echo "revision_suffix=${DEPLOY_SHA::7}-${GITHUB_RUN_ATTEMPT}" >> "$GITHUB_OUTPUT"
 
       - name: Install Python deps for deploy scripts
         run: python3 -m pip install -q pyyaml

--- a/backend/scripts/bless-python-backend.sh
+++ b/backend/scripts/bless-python-backend.sh
@@ -1,0 +1,197 @@
+#!/usr/bin/env bash
+# Bless a Python backend SHA by running required checks and publishing evidence.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+BACKEND_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPO_ROOT="$(cd "$BACKEND_DIR/.." && pwd)"
+
+TARGET_REF="HEAD"
+REPO="BasedHardware/omi"
+KEEP_EVIDENCE=0
+
+usage() {
+  cat <<'USAGE'
+Bless a Python backend SHA (tests + workflow contracts + OpenAPI evidence).
+
+Usage:
+  backend/scripts/bless-python-backend.sh [--ref <git-ref>] [--repo owner/name] [--keep-evidence]
+
+The script creates or updates GitHub Release python-backend-bless-<full-sha> and
+uploads python-backend-bless-evidence-<short-sha>-<timestamp>.json.
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --ref)
+      if [[ $# -lt 2 || "${2:-}" == -* ]]; then
+        echo "--ref requires a git ref value" >&2
+        usage >&2
+        exit 2
+      fi
+      TARGET_REF="${2:-}"
+      shift 2
+      ;;
+    --repo)
+      if [[ $# -lt 2 || "${2:-}" == -* ]]; then
+        echo "--repo requires an owner/name value" >&2
+        usage >&2
+        exit 2
+      fi
+      REPO="${2:-}"
+      shift 2
+      ;;
+    --keep-evidence)
+      KEEP_EVIDENCE=1
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    -*)
+      echo "unknown option: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+    *)
+      echo "unexpected argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$TARGET_REF" || -z "$REPO" ]]; then
+  usage >&2
+  exit 2
+fi
+if ! command -v gh >/dev/null 2>&1; then
+  echo "bless-python-backend.sh requires gh CLI" >&2
+  exit 1
+fi
+
+TARGET_SHA="$(git -C "$REPO_ROOT" rev-parse "$TARGET_REF^{commit}")"
+CURRENT_SHA="$(git -C "$REPO_ROOT" rev-parse HEAD)"
+if [[ "$CURRENT_SHA" != "$TARGET_SHA" ]]; then
+  echo "ref $TARGET_REF resolves to $TARGET_SHA, but this checkout is at $CURRENT_SHA" >&2
+  echo "Check out the target commit before blessing so evidence is collected from the blessed source." >&2
+  exit 1
+fi
+if [[ -n "$(git -C "$REPO_ROOT" status --porcelain --untracked-files=no)" ]]; then
+  echo "worktree has tracked changes; refusing to bless dirty source" >&2
+  git -C "$REPO_ROOT" status --short --untracked-files=no >&2
+  exit 1
+fi
+SHORT_SHA="${TARGET_SHA:0:12}"
+STAMP="$(date -u +%Y%m%dT%H%M%SZ)"
+ISO_STAMP="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+BLESS_TAG="python-backend-bless-${TARGET_SHA}"
+EVIDENCE_DIR="$(mktemp -d "${TMPDIR:-/tmp}/python-backend-bless.XXXXXX")"
+EVIDENCE_FILE="$EVIDENCE_DIR/python-backend-bless-evidence-${SHORT_SHA}-${STAMP}.json"
+BODY_FILE="$EVIDENCE_DIR/release-body.md"
+COMMANDS_FILE="$EVIDENCE_DIR/commands.jsonl"
+
+cleanup() {
+  if [[ "$KEEP_EVIDENCE" -eq 0 ]]; then
+    rm -rf "$EVIDENCE_DIR"
+  else
+    echo "kept evidence directory: $EVIDENCE_DIR"
+  fi
+}
+trap cleanup EXIT
+
+run_evidence_command() {
+  local name="$1"
+  shift
+  local log_file="$EVIDENCE_DIR/${name}.log"
+  local started_at ended_at status
+  started_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  echo "running $name: $*"
+  set +e
+  (cd "$BACKEND_DIR" && "$@") >"$log_file" 2>&1
+  status=$?
+  set -e
+  ended_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  python3 - "$COMMANDS_FILE" "$name" "$started_at" "$ended_at" "$status" "$log_file" "$@" <<'PY'
+import json
+import sys
+
+path, name, started_at, ended_at, status, log_file, *command = sys.argv[1:]
+with open(path, "a", encoding="utf-8") as f:
+    f.write(
+        json.dumps(
+            {
+                "name": name,
+                "command": command,
+                "started_at": started_at,
+                "ended_at": ended_at,
+                "exit_code": int(status),
+                "log": log_file,
+            },
+            sort_keys=True,
+        )
+        + "\n"
+    )
+PY
+  if [[ "$status" -ne 0 ]]; then
+    echo "$name failed; see $log_file" >&2
+    tail -80 "$log_file" >&2 || true
+    return "$status"
+  fi
+}
+
+run_evidence_command test-preflight bash test-preflight.sh
+run_evidence_command backend-test bash test.sh
+run_evidence_command workflow-contracts python3 scripts/check_workflow_contracts.py
+run_evidence_command openapi-public scripts/openapi_runner.sh scripts/export_openapi.py --check ../docs/api-reference/openapi.json
+run_evidence_command openapi-app-client scripts/openapi_runner.sh scripts/export_openapi.py --surface app-client --check ../docs/api-reference/app-client-openapi.json
+run_evidence_command openapi-integration-public scripts/openapi_runner.sh scripts/export_openapi.py --surface integration-public --check ../docs/api-reference/integration-public-openapi.json
+
+python3 - "$COMMANDS_FILE" "$EVIDENCE_FILE" "$TARGET_SHA" "$ISO_STAMP" <<'PY'
+import json
+import sys
+
+commands_path, evidence_path, target_sha, blessed_at = sys.argv[1:]
+commands = [json.loads(line) for line in open(commands_path, encoding="utf-8")]
+evidence = {
+    "surface": "python-backend",
+    "sha": target_sha,
+    "blessed_at": blessed_at,
+    "tier": "unit+workflow-contracts+openapi",
+    "passed": all(command["exit_code"] == 0 for command in commands),
+    "commands": commands,
+}
+with open(evidence_path, "w", encoding="utf-8") as f:
+    json.dump(evidence, f, indent=2, sort_keys=True)
+    f.write("\n")
+PY
+
+cat >"$BODY_FILE" <<EOF
+Python backend blessing for ${TARGET_SHA}
+
+KEY_VALUE_START
+surface: python-backend
+blessed.python-backend: true
+blessed.python-backend.at: ${ISO_STAMP}
+blessed.python-backend.sha: ${TARGET_SHA}
+blessed.python-backend.tier: unit+workflow-contracts+openapi
+blessed.python-backend.evidence: $(basename "$EVIDENCE_FILE")
+KEY_VALUE_END
+EOF
+
+if gh release view "$BLESS_TAG" --repo "$REPO" >/dev/null 2>&1; then
+  gh release edit "$BLESS_TAG" --repo "$REPO" --notes-file "$BODY_FILE" --title "Python backend blessing ${SHORT_SHA}"
+else
+  gh release create "$BLESS_TAG" "$EVIDENCE_FILE" \
+    --repo "$REPO" \
+    --target "$TARGET_SHA" \
+    --title "Python backend blessing ${SHORT_SHA}" \
+    --notes-file "$BODY_FILE" \
+    --prerelease \
+    --latest=false
+fi
+
+gh release upload "$BLESS_TAG" "$EVIDENCE_FILE" --repo "$REPO" --clobber
+echo "blessed python-backend $TARGET_SHA with evidence $(basename "$EVIDENCE_FILE")"


### PR DESCRIPTION
## Summary
- add typed override inputs to gcp_backend.yml
- gate only prod backend deploys on the exact python-backend blessing release
- compute deploy image/revision identity from the checked-out ref instead of raw GITHUB_SHA
- add a workflow policy guard so the gate stays before GCP auth/build/deploy mutations

## Stack
1. #9201 — Release blessing surface registry
2. #9202 — Python backend blessing command
3. #9203 — this PR
4. #9204 — Desktop promotion requires backend blessing

## Verification
- python3 .github/scripts/check-backend-prod-promotion-policy.py
- python3 .github/scripts/test_check_python_backend_blessing.py
- python3 .github/scripts/test_release_blessing.py
- YAML parse check for .github/workflows/gcp_backend.yml
- pre-push hook passed for the full stack, including OpenAPI checks