### PR TITLE
test(backend): split fast unit duration thresholds

### DIFF
--- a/.github/workflows/backend-unit-tests.yml
+++ b/.github/workflows/backend-unit-tests.yml
@@ -77,7 +77,8 @@ jobs:
         working-directory: backend
         env:
           BACKEND_UNIT_TEST_FILE_LIST: /tmp/backend-unit-tests.txt
-          BACKEND_FAST_UNIT_MAX_SECONDS: "0.1"
+          BACKEND_FAST_UNIT_WARN_SECONDS: "0.1"
+          BACKEND_FAST_UNIT_FAIL_SECONDS: "0.25"
           BACKEND_PYTEST_FILE_ISOLATION: "1"
           BACKEND_PYTEST_MARK_EXPR: "not integration and not slow"
           BACKEND_PYTEST_XDIST: auto

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -16,10 +16,8 @@ fi
 export ENCRYPTION_SECRET="omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv"
 export OPENAI_API_KEY="test-openai-key-not-real"
 export BACKEND_PYTEST_TIMING_SUMMARY="${BACKEND_PYTEST_TIMING_SUMMARY:-1}"
-export BACKEND_FAST_UNIT_MAX_SECONDS="${BACKEND_FAST_UNIT_MAX_SECONDS:-0.1}"
-# Keep the CI fast-unit guard focused on materially slow tests while allowing
-# only a narrow CPU accounting jitter margin around the 100ms target.
-export BACKEND_FAST_UNIT_GRACE_SECONDS="${BACKEND_FAST_UNIT_GRACE_SECONDS:-0.02}"
+export BACKEND_FAST_UNIT_WARN_SECONDS="${BACKEND_FAST_UNIT_WARN_SECONDS:-0.1}"
+export BACKEND_FAST_UNIT_FAIL_SECONDS="${BACKEND_FAST_UNIT_FAIL_SECONDS:-0.12}"
 
 pytest_args=(-v)
 

--- a/backend/tests/README.md
+++ b/backend/tests/README.md
@@ -28,19 +28,20 @@ the old serial file-by-file run. Set `BACKEND_PYTEST_FILE_ISOLATION=0` to try on
 
 ### Per-test duration guard
 
-`BACKEND_FAST_UNIT_MAX_SECONDS=<seconds>` (default `0.1`) is the per-test CPU-time target. The guard
-measures **CPU time of the call phase only** (`time.process_time`), not wall-clock: wall-clock inflates
-unpredictably under parallel contention and makes a hard limit flake, while CPU time is load-independent and
-deterministic regardless of `BACKEND_PYTEST_WORKERS`. `BACKEND_FAST_UNIT_GRACE_SECONDS` can add an optional
-grace; CI defaults it to `0.02` so the 100ms target tolerates only a narrow CPU-accounting jitter margin. The
-slowest wall-clock times are still printed in the `Backend unit test durations` summary for visibility.
+`BACKEND_FAST_UNIT_WARN_SECONDS=<seconds>` (default `0.1`) is the per-test CPU-time target.
+`BACKEND_FAST_UNIT_FAIL_SECONDS=<seconds>` (default `0.12` locally) is the blocking budget. The guard measures
+**CPU time of the call phase only** (`time.process_time`), not wall-clock: wall-clock inflates unpredictably
+under parallel contention and makes a hard limit flake, while CPU time is load-independent and deterministic
+regardless of `BACKEND_PYTEST_WORKERS`. GitHub Actions keeps the same 100ms warning target but uses a higher
+failure threshold so near-target CPU-accounting differences do not block unrelated PRs. The slowest wall-clock
+times are still printed in the `Backend unit test durations` summary for visibility.
 
 Under the default file-isolated runner each test file is a separate pytest process, so the first test of a
 file/class amortizes that process's module import (FastAPI app / router / database graph) into its measured
 time. That import cost is structural, not a per-test regression; existing over-target unit tests are
 grandfathered in `tests/fast_unit_duration_allowlist.txt` (one node ID per line). To shrink that list, run a
 single pytest session instead (`BACKEND_PYTEST_FILE_ISOLATION=0`, pays imports once per worker) or raise the
