### PR TITLE
fix(listen): flush tail audio before pusher_close on teardown

### DIFF
--- a/backend/routers/transcribe.py
+++ b/backend/routers/transcribe.py
@@ -2542,6 +2542,22 @@ async def _stream_handler(
             except Exception as e:
                 logger.error(f"Error processing multi-channel conversation: {e} {uid} {session_id}")
 
+        # Flush any remaining mixed audio to pusher before closing the socket
+        if should_flush_final_multi_channel_mix(
+            is_multi_channel=is_multi_channel,
+            audio_bytes_enabled=audio_bytes_send is not None,
+            buffers=channel_mix_buffers,
+        ):
+            try:
+                mixed = mix_n_channel_buffers(channel_mix_buffers)
+                if mixed:
+                    if audio_bytes_send is not None:
+                        audio_bytes_send(mixed, time.time())
+            except Exception as e:
+                logger.error(f"Error flushing final multi-channel mix to pusher: {e} {uid} {session_id}")
+            for buf in channel_mix_buffers:
+                buf.clear()
+
         # Pusher sockets
         if pusher_close is not None:
             try:
@@ -2554,22 +2570,6 @@ async def _stream_handler(
             onboarding_handler.cleanup()
 
         await task_supervisor.drain_all(timeout=5.0, cancel=True)
-
-        # Flush any remaining mixed audio to pusher
-        if should_flush_final_multi_channel_mix(
-            is_multi_channel=is_multi_channel,
-            audio_bytes_enabled=audio_bytes_send is not None,
-            buffers=channel_mix_buffers,
-        ):
-            try:
-                mixed = mix_n_channel_buffers(channel_mix_buffers)
-                if mixed:
-                    if audio_bytes_send is not None:
-                        audio_bytes_send(mixed, time.time())
-            except Exception:
-                pass
-            for buf in channel_mix_buffers:
-                buf.clear()
 
         # Clean up collections and heavy objects to aid garbage collection
         try:

--- a/backend/tests/unit/test_transcribe_teardown_flush.py
+++ b/backend/tests/unit/test_transcribe_teardown_flush.py
@@ -1,0 +1,134 @@
+"""Regression tests for listen teardown tail-audio flush ordering (#9237)."""
+
+import struct
+import time
+from pathlib import Path
+
+import pytest
+
+from utils.transcribe_decisions import should_flush_final_multi_channel_mix
+
+from tests.unit.utils.test_listen_pusher_session import FakePusherWebSocket, frame_type, make_session
+
+
+def mix_n_channel_buffers(buffers):
+    """Local copy of routers.transcribe.mix_n_channel_buffers for hermetic tests."""
+    min_len = min((len(b) for b in buffers), default=0)
+    if min_len < 2:
+        return b''
+    min_len = min_len - (min_len % 2)
+    num_samples = min_len // 2
+    channel_samples = [struct.unpack(f'<{num_samples}h', b[:min_len]) for b in buffers]
+    mixed = []
+    for i in range(num_samples):
+        s = sum(ch[i] for ch in channel_samples)
+        mixed.append(max(-32768, min(32767, s)))
+    return struct.pack(f'<{num_samples}h', *mixed)
+
+
+async def _flush_tail_then_close(*, session, channel_mix_buffers, is_multi_channel: bool):
+    """Mirrors the corrected _stream_handler finally ordering."""
+    audio_bytes_send = session.audio_bytes_send
+    if should_flush_final_multi_channel_mix(
+        is_multi_channel=is_multi_channel,
+        audio_bytes_enabled=True,
+        buffers=channel_mix_buffers,
+    ):
+        mixed = mix_n_channel_buffers(channel_mix_buffers)
+        if mixed:
+            audio_bytes_send(mixed, time.time())
+        for buf in channel_mix_buffers:
+            buf.clear()
+    await session.close()
+
+
+async def _close_then_flush_tail(*, session, channel_mix_buffers, is_multi_channel: bool):
+    """Buggy ordering: pusher close before tail enqueue loses audio on the wire."""
+    await session.close()
+    audio_bytes_send = session.audio_bytes_send
+    if should_flush_final_multi_channel_mix(
+        is_multi_channel=is_multi_channel,
+        audio_bytes_enabled=True,
+        buffers=channel_mix_buffers,
+    ):
+        mixed = mix_n_channel_buffers(channel_mix_buffers)
+        if mixed:
+            audio_bytes_send(mixed, time.time())
+        for buf in channel_mix_buffers:
+            buf.clear()
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.mark.anyio
+async def test_teardown_tail_audio_flushed_when_enqueued_before_close():
+    ws = FakePusherWebSocket()
+    session = make_session(
+        ws=ws,
+        config_overrides={"is_multi_channel": True, "sample_rate": 16000},
+    )
+    await session.connect()
+
+    channel_mix_buffers = [
+        bytearray(struct.pack('<2h', 1000, 2000)),
+        bytearray(struct.pack('<2h', 3000, 4000)),
+    ]
+
+    flush_started_with_audio = {}
+
+    original_flush = session._flush
+
+    async def tracking_flush():
+        flush_started_with_audio["size"] = session.audio_total_size
+        await original_flush()
+
+    session._flush = tracking_flush
+
+    await _flush_tail_then_close(
+        session=session,
+        channel_mix_buffers=channel_mix_buffers,
+        is_multi_channel=True,
+    )
+
+    assert flush_started_with_audio["size"] > 0
+    assert any(frame_type(frame) == 101 for frame in ws.sent)
+
+
+@pytest.mark.anyio
+async def test_teardown_close_before_tail_enqueue_drops_audio():
+    ws = FakePusherWebSocket()
+    session = make_session(
+        ws=ws,
+        config_overrides={"is_multi_channel": True, "sample_rate": 16000},
+    )
+    await session.connect()
+
+    channel_mix_buffers = [
+        bytearray(struct.pack('<2h', 1000, 2000)),
+        bytearray(struct.pack('<2h', 3000, 4000)),
+    ]
+
+    await _close_then_flush_tail(
+        session=session,
+        channel_mix_buffers=channel_mix_buffers,
+        is_multi_channel=True,
+    )
+
+    assert not any(frame_type(frame) == 101 for frame in ws.sent)
+    assert session.audio_total_size > 0
+
+
+def test_stream_handler_teardown_flushes_tail_before_pusher_close():
+    transcribe_path = Path(__file__).resolve().parents[2] / "routers" / "transcribe.py"
+    source = transcribe_path.read_text()
+    handler_end = source.find('logger.info(f"_stream_handler ended')
+    finally_start = source.rfind("    finally:", 0, handler_end)
+    teardown = source[finally_start:handler_end]
+    flush_pos = teardown.find("# Flush any remaining mixed audio to pusher")
+    pusher_pos = teardown.find("# Pusher sockets")
+    assert flush_pos != -1
+    assert pusher_pos != -1
+    assert flush_pos < pusher_pos

--- a/docs/doc/developer/backend/listen_pusher_pipeline.mdx
+++ b/docs/doc/developer/backend/listen_pusher_pipeline.mdx
@@ -145,6 +145,8 @@ sequenceDiagram
     Note over Backend: No local fallback processing (#6061).<br/>Pusher is required for conversation processing.<br/>Without it, conversations stay in_progress permanently.
 ```
 
+**Teardown invariant:** flush any remaining multi-channel mix via `audio_bytes_send` **before** `pusher_close()` so `ListenPusherSession._flush()` can deliver tail audio to pusher.
+
 ## 3.1 Pusher Reconnect & Pending Flush
 
 When pusher reconnects after a disconnection, all buffered conversations are replayed.


### PR DESCRIPTION
## Merge order & dependencies

| PR | Dependencies |
|----|--------------|
| 9250 | None — **merge first** (unblocks CI) |
| 9252 | None — parallel with #9253, #9254 |
| 9253 | None — parallel with #9252, #9254 |
| 9254 | None — parallel with #9252, #9253; **#9255 should merge after this** |
| 9255 | Merge after #9254 (registers teardown tests). Merge after #9250 recommended. |
| 9256 | Independent code PR; **PR6b prod deploy** after merge. Related #9255 not blocking. |
| 9257 | **Draft.** Merge after #9255 (workflow contract CI). |
| 9258 | **Draft.** Independent; merge after wave 1. |
| 9260 | **Draft.** Independent; merge after wave 1. |
| 9261 | **Draft.** Merge after wave 1; **PR10c** proxy routing follow-up optional. |


## Summary
- Reorder `_stream_handler` `finally` so final mix and `audio_bytes_send` run before `pusher_close()`.
- Replace bare `except` with `logger.error` and add behavioral teardown regression test.

Related: #6952

## Test plan
```bash
cd backend && .venv/bin/python -m pytest tests/unit/test_transcribe_teardown_flush.py -v
# 3 passed
```

Merge with a **regular merge** (no squash).

Closes #9237

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9254?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->