### PR TITLE
fix(desktop): classify Rewind disk-write failures as non-actionable Sentry noise (#9193)

### DIFF
--- a/desktop/macos/Desktop/Sources/Logger.swift
+++ b/desktop/macos/Desktop/Sources/Logger.swift
@@ -200,7 +200,7 @@ func log(_ message: String) {
 /// offline, timeouts, dropped connections, cancellations. These dominate event
 /// volume (timeouts, "no internet", socket resets) without indicating an app bug.
 /// We still write them to the local log + breadcrumbs for debugging context.
-private func isNonActionableTransient(_ error: Error?) -> Bool {
+func isNonActionableTransient(_ error: Error?) -> Bool {
   guard let error = error else { return false }
   // Swift structured-concurrency cancellation: thrown when a Task/operation is
   // cancelled (assistant stopped, frame superseded). Expected, not an app bug.
@@ -221,7 +221,11 @@ private func isNonActionableTransient(_ error: Error?) -> Bool {
   // backfill loops don't create high-volume Sentry issues.
   if let embeddingError = error as? EmbeddingService.EmbeddingError,
      embeddingError.isNonActionableForSentry { return true }
-  let nsError = error as NSError
+  // Rewind encoder disk failures wrap the underlying OS error — inspect that so a
+  // full/read-only disk ("The file couldn't be saved") is classified below rather
+  // than captured as an opaque storage-error cluster (OMI-DESKTOP-28/29).
+  let inspected = (error as? RewindError)?.underlyingError ?? error
+  let nsError = inspected as NSError
   switch nsError.domain {
   case NSURLErrorDomain:
     // -999 cancelled, -1001 timed out, -1003 host not found, -1004 cannot connect,
@@ -237,7 +241,26 @@ private func isNonActionableTransient(_ error: Error?) -> Bool {
     return transient.contains(nsError.code)
   case NSPOSIXErrorDomain:
     // 54 connection reset, 57 socket not connected, 89 operation canceled.
-    return [54, 57, 89].contains(nsError.code)
+    // 28 ENOSPC (disk full), 69 EDQUOT (over quota), 30 EROFS (read-only fs) —
+    // environmental storage exhaustion, not app bugs.
+    return [54, 57, 89, 28, 69, 30].contains(nsError.code)
+  case NSCocoaErrorDomain:
+    // Environmental file-write failures (disk full / read-only volume / no write
+    // permission) surface here as "The file couldn't be saved". Not app bugs —
+    // keep them as local logs + breadcrumbs instead of Sentry error clusters.
+    let storageExhausted: Set<Int> = [
+      NSFileWriteOutOfSpaceError,      // 640 — disk full
+      NSFileWriteVolumeReadOnlyError,  // 642 — read-only volume
+      NSFileWriteNoPermissionError,    // 513 — no write permission
+    ]
+    if storageExhausted.contains(nsError.code) { return true }
+    // Cocoa file errors often wrap a POSIX cause in NSUnderlyingErrorKey.
+    if let underlying = nsError.userInfo[NSUnderlyingErrorKey] as? NSError,
+       underlying.domain == NSPOSIXErrorDomain,
+       [28, 69, 30].contains(underlying.code) {
+      return true
+    }
+    return false
   default:
     return false
   }

--- a/desktop/macos/Desktop/Sources/Rewind/Core/RewindModels.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/RewindModels.swift
@@ -303,9 +303,21 @@ enum RewindError: LocalizedError {
     case databaseCorrupted(message: String)
     case invalidImage
     case storageError(String)
+    /// A storage failure that preserves the underlying OS error (e.g. an
+    /// AVAssetWriter disk-out-of-space failure). Keeping the wrapped `NSError`
+    /// lets the Sentry classifier recognize environmental disk failures
+    /// ("The file couldn't be saved") and collapse them into breadcrumbs instead
+    /// of flooding Sentry with unactionable error clusters.
+    case storageWriteFailed(String, underlying: Error)
     case ocrFailed(String)
     case screenshotNotFound
     case corruptedVideoChunk(String)
+
+    /// The wrapped OS error, when this error carries one.
+    var underlyingError: Error? {
+        if case .storageWriteFailed(_, let underlying) = self { return underlying }
+        return nil
+    }
 
     var errorDescription: String? {
         switch self {
@@ -317,6 +329,8 @@ enum RewindError: LocalizedError {
             return "Invalid image data"
         case .storageError(let message):
             return "Storage error: \(message)"
+        case .storageWriteFailed(let message, let underlying):
+            return "Storage error: \(message): \(underlying.localizedDescription)"
         case .ocrFailed(let message):
             return "OCR failed: \(message)"
         case .screenshotNotFound:

--- a/desktop/macos/Desktop/Sources/Rewind/Core/VideoChunkEncoder.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/VideoChunkEncoder.swift
@@ -324,7 +324,10 @@ actor VideoChunkEncoder {
         )
 
         guard writer.startWriting() else {
-            throw RewindError.storageError("Failed to start HEVC writer: \(writer.error?.localizedDescription ?? "unknown error")")
+            if let writerError = writer.error {
+                throw RewindError.storageWriteFailed("Failed to start HEVC writer", underlying: writerError)
+            }
+            throw RewindError.storageError("Failed to start HEVC writer: unknown error")
         }
         writer.startSession(atSourceTime: .zero)
 
@@ -377,7 +380,10 @@ actor VideoChunkEncoder {
 
         let presentationTime = CMTime(seconds: Double(max(0, frameOffsetInChunk - 1)) / frameRate, preferredTimescale: 600)
         guard adaptor.append(pixelBuffer, withPresentationTime: presentationTime) else {
-            throw RewindError.storageError("Failed to append frame to HEVC writer: \(assetWriter?.error?.localizedDescription ?? "unknown error")")
+            if let writerError = assetWriter?.error {
+                throw RewindError.storageWriteFailed("Failed to append frame to HEVC writer", underlying: writerError)
+            }
+            throw RewindError.storageError("Failed to append frame to HEVC writer: unknown error")
         }
         writerNotReadyCount = 0
     }
@@ -575,7 +581,11 @@ actor VideoChunkEncoder {
                 case .completed:
                     continuation.resume()
                 case .failed, .cancelled:
-                    continuation.resume(throwing: RewindError.storageError("HEVC writer failed: \(writerBox.writer.error?.localizedDescription ?? Self.writerStatusDescription(writerBox.writer.status))"))
+                    if let writerError = writerBox.writer.error {
+                        continuation.resume(throwing: RewindError.storageWriteFailed("HEVC writer failed", underlying: writerError))
+                    } else {
+                        continuation.resume(throwing: RewindError.storageError("HEVC writer failed: \(Self.writerStatusDescription(writerBox.writer.status))"))
+                    }
                 default:
                     continuation.resume(throwing: RewindError.storageError("HEVC writer ended in unexpected state: \(Self.writerStatusDescription(writerBox.writer.status))"))
                 }

--- a/desktop/macos/Desktop/Tests/RewindStorageErrorClassificationTests.swift
+++ b/desktop/macos/Desktop/Tests/RewindStorageErrorClassificationTests.swift
@@ -1,0 +1,55 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// Regression coverage for #9193: environmental disk/storage failures (the Rewind
+/// ffmpeg "The file couldn't be saved" clusters, OMI-DESKTOP-28/29) must be
+/// classified as non-actionable so they collapse into breadcrumbs instead of
+/// flooding Sentry with unactionable error groups.
+final class RewindStorageErrorClassificationTests: XCTestCase {
+  func testDiskFullCocoaErrorIsNonActionable() {
+    let err = NSError(domain: NSCocoaErrorDomain, code: NSFileWriteOutOfSpaceError)
+    XCTAssertTrue(isNonActionableTransient(err))
+  }
+
+  func testReadOnlyVolumeIsNonActionable() {
+    let err = NSError(domain: NSCocoaErrorDomain, code: NSFileWriteVolumeReadOnlyError)
+    XCTAssertTrue(isNonActionableTransient(err))
+  }
+
+  func testNoWritePermissionIsNonActionable() {
+    let err = NSError(domain: NSCocoaErrorDomain, code: NSFileWriteNoPermissionError)
+    XCTAssertTrue(isNonActionableTransient(err))
+  }
+
+  func testCocoaErrorWrappingPosixNoSpaceIsNonActionable() {
+    let posix = NSError(domain: NSPOSIXErrorDomain, code: 28)  // ENOSPC
+    let cocoa = NSError(
+      domain: NSCocoaErrorDomain, code: NSFileWriteUnknownError,
+      userInfo: [NSUnderlyingErrorKey: posix])
+    XCTAssertTrue(isNonActionableTransient(cocoa))
+  }
+
+  func testPosixDiskCodesAreNonActionable() {
+    XCTAssertTrue(isNonActionableTransient(NSError(domain: NSPOSIXErrorDomain, code: 28)))  // ENOSPC
+    XCTAssertTrue(isNonActionableTransient(NSError(domain: NSPOSIXErrorDomain, code: 69)))  // EDQUOT
+    XCTAssertTrue(isNonActionableTransient(NSError(domain: NSPOSIXErrorDomain, code: 30)))  // EROFS
+  }
+
+  func testRewindStorageWriteFailureWrappingDiskFullIsNonActionable() {
+    let disk = NSError(domain: NSCocoaErrorDomain, code: NSFileWriteOutOfSpaceError)
+    let rewindError = RewindError.storageWriteFailed("Failed to append frame to HEVC writer", underlying: disk)
+    XCTAssertTrue(isNonActionableTransient(rewindError))
+  }
+
+  func testGenericStorageErrorStillCaptured() {
+    // A plain storage error with no underlying OS cause may be a real bug — keep it.
+    XCTAssertFalse(isNonActionableTransient(RewindError.storageError("Cannot add HEVC writer input")))
+  }
+
+  func testUnknownCocoaWriteErrorStillCaptured() {
+    // NSFileWriteUnknownError (512) with no disk cause may indicate a real bug.
+    let err = NSError(domain: NSCocoaErrorDomain, code: NSFileWriteUnknownError)
+    XCTAssertFalse(isNonActionableTransient(err))
+  }
+}


### PR DESCRIPTION
## Bug (#9193)

Desktop Sentry has large unresolved Rewind/FFmpeg/storage error clusters (OMI-DESKTOP-28/29):

> `RewindIndexer: Failed to process CGImage frame: storageError("Failed to write frame to ffmpeg: The file couldn't be saved.")`

"The file couldn't be saved" is a Cocoa `NSFileWriteOutOfSpaceError` (disk full) / read-only volume / no-permission failure — an **environmental** condition on the user's machine, not an app bug. These flood Sentry as unactionable error groups.

## Root cause

1. The Sentry transient classifier (`isNonActionableTransient` in `Logger.swift`) only recognized `NSURLErrorDomain` and POSIX-socket errors. Disk-exhaustion file-write errors (`NSCocoaErrorDomain` / POSIX `ENOSPC`/`EDQUOT`/`EROFS`) were never classified, so every failure was captured as a distinct error.
2. `VideoChunkEncoder` flattened the underlying `AVAssetWriter`/`NSError` into a `RewindError.storageError(String)`, destroying the domain/code the classifier needs — so even after (1), the Rewind clusters could not be recognized.

## Fix (surgical, +108/-6, 4 files)

- **`RewindModels.swift`** — add `RewindError.storageWriteFailed(String, underlying: Error)` that preserves the wrapped `NSError` (existing `storageError` cases untouched).
- **`VideoChunkEncoder.swift`** — throw the new case on writer-start / frame-append / finish OS-write failures so the real disk error is carried.
- **`Logger.swift`** — `isNonActionableTransient` now unwraps `RewindError` to inspect the underlying cause and treats disk-full / read-only / no-permission file-write errors as non-actionable. They stay as **local logs + breadcrumbs**, not standalone Sentry error clusters. Real/unknown write errors (e.g. `NSFileWriteUnknownError`) stay captured.

## Verification

```
xcrun swift build -c debug --package-path Desktop        # Build complete
xcrun swift test --package-path Desktop --filter RewindStorageErrorClassificationTests
# Executed 8 tests, with 0 failures
```

New regression test `RewindStorageErrorClassificationTests` (8 cases) covers disk-full/read-only/no-permission Cocoa codes, POSIX disk codes, Cocoa-wrapping-POSIX, the wrapped `RewindError`, and negative cases (generic + unknown write errors still captured).

Note: this reduces Sentry *noise*; it does not change user-facing capture behavior, so no changelog fragment. Full Sentry-group cleanup / stale-group resolution in #9193 remains a dashboard task.

🤖 automated by hourly watchdog; opened for review, not merged.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9230?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

