### PR TITLE
feat(memory): enable full canonical maintenance for first-user whitelist in dev

### DIFF
--- a/.github/workflows/gcp_notifications_job.yml
+++ b/.github/workflows/gcp_notifications_job.yml
@@ -65,8 +65,25 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Compute short SHA
+        id: image-tag
+        run: |
+          echo "short_sha=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+
       - name: Google Service Account
         run: echo "${{ secrets.GCP_SERVICE_ACCOUNT }}" | base64 -d > ./backend/google-credentials.json
+
+      - name: Install Python deps for deploy scripts
+        run: python3 -m pip install -q pyyaml
+
+      - name: Render backend runtime env
+        id: runtime-env
+        run: |
+          python3 backend/scripts/render_backend_runtime_env.py --env ${{ vars.ENV }} >> "$GITHUB_OUTPUT"
+
+      - name: Validate backend runtime env before deploy
+        run: |
+          python3 backend/scripts/validate-backend-runtime-env.py --env ${{ vars.ENV }} --check-workflows
 
       - name: Build and Push Docker image
         uses: docker/build-push-action@v6
@@ -74,7 +91,9 @@ jobs:
           context: .
           file: ./backend/modal/Dockerfile.notifications_job
           push: true
-          tags: gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}:latest
+          tags: |
+            gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}:latest
+            gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}:${{ steps.image-tag.outputs.short_sha }}
           cache-from: type=registry,ref=gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}:buildcache
           cache-to: type=registry,ref=gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}:buildcache,mode=max
 
@@ -84,7 +103,10 @@ jobs:
         with:
           job: ${{ env.SERVICE }}
           region: ${{ env.REGION }}
-          image: gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}
+          project_id: ${{ vars.GCP_PROJECT_ID }}
+          image: gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}:${{ steps.image-tag.outputs.short_sha }}
+          env_vars: ${{ steps.runtime-env.outputs.notifications_job_env_vars }}
+          secrets: ${{ steps.runtime-env.outputs.notifications_job_secrets }}
 
       # If required, use the Cloud Run url output in later steps
       - name: Show Output

--- a/backend/charts/backend-listen/dev_omi_backend_listen_values.yaml
+++ b/backend/charts/backend-listen/dev_omi_backend_listen_values.yaml
@@ -141,9 +141,9 @@ env:
   - name: MEMORY_V3_GET_ENABLED
     value: "true"
   - name: MEMORY_CANONICAL_PROMOTION_CRON_ENABLED
-    value: "false"
+    value: "true"
   - name: MEMORY_CANONICAL_PROMOTION_FAST_TRACK_ENABLED
-    value: "false"
+    value: "true"
   - name: GOOGLE_MAPS_API_KEY
     valueFrom:
       secretKeyRef:

--- a/backend/deploy/runtime_env.yaml
+++ b/backend/deploy/runtime_env.yaml
@@ -1,5 +1,4 @@
 schema_version: 1
-
 environments:
   dev:
     gcp_project: based-hardware-dev
@@ -19,25 +18,25 @@ environments:
             value: gateway
             category: rollout
           OMI_LLM_GATEWAY_ALLOW_DIRECT_MODEL_EXCEPTION:
-            value: "true"
+            value: 'true'
             category: rollout
           OMI_LLM_GATEWAY_CONVERSATION_STRUCTURE_SHADOW_ENABLED:
-            value: "false"
+            value: 'false'
             category: rollout
           OMI_LLM_GATEWAY_CONVERSATION_STRUCTURE_SHADOW_SAMPLE_RATE:
-            value: "1.0"
+            value: '1.0'
             category: rollout
           OMI_LLM_GATEWAY_CONVERSATION_ACTION_ITEMS_SHADOW_ENABLED:
-            value: "false"
+            value: 'false'
             category: rollout
           OMI_LLM_GATEWAY_CONVERSATION_ACTION_ITEMS_SHADOW_SAMPLE_RATE:
-            value: "1.0"
+            value: '1.0'
             category: rollout
           OMI_LLM_GATEWAY_DEV_SHADOW_ALL_ENABLED:
-            value: "false"
+            value: 'false'
             category: rollout
           OMI_LLM_GATEWAY_DEV_SHADOW_ALL_SAMPLE_RATE:
-            value: "1.0"
+            value: '1.0'
             category: rollout
           OMI_LLM_GATEWAY_SERVICE_TOKEN:
             secret:
@@ -50,13 +49,13 @@ environments:
             value: vi7SA9ckQCe4ccobWNxlbdcNdC23
             category: memory_rollout
           MEMORY_V3_GET_ENABLED:
-            value: "true"
+            value: 'true'
             category: memory_rollout
           MEMORY_CANONICAL_PROMOTION_CRON_ENABLED:
-            value: "false"
+            value: 'true'
             category: memory_rollout
           MEMORY_CANONICAL_PROMOTION_FAST_TRACK_ENABLED:
-            value: "false"
+            value: 'true'
             category: memory_rollout
           MEMORY_TYPESENSE_COLLECTION:
             value: canonical_memory_atoms
@@ -65,6 +64,7 @@ environments:
       workflow_files:
         - .github/workflows/gcp_backend_auto_dev.yml
         - .github/workflows/gcp_backend.yml
+        - .github/workflows/gcp_notifications_job.yml
       network:
         flags:
           --network: omi-dev-vpc-1
@@ -85,25 +85,25 @@ environments:
               value: gateway
               category: rollout
             OMI_LLM_GATEWAY_ALLOW_DIRECT_MODEL_EXCEPTION:
-              value: "true"
+              value: 'true'
               category: rollout
             OMI_LLM_GATEWAY_CONVERSATION_STRUCTURE_SHADOW_ENABLED:
