### PR TITLE
fix(ci): harden notifications-job deploy contract for prod render

### DIFF
--- a/.github/workflows/gcp_notifications_job.yml
+++ b/.github/workflows/gcp_notifications_job.yml
@@ -68,7 +68,9 @@ jobs:
       - name: Compute short SHA
         id: image-tag
         run: |
-          echo "short_sha=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+          # Use checked-out HEAD so the image tag matches the branch input, not
+          # the workflow-file ref (GITHUB_SHA), when they diverge.
+          echo "short_sha=$(git rev-parse --short=7 HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Google Service Account
         run: echo "${{ secrets.GCP_SERVICE_ACCOUNT }}" | base64 -d > ./backend/google-credentials.json
@@ -78,6 +80,11 @@ jobs:
 
       - name: Render backend runtime env
         id: runtime-env
+        env:
+          # Prod network flags are env_var-backed; without these the renderer
+          # exits before notifications_job_* outputs are emitted (same as gcp_backend.yml).
+          CLOUD_RUN_VPC_NETWORK: ${{ vars.CLOUD_RUN_VPC_NETWORK }}
+          CLOUD_RUN_VPC_SUBNET: ${{ vars.CLOUD_RUN_VPC_SUBNET }}
         run: |
           python3 backend/scripts/render_backend_runtime_env.py --env ${{ vars.ENV }} >> "$GITHUB_OUTPUT"
 

--- a/backend/tests/unit/test_render_backend_runtime_env.py
+++ b/backend/tests/unit/test_render_backend_runtime_env.py
@@ -74,3 +74,25 @@ def test_render_prod_keeps_notifications_job_promotion_off(capsys, monkeypatch):
     assert 'MEMORY_CANONICAL_PROMOTION_CRON_ENABLED=false' in job_env
     assert 'MEMORY_CANONICAL_PROMOTION_FAST_TRACK_ENABLED=false' in job_env
     assert 'MEMORY_ENABLED_USERS=vi7SA9ckQCe4ccobWNxlbdcNdC23' not in job_env
+
+
+def test_render_prod_requires_vpc_env_vars_before_job_outputs(monkeypatch):
+    """Prod network flags are env_var-backed; missing VPC vars abort render before job outputs.
+
+    gcp_notifications_job.yml must pass CLOUD_RUN_VPC_* like gcp_backend.yml, or prod
+    workflow_dispatch fails before notifications-job env/secrets are emitted.
+    """
+    monkeypatch.delenv('CLOUD_RUN_VPC_NETWORK', raising=False)
+    monkeypatch.delenv('CLOUD_RUN_VPC_SUBNET', raising=False)
+    monkeypatch.setattr('sys.argv', ['render_backend_runtime_env.py', '--env', 'prod'])
+    with pytest.raises(ValueError, match='CLOUD_RUN_VPC'):
+        _MODULE['main']()
+
+
+def test_notifications_job_workflow_passes_vpc_vars_and_checkout_sha():
+    workflow = Path(__file__).resolve().parents[3] / '.github/workflows/gcp_notifications_job.yml'
+    text = workflow.read_text(encoding='utf-8')
+    assert 'CLOUD_RUN_VPC_NETWORK: ${{ vars.CLOUD_RUN_VPC_NETWORK }}' in text
+    assert 'CLOUD_RUN_VPC_SUBNET: ${{ vars.CLOUD_RUN_VPC_SUBNET }}' in text
+    assert 'git rev-parse --short=7 HEAD' in text
+    assert 'short_sha=${GITHUB_SHA::7}' not in text


### PR DESCRIPTION
## Summary
Follow-up to #9295 review feedback before any prod `notifications-job` deploy:

- Pass `CLOUD_RUN_VPC_NETWORK` / `CLOUD_RUN_VPC_SUBNET` into the render step (same as `gcp_backend.yml`). Prod network flags are `env_var`-backed; without them `render_backend_runtime_env.py` exits before `notifications_job_*` outputs are emitted.
- Derive the immutable image short SHA from `git rev-parse --short=7 HEAD` after checkout so the tag matches the `branch` input, not a divergent `GITHUB_SHA` workflow-file ref.

## Why
- Codex P1 on #9295: prod workflow_dispatch could fail at render.
- Cubic P2 on #9295: SHA/tag mismatch when `branch` ≠ run ref.

## Test plan
- [x] `pytest backend/tests/unit/test_render_backend_runtime_env.py` (8 passed), including regression that prod render requires VPC vars and workflow source assertions
- [x] `validate-backend-runtime-env.py --env dev|prod --check-workflows`
- [ ] CI on this PR

## Notes
- No memory flag / cohort / prod enablement changes.
- Safe to land independently of whitelist dogfood; required before relying on prod notifications-job deploys.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9296?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