-target.
+failure threshold.
 
 Genuinely non-unit tests (real `asyncio` sleeps, network/Redis, stress, codebase-wide greps, full-app
 wiring, per-test fresh module reload) must be marked `@pytest.mark.slow` / `@pytest.mark.integration` so they

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -153,16 +153,30 @@ def pytest_terminal_summary(terminalreporter, exitstatus, config):
 
 
 def _enforce_fast_unit_duration_guard(session):
-    raw_limit = os.environ.get('BACKEND_FAST_UNIT_MAX_SECONDS')
-    if not raw_limit or not _collected_unit_files:
+    raw_warn_limit = os.environ.get('BACKEND_FAST_UNIT_WARN_SECONDS')
+    raw_fail_limit = os.environ.get('BACKEND_FAST_UNIT_FAIL_SECONDS')
+    if (not raw_warn_limit and not raw_fail_limit) or not _collected_unit_files:
         return
-    try:
-        limit = float(raw_limit)
-    except ValueError:
+
+    terminalreporter = session.config.pluginmanager.get_plugin('terminalreporter')
+    warn_limit = _parse_fast_unit_limit(raw_warn_limit, 'BACKEND_FAST_UNIT_WARN_SECONDS', terminalreporter)
+    fail_limit = _parse_fast_unit_limit(raw_fail_limit, 'BACKEND_FAST_UNIT_FAIL_SECONDS', terminalreporter)
+    if warn_limit is None and raw_warn_limit:
+        session.exitstatus = 1
+        return
+    if fail_limit is None and raw_fail_limit:
+        session.exitstatus = 1
+        return
+
+    if warn_limit is None:
+        warn_limit = fail_limit
+    if fail_limit is not None and warn_limit is not None and fail_limit < warn_limit:
         terminalreporter = session.config.pluginmanager.get_plugin('terminalreporter')
         if terminalreporter is not None:
-            terminalreporter.section('Backend fast unit duration guard failures')
-            terminalreporter.line(f'Invalid BACKEND_FAST_UNIT_MAX_SECONDS value: {raw_limit}')
+            terminalreporter.section('Backend fast unit duration guard configuration error')
+            terminalreporter.line(
+                'BACKEND_FAST_UNIT_FAIL_SECONDS must be greater than or equal to ' 'BACKEND_FAST_UNIT_WARN_SECONDS.'
+            )
         session.exitstatus = 1
         return
 
@@ -173,14 +187,9 @@ def _enforce_fast_unit_duration_guard(session):
     # slowness (real asyncio sleeps, network, stress) is excluded from the PR unit lane via
     # ``slow``/``integration`` markers, so CPU time is the right signal here. The advisory
     # timing summary in pytest_terminal_summary still reports wall-clock for visibility.
-    #
-    # A local-only grace can be supplied for noisy investigations, but CI defaults to a strict
-    # comparison so BACKEND_FAST_UNIT_MAX_SECONDS=0.1 means 100ms.
-    try:
-        grace = float(os.environ.get('BACKEND_FAST_UNIT_GRACE_SECONDS', '0'))
-    except ValueError:
-        grace = 0
-    fail_limit = limit + grace
+    # The warning threshold is the target for fast unit tests. The failure threshold is the
+    # blocking budget; CI keeps it higher than local pre-push so machine variance around the
+    # target does not block unrelated PRs.
 
     allowlist = _read_duration_allowlist()
     unit_test_items = {
@@ -188,24 +197,52 @@ def _enforce_fast_unit_duration_guard(session):
         for nodeid, seconds in _test_item_cpu.items()
         if nodeid.split('::', 1)[0] in _collected_unit_files
     }
