### PR TITLE
Enable full-dev LLM gateway feature-mode serving

### DIFF
--- a/backend/charts/backend-listen/dev_omi_backend_listen_values.yaml
+++ b/backend/charts/backend-listen/dev_omi_backend_listen_values.yaml
@@ -113,16 +113,20 @@ env:
     value: "http://dev-omi-llm-gateway.dev-omi-backend.svc.cluster.local:8080"
   - name: OMI_ENV_STAGE
     value: "dev"
-  - name: OMI_LLM_GATEWAY_CONVERSATION_STRUCTURE_SHADOW_ENABLED
+  - name: OMI_LLM_GATEWAY_FEATURE_MODE
+    value: "gateway"
+  - name: OMI_LLM_GATEWAY_ALLOW_DIRECT_MODEL_EXCEPTION
     value: "true"
+  - name: OMI_LLM_GATEWAY_CONVERSATION_STRUCTURE_SHADOW_ENABLED
+    value: "false"
   - name: OMI_LLM_GATEWAY_CONVERSATION_STRUCTURE_SHADOW_SAMPLE_RATE
     value: "1.0"
   - name: OMI_LLM_GATEWAY_CONVERSATION_ACTION_ITEMS_SHADOW_ENABLED
-    value: "true"
+    value: "false"
   - name: OMI_LLM_GATEWAY_CONVERSATION_ACTION_ITEMS_SHADOW_SAMPLE_RATE
     value: "1.0"
   - name: OMI_LLM_GATEWAY_DEV_SHADOW_ALL_ENABLED
-    value: "true"
+    value: "false"
   - name: OMI_LLM_GATEWAY_DEV_SHADOW_ALL_SAMPLE_RATE
     value: "1.0"
   - name: OMI_LLM_GATEWAY_SERVICE_TOKEN

--- a/backend/charts/llm-gateway/dev_omi_llm_gateway_values.yaml
+++ b/backend/charts/llm-gateway/dev_omi_llm_gateway_values.yaml
@@ -68,6 +68,16 @@ env:
       secretKeyRef:
         name: dev-omi-backend-secrets
         key: OPENAI_API_KEY
+  - name: GEMINI_API_KEY
+    valueFrom:
+      secretKeyRef:
+        name: dev-omi-backend-secrets
+        key: GEMINI_API_KEY
+  - name: OPENROUTER_API_KEY
+    valueFrom:
+      secretKeyRef:
+        name: dev-omi-backend-secrets
+        key: OPENROUTER_API_KEY
   - name: METRICS_SECRET
     valueFrom:
       secretKeyRef:

--- a/backend/deploy/runtime_env.yaml
+++ b/backend/deploy/runtime_env.yaml
@@ -15,20 +15,26 @@ environments:
           OMI_ENV_STAGE:
             value: dev
             category: runtime_identity
-          OMI_LLM_GATEWAY_CONVERSATION_STRUCTURE_SHADOW_ENABLED:
+          OMI_LLM_GATEWAY_FEATURE_MODE:
+            value: gateway
+            category: rollout
+          OMI_LLM_GATEWAY_ALLOW_DIRECT_MODEL_EXCEPTION:
             value: "true"
+            category: rollout
+          OMI_LLM_GATEWAY_CONVERSATION_STRUCTURE_SHADOW_ENABLED:
+            value: "false"
             category: rollout
           OMI_LLM_GATEWAY_CONVERSATION_STRUCTURE_SHADOW_SAMPLE_RATE:
             value: "1.0"
             category: rollout
           OMI_LLM_GATEWAY_CONVERSATION_ACTION_ITEMS_SHADOW_ENABLED:
-            value: "true"
+            value: "false"
             category: rollout
           OMI_LLM_GATEWAY_CONVERSATION_ACTION_ITEMS_SHADOW_SAMPLE_RATE:
             value: "1.0"
             category: rollout
           OMI_LLM_GATEWAY_DEV_SHADOW_ALL_ENABLED:
-            value: "true"
+            value: "false"
             category: rollout
           OMI_LLM_GATEWAY_DEV_SHADOW_ALL_SAMPLE_RATE:
             value: "1.0"
@@ -75,20 +81,26 @@ environments:
             OMI_LLM_GATEWAY_URL:
               value: http://172.16.63.232
               category: service_discovery
-            OMI_LLM_GATEWAY_CONVERSATION_STRUCTURE_SHADOW_ENABLED:
+            OMI_LLM_GATEWAY_FEATURE_MODE:
+              value: gateway
+              category: rollout
+            OMI_LLM_GATEWAY_ALLOW_DIRECT_MODEL_EXCEPTION:
               value: "true"
+              category: rollout
+            OMI_LLM_GATEWAY_CONVERSATION_STRUCTURE_SHADOW_ENABLED:
+              value: "false"
               category: rollout
             OMI_LLM_GATEWAY_CONVERSATION_STRUCTURE_SHADOW_SAMPLE_RATE:
               value: "1.0"
               category: rollout
             OMI_LLM_GATEWAY_CONVERSATION_ACTION_ITEMS_SHADOW_ENABLED:
-              value: "true"
+              value: "false"
               category: rollout
             OMI_LLM_GATEWAY_CONVERSATION_ACTION_ITEMS_SHADOW_SAMPLE_RATE:
               value: "1.0"
               category: rollout
             OMI_LLM_GATEWAY_DEV_SHADOW_ALL_ENABLED:
-              value: "true"
+              value: "false"
               category: rollout
             OMI_LLM_GATEWAY_DEV_SHADOW_ALL_SAMPLE_RATE:
               value: "1.0"
@@ -143,20 +155,26 @@ environments:
             OMI_LLM_GATEWAY_URL:
               value: http://172.16.63.232
               category: service_discovery
-            OMI_LLM_GATEWAY_CONVERSATION_STRUCTURE_SHADOW_ENABLED:
+            OMI_LLM_GATEWAY_FEATURE_MODE:
+              value: gateway
+              category: rollout
+            OMI_LLM_GATEWAY_ALLOW_DIRECT_MODEL_EXCEPTION:
               value: "true"
+              category: rollout
+            OMI_LLM_GATEWAY_CONVERSATION_STRUCTURE_SHADOW_ENABLED:
+              value: "false"
               category: rollout
             OMI_LLM_GATEWAY_CONVERSATION_STRUCTURE_SHADOW_SAMPLE_RATE:
               value: "1.0"
               category: rollout
             OMI_LLM_GATEWAY_CONVERSATION_ACTION_ITEMS_SHADOW_ENABLED:
-              value: "true"
+              value: "false"
               category: rollout
             OMI_LLM_GATEWAY_CONVERSATION_ACTION_ITEMS_SHADOW_SAMPLE_RATE:
               value: "1.0"
               category: rollout
             OMI_LLM_GATEWAY_DEV_SHADOW_ALL_ENABLED:
-              value: "true"
+              value: "false"
               category: rollout
             OMI_LLM_GATEWAY_DEV_SHADOW_ALL_SAMPLE_RATE:
               value: "1.0"
@@ -211,20 +229,26 @@ environments:
             OMI_LLM_GATEWAY_URL:
               value: http://172.16.63.232
               category: service_discovery
-            OMI_LLM_GATEWAY_CONVERSATION_STRUCTURE_SHADOW_ENABLED:
+            OMI_LLM_GATEWAY_FEATURE_MODE:
+              value: gateway
+              category: rollout
+            OMI_LLM_GATEWAY_ALLOW_DIRECT_MODEL_EXCEPTION:
               value: "true"
+              category: rollout
+            OMI_LLM_GATEWAY_CONVERSATION_STRUCTURE_SHADOW_ENABLED:
+              value: "false"
               category: rollout
             OMI_LLM_GATEWAY_CONVERSATION_STRUCTURE_SHADOW_SAMPLE_RATE:
               value: "1.0"
               category: rollout
             OMI_LLM_GATEWAY_CONVERSATION_ACTION_ITEMS_SHADOW_ENABLED:
-              value: "true"
+              value: "false"
               category: rollout
             OMI_LLM_GATEWAY_CONVERSATION_ACTION_ITEMS_SHADOW_SAMPLE_RATE:
               value: "1.0"
               category: rollout
             OMI_LLM_GATEWAY_DEV_SHADOW_ALL_ENABLED:
-              value: "true"
+              value: "false"
               category: rollout
             OMI_LLM_GATEWAY_DEV_SHADOW_ALL_SAMPLE_RATE:
               value: "1.0"

--- a/backend/pyrightconfig.json
+++ b/backend/pyrightconfig.json
@@ -167,6 +167,7 @@
         "utils/llm/conversation_processing.py",
         "utils/llm/external_integrations.py",
         "utils/llm/gateway_shadow.py",
+        "utils/llm/gateway_serving.py",
         "utils/llm/providers.py",
         "utils/retrieval/agentic.py",
         "utils/retrieval/tools/preference_tools.py",