-              value: "false"
+              value: 'false'
               category: rollout
             OMI_LLM_GATEWAY_CONVERSATION_STRUCTURE_SHADOW_SAMPLE_RATE:
-              value: "1.0"
+              value: '1.0'
               category: rollout
             OMI_LLM_GATEWAY_CONVERSATION_ACTION_ITEMS_SHADOW_ENABLED:
-              value: "false"
+              value: 'false'
               category: rollout
             OMI_LLM_GATEWAY_CONVERSATION_ACTION_ITEMS_SHADOW_SAMPLE_RATE:
-              value: "1.0"
+              value: '1.0'
               category: rollout
             OMI_LLM_GATEWAY_DEV_SHADOW_ALL_ENABLED:
-              value: "false"
+              value: 'false'
               category: rollout
             OMI_LLM_GATEWAY_DEV_SHADOW_ALL_SAMPLE_RATE:
-              value: "1.0"
+              value: '1.0'
               category: rollout
             POSTHOG_HOST:
               value: https://app.posthog.com
@@ -115,13 +115,13 @@ environments:
               value: vi7SA9ckQCe4ccobWNxlbdcNdC23
               category: memory_rollout
             MEMORY_V3_GET_ENABLED:
-              value: "true"
+              value: 'true'
               category: memory_rollout
             MEMORY_CANONICAL_PROMOTION_CRON_ENABLED:
-              value: "false"
+              value: 'true'
               category: memory_rollout
             MEMORY_CANONICAL_PROMOTION_FAST_TRACK_ENABLED:
-              value: "false"
+              value: 'true'
               category: memory_rollout
             MEMORY_TYPESENSE_COLLECTION:
               value: canonical_memory_atoms
@@ -159,25 +159,25 @@ environments:
               value: gateway
               category: rollout
             OMI_LLM_GATEWAY_ALLOW_DIRECT_MODEL_EXCEPTION:
-              value: "true"
+              value: 'true'
               category: rollout
             OMI_LLM_GATEWAY_CONVERSATION_STRUCTURE_SHADOW_ENABLED:
-              value: "false"
+              value: 'false'
               category: rollout
             OMI_LLM_GATEWAY_CONVERSATION_STRUCTURE_SHADOW_SAMPLE_RATE:
-              value: "1.0"
+              value: '1.0'
               category: rollout
             OMI_LLM_GATEWAY_CONVERSATION_ACTION_ITEMS_SHADOW_ENABLED:
-              value: "false"
+              value: 'false'
               category: rollout
             OMI_LLM_GATEWAY_CONVERSATION_ACTION_ITEMS_SHADOW_SAMPLE_RATE:
-              value: "1.0"
+              value: '1.0'
               category: rollout
             OMI_LLM_GATEWAY_DEV_SHADOW_ALL_ENABLED:
-              value: "false"
+              value: 'false'
               category: rollout
             OMI_LLM_GATEWAY_DEV_SHADOW_ALL_SAMPLE_RATE:
-              value: "1.0"
+              value: '1.0'
               category: rollout
             POSTHOG_HOST:
               value: https://app.posthog.com
@@ -189,13 +189,13 @@ environments:
               value: vi7SA9ckQCe4ccobWNxlbdcNdC23
               category: memory_rollout
             MEMORY_V3_GET_ENABLED:
-              value: "true"
+              value: 'true'
               category: memory_rollout
             MEMORY_CANONICAL_PROMOTION_CRON_ENABLED:
-              value: "false"
+              value: 'true'
               category: memory_rollout
             MEMORY_CANONICAL_PROMOTION_FAST_TRACK_ENABLED:
-              value: "false"
+              value: 'true'
               category: memory_rollout
             MEMORY_TYPESENSE_COLLECTION:
               value: canonical_memory_atoms
@@ -233,25 +233,25 @@ environments:
               value: gateway
               category: rollout
             OMI_LLM_GATEWAY_ALLOW_DIRECT_MODEL_EXCEPTION:
-              value: "true"
+              value: 'true'
               category: rollout
             OMI_LLM_GATEWAY_CONVERSATION_STRUCTURE_SHADOW_ENABLED:
-              value: "false"
+              value: 'false'
               category: rollout
             OMI_LLM_GATEWAY_CONVERSATION_STRUCTURE_SHADOW_SAMPLE_RATE:
-              value: "1.0"
+              value: '1.0'
               category: rollout
             OMI_LLM_GATEWAY_CONVERSATION_ACTION_ITEMS_SHADOW_ENABLED:
-              value: "false"
+              value: 'false'
               category: rollout
             OMI_LLM_GATEWAY_CONVERSATION_ACTION_ITEMS_SHADOW_SAMPLE_RATE:
-              value: "1.0"
+              value: '1.0'
               category: rollout
             OMI_LLM_GATEWAY_DEV_SHADOW_ALL_ENABLED:
-              value: "false"
+              value: 'false'
               category: rollout
             OMI_LLM_GATEWAY_DEV_SHADOW_ALL_SAMPLE_RATE:
-              value: "1.0"
+              value: '1.0'
               category: rollout
             POSTHOG_HOST:
               value: https://app.posthog.com
@@ -263,13 +263,13 @@ environments:
               value: vi7SA9ckQCe4ccobWNxlbdcNdC23
               category: memory_rollout
             MEMORY_V3_GET_ENABLED:
-              value: "true"
+              value: 'true'
               category: memory_rollout
             MEMORY_CANONICAL_PROMOTION_CRON_ENABLED:
-              value: "false"
+              value: 'true'
               category: memory_rollout
             MEMORY_CANONICAL_PROMOTION_FAST_TRACK_ENABLED:
-              value: "false"
+              value: 'true'
               category: memory_rollout
             MEMORY_TYPESENSE_COLLECTION:
               value: canonical_memory_atoms
