### PR TITLE
fix(desktop): inject single AppState from OmiApp into DesktopHomeView

### DIFF
--- a/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
@@ -18,7 +18,7 @@ struct DesktopHomeView: View {
   private let minimumWindowHeight: CGFloat = 680
   private static let pageNavigationAnimation = Animation.easeOut(duration: 0.08)
 
-  @StateObject private var appState = AppState()
+  @EnvironmentObject private var appState: AppState
   @StateObject private var viewModelContainer = ViewModelContainer()
   @ObservedObject private var authState = AuthState.shared
   @ObservedObject private var apiKeyService = APIKeyService.shared
@@ -1150,5 +1150,6 @@ private struct ConversationsPageHost: View {
 #if canImport(PreviewsMacros)
 #Preview {
   DesktopHomeView()
+    .environmentObject(AppState())
 }
 #endif

--- a/desktop/macos/Desktop/Sources/OmiApp.swift
+++ b/desktop/macos/Desktop/Sources/OmiApp.swift
@@ -116,6 +116,7 @@ struct OMIApp: App {
     // Main desktop window - same view for both modes, sidebar hidden in rewind mode
     return Window(windowTitle, id: "main") {
       DesktopHomeView()
+        .environmentObject(appState)
         .withFontScaling()
         .overlay(alignment: .bottomTrailing) { WhatsNewToastOverlay() }
         .onAppear {

--- a/desktop/macos/Desktop/Sources/ViewExporter.swift
+++ b/desktop/macos/Desktop/Sources/ViewExporter.swift
@@ -109,7 +109,7 @@ enum ViewExporter {
 
       (
         "11-desktop-home",
-        { AnyView(DesktopHomeView()) },
+        { AnyView(DesktopHomeView().environmentObject(AppState())) },
         CGSize(width: 1200, height: 800)
       ),
 

--- a/desktop/macos/Desktop/Tests/AppStateOwnershipTests.swift
+++ b/desktop/macos/Desktop/Tests/AppStateOwnershipTests.swift
@@ -1,0 +1,42 @@
+import XCTest
+
+@testable import Omi_Computer
+
+@MainActor
+final class AppStateOwnershipTests: XCTestCase {
+
+  func testAppStateCurrentMatchesMostRecentlyInitializedInstance() {
+    let state = AppState()
+    XCTAssertTrue(state === AppState.current)
+  }
+
+  func testDesktopHomeViewDoesNotOwnAppState() throws {
+    let path = Bundle.module.bundlePath
+      .replacingOccurrences(of: "/.build/.+", with: "", options: .regularExpression)
+    let sourceRoot = URL(fileURLWithPath: #filePath)
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+      .appendingPathComponent("Sources/MainWindow/DesktopHomeView.swift")
+    let source = try String(contentsOf: sourceRoot, encoding: .utf8)
+    XCTAssertFalse(
+      source.contains("@StateObject private var appState = AppState()"),
+      "DesktopHomeView must receive AppState from OmiApp via environmentObject, not create its own"
+    )
+    XCTAssertTrue(
+      source.contains("@EnvironmentObject private var appState: AppState"),
+      "DesktopHomeView must declare @EnvironmentObject for appState"
+    )
+  }
+
+  func testOmiAppInjectsAppStateIntoDesktopHomeView() throws {
+    let sourceRoot = URL(fileURLWithPath: #filePath)
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+      .appendingPathComponent("Sources/OmiApp.swift")
+    let source = try String(contentsOf: sourceRoot, encoding: .utf8)
+    XCTAssertTrue(
+      source.contains(".environmentObject(appState)"),
+      "OmiApp must inject the root AppState into DesktopHomeView"
+    )
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260707-single-appstate-owner.json
+++ b/desktop/macos/changelog/unreleased/20260707-single-appstate-owner.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed a duplicate AppState at desktop launch that could cause double lifecycle observers and fragile state initialization"
+}

--- a/desktop/macos/e2e/flows/harness-smoke.yaml
+++ b/desktop/macos/e2e/flows/harness-smoke.yaml
@@ -6,6 +6,7 @@ app: non-prod
 covers:
   - desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
   - desktop/macos/Desktop/Sources/AuthService.swift
+  - desktop/macos/Desktop/Sources/ViewExporter.swift
 preconditions:
   - automation_bridge_ready
 

--- a/desktop/macos/e2e/flows/navigation.yaml
+++ b/desktop/macos/e2e/flows/navigation.yaml
@@ -4,6 +4,7 @@ tier: 1
 description: Desktop sidebar navigation — verify core sections load via bridge navigation
 app: non-prod
 covers:
+  - desktop/macos/Desktop/Sources/OmiApp.swift
   - desktop/macos/Desktop/Sources/MainWindow/SidebarView.swift
   - desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
 preconditions:


### PR DESCRIPTION
## Summary
- Remove duplicate `@StateObject AppState()` from `DesktopHomeView`; receive root instance via `@EnvironmentObject`
- `OmiApp` injects its `@StateObject appState` with `.environmentObject(appState)`
- Add `AppStateOwnershipTests` regression guards

## Test plan
- [x] `xcrun swift test --filter AppStateOwnershipTests` (3 passed)
- [x] `xcrun swift build -c debug --package-path Desktop`

Closes #9205

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9206?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

