### PR TITLE
ci(desktop): run launcher script tests in PR CI; discover them instead of hardcoding

### DIFF
--- a/.github/workflows/desktop-swift-ci.yml
+++ b/.github/workflows/desktop-swift-ci.yml
@@ -57,6 +57,17 @@ jobs:
           fi
           python3 desktop/macos/scripts/check-e2e-flow-coverage.py --strict --base "$DIFF_BASE"
 
+      - name: Desktop launcher script tests
+        if: steps.changed.outputs.should_run == 'true'
+        working-directory: desktop/macos
+        run: |
+          # Discovery, not a hardcoded list — a new tests/test-*.sh runs here
+          # automatically, mirroring swift-test-suites.sh's auto-discovery.
+          for t in tests/test-*.sh; do
+            echo "== $t"
+            bash "$t"
+          done
+
       - name: Build desktop Swift app
         if: steps.changed.outputs.should_run == 'true'
         working-directory: desktop/macos

--- a/desktop/macos/test.sh
+++ b/desktop/macos/test.sh
@@ -7,15 +7,13 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 echo "=== Desktop Launcher Script Tests ==="
 cd "$SCRIPT_DIR"
-bash tests/test-app-config.sh
-bash tests/test-settings-seed.sh
-bash tests/test-cleanup-omi-tcc.sh
-bash tests/test-omi-harness.sh
-bash tests/test-signed-artifact-smoke.sh
-bash tests/test-e2e-flow-coverage.sh
-bash tests/test-desktop-doctor-preflight.sh
-bash tests/test-swift-test-skip-ratchet.sh
-bash tests/test-swift-test-suites.sh
+# Discovery, not a hardcoded list — a hardcoded list already orphaned one test
+# (test-prepare-desktop-bundle-native-deps.sh ran nowhere). Every tests/test-*.sh
+# runs, mirroring swift-test-suites.sh's auto-discovery of Swift suites.
+for t in tests/test-*.sh; do
+  echo "== $t"
+  bash "$t"
+done
 python3 scripts/check-e2e-flow-coverage.py --strict
 echo ""
 


### PR DESCRIPTION
## Problem

A CI-coverage audit of the last 24 desktop bug fixes checked whether each fix's regression test actually executes in PR CI. The Swift side is healthy — `swift-test-suites.sh` auto-discovers suites, so every Swift regression test added by a fix PR runs in `desktop-swift-ci.yml` with no registration. But two structural gaps surfaced:

1. **The bash launcher lane never runs in CI.** No workflow references `desktop/macos/tests/test-*.sh` — the lane exists only in local `test.sh`. That silently exempts `test-settings-seed.sh` (the hermeticity regression test from the settings-seed fix) and every future launcher-level guard from CI.
2. **The hardcoded list already orphaned a test.** `tests/test-prepare-desktop-bundle-native-deps.sh` exists in `tests/` but was never added to `test.sh`'s hardcoded 9-entry list — it ran in **neither CI nor local runs**. (It passes when actually invoked.)

## Fix — discovery, not registration

- **`.github/workflows/desktop-swift-ci.yml`**: new "Desktop launcher script tests" step — `for t in tests/test-*.sh; do bash "$t"; done` — placed before the release build so cheap failures land in ~1 minute. The job is already `macos-15` and its changed-path gate already covers `desktop/macos/tests/`, so no new workflow or gate is needed.
- **`desktop/macos/test.sh`**: the hardcoded launcher list becomes the same discovery loop, so local and CI can never drift again and a new `tests/test-*.sh` is guaranteed to run in both.

## Verification

- All 10 current `tests/test-*.sh` pass locally via the exact discovery loop — including the previously-orphaned native-deps test.
- Hermeticity re-checked per test: every one uses `mktemp -d` isolation and stubs its externals (the swift-suite tests stub `xcrun`; the signed-artifact test only exercises help/arg-parse paths — nothing builds, signs, or touches the network/real defaults domains). Estimated added CI wall-clock: ~15–20s.
- Independent review (empirical): under GitHub Actions' default `bash -eo pipefail` step shell, a failing test inside the loop **fails the step immediately** (verified for middle and last positions); empty-glob fails loud rather than passing silently; no untrusted `${{ }}` interpolation in the new step.
- Composes with #9242 in either merge order: its `tests/test-omi-hardening-smoke.sh` matches the discovery glob, so whichever lands second just drops the now-redundant explicit line in `test.sh` during rebase.

Dev/CI tooling only — `no-changelog-needed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9243?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

