### PR TITLE
fix(backend): map screen-activity missing-index error to typed MCP error (#9189)

### DIFF
--- a/backend/routers/mcp_sse.py
+++ b/backend/routers/mcp_sse.py
@@ -19,6 +19,7 @@ from urllib.parse import urlencode, urlsplit, urlunsplit, parse_qsl
 from pydantic import BaseModel
 
 import firebase_admin.auth
+from google.api_core.exceptions import FailedPrecondition
 from fastapi import APIRouter, HTTPException, Header, Request, Response, Form
 from fastapi.responses import StreamingResponse, JSONResponse, HTMLResponse
 from fastapi.templating import Jinja2Templates
@@ -1288,15 +1289,25 @@ def execute_tool(
         end = _parse_mcp_date(arguments.get("end_date"), "end_date")
         app = arguments.get("app")
         summary = parse_mcp_bool(arguments.get("summary"), "summary", default=False)
-        if summary:
-            return screen_activity_db.get_screen_activity_summary(user_id, start_date=start, end_date=end)
         try:
             limit = parse_mcp_int(arguments.get("limit"), "limit", default=200, minimum=1, maximum=1000)
         except ValueError as e:
             raise ToolExecutionError(str(e), code=-32602)
-        rows = screen_activity_db.get_screen_activity(
-            user_id, start_date=start, end_date=end, app_filter=app, limit=limit
-        )
+        # A filtered screen-activity query needs a composite Firestore index; while that index is
+        # still building (or missing) Firestore raises FailedPrecondition, which would otherwise
+        # surface as a raw 500. Convert it into an actionable typed tool error instead. (#9189)
+        try:
+            if summary:
+                return screen_activity_db.get_screen_activity_summary(user_id, start_date=start, end_date=end)
+            rows = screen_activity_db.get_screen_activity(
+                user_id, start_date=start, end_date=end, app_filter=app, limit=limit
+            )
+        except FailedPrecondition as e:
+            raise ToolExecutionError(
+                "Screen activity is temporarily unavailable for this query while a database index "
+                "finishes building. Retry without the app filter, or try again in a few minutes.",
+                code=-32000,
+            ) from e
         return {"screen_activity": [clean_screen_activity_row(r) for r in rows]}
 
     elif tool_name == "get_daily_summaries":

--- a/backend/tests/unit/test_mcp_data_endpoints.py
+++ b/backend/tests/unit/test_mcp_data_endpoints.py
@@ -145,6 +145,18 @@ sys.modules['firebase_admin.auth'].RevokedIdTokenError = type('RevokedIdTokenErr
 sys.modules['firebase_admin.auth'].CertificateFetchError = type('CertificateFetchError', (Exception,), {})
 sys.modules['firebase_admin.auth'].UserNotFoundError = type('UserNotFoundError', (Exception,), {})
 
+# The heavy-dep stubs replace the real `google` namespace with an auto-mock, so
+# `from google.api_core.exceptions import FailedPrecondition` (used by mcp_sse's #9189
+# typed-error mapping) can't resolve. Register a real exception class under that path so
+# the import works and the tool's except clause and this test's raiser share one class.
+_gapic_exceptions = ModuleType('google.api_core.exceptions')
+_gapic_exceptions.FailedPrecondition = type('FailedPrecondition', (Exception,), {})
+_gapic_api_core = ModuleType('google.api_core')
+_gapic_api_core.exceptions = _gapic_exceptions
+sys.modules['google.api_core'] = _gapic_api_core
+sys.modules['google.api_core.exceptions'] = _gapic_exceptions
+sys.modules['google'].api_core = _gapic_api_core
+
 from routers import mcp as rest  # noqa: E402
 from routers import mcp_sse as sse  # noqa: E402
 
@@ -492,6 +504,17 @@ class TestScreenActivity:
         mock_db.get_screen_activity_summary.return_value = {'apps': {}, 'total_screenshots': 0}
         result = sse.execute_tool(UID, 'get_screen_activity', {'summary': True})
         assert result['total_screenshots'] == 0
+
+    @patch('routers.mcp_sse.screen_activity_db')
+    def test_tool_maps_missing_index_to_actionable_error(self, mock_db):
+        # A filtered query on a missing/building Firestore index raises FailedPrecondition;
+        # it must surface as a typed ToolExecutionError, not a raw 500 (#9189).
+        from google.api_core.exceptions import FailedPrecondition
+
+        mock_db.get_screen_activity.side_effect = FailedPrecondition('query requires an index')
+        with pytest.raises(sse.ToolExecutionError) as exc:
+            sse.execute_tool(UID, 'get_screen_activity', {'app': 'Cursor'})
+        assert 'index' in str(exc.value).lower()
 
 
 class TestDailySummaries:


### PR DESCRIPTION
## Bug (#9189)
`/v1/mcp/sse` returned a raw **500** when the MCP `get_screen_activity` tool ran a filtered query. The tool issues a Firestore query with `appName ==` + `timestamp` range/order, which requires a composite index. When that index is missing or still building, Firestore raises `FailedPrecondition` — this was uncaught in `execute_tool`, so it propagated as an unhandled 500 with no actionable JSON-RPC error.

## Root cause
`execute_tool` only catches `ToolExecutionError`; any other exception (like `google.api_core.exceptions.FailedPrecondition`) bubbles up to the HTTP layer as a 500.

## Fix
Catch `FailedPrecondition` in the `get_screen_activity` branch and raise a typed `ToolExecutionError` with an actionable message ("retry without the app filter, or try again in a few minutes"). MCP clients now get a proper JSON-RPC error instead of a raw 500. Scoped to this one tool per the issue.

Note: the underlying composite index itself (an infra/Firestore-config change) is out of scope for this code fix; this change makes the tool fail soft while the index builds.

## Test
Added `TestScreenActivity::test_tool_maps_missing_index_to_actionable_error` — mocks the DB call to raise `FailedPrecondition` and asserts it surfaces as `ToolExecutionError`. Verified it fails without the fix.

```
$ python -m pytest tests/unit/test_mcp_data_endpoints.py -q
32 passed
$ python scripts/scan_import_time_side_effects.py
Checked 576 backend production file(s); 0 violation(s).
```

🤖 automated by hourly watchdog; opened for review, not merged.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9223?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

