### PR TITLE
fix(backend): fail soft on transient Typesense timeouts in conversation search (#9188)

### DIFF
--- a/backend/routers/conversations.py
+++ b/backend/routers/conversations.py
@@ -47,7 +47,7 @@ from utils.memory.memory_service import MemoryService
 from utils.memory.memory_system import MemorySystem
 from utils.memory.canonical_activation import canonical_write_enabled
 from utils.memory.surface_routing import pin_memory_system
-from utils.conversations.search import search_conversations
+from utils.conversations.search import search_conversations, ConversationSearchUnavailable
 from utils.llm.conversation_processing import generate_summary_with_prompt
 from utils.speaker_identification import extract_speaker_samples
 from utils.other import endpoints as auth
@@ -1074,16 +1074,19 @@ def search_conversations_endpoint(
         except ValueError:
             raise HTTPException(status_code=400, detail="Invalid end_date; expected an ISO 8601 datetime string")
 
-    search_results = search_conversations(
-        query=search_request.query,
-        page=search_request.page,
-        per_page=search_request.per_page,
-        uid=uid,
-        include_discarded=search_request.include_discarded,
-        start_date=start_timestamp,
-        end_date=end_timestamp,
-        speaker_id=search_request.speaker_id,
-    )
+    try:
+        search_results = search_conversations(
+            query=search_request.query,
+            page=search_request.page,
+            per_page=search_request.per_page,
+            uid=uid,
+            include_discarded=search_request.include_discarded,
+            start_date=start_timestamp,
+            end_date=end_timestamp,
+            speaker_id=search_request.speaker_id,
+        )
+    except ConversationSearchUnavailable:
+        raise HTTPException(status_code=503, detail="Conversation search is temporarily unavailable. Please try again.")
     conversation_ids = [item.get('id') for item in search_results.get('items', []) if item.get('id')]
     conversations = conversations_db.get_conversations_by_id_without_photos(
         uid,

--- a/backend/routers/integration.py
+++ b/backend/routers/integration.py
@@ -30,7 +30,7 @@ from utils.conversations.location import get_google_maps_location
 from utils.conversations.render import redact_conversation_for_integration
 from utils.conversations.memories import process_external_integration_memory
 from utils.conversations.process_conversation import process_conversation
-from utils.conversations.search import search_conversations
+from utils.conversations.search import search_conversations, ConversationSearchUnavailable
 from utils.other.endpoints import check_rate_limit_inline
 from utils.executors import run_blocking, db_executor, postprocess_executor, critical_executor
 import logging
@@ -482,15 +482,18 @@ def search_conversations_via_integration(
             )
 
     # Search conversations
-    search_results = search_conversations(
-        query=search_request.query,
-        page=cast(int, search_request.page),
-        per_page=cast(int, search_request.per_page),
-        uid=uid,
-        include_discarded=cast(bool, search_request.include_discarded),
-        start_date=cast(int, start_timestamp),
-        end_date=cast(int, end_timestamp),
-    )
+    try:
+        search_results = search_conversations(
+            query=search_request.query,
+            page=cast(int, search_request.page),
+            per_page=cast(int, search_request.per_page),
+            uid=uid,
+            include_discarded=cast(bool, search_request.include_discarded),
+            start_date=cast(int, start_timestamp),
+            end_date=cast(int, end_timestamp),
+        )
+    except ConversationSearchUnavailable:
+        raise HTTPException(status_code=503, detail="Conversation search is temporarily unavailable. Please try again.")
 
     # Extract conversation IDs from search results
     conversation_ids = [conv.get('id') for conv in search_results['items']]

--- a/backend/tests/unit/test_search_conversations_fail_soft.py
+++ b/backend/tests/unit/test_search_conversations_fail_soft.py
@@ -1,0 +1,67 @@
+"""Regression tests for fail-soft handling of transient Typesense failures (issue #9188).
+
+A hosted-Typesense read timeout during `search_conversations` used to bubble out of the generic
+`except Exception` as `Exception("Failed to search conversations: ...")`, which the direct search
+endpoints (`/v1/conversations/search`, `/v2/integrations/{app_id}/search/conversations`) surfaced as
+a 500 traceback. It now raises the typed `ConversationSearchUnavailable`, which those endpoints map
+to a 503 and the hybrid keyword path falls open on. A genuine query error (RequestMalformed) must
+still surface as a bug, not be masked as "unavailable".
+
+These use the real typesense exception classes and monkeypatch only the module-level client, so the
+transient-vs-real classification is exercised exactly as production would hit it.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+import requests
+from typesense import exceptions as typesense_exceptions
+
+from utils.conversations import search
+from utils.conversations.search import ConversationSearchUnavailable
+
+
+def _client_raising(exc):
+    """A fake Typesense client whose conversations search raises ``exc``."""
+    client = MagicMock()
+    client.collections.__getitem__.return_value.documents.search.side_effect = exc
+    return client
+
+
+def test_read_timeout_raises_typed_unavailable(monkeypatch):
+    monkeypatch.setattr(
+        search,
+        "client",
+        _client_raising(requests.exceptions.ReadTimeout("HTTPSConnectionPool: Read timed out (read timeout=2)")),
+    )
+    with pytest.raises(ConversationSearchUnavailable):
+        search.search_conversations(uid="u1", query="dinner plans")
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        requests.exceptions.ConnectionError("connection refused"),
+        typesense_exceptions.ServiceUnavailable(503, "unavailable"),
+        typesense_exceptions.ServerError(500, "server error"),
+    ],
+)
+def test_transient_upstream_errors_are_typed_unavailable(monkeypatch, exc):
+    monkeypatch.setattr(search, "client", _client_raising(exc))
+    with pytest.raises(ConversationSearchUnavailable):
+        search.search_conversations(uid="u1", query="dinner plans")
+
+
+def test_malformed_query_is_not_masked_as_unavailable(monkeypatch):
+    # A bad filter/query is a real bug, not a transient blip — it must NOT become a soft 503.
+    monkeypatch.setattr(search, "client", _client_raising(typesense_exceptions.RequestMalformed(400, "bad filter_by")))
+    with pytest.raises(Exception) as exc_info:
+        search.search_conversations(uid="u1", query="dinner plans")
+    assert not isinstance(exc_info.value, ConversationSearchUnavailable)
+    assert "Failed to search conversations" in str(exc_info.value)
+
+
+def test_keyword_search_fails_open_on_transient(monkeypatch):
+    # Hybrid (keyword + vector) retrieval must degrade to vector-only, not crash the chat request.
+    monkeypatch.setattr(search, "client", _client_raising(requests.exceptions.ReadTimeout("Read timed out")))
+    assert search.keyword_search_conversation_ids(uid="u1", query="dinner plans") == []

--- a/backend/utils/conversations/search.py
+++ b/backend/utils/conversations/search.py
@@ -3,9 +3,32 @@ import os
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, cast
 
+import requests
 import typesense
+from typesense import exceptions as typesense_exceptions
 
 logger = logging.getLogger(__name__)
+
+
+class ConversationSearchUnavailable(Exception):
+    """Raised when hosted Typesense is transiently unreachable (read timeout, connection drop, 5xx).
+
+    Callers on a direct search endpoint should map this to a 503 instead of a 500 traceback;
+    hybrid callers (keyword + vector) fall open to vector-only results (issue #9188).
+    """
+
+
+# Transient upstream failures where the user's data is fine and a later retry may succeed — a read
+# timeout / connection drop / SSL / 5xx from hosted Typesense. typesense re-raises the raw
+# requests.exceptions.* after exhausting node retries, so catch those plus its own 5xx/timeout types.
+# NOT included: RequestMalformed/RequestUnauthorized (bad query/config) — those stay surfaced as bugs.
+_TRANSIENT_SEARCH_ERRORS = (
+    requests.exceptions.RequestException,
+    typesense_exceptions.Timeout,
+    typesense_exceptions.ServerError,
+    typesense_exceptions.ServiceUnavailable,
+    typesense_exceptions.HTTPStatus0Error,
+)
 
 client = typesense.Client(
     {
@@ -78,7 +101,14 @@ def search_conversations(
             'page': page,
         }
 
-        results: Dict[str, Any] = cast(Dict[str, Any], client.collections['conversations'].documents.search(search_parameters))  # type: ignore[reportUnknownMemberType]  # typesense client untyped
+        try:
+            results: Dict[str, Any] = cast(Dict[str, Any], client.collections['conversations'].documents.search(search_parameters))  # type: ignore[reportUnknownMemberType]  # typesense client untyped
+        except _TRANSIENT_SEARCH_ERRORS as e:
+            # Compact one-line bucket instead of a full traceback for an expected upstream blip.
+            logger.warning(
+                "search_conversations upstream unavailable uid=%s service=typesense err=%s", uid, type(e).__name__
+            )
+            raise ConversationSearchUnavailable("conversation search temporarily unavailable") from e
         memories: List[Dict[str, Any]] = []
         for item in results.get('hits', []):
             doc: Dict[str, Any] = item.get('document', {})
@@ -110,6 +140,9 @@ def search_conversations(
             'current_page': page,
             'per_page': per_page,
         }
+    except ConversationSearchUnavailable:
+        # Typed transient-upstream signal — let callers map it to a degraded/503 response.
+        raise
     except Exception as e:
         raise Exception(f"Failed to search conversations: {str(e)}")
 


### PR DESCRIPTION
## Bug (#9188)
Prod backend conversation search can return a **500** when hosted Typesense times out during `search_conversations`. Observed on prod revision `backend-01118-phg`:

```
utils/conversations/search.py search_conversations
HTTPSConnectionPool(...typesense...): Read timed out (read timeout=2)
```

## Root cause
typesense (`0.21.0`) catches `requests.exceptions.Timeout`/`ConnectionError`, retries across nodes, and after exhausting retries **re-raises the raw `requests` exception**. `search_conversations` had no classification — its generic `except Exception` rewrapped everything into `Exception("Failed to search conversations: ...")`, so a transient upstream blip looked identical to a real bug and 500'd the direct search endpoints (`/v1/conversations/search`, `/v2/integrations/{app_id}/search/conversations`).

## Fix
- `utils/conversations/search.py`: classify transient upstream failures (the `requests.exceptions.RequestException` family that typesense re-raises + typesense `Timeout`/`ServerError`/`ServiceUnavailable`/`HTTPStatus0Error`) and raise a typed `ConversationSearchUnavailable`, logging a **compact one-line warning** instead of a full traceback. `RequestMalformed`/`RequestUnauthorized` (bad query/config) stay surfaced as real bugs.
- `routers/conversations.py` + `routers/integration.py`: map the typed error to **HTTP 503** ("temporarily unavailable, please try again").
- `keyword_search_conversation_ids` already fails open, so hybrid (keyword + vector) retrieval **degrades to vector-only** — unchanged.

## Test
`tests/unit/test_search_conversations_fail_soft.py` — exercises the **real** typesense exception classes:
- read timeout / connection error / 503 / 5xx → `ConversationSearchUnavailable`
- malformed query is **not** masked as unavailable (stays a bug)
- keyword path fails open to `[]`

Ran in an isolated venv with pinned `typesense==0.21.0`: **6 passed**.

🤖 automated by hourly watchdog; opened for review, not merged.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9210?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

