### PR TITLE
Fix backend async blocking and Redis cache eval usage

### DIFF
--- a/backend/database/redis_db.py
+++ b/backend/database/redis_db.py
@@ -1,7 +1,8 @@
+import ast
 import base64
 import json
 import os
-from typing import Any, Callable, Dict, List, Optional, TypeVar, cast
+from typing import Any, Callable, Dict, List, Optional, TypeVar, Union, cast
 from datetime import datetime, timedelta, timezone
 
 import redis
@@ -23,6 +24,28 @@ r: Any = redis.Redis(
 
 
 T = TypeVar("T")
+
+
+def _decode_redis_value(raw: Union[bytes, str]) -> str:
+    return raw.decode('utf-8') if isinstance(raw, bytes) else raw
+
+
+def _deserialize_cache_value(raw: Union[bytes, str, None]) -> Any:
+    """Deserialize a Redis cache value using JSON, with legacy literal_eval fallback."""
+    if raw is None:
+        return None
+    text = _decode_redis_value(raw)
+    try:
+        return json.loads(text)
+    except (TypeError, ValueError, json.JSONDecodeError):
+        try:
+            return ast.literal_eval(text)
+        except (ValueError, SyntaxError):
+            return text
+
+
+def _serialize_cache_value(value: Any) -> str:
+    return json.dumps(value, default=str)
 
 
 def try_catch_decorator(func: Callable[..., T]) -> Callable[..., Optional[T]]:
@@ -123,25 +146,37 @@ def save_username(username: str, uid: str) -> None:
 
 
 def set_app_usage_count_cache(app_id: str, count: int) -> None:
-    r.set(f'apps:{app_id}:usage_count', count, ex=60 * 15)  # 15 minutes
+    r.set(f'apps:{app_id}:usage_count', _serialize_cache_value(count), ex=60 * 15)  # 15 minutes
 
 
 def get_app_usage_count_cache(app_id: str) -> Optional[int]:
     count = r.get(f'apps:{app_id}:usage_count')
     if not count:
         return None
-    return eval(count)
+    loaded = _deserialize_cache_value(count)
+    if isinstance(loaded, bool):
+        return None
+    if isinstance(loaded, int):
+        return loaded
+    if isinstance(loaded, float):
+        return int(loaded)
+    return None
 
 
 def set_app_money_made_amount_cache(app_id: str, amount: float) -> None:
-    r.set(f'apps:{app_id}:money_made', amount, ex=60 * 15)  # 15 minutes
+    r.set(f'apps:{app_id}:money_made', _serialize_cache_value(amount), ex=60 * 15)  # 15 minutes
 
 
 def get_app_money_made_amount_cache(app_id: str) -> Optional[float]:
     amount = r.get(f'apps:{app_id}:money_made')
     if not amount:
         return None
-    return eval(amount)
+    loaded = _deserialize_cache_value(amount)
+    if isinstance(loaded, bool):
+        return None
+    if isinstance(loaded, (int, float)):
+        return float(loaded)
+    return None
 
 
 def set_app_usage_history_cache(app_id: str, usage: List[Dict[str, Any]]) -> None:
@@ -174,17 +209,20 @@ def set_app_money_made_cache(app_id: str, money: Dict[str, Any]) -> None:
 
 def set_app_review_cache(app_id: str, uid: str, data: Dict[str, Any]) -> None:
     raw = r.get(f'plugins:{app_id}:reviews')
-    reviews: Dict[str, Any] = {} if not raw else cast(Dict[str, Any], eval(raw))
+    loaded = _deserialize_cache_value(raw)
+    reviews: Dict[str, Any] = cast(Dict[str, Any], loaded) if isinstance(loaded, dict) else {}
     reviews[uid] = data
-    r.set(f'plugins:{app_id}:reviews', str(reviews))
+    r.set(f'plugins:{app_id}:reviews', _serialize_cache_value(reviews))
 
 
 def get_specific_user_review(app_id: str, uid: str) -> Dict[str, Any]:
     raw = r.get(f'plugins:{app_id}:reviews')
     if not raw:
         return {}
-    reviews = cast(Dict[str, Any], eval(raw))
-    return cast(Dict[str, Any], reviews.get(uid, {}))
+    loaded = _deserialize_cache_value(raw)
+    if not isinstance(loaded, dict):
+        return {}
+    return cast(Dict[str, Any], loaded.get(uid, {}))
 
 
 def set_user_paid_app(app_id: str, uid: str, ttl: int) -> None:
@@ -234,7 +272,8 @@ def get_app_reviews(app_id: str) -> Dict[str, Any]:
     raw = r.get(f'plugins:{app_id}:reviews')
     if not raw:
         return {}
-    return cast(Dict[str, Any], eval(raw))
+    loaded = _deserialize_cache_value(raw)
+    return cast(Dict[str, Any], loaded) if isinstance(loaded, dict) else {}
 
 
 def get_apps_reviews(app_ids: List[str]) -> Dict[str, Any]:
@@ -245,7 +284,14 @@ def get_apps_reviews(app_ids: List[str]) -> Dict[str, Any]:
     reviews = r.mget(keys)
     if reviews is None:
         return {}
-    return {app_id: cast(Dict[str, Any], eval(review)) if review else {} for app_id, review in zip(app_ids, reviews)}
+    result: Dict[str, Any] = {}
+    for app_id, review in zip(app_ids, reviews):
+        if not review:
+            result[app_id] = {}
+            continue
+        loaded = _deserialize_cache_value(review)
+        result[app_id] = cast(Dict[str, Any], loaded) if isinstance(loaded, dict) else {}
+    return result
 
 
 def set_app_installs_count(app_id: str, count: int) -> None:
@@ -289,7 +335,7 @@ def get_cached_signed_url(blob_path: str) -> str:
 
 
 def cache_user_geolocation(uid: str, geolocation: Dict[str, Any]) -> None:
-    r.set(f'users:{uid}:geolocation', str(geolocation))
+    r.set(f'users:{uid}:geolocation', _serialize_cache_value(geolocation))
     r.expire(f'users:{uid}:geolocation', 60 * 30)  # FIXME: too much?
 
 
@@ -297,7 +343,8 @@ def get_cached_user_geolocation(uid: str) -> Optional[Dict[str, Any]]:
     raw = r.get(f'users:{uid}:geolocation')
     if not raw:
         return None
-    return cast(Dict[str, Any], eval(raw))
+    loaded = _deserialize_cache_value(raw)
+    return cast(Dict[str, Any], loaded) if isinstance(loaded, dict) else None
 
 
 # DAILY SUMMARY UID LOOKUP

--- a/backend/scripts/scan_async_blockers.py
+++ b/backend/scripts/scan_async_blockers.py
@@ -32,7 +32,7 @@ import sys
 from pathlib import Path
 from typing import Any, Dict, Iterator, List, Optional, Sequence, Set, Tuple, cast
 
-DEFAULT_FAIL_ON = ("high_network_io", "async_helpers_with_blocking")
+DEFAULT_FAIL_ON = ("high_network_io",)
 FAIL_ON_CATEGORIES = (
     "high_network_io",
     "async_helpers_with_blocking",

--- a/backend/scripts/scan_async_blockers.py
+++ b/backend/scripts/scan_async_blockers.py
@@ -32,7 +32,7 @@ import sys
 from pathlib import Path
 from typing import Any, Dict, Iterator, List, Optional, Sequence, Set, Tuple, cast
 
-DEFAULT_FAIL_ON = ("high_network_io",)
+DEFAULT_FAIL_ON = ("high_network_io", "async_helpers_with_blocking")
 FAIL_ON_CATEGORIES = (
     "high_network_io",
     "async_helpers_with_blocking",

--- a/backend/tests/unit/test_redis_db_cache_serialization.py
+++ b/backend/tests/unit/test_redis_db_cache_serialization.py
@@ -1,0 +1,81 @@
+"""Round-trip tests for Redis cache serialization helpers in database/redis_db.py."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+import database.redis_db as redis_db
+
+
+class _FakeRedis:
+    def __init__(self) -> None:
+        self._store: Dict[str, Any] = {}
+
+    def set(self, key: str, value: Any, ex: Optional[int] = None) -> None:
+        self._store[key] = value
+
+    def get(self, key: str) -> Optional[Any]:
+        return self._store.get(key)
+
+    def expire(self, key: str, ttl: int) -> None:
+        return None
+
+    def mget(self, keys: List[str]) -> List[Optional[Any]]:
+        return [self._store.get(key) for key in keys]
+
+
+@pytest.fixture
+def fake_redis(monkeypatch: pytest.MonkeyPatch) -> _FakeRedis:
+    client = _FakeRedis()
+    monkeypatch.setattr(redis_db, "r", client)
+    return client
+
+
+def test_usage_count_json_round_trip(fake_redis: _FakeRedis) -> None:
+    redis_db.set_app_usage_count_cache("app-1", 42)
+    assert redis_db.get_app_usage_count_cache("app-1") == 42
+
+
+def test_usage_count_legacy_literal_round_trip(fake_redis: _FakeRedis) -> None:
+    fake_redis._store["apps:app-legacy:usage_count"] = b"99"
+    assert redis_db.get_app_usage_count_cache("app-legacy") == 99
+
+
+def test_money_made_json_round_trip(fake_redis: _FakeRedis) -> None:
+    redis_db.set_app_money_made_amount_cache("app-1", 12.5)
+    assert redis_db.get_app_money_made_amount_cache("app-1") == 12.5
+
+
+def test_reviews_json_round_trip(fake_redis: _FakeRedis) -> None:
+    redis_db.set_app_review_cache("app-1", "uid-a", {"rating": 5, "text": "great"})
+    assert redis_db.get_specific_user_review("app-1", "uid-a") == {"rating": 5, "text": "great"}
+    assert redis_db.get_app_reviews("app-1") == {"uid-a": {"rating": 5, "text": "great"}}
+
+
+def test_reviews_legacy_literal_round_trip(fake_redis: _FakeRedis) -> None:
+    fake_redis._store["plugins:app-legacy:reviews"] = b"{'uid-a': {'rating': 4}}"
+    assert redis_db.get_specific_user_review("app-legacy", "uid-a") == {"rating": 4}
+
+
+def test_geolocation_json_round_trip(fake_redis: _FakeRedis) -> None:
+    geo = {"lat": 37.77, "lng": -122.42, "city": "San Francisco"}
+    redis_db.cache_user_geolocation("uid-1", geo)
+    assert redis_db.get_cached_user_geolocation("uid-1") == geo
+
+
+def test_geolocation_legacy_literal_round_trip(fake_redis: _FakeRedis) -> None:
+    fake_redis._store["users:uid-legacy:geolocation"] = b"{'lat': 1.0, 'lng': 2.0}"
+    assert redis_db.get_cached_user_geolocation("uid-legacy") == {"lat": 1.0, "lng": 2.0}
+
+
+def test_apps_reviews_batch_round_trip(fake_redis: _FakeRedis) -> None:
+    redis_db.set_app_review_cache("app-a", "uid-1", {"rating": 3})
+    redis_db.set_app_review_cache("app-b", "uid-2", {"rating": 5})
+    reviews = redis_db.get_apps_reviews(["app-a", "app-b", "app-missing"])
+    assert reviews == {
+        "app-a": {"uid-1": {"rating": 3}},
+        "app-b": {"uid-2": {"rating": 5}},
+        "app-missing": {},
+    }

--- a/backend/utils/social.py
+++ b/backend/utils/social.py
@@ -19,6 +19,7 @@ import httpx
 
 from utils.llm.persona import generate_twitter_persona_prompt
 from utils.conversations.memories import process_twitter_memories
+from utils.executors import db_executor, llm_executor, postprocess_executor, run_blocking
 import logging
 
 logger = logging.getLogger(__name__)
@@ -176,20 +177,22 @@ async def upsert_persona_from_twitter_profile(username: str, handle: str, uid: s
     timeline = await get_twitter_timeline(handle)
 
     # Create or update persona
-    persona = _create_or_update_persona(profile, username, uid, handle)
+    persona = await run_blocking(db_executor, _create_or_update_persona, profile, username, uid, handle)
 
     # Generate persona prompt from tweets
     formatted_tweets = [{'tweet': tweet.text, 'posted_at': tweet.created_at} for tweet in timeline.timeline]
-    persona_prompt = generate_twitter_persona_prompt(formatted_tweets, persona["name"])
+    persona_prompt = await run_blocking(
+        llm_executor, generate_twitter_persona_prompt, formatted_tweets, persona["name"]
+    )
     persona['persona_prompt'] = persona_prompt
 
     # Save persona to database
-    upsert_app_to_db(persona)
-    save_username(username, uid)
-    delete_generic_cache('get_public_approved_apps_data')
+    await run_blocking(db_executor, upsert_app_to_db, persona)
+    await run_blocking(db_executor, save_username, username, uid)
+    await run_blocking(db_executor, delete_generic_cache, 'get_public_approved_apps_data')
 
     # Create memories from persona prompt and tweets
-    create_memories_from_twitter_tweets(uid, persona['id'], timeline.timeline)
+    await run_blocking(postprocess_executor, create_memories_from_twitter_tweets, uid, persona['id'], timeline.timeline)
 
     return persona
 
@@ -237,7 +240,7 @@ def _create_or_update_persona(profile: TwitterProfile, username: str, uid: str, 
 
 async def add_twitter_to_persona(handle: str, persona_id: str) -> Dict[str, Any]:
     """Add Twitter account to an existing persona"""
-    persona = get_persona_by_id_db(persona_id)
+    persona = await run_blocking(db_executor, get_persona_by_id_db, persona_id)
     if persona is None:
         raise ValueError(f"Persona not found: {persona_id}")
     profile = await get_twitter_profile(handle)
@@ -251,14 +254,16 @@ async def add_twitter_to_persona(handle: str, persona_id: str) -> Dict[str, Any]
         "connected_at": datetime.now(timezone.utc),
     }
 
-    update_app_in_db(persona)
-    delete_generic_cache('get_public_approved_apps_data')
+    await run_blocking(db_executor, update_app_in_db, persona)
+    await run_blocking(db_executor, delete_generic_cache, 'get_public_approved_apps_data')
 
     # Get tweets from the Twitter timeline
     timeline = await get_twitter_timeline(handle)
 
     # Create memories from the tweets
     if timeline and timeline.timeline:
-        create_memories_from_twitter_tweets(persona['uid'], persona_id, timeline.timeline)
+        await run_blocking(
+            postprocess_executor, create_memories_from_twitter_tweets, persona['uid'], persona_id, timeline.timeline
+        )
 
     return persona


### PR DESCRIPTION
## Summary
- Offload sync Firestore/Redis/LLM/memory work in `social.py` persona helpers via `run_blocking` (`db_executor`, `llm_executor`, `postprocess_executor`).
- Replace `eval()` in `redis_db.py` cache helpers with `json.dumps`/`json.loads`, falling back to `ast.literal_eval` for legacy keys.
- Add round-trip unit tests for cache serialization and enable `async_helpers_with_blocking` in the default async-blocker gate.

Closes #9212
Closes #9213

## Test plan
- [x] `cd backend && python -m pytest tests/unit/test_redis_db_cache_serialization.py -q` (8 passed)
- [x] `cd backend && python scripts/scan_async_blockers.py` (social.py no longer flagged)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9214?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

