### PR TITLE
fix(app): center FaIcon glyphs broken by the Font Awesome v11 migration

### DIFF
--- a/app/lib/pages/capture/connect.dart
+++ b/app/lib/pages/capture/connect.dart
@@ -54,6 +54,7 @@ class _ConnectDevicePageState extends State<ConnectDevicePage> {
             child: Container(
               width: 36,
               height: 36,
+              alignment: Alignment.center,
               decoration: const BoxDecoration(color: Color(0xFF1F1F25), shape: BoxShape.circle),
               child: FaIcon(FontAwesomeIcons.chevronLeft, size: 16, color: Colors.white70),
             ),

--- a/app/lib/pages/chat/page.dart
+++ b/app/lib/pages/chat/page.dart
@@ -435,6 +435,7 @@ class ChatPageState extends State<ChatPage> with AutomaticKeepAliveClientMixin {
                                                 child: Container(
                                                   width: 16,
                                                   height: 16,
+                                                  alignment: Alignment.center,
                                                   decoration: BoxDecoration(
                                                     color: Colors.white,
                                                     borderRadius: BorderRadius.circular(10),


### PR DESCRIPTION
## Problem

The Font Awesome v11 migration ([`0bd8cacf73`](https://github.com/BasedHardware/omi/commit/0bd8cacf73), *"restore FaIcon across 69 app files"*) mass-swapped `Icon(SomeIcons.x.data, …)` → `FaIcon(SomeIcons.x, …)`. The stock `Icon` widget wraps its glyph in `SizedBox(iconSize, iconSize)` + `Center`, so it self-centers inside a parent box. `FaIcon` (font_awesome_flutter 11.0.0) does **not** — its `build()` returns just `Semantics(child: ExcludeSemantics(child: RichText(glyph)))`, a tight glyph-sized box with no centering.

Result: any `FaIcon` that sits in a **fixed-size box** which relied on `Icon`'s implicit centering now renders pinned to the **top-left corner**.

## Fixes in this PR

| Screen | Site | Box |
|---|---|---|
| **Connect** — back-arrow button | `lib/pages/capture/connect.dart` | 36×36 circle / 16px chevron |
| **Chat** — attachment thumbnail "×" remove button | `lib/pages/chat/page.dart` | 16×16 circle / 10px ✕ |

Both get `alignment: Alignment.center` on the container, restoring the centering `Icon` used to provide. (Icons inside `IconButton` — e.g. the Connect gear — were unaffected because `IconButton` centers its icon.)

## Scope note

An audit of all ~55 app files touched by that commit found **13 more** at-risk sites of the same class (device settings rows, settings drawer/profile row icons, battery card, action-item badges, task-integration tiles, etc.). Those are being reviewed visually first and will land separately; this PR covers the two confirmed-visible ones.

## Verification

- `flutter analyze` on both changed files → no new issues (only pre-existing `prefer_const` infos).
- Root cause confirmed against the `FaIcon` source in `font_awesome_flutter-11.0.0` (no `SizedBox`+`Center` wrapper, unlike stock `Icon`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)