### PR TITLE
Fix README desktop quick start paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,15 +19,29 @@ Trusted by 300,000+ professionals.
 
 ## Quick Start
 
+### macOS
 
-
-```bash
-git clone https://github.com/BasedHardware/omi.git && cd omi/desktop && ./run.sh --yolo
+```sh
+git clone https://github.com/BasedHardware/omi.git && cd omi/desktop/macos && ./run.sh --yolo
 ```
 
 Builds the macOS app, connects to the cloud backend, and launches. No env files, no credentials, no local backend.
 
 > **Requirements:** macOS 14+, [Xcode](https://developer.apple.com/xcode/) (includes Swift & code signing), [Node.js](https://nodejs.org/)
+
+### Windows
+
+```powershell
+git clone https://github.com/BasedHardware/omi.git
+cd omi\desktop\windows
+npm install
+copy .env.example .env
+npm run dev
+```
+
+Starts the Windows desktop app from source using the public config in `.env.example`.
+
+> **Requirements:** [Node.js](https://nodejs.org/)
 
 For development worktrees, run the cheap local setup once:
 
@@ -51,7 +65,7 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 
 ```bash
 git clone https://github.com/BasedHardware/omi.git
-cd omi/desktop
+cd omi/desktop/macos
 cp Backend-Rust/.env.example Backend-Rust/.env
 ```
 


### PR DESCRIPTION
## Summary
- Split the root README quick start into macOS and Windows sections.
- Point macOS commands at `desktop/macos` before running `run.sh`.
- Add the Windows source startup path under `desktop/windows`.
- Fix the stale full-install macOS path from `omi/desktop` to `omi/desktop/macos`.

## Why
The README told new contributors to run `./run.sh` from `omi/desktop`, but the script lives under `desktop/macos`. Windows contributors also need to enter `desktop/windows` and run the Electron app setup commands.

## Validation
- `make setup`
- `git diff --check`
- `rg -n "cd omi/desktop(\\s|$)|cd omi/desktop &&|omi/desktop && ./run\\.sh|desktop && ./run\\.sh" README.md` returned no matches
- Pre-push hook passed all fast checks for the README-only diff

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9225?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

