### PR TITLE
fix(app): avoid deactivated-context crash in speaker filter sheet

### DIFF
--- a/app/lib/pages/conversations/widgets/speaker_filter_sheet.dart
+++ b/app/lib/pages/conversations/widgets/speaker_filter_sheet.dart
@@ -11,6 +11,10 @@ typedef SpeakerSelected = Future<void> Function(String? speakerId);
 Future<void> showSpeakerFilterSheet(BuildContext context) async {
   final conversationProvider = context.read<ConversationProvider>();
   final people = context.read<PeopleProvider>().people;
+  final l10n = context.l10n;
+  final title = l10n.phoneSpeaker;
+  final allLabel = l10n.all;
+  final userLabel = l10n.speakerLabelYou;
 
   await showModalBottomSheet<void>(
     context: context,
@@ -20,9 +24,9 @@ Future<void> showSpeakerFilterSheet(BuildContext context) async {
       return SpeakerFilterSheet(
         people: people,
         selectedSpeakerId: conversationProvider.selectedSpeakerId,
-        title: context.l10n.phoneSpeaker,
-        allLabel: context.l10n.all,
-        userLabel: context.l10n.speakerLabelYou,
+        title: title,
+        allLabel: allLabel,
+        userLabel: userLabel,
         onSelected: (speakerId) async {
           Navigator.of(sheetContext).pop();
           await conversationProvider.setSpeakerFilter(speakerId);


### PR DESCRIPTION
## Problem

Tapping the **search icon** on the Conversations tab and then the **person icon** beside the search field threw a Crashlytics-reported error:

> Looking up a deactivated widget's ancestor is unsafe.

Stack trace pointed at `showSpeakerFilterSheet` → `context.l10n` → `Localizations.of(context)` → `dependOnInheritedWidgetOfExactType`.

## Cause

`showSpeakerFilterSheet` read `context.l10n.*` **inside** the `showModalBottomSheet` `builder`. That builder runs after the sheet route mounts, by which point the tapped search-bar widget owning the outer `context` has been deactivated — so the `Localizations.of` ancestor lookup on that stale context throws.

## Fix

Resolve the three l10n strings up front, while `context` is still active (exactly as the providers are already read up front), and pass them into `SpeakerFilterSheet`. The builder no longer touches the outer context for anything but `Navigator.of(sheetContext)`, which is always valid.

## Verification

- `flutter analyze lib/pages/conversations/widgets/speaker_filter_sheet.dart` → **No issues found**.
- Reasoning: the builder no longer performs any inherited-widget lookup on the outer (deactivated) context, which is the exact operation the stack trace faulted on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9273?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