-    offenders = [
+    warning_offenders = [
         (test_id, seconds)
         for test_id, seconds in sorted(unit_test_items.items(), key=lambda item: item[1], reverse=True)
-        if seconds > fail_limit and not _duration_allowlisted(test_id, allowlist)
+        if (
+            warn_limit is not None
+            and seconds > warn_limit
+            and (fail_limit is None or seconds <= fail_limit)
+            and not _duration_allowlisted(test_id, allowlist)
+        )
     ]
-    if not offenders:
+    failure_offenders = [
+        (test_id, seconds)
+        for test_id, seconds in sorted(unit_test_items.items(), key=lambda item: item[1], reverse=True)
+        if fail_limit is not None and seconds > fail_limit and not _duration_allowlisted(test_id, allowlist)
+    ]
+    if not warning_offenders and not failure_offenders:
         return
 
-    terminalreporter = session.config.pluginmanager.get_plugin('terminalreporter')
     if terminalreporter is not None:
-        terminalreporter.section('Backend fast unit duration guard failures (CPU time)')
-        for test_id, seconds in offenders:
-            terminalreporter.line(f'{seconds:7.2f}s > {fail_limit:.2f}s  {test_id}')
+        if warning_offenders:
+            terminalreporter.section('Backend fast unit duration guard warnings (CPU time)')
+            for test_id, seconds in warning_offenders:
+                terminalreporter.line(f'{seconds:7.2f}s > {warn_limit:.2f}s  {test_id}')
+        if failure_offenders:
+            terminalreporter.section('Backend fast unit duration guard failures (CPU time)')
+            for test_id, seconds in failure_offenders:
+                terminalreporter.line(f'{seconds:7.2f}s > {fail_limit:.2f}s  {test_id}')
         terminalreporter.line(
-            f'(CPU time, call phase only; fail limit = {limit:.2f}s target + {grace:.2f}s ' f'optional grace.)'
+            f'(CPU time, call phase only; warn limit = {warn_limit:.2f}s'
+            + (f', fail limit = {fail_limit:.2f}s.)' if fail_limit is not None else '.)')
         )
         terminalreporter.line(f'Allow intentional exceptions in {_FAST_UNIT_ALLOWLIST.relative_to(BACKEND_DIR)}.')
-    session.exitstatus = 1
+    if failure_offenders:
+        session.exitstatus = 1
+
+
+def _parse_fast_unit_limit(raw_value, name, terminalreporter):
+    if raw_value is None or raw_value == '':
+        return None
+    try:
+        return float(raw_value)
+    except ValueError:
+        if terminalreporter is not None:
+            terminalreporter.section('Backend fast unit duration guard configuration error')
+            terminalreporter.line(f'Invalid {name} value: {raw_value}')
+        return None
 
 
 def _duration_allowlisted(test_id, allowlist):

--- a/backend/tests/fast_unit_duration_allowlist.txt
+++ b/backend/tests/fast_unit_duration_allowlist.txt
@@ -1,15 +1,15 @@
-# Backend unit-test node IDs grandfathered against BACKEND_FAST_UNIT_MAX_SECONDS (default 0.1s).
+# Backend unit-test node IDs grandfathered against BACKEND_FAST_UNIT_FAIL_SECONDS (default 0.12s locally).
 #
-# The duration guard measures per-test CPU time (call phase) with a strict 100ms default. CPU time
-# is load-independent, so the guard is deterministic regardless of parallelism. The entries below are
-# genuine unit tests whose measured CPU exceeds the target. The dominant cause is the file-isolation
+# The duration guard measures per-test CPU time (call phase). CPU time is load-independent, so the
+# guard is deterministic regardless of parallelism. The entries below are genuine unit tests whose
+# measured CPU exceeds the failure threshold. The dominant cause is the file-isolation
 # runner model: each test file runs in its own pytest process, so the first test of a file/class
 # amortizes that process's module import (FastAPI app / router / database graph) into its call.
 # This is structural, not a per-test regression. They STAY in the PR unit lane; this file only
 # suppresses the duration guard for these baseline node IDs. NEW slow tests are still flagged.
 #
 # To shrink this list: (a) migrate the runner to a single pytest session (BACKEND_PYTEST_FILE_ISOLATION=0)
-# so imports are paid once per worker instead of per file, or (b) raise BACKEND_FAST_UNIT_MAX_SECONDS.
+# so imports are paid once per worker instead of per file, or (b) raise BACKEND_FAST_UNIT_FAIL_SECONDS.
 # Genuinely non-unit tests (real asyncio sleeps, network, stress, codebase greps, full-app wiring,
 # per-test fresh module reload) are marked `slow`/`integration` and are NOT listed here.
 tests/unit/test_app_client_schema_inventory.py::test_inventory_ignores_static_base_url_field_routes

--- a/backend/tests/unit/test_fast_unit_duration_guard.py
+++ b/backend/tests/unit/test_fast_unit_duration_guard.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from pathlib import Path
+import sys
+
+TESTS_DIR = Path(__file__).resolve().parents[1]
+if str(TESTS_DIR) not in sys.path:
+    sys.path.insert(0, str(TESTS_DIR))
+import conftest as backend_conftest
+
+
+class _Reporter:
+    def __init__(self):
+        self.messages: list[str] = []
+
+    def section(self, message):
+        self.messages.append(message)
+
+    def line(self, message):
+        self.messages.append(message)
+
+
+class _PluginManager:
+    def __init__(self, reporter):
+        self._reporter = reporter
+
+    def get_plugin(self, name):
+        return self._reporter if name == 'terminalreporter' else None
+
+
+class _Config:
+    def __init__(self, reporter):
+        self.pluginmanager = _PluginManager(reporter)
+
+
+class _Session:
+    def __init__(self, reporter):
+        self.config = _Config(reporter)
+        self.exitstatus = 0
+
+
+def test_fast_unit_duration_guard_warns_without_failing_below_fail_threshold(monkeypatch):
+    reporter = _Reporter()
+    session = _Session(reporter)
+
+    monkeypatch.setenv('BACKEND_FAST_UNIT_WARN_SECONDS', '0.1')
+    monkeypatch.setenv('BACKEND_FAST_UNIT_FAIL_SECONDS', '0.25')
+    monkeypatch.setattr(backend_conftest, '_collected_unit_files', {'tests/unit/test_example.py'})
+    monkeypatch.setattr(
+        backend_conftest,
+        '_test_item_cpu',
+        defaultdict(float, {'tests/unit/test_example.py::test_near_target': 0.14}),
+    )
+    monkeypatch.setattr(backend_conftest, '_read_duration_allowlist', lambda: set())
+
+    backend_conftest._enforce_fast_unit_duration_guard(session)
+
+    assert session.exitstatus == 0
+    assert any('warnings' in message for message in reporter.messages)
+    assert not any('failures' in message for message in reporter.messages)
+
+
+def test_fast_unit_duration_guard_fails_above_fail_threshold(monkeypatch):
+    reporter = _Reporter()
+    session = _Session(reporter)
+
+    monkeypatch.setenv('BACKEND_FAST_UNIT_WARN_SECONDS', '0.1')
+    monkeypatch.setenv('BACKEND_FAST_UNIT_FAIL_SECONDS', '0.12')
+    monkeypatch.setattr(backend_conftest, '_collected_unit_files', {'tests/unit/test_example.py'})
+    monkeypatch.setattr(
+        backend_conftest,
+        '_test_item_cpu',
+        defaultdict(float, {'tests/unit/test_example.py::test_slow': 0.14}),
+    )
+    monkeypatch.setattr(backend_conftest, '_read_duration_allowlist', lambda: set())
+
+    backend_conftest._enforce_fast_unit_duration_guard(session)
+
+    assert session.exitstatus == 1
+    assert any('failures' in message for message in reporter.messages)
+
+
+def test_fast_unit_duration_guard_rejects_fail_threshold_below_warn_threshold(monkeypatch):
+    reporter = _Reporter()
+    session = _Session(reporter)
+
+    monkeypatch.setenv('BACKEND_FAST_UNIT_WARN_SECONDS', '0.2')
+    monkeypatch.setenv('BACKEND_FAST_UNIT_FAIL_SECONDS', '0.1')
+    monkeypatch.setattr(backend_conftest, '_collected_unit_files', {'tests/unit/test_example.py'})
+    monkeypatch.setattr(
+        backend_conftest,
+        '_test_item_cpu',
+        defaultdict(float, {'tests/unit/test_example.py::test_fast': 0.01}),
+    )
+
+    backend_conftest._enforce_fast_unit_duration_guard(session)
+
+    assert session.exitstatus == 1
+    assert any('configuration error' in message for message in reporter.messages)

--- a/backend/tests/unit/test_llm_gateway_executor.py
+++ b/backend/tests/unit/test_llm_gateway_executor.py
@@ -450,12 +450,7 @@ async def test_canary_active_route_with_percent_zero_serves_lkg():
 
 @pytest.mark.asyncio
 async def test_canary_route_enforces_partial_rollout_percentage():
-    """A canary route at <100% should send only a proportional fraction of
-    requests to the active route, with the rest falling back to LKG.
-
-    Deterministic hashing means the distribution is stable per-request, but
-    over many distinct requests the percentage is honored within a tolerance.
-    """
+    """A canary route at <100% should send stable in-bucket requests active and the rest to LKG."""
     from llm_gateway.gateway.executor import _is_route_eligible_to_serve
 
     canary_route = active_route_with_fallbacks([]).model_copy(
@@ -463,17 +458,17 @@ async def test_canary_route_enforces_partial_rollout_percentage():
     )
     config = config_with_active_route(canary_route)
 
-    active_count = 0
-    total = 500
-    from llm_gateway.gateway.resolver import resolve_chat_completion_route as _resolve
+    active_messages = ('msg 1', 'msg 3', 'msg 5')
+    lkg_messages = ('msg 0', 'msg 2', 'msg 4')
 
-    for i in range(total):
-        resolved = _resolve(config, valid_request(messages=[{'role': 'user', 'content': f'msg {i}'}]))
+    for content in active_messages:
+        resolved = resolve_chat_completion_route(config, valid_request(messages=[{'role': 'user', 'content': content}]))
+        assert _is_route_eligible_to_serve(resolved.active_route, resolved.validated_request)
+
+    for content in lkg_messages:
+        resolved = resolve_chat_completion_route(config, valid_request(messages=[{'role': 'user', 'content': content}]))
         if _is_route_eligible_to_serve(resolved.active_route, resolved.validated_request):
-            active_count += 1
-
-    # With 30% canary, expect ~150 ± 30 (generous tolerance for deterministic hash)
-    assert 100 <= active_count <= 200, f'canary distribution off: {active_count}/{total}'
+            pytest.fail(f'{content!r} unexpectedly entered the 30% canary bucket')
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- split the backend fast-unit duration guard into warning and failure thresholds
- keep local backend test runs strict at 100ms warn / 120ms fail while GitHub Actions warns at 100ms and fails at 250ms
- add focused guard tests and replace the LLM gateway canary rollout distribution loop with deterministic bucket samples

## Verification
- cd backend && BACKEND_UNIT_TEST_FILE_LIST=<focused list> PYTHON=.venv/bin/python bash test.sh
  - tests/unit/test_fast_unit_duration_guard.py
  - tests/unit/test_llm_gateway_executor.py
  - 33 passed

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9262?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

