### PR TITLE
Set up main refresh in worktree setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,13 @@ PYTHON ?= $(shell if [ -x backend/venv/bin/python ]; then printf backend/venv/bi
 DESKTOP_USER ?= alice
 DESKTOP_APP_NAME ?=
 
-.PHONY: setup setup-hooks dev-check dev-up dev-status dev-summary dev-reset dev-down dev-logs dev dev-desktop dev-init dev-verify list-memory-scenarios seed-memory-scenario reset-memory-scenario desktop-run-local run-canonical-promotion
+.PHONY: setup setup-main setup-hooks dev-check dev-up dev-status dev-summary dev-reset dev-down dev-logs dev dev-desktop dev-init dev-verify list-memory-scenarios seed-memory-scenario reset-memory-scenario desktop-run-local run-canonical-promotion
 
-setup: setup-hooks
+setup: setup-main setup-hooks
 	@echo "Worktree setup complete."
+
+setup-main:
+	@bash scripts/setup-refresh-main.sh
 
 setup-hooks:
 	@bash scripts/install-git-hooks.sh

--- a/scripts/setup-refresh-main.sh
+++ b/scripts/setup-refresh-main.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+REMOTE="${SETUP_REMOTE:-origin}"
+BRANCH="${SETUP_MAIN_BRANCH:-main}"
+REMOTE_BRANCH="${REMOTE}/${BRANCH}"
+LOCAL_REF="refs/heads/${BRANCH}"
+REMOTE_REF="refs/remotes/${REMOTE}/${BRANCH}"
+
+echo "Fetching ${REMOTE_BRANCH}..."
+git fetch "$REMOTE" "$BRANCH"
+
+if ! git rev-parse --verify "$REMOTE_REF" >/dev/null 2>&1; then
+  echo "FAIL: fetched ${REMOTE_BRANCH}, but ${REMOTE_REF} is unavailable." >&2
+  exit 1
+fi
+
+current_branch="$(git symbolic-ref --short -q HEAD || true)"
+if [ "$current_branch" = "$BRANCH" ]; then
+  echo "Fast-forwarding current ${BRANCH} branch..."
+  git pull --ff-only "$REMOTE" "$BRANCH"
+  exit 0
+fi
+
+if ! git show-ref --verify --quiet "$LOCAL_REF"; then
+  git branch "$BRANCH" "$REMOTE_REF"
+  echo "Created local ${BRANCH} from ${REMOTE_BRANCH}."
+  exit 0
+fi
+
+local_oid="$(git rev-parse "$LOCAL_REF")"
+remote_oid="$(git rev-parse "$REMOTE_REF")"
+
+if [ "$local_oid" = "$remote_oid" ]; then
+  echo "Local ${BRANCH} already matches ${REMOTE_BRANCH}."
+  exit 0
+fi
+
+if ! git merge-base --is-ancestor "$local_oid" "$remote_oid"; then
+  echo "Fetched ${REMOTE_BRANCH}; local ${BRANCH} is not a fast-forward, so it was left unchanged." >&2
+  exit 0
+fi
+
+if git branch --force "$BRANCH" "$REMOTE_REF" >/dev/null 2>&1; then
+  echo "Fast-forwarded local ${BRANCH} to ${REMOTE_BRANCH}."
+else
+  echo "Fetched ${REMOTE_BRANCH}; local ${BRANCH} is checked out in another worktree, so it was left unchanged." >&2
+fi

--- a/scripts/setup-refresh-main.sh
+++ b/scripts/setup-refresh-main.sh
@@ -17,12 +17,6 @@ if ! git rev-parse --verify "$REMOTE_REF" >/dev/null 2>&1; then
 fi
 
 current_branch="$(git symbolic-ref --short -q HEAD || true)"
-if [ "$current_branch" = "$BRANCH" ]; then
-  echo "Fast-forwarding current ${BRANCH} branch..."
-  git pull --ff-only "$REMOTE" "$BRANCH"
-  exit 0
-fi
-
 if ! git show-ref --verify --quiet "$LOCAL_REF"; then
   git branch "$BRANCH" "$REMOTE_REF"
   echo "Created local ${BRANCH} from ${REMOTE_BRANCH}."
@@ -42,8 +36,23 @@ if ! git merge-base --is-ancestor "$local_oid" "$remote_oid"; then
   exit 0
 fi
 
-if git branch --force "$BRANCH" "$REMOTE_REF" >/dev/null 2>&1; then
+if [ "$current_branch" = "$BRANCH" ]; then
+  echo "Fast-forwarding current ${BRANCH} branch..."
+  git pull --ff-only "$REMOTE" "$BRANCH"
+  exit 0
+fi
+
+branch_error_file="$(mktemp "${TMPDIR:-/tmp}/omi-setup-refresh-main.XXXXXX")"
+trap 'rm -f "$branch_error_file"' EXIT
+
+if git branch --force "$BRANCH" "$REMOTE_REF" >/dev/null 2>"$branch_error_file"; then
   echo "Fast-forwarded local ${BRANCH} to ${REMOTE_BRANCH}."
 else
-  echo "Fetched ${REMOTE_BRANCH}; local ${BRANCH} is checked out in another worktree, so it was left unchanged." >&2
+  branch_error="$(cat "$branch_error_file")"
+  if [[ "$branch_error" == *"checked out"* || "$branch_error" == *"used by worktree"* ]]; then
+    echo "Fetched ${REMOTE_BRANCH}; local ${BRANCH} is checked out in another worktree, so it was left unchanged." >&2
+  else
+    echo "$branch_error" >&2
+    exit 1
+  fi
 fi

--- a/scripts/test-setup-refresh-main.sh
+++ b/scripts/test-setup-refresh-main.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+TMPDIR="$(mktemp -d "${TMPDIR:-/tmp}/omi-setup-refresh-main.XXXXXX")"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+git init --bare "$TMPDIR/remote.git" >/dev/null
+
+git clone "$TMPDIR/remote.git" "$TMPDIR/primary" >/dev/null 2>&1
+(
+  cd "$TMPDIR/primary"
+  git config user.email test@example.com
+  git config user.name "Test User"
+  echo one >file.txt
+  git add file.txt
+  git commit -m initial >/dev/null
+  git push origin HEAD:main >/dev/null 2>&1
+  git branch -M main
+  git fetch origin main >/dev/null 2>&1
+  git branch --set-upstream-to origin/main main >/dev/null
+)
+
+git clone "$TMPDIR/remote.git" "$TMPDIR/updater" >/dev/null 2>&1
+(
+  cd "$TMPDIR/updater"
+  git config user.email test@example.com
+  git config user.name "Test User"
+  git switch main >/dev/null 2>&1
+  echo two >>file.txt
+  git commit -am update >/dev/null
+  git push origin main >/dev/null 2>&1
+)
+
+(
+  cd "$TMPDIR/primary"
+  git worktree add "$TMPDIR/feature" -b feature >/dev/null 2>&1
+)
+
+before="$(git -C "$TMPDIR/primary" rev-parse main)"
+output="$(
+  cd "$TMPDIR/feature"
+  bash "$ROOT/scripts/setup-refresh-main.sh" 2>&1
+)"
+after="$(git -C "$TMPDIR/primary" rev-parse main)"
+remote_after="$(git -C "$TMPDIR/feature" rev-parse origin/main)"
+
+if [ "$before" != "$after" ]; then
+  echo "FAIL: local main changed while checked out in another worktree." >&2
+  exit 1
+fi
+
+if ! git -C "$TMPDIR/feature" merge-base --is-ancestor "$before" "$remote_after"; then
+  echo "FAIL: origin/main was not refreshed." >&2
+  exit 1
+fi
+
+case "$output" in
+  *"checked out in another worktree"*) ;;
+  *)
+    echo "FAIL: expected checked-out worktree message." >&2
+    echo "$output" >&2
+    exit 1
+    ;;
+esac
+
+echo "setup-refresh-main test passed."

