### PR TITLE
feat(desktop): non-prod feedback-payload dry-run bridge action (SET-02)

### DIFF
--- a/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
+++ b/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
@@ -1678,6 +1678,56 @@ final class DesktopAutomationActionRegistry {
         title: title, subtitle: subtitle, near: anchor)
       return CloudConnectorGuidanceOverlay.shared.automationState()
     }
+
+    // SET-02: assemble the exact payload FeedbackView.submitFeedback() would
+    // attach — the report title + the desktop_diagnostics.json attachment + the
+    // log-attachment metadata — WITHOUT calling SentrySDK, so a harness can grep
+    // the diagnostics JSON for secrets without firing a real Sentry event. The
+    // title and diagnostics JSON come from the same builders the real submit
+    // uses (feedbackReportTitle / writeDiagnosticsAttachment), so the dry-run
+    // can't diverge from what ships. The raw log is attached unredacted to Sentry
+    // by design (trusted sink, explicit user report); we surface only its
+    // metadata here — never its contents — so the bridge response can't leak it.
+    register(
+      name: "dump_feedback_payload_dryrun",
+      summary: "Assemble the feedback report payload (title + desktop_diagnostics.json + log-attachment metadata) without submitting to Sentry; returns the diagnostics JSON for secret-scanning. Non-prod only.",
+      params: ["message"]
+    ) { params in
+      guard AppBuild.isNonProduction else {
+        return ["error": "dump_feedback_payload_dryrun is disabled on production bundles"]
+      }
+      let message = (params["message"] ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+      var detail: [String: String] = [
+        "sentry_message": feedbackReportTitle(for: message),
+        "diagnostics_filename": feedbackDiagnosticsAttachmentFilename,
+        "sentry_capture_invoked": "false",
+        "would_submit_to_sentry": "false",
+      ]
+
+      if let url = DesktopDiagnosticsManager.shared.writeDiagnosticsAttachment() {
+        defer { try? FileManager.default.removeItem(at: url) }
+        if let data = try? Data(contentsOf: url), let json = String(data: data, encoding: .utf8) {
+          detail["diagnostics_json"] = json
+          detail["diagnostics_byte_count"] = "\(data.count)"
+        } else {
+          detail["diagnostics_error"] = "unreadable_attachment"
+        }
+      } else {
+        detail["diagnostics_error"] = "attachment_write_failed"
+      }
+
+      let logPath = omiLogFilePath()
+      let logExists = FileManager.default.fileExists(atPath: logPath)
+      detail["log_attachment_filename"] = (logPath as NSString).lastPathComponent
+      detail["log_attachment_exists"] = logExists ? "true" : "false"
+      if logExists,
+        let attributes = try? FileManager.default.attributesOfItem(atPath: logPath),
+        let size = attributes[.size] as? NSNumber
+      {
+        detail["log_attachment_bytes"] = "\(size.intValue)"
+      }
+      return detail
+    }
   }
 }
 

--- a/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
+++ b/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
@@ -1724,7 +1724,8 @@ final class DesktopAutomationActionRegistry {
         let attributes = try? FileManager.default.attributesOfItem(atPath: logPath),
         let size = attributes[.size] as? NSNumber
       {
-        detail["log_attachment_bytes"] = "\(size.intValue)"
+        // int64Value, not intValue (Int32): the log can exceed 2 GB in a long dev session.
+        detail["log_attachment_bytes"] = "\(size.int64Value)"
       }
       return detail
     }

--- a/desktop/macos/Desktop/Sources/FeedbackView.swift
+++ b/desktop/macos/Desktop/Sources/FeedbackView.swift
@@ -3,6 +3,17 @@ import SwiftUI
 import UniformTypeIdentifiers
 import OmiTheme
 