@@ -293,7 +293,57 @@ environments:
             POSTHOG_PROJECT_API_KEY:
               secret: POSTHOG_PROJECT_API_KEY
               version: latest
-
+      jobs:
+        notifications-job:
+          env:
+            GOOGLE_CLOUD_PROJECT:
+              value: based-hardware
+            OMI_ENV_STAGE:
+              value: dev
+              category: runtime_identity
+            MEMORY_MODE:
+              value: read
+              category: memory_rollout
+            MEMORY_ENABLED_USERS:
+              value: vi7SA9ckQCe4ccobWNxlbdcNdC23
+              category: memory_rollout
+            MEMORY_V3_GET_ENABLED:
+              value: 'true'
+              category: memory_rollout
+            MEMORY_CANONICAL_PROMOTION_CRON_ENABLED:
+              value: 'true'
+              category: memory_rollout
+            MEMORY_CANONICAL_PROMOTION_FAST_TRACK_ENABLED:
+              value: 'true'
+              category: memory_rollout
+            MEMORY_CANONICAL_CONSOLIDATION_ENABLED:
+              value: 'true'
+              category: memory_rollout
+            MEMORY_TYPESENSE_COLLECTION:
+              value: canonical_memory_atoms
+              category: memory_rollout
+            PINECONE_INDEX_NAME:
+              value: memories-backend-dev
+              category: memory_rollout
+          secrets:
+            SERVICE_ACCOUNT_JSON:
+              secret: SERVICE_ACCOUNT_JSON
+              version: latest
+            ENCRYPTION_SECRET:
+              secret: ENCRYPTION_SECRET
+              version: latest
+            OPENAI_API_KEY:
+              secret: OPENAI_API_KEY
+              version: latest
+            PINECONE_API_KEY:
+              secret: PINECONE_API_KEY
+              version: latest
+            TYPESENSE_HOST:
+              secret: TYPESENSE_HOST
+              version: latest
+            TYPESENSE_API_KEY:
+              secret: TYPESENSE_API_KEY
+              version: latest
   prod:
     gcp_project: based-hardware
     runtime_gcp_project: based-hardware
@@ -313,16 +363,16 @@ environments:
             value: "off"
             category: memory_rollout
           MEMORY_ENABLED_USERS:
-            value: ""
+            value: ''
             category: memory_rollout
           MEMORY_V3_GET_ENABLED:
-            value: "false"
+            value: 'false'
             category: memory_rollout
           MEMORY_CANONICAL_PROMOTION_CRON_ENABLED:
-            value: "false"
+            value: 'false'
             category: memory_rollout
           MEMORY_CANONICAL_PROMOTION_FAST_TRACK_ENABLED:
-            value: "false"
+            value: 'false'
             category: memory_rollout
           MEMORY_TYPESENSE_COLLECTION:
             value: canonical_memory_atoms
@@ -330,6 +380,7 @@ environments:
     cloud_run:
       workflow_files:
         - .github/workflows/gcp_backend.yml
+        - .github/workflows/gcp_notifications_job.yml
       network:
         flags:
           --network:
@@ -350,16 +401,16 @@ environments:
               value: "off"
               category: memory_rollout
             MEMORY_ENABLED_USERS:
-              value: ""
+              value: ''
               category: memory_rollout
             MEMORY_V3_GET_ENABLED:
-              value: "false"
+              value: 'false'
               category: memory_rollout
             MEMORY_CANONICAL_PROMOTION_CRON_ENABLED:
-              value: "false"
+              value: 'false'
               category: memory_rollout
             MEMORY_CANONICAL_PROMOTION_FAST_TRACK_ENABLED:
-              value: "false"
+              value: 'false'
               category: memory_rollout
             MEMORY_TYPESENSE_COLLECTION:
               value: canonical_memory_atoms
@@ -386,16 +437,16 @@ environments:
               value: "off"
               category: memory_rollout
             MEMORY_ENABLED_USERS:
-              value: ""
+              value: ''
               category: memory_rollout
             MEMORY_V3_GET_ENABLED:
-              value: "false"
+              value: 'false'
               category: memory_rollout
             MEMORY_CANONICAL_PROMOTION_CRON_ENABLED:
-              value: "false"
+              value: 'false'
               category: memory_rollout
             MEMORY_CANONICAL_PROMOTION_FAST_TRACK_ENABLED:
-              value: "false"
+              value: 'false'
               category: memory_rollout
             MEMORY_TYPESENSE_COLLECTION:
               value: canonical_memory_atoms
@@ -422,16 +473,16 @@ environments:
               value: "off"
               category: memory_rollout
             MEMORY_ENABLED_USERS:
-              value: ""
+              value: ''
               category: memory_rollout
             MEMORY_V3_GET_ENABLED:
-              value: "false"
+              value: 'false'
               category: memory_rollout
             MEMORY_CANONICAL_PROMOTION_CRON_ENABLED:
-              value: "false"
+              value: 'false'
               category: memory_rollout
             MEMORY_CANONICAL_PROMOTION_FAST_TRACK_ENABLED:
-              value: "false"
+              value: 'false'
               category: memory_rollout
             MEMORY_TYPESENSE_COLLECTION:
               value: canonical_memory_atoms
@@ -445,4 +496,50 @@ environments:
               version: latest
             GOOGLE_CLIENT_SECRET:
               secret: GOOGLE_CLIENT_SECRET
