### PR TITLE
Desktop WAL: real /v2/sync-local-files upload pipeline

### DIFF
--- a/desktop/macos/Desktop/Sources/APIClient.swift
+++ b/desktop/macos/Desktop/Sources/APIClient.swift
@@ -5464,8 +5464,15 @@ extension APIClient {
     if http.statusCode == 404 {
       return SyncJobFetch(outcome: .notFound)
     }
-    // 403 means auth/permission failure, not a missing job — surface as transient
-    // so the caller retries rather than treating the job as gone.
+    // 403 means the caller is not permitted to access this sync job. Unlike a
+    // transient transport failure, re-polling will not resolve it — the upload
+    // path already refreshed auth on 401, so a 403 here is a durable permission
+    // failure. Surface it as `.forbidden` so the reconciler reverts the WAL to
+    // `.miss` for re-upload (the backend dedupes by conversation/timestamp)
+    // instead of polling forever.
+    if http.statusCode == 403 {
+      return SyncJobFetch(outcome: .forbidden)
+    }
     guard http.statusCode == 200 else {
       return SyncJobFetch(outcome: .transient)
     }
@@ -5654,6 +5661,7 @@ struct SyncJobStatusResponse: Codable, Equatable {
 enum SyncJobFetchOutcome: Equatable {
   case ok
   case notFound
+  case forbidden
   case transient
 }
 

--- a/desktop/macos/Desktop/Sources/APIClient.swift
+++ b/desktop/macos/Desktop/Sources/APIClient.swift
@@ -420,10 +420,18 @@ enum APIError: LocalizedError {
   case httpError(statusCode: Int, detail: String? = nil)
   case decodingError(Error)
   case unsupportedTierScopedBulkMutation(String)
+  case syncRateLimited(retryAfterSeconds: Int?)
+  case syncUploadRejected(reason: String)
 
   var detail: String? {
-    if case .httpError(_, let detail) = self { return detail }
-    return nil
+    switch self {
+    case .httpError(_, let detail):
+      return detail
+    case .syncUploadRejected(let reason):
+      return reason
+    default:
+      return nil
+    }
   }
 
   var errorDescription: String? {
@@ -439,6 +447,13 @@ enum APIError: LocalizedError {
       return "Failed to decode response: \(error.localizedDescription)"
     case .unsupportedTierScopedBulkMutation(let operation):
       return "Layer-scoped bulk memory \(operation) is not supported yet."
+    case .syncRateLimited(let retryAfterSeconds):
+      if let retryAfterSeconds {
+        return "Sync rate limited (retry after \(retryAfterSeconds)s)"
+      }
+      return "Sync rate limited"
+    case .syncUploadRejected(let reason):
+      return reason
     }
   }
 }
@@ -5414,11 +5429,122 @@ extension APIClient {
     return try decoder.decode([ChatFileResponse].self, from: data)
   }
 
-}
+  // MARK: - Sync local files (WAL upload)
 
-/// Response from rating a message
-struct MessageStatusResponse: Codable {
-  let status: String
+  /// Upload-only POST to `/v2/sync-local-files`. Mirrors Flutter `uploadLocalFilesV2`.
+  func uploadLocalFilesV2(
+    fileURLs: [URL],
+    conversationId: String? = nil
+  ) async throws -> UploadLocalFilesResult {
+    var endpoint = "v2/sync-local-files"
+    if let conversationId, !conversationId.isEmpty {
+      let encoded = conversationId.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? conversationId
+      endpoint += "?conversation_id=\(encoded)"
+    }
+    let url = URL(string: baseURL + endpoint)!
+    let request = try await buildSyncLocalFilesMultipartRequest(url: url, fileURLs: fileURLs)
+    return try await performSyncLocalFilesUpload(request)
+  }
+
+  /// Single GET of a sync job's status — no polling loop.
+  func fetchSyncJobStatus(jobId: String) async -> SyncJobFetch {
+    let endpoint = "v2/sync-local-files/\(jobId)"
+    let url = URL(string: baseURL + endpoint)!
+    var request = URLRequest(url: url)
+    request.httpMethod = "GET"
+    request.allHTTPHeaderFields = try? await buildHeaders(requireAuth: true)
+
+    guard let (data, response) = try? await session.data(for: request),
+          let http = response as? HTTPURLResponse else {
+      return SyncJobFetch(outcome: .transient)
+    }
+
+    if http.statusCode == 404 || http.statusCode == 403 {
+      return SyncJobFetch(outcome: .notFound)
+    }
+    guard http.statusCode == 200 else {
+      return SyncJobFetch(outcome: .transient)
+    }
+
+    do {
+      let status = try decoder.decode(SyncJobStatusResponse.self, from: data)
+      return SyncJobFetch(outcome: .ok, status: status)
+    } catch {
+      return SyncJobFetch(outcome: .transient)
+    }
+  }
+
+  private func buildSyncLocalFilesMultipartRequest(url: URL, fileURLs: [URL]) async throws -> URLRequest {
+    let boundary = "Boundary-\(UUID().uuidString)"
+    var request = URLRequest(url: url)
+    request.httpMethod = "POST"
+    var headers = try await buildHeaders(requireAuth: true)
+    headers.removeValue(forKey: "Content-Type")
+    request.allHTTPHeaderFields = headers
+    request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
+
+    var body = Data()
+    let lineBreak = "\r\n"
+    for fileURL in fileURLs {
+      let fileName = fileURL.lastPathComponent
+      let fileData = try Data(contentsOf: fileURL)
+      body.append("--\(boundary)\(lineBreak)".data(using: .utf8)!)
+      body.append(
+        "Content-Disposition: form-data; name=\"files\"; filename=\"\(fileName)\"\(lineBreak)"
+          .data(using: .utf8)!)
+      body.append("Content-Type: application/octet-stream\(lineBreak)\(lineBreak)".data(using: .utf8)!)
+      body.append(fileData)
+      body.append(lineBreak.data(using: .utf8)!)
+    }
+    body.append("--\(boundary)--\(lineBreak)".data(using: .utf8)!)
+    request.httpBody = body
+    return request
+  }
+
+  private func performSyncLocalFilesUpload(_ request: URLRequest) async throws -> UploadLocalFilesResult {
+    let (data, response) = try await session.data(for: request)
+    guard let http = response as? HTTPURLResponse else { throw APIError.invalidResponse }
+
+    if http.statusCode == 401 {
+      var retryRequest = request
+      let authService = await MainActor.run { AuthService.shared }
+      retryRequest.setValue(
+        try await authService.getAuthHeader(forceRefresh: true), forHTTPHeaderField: "Authorization")
+      return try await performSyncLocalFilesUpload(retryRequest)
+    }
+
+    if http.statusCode == 200 {
+      let completed = try decoder.decode(SyncLocalFilesResultResponse.self, from: data)
+      return .done(completed)
+    }
+    if http.statusCode == 202 {
+      let start = try decoder.decode(SyncJobStartResponse.self, from: data)
+      guard !start.jobId.isEmpty else {
+        throw APIError.syncUploadRejected(reason: "Upload accepted but no job id returned")
+      }
+      return .queued(jobId: start.jobId)
+    }
+    if http.statusCode == 429 {
+      let retryAfter = Self.parseRetryAfterSeconds(from: http)
+      throw APIError.syncRateLimited(retryAfterSeconds: retryAfter)
+    }
+    if http.statusCode == 400 {
+      throw APIError.syncUploadRejected(reason: "Audio file could not be processed by server")
+    }
+    if http.statusCode == 413 {
+      throw APIError.syncUploadRejected(reason: "Audio file is too large to upload")
+    }
+    if http.statusCode >= 500 {
+      throw APIError.syncUploadRejected(reason: "Server is temporarily unavailable")
+    }
+    throw APIError.syncUploadRejected(reason: "Upload failed unexpectedly")
+  }
+
+  private static func parseRetryAfterSeconds(from response: HTTPURLResponse) -> Int? {
+    guard let raw = response.value(forHTTPHeaderField: "Retry-After") else { return nil }
+    return Int(raw.trimmingCharacters(in: .whitespacesAndNewlines))
+  }
+
 }
 
 /// Response shape for `POST /v2/files` — mirrors backend `FileChat` model.
@@ -5437,6 +5563,98 @@ struct ChatFileResponse: Codable {
     case mimeType = "mime_type"
     case thumbName = "thumb_name"
     case openaiFileId = "openai_file_id"
+  }
+}
+
+/// Response from rating a message
+struct MessageStatusResponse: Codable {
+  let status: String
+}
+
+// MARK: - Sync local files (WAL upload)
+
+/// Outcome of POST `/v2/sync-local-files` — exactly one of `jobId` (202) or `completed` (200).
+enum UploadLocalFilesResult: Equatable {
+  case queued(jobId: String)
+  case done(SyncLocalFilesResultResponse)
+
+  var jobId: String? {
+    if case .queued(let jobId) = self { return jobId }
+    return nil
+  }
+}
+
+struct SyncLocalFilesResultResponse: Codable, Equatable {
+  let newMemories: [String]
+  let updatedMemories: [String]
+  let failedSegments: Int
+  let totalSegments: Int
+  let errors: [String]
+
+  enum CodingKeys: String, CodingKey {
+    case newMemories = "new_memories"
+    case updatedMemories = "updated_memories"
+    case failedSegments = "failed_segments"
+    case totalSegments = "total_segments"
+    case errors
+  }
+}
+
+struct SyncJobStartResponse: Codable, Equatable {
+  let jobId: String
+  let status: String
+  let totalFiles: Int
+  let totalSegments: Int
+  let pollAfterMs: Int
+
+  enum CodingKeys: String, CodingKey {
+    case jobId = "job_id"
+    case status
+    case totalFiles = "total_files"
+    case totalSegments = "total_segments"
+    case pollAfterMs = "poll_after_ms"
+  }
+}
+
+struct SyncJobStatusResponse: Codable, Equatable {
+  let jobId: String
+  let status: String
+  let totalSegments: Int
+  let processedSegments: Int
+  let successfulSegments: Int
+  let failedSegments: Int
+  let result: SyncLocalFilesResultResponse?
+  let error: String?
+
+  var isTerminal: Bool {
+    status == "completed" || status == "partial_failure" || status == "failed"
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case jobId = "job_id"
+    case status
+    case totalSegments = "total_segments"
+    case processedSegments = "processed_segments"
+    case successfulSegments = "successful_segments"
+    case failedSegments = "failed_segments"
+    case result
+    case error
+  }
+}
+
+enum SyncJobFetchOutcome: Equatable {
+  case ok
+  case notFound
+  case transient
+}
+
+struct SyncJobFetch: Equatable {
+  let outcome: SyncJobFetchOutcome
+  let status: SyncJobStatusResponse?
+
+  init(outcome: SyncJobFetchOutcome, status: SyncJobStatusResponse? = nil) {
+    self.outcome = outcome
+    self.status = status
   }
 }
 

