### PR TITLE
fix(desktop/auth): store tokens in Keychain on all builds, drop UserDefaults fallback

### DIFF
--- a/desktop/macos/Desktop/Sources/AuthService.swift
+++ b/desktop/macos/Desktop/Sources/AuthService.swift
@@ -358,8 +358,14 @@ class AuthService {
     // UserDefaults keys for auth persistence (dev builds with ad-hoc signing).
     // Keys are defined once in `DefaultsKey` and read/written through the typed
     // `UserDefaults` accessors so a typo is a compile error, not a silent nil.
-    private let authTokenKeychainService = "com.omi.desktop.firebase-rest-session"
+    //
+    // Keychain service is team-scoped so Apple Development / named-bundle builds
+    // cannot poison the notarized Beta/Prod item (and trigger a login-keychain
+    // password dialog). See DesktopKeychainStore.scopedService.
     private let authTokenKeychainAccount = "firebase-rest-tokens"
+    private var authTokenKeychainService: String {
+        DesktopKeychainStore.scopedService(DesktopKeychainStore.legacyAuthTokenService)
+    }
 
     private struct StoredAuthTokens: Codable {
         let idToken: String
@@ -397,12 +403,18 @@ class AuthService {
             usesKeychainTokenStorage: { true },
             allowsUserDefaultsFallback: { false },
             readKeychainString: { service, account in
+                // Only the team-scoped service. Never query the unscoped legacy
+                // `com.omi.desktop.firebase-rest-session` item — a foreign-team ACL
+                // on that name is what triggers the login-keychain password dialog.
+                // Pre-scoping installs recover via the UserDefaults migration path below.
                 DesktopKeychainStore.string(service: service, account: account)
             },
             writeKeychainString: { value, service, account in
                 DesktopKeychainStore.setString(value, service: service, account: account)
             },
             deleteKeychainString: { service, account in
+                // Only delete the scoped item. Touching the legacy unscoped name can
+                // itself prompt when the ACL belongs to another signing team.
                 DesktopKeychainStore.delete(service: service, account: account)
             },
             recordsFallbackTelemetry: true

--- a/desktop/macos/Desktop/Sources/AuthService.swift
+++ b/desktop/macos/Desktop/Sources/AuthService.swift
@@ -359,9 +359,9 @@ class AuthService {
     // Keys are defined once in `DefaultsKey` and read/written through the typed
     // `UserDefaults` accessors so a typo is a compile error, not a silent nil.
     //
-    // Keychain service is team-scoped so Apple Development / named-bundle builds
-    // cannot poison the notarized Beta/Prod item (and trigger a login-keychain
-    // password dialog). See DesktopKeychainStore.scopedService.
+    // Keychain service is team+bundle scoped so local Dev / named-bundle builds
+    // cannot poison each other or notarized Beta/Prod (login-keychain password
+    // dialog). See DesktopKeychainStore.scopedService.
     private let authTokenKeychainAccount = "firebase-rest-tokens"
     private var authTokenKeychainService: String {
         DesktopKeychainStore.scopedService(DesktopKeychainStore.legacyAuthTokenService)
@@ -403,10 +403,10 @@ class AuthService {
             usesKeychainTokenStorage: { true },
             allowsUserDefaultsFallback: { false },
             readKeychainString: { service, account in
-                // Only the team-scoped service. Never query the unscoped legacy
-                // `com.omi.desktop.firebase-rest-session` item — a foreign-team ACL
-                // on that name is what triggers the login-keychain password dialog.
-                // Pre-scoping installs recover via the UserDefaults migration path below.
+                // Only the team+bundle scoped service. Never query the unscoped
+                // legacy `com.omi.desktop.firebase-rest-session` item — a foreign
+                // ACL on that name is what triggers the login-keychain password
+                // dialog. Pre-scoping installs recover via UserDefaults migration.
                 DesktopKeychainStore.string(service: service, account: account)
             },
             writeKeychainString: { value, service, account in

--- a/desktop/macos/Desktop/Sources/AuthService.swift
+++ b/desktop/macos/Desktop/Sources/AuthService.swift
@@ -384,9 +384,18 @@ class AuthService {
         var deleteKeychainString: (_ service: String, _ account: String) -> Void
         var recordsFallbackTelemetry: Bool
 
+        // Security invariant: auth tokens live in the Keychain on EVERY build — including
+        // dev and the Sparkle-distributed beta — and the plaintext UserDefaults write
+        // fallback is OFF. The file-based Keychain write now works on all builds (see
+        // DesktopKeychainStore), so a fallback that spills OAuth/refresh tokens into
+        // UserDefaults (plaintext on disk, included in backups, readable by any process with
+        // disk access) is pure risk with no correctness benefit. If a Keychain write fails we
+        // surface it via AuthError.keychainTokenStorageUnavailable instead of leaking secrets.
+        // The UserDefaults *read* path in storedTokens() is intentionally retained only to
+        // migrate pre-existing tokens into the Keychain on first launch, then clear them.
         static let live = TokenStorageHooks(
-            usesKeychainTokenStorage: { !AppBuild.isNonProduction },
-            allowsUserDefaultsFallback: { true },
+            usesKeychainTokenStorage: { true },
+            allowsUserDefaultsFallback: { false },
             readKeychainString: { service, account in
                 DesktopKeychainStore.string(service: service, account: account)
             },

--- a/desktop/macos/Desktop/Sources/ClientDeviceService.swift
+++ b/desktop/macos/Desktop/Sources/ClientDeviceService.swift
@@ -1,12 +1,12 @@
 import CryptoKit
 import Foundation
+import LocalAuthentication
 import Security
 
 /// Stable per-installation device identity for capture provenance (mirrors Flutter `deviceIdHash`).
 final class ClientDeviceService {
   static let shared = ClientDeviceService()
 
-  private let keychainService = "com.omi.client-device-id"
   private let keychainAccount = "install-uuid"
   private let devInstallIdDefaultsKey = "dev-client-device-install-uuid"
   private let installIdMirrorDefaultsKey = "client-device-install-uuid-mirror"
@@ -14,6 +14,16 @@ final class ClientDeviceService {
   private let userDefaults: UserDefaults
   private let cacheLock = NSLock()
   private var cachedInstallId: String?
+
+  /// Team+bundle scoped service for this process. Never the shared legacy
+  /// `com.omi.client-device-id` name — querying that from a binary not on its ACL
+  /// is what caused keychain password prompt spam (#8799).
+  private var keychainService: String {
+    DesktopKeychainStore.scopedService(
+      DesktopKeychainStore.legacyClientDeviceService,
+      bundleID: bundleIdentifier ?? Bundle.main.bundleIdentifier ?? "unknown.bundle"
+    )
+  }
 
   init(
     bundleIdentifier: String? = Bundle.main.bundleIdentifier,
@@ -71,7 +81,10 @@ final class ClientDeviceService {
   }
 
   private func loadOrCreateInstallId() -> String {
-    if usesBundleScopedDevInstallId {
+    // All non-production bundles (Omi Dev + named omi-*) stay out of Keychain
+    // entirely — UserDefaults is enough for throwaway local identity and never
+    // prompts. Production Beta/Prod use the team+bundle scoped Keychain item.
+    if usesUserDefaultsInstallId {
       return loadOrCreateDevInstallId()
     }
     switch readKeychainInstallId() {
@@ -84,8 +97,8 @@ final class ClientDeviceService {
       userDefaults.set(fresh, forKey: installIdMirrorDefaultsKey)
       return fresh
     case .unavailable(let status):
-      // Denied prompt or transient keychain failure. Never rotate the shared
-      // item here — that would change this Mac's identity for all Omi builds.
+      // Denied prompt or transient keychain failure. Never rotate the item here —
+      // and never fall through to the legacy unscoped service (that prompts).
       log("ClientDeviceService: keychain read unavailable (status \(status)); using mirror fallback")
       if let mirror = userDefaults.string(forKey: installIdMirrorDefaultsKey), !mirror.isEmpty {
         return mirror
@@ -96,10 +109,11 @@ final class ClientDeviceService {
     }
   }
 
-  private var usesBundleScopedDevInstallId: Bool {
+  private var usesUserDefaultsInstallId: Bool {
     guard let bundleIdentifier else { return false }
-    // Throwaway named dev bundles should not prompt for the shared login-keychain item.
-    return bundleIdentifier.hasPrefix("com.omi.omi-")
+    // Any non-production com.omi.* bundle (desktop-dev + omi-*) — avoid Keychain.
+    return bundleIdentifier.hasPrefix("com.omi.")
+      && bundleIdentifier != AppBuild.productionBundleIdentifier
   }
 
   private func loadOrCreateDevInstallId() -> String {
@@ -118,12 +132,15 @@ final class ClientDeviceService {
   }
 
   private func readKeychainInstallId() -> KeychainReadResult {
+    let context = LAContext()
+    context.interactionNotAllowed = true
     let query: [String: Any] = [
       kSecClass as String: kSecClassGenericPassword,
       kSecAttrService as String: keychainService,
       kSecAttrAccount as String: keychainAccount,
       kSecReturnData as String: true,
       kSecMatchLimit as String: kSecMatchLimitOne,
+      kSecUseAuthenticationContext as String: context,
     ]
     var item: CFTypeRef?
     let status = SecItemCopyMatching(query as CFDictionary, &item)
@@ -143,14 +160,34 @@ final class ClientDeviceService {
 
   private func saveKeychainInstallId(_ value: String) {
     let data = Data(value.utf8)
+    let context = LAContext()
+    context.interactionNotAllowed = true
     let query: [String: Any] = [
       kSecClass as String: kSecClassGenericPassword,
       kSecAttrService as String: keychainService,
       kSecAttrAccount as String: keychainAccount,
+      kSecUseAuthenticationContext as String: context,
+    ]
+    let attributes: [String: Any] = [
       kSecValueData as String: data,
       kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlock,
     ]
-    SecItemDelete(query as CFDictionary)
-    SecItemAdd(query as CFDictionary, nil)
+    let updateStatus = SecItemUpdate(query as CFDictionary, attributes as CFDictionary)
+    if updateStatus == errSecSuccess {
+      return
+    }
+    if updateStatus != errSecItemNotFound {
+      // Do not SecItemDelete+Add on auth failure — that can prompt. Fail closed;
+      // the mirror fallback in loadOrCreateInstallId covers continuity.
+      log("ClientDeviceService: keychain update unavailable (status \(updateStatus))")
+      return
+    }
+    var addQuery = query
+    addQuery[kSecValueData as String] = data
+    addQuery[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlock
+    let addStatus = SecItemAdd(addQuery as CFDictionary, nil)
+    if addStatus != errSecSuccess {
+      log("ClientDeviceService: keychain add unavailable (status \(addStatus))")
+    }
   }
 }

--- a/desktop/macos/Desktop/Sources/DesktopKeychainStore.swift
+++ b/desktop/macos/Desktop/Sources/DesktopKeychainStore.swift
@@ -10,11 +10,11 @@ enum DesktopKeychainStore {
     // every SecItem write fail with errSecMissingEntitlement (-34018), so token storage failed
     // ("Could not securely store sign-in tokens") and sign-in was blocked. The default
     // file-based keychain works for a signed non-sandboxed app with no extra entitlement and
-    // still keeps tokens out of UserDefaults. (The *auth-token* path uses UserDefaults on
-    // non-production builds — usesKeychainTokenStorage = !AppBuild.isNonProduction — so the
-    // sign-in failure only surfaced on prod/beta. This store is also used by
-    // LocalAgentAPIServer on all builds, whose keychain writes hit the same failure and are
-    // fixed by the same change.)
+    // still keeps tokens out of UserDefaults. (The auth-token path now uses this Keychain on
+    // ALL builds — AuthService.TokenStorageHooks.live sets usesKeychainTokenStorage = true with
+    // no UserDefaults write fallback — so the historical prod/beta-only sign-in failure is
+    // fully closed off. This store is also used by LocalAgentAPIServer on all builds, whose
+    // keychain writes hit the same errSecMissingEntitlement and are fixed by the same change.)
     [
       kSecClass as String: kSecClassGenericPassword,
       kSecAttrService as String: service,

--- a/desktop/macos/Desktop/Sources/DesktopKeychainStore.swift
+++ b/desktop/macos/Desktop/Sources/DesktopKeychainStore.swift
@@ -1,7 +1,48 @@
 import Foundation
+import LocalAuthentication
 import Security
 
+/// File-based (login) keychain helpers for desktop secrets.
+///
+/// Design constraints (see #9167 / keychain ACL prompt fix):
+/// - Never opt into the data-protection keychain (`kSecUseDataProtectionKeychain`) — this
+///   non-sandboxed Developer ID app has no `keychain-access-groups` entitlement.
+/// - Never present the macOS keychain password dialog. Reads/writes that would require UI
+///   fail closed (`nil` / `false`).
+/// - Scope service names by signing Team ID so Apple Development / named-bundle builds
+///   cannot create or overwrite the notarized Beta/Prod item (and vice versa).
+/// - Do **not** query the pre-scoping legacy service names from app code. Those items may
+///   carry a foreign-team ACL; even with `LAContext.interactionNotAllowed`, SecItem can
+///   still surface the login-keychain password sheet (`errSecUserCanceled` / -128). Leave
+///   orphans alone — UserDefaults migration covers auth continuity for older installs.
 enum DesktopKeychainStore {
+  /// Pre-scoping service names. Kept as constants for dump/seed scripts and docs only —
+  /// app runtime must not SecItem-query these (see file header).
+  static let legacyAuthTokenService = "com.omi.desktop.firebase-rest-session"
+  static let legacyLocalAgentTokenService = "com.omi.desktop.local-agent-api"
+
+  /// Signing Team ID of the running binary (e.g. `9536L8KLMP` for Developer ID,
+  /// `JVMXE5G542` for a personal Apple Development cert). Falls back to an ad-hoc
+  /// bundle-scoped token when codesign info has no Team ID.
+  static var signingTeamID: String {
+    if let cached = _cachedSigningTeamID {
+      return cached
+    }
+    let resolved = resolveSigningTeamID()
+    _cachedSigningTeamID = resolved
+    return resolved
+  }
+
+  private static var _cachedSigningTeamID: String?
+
+  /// Team-scoped service name. Production Beta/Prod and local Dev builds get different
+  /// items, so a local rebuild cannot poison the notarized app's ACL. Same-team named
+  /// bundles intentionally share (auth dump/seed). The `v2` marker avoids colliding with
+  /// any accidental `.team.*` suffix on the legacy unscoped name.
+  static func scopedService(_ base: String, teamID: String = signingTeamID) -> String {
+    "\(base).v2.team.\(teamID)"
+  }
+
   private static func baseQuery(service: String, account: String) -> [String: Any] {
     // Use the file-based (login) keychain, NOT the iOS-style data-protection keychain.
     // Opting into the data-protection keychain requires a `keychain-access-groups` entitlement
@@ -10,11 +51,7 @@ enum DesktopKeychainStore {
     // every SecItem write fail with errSecMissingEntitlement (-34018), so token storage failed
     // ("Could not securely store sign-in tokens") and sign-in was blocked. The default
     // file-based keychain works for a signed non-sandboxed app with no extra entitlement and
-    // still keeps tokens out of UserDefaults. (The auth-token path now uses this Keychain on
-    // ALL builds — AuthService.TokenStorageHooks.live sets usesKeychainTokenStorage = true with
-    // no UserDefaults write fallback — so the historical prod/beta-only sign-in failure is
-    // fully closed off. This store is also used by LocalAgentAPIServer on all builds, whose
-    // keychain writes hit the same errSecMissingEntitlement and are fixed by the same change.)
+    // still keeps tokens out of UserDefaults.
     [
       kSecClass as String: kSecClassGenericPassword,
       kSecAttrService as String: service,
@@ -22,30 +59,70 @@ enum DesktopKeychainStore {
     ]
   }
 
-  static func string(service: String, account: String) -> String? {
+  /// Attach silent-auth constraints so SecItem prefers failing over showing UI.
+  /// Note: this does **not** reliably suppress file-based keychain ACL password sheets for
+  /// foreign TrustedApplication items — callers must not query those legacy services.
+  private static func applySilentAuth(_ query: inout [String: Any]) {
+    let context = LAContext()
+    context.interactionNotAllowed = true
+    query[kSecUseAuthenticationContext as String] = context
+  }
+
+  private static func isMissing(_ status: OSStatus) -> Bool {
+    status == errSecItemNotFound
+  }
+
+  /// Statuses that mean "cannot access without UI / wrong ACL / user would be prompted".
+  private static func isAuthUnavailable(_ status: OSStatus) -> Bool {
+    status == errSecInteractionNotAllowed
+      || status == errSecAuthFailed
+      || status == errSecUserCanceled
+      || status == errSecMissingEntitlement
+  }
+
+  enum ReadResult: Equatable {
+    case found(String)
+    case missing
+    case unavailable(OSStatus)
+  }
+
+  static func readString(service: String, account: String) -> ReadResult {
     var query = baseQuery(service: service, account: account)
     query[kSecReturnData as String] = true
     query[kSecMatchLimit as String] = kSecMatchLimitOne
+    applySilentAuth(&query)
 
     var item: CFTypeRef?
     let status = SecItemCopyMatching(query as CFDictionary, &item)
-    guard status == errSecSuccess else {
-      if status != errSecItemNotFound {
-        log("DesktopKeychainStore: read failed for \(service)/\(account) (status \(status))")
+    if status == errSecSuccess {
+      guard let data = item as? Data, let value = String(data: data, encoding: .utf8), !value.isEmpty else {
+        return .missing
       }
-      return nil
+      return .found(value)
     }
+    if isMissing(status) {
+      return .missing
+    }
+    if isAuthUnavailable(status) {
+      log("DesktopKeychainStore: silent read unavailable for \(service)/\(account) (status \(status))")
+      return .unavailable(status)
+    }
+    log("DesktopKeychainStore: read failed for \(service)/\(account) (status \(status))")
+    return .unavailable(status)
+  }
 
-    guard let data = item as? Data, let value = String(data: data, encoding: .utf8), !value.isEmpty else {
-      return nil
+  static func string(service: String, account: String) -> String? {
+    if case .found(let value) = readString(service: service, account: account) {
+      return value
     }
-    return value
+    return nil
   }
 
   @discardableResult
   static func setString(_ value: String, service: String, account: String) -> Bool {
     let data = Data(value.utf8)
-    let query = baseQuery(service: service, account: account)
+    var query = baseQuery(service: service, account: account)
+    applySilentAuth(&query)
     let attributes: [String: Any] = [
       kSecValueData as String: data,
       // Advisory on the file-based keychain (it's a data-protection-keychain attribute, so it's
@@ -57,27 +134,77 @@ enum DesktopKeychainStore {
     if updateStatus == errSecSuccess {
       return true
     }
-    guard updateStatus == errSecItemNotFound else {
-      log("DesktopKeychainStore: update failed for \(service)/\(account) (status \(updateStatus))")
-      return false
+    if !isMissing(updateStatus) {
+      if isAuthUnavailable(updateStatus) {
+        // Existing item is unreadable/unwritable under silent auth. Do not prompt; try a
+        // fresh add after a silent delete. If delete also fails, fail closed.
+        delete(service: service, account: account)
+      } else {
+        log("DesktopKeychainStore: update failed for \(service)/\(account) (status \(updateStatus))")
+        return false
+      }
     }
 
-    var addQuery = query
+    var addQuery = baseQuery(service: service, account: account)
+    applySilentAuth(&addQuery)
     addQuery[kSecValueData as String] = data
     addQuery[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
     let addStatus = SecItemAdd(addQuery as CFDictionary, nil)
-    if addStatus != errSecSuccess {
-      log("DesktopKeychainStore: add failed for \(service)/\(account) (status \(addStatus))")
+    if addStatus == errSecSuccess {
+      return true
+    }
+    if addStatus == errSecDuplicateItem {
+      let retry = SecItemUpdate(query as CFDictionary, attributes as CFDictionary)
+      if retry == errSecSuccess {
+        return true
+      }
+      log("DesktopKeychainStore: add/update race failed for \(service)/\(account) (status \(retry))")
       return false
     }
-    return true
+    log("DesktopKeychainStore: add failed for \(service)/\(account) (status \(addStatus))")
+    return false
   }
 
   static func delete(service: String, account: String) {
-    let query = baseQuery(service: service, account: account)
+    var query = baseQuery(service: service, account: account)
+    applySilentAuth(&query)
     let status = SecItemDelete(query as CFDictionary)
-    if status != errSecSuccess && status != errSecItemNotFound {
+    if status != errSecSuccess && !isMissing(status) {
+      // Wrong-team / ACL-blocked deletes must stay silent — never escalate to a prompt.
       log("DesktopKeychainStore: delete failed for \(service)/\(account) (status \(status))")
     }
+  }
+
+  private static func resolveSigningTeamID() -> String {
+    var code: SecCode?
+    var status = SecCodeCopySelf([], &code)
+    guard status == errSecSuccess, let code else {
+      log("DesktopKeychainStore: SecCodeCopySelf failed (\(status)); using unknown team scope")
+      return "unknown"
+    }
+
+    var staticCode: SecStaticCode?
+    status = SecCodeCopyStaticCode(code, [], &staticCode)
+    guard status == errSecSuccess, let staticCode else {
+      log("DesktopKeychainStore: SecCodeCopyStaticCode failed (\(status)); using unknown team scope")
+      return "unknown"
+    }
+
+    var info: CFDictionary?
+    status = SecCodeCopySigningInformation(staticCode, SecCSFlags(rawValue: kSecCSSigningInformation), &info)
+    guard status == errSecSuccess, let info = info as? [String: Any] else {
+      log("DesktopKeychainStore: SecCodeCopySigningInformation failed (\(status)); using unknown team scope")
+      return "unknown"
+    }
+
+    if let team = info[kSecCodeInfoTeamIdentifier as String] as? String, !team.isEmpty {
+      return team
+    }
+    // Ad-hoc / unsigned local builds have no Team ID. Scope by bundle id so they still
+    // cannot collide with Developer ID / Apple Development items.
+    if let bundleID = Bundle.main.bundleIdentifier, !bundleID.isEmpty {
+      return "adhoc.\(bundleID)"
+    }
+    return "unknown"
   }
 }

--- a/desktop/macos/Desktop/Sources/DesktopKeychainStore.swift
+++ b/desktop/macos/Desktop/Sources/DesktopKeychainStore.swift
@@ -9,8 +9,10 @@ import Security
 ///   non-sandboxed Developer ID app has no `keychain-access-groups` entitlement.
 /// - Never present the macOS keychain password dialog. Reads/writes that would require UI
 ///   fail closed (`nil` / `false`).
-/// - Scope service names by signing Team ID so Apple Development / named-bundle builds
-///   cannot create or overwrite the notarized Beta/Prod item (and vice versa).
+/// - Scope service names by signing Team ID **and** bundle id so:
+///   - Apple Development / named-bundle builds cannot poison notarized Beta/Prod
+///   - Local contributors' Omi Dev / `omi-*` / ad-hoc rebuilds cannot poison each other
+///     (path/signature ACL mismatches between same-team apps)
 /// - Do **not** query the pre-scoping legacy service names from app code. Those items may
 ///   carry a foreign-team ACL; even with `LAContext.interactionNotAllowed`, SecItem can
 ///   still surface the login-keychain password sheet (`errSecUserCanceled` / -128). Leave
@@ -20,6 +22,7 @@ enum DesktopKeychainStore {
   /// app runtime must not SecItem-query these (see file header).
   static let legacyAuthTokenService = "com.omi.desktop.firebase-rest-session"
   static let legacyLocalAgentTokenService = "com.omi.desktop.local-agent-api"
+  static let legacyClientDeviceService = "com.omi.client-device-id"
 
   /// Signing Team ID of the running binary (e.g. `9536L8KLMP` for Developer ID,
   /// `JVMXE5G542` for a personal Apple Development cert). Falls back to an ad-hoc
@@ -35,12 +38,20 @@ enum DesktopKeychainStore {
 
   private static var _cachedSigningTeamID: String?
 
-  /// Team-scoped service name. Production Beta/Prod and local Dev builds get different
-  /// items, so a local rebuild cannot poison the notarized app's ACL. Same-team named
-  /// bundles intentionally share (auth dump/seed). The `v2` marker avoids colliding with
-  /// any accidental `.team.*` suffix on the legacy unscoped name.
-  static func scopedService(_ base: String, teamID: String = signingTeamID) -> String {
-    "\(base).v2.team.\(teamID)"
+  /// Team + bundle scoped service name.
+  ///
+  /// Format: `<base>.v2.team.<TeamID>.bundle.<bundleID>`
+  ///
+  /// Beta and stable share `com.omi.computer-macos` + Developer ID team, so they keep one
+  /// auth item. Every local contributor bundle (`com.omi.desktop-dev`, `com.omi.omi-*`,
+  /// ad-hoc) gets its own item — dump/seed scripts write into the *target* bundle's
+  /// scoped service explicitly.
+  static func scopedService(
+    _ base: String,
+    teamID: String = signingTeamID,
+    bundleID: String = Bundle.main.bundleIdentifier ?? "unknown.bundle"
+  ) -> String {
+    "\(base).v2.team.\(teamID).bundle.\(bundleID)"
   }
 
   private static func baseQuery(service: String, account: String) -> [String: Any] {

--- a/desktop/macos/Desktop/Sources/LocalAgentAPIServer.swift
+++ b/desktop/macos/Desktop/Sources/LocalAgentAPIServer.swift
@@ -17,9 +17,12 @@ enum LocalAgentAPISettings {
 
   private static let enabledKey = "localAgentAPIEnabled"
   private static let tokenKey = "localAgentAPIToken"
-  private static let tokenKeychainService = "com.omi.desktop.local-agent-api"
   private static let tokenKeychainAccount = "local-agent-api-token"
   private static let portKey = "localAgentAPIPort"
+  /// Team-scoped so local Apple Development builds cannot poison the notarized item.
+  private static var tokenKeychainService: String {
+    DesktopKeychainStore.scopedService(DesktopKeychainStore.legacyLocalAgentTokenService)
+  }
 
   static var isEnabled: Bool {
     get { UserDefaults.standard.bool(forKey: enabledKey) }
@@ -43,7 +46,10 @@ enum LocalAgentAPISettings {
   }
 
   static func storedToken() -> String? {
-    if let token = DesktopKeychainStore.string(service: tokenKeychainService, account: tokenKeychainAccount) {
+    if let token = DesktopKeychainStore.string(
+      service: tokenKeychainService,
+      account: tokenKeychainAccount
+    ) {
       return token
     }
     let token = UserDefaults.standard.string(forKey: tokenKey) ?? ""

--- a/desktop/macos/Desktop/Sources/LocalAgentAPIServer.swift
+++ b/desktop/macos/Desktop/Sources/LocalAgentAPIServer.swift
@@ -19,7 +19,8 @@ enum LocalAgentAPISettings {
   private static let tokenKey = "localAgentAPIToken"
   private static let tokenKeychainAccount = "local-agent-api-token"
   private static let portKey = "localAgentAPIPort"
-  /// Team-scoped so local Apple Development builds cannot poison the notarized item.
+  /// Team+bundle scoped so local Apple Development / named bundles cannot poison
+  /// each other or the notarized item. Never query the unscoped legacy service.
   private static var tokenKeychainService: String {
     DesktopKeychainStore.scopedService(DesktopKeychainStore.legacyLocalAgentTokenService)
   }
@@ -68,12 +69,17 @@ enum LocalAgentAPISettings {
     if let token = storedToken() {
       return token
     }
+    // No readable scoped/UserDefaults token. Mint a fresh one into the scoped
+    // service. We deliberately do NOT read the unscoped legacy Keychain item
+    // (that query can show the login-keychain password dialog). Callers that
+    // still hold the pre-scoping token must re-copy the new token from Settings.
     let token = "omi_local_\(UUID().uuidString.replacingOccurrences(of: "-", with: "").lowercased())"
     guard DesktopKeychainStore.setString(token, service: tokenKeychainService, account: tokenKeychainAccount) else {
       log("LocalAgentAPISettings: failed to save token to Keychain")
       throw LocalAgentAPIError.tokenStorageUnavailable
     }
     UserDefaults.standard.removeObject(forKey: tokenKey)
+    log("LocalAgentAPISettings: minted replacement local-agent token into scoped Keychain (re-copy token for clients)")
     return token
   }
 
@@ -117,6 +123,16 @@ final class LocalAgentAPIServer {
 
   func startIfNeeded() {
     guard LocalAgentAPISettings.isEnabled else { return }
+    // If the feature was enabled before team+bundle scoping, the old Keychain
+    // token is intentionally unread (to avoid password prompts). Mint a fresh
+    // scoped token so the server can authenticate again; clients must re-copy it.
+    do {
+      _ = try LocalAgentAPISettings.ensureToken()
+    } catch {
+      log("LocalAgentAPIServer: cannot start — token storage unavailable (\(error.localizedDescription))")
+      LocalAgentAPISettings.isEnabled = false
+      return
+    }
     guard listener == nil else { return }
 
     do {

--- a/desktop/macos/Desktop/Tests/AuthTokenStorageTests.swift
+++ b/desktop/macos/Desktop/Tests/AuthTokenStorageTests.swift
@@ -134,8 +134,8 @@ final class AuthTokenStorageTests: XCTestCase {
 
   /// Regression: never show the login-keychain password dialog. Local Apple Development
   /// builds previously wrote the unscoped `firebase-rest-session` item; notarized Beta then
-  /// prompted on every launch. Team-scoped v2 service names + never querying the legacy
-  /// unscoped item close that path (LAContext alone does not suppress file-based ACL sheets).
+  /// prompted on every launch. Team+bundle scoped v2 service names + never querying the
+  /// legacy unscoped item close that path (LAContext alone does not suppress file-based ACL sheets).
   func testKeychainStoreNeverPresentsAuthenticationUI() throws {
     let source = try sourceFile("DesktopKeychainStore.swift")
     XCTAssertTrue(
@@ -146,10 +146,13 @@ final class AuthTokenStorageTests: XCTestCase {
       "DesktopKeychainStore must pass an LAContext via kSecUseAuthenticationContext")
     XCTAssertTrue(
       source.contains("scopedService"),
-      "DesktopKeychainStore must team-scope service names so Dev and Developer ID items diverge")
+      "DesktopKeychainStore must scope service names so Dev and Developer ID items diverge")
     XCTAssertTrue(
       source.contains(".v2.team."),
-      "Scoped service names must include a v2 marker so they never collide with the legacy item")
+      "Scoped service names must include a v2.team marker")
+    XCTAssertTrue(
+      source.contains(".bundle."),
+      "Scoped service names must include bundle id so local contributor apps cannot poison each other")
     XCTAssertFalse(
       source.contains("legacyServices"),
       "DesktopKeychainStore must not offer a legacy-service migration path that SecItem-queries "
@@ -160,7 +163,7 @@ final class AuthTokenStorageTests: XCTestCase {
     let source = try sourceFile("AuthService.swift")
     XCTAssertTrue(
       source.contains("DesktopKeychainStore.scopedService(DesktopKeychainStore.legacyAuthTokenService)"),
-      "AuthService must store tokens under the team-scoped Keychain service")
+      "AuthService must store tokens under the team+bundle scoped Keychain service")
     XCTAssertFalse(
       source.contains("private let authTokenKeychainService = \"com.omi.desktop.firebase-rest-session\""),
       "AuthService must not hardcode the unscoped firebase-rest-session service name")
@@ -173,12 +176,51 @@ final class AuthTokenStorageTests: XCTestCase {
       "AuthService must not delete the unscoped legacy Keychain item (can itself prompt)")
   }
 
-  func testScopedServiceIncludesTeamID() {
-    let scoped = DesktopKeychainStore.scopedService("com.omi.desktop.firebase-rest-session", teamID: "9536L8KLMP")
-    XCTAssertEqual(scoped, "com.omi.desktop.firebase-rest-session.v2.team.9536L8KLMP")
-    let other = DesktopKeychainStore.scopedService("com.omi.desktop.firebase-rest-session", teamID: "JVMXE5G542")
-    XCTAssertEqual(other, "com.omi.desktop.firebase-rest-session.v2.team.JVMXE5G542")
-    XCTAssertNotEqual(scoped, other)
+  func testScopedServiceIncludesTeamAndBundle() {
+    let prod = DesktopKeychainStore.scopedService(
+      "com.omi.desktop.firebase-rest-session",
+      teamID: "9536L8KLMP",
+      bundleID: "com.omi.computer-macos"
+    )
+    XCTAssertEqual(
+      prod,
+      "com.omi.desktop.firebase-rest-session.v2.team.9536L8KLMP.bundle.com.omi.computer-macos")
+
+    let sameTeamDifferentBundle = DesktopKeychainStore.scopedService(
+      "com.omi.desktop.firebase-rest-session",
+      teamID: "JVMXE5G542",
+      bundleID: "com.omi.desktop-dev"
+    )
+    let named = DesktopKeychainStore.scopedService(
+      "com.omi.desktop.firebase-rest-session",
+      teamID: "JVMXE5G542",
+      bundleID: "com.omi.omi-fix-rewind"
+    )
+    XCTAssertEqual(
+      sameTeamDifferentBundle,
+      "com.omi.desktop.firebase-rest-session.v2.team.JVMXE5G542.bundle.com.omi.desktop-dev")
+    XCTAssertEqual(
+      named,
+      "com.omi.desktop.firebase-rest-session.v2.team.JVMXE5G542.bundle.com.omi.omi-fix-rewind")
+    XCTAssertNotEqual(prod, sameTeamDifferentBundle)
+    XCTAssertNotEqual(sameTeamDifferentBundle, named)
+  }
+
+  func testClientDeviceServiceNeverUsesSharedLegacyKeychain() throws {
+    let source = try sourceFile("ClientDeviceService.swift")
+    XCTAssertTrue(
+      source.contains("DesktopKeychainStore.scopedService"),
+      "ClientDeviceService must use a scoped Keychain service on production builds")
+    XCTAssertTrue(
+      source.contains("interactionNotAllowed = true"),
+      "ClientDeviceService Keychain access must be silent")
+    XCTAssertFalse(
+      source.contains("private let keychainService = \"com.omi.client-device-id\""),
+      "ClientDeviceService must not hardcode the shared legacy device-id Keychain service")
+    // All non-production bundles must stay on UserDefaults (no Keychain prompt risk).
+    XCTAssertTrue(
+      source.contains("productionBundleIdentifier"),
+      "ClientDeviceService must gate Keychain use to the production bundle only")
   }
 
   private func sourceFile(_ relativePath: String) throws -> String {

--- a/desktop/macos/Desktop/Tests/AuthTokenStorageTests.swift
+++ b/desktop/macos/Desktop/Tests/AuthTokenStorageTests.swift
@@ -116,18 +116,69 @@ final class AuthTokenStorageTests: XCTestCase {
     XCTAssertEqual(UserDefaults.standard.string(forKey: .authUserId), "user-keychain")
   }
 
-  /// Regression: the token Keychain store must NOT opt into the data-protection keychain
-  /// (`kSecUseDataProtectionKeychain`). That requires a `keychain-access-groups` entitlement
-  /// this non-sandboxed Developer ID app doesn't have, so on the signed/notarized build every
-  /// SecItem write failed with errSecMissingEntitlement and sign-in broke with "Could not
-  /// securely store sign-in tokens". Dev builds use UserDefaults, so this only ever failed on
-  /// prod/beta and is invisible to the behavioral tests — hence a source-level guard.
+  /// Regression: the token Keychain store must NOT opt into the data-protection keychain.
+  /// That requires a `keychain-access-groups` entitlement this non-sandboxed Developer ID
+  /// app doesn't have, so on the signed/notarized build every SecItem write failed with
+  /// errSecMissingEntitlement and sign-in broke with "Could not securely store sign-in
+  /// tokens". This only ever failed on signed prod/beta builds and is invisible to the
+  /// behavioral tests — hence a source-level guard.
   func testKeychainStoreDoesNotUseDataProtectionKeychain() throws {
     let source = try sourceFile("DesktopKeychainStore.swift")
+    // Match an actual query assignment, not the explanatory comment that names the flag.
     XCTAssertFalse(
-      source.contains("kSecUseDataProtectionKeychain"),
+      source.contains("kSecUseDataProtectionKeychain as String")
+        || source.contains("[kSecUseDataProtectionKeychain"),
       "DesktopKeychainStore must use the file-based login keychain (no keychain-access-groups "
         + "entitlement); the data-protection keychain breaks sign-in on signed builds.")
+  }
+
+  /// Regression: never show the login-keychain password dialog. Local Apple Development
+  /// builds previously wrote the unscoped `firebase-rest-session` item; notarized Beta then
+  /// prompted on every launch. Team-scoped v2 service names + never querying the legacy
+  /// unscoped item close that path (LAContext alone does not suppress file-based ACL sheets).
+  func testKeychainStoreNeverPresentsAuthenticationUI() throws {
+    let source = try sourceFile("DesktopKeychainStore.swift")
+    XCTAssertTrue(
+      source.contains("interactionNotAllowed = true"),
+      "DesktopKeychainStore must set LAContext.interactionNotAllowed so SecItem prefers fail-closed")
+    XCTAssertTrue(
+      source.contains("kSecUseAuthenticationContext"),
+      "DesktopKeychainStore must pass an LAContext via kSecUseAuthenticationContext")
+    XCTAssertTrue(
+      source.contains("scopedService"),
+      "DesktopKeychainStore must team-scope service names so Dev and Developer ID items diverge")
+    XCTAssertTrue(
+      source.contains(".v2.team."),
+      "Scoped service names must include a v2 marker so they never collide with the legacy item")
+    XCTAssertFalse(
+      source.contains("legacyServices"),
+      "DesktopKeychainStore must not offer a legacy-service migration path that SecItem-queries "
+        + "the unscoped firebase-rest-session item (that query is what triggers the password dialog)")
+  }
+
+  func testAuthTokenServiceIsTeamScopedAndNeverTouchesLegacyItem() throws {
+    let source = try sourceFile("AuthService.swift")
+    XCTAssertTrue(
+      source.contains("DesktopKeychainStore.scopedService(DesktopKeychainStore.legacyAuthTokenService)"),
+      "AuthService must store tokens under the team-scoped Keychain service")
+    XCTAssertFalse(
+      source.contains("private let authTokenKeychainService = \"com.omi.desktop.firebase-rest-session\""),
+      "AuthService must not hardcode the unscoped firebase-rest-session service name")
+    // Live hooks must not pass the unscoped legacy name into SecItem (read or delete).
+    XCTAssertFalse(
+      source.contains("legacyServices: [DesktopKeychainStore.legacyAuthTokenService]"),
+      "AuthService must not migrate by reading the unscoped legacy Keychain item")
+    XCTAssertFalse(
+      source.contains("delete(\n                    service: DesktopKeychainStore.legacyAuthTokenService"),
+      "AuthService must not delete the unscoped legacy Keychain item (can itself prompt)")
+  }
+
+  func testScopedServiceIncludesTeamID() {
+    let scoped = DesktopKeychainStore.scopedService("com.omi.desktop.firebase-rest-session", teamID: "9536L8KLMP")
+    XCTAssertEqual(scoped, "com.omi.desktop.firebase-rest-session.v2.team.9536L8KLMP")
+    let other = DesktopKeychainStore.scopedService("com.omi.desktop.firebase-rest-session", teamID: "JVMXE5G542")
+    XCTAssertEqual(other, "com.omi.desktop.firebase-rest-session.v2.team.JVMXE5G542")
+    XCTAssertNotEqual(scoped, other)
   }
 
   private func sourceFile(_ relativePath: String) throws -> String {

--- a/desktop/macos/Desktop/Tests/ClientDeviceServiceTests.swift
+++ b/desktop/macos/Desktop/Tests/ClientDeviceServiceTests.swift
@@ -40,6 +40,22 @@ final class ClientDeviceServiceTests: XCTestCase {
     )
   }
 
+  func testDesktopDevBundleAlsoUsesUserDefaultsInstallId() {
+    // Omi Dev must not touch the shared login-keychain device-id item either.
+    let suiteName = "ClientDeviceServiceTests.dev.\(UUID().uuidString)"
+    let defaults = UserDefaults(suiteName: suiteName)!
+    defer {
+      defaults.removePersistentDomain(forName: suiteName)
+    }
+
+    let service = ClientDeviceService(
+      bundleIdentifier: AppBuild.desktopDevBundleIdentifier,
+      userDefaults: defaults
+    )
+    _ = service.deviceIdHash
+    XCTAssertNotNil(defaults.string(forKey: "dev-client-device-install-uuid"))
+  }
+
   func testNamedDevelopmentBundlesDoNotShareInstallIds() {
     let firstSuiteName = "ClientDeviceServiceTests.first.\(UUID().uuidString)"
     let secondSuiteName = "ClientDeviceServiceTests.second.\(UUID().uuidString)"

--- a/desktop/macos/Desktop/Tests/FailLoudConfigTests.swift
+++ b/desktop/macos/Desktop/Tests/FailLoudConfigTests.swift
@@ -195,11 +195,15 @@ final class FailLoudConfigTests: XCTestCase {
     let src = try source(relativePath: "Sources/LocalAgentAPIServer.swift")
 
     XCTAssertTrue(src.contains("tokenKeychainService"))
-    XCTAssertTrue(src.contains("DesktopKeychainStore.string(service: tokenKeychainService"))
+    XCTAssertTrue(src.contains("DesktopKeychainStore.scopedService(DesktopKeychainStore.legacyLocalAgentTokenService)"))
+    XCTAssertTrue(src.contains("DesktopKeychainStore.string("))
     XCTAssertTrue(src.contains("DesktopKeychainStore.setString(token, service: tokenKeychainService"))
     XCTAssertTrue(src.contains("enum LocalAgentAPIError"))
     XCTAssertTrue(src.contains("throw LocalAgentAPIError.tokenStorageUnavailable"))
     XCTAssertFalse(src.contains("UserDefaults.standard.set(token, forKey: tokenKey)"))
+    XCTAssertFalse(
+      src.contains("private static let tokenKeychainService = \"com.omi.desktop.local-agent-api\""),
+      "Local agent token service must be team-scoped, not a shared unscoped constant")
   }
 
   // The data-protection keychain assertion was inverted by the file-based-keychain fix:

--- a/desktop/macos/Desktop/Tests/FailLoudConfigTests.swift
+++ b/desktop/macos/Desktop/Tests/FailLoudConfigTests.swift
@@ -173,11 +173,14 @@ final class FailLoudConfigTests: XCTestCase {
     XCTAssertEqual(SystemAudioPermissionStatus.classify(captureError: OtherError()), .unknown)
   }
 
-  func testProductionAuthTokensUseKeychainStorage() throws {
+  func testAuthTokensUseKeychainStorageOnAllBuilds() throws {
     let src = try source(relativePath: "Sources/AuthService.swift")
 
-    XCTAssertTrue(src.contains("private var usesKeychainTokenStorage: Bool"))
-    XCTAssertTrue(src.contains("!AppBuild.isNonProduction"))
+    // Security invariant: the live config stores auth tokens in the Keychain on EVERY build
+    // (dev, beta, and production) with the plaintext UserDefaults write fallback disabled.
+    XCTAssertTrue(src.contains("usesKeychainTokenStorage: { true }"))
+    XCTAssertFalse(src.contains("!AppBuild.isNonProduction"))
+    XCTAssertTrue(src.contains("allowsUserDefaultsFallback: { false }"))
     XCTAssertTrue(src.contains("DesktopKeychainStore.setString("))
     XCTAssertTrue(src.contains("migrated production auth tokens from UserDefaults to Keychain"))
     XCTAssertTrue(src.contains("clearUserDefaultsTokens()"))

--- a/desktop/macos/changelog/unreleased/20260708-keychain-auth-tokens-all-builds.json
+++ b/desktop/macos/changelog/unreleased/20260708-keychain-auth-tokens-all-builds.json
@@ -1,0 +1,3 @@
+{
+  "change": "Sign-in tokens are now stored in the macOS Keychain on every build; dev and beta builds no longer fall back to keeping credentials in plaintext UserDefaults."
+}

--- a/desktop/macos/changelog/unreleased/20260708-keychain-auth-tokens-all-builds.json
+++ b/desktop/macos/changelog/unreleased/20260708-keychain-auth-tokens-all-builds.json
@@ -1,3 +1,3 @@
 {
-  "change": "Sign-in tokens are now stored in the macOS Keychain on every build; dev and beta builds no longer fall back to keeping credentials in plaintext UserDefaults."
+  "change": "Sign-in tokens are now stored in the macOS Keychain on every build; dev and beta builds no longer fall back to keeping credentials in plaintext UserDefaults"
 }

--- a/desktop/macos/changelog/unreleased/20260708-keychain-no-password-prompt.json
+++ b/desktop/macos/changelog/unreleased/20260708-keychain-no-password-prompt.json
@@ -1,3 +1,3 @@
 {
-  "change": "Fixed a macOS Keychain password prompt on Beta/Prod launch caused by local developer builds writing the shared sign-in token item — tokens now use a team-scoped Keychain service and the app never queries the old shared item"
+  "change": "Fixed macOS Keychain password prompts for Beta/Prod and local contributor builds by isolating sign-in and device-id secrets per signing team and bundle, and never querying the old shared Keychain items"
 }

--- a/desktop/macos/changelog/unreleased/20260708-keychain-no-password-prompt.json
+++ b/desktop/macos/changelog/unreleased/20260708-keychain-no-password-prompt.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed a macOS Keychain password prompt on Beta/Prod launch caused by local developer builds writing the shared sign-in token item — tokens now use a team-scoped Keychain service and the app never queries the old shared item"
+}

--- a/desktop/macos/e2e/flows/harness-smoke.yaml
+++ b/desktop/macos/e2e/flows/harness-smoke.yaml
@@ -6,6 +6,7 @@ app: non-prod
 covers:
   - desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
   - desktop/macos/Desktop/Sources/AuthService.swift
+  - desktop/macos/Desktop/Sources/DesktopKeychainStore.swift
   - desktop/macos/Desktop/Sources/OmiApp.swift
   - desktop/macos/Desktop/Sources/Telemetry/SentryHeartbeatTelemetry.swift
   - desktop/macos/Desktop/Sources/ViewExporter.swift

--- a/desktop/macos/e2e/flows/harness-smoke.yaml
+++ b/desktop/macos/e2e/flows/harness-smoke.yaml
@@ -7,6 +7,8 @@ covers:
   - desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
   - desktop/macos/Desktop/Sources/AuthService.swift
   - desktop/macos/Desktop/Sources/DesktopKeychainStore.swift
+  - desktop/macos/Desktop/Sources/ClientDeviceService.swift
+  - desktop/macos/Desktop/Sources/LocalAgentAPIServer.swift
   - desktop/macos/Desktop/Sources/OmiApp.swift
   - desktop/macos/Desktop/Sources/Telemetry/SentryHeartbeatTelemetry.swift
   - desktop/macos/Desktop/Sources/ViewExporter.swift

--- a/desktop/macos/scripts/omi-auth-dump.sh
+++ b/desktop/macos/scripts/omi-auth-dump.sh
@@ -1,10 +1,13 @@
 #!/bin/bash
 # omi-auth-dump.sh — capture a signed-in dev bundle's auth session to JSON.
 #
-# Dev/named bundles store auth in UserDefaults (not Keychain) — see
-# AuthService.restoreAuthState(). This script copies those keys verbatim so they
-# can be replayed into other test bundles with omi-auth-seed.sh, letting an agent
-# skip the web OAuth login on every run.
+# Auth tokens (idToken, refreshToken, expiry, tokenUserId) live in the macOS
+# Keychain on ALL builds (service "com.omi.desktop.firebase-rest-session",
+# account "firebase-rest-tokens") — see AuthService.saveTokens(). The remaining
+# auth-state keys (isSignedIn, userEmail, userId, names, onboarding) are in
+# UserDefaults. This script reads BOTH so the captured session can be replayed
+# into other test bundles with omi-auth-seed.sh, letting an agent skip the web
+# OAuth login on every run.
 #
 # It does NOT mint or refresh tokens — it copies whatever the source session has.
 # The captured Firebase idToken expires (~1h); re-run this after signing in again.
@@ -16,20 +19,60 @@ set -euo pipefail
 
 SRC="${1:-com.omi.desktop-dev}"
 OUT="${2:-$(cd "$(dirname "$0")/.." && pwd)/tmp/desktop-auth.json}"
-KEYS=(auth_isSignedIn auth_userEmail auth_userId auth_givenName auth_familyName \
-      auth_idToken auth_refreshToken auth_tokenExpiry auth_tokenUserId hasCompletedOnboarding)
+
+# Auth-state keys that remain in UserDefaults (not token secrets).
+UD_KEYS=(auth_isSignedIn auth_userEmail auth_userId auth_givenName auth_familyName \
+         hasCompletedOnboarding)
+
+# Keychain item that holds the JSON-encoded token blob (StoredAuthTokens).
+KC_SERVICE="com.omi.desktop.firebase-rest-session"
+KC_ACCOUNT="firebase-rest-tokens"
 
 mkdir -p "$(dirname "$OUT")"
 
-python3 - "$SRC" "$OUT" "${KEYS[@]}" <<'PY'
+python3 - "$SRC" "$OUT" "${UD_KEYS[@]}" "$KC_SERVICE" "$KC_ACCOUNT" <<'PY'
 import json, subprocess, sys
-src, out, keys = sys.argv[1], sys.argv[2], sys.argv[3:]
+
+src, out = sys.argv[1], sys.argv[2]
+ud_keys = sys.argv[3:-2]
+kc_service, kc_account = sys.argv[-2], sys.argv[-1]
 
 def defaults(*args):
     return subprocess.run(["defaults", *args], capture_output=True, text=True)
 
 data = {}
-for k in keys:
+for k in ud_keys:
+    t = defaults("read-type", src, k)
+    if t.returncode != 0:
+        continue
+    v = defaults("read", src, k)
+    if v.returncode != 0:
+        continue
+    data[k] = {"type": t.stdout.strip().replace("Type is ", ""), "value": v.stdout.strip()}
+
+# Read the token blob from the Keychain (shared login keychain, same
+# service/account on every build).  `security find-generic-password -w` prints
+# only the secret value to stdout.  Fall back to the legacy UserDefaults token
+# keys for bundles that still have pre-migration tokens sitting there.
+kc = subprocess.run(
+    ["security", "find-generic-password", "-s", kc_service, "-a", kc_account, "-w"],
+    capture_output=True, text=True,
+)
+if kc.returncode == 0 and kc.stdout.strip():
+    payload = kc.stdout.strip()
+    try:
+        tokens = json.loads(payload)
+        data["auth_idToken"] = {"type": "string", "value": tokens.get("idToken", "")}
+        data["auth_refreshToken"] = {"type": "string", "value": tokens.get("refreshToken", "")}
+        data["auth_tokenExpiry"] = {"type": "float", "value": str(tokens.get("expiryTime", 0))}
+        data["auth_tokenUserId"] = {"type": "string", "value": tokens.get("tokenUserId", "")}
+    except (json.JSONDecodeError, KeyError):
+        pass  # fall through to UserDefaults below
+
+# Legacy fallback: pre-migration bundles may still have token keys in UserDefaults.
+for k in ("auth_idToken", "auth_refreshToken", "auth_tokenExpiry", "auth_tokenUserId"):
+    if k in data:
+        continue
     t = defaults("read-type", src, k)
     if t.returncode != 0:
         continue
@@ -44,6 +87,6 @@ with open(out, "w") as f:
 print(f"Dumped {len(data)} keys from {src} -> {out}")
 print(f"  signed_in={data.get('auth_isSignedIn', {}).get('value')} "
       f"email={data.get('auth_userEmail', {}).get('value')}")
-if "auth_idToken" not in data:
+if "auth_idToken" not in data or not data["auth_idToken"].get("value"):
     sys.exit("WARNING: no auth_idToken found — is the source bundle signed in?")
 PY

--- a/desktop/macos/scripts/omi-auth-dump.sh
+++ b/desktop/macos/scripts/omi-auth-dump.sh
@@ -2,12 +2,12 @@
 # omi-auth-dump.sh — capture a signed-in dev bundle's auth session to JSON.
 #
 # Auth tokens (idToken, refreshToken, expiry, tokenUserId) live in the macOS
-# Keychain on ALL builds (service "com.omi.desktop.firebase-rest-session",
-# account "firebase-rest-tokens") — see AuthService.saveTokens(). The remaining
-# auth-state keys (isSignedIn, userEmail, userId, names, onboarding) are in
-# UserDefaults. This script reads BOTH so the captured session can be replayed
-# into other test bundles with omi-auth-seed.sh, letting an agent skip the web
-# OAuth login on every run.
+# Keychain on ALL builds under a Team-ID-scoped service name derived from
+# "com.omi.desktop.firebase-rest-session" (see DesktopKeychainStore.scopedService).
+# The remaining auth-state keys (isSignedIn, userEmail, userId, names, onboarding)
+# are in UserDefaults. This script reads BOTH so the captured session can be
+# replayed into other test bundles with omi-auth-seed.sh, letting an agent skip
+# the web OAuth login on every run.
 #
 # It does NOT mint or refresh tokens — it copies whatever the source session has.
 # The captured Firebase idToken expires (~1h); re-run this after signing in again.
@@ -24,21 +24,67 @@ OUT="${2:-$(cd "$(dirname "$0")/.." && pwd)/tmp/desktop-auth.json}"
 UD_KEYS=(auth_isSignedIn auth_userEmail auth_userId auth_givenName auth_familyName \
          hasCompletedOnboarding)
 
-# Keychain item that holds the JSON-encoded token blob (StoredAuthTokens).
-KC_SERVICE="com.omi.desktop.firebase-rest-session"
+# Keychain base service/account. The actual service is team-scoped at runtime.
+KC_SERVICE_BASE="com.omi.desktop.firebase-rest-session"
 KC_ACCOUNT="firebase-rest-tokens"
 
 mkdir -p "$(dirname "$OUT")"
 
-python3 - "$SRC" "$OUT" "${UD_KEYS[@]}" "$KC_SERVICE" "$KC_ACCOUNT" <<'PY'
+# Resolve an installed .app path for the source bundle so we can read its Team ID.
+resolve_app_path() {
+  local bid="$1"
+  local path
+  path="$(mdfind "kMDItemCFBundleIdentifier == '$bid'" 2>/dev/null | head -1 || true)"
+  if [ -n "$path" ] && [ -d "$path" ]; then
+    printf '%s\n' "$path"
+    return 0
+  fi
+  # Common install locations for Omi Dev / named bundles.
+  for candidate in \
+    "/Applications/Omi Dev.app" \
+    "/Applications/${bid#com.omi.}.app" \
+    "/Applications/omi.app"
+  do
+    if [ -d "$candidate" ]; then
+      local found
+      found="$(defaults read "$candidate/Contents/Info" CFBundleIdentifier 2>/dev/null || true)"
+      if [ "$found" = "$bid" ]; then
+        printf '%s\n' "$candidate"
+        return 0
+      fi
+    fi
+  done
+  return 1
+}
+
+APP_PATH="$(resolve_app_path "$SRC" || true)"
+TEAM_ID=""
+if [ -n "$APP_PATH" ]; then
+  TEAM_ID="$(codesign -dv --verbose=4 "$APP_PATH" 2>&1 | awk -F= '/^TeamIdentifier=/{print $2; exit}')"
+fi
+if [ -z "$TEAM_ID" ] || [ "$TEAM_ID" = "not set" ]; then
+  TEAM_ID="adhoc.${SRC}"
+fi
+KC_SERVICE="${KC_SERVICE_BASE}.v2.team.${TEAM_ID}"
+
+python3 - "$SRC" "$OUT" "${UD_KEYS[@]}" "$KC_SERVICE" "$KC_SERVICE_BASE" "$KC_ACCOUNT" <<'PY'
 import json, subprocess, sys
 
 src, out = sys.argv[1], sys.argv[2]
-ud_keys = sys.argv[3:-2]
-kc_service, kc_account = sys.argv[-2], sys.argv[-1]
+ud_keys = sys.argv[3:-3]
+kc_service, kc_service_legacy, kc_account = sys.argv[-3], sys.argv[-2], sys.argv[-1]
 
 def defaults(*args):
     return subprocess.run(["defaults", *args], capture_output=True, text=True)
+
+def read_keychain(service):
+    kc = subprocess.run(
+        ["security", "find-generic-password", "-s", service, "-a", kc_account, "-w"],
+        capture_output=True, text=True,
+    )
+    if kc.returncode == 0 and kc.stdout.strip():
+        return kc.stdout.strip()
+    return None
 
 data = {}
 for k in ud_keys:
@@ -50,21 +96,18 @@ for k in ud_keys:
         continue
     data[k] = {"type": t.stdout.strip().replace("Type is ", ""), "value": v.stdout.strip()}
 
-# Read the token blob from the Keychain (shared login keychain, same
-# service/account on every build).  `security find-generic-password -w` prints
-# only the secret value to stdout.  Fall back to the legacy UserDefaults token
-# keys for bundles that still have pre-migration tokens sitting there.
-kc = subprocess.run(
-    ["security", "find-generic-password", "-s", kc_service, "-a", kc_account, "-w"],
-    capture_output=True, text=True,
-)
-if kc.returncode == 0 and kc.stdout.strip():
-    payload = kc.stdout.strip()
+# Prefer the team-scoped v2 item. Optionally try the unscoped legacy name for
+# pre-migration sessions — `security` may itself prompt if that ACL is poisoned;
+# Prefer Always Allow once, or delete the poisoned item. The app never queries
+# the legacy name (that is what caused the Beta password dialog).
+payload = read_keychain(kc_service) or read_keychain(kc_service_legacy)
+if payload:
     try:
         tokens = json.loads(payload)
         # Validate tokenUserId against the UserDefaults auth_userId to avoid
         # seeding signed-in state for one user with Keychain tokens belonging
-        # to a different user (the login Keychain is shared across all bundles).
+        # to a different user (the login Keychain is shared across all bundles
+        # of the same signing team).
         kc_uid = tokens.get("tokenUserId", "")
         ud_uid = data.get("auth_userId", {}).get("value", "")
         if ud_uid and kc_uid != ud_uid:
@@ -76,6 +119,7 @@ if kc.returncode == 0 and kc.stdout.strip():
             data["auth_refreshToken"] = {"type": "string", "value": tokens.get("refreshToken", "")}
             data["auth_tokenExpiry"] = {"type": "float", "value": str(tokens.get("expiryTime", 0))}
             data["auth_tokenUserId"] = {"type": "string", "value": kc_uid}
+            data["_keychainService"] = {"type": "string", "value": kc_service}
     except (json.JSONDecodeError, KeyError):
         pass  # fall through to UserDefaults below
 
@@ -97,6 +141,7 @@ with open(out, "w") as f:
 print(f"Dumped {len(data)} keys from {src} -> {out}")
 print(f"  signed_in={data.get('auth_isSignedIn', {}).get('value')} "
       f"email={data.get('auth_userEmail', {}).get('value')}")
+print(f"  keychain_service={kc_service}")
 if "auth_idToken" not in data or not data["auth_idToken"].get("value"):
     sys.exit("WARNING: no auth_idToken found — is the source bundle signed in?")
 PY

--- a/desktop/macos/scripts/omi-auth-dump.sh
+++ b/desktop/macos/scripts/omi-auth-dump.sh
@@ -67,7 +67,7 @@ if kc.returncode == 0 and kc.stdout.strip():
         # to a different user (the login Keychain is shared across all bundles).
         kc_uid = tokens.get("tokenUserId", "")
         ud_uid = data.get("auth_userId", {}).get("value", "")
-        if kc_uid and ud_uid and kc_uid != ud_uid:
+        if ud_uid and kc_uid != ud_uid:
             print(f"WARNING: Keychain tokenUserId ({kc_uid}) does not match "
                   f"UserDefaults auth_userId ({ud_uid}) — falling back to "
                   f"UserDefaults token keys.", file=sys.stderr)

--- a/desktop/macos/scripts/omi-auth-dump.sh
+++ b/desktop/macos/scripts/omi-auth-dump.sh
@@ -62,10 +62,20 @@ if kc.returncode == 0 and kc.stdout.strip():
     payload = kc.stdout.strip()
     try:
         tokens = json.loads(payload)
-        data["auth_idToken"] = {"type": "string", "value": tokens.get("idToken", "")}
-        data["auth_refreshToken"] = {"type": "string", "value": tokens.get("refreshToken", "")}
-        data["auth_tokenExpiry"] = {"type": "float", "value": str(tokens.get("expiryTime", 0))}
-        data["auth_tokenUserId"] = {"type": "string", "value": tokens.get("tokenUserId", "")}
+        # Validate tokenUserId against the UserDefaults auth_userId to avoid
+        # seeding signed-in state for one user with Keychain tokens belonging
+        # to a different user (the login Keychain is shared across all bundles).
+        kc_uid = tokens.get("tokenUserId", "")
+        ud_uid = data.get("auth_userId", {}).get("value", "")
+        if kc_uid and ud_uid and kc_uid != ud_uid:
+            print(f"WARNING: Keychain tokenUserId ({kc_uid}) does not match "
+                  f"UserDefaults auth_userId ({ud_uid}) — falling back to "
+                  f"UserDefaults token keys.", file=sys.stderr)
+        else:
+            data["auth_idToken"] = {"type": "string", "value": tokens.get("idToken", "")}
+            data["auth_refreshToken"] = {"type": "string", "value": tokens.get("refreshToken", "")}
+            data["auth_tokenExpiry"] = {"type": "float", "value": str(tokens.get("expiryTime", 0))}
+            data["auth_tokenUserId"] = {"type": "string", "value": kc_uid}
     except (json.JSONDecodeError, KeyError):
         pass  # fall through to UserDefaults below
 

--- a/desktop/macos/scripts/omi-auth-dump.sh
+++ b/desktop/macos/scripts/omi-auth-dump.sh
@@ -2,8 +2,9 @@
 # omi-auth-dump.sh — capture a signed-in dev bundle's auth session to JSON.
 #
 # Auth tokens (idToken, refreshToken, expiry, tokenUserId) live in the macOS
-# Keychain on ALL builds under a Team-ID-scoped service name derived from
+# Keychain on ALL builds under a Team+bundle scoped service name derived from
 # "com.omi.desktop.firebase-rest-session" (see DesktopKeychainStore.scopedService).
+# Format: <base>.v2.team.<TeamID>.bundle.<bundleID>
 # The remaining auth-state keys (isSignedIn, userEmail, userId, names, onboarding)
 # are in UserDefaults. This script reads BOTH so the captured session can be
 # replayed into other test bundles with omi-auth-seed.sh, letting an agent skip
@@ -24,7 +25,7 @@ OUT="${2:-$(cd "$(dirname "$0")/.." && pwd)/tmp/desktop-auth.json}"
 UD_KEYS=(auth_isSignedIn auth_userEmail auth_userId auth_givenName auth_familyName \
          hasCompletedOnboarding)
 
-# Keychain base service/account. The actual service is team-scoped at runtime.
+# Keychain base service/account. The actual service is team+bundle scoped at runtime.
 KC_SERVICE_BASE="com.omi.desktop.firebase-rest-session"
 KC_ACCOUNT="firebase-rest-tokens"
 
@@ -65,7 +66,7 @@ fi
 if [ -z "$TEAM_ID" ] || [ "$TEAM_ID" = "not set" ]; then
   TEAM_ID="adhoc.${SRC}"
 fi
-KC_SERVICE="${KC_SERVICE_BASE}.v2.team.${TEAM_ID}"
+KC_SERVICE="${KC_SERVICE_BASE}.v2.team.${TEAM_ID}.bundle.${SRC}"
 
 python3 - "$SRC" "$OUT" "${UD_KEYS[@]}" "$KC_SERVICE" "$KC_SERVICE_BASE" "$KC_ACCOUNT" <<'PY'
 import json, subprocess, sys
@@ -96,18 +97,17 @@ for k in ud_keys:
         continue
     data[k] = {"type": t.stdout.strip().replace("Type is ", ""), "value": v.stdout.strip()}
 
-# Prefer the team-scoped v2 item. Optionally try the unscoped legacy name for
-# pre-migration sessions — `security` may itself prompt if that ACL is poisoned;
-# Prefer Always Allow once, or delete the poisoned item. The app never queries
-# the legacy name (that is what caused the Beta password dialog).
+# Prefer the team+bundle scoped v2 item. Optionally try the unscoped legacy name
+# for pre-migration sessions — `security` may itself prompt if that ACL is
+# poisoned; Prefer Always Allow once, or delete the poisoned item. The app never
+# queries the legacy name (that is what caused the Beta password dialog).
 payload = read_keychain(kc_service) or read_keychain(kc_service_legacy)
 if payload:
     try:
         tokens = json.loads(payload)
         # Validate tokenUserId against the UserDefaults auth_userId to avoid
         # seeding signed-in state for one user with Keychain tokens belonging
-        # to a different user (the login Keychain is shared across all bundles
-        # of the same signing team).
+        # to a different user.
         kc_uid = tokens.get("tokenUserId", "")
         ud_uid = data.get("auth_userId", {}).get("value", "")
         if ud_uid and kc_uid != ud_uid:

--- a/desktop/macos/scripts/omi-auth-dump.sh
+++ b/desktop/macos/scripts/omi-auth-dump.sh
@@ -68,12 +68,12 @@ if [ -z "$TEAM_ID" ] || [ "$TEAM_ID" = "not set" ]; then
 fi
 KC_SERVICE="${KC_SERVICE_BASE}.v2.team.${TEAM_ID}.bundle.${SRC}"
 
-python3 - "$SRC" "$OUT" "${UD_KEYS[@]}" "$KC_SERVICE" "$KC_SERVICE_BASE" "$KC_ACCOUNT" <<'PY'
+python3 - "$SRC" "$OUT" "${UD_KEYS[@]}" "$KC_SERVICE" "$KC_ACCOUNT" <<'PY'
 import json, subprocess, sys
 
 src, out = sys.argv[1], sys.argv[2]
-ud_keys = sys.argv[3:-3]
-kc_service, kc_service_legacy, kc_account = sys.argv[-3], sys.argv[-2], sys.argv[-1]
+ud_keys = sys.argv[3:-2]
+kc_service, kc_account = sys.argv[-2], sys.argv[-1]
 
 def defaults(*args):
     return subprocess.run(["defaults", *args], capture_output=True, text=True)
@@ -97,11 +97,11 @@ for k in ud_keys:
         continue
     data[k] = {"type": t.stdout.strip().replace("Type is ", ""), "value": v.stdout.strip()}
 
-# Prefer the team+bundle scoped v2 item. Optionally try the unscoped legacy name
-# for pre-migration sessions — `security` may itself prompt if that ACL is
-# poisoned; Prefer Always Allow once, or delete the poisoned item. The app never
-# queries the legacy name (that is what caused the Beta password dialog).
-payload = read_keychain(kc_service) or read_keychain(kc_service_legacy)
+# Only the team+bundle scoped v2 item. Never query the unscoped legacy service —
+# `security find-generic-password` on a poisoned ACL can show the same login-
+# keychain password dialog this PR eliminates. Pre-migration sessions fall
+# through to UserDefaults token keys below.
+payload = read_keychain(kc_service)
 if payload:
     try:
         tokens = json.loads(payload)

--- a/desktop/macos/scripts/omi-auth-seed.sh
+++ b/desktop/macos/scripts/omi-auth-seed.sh
@@ -4,14 +4,10 @@
 # Writes the auth-state UserDefaults keys (isSignedIn, userEmail, userId,
 # names, onboarding) captured by omi-auth-dump.sh into the target bundle's
 # domain. Auth tokens (idToken, refreshToken, expiry, tokenUserId) live in the
-# login Keychain under a Team-ID-scoped service name (see
-# DesktopKeychainStore.scopedService). Named test bundles signed with the same
-# Apple Development team as Omi Dev share that scoped item — no per-bundle
-# Keychain seed is needed when the dump came from the same team.
-#
-# If the dump captured tokens from UserDefaults (pre-migration source) or the
-# target team differs, those token values are written into the target team's
-# scoped Keychain item so the target bundle can read them on launch.
+# login Keychain under a Team+bundle scoped service name (see
+# DesktopKeychainStore.scopedService). Each bundle has its own Keychain item, so
+# this script always writes the token blob into the *target* bundle's scoped
+# service (dump from Omi Dev → seed into com.omi.omi-fix-rewind copies tokens).
 #
 # Run this BEFORE launching the bundle (UserDefaults is read at startup).
 #
@@ -66,11 +62,11 @@ fi
 if [ -z "$TEAM_ID" ] || [ "$TEAM_ID" = "not set" ]; then
   TEAM_ID="adhoc.${TARGET}"
 fi
-KC_SERVICE="${KC_SERVICE_BASE}.v2.team.${TEAM_ID}"
+KC_SERVICE="${KC_SERVICE_BASE}.v2.team.${TEAM_ID}.bundle.${TARGET}"
 
 # Token secrets are never written to the target bundle's UserDefaults — that
-# was the plaintext path this PR removed. If tokens are present in the dump,
-# they are written to the team-scoped Keychain item.
+# was the plaintext path this PR removed. Tokens from the dump are written to
+# the target bundle's team+bundle scoped Keychain item.
 SKIP_KEYS="auth_idToken auth_refreshToken auth_tokenExpiry auth_tokenUserId _keychainService"
 
 python3 - "$TARGET" "$IN" "$SKIP_KEYS" "$KC_SERVICE" "$KC_ACCOUNT" <<'PY'
@@ -97,9 +93,8 @@ for k, info in data.items():
     n += 1
 print(f"Seeded {n} keys into {target}")
 
-# Write token blob into the target team's scoped Keychain item. Same-team dumps
-# already share the item; this still refreshes the blob when the dump carried
-# explicit token values (pre-migration source or cross-team seed).
+# Always write the token blob into the target bundle's scoped Keychain item —
+# bundles no longer share a team-only item.
 id_token = data.get("auth_idToken", {}).get("value", "")
 refresh_token = data.get("auth_refreshToken", {}).get("value", "")
 token_expiry = data.get("auth_tokenExpiry", {}).get("value", "0")
@@ -116,8 +111,7 @@ if id_token and refresh_token:
         "expiryTime": expiry,
         "tokenUserId": token_uid,
     })
-    # Delete any existing item first so -U update cannot hit a poisoned ACL
-    # from a different signing identity under the same service name.
+    # Delete any existing item first so -U update cannot hit a poisoned ACL.
     subprocess.run(
         ["security", "delete-generic-password", "-s", kc_service, "-a", kc_account],
         capture_output=True, text=True,
@@ -133,7 +127,8 @@ if id_token and refresh_token:
         print(f"WARNING: could not write token blob to Keychain: {r.stderr.strip()}",
               file=sys.stderr)
 else:
-    print(f"No token values in dump — relying on existing Keychain item for {kc_service}")
+    print("WARNING: no token values in dump — target bundle will not have Keychain tokens",
+          file=sys.stderr)
 PY
 
 echo "Done — launch $TARGET and it boots signed-in (no web login)."

--- a/desktop/macos/scripts/omi-auth-seed.sh
+++ b/desktop/macos/scripts/omi-auth-seed.sh
@@ -1,9 +1,11 @@
 #!/bin/bash
 # omi-auth-seed.sh — replay a captured auth session into a test bundle.
 #
-# Writes the auth_* UserDefaults keys (and hasCompletedOnboarding) captured by
-# omi-auth-dump.sh into the target bundle's domain. On next launch the app's
-# restoreAuthState() picks them up and boots already-signed-in — no browser.
+# Writes the auth-state UserDefaults keys (isSignedIn, userEmail, userId,
+# names, onboarding) captured by omi-auth-dump.sh into the target bundle's
+# domain.  Auth tokens (idToken, refreshToken, expiry, tokenUserId) are shared
+# via the login Keychain under a fixed service/account on ALL builds, so they
+# are already available to the named bundle — no per-bundle seed needed.
 #
 # Run this BEFORE launching the bundle (UserDefaults is read at startup).
 #
@@ -22,9 +24,15 @@ IN="${2:-$(cd "$(dirname "$0")/.." && pwd)/tmp/desktop-auth.json}"
 
 [ -f "$IN" ] || { echo "No auth file at $IN — run omi-auth-dump.sh first." >&2; exit 1; }
 
-python3 - "$TARGET" "$IN" <<'PY'
+# Token secrets live in the shared login Keychain — never write them to the
+# target bundle's UserDefaults (that was the plaintext path this PR removed).
+SKIP_KEYS="auth_idToken auth_refreshToken auth_tokenExpiry auth_tokenUserId"
+
+python3 - "$TARGET" "$IN" "$SKIP_KEYS" <<'PY'
 import json, subprocess, sys
+
 target, inp = sys.argv[1], sys.argv[2]
+skip = set(sys.argv[3].split())
 data = json.load(open(inp))
 
 flag = {"boolean": "-bool", "string": "-string", "integer": "-int",
@@ -32,6 +40,8 @@ flag = {"boolean": "-bool", "string": "-string", "integer": "-int",
 
 n = 0
 for k, info in data.items():
+    if k in skip:
+        continue
     typ, val = info["type"], info["value"]
     # `defaults read` prints booleans as 1/0, but `defaults write -bool` only
     # accepts true/false/yes/no — convert so the write doesn't fail.
@@ -43,3 +53,4 @@ print(f"Seeded {n} keys into {target}")
 PY
 
 echo "Done — launch $TARGET and it boots signed-in (no web login)."
+echo "Auth tokens are shared via the login Keychain — no per-bundle token seed needed."

--- a/desktop/macos/scripts/omi-auth-seed.sh
+++ b/desktop/macos/scripts/omi-auth-seed.sh
@@ -3,13 +3,15 @@
 #
 # Writes the auth-state UserDefaults keys (isSignedIn, userEmail, userId,
 # names, onboarding) captured by omi-auth-dump.sh into the target bundle's
-# domain.  Auth tokens (idToken, refreshToken, expiry, tokenUserId) are shared
-# via the login Keychain under a fixed service/account on ALL builds, so they
-# are already available to the named bundle — no per-bundle seed needed.
+# domain. Auth tokens (idToken, refreshToken, expiry, tokenUserId) live in the
+# login Keychain under a Team-ID-scoped service name (see
+# DesktopKeychainStore.scopedService). Named test bundles signed with the same
+# Apple Development team as Omi Dev share that scoped item — no per-bundle
+# Keychain seed is needed when the dump came from the same team.
 #
-# If the dump captured tokens from UserDefaults (pre-migration source bundle
-# that has not yet migrated to Keychain), those token values are written into
-# the shared Keychain item so the target bundle can read them on launch.
+# If the dump captured tokens from UserDefaults (pre-migration source) or the
+# target team differs, those token values are written into the target team's
+# scoped Keychain item so the target bundle can read them on launch.
 #
 # Run this BEFORE launching the bundle (UserDefaults is read at startup).
 #
@@ -28,14 +30,48 @@ IN="${2:-$(cd "$(dirname "$0")/.." && pwd)/tmp/desktop-auth.json}"
 
 [ -f "$IN" ] || { echo "No auth file at $IN — run omi-auth-dump.sh first." >&2; exit 1; }
 
-# Keychain item that holds the JSON-encoded token blob (StoredAuthTokens).
-KC_SERVICE="com.omi.desktop.firebase-rest-session"
+KC_SERVICE_BASE="com.omi.desktop.firebase-rest-session"
 KC_ACCOUNT="firebase-rest-tokens"
 
+resolve_app_path() {
+  local bid="$1"
+  local path
+  path="$(mdfind "kMDItemCFBundleIdentifier == '$bid'" 2>/dev/null | head -1 || true)"
+  if [ -n "$path" ] && [ -d "$path" ]; then
+    printf '%s\n' "$path"
+    return 0
+  fi
+  for candidate in \
+    "/Applications/Omi Dev.app" \
+    "/Applications/${bid#com.omi.}.app" \
+    "/Applications/omi.app"
+  do
+    if [ -d "$candidate" ]; then
+      local found
+      found="$(defaults read "$candidate/Contents/Info" CFBundleIdentifier 2>/dev/null || true)"
+      if [ "$found" = "$bid" ]; then
+        printf '%s\n' "$candidate"
+        return 0
+      fi
+    fi
+  done
+  return 1
+}
+
+APP_PATH="$(resolve_app_path "$TARGET" || true)"
+TEAM_ID=""
+if [ -n "$APP_PATH" ]; then
+  TEAM_ID="$(codesign -dv --verbose=4 "$APP_PATH" 2>&1 | awk -F= '/^TeamIdentifier=/{print $2; exit}')"
+fi
+if [ -z "$TEAM_ID" ] || [ "$TEAM_ID" = "not set" ]; then
+  TEAM_ID="adhoc.${TARGET}"
+fi
+KC_SERVICE="${KC_SERVICE_BASE}.v2.team.${TEAM_ID}"
+
 # Token secrets are never written to the target bundle's UserDefaults — that
-# was the plaintext path this PR removed.  If tokens are present in the dump
-# (from a pre-migration source), they are written to the shared Keychain.
-SKIP_KEYS="auth_idToken auth_refreshToken auth_tokenExpiry auth_tokenUserId"
+# was the plaintext path this PR removed. If tokens are present in the dump,
+# they are written to the team-scoped Keychain item.
+SKIP_KEYS="auth_idToken auth_refreshToken auth_tokenExpiry auth_tokenUserId _keychainService"
 
 python3 - "$TARGET" "$IN" "$SKIP_KEYS" "$KC_SERVICE" "$KC_ACCOUNT" <<'PY'
 import json, subprocess, sys
@@ -61,10 +97,9 @@ for k, info in data.items():
     n += 1
 print(f"Seeded {n} keys into {target}")
 
-# If the dump captured token values (from a pre-migration source bundle that
-# still had them in UserDefaults), write them into the shared Keychain item so
-# the target bundle can read them on launch.  On post-migration bundles the
-# Keychain item already exists and this is a no-op (same service/account).
+# Write token blob into the target team's scoped Keychain item. Same-team dumps
+# already share the item; this still refreshes the blob when the dump carried
+# explicit token values (pre-migration source or cross-team seed).
 id_token = data.get("auth_idToken", {}).get("value", "")
 refresh_token = data.get("auth_refreshToken", {}).get("value", "")
 token_expiry = data.get("auth_tokenExpiry", {}).get("value", "0")
@@ -81,6 +116,12 @@ if id_token and refresh_token:
         "expiryTime": expiry,
         "tokenUserId": token_uid,
     })
+    # Delete any existing item first so -U update cannot hit a poisoned ACL
+    # from a different signing identity under the same service name.
+    subprocess.run(
+        ["security", "delete-generic-password", "-s", kc_service, "-a", kc_account],
+        capture_output=True, text=True,
+    )
     r = subprocess.run(
         ["security", "add-generic-password", "-s", kc_service, "-a", kc_account,
          "-w", blob, "-U"],
@@ -91,6 +132,8 @@ if id_token and refresh_token:
     else:
         print(f"WARNING: could not write token blob to Keychain: {r.stderr.strip()}",
               file=sys.stderr)
+else:
+    print(f"No token values in dump — relying on existing Keychain item for {kc_service}")
 PY
 
 echo "Done — launch $TARGET and it boots signed-in (no web login)."

--- a/desktop/macos/scripts/omi-auth-seed.sh
+++ b/desktop/macos/scripts/omi-auth-seed.sh
@@ -77,6 +77,45 @@ skip = set(sys.argv[3].split())
 kc_service, kc_account = sys.argv[4], sys.argv[5]
 data = json.load(open(inp))
 
+id_token = data.get("auth_idToken", {}).get("value", "")
+refresh_token = data.get("auth_refreshToken", {}).get("value", "")
+token_expiry = data.get("auth_tokenExpiry", {}).get("value", "0")
+token_uid = data.get("auth_tokenUserId", {}).get("value", "")
+
+# Bundle-scoped Keychain items are not shared across apps. Refuse to seed a
+# signed-in UserDefaults state without credentials — that leaves a ghost session.
+if not id_token or not refresh_token:
+    print("ERROR: dump has no auth_idToken/auth_refreshToken — refusing to seed "
+          "signed-in state without Keychain credentials. Re-run omi-auth-dump.sh "
+          "from a signed-in source bundle.", file=sys.stderr)
+    sys.exit(1)
+
+try:
+    expiry = float(token_expiry)
+except (ValueError, TypeError):
+    expiry = 0.0
+blob = json.dumps({
+    "idToken": id_token,
+    "refreshToken": refresh_token,
+    "expiryTime": expiry,
+    "tokenUserId": token_uid,
+})
+# Delete any existing item first so -U update cannot hit a poisoned ACL.
+subprocess.run(
+    ["security", "delete-generic-password", "-s", kc_service, "-a", kc_account],
+    capture_output=True, text=True,
+)
+r = subprocess.run(
+    ["security", "add-generic-password", "-s", kc_service, "-a", kc_account,
+     "-w", blob, "-U"],
+    capture_output=True, text=True,
+)
+if r.returncode != 0:
+    print(f"ERROR: could not write token blob to Keychain ({kc_service}): "
+          f"{r.stderr.strip()}", file=sys.stderr)
+    sys.exit(1)
+print(f"Wrote token blob to Keychain ({kc_service}/{kc_account})")
+
 flag = {"boolean": "-bool", "string": "-string", "integer": "-int",
         "float": "-float", "date": "-date", "data": "-data"}
 
@@ -92,43 +131,6 @@ for k, info in data.items():
     subprocess.run(["defaults", "write", target, k, flag.get(typ, "-string"), val], check=True)
     n += 1
 print(f"Seeded {n} keys into {target}")
-
-# Always write the token blob into the target bundle's scoped Keychain item —
-# bundles no longer share a team-only item.
-id_token = data.get("auth_idToken", {}).get("value", "")
-refresh_token = data.get("auth_refreshToken", {}).get("value", "")
-token_expiry = data.get("auth_tokenExpiry", {}).get("value", "0")
-token_uid = data.get("auth_tokenUserId", {}).get("value", "")
-
-if id_token and refresh_token:
-    try:
-        expiry = float(token_expiry)
-    except (ValueError, TypeError):
-        expiry = 0.0
-    blob = json.dumps({
-        "idToken": id_token,
-        "refreshToken": refresh_token,
-        "expiryTime": expiry,
-        "tokenUserId": token_uid,
-    })
-    # Delete any existing item first so -U update cannot hit a poisoned ACL.
-    subprocess.run(
-        ["security", "delete-generic-password", "-s", kc_service, "-a", kc_account],
-        capture_output=True, text=True,
-    )
-    r = subprocess.run(
-        ["security", "add-generic-password", "-s", kc_service, "-a", kc_account,
-         "-w", blob, "-U"],
-        capture_output=True, text=True,
-    )
-    if r.returncode == 0:
-        print(f"Wrote token blob to Keychain ({kc_service}/{kc_account})")
-    else:
-        print(f"WARNING: could not write token blob to Keychain: {r.stderr.strip()}",
-              file=sys.stderr)
-else:
-    print("WARNING: no token values in dump — target bundle will not have Keychain tokens",
-          file=sys.stderr)
 PY
 
 echo "Done — launch $TARGET and it boots signed-in (no web login)."

--- a/desktop/macos/scripts/omi-auth-seed.sh
+++ b/desktop/macos/scripts/omi-auth-seed.sh
@@ -7,6 +7,10 @@
 # via the login Keychain under a fixed service/account on ALL builds, so they
 # are already available to the named bundle — no per-bundle seed needed.
 #
+# If the dump captured tokens from UserDefaults (pre-migration source bundle
+# that has not yet migrated to Keychain), those token values are written into
+# the shared Keychain item so the target bundle can read them on launch.
+#
 # Run this BEFORE launching the bundle (UserDefaults is read at startup).
 #
 # Usage: omi-auth-seed.sh <target-bundle-id> [in-file]
@@ -24,15 +28,21 @@ IN="${2:-$(cd "$(dirname "$0")/.." && pwd)/tmp/desktop-auth.json}"
 
 [ -f "$IN" ] || { echo "No auth file at $IN — run omi-auth-dump.sh first." >&2; exit 1; }
 
-# Token secrets live in the shared login Keychain — never write them to the
-# target bundle's UserDefaults (that was the plaintext path this PR removed).
+# Keychain item that holds the JSON-encoded token blob (StoredAuthTokens).
+KC_SERVICE="com.omi.desktop.firebase-rest-session"
+KC_ACCOUNT="firebase-rest-tokens"
+
+# Token secrets are never written to the target bundle's UserDefaults — that
+# was the plaintext path this PR removed.  If tokens are present in the dump
+# (from a pre-migration source), they are written to the shared Keychain.
 SKIP_KEYS="auth_idToken auth_refreshToken auth_tokenExpiry auth_tokenUserId"
 
-python3 - "$TARGET" "$IN" "$SKIP_KEYS" <<'PY'
+python3 - "$TARGET" "$IN" "$SKIP_KEYS" "$KC_SERVICE" "$KC_ACCOUNT" <<'PY'
 import json, subprocess, sys
 
 target, inp = sys.argv[1], sys.argv[2]
 skip = set(sys.argv[3].split())
+kc_service, kc_account = sys.argv[4], sys.argv[5]
 data = json.load(open(inp))
 
 flag = {"boolean": "-bool", "string": "-string", "integer": "-int",
@@ -50,7 +60,37 @@ for k, info in data.items():
     subprocess.run(["defaults", "write", target, k, flag.get(typ, "-string"), val], check=True)
     n += 1
 print(f"Seeded {n} keys into {target}")
+
+# If the dump captured token values (from a pre-migration source bundle that
+# still had them in UserDefaults), write them into the shared Keychain item so
+# the target bundle can read them on launch.  On post-migration bundles the
+# Keychain item already exists and this is a no-op (same service/account).
+id_token = data.get("auth_idToken", {}).get("value", "")
+refresh_token = data.get("auth_refreshToken", {}).get("value", "")
+token_expiry = data.get("auth_tokenExpiry", {}).get("value", "0")
+token_uid = data.get("auth_tokenUserId", {}).get("value", "")
+
+if id_token and refresh_token:
+    try:
+        expiry = float(token_expiry)
+    except (ValueError, TypeError):
+        expiry = 0.0
+    blob = json.dumps({
+        "idToken": id_token,
+        "refreshToken": refresh_token,
+        "expiryTime": expiry,
+        "tokenUserId": token_uid,
+    })
+    r = subprocess.run(
+        ["security", "add-generic-password", "-s", kc_service, "-a", kc_account,
+         "-w", blob, "-U"],
+        capture_output=True, text=True,
+    )
+    if r.returncode == 0:
+        print(f"Wrote token blob to Keychain ({kc_service}/{kc_account})")
+    else:
+        print(f"WARNING: could not write token blob to Keychain: {r.stderr.strip()}",
+              file=sys.stderr)
 PY
 
 echo "Done — launch $TARGET and it boots signed-in (no web login)."
-echo "Auth tokens are shared via the login Keychain — no per-bundle token seed needed."


### PR DESCRIPTION
## Summary

Two related desktop auth Keychain hardening changes:

1. **Keychain on all builds** — store Firebase REST tokens in Keychain on every build (including Sparkle beta / named dev bundles) and disable the plaintext UserDefaults write fallback. UserDefaults is still read once to migrate pre-existing tokens.

2. **No more login-keychain password dialogs for Beta/Prod *and* local contributors** — local Apple Development builds were writing shared Keychain items (`com.omi.desktop.firebase-rest-session`, `com.omi.client-device-id`). Notarized Beta/Prod and other same-team local apps then hit foreign ACLs and showed the scary keychain password sheet. Secrets now live under a **team+bundle scoped v2 service** (`….v2.team.<TeamID>.bundle.<bundleID>`), and the app **never SecItem-queries the legacy unscoped names**. Older auth sessions recover via UserDefaults migration.

Also:
- Team+bundle scopes the local-agent API token Keychain service
- Production device-id Keychain is scoped; **all** non-production bundles (`com.omi.desktop-dev` + `com.omi.omi-*`) keep device IDs in UserDefaults only
- `omi-auth-dump.sh` / `omi-auth-seed.sh` read/write the target bundle's scoped service (seed copies tokens across bundles)

## Root cause (prompt)

- Shared unscoped services + TrustedApplication / team partition ACLs
- Poisoned items from personal Apple Development (`JVMXE5G542`) or path-different same-team apps
- Shipped Beta/Prod: Developer ID `9536L8KLMP` / `com.omi.computer-macos`
- Querying a foreign ACL item triggers the password dialog; silent-auth flags do not fully suppress login-keychain ACL UI

## Test plan

- [x] `xcrun swift test --package-path Desktop --filter 'AuthTokenStorageTests|FailLoudConfigTests|ClientDeviceServiceTests'` — 25/25 pass
- [ ] Launch notarized Beta on a machine that previously showed the prompt — no keychain password dialog
- [ ] Local Omi Dev and a named `omi-*` bundle each write distinct `….bundle.<id>` auth items; neither prompts
- [ ] `omi-auth-dump.sh` from Dev + `omi-auth-seed.sh` into a named bundle still boots signed-in
- [ ] Clean sign-in on fixed Beta — writes only `….v2.team.9536L8KLMP.bundle.com.omi.computer-macos`