### PR TITLE
fix(desktop): restore chat screen vision behind a Screen Sharing in Chat setting

### DIFF
--- a/desktop/macos/Desktop/Sources/DefaultsKey.swift
+++ b/desktop/macos/Desktop/Sources/DefaultsKey.swift
@@ -28,6 +28,7 @@ enum DefaultsKey: String {
     case authIsImpersonating = "auth_isImpersonating"
     case chatBridgeMode = "chatBridgeMode"
     case onboardingStep = "onboardingStep"
+    case chatScreenshotSharingEnabled = "chatScreenshotSharingEnabled"
 }
 
 /// Typed accessors that take a `DefaultsKey` instead of a `String`.

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+FloatingBarAndChat.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+FloatingBarAndChat.swift
@@ -94,6 +94,23 @@ extension SettingsContentView {
         }
       }
 
+      settingsCard(settingId: "floatingbar.screenshare") {
+        HStack(spacing: 16) {
+          VStack(alignment: .leading, spacing: 4) {
+            Text("Screen Sharing in Chat")
+              .scaledFont(size: 16, weight: .semibold)
+              .foregroundColor(OmiColors.textPrimary)
+            Text("Let Ask Omi capture your screen when you ask about what's on it.")
+              .scaledFont(size: 13)
+              .foregroundColor(OmiColors.textSecondary)
+          }
+          Spacer()
+          Toggle("", isOn: $chatScreenshotSharingEnabled)
+            .toggleStyle(.switch)
+            .labelsHidden()
+        }
+      }
+
       voicePicker(settingId: "floatingbar.voice")
         .opacity(shortcutSettings.hasAnyFloatingBarVoiceAnswersEnabled ? 1 : 0.55)
         .disabled(!shortcutSettings.hasAnyFloatingBarVoiceAnswersEnabled)

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
@@ -132,6 +132,11 @@ struct SettingsContentView: View {
   // Ask Omi floating bar state
   @State var showAskOmiBar: Bool = false
 
+  // Grant for chat screenshot tools (capture_screen / get_screenshot);
+  // read by ChatToolExecutor.localPolicyDecision. Default on.
+  @AppStorage(DefaultsKey.chatScreenshotSharingEnabled.rawValue)
+  var chatScreenshotSharingEnabled: Bool = true
+
   // Transcription state
   @State var isTranscribing: Bool
   @State var isTogglingTranscription: Bool = false

--- a/desktop/macos/Desktop/Sources/MainWindow/SettingsSidebar.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/SettingsSidebar.swift
@@ -267,6 +267,11 @@ struct SettingsSearchItem: Identifiable {
       keywords: ["typed", "text", "speech", "tts", "audio answers"], section: .floatingBar,
       icon: "sparkles", settingId: "floatingbar.typedvoiceanswers"),
     SettingsSearchItem(
+      name: "Screen Sharing in Chat",
+      subtitle: "Let Ask Omi capture your screen when you ask about it",
+      keywords: ["screenshot", "screen", "capture", "share screen", "vision", "see my screen"],
+      section: .floatingBar, icon: "camera.viewfinder", settingId: "floatingbar.screenshare"),
+    SettingsSearchItem(
       name: "Voice Speed", subtitle: "Adjust the playback speed for voice replies",
       keywords: ["voice speed", "speech speed", "playback speed", "tts speed"],
       section: .floatingBar, icon: "sparkles", settingId: "floatingbar.voicespeed"),

--- a/desktop/macos/Desktop/Sources/Providers/ChatToolExecutor.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatToolExecutor.swift
@@ -230,17 +230,33 @@ class ChatToolExecutor {
       return .allow
 
     case "capture_screen", "get_screenshot":
+      // Screen-image bytes flow to the chat model only while the user-facing
+      // "Screen Sharing in Chat" setting is on (default on — asking Omi about
+      // the screen is the consent signal). The original unconditional deny
+      // shipped without any approval flow, leaving chat screen vision dead.
+      if isChatScreenshotSharingEnabled {
+        return .allow
+      }
       return .deny(
         policyDeniedMessage(
           toolName: toolName,
           code: "approval_required",
           capability: "desktop.context.screenshot_image",
-          message: "Screenshot image access requires explicit approval before Omi can share screen image bytes."
+          message:
+            "Screenshot sharing is turned off. The user can enable \"Screen Sharing in Chat\" in Settings → Floating Bar to let Omi see the screen."
         ))
 
     default:
       return .allow
     }
+  }
+
+  /// User-facing grant for `desktop.context.screenshot_image`. Stored in
+  /// UserDefaults so the nonisolated policy check can read it synchronously;
+  /// absent key means enabled (default on).
+  nonisolated static var isChatScreenshotSharingEnabled: Bool {
+    UserDefaults.standard.object(forKey: DefaultsKey.chatScreenshotSharingEnabled.rawValue) == nil
+      || UserDefaults.standard.bool(forKey: DefaultsKey.chatScreenshotSharingEnabled)
   }
 
   private nonisolated static func policyDeniedMessage(

--- a/desktop/macos/Desktop/Sources/Providers/ChatToolExecutor.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatToolExecutor.swift
@@ -232,15 +232,14 @@ class ChatToolExecutor {
     case "capture_screen", "get_screenshot":
       // Screen-image bytes flow to the chat model only while the user-facing
       // "Screen Sharing in Chat" setting is on (default on — asking Omi about
-      // the screen is the consent signal). The original unconditional deny
-      // shipped without any approval flow, leaving chat screen vision dead.
+      // the screen is the consent signal).
       if isChatScreenshotSharingEnabled {
         return .allow
       }
       return .deny(
         policyDeniedMessage(
           toolName: toolName,
-          code: "approval_required",
+          code: "disabled_by_user_setting",
           capability: "desktop.context.screenshot_image",
           message:
             "Screenshot sharing is turned off. The user can enable \"Screen Sharing in Chat\" in Settings → Floating Bar to let Omi see the screen."

--- a/desktop/macos/Desktop/Tests/CaptureScreenToolTests.swift
+++ b/desktop/macos/Desktop/Tests/CaptureScreenToolTests.swift
@@ -5,11 +5,20 @@ import XCTest
 @MainActor
 final class CaptureScreenToolTests: XCTestCase {
 
+  private let screenshotKey = DefaultsKey.chatScreenshotSharingEnabled.rawValue
+
+  override func tearDown() {
+    UserDefaults.standard.removeObject(forKey: screenshotKey)
+    super.tearDown()
+  }
+
   // MARK: - Tool dispatch
 
   /// Verify "capture_screen" is handled by ChatToolExecutor and does NOT fall
-  /// through to "Unknown tool: capture_screen".
-  func testCaptureScreenToolIsDeniedByDefaultPolicy() async {
+  /// through to "Unknown tool: capture_screen". With Screen Sharing in Chat off,
+  /// it must fail closed with the policy denial.
+  func testCaptureScreenToolIsDeniedWhenSharingDisabled() async {
+    UserDefaults.standard.set(false, forKey: screenshotKey)
     let toolCall = ToolCall(name: "capture_screen", arguments: [:], thoughtSignature: nil)
     let result = await ChatToolExecutor.execute(toolCall)
 
@@ -18,10 +27,11 @@ final class CaptureScreenToolTests: XCTestCase {
       "capture_screen should be dispatched, got: \(result)")
     XCTAssertTrue(result.hasPrefix("POLICY_DENIED:"), "capture_screen should fail closed, got: \(result)")
     XCTAssertTrue(result.contains("\"capability\":\"desktop.context.screenshot_image\""))
-    XCTAssertTrue(result.contains("Screenshot image access requires explicit approval"))
+    XCTAssertTrue(result.contains("Screen Sharing in Chat"))
   }
 
-  func testScreenshotImagePolicyDeniesLocalImageBytesByDefault() {
+  func testScreenshotImagePolicyDeniesLocalImageBytesWhenSharingDisabled() {
+    UserDefaults.standard.set(false, forKey: screenshotKey)
     for toolName in ["capture_screen", "get_screenshot"] {
       let decision = ChatToolExecutor.localPolicyDecision(
         toolName: toolName,
@@ -32,8 +42,19 @@ final class CaptureScreenToolTests: XCTestCase {
       }
       XCTAssertTrue(message.hasPrefix("POLICY_DENIED:"))
       XCTAssertTrue(message.contains("\"capability\":\"desktop.context.screenshot_image\""))
-      XCTAssertTrue(message.contains("Screenshot image access requires explicit approval"))
       XCTAssertFalse(message.contains("123"))
+    }
+  }
+
+  /// Regression: chat screen vision was hard-denied with no approval path from
+  /// 2026-06-29 (a4160e40cf) until the Screen Sharing in Chat setting. Default
+  /// (setting unset) must allow the tools to dispatch.
+  func testScreenshotImagePolicyAllowsByDefault() {
+    UserDefaults.standard.removeObject(forKey: screenshotKey)
+    for toolName in ["capture_screen", "get_screenshot"] {
+      XCTAssertEqual(
+        ChatToolExecutor.localPolicyDecision(toolName: toolName, arguments: [:]), .allow,
+        "\(toolName) must dispatch when Screen Sharing in Chat is on (default)")
     }
   }
 

--- a/desktop/macos/Desktop/Tests/ChatToolExecutorPolicyTests.swift
+++ b/desktop/macos/Desktop/Tests/ChatToolExecutorPolicyTests.swift
@@ -40,8 +40,7 @@ final class ChatToolExecutorPolicyTests: XCTestCase {
 
   func testRawSensitiveSurfacesStillRequireApproval() {
     for (toolName, arguments, capability) in [
-      ("execute_sql", ["query": "UPDATE action_items SET completed = 1 WHERE id = 42"], "desktop.context.local_write"),
-      ("capture_screen", [:], "desktop.context.screenshot_image"),
+      ("execute_sql", ["query": "UPDATE action_items SET completed = 1 WHERE id = 42"], "desktop.context.local_write")
     ] {
       let decision = ChatToolExecutor.localPolicyDecision(toolName: toolName, arguments: arguments)
       guard case .deny(let message) = decision else {
@@ -49,6 +48,50 @@ final class ChatToolExecutorPolicyTests: XCTestCase {
       }
       XCTAssertTrue(message.hasPrefix("POLICY_DENIED:"), "\(toolName) returned: \(message)")
       XCTAssertTrue(message.contains("\"capability\":\"\(capability)\""), "\(toolName) returned: \(message)")
+    }
+  }
+
+  // MARK: - Chat screenshot sharing (regression: chat screen vision was hard-denied
+  // with no approval path from 2026-06-29 until the Screen Sharing in Chat setting)
+
+  private let screenshotKey = DefaultsKey.chatScreenshotSharingEnabled.rawValue
+
+  override func tearDown() {
+    UserDefaults.standard.removeObject(forKey: screenshotKey)
+    super.tearDown()
+  }
+
+  func testScreenshotToolsAllowedByDefault() {
+    UserDefaults.standard.removeObject(forKey: screenshotKey)
+    for toolName in ["capture_screen", "get_screenshot"] {
+      XCTAssertEqual(
+        ChatToolExecutor.localPolicyDecision(toolName: toolName, arguments: [:]), .allow,
+        "\(toolName) must be allowed when the setting is unset (default on)")
+    }
+  }
+
+  func testScreenshotToolsAllowedWhenSettingEnabled() {
+    UserDefaults.standard.set(true, forKey: screenshotKey)
+    XCTAssertEqual(
+      ChatToolExecutor.localPolicyDecision(toolName: "capture_screen", arguments: [:]), .allow)
+  }
+
+  func testScreenshotToolsDeniedWhenSettingDisabled() {
+    UserDefaults.standard.set(false, forKey: screenshotKey)
+    for toolName in ["capture_screen", "get_screenshot"] {
+      guard
+        case .deny(let message) = ChatToolExecutor.localPolicyDecision(
+          toolName: toolName, arguments: [:])
+      else {
+        return XCTFail("\(toolName) should be denied when Screen Sharing in Chat is off")
+      }
+      XCTAssertTrue(message.hasPrefix("POLICY_DENIED:"), "\(toolName) returned: \(message)")
+      XCTAssertTrue(
+        message.contains("\"capability\":\"desktop.context.screenshot_image\""),
+        "\(toolName) returned: \(message)")
+      XCTAssertTrue(
+        message.contains("Screen Sharing in Chat"),
+        "deny message should point the user at the setting; returned: \(message)")
     }
   }
 }

--- a/desktop/macos/changelog/unreleased/20260707-chat-screen-sharing.json
+++ b/desktop/macos/changelog/unreleased/20260707-chat-screen-sharing.json
@@ -1,0 +1,3 @@
+{
+  "change": "Ask Omi can see your screen again when you ask about it — screenshot sharing in chat was accidentally dead since June 29; a new \"Screen Sharing in Chat\" toggle in Settings → Floating Bar (on by default) controls it"
+}


### PR DESCRIPTION
Restores Ask Omi's ability to see the screen when the user asks about it.

## Bug

Since a4160e40cf (2026-06-29, "Gate ChatToolExecutor sensitive tools"), every `capture_screen` / `get_screenshot` call from chat was unconditionally `POLICY_DENIED` with `approval_required` — but no approval flow was ever built (no store, no UI, no flag). Chat screen vision has been dead on every build since; models fell back to describing the screen from Rewind OCR text via `execute_sql`, which is why the breakage was easy to miss.

## Fix

`ChatToolExecutor.localPolicyDecision` now honors a user-facing **"Screen Sharing in Chat"** setting:
- Default **ON** (absent key = enabled) — the user's own "what's on my screen?" question is the consent signal, and ON restores the pre-June-29 shipped behavior, still behind the OS-level Screen Recording permission.
- Settings → Floating Bar gets the toggle (plus a settings-search entry); when OFF the deny message tells the model to point the user at it, with code `disabled_by_user_setting`.
- The SQL-write gate from the same commit is untouched.
- New UserDefaults key routed through `DefaultsKey` (ratchet passes).

Known scope note (reviewer): the local agent API `get_screenshot` HTTP path (agent surface) is governed by the agent-side dispatch policy, not this toggle — the toggle covers the chat executor path, as its name says. Follow-up decision welcome.

## Verification

- Policy suites (`CaptureScreenToolTests`, `ChatToolExecutorPolicyTests`) rewritten for both states: 10/10.
- Ratchets green (`check-userdefaults-key-ratchet`, `check-sources-root-layout`); clean release build (`rm -rf .build && swift build -c release --triple arm64-apple-macosx`) exit 0.
- **Real end-to-end** (named test bundle with Screen Recording TCC, real Home chat): asked *"What is on my screen right now?"* → log shows `Executing tool: capture_screen` → `ScreenCaptureManager: Screenshot captured 3840x2160, WebP 207 KB` → the model's chat reply accurately described the live screen (tool chip shows it reading the captured .webp).
- **Off path**: `defaults write … chatScreenshotSharingEnabled -bool false` → same ask → `Tool capture_screen denied by local policy`, deny text references the setting.
- Settings → Floating Bar renders the new toggle (screenshot taken; default ON).
- Independent agent review: approved (minor nits addressed: truthful deny code; comment trimmed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9281?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

