### PR TITLE
fix(desktop): WAL flush persists disk storage correctly

### DIFF
--- a/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
+++ b/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
@@ -610,6 +610,36 @@ final class DesktopAutomationActionRegistry {
     }
 
     register(
+      name: "wal_snapshot",
+      summary: "Return WAL pending count and storage/filePath per entry for harness assertions",
+      params: []
+    ) { _ in
+      let walService = WALService.shared
+      let entries: [[String: String]] = walService.wals.map { wal in
+        [
+          "id": wal.id,
+          "storage": wal.storage.rawValue,
+          "file_path": wal.filePath ?? "",
+          "status": wal.status.rawValue,
+          "total_frames": "\(wal.totalFrames)",
+        ]
+      }
+      let entriesJSON: String
+      if let data = try? JSONSerialization.data(withJSONObject: entries),
+        let encoded = String(data: data, encoding: .utf8)
+      {
+        entriesJSON = encoded
+      } else {
+        entriesJSON = "[]"
+      }
+      return [
+        "pending_count": "\(walService.pendingWals.count)",
+        "wal_count": "\(walService.wals.count)",
+        "entries_json": entriesJSON,
+      ]
+    }
+
+    register(
       name: "memories_snapshot",
       summary: "Return memories page load state for harness assertions",
       params: []

--- a/desktop/macos/Desktop/Sources/WAL/WALService.swift
+++ b/desktop/macos/Desktop/Sources/WAL/WALService.swift
@@ -189,6 +189,16 @@ final class WALService: ObservableObject {
             guard wals[index].storage == .disk else { continue }
 
             if wals[index].filePath == nil {
+                // The old flush race could leave filePath=nil while the
+                // background writer already persisted frames under the
+                // deterministic generateFileName() path. Attempt recovery
+                // via persistedWalFilePath(for:) before corrupting.
+                if let recovered = persistedWalFilePath(for: wals[index]) {
+                    wals[index].filePath = recovered
+                    changed = true
+                    logger.info("Recovered WAL \(self.wals[index].id) filePath: \(recovered)")
+                    continue
+                }
                 wals[index].status = .corrupted
                 changed = true
                 logger.warning("Marked WAL \(self.wals[index].id) corrupted: disk storage without filePath")

--- a/desktop/macos/Desktop/Sources/WAL/WALService.swift
+++ b/desktop/macos/Desktop/Sources/WAL/WALService.swift
@@ -73,9 +73,30 @@ final class WALService: ObservableObject {
         try await uploadWalToCloud(wal)
     }
 
+    func flushToDiskForTesting() {
+        flushToDisk()
+    }
+
+    func chunkCurrentFramesForTesting() {
+        createWalFromCurrentFrames()
+    }
+
+    func reloadWalsFromDiskForTesting() {
+        wals = []
+        pendingWals = []
+        loadWals()
+    }
+
+    /// Test seam: delay before async frame writes complete so flush races are observable.
+    var diskWriteDelayForTesting: TimeInterval?
+
     private var walDirectory: URL?
     private var flushTimer: Timer?
     private var chunkTimer: Timer?
+
+    /// Tracks async frame writes keyed by WAL id so flush can wait instead of
+    /// marking storage=disk before filePath exists.
+    private var inFlightDiskWrites: [String: DispatchGroup] = [:]
 
     // In-memory frame buffer for current recording
     private var currentFrames: [Data] = []
@@ -132,6 +153,7 @@ final class WALService: ObservableObject {
             let data = try Data(contentsOf: file)
             let metadata = try JSONDecoder().decode(WALMetadata.self, from: data)
             wals = metadata.wals
+            repairInconsistentWalsOnLoad()
             updatePendingWals()
             logger.info("Loaded \(self.wals.count) WALs from disk")
         } catch {
@@ -150,10 +172,39 @@ final class WALService: ObservableObject {
             let data = try Data(contentsOf: backup)
             let metadata = try JSONDecoder().decode(WALMetadata.self, from: data)
             wals = metadata.wals
+            repairInconsistentWalsOnLoad()
             updatePendingWals()
             logger.info("Loaded \(self.wals.count) WALs from backup")
         } catch {
             logger.error("Failed to load WALs from backup: \(error.localizedDescription)")
+        }
+    }
+
+    /// Migrate metadata that claims disk storage without a persisted frame file.
+    private func repairInconsistentWalsOnLoad() {
+        guard let walDir = walDirectory else { return }
+
+        var changed = false
+        for index in wals.indices {
+            guard wals[index].storage == .disk else { continue }
+
+            if wals[index].filePath == nil {
+                wals[index].status = .corrupted
+                changed = true
+                logger.warning("Marked WAL \(self.wals[index].id) corrupted: disk storage without filePath")
+                continue
+            }
+
+            let fileUrl = walDir.appendingPathComponent(wals[index].filePath!)
+            if !fileManager.fileExists(atPath: fileUrl.path) {
+                wals[index].status = .corrupted
+                changed = true
+                logger.warning("Marked WAL \(self.wals[index].id) corrupted: missing frame file")
+            }
+        }
+
+        if changed {
+            saveWals()
         }
     }
 
@@ -335,11 +386,26 @@ final class WALService: ObservableObject {
         }
 
         let frameCount = frames.count
+        let writeDelay = diskWriteDelayForTesting ?? 0
+        let group = DispatchGroup()
+        group.enter()
+        inFlightDiskWrites[walId] = group
 
         // Write to disk on background thread to avoid blocking the main actor.
         // The completion handler hops back to main to set filePath — callers that
         // need filePath set before proceeding should use writeFramesToDiskAndWait.
         DispatchQueue.global(qos: .utility).async { [weak self] in
+            defer {
+                group.leave()
+                DispatchQueue.main.async {
+                    self?.inFlightDiskWrites.removeValue(forKey: walId)
+                }
+            }
+
+            if writeDelay > 0 {
+                Thread.sleep(forTimeInterval: writeDelay)
+            }
+
             do {
                 try fileData.write(to: fileUrl, options: .atomic)
                 log("WALService: Wrote \(frameCount) frames to \(fileName)")
@@ -400,9 +466,59 @@ final class WALService: ObservableObject {
     }
 
     private func writeWalToDisk(at index: Int) {
-        // For in-memory WALs that don't have frames here, just mark as disk
-        // In a full implementation, this would write buffered frames
+        guard wals.indices.contains(index) else { return }
+
+        let walId = wals[index].id
+
+        if wals[index].totalFrames == 0 {
+            return
+        }
+
+        if walHasPersistedFrames(wals[index]) {
+            promoteWalToDiskIfPersisted(at: index)
+            return
+        }
+
+        if let group = inFlightDiskWrites[walId] {
+            group.wait()
+            if let refreshedIndex = wals.firstIndex(where: { $0.id == walId }) {
+                promoteWalToDiskIfPersisted(at: refreshedIndex)
+                return
+            }
+        }
+
+        logger.warning("WAL flush deferred for \(walId): frames not yet on disk")
+    }
+
+    private func promoteWalToDiskIfPersisted(at index: Int) {
+        guard let persistedPath = persistedWalFilePath(for: wals[index]) else { return }
         wals[index].storage = .disk
+        if wals[index].filePath == nil {
+            wals[index].filePath = persistedPath
+        }
+    }
+
+    private func walHasPersistedFrames(_ wal: WALEntry) -> Bool {
+        persistedWalFilePath(for: wal) != nil
+    }
+
+    private func persistedWalFilePath(for wal: WALEntry) -> String? {
+        guard let walDir = walDirectory else { return nil }
+
+        if let filePath = wal.filePath {
+            let fileUrl = walDir.appendingPathComponent(filePath)
+            if fileManager.fileExists(atPath: fileUrl.path) {
+                return filePath
+            }
+        }
+
+        let expected = wal.generateFileName()
+        let expectedUrl = walDir.appendingPathComponent(expected)
+        if fileManager.fileExists(atPath: expectedUrl.path) {
+            return expected
+        }
+
+        return nil
     }
 
     // MARK: - SD Card Sync

--- a/desktop/macos/Desktop/Tests/WALFlushTests.swift
+++ b/desktop/macos/Desktop/Tests/WALFlushTests.swift
@@ -70,6 +70,37 @@ final class WALFlushTests: XCTestCase {
     XCTAssertNil(service.wals.first?.filePath)
   }
 
+  func testLoadRecoversDiskWalWhenGeneratedFileExists() throws {
+    // A WAL with storage=.disk and no filePath should be recovered (not
+    // corrupted) when the deterministic generateFileName() file exists.
+    let wal = WALEntry(
+      timerStart: 1_700_000_000,
+      codec: "opus",
+      status: .miss,
+      storage: .disk,
+      seconds: 60,
+      device: "dev1",
+      deviceModel: "Omi",
+      totalFrames: 100
+    )
+    // Write a dummy frame file at the generated path.
+    let generatedName = wal.generateFileName()
+    try Data(repeating: 0, count: 80).write(
+      to: walDir.appendingPathComponent(generatedName))
+
+    let metadata = WALMetadata(wals: [wal])
+    let metadataURL = walDir.appendingPathComponent("wals.json")
+    try JSONEncoder().encode(metadata).write(to: metadataURL)
+
+    let reloaded = WALService(apiClient: APIClient(session: makeMockSession()))
+    reloaded.setWalDirectoryForTesting(walDir)
+    reloaded.reloadWalsFromDiskForTesting()
+
+    let recovered = try XCTUnwrap(reloaded.wals.first)
+    XCTAssertNotEqual(recovered.status, .corrupted)
+    XCTAssertEqual(recovered.filePath, generatedName)
+  }
+
   func testLoadMarksDiskWithoutFilePathCorrupted() throws {
     let wal = WALEntry(
       timerStart: 1_700_000_000,

--- a/desktop/macos/Desktop/Tests/WALFlushTests.swift
+++ b/desktop/macos/Desktop/Tests/WALFlushTests.swift
@@ -1,0 +1,118 @@
+import XCTest
+@testable import Omi_Computer
+import OmiWAL
+
+@MainActor
+final class WALFlushTests: XCTestCase {
+
+  private var walDir: URL!
+  private var service: WALService!
+
+  override func setUp() async throws {
+    walDir = FileManager.default.temporaryDirectory
+      .appendingPathComponent("wal-flush-test-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: walDir, withIntermediateDirectories: true)
+
+    service = WALService(apiClient: APIClient(session: makeMockSession()))
+    service.setWalDirectoryForTesting(walDir)
+    service.setWalsForTesting([])
+    service.diskWriteDelayForTesting = nil
+  }
+
+  override func tearDown() async throws {
+    service.diskWriteDelayForTesting = nil
+    try? FileManager.default.removeItem(at: walDir)
+  }
+
+  private func makeMockSession() -> URLSession {
+    URLSession(configuration: .ephemeral)
+  }
+
+  private func validOpusFrame() -> Data {
+    var frame = Data(repeating: 0, count: 80)
+    frame[0] = 0xb8
+    return frame
+  }
+
+  func testFlushWaitsForInFlightWriteAndSetsFilePath() throws {
+    service.diskWriteDelayForTesting = 0.2
+    service.startRecording(device: "dev1", codec: "opus")
+    service.addFrame(validOpusFrame())
+    service.chunkCurrentFramesForTesting()
+
+    XCTAssertEqual(service.wals.first?.storage, .memory)
+
+    service.flushToDiskForTesting()
+
+    let wal = try XCTUnwrap(service.wals.first)
+    XCTAssertEqual(wal.storage, .disk)
+    XCTAssertNotNil(wal.filePath)
+    let fileURL = walDir.appendingPathComponent(try XCTUnwrap(wal.filePath))
+    XCTAssertTrue(FileManager.default.fileExists(atPath: fileURL.path))
+  }
+
+  func testFlushSkipsEmptyMemoryWal() {
+    let emptyWal = WALEntry(
+      timerStart: 1_700_000_000,
+      codec: "opus",
+      status: .miss,
+      storage: .memory,
+      seconds: 0,
+      device: "dev1",
+      deviceModel: "Omi",
+      totalFrames: 0
+    )
+    service.setWalsForTesting([emptyWal])
+
+    service.flushToDiskForTesting()
+
+    XCTAssertEqual(service.wals.first?.storage, .memory)
+    XCTAssertNil(service.wals.first?.filePath)
+  }
+
+  func testLoadMarksDiskWithoutFilePathCorrupted() throws {
+    let wal = WALEntry(
+      timerStart: 1_700_000_000,
+      codec: "opus",
+      status: .miss,
+      storage: .disk,
+      seconds: 60,
+      device: "dev1",
+      deviceModel: "Omi",
+      totalFrames: 100
+    )
+    let metadata = WALMetadata(wals: [wal])
+    let metadataURL = walDir.appendingPathComponent("wals.json")
+    try JSONEncoder().encode(metadata).write(to: metadataURL)
+
+    let reloaded = WALService(apiClient: APIClient(session: makeMockSession()))
+    reloaded.setWalDirectoryForTesting(walDir)
+    reloaded.reloadWalsFromDiskForTesting()
+
+    XCTAssertEqual(reloaded.wals.first?.status, .corrupted)
+  }
+
+  func testLoadMarksMissingDiskFileCorrupted() throws {
+    let fileName = "audio_dev1_opus_16000_1_fs160_1700000000.bin"
+    let wal = WALEntry(
+      timerStart: 1_700_000_000,
+      codec: "opus",
+      status: .miss,
+      storage: .disk,
+      filePath: fileName,
+      seconds: 60,
+      device: "dev1",
+      deviceModel: "Omi",
+      totalFrames: 100
+    )
+    let metadata = WALMetadata(wals: [wal])
+    let metadataURL = walDir.appendingPathComponent("wals.json")
+    try JSONEncoder().encode(metadata).write(to: metadataURL)
+
+    let reloaded = WALService(apiClient: APIClient(session: makeMockSession()))
+    reloaded.setWalDirectoryForTesting(walDir)
+    reloaded.reloadWalsFromDiskForTesting()
+
+    XCTAssertEqual(reloaded.wals.first?.status, .corrupted)
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260707-wal-flush-to-disk.json
+++ b/desktop/macos/changelog/unreleased/20260707-wal-flush-to-disk.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed WAL periodic flush marking recordings as on-disk before frame files were persisted"
+}


### PR DESCRIPTION
## Merge order & dependencies

| PR | Dependencies |
|----|--------------|
| 9250 | None — **merge first** (unblocks CI) |
| 9252 | None — parallel with #9253, #9254 |
| 9253 | None — parallel with #9252, #9254 |
| 9254 | None — parallel with #9252, #9253; **#9255 should merge after this** |
| 9255 | Merge after #9254 (registers teardown tests). Merge after #9250 recommended. |
| 9256 | Independent code PR; **PR6b prod deploy** after merge. Related #9255 not blocking. |
| 9257 | **Draft.** Merge after #9255 (workflow contract CI). |
| 9258 | **Draft.** Independent; merge after wave 1. |
| 9260 | **Draft.** Independent; merge after wave 1. |
| 9261 | **Draft.** Merge after wave 1; **PR10c** proxy routing follow-up optional. |


## Summary
- Fix `writeWalToDisk` so WALs are not marked `.disk` without `filePath`; skip empty WALs and await in-flight writes.
- Migrate inconsistent entries to `.corrupted` on load; add `WALFlushTests` and `omi-ctl` `wal_snapshot` seam.

Related: #8006

## Test plan
```bash
cd desktop/macos && xcrun swift test --filter WALFlush
```
**Local note:** blocked by AudioKit/macOS platform mismatch in this worktree; CI desktop-swift-ci covers the filter.

Merge with a **regular merge** (no squash).

Closes #9240

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9258?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->