### PR TITLE
ci: speed desktop Swift PRs and stop false full backend suites

### DIFF
--- a/.github/workflows/desktop-swift-ci.yml
+++ b/.github/workflows/desktop-swift-ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: main
 
+concurrency:
+  group: desktop-swift-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   desktop-swift:
     name: Desktop Swift Build & Tests
@@ -68,12 +72,61 @@ jobs:
             bash "$t"
           done
 
-      - name: Build desktop Swift app
-        if: steps.changed.outputs.should_run == 'true'
-        working-directory: desktop/macos
-        run: xcrun swift build -c release --package-path Desktop --triple arm64-apple-macosx
-
+      # Debug build+test only on the PR critical path. Release compile is a
+      # separate job (main push, or PRs that touch Package.swift) so we do not
+      # pay for a second configuration that tests never consume.
       - name: Test desktop Swift app
         if: steps.changed.outputs.should_run == 'true'
         working-directory: desktop/macos
+        env:
+          OMI_SWIFT_TEST_SUITE_WORKERS: "4"
         run: ./scripts/swift-test-suites.sh
+
+  desktop-swift-release-compile:
+    name: Desktop Swift Release Compile
+    runs-on: macos-15
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check changed files
+        id: changed
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            DIFF_BASE="origin/${{ github.base_ref }}"
+          else
+            DIFF_BASE="HEAD~1"
+          fi
+          FILES=$(git diff --name-only --diff-filter=ACMRD "$DIFF_BASE"...HEAD)
+          echo "$FILES"
+          DESKTOP_SWIFT=false
+          if echo "$FILES" | grep -qE '^desktop/macos/Desktop/|^desktop/macos/test\.sh$|^desktop/macos/scripts/|^desktop/macos/tests/|^desktop/macos/e2e/flows/|^\.github/workflows/desktop-swift-ci\.yml$'; then
+            DESKTOP_SWIFT=true
+          fi
+          PACKAGE_SWIFT=false
+          if echo "$FILES" | grep -qx 'desktop/macos/Desktop/Package.swift'; then
+            PACKAGE_SWIFT=true
+          fi
+          # Clean release compile: every main push that touches desktop Swift,
+          # plus PRs that change the package manifest (highest release-risk).
+          SHOULD_RUN=false
+          if [ "$DESKTOP_SWIFT" = "true" ]; then
+            if [ "${{ github.event_name }}" = "push" ] || [ "$PACKAGE_SWIFT" = "true" ]; then
+              SHOULD_RUN=true
+            fi
+          fi
+          echo "should_run=$SHOULD_RUN" >> "$GITHUB_OUTPUT"
+          echo "desktop_swift=$DESKTOP_SWIFT package_swift=$PACKAGE_SWIFT should_run=$SHOULD_RUN"
+
+      - name: Install Swift system dependencies
+        if: steps.changed.outputs.should_run == 'true'
+        run: brew install pkg-config webp
+
+      - name: Clean release compile
+        if: steps.changed.outputs.should_run == 'true'
+        working-directory: desktop/macos
+        run: |
+          rm -rf Desktop/.build
+          xcrun swift build -c release --package-path Desktop --triple arm64-apple-macosx

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -208,8 +208,9 @@ The desktop app is a **Swift Package Manager** project (no Xcode project, no `.x
 - Local Python backend (per-worktree port): `cd backend && ./scripts/dev-serve.sh`.
 - Compile-only check: `cd desktop/macos && xcrun swift build -c debug --package-path Desktop` (the `xcrun` prefix is required to match the SDK).
 - **DO NOT** use bare `swift build`, `xcodebuild`, or launch from `build/` directly. Always launch via `cd desktop/macos && ./run.sh` (installs to `/Applications/` and registers with LaunchServices, required for permission "Quit & Reopen").
-- Release builds are handled entirely by Codemagic CI (no local release script).
-- For PRs that change function signatures or cross-file types, run a clean release build before merge: `cd desktop/macos && rm -rf .build && xcrun swift build -c release --triple arm64-apple-macosx` — incremental debug builds miss stale-cache type errors that Codemagic's clean release build catches later.
+- **PR CI** (`desktop-swift-ci.yml`): debug build + parallel suite tests (`OMI_SWIFT_TEST_SUITE_WORKERS=4`). No release compile on ordinary PRs.
+- **Clean release compile** runs in CI on `main` pushes that touch desktop Swift, and on PRs that change `desktop/macos/Desktop/Package.swift`. Locally, for signature / cross-file type changes: `cd desktop/macos && rm -rf Desktop/.build && xcrun swift build -c release --package-path Desktop --triple arm64-apple-macosx` — incremental debug builds can miss stale-cache type errors.
+- **Ship builds** (universal, signed, notarized) are handled entirely by Codemagic CI (no local release script).
 
 #### Named Test Bundles
 

--- a/backend/scripts/select_backend_unit_tests.py
+++ b/backend/scripts/select_backend_unit_tests.py
@@ -50,16 +50,19 @@ FULL_RUN_PREFIXES = (
     'backend/testing/',
 )
 
+# Explicit cross-cutting paths only. Do not use `backend/*` or
+# `backend/utils/*.py` — those force the full suite for docs/AGENTS edits and
+# every flat utils module before AREA_TESTS can narrow.
 FULL_RUN_GLOBS = (
-    'backend/*',
+    'backend/main.py',
+    'backend/dependencies.py',
     'backend/scripts/update-python-lock.sh',
     'backend/scripts/sync-python-deps.sh',
     'backend/utils/executors.py',
     'backend/utils/log_sanitizer.py',
     'backend/utils/http_client.py',
-    'backend/utils/auth.py',
-    'backend/utils/secrets.py',
-    'backend/utils/*.py',
+    'backend/utils/async_tasks.py',
+    'backend/utils/encryption.py',
 )
 
 AREA_TESTS = (
@@ -222,6 +225,21 @@ def is_full_run_path(path: str) -> bool:
     return any(path_matches(path, pattern) for pattern in FULL_RUN_GLOBS)
 
 
+def is_selectable_backend_path(path: str) -> bool:
+    """Return True for backend paths that can select or force unit tests.
+
+    Docs, AGENTS, and chart/dashboard artifacts are ignored so editing them
+    does not trip the unmapped-path full-suite fallback.
+    """
+    if not path.startswith('backend/'):
+        return False
+    if path.endswith('.md'):
+        return False
+    if path.startswith('backend/docs/') or path.startswith('backend/charts/'):
+        return False
+    return True
+
+
 def path_matches(path: str, pattern: str) -> bool:
     return PurePosixPath(path).match(pattern)
 
@@ -254,13 +272,13 @@ def tests_for_changed_paths(changed_paths: list[str], all_tests: list[str]) -> t
         return all_tests, 'no changed paths were provided'
 
     selected: set[str] = set()
-    backend_paths = [path for path in changed_paths if path.startswith('backend/')]
+    backend_paths = [path for path in changed_paths if is_selectable_backend_path(path)]
     test_paths = [path for path in backend_paths if path.startswith('backend/tests/') and path.endswith('.py')]
 
     for path in changed_paths:
         selected.update(workflow_contract_tests_for_path(path, all_tests))
 
-    for path in changed_paths:
+    for path in backend_paths:
         if is_full_run_path(path):
             return all_tests, f'{path} requires the full backend unit suite'
 

--- a/backend/tests/unit/test_workflow_contracts.py
+++ b/backend/tests/unit/test_workflow_contracts.py
@@ -20,7 +20,8 @@ def test_workflow_contract_sources_select_adjacent_tests():
     full_run_cases = {
         "backend/database/memory_vector_repair_outbox_worker.py": "tests/unit/test_vector_repair_outbox_worker.py",
         "backend/database/projection_repair.py": "tests/unit/test_memory_ledger.py",
-        "backend/utils/webhooks.py": "tests/unit/test_async_webhooks.py",
+        "backend/main.py": "tests/unit/test_vector_repair_outbox_worker.py",
+        "backend/utils/executors.py": "tests/unit/test_vector_repair_outbox_worker.py",
     }
     selected_cases = {
         "backend/utils/memory/legacy_backfill.py": "tests/unit/test_ws_c_backfill.py",
@@ -41,6 +42,36 @@ def test_workflow_contract_sources_select_adjacent_tests():
         assert expected_test in selected, source_path
         assert reason == f"{source_path} requires the full backend unit suite"
         assert selected == all_tests
+
+
+def test_selector_docs_and_flat_utils_do_not_force_full_suite_via_globs():
+    """Docs/AGENTS skip selection; metrics is not a FULL_RUN_GLOBS hit."""
+    selector = _load_script("select_backend_unit_tests")
+    all_tests = selector.discover_all_tests()
+
+    for path in (
+        "backend/AGENTS.md",
+        "backend/docs/runbooks/resilience-dashboards.md",
+        "backend/charts/monitoring/alerts/resilience.json",
+    ):
+        selected, reason = selector.tests_for_changed_paths([path], all_tests)
+        assert selected == [], path
+        assert reason == "no backend files changed", (path, reason)
+
+    selected, reason = selector.tests_for_changed_paths(["backend/utils/metrics.py"], all_tests)
+    # Not a FULL_RUN_GLOBS path; unmapped flat utils still use the fallback.
+    assert reason == "backend changes did not match a narrow area", reason
+    assert selected == all_tests
+
+    selected, reason = selector.tests_for_changed_paths(["backend/routers/sync.py"], all_tests)
+    assert "tests/unit/test_sync_v2.py" in selected
+    assert selected != all_tests
+    assert reason == "selected backend unit tests from changed paths and workflow contracts"
+
+    for path in ("backend/main.py", "backend/dependencies.py", "backend/utils/executors.py"):
+        selected, reason = selector.tests_for_changed_paths([path], all_tests)
+        assert selected == all_tests, path
+        assert reason == f"{path} requires the full backend unit suite"
 
 
 def test_workflow_contracts_static_check_accepts_current_allowlist():


### PR DESCRIPTION
## Summary
- Desktop Swift PR CI drops the unused `swift build -c release` step (tests already rebuild debug), runs suites with `OMI_SWIFT_TEST_SUITE_WORKERS=4`, and cancels stale macOS runs.
- Clean release compile moves to a separate job on `main` desktop Swift pushes and on PRs that change `Package.swift`, so Codemagic is not the first release compile.
- Backend unit-test selector no longer treats `backend/*` / `backend/utils/*.py` (or docs/AGENTS/charts) as full-suite triggers; #9286-shaped diffs select ~71 files instead of ~485.

## Test plan
- [x] `python3 -m pytest backend/tests/unit/test_workflow_contracts.py -q` (6 passed)
- [x] Dry-run selector on PR #9286 changed files → 71 selected (was full suite)
- [x] Workflow YAML sanity: concurrency present; PR test job has no release build; release-compile job present
- [ ] Watch one desktop PR after merge for suite flake rate at WORKERS=4
- [ ] Confirm a non-Package.swift desktop PR skips **Desktop Swift Release Compile**
- [ ] Confirm a `main` desktop push (or Package.swift PR) runs the release-compile job


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9300?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

