### PR TITLE
fix(desktop/chat): isolate floating-bar and main-chat transcripts

### DIFF
--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
@@ -2485,7 +2485,7 @@ class FloatingControlBarManager {
         guard let provider = sharedFloatingProvider else {
             return ["error": "floating chat provider unavailable"]
         }
-        return provider.automationMainChatSnapshot(limit: limit)
+        return provider.automationFloatingChatSnapshot(limit: limit)
     }
 
     func seedSubagentsForAutomation(count: Int) async -> [String: String] {

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/ChatPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/ChatPage.swift
@@ -5,6 +5,12 @@ import OmiTheme
 struct ChatPage: View {
   @ObservedObject var appProvider: AppProvider
   @ObservedObject var chatProvider: ChatProvider
+
+  /// CHAT-06: the main-surface transcript (floating-bar turns filtered out).
+  /// Single accessor so the filter expression isn't repeated at every use site.
+  private var mainTranscript: [ChatMessage] {
+    ChatTurnOwner.transcriptMessages(chatProvider.messages, floatingSurface: false)
+  }
   @State private var showAppPicker = false
   @State private var showHistoryPopover = false
   @State private var selectedCitation: Citation?
@@ -296,7 +302,7 @@ struct ChatPage: View {
         .omiControlSurface(fill: OmiColors.backgroundTertiary.opacity(0.9), radius: 12)
 
       // Copy conversation button
-      if !chatProvider.messages.isEmpty {
+      if !mainTranscript.isEmpty {
         Button(action: {
           copyConversation()
         }) {
@@ -309,7 +315,7 @@ struct ChatPage: View {
       }
 
       // Clear chat button
-      if !chatProvider.messages.isEmpty || chatProvider.isClearing {
+      if !mainTranscript.isEmpty || chatProvider.isClearing {
         Button(action: {
           Task {
             await chatProvider.clearChat()
@@ -364,7 +370,7 @@ struct ChatPage: View {
 
   private var messagesView: some View {
     ChatMessagesView(
-      messages: chatProvider.messages,
+      messages: mainTranscript,
       isSending: chatProvider.isSending,
       hasMoreMessages: chatProvider.hasMoreMessages,
       isLoadingMoreMessages: chatProvider.isLoadingMoreMessages,
@@ -473,7 +479,7 @@ struct ChatPage: View {
 
   /// Copy the entire conversation to clipboard
   private func copyConversation() {
-    let text: String = chatProvider.messages.map { message in
+    let text: String = mainTranscript.map { message in
       let sender = message.sender == .user ? "You" : (selectedApp?.name ?? "omi")
       return "\(sender): \(message.text)"
     }.joined(separator: "\n\n")

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
@@ -493,7 +493,7 @@ struct DashboardPage: View {
             dashboardWidgets
 
             ChatMessagesView(
-                messages: chatProvider.messages,
+                messages: ChatTurnOwner.transcriptMessages(chatProvider.messages, floatingSurface: false),
                 isSending: chatProvider.isSending,
                 hasMoreMessages: chatProvider.hasMoreMessages,
                 isLoadingMoreMessages: chatProvider.isLoadingMoreMessages,
@@ -725,7 +725,7 @@ struct DashboardPage: View {
     private var homeChatPanel: some View {
         VStack(spacing: 0) {
             ChatMessagesView(
-                messages: chatProvider.messages,
+                messages: ChatTurnOwner.transcriptMessages(chatProvider.messages, floatingSurface: false),
                 isSending: chatProvider.isSending,
                 hasMoreMessages: chatProvider.hasMoreMessages,
                 isLoadingMoreMessages: chatProvider.isLoadingMoreMessages,

--- a/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
@@ -504,8 +504,13 @@ struct ChatMessage: Identifiable {
     /// `attachments` for backwards compatibility.
     var resources: [ChatResource]
 
-    init(id: String = UUID().uuidString, clientTurnId: String? = nil, text: String, createdAt: Date = Date(), sender: ChatSender, isStreaming: Bool = false, rating: Int? = nil, isSynced: Bool = false, citations: [Citation] = [], contentBlocks: [ChatContentBlock] = [], metadata: MessageMetadata? = nil, notificationContext: String? = nil, notificationScreenshot: Data? = nil, attachments: [ChatAttachment] = [], resources: [ChatResource] = []) {
+    /// CHAT-06: which surface produced this turn. nil (history/restored rows)
+    /// renders as main chat.
+    var turnOwner: ChatTurnOwner?
+
+    init(id: String = UUID().uuidString, clientTurnId: String? = nil, text: String, createdAt: Date = Date(), sender: ChatSender, isStreaming: Bool = false, rating: Int? = nil, isSynced: Bool = false, citations: [Citation] = [], contentBlocks: [ChatContentBlock] = [], metadata: MessageMetadata? = nil, notificationContext: String? = nil, notificationScreenshot: Data? = nil, attachments: [ChatAttachment] = [], resources: [ChatResource] = [], turnOwner: ChatTurnOwner? = nil) {
         self.id = id
+        self.turnOwner = turnOwner
         self.clientTurnId = clientTurnId
         self.text = text
         self.createdAt = createdAt
@@ -572,6 +577,23 @@ enum ChatTurnOwner: Equatable {
     case floatingVoice
     case taskChat(String)
     case agentPill(UUID)
+
+    /// CHAT-06: turns owned by a floating-bar surface must not appear in the
+    /// main-chat transcript (and vice versa). taskChat/agentPill turns are NOT
+    /// floating-bar surfaces — they keep rendering with the main transcript
+    /// (pre-fix behavior) if they ever share this provider.
+    var isFloating: Bool {
+        switch self {
+        case .floatingDefault, .floatingVoice: return true
+        case .mainChat, .taskChat, .agentPill: return false
+        }
+    }
+
+    /// Pure per-surface transcript filter (unit-tested): nil owners are legacy/
+    /// restored history and belong to the main surface.
+    static func transcriptMessages(_ messages: [ChatMessage], floatingSurface: Bool) -> [ChatMessage] {
+        messages.filter { ($0.turnOwner?.isFloating ?? false) == floatingSurface }
+    }
 
     func canInterrupt(_ activeOwner: ChatTurnOwner) -> Bool {
         switch (self, activeOwner) {
@@ -2754,13 +2776,16 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
         guard !trimmedText.isEmpty || !resources.isEmpty else { return nil }
 
         let messageText = trimmedText.isEmpty ? "Done." : trimmedText
+        // Proactive notifications and agent-pill summaries are main-destined by
+        // design (projected into kernel main_chat for cross-surface continuity).
         let aiMessage = ChatMessage(
             clientTurnId: clientTurnId,
             text: messageText,
             sender: .ai,
             notificationContext: notificationContext,
             notificationScreenshot: notificationScreenshot,
-            resources: resources
+            resources: resources,
+            turnOwner: .mainChat
         )
         let localId = aiMessage.id
         let capturedSessionId = isInDefaultChat ? nil : currentSessionId
@@ -3258,7 +3283,8 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
             clientTurnId: clientTurnId,
             text: trimmedText,
             sender: .user,
-            attachments: attachmentsForMessage
+            attachments: attachmentsForMessage,
+            turnOwner: turnOwner
         )
         messages.append(userMessage)
         // Signal to ChatMessagesView after the local user row exists so
@@ -3290,7 +3316,8 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
             clientTurnId: clientTurnId,
             text: "",
             sender: .ai,
-            isStreaming: true
+            isStreaming: true,
+            turnOwner: turnOwner
         )
         messages.append(aiMessage)
 
@@ -4463,7 +4490,9 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
             // Default chat mode: clear UI immediately, delete in background
             let runtimeChatId = mainChatRuntimeChatId(sessionId: nil)
             let surface = AgentSurfaceReference.mainChat(chatId: runtimeChatId)
-            messages = []
+            // CHAT-06: clearing the MAIN transcript must not wipe the floating
+            // bar's turns, which live in the same shared array.
+            messages = ChatTurnOwner.transcriptMessages(messages, floatingSurface: true)
             resetMessagesPagination()
             AgentRuntimeStatusStore.shared.clear(surface: surface)
             await invalidateAgentSurface(surface: surface)
@@ -4489,7 +4518,9 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
                 sessions.removeAll { $0.id == session.id }
             }
             currentSession = nil
-            messages = []
+            // CHAT-06: clearing the MAIN transcript must not wipe the floating
+            // bar's turns, which live in the same shared array.
+            messages = ChatTurnOwner.transcriptMessages(messages, floatingSurface: true)
             resetMessagesPagination()
 
             // Delete old session in background (don't await — backend is slow)
@@ -4689,9 +4720,20 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
 
     /// Snapshot for `main_chat_snapshot` / `wait_main_chat_idle` harness actions.
     func automationMainChatSnapshot(limit: Int) -> [String: String] {
+        automationChatSnapshot(limit: limit, floatingSurface: false)
+    }
+
+    /// CHAT-06: floating-bar transcript view — only turns owned by a floating
+    /// surface, so the harness can assert cross-surface isolation.
+    func automationFloatingChatSnapshot(limit: Int) -> [String: String] {
+        automationChatSnapshot(limit: limit, floatingSurface: true)
+    }
+
+    private func automationChatSnapshot(limit: Int, floatingSurface: Bool) -> [String: String] {
         let boundedLimit = max(1, limit)
         let runtimeChatId = mainChatRuntimeChatId(sessionId: currentSessionId)
-        let rows: [[String: String]] = messages.suffix(boundedLimit).map { message in
+        let transcript = ChatTurnOwner.transcriptMessages(messages, floatingSurface: floatingSurface)
+        let rows: [[String: String]] = transcript.suffix(boundedLimit).map { message in
             [
                 "id": message.id,
                 "role": message.sender == .user ? "user" : "assistant",
@@ -4711,11 +4753,11 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
             "chat_session_id": currentSessionId ?? "",
             "runtime_chat_id": runtimeChatId,
             "is_sending": isSending ? "true" : "false",
-            "is_streaming": messages.contains(where: { $0.isStreaming }) ? "true" : "false",
-            "message_count": "\(messages.count)",
+            "is_streaming": transcript.contains(where: { $0.isStreaming }) ? "true" : "false",
+            "message_count": "\(transcript.count)",
             "messages_json": messagesJSON,
         ]
-        if let lastAssistant = messages.last(where: { $0.sender != .user })?.copyableText {
+        if let lastAssistant = transcript.last(where: { $0.sender != .user })?.copyableText {
             detail["last_assistant_text"] = lastAssistant
         }
         if let ownerId = runtimeOwnerId {

--- a/desktop/macos/Desktop/Tests/ChatTranscriptIsolationTests.swift
+++ b/desktop/macos/Desktop/Tests/ChatTranscriptIsolationTests.swift
@@ -1,0 +1,127 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// CHAT-06: floating-bar and main-chat share one ChatProvider by design (turn
+/// interruption needs a single streaming pipeline), but their TRANSCRIPTS must
+/// not co-mingle. Turns are stamped with a `ChatTurnOwner` at append and every
+/// surface (main render, main snapshot, floating snapshot) filters through
+/// `ChatTurnOwner.transcriptMessages`.
+final class ChatTranscriptIsolationTests: XCTestCase {
+
+  private func msg(_ text: String, sender: ChatSender, owner: ChatTurnOwner?) -> ChatMessage {
+    ChatMessage(text: text, sender: sender, turnOwner: owner)
+  }
+
+  func testMainSurfaceExcludesFloatingTurns() {
+    let mixed = [
+      msg("m1", sender: .user, owner: .mainChat),
+      msg("f1", sender: .user, owner: .floatingDefault),
+      msg("f1r", sender: .ai, owner: .floatingDefault),
+      msg("m1r", sender: .ai, owner: .mainChat),
+      msg("v1", sender: .user, owner: .floatingVoice),
+    ]
+    let main = ChatTurnOwner.transcriptMessages(mixed, floatingSurface: false)
+    XCTAssertEqual(main.map(\.text), ["m1", "m1r"])
+  }
+
+  func testFloatingSurfaceExcludesMainTurns() {
+    let mixed = [
+      msg("m1", sender: .user, owner: .mainChat),
+      msg("f1", sender: .user, owner: .floatingDefault),
+      msg("v1", sender: .user, owner: .floatingVoice),
+      msg("m2", sender: .user, owner: .mainChat),
+    ]
+    let floating = ChatTurnOwner.transcriptMessages(mixed, floatingSurface: true)
+    XCTAssertEqual(floating.map(\.text), ["f1", "v1"])
+  }
+
+  func testNilOwnerIsLegacyHistoryAndBelongsToMain() {
+    // Restored/backend-loaded rows carry no owner — they must keep appearing in
+    // the main transcript (pre-fix behavior) and never in the floating one.
+    let mixed = [
+      msg("legacy", sender: .ai, owner: nil),
+      msg("f1", sender: .user, owner: .floatingDefault),
+    ]
+    XCTAssertEqual(ChatTurnOwner.transcriptMessages(mixed, floatingSurface: false).map(\.text), ["legacy"])
+    XCTAssertEqual(ChatTurnOwner.transcriptMessages(mixed, floatingSurface: true).map(\.text), ["f1"])
+  }
+
+  func testOrderPreservedWithinSurface() {
+    let mixed = (0..<10).map { i in
+      msg("t\(i)", sender: .user, owner: i % 2 == 0 ? .mainChat : .floatingDefault)
+    }
+    let main = ChatTurnOwner.transcriptMessages(mixed, floatingSurface: false).map(\.text)
+    XCTAssertEqual(main, ["t0", "t2", "t4", "t6", "t8"])
+  }
+
+  func testOwnerFloatingClassification() {
+    XCTAssertFalse(ChatTurnOwner.mainChat.isFloating)
+    XCTAssertTrue(ChatTurnOwner.floatingDefault.isFloating)
+    XCTAssertTrue(ChatTurnOwner.floatingVoice.isFloating)
+    // taskChat/agentPill are NOT floating-bar surfaces — they must keep
+    // rendering with the main transcript if they ever share this provider.
+    XCTAssertFalse(ChatTurnOwner.taskChat("t1").isFloating)
+    XCTAssertFalse(ChatTurnOwner.agentPill(UUID()).isFloating)
+  }
+
+  func testClearingMainRetainsFloatingTurns() {
+    // clearChat semantics: wiping the MAIN transcript keeps floating turns
+    // (same array, different surface).
+    let mixed = [
+      msg("m1", sender: .user, owner: .mainChat),
+      msg("f1", sender: .user, owner: .floatingDefault),
+      msg("legacy", sender: .ai, owner: nil),
+    ]
+    let retained = ChatTurnOwner.transcriptMessages(mixed, floatingSurface: true)
+    XCTAssertEqual(retained.map(\.text), ["f1"])
+  }
+
+  func testSendPathsStampTurnOwner() throws {
+    // Source invariant: the four live-turn ChatMessage constructions in the
+    // send paths carry a turnOwner stamp, and the floating snapshot no longer
+    // delegates to the unfiltered main snapshot.
+    let root = URL(fileURLWithPath: #filePath)
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+    let provider = try String(
+      contentsOf: root.appendingPathComponent("Sources/Providers/ChatProvider.swift"),
+      encoding: .utf8)
+    // Wiring invariants (kept identifier-loose: pre-existing context structs
+    // also pass turnOwner, so we assert the *filtered surfaces*, and that the
+    // live ChatMessage constructions stamp an owner at all).
+    XCTAssertGreaterThanOrEqual(
+      provider.components(separatedBy: "turnOwner: turnOwner").count - 1, 2,
+      "sendMessage must stamp its user and ai messages (follow-ups ride the same path post-#9231)")
+    XCTAssertTrue(
+      provider.contains("automationChatSnapshot(limit: limit, floatingSurface:"),
+      "snapshots must run through the surface-filtered core")
+    let chatPage = try String(
+      contentsOf: root.appendingPathComponent("Sources/MainWindow/Pages/ChatPage.swift"),
+      encoding: .utf8)
+    XCTAssertTrue(
+      chatPage.contains("ChatTurnOwner.transcriptMessages(chatProvider.messages, floatingSurface: false)"),
+      "main chat must derive its transcript through the surface filter")
+    XCTAssertTrue(
+      chatPage.contains("messages: mainTranscript,"),
+      "main chat must render the filtered transcript, not the raw shared array")
+    let dashboard = try String(
+      contentsOf: root.appendingPathComponent("Sources/MainWindow/Pages/DashboardPage.swift"),
+      encoding: .utf8)
+    XCTAssertEqual(
+      dashboard.components(
+        separatedBy: "messages: ChatTurnOwner.transcriptMessages(chatProvider.messages, floatingSurface: false)"
+      ).count - 1, 2,
+      "both dashboard home-chat surfaces (legacyHome + homeChatPanel) must render filtered")
+    XCTAssertFalse(
+      dashboard.contains("messages: chatProvider.messages,"),
+      "no dashboard chat surface may render the raw shared array")
+    let floating = try String(
+      contentsOf: root.appendingPathComponent("Sources/FloatingControlBar/FloatingControlBarWindow.swift"),
+      encoding: .utf8)
+    XCTAssertTrue(floating.contains("automationFloatingChatSnapshot(limit:"))
+    XCTAssertFalse(
+      floating.contains("return provider.automationMainChatSnapshot"),
+      "floating snapshot must not delegate to the unfiltered main snapshot")
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260707-floating-main-chat-isolation.json
+++ b/desktop/macos/changelog/unreleased/20260707-floating-main-chat-isolation.json
@@ -1,0 +1,3 @@
+{
+  "change": "Questions asked from the floating bar no longer mix into the main chat transcript during a session (restored history from before the app relaunches still shows in the main chat)"
+}


### PR DESCRIPTION
## Problem (runtime-verified)

The floating bar and main chat deliberately share one `ChatProvider` (a single streaming pipeline with `ChatTurnOwner`-based interruption) — but the shared `messages` array co-mingled the **transcripts**: a question asked from the floating bar appeared in the main chat (and dashboard home chat) transcript, and the bridge's `floating_bar_chat_snapshot` literally delegated to `automationMainChatSnapshot`, making cross-surface isolation unobservable. Runtime verification captured both snapshots containing the same floating turn.

## Fix — stamp turns with their owning surface, filter per surface

- `ChatMessage` gains an optional `turnOwner` (`nil` = restored/legacy history → renders as main chat; the defaulted init parameter keeps every existing constructor working).
- The live send paths stamp it: `sendMessage` (user + ai, via its existing `turnOwner` parameter), `sendFollowUp` (user, inheriting the active turn's owner per the chaining model), `appendAssistantMessage` (active turn's owner — its proactive-notification/agent-pill callers are deliberately main-destined).
- `ChatTurnOwner.transcriptMessages(_:floatingSurface:)` is the single pure, unit-tested filter, consumed by **every transcript surface**: main ChatPage (render, copy-all, button gates), both Dashboard home-chat surfaces (`legacyHome` + `homeChatPanel`), `automationMainChatSnapshot`, and the new `automationFloatingChatSnapshot` (the bridge action no longer delegates to the unfiltered main snapshot).
- Floating streaming pickers already key on `clientTurnId` — untouched.
- Persistence note: owners are in-memory; restored history renders as main chat, matching pre-fix behavior after relaunch.

## Verification

- Build green on current `main`; new `ChatTranscriptIsolationTests` **6/6** — per-surface filtering, nil-owner legacy classification, order preservation, owner classification, and wiring invariants (surface-filtered snapshot core; filtered ChatPage + both Dashboard render sites; no raw-array render remains).
- Independent review: mechanism confirmed sound; its blocker (Dashboard home chat still rendering the raw array — the exact leak, on the surface the first pass missed) and test-coverage gap are fixed and the wiring test now fails if any dashboard surface renders unfiltered. Cleared explicitly: `showSharedProviderBusy` writes only to window state (not the transcript); interactive floating answers stamp at creation, so the end-of-turn `activeTurnOwner` clear cannot leak a floating answer to main.
- Runtime re-run of the isolation probe (floating marker absent from main snapshot and vice versa) is left to the post-merge verification lane; the acceptance row stays FAIL until it passes.

Changelog fragment included (user-visible behavior change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9245?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