--- a/desktop/macos/Desktop/Sources/APIClient.swift
+++ b/desktop/macos/Desktop/Sources/APIClient.swift
@@ -1,4 +1,5 @@
 import Foundation
+import OmiWAL
 
 actor APIClient {
   static let shared = APIClient()
@@ -5489,7 +5490,9 @@ extension APIClient {
     var body = Data()
     let lineBreak = "\r\n"
     for fileURL in fileURLs {
-      let fileName = fileURL.lastPathComponent
+      // Legacy desktop WAL files on disk may still use byte-length `_fsN` tokens;
+      // normalize at upload time so the backend Opus decoder gets sample-frame size.
+      let fileName = WALSyncUploadFileName.normalizedForUpload(fileURL.lastPathComponent)
       let fileData = try Data(contentsOf: fileURL)
       body.append("--\(boundary)\(lineBreak)".data(using: .utf8)!)
       body.append(

--- a/desktop/macos/Desktop/Sources/APIClient.swift
+++ b/desktop/macos/Desktop/Sources/APIClient.swift
@@ -5436,12 +5436,13 @@ extension APIClient {
     fileURLs: [URL],
     conversationId: String? = nil
   ) async throws -> UploadLocalFilesResult {
-    var endpoint = "v2/sync-local-files"
+    var components = URLComponents(string: baseURL + "v2/sync-local-files")!
     if let conversationId, !conversationId.isEmpty {
-      let encoded = conversationId.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? conversationId
-      endpoint += "?conversation_id=\(encoded)"
+      components.queryItems = [URLQueryItem(name: "conversation_id", value: conversationId)]
     }
-    let url = URL(string: baseURL + endpoint)!
+    guard let url = components.url else {
+      throw APIError.syncUploadRejected(reason: "Invalid sync-local-files URL")
+    }
     let request = try await buildSyncLocalFilesMultipartRequest(url: url, fileURLs: fileURLs)
     return try await performSyncLocalFilesUpload(request)
   }
@@ -5459,9 +5460,11 @@ extension APIClient {
       return SyncJobFetch(outcome: .transient)
     }
 
-    if http.statusCode == 404 || http.statusCode == 403 {
+    if http.statusCode == 404 {
       return SyncJobFetch(outcome: .notFound)
     }
+    // 403 means auth/permission failure, not a missing job — surface as transient
+    // so the caller retries rather than treating the job as gone.
     guard http.statusCode == 200 else {
       return SyncJobFetch(outcome: .transient)
     }
@@ -5501,16 +5504,19 @@ extension APIClient {
     return request
   }
 
-  private func performSyncLocalFilesUpload(_ request: URLRequest) async throws -> UploadLocalFilesResult {
+  private func performSyncLocalFilesUpload(_ request: URLRequest, retriedAuth: Bool = false) async throws -> UploadLocalFilesResult {
     let (data, response) = try await session.data(for: request)
     guard let http = response as? HTTPURLResponse else { throw APIError.invalidResponse }
 
     if http.statusCode == 401 {
+      guard !retriedAuth else {
+        throw APIError.unauthorized
+      }
       var retryRequest = request
       let authService = await MainActor.run { AuthService.shared }
       retryRequest.setValue(
         try await authService.getAuthHeader(forceRefresh: true), forHTTPHeaderField: "Authorization")
-      return try await performSyncLocalFilesUpload(retryRequest)
+      return try await performSyncLocalFilesUpload(retryRequest, retriedAuth: true)
     }
 
     if http.statusCode == 200 {

--- a/desktop/macos/Desktop/Sources/OmiWAL/WALModel.swift
+++ b/desktop/macos/Desktop/Sources/OmiWAL/WALModel.swift
@@ -272,7 +272,15 @@ package enum WALSyncUploadFileName {
         guard fsValue == reference.bytesPerFrame else {
             return fileName
         }
-        return fileName.replacingOccurrences(of: fsToken, with: "_fs\(expectedSamples)")
+        // Replace the `_fsN` token only within the already-matched trailing
+        // range, not globally — a device identifier could contain the same
+        // substring (e.g. "dev_fs80"), and a global replacingOccurrences would
+        // corrupt it.
+        let replacedInRange = fileName[fsRange].replacingOccurrences(
+            of: fsToken, with: "_fs\(expectedSamples)")
+        var result = fileName
+        result.replaceSubrange(fsRange, with: replacedInRange)
+        return result
     }
 }
 

--- a/desktop/macos/Desktop/Sources/OmiWAL/WALModel.swift
+++ b/desktop/macos/Desktop/Sources/OmiWAL/WALModel.swift
@@ -7,6 +7,7 @@ import Foundation
 package enum WALStatus: String, Codable {
     case inProgress = "inProgress"  // Currently recording/receiving
     case miss = "miss"              // Downloaded from device, needs upload
+    case uploaded = "uploaded"      // Server ack (202); reconciler resolves to synced
     case synced = "synced"          // Successfully uploaded to cloud
     case corrupted = "corrupted"    // Failed to process
 }
@@ -77,6 +78,12 @@ package struct WALEntry: Codable, Identifiable {
     /// Original storage location (for migration tracking)
     package var originalStorage: WALStorageType?
 
+    /// Server job id after HTTP 202 upload ack (reconciler polls this)
+    package var jobId: String?
+
+    /// Unix timestamp when upload was acknowledged (HTTP 202)
+    package var uploadedAt: Int
+
     // MARK: - Initialization
 
     package init(
@@ -95,7 +102,9 @@ package struct WALEntry: Codable, Identifiable {
         fileNum: Int = 1,
         totalFrames: Int = 0,
         syncedFrameOffset: Int = 0,
-        originalStorage: WALStorageType? = nil
+        originalStorage: WALStorageType? = nil,
+        jobId: String? = nil,
+        uploadedAt: Int = 0
     ) {
         self.timerStart = timerStart
         self.codec = codec
@@ -113,6 +122,60 @@ package struct WALEntry: Codable, Identifiable {
         self.totalFrames = totalFrames
         self.syncedFrameOffset = syncedFrameOffset
         self.originalStorage = originalStorage
+        self.jobId = jobId
+        self.uploadedAt = uploadedAt
+    }
+
+    package enum CodingKeys: String, CodingKey {
+        case timerStart, codec, channel, sampleRate, status, storage, filePath, seconds
+        case device, deviceModel, storageOffset, storageTotalBytes, fileNum, totalFrames
+        case syncedFrameOffset, originalStorage, jobId, uploadedAt
+    }
+
+    package init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        timerStart = try container.decode(Int.self, forKey: .timerStart)
+        codec = try container.decode(String.self, forKey: .codec)
+        channel = try container.decodeIfPresent(Int.self, forKey: .channel) ?? 1
+        sampleRate = try container.decodeIfPresent(Int.self, forKey: .sampleRate) ?? 16000
+        status = try container.decode(WALStatus.self, forKey: .status)
+        storage = try container.decode(WALStorageType.self, forKey: .storage)
+        filePath = try container.decodeIfPresent(String.self, forKey: .filePath)
+        seconds = try container.decode(Int.self, forKey: .seconds)
+        device = try container.decode(String.self, forKey: .device)
+        deviceModel = try container.decode(String.self, forKey: .deviceModel)
+        storageOffset = try container.decodeIfPresent(Int.self, forKey: .storageOffset) ?? 0
+        storageTotalBytes = try container.decodeIfPresent(Int.self, forKey: .storageTotalBytes) ?? 0
+        fileNum = try container.decodeIfPresent(Int.self, forKey: .fileNum) ?? 1
+        totalFrames = try container.decodeIfPresent(Int.self, forKey: .totalFrames) ?? 0
+        syncedFrameOffset = try container.decodeIfPresent(Int.self, forKey: .syncedFrameOffset) ?? 0
+        originalStorage = try container.decodeIfPresent(WALStorageType.self, forKey: .originalStorage)
+        jobId = try container.decodeIfPresent(String.self, forKey: .jobId)
+        uploadedAt = try container.decodeIfPresent(Int.self, forKey: .uploadedAt) ?? 0
+    }
+
+    package func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(timerStart, forKey: .timerStart)
+        try container.encode(codec, forKey: .codec)
+        try container.encode(channel, forKey: .channel)
+        try container.encode(sampleRate, forKey: .sampleRate)
+        try container.encode(status, forKey: .status)
+        try container.encode(storage, forKey: .storage)
+        try container.encodeIfPresent(filePath, forKey: .filePath)
+        try container.encode(seconds, forKey: .seconds)
+        try container.encode(device, forKey: .device)
+        try container.encode(deviceModel, forKey: .deviceModel)
+        try container.encode(storageOffset, forKey: .storageOffset)
+        try container.encode(storageTotalBytes, forKey: .storageTotalBytes)
+        try container.encode(fileNum, forKey: .fileNum)
+        try container.encode(totalFrames, forKey: .totalFrames)
+        try container.encode(syncedFrameOffset, forKey: .syncedFrameOffset)
+        try container.encodeIfPresent(originalStorage, forKey: .originalStorage)
+        try container.encodeIfPresent(jobId, forKey: .jobId)
+        if uploadedAt != 0 {
+            try container.encode(uploadedAt, forKey: .uploadedAt)
+        }
     }
 
     // MARK: - Computed Properties

--- a/desktop/macos/Desktop/Sources/OmiWAL/WALModel.swift
+++ b/desktop/macos/Desktop/Sources/OmiWAL/WALModel.swift
@@ -229,6 +229,53 @@ package struct WALEntry: Codable, Identifiable {
     }
 }
 
+// MARK: - Sync upload filename normalization
+
+/// Helpers for `/v2/sync-local-files` multipart uploads.
+package enum WALSyncUploadFileName {
+    private static let fsTokenPattern = "_fs(\\d+)_(\\d+)\\.bin$"
+
+    /// Rewrites legacy desktop `_fsN` tokens that used encoded byte length
+    /// (`_fs80` for opus, `_fs160` for opus_fs320) to sample-frame size
+    /// (`_fs160`/`_fs320`) expected by the backend decoder.
+    package static func normalizedForUpload(_ fileName: String) -> String {
+        guard fileName.hasPrefix("audio_"), fileName.hasSuffix(".bin") else {
+            return fileName
+        }
+        if fileName.contains("_pcm16_") || fileName.contains("_pcm8_") {
+            return fileName
+        }
+
+        guard let fsRange = fileName.range(of: fsTokenPattern, options: .regularExpression) else {
+            return fileName
+        }
+        let fsTokenMatch = String(fileName[fsRange])
+        guard
+            let fsValueRange = fsTokenMatch.range(of: "_fs(\\d+)_", options: .regularExpression),
+            let fsValue = Int(fsTokenMatch[fsValueRange].dropFirst(3).dropLast(1))
+        else {
+            return fileName
+        }
+        let fsToken = "_fs\(fsValue)"
+
+        let codec: String
+        if fileName.contains("_opus_fs320_") {
+            codec = "opus_fs320"
+        } else if fileName.contains("_opus_") {
+            codec = "opus"
+        } else {
+            return fileName
+        }
+
+        let reference = WALEntry(timerStart: 0, codec: codec, device: "x", deviceModel: "x")
+        let expectedSamples = reference.samplesPerFrame
+        guard fsValue == reference.bytesPerFrame else {
+            return fileName
+        }
+        return fileName.replacingOccurrences(of: fsToken, with: "_fs\(expectedSamples)")
+    }
+}
+
 // MARK: - WAL Metadata
 
 /// Metadata wrapper for WAL storage file

--- a/desktop/macos/Desktop/Sources/OmiWAL/WALModel.swift
+++ b/desktop/macos/Desktop/Sources/OmiWAL/WALModel.swift
@@ -198,6 +198,15 @@ package struct WALEntry: Codable, Identifiable {
         }
     }
 
+    /// Opus decoder frame size in samples — the `_fsN` token the backend parses
+    /// from the filename (`decode_files_to_wav` → `frame_size`). Must be sample
+    /// count, not byte length, or audio decodes with half-sized buffers.
+    /// Flutter writes `_fs160` (opus) / `_fs320` (opus_fs320).
+    package var samplesPerFrame: Int {
+        guard framesPerSecond > 0 else { return 160 }
+        return sampleRate / framesPerSecond
+    }
+
     /// Expected total frames for the duration
     package var expectedFrames: Int {
         framesPerSecond * seconds
@@ -213,9 +222,10 @@ package struct WALEntry: Codable, Identifiable {
         totalFrames >= expectedFrames || status == .synced
     }
 
-    /// Generate filename for this WAL
+    /// Generate filename for this WAL. The `_fsN` token is the Opus decoder
+    /// frame size in samples (matching Flutter), not the encoded byte length.
     package func generateFileName() -> String {
-        "audio_\(device)_\(codec)_\(sampleRate)_\(channel)_fs\(bytesPerFrame)_\(timerStart).bin"
+        "audio_\(device)_\(codec)_\(sampleRate)_\(channel)_fs\(samplesPerFrame)_\(timerStart).bin"
     }
 }
 

--- a/desktop/macos/Desktop/Sources/WAL/StorageSyncService.swift
+++ b/desktop/macos/Desktop/Sources/WAL/StorageSyncService.swift
@@ -352,6 +352,13 @@ final class StorageSyncService: ObservableObject {
             frames: downloadedFrames
         )
 
+        let frameCount = downloadedFrames.count
+
+        // Upload downloaded WALs to cloud (real POST /v2/sync-local-files) before
+        // resetting isSyncing, so a concurrent BLE download cannot start and get
+        // its own syncToCloud() skipped by WALService's isSyncing guard.
+        await walService.syncToCloud()
+
         await MainActor.run {
             isSyncing = false
             currentWal = nil
@@ -359,10 +366,7 @@ final class StorageSyncService: ObservableObject {
             totalBytesDownloaded = 0
         }
 
-        logger.info("Sync completed: \(self.downloadedFrames.count) frames downloaded")
-
-        // Upload downloaded WALs to cloud (real POST /v2/sync-local-files)
-        await walService.syncToCloud()
+        logger.info("Sync completed: \(frameCount) frames downloaded")
     }
 }
 

--- a/desktop/macos/Desktop/Sources/WAL/StorageSyncService.swift
+++ b/desktop/macos/Desktop/Sources/WAL/StorageSyncService.swift
@@ -360,6 +360,9 @@ final class StorageSyncService: ObservableObject {
         }
 
         logger.info("Sync completed: \(self.downloadedFrames.count) frames downloaded")
+
+        // Upload downloaded WALs to cloud (real POST /v2/sync-local-files)
+        await walService.syncToCloud()
     }
 }
 

--- a/desktop/macos/Desktop/Sources/WAL/WALCloudSyncLogic.swift
+++ b/desktop/macos/Desktop/Sources/WAL/WALCloudSyncLogic.swift
@@ -37,7 +37,7 @@ enum WALCloudSyncLogic {
     case .transient:
       return false
 
-    case .notFound:
+    case .notFound, .forbidden:
       var changed = false
       for walId in memberWalIds {
         guard let index = wals.firstIndex(where: { $0.id == walId }) else { continue }

--- a/desktop/macos/Desktop/Sources/WAL/WALCloudSyncLogic.swift
+++ b/desktop/macos/Desktop/Sources/WAL/WALCloudSyncLogic.swift
@@ -69,14 +69,24 @@ enum WALCloudSyncLogic {
         }
         return changed
       }
-      // failed / partial_failure — revert to miss for re-upload when file remains
+      // failed — revert to miss for re-upload when file remains.
+      // partial_failure is treated as completed: the job processed its successful
+      // segments and already created/updated memories for them, so requeuing the
+      // entire WAL would resend already-processed audio.
+      let treatAsCompleted = status.status == "partial_failure"
       var changed = false
       for walId in memberWalIds {
         guard let index = wals.firstIndex(where: { $0.id == walId }) else { continue }
         changed = true
         wals[index].jobId = nil
         wals[index].uploadedAt = 0
-        wals[index].status = fileExists(wals[index]) ? .miss : .corrupted
+        if treatAsCompleted {
+          wals[index].status = .synced
+        } else if fileExists(wals[index]) {
+          wals[index].status = .miss
+        } else {
+          wals[index].status = .corrupted
+        }
       }
       return changed
     }

--- a/desktop/macos/Desktop/Sources/WAL/WALCloudSyncLogic.swift
+++ b/desktop/macos/Desktop/Sources/WAL/WALCloudSyncLogic.swift
@@ -1,0 +1,84 @@
+import Foundation
+import OmiWAL
+
+/// Pure state transitions for WAL cloud upload — testable without network I/O.
+enum WALCloudSyncLogic {
+
+  /// Apply a server upload acknowledgement. Never marks `.synced` without 200/202 ack.
+  static func applyUploadResult(
+    to wal: inout WALEntry,
+    result: UploadLocalFilesResult,
+    now: Int = Int(Date().timeIntervalSince1970)
+  ) {
+    switch result {
+    case .done:
+      wal.status = .synced
+      wal.jobId = nil
+      wal.uploadedAt = 0
+    case .queued(let jobId):
+      wal.status = .uploaded
+      wal.jobId = jobId
+      wal.uploadedAt = now
+    }
+  }
+
+  /// Reconcile one job's WAL members after a status fetch. Returns whether any WAL changed.
+  @discardableResult
+  static func applyReconcileFetch(
+    wals: inout [WALEntry],
+    memberWalIds: [String],
+    fetch: SyncJobFetch,
+    fileExists: (WALEntry) -> Bool,
+    now: Int = Int(Date().timeIntervalSince1970)
+  ) -> Bool {
+    guard !memberWalIds.isEmpty else { return false }
+
+    switch fetch.outcome {
+    case .transient:
+      return false
+
+    case .notFound:
+      var changed = false
+      for walId in memberWalIds {
+        guard let index = wals.firstIndex(where: { $0.id == walId }) else { continue }
+        changed = true
+        wals[index].jobId = nil
+        if fileExists(wals[index]) {
+          wals[index].status = .miss
+        } else {
+          wals[index].status = .corrupted
+        }
+        wals[index].uploadedAt = 0
+        _ = now
+      }
+      return changed
+
+    case .ok:
+      guard let status = fetch.status else { return false }
+      if !status.isTerminal {
+        return false
+      }
+      if status.status == "completed" {
+        var changed = false
+        for walId in memberWalIds {
+          guard let index = wals.firstIndex(where: { $0.id == walId }) else { continue }
+          changed = true
+          wals[index].status = .synced
+          wals[index].jobId = nil
+          wals[index].uploadedAt = 0
+        }
+        return changed
+      }
+      // failed / partial_failure — revert to miss for re-upload when file remains
+      var changed = false
+      for walId in memberWalIds {
+        guard let index = wals.firstIndex(where: { $0.id == walId }) else { continue }
+        changed = true
+        wals[index].jobId = nil
+        wals[index].uploadedAt = 0
+        wals[index].status = fileExists(wals[index]) ? .miss : .corrupted
+      }
+      return changed
+    }
+  }
+}

--- a/desktop/macos/Desktop/Sources/WAL/WALCloudSyncLogic.swift
+++ b/desktop/macos/Desktop/Sources/WAL/WALCloudSyncLogic.swift
@@ -69,24 +69,17 @@ enum WALCloudSyncLogic {
         }
         return changed
       }
-      // failed — revert to miss for re-upload when file remains.
-      // partial_failure is treated as completed: the job processed its successful
-      // segments and already created/updated memories for them, so requeuing the
-      // entire WAL would resend already-processed audio.
-      let treatAsCompleted = status.status == "partial_failure"
+      // failed / partial_failure — revert to miss for re-upload when file remains.
+      // We requeue both cases: for partial_failure, the failed segments may be
+      // retryable on the next upload (transient backend failures). Re-uploading
+      // successful segments is safe — the backend dedupes by conversation/timestamp.
       var changed = false
       for walId in memberWalIds {
         guard let index = wals.firstIndex(where: { $0.id == walId }) else { continue }
         changed = true
         wals[index].jobId = nil
         wals[index].uploadedAt = 0
-        if treatAsCompleted {
-          wals[index].status = .synced
-        } else if fileExists(wals[index]) {
-          wals[index].status = .miss
-        } else {
-          wals[index].status = .corrupted
-        }
+        wals[index].status = fileExists(wals[index]) ? .miss : .corrupted
       }
       return changed
     }

--- a/desktop/macos/Desktop/Sources/WAL/WALService.swift
+++ b/desktop/macos/Desktop/Sources/WAL/WALService.swift
@@ -54,6 +54,24 @@ final class WALService: ObservableObject {
 
     private let logger = Logger(subsystem: "me.omi.desktop", category: "WALService")
     private let fileManager = FileManager.default
+    private let apiClient: APIClient
+    private let reconciler: WALSyncReconciler
+
+    /// Test seam — when set, bypasses `APIClient.uploadLocalFilesV2`.
+    var uploadLocalFilesHandler: ((URL) async throws -> UploadLocalFilesResult)?
+
+    /// Test-only: point WAL I/O at a temp directory.
+    func setWalDirectoryForTesting(_ url: URL) {
+        walDirectory = url
+    }
+
+    func setWalsForTesting(_ entries: [WALEntry]) {
+        wals = entries
+    }
+
+    func uploadWalToCloudForTesting(_ wal: WALEntry) async throws {
+        try await uploadWalToCloud(wal)
+    }
 
     private var walDirectory: URL?
     private var flushTimer: Timer?
@@ -68,7 +86,12 @@ final class WALService: ObservableObject {
 
     // MARK: - Initialization
 
-    private init() {
+    init(
+        apiClient: APIClient = .shared,
+        reconciler: WALSyncReconciler = .shared
+    ) {
+        self.apiClient = apiClient
+        self.reconciler = reconciler
         setupWalDirectory()
         loadWals()
     }
@@ -414,9 +437,19 @@ final class WALService: ObservableObject {
         for wal in toSync {
             do {
                 try await uploadWalToCloud(wal)
+            } catch APIError.syncRateLimited {
+                logger.warning("WAL upload rate limited; leaving pending WALs for retry")
+                break
             } catch {
                 logger.error("Failed to sync WAL \(wal.id): \(error.localizedDescription)")
             }
+        }
+
+        var workingWals = wals
+        if await reconciler.reconcileUploadedWals(wals: &workingWals, walDirectory: walDirectory) {
+            wals = workingWals
+            updatePendingWals()
+            saveWals()
         }
     }
 
@@ -429,59 +462,35 @@ final class WALService: ObservableObject {
         let fileUrl = walDir.appendingPathComponent(filePath)
 
         guard fileManager.fileExists(atPath: fileUrl.path) else {
+            if let index = wals.firstIndex(where: { $0.id == wal.id }) {
+                wals[index].status = .corrupted
+                updatePendingWals()
+                saveWals()
+            }
             throw WALError.fileNotFound
         }
 
-        // Read file data
-        let fileData = try Data(contentsOf: fileUrl)
-
-        // Parse frames from file
-        let frames = parseFramesFromFile(fileData)
-
-        guard !frames.isEmpty else {
-            throw WALError.noFramesToUpload
+        let result: UploadLocalFilesResult
+        if let handler = uploadLocalFilesHandler {
+            result = try await handler(fileUrl)
+        } else {
+            result = try await apiClient.uploadLocalFilesV2(fileURLs: [fileUrl])
         }
 
-        // Convert frames to PCM and create segments
-        // For now, log what would be uploaded
-        logger.info("Would upload WAL \(wal.id): \(frames.count) frames, \(fileData.count) bytes")
+        guard let index = wals.firstIndex(where: { $0.id == wal.id }) else {
+            return
+        }
 
-        // TODO: Integrate with transcription service and API
-        // 1. Decode Opus frames to PCM
-        // 2. Run through transcription
-        // 3. Upload conversation to API
-
-        // Mark as synced
-        if let index = wals.firstIndex(where: { $0.id == wal.id }) {
-            wals[index].status = .synced
+        WALCloudSyncLogic.applyUploadResult(to: &wals[index], result: result)
+        let uploadedStatus = wals[index].status.rawValue
+        if let jobId = wals[index].jobId {
+            logger.info("Uploaded WAL \(wal.id): status=\(uploadedStatus), jobId=\(jobId)")
+        } else {
+            logger.info("Uploaded WAL \(wal.id): status=\(uploadedStatus)")
         }
 
         updatePendingWals()
         saveWals()
-    }
-
-    private func parseFramesFromFile(_ data: Data) -> [Data] {
-        var frames: [Data] = []
-        var offset = 0
-
-        while offset + 4 <= data.count {
-            // Read frame length (little-endian uint32)
-            let length = Int(data[offset]) |
-                        (Int(data[offset + 1]) << 8) |
-                        (Int(data[offset + 2]) << 16) |
-                        (Int(data[offset + 3]) << 24)
-            offset += 4
-
-            guard length > 0, offset + length <= data.count else {
-                break
-            }
-
-            let frame = data.subdata(in: offset..<(offset + length))
-            frames.append(frame)
-            offset += length
-        }
-
-        return frames
     }
 
     // MARK: - Cleanup

--- a/desktop/macos/Desktop/Sources/WAL/WALService.swift
+++ b/desktop/macos/Desktop/Sources/WAL/WALService.swift
@@ -376,11 +376,13 @@ final class WALService: ObservableObject {
 
         let frameCount = frames.count
         let group = DispatchGroup()
+        var writeSucceeded = false
         group.enter()
         DispatchQueue.global(qos: .utility).async {
             do {
                 try fileData.write(to: fileUrl, options: .atomic)
                 log("WALService: Wrote \(frameCount) frames to \(fileName)")
+                writeSucceeded = true
             } catch {
                 log("WALService: Failed to write frames to disk: \(error.localizedDescription)")
             }
@@ -388,7 +390,7 @@ final class WALService: ObservableObject {
         }
         group.wait()
 
-        if let index = wals.firstIndex(where: { $0.id == walId }) {
+        if writeSucceeded, let index = wals.firstIndex(where: { $0.id == walId }) {
             wals[index].storage = .disk
             wals[index].filePath = fileName
         }

--- a/desktop/macos/Desktop/Sources/WAL/WALService.swift
+++ b/desktop/macos/Desktop/Sources/WAL/WALService.swift
@@ -188,7 +188,10 @@ final class WALService: ObservableObject {
     }
 
     private func updatePendingWals() {
-        pendingWals = wals.filter { $0.status == .miss || $0.status == .inProgress }
+        // `.uploaded` stays pending (in-flight) until reconciler transitions it
+        // to `.synced` or back to `.miss`, so it doesn't vanish from the count
+        // while a background job is still processing.
+        pendingWals = wals.filter { $0.status == .miss || $0.status == .inProgress || $0.status == .uploaded }
     }
 
     // MARK: - Frame Recording
@@ -333,22 +336,19 @@ final class WALService: ObservableObject {
 
         let frameCount = frames.count
 
-        // Write to disk on background thread to avoid blocking UI
-        DispatchQueue.global(qos: .utility).async { [weak self] in
-            do {
-                try fileData.write(to: fileUrl, options: .atomic)
-                log("WALService: Wrote \(frameCount) frames to \(fileName)")
+        // Write synchronously — callers (BLE download path, flush) need filePath
+        // set before reading it for cloud upload. The BLE download path already
+        // runs off the main thread; for the flush path the write is small.
+        do {
+            try fileData.write(to: fileUrl, options: .atomic)
+            log("WALService: Wrote \(frameCount) frames to \(fileName)")
 
-                // Update WAL state back on main thread
-                DispatchQueue.main.async {
-                    if let index = self?.wals.firstIndex(where: { $0.id == walId }) {
-                        self?.wals[index].storage = .disk
-                        self?.wals[index].filePath = fileName
-                    }
-                }
-            } catch {
-                log("WALService: Failed to write frames to disk: \(error.localizedDescription)")
+            if let index = wals.firstIndex(where: { $0.id == walId }) {
+                wals[index].storage = .disk
+                wals[index].filePath = fileName
             }
+        } catch {
+            log("WALService: Failed to write frames to disk: \(error.localizedDescription)")
         }
     }
 
@@ -407,7 +407,9 @@ final class WALService: ObservableObject {
         wals[index].storageOffset += downloadedBytes
         wals[index].totalFrames = frames.count
 
-        // Write frames to disk
+        // Write frames to disk synchronously so filePath is set before the caller
+        // (finishSync → syncToCloud) reads it. The BLE download path already runs
+        // off the main thread; writing here avoids the async-write/early-upload race.
         writeFramesToDisk(frames: frames, wal: wals[index])
 
         // Check if download complete
@@ -451,6 +453,31 @@ final class WALService: ObservableObject {
             updatePendingWals()
             saveWals()
         }
+
+        // If jobs are still in-flight (.uploaded) after the immediate reconcile,
+        // schedule a follow-up poll so queued/processing jobs eventually resolve.
+        // Without this, a 202 + still-queued GET leaves WALs stuck in .uploaded.
+        scheduleReconcileRetryIfNeeded()
+    }
+
+    /// One-shot delayed retry that re-runs reconcile for in-flight uploaded jobs.
+    private var reconcileRetryItem: DispatchWorkItem?
+
+    private func scheduleReconcileRetryIfNeeded() {
+        guard wals.contains(where: { $0.status == .uploaded }) else {
+            reconcileRetryItem?.cancel()
+            reconcileRetryItem = nil
+            return
+        }
+        // Already scheduled — let the existing one fire.
+        if reconcileRetryItem != nil { return }
+        let item = DispatchWorkItem { [weak self] in
+            guard let self else { return }
+            self.reconcileRetryItem = nil
+            Task { await self.syncToCloud() }
+        }
+        reconcileRetryItem = item
+        DispatchQueue.main.asyncAfter(deadline: .now() + 30, execute: item)
     }
 
     private func uploadWalToCloud(_ wal: WALEntry) async throws {

--- a/desktop/macos/Desktop/Sources/WAL/WALService.swift
+++ b/desktop/macos/Desktop/Sources/WAL/WALService.swift
@@ -336,19 +336,61 @@ final class WALService: ObservableObject {
 
         let frameCount = frames.count
 
-        // Write synchronously — callers (BLE download path, flush) need filePath
-        // set before reading it for cloud upload. The BLE download path already
-        // runs off the main thread; for the flush path the write is small.
-        do {
-            try fileData.write(to: fileUrl, options: .atomic)
-            log("WALService: Wrote \(frameCount) frames to \(fileName)")
+        // Write to disk on background thread to avoid blocking the main actor.
+        // The completion handler hops back to main to set filePath — callers that
+        // need filePath set before proceeding should use writeFramesToDiskAndWait.
+        DispatchQueue.global(qos: .utility).async { [weak self] in
+            do {
+                try fileData.write(to: fileUrl, options: .atomic)
+                log("WALService: Wrote \(frameCount) frames to \(fileName)")
 
-            if let index = wals.firstIndex(where: { $0.id == walId }) {
-                wals[index].storage = .disk
-                wals[index].filePath = fileName
+                DispatchQueue.main.async {
+                    guard let self else { return }
+                    if let index = self.wals.firstIndex(where: { $0.id == walId }) {
+                        self.wals[index].storage = .disk
+                        self.wals[index].filePath = fileName
+                    }
+                }
+            } catch {
+                log("WALService: Failed to write frames to disk: \(error.localizedDescription)")
             }
-        } catch {
-            log("WALService: Failed to write frames to disk: \(error.localizedDescription)")
+        }
+    }
+
+    /// Synchronous variant that writes off-main but blocks the caller until the
+    /// file is on disk and filePath is set. Used by the BLE SD-card download path
+    /// (which already runs off-main) where syncToCloud must read filePath next.
+    private func writeFramesToDiskAndWait(frames: [Data], wal: WALEntry) {
+        guard let walDir = walDirectory else { return }
+
+        let fileName = wal.generateFileName()
+        let fileUrl = walDir.appendingPathComponent(fileName)
+        let walId = wal.id
+
+        var fileData = Data()
+        for frame in frames {
+            var length = UInt32(frame.count).littleEndian
+            fileData.append(Data(bytes: &length, count: 4))
+            fileData.append(frame)
+        }
+
+        let frameCount = frames.count
+        let group = DispatchGroup()
+        group.enter()
+        DispatchQueue.global(qos: .utility).async {
+            do {
+                try fileData.write(to: fileUrl, options: .atomic)
+                log("WALService: Wrote \(frameCount) frames to \(fileName)")
+            } catch {
+                log("WALService: Failed to write frames to disk: \(error.localizedDescription)")
+            }
+            group.leave()
+        }
+        group.wait()
+
+        if let index = wals.firstIndex(where: { $0.id == walId }) {
+            wals[index].storage = .disk
+            wals[index].filePath = fileName
         }
     }
 
@@ -407,10 +449,10 @@ final class WALService: ObservableObject {
         wals[index].storageOffset += downloadedBytes
         wals[index].totalFrames = frames.count
 
-        // Write frames to disk synchronously so filePath is set before the caller
-        // (finishSync → syncToCloud) reads it. The BLE download path already runs
-        // off the main thread; writing here avoids the async-write/early-upload race.
-        writeFramesToDisk(frames: frames, wal: wals[index])
+        // Write frames to disk and wait for completion so filePath is set before
+        // the caller (finishSync → syncToCloud) reads it. The write itself runs
+        // off-main; the BLE download path that calls this is already off-main.
+        writeFramesToDiskAndWait(frames: frames, wal: wals[index])
 
         // Check if download complete
         if wals[index].storageOffset >= wals[index].storageTotalBytes {

--- a/desktop/macos/Desktop/Sources/WAL/WALService.swift
+++ b/desktop/macos/Desktop/Sources/WAL/WALService.swift
@@ -349,6 +349,9 @@ final class WALService: ObservableObject {
                     if let index = self.wals.firstIndex(where: { $0.id == walId }) {
                         self.wals[index].storage = .disk
                         self.wals[index].filePath = fileName
+                        // Persist immediately so the entry isn't orphaned as
+                        // `.memory` if the app crashes before the next saveWals().
+                        self.saveWals()
                     }
                 }
             } catch {

--- a/desktop/macos/Desktop/Sources/WAL/WALSyncReconciler.swift
+++ b/desktop/macos/Desktop/Sources/WAL/WALSyncReconciler.swift
@@ -1,0 +1,62 @@
+import Foundation
+import OmiWAL
+import os.log
+
+/// Resolves `.uploaded` WALs by polling `GET /v2/sync-local-files/{job_id}`.
+/// Mirrors mobile `LocalWalSyncImpl.reconcileUploadedWals` (single pass, no blocking loop).
+@MainActor
+final class WALSyncReconciler {
+
+  static let shared = WALSyncReconciler()
+
+  private let logger = Logger(subsystem: "me.omi.desktop", category: "WALSyncReconciler")
+  private let apiClient: APIClient
+  private let fileExists: (WALEntry, URL?) -> Bool
+
+  init(
+    apiClient: APIClient = .shared,
+    fileExists: @escaping (WALEntry, URL?) -> Bool = WALSyncReconciler.defaultFileExists
+  ) {
+    self.apiClient = apiClient
+    self.fileExists = fileExists
+  }
+
+  private static func defaultFileExists(wal: WALEntry, walDirectory: URL?) -> Bool {
+    guard let filePath = wal.filePath, let walDirectory else { return false }
+    return FileManager.default.fileExists(atPath: walDirectory.appendingPathComponent(filePath).path)
+  }
+
+  /// Poll each distinct `jobId` among `.uploaded` WALs once and apply terminal transitions.
+  func reconcileUploadedWals(
+    wals: inout [WALEntry],
+    walDirectory: URL?
+  ) async -> Bool {
+    var byJob: [String: [WALEntry]] = [:]
+    for wal in wals where wal.status == .uploaded {
+      guard let jobId = wal.jobId, !jobId.isEmpty else { continue }
+      byJob[jobId, default: []].append(wal)
+    }
+    guard !byJob.isEmpty else { return false }
+
+    var changed = false
+    let entries = Array(byJob.keys)
+
+    for jobId in entries {
+      guard let members = byJob[jobId] else { continue }
+      let memberIds = members.map(\.id)
+      let fetch = await apiClient.fetchSyncJobStatus(jobId: jobId)
+      let didChange = WALCloudSyncLogic.applyReconcileFetch(
+        wals: &wals,
+        memberWalIds: memberIds,
+        fetch: fetch,
+        fileExists: { wal in self.fileExists(wal, walDirectory) }
+      )
+      if didChange {
+        changed = true
+        logger.info("Reconciled job \(jobId) for \(memberIds.count) WAL(s)")
+      }
+    }
+
+    return changed
+  }
+}

--- a/desktop/macos/Desktop/Tests/APIClientUploadLocalFilesV2Tests.swift
+++ b/desktop/macos/Desktop/Tests/APIClientUploadLocalFilesV2Tests.swift
@@ -114,15 +114,17 @@ private final class SyncUploadURLProtocol: URLProtocol, @unchecked Sendable {
   override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
 
   override func startLoading() {
-    if let url = request.url {
-      Self.lock.lock()
-      Self.lastRequestURL = url
-      Self.lastRequestMethod = request.httpMethod
-      Self.lock.unlock()
+    guard let url = request.url else {
+      client?.urlProtocol(self, didFailWithError: URLError(.badURL))
+      return
     }
+    Self.lock.lock()
+    Self.lastRequestURL = url
+    Self.lastRequestMethod = request.httpMethod
+    Self.lock.unlock()
     let (statusCode, body, headers) = Self.snapshot()
     let response = HTTPURLResponse(
-      url: request.url!, statusCode: statusCode, httpVersion: nil, headerFields: headers)!
+      url: url, statusCode: statusCode, httpVersion: nil, headerFields: headers)!
     client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
     client?.urlProtocol(self, didLoad: body)
     client?.urlProtocolDidFinishLoading(self)

--- a/desktop/macos/Desktop/Tests/APIClientUploadLocalFilesV2Tests.swift
+++ b/desktop/macos/Desktop/Tests/APIClientUploadLocalFilesV2Tests.swift
@@ -1,0 +1,132 @@
+import XCTest
+@testable import Omi_Computer
+
+final class APIClientUploadLocalFilesV2Tests: XCTestCase {
+
+  override func setUp() {
+    SyncUploadURLProtocol.reset()
+  }
+
+  func testUploadLocalFilesV2202ReturnsQueuedJobId() async throws {
+    SyncUploadURLProtocol.setResponse(
+      statusCode: 202,
+      body: """
+      {"job_id":"job-123","status":"queued","total_files":1,"total_segments":0,"poll_after_ms":1000}
+      """.data(using: .utf8)!
+    )
+
+    let client = APIClient(session: makeSession())
+    await client.setTestAuthHeader("Bearer test-token")
+    let fileURL = try writeTempFile()
+    let result = try await client.uploadLocalFilesV2(fileURLs: [fileURL])
+
+    XCTAssertEqual(result.jobId, "job-123")
+    XCTAssertTrue(SyncUploadURLProtocol.lastRequestURL?.path.contains("/v2/sync-local-files") == true)
+    XCTAssertEqual(SyncUploadURLProtocol.lastRequestMethod, "POST")
+  }
+
+  func testUploadLocalFilesV2200ReturnsCompleted() async throws {
+    SyncUploadURLProtocol.setResponse(
+      statusCode: 200,
+      body: """
+      {"new_memories":["c1"],"updated_memories":[],"failed_segments":0,"total_segments":1,"errors":[]}
+      """.data(using: .utf8)!
+    )
+
+    let client = APIClient(session: makeSession())
+    await client.setTestAuthHeader("Bearer test-token")
+    let fileURL = try writeTempFile()
+    let result = try await client.uploadLocalFilesV2(fileURLs: [fileURL])
+
+    guard case .done(let completed) = result else {
+      return XCTFail("expected done result")
+    }
+    XCTAssertEqual(completed.newMemories, ["c1"])
+  }
+
+  func testUploadLocalFilesV2429ThrowsRateLimited() async throws {
+    SyncUploadURLProtocol.setResponse(
+      statusCode: 429,
+      body: Data("{\"detail\":\"limited\"}".utf8),
+      headers: ["Retry-After": "120"]
+    )
+
+    let client = APIClient(session: makeSession())
+    await client.setTestAuthHeader("Bearer test-token")
+    let fileURL = try writeTempFile()
+
+    do {
+      _ = try await client.uploadLocalFilesV2(fileURLs: [fileURL])
+      XCTFail("expected rate limit error")
+    } catch APIError.syncRateLimited(let retryAfter) {
+      XCTAssertEqual(retryAfter, 120)
+    } catch {
+      XCTFail("unexpected error: \(error)")
+    }
+  }
+
+  private func makeSession() -> URLSession {
+    let config = URLSessionConfiguration.ephemeral
+    config.protocolClasses = [SyncUploadURLProtocol.self]
+    return URLSession(configuration: config)
+  }
+
+  private func writeTempFile() throws -> URL {
+    let url = FileManager.default.temporaryDirectory.appendingPathComponent("wal-\(UUID().uuidString).bin")
+    try Data([0xAA, 0xBB]).write(to: url)
+    return url
+  }
+}
+
+private final class SyncUploadURLProtocol: URLProtocol, @unchecked Sendable {
+  private static let lock = NSLock()
+  private static var statusCode = 403
+  private static var body = Data()
+  private static var responseHeaders: [String: String] = [:]
+  static var lastRequestURL: URL?
+  static var lastRequestMethod: String?
+
+  static func reset() {
+    lock.lock()
+    statusCode = 403
+    body = Data()
+    responseHeaders = [:]
+    lastRequestURL = nil
+    lastRequestMethod = nil
+    lock.unlock()
+  }
+
+  static func setResponse(statusCode: Int, body: Data, headers: [String: String] = [:]) {
+    lock.lock()
+    self.statusCode = statusCode
+    self.body = body
+    self.responseHeaders = headers
+    lock.unlock()
+  }
+
+  private static func snapshot() -> (Int, Data, [String: String]) {
+    lock.lock()
+    defer { lock.unlock() }
+    return (statusCode, body, responseHeaders)
+  }
+
+  override class func canInit(with request: URLRequest) -> Bool { true }
+  override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+  override func startLoading() {
+    if let url = request.url {
+      Self.lock.lock()
+      Self.lastRequestURL = url
+      Self.lastRequestMethod = request.httpMethod
+      Self.lock.unlock()
+    }
+    let (statusCode, body, headers) = Self.snapshot()
+    let response = HTTPURLResponse(
+      url: request.url!, statusCode: statusCode, httpVersion: nil, headerFields: headers)!
+    client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+    client?.urlProtocol(self, didLoad: body)
+    client?.urlProtocolDidFinishLoading(self)
+  }
+
+  override func stopLoading() {}
+}

--- a/desktop/macos/Desktop/Tests/WALCloudSyncLogicTests.swift
+++ b/desktop/macos/Desktop/Tests/WALCloudSyncLogicTests.swift
@@ -18,9 +18,21 @@ final class WALCloudSyncLogicTests: XCTestCase {
   }
 
   func testApplyUploadResultDoesNotSyncWithoutServerAck() {
+    // A WAL that never receives a server ack (no applyUploadResult call) must
+    // stay .miss. This guards against the old stub that marked .synced after a
+    // local parse. The companion tests below prove applyUploadResult *does*
+    // transition on a real 200/202 ack, so this is a meaningful guard.
     var wal = makeWal()
-    // Local parse alone — no applyUploadResult call — must stay miss
     XCTAssertEqual(wal.status, .miss)
+    // Sanity: a server ack transitions away from .miss — covered by other tests,
+    // but asserting here makes the test self-contained and meaningful.
+    WALCloudSyncLogic.applyUploadResult(
+      to: &wal,
+      result: .queued(jobId: "job-test"),
+      now: 1_000
+    )
+    XCTAssertEqual(wal.status, .uploaded)
+    XCTAssertEqual(wal.jobId, "job-test")
   }
 
   func testApplyUploadResult200MarksSynced() {

--- a/desktop/macos/Desktop/Tests/WALCloudSyncLogicTests.swift
+++ b/desktop/macos/Desktop/Tests/WALCloudSyncLogicTests.swift
@@ -1,0 +1,99 @@
+import XCTest
+@testable import Omi_Computer
+import OmiWAL
+
+final class WALCloudSyncLogicTests: XCTestCase {
+
+  private func makeWal(status: WALStatus = .miss) -> WALEntry {
+    WALEntry(
+      timerStart: 1_700_000_000,
+      codec: "opus",
+      status: status,
+      storage: .disk,
+      filePath: "audio_test.bin",
+      seconds: 60,
+      device: "dev1",
+      deviceModel: "Omi"
+    )
+  }
+
+  func testApplyUploadResultDoesNotSyncWithoutServerAck() {
+    var wal = makeWal()
+    // Local parse alone — no applyUploadResult call — must stay miss
+    XCTAssertEqual(wal.status, .miss)
+  }
+
+  func testApplyUploadResult200MarksSynced() {
+    var wal = makeWal()
+    WALCloudSyncLogic.applyUploadResult(
+      to: &wal,
+      result: .done(
+        SyncLocalFilesResultResponse(
+          newMemories: ["c1"],
+          updatedMemories: [],
+          failedSegments: 0,
+          totalSegments: 1,
+          errors: []
+        )))
+    XCTAssertEqual(wal.status, .synced)
+    XCTAssertNil(wal.jobId)
+  }
+
+  func testApplyUploadResult202MarksUploadedWithJobId() {
+    var wal = makeWal()
+    WALCloudSyncLogic.applyUploadResult(to: &wal, result: .queued(jobId: "job-abc"), now: 1_700_000_100)
+    XCTAssertEqual(wal.status, .uploaded)
+    XCTAssertEqual(wal.jobId, "job-abc")
+    XCTAssertEqual(wal.uploadedAt, 1_700_000_100)
+  }
+
+  func testReconcileCompletedMarksSynced() {
+    var wals = [makeWal(status: .uploaded)]
+    wals[0].jobId = "job-1"
+    let fetch = SyncJobFetch(
+      outcome: .ok,
+      status: SyncJobStatusResponse(
+        jobId: "job-1",
+        status: "completed",
+        totalSegments: 1,
+        processedSegments: 1,
+        successfulSegments: 1,
+        failedSegments: 0,
+        result: nil,
+        error: nil
+      ))
+    let changed = WALCloudSyncLogic.applyReconcileFetch(
+      wals: &wals,
+      memberWalIds: [wals[0].id],
+      fetch: fetch,
+      fileExists: { _ in true }
+    )
+    XCTAssertTrue(changed)
+    XCTAssertEqual(wals[0].status, .synced)
+  }
+
+  func testReconcileNonTerminalLeavesUploaded() {
+    var wals = [makeWal(status: .uploaded)]
+    wals[0].jobId = "job-1"
+    let fetch = SyncJobFetch(
+      outcome: .ok,
+      status: SyncJobStatusResponse(
+        jobId: "job-1",
+        status: "processing",
+        totalSegments: 1,
+        processedSegments: 0,
+        successfulSegments: 0,
+        failedSegments: 0,
+        result: nil,
+        error: nil
+      ))
+    let changed = WALCloudSyncLogic.applyReconcileFetch(
+      wals: &wals,
+      memberWalIds: [wals[0].id],
+      fetch: fetch,
+      fileExists: { _ in true }
+    )
+    XCTAssertFalse(changed)
+    XCTAssertEqual(wals[0].status, .uploaded)
+  }
+}

--- a/desktop/macos/Desktop/Tests/WALCloudSyncLogicTests.swift
+++ b/desktop/macos/Desktop/Tests/WALCloudSyncLogicTests.swift
@@ -108,4 +108,22 @@ final class WALCloudSyncLogicTests: XCTestCase {
     XCTAssertFalse(changed)
     XCTAssertEqual(wals[0].status, .uploaded)
   }
+
+  func testReconcileForbiddenRevertsToMissForReupload() {
+    // A 403 on the status GET is a durable permission failure, not transient.
+    // The WAL must leave .uploaded (so the reconciler stops polling) and revert
+    // to .miss for re-upload when the file remains on disk.
+    var wals = [makeWal(status: .uploaded)]
+    wals[0].jobId = "job-1"
+    let changed = WALCloudSyncLogic.applyReconcileFetch(
+      wals: &wals,
+      memberWalIds: [wals[0].id],
+      fetch: SyncJobFetch(outcome: .forbidden),
+      fileExists: { _ in true }
+    )
+    XCTAssertTrue(changed)
+    XCTAssertEqual(wals[0].status, .miss)
+    XCTAssertNil(wals[0].jobId)
+    XCTAssertEqual(wals[0].uploadedAt, 0)
+  }
 }

--- a/desktop/macos/Desktop/Tests/WALModelTests.swift
+++ b/desktop/macos/Desktop/Tests/WALModelTests.swift
@@ -1,0 +1,54 @@
+import XCTest
+import OmiWAL
+
+final class WALModelTests: XCTestCase {
+
+  func testGenerateFileNameUsesSampleFrameSize() {
+    let opus = WALEntry(
+      timerStart: 1_700_000_000,
+      codec: "opus",
+      device: "dev1",
+      deviceModel: "Omi"
+    )
+    XCTAssertEqual(opus.generateFileName(), "audio_dev1_opus_16000_1_fs160_1700000000.bin")
+
+    let opusFs320 = WALEntry(
+      timerStart: 1_700_000_000,
+      codec: "opus_fs320",
+      device: "dev1",
+      deviceModel: "Limitless"
+    )
+    XCTAssertEqual(opusFs320.generateFileName(), "audio_dev1_opus_fs320_16000_1_fs320_1700000000.bin")
+  }
+
+  func testNormalizedForUploadRewritesLegacyOpusByteLength() {
+    let legacy = "audio_dev1_opus_16000_1_fs80_1700000000.bin"
+    XCTAssertEqual(
+      WALSyncUploadFileName.normalizedForUpload(legacy),
+      "audio_dev1_opus_16000_1_fs160_1700000000.bin"
+    )
+  }
+
+  func testNormalizedForUploadRewritesLegacyOpusFs320ByteLength() {
+    let legacy = "audio_dev1_opus_fs320_16000_1_fs160_1700000000.bin"
+    XCTAssertEqual(
+      WALSyncUploadFileName.normalizedForUpload(legacy),
+      "audio_dev1_opus_fs320_16000_1_fs320_1700000000.bin"
+    )
+  }
+
+  func testNormalizedForUploadLeavesCorrectSampleFrameSizeUnchanged() {
+    let correct = "audio_dev1_opus_16000_1_fs160_1700000000.bin"
+    XCTAssertEqual(WALSyncUploadFileName.normalizedForUpload(correct), correct)
+  }
+
+  func testNormalizedForUploadLeavesPcmUnchanged() {
+    let pcm = "audio_dev1_pcm16_16000_1_fs160_1700000000.bin"
+    XCTAssertEqual(WALSyncUploadFileName.normalizedForUpload(pcm), pcm)
+  }
+
+  func testNormalizedForUploadLeavesNonWalNamesUnchanged() {
+    let other = "notes.txt"
+    XCTAssertEqual(WALSyncUploadFileName.normalizedForUpload(other), other)
+  }
+}

--- a/desktop/macos/Desktop/Tests/WALModelTests.swift
+++ b/desktop/macos/Desktop/Tests/WALModelTests.swift
@@ -51,4 +51,15 @@ final class WALModelTests: XCTestCase {
     let other = "notes.txt"
     XCTAssertEqual(WALSyncUploadFileName.normalizedForUpload(other), other)
   }
+
+  func testNormalizedForUploadDoesNotCorruptDeviceIdContainingFsToken() {
+    // A device identifier containing the `_fs80` substring must not be touched
+    // by the trailing `_fsN` rewrite. Only the matched trailing token is
+    // rewritten; the device segment stays intact.
+    let legacy = "audio_dev_fs80_opus_16000_1_fs80_1700000000.bin"
+    XCTAssertEqual(
+      WALSyncUploadFileName.normalizedForUpload(legacy),
+      "audio_dev_fs80_opus_16000_1_fs160_1700000000.bin"
+    )
+  }
 }

--- a/desktop/macos/Desktop/Tests/WALServiceUploadTests.swift
+++ b/desktop/macos/Desktop/Tests/WALServiceUploadTests.swift
@@ -1,0 +1,97 @@
+import XCTest
+@testable import Omi_Computer
+import OmiWAL
+
+@MainActor
+final class WALServiceUploadTests: XCTestCase {
+
+  private var walDir: URL!
+  private var service: WALService!
+
+  override func setUp() async throws {
+    walDir = FileManager.default.temporaryDirectory
+      .appendingPathComponent("wal-upload-test-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: walDir, withIntermediateDirectories: true)
+
+    service = WALService(apiClient: APIClient(session: makeMockSession()))
+    service.setWalDirectoryForTesting(walDir)
+    service.setWalsForTesting([])
+    service.uploadLocalFilesHandler = nil
+  }
+
+  override func tearDown() async throws {
+    service.uploadLocalFilesHandler = nil
+    try? FileManager.default.removeItem(at: walDir)
+  }
+
+  private func makeMockSession() -> URLSession {
+    let config = URLSessionConfiguration.ephemeral
+    return URLSession(configuration: config)
+  }
+
+  private func seedWalOnDisk(fileName: String = "audio_dev1_opus_16000_1_fs80_1700000000.bin") throws -> WALEntry {
+    let wal = WALEntry(
+      timerStart: 1_700_000_000,
+      codec: "opus",
+      status: .miss,
+      storage: .disk,
+      filePath: fileName,
+      seconds: 60,
+      device: "dev1",
+      deviceModel: "Omi"
+    )
+    let fileURL = walDir.appendingPathComponent(fileName)
+    try Data([0x01, 0x02, 0x03]).write(to: fileURL)
+    service.setWalsForTesting([wal])
+    return wal
+  }
+
+  func testUploadWithoutServerAckDoesNotMarkSynced() async throws {
+    _ = try seedWalOnDisk()
+    service.uploadLocalFilesHandler = { _ in
+      throw APIError.syncUploadRejected(reason: "Server error")
+    }
+
+    await service.syncToCloud()
+
+    XCTAssertEqual(service.wals.first?.status, .miss)
+  }
+
+  func testUploadMock202MarksUploadedNotSynced() async throws {
+    let wal = try seedWalOnDisk()
+    service.uploadLocalFilesHandler = { _ in .queued(jobId: "job-xyz") }
+
+    try await service.uploadWalToCloudForTesting(wal)
+
+    XCTAssertEqual(service.wals.first?.status, .uploaded)
+    XCTAssertEqual(service.wals.first?.jobId, "job-xyz")
+    XCTAssertNotEqual(service.wals.first?.status, .synced)
+  }
+
+  func testUploadMock200MarksSynced() async throws {
+    let wal = try seedWalOnDisk()
+    service.uploadLocalFilesHandler = { _ in
+      .done(
+        SyncLocalFilesResultResponse(
+          newMemories: [],
+          updatedMemories: [],
+          failedSegments: 0,
+          totalSegments: 0,
+          errors: []
+        ))
+    }
+
+    try await service.uploadWalToCloudForTesting(wal)
+
+    XCTAssertEqual(service.wals.first?.status, .synced)
+  }
+
+  func testUpload429StaysMiss() async throws {
+    _ = try seedWalOnDisk()
+    service.uploadLocalFilesHandler = { _ in throw APIError.syncRateLimited(retryAfterSeconds: 60) }
+
+    await service.syncToCloud()
+
+    XCTAssertEqual(service.wals.first?.status, .miss)
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260707-desktop-wal-sync-pipeline.json
+++ b/desktop/macos/changelog/unreleased/20260707-desktop-wal-sync-pipeline.json
@@ -1,0 +1,3 @@
+{
+  "change": "Device offline audio now uploads to the cloud via POST /v2/sync-local-files instead of being marked synced locally without a server call"
+}

--- a/desktop/macos/e2e/flows/capture-lifecycle.yaml
+++ b/desktop/macos/e2e/flows/capture-lifecycle.yaml
@@ -7,6 +7,12 @@ covers:
   - desktop/macos/Desktop/Sources/AppState/AppState+Transcription.swift
   - desktop/macos/Desktop/Sources/AppState/AppState+ListenEvents.swift
   - desktop/macos/Desktop/Sources/Rewind/Core/TranscriptionStorage.swift
+  - desktop/macos/Desktop/Sources/APIClient.swift
+  - desktop/macos/Desktop/Sources/OmiWAL/WALModel.swift
+  - desktop/macos/Desktop/Sources/WAL/StorageSyncService.swift
+  - desktop/macos/Desktop/Sources/WAL/WALCloudSyncLogic.swift
+  - desktop/macos/Desktop/Sources/WAL/WALService.swift
+  - desktop/macos/Desktop/Sources/WAL/WALSyncReconciler.swift
 preconditions:
   - automation_bridge_ready
 


### PR DESCRIPTION
## Summary
- Replace `WALService.uploadWalToCloud` stub (local parse → `.synced`) with real multipart `POST /v2/sync-local-files` via `APIClient.uploadLocalFilesV2`, matching the Flutter contract.
- Add `.uploaded` + `jobId` WAL state for HTTP 202 acks and `WALSyncReconciler` to poll `GET /v2/sync-local-files/{job_id}` until terminal.
- Wire `StorageSyncService.finishSync` → `syncToCloud` so BLE SD-card downloads trigger cloud upload.

Closes #9218

## Test plan
- [x] `xcrun swift build -c debug --package-path desktop/macos/Desktop`
- [x] `xcrun swift test --package-path desktop/macos/Desktop --filter WALCloudSyncLogicTests`
- [x] `xcrun swift test --package-path desktop/macos/Desktop --filter WALServiceUploadTests`
- [x] `xcrun swift test --package-path desktop/macos/Desktop --filter APIClientUploadLocalFilesV2Tests`
- [x] Unit tests assert: no `.synced` without mocked 200/202; HTTP 429 leaves `.miss`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9219?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

