### PR TITLE
fix(desktop): Gemini realtime token mint — send body flat, not wrapped under authToken (#9190)

### DIFF
--- a/desktop/macos/Backend-Rust/src/routes/realtime.rs
+++ b/desktop/macos/Backend-Rust/src/routes/realtime.rs
@@ -401,14 +401,16 @@ async fn mint_gemini(state: &AppState, uid: &str) -> Result<MintResponse, MintEr
 }
 
 fn gemini_auth_token_body(new_session_expire: &str, expire: &str) -> serde_json::Value {
-    // Google's CreateAuthTokenRequest wraps token settings under `authToken`.
-    // Top-level `uses`/`expireTime` fields are ignored/rejected by the v1alpha API.
+    // The Gemini Developer API's CreateAuthToken (POST /v1alpha/auth_tokens)
+    // takes the token settings FLAT at the request root — this matches the
+    // google-genai SDK, whose request converter sets `uses`/`expireTime`/
+    // `newSessionExpireTime` directly on the request body. Wrapping them under
+    // `authToken` makes v1alpha reject the request with
+    // `Unknown name "authToken" ... Cannot find field`.
     serde_json::json!({
-        "authToken": {
-            "uses": 1,
-            "expireTime": expire,
-            "newSessionExpireTime": new_session_expire,
-        }
+        "uses": 1,
+        "expireTime": expire,
+        "newSessionExpireTime": new_session_expire,
     })
 }
 
@@ -549,18 +551,15 @@ mod tests {
     use super::*;
 
     #[test]
-    fn gemini_auth_token_body_wraps_settings_under_auth_token() {
+    fn gemini_auth_token_body_is_flat_at_request_root() {
         let body = gemini_auth_token_body("2026-07-03T18:40:00Z", "2026-07-03T19:08:00Z");
 
-        assert_eq!(body["authToken"]["uses"], 1);
-        assert_eq!(
-            body["authToken"]["newSessionExpireTime"],
-            "2026-07-03T18:40:00Z"
-        );
-        assert_eq!(body["authToken"]["expireTime"], "2026-07-03T19:08:00Z");
-        assert!(body.get("uses").is_none());
-        assert!(body.get("expireTime").is_none());
-        assert!(body.get("newSessionExpireTime").is_none());
+        // v1alpha auth_tokens takes the settings flat at the root (google-genai
+        // SDK shape); wrapping under `authToken` is what caused the mint 400s.
+        assert_eq!(body["uses"], 1);
+        assert_eq!(body["newSessionExpireTime"], "2026-07-03T18:40:00Z");
+        assert_eq!(body["expireTime"], "2026-07-03T19:08:00Z");
+        assert!(body.get("authToken").is_none());
     }
 
     #[test]

--- a/desktop/macos/changelog/unreleased/20260707-gemini-realtime-mint.json
+++ b/desktop/macos/changelog/unreleased/20260707-gemini-realtime-mint.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed Gemini realtime voice sessions failing to start for managed users due to a malformed token-mint request"
+}


### PR DESCRIPTION
## Bug
`POST /v2/realtime/session` for the Gemini provider mints an ephemeral token via Google's `generativelanguage v1alpha/auth_tokens`. The request body wrapped the settings under an `authToken` key, which Gemini rejects with HTTP 400:

```
Invalid JSON payload received. Unknown name "authToken" at 'auth_token': Cannot find field.
```

So managed Gemini realtime sessions never started — the client fell back to the legacy cascade on the non-200. This is the `authToken` mismatch reported in #9190 (still present after the #9102 diagnostics-only fix).

## Root cause
The `authToken` wrapper was introduced in 69c584830. The Gemini Developer API takes the token settings **flat at the request root** — matching the official `google-genai` SDK, whose request converter (`_CreateAuthTokenConfig_to_mldev`) sets `uses`/`expireTime`/`newSessionExpireTime` directly on the request body, not under a wrapper.

## Fix
Send `{ uses, expireTime, newSessionExpireTime }` flat. Updated the regression test to lock in the flat shape.

## Verification (real endpoint, `DESKTOP_GEMINI_API_KEY`)
Exercised the identical upstream request `mint_gemini` makes:
- **wrapped body** → HTTP 400, exact error above
- **flat body** → HTTP 200, returns `auth_tokens/<name>`

`cargo test` (realtime module) and `cargo build` pass.

🤖 automated by hourly watchdog; opened for review, not merged.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9220?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