+              version: latest
+      jobs:
+        notifications-job:
+          env:
+            OMI_ENV_STAGE:
+              value: prod
+              category: runtime_identity
+            MEMORY_MODE:
+              value: "off"
+              category: memory_rollout
+            MEMORY_ENABLED_USERS:
+              value: ''
+              category: memory_rollout
+            MEMORY_V3_GET_ENABLED:
+              value: 'false'
+              category: memory_rollout
+            MEMORY_CANONICAL_PROMOTION_CRON_ENABLED:
+              value: 'false'
+              category: memory_rollout
+            MEMORY_CANONICAL_PROMOTION_FAST_TRACK_ENABLED:
+              value: 'false'
+              category: memory_rollout
+            MEMORY_CANONICAL_CONSOLIDATION_ENABLED:
+              value: 'true'
+              category: memory_rollout
+            MEMORY_TYPESENSE_COLLECTION:
+              value: canonical_memory_atoms
+              category: memory_rollout
+          secrets:
+            SERVICE_ACCOUNT_JSON:
+              secret: SERVICE_ACCOUNT_JSON
+              version: latest
+            ENCRYPTION_SECRET:
+              secret: ENCRYPTION_SECRET
+              version: latest
+            OPENAI_API_KEY:
+              secret: OPENAI_API_KEY
+              version: latest
+            PINECONE_API_KEY:
+              secret: PINECONE_API_KEY
+              version: latest
+            TYPESENSE_HOST:
+              secret: TYPESENSE_HOST
+              version: latest
+            TYPESENSE_API_KEY:
+              secret: TYPESENSE_API_KEY
               version: latest

--- a/backend/scripts/render_backend_runtime_env.py
+++ b/backend/scripts/render_backend_runtime_env.py
@@ -30,7 +30,7 @@ def main() -> int:
 
     network = _as_config_dict(cloud_run.get('network')) or {}
     _emit_output('cloud_run_flags', _render_flags(_as_config_dict(network.get('flags')) or {}))
-    services = _as_config_dict(cloud_run['services']) or {}
+    services = _as_config_dict(cloud_run.get('services')) or {}
     for service, raw_service_config in services.items():
         service_config = _as_config_dict(raw_service_config)
         if service_config is None:
@@ -38,6 +38,14 @@ def main() -> int:
         output_prefix = _output_prefix(service)
         _emit_output(f'{output_prefix}_env_vars', _render_env_vars(service_config.get('env', {})))
         _emit_output(f'{output_prefix}_secrets', _render_secrets(service_config.get('secrets', {})))
+    jobs = _as_config_dict(cloud_run.get('jobs')) or {}
+    for job, raw_job_config in jobs.items():
+        job_config = _as_config_dict(raw_job_config)
+        if job_config is None:
+            raise ValueError(f'Cloud Run job {job} must be a mapping')
+        output_prefix = _output_prefix(job)
+        _emit_output(f'{output_prefix}_env_vars', _render_env_vars(job_config.get('env', {})))
+        _emit_output(f'{output_prefix}_secrets', _render_secrets(job_config.get('secrets', {})))
     return 0
 
 

