### PR TITLE
fix(backend): drop transcript text from speaker-ID segment queue

### DIFF
--- a/backend/routers/transcribe.py
+++ b/backend/routers/transcribe.py
@@ -123,6 +123,7 @@ from utils.translation_coordinator import TranslationCoordinator
 from utils.transcribe_decisions import (  # async-blockers: no-import-scope; async-blockers: no-changed-range-scope
     ConversationLifecycleAction,
     USER_SELF_PERSON_ID,
+    build_speaker_id_segment_payload,
     decide_existing_conversation_action,
     decide_lifecycle_action,
     decide_multi_channel_mix,
@@ -1835,16 +1836,13 @@ async def _stream_handler(
                     ):
                         try:
                             speaker_id_segment_queue.put_nowait(
-                                {
-                                    'id': segment.id,
-                                    'speaker_id': segment.speaker_id,
-                                    'abs_start': session.first_audio_byte_timestamp
-                                    + segment.start
-                                    - time_offset,  # raw start/end
-                                    'abs_end': session.first_audio_byte_timestamp + segment.end - time_offset,
-                                    'duration': segment.end - segment.start,
-                                    'text': segment.text,  # TODO: remove
-                                }
+                                build_speaker_id_segment_payload(
+                                    segment_id=segment.id,
+                                    speaker_id=segment.speaker_id,
+                                    abs_start=session.first_audio_byte_timestamp + segment.start - time_offset,
+                                    abs_end=session.first_audio_byte_timestamp + segment.end - time_offset,
+                                    duration=segment.end - segment.start,
+                                )
                             )
                         except asyncio.QueueFull:
                             pass  # Drop if queue is full

--- a/backend/tests/unit/test_transcribe_decisions.py
+++ b/backend/tests/unit/test_transcribe_decisions.py
@@ -2,6 +2,7 @@ from utils.transcribe_decisions import (
     ConversationLifecycleAction,
     TARGET_SAMPLE_RATE,
     USER_SELF_PERSON_ID,
+    build_speaker_id_segment_payload,
     decide_existing_conversation_action,
     decide_lifecycle_action,
     decide_multi_channel_mix,
@@ -498,6 +499,26 @@ def test_speaker_detection_gates():
     assert should_spawn_speaker_match(speaker_already_mapped=False, duration=2.0, min_audio_seconds=2.0) is True
     assert should_spawn_speaker_match(speaker_already_mapped=False, duration=1.99, min_audio_seconds=2.0) is False
     assert should_spawn_speaker_match(speaker_already_mapped=True, duration=4.0, min_audio_seconds=2.0) is False
+
+
+def test_speaker_id_segment_payload_excludes_transcript_text():
+    # Speaker ID matches on audio embeddings only — transcript text must never
+    # enter the queue payload (PII minimization, issue #9209).
+    payload = build_speaker_id_segment_payload(
+        segment_id='seg-1',
+        speaker_id=3,
+        abs_start=10.0,
+        abs_end=14.5,
+        duration=4.5,
+    )
+    assert payload == {
+        'id': 'seg-1',
+        'speaker_id': 3,
+        'abs_start': 10.0,
+        'abs_end': 14.5,
+        'duration': 4.5,
+    }
+    assert 'text' not in payload
 
 
 def test_text_speaker_assignment_create_speakers_compatibility():

--- a/backend/utils/transcribe_decisions.py
+++ b/backend/utils/transcribe_decisions.py
@@ -258,6 +258,23 @@ def should_spawn_speaker_match(*, speaker_already_mapped: bool, duration: float,
     return not speaker_already_mapped and duration >= min_audio_seconds
 
 
+def build_speaker_id_segment_payload(
+    *, segment_id: str, speaker_id: Any, abs_start: float, abs_end: float, duration: float
+) -> dict:
+    """Payload queued for audio-only speaker identification.
+
+    Deliberately excludes transcript text — the consumer matches on audio
+    embeddings and never reads it, so carrying it only widens the PII surface.
+    """
+    return {
+        'id': segment_id,
+        'speaker_id': speaker_id,
+        'abs_start': abs_start,  # raw start/end
+        'abs_end': abs_end,
+        'duration': duration,
+    }
+
+
 def decide_text_speaker_assignment(
     *,
     existing_person_id: Optional[str],


### PR DESCRIPTION
## What
`speaker_id_segment_queue` in `transcribe.py` shipped `segment.text` in its payload (explicitly marked `# TODO: remove`). This PR stops queuing transcript text: payload construction is extracted into a pure `build_speaker_id_segment_payload()` helper in `utils/transcribe_decisions.py`, and `text` is dropped.

## Why
From the issue:
> transcribe.py ships unused `segment.text` in `speaker_id_segment_queue` payload (PII surface).

The speaker-ID consumer (`_match_speaker_embedding` and its dispatch loop) matches speakers purely on **audio embeddings** — it reads only `id`, `speaker_id`, `abs_start`, `abs_end`, `duration`. `text` was never read, so carrying it only widened the PII surface sitting in an in-memory queue. This also clears the orphaned `TODO` marker (AGENTS.md: no orphaned deferrals).

## Verified
- Confirmed via grep that no consumer of the queued dict reads `text` (only the five audio/id fields).
- Added regression test `test_speaker_id_segment_payload_excludes_transcript_text` asserting the payload never contains `text`.
- Ran the unit suite for the touched module:
  ```
  PYTHONPATH=. pytest tests/unit/test_transcribe_decisions.py -q
  → 20 passed
  ```
- `black --line-length 120 --skip-string-normalization` clean on all three files.

Auto-generated from issue feedback by the mini issues-improver. Review before merge.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9226?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

