### PR TITLE
feat(desktop/automation): suspend_agent_stream hook to induce chat stalls (CHAT-02)

### DIFF
--- a/desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift
+++ b/desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift
@@ -631,11 +631,12 @@ actor AgentRuntimeProcess {
     // Only the suspend that scheduled this auto-resume may clear it; a newer
     // suspend or an explicit resume has already moved the generation on.
     guard generation == debugSuspendGeneration else { return }
-    // If the agent was torn down and relaunched during the freeze, the current
-    // process has a different pid; SIGCONT-ing the old pid could hit a reused
-    // pid. restart()/stop() already SIGKILL the old process, so there is nothing
-    // to resume in that case.
-    guard process?.processIdentifier == pid else { return }
+    // Only resume if the SAME process is still alive. A stored Process that has
+    // already exited can still report its original pid (which the OS may have
+    // reused), so require isRunning as well as a pid match — never SIGCONT a
+    // reused pid. restart()/stop() already SIGKILL the old process, so a
+    // torn-down/relaunched agent has nothing to resume here.
+    guard let process, process.isRunning, process.processIdentifier == pid else { return }
     _ = kill(pid, SIGCONT)
     log("AgentRuntimeProcess: DEBUG auto-resumed stream pid=\(pid) (gen \(generation))")
   }

--- a/desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift
+++ b/desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift
@@ -613,10 +613,16 @@ actor AgentRuntimeProcess {
     guard let process, process.isRunning, process.processIdentifier > 0 else {
       return ["error": "no running agent process to resume"]
     }
-    // Bump the generation so any pending auto-resume becomes a no-op.
-    debugSuspendGeneration &+= 1
     let pid = process.processIdentifier
-    _ = kill(pid, SIGCONT)
+    guard kill(pid, SIGCONT) == 0 else {
+      // SIGCONT failed (pid raced to exit, or an unexpected errno). Do NOT bump
+      // the generation here: leaving the pending auto-resume armed is the safe
+      // choice, so a still-frozen process can't stay stuck until app restart.
+      return ["error": "SIGCONT failed for pid \(pid) (errno \(errno))"]
+    }
+    // Only cancel the pending safety auto-resume once the explicit resume
+    // actually succeeded.
+    debugSuspendGeneration &+= 1
     log("AgentRuntimeProcess: DEBUG resumed stream pid=\(pid)")
     return ["resumed": "true", "pid": "\(pid)"]
   }

--- a/desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift
+++ b/desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift
@@ -569,6 +569,76 @@ actor AgentRuntimeProcess {
     }
   }
 
