### PR TITLE
fix(backend): Firestore test fake missing update() for cron promotion

### DIFF
--- a/backend/tests/unit/test_firestore_fake_contract.py
+++ b/backend/tests/unit/test_firestore_fake_contract.py
@@ -1,0 +1,47 @@
+"""Contract tests for shared Firestore in-memory fakes used in WS-B/WS-I tests."""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.unit.test_ws_b_short_term_lifecycle import _DocRef as WsBDocRef
+from tests.unit.test_ws_i_write_convergence import _DocRef as WsIDocRef
+
+
+class _MinimalDb:
+    def __init__(self):
+        self.docs = {}
+
+
+@pytest.mark.parametrize("doc_ref_cls", [WsBDocRef, WsIDocRef])
+def test_doc_ref_get_set_update_merge_contract(doc_ref_cls):
+    db = _MinimalDb()
+    ref = doc_ref_cls(db, "users/uid1/doc1")
+
+    snap = ref.get()
+    assert snap.exists is False
+
+    ref.set({"a": 1, "b": 2})
+    snap = ref.get()
+    assert snap.exists is True
+    assert snap.to_dict() == {"a": 1, "b": 2}
+
+    ref.update({"b": 3, "c": 4})
+    snap = ref.get()
+    assert snap.to_dict() == {"a": 1, "b": 3, "c": 4}
+
+    ref.set({"d": 5}, merge=True)
+    snap = ref.get()
+    assert snap.to_dict() == {"a": 1, "b": 3, "c": 4, "d": 5}
+
+    ref.set({"x": 10})
+    snap = ref.get()
+    assert snap.to_dict() == {"x": 10}
+
+
+@pytest.mark.parametrize("doc_ref_cls", [WsBDocRef, WsIDocRef])
+def test_doc_ref_update_raises_on_missing_doc(doc_ref_cls):
+    db = _MinimalDb()
+    ref = doc_ref_cls(db, "missing/path")
+    with pytest.raises(KeyError):
+        ref.update({"a": 1})

--- a/backend/tests/unit/test_firestore_fake_contract.py
+++ b/backend/tests/unit/test_firestore_fake_contract.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import pytest
+from google.api_core.exceptions import NotFound
 
 from tests.unit.test_ws_b_short_term_lifecycle import _DocRef as WsBDocRef
 from tests.unit.test_ws_i_write_convergence import _DocRef as WsIDocRef
@@ -43,5 +44,5 @@ def test_doc_ref_get_set_update_merge_contract(doc_ref_cls):
 def test_doc_ref_update_raises_on_missing_doc(doc_ref_cls):
     db = _MinimalDb()
     ref = doc_ref_cls(db, "missing/path")
-    with pytest.raises(KeyError):
+    with pytest.raises(NotFound):
         ref.update({"a": 1})

--- a/backend/tests/unit/test_ws_b_short_term_lifecycle.py
+++ b/backend/tests/unit/test_ws_b_short_term_lifecycle.py
@@ -9,6 +9,7 @@ from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, patch
 
 import pytest
+from google.api_core.exceptions import NotFound
 
 os.environ.setdefault(
     "ENCRYPTION_SECRET",
@@ -140,7 +141,7 @@ class _DocRef:
 
     def update(self, data):
         if self.path not in self._db.docs:
-            raise KeyError(self.path)
+            raise NotFound(f"Document {self.path} not found")
         self._db.docs[self.path] = self._db.docs[self.path] | data
 
 

--- a/backend/tests/unit/test_ws_i_write_convergence.py
+++ b/backend/tests/unit/test_ws_i_write_convergence.py
@@ -13,6 +13,7 @@ from types import ModuleType, SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
+from google.api_core.exceptions import NotFound
 
 BACKEND_DIR = Path(__file__).resolve().parents[2]
 PROCESS_CONVERSATION_PATH = BACKEND_DIR / "utils" / "conversations" / "process_conversation.py"
@@ -136,7 +137,7 @@ class _DocRef:
 
     def update(self, data):
         if self.path not in self._db.docs:
-            raise KeyError(self.path)
+            raise NotFound(f"Document {self.path} not found")
         self._db.docs[self.path] = self._db.docs[self.path] | data
 
 


### PR DESCRIPTION
## Merge order & dependencies

| PR | Dependencies |
|----|--------------|
| 9250 | None — **merge first** (unblocks CI) |
| 9252 | None — parallel with #9253, #9254 |
| 9253 | None — parallel with #9252, #9254 |
| 9254 | None — parallel with #9252, #9253; **#9255 should merge after this** |
| 9255 | Merge after #9254 (registers teardown tests). Merge after #9250 recommended. |
| 9256 | Independent code PR; **PR6b prod deploy** after merge. Related #9255 not blocking. |
| 9257 | **Draft.** Merge after #9255 (workflow contract CI). |
| 9258 | **Draft.** Independent; merge after wave 1. |
| 9260 | **Draft.** Independent; merge after wave 1. |
| 9261 | **Draft.** Merge after wave 1; **PR10c** proxy routing follow-up optional. |


## Summary
- Add `update()` to shared `_DocRef` fakes in cron/ws unit tests so KG promotion maintenance tests match production Firestore semantics.
- Add `test_firestore_fake_contract.py` ratchet so shared fakes must implement `get`/`set`/`update` with merge behavior.

Related: #9211

## Test plan
```bash
cd backend && python3 -m pytest tests/unit/test_canonical_short_term_maintenance_cron.py tests/unit/test_firestore_fake_contract.py -v -q
# 12 passed
```

Merge with a **regular merge** (no squash).

Closes #9234

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9250?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->