--- a/backend/scripts/validate-backend-runtime-env.py
+++ b/backend/scripts/validate-backend-runtime-env.py
@@ -293,59 +293,25 @@ def _validate_cloud_run_workflows(
         return [ValidationError('cloud_run/workflows', 'workflow_files must be a list')]
 
     expected_services = _as_config_dict(cloud_run.get('services')) or {}
+    expected_jobs = _as_config_dict(cloud_run.get('jobs')) or {}
     workflow_services: dict[str, ConfigDict] = {}
+    workflow_jobs: dict[str, ConfigDict] = {}
     for workflow_file in workflow_files:
         if not isinstance(workflow_file, str):
             errors.append(ValidationError('cloud_run/workflows', 'workflow file paths must be strings'))
             continue
         workflow_path = ROOT / workflow_file
         workflow = _load_yaml(workflow_path)
-        workflow_services.update(_extract_workflow_cloud_run_services(workflow, env=env, manifest_path=manifest_path))
+        extracted = _extract_workflow_cloud_run_targets(workflow, env=env, manifest_path=manifest_path)
+        workflow_services.update(extracted['services'])
+        workflow_jobs.update(extracted['jobs'])
 
+    workflow_vars = _workflow_variable_map(env_config, expected_services)
     for service, service_config in expected_services.items():
         service_state = workflow_services.get(service)
         if service_state is None:
             errors.append(ValidationError(f'cloud_run_workflow/{service}', 'missing deploy-cloudrun env_vars block'))
             continue
-        runtime_gcp_project = str(env_config.get('runtime_gcp_project', env_config['gcp_project']))
-        workflow_vars = {
-            '${{ vars.GCP_PROJECT_ID }}': str(env_config['gcp_project']),
-            '${{vars.GCP_PROJECT_ID}}': str(env_config['gcp_project']),
-            '${{ vars.RUNTIME_GCP_PROJECT_ID }}': runtime_gcp_project,
-            '${{vars.RUNTIME_GCP_PROJECT_ID}}': runtime_gcp_project,
-            '${{ vars.OMI_LLM_GATEWAY_URL }}': _manifest_env_value(expected_services, 'OMI_LLM_GATEWAY_URL'),
-            '${{vars.OMI_LLM_GATEWAY_URL}}': _manifest_env_value(expected_services, 'OMI_LLM_GATEWAY_URL'),
-            '${{ vars.CLOUD_RUN_VPC_NETWORK }}': _expected_flag_value(
-                env_config.get('cloud_run', {}).get('network', {}).get('flags', {}).get('--network', '')
-            ),
-            '${{vars.CLOUD_RUN_VPC_NETWORK}}': _expected_flag_value(
-                env_config.get('cloud_run', {}).get('network', {}).get('flags', {}).get('--network', '')
-            ),
-            '${{ vars.CLOUD_RUN_VPC_SUBNET }}': _expected_flag_value(
-                env_config.get('cloud_run', {}).get('network', {}).get('flags', {}).get('--subnet', '')
-            ),
-            '${{vars.CLOUD_RUN_VPC_SUBNET}}': _expected_flag_value(
-                env_config.get('cloud_run', {}).get('network', {}).get('flags', {}).get('--subnet', '')
-            ),
-            '${{ vars.MEMORY_MODE }}': _manifest_env_value(expected_services, 'MEMORY_MODE'),
-            '${{vars.MEMORY_MODE}}': _manifest_env_value(expected_services, 'MEMORY_MODE'),
-            '${{ vars.MEMORY_ENABLED_USERS }}': _manifest_env_value(expected_services, 'MEMORY_ENABLED_USERS'),
-            '${{vars.MEMORY_ENABLED_USERS}}': _manifest_env_value(expected_services, 'MEMORY_ENABLED_USERS'),
-            '${{ vars.MEMORY_V3_GET_ENABLED }}': _manifest_env_value(expected_services, 'MEMORY_V3_GET_ENABLED'),
-            '${{vars.MEMORY_V3_GET_ENABLED}}': _manifest_env_value(expected_services, 'MEMORY_V3_GET_ENABLED'),
-            '${{ vars.MEMORY_CANONICAL_PROMOTION_CRON_ENABLED }}': _manifest_env_value(
-                expected_services, 'MEMORY_CANONICAL_PROMOTION_CRON_ENABLED'
-            ),
-            '${{vars.MEMORY_CANONICAL_PROMOTION_CRON_ENABLED}}': _manifest_env_value(
-                expected_services, 'MEMORY_CANONICAL_PROMOTION_CRON_ENABLED'
-            ),
-            '${{ vars.MEMORY_CANONICAL_PROMOTION_FAST_TRACK_ENABLED }}': _manifest_env_value(
-                expected_services, 'MEMORY_CANONICAL_PROMOTION_FAST_TRACK_ENABLED'
-            ),
-            '${{vars.MEMORY_CANONICAL_PROMOTION_FAST_TRACK_ENABLED}}': _manifest_env_value(
-                expected_services, 'MEMORY_CANONICAL_PROMOTION_FAST_TRACK_ENABLED'
-            ),
-        }
         actual_env = _literal_env_entries_by_name(service_state.get('env_vars', {}), variables=workflow_vars)
         errors.extend(
             _validate_env_entries(
@@ -371,7 +337,72 @@ def _validate_cloud_run_workflows(
                 strict_provisional=strict_provisional,
             )
         )
+
+    for job, job_config in expected_jobs.items():
+        job_state = workflow_jobs.get(job)
+        if job_state is None:
+            errors.append(ValidationError(f'cloud_run_workflow/{job}', 'missing deploy-cloudrun job env_vars block'))
+            continue
+        actual_env = _literal_env_entries_by_name(job_state.get('env_vars', {}), variables=workflow_vars)
+        errors.extend(
+            _validate_env_entries(
+                scope=f'cloud_run_workflow/{job}',
+                expected=job_config.get('env', {}),
+                actual=actual_env,
+                strict_provisional=strict_provisional,
+            )
+        )
+        actual_secrets = _workflow_secret_entries_by_name(job_state.get('secrets', {}))
+        errors.extend(
+            _validate_cloud_run_secret_entries(
+                scope=f'cloud_run_workflow/{job}',
+                expected=job_config.get('secrets', {}),
+                actual=actual_secrets,
+            )
+        )
     return errors
+
+
+def _workflow_variable_map(env_config: ConfigDict, expected_services: ConfigDict) -> StringMap:
+    runtime_gcp_project = str(env_config.get('runtime_gcp_project', env_config['gcp_project']))
+    return {
+        '${{ vars.GCP_PROJECT_ID }}': str(env_config['gcp_project']),
+        '${{vars.GCP_PROJECT_ID}}': str(env_config['gcp_project']),
+        '${{ vars.RUNTIME_GCP_PROJECT_ID }}': runtime_gcp_project,
+        '${{vars.RUNTIME_GCP_PROJECT_ID}}': runtime_gcp_project,
+        '${{ vars.OMI_LLM_GATEWAY_URL }}': _manifest_env_value(expected_services, 'OMI_LLM_GATEWAY_URL'),
+        '${{vars.OMI_LLM_GATEWAY_URL}}': _manifest_env_value(expected_services, 'OMI_LLM_GATEWAY_URL'),
+        '${{ vars.CLOUD_RUN_VPC_NETWORK }}': _expected_flag_value(
+            env_config.get('cloud_run', {}).get('network', {}).get('flags', {}).get('--network', '')
+        ),
+        '${{vars.CLOUD_RUN_VPC_NETWORK}}': _expected_flag_value(
+            env_config.get('cloud_run', {}).get('network', {}).get('flags', {}).get('--network', '')
+        ),
+        '${{ vars.CLOUD_RUN_VPC_SUBNET }}': _expected_flag_value(
+            env_config.get('cloud_run', {}).get('network', {}).get('flags', {}).get('--subnet', '')
+        ),
+        '${{vars.CLOUD_RUN_VPC_SUBNET}}': _expected_flag_value(
+            env_config.get('cloud_run', {}).get('network', {}).get('flags', {}).get('--subnet', '')
+        ),
+        '${{ vars.MEMORY_MODE }}': _manifest_env_value(expected_services, 'MEMORY_MODE'),
+        '${{vars.MEMORY_MODE}}': _manifest_env_value(expected_services, 'MEMORY_MODE'),
+        '${{ vars.MEMORY_ENABLED_USERS }}': _manifest_env_value(expected_services, 'MEMORY_ENABLED_USERS'),
+        '${{vars.MEMORY_ENABLED_USERS}}': _manifest_env_value(expected_services, 'MEMORY_ENABLED_USERS'),
+        '${{ vars.MEMORY_V3_GET_ENABLED }}': _manifest_env_value(expected_services, 'MEMORY_V3_GET_ENABLED'),
+        '${{vars.MEMORY_V3_GET_ENABLED}}': _manifest_env_value(expected_services, 'MEMORY_V3_GET_ENABLED'),
+        '${{ vars.MEMORY_CANONICAL_PROMOTION_CRON_ENABLED }}': _manifest_env_value(
+            expected_services, 'MEMORY_CANONICAL_PROMOTION_CRON_ENABLED'
+        ),
+        '${{vars.MEMORY_CANONICAL_PROMOTION_CRON_ENABLED}}': _manifest_env_value(
+            expected_services, 'MEMORY_CANONICAL_PROMOTION_CRON_ENABLED'
+        ),
+        '${{ vars.MEMORY_CANONICAL_PROMOTION_FAST_TRACK_ENABLED }}': _manifest_env_value(
+            expected_services, 'MEMORY_CANONICAL_PROMOTION_FAST_TRACK_ENABLED'
+        ),
+        '${{vars.MEMORY_CANONICAL_PROMOTION_FAST_TRACK_ENABLED}}': _manifest_env_value(
+            expected_services, 'MEMORY_CANONICAL_PROMOTION_FAST_TRACK_ENABLED'
+        ),
+    }
 
 
 def _network_flags(env_config: ConfigDict) -> ConfigDict:
@@ -497,19 +528,20 @@ def _workflow_secret_entries_by_name(raw_secrets: object) -> EnvEntryMap:
     return result
 
 
-def _extract_workflow_cloud_run_services(
+def _extract_workflow_cloud_run_targets(
     workflow: ConfigDict,
     *,
     env: str,
     manifest_path: Path,
-) -> dict[str, ConfigDict]:
+) -> dict[str, dict[str, ConfigDict]]:
     workflow_env = _as_config_dict(workflow.get('env')) or {}
     rendered_runtime_env = _rendered_runtime_env_outputs(workflow, env=env, manifest_path=manifest_path)
-    result: dict[str, ConfigDict] = {}
-    jobs = _as_config_dict(workflow.get('jobs'))
-    if jobs is None:
-        return result
-    for raw_job in jobs.values():
+    services: dict[str, ConfigDict] = {}
+    jobs: dict[str, ConfigDict] = {}
+    workflow_jobs = _as_config_dict(workflow.get('jobs'))
+    if workflow_jobs is None:
+        return {'services': services, 'jobs': jobs}
+    for raw_job in workflow_jobs.values():
         job = _as_config_dict(raw_job)
         if job is None:
             continue
@@ -521,9 +553,6 @@ def _extract_workflow_cloud_run_services(
                 continue
             step_dict = _as_config_dict(step) or {}
             step_with = _as_config_dict(step_dict.get('with')) or {}
-            service = _resolve_workflow_string(step_with.get('service'), workflow_env)
-            if service is None:
-                continue
             env_vars = _parse_workflow_env_vars(
                 _resolve_step_output_reference(step_with.get('env_vars'), rendered_runtime_env)
             )
@@ -531,9 +560,25 @@ def _extract_workflow_cloud_run_services(
                 _resolve_step_output_reference(step_with.get('secrets'), rendered_runtime_env)
             )
             flags = _parse_workflow_flags(_resolve_step_output_reference(step_with.get('flags'), rendered_runtime_env))
-            if env_vars or secrets or flags:
-                result[service] = {'env_vars': env_vars, 'secrets': secrets, 'flags': flags}
-    return result
+            if not (env_vars or secrets or flags):
+                continue
+            service = _resolve_workflow_string(step_with.get('service'), workflow_env)
+            job_name = _resolve_workflow_string(step_with.get('job'), workflow_env)
+            payload = {'env_vars': env_vars, 'secrets': secrets, 'flags': flags}
+            if service is not None:
+                services[service] = payload
+            if job_name is not None:
+                jobs[job_name] = payload
+    return {'services': services, 'jobs': jobs}
+
+
+def _extract_workflow_cloud_run_services(
+    workflow: ConfigDict,
+    *,
+    env: str,
+    manifest_path: Path,
+) -> dict[str, ConfigDict]:
+    return _extract_workflow_cloud_run_targets(workflow, env=env, manifest_path=manifest_path)['services']
 
 
 def _is_cloud_run_deploy_step(step: object) -> bool:
@@ -582,6 +627,14 @@ def _rendered_runtime_env_outputs(workflow: ConfigDict, *, env: str, manifest_pa
             output_prefix = service.replace('-', '_')
             outputs[f'{output_prefix}_env_vars'] = _render_cloud_run_env_vars(service_config.get('env', {}))
             outputs[f'{output_prefix}_secrets'] = _render_cloud_run_secrets(service_config.get('secrets', {}))
+        jobs = _as_config_dict(cloud_run.get('jobs')) or {}
+        for job, raw_job_config in jobs.items():
+            job_config = _as_config_dict(raw_job_config)
+            if job_config is None:
+                continue
+            output_prefix = job.replace('-', '_')
+            outputs[f'{output_prefix}_env_vars'] = _render_cloud_run_env_vars(job_config.get('env', {}))
+            outputs[f'{output_prefix}_secrets'] = _render_cloud_run_secrets(job_config.get('secrets', {}))
     return outputs
 
 

--- a/backend/scripts/validate-backend-runtime-env.py
+++ b/backend/scripts/validate-backend-runtime-env.py
@@ -572,15 +572,6 @@ def _extract_workflow_cloud_run_targets(
     return {'services': services, 'jobs': jobs}
 
 
-def _extract_workflow_cloud_run_services(
-    workflow: ConfigDict,
-    *,
-    env: str,
-    manifest_path: Path,
-) -> dict[str, ConfigDict]:
-    return _extract_workflow_cloud_run_targets(workflow, env=env, manifest_path=manifest_path)['services']
-
-
 def _is_cloud_run_deploy_step(step: object) -> bool:
     step_dict = _as_config_dict(step)
     if step_dict is None:

--- a/backend/tests/unit/test_backend_runtime_env_validator.py
+++ b/backend/tests/unit/test_backend_runtime_env_validator.py
@@ -41,8 +41,8 @@ def with_memory_env(payload: str) -> str:
         {"name": "MEMORY_MODE", "value": "read"},
         {"name": "MEMORY_ENABLED_USERS", "value": "vi7SA9ckQCe4ccobWNxlbdcNdC23"},
         {"name": "MEMORY_V3_GET_ENABLED", "value": "true"},
-        {"name": "MEMORY_CANONICAL_PROMOTION_CRON_ENABLED", "value": "false"},
-        {"name": "MEMORY_CANONICAL_PROMOTION_FAST_TRACK_ENABLED", "value": "false"},'''
+        {"name": "MEMORY_CANONICAL_PROMOTION_CRON_ENABLED", "value": "true"},
+        {"name": "MEMORY_CANONICAL_PROMOTION_FAST_TRACK_ENABLED", "value": "true"},'''
     return payload.replace(
         '        {"name": "GOOGLE_CLOUD_PROJECT", "value": "based-hardware"},',
         '        {"name": "GOOGLE_CLOUD_PROJECT", "value": "based-hardware"},\n' + memory_env,

--- a/backend/tests/unit/test_render_backend_runtime_env.py
+++ b/backend/tests/unit/test_render_backend_runtime_env.py
@@ -38,3 +38,39 @@ def test_network_flags_still_required(monkeypatch):
     monkeypatch.delenv('CLOUD_RUN_VPC_NETWORK', raising=False)
     with pytest.raises(ValueError, match='requires'):
         _MODULE['_render_flags']({'--network': {'env_var': 'CLOUD_RUN_VPC_NETWORK'}})
+
+
+def test_render_dev_emits_notifications_job_outputs(capsys, monkeypatch):
+    monkeypatch.setenv('CLOUD_RUN_VPC_NETWORK', 'omi-dev-vpc-1')
+    monkeypatch.setenv('CLOUD_RUN_VPC_SUBNET', 'omi-us-central1-dev-vpc-1-subnet-1')
+    monkeypatch.setenv('OMI_LLM_GATEWAY_URL', 'http://172.16.63.232')
+    monkeypatch.setattr('sys.argv', ['render_backend_runtime_env.py', '--env', 'dev'])
+    rc = _MODULE['main']()
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert 'notifications_job_env_vars<<' in out
+    assert 'MEMORY_CANONICAL_PROMOTION_CRON_ENABLED=true' in out
+    assert 'MEMORY_CANONICAL_PROMOTION_FAST_TRACK_ENABLED=true' in out
+    assert 'MEMORY_CANONICAL_CONSOLIDATION_ENABLED=true' in out
+    assert 'MEMORY_ENABLED_USERS=vi7SA9ckQCe4ccobWNxlbdcNdC23' in out
+    assert 'notifications_job_secrets<<' in out
+    assert 'OPENAI_API_KEY=OPENAI_API_KEY:latest' in out
+    assert 'PINECONE_API_KEY=PINECONE_API_KEY:latest' in out
+    assert 'TYPESENSE_API_KEY=TYPESENSE_API_KEY:latest' in out
+
+
+def test_render_prod_keeps_notifications_job_promotion_off(capsys, monkeypatch):
+    monkeypatch.setenv('CLOUD_RUN_VPC_NETWORK', 'omi-prod-vpc')
+    monkeypatch.setenv('CLOUD_RUN_VPC_SUBNET', 'omi-prod-subnet')
+    monkeypatch.setattr('sys.argv', ['render_backend_runtime_env.py', '--env', 'prod'])
+    rc = _MODULE['main']()
+    assert rc == 0
+    out = capsys.readouterr().out
+    # Isolate the notifications-job env block
+    start = out.index('notifications_job_env_vars<<')
+    end = out.index('notifications_job_secrets<<')
+    job_env = out[start:end]
+    assert 'MEMORY_MODE=off' in job_env
+    assert 'MEMORY_CANONICAL_PROMOTION_CRON_ENABLED=false' in job_env
+    assert 'MEMORY_CANONICAL_PROMOTION_FAST_TRACK_ENABLED=false' in job_env
+    assert 'MEMORY_ENABLED_USERS=vi7SA9ckQCe4ccobWNxlbdcNdC23' not in job_env

--- a/docs/rollout/memory-v3-proof-order.md
+++ b/docs/rollout/memory-v3-proof-order.md
@@ -127,10 +127,10 @@ For this lane, checked-in dev runtime config may persist:
 - `MEMORY_MODE=read`;
 - `MEMORY_ENABLED_USERS=vi7SA9ckQCe4ccobWNxlbdcNdC23`;
 - `MEMORY_V3_GET_ENABLED=true`;
-- `MEMORY_CANONICAL_PROMOTION_CRON_ENABLED=false`;
-- `MEMORY_CANONICAL_PROMOTION_FAST_TRACK_ENABLED=false`.
+- `MEMORY_CANONICAL_PROMOTION_CRON_ENABLED=true`;
+- `MEMORY_CANONICAL_PROMOTION_FAST_TRACK_ENABLED=true`.
 
-Production must remain off with an empty cohort and `MEMORY_V3_GET_ENABLED=false` until Gate 2 and Gate 3 requirements are satisfied.
+Hourly ST→LT maintenance (TTL → consolidation → promotion) is hosted by `notifications-job` and must receive the same whitelist-scoped flags via the runtime env contract. Production must remain off with an empty cohort and `MEMORY_V3_GET_ENABLED=false` until Gate 2 and Gate 3 requirements are satisfied.
 
 First-user projection tooling may write only the compatibility projection state/items for the same UID after an explicit apply confirmation. Its dry-run and apply output must redact content and include a rollback manifest with exact touched doc paths. The first-user E2E proof is read-only and must report non-`/v3/memories` read surfaces as `not_checked` when they cannot be generically exercised.
 

--- a/docs/runbooks/memory-v3-dev-cloud-proof.md
+++ b/docs/runbooks/memory-v3-dev-cloud-proof.md
@@ -28,17 +28,19 @@ Expected status without a fully specified dev target is `BLOCKED` with missing-e
 
 The first-user dev/beta read proof uses deploy plane `based-hardware-dev` and runtime data/auth Firestore project `based-hardware`.
 
-Checked-in dev runtime config intentionally preserves the first-user read baseline across future dev deploys:
+Checked-in dev runtime config intentionally preserves the first-user full canonical baseline across future dev deploys:
 
 ```text
 MEMORY_MODE=read
 MEMORY_ENABLED_USERS=vi7SA9ckQCe4ccobWNxlbdcNdC23
 MEMORY_V3_GET_ENABLED=true
-MEMORY_CANONICAL_PROMOTION_CRON_ENABLED=false
-MEMORY_CANONICAL_PROMOTION_FAST_TRACK_ENABLED=false
+MEMORY_CANONICAL_PROMOTION_CRON_ENABLED=true
+MEMORY_CANONICAL_PROMOTION_FAST_TRACK_ENABLED=true
 ```
 
-This is dev-only. Production remains `MEMORY_MODE=off`, `MEMORY_ENABLED_USERS=""`, `MEMORY_V3_GET_ENABLED=false`, and promotion cron/fast-track disabled.
+Promotion/consolidation maintenance runs from the hourly `notifications-job` Cloud Run job (not request-path backend). That job is part of `backend/deploy/runtime_env.yaml` and is deployed via `.github/workflows/gcp_notifications_job.yml` with the same whitelist-scoped `MEMORY_*` flags plus consolidation secrets (`OPENAI_API_KEY`, Pinecone, Typesense, `SERVICE_ACCOUNT_JSON`).
+
+This is dev-only. Production remains `MEMORY_MODE=off`, `MEMORY_ENABLED_USERS=""`, `MEMORY_V3_GET_ENABLED=false`, and promotion cron/fast-track disabled. Non-whitelisted users stay on legacy memory with Desktop lifecycle UI fail-closed.
 
 ## First-user projection operator
 


### PR DESCRIPTION
## Summary
- Turns on durable full canonical maintenance for the single whitelisted UID (`vi7SA9ckQCe4ccobWNxlbdcNdC23`) in **dev only**: `MEMORY_MODE=read` (already on) plus `MEMORY_CANONICAL_PROMOTION_CRON_ENABLED=true` and `MEMORY_CANONICAL_PROMOTION_FAST_TRACK_ENABLED=true`.
- Wires hourly `notifications-job` into `backend/deploy/runtime_env.yaml` (env + consolidation secrets) and updates `gcp_notifications_job.yml` to render/apply that contract on deploy — so merge+deploy is enough for real ST→LT (TTL → consolidation → promotion), not a half-enabled backend-only flag flip.
- Leaves **prod** off/empty and does not expand `CANONICAL_MEMORY_USERS`. Non-whitelisted users stay on legacy API with Desktop lifecycle UI fail-closed.

## Isolation
- Code cohort: only David’s UID in `CANONICAL_MEMORY_USERS`.
- Env allowlist: only that UID in `MEMORY_ENABLED_USERS` (dev); prod empty + `MEMORY_MODE=off`.
- Cron iterates code whitelist only; each UID still must pass `resolve_memory_system()`.
- Desktop lifecycle requires `X-Omi-Memory-Canonical-Lifecycle-Exposed: true` (exact).

## Preflight (read-only, 2026-07-08)
Firestore `based-hardware` enrollment already at read-stage for this UID:
- `global_read_gate` open (`memory_reads_enabled=true`, kill switch off)
- `write_convergence_gate` ready
- `users/.../memory_control/state` `mode=read`, stage gates passed, `grants.omi_chat.default_memory=true`
- `memory_state/head` and `v3_compatibility_projection/state` present

## Test plan
- [x] `python3 backend/scripts/validate-backend-runtime-env.py --env dev --check-workflows`
- [x] `python3 backend/scripts/validate-backend-runtime-env.py --env prod --check-workflows`
- [x] `pytest tests/unit/test_render_backend_runtime_env.py tests/unit/test_backend_runtime_env_validator.py` (19 passed)
- [ ] CI backend unit / lint on this PR

## Post-merge deploy checklist (only remaining work)
1. Merge with a **regular merge** (not squash).
2. Confirm auto-dev backend deploy picks up promotion flag parity on Cloud Run backend / GKE listen (or dispatch backend deploy if needed).
3. `workflow_dispatch` `.github/workflows/gcp_notifications_job.yml` with `environment=development`, `branch=main`.
4. Confirm live job env: cron+fast-track `true`, allowlist = David only, secrets present (`SERVICE_ACCOUNT_JSON`, `OPENAI_API_KEY`, Pinecone, Typesense).
5. Wait for next hourly tick (or execute the job once) → logs show maintenance for David only.
6. Desktop dogfood: Long-term layer filter shows promotions; Short-term continues; non-whitelist account unchanged.

## Kill switches
1. Set `MEMORY_CANONICAL_PROMOTION_CRON_ENABLED=false` on notifications-job (dev) and redeploy.
2. Remove UID from `MEMORY_ENABLED_USERS`.
3. Remove UID from `CANONICAL_MEMORY_USERS` + redeploy (hard kill).

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9295?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