+/// The Sentry event title used when a user submits feedback. Shared by the real
+/// `submitFeedback()` path and the non-prod dry-run bridge action so the dry-run
+/// can never drift from the title that actually ships to Sentry (SET-02).
+func feedbackReportTitle(for message: String) -> String {
+  message.isEmpty ? "User Report (logs only)" : "User Report: \(message)"
+}
+
+/// Filename of the JSON diagnostics attachment on the feedback Sentry event.
+/// Shared so the dry-run reports the same attachment name the real submit uses.
+let feedbackDiagnosticsAttachmentFilename = "desktop_diagnostics.json"
+
 /// Window controller for the feedback dialog
 @MainActor
 class FeedbackWindow {
@@ -145,7 +156,7 @@ struct FeedbackView: View {
     AnalyticsManager.shared.feedbackSubmitted(feedbackLength: message.count)
 
     // Submit to Sentry with log file attachment (dev + prod — user explicitly chose to report)
-    let sentryMessage = message.isEmpty ? "User Report (logs only)" : "User Report: \(message)"
+    let sentryMessage = feedbackReportTitle(for: message)
 
     // Capture event with log file attached via scope
     let eventId = SentrySDK.capture(message: sentryMessage) { scope in
@@ -158,7 +169,7 @@ struct FeedbackView: View {
       if let diagnosticsURL = DesktopDiagnosticsManager.shared.writeDiagnosticsAttachment() {
         let attachment = Attachment(
           path: diagnosticsURL.path,
-          filename: "desktop_diagnostics.json",
+          filename: feedbackDiagnosticsAttachmentFilename,
           contentType: "application/json")
         scope.addAttachment(attachment)
       }

--- a/desktop/macos/Desktop/Tests/FeedbackPayloadDryRunTests.swift
+++ b/desktop/macos/Desktop/Tests/FeedbackPayloadDryRunTests.swift
@@ -1,0 +1,152 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// SET-02: the feedback dry-run bridge action must let a harness inspect the exact
+/// payload `FeedbackView.submitFeedback()` would attach — WITHOUT firing a Sentry
+/// event — so the diagnostics JSON can be scanned for secrets.
+///
+/// The redaction guarantee of the diagnostics attachment itself is already covered
+/// by `DesktopDiagnosticsManagerTests`. These tests instead pin the *dry-run seam*:
+/// that the action is registered, derives its payload from the same builders the
+/// real submit uses (so it can't silently drift), and never touches Sentry.
+final class FeedbackPayloadDryRunTests: XCTestCase {
+  private let actionName = "dump_feedback_payload_dryrun"
+
+  // MARK: - Source-invariant guards on the dry-run seam
+
+  func testActionIsRegisteredAndNonProdGated() throws {
+    // Assert presence against the FULL source and FAIL (not XCTSkip) if the action
+    // is ever deleted/renamed. `dryRunActionBlock()` skips when the marker is
+    // absent, so without this hard check every source-invariant test in this file
+    // would skip silently and CI would stay green on a removed action.
+    let source = try bridgeSource()
+    XCTAssertTrue(
+      source.contains("name: \"\(actionName)\""),
+      "dry-run action must be registered under its stable name")
+
+    let block = try dryRunActionBlock()
+    XCTAssertTrue(
+      block.contains("guard AppBuild.isNonProduction"),
+      "dry-run action must refuse to run on production bundles")
+  }
+
+  func testDryRunUsesTheSameBuildersAsTheRealSubmit() throws {
+    let block = try dryRunActionBlock()
+    // Same diagnostics builder the real Sentry attachment uses — the dry-run
+    // returns the identical JSON, not a parallel reimplementation.
+    XCTAssertTrue(
+      block.contains("DesktopDiagnosticsManager.shared.writeDiagnosticsAttachment()"),
+      "dry-run must build the diagnostics JSON via the shared attachment builder")
+    // Same title builder the real submit uses.
+    XCTAssertTrue(
+      block.contains("feedbackReportTitle(for:"),
+      "dry-run must derive the report title from the shared builder")
+    XCTAssertTrue(
+      block.contains("feedbackDiagnosticsAttachmentFilename"),
+      "dry-run must report the shared diagnostics attachment filename")
+  }
+
+  func testDryRunNeverSubmitsToSentry() throws {
+    let block = try dryRunActionBlock()
+    XCTAssertFalse(
+      block.contains("SentrySDK"),
+      "dry-run must not invoke Sentry — that is the whole point of a dry run")
+    XCTAssertTrue(
+      block.contains("\"sentry_capture_invoked\": \"false\""),
+      "dry-run must declare that no Sentry capture happened")
+  }
+
+  func testDryRunReturnsLogMetadataOnlyNotContents() throws {
+    let block = try dryRunActionBlock()
+    // The raw log is attached unredacted to Sentry by design; the dry-run must
+    // surface only metadata so the bridge response can't leak the log itself.
+    XCTAssertTrue(block.contains("log_attachment_filename"))
+    XCTAssertTrue(block.contains("log_attachment_exists"))
+    // Targeted guard: reject the common ways of reading the log *contents* keyed
+    // on logPath. Not exhaustive (a FileHandle read would slip past), but paired
+    // with the positive metadata-only assertions above it pins the intent.
+    XCTAssertFalse(
+      block.contains("contentsOfFile: logPath"),
+      "dry-run must not read the raw log contents into its response")
+    XCTAssertFalse(
+      block.contains("contentsOf: URL(fileURLWithPath: logPath)"),
+      "dry-run must not read the raw log contents into its response")
+  }
+
+  func testRealSubmitSharesTheSameBuilders() throws {
+    // If submitFeedback stopped using the shared builders, the dry-run would no
+    // longer reflect what actually ships — pin that both sides share them.
+    let source = try feedbackViewSource()
+    XCTAssertTrue(
+      source.contains("let sentryMessage = feedbackReportTitle(for: message)"),
+      "submitFeedback must build its Sentry title via the shared builder")
+    XCTAssertTrue(
+      source.contains("filename: feedbackDiagnosticsAttachmentFilename"),
+      "submitFeedback must attach the diagnostics JSON under the shared filename")
+  }
+
+  // MARK: - Behavioral: shared title builder + payload shape
+
+  func testReportTitleBuilderMatchesTheShippedStrings() {
+    XCTAssertEqual(feedbackReportTitle(for: ""), "User Report (logs only)")
+    XCTAssertEqual(feedbackReportTitle(for: "mic dropped"), "User Report: mic dropped")
+  }
+
+  func testDiagnosticsPayloadIsParseableAndCarriesPrivacyMarker() throws {
+    DesktopDiagnosticsManager.shared.resetForTests()
+    defer { DesktopDiagnosticsManager.shared.resetForTests() }
+    DesktopDiagnosticsManager.shared.recordPTTSilentTurn(
+      source: "hub",
+      mode: "hold",
+      audioSeconds: 2.0,
+      voicedSeconds: nil,
+      peak: 0,
+      rms: 0,
+      deviceDescription: "built-in microphone",
+      micPermissionGranted: true,
+      hubActive: true)
+
+    let url = try XCTUnwrap(DesktopDiagnosticsManager.shared.writeDiagnosticsAttachment())
+    defer { try? FileManager.default.removeItem(at: url) }
+    let data = try Data(contentsOf: url)
+    let root = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+
+    // This is exactly the JSON the dry-run returns as `diagnostics_json`: valid,
+    // shaped, and flagged as operational-only so a secret-scan has a clean target.
+    XCTAssertEqual(root["privacy"] as? String, "safe_operational_fields_only")
+    XCTAssertNotNil(root["snapshots"] as? [[String: Any]])
+  }
+
+  // MARK: - Helpers
+
+  private func dryRunActionBlock() throws -> String {
+    let source = try bridgeSource()
+    guard let start = source.range(of: "name: \"\(actionName)\"") else {
+      throw XCTSkip("\(actionName) registration not found")
+    }
+    let tail = source[start.lowerBound...]
+    // The dry-run action is the last register() in registerBuiltins(); slice to
+    // the next register() if one is ever added after it, else take the rest.
+    if let next = tail.dropFirst().range(of: "\n    register(") {
+      return String(tail[..<next.lowerBound])
+    }
+    return String(tail)
+  }
+
+  private func bridgeSource() throws -> String {
+    try sourceFile(named: "DesktopAutomationBridge.swift")
+  }
+
+  private func feedbackViewSource() throws -> String {
+    try sourceFile(named: "FeedbackView.swift")
+  }
+
+  private func sourceFile(named name: String) throws -> String {
+    let url = URL(fileURLWithPath: #filePath)
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+      .appendingPathComponent("Sources/\(name)")
+    return try String(contentsOf: url, encoding: .utf8)
+  }
+}

--- a/desktop/macos/e2e/SKILL.md
+++ b/desktop/macos/e2e/SKILL.md
@@ -185,6 +185,30 @@ without the drag guard. `had_non_status_filters=false` means no filter is active
 requery path is inert (the suppression assertion is then vacuous — apply a date/tag
 filter first). Non-production bundles only.
 
+### 2g. Inspect the feedback payload without submitting (SET-02)
+`FeedbackView.submitFeedback()` always fires a real Sentry event and attaches the app log
+plus a `desktop_diagnostics.json`, so there's no way to verify the payload is token-free
+without spamming Sentry. `dump_feedback_payload_dryrun` (non-prod only) assembles the
+**same** payload — the report title (`feedbackReportTitle`) and the diagnostics JSON
+(`writeDiagnosticsAttachment`, the exact builder the real submit uses) — and returns it
+**without** calling `SentrySDK`, so the diagnostics JSON can be secret-scanned.
+
+```bash
+cd desktop/macos
+./scripts/omi-ctl action dump_feedback_payload_dryrun message="mic dropped mid-call" \
+  | python3 -c 'import json,sys,re; d=json.load(sys.stdin)["result"]["detail"]; \
+assert d["sentry_capture_invoked"]=="false" and d["would_submit_to_sentry"]=="false"; \
+dj=d["diagnostics_json"]; \
+pats=[r"eyJ[A-Za-z0-9_-]{10,}",r"AIza[0-9A-Za-z_-]{10,}",r"omi_(auto|mcp)_[0-9a-f]{8,}",r"AMf-[A-Za-z0-9_-]{10,}",r"[Bb]earer\s+\S{12,}",r"(?i)_API_KEY\s*[=:]\s*\S+"]; \
+hits=[p for p in pats if re.search(p,dj)]; \
+print("title:", d["sentry_message"]); print("secret hits:", hits or "NONE")'
+```
+Assert `sentry_capture_invoked=false`, `would_submit_to_sentry=false`, and **no secret
+hits** in `diagnostics_json`. Empty `message` yields the "User Report (logs only)" title.
+The action returns the log only as **metadata** (`log_attachment_filename`/`_exists`/`_bytes`) —
+never its contents — so the bridge response itself can't leak the raw log. To confirm no
+Sentry event fired, check the app log has no "User report submitted to Sentry" line.
+
 ### The full loop
 ```bash
 cd desktop/macos

--- a/desktop/macos/e2e/flows/feedback-payload-dryrun.yaml
+++ b/desktop/macos/e2e/flows/feedback-payload-dryrun.yaml
@@ -1,0 +1,38 @@
+version: 2
+name: feedback-payload-dryrun
+tier: 2
+description: SET-02 — assemble the feedback report payload via the shared builders without submitting to Sentry
+app: non-prod
+covers:
+  - desktop/macos/Desktop/Sources/FeedbackView.swift
+  - desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
+preconditions:
+  - automation_bridge_ready
+
+steps:
+  - id: S1
+    name: Dry-run builds the report title from a message, no Sentry capture
+    bridge.action:
+      name: dump_feedback_payload_dryrun
+      params:
+        message: "[[MARKER:set02-dryrun]]"
+    expect:
+      result.detail.sentry_message: "User Report: [[MARKER:set02-dryrun]]"
+      result.detail.sentry_capture_invoked: "false"
+      result.detail.would_submit_to_sentry: "false"
+      result.detail.diagnostics_filename: "desktop_diagnostics.json"
+
+  - id: S2
+    name: Empty message yields the logs-only title
+    bridge.action:
+      name: dump_feedback_payload_dryrun
+    expect:
+      result.detail.sentry_message: "User Report (logs only)"
+      result.detail.sentry_capture_invoked: "false"
+
+  - id: S3
+    name: No real feedback submission was logged
+    log.expect:
+      absent:
+        - "User report submitted to Sentry"
+        - "DesktopAutomationBridge: failed"


### PR DESCRIPTION
## What
`FeedbackView.submitFeedback()` always fires a real Sentry event and attaches the app log plus a `desktop_diagnostics.json`, so there was no way to verify the feedback payload is token-free without spamming Sentry. This adds a non-prod automation-bridge action `dump_feedback_payload_dryrun` that assembles the **same** payload the real submit would attach — the report title (`feedbackReportTitle`) and the diagnostics JSON (`DesktopDiagnosticsManager.writeDiagnosticsAttachment()`, the exact builder the real submit uses) — and returns it **without** calling `SentrySDK`, so the diagnostics JSON can be secret-scanned.

The raw log is surfaced as **metadata only** (`log_attachment_filename`/`_exists`/`_bytes`) — never its contents — so the bridge response itself can't leak the unredacted log. The temp diagnostics file is cleaned up via `defer` on every path. Non-prod only (gated on `AppBuild.isNonProduction`, matching the other bridge actions).

## Why a shared builder
Commit 1 extracts the report title and attachment filename into two file-scope helpers so the dry-run and the real `submitFeedback()` provably share them and the dry-run can't silently drift from what ships. Commit 2 adds the action + tests + e2e flow + SKILL recipe.

## Test
- `FeedbackPayloadDryRunTests` (7): pins the seam — action registered + non-prod gated (fails, not skips, if the action is deleted), derives its payload from the same builders as the real submit, never references `SentrySDK`, returns log metadata only, plus a hermetic check that the diagnostics JSON is parseable and flagged `safe_operational_fields_only`. The attachment's redaction guarantee itself is already covered by `DesktopDiagnosticsManagerTests`.
- Runtime-verified on a named bundle: message → `User Report: <msg>`, empty → `User Report (logs only)`, `sentry_capture_invoked=false`, diagnostics_json secret-scan 0 hits, no "User report submitted to Sentry" log line.
- e2e flow `feedback-payload-dryrun` runs green (3/3 steps, 0 log errors, cursor-free).

no-changelog-needed: non-prod dev/QA tooling, not user-visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9305?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

