### PR TITLE
fix(mcp): typed error + index for screen_activity missing-index 500 (#9189)

### DIFF
--- a/backend/routers/mcp_sse.py
+++ b/backend/routers/mcp_sse.py
@@ -19,6 +19,7 @@ from urllib.parse import urlencode, urlsplit, urlunsplit, parse_qsl
 from pydantic import BaseModel
 
 import firebase_admin.auth
+from google.api_core.exceptions import FailedPrecondition
 from fastapi import APIRouter, HTTPException, Header, Request, Response, Form
 from fastapi.responses import StreamingResponse, JSONResponse, HTMLResponse
 from fastapi.templating import Jinja2Templates
@@ -742,6 +743,20 @@ def _raise_tool_error_from_http(exc: HTTPException) -> NoReturn:
     raise ToolExecutionError(str(exc.detail)) from exc
 
 
+def _raise_screen_activity_index_error(exc: FailedPrecondition) -> NoReturn:
+    """Turn a missing-Firestore-index failure into a typed, actionable tool error.
+
+    The app-filtered screen activity query needs a composite index (appName +
+    timestamp). Without it Firestore raises FailedPrecondition, which otherwise
+    surfaces to the MCP client as an opaque 500 (see AGENTS.md gotcha #7).
+    """
+    raise ToolExecutionError(
+        "Screen activity isn't queryable right now — its search index is still being built. "
+        "Retry in a few minutes, or narrow the request by removing the app filter.",
+        code=-32009,
+    ) from exc
+
+
 def _parse_mcp_date(value: Optional[str], field: str) -> Optional[datetime]:
     """Parse a yyyy-mm-dd MCP argument into a datetime, or None when absent."""
     if not value:
@@ -1289,14 +1304,20 @@ def execute_tool(
         app = arguments.get("app")
         summary = parse_mcp_bool(arguments.get("summary"), "summary", default=False)
         if summary:
-            return screen_activity_db.get_screen_activity_summary(user_id, start_date=start, end_date=end)
+            try:
+                return screen_activity_db.get_screen_activity_summary(user_id, start_date=start, end_date=end)
+            except FailedPrecondition as e:
+                _raise_screen_activity_index_error(e)
         try:
             limit = parse_mcp_int(arguments.get("limit"), "limit", default=200, minimum=1, maximum=1000)
         except ValueError as e:
             raise ToolExecutionError(str(e), code=-32602)
-        rows = screen_activity_db.get_screen_activity(
-            user_id, start_date=start, end_date=end, app_filter=app, limit=limit
-        )
+        try:
+            rows = screen_activity_db.get_screen_activity(
+                user_id, start_date=start, end_date=end, app_filter=app, limit=limit
+            )
+        except FailedPrecondition as e:
+            _raise_screen_activity_index_error(e)
         return {"screen_activity": [clean_screen_activity_row(r) for r in rows]}
 
     elif tool_name == "get_daily_summaries":

--- a/backend/tests/unit/test_firestore_index_config.py
+++ b/backend/tests/unit/test_firestore_index_config.py
@@ -56,3 +56,21 @@ def test_firestore_config_declares_mcp_conversation_category_filter_index():
         and _fields(index) == required_fields
         for index in _index_specs()
     )
+
+
+def test_firestore_config_declares_screen_activity_app_filter_index():
+    # Regression for #9189: the MCP get_screen_activity tool filters by appName
+    # and orders/ranges on timestamp, which needs this composite index — without
+    # it Firestore raises FailedPrecondition and the tool returned an opaque 500.
+    required_fields = [
+        ('appName', 'ASCENDING'),
+        ('timestamp', 'ASCENDING'),
+        ('__name__', 'ASCENDING'),
+    ]
+
+    assert any(
+        index.get('collectionGroup') == 'screen_activity'
+        and index.get('queryScope') == 'COLLECTION'
+        and _fields(index) == required_fields
+        for index in _index_specs()
+    )

--- a/backend/tests/unit/test_mcp_data_endpoints.py
+++ b/backend/tests/unit/test_mcp_data_endpoints.py
@@ -99,6 +99,8 @@ _stubs = [
     'google.cloud.firestore_v1.FieldFilter',
     'google',
     'google.cloud',
+    'google.api_core',
+    'google.api_core.exceptions',
     'pinecone',
     'typesense',
     'opuslib',
@@ -144,6 +146,7 @@ sys.modules['firebase_admin.auth'].ExpiredIdTokenError = type('ExpiredIdTokenErr
 sys.modules['firebase_admin.auth'].RevokedIdTokenError = type('RevokedIdTokenError', (Exception,), {})
 sys.modules['firebase_admin.auth'].CertificateFetchError = type('CertificateFetchError', (Exception,), {})
 sys.modules['firebase_admin.auth'].UserNotFoundError = type('UserNotFoundError', (Exception,), {})
+sys.modules['google.api_core.exceptions'].FailedPrecondition = type('FailedPrecondition', (Exception,), {})
 
 from routers import mcp as rest  # noqa: E402
 from routers import mcp_sse as sse  # noqa: E402
@@ -492,6 +495,27 @@ class TestScreenActivity:
         mock_db.get_screen_activity_summary.return_value = {'apps': {}, 'total_screenshots': 0}
         result = sse.execute_tool(UID, 'get_screen_activity', {'summary': True})
         assert result['total_screenshots'] == 0
+
+    @patch('routers.mcp_sse.screen_activity_db')
+    def test_tool_rows_missing_index_returns_typed_error(self, mock_db):
+        # Regression for #9189: a missing Firestore index must surface as a typed,
+        # actionable ToolExecutionError, not an opaque 500.
+        from google.api_core.exceptions import FailedPrecondition
+
+        mock_db.get_screen_activity.side_effect = FailedPrecondition('query requires an index')
+        with pytest.raises(sse.ToolExecutionError) as exc_info:
+            sse.execute_tool(UID, 'get_screen_activity', {'app': 'Cursor'})
+        assert exc_info.value.code == -32009
+        assert 'index' in exc_info.value.message.lower()
+
+    @patch('routers.mcp_sse.screen_activity_db')
+    def test_tool_summary_missing_index_returns_typed_error(self, mock_db):
+        from google.api_core.exceptions import FailedPrecondition
+
+        mock_db.get_screen_activity_summary.side_effect = FailedPrecondition('query requires an index')
+        with pytest.raises(sse.ToolExecutionError) as exc_info:
+            sse.execute_tool(UID, 'get_screen_activity', {'summary': True})
+        assert exc_info.value.code == -32009
 
 
 class TestDailySummaries:

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -85,6 +85,15 @@
         { "fieldPath": "lease_expires_at", "order": "ASCENDING" },
         { "fieldPath": "__name__", "order": "ASCENDING" }
       ]
+    },
+    {
+      "collectionGroup": "screen_activity",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "appName", "order": "ASCENDING" },
+        { "fieldPath": "timestamp", "order": "ASCENDING" },
+        { "fieldPath": "__name__", "order": "ASCENDING" }
+      ]
     }
   ],
   "fieldOverrides": []