--- a/backend/tests/unit/test_backend_runtime_env_validator.py
+++ b/backend/tests/unit/test_backend_runtime_env_validator.py
@@ -28,9 +28,11 @@ def write_yaml(path: Path, payload: dict) -> None:
 def with_memory_env(payload: str) -> str:
     memory_env = '''\
         {"name": "OMI_ENV_STAGE", "value": "dev"},
-        {"name": "OMI_LLM_GATEWAY_CONVERSATION_ACTION_ITEMS_SHADOW_ENABLED", "value": "true"},
+        {"name": "OMI_LLM_GATEWAY_FEATURE_MODE", "value": "gateway"},
+        {"name": "OMI_LLM_GATEWAY_ALLOW_DIRECT_MODEL_EXCEPTION", "value": "true"},
+        {"name": "OMI_LLM_GATEWAY_CONVERSATION_ACTION_ITEMS_SHADOW_ENABLED", "value": "false"},
         {"name": "OMI_LLM_GATEWAY_CONVERSATION_ACTION_ITEMS_SHADOW_SAMPLE_RATE", "value": "1.0"},
-        {"name": "OMI_LLM_GATEWAY_DEV_SHADOW_ALL_ENABLED", "value": "true"},
+        {"name": "OMI_LLM_GATEWAY_DEV_SHADOW_ALL_ENABLED", "value": "false"},
         {"name": "OMI_LLM_GATEWAY_DEV_SHADOW_ALL_SAMPLE_RATE", "value": "1.0"},
         {"name": "POSTHOG_HOST", "value": "https://app.posthog.com"},
         {"name": "GOOGLE_CLIENT_ID", "valueFrom": {"secretKeyRef": {"name": "GOOGLE_CLIENT_ID", "key": "latest"}}},
@@ -96,7 +98,7 @@ def test_cloud_run_state_reports_missing_gateway_url(tmp_path):
       "flags": {"--network": "omi-dev-vpc-1", "--subnet": "omi-us-central1-dev-vpc-1-subnet-1", "--vpc-egress": "private-ranges-only"},
       "env": [
         {"name": "GOOGLE_CLOUD_PROJECT", "value": "based-hardware"},
-        {"name": "OMI_LLM_GATEWAY_CONVERSATION_STRUCTURE_SHADOW_ENABLED", "value": "true"},
+        {"name": "OMI_LLM_GATEWAY_CONVERSATION_STRUCTURE_SHADOW_ENABLED", "value": "false"},
         {"name": "OMI_LLM_GATEWAY_CONVERSATION_STRUCTURE_SHADOW_SAMPLE_RATE", "value": "1.0"},
         {"name": "MEMORY_TYPESENSE_COLLECTION", "value": "canonical_memory_atoms"},
         {"name": "SERVICE_ACCOUNT_JSON", "valueFrom": {"secretKeyRef": {"name": "SERVICE_ACCOUNT_JSON"}}},
@@ -109,7 +111,7 @@ def test_cloud_run_state_reports_missing_gateway_url(tmp_path):
       "env": [
         {"name": "GOOGLE_CLOUD_PROJECT", "value": "based-hardware"},
         {"name": "OMI_LLM_GATEWAY_URL", "value": "http://172.16.63.232"},
-        {"name": "OMI_LLM_GATEWAY_CONVERSATION_STRUCTURE_SHADOW_ENABLED", "value": "true"},
+        {"name": "OMI_LLM_GATEWAY_CONVERSATION_STRUCTURE_SHADOW_ENABLED", "value": "false"},
         {"name": "OMI_LLM_GATEWAY_CONVERSATION_STRUCTURE_SHADOW_SAMPLE_RATE", "value": "1.0"},
         {"name": "MEMORY_TYPESENSE_COLLECTION", "value": "canonical_memory_atoms"},
         {"name": "SERVICE_ACCOUNT_JSON", "valueFrom": {"secretKeyRef": {"name": "SERVICE_ACCOUNT_JSON"}}},
@@ -122,7 +124,7 @@ def test_cloud_run_state_reports_missing_gateway_url(tmp_path):
       "env": [
         {"name": "GOOGLE_CLOUD_PROJECT", "value": "based-hardware"},
         {"name": "OMI_LLM_GATEWAY_URL", "value": "http://172.16.63.232"},
-        {"name": "OMI_LLM_GATEWAY_CONVERSATION_STRUCTURE_SHADOW_ENABLED", "value": "true"},
+        {"name": "OMI_LLM_GATEWAY_CONVERSATION_STRUCTURE_SHADOW_ENABLED", "value": "false"},
         {"name": "OMI_LLM_GATEWAY_CONVERSATION_STRUCTURE_SHADOW_SAMPLE_RATE", "value": "1.0"},
         {"name": "MEMORY_TYPESENSE_COLLECTION", "value": "canonical_memory_atoms"},
         {"name": "SERVICE_ACCOUNT_JSON", "valueFrom": {"secretKeyRef": {"name": "SERVICE_ACCOUNT_JSON"}}},
@@ -289,7 +291,9 @@ def test_cloud_run_workflow_validation_uses_custom_manifest_for_runtime_env_outp
                                     'GOOGLE_CLOUD_PROJECT': {'value': 'based-hardware'},
                                     'OMI_ENV_STAGE': {'value': 'dev'},
                                     'OMI_LLM_GATEWAY_URL': {'value': 'http://custom-manifest-gateway'},
-                                    'OMI_LLM_GATEWAY_DEV_SHADOW_ALL_ENABLED': {'value': 'true'},
+                                    'OMI_LLM_GATEWAY_FEATURE_MODE': {'value': 'gateway'},
+                                    'OMI_LLM_GATEWAY_ALLOW_DIRECT_MODEL_EXCEPTION': {'value': 'true'},
+                                    'OMI_LLM_GATEWAY_DEV_SHADOW_ALL_ENABLED': {'value': 'false'},
                                     'OMI_LLM_GATEWAY_DEV_SHADOW_ALL_SAMPLE_RATE': {'value': '1.0'},
                                     'CUSTOM_MANIFEST_ONLY_MARKER': {'value': 'present'},
                                 },
@@ -318,7 +322,7 @@ def test_cloud_run_workflow_validation_uses_custom_manifest_for_runtime_env_outp
       "env": [
         {"name": "GOOGLE_CLOUD_PROJECT", "value": "based-hardware"},
         {"name": "OMI_LLM_GATEWAY_URL", "value": "http://172.16.63.232"},
-        {"name": "OMI_LLM_GATEWAY_CONVERSATION_STRUCTURE_SHADOW_ENABLED", "value": "true"},
+        {"name": "OMI_LLM_GATEWAY_CONVERSATION_STRUCTURE_SHADOW_ENABLED", "value": "false"},
         {"name": "OMI_LLM_GATEWAY_CONVERSATION_STRUCTURE_SHADOW_SAMPLE_RATE", "value": "1.0"},
         {"name": "MEMORY_TYPESENSE_COLLECTION", "value": "canonical_memory_atoms"},
         {"name": "SERVICE_ACCOUNT_JSON", "valueFrom": {"secretKeyRef": {"name": "SERVICE_ACCOUNT_JSON"}}},
@@ -331,7 +335,7 @@ def test_cloud_run_workflow_validation_uses_custom_manifest_for_runtime_env_outp
       "env": [
         {"name": "GOOGLE_CLOUD_PROJECT", "value": "based-hardware"},
         {"name": "OMI_LLM_GATEWAY_URL", "value": "http://172.16.63.232"},
-        {"name": "OMI_LLM_GATEWAY_CONVERSATION_STRUCTURE_SHADOW_ENABLED", "value": "true"},
+        {"name": "OMI_LLM_GATEWAY_CONVERSATION_STRUCTURE_SHADOW_ENABLED", "value": "false"},
         {"name": "OMI_LLM_GATEWAY_CONVERSATION_STRUCTURE_SHADOW_SAMPLE_RATE", "value": "1.0"},
         {"name": "MEMORY_TYPESENSE_COLLECTION", "value": "canonical_memory_atoms"},
         {"name": "SERVICE_ACCOUNT_JSON", "valueFrom": {"secretKeyRef": {"name": "SERVICE_ACCOUNT_JSON"}}},
@@ -344,7 +348,7 @@ def test_cloud_run_workflow_validation_uses_custom_manifest_for_runtime_env_outp
       "env": [
         {"name": "GOOGLE_CLOUD_PROJECT", "value": "based-hardware"},
         {"name": "OMI_LLM_GATEWAY_URL", "value": "http://172.16.63.232"},
-        {"name": "OMI_LLM_GATEWAY_CONVERSATION_STRUCTURE_SHADOW_ENABLED", "value": "true"},
+        {"name": "OMI_LLM_GATEWAY_CONVERSATION_STRUCTURE_SHADOW_ENABLED", "value": "false"},
         {"name": "OMI_LLM_GATEWAY_CONVERSATION_STRUCTURE_SHADOW_SAMPLE_RATE", "value": "1.0"},
         {"name": "MEMORY_TYPESENSE_COLLECTION", "value": "canonical_memory_atoms"},
         {"name": "SERVICE_ACCOUNT_JSON", "valueFrom": {"secretKeyRef": {"name": "SERVICE_ACCOUNT_JSON"}}},
@@ -377,7 +381,7 @@ def test_cloud_run_state_rejects_old_secret_versions(tmp_path):
       "env": [
         {"name": "GOOGLE_CLOUD_PROJECT", "value": "based-hardware"},
         {"name": "OMI_LLM_GATEWAY_URL", "value": "http://172.16.63.232"},
-        {"name": "OMI_LLM_GATEWAY_CONVERSATION_STRUCTURE_SHADOW_ENABLED", "value": "true"},
+        {"name": "OMI_LLM_GATEWAY_CONVERSATION_STRUCTURE_SHADOW_ENABLED", "value": "false"},
         {"name": "OMI_LLM_GATEWAY_CONVERSATION_STRUCTURE_SHADOW_SAMPLE_RATE", "value": "1.0"},
         {"name": "MEMORY_TYPESENSE_COLLECTION", "value": "canonical_memory_atoms"},
         {"name": "SERVICE_ACCOUNT_JSON", "valueFrom": {"secretKeyRef": {"name": "SERVICE_ACCOUNT_JSON", "key": "1"}}},
@@ -390,7 +394,7 @@ def test_cloud_run_state_rejects_old_secret_versions(tmp_path):
       "env": [
         {"name": "GOOGLE_CLOUD_PROJECT", "value": "based-hardware"},
         {"name": "OMI_LLM_GATEWAY_URL", "value": "http://172.16.63.232"},
-        {"name": "OMI_LLM_GATEWAY_CONVERSATION_STRUCTURE_SHADOW_ENABLED", "value": "true"},
+        {"name": "OMI_LLM_GATEWAY_CONVERSATION_STRUCTURE_SHADOW_ENABLED", "value": "false"},
         {"name": "OMI_LLM_GATEWAY_CONVERSATION_STRUCTURE_SHADOW_SAMPLE_RATE", "value": "1.0"},
         {"name": "MEMORY_TYPESENSE_COLLECTION", "value": "canonical_memory_atoms"},
         {"name": "SERVICE_ACCOUNT_JSON", "valueFrom": {"secretKeyRef": {"name": "SERVICE_ACCOUNT_JSON", "key": "latest"}}},
@@ -403,7 +407,7 @@ def test_cloud_run_state_rejects_old_secret_versions(tmp_path):
       "env": [
         {"name": "GOOGLE_CLOUD_PROJECT", "value": "based-hardware"},
         {"name": "OMI_LLM_GATEWAY_URL", "value": "http://172.16.63.232"},
-        {"name": "OMI_LLM_GATEWAY_CONVERSATION_STRUCTURE_SHADOW_ENABLED", "value": "true"},
+        {"name": "OMI_LLM_GATEWAY_CONVERSATION_STRUCTURE_SHADOW_ENABLED", "value": "false"},
         {"name": "OMI_LLM_GATEWAY_CONVERSATION_STRUCTURE_SHADOW_SAMPLE_RATE", "value": "1.0"},
         {"name": "MEMORY_TYPESENSE_COLLECTION", "value": "canonical_memory_atoms"},
         {"name": "SERVICE_ACCOUNT_JSON", "valueFrom": {"secretKeyRef": {"name": "SERVICE_ACCOUNT_JSON", "key": "latest"}}},

--- a/backend/tests/unit/test_llm_gateway_client_config.py
+++ b/backend/tests/unit/test_llm_gateway_client_config.py
@@ -24,6 +24,7 @@ from utils.llm.gateway_client import (
     should_route_features_through_gateway,
 )
 from utils.llm.clients import get_llm_gateway_chat_structured
+import httpx
 
 
 class FakeChatModel(BaseChatModel):
@@ -167,6 +168,7 @@ def test_get_llm_dev_shadow_is_disabled_for_prod_like_runtime(monkeypatch):
 def test_get_llm_feature_gateway_mode_uses_generated_auto_lane(monkeypatch):
     captured = {}
     gateway = FakeChatModel(name='gateway', calls=[])
+    legacy = FakeChatModel(name='legacy', calls=[])
 
     def fake_gateway(lane_id, streaming=False, options=None):
         captured['lane_id'] = lane_id
@@ -174,16 +176,84 @@ def test_get_llm_feature_gateway_mode_uses_generated_auto_lane(monkeypatch):
         return gateway
 
     monkeypatch.setenv(LLM_GATEWAY_FEATURE_MODE_ENV_VAR, 'gateway')
+    monkeypatch.setenv('OMI_ENV_STAGE', 'dev')
+    monkeypatch.delenv(gateway_shadow.DEV_SHADOW_ALL_ENABLED_ENV, raising=False)
     monkeypatch.setattr(clients, 'get_or_create_omi_gateway_llm', fake_gateway)
+    monkeypatch.setattr(clients, 'get_default_client', lambda *args, **kwargs: legacy)
 
     result = clients.get_llm('conv_discard', streaming=True).invoke('hello')
 
     assert result.content == 'gateway response'
     assert captured == {'lane_id': feature_auto_lane_id('conv_discard'), 'streaming': True}
+    assert len(gateway.calls) == 1
+    assert legacy.calls == []
+
+
+def test_get_llm_feature_gateway_mode_falls_back_on_transport_failure(monkeypatch):
+    from utils.llm import gateway_serving
+
+    recorded = []
+    legacy = FakeChatModel(name='legacy', calls=[])
+
+    class FailingGateway(FakeChatModel):
+        def _generate(self, messages, stop=None, run_manager=None, **kwargs):
+            raise httpx.ConnectError('connection refused')
+
+    monkeypatch.setenv(LLM_GATEWAY_FEATURE_MODE_ENV_VAR, 'gateway')
+    monkeypatch.setenv('OMI_ENV_STAGE', 'dev')
+    monkeypatch.delenv(gateway_shadow.DEV_SHADOW_ALL_ENABLED_ENV, raising=False)
+    monkeypatch.setattr(
+        clients, 'get_or_create_omi_gateway_llm', lambda *args, **kwargs: FailingGateway(name='gateway', calls=[])
+    )
+    monkeypatch.setattr(clients, 'get_default_client', lambda *args, **kwargs: legacy)
+    monkeypatch.setattr(
+        gateway_serving,
+        'record_gateway_request_result',
+        lambda **kwargs: recorded.append(kwargs),
+    )
+
+    result = clients.get_llm('conv_discard').invoke('hello')
+
+    assert result.content == 'legacy response'
+    assert len(legacy.calls) == 1
+    assert recorded == [
+        {
+            'feature': 'conv_discard',
+            'outcome': 'fallback',
+            'reason': 'request_error',
+            'route': feature_auto_lane_id('conv_discard'),
+        }
+    ]
+
+
+def test_gateway_serving_does_not_fallback_on_non_transport_errors():
+    from utils.llm import gateway_serving
+
+    gateway = FakeChatModel(name='gateway', calls=[])
+    legacy = FakeChatModel(name='legacy', calls=[])
+    wrapped = gateway_serving.wrap_gateway_with_legacy_fallback(
+        feature='conv_discard',
+        gateway_model=gateway,
+        legacy_model=legacy,
+    )
+
+    def boom(*_args, **_kwargs):
+        raise ValueError('schema validation failed')
+
+    gateway._generate = boom  # type: ignore[method-assign]
+
+    try:
+        wrapped.invoke('hello')
+    except ValueError as exc:
+        assert 'schema validation failed' in str(exc)
+    else:
+        raise AssertionError('expected non-transport errors to propagate')
+    assert legacy.calls == []
 
 
 def test_get_llm_feature_gateway_mode_blocks_byok_direct_bypass(monkeypatch):
     monkeypatch.setenv(LLM_GATEWAY_FEATURE_MODE_ENV_VAR, 'gateway')
+    monkeypatch.setenv('OMI_ENV_STAGE', 'dev')
     monkeypatch.delenv(LLM_GATEWAY_ALLOW_DIRECT_EXCEPTION_ENV_VAR, raising=False)
     monkeypatch.delenv('K_SERVICE', raising=False)
     monkeypatch.setattr(clients, 'get_byok_key', lambda provider: 'sk-test-byok' if provider == 'openai' else None)
@@ -194,6 +264,22 @@ def test_get_llm_feature_gateway_mode_blocks_byok_direct_bypass(monkeypatch):
         assert 'get_llm.conv_discard.byok' in str(exc)
     else:
         raise AssertionError('expected gateway mode to block BYOK direct bypass')
+
+
+def test_get_llm_feature_gateway_mode_allows_byok_with_direct_exception(monkeypatch):
+    legacy = FakeChatModel(name='byok', calls=[])
+
+    monkeypatch.setenv(LLM_GATEWAY_FEATURE_MODE_ENV_VAR, 'gateway')
+    monkeypatch.setenv('OMI_ENV_STAGE', 'dev')
+    monkeypatch.setenv(LLM_GATEWAY_ALLOW_DIRECT_EXCEPTION_ENV_VAR, 'true')
+    monkeypatch.delenv(gateway_shadow.DEV_SHADOW_ALL_ENABLED_ENV, raising=False)
+    monkeypatch.setattr(clients, 'get_byok_key', lambda provider: 'sk-test-byok' if provider == 'openai' else None)
+    monkeypatch.setattr(clients, '_create_byok_client', lambda *args, **kwargs: legacy)
+
+    result = clients.get_llm('conv_discard').invoke('hello')
+
+    assert result.content == 'byok response'
+    assert len(legacy.calls) == 1
 
 
 def test_gateway_feature_mode_is_blocked_in_prod_without_explicit_allow(monkeypatch):

--- a/backend/tests/unit/test_prompt_cache_integration.py
+++ b/backend/tests/unit/test_prompt_cache_integration.py
@@ -132,6 +132,11 @@ gateway_mod.raise_if_gateway_feature_mode_blocks_direct_model_surface = MagicMoc
 gateway_shadow_mod = _stub_module("utils.llm.gateway_shadow")
 gateway_shadow_mod.maybe_wrap_dev_gateway_shadow = MagicMock(side_effect=lambda legacy_model, **_kwargs: legacy_model)
 
+gateway_serving_mod = _stub_module("utils.llm.gateway_serving")
+gateway_serving_mod.wrap_gateway_with_legacy_fallback = MagicMock(
+    side_effect=lambda *, gateway_model, **_kwargs: gateway_model
+)
+
 # --- langchain core stubs ---
 langchain_core_mod = _stub_module("langchain_core")
 if not hasattr(langchain_core_mod, "__path__"):

--- a/backend/utils/llm/clients.py
+++ b/backend/utils/llm/clients.py
@@ -105,6 +105,16 @@ except ImportError as exc:
         return legacy_model
 
 
+try:
+    from utils.llm.gateway_serving import wrap_gateway_with_legacy_fallback
+except ImportError as exc:
+    if exc.name != 'utils.llm.gateway_serving':
+        raise
+
+    def wrap_gateway_with_legacy_fallback(*, gateway_model, **_kwargs):
+        return gateway_model
+
+
 from utils.llm.usage_tracker import get_usage_callback
 
 logger = logging.getLogger(__name__)
@@ -457,7 +467,17 @@ def get_llm(feature: str, streaming: bool = False, cache_key: Optional[str] = No
             else get_default_client(model, provider, streaming, get_route_options(feature, model, provider))
         )
     elif gateway_feature_mode:
-        result = get_or_create_omi_gateway_llm(feature_auto_lane_id(feature), streaming)
+        gateway_model = get_or_create_omi_gateway_llm(feature_auto_lane_id(feature), streaming)
+        if provider in {'anthropic', 'perplexity'}:
+            # No OpenAI-compatible LangChain legacy client for these providers.
+            result = gateway_model
+        else:
+            legacy_model = get_default_client(model, provider, streaming, get_route_options(feature, model, provider))
+            result = wrap_gateway_with_legacy_fallback(
+                feature=feature,
+                gateway_model=gateway_model,
+                legacy_model=legacy_model,
+            )
     else:
         result = get_default_client(model, provider, streaming, get_route_options(feature, model, provider))
 

--- a/backend/utils/llm/clients.py
+++ b/backend/utils/llm/clients.py
@@ -107,10 +107,8 @@ except ImportError as exc:
 
 try:
     from utils.llm.gateway_serving import wrap_gateway_with_legacy_fallback
-except ImportError as exc:
-    if exc.name != 'utils.llm.gateway_serving':
-        raise
-
+except ImportError:
+    # Stubbed/isolated test environments may lack langchain_core submodules.
     def wrap_gateway_with_legacy_fallback(*, gateway_model, **_kwargs):
         return gateway_model
 

--- a/backend/utils/llm/gateway_serving.py
+++ b/backend/utils/llm/gateway_serving.py
@@ -10,24 +10,24 @@ except ImportError:
     try:
         from langchain_core.callbacks import BaseCallbackHandler as CallbackManagerForLLMRun
     except ImportError:
-        CallbackManagerForLLMRun = Any
+        CallbackManagerForLLMRun = Any  # type: ignore[misc,assignment]
 
-    AsyncCallbackManagerForLLMRun = CallbackManagerForLLMRun
+    AsyncCallbackManagerForLLMRun = CallbackManagerForLLMRun  # type: ignore[misc,assignment]
 from langchain_core.language_models import BaseChatModel
 
 try:
     from langchain_core.messages import BaseMessage
 except ImportError:
-    BaseMessage = None
+    BaseMessage = None  # type: ignore[assignment,misc]
 try:
     from langchain_core.outputs import ChatResult
 except ImportError:
-    ChatResult = Any
+    ChatResult = Any  # type: ignore[misc,assignment]
 try:
     from langchain_core.runnables import Runnable
 except ImportError:
 
-    class Runnable:
+    class Runnable:  # type: ignore[no-redef]
         pass
 
 
@@ -178,7 +178,7 @@ class GatewayWithLegacyFallbackChatModel(BaseChatModel):
         stop: list[str] | None = None,
         run_manager: CallbackManagerForLLMRun | None = None,
         **kwargs: Any,
-    ) -> Iterator:
+    ) -> Iterator[Any]:
         try:
             stream = self.gateway_model._stream(messages, stop=stop, run_manager=run_manager, **kwargs)
             yielded = False
@@ -216,7 +216,7 @@ class GatewayWithLegacyFallbackRunnable(Runnable):
         self._gateway = gateway
         self._legacy = legacy
 
-    def invoke(self, input: Any, config=None, **kwargs: Any) -> Any:
+    def invoke(self, input: Any, config: Any = None, **kwargs: Any) -> Any:
         try:
             result = self._gateway.invoke(input, config=config, **kwargs)
         except Exception as exc:
@@ -238,7 +238,7 @@ class GatewayWithLegacyFallbackRunnable(Runnable):
         )
         return result
 
-    async def ainvoke(self, input: Any, config=None, **kwargs: Any) -> Any:
+    async def ainvoke(self, input: Any, config: Any = None, **kwargs: Any) -> Any:
         try:
             result = await self._gateway.ainvoke(input, config=config, **kwargs)
         except Exception as exc:

--- a/backend/utils/llm/gateway_serving.py
+++ b/backend/utils/llm/gateway_serving.py
@@ -13,7 +13,13 @@ except ImportError:
         CallbackManagerForLLMRun = Any  # type: ignore[misc,assignment]
 
     AsyncCallbackManagerForLLMRun = CallbackManagerForLLMRun  # type: ignore[misc,assignment]
-from langchain_core.language_models import BaseChatModel
+try:
+    from langchain_core.language_models import BaseChatModel
+except ImportError:
+
+    class BaseChatModel:  # type: ignore[no-redef]
+        pass
+
 
 try:
     from langchain_core.messages import BaseMessage
@@ -31,8 +37,18 @@ except ImportError:
         pass
 
 
-import httpx
-from pydantic import ConfigDict
+try:
+    import httpx
+except ImportError:  # pragma: no cover - stubbed test environments
+    httpx = None  # type: ignore[assignment]
+
+try:
+    from pydantic import ConfigDict
+except ImportError:  # pragma: no cover - stubbed test environments
+
+    def ConfigDict(**_kwargs):  # type: ignore[misc]
+        return {}
+
 
 from utils.llm.gateway_client import feature_auto_lane_id
 from utils.llm.gateway_observability import record_gateway_request_result

--- a/backend/utils/llm/gateway_serving.py
+++ b/backend/utils/llm/gateway_serving.py
@@ -1,0 +1,261 @@
+"""Gateway-first serving with legacy provider fallback on hard transport failures."""
+
+from __future__ import annotations
+
+from typing import Any, Iterator
+
+try:
+    from langchain_core.callbacks.manager import AsyncCallbackManagerForLLMRun, CallbackManagerForLLMRun
+except ImportError:
+    try:
+        from langchain_core.callbacks import BaseCallbackHandler as CallbackManagerForLLMRun
+    except ImportError:
+        CallbackManagerForLLMRun = Any
+
+    AsyncCallbackManagerForLLMRun = CallbackManagerForLLMRun
+from langchain_core.language_models import BaseChatModel
+
+try:
+    from langchain_core.messages import BaseMessage
+except ImportError:
+    BaseMessage = None
+try:
+    from langchain_core.outputs import ChatResult
+except ImportError:
+    ChatResult = Any
+try:
+    from langchain_core.runnables import Runnable
+except ImportError:
+
+    class Runnable:
+        pass
+
+
+import httpx
+from pydantic import ConfigDict
+
+from utils.llm.gateway_client import feature_auto_lane_id
+from utils.llm.gateway_observability import record_gateway_request_result
+
+_TRANSPORT_STATUS_CODES = frozenset({502, 503, 504})
+
+
+def wrap_gateway_with_legacy_fallback(
+    *,
+    feature: str,
+    gateway_model: BaseChatModel,
+    legacy_model: BaseChatModel,
+) -> BaseChatModel:
+    return GatewayWithLegacyFallbackChatModel(
+        feature=feature,
+        gateway_model=gateway_model,
+        legacy_model=legacy_model,
+    )
+
+
+def is_gateway_transport_failure(exc: BaseException) -> bool:
+    """Return True for gateway unreachable / hard HTTP failures that should fall back."""
+    if isinstance(exc, (httpx.TimeoutException, httpx.NetworkError, httpx.RemoteProtocolError)):
+        return True
+    if isinstance(exc, httpx.HTTPStatusError):
+        return exc.response is not None and exc.response.status_code in _TRANSPORT_STATUS_CODES
+
+    status_code = getattr(exc, 'status_code', None)
+    if isinstance(status_code, int) and status_code in _TRANSPORT_STATUS_CODES:
+        return True
+
+    response = getattr(exc, 'response', None)
+    response_status = getattr(response, 'status_code', None)
+    if isinstance(response_status, int) and response_status in _TRANSPORT_STATUS_CODES:
+        return True
+
+    message = str(exc).casefold()
+    transport_markers = (
+        'timeout',
+        'timed out',
+        'connection refused',
+        'connection reset',
+        'connecterror',
+        'network error',
+        'bad gateway',
+        'service unavailable',
+        'gateway timeout',
+        '502',
+        '503',
+        '504',
+    )
+    return any(marker in message for marker in transport_markers)
+
+
+def _fallback_reason(exc: BaseException) -> str:
+    if (
+        isinstance(exc, httpx.TimeoutException)
+        or 'timeout' in str(exc).casefold()
+        or 'timed out' in str(exc).casefold()
+    ):
+        return 'timeout'
+    if isinstance(exc, (httpx.NetworkError, httpx.RemoteProtocolError)):
+        return 'request_error'
+    status_code = getattr(exc, 'status_code', None)
+    if not isinstance(status_code, int):
+        response = getattr(exc, 'response', None)
+        status_code = getattr(response, 'status_code', None)
+    if isinstance(status_code, int) and status_code in _TRANSPORT_STATUS_CODES:
+        return 'request_error'
+    return 'unexpected_error'
+
+
+class GatewayWithLegacyFallbackChatModel(BaseChatModel):
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    feature: str
+    gateway_model: BaseChatModel
+    legacy_model: BaseChatModel
+
+    @property
+    def _llm_type(self) -> str:
+        return f'{getattr(self.gateway_model, "_llm_type", "chat")}-omi-gateway-fallback'
+
+    def _generate(
+        self,
+        messages: list[BaseMessage],
+        stop: list[str] | None = None,
+        run_manager: CallbackManagerForLLMRun | None = None,
+        **kwargs: Any,
+    ) -> ChatResult:
+        try:
+            result = self.gateway_model._generate(messages, stop=stop, run_manager=run_manager, **kwargs)
+        except Exception as exc:
+            if not is_gateway_transport_failure(exc):
+                raise
+            record_gateway_request_result(
+                feature=self.feature,
+                outcome='fallback',
+                reason=_fallback_reason(exc),
+                route=feature_auto_lane_id(self.feature),
+            )
+            return self.legacy_model._generate(messages, stop=stop, run_manager=run_manager, **kwargs)
+
+        record_gateway_request_result(
+            feature=self.feature,
+            outcome='success',
+            reason='ok',
+            route=feature_auto_lane_id(self.feature),
+        )
+        return result
+
+    async def _agenerate(
+        self,
+        messages: list[BaseMessage],
+        stop: list[str] | None = None,
+        run_manager: AsyncCallbackManagerForLLMRun | None = None,
+        **kwargs: Any,
+    ) -> ChatResult:
+        try:
+            result = await self.gateway_model._agenerate(messages, stop=stop, run_manager=run_manager, **kwargs)
+        except Exception as exc:
+            if not is_gateway_transport_failure(exc):
+                raise
+            record_gateway_request_result(
+                feature=self.feature,
+                outcome='fallback',
+                reason=_fallback_reason(exc),
+                route=feature_auto_lane_id(self.feature),
+            )
+            return await self.legacy_model._agenerate(messages, stop=stop, run_manager=run_manager, **kwargs)
+
+        record_gateway_request_result(
+            feature=self.feature,
+            outcome='success',
+            reason='ok',
+            route=feature_auto_lane_id(self.feature),
+        )
+        return result
+
+    def _stream(
+        self,
+        messages: list[BaseMessage],
+        stop: list[str] | None = None,
+        run_manager: CallbackManagerForLLMRun | None = None,
+        **kwargs: Any,
+    ) -> Iterator:
+        try:
+            stream = self.gateway_model._stream(messages, stop=stop, run_manager=run_manager, **kwargs)
+            yielded = False
+            for chunk in stream:
+                yielded = True
+                yield chunk
+            if yielded:
+                record_gateway_request_result(
+                    feature=self.feature,
+                    outcome='success',
+                    reason='ok',
+                    route=feature_auto_lane_id(self.feature),
+                )
+            return
+        except Exception as exc:
+            if not is_gateway_transport_failure(exc):
+                raise
+            record_gateway_request_result(
+                feature=self.feature,
+                outcome='fallback',
+                reason=_fallback_reason(exc),
+                route=feature_auto_lane_id(self.feature),
+            )
+            yield from self.legacy_model._stream(messages, stop=stop, run_manager=run_manager, **kwargs)
+
+    def with_structured_output(self, schema: dict[str, Any] | type, *, include_raw: bool = False, **kwargs: Any):
+        gateway = self.gateway_model.with_structured_output(schema, include_raw=include_raw, **kwargs)
+        legacy = self.legacy_model.with_structured_output(schema, include_raw=include_raw, **kwargs)
+        return GatewayWithLegacyFallbackRunnable(feature=self.feature, gateway=gateway, legacy=legacy)
+
+
+class GatewayWithLegacyFallbackRunnable(Runnable):
+    def __init__(self, *, feature: str, gateway: Runnable, legacy: Runnable):
+        self._feature = feature
+        self._gateway = gateway
+        self._legacy = legacy
+
+    def invoke(self, input: Any, config=None, **kwargs: Any) -> Any:
+        try:
+            result = self._gateway.invoke(input, config=config, **kwargs)
+        except Exception as exc:
+            if not is_gateway_transport_failure(exc):
+                raise
+            record_gateway_request_result(
+                feature=self._feature,
+                outcome='fallback',
+                reason=_fallback_reason(exc),
+                route=feature_auto_lane_id(self._feature),
+            )
+            return self._legacy.invoke(input, config=config, **kwargs)
+
+        record_gateway_request_result(
+            feature=self._feature,
+            outcome='success',
+            reason='ok',
+            route=feature_auto_lane_id(self._feature),
+        )
+        return result
+
+    async def ainvoke(self, input: Any, config=None, **kwargs: Any) -> Any:
+        try:
+            result = await self._gateway.ainvoke(input, config=config, **kwargs)
+        except Exception as exc:
+            if not is_gateway_transport_failure(exc):
+                raise
+            record_gateway_request_result(
+                feature=self._feature,
+                outcome='fallback',
+                reason=_fallback_reason(exc),
+                route=feature_auto_lane_id(self._feature),
+            )
+            return await self._legacy.ainvoke(input, config=config, **kwargs)
+
+        record_gateway_request_result(
+            feature=self._feature,
+            outcome='success',
+            reason='ok',
+            route=feature_auto_lane_id(self._feature),
+        )
+        return result

--- a/backend/utils/llm/gateway_serving.py
+++ b/backend/utils/llm/gateway_serving.py
@@ -71,10 +71,11 @@ def wrap_gateway_with_legacy_fallback(
 
 def is_gateway_transport_failure(exc: BaseException) -> bool:
     """Return True for gateway unreachable / hard HTTP failures that should fall back."""
-    if isinstance(exc, (httpx.TimeoutException, httpx.NetworkError, httpx.RemoteProtocolError)):
-        return True
-    if isinstance(exc, httpx.HTTPStatusError):
-        return exc.response is not None and exc.response.status_code in _TRANSPORT_STATUS_CODES
+    if httpx is not None:
+        if isinstance(exc, (httpx.TimeoutException, httpx.NetworkError, httpx.RemoteProtocolError)):
+            return True
+        if isinstance(exc, httpx.HTTPStatusError):
+            return exc.response is not None and exc.response.status_code in _TRANSPORT_STATUS_CODES
 
     status_code = getattr(exc, 'status_code', None)
     if isinstance(status_code, int) and status_code in _TRANSPORT_STATUS_CODES:
@@ -104,13 +105,11 @@ def is_gateway_transport_failure(exc: BaseException) -> bool:
 
 
 def _fallback_reason(exc: BaseException) -> str:
-    if (
-        isinstance(exc, httpx.TimeoutException)
-        or 'timeout' in str(exc).casefold()
-        or 'timed out' in str(exc).casefold()
-    ):
+    if 'timeout' in str(exc).casefold() or 'timed out' in str(exc).casefold():
         return 'timeout'
-    if isinstance(exc, (httpx.NetworkError, httpx.RemoteProtocolError)):
+    if httpx is not None and isinstance(exc, httpx.TimeoutException):
+        return 'timeout'
+    if httpx is not None and isinstance(exc, (httpx.NetworkError, httpx.RemoteProtocolError)):
         return 'request_error'
     status_code = getattr(exc, 'status_code', None)
     if not isinstance(status_code, int):

--- a/backend/utils/retrieval/tools/perplexity_tools.py
+++ b/backend/utils/retrieval/tools/perplexity_tools.py
@@ -70,6 +70,13 @@ async def _perplexity_gateway_search(query: str) -> str:
             timeout=30.0,
         )
 
+        if response.status_code in {502, 503, 504}:
+            logger.warning(
+                "perplexity_web_search_tool - gateway transport failure %s; falling back to legacy",
+                response.status_code,
+            )
+            return await _perplexity_legacy_search(query)
+
         if response.status_code != 200:
             logger.error(
                 f"❌ perplexity_web_search_tool - Gateway API error: {response.status_code} - "
@@ -79,11 +86,11 @@ async def _perplexity_gateway_search(query: str) -> str:
 
         return _format_perplexity_response(response.json())
     except httpx.TimeoutException:
-        logger.warning("❌ perplexity_web_search_tool - Request timeout")
-        return "Error: Request to Perplexity API timed out. Please try again later."
+        logger.warning("❌ perplexity_web_search_tool - Gateway timeout; falling back to legacy")
+        return await _perplexity_legacy_search(query)
     except httpx.HTTPError as e:
-        logger.error(f"❌ perplexity_web_search_tool - Request error: {e}")
-        return f"Error: Failed to connect to Perplexity API. {str(e)}"
+        logger.error(f"❌ perplexity_web_search_tool - Gateway request error: {e}; falling back to legacy")
+        return await _perplexity_legacy_search(query)
     except (ValueError, IndexError, KeyError, TypeError):
         logger.error("⚠️ perplexity_web_search_tool - Unexpected response format")
         return "Error: Unexpected response format from Perplexity API"

--- a/docs/doc/developer/backend/llm_gateway.mdx
+++ b/docs/doc/developer/backend/llm_gateway.mdx
@@ -138,10 +138,12 @@ For v1, build the gateway as a separate FastAPI app in the backend tree, using t
 Promotion model:
 
 1. Start with no live product traffic while service startup, readiness, config validation, and service auth are verified.
-2. Route one structured feature through the gateway in shadow mode.
-3. Promote dev to gateway-serving only after shadow metrics and feature-specific gates pass.
-4. Run prod shadow before prod serving when the feature touches user content or user-visible behavior.
+2. Route non-embedding features through the gateway in shadow mode (`OMI_LLM_GATEWAY_DEV_SHADOW_ALL_*` and feature shadow flags).
+3. Promote **dev** to gateway-serving with `OMI_LLM_GATEWAY_FEATURE_MODE=gateway`. When serving is on, turn shadow flags **off** so callers do not double-hit the gateway. Keep hard direct surfaces (BYOK, Anthropic agentic chat, Assistants/file chat, omni realtime) on providers via `OMI_LLM_GATEWAY_ALLOW_DIRECT_MODEL_EXCEPTION=true`. Backend wraps gateway clients with legacy fallback on hard transport failures (timeout / 5xx / connection).
+4. Run prod shadow before prod serving when the feature touches user content or user-visible behavior. Prod serving also requires `OMI_LLM_GATEWAY_ALLOW_PROD_FEATURE_MODE=true` and an explicit gateway URL.
 5. Promote prod serving only after rollback has been tested and the route artifact has suitable eval evidence.
+
+**Dev serving rollback (config-only):** unset `OMI_LLM_GATEWAY_FEATURE_MODE` (or set it to anything other than `gateway`/`true`/`1`/`yes`) on Cloud Run `backend` / `backend-sync` / `backend-integration` and GKE `backend-listen`. Optionally restore shadow flags. Do not set feature mode on prod without the prod allow env.
 
 Do not start by embedding the gateway router into `backend/main.py`. That would make the gateway look separate in code while still sharing the main backend process, lifecycle, scaling, and blast radius.
 
@@ -181,8 +183,13 @@ Backend-listen env:
 |---|---|
 | `OMI_LLM_GATEWAY_URL` | Internal service URL above |
 | `OMI_LLM_GATEWAY_SERVICE_TOKEN` | `*-omi-backend-secrets` key `OMI_LLM_GATEWAY_SERVICE_TOKEN` |
+| `OMI_LLM_GATEWAY_FEATURE_MODE` | Dev serving flip: `gateway` routes non-BYOK `get_llm` traffic through per-feature `omi:auto:*` lanes |
+| `OMI_LLM_GATEWAY_ALLOW_DIRECT_MODEL_EXCEPTION` | When `true`, acknowledged direct surfaces (BYOK, agentic, file chat, omni realtime) stay on providers |
+| `OMI_LLM_GATEWAY_DEV_SHADOW_ALL_ENABLED` | Broad dev shadow kill switch; keep `false` while feature mode is serving |
 | `OMI_LLM_GATEWAY_CONVERSATION_STRUCTURE_SHADOW_ENABLED` | Feature-level shadow kill switch for conversation structure extraction |
 | `OMI_LLM_GATEWAY_CONVERSATION_STRUCTURE_SHADOW_SAMPLE_RATE` | Deterministic sample rate from `0.0` to `1.0` for conversation structure shadow traffic |
+| `OMI_LLM_GATEWAY_CONVERSATION_ACTION_ITEMS_SHADOW_ENABLED` | Feature-level shadow kill switch for conversation action-item extraction |
+| `OMI_LLM_GATEWAY_CONVERSATION_ACTION_ITEMS_SHADOW_SAMPLE_RATE` | Deterministic sample rate from `0.0` to `1.0` for conversation action-item shadow traffic |
 
 Gateway env:
 
@@ -192,6 +199,8 @@ Gateway env:
 | `OMI_LLM_GATEWAY_SERVICE_TOKEN` | same `*-omi-backend-secrets` key `OMI_LLM_GATEWAY_SERVICE_TOKEN` |
 | `LLM_GATEWAY_ALLOWED_CALLERS` | `backend` |
 | `OPENAI_API_KEY` | existing `*-omi-backend-secrets` key `OPENAI_API_KEY` |
+| `GEMINI_API_KEY` | existing `*-omi-backend-secrets` key `GEMINI_API_KEY` (required for gemini-backed feature lanes) |
+| `OPENROUTER_API_KEY` | existing `*-omi-backend-secrets` key `OPENROUTER_API_KEY` (required for openrouter-backed feature lanes) |
 | `METRICS_SECRET` | existing `*-omi-backend-secrets` key `METRICS_SECRET` |
 
 ExternalSecrets expect a GCP Secret Manager secret named `OMI_LLM_GATEWAY_SERVICE_TOKEN` in both projects:


### PR DESCRIPTION
## Summary
- Enable `OMI_LLM_GATEWAY_FEATURE_MODE=gateway` on all **dev** backends (Cloud Run + listen), with `ALLOW_DIRECT_MODEL_EXCEPTION=true` for BYOK/agentic/file/omni surfaces.
- Disable redundant shadow flags while serving to avoid double gateway calls.
- Add backend legacy transport fallback (`GatewayWithLegacyFallbackChatModel`) for non-BYOK `get_llm` paths; wire Gemini/OpenRouter keys into the dev gateway chart; fall back Perplexity web search on gateway transport failures.
- Update runtime_env validator fixtures + `llm_gateway.mdx` (feature-mode, shadow-off-when-serving, rollback).

## Test plan
- [x] `pytest tests/unit/test_llm_gateway_client_config.py tests/unit/test_backend_runtime_env_validator.py tests/unit/test_llm_gateway_coverage_guardrails.py`
- [x] `python3 scripts/validate-backend-runtime-env.py --env dev`
- [x] Inventory: all 38 model_config features have generated `omi:auto:*` lanes
- [ ] Auto Deploy Backend to Development succeeds; traffic on new revisions
- [ ] Live env shows FEATURE_MODE=gateway, ALLOW_DIRECT=true, shadows false
- [ ] Soak: `llm_gateway_backend_event` success/fallback buckets + gateway HTTP 200s

## Rollback
Unset `OMI_LLM_GATEWAY_FEATURE_MODE` on backend / backend-sync / backend-integration / backend-listen. Prod unchanged.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9290?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

