### PR TITLE
desktop: center the Home hub cluster vertically

### DIFF
--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
@@ -665,10 +665,15 @@ struct DashboardPage: View {
                     .transition(.homeSuggestionsFade)
             }
 
-            // Lifts the hub cluster toward the optical center; collapses while
+            // Hub: flexible spacer balances the flexible stage area above, so
+            // the wordmark→suggestions cluster sits vertically centered (a
+            // touch above true center) at any window height. Collapses while
             // a panel is up so the ask bar anchors at the bottom.
-            Spacer(minLength: 0)
-                .frame(height: homeMode == .hub ? 64 : 0)
+            if homeMode == .hub {
+                Spacer(minLength: 0)
+                    .frame(maxHeight: .infinity)
+                    .transition(.homeSuggestionsFade)
+            }
         }
         .padding(.top, 74)
         .padding(.bottom, 26)

--- a/desktop/macos/changelog/unreleased/20260708-home-hub-centered.json
+++ b/desktop/macos/changelog/unreleased/20260708-home-hub-centered.json
@@ -1,0 +1,3 @@
+{
+  "change": "Centered the Home content vertically so it no longer sits low on tall windows"
+}


### PR DESCRIPTION
The fixed 64pt lift spacer pinned the Home cluster (wordmark, tiles, ask bar, suggestions) low on tall windows. A flexible bottom spacer now balances the flexible area above, centering the cluster at any window height; it still collapses when the inline chat / Connect tray anchors the bar at the bottom.

Verified in the omi-home-chat bundle: hub centered, chat mode still bottom-anchors the bar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9278?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