### PR DESCRIPTION
## What

The MCP `get_screen_activity` tool returned an opaque **500** when its filtered Firestore query hit a missing-index error. This fixes both the root cause and the failure mode:

1. **Declare the missing composite index** in `firestore.indexes.json` — `screen_activity` (COLLECTION): `appName ASC, timestamp ASC, __name__ ASC`. The tool's app-filtered query orders/ranges on `timestamp` and filters on `appName`, which requires this index. Provisioning it via config (not by hand) is the durable fix.
2. **Convert `FailedPrecondition` into a typed, actionable MCP tool error** (`ToolExecutionError`, code `-32009`) on both the rows and summary paths, so a still-building/absent index degrades gracefully instead of surfacing a generic 500. (`AGENTS.md` gotcha #7: "Firestore collection group queries need explicit indexes — 500 with no useful error.")

## Why (evidence from the issue)

> Dev `/v1/mcp/sse` returned a 500 when the MCP `get_screen_activity` tool hit a Firestore missing-index error for a filtered screen activity query.
> ```
> /v1/mcp/sse 500 · MCP tool get_screen_activity
> Firestore FailedPrecondition: query requires an index
> collection group: screen_activity · order/filter shape: appName ASC, timestamp ASC, __name__ ASC
> ```

Acceptance criteria from #9189 addressed: index declared, `FailedPrecondition` → typed actionable error, regression coverage added.

## What I verified

- **Real code path** (not just mocks): imported `routers.mcp_sse.execute_tool` and raised a genuine `google.api_core.exceptions.FailedPrecondition` from the DB layer — both the app-filtered and `summary` paths return `ToolExecutionError(code=-32009)` with the actionable message; the happy path still returns rows. `execute_tool`'s caller catches `ToolExecutionError` → `create_mcp_error` (JSON-RPC error, HTTP 200), so the 500 is gone.
- **Tests** (`backend/.venv`, py3.11):
  - `tests/unit/test_mcp_data_endpoints.py::TestScreenActivity` — added `test_tool_rows_missing_index_returns_typed_error` and `test_tool_summary_missing_index_returns_typed_error` (both PASS).
  - `tests/unit/test_firestore_index_config.py::test_firestore_config_declares_screen_activity_app_filter_index` (PASS).
  - Full `test_mcp_data_endpoints.py`, `test_firestore_index_config.py`, `test_firestore_indexes.py`, `test_mcp_oauth.py`, `test_screen_activity_*` all green.
- `black --line-length 120 --skip-string-normalization` clean; `firestore.indexes.json` validates.

## Scope note

Code + index-config only. Actually applying the index to a given Firestore project is a deploy/ops step (`firebase deploy --only firestore:indexes` or the console); until it lands, the tool now returns a clear, retryable error instead of a 500.

Auto-generated from issue feedback by the mini issues-improver. Review before merge.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9276?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

