### PR TITLE
test(desktop): de-flake RealtimeResponseGlowGate CI wait timeouts

### DIFF
--- a/desktop/macos/Desktop/Tests/RealtimeResponseGlowGateTests.swift
+++ b/desktop/macos/Desktop/Tests/RealtimeResponseGlowGateTests.swift
@@ -16,7 +16,7 @@ final class RealtimeResponseGlowGateTests: XCTestCase {
     DispatchQueue.main.asyncAfter(deadline: .now() + 0.08) {
       expectation.fulfill()
     }
-    wait(for: [expectation], timeout: 0.2)
+    wait(for: [expectation], timeout: 2.0)
 
     XCTAssertEqual(states, [true])
     XCTAssertTrue(gate.isActive)
@@ -35,7 +35,7 @@ final class RealtimeResponseGlowGateTests: XCTestCase {
     DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
       expectation.fulfill()
     }
-    wait(for: [expectation], timeout: 0.2)
+    wait(for: [expectation], timeout: 2.0)
 
     XCTAssertEqual(states, [true, false])
     XCTAssertFalse(gate.isActive)


### PR DESCRIPTION
## What
Both methods in `RealtimeResponseGlowGateTests` wait on a `DispatchQueue.main.asyncAfter` probe with `timeout: 0.2`. Under CI main-queue starvation the probe fulfillment slips past 0.2s and the test fails spuriously — the glow logic under test is fine; it's the test's own fulfillment timer that starves. Observed on PR #9292's CI run (unrelated tasks-drag change), cleared by a re-run.

## Change
Raise both `wait(for:timeout:)` to `2.0`. The `0.05`/`0.08` scheduling delays and every assertion are unchanged, so behavior asserted is identical — this only widens the tolerance for a starved CI queue.

## Test
`xcrun swift test --filter RealtimeResponseGlowGateTests` — both pass locally.

no-changelog-needed (test-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9303?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