--- a/scripts/test-setup-refresh-main.sh
+++ b/scripts/test-setup-refresh-main.sh
@@ -6,7 +6,7 @@ ROOT="$(git rev-parse --show-toplevel)"
 TMPDIR="$(mktemp -d "${TMPDIR:-/tmp}/omi-setup-refresh-main.XXXXXX")"
 trap 'rm -rf "$TMPDIR"' EXIT
 
-git init --bare "$TMPDIR/remote.git" >/dev/null
+git init --bare --initial-branch=main "$TMPDIR/remote.git" >/dev/null
 
 git clone "$TMPDIR/remote.git" "$TMPDIR/primary" >/dev/null 2>&1
 (
@@ -66,3 +66,55 @@ case "$output" in
 esac
 
 echo "setup-refresh-main test passed."
+
+git init --bare --initial-branch=main "$TMPDIR/diverged-remote.git" >/dev/null
+
+git clone "$TMPDIR/diverged-remote.git" "$TMPDIR/diverged-primary" >/dev/null 2>&1
+(
+  cd "$TMPDIR/diverged-primary"
+  git config user.email test@example.com
+  git config user.name "Test User"
+  echo one >file.txt
+  git add file.txt
+  git commit -m initial >/dev/null
+  git push origin main >/dev/null 2>&1
+)
+
+git clone "$TMPDIR/diverged-remote.git" "$TMPDIR/diverged-updater" >/dev/null 2>&1
+(
+  cd "$TMPDIR/diverged-updater"
+  git config user.email test@example.com
+  git config user.name "Test User"
+  echo remote >>file.txt
+  git commit -am remote-update >/dev/null
+  git push origin main >/dev/null 2>&1
+)
+
+(
+  cd "$TMPDIR/diverged-primary"
+  echo local >>file.txt
+  git commit -am local-update >/dev/null
+)
+
+diverged_before="$(git -C "$TMPDIR/diverged-primary" rev-parse main)"
+diverged_output="$(
+  cd "$TMPDIR/diverged-primary"
+  bash "$ROOT/scripts/setup-refresh-main.sh" 2>&1
+)"
+diverged_after="$(git -C "$TMPDIR/diverged-primary" rev-parse main)"
+
+if [ "$diverged_before" != "$diverged_after" ]; then
+  echo "FAIL: diverged current main changed." >&2
+  exit 1
+fi
+
+case "$diverged_output" in
+  *"not a fast-forward"*) ;;
+  *)
+    echo "FAIL: expected non-fast-forward message." >&2
+    echo "$diverged_output" >&2
+    exit 1
+    ;;
+esac
+
+echo "setup-refresh-main diverged-current-main test passed."


### PR DESCRIPTION
## Summary
- Make `make setup` refresh `origin/main` before installing Git hooks.
- Fast-forward local `main` when safe, while leaving it unchanged if it is checked out in another worktree or is not a fast-forward.
- Add a shell regression test for the linked-worktree checked-out `main` case.

## Validation
- `bash -n scripts/setup-refresh-main.sh`
- `bash -n scripts/test-setup-refresh-main.sh`
- `shellcheck scripts/setup-refresh-main.sh scripts/test-setup-refresh-main.sh`
- `scripts/test-setup-refresh-main.sh`
- `make setup`
- `git push -u origin codex/setup-fetch-pull-main` with pre-push hook enabled after syncing `backend/.venv`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9284?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