+  // MARK: - Automation stall hook (non-production only)
+
+  /// Generation guard so a late auto-resume from an earlier suspend can't
+  /// SIGCONT a process that a newer suspend is deliberately holding.
+  private var debugSuspendGeneration: UInt64 = 0
+
+  /// Freeze the agent's stdio stream by sending SIGSTOP to the node bridge
+  /// process. With the process paused it emits no further events, so an in-flight
+  /// chat send stalls exactly like a hung ACP subprocess — driving the
+  /// StallDetector to `.stalled` (20s) and, if held long enough, ChatProvider's
+  /// 180s send watchdog (CHAT-02). A safety auto-resume fires after `durationMs`
+  /// (hard-capped) so the process can never stay frozen if `debugResumeStream`
+  /// is never called. Non-production bundles only.
+  func debugSuspendStream(durationMs: Int) -> [String: String] {
+    guard AppBuild.isNonProduction else {
+      return ["error": "suspend_agent_stream is disabled on production bundles"]
+    }
+    guard let process, process.isRunning, process.processIdentifier > 0 else {
+      return ["error": "no running agent process to suspend"]
+    }
+    let pid = process.processIdentifier
+    guard kill(pid, SIGSTOP) == 0 else {
+      return ["error": "SIGSTOP failed for pid \(pid) (errno \(errno))"]
+    }
+    debugSuspendGeneration &+= 1
+    let generation = debugSuspendGeneration
+    // Cap the freeze window so a forgotten resume can't wedge the agent.
+    let cappedMs = max(1_000, min(durationMs, 300_000))
+    log("AgentRuntimeProcess: DEBUG suspended stream pid=\(pid) for \(cappedMs)ms (gen \(generation))")
+    Task { [weak self] in
+      try? await Task.sleep(nanoseconds: UInt64(cappedMs) * 1_000_000)
+      await self?.autoResumeStream(pid: pid, generation: generation)
+    }
+    return ["suspended": "true", "pid": "\(pid)", "durationMs": "\(cappedMs)"]
+  }
+
+  /// SIGCONT the agent process immediately (early clear of a debug suspend).
+  func debugResumeStream() -> [String: String] {
+    guard AppBuild.isNonProduction else {
+      return ["error": "resume_agent_stream is disabled on production bundles"]
+    }
+    guard let process, process.isRunning, process.processIdentifier > 0 else {
+      return ["error": "no running agent process to resume"]
+    }
+    // Bump the generation so any pending auto-resume becomes a no-op.
+    debugSuspendGeneration &+= 1
+    let pid = process.processIdentifier
+    _ = kill(pid, SIGCONT)
+    log("AgentRuntimeProcess: DEBUG resumed stream pid=\(pid)")
+    return ["resumed": "true", "pid": "\(pid)"]
+  }
+
+  private func autoResumeStream(pid: pid_t, generation: UInt64) {
+    // Only the suspend that scheduled this auto-resume may clear it; a newer
+    // suspend or an explicit resume has already moved the generation on.
+    guard generation == debugSuspendGeneration else { return }
+    // If the agent was torn down and relaunched during the freeze, the current
+    // process has a different pid; SIGCONT-ing the old pid could hit a reused
+    // pid. restart()/stop() already SIGKILL the old process, so there is nothing
+    // to resume in that case.
+    guard process?.processIdentifier == pid else { return }
+    _ = kill(pid, SIGCONT)
+    log("AgentRuntimeProcess: DEBUG auto-resumed stream pid=\(pid) (gen \(generation))")
+  }
+  // Caveat: autoResumeStream is actor-isolated, so it can only run once the
+  // actor is idle. The intended stall flow writes only the tiny 180s interrupt
+  // to the frozen process (far below the stdin pipe buffer), so the actor never
+  // blocks on a write while suspended; do not push large stdin payloads to a
+  // suspended agent or the auto-resume could be delayed until the actor frees.
+
   func interrupt(clientId: String, requestId: String) {
     let requestKey = RuntimeMessage.RequestKey(clientId: clientId, requestId: requestId)
     guard var request = activeRequests[requestKey] else { return }

--- a/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
+++ b/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
@@ -1001,6 +1001,31 @@ final class DesktopAutomationActionRegistry {
     }
 
     register(
+      name: "suspend_agent_stream",
+      summary: "Freeze the agent stdio stream (SIGSTOP) to induce a chat stall; auto-resumes after durationMs. Non-prod only.",
+      params: ["durationMs"]
+    ) { params in
+      guard AppBuild.isNonProduction else {
+        return ["error": "suspend_agent_stream is disabled on production bundles"]
+      }
+      // Default just past the 180s send watchdog so CHAT-02 can assert the
+      // "Response took too long" error + recoverable retry; capped at 300s.
+      let durationMs = intParam(params["durationMs"], default: 190_000)
+      return await AgentRuntimeProcess.shared.debugSuspendStream(durationMs: durationMs)
+    }
+
+    register(
+      name: "resume_agent_stream",
+      summary: "Resume a suspended agent stdio stream (SIGCONT) immediately. Non-prod only.",
+      params: []
+    ) { _ in
+      guard AppBuild.isNonProduction else {
+        return ["error": "resume_agent_stream is disabled on production bundles"]
+      }
+      return await AgentRuntimeProcess.shared.debugResumeStream()
+    }
+
+    register(
       name: "floating_bar_chat_snapshot",
       summary: "Export floating-bar chat transcript and stream state for harness assertions",
       params: ["limit"]

--- a/desktop/macos/Desktop/Tests/AgentRuntimeProcessTests.swift
+++ b/desktop/macos/Desktop/Tests/AgentRuntimeProcessTests.swift
@@ -3,6 +3,58 @@ import XCTest
 @testable import Omi_Computer
 
 final class AgentRuntimeProcessTests: XCTestCase {
+  // MARK: - CHAT-02 agent stall hook
+
+  func testSuspendStreamNoOpsWithoutRunningProcess() async {
+    // External contract: the debug suspend never reports success without a real
+    // suspend — it returns an error (prod-gated in the test host, or no running
+    // process on a dev bundle), never suspended:true, and never SIGSTOPs a bogus pid.
+    let result = await AgentRuntimeProcess.shared.debugSuspendStream(durationMs: 190_000)
+    XCTAssertNotEqual(result["suspended"], "true")
+    XCTAssertNotNil(result["error"])
+  }
+
+  func testResumeStreamNoOpsWithoutProcess() async {
+    let result = await AgentRuntimeProcess.shared.debugResumeStream()
+    XCTAssertNotEqual(result["resumed"], "true")
+    XCTAssertNotNil(result["error"])
+  }
+
+  func testAgentStallHookIsNonProdGatedAndSafe() throws {
+    let processSource = try String(
+      contentsOf: URL(fileURLWithPath: #filePath)
+        .deletingLastPathComponent().deletingLastPathComponent()
+        .appendingPathComponent("Sources/Chat/AgentRuntimeProcess.swift"),
+      encoding: .utf8)
+    // Production gate, live-process guard, real signals, bounded window, and a
+    // generation-guarded auto-resume so a forgotten resume can't wedge the agent.
+    for needle in [
+      "func debugSuspendStream(durationMs: Int)",
+      "guard AppBuild.isNonProduction else",
+      "process.isRunning, process.processIdentifier > 0",
+      "kill(pid, SIGSTOP)",
+      "kill(pid, SIGCONT)",
+      "min(durationMs, 300_000)",
+      "generation == debugSuspendGeneration",
+    ] {
+      XCTAssertTrue(processSource.contains(needle), "AgentRuntimeProcess missing stall-hook invariant: \(needle)")
+    }
+
+    let bridgeSource = try String(
+      contentsOf: URL(fileURLWithPath: #filePath)
+        .deletingLastPathComponent().deletingLastPathComponent()
+        .appendingPathComponent("Sources/DesktopAutomationBridge.swift"),
+      encoding: .utf8)
+    for needle in ["name: \"suspend_agent_stream\"", "name: \"resume_agent_stream\""] {
+      XCTAssertTrue(bridgeSource.contains(needle), "bridge missing action: \(needle)")
+    }
+    // Both actions must be behind the non-prod guard.
+    let suspendIdx = bridgeSource.range(of: "name: \"suspend_agent_stream\"")!.lowerBound
+    let afterSuspend = String(bridgeSource[suspendIdx...].prefix(600))
+    XCTAssertTrue(afterSuspend.contains("AppBuild.isNonProduction"),
+      "suspend_agent_stream must be gated to non-production bundles")
+  }
+
   func testV2ResultParsingPreservesCanonicalAndAdapterIds() {
     let line = """
       {"type":"result","protocolVersion":2,"requestId":"req-1","clientId":"client-1","sessionId":"omi-1","runId":"run-1","attemptId":"attempt-1","adapterSessionId":"acp-1","terminalStatus":"succeeded","text":"done","costUsd":1.25,"inputTokens":3,"outputTokens":4,"cacheReadTokens":5,"cacheWriteTokens":6}

--- a/desktop/macos/Desktop/Tests/StallDetectorTests.swift
+++ b/desktop/macos/Desktop/Tests/StallDetectorTests.swift
@@ -31,6 +31,16 @@ final class StallDetectorTests: XCTestCase {
     XCTAssertEqual(transitions, [.interEvent(from: .running, to: .slow)])
   }
 
+  func testGapWellBeyondStalledStaysStalled() async {
+    // A persistent stall (e.g. the full 180s until ChatProvider's send watchdog
+    // fires, CHAT-02) must remain .stalled, not decay back to running.
+    let detector = StallDetector(thresholds: thresholds, startedAtMs: 0)
+    _ = await detector.tick(atMs: thresholds.stalledGapMs)
+    _ = await detector.tick(atMs: 185_000)
+    let state = await detector.interEventState
+    XCTAssertEqual(state, .stalled)
+  }
+
   func testGapAtStalledThresholdPromotesToStalled() async {
     let detector = StallDetector(thresholds: thresholds, startedAtMs: 0)
     let transitions = await detector.tick(atMs: thresholds.stalledGapMs)

--- a/desktop/macos/e2e/SKILL.md
+++ b/desktop/macos/e2e/SKILL.md
@@ -110,6 +110,38 @@ Exit codes: `0` all PASS · `1` any FAIL (a regression — investigate) · `2` u
 given. Safety: only `com.omi.omi-*` bundles are accepted; the sole production interaction is
 the read-only `defaults read` in `auth-06`.
 
+### 2e. Stall the agent stream (chat watchdog testing)
+The HTTP fault harness (§2c) can't stall the **agent** stream — that's a node/stdio
+bridge, not HTTP. Two non-prod bridge actions freeze it so the chat stall path can be
+exercised end-to-end (CHAT-02): a slow/stalled annotation at 8s/20s (`StallDetector`),
+and ChatProvider's **180s send watchdog** which force-releases `isSending` and surfaces
+"Response took too long. Try again." (recoverable — the next send works).
+
+- `suspend_agent_stream` — SIGSTOP the agent process so it emits no events; `durationMs`
+  (default `190000`, just past the 180s watchdog; capped at `300000`) auto-resumes it, so
+  a forgotten resume can never wedge the agent.
+- `resume_agent_stream` — SIGCONT immediately (early clear).
+
+Both are non-production only (`AppBuild.isNonProduction`). Recipe (drive against a named
+test bundle's automation port):
+```bash
+cd desktop/macos
+# 1. start a chat turn so a send is in flight
+./scripts/omi-ctl action ask query="write a long detailed answer" &
+sleep 2
+# 2. freeze the agent stream past the 180s watchdog
+./scripts/omi-ctl action suspend_agent_stream durationMs=190000
+# 3. within <=180s the send watchdog fires: assert the error + that sending is released
+sleep 185
+./scripts/omi-ctl action main_chat_snapshot | python3 -c 'import json,sys; d=json.load(sys.stdin)["result"]; print("error:", d.get("has_error"), d.get("error_message")); print("is_sending:", d.get("is_sending"))'
+#   expect has_error=true / "Response took too long…" and is_sending=false (recoverable)
+# 4. resume + prove recovery with a fresh turn
+./scripts/omi-ctl action resume_agent_stream
+./scripts/omi-ctl action ask query="are you back?"   # succeeds — not blocked by the stale send
+```
+`suspend_agent_stream` returns `{suspended:true, pid, durationMs}` (or an `error` if no
+agent process is running / on a prod bundle).
+
 ### The full loop
 ```bash
 cd desktop/macos


### PR DESCRIPTION
## Problem

CHAT-02 (induced agent stall → watchdog error ≤180s, recoverable retry) was **BLOCKED(bridge-action-needed)**: the HTTP fault harness (#9159) and the runtime smoke harness (#9242) can't stall the **agent** stream — it's a node/stdio bridge, not HTTP — so there was no way to drive the stall path for verification.

## What this adds

Two **non-production** automation-bridge actions that freeze the *real* agent stream so the whole stall path runs end to end:

- **`suspend_agent_stream`** (`durationMs`, default `190000` — just past ChatProvider's 180s send watchdog; capped at `300000`): `AgentRuntimeProcess.debugSuspendStream` sends **SIGSTOP** to the node bridge process. With it paused, no events reach ChatProvider, so an in-flight send stalls exactly like a hung ACP subprocess — driving `StallDetector` to `.stalled` at 20s and, held past 180s, the **send watchdog** (which `interrupt()`s, force-releases `isSending`, and shows "Response took too long. Try again."). A **generation-guarded auto-resume** SIGCONTs after `durationMs` so a forgotten resume can never wedge the agent.
- **`resume_agent_stream`**: SIGCONT immediately (early clear).

Safety: both are gated on `AppBuild.isNonProduction` at the action **and** the actor method (and the bridge itself never opens on prod); the actor methods no-op cleanly when no agent process is running; auto-resume skips a process whose pid changed (torn-down/relaunched) to avoid a reused-pid SIGCONT.

## Verification

- Build green. `AgentRuntimeProcessTests` **33** (added: suspend/resume no-op without a process; a source-invariant that the hook is non-prod-gated, guards a live pid, uses real SIGSTOP/SIGCONT, caps the window, generation-guards auto-resume, and that the bridge registers both gated actions). `StallDetectorTests` **15** (added: a 180s-scale gap stays `.stalled`). e2e flow coverage **2/2**.
- **Independent review**: no blockers — confirmed the stdout reader can't deadlock the actor under SIGSTOP, the prod gating has no bypass, and no generation sequence leaves the process permanently frozen; its one should-fix (reused-pid SIGCONT after a mid-freeze restart) and nits are addressed.

## For the CHAT-02 verifier (Wave 13)

`e2e/SKILL.md` §2e has the exact recipe. One-liner to induce the stall against a named test bundle's automation port:

```bash
./scripts/omi-ctl action suspend_agent_stream durationMs=190000
```

Then, within ≤180s, `./scripts/omi-ctl action main_chat_snapshot` reports `has_error=true` / `error_message="Response took too long…"` / `is_sending=false`; `resume_agent_stream` + a fresh `ask` proves recovery.

Automation-only (never on prod) → `no-changelog-needed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9269?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

