### PR TITLE
fix(app): stop forcing CV1 onboarding on omi-enumerated non-CV1 devices

### DIFF
--- a/app/lib/pages/home/page.dart
+++ b/app/lib/pages/home/page.dart
@@ -482,10 +482,11 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver, Ticker
     if (device.type != DeviceType.omi) return;
     if (!mounted) return;
 
-    // Onboarding targets the consumer pendant; DevKit boards also enumerate as
-    // DeviceType.omi, so skip them. pairedDevice has the GATT model by now.
+    // Onboarding is the CV1 consumer-pendant button tutorial. DevKit/Glass/Neo/
+    // Friend all also enumerate as DeviceType.omi, so only proceed for a positively
+    // identified CV1. pairedDevice has the GATT model by now.
     final pairedModel = Provider.of<DeviceProvider>(context, listen: false).pairedDevice?.modelNumber;
-    if (DeviceUtils.isOmiDevKit(modelNumber: pairedModel, deviceName: device.name)) return;
+    if (!DeviceUtils.isOmiCv1(modelNumber: pairedModel, deviceName: device.name)) return;
 
     if (_deviceOnboardingShown) return;
     if (SharedPreferencesUtil().deviceOnboardingCompleted) return;

--- a/app/lib/utils/device.dart
+++ b/app/lib/utils/device.dart
@@ -48,12 +48,14 @@ class DeviceUtils {
   }
 
   /// Whether an Omi-type device is a DevKit board rather than the consumer
-  /// pendant. Match on `DEVKIT`, not a loose `DEV` — the consumer's default
-  /// model fallback is `'Omi Device'`.
+  /// pendant. Match on `DEVKIT`/`DEV KIT` (both spellings ship, e.g.
+  /// "Friend Dev Kit 1"), not a loose `DEV` — the consumer's default model
+  /// fallback is `'Omi Device'`.
   static bool isOmiDevKit({String? modelNumber, String? deviceName}) {
     bool matches(String? value) {
       if (value == null || value.isEmpty) return false;
-      return value.toUpperCase().contains('DEVKIT');
+      final upper = value.toUpperCase();
+      return upper.contains('DEVKIT') || upper.contains('DEV KIT');
     }
 
     return matches(modelNumber) || matches(deviceName);

--- a/app/test/utils/device_test.dart
+++ b/app/test/utils/device_test.dart
@@ -12,6 +12,11 @@ void main() {
       expect(DeviceUtils.isOmiDevKit(deviceName: 'Omi DevKit'), isTrue);
     });
 
+    test('detects the spaced "Dev Kit" spelling (Friend Dev Kit 1)', () {
+      expect(DeviceUtils.isOmiDevKit(deviceName: 'Friend Dev Kit 1'), isTrue);
+      expect(DeviceUtils.isOmiDevKit(modelNumber: 'Omi Dev Kit 2'), isTrue);
+    });
+
     test('is case-insensitive', () {
       expect(DeviceUtils.isOmiDevKit(modelNumber: 'omi devkit 2'), isTrue);
     });
@@ -56,6 +61,11 @@ void main() {
 
     test('Friend DevKit 1 is NOT CV1', () {
       expect(DeviceUtils.isOmiCv1(modelNumber: 'Friend DevKit 1'), isFalse);
+    });
+
+    test('Friend Dev Kit 1 (spaced) is NOT CV1 — the forced-onboarding regression', () {
+      expect(DeviceUtils.isOmiCv1(deviceName: 'Friend Dev Kit 1'), isFalse);
+      expect(DeviceUtils.isOmiCv1(modelNumber: 'Friend Dev Kit 1'), isFalse);
     });
 
     test('Glass is NOT CV1', () {


### PR DESCRIPTION
## Problem

Connecting a **Friend Dev Kit 1** force-showed the interactive device onboarding — the CV1 consumer-pendant button tutorial (transcription demo → single-press → power-cycle → double-tap config). That tutorial is meant only for the CV1 pendant.

## Cause

DevKit boards (and Glass / Neo / Friend) share the omi BLE service UUID, so they all enumerate as `DeviceType.omi`. The onboarding gate in `_checkDeviceOnboarding` tried to skip DevKits via `DeviceUtils.isOmiDevKit`, but that helper only matched the substring `DEVKIT` (no space):

```dart
return value.toUpperCase().contains('DEVKIT');
```

The device advertises **"Friend Dev Kit 1"** → `"FRIEND DEV KIT 1"`, which contains `"DEV KIT"` (spaced) but not `"DEVKIT"`. So the skip didn't fire and the CV1 tutorial was shown. This contradicted the sibling helpers `isOmiCv1` (excludes `'DEV KIT'`) and `getDeviceImagePath`, which already treat the same device as *not* a CV1.

## Fix

1. **`lib/pages/home/page.dart`** — flip the gate from deny-listing DevKit to allow-listing CV1:
   ```dart
   if (!DeviceUtils.isOmiCv1(modelNumber: pairedModel, deviceName: device.name)) return;
   ```
   `isOmiCv1`'s documented purpose is *"scoping CV1-only UI like the button tutorial"* — exactly this flow. Onboarding now fires only for a positively-identified CV1, and also correctly skips Glass / Neo / Friend.

2. **`lib/utils/device.dart`** — `isOmiDevKit` now also matches the spaced `"DEV KIT"` spelling. It's no longer called in `lib/` after (1), but it's a public helper that carried the same space bug — this removes the latent trap and makes it consistent with its siblings.

3. **`test/utils/device_test.dart`** — regression tests for the spaced `"Friend Dev Kit 1"` form in both `isOmiDevKit` and `isOmiCv1` groups.

## Verification

- `flutter test test/utils/device_test.dart` → **22/22 pass**, including `isOmiCv1(deviceName: 'Friend Dev Kit 1') == false` (the assertion that would have caught this bug).
- `flutter analyze lib/pages/home/page.dart lib/utils/device.dart test/utils/device_test.dart` → no new issues (remaining infos are pre-existing, far from the edited gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9274?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

