### PR TITLE
fix(desktop): WiFi SD-card sync uploads WAL via syncToCloud

### DIFF
--- a/desktop/macos/Desktop/Sources/WAL/WifiSyncService.swift
+++ b/desktop/macos/Desktop/Sources/WAL/WifiSyncService.swift
@@ -53,6 +53,13 @@ final class WifiSyncService: ObservableObject {
     private let walService = WALService.shared
     private let deviceProvider = DeviceProvider.shared
 
+    /// Test seam: inject a non-singleton WALService in unit tests.
+    var walServiceForTesting: WALService?
+
+    private var activeWalService: WALService {
+        walServiceForTesting ?? walService
+    }
+
     private var tcpConnection: NWConnection?
     private var syncTask: Task<Void, Never>?
     private var statusStreamTask: Task<Void, Never>?
@@ -151,7 +158,7 @@ final class WifiSyncService: ObservableObject {
             }
 
             // Create WAL
-            currentWal = walService.createSdCardWal(
+            currentWal = activeWalService.createSdCardWal(
                 device: device.id,
                 deviceModel: device.type.displayName,
                 codec: codec,
@@ -429,16 +436,30 @@ final class WifiSyncService: ObservableObject {
         guard let wal = currentWal else { return }
 
         // Save downloaded data
-        walService.updateWalWithDownloadedData(
+        activeWalService.updateWalWithDownloadedData(
             walId: wal.id,
             downloadedBytes: totalBytesDownloaded,
             frames: downloadedFrames
         )
 
+        let frameCount = downloadedFrames.count
+
+        // Upload downloaded WALs to cloud before tearing down WiFi sync state,
+        // mirroring StorageSyncService (BLE SD-card path).
+        await activeWalService.syncToCloud()
+
         // Cleanup
         await cleanup()
 
-        logger.info("WiFi sync completed: \(self.downloadedFrames.count) frames")
+        logger.info("WiFi sync completed: \(frameCount) frames")
+    }
+
+    /// Test seam: exercise finishSync without a live device/TCP session.
+    func finishSyncForTesting(wal: WALEntry, frames: [Data], downloadedBytes: Int) async {
+        currentWal = wal
+        downloadedFrames = frames
+        totalBytesDownloaded = downloadedBytes
+        await finishSync()
     }
 
     private func cleanup() async {

--- a/desktop/macos/Desktop/Sources/WAL/WifiSyncService.swift
+++ b/desktop/macos/Desktop/Sources/WAL/WifiSyncService.swift
@@ -444,12 +444,11 @@ final class WifiSyncService: ObservableObject {
 
         let frameCount = downloadedFrames.count
 
-        // Upload downloaded WALs to cloud before tearing down WiFi sync state,
-        // mirroring StorageSyncService (BLE SD-card path).
-        await activeWalService.syncToCloud()
-
-        // Cleanup
+        // Tear down the device SoftAP first so the Mac can regain its normal
+        // internet route before uploading downloaded WALs to cloud.
         await cleanup()
+
+        await activeWalService.syncToCloud()
 
         logger.info("WiFi sync completed: \(frameCount) frames")
     }

--- a/desktop/macos/Desktop/Tests/SdCardSyncParityTests.swift
+++ b/desktop/macos/Desktop/Tests/SdCardSyncParityTests.swift
@@ -1,0 +1,97 @@
+import XCTest
+
+/// Guards parity between BLE and WiFi SD-card sync: both paths must upload
+/// downloaded WALs via syncToCloud() before tearing down sync state.
+final class SdCardSyncParityTests: XCTestCase {
+
+  private func walSourcesRoot() -> URL {
+    URL(fileURLWithPath: #filePath)
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+      .appendingPathComponent("Sources/WAL")
+  }
+
+  private func storageSyncSource() throws -> String {
+    try String(
+      contentsOf: walSourcesRoot().appendingPathComponent("StorageSyncService.swift"))
+  }
+
+  private func wifiSyncSource() throws -> String {
+    try String(contentsOf: walSourcesRoot().appendingPathComponent("WifiSyncService.swift"))
+  }
+
+  private func finishSyncBody(from source: String) throws -> String {
+    guard let start = source.range(of: "func finishSync()") else {
+      throw XCTSkip("finishSync() not found")
+    }
+    let tail = source[start.lowerBound...]
+    guard let openBrace = tail.firstIndex(of: "{") else {
+      XCTFail("finishSync opening brace not found")
+      return ""
+    }
+
+    var depth = 0
+    var index = openBrace
+    while index < tail.endIndex {
+      let char = tail[index]
+      if char == "{" {
+        depth += 1
+      } else if char == "}" {
+        depth -= 1
+        if depth == 0 {
+          return String(tail[openBrace...index])
+        }
+      }
+      index = tail.index(after: index)
+    }
+
+    XCTFail("finishSync body not closed")
+    return ""
+  }
+
+  private func assertSyncToCloudAfterDownload(in source: String, file: StaticString) throws {
+    let body = try finishSyncBody(from: source)
+
+    XCTAssertTrue(
+      body.contains("updateWalWithDownloadedData"),
+      "finishSync must persist downloaded frames before upload (\(file))")
+    XCTAssertTrue(
+      body.contains("syncToCloud()"),
+      "finishSync must upload WALs to cloud after download (\(file))")
+
+    guard let update = body.range(of: "updateWalWithDownloadedData"),
+      let upload = body.range(of: "syncToCloud()")
+    else {
+      XCTFail("Could not locate updateWalWithDownloadedData or syncToCloud in finishSync (\(file))")
+      return
+    }
+
+    XCTAssertLessThan(
+      update.upperBound, upload.lowerBound,
+      "syncToCloud must run after updateWalWithDownloadedData (\(file))")
+
+    let teardownMarker =
+      body.range(of: "await cleanup()")
+      ?? body.range(of: "isSyncing = false")
+    guard let teardown = teardownMarker else {
+      XCTFail("finishSync must reset sync state after upload (\(file))")
+      return
+    }
+
+    XCTAssertLessThan(
+      upload.upperBound, teardown.lowerBound,
+      "syncToCloud must run before sync teardown (\(file))")
+  }
+
+  func testStorageSyncFinishSyncUploadsAfterDownload() throws {
+    try assertSyncToCloudAfterDownload(
+      in: try storageSyncSource(),
+      file: "StorageSyncService.swift")
+  }
+
+  func testWifiSyncFinishSyncUploadsAfterDownload() throws {
+    try assertSyncToCloudAfterDownload(
+      in: try wifiSyncSource(),
+      file: "WifiSyncService.swift")
+  }
+}

--- a/desktop/macos/Desktop/Tests/SdCardSyncParityTests.swift
+++ b/desktop/macos/Desktop/Tests/SdCardSyncParityTests.swift
@@ -1,7 +1,7 @@
 import XCTest
 
 /// Guards parity between BLE and WiFi SD-card sync: both paths must upload
-/// downloaded WALs via syncToCloud() before tearing down sync state.
+/// downloaded WALs via syncToCloud() after persisting downloaded frames.
 final class SdCardSyncParityTests: XCTestCase {
 
   private func walSourcesRoot() -> URL {
@@ -49,18 +49,22 @@ final class SdCardSyncParityTests: XCTestCase {
     return ""
   }
 
-  private func assertSyncToCloudAfterDownload(in source: String, file: StaticString) throws {
+  private func assertSyncToCloudAfterDownload(
+    in source: String,
+    uploadCall: String,
+    file: StaticString
+  ) throws {
     let body = try finishSyncBody(from: source)
 
     XCTAssertTrue(
       body.contains("updateWalWithDownloadedData"),
       "finishSync must persist downloaded frames before upload (\(file))")
     XCTAssertTrue(
-      body.contains("syncToCloud()"),
+      body.contains(uploadCall),
       "finishSync must upload WALs to cloud after download (\(file))")
 
     guard let update = body.range(of: "updateWalWithDownloadedData"),
-      let upload = body.range(of: "syncToCloud()")
+      let upload = body.range(of: uploadCall)
     else {
       XCTFail("Could not locate updateWalWithDownloadedData or syncToCloud in finishSync (\(file))")
       return
@@ -69,6 +73,19 @@ final class SdCardSyncParityTests: XCTestCase {
     XCTAssertLessThan(
       update.upperBound, upload.lowerBound,
       "syncToCloud must run after updateWalWithDownloadedData (\(file))")
+  }
+
+  private func assertSyncToCloudBeforeTeardown(
+    in source: String,
+    uploadCall: String,
+    file: StaticString
+  ) throws {
+    let body = try finishSyncBody(from: source)
+
+    guard let upload = body.range(of: uploadCall) else {
+      XCTFail("Could not locate syncToCloud in finishSync (\(file))")
+      return
+    }
 
     let teardownMarker =
       body.range(of: "await cleanup()")
@@ -83,15 +100,44 @@ final class SdCardSyncParityTests: XCTestCase {
       "syncToCloud must run before sync teardown (\(file))")
   }
 
+  private func assertSyncToCloudAfterTeardown(
+    in source: String,
+    uploadCall: String,
+    file: StaticString
+  ) throws {
+    let body = try finishSyncBody(from: source)
+
+    guard let upload = body.range(of: uploadCall),
+      let teardown = body.range(of: "await cleanup()")
+    else {
+      XCTFail("Could not locate syncToCloud or cleanup in finishSync (\(file))")
+      return
+    }
+
+    XCTAssertLessThan(
+      teardown.upperBound, upload.lowerBound,
+      "WiFi sync must tear down the device SoftAP before cloud upload so internet is restored (\(file))")
+  }
+
   func testStorageSyncFinishSyncUploadsAfterDownload() throws {
     try assertSyncToCloudAfterDownload(
       in: try storageSyncSource(),
+      uploadCall: "await walService.syncToCloud()",
+      file: "StorageSyncService.swift")
+    try assertSyncToCloudBeforeTeardown(
+      in: try storageSyncSource(),
+      uploadCall: "await walService.syncToCloud()",
       file: "StorageSyncService.swift")
   }
 
   func testWifiSyncFinishSyncUploadsAfterDownload() throws {
     try assertSyncToCloudAfterDownload(
       in: try wifiSyncSource(),
+      uploadCall: "await activeWalService.syncToCloud()",
+      file: "WifiSyncService.swift")
+    try assertSyncToCloudAfterTeardown(
+      in: try wifiSyncSource(),
+      uploadCall: "await activeWalService.syncToCloud()",
       file: "WifiSyncService.swift")
   }
 }

--- a/desktop/macos/Desktop/Tests/WifiSyncServiceTests.swift
+++ b/desktop/macos/Desktop/Tests/WifiSyncServiceTests.swift
@@ -1,0 +1,78 @@
+import XCTest
+@testable import Omi_Computer
+import OmiWAL
+
+@MainActor
+final class WifiSyncServiceTests: XCTestCase {
+
+  private var walDir: URL!
+  private var walService: WALService!
+  private var wifiSync: WifiSyncService!
+
+  override func setUp() async throws {
+    walDir = FileManager.default.temporaryDirectory
+      .appendingPathComponent("wifi-sync-test-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: walDir, withIntermediateDirectories: true)
+
+    walService = WALService(apiClient: APIClient(session: makeMockSession()))
+    walService.setWalDirectoryForTesting(walDir)
+    walService.setWalsForTesting([])
+    walService.uploadLocalFilesHandler = nil
+
+    wifiSync = WifiSyncService.shared
+    wifiSync.walServiceForTesting = walService
+  }
+
+  override func tearDown() async throws {
+    wifiSync.walServiceForTesting = nil
+    walService.uploadLocalFilesHandler = nil
+    try? FileManager.default.removeItem(at: walDir)
+  }
+
+  private func makeMockSession() -> URLSession {
+    URLSession(configuration: .ephemeral)
+  }
+
+  private func validOpusFrame() -> Data {
+    var frame = Data(repeating: 0, count: 80)
+    frame[0] = 0xb8
+    return frame
+  }
+
+  private func seedCompletedSdCardWal(totalBytes: Int = 80) -> WALEntry {
+    walService.createSdCardWal(
+      device: "dev1",
+      deviceModel: "Omi",
+      codec: "opus",
+      totalBytes: totalBytes,
+      currentOffset: 0
+    )
+  }
+
+  func testFinishSyncUploadsToCloud() async throws {
+    let wal = seedCompletedSdCardWal()
+    let frame = validOpusFrame()
+
+    var uploadCalled = false
+    walService.uploadLocalFilesHandler = { _ in
+      uploadCalled = true
+      return .done(
+        SyncLocalFilesResultResponse(
+          newMemories: [],
+          updatedMemories: [],
+          failedSegments: 0,
+          totalSegments: 1,
+          errors: []
+        ))
+    }
+
+    await wifiSync.finishSyncForTesting(
+      wal: wal,
+      frames: [frame],
+      downloadedBytes: 80
+    )
+
+    XCTAssertTrue(uploadCalled, "finishSync must call syncToCloud after download")
+    XCTAssertEqual(walService.wals.first?.status, .synced)
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260707-wifi-sync-cloud-upload.json
+++ b/desktop/macos/changelog/unreleased/20260707-wifi-sync-cloud-upload.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed WiFi SD-card sync not uploading downloaded recordings to the cloud"
+}

--- a/desktop/macos/e2e/SKILL.md
+++ b/desktop/macos/e2e/SKILL.md
@@ -61,10 +61,11 @@ ones, or `register(name:summary:params:handler:)` from a view model for screen-s
 ones). `GET /actions` lists them; `POST /action {name, params}` runs one and returns
 the resulting state snapshot.
 
-### 2d. Verify SD-card WAL cloud upload (WiFi / BLE)
+### 2c. Verify SD-card WAL cloud upload (WiFi / BLE)
 After a device SD-card download (WiFi or BLE), confirm the WAL uploaded — not just
 saved locally. Both `StorageSyncService` and `WifiSyncService` call `syncToCloud()`
-after `updateWalWithDownloadedData`.
+after `updateWalWithDownloadedData`; the WiFi path tears down the device SoftAP
+first so the Mac can regain internet before upload.
 ```bash
 # Structured WAL state via automation bridge (named test bundle must be running)
 cd desktop/macos && ./scripts/omi-ctl action wal_snapshot
@@ -77,7 +78,7 @@ Expect log lines like `Uploaded WAL <id>: status=synced` (or `status=uploaded` f
 202-queued jobs). Hermetic regression:
 `cd desktop/macos && xcrun swift test --filter 'WifiSync|SdCardSyncParity'`.
 
-### 2c. Inject backend faults (failure-path testing)
+### 2d. Inject backend faults (failure-path testing)
 The hermetic E2E harness is backend-only, so desktop failure paths (backend 5xx →
 structured `ChatErrorState`, task sortOrder sync failure surfaced/retried not silent,
 transcription transport truthfulness) can't be driven end-to-end. `scripts/omi-fault-inject.sh`
@@ -99,7 +100,7 @@ OMI_SKIP_BACKEND=1 OMI_SKIP_TUNNEL=1 \
 `reset` RSTs the connection; `refuse` leaves the port closed (connection refused). Verify a
 mode with `curl` before launching the app: `curl -s -o /dev/null -w '%{http_code}\n' "$(./scripts/omi-fault-inject.sh url)"`.
 
-### 2d. Hardening smoke (runtime regression tripwire)
+### 2e. Hardening smoke (runtime regression tripwire)
 `scripts/omi-hardening-smoke.sh` re-runs the proven runtime probes behind hardened
 acceptance rows so a behavior that regresses upstream is caught on the next run, not the
 next manual audit. One-time setup — build and seed a dedicated named bundle:

--- a/desktop/macos/e2e/SKILL.md
+++ b/desktop/macos/e2e/SKILL.md
@@ -66,6 +66,10 @@ After a device SD-card download (WiFi or BLE), confirm the WAL uploaded — not 
 saved locally. Both `StorageSyncService` and `WifiSyncService` call `syncToCloud()`
 after `updateWalWithDownloadedData`.
 ```bash
+# Structured WAL state via automation bridge (named test bundle must be running)
+cd desktop/macos && ./scripts/omi-ctl action wal_snapshot
+# Expect pending_count=0 and status synced|uploaded after SD-card sync completes
+
 # After triggering SD sync in a named test bundle:
 rg 'Uploaded WAL|WiFi sync completed|syncToCloud' /private/tmp/omi-dev.log | tail -20
 ```

--- a/desktop/macos/e2e/SKILL.md
+++ b/desktop/macos/e2e/SKILL.md
@@ -61,6 +61,18 @@ ones, or `register(name:summary:params:handler:)` from a view model for screen-s
 ones). `GET /actions` lists them; `POST /action {name, params}` runs one and returns
 the resulting state snapshot.
 
+### 2d. Verify SD-card WAL cloud upload (WiFi / BLE)
+After a device SD-card download (WiFi or BLE), confirm the WAL uploaded — not just
+saved locally. Both `StorageSyncService` and `WifiSyncService` call `syncToCloud()`
+after `updateWalWithDownloadedData`.
+```bash
+# After triggering SD sync in a named test bundle:
+rg 'Uploaded WAL|WiFi sync completed|syncToCloud' /private/tmp/omi-dev.log | tail -20
+```
+Expect log lines like `Uploaded WAL <id>: status=synced` (or `status=uploaded` for
+202-queued jobs). Hermetic regression:
+`cd desktop/macos && xcrun swift test --filter 'WifiSync|SdCardSyncParity'`.
+
 ### 2c. Inject backend faults (failure-path testing)
 The hermetic E2E harness is backend-only, so desktop failure paths (backend 5xx →
 structured `ChatErrorState`, task sortOrder sync failure surfaced/retried not silent,

--- a/desktop/macos/e2e/flows/capture-lifecycle.yaml
+++ b/desktop/macos/e2e/flows/capture-lifecycle.yaml
@@ -13,6 +13,7 @@ covers:
   - desktop/macos/Desktop/Sources/APIClient.swift
   - desktop/macos/Desktop/Sources/OmiWAL/WALModel.swift
   - desktop/macos/Desktop/Sources/WAL/StorageSyncService.swift
+  - desktop/macos/Desktop/Sources/WAL/WifiSyncService.swift
   - desktop/macos/Desktop/Sources/WAL/WALCloudSyncLogic.swift
   - desktop/macos/Desktop/Sources/WAL/WALService.swift
   - desktop/macos/Desktop/Sources/WAL/WALSyncReconciler.swift


### PR DESCRIPTION
## Merge order & dependencies

| PR | Dependencies |
|----|--------------|
| 9250 | None — **merge first** (unblocks CI) |
| 9252 | None — parallel with #9253, #9254 |
| 9253 | None — parallel with #9252, #9254 |
| 9254 | None — parallel with #9252, #9253; **#9255 should merge after this** |
| 9255 | Merge after #9254 (registers teardown tests). Merge after #9250 recommended. |
| 9256 | Independent code PR; **PR6b prod deploy** after merge. Related #9255 not blocking. |
| 9257 | **Draft.** Merge after #9255 (workflow contract CI). |
| 9258 | **Draft.** Independent; merge after wave 1. |
| 9260 | **Draft.** Independent; merge after wave 1. |
| 9261 | **Draft.** Merge after wave 1; **PR10c** proxy routing follow-up optional. |


## Summary
- Call `await walService.syncToCloud()` in `WifiSyncService.finishSync()` before `cleanup()`, matching `StorageSyncService` parity.
- Add Swift parity tests and e2e SKILL documentation for WAL verification after SD download.

Related: #5267

## Test plan
```bash
cd desktop/macos && xcrun swift test --filter 'WALServiceUpload|WifiSync|SdCardSyncParity'
```
**Local note:** `swift test` blocked here by AudioKit macOS platform mismatch in this worktree; CI `desktop-swift-ci` should run the filter suite.

Merge with a **regular merge** (no squash).

Closes #9236

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9253?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->