### PR TITLE
fix(desktop): truthful System Audio permission row from observed tap outcomes

### DIFF
--- a/desktop/macos/Desktop/Sources/AppState.swift
+++ b/desktop/macos/Desktop/Sources/AppState.swift
@@ -4,6 +4,13 @@ import Combine
 import SwiftUI
 import UserNotifications
 
+enum SystemAudioPermissionStatus: String {
+  case unknown
+  case granted
+  case denied
+  case unsupported
+}
+
 /// Translation from backend (e.g., Japanese speech translated to English)
 struct SegmentTranslation: Identifiable {
   var id: String { lang }
@@ -146,6 +153,7 @@ class AppState: ObservableObject {
   var currentTranscript: String = ""
   @Published var hasMicrophonePermission = false
   @Published var hasSystemAudioPermission = false
+  @Published var systemAudioPermissionStatus: SystemAudioPermissionStatus = .unknown
   @Published var isSystemAudioSupported = false
 
   // Audio source (microphone or BLE device)

--- a/desktop/macos/Desktop/Sources/AppState.swift
+++ b/desktop/macos/Desktop/Sources/AppState.swift
@@ -9,6 +9,25 @@ enum SystemAudioPermissionStatus: String {
   case granted
   case denied
   case unsupported
+
+  /// Map a capture-start failure to an honest permission status. A TCC denial
+  /// manifests as the tap failing to create or the device failing to start;
+  /// format/converter/aggregate failures are provably NOT permission problems
+  /// and must not claim a denial.
+  @available(macOS 14.4, *)
+  static func classify(captureError error: Error) -> SystemAudioPermissionStatus {
+    guard let captureError = error as? SystemAudioCaptureService.SystemAudioCaptureError else {
+      return .unknown
+    }
+    switch captureError {
+    case .tapCreationFailed, .deviceStartFailed:
+      return .denied
+    case .aggregateDeviceFailed, .ioProcCreationFailed, .formatError, .converterCreationFailed:
+      return .unknown
+    case .unsupportedOS:
+      return .unsupported
+    }
+  }
 }
 
 /// Translation from backend (e.g., Japanese speech translated to English)

--- a/desktop/macos/Desktop/Sources/AppState/AppState+SystemActions.swift
+++ b/desktop/macos/Desktop/Sources/AppState/AppState+SystemActions.swift
@@ -332,23 +332,28 @@ extension AppState {
     }
   }
 
-  /// Check system audio permission status and update `hasSystemAudioPermission`.
+  func recordSystemAudioCaptureOutcome(_ status: SystemAudioPermissionStatus) {
+    systemAudioPermissionStatus = status
+    hasSystemAudioPermission = status == .granted
+  }
+
+  /// Check system audio permission support and keep the last observed tap result fresh.
   ///
-  /// Core Audio process taps (macOS 14.4+) have no dedicated preflight API, but a
-  /// *global* tap that captures other apps' output is gated behind the same Screen
-  /// Recording TCC grant the rest of the app already checks — which is why a failed
-  /// test capture in `triggerSystemAudioPermission()` deep-links the user to
-  /// Privacy → Screen Recording. Previously this was a no-op (BL-020) that left the
-  /// flag reflecting only a prior successful test capture, so a revoked grant (or a
-  /// user who never ran onboarding's test) was never reflected. Mirror
-  /// `checkScreenRecordingPermission()` so the reported state tracks real TCC state.
+  /// Core Audio process taps (macOS 14.4+) do not provide a preflight API. Unlike
+  /// Screen Recording, the truthful product state comes from a real tap outcome.
+  /// If no tap is currently running, a previously granted outcome is no longer a
+  /// fresh assertion, so refreshes return to unknown until the next tap succeeds.
   func checkSystemAudioPermission() {
     guard #available(macOS 14.4, *) else {
-      hasSystemAudioPermission = false
+      recordSystemAudioCaptureOutcome(.unsupported)
       return
     }
-    hasSystemAudioPermission = ScreenRecordingPermissionPolicy.uiPermissionGranted(
-      tccGranted: ScreenCaptureService.checkPermission())
+
+    if let service = systemAudioCaptureService as? SystemAudioCaptureService, service.capturing {
+      recordSystemAudioCaptureOutcome(.granted)
+    } else if systemAudioPermissionStatus == .granted {
+      recordSystemAudioCaptureOutcome(.unknown)
+    }
   }
 
   /// Trigger system audio permission by actually testing capture
