### PR TITLE
fix(desktop): record session heartbeat as breadcrumb, not Sentry event (#9191)

### DIFF
--- a/desktop/macos/Desktop/Sources/OmiApp.swift
+++ b/desktop/macos/Desktop/Sources/OmiApp.swift
@@ -639,12 +639,15 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
   private func startSentryHeartbeat() {
     guard !AnalyticsManager.isDevBuild else { return }
     sentryHeartbeatTimer = Timer.scheduledTimer(withTimeInterval: 300, repeats: true) { _ in
-      // Capture a session heartbeat event with current breadcrumbs
-      SentrySDK.capture(message: "Session Heartbeat") { scope in
-        scope.setLevel(.info)
-        scope.setTag(value: "heartbeat", key: "event_type")
-      }
-      log("Sentry: Session heartbeat captured")
+      // Record the session heartbeat as a breadcrumb, not a captured event.
+      // `SentrySDK.capture(message:)` created a distinct Sentry issue every 5 min
+      // (millions of unresolved events / thousands of users) that buried real
+      // crashes. A breadcrumb keeps the same observability — it rides along with
+      // any subsequent error event — without generating its own issue.
+      let breadcrumb = Breadcrumb(level: .info, category: "heartbeat")
+      breadcrumb.message = "Session Heartbeat"
+      SentrySDK.addBreadcrumb(breadcrumb)
+      log("Sentry: Session heartbeat breadcrumb recorded")
     }
   }
 

--- a/desktop/macos/Desktop/Tests/SentryHeartbeatSourceTests.swift
+++ b/desktop/macos/Desktop/Tests/SentryHeartbeatSourceTests.swift
@@ -1,0 +1,25 @@
+import XCTest
+
+/// Regression guard for #9191: the periodic session heartbeat must be recorded
+/// as a Sentry breadcrumb, never captured as an event/message. Capturing it as
+/// an event created millions of unresolved Sentry issues that buried real crashes.
+final class SentryHeartbeatSourceTests: XCTestCase {
+  func testHeartbeatUsesBreadcrumbNotCapturedEvent() throws {
+    let source = try readSource("Sources/OmiApp.swift")
+
+    // The heartbeat timer must add a breadcrumb, not capture a Sentry event.
+    XCTAssertTrue(
+      source.contains("Breadcrumb(level: .info, category: \"heartbeat\")"),
+      "Session heartbeat should be recorded as a breadcrumb")
+    XCTAssertFalse(
+      source.contains("SentrySDK.capture(message: \"Session Heartbeat\")"),
+      "Session heartbeat must not be captured as a Sentry event/issue (see #9191)")
+  }
+
+  private func readSource(_ relativePath: String) throws -> String {
+    let testFile = URL(fileURLWithPath: #filePath)
+    let desktopDir = testFile.deletingLastPathComponent().deletingLastPathComponent()
+    let file = desktopDir.appendingPathComponent(relativePath)
+    return try String(contentsOf: file, encoding: .utf8)
+  }
+}


### PR DESCRIPTION
## Bug (#9191)
Desktop `Session Heartbeat` dominated the unresolved Sentry backlog — one representative group had **~2.5M events / 6.7k users** — because the 5-minute heartbeat timer called `SentrySDK.capture(message: "Session Heartbeat")`, creating a distinct issue on every tick. This routine telemetry buried real crashes/regressions.

## Root cause
`AppDelegate.startSentryHeartbeat()` used `SentrySDK.capture(message:)` (an *event*) for what is meant to be passive session telemetry.

## Fix
Record the heartbeat as a **breadcrumb** (`SentrySDK.addBreadcrumb`), matching the existing pattern in `ResourceMonitor.swift`/`Logger.swift`. Breadcrumbs attach to any subsequent error event, so crash-context observability is preserved — but they generate **no standalone Sentry issue**, so the heartbeat stops polluting the unresolved backlog.

## Regression guard
`SentryHeartbeatSourceTests` (mirrors the existing `RewindEncoderDiagnosticsSourceTests` source-scan pattern) asserts the heartbeat uses a breadcrumb and never re-introduces `capture(message: "Session Heartbeat")`.

Scope: 2 files, +34/-6. Telemetry-only (no user-visible behavior), so no changelog fragment.

🤖 automated by hourly watchdog; opened for review, not merged.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9222?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

