### PR TITLE
fix(desktop): WAL flush marks storage=disk without persisting frames — data loss (#9240)

### DIFF
--- a/desktop/macos/Desktop/Sources/WAL/WALService.swift
+++ b/desktop/macos/Desktop/Sources/WAL/WALService.swift
@@ -73,6 +73,10 @@ final class WALService: ObservableObject {
         try await uploadWalToCloud(wal)
     }
 
+    func flushToDiskForTesting() {
+        flushToDisk()
+    }
+
     private var walDirectory: URL?
     private var flushTimer: Timer?
     private var chunkTimer: Timer?
@@ -400,8 +404,20 @@ final class WALService: ObservableObject {
     }
 
     private func writeWalToDisk(at index: Int) {
-        // For in-memory WALs that don't have frames here, just mark as disk
-        // In a full implementation, this would write buffered frames
+        // Frames are persisted by `writeFramesToDisk` when the WAL is created;
+        // there is no separate in-memory frame buffer to flush here. Only promote
+        // to `.disk` once the backing file actually exists — otherwise we'd mark an
+        // entry `.disk` with no frames and no `filePath`, which sends it into the
+        // sync path where it fails with `fileNotFound` and the recording is lost
+        // (#9240). Leave it `.memory` so the in-flight write (or a retry) can
+        // complete it.
+        guard let walDir = walDirectory,
+              let fileName = wals[index].filePath, !fileName.isEmpty,
+              fileManager.fileExists(atPath: walDir.appendingPathComponent(fileName).path)
+        else {
+            logger.warning("WALService: skipping disk promotion for \(self.wals[index].id); frames not yet persisted")
+            return
+        }
         wals[index].storage = .disk
     }
 

--- a/desktop/macos/Desktop/Tests/WALServiceUploadTests.swift
+++ b/desktop/macos/Desktop/Tests/WALServiceUploadTests.swift
@@ -94,4 +94,45 @@ final class WALServiceUploadTests: XCTestCase {
 
     XCTAssertEqual(service.wals.first?.status, .miss)
   }
+
+  // #9240: flush must not promote a `.memory` WAL to `.disk` when its frames were
+  // never persisted — doing so loses the recording and sends a filePath-less entry
+  // into the sync path where it fails with fileNotFound.
+  func testFlushDoesNotPromoteMemoryWalWithoutBackingFile() throws {
+    let wal = WALEntry(
+      timerStart: 1_700_000_100,
+      codec: "opus",
+      status: .miss,
+      storage: .memory,
+      filePath: nil,
+      seconds: 60,
+      device: "dev1",
+      deviceModel: "Omi"
+    )
+    service.setWalsForTesting([wal])
+
+    service.flushToDiskForTesting()
+
+    XCTAssertEqual(service.wals.first?.storage, .memory)
+  }
+
+  func testFlushPromotesMemoryWalOnceFileIsOnDisk() throws {
+    let fileName = "audio_dev1_opus_16000_1_fs80_1700000200.bin"
+    try Data([0x01, 0x02, 0x03]).write(to: walDir.appendingPathComponent(fileName))
+    let wal = WALEntry(
+      timerStart: 1_700_000_200,
+      codec: "opus",
+      status: .miss,
+      storage: .memory,
+      filePath: fileName,
+      seconds: 60,
+      device: "dev1",
+      deviceModel: "Omi"
+    )
+    service.setWalsForTesting([wal])
+
+    service.flushToDiskForTesting()
+
+    XCTAssertEqual(service.wals.first?.storage, .disk)
+  }
 }

--- a/desktop/macos/changelog/unreleased/20260708-wal-flush-data-loss.json
+++ b/desktop/macos/changelog/unreleased/20260708-wal-flush-data-loss.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed a data-loss bug where periodic WAL flush could mark a recording as saved to disk without actually persisting it, causing the audio to be lost during sync"
+}


### PR DESCRIPTION
## Bug (#9240)

`WALService.writeWalToDisk(at:)` was a stub that unconditionally flipped an in-memory WAL to `storage = .disk` during the periodic `flushToDisk()` pass, **without writing frames or setting `filePath`** — causing WAL (recording) data loss.

## Root cause

Frames are persisted asynchronously when a WAL is created (`writeFramesToDisk`) and are **not retained per-WAL** in memory. So a WAL only remains `.memory` when its write is still in flight or has failed. The `flushToDisk()` timer iterates all `.memory` WALs and called `writeWalToDisk`, which just set `storage = .disk`.

Once falsely marked `.disk`, the entry matches `syncToCloud()`'s filter (`status == .miss && storage == .disk`). `uploadWalToCloud()` then hits `guard let filePath = wal.filePath` on a `nil` path, throws `WALError.fileNotFound`, and the recording is silently lost (and spams sync errors).

## Fix

Only promote a WAL to `.disk` when its backing file **actually exists** on disk (non-empty `filePath` + file present). Otherwise leave it `.memory` so the in-flight write — or a retry — can complete it. Surgical change to one method; no behavior change on the happy path (frames written at creation already set `filePath` + `.disk`).

## Tests

Added regression tests to `WALServiceUploadTests`:
- `testFlushDoesNotPromoteMemoryWalWithoutBackingFile` — a `.memory` WAL with no file stays `.memory` (fails against the old stub).
- `testFlushPromotesMemoryWalOnceFileIsOnDisk` — promotes to `.disk` once the file is present.

## Verification

- `xcrun swift build -c debug --package-path Desktop` — build complete.
- `xcrun swift test --package-path Desktop --filter WALServiceUploadTests` — 6/6 pass.

🤖 automated by hourly watchdog; opened for review, not merged.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9277?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

