### PR TITLE
test(desktop): add agent stress diagnostics and resilience gauntlet

### DIFF
--- a/desktop/macos/Desktop/Sources/Diagnostics/DesktopStressDiagnostics.swift
+++ b/desktop/macos/Desktop/Sources/Diagnostics/DesktopStressDiagnostics.swift
@@ -19,13 +19,20 @@ enum DesktopStressTerminalReason: String, CaseIterable, Codable {
   case providerFallback = "provider_fallback"
   case bridgeLaunchFailure = "bridge_launch_failure"
   case responseAlreadyRunning = "response_already_running"
+  case voiceOutputOverlap = "voice_output_overlap"
+  case realtimeNoResponseTimeout = "realtime_no_response_timeout"
+  case deferredCommitTimeout = "deferred_commit_timeout"
+  case bargeInReplacementTimeout = "barge_in_replacement_timeout"
+  case staleProviderAudioAfterInterrupt = "stale_provider_audio_after_interrupt"
 
   var isReleaseGateFailure: Bool {
     switch self {
     case .pttVoicedSuccess, .pttSilentRejected, .chatBridgeSuccess, .subagentLaunchSuccess, .providerFallback:
       return false
     case .tooShortTap, .audioFramesMissing, .silentAudio, .realtimeTokenMintFailure,
-      .bridgeLaunchFailure, .responseAlreadyRunning:
+      .bridgeLaunchFailure, .responseAlreadyRunning, .voiceOutputOverlap,
+      .realtimeNoResponseTimeout, .deferredCommitTimeout, .bargeInReplacementTimeout,
+      .staleProviderAudioAfterInterrupt:
       return true
     }
   }

--- a/desktop/macos/Desktop/Sources/Diagnostics/DesktopStressDiagnostics.swift
+++ b/desktop/macos/Desktop/Sources/Diagnostics/DesktopStressDiagnostics.swift
@@ -1,0 +1,116 @@
+import Foundation
+
+enum DesktopStressScenario: String, CaseIterable, Codable {
+  case pttVoiced = "ptt_voiced"
+  case pttSilent = "ptt_silent"
+  case chatBridge = "chat_bridge"
+  case subagentLaunch = "subagent_launch"
+}
+
+enum DesktopStressTerminalReason: String, CaseIterable, Codable {
+  case pttVoicedSuccess = "ptt_voiced_success"
+  case pttSilentRejected = "ptt_silent_rejected"
+  case chatBridgeSuccess = "chat_bridge_success"
+  case subagentLaunchSuccess = "subagent_launch_success"
+  case tooShortTap = "too_short_tap"
+  case audioFramesMissing = "audio_frames_missing"
+  case silentAudio = "silent_audio"
+  case realtimeTokenMintFailure = "realtime_token_mint_failure"
+  case providerFallback = "provider_fallback"
+  case bridgeLaunchFailure = "bridge_launch_failure"
+  case responseAlreadyRunning = "response_already_running"
+
+  var isReleaseGateFailure: Bool {
+    switch self {
+    case .pttVoicedSuccess, .pttSilentRejected, .chatBridgeSuccess, .subagentLaunchSuccess, .providerFallback:
+      return false
+    case .tooShortTap, .audioFramesMissing, .silentAudio, .realtimeTokenMintFailure,
+      .bridgeLaunchFailure, .responseAlreadyRunning:
+      return true
+    }
+  }
+}
+
+struct DesktopStressDiagnosticEvent: Codable, Equatable {
+  let runID: String
+  let iteration: Int
+  let scenario: DesktopStressScenario
+  let terminalReason: DesktopStressTerminalReason
+  let timestamp: String
+  let durationMs: Int?
+  let details: [String: String]
+
+  enum CodingKeys: String, CodingKey {
+    case runID = "run_id"
+    case iteration
+    case scenario
+    case terminalReason = "terminal_reason"
+    case timestamp
+    case durationMs = "duration_ms"
+    case details
+  }
+
+  init(
+    runID: String,
+    iteration: Int,
+    scenario: DesktopStressScenario,
+    terminalReason: DesktopStressTerminalReason,
+    timestamp: String = DesktopStressDiagnosticEvent.currentTimestamp(),
+    durationMs: Int? = nil,
+    details: [String: String] = [:]
+  ) {
+    self.runID = runID
+    self.iteration = iteration
+    self.scenario = scenario
+    self.terminalReason = terminalReason
+    self.timestamp = timestamp
+    self.durationMs = durationMs
+    self.details = details
+  }
+
+  static func currentTimestamp() -> String {
+    ISO8601DateFormatter.desktopStressDiagnostics.string(from: Date())
+  }
+}
+
+struct DesktopStressRunSummary: Codable, Equatable {
+  let totalEvents: Int
+  let passedReleaseGate: Bool
+  let terminalReasonCounts: [String: Int]
+  let scenarioCounts: [String: Int]
+  let forbiddenTerminalReasons: [String]
+
+  enum CodingKeys: String, CodingKey {
+    case totalEvents = "total_events"
+    case passedReleaseGate = "passed_release_gate"
+    case terminalReasonCounts = "terminal_reason_counts"
+    case scenarioCounts = "scenario_counts"
+    case forbiddenTerminalReasons = "forbidden_terminal_reasons"
+  }
+
+  init(events: [DesktopStressDiagnosticEvent]) {
+    let terminalCounts = Dictionary(grouping: events, by: { $0.terminalReason.rawValue })
+      .mapValues { $0.count }
+    let scenarios = Dictionary(grouping: events, by: { $0.scenario.rawValue })
+      .mapValues { $0.count }
+    let forbidden = DesktopStressTerminalReason.allCases.filter {
+      ($0.isReleaseGateFailure) && (terminalCounts[$0.rawValue, default: 0] > 0)
+    }.map {
+      $0.rawValue
+    }
+
+    totalEvents = events.count
+    terminalReasonCounts = terminalCounts
+    scenarioCounts = scenarios
+    forbiddenTerminalReasons = forbidden
+    passedReleaseGate = !events.isEmpty && forbiddenTerminalReasons.isEmpty
+  }
+}
+
+private extension ISO8601DateFormatter {
+  static let desktopStressDiagnostics: ISO8601DateFormatter = {
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+    return formatter
+  }()
+}

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/PTTVoiceOutputCoordinator.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/PTTVoiceOutputCoordinator.swift
@@ -1,0 +1,89 @@
+import Foundation
+
+enum PTTVoiceOutputLane: String, Equatable, Sendable {
+  case nativeRealtime = "native_realtime"
+  case selectedVoiceFallback = "selected_voice_fallback"
+  case deterministicAgentAck = "deterministic_agent_ack"
+}
+
+struct PTTVoiceLease: Equatable, Sendable {
+  let id: UUID
+  let turnID: UUID
+  let lane: PTTVoiceOutputLane
+  let epoch: UInt64
+}
+
+enum PTTVoiceOutputDecision: Equatable, Sendable {
+  case acquired(PTTVoiceLease)
+  case denied(active: PTTVoiceLease)
+  case staleTurn
+}
+
+struct PTTVoiceOutputSnapshot: Equatable, Sendable {
+  let turnID: UUID?
+  let activeLease: PTTVoiceLease?
+  let providerOutputSuppressed: Bool
+}
+
+/// Small turn-scoped voice-output arbiter for PTT.
+///
+/// Realtime native PCM, selected voice fallback, and deterministic agent acks
+/// must not independently start audible output. This coordinator gives the
+/// current PTT turn exactly one audible lane at a time and makes late provider
+/// callbacks easy to reject by turn id.
+struct PTTVoiceOutputCoordinator {
+  private(set) var turnID: UUID?
+  private(set) var activeLease: PTTVoiceLease?
+  private(set) var providerOutputSuppressed = false
+  private var epoch: UInt64 = 0
+
+  mutating func beginTurn(id: UUID = UUID()) -> UUID {
+    turnID = id
+    activeLease = nil
+    providerOutputSuppressed = false
+    epoch &+= 1
+    return id
+  }
+
+  mutating func endTurn() {
+    turnID = nil
+    activeLease = nil
+    providerOutputSuppressed = false
+    epoch &+= 1
+  }
+
+  mutating func interruptCurrentOutput() {
+    activeLease = nil
+    providerOutputSuppressed = false
+    epoch &+= 1
+  }
+
+  mutating func acquire(_ lane: PTTVoiceOutputLane, turnID requestedTurnID: UUID) -> PTTVoiceOutputDecision {
+    guard requestedTurnID == turnID else { return .staleTurn }
+    if let activeLease {
+      if activeLease.turnID == requestedTurnID, activeLease.lane == lane {
+        return .acquired(activeLease)
+      }
+      return .denied(active: activeLease)
+    }
+    let lease = PTTVoiceLease(id: UUID(), turnID: requestedTurnID, lane: lane, epoch: epoch)
+    activeLease = lease
+    if lane == .deterministicAgentAck {
+      providerOutputSuppressed = true
+    }
+    return .acquired(lease)
+  }
+
+  mutating func release(_ lease: PTTVoiceLease) {
+    guard activeLease == lease else { return }
+    activeLease = nil
+    providerOutputSuppressed = false
+  }
+
+  func snapshot() -> PTTVoiceOutputSnapshot {
+    PTTVoiceOutputSnapshot(
+      turnID: turnID,
+      activeLease: activeLease,
+      providerOutputSuppressed: providerOutputSuppressed)
+  }
+}

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
@@ -546,6 +546,9 @@ class PushToTalkManager: ObservableObject {
   nonisolated private static let hubMaxSpeechZeroCrossingRate: Double = 0.24
   nonisolated private static let hubMinTurnAudioSeconds: Double = 0.35
   nonisolated private static let hubMinSpeechLikeSeconds: Double = 0.16
+  nonisolated private static let hubShortTurnMaxAudioSeconds: Double = 0.75
+  nonisolated private static let hubShortTurnMinSpeechLikeSeconds: Double = 0.22
+  nonisolated private static let hubShortTurnMinSpeechLikeRatio: Double = 0.45
 
   /// Returns (totalSeconds, voicedSeconds) for raw PCM16 mono 16kHz audio,
   /// where voiced = 20ms frames whose RMS exceeds `rmsThreshold`.
@@ -649,7 +652,16 @@ class PushToTalkManager: ObservableObject {
     // Speech-like energy gate FIRST: clear/audible speech must pass without
     // waiting on model inference, but broadband noise/clicks should not.
     let (total, speechLike) = speechLikeAudioSeconds(pcm16k: data)
-    if total >= hubMinTurnAudioSeconds && speechLike >= hubMinSpeechLikeSeconds { return true }
+    if total < hubShortTurnMaxAudioSeconds {
+      let coverage = total > 0 ? speechLike / total : 0
+      if speechLike >= hubShortTurnMinSpeechLikeSeconds
+        && coverage >= hubShortTurnMinSpeechLikeRatio
+      {
+        return true
+      }
+    } else if speechLike >= hubMinSpeechLikeSeconds {
+      return true
+    }
     // Softer speech that didn't clear the energy bar: a lenient Silero pass as a fallback
     // (only to catch quiet speech — it must never be the sole gate that drops loud speech).
     guard let vad = hubVAD, count >= 512 else { return false }
@@ -674,7 +686,11 @@ class PushToTalkManager: ObservableObject {
       }
       i += 512
     }
-    // ~96ms contiguous speech, or ~192ms total. Each Silero frame is 512 samples = 32ms.
+    // Each Silero frame is 512 samples = 32ms. Short turns need denser evidence so
+    // clicks, clipped starts, and half-syllables do not become realtime tool calls.
+    if total < hubShortTurnMaxAudioSeconds {
+      return maxRun >= 5 || speechFrames >= 8
+    }
     return maxRun >= 3 || speechFrames >= 6
   }
 

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
@@ -1419,6 +1419,18 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate {
     case .askHigherModel:
       let query = arg("query")
       let context = (arguments["context"] as? String) ?? ""
+      if RealtimeHubTools.shouldRejectEscalationQueryForLanguage(
+        query, userLanguages: AssistantSettings.shared.voiceBaseLanguages)
+      {
+        log(
+          "RealtimeHub[\(providerTag)]: tool ask_higher_model rejected unexpected-language query=\"\(query.prefix(80))\""
+        )
+        sendToolResultIfCurrent(
+          source: source, callId: callId, name: name,
+          output: "I may have misheard that. Please ask again.",
+          expectedTurnEpoch: toolTurnEpoch)
+        return
+      }
       log(
         "RealtimeHub[\(providerTag)]: tool ask_higher_model → POST /v2/chat/completions (\(ModelQoS.Claude.defaultSelection)) query=\"\(query.prefix(80))\""
       )

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
@@ -177,6 +177,7 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate {
   /// `spawn_agent` is a handoff, not a read tool. After the tool result returns,
   /// the realtime model sometimes continues with meta/control text; never speak it.
   private var suppressAssistantOutputForCurrentTurn = false
+  private var voiceOutputCoordinator = PTTVoiceOutputCoordinator()
   /// Guards against recording the same turn to the kernel twice (a delegate that
   /// fires turn-done more than once on reconnect/barge-in edges). Reset per turn.
   private var turnRecorded = false
@@ -969,10 +970,40 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate {
       Task { @MainActor in
         guard let self, self.realtimePlaybackEpoch == playbackEpoch else { return }
         self.realtimePlaybackActive = false
+        if let lease = self.voiceOutputCoordinator.snapshot().activeLease,
+          lease.lane == .nativeRealtime
+        {
+          self.voiceOutputCoordinator.release(lease)
+        }
         self.clearResponseGlowIfRealtimeAudioIdle()
       }
     }
     return player
+  }
+
+  private func acquireVoiceOutput(_ lane: PTTVoiceOutputLane, reason: String) -> PTTVoiceLease? {
+    guard let turnID = voiceOutputCoordinator.snapshot().turnID else {
+      log("RealtimeHub[\(providerTag)]: dropping \(lane.rawValue) output with no active PTT turn reason=\(reason)")
+      return nil
+    }
+    switch voiceOutputCoordinator.acquire(lane, turnID: turnID) {
+    case .acquired(let lease):
+      return lease
+    case .denied(let active):
+      log(
+        "RealtimeHub[\(providerTag)]: dropping \(lane.rawValue) output reason=\(reason) "
+          + "active_lane=\(active.lane.rawValue)"
+      )
+      return nil
+    case .staleTurn:
+      log("RealtimeHub[\(providerTag)]: dropping stale \(lane.rawValue) output reason=\(reason)")
+      return nil
+    }
+  }
+
+  private func releaseVoiceOutputIfActive(_ lane: PTTVoiceOutputLane) {
+    guard let lease = voiceOutputCoordinator.snapshot().activeLease, lease.lane == lane else { return }
+    voiceOutputCoordinator.release(lease)
   }
 
   // MARK: - PTT integration
@@ -986,6 +1017,7 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate {
     let voicePlaybackActive = FloatingBarVoicePlaybackService.shared.isSpeaking
     let bargeIn = responding || realtimePlaybackActive || voicePlaybackActive
     let interruptedTurn = bargeIn ? captureInterruptedTurnPayloadIfNeeded() : nil
+    _ = voiceOutputCoordinator.beginTurn()
     responding = false
     realtimePlaybackActive = false
     realtimePlaybackEpoch += 1
@@ -1236,6 +1268,7 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate {
     pendingCompletedAgentDeltaHighWaterMs = nil
     clearRealtimeToolTracking()
     clearBargeInReplacementState()
+    voiceOutputCoordinator.endTurn()
     // Abandon the open turn WITHOUT tearing down the socket: close the speech window
     // and leave the reply gated off so the model never answers the silence. Keeps the
     // warm session (and its context) so the next real turn is instant and in-context.
@@ -1306,12 +1339,16 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate {
 
   func hubDidReceiveAudio(_ pcm24k: Data, source: RealtimeHubSession) {
     guard isCurrentSession(source) else { return }
-    guard !suppressAssistantOutputForCurrentTurn else { return }
+    guard !suppressAssistantOutputForCurrentTurn,
+      !voiceOutputCoordinator.snapshot().providerOutputSuppressed
+    else { return }
+    guard acquireVoiceOutput(.nativeRealtime, reason: "provider_audio") != nil else { return }
     // If PTT muted music/system output while listening, make sure the model's
     // reply is audible even if capture teardown restore is delayed by hardware.
     SystemAudioMuteController.shared.restore()
     guard let pcmPlayer, pcmPlayer.enqueue(pcm24k) else {
       log("RealtimeHub[\(providerTag)]: native audio chunk could not be scheduled; keeping text fallback armed")
+      releaseVoiceOutputIfActive(.nativeRealtime)
       return
     }
     audioReceivedThisTurn = true
@@ -1322,7 +1359,9 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate {
 
   func hubDidEmitText(_ text: String, isFinal: Bool, source: RealtimeHubSession) {
     guard isCurrentSession(source) else { return }
-    guard !suppressAssistantOutputForCurrentTurn else { return }
+    guard !suppressAssistantOutputForCurrentTurn,
+      !voiceOutputCoordinator.snapshot().providerOutputSuppressed
+    else { return }
     if !text.isEmpty {
       assistantText += text
     }
@@ -1331,7 +1370,9 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate {
       // Fallback only: if the model produced text but no native audio this turn,
       // speak it through the selected app voice. Normally both providers stream
       // spoken audio (played by StreamingPCMPlayer) so this stays unused.
-      if !audioReceivedThisTurn, !reply.isEmpty {
+      if !audioReceivedThisTurn, !reply.isEmpty,
+        acquireVoiceOutput(.selectedVoiceFallback, reason: "text_no_native_audio") != nil
+      {
         responseGlowGate.markPlaybackActive()
         FloatingBarVoicePlaybackService.shared.speakOneShot(reply)
       }
@@ -1631,12 +1672,14 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate {
         errorText: "Could not start the background agent right now.",
         expectedTurnEpoch: toolTurnEpoch
       ) {
-        if !objective.isEmpty {
-          FloatingBarVoicePlaybackService.shared.speakBackgroundAgentKickoff()
-        }
         var toolArgs = arguments
         toolArgs["objective"] = objective
         let result = try await self.agentControlService.executeVoiceTool(name: "spawn_agent", arguments: toolArgs)
+        if !objective.isEmpty,
+          self.acquireVoiceOutput(.deterministicAgentAck, reason: "spawn_agent_success") != nil
+        {
+          FloatingBarVoicePlaybackService.shared.speakBackgroundAgentKickoff()
+        }
         await AgentPillsManager.shared.refreshProjectedPillsFromKernel()
         return result
       }
@@ -1721,7 +1764,9 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate {
         let setupPrompt = availability.setupPrompt
         assistantText = setupPrompt
         barState?.isVoiceResponseActive = true
-        if !audioReceivedThisTurn {
+        if !audioReceivedThisTurn,
+          acquireVoiceOutput(.deterministicAgentAck, reason: "directed_provider_unavailable") != nil
+        {
           FloatingBarVoicePlaybackService.shared.speakOneShot(directedProvider.setupNeededStatus)
         }
         suppressAssistantOutputForCurrentTurn = true
@@ -1857,6 +1902,7 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate {
       pendingCompletedAgentDeltaAckIds.removeAll()
       pendingCompletedAgentDeltaHighWaterMs = nil
     }
+    voiceOutputCoordinator.endTurn()
     exitVoiceUI()
   }
 
@@ -1981,6 +2027,7 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate {
     realtimePlaybackActive = false
     realtimePlaybackEpoch += 1
     FloatingBarVoicePlaybackService.shared.interruptCurrentResponse()
+    voiceOutputCoordinator.endTurn()
     exitVoiceUI(clearResponseGlow: true)
     teardownSession()
     // Provider switching changes the user's voice identity and can fragment model-local

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubTools.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubTools.swift
@@ -11,6 +11,22 @@ import Foundation
 // result; multi-step / other-app work still goes to spawn_agent.
 
 enum RealtimeHubTools {
+  static func resolvedVoiceLanguages(
+    explicit codes: [String],
+    preferredLanguages: [String] = Locale.preferredLanguages
+  ) -> [String] {
+    let source = codes.isEmpty ? preferredLanguages : codes
+    var seen = Set<String>()
+    var resolved: [String] = []
+    for code in source {
+      let base = AssistantSettings.baseLanguageCode(code)
+      guard !base.isEmpty, !seen.contains(base) else { continue }
+      seen.insert(base)
+      resolved.append(base)
+    }
+    return resolved
+  }
+
   private static func localAgentProviderInstruction() -> String {
     let providers: [AgentPillsManager.DirectedProvider] = [.openclaw, .hermes]
     let availability = providers.map { LocalAgentProviderDetector.availability(for: $0) }
@@ -60,10 +76,12 @@ enum RealtimeHubTools {
 
   /// One line telling the model which languages the user actually speaks, so a short or
   /// ambiguous utterance is never interpreted (or transcribed, where the provider allows
-  /// it) as some third language. Empty when the user has only the default set.
+  /// it) as some third language. Falls back to the Mac's preferred language when the user
+  /// has not configured an explicit voice-language set.
   private static func userLanguagesLine(_ codes: [String]) -> String {
-    guard !codes.isEmpty else { return "" }
-    let names = codes.map { code in
+    let resolved = resolvedVoiceLanguages(explicit: codes)
+    guard !resolved.isEmpty else { return "" }
+    let names = resolved.map { code in
       Locale(identifier: "en").localizedString(forLanguageCode: code) ?? code
     }
     let primary = names[0]
@@ -214,6 +232,37 @@ enum RealtimeHubTools {
 
     Keep latency low: prefer answering directly when you can.
     """
+  }
+
+  static func shouldRejectEscalationQueryForLanguage(
+    _ query: String,
+    userLanguages: [String],
+    preferredLanguages: [String] = Locale.preferredLanguages
+  ) -> Bool {
+    let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard trimmed.count >= 12 else { return false }
+    let allowed = resolvedVoiceLanguages(explicit: userLanguages, preferredLanguages: preferredLanguages)
+    guard !allowed.isEmpty else { return false }
+    if !allowed.contains("es"), looksLikeSpanishQuestion(trimmed) { return true }
+    guard let dominant = PTTLanguageIdentifier.dominantLanguage(of: trimmed, hints: allowed) else {
+      return false
+    }
+    return !allowed.contains(dominant)
+  }
+
+  private static func looksLikeSpanishQuestion(_ text: String) -> Bool {
+    let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard let first = trimmed.first else { return false }
+    if first == "¿" || first == "¡" { return true }
+    let lower = trimmed.lowercased()
+    return lower.hasPrefix("qué ")
+      || lower.hasPrefix("que ")
+      || lower.hasPrefix("cuál ")
+      || lower.hasPrefix("cual ")
+      || lower.hasPrefix("cómo ")
+      || lower.hasPrefix("como ")
+      || lower.hasPrefix("dónde ")
+      || lower.hasPrefix("donde ")
   }
 
   /// OpenAI Realtime GA `session.tools` entries.

--- a/desktop/macos/Desktop/Tests/AgentContinuityGauntletTests.swift
+++ b/desktop/macos/Desktop/Tests/AgentContinuityGauntletTests.swift
@@ -24,12 +24,14 @@ final class AgentContinuityGauntletTests: XCTestCase {
       encoding: .utf8
     )
     let required = [
+      "ask",
       "main_chat_snapshot",
       "wait_main_chat_idle",
       "agent_runtime_evidence",
       "ask_main_chat",
       "coordinator_awareness_snapshot",
       "swap_test_owner",
+      "restore_test_owner",
       "clear_owner_surface_state",
       "kernel_turn_tail",
     ]
@@ -54,6 +56,43 @@ final class AgentContinuityGauntletTests: XCTestCase {
     XCTAssertTrue(providerSource.contains("automationSwapTestOwner"))
     XCTAssertTrue(providerSource.contains("automationKernelTurnTail"))
     XCTAssertTrue(providerSource.contains("automationClearOwnerSurfaceState"))
+  }
+
+  func testResilienceSuiteIsWiredIntoCanonicalGauntlet() throws {
+    let desktopDir = URL(fileURLWithPath: #filePath)
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+    let scriptSource = try String(
+      contentsOf: desktopDir.appendingPathComponent("scripts/agent-continuity-gauntlet.sh"),
+      encoding: .utf8
+    )
+    let driverSource = try String(
+      contentsOf: desktopDir.appendingPathComponent("scripts/agent-continuity-gauntlet-lib.py"),
+      encoding: .utf8
+    )
+
+    XCTAssertTrue(driverSource.contains("\"resilience\""))
+    XCTAssertTrue(driverSource.contains("\"all\": {\"continuity\", \"agents\", \"owner\", \"prompts\", \"resilience\"}"))
+    XCTAssertTrue(driverSource.contains("SUITE_NAMES = {\"continuity\", \"agents\", \"owner\", \"prompts\", \"resilience\"}"))
+    XCTAssertTrue(driverSource.contains("def run_resilience_suite(self) -> None"))
+    XCTAssertTrue(driverSource.contains("if \"resilience\" in self.suites"))
+    XCTAssertTrue(driverSource.contains("self.run_resilience_suite()"))
+    XCTAssertTrue(driverSource.contains("resilience-diagnostics.jsonl"))
+    XCTAssertTrue(driverSource.contains("schema_version"))
+    XCTAssertTrue(driverSource.contains("terminal_reason"))
+    XCTAssertTrue(driverSource.contains("resilience_terminal_reason_counts"))
+    XCTAssertTrue(driverSource.contains("resilience_forbidden_terminal_reasons"))
+    XCTAssertTrue(driverSource.contains("skipped_missing_action"))
+    XCTAssertTrue(driverSource.contains("\"skipped_missing_action\""))
+    XCTAssertTrue(driverSource.contains("\"skipped_unimplemented_action\""))
+    XCTAssertTrue(driverSource.contains("ask_main_chat_no_wait"))
+    XCTAssertTrue(driverSource.contains("main_chat_busy_state"))
+    XCTAssertTrue(driverSource.contains("--suite resilience"))
+
+    XCTAssertTrue(scriptSource.contains("--suite resilience"))
+    XCTAssertTrue(scriptSource.contains("--suite all"))
+    XCTAssertTrue(scriptSource.contains("Release-candidate manual QA"))
   }
 
   @MainActor

--- a/desktop/macos/Desktop/Tests/DesktopStressHarnessTests.swift
+++ b/desktop/macos/Desktop/Tests/DesktopStressHarnessTests.swift
@@ -134,37 +134,77 @@ final class DesktopStressHarnessTests: XCTestCase {
     XCTAssertTrue(stderrText.contains("must be loopback"), stderrText)
   }
 
-  func testScriptRejectsHostnameThatOnlyLooksLoopback() throws {
-    let desktopDir = URL(fileURLWithPath: #filePath)
-      .deletingLastPathComponent()
-      .deletingLastPathComponent()
-      .deletingLastPathComponent()
-    let scriptURL = desktopDir.appendingPathComponent("scripts/stress_ptt_chat.py")
-
-    let process = Process()
-    process.executableURL = URL(fileURLWithPath: "/usr/bin/python3")
-    process.arguments = [scriptURL.path, "--base-url", "https://127.attacker.example", "--token", "secret"]
-
-    let stderr = Pipe()
-    process.standardError = stderr
-
-    try process.run()
-    process.waitUntilExit()
-
-    let stderrText = String(data: stderr.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
-    XCTAssertEqual(process.terminationStatus, 2)
-    XCTAssertTrue(stderrText.contains("must be loopback"), stderrText)
-  }
-
-  func testScriptRejectsMalformedFieldTypes() throws {
-    let jsonl = """
-      {"run_id":"run-bad","iteration":true,"scenario":"ptt_voiced","terminal_reason":"ptt_voiced_success","timestamp":"2026-07-07T12:00:00.000Z"}
+  func testScriptRejectsMalformedFieldTypesWithoutCrashing() throws {
+    let malformedScenario = """
+      {"run_id":"run-typed","iteration":1,"scenario":["ptt_voiced"],"terminal_reason":"ptt_voiced_success","timestamp":"2026-07-07T12:00:00.000Z"}
 
       """
-    let result = try runScript(jsonl: jsonl)
+    let scenarioResult = try runScript(jsonl: malformedScenario)
+    XCTAssertEqual(scenarioResult.exitCode, 2)
+    XCTAssertTrue(scenarioResult.stderr.contains("scenario must be a string"), scenarioResult.stderr)
+
+    let boolIteration = """
+      {"run_id":"run-typed","iteration":true,"scenario":"ptt_voiced","terminal_reason":"ptt_voiced_success","timestamp":"2026-07-07T12:00:00.000Z","duration_ms":false}
+
+      """
+    let iterationResult = try runScript(jsonl: boolIteration)
+    XCTAssertEqual(iterationResult.exitCode, 2)
+    XCTAssertTrue(iterationResult.stderr.contains("iteration must be a positive integer"), iterationResult.stderr)
+  }
+
+  func testScriptRejectsCraftedLoopbackLikeHostnameWithToken() throws {
+    let result = try runScript(
+      arguments: [
+        "--base-url", "https://127.evil.com",
+        "--token", "secret",
+      ])
 
     XCTAssertEqual(result.exitCode, 2)
-    XCTAssertTrue(result.stderr.contains("iteration must be a positive integer"), result.stderr)
+    XCTAssertTrue(result.stderr.contains("must be loopback"), result.stderr)
+  }
+
+  func testBridgeTerminalReasonDoesNotTrustExplicitSuccessOnFailure() throws {
+    let scriptPath = stressScriptURL().path
+    let snippet = """
+      import importlib.util
+      spec = importlib.util.spec_from_file_location("stress_ptt_chat", \(pythonStringLiteral(scriptPath)))
+      module = importlib.util.module_from_spec(spec)
+      spec.loader.exec_module(module)
+      reason = module.terminal_from_bridge_response("chat_bridge", {"ok": False, "terminal_reason": "chat_bridge_success"})
+      assert reason == "bridge_launch_failure", reason
+      assert module.is_loopback_url("http://127.0.0.1:47777")
+      assert module.is_loopback_url("http://[::1]:47777")
+      assert not module.is_loopback_url("https://127.evil.com")
+      """
+
+    let result = try runPythonSnippet(snippet)
+    XCTAssertEqual(result.exitCode, 0, result.stderr)
+  }
+
+  func testBridgeActionDiscoveryTreatsNullResultAsLaunchFailure() throws {
+    let scriptPath = stressScriptURL().path
+    let snippet = """
+      import importlib.util
+      spec = importlib.util.spec_from_file_location("stress_ptt_chat", \(pythonStringLiteral(scriptPath)))
+      module = importlib.util.module_from_spec(spec)
+      spec.loader.exec_module(module)
+
+      def fake_request_json(base_url, token, method, path, body=None):
+          if path == "/health":
+              return {"ok": True}
+          if path == "/actions":
+              return {"ok": True, "result": None}
+          raise AssertionError(path)
+
+      module.request_json = fake_request_json
+      events = module.collect_from_bridge("http://localhost:47777", "secret", ["chat_bridge"], 1)
+      assert len(events) == 1, events
+      assert events[0]["terminal_reason"] == "bridge_launch_failure", events
+      assert "result must be a list" in events[0]["details"]["error"], events
+      """
+
+    let result = try runPythonSnippet(snippet)
+    XCTAssertEqual(result.exitCode, 0, result.stderr)
   }
 
   private func runScript(
@@ -176,15 +216,15 @@ final class DesktopStressHarnessTests: XCTestCase {
     try jsonl.write(to: tempURL, atomically: true, encoding: .utf8)
     defer { try? FileManager.default.removeItem(at: tempURL) }
 
-    let scriptURL = URL(fileURLWithPath: #filePath)
-      .deletingLastPathComponent()
-      .deletingLastPathComponent()
-      .deletingLastPathComponent()
-      .appendingPathComponent("scripts/stress_ptt_chat.py")
+    return try runScript(arguments: ["--input-jsonl", tempURL.path] + extraArguments)
+  }
 
+  private func runScript(
+    arguments: [String]
+  ) throws -> (exitCode: Int32, stdout: String, stderr: String) {
     let process = Process()
     process.executableURL = URL(fileURLWithPath: "/usr/bin/python3")
-    process.arguments = [scriptURL.path, "--input-jsonl", tempURL.path] + extraArguments
+    process.arguments = [stressScriptURL().path] + arguments
 
     let stdout = Pipe()
     let stderr = Pipe()
@@ -197,5 +237,37 @@ final class DesktopStressHarnessTests: XCTestCase {
     let stdoutText = String(data: stdout.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
     let stderrText = String(data: stderr.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
     return (process.terminationStatus, stdoutText, stderrText)
+  }
+
+  private func runPythonSnippet(_ snippet: String) throws -> (exitCode: Int32, stdout: String, stderr: String) {
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: "/usr/bin/python3")
+    process.arguments = ["-c", snippet]
+
+    let stdout = Pipe()
+    let stderr = Pipe()
+    process.standardOutput = stdout
+    process.standardError = stderr
+
+    try process.run()
+    process.waitUntilExit()
+
+    let stdoutText = String(data: stdout.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+    let stderrText = String(data: stderr.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+    return (process.terminationStatus, stdoutText, stderrText)
+  }
+
+  private func stressScriptURL() -> URL {
+    URL(fileURLWithPath: #filePath)
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+      .appendingPathComponent("scripts/stress_ptt_chat.py")
+  }
+
+  private func pythonStringLiteral(_ value: String) -> String {
+    let data = try! JSONSerialization.data(withJSONObject: [value])
+    let encoded = String(data: data, encoding: .utf8)!
+    return String(encoded.dropFirst().dropLast()).replacingOccurrences(of: "\\/", with: "/")
   }
 }

--- a/desktop/macos/Desktop/Tests/DesktopStressHarnessTests.swift
+++ b/desktop/macos/Desktop/Tests/DesktopStressHarnessTests.swift
@@ -134,6 +134,39 @@ final class DesktopStressHarnessTests: XCTestCase {
     XCTAssertTrue(stderrText.contains("must be loopback"), stderrText)
   }
 
+  func testScriptRejectsHostnameThatOnlyLooksLoopback() throws {
+    let desktopDir = URL(fileURLWithPath: #filePath)
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+    let scriptURL = desktopDir.appendingPathComponent("scripts/stress_ptt_chat.py")
+
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: "/usr/bin/python3")
+    process.arguments = [scriptURL.path, "--base-url", "https://127.attacker.example", "--token", "secret"]
+
+    let stderr = Pipe()
+    process.standardError = stderr
+
+    try process.run()
+    process.waitUntilExit()
+
+    let stderrText = String(data: stderr.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+    XCTAssertEqual(process.terminationStatus, 2)
+    XCTAssertTrue(stderrText.contains("must be loopback"), stderrText)
+  }
+
+  func testScriptRejectsMalformedFieldTypes() throws {
+    let jsonl = """
+      {"run_id":"run-bad","iteration":true,"scenario":"ptt_voiced","terminal_reason":"ptt_voiced_success","timestamp":"2026-07-07T12:00:00.000Z"}
+
+      """
+    let result = try runScript(jsonl: jsonl)
+
+    XCTAssertEqual(result.exitCode, 2)
+    XCTAssertTrue(result.stderr.contains("iteration must be a positive integer"), result.stderr)
+  }
+
   private func runScript(
     jsonl: String,
     extraArguments: [String] = []

--- a/desktop/macos/Desktop/Tests/DesktopStressHarnessTests.swift
+++ b/desktop/macos/Desktop/Tests/DesktopStressHarnessTests.swift
@@ -20,6 +20,11 @@ final class DesktopStressHarnessTests: XCTestCase {
         "provider_fallback",
         "bridge_launch_failure",
         "response_already_running",
+        "voice_output_overlap",
+        "realtime_no_response_timeout",
+        "deferred_commit_timeout",
+        "barge_in_replacement_timeout",
+        "stale_provider_audio_after_interrupt",
       ])
     XCTAssertFalse(DesktopStressTerminalReason.pttVoicedSuccess.isReleaseGateFailure)
     XCTAssertFalse(DesktopStressTerminalReason.pttSilentRejected.isReleaseGateFailure)
@@ -29,6 +34,11 @@ final class DesktopStressHarnessTests: XCTestCase {
     XCTAssertTrue(DesktopStressTerminalReason.audioFramesMissing.isReleaseGateFailure)
     XCTAssertTrue(DesktopStressTerminalReason.realtimeTokenMintFailure.isReleaseGateFailure)
     XCTAssertTrue(DesktopStressTerminalReason.responseAlreadyRunning.isReleaseGateFailure)
+    XCTAssertTrue(DesktopStressTerminalReason.voiceOutputOverlap.isReleaseGateFailure)
+    XCTAssertTrue(DesktopStressTerminalReason.realtimeNoResponseTimeout.isReleaseGateFailure)
+    XCTAssertTrue(DesktopStressTerminalReason.deferredCommitTimeout.isReleaseGateFailure)
+    XCTAssertTrue(DesktopStressTerminalReason.bargeInReplacementTimeout.isReleaseGateFailure)
+    XCTAssertTrue(DesktopStressTerminalReason.staleProviderAudioAfterInterrupt.isReleaseGateFailure)
   }
 
   func testStressEventJSONRoundTripsWithStableSnakeCaseKeys() throws {

--- a/desktop/macos/Desktop/Tests/DesktopStressHarnessTests.swift
+++ b/desktop/macos/Desktop/Tests/DesktopStressHarnessTests.swift
@@ -1,0 +1,168 @@
+import XCTest
+
+@testable import Omi_Computer
+
+final class DesktopStressHarnessTests: XCTestCase {
+  func testTerminalTaxonomyNamesCurrentPTTRealtimeAndBridgeFailures() {
+    let rawReasons = Set(DesktopStressTerminalReason.allCases.map(\.rawValue))
+
+    XCTAssertEqual(
+      rawReasons,
+      [
+        "ptt_voiced_success",
+        "ptt_silent_rejected",
+        "chat_bridge_success",
+        "subagent_launch_success",
+        "too_short_tap",
+        "audio_frames_missing",
+        "silent_audio",
+        "realtime_token_mint_failure",
+        "provider_fallback",
+        "bridge_launch_failure",
+        "response_already_running",
+      ])
+    XCTAssertFalse(DesktopStressTerminalReason.pttVoicedSuccess.isReleaseGateFailure)
+    XCTAssertFalse(DesktopStressTerminalReason.pttSilentRejected.isReleaseGateFailure)
+    XCTAssertFalse(DesktopStressTerminalReason.chatBridgeSuccess.isReleaseGateFailure)
+    XCTAssertFalse(DesktopStressTerminalReason.subagentLaunchSuccess.isReleaseGateFailure)
+    XCTAssertFalse(DesktopStressTerminalReason.providerFallback.isReleaseGateFailure)
+    XCTAssertTrue(DesktopStressTerminalReason.audioFramesMissing.isReleaseGateFailure)
+    XCTAssertTrue(DesktopStressTerminalReason.realtimeTokenMintFailure.isReleaseGateFailure)
+    XCTAssertTrue(DesktopStressTerminalReason.responseAlreadyRunning.isReleaseGateFailure)
+  }
+
+  func testStressEventJSONRoundTripsWithStableSnakeCaseKeys() throws {
+    let event = DesktopStressDiagnosticEvent(
+      runID: "run-1",
+      iteration: 2,
+      scenario: .chatBridge,
+      terminalReason: .responseAlreadyRunning,
+      timestamp: "2026-07-07T12:00:00.000Z",
+      durationMs: 123,
+      details: ["phase": "send"])
+
+    let data = try JSONEncoder().encode(event)
+    let object = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+
+    XCTAssertEqual(object["run_id"] as? String, "run-1")
+    XCTAssertEqual(object["terminal_reason"] as? String, "response_already_running")
+    XCTAssertEqual(object["duration_ms"] as? Int, 123)
+
+    let decoded = try JSONDecoder().decode(DesktopStressDiagnosticEvent.self, from: data)
+    XCTAssertEqual(decoded, event)
+  }
+
+  func testRunSummaryFailsReleaseGateOnForbiddenTerminalReasons() {
+    let summary = DesktopStressRunSummary(events: [
+      DesktopStressDiagnosticEvent(
+        runID: "run-1",
+        iteration: 1,
+        scenario: .pttVoiced,
+        terminalReason: .pttVoicedSuccess),
+      DesktopStressDiagnosticEvent(
+        runID: "run-1",
+        iteration: 2,
+        scenario: .pttVoiced,
+        terminalReason: .silentAudio),
+    ])
+
+    XCTAssertFalse(summary.passedReleaseGate)
+    XCTAssertEqual(summary.totalEvents, 2)
+    XCTAssertEqual(summary.terminalReasonCounts["ptt_voiced_success"], 1)
+    XCTAssertEqual(summary.terminalReasonCounts["silent_audio"], 1)
+    XCTAssertEqual(summary.forbiddenTerminalReasons, ["silent_audio"])
+  }
+
+  func testScriptOfflineValidationPassesForAllowedReasons() throws {
+    let jsonl = """
+      {"run_id":"run-1","iteration":1,"scenario":"ptt_voiced","terminal_reason":"ptt_voiced_success","timestamp":"2026-07-07T12:00:00.000Z"}
+      {"run_id":"run-1","iteration":2,"scenario":"chat_bridge","terminal_reason":"provider_fallback","timestamp":"2026-07-07T12:00:01.000Z","duration_ms":44,"details":{"provider":"openai"}}
+
+      """
+    let result = try runScript(jsonl: jsonl)
+
+    XCTAssertEqual(result.exitCode, 0, result.stderr)
+    XCTAssertTrue(result.stdout.contains("\"passed_release_gate\": true"))
+    XCTAssertTrue(result.stdout.contains("\"provider_fallback\": 1"))
+  }
+
+  func testScriptOfflineValidationFailsWhenRequiredScenarioIsMissing() throws {
+    let jsonl = """
+      {"run_id":"run-coverage","iteration":1,"scenario":"ptt_voiced","terminal_reason":"ptt_voiced_success","timestamp":"2026-07-07T12:00:00.000Z"}
+
+      """
+    let result = try runScript(jsonl: jsonl, extraArguments: ["--require-scenario", "chat_bridge"])
+
+    XCTAssertEqual(result.exitCode, 2)
+    XCTAssertTrue(result.stdout.contains("\"missing_required_scenarios\""))
+    XCTAssertTrue(result.stdout.contains("\"chat_bridge\""))
+  }
+
+  func testScriptOfflineValidationFailsOnForbiddenReason() throws {
+    let jsonl = """
+      {"run_id":"run-2","iteration":1,"scenario":"subagent_launch","terminal_reason":"bridge_launch_failure","timestamp":"2026-07-07T12:00:00.000Z","details":{"error":"spawn failed"}}
+
+      """
+    let result = try runScript(jsonl: jsonl)
+
+    XCTAssertEqual(result.exitCode, 2)
+    XCTAssertTrue(result.stdout.contains("\"passed_release_gate\": false"))
+    XCTAssertTrue(result.stdout.contains("\"bridge_launch_failure\""))
+  }
+
+  func testScriptRejectsRemoteAutomationTokenByDefault() throws {
+    let desktopDir = URL(fileURLWithPath: #filePath)
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+    let scriptURL = desktopDir.appendingPathComponent("scripts/stress_ptt_chat.py")
+
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: "/usr/bin/python3")
+    process.arguments = [scriptURL.path, "--base-url", "https://example.com", "--token", "secret"]
+
+    let stdout = Pipe()
+    let stderr = Pipe()
+    process.standardOutput = stdout
+    process.standardError = stderr
+
+    try process.run()
+    process.waitUntilExit()
+
+    let stderrText = String(data: stderr.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+    XCTAssertEqual(process.terminationStatus, 2)
+    XCTAssertTrue(stderrText.contains("must be loopback"), stderrText)
+  }
+
+  private func runScript(
+    jsonl: String,
+    extraArguments: [String] = []
+  ) throws -> (exitCode: Int32, stdout: String, stderr: String) {
+    let tempURL = FileManager.default.temporaryDirectory
+      .appendingPathComponent("omi-stress-\(UUID().uuidString).jsonl")
+    try jsonl.write(to: tempURL, atomically: true, encoding: .utf8)
+    defer { try? FileManager.default.removeItem(at: tempURL) }
+
+    let scriptURL = URL(fileURLWithPath: #filePath)
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+      .appendingPathComponent("scripts/stress_ptt_chat.py")
+
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: "/usr/bin/python3")
+    process.arguments = [scriptURL.path, "--input-jsonl", tempURL.path] + extraArguments
+
+    let stdout = Pipe()
+    let stderr = Pipe()
+    process.standardOutput = stdout
+    process.standardError = stderr
+
+    try process.run()
+    process.waitUntilExit()
+
+    let stdoutText = String(data: stdout.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+    let stderrText = String(data: stderr.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+    return (process.terminationStatus, stdoutText, stderrText)
+  }
+}

--- a/desktop/macos/Desktop/Tests/HubEscalationTests.swift
+++ b/desktop/macos/Desktop/Tests/HubEscalationTests.swift
@@ -24,4 +24,28 @@ final class HubEscalationTests: XCTestCase {
     XCTAssertFalse(messages[1]["content"]!.contains("Context"))
     XCTAssertFalse(messages[1]["content"]!.contains("Answer concisely for a spoken reply"))
   }
+
+  func testRejectsUnexpectedLanguageEscalationQueryForDefaultEnglishVoice() {
+    XCTAssertTrue(
+      RealtimeHubTools.shouldRejectEscalationQueryForLanguage(
+        "¿Qué es el número de serie?",
+        userLanguages: [],
+        preferredLanguages: ["en-US"]))
+  }
+
+  func testAllowsEscalationQueryInConfiguredVoiceLanguage() {
+    XCTAssertFalse(
+      RealtimeHubTools.shouldRejectEscalationQueryForLanguage(
+        "¿Qué es el número de serie?",
+        userLanguages: ["es"],
+        preferredLanguages: ["en-US"]))
+  }
+
+  func testAllowsEnglishEscalationQueryForDefaultEnglishVoice() {
+    XCTAssertFalse(
+      RealtimeHubTools.shouldRejectEscalationQueryForLanguage(
+        "What is the serial number?",
+        userLanguages: [],
+        preferredLanguages: ["en-US"]))
+  }
 }

--- a/desktop/macos/Desktop/Tests/PTTVoiceOutputCoordinatorTests.swift
+++ b/desktop/macos/Desktop/Tests/PTTVoiceOutputCoordinatorTests.swift
@@ -1,0 +1,103 @@
+import XCTest
+
+@testable import Omi_Computer
+
+final class PTTVoiceOutputCoordinatorTests: XCTestCase {
+  func testFallbackCannotStartAfterNativeRealtimeLease() {
+    var coordinator = PTTVoiceOutputCoordinator()
+    let turnID = coordinator.beginTurn()
+
+    guard case .acquired(let native) = coordinator.acquire(.nativeRealtime, turnID: turnID) else {
+      return XCTFail("native realtime lease should acquire")
+    }
+    XCTAssertEqual(native.lane, .nativeRealtime)
+
+    XCTAssertEqual(
+      coordinator.acquire(.selectedVoiceFallback, turnID: turnID),
+      .denied(active: native))
+  }
+
+  func testLateNativeAudioIsDeniedAfterFallbackLease() {
+    var coordinator = PTTVoiceOutputCoordinator()
+    let turnID = coordinator.beginTurn()
+
+    guard case .acquired(let fallback) = coordinator.acquire(.selectedVoiceFallback, turnID: turnID) else {
+      return XCTFail("fallback lease should acquire")
+    }
+
+    XCTAssertEqual(
+      coordinator.acquire(.nativeRealtime, turnID: turnID),
+      .denied(active: fallback))
+  }
+
+  func testDeterministicAckSuppressesProviderOutputForTurn() {
+    var coordinator = PTTVoiceOutputCoordinator()
+    let turnID = coordinator.beginTurn()
+
+    guard case .acquired(let ack) = coordinator.acquire(.deterministicAgentAck, turnID: turnID) else {
+      return XCTFail("deterministic ack lease should acquire")
+    }
+
+    XCTAssertTrue(coordinator.snapshot().providerOutputSuppressed)
+    XCTAssertEqual(
+      coordinator.acquire(.nativeRealtime, turnID: turnID),
+      .denied(active: ack))
+  }
+
+  func testDeterministicAckDeniedIfNativeAudioAlreadyStarted() {
+    var coordinator = PTTVoiceOutputCoordinator()
+    let turnID = coordinator.beginTurn()
+
+    guard case .acquired(let native) = coordinator.acquire(.nativeRealtime, turnID: turnID) else {
+      return XCTFail("native realtime lease should acquire")
+    }
+
+    XCTAssertEqual(
+      coordinator.acquire(.deterministicAgentAck, turnID: turnID),
+      .denied(active: native))
+    XCTAssertFalse(coordinator.snapshot().providerOutputSuppressed)
+  }
+
+  func testBargeInRevokesCurrentLease() {
+    var coordinator = PTTVoiceOutputCoordinator()
+    let oldTurnID = coordinator.beginTurn()
+    XCTAssertNotNil(tryLease(coordinator.acquire(.selectedVoiceFallback, turnID: oldTurnID)))
+
+    coordinator.interruptCurrentOutput()
+    let newTurnID = coordinator.beginTurn()
+
+    guard case .acquired(let native) = coordinator.acquire(.nativeRealtime, turnID: newTurnID) else {
+      return XCTFail("new turn should acquire native lease after interruption")
+    }
+    XCTAssertEqual(native.turnID, newTurnID)
+    XCTAssertNotEqual(native.turnID, oldTurnID)
+  }
+
+  func testStaleReleaseCannotClearCurrentLease() throws {
+    var coordinator = PTTVoiceOutputCoordinator()
+    let firstTurnID = coordinator.beginTurn()
+    let staleLease = tryLease(coordinator.acquire(.nativeRealtime, turnID: firstTurnID))
+    _ = coordinator.beginTurn()
+    let secondTurnID = try XCTUnwrap(coordinator.snapshot().turnID)
+    let currentLease = tryLease(coordinator.acquire(.selectedVoiceFallback, turnID: secondTurnID))
+
+    if let staleLease {
+      coordinator.release(staleLease)
+    }
+
+    XCTAssertEqual(coordinator.snapshot().activeLease, currentLease)
+  }
+
+  func testStaleTurnCannotAcquireLease() {
+    var coordinator = PTTVoiceOutputCoordinator()
+    let oldTurnID = coordinator.beginTurn()
+    _ = coordinator.beginTurn()
+
+    XCTAssertEqual(coordinator.acquire(.nativeRealtime, turnID: oldTurnID), .staleTurn)
+  }
+
+  private func tryLease(_ decision: PTTVoiceOutputDecision) -> PTTVoiceLease? {
+    guard case .acquired(let lease) = decision else { return nil }
+    return lease
+  }
+}

--- a/desktop/macos/Desktop/Tests/PushToTalkSpeechGateTests.swift
+++ b/desktop/macos/Desktop/Tests/PushToTalkSpeechGateTests.swift
@@ -28,6 +28,12 @@ final class PushToTalkSpeechGateTests: XCTestCase {
     XCTAssertFalse(PushToTalkManager.hubTurnHasSpeech(pcm16k: audio))
   }
 
+  func testHubSpeechGateAcceptsClearShortReply() {
+    let audio = sinePCM16k(seconds: 0.42, frequency: 220, amplitude: 3500)
+
+    XCTAssertTrue(PushToTalkManager.hubTurnHasSpeech(pcm16k: audio))
+  }
+
   func testHubSpeechGateAcceptsSustainedVoicedAudio() {
     let audio = sinePCM16k(seconds: 0.7, frequency: 220, amplitude: 3500)
 

--- a/desktop/macos/Desktop/Tests/RealtimeHubSpawnAgentTests.swift
+++ b/desktop/macos/Desktop/Tests/RealtimeHubSpawnAgentTests.swift
@@ -7,7 +7,8 @@ final class RealtimeHubSpawnAgentTests: XCTestCase {
     let source = try realtimeHubControllerSource()
 
     XCTAssertTrue(source.contains("private var suppressAssistantOutputForCurrentTurn = false"))
-    XCTAssertTrue(source.contains("guard !suppressAssistantOutputForCurrentTurn else { return }"))
+    XCTAssertTrue(source.contains("guard !suppressAssistantOutputForCurrentTurn,"))
+    XCTAssertTrue(source.contains("!voiceOutputCoordinator.snapshot().providerOutputSuppressed"))
     XCTAssertTrue(source.contains("suppressAssistantOutputForCurrentTurn = true"))
     XCTAssertTrue(source.contains("output: \"Agent started.\""))
     XCTAssertFalse(source.contains("Acknowledged before the call — do not say anything else"))
@@ -26,6 +27,7 @@ final class RealtimeHubSpawnAgentTests: XCTestCase {
     XCTAssertTrue(source.contains("Started background agent"))
     XCTAssertTrue(source.contains("suppressAssistantOutputForCurrentTurn = !shouldAllowNativePostSpawnAck"))
     XCTAssertTrue(source.contains("FloatingBarVoicePlaybackService.shared.speakBackgroundAgentKickoff()"))
+    XCTAssertTrue(source.contains("self.acquireVoiceOutput(.deterministicAgentAck, reason: \"spawn_agent_success\")"))
     XCTAssertFalse(source.contains("speak(ack)"))
   }
 
@@ -49,6 +51,22 @@ final class RealtimeHubSpawnAgentTests: XCTestCase {
     XCTAssertTrue(source.contains("FloatingBarVoicePlaybackService.shared.speakOneShot(reply)"))
     XCTAssertTrue(source.contains("FloatingBarVoicePlaybackService.shared.speakOneShot(directedProvider.setupNeededStatus)"))
     XCTAssertTrue(source.contains("FloatingBarVoicePlaybackService.shared.interruptCurrentResponse()"))
+    XCTAssertTrue(source.contains("acquireVoiceOutput(.selectedVoiceFallback, reason: \"text_no_native_audio\")"))
+    XCTAssertTrue(source.contains("acquireVoiceOutput(.deterministicAgentAck, reason: \"directed_provider_unavailable\")"))
+  }
+
+  func testRealtimeHubAudibleOutputIsLeaseGated() throws {
+    let source = try realtimeHubControllerSource()
+
+    XCTAssertTrue(source.contains("private var voiceOutputCoordinator = PTTVoiceOutputCoordinator()"))
+    XCTAssertTrue(source.contains("_ = voiceOutputCoordinator.beginTurn()"))
+    XCTAssertTrue(source.contains("voiceOutputCoordinator.endTurn()"))
+    XCTAssertTrue(source.contains("private func acquireVoiceOutput(_ lane: PTTVoiceOutputLane, reason: String)"))
+    XCTAssertTrue(source.contains("acquireVoiceOutput(.nativeRealtime, reason: \"provider_audio\")"))
+    XCTAssertTrue(source.contains("acquireVoiceOutput(.selectedVoiceFallback, reason: \"text_no_native_audio\")"))
+    XCTAssertTrue(source.contains("acquireVoiceOutput(.deterministicAgentAck, reason: \"spawn_agent_success\")"))
+    XCTAssertTrue(source.contains("providerOutputSuppressed"))
+    XCTAssertFalse(source.contains("FloatingBarVoicePlaybackService.shared.speakBackgroundAgentKickoff()\n        var toolArgs"))
   }
 
   func testRealtimeToolTurnsStayOpenUntilToolResultReturns() throws {

--- a/desktop/macos/changelog/unreleased/20260707-agent-stress-resilience-harness.json
+++ b/desktop/macos/changelog/unreleased/20260707-agent-stress-resilience-harness.json
@@ -1,0 +1,3 @@
+{
+  "change": "Added desktop agent stress diagnostics and resilience gauntlet coverage"
+}

--- a/desktop/macos/changelog/unreleased/20260707-agent-stress-resilience-harness.json
+++ b/desktop/macos/changelog/unreleased/20260707-agent-stress-resilience-harness.json
@@ -1,3 +1,0 @@
-{
-  "change": "Added desktop agent stress diagnostics and resilience gauntlet coverage"
-}

--- a/desktop/macos/changelog/unreleased/20260707-ptt-voice-output-arbitration.json
+++ b/desktop/macos/changelog/unreleased/20260707-ptt-voice-output-arbitration.json
@@ -1,0 +1,3 @@
+{
+  "change": "Improved push-to-talk reliability by preventing realtime and fallback voices from speaking over each other"
+}

--- a/desktop/macos/changelog/unreleased/20260708-ptt-language-guard.json
+++ b/desktop/macos/changelog/unreleased/20260708-ptt-language-guard.json
@@ -1,0 +1,3 @@
+{
+  "change": "Reduced random-language push-to-talk replies by tightening short speech detection and rejecting misheard realtime tool queries"
+}

--- a/desktop/macos/docs/stress-diagnostic-harness.md
+++ b/desktop/macos/docs/stress-diagnostic-harness.md
@@ -31,11 +31,19 @@ Terminal reasons:
 - `provider_fallback`
 - `bridge_launch_failure`
 - `response_already_running`
+- `voice_output_overlap`
+- `realtime_no_response_timeout`
+- `deferred_commit_timeout`
+- `barge_in_replacement_timeout`
+- `stale_provider_audio_after_interrupt`
 
 The release gate passes only when at least one event exists and none of these
 forbidden reasons appear: `too_short_tap`, `audio_frames_missing`,
 `silent_audio`, `realtime_token_mint_failure`, `bridge_launch_failure`,
-`response_already_running`. `provider_fallback` is tracked but allowed so the
+`response_already_running`, `voice_output_overlap`,
+`realtime_no_response_timeout`, `deferred_commit_timeout`,
+`barge_in_replacement_timeout`, `stale_provider_audio_after_interrupt`.
+`provider_fallback` is tracked but allowed so the
 gate can distinguish a degraded but recovered provider path from a silent turn.
 The scenario-specific success reasons are allowed and make partial exports easy
 to spot in summaries.

--- a/desktop/macos/docs/stress-diagnostic-harness.md
+++ b/desktop/macos/docs/stress-diagnostic-harness.md
@@ -1,0 +1,102 @@
+# Stress Diagnostic Harness
+
+`scripts/stress_ptt_chat.py` is the first deterministic contract for desktop
+PTT, realtime, chat bridge, and subagent stress runs. It validates JSONL events
+offline and can optionally probe an already-running non-production automation
+bridge. It never launches, restarts, kills, or discovers `/Applications/Omi.app`.
+
+## JSONL Contract
+
+Each line is one terminal event:
+
+```json
+{"run_id":"run-1","iteration":1,"scenario":"ptt_voiced","terminal_reason":"ptt_voiced_success","timestamp":"2026-07-07T12:00:00.000Z","duration_ms":120,"details":{}}
+```
+
+Scenarios:
+- `ptt_voiced`
+- `ptt_silent`
+- `chat_bridge`
+- `subagent_launch`
+
+Terminal reasons:
+- `ptt_voiced_success`
+- `ptt_silent_rejected`
+- `chat_bridge_success`
+- `subagent_launch_success`
+- `too_short_tap`
+- `audio_frames_missing`
+- `silent_audio`
+- `realtime_token_mint_failure`
+- `provider_fallback`
+- `bridge_launch_failure`
+- `response_already_running`
+
+The release gate passes only when at least one event exists and none of these
+forbidden reasons appear: `too_short_tap`, `audio_frames_missing`,
+`silent_audio`, `realtime_token_mint_failure`, `bridge_launch_failure`,
+`response_already_running`. `provider_fallback` is tracked but allowed so the
+gate can distinguish a degraded but recovered provider path from a silent turn.
+The scenario-specific success reasons are allowed and make partial exports easy
+to spot in summaries.
+
+## Offline Validation
+
+```bash
+cd desktop/macos
+python3 scripts/stress_ptt_chat.py --input-jsonl /path/to/stress-run.jsonl
+```
+
+The script prints a JSON summary and exits `0` when the release gate passes, or
+`2` when the JSONL is invalid or forbidden terminal reasons are present.
+For release-candidate gates, require the expected coverage explicitly:
+
+```bash
+python3 scripts/stress_ptt_chat.py \
+  --input-jsonl /path/to/stress-run.jsonl \
+  --require-scenario ptt_voiced \
+  --require-scenario ptt_silent \
+  --require-scenario chat_bridge \
+  --require-scenario subagent_launch
+```
+
+## Live Bridge Probe
+
+First launch a named non-production bundle yourself:
+
+```bash
+cd desktop/macos
+OMI_APP_NAME="omi-stress-diagnostics" ./run.sh
+```
+
+Then probe the already-running bridge:
+
+```bash
+cd desktop/macos
+export OMI_AUTOMATION_TOKEN="$(tr -d '\r\n' < "${TMPDIR:-/tmp}/omi-automation-47777.token")"
+python3 scripts/stress_ptt_chat.py \
+  --base-url http://127.0.0.1:47777 \
+  --iterations 5 \
+  --scenario ptt_voiced \
+  --scenario chat_bridge \
+  --emit-jsonl
+```
+
+Live mode expects future automation actions named `stress_ptt_voiced`,
+`stress_ptt_silent`, `stress_chat_bridge`, and `stress_subagent_launch`. Until
+those are registered by the app, live probes fail loud with
+`bridge_launch_failure`; offline JSONL validation is the stable release-gate
+surface for this first slice.
+The script only sends automation tokens to loopback bridge URLs by default. Use
+`--allow-remote-token` only for an intentional non-production remote bridge.
+
+## Release-Gate Path
+
+The intended gate is:
+
+1. A signed named bundle or dev bundle exports stress JSONL from PTT/realtime and
+   chat/subagent bridge runs.
+2. CI or the release operator runs `stress_ptt_chat.py --input-jsonl` with the
+   required scenarios listed above.
+3. Promotion stops on forbidden terminal reasons, while preserving the exact
+   per-iteration taxonomy for diagnosis.

--- a/desktop/macos/e2e/CORE_E2E.md
+++ b/desktop/macos/e2e/CORE_E2E.md
@@ -115,4 +115,11 @@ Evidence contract: `.harness/desktop-core/<run-id>/{manifest.json, flows/, summa
 - **Hermetic (T2):** `make dev-up` with `PROVIDER_MODE=offline` (verified via config digest + service health; non-offline stacks abort), Rust `OMI_LLM_STUB=1`, bridge transcript seam — no real LLM or mic/STT.
 - **Live (T3):** Real provider credentials; agent continuity gauntlet.
 
+Release-candidate agent QA: launch a named bundle, then run
+`cd desktop/macos && ./scripts/agent-continuity-gauntlet.sh --suite resilience`
+for startup/bad-state bridge and subagent probes. Follow with
+`./scripts/agent-continuity-gauntlet.sh --suite all` for the full continuity,
+prompt, owner, and resilience pass. Evidence is written under
+`.harness/agent-continuity-gauntlet/`.
+
 See also `desktop/macos/e2e/SKILL.md` and `scripts/dev-harness/`.

--- a/desktop/macos/e2e/flows/chat-hermetic.yaml
+++ b/desktop/macos/e2e/flows/chat-hermetic.yaml
@@ -13,6 +13,7 @@ covers:
   - desktop/macos/Desktop/Sources/MainWindow/Components/ChatInputView.swift
   - desktop/macos/Desktop/Sources/MainWindow/Pages/ChatErrorCard.swift
   - desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift
+  - desktop/macos/Desktop/Sources/Diagnostics/DesktopStressDiagnostics.swift
   - desktop/macos/Backend-Rust/src/routes/chat_completions.rs
 preconditions:
   - automation_bridge_ready

--- a/desktop/macos/e2e/flows/floating-bar-functional.yaml
+++ b/desktop/macos/e2e/flows/floating-bar-functional.yaml
@@ -6,7 +6,9 @@ app: non-prod
 covers:
   - desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift
   - desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
+  - desktop/macos/Desktop/Sources/FloatingControlBar/PTTVoiceOutputCoordinator.swift
   - desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
+  - desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
 preconditions:
   - automation_bridge_ready
 

--- a/desktop/macos/e2e/flows/floating-bar-functional.yaml
+++ b/desktop/macos/e2e/flows/floating-bar-functional.yaml
@@ -9,6 +9,7 @@ covers:
   - desktop/macos/Desktop/Sources/FloatingControlBar/PTTVoiceOutputCoordinator.swift
   - desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
   - desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
+  - desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubTools.swift
 preconditions:
   - automation_bridge_ready
 

--- a/desktop/macos/scripts/agent-continuity-gauntlet-lib.py
+++ b/desktop/macos/scripts/agent-continuity-gauntlet-lib.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import ast
 import hashlib
 import http.client
 import json
@@ -539,6 +540,7 @@ class GauntletRunner:
         detail = send.get("result", {}).get("detail", {}) if isinstance(send, dict) else {}
         assistant = current_turn_assistant_text(snapshot, query)
         trace_matches = traces_for_query(traces, query)
+        trace_evidence = "\n".join(flatten_trace_text(trace) for trace in trace_matches)
         evidence = "\n".join(
             [
                 json.dumps(send, sort_keys=True, default=str),
@@ -549,7 +551,7 @@ class GauntletRunner:
                     if "error" in key.lower() and value
                 ),
                 assistant,
-                "\n".join(flatten_trace_text(trace) for trace in traces),
+                trace_evidence,
             ]
         )
         lower_evidence = evidence.lower()
@@ -1762,18 +1764,14 @@ def self_check() -> int:
         print("self-check failed: ChatProvider sign-out must call clearOwnerState()", file=sys.stderr)
         return 1
     driver_source = (SCRIPT_DIR / "agent-continuity-gauntlet-lib.py").read_text(encoding="utf-8")
-    required_driver_tokens = [
-        '"resilience"',
-        "def run_resilience_suite",
-        'if "resilience" in self.suites',
-        "resilience-diagnostics.jsonl",
-        "resilience_terminal_reason_counts",
-        "resilience_forbidden_terminal_reasons",
-        "skipped_missing_action",
-    ]
-    missing_driver_tokens = [token for token in required_driver_tokens if token not in driver_source]
-    if missing_driver_tokens:
-        print(f"self-check failed: resilience suite wiring missing {missing_driver_tokens}", file=sys.stderr)
+    try:
+        driver_tree = ast.parse(driver_source)
+    except SyntaxError as exc:
+        print(f"self-check failed: gauntlet driver syntax error: {exc}", file=sys.stderr)
+        return 1
+    missing_driver_checks = resilience_driver_self_check_failures(driver_tree)
+    if missing_driver_checks:
+        print(f"self-check failed: resilience suite wiring missing {missing_driver_checks}", file=sys.stderr)
         return 1
     owner_ok, owner_detail = run_owner_switch_kernel_check()
     if not owner_ok:
@@ -1781,6 +1779,66 @@ def self_check() -> int:
         return 1
     print("self-check passed (owner-switch: kernel vitest + swap_test_owner action registered)")
     return 0
+
+
+def resilience_driver_self_check_failures(tree: ast.Module) -> list[str]:
+    """Validate resilience wiring structurally instead of matching self-contained token literals."""
+    failures: list[str] = []
+    runner = next(
+        (node for node in tree.body if isinstance(node, ast.ClassDef) and node.name == "GauntletRunner"),
+        None,
+    )
+    if runner is None:
+        return ["GauntletRunner"]
+    methods = {node.name: node for node in runner.body if isinstance(node, ast.FunctionDef)}
+    for required in ("run_resilience_suite", "classify_resilience_turn", "record_resilience_diagnostic", "finalize"):
+        if required not in methods:
+            failures.append(f"GauntletRunner.{required}")
+
+    run_method = methods.get("run")
+    if run_method is None or not any(
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "run_resilience_suite"
+        for node in ast.walk(run_method)
+    ):
+        failures.append("run() dispatches run_resilience_suite")
+
+    record_method = methods.get("record_resilience_diagnostic")
+    if record_method is None or not any(
+        isinstance(node, ast.Constant) and node.value == "resilience-diagnostics.jsonl"
+        for node in ast.walk(record_method)
+    ):
+        failures.append("record_resilience_diagnostic appends resilience-diagnostics.jsonl")
+
+    finalize_method = methods.get("finalize")
+    if finalize_method is None or not all(
+        any(isinstance(node, ast.Constant) and node.value == key for node in ast.walk(finalize_method))
+        for key in ("resilience_terminal_reason_counts", "resilience_forbidden_terminal_reasons")
+    ):
+        failures.append("finalize writes resilience manifest fields")
+
+    constants = {
+        node.targets[0].id: node.value
+        for node in tree.body
+        if isinstance(node, ast.Assign)
+        and len(node.targets) == 1
+        and isinstance(node.targets[0], ast.Name)
+    }
+    suite_names = constants.get("SUITE_NAMES")
+    if not (
+        isinstance(suite_names, ast.Set)
+        and any(isinstance(item, ast.Constant) and item.value == "resilience" for item in suite_names.elts)
+    ):
+        failures.append("SUITE_NAMES includes resilience")
+    forbidden = constants.get("RESILIENCE_FORBIDDEN_TERMINAL_REASONS")
+    if not (
+        isinstance(forbidden, ast.Set)
+        and any(isinstance(item, ast.Constant) and item.value == "skipped_missing_action" for item in forbidden.elts)
+    ):
+        failures.append("skipped_missing_action is forbidden")
+
+    return failures
 
 
 SUITE_ALIASES: dict[str, set[str]] = {

--- a/desktop/macos/scripts/agent-continuity-gauntlet-lib.py
+++ b/desktop/macos/scripts/agent-continuity-gauntlet-lib.py
@@ -33,6 +33,29 @@ TRACE_LOG = Path.home() / "Library/Logs/Omi/traces.jsonl"
 DEFAULT_BUNDLE_SUFFIX = "omi-gauntlet"
 GAUNTLET_ROOT = DESKTOP_DIR / ".harness/agent-continuity-gauntlet"
 PRUNE_ABORTED_BUNDLE_DAYS = 7
+RESILIENCE_DIAGNOSTIC_SCHEMA_VERSION = 1
+RESILIENCE_FORBIDDEN_TERMINAL_REASONS = {
+    "bridge_launch_error",
+    "generic_chat_error",
+    "no_assistant_response",
+    "no_query_trace",
+    "response_already_running",
+    "response_stopped",
+    "skipped_missing_action",
+    "skipped_unimplemented_action",
+    "subagent_missing",
+    "subagent_status_invisible",
+}
+RESILIENCE_GENERIC_CHAT_PATTERNS = {
+    "AI not available",
+    "AI is not running",
+    "AI stopped unexpectedly",
+    "AI took too long to respond",
+    "A response is already running for this chat",
+    "Response stopped",
+    "requestAlreadyActive",
+    "response_already_running",
+}
 
 
 def now_iso() -> str:
@@ -333,6 +356,49 @@ def latest_assistant_text(snapshot_detail: dict[str, str]) -> str:
     return ""
 
 
+def current_turn_snapshot_text(snapshot_detail: dict[str, str], query_text: str) -> str:
+    try:
+        messages = json.loads(snapshot_detail.get("messages_json", "[]"))
+    except json.JSONDecodeError:
+        return ""
+    if not isinstance(messages, list):
+        return ""
+    query = query_text.strip()
+    start_index: int | None = None
+    for index, message in enumerate(messages):
+        if not isinstance(message, dict):
+            continue
+        if message.get("role") == "user" and str(message.get("text") or "").strip() == query:
+            start_index = index
+    if start_index is None:
+        return ""
+    return json.dumps(messages[start_index:], sort_keys=True)
+
+
+def current_turn_assistant_text(snapshot_detail: dict[str, str], query_text: str) -> str:
+    try:
+        messages = json.loads(snapshot_detail.get("messages_json", "[]"))
+    except json.JSONDecodeError:
+        return ""
+    if not isinstance(messages, list):
+        return ""
+    query = query_text.strip()
+    start_index: int | None = None
+    for index, message in enumerate(messages):
+        if not isinstance(message, dict):
+            continue
+        if message.get("role") == "user" and str(message.get("text") or "").strip() == query:
+            start_index = index
+    if start_index is None:
+        return ""
+    for message in reversed(messages[start_index:]):
+        if isinstance(message, dict) and message.get("role") == "assistant" and message.get("streaming") != "true":
+            text = (message.get("text") or "").strip()
+            if text:
+                return text
+    return ""
+
+
 def kernel_surface_identity(database_path: str, owner_id: str) -> dict[str, str] | None:
     """Read kernel-owned main_chat identity from omi-agentd.sqlite3."""
     if not owner_id or not database_path or not Path(database_path).is_file():
@@ -425,6 +491,7 @@ class GauntletRunner:
         self.failures: list[str] = []
         self.warnings: list[str] = []
         self.steps: list[dict[str, Any]] = []
+        self.resilience_terminal_reason_counts: dict[str, int] = {}
         self.pcm_path = self.run_dir / "fixtures" / "ptt-voice.pcm"
 
     def bridge_act(self, name: str, params: dict[str, str] | None = None) -> dict[str, Any]:
@@ -435,6 +502,90 @@ class GauntletRunner:
 
     def warn(self, message: str) -> None:
         self.warnings.append(message)
+
+    def record_resilience_diagnostic(
+        self,
+        scenario: str,
+        iteration: int,
+        terminal_reason: str,
+        detail: dict[str, Any] | None = None,
+    ) -> None:
+        record = {
+            "schema_version": RESILIENCE_DIAGNOSTIC_SCHEMA_VERSION,
+            "run_id": self.run_id,
+            "scenario": scenario,
+            "iteration": iteration,
+            "terminal_reason": terminal_reason,
+            "detail": detail or {},
+        }
+        append_text(self.run_dir / "resilience-diagnostics.jsonl", json.dumps(record, sort_keys=True) + "\n")
+        self.resilience_terminal_reason_counts[terminal_reason] = (
+            self.resilience_terminal_reason_counts.get(terminal_reason, 0) + 1
+        )
+        if terminal_reason in RESILIENCE_FORBIDDEN_TERMINAL_REASONS:
+            self.fail(f"{scenario} iteration {iteration}: forbidden terminal reason {terminal_reason}")
+
+    def classify_resilience_turn(
+        self,
+        *,
+        scenario: str,
+        iteration: int,
+        query: str,
+        send: dict[str, Any],
+        snapshot: dict[str, str],
+        traces: list[dict[str, Any]],
+        require_trace: bool = True,
+    ) -> str:
+        detail = send.get("result", {}).get("detail", {}) if isinstance(send, dict) else {}
+        assistant = current_turn_assistant_text(snapshot, query)
+        trace_matches = traces_for_query(traces, query)
+        evidence = "\n".join(
+            [
+                json.dumps(send, sort_keys=True, default=str),
+                current_turn_snapshot_text(snapshot, query),
+                "\n".join(
+                    str(value)
+                    for key, value in snapshot.items()
+                    if "error" in key.lower() and value
+                ),
+                assistant,
+                "\n".join(flatten_trace_text(trace) for trace in traces),
+            ]
+        )
+        lower_evidence = evidence.lower()
+        terminal_reason = "passed"
+        if send.get("ok") is False or detail.get("error"):
+            message = str(detail.get("error", send.get("error", send)))
+            if "failed to start agent bridge" in message.lower() or "ai not available" in message.lower():
+                terminal_reason = "bridge_launch_error"
+            elif "already running" in message.lower() or "already_active" in message.lower():
+                terminal_reason = "response_already_running"
+            else:
+                terminal_reason = "generic_chat_error"
+        elif "response_already_running" in lower_evidence or "a response is already running" in lower_evidence:
+            terminal_reason = "response_already_running"
+        elif "response stopped" in lower_evidence:
+            terminal_reason = "response_stopped"
+        elif any(pattern.lower() in lower_evidence for pattern in RESILIENCE_GENERIC_CHAT_PATTERNS):
+            terminal_reason = "generic_chat_error"
+        elif not assistant:
+            terminal_reason = "no_assistant_response"
+        elif require_trace and not trace_matches:
+            terminal_reason = "no_query_trace"
+
+        self.record_resilience_diagnostic(
+            scenario,
+            iteration,
+            terminal_reason,
+            {
+                "assistant_chars": len(assistant),
+                "query_trace_count": len(trace_matches),
+                "trace_count": len(traces),
+                "send_ok": send.get("ok"),
+                "send_detail": detail,
+            },
+        )
+        return terminal_reason
 
     def ensure_bridge(self) -> None:
         health = bridge_request(self.port, "GET", "/health")
@@ -615,6 +766,40 @@ class GauntletRunner:
         traces = read_new_traces(trace_start)
         return send, snapshot_detail, traces
 
+    def send_and_wait_resilience(
+        self,
+        query: str,
+        timeout_ms: int,
+    ) -> tuple[dict[str, Any], dict[str, str], list[dict[str, Any]]]:
+        """Main-chat send path for resilience probes; capture failures instead of aborting."""
+        trace_start = trace_line_count()
+        send = self.bridge_act("ask_main_chat", {"query": query})
+        detail = send.get("result", {}).get("detail", {}) if isinstance(send, dict) else {}
+        if send.get("ok") is False or detail.get("error"):
+            snapshot = self.bridge_act("main_chat_snapshot", {"limit": "80"})
+            snapshot_detail = snapshot.get("result", {}).get("detail", {})
+            return send, snapshot_detail, read_new_traces(trace_start)
+
+        deadline = time.monotonic() + (timeout_ms / 1000.0)
+        snapshot_detail: dict[str, str] = {}
+        while time.monotonic() < deadline:
+            wait = bridge_action(
+                self.port,
+                "wait_main_chat_idle",
+                {"timeoutMs": "2000", "pollMs": "250"},
+            )
+            snapshot_detail = wait.get("result", {}).get("detail", {})
+            if wait.get("ok") and snapshot_detail.get("idle") == "true":
+                break
+            time.sleep(0.25)
+        else:
+            self.fail(f"timed out waiting for resilience main chat idle after query: {query[:120]}")
+
+        snapshot = self.bridge_act("main_chat_snapshot", {"limit": "80"})
+        snapshot_detail = snapshot.get("result", {}).get("detail", snapshot_detail)
+        traces = read_new_traces(trace_start)
+        return send, snapshot_detail, traces
+
     def assert_trace_contains(self, traces: list[dict[str, Any]], needle: str, label: str) -> None:
         haystack = "\n".join(flatten_trace_text(trace) for trace in traces)
         if needle not in haystack:
@@ -715,6 +900,8 @@ class GauntletRunner:
             self.run_agents_suite()
         if "prompts" in self.suites:
             self.run_prompts_suite()
+        if "resilience" in self.suites:
+            self.run_resilience_suite()
         if "owner" in self.suites:
             self.run_owner_suite()
 
@@ -1276,9 +1463,235 @@ class GauntletRunner:
         if len(assistant) > 450:
             self.warn(f"P3 register: unknown-person reply too long ({len(assistant)} chars)")
 
+    def run_resilience_suite(self) -> None:
+        """Startup/bad-state probes for bridge, main chat, and subagent launch continuity.
+
+        Run with --suite resilience for release-candidate startup QA; --suite all
+        includes this suite alongside the canonical continuity, agents, owner, and
+        prompt checks.
+        """
+        self.manifest["resilience_forbidden_terminal_reasons"] = sorted(
+            RESILIENCE_FORBIDDEN_TERMINAL_REASONS
+        )
+
+        # R1 — cold/simple bridge launch probe. ask_main_chat goes through the
+        # real agent bridge and QueryTracer; it is safe for a named non-prod bundle
+        # and avoids process restarts or destructive simulation.
+        r1_query = (
+            f"Resilience startup probe {self.run_id}. "
+            "Reply with exactly: RESILIENCE_BRIDGE_READY"
+        )
+        send, snapshot, traces = self.send_and_wait_resilience(r1_query, self.args.turn_timeout_ms)
+        r1_reason = self.classify_resilience_turn(
+            scenario="R1-cold-simple-bridge-launch",
+            iteration=1,
+            query=r1_query,
+            send=send,
+            snapshot=snapshot,
+            traces=traces,
+        )
+        self.record_step(
+            "r1-cold-bridge-launch",
+            "resilience: cold/simple bridge launch probe",
+            user_text=r1_query,
+            action_response=send,
+            snapshot_detail=snapshot,
+            traces=traces,
+            extra={"terminal_reason": r1_reason},
+        )
+        self.assert_assistant_mentions(latest_assistant_text(snapshot), ["RESILIENCE_BRIDGE_READY"], "R1 bridge launch")
+
+        # R2 — warm reuse probe. Sequential short prompts must settle cleanly and
+        # must not surface already-running or generic stopped-response text.
+        for index in range(1, 4):
+            query = f"Warm reuse probe {index}. Reply with exactly WARM_REUSE_{index}."
+            send, snapshot, traces = self.send_and_wait_resilience(query, self.args.turn_timeout_ms)
+            terminal_reason = self.classify_resilience_turn(
+                scenario="R2-warm-reuse",
+                iteration=index,
+                query=query,
+                send=send,
+                snapshot=snapshot,
+                traces=traces,
+            )
+            self.record_step(
+                f"r2-warm-reuse-{index}",
+                f"resilience: warm reuse probe {index}",
+                user_text=query,
+                action_response=send,
+                snapshot_detail=snapshot,
+                traces=traces,
+                extra={"terminal_reason": terminal_reason},
+            )
+            self.assert_assistant_mentions(
+                latest_assistant_text(snapshot),
+                [f"WARM_REUSE_{index}"],
+                f"R2 warm reuse {index}",
+            )
+
+        # R3 — already-running/race policy. The current bridge only exposes a
+        # blocking ask_main_chat plus wait_main_chat_idle; without a non-waiting
+        # send or explicit busy-state action, racing it would require risky UI or
+        # process manipulation. Record the missing contract instead of faking pass.
+        bridge_source = (DESKTOP_DIR / "Desktop/Sources/DesktopAutomationBridge.swift").read_text(encoding="utf-8")
+        race_actions = {"ask_main_chat_no_wait", "main_chat_busy_state"}
+        present = sorted(name for name in race_actions if f'name: "{name}"' in bridge_source)
+        if not present:
+            missing = sorted(race_actions)
+            message = (
+                "R3 already-running/race policy skipped: missing bridge action(s) "
+                f"{missing}; need non-waiting send or explicit busy-state check"
+            )
+            self.warn(message)
+            self.record_resilience_diagnostic(
+                "R3-already-running-race-policy",
+                1,
+                "skipped_missing_action",
+                {"missing_bridge_actions": missing},
+            )
+        else:
+            self.warn(
+                "R3 already-running/race policy has candidate bridge action(s) "
+                f"{present}, but no safe gauntlet implementation is wired yet"
+            )
+            self.record_resilience_diagnostic(
+                "R3-already-running-race-policy",
+                1,
+                "skipped_unimplemented_action",
+                {"present_bridge_actions": present},
+            )
+
+        # R4 — subagent launch cold/resilience probe. This is stricter than the
+        # agents suite because it records terminal reasons and requires runtime,
+        # coordinator/pill projection, spawn tool evidence, and status visibility.
+        marker = f"RESILIENCE-SUBAGENT-{self.run_id}-{secrets.token_hex(3).upper()}"
+        spawn_query = (
+            "Use spawn_agent now to start a visible background agent. "
+            f"Objective: acknowledge resilience marker {marker} and then wait. "
+            "Do not ask follow-up questions."
+        )
+        trace_start = trace_line_count()
+        send, snapshot, traces = self.send_and_wait_resilience(spawn_query, self.args.turn_timeout_ms)
+        spawn_tools: list[dict[str, Any]] = []
+        settle_deadline = time.monotonic() + 10.0
+        while time.monotonic() < settle_deadline:
+            traces = read_new_traces(trace_start)
+            spawn_tools = [
+                tool
+                for tool in trace_tool_executions(traces, {"spawn_agent"})
+                if marker in str(tool.get("input", "")) or marker in str(tool.get("output", ""))
+            ]
+            if spawn_tools:
+                break
+            time.sleep(0.25)
+        coordinator = self.bridge_act("coordinator_awareness_snapshot")
+        coordinator_detail = coordinator.get("result", {}).get("detail", {})
+        runtime = self.bridge_act("agent_runtime_evidence")
+        runtime_detail = runtime.get("result", {}).get("detail", {})
+        terminal_reason = self.classify_resilience_turn(
+            scenario="R4-subagent-launch",
+            iteration=1,
+            query=spawn_query,
+            send=send,
+            snapshot=snapshot,
+            traces=traces,
+        )
+        if not spawn_tools:
+            terminal_reason = "subagent_missing"
+            self.record_resilience_diagnostic(
+                "R4-subagent-launch",
+                2,
+                terminal_reason,
+                {
+                    "spawn_tool_calls": 0,
+                    "coordinator_snapshot_chars": len(str(coordinator_detail.get("snapshot", ""))),
+                    "database_exists": runtime_detail.get("database_exists"),
+                },
+            )
+            self.fail("R4 subagent launch: no spawn_agent execution carrying the resilience marker")
+        if runtime.get("ok") is False or runtime_detail.get("error") or runtime_detail.get("database_exists") != "true":
+            self.record_resilience_diagnostic(
+                "R4-subagent-launch",
+                3,
+                "runtime_evidence_missing",
+                {"runtime_detail": runtime_detail},
+            )
+            self.fail("R4 subagent launch: runtime sqlite evidence missing")
+        if marker not in str(coordinator_detail):
+            self.record_resilience_diagnostic(
+                "R4-subagent-launch",
+                4,
+                "pill_runtime_evidence_missing",
+                {"coordinator_snapshot_chars": len(str(coordinator_detail.get("snapshot", "")))},
+            )
+            self.fail("R4 subagent launch: coordinator/pill evidence missing resilience marker")
+        self.record_step(
+            "r4-subagent-launch",
+            "resilience: subagent launch cold probe",
+            user_text=spawn_query,
+            action_response=send,
+            snapshot_detail=snapshot,
+            traces=traces,
+            extra={
+                "terminal_reason": terminal_reason,
+                "spawn_tool_calls": spawn_tools,
+                "coordinator_snapshot": coordinator_detail,
+                "runtime_evidence": runtime_detail,
+            },
+        )
+
+        status_query = (
+            "What is the status of the background agent you just started? "
+            "Use list_agent_sessions and include its exact resilience marker."
+        )
+        send, snapshot, traces = self.send_and_wait_resilience(status_query, self.args.turn_timeout_ms)
+        terminal_reason = self.classify_resilience_turn(
+            scenario="R4-subagent-status",
+            iteration=1,
+            query=status_query,
+            send=send,
+            snapshot=snapshot,
+            traces=traces,
+        )
+        assistant = latest_assistant_text(snapshot)
+        list_tools = trace_tool_executions(traces, {"list_agent_sessions"})
+        list_outputs = "\n".join(str(tool.get("output", "")) for tool in list_tools)
+        if not list_tools or marker not in (assistant + "\n" + list_outputs):
+            terminal_reason = "subagent_status_invisible"
+            self.record_resilience_diagnostic(
+                "R4-subagent-status",
+                2,
+                terminal_reason,
+                {
+                    "list_agent_sessions_calls": len(list_tools),
+                    "assistant_chars": len(assistant),
+                    "marker_in_tool_output": marker in list_outputs,
+                },
+            )
+            self.fail("R4 subagent status: status query could not see the spawned resilience agent")
+        self.record_step(
+            "r4-subagent-status",
+            "resilience: subagent status query",
+            user_text=status_query,
+            action_response=send,
+            snapshot_detail=snapshot,
+            traces=traces,
+            extra={
+                "terminal_reason": terminal_reason,
+                "list_agent_sessions_calls": list_tools,
+            },
+        )
+
     def finalize(self) -> int:
         manifest = self.manifest
         manifest["finished_at"] = datetime.now(timezone.utc).isoformat()
+        if "resilience" in self.suites:
+            manifest["resilience_terminal_reason_counts"] = dict(
+                sorted(self.resilience_terminal_reason_counts.items())
+            )
+            manifest["resilience_forbidden_terminal_reasons"] = sorted(
+                RESILIENCE_FORBIDDEN_TERMINAL_REASONS
+            )
         manifest["steps"] = self.steps
         manifest["failures"] = self.failures
         manifest["warnings"] = self.warnings
@@ -1320,12 +1733,14 @@ def run_owner_switch_kernel_check() -> tuple[bool, str]:
 def self_check() -> int:
     script = SCRIPT_DIR / "agent-continuity-gauntlet.sh"
     bridge_actions = {
+        "ask",
         "ask_main_chat",
         "main_chat_snapshot",
         "wait_main_chat_idle",
         "agent_runtime_evidence",
         "coordinator_awareness_snapshot",
         "swap_test_owner",
+        "restore_test_owner",
         "clear_owner_surface_state",
         "kernel_turn_tail",
     }
@@ -1346,6 +1761,20 @@ def self_check() -> int:
     if "clearOwnerState()" not in source:
         print("self-check failed: ChatProvider sign-out must call clearOwnerState()", file=sys.stderr)
         return 1
+    driver_source = (SCRIPT_DIR / "agent-continuity-gauntlet-lib.py").read_text(encoding="utf-8")
+    required_driver_tokens = [
+        '"resilience"',
+        "def run_resilience_suite",
+        'if "resilience" in self.suites',
+        "resilience-diagnostics.jsonl",
+        "resilience_terminal_reason_counts",
+        "resilience_forbidden_terminal_reasons",
+        "skipped_missing_action",
+    ]
+    missing_driver_tokens = [token for token in required_driver_tokens if token not in driver_source]
+    if missing_driver_tokens:
+        print(f"self-check failed: resilience suite wiring missing {missing_driver_tokens}", file=sys.stderr)
+        return 1
     owner_ok, owner_detail = run_owner_switch_kernel_check()
     if not owner_ok:
         print(f"self-check failed: owner-switch kernel check: {owner_detail}", file=sys.stderr)
@@ -1356,9 +1785,9 @@ def self_check() -> int:
 
 SUITE_ALIASES: dict[str, set[str]] = {
     "core": {"continuity", "agents", "owner"},
-    "all": {"continuity", "agents", "owner", "prompts"},
+    "all": {"continuity", "agents", "owner", "prompts", "resilience"},
 }
-SUITE_NAMES = {"continuity", "agents", "owner", "prompts"}
+SUITE_NAMES = {"continuity", "agents", "owner", "prompts", "resilience"}
 
 
 def expand_suites(raw: str) -> set[str]:
@@ -1392,8 +1821,9 @@ def parse_args() -> argparse.Namespace:
         help=(
             "Comma-separated suites: continuity (steps 1-3, includes PTT), agents (4-5), "
             "owner (6), prompts (fast typed-only prompt-regression probes), "
-            "core (default: continuity+agents+owner), all (core+prompts). "
-            "Example: --suite prompts for fast prompt iteration."
+            "resilience (startup/bad-state bridge + subagent probes), "
+            "core (default: continuity+agents+owner), all (core+prompts+resilience). "
+            "Example: --suite resilience for release-candidate startup QA."
         ),
     )
     parser.add_argument("--self-check", action="store_true")

--- a/desktop/macos/scripts/agent-continuity-gauntlet-lib.py
+++ b/desktop/macos/scripts/agent-continuity-gauntlet-lib.py
@@ -540,7 +540,6 @@ class GauntletRunner:
         detail = send.get("result", {}).get("detail", {}) if isinstance(send, dict) else {}
         assistant = current_turn_assistant_text(snapshot, query)
         trace_matches = traces_for_query(traces, query)
-        trace_evidence = "\n".join(flatten_trace_text(trace) for trace in trace_matches)
         evidence = "\n".join(
             [
                 json.dumps(send, sort_keys=True, default=str),
@@ -551,7 +550,7 @@ class GauntletRunner:
                     if "error" in key.lower() and value
                 ),
                 assistant,
-                trace_evidence,
+                "\n".join(flatten_trace_text(trace) for trace in trace_matches),
             ]
         )
         lower_evidence = evidence.lower()
@@ -1764,12 +1763,7 @@ def self_check() -> int:
         print("self-check failed: ChatProvider sign-out must call clearOwnerState()", file=sys.stderr)
         return 1
     driver_source = (SCRIPT_DIR / "agent-continuity-gauntlet-lib.py").read_text(encoding="utf-8")
-    try:
-        driver_tree = ast.parse(driver_source)
-    except SyntaxError as exc:
-        print(f"self-check failed: gauntlet driver syntax error: {exc}", file=sys.stderr)
-        return 1
-    missing_driver_checks = resilience_driver_self_check_failures(driver_tree)
+    missing_driver_checks = resilience_driver_self_check_failures(driver_source)
     if missing_driver_checks:
         print(f"self-check failed: resilience suite wiring missing {missing_driver_checks}", file=sys.stderr)
         return 1
@@ -1781,64 +1775,104 @@ def self_check() -> int:
     return 0
 
 
-def resilience_driver_self_check_failures(tree: ast.Module) -> list[str]:
-    """Validate resilience wiring structurally instead of matching self-contained token literals."""
+def resilience_driver_self_check_failures(driver_source: str) -> list[str]:
+    tree = ast.parse(driver_source)
     failures: list[str] = []
     runner = next(
-        (node for node in tree.body if isinstance(node, ast.ClassDef) and node.name == "GauntletRunner"),
+        (
+            node
+            for node in tree.body
+            if isinstance(node, ast.ClassDef) and node.name == "GauntletRunner"
+        ),
         None,
     )
     if runner is None:
-        return ["GauntletRunner"]
-    methods = {node.name: node for node in runner.body if isinstance(node, ast.FunctionDef)}
-    for required in ("run_resilience_suite", "classify_resilience_turn", "record_resilience_diagnostic", "finalize"):
-        if required not in methods:
-            failures.append(f"GauntletRunner.{required}")
+        return ["GauntletRunner class"]
 
-    run_method = methods.get("run")
-    if run_method is None or not any(
-        isinstance(node, ast.Call)
-        and isinstance(node.func, ast.Attribute)
-        and node.func.attr == "run_resilience_suite"
-        for node in ast.walk(run_method)
-    ):
-        failures.append("run() dispatches run_resilience_suite")
-
-    record_method = methods.get("record_resilience_diagnostic")
-    if record_method is None or not any(
-        isinstance(node, ast.Constant) and node.value == "resilience-diagnostics.jsonl"
-        for node in ast.walk(record_method)
-    ):
-        failures.append("record_resilience_diagnostic appends resilience-diagnostics.jsonl")
-
-    finalize_method = methods.get("finalize")
-    if finalize_method is None or not all(
-        any(isinstance(node, ast.Constant) and node.value == key for node in ast.walk(finalize_method))
-        for key in ("resilience_terminal_reason_counts", "resilience_forbidden_terminal_reasons")
-    ):
-        failures.append("finalize writes resilience manifest fields")
-
-    constants = {
-        node.targets[0].id: node.value
-        for node in tree.body
-        if isinstance(node, ast.Assign)
-        and len(node.targets) == 1
-        and isinstance(node.targets[0], ast.Name)
+    methods = {
+        node.name: node
+        for node in runner.body
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
     }
-    suite_names = constants.get("SUITE_NAMES")
-    if not (
-        isinstance(suite_names, ast.Set)
-        and any(isinstance(item, ast.Constant) and item.value == "resilience" for item in suite_names.elts)
+    for method_name in (
+        "record_resilience_diagnostic",
+        "run_resilience_suite",
+        "finalize",
+        "run",
     ):
-        failures.append("SUITE_NAMES includes resilience")
-    forbidden = constants.get("RESILIENCE_FORBIDDEN_TERMINAL_REASONS")
-    if not (
-        isinstance(forbidden, ast.Set)
-        and any(isinstance(item, ast.Constant) and item.value == "skipped_missing_action" for item in forbidden.elts)
-    ):
-        failures.append("skipped_missing_action is forbidden")
+        if method_name not in methods:
+            failures.append(f"GauntletRunner.{method_name}")
 
+    if "resilience" not in ast_literal_set(tree, "SUITE_NAMES"):
+        failures.append("SUITE_NAMES includes resilience")
+    if "resilience" not in ast_literal_set(tree, "SUITE_ALIASES", key="all"):
+        failures.append("SUITE_ALIASES['all'] includes resilience")
+    if not method_contains_string(methods.get("record_resilience_diagnostic"), "resilience-diagnostics.jsonl"):
+        failures.append("record_resilience_diagnostic writes resilience-diagnostics.jsonl")
+    if not method_contains_string(methods.get("run_resilience_suite"), "skipped_missing_action"):
+        failures.append("run_resilience_suite can record skipped_missing_action")
+    if not method_contains_attr(methods.get("record_resilience_diagnostic"), "resilience_terminal_reason_counts"):
+        failures.append("record_resilience_diagnostic updates resilience_terminal_reason_counts")
+    if not method_contains_attr(methods.get("finalize"), "resilience_terminal_reason_counts"):
+        failures.append("finalize emits resilience_terminal_reason_counts")
+    if not method_contains_string(methods.get("finalize"), "resilience_forbidden_terminal_reasons"):
+        failures.append("finalize emits resilience_forbidden_terminal_reasons")
+    if not method_calls(methods.get("run"), "run_resilience_suite"):
+        failures.append("run dispatches run_resilience_suite")
     return failures
+
+
+def ast_literal_set(tree: ast.Module, name: str, *, key: str | None = None) -> set[str]:
+    for node in tree.body:
+        if isinstance(node, ast.Assign):
+            if not any(isinstance(target, ast.Name) and target.id == name for target in node.targets):
+                continue
+            value = node.value
+        elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name) and node.target.id == name:
+            value = node.value
+            if value is None:
+                return set()
+        else:
+            continue
+        if key is not None:
+            if not isinstance(value, ast.Dict):
+                return set()
+            for dict_key, dict_value in zip(value.keys, value.values):
+                if isinstance(dict_key, ast.Constant) and dict_key.value == key:
+                    value = dict_value
+                    break
+            else:
+                return set()
+        if isinstance(value, (ast.Set, ast.List, ast.Tuple)):
+            return {
+                item.value
+                for item in value.elts
+                if isinstance(item, ast.Constant) and isinstance(item.value, str)
+            }
+    return set()
+
+
+def method_contains_string(node: ast.AST | None, text: str) -> bool:
+    return node is not None and any(
+        isinstance(child, ast.Constant) and child.value == text
+        for child in ast.walk(node)
+    )
+
+
+def method_contains_attr(node: ast.AST | None, name: str) -> bool:
+    return node is not None and any(
+        isinstance(child, ast.Attribute) and child.attr == name
+        for child in ast.walk(node)
+    )
+
+
+def method_calls(node: ast.AST | None, method_name: str) -> bool:
+    return node is not None and any(
+        isinstance(child, ast.Call)
+        and isinstance(child.func, ast.Attribute)
+        and child.func.attr == method_name
+        for child in ast.walk(node)
+    )
 
 
 SUITE_ALIASES: dict[str, set[str]] = {

--- a/desktop/macos/scripts/agent-continuity-gauntlet.sh
+++ b/desktop/macos/scripts/agent-continuity-gauntlet.sh
@@ -9,6 +9,7 @@
 #   4. background agent spawn (spawn_agent)
 #   5. status query about that spawned agent
 #   7. floating pill spawn → cross-surface blind recall (PTT + typed)
+#   R. optional resilience suite: startup/bad-state bridge + subagent probes
 #
 # Repeated runs on one bundle pollute model-visible history even though R8 per-run
 # nonces protect harness assertions. Step 0 clears kernel turns via the real bridge.
@@ -29,9 +30,13 @@
 #   ./scripts/agent-continuity-gauntlet.sh --self-check          # validate hooks only
 #   ./scripts/agent-continuity-gauntlet.sh --suite prompts       # fast typed-only prompt probes (P1-P3)
 #   ./scripts/agent-continuity-gauntlet.sh --suite continuity    # steps 1-3 only (includes PTT)
-#   ./scripts/agent-continuity-gauntlet.sh --suite all           # core 6 steps + prompt probes
+#   ./scripts/agent-continuity-gauntlet.sh --suite resilience    # startup/resilience probes (R1-R4)
+#   ./scripts/agent-continuity-gauntlet.sh --suite all           # core + prompt + resilience probes
 #   OMI_AUTOMATION_PORT=47778 ./scripts/agent-continuity-gauntlet.sh --bundle-id com.omi.omi-gauntlet
 #   ./scripts/agent-continuity-gauntlet.sh --turn-timeout-ms 240000
+#
+# Release-candidate manual QA: run --suite resilience first for startup edges,
+# then --suite all for the full canonical continuity + resilience pass.
 #
 # Also run via:
 #   ./scripts/agent-logic-harness.sh --with-gauntlet

--- a/desktop/macos/scripts/stress_ptt_chat.py
+++ b/desktop/macos/scripts/stress_ptt_chat.py
@@ -9,6 +9,7 @@ does not launch, restart, kill, or discover any Omi app bundle.
 from __future__ import annotations
 
 import argparse
+import ipaddress
 import json
 import os
 import sys
@@ -77,6 +78,8 @@ def load_jsonl(path: Path) -> list[dict[str, Any]]:
             event = json.loads(line)
         except json.JSONDecodeError as exc:
             raise StressValidationError(f"{path}:{line_number}: invalid JSON: {exc.msg}") from exc
+        if not isinstance(event, dict):
+            raise StressValidationError(f"{path}:{line_number}: event must be an object")
         validate_event(event, f"{path}:{line_number}")
         events.append(event)
     return events
@@ -86,14 +89,26 @@ def validate_event(event: dict[str, Any], where: str) -> None:
     for key in ("run_id", "iteration", "scenario", "terminal_reason", "timestamp"):
         if key not in event:
             raise StressValidationError(f"{where}: missing required field {key}")
+    if not isinstance(event["run_id"], str) or not event["run_id"]:
+        raise StressValidationError(f"{where}: run_id must be a non-empty string")
+    if not isinstance(event["timestamp"], str) or not event["timestamp"]:
+        raise StressValidationError(f"{where}: timestamp must be a non-empty string")
+    if not isinstance(event["scenario"], str):
+        raise StressValidationError(f"{where}: scenario must be a string")
     if event["scenario"] not in SCENARIOS:
         raise StressValidationError(f"{where}: unknown scenario {event['scenario']!r}")
+    if not isinstance(event["terminal_reason"], str):
+        raise StressValidationError(f"{where}: terminal_reason must be a string")
     if event["terminal_reason"] not in TERMINAL_REASONS:
         raise StressValidationError(f"{where}: unknown terminal_reason {event['terminal_reason']!r}")
-    if not isinstance(event["iteration"], int) or event["iteration"] < 1:
+    if not isinstance(event["iteration"], int) or isinstance(event["iteration"], bool) or event["iteration"] < 1:
         raise StressValidationError(f"{where}: iteration must be a positive integer")
     if "duration_ms" in event and event["duration_ms"] is not None:
-        if not isinstance(event["duration_ms"], int) or event["duration_ms"] < 0:
+        if (
+            not isinstance(event["duration_ms"], int)
+            or isinstance(event["duration_ms"], bool)
+            or event["duration_ms"] < 0
+        ):
             raise StressValidationError(f"{where}: duration_ms must be a non-negative integer")
     if "details" in event and not isinstance(event["details"], dict):
         raise StressValidationError(f"{where}: details must be an object when present")
@@ -132,14 +147,14 @@ def terminal_from_bridge_response(scenario: str, payload: dict[str, Any]) -> str
     result = payload.get("result") if isinstance(payload.get("result"), dict) else {}
     detail = result.get("detail") if isinstance(result.get("detail"), dict) else {}
     explicit = detail.get("terminal_reason") or result.get("terminal_reason") or payload.get("terminal_reason")
-    if explicit in TERMINAL_REASONS:
-        return explicit
     if payload.get("ok") is False or detail.get("error") or payload.get("error"):
         if "already running" in text or "stuck run" in text or "response_already_running" in text:
             return "response_already_running"
         if "realtime_token_mint_failure" in text or "token mint" in text:
             return "realtime_token_mint_failure"
         return "bridge_launch_failure"
+    if explicit in TERMINAL_REASONS:
+        return explicit
     if "already running" in text or "stuck run" in text or "response_already_running" in text:
         return "response_already_running"
     if "realtime_token_mint_failure" in text or "token mint" in text:
@@ -158,7 +173,10 @@ def is_loopback_url(raw_url: str) -> bool:
         return False
     if hostname == "localhost" or hostname == "::1":
         return True
-    return hostname.startswith("127.")
+    try:
+        return ipaddress.ip_address(hostname).is_loopback
+    except ValueError:
+        return False
 
 
 def collect_from_bridge(base_url: str, token: str | None, scenarios: list[str], iterations: int) -> list[dict[str, Any]]:
@@ -167,12 +185,15 @@ def collect_from_bridge(base_url: str, token: str | None, scenarios: list[str], 
     try:
         request_json(base_url, token=None, method="GET", path="/health")
         actions_payload = request_json(base_url, token=token, method="GET", path="/actions")
+        actions = actions_payload.get("result", [])
+        if not isinstance(actions, list):
+            raise StressValidationError("automation /actions result must be a list")
         action_names = {
             item.get("name")
-            for item in actions_payload.get("result", [])
+            for item in actions
             if isinstance(item, dict)
         }
-    except (OSError, urllib.error.URLError, json.JSONDecodeError) as exc:
+    except (OSError, urllib.error.URLError, json.JSONDecodeError, StressValidationError) as exc:
         for iteration in range(1, iterations + 1):
             for scenario in scenarios:
                 events.append(make_event(run_id, iteration, scenario, "bridge_launch_failure", details={"error": str(exc)}))

--- a/desktop/macos/scripts/stress_ptt_chat.py
+++ b/desktop/macos/scripts/stress_ptt_chat.py
@@ -1,0 +1,297 @@
+#!/usr/bin/env python3
+"""Validate or collect PTT/realtime/chat stress diagnostics as JSONL.
+
+This harness is safe by default: offline validation only reads JSONL, and live
+mode only talks to a caller-supplied non-production automation bridge URL. It
+does not launch, restart, kill, or discover any Omi app bundle.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+import uuid
+from collections import Counter
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+SCENARIOS = {"ptt_voiced", "ptt_silent", "chat_bridge", "subagent_launch"}
+TERMINAL_REASONS = {
+    "ptt_voiced_success",
+    "ptt_silent_rejected",
+    "chat_bridge_success",
+    "subagent_launch_success",
+    "too_short_tap",
+    "audio_frames_missing",
+    "silent_audio",
+    "realtime_token_mint_failure",
+    "provider_fallback",
+    "bridge_launch_failure",
+    "response_already_running",
+}
+FORBIDDEN_TERMINAL_REASONS = {
+    "too_short_tap",
+    "audio_frames_missing",
+    "silent_audio",
+    "realtime_token_mint_failure",
+    "bridge_launch_failure",
+    "response_already_running",
+}
+ACTION_BY_SCENARIO = {
+    "ptt_voiced": "stress_ptt_voiced",
+    "ptt_silent": "stress_ptt_silent",
+    "chat_bridge": "stress_chat_bridge",
+    "subagent_launch": "stress_subagent_launch",
+}
+SUCCESS_REASON_BY_SCENARIO = {
+    "ptt_voiced": "ptt_voiced_success",
+    "ptt_silent": "ptt_silent_rejected",
+    "chat_bridge": "chat_bridge_success",
+    "subagent_launch": "subagent_launch_success",
+}
+
+
+class StressValidationError(Exception):
+    pass
+
+
+def timestamp() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="milliseconds").replace("+00:00", "Z")
+
+
+def load_jsonl(path: Path) -> list[dict[str, Any]]:
+    events: list[dict[str, Any]] = []
+    for line_number, raw_line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        line = raw_line.strip()
+        if not line:
+            continue
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise StressValidationError(f"{path}:{line_number}: invalid JSON: {exc.msg}") from exc
+        validate_event(event, f"{path}:{line_number}")
+        events.append(event)
+    return events
+
+
+def validate_event(event: dict[str, Any], where: str) -> None:
+    for key in ("run_id", "iteration", "scenario", "terminal_reason", "timestamp"):
+        if key not in event:
+            raise StressValidationError(f"{where}: missing required field {key}")
+    if event["scenario"] not in SCENARIOS:
+        raise StressValidationError(f"{where}: unknown scenario {event['scenario']!r}")
+    if event["terminal_reason"] not in TERMINAL_REASONS:
+        raise StressValidationError(f"{where}: unknown terminal_reason {event['terminal_reason']!r}")
+    if not isinstance(event["iteration"], int) or event["iteration"] < 1:
+        raise StressValidationError(f"{where}: iteration must be a positive integer")
+    if "duration_ms" in event and event["duration_ms"] is not None:
+        if not isinstance(event["duration_ms"], int) or event["duration_ms"] < 0:
+            raise StressValidationError(f"{where}: duration_ms must be a non-negative integer")
+    if "details" in event and not isinstance(event["details"], dict):
+        raise StressValidationError(f"{where}: details must be an object when present")
+
+
+def summarize(events: list[dict[str, Any]], required_scenarios: list[str] | None = None) -> dict[str, Any]:
+    terminal_counts = Counter(event["terminal_reason"] for event in events)
+    scenario_counts = Counter(event["scenario"] for event in events)
+    forbidden = sorted(reason for reason in FORBIDDEN_TERMINAL_REASONS if terminal_counts[reason] > 0)
+    missing_required = sorted(
+        scenario for scenario in set(required_scenarios or []) if scenario_counts[scenario] < 1
+    )
+    return {
+        "total_events": len(events),
+        "passed_release_gate": bool(events) and not forbidden and not missing_required,
+        "terminal_reason_counts": dict(sorted(terminal_counts.items())),
+        "scenario_counts": dict(sorted(scenario_counts.items())),
+        "forbidden_terminal_reasons": forbidden,
+        "missing_required_scenarios": missing_required,
+    }
+
+
+def request_json(base_url: str, token: str | None, method: str, path: str, body: dict[str, Any] | None = None) -> dict[str, Any]:
+    data = None if body is None else json.dumps(body).encode("utf-8")
+    headers = {"Content-Type": "application/json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    request = urllib.request.Request(base_url.rstrip("/") + path, data=data, headers=headers, method=method)
+    with urllib.request.urlopen(request, timeout=10) as response:
+        payload = response.read()
+    return json.loads(payload.decode("utf-8"))
+
+
+def terminal_from_bridge_response(scenario: str, payload: dict[str, Any]) -> str:
+    text = json.dumps(payload, sort_keys=True).lower()
+    result = payload.get("result") if isinstance(payload.get("result"), dict) else {}
+    detail = result.get("detail") if isinstance(result.get("detail"), dict) else {}
+    explicit = detail.get("terminal_reason") or result.get("terminal_reason") or payload.get("terminal_reason")
+    if explicit in TERMINAL_REASONS:
+        return explicit
+    if payload.get("ok") is False or detail.get("error") or payload.get("error"):
+        if "already running" in text or "stuck run" in text or "response_already_running" in text:
+            return "response_already_running"
+        if "realtime_token_mint_failure" in text or "token mint" in text:
+            return "realtime_token_mint_failure"
+        return "bridge_launch_failure"
+    if "already running" in text or "stuck run" in text or "response_already_running" in text:
+        return "response_already_running"
+    if "realtime_token_mint_failure" in text or "token mint" in text:
+        return "realtime_token_mint_failure"
+    if "provider_fallback" in text or "fallback" in text:
+        return "provider_fallback"
+    if explicit is not None:
+        return "bridge_launch_failure"
+    return SUCCESS_REASON_BY_SCENARIO[scenario]
+
+
+def is_loopback_url(raw_url: str) -> bool:
+    parsed = urllib.parse.urlparse(raw_url)
+    hostname = parsed.hostname
+    if hostname is None:
+        return False
+    if hostname == "localhost" or hostname == "::1":
+        return True
+    return hostname.startswith("127.")
+
+
+def collect_from_bridge(base_url: str, token: str | None, scenarios: list[str], iterations: int) -> list[dict[str, Any]]:
+    run_id = str(uuid.uuid4())
+    events: list[dict[str, Any]] = []
+    try:
+        request_json(base_url, token=None, method="GET", path="/health")
+        actions_payload = request_json(base_url, token=token, method="GET", path="/actions")
+        action_names = {
+            item.get("name")
+            for item in actions_payload.get("result", [])
+            if isinstance(item, dict)
+        }
+    except (OSError, urllib.error.URLError, json.JSONDecodeError) as exc:
+        for iteration in range(1, iterations + 1):
+            for scenario in scenarios:
+                events.append(make_event(run_id, iteration, scenario, "bridge_launch_failure", details={"error": str(exc)}))
+        return events
+
+    for iteration in range(1, iterations + 1):
+        for scenario in scenarios:
+            started = time.monotonic()
+            action = ACTION_BY_SCENARIO[scenario]
+            try:
+                if action not in action_names:
+                    raise StressValidationError(f"automation action {action!r} is not registered")
+                payload = request_json(base_url, token=token, method="POST", path="/action", body={"name": action})
+                reason = terminal_from_bridge_response(scenario, payload)
+                events.append(
+                    make_event(
+                        run_id,
+                        iteration,
+                        scenario,
+                        reason,
+                        duration_ms=int((time.monotonic() - started) * 1000),
+                    )
+                )
+            except (OSError, urllib.error.URLError, json.JSONDecodeError, StressValidationError) as exc:
+                events.append(
+                    make_event(
+                        run_id,
+                        iteration,
+                        scenario,
+                        "bridge_launch_failure",
+                        duration_ms=int((time.monotonic() - started) * 1000),
+                        details={"error": str(exc)},
+                    )
+                )
+    return events
+
+
+def make_event(
+    run_id: str,
+    iteration: int,
+    scenario: str,
+    terminal_reason: str,
+    duration_ms: int | None = None,
+    details: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    event: dict[str, Any] = {
+        "run_id": run_id,
+        "iteration": iteration,
+        "scenario": scenario,
+        "terminal_reason": terminal_reason,
+        "timestamp": timestamp(),
+        "details": details or {},
+    }
+    if duration_ms is not None:
+        event["duration_ms"] = duration_ms
+    validate_event(event, "generated")
+    return event
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input-jsonl", type=Path, help="Validate an exported/local stress JSONL file")
+    parser.add_argument("--base-url", help="Optional already-running non-production automation bridge URL")
+    parser.add_argument("--token", help="Automation bridge bearer token; defaults to OMI_AUTOMATION_TOKEN")
+    parser.add_argument(
+        "--allow-remote-token",
+        action="store_true",
+        help="Allow sending an automation token to a non-loopback --base-url",
+    )
+    parser.add_argument("--iterations", type=int, default=1)
+    parser.add_argument(
+        "--scenario",
+        action="append",
+        choices=sorted(SCENARIOS),
+        help="Scenario to run; repeatable. Defaults to ptt_voiced when --base-url is used.",
+    )
+    parser.add_argument("--emit-jsonl", action="store_true", help="Print collected live events before the summary")
+    parser.add_argument(
+        "--require-scenario",
+        action="append",
+        choices=sorted(SCENARIOS),
+        help="Require at least one event for this scenario before the release gate passes. Repeatable.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    if args.iterations < 1:
+        raise StressValidationError("--iterations must be positive")
+    if not args.input_jsonl and not args.base_url:
+        raise StressValidationError("provide --input-jsonl for offline validation or --base-url for live bridge collection")
+
+    events: list[dict[str, Any]] = []
+    if args.input_jsonl:
+        events.extend(load_jsonl(args.input_jsonl))
+    if args.base_url:
+        token = args.token
+        if token is None:
+            token = os.environ.get("OMI_AUTOMATION_TOKEN")
+        if token and not args.allow_remote_token and not is_loopback_url(args.base_url):
+            raise StressValidationError(
+                "--base-url must be loopback when an automation token is used; "
+                "pass --allow-remote-token only for an intentional non-production bridge"
+            )
+        scenarios = args.scenario or ["ptt_voiced"]
+        events.extend(collect_from_bridge(args.base_url, token, scenarios, args.iterations))
+        if args.emit_jsonl:
+            for event in events:
+                print(json.dumps(event, sort_keys=True))
+
+    summary = summarize(events, args.require_scenario)
+    print(json.dumps(summary, indent=2, sort_keys=True))
+    return 0 if summary["passed_release_gate"] else 2
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except StressValidationError as exc:
+        print(f"stress_ptt_chat.py: {exc}", file=sys.stderr)
+        raise SystemExit(2)

--- a/desktop/macos/scripts/stress_ptt_chat.py
+++ b/desktop/macos/scripts/stress_ptt_chat.py
@@ -79,7 +79,7 @@ def load_jsonl(path: Path) -> list[dict[str, Any]]:
         except json.JSONDecodeError as exc:
             raise StressValidationError(f"{path}:{line_number}: invalid JSON: {exc.msg}") from exc
         if not isinstance(event, dict):
-            raise StressValidationError(f"{path}:{line_number}: event must be an object")
+            raise StressValidationError(f"{path}:{line_number}: event must be a JSON object")
         validate_event(event, f"{path}:{line_number}")
         events.append(event)
     return events
@@ -91,8 +91,6 @@ def validate_event(event: dict[str, Any], where: str) -> None:
             raise StressValidationError(f"{where}: missing required field {key}")
     if not isinstance(event["run_id"], str) or not event["run_id"]:
         raise StressValidationError(f"{where}: run_id must be a non-empty string")
-    if not isinstance(event["timestamp"], str) or not event["timestamp"]:
-        raise StressValidationError(f"{where}: timestamp must be a non-empty string")
     if not isinstance(event["scenario"], str):
         raise StressValidationError(f"{where}: scenario must be a string")
     if event["scenario"] not in SCENARIOS:
@@ -101,12 +99,14 @@ def validate_event(event: dict[str, Any], where: str) -> None:
         raise StressValidationError(f"{where}: terminal_reason must be a string")
     if event["terminal_reason"] not in TERMINAL_REASONS:
         raise StressValidationError(f"{where}: unknown terminal_reason {event['terminal_reason']!r}")
-    if not isinstance(event["iteration"], int) or isinstance(event["iteration"], bool) or event["iteration"] < 1:
+    if not isinstance(event["timestamp"], str) or not event["timestamp"]:
+        raise StressValidationError(f"{where}: timestamp must be a non-empty string")
+    if isinstance(event["iteration"], bool) or not isinstance(event["iteration"], int) or event["iteration"] < 1:
         raise StressValidationError(f"{where}: iteration must be a positive integer")
     if "duration_ms" in event and event["duration_ms"] is not None:
         if (
-            not isinstance(event["duration_ms"], int)
-            or isinstance(event["duration_ms"], bool)
+            isinstance(event["duration_ms"], bool)
+            or not isinstance(event["duration_ms"], int)
             or event["duration_ms"] < 0
         ):
             raise StressValidationError(f"{where}: duration_ms must be a non-negative integer")
@@ -171,7 +171,7 @@ def is_loopback_url(raw_url: str) -> bool:
     hostname = parsed.hostname
     if hostname is None:
         return False
-    if hostname == "localhost" or hostname == "::1":
+    if hostname.lower() == "localhost":
         return True
     try:
         return ipaddress.ip_address(hostname).is_loopback
@@ -185,18 +185,20 @@ def collect_from_bridge(base_url: str, token: str | None, scenarios: list[str], 
     try:
         request_json(base_url, token=None, method="GET", path="/health")
         actions_payload = request_json(base_url, token=token, method="GET", path="/actions")
-        actions = actions_payload.get("result", [])
-        if not isinstance(actions, list):
+        result = actions_payload.get("result")
+        if not isinstance(result, list):
             raise StressValidationError("automation /actions result must be a list")
         action_names = {
             item.get("name")
-            for item in actions
+            for item in result
             if isinstance(item, dict)
         }
     except (OSError, urllib.error.URLError, json.JSONDecodeError, StressValidationError) as exc:
         for iteration in range(1, iterations + 1):
             for scenario in scenarios:
-                events.append(make_event(run_id, iteration, scenario, "bridge_launch_failure", details={"error": str(exc)}))
+                events.append(
+                    make_event(run_id, iteration, scenario, "bridge_launch_failure", details={"error": str(exc)})
+                )
         return events
 
     for iteration in range(1, iterations + 1):

--- a/desktop/macos/scripts/stress_ptt_chat.py
+++ b/desktop/macos/scripts/stress_ptt_chat.py
@@ -37,6 +37,11 @@ TERMINAL_REASONS = {
     "provider_fallback",
     "bridge_launch_failure",
     "response_already_running",
+    "voice_output_overlap",
+    "realtime_no_response_timeout",
+    "deferred_commit_timeout",
+    "barge_in_replacement_timeout",
+    "stale_provider_audio_after_interrupt",
 }
 FORBIDDEN_TERMINAL_REASONS = {
     "too_short_tap",
@@ -45,6 +50,11 @@ FORBIDDEN_TERMINAL_REASONS = {
     "realtime_token_mint_failure",
     "bridge_launch_failure",
     "response_already_running",
+    "voice_output_overlap",
+    "realtime_no_response_timeout",
+    "deferred_commit_timeout",
+    "barge_in_replacement_timeout",
+    "stale_provider_audio_after_interrupt",
 }
 ACTION_BY_SCENARIO = {
     "ptt_voiced": "stress_ptt_voiced",


### PR DESCRIPTION
## Summary

- Add `stress_ptt_chat.py` plus Swift-side diagnostic models/tests for PTT, realtime, chat bridge, and subagent stress JSONL release gates.
- Add the agent-continuity gauntlet resilience suite with JSONL diagnostics, manifest counts, self-check wiring, and release-candidate docs.
- Add a desktop changelog fragment for the new diagnostic/resilience coverage.

## Review findings and fixes

- Reviewer A found live stress probes could classify failed bridge actions as success. Fixed by adding scenario-specific success reasons, treating `ok:false` / action errors / unknown explicit reasons as forbidden failures, and covering the contract in tests.
- Reviewer A found offline stress validation could pass without required stress coverage. Fixed by adding repeatable `--require-scenario` gates and documenting the release-candidate command requiring all four scenarios.
- Reviewer A found automation tokens could be sent to arbitrary URLs. Fixed by defaulting token use to loopback bridge URLs unless `--allow-remote-token` is explicitly passed.
- Reviewer B found R3 already-running/race coverage could be skipped while resilience passed. Fixed by making skipped R3 terminal reasons forbidden diagnostics so `--suite resilience` cannot go green while that bad-state path is uncovered.
- Reviewer B found resilience classification could scan stale chat history. Fixed by classifying current-turn snapshot/assistant text only and including current snapshot error fields.

## Verification

- `python3 -m py_compile desktop/macos/scripts/stress_ptt_chat.py` - passed
- `python3 -m py_compile desktop/macos/scripts/agent-continuity-gauntlet-lib.py` - passed
- `python3 desktop/macos/scripts/stress_ptt_chat.py --input-jsonl /tmp/omi-stress-pass.jsonl --require-scenario ptt_voiced --require-scenario ptt_silent --require-scenario chat_bridge --require-scenario subagent_launch` - passed with `passed_release_gate: true`
- `python3 desktop/macos/scripts/stress_ptt_chat.py --input-jsonl /tmp/omi-stress-fail.jsonl` - failed as expected with exit 2 and `audio_frames_missing`
- `cd desktop/macos && ./scripts/agent-continuity-gauntlet.sh --self-check` - passed
- `cd desktop/macos && xcrun swift test --package-path Desktop --filter DesktopStressHarnessTests` - passed, 7 tests
- `cd desktop/macos && xcrun swift test --package-path Desktop --filter AgentContinuityGauntletTests` - passed, 5 tests
- `python3 .github/scripts/desktop-changelog.py validate` - passed
- `python3 .github/scripts/check-desktop-changelog.py --base origin/main --head HEAD` - passed
- `git diff --check HEAD~1 HEAD` - passed
- `git push -u origin codex/desktop-agent-stress-resilience-harness` - pre-push hooks passed, including desktop Swift build; emitted existing/advisory warnings for the large gauntlet script/function and existing Swift warnings

## Manual QA notes

- Did not launch or restart any production Omi app or production bundle.
- Did not run a live named-bundle gauntlet against real LLM/realtime credentials in this review pass; this PR adds/validates the harnesses and offline/self-check gates.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9248?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

