### PR TITLE
fix(desktop): register screen-recording TCC row while frontmost, then open Settings

### DIFF
--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
@@ -1392,10 +1392,7 @@ struct DashboardPage: View {
                 screenAnalysisEnabled = false
                 isCaptureMonitoring = false
                 isTogglingCapture = false
-                ProactiveAssistantsPlugin.shared.openScreenRecordingPreferences()
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-                    ScreenCaptureService.requestAllScreenCapturePermissions()
-                }
+                ScreenCaptureService.requestScreenRecordingAccessAndOpenSettings()
                 return
             }
         }

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/PermissionsPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/PermissionsPage.swift
@@ -572,12 +572,7 @@ struct ScreenRecordingPermissionSection: View {
                             // Reset stale state so Grant flow works fresh
                             appState.isScreenRecordingStale = false
                             appState.screenRecordingGrantAttempts = 0
-                            // Open Settings FIRST so it's visible before system dialog
-                            ScreenCaptureService.openScreenRecordingPreferences()
-                            // Then request permission (may show system dialog)
-                            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-                                ScreenCaptureService.requestAllScreenCapturePermissions()
-                            }
+                            ScreenCaptureService.requestScreenRecordingAccessAndOpenSettings()
                         }) {
                             HStack(spacing: 6) {
                                 Image(systemName: "checkmark.shield")
@@ -625,14 +620,7 @@ struct ScreenRecordingPermissionSection: View {
                 )
 
             Button(action: {
-                // Open System Settings FIRST so it's visible before any system dialog appears
-                ScreenCaptureService.openScreenRecordingPreferences()
-                // Then trigger screen capture to make app appear in the list
-                // (CGRequestScreenCaptureAccess may show a system dialog that steals focus,
-                //  so we open Settings before triggering it)
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-                    appState.triggerScreenRecordingPermission()
-                }
+                ScreenCaptureService.requestScreenRecordingAccessAndOpenSettings()
                 // Track attempt — if still not granted on next check, show recovery instructions
                 appState.screenRecordingGrantAttempts += 1
             }) {

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Components/SettingsContentView+BillingHelpers.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Components/SettingsContentView+BillingHelpers.swift
@@ -537,7 +537,7 @@ extension SettingsContentView {
     if enabled && !ProactiveAssistantsPlugin.shared.hasScreenRecordingPermission {
       permissionError = "Screen recording permission required"
       isMonitoring = false
-      ProactiveAssistantsPlugin.shared.openScreenRecordingPreferences()
+      ScreenCaptureService.requestScreenRecordingAccessAndOpenSettings()
       return
     }
 

--- a/desktop/macos/Desktop/Sources/MainWindow/RewindOnlyView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/RewindOnlyView.swift
@@ -310,7 +310,7 @@ struct RewindSettingsView: View {
                 .foregroundColor(.white.opacity(0.8))
 
             Button {
-                ScreenCaptureService.openScreenRecordingPreferences()
+                ScreenCaptureService.requestScreenRecordingAccessAndOpenSettings()
             } label: {
                 HStack {
                     Image(systemName: "rectangle.on.rectangle")

--- a/desktop/macos/Desktop/Sources/MainWindow/SidebarView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/SidebarView.swift
@@ -810,12 +810,7 @@ struct SidebarView: View {
               // Reset and restart to fix broken ScreenCaptureKit state
               ScreenCaptureService.resetScreenCapturePermissionAndRestart()
             } else {
-              // Open Settings FIRST so it's visible before system dialog steals focus
-              ScreenCaptureService.openScreenRecordingPreferences()
-              // Then request permissions (may show system dialog)
-              DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-                ScreenCaptureService.requestAllScreenCapturePermissions()
-              }
+              ScreenCaptureService.requestScreenRecordingAccessAndOpenSettings()
               // Track attempt — if still not granted on next check, show recovery instructions
               appState.screenRecordingGrantAttempts += 1
             }
@@ -1068,11 +1063,7 @@ struct SidebarView: View {
 
     if enabled && !ProactiveAssistantsPlugin.shared.hasScreenRecordingPermission {
       isMonitoring = false
-      // Open Settings FIRST, then request permissions after a delay
-      ProactiveAssistantsPlugin.shared.openScreenRecordingPreferences()
-      DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-        ScreenCaptureService.requestAllScreenCapturePermissions()
-      }
+      ScreenCaptureService.requestScreenRecordingAccessAndOpenSettings()
       return
     }
 

--- a/desktop/macos/Desktop/Sources/OmiApp.swift
+++ b/desktop/macos/Desktop/Sources/OmiApp.swift
@@ -1172,9 +1172,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         return
       }
       if !ProactiveAssistantsPlugin.shared.hasScreenRecordingPermission {
-        // No permission — revert toggle and open preferences
+        // No permission — revert toggle, register + open preferences (PERM-02)
         sender.state = .off
-        ProactiveAssistantsPlugin.shared.openScreenRecordingPreferences()
+        ScreenCaptureService.requestScreenRecordingAccessAndOpenSettings()
         return
       }
       AssistantSettings.shared.screenAnalysisEnabled = true

--- a/desktop/macos/Desktop/Sources/Rewind/UI/RewindPage.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/UI/RewindPage.swift
@@ -355,11 +355,7 @@ struct RewindPage: View {
 
         if enabled && !ProactiveAssistantsPlugin.shared.hasScreenRecordingPermission {
             isMonitoring = false
-            // Open Settings FIRST, then request permissions after a delay
-            ProactiveAssistantsPlugin.shared.openScreenRecordingPreferences()
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-                ScreenCaptureService.requestAllScreenCapturePermissions()
-            }
+            ScreenCaptureService.requestScreenRecordingAccessAndOpenSettings()
             return
         }
 
@@ -1028,11 +1024,7 @@ struct RewindPage: View {
                     // Re-enable screen analysis so it auto-starts after permission is granted and app restarts
                     screenAnalysisEnabled = true
                     AssistantSettings.shared.screenAnalysisEnabled = true
-                    // Open Settings FIRST, then request permissions after a delay
-                    ScreenCaptureService.openScreenRecordingPreferences()
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-                        ScreenCaptureService.requestAllScreenCapturePermissions()
-                    }
+                    ScreenCaptureService.requestScreenRecordingAccessAndOpenSettings()
                 } label: {
                     Text("Grant Permission")
                         .scaledFont(size: 13, weight: .semibold)

--- a/desktop/macos/Desktop/Sources/ScreenCaptureService.swift
+++ b/desktop/macos/Desktop/Sources/ScreenCaptureService.swift
@@ -209,7 +209,13 @@ final class ScreenCaptureService: Sendable {
     // cause macOS to grant permissions to the wrong app
     ensureLaunchServicesRegistration()
 
-    // 1. Request traditional Screen Recording TCC permission
+    // 1. Request traditional Screen Recording TCC permission.
+    // Activate first so the request fires while Omi is frontmost. A
+    // screen-capture access request from a backgrounded app does not reliably
+    // register the kTCCServiceScreenCapture row, so the app never appears in the
+    // Screen Recording list (PERM-02). This mirrors requestMicrophonePermission,
+    // which activates before requesting and reliably creates its TCC row.
+    NSApp.activate()
     CGRequestScreenCaptureAccess()
 
     // 2. Request ScreenCaptureKit permission (macOS 14+)
@@ -221,6 +227,18 @@ final class ScreenCaptureService: Sendable {
 
     // Note: callers are responsible for opening System Settings
     // (removed duplicate open that conflicted with caller's own open call)
+  }
+
+  /// Guided grant flow (PERM-02 / BL-050): register the screen-recording TCC row
+  /// **while Omi is frontmost**, then open System Settings so the user lands on a
+  /// list that already contains Omi. Opening Settings first backgrounded the app
+  /// before the registering call, so a screen-capture request from the
+  /// backgrounded app never created the `kTCCServiceScreenCapture` row and Omi
+  /// never appeared in the list. Mirrors MemoryExportExecutor.requestScreenRecordingApprovalForCloudSetup, the existing register-while-frontmost path.
+  @MainActor
+  static func requestScreenRecordingAccessAndOpenSettings() {
+    requestAllScreenCapturePermissions()
+    openScreenRecordingPreferences()
   }
 
   /// Test if ScreenCaptureKit specifically works (macOS 14+)

--- a/desktop/macos/Desktop/Sources/ScreenCaptureService.swift
+++ b/desktop/macos/Desktop/Sources/ScreenCaptureService.swift
@@ -203,6 +203,7 @@ final class ScreenCaptureService: Sendable {
   }
 
   /// Request all screen capture permissions (both traditional TCC and ScreenCaptureKit)
+  @MainActor
   static func requestAllScreenCapturePermissions() {
     // 0. Ensure this app is the authoritative version in Launch Services
     // This fixes issues where stale registrations from old builds, DMGs, or Trash

--- a/desktop/macos/Desktop/Tests/ScreenRecordingPermissionPolicyTests.swift
+++ b/desktop/macos/Desktop/Tests/ScreenRecordingPermissionPolicyTests.swift
@@ -3,6 +3,74 @@ import XCTest
 @testable import Omi_Computer
 
 final class ScreenRecordingPermissionPolicyTests: XCTestCase {
+  private func sourceFile(_ relativePath: String) throws -> String {
+    let url = URL(fileURLWithPath: #filePath)
+      .deletingLastPathComponent().deletingLastPathComponent()
+      .appendingPathComponent(relativePath)
+    return try String(contentsOf: url, encoding: .utf8)
+  }
+
+  /// PERM-02 / BL-050: register the screen-recording TCC row while Omi is
+  /// frontmost, then open Settings. The guided-grant helper must call
+  /// requestAllScreenCapturePermissions() BEFORE openScreenRecordingPreferences(),
+  /// and requestAll must activate before CGRequestScreenCaptureAccess(). A
+  /// backgrounded request never creates the row (the Wave-11 failure).
+  func testGuidedGrantRegistersBeforeOpeningSettings() throws {
+    let src = try sourceFile("Sources/ScreenCaptureService.swift")
+    guard let fn = src.range(of: "static func requestScreenRecordingAccessAndOpenSettings() {"),
+      let end = src.range(of: "\n  }", range: fn.upperBound..<src.endIndex)?.lowerBound
+    else { return XCTFail("requestScreenRecordingAccessAndOpenSettings must exist") }
+    let body = String(src[fn.upperBound..<end])
+    guard let reg = body.range(of: "requestAllScreenCapturePermissions()")?.lowerBound,
+      let open = body.range(of: "openScreenRecordingPreferences()")?.lowerBound
+    else { return XCTFail("helper must both register and open Settings") }
+    XCTAssertLessThan(reg, open, "must register the TCC row before opening System Settings")
+
+    guard let rfn = src.range(of: "static func requestAllScreenCapturePermissions() {"),
+      let rend = src.range(of: "\n  }", range: rfn.upperBound..<src.endIndex)?.lowerBound
+    else { return XCTFail("requestAllScreenCapturePermissions must exist") }
+    let rbody = String(src[rfn.upperBound..<rend])
+    guard let act = rbody.range(of: "NSApp.activate()")?.lowerBound,
+      let cg = rbody.range(of: "CGRequestScreenCaptureAccess()")?.lowerBound
+    else { return XCTFail("requestAll must activate and request") }
+    XCTAssertLessThan(act, cg, "NSApp.activate() must precede CGRequestScreenCaptureAccess()")
+  }
+
+  /// The permission buttons must use the register-first helper, not the old
+  /// open-Settings-then-asyncAfter-register anti-pattern that backgrounded the
+  /// app before registering.
+  func testPermissionButtonsUseRegisterFirstHelper() throws {
+    // Positive guard: every screen-recording grant surface routes through the
+    // register-first helper (each of these files had an open-then-register path).
+    for path in [
+      "Sources/MainWindow/Pages/PermissionsPage.swift",
+      "Sources/MainWindow/SidebarView.swift",
+      "Sources/Rewind/UI/RewindPage.swift",
+      "Sources/MainWindow/Pages/DashboardPage.swift",
+      "Sources/OmiApp.swift",
+      "Sources/MainWindow/Pages/Settings/Components/SettingsContentView+BillingHelpers.swift",
+      "Sources/MainWindow/RewindOnlyView.swift",
+    ] {
+      XCTAssertTrue(
+        try sourceFile(path).contains("requestScreenRecordingAccessAndOpenSettings()"),
+        "\(path) must route its screen-recording grant through the register-first helper")
+    }
+    // Negative guard: the register-after-open-Settings anti-pattern is gone.
+    for path in [
+      "Sources/MainWindow/Pages/PermissionsPage.swift",
+      "Sources/MainWindow/SidebarView.swift",
+      "Sources/Rewind/UI/RewindPage.swift",
+      "Sources/MainWindow/Pages/DashboardPage.swift",
+    ] {
+      let src = try sourceFile(path)
+      XCTAssertNil(
+        src.range(
+          of: "openScreenRecordingPreferences\\([\\s\\S]{0,240}(requestAllScreenCapturePermissions|triggerScreenRecordingPermission)",
+          options: .regularExpression),
+        "\(path) still opens Settings before requesting screen-recording access")
+    }
+  }
+
   func testUiPermissionFollowsTccGrant() {
     XCTAssertTrue(ScreenRecordingPermissionPolicy.uiPermissionGranted(tccGranted: true))
     XCTAssertFalse(ScreenRecordingPermissionPolicy.uiPermissionGranted(tccGranted: false))

--- a/desktop/macos/changelog/unreleased/20260708-screen-recording-tcc-registration.json
+++ b/desktop/macos/changelog/unreleased/20260708-screen-recording-tcc-registration.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed the Screen Recording permission flow so Omi reliably appears in the Screen Recording list when you click Open Settings, instead of sometimes needing a second attempt"
+}

--- a/desktop/macos/e2e/flows/screen-recording-permission.yaml
+++ b/desktop/macos/e2e/flows/screen-recording-permission.yaml
@@ -9,6 +9,8 @@ covers:
   - desktop/Desktop/Sources/MainWindow/Pages/PermissionsPage.swift
   - desktop/Desktop/Sources/AppState/AppState+SystemActions.swift
   - desktop/Desktop/Sources/AppState/AppState+TrialPaywall.swift
+  - desktop/Desktop/Sources/MainWindow/Pages/Settings/Components/SettingsContentView+BillingHelpers.swift
+  - desktop/Desktop/Sources/MainWindow/RewindOnlyView.swift
 preconditions:
   - auth_ready
 


### PR DESCRIPTION
## Problem (runtime-verified)

Clicking any Screen Recording **Open Settings**/**Grant** surface opened System Settings but often did **not** add Omi to the Screen Recording list, so users had to try twice. Wave-11 runtime: after `tccutil reset ScreenCapture`, the grant path left **no `kTCCServiceScreenCapture` row** for the bundle; a relaunch + retry was the same.

Root cause: every grant button opened System Settings **first** (foregrounding Settings, backgrounding Omi), then fired `CGRequestScreenCaptureAccess()` 0.5s later via `asyncAfter` — while Omi was backgrounded. A screen-capture access request from a non-frontmost app does not register the TCC row, so the app never appears in the list. (The microphone request — which works — activates the app before requesting, and the cloud-setup path `MemoryExportExecutor.requestScreenRecordingApprovalForCloudSetup` already requests while frontmost.)

## Fix — register while frontmost, then open Settings

- New `ScreenCaptureService.requestScreenRecordingAccessAndOpenSettings()` (`@MainActor`): `requestAllScreenCapturePermissions()` (which now `NSApp.activate()`s before `CGRequestScreenCaptureAccess()`) **then** `openScreenRecordingPreferences()`. Because the buttons are invoked from a user click inside Omi, Omi is frontmost when the register call fires.
- **Every** screen-recording grant surface routes through the helper: PermissionsPage ×2, SidebarView ×2, RewindPage ×2, DashboardPage, the menu-bar toggle in OmiApp, the billing/monitoring toggle, and RewindOnlyView. The last three previously opened Settings **without ever calling `CGRequestScreenCaptureAccess()`**, so they never registered at all — now fixed too.

## Verification

- Build green; `ScreenRecordingPermissionPolicyTests` **5/5** — asserts the helper registers before opening, `requestAll` activates before the CG request, a positive guard that all seven grant surfaces use the helper, and a negative guard that the open-before-request anti-pattern (both `requestAll` and `trigger` variants) is gone. e2e flow-coverage gate: **8/8**.
- **Independent review** (two rounds): the first flagged that a synchronous `CGRequestScreenCaptureAccess()` after an async `NSApp.activate()`, with callers still opening Settings first, wouldn't actually register the row — this revision implements the reviewer's recommended "register-while-frontmost, then open Settings" and the re-review confirmed the mechanism is fixed and all conversions preserve surrounding control flow.
- The definitive runtime proof — that a `kTCCServiceScreenCapture` row now appears — reads the **root-owned system TCC.db** and drives the **TCC-protected consent dialog**, so it is real-device and left to the post-merge verification lane (PERM-02 stays FAIL in our matrix until that re-run passes). Disposition memo: `.omi-hardening/slices/024-perm02-disposition/triage.md`.

Changelog fragment included (user-visible).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9265?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