@@ -356,7 +361,7 @@ extension AppState {
   func triggerSystemAudioPermission() {
     guard #available(macOS 14.4, *) else {
       log("System audio not supported on this macOS version")
-      hasSystemAudioPermission = false
+      recordSystemAudioCaptureOutcome(.unsupported)
       return
     }
 
@@ -380,12 +385,12 @@ extension AppState {
         log("System audio: Test capture stopped")
 
         // Mark permission as granted
-        hasSystemAudioPermission = true
+        recordSystemAudioCaptureOutcome(.granted)
         log("System audio: Permission verified")
 
       } catch {
         logError("System audio: Test capture failed", error: error)
-        hasSystemAudioPermission = false
+        recordSystemAudioCaptureOutcome(.denied)
 
         // Open System Settings to Screen Recording section
         if let url = URL(

--- a/desktop/macos/Desktop/Sources/AppState/AppState+SystemActions.swift
+++ b/desktop/macos/Desktop/Sources/AppState/AppState+SystemActions.swift
@@ -390,7 +390,7 @@ extension AppState {
 
       } catch {
         logError("System audio: Test capture failed", error: error)
-        recordSystemAudioCaptureOutcome(.denied)
+        recordSystemAudioCaptureOutcome(SystemAudioPermissionStatus.classify(captureError: error))
 
         // Open System Settings to Screen Recording section
         if let url = URL(

--- a/desktop/macos/Desktop/Sources/AppState/AppState+Transcription.swift
+++ b/desktop/macos/Desktop/Sources/AppState/AppState+Transcription.swift
@@ -415,8 +415,10 @@ extension AppState {
         log("Transcription: System audio capture aborted (recording stopped during start)")
         return
       }
+      recordSystemAudioCaptureOutcome(.granted)
       log("Transcription: System audio capture started (mode=\(effectiveSystemAudioMode.rawValue))")
     } catch {
+      recordSystemAudioCaptureOutcome(.denied)
       logError(
         "Transcription: System audio capture failed (continuing with mic only)", error: error)
     }

--- a/desktop/macos/Desktop/Sources/AppState/AppState+Transcription.swift
+++ b/desktop/macos/Desktop/Sources/AppState/AppState+Transcription.swift
@@ -418,6 +418,15 @@ extension AppState {
       recordSystemAudioCaptureOutcome(.granted)
       log("Transcription: System audio capture started (mode=\(effectiveSystemAudioMode.rawValue))")
     } catch {
+      // Mirror the success path's staleness guards: if recording stopped or the
+      // service was replaced while startCapture was suspended, the failure says
+      // nothing about permission for the CURRENT session — don't record it.
+      guard isTranscribing,
+        (systemAudioCaptureService as? SystemAudioCaptureService) === systemService
+      else {
+        log("Transcription: System audio capture failed after session ended — outcome not recorded")
+        return
+      }
       recordSystemAudioCaptureOutcome(SystemAudioPermissionStatus.classify(captureError: error))
       logError(
         "Transcription: System audio capture failed (continuing with mic only)", error: error)

--- a/desktop/macos/Desktop/Sources/AppState/AppState+Transcription.swift
+++ b/desktop/macos/Desktop/Sources/AppState/AppState+Transcription.swift
@@ -418,7 +418,7 @@ extension AppState {
       recordSystemAudioCaptureOutcome(.granted)
       log("Transcription: System audio capture started (mode=\(effectiveSystemAudioMode.rawValue))")
     } catch {
-      recordSystemAudioCaptureOutcome(.denied)
+      recordSystemAudioCaptureOutcome(SystemAudioPermissionStatus.classify(captureError: error))
       logError(
         "Transcription: System audio capture failed (continuing with mic only)", error: error)
     }

--- a/desktop/macos/Desktop/Sources/AppState/AppState+TrialPaywall.swift
+++ b/desktop/macos/Desktop/Sources/AppState/AppState+TrialPaywall.swift
@@ -192,8 +192,13 @@ extension AppState {
     if !hasScreenRecordingPermission || isScreenRecordingStale {
       missing.append("Screen Recording")
     }
+    // System audio is optional/best-effort and its status idles at .unknown
+    // (Core Audio taps have no preflight API — only a live capture proves the
+    // grant). Counting .unknown as missing would permanently suppress the
+    // "All permissions granted" banner for default users, so only a proven
+    // denial counts.
     if isSystemAudioSupported, effectiveSystemAudioMode != .never,
-      systemAudioPermissionStatus != .granted
+      systemAudioPermissionStatus == .denied
     {
       missing.append("System Audio")
     }

--- a/desktop/macos/Desktop/Sources/AppState/AppState+TrialPaywall.swift
+++ b/desktop/macos/Desktop/Sources/AppState/AppState+TrialPaywall.swift
@@ -192,6 +192,11 @@ extension AppState {
     if !hasScreenRecordingPermission || isScreenRecordingStale {
       missing.append("Screen Recording")
     }
+    if isSystemAudioSupported, effectiveSystemAudioMode != .never,
+      systemAudioPermissionStatus != .granted
+    {
+      missing.append("System Audio")
+    }
     if !hasNotificationPermission {
       missing.append("Notifications")
     } else if isNotificationBannerDisabled {

--- a/desktop/macos/Desktop/Sources/Audio/AudioSourceManager.swift
+++ b/desktop/macos/Desktop/Sources/Audio/AudioSourceManager.swift
@@ -269,10 +269,15 @@ final class AudioSourceManager: ObservableObject {
                     AppState.current?.recordSystemAudioCaptureOutcome(.granted)
                 }
             } catch {
+                // System audio is optional/best-effort: the mic and mixer are
+                // already running, so a tap failure must not abort the stream
+                // (rethrowing here leaked a live mic/mixer with isStreaming
+                // never set). Record the honest outcome and continue mic-only.
                 await MainActor.run {
-                    AppState.current?.recordSystemAudioCaptureOutcome(.denied)
+                    AppState.current?.recordSystemAudioCaptureOutcome(
+                        SystemAudioPermissionStatus.classify(captureError: error))
                 }
-                throw error
+                print("AudioSourceManager: system audio capture failed, continuing mic-only: \(error)")
             }
         }
 

--- a/desktop/macos/Desktop/Sources/Audio/AudioSourceManager.swift
+++ b/desktop/macos/Desktop/Sources/Audio/AudioSourceManager.swift
@@ -254,16 +254,26 @@ final class AudioSourceManager: ObservableObject {
 
         // Start system audio capture if available
         if #available(macOS 14.4, *), let systemCapture = systemAudioCaptureService as? SystemAudioCaptureService {
-            try await systemCapture.startCapture(
-                onAudioChunk: { [weak self] audioData in
-                    self?.audioMixer?.setSystemAudio(audioData)
-                },
-                onAudioLevel: { level in
-                    Task { @MainActor in
-                        AudioLevelMonitor.shared.updateSystemLevel(level)
+            do {
+                try await systemCapture.startCapture(
+                    onAudioChunk: { [weak self] audioData in
+                        self?.audioMixer?.setSystemAudio(audioData)
+                    },
+                    onAudioLevel: { level in
+                        Task { @MainActor in
+                            AudioLevelMonitor.shared.updateSystemLevel(level)
+                        }
                     }
+                )
+                await MainActor.run {
+                    AppState.current?.recordSystemAudioCaptureOutcome(.granted)
                 }
-            )
+            } catch {
+                await MainActor.run {
+                    AppState.current?.recordSystemAudioCaptureOutcome(.denied)
+                }
+                throw error
+            }
         }
 
         conversationSource = .desktop
@@ -449,4 +459,3 @@ enum AudioSourceError: LocalizedError {
         }
     }
 }
-

--- a/desktop/macos/Desktop/Sources/Audio/AudioSourceManager.swift
+++ b/desktop/macos/Desktop/Sources/Audio/AudioSourceManager.swift
@@ -277,7 +277,7 @@ final class AudioSourceManager: ObservableObject {
                     AppState.current?.recordSystemAudioCaptureOutcome(
                         SystemAudioPermissionStatus.classify(captureError: error))
                 }
-                print("AudioSourceManager: system audio capture failed, continuing mic-only: \(error)")
+                logger.error("System audio capture failed, continuing mic-only: \(error)")
             }
         }
 

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/PermissionsPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/PermissionsPage.swift
@@ -35,6 +35,11 @@ struct PermissionsPage: View {
                     // Screen Recording Permission
                     ScreenRecordingPermissionSection(appState: appState)
 
+                    // System Audio Permission (Core Audio process taps, macOS 14.4+)
+                    if #available(macOS 14.4, *) {
+                        SystemAudioPermissionSection(appState: appState)
+                    }
+
                     // Notification Permission
                     NotificationPermissionSection(appState: appState)
                 }
@@ -650,6 +655,250 @@ struct ScreenRecordingPermissionSection: View {
     }
 }
 
+// MARK: - System Audio Permission Section
+struct SystemAudioPermissionSection: View {
+    @ObservedObject var appState: AppState
+    @State private var isExpanded = true
+    @State private var isTesting = false
+
+    private var status: SystemAudioPermissionStatus {
+        appState.systemAudioPermissionStatus
+    }
+
+    private var mode: AssistantSettings.SystemAudioCaptureMode {
+        appState.effectiveSystemAudioMode
+    }
+
+    private var isDisabledBySetting: Bool {
+        mode == .never
+    }
+
+    private var isGranted: Bool {
+        status == .granted
+    }
+
+    private var iconBackgroundColor: Color {
+        switch status {
+        case .granted:
+            return Color.green.opacity(0.15)
+        case .denied:
+            return OmiColors.warning.opacity(0.15)
+        case .unsupported:
+            return OmiColors.backgroundTertiary.opacity(0.7)
+        case .unknown:
+            return OmiColors.backgroundTertiary
+        }
+    }
+
+    private var iconColor: Color {
+        switch status {
+        case .granted:
+            return .green
+        case .denied:
+            return OmiColors.warning
+        case .unsupported:
+            return OmiColors.textTertiary
+        case .unknown:
+            return OmiColors.textSecondary
+        }
+    }
+
+    private var borderColor: Color {
+        switch status {
+        case .granted:
+            return Color.green.opacity(0.3)
+        case .denied:
+            return OmiColors.warning.opacity(0.5)
+        case .unsupported, .unknown:
+            return OmiColors.backgroundQuaternary.opacity(0.5)
+        }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Button(action: { withAnimation { isExpanded.toggle() } }) {
+                HStack(spacing: 16) {
+                    ZStack {
+                        Circle()
+                            .fill(iconBackgroundColor)
+                            .frame(width: 48, height: 48)
+
+                        Image(systemName: isGranted ? "speaker.wave.2.fill" : "speaker.slash.fill")
+                            .scaledFont(size: 22)
+                            .foregroundColor(iconColor)
+                    }
+
+                    VStack(alignment: .leading, spacing: 4) {
+                        HStack(spacing: 8) {
+                            Text("System Audio")
+                                .scaledFont(size: 16, weight: .semibold)
+                                .foregroundColor(OmiColors.textPrimary)
+
+                            systemAudioStatusBadge
+                        }
+
+                        Text(descriptionText)
+                            .scaledFont(size: 13)
+                            .foregroundColor(status == .denied ? OmiColors.warning : OmiColors.textTertiary)
+                    }
+
+                    Spacer()
+
+                    Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
+                        .scaledFont(size: 14, weight: .medium)
+                        .foregroundColor(OmiColors.textTertiary)
+                }
+                .padding(20)
+            }
+            .buttonStyle(.plain)
+
+            if isExpanded {
+                VStack(alignment: .leading, spacing: 16) {
+                    Divider()
+                        .background(OmiColors.backgroundQuaternary)
+
+                    expandedContent
+                }
+                .padding(.horizontal, 20)
+                .padding(.bottom, 20)
+            }
+        }
+        .background(
+            RoundedRectangle(cornerRadius: 16)
+                .fill(OmiColors.backgroundSecondary.opacity(0.5))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 16)
+                        .stroke(borderColor, lineWidth: status == .denied ? 2 : 1)
+                )
+        )
+    }
+
+    private var descriptionText: String {
+        if isDisabledBySetting {
+            return "Disabled in Settings > General"
+        }
+
+        switch status {
+        case .granted:
+            return "Captures audio from calls, videos, and other apps"
+        case .denied:
+            return "Access was not granted or the last system audio test failed"
+        case .unsupported:
+            return "Requires macOS 14.4 or later"
+        case .unknown:
+            return "Test access to confirm Omi can capture audio from other apps"
+        }
+    }
+
+    private var systemAudioStatusBadge: some View {
+        let label: String
+        let foreground: Color
+        let background: Color
+        let icon: String
+
+        if isDisabledBySetting {
+            label = "Disabled"
+            foreground = OmiColors.textTertiary
+            background = OmiColors.backgroundTertiary.opacity(0.8)
+            icon = "minus.circle.fill"
+        } else {
+            switch status {
+            case .granted:
+                label = "Granted"
+                foreground = .green
+                background = Color.green.opacity(0.15)
+                icon = "checkmark.circle.fill"
+            case .denied:
+                label = "Not Granted"
+                foreground = OmiColors.warning
+                background = OmiColors.warning.opacity(0.15)
+                icon = "xmark.circle.fill"
+            case .unsupported:
+                label = "Unsupported"
+                foreground = OmiColors.textTertiary
+                background = OmiColors.backgroundTertiary.opacity(0.8)
+                icon = "slash.circle.fill"
+            case .unknown:
+                label = "Unknown"
+                foreground = OmiColors.textSecondary
+                background = OmiColors.backgroundTertiary.opacity(0.8)
+                icon = "questionmark.circle.fill"
+            }
+        }
+
+        return HStack(spacing: 4) {
+            Image(systemName: icon)
+                .scaledFont(size: 12)
+            Text(label)
+                .scaledFont(size: 12, weight: .medium)
+        }
+        .foregroundColor(foreground)
+        .padding(.horizontal, 8)
+        .padding(.vertical, 4)
+        .background(Capsule().fill(background))
+    }
+
+    private var expandedContent: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            if isDisabledBySetting {
+                Text("System audio capture is set to Never in Settings > General. Change that setting before testing access.")
+                    .scaledFont(size: 14, weight: .medium)
+                    .foregroundColor(OmiColors.textPrimary)
+            } else if status == .granted {
+                Text("System audio access was confirmed by a successful Core Audio tap.")
+                    .scaledFont(size: 14, weight: .medium)
+                    .foregroundColor(OmiColors.textPrimary)
+            } else {
+                Text("How to grant system audio access:")
+                    .scaledFont(size: 14, weight: .medium)
+                    .foregroundColor(OmiColors.textPrimary)
+
+                VStack(alignment: .leading, spacing: 12) {
+                    neutralInstructionStep(number: 1, text: "Click Test Access below")
+                    neutralInstructionStep(number: 2, text: "If System Settings opens, enable Omi under Screen & System Audio Recording")
+                    neutralInstructionStep(number: 3, text: "Return to Omi and click Test Access again")
+                }
+            }
+
+            Button(action: testSystemAudioAccess) {
+                HStack(spacing: 8) {
+                    if isTesting {
+                        ProgressView()
+                            .scaleEffect(0.7)
+                    } else {
+                        Image(systemName: "speaker.wave.2.fill")
+                            .scaledFont(size: 14)
+                    }
+                    Text(isGranted ? "Test Again" : "Test Access")
+                        .scaledFont(size: 14, weight: .semibold)
+                }
+                .foregroundColor(OmiColors.textPrimary)
+                .padding(.horizontal, 20)
+                .padding(.vertical, 12)
+                .background(
+                    RoundedRectangle(cornerRadius: 10)
+                        .fill(OmiColors.backgroundTertiary)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 10)
+                                .stroke(OmiColors.backgroundQuaternary, lineWidth: 1)
+                        )
+                )
+            }
+            .buttonStyle(.plain)
+            .disabled(isTesting || isDisabledBySetting || status == .unsupported)
+            .opacity((isTesting || isDisabledBySetting || status == .unsupported) ? 0.6 : 1)
+        }
+    }
+
+    private func testSystemAudioAccess() {
+        isTesting = true
+        appState.triggerSystemAudioPermission()
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2.5) {
+            isTesting = false
+        }
+    }
+}
+
 // MARK: - Notification Permission Section
 struct NotificationPermissionSection: View {
     @ObservedObject var appState: AppState
@@ -874,6 +1123,20 @@ private func instructionStep(number: Int, text: String) -> some View {
             .foregroundColor(.white)
             .frame(width: 22, height: 22)
             .background(Circle().fill(OmiColors.purplePrimary))
+
+        Text(text)
+            .scaledFont(size: 13)
+            .foregroundColor(OmiColors.textSecondary)
+    }
+}
+
+private func neutralInstructionStep(number: Int, text: String) -> some View {
+    HStack(alignment: .top, spacing: 12) {
+        Text("\(number)")
+            .scaledFont(size: 12, weight: .bold)
+            .foregroundColor(OmiColors.textPrimary)
+            .frame(width: 22, height: 22)
+            .background(Circle().fill(OmiColors.backgroundTertiary))
 
         Text(text)
             .scaledFont(size: 13)

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/PermissionsPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/PermissionsPage.swift
@@ -844,6 +844,10 @@ struct SystemAudioPermissionSection: View {
                 Text("System audio capture is set to Never in Settings > General. Change that setting before testing access.")
                     .scaledFont(size: 14, weight: .medium)
                     .foregroundColor(OmiColors.textPrimary)
+            } else if status == .unsupported {
+                Text("System audio capture requires macOS 14.4 or later.")
+                    .scaledFont(size: 14, weight: .medium)
+                    .foregroundColor(OmiColors.textPrimary)
             } else if status == .granted {
                 Text("System audio access was confirmed by a successful Core Audio tap.")
                     .scaledFont(size: 14, weight: .medium)
@@ -1116,13 +1120,17 @@ private func statusBadge(isGranted: Bool) -> some View {
     )
 }
 
-private func instructionStep(number: Int, text: String) -> some View {
+private func instructionStep(
+    number: Int, text: String,
+    numberColor: Color = .white,
+    circleFill: Color = OmiColors.purplePrimary
+) -> some View {
     HStack(alignment: .top, spacing: 12) {
         Text("\(number)")
             .scaledFont(size: 12, weight: .bold)
-            .foregroundColor(.white)
+            .foregroundColor(numberColor)
             .frame(width: 22, height: 22)
-            .background(Circle().fill(OmiColors.purplePrimary))
+            .background(Circle().fill(circleFill))
 
         Text(text)
             .scaledFont(size: 13)
@@ -1130,18 +1138,12 @@ private func instructionStep(number: Int, text: String) -> some View {
     }
 }
 
+/// Neutral (non-purple) variant used by the System Audio section.
 private func neutralInstructionStep(number: Int, text: String) -> some View {
-    HStack(alignment: .top, spacing: 12) {
-        Text("\(number)")
-            .scaledFont(size: 12, weight: .bold)
-            .foregroundColor(OmiColors.textPrimary)
-            .frame(width: 22, height: 22)
-            .background(Circle().fill(OmiColors.backgroundTertiary))
-
-        Text(text)
-            .scaledFont(size: 13)
-            .foregroundColor(OmiColors.textSecondary)
-    }
+    instructionStep(
+        number: number, text: text,
+        numberColor: OmiColors.textPrimary,
+        circleFill: OmiColors.backgroundTertiary)
 }
 
 #if canImport(PreviewsMacros)

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/PermissionsPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/PermissionsPage.swift
@@ -1120,10 +1120,12 @@ private func statusBadge(isGranted: Bool) -> some View {
     )
 }
 
+/// Numbered how-to row. Neutral styling by default — purple is off-brand
+/// (repo UI rule: never use purple anywhere).
 private func instructionStep(
     number: Int, text: String,
-    numberColor: Color = .white,
-    circleFill: Color = OmiColors.purplePrimary
+    numberColor: Color = OmiColors.textPrimary,
+    circleFill: Color = OmiColors.backgroundTertiary
 ) -> some View {
     HStack(alignment: .top, spacing: 12) {
         Text("\(number)")
@@ -1138,12 +1140,9 @@ private func instructionStep(
     }
 }
 
-/// Neutral (non-purple) variant used by the System Audio section.
+/// Kept as an alias for the System Audio section (now identical to the default).
 private func neutralInstructionStep(number: Int, text: String) -> some View {
-    instructionStep(
-        number: number, text: text,
-        numberColor: OmiColors.textPrimary,
-        circleFill: OmiColors.backgroundTertiary)
+    instructionStep(number: number, text: text)
 }
 
 #if canImport(PreviewsMacros)

--- a/desktop/macos/Desktop/Tests/FailLoudConfigTests.swift
+++ b/desktop/macos/Desktop/Tests/FailLoudConfigTests.swift
@@ -110,6 +110,37 @@ final class FailLoudConfigTests: XCTestCase {
     XCTAssertTrue(src.contains("appState.triggerSystemAudioPermission()"))
   }
 
+  @MainActor
+  func testSystemAudioOutcomeMappingAndIdleDowngrade() {
+    // Behavioral contract (BL-047): status follows OBSERVED tap outcomes and
+    // never claims granted while idle.
+    let state = AppState()
+    state.recordSystemAudioCaptureOutcome(.granted)
+    XCTAssertEqual(state.systemAudioPermissionStatus, .granted)
+    XCTAssertTrue(state.hasSystemAudioPermission)
+
+    state.recordSystemAudioCaptureOutcome(.denied)
+    XCTAssertEqual(state.systemAudioPermissionStatus, .denied)
+    XCTAssertFalse(state.hasSystemAudioPermission)
+
+    // A stale granted (no live capture) must downgrade to unknown on re-check,
+    // never persist as granted — and idle unknown must not count as a missing
+    // permission (it would permanently suppress the all-granted banner).
+    state.recordSystemAudioCaptureOutcome(.granted)
+    state.checkSystemAudioPermission()
+    XCTAssertEqual(state.systemAudioPermissionStatus, .unknown)
+    XCTAssertFalse(state.hasSystemAudioPermission)
+    XCTAssertFalse(state.missingPermissions.contains("System Audio"))
+
+    // A proven denial DOES count as missing, and persists through re-checks
+    // (denial was observed; only stale grants decay).
+    state.recordSystemAudioCaptureOutcome(.denied)
+    XCTAssertTrue(state.missingPermissions.contains("System Audio"))
+    state.checkSystemAudioPermission()
+    XCTAssertEqual(state.systemAudioPermissionStatus, .denied)
+    XCTAssertTrue(state.missingPermissions.contains("System Audio"))
+  }
+
   func testProductionAuthTokensUseKeychainStorage() throws {
     let src = try source(relativePath: "Sources/AuthService.swift")
 

--- a/desktop/macos/Desktop/Tests/FailLoudConfigTests.swift
+++ b/desktop/macos/Desktop/Tests/FailLoudConfigTests.swift
@@ -47,28 +47,67 @@ final class FailLoudConfigTests: XCTestCase {
     XCTAssertTrue(src.contains("signInWithIdp?key=\\(apiKey)"))
   }
 
-  // MARK: BL-020 — checkSystemAudioPermission() must report the real state
+  // MARK: BL-047 — system audio permission truth
 
-  /// The check is no longer a no-op: it must derive `hasSystemAudioPermission`
-  /// from the real screen-recording TCC preflight the rest of the app uses,
-  /// mirroring `checkScreenRecordingPermission()`.
-  func testCheckSystemAudioPermissionReadsRealTccState() throws {
+  /// Core Audio process taps do not expose a preflight API. The app must not
+  /// proxy this through Screen Recording; it reports the last real tap outcome.
+  func testCheckSystemAudioPermissionUsesObservedTapOutcome() throws {
     let src = try source(relativePath: "Sources/AppState/AppState+SystemActions.swift")
 
     guard let range = src.range(of: "func checkSystemAudioPermission() {") else {
       return XCTFail("checkSystemAudioPermission not found")
     }
-    let body = String(src[range.lowerBound...].prefix(600))
+    let body = String(src[range.lowerBound...].prefix(900))
 
     XCTAssertFalse(
       body.contains("No-op"),
       "checkSystemAudioPermission must no longer be a no-op")
-    XCTAssertTrue(
-      body.contains("hasSystemAudioPermission ="),
-      "it must actually assign the reported permission state")
-    XCTAssertTrue(
+    XCTAssertFalse(
       body.contains("ScreenCaptureService.checkPermission()"),
-      "it must query the real TCC preflight the rest of the app relies on")
+      "system audio permission must not be proxied from Screen Recording TCC")
+    XCTAssertTrue(
+      src.contains("func recordSystemAudioCaptureOutcome(_ status: SystemAudioPermissionStatus)"),
+      "tap outcomes should be recorded through a single AppState helper")
+    XCTAssertTrue(
+      body.contains("recordSystemAudioCaptureOutcome(.unsupported)"),
+      "unsupported OS should be explicitly represented")
+    XCTAssertTrue(
+      body.contains("service.capturing"),
+      "active system audio capture should preserve a granted state")
+    XCTAssertTrue(
+      body.contains("recordSystemAudioCaptureOutcome(.unknown)"),
+      "refreshes without an active tap must not keep stale granted state")
+  }
+
+  func testSystemAudioCaptureOutcomesUpdatePermissionState() throws {
+    let src = try source(relativePath: "Sources/AppState/AppState+Transcription.swift")
+
+    XCTAssertTrue(
+      src.contains("recordSystemAudioCaptureOutcome(.granted)"),
+      "successful system-audio tap starts must mark the permission granted")
+    XCTAssertTrue(
+      src.contains("recordSystemAudioCaptureOutcome(.denied)"),
+      "failed system-audio tap starts must mark the permission denied")
+  }
+
+  func testAudioSourceManagerSystemAudioOutcomesUpdatePermissionState() throws {
+    let src = try source(relativePath: "Sources/Audio/AudioSourceManager.swift")
+
+    XCTAssertTrue(
+      src.contains("AppState.current?.recordSystemAudioCaptureOutcome(.granted)"),
+      "desktop audio-source system audio starts should mark the state granted")
+    XCTAssertTrue(
+      src.contains("AppState.current?.recordSystemAudioCaptureOutcome(.denied)"),
+      "desktop audio-source system audio failures should mark the state denied")
+  }
+
+  func testPermissionsPageSurfacesSystemAudioRow() throws {
+    let src = try source(relativePath: "Sources/MainWindow/Pages/PermissionsPage.swift")
+
+    XCTAssertTrue(src.contains("SystemAudioPermissionSection(appState: appState)"))
+    XCTAssertTrue(src.contains("Text(\"System Audio\")"))
+    XCTAssertTrue(src.contains("appState.systemAudioPermissionStatus"))
+    XCTAssertTrue(src.contains("appState.triggerSystemAudioPermission()"))
   }
 
   func testProductionAuthTokensUseKeychainStorage() throws {

--- a/desktop/macos/Desktop/Tests/FailLoudConfigTests.swift
+++ b/desktop/macos/Desktop/Tests/FailLoudConfigTests.swift
@@ -86,8 +86,8 @@ final class FailLoudConfigTests: XCTestCase {
       src.contains("recordSystemAudioCaptureOutcome(.granted)"),
       "successful system-audio tap starts must mark the permission granted")
     XCTAssertTrue(
-      src.contains("recordSystemAudioCaptureOutcome(.denied)"),
-      "failed system-audio tap starts must mark the permission denied")
+      src.contains("recordSystemAudioCaptureOutcome(SystemAudioPermissionStatus.classify(captureError: error))"),
+      "failed system-audio tap starts must record the CLASSIFIED outcome (denial only for permission-class errors)")
   }
 
   func testAudioSourceManagerSystemAudioOutcomesUpdatePermissionState() throws {
@@ -97,8 +97,11 @@ final class FailLoudConfigTests: XCTestCase {
       src.contains("AppState.current?.recordSystemAudioCaptureOutcome(.granted)"),
       "desktop audio-source system audio starts should mark the state granted")
     XCTAssertTrue(
-      src.contains("AppState.current?.recordSystemAudioCaptureOutcome(.denied)"),
-      "desktop audio-source system audio failures should mark the state denied")
+      src.contains("SystemAudioPermissionStatus.classify(captureError: error)"),
+      "desktop audio-source system audio failures should record the CLASSIFIED outcome")
+    XCTAssertFalse(
+      src.contains("throw error"),
+      "a system-audio tap failure must not abort the already-running mic/mixer stream")
   }
 
   func testPermissionsPageSurfacesSystemAudioRow() throws {
@@ -139,6 +142,35 @@ final class FailLoudConfigTests: XCTestCase {
     state.checkSystemAudioPermission()
     XCTAssertEqual(state.systemAudioPermissionStatus, .denied)
     XCTAssertTrue(state.missingPermissions.contains("System Audio"))
+  }
+
+  @available(macOS 14.4, *)
+  func testSystemAudioCaptureErrorClassification() {
+    // A TCC denial manifests as tap-creation/device-start failure; format and
+    // converter errors are provably NOT permission problems and must not claim
+    // a denial (they map to unknown so the row stays honest).
+    XCTAssertEqual(
+      SystemAudioPermissionStatus.classify(
+        captureError: SystemAudioCaptureService.SystemAudioCaptureError.tapCreationFailed(-1)),
+      .denied)
+    XCTAssertEqual(
+      SystemAudioPermissionStatus.classify(
+        captureError: SystemAudioCaptureService.SystemAudioCaptureError.deviceStartFailed(-1)),
+      .denied)
+    XCTAssertEqual(
+      SystemAudioPermissionStatus.classify(
+        captureError: SystemAudioCaptureService.SystemAudioCaptureError.formatError),
+      .unknown)
+    XCTAssertEqual(
+      SystemAudioPermissionStatus.classify(
+        captureError: SystemAudioCaptureService.SystemAudioCaptureError.converterCreationFailed),
+      .unknown)
+    XCTAssertEqual(
+      SystemAudioPermissionStatus.classify(
+        captureError: SystemAudioCaptureService.SystemAudioCaptureError.unsupportedOS),
+      .unsupported)
+    struct OtherError: Error {}
+    XCTAssertEqual(SystemAudioPermissionStatus.classify(captureError: OtherError()), .unknown)
   }
 
   func testProductionAuthTokensUseKeychainStorage() throws {

--- a/desktop/macos/changelog/unreleased/20260707-system-audio-permission-row.json
+++ b/desktop/macos/changelog/unreleased/20260707-system-audio-permission-row.json
@@ -1,0 +1,3 @@
+{
+  "change": "Added a System Audio permission status row that can test and reflect whether Omi can capture audio from other apps"
+}

--- a/desktop/macos/e2e/flows/audio-recording.yaml
+++ b/desktop/macos/e2e/flows/audio-recording.yaml
@@ -6,6 +6,7 @@ app: com.omi.computer-macos
 covers:
   - desktop/Desktop/Sources/MainWindow/Pages/ConversationsPage.swift
   - desktop/Desktop/Sources/AudioCaptureService.swift
+  - desktop/Desktop/Sources/Audio/AudioSourceManager.swift
   - desktop/Desktop/Sources/AppState.swift
 preconditions:
   - auth_ready

--- a/desktop/macos/e2e/flows/screen-recording-permission.yaml
+++ b/desktop/macos/e2e/flows/screen-recording-permission.yaml
@@ -7,6 +7,8 @@ covers:
   - desktop/Desktop/Sources/Rewind/UI/RewindPage.swift
   - desktop/Desktop/Sources/ScreenCaptureService.swift
   - desktop/Desktop/Sources/MainWindow/Pages/PermissionsPage.swift
+  - desktop/Desktop/Sources/AppState/AppState+SystemActions.swift
+  - desktop/Desktop/Sources/AppState/AppState+TrialPaywall.swift
 preconditions:
   - auth_ready
 


### PR DESCRIPTION
## Problem (runtime-verified)

macOS granted and later revoked `kTCCServiceAudioCapture` for a test bundle, and Omi successfully captured system audio while granted — but the app's Permissions screen never showed a system-audio-specific status and did not reflect the revoke. Three root causes:

1. `checkSystemAudioPermission()` proxied the **Screen Recording** TCC (`ScreenCaptureService.checkPermission()`) — system-audio capture is a CoreAudio **process tap** (`kTCCServiceAudioCapture`, macOS 14.4+), a different permission with **no preflight API**.
2. No UI row consumed `hasSystemAudioPermission` — the Permissions page rendered only Microphone / Screen Recording / Notifications.
3. Nothing refreshed on TCC change.

## Fix — truthful tri-state from observed tap outcomes

- `systemAudioPermissionStatus` (unknown / granted / denied / unsupported) is derived from **real capture outcomes**: every genuine tap start success/failure reports via `recordSystemAudioCaptureOutcome`, and the existing test-tap acts as an on-demand "Test". With no preflight API, "last observed tap outcome, else unknown" is the honest primitive — a stale granted decays to unknown on re-check rather than claiming a grant it can't prove.
- New **System Audio** row on the Permissions page (macOS 14.4+ only), mirroring the existing row pattern, with a Test button and helper copy pointing at Privacy & Security → Screen & System Audio Recording.
- The screen-recording proxy is gone.
- Review follow-up included: only a **proven denial** counts toward `missingPermissions` — the idle `unknown` must not permanently suppress the "All permissions granted" banner for default users (system audio is optional/best-effort).

## Verification

- Build green on current `main`; `FailLoudConfigTests` **10/10**, including a new behavioral test of the outcome→state contract (granted/denied mapping, stale-granted decay, denial persistence, missing-permissions gating) plus source guards that the proxy cannot silently return.
- Independent review: design confirmed (real outcomes, honest unknown, MainActor-safe reporting); its one leaning-blocker (banner regression via `.unknown`) and test-quality gap are fixed in the second commit.
- Runtime grant/revoke re-verification on a named bundle is deliberately left to the post-merge verification lane (the acceptance row stays FAIL until that re-run passes).

Changelog fragment included (user-visible Permissions row).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9244?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

