### PR TITLE
fix(desktop): crash on duplicate ids in task/apps/chat data (#6506)

### DIFF
--- a/desktop/macos/Desktop/Sources/Providers/AppProvider.swift
+++ b/desktop/macos/Desktop/Sources/Providers/AppProvider.swift
@@ -197,8 +197,10 @@ class AppProvider: ObservableObject {
             Task {
                 do {
                     let ratedApps = try await self.apiClient.getAppsWithRatings()
-                    // Build a map of id → full app (for ratings AND enabled state)
-                    let v1Map = Dictionary(uniqueKeysWithValues: ratedApps.map { ($0.id, $0) })
+                    // Build a map of id → full app (for ratings AND enabled state).
+                    // The API can return duplicate app ids; use last-write-wins instead of
+                    // Dictionary(uniqueKeysWithValues:), which traps on a duplicate key.
+                    let v1Map = Dictionary(ratedApps.map { ($0.id, $0) }, uniquingKeysWith: { _, latest in latest })
                     func enrich(_ list: inout [OmiApp]) {
                         for index in list.indices {
                             guard let v1App = v1Map[list[index].id] else { continue }

--- a/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
@@ -4359,7 +4359,10 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
         for runId in runIds {
             guard let artifacts = try? await DesktopCoordinatorService.shared.inspectArtifactsForRun(runId: runId)
             else { continue }
-            artifactsByRunId[runId] = Dictionary(uniqueKeysWithValues: artifacts.map { ($0.artifactId, $0) })
+            // Guard against duplicate artifact ids (last-write-wins); Dictionary(uniqueKeysWithValues:)
+            // traps on a duplicate key and would crash the chat view.
+            artifactsByRunId[runId] = Dictionary(
+                artifacts.map { ($0.artifactId, $0) }, uniquingKeysWith: { _, latest in latest })
         }
         guard !artifactsByRunId.isEmpty else { return }
 

--- a/desktop/macos/Desktop/Sources/Stores/TasksStore.swift
+++ b/desktop/macos/Desktop/Sources/Stores/TasksStore.swift
@@ -274,7 +274,7 @@ class TasksStore: ObservableObject {
             )
 
             // Merge without triggering @Published unless something actually changed
-            let merged = mergeWithoutAdding(source: mergedTasks, current: incompleteTasks)
+            let merged = Self.mergeWithoutAdding(source: mergedTasks, current: incompleteTasks)
             if merged != incompleteTasks {
                 // Log what actually changed
                 let currentIds = Set(incompleteTasks.map { $0.id })
@@ -332,7 +332,7 @@ class TasksStore: ObservableObject {
                     offset: 0,
                     completed: true
                 )
-                let merged = mergeWithoutAdding(source: mergedTasks, current: completedTasks)
+                let merged = Self.mergeWithoutAdding(source: mergedTasks, current: completedTasks)
                 if merged != completedTasks {
                     completedTasks = merged
                     completedOffset = merged.count
@@ -369,7 +369,7 @@ class TasksStore: ObservableObject {
                 )
                 // Filter to only deleted
                 let newDeleted = mergedTasks.filter { $0.deleted == true }
-                let merged = mergeWithoutAdding(source: newDeleted, current: deletedTasks)
+                let merged = Self.mergeWithoutAdding(source: newDeleted, current: deletedTasks)
                 if merged != deletedTasks {
                     deletedTasks = merged
                     deletedOffset = merged.count
@@ -446,8 +446,11 @@ class TasksStore: ObservableObject {
     /// Does NOT add new items — new tasks only appear on explicit load (initial load, tab switch).
     /// Returns a new array only if different from current (caller compares with == before assigning
     /// to @Published property, preventing unnecessary objectWillChange notifications).
-    private func mergeWithoutAdding(source: [TaskActionItem], current: [TaskActionItem]) -> [TaskActionItem] {
-        let sourceById = Dictionary(uniqueKeysWithValues: source.map { ($0.id, $0) })
+    static func mergeWithoutAdding(source: [TaskActionItem], current: [TaskActionItem]) -> [TaskActionItem] {
+        // The source list can contain duplicate ids (local sync/reconciliation races),
+        // so build the lookup with last-write-wins. `Dictionary(uniqueKeysWithValues:)`
+        // traps on a duplicate key and crashes the app (same crash class as #6506).
+        let sourceById = Dictionary(source.map { ($0.id, $0) }, uniquingKeysWith: { _, latest in latest })
         let sourceIds = Set(source.map { $0.id })
 
         var result = current

--- a/desktop/macos/Desktop/Tests/TasksStoreMergeWithoutAddingTests.swift
+++ b/desktop/macos/Desktop/Tests/TasksStoreMergeWithoutAddingTests.swift
@@ -1,0 +1,31 @@
+import XCTest
+
+@testable import Omi_Computer
+
+@MainActor
+final class TasksStoreMergeWithoutAddingTests: XCTestCase {
+
+  private func task(id: String, description: String) -> TaskActionItem {
+    TaskActionItem(id: id, description: description, completed: false, createdAt: Date(timeIntervalSince1970: 0))
+  }
+
+  /// Regression for the #6506 crash class: a source list with duplicate ids must not
+  /// trap. `Dictionary(uniqueKeysWithValues:)` crashed here; the lookup now uses
+  /// last-write-wins.
+  func testDuplicateSourceIdsDoNotCrashAndLastWriteWins() {
+    let source = [
+      task(id: "a", description: "old"),
+      task(id: "a", description: "new"),
+      task(id: "b", description: "b"),
+    ]
+    let current = [task(id: "a", description: "current-a")]
+
+    let merged = TasksStore.mergeWithoutAdding(source: source, current: current)
+
+    // Only ids already present in `current` are kept, updated from the source.
+    XCTAssertEqual(merged.count, 1)
+    XCTAssertEqual(merged.first?.id, "a")
+    // Last occurrence of the duplicate id wins.
+    XCTAssertEqual(merged.first?.description, "new")
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260708-fix-duplicate-id-dictionary-crash.json
+++ b/desktop/macos/changelog/unreleased/20260708-fix-duplicate-id-dictionary-crash.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed rare crashes when the app received data with duplicate ids (tasks, apps list, chat artifacts)"
+}


### PR DESCRIPTION
## Bug
Issue #6506 reported a hard crash (`EXC_BREAKPOINT` / assertion failure) when opening the **Plan and Usage** settings pane. The crash report bottoms out in `_NativeDictionary.merge(uniquingKeysWith:)` from `SettingsContentView.mergePlanCatalog` — i.e. building a dictionary with `Dictionary(uniqueKeysWithValues:)` / `merge(...)` that **traps when a key appears twice**.

That specific pane was already refactored to a safe merger (`SubscriptionPlanCatalogMerger`, with a regression test). But the **same crash class** — a trapping `Dictionary(uniqueKeysWithValues:)` over an `($0.id, $0)` map of server/collection data — still exists in three sibling desktop paths, any of which crashes the app if the source contains a duplicate id:

- `TasksStore.mergeWithoutAdding` — task reconciliation (local sync/reconciliation races can produce duplicate task ids)
- `AppProvider` — `v1/apps` ratings/enabled enrichment (marketplace apps list)
- `ChatProvider` — agent-run artifact projections

The codebase already acknowledges the API returns duplicate ids and uses the safe `uniquingKeysWith: { _, latest in latest }` variant in `TasksPage`, `TaskDeduplicationService`, `AppState`, and `ConversationDetailView` — these three sites simply missed it.

## Fix
Switch all three to the established last-write-wins pattern (`Dictionary(_, uniquingKeysWith:)`). No behavior change for the normal (unique-id) case; duplicates now dedupe instead of crashing.

`TasksStore.mergeWithoutAdding` is extracted as a pure `static` func so it is unit-testable.

## Verification
- `xcrun swift build -c debug --package-path Desktop` → **Build complete!** (only pre-existing warnings)
- New regression test `TasksStoreMergeWithoutAddingTests` (duplicate-id source → no crash, last-write-wins) → **passed**. This test traps/crashes against the old code.
- Unit-level verification only (mirrors the existing #6506 `SubscriptionPlanCatalogMergerTests` approach); I did not reproduce a duplicate-id server response through the live UI.

🤖 automated by hourly watchdog; opened for review, not merged.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9288?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

