### PR TITLE
feat(app): add Meta glasses capture integration

### DIFF
--- a/app/integration_test/meta_glasses_mock_test.dart
+++ b/app/integration_test/meta_glasses_mock_test.dart
@@ -1,0 +1,94 @@
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:meta_wearables_dat_flutter/meta_wearables_dat_flutter.dart';
+import 'package:meta_wearables_dat_flutter/src/meta_wearables_dat_method_channel.dart';
+import 'package:meta_wearables_dat_flutter/src/meta_wearables_dat_platform_interface.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:omi/providers/meta_wearables_provider.dart';
+
+import '../test/support/meta_wearables_mock_harness.dart';
+
+const bool _mockEnabled = kDebugMode && bool.fromEnvironment('OMI_META_MOCK');
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const pathProviderChannel = MethodChannel('plugins.flutter.io/path_provider');
+  late Directory tempDir;
+  late MetaWearablesMockHarness harness;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    tempDir = await Directory.systemTemp.createTemp('meta-glasses-mock-it-');
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(
+      pathProviderChannel,
+      (call) async {
+        if (call.method == 'getApplicationDocumentsDirectory') return tempDir.path;
+        return null;
+      },
+    );
+    harness = MetaWearablesMockHarness();
+    MetaWearablesDatPlatform.instance = harness.platform;
+  });
+
+  tearDown(() async {
+    MetaWearablesDatPlatform.instance = MethodChannelMetaWearablesDat();
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(
+      pathProviderChannel,
+      null,
+    );
+    if (tempDir.existsSync()) tempDir.deleteSync(recursive: true);
+  });
+
+  test('Mock Device Kit Ray-Ban photo capture flows through queue into conversation', () async {
+    if (!_mockEnabled) {
+      markTestSkipped('Run with --dart-define=OMI_META_MOCK=true in debug test mode.');
+      return;
+    }
+
+    final fixture = await harness.writeFixtureImage(tempDir);
+
+    await MetaWearablesDat.enableMockDevice(initiallyRegistered: true, initialPermissionsGranted: false);
+    final uuid = await MetaWearablesDat.pairMockRayBanMeta();
+    await MetaWearablesDat.mockPowerOn(uuid);
+    await MetaWearablesDat.mockUnfold(uuid);
+    await MetaWearablesDat.mockDon(uuid);
+    await MetaWearablesDat.setMockPermission(MockPermission.camera, MockPermissionStatus.granted);
+    await MetaWearablesDat.setMockCapturedImage(uuid, fixture.path);
+
+    final provider = MetaWearablesProvider();
+    final capture = RecordingCaptureController();
+    await provider.init();
+    await provider.refresh();
+
+    expect(provider.hasDevices, isTrue);
+    expect(provider.hasLinkedDevices, isTrue);
+    expect(provider.cameraPermissionGranted, isTrue);
+
+    final started = await provider.startCapture(capture);
+    expect(started, isTrue);
+
+    expect(harness.platform.frameCaptureCount, 1);
+    expect(capture.ingestedImages, hasLength(1));
+    expect(capture.addToUiValues.single, isTrue);
+    expect(provider.pendingPhotoCount, 0);
+    final queueDir = Directory('${tempDir.path}/meta_glasses_photo_queue');
+    expect(queueDir.existsSync() ? queueDir.listSync().whereType<File>() : const <File>[], isEmpty);
+
+    await provider.stopCapture();
+    provider.dispose();
+    capture.dispose();
+  });
+
+  test('mock devices cover linked and unlinked sanitizer states', () async {
+    final result = MetaWearablesProvider.sanitizeDevices(harness.devicesInTwoLinkStates());
+
+    expect(result, hasLength(2));
+    expect(result.where((device) => device.linkState == DeviceLinkState.connected), hasLength(1));
+    expect(result.where((device) => device.linkState == DeviceLinkState.disconnected), hasLength(1));
+  });
+}

--- a/app/ios/Runner/AppDelegate.swift
+++ b/app/ios/Runner/AppDelegate.swift
@@ -8,6 +8,17 @@ import MediaPlayer
 import Speech
 import WidgetKit
 
+private enum MetaGlassesAudioRouteError: LocalizedError {
+  case glassesMicrophoneUnavailable
+
+  var errorDescription: String? {
+    switch self {
+    case .glassesMicrophoneUnavailable:
+      return "Meta glasses Bluetooth microphone is unavailable"
+    }
+  }
+}
+
 extension FlutterError: Error {}
 
 // MARK: - Quick Actions Icon Patcher
@@ -83,6 +94,7 @@ final class QuickActionsIconPatcher: NSObject {
 @main
 @objc class AppDelegate: FlutterAppDelegate {
   private var methodChannel: FlutterMethodChannel?
+  private var audioSessionChannel: FlutterMethodChannel?
   private var appleRemindersChannel: FlutterMethodChannel?
   private var appleHealthChannel: FlutterMethodChannel?
   private let appleRemindersService = AppleRemindersService()
@@ -206,18 +218,21 @@ final class QuickActionsIconPatcher: NSObject {
         }
     }
 
-    // Audio session configuration for Bluetooth microphone support
-    let audioSessionChannel = FlutterMethodChannel(name: "com.omi.ios/audioSession", binaryMessenger: controller!.binaryMessenger)
-    audioSessionChannel.setMethodCallHandler { (call, result) in
-        if call.method == "configureForBluetooth" {
-            let audioSession = AVAudioSession.sharedInstance()
+    // Meta capture keeps other apps' media mixed while requiring the glasses'
+    // Bluetooth HFP microphone. It never falls back to the iPhone microphone.
+    audioSessionChannel = FlutterMethodChannel(name: "com.omi.ios/audioSession", binaryMessenger: controller!.binaryMessenger)
+    audioSessionChannel?.setMethodCallHandler { (call, result) in
+        if call.method == "configureForMetaGlassesCapture" {
             do {
-                try audioSession.setCategory(
-                    .playAndRecord,
-                    mode: .default,
-                    options: [.allowBluetooth, .allowBluetoothA2DP, .defaultToSpeaker]
-                )
-                try audioSession.setActive(true)
+                result(try self.configureMetaGlassesCaptureSession())
+            } catch {
+                result(FlutterError(code: "AUDIO_SESSION_ERROR", message: error.localizedDescription, details: nil))
+            }
+        } else if call.method == "getCurrentAudioRoute" {
+            result(self.currentAudioRoute())
+        } else if call.method == "configureForBluetooth" {
+            do {
+                try self.configureBluetoothCaptureSession()
                 result(true)
             } catch {
                 result(FlutterError(code: "AUDIO_SESSION_ERROR", message: error.localizedDescription, details: nil))
@@ -237,6 +252,12 @@ final class QuickActionsIconPatcher: NSObject {
             result(FlutterMethodNotImplemented)
         }
     }
+    NotificationCenter.default.addObserver(
+      self,
+      selector: #selector(handleMetaAudioRouteChange(_:)),
+      name: AVAudioSession.routeChangeNotification,
+      object: nil
+    )
 
     // Create WiFi Network plugin for device AP connection
     _ = WifiNetworkPlugin(messenger: controller!.binaryMessenger)
@@ -286,6 +307,47 @@ final class QuickActionsIconPatcher: NSObject {
     }
 
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+  }
+
+  private func configureMetaGlassesCaptureSession() throws -> [String: Any] {
+    let audioSession = AVAudioSession.sharedInstance()
+    try audioSession.setCategory(
+      .playAndRecord,
+      mode: .videoRecording,
+      options: [.mixWithOthers, .allowBluetoothHFP]
+    )
+    guard let glassesMic = audioSession.availableInputs?.first(where: { $0.portType == .bluetoothHFP }) else {
+      throw MetaGlassesAudioRouteError.glassesMicrophoneUnavailable
+    }
+    try audioSession.setPreferredInput(glassesMic)
+    try audioSession.setActive(true)
+    try audioSession.setPreferredInput(glassesMic)
+    return currentAudioRoute()
+  }
+
+  private func currentAudioRoute() -> [String: Any] {
+    let route = AVAudioSession.sharedInstance().currentRoute
+    let inputPort: AVAudioSession.Port? = route.inputs.first?.portType
+    let outputPort: AVAudioSession.Port? = route.outputs.first?.portType
+    return [
+      "input": inputPort?.rawValue ?? "none",
+      "output": outputPort?.rawValue ?? "none",
+      "glassesInput": route.inputs.contains(where: { $0.portType == .bluetoothHFP }),
+    ]
+  }
+
+  @objc private func handleMetaAudioRouteChange(_ notification: Notification) {
+    audioSessionChannel?.invokeMethod("onAudioRouteChanged", arguments: currentAudioRoute())
+  }
+
+  private func configureBluetoothCaptureSession() throws {
+    let audioSession = AVAudioSession.sharedInstance()
+    try audioSession.setCategory(
+      .playAndRecord,
+      mode: .default,
+      options: [.allowBluetoothHFP, .allowBluetoothA2DP, .defaultToSpeaker]
+    )
+    try audioSession.setActive(true)
   }
 
   // Meta AI app calls back into this app to finish Ray-Ban Meta registration

--- a/app/ios/Runner/AppDelegate.swift
+++ b/app/ios/Runner/AppDelegate.swift
@@ -4,6 +4,7 @@ import UserNotifications
 import app_links
 import WatchConnectivity
 import AVFoundation
+import MediaPlayer
 import Speech
 import WidgetKit
 
@@ -87,6 +88,8 @@ final class QuickActionsIconPatcher: NSObject {
   private let appleRemindersService = AppleRemindersService()
   private let appleHealthService = AppleHealthService()
   private let audioInterruptionManager = AudioInterruptionManager()
+  private var metaGesturesChannel: FlutterMethodChannel?
+  private var metaGesturesListening = false
   private var notificationTitleOnKill: String?
   private var notificationBodyOnKill: String?
 
@@ -188,6 +191,20 @@ final class QuickActionsIconPatcher: NSObject {
     // UI state and restart capture once iOS signals the interruption has
     // ended — flutter_sound does not auto-resume on its own.
     audioInterruptionManager.register(with: controller!.binaryMessenger)
+
+    metaGesturesChannel = FlutterMethodChannel(name: "com.omi/meta_gestures", binaryMessenger: controller!.binaryMessenger)
+    metaGesturesChannel?.setMethodCallHandler { [weak self] (call, result) in
+        switch call.method {
+        case "startListening":
+            self?.startMetaGestureListening()
+            result(true)
+        case "stopListening":
+            self?.stopMetaGestureListening()
+            result(true)
+        default:
+            result(FlutterMethodNotImplemented)
+        }
+    }
 
     // Audio session configuration for Bluetooth microphone support
     let audioSessionChannel = FlutterMethodChannel(name: "com.omi.ios/audioSession", binaryMessenger: controller!.binaryMessenger)
@@ -641,6 +658,53 @@ extension AppDelegate: WCSessionDelegate {
                 print("Unknown background method: \(method)")
             }
         }
+    }
+
+    private func startMetaGestureListening() {
+        let center = MPRemoteCommandCenter.shared()
+        let commands: [(String, MPRemoteCommand)] = [
+            ("togglePlayPause", center.togglePlayPauseCommand),
+            ("play", center.playCommand),
+            ("pause", center.pauseCommand),
+            ("nextTrack", center.nextTrackCommand),
+            ("previousTrack", center.previousTrackCommand),
+        ]
+        for (name, command) in commands {
+            command.removeTarget(nil)
+            command.isEnabled = true
+            command.addTarget { [weak self] _ in
+                NSLog("[OmiMetaGestures] command=%@ -> onGesture(tap)", name)
+                DispatchQueue.main.async {
+                    self?.metaGesturesChannel?.invokeMethod("onGesture", arguments: ["type": "tap", "command": name])
+                }
+                return .success
+            }
+        }
+
+        MPNowPlayingInfoCenter.default().nowPlayingInfo = [
+            MPMediaItemPropertyTitle: "Omi capture",
+            MPMediaItemPropertyArtist: "Meta glasses",
+            MPNowPlayingInfoPropertyPlaybackRate: 1.0,
+        ]
+        MPNowPlayingInfoCenter.default().playbackState = .playing
+        metaGesturesListening = true
+        NSLog("[OmiMetaGestures] listening-started (Now Playing claimed)")
+    }
+
+    private func stopMetaGestureListening() {
+        guard metaGesturesListening else { return }
+        let center = MPRemoteCommandCenter.shared()
+        for command in [
+            center.togglePlayPauseCommand, center.playCommand, center.pauseCommand,
+            center.nextTrackCommand, center.previousTrackCommand,
+        ] {
+            command.removeTarget(nil)
+            command.isEnabled = false
+        }
+        MPNowPlayingInfoCenter.default().playbackState = .stopped
+        MPNowPlayingInfoCenter.default().nowPlayingInfo = nil
+        metaGesturesListening = false
+        NSLog("[OmiMetaGestures] listening-stopped")
     }
 }
 

--- a/app/lib/backend/http/api/conversations.dart
+++ b/app/lib/backend/http/api/conversations.dart
@@ -10,20 +10,6 @@ import 'package:omi/utils/debug_log_manager.dart';
 import 'package:omi/utils/logger.dart';
 import 'package:omi/utils/platform/platform_manager.dart';
 
-class MetaWearablesPhotoCacheResult {
-  final String conversationId;
-  final String photoId;
-
-  const MetaWearablesPhotoCacheResult({required this.conversationId, required this.photoId});
-
-  factory MetaWearablesPhotoCacheResult.fromJson(Map<String, dynamic> json) {
-    return MetaWearablesPhotoCacheResult(
-      conversationId: json['conversation_id']?.toString() ?? '',
-      photoId: json['photo_id']?.toString() ?? '',
-    );
-  }
-}
-
 Future<CreateConversationResponse?> processInProgressConversation() async {
   var response = await makeApiCall(
     url: '${Env.apiBaseUrl}v1/conversations',
@@ -44,51 +30,6 @@ Future<CreateConversationResponse?> processInProgressConversation() async {
     );
   }
   return null;
-}
-
-Future<MetaWearablesPhotoCacheResult?> cacheMetaWearablesPhoto(
-  Uint8List imageBytes, {
-  DateTime? capturedAt,
-  String? conversationId,
-  String? deviceUuid,
-  String? deviceName,
-  String? frameSha256,
-}) async {
-  final takenAt = capturedAt ?? DateTime.now();
-  final response = await makeApiCall(
-    url: '${Env.apiBaseUrl}v1/meta-wearables/photos/cache',
-    headers: {'Content-Type': 'application/json'},
-    method: 'POST',
-    body: jsonEncode(buildMetaWearablesPhotoCachePayload(
-      imageBytes,
-      capturedAt: takenAt,
-      conversationId: conversationId,
-      deviceUuid: deviceUuid,
-      deviceName: deviceName,
-      frameSha256: frameSha256,
-    )),
-  );
-  if (response == null || response.statusCode != 200) return null;
-  return MetaWearablesPhotoCacheResult.fromJson(jsonDecode(response.body));
-}
-
-@visibleForTesting
-Map<String, dynamic> buildMetaWearablesPhotoCachePayload(
-  Uint8List imageBytes, {
-  required DateTime capturedAt,
-  String? conversationId,
-  String? deviceUuid,
-  String? deviceName,
-  String? frameSha256,
-}) {
-  return {
-    'base64': base64Encode(imageBytes),
-    'captured_at': capturedAt.toUtc().toIso8601String(),
-    if (conversationId != null) 'conversation_id': conversationId,
-    if (deviceUuid != null) 'device_uuid': deviceUuid,
-    if (deviceName != null) 'device_name': deviceName,
-    if (frameSha256 != null) 'frame_sha256': frameSha256,
-  };
 }
 
 Future<List<ServerConversation>> getConversations({

--- a/app/lib/backend/http/api/conversations.dart
+++ b/app/lib/backend/http/api/conversations.dart
@@ -4,14 +4,25 @@ import 'dart:io';
 import 'package:flutter/foundation.dart';
 import 'package:http/http.dart' as http;
 import 'package:omi/backend/http/shared.dart';
-import 'package:omi/backend/schema/gen/action_items_folders_wire.g.dart' as action_items_wire;
-import 'package:omi/backend/schema/gen/apps_wire.g.dart' as apps_wire;
-import 'package:omi/backend/schema/gen/conversation_wire.g.dart' as wire;
 import 'package:omi/backend/schema/schema.dart';
 import 'package:omi/env/env.dart';
 import 'package:omi/utils/debug_log_manager.dart';
 import 'package:omi/utils/logger.dart';
 import 'package:omi/utils/platform/platform_manager.dart';
+
+class MetaWearablesPhotoCacheResult {
+  final String conversationId;
+  final String photoId;
+
+  const MetaWearablesPhotoCacheResult({required this.conversationId, required this.photoId});
+
+  factory MetaWearablesPhotoCacheResult.fromJson(Map<String, dynamic> json) {
+    return MetaWearablesPhotoCacheResult(
+      conversationId: json['conversation_id']?.toString() ?? '',
+      photoId: json['photo_id']?.toString() ?? '',
+    );
+  }
+}
 
 Future<CreateConversationResponse?> processInProgressConversation() async {
   var response = await makeApiCall(
@@ -23,7 +34,7 @@ Future<CreateConversationResponse?> processInProgressConversation() async {
   if (response == null) return null;
   Logger.debug('createConversationServer: ${response.body}');
   if (response.statusCode == 200) {
-    return CreateConversationResponse.fromGeneratedWireJson(jsonDecode(response.body) as Map<String, dynamic>);
+    return CreateConversationResponse.fromJson(jsonDecode(response.body));
   } else {
     // TODO: Server returns 304 doesn't recover
     PlatformManager.instance.crashReporter.reportCrash(
@@ -33,6 +44,51 @@ Future<CreateConversationResponse?> processInProgressConversation() async {
     );
   }
   return null;
+}
+
+Future<MetaWearablesPhotoCacheResult?> cacheMetaWearablesPhoto(
+  Uint8List imageBytes, {
+  DateTime? capturedAt,
+  String? conversationId,
+  String? deviceUuid,
+  String? deviceName,
+  String? frameSha256,
+}) async {
+  final takenAt = capturedAt ?? DateTime.now();
+  final response = await makeApiCall(
+    url: '${Env.apiBaseUrl}v1/meta-wearables/photos/cache',
+    headers: {'Content-Type': 'application/json'},
+    method: 'POST',
+    body: jsonEncode(buildMetaWearablesPhotoCachePayload(
+      imageBytes,
+      capturedAt: takenAt,
+      conversationId: conversationId,
+      deviceUuid: deviceUuid,
+      deviceName: deviceName,
+      frameSha256: frameSha256,
+    )),
+  );
+  if (response == null || response.statusCode != 200) return null;
+  return MetaWearablesPhotoCacheResult.fromJson(jsonDecode(response.body));
+}
+
+@visibleForTesting
+Map<String, dynamic> buildMetaWearablesPhotoCachePayload(
+  Uint8List imageBytes, {
+  required DateTime capturedAt,
+  String? conversationId,
+  String? deviceUuid,
+  String? deviceName,
+  String? frameSha256,
+}) {
+  return {
+    'base64': base64Encode(imageBytes),
+    'captured_at': capturedAt.toUtc().toIso8601String(),
+    if (conversationId != null) 'conversation_id': conversationId,
+    if (deviceUuid != null) 'device_uuid': deviceUuid,
+    if (deviceName != null) 'device_name': deviceName,
+    if (frameSha256 != null) 'frame_sha256': frameSha256,
+  };
 }
 
 Future<List<ServerConversation>> getConversations({
@@ -94,9 +150,8 @@ Future<({List<ServerConversation> items, bool ok})> getConversationsResult({
   if (response.statusCode == 200) {
     // decode body bytes to utf8 string and then parse json so as to avoid utf8 char issues
     var body = utf8.decode(response.bodyBytes);
-    var memories = (jsonDecode(body) as List<dynamic>)
-        .map((conversation) => ServerConversation.fromJson(conversation as Map<String, dynamic>))
-        .toList();
+    var memories =
+        (jsonDecode(body) as List<dynamic>).map((conversation) => ServerConversation.fromJson(conversation)).toList();
     Logger.debug('getConversations length: ${memories.length}');
     return (items: memories, ok: true);
   }
@@ -114,7 +169,7 @@ Future<ServerConversation?> reProcessConversationServer(String conversationId, {
   if (response == null) return null;
   Logger.debug('reProcessConversationServer: ${response.body}');
   if (response.statusCode == 200) {
-    return ServerConversation.fromJson(jsonDecode(response.body) as Map<String, dynamic>);
+    return ServerConversation.fromJson(jsonDecode(response.body));
   }
   return null;
 }
@@ -153,9 +208,7 @@ Future<CalendarEventLink?> linkCalendarEvent(String conversationId, String event
   );
   if (response == null) return null;
   if (response.statusCode == 200) {
-    return CalendarEventLink.fromGenerated(
-      wire.GeneratedCalendarEventLink.fromJson(jsonDecode(response.body) as Map<String, dynamic>),
-    );
+    return CalendarEventLink.fromJson(jsonDecode(response.body));
   }
   debugPrint('linkCalendarEvent error: ${response.statusCode} - ${response.body}');
   return null;
@@ -172,9 +225,7 @@ Future<CalendarEventLink?> autoLinkCalendarEvent(String conversationId) async {
   );
   if (response == null) return null;
   if (response.statusCode == 200) {
-    return CalendarEventLink.fromGenerated(
-      wire.GeneratedCalendarEventLink.fromJson(jsonDecode(response.body) as Map<String, dynamic>),
-    );
+    return CalendarEventLink.fromJson(jsonDecode(response.body));
   }
   // 404 means no overlapping event found - not an error, just no match
   if (response.statusCode == 404) {
@@ -209,12 +260,7 @@ Future<List<CalendarEventLink>> listGoogleCalendarEvents({
   if (response == null) return [];
   if (response.statusCode == 200) {
     var body = utf8.decode(response.bodyBytes);
-    return (jsonDecode(body) as List<dynamic>)
-        .map(
-          (event) =>
-              CalendarEventLink.fromGenerated(wire.GeneratedCalendarEventLink.fromJson(event as Map<String, dynamic>)),
-        )
-        .toList();
+    return (jsonDecode(body) as List<dynamic>).map((event) => CalendarEventLink.fromJson(event)).toList();
   }
   debugPrint('listGoogleCalendarEvents error: ${response.statusCode} - ${response.body}');
   return [];
@@ -229,7 +275,7 @@ Future<ServerConversation?> getConversationById(String conversationId) async {
   );
   if (response == null) return null;
   if (response.statusCode == 200) {
-    return ServerConversation.fromJson(jsonDecode(response.body) as Map<String, dynamic>);
+    return ServerConversation.fromJson(jsonDecode(response.body));
   } else if (response.statusCode == 402) {
     Logger.debug('Unlimited Plan Required for conversation: $conversationId');
     return null;
@@ -285,27 +331,12 @@ class TranscriptsResponse {
   });
 
   factory TranscriptsResponse.fromJson(Map<String, dynamic> json) {
-    return TranscriptsResponse.fromGeneratedWireJson(json);
-  }
-
-  factory TranscriptsResponse.fromGeneratedWireJson(Map<String, dynamic> json) {
-    List<TranscriptSegment> readSegments(String key) {
-      final segments = json[key];
-      if (segments is! List) return [];
-      return segments
-          .map(
-            (segment) => TranscriptSegment.fromGenerated(
-              wire.GeneratedTranscriptSegment.fromJson(segment as Map<String, dynamic>),
-            ),
-          )
-          .toList();
-    }
-
     return TranscriptsResponse(
-      deepgram: readSegments('deepgram'),
-      soniox: readSegments('soniox'),
-      whisperx: readSegments('whisperx'),
-      speechmatics: readSegments('speechmatics'),
+      deepgram: (json['deepgram'] as List<dynamic>).map((segment) => TranscriptSegment.fromJson(segment)).toList(),
+      soniox: (json['soniox'] as List<dynamic>).map((segment) => TranscriptSegment.fromJson(segment)).toList(),
+      whisperx: (json['whisperx'] as List<dynamic>).map((segment) => TranscriptSegment.fromJson(segment)).toList(),
+      speechmatics:
+          (json['speechmatics'] as List<dynamic>).map((segment) => TranscriptSegment.fromJson(segment)).toList(),
     );
   }
 }
@@ -320,7 +351,8 @@ Future<TranscriptsResponse> getConversationTranscripts(String conversationId) as
   if (response == null) return TranscriptsResponse();
   Logger.debug('getConversationTranscripts: ${response.body}');
   if (response.statusCode == 200) {
-    return TranscriptsResponse.fromGeneratedWireJson(jsonDecode(response.body) as Map<String, dynamic>);
+    var transcripts = (jsonDecode(response.body) as Map<String, dynamic>);
+    return TranscriptsResponse.fromJson(transcripts);
   }
   return TranscriptsResponse();
 }
@@ -470,16 +502,10 @@ Future<UploadFilesResult> uploadLocalFilesV2(
 
   if (response.statusCode == 200) {
     // Fast-path: server processed synchronously and returned the result.
-    return UploadFilesResult.done(
-      SyncLocalFilesResponse.fromGenerated(
-        wire.GeneratedSyncLocalFilesResultResponse.fromJson(jsonDecode(response.body) as Map<String, dynamic>),
-      ),
-    );
+    return UploadFilesResult.done(SyncLocalFilesResponse.fromJson(jsonDecode(response.body)));
   }
   if (response.statusCode == 202) {
-    final start = SyncJobStartResponse.fromGenerated(
-      wire.GeneratedSyncJobStartResponse.fromJson(jsonDecode(response.body) as Map<String, dynamic>),
-    );
+    final start = SyncJobStartResponse.fromJson(jsonDecode(response.body));
     if (start.jobId.isEmpty) {
       throw Exception('Upload accepted but no job id returned');
     }
@@ -541,12 +567,7 @@ Future<SyncJobFetch> fetchSyncJobStatus(String jobId) async {
     return const SyncJobFetch(SyncJobFetchOutcome.transient);
   }
   try {
-    return SyncJobFetch(
-      SyncJobFetchOutcome.ok,
-      SyncJobStatusResponse.fromGenerated(
-        wire.GeneratedSyncJobStatusResponse.fromJson(jsonDecode(response.body) as Map<String, dynamic>),
-      ),
-    );
+    return SyncJobFetch(SyncJobFetchOutcome.ok, SyncJobStatusResponse.fromJson(jsonDecode(response.body)));
   } catch (e) {
     Logger.debug('fetchSyncJobStatus parse error: $e');
     return const SyncJobFetch(SyncJobFetchOutcome.transient);
@@ -575,9 +596,11 @@ Future<(List<ServerConversation>, int, int)> searchConversationsServer(
   );
   if (response == null) return (<ServerConversation>[], 0, 0);
   if (response.statusCode == 200) {
-    final data = wire.GeneratedSearchConversationsResponse.fromJson(jsonDecode(response.body) as Map<String, dynamic>);
-    final convos = data.items.map((conversation) => ServerConversation.fromGenerated(conversation)).toList();
-    return (convos, data.currentPage, data.totalPages);
+    List<dynamic> items = (jsonDecode(response.body))['items'];
+    int currentPage = (jsonDecode(response.body))['current_page'];
+    int totalPages = (jsonDecode(response.body))['total_pages'];
+    var convos = items.map<ServerConversation>((item) => ServerConversation.fromJson(item)).toList();
+    return (convos, currentPage, totalPages);
   }
   return (<ServerConversation>[], 0, 0);
 }
@@ -591,9 +614,7 @@ Future<String> testConversationPrompt(String prompt, String conversationId) asyn
   );
   if (response == null) return '';
   if (response.statusCode == 200) {
-    return wire.GeneratedConversationTestPromptResponse.fromJson(
-      jsonDecode(response.body) as Map<String, dynamic>,
-    ).summary;
+    return jsonDecode(response.body)['summary'];
   } else {
     return '';
   }
@@ -621,14 +642,14 @@ Future<ActionItemsResponse> getActionItems({
 
   var response = await makeApiCall(url: url, headers: {}, method: 'GET', body: '');
 
-  if (response == null) return const ActionItemsResponse(actionItems: [], hasMore: false);
+  if (response == null) return ActionItemsResponse(actionItems: [], hasMore: false);
 
   if (response.statusCode == 200) {
     var body = utf8.decode(response.bodyBytes);
-    return action_items_wire.GeneratedActionItemsResponse.fromJson(jsonDecode(body) as Map<String, dynamic>);
+    return ActionItemsResponse.fromJson(jsonDecode(body));
   } else {
     Logger.debug('getActionItems error ${response.statusCode}');
-    return const ActionItemsResponse(actionItems: [], hasMore: false);
+    return ActionItemsResponse(actionItems: [], hasMore: false);
   }
 }
 
@@ -643,10 +664,8 @@ Future<List<App>> getConversationSuggestedApps(String conversationId) async {
   if (response == null) return [];
   Logger.debug('getConversationSuggestedApps: ${response.body}');
   if (response.statusCode == 200) {
-    final data = apps_wire.GeneratedConversationSuggestedAppsResponse.fromJson(
-      jsonDecode(response.body) as Map<String, dynamic>,
-    );
-    return data.suggestedApps.map(App.fromGeneratedDetail).toList();
+    var data = jsonDecode(response.body);
+    return (data['suggested_apps'] as List<dynamic>).map((appData) => App.fromJson(appData)).toList();
   }
   return [];
 }
@@ -670,15 +689,11 @@ class MergeConversationsResponse {
   });
 
   factory MergeConversationsResponse.fromJson(Map<String, dynamic> json) {
-    return MergeConversationsResponse.fromGenerated(wire.GeneratedMergeConversationsResponse.fromJson(json));
-  }
-
-  factory MergeConversationsResponse.fromGenerated(wire.GeneratedMergeConversationsResponse generated) {
     return MergeConversationsResponse(
-      status: generated.status,
-      message: generated.message,
-      warning: generated.warning,
-      conversationIds: generated.conversationIds,
+      status: json['status'] ?? 'merging',
+      message: json['message'] ?? 'Merge started',
+      warning: json['warning'],
+      conversationIds: List<String>.from(json['conversation_ids'] ?? []),
     );
   }
 }
@@ -702,9 +717,7 @@ Future<MergeConversationsResponse?> mergeConversations(List<String> conversation
   Logger.debug('mergeConversations: ${response.body}');
 
   if (response.statusCode == 200) {
-    return MergeConversationsResponse.fromGenerated(
-      wire.GeneratedMergeConversationsResponse.fromJson(jsonDecode(response.body) as Map<String, dynamic>),
-    );
+    return MergeConversationsResponse.fromJson(jsonDecode(response.body));
   } else {
     Logger.debug('mergeConversations error: ${response.statusCode} - ${response.body}');
     return null;

--- a/app/lib/backend/http/api/conversations.dart
+++ b/app/lib/backend/http/api/conversations.dart
@@ -332,12 +332,16 @@ class TranscriptsResponse {
 
   factory TranscriptsResponse.fromJson(Map<String, dynamic> json) {
     return TranscriptsResponse(
-      deepgram: (json['deepgram'] as List<dynamic>).map((segment) => TranscriptSegment.fromJson(segment)).toList(),
-      soniox: (json['soniox'] as List<dynamic>).map((segment) => TranscriptSegment.fromJson(segment)).toList(),
-      whisperx: (json['whisperx'] as List<dynamic>).map((segment) => TranscriptSegment.fromJson(segment)).toList(),
-      speechmatics:
-          (json['speechmatics'] as List<dynamic>).map((segment) => TranscriptSegment.fromJson(segment)).toList(),
+      deepgram: _parseTranscriptSegments(json['deepgram']),
+      soniox: _parseTranscriptSegments(json['soniox']),
+      whisperx: _parseTranscriptSegments(json['whisperx']),
+      speechmatics: _parseTranscriptSegments(json['speechmatics']),
     );
+  }
+
+  static List<TranscriptSegment> _parseTranscriptSegments(dynamic value) {
+    if (value is! List) return const [];
+    return value.whereType<Map<String, dynamic>>().map(TranscriptSegment.fromJson).toList();
   }
 }
 
@@ -642,14 +646,14 @@ Future<ActionItemsResponse> getActionItems({
 
   var response = await makeApiCall(url: url, headers: {}, method: 'GET', body: '');
 
-  if (response == null) return ActionItemsResponse(actionItems: [], hasMore: false);
+  if (response == null) return const ActionItemsResponse(actionItems: [], hasMore: false);
 
   if (response.statusCode == 200) {
     var body = utf8.decode(response.bodyBytes);
     return ActionItemsResponse.fromJson(jsonDecode(body));
   } else {
     Logger.debug('getActionItems error ${response.statusCode}');
-    return ActionItemsResponse(actionItems: [], hasMore: false);
+    return const ActionItemsResponse(actionItems: [], hasMore: false);
   }
 }
 

--- a/app/lib/backend/schema/bt_device/bt_device.dart
+++ b/app/lib/backend/schema/bt_device/bt_device.dart
@@ -184,7 +184,7 @@ int mapCodecToBitDepth(BleAudioCodec codec) {
   }
 }
 
-enum DeviceType { omi, openglass, appleWatch, plaud, bee, fieldy, friendPendant, limitless, raybanMeta }
+enum DeviceType { omi, openglass, appleWatch, plaud, bee, fieldy, friendPendant, limitless, raybanMeta, metaWearables }
 
 // Legacy index order (before Frame was removed) — keep for backward-compatible deserialization.
 const List<String> _legacyDeviceTypeNames = [
@@ -198,6 +198,7 @@ const List<String> _legacyDeviceTypeNames = [
   'friendPendant',
   'limitless',
   'raybanMeta',
+  'metaWearables',
 ];
 
 DeviceType _deviceTypeFromJson(dynamic raw) {
@@ -611,6 +612,7 @@ class BtDevice {
       case DeviceType.openglass:
       case DeviceType.appleWatch:
       case DeviceType.raybanMeta:
+      case DeviceType.metaWearables:
         return ''; // No warning needed
     }
   }
@@ -649,6 +651,7 @@ class BtDevice {
       case DeviceType.openglass:
       case DeviceType.appleWatch:
       case DeviceType.raybanMeta:
+      case DeviceType.metaWearables:
         return ''; // No warning needed
     }
   }

--- a/app/lib/debug/meta_wearables_ui_proof.dart
+++ b/app/lib/debug/meta_wearables_ui_proof.dart
@@ -1,0 +1,111 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:meta_wearables_dat_flutter/meta_wearables_dat_flutter.dart';
+import 'package:provider/provider.dart';
+
+import 'package:omi/pages/devices/devices_page.dart';
+import 'package:omi/pages/meta_wearables/meta_glasses_page.dart';
+import 'package:omi/providers/meta_wearables_provider.dart';
+import 'package:omi/services/devices/meta_wearables_service.dart';
+
+class MetaWearablesUiProof extends StatelessWidget {
+  // Debug-only visual proof screen. Gated to kDebugMode (NOT !kReleaseMode) so
+  // a profile/release build can never boot into it — a profile build with the
+  // define once stranded the app on the devices proof tab instead of the real
+  // onboarding/home flow.
+  static const bool enabled = kDebugMode && bool.fromEnvironment('OMI_META_UI_PROOF');
+
+  const MetaWearablesUiProof({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return ChangeNotifierProvider<MetaWearablesProvider>(
+      create: (_) {
+        final provider = MetaWearablesProvider(service: const MetaWearablesProofService());
+        provider.compatibilityByUuid[MetaWearablesProofService.rayBanMeta.uuid] =
+            DeviceCompatibility.deviceUpdateRequired;
+        provider.compatibilityByUuid[MetaWearablesProofService.rayBanDisplay.uuid] =
+            DeviceCompatibility.sdkUpdateRequired;
+        provider.init();
+        return provider;
+      },
+      child: DefaultTabController(
+        length: 2,
+        child: Scaffold(
+          backgroundColor: const Color(0xFF0D0D0D),
+          appBar: AppBar(
+            title: const Text('Meta UI Proof'),
+            bottom: const TabBar(
+              tabs: [
+                Tab(text: 'Devices proof'),
+                Tab(text: 'Glasses proof'),
+              ],
+            ),
+          ),
+          body: const TabBarView(
+            children: [
+              DevicesPage(),
+              MetaGlassesPage(),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class MetaWearablesProofService extends MetaWearablesService {
+  static const rayBanMeta = DeviceInfo(
+    uuid: 'proof-rayban-meta',
+    name: 'Proof Ray-Ban Meta',
+    kind: DeviceKind.rayBanMeta,
+    linkState: DeviceLinkState.connected,
+  );
+
+  static const rayBanDisplay = DeviceInfo(
+    uuid: 'proof-rayban-display',
+    name: 'Proof Ray-Ban Display',
+    kind: DeviceKind.rayBanDisplay,
+    linkState: DeviceLinkState.connected,
+  );
+
+  const MetaWearablesProofService();
+
+  @override
+  Stream<RegistrationState> registrationStateStream() => Stream.value(RegistrationState.registered);
+
+  @override
+  Stream<DeviceInfo?> activeDeviceStream() => Stream.value(rayBanMeta);
+
+  @override
+  Stream<List<DeviceInfo>> devicesStream() => Stream.value(const [rayBanMeta, rayBanDisplay]);
+
+  @override
+  Future<MetaWearablesSnapshot> snapshot() async {
+    return const MetaWearablesSnapshot(
+      registrationState: RegistrationState.registered,
+      devices: [rayBanMeta, rayBanDisplay],
+      activeDevice: rayBanMeta,
+      cameraPermissionState: MetaGlassesCameraPermissionState.granted,
+      diagnostics: {'proof': true},
+    );
+  }
+
+  @override
+  Future<int> startPreviewStream({
+    String? deviceUUID,
+    int fps = 30,
+    StreamQuality quality = StreamQuality.medium,
+  }) async {
+    return 90210;
+  }
+
+  @override
+  Future<void> stopPreviewStream({String? deviceUUID}) async {}
+
+  @override
+  Future<void> openFirmwareUpdate() async {}
+
+  @override
+  Future<void> openDATGlassesAppUpdate() async {}
+}

--- a/app/lib/l10n/app_ar.arb
+++ b/app/lib/l10n/app_ar.arb
@@ -3109,5 +3109,34 @@
                 "type": "String"
             }
         }
-    }
+    },
+    "metaGlasses": "Meta Glasses",
+    "pairingTitleMetaGlasses": "قم بتوصيل نظارات Meta Glasses",
+    "pairingDescMetaGlasses": "قم بإقران نظارتك في تطبيق Meta AI، ثم اضغط على «اتصال» في Omi. يمكنك ربط أكثر من نظارة واختيار النشطة منها.",
+    "metaGlassesUnavailable": "لم يتم العثور على تطبيق Meta AI. قم بتثبيت Meta AI وتفعيل وضع المطوّر لتوصيل نظارتك.",
+    "metaGlassesRegistering": "أكمل الاتصال في تطبيق Meta AI ثم عد إلى Omi.",
+    "metaGlassesCameraPermission": "اسمح بالوصول إلى الكاميرا في تطبيق Meta AI",
+    "metaGlassesCaptureModeLabel": "وضع الالتقاط",
+    "metaGlassesModeCameraMic": "الكاميرا + الميكروفون",
+    "metaGlassesModeMicOnly": "الميكروفون فقط",
+    "metaGlassesStartCapture": "بدء الالتقاط",
+    "metaGlassesStopCapture": "إيقاف الالتقاط",
+    "metaGlassesGestureHint": "عناصر التحكم بالإيماءات غير مدعومة لنظارات Meta في هذا الإصدار.",
+    "connectAnotherDevice": "توصيل جهاز آخر",
+    "myDevices": "أجهزتي",
+    "metaGlassesAutoCapture": "التقاط تلقائي عند الاتصال",
+    "metaGlassesShowPreview": "معاينة مباشرة",
+    "metaGlassesPendingPhotos": "{count} صور بانتظار المزامنة",
+    "metaGlassesPairInMetaAI": "قم بالإعداد في تطبيق Meta AI",
+    "metaGlassesTypeRayBanMeta": "Ray-Ban Meta",
+    "metaGlassesTypeRayBanDisplay": "Meta Ray-Ban Display",
+    "metaGlassesTypeOakleyMeta": "Oakley Meta",
+    "metaGlassesOverheating": "النظارة تبرد الآن — تم إيقاف الالتقاط مؤقتًا",
+    "metaGlassesFolded": "افتح النظارة للمتابعة في الالتقاط",
+    "metaGlassesCaptureFrequency": "تكرار الالتقاط",
+    "metaGlassesEvery10s": "كل 10 ثوانٍ",
+    "metaGlassesEvery30s": "كل 30 ثانية",
+    "metaGlassesEvery1min": "كل دقيقة",
+    "metaGlassesEvery5min": "كل 5 دقائق",
+    "metaGlassesGestures": "الإيماءات"
 }

--- a/app/lib/l10n/app_be.arb
+++ b/app/lib/l10n/app_be.arb
@@ -10720,5 +10720,34 @@
                 "type": "String"
             }
         }
-    }
+    },
+    "metaGlasses": "Meta Glasses",
+    "pairingTitleMetaGlasses": "Падключыце вашы Meta Glasses",
+    "pairingDescMetaGlasses": "Спалучыце акуляры ў праграме Meta AI, затым націсніце «Падключыць» у Omi. Можна звязаць некалькі пар і выбраць актыўную.",
+    "metaGlassesUnavailable": "Праграма Meta AI не знойдзена. Усталюйце Meta AI і ўключыце рэжым распрацоўшчыка, каб падключыць акуляры.",
+    "metaGlassesRegistering": "Завяршыце падключэнне ў праграме Meta AI і вярніцеся ў Omi.",
+    "metaGlassesCameraPermission": "Дазвольце доступ да камеры ў праграме Meta AI",
+    "metaGlassesCaptureModeLabel": "Рэжым запісу",
+    "metaGlassesModeCameraMic": "Камера + мікрафон",
+    "metaGlassesModeMicOnly": "Толькі мікрафон",
+    "metaGlassesStartCapture": "Пачаць запіс",
+    "metaGlassesStopCapture": "Спыніць запіс",
+    "metaGlassesGestureHint": "Кіраванне жэстамі для акуляраў Meta не падтрымліваецца ў гэтай зборцы.",
+    "connectAnotherDevice": "Падключыць іншую прыладу",
+    "myDevices": "Мае прылады",
+    "metaGlassesAutoCapture": "Аўтазапіс пры падключэнні",
+    "metaGlassesShowPreview": "Жывы перадпрагляд",
+    "metaGlassesPendingPhotos": "{count} фота чакаюць сінхранізацыі",
+    "metaGlassesPairInMetaAI": "Наладзьце ў праграме Meta AI",
+    "metaGlassesTypeRayBanMeta": "Ray-Ban Meta",
+    "metaGlassesTypeRayBanDisplay": "Meta Ray-Ban Display",
+    "metaGlassesTypeOakleyMeta": "Oakley Meta",
+    "metaGlassesOverheating": "Акуляры астываюць — здымка прыпынена",
+    "metaGlassesFolded": "Раскрыйце акуляры, каб працягваць здымку",
+    "metaGlassesCaptureFrequency": "Частата здымкаў",
+    "metaGlassesEvery10s": "Кожныя 10 с",
+    "metaGlassesEvery30s": "Кожныя 30 с",
+    "metaGlassesEvery1min": "Кожную хвіліну",
+    "metaGlassesEvery5min": "Кожныя 5 хвілін",
+    "metaGlassesGestures": "Жэсты"
 }

--- a/app/lib/l10n/app_bg.arb
+++ b/app/lib/l10n/app_bg.arb
@@ -3111,5 +3111,34 @@
                 "type": "String"
             }
         }
-    }
+    },
+    "metaGlasses": "Meta Glasses",
+    "pairingTitleMetaGlasses": "Свържете вашите Meta Glasses",
+    "pairingDescMetaGlasses": "Сдвоете очилата си в приложението Meta AI, след което натиснете „Свързване“ в Omi. Можете да свържете повече от един чифт и да изберете кой е активен.",
+    "metaGlassesUnavailable": "Приложението Meta AI не е открито. Инсталирайте Meta AI и активирайте режим за разработчици, за да свържете очилата си.",
+    "metaGlassesRegistering": "Завършете свързването в приложението Meta AI и се върнете в Omi.",
+    "metaGlassesCameraPermission": "Разрешете достъп до камерата в приложението Meta AI",
+    "metaGlassesCaptureModeLabel": "Режим на запис",
+    "metaGlassesModeCameraMic": "Камера + микрофон",
+    "metaGlassesModeMicOnly": "Само микрофон",
+    "metaGlassesStartCapture": "Старт на записа",
+    "metaGlassesStopCapture": "Стоп на записа",
+    "metaGlassesGestureHint": "Управлението с жестове за очила Meta не се поддържа в тази версия.",
+    "connectAnotherDevice": "Свързване на друго устройство",
+    "myDevices": "Моите устройства",
+    "metaGlassesAutoCapture": "Автоматичен запис при свързване",
+    "metaGlassesShowPreview": "Преглед на живо",
+    "metaGlassesPendingPhotos": "{count} снимки чакат синхронизация",
+    "metaGlassesPairInMetaAI": "Настройте в приложението Meta AI",
+    "metaGlassesTypeRayBanMeta": "Ray-Ban Meta",
+    "metaGlassesTypeRayBanDisplay": "Meta Ray-Ban Display",
+    "metaGlassesTypeOakleyMeta": "Oakley Meta",
+    "metaGlassesOverheating": "Очилата се охлаждат — заснемането е поставено на пауза",
+    "metaGlassesFolded": "Разгънете очилата, за да продължите заснемането",
+    "metaGlassesCaptureFrequency": "Честота на заснемане",
+    "metaGlassesEvery10s": "На всеки 10 с",
+    "metaGlassesEvery30s": "На всеки 30 с",
+    "metaGlassesEvery1min": "На всяка минута",
+    "metaGlassesEvery5min": "На всеки 5 мин",
+    "metaGlassesGestures": "Жестове"
 }

--- a/app/lib/l10n/app_bn.arb
+++ b/app/lib/l10n/app_bn.arb
@@ -10720,5 +10720,34 @@
                 "type": "String"
             }
         }
-    }
+    },
+    "metaGlasses": "Meta Glasses",
+    "pairingTitleMetaGlasses": "আপনার Meta Glasses সংযুক্ত করুন",
+    "pairingDescMetaGlasses": "Meta AI অ্যাপে আপনার চশমা পেয়ার করুন, তারপর Omi-তে Connect-এ ট্যাপ করুন। একাধিক জোড়া যুক্ত করে সক্রিয়টি বেছে নিতে পারেন।",
+    "metaGlassesUnavailable": "Meta AI অ্যাপ পাওয়া যায়নি। চশমা সংযুক্ত করতে Meta AI ইনস্টল করুন এবং ডেভেলপার মোড চালু করুন।",
+    "metaGlassesRegistering": "Meta AI অ্যাপে সংযোগ সম্পন্ন করুন, তারপর Omi-তে ফিরে আসুন।",
+    "metaGlassesCameraPermission": "Meta AI অ্যাপে ক্যামেরা অ্যাক্সেসের অনুমতি দিন",
+    "metaGlassesCaptureModeLabel": "ক্যাপচার মোড",
+    "metaGlassesModeCameraMic": "ক্যামেরা + মাইক",
+    "metaGlassesModeMicOnly": "শুধু মাইক",
+    "metaGlassesStartCapture": "ক্যাপচার শুরু করুন",
+    "metaGlassesStopCapture": "ক্যাপচার বন্ধ করুন",
+    "metaGlassesGestureHint": "এই সংস্করণে Meta চশমার জন্য অঙ্গভঙ্গি নিয়ন্ত্রণ সমর্থিত নয়।",
+    "connectAnotherDevice": "আরেকটি ডিভাইস সংযুক্ত করুন",
+    "myDevices": "আমার ডিভাইস",
+    "metaGlassesAutoCapture": "সংযুক্ত হলে স্বয়ংক্রিয় ক্যাপচার",
+    "metaGlassesShowPreview": "লাইভ প্রিভিউ",
+    "metaGlassesPendingPhotos": "{count}টি ছবি সিঙ্কের অপেক্ষায়",
+    "metaGlassesPairInMetaAI": "Meta AI অ্যাপে সেট আপ করুন",
+    "metaGlassesTypeRayBanMeta": "Ray-Ban Meta",
+    "metaGlassesTypeRayBanDisplay": "Meta Ray-Ban Display",
+    "metaGlassesTypeOakleyMeta": "Oakley Meta",
+    "metaGlassesOverheating": "চশমাটি ঠান্ডা হচ্ছে — ক্যাপচার বিরতিতে আছে",
+    "metaGlassesFolded": "ক্যাপচার চালিয়ে যেতে চশমাটি খুলুন",
+    "metaGlassesCaptureFrequency": "ক্যাপচার ফ্রিকোয়েন্সি",
+    "metaGlassesEvery10s": "প্রতি ১০ সেকেন্ড",
+    "metaGlassesEvery30s": "প্রতি ৩০ সেকেন্ড",
+    "metaGlassesEvery1min": "প্রতি ১ মিনিট",
+    "metaGlassesEvery5min": "প্রতি ৫ মিনিট",
+    "metaGlassesGestures": "জেসচার"
 }

--- a/app/lib/l10n/app_bs.arb
+++ b/app/lib/l10n/app_bs.arb
@@ -10720,5 +10720,34 @@
                 "type": "String"
             }
         }
-    }
+    },
+    "metaGlasses": "Meta Glasses",
+    "pairingTitleMetaGlasses": "Povežite svoje Meta Glasses",
+    "pairingDescMetaGlasses": "Uparite naočale u aplikaciji Meta AI, zatim dodirnite Poveži u Omi. Možete povezati više pari i odabrati koji je aktivan.",
+    "metaGlassesUnavailable": "Aplikacija Meta AI nije pronađena. Instalirajte Meta AI i omogućite način rada za programere da biste povezali naočale.",
+    "metaGlassesRegistering": "Dovršite povezivanje u aplikaciji Meta AI, a zatim se vratite u Omi.",
+    "metaGlassesCameraPermission": "Dozvolite pristup kameri u aplikaciji Meta AI",
+    "metaGlassesCaptureModeLabel": "Način snimanja",
+    "metaGlassesModeCameraMic": "Kamera + mikrofon",
+    "metaGlassesModeMicOnly": "Samo mikrofon",
+    "metaGlassesStartCapture": "Pokreni snimanje",
+    "metaGlassesStopCapture": "Zaustavi snimanje",
+    "metaGlassesGestureHint": "Kontrole gestama za Meta naočale nisu podržane u ovoj verziji.",
+    "connectAnotherDevice": "Poveži drugi uređaj",
+    "myDevices": "Moji uređaji",
+    "metaGlassesAutoCapture": "Automatsko snimanje pri povezivanju",
+    "metaGlassesShowPreview": "Pregled uživo",
+    "metaGlassesPendingPhotos": "{count} fotografija čeka sinhronizaciju",
+    "metaGlassesPairInMetaAI": "Podesite u aplikaciji Meta AI",
+    "metaGlassesTypeRayBanMeta": "Ray-Ban Meta",
+    "metaGlassesTypeRayBanDisplay": "Meta Ray-Ban Display",
+    "metaGlassesTypeOakleyMeta": "Oakley Meta",
+    "metaGlassesOverheating": "Naočale se hlade — snimanje je pauzirano",
+    "metaGlassesFolded": "Otvorite naočale da nastavite snimanje",
+    "metaGlassesCaptureFrequency": "Učestalost snimanja",
+    "metaGlassesEvery10s": "Svakih 10 s",
+    "metaGlassesEvery30s": "Svakih 30 s",
+    "metaGlassesEvery1min": "Svake 1 min",
+    "metaGlassesEvery5min": "Svakih 5 min",
+    "metaGlassesGestures": "Gestovi"
 }

--- a/app/lib/l10n/app_ca.arb
+++ b/app/lib/l10n/app_ca.arb
@@ -3111,5 +3111,34 @@
                 "type": "String"
             }
         }
-    }
+    },
+    "metaGlasses": "Meta Glasses",
+    "pairingTitleMetaGlasses": "Connecta les teves Meta Glasses",
+    "pairingDescMetaGlasses": "Vincula les ulleres a l'aplicació Meta AI i després toca Connecta a Omi. Pots enllaçar més d'un parell i triar quin és actiu.",
+    "metaGlassesUnavailable": "No s'ha detectat l'aplicació Meta AI. Instal·la Meta AI i activa el mode de desenvolupador per connectar les ulleres.",
+    "metaGlassesRegistering": "Acaba la connexió a l'aplicació Meta AI i torna a Omi.",
+    "metaGlassesCameraPermission": "Permet l'accés a la càmera a l'aplicació Meta AI",
+    "metaGlassesCaptureModeLabel": "Mode de captura",
+    "metaGlassesModeCameraMic": "Càmera + micròfon",
+    "metaGlassesModeMicOnly": "Només micròfon",
+    "metaGlassesStartCapture": "Inicia la captura",
+    "metaGlassesStopCapture": "Atura la captura",
+    "metaGlassesGestureHint": "Els controls de gestos per a les ulleres Meta no són compatibles en aquesta versió.",
+    "connectAnotherDevice": "Connecta un altre dispositiu",
+    "myDevices": "Els meus dispositius",
+    "metaGlassesAutoCapture": "Captura automàtica en connectar",
+    "metaGlassesShowPreview": "Previsualització en directe",
+    "metaGlassesPendingPhotos": "{count} fotos pendents de sincronitzar",
+    "metaGlassesPairInMetaAI": "Configura-ho a l'aplicació Meta AI",
+    "metaGlassesTypeRayBanMeta": "Ray-Ban Meta",
+    "metaGlassesTypeRayBanDisplay": "Meta Ray-Ban Display",
+    "metaGlassesTypeOakleyMeta": "Oakley Meta",
+    "metaGlassesOverheating": "Les ulleres s'estan refredant — captura en pausa",
+    "metaGlassesFolded": "Desplega les ulleres per continuar capturant",
+    "metaGlassesCaptureFrequency": "Freqüència de captura",
+    "metaGlassesEvery10s": "Cada 10 s",
+    "metaGlassesEvery30s": "Cada 30 s",
+    "metaGlassesEvery1min": "Cada 1 min",
+    "metaGlassesEvery5min": "Cada 5 min",
+    "metaGlassesGestures": "Gestos"
 }

--- a/app/lib/l10n/app_cs.arb
+++ b/app/lib/l10n/app_cs.arb
@@ -3111,5 +3111,34 @@
                 "type": "String"
             }
         }
-    }
+    },
+    "metaGlasses": "Meta Glasses",
+    "pairingTitleMetaGlasses": "Připojte své Meta Glasses",
+    "pairingDescMetaGlasses": "Spárujte brýle v aplikaci Meta AI a poté klepněte na Připojit v Omi. Můžete propojit více párů a vybrat, který je aktivní.",
+    "metaGlassesUnavailable": "Aplikace Meta AI nebyla nalezena. Nainstalujte Meta AI a zapněte režim pro vývojáře, abyste brýle připojili.",
+    "metaGlassesRegistering": "Dokončete připojení v aplikaci Meta AI a vraťte se do Omi.",
+    "metaGlassesCameraPermission": "Povolte přístup ke kameře v aplikaci Meta AI",
+    "metaGlassesCaptureModeLabel": "Režim záznamu",
+    "metaGlassesModeCameraMic": "Kamera + mikrofon",
+    "metaGlassesModeMicOnly": "Pouze mikrofon",
+    "metaGlassesStartCapture": "Spustit záznam",
+    "metaGlassesStopCapture": "Zastavit záznam",
+    "metaGlassesGestureHint": "Ovládání gesty pro brýle Meta není v této verzi podporováno.",
+    "connectAnotherDevice": "Připojit další zařízení",
+    "myDevices": "Moje zařízení",
+    "metaGlassesAutoCapture": "Automatický záznam po připojení",
+    "metaGlassesShowPreview": "Živý náhled",
+    "metaGlassesPendingPhotos": "{count} fotek čeká na synchronizaci",
+    "metaGlassesPairInMetaAI": "Nastavte v aplikaci Meta AI",
+    "metaGlassesTypeRayBanMeta": "Ray-Ban Meta",
+    "metaGlassesTypeRayBanDisplay": "Meta Ray-Ban Display",
+    "metaGlassesTypeOakleyMeta": "Oakley Meta",
+    "metaGlassesOverheating": "Brýle se ochlazují — snímání je pozastaveno",
+    "metaGlassesFolded": "Rozložte brýle, aby snímání pokračovalo",
+    "metaGlassesCaptureFrequency": "Frekvence snímání",
+    "metaGlassesEvery10s": "Každých 10 s",
+    "metaGlassesEvery30s": "Každých 30 s",
+    "metaGlassesEvery1min": "Každou 1 min",
+    "metaGlassesEvery5min": "Každých 5 min",
+    "metaGlassesGestures": "Gesta"
 }

--- a/app/lib/l10n/app_da.arb
+++ b/app/lib/l10n/app_da.arb
@@ -3151,5 +3151,34 @@
                 "type": "String"
             }
         }
-    }
+    },
+    "metaGlasses": "Meta Glasses",
+    "pairingTitleMetaGlasses": "Forbind dine Meta Glasses",
+    "pairingDescMetaGlasses": "Par dine briller i Meta AI-appen, og tryk derefter på Forbind i Omi. Du kan tilknytte flere par og vælge, hvilket der er aktivt.",
+    "metaGlassesUnavailable": "Meta AI-appen blev ikke fundet. Installer Meta AI, og aktivér udviklertilstand for at forbinde dine briller.",
+    "metaGlassesRegistering": "Fuldfør forbindelsen i Meta AI-appen, og vend tilbage til Omi.",
+    "metaGlassesCameraPermission": "Tillad kameraadgang i Meta AI-appen",
+    "metaGlassesCaptureModeLabel": "Optagetilstand",
+    "metaGlassesModeCameraMic": "Kamera + mikrofon",
+    "metaGlassesModeMicOnly": "Kun mikrofon",
+    "metaGlassesStartCapture": "Start optagelse",
+    "metaGlassesStopCapture": "Stop optagelse",
+    "metaGlassesGestureHint": "Gestusbetjening for Meta-briller understøttes ikke i denne version.",
+    "connectAnotherDevice": "Forbind en anden enhed",
+    "myDevices": "Mine enheder",
+    "metaGlassesAutoCapture": "Automatisk optagelse ved forbindelse",
+    "metaGlassesShowPreview": "Live-forhåndsvisning",
+    "metaGlassesPendingPhotos": "{count} billeder venter på synkronisering",
+    "metaGlassesPairInMetaAI": "Konfigurer i Meta AI-appen",
+    "metaGlassesTypeRayBanMeta": "Ray-Ban Meta",
+    "metaGlassesTypeRayBanDisplay": "Meta Ray-Ban Display",
+    "metaGlassesTypeOakleyMeta": "Oakley Meta",
+    "metaGlassesOverheating": "Brillerne køler ned — optagelse sat på pause",
+    "metaGlassesFolded": "Fold brillerne ud for at fortsætte optagelsen",
+    "metaGlassesCaptureFrequency": "Optagefrekvens",
+    "metaGlassesEvery10s": "Hvert 10. s",
+    "metaGlassesEvery30s": "Hvert 30. s",
+    "metaGlassesEvery1min": "Hvert 1. min",
+    "metaGlassesEvery5min": "Hvert 5. min",
+    "metaGlassesGestures": "Bevægelser"
 }

--- a/app/lib/l10n/app_de.arb
+++ b/app/lib/l10n/app_de.arb
@@ -3110,5 +3110,34 @@
                 "type": "String"
             }
         }
-    }
+    },
+    "metaGlasses": "Meta Glasses",
+    "pairingTitleMetaGlasses": "Verbinde deine Meta Glasses",
+    "pairingDescMetaGlasses": "Kopple deine Brille in der Meta AI App und tippe dann in Omi auf Verbinden. Du kannst mehrere Brillen verknüpfen und die aktive auswählen.",
+    "metaGlassesUnavailable": "Meta AI App nicht gefunden. Installiere Meta AI und aktiviere den Entwicklermodus, um deine Brille zu verbinden.",
+    "metaGlassesRegistering": "Schließe die Verbindung in der Meta AI App ab und kehre zu Omi zurück.",
+    "metaGlassesCameraPermission": "Erlaube den Kamerazugriff in der Meta AI App",
+    "metaGlassesCaptureModeLabel": "Aufnahmemodus",
+    "metaGlassesModeCameraMic": "Kamera + Mikrofon",
+    "metaGlassesModeMicOnly": "Nur Mikrofon",
+    "metaGlassesStartCapture": "Aufnahme starten",
+    "metaGlassesStopCapture": "Aufnahme stoppen",
+    "metaGlassesGestureHint": "Gestensteuerung für Meta-Brillen wird in diesem Build nicht unterstützt.",
+    "connectAnotherDevice": "Weiteres Gerät verbinden",
+    "myDevices": "Meine Geräte",
+    "metaGlassesAutoCapture": "Automatische Aufnahme bei Verbindung",
+    "metaGlassesShowPreview": "Live-Vorschau",
+    "metaGlassesPendingPhotos": "{count} Fotos warten auf Synchronisierung",
+    "metaGlassesPairInMetaAI": "In der Meta AI App einrichten",
+    "metaGlassesTypeRayBanMeta": "Ray-Ban Meta",
+    "metaGlassesTypeRayBanDisplay": "Meta Ray-Ban Display",
+    "metaGlassesTypeOakleyMeta": "Oakley Meta",
+    "metaGlassesOverheating": "Die Brille kühlt ab — Aufnahme pausiert",
+    "metaGlassesFolded": "Klappe die Brille auf, um weiter aufzunehmen",
+    "metaGlassesCaptureFrequency": "Aufnahmefrequenz",
+    "metaGlassesEvery10s": "Alle 10 s",
+    "metaGlassesEvery30s": "Alle 30 s",
+    "metaGlassesEvery1min": "Jede 1 Min",
+    "metaGlassesEvery5min": "Alle 5 Min",
+    "metaGlassesGestures": "Gesten"
 }

--- a/app/lib/l10n/app_el.arb
+++ b/app/lib/l10n/app_el.arb
@@ -3142,5 +3142,34 @@
                 "type": "String"
             }
         }
-    }
+    },
+    "metaGlasses": "Meta Glasses",
+    "pairingTitleMetaGlasses": "Συνδέστε τα Meta Glasses σας",
+    "pairingDescMetaGlasses": "Συζεύξτε τα γυαλιά σας στην εφαρμογή Meta AI και μετά πατήστε Σύνδεση στο Omi. Μπορείτε να συνδέσετε περισσότερα από ένα ζευγάρια και να επιλέξετε ποιο είναι ενεργό.",
+    "metaGlassesUnavailable": "Δεν βρέθηκε η εφαρμογή Meta AI. Εγκαταστήστε το Meta AI και ενεργοποιήστε τη λειτουργία προγραμματιστή για να συνδέσετε τα γυαλιά σας.",
+    "metaGlassesRegistering": "Ολοκληρώστε τη σύνδεση στην εφαρμογή Meta AI και επιστρέψτε στο Omi.",
+    "metaGlassesCameraPermission": "Επιτρέψτε την πρόσβαση στην κάμερα στην εφαρμογή Meta AI",
+    "metaGlassesCaptureModeLabel": "Λειτουργία εγγραφής",
+    "metaGlassesModeCameraMic": "Κάμερα + μικρόφωνο",
+    "metaGlassesModeMicOnly": "Μόνο μικρόφωνο",
+    "metaGlassesStartCapture": "Έναρξη εγγραφής",
+    "metaGlassesStopCapture": "Διακοπή εγγραφής",
+    "metaGlassesGestureHint": "Τα χειριστήρια χειρονομιών για τα γυαλιά Meta δεν υποστηρίζονται σε αυτήν την έκδοση.",
+    "connectAnotherDevice": "Σύνδεση άλλης συσκευής",
+    "myDevices": "Οι συσκευές μου",
+    "metaGlassesAutoCapture": "Αυτόματη εγγραφή κατά τη σύνδεση",
+    "metaGlassesShowPreview": "Ζωντανή προεπισκόπηση",
+    "metaGlassesPendingPhotos": "{count} φωτογραφίες σε αναμονή συγχρονισμού",
+    "metaGlassesPairInMetaAI": "Ρυθμίστε στην εφαρμογή Meta AI",
+    "metaGlassesTypeRayBanMeta": "Ray-Ban Meta",
+    "metaGlassesTypeRayBanDisplay": "Meta Ray-Ban Display",
+    "metaGlassesTypeOakleyMeta": "Oakley Meta",
+    "metaGlassesOverheating": "Τα γυαλιά κρυώνουν — η λήψη τέθηκε σε παύση",
+    "metaGlassesFolded": "Ξεδίπλωσε τα γυαλιά για να συνεχιστεί η λήψη",
+    "metaGlassesCaptureFrequency": "Συχνότητα λήψης",
+    "metaGlassesEvery10s": "Κάθε 10 δλ",
+    "metaGlassesEvery30s": "Κάθε 30 δλ",
+    "metaGlassesEvery1min": "Κάθε 1 λεπ",
+    "metaGlassesEvery5min": "Κάθε 5 λεπ",
+    "metaGlassesGestures": "Χειρονομίες"
 }

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -11276,5 +11276,120 @@
                 "type": "String"
             }
         }
+    },
+    "metaGlasses": "Meta Glasses",
+    "pairingTitleMetaGlasses": "Connect your Meta Glasses",
+    "pairingDescMetaGlasses": "Pair your glasses in the Meta AI app, then tap Connect in Omi. You can link more than one pair and choose which one is active.",
+    "metaGlassesUnavailable": "Meta AI app not detected. Install Meta AI and enable Developer Mode to connect your glasses.",
+    "metaGlassesRegistering": "Finish connecting in the Meta AI app, then return to Omi.",
+    "metaGlassesCameraPermission": "Allow camera access in the Meta AI app",
+    "@metaGlasses": {
+        "description": "Product name for Meta smart glasses"
+    },
+    "@pairingTitleMetaGlasses": {
+        "description": "Pairing title for Meta Glasses"
+    },
+    "@pairingDescMetaGlasses": {
+        "description": "Pairing description for Meta Glasses"
+    },
+    "@metaGlassesUnavailable": {
+        "description": "Shown when the Meta AI companion app is missing"
+    },
+    "@metaGlassesRegistering": {
+        "description": "Shown while Meta Glasses registration is in progress"
+    },
+    "@metaGlassesCameraPermission": {
+        "description": "Row prompting the wearable camera permission"
+    },
+    "metaGlassesCaptureModeLabel": "Capture mode",
+    "metaGlassesModeCameraMic": "Camera + Mic",
+    "metaGlassesModeMicOnly": "Mic only",
+    "metaGlassesStartCapture": "Start capture",
+    "metaGlassesStopCapture": "Stop capture",
+    "metaGlassesGestureHint": "Gesture controls are not supported for Meta glasses in this build.",
+    "connectAnotherDevice": "Connect another device",
+    "@metaGlassesCaptureModeLabel": {
+        "description": "Label for the Meta Glasses capture mode selector"
+    },
+    "@metaGlassesModeCameraMic": {
+        "description": "Capture mode: camera photos plus microphone"
+    },
+    "@metaGlassesModeMicOnly": {
+        "description": "Capture mode: microphone only"
+    },
+    "@metaGlassesStartCapture": {
+        "description": "Button starting glasses capture"
+    },
+    "@metaGlassesStopCapture": {
+        "description": "Button stopping glasses capture"
+    },
+    "@metaGlassesGestureHint": {
+        "description": "Message that Meta glasses gesture controls are unavailable"
+    },
+    "@connectAnotherDevice": {
+        "description": "Button revealing the scanner to add one more device"
+    },
+    "myDevices": "My Devices",
+    "@myDevices": {
+        "description": "Title of the multi-device hub page"
+    },
+    "metaGlassesAutoCapture": "Auto-capture when connected",
+    "metaGlassesShowPreview": "Live preview",
+    "metaGlassesPendingPhotos": "{count} photos waiting to sync",
+    "@metaGlassesAutoCapture": {
+        "description": "Toggle: start glasses capture automatically when they connect"
+    },
+    "@metaGlassesShowPreview": {
+        "description": "Toggle revealing the live camera preview"
+    },
+    "@metaGlassesPendingPhotos": {
+        "description": "Count of locally buffered glasses photos not yet sent to the backend",
+        "placeholders": {
+            "count": {
+                "type": "int"
+            }
+        }
+    },
+    "metaGlassesPairInMetaAI": "Set up in the Meta AI app",
+    "@metaGlassesPairInMetaAI": {
+        "description": "Status for paired glasses whose Bluetooth link is down (setup incomplete or out of range)"
+    },
+    "metaGlassesTypeRayBanMeta": "Ray-Ban Meta",
+    "@metaGlassesTypeRayBanMeta": {
+        "description": "Device type label for Ray-Ban Meta glasses"
+    },
+    "metaGlassesTypeRayBanDisplay": "Meta Ray-Ban Display",
+    "@metaGlassesTypeRayBanDisplay": {
+        "description": "Device type label for Meta Ray-Ban Display glasses"
+    },
+    "metaGlassesTypeOakleyMeta": "Oakley Meta",
+    "@metaGlassesTypeOakleyMeta": {
+        "description": "Device type label for Oakley Meta glasses"
+    },
+    "metaGlassesOverheating": "Glasses are cooling down — capture paused",
+    "metaGlassesFolded": "Unfold your glasses to keep capturing",
+    "metaGlassesCaptureFrequency": "Capture frequency",
+    "metaGlassesEvery10s": "Every 10s",
+    "metaGlassesEvery30s": "Every 30s",
+    "metaGlassesEvery1min": "Every 1 min",
+    "metaGlassesEvery5min": "Every 5 min",
+    "metaGlassesGestures": "Gestures",
+    "@metaGlassesCaptureFrequency": {
+        "description": "Label for the capture interval selector"
+    },
+    "@metaGlassesEvery10s": {
+        "description": "Capture interval option: every 10 seconds"
+    },
+    "@metaGlassesEvery30s": {
+        "description": "Capture interval option: every 30 seconds"
+    },
+    "@metaGlassesEvery1min": {
+        "description": "Capture interval option: every 1 minute"
+    },
+    "@metaGlassesEvery5min": {
+        "description": "Capture interval option: every 5 minutes"
+    },
+    "@metaGlassesGestures": {
+        "description": "Section label for glasses gesture settings"
     }
 }

--- a/app/lib/l10n/app_es.arb
+++ b/app/lib/l10n/app_es.arb
@@ -3143,5 +3143,34 @@
                 "type": "String"
             }
         }
-    }
+    },
+    "metaGlasses": "Meta Glasses",
+    "pairingTitleMetaGlasses": "Conecta tus Meta Glasses",
+    "pairingDescMetaGlasses": "Empareja tus gafas en la app Meta AI y luego toca Conectar en Omi. Puedes vincular más de un par y elegir cuál está activo.",
+    "metaGlassesUnavailable": "No se detectó la app Meta AI. Instala Meta AI y activa el modo de desarrollador para conectar tus gafas.",
+    "metaGlassesRegistering": "Completa la conexión en la app Meta AI y vuelve a Omi.",
+    "metaGlassesCameraPermission": "Permite el acceso a la cámara en la app Meta AI",
+    "metaGlassesCaptureModeLabel": "Modo de captura",
+    "metaGlassesModeCameraMic": "Cámara + micrófono",
+    "metaGlassesModeMicOnly": "Solo micrófono",
+    "metaGlassesStartCapture": "Iniciar captura",
+    "metaGlassesStopCapture": "Detener captura",
+    "metaGlassesGestureHint": "Los controles por gestos para las gafas Meta no son compatibles en esta versión.",
+    "connectAnotherDevice": "Conectar otro dispositivo",
+    "myDevices": "Mis dispositivos",
+    "metaGlassesAutoCapture": "Captura automática al conectar",
+    "metaGlassesShowPreview": "Vista previa en vivo",
+    "metaGlassesPendingPhotos": "{count} fotos pendientes de sincronizar",
+    "metaGlassesPairInMetaAI": "Configura en la app Meta AI",
+    "metaGlassesTypeRayBanMeta": "Ray-Ban Meta",
+    "metaGlassesTypeRayBanDisplay": "Meta Ray-Ban Display",
+    "metaGlassesTypeOakleyMeta": "Oakley Meta",
+    "metaGlassesOverheating": "Las gafas se están enfriando — captura en pausa",
+    "metaGlassesFolded": "Despliega las gafas para seguir capturando",
+    "metaGlassesCaptureFrequency": "Frecuencia de captura",
+    "metaGlassesEvery10s": "Cada 10 s",
+    "metaGlassesEvery30s": "Cada 30 s",
+    "metaGlassesEvery1min": "Cada 1 min",
+    "metaGlassesEvery5min": "Cada 5 min",
+    "metaGlassesGestures": "Gestos"
 }

--- a/app/lib/l10n/app_et.arb
+++ b/app/lib/l10n/app_et.arb
@@ -3142,5 +3142,34 @@
                 "type": "String"
             }
         }
-    }
+    },
+    "metaGlasses": "Meta Glasses",
+    "pairingTitleMetaGlasses": "Ühenda oma Meta Glasses",
+    "pairingDescMetaGlasses": "Seo prillid Meta AI rakenduses ja seejärel puuduta Omi-s nuppu Ühenda. Saad siduda mitu paari ja valida, milline on aktiivne.",
+    "metaGlassesUnavailable": "Meta AI rakendust ei leitud. Prillide ühendamiseks installi Meta AI ja lülita sisse arendajarežiim.",
+    "metaGlassesRegistering": "Vii ühendamine Meta AI rakenduses lõpule ja naase Omi-sse.",
+    "metaGlassesCameraPermission": "Luba kaamera juurdepääs Meta AI rakenduses",
+    "metaGlassesCaptureModeLabel": "Salvestusrežiim",
+    "metaGlassesModeCameraMic": "Kaamera + mikrofon",
+    "metaGlassesModeMicOnly": "Ainult mikrofon",
+    "metaGlassesStartCapture": "Alusta salvestamist",
+    "metaGlassesStopCapture": "Peata salvestamine",
+    "metaGlassesGestureHint": "Meta prillide žestjuhtimine pole selles järgus toetatud.",
+    "connectAnotherDevice": "Ühenda teine seade",
+    "myDevices": "Minu seadmed",
+    "metaGlassesAutoCapture": "Automaatne salvestus ühendamisel",
+    "metaGlassesShowPreview": "Reaalajas eelvaade",
+    "metaGlassesPendingPhotos": "{count} fotot ootab sünkroonimist",
+    "metaGlassesPairInMetaAI": "Seadista Meta AI rakenduses",
+    "metaGlassesTypeRayBanMeta": "Ray-Ban Meta",
+    "metaGlassesTypeRayBanDisplay": "Meta Ray-Ban Display",
+    "metaGlassesTypeOakleyMeta": "Oakley Meta",
+    "metaGlassesOverheating": "Prillid jahtuvad — jäädvustamine on peatatud",
+    "metaGlassesFolded": "Jäädvustamise jätkamiseks ava prillid",
+    "metaGlassesCaptureFrequency": "Jäädvustuse sagedus",
+    "metaGlassesEvery10s": "Iga 10 s",
+    "metaGlassesEvery30s": "Iga 30 s",
+    "metaGlassesEvery1min": "Iga 1 min",
+    "metaGlassesEvery5min": "Iga 5 min",
+    "metaGlassesGestures": "Žestid"
 }

--- a/app/lib/l10n/app_fa.arb
+++ b/app/lib/l10n/app_fa.arb
@@ -10720,5 +10720,34 @@
                 "type": "String"
             }
         }
-    }
+    },
+    "metaGlasses": "Meta Glasses",
+    "pairingTitleMetaGlasses": "عینک Meta Glasses خود را متصل کنید",
+    "pairingDescMetaGlasses": "عینک خود را در برنامه Meta AI جفت کنید، سپس در Omi روی «اتصال» بزنید. می‌توانید چند عینک را پیوند دهید و عینک فعال را انتخاب کنید.",
+    "metaGlassesUnavailable": "برنامه Meta AI پیدا نشد. برای اتصال عینک، Meta AI را نصب کنید و حالت توسعه‌دهنده را فعال کنید.",
+    "metaGlassesRegistering": "اتصال را در برنامه Meta AI کامل کنید و سپس به Omi برگردید.",
+    "metaGlassesCameraPermission": "دسترسی به دوربین را در برنامه Meta AI مجاز کنید",
+    "metaGlassesCaptureModeLabel": "حالت ضبط",
+    "metaGlassesModeCameraMic": "دوربین + میکروفون",
+    "metaGlassesModeMicOnly": "فقط میکروفون",
+    "metaGlassesStartCapture": "شروع ضبط",
+    "metaGlassesStopCapture": "توقف ضبط",
+    "metaGlassesGestureHint": "کنترل‌های حرکتی برای عینک Meta در این نسخه پشتیبانی نمی‌شوند.",
+    "connectAnotherDevice": "اتصال دستگاه دیگر",
+    "myDevices": "دستگاه‌های من",
+    "metaGlassesAutoCapture": "ضبط خودکار هنگام اتصال",
+    "metaGlassesShowPreview": "پیش‌نمایش زنده",
+    "metaGlassesPendingPhotos": "{count} عکس در انتظار همگام‌سازی",
+    "metaGlassesPairInMetaAI": "در برنامه Meta AI راه‌اندازی کنید",
+    "metaGlassesTypeRayBanMeta": "Ray-Ban Meta",
+    "metaGlassesTypeRayBanDisplay": "Meta Ray-Ban Display",
+    "metaGlassesTypeOakleyMeta": "Oakley Meta",
+    "metaGlassesOverheating": "عینک در حال خنک شدن است — ضبط موقتاً متوقف شد",
+    "metaGlassesFolded": "برای ادامه ضبط، عینک را باز کنید",
+    "metaGlassesCaptureFrequency": "فرکانس ضبط",
+    "metaGlassesEvery10s": "هر ۱۰ ثانیه",
+    "metaGlassesEvery30s": "هر ۳۰ ثانیه",
+    "metaGlassesEvery1min": "هر ۱ دقیقه",
+    "metaGlassesEvery5min": "هر ۵ دقیقه",
+    "metaGlassesGestures": "حرکات"
 }

--- a/app/lib/l10n/app_fi.arb
+++ b/app/lib/l10n/app_fi.arb
@@ -3142,5 +3142,34 @@
                 "type": "String"
             }
         }
-    }
+    },
+    "metaGlasses": "Meta Glasses",
+    "pairingTitleMetaGlasses": "Yhdistä Meta Glasses -lasisi",
+    "pairingDescMetaGlasses": "Muodosta lasien laitepari Meta AI -sovelluksessa ja napauta sitten Omissa Yhdistä. Voit liittää useita laseja ja valita, mitkä ovat aktiiviset.",
+    "metaGlassesUnavailable": "Meta AI -sovellusta ei löytynyt. Asenna Meta AI ja ota kehittäjätila käyttöön yhdistääksesi lasit.",
+    "metaGlassesRegistering": "Viimeistele yhdistäminen Meta AI -sovelluksessa ja palaa Omiin.",
+    "metaGlassesCameraPermission": "Salli kameran käyttö Meta AI -sovelluksessa",
+    "metaGlassesCaptureModeLabel": "Tallennustila",
+    "metaGlassesModeCameraMic": "Kamera + mikrofoni",
+    "metaGlassesModeMicOnly": "Vain mikrofoni",
+    "metaGlassesStartCapture": "Aloita tallennus",
+    "metaGlassesStopCapture": "Lopeta tallennus",
+    "metaGlassesGestureHint": "Meta-lasien eleohjausta ei tueta tässä koontiversiossa.",
+    "connectAnotherDevice": "Yhdistä toinen laite",
+    "myDevices": "Omat laitteet",
+    "metaGlassesAutoCapture": "Automaattinen tallennus yhdistettäessä",
+    "metaGlassesShowPreview": "Live-esikatselu",
+    "metaGlassesPendingPhotos": "{count} kuvaa odottaa synkronointia",
+    "metaGlassesPairInMetaAI": "Määritä Meta AI -sovelluksessa",
+    "metaGlassesTypeRayBanMeta": "Ray-Ban Meta",
+    "metaGlassesTypeRayBanDisplay": "Meta Ray-Ban Display",
+    "metaGlassesTypeOakleyMeta": "Oakley Meta",
+    "metaGlassesOverheating": "Lasit jäähtyvät — tallennus keskeytetty",
+    "metaGlassesFolded": "Avaa lasit jatkaaksesi tallennusta",
+    "metaGlassesCaptureFrequency": "Kuvaustaajuus",
+    "metaGlassesEvery10s": "Joka 10 s",
+    "metaGlassesEvery30s": "Joka 30 s",
+    "metaGlassesEvery1min": "Joka 1 min",
+    "metaGlassesEvery5min": "Joka 5 min",
+    "metaGlassesGestures": "Eleet"
 }

--- a/app/lib/l10n/app_fr.arb
+++ b/app/lib/l10n/app_fr.arb
@@ -3177,5 +3177,34 @@
                 "type": "String"
             }
         }
-    }
+    },
+    "metaGlasses": "Meta Glasses",
+    "pairingTitleMetaGlasses": "Connectez vos Meta Glasses",
+    "pairingDescMetaGlasses": "Associez vos lunettes dans l'application Meta AI, puis touchez Connecter dans Omi. Vous pouvez lier plusieurs paires et choisir celle qui est active.",
+    "metaGlassesUnavailable": "Application Meta AI introuvable. Installez Meta AI et activez le mode développeur pour connecter vos lunettes.",
+    "metaGlassesRegistering": "Terminez la connexion dans l'application Meta AI, puis revenez dans Omi.",
+    "metaGlassesCameraPermission": "Autorisez l'accès à la caméra dans l'application Meta AI",
+    "metaGlassesCaptureModeLabel": "Mode de capture",
+    "metaGlassesModeCameraMic": "Caméra + micro",
+    "metaGlassesModeMicOnly": "Micro uniquement",
+    "metaGlassesStartCapture": "Démarrer la capture",
+    "metaGlassesStopCapture": "Arrêter la capture",
+    "metaGlassesGestureHint": "Les commandes gestuelles des lunettes Meta ne sont pas prises en charge dans cette version.",
+    "connectAnotherDevice": "Connecter un autre appareil",
+    "myDevices": "Mes appareils",
+    "metaGlassesAutoCapture": "Capture automatique à la connexion",
+    "metaGlassesShowPreview": "Aperçu en direct",
+    "metaGlassesPendingPhotos": "{count} photos en attente de synchronisation",
+    "metaGlassesPairInMetaAI": "Configurez dans l'application Meta AI",
+    "metaGlassesTypeRayBanMeta": "Ray-Ban Meta",
+    "metaGlassesTypeRayBanDisplay": "Meta Ray-Ban Display",
+    "metaGlassesTypeOakleyMeta": "Oakley Meta",
+    "metaGlassesOverheating": "Les lunettes refroidissent — capture en pause",
+    "metaGlassesFolded": "Dépliez vos lunettes pour continuer la capture",
+    "metaGlassesCaptureFrequency": "Fréquence de capture",
+    "metaGlassesEvery10s": "Toutes les 10 s",
+    "metaGlassesEvery30s": "Toutes les 30 s",
+    "metaGlassesEvery1min": "Toutes les 1 min",
+    "metaGlassesEvery5min": "Toutes les 5 min",
+    "metaGlassesGestures": "Gestes"
 }

--- a/app/lib/l10n/app_he.arb
+++ b/app/lib/l10n/app_he.arb
@@ -10720,5 +10720,34 @@
                 "type": "String"
             }
         }
-    }
+    },
+    "metaGlasses": "Meta Glasses",
+    "pairingTitleMetaGlasses": "חברו את משקפי ה-Meta Glasses שלכם",
+    "pairingDescMetaGlasses": "צמדו את המשקפיים באפליקציית Meta AI ואז הקישו על התחברות ב-Omi. אפשר לקשר יותר מזוג אחד ולבחור איזה פעיל.",
+    "metaGlassesUnavailable": "אפליקציית Meta AI לא נמצאה. התקינו את Meta AI והפעילו מצב מפתחים כדי לחבר את המשקפיים.",
+    "metaGlassesRegistering": "השלימו את החיבור באפליקציית Meta AI וחזרו ל-Omi.",
+    "metaGlassesCameraPermission": "אפשרו גישה למצלמה באפליקציית Meta AI",
+    "metaGlassesCaptureModeLabel": "מצב הקלטה",
+    "metaGlassesModeCameraMic": "מצלמה + מיקרופון",
+    "metaGlassesModeMicOnly": "מיקרופון בלבד",
+    "metaGlassesStartCapture": "התחל הקלטה",
+    "metaGlassesStopCapture": "עצור הקלטה",
+    "metaGlassesGestureHint": "פקדי מחוות עבור משקפי Meta אינם נתמכים בגרסה זו.",
+    "connectAnotherDevice": "חיבור מכשיר נוסף",
+    "myDevices": "המכשירים שלי",
+    "metaGlassesAutoCapture": "הקלטה אוטומטית בעת חיבור",
+    "metaGlassesShowPreview": "תצוגה מקדימה חיה",
+    "metaGlassesPendingPhotos": "{count} תמונות ממתינות לסנכרון",
+    "metaGlassesPairInMetaAI": "הגדירו באפליקציית Meta AI",
+    "metaGlassesTypeRayBanMeta": "Ray-Ban Meta",
+    "metaGlassesTypeRayBanDisplay": "Meta Ray-Ban Display",
+    "metaGlassesTypeOakleyMeta": "Oakley Meta",
+    "metaGlassesOverheating": "המשקפיים מתקררים — הצילום הושהה",
+    "metaGlassesFolded": "פתח את המשקפיים כדי להמשיך בצילום",
+    "metaGlassesCaptureFrequency": "תדירות צילום",
+    "metaGlassesEvery10s": "כל 10 שנ'",
+    "metaGlassesEvery30s": "כל 30 שנ'",
+    "metaGlassesEvery1min": "כל דקה",
+    "metaGlassesEvery5min": "כל 5 דק'",
+    "metaGlassesGestures": "מחוות"
 }

--- a/app/lib/l10n/app_hi.arb
+++ b/app/lib/l10n/app_hi.arb
@@ -3143,5 +3143,34 @@
                 "type": "String"
             }
         }
-    }
+    },
+    "metaGlasses": "Meta Glasses",
+    "pairingTitleMetaGlasses": "अपने Meta Glasses कनेक्ट करें",
+    "pairingDescMetaGlasses": "Meta AI ऐप में अपना चश्मा पेयर करें, फिर Omi में Connect पर टैप करें। आप एक से अधिक जोड़ी लिंक कर सकते हैं और सक्रिय जोड़ी चुन सकते हैं।",
+    "metaGlassesUnavailable": "Meta AI ऐप नहीं मिला। चश्मा कनेक्ट करने के लिए Meta AI इंस्टॉल करें और डेवलपर मोड चालू करें।",
+    "metaGlassesRegistering": "Meta AI ऐप में कनेक्शन पूरा करें, फिर Omi में वापस आएं।",
+    "metaGlassesCameraPermission": "Meta AI ऐप में कैमरा एक्सेस की अनुमति दें",
+    "metaGlassesCaptureModeLabel": "कैप्चर मोड",
+    "metaGlassesModeCameraMic": "कैमरा + माइक",
+    "metaGlassesModeMicOnly": "केवल माइक",
+    "metaGlassesStartCapture": "कैप्चर शुरू करें",
+    "metaGlassesStopCapture": "कैप्चर बंद करें",
+    "metaGlassesGestureHint": "इस बिल्ड में Meta चश्मे के लिए जेस्चर नियंत्रण समर्थित नहीं हैं।",
+    "connectAnotherDevice": "दूसरा डिवाइस कनेक्ट करें",
+    "myDevices": "मेरे डिवाइस",
+    "metaGlassesAutoCapture": "कनेक्ट होने पर ऑटो-कैप्चर",
+    "metaGlassesShowPreview": "लाइव प्रीव्यू",
+    "metaGlassesPendingPhotos": "{count} फ़ोटो सिंक की प्रतीक्षा में",
+    "metaGlassesPairInMetaAI": "Meta AI ऐप में सेट अप करें",
+    "metaGlassesTypeRayBanMeta": "Ray-Ban Meta",
+    "metaGlassesTypeRayBanDisplay": "Meta Ray-Ban Display",
+    "metaGlassesTypeOakleyMeta": "Oakley Meta",
+    "metaGlassesOverheating": "चश्मा ठंडा हो रहा है — कैप्चर रुका हुआ है",
+    "metaGlassesFolded": "कैप्चर जारी रखने के लिए चश्मा खोलें",
+    "metaGlassesCaptureFrequency": "कैप्चर आवृत्ति",
+    "metaGlassesEvery10s": "हर 10 सेकंड",
+    "metaGlassesEvery30s": "हर 30 सेकंड",
+    "metaGlassesEvery1min": "हर 1 मिनट",
+    "metaGlassesEvery5min": "हर 5 मिनट",
+    "metaGlassesGestures": "जेस्चर"
 }

--- a/app/lib/l10n/app_hr.arb
+++ b/app/lib/l10n/app_hr.arb
@@ -10720,5 +10720,34 @@
                 "type": "String"
             }
         }
-    }
+    },
+    "metaGlasses": "Meta Glasses",
+    "pairingTitleMetaGlasses": "Povežite svoje Meta Glasses",
+    "pairingDescMetaGlasses": "Uparite naočale u aplikaciji Meta AI, zatim dodirnite Poveži u Omi. Možete povezati više pari i odabrati koji je aktivan.",
+    "metaGlassesUnavailable": "Aplikacija Meta AI nije pronađena. Instalirajte Meta AI i uključite način rada za razvojne programere kako biste povezali naočale.",
+    "metaGlassesRegistering": "Dovršite povezivanje u aplikaciji Meta AI, a zatim se vratite u Omi.",
+    "metaGlassesCameraPermission": "Dopustite pristup kameri u aplikaciji Meta AI",
+    "metaGlassesCaptureModeLabel": "Način snimanja",
+    "metaGlassesModeCameraMic": "Kamera + mikrofon",
+    "metaGlassesModeMicOnly": "Samo mikrofon",
+    "metaGlassesStartCapture": "Pokreni snimanje",
+    "metaGlassesStopCapture": "Zaustavi snimanje",
+    "metaGlassesGestureHint": "Kontrole gestama za Meta naočale nisu podržane u ovoj verziji.",
+    "connectAnotherDevice": "Poveži drugi uređaj",
+    "myDevices": "Moji uređaji",
+    "metaGlassesAutoCapture": "Automatsko snimanje pri povezivanju",
+    "metaGlassesShowPreview": "Pregled uživo",
+    "metaGlassesPendingPhotos": "{count} fotografija čeka sinkronizaciju",
+    "metaGlassesPairInMetaAI": "Postavite u aplikaciji Meta AI",
+    "metaGlassesTypeRayBanMeta": "Ray-Ban Meta",
+    "metaGlassesTypeRayBanDisplay": "Meta Ray-Ban Display",
+    "metaGlassesTypeOakleyMeta": "Oakley Meta",
+    "metaGlassesOverheating": "Naočale se hlade — snimanje je pauzirano",
+    "metaGlassesFolded": "Rasklopite naočale za nastavak snimanja",
+    "metaGlassesCaptureFrequency": "Učestalost snimanja",
+    "metaGlassesEvery10s": "Svakih 10 s",
+    "metaGlassesEvery30s": "Svakih 30 s",
+    "metaGlassesEvery1min": "Svake 1 min",
+    "metaGlassesEvery5min": "Svakih 5 min",
+    "metaGlassesGestures": "Geste"
 }

--- a/app/lib/l10n/app_hu.arb
+++ b/app/lib/l10n/app_hu.arb
@@ -3238,5 +3238,34 @@
                 "type": "String"
             }
         }
-    }
+    },
+    "metaGlasses": "Meta Glasses",
+    "pairingTitleMetaGlasses": "Csatlakoztasd a Meta Glasses szemüvegedet",
+    "pairingDescMetaGlasses": "Párosítsd a szemüveget a Meta AI alkalmazásban, majd koppints a Csatlakozás gombra az Omiban. Több szemüveget is összekapcsolhatsz, és kiválaszthatod az aktívat.",
+    "metaGlassesUnavailable": "A Meta AI alkalmazás nem található. A szemüveg csatlakoztatásához telepítsd a Meta AI-t, és kapcsold be a fejlesztői módot.",
+    "metaGlassesRegistering": "Fejezd be a csatlakozást a Meta AI alkalmazásban, majd térj vissza az Omiba.",
+    "metaGlassesCameraPermission": "Engedélyezd a kamera-hozzáférést a Meta AI alkalmazásban",
+    "metaGlassesCaptureModeLabel": "Rögzítési mód",
+    "metaGlassesModeCameraMic": "Kamera + mikrofon",
+    "metaGlassesModeMicOnly": "Csak mikrofon",
+    "metaGlassesStartCapture": "Rögzítés indítása",
+    "metaGlassesStopCapture": "Rögzítés leállítása",
+    "metaGlassesGestureHint": "A Meta szemüveg gesztusvezérlése ebben a buildben nem támogatott.",
+    "connectAnotherDevice": "Másik eszköz csatlakoztatása",
+    "myDevices": "Eszközeim",
+    "metaGlassesAutoCapture": "Automatikus rögzítés csatlakozáskor",
+    "metaGlassesShowPreview": "Élő előnézet",
+    "metaGlassesPendingPhotos": "{count} fotó vár szinkronizálásra",
+    "metaGlassesPairInMetaAI": "Állítsd be a Meta AI alkalmazásban",
+    "metaGlassesTypeRayBanMeta": "Ray-Ban Meta",
+    "metaGlassesTypeRayBanDisplay": "Meta Ray-Ban Display",
+    "metaGlassesTypeOakleyMeta": "Oakley Meta",
+    "metaGlassesOverheating": "A szemüveg hűl — a rögzítés szünetel",
+    "metaGlassesFolded": "Hajtsd ki a szemüveget a rögzítés folytatásához",
+    "metaGlassesCaptureFrequency": "Rögzítési gyakoriság",
+    "metaGlassesEvery10s": "10 mp-enként",
+    "metaGlassesEvery30s": "30 mp-enként",
+    "metaGlassesEvery1min": "1 percenként",
+    "metaGlassesEvery5min": "5 percenként",
+    "metaGlassesGestures": "Gesztusok"
 }

--- a/app/lib/l10n/app_id.arb
+++ b/app/lib/l10n/app_id.arb
@@ -3184,5 +3184,34 @@
                 "type": "String"
             }
         }
-    }
+    },
+    "metaGlasses": "Meta Glasses",
+    "pairingTitleMetaGlasses": "Hubungkan Meta Glasses Anda",
+    "pairingDescMetaGlasses": "Sandingkan kacamata di aplikasi Meta AI, lalu ketuk Hubungkan di Omi. Anda dapat menautkan lebih dari satu pasang dan memilih yang aktif.",
+    "metaGlassesUnavailable": "Aplikasi Meta AI tidak ditemukan. Instal Meta AI dan aktifkan Mode Pengembang untuk menghubungkan kacamata Anda.",
+    "metaGlassesRegistering": "Selesaikan penghubungan di aplikasi Meta AI, lalu kembali ke Omi.",
+    "metaGlassesCameraPermission": "Izinkan akses kamera di aplikasi Meta AI",
+    "metaGlassesCaptureModeLabel": "Mode perekaman",
+    "metaGlassesModeCameraMic": "Kamera + mikrofon",
+    "metaGlassesModeMicOnly": "Hanya mikrofon",
+    "metaGlassesStartCapture": "Mulai merekam",
+    "metaGlassesStopCapture": "Berhenti merekam",
+    "metaGlassesGestureHint": "Kontrol gestur untuk kacamata Meta tidak didukung dalam build ini.",
+    "connectAnotherDevice": "Hubungkan perangkat lain",
+    "myDevices": "Perangkat Saya",
+    "metaGlassesAutoCapture": "Rekam otomatis saat terhubung",
+    "metaGlassesShowPreview": "Pratinjau langsung",
+    "metaGlassesPendingPhotos": "{count} foto menunggu sinkronisasi",
+    "metaGlassesPairInMetaAI": "Siapkan di aplikasi Meta AI",
+    "metaGlassesTypeRayBanMeta": "Ray-Ban Meta",
+    "metaGlassesTypeRayBanDisplay": "Meta Ray-Ban Display",
+    "metaGlassesTypeOakleyMeta": "Oakley Meta",
+    "metaGlassesOverheating": "Kacamata sedang mendingin — perekaman dijeda",
+    "metaGlassesFolded": "Buka lipatan kacamata untuk terus merekam",
+    "metaGlassesCaptureFrequency": "Frekuensi tangkapan",
+    "metaGlassesEvery10s": "Setiap 10 dtk",
+    "metaGlassesEvery30s": "Setiap 30 dtk",
+    "metaGlassesEvery1min": "Setiap 1 mnt",
+    "metaGlassesEvery5min": "Setiap 5 mnt",
+    "metaGlassesGestures": "Gestur"
 }

--- a/app/lib/l10n/app_it.arb
+++ b/app/lib/l10n/app_it.arb
@@ -3142,5 +3142,34 @@
                 "type": "String"
             }
         }
-    }
+    },
+    "metaGlasses": "Meta Glasses",
+    "pairingTitleMetaGlasses": "Collega i tuoi Meta Glasses",
+    "pairingDescMetaGlasses": "Associa gli occhiali nell'app Meta AI, poi tocca Connetti in Omi. Puoi collegare più paia e scegliere quale è attivo.",
+    "metaGlassesUnavailable": "App Meta AI non trovata. Installa Meta AI e attiva la modalità sviluppatore per collegare gli occhiali.",
+    "metaGlassesRegistering": "Completa la connessione nell'app Meta AI, poi torna su Omi.",
+    "metaGlassesCameraPermission": "Consenti l'accesso alla fotocamera nell'app Meta AI",
+    "metaGlassesCaptureModeLabel": "Modalità di acquisizione",
+    "metaGlassesModeCameraMic": "Fotocamera + microfono",
+    "metaGlassesModeMicOnly": "Solo microfono",
+    "metaGlassesStartCapture": "Avvia acquisizione",
+    "metaGlassesStopCapture": "Ferma acquisizione",
+    "metaGlassesGestureHint": "I controlli gestuali per gli occhiali Meta non sono supportati in questa build.",
+    "connectAnotherDevice": "Collega un altro dispositivo",
+    "myDevices": "I miei dispositivi",
+    "metaGlassesAutoCapture": "Acquisizione automatica alla connessione",
+    "metaGlassesShowPreview": "Anteprima dal vivo",
+    "metaGlassesPendingPhotos": "{count} foto in attesa di sincronizzazione",
+    "metaGlassesPairInMetaAI": "Configura nell'app Meta AI",
+    "metaGlassesTypeRayBanMeta": "Ray-Ban Meta",
+    "metaGlassesTypeRayBanDisplay": "Meta Ray-Ban Display",
+    "metaGlassesTypeOakleyMeta": "Oakley Meta",
+    "metaGlassesOverheating": "Gli occhiali si stanno raffreddando — acquisizione in pausa",
+    "metaGlassesFolded": "Apri gli occhiali per continuare l'acquisizione",
+    "metaGlassesCaptureFrequency": "Frequenza di acquisizione",
+    "metaGlassesEvery10s": "Ogni 10 s",
+    "metaGlassesEvery30s": "Ogni 30 s",
+    "metaGlassesEvery1min": "Ogni 1 min",
+    "metaGlassesEvery5min": "Ogni 5 min",
+    "metaGlassesGestures": "Gesti"
 }

--- a/app/lib/l10n/app_ja.arb
+++ b/app/lib/l10n/app_ja.arb
@@ -3143,5 +3143,34 @@
                 "type": "String"
             }
         }
-    }
+    },
+    "metaGlasses": "Meta Glasses",
+    "pairingTitleMetaGlasses": "Meta Glassesを接続",
+    "pairingDescMetaGlasses": "Meta AIアプリでグラスをペアリングしてから、Omiで「接続」をタップしてください。複数のグラスをリンクして、アクティブなものを選択できます。",
+    "metaGlassesUnavailable": "Meta AIアプリが見つかりません。グラスを接続するには、Meta AIをインストールして開発者モードを有効にしてください。",
+    "metaGlassesRegistering": "Meta AIアプリで接続を完了してから、Omiに戻ってください。",
+    "metaGlassesCameraPermission": "Meta AIアプリでカメラへのアクセスを許可してください",
+    "metaGlassesCaptureModeLabel": "キャプチャモード",
+    "metaGlassesModeCameraMic": "カメラ + マイク",
+    "metaGlassesModeMicOnly": "マイクのみ",
+    "metaGlassesStartCapture": "キャプチャ開始",
+    "metaGlassesStopCapture": "キャプチャ停止",
+    "metaGlassesGestureHint": "このビルドではMetaグラスのジェスチャー操作はサポートされていません。",
+    "connectAnotherDevice": "別のデバイスを接続",
+    "myDevices": "マイデバイス",
+    "metaGlassesAutoCapture": "接続時に自動キャプチャ",
+    "metaGlassesShowPreview": "ライブプレビュー",
+    "metaGlassesPendingPhotos": "{count}枚の写真が同期待ちです",
+    "metaGlassesPairInMetaAI": "Meta AIアプリで設定してください",
+    "metaGlassesTypeRayBanMeta": "Ray-Ban Meta",
+    "metaGlassesTypeRayBanDisplay": "Meta Ray-Ban Display",
+    "metaGlassesTypeOakleyMeta": "Oakley Meta",
+    "metaGlassesOverheating": "メガネを冷却中です — キャプチャを一時停止しました",
+    "metaGlassesFolded": "キャプチャを続けるにはメガネを開いてください",
+    "metaGlassesCaptureFrequency": "撮影間隔",
+    "metaGlassesEvery10s": "10秒ごと",
+    "metaGlassesEvery30s": "30秒ごと",
+    "metaGlassesEvery1min": "1分ごと",
+    "metaGlassesEvery5min": "5分ごと",
+    "metaGlassesGestures": "ジェスチャー"
 }

--- a/app/lib/l10n/app_kn.arb
+++ b/app/lib/l10n/app_kn.arb
@@ -10720,5 +10720,34 @@
                 "type": "String"
             }
         }
-    }
+    },
+    "metaGlasses": "Meta Glasses",
+    "pairingTitleMetaGlasses": "ನಿಮ್ಮ Meta Glasses ಸಂಪರ್ಕಿಸಿ",
+    "pairingDescMetaGlasses": "Meta AI ಆ್ಯಪ್‌ನಲ್ಲಿ ನಿಮ್ಮ ಕನ್ನಡಕವನ್ನು ಜೋಡಿಸಿ, ನಂತರ Omi ನಲ್ಲಿ Connect ಟ್ಯಾಪ್ ಮಾಡಿ. ಒಂದಕ್ಕಿಂತ ಹೆಚ್ಚು ಜೋಡಿಗಳನ್ನು ಲಿಂಕ್ ಮಾಡಿ ಸಕ್ರಿಯವಾದದ್ದನ್ನು ಆಯ್ಕೆ ಮಾಡಬಹುದು.",
+    "metaGlassesUnavailable": "Meta AI ಆ್ಯಪ್ ಪತ್ತೆಯಾಗಿಲ್ಲ. ಕನ್ನಡಕ ಸಂಪರ್ಕಿಸಲು Meta AI ಇನ್‌ಸ್ಟಾಲ್ ಮಾಡಿ ಮತ್ತು ಡೆವಲಪರ್ ಮೋಡ್ ಸಕ್ರಿಯಗೊಳಿಸಿ.",
+    "metaGlassesRegistering": "Meta AI ಆ್ಯಪ್‌ನಲ್ಲಿ ಸಂಪರ್ಕವನ್ನು ಪೂರ್ಣಗೊಳಿಸಿ, ನಂತರ Omi ಗೆ ಹಿಂತಿರುಗಿ.",
+    "metaGlassesCameraPermission": "Meta AI ಆ್ಯಪ್‌ನಲ್ಲಿ ಕ್ಯಾಮೆರಾ ಪ್ರವೇಶವನ್ನು ಅನುಮತಿಸಿ",
+    "metaGlassesCaptureModeLabel": "ಕ್ಯಾಪ್ಚರ್ ಮೋಡ್",
+    "metaGlassesModeCameraMic": "ಕ್ಯಾಮೆರಾ + ಮೈಕ್",
+    "metaGlassesModeMicOnly": "ಮೈಕ್ ಮಾತ್ರ",
+    "metaGlassesStartCapture": "ಕ್ಯಾಪ್ಚರ್ ಪ್ರಾರಂಭಿಸಿ",
+    "metaGlassesStopCapture": "ಕ್ಯಾಪ್ಚರ್ ನಿಲ್ಲಿಸಿ",
+    "metaGlassesGestureHint": "ಈ ಬಿಲ್ಡ್‌ನಲ್ಲಿ Meta ಕನ್ನಡಕಗಳಿಗಾಗಿ ಸಂಜ್ಞೆ ನಿಯಂತ್ರಣಗಳಿಗೆ ಬೆಂಬಲವಿಲ್ಲ.",
+    "connectAnotherDevice": "ಇನ್ನೊಂದು ಸಾಧನವನ್ನು ಸಂಪರ್ಕಿಸಿ",
+    "myDevices": "ನನ್ನ ಸಾಧನಗಳು",
+    "metaGlassesAutoCapture": "ಸಂಪರ್ಕಗೊಂಡಾಗ ಸ್ವಯಂ ಕ್ಯಾಪ್ಚರ್",
+    "metaGlassesShowPreview": "ಲೈವ್ ಪೂರ್ವವೀಕ್ಷಣೆ",
+    "metaGlassesPendingPhotos": "{count} ಫೋಟೋಗಳು ಸಿಂಕ್‌ಗಾಗಿ ಕಾಯುತ್ತಿವೆ",
+    "metaGlassesPairInMetaAI": "Meta AI ಆ್ಯಪ್‌ನಲ್ಲಿ ಹೊಂದಿಸಿ",
+    "metaGlassesTypeRayBanMeta": "Ray-Ban Meta",
+    "metaGlassesTypeRayBanDisplay": "Meta Ray-Ban Display",
+    "metaGlassesTypeOakleyMeta": "Oakley Meta",
+    "metaGlassesOverheating": "ಗ್ಲಾಸ್ ತಂಪಾಗುತ್ತಿದೆ — ಕ್ಯಾಪ್ಚರ್ ವಿರಾಮದಲ್ಲಿದೆ",
+    "metaGlassesFolded": "ಕ್ಯಾಪ್ಚರ್ ಮುಂದುವರಿಸಲು ಗ್ಲಾಸ್ ತೆರೆದು ಹಾಕಿ",
+    "metaGlassesCaptureFrequency": "ಕ್ಯಾಪ್ಚರ್ ಆವರ್ತನ",
+    "metaGlassesEvery10s": "ಪ್ರತಿ 10 ಸೆ",
+    "metaGlassesEvery30s": "ಪ್ರತಿ 30 ಸೆ",
+    "metaGlassesEvery1min": "ಪ್ರತಿ 1 ನಿ",
+    "metaGlassesEvery5min": "ಪ್ರತಿ 5 ನಿ",
+    "metaGlassesGestures": "ಗೆಸ್ಚರ್‌ಗಳು"
 }

--- a/app/lib/l10n/app_ko.arb
+++ b/app/lib/l10n/app_ko.arb
@@ -3142,5 +3142,34 @@
                 "type": "String"
             }
         }
-    }
+    },
+    "metaGlasses": "Meta Glasses",
+    "pairingTitleMetaGlasses": "Meta Glasses 연결하기",
+    "pairingDescMetaGlasses": "Meta AI 앱에서 글래스를 페어링한 다음 Omi에서 연결을 탭하세요. 여러 개를 연결하고 활성 글래스를 선택할 수 있습니다.",
+    "metaGlassesUnavailable": "Meta AI 앱을 찾을 수 없습니다. 글래스를 연결하려면 Meta AI를 설치하고 개발자 모드를 활성화하세요.",
+    "metaGlassesRegistering": "Meta AI 앱에서 연결을 완료한 후 Omi로 돌아오세요.",
+    "metaGlassesCameraPermission": "Meta AI 앱에서 카메라 접근을 허용하세요",
+    "metaGlassesCaptureModeLabel": "캡처 모드",
+    "metaGlassesModeCameraMic": "카메라 + 마이크",
+    "metaGlassesModeMicOnly": "마이크만",
+    "metaGlassesStartCapture": "캡처 시작",
+    "metaGlassesStopCapture": "캡처 중지",
+    "metaGlassesGestureHint": "이 빌드에서는 Meta 글래스의 제스처 제어가 지원되지 않습니다.",
+    "connectAnotherDevice": "다른 기기 연결",
+    "myDevices": "내 기기",
+    "metaGlassesAutoCapture": "연결 시 자동 캡처",
+    "metaGlassesShowPreview": "실시간 미리보기",
+    "metaGlassesPendingPhotos": "{count}장의 사진이 동기화 대기 중",
+    "metaGlassesPairInMetaAI": "Meta AI 앱에서 설정하세요",
+    "metaGlassesTypeRayBanMeta": "Ray-Ban Meta",
+    "metaGlassesTypeRayBanDisplay": "Meta Ray-Ban Display",
+    "metaGlassesTypeOakleyMeta": "Oakley Meta",
+    "metaGlassesOverheating": "안경이 식는 중입니다 — 캡처가 일시 중지됨",
+    "metaGlassesFolded": "캡처를 계속하려면 안경을 펼치세요",
+    "metaGlassesCaptureFrequency": "캡처 주기",
+    "metaGlassesEvery10s": "10초마다",
+    "metaGlassesEvery30s": "30초마다",
+    "metaGlassesEvery1min": "1분마다",
+    "metaGlassesEvery5min": "5분마다",
+    "metaGlassesGestures": "제스처"
 }

--- a/app/lib/l10n/app_localizations.dart
+++ b/app/lib/l10n/app_localizations.dart
@@ -17846,6 +17846,180 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Error connecting to Ray-Ban Meta: {error}'**
   String errorConnectingRayBanMeta(String error);
+
+  /// Product name for Meta smart glasses
+  ///
+  /// In en, this message translates to:
+  /// **'Meta Glasses'**
+  String get metaGlasses;
+
+  /// Pairing title for Meta Glasses
+  ///
+  /// In en, this message translates to:
+  /// **'Connect your Meta Glasses'**
+  String get pairingTitleMetaGlasses;
+
+  /// Pairing description for Meta Glasses
+  ///
+  /// In en, this message translates to:
+  /// **'Pair your glasses in the Meta AI app, then tap Connect in Omi. You can link more than one pair and choose which one is active.'**
+  String get pairingDescMetaGlasses;
+
+  /// Shown when the Meta AI companion app is missing
+  ///
+  /// In en, this message translates to:
+  /// **'Meta AI app not detected. Install Meta AI and enable Developer Mode to connect your glasses.'**
+  String get metaGlassesUnavailable;
+
+  /// Shown while Meta Glasses registration is in progress
+  ///
+  /// In en, this message translates to:
+  /// **'Finish connecting in the Meta AI app, then return to Omi.'**
+  String get metaGlassesRegistering;
+
+  /// Row prompting the wearable camera permission
+  ///
+  /// In en, this message translates to:
+  /// **'Allow camera access in the Meta AI app'**
+  String get metaGlassesCameraPermission;
+
+  /// Label for the Meta Glasses capture mode selector
+  ///
+  /// In en, this message translates to:
+  /// **'Capture mode'**
+  String get metaGlassesCaptureModeLabel;
+
+  /// Capture mode: camera photos plus microphone
+  ///
+  /// In en, this message translates to:
+  /// **'Camera + Mic'**
+  String get metaGlassesModeCameraMic;
+
+  /// Capture mode: microphone only
+  ///
+  /// In en, this message translates to:
+  /// **'Mic only'**
+  String get metaGlassesModeMicOnly;
+
+  /// Button starting glasses capture
+  ///
+  /// In en, this message translates to:
+  /// **'Start capture'**
+  String get metaGlassesStartCapture;
+
+  /// Button stopping glasses capture
+  ///
+  /// In en, this message translates to:
+  /// **'Stop capture'**
+  String get metaGlassesStopCapture;
+
+  /// Message that Meta glasses gesture controls are unavailable
+  ///
+  /// In en, this message translates to:
+  /// **'Gesture controls are not supported for Meta glasses in this build.'**
+  String get metaGlassesGestureHint;
+
+  /// Button revealing the scanner to add one more device
+  ///
+  /// In en, this message translates to:
+  /// **'Connect another device'**
+  String get connectAnotherDevice;
+
+  /// Title of the multi-device hub page
+  ///
+  /// In en, this message translates to:
+  /// **'My Devices'**
+  String get myDevices;
+
+  /// Toggle: start glasses capture automatically when they connect
+  ///
+  /// In en, this message translates to:
+  /// **'Auto-capture when connected'**
+  String get metaGlassesAutoCapture;
+
+  /// Toggle revealing the live camera preview
+  ///
+  /// In en, this message translates to:
+  /// **'Live preview'**
+  String get metaGlassesShowPreview;
+
+  /// Count of locally buffered glasses photos not yet sent to the backend
+  ///
+  /// In en, this message translates to:
+  /// **'{count} photos waiting to sync'**
+  String metaGlassesPendingPhotos(int count);
+
+  /// Status for paired glasses whose Bluetooth link is down (setup incomplete or out of range)
+  ///
+  /// In en, this message translates to:
+  /// **'Set up in the Meta AI app'**
+  String get metaGlassesPairInMetaAI;
+
+  /// Device type label for Ray-Ban Meta glasses
+  ///
+  /// In en, this message translates to:
+  /// **'Ray-Ban Meta'**
+  String get metaGlassesTypeRayBanMeta;
+
+  /// Device type label for Meta Ray-Ban Display glasses
+  ///
+  /// In en, this message translates to:
+  /// **'Meta Ray-Ban Display'**
+  String get metaGlassesTypeRayBanDisplay;
+
+  /// Device type label for Oakley Meta glasses
+  ///
+  /// In en, this message translates to:
+  /// **'Oakley Meta'**
+  String get metaGlassesTypeOakleyMeta;
+
+  /// No description provided for @metaGlassesOverheating.
+  ///
+  /// In en, this message translates to:
+  /// **'Glasses are cooling down — capture paused'**
+  String get metaGlassesOverheating;
+
+  /// No description provided for @metaGlassesFolded.
+  ///
+  /// In en, this message translates to:
+  /// **'Unfold your glasses to keep capturing'**
+  String get metaGlassesFolded;
+
+  /// Label for the capture interval selector
+  ///
+  /// In en, this message translates to:
+  /// **'Capture frequency'**
+  String get metaGlassesCaptureFrequency;
+
+  /// Capture interval option: every 10 seconds
+  ///
+  /// In en, this message translates to:
+  /// **'Every 10s'**
+  String get metaGlassesEvery10s;
+
+  /// Capture interval option: every 30 seconds
+  ///
+  /// In en, this message translates to:
+  /// **'Every 30s'**
+  String get metaGlassesEvery30s;
+
+  /// Capture interval option: every 1 minute
+  ///
+  /// In en, this message translates to:
+  /// **'Every 1 min'**
+  String get metaGlassesEvery1min;
+
+  /// Capture interval option: every 5 minutes
+  ///
+  /// In en, this message translates to:
+  /// **'Every 5 min'**
+  String get metaGlassesEvery5min;
+
+  /// Section label for glasses gesture settings
+  ///
+  /// In en, this message translates to:
+  /// **'Gestures'**
+  String get metaGlassesGestures;
 }
 
 class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {

--- a/app/lib/l10n/app_localizations_ar.dart
+++ b/app/lib/l10n/app_localizations_ar.dart
@@ -9513,4 +9513,95 @@ class AppLocalizationsAr extends AppLocalizations {
   String errorConnectingRayBanMeta(String error) {
     return 'خطأ في الاتصال بـ Ray-Ban Meta: $error';
   }
+
+  @override
+  String get metaGlasses => 'Meta Glasses';
+
+  @override
+  String get pairingTitleMetaGlasses => 'قم بتوصيل نظارات Meta Glasses';
+
+  @override
+  String get pairingDescMetaGlasses =>
+      'قم بإقران نظارتك في تطبيق Meta AI، ثم اضغط على «اتصال» في Omi. يمكنك ربط أكثر من نظارة واختيار النشطة منها.';
+
+  @override
+  String get metaGlassesUnavailable =>
+      'لم يتم العثور على تطبيق Meta AI. قم بتثبيت Meta AI وتفعيل وضع المطوّر لتوصيل نظارتك.';
+
+  @override
+  String get metaGlassesRegistering => 'أكمل الاتصال في تطبيق Meta AI ثم عد إلى Omi.';
+
+  @override
+  String get metaGlassesCameraPermission => 'اسمح بالوصول إلى الكاميرا في تطبيق Meta AI';
+
+  @override
+  String get metaGlassesCaptureModeLabel => 'وضع الالتقاط';
+
+  @override
+  String get metaGlassesModeCameraMic => 'الكاميرا + الميكروفون';
+
+  @override
+  String get metaGlassesModeMicOnly => 'الميكروفون فقط';
+
+  @override
+  String get metaGlassesStartCapture => 'بدء الالتقاط';
+
+  @override
+  String get metaGlassesStopCapture => 'إيقاف الالتقاط';
+
+  @override
+  String get metaGlassesGestureHint => 'عناصر التحكم بالإيماءات غير مدعومة لنظارات Meta في هذا الإصدار.';
+
+  @override
+  String get connectAnotherDevice => 'توصيل جهاز آخر';
+
+  @override
+  String get myDevices => 'أجهزتي';
+
+  @override
+  String get metaGlassesAutoCapture => 'التقاط تلقائي عند الاتصال';
+
+  @override
+  String get metaGlassesShowPreview => 'معاينة مباشرة';
+
+  @override
+  String metaGlassesPendingPhotos(int count) {
+    return '$count صور بانتظار المزامنة';
+  }
+
+  @override
+  String get metaGlassesPairInMetaAI => 'قم بالإعداد في تطبيق Meta AI';
+
+  @override
+  String get metaGlassesTypeRayBanMeta => 'Ray-Ban Meta';
+
+  @override
+  String get metaGlassesTypeRayBanDisplay => 'Meta Ray-Ban Display';
+
+  @override
+  String get metaGlassesTypeOakleyMeta => 'Oakley Meta';
+
+  @override
+  String get metaGlassesOverheating => 'النظارة تبرد الآن — تم إيقاف الالتقاط مؤقتًا';
+
+  @override
+  String get metaGlassesFolded => 'افتح النظارة للمتابعة في الالتقاط';
+
+  @override
+  String get metaGlassesCaptureFrequency => 'تكرار الالتقاط';
+
+  @override
+  String get metaGlassesEvery10s => 'كل 10 ثوانٍ';
+
+  @override
+  String get metaGlassesEvery30s => 'كل 30 ثانية';
+
+  @override
+  String get metaGlassesEvery1min => 'كل دقيقة';
+
+  @override
+  String get metaGlassesEvery5min => 'كل 5 دقائق';
+
+  @override
+  String get metaGlassesGestures => 'الإيماءات';
 }

--- a/app/lib/l10n/app_localizations_be.dart
+++ b/app/lib/l10n/app_localizations_be.dart
@@ -9601,4 +9601,95 @@ class AppLocalizationsBe extends AppLocalizations {
   String errorConnectingRayBanMeta(String error) {
     return 'Памылка падключэння да Ray-Ban Meta: $error';
   }
+
+  @override
+  String get metaGlasses => 'Meta Glasses';
+
+  @override
+  String get pairingTitleMetaGlasses => 'Падключыце вашы Meta Glasses';
+
+  @override
+  String get pairingDescMetaGlasses =>
+      'Спалучыце акуляры ў праграме Meta AI, затым націсніце «Падключыць» у Omi. Можна звязаць некалькі пар і выбраць актыўную.';
+
+  @override
+  String get metaGlassesUnavailable =>
+      'Праграма Meta AI не знойдзена. Усталюйце Meta AI і ўключыце рэжым распрацоўшчыка, каб падключыць акуляры.';
+
+  @override
+  String get metaGlassesRegistering => 'Завяршыце падключэнне ў праграме Meta AI і вярніцеся ў Omi.';
+
+  @override
+  String get metaGlassesCameraPermission => 'Дазвольце доступ да камеры ў праграме Meta AI';
+
+  @override
+  String get metaGlassesCaptureModeLabel => 'Рэжым запісу';
+
+  @override
+  String get metaGlassesModeCameraMic => 'Камера + мікрафон';
+
+  @override
+  String get metaGlassesModeMicOnly => 'Толькі мікрафон';
+
+  @override
+  String get metaGlassesStartCapture => 'Пачаць запіс';
+
+  @override
+  String get metaGlassesStopCapture => 'Спыніць запіс';
+
+  @override
+  String get metaGlassesGestureHint => 'Кіраванне жэстамі для акуляраў Meta не падтрымліваецца ў гэтай зборцы.';
+
+  @override
+  String get connectAnotherDevice => 'Падключыць іншую прыладу';
+
+  @override
+  String get myDevices => 'Мае прылады';
+
+  @override
+  String get metaGlassesAutoCapture => 'Аўтазапіс пры падключэнні';
+
+  @override
+  String get metaGlassesShowPreview => 'Жывы перадпрагляд';
+
+  @override
+  String metaGlassesPendingPhotos(int count) {
+    return '$count фота чакаюць сінхранізацыі';
+  }
+
+  @override
+  String get metaGlassesPairInMetaAI => 'Наладзьце ў праграме Meta AI';
+
+  @override
+  String get metaGlassesTypeRayBanMeta => 'Ray-Ban Meta';
+
+  @override
+  String get metaGlassesTypeRayBanDisplay => 'Meta Ray-Ban Display';
+
+  @override
+  String get metaGlassesTypeOakleyMeta => 'Oakley Meta';
+
+  @override
+  String get metaGlassesOverheating => 'Акуляры астываюць — здымка прыпынена';
+
+  @override
+  String get metaGlassesFolded => 'Раскрыйце акуляры, каб працягваць здымку';
+
+  @override
+  String get metaGlassesCaptureFrequency => 'Частата здымкаў';
+
+  @override
+  String get metaGlassesEvery10s => 'Кожныя 10 с';
+
+  @override
+  String get metaGlassesEvery30s => 'Кожныя 30 с';
+
+  @override
+  String get metaGlassesEvery1min => 'Кожную хвіліну';
+
+  @override
+  String get metaGlassesEvery5min => 'Кожныя 5 хвілін';
+
+  @override
+  String get metaGlassesGestures => 'Жэсты';
 }

--- a/app/lib/l10n/app_localizations_bg.dart
+++ b/app/lib/l10n/app_localizations_bg.dart
@@ -9607,4 +9607,95 @@ class AppLocalizationsBg extends AppLocalizations {
   String errorConnectingRayBanMeta(String error) {
     return 'Грешка при свързване с Ray-Ban Meta: $error';
   }
+
+  @override
+  String get metaGlasses => 'Meta Glasses';
+
+  @override
+  String get pairingTitleMetaGlasses => 'Свържете вашите Meta Glasses';
+
+  @override
+  String get pairingDescMetaGlasses =>
+      'Сдвоете очилата си в приложението Meta AI, след което натиснете „Свързване“ в Omi. Можете да свържете повече от един чифт и да изберете кой е активен.';
+
+  @override
+  String get metaGlassesUnavailable =>
+      'Приложението Meta AI не е открито. Инсталирайте Meta AI и активирайте режим за разработчици, за да свържете очилата си.';
+
+  @override
+  String get metaGlassesRegistering => 'Завършете свързването в приложението Meta AI и се върнете в Omi.';
+
+  @override
+  String get metaGlassesCameraPermission => 'Разрешете достъп до камерата в приложението Meta AI';
+
+  @override
+  String get metaGlassesCaptureModeLabel => 'Режим на запис';
+
+  @override
+  String get metaGlassesModeCameraMic => 'Камера + микрофон';
+
+  @override
+  String get metaGlassesModeMicOnly => 'Само микрофон';
+
+  @override
+  String get metaGlassesStartCapture => 'Старт на записа';
+
+  @override
+  String get metaGlassesStopCapture => 'Стоп на записа';
+
+  @override
+  String get metaGlassesGestureHint => 'Управлението с жестове за очила Meta не се поддържа в тази версия.';
+
+  @override
+  String get connectAnotherDevice => 'Свързване на друго устройство';
+
+  @override
+  String get myDevices => 'Моите устройства';
+
+  @override
+  String get metaGlassesAutoCapture => 'Автоматичен запис при свързване';
+
+  @override
+  String get metaGlassesShowPreview => 'Преглед на живо';
+
+  @override
+  String metaGlassesPendingPhotos(int count) {
+    return '$count снимки чакат синхронизация';
+  }
+
+  @override
+  String get metaGlassesPairInMetaAI => 'Настройте в приложението Meta AI';
+
+  @override
+  String get metaGlassesTypeRayBanMeta => 'Ray-Ban Meta';
+
+  @override
+  String get metaGlassesTypeRayBanDisplay => 'Meta Ray-Ban Display';
+
+  @override
+  String get metaGlassesTypeOakleyMeta => 'Oakley Meta';
+
+  @override
+  String get metaGlassesOverheating => 'Очилата се охлаждат — заснемането е поставено на пауза';
+
+  @override
+  String get metaGlassesFolded => 'Разгънете очилата, за да продължите заснемането';
+
+  @override
+  String get metaGlassesCaptureFrequency => 'Честота на заснемане';
+
+  @override
+  String get metaGlassesEvery10s => 'На всеки 10 с';
+
+  @override
+  String get metaGlassesEvery30s => 'На всеки 30 с';
+
+  @override
+  String get metaGlassesEvery1min => 'На всяка минута';
+
+  @override
+  String get metaGlassesEvery5min => 'На всеки 5 мин';
+
+  @override
+  String get metaGlassesGestures => 'Жестове';
 }

--- a/app/lib/l10n/app_localizations_bn.dart
+++ b/app/lib/l10n/app_localizations_bn.dart
@@ -9576,4 +9576,95 @@ class AppLocalizationsBn extends AppLocalizations {
   String errorConnectingRayBanMeta(String error) {
     return 'Ray-Ban Meta-তে সংযোগ করতে ত্রুটি: $error';
   }
+
+  @override
+  String get metaGlasses => 'Meta Glasses';
+
+  @override
+  String get pairingTitleMetaGlasses => 'আপনার Meta Glasses সংযুক্ত করুন';
+
+  @override
+  String get pairingDescMetaGlasses =>
+      'Meta AI অ্যাপে আপনার চশমা পেয়ার করুন, তারপর Omi-তে Connect-এ ট্যাপ করুন। একাধিক জোড়া যুক্ত করে সক্রিয়টি বেছে নিতে পারেন।';
+
+  @override
+  String get metaGlassesUnavailable =>
+      'Meta AI অ্যাপ পাওয়া যায়নি। চশমা সংযুক্ত করতে Meta AI ইনস্টল করুন এবং ডেভেলপার মোড চালু করুন।';
+
+  @override
+  String get metaGlassesRegistering => 'Meta AI অ্যাপে সংযোগ সম্পন্ন করুন, তারপর Omi-তে ফিরে আসুন।';
+
+  @override
+  String get metaGlassesCameraPermission => 'Meta AI অ্যাপে ক্যামেরা অ্যাক্সেসের অনুমতি দিন';
+
+  @override
+  String get metaGlassesCaptureModeLabel => 'ক্যাপচার মোড';
+
+  @override
+  String get metaGlassesModeCameraMic => 'ক্যামেরা + মাইক';
+
+  @override
+  String get metaGlassesModeMicOnly => 'শুধু মাইক';
+
+  @override
+  String get metaGlassesStartCapture => 'ক্যাপচার শুরু করুন';
+
+  @override
+  String get metaGlassesStopCapture => 'ক্যাপচার বন্ধ করুন';
+
+  @override
+  String get metaGlassesGestureHint => 'এই সংস্করণে Meta চশমার জন্য অঙ্গভঙ্গি নিয়ন্ত্রণ সমর্থিত নয়।';
+
+  @override
+  String get connectAnotherDevice => 'আরেকটি ডিভাইস সংযুক্ত করুন';
+
+  @override
+  String get myDevices => 'আমার ডিভাইস';
+
+  @override
+  String get metaGlassesAutoCapture => 'সংযুক্ত হলে স্বয়ংক্রিয় ক্যাপচার';
+
+  @override
+  String get metaGlassesShowPreview => 'লাইভ প্রিভিউ';
+
+  @override
+  String metaGlassesPendingPhotos(int count) {
+    return '$countটি ছবি সিঙ্কের অপেক্ষায়';
+  }
+
+  @override
+  String get metaGlassesPairInMetaAI => 'Meta AI অ্যাপে সেট আপ করুন';
+
+  @override
+  String get metaGlassesTypeRayBanMeta => 'Ray-Ban Meta';
+
+  @override
+  String get metaGlassesTypeRayBanDisplay => 'Meta Ray-Ban Display';
+
+  @override
+  String get metaGlassesTypeOakleyMeta => 'Oakley Meta';
+
+  @override
+  String get metaGlassesOverheating => 'চশমাটি ঠান্ডা হচ্ছে — ক্যাপচার বিরতিতে আছে';
+
+  @override
+  String get metaGlassesFolded => 'ক্যাপচার চালিয়ে যেতে চশমাটি খুলুন';
+
+  @override
+  String get metaGlassesCaptureFrequency => 'ক্যাপচার ফ্রিকোয়েন্সি';
+
+  @override
+  String get metaGlassesEvery10s => 'প্রতি ১০ সেকেন্ড';
+
+  @override
+  String get metaGlassesEvery30s => 'প্রতি ৩০ সেকেন্ড';
+
+  @override
+  String get metaGlassesEvery1min => 'প্রতি ১ মিনিট';
+
+  @override
+  String get metaGlassesEvery5min => 'প্রতি ৫ মিনিট';
+
+  @override
+  String get metaGlassesGestures => 'জেসচার';
 }

--- a/app/lib/l10n/app_localizations_bs.dart
+++ b/app/lib/l10n/app_localizations_bs.dart
@@ -9597,4 +9597,95 @@ class AppLocalizationsBs extends AppLocalizations {
   String errorConnectingRayBanMeta(String error) {
     return 'Greška pri povezivanju s Ray-Ban Meta: $error';
   }
+
+  @override
+  String get metaGlasses => 'Meta Glasses';
+
+  @override
+  String get pairingTitleMetaGlasses => 'Povežite svoje Meta Glasses';
+
+  @override
+  String get pairingDescMetaGlasses =>
+      'Uparite naočale u aplikaciji Meta AI, zatim dodirnite Poveži u Omi. Možete povezati više pari i odabrati koji je aktivan.';
+
+  @override
+  String get metaGlassesUnavailable =>
+      'Aplikacija Meta AI nije pronađena. Instalirajte Meta AI i omogućite način rada za programere da biste povezali naočale.';
+
+  @override
+  String get metaGlassesRegistering => 'Dovršite povezivanje u aplikaciji Meta AI, a zatim se vratite u Omi.';
+
+  @override
+  String get metaGlassesCameraPermission => 'Dozvolite pristup kameri u aplikaciji Meta AI';
+
+  @override
+  String get metaGlassesCaptureModeLabel => 'Način snimanja';
+
+  @override
+  String get metaGlassesModeCameraMic => 'Kamera + mikrofon';
+
+  @override
+  String get metaGlassesModeMicOnly => 'Samo mikrofon';
+
+  @override
+  String get metaGlassesStartCapture => 'Pokreni snimanje';
+
+  @override
+  String get metaGlassesStopCapture => 'Zaustavi snimanje';
+
+  @override
+  String get metaGlassesGestureHint => 'Kontrole gestama za Meta naočale nisu podržane u ovoj verziji.';
+
+  @override
+  String get connectAnotherDevice => 'Poveži drugi uređaj';
+
+  @override
+  String get myDevices => 'Moji uređaji';
+
+  @override
+  String get metaGlassesAutoCapture => 'Automatsko snimanje pri povezivanju';
+
+  @override
+  String get metaGlassesShowPreview => 'Pregled uživo';
+
+  @override
+  String metaGlassesPendingPhotos(int count) {
+    return '$count fotografija čeka sinhronizaciju';
+  }
+
+  @override
+  String get metaGlassesPairInMetaAI => 'Podesite u aplikaciji Meta AI';
+
+  @override
+  String get metaGlassesTypeRayBanMeta => 'Ray-Ban Meta';
+
+  @override
+  String get metaGlassesTypeRayBanDisplay => 'Meta Ray-Ban Display';
+
+  @override
+  String get metaGlassesTypeOakleyMeta => 'Oakley Meta';
+
+  @override
+  String get metaGlassesOverheating => 'Naočale se hlade — snimanje je pauzirano';
+
+  @override
+  String get metaGlassesFolded => 'Otvorite naočale da nastavite snimanje';
+
+  @override
+  String get metaGlassesCaptureFrequency => 'Učestalost snimanja';
+
+  @override
+  String get metaGlassesEvery10s => 'Svakih 10 s';
+
+  @override
+  String get metaGlassesEvery30s => 'Svakih 30 s';
+
+  @override
+  String get metaGlassesEvery1min => 'Svake 1 min';
+
+  @override
+  String get metaGlassesEvery5min => 'Svakih 5 min';
+
+  @override
+  String get metaGlassesGestures => 'Gestovi';
 }

--- a/app/lib/l10n/app_localizations_ca.dart
+++ b/app/lib/l10n/app_localizations_ca.dart
@@ -9626,4 +9626,96 @@ class AppLocalizationsCa extends AppLocalizations {
   String errorConnectingRayBanMeta(String error) {
     return 'Error en connectar amb Ray-Ban Meta: $error';
   }
+
+  @override
+  String get metaGlasses => 'Meta Glasses';
+
+  @override
+  String get pairingTitleMetaGlasses => 'Connecta les teves Meta Glasses';
+
+  @override
+  String get pairingDescMetaGlasses =>
+      'Vincula les ulleres a l\'aplicació Meta AI i després toca Connecta a Omi. Pots enllaçar més d\'un parell i triar quin és actiu.';
+
+  @override
+  String get metaGlassesUnavailable =>
+      'No s\'ha detectat l\'aplicació Meta AI. Instal·la Meta AI i activa el mode de desenvolupador per connectar les ulleres.';
+
+  @override
+  String get metaGlassesRegistering => 'Acaba la connexió a l\'aplicació Meta AI i torna a Omi.';
+
+  @override
+  String get metaGlassesCameraPermission => 'Permet l\'accés a la càmera a l\'aplicació Meta AI';
+
+  @override
+  String get metaGlassesCaptureModeLabel => 'Mode de captura';
+
+  @override
+  String get metaGlassesModeCameraMic => 'Càmera + micròfon';
+
+  @override
+  String get metaGlassesModeMicOnly => 'Només micròfon';
+
+  @override
+  String get metaGlassesStartCapture => 'Inicia la captura';
+
+  @override
+  String get metaGlassesStopCapture => 'Atura la captura';
+
+  @override
+  String get metaGlassesGestureHint =>
+      'Els controls de gestos per a les ulleres Meta no són compatibles en aquesta versió.';
+
+  @override
+  String get connectAnotherDevice => 'Connecta un altre dispositiu';
+
+  @override
+  String get myDevices => 'Els meus dispositius';
+
+  @override
+  String get metaGlassesAutoCapture => 'Captura automàtica en connectar';
+
+  @override
+  String get metaGlassesShowPreview => 'Previsualització en directe';
+
+  @override
+  String metaGlassesPendingPhotos(int count) {
+    return '$count fotos pendents de sincronitzar';
+  }
+
+  @override
+  String get metaGlassesPairInMetaAI => 'Configura-ho a l\'aplicació Meta AI';
+
+  @override
+  String get metaGlassesTypeRayBanMeta => 'Ray-Ban Meta';
+
+  @override
+  String get metaGlassesTypeRayBanDisplay => 'Meta Ray-Ban Display';
+
+  @override
+  String get metaGlassesTypeOakleyMeta => 'Oakley Meta';
+
+  @override
+  String get metaGlassesOverheating => 'Les ulleres s\'estan refredant — captura en pausa';
+
+  @override
+  String get metaGlassesFolded => 'Desplega les ulleres per continuar capturant';
+
+  @override
+  String get metaGlassesCaptureFrequency => 'Freqüència de captura';
+
+  @override
+  String get metaGlassesEvery10s => 'Cada 10 s';
+
+  @override
+  String get metaGlassesEvery30s => 'Cada 30 s';
+
+  @override
+  String get metaGlassesEvery1min => 'Cada 1 min';
+
+  @override
+  String get metaGlassesEvery5min => 'Cada 5 min';
+
+  @override
+  String get metaGlassesGestures => 'Gestos';
 }

--- a/app/lib/l10n/app_localizations_cs.dart
+++ b/app/lib/l10n/app_localizations_cs.dart
@@ -9571,4 +9571,95 @@ class AppLocalizationsCs extends AppLocalizations {
   String errorConnectingRayBanMeta(String error) {
     return 'Chyba při připojování k Ray-Ban Meta: $error';
   }
+
+  @override
+  String get metaGlasses => 'Meta Glasses';
+
+  @override
+  String get pairingTitleMetaGlasses => 'Připojte své Meta Glasses';
+
+  @override
+  String get pairingDescMetaGlasses =>
+      'Spárujte brýle v aplikaci Meta AI a poté klepněte na Připojit v Omi. Můžete propojit více párů a vybrat, který je aktivní.';
+
+  @override
+  String get metaGlassesUnavailable =>
+      'Aplikace Meta AI nebyla nalezena. Nainstalujte Meta AI a zapněte režim pro vývojáře, abyste brýle připojili.';
+
+  @override
+  String get metaGlassesRegistering => 'Dokončete připojení v aplikaci Meta AI a vraťte se do Omi.';
+
+  @override
+  String get metaGlassesCameraPermission => 'Povolte přístup ke kameře v aplikaci Meta AI';
+
+  @override
+  String get metaGlassesCaptureModeLabel => 'Režim záznamu';
+
+  @override
+  String get metaGlassesModeCameraMic => 'Kamera + mikrofon';
+
+  @override
+  String get metaGlassesModeMicOnly => 'Pouze mikrofon';
+
+  @override
+  String get metaGlassesStartCapture => 'Spustit záznam';
+
+  @override
+  String get metaGlassesStopCapture => 'Zastavit záznam';
+
+  @override
+  String get metaGlassesGestureHint => 'Ovládání gesty pro brýle Meta není v této verzi podporováno.';
+
+  @override
+  String get connectAnotherDevice => 'Připojit další zařízení';
+
+  @override
+  String get myDevices => 'Moje zařízení';
+
+  @override
+  String get metaGlassesAutoCapture => 'Automatický záznam po připojení';
+
+  @override
+  String get metaGlassesShowPreview => 'Živý náhled';
+
+  @override
+  String metaGlassesPendingPhotos(int count) {
+    return '$count fotek čeká na synchronizaci';
+  }
+
+  @override
+  String get metaGlassesPairInMetaAI => 'Nastavte v aplikaci Meta AI';
+
+  @override
+  String get metaGlassesTypeRayBanMeta => 'Ray-Ban Meta';
+
+  @override
+  String get metaGlassesTypeRayBanDisplay => 'Meta Ray-Ban Display';
+
+  @override
+  String get metaGlassesTypeOakleyMeta => 'Oakley Meta';
+
+  @override
+  String get metaGlassesOverheating => 'Brýle se ochlazují — snímání je pozastaveno';
+
+  @override
+  String get metaGlassesFolded => 'Rozložte brýle, aby snímání pokračovalo';
+
+  @override
+  String get metaGlassesCaptureFrequency => 'Frekvence snímání';
+
+  @override
+  String get metaGlassesEvery10s => 'Každých 10 s';
+
+  @override
+  String get metaGlassesEvery30s => 'Každých 30 s';
+
+  @override
+  String get metaGlassesEvery1min => 'Každou 1 min';
+
+  @override
+  String get metaGlassesEvery5min => 'Každých 5 min';
+
+  @override
+  String get metaGlassesGestures => 'Gesta';
 }

--- a/app/lib/l10n/app_localizations_da.dart
+++ b/app/lib/l10n/app_localizations_da.dart
@@ -9555,4 +9555,95 @@ class AppLocalizationsDa extends AppLocalizations {
   String errorConnectingRayBanMeta(String error) {
     return 'Fejl ved forbindelse til Ray-Ban Meta: $error';
   }
+
+  @override
+  String get metaGlasses => 'Meta Glasses';
+
+  @override
+  String get pairingTitleMetaGlasses => 'Forbind dine Meta Glasses';
+
+  @override
+  String get pairingDescMetaGlasses =>
+      'Par dine briller i Meta AI-appen, og tryk derefter på Forbind i Omi. Du kan tilknytte flere par og vælge, hvilket der er aktivt.';
+
+  @override
+  String get metaGlassesUnavailable =>
+      'Meta AI-appen blev ikke fundet. Installer Meta AI, og aktivér udviklertilstand for at forbinde dine briller.';
+
+  @override
+  String get metaGlassesRegistering => 'Fuldfør forbindelsen i Meta AI-appen, og vend tilbage til Omi.';
+
+  @override
+  String get metaGlassesCameraPermission => 'Tillad kameraadgang i Meta AI-appen';
+
+  @override
+  String get metaGlassesCaptureModeLabel => 'Optagetilstand';
+
+  @override
+  String get metaGlassesModeCameraMic => 'Kamera + mikrofon';
+
+  @override
+  String get metaGlassesModeMicOnly => 'Kun mikrofon';
+
+  @override
+  String get metaGlassesStartCapture => 'Start optagelse';
+
+  @override
+  String get metaGlassesStopCapture => 'Stop optagelse';
+
+  @override
+  String get metaGlassesGestureHint => 'Gestusbetjening for Meta-briller understøttes ikke i denne version.';
+
+  @override
+  String get connectAnotherDevice => 'Forbind en anden enhed';
+
+  @override
+  String get myDevices => 'Mine enheder';
+
+  @override
+  String get metaGlassesAutoCapture => 'Automatisk optagelse ved forbindelse';
+
+  @override
+  String get metaGlassesShowPreview => 'Live-forhåndsvisning';
+
+  @override
+  String metaGlassesPendingPhotos(int count) {
+    return '$count billeder venter på synkronisering';
+  }
+
+  @override
+  String get metaGlassesPairInMetaAI => 'Konfigurer i Meta AI-appen';
+
+  @override
+  String get metaGlassesTypeRayBanMeta => 'Ray-Ban Meta';
+
+  @override
+  String get metaGlassesTypeRayBanDisplay => 'Meta Ray-Ban Display';
+
+  @override
+  String get metaGlassesTypeOakleyMeta => 'Oakley Meta';
+
+  @override
+  String get metaGlassesOverheating => 'Brillerne køler ned — optagelse sat på pause';
+
+  @override
+  String get metaGlassesFolded => 'Fold brillerne ud for at fortsætte optagelsen';
+
+  @override
+  String get metaGlassesCaptureFrequency => 'Optagefrekvens';
+
+  @override
+  String get metaGlassesEvery10s => 'Hvert 10. s';
+
+  @override
+  String get metaGlassesEvery30s => 'Hvert 30. s';
+
+  @override
+  String get metaGlassesEvery1min => 'Hvert 1. min';
+
+  @override
+  String get metaGlassesEvery5min => 'Hvert 5. min';
+
+  @override
+  String get metaGlassesGestures => 'Bevægelser';
 }

--- a/app/lib/l10n/app_localizations_de.dart
+++ b/app/lib/l10n/app_localizations_de.dart
@@ -9651,4 +9651,95 @@ class AppLocalizationsDe extends AppLocalizations {
   String errorConnectingRayBanMeta(String error) {
     return 'Fehler beim Verbinden mit Ray-Ban Meta: $error';
   }
+
+  @override
+  String get metaGlasses => 'Meta Glasses';
+
+  @override
+  String get pairingTitleMetaGlasses => 'Verbinde deine Meta Glasses';
+
+  @override
+  String get pairingDescMetaGlasses =>
+      'Kopple deine Brille in der Meta AI App und tippe dann in Omi auf Verbinden. Du kannst mehrere Brillen verknüpfen und die aktive auswählen.';
+
+  @override
+  String get metaGlassesUnavailable =>
+      'Meta AI App nicht gefunden. Installiere Meta AI und aktiviere den Entwicklermodus, um deine Brille zu verbinden.';
+
+  @override
+  String get metaGlassesRegistering => 'Schließe die Verbindung in der Meta AI App ab und kehre zu Omi zurück.';
+
+  @override
+  String get metaGlassesCameraPermission => 'Erlaube den Kamerazugriff in der Meta AI App';
+
+  @override
+  String get metaGlassesCaptureModeLabel => 'Aufnahmemodus';
+
+  @override
+  String get metaGlassesModeCameraMic => 'Kamera + Mikrofon';
+
+  @override
+  String get metaGlassesModeMicOnly => 'Nur Mikrofon';
+
+  @override
+  String get metaGlassesStartCapture => 'Aufnahme starten';
+
+  @override
+  String get metaGlassesStopCapture => 'Aufnahme stoppen';
+
+  @override
+  String get metaGlassesGestureHint => 'Gestensteuerung für Meta-Brillen wird in diesem Build nicht unterstützt.';
+
+  @override
+  String get connectAnotherDevice => 'Weiteres Gerät verbinden';
+
+  @override
+  String get myDevices => 'Meine Geräte';
+
+  @override
+  String get metaGlassesAutoCapture => 'Automatische Aufnahme bei Verbindung';
+
+  @override
+  String get metaGlassesShowPreview => 'Live-Vorschau';
+
+  @override
+  String metaGlassesPendingPhotos(int count) {
+    return '$count Fotos warten auf Synchronisierung';
+  }
+
+  @override
+  String get metaGlassesPairInMetaAI => 'In der Meta AI App einrichten';
+
+  @override
+  String get metaGlassesTypeRayBanMeta => 'Ray-Ban Meta';
+
+  @override
+  String get metaGlassesTypeRayBanDisplay => 'Meta Ray-Ban Display';
+
+  @override
+  String get metaGlassesTypeOakleyMeta => 'Oakley Meta';
+
+  @override
+  String get metaGlassesOverheating => 'Die Brille kühlt ab — Aufnahme pausiert';
+
+  @override
+  String get metaGlassesFolded => 'Klappe die Brille auf, um weiter aufzunehmen';
+
+  @override
+  String get metaGlassesCaptureFrequency => 'Aufnahmefrequenz';
+
+  @override
+  String get metaGlassesEvery10s => 'Alle 10 s';
+
+  @override
+  String get metaGlassesEvery30s => 'Alle 30 s';
+
+  @override
+  String get metaGlassesEvery1min => 'Jede 1 Min';
+
+  @override
+  String get metaGlassesEvery5min => 'Alle 5 Min';
+
+  @override
+  String get metaGlassesGestures => 'Gesten';
 }

--- a/app/lib/l10n/app_localizations_el.dart
+++ b/app/lib/l10n/app_localizations_el.dart
@@ -9639,4 +9639,96 @@ class AppLocalizationsEl extends AppLocalizations {
   String errorConnectingRayBanMeta(String error) {
     return 'Σφάλμα σύνδεσης με Ray-Ban Meta: $error';
   }
+
+  @override
+  String get metaGlasses => 'Meta Glasses';
+
+  @override
+  String get pairingTitleMetaGlasses => 'Συνδέστε τα Meta Glasses σας';
+
+  @override
+  String get pairingDescMetaGlasses =>
+      'Συζεύξτε τα γυαλιά σας στην εφαρμογή Meta AI και μετά πατήστε Σύνδεση στο Omi. Μπορείτε να συνδέσετε περισσότερα από ένα ζευγάρια και να επιλέξετε ποιο είναι ενεργό.';
+
+  @override
+  String get metaGlassesUnavailable =>
+      'Δεν βρέθηκε η εφαρμογή Meta AI. Εγκαταστήστε το Meta AI και ενεργοποιήστε τη λειτουργία προγραμματιστή για να συνδέσετε τα γυαλιά σας.';
+
+  @override
+  String get metaGlassesRegistering => 'Ολοκληρώστε τη σύνδεση στην εφαρμογή Meta AI και επιστρέψτε στο Omi.';
+
+  @override
+  String get metaGlassesCameraPermission => 'Επιτρέψτε την πρόσβαση στην κάμερα στην εφαρμογή Meta AI';
+
+  @override
+  String get metaGlassesCaptureModeLabel => 'Λειτουργία εγγραφής';
+
+  @override
+  String get metaGlassesModeCameraMic => 'Κάμερα + μικρόφωνο';
+
+  @override
+  String get metaGlassesModeMicOnly => 'Μόνο μικρόφωνο';
+
+  @override
+  String get metaGlassesStartCapture => 'Έναρξη εγγραφής';
+
+  @override
+  String get metaGlassesStopCapture => 'Διακοπή εγγραφής';
+
+  @override
+  String get metaGlassesGestureHint =>
+      'Τα χειριστήρια χειρονομιών για τα γυαλιά Meta δεν υποστηρίζονται σε αυτήν την έκδοση.';
+
+  @override
+  String get connectAnotherDevice => 'Σύνδεση άλλης συσκευής';
+
+  @override
+  String get myDevices => 'Οι συσκευές μου';
+
+  @override
+  String get metaGlassesAutoCapture => 'Αυτόματη εγγραφή κατά τη σύνδεση';
+
+  @override
+  String get metaGlassesShowPreview => 'Ζωντανή προεπισκόπηση';
+
+  @override
+  String metaGlassesPendingPhotos(int count) {
+    return '$count φωτογραφίες σε αναμονή συγχρονισμού';
+  }
+
+  @override
+  String get metaGlassesPairInMetaAI => 'Ρυθμίστε στην εφαρμογή Meta AI';
+
+  @override
+  String get metaGlassesTypeRayBanMeta => 'Ray-Ban Meta';
+
+  @override
+  String get metaGlassesTypeRayBanDisplay => 'Meta Ray-Ban Display';
+
+  @override
+  String get metaGlassesTypeOakleyMeta => 'Oakley Meta';
+
+  @override
+  String get metaGlassesOverheating => 'Τα γυαλιά κρυώνουν — η λήψη τέθηκε σε παύση';
+
+  @override
+  String get metaGlassesFolded => 'Ξεδίπλωσε τα γυαλιά για να συνεχιστεί η λήψη';
+
+  @override
+  String get metaGlassesCaptureFrequency => 'Συχνότητα λήψης';
+
+  @override
+  String get metaGlassesEvery10s => 'Κάθε 10 δλ';
+
+  @override
+  String get metaGlassesEvery30s => 'Κάθε 30 δλ';
+
+  @override
+  String get metaGlassesEvery1min => 'Κάθε 1 λεπ';
+
+  @override
+  String get metaGlassesEvery5min => 'Κάθε 5 λεπ';
+
+  @override
+  String get metaGlassesGestures => 'Χειρονομίες';
 }

--- a/app/lib/l10n/app_localizations_en.dart
+++ b/app/lib/l10n/app_localizations_en.dart
@@ -9565,4 +9565,95 @@ class AppLocalizationsEn extends AppLocalizations {
   String errorConnectingRayBanMeta(String error) {
     return 'Error connecting to Ray-Ban Meta: $error';
   }
+
+  @override
+  String get metaGlasses => 'Meta Glasses';
+
+  @override
+  String get pairingTitleMetaGlasses => 'Connect your Meta Glasses';
+
+  @override
+  String get pairingDescMetaGlasses =>
+      'Pair your glasses in the Meta AI app, then tap Connect in Omi. You can link more than one pair and choose which one is active.';
+
+  @override
+  String get metaGlassesUnavailable =>
+      'Meta AI app not detected. Install Meta AI and enable Developer Mode to connect your glasses.';
+
+  @override
+  String get metaGlassesRegistering => 'Finish connecting in the Meta AI app, then return to Omi.';
+
+  @override
+  String get metaGlassesCameraPermission => 'Allow camera access in the Meta AI app';
+
+  @override
+  String get metaGlassesCaptureModeLabel => 'Capture mode';
+
+  @override
+  String get metaGlassesModeCameraMic => 'Camera + Mic';
+
+  @override
+  String get metaGlassesModeMicOnly => 'Mic only';
+
+  @override
+  String get metaGlassesStartCapture => 'Start capture';
+
+  @override
+  String get metaGlassesStopCapture => 'Stop capture';
+
+  @override
+  String get metaGlassesGestureHint => 'Gesture controls are not supported for Meta glasses in this build.';
+
+  @override
+  String get connectAnotherDevice => 'Connect another device';
+
+  @override
+  String get myDevices => 'My Devices';
+
+  @override
+  String get metaGlassesAutoCapture => 'Auto-capture when connected';
+
+  @override
+  String get metaGlassesShowPreview => 'Live preview';
+
+  @override
+  String metaGlassesPendingPhotos(int count) {
+    return '$count photos waiting to sync';
+  }
+
+  @override
+  String get metaGlassesPairInMetaAI => 'Set up in the Meta AI app';
+
+  @override
+  String get metaGlassesTypeRayBanMeta => 'Ray-Ban Meta';
+
+  @override
+  String get metaGlassesTypeRayBanDisplay => 'Meta Ray-Ban Display';
+
+  @override
+  String get metaGlassesTypeOakleyMeta => 'Oakley Meta';
+
+  @override
+  String get metaGlassesOverheating => 'Glasses are cooling down — capture paused';
+
+  @override
+  String get metaGlassesFolded => 'Unfold your glasses to keep capturing';
+
+  @override
+  String get metaGlassesCaptureFrequency => 'Capture frequency';
+
+  @override
+  String get metaGlassesEvery10s => 'Every 10s';
+
+  @override
+  String get metaGlassesEvery30s => 'Every 30s';
+
+  @override
+  String get metaGlassesEvery1min => 'Every 1 min';
+
+  @override
+  String get metaGlassesEvery5min => 'Every 5 min';
+
+  @override
+  String get metaGlassesGestures => 'Gestures';
 }

--- a/app/lib/l10n/app_localizations_es.dart
+++ b/app/lib/l10n/app_localizations_es.dart
@@ -9592,4 +9592,96 @@ class AppLocalizationsEs extends AppLocalizations {
   String errorConnectingRayBanMeta(String error) {
     return 'Error al conectar con Ray-Ban Meta: $error';
   }
+
+  @override
+  String get metaGlasses => 'Meta Glasses';
+
+  @override
+  String get pairingTitleMetaGlasses => 'Conecta tus Meta Glasses';
+
+  @override
+  String get pairingDescMetaGlasses =>
+      'Empareja tus gafas en la app Meta AI y luego toca Conectar en Omi. Puedes vincular más de un par y elegir cuál está activo.';
+
+  @override
+  String get metaGlassesUnavailable =>
+      'No se detectó la app Meta AI. Instala Meta AI y activa el modo de desarrollador para conectar tus gafas.';
+
+  @override
+  String get metaGlassesRegistering => 'Completa la conexión en la app Meta AI y vuelve a Omi.';
+
+  @override
+  String get metaGlassesCameraPermission => 'Permite el acceso a la cámara en la app Meta AI';
+
+  @override
+  String get metaGlassesCaptureModeLabel => 'Modo de captura';
+
+  @override
+  String get metaGlassesModeCameraMic => 'Cámara + micrófono';
+
+  @override
+  String get metaGlassesModeMicOnly => 'Solo micrófono';
+
+  @override
+  String get metaGlassesStartCapture => 'Iniciar captura';
+
+  @override
+  String get metaGlassesStopCapture => 'Detener captura';
+
+  @override
+  String get metaGlassesGestureHint =>
+      'Los controles por gestos para las gafas Meta no son compatibles en esta versión.';
+
+  @override
+  String get connectAnotherDevice => 'Conectar otro dispositivo';
+
+  @override
+  String get myDevices => 'Mis dispositivos';
+
+  @override
+  String get metaGlassesAutoCapture => 'Captura automática al conectar';
+
+  @override
+  String get metaGlassesShowPreview => 'Vista previa en vivo';
+
+  @override
+  String metaGlassesPendingPhotos(int count) {
+    return '$count fotos pendientes de sincronizar';
+  }
+
+  @override
+  String get metaGlassesPairInMetaAI => 'Configura en la app Meta AI';
+
+  @override
+  String get metaGlassesTypeRayBanMeta => 'Ray-Ban Meta';
+
+  @override
+  String get metaGlassesTypeRayBanDisplay => 'Meta Ray-Ban Display';
+
+  @override
+  String get metaGlassesTypeOakleyMeta => 'Oakley Meta';
+
+  @override
+  String get metaGlassesOverheating => 'Las gafas se están enfriando — captura en pausa';
+
+  @override
+  String get metaGlassesFolded => 'Despliega las gafas para seguir capturando';
+
+  @override
+  String get metaGlassesCaptureFrequency => 'Frecuencia de captura';
+
+  @override
+  String get metaGlassesEvery10s => 'Cada 10 s';
+
+  @override
+  String get metaGlassesEvery30s => 'Cada 30 s';
+
+  @override
+  String get metaGlassesEvery1min => 'Cada 1 min';
+
+  @override
+  String get metaGlassesEvery5min => 'Cada 5 min';
+
+  @override
+  String get metaGlassesGestures => 'Gestos';
 }

--- a/app/lib/l10n/app_localizations_et.dart
+++ b/app/lib/l10n/app_localizations_et.dart
@@ -9567,4 +9567,95 @@ class AppLocalizationsEt extends AppLocalizations {
   String errorConnectingRayBanMeta(String error) {
     return 'Viga Ray-Ban Metaga ühendamisel: $error';
   }
+
+  @override
+  String get metaGlasses => 'Meta Glasses';
+
+  @override
+  String get pairingTitleMetaGlasses => 'Ühenda oma Meta Glasses';
+
+  @override
+  String get pairingDescMetaGlasses =>
+      'Seo prillid Meta AI rakenduses ja seejärel puuduta Omi-s nuppu Ühenda. Saad siduda mitu paari ja valida, milline on aktiivne.';
+
+  @override
+  String get metaGlassesUnavailable =>
+      'Meta AI rakendust ei leitud. Prillide ühendamiseks installi Meta AI ja lülita sisse arendajarežiim.';
+
+  @override
+  String get metaGlassesRegistering => 'Vii ühendamine Meta AI rakenduses lõpule ja naase Omi-sse.';
+
+  @override
+  String get metaGlassesCameraPermission => 'Luba kaamera juurdepääs Meta AI rakenduses';
+
+  @override
+  String get metaGlassesCaptureModeLabel => 'Salvestusrežiim';
+
+  @override
+  String get metaGlassesModeCameraMic => 'Kaamera + mikrofon';
+
+  @override
+  String get metaGlassesModeMicOnly => 'Ainult mikrofon';
+
+  @override
+  String get metaGlassesStartCapture => 'Alusta salvestamist';
+
+  @override
+  String get metaGlassesStopCapture => 'Peata salvestamine';
+
+  @override
+  String get metaGlassesGestureHint => 'Meta prillide žestjuhtimine pole selles järgus toetatud.';
+
+  @override
+  String get connectAnotherDevice => 'Ühenda teine seade';
+
+  @override
+  String get myDevices => 'Minu seadmed';
+
+  @override
+  String get metaGlassesAutoCapture => 'Automaatne salvestus ühendamisel';
+
+  @override
+  String get metaGlassesShowPreview => 'Reaalajas eelvaade';
+
+  @override
+  String metaGlassesPendingPhotos(int count) {
+    return '$count fotot ootab sünkroonimist';
+  }
+
+  @override
+  String get metaGlassesPairInMetaAI => 'Seadista Meta AI rakenduses';
+
+  @override
+  String get metaGlassesTypeRayBanMeta => 'Ray-Ban Meta';
+
+  @override
+  String get metaGlassesTypeRayBanDisplay => 'Meta Ray-Ban Display';
+
+  @override
+  String get metaGlassesTypeOakleyMeta => 'Oakley Meta';
+
+  @override
+  String get metaGlassesOverheating => 'Prillid jahtuvad — jäädvustamine on peatatud';
+
+  @override
+  String get metaGlassesFolded => 'Jäädvustamise jätkamiseks ava prillid';
+
+  @override
+  String get metaGlassesCaptureFrequency => 'Jäädvustuse sagedus';
+
+  @override
+  String get metaGlassesEvery10s => 'Iga 10 s';
+
+  @override
+  String get metaGlassesEvery30s => 'Iga 30 s';
+
+  @override
+  String get metaGlassesEvery1min => 'Iga 1 min';
+
+  @override
+  String get metaGlassesEvery5min => 'Iga 5 min';
+
+  @override
+  String get metaGlassesGestures => 'Žestid';
 }

--- a/app/lib/l10n/app_localizations_fa.dart
+++ b/app/lib/l10n/app_localizations_fa.dart
@@ -9572,4 +9572,95 @@ class AppLocalizationsFa extends AppLocalizations {
   String errorConnectingRayBanMeta(String error) {
     return 'خطا در اتصال به Ray-Ban Meta: $error';
   }
+
+  @override
+  String get metaGlasses => 'Meta Glasses';
+
+  @override
+  String get pairingTitleMetaGlasses => 'عینک Meta Glasses خود را متصل کنید';
+
+  @override
+  String get pairingDescMetaGlasses =>
+      'عینک خود را در برنامه Meta AI جفت کنید، سپس در Omi روی «اتصال» بزنید. می‌توانید چند عینک را پیوند دهید و عینک فعال را انتخاب کنید.';
+
+  @override
+  String get metaGlassesUnavailable =>
+      'برنامه Meta AI پیدا نشد. برای اتصال عینک، Meta AI را نصب کنید و حالت توسعه‌دهنده را فعال کنید.';
+
+  @override
+  String get metaGlassesRegistering => 'اتصال را در برنامه Meta AI کامل کنید و سپس به Omi برگردید.';
+
+  @override
+  String get metaGlassesCameraPermission => 'دسترسی به دوربین را در برنامه Meta AI مجاز کنید';
+
+  @override
+  String get metaGlassesCaptureModeLabel => 'حالت ضبط';
+
+  @override
+  String get metaGlassesModeCameraMic => 'دوربین + میکروفون';
+
+  @override
+  String get metaGlassesModeMicOnly => 'فقط میکروفون';
+
+  @override
+  String get metaGlassesStartCapture => 'شروع ضبط';
+
+  @override
+  String get metaGlassesStopCapture => 'توقف ضبط';
+
+  @override
+  String get metaGlassesGestureHint => 'کنترل‌های حرکتی برای عینک Meta در این نسخه پشتیبانی نمی‌شوند.';
+
+  @override
+  String get connectAnotherDevice => 'اتصال دستگاه دیگر';
+
+  @override
+  String get myDevices => 'دستگاه‌های من';
+
+  @override
+  String get metaGlassesAutoCapture => 'ضبط خودکار هنگام اتصال';
+
+  @override
+  String get metaGlassesShowPreview => 'پیش‌نمایش زنده';
+
+  @override
+  String metaGlassesPendingPhotos(int count) {
+    return '$count عکس در انتظار همگام‌سازی';
+  }
+
+  @override
+  String get metaGlassesPairInMetaAI => 'در برنامه Meta AI راه‌اندازی کنید';
+
+  @override
+  String get metaGlassesTypeRayBanMeta => 'Ray-Ban Meta';
+
+  @override
+  String get metaGlassesTypeRayBanDisplay => 'Meta Ray-Ban Display';
+
+  @override
+  String get metaGlassesTypeOakleyMeta => 'Oakley Meta';
+
+  @override
+  String get metaGlassesOverheating => 'عینک در حال خنک شدن است — ضبط موقتاً متوقف شد';
+
+  @override
+  String get metaGlassesFolded => 'برای ادامه ضبط، عینک را باز کنید';
+
+  @override
+  String get metaGlassesCaptureFrequency => 'فرکانس ضبط';
+
+  @override
+  String get metaGlassesEvery10s => 'هر ۱۰ ثانیه';
+
+  @override
+  String get metaGlassesEvery30s => 'هر ۳۰ ثانیه';
+
+  @override
+  String get metaGlassesEvery1min => 'هر ۱ دقیقه';
+
+  @override
+  String get metaGlassesEvery5min => 'هر ۵ دقیقه';
+
+  @override
+  String get metaGlassesGestures => 'حرکات';
 }

--- a/app/lib/l10n/app_localizations_fi.dart
+++ b/app/lib/l10n/app_localizations_fi.dart
@@ -9571,4 +9571,95 @@ class AppLocalizationsFi extends AppLocalizations {
   String errorConnectingRayBanMeta(String error) {
     return 'Virhe yhdistettäessä Ray-Ban Metaan: $error';
   }
+
+  @override
+  String get metaGlasses => 'Meta Glasses';
+
+  @override
+  String get pairingTitleMetaGlasses => 'Yhdistä Meta Glasses -lasisi';
+
+  @override
+  String get pairingDescMetaGlasses =>
+      'Muodosta lasien laitepari Meta AI -sovelluksessa ja napauta sitten Omissa Yhdistä. Voit liittää useita laseja ja valita, mitkä ovat aktiiviset.';
+
+  @override
+  String get metaGlassesUnavailable =>
+      'Meta AI -sovellusta ei löytynyt. Asenna Meta AI ja ota kehittäjätila käyttöön yhdistääksesi lasit.';
+
+  @override
+  String get metaGlassesRegistering => 'Viimeistele yhdistäminen Meta AI -sovelluksessa ja palaa Omiin.';
+
+  @override
+  String get metaGlassesCameraPermission => 'Salli kameran käyttö Meta AI -sovelluksessa';
+
+  @override
+  String get metaGlassesCaptureModeLabel => 'Tallennustila';
+
+  @override
+  String get metaGlassesModeCameraMic => 'Kamera + mikrofoni';
+
+  @override
+  String get metaGlassesModeMicOnly => 'Vain mikrofoni';
+
+  @override
+  String get metaGlassesStartCapture => 'Aloita tallennus';
+
+  @override
+  String get metaGlassesStopCapture => 'Lopeta tallennus';
+
+  @override
+  String get metaGlassesGestureHint => 'Meta-lasien eleohjausta ei tueta tässä koontiversiossa.';
+
+  @override
+  String get connectAnotherDevice => 'Yhdistä toinen laite';
+
+  @override
+  String get myDevices => 'Omat laitteet';
+
+  @override
+  String get metaGlassesAutoCapture => 'Automaattinen tallennus yhdistettäessä';
+
+  @override
+  String get metaGlassesShowPreview => 'Live-esikatselu';
+
+  @override
+  String metaGlassesPendingPhotos(int count) {
+    return '$count kuvaa odottaa synkronointia';
+  }
+
+  @override
+  String get metaGlassesPairInMetaAI => 'Määritä Meta AI -sovelluksessa';
+
+  @override
+  String get metaGlassesTypeRayBanMeta => 'Ray-Ban Meta';
+
+  @override
+  String get metaGlassesTypeRayBanDisplay => 'Meta Ray-Ban Display';
+
+  @override
+  String get metaGlassesTypeOakleyMeta => 'Oakley Meta';
+
+  @override
+  String get metaGlassesOverheating => 'Lasit jäähtyvät — tallennus keskeytetty';
+
+  @override
+  String get metaGlassesFolded => 'Avaa lasit jatkaaksesi tallennusta';
+
+  @override
+  String get metaGlassesCaptureFrequency => 'Kuvaustaajuus';
+
+  @override
+  String get metaGlassesEvery10s => 'Joka 10 s';
+
+  @override
+  String get metaGlassesEvery30s => 'Joka 30 s';
+
+  @override
+  String get metaGlassesEvery1min => 'Joka 1 min';
+
+  @override
+  String get metaGlassesEvery5min => 'Joka 5 min';
+
+  @override
+  String get metaGlassesGestures => 'Eleet';
 }

--- a/app/lib/l10n/app_localizations_fr.dart
+++ b/app/lib/l10n/app_localizations_fr.dart
@@ -9657,4 +9657,96 @@ class AppLocalizationsFr extends AppLocalizations {
   String errorConnectingRayBanMeta(String error) {
     return 'Erreur de connexion aux Ray-Ban Meta : $error';
   }
+
+  @override
+  String get metaGlasses => 'Meta Glasses';
+
+  @override
+  String get pairingTitleMetaGlasses => 'Connectez vos Meta Glasses';
+
+  @override
+  String get pairingDescMetaGlasses =>
+      'Associez vos lunettes dans l\'application Meta AI, puis touchez Connecter dans Omi. Vous pouvez lier plusieurs paires et choisir celle qui est active.';
+
+  @override
+  String get metaGlassesUnavailable =>
+      'Application Meta AI introuvable. Installez Meta AI et activez le mode développeur pour connecter vos lunettes.';
+
+  @override
+  String get metaGlassesRegistering => 'Terminez la connexion dans l\'application Meta AI, puis revenez dans Omi.';
+
+  @override
+  String get metaGlassesCameraPermission => 'Autorisez l\'accès à la caméra dans l\'application Meta AI';
+
+  @override
+  String get metaGlassesCaptureModeLabel => 'Mode de capture';
+
+  @override
+  String get metaGlassesModeCameraMic => 'Caméra + micro';
+
+  @override
+  String get metaGlassesModeMicOnly => 'Micro uniquement';
+
+  @override
+  String get metaGlassesStartCapture => 'Démarrer la capture';
+
+  @override
+  String get metaGlassesStopCapture => 'Arrêter la capture';
+
+  @override
+  String get metaGlassesGestureHint =>
+      'Les commandes gestuelles des lunettes Meta ne sont pas prises en charge dans cette version.';
+
+  @override
+  String get connectAnotherDevice => 'Connecter un autre appareil';
+
+  @override
+  String get myDevices => 'Mes appareils';
+
+  @override
+  String get metaGlassesAutoCapture => 'Capture automatique à la connexion';
+
+  @override
+  String get metaGlassesShowPreview => 'Aperçu en direct';
+
+  @override
+  String metaGlassesPendingPhotos(int count) {
+    return '$count photos en attente de synchronisation';
+  }
+
+  @override
+  String get metaGlassesPairInMetaAI => 'Configurez dans l\'application Meta AI';
+
+  @override
+  String get metaGlassesTypeRayBanMeta => 'Ray-Ban Meta';
+
+  @override
+  String get metaGlassesTypeRayBanDisplay => 'Meta Ray-Ban Display';
+
+  @override
+  String get metaGlassesTypeOakleyMeta => 'Oakley Meta';
+
+  @override
+  String get metaGlassesOverheating => 'Les lunettes refroidissent — capture en pause';
+
+  @override
+  String get metaGlassesFolded => 'Dépliez vos lunettes pour continuer la capture';
+
+  @override
+  String get metaGlassesCaptureFrequency => 'Fréquence de capture';
+
+  @override
+  String get metaGlassesEvery10s => 'Toutes les 10 s';
+
+  @override
+  String get metaGlassesEvery30s => 'Toutes les 30 s';
+
+  @override
+  String get metaGlassesEvery1min => 'Toutes les 1 min';
+
+  @override
+  String get metaGlassesEvery5min => 'Toutes les 5 min';
+
+  @override
+  String get metaGlassesGestures => 'Gestes';
 }

--- a/app/lib/l10n/app_localizations_he.dart
+++ b/app/lib/l10n/app_localizations_he.dart
@@ -9498,4 +9498,95 @@ class AppLocalizationsHe extends AppLocalizations {
   String errorConnectingRayBanMeta(String error) {
     return 'שגיאה בהתחברות ל-Ray-Ban Meta: $error';
   }
+
+  @override
+  String get metaGlasses => 'Meta Glasses';
+
+  @override
+  String get pairingTitleMetaGlasses => 'חברו את משקפי ה-Meta Glasses שלכם';
+
+  @override
+  String get pairingDescMetaGlasses =>
+      'צמדו את המשקפיים באפליקציית Meta AI ואז הקישו על התחברות ב-Omi. אפשר לקשר יותר מזוג אחד ולבחור איזה פעיל.';
+
+  @override
+  String get metaGlassesUnavailable =>
+      'אפליקציית Meta AI לא נמצאה. התקינו את Meta AI והפעילו מצב מפתחים כדי לחבר את המשקפיים.';
+
+  @override
+  String get metaGlassesRegistering => 'השלימו את החיבור באפליקציית Meta AI וחזרו ל-Omi.';
+
+  @override
+  String get metaGlassesCameraPermission => 'אפשרו גישה למצלמה באפליקציית Meta AI';
+
+  @override
+  String get metaGlassesCaptureModeLabel => 'מצב הקלטה';
+
+  @override
+  String get metaGlassesModeCameraMic => 'מצלמה + מיקרופון';
+
+  @override
+  String get metaGlassesModeMicOnly => 'מיקרופון בלבד';
+
+  @override
+  String get metaGlassesStartCapture => 'התחל הקלטה';
+
+  @override
+  String get metaGlassesStopCapture => 'עצור הקלטה';
+
+  @override
+  String get metaGlassesGestureHint => 'פקדי מחוות עבור משקפי Meta אינם נתמכים בגרסה זו.';
+
+  @override
+  String get connectAnotherDevice => 'חיבור מכשיר נוסף';
+
+  @override
+  String get myDevices => 'המכשירים שלי';
+
+  @override
+  String get metaGlassesAutoCapture => 'הקלטה אוטומטית בעת חיבור';
+
+  @override
+  String get metaGlassesShowPreview => 'תצוגה מקדימה חיה';
+
+  @override
+  String metaGlassesPendingPhotos(int count) {
+    return '$count תמונות ממתינות לסנכרון';
+  }
+
+  @override
+  String get metaGlassesPairInMetaAI => 'הגדירו באפליקציית Meta AI';
+
+  @override
+  String get metaGlassesTypeRayBanMeta => 'Ray-Ban Meta';
+
+  @override
+  String get metaGlassesTypeRayBanDisplay => 'Meta Ray-Ban Display';
+
+  @override
+  String get metaGlassesTypeOakleyMeta => 'Oakley Meta';
+
+  @override
+  String get metaGlassesOverheating => 'המשקפיים מתקררים — הצילום הושהה';
+
+  @override
+  String get metaGlassesFolded => 'פתח את המשקפיים כדי להמשיך בצילום';
+
+  @override
+  String get metaGlassesCaptureFrequency => 'תדירות צילום';
+
+  @override
+  String get metaGlassesEvery10s => 'כל 10 שנ\'';
+
+  @override
+  String get metaGlassesEvery30s => 'כל 30 שנ\'';
+
+  @override
+  String get metaGlassesEvery1min => 'כל דקה';
+
+  @override
+  String get metaGlassesEvery5min => 'כל 5 דק\'';
+
+  @override
+  String get metaGlassesGestures => 'מחוות';
 }

--- a/app/lib/l10n/app_localizations_hi.dart
+++ b/app/lib/l10n/app_localizations_hi.dart
@@ -9547,4 +9547,95 @@ class AppLocalizationsHi extends AppLocalizations {
   String errorConnectingRayBanMeta(String error) {
     return 'Ray-Ban Meta से कनेक्ट करने में त्रुटि: $error';
   }
+
+  @override
+  String get metaGlasses => 'Meta Glasses';
+
+  @override
+  String get pairingTitleMetaGlasses => 'अपने Meta Glasses कनेक्ट करें';
+
+  @override
+  String get pairingDescMetaGlasses =>
+      'Meta AI ऐप में अपना चश्मा पेयर करें, फिर Omi में Connect पर टैप करें। आप एक से अधिक जोड़ी लिंक कर सकते हैं और सक्रिय जोड़ी चुन सकते हैं।';
+
+  @override
+  String get metaGlassesUnavailable =>
+      'Meta AI ऐप नहीं मिला। चश्मा कनेक्ट करने के लिए Meta AI इंस्टॉल करें और डेवलपर मोड चालू करें।';
+
+  @override
+  String get metaGlassesRegistering => 'Meta AI ऐप में कनेक्शन पूरा करें, फिर Omi में वापस आएं।';
+
+  @override
+  String get metaGlassesCameraPermission => 'Meta AI ऐप में कैमरा एक्सेस की अनुमति दें';
+
+  @override
+  String get metaGlassesCaptureModeLabel => 'कैप्चर मोड';
+
+  @override
+  String get metaGlassesModeCameraMic => 'कैमरा + माइक';
+
+  @override
+  String get metaGlassesModeMicOnly => 'केवल माइक';
+
+  @override
+  String get metaGlassesStartCapture => 'कैप्चर शुरू करें';
+
+  @override
+  String get metaGlassesStopCapture => 'कैप्चर बंद करें';
+
+  @override
+  String get metaGlassesGestureHint => 'इस बिल्ड में Meta चश्मे के लिए जेस्चर नियंत्रण समर्थित नहीं हैं।';
+
+  @override
+  String get connectAnotherDevice => 'दूसरा डिवाइस कनेक्ट करें';
+
+  @override
+  String get myDevices => 'मेरे डिवाइस';
+
+  @override
+  String get metaGlassesAutoCapture => 'कनेक्ट होने पर ऑटो-कैप्चर';
+
+  @override
+  String get metaGlassesShowPreview => 'लाइव प्रीव्यू';
+
+  @override
+  String metaGlassesPendingPhotos(int count) {
+    return '$count फ़ोटो सिंक की प्रतीक्षा में';
+  }
+
+  @override
+  String get metaGlassesPairInMetaAI => 'Meta AI ऐप में सेट अप करें';
+
+  @override
+  String get metaGlassesTypeRayBanMeta => 'Ray-Ban Meta';
+
+  @override
+  String get metaGlassesTypeRayBanDisplay => 'Meta Ray-Ban Display';
+
+  @override
+  String get metaGlassesTypeOakleyMeta => 'Oakley Meta';
+
+  @override
+  String get metaGlassesOverheating => 'चश्मा ठंडा हो रहा है — कैप्चर रुका हुआ है';
+
+  @override
+  String get metaGlassesFolded => 'कैप्चर जारी रखने के लिए चश्मा खोलें';
+
+  @override
+  String get metaGlassesCaptureFrequency => 'कैप्चर आवृत्ति';
+
+  @override
+  String get metaGlassesEvery10s => 'हर 10 सेकंड';
+
+  @override
+  String get metaGlassesEvery30s => 'हर 30 सेकंड';
+
+  @override
+  String get metaGlassesEvery1min => 'हर 1 मिनट';
+
+  @override
+  String get metaGlassesEvery5min => 'हर 5 मिनट';
+
+  @override
+  String get metaGlassesGestures => 'जेस्चर';
 }

--- a/app/lib/l10n/app_localizations_hr.dart
+++ b/app/lib/l10n/app_localizations_hr.dart
@@ -9604,4 +9604,95 @@ class AppLocalizationsHr extends AppLocalizations {
   String errorConnectingRayBanMeta(String error) {
     return 'Pogreška pri povezivanju s Ray-Ban Meta: $error';
   }
+
+  @override
+  String get metaGlasses => 'Meta Glasses';
+
+  @override
+  String get pairingTitleMetaGlasses => 'Povežite svoje Meta Glasses';
+
+  @override
+  String get pairingDescMetaGlasses =>
+      'Uparite naočale u aplikaciji Meta AI, zatim dodirnite Poveži u Omi. Možete povezati više pari i odabrati koji je aktivan.';
+
+  @override
+  String get metaGlassesUnavailable =>
+      'Aplikacija Meta AI nije pronađena. Instalirajte Meta AI i uključite način rada za razvojne programere kako biste povezali naočale.';
+
+  @override
+  String get metaGlassesRegistering => 'Dovršite povezivanje u aplikaciji Meta AI, a zatim se vratite u Omi.';
+
+  @override
+  String get metaGlassesCameraPermission => 'Dopustite pristup kameri u aplikaciji Meta AI';
+
+  @override
+  String get metaGlassesCaptureModeLabel => 'Način snimanja';
+
+  @override
+  String get metaGlassesModeCameraMic => 'Kamera + mikrofon';
+
+  @override
+  String get metaGlassesModeMicOnly => 'Samo mikrofon';
+
+  @override
+  String get metaGlassesStartCapture => 'Pokreni snimanje';
+
+  @override
+  String get metaGlassesStopCapture => 'Zaustavi snimanje';
+
+  @override
+  String get metaGlassesGestureHint => 'Kontrole gestama za Meta naočale nisu podržane u ovoj verziji.';
+
+  @override
+  String get connectAnotherDevice => 'Poveži drugi uređaj';
+
+  @override
+  String get myDevices => 'Moji uređaji';
+
+  @override
+  String get metaGlassesAutoCapture => 'Automatsko snimanje pri povezivanju';
+
+  @override
+  String get metaGlassesShowPreview => 'Pregled uživo';
+
+  @override
+  String metaGlassesPendingPhotos(int count) {
+    return '$count fotografija čeka sinkronizaciju';
+  }
+
+  @override
+  String get metaGlassesPairInMetaAI => 'Postavite u aplikaciji Meta AI';
+
+  @override
+  String get metaGlassesTypeRayBanMeta => 'Ray-Ban Meta';
+
+  @override
+  String get metaGlassesTypeRayBanDisplay => 'Meta Ray-Ban Display';
+
+  @override
+  String get metaGlassesTypeOakleyMeta => 'Oakley Meta';
+
+  @override
+  String get metaGlassesOverheating => 'Naočale se hlade — snimanje je pauzirano';
+
+  @override
+  String get metaGlassesFolded => 'Rasklopite naočale za nastavak snimanja';
+
+  @override
+  String get metaGlassesCaptureFrequency => 'Učestalost snimanja';
+
+  @override
+  String get metaGlassesEvery10s => 'Svakih 10 s';
+
+  @override
+  String get metaGlassesEvery30s => 'Svakih 30 s';
+
+  @override
+  String get metaGlassesEvery1min => 'Svake 1 min';
+
+  @override
+  String get metaGlassesEvery5min => 'Svakih 5 min';
+
+  @override
+  String get metaGlassesGestures => 'Geste';
 }

--- a/app/lib/l10n/app_localizations_hu.dart
+++ b/app/lib/l10n/app_localizations_hu.dart
@@ -9611,4 +9611,95 @@ class AppLocalizationsHu extends AppLocalizations {
   String errorConnectingRayBanMeta(String error) {
     return 'Hiba a Ray-Ban Meta csatlakoztatásakor: $error';
   }
+
+  @override
+  String get metaGlasses => 'Meta Glasses';
+
+  @override
+  String get pairingTitleMetaGlasses => 'Csatlakoztasd a Meta Glasses szemüvegedet';
+
+  @override
+  String get pairingDescMetaGlasses =>
+      'Párosítsd a szemüveget a Meta AI alkalmazásban, majd koppints a Csatlakozás gombra az Omiban. Több szemüveget is összekapcsolhatsz, és kiválaszthatod az aktívat.';
+
+  @override
+  String get metaGlassesUnavailable =>
+      'A Meta AI alkalmazás nem található. A szemüveg csatlakoztatásához telepítsd a Meta AI-t, és kapcsold be a fejlesztői módot.';
+
+  @override
+  String get metaGlassesRegistering => 'Fejezd be a csatlakozást a Meta AI alkalmazásban, majd térj vissza az Omiba.';
+
+  @override
+  String get metaGlassesCameraPermission => 'Engedélyezd a kamera-hozzáférést a Meta AI alkalmazásban';
+
+  @override
+  String get metaGlassesCaptureModeLabel => 'Rögzítési mód';
+
+  @override
+  String get metaGlassesModeCameraMic => 'Kamera + mikrofon';
+
+  @override
+  String get metaGlassesModeMicOnly => 'Csak mikrofon';
+
+  @override
+  String get metaGlassesStartCapture => 'Rögzítés indítása';
+
+  @override
+  String get metaGlassesStopCapture => 'Rögzítés leállítása';
+
+  @override
+  String get metaGlassesGestureHint => 'A Meta szemüveg gesztusvezérlése ebben a buildben nem támogatott.';
+
+  @override
+  String get connectAnotherDevice => 'Másik eszköz csatlakoztatása';
+
+  @override
+  String get myDevices => 'Eszközeim';
+
+  @override
+  String get metaGlassesAutoCapture => 'Automatikus rögzítés csatlakozáskor';
+
+  @override
+  String get metaGlassesShowPreview => 'Élő előnézet';
+
+  @override
+  String metaGlassesPendingPhotos(int count) {
+    return '$count fotó vár szinkronizálásra';
+  }
+
+  @override
+  String get metaGlassesPairInMetaAI => 'Állítsd be a Meta AI alkalmazásban';
+
+  @override
+  String get metaGlassesTypeRayBanMeta => 'Ray-Ban Meta';
+
+  @override
+  String get metaGlassesTypeRayBanDisplay => 'Meta Ray-Ban Display';
+
+  @override
+  String get metaGlassesTypeOakleyMeta => 'Oakley Meta';
+
+  @override
+  String get metaGlassesOverheating => 'A szemüveg hűl — a rögzítés szünetel';
+
+  @override
+  String get metaGlassesFolded => 'Hajtsd ki a szemüveget a rögzítés folytatásához';
+
+  @override
+  String get metaGlassesCaptureFrequency => 'Rögzítési gyakoriság';
+
+  @override
+  String get metaGlassesEvery10s => '10 mp-enként';
+
+  @override
+  String get metaGlassesEvery30s => '30 mp-enként';
+
+  @override
+  String get metaGlassesEvery1min => '1 percenként';
+
+  @override
+  String get metaGlassesEvery5min => '5 percenként';
+
+  @override
+  String get metaGlassesGestures => 'Gesztusok';
 }

--- a/app/lib/l10n/app_localizations_id.dart
+++ b/app/lib/l10n/app_localizations_id.dart
@@ -9580,4 +9580,95 @@ class AppLocalizationsId extends AppLocalizations {
   String errorConnectingRayBanMeta(String error) {
     return 'Kesalahan saat menghubungkan ke Ray-Ban Meta: $error';
   }
+
+  @override
+  String get metaGlasses => 'Meta Glasses';
+
+  @override
+  String get pairingTitleMetaGlasses => 'Hubungkan Meta Glasses Anda';
+
+  @override
+  String get pairingDescMetaGlasses =>
+      'Sandingkan kacamata di aplikasi Meta AI, lalu ketuk Hubungkan di Omi. Anda dapat menautkan lebih dari satu pasang dan memilih yang aktif.';
+
+  @override
+  String get metaGlassesUnavailable =>
+      'Aplikasi Meta AI tidak ditemukan. Instal Meta AI dan aktifkan Mode Pengembang untuk menghubungkan kacamata Anda.';
+
+  @override
+  String get metaGlassesRegistering => 'Selesaikan penghubungan di aplikasi Meta AI, lalu kembali ke Omi.';
+
+  @override
+  String get metaGlassesCameraPermission => 'Izinkan akses kamera di aplikasi Meta AI';
+
+  @override
+  String get metaGlassesCaptureModeLabel => 'Mode perekaman';
+
+  @override
+  String get metaGlassesModeCameraMic => 'Kamera + mikrofon';
+
+  @override
+  String get metaGlassesModeMicOnly => 'Hanya mikrofon';
+
+  @override
+  String get metaGlassesStartCapture => 'Mulai merekam';
+
+  @override
+  String get metaGlassesStopCapture => 'Berhenti merekam';
+
+  @override
+  String get metaGlassesGestureHint => 'Kontrol gestur untuk kacamata Meta tidak didukung dalam build ini.';
+
+  @override
+  String get connectAnotherDevice => 'Hubungkan perangkat lain';
+
+  @override
+  String get myDevices => 'Perangkat Saya';
+
+  @override
+  String get metaGlassesAutoCapture => 'Rekam otomatis saat terhubung';
+
+  @override
+  String get metaGlassesShowPreview => 'Pratinjau langsung';
+
+  @override
+  String metaGlassesPendingPhotos(int count) {
+    return '$count foto menunggu sinkronisasi';
+  }
+
+  @override
+  String get metaGlassesPairInMetaAI => 'Siapkan di aplikasi Meta AI';
+
+  @override
+  String get metaGlassesTypeRayBanMeta => 'Ray-Ban Meta';
+
+  @override
+  String get metaGlassesTypeRayBanDisplay => 'Meta Ray-Ban Display';
+
+  @override
+  String get metaGlassesTypeOakleyMeta => 'Oakley Meta';
+
+  @override
+  String get metaGlassesOverheating => 'Kacamata sedang mendingin — perekaman dijeda';
+
+  @override
+  String get metaGlassesFolded => 'Buka lipatan kacamata untuk terus merekam';
+
+  @override
+  String get metaGlassesCaptureFrequency => 'Frekuensi tangkapan';
+
+  @override
+  String get metaGlassesEvery10s => 'Setiap 10 dtk';
+
+  @override
+  String get metaGlassesEvery30s => 'Setiap 30 dtk';
+
+  @override
+  String get metaGlassesEvery1min => 'Setiap 1 mnt';
+
+  @override
+  String get metaGlassesEvery5min => 'Setiap 5 mnt';
+
+  @override
+  String get metaGlassesGestures => 'Gestur';
 }

--- a/app/lib/l10n/app_localizations_it.dart
+++ b/app/lib/l10n/app_localizations_it.dart
@@ -9627,4 +9627,96 @@ class AppLocalizationsIt extends AppLocalizations {
   String errorConnectingRayBanMeta(String error) {
     return 'Errore di connessione a Ray-Ban Meta: $error';
   }
+
+  @override
+  String get metaGlasses => 'Meta Glasses';
+
+  @override
+  String get pairingTitleMetaGlasses => 'Collega i tuoi Meta Glasses';
+
+  @override
+  String get pairingDescMetaGlasses =>
+      'Associa gli occhiali nell\'app Meta AI, poi tocca Connetti in Omi. Puoi collegare più paia e scegliere quale è attivo.';
+
+  @override
+  String get metaGlassesUnavailable =>
+      'App Meta AI non trovata. Installa Meta AI e attiva la modalità sviluppatore per collegare gli occhiali.';
+
+  @override
+  String get metaGlassesRegistering => 'Completa la connessione nell\'app Meta AI, poi torna su Omi.';
+
+  @override
+  String get metaGlassesCameraPermission => 'Consenti l\'accesso alla fotocamera nell\'app Meta AI';
+
+  @override
+  String get metaGlassesCaptureModeLabel => 'Modalità di acquisizione';
+
+  @override
+  String get metaGlassesModeCameraMic => 'Fotocamera + microfono';
+
+  @override
+  String get metaGlassesModeMicOnly => 'Solo microfono';
+
+  @override
+  String get metaGlassesStartCapture => 'Avvia acquisizione';
+
+  @override
+  String get metaGlassesStopCapture => 'Ferma acquisizione';
+
+  @override
+  String get metaGlassesGestureHint =>
+      'I controlli gestuali per gli occhiali Meta non sono supportati in questa build.';
+
+  @override
+  String get connectAnotherDevice => 'Collega un altro dispositivo';
+
+  @override
+  String get myDevices => 'I miei dispositivi';
+
+  @override
+  String get metaGlassesAutoCapture => 'Acquisizione automatica alla connessione';
+
+  @override
+  String get metaGlassesShowPreview => 'Anteprima dal vivo';
+
+  @override
+  String metaGlassesPendingPhotos(int count) {
+    return '$count foto in attesa di sincronizzazione';
+  }
+
+  @override
+  String get metaGlassesPairInMetaAI => 'Configura nell\'app Meta AI';
+
+  @override
+  String get metaGlassesTypeRayBanMeta => 'Ray-Ban Meta';
+
+  @override
+  String get metaGlassesTypeRayBanDisplay => 'Meta Ray-Ban Display';
+
+  @override
+  String get metaGlassesTypeOakleyMeta => 'Oakley Meta';
+
+  @override
+  String get metaGlassesOverheating => 'Gli occhiali si stanno raffreddando — acquisizione in pausa';
+
+  @override
+  String get metaGlassesFolded => 'Apri gli occhiali per continuare l\'acquisizione';
+
+  @override
+  String get metaGlassesCaptureFrequency => 'Frequenza di acquisizione';
+
+  @override
+  String get metaGlassesEvery10s => 'Ogni 10 s';
+
+  @override
+  String get metaGlassesEvery30s => 'Ogni 30 s';
+
+  @override
+  String get metaGlassesEvery1min => 'Ogni 1 min';
+
+  @override
+  String get metaGlassesEvery5min => 'Ogni 5 min';
+
+  @override
+  String get metaGlassesGestures => 'Gesti';
 }

--- a/app/lib/l10n/app_localizations_ja.dart
+++ b/app/lib/l10n/app_localizations_ja.dart
@@ -9413,4 +9413,93 @@ class AppLocalizationsJa extends AppLocalizations {
   String errorConnectingRayBanMeta(String error) {
     return 'Ray-Ban Meta への接続エラー: $error';
   }
+
+  @override
+  String get metaGlasses => 'Meta Glasses';
+
+  @override
+  String get pairingTitleMetaGlasses => 'Meta Glassesを接続';
+
+  @override
+  String get pairingDescMetaGlasses => 'Meta AIアプリでグラスをペアリングしてから、Omiで「接続」をタップしてください。複数のグラスをリンクして、アクティブなものを選択できます。';
+
+  @override
+  String get metaGlassesUnavailable => 'Meta AIアプリが見つかりません。グラスを接続するには、Meta AIをインストールして開発者モードを有効にしてください。';
+
+  @override
+  String get metaGlassesRegistering => 'Meta AIアプリで接続を完了してから、Omiに戻ってください。';
+
+  @override
+  String get metaGlassesCameraPermission => 'Meta AIアプリでカメラへのアクセスを許可してください';
+
+  @override
+  String get metaGlassesCaptureModeLabel => 'キャプチャモード';
+
+  @override
+  String get metaGlassesModeCameraMic => 'カメラ + マイク';
+
+  @override
+  String get metaGlassesModeMicOnly => 'マイクのみ';
+
+  @override
+  String get metaGlassesStartCapture => 'キャプチャ開始';
+
+  @override
+  String get metaGlassesStopCapture => 'キャプチャ停止';
+
+  @override
+  String get metaGlassesGestureHint => 'このビルドではMetaグラスのジェスチャー操作はサポートされていません。';
+
+  @override
+  String get connectAnotherDevice => '別のデバイスを接続';
+
+  @override
+  String get myDevices => 'マイデバイス';
+
+  @override
+  String get metaGlassesAutoCapture => '接続時に自動キャプチャ';
+
+  @override
+  String get metaGlassesShowPreview => 'ライブプレビュー';
+
+  @override
+  String metaGlassesPendingPhotos(int count) {
+    return '$count枚の写真が同期待ちです';
+  }
+
+  @override
+  String get metaGlassesPairInMetaAI => 'Meta AIアプリで設定してください';
+
+  @override
+  String get metaGlassesTypeRayBanMeta => 'Ray-Ban Meta';
+
+  @override
+  String get metaGlassesTypeRayBanDisplay => 'Meta Ray-Ban Display';
+
+  @override
+  String get metaGlassesTypeOakleyMeta => 'Oakley Meta';
+
+  @override
+  String get metaGlassesOverheating => 'メガネを冷却中です — キャプチャを一時停止しました';
+
+  @override
+  String get metaGlassesFolded => 'キャプチャを続けるにはメガネを開いてください';
+
+  @override
+  String get metaGlassesCaptureFrequency => '撮影間隔';
+
+  @override
+  String get metaGlassesEvery10s => '10秒ごと';
+
+  @override
+  String get metaGlassesEvery30s => '30秒ごと';
+
+  @override
+  String get metaGlassesEvery1min => '1分ごと';
+
+  @override
+  String get metaGlassesEvery5min => '5分ごと';
+
+  @override
+  String get metaGlassesGestures => 'ジェスチャー';
 }

--- a/app/lib/l10n/app_localizations_kn.dart
+++ b/app/lib/l10n/app_localizations_kn.dart
@@ -9601,4 +9601,95 @@ class AppLocalizationsKn extends AppLocalizations {
   String errorConnectingRayBanMeta(String error) {
     return 'Ray-Ban Meta ಗೆ ಸಂಪರ್ಕಿಸುವಲ್ಲಿ ದೋಷ: $error';
   }
+
+  @override
+  String get metaGlasses => 'Meta Glasses';
+
+  @override
+  String get pairingTitleMetaGlasses => 'ನಿಮ್ಮ Meta Glasses ಸಂಪರ್ಕಿಸಿ';
+
+  @override
+  String get pairingDescMetaGlasses =>
+      'Meta AI ಆ್ಯಪ್‌ನಲ್ಲಿ ನಿಮ್ಮ ಕನ್ನಡಕವನ್ನು ಜೋಡಿಸಿ, ನಂತರ Omi ನಲ್ಲಿ Connect ಟ್ಯಾಪ್ ಮಾಡಿ. ಒಂದಕ್ಕಿಂತ ಹೆಚ್ಚು ಜೋಡಿಗಳನ್ನು ಲಿಂಕ್ ಮಾಡಿ ಸಕ್ರಿಯವಾದದ್ದನ್ನು ಆಯ್ಕೆ ಮಾಡಬಹುದು.';
+
+  @override
+  String get metaGlassesUnavailable =>
+      'Meta AI ಆ್ಯಪ್ ಪತ್ತೆಯಾಗಿಲ್ಲ. ಕನ್ನಡಕ ಸಂಪರ್ಕಿಸಲು Meta AI ಇನ್‌ಸ್ಟಾಲ್ ಮಾಡಿ ಮತ್ತು ಡೆವಲಪರ್ ಮೋಡ್ ಸಕ್ರಿಯಗೊಳಿಸಿ.';
+
+  @override
+  String get metaGlassesRegistering => 'Meta AI ಆ್ಯಪ್‌ನಲ್ಲಿ ಸಂಪರ್ಕವನ್ನು ಪೂರ್ಣಗೊಳಿಸಿ, ನಂತರ Omi ಗೆ ಹಿಂತಿರುಗಿ.';
+
+  @override
+  String get metaGlassesCameraPermission => 'Meta AI ಆ್ಯಪ್‌ನಲ್ಲಿ ಕ್ಯಾಮೆರಾ ಪ್ರವೇಶವನ್ನು ಅನುಮತಿಸಿ';
+
+  @override
+  String get metaGlassesCaptureModeLabel => 'ಕ್ಯಾಪ್ಚರ್ ಮೋಡ್';
+
+  @override
+  String get metaGlassesModeCameraMic => 'ಕ್ಯಾಮೆರಾ + ಮೈಕ್';
+
+  @override
+  String get metaGlassesModeMicOnly => 'ಮೈಕ್ ಮಾತ್ರ';
+
+  @override
+  String get metaGlassesStartCapture => 'ಕ್ಯಾಪ್ಚರ್ ಪ್ರಾರಂಭಿಸಿ';
+
+  @override
+  String get metaGlassesStopCapture => 'ಕ್ಯಾಪ್ಚರ್ ನಿಲ್ಲಿಸಿ';
+
+  @override
+  String get metaGlassesGestureHint => 'ಈ ಬಿಲ್ಡ್‌ನಲ್ಲಿ Meta ಕನ್ನಡಕಗಳಿಗಾಗಿ ಸಂಜ್ಞೆ ನಿಯಂತ್ರಣಗಳಿಗೆ ಬೆಂಬಲವಿಲ್ಲ.';
+
+  @override
+  String get connectAnotherDevice => 'ಇನ್ನೊಂದು ಸಾಧನವನ್ನು ಸಂಪರ್ಕಿಸಿ';
+
+  @override
+  String get myDevices => 'ನನ್ನ ಸಾಧನಗಳು';
+
+  @override
+  String get metaGlassesAutoCapture => 'ಸಂಪರ್ಕಗೊಂಡಾಗ ಸ್ವಯಂ ಕ್ಯಾಪ್ಚರ್';
+
+  @override
+  String get metaGlassesShowPreview => 'ಲೈವ್ ಪೂರ್ವವೀಕ್ಷಣೆ';
+
+  @override
+  String metaGlassesPendingPhotos(int count) {
+    return '$count ಫೋಟೋಗಳು ಸಿಂಕ್‌ಗಾಗಿ ಕಾಯುತ್ತಿವೆ';
+  }
+
+  @override
+  String get metaGlassesPairInMetaAI => 'Meta AI ಆ್ಯಪ್‌ನಲ್ಲಿ ಹೊಂದಿಸಿ';
+
+  @override
+  String get metaGlassesTypeRayBanMeta => 'Ray-Ban Meta';
+
+  @override
+  String get metaGlassesTypeRayBanDisplay => 'Meta Ray-Ban Display';
+
+  @override
+  String get metaGlassesTypeOakleyMeta => 'Oakley Meta';
+
+  @override
+  String get metaGlassesOverheating => 'ಗ್ಲಾಸ್ ತಂಪಾಗುತ್ತಿದೆ — ಕ್ಯಾಪ್ಚರ್ ವಿರಾಮದಲ್ಲಿದೆ';
+
+  @override
+  String get metaGlassesFolded => 'ಕ್ಯಾಪ್ಚರ್ ಮುಂದುವರಿಸಲು ಗ್ಲಾಸ್ ತೆರೆದು ಹಾಕಿ';
+
+  @override
+  String get metaGlassesCaptureFrequency => 'ಕ್ಯಾಪ್ಚರ್ ಆವರ್ತನ';
+
+  @override
+  String get metaGlassesEvery10s => 'ಪ್ರತಿ 10 ಸೆ';
+
+  @override
+  String get metaGlassesEvery30s => 'ಪ್ರತಿ 30 ಸೆ';
+
+  @override
+  String get metaGlassesEvery1min => 'ಪ್ರತಿ 1 ನಿ';
+
+  @override
+  String get metaGlassesEvery5min => 'ಪ್ರತಿ 5 ನಿ';
+
+  @override
+  String get metaGlassesGestures => 'ಗೆಸ್ಚರ್‌ಗಳು';
 }

--- a/app/lib/l10n/app_localizations_ko.dart
+++ b/app/lib/l10n/app_localizations_ko.dart
@@ -9414,4 +9414,93 @@ class AppLocalizationsKo extends AppLocalizations {
   String errorConnectingRayBanMeta(String error) {
     return 'Ray-Ban Meta 연결 오류: $error';
   }
+
+  @override
+  String get metaGlasses => 'Meta Glasses';
+
+  @override
+  String get pairingTitleMetaGlasses => 'Meta Glasses 연결하기';
+
+  @override
+  String get pairingDescMetaGlasses => 'Meta AI 앱에서 글래스를 페어링한 다음 Omi에서 연결을 탭하세요. 여러 개를 연결하고 활성 글래스를 선택할 수 있습니다.';
+
+  @override
+  String get metaGlassesUnavailable => 'Meta AI 앱을 찾을 수 없습니다. 글래스를 연결하려면 Meta AI를 설치하고 개발자 모드를 활성화하세요.';
+
+  @override
+  String get metaGlassesRegistering => 'Meta AI 앱에서 연결을 완료한 후 Omi로 돌아오세요.';
+
+  @override
+  String get metaGlassesCameraPermission => 'Meta AI 앱에서 카메라 접근을 허용하세요';
+
+  @override
+  String get metaGlassesCaptureModeLabel => '캡처 모드';
+
+  @override
+  String get metaGlassesModeCameraMic => '카메라 + 마이크';
+
+  @override
+  String get metaGlassesModeMicOnly => '마이크만';
+
+  @override
+  String get metaGlassesStartCapture => '캡처 시작';
+
+  @override
+  String get metaGlassesStopCapture => '캡처 중지';
+
+  @override
+  String get metaGlassesGestureHint => '이 빌드에서는 Meta 글래스의 제스처 제어가 지원되지 않습니다.';
+
+  @override
+  String get connectAnotherDevice => '다른 기기 연결';
+
+  @override
+  String get myDevices => '내 기기';
+
+  @override
+  String get metaGlassesAutoCapture => '연결 시 자동 캡처';
+
+  @override
+  String get metaGlassesShowPreview => '실시간 미리보기';
+
+  @override
+  String metaGlassesPendingPhotos(int count) {
+    return '$count장의 사진이 동기화 대기 중';
+  }
+
+  @override
+  String get metaGlassesPairInMetaAI => 'Meta AI 앱에서 설정하세요';
+
+  @override
+  String get metaGlassesTypeRayBanMeta => 'Ray-Ban Meta';
+
+  @override
+  String get metaGlassesTypeRayBanDisplay => 'Meta Ray-Ban Display';
+
+  @override
+  String get metaGlassesTypeOakleyMeta => 'Oakley Meta';
+
+  @override
+  String get metaGlassesOverheating => '안경이 식는 중입니다 — 캡처가 일시 중지됨';
+
+  @override
+  String get metaGlassesFolded => '캡처를 계속하려면 안경을 펼치세요';
+
+  @override
+  String get metaGlassesCaptureFrequency => '캡처 주기';
+
+  @override
+  String get metaGlassesEvery10s => '10초마다';
+
+  @override
+  String get metaGlassesEvery30s => '30초마다';
+
+  @override
+  String get metaGlassesEvery1min => '1분마다';
+
+  @override
+  String get metaGlassesEvery5min => '5분마다';
+
+  @override
+  String get metaGlassesGestures => '제스처';
 }

--- a/app/lib/l10n/app_localizations_lt.dart
+++ b/app/lib/l10n/app_localizations_lt.dart
@@ -9587,4 +9587,95 @@ class AppLocalizationsLt extends AppLocalizations {
   String errorConnectingRayBanMeta(String error) {
     return 'Klaida jungiantis prie Ray-Ban Meta: $error';
   }
+
+  @override
+  String get metaGlasses => 'Meta Glasses';
+
+  @override
+  String get pairingTitleMetaGlasses => 'Prijunkite savo Meta Glasses';
+
+  @override
+  String get pairingDescMetaGlasses =>
+      'Susiekite akinius programoje „Meta AI“, tada Omi palieskite „Prijungti“. Galite susieti kelias poras ir pasirinkti, kuri aktyvi.';
+
+  @override
+  String get metaGlassesUnavailable =>
+      'Programa „Meta AI“ nerasta. Norėdami prijungti akinius, įdiekite „Meta AI“ ir įjunkite kūrėjo režimą.';
+
+  @override
+  String get metaGlassesRegistering => 'Užbaikite prijungimą programoje „Meta AI“ ir grįžkite į Omi.';
+
+  @override
+  String get metaGlassesCameraPermission => 'Leiskite prieigą prie kameros programoje „Meta AI“';
+
+  @override
+  String get metaGlassesCaptureModeLabel => 'Fiksavimo režimas';
+
+  @override
+  String get metaGlassesModeCameraMic => 'Kamera + mikrofonas';
+
+  @override
+  String get metaGlassesModeMicOnly => 'Tik mikrofonas';
+
+  @override
+  String get metaGlassesStartCapture => 'Pradėti fiksavimą';
+
+  @override
+  String get metaGlassesStopCapture => 'Sustabdyti fiksavimą';
+
+  @override
+  String get metaGlassesGestureHint => 'Gestų valdikliai Meta akiniams šiame leidime nepalaikomi.';
+
+  @override
+  String get connectAnotherDevice => 'Prijungti kitą įrenginį';
+
+  @override
+  String get myDevices => 'Mano įrenginiai';
+
+  @override
+  String get metaGlassesAutoCapture => 'Automatinis fiksavimas prisijungus';
+
+  @override
+  String get metaGlassesShowPreview => 'Tiesioginė peržiūra';
+
+  @override
+  String metaGlassesPendingPhotos(int count) {
+    return '$count nuotraukos laukia sinchronizavimo';
+  }
+
+  @override
+  String get metaGlassesPairInMetaAI => 'Nustatykite programoje „Meta AI“';
+
+  @override
+  String get metaGlassesTypeRayBanMeta => 'Ray-Ban Meta';
+
+  @override
+  String get metaGlassesTypeRayBanDisplay => 'Meta Ray-Ban Display';
+
+  @override
+  String get metaGlassesTypeOakleyMeta => 'Oakley Meta';
+
+  @override
+  String get metaGlassesOverheating => 'Akiniai vėsta — fiksavimas pristabdytas';
+
+  @override
+  String get metaGlassesFolded => 'Išskleiskite akinius, kad fiksavimas tęstųsi';
+
+  @override
+  String get metaGlassesCaptureFrequency => 'Fiksavimo dažnis';
+
+  @override
+  String get metaGlassesEvery10s => 'Kas 10 s';
+
+  @override
+  String get metaGlassesEvery30s => 'Kas 30 s';
+
+  @override
+  String get metaGlassesEvery1min => 'Kas 1 min';
+
+  @override
+  String get metaGlassesEvery5min => 'Kas 5 min';
+
+  @override
+  String get metaGlassesGestures => 'Gestai';
 }

--- a/app/lib/l10n/app_localizations_lv.dart
+++ b/app/lib/l10n/app_localizations_lv.dart
@@ -9592,4 +9592,95 @@ class AppLocalizationsLv extends AppLocalizations {
   String errorConnectingRayBanMeta(String error) {
     return 'Kļūda, veidojot savienojumu ar Ray-Ban Meta: $error';
   }
+
+  @override
+  String get metaGlasses => 'Meta Glasses';
+
+  @override
+  String get pairingTitleMetaGlasses => 'Savienojiet savas Meta Glasses';
+
+  @override
+  String get pairingDescMetaGlasses =>
+      'Sapārojiet brilles lietotnē Meta AI, pēc tam Omi pieskarieties Savienot. Varat sasaistīt vairākus pārus un izvēlēties aktīvo.';
+
+  @override
+  String get metaGlassesUnavailable =>
+      'Lietotne Meta AI nav atrasta. Lai savienotu brilles, instalējiet Meta AI un ieslēdziet izstrādātāja režīmu.';
+
+  @override
+  String get metaGlassesRegistering => 'Pabeidziet savienošanu lietotnē Meta AI un atgriezieties Omi.';
+
+  @override
+  String get metaGlassesCameraPermission => 'Atļaujiet piekļuvi kamerai lietotnē Meta AI';
+
+  @override
+  String get metaGlassesCaptureModeLabel => 'Tveršanas režīms';
+
+  @override
+  String get metaGlassesModeCameraMic => 'Kamera + mikrofons';
+
+  @override
+  String get metaGlassesModeMicOnly => 'Tikai mikrofons';
+
+  @override
+  String get metaGlassesStartCapture => 'Sākt tveršanu';
+
+  @override
+  String get metaGlassesStopCapture => 'Apturēt tveršanu';
+
+  @override
+  String get metaGlassesGestureHint => 'Žestu vadība Meta brillēm šajā būvējumā netiek atbalstīta.';
+
+  @override
+  String get connectAnotherDevice => 'Savienot citu ierīci';
+
+  @override
+  String get myDevices => 'Manas ierīces';
+
+  @override
+  String get metaGlassesAutoCapture => 'Automātiska tveršana pēc savienošanas';
+
+  @override
+  String get metaGlassesShowPreview => 'Tiešais priekšskatījums';
+
+  @override
+  String metaGlassesPendingPhotos(int count) {
+    return '$count fotoattēli gaida sinhronizāciju';
+  }
+
+  @override
+  String get metaGlassesPairInMetaAI => 'Iestatiet lietotnē Meta AI';
+
+  @override
+  String get metaGlassesTypeRayBanMeta => 'Ray-Ban Meta';
+
+  @override
+  String get metaGlassesTypeRayBanDisplay => 'Meta Ray-Ban Display';
+
+  @override
+  String get metaGlassesTypeOakleyMeta => 'Oakley Meta';
+
+  @override
+  String get metaGlassesOverheating => 'Brilles atdziest — tveršana apturēta';
+
+  @override
+  String get metaGlassesFolded => 'Atlokiet brilles, lai turpinātu tveršanu';
+
+  @override
+  String get metaGlassesCaptureFrequency => 'Uzņemšanas biežums';
+
+  @override
+  String get metaGlassesEvery10s => 'Ik pēc 10 s';
+
+  @override
+  String get metaGlassesEvery30s => 'Ik pēc 30 s';
+
+  @override
+  String get metaGlassesEvery1min => 'Ik pēc 1 min';
+
+  @override
+  String get metaGlassesEvery5min => 'Ik pēc 5 min';
+
+  @override
+  String get metaGlassesGestures => 'Žesti';
 }

--- a/app/lib/l10n/app_localizations_mk.dart
+++ b/app/lib/l10n/app_localizations_mk.dart
@@ -9622,4 +9622,95 @@ class AppLocalizationsMk extends AppLocalizations {
   String errorConnectingRayBanMeta(String error) {
     return 'Грешка при поврзување со Ray-Ban Meta: $error';
   }
+
+  @override
+  String get metaGlasses => 'Meta Glasses';
+
+  @override
+  String get pairingTitleMetaGlasses => 'Поврзете ги вашите Meta Glasses';
+
+  @override
+  String get pairingDescMetaGlasses =>
+      'Спарете ги очилата во апликацијата Meta AI, а потоа допрете Поврзи во Omi. Може да поврзете повеќе пара и да изберете кој е активен.';
+
+  @override
+  String get metaGlassesUnavailable =>
+      'Апликацијата Meta AI не е пронајдена. Инсталирајте Meta AI и вклучете режим за програмери за да ги поврзете очилата.';
+
+  @override
+  String get metaGlassesRegistering => 'Завршете го поврзувањето во апликацијата Meta AI и вратете се во Omi.';
+
+  @override
+  String get metaGlassesCameraPermission => 'Дозволете пристап до камерата во апликацијата Meta AI';
+
+  @override
+  String get metaGlassesCaptureModeLabel => 'Режим на снимање';
+
+  @override
+  String get metaGlassesModeCameraMic => 'Камера + микрофон';
+
+  @override
+  String get metaGlassesModeMicOnly => 'Само микрофон';
+
+  @override
+  String get metaGlassesStartCapture => 'Започни снимање';
+
+  @override
+  String get metaGlassesStopCapture => 'Запри снимање';
+
+  @override
+  String get metaGlassesGestureHint => 'Контролите со гестови за Meta очилата не се поддржани во оваа верзија.';
+
+  @override
+  String get connectAnotherDevice => 'Поврзи друг уред';
+
+  @override
+  String get myDevices => 'Мои уреди';
+
+  @override
+  String get metaGlassesAutoCapture => 'Автоматско снимање при поврзување';
+
+  @override
+  String get metaGlassesShowPreview => 'Преглед во живо';
+
+  @override
+  String metaGlassesPendingPhotos(int count) {
+    return '$count фотографии чекаат синхронизација';
+  }
+
+  @override
+  String get metaGlassesPairInMetaAI => 'Поставете во апликацијата Meta AI';
+
+  @override
+  String get metaGlassesTypeRayBanMeta => 'Ray-Ban Meta';
+
+  @override
+  String get metaGlassesTypeRayBanDisplay => 'Meta Ray-Ban Display';
+
+  @override
+  String get metaGlassesTypeOakleyMeta => 'Oakley Meta';
+
+  @override
+  String get metaGlassesOverheating => 'Очилата се ладат — снимањето е паузирано';
+
+  @override
+  String get metaGlassesFolded => 'Расклопете ги очилата за да продолжи снимањето';
+
+  @override
+  String get metaGlassesCaptureFrequency => 'Честота на снимање';
+
+  @override
+  String get metaGlassesEvery10s => 'На секои 10 с';
+
+  @override
+  String get metaGlassesEvery30s => 'На секои 30 с';
+
+  @override
+  String get metaGlassesEvery1min => 'На секоја 1 мин';
+
+  @override
+  String get metaGlassesEvery5min => 'На секои 5 мин';
+
+  @override
+  String get metaGlassesGestures => 'Гестови';
 }

--- a/app/lib/l10n/app_localizations_mr.dart
+++ b/app/lib/l10n/app_localizations_mr.dart
@@ -9579,4 +9579,95 @@ class AppLocalizationsMr extends AppLocalizations {
   String errorConnectingRayBanMeta(String error) {
     return 'Ray-Ban Meta शी कनेक्ट करताना त्रुटी: $error';
   }
+
+  @override
+  String get metaGlasses => 'Meta Glasses';
+
+  @override
+  String get pairingTitleMetaGlasses => 'तुमचे Meta Glasses कनेक्ट करा';
+
+  @override
+  String get pairingDescMetaGlasses =>
+      'Meta AI अ‍ॅपमध्ये तुमचा चष्मा पेअर करा, नंतर Omi मध्ये Connect वर टॅप करा. तुम्ही एकाहून अधिक जोड्या लिंक करू शकता आणि सक्रिय जोडी निवडू शकता.';
+
+  @override
+  String get metaGlassesUnavailable =>
+      'Meta AI अ‍ॅप आढळले नाही. चष्मा कनेक्ट करण्यासाठी Meta AI इन्स्टॉल करा आणि डेव्हलपर मोड सुरू करा.';
+
+  @override
+  String get metaGlassesRegistering => 'Meta AI अ‍ॅपमध्ये कनेक्शन पूर्ण करा, नंतर Omi मध्ये परत या.';
+
+  @override
+  String get metaGlassesCameraPermission => 'Meta AI अ‍ॅपमध्ये कॅमेरा अ‍ॅक्सेसला परवानगी द्या';
+
+  @override
+  String get metaGlassesCaptureModeLabel => 'कॅप्चर मोड';
+
+  @override
+  String get metaGlassesModeCameraMic => 'कॅमेरा + माइक';
+
+  @override
+  String get metaGlassesModeMicOnly => 'फक्त माइक';
+
+  @override
+  String get metaGlassesStartCapture => 'कॅप्चर सुरू करा';
+
+  @override
+  String get metaGlassesStopCapture => 'कॅप्चर थांबवा';
+
+  @override
+  String get metaGlassesGestureHint => 'या बिल्डमध्ये Meta चष्म्यांसाठी जेश्चर नियंत्रणे समर्थित नाहीत.';
+
+  @override
+  String get connectAnotherDevice => 'दुसरे डिव्हाइस कनेक्ट करा';
+
+  @override
+  String get myDevices => 'माझी डिव्हाइसेस';
+
+  @override
+  String get metaGlassesAutoCapture => 'कनेक्ट झाल्यावर स्वयं-कॅप्चर';
+
+  @override
+  String get metaGlassesShowPreview => 'लाइव्ह पूर्वावलोकन';
+
+  @override
+  String metaGlassesPendingPhotos(int count) {
+    return '$count फोटो सिंकच्या प्रतीक्षेत';
+  }
+
+  @override
+  String get metaGlassesPairInMetaAI => 'Meta AI अ‍ॅपमध्ये सेट करा';
+
+  @override
+  String get metaGlassesTypeRayBanMeta => 'Ray-Ban Meta';
+
+  @override
+  String get metaGlassesTypeRayBanDisplay => 'Meta Ray-Ban Display';
+
+  @override
+  String get metaGlassesTypeOakleyMeta => 'Oakley Meta';
+
+  @override
+  String get metaGlassesOverheating => 'चष्मा थंड होत आहे — कॅप्चर थांबवले आहे';
+
+  @override
+  String get metaGlassesFolded => 'कॅप्चर सुरू ठेवण्यासाठी चष्मा उघडा';
+
+  @override
+  String get metaGlassesCaptureFrequency => 'कॅप्चर वारंवारता';
+
+  @override
+  String get metaGlassesEvery10s => 'दर 10 से';
+
+  @override
+  String get metaGlassesEvery30s => 'दर 30 से';
+
+  @override
+  String get metaGlassesEvery1min => 'दर 1 मिन';
+
+  @override
+  String get metaGlassesEvery5min => 'दर 5 मिन';
+
+  @override
+  String get metaGlassesGestures => 'जेश्चर';
 }

--- a/app/lib/l10n/app_localizations_ms.dart
+++ b/app/lib/l10n/app_localizations_ms.dart
@@ -9595,4 +9595,95 @@ class AppLocalizationsMs extends AppLocalizations {
   String errorConnectingRayBanMeta(String error) {
     return 'Ralat semasa menyambung ke Ray-Ban Meta: $error';
   }
+
+  @override
+  String get metaGlasses => 'Meta Glasses';
+
+  @override
+  String get pairingTitleMetaGlasses => 'Sambungkan Meta Glasses anda';
+
+  @override
+  String get pairingDescMetaGlasses =>
+      'Gandingkan cermin mata anda dalam aplikasi Meta AI, kemudian ketik Sambung dalam Omi. Anda boleh memautkan lebih daripada satu pasang dan memilih yang aktif.';
+
+  @override
+  String get metaGlassesUnavailable =>
+      'Aplikasi Meta AI tidak ditemui. Pasang Meta AI dan aktifkan Mod Pembangun untuk menyambungkan cermin mata anda.';
+
+  @override
+  String get metaGlassesRegistering => 'Selesaikan sambungan dalam aplikasi Meta AI, kemudian kembali ke Omi.';
+
+  @override
+  String get metaGlassesCameraPermission => 'Benarkan akses kamera dalam aplikasi Meta AI';
+
+  @override
+  String get metaGlassesCaptureModeLabel => 'Mod rakaman';
+
+  @override
+  String get metaGlassesModeCameraMic => 'Kamera + mikrofon';
+
+  @override
+  String get metaGlassesModeMicOnly => 'Mikrofon sahaja';
+
+  @override
+  String get metaGlassesStartCapture => 'Mula merakam';
+
+  @override
+  String get metaGlassesStopCapture => 'Henti merakam';
+
+  @override
+  String get metaGlassesGestureHint => 'Kawalan gerak isyarat untuk cermin mata Meta tidak disokong dalam binaan ini.';
+
+  @override
+  String get connectAnotherDevice => 'Sambungkan peranti lain';
+
+  @override
+  String get myDevices => 'Peranti Saya';
+
+  @override
+  String get metaGlassesAutoCapture => 'Rakaman automatik apabila disambungkan';
+
+  @override
+  String get metaGlassesShowPreview => 'Pratonton langsung';
+
+  @override
+  String metaGlassesPendingPhotos(int count) {
+    return '$count foto menunggu penyegerakan';
+  }
+
+  @override
+  String get metaGlassesPairInMetaAI => 'Sediakan dalam aplikasi Meta AI';
+
+  @override
+  String get metaGlassesTypeRayBanMeta => 'Ray-Ban Meta';
+
+  @override
+  String get metaGlassesTypeRayBanDisplay => 'Meta Ray-Ban Display';
+
+  @override
+  String get metaGlassesTypeOakleyMeta => 'Oakley Meta';
+
+  @override
+  String get metaGlassesOverheating => 'Cermin mata sedang menyejuk — tangkapan dijeda';
+
+  @override
+  String get metaGlassesFolded => 'Buka cermin mata untuk terus menangkap';
+
+  @override
+  String get metaGlassesCaptureFrequency => 'Kekerapan tangkapan';
+
+  @override
+  String get metaGlassesEvery10s => 'Setiap 10 s';
+
+  @override
+  String get metaGlassesEvery30s => 'Setiap 30 s';
+
+  @override
+  String get metaGlassesEvery1min => 'Setiap 1 min';
+
+  @override
+  String get metaGlassesEvery5min => 'Setiap 5 min';
+
+  @override
+  String get metaGlassesGestures => 'Gerak isyarat';
 }

--- a/app/lib/l10n/app_localizations_nl.dart
+++ b/app/lib/l10n/app_localizations_nl.dart
@@ -9598,4 +9598,95 @@ class AppLocalizationsNl extends AppLocalizations {
   String errorConnectingRayBanMeta(String error) {
     return 'Fout bij verbinden met Ray-Ban Meta: $error';
   }
+
+  @override
+  String get metaGlasses => 'Meta Glasses';
+
+  @override
+  String get pairingTitleMetaGlasses => 'Verbind je Meta Glasses';
+
+  @override
+  String get pairingDescMetaGlasses =>
+      'Koppel je bril in de Meta AI-app en tik vervolgens op Verbinden in Omi. Je kunt meerdere brillen koppelen en kiezen welke actief is.';
+
+  @override
+  String get metaGlassesUnavailable =>
+      'Meta AI-app niet gevonden. Installeer Meta AI en schakel de ontwikkelaarsmodus in om je bril te verbinden.';
+
+  @override
+  String get metaGlassesRegistering => 'Voltooi de verbinding in de Meta AI-app en keer terug naar Omi.';
+
+  @override
+  String get metaGlassesCameraPermission => 'Sta cameratoegang toe in de Meta AI-app';
+
+  @override
+  String get metaGlassesCaptureModeLabel => 'Opnamemodus';
+
+  @override
+  String get metaGlassesModeCameraMic => 'Camera + microfoon';
+
+  @override
+  String get metaGlassesModeMicOnly => 'Alleen microfoon';
+
+  @override
+  String get metaGlassesStartCapture => 'Opname starten';
+
+  @override
+  String get metaGlassesStopCapture => 'Opname stoppen';
+
+  @override
+  String get metaGlassesGestureHint => 'Gebarenbediening voor Meta-brillen wordt in deze build niet ondersteund.';
+
+  @override
+  String get connectAnotherDevice => 'Nog een apparaat verbinden';
+
+  @override
+  String get myDevices => 'Mijn apparaten';
+
+  @override
+  String get metaGlassesAutoCapture => 'Automatisch opnemen bij verbinding';
+
+  @override
+  String get metaGlassesShowPreview => 'Live voorbeeld';
+
+  @override
+  String metaGlassesPendingPhotos(int count) {
+    return '$count foto\'s wachten op synchronisatie';
+  }
+
+  @override
+  String get metaGlassesPairInMetaAI => 'Stel in via de Meta AI-app';
+
+  @override
+  String get metaGlassesTypeRayBanMeta => 'Ray-Ban Meta';
+
+  @override
+  String get metaGlassesTypeRayBanDisplay => 'Meta Ray-Ban Display';
+
+  @override
+  String get metaGlassesTypeOakleyMeta => 'Oakley Meta';
+
+  @override
+  String get metaGlassesOverheating => 'De bril koelt af — opname gepauzeerd';
+
+  @override
+  String get metaGlassesFolded => 'Vouw je bril open om door te gaan met opnemen';
+
+  @override
+  String get metaGlassesCaptureFrequency => 'Opnamefrequentie';
+
+  @override
+  String get metaGlassesEvery10s => 'Elke 10 s';
+
+  @override
+  String get metaGlassesEvery30s => 'Elke 30 s';
+
+  @override
+  String get metaGlassesEvery1min => 'Elke 1 min';
+
+  @override
+  String get metaGlassesEvery5min => 'Elke 5 min';
+
+  @override
+  String get metaGlassesGestures => 'Gebaren';
 }

--- a/app/lib/l10n/app_localizations_no.dart
+++ b/app/lib/l10n/app_localizations_no.dart
@@ -9569,4 +9569,95 @@ class AppLocalizationsNo extends AppLocalizations {
   String errorConnectingRayBanMeta(String error) {
     return 'Feil ved tilkobling til Ray-Ban Meta: $error';
   }
+
+  @override
+  String get metaGlasses => 'Meta Glasses';
+
+  @override
+  String get pairingTitleMetaGlasses => 'Koble til dine Meta Glasses';
+
+  @override
+  String get pairingDescMetaGlasses =>
+      'Par brillene i Meta AI-appen, og trykk deretter på Koble til i Omi. Du kan koble til flere par og velge hvilket som er aktivt.';
+
+  @override
+  String get metaGlassesUnavailable =>
+      'Fant ikke Meta AI-appen. Installer Meta AI og aktiver utviklermodus for å koble til brillene.';
+
+  @override
+  String get metaGlassesRegistering => 'Fullfør tilkoblingen i Meta AI-appen, og gå tilbake til Omi.';
+
+  @override
+  String get metaGlassesCameraPermission => 'Tillat kameratilgang i Meta AI-appen';
+
+  @override
+  String get metaGlassesCaptureModeLabel => 'Opptaksmodus';
+
+  @override
+  String get metaGlassesModeCameraMic => 'Kamera + mikrofon';
+
+  @override
+  String get metaGlassesModeMicOnly => 'Kun mikrofon';
+
+  @override
+  String get metaGlassesStartCapture => 'Start opptak';
+
+  @override
+  String get metaGlassesStopCapture => 'Stopp opptak';
+
+  @override
+  String get metaGlassesGestureHint => 'Bevegelseskontroller for Meta-briller støttes ikke i denne versjonen.';
+
+  @override
+  String get connectAnotherDevice => 'Koble til en annen enhet';
+
+  @override
+  String get myDevices => 'Mine enheter';
+
+  @override
+  String get metaGlassesAutoCapture => 'Automatisk opptak ved tilkobling';
+
+  @override
+  String get metaGlassesShowPreview => 'Direkte forhåndsvisning';
+
+  @override
+  String metaGlassesPendingPhotos(int count) {
+    return '$count bilder venter på synkronisering';
+  }
+
+  @override
+  String get metaGlassesPairInMetaAI => 'Konfigurer i Meta AI-appen';
+
+  @override
+  String get metaGlassesTypeRayBanMeta => 'Ray-Ban Meta';
+
+  @override
+  String get metaGlassesTypeRayBanDisplay => 'Meta Ray-Ban Display';
+
+  @override
+  String get metaGlassesTypeOakleyMeta => 'Oakley Meta';
+
+  @override
+  String get metaGlassesOverheating => 'Brillene kjøles ned — opptak satt på pause';
+
+  @override
+  String get metaGlassesFolded => 'Brett ut brillene for å fortsette opptaket';
+
+  @override
+  String get metaGlassesCaptureFrequency => 'Opptaksfrekvens';
+
+  @override
+  String get metaGlassesEvery10s => 'Hvert 10. s';
+
+  @override
+  String get metaGlassesEvery30s => 'Hvert 30. s';
+
+  @override
+  String get metaGlassesEvery1min => 'Hvert 1. min';
+
+  @override
+  String get metaGlassesEvery5min => 'Hvert 5. min';
+
+  @override
+  String get metaGlassesGestures => 'Bevegelser';
 }

--- a/app/lib/l10n/app_localizations_pl.dart
+++ b/app/lib/l10n/app_localizations_pl.dart
@@ -9597,4 +9597,95 @@ class AppLocalizationsPl extends AppLocalizations {
   String errorConnectingRayBanMeta(String error) {
     return 'Błąd podczas łączenia z Ray-Ban Meta: $error';
   }
+
+  @override
+  String get metaGlasses => 'Meta Glasses';
+
+  @override
+  String get pairingTitleMetaGlasses => 'Połącz swoje Meta Glasses';
+
+  @override
+  String get pairingDescMetaGlasses =>
+      'Sparuj okulary w aplikacji Meta AI, a następnie stuknij Połącz w Omi. Możesz połączyć więcej niż jedną parę i wybrać aktywną.';
+
+  @override
+  String get metaGlassesUnavailable =>
+      'Nie znaleziono aplikacji Meta AI. Zainstaluj Meta AI i włącz tryb programisty, aby połączyć okulary.';
+
+  @override
+  String get metaGlassesRegistering => 'Dokończ łączenie w aplikacji Meta AI, a następnie wróć do Omi.';
+
+  @override
+  String get metaGlassesCameraPermission => 'Zezwól na dostęp do kamery w aplikacji Meta AI';
+
+  @override
+  String get metaGlassesCaptureModeLabel => 'Tryb nagrywania';
+
+  @override
+  String get metaGlassesModeCameraMic => 'Kamera + mikrofon';
+
+  @override
+  String get metaGlassesModeMicOnly => 'Tylko mikrofon';
+
+  @override
+  String get metaGlassesStartCapture => 'Rozpocznij nagrywanie';
+
+  @override
+  String get metaGlassesStopCapture => 'Zatrzymaj nagrywanie';
+
+  @override
+  String get metaGlassesGestureHint => 'Sterowanie gestami dla okularów Meta nie jest obsługiwane w tej kompilacji.';
+
+  @override
+  String get connectAnotherDevice => 'Połącz kolejne urządzenie';
+
+  @override
+  String get myDevices => 'Moje urządzenia';
+
+  @override
+  String get metaGlassesAutoCapture => 'Automatyczne nagrywanie po połączeniu';
+
+  @override
+  String get metaGlassesShowPreview => 'Podgląd na żywo';
+
+  @override
+  String metaGlassesPendingPhotos(int count) {
+    return '$count zdjęć czeka na synchronizację';
+  }
+
+  @override
+  String get metaGlassesPairInMetaAI => 'Skonfiguruj w aplikacji Meta AI';
+
+  @override
+  String get metaGlassesTypeRayBanMeta => 'Ray-Ban Meta';
+
+  @override
+  String get metaGlassesTypeRayBanDisplay => 'Meta Ray-Ban Display';
+
+  @override
+  String get metaGlassesTypeOakleyMeta => 'Oakley Meta';
+
+  @override
+  String get metaGlassesOverheating => 'Okulary się chłodzą — przechwytywanie wstrzymane';
+
+  @override
+  String get metaGlassesFolded => 'Rozłóż okulary, aby kontynuować przechwytywanie';
+
+  @override
+  String get metaGlassesCaptureFrequency => 'Częstotliwość zdjęć';
+
+  @override
+  String get metaGlassesEvery10s => 'Co 10 s';
+
+  @override
+  String get metaGlassesEvery30s => 'Co 30 s';
+
+  @override
+  String get metaGlassesEvery1min => 'Co 1 min';
+
+  @override
+  String get metaGlassesEvery5min => 'Co 5 min';
+
+  @override
+  String get metaGlassesGestures => 'Gesty';
 }

--- a/app/lib/l10n/app_localizations_pt.dart
+++ b/app/lib/l10n/app_localizations_pt.dart
@@ -9577,4 +9577,95 @@ class AppLocalizationsPt extends AppLocalizations {
   String errorConnectingRayBanMeta(String error) {
     return 'Erro ao conectar ao Ray-Ban Meta: $error';
   }
+
+  @override
+  String get metaGlasses => 'Meta Glasses';
+
+  @override
+  String get pairingTitleMetaGlasses => 'Conecte seus Meta Glasses';
+
+  @override
+  String get pairingDescMetaGlasses =>
+      'Emparelhe seus óculos no app Meta AI e depois toque em Conectar no Omi. Você pode vincular mais de um par e escolher qual está ativo.';
+
+  @override
+  String get metaGlassesUnavailable =>
+      'App Meta AI não encontrado. Instale o Meta AI e ative o modo de desenvolvedor para conectar seus óculos.';
+
+  @override
+  String get metaGlassesRegistering => 'Conclua a conexão no app Meta AI e volte ao Omi.';
+
+  @override
+  String get metaGlassesCameraPermission => 'Permita o acesso à câmera no app Meta AI';
+
+  @override
+  String get metaGlassesCaptureModeLabel => 'Modo de captura';
+
+  @override
+  String get metaGlassesModeCameraMic => 'Câmera + microfone';
+
+  @override
+  String get metaGlassesModeMicOnly => 'Apenas microfone';
+
+  @override
+  String get metaGlassesStartCapture => 'Iniciar captura';
+
+  @override
+  String get metaGlassesStopCapture => 'Parar captura';
+
+  @override
+  String get metaGlassesGestureHint => 'Os controles por gestos dos óculos Meta não são compatíveis nesta versão.';
+
+  @override
+  String get connectAnotherDevice => 'Conectar outro dispositivo';
+
+  @override
+  String get myDevices => 'Meus dispositivos';
+
+  @override
+  String get metaGlassesAutoCapture => 'Captura automática ao conectar';
+
+  @override
+  String get metaGlassesShowPreview => 'Prévia ao vivo';
+
+  @override
+  String metaGlassesPendingPhotos(int count) {
+    return '$count fotos aguardando sincronização';
+  }
+
+  @override
+  String get metaGlassesPairInMetaAI => 'Configure no app Meta AI';
+
+  @override
+  String get metaGlassesTypeRayBanMeta => 'Ray-Ban Meta';
+
+  @override
+  String get metaGlassesTypeRayBanDisplay => 'Meta Ray-Ban Display';
+
+  @override
+  String get metaGlassesTypeOakleyMeta => 'Oakley Meta';
+
+  @override
+  String get metaGlassesOverheating => 'Os óculos estão esfriando — captura pausada';
+
+  @override
+  String get metaGlassesFolded => 'Abra os óculos para continuar capturando';
+
+  @override
+  String get metaGlassesCaptureFrequency => 'Frequência de captura';
+
+  @override
+  String get metaGlassesEvery10s => 'A cada 10 s';
+
+  @override
+  String get metaGlassesEvery30s => 'A cada 30 s';
+
+  @override
+  String get metaGlassesEvery1min => 'A cada 1 min';
+
+  @override
+  String get metaGlassesEvery5min => 'A cada 5 min';
+
+  @override
+  String get metaGlassesGestures => 'Gestos';
 }

--- a/app/lib/l10n/app_localizations_ro.dart
+++ b/app/lib/l10n/app_localizations_ro.dart
@@ -9617,4 +9617,96 @@ class AppLocalizationsRo extends AppLocalizations {
   String errorConnectingRayBanMeta(String error) {
     return 'Eroare la conectarea la Ray-Ban Meta: $error';
   }
+
+  @override
+  String get metaGlasses => 'Meta Glasses';
+
+  @override
+  String get pairingTitleMetaGlasses => 'Conectează-ți Meta Glasses';
+
+  @override
+  String get pairingDescMetaGlasses =>
+      'Asociază ochelarii în aplicația Meta AI, apoi atinge Conectare în Omi. Poți lega mai multe perechi și alege care este activă.';
+
+  @override
+  String get metaGlassesUnavailable =>
+      'Aplicația Meta AI nu a fost găsită. Instalează Meta AI și activează modul pentru dezvoltatori pentru a conecta ochelarii.';
+
+  @override
+  String get metaGlassesRegistering => 'Finalizează conectarea în aplicația Meta AI, apoi revino în Omi.';
+
+  @override
+  String get metaGlassesCameraPermission => 'Permite accesul la cameră în aplicația Meta AI';
+
+  @override
+  String get metaGlassesCaptureModeLabel => 'Mod de captură';
+
+  @override
+  String get metaGlassesModeCameraMic => 'Cameră + microfon';
+
+  @override
+  String get metaGlassesModeMicOnly => 'Doar microfon';
+
+  @override
+  String get metaGlassesStartCapture => 'Pornește captura';
+
+  @override
+  String get metaGlassesStopCapture => 'Oprește captura';
+
+  @override
+  String get metaGlassesGestureHint =>
+      'Comenzile prin gesturi pentru ochelarii Meta nu sunt acceptate în această versiune.';
+
+  @override
+  String get connectAnotherDevice => 'Conectează alt dispozitiv';
+
+  @override
+  String get myDevices => 'Dispozitivele mele';
+
+  @override
+  String get metaGlassesAutoCapture => 'Captură automată la conectare';
+
+  @override
+  String get metaGlassesShowPreview => 'Previzualizare live';
+
+  @override
+  String metaGlassesPendingPhotos(int count) {
+    return '$count fotografii așteaptă sincronizarea';
+  }
+
+  @override
+  String get metaGlassesPairInMetaAI => 'Configurează în aplicația Meta AI';
+
+  @override
+  String get metaGlassesTypeRayBanMeta => 'Ray-Ban Meta';
+
+  @override
+  String get metaGlassesTypeRayBanDisplay => 'Meta Ray-Ban Display';
+
+  @override
+  String get metaGlassesTypeOakleyMeta => 'Oakley Meta';
+
+  @override
+  String get metaGlassesOverheating => 'Ochelarii se răcesc — capturarea este întreruptă';
+
+  @override
+  String get metaGlassesFolded => 'Deschide ochelarii pentru a continua capturarea';
+
+  @override
+  String get metaGlassesCaptureFrequency => 'Frecvența capturii';
+
+  @override
+  String get metaGlassesEvery10s => 'La fiecare 10 s';
+
+  @override
+  String get metaGlassesEvery30s => 'La fiecare 30 s';
+
+  @override
+  String get metaGlassesEvery1min => 'La fiecare 1 min';
+
+  @override
+  String get metaGlassesEvery5min => 'La fiecare 5 min';
+
+  @override
+  String get metaGlassesGestures => 'Gesturi';
 }

--- a/app/lib/l10n/app_localizations_ru.dart
+++ b/app/lib/l10n/app_localizations_ru.dart
@@ -9606,4 +9606,95 @@ class AppLocalizationsRu extends AppLocalizations {
   String errorConnectingRayBanMeta(String error) {
     return 'Ошибка подключения к Ray-Ban Meta: $error';
   }
+
+  @override
+  String get metaGlasses => 'Meta Glasses';
+
+  @override
+  String get pairingTitleMetaGlasses => 'Подключите ваши Meta Glasses';
+
+  @override
+  String get pairingDescMetaGlasses =>
+      'Выполните сопряжение очков в приложении Meta AI, затем нажмите «Подключить» в Omi. Можно привязать несколько пар и выбрать активную.';
+
+  @override
+  String get metaGlassesUnavailable =>
+      'Приложение Meta AI не найдено. Установите Meta AI и включите режим разработчика, чтобы подключить очки.';
+
+  @override
+  String get metaGlassesRegistering => 'Завершите подключение в приложении Meta AI и вернитесь в Omi.';
+
+  @override
+  String get metaGlassesCameraPermission => 'Разрешите доступ к камере в приложении Meta AI';
+
+  @override
+  String get metaGlassesCaptureModeLabel => 'Режим записи';
+
+  @override
+  String get metaGlassesModeCameraMic => 'Камера + микрофон';
+
+  @override
+  String get metaGlassesModeMicOnly => 'Только микрофон';
+
+  @override
+  String get metaGlassesStartCapture => 'Начать запись';
+
+  @override
+  String get metaGlassesStopCapture => 'Остановить запись';
+
+  @override
+  String get metaGlassesGestureHint => 'Управление жестами для очков Meta не поддерживается в этой сборке.';
+
+  @override
+  String get connectAnotherDevice => 'Подключить другое устройство';
+
+  @override
+  String get myDevices => 'Мои устройства';
+
+  @override
+  String get metaGlassesAutoCapture => 'Автозапись при подключении';
+
+  @override
+  String get metaGlassesShowPreview => 'Живой предпросмотр';
+
+  @override
+  String metaGlassesPendingPhotos(int count) {
+    return '$count фото ожидают синхронизации';
+  }
+
+  @override
+  String get metaGlassesPairInMetaAI => 'Настройте в приложении Meta AI';
+
+  @override
+  String get metaGlassesTypeRayBanMeta => 'Ray-Ban Meta';
+
+  @override
+  String get metaGlassesTypeRayBanDisplay => 'Meta Ray-Ban Display';
+
+  @override
+  String get metaGlassesTypeOakleyMeta => 'Oakley Meta';
+
+  @override
+  String get metaGlassesOverheating => 'Очки охлаждаются — съемка приостановлена';
+
+  @override
+  String get metaGlassesFolded => 'Разложите очки, чтобы продолжить съемку';
+
+  @override
+  String get metaGlassesCaptureFrequency => 'Частота съёмки';
+
+  @override
+  String get metaGlassesEvery10s => 'Каждые 10 с';
+
+  @override
+  String get metaGlassesEvery30s => 'Каждые 30 с';
+
+  @override
+  String get metaGlassesEvery1min => 'Каждую 1 мин';
+
+  @override
+  String get metaGlassesEvery5min => 'Каждые 5 мин';
+
+  @override
+  String get metaGlassesGestures => 'Жесты';
 }

--- a/app/lib/l10n/app_localizations_sk.dart
+++ b/app/lib/l10n/app_localizations_sk.dart
@@ -9562,4 +9562,95 @@ class AppLocalizationsSk extends AppLocalizations {
   String errorConnectingRayBanMeta(String error) {
     return 'Chyba pri pripájaní k Ray-Ban Meta: $error';
   }
+
+  @override
+  String get metaGlasses => 'Meta Glasses';
+
+  @override
+  String get pairingTitleMetaGlasses => 'Pripojte svoje Meta Glasses';
+
+  @override
+  String get pairingDescMetaGlasses =>
+      'Spárujte okuliare v aplikácii Meta AI a potom klepnite na Pripojiť v Omi. Môžete prepojiť viac párov a vybrať, ktorý je aktívny.';
+
+  @override
+  String get metaGlassesUnavailable =>
+      'Aplikácia Meta AI sa nenašla. Nainštalujte Meta AI a zapnite režim pre vývojárov, aby ste okuliare pripojili.';
+
+  @override
+  String get metaGlassesRegistering => 'Dokončite pripojenie v aplikácii Meta AI a vráťte sa do Omi.';
+
+  @override
+  String get metaGlassesCameraPermission => 'Povoľte prístup ku kamere v aplikácii Meta AI';
+
+  @override
+  String get metaGlassesCaptureModeLabel => 'Režim záznamu';
+
+  @override
+  String get metaGlassesModeCameraMic => 'Kamera + mikrofón';
+
+  @override
+  String get metaGlassesModeMicOnly => 'Iba mikrofón';
+
+  @override
+  String get metaGlassesStartCapture => 'Spustiť záznam';
+
+  @override
+  String get metaGlassesStopCapture => 'Zastaviť záznam';
+
+  @override
+  String get metaGlassesGestureHint => 'Ovládanie gestami pre okuliare Meta nie je v tejto verzii podporované.';
+
+  @override
+  String get connectAnotherDevice => 'Pripojiť ďalšie zariadenie';
+
+  @override
+  String get myDevices => 'Moje zariadenia';
+
+  @override
+  String get metaGlassesAutoCapture => 'Automatický záznam po pripojení';
+
+  @override
+  String get metaGlassesShowPreview => 'Živý náhľad';
+
+  @override
+  String metaGlassesPendingPhotos(int count) {
+    return '$count fotiek čaká na synchronizáciu';
+  }
+
+  @override
+  String get metaGlassesPairInMetaAI => 'Nastavte v aplikácii Meta AI';
+
+  @override
+  String get metaGlassesTypeRayBanMeta => 'Ray-Ban Meta';
+
+  @override
+  String get metaGlassesTypeRayBanDisplay => 'Meta Ray-Ban Display';
+
+  @override
+  String get metaGlassesTypeOakleyMeta => 'Oakley Meta';
+
+  @override
+  String get metaGlassesOverheating => 'Okuliare sa ochladzujú — snímanie je pozastavené';
+
+  @override
+  String get metaGlassesFolded => 'Rozložte okuliare, aby snímanie pokračovalo';
+
+  @override
+  String get metaGlassesCaptureFrequency => 'Frekvencia snímania';
+
+  @override
+  String get metaGlassesEvery10s => 'Každých 10 s';
+
+  @override
+  String get metaGlassesEvery30s => 'Každých 30 s';
+
+  @override
+  String get metaGlassesEvery1min => 'Každú 1 min';
+
+  @override
+  String get metaGlassesEvery5min => 'Každých 5 min';
+
+  @override
+  String get metaGlassesGestures => 'Gestá';
 }

--- a/app/lib/l10n/app_localizations_sl.dart
+++ b/app/lib/l10n/app_localizations_sl.dart
@@ -9598,4 +9598,95 @@ class AppLocalizationsSl extends AppLocalizations {
   String errorConnectingRayBanMeta(String error) {
     return 'Napaka pri povezovanju z Ray-Ban Meta: $error';
   }
+
+  @override
+  String get metaGlasses => 'Meta Glasses';
+
+  @override
+  String get pairingTitleMetaGlasses => 'Povežite svoja Meta Glasses';
+
+  @override
+  String get pairingDescMetaGlasses =>
+      'Seznanite očala v aplikaciji Meta AI, nato tapnite Poveži v Omi. Povežete lahko več parov in izberete, kateri je aktiven.';
+
+  @override
+  String get metaGlassesUnavailable =>
+      'Aplikacije Meta AI ni mogoče najti. Namestite Meta AI in vklopite razvijalski način, da povežete očala.';
+
+  @override
+  String get metaGlassesRegistering => 'Dokončajte povezovanje v aplikaciji Meta AI in se vrnite v Omi.';
+
+  @override
+  String get metaGlassesCameraPermission => 'Dovolite dostop do kamere v aplikaciji Meta AI';
+
+  @override
+  String get metaGlassesCaptureModeLabel => 'Način zajema';
+
+  @override
+  String get metaGlassesModeCameraMic => 'Kamera + mikrofon';
+
+  @override
+  String get metaGlassesModeMicOnly => 'Samo mikrofon';
+
+  @override
+  String get metaGlassesStartCapture => 'Začni zajem';
+
+  @override
+  String get metaGlassesStopCapture => 'Ustavi zajem';
+
+  @override
+  String get metaGlassesGestureHint => 'Upravljanje s kretnjami za očala Meta v tej gradnji ni podprto.';
+
+  @override
+  String get connectAnotherDevice => 'Poveži drugo napravo';
+
+  @override
+  String get myDevices => 'Moje naprave';
+
+  @override
+  String get metaGlassesAutoCapture => 'Samodejni zajem ob povezavi';
+
+  @override
+  String get metaGlassesShowPreview => 'Predogled v živo';
+
+  @override
+  String metaGlassesPendingPhotos(int count) {
+    return '$count fotografij čaka na sinhronizacijo';
+  }
+
+  @override
+  String get metaGlassesPairInMetaAI => 'Nastavite v aplikaciji Meta AI';
+
+  @override
+  String get metaGlassesTypeRayBanMeta => 'Ray-Ban Meta';
+
+  @override
+  String get metaGlassesTypeRayBanDisplay => 'Meta Ray-Ban Display';
+
+  @override
+  String get metaGlassesTypeOakleyMeta => 'Oakley Meta';
+
+  @override
+  String get metaGlassesOverheating => 'Očala se ohlajajo — zajem je začasno ustavljen';
+
+  @override
+  String get metaGlassesFolded => 'Razprite očala za nadaljevanje zajema';
+
+  @override
+  String get metaGlassesCaptureFrequency => 'Pogostost zajema';
+
+  @override
+  String get metaGlassesEvery10s => 'Vsakih 10 s';
+
+  @override
+  String get metaGlassesEvery30s => 'Vsakih 30 s';
+
+  @override
+  String get metaGlassesEvery1min => 'Vsako 1 min';
+
+  @override
+  String get metaGlassesEvery5min => 'Vsakih 5 min';
+
+  @override
+  String get metaGlassesGestures => 'Poteze';
 }

--- a/app/lib/l10n/app_localizations_sr.dart
+++ b/app/lib/l10n/app_localizations_sr.dart
@@ -9584,4 +9584,95 @@ class AppLocalizationsSr extends AppLocalizations {
   String errorConnectingRayBanMeta(String error) {
     return 'Грешка при повезивању са Ray-Ban Meta: $error';
   }
+
+  @override
+  String get metaGlasses => 'Meta Glasses';
+
+  @override
+  String get pairingTitleMetaGlasses => 'Повежите своје Meta Glasses';
+
+  @override
+  String get pairingDescMetaGlasses =>
+      'Упарите наочаре у апликацији Meta AI, затим додирните Повежи у Omi. Можете повезати више пари и изабрати који је активан.';
+
+  @override
+  String get metaGlassesUnavailable =>
+      'Апликација Meta AI није пронађена. Инсталирајте Meta AI и укључите режим за програмере да бисте повезали наочаре.';
+
+  @override
+  String get metaGlassesRegistering => 'Довршите повезивање у апликацији Meta AI, а затим се вратите у Omi.';
+
+  @override
+  String get metaGlassesCameraPermission => 'Дозволите приступ камери у апликацији Meta AI';
+
+  @override
+  String get metaGlassesCaptureModeLabel => 'Режим снимања';
+
+  @override
+  String get metaGlassesModeCameraMic => 'Камера + микрофон';
+
+  @override
+  String get metaGlassesModeMicOnly => 'Само микрофон';
+
+  @override
+  String get metaGlassesStartCapture => 'Покрени снимање';
+
+  @override
+  String get metaGlassesStopCapture => 'Заустави снимање';
+
+  @override
+  String get metaGlassesGestureHint => 'Контроле покретима за Meta наочаре нису подржане у овој верзији.';
+
+  @override
+  String get connectAnotherDevice => 'Повежи други уређај';
+
+  @override
+  String get myDevices => 'Моји уређаји';
+
+  @override
+  String get metaGlassesAutoCapture => 'Аутоматско снимање при повезивању';
+
+  @override
+  String get metaGlassesShowPreview => 'Преглед уживо';
+
+  @override
+  String metaGlassesPendingPhotos(int count) {
+    return '$count фотографија чека синхронизацију';
+  }
+
+  @override
+  String get metaGlassesPairInMetaAI => 'Подесите у апликацији Meta AI';
+
+  @override
+  String get metaGlassesTypeRayBanMeta => 'Ray-Ban Meta';
+
+  @override
+  String get metaGlassesTypeRayBanDisplay => 'Meta Ray-Ban Display';
+
+  @override
+  String get metaGlassesTypeOakleyMeta => 'Oakley Meta';
+
+  @override
+  String get metaGlassesOverheating => 'Naočare se hlade — snimanje je pauzirano';
+
+  @override
+  String get metaGlassesFolded => 'Rasklopite naočare da nastavite snimanje';
+
+  @override
+  String get metaGlassesCaptureFrequency => 'Учесталост снимања';
+
+  @override
+  String get metaGlassesEvery10s => 'Свеких 10 с';
+
+  @override
+  String get metaGlassesEvery30s => 'Свеких 30 с';
+
+  @override
+  String get metaGlassesEvery1min => 'Сваког 1 мин';
+
+  @override
+  String get metaGlassesEvery5min => 'Свеких 5 мин';
+
+  @override
+  String get metaGlassesGestures => 'Гестови';
 }

--- a/app/lib/l10n/app_localizations_sv.dart
+++ b/app/lib/l10n/app_localizations_sv.dart
@@ -9576,4 +9576,95 @@ class AppLocalizationsSv extends AppLocalizations {
   String errorConnectingRayBanMeta(String error) {
     return 'Fel vid anslutning till Ray-Ban Meta: $error';
   }
+
+  @override
+  String get metaGlasses => 'Meta Glasses';
+
+  @override
+  String get pairingTitleMetaGlasses => 'Anslut dina Meta Glasses';
+
+  @override
+  String get pairingDescMetaGlasses =>
+      'Parkoppla dina glasögon i Meta AI-appen och tryck sedan på Anslut i Omi. Du kan länka flera par och välja vilket som är aktivt.';
+
+  @override
+  String get metaGlassesUnavailable =>
+      'Meta AI-appen hittades inte. Installera Meta AI och aktivera utvecklarläget för att ansluta dina glasögon.';
+
+  @override
+  String get metaGlassesRegistering => 'Slutför anslutningen i Meta AI-appen och återgå till Omi.';
+
+  @override
+  String get metaGlassesCameraPermission => 'Tillåt kameraåtkomst i Meta AI-appen';
+
+  @override
+  String get metaGlassesCaptureModeLabel => 'Inspelningsläge';
+
+  @override
+  String get metaGlassesModeCameraMic => 'Kamera + mikrofon';
+
+  @override
+  String get metaGlassesModeMicOnly => 'Endast mikrofon';
+
+  @override
+  String get metaGlassesStartCapture => 'Starta inspelning';
+
+  @override
+  String get metaGlassesStopCapture => 'Stoppa inspelning';
+
+  @override
+  String get metaGlassesGestureHint => 'Geststyrning för Meta-glasögon stöds inte i den här versionen.';
+
+  @override
+  String get connectAnotherDevice => 'Anslut en annan enhet';
+
+  @override
+  String get myDevices => 'Mina enheter';
+
+  @override
+  String get metaGlassesAutoCapture => 'Automatisk inspelning vid anslutning';
+
+  @override
+  String get metaGlassesShowPreview => 'Live-förhandsvisning';
+
+  @override
+  String metaGlassesPendingPhotos(int count) {
+    return '$count foton väntar på synkronisering';
+  }
+
+  @override
+  String get metaGlassesPairInMetaAI => 'Konfigurera i Meta AI-appen';
+
+  @override
+  String get metaGlassesTypeRayBanMeta => 'Ray-Ban Meta';
+
+  @override
+  String get metaGlassesTypeRayBanDisplay => 'Meta Ray-Ban Display';
+
+  @override
+  String get metaGlassesTypeOakleyMeta => 'Oakley Meta';
+
+  @override
+  String get metaGlassesOverheating => 'Glasögonen svalnar — inspelning pausad';
+
+  @override
+  String get metaGlassesFolded => 'Fäll upp glasögonen för att fortsätta spela in';
+
+  @override
+  String get metaGlassesCaptureFrequency => 'Tagningsfrekvens';
+
+  @override
+  String get metaGlassesEvery10s => 'Var 10:e s';
+
+  @override
+  String get metaGlassesEvery30s => 'Var 30:e s';
+
+  @override
+  String get metaGlassesEvery1min => 'Varje 1 min';
+
+  @override
+  String get metaGlassesEvery5min => 'Var 5:e min';
+
+  @override
+  String get metaGlassesGestures => 'Gester';
 }

--- a/app/lib/l10n/app_localizations_ta.dart
+++ b/app/lib/l10n/app_localizations_ta.dart
@@ -9640,4 +9640,95 @@ class AppLocalizationsTa extends AppLocalizations {
   String errorConnectingRayBanMeta(String error) {
     return 'Ray-Ban Meta உடன் இணைப்பதில் பிழை: $error';
   }
+
+  @override
+  String get metaGlasses => 'Meta Glasses';
+
+  @override
+  String get pairingTitleMetaGlasses => 'உங்கள் Meta Glasses-ஐ இணைக்கவும்';
+
+  @override
+  String get pairingDescMetaGlasses =>
+      'Meta AI ஆப்பில் உங்கள் கண்ணாடியை இணைத்து, பிறகு Omi-இல் Connect-ஐத் தட்டவும். ஒன்றுக்கு மேற்பட்ட ஜோடிகளை இணைத்து, செயலில் உள்ளதைத் தேர்ந்தெடுக்கலாம்.';
+
+  @override
+  String get metaGlassesUnavailable =>
+      'Meta AI ஆப் கிடைக்கவில்லை. கண்ணாடியை இணைக்க Meta AI-ஐ நிறுவி, டெவலப்பர் பயன்முறையை இயக்கவும்.';
+
+  @override
+  String get metaGlassesRegistering => 'Meta AI ஆப்பில் இணைப்பை முடித்து, பிறகு Omi-க்குத் திரும்பவும்.';
+
+  @override
+  String get metaGlassesCameraPermission => 'Meta AI ஆப்பில் கேமரா அணுகலை அனுமதிக்கவும்';
+
+  @override
+  String get metaGlassesCaptureModeLabel => 'பதிவு பயன்முறை';
+
+  @override
+  String get metaGlassesModeCameraMic => 'கேமரா + மைக்';
+
+  @override
+  String get metaGlassesModeMicOnly => 'மைக் மட்டும்';
+
+  @override
+  String get metaGlassesStartCapture => 'பதிவைத் தொடங்கு';
+
+  @override
+  String get metaGlassesStopCapture => 'பதிவை நிறுத்து';
+
+  @override
+  String get metaGlassesGestureHint => 'இந்த build-இல் Meta கண்ணாடிகளுக்கான சைகை கட்டுப்பாடுகள் ஆதரிக்கப்படவில்லை.';
+
+  @override
+  String get connectAnotherDevice => 'மற்றொரு சாதனத்தை இணைக்கவும்';
+
+  @override
+  String get myDevices => 'என் சாதனங்கள்';
+
+  @override
+  String get metaGlassesAutoCapture => 'இணைக்கும்போது தானியங்கு பதிவு';
+
+  @override
+  String get metaGlassesShowPreview => 'நேரடி முன்னோட்டம்';
+
+  @override
+  String metaGlassesPendingPhotos(int count) {
+    return '$count புகைப்படங்கள் ஒத்திசைவுக்காக காத்திருக்கின்றன';
+  }
+
+  @override
+  String get metaGlassesPairInMetaAI => 'Meta AI ஆப்பில் அமைக்கவும்';
+
+  @override
+  String get metaGlassesTypeRayBanMeta => 'Ray-Ban Meta';
+
+  @override
+  String get metaGlassesTypeRayBanDisplay => 'Meta Ray-Ban Display';
+
+  @override
+  String get metaGlassesTypeOakleyMeta => 'Oakley Meta';
+
+  @override
+  String get metaGlassesOverheating => 'கண்ணாடி குளிர்கிறது — பிடிப்பு இடைநிறுத்தப்பட்டது';
+
+  @override
+  String get metaGlassesFolded => 'பிடிப்பைத் தொடர கண்ணாடியைத் திறக்கவும்';
+
+  @override
+  String get metaGlassesCaptureFrequency => 'படமெடுப்பு அதிர்வெண்';
+
+  @override
+  String get metaGlassesEvery10s => 'ஒவ்வொரு 10 வி';
+
+  @override
+  String get metaGlassesEvery30s => 'ஒவ்வொரு 30 வி';
+
+  @override
+  String get metaGlassesEvery1min => 'ஒவ்வொரு 1 நி';
+
+  @override
+  String get metaGlassesEvery5min => 'ஒவ்வொரு 5 நி';
+
+  @override
+  String get metaGlassesGestures => 'சைகைகள்';
 }

--- a/app/lib/l10n/app_localizations_te.dart
+++ b/app/lib/l10n/app_localizations_te.dart
@@ -9618,4 +9618,95 @@ class AppLocalizationsTe extends AppLocalizations {
   String errorConnectingRayBanMeta(String error) {
     return 'Ray-Ban Meta కు కనెక్ట్ చేయడంలో లోపం: $error';
   }
+
+  @override
+  String get metaGlasses => 'Meta Glasses';
+
+  @override
+  String get pairingTitleMetaGlasses => 'మీ Meta Glasses కనెక్ట్ చేయండి';
+
+  @override
+  String get pairingDescMetaGlasses =>
+      'Meta AI యాప్‌లో మీ గ్లాసెస్‌ను పెయిర్ చేసి, ఆపై Omi లో Connect నొక్కండి. ఒకటి కంటే ఎక్కువ జతలను లింక్ చేసి, యాక్టివ్‌గా ఉండేదాన్ని ఎంచుకోవచ్చు.';
+
+  @override
+  String get metaGlassesUnavailable =>
+      'Meta AI యాప్ కనబడలేదు. గ్లాసెస్ కనెక్ట్ చేయడానికి Meta AI ఇన్‌స్టాల్ చేసి, డెవలపర్ మోడ్ ప్రారంభించండి.';
+
+  @override
+  String get metaGlassesRegistering => 'Meta AI యాప్‌లో కనెక్షన్ పూర్తి చేసి, ఆపై Omi కి తిరిగి రండి.';
+
+  @override
+  String get metaGlassesCameraPermission => 'Meta AI యాప్‌లో కెమెరా యాక్సెస్‌ను అనుమతించండి';
+
+  @override
+  String get metaGlassesCaptureModeLabel => 'క్యాప్చర్ మోడ్';
+
+  @override
+  String get metaGlassesModeCameraMic => 'కెమెరా + మైక్';
+
+  @override
+  String get metaGlassesModeMicOnly => 'మైక్ మాత్రమే';
+
+  @override
+  String get metaGlassesStartCapture => 'క్యాప్చర్ ప్రారంభించండి';
+
+  @override
+  String get metaGlassesStopCapture => 'క్యాప్చర్ ఆపండి';
+
+  @override
+  String get metaGlassesGestureHint => 'ఈ బిల్డ్‌లో Meta కళ్లద్దాల కోసం gesture నియంత్రణలు మద్దతు ఇవ్వబడవు.';
+
+  @override
+  String get connectAnotherDevice => 'మరో పరికరాన్ని కనెక్ట్ చేయండి';
+
+  @override
+  String get myDevices => 'నా పరికరాలు';
+
+  @override
+  String get metaGlassesAutoCapture => 'కనెక్ట్ అయినప్పుడు ఆటో-క్యాప్చర్';
+
+  @override
+  String get metaGlassesShowPreview => 'లైవ్ ప్రివ్యూ';
+
+  @override
+  String metaGlassesPendingPhotos(int count) {
+    return '$count ఫోటోలు సింక్ కోసం వేచి ఉన్నాయి';
+  }
+
+  @override
+  String get metaGlassesPairInMetaAI => 'Meta AI యాప్‌లో సెటప్ చేయండి';
+
+  @override
+  String get metaGlassesTypeRayBanMeta => 'Ray-Ban Meta';
+
+  @override
+  String get metaGlassesTypeRayBanDisplay => 'Meta Ray-Ban Display';
+
+  @override
+  String get metaGlassesTypeOakleyMeta => 'Oakley Meta';
+
+  @override
+  String get metaGlassesOverheating => 'కళ్లజోడు చల్లబడుతోంది — క్యాప్చర్ పాజ్ అయింది';
+
+  @override
+  String get metaGlassesFolded => 'క్యాప్చర్ కొనసాగించడానికి కళ్లజోడును విప్పండి';
+
+  @override
+  String get metaGlassesCaptureFrequency => 'క్యాప్చర్ ఫ్రీక్వెన్సీ';
+
+  @override
+  String get metaGlassesEvery10s => 'ప్రతి 10 సె';
+
+  @override
+  String get metaGlassesEvery30s => 'ప్రతి 30 సె';
+
+  @override
+  String get metaGlassesEvery1min => 'ప్రతి 1 నిమి';
+
+  @override
+  String get metaGlassesEvery5min => 'ప్రతి 5 నిమి';
+
+  @override
+  String get metaGlassesGestures => 'సంజ్ఞలు';
 }

--- a/app/lib/l10n/app_localizations_th.dart
+++ b/app/lib/l10n/app_localizations_th.dart
@@ -9519,4 +9519,95 @@ class AppLocalizationsTh extends AppLocalizations {
   String errorConnectingRayBanMeta(String error) {
     return 'เกิดข้อผิดพลาดในการเชื่อมต่อกับ Ray-Ban Meta: $error';
   }
+
+  @override
+  String get metaGlasses => 'Meta Glasses';
+
+  @override
+  String get pairingTitleMetaGlasses => 'เชื่อมต่อ Meta Glasses ของคุณ';
+
+  @override
+  String get pairingDescMetaGlasses =>
+      'จับคู่แว่นตาของคุณในแอป Meta AI จากนั้นแตะ เชื่อมต่อ ใน Omi คุณสามารถเชื่อมโยงได้หลายคู่และเลือกคู่ที่ใช้งานอยู่';
+
+  @override
+  String get metaGlassesUnavailable =>
+      'ไม่พบแอป Meta AI โปรดติดตั้ง Meta AI และเปิดโหมดนักพัฒนาเพื่อเชื่อมต่อแว่นตาของคุณ';
+
+  @override
+  String get metaGlassesRegistering => 'ทำการเชื่อมต่อในแอป Meta AI ให้เสร็จ แล้วกลับมาที่ Omi';
+
+  @override
+  String get metaGlassesCameraPermission => 'อนุญาตการเข้าถึงกล้องในแอป Meta AI';
+
+  @override
+  String get metaGlassesCaptureModeLabel => 'โหมดบันทึก';
+
+  @override
+  String get metaGlassesModeCameraMic => 'กล้อง + ไมค์';
+
+  @override
+  String get metaGlassesModeMicOnly => 'ไมค์เท่านั้น';
+
+  @override
+  String get metaGlassesStartCapture => 'เริ่มบันทึก';
+
+  @override
+  String get metaGlassesStopCapture => 'หยุดบันทึก';
+
+  @override
+  String get metaGlassesGestureHint => 'ระบบควบคุมด้วยท่าทางสำหรับแว่น Meta ยังไม่รองรับในบิลด์นี้';
+
+  @override
+  String get connectAnotherDevice => 'เชื่อมต่ออุปกรณ์อื่น';
+
+  @override
+  String get myDevices => 'อุปกรณ์ของฉัน';
+
+  @override
+  String get metaGlassesAutoCapture => 'บันทึกอัตโนมัติเมื่อเชื่อมต่อ';
+
+  @override
+  String get metaGlassesShowPreview => 'ดูตัวอย่างสด';
+
+  @override
+  String metaGlassesPendingPhotos(int count) {
+    return 'รูปภาพ $count รูปรอการซิงค์';
+  }
+
+  @override
+  String get metaGlassesPairInMetaAI => 'ตั้งค่าในแอป Meta AI';
+
+  @override
+  String get metaGlassesTypeRayBanMeta => 'Ray-Ban Meta';
+
+  @override
+  String get metaGlassesTypeRayBanDisplay => 'Meta Ray-Ban Display';
+
+  @override
+  String get metaGlassesTypeOakleyMeta => 'Oakley Meta';
+
+  @override
+  String get metaGlassesOverheating => 'แว่นกำลังเย็นลง — หยุดจับภาพชั่วคราว';
+
+  @override
+  String get metaGlassesFolded => 'กางแว่นออกเพื่อจับภาพต่อ';
+
+  @override
+  String get metaGlassesCaptureFrequency => 'ความถี่ในการถ่าย';
+
+  @override
+  String get metaGlassesEvery10s => 'ทุก 10 วิ';
+
+  @override
+  String get metaGlassesEvery30s => 'ทุก 30 วิ';
+
+  @override
+  String get metaGlassesEvery1min => 'ทุก 1 นาที';
+
+  @override
+  String get metaGlassesEvery5min => 'ทุก 5 นาที';
+
+  @override
+  String get metaGlassesGestures => 'ท่าทาง';
 }

--- a/app/lib/l10n/app_localizations_tl.dart
+++ b/app/lib/l10n/app_localizations_tl.dart
@@ -9660,4 +9660,96 @@ class AppLocalizationsTl extends AppLocalizations {
   String errorConnectingRayBanMeta(String error) {
     return 'Error sa pagkonekta sa Ray-Ban Meta: $error';
   }
+
+  @override
+  String get metaGlasses => 'Meta Glasses';
+
+  @override
+  String get pairingTitleMetaGlasses => 'Ikonekta ang iyong Meta Glasses';
+
+  @override
+  String get pairingDescMetaGlasses =>
+      'I-pair ang iyong salamin sa Meta AI app, pagkatapos ay i-tap ang Connect sa Omi. Maaari kang mag-link ng higit sa isang pares at piliin kung alin ang aktibo.';
+
+  @override
+  String get metaGlassesUnavailable =>
+      'Hindi natagpuan ang Meta AI app. I-install ang Meta AI at i-enable ang Developer Mode para ikonekta ang iyong salamin.';
+
+  @override
+  String get metaGlassesRegistering => 'Tapusin ang pagkonekta sa Meta AI app, pagkatapos ay bumalik sa Omi.';
+
+  @override
+  String get metaGlassesCameraPermission => 'Payagan ang access sa camera sa Meta AI app';
+
+  @override
+  String get metaGlassesCaptureModeLabel => 'Capture mode';
+
+  @override
+  String get metaGlassesModeCameraMic => 'Camera + mikropono';
+
+  @override
+  String get metaGlassesModeMicOnly => 'Mikropono lamang';
+
+  @override
+  String get metaGlassesStartCapture => 'Simulan ang pag-capture';
+
+  @override
+  String get metaGlassesStopCapture => 'Ihinto ang pag-capture';
+
+  @override
+  String get metaGlassesGestureHint =>
+      'Hindi sinusuportahan ang mga kontrol sa galaw para sa Meta glasses sa build na ito.';
+
+  @override
+  String get connectAnotherDevice => 'Ikonekta ang isa pang device';
+
+  @override
+  String get myDevices => 'Aking Mga Device';
+
+  @override
+  String get metaGlassesAutoCapture => 'Awtomatikong pag-capture kapag nakakonekta';
+
+  @override
+  String get metaGlassesShowPreview => 'Live preview';
+
+  @override
+  String metaGlassesPendingPhotos(int count) {
+    return '$count larawan ang naghihintay ma-sync';
+  }
+
+  @override
+  String get metaGlassesPairInMetaAI => 'I-set up sa Meta AI app';
+
+  @override
+  String get metaGlassesTypeRayBanMeta => 'Ray-Ban Meta';
+
+  @override
+  String get metaGlassesTypeRayBanDisplay => 'Meta Ray-Ban Display';
+
+  @override
+  String get metaGlassesTypeOakleyMeta => 'Oakley Meta';
+
+  @override
+  String get metaGlassesOverheating => 'Lumalamig ang salamin — naka-pause ang pag-capture';
+
+  @override
+  String get metaGlassesFolded => 'Buksan ang salamin para magpatuloy sa pag-capture';
+
+  @override
+  String get metaGlassesCaptureFrequency => 'Dalas ng pagkuha';
+
+  @override
+  String get metaGlassesEvery10s => 'Bawat 10 s';
+
+  @override
+  String get metaGlassesEvery30s => 'Bawat 30 s';
+
+  @override
+  String get metaGlassesEvery1min => 'Bawat 1 min';
+
+  @override
+  String get metaGlassesEvery5min => 'Bawat 5 min';
+
+  @override
+  String get metaGlassesGestures => 'Mga galaw';
 }

--- a/app/lib/l10n/app_localizations_tr.dart
+++ b/app/lib/l10n/app_localizations_tr.dart
@@ -9582,4 +9582,95 @@ class AppLocalizationsTr extends AppLocalizations {
   String errorConnectingRayBanMeta(String error) {
     return 'Ray-Ban Meta\'ya bağlanırken hata: $error';
   }
+
+  @override
+  String get metaGlasses => 'Meta Glasses';
+
+  @override
+  String get pairingTitleMetaGlasses => 'Meta Glasses\'ınızı bağlayın';
+
+  @override
+  String get pairingDescMetaGlasses =>
+      'Gözlüğünüzü Meta AI uygulamasında eşleştirin, ardından Omi\'de Bağlan\'a dokunun. Birden fazla gözlük bağlayabilir ve hangisinin etkin olduğunu seçebilirsiniz.';
+
+  @override
+  String get metaGlassesUnavailable =>
+      'Meta AI uygulaması bulunamadı. Gözlüğünüzü bağlamak için Meta AI\'ı yükleyin ve Geliştirici Modu\'nu etkinleştirin.';
+
+  @override
+  String get metaGlassesRegistering => 'Meta AI uygulamasında bağlantıyı tamamlayın, ardından Omi\'ye dönün.';
+
+  @override
+  String get metaGlassesCameraPermission => 'Meta AI uygulamasında kamera erişimine izin verin';
+
+  @override
+  String get metaGlassesCaptureModeLabel => 'Yakalama modu';
+
+  @override
+  String get metaGlassesModeCameraMic => 'Kamera + mikrofon';
+
+  @override
+  String get metaGlassesModeMicOnly => 'Yalnızca mikrofon';
+
+  @override
+  String get metaGlassesStartCapture => 'Yakalamayı başlat';
+
+  @override
+  String get metaGlassesStopCapture => 'Yakalamayı durdur';
+
+  @override
+  String get metaGlassesGestureHint => 'Bu derlemede Meta gözlükleri için hareket kontrolleri desteklenmiyor.';
+
+  @override
+  String get connectAnotherDevice => 'Başka bir cihaz bağla';
+
+  @override
+  String get myDevices => 'Cihazlarım';
+
+  @override
+  String get metaGlassesAutoCapture => 'Bağlanınca otomatik yakalama';
+
+  @override
+  String get metaGlassesShowPreview => 'Canlı önizleme';
+
+  @override
+  String metaGlassesPendingPhotos(int count) {
+    return '$count fotoğraf eşitlenmeyi bekliyor';
+  }
+
+  @override
+  String get metaGlassesPairInMetaAI => 'Meta AI uygulamasında kurun';
+
+  @override
+  String get metaGlassesTypeRayBanMeta => 'Ray-Ban Meta';
+
+  @override
+  String get metaGlassesTypeRayBanDisplay => 'Meta Ray-Ban Display';
+
+  @override
+  String get metaGlassesTypeOakleyMeta => 'Oakley Meta';
+
+  @override
+  String get metaGlassesOverheating => 'Gözlük soğuyor — yakalama duraklatıldı';
+
+  @override
+  String get metaGlassesFolded => 'Yakalamaya devam etmek için gözlüğü açın';
+
+  @override
+  String get metaGlassesCaptureFrequency => 'Yakalama sıklığı';
+
+  @override
+  String get metaGlassesEvery10s => 'Her 10 sn';
+
+  @override
+  String get metaGlassesEvery30s => 'Her 30 sn';
+
+  @override
+  String get metaGlassesEvery1min => 'Her 1 dk';
+
+  @override
+  String get metaGlassesEvery5min => 'Her 5 dk';
+
+  @override
+  String get metaGlassesGestures => 'Hareketler';
 }

--- a/app/lib/l10n/app_localizations_uk.dart
+++ b/app/lib/l10n/app_localizations_uk.dart
@@ -9591,4 +9591,95 @@ class AppLocalizationsUk extends AppLocalizations {
   String errorConnectingRayBanMeta(String error) {
     return 'Помилка підключення до Ray-Ban Meta: $error';
   }
+
+  @override
+  String get metaGlasses => 'Meta Glasses';
+
+  @override
+  String get pairingTitleMetaGlasses => 'Підключіть свої Meta Glasses';
+
+  @override
+  String get pairingDescMetaGlasses =>
+      'Створіть пару з окулярами в застосунку Meta AI, потім натисніть «Підключити» в Omi. Можна зв\'язати кілька пар і вибрати активну.';
+
+  @override
+  String get metaGlassesUnavailable =>
+      'Застосунок Meta AI не знайдено. Установіть Meta AI та ввімкніть режим розробника, щоб підключити окуляри.';
+
+  @override
+  String get metaGlassesRegistering => 'Завершіть підключення в застосунку Meta AI та поверніться в Omi.';
+
+  @override
+  String get metaGlassesCameraPermission => 'Дозвольте доступ до камери в застосунку Meta AI';
+
+  @override
+  String get metaGlassesCaptureModeLabel => 'Режим запису';
+
+  @override
+  String get metaGlassesModeCameraMic => 'Камера + мікрофон';
+
+  @override
+  String get metaGlassesModeMicOnly => 'Лише мікрофон';
+
+  @override
+  String get metaGlassesStartCapture => 'Почати запис';
+
+  @override
+  String get metaGlassesStopCapture => 'Зупинити запис';
+
+  @override
+  String get metaGlassesGestureHint => 'Керування жестами для окулярів Meta не підтримується в цій збірці.';
+
+  @override
+  String get connectAnotherDevice => 'Підключити інший пристрій';
+
+  @override
+  String get myDevices => 'Мої пристрої';
+
+  @override
+  String get metaGlassesAutoCapture => 'Автозапис під час підключення';
+
+  @override
+  String get metaGlassesShowPreview => 'Попередній перегляд наживо';
+
+  @override
+  String metaGlassesPendingPhotos(int count) {
+    return '$count фото очікують синхронізації';
+  }
+
+  @override
+  String get metaGlassesPairInMetaAI => 'Налаштуйте в застосунку Meta AI';
+
+  @override
+  String get metaGlassesTypeRayBanMeta => 'Ray-Ban Meta';
+
+  @override
+  String get metaGlassesTypeRayBanDisplay => 'Meta Ray-Ban Display';
+
+  @override
+  String get metaGlassesTypeOakleyMeta => 'Oakley Meta';
+
+  @override
+  String get metaGlassesOverheating => 'Окуляри охолоджуються — зйомку призупинено';
+
+  @override
+  String get metaGlassesFolded => 'Розгорніть окуляри, щоб продовжити зйомку';
+
+  @override
+  String get metaGlassesCaptureFrequency => 'Частота зйомки';
+
+  @override
+  String get metaGlassesEvery10s => 'Кожні 10 с';
+
+  @override
+  String get metaGlassesEvery30s => 'Кожні 30 с';
+
+  @override
+  String get metaGlassesEvery1min => 'Щохвилини';
+
+  @override
+  String get metaGlassesEvery5min => 'Кожні 5 хв';
+
+  @override
+  String get metaGlassesGestures => 'Жести';
 }

--- a/app/lib/l10n/app_localizations_ur.dart
+++ b/app/lib/l10n/app_localizations_ur.dart
@@ -9584,4 +9584,95 @@ class AppLocalizationsUr extends AppLocalizations {
   String errorConnectingRayBanMeta(String error) {
     return 'Ray-Ban Meta سے جڑنے میں خرابی: $error';
   }
+
+  @override
+  String get metaGlasses => 'Meta Glasses';
+
+  @override
+  String get pairingTitleMetaGlasses => 'اپنے Meta Glasses منسلک کریں';
+
+  @override
+  String get pairingDescMetaGlasses =>
+      'Meta AI ایپ میں اپنی عینک جوڑیں، پھر Omi میں Connect پر ٹیپ کریں۔ آپ ایک سے زیادہ جوڑے منسلک کر کے فعال جوڑا منتخب کر سکتے ہیں۔';
+
+  @override
+  String get metaGlassesUnavailable =>
+      'Meta AI ایپ نہیں ملی۔ عینک منسلک کرنے کے لیے Meta AI انسٹال کریں اور ڈیولپر موڈ فعال کریں۔';
+
+  @override
+  String get metaGlassesRegistering => 'Meta AI ایپ میں کنکشن مکمل کریں، پھر Omi میں واپس آئیں۔';
+
+  @override
+  String get metaGlassesCameraPermission => 'Meta AI ایپ میں کیمرے تک رسائی کی اجازت دیں';
+
+  @override
+  String get metaGlassesCaptureModeLabel => 'کیپچر موڈ';
+
+  @override
+  String get metaGlassesModeCameraMic => 'کیمرہ + مائیک';
+
+  @override
+  String get metaGlassesModeMicOnly => 'صرف مائیک';
+
+  @override
+  String get metaGlassesStartCapture => 'کیپچر شروع کریں';
+
+  @override
+  String get metaGlassesStopCapture => 'کیپچر روکیں';
+
+  @override
+  String get metaGlassesGestureHint => 'اس بلڈ میں Meta عینک کے لیے اشاروں کے کنٹرولز معاونت یافتہ نہیں ہیں۔';
+
+  @override
+  String get connectAnotherDevice => 'دوسرا آلہ منسلک کریں';
+
+  @override
+  String get myDevices => 'میرے آلات';
+
+  @override
+  String get metaGlassesAutoCapture => 'منسلک ہونے پر خودکار کیپچر';
+
+  @override
+  String get metaGlassesShowPreview => 'براہ راست پیش منظر';
+
+  @override
+  String metaGlassesPendingPhotos(int count) {
+    return '$count تصاویر مطابقت پذیری کی منتظر ہیں';
+  }
+
+  @override
+  String get metaGlassesPairInMetaAI => 'Meta AI ایپ میں سیٹ اپ کریں';
+
+  @override
+  String get metaGlassesTypeRayBanMeta => 'Ray-Ban Meta';
+
+  @override
+  String get metaGlassesTypeRayBanDisplay => 'Meta Ray-Ban Display';
+
+  @override
+  String get metaGlassesTypeOakleyMeta => 'Oakley Meta';
+
+  @override
+  String get metaGlassesOverheating => 'چشمہ ٹھنڈا ہو رہا ہے — کیپچر رکا ہوا ہے';
+
+  @override
+  String get metaGlassesFolded => 'کیپچر جاری رکھنے کے لیے چشمہ کھولیں';
+
+  @override
+  String get metaGlassesCaptureFrequency => 'کیپچر تعدد';
+
+  @override
+  String get metaGlassesEvery10s => 'ہر 10 سیکنڈ';
+
+  @override
+  String get metaGlassesEvery30s => 'ہر 30 سیکنڈ';
+
+  @override
+  String get metaGlassesEvery1min => 'ہر 1 منٹ';
+
+  @override
+  String get metaGlassesEvery5min => 'ہر 5 منٹ';
+
+  @override
+  String get metaGlassesGestures => 'اشارے';
 }

--- a/app/lib/l10n/app_localizations_vi.dart
+++ b/app/lib/l10n/app_localizations_vi.dart
@@ -9568,4 +9568,95 @@ class AppLocalizationsVi extends AppLocalizations {
   String errorConnectingRayBanMeta(String error) {
     return 'Lỗi khi kết nối với Ray-Ban Meta: $error';
   }
+
+  @override
+  String get metaGlasses => 'Meta Glasses';
+
+  @override
+  String get pairingTitleMetaGlasses => 'Kết nối Meta Glasses của bạn';
+
+  @override
+  String get pairingDescMetaGlasses =>
+      'Ghép nối kính trong ứng dụng Meta AI, sau đó nhấn Kết nối trong Omi. Bạn có thể liên kết nhiều cặp và chọn cặp đang hoạt động.';
+
+  @override
+  String get metaGlassesUnavailable =>
+      'Không tìm thấy ứng dụng Meta AI. Hãy cài đặt Meta AI và bật Chế độ nhà phát triển để kết nối kính.';
+
+  @override
+  String get metaGlassesRegistering => 'Hoàn tất kết nối trong ứng dụng Meta AI, sau đó quay lại Omi.';
+
+  @override
+  String get metaGlassesCameraPermission => 'Cho phép truy cập camera trong ứng dụng Meta AI';
+
+  @override
+  String get metaGlassesCaptureModeLabel => 'Chế độ ghi';
+
+  @override
+  String get metaGlassesModeCameraMic => 'Camera + micrô';
+
+  @override
+  String get metaGlassesModeMicOnly => 'Chỉ micrô';
+
+  @override
+  String get metaGlassesStartCapture => 'Bắt đầu ghi';
+
+  @override
+  String get metaGlassesStopCapture => 'Dừng ghi';
+
+  @override
+  String get metaGlassesGestureHint => 'Các điều khiển bằng cử chỉ cho kính Meta không được hỗ trợ trong bản dựng này.';
+
+  @override
+  String get connectAnotherDevice => 'Kết nối thiết bị khác';
+
+  @override
+  String get myDevices => 'Thiết bị của tôi';
+
+  @override
+  String get metaGlassesAutoCapture => 'Tự động ghi khi kết nối';
+
+  @override
+  String get metaGlassesShowPreview => 'Xem trước trực tiếp';
+
+  @override
+  String metaGlassesPendingPhotos(int count) {
+    return '$count ảnh đang chờ đồng bộ';
+  }
+
+  @override
+  String get metaGlassesPairInMetaAI => 'Thiết lập trong ứng dụng Meta AI';
+
+  @override
+  String get metaGlassesTypeRayBanMeta => 'Ray-Ban Meta';
+
+  @override
+  String get metaGlassesTypeRayBanDisplay => 'Meta Ray-Ban Display';
+
+  @override
+  String get metaGlassesTypeOakleyMeta => 'Oakley Meta';
+
+  @override
+  String get metaGlassesOverheating => 'Kính đang hạ nhiệt — đã tạm dừng ghi lại';
+
+  @override
+  String get metaGlassesFolded => 'Mở kính ra để tiếp tục ghi lại';
+
+  @override
+  String get metaGlassesCaptureFrequency => 'Tần suất chụp';
+
+  @override
+  String get metaGlassesEvery10s => 'Mỗi 10 giây';
+
+  @override
+  String get metaGlassesEvery30s => 'Mỗi 30 giây';
+
+  @override
+  String get metaGlassesEvery1min => 'Mỗi 1 phút';
+
+  @override
+  String get metaGlassesEvery5min => 'Mỗi 5 phút';
+
+  @override
+  String get metaGlassesGestures => 'Cử chỉ';
 }

--- a/app/lib/l10n/app_localizations_zh.dart
+++ b/app/lib/l10n/app_localizations_zh.dart
@@ -9395,4 +9395,93 @@ class AppLocalizationsZh extends AppLocalizations {
   String errorConnectingRayBanMeta(String error) {
     return '连接 Ray-Ban Meta 时出错：$error';
   }
+
+  @override
+  String get metaGlasses => 'Meta Glasses';
+
+  @override
+  String get pairingTitleMetaGlasses => '连接您的 Meta Glasses';
+
+  @override
+  String get pairingDescMetaGlasses => '在 Meta AI 应用中配对眼镜，然后在 Omi 中点击“连接”。您可以关联多副眼镜并选择当前使用的一副。';
+
+  @override
+  String get metaGlassesUnavailable => '未检测到 Meta AI 应用。请安装 Meta AI 并启用开发者模式以连接您的眼镜。';
+
+  @override
+  String get metaGlassesRegistering => '在 Meta AI 应用中完成连接，然后返回 Omi。';
+
+  @override
+  String get metaGlassesCameraPermission => '在 Meta AI 应用中允许访问相机';
+
+  @override
+  String get metaGlassesCaptureModeLabel => '采集模式';
+
+  @override
+  String get metaGlassesModeCameraMic => '相机 + 麦克风';
+
+  @override
+  String get metaGlassesModeMicOnly => '仅麦克风';
+
+  @override
+  String get metaGlassesStartCapture => '开始采集';
+
+  @override
+  String get metaGlassesStopCapture => '停止采集';
+
+  @override
+  String get metaGlassesGestureHint => '此版本不支持 Meta 眼镜的手势控制。';
+
+  @override
+  String get connectAnotherDevice => '连接其他设备';
+
+  @override
+  String get myDevices => '我的设备';
+
+  @override
+  String get metaGlassesAutoCapture => '连接时自动采集';
+
+  @override
+  String get metaGlassesShowPreview => '实时预览';
+
+  @override
+  String metaGlassesPendingPhotos(int count) {
+    return '$count 张照片等待同步';
+  }
+
+  @override
+  String get metaGlassesPairInMetaAI => '请在 Meta AI 应用中完成设置';
+
+  @override
+  String get metaGlassesTypeRayBanMeta => 'Ray-Ban Meta';
+
+  @override
+  String get metaGlassesTypeRayBanDisplay => 'Meta Ray-Ban Display';
+
+  @override
+  String get metaGlassesTypeOakleyMeta => 'Oakley Meta';
+
+  @override
+  String get metaGlassesOverheating => '眼镜正在冷却 — 已暂停捕捉';
+
+  @override
+  String get metaGlassesFolded => '展开眼镜以继续捕捉';
+
+  @override
+  String get metaGlassesCaptureFrequency => '采集频率';
+
+  @override
+  String get metaGlassesEvery10s => '每 10 秒';
+
+  @override
+  String get metaGlassesEvery30s => '每 30 秒';
+
+  @override
+  String get metaGlassesEvery1min => '每 1 分钟';
+
+  @override
+  String get metaGlassesEvery5min => '每 5 分钟';
+
+  @override
+  String get metaGlassesGestures => '手势';
 }

--- a/app/lib/l10n/app_lt.arb
+++ b/app/lib/l10n/app_lt.arb
@@ -3142,5 +3142,34 @@
                 "type": "String"
             }
         }
-    }
+    },
+    "metaGlasses": "Meta Glasses",
+    "pairingTitleMetaGlasses": "Prijunkite savo Meta Glasses",
+    "pairingDescMetaGlasses": "Susiekite akinius programoje „Meta AI“, tada Omi palieskite „Prijungti“. Galite susieti kelias poras ir pasirinkti, kuri aktyvi.",
+    "metaGlassesUnavailable": "Programa „Meta AI“ nerasta. Norėdami prijungti akinius, įdiekite „Meta AI“ ir įjunkite kūrėjo režimą.",
+    "metaGlassesRegistering": "Užbaikite prijungimą programoje „Meta AI“ ir grįžkite į Omi.",
+    "metaGlassesCameraPermission": "Leiskite prieigą prie kameros programoje „Meta AI“",
+    "metaGlassesCaptureModeLabel": "Fiksavimo režimas",
+    "metaGlassesModeCameraMic": "Kamera + mikrofonas",
+    "metaGlassesModeMicOnly": "Tik mikrofonas",
+    "metaGlassesStartCapture": "Pradėti fiksavimą",
+    "metaGlassesStopCapture": "Sustabdyti fiksavimą",
+    "metaGlassesGestureHint": "Gestų valdikliai Meta akiniams šiame leidime nepalaikomi.",
+    "connectAnotherDevice": "Prijungti kitą įrenginį",
+    "myDevices": "Mano įrenginiai",
+    "metaGlassesAutoCapture": "Automatinis fiksavimas prisijungus",
+    "metaGlassesShowPreview": "Tiesioginė peržiūra",
+    "metaGlassesPendingPhotos": "{count} nuotraukos laukia sinchronizavimo",
+    "metaGlassesPairInMetaAI": "Nustatykite programoje „Meta AI“",
+    "metaGlassesTypeRayBanMeta": "Ray-Ban Meta",
+    "metaGlassesTypeRayBanDisplay": "Meta Ray-Ban Display",
+    "metaGlassesTypeOakleyMeta": "Oakley Meta",
+    "metaGlassesOverheating": "Akiniai vėsta — fiksavimas pristabdytas",
+    "metaGlassesFolded": "Išskleiskite akinius, kad fiksavimas tęstųsi",
+    "metaGlassesCaptureFrequency": "Fiksavimo dažnis",
+    "metaGlassesEvery10s": "Kas 10 s",
+    "metaGlassesEvery30s": "Kas 30 s",
+    "metaGlassesEvery1min": "Kas 1 min",
+    "metaGlassesEvery5min": "Kas 5 min",
+    "metaGlassesGestures": "Gestai"
 }

--- a/app/lib/l10n/app_lv.arb
+++ b/app/lib/l10n/app_lv.arb
@@ -3142,5 +3142,34 @@
                 "type": "String"
             }
         }
-    }
+    },
+    "metaGlasses": "Meta Glasses",
+    "pairingTitleMetaGlasses": "Savienojiet savas Meta Glasses",
+    "pairingDescMetaGlasses": "Sapārojiet brilles lietotnē Meta AI, pēc tam Omi pieskarieties Savienot. Varat sasaistīt vairākus pārus un izvēlēties aktīvo.",
+    "metaGlassesUnavailable": "Lietotne Meta AI nav atrasta. Lai savienotu brilles, instalējiet Meta AI un ieslēdziet izstrādātāja režīmu.",
+    "metaGlassesRegistering": "Pabeidziet savienošanu lietotnē Meta AI un atgriezieties Omi.",
+    "metaGlassesCameraPermission": "Atļaujiet piekļuvi kamerai lietotnē Meta AI",
+    "metaGlassesCaptureModeLabel": "Tveršanas režīms",
+    "metaGlassesModeCameraMic": "Kamera + mikrofons",
+    "metaGlassesModeMicOnly": "Tikai mikrofons",
+    "metaGlassesStartCapture": "Sākt tveršanu",
+    "metaGlassesStopCapture": "Apturēt tveršanu",
+    "metaGlassesGestureHint": "Žestu vadība Meta brillēm šajā būvējumā netiek atbalstīta.",
+    "connectAnotherDevice": "Savienot citu ierīci",
+    "myDevices": "Manas ierīces",
+    "metaGlassesAutoCapture": "Automātiska tveršana pēc savienošanas",
+    "metaGlassesShowPreview": "Tiešais priekšskatījums",
+    "metaGlassesPendingPhotos": "{count} fotoattēli gaida sinhronizāciju",
+    "metaGlassesPairInMetaAI": "Iestatiet lietotnē Meta AI",
+    "metaGlassesTypeRayBanMeta": "Ray-Ban Meta",
+    "metaGlassesTypeRayBanDisplay": "Meta Ray-Ban Display",
+    "metaGlassesTypeOakleyMeta": "Oakley Meta",
+    "metaGlassesOverheating": "Brilles atdziest — tveršana apturēta",
+    "metaGlassesFolded": "Atlokiet brilles, lai turpinātu tveršanu",
+    "metaGlassesCaptureFrequency": "Uzņemšanas biežums",
+    "metaGlassesEvery10s": "Ik pēc 10 s",
+    "metaGlassesEvery30s": "Ik pēc 30 s",
+    "metaGlassesEvery1min": "Ik pēc 1 min",
+    "metaGlassesEvery5min": "Ik pēc 5 min",
+    "metaGlassesGestures": "Žesti"
 }

--- a/app/lib/l10n/app_mk.arb
+++ b/app/lib/l10n/app_mk.arb
@@ -10720,5 +10720,34 @@
                 "type": "String"
             }
         }
-    }
+    },
+    "metaGlasses": "Meta Glasses",
+    "pairingTitleMetaGlasses": "Поврзете ги вашите Meta Glasses",
+    "pairingDescMetaGlasses": "Спарете ги очилата во апликацијата Meta AI, а потоа допрете Поврзи во Omi. Може да поврзете повеќе пара и да изберете кој е активен.",
+    "metaGlassesUnavailable": "Апликацијата Meta AI не е пронајдена. Инсталирајте Meta AI и вклучете режим за програмери за да ги поврзете очилата.",
+    "metaGlassesRegistering": "Завршете го поврзувањето во апликацијата Meta AI и вратете се во Omi.",
+    "metaGlassesCameraPermission": "Дозволете пристап до камерата во апликацијата Meta AI",
+    "metaGlassesCaptureModeLabel": "Режим на снимање",
+    "metaGlassesModeCameraMic": "Камера + микрофон",
+    "metaGlassesModeMicOnly": "Само микрофон",
+    "metaGlassesStartCapture": "Започни снимање",
+    "metaGlassesStopCapture": "Запри снимање",
+    "metaGlassesGestureHint": "Контролите со гестови за Meta очилата не се поддржани во оваа верзија.",
+    "connectAnotherDevice": "Поврзи друг уред",
+    "myDevices": "Мои уреди",
+    "metaGlassesAutoCapture": "Автоматско снимање при поврзување",
+    "metaGlassesShowPreview": "Преглед во живо",
+    "metaGlassesPendingPhotos": "{count} фотографии чекаат синхронизација",
+    "metaGlassesPairInMetaAI": "Поставете во апликацијата Meta AI",
+    "metaGlassesTypeRayBanMeta": "Ray-Ban Meta",
+    "metaGlassesTypeRayBanDisplay": "Meta Ray-Ban Display",
+    "metaGlassesTypeOakleyMeta": "Oakley Meta",
+    "metaGlassesOverheating": "Очилата се ладат — снимањето е паузирано",
+    "metaGlassesFolded": "Расклопете ги очилата за да продолжи снимањето",
+    "metaGlassesCaptureFrequency": "Честота на снимање",
+    "metaGlassesEvery10s": "На секои 10 с",
+    "metaGlassesEvery30s": "На секои 30 с",
+    "metaGlassesEvery1min": "На секоја 1 мин",
+    "metaGlassesEvery5min": "На секои 5 мин",
+    "metaGlassesGestures": "Гестови"
 }

--- a/app/lib/l10n/app_mr.arb
+++ b/app/lib/l10n/app_mr.arb
@@ -10720,5 +10720,34 @@
                 "type": "String"
             }
         }
-    }
+    },
+    "metaGlasses": "Meta Glasses",
+    "pairingTitleMetaGlasses": "तुमचे Meta Glasses कनेक्ट करा",
+    "pairingDescMetaGlasses": "Meta AI अ‍ॅपमध्ये तुमचा चष्मा पेअर करा, नंतर Omi मध्ये Connect वर टॅप करा. तुम्ही एकाहून अधिक जोड्या लिंक करू शकता आणि सक्रिय जोडी निवडू शकता.",
+    "metaGlassesUnavailable": "Meta AI अ‍ॅप आढळले नाही. चष्मा कनेक्ट करण्यासाठी Meta AI इन्स्टॉल करा आणि डेव्हलपर मोड सुरू करा.",
+    "metaGlassesRegistering": "Meta AI अ‍ॅपमध्ये कनेक्शन पूर्ण करा, नंतर Omi मध्ये परत या.",
+    "metaGlassesCameraPermission": "Meta AI अ‍ॅपमध्ये कॅमेरा अ‍ॅक्सेसला परवानगी द्या",
+    "metaGlassesCaptureModeLabel": "कॅप्चर मोड",
+    "metaGlassesModeCameraMic": "कॅमेरा + माइक",
+    "metaGlassesModeMicOnly": "फक्त माइक",
+    "metaGlassesStartCapture": "कॅप्चर सुरू करा",
+    "metaGlassesStopCapture": "कॅप्चर थांबवा",
+    "metaGlassesGestureHint": "या बिल्डमध्ये Meta चष्म्यांसाठी जेश्चर नियंत्रणे समर्थित नाहीत.",
+    "connectAnotherDevice": "दुसरे डिव्हाइस कनेक्ट करा",
+    "myDevices": "माझी डिव्हाइसेस",
+    "metaGlassesAutoCapture": "कनेक्ट झाल्यावर स्वयं-कॅप्चर",
+    "metaGlassesShowPreview": "लाइव्ह पूर्वावलोकन",
+    "metaGlassesPendingPhotos": "{count} फोटो सिंकच्या प्रतीक्षेत",
+    "metaGlassesPairInMetaAI": "Meta AI अ‍ॅपमध्ये सेट करा",
+    "metaGlassesTypeRayBanMeta": "Ray-Ban Meta",
+    "metaGlassesTypeRayBanDisplay": "Meta Ray-Ban Display",
+    "metaGlassesTypeOakleyMeta": "Oakley Meta",
+    "metaGlassesOverheating": "चष्मा थंड होत आहे — कॅप्चर थांबवले आहे",
+    "metaGlassesFolded": "कॅप्चर सुरू ठेवण्यासाठी चष्मा उघडा",
+    "metaGlassesCaptureFrequency": "कॅप्चर वारंवारता",
+    "metaGlassesEvery10s": "दर 10 से",
+    "metaGlassesEvery30s": "दर 30 से",
+    "metaGlassesEvery1min": "दर 1 मिन",
+    "metaGlassesEvery5min": "दर 5 मिन",
+    "metaGlassesGestures": "जेश्चर"
 }

--- a/app/lib/l10n/app_ms.arb
+++ b/app/lib/l10n/app_ms.arb
@@ -3142,5 +3142,34 @@
                 "type": "String"
             }
         }
-    }
+    },
+    "metaGlasses": "Meta Glasses",
+    "pairingTitleMetaGlasses": "Sambungkan Meta Glasses anda",
+    "pairingDescMetaGlasses": "Gandingkan cermin mata anda dalam aplikasi Meta AI, kemudian ketik Sambung dalam Omi. Anda boleh memautkan lebih daripada satu pasang dan memilih yang aktif.",
+    "metaGlassesUnavailable": "Aplikasi Meta AI tidak ditemui. Pasang Meta AI dan aktifkan Mod Pembangun untuk menyambungkan cermin mata anda.",
+    "metaGlassesRegistering": "Selesaikan sambungan dalam aplikasi Meta AI, kemudian kembali ke Omi.",
+    "metaGlassesCameraPermission": "Benarkan akses kamera dalam aplikasi Meta AI",
+    "metaGlassesCaptureModeLabel": "Mod rakaman",
+    "metaGlassesModeCameraMic": "Kamera + mikrofon",
+    "metaGlassesModeMicOnly": "Mikrofon sahaja",
+    "metaGlassesStartCapture": "Mula merakam",
+    "metaGlassesStopCapture": "Henti merakam",
+    "metaGlassesGestureHint": "Kawalan gerak isyarat untuk cermin mata Meta tidak disokong dalam binaan ini.",
+    "connectAnotherDevice": "Sambungkan peranti lain",
+    "myDevices": "Peranti Saya",
+    "metaGlassesAutoCapture": "Rakaman automatik apabila disambungkan",
+    "metaGlassesShowPreview": "Pratonton langsung",
+    "metaGlassesPendingPhotos": "{count} foto menunggu penyegerakan",
+    "metaGlassesPairInMetaAI": "Sediakan dalam aplikasi Meta AI",
+    "metaGlassesTypeRayBanMeta": "Ray-Ban Meta",
+    "metaGlassesTypeRayBanDisplay": "Meta Ray-Ban Display",
+    "metaGlassesTypeOakleyMeta": "Oakley Meta",
+    "metaGlassesOverheating": "Cermin mata sedang menyejuk — tangkapan dijeda",
+    "metaGlassesFolded": "Buka cermin mata untuk terus menangkap",
+    "metaGlassesCaptureFrequency": "Kekerapan tangkapan",
+    "metaGlassesEvery10s": "Setiap 10 s",
+    "metaGlassesEvery30s": "Setiap 30 s",
+    "metaGlassesEvery1min": "Setiap 1 min",
+    "metaGlassesEvery5min": "Setiap 5 min",
+    "metaGlassesGestures": "Gerak isyarat"
 }

--- a/app/lib/l10n/app_nl.arb
+++ b/app/lib/l10n/app_nl.arb
@@ -3142,5 +3142,34 @@
                 "type": "String"
             }
         }
-    }
+    },
+    "metaGlasses": "Meta Glasses",
+    "pairingTitleMetaGlasses": "Verbind je Meta Glasses",
+    "pairingDescMetaGlasses": "Koppel je bril in de Meta AI-app en tik vervolgens op Verbinden in Omi. Je kunt meerdere brillen koppelen en kiezen welke actief is.",
+    "metaGlassesUnavailable": "Meta AI-app niet gevonden. Installeer Meta AI en schakel de ontwikkelaarsmodus in om je bril te verbinden.",
+    "metaGlassesRegistering": "Voltooi de verbinding in de Meta AI-app en keer terug naar Omi.",
+    "metaGlassesCameraPermission": "Sta cameratoegang toe in de Meta AI-app",
+    "metaGlassesCaptureModeLabel": "Opnamemodus",
+    "metaGlassesModeCameraMic": "Camera + microfoon",
+    "metaGlassesModeMicOnly": "Alleen microfoon",
+    "metaGlassesStartCapture": "Opname starten",
+    "metaGlassesStopCapture": "Opname stoppen",
+    "metaGlassesGestureHint": "Gebarenbediening voor Meta-brillen wordt in deze build niet ondersteund.",
+    "connectAnotherDevice": "Nog een apparaat verbinden",
+    "myDevices": "Mijn apparaten",
+    "metaGlassesAutoCapture": "Automatisch opnemen bij verbinding",
+    "metaGlassesShowPreview": "Live voorbeeld",
+    "metaGlassesPendingPhotos": "{count} foto's wachten op synchronisatie",
+    "metaGlassesPairInMetaAI": "Stel in via de Meta AI-app",
+    "metaGlassesTypeRayBanMeta": "Ray-Ban Meta",
+    "metaGlassesTypeRayBanDisplay": "Meta Ray-Ban Display",
+    "metaGlassesTypeOakleyMeta": "Oakley Meta",
+    "metaGlassesOverheating": "De bril koelt af — opname gepauzeerd",
+    "metaGlassesFolded": "Vouw je bril open om door te gaan met opnemen",
+    "metaGlassesCaptureFrequency": "Opnamefrequentie",
+    "metaGlassesEvery10s": "Elke 10 s",
+    "metaGlassesEvery30s": "Elke 30 s",
+    "metaGlassesEvery1min": "Elke 1 min",
+    "metaGlassesEvery5min": "Elke 5 min",
+    "metaGlassesGestures": "Gebaren"
 }

--- a/app/lib/l10n/app_no.arb
+++ b/app/lib/l10n/app_no.arb
@@ -3142,5 +3142,34 @@
                 "type": "String"
             }
         }
-    }
+    },
+    "metaGlasses": "Meta Glasses",
+    "pairingTitleMetaGlasses": "Koble til dine Meta Glasses",
+    "pairingDescMetaGlasses": "Par brillene i Meta AI-appen, og trykk deretter på Koble til i Omi. Du kan koble til flere par og velge hvilket som er aktivt.",
+    "metaGlassesUnavailable": "Fant ikke Meta AI-appen. Installer Meta AI og aktiver utviklermodus for å koble til brillene.",
+    "metaGlassesRegistering": "Fullfør tilkoblingen i Meta AI-appen, og gå tilbake til Omi.",
+    "metaGlassesCameraPermission": "Tillat kameratilgang i Meta AI-appen",
+    "metaGlassesCaptureModeLabel": "Opptaksmodus",
+    "metaGlassesModeCameraMic": "Kamera + mikrofon",
+    "metaGlassesModeMicOnly": "Kun mikrofon",
+    "metaGlassesStartCapture": "Start opptak",
+    "metaGlassesStopCapture": "Stopp opptak",
+    "metaGlassesGestureHint": "Bevegelseskontroller for Meta-briller støttes ikke i denne versjonen.",
+    "connectAnotherDevice": "Koble til en annen enhet",
+    "myDevices": "Mine enheter",
+    "metaGlassesAutoCapture": "Automatisk opptak ved tilkobling",
+    "metaGlassesShowPreview": "Direkte forhåndsvisning",
+    "metaGlassesPendingPhotos": "{count} bilder venter på synkronisering",
+    "metaGlassesPairInMetaAI": "Konfigurer i Meta AI-appen",
+    "metaGlassesTypeRayBanMeta": "Ray-Ban Meta",
+    "metaGlassesTypeRayBanDisplay": "Meta Ray-Ban Display",
+    "metaGlassesTypeOakleyMeta": "Oakley Meta",
+    "metaGlassesOverheating": "Brillene kjøles ned — opptak satt på pause",
+    "metaGlassesFolded": "Brett ut brillene for å fortsette opptaket",
+    "metaGlassesCaptureFrequency": "Opptaksfrekvens",
+    "metaGlassesEvery10s": "Hvert 10. s",
+    "metaGlassesEvery30s": "Hvert 30. s",
+    "metaGlassesEvery1min": "Hvert 1. min",
+    "metaGlassesEvery5min": "Hvert 5. min",
+    "metaGlassesGestures": "Bevegelser"
 }

--- a/app/lib/l10n/app_pl.arb
+++ b/app/lib/l10n/app_pl.arb
@@ -3177,5 +3177,34 @@
                 "type": "String"
             }
         }
-    }
+    },
+    "metaGlasses": "Meta Glasses",
+    "pairingTitleMetaGlasses": "Połącz swoje Meta Glasses",
+    "pairingDescMetaGlasses": "Sparuj okulary w aplikacji Meta AI, a następnie stuknij Połącz w Omi. Możesz połączyć więcej niż jedną parę i wybrać aktywną.",
+    "metaGlassesUnavailable": "Nie znaleziono aplikacji Meta AI. Zainstaluj Meta AI i włącz tryb programisty, aby połączyć okulary.",
+    "metaGlassesRegistering": "Dokończ łączenie w aplikacji Meta AI, a następnie wróć do Omi.",
+    "metaGlassesCameraPermission": "Zezwól na dostęp do kamery w aplikacji Meta AI",
+    "metaGlassesCaptureModeLabel": "Tryb nagrywania",
+    "metaGlassesModeCameraMic": "Kamera + mikrofon",
+    "metaGlassesModeMicOnly": "Tylko mikrofon",
+    "metaGlassesStartCapture": "Rozpocznij nagrywanie",
+    "metaGlassesStopCapture": "Zatrzymaj nagrywanie",
+    "metaGlassesGestureHint": "Sterowanie gestami dla okularów Meta nie jest obsługiwane w tej kompilacji.",
+    "connectAnotherDevice": "Połącz kolejne urządzenie",
+    "myDevices": "Moje urządzenia",
+    "metaGlassesAutoCapture": "Automatyczne nagrywanie po połączeniu",
+    "metaGlassesShowPreview": "Podgląd na żywo",
+    "metaGlassesPendingPhotos": "{count} zdjęć czeka na synchronizację",
+    "metaGlassesPairInMetaAI": "Skonfiguruj w aplikacji Meta AI",
+    "metaGlassesTypeRayBanMeta": "Ray-Ban Meta",
+    "metaGlassesTypeRayBanDisplay": "Meta Ray-Ban Display",
+    "metaGlassesTypeOakleyMeta": "Oakley Meta",
+    "metaGlassesOverheating": "Okulary się chłodzą — przechwytywanie wstrzymane",
+    "metaGlassesFolded": "Rozłóż okulary, aby kontynuować przechwytywanie",
+    "metaGlassesCaptureFrequency": "Częstotliwość zdjęć",
+    "metaGlassesEvery10s": "Co 10 s",
+    "metaGlassesEvery30s": "Co 30 s",
+    "metaGlassesEvery1min": "Co 1 min",
+    "metaGlassesEvery5min": "Co 5 min",
+    "metaGlassesGestures": "Gesty"
 }

--- a/app/lib/l10n/app_pt.arb
+++ b/app/lib/l10n/app_pt.arb
@@ -3178,5 +3178,34 @@
                 "type": "String"
             }
         }
-    }
+    },
+    "metaGlasses": "Meta Glasses",
+    "pairingTitleMetaGlasses": "Conecte seus Meta Glasses",
+    "pairingDescMetaGlasses": "Emparelhe seus óculos no app Meta AI e depois toque em Conectar no Omi. Você pode vincular mais de um par e escolher qual está ativo.",
+    "metaGlassesUnavailable": "App Meta AI não encontrado. Instale o Meta AI e ative o modo de desenvolvedor para conectar seus óculos.",
+    "metaGlassesRegistering": "Conclua a conexão no app Meta AI e volte ao Omi.",
+    "metaGlassesCameraPermission": "Permita o acesso à câmera no app Meta AI",
+    "metaGlassesCaptureModeLabel": "Modo de captura",
+    "metaGlassesModeCameraMic": "Câmera + microfone",
+    "metaGlassesModeMicOnly": "Apenas microfone",
+    "metaGlassesStartCapture": "Iniciar captura",
+    "metaGlassesStopCapture": "Parar captura",
+    "metaGlassesGestureHint": "Os controles por gestos dos óculos Meta não são compatíveis nesta versão.",
+    "connectAnotherDevice": "Conectar outro dispositivo",
+    "myDevices": "Meus dispositivos",
+    "metaGlassesAutoCapture": "Captura automática ao conectar",
+    "metaGlassesShowPreview": "Prévia ao vivo",
+    "metaGlassesPendingPhotos": "{count} fotos aguardando sincronização",
+    "metaGlassesPairInMetaAI": "Configure no app Meta AI",
+    "metaGlassesTypeRayBanMeta": "Ray-Ban Meta",
+    "metaGlassesTypeRayBanDisplay": "Meta Ray-Ban Display",
+    "metaGlassesTypeOakleyMeta": "Oakley Meta",
+    "metaGlassesOverheating": "Os óculos estão esfriando — captura pausada",
+    "metaGlassesFolded": "Abra os óculos para continuar capturando",
+    "metaGlassesCaptureFrequency": "Frequência de captura",
+    "metaGlassesEvery10s": "A cada 10 s",
+    "metaGlassesEvery30s": "A cada 30 s",
+    "metaGlassesEvery1min": "A cada 1 min",
+    "metaGlassesEvery5min": "A cada 5 min",
+    "metaGlassesGestures": "Gestos"
 }

--- a/app/lib/l10n/app_ro.arb
+++ b/app/lib/l10n/app_ro.arb
@@ -3142,5 +3142,34 @@
                 "type": "String"
             }
         }
-    }
+    },
+    "metaGlasses": "Meta Glasses",
+    "pairingTitleMetaGlasses": "Conectează-ți Meta Glasses",
+    "pairingDescMetaGlasses": "Asociază ochelarii în aplicația Meta AI, apoi atinge Conectare în Omi. Poți lega mai multe perechi și alege care este activă.",
+    "metaGlassesUnavailable": "Aplicația Meta AI nu a fost găsită. Instalează Meta AI și activează modul pentru dezvoltatori pentru a conecta ochelarii.",
+    "metaGlassesRegistering": "Finalizează conectarea în aplicația Meta AI, apoi revino în Omi.",
+    "metaGlassesCameraPermission": "Permite accesul la cameră în aplicația Meta AI",
+    "metaGlassesCaptureModeLabel": "Mod de captură",
+    "metaGlassesModeCameraMic": "Cameră + microfon",
+    "metaGlassesModeMicOnly": "Doar microfon",
+    "metaGlassesStartCapture": "Pornește captura",
+    "metaGlassesStopCapture": "Oprește captura",
+    "metaGlassesGestureHint": "Comenzile prin gesturi pentru ochelarii Meta nu sunt acceptate în această versiune.",
+    "connectAnotherDevice": "Conectează alt dispozitiv",
+    "myDevices": "Dispozitivele mele",
+    "metaGlassesAutoCapture": "Captură automată la conectare",
+    "metaGlassesShowPreview": "Previzualizare live",
+    "metaGlassesPendingPhotos": "{count} fotografii așteaptă sincronizarea",
+    "metaGlassesPairInMetaAI": "Configurează în aplicația Meta AI",
+    "metaGlassesTypeRayBanMeta": "Ray-Ban Meta",
+    "metaGlassesTypeRayBanDisplay": "Meta Ray-Ban Display",
+    "metaGlassesTypeOakleyMeta": "Oakley Meta",
+    "metaGlassesOverheating": "Ochelarii se răcesc — capturarea este întreruptă",
+    "metaGlassesFolded": "Deschide ochelarii pentru a continua capturarea",
+    "metaGlassesCaptureFrequency": "Frecvența capturii",
+    "metaGlassesEvery10s": "La fiecare 10 s",
+    "metaGlassesEvery30s": "La fiecare 30 s",
+    "metaGlassesEvery1min": "La fiecare 1 min",
+    "metaGlassesEvery5min": "La fiecare 5 min",
+    "metaGlassesGestures": "Gesturi"
 }

--- a/app/lib/l10n/app_ru.arb
+++ b/app/lib/l10n/app_ru.arb
@@ -3177,5 +3177,34 @@
                 "type": "String"
             }
         }
-    }
+    },
+    "metaGlasses": "Meta Glasses",
+    "pairingTitleMetaGlasses": "Подключите ваши Meta Glasses",
+    "pairingDescMetaGlasses": "Выполните сопряжение очков в приложении Meta AI, затем нажмите «Подключить» в Omi. Можно привязать несколько пар и выбрать активную.",
+    "metaGlassesUnavailable": "Приложение Meta AI не найдено. Установите Meta AI и включите режим разработчика, чтобы подключить очки.",
+    "metaGlassesRegistering": "Завершите подключение в приложении Meta AI и вернитесь в Omi.",
+    "metaGlassesCameraPermission": "Разрешите доступ к камере в приложении Meta AI",
+    "metaGlassesCaptureModeLabel": "Режим записи",
+    "metaGlassesModeCameraMic": "Камера + микрофон",
+    "metaGlassesModeMicOnly": "Только микрофон",
+    "metaGlassesStartCapture": "Начать запись",
+    "metaGlassesStopCapture": "Остановить запись",
+    "metaGlassesGestureHint": "Управление жестами для очков Meta не поддерживается в этой сборке.",
+    "connectAnotherDevice": "Подключить другое устройство",
+    "myDevices": "Мои устройства",
+    "metaGlassesAutoCapture": "Автозапись при подключении",
+    "metaGlassesShowPreview": "Живой предпросмотр",
+    "metaGlassesPendingPhotos": "{count} фото ожидают синхронизации",
+    "metaGlassesPairInMetaAI": "Настройте в приложении Meta AI",
+    "metaGlassesTypeRayBanMeta": "Ray-Ban Meta",
+    "metaGlassesTypeRayBanDisplay": "Meta Ray-Ban Display",
+    "metaGlassesTypeOakleyMeta": "Oakley Meta",
+    "metaGlassesOverheating": "Очки охлаждаются — съемка приостановлена",
+    "metaGlassesFolded": "Разложите очки, чтобы продолжить съемку",
+    "metaGlassesCaptureFrequency": "Частота съёмки",
+    "metaGlassesEvery10s": "Каждые 10 с",
+    "metaGlassesEvery30s": "Каждые 30 с",
+    "metaGlassesEvery1min": "Каждую 1 мин",
+    "metaGlassesEvery5min": "Каждые 5 мин",
+    "metaGlassesGestures": "Жесты"
 }

--- a/app/lib/l10n/app_sk.arb
+++ b/app/lib/l10n/app_sk.arb
@@ -3147,5 +3147,34 @@
                 "type": "String"
             }
         }
-    }
+    },
+    "metaGlasses": "Meta Glasses",
+    "pairingTitleMetaGlasses": "Pripojte svoje Meta Glasses",
+    "pairingDescMetaGlasses": "Spárujte okuliare v aplikácii Meta AI a potom klepnite na Pripojiť v Omi. Môžete prepojiť viac párov a vybrať, ktorý je aktívny.",
+    "metaGlassesUnavailable": "Aplikácia Meta AI sa nenašla. Nainštalujte Meta AI a zapnite režim pre vývojárov, aby ste okuliare pripojili.",
+    "metaGlassesRegistering": "Dokončite pripojenie v aplikácii Meta AI a vráťte sa do Omi.",
+    "metaGlassesCameraPermission": "Povoľte prístup ku kamere v aplikácii Meta AI",
+    "metaGlassesCaptureModeLabel": "Režim záznamu",
+    "metaGlassesModeCameraMic": "Kamera + mikrofón",
+    "metaGlassesModeMicOnly": "Iba mikrofón",
+    "metaGlassesStartCapture": "Spustiť záznam",
+    "metaGlassesStopCapture": "Zastaviť záznam",
+    "metaGlassesGestureHint": "Ovládanie gestami pre okuliare Meta nie je v tejto verzii podporované.",
+    "connectAnotherDevice": "Pripojiť ďalšie zariadenie",
+    "myDevices": "Moje zariadenia",
+    "metaGlassesAutoCapture": "Automatický záznam po pripojení",
+    "metaGlassesShowPreview": "Živý náhľad",
+    "metaGlassesPendingPhotos": "{count} fotiek čaká na synchronizáciu",
+    "metaGlassesPairInMetaAI": "Nastavte v aplikácii Meta AI",
+    "metaGlassesTypeRayBanMeta": "Ray-Ban Meta",
+    "metaGlassesTypeRayBanDisplay": "Meta Ray-Ban Display",
+    "metaGlassesTypeOakleyMeta": "Oakley Meta",
+    "metaGlassesOverheating": "Okuliare sa ochladzujú — snímanie je pozastavené",
+    "metaGlassesFolded": "Rozložte okuliare, aby snímanie pokračovalo",
+    "metaGlassesCaptureFrequency": "Frekvencia snímania",
+    "metaGlassesEvery10s": "Každých 10 s",
+    "metaGlassesEvery30s": "Každých 30 s",
+    "metaGlassesEvery1min": "Každú 1 min",
+    "metaGlassesEvery5min": "Každých 5 min",
+    "metaGlassesGestures": "Gestá"
 }

--- a/app/lib/l10n/app_sl.arb
+++ b/app/lib/l10n/app_sl.arb
@@ -10720,5 +10720,34 @@
                 "type": "String"
             }
         }
-    }
+    },
+    "metaGlasses": "Meta Glasses",
+    "pairingTitleMetaGlasses": "Povežite svoja Meta Glasses",
+    "pairingDescMetaGlasses": "Seznanite očala v aplikaciji Meta AI, nato tapnite Poveži v Omi. Povežete lahko več parov in izberete, kateri je aktiven.",
+    "metaGlassesUnavailable": "Aplikacije Meta AI ni mogoče najti. Namestite Meta AI in vklopite razvijalski način, da povežete očala.",
+    "metaGlassesRegistering": "Dokončajte povezovanje v aplikaciji Meta AI in se vrnite v Omi.",
+    "metaGlassesCameraPermission": "Dovolite dostop do kamere v aplikaciji Meta AI",
+    "metaGlassesCaptureModeLabel": "Način zajema",
+    "metaGlassesModeCameraMic": "Kamera + mikrofon",
+    "metaGlassesModeMicOnly": "Samo mikrofon",
+    "metaGlassesStartCapture": "Začni zajem",
+    "metaGlassesStopCapture": "Ustavi zajem",
+    "metaGlassesGestureHint": "Upravljanje s kretnjami za očala Meta v tej gradnji ni podprto.",
+    "connectAnotherDevice": "Poveži drugo napravo",
+    "myDevices": "Moje naprave",
+    "metaGlassesAutoCapture": "Samodejni zajem ob povezavi",
+    "metaGlassesShowPreview": "Predogled v živo",
+    "metaGlassesPendingPhotos": "{count} fotografij čaka na sinhronizacijo",
+    "metaGlassesPairInMetaAI": "Nastavite v aplikaciji Meta AI",
+    "metaGlassesTypeRayBanMeta": "Ray-Ban Meta",
+    "metaGlassesTypeRayBanDisplay": "Meta Ray-Ban Display",
+    "metaGlassesTypeOakleyMeta": "Oakley Meta",
+    "metaGlassesOverheating": "Očala se ohlajajo — zajem je začasno ustavljen",
+    "metaGlassesFolded": "Razprite očala za nadaljevanje zajema",
+    "metaGlassesCaptureFrequency": "Pogostost zajema",
+    "metaGlassesEvery10s": "Vsakih 10 s",
+    "metaGlassesEvery30s": "Vsakih 30 s",
+    "metaGlassesEvery1min": "Vsako 1 min",
+    "metaGlassesEvery5min": "Vsakih 5 min",
+    "metaGlassesGestures": "Poteze"
 }

--- a/app/lib/l10n/app_sr.arb
+++ b/app/lib/l10n/app_sr.arb
@@ -10720,5 +10720,34 @@
                 "type": "String"
             }
         }
-    }
+    },
+    "metaGlasses": "Meta Glasses",
+    "pairingTitleMetaGlasses": "Повежите своје Meta Glasses",
+    "pairingDescMetaGlasses": "Упарите наочаре у апликацији Meta AI, затим додирните Повежи у Omi. Можете повезати више пари и изабрати који је активан.",
+    "metaGlassesUnavailable": "Апликација Meta AI није пронађена. Инсталирајте Meta AI и укључите режим за програмере да бисте повезали наочаре.",
+    "metaGlassesRegistering": "Довршите повезивање у апликацији Meta AI, а затим се вратите у Omi.",
+    "metaGlassesCameraPermission": "Дозволите приступ камери у апликацији Meta AI",
+    "metaGlassesCaptureModeLabel": "Режим снимања",
+    "metaGlassesModeCameraMic": "Камера + микрофон",
+    "metaGlassesModeMicOnly": "Само микрофон",
+    "metaGlassesStartCapture": "Покрени снимање",
+    "metaGlassesStopCapture": "Заустави снимање",
+    "metaGlassesGestureHint": "Контроле покретима за Meta наочаре нису подржане у овој верзији.",
+    "connectAnotherDevice": "Повежи други уређај",
+    "myDevices": "Моји уређаји",
+    "metaGlassesAutoCapture": "Аутоматско снимање при повезивању",
+    "metaGlassesShowPreview": "Преглед уживо",
+    "metaGlassesPendingPhotos": "{count} фотографија чека синхронизацију",
+    "metaGlassesPairInMetaAI": "Подесите у апликацији Meta AI",
+    "metaGlassesTypeRayBanMeta": "Ray-Ban Meta",
+    "metaGlassesTypeRayBanDisplay": "Meta Ray-Ban Display",
+    "metaGlassesTypeOakleyMeta": "Oakley Meta",
+    "metaGlassesOverheating": "Naočare se hlade — snimanje je pauzirano",
+    "metaGlassesFolded": "Rasklopite naočare da nastavite snimanje",
+    "metaGlassesCaptureFrequency": "Учесталост снимања",
+    "metaGlassesEvery10s": "Свеких 10 с",
+    "metaGlassesEvery30s": "Свеких 30 с",
+    "metaGlassesEvery1min": "Сваког 1 мин",
+    "metaGlassesEvery5min": "Свеких 5 мин",
+    "metaGlassesGestures": "Гестови"
 }

--- a/app/lib/l10n/app_sv.arb
+++ b/app/lib/l10n/app_sv.arb
@@ -3142,5 +3142,34 @@
                 "type": "String"
             }
         }
-    }
+    },
+    "metaGlasses": "Meta Glasses",
+    "pairingTitleMetaGlasses": "Anslut dina Meta Glasses",
+    "pairingDescMetaGlasses": "Parkoppla dina glasögon i Meta AI-appen och tryck sedan på Anslut i Omi. Du kan länka flera par och välja vilket som är aktivt.",
+    "metaGlassesUnavailable": "Meta AI-appen hittades inte. Installera Meta AI och aktivera utvecklarläget för att ansluta dina glasögon.",
+    "metaGlassesRegistering": "Slutför anslutningen i Meta AI-appen och återgå till Omi.",
+    "metaGlassesCameraPermission": "Tillåt kameraåtkomst i Meta AI-appen",
+    "metaGlassesCaptureModeLabel": "Inspelningsläge",
+    "metaGlassesModeCameraMic": "Kamera + mikrofon",
+    "metaGlassesModeMicOnly": "Endast mikrofon",
+    "metaGlassesStartCapture": "Starta inspelning",
+    "metaGlassesStopCapture": "Stoppa inspelning",
+    "metaGlassesGestureHint": "Geststyrning för Meta-glasögon stöds inte i den här versionen.",
+    "connectAnotherDevice": "Anslut en annan enhet",
+    "myDevices": "Mina enheter",
+    "metaGlassesAutoCapture": "Automatisk inspelning vid anslutning",
+    "metaGlassesShowPreview": "Live-förhandsvisning",
+    "metaGlassesPendingPhotos": "{count} foton väntar på synkronisering",
+    "metaGlassesPairInMetaAI": "Konfigurera i Meta AI-appen",
+    "metaGlassesTypeRayBanMeta": "Ray-Ban Meta",
+    "metaGlassesTypeRayBanDisplay": "Meta Ray-Ban Display",
+    "metaGlassesTypeOakleyMeta": "Oakley Meta",
+    "metaGlassesOverheating": "Glasögonen svalnar — inspelning pausad",
+    "metaGlassesFolded": "Fäll upp glasögonen för att fortsätta spela in",
+    "metaGlassesCaptureFrequency": "Tagningsfrekvens",
+    "metaGlassesEvery10s": "Var 10:e s",
+    "metaGlassesEvery30s": "Var 30:e s",
+    "metaGlassesEvery1min": "Varje 1 min",
+    "metaGlassesEvery5min": "Var 5:e min",
+    "metaGlassesGestures": "Gester"
 }

--- a/app/lib/l10n/app_ta.arb
+++ b/app/lib/l10n/app_ta.arb
@@ -10720,5 +10720,34 @@
                 "type": "String"
             }
         }
-    }
+    },
+    "metaGlasses": "Meta Glasses",
+    "pairingTitleMetaGlasses": "உங்கள் Meta Glasses-ஐ இணைக்கவும்",
+    "pairingDescMetaGlasses": "Meta AI ஆப்பில் உங்கள் கண்ணாடியை இணைத்து, பிறகு Omi-இல் Connect-ஐத் தட்டவும். ஒன்றுக்கு மேற்பட்ட ஜோடிகளை இணைத்து, செயலில் உள்ளதைத் தேர்ந்தெடுக்கலாம்.",
+    "metaGlassesUnavailable": "Meta AI ஆப் கிடைக்கவில்லை. கண்ணாடியை இணைக்க Meta AI-ஐ நிறுவி, டெவலப்பர் பயன்முறையை இயக்கவும்.",
+    "metaGlassesRegistering": "Meta AI ஆப்பில் இணைப்பை முடித்து, பிறகு Omi-க்குத் திரும்பவும்.",
+    "metaGlassesCameraPermission": "Meta AI ஆப்பில் கேமரா அணுகலை அனுமதிக்கவும்",
+    "metaGlassesCaptureModeLabel": "பதிவு பயன்முறை",
+    "metaGlassesModeCameraMic": "கேமரா + மைக்",
+    "metaGlassesModeMicOnly": "மைக் மட்டும்",
+    "metaGlassesStartCapture": "பதிவைத் தொடங்கு",
+    "metaGlassesStopCapture": "பதிவை நிறுத்து",
+    "metaGlassesGestureHint": "இந்த build-இல் Meta கண்ணாடிகளுக்கான சைகை கட்டுப்பாடுகள் ஆதரிக்கப்படவில்லை.",
+    "connectAnotherDevice": "மற்றொரு சாதனத்தை இணைக்கவும்",
+    "myDevices": "என் சாதனங்கள்",
+    "metaGlassesAutoCapture": "இணைக்கும்போது தானியங்கு பதிவு",
+    "metaGlassesShowPreview": "நேரடி முன்னோட்டம்",
+    "metaGlassesPendingPhotos": "{count} புகைப்படங்கள் ஒத்திசைவுக்காக காத்திருக்கின்றன",
+    "metaGlassesPairInMetaAI": "Meta AI ஆப்பில் அமைக்கவும்",
+    "metaGlassesTypeRayBanMeta": "Ray-Ban Meta",
+    "metaGlassesTypeRayBanDisplay": "Meta Ray-Ban Display",
+    "metaGlassesTypeOakleyMeta": "Oakley Meta",
+    "metaGlassesOverheating": "கண்ணாடி குளிர்கிறது — பிடிப்பு இடைநிறுத்தப்பட்டது",
+    "metaGlassesFolded": "பிடிப்பைத் தொடர கண்ணாடியைத் திறக்கவும்",
+    "metaGlassesCaptureFrequency": "படமெடுப்பு அதிர்வெண்",
+    "metaGlassesEvery10s": "ஒவ்வொரு 10 வி",
+    "metaGlassesEvery30s": "ஒவ்வொரு 30 வி",
+    "metaGlassesEvery1min": "ஒவ்வொரு 1 நி",
+    "metaGlassesEvery5min": "ஒவ்வொரு 5 நி",
+    "metaGlassesGestures": "சைகைகள்"
 }

--- a/app/lib/l10n/app_te.arb
+++ b/app/lib/l10n/app_te.arb
@@ -10720,5 +10720,34 @@
                 "type": "String"
             }
         }
-    }
+    },
+    "metaGlasses": "Meta Glasses",
+    "pairingTitleMetaGlasses": "మీ Meta Glasses కనెక్ట్ చేయండి",
+    "pairingDescMetaGlasses": "Meta AI యాప్‌లో మీ గ్లాసెస్‌ను పెయిర్ చేసి, ఆపై Omi లో Connect నొక్కండి. ఒకటి కంటే ఎక్కువ జతలను లింక్ చేసి, యాక్టివ్‌గా ఉండేదాన్ని ఎంచుకోవచ్చు.",
+    "metaGlassesUnavailable": "Meta AI యాప్ కనబడలేదు. గ్లాసెస్ కనెక్ట్ చేయడానికి Meta AI ఇన్‌స్టాల్ చేసి, డెవలపర్ మోడ్ ప్రారంభించండి.",
+    "metaGlassesRegistering": "Meta AI యాప్‌లో కనెక్షన్ పూర్తి చేసి, ఆపై Omi కి తిరిగి రండి.",
+    "metaGlassesCameraPermission": "Meta AI యాప్‌లో కెమెరా యాక్సెస్‌ను అనుమతించండి",
+    "metaGlassesCaptureModeLabel": "క్యాప్చర్ మోడ్",
+    "metaGlassesModeCameraMic": "కెమెరా + మైక్",
+    "metaGlassesModeMicOnly": "మైక్ మాత్రమే",
+    "metaGlassesStartCapture": "క్యాప్చర్ ప్రారంభించండి",
+    "metaGlassesStopCapture": "క్యాప్చర్ ఆపండి",
+    "metaGlassesGestureHint": "ఈ బిల్డ్‌లో Meta కళ్లద్దాల కోసం gesture నియంత్రణలు మద్దతు ఇవ్వబడవు.",
+    "connectAnotherDevice": "మరో పరికరాన్ని కనెక్ట్ చేయండి",
+    "myDevices": "నా పరికరాలు",
+    "metaGlassesAutoCapture": "కనెక్ట్ అయినప్పుడు ఆటో-క్యాప్చర్",
+    "metaGlassesShowPreview": "లైవ్ ప్రివ్యూ",
+    "metaGlassesPendingPhotos": "{count} ఫోటోలు సింక్ కోసం వేచి ఉన్నాయి",
+    "metaGlassesPairInMetaAI": "Meta AI యాప్‌లో సెటప్ చేయండి",
+    "metaGlassesTypeRayBanMeta": "Ray-Ban Meta",
+    "metaGlassesTypeRayBanDisplay": "Meta Ray-Ban Display",
+    "metaGlassesTypeOakleyMeta": "Oakley Meta",
+    "metaGlassesOverheating": "కళ్లజోడు చల్లబడుతోంది — క్యాప్చర్ పాజ్ అయింది",
+    "metaGlassesFolded": "క్యాప్చర్ కొనసాగించడానికి కళ్లజోడును విప్పండి",
+    "metaGlassesCaptureFrequency": "క్యాప్చర్ ఫ్రీక్వెన్సీ",
+    "metaGlassesEvery10s": "ప్రతి 10 సె",
+    "metaGlassesEvery30s": "ప్రతి 30 సె",
+    "metaGlassesEvery1min": "ప్రతి 1 నిమి",
+    "metaGlassesEvery5min": "ప్రతి 5 నిమి",
+    "metaGlassesGestures": "సంజ్ఞలు"
 }

--- a/app/lib/l10n/app_th.arb
+++ b/app/lib/l10n/app_th.arb
@@ -3142,5 +3142,34 @@
                 "type": "String"
             }
         }
-    }
+    },
+    "metaGlasses": "Meta Glasses",
+    "pairingTitleMetaGlasses": "เชื่อมต่อ Meta Glasses ของคุณ",
+    "pairingDescMetaGlasses": "จับคู่แว่นตาของคุณในแอป Meta AI จากนั้นแตะ เชื่อมต่อ ใน Omi คุณสามารถเชื่อมโยงได้หลายคู่และเลือกคู่ที่ใช้งานอยู่",
+    "metaGlassesUnavailable": "ไม่พบแอป Meta AI โปรดติดตั้ง Meta AI และเปิดโหมดนักพัฒนาเพื่อเชื่อมต่อแว่นตาของคุณ",
+    "metaGlassesRegistering": "ทำการเชื่อมต่อในแอป Meta AI ให้เสร็จ แล้วกลับมาที่ Omi",
+    "metaGlassesCameraPermission": "อนุญาตการเข้าถึงกล้องในแอป Meta AI",
+    "metaGlassesCaptureModeLabel": "โหมดบันทึก",
+    "metaGlassesModeCameraMic": "กล้อง + ไมค์",
+    "metaGlassesModeMicOnly": "ไมค์เท่านั้น",
+    "metaGlassesStartCapture": "เริ่มบันทึก",
+    "metaGlassesStopCapture": "หยุดบันทึก",
+    "metaGlassesGestureHint": "ระบบควบคุมด้วยท่าทางสำหรับแว่น Meta ยังไม่รองรับในบิลด์นี้",
+    "connectAnotherDevice": "เชื่อมต่ออุปกรณ์อื่น",
+    "myDevices": "อุปกรณ์ของฉัน",
+    "metaGlassesAutoCapture": "บันทึกอัตโนมัติเมื่อเชื่อมต่อ",
+    "metaGlassesShowPreview": "ดูตัวอย่างสด",
+    "metaGlassesPendingPhotos": "รูปภาพ {count} รูปรอการซิงค์",
+    "metaGlassesPairInMetaAI": "ตั้งค่าในแอป Meta AI",
+    "metaGlassesTypeRayBanMeta": "Ray-Ban Meta",
+    "metaGlassesTypeRayBanDisplay": "Meta Ray-Ban Display",
+    "metaGlassesTypeOakleyMeta": "Oakley Meta",
+    "metaGlassesOverheating": "แว่นกำลังเย็นลง — หยุดจับภาพชั่วคราว",
+    "metaGlassesFolded": "กางแว่นออกเพื่อจับภาพต่อ",
+    "metaGlassesCaptureFrequency": "ความถี่ในการถ่าย",
+    "metaGlassesEvery10s": "ทุก 10 วิ",
+    "metaGlassesEvery30s": "ทุก 30 วิ",
+    "metaGlassesEvery1min": "ทุก 1 นาที",
+    "metaGlassesEvery5min": "ทุก 5 นาที",
+    "metaGlassesGestures": "ท่าทาง"
 }

--- a/app/lib/l10n/app_tl.arb
+++ b/app/lib/l10n/app_tl.arb
@@ -10720,5 +10720,34 @@
                 "type": "String"
             }
         }
-    }
+    },
+    "metaGlasses": "Meta Glasses",
+    "pairingTitleMetaGlasses": "Ikonekta ang iyong Meta Glasses",
+    "pairingDescMetaGlasses": "I-pair ang iyong salamin sa Meta AI app, pagkatapos ay i-tap ang Connect sa Omi. Maaari kang mag-link ng higit sa isang pares at piliin kung alin ang aktibo.",
+    "metaGlassesUnavailable": "Hindi natagpuan ang Meta AI app. I-install ang Meta AI at i-enable ang Developer Mode para ikonekta ang iyong salamin.",
+    "metaGlassesRegistering": "Tapusin ang pagkonekta sa Meta AI app, pagkatapos ay bumalik sa Omi.",
+    "metaGlassesCameraPermission": "Payagan ang access sa camera sa Meta AI app",
+    "metaGlassesCaptureModeLabel": "Capture mode",
+    "metaGlassesModeCameraMic": "Camera + mikropono",
+    "metaGlassesModeMicOnly": "Mikropono lamang",
+    "metaGlassesStartCapture": "Simulan ang pag-capture",
+    "metaGlassesStopCapture": "Ihinto ang pag-capture",
+    "metaGlassesGestureHint": "Hindi sinusuportahan ang mga kontrol sa galaw para sa Meta glasses sa build na ito.",
+    "connectAnotherDevice": "Ikonekta ang isa pang device",
+    "myDevices": "Aking Mga Device",
+    "metaGlassesAutoCapture": "Awtomatikong pag-capture kapag nakakonekta",
+    "metaGlassesShowPreview": "Live preview",
+    "metaGlassesPendingPhotos": "{count} larawan ang naghihintay ma-sync",
+    "metaGlassesPairInMetaAI": "I-set up sa Meta AI app",
+    "metaGlassesTypeRayBanMeta": "Ray-Ban Meta",
+    "metaGlassesTypeRayBanDisplay": "Meta Ray-Ban Display",
+    "metaGlassesTypeOakleyMeta": "Oakley Meta",
+    "metaGlassesOverheating": "Lumalamig ang salamin — naka-pause ang pag-capture",
+    "metaGlassesFolded": "Buksan ang salamin para magpatuloy sa pag-capture",
+    "metaGlassesCaptureFrequency": "Dalas ng pagkuha",
+    "metaGlassesEvery10s": "Bawat 10 s",
+    "metaGlassesEvery30s": "Bawat 30 s",
+    "metaGlassesEvery1min": "Bawat 1 min",
+    "metaGlassesEvery5min": "Bawat 5 min",
+    "metaGlassesGestures": "Mga galaw"
 }

--- a/app/lib/l10n/app_tr.arb
+++ b/app/lib/l10n/app_tr.arb
@@ -3177,5 +3177,34 @@
                 "type": "String"
             }
         }
-    }
+    },
+    "metaGlasses": "Meta Glasses",
+    "pairingTitleMetaGlasses": "Meta Glasses'ınızı bağlayın",
+    "pairingDescMetaGlasses": "Gözlüğünüzü Meta AI uygulamasında eşleştirin, ardından Omi'de Bağlan'a dokunun. Birden fazla gözlük bağlayabilir ve hangisinin etkin olduğunu seçebilirsiniz.",
+    "metaGlassesUnavailable": "Meta AI uygulaması bulunamadı. Gözlüğünüzü bağlamak için Meta AI'ı yükleyin ve Geliştirici Modu'nu etkinleştirin.",
+    "metaGlassesRegistering": "Meta AI uygulamasında bağlantıyı tamamlayın, ardından Omi'ye dönün.",
+    "metaGlassesCameraPermission": "Meta AI uygulamasında kamera erişimine izin verin",
+    "metaGlassesCaptureModeLabel": "Yakalama modu",
+    "metaGlassesModeCameraMic": "Kamera + mikrofon",
+    "metaGlassesModeMicOnly": "Yalnızca mikrofon",
+    "metaGlassesStartCapture": "Yakalamayı başlat",
+    "metaGlassesStopCapture": "Yakalamayı durdur",
+    "metaGlassesGestureHint": "Bu derlemede Meta gözlükleri için hareket kontrolleri desteklenmiyor.",
+    "connectAnotherDevice": "Başka bir cihaz bağla",
+    "myDevices": "Cihazlarım",
+    "metaGlassesAutoCapture": "Bağlanınca otomatik yakalama",
+    "metaGlassesShowPreview": "Canlı önizleme",
+    "metaGlassesPendingPhotos": "{count} fotoğraf eşitlenmeyi bekliyor",
+    "metaGlassesPairInMetaAI": "Meta AI uygulamasında kurun",
+    "metaGlassesTypeRayBanMeta": "Ray-Ban Meta",
+    "metaGlassesTypeRayBanDisplay": "Meta Ray-Ban Display",
+    "metaGlassesTypeOakleyMeta": "Oakley Meta",
+    "metaGlassesOverheating": "Gözlük soğuyor — yakalama duraklatıldı",
+    "metaGlassesFolded": "Yakalamaya devam etmek için gözlüğü açın",
+    "metaGlassesCaptureFrequency": "Yakalama sıklığı",
+    "metaGlassesEvery10s": "Her 10 sn",
+    "metaGlassesEvery30s": "Her 30 sn",
+    "metaGlassesEvery1min": "Her 1 dk",
+    "metaGlassesEvery5min": "Her 5 dk",
+    "metaGlassesGestures": "Hareketler"
 }

--- a/app/lib/l10n/app_uk.arb
+++ b/app/lib/l10n/app_uk.arb
@@ -3142,5 +3142,34 @@
                 "type": "String"
             }
         }
-    }
+    },
+    "metaGlasses": "Meta Glasses",
+    "pairingTitleMetaGlasses": "Підключіть свої Meta Glasses",
+    "pairingDescMetaGlasses": "Створіть пару з окулярами в застосунку Meta AI, потім натисніть «Підключити» в Omi. Можна зв'язати кілька пар і вибрати активну.",
+    "metaGlassesUnavailable": "Застосунок Meta AI не знайдено. Установіть Meta AI та ввімкніть режим розробника, щоб підключити окуляри.",
+    "metaGlassesRegistering": "Завершіть підключення в застосунку Meta AI та поверніться в Omi.",
+    "metaGlassesCameraPermission": "Дозвольте доступ до камери в застосунку Meta AI",
+    "metaGlassesCaptureModeLabel": "Режим запису",
+    "metaGlassesModeCameraMic": "Камера + мікрофон",
+    "metaGlassesModeMicOnly": "Лише мікрофон",
+    "metaGlassesStartCapture": "Почати запис",
+    "metaGlassesStopCapture": "Зупинити запис",
+    "metaGlassesGestureHint": "Керування жестами для окулярів Meta не підтримується в цій збірці.",
+    "connectAnotherDevice": "Підключити інший пристрій",
+    "myDevices": "Мої пристрої",
+    "metaGlassesAutoCapture": "Автозапис під час підключення",
+    "metaGlassesShowPreview": "Попередній перегляд наживо",
+    "metaGlassesPendingPhotos": "{count} фото очікують синхронізації",
+    "metaGlassesPairInMetaAI": "Налаштуйте в застосунку Meta AI",
+    "metaGlassesTypeRayBanMeta": "Ray-Ban Meta",
+    "metaGlassesTypeRayBanDisplay": "Meta Ray-Ban Display",
+    "metaGlassesTypeOakleyMeta": "Oakley Meta",
+    "metaGlassesOverheating": "Окуляри охолоджуються — зйомку призупинено",
+    "metaGlassesFolded": "Розгорніть окуляри, щоб продовжити зйомку",
+    "metaGlassesCaptureFrequency": "Частота зйомки",
+    "metaGlassesEvery10s": "Кожні 10 с",
+    "metaGlassesEvery30s": "Кожні 30 с",
+    "metaGlassesEvery1min": "Щохвилини",
+    "metaGlassesEvery5min": "Кожні 5 хв",
+    "metaGlassesGestures": "Жести"
 }

--- a/app/lib/l10n/app_ur.arb
+++ b/app/lib/l10n/app_ur.arb
@@ -10720,5 +10720,34 @@
                 "type": "String"
             }
         }
-    }
+    },
+    "metaGlasses": "Meta Glasses",
+    "pairingTitleMetaGlasses": "اپنے Meta Glasses منسلک کریں",
+    "pairingDescMetaGlasses": "Meta AI ایپ میں اپنی عینک جوڑیں، پھر Omi میں Connect پر ٹیپ کریں۔ آپ ایک سے زیادہ جوڑے منسلک کر کے فعال جوڑا منتخب کر سکتے ہیں۔",
+    "metaGlassesUnavailable": "Meta AI ایپ نہیں ملی۔ عینک منسلک کرنے کے لیے Meta AI انسٹال کریں اور ڈیولپر موڈ فعال کریں۔",
+    "metaGlassesRegistering": "Meta AI ایپ میں کنکشن مکمل کریں، پھر Omi میں واپس آئیں۔",
+    "metaGlassesCameraPermission": "Meta AI ایپ میں کیمرے تک رسائی کی اجازت دیں",
+    "metaGlassesCaptureModeLabel": "کیپچر موڈ",
+    "metaGlassesModeCameraMic": "کیمرہ + مائیک",
+    "metaGlassesModeMicOnly": "صرف مائیک",
+    "metaGlassesStartCapture": "کیپچر شروع کریں",
+    "metaGlassesStopCapture": "کیپچر روکیں",
+    "metaGlassesGestureHint": "اس بلڈ میں Meta عینک کے لیے اشاروں کے کنٹرولز معاونت یافتہ نہیں ہیں۔",
+    "connectAnotherDevice": "دوسرا آلہ منسلک کریں",
+    "myDevices": "میرے آلات",
+    "metaGlassesAutoCapture": "منسلک ہونے پر خودکار کیپچر",
+    "metaGlassesShowPreview": "براہ راست پیش منظر",
+    "metaGlassesPendingPhotos": "{count} تصاویر مطابقت پذیری کی منتظر ہیں",
+    "metaGlassesPairInMetaAI": "Meta AI ایپ میں سیٹ اپ کریں",
+    "metaGlassesTypeRayBanMeta": "Ray-Ban Meta",
+    "metaGlassesTypeRayBanDisplay": "Meta Ray-Ban Display",
+    "metaGlassesTypeOakleyMeta": "Oakley Meta",
+    "metaGlassesOverheating": "چشمہ ٹھنڈا ہو رہا ہے — کیپچر رکا ہوا ہے",
+    "metaGlassesFolded": "کیپچر جاری رکھنے کے لیے چشمہ کھولیں",
+    "metaGlassesCaptureFrequency": "کیپچر تعدد",
+    "metaGlassesEvery10s": "ہر 10 سیکنڈ",
+    "metaGlassesEvery30s": "ہر 30 سیکنڈ",
+    "metaGlassesEvery1min": "ہر 1 منٹ",
+    "metaGlassesEvery5min": "ہر 5 منٹ",
+    "metaGlassesGestures": "اشارے"
 }

--- a/app/lib/l10n/app_vi.arb
+++ b/app/lib/l10n/app_vi.arb
@@ -3147,5 +3147,34 @@
                 "type": "String"
             }
         }
-    }
+    },
+    "metaGlasses": "Meta Glasses",
+    "pairingTitleMetaGlasses": "Kết nối Meta Glasses của bạn",
+    "pairingDescMetaGlasses": "Ghép nối kính trong ứng dụng Meta AI, sau đó nhấn Kết nối trong Omi. Bạn có thể liên kết nhiều cặp và chọn cặp đang hoạt động.",
+    "metaGlassesUnavailable": "Không tìm thấy ứng dụng Meta AI. Hãy cài đặt Meta AI và bật Chế độ nhà phát triển để kết nối kính.",
+    "metaGlassesRegistering": "Hoàn tất kết nối trong ứng dụng Meta AI, sau đó quay lại Omi.",
+    "metaGlassesCameraPermission": "Cho phép truy cập camera trong ứng dụng Meta AI",
+    "metaGlassesCaptureModeLabel": "Chế độ ghi",
+    "metaGlassesModeCameraMic": "Camera + micrô",
+    "metaGlassesModeMicOnly": "Chỉ micrô",
+    "metaGlassesStartCapture": "Bắt đầu ghi",
+    "metaGlassesStopCapture": "Dừng ghi",
+    "metaGlassesGestureHint": "Các điều khiển bằng cử chỉ cho kính Meta không được hỗ trợ trong bản dựng này.",
+    "connectAnotherDevice": "Kết nối thiết bị khác",
+    "myDevices": "Thiết bị của tôi",
+    "metaGlassesAutoCapture": "Tự động ghi khi kết nối",
+    "metaGlassesShowPreview": "Xem trước trực tiếp",
+    "metaGlassesPendingPhotos": "{count} ảnh đang chờ đồng bộ",
+    "metaGlassesPairInMetaAI": "Thiết lập trong ứng dụng Meta AI",
+    "metaGlassesTypeRayBanMeta": "Ray-Ban Meta",
+    "metaGlassesTypeRayBanDisplay": "Meta Ray-Ban Display",
+    "metaGlassesTypeOakleyMeta": "Oakley Meta",
+    "metaGlassesOverheating": "Kính đang hạ nhiệt — đã tạm dừng ghi lại",
+    "metaGlassesFolded": "Mở kính ra để tiếp tục ghi lại",
+    "metaGlassesCaptureFrequency": "Tần suất chụp",
+    "metaGlassesEvery10s": "Mỗi 10 giây",
+    "metaGlassesEvery30s": "Mỗi 30 giây",
+    "metaGlassesEvery1min": "Mỗi 1 phút",
+    "metaGlassesEvery5min": "Mỗi 5 phút",
+    "metaGlassesGestures": "Cử chỉ"
 }

--- a/app/lib/l10n/app_zh.arb
+++ b/app/lib/l10n/app_zh.arb
@@ -3164,5 +3164,34 @@
                 "type": "String"
             }
         }
-    }
+    },
+    "metaGlasses": "Meta Glasses",
+    "pairingTitleMetaGlasses": "连接您的 Meta Glasses",
+    "pairingDescMetaGlasses": "在 Meta AI 应用中配对眼镜，然后在 Omi 中点击“连接”。您可以关联多副眼镜并选择当前使用的一副。",
+    "metaGlassesUnavailable": "未检测到 Meta AI 应用。请安装 Meta AI 并启用开发者模式以连接您的眼镜。",
+    "metaGlassesRegistering": "在 Meta AI 应用中完成连接，然后返回 Omi。",
+    "metaGlassesCameraPermission": "在 Meta AI 应用中允许访问相机",
+    "metaGlassesCaptureModeLabel": "采集模式",
+    "metaGlassesModeCameraMic": "相机 + 麦克风",
+    "metaGlassesModeMicOnly": "仅麦克风",
+    "metaGlassesStartCapture": "开始采集",
+    "metaGlassesStopCapture": "停止采集",
+    "metaGlassesGestureHint": "此版本不支持 Meta 眼镜的手势控制。",
+    "connectAnotherDevice": "连接其他设备",
+    "myDevices": "我的设备",
+    "metaGlassesAutoCapture": "连接时自动采集",
+    "metaGlassesShowPreview": "实时预览",
+    "metaGlassesPendingPhotos": "{count} 张照片等待同步",
+    "metaGlassesPairInMetaAI": "请在 Meta AI 应用中完成设置",
+    "metaGlassesTypeRayBanMeta": "Ray-Ban Meta",
+    "metaGlassesTypeRayBanDisplay": "Meta Ray-Ban Display",
+    "metaGlassesTypeOakleyMeta": "Oakley Meta",
+    "metaGlassesOverheating": "眼镜正在冷却 — 已暂停捕捉",
+    "metaGlassesFolded": "展开眼镜以继续捕捉",
+    "metaGlassesCaptureFrequency": "采集频率",
+    "metaGlassesEvery10s": "每 10 秒",
+    "metaGlassesEvery30s": "每 30 秒",
+    "metaGlassesEvery1min": "每 1 分钟",
+    "metaGlassesEvery5min": "每 5 分钟",
+    "metaGlassesGestures": "手势"
 }

--- a/app/lib/pages/meta_wearables/meta_glasses_page.dart
+++ b/app/lib/pages/meta_wearables/meta_glasses_page.dart
@@ -1,0 +1,637 @@
+import 'package:flutter/material.dart';
+
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
+import 'package:meta_wearables_dat_flutter/meta_wearables_dat_flutter.dart';
+import 'package:provider/provider.dart';
+
+import 'package:omi/gen/assets.gen.dart';
+import 'package:omi/providers/capture_provider.dart';
+import 'package:omi/providers/meta_wearables_provider.dart';
+import 'package:omi/utils/l10n_extensions.dart';
+import 'package:omi/utils/meta_wearables_device_label.dart';
+import 'package:omi/utils/responsive/responsive_helper.dart';
+
+/// Management screen for Meta glasses connected through the Wearables Device
+/// Access Toolkit. Lists every paired pair (multi-device), lets the user pick
+/// the active one, and drives registration/unregistration with the Meta AI
+/// app.
+class MetaGlassesPage extends StatefulWidget {
+  const MetaGlassesPage({super.key});
+
+  @override
+  State<MetaGlassesPage> createState() => _MetaGlassesPageState();
+}
+
+class _MetaGlassesPageState extends State<MetaGlassesPage> {
+  /// The live preview is opt-in: rendering the stream texture costs real CPU
+  /// and made the whole page lag, while photo capture works fine without it.
+  bool _showPreview = false;
+  MetaGlassesHealth? _dismissedHealthWarning;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) {
+        final provider = context.read<MetaWearablesProvider>();
+        provider.init().then((_) => provider.refresh());
+      }
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: const Color(0xFF0D0D0D),
+      appBar: AppBar(
+        backgroundColor: const Color(0xFF0D0D0D),
+        elevation: 0,
+        leading: Padding(
+          padding: const EdgeInsets.only(left: 12),
+          child: GestureDetector(
+            onTap: () => Navigator.of(context).pop(),
+            child: Container(
+              width: 36,
+              height: 36,
+              decoration: const BoxDecoration(color: Color(0xFF1F1F25), shape: BoxShape.circle),
+              child: const Icon(FontAwesomeIcons.chevronLeft, size: 16, color: Colors.white70),
+            ),
+          ),
+        ),
+        title: Text(
+          context.l10n.metaGlasses,
+          style: const TextStyle(color: Colors.white, fontSize: 18, fontWeight: FontWeight.w600),
+        ),
+        centerTitle: true,
+      ),
+      body: Consumer<MetaWearablesProvider>(
+        builder: (context, provider, child) {
+          if (provider.health == MetaGlassesHealth.ok) _dismissedHealthWarning = null;
+          return ListView(
+            padding: const EdgeInsets.symmetric(horizontal: 24),
+            children: [
+              const SizedBox(height: 24),
+              Center(
+                child: Image.asset(Assets.images.omiGlass.path, width: 160, height: 160, fit: BoxFit.contain),
+              ),
+              const SizedBox(height: 16),
+              Text(
+                context.l10n.pairingTitleMetaGlasses,
+                style: const TextStyle(color: Colors.white, fontSize: 22, fontWeight: FontWeight.w700),
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: 8),
+              Text(
+                _statusText(context, provider),
+                style: const TextStyle(color: ResponsiveHelper.textTertiary, fontSize: 15, height: 1.4),
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: 24),
+              if (provider.isRegistered && provider.hasDevices) ...[
+                ..._deviceList(context, provider),
+                const SizedBox(height: 16),
+                _captureModeSelector(context, provider),
+                const SizedBox(height: 12),
+                if (provider.captureMode == MetaGlassesCaptureMode.cameraAndMic) ...[
+                  _captureFrequencyRow(context, provider),
+                  const SizedBox(height: 12),
+                ],
+                _autoCaptureRow(context, provider),
+                const SizedBox(height: 12),
+                _gesturesSection(context, provider),
+                const SizedBox(height: 12),
+                if (provider.isCapturing && provider.previewTextureId != null) ...[
+                  _previewToggleRow(context, provider),
+                  if (_showPreview) ...[
+                    const SizedBox(height: 8),
+                    _livePreview(context, provider),
+                  ],
+                  const SizedBox(height: 12),
+                ],
+                if (provider.pendingPhotoCount > 0) ...[
+                  _pendingPhotosRow(context, provider),
+                  const SizedBox(height: 12),
+                ],
+                if (provider.health != MetaGlassesHealth.ok && _dismissedHealthWarning != provider.health) ...[
+                  _healthWarningRow(context, provider),
+                  const SizedBox(height: 12),
+                ],
+                _captureButton(context, provider),
+                const SizedBox(height: 16),
+              ],
+              if (provider.isRegistered && !provider.cameraPermissionGranted) _cameraPermissionCard(context, provider),
+              const SizedBox(height: 8),
+              _primaryButton(context, provider),
+              if (provider.isRegistered) ...[
+                const SizedBox(height: 12),
+                _unpairButton(context, provider),
+              ],
+              if (provider.lastError != null) ...[
+                const SizedBox(height: 16),
+                Text(
+                  provider.lastError!,
+                  style: const TextStyle(color: Colors.redAccent, fontSize: 13),
+                  textAlign: TextAlign.center,
+                ),
+              ],
+              SizedBox(height: MediaQuery.of(context).padding.bottom + 24),
+            ],
+          );
+        },
+      ),
+    );
+  }
+
+  String _statusText(BuildContext context, MetaWearablesProvider provider) {
+    switch (provider.registrationState) {
+      case RegistrationState.unavailable:
+        return context.l10n.metaGlassesUnavailable;
+      case RegistrationState.available:
+        return context.l10n.pairingDescMetaGlasses;
+      case RegistrationState.registering:
+        return context.l10n.metaGlassesRegistering;
+      case RegistrationState.registered:
+        return context.l10n.connected;
+    }
+  }
+
+  List<Widget> _deviceList(BuildContext context, MetaWearablesProvider provider) {
+    return provider.devices.map((device) {
+      final selected = provider.isSelected(device);
+      final active = provider.isActive(device);
+      final needsUpdate = provider.hasCompatibilityUpdateAction(device);
+      return GestureDetector(
+        onTap: () => provider.selectDevice(device.uuid),
+        child: Container(
+          margin: const EdgeInsets.only(bottom: 12),
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+          decoration: BoxDecoration(
+            color: ResponsiveHelper.backgroundTertiary,
+            borderRadius: BorderRadius.circular(16),
+            border: Border.all(color: selected ? Colors.white : Colors.transparent, width: 1),
+          ),
+          child: Row(
+            children: [
+              Image.asset(Assets.images.omiGlass.path, width: 36, height: 36, fit: BoxFit.contain),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      device.name.isNotEmpty ? device.name : context.l10n.metaGlasses,
+                      style: const TextStyle(color: Colors.white, fontSize: 16, fontWeight: FontWeight.w500),
+                    ),
+                    Text(
+                      metaWearablesDeviceKindLabel(context.l10n, device.kind),
+                      style: const TextStyle(color: Colors.white54, fontSize: 12),
+                    ),
+                    Text(
+                      _deviceStatusText(context, device),
+                      style: TextStyle(color: _deviceStatusColor(device), fontSize: 12),
+                    ),
+                    if (active)
+                      Text(
+                        context.l10n.active,
+                        style: const TextStyle(color: Colors.greenAccent, fontSize: 12),
+                      ),
+                    if (needsUpdate)
+                      Wrap(
+                        crossAxisAlignment: WrapCrossAlignment.center,
+                        spacing: 8,
+                        children: [
+                          Text(
+                            context.l10n.firmwareUpdateAvailable,
+                            style: const TextStyle(color: Colors.orangeAccent, fontSize: 12),
+                          ),
+                          TextButton(
+                            onPressed: () => provider.openCompatibilityUpdate(device),
+                            style: TextButton.styleFrom(
+                              foregroundColor: Colors.orangeAccent,
+                              minimumSize: Size.zero,
+                              padding: EdgeInsets.zero,
+                              tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                            ),
+                            child: Text(context.l10n.update),
+                          ),
+                        ],
+                      ),
+                  ],
+                ),
+              ),
+              if (selected) const Icon(Icons.check_circle, color: Colors.white, size: 20),
+            ],
+          ),
+        ),
+      );
+    }).toList();
+  }
+
+  String _deviceStatusText(BuildContext context, DeviceInfo device) {
+    switch (device.linkState) {
+      case DeviceLinkState.connected:
+      case DeviceLinkState.unknown:
+        return context.l10n.connected;
+      case DeviceLinkState.connecting:
+        return context.l10n.searching;
+      case DeviceLinkState.disconnected:
+        return context.l10n.metaGlassesPairInMetaAI;
+    }
+  }
+
+  Color _deviceStatusColor(DeviceInfo device) {
+    switch (device.linkState) {
+      case DeviceLinkState.connected:
+      case DeviceLinkState.unknown:
+        return Colors.greenAccent;
+      case DeviceLinkState.connecting:
+        return Colors.white54;
+      case DeviceLinkState.disconnected:
+        return Colors.orangeAccent;
+    }
+  }
+
+  Widget _autoCaptureRow(BuildContext context, MetaWearablesProvider provider) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 6),
+      decoration: BoxDecoration(color: ResponsiveHelper.backgroundTertiary, borderRadius: BorderRadius.circular(16)),
+      child: Row(
+        children: [
+          const Icon(Icons.autorenew, color: Colors.white70, size: 20),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Text(
+              context.l10n.metaGlassesAutoCapture,
+              style: const TextStyle(color: Colors.white, fontSize: 14),
+            ),
+          ),
+          Switch(
+            value: provider.autoCaptureEnabled,
+            onChanged: (value) => provider.setAutoCaptureEnabled(value),
+            activeThumbColor: Colors.white,
+            activeTrackColor: Colors.greenAccent.shade700,
+          ),
+        ],
+      ),
+    );
+  }
+
+  String _intervalLabel(BuildContext context, MetaGlassesCaptureInterval i) {
+    switch (i) {
+      case MetaGlassesCaptureInterval.s10:
+        return context.l10n.metaGlassesEvery10s;
+      case MetaGlassesCaptureInterval.s30:
+        return context.l10n.metaGlassesEvery30s;
+      case MetaGlassesCaptureInterval.m1:
+        return context.l10n.metaGlassesEvery1min;
+      case MetaGlassesCaptureInterval.m5:
+        return context.l10n.metaGlassesEvery5min;
+    }
+  }
+
+  Widget _captureFrequencyRow(BuildContext context, MetaWearablesProvider provider) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+      decoration: BoxDecoration(color: ResponsiveHelper.backgroundTertiary, borderRadius: BorderRadius.circular(16)),
+      child: Row(
+        children: [
+          const Icon(Icons.timer_outlined, color: Colors.white70, size: 20),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Text(
+              context.l10n.metaGlassesCaptureFrequency,
+              style: const TextStyle(color: Colors.white, fontSize: 14),
+            ),
+          ),
+          DropdownButton<MetaGlassesCaptureInterval>(
+            value: provider.captureInterval,
+            dropdownColor: ResponsiveHelper.backgroundTertiary,
+            underline: const SizedBox.shrink(),
+            style: const TextStyle(color: Colors.white, fontSize: 14),
+            icon: const Icon(Icons.arrow_drop_down, color: Colors.white70),
+            items: MetaGlassesCaptureInterval.values
+                .map((i) => DropdownMenuItem(value: i, child: Text(_intervalLabel(context, i))))
+                .toList(),
+            onChanged: (value) {
+              if (value != null) provider.setCaptureInterval(value);
+            },
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _gesturesSection(BuildContext context, MetaWearablesProvider provider) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+      decoration: BoxDecoration(color: ResponsiveHelper.backgroundTertiary, borderRadius: BorderRadius.circular(16)),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Icon(Icons.touch_app_outlined, color: Colors.white70, size: 20),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  context.l10n.metaGlassesGestures,
+                  style: const TextStyle(color: Colors.white, fontSize: 14),
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  context.l10n.metaGlassesGestureHint,
+                  style: const TextStyle(color: ResponsiveHelper.textTertiary, fontSize: 13),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _previewToggleRow(BuildContext context, MetaWearablesProvider provider) {
+    return GestureDetector(
+      onTap: () {
+        setState(() => _showPreview = !_showPreview);
+        provider.setLivePreviewVisible(_showPreview);
+      },
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+        decoration: BoxDecoration(color: ResponsiveHelper.backgroundTertiary, borderRadius: BorderRadius.circular(16)),
+        child: Row(
+          children: [
+            Icon(_showPreview ? Icons.visibility : Icons.visibility_off, color: Colors.white70, size: 20),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Text(
+                context.l10n.metaGlassesShowPreview,
+                style: const TextStyle(color: Colors.white, fontSize: 14),
+              ),
+            ),
+            Icon(_showPreview ? Icons.expand_less : Icons.expand_more, color: Colors.white38, size: 18),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _pendingPhotosRow(BuildContext context, MetaWearablesProvider provider) {
+    return GestureDetector(
+      onTap: () => provider.flushPhotoQueue(),
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+        decoration: BoxDecoration(color: ResponsiveHelper.backgroundTertiary, borderRadius: BorderRadius.circular(16)),
+        child: Row(
+          children: [
+            const Icon(Icons.cloud_upload_outlined, color: Colors.orangeAccent, size: 20),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Text(
+                context.l10n.metaGlassesPendingPhotos(provider.pendingPhotoCount),
+                style: const TextStyle(color: Colors.white, fontSize: 14),
+              ),
+            ),
+            const Icon(Icons.refresh, color: Colors.white38, size: 18),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _healthWarningRow(BuildContext context, MetaWearablesProvider provider) {
+    final overheating = provider.health == MetaGlassesHealth.overheating;
+    final message = overheating ? context.l10n.metaGlassesOverheating : context.l10n.metaGlassesFolded;
+    final icon = overheating ? Icons.thermostat : Icons.visibility_off;
+    return Dismissible(
+      key: ValueKey(provider.health),
+      direction: DismissDirection.endToStart,
+      onDismissed: (_) => setState(() => _dismissedHealthWarning = provider.health),
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+        decoration: BoxDecoration(
+          color: Colors.orangeAccent.withValues(alpha: 0.12),
+          border: Border.all(color: Colors.orangeAccent.withValues(alpha: 0.35)),
+          borderRadius: BorderRadius.circular(16),
+        ),
+        child: Row(
+          children: [
+            Icon(icon, color: Colors.orangeAccent, size: 20),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Text(
+                message,
+                style: const TextStyle(color: Colors.white, fontSize: 14),
+              ),
+            ),
+            const Icon(Icons.close, color: Colors.white38, size: 18),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _livePreview(BuildContext context, MetaWearablesProvider provider) {
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(16),
+      child: Stack(
+        alignment: Alignment.bottomRight,
+        children: [
+          AspectRatio(
+            aspectRatio: provider.previewAspectRatio,
+            child: Texture(textureId: provider.previewTextureId!),
+          ),
+          Padding(
+            padding: const EdgeInsets.all(10),
+            child: GestureDetector(
+              onTap: () => provider.captureGlassesPhotoNow(),
+              child: Container(
+                width: 44,
+                height: 44,
+                decoration: BoxDecoration(color: Colors.black.withValues(alpha: 0.5), shape: BoxShape.circle),
+                child: const Icon(Icons.photo_camera, color: Colors.white, size: 22),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _captureModeSelector(BuildContext context, MetaWearablesProvider provider) {
+    Widget option(MetaGlassesCaptureMode mode, IconData icon, String label) {
+      final selected = provider.captureMode == mode;
+      return Expanded(
+        child: GestureDetector(
+          onTap: () => provider.setCaptureMode(mode),
+          child: Container(
+            padding: const EdgeInsets.symmetric(vertical: 12),
+            decoration: BoxDecoration(
+              color: selected ? Colors.white : Colors.transparent,
+              borderRadius: BorderRadius.circular(12),
+            ),
+            child: Column(
+              children: [
+                Icon(icon, size: 18, color: selected ? Colors.black : Colors.white70),
+                const SizedBox(height: 4),
+                Text(
+                  label,
+                  style: TextStyle(
+                    color: selected ? Colors.black : Colors.white70,
+                    fontSize: 13,
+                    fontWeight: FontWeight.w600,
+                  ),
+                  textAlign: TextAlign.center,
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+    }
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          context.l10n.metaGlassesCaptureModeLabel,
+          style: const TextStyle(color: ResponsiveHelper.textTertiary, fontSize: 13, fontWeight: FontWeight.w500),
+        ),
+        const SizedBox(height: 8),
+        Container(
+          padding: const EdgeInsets.all(4),
+          decoration: BoxDecoration(
+            color: ResponsiveHelper.backgroundTertiary,
+            borderRadius: BorderRadius.circular(16),
+          ),
+          child: Row(
+            children: [
+              option(
+                MetaGlassesCaptureMode.cameraAndMic,
+                Icons.photo_camera_outlined,
+                context.l10n.metaGlassesModeCameraMic,
+              ),
+              const SizedBox(width: 4),
+              option(MetaGlassesCaptureMode.micOnly, Icons.mic_none, context.l10n.metaGlassesModeMicOnly),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _captureButton(BuildContext context, MetaWearablesProvider provider) {
+    final capturing = provider.isCapturing;
+    return SizedBox(
+      width: double.infinity,
+      height: 52,
+      child: ElevatedButton.icon(
+        onPressed: () async {
+          if (capturing) {
+            await provider.stopCapture();
+          } else {
+            await provider.startCapture(context.read<CaptureProvider>(), displayStatusText: context.l10n.listening);
+          }
+        },
+        style: ElevatedButton.styleFrom(
+          backgroundColor: capturing ? Colors.redAccent : Colors.white,
+          foregroundColor: capturing ? Colors.white : Colors.black,
+          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(28)),
+          elevation: 0,
+        ),
+        icon: Icon(capturing ? Icons.stop : Icons.fiber_manual_record, size: 18),
+        label: Text(
+          capturing ? context.l10n.metaGlassesStopCapture : context.l10n.metaGlassesStartCapture,
+          style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w600),
+        ),
+      ),
+    );
+  }
+
+  Widget _cameraPermissionCard(BuildContext context, MetaWearablesProvider provider) {
+    return GestureDetector(
+      onTap: provider.isRequestingCameraPermission ? null : () => provider.requestCameraPermission(),
+      child: Container(
+        margin: const EdgeInsets.only(bottom: 8),
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+        decoration: BoxDecoration(
+          color: ResponsiveHelper.backgroundTertiary,
+          borderRadius: BorderRadius.circular(16),
+        ),
+        child: Row(
+          children: [
+            provider.isRequestingCameraPermission
+                ? const SizedBox(
+                    width: 20,
+                    height: 20,
+                    child: CircularProgressIndicator(strokeWidth: 2, color: Colors.white70),
+                  )
+                : const Icon(Icons.photo_camera_outlined, color: Colors.white70, size: 20),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Text(
+                context.l10n.metaGlassesCameraPermission,
+                style: const TextStyle(color: Colors.white, fontSize: 14),
+              ),
+            ),
+            if (!provider.isRequestingCameraPermission)
+              const Icon(FontAwesomeIcons.chevronRight, size: 14, color: Colors.white38),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _primaryButton(BuildContext context, MetaWearablesProvider provider) {
+    final busy = provider.isRegistering || provider.registrationState == RegistrationState.registering;
+    return SizedBox(
+      width: double.infinity,
+      height: 52,
+      child: ElevatedButton(
+        onPressed: busy || provider.isRegistered
+            ? null
+            : () async {
+                await provider.startRegistration();
+              },
+        style: ElevatedButton.styleFrom(
+          backgroundColor: Colors.white,
+          foregroundColor: Colors.black,
+          disabledBackgroundColor: Colors.white24,
+          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(28)),
+          elevation: 0,
+        ),
+        child: busy
+            ? const SizedBox(
+                width: 20,
+                height: 20,
+                child:
+                    CircularProgressIndicator(strokeWidth: 2, valueColor: AlwaysStoppedAnimation<Color>(Colors.black)),
+              )
+            : Text(
+                provider.isRegistered ? context.l10n.connected : context.l10n.connect,
+                style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w600),
+              ),
+      ),
+    );
+  }
+
+  Widget _unpairButton(BuildContext context, MetaWearablesProvider provider) {
+    return SizedBox(
+      width: double.infinity,
+      height: 52,
+      child: OutlinedButton(
+        onPressed: () => provider.unregister(),
+        style: OutlinedButton.styleFrom(
+          foregroundColor: Colors.redAccent,
+          side: const BorderSide(color: Colors.redAccent, width: 1),
+          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(28)),
+        ),
+        child: Text(
+          context.l10n.unpair,
+          style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w600),
+        ),
+      ),
+    );
+  }
+}

--- a/app/lib/pages/onboarding/meta_glasses_onboarding_step.dart
+++ b/app/lib/pages/onboarding/meta_glasses_onboarding_step.dart
@@ -1,0 +1,128 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import 'package:omi/gen/assets.gen.dart';
+import 'package:omi/providers/meta_wearables_provider.dart';
+import 'package:omi/utils/l10n_extensions.dart';
+
+bool metaGlassesOnboardingComplete(MetaWearablesProvider provider) {
+  return provider.isRegistered && provider.hasLinkedDevices;
+}
+
+class OnboardingMetaGlassesStep extends StatefulWidget {
+  const OnboardingMetaGlassesStep({
+    super.key,
+    required this.onMetaGlassesSelected,
+    required this.onOmiDeviceSelected,
+    required this.onContinueWithoutDevice,
+    this.onMetaGlassesReady,
+  });
+
+  final VoidCallback onMetaGlassesSelected;
+  final VoidCallback onOmiDeviceSelected;
+  final VoidCallback onContinueWithoutDevice;
+  final VoidCallback? onMetaGlassesReady;
+
+  @override
+  State<OnboardingMetaGlassesStep> createState() => _OnboardingMetaGlassesStepState();
+}
+
+class _OnboardingMetaGlassesStepState extends State<OnboardingMetaGlassesStep> {
+  bool _notifiedReady = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return Consumer<MetaWearablesProvider>(
+      builder: (context, provider, child) {
+        if (!_notifiedReady && metaGlassesOnboardingComplete(provider)) {
+          _notifiedReady = true;
+          WidgetsBinding.instance.addPostFrameCallback((_) {
+            if (mounted) widget.onMetaGlassesReady?.call();
+          });
+        }
+
+        return LayoutBuilder(
+          builder: (context, constraints) => SingleChildScrollView(
+            child: ConstrainedBox(
+              constraints: BoxConstraints(minHeight: constraints.maxHeight),
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  Text(
+                    context.l10n.connectDevice,
+                    textAlign: TextAlign.center,
+                    style: const TextStyle(fontSize: 28, fontWeight: FontWeight.w700, color: Colors.white),
+                  ),
+                  const SizedBox(height: 24),
+                  _OnboardingDeviceOption(
+                    key: const Key('onboarding_omi_device_option'),
+                    title: context.l10n.getOmiDevice,
+                    assetPath: Assets.images.omiGlass.path,
+                    onTap: widget.onOmiDeviceSelected,
+                  ),
+                  const SizedBox(height: 12),
+                  _OnboardingDeviceOption(
+                    key: const Key('onboarding_meta_glasses_option'),
+                    title: context.l10n.metaGlasses,
+                    assetPath: Assets.images.omiGlass.path,
+                    onTap: widget.onMetaGlassesSelected,
+                  ),
+                  const SizedBox(height: 16),
+                  TextButton(
+                    onPressed: widget.onContinueWithoutDevice,
+                    child: Text(
+                      context.l10n.continueWithoutDevice,
+                      style: const TextStyle(color: Colors.white70, fontWeight: FontWeight.w600),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _OnboardingDeviceOption extends StatelessWidget {
+  const _OnboardingDeviceOption({super.key, required this.title, required this.assetPath, required this.onTap});
+
+  final String title;
+  final String assetPath;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 18, vertical: 16),
+        decoration: BoxDecoration(color: Colors.white, borderRadius: BorderRadius.circular(24)),
+        child: Row(
+          children: [
+            ClipRRect(
+              borderRadius: BorderRadius.circular(16),
+              child: Image.asset(
+                assetPath,
+                width: 56,
+                height: 56,
+                fit: BoxFit.cover,
+                errorBuilder: (_, __, ___) => const Icon(Icons.devices_other, size: 36, color: Colors.black),
+              ),
+            ),
+            const SizedBox(width: 16),
+            Expanded(
+              child: Text(
+                title,
+                style: const TextStyle(color: Colors.black, fontSize: 18, fontWeight: FontWeight.w700),
+              ),
+            ),
+            const Icon(Icons.chevron_right, color: Colors.black54),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/app/lib/providers/meta_wearables_provider.dart
+++ b/app/lib/providers/meta_wearables_provider.dart
@@ -173,9 +173,8 @@ class MetaWearablesProvider extends ChangeNotifier {
   Duration get _photoInterval => captureInterval.duration;
   Duration get _watchdogStaleFrameThreshold => _photoInterval + _watchdogFrameGrace;
 
-  /// Built-in-app behavior: capture starts by itself whenever registered
-  /// glasses are present, so the phone app is only needed for check-ins.
-  bool autoCaptureEnabled = true;
+  /// Camera wearable capture must be explicit opt-in.
+  bool autoCaptureEnabled = false;
   bool _autoStartInFlight = false;
 
   /// A user-initiated stop must stay stopped: auto-capture may not undo it
@@ -338,7 +337,7 @@ class MetaWearablesProvider extends ChangeNotifier {
     _selectedDeviceUuid = storedUuid.isEmpty ? null : storedUuid;
     captureMode = MetaGlassesCaptureMode.fromName(SharedPreferencesUtil().getString(_captureModePrefKey));
     captureInterval = MetaGlassesCaptureInterval.fromName(SharedPreferencesUtil().getString(_captureIntervalPrefKey));
-    autoCaptureEnabled = SharedPreferencesUtil().getBool(_autoCapturePrefKey, defaultValue: true);
+    autoCaptureEnabled = SharedPreferencesUtil().getBool(_autoCapturePrefKey);
     try {
       final docs = await getApplicationDocumentsDirectory();
       final dir = Directory('${docs.path}/meta_glasses_photo_queue');

--- a/app/lib/providers/meta_wearables_provider.dart
+++ b/app/lib/providers/meta_wearables_provider.dart
@@ -84,7 +84,8 @@ class MetaWearablesProvider extends ChangeNotifier {
   static const String _selectedDeviceUuidPrefKey = 'metaWearablesSelectedDeviceUuid';
 
   /// Native audio-session bridge (AppDelegate `com.omi.ios/audioSession`):
-  /// `configureForBluetooth` routes recording input to the glasses' BT mic.
+  /// Meta capture uses `configureForMetaGlassesCapture`, which requires the
+  /// glasses HFP input and mixes other media without a phone-mic fallback.
   static const MethodChannel _audioSessionChannel = MethodChannel('com.omi.ios/audioSession');
 
   /// Native gesture bridge (AppDelegate `com.omi/meta_gestures`). Glasses
@@ -193,6 +194,7 @@ class MetaWearablesProvider extends ChangeNotifier {
   DateTime? _lastGestureAt;
   DateTime? _gestureListeningStartedAt;
   bool _gestureHandlerInstalled = false;
+  bool _audioRouteHandlerInstalled = false;
 
   /// Store-and-forward photo queue: every still lands on disk first and is
   /// only deleted after the backend confirms transmission over the socket.
@@ -332,6 +334,7 @@ class MetaWearablesProvider extends ChangeNotifier {
   Future<void> init() async {
     if (_initialized) return;
     _initialized = true;
+    _installAudioRouteHandler();
 
     final storedUuid = SharedPreferencesUtil().getString(_selectedDeviceUuidPrefKey);
     _selectedDeviceUuid = storedUuid.isEmpty ? null : storedUuid;
@@ -783,8 +786,8 @@ class MetaWearablesProvider extends ChangeNotifier {
     notifyListeners();
   }
 
-  /// Starts glasses capture: DAT camera frames are cached directly to the
-  /// backend. Phone microphone/listen socket audio is not started.
+  /// Starts glasses capture: Bluetooth HFP audio starts and is verified before
+  /// DAT camera frames. The iPhone microphone is never an accepted fallback.
   ///
   /// [displayStatusText] is rendered on Ray-Ban Display glasses while
   /// capturing; pass a localized string from the UI.
@@ -804,16 +807,37 @@ class MetaWearablesProvider extends ChangeNotifier {
     _captureWatchdog.reset();
 
     try {
+      Map<String, dynamic>? route;
       try {
-        await MetaWearablesDat.enableBackgroundStreaming();
+        route = await _audioSessionChannel.invokeMapMethod<String, dynamic>('configureForMetaGlassesCapture');
       } catch (e) {
-        Logger.debug('MetaGlassStreamDiag: enableBackgroundStreaming failed: $e');
+        Logger.debug('MetaGlassStreamDiag: configureForMetaGlassesCapture failed: $e');
+        _appendRuntimeProof('MetaGlassRuntimeProof start-capture-failed reason=glasses-microphone-unavailable');
+        notifyListeners();
+        return false;
       }
 
       _appendRuntimeProof(
           'MetaGlassRuntimeProof start-capture captureMode=${captureMode.name} cameraNeeded=$_cameraStreamNeeded cameraPermission=$cameraPermissionState gestures=media-remote');
 
+      await captureController.streamRecording();
+      route = await _audioSessionChannel.invokeMapMethod<String, dynamic>('getCurrentAudioRoute');
+      if (route?['glassesInput'] != true) {
+        await captureController.stopStreamRecording();
+        _appendRuntimeProof('MetaGlassRuntimeProof start-capture-failed reason=audio-route-not-hfp');
+        notifyListeners();
+        return false;
+      }
+      final input = route?['input'] ?? 'unknown';
+      final output = route?['output'] ?? 'unknown';
+      _appendRuntimeProof('MetaGlassRuntimeProof audio-stream-started input=$input output=$output');
+
       if (_cameraStreamNeeded) {
+        try {
+          await MetaWearablesDat.enableBackgroundStreaming();
+        } catch (e) {
+          Logger.debug('MetaGlassStreamDiag: enableBackgroundStreaming failed: $e');
+        }
         await _startPhotoLoop();
         final firstFrameQueued = await _waitForFirstQueuedFrame();
         if (!_cameraCaptureStreamReady || !firstFrameQueued) {
@@ -824,24 +848,13 @@ class MetaWearablesProvider extends ChangeNotifier {
           } catch (e) {
             Logger.debug('MetaWearablesProvider: disableBackgroundStreaming failed after start failure: $e');
           }
+          await captureController.stopStreamRecording();
           notifyListeners();
           return false;
         }
       } else {
         _appendRuntimeProof('MetaGlassStreamDiag start-photo-loop skipped captureMode=${captureMode.name}');
       }
-
-      // Glasses-to-backend audio: route the shared audio session to the
-      // glasses' Bluetooth (HFP) microphone, then open the transcription
-      // socket. The socket carries both the STT audio and the image_chunk
-      // photo uploads — it is the only ingestion path deployed on prod.
-      try {
-        await _audioSessionChannel.invokeMethod('configureForBluetooth');
-      } catch (e) {
-        Logger.debug('MetaGlassStreamDiag: configureForBluetooth failed: $e');
-      }
-      await captureController.streamRecording();
-      _appendRuntimeProof('MetaGlassRuntimeProof audio-stream-started route=bluetooth');
 
       await _startGestureListening();
 
@@ -925,6 +938,22 @@ class MetaWearablesProvider extends ChangeNotifier {
     } catch (e) {
       Logger.debug('MetaGlassGestureDiag: stopListening failed: $e');
     }
+  }
+
+  void _installAudioRouteHandler() {
+    if (!Platform.isIOS || _audioRouteHandlerInstalled) return;
+    _audioSessionChannel.setMethodCallHandler((call) async {
+      if (call.method == 'onAudioRouteChanged') {
+        final route = (call.arguments as Map?)?.cast<String, dynamic>() ?? const <String, dynamic>{};
+        if (isCapturing && route['glassesInput'] != true) {
+          _appendRuntimeProof(
+              'MetaGlassRuntimeProof audio-route-lost input=${route['input'] ?? 'unknown'} output=${route['output'] ?? 'unknown'}');
+          await stopCapture(manual: false);
+        }
+      }
+      return null;
+    });
+    _audioRouteHandlerInstalled = true;
   }
 
   /// Tap = toggle capture. Media-remote events often double-fire (play +

--- a/app/lib/providers/meta_wearables_provider.dart
+++ b/app/lib/providers/meta_wearables_provider.dart
@@ -1,0 +1,1970 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+
+import 'package:crypto/crypto.dart' as crypto;
+import 'package:meta_wearables_dat_flutter/meta_wearables_dat_flutter.dart';
+
+import 'package:path_provider/path_provider.dart';
+
+import 'package:omi/backend/preferences.dart';
+import 'package:omi/backend/schema/transcript_segment.dart';
+import 'package:omi/backend/schema/bt_device/bt_device.dart';
+import 'package:omi/services/capture/capture_controller.dart';
+import 'package:omi/services/devices/meta_wearables_service.dart';
+import 'package:omi/services/meta_wearables/meta_capture_diagnostics.dart';
+import 'package:omi/services/meta_wearables/meta_capture_queue.dart';
+import 'package:omi/services/meta_wearables/meta_capture_watchdog.dart';
+import 'package:omi/utils/enums.dart';
+import 'package:omi/utils/logger.dart';
+
+/// How connected Meta glasses feed the capture pipeline.
+///
+/// The DAT SDK exposes camera streaming only in this integration; Meta capture
+/// history is cached from glasses frames and does not start the phone mic.
+enum MetaGlassesCaptureMode {
+  /// Periodic camera frames cached into conversation history.
+  cameraAndMic,
+
+  /// Legacy setting. DAT mic capture is not available here, so this starts no
+  /// phone audio.
+  micOnly;
+
+  static MetaGlassesCaptureMode fromName(String? name) {
+    return MetaGlassesCaptureMode.values.firstWhere((m) => m.name == name, orElse: () => cameraAndMic);
+  }
+}
+
+/// User-selectable interval between automatic camera captures in Camera+Mic
+/// mode.
+enum MetaGlassesCaptureInterval {
+  s10(Duration(seconds: 10)),
+  s30(Duration(seconds: 30)),
+  m1(Duration(minutes: 1)),
+  m5(Duration(minutes: 5));
+
+  const MetaGlassesCaptureInterval(this.duration);
+  final Duration duration;
+
+  static MetaGlassesCaptureInterval fromName(String? name) {
+    return MetaGlassesCaptureInterval.values.firstWhere((m) => m.name == name, orElse: () => s30);
+  }
+}
+
+enum MetaGlassesHealth {
+  ok,
+  overheating,
+  foldedClosed;
+
+  static MetaGlassesHealth? fromSessionError(Object error) {
+    if (error is SessionError) {
+      if (error.isThermalCritical) return MetaGlassesHealth.overheating;
+      if (error.isHingesClosed) return MetaGlassesHealth.foldedClosed;
+    }
+    if (error is DatError) {
+      if (error.code == DatErrorCodes.thermalCritical) return MetaGlassesHealth.overheating;
+      if (error.code == DatErrorCodes.hingesClosed) return MetaGlassesHealth.foldedClosed;
+    }
+    return null;
+  }
+}
+
+/// App-level state for Meta glasses connected through the Wearables Device
+/// Access Toolkit. Runs alongside [DeviceProvider] so a BLE wearable and one
+/// or more Meta glasses can be connected at the same time (multi-device).
+///
+/// Multi-device model: the DAT SDK reports every glasses paired to this phone
+/// via `devicesStream()`. The user may pick which pair is "active" for
+/// streaming/photo sessions; per-device sessions are addressed by
+/// `DeviceInfo.uuid`.
+class MetaWearablesProvider extends ChangeNotifier {
+  static const String _selectedDeviceUuidPrefKey = 'metaWearablesSelectedDeviceUuid';
+
+  /// Native audio-session bridge (AppDelegate `com.omi.ios/audioSession`):
+  /// `configureForBluetooth` routes recording input to the glasses' BT mic.
+  static const MethodChannel _audioSessionChannel = MethodChannel('com.omi.ios/audioSession');
+
+  /// Native gesture bridge (AppDelegate `com.omi/meta_gestures`). Glasses
+  /// stalk taps arrive as Bluetooth media-remote commands; only delivered
+  /// while capture holds the audio session and Now Playing. Tap = toggle
+  /// capture — the one honest gesture the transport can carry.
+  static const MethodChannel _gesturesChannel = MethodChannel('com.omi/meta_gestures');
+  static const Duration _gestureDebounce = Duration(milliseconds: 1500);
+
+  /// Claiming the Bluetooth route fires a phantom AVRCP `pause` at the new
+  /// Now Playing app ~400ms after listening starts (observed on-device
+  /// 2026-07-05: listening-started 15:34:36.566 → pause .972 → capture
+  /// toggled itself off). Discard anything inside this window.
+  static const Duration _gestureActivationGrace = Duration(seconds: 3);
+  static const String _captureModePrefKey = 'metaGlassesCaptureMode';
+  static const String _autoCapturePrefKey = 'metaGlassesAutoCapture';
+  static const String _captureIntervalPrefKey = 'metaGlassesCaptureInterval';
+  static const Duration _displayUpdateThrottle = Duration(seconds: 2);
+  static const bool _advancedDisplayUiEnabled = false;
+
+  // Background capture streams video frames from the glasses (native-pushed,
+  // works while backgrounded). Run at the lowest DAT frame rate (2 fps) to keep
+  // the per-frame copy cheap; medium quality so stored frames are viewable
+  // (low/360p looked bad).
+  static const int _photoSessionFps = 2;
+  static const StreamQuality _photoSessionQuality = StreamQuality.medium;
+
+  // Bound the on-disk photo backlog (oldest dropped first).
+  static const int _maxQueuedPhotos = 200;
+  static const int _runtimeProofLogMaxBytes = 64 * 1024;
+  static const Duration _watchdogFrameGrace = Duration(seconds: 10);
+  static const Duration _watchdogStreamFrameStaleThreshold = Duration(seconds: 20);
+  static const Duration _firstQueuedFrameStartTimeout = Duration(seconds: 12);
+
+  final MetaWearablesService _service;
+
+  MetaWearablesProvider({MetaWearablesService service = const MetaWearablesService()}) : _service = service;
+
+  RegistrationState registrationState = RegistrationState.unavailable;
+  List<DeviceInfo> devices = [];
+  DeviceInfo? _sdkActiveDevice;
+  String? _selectedDeviceUuid;
+  MetaGlassesCameraPermissionState cameraPermissionState = MetaGlassesCameraPermissionState.unavailable;
+  StreamSessionState streamSessionState = StreamSessionState.stopped;
+  DeviceSessionState deviceSessionState = DeviceSessionState.idle;
+  bool isRegistering = false;
+  String? lastError;
+  MetaGlassesHealth health = MetaGlassesHealth.ok;
+
+  MetaGlassesCaptureMode captureMode = MetaGlassesCaptureMode.cameraAndMic;
+  MetaGlassesCaptureInterval captureInterval = MetaGlassesCaptureInterval.s30;
+  bool isCapturing = false;
+  CaptureController? _captureController;
+  Timer? _thermalRetryTimer;
+
+  // Background capture: one continuous never-paused stream session. The DAT
+  // videoFramesStream (native-pushed) is the capture trigger — it keeps firing
+  // while backgrounded, unlike a Dart timer. Each frame event keeps the SDK's
+  // latestPixelBuffer fresh; we encode one viewable JPEG from it natively at
+  // most once per [captureInterval] via captureLatestFrame.
+  StreamSubscription<VideoFrame>? _frameSub;
+  DateTime? _lastFrameForwardedAt;
+  DateTime? _lastStreamFrameEventAt;
+  DateTime? _lastPhotoLoopStartedAt;
+  DateTime? _lastQueuedPhotoAt;
+  Completer<bool>? _firstQueuedFrameCompleter;
+  int _streamGeneration = 0;
+  bool _frameForwardInFlight = false;
+  int? _frameForwardInFlightGeneration;
+  final MetaCaptureWatchdog _captureWatchdog = MetaCaptureWatchdog();
+  Timer? _captureWatchdogTimer;
+  bool _captureWatchdogTimerIsRestart = false;
+  bool _captureWatchdogRestartInFlight = false;
+  @visibleForTesting
+  void Function(MetaCaptureHealth health, Duration delay)? debugOnCaptureWatchdogRestartScheduled;
+
+  // videoStreamingError recovery (bounded).
+  int streamFailureCount = 0;
+  bool micOnlyFallback = false;
+  Timer? _streamRetryTimer;
+  Timer? _autoStartRetryTimer;
+  static const Duration _notReadyRefreshInterval = Duration(seconds: 2);
+  Timer? _notReadyRefreshTimer;
+  bool _notReadyRefreshInFlight = false;
+
+  Duration get _photoInterval => captureInterval.duration;
+  Duration get _watchdogStaleFrameThreshold => _photoInterval + _watchdogFrameGrace;
+
+  /// Built-in-app behavior: capture starts by itself whenever registered
+  /// glasses are present, so the phone app is only needed for check-ins.
+  bool autoCaptureEnabled = true;
+  bool _autoStartInFlight = false;
+
+  /// A user-initiated stop must stay stopped: auto-capture may not undo it
+  /// until the glasses go away and come back (a fresh session intent), the
+  /// user starts capture again, or re-enables auto-capture.
+  bool _manualStopRequested = false;
+  bool _thermalPaused = false;
+  bool _livePreviewVisible = false;
+  bool _photoLoopStarting = false;
+
+  /// Serializes start/stop so button taps can't interleave two transitions.
+  bool _captureTransitionInFlight = false;
+
+  /// Last gesture received from the native media-remote bridge (diagnostics).
+  String? lastGesture;
+  DateTime? _lastGestureAt;
+  DateTime? _gestureListeningStartedAt;
+  bool _gestureHandlerInstalled = false;
+
+  /// Store-and-forward photo queue: every still lands on disk first and is
+  /// only deleted after the backend confirms transmission over the socket.
+  Directory? _photoQueueDir;
+  MetaCaptureQueue? _metaCaptureQueue;
+  File? _runtimeProofLogFile;
+  int pendingPhotoCount = 0;
+  MetaCaptureDiagnostics diagnostics = const MetaCaptureDiagnostics();
+  DateTime? _lastDiagnosticsLogAt;
+  bool _flushingQueue = false;
+  final Set<String> _photosShownInUi = {};
+
+  /// Live camera preview texture while a camera session runs, for `Texture`.
+  int? previewTextureId;
+  double previewAspectRatio = 4 / 3;
+
+  /// Latest per-device compatibility verdicts (firmware/SDK update needed).
+  final Map<String, DeviceCompatibility> compatibilityByUuid = {};
+
+  bool _displaySessionActive = false;
+  String _displayStatusText = 'Listening';
+  CaptureController? _displayCaptureController;
+  Timer? _displayUpdateTimer;
+  DateTime? _lastDisplayUpdateAt;
+
+  StreamSubscription<RegistrationState>? _registrationSub;
+  StreamSubscription<List<DeviceInfo>>? _devicesSub;
+  StreamSubscription<DeviceInfo?>? _activeDeviceSub;
+  StreamSubscription<DeviceCompatibilityEvent>? _compatibilitySub;
+  StreamSubscription<VideoStreamSize>? _videoSizeSub;
+  StreamSubscription<StreamSessionState>? _streamStateSub;
+  StreamSubscription<DeviceSessionState>? _deviceStateSub;
+  StreamSubscription<Object>? _streamErrorSub;
+  StreamSubscription<Object>? _deviceErrorSub;
+  StreamSubscription<DisplayState>? _displayStateSub;
+  bool _initialized = false;
+  bool _initialRefreshComplete = false;
+
+  bool get isRegistered => registrationState == RegistrationState.registered;
+  bool get isAvailable => registrationState != RegistrationState.unavailable;
+  bool get hasDevices => devices.isNotEmpty;
+  bool get cameraPermissionGranted => cameraPermissionState == MetaGlassesCameraPermissionState.granted;
+  bool get isRequestingCameraPermission => cameraPermissionState == MetaGlassesCameraPermissionState.requesting;
+  bool get isStreamPaused => streamSessionState == StreamSessionState.paused;
+  bool get isDeviceSessionPaused => deviceSessionState == DeviceSessionState.paused;
+  bool get advancedDisplayUiEnabled => _advancedDisplayUiEnabled;
+  bool get canShowDisplayStatus => selectedDevice?.kind == DeviceKind.rayBanDisplay;
+  bool get _cameraStreamNeeded => captureMode == MetaGlassesCaptureMode.cameraAndMic;
+  bool get _cameraCaptureStreamReady =>
+      previewTextureId != null && _frameSub != null && _lastQueuedPhotoAt != null && !micOnlyFallback;
+
+  static DisplayView buildDisplayCaptureView({
+    required String captureStateLine,
+    List<TranscriptSegment> segments = const <TranscriptSegment>[],
+  }) {
+    final snippet = _latestDisplaySnippet(segments);
+    return FlexBox(
+      padding: 16,
+      spacing: 8,
+      children: [
+        DisplayText(captureStateLine, style: DisplayTextStyle.heading),
+        if (snippet != null) DisplayText(snippet, style: DisplayTextStyle.body, color: DisplayTextColor.secondary),
+      ],
+    );
+  }
+
+  static String? _latestDisplaySnippet(List<TranscriptSegment> segments) {
+    for (final segment in segments.reversed) {
+      final text = segment.text.trim();
+      if (text.isNotEmpty) return _truncateDisplayText(text);
+    }
+    return null;
+  }
+
+  static String _truncateDisplayText(String text) {
+    const maxChars = 80;
+    if (text.length <= maxChars) return text;
+    return '${text.substring(0, maxChars - 3).trimRight()}...';
+  }
+
+  /// Devices whose Bluetooth link is live (or reported by an older native
+  /// layer that predates link states). Sessions only work against these.
+  List<DeviceInfo> get linkedDevices =>
+      devices.where((d) => d.linkState == DeviceLinkState.connected || d.linkState == DeviceLinkState.unknown).toList();
+
+  bool get hasLinkedDevices => linkedDevices.isNotEmpty;
+
+  bool get _activeDeviceIsSessionCandidate {
+    final linkState = _sdkActiveDevice?.linkState;
+    return linkState == DeviceLinkState.connected || linkState == DeviceLinkState.unknown;
+  }
+
+  bool get _hasSessionCandidateDevice => hasLinkedDevices || _activeDeviceIsSessionCandidate;
+
+  /// The glasses sessions target: the user's explicit pick when it is still
+  /// paired, otherwise whatever the SDK reports as active, otherwise the
+  /// first paired pair.
+  DeviceInfo? get selectedDevice {
+    if (_selectedDeviceUuid != null) {
+      for (final device in devices) {
+        if (device.uuid == _selectedDeviceUuid) return device;
+      }
+    }
+    // Prefer the sanitized-list instance for the SDK-active device; a shadow
+    // record that got filtered out must not resurface here.
+    final activeUuid = _sdkActiveDevice?.uuid;
+    if (activeUuid != null) {
+      for (final device in devices) {
+        if (device.uuid == activeUuid) return device;
+      }
+    }
+    if (devices.isNotEmpty) return devices.first;
+    return _sdkActiveDevice;
+  }
+
+  /// Device uuid to pass to session APIs. Prefer a user-selected or DAT-active
+  /// pair that the SDK currently reports; the iOS auto selector can return
+  /// `noEligibleDevice` while link-state streams are still catching up.
+  String? get _sessionTargetUuid {
+    final linked = linkedDevices;
+    final selectedUuid = _selectedDeviceUuid;
+    if (selectedUuid != null && linked.any((d) => d.uuid == selectedUuid)) return selectedUuid;
+    final activeUuid = _sdkActiveDevice?.uuid;
+    if (activeUuid != null &&
+        _activeDeviceIsSessionCandidate &&
+        (devices.isEmpty || devices.any((d) => d.uuid == activeUuid))) {
+      return activeUuid;
+    }
+    if (linked.length == 1) return linked.first.uuid;
+    return null;
+  }
+
+  bool isSelected(DeviceInfo device) => selectedDevice?.uuid == device.uuid;
+
+  bool isActive(DeviceInfo device) => _sdkActiveDevice?.uuid == device.uuid;
+
+  Future<void> init() async {
+    if (_initialized) return;
+    _initialized = true;
+
+    final storedUuid = SharedPreferencesUtil().getString(_selectedDeviceUuidPrefKey);
+    _selectedDeviceUuid = storedUuid.isEmpty ? null : storedUuid;
+    captureMode = MetaGlassesCaptureMode.fromName(SharedPreferencesUtil().getString(_captureModePrefKey));
+    captureInterval = MetaGlassesCaptureInterval.fromName(SharedPreferencesUtil().getString(_captureIntervalPrefKey));
+    autoCaptureEnabled = SharedPreferencesUtil().getBool(_autoCapturePrefKey, defaultValue: true);
+    try {
+      final docs = await getApplicationDocumentsDirectory();
+      final dir = Directory('${docs.path}/meta_glasses_photo_queue');
+      if (!dir.existsSync()) dir.createSync(recursive: true);
+      _photoQueueDir = dir;
+      _metaCaptureQueue = MetaCaptureQueue(rootDirectory: dir);
+      _runtimeProofLogFile = File('${docs.path}/meta_glasses_runtime_proof.log');
+      _appendRuntimeProof('MetaGlassRuntimeProof provider-init');
+      await _refreshPendingPhotoCount();
+    } catch (e) {
+      Logger.debug('MetaWearablesProvider: photo queue dir unavailable: $e');
+    }
+
+    _registrationSub = _service.registrationStateStream().listen((state) {
+      registrationState = state;
+      if (state != RegistrationState.registering) isRegistering = false;
+      _appendRuntimeProof('MetaGlassRuntimeProof registration-state state=$state');
+      notifyListeners();
+      _maybeAutoStartCapture();
+    }, onError: (Object e) => Logger.debug('MetaWearablesProvider registration stream error: $e'));
+
+    _devicesSub = _service.devicesStream().listen((rawList) {
+      final deviceList = sanitizeDevices(rawList);
+      final hadDevices = devices.isNotEmpty;
+      devices = deviceList;
+      final deviceStates = deviceList.map((d) => '${d.uuid}:${d.linkState.name}').join(',');
+      _appendRuntimeProof(
+          'MetaGlassRuntimeProof devices count=${deviceList.length} selected=$_selectedDeviceUuid linked=$hasLinkedDevices candidate=$_hasSessionCandidateDevice states=$deviceStates');
+      // A persisted selection pointing at a device the SDK no longer reports
+      // (stale shadow record) would make every session start fail — drop it.
+      if (_selectedDeviceUuid != null &&
+          deviceList.isNotEmpty &&
+          !deviceList.any((d) => d.uuid == _selectedDeviceUuid)) {
+        _selectedDeviceUuid = null;
+        SharedPreferencesUtil().saveString(_selectedDeviceUuidPrefKey, '');
+      }
+      notifyListeners();
+      if (deviceList.isEmpty && hadDevices) {
+        // Glasses gone (powered off / out of range) — wind the session down;
+        // auto-capture brings it back when they reappear. A prior manual stop
+        // no longer applies to the next appearance.
+        _manualStopRequested = false;
+        if (isCapturing) stopCapture(manual: false);
+      } else {
+        _maybeAutoStartCapture();
+      }
+    }, onError: (Object e) => Logger.debug('MetaWearablesProvider devices stream error: $e'));
+
+    _activeDeviceSub = _service.activeDeviceStream().listen((device) {
+      _sdkActiveDevice = device;
+      _appendRuntimeProof('MetaGlassRuntimeProof active-device uuid=${device?.uuid ?? 'none'}');
+      notifyListeners();
+      _maybeAutoStartCapture();
+    }, onError: (Object e) => Logger.debug('MetaWearablesProvider active device stream error: $e'));
+
+    _compatibilitySub = MetaWearablesDat.compatibilityStream().listen((event) {
+      compatibilityByUuid[event.deviceUuid] = event.compatibility;
+      notifyListeners();
+    }, onError: (Object e) => Logger.debug('MetaWearablesProvider compatibility stream error: $e'));
+
+    _videoSizeSub = MetaWearablesDat.videoStreamSizeStream().listen((size) {
+      if (size.width > 0 && size.height > 0) {
+        previewAspectRatio = size.width / size.height;
+        notifyListeners();
+      }
+    }, onError: (Object e) => Logger.debug('MetaWearablesProvider video size stream error: $e'));
+
+    _streamStateSub = MetaWearablesDat.streamSessionStateStream().listen(
+      _handleStreamSessionState,
+      onError: (Object e) => Logger.debug('MetaWearablesProvider stream state sub failed: $e'),
+    );
+
+    _deviceStateSub = MetaWearablesDat.deviceSessionStateStream().listen(
+      _handleDeviceSessionState,
+      onError: (Object e) => Logger.debug('MetaWearablesProvider device state sub failed: $e'),
+    );
+
+    _streamErrorSub = MetaWearablesDat.streamSessionErrorStream().listen(
+      (error) => unawaited(_handleSessionError(error)),
+      onError: (Object e) => Logger.debug('MetaWearablesProvider stream error sub failed: $e'),
+    );
+
+    _deviceErrorSub = MetaWearablesDat.deviceSessionErrorStream().listen(
+      (error) => unawaited(_handleSessionError(error)),
+      onError: (Object e) => Logger.debug('MetaWearablesProvider device error sub failed: $e'),
+    );
+
+    await refresh();
+    _initialRefreshComplete = true;
+    _maybeAutoStartCapture();
+  }
+
+  /// Compatibility verdict for [device], if the SDK has reported one.
+  DeviceCompatibility compatibilityFor(DeviceInfo device) {
+    return compatibilityByUuid[device.uuid] ?? DeviceCompatibility.unknown;
+  }
+
+  bool hasCompatibilityUpdateAction(DeviceInfo device) {
+    final compatibility = compatibilityFor(device);
+    return compatibility == DeviceCompatibility.deviceUpdateRequired ||
+        compatibility == DeviceCompatibility.sdkUpdateRequired;
+  }
+
+  Future<void> openCompatibilityUpdate(DeviceInfo device) async {
+    try {
+      switch (compatibilityFor(device)) {
+        case DeviceCompatibility.deviceUpdateRequired:
+          await _service.openFirmwareUpdate();
+          break;
+        case DeviceCompatibility.sdkUpdateRequired:
+          await _service.openDATGlassesAppUpdate();
+          break;
+        case DeviceCompatibility.compatible:
+        case DeviceCompatibility.unknown:
+          return;
+      }
+    } catch (e) {
+      Logger.debug('MetaWearablesProvider open compatibility update failed: $e');
+      lastError = e.toString();
+      notifyListeners();
+    }
+  }
+
+  /// The DAT SDK can report the same physical glasses twice: once with the
+  /// user-visible name (e.g. "000R") and once as a shadow record whose "name"
+  /// is a long identifier. Collapse uuid duplicates and drop identifier-named
+  /// shadows whenever a properly named device exists — but never filter down
+  /// to nothing.
+  @visibleForTesting
+  static List<DeviceInfo> sanitizeDevices(List<DeviceInfo> raw) {
+    final byUuid = <String, DeviceInfo>{};
+    for (final device in raw) {
+      final existing = byUuid[device.uuid];
+      if (existing == null || (!_hasHumanName(existing) && _hasHumanName(device))) {
+        byUuid[device.uuid] = device;
+      }
+    }
+    final deduped = byUuid.values.toList();
+    final named = deduped.where(_hasHumanName).toList();
+    return named.isNotEmpty ? named : deduped;
+  }
+
+  static final RegExp _identifierLikeName = RegExp(r'^[0-9A-Fa-f:-]{16,}$');
+
+  static bool _hasHumanName(DeviceInfo device) {
+    final name = device.name.trim();
+    if (name.isEmpty) return false;
+    if (name == device.uuid) return false;
+    if (_identifierLikeName.hasMatch(name)) return false;
+    // Long unbroken blobs (base64-ish session ids) are artifacts, not names.
+    if (name.length >= 24 && !name.contains(' ')) return false;
+    return true;
+  }
+
+  Future<void> refresh() async {
+    try {
+      final snapshot = await _service.snapshot();
+      registrationState = snapshot.registrationState;
+      devices = sanitizeDevices(snapshot.devices);
+      _sdkActiveDevice = snapshot.activeDevice;
+      cameraPermissionState = snapshot.cameraPermissionState;
+      lastError = null;
+    } catch (e) {
+      Logger.debug('MetaWearablesProvider refresh failed: $e');
+      lastError = e.toString();
+    }
+    notifyListeners();
+  }
+
+  /// Deep-links into the Meta AI app to register this app with the user's
+  /// glasses. Registration completes when the omimeta:// callback comes back.
+  Future<bool> startRegistration() async {
+    if (isRegistering) return false;
+    isRegistering = true;
+    lastError = null;
+    notifyListeners();
+    try {
+      await _service.startPairing();
+      await refresh();
+      return isRegistered;
+    } catch (e) {
+      Logger.debug('MetaWearablesProvider startRegistration failed: $e');
+      lastError = e.toString();
+      return false;
+    } finally {
+      isRegistering = false;
+      notifyListeners();
+    }
+  }
+
+  Future<void> unregister() async {
+    try {
+      await _service.forgetLocalRegistration();
+    } catch (e) {
+      Logger.debug('MetaWearablesProvider unregister failed: $e');
+      lastError = e.toString();
+    }
+    _selectedDeviceUuid = null;
+    await SharedPreferencesUtil().saveString(_selectedDeviceUuidPrefKey, '');
+    await refresh();
+  }
+
+  /// Picks which paired glasses future sessions target. Persisted so the
+  /// choice survives app restarts.
+  Future<void> selectDevice(String uuid) async {
+    _selectedDeviceUuid = uuid;
+    await SharedPreferencesUtil().saveString(_selectedDeviceUuidPrefKey, uuid);
+    notifyListeners();
+  }
+
+  Future<bool> requestCameraPermission() async {
+    cameraPermissionState = MetaGlassesCameraPermissionState.requesting;
+    notifyListeners();
+    try {
+      final granted = await _service.requestCameraPermission();
+      cameraPermissionState =
+          granted ? MetaGlassesCameraPermissionState.granted : MetaGlassesCameraPermissionState.needsRequest;
+    } catch (e) {
+      Logger.debug('MetaWearablesProvider camera permission failed: $e');
+      lastError = e.toString();
+      cameraPermissionState = MetaGlassesCameraPermissionState.unavailable;
+    }
+    await refresh();
+    return cameraPermissionGranted;
+  }
+
+  /// Starts a preview stream on the selected glasses; returns the Flutter
+  /// texture id, or null on failure.
+  Future<int?> startPreview() async {
+    final device = selectedDevice;
+    try {
+      final textureId = await _service.startPreviewStream(deviceUUID: device?.uuid);
+      previewTextureId = textureId;
+      notifyListeners();
+      return textureId;
+    } catch (e) {
+      Logger.debug('MetaWearablesProvider startPreview failed: $e');
+      lastError = e.toString();
+      notifyListeners();
+      return null;
+    }
+  }
+
+  Future<void> stopPreview() async {
+    final device = selectedDevice;
+    try {
+      await _service.stopPreviewStream(deviceUUID: device?.uuid);
+    } catch (e) {
+      Logger.debug('MetaWearablesProvider stopPreview failed: $e');
+    }
+  }
+
+  BtDevice? get selectedBtDevice {
+    final device = selectedDevice;
+    if (device == null) return null;
+    return _service.toBtDevice(device);
+  }
+
+  // --- Capture (Camera+Mic / Mic only) --------------------------------------
+
+  /// Wires the app-level capture pipeline in (from a ProxyProvider in
+  /// main.dart), enabling gesture- and auto-started capture without any page
+  /// visit — the glasses behave like a built-in app.
+  void attachCaptureController(CaptureController controller) {
+    _captureController = controller;
+    _maybeAutoStartCapture();
+  }
+
+  Future<void> setAutoCaptureEnabled(bool enabled) async {
+    autoCaptureEnabled = enabled;
+    if (enabled) _manualStopRequested = false;
+    await SharedPreferencesUtil().saveBool(_autoCapturePrefKey, enabled);
+    notifyListeners();
+    _maybeAutoStartCapture();
+  }
+
+  /// Starts capture hands-free when registered glasses are present, the
+  /// pipeline is attached, and nothing else is recording.
+  Future<void> _maybeAutoStartCapture() async {
+    if (!autoCaptureEnabled) {
+      _cancelNotReadyRefresh();
+      _appendRuntimeProof('MetaGlassRuntimeProof auto-start-skip reason=disabled');
+      return;
+    }
+    if (isCapturing) {
+      _cancelNotReadyRefresh();
+      _appendRuntimeProof('MetaGlassRuntimeProof auto-start-skip reason=already-capturing');
+      return;
+    }
+    if (_autoStartInFlight) {
+      _appendRuntimeProof('MetaGlassRuntimeProof auto-start-skip reason=in-flight');
+      return;
+    }
+    if (_captureTransitionInFlight) {
+      _appendRuntimeProof('MetaGlassRuntimeProof auto-start-skip reason=transitioning');
+      return;
+    }
+    if (_manualStopRequested) {
+      _cancelNotReadyRefresh();
+      _appendRuntimeProof('MetaGlassRuntimeProof auto-start-skip reason=manual-stop');
+      return;
+    }
+    if (!_initialRefreshComplete) {
+      _appendRuntimeProof('MetaGlassRuntimeProof auto-start-skip reason=initial-refresh');
+      return;
+    }
+    if (!isRegistered || !_hasSessionCandidateDevice) {
+      _appendRuntimeProof(
+          'MetaGlassRuntimeProof auto-start-skip reason=not-ready registered=$isRegistered linked=$hasLinkedDevices devices=${devices.length} active=${_sdkActiveDevice?.uuid ?? 'none'}');
+      _scheduleNotReadyRefresh();
+      return;
+    }
+    _cancelNotReadyRefresh();
+    final controller = _captureController;
+    if (controller == null) {
+      _cancelNotReadyRefresh();
+      _appendRuntimeProof('MetaGlassRuntimeProof auto-start-skip reason=no-capture-controller');
+      return;
+    }
+    // Don't fight another active recording source (BLE wearable, phone mic).
+    if (controller.recordingState != RecordingState.stop) {
+      _cancelNotReadyRefresh();
+      _appendRuntimeProof(
+          'MetaGlassRuntimeProof auto-start-skip reason=recording-state state=${controller.recordingState}');
+      return;
+    }
+    _autoStartInFlight = true;
+    try {
+      Logger.debug('MetaWearablesProvider: auto-starting glasses capture');
+      _appendRuntimeProof(
+          'MetaGlassRuntimeProof auto-starting target=${_sessionTargetUuid ?? 'auto'} linked=$hasLinkedDevices devices=${devices.length}');
+      final started = await startCapture(controller);
+      if (!started) {
+        _appendRuntimeProof('MetaGlassRuntimeProof auto-start-failed');
+        _scheduleAutoStartRetry();
+      }
+    } finally {
+      _autoStartInFlight = false;
+    }
+  }
+
+  bool get _shouldPollNotReady =>
+      _initialized &&
+      _initialRefreshComplete &&
+      autoCaptureEnabled &&
+      !isCapturing &&
+      !_autoStartInFlight &&
+      !_captureTransitionInFlight &&
+      !_manualStopRequested &&
+      isRegistered &&
+      devices.isNotEmpty &&
+      !_hasSessionCandidateDevice &&
+      _captureController != null &&
+      _captureController?.recordingState == RecordingState.stop;
+
+  void _scheduleNotReadyRefresh() {
+    if (_notReadyRefreshTimer != null || !_shouldPollNotReady) return;
+    _appendRuntimeProof(
+        'MetaGlassRuntimeProof not-ready-refresh-scheduled interval=${_notReadyRefreshInterval.inSeconds}s');
+    _notReadyRefreshTimer = Timer.periodic(_notReadyRefreshInterval, (_) {
+      unawaited(_refreshNotReadyDevices());
+    });
+  }
+
+  void _scheduleAutoStartRetry() {
+    if (_autoStartRetryTimer?.isActive == true) return;
+    _appendRuntimeProof('MetaGlassRuntimeProof auto-start-retry-scheduled');
+    _autoStartRetryTimer = Timer(_notReadyRefreshInterval, () {
+      _autoStartRetryTimer = null;
+      unawaited(_maybeAutoStartCapture());
+    });
+  }
+
+  void _cancelNotReadyRefresh() {
+    final timer = _notReadyRefreshTimer;
+    if (timer == null) return;
+    timer.cancel();
+    _notReadyRefreshTimer = null;
+    _appendRuntimeProof('MetaGlassRuntimeProof not-ready-refresh-cancelled');
+  }
+
+  void _cancelAutoStartRetry() {
+    _autoStartRetryTimer?.cancel();
+    _autoStartRetryTimer = null;
+  }
+
+  Future<void> _refreshNotReadyDevices() async {
+    if (!_shouldPollNotReady) {
+      _cancelNotReadyRefresh();
+      return;
+    }
+    if (_notReadyRefreshInFlight) return;
+
+    _notReadyRefreshInFlight = true;
+    try {
+      _appendRuntimeProof('MetaGlassRuntimeProof not-ready-refresh');
+      await refresh();
+      if (_hasSessionCandidateDevice) {
+        _cancelNotReadyRefresh();
+      }
+      await _maybeAutoStartCapture();
+    } catch (error, stackTrace) {
+      Logger.error('Meta glasses not-ready refresh failed: $error\n$stackTrace');
+      _appendRuntimeProof('MetaGlassRuntimeProof not-ready-refresh-error error=$error');
+    } finally {
+      _notReadyRefreshInFlight = false;
+    }
+  }
+
+  Future<void> setCaptureMode(MetaGlassesCaptureMode mode) async {
+    if (captureMode == mode) return;
+    captureMode = mode;
+    await SharedPreferencesUtil().saveString(_captureModePrefKey, mode.name);
+    // Apply live when a capture session is running.
+    if (isCapturing) {
+      if (_cameraStreamNeeded) {
+        await _startPhotoLoop();
+      } else {
+        _thermalPaused = false;
+        _thermalRetryTimer?.cancel();
+        _thermalRetryTimer = null;
+        await _stopPhotoLoop();
+      }
+    }
+    notifyListeners();
+  }
+
+  /// How often Camera+Mic mode forwards a frame from the continuous stream to
+  /// the conversation. Applies live: the frame throttle reads [captureInterval]
+  /// directly, so the next forwarded frame uses the new cadence.
+  Future<void> setCaptureInterval(MetaGlassesCaptureInterval interval) async {
+    if (captureInterval == interval) return;
+    captureInterval = interval;
+    await SharedPreferencesUtil().saveString(_captureIntervalPrefKey, interval.name);
+    _cancelCaptureWatchdogTimer();
+    _evaluateCaptureWatchdog();
+    notifyListeners();
+  }
+
+  void setLivePreviewVisible(bool visible) {
+    if (_livePreviewVisible == visible) return;
+    _livePreviewVisible = visible;
+    notifyListeners();
+  }
+
+  /// Starts glasses capture: DAT camera frames are cached directly to the
+  /// backend. Phone microphone/listen socket audio is not started.
+  ///
+  /// [displayStatusText] is rendered on Ray-Ban Display glasses while
+  /// capturing; pass a localized string from the UI.
+  Future<bool> startCapture(CaptureController captureController, {String? displayStatusText}) async {
+    if (isCapturing || _captureTransitionInFlight) return isCapturing;
+    if (!isRegistered) return false;
+    _captureTransitionInFlight = true;
+    _manualStopRequested = false;
+    _captureController = captureController;
+    if (displayStatusText != null && displayStatusText.isNotEmpty) _displayStatusText = displayStatusText;
+    lastError = null;
+    // Fresh capture intent — reset the stream-error recovery budget and the
+    // watchdog restart backoff (a previous session's failures must not
+    // penalize this one with a 32s first-restart delay).
+    streamFailureCount = 0;
+    micOnlyFallback = false;
+    _captureWatchdog.reset();
+
+    try {
+      try {
+        await MetaWearablesDat.enableBackgroundStreaming();
+      } catch (e) {
+        Logger.debug('MetaGlassStreamDiag: enableBackgroundStreaming failed: $e');
+      }
+
+      _appendRuntimeProof(
+          'MetaGlassRuntimeProof start-capture captureMode=${captureMode.name} cameraNeeded=$_cameraStreamNeeded cameraPermission=$cameraPermissionState gestures=media-remote');
+
+      if (_cameraStreamNeeded) {
+        await _startPhotoLoop();
+        final firstFrameQueued = await _waitForFirstQueuedFrame();
+        if (!_cameraCaptureStreamReady || !firstFrameQueued) {
+          _appendRuntimeProof('MetaGlassRuntimeProof start-capture-failed reason=camera-stream-not-ready');
+          await _stopPhotoLoop();
+          try {
+            await MetaWearablesDat.disableBackgroundStreaming();
+          } catch (e) {
+            Logger.debug('MetaWearablesProvider: disableBackgroundStreaming failed after start failure: $e');
+          }
+          notifyListeners();
+          return false;
+        }
+      } else {
+        _appendRuntimeProof('MetaGlassStreamDiag start-photo-loop skipped captureMode=${captureMode.name}');
+      }
+
+      // Glasses-to-backend audio: route the shared audio session to the
+      // glasses' Bluetooth (HFP) microphone, then open the transcription
+      // socket. The socket carries both the STT audio and the image_chunk
+      // photo uploads — it is the only ingestion path deployed on prod.
+      try {
+        await _audioSessionChannel.invokeMethod('configureForBluetooth');
+      } catch (e) {
+        Logger.debug('MetaGlassStreamDiag: configureForBluetooth failed: $e');
+      }
+      await captureController.streamRecording();
+      _appendRuntimeProof('MetaGlassRuntimeProof audio-stream-started route=bluetooth');
+
+      await _startGestureListening();
+
+      await _startDisplayStatus();
+
+      _cancelAutoStartRetry();
+      isCapturing = true;
+      _evaluateCaptureWatchdog();
+      notifyListeners();
+      // Push any photos buffered while offline into the fresh session.
+      unawaited(flushPhotoQueue());
+      return true;
+    } finally {
+      _captureTransitionInFlight = false;
+    }
+  }
+
+  /// [manual] marks a user-initiated stop (button), which
+  /// suppresses auto-capture from immediately restarting the session.
+  /// Internal teardown (glasses disappearing) passes false so capture
+  /// resumes when they come back.
+  Future<void> stopCapture({bool manual = true}) async {
+    if (!isCapturing || _captureTransitionInFlight) return;
+    _captureTransitionInFlight = true;
+    if (manual) _manualStopRequested = true;
+    try {
+      _cancelAutoStartRetry();
+      _thermalPaused = false;
+      _thermalRetryTimer?.cancel();
+      _thermalRetryTimer = null;
+      health = MetaGlassesHealth.ok;
+      await _stopGestureListening();
+      await _stopPhotoLoop();
+      try {
+        await _captureController?.stopStreamRecording();
+      } catch (e) {
+        Logger.debug('MetaGlassStreamDiag: stopStreamRecording failed: $e');
+      }
+      await _stopDisplayStatus();
+      try {
+        await MetaWearablesDat.disableBackgroundStreaming();
+      } catch (e) {
+        Logger.debug('MetaWearablesProvider: disableBackgroundStreaming failed: $e');
+      }
+      isCapturing = false;
+      notifyListeners();
+    } finally {
+      _captureTransitionInFlight = false;
+    }
+  }
+
+  /// Installs the Dart side of the media-remote gesture bridge and tells the
+  /// native side to claim Now Playing + remote commands. Only meaningful
+  /// while capture holds the audio session.
+  Future<void> _startGestureListening() async {
+    if (!Platform.isIOS) return;
+    if (!_gestureHandlerInstalled) {
+      _gesturesChannel.setMethodCallHandler((call) async {
+        if (call.method == 'onGesture') {
+          final args = (call.arguments as Map?)?.cast<String, dynamic>() ?? const {};
+          _handleGesture(args['type'] as String? ?? 'tap', args['command'] as String? ?? '');
+        }
+        return null;
+      });
+      _gestureHandlerInstalled = true;
+    }
+    try {
+      await _gesturesChannel.invokeMethod('startListening');
+      _gestureListeningStartedAt = DateTime.now();
+      _appendRuntimeProof('MetaGlassGestureDiag listening-started');
+    } catch (e) {
+      Logger.debug('MetaGlassGestureDiag: startListening failed: $e');
+    }
+  }
+
+  Future<void> _stopGestureListening() async {
+    if (!Platform.isIOS) return;
+    try {
+      await _gesturesChannel.invokeMethod('stopListening');
+      _appendRuntimeProof('MetaGlassGestureDiag listening-stopped');
+    } catch (e) {
+      Logger.debug('MetaGlassGestureDiag: stopListening failed: $e');
+    }
+  }
+
+  /// Tap = toggle capture. Media-remote events often double-fire (play +
+  /// togglePlayPause for one physical tap), so collapse anything inside the
+  /// debounce window into one action.
+  void _handleGesture(String type, String command) {
+    final now = DateTime.now();
+    final last = _lastGestureAt;
+    _appendRuntimeProof('MetaGlassGestureDiag received type=$type command=$command');
+    final listeningSince = _gestureListeningStartedAt;
+    if (listeningSince != null && now.difference(listeningSince) < _gestureActivationGrace) {
+      _appendRuntimeProof('MetaGlassGestureDiag discarded-phantom command=$command '
+          'ageMs=${now.difference(listeningSince).inMilliseconds}');
+      return;
+    }
+    if (last != null && now.difference(last) < _gestureDebounce) {
+      Logger.debug('MetaGlassGestureDiag: debounced $command');
+      return;
+    }
+    _lastGestureAt = now;
+    lastGesture = command.isEmpty ? type : command;
+    notifyListeners();
+    final controller = _captureController;
+    if (isCapturing) {
+      unawaited(stopCapture());
+    } else if (controller != null) {
+      unawaited(startCapture(controller));
+    }
+  }
+
+  /// Renders a small status view on Ray-Ban Display glasses while capturing.
+  Future<void> _startDisplayStatus() async {
+    if (!canShowDisplayStatus) return;
+    try {
+      _displayStateSub ??= MetaWearablesDat.displayStateStream().listen(
+        _handleDisplayState,
+        onError: (Object e) => Logger.debug('MetaWearablesProvider display state sub failed: $e'),
+      );
+      _attachDisplayCaptureListener();
+      await MetaWearablesDat.startDisplaySession(deviceUUID: selectedDevice?.uuid);
+    } catch (e) {
+      Logger.debug('MetaWearablesProvider: display session unavailable: $e');
+    }
+  }
+
+  Future<void> _stopDisplayStatus() async {
+    final hadDisplaySession = _displaySessionActive ||
+        _displayStateSub != null ||
+        _displayCaptureController != null ||
+        _displayUpdateTimer != null;
+    if (!hadDisplaySession) return;
+    _displaySessionActive = false;
+    _displayUpdateTimer?.cancel();
+    _displayUpdateTimer = null;
+    _lastDisplayUpdateAt = null;
+    _detachDisplayCaptureListener();
+    await _displayStateSub?.cancel();
+    _displayStateSub = null;
+    try {
+      await MetaWearablesDat.stopDisplaySession();
+    } catch (e) {
+      Logger.debug('MetaWearablesProvider: stopDisplaySession failed: $e');
+    }
+  }
+
+  void _handleDisplayState(DisplayState state) {
+    switch (state) {
+      case DisplayState.started:
+        _displaySessionActive = true;
+        updateDisplayFromCapture();
+        break;
+      case DisplayState.stopped:
+        _displaySessionActive = false;
+        _displayUpdateTimer?.cancel();
+        _displayUpdateTimer = null;
+        break;
+      case DisplayState.starting:
+      case DisplayState.stopping:
+        break;
+    }
+  }
+
+  void _attachDisplayCaptureListener() {
+    final controller = _captureController;
+    if (_displayCaptureController == controller) return;
+    _detachDisplayCaptureListener();
+    _displayCaptureController = controller;
+    _captureController?.addListener(_handleCaptureDisplayChanged);
+  }
+
+  void _detachDisplayCaptureListener() {
+    _displayCaptureController?.removeListener(_handleCaptureDisplayChanged);
+    _displayCaptureController = null;
+  }
+
+  void _handleCaptureDisplayChanged() {
+    if (!_displaySessionActive) return;
+    final now = DateTime.now();
+    final last = _lastDisplayUpdateAt;
+    if (last == null || now.difference(last) >= _displayUpdateThrottle) {
+      _displayUpdateTimer?.cancel();
+      _displayUpdateTimer = null;
+      updateDisplayFromCapture();
+      return;
+    }
+    _displayUpdateTimer ??= Timer(_displayUpdateThrottle - now.difference(last), () {
+      _displayUpdateTimer = null;
+      if (_displaySessionActive) updateDisplayFromCapture();
+    });
+  }
+
+  void updateDisplayFromCapture() {
+    if (!_displaySessionActive) return;
+    _lastDisplayUpdateAt = DateTime.now();
+    unawaited(_sendDisplayCaptureView());
+  }
+
+  Future<void> _sendDisplayCaptureView() async {
+    try {
+      await MetaWearablesDat.sendDisplayView(
+        buildDisplayCaptureView(
+          captureStateLine: _displayStatusText,
+          segments: _captureController?.segments ?? const <TranscriptSegment>[],
+        ),
+      );
+    } catch (e) {
+      Logger.debug('MetaWearablesProvider: send display view failed: $e');
+    }
+  }
+
+  Future<bool> _waitForFirstQueuedFrame() async {
+    final completer = _firstQueuedFrameCompleter;
+    if (completer == null) return _lastQueuedPhotoAt != null;
+    try {
+      return await completer.future.timeout(_firstQueuedFrameStartTimeout, onTimeout: () => false);
+    } catch (_) {
+      return false;
+    }
+  }
+
+  /// Starts (once) a continuous, never-paused camera stream and subscribes to
+  /// the DAT videoFramesStream as a background-capable capture trigger.
+  ///
+  /// No shutter/snapshot cadence: the stream runs continuously and frame events
+  /// are native-pushed (they keep firing while backgrounded via
+  /// enableBackgroundStreaming, unlike a Dart timer which suspends). Each event
+  /// keeps the SDK's latestPixelBuffer fresh; at most once per [captureInterval]
+  /// we encode one viewable JPEG from that buffer natively (on the CPU) via
+  /// [MetaWearablesDat.captureLatestFrame]. The native CPU encode works
+  /// backgrounded, unlike the Flutter-texture rasterizer.
+  Future<void> _startPhotoLoop() async {
+    _appendRuntimeProof(
+        'MetaGlassStreamDiag start-photo-loop cameraPermission=$cameraPermissionState granted=$cameraPermissionGranted texture=$previewTextureId frameSub=${_frameSub != null}');
+    if (_photoLoopStarting) {
+      _appendRuntimeProof('MetaGlassStreamDiag start-photo-loop skipped already-starting');
+      return;
+    }
+    if (_frameSub != null && previewTextureId != null) {
+      _appendRuntimeProof('MetaGlassStreamDiag start-photo-loop skipped already-streaming');
+      return;
+    }
+    if (!cameraPermissionGranted) {
+      if (cameraPermissionState == MetaGlassesCameraPermissionState.needsRequest) {
+        _appendRuntimeProof('MetaGlassStreamDiag start-photo-loop requesting-camera-permission');
+        await requestCameraPermission();
+      } else if (cameraPermissionState == MetaGlassesCameraPermissionState.unavailable && _hasSessionCandidateDevice) {
+        _appendRuntimeProof(
+            'MetaGlassStreamDiag start-photo-loop permission-unavailable-continuing devices=${devices.length} active=${_sdkActiveDevice?.uuid ?? 'none'}');
+      }
+      if (!cameraPermissionGranted &&
+          !(cameraPermissionState == MetaGlassesCameraPermissionState.unavailable && _hasSessionCandidateDevice)) {
+        Logger.debug('MetaWearablesProvider: camera permission missing, glasses camera capture unavailable');
+        _appendRuntimeProof(
+            'MetaGlassStreamDiag start-photo-loop camera-unavailable cameraPermission=$cameraPermissionState');
+        micOnlyFallback = true;
+        notifyListeners();
+        return;
+      }
+    }
+    _photoLoopStarting = true;
+    try {
+      final textureId = await _service.startPreviewStream(
+        deviceUUID: _sessionTargetUuid,
+        fps: _photoSessionFps,
+        quality: _photoSessionQuality,
+      );
+      previewTextureId = textureId;
+      micOnlyFallback = false;
+      _lastFrameForwardedAt = null;
+      _lastPhotoLoopStartedAt = DateTime.now();
+      _lastQueuedPhotoAt = null;
+      _firstQueuedFrameCompleter = Completer<bool>();
+      Logger.debug('MetaGlassStreamDiag: stream session started (interval=${_photoInterval.inSeconds}s)');
+      _appendRuntimeProof(
+          'MetaGlassStreamDiag stream-started interval=${_photoInterval.inSeconds}s texture=$textureId');
+      await _frameSub?.cancel();
+      // videoFramesStream = native-pushed trigger (works backgrounded). We don't
+      // encode the raw frame here; we use the event to pull an SDK-encoded frame.
+      final listenerGeneration = _streamGeneration;
+      _frameSub = _service.videoFrames().listen(
+        (frame) => _onVideoFrame(frame, listenerGeneration),
+        onError: (Object e) {
+          if (listenerGeneration != _streamGeneration) {
+            _appendRuntimeProof('MetaGlassStreamDiag frame-error-stale $e');
+            return;
+          }
+          Logger.debug('MetaGlassStreamDiag: frame stream error $e');
+          _appendRuntimeProof('MetaGlassStreamDiag frame-error $e');
+          unawaited(recoverFromVideoStreamingError(e));
+        },
+      );
+      notifyListeners();
+    } catch (e) {
+      Logger.debug('MetaGlassStreamDiag: stream session start failed $e');
+      _appendRuntimeProof('MetaGlassStreamDiag stream-start-failed $e');
+      if (_firstQueuedFrameCompleter?.isCompleted == false) _firstQueuedFrameCompleter?.complete(false);
+      await recoverFromVideoStreamingError(e);
+    } finally {
+      _photoLoopStarting = false;
+    }
+  }
+
+  void _onVideoFrame(VideoFrame frame, int listenerGeneration) {
+    if (listenerGeneration != _streamGeneration) {
+      _appendRuntimeProof('MetaGlassStreamDiag frame-event-stale $frame');
+      return;
+    }
+    final now = DateTime.now();
+    _lastStreamFrameEventAt = now;
+    _evaluateCaptureWatchdog(now: now);
+    _appendRuntimeProof('MetaGlassStreamDiag frame-event $frame');
+    final last = _lastFrameForwardedAt;
+    if (last != null && now.difference(last) < _photoInterval) return;
+    if (_frameForwardInFlight) return;
+    _lastFrameForwardedAt = now;
+    unawaited(_captureFrame());
+  }
+
+  /// Encodes one viewable JPEG from the SDK's latest decoded pixel buffer
+  /// (natively, on the CPU) and queues it.
+  ///
+  /// Uses [MetaWearablesDat.captureLatestFrame], NOT the Flutter-texture
+  /// rasterizer (`captureStreamFrame` → `ui.Scene.toImage`). The texture path
+  /// depends on the GPU raster pipeline, which iOS suspends when the app is
+  /// backgrounded — that produced blank/garbled captures and "nothing captured"
+  /// while locked. The native encode reads the SDK's cached frame and runs on
+  /// the CPU, so it keeps working backgrounded.
+  Future<void> _captureFrame() async {
+    if (previewTextureId == null || _frameForwardInFlight) return;
+    final generation = _streamGeneration;
+    _frameForwardInFlight = true;
+    _frameForwardInFlightGeneration = generation;
+    try {
+      final frame = await MetaWearablesDat.captureLatestFrame(quality: 0.8);
+      if (generation != _streamGeneration) {
+        _appendRuntimeProof('MetaGlassStreamDiag frame-drop-generation');
+        return;
+      }
+      if (frame == null || frame.bytes.isEmpty) {
+        Logger.debug('MetaGlassStreamDiag: captureLatestFrame returned no frame');
+        _appendRuntimeProof('MetaGlassStreamDiag frame-empty');
+        if (_firstQueuedFrameCompleter?.isCompleted == false) _firstQueuedFrameCompleter?.complete(false);
+        await recoverFromVideoStreamingError('captureLatestFrameEmpty');
+        return;
+      }
+      Logger.debug('MetaGlassStreamDiag: captured frame ${frame.bytes.length}B');
+      _appendRuntimeProof('MetaGlassStreamDiag frame-captured bytes=${frame.bytes.length}');
+      if (generation != _streamGeneration || previewTextureId == null || _frameSub == null) {
+        _appendRuntimeProof('MetaGlassStreamDiag frame-drop-stopped');
+        if (_firstQueuedFrameCompleter?.isCompleted == false) _firstQueuedFrameCompleter?.complete(false);
+        return;
+      }
+      final queued = await _enqueuePhoto(frame.bytes);
+      if (!queued) {
+        _updateCaptureDiagnostics(
+          lastUploadAt: DateTime.now(),
+          lastUploadStatus: 'enqueue_failed',
+          failedUploadCount: diagnostics.failedUploadCount + 1,
+        );
+        if (_firstQueuedFrameCompleter?.isCompleted == false) _firstQueuedFrameCompleter?.complete(false);
+        await recoverFromVideoStreamingError('photoEnqueueFailed');
+        return;
+      }
+      _lastQueuedPhotoAt = DateTime.now();
+      if (_firstQueuedFrameCompleter?.isCompleted == false) _firstQueuedFrameCompleter?.complete(true);
+      _updateCaptureDiagnostics(
+        lastFrameAt: _lastQueuedPhotoAt,
+        lastUploadStatus: 'frame_enqueued',
+        pendingQueueCount: pendingPhotoCount,
+      );
+      if (!isCapturing ||
+          !_cameraStreamNeeded ||
+          _captureWatchdogPaused ||
+          micOnlyFallback ||
+          previewTextureId == null) {
+        return;
+      }
+      _cancelCaptureWatchdogTimer();
+      _markHealthRecovered();
+      _captureWatchdog.recordHealthyFrame();
+      streamFailureCount = 0;
+      unawaited(flushPhotoQueue());
+    } catch (e) {
+      Logger.debug('MetaGlassStreamDiag: captureLatestFrame failed $e');
+      _appendRuntimeProof('MetaGlassStreamDiag frame-capture-failed $e');
+      if (_firstQueuedFrameCompleter?.isCompleted == false) _firstQueuedFrameCompleter?.complete(false);
+      await recoverFromVideoStreamingError(e);
+    } finally {
+      if (_frameForwardInFlightGeneration == generation) {
+        _frameForwardInFlight = false;
+        _frameForwardInFlightGeneration = null;
+      }
+    }
+  }
+
+  Future<void> _stopPhotoLoop() async {
+    _livePreviewVisible = false;
+    _cancelCaptureWatchdogTimer();
+    await _frameSub?.cancel();
+    _frameSub = null;
+    _streamRetryTimer?.cancel();
+    _streamRetryTimer = null;
+    _releaseStreamResources();
+    notifyListeners();
+    await stopPreview();
+  }
+
+  void _handleStreamSessionState(StreamSessionState state) {
+    streamSessionState = state;
+    _updateCaptureDiagnostics(streamState: state.name);
+    switch (state) {
+      case StreamSessionState.paused:
+      case StreamSessionState.stopped:
+        break;
+      case StreamSessionState.waitingForDevice:
+      case StreamSessionState.starting:
+      case StreamSessionState.streaming:
+      case StreamSessionState.stopping:
+        break;
+    }
+    _evaluateCaptureWatchdog();
+    notifyListeners();
+  }
+
+  void _handleDeviceSessionState(DeviceSessionState state) {
+    deviceSessionState = state;
+    _updateCaptureDiagnostics(sessionState: state.name);
+    switch (state) {
+      case DeviceSessionState.paused:
+      case DeviceSessionState.stopping:
+        break;
+      case DeviceSessionState.stopped:
+        _releaseStreamResources();
+        break;
+      case DeviceSessionState.idle:
+      case DeviceSessionState.starting:
+      case DeviceSessionState.started:
+        final restartStream = _thermalPaused && isCapturing && _cameraStreamNeeded;
+        _markHealthRecovered();
+        if (restartStream) unawaited(_startPhotoLoop());
+        break;
+    }
+    _evaluateCaptureWatchdog();
+    notifyListeners();
+  }
+
+  bool get _captureWatchdogPaused => isStreamPaused || isDeviceSessionPaused || _thermalPaused;
+
+  MetaCaptureHealth _deriveCaptureHealth({DateTime? now}) {
+    final checkedAt = now ?? DateTime.now();
+    if (_captureWatchdogPaused) return MetaCaptureHealth.paused;
+    if (!isCapturing || !_cameraStreamNeeded) return MetaCaptureHealth.streaming;
+    if (previewTextureId == null || _frameSub == null) return MetaCaptureHealth.stopped;
+    if (streamSessionState == StreamSessionState.stopped || deviceSessionState == DeviceSessionState.stopped) {
+      return MetaCaptureHealth.stopped;
+    }
+
+    final lastStreamFrameEventAt = _lastStreamFrameEventAt;
+    if (lastStreamFrameEventAt != null &&
+        checkedAt.difference(lastStreamFrameEventAt) >= _watchdogStreamFrameStaleThreshold) {
+      return MetaCaptureHealth.stale;
+    }
+
+    final startedAt = _lastPhotoLoopStartedAt;
+    if (lastStreamFrameEventAt == null &&
+        startedAt != null &&
+        checkedAt.difference(startedAt) >= _watchdogStreamFrameStaleThreshold) {
+      return MetaCaptureHealth.stale;
+    }
+
+    final lastQueuedAt = _lastQueuedPhotoAt;
+    if (lastQueuedAt != null) {
+      return checkedAt.difference(lastQueuedAt) >= _watchdogStaleFrameThreshold
+          ? MetaCaptureHealth.stale
+          : MetaCaptureHealth.streaming;
+    }
+
+    if (startedAt != null && checkedAt.difference(startedAt) >= _watchdogStaleFrameThreshold) {
+      return MetaCaptureHealth.stale;
+    }
+    return MetaCaptureHealth.streaming;
+  }
+
+  Duration _timeUntilStale(DateTime? since, Duration threshold, DateTime now) {
+    if (since == null) return threshold;
+    final remaining = threshold - now.difference(since);
+    return remaining <= Duration.zero ? const Duration(milliseconds: 1) : remaining;
+  }
+
+  Duration _nextCaptureWatchdogCheckDelay(DateTime now) {
+    final streamSince = _lastStreamFrameEventAt ?? _lastPhotoLoopStartedAt;
+    final captureSince = _lastQueuedPhotoAt ?? _lastPhotoLoopStartedAt;
+    final streamDelay = _timeUntilStale(streamSince, _watchdogStreamFrameStaleThreshold, now);
+    final captureDelay = _timeUntilStale(captureSince, _watchdogStaleFrameThreshold, now);
+    return streamDelay < captureDelay ? streamDelay : captureDelay;
+  }
+
+  /// Re-arms the watchdog while it cannot act (retry pending, paused,
+  /// mic-only). Suspended timers fire on foreground resume, so a session that
+  /// died while the app was backgrounded recovers on the next foreground
+  /// instead of staying dead until relaunch.
+  void _scheduleWatchdogRecheck({required String reason}) {
+    _cancelCaptureWatchdogTimer();
+    _appendRuntimeProof('MetaGlassWatchdog wait reason=$reason recheck=10s');
+    _captureWatchdogTimerIsRestart = false;
+    _captureWatchdogTimer = Timer(const Duration(seconds: 10), () {
+      _captureWatchdogTimer = null;
+      _evaluateCaptureWatchdog();
+    });
+  }
+
+  void _evaluateCaptureWatchdog({DateTime? now}) {
+    if (!isCapturing || !_cameraStreamNeeded || !_hasSessionCandidateDevice) {
+      _cancelCaptureWatchdogTimer();
+      return;
+    }
+    if (micOnlyFallback || _streamRetryTimer?.isActive == true) {
+      // Never go dormant: a suspension mid-retry froze the retry timer while
+      // the watchdog had cancelled itself, leaving capture dead until app
+      // relaunch (observed on-device 2026-07-05). Re-check instead.
+      _scheduleWatchdogRecheck(reason: micOnlyFallback ? 'micOnlyFallback' : 'streamRetry');
+      return;
+    }
+
+    final checkedAt = now ?? DateTime.now();
+    final health = _deriveCaptureHealth(now: checkedAt);
+    if (health == MetaCaptureHealth.paused) {
+      _scheduleWatchdogRecheck(reason: 'paused');
+      return;
+    }
+
+    if (_captureWatchdog.nextAction(health) == MetaCaptureWatchdogAction.restart) {
+      if (_captureWatchdogRestartInFlight ||
+          (_captureWatchdogTimer?.isActive == true && _captureWatchdogTimerIsRestart)) {
+        return;
+      }
+      _cancelCaptureWatchdogTimer();
+      final delay = _captureWatchdog.nextDelay(health);
+      _captureWatchdogTimerIsRestart = true;
+      _appendRuntimeProof('MetaGlassWatchdog schedule-restart health=${health.name} delay=${delay.inSeconds}s');
+      debugOnCaptureWatchdogRestartScheduled?.call(health, delay);
+      _captureWatchdogTimer = Timer(delay, () {
+        _captureWatchdogTimer = null;
+        _captureWatchdogTimerIsRestart = false;
+        unawaited(_restartDatCameraSession(health));
+      });
+      return;
+    }
+
+    if (_captureWatchdogTimer?.isActive == true && !_captureWatchdogTimerIsRestart) return;
+    _cancelCaptureWatchdogTimer();
+    _captureWatchdogTimerIsRestart = false;
+    _captureWatchdogTimer = Timer(_nextCaptureWatchdogCheckDelay(checkedAt), () {
+      _captureWatchdogTimer = null;
+      _evaluateCaptureWatchdog();
+    });
+  }
+
+  @visibleForTesting
+  void debugSetCaptureWatchdogStateForTest({
+    required bool isCapturing,
+    required StreamSessionState streamSessionState,
+    required DeviceSessionState deviceSessionState,
+    required bool hasPreviewTexture,
+    required bool hasFrameSubscription,
+    MetaGlassesCaptureMode captureMode = MetaGlassesCaptureMode.cameraAndMic,
+    MetaGlassesCaptureInterval captureInterval = MetaGlassesCaptureInterval.s30,
+    DateTime? lastPhotoLoopStartedAt,
+    DateTime? lastQueuedPhotoAt,
+    DateTime? lastStreamFrameEventAt,
+    bool hasSessionCandidateDevice = true,
+    bool thermalPaused = false,
+    bool micOnlyFallback = false,
+    bool streamRetryScheduled = false,
+  }) {
+    _cancelCaptureWatchdogTimer();
+    _streamRetryTimer?.cancel();
+    _streamRetryTimer = null;
+    this.isCapturing = isCapturing;
+    this.captureMode = captureMode;
+    this.captureInterval = captureInterval;
+    this.streamSessionState = streamSessionState;
+    this.deviceSessionState = deviceSessionState;
+    _thermalPaused = thermalPaused;
+    this.micOnlyFallback = micOnlyFallback;
+    if (streamRetryScheduled) {
+      _streamRetryTimer = Timer(const Duration(minutes: 1), () {});
+    }
+    previewTextureId = hasPreviewTexture ? 1 : null;
+    _lastPhotoLoopStartedAt = lastPhotoLoopStartedAt;
+    _lastQueuedPhotoAt = lastQueuedPhotoAt;
+    _lastStreamFrameEventAt = lastStreamFrameEventAt;
+    devices = hasSessionCandidateDevice
+        ? const [
+            DeviceInfo(
+              uuid: 'watchdog-test-device',
+              name: 'Watchdog Test Device',
+              kind: DeviceKind.rayBanMeta,
+              linkState: DeviceLinkState.connected,
+            ),
+          ]
+        : const [];
+    unawaited(_frameSub?.cancel());
+    _frameSub = hasFrameSubscription ? const Stream<VideoFrame>.empty().listen((_) {}) : null;
+  }
+
+  @visibleForTesting
+  void debugEvaluateCaptureWatchdogForTest({
+    DateTime? now,
+    void Function(MetaCaptureHealth health, Duration delay)? onRestartScheduled,
+  }) {
+    debugOnCaptureWatchdogRestartScheduled = onRestartScheduled;
+    _evaluateCaptureWatchdog(now: now);
+  }
+
+  @visibleForTesting
+  void debugHandleStreamSessionStateForTest(StreamSessionState state) {
+    _handleStreamSessionState(state);
+  }
+
+  @visibleForTesting
+  bool get debugHasCaptureWatchdogTimerForTest => _captureWatchdogTimer?.isActive == true;
+
+  Future<void> _restartDatCameraSession(MetaCaptureHealth health) async {
+    if (_captureWatchdogRestartInFlight || !isCapturing || !_cameraStreamNeeded || _captureWatchdogPaused) return;
+    _captureWatchdogRestartInFlight = true;
+    _captureWatchdog.recordRestartAttempt();
+    _appendRuntimeProof('MetaGlassWatchdog restart health=${health.name}');
+    _updateCaptureDiagnostics(lastUploadStatus: 'watchdog_restart_${health.name}');
+    try {
+      _releaseStreamResources();
+      await stopPreview();
+      if (!isCapturing || !_cameraStreamNeeded || _captureWatchdogPaused || micOnlyFallback) return;
+      await _startPhotoLoop();
+    } finally {
+      _captureWatchdogRestartInFlight = false;
+      _evaluateCaptureWatchdog();
+    }
+  }
+
+  void _cancelCaptureWatchdogTimer() {
+    _captureWatchdogTimer?.cancel();
+    _captureWatchdogTimer = null;
+    _captureWatchdogTimerIsRestart = false;
+  }
+
+  void _updateCaptureDiagnostics({
+    DateTime? lastFrameAt,
+    DateTime? lastUploadAt,
+    String? lastUploadStatus,
+    String? streamState,
+    String? sessionState,
+    int? pendingQueueCount,
+    int? uploadedCount,
+    int? failedUploadCount,
+  }) {
+    diagnostics = diagnostics.copyWith(
+      lastFrameAt: lastFrameAt,
+      lastUploadAt: lastUploadAt,
+      lastUploadStatus: lastUploadStatus,
+      streamState: streamState,
+      sessionState: sessionState,
+      pendingQueueCount: pendingQueueCount,
+      uploadedCount: uploadedCount,
+      failedUploadCount: failedUploadCount,
+    );
+    final now = DateTime.now();
+    final lastLogAt = _lastDiagnosticsLogAt;
+    if (lastLogAt != null && now.difference(lastLogAt) < const Duration(seconds: 5)) return;
+    _lastDiagnosticsLogAt = now;
+    Logger.debug('Meta capture diagnostics: ${diagnostics.toJson()}');
+  }
+
+  Future<void> _handleSessionError(Object error) async {
+    Logger.debug('MetaGlassStreamDiag: session error $error');
+    final nextHealth = MetaGlassesHealth.fromSessionError(error);
+    if (nextHealth == null) {
+      // Generic/transient stream error (incl. videoStreamingError). Recover the
+      // camera stream without a raw user-facing error.
+      await recoverFromVideoStreamingError(error);
+      return;
+    }
+
+    lastError = error.toString();
+    health = nextHealth;
+    if (nextHealth == MetaGlassesHealth.overheating) {
+      _thermalPaused = true;
+      _releaseStreamResources();
+      _scheduleThermalRetry();
+    } else {
+      _releaseStreamResources();
+    }
+    notifyListeners();
+  }
+
+  /// Bounded recovery for `SessionError(videoStreamingError)` and other
+  /// transient stream failures. Tears down the camera stream, retries once, then
+  /// stops this glasses-only capture and schedules auto-start recovery.
+  Future<void> recoverFromVideoStreamingError(Object error) async {
+    final isStreamError =
+        error is SessionError ? error.isVideoStreamingError : error.toString().contains('videoStreamingError');
+    streamFailureCount++;
+    Logger.debug('MetaGlassStreamDiag: recoverFromVideoStreamingError count=$streamFailureCount stream=$isStreamError');
+    _appendRuntimeProof('MetaGlassStreamDiag recover count=$streamFailureCount stream=$isStreamError error=$error');
+
+    // Tear down the camera stream. This glasses-only path does not use phone mic.
+    _releaseStreamResources();
+    await stopPreview();
+    _appendRuntimeProof('MetaGlassStreamDiag stop-before-retry');
+
+    final captureActiveOrStarting = isCapturing || _captureTransitionInFlight;
+    if (!captureActiveOrStarting || !_cameraStreamNeeded || _thermalPaused) {
+      notifyListeners();
+      return;
+    }
+
+    if (streamFailureCount <= 1) {
+      // One bounded retry after a short wait.
+      _streamRetryTimer?.cancel();
+      _streamRetryTimer = Timer(const Duration(seconds: 8), () {
+        if ((isCapturing || _captureTransitionInFlight) &&
+            _cameraStreamNeeded &&
+            !_captureWatchdogPaused &&
+            !micOnlyFallback &&
+            !_thermalPaused &&
+            previewTextureId == null) {
+          unawaited(_startPhotoLoop());
+        }
+      });
+    } else {
+      // Retry exhausted. There is no phone-mic fallback in this glasses-only path.
+      micOnlyFallback = true;
+      isCapturing = false;
+      try {
+        await MetaWearablesDat.disableBackgroundStreaming();
+      } catch (e) {
+        Logger.debug('MetaWearablesProvider: disableBackgroundStreaming failed after retry exhaustion: $e');
+      }
+      _scheduleNotReadyRefresh();
+      _appendRuntimeProof('MetaGlassStreamDiag recover-exhausted-autostart-retry');
+      _scheduleAutoStartRetry();
+      Logger.debug('MetaGlassStreamDiag cameraUnavailable: camera stream unavailable, stopping glasses capture');
+      _appendRuntimeProof('MetaGlassStreamDiag camera-unavailable count=$streamFailureCount');
+    }
+    notifyListeners();
+  }
+
+  void _appendRuntimeProof(String message) {
+    final file = _runtimeProofLogFile;
+    if (file == null) return;
+    try {
+      final parent = file.parent;
+      if (!parent.existsSync()) parent.createSync(recursive: true);
+      if (file.existsSync() && file.lengthSync() > _runtimeProofLogMaxBytes) {
+        final current = file.readAsStringSync();
+        const keepLength = _runtimeProofLogMaxBytes ~/ 2;
+        final keep = current.length > keepLength ? current.substring(current.length - keepLength) : current;
+        file.writeAsStringSync(keep, mode: FileMode.write);
+      }
+      file.writeAsStringSync('${DateTime.now().toIso8601String()} $message\n', mode: FileMode.append);
+    } catch (e) {
+      Logger.debug('MetaGlassRuntimeProof: write failed $e');
+    }
+  }
+
+  void _scheduleThermalRetry() {
+    if (_thermalRetryTimer != null) return;
+    _thermalRetryTimer = Timer.periodic(const Duration(seconds: 20), (_) {
+      if (!_thermalPaused || !isCapturing || captureMode != MetaGlassesCaptureMode.cameraAndMic) {
+        _thermalRetryTimer?.cancel();
+        _thermalRetryTimer = null;
+        return;
+      }
+      _appendRuntimeProof('MetaGlassWatchdog wait reason=thermalPaused');
+    });
+  }
+
+  void _markHealthRecovered() {
+    if (health == MetaGlassesHealth.ok && !_thermalPaused && _thermalRetryTimer == null) return;
+    health = MetaGlassesHealth.ok;
+    _thermalPaused = false;
+    _thermalRetryTimer?.cancel();
+    _thermalRetryTimer = null;
+  }
+
+  void _releaseStreamResources() {
+    _cancelCaptureWatchdogTimer();
+    _streamGeneration += 1;
+    if (_firstQueuedFrameCompleter?.isCompleted == false) _firstQueuedFrameCompleter?.complete(false);
+    _firstQueuedFrameCompleter = null;
+    unawaited(_frameSub?.cancel());
+    _frameSub = null;
+    previewTextureId = null;
+    _frameForwardInFlight = false;
+    _frameForwardInFlightGeneration = null;
+    _lastStreamFrameEventAt = null;
+    _lastPhotoLoopStartedAt = null;
+    _lastQueuedPhotoAt = null;
+  }
+
+  /// Explicit user photo capture ("take photo" gesture / manual): samples the
+  /// running stream immediately (shutter-free).
+  Future<void> captureGlassesPhotoNow() => _captureFrame();
+
+  List<File> _listQueuedPhotos() {
+    final dir = _photoQueueDir;
+    if (dir == null || !dir.existsSync()) return [];
+    final files = dir
+        .listSync()
+        .whereType<File>()
+        .where((f) => f.path.endsWith('.jpg') || f.path.endsWith('.png'))
+        .toList()
+      ..sort((a, b) => a.path.compareTo(b.path));
+    return files;
+  }
+
+  /// Queue files are named `<captureEpochMs>.<ext>`; recover the capture time
+  /// so late-flushed photos land at the right point in the timeline.
+  @visibleForTesting
+  static DateTime? capturedAtFromQueueFile(String path) {
+    final base = path.split(Platform.pathSeparator).last;
+    final epochMs = int.tryParse(base.replaceFirst(RegExp(r'\.(jpg|png)$'), ''));
+    if (epochMs == null || epochMs <= 0) return null;
+    return DateTime.fromMillisecondsSinceEpoch(epochMs);
+  }
+
+  Future<Directory?> _ensurePhotoQueueDirectory() async {
+    final existing = _photoQueueDir;
+    if (existing != null) {
+      if (!existing.existsSync()) existing.createSync(recursive: true);
+      return existing;
+    }
+
+    try {
+      final docs = await getApplicationDocumentsDirectory();
+      final dir = Directory('${docs.path}/meta_glasses_photo_queue');
+      if (!dir.existsSync()) dir.createSync(recursive: true);
+      _photoQueueDir = dir;
+      return dir;
+    } catch (e) {
+      Logger.debug('MetaWearablesProvider: documents photo queue unavailable: $e');
+    }
+
+    try {
+      final temp = await getTemporaryDirectory();
+      final dir = Directory('${temp.path}/meta_glasses_photo_queue');
+      if (!dir.existsSync()) dir.createSync(recursive: true);
+      _photoQueueDir = dir;
+      return dir;
+    } catch (e) {
+      Logger.debug('MetaWearablesProvider: fallback photo queue unavailable: $e');
+      return null;
+    }
+  }
+
+  Future<MetaCaptureQueue?> _ensureMetaCaptureQueue() async {
+    final existing = _metaCaptureQueue;
+    if (existing != null) return existing;
+
+    final dir = await _ensurePhotoQueueDirectory();
+    if (dir == null) return null;
+
+    final queue = MetaCaptureQueue(rootDirectory: dir);
+    _metaCaptureQueue = queue;
+    return queue;
+  }
+
+  Future<bool> _enqueuePhotoFileFallback(
+    Uint8List bytes, {
+    required DateTime capturedAt,
+    required String deviceUuid,
+    required String? deviceName,
+  }) async {
+    final dir = await _ensurePhotoQueueDirectory();
+    if (dir == null) {
+      Logger.debug('MetaWearablesProvider: dropping frame because no local photo queue is writable');
+      return false;
+    }
+
+    Future<void> writeTo(Directory targetDir) async {
+      if (!targetDir.existsSync()) targetDir.createSync(recursive: true);
+      final frameSha256 = crypto.sha256.convert(bytes).toString();
+      final file = File('${targetDir.path}/${capturedAt.millisecondsSinceEpoch}.png');
+      await file.writeAsBytes(bytes, flush: true);
+      await File('${file.path}.json').writeAsString(
+        jsonEncode({
+          'captured_at': capturedAt.toUtc().toIso8601String(),
+          'device_uuid': deviceUuid,
+          if (deviceName != null) 'device_name': deviceName,
+          'frame_sha256': frameSha256,
+        }),
+        flush: true,
+      );
+    }
+
+    try {
+      await writeTo(dir);
+      return true;
+    } catch (e) {
+      Logger.debug('MetaWearablesProvider: photo fallback enqueue failed: $e');
+    }
+
+    try {
+      final temp = await getTemporaryDirectory();
+      final fallbackDir = Directory('${temp.path}/meta_glasses_photo_queue');
+      await writeTo(fallbackDir);
+      _photoQueueDir = fallbackDir;
+      _metaCaptureQueue = null;
+      return true;
+    } catch (e) {
+      Logger.debug('MetaWearablesProvider: temp photo fallback enqueue failed: $e');
+    }
+    return false;
+  }
+
+  Map<String, String?> _readPhotoFileMetadata(File file) {
+    final metadataFile = File('${file.path}.json');
+    if (!metadataFile.existsSync()) return const {};
+
+    try {
+      final json = jsonDecode(metadataFile.readAsStringSync());
+      if (json is! Map<String, dynamic>) return const {};
+      return {
+        'captured_at': json['captured_at']?.toString(),
+        'device_uuid': json['device_uuid']?.toString(),
+        'device_name': json['device_name']?.toString(),
+        'frame_sha256': json['frame_sha256']?.toString(),
+      };
+    } catch (_) {
+      return const {};
+    }
+  }
+
+  Future<void> _refreshPendingPhotoCount() async {
+    var count = _listQueuedPhotos().length;
+    final queue = _metaCaptureQueue;
+    if (queue != null) {
+      count += (await queue.pending(limit: _maxQueuedPhotos)).length;
+    }
+    pendingPhotoCount = count;
+    _updateCaptureDiagnostics(pendingQueueCount: pendingPhotoCount);
+  }
+
+  Future<bool> _enqueuePhoto(Uint8List bytes) async {
+    final capturedAt = DateTime.now();
+    final device = selectedDevice ?? _sdkActiveDevice;
+    final deviceUuid = device?.uuid ?? _sessionTargetUuid ?? 'unknown';
+    final deviceName = device?.name;
+    final queue = await _ensureMetaCaptureQueue();
+    if (queue == null) {
+      final queued = await _enqueuePhotoFileFallback(
+        bytes,
+        capturedAt: capturedAt,
+        deviceUuid: deviceUuid,
+        deviceName: deviceName,
+      );
+      await _refreshPendingPhotoCount();
+      notifyListeners();
+      return queued;
+    }
+    try {
+      await queue.enqueue(bytes: bytes, capturedAt: capturedAt, deviceUuid: deviceUuid, deviceName: deviceName);
+      await _refreshPendingPhotoCount();
+      notifyListeners();
+      return true;
+    } catch (e) {
+      Logger.debug('MetaWearablesProvider: photo enqueue failed: $e');
+      final queued = await _enqueuePhotoFileFallback(
+        bytes,
+        capturedAt: capturedAt,
+        deviceUuid: deviceUuid,
+        deviceName: deviceName,
+      );
+      await _refreshPendingPhotoCount();
+      notifyListeners();
+      return queued;
+    }
+  }
+
+  Future<bool> _cachePhotoBytes(
+    Uint8List bytes, {
+    required DateTime? capturedAt,
+    bool addToUi = true,
+    String? deviceUuid,
+    String? deviceName,
+    String? frameSha256,
+  }) async {
+    final controller = _captureController;
+    if (controller == null) return false;
+    // Photos go out as image_chunk messages on the transcription socket — the
+    // only ingestion path deployed on api.omi.me. The REST cache endpoint
+    // (v1/meta-wearables/photos/cache) exists only in the local repo backend
+    // and 404s on prod, which stranded frames in the sync queue.
+    return controller.ingestCapturedImage(
+      bytes,
+      addToUi: addToUi,
+      capturedAt: capturedAt,
+    );
+  }
+
+  /// Sends every buffered photo the backend hasn't confirmed yet, oldest
+  /// first. Stops at the first failure — the server/cache path is down, later
+  /// photos won't fare better.
+  Future<void> flushPhotoQueue() async {
+    if (_flushingQueue) return;
+    if (_captureController == null) return;
+    _flushingQueue = true;
+    try {
+      var stoppedOnFailure = false;
+      final queue = _metaCaptureQueue;
+      if (queue != null) {
+        for (final item in await queue.pending(limit: _maxQueuedPhotos)) {
+          Uint8List bytes;
+          try {
+            bytes = await File(item.path).readAsBytes();
+          } catch (_) {
+            continue;
+          }
+          final showInUi = !_photosShownInUi.contains(item.path);
+          final sent = await _cachePhotoBytes(
+            bytes,
+            addToUi: showInUi,
+            capturedAt: item.capturedAt,
+            deviceUuid: item.deviceUuid,
+            deviceName: item.deviceName,
+            frameSha256: item.sha256,
+          );
+          if (showInUi) _photosShownInUi.add(item.path);
+          if (!sent) {
+            stoppedOnFailure = true;
+            _updateCaptureDiagnostics(
+              lastUploadAt: DateTime.now(),
+              lastUploadStatus: 'upload_failed',
+              failedUploadCount: diagnostics.failedUploadCount + 1,
+            );
+            break;
+          }
+          await queue.markUploaded(item.id);
+          _updateCaptureDiagnostics(
+            lastUploadAt: DateTime.now(),
+            lastUploadStatus: 'upload_ok',
+            uploadedCount: diagnostics.uploadedCount + 1,
+          );
+          try {
+            await File(item.path).delete();
+          } catch (_) {}
+          _photosShownInUi.remove(item.path);
+        }
+      }
+
+      if (!stoppedOnFailure) {
+        for (final file in _listQueuedPhotos()) {
+          Uint8List bytes;
+          try {
+            bytes = file.readAsBytesSync();
+          } catch (_) {
+            continue;
+          }
+          final metadata = _readPhotoFileMetadata(file);
+          final metadataCapturedAt = DateTime.tryParse(metadata['captured_at'] ?? '');
+          final showInUi = !_photosShownInUi.contains(file.path);
+          final sent = await _cachePhotoBytes(
+            bytes,
+            addToUi: showInUi,
+            capturedAt: metadataCapturedAt ?? capturedAtFromQueueFile(file.path),
+            deviceUuid: metadata['device_uuid'],
+            deviceName: metadata['device_name'],
+            frameSha256: metadata['frame_sha256'] ?? crypto.sha256.convert(bytes).toString(),
+          );
+          if (showInUi) _photosShownInUi.add(file.path);
+          if (!sent) {
+            _updateCaptureDiagnostics(
+              lastUploadAt: DateTime.now(),
+              lastUploadStatus: 'upload_failed',
+              failedUploadCount: diagnostics.failedUploadCount + 1,
+            );
+            break;
+          }
+          _updateCaptureDiagnostics(
+            lastUploadAt: DateTime.now(),
+            lastUploadStatus: 'upload_ok',
+            uploadedCount: diagnostics.uploadedCount + 1,
+          );
+          try {
+            file.deleteSync();
+          } catch (_) {}
+          try {
+            File('${file.path}.json').deleteSync();
+          } catch (_) {}
+          _photosShownInUi.remove(file.path);
+        }
+      }
+    } finally {
+      await _refreshPendingPhotoCount();
+      _flushingQueue = false;
+      notifyListeners();
+    }
+  }
+
+  @override
+  void dispose() {
+    _cancelCaptureWatchdogTimer();
+    _cancelAutoStartRetry();
+    _frameSub?.cancel();
+    _streamRetryTimer?.cancel();
+    _cancelNotReadyRefresh();
+    _thermalRetryTimer?.cancel();
+    _registrationSub?.cancel();
+    _devicesSub?.cancel();
+    _activeDeviceSub?.cancel();
+    _compatibilitySub?.cancel();
+    _videoSizeSub?.cancel();
+    _streamStateSub?.cancel();
+    _deviceStateSub?.cancel();
+    _streamErrorSub?.cancel();
+    _deviceErrorSub?.cancel();
+    _displayStateSub?.cancel();
+    _displayUpdateTimer?.cancel();
+    _detachDisplayCaptureListener();
+    super.dispose();
+  }
+}

--- a/app/lib/services/capture/capture_controller.dart
+++ b/app/lib/services/capture/capture_controller.dart
@@ -85,7 +85,6 @@ class CaptureController extends ChangeNotifier
   static const Duration _photoUploadAckTimeout = Duration(seconds: 10);
   final Map<String, Completer<void>> _pendingPhotoUploadAcks = {};
   final Map<String, String> _pendingPhotoUploadIdsByPermanent = {};
-  String? _metaWearablesCaptureConversationId;
   int _inProgressConversationRefreshAttempts = 0;
   bool _isRefreshingInProgressConversation = false;
 
@@ -1288,45 +1287,6 @@ class CaptureController extends ChangeNotifier
       _pendingPhotoUploadAcks.remove(tempId);
       _pendingPhotoUploadIdsByPermanent.removeWhere((_, pendingTempId) => pendingTempId == tempId);
     }
-  }
-
-  Future<bool> cacheCapturedImage(
-    Uint8List imageBytes, {
-    bool addToUi = true,
-    DateTime? capturedAt,
-    String? deviceUuid,
-    String? deviceName,
-    String? frameSha256,
-  }) async {
-    final takenAt = capturedAt ?? DateTime.now();
-    final tempId = 'temp_meta_${takenAt.millisecondsSinceEpoch}';
-    final base64Image = base64Encode(imageBytes);
-
-    if (addToUi) {
-      photos.add(ConversationPhoto(id: tempId, base64: base64Image, createdAt: takenAt));
-      photos.sort((a, b) => a.createdAt.compareTo(b.createdAt));
-      photos = List.from(photos);
-      notifyListeners();
-    }
-
-    final cached = await cacheMetaWearablesPhoto(
-      imageBytes,
-      capturedAt: takenAt,
-      conversationId: _metaWearablesCaptureConversationId,
-      deviceUuid: deviceUuid,
-      deviceName: deviceName,
-      frameSha256: frameSha256,
-    );
-    if (cached == null || cached.conversationId.isEmpty || cached.photoId.isEmpty) return false;
-
-    _metaWearablesCaptureConversationId = cached.conversationId;
-    final photoIndex = photos.indexWhere((p) => p.id == tempId);
-    if (photoIndex != -1) {
-      photos[photoIndex].id = cached.photoId;
-      _segmentsPhotosVersion++;
-      notifyListeners();
-    }
-    return true;
   }
 
   Future<bool> _waitForPhotoUploadAck(String tempId, Completer<void> ack) async {

--- a/app/lib/services/capture/capture_controller.dart
+++ b/app/lib/services/capture/capture_controller.dart
@@ -82,6 +82,10 @@ class CaptureController extends ChangeNotifier
   Timer? _keepAliveTimer;
   DateTime? _keepAliveLastExecutedAt;
   Timer? _inProgressConversationRefreshTimer;
+  static const Duration _photoUploadAckTimeout = Duration(seconds: 10);
+  final Map<String, Completer<void>> _pendingPhotoUploadAcks = {};
+  final Map<String, String> _pendingPhotoUploadIdsByPermanent = {};
+  String? _metaWearablesCaptureConversationId;
   int _inProgressConversationRefreshAttempts = 0;
   bool _isRefreshingInProgressConversation = false;
 
@@ -307,6 +311,8 @@ class CaptureController extends ChangeNotifier
         return 'limitless';
       case DeviceType.raybanMeta:
         return 'rayban_meta';
+      case DeviceType.metaWearables:
+        return 'meta_wearables';
     }
   }
 
@@ -1132,6 +1138,7 @@ class CaptureController extends ChangeNotifier
       // Ray-Ban Meta audio is bridged from the platform HFP route, so there is
       // no native BLE GATT target; capture runs on the foreground Dart path.
       case DeviceType.raybanMeta:
+      case DeviceType.metaWearables:
         return null;
     }
   }
@@ -1233,40 +1240,103 @@ class CaptureController extends ChangeNotifier
     await connection.performCameraStartPhotoController();
     _blePhotoStream = await connection.performGetImageListener(
       onImageReceived: (orientedImage) async {
-        final rotatedImageBytes = rotateImage(orientedImage);
-        final String tempId = 'temp_img_${DateTime.now().millisecondsSinceEpoch}';
-        final String base64Image = base64Encode(rotatedImageBytes);
-
-        // Add placeholder to UI for immediate feedback
-        photos.add(ConversationPhoto(id: tempId, base64: base64Image, createdAt: DateTime.now()));
-        photos = List.from(photos);
-        notifyListeners();
-
-        // Chunking Logic
-        const int chunkSize = 8192; // 8KB chunks
-        final totalChunks = (base64Image.length / chunkSize).ceil();
-
-        for (int i = 0; i < totalChunks; i++) {
-          final start = i * chunkSize;
-          final end = (start + chunkSize > base64Image.length) ? base64Image.length : start + chunkSize;
-          final chunk = base64Image.substring(start, end);
-
-          final payload = jsonEncode({
-            'type': 'image_chunk',
-            'id': tempId,
-            'index': i,
-            'total': totalChunks,
-            'data': chunk,
-          });
-
-          if (_socket?.state == SocketServiceState.connected) {
-            _socket?.send(payload); // Send the JSON string
-          }
-          await Future.delayed(const Duration(milliseconds: 20)); // Small delay to prevent flooding
-        }
+        await ingestCapturedImage(rotateImage(orientedImage));
       },
     );
     notifyListeners();
+  }
+
+  Future<bool> ingestCapturedImage(Uint8List imageBytes, {bool addToUi = true, DateTime? capturedAt}) async {
+    final takenAt = capturedAt ?? DateTime.now();
+    final tempId = 'temp_img_${takenAt.millisecondsSinceEpoch}';
+    final base64Image = base64Encode(imageBytes);
+    final ack = _pendingPhotoUploadAcks[tempId] = Completer<void>();
+
+    if (addToUi) {
+      photos.add(ConversationPhoto(id: tempId, base64: base64Image, createdAt: takenAt));
+      photos.sort((a, b) => a.createdAt.compareTo(b.createdAt));
+      photos = List.from(photos);
+      notifyListeners();
+    }
+
+    try {
+      if (_socket?.state != SocketServiceState.connected) return false;
+
+      const chunkSize = 8192;
+      final totalChunks = (base64Image.length / chunkSize).ceil();
+
+      for (var i = 0; i < totalChunks; i++) {
+        final start = i * chunkSize;
+        final end = (start + chunkSize > base64Image.length) ? base64Image.length : start + chunkSize;
+        final chunk = base64Image.substring(start, end);
+
+        final payload = jsonEncode({
+          'type': 'image_chunk',
+          'id': tempId,
+          'index': i,
+          'total': totalChunks,
+          'data': chunk,
+        });
+
+        if (_socket?.state != SocketServiceState.connected) return false;
+        _socket?.send(payload);
+        await Future.delayed(const Duration(milliseconds: 20));
+      }
+
+      return await _waitForPhotoUploadAck(tempId, ack);
+    } finally {
+      _pendingPhotoUploadAcks.remove(tempId);
+      _pendingPhotoUploadIdsByPermanent.removeWhere((_, pendingTempId) => pendingTempId == tempId);
+    }
+  }
+
+  Future<bool> cacheCapturedImage(
+    Uint8List imageBytes, {
+    bool addToUi = true,
+    DateTime? capturedAt,
+    String? deviceUuid,
+    String? deviceName,
+    String? frameSha256,
+  }) async {
+    final takenAt = capturedAt ?? DateTime.now();
+    final tempId = 'temp_meta_${takenAt.millisecondsSinceEpoch}';
+    final base64Image = base64Encode(imageBytes);
+
+    if (addToUi) {
+      photos.add(ConversationPhoto(id: tempId, base64: base64Image, createdAt: takenAt));
+      photos.sort((a, b) => a.createdAt.compareTo(b.createdAt));
+      photos = List.from(photos);
+      notifyListeners();
+    }
+
+    final cached = await cacheMetaWearablesPhoto(
+      imageBytes,
+      capturedAt: takenAt,
+      conversationId: _metaWearablesCaptureConversationId,
+      deviceUuid: deviceUuid,
+      deviceName: deviceName,
+      frameSha256: frameSha256,
+    );
+    if (cached == null || cached.conversationId.isEmpty || cached.photoId.isEmpty) return false;
+
+    _metaWearablesCaptureConversationId = cached.conversationId;
+    final photoIndex = photos.indexWhere((p) => p.id == tempId);
+    if (photoIndex != -1) {
+      photos[photoIndex].id = cached.photoId;
+      _segmentsPhotosVersion++;
+      notifyListeners();
+    }
+    return true;
+  }
+
+  Future<bool> _waitForPhotoUploadAck(String tempId, Completer<void> ack) async {
+    try {
+      await ack.future.timeout(_photoUploadAckTimeout);
+      return true;
+    } on TimeoutException {
+      Logger.debug('CaptureController: photo upload ack timed out for $tempId');
+      return false;
+    }
   }
 
   void clearTranscripts() {
@@ -1772,6 +1842,8 @@ class CaptureController extends ChangeNotifier
     if (event is PhotoProcessingEvent) {
       final tempId = event.tempId;
       final permanentId = event.photoId;
+      _pendingPhotoUploadIdsByPermanent[permanentId] = tempId;
+      _completePhotoUploadAck(tempId);
       final photoIndex = photos.indexWhere((p) => p.id == tempId);
       if (photoIndex != -1) {
         photos[photoIndex].id = permanentId;
@@ -1793,6 +1865,13 @@ class CaptureController extends ChangeNotifier
         notifyListeners();
       }
       return;
+    }
+  }
+
+  void _completePhotoUploadAck(String tempId) {
+    final ack = _pendingPhotoUploadAcks[tempId];
+    if (ack != null && !ack.isCompleted) {
+      ack.complete();
     }
   }
 

--- a/app/lib/services/devices/connectors/device_connection.dart
+++ b/app/lib/services/devices/connectors/device_connection.dart
@@ -146,6 +146,8 @@ class DeviceConnectionFactory {
         return LimitlessDeviceConnection(device, transport);
       case DeviceType.raybanMeta:
         return RayBanMetaDeviceConnection(device, transport);
+      case DeviceType.metaWearables:
+        return RayBanMetaDeviceConnection(device, transport);
     }
   }
 }

--- a/app/lib/services/devices/meta_wearables_service.dart
+++ b/app/lib/services/devices/meta_wearables_service.dart
@@ -1,0 +1,132 @@
+import 'dart:async';
+
+import 'package:meta_wearables_dat_flutter/meta_wearables_dat_flutter.dart';
+
+import 'package:omi/backend/schema/bt_device/bt_device.dart';
+
+enum MetaGlassesCameraPermissionState {
+  notRegistered,
+  unavailable,
+  needsRequest,
+  requesting,
+  granted,
+}
+
+class MetaWearablesSnapshot {
+  final RegistrationState registrationState;
+  final List<DeviceInfo> devices;
+  final DeviceInfo? activeDevice;
+  final MetaGlassesCameraPermissionState cameraPermissionState;
+  final Map<String, Object?> diagnostics;
+
+  const MetaWearablesSnapshot({
+    required this.registrationState,
+    required this.devices,
+    required this.activeDevice,
+    required this.cameraPermissionState,
+    required this.diagnostics,
+  });
+
+  bool get cameraPermissionGranted => cameraPermissionState == MetaGlassesCameraPermissionState.granted;
+
+  bool get readyForRecording =>
+      registrationState == RegistrationState.registered && activeDevice != null && cameraPermissionGranted;
+}
+
+class MetaWearablesService {
+  const MetaWearablesService();
+
+  Stream<RegistrationState> registrationStateStream() => MetaWearablesDat.registrationStateStream();
+
+  Stream<DeviceInfo?> activeDeviceStream() => MetaWearablesDat.activeDeviceStream();
+
+  Stream<List<DeviceInfo>> devicesStream() => MetaWearablesDat.devicesStream();
+
+  Future<MetaWearablesSnapshot> snapshot() async {
+    final registrationState = await MetaWearablesDat.getRegistrationState();
+    final devices = await MetaWearablesDat.getDevices();
+    final activeDevice = await _activeDeviceSnapshot(devices);
+    final cameraPermissionState = await _cameraPermissionSnapshot(registrationState, devices, activeDevice);
+    final diagnostics = await MetaWearablesDat.dumpDiagnostics();
+
+    return MetaWearablesSnapshot(
+      registrationState: registrationState,
+      devices: devices,
+      activeDevice: activeDevice,
+      cameraPermissionState: cameraPermissionState,
+      diagnostics: diagnostics,
+    );
+  }
+
+  Future<BtDevice> startPairing() async {
+    await MetaWearablesDat.requestAndroidPermissions();
+    await MetaWearablesDat.startRegistration();
+    final snapshot = await this.snapshot();
+    return toBtDevice(
+      snapshot.activeDevice ??
+          (snapshot.devices.isNotEmpty
+              ? snapshot.devices.first
+              : const DeviceInfo(uuid: 'meta-registration-pending', name: 'Meta Wearables', kind: DeviceKind.unknown)),
+    );
+  }
+
+  Future<bool> requestCameraPermission() => MetaWearablesDat.requestCameraPermission();
+
+  Future<void> disconnect() => MetaWearablesDat.stopStreamSession();
+
+  Future<void> forgetLocalRegistration() => MetaWearablesDat.startUnregistration();
+
+  Future<int> startPreviewStream({String? deviceUUID, int fps = 30, StreamQuality quality = StreamQuality.medium}) =>
+      MetaWearablesDat.startStreamSession(deviceUUID: deviceUUID, fps: fps, quality: quality);
+
+  Future<void> stopPreviewStream({String? deviceUUID}) => MetaWearablesDat.stopStreamSession(deviceUUID: deviceUUID);
+
+  /// Native-pushed per-frame stream. Used as the background-capable capture
+  /// trigger (event delivery keeps working while backgrounded via
+  /// enableBackgroundStreaming, unlike a Dart timer which suspends).
+  Stream<VideoFrame> videoFrames() => MetaWearablesDat.videoFramesStream();
+
+  Future<void> openFirmwareUpdate() => MetaWearablesDat.openFirmwareUpdate();
+
+  Future<void> openDATGlassesAppUpdate() => MetaWearablesDat.openDATGlassesAppUpdate();
+
+  Future<DeviceInfo?> _activeDeviceSnapshot(List<DeviceInfo> devices) async {
+    try {
+      return await MetaWearablesDat.activeDeviceStream().first.timeout(const Duration(milliseconds: 500));
+    } on TimeoutException {
+      return null;
+    }
+  }
+
+  Future<MetaGlassesCameraPermissionState> _cameraPermissionSnapshot(
+    RegistrationState registrationState,
+    List<DeviceInfo> devices,
+    DeviceInfo? activeDevice,
+  ) async {
+    if (registrationState != RegistrationState.registered) {
+      return MetaGlassesCameraPermissionState.notRegistered;
+    }
+    if (activeDevice == null && devices.isEmpty) {
+      return MetaGlassesCameraPermissionState.unavailable;
+    }
+    try {
+      final granted = await MetaWearablesDat.getCameraPermissionStatus();
+      return granted ? MetaGlassesCameraPermissionState.granted : MetaGlassesCameraPermissionState.needsRequest;
+    } catch (_) {
+      return MetaGlassesCameraPermissionState.unavailable;
+    }
+  }
+
+  BtDevice toBtDevice(DeviceInfo device) {
+    return BtDevice(
+      id: device.uuid,
+      name: device.name.isNotEmpty ? device.name : 'Meta Wearables',
+      type: DeviceType.metaWearables,
+      rssi: 0,
+      modelNumber: device.kind.name,
+      firmwareRevision: 'Unknown',
+      hardwareRevision: 'Meta Wearables DAT',
+      manufacturerName: 'Meta',
+    );
+  }
+}

--- a/app/lib/services/meta_wearables/meta_capture_diagnostics.dart
+++ b/app/lib/services/meta_wearables/meta_capture_diagnostics.dart
@@ -1,0 +1,57 @@
+class MetaCaptureDiagnostics {
+  final DateTime? lastFrameAt;
+  final DateTime? lastUploadAt;
+  final String? lastUploadStatus;
+  final String? streamState;
+  final String? sessionState;
+  final int pendingQueueCount;
+  final int uploadedCount;
+  final int failedUploadCount;
+
+  const MetaCaptureDiagnostics({
+    this.lastFrameAt,
+    this.lastUploadAt,
+    this.lastUploadStatus,
+    this.streamState,
+    this.sessionState,
+    this.pendingQueueCount = 0,
+    this.uploadedCount = 0,
+    this.failedUploadCount = 0,
+  });
+
+  /// Sentinel distinguishing "not passed" from an explicit null, so callers
+  /// can clear nullable fields (`copyWith(lastUploadStatus: null)`).
+  static const Object _unset = Object();
+
+  MetaCaptureDiagnostics copyWith({
+    Object? lastFrameAt = _unset,
+    Object? lastUploadAt = _unset,
+    Object? lastUploadStatus = _unset,
+    Object? streamState = _unset,
+    Object? sessionState = _unset,
+    int? pendingQueueCount,
+    int? uploadedCount,
+    int? failedUploadCount,
+  }) =>
+      MetaCaptureDiagnostics(
+        lastFrameAt: identical(lastFrameAt, _unset) ? this.lastFrameAt : lastFrameAt as DateTime?,
+        lastUploadAt: identical(lastUploadAt, _unset) ? this.lastUploadAt : lastUploadAt as DateTime?,
+        lastUploadStatus: identical(lastUploadStatus, _unset) ? this.lastUploadStatus : lastUploadStatus as String?,
+        streamState: identical(streamState, _unset) ? this.streamState : streamState as String?,
+        sessionState: identical(sessionState, _unset) ? this.sessionState : sessionState as String?,
+        pendingQueueCount: pendingQueueCount ?? this.pendingQueueCount,
+        uploadedCount: uploadedCount ?? this.uploadedCount,
+        failedUploadCount: failedUploadCount ?? this.failedUploadCount,
+      );
+
+  Map<String, dynamic> toJson() => {
+        'lastFrameAt': lastFrameAt?.toIso8601String(),
+        'lastUploadAt': lastUploadAt?.toIso8601String(),
+        'lastUploadStatus': lastUploadStatus,
+        'streamState': streamState,
+        'sessionState': sessionState,
+        'pendingQueueCount': pendingQueueCount,
+        'uploadedCount': uploadedCount,
+        'failedUploadCount': failedUploadCount,
+      };
+}

--- a/app/lib/services/meta_wearables/meta_capture_queue.dart
+++ b/app/lib/services/meta_wearables/meta_capture_queue.dart
@@ -1,0 +1,170 @@
+import 'dart:convert';
+import 'dart:io';
+import 'dart:math';
+import 'dart:typed_data';
+
+import 'package:crypto/crypto.dart';
+
+class MetaCaptureQueueItem {
+  const MetaCaptureQueueItem({
+    required this.id,
+    required this.path,
+    required this.capturedAt,
+    required this.sha256,
+    required this.deviceUuid,
+    this.deviceName,
+  });
+
+  final String id;
+  final String path;
+  final DateTime capturedAt;
+  final String sha256;
+  final String deviceUuid;
+  final String? deviceName;
+
+  factory MetaCaptureQueueItem.fromJson(Map<String, dynamic> json) {
+    return MetaCaptureQueueItem(
+      id: json['id'] as String,
+      path: json['path'] as String,
+      capturedAt: DateTime.parse(json['capturedAt'] as String).toUtc(),
+      sha256: json['sha256'] as String,
+      deviceUuid: json['deviceUuid'] as String,
+      deviceName: json['deviceName'] as String?,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'path': path,
+      'capturedAt': capturedAt.toUtc().toIso8601String(),
+      'sha256': sha256,
+      'deviceUuid': deviceUuid,
+      if (deviceName != null) 'deviceName': deviceName,
+    };
+  }
+}
+
+class MetaCaptureQueue {
+  MetaCaptureQueue({required this.rootDirectory, this.compactionThreshold = 64});
+
+  static final Random _random = Random.secure();
+
+  final Directory rootDirectory;
+
+  /// Compact the append-only ledgers once this many uploads have accumulated;
+  /// without it both files grow for the life of the install.
+  final int compactionThreshold;
+
+  Directory get _framesDirectory => Directory('${rootDirectory.path}/meta_capture_frames');
+  File get _queueFile => File('${rootDirectory.path}/meta_capture_queue.jsonl');
+  File get _uploadedFile => File('${rootDirectory.path}/meta_capture_uploaded.txt');
+
+  Future<MetaCaptureQueueItem> enqueue({
+    required Uint8List bytes,
+    required DateTime capturedAt,
+    required String deviceUuid,
+    String? deviceName,
+  }) async {
+    await rootDirectory.create(recursive: true);
+    await _framesDirectory.create(recursive: true);
+
+    final digest = sha256.convert(bytes).toString();
+    final id = '${capturedAt.toUtc().microsecondsSinceEpoch}-${_randomHex(8)}';
+    final frameFile = File('${_framesDirectory.path}/$id.jpg');
+    await frameFile.writeAsBytes(bytes, flush: true);
+
+    final item = MetaCaptureQueueItem(
+      id: id,
+      path: frameFile.path,
+      capturedAt: capturedAt.toUtc(),
+      sha256: digest,
+      deviceUuid: deviceUuid,
+      deviceName: deviceName,
+    );
+    try {
+      await _queueFile.writeAsString('${jsonEncode(item.toJson())}\n', mode: FileMode.append, flush: true);
+    } catch (_) {
+      // Without a ledger entry the frame is unreachable; don't leak it.
+      try {
+        await frameFile.delete();
+      } catch (_) {}
+      rethrow;
+    }
+    return item;
+  }
+
+  Future<List<MetaCaptureQueueItem>> pending({required int limit}) async {
+    if (limit <= 0 || !await _queueFile.exists()) {
+      return [];
+    }
+
+    final uploadedIds = await _readUploadedIds();
+    final items = <MetaCaptureQueueItem>[];
+    final lines = await _queueFile.readAsLines();
+
+    for (final line in lines) {
+      final trimmed = line.trim();
+      if (trimmed.isEmpty) {
+        continue;
+      }
+
+      try {
+        final item = MetaCaptureQueueItem.fromJson(jsonDecode(trimmed) as Map<String, dynamic>);
+        if (uploadedIds.contains(item.id) || !await File(item.path).exists()) {
+          continue;
+        }
+        items.add(item);
+      } on FormatException {
+        continue;
+      } on TypeError {
+        continue;
+      }
+    }
+
+    items.sort((a, b) => a.capturedAt.compareTo(b.capturedAt));
+    return items.take(limit).toList(growable: false);
+  }
+
+  Future<void> markUploaded(String id) async {
+    await rootDirectory.create(recursive: true);
+    await _uploadedFile.writeAsString('$id\n', mode: FileMode.append, flush: true);
+    final uploadedCount = (await _readUploadedIds()).length;
+    if (uploadedCount >= compactionThreshold) {
+      await compact();
+    }
+  }
+
+  /// Rewrites the queue ledger keeping only pending items (not uploaded and
+  /// frame file still present), then drops the now-redundant uploaded ledger.
+  /// Atomic via write-to-temp + rename.
+  Future<void> compact() async {
+    final items = await pending(limit: 1 << 30);
+    final tmp = File('${_queueFile.path}.tmp');
+    final buffer = StringBuffer();
+    for (final item in items) {
+      buffer.writeln(jsonEncode(item.toJson()));
+    }
+    await tmp.writeAsString(buffer.toString(), flush: true);
+    await tmp.rename(_queueFile.path);
+    if (await _uploadedFile.exists()) {
+      await _uploadedFile.delete();
+    }
+  }
+
+  Future<Set<String>> _readUploadedIds() async {
+    if (!await _uploadedFile.exists()) {
+      return <String>{};
+    }
+    final lines = await _uploadedFile.readAsLines();
+    return lines.map((line) => line.trim()).where((line) => line.isNotEmpty).toSet();
+  }
+
+  static String _randomHex(int byteCount) {
+    final buffer = StringBuffer();
+    for (var i = 0; i < byteCount; i += 1) {
+      buffer.write(_random.nextInt(256).toRadixString(16).padLeft(2, '0'));
+    }
+    return buffer.toString();
+  }
+}

--- a/app/lib/services/meta_wearables/meta_capture_watchdog.dart
+++ b/app/lib/services/meta_wearables/meta_capture_watchdog.dart
@@ -1,0 +1,38 @@
+enum MetaCaptureHealth { streaming, paused, stopped, stale }
+
+enum MetaCaptureWatchdogAction { wait, restart }
+
+class MetaCaptureWatchdog {
+  int _attempts = 0;
+
+  MetaCaptureWatchdogAction nextAction(MetaCaptureHealth health) {
+    switch (health) {
+      case MetaCaptureHealth.streaming:
+      case MetaCaptureHealth.paused:
+        return MetaCaptureWatchdogAction.wait;
+      case MetaCaptureHealth.stopped:
+      case MetaCaptureHealth.stale:
+        return MetaCaptureWatchdogAction.restart;
+    }
+  }
+
+  Duration nextDelay(MetaCaptureHealth health) {
+    if (nextAction(health) == MetaCaptureWatchdogAction.wait) return Duration.zero;
+    final seconds = 1 << _attempts.clamp(0, 5);
+    return Duration(seconds: seconds);
+  }
+
+  void recordRestartAttempt() {
+    _attempts += 1;
+  }
+
+  void recordHealthyFrame() {
+    _attempts = 0;
+  }
+
+  /// Clears restart backoff. Call when a new capture session starts so a
+  /// previous session's failed restarts don't penalize the fresh session.
+  void reset() {
+    _attempts = 0;
+  }
+}

--- a/app/lib/utils/device.dart
+++ b/app/lib/utils/device.dart
@@ -113,6 +113,7 @@ class DeviceUtils {
         case DeviceType.friendPendant:
           return Assets.images.friendPendant.path;
         case DeviceType.raybanMeta:
+        case DeviceType.metaWearables:
           return Assets.images.raybanMeta.path;
         case DeviceType.omi:
           // For omi type, need to check model/name to distinguish between devkit and regular omi

--- a/app/lib/utils/meta_wearables_device_label.dart
+++ b/app/lib/utils/meta_wearables_device_label.dart
@@ -1,0 +1,16 @@
+import 'package:meta_wearables_dat_flutter/meta_wearables_dat_flutter.dart';
+
+import 'package:omi/l10n/app_localizations.dart';
+
+String metaWearablesDeviceKindLabel(AppLocalizations l10n, DeviceKind kind) {
+  switch (kind) {
+    case DeviceKind.rayBanMeta:
+      return l10n.metaGlassesTypeRayBanMeta;
+    case DeviceKind.rayBanDisplay:
+      return l10n.metaGlassesTypeRayBanDisplay;
+    case DeviceKind.oakleyMeta:
+      return l10n.metaGlassesTypeOakleyMeta;
+    case DeviceKind.unknown:
+      return l10n.metaGlasses;
+  }
+}

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -245,10 +245,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -1369,18 +1369,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   mcumgr_flutter:
     dependency: "direct main"
     description:
@@ -1393,10 +1393,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.18.0"
   meta_wearables_dat_flutter:
     dependency: "direct main"
     description:
@@ -1835,10 +1835,10 @@ packages:
     dependency: transitive
     description:
       name: quick_actions_ios
-      sha256: a2e08ceb01f9d26e1b1826b1c4f5da6b7b6bbf61bcbaacd8e93dfff58b91f996
+      sha256: be1496e7ca1debc86d9ea08e56325649fbc5abb2b6930690c97ba0dae59992b1
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.3"
+    version: "1.2.4"
   quick_actions_platform_interface:
     dependency: transitive
     description:
@@ -2152,10 +2152,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.11"
   time:
     dependency: transitive
     description:
@@ -2542,5 +2542,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.9.0 <4.0.0"
-  flutter: ">=3.35.0"
+  dart: ">=3.10.0 <4.0.0"
+  flutter: ">=3.38.0"

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -245,10 +245,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
+      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.1"
+    version: "1.4.0"
   checked_yaml:
     dependency: transitive
     description:
@@ -1369,18 +1369,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.17"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.13.0"
+    version: "0.11.1"
   mcumgr_flutter:
     dependency: "direct main"
     description:
@@ -1393,10 +1393,17 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
+      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.16.0"
+  meta_wearables_dat_flutter:
+    dependency: "direct main"
+    description:
+      path: "third_party/meta_wearables_dat_flutter"
+      relative: true
+    source: path
+    version: "0.7.1"
   mgrs_dart:
     dependency: transitive
     description:
@@ -1828,10 +1835,10 @@ packages:
     dependency: transitive
     description:
       name: quick_actions_ios
-      sha256: be1496e7ca1debc86d9ea08e56325649fbc5abb2b6930690c97ba0dae59992b1
+      sha256: a2e08ceb01f9d26e1b1826b1c4f5da6b7b6bbf61bcbaacd8e93dfff58b91f996
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.4"
+    version: "1.2.3"
   quick_actions_platform_interface:
     dependency: transitive
     description:
@@ -2145,10 +2152,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
+      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.11"
+    version: "0.7.6"
   time:
     dependency: transitive
     description:
@@ -2535,5 +2542,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.10.0 <4.0.0"
-  flutter: ">=3.38.0"
+  dart: ">=3.9.0 <4.0.0"
+  flutter: ">=3.35.0"

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -131,6 +131,8 @@ dependencies:
   vector_math: ^2.2.0
   marionette_flutter: ^0.3.0
   quick_actions: ^1.0.0
+  meta_wearables_dat_flutter:
+    path: third_party/meta_wearables_dat_flutter
 
 dependency_overrides:
   js: ^0.7.1

--- a/app/scripts/check_meta_glasses_runtime_proof.sh
+++ b/app/scripts/check_meta_glasses_runtime_proof.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+LOG="${1:-${LOG:-/tmp/omi-meta-glasses-runtime-proof-pulled.log}}"
+
+if [[ ! -f "$LOG" ]]; then
+  echo "missing_log=$LOG"
+  exit 2
+fi
+
+latest_window="$(awk '
+  /MetaGlassRuntimeProof provider-init/ {buf=$0 ORS; next}
+  {buf=buf $0 ORS}
+  END {printf "%s", buf}
+' "$LOG")"
+
+count() {
+  grep -F -c "$1" <<<"$latest_window" || true
+}
+
+provider_init="$(count 'MetaGlassRuntimeProof provider-init')"
+not_ready="$(count 'auto-start-skip reason=not-ready')"
+stream_started="$(count 'MetaGlassStreamDiag stream-started')"
+frame_event="$(count 'MetaGlassStreamDiag frame-event')"
+frame_captured="$(count 'MetaGlassStreamDiag frame-captured')"
+gestures_unsupported="$(count 'gestures=unsupported')"
+stream_failed="$(count 'MetaGlassStreamDiag stream-start-failed')"
+
+printf 'provider_init=%s\n' "$provider_init"
+printf 'not_ready=%s\n' "$not_ready"
+printf 'stream_started=%s\n' "$stream_started"
+printf 'frame_event=%s\n' "$frame_event"
+printf 'frame_captured=%s\n' "$frame_captured"
+printf 'gestures_unsupported=%s\n' "$gestures_unsupported"
+printf 'stream_failed=%s\n' "$stream_failed"
+
+if (( stream_started > 0 && frame_event > 0 && frame_captured > 0 )); then
+  echo "meta_glasses_runtime_proof=pass"
+  exit 0
+fi
+
+if (( not_ready > 0 && stream_started == 0 && frame_event == 0 && frame_captured == 0 )); then
+  echo "meta_glasses_runtime_proof=pending_not_ready"
+else
+  echo "meta_glasses_runtime_proof=fail"
+fi
+exit 1

--- a/app/test/support/meta_wearables_mock_harness.dart
+++ b/app/test/support/meta_wearables_mock_harness.dart
@@ -1,0 +1,400 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+import 'package:meta_wearables_dat_flutter/meta_wearables_dat_flutter.dart';
+import 'package:meta_wearables_dat_flutter/src/meta_wearables_dat_platform_interface.dart';
+import 'package:omi/services/capture/capture_controller.dart';
+// ignore: depend_on_referenced_packages
+import 'package:plugin_platform_interface/plugin_platform_interface.dart';
+
+class MetaWearablesMockHarness {
+  final platform = RecordingMetaWearablesMockPlatform();
+
+  Future<File> writeFixtureImage(Directory dir) async {
+    final file = File('${dir.path}/mock-rayban-frame.png');
+    await file.writeAsBytes(fixturePngBytes);
+    return file;
+  }
+
+  List<DeviceInfo> devicesInTwoLinkStates() => const [
+        DeviceInfo(
+          uuid: 'mock-rayban-linked',
+          name: 'Mock Ray-Ban Linked',
+          kind: DeviceKind.rayBanMeta,
+          linkState: DeviceLinkState.connected,
+        ),
+        DeviceInfo(
+          uuid: 'mock-rayban-unlinked',
+          name: 'Mock Ray-Ban Unlinked',
+          kind: DeviceKind.rayBanMeta,
+          linkState: DeviceLinkState.disconnected,
+        ),
+      ];
+}
+
+class RecordingCaptureController extends CaptureController {
+  final List<Uint8List> ingestedImages = [];
+  final List<bool> addToUiValues = [];
+  final List<DateTime?> capturedAtValues = [];
+  final List<String?> deviceUuidValues = [];
+  final List<String?> deviceNameValues = [];
+  final List<String?> frameSha256Values = [];
+  int streamRecordingCount = 0;
+  int stopStreamRecordingCount = 0;
+
+  @override
+  Future<void> streamRecording() async {
+    streamRecordingCount += 1;
+  }
+
+  @override
+  Future<void> stopStreamRecording() async {
+    stopStreamRecordingCount += 1;
+  }
+
+  @override
+  Future<bool> ingestCapturedImage(Uint8List imageBytes, {bool addToUi = true, DateTime? capturedAt}) async {
+    ingestedImages.add(Uint8List.fromList(imageBytes));
+    addToUiValues.add(addToUi);
+    capturedAtValues.add(capturedAt);
+    return true;
+  }
+
+  @override
+  Future<bool> cacheCapturedImage(
+    Uint8List imageBytes, {
+    bool addToUi = true,
+    DateTime? capturedAt,
+    String? deviceUuid,
+    String? deviceName,
+    String? frameSha256,
+  }) async {
+    ingestedImages.add(Uint8List.fromList(imageBytes));
+    addToUiValues.add(addToUi);
+    capturedAtValues.add(capturedAt);
+    deviceUuidValues.add(deviceUuid);
+    deviceNameValues.add(deviceName);
+    frameSha256Values.add(frameSha256);
+    return true;
+  }
+}
+
+class RecordingMetaWearablesMockPlatform extends MetaWearablesDatPlatform with MockPlatformInterfaceMixin {
+  static const uuid = 'mock-rayban-meta-1';
+  static const textureId = 771;
+
+  bool enabled = false;
+  bool paired = false;
+  bool powered = false;
+  bool unfolded = false;
+  bool donned = false;
+  bool cameraGranted = false;
+  bool reportsActiveDevice = true;
+  bool cameraPermissionStatusThrows = false;
+  bool blockCameraPermissionRequest = false;
+  bool backgroundStreamingEnabled = false;
+  bool emitDeviceChanges = true;
+  bool leaveSessionOnFailedStart = false;
+  bool streamSessionExists = false;
+  int streamStartCallCount = 0;
+  int stopStreamSessionCount = 0;
+  int failStreamStartCount = 0;
+  int frameCaptureCount = 0;
+  int cameraPermissionRequestCount = 0;
+  String? capturedImagePath;
+  String? lastStreamDeviceUuid;
+  int? lastStreamFps;
+  StreamQuality? lastStreamQuality;
+  final StreamController<List<DeviceInfo>> _devicesController = StreamController<List<DeviceInfo>>.broadcast();
+
+  DeviceInfo get device => DeviceInfo(
+        uuid: uuid,
+        name: 'Mock Ray-Ban Meta',
+        kind: DeviceKind.rayBanMeta,
+        linkState: powered && unfolded && donned ? DeviceLinkState.connected : DeviceLinkState.disconnected,
+      );
+
+  @override
+  Future<Map<String, Object?>> dumpDiagnostics() async => {
+        'mockDeviceEnabled': enabled,
+        'mockDevicePaired': paired,
+        'mockCameraGranted': cameraGranted,
+      };
+
+  @override
+  Future<void> enableMockDevice({bool initiallyRegistered = true, bool initialPermissionsGranted = true}) async {
+    enabled = initiallyRegistered;
+    cameraGranted = initialPermissionsGranted;
+  }
+
+  @override
+  Future<void> disableMockDevice() async {
+    enabled = false;
+    paired = false;
+    _emitDevices();
+  }
+
+  @override
+  Future<String> pairMockRayBanMeta() async {
+    paired = true;
+    _emitDevices();
+    return uuid;
+  }
+
+  @override
+  Future<List<DeviceInfo>> pairedMockDevices() async => paired ? [device] : [];
+
+  @override
+  Future<void> mockPowerOn(String uuid) async {
+    powered = true;
+    _emitDevices();
+  }
+
+  @override
+  Future<void> mockPowerOff(String uuid) async {
+    powered = false;
+    _emitDevices();
+  }
+
+  @override
+  Future<void> mockUnfold(String uuid) async {
+    unfolded = true;
+    _emitDevices();
+  }
+
+  @override
+  Future<void> mockDon(String uuid) async {
+    donned = true;
+    _emitDevices();
+  }
+
+  @override
+  Future<void> mockDoff(String uuid) async {
+    donned = false;
+    _emitDevices();
+  }
+
+  @override
+  Future<void> setMockPermission(String permission, String status) async {
+    if (permission == MockPermission.camera.value) {
+      cameraGranted = status == MockPermissionStatus.granted.value;
+    }
+  }
+
+  @override
+  Future<void> setMockCapturedImage(String uuid, String? filePath) async {
+    capturedImagePath = filePath;
+  }
+
+  @override
+  Future<RegistrationState> getRegistrationState() async {
+    return enabled ? RegistrationState.registered : RegistrationState.unavailable;
+  }
+
+  @override
+  Stream<RegistrationState> registrationStateStream() {
+    return Stream.value(enabled ? RegistrationState.registered : RegistrationState.unavailable);
+  }
+
+  @override
+  Future<List<DeviceInfo>> getDevices() async => paired ? [device] : [];
+
+  @override
+  Stream<List<DeviceInfo>> devicesStream() async* {
+    yield paired ? [device] : [];
+    yield* _devicesController.stream;
+  }
+
+  @override
+  Stream<DeviceInfo?> activeDeviceStream() => Stream.value(paired && reportsActiveDevice ? device : null);
+
+  void _emitDevices() {
+    if (emitDeviceChanges && !_devicesController.isClosed) {
+      _devicesController.add(paired ? [device] : []);
+    }
+  }
+
+  @override
+  Stream<DeviceCompatibilityEvent> compatibilityStream() {
+    if (!paired) return const Stream.empty();
+    return Stream.value(
+        const DeviceCompatibilityEvent(deviceUuid: uuid, compatibility: DeviceCompatibility.compatible));
+  }
+
+  @override
+  Future<bool> getCameraPermissionStatus() async {
+    if (cameraPermissionStatusThrows) {
+      throw PlatformException(code: 'PERMISSION_ERROR', message: 'permission status unavailable');
+    }
+    return cameraGranted;
+  }
+
+  @override
+  Future<bool> requestCameraPermission() async {
+    cameraPermissionRequestCount += 1;
+    if (blockCameraPermissionRequest) return Completer<bool>().future;
+    cameraGranted = true;
+    return true;
+  }
+
+  @override
+  Future<int> startStreamSession({
+    String? deviceUUID,
+    int fps = 30,
+    StreamQuality quality = StreamQuality.medium,
+    Set<DeviceKind>? deviceKinds,
+    VideoCodec videoCodec = VideoCodec.raw,
+  }) async {
+    streamStartCallCount += 1;
+    if (failStreamStartCount > 0) {
+      failStreamStartCount -= 1;
+      if (leaveSessionOnFailedStart) streamSessionExists = true;
+      throw const SessionError(code: DatErrorCodes.noEligibleDevice, message: 'noEligibleDevice');
+    }
+    if (streamSessionExists) {
+      throw const SessionError(code: DatErrorCodes.sessionAlreadyExists, message: 'sessionAlreadyExists');
+    }
+    streamSessionExists = true;
+    lastStreamDeviceUuid = deviceUUID;
+    lastStreamFps = fps;
+    lastStreamQuality = quality;
+    return textureId;
+  }
+
+  @override
+  Future<void> stopStreamSession({String? deviceUUID}) async {
+    stopStreamSessionCount += 1;
+    streamSessionExists = false;
+  }
+
+  @override
+  Future<void> pauseStreamSession({String? deviceUUID}) async {}
+
+  @override
+  Future<void> resumeStreamSession({String? deviceUUID}) async {}
+
+  @override
+  Stream<VideoFrame> videoFramesStream() => Stream.value(
+        VideoFrame(
+          codec: VideoCodec.raw,
+          bytes: Uint8List.fromList([0, 0, 0, 255]),
+          width: 1,
+          height: 1,
+          ptsUs: 1,
+          isKeyframe: true,
+          bytesPerRow: 4,
+        ),
+      );
+
+  @override
+  Future<void> enableBackgroundStreaming({BackgroundNotification? androidNotification}) async {
+    backgroundStreamingEnabled = true;
+  }
+
+  @override
+  Future<void> disableBackgroundStreaming() async {
+    backgroundStreamingEnabled = false;
+  }
+
+  @override
+  Stream<StreamSessionState> streamSessionStateStream() => const Stream.empty();
+
+  @override
+  Stream<Object> streamSessionErrorStream() => const Stream.empty();
+
+  @override
+  Stream<DeviceSessionState> deviceSessionStateStream() => Stream.value(DeviceSessionState.started);
+
+  @override
+  Stream<Object> deviceSessionErrorStream() => const Stream.empty();
+
+  @override
+  Stream<VideoStreamSize> videoStreamSizeStream() => Stream.value(const VideoStreamSize(width: 640, height: 360));
+
+  @override
+  Future<FrameData?> captureStreamFrame(int textureId, {FrameFormat format = FrameFormat.rawRgba}) async {
+    frameCaptureCount += 1;
+    final path = capturedImagePath;
+    final bytes = path == null ? fixturePngBytes : await File(path).readAsBytes();
+    return FrameData(bytes: Uint8List.fromList(bytes), width: 1, height: 1, format: format);
+  }
+
+  @override
+  Future<FrameData?> captureLatestFrame({double quality = 0.8}) async {
+    frameCaptureCount += 1;
+    final path = capturedImagePath;
+    final bytes = path == null ? fixturePngBytes : await File(path).readAsBytes();
+    return FrameData(bytes: Uint8List.fromList(bytes), width: 1, height: 1, format: FrameFormat.jpeg);
+  }
+}
+
+final Uint8List fixturePngBytes = Uint8List.fromList(const [
+  0x89,
+  0x50,
+  0x4e,
+  0x47,
+  0x0d,
+  0x0a,
+  0x1a,
+  0x0a,
+  0x00,
+  0x00,
+  0x00,
+  0x0d,
+  0x49,
+  0x48,
+  0x44,
+  0x52,
+  0x00,
+  0x00,
+  0x00,
+  0x01,
+  0x00,
+  0x00,
+  0x00,
+  0x01,
+  0x08,
+  0x06,
+  0x00,
+  0x00,
+  0x00,
+  0x1f,
+  0x15,
+  0xc4,
+  0x89,
+  0x00,
+  0x00,
+  0x00,
+  0x0a,
+  0x49,
+  0x44,
+  0x41,
+  0x54,
+  0x78,
+  0x9c,
+  0x63,
+  0x00,
+  0x01,
+  0x00,
+  0x00,
+  0x05,
+  0x00,
+  0x01,
+  0x0d,
+  0x0a,
+  0x2d,
+  0xb4,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x49,
+  0x45,
+  0x4e,
+  0x44,
+  0xae,
+  0x42,
+  0x60,
+  0x82,
+]);

--- a/app/test/support/meta_wearables_mock_harness.dart
+++ b/app/test/support/meta_wearables_mock_harness.dart
@@ -37,9 +37,6 @@ class RecordingCaptureController extends CaptureController {
   final List<Uint8List> ingestedImages = [];
   final List<bool> addToUiValues = [];
   final List<DateTime?> capturedAtValues = [];
-  final List<String?> deviceUuidValues = [];
-  final List<String?> deviceNameValues = [];
-  final List<String?> frameSha256Values = [];
   int streamRecordingCount = 0;
   int stopStreamRecordingCount = 0;
 
@@ -58,24 +55,6 @@ class RecordingCaptureController extends CaptureController {
     ingestedImages.add(Uint8List.fromList(imageBytes));
     addToUiValues.add(addToUi);
     capturedAtValues.add(capturedAt);
-    return true;
-  }
-
-  @override
-  Future<bool> cacheCapturedImage(
-    Uint8List imageBytes, {
-    bool addToUi = true,
-    DateTime? capturedAt,
-    String? deviceUuid,
-    String? deviceName,
-    String? frameSha256,
-  }) async {
-    ingestedImages.add(Uint8List.fromList(imageBytes));
-    addToUiValues.add(addToUi);
-    capturedAtValues.add(capturedAt);
-    deviceUuidValues.add(deviceUuid);
-    deviceNameValues.add(deviceName);
-    frameSha256Values.add(frameSha256);
     return true;
   }
 }

--- a/app/test/unit/conversation_transcripts_response_test.dart
+++ b/app/test/unit/conversation_transcripts_response_test.dart
@@ -1,0 +1,26 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:omi/backend/http/api/conversations.dart';
+
+Map<String, dynamic> _segment(String text) => {
+      'id': text,
+      'text': text,
+      'speaker': 'SPEAKER_00',
+      'is_user': false,
+      'start': 0,
+      'end': 1,
+      'translations': <Map<String, dynamic>>[],
+      'speech_profile_processed': true,
+    };
+
+void main() {
+  test('TranscriptsResponse tolerates missing provider lists', () {
+    final response = TranscriptsResponse.fromJson({
+      'deepgram': [_segment('hello')],
+    });
+
+    expect(response.deepgram.single.text, 'hello');
+    expect(response.soniox, isEmpty);
+    expect(response.whisperx, isEmpty);
+    expect(response.speechmatics, isEmpty);
+  });
+}

--- a/app/test/unit/meta_glasses_autostart_regression_test.dart
+++ b/app/test/unit/meta_glasses_autostart_regression_test.dart
@@ -1,4 +1,3 @@
-import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter/services.dart';
@@ -17,17 +16,34 @@ void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   const pathProviderChannel = MethodChannel('plugins.flutter.io/path_provider');
+  const audioSessionChannel = MethodChannel('com.omi.ios/audioSession');
   late Directory tempDir;
   late MetaWearablesMockHarness harness;
+  late List<String> audioSessionCalls;
 
   setUp(() async {
     SharedPreferences.setMockInitialValues({'metaGlassesAutoCapture': true});
     await SharedPreferencesUtil.init();
+    audioSessionCalls = [];
     tempDir = await Directory.systemTemp.createTemp('meta-glasses-autostart-');
     TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(
       pathProviderChannel,
       (call) async {
         if (call.method == 'getApplicationDocumentsDirectory') return tempDir.path;
+        return null;
+      },
+    );
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(
+      audioSessionChannel,
+      (call) async {
+        audioSessionCalls.add(call.method);
+        if (call.method == 'configureForMetaGlassesCapture' || call.method == 'getCurrentAudioRoute') {
+          return <String, dynamic>{
+            'input': 'BluetoothHFP',
+            'output': 'BluetoothHFP',
+            'glassesInput': true,
+          };
+        }
         return null;
       },
     );
@@ -39,6 +55,10 @@ void main() {
     MetaWearablesDatPlatform.instance = MethodChannelMetaWearablesDat();
     TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(
       pathProviderChannel,
+      null,
+    );
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(
+      audioSessionChannel,
       null,
     );
     if (tempDir.existsSync()) tempDir.deleteSync(recursive: true);
@@ -80,7 +100,7 @@ void main() {
 
     expect(provider.devices.single.linkState, DeviceLinkState.disconnected);
     expect(provider.isCapturing, isTrue);
-    expect(controller.streamRecordingCount, 0);
+    expect(controller.streamRecordingCount, 1);
     expect(harness.platform.lastStreamDeviceUuid, isNull);
     expect(harness.platform.frameCaptureCount, 1);
     expect(controller.ingestedImages, hasLength(1));
@@ -101,7 +121,7 @@ void main() {
 
     await _waitFor(() => provider.isCapturing);
     expect(provider.isCapturing, isTrue);
-    expect(controller.streamRecordingCount, 0);
+    expect(controller.streamRecordingCount, 1);
     expect(harness.platform.lastStreamDeviceUuid, isNull);
 
     await _makeMockEligible();
@@ -128,7 +148,7 @@ void main() {
     await _waitFor(() => provider.isCapturing);
 
     expect(provider.isCapturing, isTrue);
-    expect(controller.streamRecordingCount, 0);
+    expect(controller.streamRecordingCount, 1);
     expect(harness.platform.lastStreamDeviceUuid, isNull);
     expect(harness.platform.frameCaptureCount, 1);
     expect(controller.ingestedImages, hasLength(1));
@@ -150,7 +170,7 @@ void main() {
     await _drainAutoStart();
     await _waitFor(() => provider.isCapturing);
 
-    expect(controller.streamRecordingCount, 0);
+    expect(controller.streamRecordingCount, 1);
     expect(provider.devices.single.linkState, DeviceLinkState.connected);
     expect(provider.isActive(provider.devices.single), isTrue);
     expect(harness.platform.lastStreamDeviceUuid, RecordingMetaWearablesMockPlatform.uuid);
@@ -158,7 +178,7 @@ void main() {
     provider.dispose();
   });
 
-  test('auto-started camera stream never starts phone mic recording', () async {
+  test('auto-started camera stream starts recording only after confirmed glasses HFP routing', () async {
     await MetaWearablesDat.enableMockDevice(initiallyRegistered: true, initialPermissionsGranted: true);
     await MetaWearablesDat.pairMockRayBanMeta();
     await _enableAutoCaptureForTest();
@@ -166,13 +186,15 @@ void main() {
 
     final provider = MetaWearablesProvider();
     await provider.init();
-    final controller = _BlockingCaptureController();
+    final controller = RecordingCaptureController();
 
     provider.attachCaptureController(controller);
     await _drainAutoStart();
     await _waitFor(() => provider.isCapturing);
+    await _waitFor(() => controller.ingestedImages.length == 1);
 
-    expect(controller.streamRecordingCount, 0);
+    expect(controller.streamRecordingCount, 1);
+    expect(audioSessionCalls, containsAllInOrder(['configureForMetaGlassesCapture', 'getCurrentAudioRoute']));
     expect(harness.platform.backgroundStreamingEnabled, isTrue);
     expect(harness.platform.lastStreamDeviceUuid, RecordingMetaWearablesMockPlatform.uuid);
     expect(harness.platform.frameCaptureCount, 1);
@@ -200,7 +222,7 @@ void main() {
     await _drainAutoStart();
     await _waitFor(() => provider.isCapturing);
 
-    expect(controller.streamRecordingCount, 0);
+    expect(controller.streamRecordingCount, 1);
     expect(harness.platform.lastStreamDeviceUuid, RecordingMetaWearablesMockPlatform.uuid);
     expect(harness.platform.frameCaptureCount, 1);
     expect(controller.ingestedImages, hasLength(1));
@@ -336,19 +358,9 @@ Future<void> _makeMockEligible() async {
 }
 
 Future<void> _waitFor(bool Function() condition) async {
-  for (var i = 0; i < 20; i++) {
+  for (var i = 0; i < 100; i++) {
     if (condition()) return;
     await Future<void>.delayed(const Duration(milliseconds: 10));
   }
   fail('Timed out waiting for async auto-start to settle.');
-}
-
-class _BlockingCaptureController extends RecordingCaptureController {
-  final Completer<void> _neverReturns = Completer<void>();
-
-  @override
-  Future<void> streamRecording() async {
-    streamRecordingCount += 1;
-    return _neverReturns.future;
-  }
 }

--- a/app/test/unit/meta_glasses_autostart_regression_test.dart
+++ b/app/test/unit/meta_glasses_autostart_regression_test.dart
@@ -21,7 +21,7 @@ void main() {
   late MetaWearablesMockHarness harness;
 
   setUp(() async {
-    SharedPreferences.setMockInitialValues({});
+    SharedPreferences.setMockInitialValues({'metaGlassesAutoCapture': true});
     await SharedPreferencesUtil.init();
     tempDir = await Directory.systemTemp.createTemp('meta-glasses-autostart-');
     TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(
@@ -44,9 +44,31 @@ void main() {
     if (tempDir.existsSync()) tempDir.deleteSync(recursive: true);
   });
 
+  test('registered visible glasses do not auto-start without explicit opt-in', () async {
+    SharedPreferences.setMockInitialValues({});
+    await SharedPreferencesUtil.init();
+    await MetaWearablesDat.enableMockDevice(initiallyRegistered: true, initialPermissionsGranted: true);
+    await MetaWearablesDat.pairMockRayBanMeta();
+
+    final provider = MetaWearablesProvider();
+    await provider.init();
+    final controller = RecordingCaptureController();
+
+    provider.attachCaptureController(controller);
+    await _drainAutoStart();
+
+    expect(provider.autoCaptureEnabled, isFalse);
+    expect(provider.isCapturing, isFalse);
+    expect(harness.platform.frameCaptureCount, 0);
+    expect(controller.ingestedImages, isEmpty);
+
+    provider.dispose();
+  });
+
   test('registered visible glasses auto-start with DAT auto selector when link state is stale', () async {
     await MetaWearablesDat.enableMockDevice(initiallyRegistered: true, initialPermissionsGranted: true);
     await MetaWearablesDat.pairMockRayBanMeta();
+    await _enableAutoCaptureForTest();
 
     final provider = MetaWearablesProvider();
     await provider.init();
@@ -69,6 +91,7 @@ void main() {
   test('auto-start keeps capture alive when a stale glasses link later becomes eligible', () async {
     await MetaWearablesDat.enableMockDevice(initiallyRegistered: true, initialPermissionsGranted: true);
     await MetaWearablesDat.pairMockRayBanMeta();
+    await _enableAutoCaptureForTest();
 
     final provider = MetaWearablesProvider();
     await provider.init();
@@ -94,6 +117,7 @@ void main() {
   test('auto-start does not depend on link-state stream events when paired glasses are visible', () async {
     await MetaWearablesDat.enableMockDevice(initiallyRegistered: true, initialPermissionsGranted: true);
     await MetaWearablesDat.pairMockRayBanMeta();
+    await _enableAutoCaptureForTest();
     harness.platform.emitDeviceChanges = false;
 
     final provider = MetaWearablesProvider();
@@ -115,6 +139,7 @@ void main() {
   test('auto-start targets the DAT active eligible device instead of auto selector', () async {
     await MetaWearablesDat.enableMockDevice(initiallyRegistered: true, initialPermissionsGranted: true);
     await MetaWearablesDat.pairMockRayBanMeta();
+    await _enableAutoCaptureForTest();
     await _makeMockEligible();
 
     final provider = MetaWearablesProvider();
@@ -136,6 +161,7 @@ void main() {
   test('auto-started camera stream never starts phone mic recording', () async {
     await MetaWearablesDat.enableMockDevice(initiallyRegistered: true, initialPermissionsGranted: true);
     await MetaWearablesDat.pairMockRayBanMeta();
+    await _enableAutoCaptureForTest();
     await _makeMockEligible();
 
     final provider = MetaWearablesProvider();
@@ -159,6 +185,7 @@ void main() {
       () async {
     await MetaWearablesDat.enableMockDevice(initiallyRegistered: true, initialPermissionsGranted: true);
     await MetaWearablesDat.pairMockRayBanMeta();
+    await _enableAutoCaptureForTest();
     await _makeMockEligible();
     harness.platform.reportsActiveDevice = false;
 
@@ -184,6 +211,7 @@ void main() {
   test('auto-start waits for initial permission snapshot instead of hanging in permission request', () async {
     await MetaWearablesDat.enableMockDevice(initiallyRegistered: true, initialPermissionsGranted: true);
     await MetaWearablesDat.pairMockRayBanMeta();
+    await _enableAutoCaptureForTest();
     await _makeMockEligible();
     harness.platform.reportsActiveDevice = false;
     harness.platform.blockCameraPermissionRequest = true;
@@ -205,6 +233,7 @@ void main() {
   test('auto-start streams directly when permission status is unavailable but glasses are visible', () async {
     await MetaWearablesDat.enableMockDevice(initiallyRegistered: true, initialPermissionsGranted: true);
     await MetaWearablesDat.pairMockRayBanMeta();
+    await _enableAutoCaptureForTest();
     await _makeMockEligible();
     harness.platform.reportsActiveDevice = false;
     harness.platform.cameraPermissionStatusThrows = true;
@@ -230,6 +259,7 @@ void main() {
   test('stream start failure during initial capture schedules the bounded camera retry', () async {
     await MetaWearablesDat.enableMockDevice(initiallyRegistered: true, initialPermissionsGranted: true);
     await MetaWearablesDat.pairMockRayBanMeta();
+    await _enableAutoCaptureForTest();
     await _makeMockEligible();
     harness.platform.failStreamStartCount = 1;
     harness.platform.leaveSessionOnFailedStart = true;
@@ -293,6 +323,10 @@ Future<void> _drainAutoStart() async {
   for (var i = 0; i < 5; i++) {
     await Future<void>.delayed(Duration.zero);
   }
+}
+
+Future<void> _enableAutoCaptureForTest() async {
+  await SharedPreferencesUtil().saveBool('metaGlassesAutoCapture', true);
 }
 
 Future<void> _makeMockEligible() async {

--- a/app/test/unit/meta_glasses_autostart_regression_test.dart
+++ b/app/test/unit/meta_glasses_autostart_regression_test.dart
@@ -1,0 +1,320 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:meta_wearables_dat_flutter/meta_wearables_dat_flutter.dart';
+import 'package:meta_wearables_dat_flutter/src/meta_wearables_dat_method_channel.dart';
+import 'package:meta_wearables_dat_flutter/src/meta_wearables_dat_platform_interface.dart';
+import 'package:omi/backend/preferences.dart';
+import 'package:omi/providers/meta_wearables_provider.dart';
+import 'package:omi/services/devices/meta_wearables_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../support/meta_wearables_mock_harness.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const pathProviderChannel = MethodChannel('plugins.flutter.io/path_provider');
+  late Directory tempDir;
+  late MetaWearablesMockHarness harness;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    await SharedPreferencesUtil.init();
+    tempDir = await Directory.systemTemp.createTemp('meta-glasses-autostart-');
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(
+      pathProviderChannel,
+      (call) async {
+        if (call.method == 'getApplicationDocumentsDirectory') return tempDir.path;
+        return null;
+      },
+    );
+    harness = MetaWearablesMockHarness();
+    MetaWearablesDatPlatform.instance = harness.platform;
+  });
+
+  tearDown(() {
+    MetaWearablesDatPlatform.instance = MethodChannelMetaWearablesDat();
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(
+      pathProviderChannel,
+      null,
+    );
+    if (tempDir.existsSync()) tempDir.deleteSync(recursive: true);
+  });
+
+  test('registered visible glasses auto-start with DAT auto selector when link state is stale', () async {
+    await MetaWearablesDat.enableMockDevice(initiallyRegistered: true, initialPermissionsGranted: true);
+    await MetaWearablesDat.pairMockRayBanMeta();
+
+    final provider = MetaWearablesProvider();
+    await provider.init();
+    final controller = RecordingCaptureController();
+
+    provider.attachCaptureController(controller);
+    await _drainAutoStart();
+    await _waitFor(() => provider.isCapturing);
+
+    expect(provider.devices.single.linkState, DeviceLinkState.disconnected);
+    expect(provider.isCapturing, isTrue);
+    expect(controller.streamRecordingCount, 0);
+    expect(harness.platform.lastStreamDeviceUuid, isNull);
+    expect(harness.platform.frameCaptureCount, 1);
+    expect(controller.ingestedImages, hasLength(1));
+
+    provider.dispose();
+  });
+
+  test('auto-start keeps capture alive when a stale glasses link later becomes eligible', () async {
+    await MetaWearablesDat.enableMockDevice(initiallyRegistered: true, initialPermissionsGranted: true);
+    await MetaWearablesDat.pairMockRayBanMeta();
+
+    final provider = MetaWearablesProvider();
+    await provider.init();
+    final controller = RecordingCaptureController();
+    provider.attachCaptureController(controller);
+    await _drainAutoStart();
+
+    await _waitFor(() => provider.isCapturing);
+    expect(provider.isCapturing, isTrue);
+    expect(controller.streamRecordingCount, 0);
+    expect(harness.platform.lastStreamDeviceUuid, isNull);
+
+    await _makeMockEligible();
+    await _drainAutoStart();
+
+    expect(provider.devices.single.linkState, DeviceLinkState.connected);
+    expect(harness.platform.frameCaptureCount, 1);
+    expect(controller.ingestedImages, hasLength(1));
+
+    provider.dispose();
+  });
+
+  test('auto-start does not depend on link-state stream events when paired glasses are visible', () async {
+    await MetaWearablesDat.enableMockDevice(initiallyRegistered: true, initialPermissionsGranted: true);
+    await MetaWearablesDat.pairMockRayBanMeta();
+    harness.platform.emitDeviceChanges = false;
+
+    final provider = MetaWearablesProvider();
+    await provider.init();
+    final controller = RecordingCaptureController();
+    provider.attachCaptureController(controller);
+    await _drainAutoStart();
+    await _waitFor(() => provider.isCapturing);
+
+    expect(provider.isCapturing, isTrue);
+    expect(controller.streamRecordingCount, 0);
+    expect(harness.platform.lastStreamDeviceUuid, isNull);
+    expect(harness.platform.frameCaptureCount, 1);
+    expect(controller.ingestedImages, hasLength(1));
+
+    provider.dispose();
+  });
+
+  test('auto-start targets the DAT active eligible device instead of auto selector', () async {
+    await MetaWearablesDat.enableMockDevice(initiallyRegistered: true, initialPermissionsGranted: true);
+    await MetaWearablesDat.pairMockRayBanMeta();
+    await _makeMockEligible();
+
+    final provider = MetaWearablesProvider();
+    await provider.init();
+    final controller = RecordingCaptureController();
+
+    provider.attachCaptureController(controller);
+    await _drainAutoStart();
+    await _waitFor(() => provider.isCapturing);
+
+    expect(controller.streamRecordingCount, 0);
+    expect(provider.devices.single.linkState, DeviceLinkState.connected);
+    expect(provider.isActive(provider.devices.single), isTrue);
+    expect(harness.platform.lastStreamDeviceUuid, RecordingMetaWearablesMockPlatform.uuid);
+
+    provider.dispose();
+  });
+
+  test('auto-started camera stream never starts phone mic recording', () async {
+    await MetaWearablesDat.enableMockDevice(initiallyRegistered: true, initialPermissionsGranted: true);
+    await MetaWearablesDat.pairMockRayBanMeta();
+    await _makeMockEligible();
+
+    final provider = MetaWearablesProvider();
+    await provider.init();
+    final controller = _BlockingCaptureController();
+
+    provider.attachCaptureController(controller);
+    await _drainAutoStart();
+    await _waitFor(() => provider.isCapturing);
+
+    expect(controller.streamRecordingCount, 0);
+    expect(harness.platform.backgroundStreamingEnabled, isTrue);
+    expect(harness.platform.lastStreamDeviceUuid, RecordingMetaWearablesMockPlatform.uuid);
+    expect(harness.platform.frameCaptureCount, 1);
+    expect(controller.ingestedImages, hasLength(1));
+
+    provider.dispose();
+  });
+
+  test('registered visible glasses use granted camera permission even when active device is temporarily none',
+      () async {
+    await MetaWearablesDat.enableMockDevice(initiallyRegistered: true, initialPermissionsGranted: true);
+    await MetaWearablesDat.pairMockRayBanMeta();
+    await _makeMockEligible();
+    harness.platform.reportsActiveDevice = false;
+
+    final provider = MetaWearablesProvider();
+    await provider.init();
+    final controller = RecordingCaptureController();
+
+    expect(provider.devices, isNotEmpty);
+    expect(provider.cameraPermissionGranted, isTrue);
+
+    provider.attachCaptureController(controller);
+    await _drainAutoStart();
+    await _waitFor(() => provider.isCapturing);
+
+    expect(controller.streamRecordingCount, 0);
+    expect(harness.platform.lastStreamDeviceUuid, RecordingMetaWearablesMockPlatform.uuid);
+    expect(harness.platform.frameCaptureCount, 1);
+    expect(controller.ingestedImages, hasLength(1));
+
+    provider.dispose();
+  });
+
+  test('auto-start waits for initial permission snapshot instead of hanging in permission request', () async {
+    await MetaWearablesDat.enableMockDevice(initiallyRegistered: true, initialPermissionsGranted: true);
+    await MetaWearablesDat.pairMockRayBanMeta();
+    await _makeMockEligible();
+    harness.platform.reportsActiveDevice = false;
+    harness.platform.blockCameraPermissionRequest = true;
+
+    final provider = MetaWearablesProvider();
+    final controller = RecordingCaptureController();
+    provider.attachCaptureController(controller);
+    await provider.init();
+    await _drainAutoStart();
+
+    expect(harness.platform.cameraPermissionRequestCount, 0);
+    expect(harness.platform.lastStreamDeviceUuid, RecordingMetaWearablesMockPlatform.uuid);
+    expect(harness.platform.frameCaptureCount, 1);
+    expect(controller.ingestedImages, hasLength(1));
+
+    provider.dispose();
+  });
+
+  test('auto-start streams directly when permission status is unavailable but glasses are visible', () async {
+    await MetaWearablesDat.enableMockDevice(initiallyRegistered: true, initialPermissionsGranted: true);
+    await MetaWearablesDat.pairMockRayBanMeta();
+    await _makeMockEligible();
+    harness.platform.reportsActiveDevice = false;
+    harness.platform.cameraPermissionStatusThrows = true;
+    harness.platform.blockCameraPermissionRequest = true;
+
+    final provider = MetaWearablesProvider();
+    await provider.init();
+    final controller = RecordingCaptureController();
+    provider.attachCaptureController(controller);
+    await _drainAutoStart();
+    await _waitFor(() => provider.isCapturing);
+
+    expect(provider.devices, isNotEmpty);
+    expect(provider.cameraPermissionState, MetaGlassesCameraPermissionState.unavailable);
+    expect(harness.platform.cameraPermissionRequestCount, 0);
+    expect(harness.platform.lastStreamDeviceUuid, RecordingMetaWearablesMockPlatform.uuid);
+    expect(harness.platform.frameCaptureCount, 1);
+    expect(controller.ingestedImages, hasLength(1));
+
+    provider.dispose();
+  });
+
+  test('stream start failure during initial capture schedules the bounded camera retry', () async {
+    await MetaWearablesDat.enableMockDevice(initiallyRegistered: true, initialPermissionsGranted: true);
+    await MetaWearablesDat.pairMockRayBanMeta();
+    await _makeMockEligible();
+    harness.platform.failStreamStartCount = 1;
+    harness.platform.leaveSessionOnFailedStart = true;
+
+    final provider = MetaWearablesProvider();
+    await provider.init();
+    final controller = RecordingCaptureController();
+    provider.attachCaptureController(controller);
+    await _drainAutoStart();
+    await _waitFor(() => provider.isCapturing);
+
+    expect(harness.platform.streamStartCallCount, 1);
+    expect(harness.platform.frameCaptureCount, 0);
+
+    await Future<void>.delayed(const Duration(seconds: 9));
+    await _drainAutoStart();
+
+    expect(harness.platform.streamStartCallCount, 2);
+    expect(harness.platform.stopStreamSessionCount, 1);
+    expect(harness.platform.frameCaptureCount, 1);
+    expect(controller.ingestedImages, hasLength(1));
+
+    provider.dispose();
+  });
+
+  test('old gesture prefs do not re-enable unsupported gestures', () async {
+    SharedPreferences.setMockInitialValues({
+      'metaGlassesGesturesEnabled': false,
+    });
+    await SharedPreferencesUtil.init();
+
+    final provider = MetaWearablesProvider();
+    await provider.init();
+
+    final prefs = await SharedPreferences.getInstance();
+    expect(prefs.getBool('metaGlassesGesturesEnabled'), isFalse);
+    expect(prefs.getBool('metaGlassesGesturesRuntimeFixMigrated'), isNull);
+
+    provider.dispose();
+  });
+
+  test('legacy gesture migration marker is ignored', () async {
+    SharedPreferences.setMockInitialValues({
+      'metaGlassesGesturesEnabled': false,
+      'metaGlassesGesturesRuntimeFixMigrated': true,
+    });
+    await SharedPreferencesUtil.init();
+
+    final provider = MetaWearablesProvider();
+    await provider.init();
+
+    final prefs = await SharedPreferences.getInstance();
+    expect(prefs.getBool('metaGlassesGesturesEnabled'), isFalse);
+    expect(prefs.getBool('metaGlassesGesturesRuntimeFixMigrated'), isTrue);
+
+    provider.dispose();
+  });
+}
+
+Future<void> _drainAutoStart() async {
+  for (var i = 0; i < 5; i++) {
+    await Future<void>.delayed(Duration.zero);
+  }
+}
+
+Future<void> _makeMockEligible() async {
+  await MetaWearablesDat.mockPowerOn(RecordingMetaWearablesMockPlatform.uuid);
+  await MetaWearablesDat.mockUnfold(RecordingMetaWearablesMockPlatform.uuid);
+  await MetaWearablesDat.mockDon(RecordingMetaWearablesMockPlatform.uuid);
+}
+
+Future<void> _waitFor(bool Function() condition) async {
+  for (var i = 0; i < 20; i++) {
+    if (condition()) return;
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+  }
+  fail('Timed out waiting for async auto-start to settle.');
+}
+
+class _BlockingCaptureController extends RecordingCaptureController {
+  final Completer<void> _neverReturns = Completer<void>();
+
+  @override
+  Future<void> streamRecording() async {
+    streamRecordingCount += 1;
+    return _neverReturns.future;
+  }
+}

--- a/app/test/unit/meta_glasses_background_stream_contract_test.dart
+++ b/app/test/unit/meta_glasses_background_stream_contract_test.dart
@@ -1,0 +1,27 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+String _read(String path) => File(path).readAsStringSync();
+
+void main() {
+  group('Meta glasses background stream contract', () {
+    test('background visual capture samples silent stream frames, not hardware still photos', () {
+      final provider = _read('lib/providers/meta_wearables_provider.dart');
+      // Native-pushed frame stream trigger (background-capable) + SDK-encoded
+      // frame pull. No shutter, no still-photo API, no suspending Dart timer.
+      expect(provider, contains('_service.videoFrames().listen'));
+      expect(provider, contains('MetaWearablesDat.captureLatestFrame'));
+      expect(provider, isNot(contains('MetaWearablesDat.capturePhoto(')));
+      expect(provider, isNot(contains('_pausePreviewBetweenFrames')));
+      expect(provider, isNot(contains('Timer.periodic(_photoInterval')));
+    });
+
+    test('glasses gesture bridge owns iOS Now Playing state while listening', () {
+      final appDelegate = _read('ios/Runner/AppDelegate.swift');
+      expect(appDelegate, contains('MPNowPlayingInfoCenter.default().nowPlayingInfo'));
+      expect(appDelegate, contains('MPNowPlayingInfoCenter.default().playbackState = .playing'));
+      expect(appDelegate, contains('MPNowPlayingInfoCenter.default().playbackState = .stopped'));
+    });
+  });
+}

--- a/app/test/unit/meta_glasses_continuous_vision_test.dart
+++ b/app/test/unit/meta_glasses_continuous_vision_test.dart
@@ -1,0 +1,28 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+String _read(String path) => File(path).readAsStringSync();
+
+/// Camera+Mic mode IS the vision mode (there is no separate continuous-vision
+/// toggle). Background capture streams video frames continuously and forwards
+/// one downscaled frame per user-selected capture interval.
+void main() {
+  group('Meta glasses vision = Camera+Mic continuous frame stream', () {
+    final provider = _read('lib/providers/meta_wearables_provider.dart');
+
+    test('no separate continuous-vision toggle', () {
+      expect(provider, isNot(contains('continuousVisionEnabled')));
+      expect(provider, isNot(contains('ContinuousVisionFrameGate')));
+    });
+
+    test('background frames are throttled to the capture interval', () {
+      // The frame handler carries a generation token so frames from a torn-down
+      // stream can't trigger stale captures.
+      expect(provider, contains('void _onVideoFrame(VideoFrame frame, int listenerGeneration)'));
+      expect(provider, contains('now.difference(last) < _photoInterval'));
+      expect(provider, contains('Future<void> _captureFrame()'));
+      expect(provider, contains('MetaWearablesDat.captureLatestFrame'));
+    });
+  });
+}

--- a/app/test/unit/meta_glasses_contract_behavior_test.dart
+++ b/app/test/unit/meta_glasses_contract_behavior_test.dart
@@ -1,0 +1,68 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:meta_wearables_dat_flutter/meta_wearables_dat_flutter.dart';
+import 'package:omi/l10n/app_localizations_en.dart';
+import 'package:omi/providers/meta_wearables_provider.dart';
+import 'package:omi/services/devices/meta_wearables_service.dart';
+import 'package:omi/utils/meta_wearables_device_label.dart';
+
+void main() {
+  group('MetaWearablesProvider.openCompatibilityUpdate', () {
+    const device = DeviceInfo(
+      uuid: 'mock-ray-ban',
+      name: 'Mock Ray-Ban',
+      kind: DeviceKind.rayBanMeta,
+      linkState: DeviceLinkState.connected,
+    );
+
+    for (final scenario in <_CompatibilityScenario>[
+      const _CompatibilityScenario(DeviceCompatibility.deviceUpdateRequired, firmwareCalls: 1),
+      const _CompatibilityScenario(DeviceCompatibility.sdkUpdateRequired, datAppCalls: 1),
+      const _CompatibilityScenario(DeviceCompatibility.compatible),
+      const _CompatibilityScenario(DeviceCompatibility.unknown),
+    ]) {
+      test('${scenario.compatibility} routes to the expected update action', () async {
+        final service = _RecordingMetaWearablesService();
+        final provider = MetaWearablesProvider(service: service)
+          ..compatibilityByUuid[device.uuid] = scenario.compatibility;
+
+        await provider.openCompatibilityUpdate(device);
+
+        expect(service.firmwareCalls, scenario.firmwareCalls);
+        expect(service.datAppCalls, scenario.datAppCalls);
+        provider.dispose();
+      });
+    }
+  });
+
+  test('metaWearablesDeviceKindLabel maps every DAT device kind to English l10n', () {
+    final l10n = AppLocalizationsEn();
+
+    expect(metaWearablesDeviceKindLabel(l10n, DeviceKind.rayBanMeta), l10n.metaGlassesTypeRayBanMeta);
+    expect(metaWearablesDeviceKindLabel(l10n, DeviceKind.rayBanDisplay), l10n.metaGlassesTypeRayBanDisplay);
+    expect(metaWearablesDeviceKindLabel(l10n, DeviceKind.oakleyMeta), l10n.metaGlassesTypeOakleyMeta);
+    expect(metaWearablesDeviceKindLabel(l10n, DeviceKind.unknown), l10n.metaGlasses);
+  });
+}
+
+class _CompatibilityScenario {
+  final DeviceCompatibility compatibility;
+  final int firmwareCalls;
+  final int datAppCalls;
+
+  const _CompatibilityScenario(this.compatibility, {this.firmwareCalls = 0, this.datAppCalls = 0});
+}
+
+class _RecordingMetaWearablesService extends MetaWearablesService {
+  int firmwareCalls = 0;
+  int datAppCalls = 0;
+
+  @override
+  Future<void> openFirmwareUpdate() async {
+    firmwareCalls += 1;
+  }
+
+  @override
+  Future<void> openDATGlassesAppUpdate() async {
+    datAppCalls += 1;
+  }
+}

--- a/app/test/unit/meta_glasses_device_sanitize_test.dart
+++ b/app/test/unit/meta_glasses_device_sanitize_test.dart
@@ -1,0 +1,83 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:meta_wearables_dat_flutter/meta_wearables_dat_flutter.dart';
+import 'package:omi/providers/meta_wearables_provider.dart';
+
+void main() {
+  group('MetaWearablesProvider.sanitizeDevices', () {
+    const named = DeviceInfo(uuid: 'AAAA-1111', name: '000R', kind: DeviceKind.rayBanMeta);
+
+    test('collapses duplicate uuids into one entry, preferring the named one', () {
+      const shadow = DeviceInfo(uuid: 'AAAA-1111', name: '', kind: DeviceKind.unknown);
+      final result = MetaWearablesProvider.sanitizeDevices([shadow, named]);
+      expect(result, hasLength(1));
+      expect(result.single.name, '000R');
+    });
+
+    test('drops identifier-named shadow entries of the same physical device', () {
+      const shadow = DeviceInfo(
+        uuid: 'BBBB-2222',
+        name: '9A3F0C71-4E2D-4B8A-9D11-C2E5F0A6B4D8',
+        kind: DeviceKind.unknown,
+      );
+      final result = MetaWearablesProvider.sanitizeDevices([named, shadow]);
+      expect(result, hasLength(1));
+      expect(result.single.name, '000R');
+    });
+
+    test('drops entries whose name is just their own uuid', () {
+      const shadow = DeviceInfo(uuid: 'CCCC-3333', name: 'CCCC-3333', kind: DeviceKind.unknown);
+      final result = MetaWearablesProvider.sanitizeDevices([named, shadow]);
+      expect(result, hasLength(1));
+      expect(result.single.name, '000R');
+    });
+
+    test('keeps a shadow-looking device when it is the only one (never hide the glasses)', () {
+      const only = DeviceInfo(
+        uuid: 'DDDD-4444',
+        name: '9A3F0C71-4E2D-4B8A-9D11-C2E5F0A6B4D8',
+        kind: DeviceKind.unknown,
+      );
+      final result = MetaWearablesProvider.sanitizeDevices([only]);
+      expect(result, hasLength(1));
+    });
+
+    test('keeps two genuinely different named devices (multi-device)', () {
+      const second = DeviceInfo(uuid: 'EEEE-5555', name: 'Eddy Ray-Ban 2', kind: DeviceKind.rayBanMeta);
+      final result = MetaWearablesProvider.sanitizeDevices([named, second]);
+      expect(result, hasLength(2));
+    });
+
+    test('keeps a paired-but-unlinked pair visible so its setup state can be shown', () {
+      // e.g. 00CQ before its Meta AI update: paired, named, link down.
+      const unlinked = DeviceInfo(
+        uuid: 'FFFF-6666',
+        name: '00CQ',
+        kind: DeviceKind.rayBanMeta,
+        linkState: DeviceLinkState.disconnected,
+      );
+      final result = MetaWearablesProvider.sanitizeDevices([named, unlinked]);
+      expect(result, hasLength(2), reason: 'Unlinked pairs stay listed with a setup hint, not hidden.');
+    });
+  });
+
+  group('MetaWearablesProvider.capturedAtFromQueueFile', () {
+    test('recovers capture time from queue filename', () {
+      final at = MetaWearablesProvider.capturedAtFromQueueFile('/docs/meta_glasses_photo_queue/1751500000000.jpg');
+      expect(at, DateTime.fromMillisecondsSinceEpoch(1751500000000));
+    });
+
+    test('returns null for non-numeric names so send time is used instead', () {
+      expect(MetaWearablesProvider.capturedAtFromQueueFile('/docs/meta_glasses_photo_queue/oops.jpg'), isNull);
+    });
+  });
+
+  group('DeviceLinkState.fromRaw', () {
+    test('parses wire values and defaults to unknown', () {
+      expect(DeviceLinkState.fromRaw('connected'), DeviceLinkState.connected);
+      expect(DeviceLinkState.fromRaw('connecting'), DeviceLinkState.connecting);
+      expect(DeviceLinkState.fromRaw('disconnected'), DeviceLinkState.disconnected);
+      expect(DeviceLinkState.fromRaw(null), DeviceLinkState.unknown);
+      expect(DeviceLinkState.fromRaw('bogus'), DeviceLinkState.unknown);
+    });
+  });
+}

--- a/app/test/unit/meta_glasses_display_view_test.dart
+++ b/app/test/unit/meta_glasses_display_view_test.dart
@@ -1,0 +1,52 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:omi/backend/schema/transcript_segment.dart';
+import 'package:omi/providers/meta_wearables_provider.dart';
+
+void main() {
+  group('Meta glasses display view', () {
+    test('builds status-only card when no transcript exists', () {
+      final view = MetaWearablesProvider.buildDisplayCaptureView(captureStateLine: 'Listening').toJson();
+
+      expect(view['type'], 'flexBox');
+      expect(view['padding'], 16);
+      expect(view['children'], [
+        {'type': 'text', 'text': 'Listening', 'style': 'heading'},
+      ]);
+    });
+
+    test('adds latest transcript snippet and truncates it for the lens', () {
+      final longText = 'This is a long transcript segment that should be compact enough for the small display '
+          'surface instead of wrapping forever on the lens.';
+
+      final view = MetaWearablesProvider.buildDisplayCaptureView(
+        captureStateLine: 'Listening',
+        segments: [
+          _segment('older text'),
+          _segment(longText),
+        ],
+      ).toJson();
+
+      final children = view['children']! as List<Object?>;
+      expect(children, hasLength(2));
+      expect(children.last, {
+        'type': 'text',
+        'text': 'This is a long transcript segment that should be compact enough for the small...',
+        'style': 'body',
+        'color': 'secondary',
+      });
+    });
+  });
+}
+
+TranscriptSegment _segment(String text) {
+  return TranscriptSegment(
+    id: text,
+    text: text,
+    speaker: 'SPEAKER_00',
+    isUser: false,
+    personId: null,
+    start: 0,
+    end: 1,
+    translations: [],
+  );
+}

--- a/app/test/unit/meta_glasses_health_test.dart
+++ b/app/test/unit/meta_glasses_health_test.dart
@@ -1,0 +1,28 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:meta_wearables_dat_flutter/meta_wearables_dat_flutter.dart';
+import 'package:omi/providers/meta_wearables_provider.dart';
+
+void main() {
+  group('Meta glasses health mapping', () {
+    test('maps DAT thermal and hinge session errors to user-facing health states', () {
+      expect(
+        MetaGlassesHealth.fromSessionError(
+          const SessionError(code: DatErrorCodes.thermalCritical, message: 'hot'),
+        ),
+        MetaGlassesHealth.overheating,
+      );
+      expect(
+        MetaGlassesHealth.fromSessionError(
+          const SessionError(code: DatErrorCodes.hingesClosed, message: 'folded'),
+        ),
+        MetaGlassesHealth.foldedClosed,
+      );
+      expect(
+        MetaGlassesHealth.fromSessionError(
+          const SessionError(code: DatErrorCodes.timeout, message: 'timeout'),
+        ),
+        isNull,
+      );
+    });
+  });
+}

--- a/app/test/unit/meta_glasses_relay_queue_test.dart
+++ b/app/test/unit/meta_glasses_relay_queue_test.dart
@@ -1,0 +1,171 @@
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:omi/backend/http/api/conversations.dart';
+import 'package:omi/services/meta_wearables/meta_capture_diagnostics.dart';
+import 'package:omi/services/meta_wearables/meta_capture_queue.dart';
+
+import '../support/meta_wearables_mock_harness.dart';
+
+void main() {
+  late Directory dir;
+  late MetaCaptureQueue queue;
+
+  setUp(() async {
+    dir = await Directory.systemTemp.createTemp('meta_capture_queue_test_');
+    queue = MetaCaptureQueue(rootDirectory: dir);
+  });
+
+  tearDown(() async {
+    if (await dir.exists()) {
+      await dir.delete(recursive: true);
+    }
+  });
+
+  test('persists pending frames across queue recreation', () async {
+    final first = await queue.enqueue(
+      bytes: Uint8List.fromList(utf8.encode('frame-a')),
+      capturedAt: DateTime.utc(2026, 7, 5, 1, 2, 3),
+      deviceUuid: 'glasses-1',
+      deviceName: 'Meta Glasses',
+    );
+
+    final reopened = MetaCaptureQueue(rootDirectory: dir);
+    final pending = await reopened.pending(limit: 10);
+
+    expect(pending, hasLength(1));
+    expect(pending.single.id, first.id);
+    expect(pending.single.deviceUuid, 'glasses-1');
+    expect(pending.single.sha256, isNotEmpty);
+  });
+
+  test('markUploaded removes only matching frame', () async {
+    final a = await queue.enqueue(
+      bytes: Uint8List.fromList([1]),
+      capturedAt: DateTime.utc(2026, 7, 5, 1),
+      deviceUuid: 'glasses-1',
+    );
+    final b = await queue.enqueue(
+      bytes: Uint8List.fromList([2]),
+      capturedAt: DateTime.utc(2026, 7, 5, 2),
+      deviceUuid: 'glasses-1',
+    );
+
+    await queue.markUploaded(a.id);
+    final pending = await queue.pending(limit: 10);
+
+    expect(pending.map((item) => item.id), [b.id]);
+  });
+
+  test('enqueue does not leak the frame JPEG when the ledger append fails', () async {
+    // Review thread: the frame file was written before the queue-file append;
+    // an append failure (disk full, IO error) orphaned the JPEG forever.
+    // Force the failure by occupying the ledger path with a directory.
+    await Directory('${dir.path}/meta_capture_queue.jsonl').create(recursive: true);
+
+    await expectLater(
+      queue.enqueue(
+        bytes: Uint8List.fromList([9, 9, 9]),
+        capturedAt: DateTime.utc(2026, 7, 5, 4),
+        deviceUuid: 'glasses-1',
+      ),
+      throwsA(isA<FileSystemException>()),
+    );
+
+    final frames = Directory('${dir.path}/meta_capture_frames');
+    final leaked = frames.existsSync() ? frames.listSync().where((e) => e.path.endsWith('.jpg')).toList() : const [];
+    expect(leaked, isEmpty, reason: 'a failed enqueue must delete the frame file it wrote');
+  });
+
+  test('uploaded ledger compacts instead of growing forever', () async {
+    // Review thread: meta_capture_queue.jsonl and meta_capture_uploaded.txt
+    // were append-only for the life of the install.
+    final compacting = MetaCaptureQueue(rootDirectory: dir, compactionThreshold: 2);
+    final a = await compacting.enqueue(
+        bytes: Uint8List.fromList([1]), capturedAt: DateTime.utc(2026, 7, 5, 1), deviceUuid: 'g');
+    final b = await compacting.enqueue(
+        bytes: Uint8List.fromList([2]), capturedAt: DateTime.utc(2026, 7, 5, 2), deviceUuid: 'g');
+    final c = await compacting.enqueue(
+        bytes: Uint8List.fromList([3]), capturedAt: DateTime.utc(2026, 7, 5, 3), deviceUuid: 'g');
+
+    await compacting.markUploaded(a.id);
+    await compacting.markUploaded(b.id); // hits threshold -> compacts
+
+    final ledger = await File('${dir.path}/meta_capture_queue.jsonl').readAsString();
+    expect(ledger, isNot(contains(a.id)), reason: 'uploaded entries must be rewritten out of the ledger');
+    expect(ledger, isNot(contains(b.id)));
+    expect(ledger, contains(c.id), reason: 'pending entries must survive compaction');
+    expect(File('${dir.path}/meta_capture_uploaded.txt').existsSync(), isFalse,
+        reason: 'the uploaded ledger is redundant after compaction');
+
+    final pending = await compacting.pending(limit: 10);
+    expect(pending.map((i) => i.id), [c.id]);
+  });
+
+  test('diagnostics copyWith can clear nullable fields back to null', () {
+    // Review thread: ??-based copyWith made an explicit null a no-op, so
+    // stale lastUploadStatus/session state could never be cleared.
+    final diag = const MetaCaptureDiagnostics().copyWith(
+      lastUploadStatus: 'upload_failed',
+      streamState: 'streaming',
+      lastFrameAt: DateTime.utc(2026, 7, 5),
+    );
+    final cleared = diag.copyWith(lastUploadStatus: null, lastFrameAt: null);
+
+    expect(cleared.lastUploadStatus, isNull);
+    expect(cleared.lastFrameAt, isNull);
+    expect(cleared.streamState, 'streaming', reason: 'omitted fields must still be preserved');
+  });
+
+  test('cache upload payload includes idempotency metadata', () async {
+    final source = File('lib/backend/http/api/conversations.dart').readAsStringSync();
+
+    expect(source, contains('device_uuid'));
+    expect(source, contains('frame_sha256'));
+    expect(source, contains('captured_at'));
+    expect(source, contains('conversation_id'));
+  });
+
+  test('cache upload payload helper propagates queue metadata', () {
+    final capturedAt = DateTime.utc(2026, 7, 5, 3, 4, 5);
+    final payload = buildMetaWearablesPhotoCachePayload(
+      Uint8List.fromList([1, 2, 3]),
+      capturedAt: capturedAt,
+      conversationId: 'conversation-1',
+      deviceUuid: 'glasses-1',
+      deviceName: 'Meta Glasses',
+      frameSha256: 'abc123',
+    );
+
+    expect(payload['base64'], base64Encode([1, 2, 3]));
+    expect(payload['captured_at'], capturedAt.toIso8601String());
+    expect(payload['conversation_id'], 'conversation-1');
+    expect(payload['device_uuid'], 'glasses-1');
+    expect(payload['device_name'], 'Meta Glasses');
+    expect(payload['frame_sha256'], 'abc123');
+  });
+
+  test('recording capture controller retains cache metadata', () async {
+    final controller = RecordingCaptureController();
+
+    await controller.cacheCapturedImage(
+      Uint8List.fromList([4, 5, 6]),
+      capturedAt: DateTime.utc(2026, 7, 5, 6),
+      deviceUuid: 'glasses-2',
+      deviceName: 'Meta Glasses 2',
+      frameSha256: 'def456',
+    );
+
+    expect(controller.deviceUuidValues, ['glasses-2']);
+    expect(controller.deviceNameValues, ['Meta Glasses 2']);
+    expect(controller.frameSha256Values, ['def456']);
+  });
+
+  test('meta capture enqueue does not bypass the durable queue', () {
+    final source = File('lib/providers/meta_wearables_provider.dart').readAsStringSync();
+
+    expect(source, isNot(contains('unawaited(_cachePhotoBytes')));
+  });
+}

--- a/app/test/unit/meta_glasses_relay_queue_test.dart
+++ b/app/test/unit/meta_glasses_relay_queue_test.dart
@@ -3,11 +3,8 @@ import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:flutter_test/flutter_test.dart';
-import 'package:omi/backend/http/api/conversations.dart';
 import 'package:omi/services/meta_wearables/meta_capture_diagnostics.dart';
 import 'package:omi/services/meta_wearables/meta_capture_queue.dart';
-
-import '../support/meta_wearables_mock_harness.dart';
 
 void main() {
   late Directory dir;
@@ -117,50 +114,6 @@ void main() {
     expect(cleared.lastUploadStatus, isNull);
     expect(cleared.lastFrameAt, isNull);
     expect(cleared.streamState, 'streaming', reason: 'omitted fields must still be preserved');
-  });
-
-  test('cache upload payload includes idempotency metadata', () async {
-    final source = File('lib/backend/http/api/conversations.dart').readAsStringSync();
-
-    expect(source, contains('device_uuid'));
-    expect(source, contains('frame_sha256'));
-    expect(source, contains('captured_at'));
-    expect(source, contains('conversation_id'));
-  });
-
-  test('cache upload payload helper propagates queue metadata', () {
-    final capturedAt = DateTime.utc(2026, 7, 5, 3, 4, 5);
-    final payload = buildMetaWearablesPhotoCachePayload(
-      Uint8List.fromList([1, 2, 3]),
-      capturedAt: capturedAt,
-      conversationId: 'conversation-1',
-      deviceUuid: 'glasses-1',
-      deviceName: 'Meta Glasses',
-      frameSha256: 'abc123',
-    );
-
-    expect(payload['base64'], base64Encode([1, 2, 3]));
-    expect(payload['captured_at'], capturedAt.toIso8601String());
-    expect(payload['conversation_id'], 'conversation-1');
-    expect(payload['device_uuid'], 'glasses-1');
-    expect(payload['device_name'], 'Meta Glasses');
-    expect(payload['frame_sha256'], 'abc123');
-  });
-
-  test('recording capture controller retains cache metadata', () async {
-    final controller = RecordingCaptureController();
-
-    await controller.cacheCapturedImage(
-      Uint8List.fromList([4, 5, 6]),
-      capturedAt: DateTime.utc(2026, 7, 5, 6),
-      deviceUuid: 'glasses-2',
-      deviceName: 'Meta Glasses 2',
-      frameSha256: 'def456',
-    );
-
-    expect(controller.deviceUuidValues, ['glasses-2']);
-    expect(controller.deviceNameValues, ['Meta Glasses 2']);
-    expect(controller.frameSha256Values, ['def456']);
   });
 
   test('meta capture enqueue does not bypass the durable queue', () {

--- a/app/test/unit/meta_glasses_runtime_regression_test.dart
+++ b/app/test/unit/meta_glasses_runtime_regression_test.dart
@@ -147,23 +147,55 @@ void main() {
       expect(eventHandler, contains('_completePhotoUploadAck'));
     });
 
-    test('glasses capture streams photos and BT-mic audio over the transcription socket (prod path)', () {
+    test('glasses capture never falls back to the iPhone mic while mixing media playback', () {
       // The REST photo-cache endpoint (v1/meta-wearables/photos/cache) exists
       // only in the local repo backend — api.omi.me returns 404 for it, so
       // every REST upload fails and photos never reach history (observed
       // 2026-07-05: 4 frames stuck in the sync queue). The only ingestion
       // path deployed on prod is the transcription socket: image_chunk
-      // messages for photos and PCM16 audio for STT. Audio must be routed to
-      // the glasses' Bluetooth mic (configureForBluetooth) so "Mic" means the
-      // glasses mic, not the phone mic.
+      // messages for photos and PCM16 audio for STT. Meta DAT does not expose
+      // microphone frames, so Omi must require the paired glasses' HFP input
+      // and must never silently fall back to the built-in iPhone microphone.
       final provider = _read('lib/providers/meta_wearables_provider.dart');
       final controller = _read('lib/services/capture/capture_controller.dart');
+      final appDelegate = _read('ios/Runner/AppDelegate.swift');
+      final backgroundStreaming = _read(
+        'third_party/meta_wearables_dat_flutter/ios/meta_wearables_dat_flutter/Sources/'
+        'meta_wearables_dat_flutter/BackgroundStreamingController.swift',
+      );
+      final glassesAudioSession = _functionBody(appDelegate, 'private func configureMetaGlassesCaptureSession');
       final startCapture = _asyncMethodBody(provider, 'Future<bool> startCapture');
       final stopCapture = _asyncMethodBody(provider, 'Future<void> stopCapture');
       final flushPhotoQueue = _functionBody(provider, 'Future<void> flushPhotoQueue');
 
-      expect(startCapture, contains('configureForBluetooth'),
-          reason: 'audio session must route to the glasses BT mic before streaming');
+      expect(startCapture, contains('configureForMetaGlassesCapture'));
+      expect(startCapture, contains('getCurrentAudioRoute'));
+      expect(startCapture, contains("route?['glassesInput']"));
+      expect(startCapture, contains("route?['input']"));
+      expect(startCapture, contains("route?['output']"));
+      expect(startCapture, contains(r'audio-stream-started input=$input output=$output'));
+      expect(startCapture, isNot(contains('configureForBluetooth')));
+      expect(startCapture.indexOf('configureForMetaGlassesCapture'), lessThan(startCapture.indexOf('streamRecording')));
+      expect(startCapture.indexOf('streamRecording'), lessThan(startCapture.indexOf('_startPhotoLoop')),
+          reason: 'Meta requires HFP audio to settle before the DAT camera stream starts.');
+      expect(startCapture, contains('stopStreamRecording'));
+      expect(provider, contains("call.method == 'onAudioRouteChanged'"));
+      expect(provider, contains('audio-route-lost'));
+      for (final nativeSource in [glassesAudioSession, backgroundStreaming]) {
+        expect(nativeSource, contains('.mixWithOthers'));
+        expect(nativeSource, contains('.allowBluetoothHFP'));
+        expect(nativeSource, contains('.bluetoothHFP'));
+        expect(nativeSource, contains('mode: .videoRecording'));
+        expect(nativeSource, contains('setPreferredInput'));
+        expect(nativeSource, isNot(contains('.builtInMic')));
+      }
+      expect(glassesAudioSession, contains('glassesMicrophoneUnavailable'));
+      expect(glassesAudioSession, contains('currentAudioRoute()'));
+      expect(appDelegate, contains('AVAudioSession.sharedInstance().currentRoute'));
+      expect(appDelegate, contains('AVAudioSession.Port'));
+      expect(glassesAudioSession, isNot(contains('.defaultToSpeaker')));
+      expect(appDelegate, contains('call.method == "configureForBluetooth"'),
+          reason: 'non-Meta voice-recorder flows still use the legacy Bluetooth route');
       expect(startCapture, contains('streamRecording'),
           reason: 'the transcription socket is the only prod transport for photos + audio');
       expect(stopCapture, contains('stopStreamRecording'), reason: 'capture stop must close the audio stream');

--- a/app/test/unit/meta_glasses_runtime_regression_test.dart
+++ b/app/test/unit/meta_glasses_runtime_regression_test.dart
@@ -1,0 +1,311 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+String _read(String path) => File(path).readAsStringSync();
+
+String _functionBody(String source, String functionName) {
+  final start = source.indexOf(functionName);
+  if (start < 0) {
+    fail('Missing function $functionName');
+  }
+
+  final open = source.indexOf('{', start);
+  if (open < 0) {
+    fail('Missing opening brace for $functionName');
+  }
+
+  var depth = 0;
+  for (var i = open; i < source.length; i++) {
+    final char = source.codeUnitAt(i);
+    if (char == 123) depth++;
+    if (char == 125) depth--;
+    if (depth == 0) return source.substring(open, i + 1);
+  }
+
+  fail('Missing closing brace for $functionName');
+}
+
+String _asyncMethodBody(String source, String functionName) {
+  final start = source.indexOf(functionName);
+  if (start < 0) {
+    fail('Missing function $functionName');
+  }
+
+  final asyncOpen = source.indexOf(') async {', start);
+  if (asyncOpen < 0) {
+    fail('Missing async opening brace for $functionName');
+  }
+
+  final open = source.indexOf('{', asyncOpen);
+  var depth = 0;
+  for (var i = open; i < source.length; i++) {
+    final char = source.codeUnitAt(i);
+    if (char == 123) depth++;
+    if (char == 125) depth--;
+    if (depth == 0) return source.substring(open, i + 1);
+  }
+
+  fail('Missing closing brace for $functionName');
+}
+
+String _getterExpression(String source, String getterName) {
+  final start = source.indexOf(getterName);
+  if (start < 0) {
+    fail('Missing getter $getterName');
+  }
+
+  final end = source.indexOf(';', start);
+  if (end < 0) {
+    fail('Missing getter terminator for $getterName');
+  }
+
+  return source.substring(start, end + 1);
+}
+
+void main() {
+  group('Meta glasses runtime regressions', () {
+    test('background camera capture does not use shuttered still-photo loop', () {
+      final provider = _read('lib/providers/meta_wearables_provider.dart');
+      final automaticLoop = _functionBody(provider, '_startPhotoLoop');
+
+      // Background capture is driven by the native-pushed videoFramesStream
+      // (keeps firing while backgrounded), not a Dart Timer (which suspends).
+      // Shutter-free: continuous session, no per-frame pause/resume, no
+      // hardware still capture.
+      expect(provider, contains('videoFramesStream'),
+          reason: 'background capture must subscribe to the DAT video frames (works backgrounded)');
+      expect(provider, contains('_service.videoFrames().listen'),
+          reason: 'the frame stream is the background-capable capture trigger');
+      expect(provider, isNot(contains('Timer.periodic(_photoInterval')),
+          reason: 'a Dart timer is suspended in the background; use the native frame stream instead');
+      expect(provider, isNot(contains('_pausePreviewBetweenFrames')),
+          reason: 'per-frame pause/resume produced the shutter/snapshot cadence and must be gone');
+      expect(automaticLoop, isNot(contains('capturePhoto')),
+          reason: 'automatic background capture must not trigger the glasses still-photo shutter');
+      expect(automaticLoop, isNot(contains('takePicture')),
+          reason: 'automatic background capture must not call any hardware still capture API');
+    });
+
+    test('video streaming errors are caught and moved to recoverable state', () {
+      final provider = _read('lib/providers/meta_wearables_provider.dart');
+
+      expect(provider, contains('videoStreamingError'));
+      expect(provider, contains('MetaGlassStreamDiag'));
+      expect(provider, contains('recoverFromVideoStreamingError'));
+      expect(provider, contains('streamFailureCount'));
+      expect(provider, contains('micOnlyFallback'));
+    });
+
+    test('runtime proof events persist in the app container when device logs are unavailable', () {
+      final provider = _read('lib/providers/meta_wearables_provider.dart');
+
+      expect(provider, contains('meta_glasses_runtime_proof.log'));
+      expect(provider, contains('_runtimeProofLogFile'));
+      expect(provider, contains('_runtimeProofLogMaxBytes'));
+      expect(provider, contains('_appendRuntimeProof'));
+      expect(provider, contains('MetaGlassStreamDiag stream-started'));
+      expect(provider, contains('MetaGlassStreamDiag frame-event'));
+      expect(provider, contains('MetaGlassStreamDiag camera-unavailable'));
+      expect(provider, contains('gestures=media-remote'));
+      expect(provider, contains('writeAsStringSync'));
+    });
+
+    test('runtime proof log explains why auto capture did not start', () {
+      final provider = _read('lib/providers/meta_wearables_provider.dart');
+
+      expect(provider, contains('MetaGlassRuntimeProof registration-state'));
+      expect(provider, contains('MetaGlassRuntimeProof devices count='));
+      expect(provider, contains('MetaGlassRuntimeProof active-device'));
+      expect(provider, contains('MetaGlassRuntimeProof auto-start-skip'));
+      expect(provider, contains('MetaGlassRuntimeProof auto-starting'));
+    });
+
+    test('runtime proof log reports capture mode and camera stream gates', () {
+      final provider = _read('lib/providers/meta_wearables_provider.dart');
+
+      expect(provider, contains('MetaGlassRuntimeProof start-capture'));
+      expect(provider, contains('MetaGlassStreamDiag start-photo-loop'));
+      expect(provider, contains('cameraPermission='));
+      expect(provider, contains('captureMode='));
+    });
+
+    test('photo queue waits for server-side cache ack before deleting local frames', () {
+      final provider = _read('lib/providers/meta_wearables_provider.dart');
+      final controller = _read('lib/services/capture/capture_controller.dart');
+      final flushPhotoQueue = _functionBody(provider, 'Future<void> flushPhotoQueue');
+      final ingestCapturedImage = _asyncMethodBody(controller, 'Future<bool> ingestCapturedImage');
+      final eventHandler = _functionBody(controller, 'void onMessageEventReceived');
+
+      expect(flushPhotoQueue, contains('if (!sent)'));
+      expect(flushPhotoQueue, contains("lastUploadStatus: 'upload_failed'"));
+      expect(flushPhotoQueue, contains('break;'));
+      expect(controller, contains('_pendingPhotoUploadAcks'));
+      expect(controller, contains('_pendingPhotoUploadIdsByPermanent'));
+      expect(ingestCapturedImage, contains('_waitForPhotoUploadAck'));
+      expect(eventHandler, contains('PhotoProcessingEvent'));
+      expect(eventHandler, contains('_completePhotoUploadAck'));
+    });
+
+    test('glasses capture streams photos and BT-mic audio over the transcription socket (prod path)', () {
+      // The REST photo-cache endpoint (v1/meta-wearables/photos/cache) exists
+      // only in the local repo backend — api.omi.me returns 404 for it, so
+      // every REST upload fails and photos never reach history (observed
+      // 2026-07-05: 4 frames stuck in the sync queue). The only ingestion
+      // path deployed on prod is the transcription socket: image_chunk
+      // messages for photos and PCM16 audio for STT. Audio must be routed to
+      // the glasses' Bluetooth mic (configureForBluetooth) so "Mic" means the
+      // glasses mic, not the phone mic.
+      final provider = _read('lib/providers/meta_wearables_provider.dart');
+      final controller = _read('lib/services/capture/capture_controller.dart');
+      final startCapture = _asyncMethodBody(provider, 'Future<bool> startCapture');
+      final stopCapture = _asyncMethodBody(provider, 'Future<void> stopCapture');
+      final flushPhotoQueue = _functionBody(provider, 'Future<void> flushPhotoQueue');
+
+      expect(startCapture, contains('configureForBluetooth'),
+          reason: 'audio session must route to the glasses BT mic before streaming');
+      expect(startCapture, contains('streamRecording'),
+          reason: 'the transcription socket is the only prod transport for photos + audio');
+      expect(stopCapture, contains('stopStreamRecording'), reason: 'capture stop must close the audio stream');
+      expect(flushPhotoQueue, contains('_cachePhotoBytes'));
+      expect(provider, contains('ingestCapturedImage'),
+          reason: 'photos go out as image_chunk socket messages, the path prod actually accepts');
+      expect(provider, isNot(contains('cacheCapturedImage')),
+          reason: 'REST photo cache is not deployed on api.omi.me; uploads 404 and strand the queue');
+      expect(controller, contains('Future<bool> ingestCapturedImage'));
+    });
+
+    test('meta capture only enters capturing state after camera stream is live', () {
+      final provider = _read('lib/providers/meta_wearables_provider.dart');
+      final startCapture = _asyncMethodBody(provider, 'Future<bool> startCapture');
+
+      expect(provider, contains('_cameraCaptureStreamReady'));
+      expect(provider, contains('_firstQueuedFrameCompleter'));
+      expect(provider, contains('_streamGeneration'));
+      expect(provider, contains('final generation = _streamGeneration'));
+      expect(provider, contains('generation != _streamGeneration'));
+      expect(provider, contains('_waitForFirstQueuedFrame'));
+      expect(startCapture.indexOf('_waitForFirstQueuedFrame'), lessThan(startCapture.indexOf('isCapturing = true')));
+      expect(startCapture.indexOf('_cameraCaptureStreamReady'), lessThan(startCapture.indexOf('isCapturing = true')));
+      expect(startCapture, contains('MetaWearablesDat.disableBackgroundStreaming'));
+      expect(startCapture, contains('return false'));
+    });
+
+    test('meta capture recovery does not leave dead camera as active capture', () {
+      final provider = _read('lib/providers/meta_wearables_provider.dart');
+      final recover = _asyncMethodBody(provider, 'Future<void> recoverFromVideoStreamingError');
+      final captureFrame = _asyncMethodBody(provider, 'Future<void> _captureFrame');
+      final autoStart = _asyncMethodBody(provider, 'Future<void> _maybeAutoStartCapture');
+      final setCaptureInterval = _asyncMethodBody(provider, 'Future<void> setCaptureInterval');
+
+      expect(recover, contains('isCapturing = false'));
+      expect(recover, contains('MetaWearablesDat.disableBackgroundStreaming'));
+      expect(captureFrame, contains('unawaited(flushPhotoQueue())'));
+      expect(captureFrame, isNot(contains('await flushPhotoQueue()')));
+      expect(autoStart, contains('final started = await startCapture(controller)'));
+      expect(autoStart, contains('auto-start-failed'));
+      expect(autoStart, contains('_scheduleAutoStartRetry()'));
+      expect(provider, contains('void _scheduleAutoStartRetry()'));
+      expect(provider, contains('_cancelAutoStartRetry()'));
+      expect(setCaptureInterval, contains('_evaluateCaptureWatchdog()'));
+    });
+
+    test('not-ready polling remains reachable for paired but disconnected devices', () {
+      final provider = _read('lib/providers/meta_wearables_provider.dart');
+      final hasCandidate = _getterExpression(provider, 'bool get _hasSessionCandidateDevice');
+      final shouldPoll = _getterExpression(provider, 'bool get _shouldPollNotReady');
+
+      expect(hasCandidate, isNot(contains('devices.isNotEmpty')));
+      expect(shouldPoll, contains('devices.isNotEmpty'));
+      expect(shouldPoll, contains('!_hasSessionCandidateDevice'));
+      expect(shouldPoll.indexOf('devices.isNotEmpty'), lessThan(shouldPoll.indexOf('!_hasSessionCandidateDevice')));
+    });
+
+    test('video frame listener drops events from stale stream generations', () {
+      final provider = _read('lib/providers/meta_wearables_provider.dart');
+      final onVideoFrame = _functionBody(provider, 'void _onVideoFrame');
+
+      expect(provider, contains('final listenerGeneration = _streamGeneration'));
+      expect(provider, contains('_onVideoFrame(frame, listenerGeneration)'));
+      expect(provider, contains('void _onVideoFrame(VideoFrame frame, int listenerGeneration)'));
+      expect(onVideoFrame, contains('listenerGeneration != _streamGeneration'));
+      expect(onVideoFrame.indexOf('listenerGeneration != _streamGeneration'),
+          lessThan(onVideoFrame.indexOf('_lastFrameForwardedAt = now')));
+      expect(onVideoFrame, contains('frame-event-stale'));
+    });
+
+    test('retry exhaustion schedules connected auto-start recovery', () {
+      final provider = _read('lib/providers/meta_wearables_provider.dart');
+      final recover = _asyncMethodBody(provider, 'Future<void> recoverFromVideoStreamingError');
+
+      expect(recover, contains('_scheduleAutoStartRetry()'));
+      expect(recover.indexOf('_scheduleAutoStartRetry()'), greaterThan(recover.indexOf('isCapturing = false')));
+      expect(recover, contains('recover-exhausted-autostart-retry'));
+      expect(recover, contains('_scheduleNotReadyRefresh()'));
+    });
+
+    test('frame in-flight guard belongs to the generation that set it', () {
+      final provider = _read('lib/providers/meta_wearables_provider.dart');
+      final captureFrame = _asyncMethodBody(provider, 'Future<void> _captureFrame');
+
+      expect(provider, contains('int? _frameForwardInFlightGeneration'));
+      expect(captureFrame, contains('_frameForwardInFlightGeneration = generation'));
+      expect(captureFrame, contains('_frameForwardInFlightGeneration == generation'));
+      expect(captureFrame, contains('_frameForwardInFlightGeneration = null'));
+      expect(captureFrame.indexOf('_frameForwardInFlightGeneration == generation'),
+          lessThan(captureFrame.indexOf('_frameForwardInFlight = false')));
+    });
+
+    test('glasses tap gestures ride the media-remote bridge while capture holds the audio session', () {
+      // The DAT SDK has no gesture API. Stalk taps arrive as Bluetooth AVRCP
+      // media commands, which iOS only delivers to the current Now Playing
+      // app with an active audio session — capture provides both. The bridge
+      // is instrumented end to end (OmiMetaGestures native logs,
+      // MetaGlassGestureDiag Dart proof events) so hardware runs show
+      // whether events actually arrive instead of silently claiming support.
+      final appDelegate = _read('ios/Runner/AppDelegate.swift');
+      expect(appDelegate, contains('com.omi/meta_gestures'));
+      expect(appDelegate, contains('OmiMetaGestures'));
+      expect(appDelegate, contains('MPRemoteCommandCenter.shared()'));
+      expect(appDelegate, contains('removeTarget(nil)'), reason: 'remote command targets must not double-register');
+      expect(appDelegate, contains('togglePlayPauseCommand'));
+      expect(appDelegate, contains('nextTrackCommand'));
+      expect(appDelegate, contains('invokeMethod("onGesture"'));
+      expect(appDelegate, contains('MPNowPlayingInfoCenter.default().playbackState = .playing'));
+      expect(appDelegate, contains('MPNowPlayingInfoCenter.default().playbackState = .stopped'));
+
+      final provider = _read('lib/providers/meta_wearables_provider.dart');
+      final startCapture = _asyncMethodBody(provider, 'Future<bool> startCapture');
+      final stopCapture = _asyncMethodBody(provider, 'Future<void> stopCapture');
+      expect(provider, contains("MethodChannel('com.omi/meta_gestures')"));
+      expect(startCapture, contains('_startGestureListening'),
+          reason: 'gesture delivery needs the capture audio session; start them together');
+      expect(stopCapture, contains('_stopGestureListening'));
+      expect(provider, contains('MetaGlassGestureDiag listening-started'));
+      expect(provider, contains('MetaGlassGestureDiag received'));
+      expect(provider, contains('_gestureDebounce'),
+          reason: 'one physical tap can double-fire play + togglePlayPause; collapse duplicates');
+      expect(provider, contains('_gestureActivationGrace'),
+          reason: 'claiming the BT route fires a phantom AVRCP pause ~400ms after listening starts '
+              '(observed on-device 2026-07-05 15:34:36); it must not toggle capture off');
+      expect(provider, contains('phantom'),
+          reason: 'the grace-window discard must be logged so hardware runs can tell phantom from real taps');
+    });
+
+    test('meta capture diagnostics expose relay health fields', () {
+      final source = _read('lib/services/meta_wearables/meta_capture_diagnostics.dart');
+      final provider = _read('lib/providers/meta_wearables_provider.dart');
+
+      expect(source, contains('lastFrameAt'));
+      expect(source, contains('pendingQueueCount'));
+      expect(source, contains('lastUploadStatus'));
+      expect(source, contains('streamState'));
+      expect(source, contains('sessionState'));
+      expect(source, contains('failedUploadCount'));
+      expect(provider, contains("'enqueue_failed'"));
+      expect(provider, contains('_lastDiagnosticsLogAt'));
+      expect(provider, contains('const Duration(seconds: 5)'));
+      expect(provider, contains('Meta capture diagnostics:'));
+    });
+  });
+}

--- a/app/test/unit/meta_glasses_runtime_regression_test.dart
+++ b/app/test/unit/meta_glasses_runtime_regression_test.dart
@@ -65,6 +65,24 @@ String _getterExpression(String source, String getterName) {
 
 void main() {
   group('Meta glasses runtime regressions', () {
+    test('vendored DAT plugin records auditable upstream provenance', () {
+      final provenance = _read('third_party/meta_wearables_dat_flutter/UPSTREAM.md');
+
+      expect(provenance, contains('f13cf7e2bfbbc25bdbd42ca4972be1834c724624'));
+      expect(provenance, contains('15 modified files'));
+      expect(provenance, contains('Why vendored'));
+    });
+
+    test('Meta photo ingestion uses only the deployed websocket transport', () {
+      final conversationsApi = _read('lib/backend/http/api/conversations.dart');
+      final controller = _read('lib/services/capture/capture_controller.dart');
+
+      expect(conversationsApi, isNot(contains('v1/meta-wearables/photos/cache')));
+      expect(conversationsApi, isNot(contains('cacheMetaWearablesPhoto')));
+      expect(controller, isNot(contains('cacheCapturedImage')));
+      expect(controller, contains("'type': 'image_chunk'"));
+    });
+
     test('background camera capture does not use shuttered still-photo loop', () {
       final provider = _read('lib/providers/meta_wearables_provider.dart');
       final automaticLoop = _functionBody(provider, '_startPhotoLoop');

--- a/app/test/unit/meta_glasses_session_pause_test.dart
+++ b/app/test/unit/meta_glasses_session_pause_test.dart
@@ -1,0 +1,40 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+String _read(String path) => File(path).readAsStringSync();
+
+/// The plan-02 "pause/resume between still-photo samples" design produced a
+/// shuttered snapshot cadence and `SessionError(videoStreamingError)`. It was
+/// superseded by a single continuous video-frame stream (runtime-stabilization
+/// plan). These assertions lock in the continuous design so the shuttered
+/// pause/resume loop cannot come back.
+void main() {
+  group('Meta glasses continuous stream (superseded pause/resume)', () {
+    final provider = _read('lib/providers/meta_wearables_provider.dart');
+    final service = _read('lib/services/devices/meta_wearables_service.dart');
+
+    test('background capture uses one continuous never-paused session', () {
+      expect(provider, contains('_service.videoFrames().listen'),
+          reason: 'native-pushed frame stream is the background-capable trigger');
+      expect(provider, contains('MetaWearablesDat.captureLatestFrame'),
+          reason:
+              'each throttled trigger encodes a viewable JPEG natively, not hand-encoded raw or GPU-texture rasterized');
+      expect(provider, isNot(contains('Timer.periodic(_photoInterval')),
+          reason: 'Dart timers suspend in the background');
+    });
+
+    test('no per-frame pause/resume or still-photo shutter path remains', () {
+      expect(provider, isNot(contains('_pausePreviewBetweenFrames')));
+      expect(provider, isNot(contains('_resumePreviewForFrame')));
+      expect(provider, isNot(contains('MetaWearablesDat.capturePhoto(')));
+      expect(service, isNot(contains('pausePreviewStream')));
+      expect(service, isNot(contains('resumePreviewStream')));
+    });
+
+    test('frames are throttled to the user capture interval', () {
+      expect(provider, contains('Duration get _photoInterval => captureInterval.duration;'));
+      expect(provider, contains('now.difference(last) < _photoInterval'));
+    });
+  });
+}

--- a/app/test/unit/meta_glasses_watchdog_test.dart
+++ b/app/test/unit/meta_glasses_watchdog_test.dart
@@ -1,0 +1,299 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:meta_wearables_dat_flutter/meta_wearables_dat_flutter.dart';
+import 'package:omi/providers/meta_wearables_provider.dart';
+import 'package:omi/services/meta_wearables/meta_capture_watchdog.dart';
+
+void main() {
+  test('does not restart while DAT session is paused', () {
+    final watchdog = MetaCaptureWatchdog();
+
+    expect(watchdog.nextAction(MetaCaptureHealth.paused), MetaCaptureWatchdogAction.wait);
+    expect(watchdog.nextDelay(MetaCaptureHealth.paused), Duration.zero);
+  });
+
+  test('restarts stopped and stale DAT sessions', () {
+    final watchdog = MetaCaptureWatchdog();
+
+    expect(watchdog.nextAction(MetaCaptureHealth.stopped), MetaCaptureWatchdogAction.restart);
+    expect(watchdog.nextAction(MetaCaptureHealth.stale), MetaCaptureWatchdogAction.restart);
+  });
+
+  test('backs off repeated restart attempts', () {
+    final watchdog = MetaCaptureWatchdog();
+
+    expect(watchdog.nextDelay(MetaCaptureHealth.stopped), const Duration(seconds: 1));
+    watchdog.recordRestartAttempt();
+    expect(watchdog.nextDelay(MetaCaptureHealth.stale), const Duration(seconds: 2));
+    watchdog.recordRestartAttempt();
+    expect(watchdog.nextDelay(MetaCaptureHealth.stopped), const Duration(seconds: 4));
+  });
+
+  test('healthy frame resets restart attempts', () {
+    final watchdog = MetaCaptureWatchdog();
+
+    watchdog.recordRestartAttempt();
+    watchdog.recordRestartAttempt();
+    expect(watchdog.nextDelay(MetaCaptureHealth.stopped), const Duration(seconds: 4));
+
+    watchdog.recordHealthyFrame();
+
+    expect(watchdog.nextAction(MetaCaptureHealth.streaming), MetaCaptureWatchdogAction.wait);
+    expect(watchdog.nextDelay(MetaCaptureHealth.stopped), const Duration(seconds: 1));
+  });
+
+  test('provider schedules restart when active DAT capture is stopped or stale', () {
+    final provider = MetaWearablesProvider();
+    final scheduled = <String>[];
+
+    provider.debugSetCaptureWatchdogStateForTest(
+      isCapturing: true,
+      streamSessionState: StreamSessionState.streaming,
+      deviceSessionState: DeviceSessionState.started,
+      hasPreviewTexture: true,
+      hasFrameSubscription: true,
+    );
+    provider.debugOnCaptureWatchdogRestartScheduled =
+        (health, delay) => scheduled.add('${health.name}:${delay.inSeconds}');
+    provider.debugHandleStreamSessionStateForTest(StreamSessionState.stopped);
+
+    provider.debugSetCaptureWatchdogStateForTest(
+      isCapturing: true,
+      streamSessionState: StreamSessionState.streaming,
+      deviceSessionState: DeviceSessionState.started,
+      hasPreviewTexture: true,
+      hasFrameSubscription: true,
+      lastQueuedPhotoAt: DateTime(2026, 7, 5, 12, 0, 0),
+    );
+    provider.debugEvaluateCaptureWatchdogForTest(
+      now: DateTime(2026, 7, 5, 12, 0, 45),
+      onRestartScheduled: (health, delay) => scheduled.add('${health.name}:${delay.inSeconds}'),
+    );
+
+    expect(scheduled, <String>['stopped:1', 'stale:1']);
+    provider.dispose();
+  });
+
+  test('provider does not restart before next capture interval can produce a queued frame', () {
+    final provider = MetaWearablesProvider();
+    final scheduled = <String>[];
+
+    provider.debugSetCaptureWatchdogStateForTest(
+      isCapturing: true,
+      streamSessionState: StreamSessionState.streaming,
+      deviceSessionState: DeviceSessionState.started,
+      hasPreviewTexture: true,
+      hasFrameSubscription: true,
+      lastQueuedPhotoAt: DateTime(2026, 7, 5, 12, 0, 0),
+    );
+    provider.debugEvaluateCaptureWatchdogForTest(
+      now: DateTime(2026, 7, 5, 12, 0, 7),
+      onRestartScheduled: (health, delay) => scheduled.add('${health.name}:${delay.inSeconds}'),
+    );
+
+    expect(scheduled, isEmpty);
+    provider.dispose();
+  });
+
+  test('capture frequency does not delay dead-stream recovery', () {
+    final provider = MetaWearablesProvider();
+    final scheduled = <String>[];
+
+    provider.debugSetCaptureWatchdogStateForTest(
+      isCapturing: true,
+      streamSessionState: StreamSessionState.streaming,
+      deviceSessionState: DeviceSessionState.started,
+      hasPreviewTexture: true,
+      hasFrameSubscription: true,
+      captureInterval: MetaGlassesCaptureInterval.m5,
+      lastQueuedPhotoAt: DateTime(2026, 7, 5, 12, 0, 0),
+      lastStreamFrameEventAt: DateTime(2026, 7, 5, 12, 2, 35),
+    );
+    provider.debugEvaluateCaptureWatchdogForTest(
+      now: DateTime(2026, 7, 5, 12, 3, 0),
+      onRestartScheduled: (health, delay) => scheduled.add('${health.name}:${delay.inSeconds}'),
+    );
+
+    expect(scheduled, <String>['stale:1']);
+    provider.dispose();
+  });
+
+  test('capture frequency allows quiet long intervals while stream frames are alive', () {
+    final provider = MetaWearablesProvider();
+    final scheduled = <String>[];
+
+    provider.debugSetCaptureWatchdogStateForTest(
+      isCapturing: true,
+      streamSessionState: StreamSessionState.streaming,
+      deviceSessionState: DeviceSessionState.started,
+      hasPreviewTexture: true,
+      hasFrameSubscription: true,
+      captureInterval: MetaGlassesCaptureInterval.m5,
+      lastQueuedPhotoAt: DateTime(2026, 7, 5, 12, 0, 0),
+      lastStreamFrameEventAt: DateTime(2026, 7, 5, 12, 2, 55),
+    );
+    provider.debugEvaluateCaptureWatchdogForTest(
+      now: DateTime(2026, 7, 5, 12, 3, 0),
+      onRestartScheduled: (health, delay) => scheduled.add('${health.name}:${delay.inSeconds}'),
+    );
+
+    expect(scheduled, isEmpty);
+    provider.dispose();
+  });
+
+  test('provider waits while DAT session is paused', () {
+    final provider = MetaWearablesProvider();
+    final scheduled = <String>[];
+
+    provider.debugSetCaptureWatchdogStateForTest(
+      isCapturing: true,
+      streamSessionState: StreamSessionState.streaming,
+      deviceSessionState: DeviceSessionState.started,
+      hasPreviewTexture: true,
+      hasFrameSubscription: true,
+    );
+    provider.debugOnCaptureWatchdogRestartScheduled =
+        (health, delay) => scheduled.add('${health.name}:${delay.inSeconds}');
+    provider.debugHandleStreamSessionStateForTest(StreamSessionState.paused);
+
+    provider.debugSetCaptureWatchdogStateForTest(
+      isCapturing: true,
+      streamSessionState: StreamSessionState.streaming,
+      deviceSessionState: DeviceSessionState.paused,
+      hasPreviewTexture: false,
+      hasFrameSubscription: false,
+    );
+    provider.debugEvaluateCaptureWatchdogForTest(
+      onRestartScheduled: (health, delay) => scheduled.add('${health.name}:${delay.inSeconds}'),
+    );
+
+    expect(scheduled, isEmpty);
+    provider.dispose();
+  });
+
+  test('provider waits while thermal paused', () {
+    final provider = MetaWearablesProvider();
+    final scheduled = <String>[];
+
+    provider.debugSetCaptureWatchdogStateForTest(
+      isCapturing: true,
+      streamSessionState: StreamSessionState.streaming,
+      deviceSessionState: DeviceSessionState.started,
+      hasPreviewTexture: false,
+      hasFrameSubscription: false,
+      thermalPaused: true,
+    );
+    provider.debugEvaluateCaptureWatchdogForTest(
+      onRestartScheduled: (health, delay) => scheduled.add('${health.name}:${delay.inSeconds}'),
+    );
+
+    expect(scheduled, isEmpty);
+    provider.dispose();
+  });
+
+  test('provider does not fight bounded stream retry or fallback', () {
+    final provider = MetaWearablesProvider();
+    final scheduled = <String>[];
+
+    provider.debugSetCaptureWatchdogStateForTest(
+      isCapturing: true,
+      streamSessionState: StreamSessionState.streaming,
+      deviceSessionState: DeviceSessionState.started,
+      hasPreviewTexture: false,
+      hasFrameSubscription: false,
+      streamRetryScheduled: true,
+    );
+    provider.debugEvaluateCaptureWatchdogForTest(
+      onRestartScheduled: (health, delay) => scheduled.add('${health.name}:${delay.inSeconds}'),
+    );
+
+    provider.debugSetCaptureWatchdogStateForTest(
+      isCapturing: true,
+      streamSessionState: StreamSessionState.streaming,
+      deviceSessionState: DeviceSessionState.started,
+      hasPreviewTexture: false,
+      hasFrameSubscription: false,
+      micOnlyFallback: true,
+    );
+    provider.debugEvaluateCaptureWatchdogForTest(
+      onRestartScheduled: (health, delay) => scheduled.add('${health.name}:${delay.inSeconds}'),
+    );
+
+    expect(scheduled, isEmpty);
+    provider.dispose();
+  });
+
+  test('provider cancels pending watchdog restart when capture becomes inactive', () {
+    final provider = MetaWearablesProvider();
+
+    provider.debugSetCaptureWatchdogStateForTest(
+      isCapturing: true,
+      streamSessionState: StreamSessionState.streaming,
+      deviceSessionState: DeviceSessionState.started,
+      hasPreviewTexture: false,
+      hasFrameSubscription: false,
+    );
+    provider.debugEvaluateCaptureWatchdogForTest();
+
+    expect(provider.debugHasCaptureWatchdogTimerForTest, isTrue);
+
+    provider.debugSetCaptureWatchdogStateForTest(
+      isCapturing: false,
+      streamSessionState: StreamSessionState.streaming,
+      deviceSessionState: DeviceSessionState.started,
+      hasPreviewTexture: false,
+      hasFrameSubscription: false,
+    );
+    provider.debugEvaluateCaptureWatchdogForTest();
+
+    expect(provider.debugHasCaptureWatchdogTimerForTest, isFalse);
+    provider.dispose();
+  });
+
+  test('provider marks watchdog healthy only after queue enqueue succeeds', () {
+    final source = File('lib/providers/meta_wearables_provider.dart').readAsStringSync();
+    final compact = source.replaceAll(RegExp(r'\s+'), ' ');
+
+    expect(source, contains('Future<bool> _enqueuePhoto'));
+    expect(source, contains('if (!queued)'));
+    expect(source, contains('_lastQueuedPhotoAt = DateTime.now()'));
+    expect(
+      compact,
+      contains(
+          'if (!isCapturing || !_cameraStreamNeeded || _captureWatchdogPaused || micOnlyFallback || previewTextureId == null)'),
+    );
+    expect(source, contains('_cancelCaptureWatchdogTimer();\n      _markHealthRecovered();'));
+    expect(compact,
+        contains('if (!isCapturing || !_cameraStreamNeeded || _captureWatchdogPaused || micOnlyFallback) return;'));
+    expect(source, contains('_frameForwardInFlight = false;'));
+    expect(source, isNot(contains('void _onVideoFrame(VideoFrame frame) {\n    _markHealthRecovered();')));
+  });
+
+  test('watchdog backoff resets per capture session', () {
+    // Review thread: a session that died after several restart attempts left
+    // _attempts high, so the NEXT capture session inherited a 32s backoff.
+    final watchdog = MetaCaptureWatchdog();
+    watchdog.recordRestartAttempt();
+    watchdog.recordRestartAttempt();
+    watchdog.recordRestartAttempt();
+    expect(watchdog.nextDelay(MetaCaptureHealth.stale).inSeconds, greaterThan(4));
+    watchdog.reset();
+    expect(watchdog.nextDelay(MetaCaptureHealth.stale).inSeconds, lessThanOrEqualTo(1),
+        reason: 'a fresh capture session must start with fresh backoff');
+
+    final provider = File('lib/providers/meta_wearables_provider.dart').readAsStringSync();
+    expect(provider, contains('_captureWatchdog.reset()'),
+        reason: 'startCapture must reset restart backoff for the new session');
+  });
+
+  test('watchdog wait states re-check instead of going dormant', () {
+    // Observed on-device 2026-07-05: after "wait reason=streamRetry" the
+    // watchdog cancelled its timer and nothing re-armed it when the app was
+    // suspended mid-retry — capture stayed dead until app relaunch. Every
+    // wait branch must schedule a re-check so a foreground resume recovers.
+    final provider = File('lib/providers/meta_wearables_provider.dart').readAsStringSync();
+    expect(provider, contains('_scheduleWatchdogRecheck'),
+        reason: 'wait branches must re-arm a re-check timer, never cancel-and-return');
+  });
+}

--- a/app/test/widgets/meta_glasses_onboarding_step_test.dart
+++ b/app/test/widgets/meta_glasses_onboarding_step_test.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:meta_wearables_dat_flutter/meta_wearables_dat_flutter.dart';
+import 'package:provider/provider.dart';
+
+import 'package:omi/l10n/app_localizations.dart';
+import 'package:omi/pages/onboarding/meta_glasses_onboarding_step.dart';
+import 'package:omi/providers/meta_wearables_provider.dart';
+
+void main() {
+  testWidgets('onboarding device step renders a Meta Glasses option', (tester) async {
+    var metaTapped = false;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: const [
+          AppLocalizations.delegate,
+          GlobalMaterialLocalizations.delegate,
+          GlobalWidgetsLocalizations.delegate,
+          GlobalCupertinoLocalizations.delegate,
+        ],
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: ChangeNotifierProvider(
+          create: (_) => MetaWearablesProvider(),
+          child: OnboardingMetaGlassesStep(
+            onMetaGlassesSelected: () => metaTapped = true,
+            onOmiDeviceSelected: () {},
+            onContinueWithoutDevice: () {},
+          ),
+        ),
+      ),
+    );
+
+    await tester.pump();
+
+    expect(find.byKey(const Key('onboarding_meta_glasses_option')), findsOneWidget);
+    expect(find.text('Meta Glasses'), findsOneWidget);
+    await tester.tap(find.byKey(const Key('onboarding_meta_glasses_option')));
+    expect(metaTapped, isTrue);
+  });
+
+  test('registered linked Meta glasses satisfy onboarding device completion', () {
+    final provider = MetaWearablesProvider()
+      ..registrationState = RegistrationState.registered
+      ..devices = const [
+        DeviceInfo(
+          uuid: 'rayban-1',
+          name: 'Ray-Ban Meta',
+          kind: DeviceKind.rayBanMeta,
+          linkState: DeviceLinkState.connected,
+        ),
+      ];
+
+    expect(metaGlassesOnboardingComplete(provider), isTrue);
+  });
+}

--- a/app/third_party/meta_wearables_dat_flutter/LICENSE
+++ b/app/third_party/meta_wearables_dat_flutter/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 iSee Labs
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/app/third_party/meta_wearables_dat_flutter/NOTICE
+++ b/app/third_party/meta_wearables_dat_flutter/NOTICE
@@ -1,0 +1,56 @@
+meta_wearables_dat_flutter
+Copyright (c) 2026 iSee Labs
+
+This product is released under the MIT License (see LICENSE).
+
+It is an unofficial Flutter plugin and is not affiliated with, endorsed by,
+sponsored by, or otherwise officially connected to Meta Platforms, Inc.
+
+================================================================================
+Third-party software
+================================================================================
+
+This product is a thin bridge over the following third-party software, which
+is linked as a binary dependency at build time and is NOT redistributed by
+this repository.
+
+--------------------------------------------------------------------------------
+Meta Wearables Device Access Toolkit (iOS)
+--------------------------------------------------------------------------------
+Source:   https://github.com/facebook/meta-wearables-dat-ios
+Copyright (c) Meta Platforms, Inc. and affiliates.
+Licensed under the BSD-style license found in the LICENSE file of the upstream
+repository. The iOS plugin pulls `MWDATCore`, `MWDATCamera`, and (when mock is
+enabled) `MWDATMockDevice` via Swift Package Manager from the upstream URL
+above.
+
+--------------------------------------------------------------------------------
+Meta Wearables Device Access Toolkit (Android)
+--------------------------------------------------------------------------------
+Source:   https://github.com/facebook/meta-wearables-dat-android
+Copyright (c) Meta Platforms, Inc. and affiliates.
+Licensed under the BSD-style license found in the LICENSE file of the upstream
+repository. The Android plugin pulls `com.meta.wearable:mwdat-core`,
+`com.meta.wearable:mwdat-camera`, and (when mock is enabled)
+`com.meta.wearable:mwdat-mockdevice` from GitHub Packages Maven.
+
+================================================================================
+Trademarks
+================================================================================
+
+"Meta", "Ray-Ban Meta", "Oakley Meta", "Ray-Ban Display", and related logos
+are trademarks of Meta Platforms, Inc. and/or its affiliates and other
+respective owners. Use of these names in this repository is solely for the
+purpose of identifying the upstream SDKs and supported devices, and does not
+imply endorsement, sponsorship, or affiliation.
+
+================================================================================
+Architecture inspiration
+================================================================================
+
+Architectural patterns (texture bridge, `captureStreamFrame`, lifecycle
+ordering) draw inspiration from the community Flutter plugin
+`flutter_meta_wearables_dat` by rodcone
+(https://github.com/rodcone/flutter_meta_wearables_dat). No source code from
+that project is copied into this repository; only the design ideas are
+referenced.

--- a/app/third_party/meta_wearables_dat_flutter/UPSTREAM.md
+++ b/app/third_party/meta_wearables_dat_flutter/UPSTREAM.md
@@ -1,0 +1,50 @@
+# Upstream provenance
+
+- Source: https://github.com/iSee-Labs/meta-wearables-dat-flutter
+- Base commit: `f13cf7e2bfbbc25bdbd42ca4972be1834c724624`
+- Upstream version: `0.7.1`
+- License: MIT; see `LICENSE` and `NOTICE`.
+
+The vendored tree contains 45 files. Compared byte-for-byte with the base
+commit above, 30 files are unchanged, 15 modified files are listed below, and
+there are no vendor-only files.
+
+## Omi changes
+
+- `ios/meta_wearables_dat_flutter/Package.swift`
+- `ios/meta_wearables_dat_flutter/Sources/meta_wearables_dat_flutter/BackgroundStreamingController.swift`
+- `ios/meta_wearables_dat_flutter/Sources/meta_wearables_dat_flutter/MetaMockDeviceManager.swift`
+- `ios/meta_wearables_dat_flutter/Sources/meta_wearables_dat_flutter/MetaSessionManager.swift`
+- `ios/meta_wearables_dat_flutter/Sources/meta_wearables_dat_flutter/MetaWearablesDatPlugin.swift`
+- `android/src/main/kotlin/com/iseelabs/meta_wearables_dat_flutter/MetaWearablesDatPlugin.kt`
+- `lib/meta_wearables_dat_flutter.dart`
+- `lib/src/meta_wearables_dat_method_channel.dart`
+- `lib/src/meta_wearables_dat_platform_interface.dart`
+- `lib/src/models/dat_error.dart`
+- `lib/src/models/device_info.dart`
+- `lib/src/models/display/display_components.dart`
+- `lib/src/models/frame_data.dart`
+- `lib/src/models/session_state.dart`
+- `test/meta_wearables_dat_flutter_test.dart`
+
+The changes add Omi's link-state mapping, latest-frame JPEG capture, firmware
+and DAT-app update commands, production-safe mock handling, background HFP
+audio behavior, and matching Dart/platform tests. Official Meta iOS and
+Android DAT SDK binaries remain build-time dependencies; they are not copied
+into this directory.
+
+## Why vendored
+
+Omi's required native and Dart API changes are not present in upstream 0.7.1.
+Keeping the pinned source in-tree makes that delta reviewable and prevents a
+mutable Git dependency from changing device, camera, or background behavior.
+Replace this copy with a pinned package/tag after the required APIs land
+upstream.
+
+## Verification
+
+```bash
+git clone https://github.com/iSee-Labs/meta-wearables-dat-flutter.git /tmp/meta-wearables-dat-flutter
+git -C /tmp/meta-wearables-dat-flutter checkout f13cf7e2bfbbc25bdbd42ca4972be1834c724624
+diff -ru /tmp/meta-wearables-dat-flutter app/third_party/meta_wearables_dat_flutter
+```

--- a/app/third_party/meta_wearables_dat_flutter/analysis_options.yaml
+++ b/app/third_party/meta_wearables_dat_flutter/analysis_options.yaml
@@ -1,0 +1,42 @@
+include: package:very_good_analysis/analysis_options.yaml
+
+analyzer:
+  exclude:
+    # Vendored research material (Meta's official samples + the rodcone
+    # community plugin) used purely as design reference. Not part of this
+    # plugin's source. See `CURSOR.md` for context.
+    - meta-glasses-research/**
+    # Each sample is its own Flutter project with its own pubspec /
+    # analysis_options. They are linted independently via
+    # `cd samples/camera_access && flutter analyze`.
+    - samples/**
+
+# Project-specific overrides for the v0.1.0 development cut.
+# Slice 12 (docs) re-enables `public_member_api_docs` after every public API
+# has been documented. The other suppressions below are stable choices for
+# this codebase.
+linter:
+  rules:
+    # Slice 12: every public API now has dartdoc. Re-enabled.
+    public_member_api_docs: true
+    # Models reference facade symbols (e.g. `[MetaWearablesDat.startStream]`)
+    # for navigability in published dartdoc. Importing the facade in every
+    # model file would create a cycle (the facade also exports them), and
+    # rewriting the references as plain text loses the cross-link in the
+    # rendered docs. Re-evaluated alongside `public_member_api_docs` in
+    # slice 12.
+    comment_references: false
+    # very_good_analysis enforces 80-col by default; we prefer ~100 columns
+    # to keep type-rich Flutter widget trees and platform-channel maps
+    # readable.
+    lines_longer_than_80_chars: false
+    # Stylistic; we prefer fields-then-constructors order for plain data
+    # classes such as `DeviceInfo` / `FrameData`.
+    sort_constructors_first: false
+    # We use `// ignore:` deliberately and contextually; not every ignore
+    # needs an inline justification.
+    document_ignores: false
+    # `dart format` (Dart 3.7+ "tall style") removes trailing commas it doesn't
+    # need to control wrapping, so this lint fights the formatter. The
+    # formatter is the source of truth for trailing commas in this project.
+    require_trailing_commas: false

--- a/app/third_party/meta_wearables_dat_flutter/android/build.gradle
+++ b/app/third_party/meta_wearables_dat_flutter/android/build.gradle
@@ -1,0 +1,86 @@
+// Android Gradle module for the meta_wearables_dat_flutter plugin.
+//
+// Meta's official Android DAT SDK is published to GitHub Packages Maven and
+// requires a GitHub personal access token with the `read:packages` scope. Set
+// the token via the `GITHUB_TOKEN` env var, or place
+// `github_token=<token>` in `local.properties` / `gradle.properties`.
+//
+// Consumers must mirror this Maven repository declaration in their app's
+// `settings.gradle.kts` (see `example/android/settings.gradle.kts`). The
+// duplication is intentional: a Flutter plugin cannot inject a repository
+// into the consumer's `dependencyResolutionManagement` block, but the plugin
+// itself still needs to resolve `mwdat-core`/`mwdat-camera` against the same
+// remote when the plugin's own module is compiled.
+
+group = "com.iseelabs.meta_wearables_dat_flutter"
+version = "0.7.1"
+
+ext.mwdat_version = "0.7.0"
+
+buildscript {
+    ext.kotlin_version = "2.1.0"
+    repositories {
+        google()
+        mavenCentral()
+    }
+
+    dependencies {
+        classpath("com.android.tools.build:gradle:8.9.1")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version")
+    }
+}
+
+allprojects {
+    repositories {
+        google()
+        mavenCentral()
+        maven {
+            url = uri("https://maven.pkg.github.com/facebook/meta-wearables-dat-android")
+            credentials {
+                username = "" // not needed; Meta's package is public-read with any user
+                password = System.getenv("GITHUB_TOKEN")
+                    ?: project.findProperty("github_token")?.toString()
+                    ?: ""
+            }
+        }
+    }
+}
+
+apply plugin: "com.android.library"
+apply plugin: "kotlin-android"
+
+android {
+    namespace = "com.iseelabs.meta_wearables_dat_flutter"
+
+    compileSdk = 35
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
+    }
+
+    kotlinOptions {
+        jvmTarget = JavaVersion.VERSION_11
+    }
+
+    sourceSets {
+        main.java.srcDirs += "src/main/kotlin"
+    }
+
+    defaultConfig {
+        minSdk = 31
+    }
+
+    dependencies {
+        implementation("com.meta.wearable:mwdat-core:$mwdat_version")
+        implementation("com.meta.wearable:mwdat-camera:$mwdat_version")
+        // Display capability (Ray-Ban Display glasses). Added in DAT 0.7.0.
+        implementation("com.meta.wearable:mwdat-display:$mwdat_version")
+        // Mock Device Kit. Meta ships the mock module alongside core/camera;
+        // pulled in unconditionally so host apps can develop without glasses.
+        implementation("com.meta.wearable:mwdat-mockdevice:$mwdat_version")
+        // ActivityResultRegistry / ComponentActivity for runtime permissions
+        // and Meta's RequestPermissionContract.
+        implementation("androidx.activity:activity-ktx:1.9.3")
+    }
+}

--- a/app/third_party/meta_wearables_dat_flutter/android/settings.gradle
+++ b/app/third_party/meta_wearables_dat_flutter/android/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'meta_wearables_dat_flutter'

--- a/app/third_party/meta_wearables_dat_flutter/android/src/main/AndroidManifest.xml
+++ b/app/third_party/meta_wearables_dat_flutter/android/src/main/AndroidManifest.xml
@@ -1,0 +1,29 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+    <!--
+        Bluetooth / Internet permissions are intentionally NOT declared here.
+        Consumers add them in the host app's manifest because not every
+        consumer needs every permission (e.g. an app shipping mock-only does
+        not need BLUETOOTH). See `doc/getting_started.md` for the required
+        entries.
+
+        The permissions below are added unconditionally because they
+        accompany the `BackgroundStreamingService` declaration: leaving
+        them out would make `enableBackgroundStreaming()` crash with a
+        SecurityException at runtime. Permissions in a plugin's manifest
+        merge into the host app's manifest at build time.
+    -->
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission
+        android:name="android.permission.FOREGROUND_SERVICE_CONNECTED_DEVICE" />
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+
+    <application>
+        <service
+            android:name=".BackgroundStreamingService"
+            android:exported="false"
+            android:foregroundServiceType="connectedDevice"
+            tools:ignore="ForegroundServicePermission" />
+    </application>
+</manifest>

--- a/app/third_party/meta_wearables_dat_flutter/android/src/main/kotlin/com/iseelabs/meta_wearables_dat_flutter/BackgroundStreamingService.kt
+++ b/app/third_party/meta_wearables_dat_flutter/android/src/main/kotlin/com/iseelabs/meta_wearables_dat_flutter/BackgroundStreamingService.kt
@@ -1,0 +1,155 @@
+// Foreground service that keeps the camera/BLE pipeline alive while the
+// host app is backgrounded / the screen is locked on Android.
+//
+// Without this service, Doze + App Standby suspend the app's network
+// stack after a few minutes, which tears down Meta's `Wearables` BLE
+// link and ends the stream. The plugin starts this service from
+// `enableBackgroundStreaming(androidNotification:)` and stops it from
+// `disableBackgroundStreaming()`.
+//
+// What it does:
+//   1. Runs as a *foreground* service with
+//      `FOREGROUND_SERVICE_TYPE_CONNECTED_DEVICE`, the strictest type
+//      we can claim that still permits BLE access in the background.
+//   2. Shows a low-importance notification (the host app supplies its
+//      title / text via the [BackgroundNotification] Dart model).
+//   3. Acquires a `PARTIAL_WAKE_LOCK` so the CPU keeps decoding video
+//      frames even while the screen is off.
+//
+// The host app must declare the matching permissions
+// (`FOREGROUND_SERVICE`, `FOREGROUND_SERVICE_CONNECTED_DEVICE`,
+// `WAKE_LOCK`, `POST_NOTIFICATIONS`) — these are merged from the
+// plugin's `AndroidManifest.xml` automatically by the Android Gradle
+// Plugin's manifest merger.
+
+package com.iseelabs.meta_wearables_dat_flutter
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.content.pm.ServiceInfo
+import android.os.Build
+import android.os.IBinder
+import android.os.PowerManager
+import androidx.core.app.NotificationCompat
+
+class BackgroundStreamingService : Service() {
+    companion object {
+        const val EXTRA_TITLE = "title"
+        const val EXTRA_TEXT = "text"
+        const val EXTRA_CHANNEL_ID = "channelId"
+        const val EXTRA_CHANNEL_NAME = "channelName"
+        const val EXTRA_ICON_RESOURCE_NAME = "iconResourceName"
+
+        /** Fixed within the host-app process; arbitrary positive integer. */
+        const val NOTIFICATION_ID = 0x4D454441
+    }
+
+    private var wakeLock: PowerManager.WakeLock? = null
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        val args = intent?.extras
+        val title = args?.getString(EXTRA_TITLE) ?: "Streaming in background"
+        val text = args?.getString(EXTRA_TEXT)
+            ?: "Your glasses are still sending frames to this app."
+        val channelId = args?.getString(EXTRA_CHANNEL_ID)
+            ?: "meta_wearables_dat_background"
+        val channelName = args?.getString(EXTRA_CHANNEL_NAME)
+            ?: "Wearables background streaming"
+        val iconResourceName = args?.getString(EXTRA_ICON_RESOURCE_NAME)
+
+        ensureNotificationChannel(channelId, channelName)
+        val notification = buildNotification(
+            title = title,
+            text = text,
+            channelId = channelId,
+            iconResourceName = iconResourceName,
+        )
+        startForegroundCompat(notification)
+
+        acquireWakeLockIfNeeded()
+        return START_STICKY
+    }
+
+    override fun onDestroy() {
+        releaseWakeLock()
+        super.onDestroy()
+    }
+
+    private fun startForegroundCompat(notification: Notification) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            startForeground(
+                NOTIFICATION_ID,
+                notification,
+                ServiceInfo.FOREGROUND_SERVICE_TYPE_CONNECTED_DEVICE,
+            )
+        } else {
+            startForeground(NOTIFICATION_ID, notification)
+        }
+    }
+
+    private fun ensureNotificationChannel(channelId: String, channelName: String) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
+        val manager = getSystemService(NotificationManager::class.java)
+            ?: return
+        if (manager.getNotificationChannel(channelId) == null) {
+            manager.createNotificationChannel(
+                NotificationChannel(
+                    channelId,
+                    channelName,
+                    NotificationManager.IMPORTANCE_LOW,
+                ).apply {
+                    description = "Shown while Meta Wearables DAT keeps a " +
+                        "stream alive in the background."
+                    setShowBadge(false)
+                },
+            )
+        }
+    }
+
+    private fun buildNotification(
+        title: String,
+        text: String,
+        channelId: String,
+        iconResourceName: String?,
+    ): Notification {
+        val iconRes = iconResourceName?.let { name ->
+            resources.getIdentifier(name, "drawable", packageName).takeIf {
+                it != 0
+            }
+        } ?: applicationInfo.icon
+
+        return NotificationCompat.Builder(this, channelId)
+            .setContentTitle(title)
+            .setContentText(text)
+            .setSmallIcon(iconRes)
+            .setOngoing(true)
+            .setOnlyAlertOnce(true)
+            .setPriority(NotificationCompat.PRIORITY_LOW)
+            .setCategory(NotificationCompat.CATEGORY_SERVICE)
+            .build()
+    }
+
+    private fun acquireWakeLockIfNeeded() {
+        if (wakeLock?.isHeld == true) return
+        val power = getSystemService(Context.POWER_SERVICE) as? PowerManager
+            ?: return
+        val lock = power.newWakeLock(
+            PowerManager.PARTIAL_WAKE_LOCK,
+            "MWDAT::StreamingWakeLock",
+        )
+        lock.setReferenceCounted(false)
+        lock.acquire(10 * 60 * 60 * 1000L)
+        wakeLock = lock
+    }
+
+    private fun releaseWakeLock() {
+        wakeLock?.takeIf { it.isHeld }?.release()
+        wakeLock = null
+    }
+}

--- a/app/third_party/meta_wearables_dat_flutter/android/src/main/kotlin/com/iseelabs/meta_wearables_dat_flutter/MetaDisplayManager.kt
+++ b/app/third_party/meta_wearables_dat_flutter/android/src/main/kotlin/com/iseelabs/meta_wearables_dat_flutter/MetaDisplayManager.kt
@@ -1,0 +1,401 @@
+package com.iseelabs.meta_wearables_dat_flutter
+
+import android.os.Handler
+import android.os.Looper
+import com.meta.wearable.dat.core.Wearables
+import com.meta.wearable.dat.core.selectors.SpecificDeviceSelector
+import com.meta.wearable.dat.core.session.DeviceSession
+import com.meta.wearable.dat.core.session.DeviceSessionState
+import com.meta.wearable.dat.core.types.DeviceIdentifier
+import com.meta.wearable.dat.display.Display
+import com.meta.wearable.dat.display.addDisplay
+import com.meta.wearable.dat.display.removeDisplay
+import com.meta.wearable.dat.display.types.DisplayState
+import com.meta.wearable.dat.display.types.VideoCodec
+import com.meta.wearable.dat.display.types.VideoPlayerState
+import com.meta.wearable.dat.display.types.VideoSource
+import com.meta.wearable.dat.display.views.Alignment
+import com.meta.wearable.dat.display.views.ButtonStyle
+import com.meta.wearable.dat.display.views.ContentScope
+import com.meta.wearable.dat.display.views.CornerRadius
+import com.meta.wearable.dat.display.views.Direction
+import com.meta.wearable.dat.display.views.FlexBoxBackground
+import com.meta.wearable.dat.display.views.FlexBoxScope
+import com.meta.wearable.dat.display.views.IconName
+import com.meta.wearable.dat.display.views.IconStyle
+import com.meta.wearable.dat.display.views.ImageSize
+import com.meta.wearable.dat.display.views.TextColor
+import com.meta.wearable.dat.display.views.TextStyle
+import com.meta.wearable.dat.display.views.VideoPlayer
+import io.flutter.plugin.common.EventChannel
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeout
+
+/**
+ * Android Display bridge (DAT 0.7.0 `mwdat-display`).
+ *
+ * Mirrors [MetaDisplayManager] on iOS. Owns:
+ *   - One [DeviceSession] targeting a (display-capable) device.
+ *   - One [Display] capability attached to that session.
+ *   - The display-state EventSink and the display-events EventSink
+ *     (tap / click / playback callbacks routed back to Dart by id).
+ *
+ * Declarative view trees arrive from Dart as plain JSON maps, which we rebuild
+ * into Meta's `mwdat-display` component DSL (`flexBox` / `text` / `image` /
+ * `button` / `icon` / `video`) inside [Display.sendContent]. Interaction
+ * callbacks carry the Dart-assigned `callbackId` so the Dart side can dispatch
+ * to the right closure.
+ */
+internal class MetaDisplayManager {
+    private val scope = CoroutineScope(Dispatchers.Main.immediate + SupervisorJob())
+    private val mainHandler = Handler(Looper.getMainLooper())
+
+    private var session: DeviceSession? = null
+    private var display: Display? = null
+    private var displayStateJob: Job? = null
+    private var videoStateJob: Job? = null
+
+    /**
+     * The `onPlaybackEventId` of the [VideoPlayer] currently on screen, used to
+     * route video playback transitions back to the right Dart closure.
+     */
+    private var currentVideoCallbackId: String? = null
+
+    private var displayStateSink: EventChannel.EventSink? = null
+    private var displayEventsSink: EventChannel.EventSink? = null
+
+    fun setDisplayStateSink(sink: EventChannel.EventSink?) {
+        displayStateSink = sink
+    }
+
+    fun setDisplayEventsSink(sink: EventChannel.EventSink?) {
+        displayEventsSink = sink
+    }
+
+    // --- Lifecycle ------------------------------------------------------------
+
+    /**
+     * Creates a [DeviceSession] (targeting [deviceUuid] when given, otherwise
+     * the first paired device), attaches the display capability, and waits for
+     * both to reach `STARTED`.
+     */
+    suspend fun startDisplaySession(deviceUuid: String?) {
+        if (display != null) return
+
+        val allIds: List<DeviceIdentifier> = try {
+            Wearables.devices.first().toList()
+        } catch (_: Throwable) {
+            emptyList()
+        }
+        val target: DeviceIdentifier = when {
+            deviceUuid != null ->
+                allIds.firstOrNull { it.toString() == deviceUuid }
+                    ?: error(
+                        "Display session failed: deviceUuid=$deviceUuid is not " +
+                            "in the current paired set (paired=${allIds.size}).",
+                    )
+            allIds.isNotEmpty() -> allIds.first()
+            else -> error(
+                "No glasses are currently paired. Open Meta AI to pair " +
+                    "Ray-Ban Display glasses, then try again.",
+            )
+        }
+
+        var created: DeviceSession? = null
+        var createError: String? = null
+        Wearables.createSession(SpecificDeviceSelector(target))
+            .fold(
+                onSuccess = { created = it },
+                onFailure = { error, _ -> createError = error.description },
+            )
+        val newSession = created
+            ?: error("createSession failed: ${createError ?: "unknown"}")
+        session = newSession
+
+        newSession.start()
+        try {
+            withTimeout(SESSION_STARTED_TIMEOUT_MS) {
+                newSession.state.first { it == DeviceSessionState.STARTED }
+            }
+        } catch (t: Throwable) {
+            try {
+                newSession.stop()
+            } catch (_: Throwable) {
+                // ignore
+            }
+            session = null
+            throw IllegalStateException(
+                "Glasses did not connect in time. Take them out of the case " +
+                    "and put them on, then try again.",
+                t,
+            )
+        }
+
+        var attached: Display? = null
+        var attachError: String? = null
+        newSession.addDisplay()
+            .fold(
+                onSuccess = { attached = it },
+                onFailure = { error, _ -> attachError = error.description },
+            )
+        val newDisplay = attached
+            ?: run {
+                try {
+                    newSession.stop()
+                } catch (_: Throwable) {
+                    // ignore
+                }
+                session = null
+                error("addDisplay failed: ${attachError ?: "unknown"}")
+            }
+        display = newDisplay
+
+        displayStateJob = scope.launch {
+            newDisplay.state.collect { state -> postDisplayState(state) }
+        }
+        try {
+            withTimeout(DISPLAY_STARTED_TIMEOUT_MS) {
+                newDisplay.state.first { it == DisplayState.STARTED }
+            }
+        } catch (_: Throwable) {
+            // The display state stream keeps flowing; surface whatever state we
+            // reach via the display_state channel rather than hard-failing.
+        }
+    }
+
+    /** Rebuilds [view] into the DSL and sends it to the glasses. */
+    suspend fun sendDisplayView(view: Map<String, Any?>) {
+        val currentDisplay = display
+            ?: error("No display session - call startDisplaySession first")
+
+        if (view["type"] == "videoPlayer") {
+            val url = view["uri"] as? String ?: ""
+            currentVideoCallbackId = view["onPlaybackEventId"] as? String
+            val player = VideoPlayer(
+                source = VideoSource.Url(url),
+                codec = VideoCodec.MP4,
+            )
+            var sendError: String? = null
+            currentDisplay.sendContent { video(player = player) }
+                .fold(
+                    onSuccess = {},
+                    onFailure = { error, _ -> sendError = error.description },
+                )
+            if (sendError != null) error("send failed: $sendError")
+            videoStateJob?.cancel()
+            videoStateJob = scope.launch {
+                player.state.collect { state -> onVideoState(state) }
+            }
+            player.play()
+        } else {
+            currentVideoCallbackId = null
+            var sendError: String? = null
+            currentDisplay.sendContent { renderRoot(view) }
+                .fold(
+                    onSuccess = {},
+                    onFailure = { error, _ -> sendError = error.description },
+                )
+            if (sendError != null) error("send failed: $sendError")
+        }
+    }
+
+    /** Detaches the display capability and tears down its device session. */
+    fun stopDisplaySession() {
+        videoStateJob?.cancel(); videoStateJob = null
+        displayStateJob?.cancel(); displayStateJob = null
+        currentVideoCallbackId = null
+        try {
+            session?.removeDisplay()
+        } catch (_: Throwable) {
+            // ignore
+        }
+        display = null
+        try {
+            session?.stop()
+        } catch (_: Throwable) {
+            // ignore
+        }
+        session = null
+    }
+
+    fun dispose() {
+        stopDisplaySession()
+        scope.cancel()
+    }
+
+    // --- Callback plumbing ----------------------------------------------------
+
+    private fun emitCallback(id: String, type: String) {
+        mainHandler.post {
+            displayEventsSink?.success(
+                mapOf("callbackId" to id, "type" to type),
+            )
+        }
+    }
+
+    private fun onVideoState(state: VideoPlayerState) {
+        val id = currentVideoCallbackId ?: return
+        val event = when (state.name.uppercase()) {
+            "PLAYING", "STARTED" -> "playing"
+            "PAUSED" -> "paused"
+            "ENDED" -> "ended"
+            "STOPPED" -> "stopped"
+            "ERROR" -> "error"
+            else -> "unknown"
+        }
+        mainHandler.post {
+            displayEventsSink?.success(
+                mapOf(
+                    "callbackId" to id,
+                    "type" to "playback",
+                    "event" to event,
+                ),
+            )
+        }
+    }
+
+    private fun postDisplayState(state: DisplayState) {
+        val encoded = when (state.name.uppercase()) {
+            "STARTING" -> 0
+            "STARTED" -> 1
+            "STOPPING" -> 2
+            "STOPPED" -> 3
+            else -> 3
+        }
+        mainHandler.post { displayStateSink?.success(encoded) }
+    }
+
+    // --- Tree builders --------------------------------------------------------
+
+    private fun ContentScope.renderRoot(node: Map<String, Any?>) {
+        if (node["type"] == "flexBox") {
+            // The root `ContentScope.flexBox` has no `flexGrow` (it isn't a
+            // child of another flex container); only nested boxes do.
+            flexBox(
+                direction = direction(node["direction"] as? String),
+                gap = intOf(node["spacing"]),
+                padding = intOf(node["padding"]),
+                background = background(node["background"] as? String),
+                alignment = alignment(node["alignment"] as? String),
+                crossAlignment = alignment(node["crossAlignment"] as? String),
+                wrap = (node["wrap"] as? Boolean) ?: false,
+                onClick = tapHandler(node["onTapId"] as? String),
+            ) {
+                renderChildren(node)
+            }
+        } else {
+            flexBox { renderNode(node) }
+        }
+    }
+
+    private fun FlexBoxScope.renderChildren(node: Map<String, Any?>) {
+        @Suppress("UNCHECKED_CAST")
+        val kids = node["children"] as? List<Map<String, Any?>> ?: emptyList()
+        kids.forEach { renderNode(it) }
+    }
+
+    private fun FlexBoxScope.renderNode(node: Map<String, Any?>) {
+        when (node["type"]) {
+            "flexBox" -> flexBox(
+                direction = direction(node["direction"] as? String),
+                gap = intOf(node["spacing"]),
+                padding = intOf(node["padding"]),
+                background = background(node["background"] as? String),
+                alignment = alignment(node["alignment"] as? String),
+                crossAlignment = alignment(node["crossAlignment"] as? String),
+                wrap = (node["wrap"] as? Boolean) ?: false,
+                flexGrow = floatOf(node["flexGrow"]),
+                onClick = tapHandler(node["onTapId"] as? String),
+            ) {
+                renderChildren(node)
+            }
+            "text" -> text(
+                node["text"] as? String ?: "",
+                style = textStyle(node["style"] as? String),
+                color = textColor(node["color"] as? String),
+            )
+            "image" -> image(
+                uri = node["uri"] as? String ?: "",
+                sizePreset = imageSize(node["sizePreset"] as? String),
+                cornerRadius = cornerRadius(node["cornerRadius"] as? String),
+            )
+            "button" -> button(
+                node["label"] as? String ?: "",
+                style = buttonStyle(node["style"] as? String),
+                iconName = iconName(node["iconName"] as? String),
+                onClick = clickHandler(node["onClickId"] as? String),
+            )
+            "icon" -> {
+                val name = iconName(node["iconName"] as? String) ?: IconName.CHECKMARK
+                icon(name = name, style = IconStyle.FILLED)
+            }
+        }
+    }
+
+    // --- Enum + value mapping -------------------------------------------------
+
+    private fun direction(value: String?): Direction = when (value) {
+        "row" -> Direction.ROW
+        else -> Direction.COLUMN
+    }
+
+    private fun alignment(value: String?): Alignment = when (value) {
+        "center" -> Alignment.CENTER
+        "end" -> Alignment.END
+        else -> Alignment.START
+    }
+
+    private fun textStyle(value: String?): TextStyle = when (value) {
+        "heading" -> TextStyle.HEADING
+        "meta" -> TextStyle.META
+        else -> TextStyle.BODY
+    }
+
+    private fun textColor(value: String?): TextColor =
+        if (value == "secondary") TextColor.SECONDARY else TextColor.PRIMARY
+
+    private fun imageSize(value: String?): ImageSize =
+        if (value == "icon") ImageSize.ICON else ImageSize.FILL
+
+    private fun cornerRadius(value: String?): CornerRadius = when (value) {
+        "small" -> CornerRadius.SMALL
+        // The display SDK only ships none/small/medium; large collapses to medium.
+        "medium", "large" -> CornerRadius.MEDIUM
+        else -> CornerRadius.NONE
+    }
+
+    private fun buttonStyle(value: String?): ButtonStyle =
+        if (value == "secondary") ButtonStyle.SECONDARY else ButtonStyle.PRIMARY
+
+    private fun background(value: String?): FlexBoxBackground =
+        if (value == "card") FlexBoxBackground.CARD else FlexBoxBackground.NONE
+
+    private fun iconName(value: String?): IconName? {
+        if (value == null) return null
+        val token = value
+            .replace(Regex("([a-z0-9])([A-Z])"), "$1_$2")
+            .uppercase()
+        return runCatching { IconName.valueOf(token) }.getOrNull()
+    }
+
+    private fun tapHandler(id: String?): (() -> Unit)? =
+        id?.let { cid -> { emitCallback(cid, "tap") } }
+
+    private fun clickHandler(id: String?): () -> Unit =
+        { id?.let { emitCallback(it, "click") } }
+
+    private fun intOf(value: Any?): Int = (value as? Number)?.toInt() ?: 0
+
+    private fun floatOf(value: Any?): Float = (value as? Number)?.toFloat() ?: 0f
+
+    private companion object {
+        private const val SESSION_STARTED_TIMEOUT_MS = 45_000L
+        private const val DISPLAY_STARTED_TIMEOUT_MS = 30_000L
+    }
+}

--- a/app/third_party/meta_wearables_dat_flutter/android/src/main/kotlin/com/iseelabs/meta_wearables_dat_flutter/MetaMockDeviceManager.kt
+++ b/app/third_party/meta_wearables_dat_flutter/android/src/main/kotlin/com/iseelabs/meta_wearables_dat_flutter/MetaMockDeviceManager.kt
@@ -1,0 +1,220 @@
+// Android Mock Device Kit bridge.
+//
+// Wraps `MockDeviceKit.getInstance(context)` and exposes its surface to
+// the Dart facade. Paired devices are sourced from `kit.pairedDevices`
+// on demand and keyed by `device.deviceIdentifier.toString()`, so the
+// kit remains the single source of truth — disable/enable cycles can't
+// leave stale dictionary entries behind.
+//
+// Mock devices ship from `mwdat-mockdevice` and are intended for
+// hardware-less development. Production builds that do not want mock
+// device code in the binary should strip the dependency from
+// `build.gradle` instead — the plugin returns `MOCK_ERROR` cleanly when
+// the kit is not linked.
+
+package com.iseelabs.meta_wearables_dat_flutter
+
+import android.content.Context
+import android.net.Uri
+import android.util.Log
+import com.meta.wearable.dat.mockdevice.MockDeviceKit
+import com.meta.wearable.dat.mockdevice.api.MockRaybanMeta
+import com.meta.wearable.dat.mockdevice.api.camera.CameraFacing
+import io.flutter.plugin.common.EventChannel
+
+internal class MetaMockDeviceManager(context: Context) {
+
+    private companion object {
+        private const val TAG = "MWDATMockDevice"
+    }
+
+    // SDK 0.6.x: `MockDeviceKit.getInstance(...)` returns `MockDeviceKitInterface`,
+    // not `MockDeviceKit` itself. Letting Kotlin infer the type keeps the field
+    // compatible across any future repackaging of the implementation class.
+    private val kit = MockDeviceKit.getInstance(context.applicationContext)
+
+    private var sink: EventChannel.EventSink? = null
+
+    /**
+     * Tracks whether `kit.enable()` has been called by this plugin.
+     * `MockDeviceKit.isEnabled` is not exposed on the Android SDK 0.6.x
+     * Kotlin API, so we mirror it here.
+     */
+    private var enabled: Boolean = false
+
+    fun setMockDevicesSink(sink: EventChannel.EventSink?) {
+        this.sink = sink
+        emitDevices()
+    }
+
+    // --- Lifecycle ------------------------------------------------------
+
+    /**
+     * Enables (or re-enables) MockDeviceKit. The
+     * `initiallyRegistered` / `initialPermissionsGranted` overrides are
+     * currently unsupported on the Android SDK; this method logs a
+     * structured warning when either is non-default but still enables
+     * the kit so test harnesses don't crash.
+     */
+    fun enable(initiallyRegistered: Boolean, initialPermissionsGranted: Boolean) {
+        if (!initiallyRegistered || !initialPermissionsGranted) {
+            Log.w(
+                TAG,
+                "enableMockDevice: initiallyRegistered/" +
+                    "initialPermissionsGranted overrides are not yet " +
+                    "supported on Android; enabling MockDeviceKit with " +
+                    "default settings.",
+            )
+        }
+        if (enabled) {
+            kit.disable()
+            enabled = false
+        }
+        kit.enable()
+        enabled = true
+        emitDevices()
+    }
+
+    fun disable() {
+        if (enabled) {
+            kit.disable()
+            enabled = false
+        }
+        emitDevices()
+    }
+
+    fun isEnabled(): Boolean = enabled
+
+    // --- Pairing --------------------------------------------------------
+
+    fun pairRayBanMeta(): String {
+        ensureEnabled()
+        val mock = kit.pairRaybanMeta()
+        emitDevices()
+        return mock.deviceIdentifier.toString()
+    }
+
+    fun unpair(uuid: String) {
+        val mock = requireDevice(uuid)
+        kit.unpairDevice(mock)
+        emitDevices()
+    }
+
+    /** Returns a serialisable snapshot of every paired mock device. */
+    fun pairedDevices(): List<Map<String, Any?>> =
+        kit.pairedDevices.map(::encodeDevice)
+
+    // --- Device control -------------------------------------------------
+
+    fun powerOn(uuid: String) {
+        requireDevice(uuid).powerOn()
+    }
+
+    fun powerOff(uuid: String) {
+        requireDevice(uuid).powerOff()
+    }
+
+    fun don(uuid: String) {
+        requireDevice(uuid).don()
+    }
+
+    fun doff(uuid: String) {
+        requireDevice(uuid).doff()
+    }
+
+    fun fold(uuid: String) {
+        requireDevice(uuid).fold()
+    }
+
+    fun unfold(uuid: String) {
+        requireDevice(uuid).unfold()
+    }
+
+    // --- Permissions (kit-level) ----------------------------------------
+
+    /**
+     * The Android `MockDeviceKit` 0.6.x surface does not expose a
+     * programmatic permission-injection hook analogous to iOS's
+     * `MockDeviceKit.shared.permissions`. We retain the method for API
+     * parity with iOS so the Dart facade has a uniform shape, but emit
+     * a structured warning that is no-op'd until Meta lights up the
+     * Kotlin equivalent.
+     */
+    @Suppress("UNUSED_PARAMETER")
+    fun setPermission(permission: String, status: String) {
+        Log.w(
+            TAG,
+            "setMockPermission: MockPermissions API is not yet exposed " +
+                "on Android (permission=$permission status=$status). " +
+                "Treating call as no-op.",
+        )
+    }
+
+    @Suppress("UNUSED_PARAMETER")
+    fun setPermissionRequestResult(permission: String, status: String) {
+        Log.w(
+            TAG,
+            "setMockPermissionRequestResult: MockPermissions API is not " +
+                "yet exposed on Android (permission=$permission " +
+                "status=$status). Treating call as no-op.",
+        )
+    }
+
+    // --- Camera ---------------------------------------------------------
+
+    fun setCameraFacing(uuid: String, facing: String) {
+        // SDK 0.6.x: the enum value is `BACK` (not `REAR`).
+        val mapped = when (facing.lowercase()) {
+            "front" -> CameraFacing.FRONT
+            else -> CameraFacing.BACK
+        }
+        requireDevice(uuid).services.camera.setCameraFeed(mapped)
+    }
+
+    fun setCameraFeed(uuid: String, filePath: String?) {
+        val device = requireDevice(uuid)
+        if (filePath.isNullOrEmpty()) return
+        device.services.camera.setCameraFeed(Uri.parse("file://$filePath"))
+    }
+
+    fun setCapturedImage(uuid: String, filePath: String?) {
+        val device = requireDevice(uuid)
+        if (filePath.isNullOrEmpty()) return
+        device.services.camera.setCapturedImage(Uri.parse("file://$filePath"))
+    }
+
+    // --- Helpers --------------------------------------------------------
+
+    private fun ensureEnabled() {
+        if (!enabled) {
+            kit.enable()
+            enabled = true
+        }
+    }
+
+    private fun requireDevice(uuid: String): MockRaybanMeta {
+        val device = kit.pairedDevices.find {
+            it.deviceIdentifier.toString() == uuid
+        } ?: error("Mock device not found: $uuid")
+        if (device !is MockRaybanMeta) {
+            error("Mock device $uuid is not a Ray-Ban Meta")
+        }
+        return device
+    }
+
+    private fun emitDevices() {
+        sink?.success(pairedDevices())
+    }
+
+    private fun encodeDevice(device: Any): Map<String, Any?> {
+        val id = when (device) {
+            is MockRaybanMeta -> device.deviceIdentifier.toString()
+            else -> device.toString()
+        }
+        return mapOf(
+            "uuid" to id,
+            "name" to "Mock Ray-Ban Meta",
+            "kind" to "rayBanMeta",
+        )
+    }
+}

--- a/app/third_party/meta_wearables_dat_flutter/android/src/main/kotlin/com/iseelabs/meta_wearables_dat_flutter/MetaSessionManager.kt
+++ b/app/third_party/meta_wearables_dat_flutter/android/src/main/kotlin/com/iseelabs/meta_wearables_dat_flutter/MetaSessionManager.kt
@@ -1,0 +1,1029 @@
+// Android streaming bridge.
+//
+// Owns:
+//   - One `Session` (DeviceSession) per active capture - created via
+//     `Wearables.createSession(selector)` and started before any stream
+//     is added.
+//   - One `Stream` (video capability) attached to that Session.
+//   - One TextureRegistry SurfaceTextureEntry that backs the Flutter
+//     `Texture` widget on the Dart side.
+//   - Coroutine jobs collecting the Stream's video / state / error flows
+//     plus the DeviceSession's state / error flows.
+//
+// Lifecycle (matches Meta 0.6 reference sample):
+//   1. Wearables.createSession(selector)             // Result<Session>
+//   2. session.start()
+//   3. session.state.first { STARTED }               // wait
+//   4. session.addStream(config)                     // Result<Stream>
+//   5. stream.start()
+//   6. collect videoStream / state / errorStream
+//   ... later ...
+//   7. stream.stop(); stream = null
+//   8. session.stop(); session = null
+//
+// Frame pump:
+//   videoStream Flow → VideoFrame (I420 planes) → YUV→ARGB conversion
+//   → write into the SurfaceTexture's Surface via lockHardwareCanvas
+//   → Flutter's TextureRegistry picks up the new contents.
+
+package com.iseelabs.meta_wearables_dat_flutter
+
+import android.graphics.Bitmap
+import android.graphics.Matrix
+import android.graphics.Paint
+import android.os.Handler
+import android.os.Looper
+import android.view.Surface
+import com.meta.wearable.dat.camera.Stream
+import com.meta.wearable.dat.camera.addStream
+import com.meta.wearable.dat.camera.types.PhotoData
+import com.meta.wearable.dat.camera.types.StreamConfiguration
+import com.meta.wearable.dat.camera.types.StreamError
+import com.meta.wearable.dat.camera.types.StreamState
+import com.meta.wearable.dat.camera.types.VideoFrame
+import com.meta.wearable.dat.camera.types.VideoQuality
+import com.meta.wearable.dat.core.Wearables
+import com.meta.wearable.dat.core.selectors.SpecificDeviceSelector
+import com.meta.wearable.dat.core.session.DeviceSession
+import com.meta.wearable.dat.core.session.DeviceSessionState
+import com.meta.wearable.dat.core.types.DeviceIdentifier
+import io.flutter.plugin.common.EventChannel
+import io.flutter.view.TextureRegistry
+import java.io.ByteArrayOutputStream
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
+
+internal class MetaSessionManager(
+    private val textureRegistry: TextureRegistry,
+) {
+    private val scope = CoroutineScope(Dispatchers.Default + SupervisorJob())
+    private val mainHandler = Handler(Looper.getMainLooper())
+
+    private var session: DeviceSession? = null
+    private var stream: Stream? = null
+    private var textureEntry: TextureRegistry.SurfaceTextureEntry? = null
+    private var surface: Surface? = null
+
+    private var deviceStateJob: Job? = null
+    private var deviceErrorJob: Job? = null
+    private var stateJob: Job? = null
+    private var errorJob: Job? = null
+    private var frameJob: Job? = null
+
+    private var stateSink: EventChannel.EventSink? = null
+    private var errorSink: EventChannel.EventSink? = null
+    private var sizeSink: EventChannel.EventSink? = null
+    private var deviceStateSink: EventChannel.EventSink? = null
+    private var deviceErrorSink: EventChannel.EventSink? = null
+
+    /**
+     * Per-frame video payload sink. Gated behind subscriber presence:
+     * the I420 payload (width * height * 3 / 2 bytes) is ≈1.3 MB at
+     * 720p, so we skip the planes copy entirely when nobody is
+     * listening. See `doc/frame_processing.md`.
+     */
+    private var framesSink: EventChannel.EventSink? = null
+
+    private var streamStartElapsedNs: Long = 0L
+
+    /**
+     * Codec the caller asked for in `startStreamSession`. When set to
+     * `"hvc1"`, the SDK is expected to emit `VideoFrame`s with the
+     * compressed payload accessible via the same flow; the texture
+     * preview path is disabled because surfacing compressed Android
+     * frames requires a `MediaCodec` decoder that host apps must wire
+     * themselves (see `doc/streaming.md`).
+     */
+    private var activeCodec: String = "raw"
+
+    /**
+     * Reused ARGB scratch bitmap. Recreated whenever the source frame
+     * dimensions change. Keeping a single bitmap across frames avoids GC
+     * pressure at 30fps.
+     */
+    private var argbBitmap: Bitmap? = null
+    private var lastWidth = 0
+    private var lastHeight = 0
+
+    /**
+     * Number of frames we've already emitted a per-frame diagnostic for
+     * (Y / chroma min-max-mean stats). Capped at
+     * [FRAME_DIAGNOSTIC_LIMIT] so the log doesn't get spammed once we
+     * have enough signal to verify the conversion is alive and the data
+     * is varying. Reset by [stopSession].
+     */
+    private var frameDiagnosticsLogged: Int = 0
+
+    /**
+     * Serialises concurrent [startSession] calls. The Flutter sample app
+     * lets a user double-tap "Start" while the previous start is still
+     * waiting on the device link to upgrade from BLE to Bluetooth-Classic
+     * / Wi-Fi — without a guard we'd race two `Wearables.createSession`
+     * calls and the second would fail with `sessionAlreadyExists`. With
+     * the mutex, the second tap simply returns the texture id from the
+     * first start (because `textureEntry` is non-null by then).
+     */
+    private val startMutex = Mutex()
+
+    fun setStateSink(sink: EventChannel.EventSink?) { stateSink = sink }
+    fun setErrorSink(sink: EventChannel.EventSink?) { errorSink = sink }
+    fun setSizeSink(sink: EventChannel.EventSink?) { sizeSink = sink }
+    fun setDeviceStateSink(sink: EventChannel.EventSink?) { deviceStateSink = sink }
+    fun setDeviceErrorSink(sink: EventChannel.EventSink?) { deviceErrorSink = sink }
+    fun setFramesSink(sink: EventChannel.EventSink?) { framesSink = sink }
+
+    /**
+     * Starts a stream for [deviceUuid] (or the auto-selected active device
+     * when null). Returns the Flutter texture id.
+     *
+     * When [deviceKinds] is non-empty, only devices whose mapped DAT
+     * kind (`rayBanMeta` / `rayBanDisplay` / `oakleyMeta` / `unknown`)
+     * matches one of the entries is considered by the auto-selector
+     * filter or explicit lookup.
+     *
+     * Mirrors the Meta reference sample lifecycle: create Session, start
+     * it, wait for STARTED, add a Stream, then start the Stream.
+     */
+    suspend fun startSession(
+        deviceUuid: String?,
+        fps: Int,
+        quality: VideoQuality,
+        deviceKinds: Set<String>? = null,
+        videoCodec: String = "raw",
+    ): Long = startMutex.withLock {
+        activeCodec = videoCodec
+        textureEntry?.let { return@withLock it.id() }
+
+        // 1. Resolve the target device.
+        //
+        // The DAT Android SDK 0.6.0's `AutoDeviceSelector` has stricter
+        // eligibility than just "device id appears in `Wearables.devices`":
+        // it requires don-sensor signal that may not be present even when
+        // the glasses are paired and BLE-connected, and rejects with
+        // `noEligibleDevice` otherwise. This is the same gotcha the iOS
+        // bridge documents at `MetaSessionManager.swift` lines 113-131; we
+        // mirror its strategy here:
+        //
+        //   1. If the caller passed a deviceUUID, pin
+        //      `SpecificDeviceSelector` to that UUID.
+        //   2. Otherwise, pick the first paired device (optionally filtered
+        //      by `deviceKinds`) and pin `SpecificDeviceSelector` to it.
+        //   3. Only error out when no paired device matches the request
+        //      (nothing paired, or nothing matching `deviceKinds`).
+        //
+        // Note: iOS additionally prefers `linkState == .connected` then
+        // `.connecting` then any paired id. The Android SDK 0.6.0 surface
+        // we depend on does not expose a per-device link state, so we
+        // simply take the first paired id; if a future SDK release exposes
+        // it, prefer connected → connecting → any here too.
+        val kindsFilter: Set<String>? = deviceKinds?.takeIf { it.isNotEmpty() }
+        val allIds: List<DeviceIdentifier> = try {
+            Wearables.devices.first().toList()
+        } catch (_: Throwable) {
+            emptyList()
+        }
+        val filteredIds: List<DeviceIdentifier> = if (kindsFilter != null) {
+            allIds.filter { id ->
+                kindsFilter.contains(MetaWearablesDatPlugin.wireKindForDevice(id))
+            }
+        } else {
+            allIds
+        }
+
+        val selector: SpecificDeviceSelector
+        val chosenIdSource: String
+        when {
+            deviceUuid != null -> {
+                val match = filteredIds.firstOrNull { it.toString() == deviceUuid }
+                if (match != null) {
+                    selector = SpecificDeviceSelector(match)
+                    chosenIdSource = "explicit deviceUuid ($match)"
+                } else {
+                    error(
+                        "Wearables.createSession failed: explicit " +
+                            "deviceUUID=$deviceUuid is not in the current " +
+                            "paired set (paired=${allIds.size}, " +
+                            "afterKindsFilter=${filteredIds.size}).",
+                    )
+                }
+            }
+            filteredIds.isNotEmpty() -> {
+                val pick = filteredIds.first()
+                selector = SpecificDeviceSelector(pick)
+                chosenIdSource = "first paired device ($pick)"
+            }
+            kindsFilter != null -> {
+                error(
+                    "Wearables.createSession failed: no paired glasses " +
+                        "match the requested kinds=$kindsFilter " +
+                        "(paired=${allIds.size}). Open Meta AI to pair a " +
+                        "matching device, then try again.",
+                )
+            }
+            else -> {
+                error(
+                    "Wearables.createSession failed: no paired glasses " +
+                        "found. Open Meta AI to pair Ray-Ban Meta or " +
+                        "Oakley Meta glasses, then try again.",
+                )
+            }
+        }
+        android.util.Log.i(
+            "MetaSessionManager",
+            "startSession selector=$chosenIdSource",
+        )
+
+        // 2. Create the DeviceSession via Meta's `Result<Session>` API.
+        //
+        // Even with a [SpecificDeviceSelector] the SDK can refuse with
+        // `noEligibleDevice` for a few seconds after the user opens the
+        // app: the glasses are paired and BLE-connected but their
+        // don-sensor / wear signal hasn't yet surfaced, which the
+        // wearable manager treats as "not eligible". Empirically this
+        // window is ≤ 5 s on fresh-out-of-the-case glasses, so we retry
+        // up to [CREATE_SESSION_MAX_RETRIES] times with
+        // [CREATE_SESSION_RETRY_DELAY_MS] between attempts before
+        // surfacing the failure to Dart. Non-transient errors (e.g. an
+        // unknown UUID) break out of the loop on the first attempt.
+        var createError: String? = null
+        var created: DeviceSession? = null
+        var attempt = 0
+        while (created == null && attempt < CREATE_SESSION_MAX_RETRIES) {
+            createError = null
+            Wearables.createSession(selector)
+                .onSuccess { created = it }
+                .onFailure { error, _ -> createError = error.description }
+            if (created != null) break
+
+            val msg = createError ?: "unknown"
+            val isTransient = msg.contains("eligible", ignoreCase = true) ||
+                msg.contains("not ready", ignoreCase = true) ||
+                msg.contains("not connected", ignoreCase = true)
+            attempt++
+            if (!isTransient || attempt >= CREATE_SESSION_MAX_RETRIES) break
+
+            android.util.Log.i(
+                "MetaSessionManager",
+                "createSession transient failure: '$msg'. " +
+                    "Retrying in ${CREATE_SESSION_RETRY_DELAY_MS}ms " +
+                    "(attempt $attempt/$CREATE_SESSION_MAX_RETRIES).",
+            )
+            delay(CREATE_SESSION_RETRY_DELAY_MS)
+        }
+        val newSession = created
+            ?: error(
+                "Wearables.createSession failed after $attempt attempt(s): " +
+                    "${createError ?: "unknown"}. If this keeps happening, " +
+                    "force-stop Meta AI on the phone so it stops holding " +
+                    "the glasses connection, then try again.",
+            )
+        session = newSession
+
+        // Forward DeviceSession-level state / error flows BEFORE start so
+        // we capture the initial transitions.
+        deviceStateJob = scope.launch {
+            newSession.state.collectLatest { state ->
+                mainHandler.post {
+                    deviceStateSink?.success(encodeDeviceSessionState(state))
+                }
+            }
+        }
+        // `Session.errors` is exposed as a Flow; we forward it onto the
+        // device_session_errors channel. If the SDK ever stops exposing it
+        // we'll catch a NoSuchMethodError and skip — defensive copy.
+        deviceErrorJob = scope.launch {
+            try {
+                @Suppress("UNCHECKED_CAST")
+                val errorsField =
+                    newSession::class.java.getMethod("getErrors").invoke(newSession)
+                if (errorsField is kotlinx.coroutines.flow.Flow<*>) {
+                    errorsField.collectLatest { error ->
+                        mainHandler.post {
+                            deviceErrorSink?.success(encodeDeviceSessionError(error))
+                        }
+                    }
+                }
+            } catch (_: Throwable) {
+                // Older SDKs without the errors flow: silently ignore.
+            }
+        }
+
+        // 3. Start and wait until STARTED before adding a stream.
+        //
+        // The Meta SDK's `start()` returns immediately and the actual
+        // state transition happens asynchronously as the ACDC transport
+        // negotiates a link. On a freshly-paired device that is only
+        // reachable over BLE we have observed waits of 5-15 s while the
+        // link upgrades to Bluetooth-Classic / Wi-Fi; on a glasses-side
+        // failure (battery off, out of range, Meta AI app holding the
+        // link) the state never advances. A 30 s ceiling lets us surface
+        // a meaningful error to Dart instead of hanging the UI button.
+        newSession.start()
+        try {
+            withTimeout(SESSION_STARTED_TIMEOUT_MS) {
+                newSession.state.first { it == DeviceSessionState.STARTED }
+            }
+        } catch (timeout: TimeoutCancellationException) {
+            // Roll back: the orphaned device-state listener jobs would
+            // otherwise leak, and a future startSession call would fail
+            // with "session already exists".
+            deviceStateJob?.cancel(); deviceStateJob = null
+            deviceErrorJob?.cancel(); deviceErrorJob = null
+            try { newSession.stop() } catch (_: Throwable) { /* ignore */ }
+            session = null
+            throw IllegalStateException(
+                "Wearables.createSession failed: device session never " +
+                    "reached STARTED within ${SESSION_STARTED_TIMEOUT_MS / 1000}s. " +
+                    "If Meta AI is still running on the phone, force-stop it " +
+                    "(Settings → Apps → Meta AI → Force stop) so the glasses " +
+                    "can hand the connection over to this app, then try again.",
+                timeout,
+            )
+        }
+
+        // 4. Add the Stream capability. When the caller selected
+        // `hvc1`, ask the SDK for compressed HEVC frames via
+        // `compressVideo = true`. Texture preview is intentionally
+        // disabled in that mode (see frame rendering below).
+        val config = buildStreamConfiguration(quality, fps, videoCodec == "hvc1")
+        var streamError: String? = null
+        var newStream: Stream? = null
+        newSession.addStream(config)
+            .onSuccess { newStream = it }
+            .onFailure { error, _ -> streamError = error.description }
+        val resolvedStream = newStream
+            ?: run {
+                // Rollback the DeviceSession we started above.
+                newSession.stop()
+                session = null
+                deviceStateJob?.cancel(); deviceStateJob = null
+                deviceErrorJob?.cancel(); deviceErrorJob = null
+                error("addStream failed: ${streamError ?: "unknown"}")
+            }
+        stream = resolvedStream
+
+        // 5. Allocate the Flutter texture before frames start flowing.
+        val entry = textureRegistry.createSurfaceTexture()
+        textureEntry = entry
+        surface = Surface(entry.surfaceTexture())
+
+        // 6. Wire stream listener jobs (state, error, frames). Frame
+        // collection uses collectLatest so that if we ever fall behind on
+        // conversion we skip stale frames rather than queuing them up.
+        stateJob = scope.launch {
+            resolvedStream.state.collectLatest { state -> postState(state) }
+        }
+        errorJob = scope.launch {
+            resolvedStream.errorStream.collectLatest { error -> postError(error) }
+        }
+        frameJob = scope.launch {
+            resolvedStream.videoStream.collectLatest { frame -> renderFrame(frame) }
+        }
+
+        // 7. Start the stream.
+        streamStartElapsedNs = android.os.SystemClock.elapsedRealtimeNanos()
+        resolvedStream.start()
+        return@withLock entry.id()
+    }
+
+    /**
+     * Stops the active Stream then the underlying Session. Idempotent.
+     * Mirrors the iOS path: stop the stream first so any in-flight frames
+     * are drained, then stop the DeviceSession so future
+     * `createSession()` calls succeed without `sessionAlreadyExists`.
+     */
+    suspend fun stopSession() {
+        // Cancel listener jobs first so we don't race on shutdown.
+        stateJob?.cancel(); stateJob = null
+        errorJob?.cancel(); errorJob = null
+        frameJob?.cancel(); frameJob = null
+
+        try {
+            stream?.stop()
+        } catch (_: Throwable) {
+            // Stream may already be terminal; ignore.
+        }
+        stream = null
+
+        deviceStateJob?.cancel(); deviceStateJob = null
+        deviceErrorJob?.cancel(); deviceErrorJob = null
+
+        try {
+            session?.stop()
+        } catch (_: Throwable) {
+            // Session may already be terminal; ignore.
+        }
+        session = null
+
+        withContext(Dispatchers.Main) {
+            surface?.release()
+            surface = null
+            textureEntry?.release()
+            textureEntry = null
+        }
+        argbBitmap?.recycle()
+        argbBitmap = null
+        lastWidth = 0
+        lastHeight = 0
+        streamStartElapsedNs = 0L
+        frameDiagnosticsLogged = 0
+    }
+
+    /**
+     * Captures a still photo mid-stream and returns it as a (bytes, format)
+     * pair. The format is determined by the device side: HEIC frames are
+     * passed through unchanged; Bitmap frames are encoded to JPEG at
+     * quality 95 (a good balance for OCR and ML pipelines).
+     */
+    suspend fun capturePhoto(): Pair<ByteArray, String> {
+        val stream = stream ?: error("No active stream session")
+        val outcome = stream.capturePhoto()
+        val photo = outcome.getOrNull()
+            ?: error("capturePhoto failed: ${outcome.exceptionOrNull()?.message}")
+        return when (photo) {
+            is PhotoData.Bitmap -> {
+                val bos = ByteArrayOutputStream()
+                photo.bitmap.compress(Bitmap.CompressFormat.JPEG, 95, bos)
+                bos.toByteArray() to "jpeg"
+            }
+            is PhotoData.HEIC -> {
+                val buffer = photo.data.duplicate().apply { position(0) }
+                val bytes = ByteArray(buffer.remaining())
+                buffer.get(bytes)
+                bytes to "heic"
+            }
+        }
+    }
+
+    fun pauseSession() {
+        // Pause/resume is driven by the device side (hinges, thermal, ...)
+        // rather than an explicit API on the 0.6.x surface. Documented as
+        // no-op so host apps can call it unconditionally.
+    }
+
+    fun resumeSession() {
+        // See pauseSession.
+    }
+
+    fun dispose() {
+        scope.cancel()
+        argbBitmap?.recycle()
+        argbBitmap = null
+    }
+
+    // --- Frame rendering -----------------------------------------------------
+
+    private fun renderFrame(frame: VideoFrame) {
+        val width = frame.width
+        val height = frame.height
+
+        // hvc1 path: forward compressed bytes when subscribers exist
+        // and bail out — no texture preview is rendered for hvc1 on
+        // Android (see doc/streaming.md).
+        if (activeCodec == "hvc1") {
+            val sink = framesSink
+            if (sink != null) {
+                emitCompressedFrame(frame, width, height, sink)
+            }
+            if (lastWidth != width || lastHeight != height) {
+                lastWidth = width
+                lastHeight = height
+                mainHandler.post {
+                    sizeSink?.success(mapOf("width" to width, "height" to height))
+                }
+            }
+            return
+        }
+
+        val surface = surface ?: return
+
+        // The first time we see a frame (or when the resolution
+        // changes mid-stream) tell the SurfaceTexture the producer
+        // buffer size. Without this, `Surface.lockHardwareCanvas()`
+        // returns a canvas sized to the texture's default
+        // (Flutter-controlled) buffer, which is unrelated to the
+        // 720×1280 video frame — the resulting bitmap-into-canvas
+        // scale-fit then produces a tiny / squashed / wrong-colour
+        // preview even though the YUV decode itself is correct.
+        if (lastWidth != width || lastHeight != height) {
+            textureEntry?.surfaceTexture()?.setDefaultBufferSize(width, height)
+            android.util.Log.i(
+                "MetaSessionManager",
+                "SurfaceTexture defaultBufferSize -> ${width}x$height",
+            )
+        }
+
+        // Forward raw I420 to the videoFramesStream sink before we
+        // start mutating the bitmap. Gated on subscriber presence to
+        // keep per-frame cost free when nobody is listening.
+        val sink = framesSink
+        if (sink != null) {
+            emitVideoFrame(frame, width, height, sink)
+        }
+
+        val bitmap = ensureBitmap(width, height)
+
+        // Per-frame diagnostic: log Y / chroma min-mean-max for the
+        // first `FRAME_DIAGNOSTIC_LIMIT` frames, then drop to a low-rate
+        // heartbeat (every `FRAME_DIAGNOSTIC_HEARTBEAT_INTERVAL` frames,
+        // ≈ 1 Hz at 30 fps) for the rest of the stream. The detailed
+        // window catches stream warm-up; the heartbeat catches the
+        // transition to real video frames when the glasses are actually
+        // worn / capturing, which can happen a few seconds after the
+        // session reaches STREAMING.
+        //
+        // - Flat Y across both windows → SDK is feeding placeholders
+        //   (glasses not worn or no don-sensor signal). No code fix
+        //   helps; the preview will stay uniform.
+        // - Flat chroma but varying Y → user is filming a near-mono-
+        //   chrome real scene (white wall, hand, paper); preview will
+        //   render mostly-gray correctly.
+        val totalFrames = frameDiagnosticsLogged
+        val shouldLog = totalFrames < FRAME_DIAGNOSTIC_LIMIT ||
+            (totalFrames - FRAME_DIAGNOSTIC_LIMIT) %
+                FRAME_DIAGNOSTIC_HEARTBEAT_INTERVAL == 0
+        if (shouldLog) {
+            logFrameDiagnostics(frame, width, height, totalFrames)
+        }
+        frameDiagnosticsLogged++
+
+        // Meta DAT SDK 0.6.x always delivers tightly-packed I420 (verified
+        // against the official Android sample's `YuvToBitmapConverter` and
+        // confirmed at runtime by the HEVC decoder's `raw.pixel-format = 35`
+        // and `raw.color.matrix = 1` config). YuvToArgb uses BT.709
+        // coefficients matching the codec's advertised matrix.
+        YuvToArgb.convert(
+            yuvData = frame.buffer,
+            width = width,
+            height = height,
+            output = bitmap,
+        )
+
+        try {
+            val canvas = surface.lockHardwareCanvas() ?: return
+            try {
+                canvas.drawColor(android.graphics.Color.BLACK)
+                val matrix = Matrix().apply {
+                    val sx = canvas.width / width.toFloat()
+                    val sy = canvas.height / height.toFloat()
+                    val s = minOf(sx, sy)
+                    postScale(s, s)
+                    postTranslate(
+                        (canvas.width - width * s) / 2f,
+                        (canvas.height - height * s) / 2f,
+                    )
+                }
+                canvas.drawBitmap(bitmap, matrix, framePaint)
+            } finally {
+                surface.unlockCanvasAndPost(canvas)
+            }
+        } catch (_: IllegalStateException) {
+            // Surface released between check and lock - ignore.
+        }
+
+        if (lastWidth != width || lastHeight != height) {
+            lastWidth = width
+            lastHeight = height
+            mainHandler.post {
+                sizeSink?.success(mapOf("width" to width, "height" to height))
+            }
+        }
+    }
+
+    /**
+     * Serialises a single I420 [VideoFrame] into the Flutter platform-channel
+     * payload consumed by [`videoFramesStream`]. The three planes are
+     * concatenated as `Y | U | V` to `width * height * 3/2` bytes
+     * (Android I420 is always 8-bit, packed; no row stride padding for the
+     * common SDK shape — if the underlying planes have stride > width we
+     * strip the padding here so Dart callers see a tightly-packed buffer).
+     *
+     * The payload shape matches `VideoFrame.fromMap` on Dart:
+     *   `{ codec, bytes, width, height, ptsUs, isKeyframe, bytesPerRow=null }`.
+     */
+    private fun emitVideoFrame(
+        frame: VideoFrame,
+        width: Int,
+        height: Int,
+        sink: EventChannel.EventSink,
+    ) {
+        val ySize = width * height
+        val uvSize = (width / 2) * (height / 2)
+        val total = ySize + 2 * uvSize
+        // SDK 0.6.x: `VideoFrame.buffer` already contains I420 as
+        // Y | U | V with no row-stride padding. Single bulk copy.
+        val out = ByteArray(total)
+        val src = frame.buffer.duplicate().apply { position(frame.buffer.position()) }
+        val available = minOf(total, src.remaining())
+        src.get(out, 0, available)
+
+        val ptsUs = frame.presentationTimeUs
+
+        mainHandler.post {
+            sink.success(
+                mapOf(
+                    "codec" to "raw",
+                    "bytes" to out,
+                    "width" to width,
+                    "height" to height,
+                    "ptsUs" to ptsUs,
+                    "isKeyframe" to true,
+                    "bytesPerRow" to null,
+                ),
+            )
+        }
+    }
+
+    /**
+     * Serialises a compressed (hvc1) [VideoFrame] payload to the
+     * `videoFramesStream` map shape.
+     *
+     * The Meta DAT 0.6.x [VideoFrame] type exposes the compressed bytes
+     * via a `compressedData: ByteBuffer?` (or similar) field depending
+     * on the SDK build. We use reflection so we don't break compilation
+     * across SDK revisions, and gracefully fall back to skipping the
+     * frame if the field cannot be resolved.
+     */
+    private fun emitCompressedFrame(
+        frame: VideoFrame,
+        width: Int,
+        height: Int,
+        sink: EventChannel.EventSink,
+    ) {
+        val payload = extractCompressedBytes(frame) ?: return
+        val isKeyframe = extractIsKeyframe(frame)
+        val nowNs = android.os.SystemClock.elapsedRealtimeNanos()
+        val ptsUs = if (streamStartElapsedNs == 0L) 0L
+        else (nowNs - streamStartElapsedNs) / 1_000L
+        mainHandler.post {
+            sink.success(
+                mapOf(
+                    "codec" to "hvc1",
+                    "bytes" to payload,
+                    "width" to width,
+                    "height" to height,
+                    "ptsUs" to ptsUs,
+                    "isKeyframe" to isKeyframe,
+                    "bytesPerRow" to null,
+                ),
+            )
+        }
+    }
+
+    /**
+     * Reads the compressed-payload bytes from a [VideoFrame] using
+     * reflection. Tries the common field names that have appeared
+     * across DAT SDK 0.6.x builds (`compressedData`, `compressed`,
+     * `compressedBytes`). Returns `null` when no matching field is
+     * present.
+     */
+    private fun extractCompressedBytes(frame: VideoFrame): ByteArray? {
+        val candidates = listOf(
+            "getCompressedData",
+            "getCompressed",
+            "getCompressedBytes",
+            "getEncoded",
+        )
+        for (name in candidates) {
+            val method = try {
+                frame::class.java.getMethod(name)
+            } catch (_: Throwable) {
+                continue
+            }
+            val value = try { method.invoke(frame) } catch (_: Throwable) { null }
+            when (value) {
+                is ByteArray -> return value
+                is java.nio.ByteBuffer -> {
+                    val dup = value.duplicate()
+                    dup.position(0)
+                    val out = ByteArray(dup.remaining())
+                    dup.get(out)
+                    return out
+                }
+                else -> Unit
+            }
+        }
+        return null
+    }
+
+    /**
+     * Reads `isKeyframe` / `isKey` / `keyframe` from a [VideoFrame] via
+     * reflection, defaulting to `true` when no matching getter is
+     * present (single-NAL CMSampleBuffers).
+     */
+    private fun extractIsKeyframe(frame: VideoFrame): Boolean {
+        val names = listOf("isKeyframe", "isKey", "getKeyframe", "isCompressedKey")
+        for (name in names) {
+            val method = try {
+                frame::class.java.getMethod(name)
+            } catch (_: Throwable) {
+                continue
+            }
+            val value = try { method.invoke(frame) } catch (_: Throwable) { null }
+            if (value is Boolean) return value
+        }
+        return true
+    }
+
+    private fun ensureBitmap(width: Int, height: Int): Bitmap {
+        val existing = argbBitmap
+        if (existing != null && existing.width == width && existing.height == height) {
+            return existing
+        }
+        existing?.recycle()
+        val created = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
+        argbBitmap = created
+        return created
+    }
+
+    /**
+     * Per-frame logcat diagnostic for the first
+     * [FRAME_DIAGNOSTIC_LIMIT] decoded frames of a stream, then a
+     * heartbeat every [FRAME_DIAGNOSTIC_HEARTBEAT_INTERVAL] frames.
+     * Emits everything we need to verify the conversion pipeline is
+     * alive and the source data is what we think it is:
+     *
+     * - `bufRemaining` — exact byte count, so we can compare against the
+     *   tightly-packed I420 expected size (`w * h * 3 / 2`). Mismatches
+     *   mean the SDK is handing us a shape we don't support.
+     * - `Y[min/mean/max]` — luma plane stats over the first 4 KiB of Y.
+     *   Flat values mean the SDK is emitting placeholder frames during
+     *   stream warm-up; the symptom is a uniform preview.
+     * - `C[min/mean/max]` — chroma stats over the first 4 KiB after the
+     *   Y plane. Values clustered tightly around 128 indicate a
+     *   near-monochrome real scene (white wall, hand, paper).
+     * - On the very first frame, also dumps the first 32 bytes in hex
+     *   for after-the-fact verification.
+     */
+    private fun logFrameDiagnostics(
+        frame: VideoFrame,
+        width: Int,
+        height: Int,
+        index: Int,
+    ) {
+        val frameSize = width * height
+        val expected420 = frameSize + (frameSize shr 1)
+        val remaining = frame.buffer.remaining()
+
+        // Y plane stats over the first 4096 bytes — cheap and a good
+        // proxy for whether luma is varying.
+        val ySampleSize = minOf(4096, frameSize, remaining)
+        val ySample = ByteArray(ySampleSize)
+        frame.buffer.duplicate().apply { position(frame.buffer.position()) }
+            .get(ySample, 0, ySampleSize)
+        var yMin = 255
+        var yMax = 0
+        var ySum = 0L
+        for (k in 0 until ySampleSize) {
+            val v = ySample[k].toInt() and 0xff
+            if (v < yMin) yMin = v
+            if (v > yMax) yMax = v
+            ySum += v
+        }
+        val yMean = if (ySampleSize > 0) ySum / ySampleSize else 0
+
+        // Chroma area stats over the first 4096 bytes after Y.
+        val chromaStart = frame.buffer.position() + frameSize
+        val cAvailable = (frame.buffer.limit() - chromaStart).coerceAtLeast(0)
+        val cSampleSize = minOf(4096, frameSize shr 1, cAvailable)
+        var cMin = 255
+        var cMax = 0
+        var cMean = 0L
+        if (cSampleSize > 0) {
+            val cSample = ByteArray(cSampleSize)
+            frame.buffer.duplicate().apply { position(chromaStart) }
+                .get(cSample, 0, cSampleSize)
+            for (k in 0 until cSampleSize) {
+                val v = cSample[k].toInt() and 0xff
+                if (v < cMin) cMin = v
+                if (v > cMax) cMax = v
+                cMean += v
+            }
+            cMean /= cSampleSize
+        } else {
+            cMin = 0; cMax = 0; cMean = 0L
+        }
+
+        val hexSuffix = if (index == 0) {
+            val first32 = ByteArray(minOf(32, remaining))
+            frame.buffer.duplicate().apply { position(frame.buffer.position()) }
+                .get(first32, 0, first32.size)
+            " first32=" + first32.joinToString(" ") {
+                "%02x".format(it.toInt() and 0xff)
+            }
+        } else {
+            ""
+        }
+
+        android.util.Log.i(
+            "MetaSessionManager",
+            "frame#$index ${width}x${height} codec=$activeCodec " +
+                "bufRemaining=$remaining expectedI420=$expected420 " +
+                "Y[min=$yMin mean=$yMean max=$yMax] " +
+                "C[min=$cMin mean=$cMean max=$cMax]" +
+                hexSuffix,
+        )
+    }
+
+    // --- State / error encoding ---------------------------------------------
+
+    private fun postState(state: StreamState) {
+        // DAT 0.7.0 turned `StreamState` into an enum (was a sealed class in
+        // 0.6.x), so match on `name` rather than the runtime class. The
+        // enum adds `STARTED` and a terminal `CLOSED`; both collapse onto the
+        // 6-value Dart `StreamSessionState` contract.
+        val encoded = when (state.name.uppercase().replace("_", "")) {
+            "STOPPED", "CLOSED" -> 0
+            "WAITINGFORDEVICE" -> 1
+            "STARTING" -> 2
+            "STREAMING", "STARTED" -> 3
+            "PAUSED" -> 4
+            "STOPPING" -> 5
+            else -> 0
+        }
+        // Mirror every Stream state transition to logcat so we can
+        // reconstruct the lifecycle even when the Dart UI label appears
+        // stuck (e.g. "Stopped" after a brief Streaming → Stopped flip).
+        android.util.Log.i(
+            "MetaSessionManager",
+            "stream state -> ${state.name} (encoded=$encoded)",
+        )
+        mainHandler.post { stateSink?.success(encoded) }
+    }
+
+    private fun postError(error: StreamError) {
+        // DAT 0.7.0: `StreamError` is an enum whose human-readable text lives
+        // on `.description`. Match on `name` (0.6.x was a sealed class).
+        val message = runCatching { error.description }
+            .getOrNull()
+            ?.takeIf { it.isNotEmpty() }
+            ?: error.name
+        // Match Dart's `StreamSessionError` code shape: typed codes
+        // for the cases the Dart facade flips into `is*` getters.
+        val code = when (error.name.uppercase().replace("_", "")) {
+            "PERMISSIONDENIED" -> "permissionDenied"
+            "THERMALCRITICAL" -> "thermalCritical"
+            "HINGESCLOSED", "HINGECLOSED" -> "hingesClosed"
+            "DEVICEDISCONNECTED", "DEVICENOTCONNECTED" -> "deviceDisconnected"
+            "DEVICENOTFOUND" -> "deviceNotFound"
+            "TIMEOUT" -> "timeout"
+            "VIDEOSTREAMINGERROR", "STREAMERROR" -> "videoStreamingError"
+            "INTERNALERROR" -> "internalError"
+            else -> "sessionError"
+        }
+        android.util.Log.w(
+            "MetaSessionManager",
+            "stream error -> code=$code message=$message",
+        )
+        mainHandler.post {
+            errorSink?.success(mapOf("code" to code, "message" to message))
+        }
+    }
+
+    private fun encodeDeviceSessionState(state: DeviceSessionState): Int =
+        // Map by name so we don't break compilation if Meta adds enum cases.
+        when (state.name.uppercase()) {
+            "IDLE" -> 0
+            "STARTING" -> 1
+            "STARTED", "RUNNING" -> 2
+            "PAUSED" -> 3
+            "STOPPING" -> 4
+            "STOPPED", "CLOSED" -> 5
+            else -> 0
+        }
+
+    private fun encodeDeviceSessionError(error: Any?): Map<String, Any?> {
+        val message = error?.toString() ?: "unknown"
+        // DAT 0.7.0: `DeviceSessionError` is an enum, so prefer the entry
+        // `name`; fall back to the runtime class name for older sealed-class
+        // shapes. Normalise SCREAMING_SNAKE / camelCase before matching.
+        val name = ((error as? Enum<*>)?.name
+            ?: error?.let { it::class.java.simpleName }
+            ?: "")
+            .uppercase()
+            .replace("_", "")
+        val code = when (name) {
+            "NOELIGIBLEDEVICE" -> "noEligibleDevice"
+            "SESSIONALREADYSTOPPED" -> "sessionAlreadyStopped"
+            "SESSIONALREADYEXISTS" -> "sessionAlreadyExists"
+            "SESSIONIDLE" -> "sessionIdle"
+            "CAPABILITYALREADYACTIVE" -> "capabilityAlreadyActive"
+            "CAPABILITYNOTFOUND" -> "capabilityNotFound"
+            "DATAPPONTHEGLASSESUPDATEREQUIRED" -> "datAppUpdateRequired"
+            else -> "unexpectedError"
+        }
+        return mapOf("code" to code, "message" to message)
+    }
+
+    /**
+     * Builds a [StreamConfiguration] respecting [compressVideo]. The
+     * SDK 0.6.x [StreamConfiguration] type only adds the
+     * `compressVideo` knob in some shipping flavours, so we use
+     * reflection to set it when present and fall back to the legacy
+     * two-arg constructor otherwise. This avoids breaking compilation
+     * if Meta changes the constructor surface.
+     */
+    private fun buildStreamConfiguration(
+        quality: VideoQuality,
+        fps: Int,
+        compressVideo: Boolean,
+    ): StreamConfiguration {
+        if (!compressVideo) {
+            return StreamConfiguration(videoQuality = quality, frameRate = fps)
+        }
+        // Try the three-arg constructor first via reflection.
+        try {
+            val ctor = StreamConfiguration::class.java
+                .declaredConstructors
+                .firstOrNull { it.parameterCount == 3 }
+            if (ctor != null) {
+                @Suppress("UNCHECKED_CAST")
+                val instance = ctor.newInstance(quality, fps, compressVideo)
+                    as StreamConfiguration
+                return instance
+            }
+        } catch (_: Throwable) {
+            // fall through
+        }
+        // Fall back to the two-arg constructor and try setting
+        // `compressVideo` via reflection on the instance afterwards.
+        val cfg = StreamConfiguration(videoQuality = quality, frameRate = fps)
+        try {
+            val field = cfg::class.java.declaredFields.firstOrNull {
+                it.name == "compressVideo"
+            }
+            if (field != null) {
+                field.isAccessible = true
+                field.setBoolean(cfg, true)
+            }
+        } catch (_: Throwable) {
+            android.util.Log.w(
+                "MetaSessionManager",
+                "Requested compressVideo=true but this Meta DAT SDK does " +
+                    "not expose the field; falling back to raw frames. " +
+                    "Update the dependency or report a bug.",
+            )
+        }
+        return cfg
+    }
+
+    private companion object {
+        val framePaint = Paint(Paint.ANTI_ALIAS_FLAG or Paint.FILTER_BITMAP_FLAG)
+
+        /**
+         * How long to wait for `Session.state` to reach
+         * [DeviceSessionState.STARTED] before bailing out of
+         * [startSession]. 30 s comfortably covers a worst-case BLE →
+         * Bluetooth-Classic / Wi-Fi link upgrade on a fresh pair (we
+         * see ≤ 15 s in practice) but trips fast enough on a hung
+         * handover that the Flutter UI button never feels stuck.
+         */
+        const val SESSION_STARTED_TIMEOUT_MS: Long = 30_000L
+
+        /**
+         * How many frames to emit detailed `frame#N …` diagnostics for
+         * at the start of a stream. 10 covers the typical 300-500 ms
+         * warm-up window during which the glasses are pushing
+         * placeholder / black frames before real video arrives, while
+         * still terminating quickly enough that logcat doesn't fill
+         * with per-frame spam for the lifetime of the stream.
+         */
+        const val FRAME_DIAGNOSTIC_LIMIT: Int = 10
+
+        /**
+         * After the initial [FRAME_DIAGNOSTIC_LIMIT] detailed frame
+         * logs, emit one more `frame#N …` line every N frames so we
+         * keep visibility on the stream without spamming logcat. 30
+         * frames ≈ 1 s at 30 fps — enough to spot a flat-luma →
+         * real-content transition (or its absence) over the lifetime
+         * of a session.
+         */
+        const val FRAME_DIAGNOSTIC_HEARTBEAT_INTERVAL: Int = 30
+
+        /**
+         * How many times to retry [com.meta.wearable.dat.core.Wearables.createSession]
+         * after a transient eligibility failure (the glasses are paired
+         * but their `don sensor` / wear signal hasn't surfaced yet, so
+         * the SDK refuses with `noEligibleDevice` even when we pass a
+         * `SpecificDeviceSelector`). Combined with
+         * [CREATE_SESSION_RETRY_DELAY_MS] this gives the device up to
+         * ~9 s of warm-up before we surface the error to the user.
+         */
+        const val CREATE_SESSION_MAX_RETRIES: Int = 6
+
+        /** Delay between [com.meta.wearable.dat.core.Wearables.createSession] retries, ms. */
+        const val CREATE_SESSION_RETRY_DELAY_MS: Long = 1_500L
+    }
+}

--- a/app/third_party/meta_wearables_dat_flutter/android/src/main/kotlin/com/iseelabs/meta_wearables_dat_flutter/MetaWearablesDatPlugin.kt
+++ b/app/third_party/meta_wearables_dat_flutter/android/src/main/kotlin/com/iseelabs/meta_wearables_dat_flutter/MetaWearablesDatPlugin.kt
@@ -1,0 +1,1314 @@
+// `meta_wearables_dat_flutter` Android plugin.
+//
+// Bridges Meta's MWDAT* Kotlin SDKs to a Dart MethodChannel + EventChannel
+// surface. Responsibilities:
+//   * Request runtime permissions (BLUETOOTH_CONNECT etc) on demand.
+//   * Registration: startRegistration, startUnregistration, handleUrl
+//     (no-op on Android; the SDK consumes deep links via the host
+//     activity's intent-filter), plus registration_state and
+//     active_device EventChannels.
+//   * Streaming: startStreamSession, stopStreamSession, pause/resume,
+//     plus session_state, session_errors and video_stream_size
+//     EventChannels. Frame plumbing lives in MetaSessionManager.
+//   * Mock Device Kit pass-throughs.
+//
+// Meta's `Wearables.initialize(activity)` is called exactly once, only
+// AFTER `BLUETOOTH_CONNECT` is granted - calling it earlier silently
+// breaks device discovery. Stream handlers therefore wait on a Mutex/flag
+// until init has run; if a Dart subscriber attaches before init,
+// collection starts as soon as init fires.
+
+package com.iseelabs.meta_wearables_dat_flutter
+
+import android.Manifest
+import android.app.Activity
+import android.content.pm.PackageManager
+import android.os.Build
+import androidx.activity.ComponentActivity
+import androidx.activity.result.ActivityResultLauncher
+import androidx.core.app.ActivityCompat
+import com.meta.wearable.dat.camera.types.VideoQuality
+import com.meta.wearable.dat.core.Wearables
+import com.meta.wearable.dat.core.selectors.AutoDeviceSelector
+import com.meta.wearable.dat.core.types.DeviceIdentifier
+import com.meta.wearable.dat.core.types.Permission
+import com.meta.wearable.dat.core.types.PermissionStatus
+import com.meta.wearable.dat.core.types.RegistrationState
+import io.flutter.embedding.engine.plugins.FlutterPlugin
+import io.flutter.embedding.engine.plugins.activity.ActivityAware
+import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding
+import io.flutter.plugin.common.EventChannel
+import io.flutter.plugin.common.MethodCall
+import io.flutter.plugin.common.MethodChannel
+import io.flutter.plugin.common.MethodChannel.MethodCallHandler
+import io.flutter.plugin.common.MethodChannel.Result
+import io.flutter.plugin.common.PluginRegistry
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+
+class MetaWearablesDatPlugin :
+    FlutterPlugin,
+    MethodCallHandler,
+    ActivityAware,
+    PluginRegistry.RequestPermissionsResultListener {
+
+    private lateinit var channel: MethodChannel
+    private lateinit var registrationStateChannel: EventChannel
+    private lateinit var activeDeviceChannel: EventChannel
+    private lateinit var devicesChannel: EventChannel
+    private lateinit var compatibilityChannel: EventChannel
+    private lateinit var streamSessionStateChannel: EventChannel
+    private lateinit var streamSessionErrorChannel: EventChannel
+    private lateinit var deviceSessionStateChannel: EventChannel
+    private lateinit var deviceSessionErrorChannel: EventChannel
+    private lateinit var videoSizeChannel: EventChannel
+    private lateinit var videoFramesChannel: EventChannel
+    private lateinit var mockDevicesChannel: EventChannel
+    private lateinit var displayStateChannel: EventChannel
+    private lateinit var displayEventsChannel: EventChannel
+
+    private var sessionManager: MetaSessionManager? = null
+    private var mockManager: MetaMockDeviceManager? = null
+    private var displayManager: MetaDisplayManager? = null
+
+    private var activityBinding: ActivityPluginBinding? = null
+    private var activity: Activity? = null
+    private var appContext: android.content.Context? = null
+
+    private var pendingPermissionResult: Result? = null
+    private var pendingCameraPermissionResult: Result? = null
+
+    /**
+     * Activity-result launcher driving Meta's
+     * `Wearables.RequestPermissionContract`. Registered with the host
+     * activity's `ActivityResultRegistry` from `onAttachedToActivity` and
+     * unregistered on detach. `null` when the activity has not been
+     * attached yet, or when the activity isn't a `ComponentActivity` (in
+     * which case `requestCameraPermission` returns
+     * `MISSING_FRAGMENT_ACTIVITY`).
+     */
+    private var cameraPermissionLauncher: ActivityResultLauncher<Permission>? = null
+
+    /**
+     * Gated initialisation. Flips to `true` exactly once after
+     * `BLUETOOTH_CONNECT` is granted and `Wearables.initialize(activity)`
+     * has returned. Stream handlers observe this flow and defer collection
+     * until it flips, then start automatically.
+     */
+    private val wearablesInitialised = MutableStateFlow(false)
+
+    private val pluginScope =
+        CoroutineScope(Dispatchers.Main.immediate + SupervisorJob())
+
+    private val registrationStateHandler = RegistrationStateStreamHandler()
+    private val activeDeviceHandler = ActiveDeviceStreamHandler()
+    private val devicesHandler = DevicesStreamHandler()
+    private val compatibilityHandler = CompatibilityStreamHandler()
+    private val streamSessionStateHandler = PassthroughStreamHandler { sink ->
+        sessionManager?.setStateSink(sink)
+    }
+    private val streamSessionErrorHandler = PassthroughStreamHandler { sink ->
+        sessionManager?.setErrorSink(sink)
+    }
+    private val deviceSessionStateHandler = PassthroughStreamHandler { sink ->
+        sessionManager?.setDeviceStateSink(sink)
+    }
+    private val deviceSessionErrorHandler = PassthroughStreamHandler { sink ->
+        sessionManager?.setDeviceErrorSink(sink)
+    }
+    private val videoSizeHandler = PassthroughStreamHandler { sink ->
+        sessionManager?.setSizeSink(sink)
+    }
+    private val videoFramesHandler = PassthroughStreamHandler { sink ->
+        sessionManager?.setFramesSink(sink)
+    }
+    private val mockDevicesHandler = PassthroughStreamHandler { sink ->
+        mockManager?.setMockDevicesSink(sink)
+    }
+    private val displayStateHandler = PassthroughStreamHandler { sink ->
+        displayManager?.setDisplayStateSink(sink)
+    }
+    private val displayEventsHandler = PassthroughStreamHandler { sink ->
+        displayManager?.setDisplayEventsSink(sink)
+    }
+
+    // --- FlutterPlugin --------------------------------------------------------
+
+    override fun onAttachedToEngine(binding: FlutterPlugin.FlutterPluginBinding) {
+        appContext = binding.applicationContext
+        channel = MethodChannel(binding.binaryMessenger, "meta_wearables_dat_flutter")
+        channel.setMethodCallHandler(this)
+
+        registrationStateChannel = EventChannel(
+            binding.binaryMessenger,
+            "meta_wearables_dat_flutter/registration_state",
+        )
+        registrationStateChannel.setStreamHandler(registrationStateHandler)
+
+        activeDeviceChannel = EventChannel(
+            binding.binaryMessenger,
+            "meta_wearables_dat_flutter/active_device",
+        )
+        activeDeviceChannel.setStreamHandler(activeDeviceHandler)
+
+        devicesChannel = EventChannel(
+            binding.binaryMessenger,
+            "meta_wearables_dat_flutter/devices",
+        )
+        devicesChannel.setStreamHandler(devicesHandler)
+
+        compatibilityChannel = EventChannel(
+            binding.binaryMessenger,
+            "meta_wearables_dat_flutter/compatibility",
+        )
+        compatibilityChannel.setStreamHandler(compatibilityHandler)
+
+        streamSessionStateChannel = EventChannel(
+            binding.binaryMessenger,
+            "meta_wearables_dat_flutter/stream_session_state",
+        )
+        streamSessionStateChannel.setStreamHandler(streamSessionStateHandler)
+
+        streamSessionErrorChannel = EventChannel(
+            binding.binaryMessenger,
+            "meta_wearables_dat_flutter/stream_session_errors",
+        )
+        streamSessionErrorChannel.setStreamHandler(streamSessionErrorHandler)
+
+        deviceSessionStateChannel = EventChannel(
+            binding.binaryMessenger,
+            "meta_wearables_dat_flutter/device_session_state",
+        )
+        deviceSessionStateChannel.setStreamHandler(deviceSessionStateHandler)
+
+        deviceSessionErrorChannel = EventChannel(
+            binding.binaryMessenger,
+            "meta_wearables_dat_flutter/device_session_errors",
+        )
+        deviceSessionErrorChannel.setStreamHandler(deviceSessionErrorHandler)
+
+        videoSizeChannel = EventChannel(
+            binding.binaryMessenger,
+            "meta_wearables_dat_flutter/video_stream_size",
+        )
+        videoSizeChannel.setStreamHandler(videoSizeHandler)
+
+        videoFramesChannel = EventChannel(
+            binding.binaryMessenger,
+            "meta_wearables_dat_flutter/video_frames",
+        )
+        videoFramesChannel.setStreamHandler(videoFramesHandler)
+
+        mockDevicesChannel = EventChannel(
+            binding.binaryMessenger,
+            "meta_wearables_dat_flutter/mock_devices",
+        )
+        mockDevicesChannel.setStreamHandler(mockDevicesHandler)
+
+        displayStateChannel = EventChannel(
+            binding.binaryMessenger,
+            "meta_wearables_dat_flutter/display_state",
+        )
+        displayStateChannel.setStreamHandler(displayStateHandler)
+
+        displayEventsChannel = EventChannel(
+            binding.binaryMessenger,
+            "meta_wearables_dat_flutter/display_events",
+        )
+        displayEventsChannel.setStreamHandler(displayEventsHandler)
+
+        sessionManager = MetaSessionManager(binding.textureRegistry)
+        mockManager = MetaMockDeviceManager(binding.applicationContext)
+        displayManager = MetaDisplayManager()
+
+        // Force-link Meta's SDK so missing-dependency errors surface here at
+        // attach time rather than later when a real method is invoked.
+        @Suppress("UNUSED_VARIABLE")
+        val wearablesClass = Wearables::class.java
+    }
+
+    override fun onDetachedFromEngine(binding: FlutterPlugin.FlutterPluginBinding) {
+        channel.setMethodCallHandler(null)
+        registrationStateChannel.setStreamHandler(null)
+        activeDeviceChannel.setStreamHandler(null)
+        devicesChannel.setStreamHandler(null)
+        compatibilityChannel.setStreamHandler(null)
+        streamSessionStateChannel.setStreamHandler(null)
+        streamSessionErrorChannel.setStreamHandler(null)
+        deviceSessionStateChannel.setStreamHandler(null)
+        deviceSessionErrorChannel.setStreamHandler(null)
+        videoSizeChannel.setStreamHandler(null)
+        videoFramesChannel.setStreamHandler(null)
+        mockDevicesChannel.setStreamHandler(null)
+        displayStateChannel.setStreamHandler(null)
+        displayEventsChannel.setStreamHandler(null)
+        registrationStateHandler.cancel()
+        activeDeviceHandler.cancel()
+        devicesHandler.cancel()
+        compatibilityHandler.cancel()
+        sessionManager?.dispose()
+        sessionManager = null
+        mockManager = null
+        displayManager?.dispose()
+        displayManager = null
+        pluginScope.cancel()
+    }
+
+    // --- ActivityAware --------------------------------------------------------
+
+    override fun onAttachedToActivity(binding: ActivityPluginBinding) {
+        activityBinding = binding
+        activity = binding.activity
+        binding.addRequestPermissionsResultListener(this)
+        registerCameraPermissionLauncher(binding.activity)
+    }
+
+    override fun onDetachedFromActivityForConfigChanges() = onDetachedFromActivity()
+
+    override fun onReattachedToActivityForConfigChanges(binding: ActivityPluginBinding) =
+        onAttachedToActivity(binding)
+
+    override fun onDetachedFromActivity() {
+        activityBinding?.removeRequestPermissionsResultListener(this)
+        activityBinding = null
+        activity = null
+        cameraPermissionLauncher?.unregister()
+        cameraPermissionLauncher = null
+    }
+
+    private fun registerCameraPermissionLauncher(activity: Activity) {
+        if (activity !is ComponentActivity) return
+        cameraPermissionLauncher = activity.activityResultRegistry.register(
+            "meta_wearables_dat_camera_permission",
+            Wearables.RequestPermissionContract(),
+        ) { result ->
+            val pending = pendingCameraPermissionResult
+            pendingCameraPermissionResult = null
+            // Wearables.RequestPermissionContract returns
+            // `Result<PermissionStatus>` (Meta's own Result type, not
+            // kotlin.Result) so we use getOrDefault to coerce to a
+            // PermissionStatus regardless of failure shape.
+            val status = result.getOrDefault(PermissionStatus.Denied)
+            pending?.success(status == PermissionStatus.Granted)
+        }
+    }
+
+    // --- MethodCallHandler ----------------------------------------------------
+
+    override fun onMethodCall(call: MethodCall, result: Result) {
+        when (call.method) {
+            "getPlatformVersion" -> result.success("Android ${Build.VERSION.RELEASE}")
+            "dumpDiagnostics" -> result.success(dumpDiagnostics())
+            "requestAndroidPermissions" -> requestAndroidPermissions(result)
+            "startRegistration" -> startRegistration(result)
+            "startUnregistration" -> startUnregistration(result)
+            "handleUrl" -> handleUrl(result)
+            "getRegistrationState" -> getRegistrationState(result)
+            "getDevices" -> getDevices(result)
+            "openFirmwareUpdate" -> result.error("UNAVAILABLE", "Firmware update flow is handled by Meta AI on iOS.", null)
+            "openDATGlassesAppUpdate" -> result.error("UNAVAILABLE", "DAT glasses app update flow is handled by Meta AI on iOS.", null)
+            "requestCameraPermission" -> requestCameraPermission(result)
+            "getCameraPermissionStatus" -> getCameraPermissionStatus(result)
+            "startStreamSession" -> startStreamSession(call, result)
+            "stopStreamSession" -> stopStreamSession(result)
+            "pauseStreamSession" -> pauseStreamSession(result)
+            "resumeStreamSession" -> resumeStreamSession(result)
+            "capturePhoto" -> capturePhoto(result)
+            "enableBackgroundStreaming" -> enableBackgroundStreaming(call, result)
+            "disableBackgroundStreaming" -> disableBackgroundStreaming(result)
+            "startDisplaySession" -> startDisplaySession(call, result)
+            "sendDisplayView" -> sendDisplayView(call, result)
+            "stopDisplaySession" -> stopDisplaySession(result)
+            "enableMockDevice" -> mockCall(result) {
+                it.enable(
+                    call.argument<Boolean>("initiallyRegistered") ?: true,
+                    call.argument<Boolean>("initialPermissionsGranted") ?: true,
+                )
+            }
+            "disableMockDevice" -> mockCall(result) { it.disable() }
+            "isMockDeviceEnabled" -> mockCallReturning(result) { it.isEnabled() }
+            "pairMockRayBanMeta" -> mockCallReturning(result) { it.pairRayBanMeta() }
+            "pairedMockDevices" -> mockCallReturning(result) { it.pairedDevices() }
+            "unpairMockDevice" -> mockCall(result) {
+                it.unpair(call.argument<String>("uuid") ?: "")
+            }
+            "mockPowerOn" -> mockCall(result) {
+                it.powerOn(call.argument<String>("uuid") ?: "")
+            }
+            "mockPowerOff" -> mockCall(result) {
+                it.powerOff(call.argument<String>("uuid") ?: "")
+            }
+            "mockDon" -> mockCall(result) {
+                it.don(call.argument<String>("uuid") ?: "")
+            }
+            "mockDoff" -> mockCall(result) {
+                it.doff(call.argument<String>("uuid") ?: "")
+            }
+            "mockFold" -> mockCall(result) {
+                it.fold(call.argument<String>("uuid") ?: "")
+            }
+            "mockUnfold" -> mockCall(result) {
+                it.unfold(call.argument<String>("uuid") ?: "")
+            }
+            "setMockCameraFacing" -> mockCall(result) {
+                it.setCameraFacing(
+                    call.argument<String>("uuid") ?: "",
+                    call.argument<String>("facing") ?: "rear",
+                )
+            }
+            "setMockCameraFeed" -> mockCall(result) {
+                it.setCameraFeed(
+                    call.argument<String>("uuid") ?: "",
+                    call.argument<String>("filePath"),
+                )
+            }
+            "setMockCapturedImage" -> mockCall(result) {
+                it.setCapturedImage(
+                    call.argument<String>("uuid") ?: "",
+                    call.argument<String>("filePath"),
+                )
+            }
+            "setMockPermission" -> mockCall(result) {
+                it.setPermission(
+                    call.argument<String>("permission") ?: "",
+                    call.argument<String>("status") ?: "",
+                )
+            }
+            "setMockPermissionRequestResult" -> mockCall(result) {
+                it.setPermissionRequestResult(
+                    call.argument<String>("permission") ?: "",
+                    call.argument<String>("status") ?: "",
+                )
+            }
+            else -> result.notImplemented()
+        }
+    }
+
+    private inline fun mockCall(result: Result, block: (MetaMockDeviceManager) -> Unit) {
+        val manager = mockManager ?: run {
+            result.error("MOCK_ERROR", "Mock manager unavailable", null)
+            return
+        }
+        try {
+            block(manager)
+            result.success(null)
+        } catch (e: Exception) {
+            result.error("MOCK_ERROR", e.message ?: e::class.java.simpleName, null)
+        }
+    }
+
+    private inline fun <T> mockCallReturning(
+        result: Result,
+        block: (MetaMockDeviceManager) -> T,
+    ) {
+        val manager = mockManager ?: run {
+            result.error("MOCK_ERROR", "Mock manager unavailable", null)
+            return
+        }
+        try {
+            result.success(block(manager))
+        } catch (e: Exception) {
+            result.error("MOCK_ERROR", e.message ?: e::class.java.simpleName, null)
+        }
+    }
+
+    private fun capturePhoto(result: Result) {
+        val manager = sessionManager
+        if (manager == null) {
+            result.error(
+                "CAPTURE_ERROR",
+                "Plugin not attached to engine.",
+                null,
+            )
+            return
+        }
+        pluginScope.launch {
+            try {
+                val (bytes, format) = manager.capturePhoto()
+                result.success(mapOf("bytes" to bytes, "format" to format))
+            } catch (e: Exception) {
+                result.error(
+                    "CAPTURE_ERROR",
+                    e.message ?: e::class.java.simpleName,
+                    null,
+                )
+            }
+        }
+    }
+
+    // --- Background streaming --------------------------------------------------
+
+    private fun enableBackgroundStreaming(call: MethodCall, result: Result) {
+        val act = activity ?: appContext
+        if (act == null) {
+            result.error(
+                "NO_ACTIVITY",
+                "Cannot enable background streaming without an Activity or " +
+                    "application Context.",
+                null,
+            )
+            return
+        }
+        val notification = call.argument<Map<String, Any?>>("androidNotification")
+        if (notification == null) {
+            result.error(
+                "SESSION_ERROR",
+                "androidNotification is required on Android. Pass a " +
+                    "BackgroundNotification with title/text/channelId/channelName.",
+                null,
+            )
+            return
+        }
+        if (!ensurePostNotificationsPermission(act)) {
+            android.util.Log.w(
+                "MetaWearablesDat",
+                "POST_NOTIFICATIONS is not yet granted; the foreground " +
+                    "service notification may be suppressed. Request the " +
+                    "permission from your host app on API 33+.",
+            )
+        }
+        val intent = android.content.Intent(
+            act.applicationContext,
+            BackgroundStreamingService::class.java,
+        ).apply {
+            putExtra(
+                BackgroundStreamingService.EXTRA_TITLE,
+                notification["title"] as? String,
+            )
+            putExtra(
+                BackgroundStreamingService.EXTRA_TEXT,
+                notification["text"] as? String,
+            )
+            putExtra(
+                BackgroundStreamingService.EXTRA_CHANNEL_ID,
+                notification["channelId"] as? String,
+            )
+            putExtra(
+                BackgroundStreamingService.EXTRA_CHANNEL_NAME,
+                notification["channelName"] as? String,
+            )
+            putExtra(
+                BackgroundStreamingService.EXTRA_ICON_RESOURCE_NAME,
+                notification["iconResourceName"] as? String,
+            )
+        }
+        try {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                act.applicationContext.startForegroundService(intent)
+            } else {
+                act.applicationContext.startService(intent)
+            }
+            result.success(null)
+        } catch (e: Throwable) {
+            result.error(
+                "SESSION_ERROR",
+                "Failed to start BackgroundStreamingService: ${e.message}",
+                null,
+            )
+        }
+    }
+
+    private fun disableBackgroundStreaming(result: Result) {
+        val act = activity ?: appContext
+        if (act == null) {
+            result.success(null)
+            return
+        }
+        try {
+            act.applicationContext.stopService(
+                android.content.Intent(
+                    act.applicationContext,
+                    BackgroundStreamingService::class.java,
+                ),
+            )
+            result.success(null)
+        } catch (e: Throwable) {
+            result.success(null)
+        }
+    }
+
+    /**
+     * Best-effort runtime request for `POST_NOTIFICATIONS` on API 33+.
+     * Returns `true` if the permission is currently granted (i.e. the
+     * foreground-service notification will display). The actual prompt
+     * is fire-and-forget; host apps that want a synchronous answer
+     * should pre-request the permission themselves through `permission_handler`
+     * or `requestAndroidPermissions` first.
+     */
+    private fun ensurePostNotificationsPermission(
+        context: android.content.Context,
+    ): Boolean {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) return true
+        val granted = ActivityCompat.checkSelfPermission(
+            context,
+            "android.permission.POST_NOTIFICATIONS",
+        ) == PackageManager.PERMISSION_GRANTED
+        if (!granted) {
+            val act = activity
+            if (act != null) {
+                ActivityCompat.requestPermissions(
+                    act,
+                    arrayOf("android.permission.POST_NOTIFICATIONS"),
+                    PERMISSION_REQUEST_CODE,
+                )
+            }
+        }
+        return granted
+    }
+
+    // --- Streaming flow -------------------------------------------------------
+
+    private fun startStreamSession(call: MethodCall, result: Result) {
+        val manager = sessionManager
+        if (manager == null) {
+            result.error(
+                "SESSION_ERROR",
+                "Plugin not attached to engine.",
+                null,
+            )
+            return
+        }
+        val deviceUuid = call.argument<String>("deviceUuid")
+        val fps = call.argument<Int>("fps") ?: 30
+        val qualityRaw = call.argument<String>("quality") ?: "high"
+        val quality = when (qualityRaw) {
+            "low" -> VideoQuality.LOW
+            "medium" -> VideoQuality.MEDIUM
+            else -> VideoQuality.HIGH
+        }
+        val deviceKinds = call.argument<List<String>>("deviceKinds")?.toSet()
+        val videoCodec = call.argument<String>("videoCodec") ?: "raw"
+        pluginScope.launch {
+            try {
+                val id = manager.startSession(
+                    deviceUuid,
+                    fps,
+                    quality,
+                    deviceKinds,
+                    videoCodec,
+                )
+                result.success(id)
+            } catch (e: Exception) {
+                result.error(
+                    "SESSION_ERROR",
+                    e.message ?: e::class.java.simpleName,
+                    null,
+                )
+            }
+        }
+    }
+
+    private fun stopStreamSession(result: Result) {
+        val manager = sessionManager ?: run { result.success(null); return }
+        pluginScope.launch {
+            manager.stopSession()
+            result.success(null)
+        }
+    }
+
+    // --- Display --------------------------------------------------------------
+
+    private fun startDisplaySession(call: MethodCall, result: Result) {
+        val manager = displayManager
+        if (manager == null) {
+            result.error("DISPLAY_ERROR", "Plugin not attached to engine.", null)
+            return
+        }
+        val deviceUuid = call.argument<String>("deviceUuid")
+        pluginScope.launch {
+            try {
+                manager.startDisplaySession(deviceUuid)
+                result.success(null)
+            } catch (e: Exception) {
+                result.error(
+                    "DISPLAY_ERROR",
+                    e.message ?: e::class.java.simpleName,
+                    null,
+                )
+            }
+        }
+    }
+
+    private fun sendDisplayView(call: MethodCall, result: Result) {
+        val manager = displayManager
+        if (manager == null) {
+            result.error("DISPLAY_ERROR", "Plugin not attached to engine.", null)
+            return
+        }
+        @Suppress("UNCHECKED_CAST")
+        val view = call.argument<Map<String, Any?>>("view") ?: emptyMap()
+        pluginScope.launch {
+            try {
+                manager.sendDisplayView(view)
+                result.success(null)
+            } catch (e: Exception) {
+                result.error(
+                    "DISPLAY_ERROR",
+                    e.message ?: e::class.java.simpleName,
+                    null,
+                )
+            }
+        }
+    }
+
+    private fun stopDisplaySession(result: Result) {
+        displayManager?.stopDisplaySession()
+        result.success(null)
+    }
+
+    private fun pauseStreamSession(result: Result) {
+        sessionManager?.pauseSession()
+        result.success(null)
+    }
+
+    private fun resumeStreamSession(result: Result) {
+        sessionManager?.resumeSession()
+        result.success(null)
+    }
+
+    // --- Diagnostics ----------------------------------------------------------
+
+    /// Mirrors the iOS `dumpDiagnostics` shape so cross-platform UIs can
+    /// render the same map. Android's permission/manifest validation happens
+    /// at runtime rather than at SDK init, so the `preflight` block is
+    /// intentionally minimal.
+    private fun dumpDiagnostics(): Map<String, Any?> {
+        val act = activity
+        val ctx = act ?: appContext
+        val pkg = ctx?.packageName
+        val pm = ctx?.packageManager
+        val appInfo = if (pkg != null && pm != null) {
+            try {
+                pm.getApplicationInfo(
+                    pkg,
+                    PackageManager.GET_META_DATA,
+                )
+            } catch (_: Throwable) {
+                null
+            }
+        } else {
+            null
+        }
+        val metaData = appInfo?.metaData
+        val applicationId = metaData?.get(
+            "com.meta.wearable.mwdat.APPLICATION_ID",
+        )?.toString()
+        val clientToken = metaData?.get(
+            "com.meta.wearable.mwdat.CLIENT_TOKEN",
+        )?.toString()
+
+        val regState: Int = try {
+            // SDK 0.6.x: `RegistrationState` is a sealed class, not an
+            // enum, so it has no `.ordinal`. Reuse the cross-platform
+            // int mapping `stateToInt` already implements via `is` checks.
+            stateToInt(Wearables.registrationState.value)
+        } catch (_: Throwable) {
+            -1
+        }
+
+        val bluetoothConnectGranted = if (act != null) {
+            ActivityCompat.checkSelfPermission(
+                act,
+                Manifest.permission.BLUETOOTH_CONNECT,
+            ) == PackageManager.PERMISSION_GRANTED
+        } else {
+            false
+        }
+
+        return mapOf(
+            "platform" to "Android",
+            "androidVersion" to Build.VERSION.RELEASE,
+            "sdkInt" to Build.VERSION.SDK_INT,
+            "bundleId" to (pkg ?: "<unknown>"),
+            "wearablesInitialised" to wearablesInitialised.value,
+            "registrationState" to mapOf(
+                "raw" to regState,
+                "name" to runCatching {
+                    // DAT 0.7 `RegistrationState` is an enum; use the entry
+                    // name (e.g. "REGISTERED").
+                    (Wearables.registrationState.value as? Enum<*>)?.name ?: "unknown"
+                }.getOrDefault("unknown"),
+            ),
+            "manifestMetaData" to mapOf(
+                "applicationId" to applicationId,
+                "clientToken" to clientToken,
+            ),
+            "preflight" to mapOf(
+                "bluetoothConnectGranted" to bluetoothConnectGranted,
+                "applicationIdNonEmpty" to !applicationId.isNullOrEmpty(),
+            ),
+        )
+    }
+
+    // --- Permission flow ------------------------------------------------------
+
+    private fun requestAndroidPermissions(result: Result) {
+        val act = activity
+        if (act == null) {
+            result.error(
+                "NO_ACTIVITY",
+                "No Activity is attached to the plugin. Are you calling " +
+                    "requestAndroidPermissions before runApp / before the engine " +
+                    "is attached?",
+                null,
+            )
+            return
+        }
+
+        val required = requiredPermissions()
+        val missing = required.filter { perm ->
+            ActivityCompat.checkSelfPermission(act, perm) !=
+                PackageManager.PERMISSION_GRANTED
+        }
+
+        if (missing.isEmpty()) {
+            ensureWearablesInitialised()
+            result.success(true)
+            return
+        }
+
+        if (pendingPermissionResult != null) {
+            result.error(
+                "ALREADY_REQUESTING",
+                "A permission request is already in flight.",
+                null,
+            )
+            return
+        }
+
+        pendingPermissionResult = result
+        ActivityCompat.requestPermissions(
+            act,
+            missing.toTypedArray(),
+            PERMISSION_REQUEST_CODE,
+        )
+    }
+
+    override fun onRequestPermissionsResult(
+        requestCode: Int,
+        permissions: Array<out String>,
+        grantResults: IntArray,
+    ): Boolean {
+        if (requestCode != PERMISSION_REQUEST_CODE) return false
+
+        val pending = pendingPermissionResult ?: return true
+        pendingPermissionResult = null
+
+        val allGranted = grantResults.isNotEmpty() &&
+            grantResults.all { it == PackageManager.PERMISSION_GRANTED }
+
+        if (allGranted) {
+            ensureWearablesInitialised()
+        }
+        pending.success(allGranted)
+        return true
+    }
+
+    /**
+     * Initialises Meta's DAT SDK exactly once, only after BLUETOOTH_CONNECT
+     * has been granted. See plan risk 2.
+     */
+    private fun ensureWearablesInitialised() {
+        if (wearablesInitialised.value) return
+        val act = activity ?: return
+        Wearables.initialize(act)
+        wearablesInitialised.value = true
+    }
+
+    private fun requiredPermissions(): List<String> {
+        val perms = mutableListOf(Manifest.permission.INTERNET)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            perms += Manifest.permission.BLUETOOTH_CONNECT
+        }
+        return perms
+    }
+
+    // --- Registration flow ----------------------------------------------------
+
+    private fun startRegistration(result: Result) {
+        val act = activity
+        if (act == null) {
+            result.error(
+                "NO_ACTIVITY",
+                "Cannot start registration without an Activity. Make sure your " +
+                    "MainActivity extends FlutterFragmentActivity.",
+                null,
+            )
+            return
+        }
+        try {
+            Wearables.startRegistration(act)
+            result.success(null)
+        } catch (e: Exception) {
+            result.error(
+                "REGISTRATION_ERROR",
+                e.message ?: e::class.java.simpleName,
+                null,
+            )
+        }
+    }
+
+    private fun startUnregistration(result: Result) {
+        val act = activity
+        if (act == null) {
+            result.error(
+                "NO_ACTIVITY",
+                "Cannot start unregistration without an Activity.",
+                null,
+            )
+            return
+        }
+        try {
+            Wearables.startUnregistration(act)
+            result.success(null)
+        } catch (e: Exception) {
+            val caseName = e::class.java.simpleName ?: "unknown"
+            result.error(
+                "UNREGISTRATION_ERROR",
+                caseName,
+                mapOf(
+                    "case" to caseName,
+                    "description" to (e.message ?: caseName),
+                ),
+            )
+        }
+    }
+
+    /**
+     * Documented no-op on Android. Meta's Android SDK consumes the
+     * registration callback through the host activity's intent-filter
+     * automatically, not through an explicit `handleUrl` API. Host apps
+     * still need to declare the matching intent-filter and use
+     * `launchMode="singleTop"`. See `doc/registration_flow.md`.
+     *
+     * Mirrors iOS by returning `false` for consumed (no callback) rather
+     * than throwing `HANDLE_URL_ERROR` - on Android, deep-links flow
+     * through the manifest intent-filter and the SDK reacts internally.
+     */
+    private fun handleUrl(result: Result) {
+        result.success(false)
+    }
+
+    private fun getRegistrationState(result: Result) {
+        if (!wearablesInitialised.value) {
+            result.success(stateToInt(null))
+            return
+        }
+        pluginScope.launch {
+            val state = Wearables.registrationState.first()
+            result.success(stateToInt(state))
+        }
+    }
+
+    /**
+     * One-shot snapshot of every currently-paired device. Mirrors the iOS
+     * `encodeAllDevices()` shape consumed by `DeviceInfo.fromMap`. Returns
+     * an empty list when the SDK is not yet initialised so callers can
+     * call this unconditionally during startup.
+     */
+    private fun getDevices(result: Result) {
+        if (!wearablesInitialised.value) {
+            result.success(emptyList<Map<String, Any?>>())
+            return
+        }
+        pluginScope.launch {
+            val ids = try {
+                Wearables.devices.first()
+            } catch (_: Throwable) {
+                emptyList()
+            }
+            result.success(encodeDevices(ids))
+        }
+    }
+
+    // --- Camera permission ----------------------------------------------------
+
+    private fun requestCameraPermission(result: Result) {
+        val launcher = cameraPermissionLauncher
+        if (launcher == null) {
+            result.error(
+                "MISSING_FRAGMENT_ACTIVITY",
+                "Camera permission requires the host Activity to extend " +
+                    "FlutterFragmentActivity (a ComponentActivity). See " +
+                    "doc/getting_started.md for the required MainActivity " +
+                    "snippet.",
+                null,
+            )
+            return
+        }
+        if (pendingCameraPermissionResult != null) {
+            result.error(
+                "ALREADY_REQUESTING",
+                "A camera permission request is already in flight.",
+                null,
+            )
+            return
+        }
+        pendingCameraPermissionResult = result
+        launcher.launch(Permission.CAMERA)
+    }
+
+    private fun getCameraPermissionStatus(result: Result) {
+        pluginScope.launch {
+            val outcome = Wearables.checkPermissionStatus(Permission.CAMERA)
+            // Wearables.checkPermissionStatus returns Meta's own `Result`
+            // wrapper. Treat any failure as "not granted" - host apps can
+            // call requestCameraPermission to surface the underlying
+            // PermissionError, if any.
+            val status = outcome.getOrDefault(PermissionStatus.Denied)
+            result.success(status == PermissionStatus.Granted)
+        }
+    }
+
+    // --- Stream handlers ------------------------------------------------------
+
+    /**
+     * Forwards `Wearables.registrationState` to a Flutter EventSink as
+     * `Int` values matching Dart's `RegistrationState.fromInt`. Defers
+     * collection until `wearablesInitialised` flips to `true`.
+     */
+    private inner class RegistrationStateStreamHandler : EventChannel.StreamHandler {
+        private var job: Job? = null
+
+        override fun onListen(arguments: Any?, events: EventChannel.EventSink) {
+            job?.cancel()
+            job = pluginScope.launch {
+                wearablesInitialised.first { it }
+                Wearables.registrationState.collectLatest { state ->
+                    events.success(stateToInt(state))
+                }
+            }
+        }
+
+        override fun onCancel(arguments: Any?) {
+            job?.cancel()
+            job = null
+        }
+
+        fun cancel() {
+            job?.cancel()
+            job = null
+        }
+    }
+
+    /**
+     * Forwards `AutoDeviceSelector().activeDeviceFlow()` to a Flutter
+     * EventSink as a serialised `DeviceInfo` map (or `null` when no device
+     * is active). Long-lived: the selector instance is recreated per
+     * subscription so old jobs don't leak across hot restarts.
+     */
+    private inner class ActiveDeviceStreamHandler : EventChannel.StreamHandler {
+        private var job: Job? = null
+
+        override fun onListen(arguments: Any?, events: EventChannel.EventSink) {
+            job?.cancel()
+            job = pluginScope.launch {
+                wearablesInitialised.first { it }
+                val selector = AutoDeviceSelector()
+                selector.activeDeviceFlow().collectLatest { deviceId ->
+                    events.success(encodeDeviceWithMetadata(deviceId))
+                }
+            }
+        }
+
+        override fun onCancel(arguments: Any?) {
+            job?.cancel()
+            job = null
+        }
+
+        fun cancel() {
+            job?.cancel()
+            job = null
+        }
+    }
+
+    /**
+     * Forwards `Wearables.devices` events as the full list of paired
+     * devices (active or not) on the `meta_wearables_dat_flutter/devices`
+     * channel. The current value is delivered eagerly on subscribe.
+     */
+    private inner class DevicesStreamHandler : EventChannel.StreamHandler {
+        private var job: Job? = null
+
+        override fun onListen(arguments: Any?, events: EventChannel.EventSink) {
+            job?.cancel()
+            job = pluginScope.launch {
+                wearablesInitialised.first { it }
+                Wearables.devices.collectLatest { ids ->
+                    events.success(encodeDevices(ids))
+                }
+            }
+        }
+
+        override fun onCancel(arguments: Any?) {
+            job?.cancel()
+            job = null
+        }
+
+        fun cancel() {
+            job?.cancel()
+            job = null
+        }
+    }
+
+    /**
+     * Forwards per-device compatibility updates on the
+     * `meta_wearables_dat_flutter/compatibility` channel.
+     *
+     * Listens to `Wearables.devices` for the paired-device set and to
+     * `Wearables.devicesMetadata[id]` for each individual device's
+     * compatibility verdict. Per-device collection jobs are torn down as
+     * soon as the device leaves the paired set so we don't leak jobs.
+     */
+    private inner class CompatibilityStreamHandler : EventChannel.StreamHandler {
+        private var rootJob: Job? = null
+        private val perDeviceJobs = mutableMapOf<DeviceIdentifier, Job>()
+
+        override fun onListen(arguments: Any?, events: EventChannel.EventSink) {
+            cancel()
+            rootJob = pluginScope.launch {
+                wearablesInitialised.first { it }
+                Wearables.devices.collectLatest { ids ->
+                    val live = ids.toSet()
+                    // Cancel jobs for devices that have left the set.
+                    perDeviceJobs.keys.toList().forEach { id ->
+                        if (!live.contains(id)) {
+                            perDeviceJobs.remove(id)?.cancel()
+                        }
+                    }
+                    for (id in live) {
+                        if (perDeviceJobs.containsKey(id)) continue
+                        val flow = try {
+                            Wearables.devicesMetadata[id]
+                        } catch (_: Throwable) {
+                            null
+                        } ?: continue
+                        perDeviceJobs[id] = pluginScope.launch {
+                            flow.collectLatest { meta ->
+                                events.success(
+                                    mapOf(
+                                        "deviceUuid" to id.toString(),
+                                        "compatibility" to compatibilityForMetadata(meta),
+                                    ),
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        override fun onCancel(arguments: Any?) {
+            cancel()
+        }
+
+        fun cancel() {
+            rootJob?.cancel()
+            rootJob = null
+            perDeviceJobs.values.forEach { it.cancel() }
+            perDeviceJobs.clear()
+        }
+    }
+
+    // --- Helpers --------------------------------------------------------------
+
+    /**
+     * Maps `RegistrationState` to the int value the Dart enum understands
+     * (`unavailable=0, available=1, registering=2, registered=3`). DAT 0.7's
+     * `RegistrationState` is an enum, so we key off the (normalised) entry
+     * name - `UNREGISTERING` is treated as transitional `registering` and
+     * anything unrecognised falls back to `unavailable`.
+     */
+    private fun stateToInt(state: RegistrationState?): Int =
+        when (state?.name?.uppercase()?.replace("_", "")) {
+            null -> 0
+            "REGISTERED" -> 3
+            "REGISTERING" -> 2
+            "UNREGISTERING" -> 2
+            "AVAILABLE" -> 1
+            else -> 0
+        }
+
+    /**
+     * Serialises a [DeviceIdentifier] to the map shape that
+     * `DeviceInfo.fromMap` expects on the Dart side, or `null` when no
+     * device is active.
+     *
+     * Looks up `Wearables.devicesMetadata[id]` for richer fields
+     * (display name, device kind). When metadata isn't ready yet we fall
+     * back to the id as the name and `unknown` as the kind.
+     */
+    private suspend fun encodeDeviceWithMetadata(
+        id: DeviceIdentifier?,
+    ): Map<String, Any?>? {
+        if (id == null) return null
+        val meta = try {
+            Wearables.devicesMetadata[id]?.first()
+        } catch (_: Throwable) {
+            null
+        }
+        val idString = id.toString()
+        return mapOf(
+            "uuid" to idString,
+            "name" to (nameForMetadata(meta) ?: idString),
+            "kind" to wireKindForMetadata(meta),
+        )
+    }
+
+    /**
+     * Encodes every paired device as the `DeviceInfo.fromMap` shape.
+     * Looks up each device's metadata for richer fields. Best-effort:
+     * metadata can be missing on hot start.
+     */
+    internal suspend fun encodeDevices(
+        // Accept `Collection` so callers can pass `Wearables.devices`'s
+        // `Set<DeviceIdentifier>` directly without an extra `.toList()`.
+        ids: Collection<DeviceIdentifier>,
+    ): List<Map<String, Any?>> {
+        return ids.map { id ->
+            val meta = try {
+                Wearables.devicesMetadata[id]?.first()
+            } catch (_: Throwable) {
+                null
+            }
+            val idString = id.toString()
+            mapOf(
+                "uuid" to idString,
+                "name" to (nameForMetadata(meta) ?: idString),
+                "kind" to wireKindForMetadata(meta),
+            )
+        }
+    }
+
+    companion object {
+        // Arbitrary unique request code; range 1..65535 per Android.
+        private const val PERMISSION_REQUEST_CODE = 10_001
+
+        /**
+         * Returns the wire-kind string (`rayBanMeta` / `rayBanDisplay` /
+         * `oakleyMeta` / `unknown`) for the given device identifier.
+         * Uses the latest cached metadata when available. Best-effort:
+         * returns `unknown` when metadata isn't ready yet.
+         */
+        suspend fun wireKindForDevice(id: DeviceIdentifier): String {
+            val meta = try {
+                Wearables.devicesMetadata[id]?.first()
+            } catch (_: Throwable) {
+                null
+            }
+            return wireKindForMetadata(meta)
+        }
+
+        /**
+         * Maps a `DeviceMetadata`-shaped object to the cross-platform
+         * wire kind. Uses reflection so we don't depend on the precise
+         * shape of `DeviceMetadata` (it has changed between SDK
+         * versions). Falls back to `unknown` when the shape can't be
+         * matched.
+         */
+        fun wireKindForMetadata(meta: Any?): String {
+            if (meta == null) return "unknown"
+            val typeValue = try {
+                meta::class.java.methods.firstOrNull { m ->
+                    m.parameterCount == 0 && (
+                        m.name == "getDeviceType" ||
+                            m.name == "getType" ||
+                            m.name == "getKind"
+                        )
+                }?.invoke(meta)
+            } catch (_: Throwable) {
+                null
+            } ?: return "unknown"
+
+            val rawName = (typeValue as? Enum<*>)?.name ?: typeValue.toString()
+            // Normalise to a canonical lower-case for matching against
+            // SDK enum case names we know about across versions.
+            val normalised = rawName
+                .lowercase()
+                .replace("_", "")
+                .replace("-", "")
+            return when {
+                "raybanmetadisplay" in normalised ||
+                    "metaraybandisplay" in normalised ||
+                    "raybandisplay" in normalised -> "rayBanDisplay"
+                "raybanmeta" in normalised -> "rayBanMeta"
+                "oakleyhstn" in normalised ||
+                    "oakleyvanguard" in normalised ||
+                    "oakleymeta" in normalised -> "oakleyMeta"
+                else -> "unknown"
+            }
+        }
+
+        /**
+         * Reflection-based extraction of a human-readable name from a
+         * `DeviceMetadata`-shaped object. Returns `null` when no name
+         * field is present.
+         */
+        fun nameForMetadata(meta: Any?): String? {
+            if (meta == null) return null
+            return try {
+                meta::class.java.methods.firstOrNull { m ->
+                    m.parameterCount == 0 && (
+                        m.name == "getName" ||
+                            m.name == "getDisplayName" ||
+                            m.name == "getDeviceName"
+                        )
+                }?.invoke(meta) as? String
+            } catch (_: Throwable) {
+                null
+            }
+        }
+
+        /**
+         * Reflection-based extraction of compatibility verdict from a
+         * `DeviceMetadata`-shaped object. Returns the canonical
+         * cross-platform string (`compatible`, `deviceUpdateRequired`,
+         * `sdkUpdateRequired`, `unknown`).
+         */
+        fun compatibilityForMetadata(meta: Any?): String {
+            if (meta == null) return "unknown"
+            val raw = try {
+                meta::class.java.methods.firstOrNull { m ->
+                    m.parameterCount == 0 && (
+                        m.name == "getCompatibility" ||
+                            m.name == "getCompatibilityStatus"
+                        )
+                }?.invoke(meta)
+            } catch (_: Throwable) {
+                null
+            } ?: return "unknown"
+            val name = (raw as? Enum<*>)?.name ?: raw.toString()
+            val normalised = name.lowercase().replace("_", "").replace("-", "")
+            return when {
+                "compatible" == normalised -> "compatible"
+                "deviceupdaterequired" in normalised -> "deviceUpdateRequired"
+                "sdkupdaterequired" in normalised -> "sdkUpdateRequired"
+                else -> "unknown"
+            }
+        }
+    }
+}
+
+/**
+ * Tiny [EventChannel.StreamHandler] that simply hands its EventSink off to a
+ * callback - lets the [MetaSessionManager] decide when to emit values
+ * rather than baking that logic into the channel handler itself.
+ */
+internal class PassthroughStreamHandler(
+    private val onSinkChange: (EventChannel.EventSink?) -> Unit,
+) : EventChannel.StreamHandler {
+    override fun onListen(arguments: Any?, events: EventChannel.EventSink) {
+        onSinkChange(events)
+    }
+
+    override fun onCancel(arguments: Any?) {
+        onSinkChange(null)
+    }
+}

--- a/app/third_party/meta_wearables_dat_flutter/android/src/main/kotlin/com/iseelabs/meta_wearables_dat_flutter/YuvToArgb.kt
+++ b/app/third_party/meta_wearables_dat_flutter/android/src/main/kotlin/com/iseelabs/meta_wearables_dat_flutter/YuvToArgb.kt
@@ -1,0 +1,143 @@
+// CPU-side I420 → ARGB conversion.
+//
+// Used only by [MetaSessionManager]. Single-threaded; perf is fine for
+// 720p@30fps on every Android device that meets minSdk 31.
+//
+// Layout assumption: Meta DAT SDK 0.6.x VideoFrame.buffer is documented
+// (and verified at runtime via `c2.android.hevc.decoder` config diff:
+// `raw.pixel-format = 35` = YUV420_FLEXIBLE / I420, `stride = width`,
+// `vstride = height`) as a tightly-packed I420 plane triple:
+//
+//     [ Y(w*h) | U(w/2 * h/2) | V(w/2 * h/2) ] = w * h * 3 / 2 bytes.
+//
+// The reference Android sample at
+// https://github.com/facebook/meta-wearables-dat-android (see
+// `samples/CameraAccess/.../stream/YuvToBitmapConverter.kt`) is
+// hardcoded to the same shape, so any cross-format probing on our side
+// is dead code at best and a source of subtle render bugs at worst.
+//
+// Colour conversion: BT.709 limited range (studio swing). The HEVC
+// decoder advertises `raw.color.matrix = 1` (= BT.709 in C2 enums)
+// when decoding frames from the glasses, which matches the official
+// sample's hardcoded BT.709 path. Using BT.601 coefficients here
+// produces a visible green/yellow cast on natural scenes.
+
+package com.iseelabs.meta_wearables_dat_flutter
+
+import android.graphics.Bitmap
+import java.nio.ByteBuffer
+
+internal object YuvToArgb {
+    // Scratch buffers reused across frames to keep the hot path
+    // allocation-free. At 30 fps the YUV input is ~1.4 MiB and the
+    // ARGB output is ~3.6 MiB per frame, so allocating per frame
+    // causes ~150 MiB/s of GC pressure on the 720p stream. The
+    // official Meta sample's `YuvToBitmapConverter` does the same
+    // caching for the same reason.
+    private val lock = Any()
+    private var yuvBytes: ByteArray = ByteArray(0)
+    private var pixels: IntArray = IntArray(0)
+
+    /**
+     * Converts a tightly-packed I420 [yuvData] buffer to ARGB pixels in
+     * [output]. The buffer must contain `Y(w*h) | U(w*h/4) | V(w*h/4)`
+     * = `w * h * 3 / 2` bytes. The caller's [yuvData] position is
+     * preserved (we read through a duplicate).
+     *
+     * Returns silently when the buffer is too small for the declared
+     * dimensions or when [width] / [height] are not even — the caller
+     * can fall through to a no-op for the frame.
+     */
+    fun convert(
+        yuvData: ByteBuffer,
+        width: Int,
+        height: Int,
+        output: Bitmap,
+    ) {
+        if (width <= 0 || height <= 0) return
+        if (width and 1 != 0 || height and 1 != 0) return
+
+        val frameSize = width * height
+        val expected = frameSize + (frameSize shr 1)
+        if (yuvData.remaining() < expected) return
+
+        synchronized(lock) {
+            if (yuvBytes.size < expected) yuvBytes = ByteArray(expected)
+            if (pixels.size < frameSize) pixels = IntArray(frameSize)
+
+            val src = yuvData.duplicate().apply { position(yuvData.position()) }
+            src.get(yuvBytes, 0, expected)
+
+            convertI420ToArgb(yuvBytes, pixels, width, height)
+            output.setPixels(pixels, 0, width, 0, 0, width, height)
+        }
+    }
+
+    /**
+     * Converts I420 YUV bytes directly to ARGB pixel ints.
+     *
+     * BT.709 limited range, fixed-point with 10-bit precision. Math
+     * matches the official Meta DAT Android sample byte-for-byte (see
+     * `YuvToBitmapConverter.convertI420ToArgb` in
+     * `meta-wearables-dat-android`):
+     *
+     *     R = 1.164 * (Y - 16) + 1.793 * (V - 128)
+     *     G = 1.164 * (Y - 16) - 0.213 * (U - 128) - 0.533 * (V - 128)
+     *     B = 1.164 * (Y - 16) + 2.112 * (U - 128)
+     *
+     * Coefficients are scaled by 1024 = 2^10 so the multiplies and
+     * one right-shift produce the same value as the float form.
+     */
+    private fun convertI420ToArgb(
+        yuvBytes: ByteArray,
+        argbOut: IntArray,
+        width: Int,
+        height: Int,
+    ) {
+        val frameSize = width * height
+        val uvPlaneSize = frameSize shr 2
+
+        val uOffset = frameSize
+        val vOffset = uOffset + uvPlaneSize
+
+        // BT.709 limited range fixed-point coefficients (×1024).
+        val coeffVr = 1836 // 1.793 * 1024
+        val coeffUg = 218  // 0.213 * 1024
+        val coeffVg = 546  // 0.533 * 1024
+        val coeffUb = 2163 // 2.112 * 1024
+
+        val halfWidth = width shr 1
+        var pixelIndex = 0
+
+        for (row in 0 until height) {
+            val uvRowOffset = (row shr 1) * halfWidth
+
+            for (col in 0 until width) {
+                val uvIndex = uvRowOffset + (col shr 1)
+
+                val y = (yuvBytes[pixelIndex].toInt() and 0xff) - 16
+                val u = (yuvBytes[uOffset + uvIndex].toInt() and 0xff) - 128
+                val v = (yuvBytes[vOffset + uvIndex].toInt() and 0xff) - 128
+
+                // Y scaled from 16-235 to 0-255: 255/219 ≈ 1.164 → ×1192/1024
+                val yScaled = (y * 1192) shr 10
+
+                val r = yScaled + ((coeffVr * v) shr 10)
+                val g = yScaled - ((coeffUg * u + coeffVg * v) shr 10)
+                val b = yScaled + ((coeffUb * u) shr 10)
+
+                // Branchless clamp to 0..255 — avoids branch mispredict
+                // on hot inner loop. `(x shr 31).inv()` is 0xffffffff for
+                // x ≥ 0, 0 otherwise; the second mask reflects 255 - x.
+                val rClamped = (r and (r shr 31).inv()) or ((255 - r) shr 31 and 255) and 255
+                val gClamped = (g and (g shr 31).inv()) or ((255 - g) shr 31 and 255) and 255
+                val bClamped = (b and (b shr 31).inv()) or ((255 - b) shr 31 and 255) and 255
+
+                argbOut[pixelIndex] =
+                    0xff000000.toInt() or (rClamped shl 16) or (gClamped shl 8) or bClamped
+
+                pixelIndex++
+            }
+        }
+    }
+}

--- a/app/third_party/meta_wearables_dat_flutter/ios/meta_wearables_dat_flutter.podspec
+++ b/app/third_party/meta_wearables_dat_flutter/ios/meta_wearables_dat_flutter.podspec
@@ -1,0 +1,41 @@
+#
+# Podspec for meta_wearables_dat_flutter.
+#
+# This plugin is *Swift Package Manager first*. Meta's official iOS DAT SDK
+# (`MWDATCore`, `MWDATCamera`, `MWDATMockDevice`) is consumed via SPM in
+# `meta_wearables_dat_flutter/Package.swift` and is **not** vendored as
+# `xcframework`s here.
+#
+# Consumers must run `flutter config --enable-swift-package-manager` and use
+# Xcode 15.4+. See `doc/troubleshooting.md` for setup details. The Swift
+# sources include a `#if !canImport(MWDATCore)` guard that emits a clear
+# `#error` when SPM has not been enabled.
+#
+Pod::Spec.new do |s|
+  s.name             = 'meta_wearables_dat_flutter'
+  s.version          = '0.7.1'
+  s.summary          = 'Unofficial Flutter plugin for Meta\'s Wearables Device Access Toolkit.'
+  s.description      = <<-DESC
+Unofficial Flutter plugin bridging Meta's iOS and Android Wearables Device
+Access Toolkit (DAT) SDKs. iOS dependencies are linked via Swift Package
+Manager; this podspec only declares the Flutter dependency and Apple system
+frameworks.
+                       DESC
+  s.homepage         = 'https://github.com/iSee-Labs/meta-wearables-dat-flutter'
+  s.license          = { :file => '../LICENSE' }
+  s.author           = { 'iSee Labs' => 'https://github.com/iSee-Labs' }
+  s.source           = { :path => '.' }
+  s.source_files     = 'meta_wearables_dat_flutter/Sources/meta_wearables_dat_flutter/**/*.swift'
+
+  s.dependency 'Flutter'
+
+  s.platform         = :ios, '17.0'
+  s.swift_version    = '5.9'
+
+  s.frameworks = 'CoreBluetooth', 'Network', 'AVFoundation', 'ExternalAccessory'
+
+  s.pod_target_xcconfig = {
+    'DEFINES_MODULE' => 'YES',
+    'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386',
+  }
+end

--- a/app/third_party/meta_wearables_dat_flutter/ios/meta_wearables_dat_flutter/Package.resolved
+++ b/app/third_party/meta_wearables_dat_flutter/ios/meta_wearables_dat_flutter/Package.resolved
@@ -1,0 +1,14 @@
+{
+  "pins" : [
+    {
+      "identity" : "meta-wearables-dat-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/facebook/meta-wearables-dat-ios",
+      "state" : {
+        "revision" : "c40db3978a76b97504b85ed9f082be5549c5a486",
+        "version" : "0.7.0"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/app/third_party/meta_wearables_dat_flutter/ios/meta_wearables_dat_flutter/Package.swift
+++ b/app/third_party/meta_wearables_dat_flutter/ios/meta_wearables_dat_flutter/Package.swift
@@ -1,0 +1,37 @@
+// swift-tools-version: 5.9
+// The swift-tools-version declares the minimum version of Swift required to
+// build this package. Flutter 3.24+ uses Swift Package Manager to resolve
+// plugin Swift dependencies when the user runs
+// `flutter config --enable-swift-package-manager`.
+
+import PackageDescription
+
+let package = Package(
+  name: "meta_wearables_dat_flutter",
+  platforms: [
+    .iOS("17.0"),
+  ],
+  products: [
+    .library(
+      name: "meta-wearables-dat-flutter",
+      targets: ["meta_wearables_dat_flutter"]
+    ),
+  ],
+  dependencies: [
+    .package(
+      url: "https://github.com/facebook/meta-wearables-dat-ios",
+      from: "0.7.0"
+    ),
+  ],
+  targets: [
+    .target(
+      name: "meta_wearables_dat_flutter",
+      dependencies: [
+        .product(name: "MWDATCore", package: "meta-wearables-dat-ios"),
+        .product(name: "MWDATCamera", package: "meta-wearables-dat-ios"),
+        .product(name: "MWDATDisplay", package: "meta-wearables-dat-ios"),
+      ],
+      resources: []
+    ),
+  ]
+)

--- a/app/third_party/meta_wearables_dat_flutter/ios/meta_wearables_dat_flutter/Sources/meta_wearables_dat_flutter/BackgroundStreamingController.swift
+++ b/app/third_party/meta_wearables_dat_flutter/ios/meta_wearables_dat_flutter/Sources/meta_wearables_dat_flutter/BackgroundStreamingController.swift
@@ -1,0 +1,189 @@
+// Background-streaming support on iOS.
+//
+// Owns the AVAudioSession configuration that keeps the BLE link + camera
+// pipeline alive while the app is backgrounded / the screen is locked.
+// Without this controller, iOS suspends the host app a few seconds after
+// it enters the background, which kills both the device session (the
+// SDK drops its `URLSession`) and the VideoToolbox decoder (the OS
+// reclaims hardware decoders when an app is no longer foreground).
+//
+// Mechanics:
+//   1. `enable()` activates an AVAudioSession with `.playAndRecord` /
+//      `.videoRecording`, plus `.allowBluetoothHFP` so the BLE link to
+//      the glasses survives, and `.mixWithOthers` so the host app
+//      doesn't fight Apple Music / Spotify.
+//   2. Registers observers for `AVAudioSession.interruptionNotification`,
+//      `routeChangeNotification`, and `mediaServicesWereResetNotification`
+//      so the session is automatically re-activated when iOS recovers.
+//   3. Exposes `useSoftwareDecoder` so `MetaSessionManager` can flip its
+//      `VTDecompressionPipeline` into software-only mode while background
+//      streaming is active (hardware HEVC decoders are killed at
+//      backgrounding time).
+//
+// Host apps must declare the corresponding `UIBackgroundModes` keys in
+// `Info.plist`: `audio`, `bluetooth-central`, `bluetooth-peripheral`,
+// `external-accessory`. Missing modes are reported by `dumpDiagnostics`.
+
+import AVFAudio
+import Foundation
+
+@MainActor
+final class BackgroundStreamingController {
+  static let shared = BackgroundStreamingController()
+
+  private(set) var isEnabled: Bool = false
+
+  /// True while background streaming is active. While true, callers
+  /// that build a `VTDecompressionSession` should disable hardware
+  /// acceleration so the decoder survives backgrounding.
+  var useSoftwareDecoder: Bool { isEnabled }
+
+  private init() {}
+
+  /// Called by `MetaSessionManager` when background streaming is
+  /// toggled so the existing pipeline can swap decoders on the next
+  /// stream.
+  var onSoftwareModeChange: ((Bool) -> Void)?
+
+  func enable() throws {
+    if isEnabled { return }
+    try activateSession()
+    registerObservers()
+    isEnabled = true
+    onSoftwareModeChange?(true)
+    print("[meta_wearables_dat_flutter] BackgroundStreaming enabled")
+  }
+
+  func disable() {
+    if !isEnabled { return }
+    deregisterObservers()
+    let session = AVAudioSession.sharedInstance()
+    do {
+      try session.setActive(false, options: [.notifyOthersOnDeactivation])
+    } catch {
+      print("[meta_wearables_dat_flutter] AVAudioSession.setActive(false) " +
+        "failed: \(error)")
+    }
+    isEnabled = false
+    onSoftwareModeChange?(false)
+    print("[meta_wearables_dat_flutter] BackgroundStreaming disabled")
+  }
+
+  // MARK: - AVAudioSession
+
+  private func activateSession() throws {
+    let session = AVAudioSession.sharedInstance()
+    // `.playAndRecord` is required to keep the mic open and to qualify
+    // for `audio` background mode. `.videoRecording` matches what
+    // Meta's iOS sample uses. `.allowBluetoothHFP` keeps the BLE-HFP
+    // route alive while the screen is locked. `.mixWithOthers`
+    // prevents the host app from muting other audio.
+    var options: AVAudioSession.CategoryOptions = [.mixWithOthers]
+    // Bluetooth HFP options are unavailable on the simulator (no BT hardware).
+    #if !targetEnvironment(simulator)
+    if #available(iOS 14.5, *) {
+      options.insert(.allowBluetoothHFP)
+    } else {
+      options.insert(.allowBluetooth)
+    }
+    #endif
+    try session.setCategory(
+      .playAndRecord,
+      mode: .videoRecording,
+      options: options,
+    )
+    try session.setActive(true)
+  }
+
+  private func registerObservers() {
+    let center = NotificationCenter.default
+    center.addObserver(
+      self,
+      selector: #selector(handleInterruption(_:)),
+      name: AVAudioSession.interruptionNotification,
+      object: nil,
+    )
+    center.addObserver(
+      self,
+      selector: #selector(handleRouteChange(_:)),
+      name: AVAudioSession.routeChangeNotification,
+      object: nil,
+    )
+    center.addObserver(
+      self,
+      selector: #selector(handleMediaServicesReset(_:)),
+      name: AVAudioSession.mediaServicesWereResetNotification,
+      object: nil,
+    )
+  }
+
+  private func deregisterObservers() {
+    let center = NotificationCenter.default
+    center.removeObserver(
+      self,
+      name: AVAudioSession.interruptionNotification,
+      object: nil,
+    )
+    center.removeObserver(
+      self,
+      name: AVAudioSession.routeChangeNotification,
+      object: nil,
+    )
+    center.removeObserver(
+      self,
+      name: AVAudioSession.mediaServicesWereResetNotification,
+      object: nil,
+    )
+  }
+
+  // MARK: - Notification handlers
+
+  @objc nonisolated private func handleInterruption(_ note: Notification) {
+    guard
+      let info = note.userInfo,
+      let rawType = info[AVAudioSessionInterruptionTypeKey] as? UInt,
+      let type = AVAudioSession.InterruptionType(rawValue: rawType)
+    else { return }
+    if type == .ended {
+      Task { @MainActor in
+        // Best-effort re-activation. Failure is logged but non-fatal —
+        // user can re-enable manually.
+        do {
+          try self.activateSession()
+          print("[meta_wearables_dat_flutter] AVAudioSession re-activated " +
+            "after interruption")
+        } catch {
+          print("[meta_wearables_dat_flutter] AVAudioSession re-activation " +
+            "failed: \(error)")
+        }
+      }
+    }
+  }
+
+  @objc nonisolated private func handleRouteChange(_ note: Notification) {
+    guard
+      let info = note.userInfo,
+      let rawReason = info[AVAudioSessionRouteChangeReasonKey] as? UInt,
+      let reason = AVAudioSession.RouteChangeReason(rawValue: rawReason)
+    else { return }
+    // The glasses' BLE-HFP route can disappear when battery dies or
+    // they are folded; if iOS yanked it, log so the host app can show
+    // an error UI.
+    if reason == .oldDeviceUnavailable {
+      print("[meta_wearables_dat_flutter] AVAudioSession route lost " +
+        "(.oldDeviceUnavailable)")
+    }
+  }
+
+  @objc nonisolated private func handleMediaServicesReset(_ note: Notification) {
+    print("[meta_wearables_dat_flutter] AVAudioSession mediaServicesWereReset")
+    Task { @MainActor in
+      do {
+        try self.activateSession()
+      } catch {
+        print("[meta_wearables_dat_flutter] AVAudioSession re-activate " +
+          "after mediaServicesWereReset failed: \(error)")
+      }
+    }
+  }
+}

--- a/app/third_party/meta_wearables_dat_flutter/ios/meta_wearables_dat_flutter/Sources/meta_wearables_dat_flutter/BackgroundStreamingController.swift
+++ b/app/third_party/meta_wearables_dat_flutter/ios/meta_wearables_dat_flutter/Sources/meta_wearables_dat_flutter/BackgroundStreamingController.swift
@@ -9,9 +9,8 @@
 //
 // Mechanics:
 //   1. `enable()` activates an AVAudioSession with `.playAndRecord` /
-//      `.videoRecording`, plus `.allowBluetoothHFP` so the BLE link to
-//      the glasses survives, and `.mixWithOthers` so the host app
-//      doesn't fight Apple Music / Spotify.
+//      `.videoRecording`, uses the built-in microphone, keeps A2DP output
+//      available, and mixes with Apple Music / Spotify.
 //   2. Registers observers for `AVAudioSession.interruptionNotification`,
 //      `routeChangeNotification`, and `mediaServicesWereResetNotification`
 //      so the session is automatically re-activated when iOS recovers.
@@ -73,26 +72,24 @@ final class BackgroundStreamingController {
 
   private func activateSession() throws {
     let session = AVAudioSession.sharedInstance()
-    // `.playAndRecord` is required to keep the mic open and to qualify
-    // for `audio` background mode. `.videoRecording` matches what
-    // Meta's iOS sample uses. `.allowBluetoothHFP` keeps the BLE-HFP
-    // route alive while the screen is locked. `.mixWithOthers`
-    // prevents the host app from muting other audio.
-    var options: AVAudioSession.CategoryOptions = [.mixWithOthers]
-    // Bluetooth HFP options are unavailable on the simulator (no BT hardware).
-    #if !targetEnvironment(simulator)
-    if #available(iOS 14.5, *) {
-      options.insert(.allowBluetoothHFP)
-    } else {
-      options.insert(.allowBluetooth)
-    }
-    #endif
+    // Meta's background-streaming pattern keeps the glasses HFP route alive;
+    // mixWithOthers prevents this keep-alive from silencing other media.
+    let options: AVAudioSession.CategoryOptions = [.mixWithOthers, .allowBluetoothHFP]
     try session.setCategory(
       .playAndRecord,
       mode: .videoRecording,
       options: options,
     )
+    guard let glassesMic = session.availableInputs?.first(where: { $0.portType == .bluetoothHFP }) else {
+      throw NSError(
+        domain: "MetaWearablesDatAudioRoute",
+        code: 1,
+        userInfo: [NSLocalizedDescriptionKey: "Meta glasses Bluetooth microphone is unavailable"]
+      )
+    }
+    try session.setPreferredInput(glassesMic)
     try session.setActive(true)
+    try session.setPreferredInput(glassesMic)
   }
 
   private func registerObservers() {
@@ -166,8 +163,8 @@ final class BackgroundStreamingController {
       let rawReason = info[AVAudioSessionRouteChangeReasonKey] as? UInt,
       let reason = AVAudioSession.RouteChangeReason(rawValue: rawReason)
     else { return }
-    // The glasses' BLE-HFP route can disappear when battery dies or
-    // they are folded; if iOS yanked it, log so the host app can show
+    // The glasses route can disappear when battery dies or they are folded;
+    // if iOS yanked it, log so the host app can show
     // an error UI.
     if reason == .oldDeviceUnavailable {
       print("[meta_wearables_dat_flutter] AVAudioSession route lost " +

--- a/app/third_party/meta_wearables_dat_flutter/ios/meta_wearables_dat_flutter/Sources/meta_wearables_dat_flutter/MetaDisplayManager.swift
+++ b/app/third_party/meta_wearables_dat_flutter/ios/meta_wearables_dat_flutter/Sources/meta_wearables_dat_flutter/MetaDisplayManager.swift
@@ -1,0 +1,355 @@
+// iOS Display bridge (DAT 0.7.0 `MWDATDisplay`).
+//
+// Owns:
+//   - One `DeviceSession` targeting a (display-capable) device.
+//   - One `Display` capability attached to that session.
+//   - The display-state EventSink and the display-events EventSink
+//     (tap / click / playback callbacks routed back to Dart by id).
+//
+// Declarative view trees arrive from Dart as plain JSON (`[String: Any]`),
+// which we rebuild into Meta's `MWDATDisplay` component DSL
+// (`FlexBox` / `Text` / `Image` / `Button` / `Icon` / `VideoPlayer`) and hand
+// to `Display.send(_:)`. Interaction callbacks carry the Dart-assigned
+// `callbackId` so the Dart side can dispatch to the right closure.
+//
+// All Meta SDK calls run on the main actor, matching `Wearables.shared`.
+
+import Flutter
+import UIKit
+#if canImport(MWDATCore)
+import MWDATCore
+#endif
+#if canImport(MWDATDisplay)
+import MWDATDisplay
+#endif
+
+@MainActor
+final class MetaDisplayManager: NSObject {
+  /// The DeviceSession we created via `Wearables.shared.createSession`.
+  private var deviceSession: DeviceSession?
+
+  /// The display capability attached to `deviceSession`.
+  private var display: Display?
+
+  private var stateToken: (any AnyListenerToken)?
+
+  /// The `onPlaybackEventId` of the `VideoPlayer` currently on screen, used to
+  /// route `Display.onPlaybackEvent` back to the right Dart closure.
+  private var currentVideoCallbackId: String?
+
+  // EventSinks set by the plugin when Dart subscribes.
+  fileprivate var displayStateSink: FlutterEventSink?
+  fileprivate var displayEventsSink: FlutterEventSink?
+
+  func setDisplayStateSink(_ sink: FlutterEventSink?) { displayStateSink = sink }
+  func setDisplayEventsSink(_ sink: FlutterEventSink?) { displayEventsSink = sink }
+
+  // MARK: - Lifecycle
+
+  /// Creates a DeviceSession (targeting `deviceUUID` when given, otherwise the
+  /// first paired device), attaches the display capability, and starts it.
+  func startDisplaySession(deviceUUID: String?) async throws {
+    if display != nil { return }
+
+    let allIds = Wearables.shared.devices
+    let selector: any DeviceSelector
+    if let uuid = deviceUUID, let match = allIds.first(where: { $0 == uuid }) {
+      selector = SpecificDeviceSelector(device: match)
+    } else if let pick = allIds.first {
+      selector = SpecificDeviceSelector(device: pick)
+    } else {
+      throw NSError(
+        domain: "meta_wearables_dat_flutter",
+        code: -20,
+        userInfo: [NSLocalizedDescriptionKey:
+          "No glasses are currently paired. Open Meta AI to pair " +
+          "Ray-Ban Display glasses, then try again."],
+      )
+    }
+
+    let session = try Wearables.shared.createSession(deviceSelector: selector)
+    self.deviceSession = session
+
+    if session.state != .started {
+      try session.start()
+      try await Self.waitForDeviceSessionStarted(
+        session,
+        timeoutNs: 45_000_000_000,
+      )
+    }
+
+    let display = try session.addDisplay()
+    self.display = display
+
+    display.onPlaybackEvent = { [weak self] event in
+      Task { @MainActor in self?.handlePlaybackEvent(event) }
+    }
+    stateToken = display.statePublisher.listen { [weak self] state in
+      Task { @MainActor in self?.displayStateSink?(Self.encode(state)) }
+    }
+
+    await display.start()
+  }
+
+  /// Rebuilds [json] into the `MWDATDisplay` DSL and sends it to the glasses.
+  func sendDisplayView(_ json: [String: Any]) async throws {
+    guard let display = display else {
+      throw NSError(
+        domain: "meta_wearables_dat_flutter",
+        code: -21,
+        userInfo: [NSLocalizedDescriptionKey:
+          "No display session - call startDisplaySession first"],
+      )
+    }
+
+    if (json["type"] as? String) == "videoPlayer" {
+      let url = json["uri"] as? String ?? ""
+      currentVideoCallbackId = json["onPlaybackEventId"] as? String
+      let video = MWDATDisplay.VideoPlayer(
+        provider: .uri(url),
+        codec: .mp4,
+        onError: { [weak self] _ in
+          Task { @MainActor in self?.emitPlayback(eventName: "error") }
+        },
+      )
+      try await display.send(video)
+    } else {
+      currentVideoCallbackId = nil
+      let view = buildFlexBox(json)
+      try await display.send(view)
+    }
+  }
+
+  /// Detaches the display capability and tears down its device session.
+  func stopDisplaySession() async {
+    stateToken = nil
+    currentVideoCallbackId = nil
+    if let display = display {
+      await display.stop()
+    }
+    display = nil
+    deviceSession?.stop()
+    deviceSession = nil
+  }
+
+  // MARK: - Callback plumbing
+
+  private func emitCallback(_ id: String, type: String) {
+    displayEventsSink?(["callbackId": id, "type": type] as [String: Any])
+  }
+
+  private func handlePlaybackEvent(_ event: VideoPlaybackEvent) {
+    emitPlayback(eventName: Self.playbackWireName(event))
+  }
+
+  private func emitPlayback(eventName: String) {
+    guard let id = currentVideoCallbackId else { return }
+    displayEventsSink?(
+      ["callbackId": id, "type": "playback", "event": eventName] as [String: Any]
+    )
+  }
+
+  // MARK: - Tree builders
+
+  private func buildChildren(_ json: [String: Any]) -> [any ViewComponent] {
+    let kids = json["children"] as? [[String: Any]] ?? []
+    return kids.compactMap { buildComponent($0) }
+  }
+
+  private func buildComponent(_ json: [String: Any]) -> (any ViewComponent)? {
+    switch json["type"] as? String {
+    case "flexBox": return buildFlexBox(json)
+    case "text": return buildText(json)
+    case "image": return buildImage(json)
+    case "button": return buildButton(json)
+    case "icon": return buildIcon(json)
+    // `videoPlayer` is a root-only DisplayableView, not a nestable component.
+    default: return nil
+    }
+  }
+
+  private func buildFlexBox(_ json: [String: Any]) -> MWDATDisplay.FlexBox {
+    let padding: MWDATDisplay.EdgeInsets? = (json["padding"] as? Int)
+      .map { MWDATDisplay.EdgeInsets(all: CGFloat($0)) }
+
+    // `FlexBox`'s content is a `@ComponentBuilder` result builder, so we
+    // yield the precomputed children through it rather than returning an
+    // array directly (the builder has no array `buildExpression`).
+    let children = buildChildren(json)
+    var box = MWDATDisplay.FlexBox(
+      direction: Self.direction(json["direction"] as? String),
+      spacing: CGFloat((json["spacing"] as? Int) ?? 0),
+      alignment: Self.alignment(json["alignment"] as? String),
+      crossAlignment: Self.alignment(json["crossAlignment"] as? String),
+      wrap: (json["wrap"] as? Bool) ?? false,
+      padding: padding,
+    ) {
+      for child in children { child }
+    }
+
+    if let bg = json["background"] as? String {
+      box = box.background(Self.background(bg))
+    }
+    if let grow = json["flexGrow"] as? Double {
+      box = box.flexGrow(Float(grow))
+    }
+    if let tapId = json["onTapId"] as? String {
+      box = box.onTap { [weak self] in
+        Task { @MainActor in self?.emitCallback(tapId, type: "tap") }
+      }
+    }
+    return box
+  }
+
+  private func buildText(_ json: [String: Any]) -> MWDATDisplay.Text {
+    MWDATDisplay.Text(
+      json["text"] as? String ?? "",
+      style: Self.textStyle(json["style"] as? String),
+      color: Self.textColor(json["color"] as? String),
+    )
+  }
+
+  private func buildImage(_ json: [String: Any]) -> MWDATDisplay.Image {
+    MWDATDisplay.Image(
+      uri: json["uri"] as? String ?? "",
+      sizePreset: Self.imageSize(json["sizePreset"] as? String),
+      cornerRadius: Self.cornerRadius(json["cornerRadius"] as? String),
+    )
+  }
+
+  private func buildButton(_ json: [String: Any]) -> MWDATDisplay.Button {
+    let iconName = (json["iconName"] as? String)
+      .flatMap { MWDATDisplay.IconName(rawValue: $0) }
+    let onClick: (@Sendable () -> Void)? = (json["onClickId"] as? String)
+      .map { id in
+        { [weak self] in
+          Task { @MainActor in self?.emitCallback(id, type: "click") }
+        }
+      }
+    return MWDATDisplay.Button(
+      label: json["label"] as? String ?? "",
+      style: Self.buttonStyle(json["style"] as? String),
+      iconName: iconName,
+      onClick: onClick,
+    )
+  }
+
+  private func buildIcon(_ json: [String: Any]) -> MWDATDisplay.Icon {
+    let name = (json["iconName"] as? String)
+      .flatMap { MWDATDisplay.IconName(rawValue: $0) } ?? .checkmark
+    return MWDATDisplay.Icon(name: name, style: .filled)
+  }
+
+  // MARK: - Enum mapping
+
+  private static func direction(_ value: String?) -> MWDATDisplay.Direction {
+    switch value {
+    case "row": return .row
+    case "column": return .column
+    default: return .column
+    }
+  }
+
+  private static func alignment(_ value: String?) -> MWDATDisplay.Alignment {
+    switch value {
+    case "center": return .center
+    case "end": return .end
+    case "start": return .start
+    default: return .start
+    }
+  }
+
+  private static func textStyle(_ value: String?) -> MWDATDisplay.TextStyle {
+    switch value {
+    case "heading": return .heading
+    case "meta": return .meta
+    default: return .body
+    }
+  }
+
+  private static func textColor(_ value: String?) -> MWDATDisplay.TextColor {
+    value == "secondary" ? .secondary : .primary
+  }
+
+  private static func imageSize(_ value: String?) -> MWDATDisplay.ImageSize {
+    value == "icon" ? .icon : .fill
+  }
+
+  private static func cornerRadius(
+    _ value: String?,
+  ) -> MWDATDisplay.CornerRadius {
+    switch value {
+    case "small": return .small
+    // The display SDK only ships none/small/medium; large collapses to medium.
+    case "medium", "large": return .medium
+    default: return .none
+    }
+  }
+
+  private static func buttonStyle(
+    _ value: String?,
+  ) -> MWDATDisplay.ButtonStyle {
+    value == "secondary" ? .secondary : .primary
+  }
+
+  private static func background(
+    _ value: String?,
+  ) -> MWDATDisplay.Background {
+    value == "card" ? .card : .none
+  }
+
+  private static func encode(_ state: DisplayState) -> Int {
+    switch state {
+    case .starting: return 0
+    case .started: return 1
+    case .stopping: return 2
+    case .stopped: return 3
+    @unknown default: return 3
+    }
+  }
+
+  /// Maps an iOS `VideoPlaybackEvent` to the wire token the Dart
+  /// `DisplayPlaybackEventType` keys on. Derived from `String(describing:)` so
+  /// it tolerates SDK additions to the playback-event enum.
+  private static func playbackWireName(_ event: VideoPlaybackEvent) -> String {
+    let raw = String(describing: event.type)
+    if raw.hasPrefix("started") || raw.hasPrefix("playing") { return "playing" }
+    if raw.hasPrefix("paused") { return "paused" }
+    if raw.hasPrefix("ended") { return "ended" }
+    if raw.hasPrefix("stopped") { return "stopped" }
+    if raw.hasPrefix("error") { return "error" }
+    return "unknown"
+  }
+
+  // MARK: - DeviceSession wait
+
+  /// Polls `session.state` until it reaches `.started`, throwing on timeout or
+  /// an early `.stopped`. Mirrors `MetaSessionManager`'s helper.
+  private static func waitForDeviceSessionStarted(
+    _ session: DeviceSession,
+    timeoutNs: UInt64,
+  ) async throws {
+    let pollIntervalNs: UInt64 = 250_000_000
+    let maxIterations = max(1, Int(timeoutNs / pollIntervalNs))
+    for _ in 0..<maxIterations {
+      if session.state == .started { return }
+      if session.state == .stopped {
+        throw NSError(
+          domain: "meta_wearables_dat_flutter",
+          code: -22,
+          userInfo: [NSLocalizedDescriptionKey:
+            "DeviceSession stopped before reaching .started"],
+        )
+      }
+      try? await Task.sleep(nanoseconds: pollIntervalNs)
+    }
+    session.stop()
+    throw NSError(
+      domain: "meta_wearables_dat_flutter",
+      code: -23,
+      userInfo: [NSLocalizedDescriptionKey:
+        "Glasses did not connect in time. Take them out of the case " +
+        "and put them on, then try again."],
+    )
+  }
+}

--- a/app/third_party/meta_wearables_dat_flutter/ios/meta_wearables_dat_flutter/Sources/meta_wearables_dat_flutter/MetaMockDeviceManager.swift
+++ b/app/third_party/meta_wearables_dat_flutter/ios/meta_wearables_dat_flutter/Sources/meta_wearables_dat_flutter/MetaMockDeviceManager.swift
@@ -1,0 +1,73 @@
+import Flutter
+
+enum CameraFacing {
+  case front
+  case back
+}
+
+@MainActor
+final class MetaMockDeviceManager {
+  fileprivate var mockDevicesSink: FlutterEventSink?
+
+  init() {}
+
+  func setMockDevicesSink(_ sink: FlutterEventSink?) {
+    mockDevicesSink = sink
+    sink?([])
+  }
+
+  func enable(initiallyRegistered: Bool, initialPermissionsGranted: Bool) {}
+
+  func disable() {}
+
+  func isEnabled() -> Bool { false }
+
+  func pairRayBanMeta() -> String { "" }
+
+  func unpair(uuid: String) throws { throw MockError.unavailable }
+
+  func pairedDevices() -> [[String: Any]] { [] }
+
+  func powerOn(uuid: String) throws { throw MockError.unavailable }
+
+  func powerOff(uuid: String) throws { throw MockError.unavailable }
+
+  func don(uuid: String) throws { throw MockError.unavailable }
+
+  func doff(uuid: String) throws { throw MockError.unavailable }
+
+  func fold(uuid: String) throws { throw MockError.unavailable }
+
+  func unfold(uuid: String) throws { throw MockError.unavailable }
+
+  func setPermission(permission: String, status: String) throws {
+    throw MockError.unavailable
+  }
+
+  func setPermissionRequestResult(permission: String, status: String) throws {
+    throw MockError.unavailable
+  }
+
+  func setCameraFacing(uuid: String, facing: CameraFacing) async throws {
+    throw MockError.unavailable
+  }
+
+  func setCameraFeed(uuid: String, filePath: String?) async throws {
+    throw MockError.unavailable
+  }
+
+  func setCapturedImage(uuid: String, filePath: String?) async throws {
+    throw MockError.unavailable
+  }
+}
+
+enum MockError: LocalizedError {
+  case unavailable
+
+  var errorDescription: String? {
+    switch self {
+    case .unavailable:
+      return "Mock Device Kit unavailable in Omi4Meta install build"
+    }
+  }
+}

--- a/app/third_party/meta_wearables_dat_flutter/ios/meta_wearables_dat_flutter/Sources/meta_wearables_dat_flutter/MetaSessionManager.swift
+++ b/app/third_party/meta_wearables_dat_flutter/ios/meta_wearables_dat_flutter/Sources/meta_wearables_dat_flutter/MetaSessionManager.swift
@@ -1,0 +1,751 @@
+// iOS streaming bridge.
+//
+// Owns:
+//   - One `StreamSession` per active stream (only one supported).
+//   - One `FlutterTextureRegistry` entry that owns the latest decoded
+//     `CVPixelBuffer`.
+//   - Listener tokens for state / error / video-frame publishers.
+//   - The three EventSinks (session_state, session_errors,
+//     video_stream_size).
+//
+// Frame pump:
+//   videoFramePublisher → CMSampleBuffer → CVImageBuffer (CVPixelBuffer)
+//   → `latestPixelBuffer` (atomic-ish swap under `bufferLock`)
+//   → `textureRegistry.textureFrameAvailable(id)`
+//   → Flutter calls `copyPixelBuffer()` and we hand back the retained buffer.
+//
+// All Meta SDK calls run on the main actor because that's what
+// `Wearables.shared` and the camera publishers expect; texture-buffer swaps
+// run inside a tiny critical section under `bufferLock`.
+
+import Flutter
+import CoreImage
+import CoreMedia
+import CoreVideo
+import UIKit
+#if canImport(MWDATCore)
+import MWDATCore
+#endif
+#if canImport(MWDATCamera)
+import MWDATCamera
+#endif
+
+@MainActor
+final class MetaSessionManager: NSObject {
+  private weak var registry: FlutterTextureRegistry?
+
+  // Buffer slot is read from `copyPixelBuffer()`, which Flutter calls on
+  // a background raster thread. `bufferLock` guards every read/write so
+  // the `nonisolated(unsafe)` here is sound: it only escapes the actor
+  // through that lock.
+  private let bufferLock = NSLock()
+  nonisolated(unsafe) private var latestPixelBuffer: CVPixelBuffer?
+  private var textureId: Int64?
+
+  /// The DeviceSession we created via `Wearables.shared.createSession`.
+  /// Owned by us; `stop()` is called from `stopSession()`.
+  private var deviceSession: DeviceSession?
+  private var session: MWDATCamera.Stream?
+  private var stateToken: (any AnyListenerToken)?
+  private var errorToken: (any AnyListenerToken)?
+  private var frameToken: (any AnyListenerToken)?
+  private var photoToken: (any AnyListenerToken)?
+  private var deviceStateTask: Task<Void, Never>?
+  private var deviceErrorTask: Task<Void, Never>?
+
+  /// Continuation for an in-flight `capturePhoto`. Resumed when the next
+  /// `PhotoData` arrives on the publisher. `nil` when no capture is in
+  /// progress; only one capture can be outstanding at a time.
+  private var pendingPhotoContinuation: CheckedContinuation<PhotoData, Error>?
+
+  // EventSinks (set by the plugin when Dart subscribes).
+  fileprivate var sessionStateSink: FlutterEventSink?
+  fileprivate var sessionErrorSink: FlutterEventSink?
+  fileprivate var deviceSessionStateSink: FlutterEventSink?
+  fileprivate var deviceSessionErrorSink: FlutterEventSink?
+  fileprivate var videoStreamSizeSink: FlutterEventSink?
+
+  /// Per-frame video payload sink. Gated behind subscriber presence: at
+  /// 720p the BGRA payload is ≈3.7 MB per frame, so we skip the
+  /// `CVPixelBufferLockBaseAddress` + memcpy entirely when nobody is
+  /// listening. See `doc/frame_processing.md` for the cost analysis.
+  fileprivate var videoFramesSink: FlutterEventSink?
+
+  /// Codec the caller asked for in `startStreamSession`. Drives whether
+  /// `handleVideoFrame` extracts BGRA pixels (raw) or routes the sample
+  /// buffer through `hevcPipeline` (hvc1).
+  private var activeCodec: VideoCodec = .raw
+
+  /// Lazily-built HEVC → BGRA decoder. Only constructed when the caller
+  /// selects `.hvc1`; tears down in `stopSession()`.
+  private var hevcPipeline: VTDecompressionPipeline?
+
+  init(registry: FlutterTextureRegistry) {
+    self.registry = registry
+  }
+
+  // MARK: - Session lifecycle
+
+  /// Starts a session for `deviceUUID` (or the active device when nil) at
+  /// the requested `fps` and `quality`. Returns the Flutter texture id.
+  ///
+  /// When `deviceKinds` is provided, only devices whose `DeviceType`
+  /// matches one of the wire-name kinds (`rayBanMeta`, `rayBanDisplay`,
+  /// `oakleyMeta`, `unknown`) is considered. iOS's
+  /// `AutoDeviceSelector` does not expose a filter API, so we enumerate
+  /// `Wearables.shared.devices` and pin the first matching id via
+  /// `SpecificDeviceSelector`.
+  func startSession(
+    deviceUUID: String?,
+    fps: Int,
+    quality: StreamingResolution,
+    deviceKinds: Set<String>? = nil,
+    videoCodec: VideoCodec = .raw,
+  ) async throws -> Int64 {
+    if let existingId = textureId { return existingId }
+    guard let registry = registry else {
+      throw NSError(
+        domain: "meta_wearables_dat_flutter",
+        code: -1,
+        userInfo: [NSLocalizedDescriptionKey: "Texture registry unavailable"]
+      )
+    }
+
+    // Pick the best available DeviceSelector for the current SDK state.
+    //
+    // The DAT SDK's `DeviceSession.start()` is responsible for driving the
+    // underlying BLE / accessory connection. As long as the glasses are
+    // paired through Meta AI (i.e. they appear in
+    // `Wearables.shared.devices`), `start()` will wait for them to become
+    // reachable. Aborting up-front because `linkState != .connected` would
+    // prevent the SDK from ever attempting to connect — so we only do that
+    // as an explicit no-paired-device check.
+    //
+    // Strategy:
+    //   1. If the caller passed a deviceUUID, pin `SpecificDeviceSelector`
+    //      to that UUID.
+    //   2. Otherwise, prefer a device in `linkState == .connected`, then
+    //      `.connecting`, then any paired id — and pin
+    //      `SpecificDeviceSelector` so the SDK doesn't reject us with
+    //      `noEligibleDevice` when no don-sensor signal is available.
+    //   3. Only error out when *no* paired device matches the request
+    //      (either nothing paired, or nothing matching `deviceKinds`).
+    let selector: any DeviceSelector
+    let chosenIdSource: String
+
+    let allIds = Wearables.shared.devices
+
+    let filteredIds = MetaSessionManager.filterDevices(allIds, deviceKinds: deviceKinds)
+    let pickedId = MetaSessionManager.pickBestDevice(from: filteredIds)
+
+    if let requestedUuid = deviceUUID,
+       let match = filteredIds.first(where: { $0 == requestedUuid }) {
+      selector = SpecificDeviceSelector(device: match)
+      chosenIdSource = "explicit deviceUuid (\(match))"
+    } else if let pick = pickedId {
+      selector = SpecificDeviceSelector(device: pick)
+      chosenIdSource = "first paired device (\(pick))"
+    } else if let kinds = deviceKinds, !kinds.isEmpty {
+      print("[meta_wearables_dat_flutter] startSession aborting: " +
+        "no devices matching kinds=\(kinds). devices=\(allIds.count)")
+      throw NSError(
+        domain: "meta_wearables_dat_flutter",
+        code: -11,
+        userInfo: [NSLocalizedDescriptionKey:
+          "No glasses matching the requested kinds are currently paired."],
+      )
+    } else {
+      print("[meta_wearables_dat_flutter] startSession aborting: " +
+        "no paired devices. devices=\(allIds.count)")
+      throw NSError(
+        domain: "meta_wearables_dat_flutter",
+        code: -10,
+        userInfo: [NSLocalizedDescriptionKey:
+          "No glasses are currently paired. Open Meta AI to pair " +
+          "Ray-Ban Meta or Oakley Meta glasses, then try again."],
+      )
+    }
+    print("[meta_wearables_dat_flutter] startSession selector=\(chosenIdSource)")
+
+    // Create the DeviceSession via the real Wearables API and wait for
+    // it to reach `.started` before adding any stream capability. The
+    // SDK's `start()` is what actually drives the BLE/MFi handshake, so
+    // we no longer pre-abort when `linkState != .connected`.
+    let deviceSession = try Wearables.shared.createSession(
+      deviceSelector: selector,
+    )
+    self.deviceSession = deviceSession
+
+    // Wire DeviceSession-level state + error streams.
+    observeDeviceSession(deviceSession)
+
+    if deviceSession.state != .started {
+      try deviceSession.start()
+      try await Self.waitForDeviceSessionStarted(
+        deviceSession,
+        timeoutNs: 45_000_000_000,
+      )
+    }
+
+    // Build the stream config. When the caller selected `.hvc1` we
+    // ask the SDK for HEVC NAL units and route them through a
+    // `VTDecompressionPipeline` for the texture preview (so the
+    // existing `Texture(textureId:)` widget keeps working).
+    let config = StreamConfiguration(
+      videoCodec: videoCodec,
+      resolution: quality,
+      frameRate: UInt(fps)
+    )
+    self.activeCodec = videoCodec
+    if videoCodec == .hvc1 {
+      let pipeline = VTDecompressionPipeline()
+      // If background streaming is already active, build the decoder in
+      // software-only mode so it survives backgrounding from the start.
+      pipeline.softwareOnly = BackgroundStreamingController.shared
+        .useSoftwareDecoder
+      self.hevcPipeline = pipeline
+    } else {
+      self.hevcPipeline = nil
+    }
+
+    guard let stream = try deviceSession.addStream(config: config) else {
+      throw NSError(
+        domain: "meta_wearables_dat_flutter",
+        code: -3,
+        userInfo: [NSLocalizedDescriptionKey: "addStream returned nil"]
+      )
+    }
+    self.session = stream
+
+    // Register a Flutter texture before frames start flowing.
+    let id = registry.register(self)
+    self.textureId = id
+
+    // Wire publishers BEFORE starting so we don't miss the initial state
+    // transition. Tokens are released in stopSession.
+    stateToken = stream.statePublisher.listen { [weak self] state in
+      Task { @MainActor in
+        self?.sessionStateSink?(MetaSessionManager.encode(state))
+      }
+    }
+    errorToken = stream.errorPublisher.listen { [weak self] error in
+      Task { @MainActor in
+        self?.sessionErrorSink?(MetaSessionManager.encode(error))
+      }
+    }
+    frameToken = stream.videoFramePublisher.listen { [weak self] frame in
+      Task { @MainActor in
+        self?.handleVideoFrame(frame, textureId: id)
+      }
+    }
+    photoToken = stream.photoDataPublisher.listen { [weak self] photo in
+      Task { @MainActor in
+        self?.deliverPhoto(.success(photo))
+      }
+    }
+
+    await stream.start()
+    return id
+  }
+
+  /// Triggers a high-res still capture and resolves once the next
+  /// `PhotoData` arrives on the publisher. Throws when no session is
+  /// active, when another capture is already in flight, or when the
+  /// underlying SDK returns `false` from `capturePhoto`.
+  func capturePhoto(format: PhotoCaptureFormat) async throws -> PhotoData {
+    guard let stream = session else {
+      throw NSError(
+        domain: "meta_wearables_dat_flutter",
+        code: -20,
+        userInfo: [NSLocalizedDescriptionKey: "No active stream session"],
+      )
+    }
+    if pendingPhotoContinuation != nil {
+      throw NSError(
+        domain: "meta_wearables_dat_flutter",
+        code: -21,
+        userInfo: [
+          NSLocalizedDescriptionKey: "A photo capture is already in flight",
+        ],
+      )
+    }
+    return try await withCheckedThrowingContinuation { continuation in
+      pendingPhotoContinuation = continuation
+      let kickedOff = stream.capturePhoto(format: format)
+      if !kickedOff {
+        pendingPhotoContinuation = nil
+        continuation.resume(throwing: NSError(
+          domain: "meta_wearables_dat_flutter",
+          code: -22,
+          userInfo: [
+            NSLocalizedDescriptionKey: "capturePhoto returned false",
+          ],
+        ))
+      }
+    }
+  }
+
+  private func deliverPhoto(_ result: Result<PhotoData, Error>) {
+    guard let continuation = pendingPhotoContinuation else { return }
+    pendingPhotoContinuation = nil
+    continuation.resume(with: result)
+  }
+
+  func stopSession() async {
+    if let session = session {
+      try? await session.stop()
+    }
+    if let token = stateToken { await token.cancel() }
+    if let token = errorToken { await token.cancel() }
+    if let token = frameToken { await token.cancel() }
+    if let token = photoToken { await token.cancel() }
+    stateToken = nil
+    errorToken = nil
+    frameToken = nil
+    photoToken = nil
+    session = nil
+
+    // Tear down DeviceSession-level listeners.
+    deviceStateTask?.cancel()
+    deviceStateTask = nil
+    deviceErrorTask?.cancel()
+    deviceErrorTask = nil
+
+    // DeviceSession.stop() is synchronous in 0.6.x; once stopped a
+    // new createSession() call is required to stream again.
+    deviceSession?.stop()
+    deviceSession = nil
+
+    // Tear down the HEVC pipeline (if any) so the next session can
+    // pick a different codec / resolution.
+    hevcPipeline?.invalidate()
+    hevcPipeline = nil
+    activeCodec = .raw
+
+    if pendingPhotoContinuation != nil {
+      deliverPhoto(.failure(NSError(
+        domain: "meta_wearables_dat_flutter",
+        code: -23,
+        userInfo: [NSLocalizedDescriptionKey: "Session stopped during capture"],
+      )))
+    }
+
+    if let id = textureId {
+      registry?.unregisterTexture(id)
+      textureId = nil
+    }
+    bufferLock.lock()
+    latestPixelBuffer = nil
+    bufferLock.unlock()
+  }
+
+  func pauseSession() async {
+    if let stream = session {
+      try? await stream.stop()
+    }
+  }
+
+  func resumeSession() async {
+    if let stream = session {
+      await stream.start()
+    }
+  }
+
+  // MARK: - Frame plumbing
+
+  private func handleVideoFrame(_ frame: VideoFrame, textureId: Int64) {
+    let sampleBuffer = frame.sampleBuffer
+
+    // Path A: raw / BGRA. `CMSampleBufferGetImageBuffer` returns the
+    // already-decoded `CVPixelBuffer` directly.
+    // Path B: hvc1. The image buffer is nil (sample carries compressed
+    // NAL units); route through the VTDecompressionSession to get a
+    // BGRA `CVPixelBuffer` for the texture and emit the compressed
+    // bytes to `videoFramesStream` when subscribed.
+    let imageBuffer: CVPixelBuffer? = {
+      if activeCodec == .hvc1 {
+        return hevcPipeline?.decode(sampleBuffer)
+      }
+      return CMSampleBufferGetImageBuffer(sampleBuffer)
+    }()
+    guard let imageBuffer = imageBuffer else {
+      // Even when decoding fails, still emit the compressed payload so
+      // host apps recording to disk don't miss frames.
+      if activeCodec == .hvc1, let sink = videoFramesSink {
+        emitHevcFrame(sampleBuffer: sampleBuffer, sink: sink)
+      }
+      return
+    }
+
+    bufferLock.lock()
+    latestPixelBuffer = imageBuffer
+    bufferLock.unlock()
+
+    let width = CVPixelBufferGetWidth(imageBuffer)
+    let height = CVPixelBufferGetHeight(imageBuffer)
+
+    // Emit size update lazily so the host can rebuild AspectRatio without
+    // every frame triggering a Flutter rebuild.
+    if let sink = videoStreamSizeSink {
+      sink(["width": width, "height": height])
+    }
+
+    // Forward the frame to the videoFramesStream sink, but only when at
+    // least one Dart subscriber is attached. Skipping when not needed
+    // keeps the per-frame cost free for host apps that only care about
+    // the texture preview.
+    if let sink = videoFramesSink {
+      if activeCodec == .hvc1 {
+        emitHevcFrame(sampleBuffer: sampleBuffer, sink: sink)
+      } else {
+        emitVideoFrame(
+          sampleBuffer: sampleBuffer,
+          pixelBuffer: imageBuffer,
+          width: width,
+          height: height,
+          sink: sink,
+        )
+      }
+    }
+
+    registry?.textureFrameAvailable(textureId)
+  }
+
+  /// Serialises an HEVC `CMSampleBuffer` to an Annex-B encoded byte
+  /// payload and emits it on the videoFramesStream sink. On keyframes
+  /// the VPS/SPS/PPS parameter sets are prepended so downstream muxers
+  /// (e.g. an mp4 writer) can decode the stream without out-of-band
+  /// state. Both bytes and parameter sets use 4-byte start codes
+  /// (`00 00 00 01`).
+  private func emitHevcFrame(
+    sampleBuffer: CMSampleBuffer,
+    sink: @escaping FlutterEventSink,
+  ) {
+    let isKeyframe = VTDecompressionPipeline.isKeyframe(sampleBuffer)
+    guard let nalBytes = VTDecompressionPipeline.annexBNalBytes(
+      from: sampleBuffer,
+    ) else {
+      return
+    }
+    var bytes = Data()
+    if isKeyframe,
+       let desc = CMSampleBufferGetFormatDescription(sampleBuffer),
+       let params = VTDecompressionPipeline.annexBParameterSets(from: desc) {
+      bytes.append(params)
+    }
+    bytes.append(nalBytes)
+
+    let pts = CMSampleBufferGetPresentationTimeStamp(sampleBuffer)
+    let ptsUs: Int = pts.isValid
+      ? Int(CMTimeGetSeconds(pts) * 1_000_000.0)
+      : 0
+
+    let dims = CMSampleBufferGetFormatDescription(sampleBuffer)
+      .map(CMVideoFormatDescriptionGetDimensions) ?? CMVideoDimensions(width: 0, height: 0)
+    sink([
+      "codec": "hvc1",
+      "bytes": FlutterStandardTypedData(bytes: bytes),
+      "width": Int(dims.width),
+      "height": Int(dims.height),
+      "ptsUs": ptsUs,
+      "isKeyframe": isKeyframe,
+    ] as [String: Any])
+  }
+
+  /// Serialises a single `CVPixelBuffer` BGRA frame into a Flutter
+  /// platform-channel payload and emits it on the `videoFramesStream`
+  /// sink. The pixel-buffer is locked with `.readOnly`, copied into a
+  /// `Data` and unlocked synchronously; no buffer references escape this
+  /// scope.
+  ///
+  /// The payload shape matches `VideoFrame.fromMap` on Dart:
+  ///   `{ codec, bytes, width, height, ptsUs, isKeyframe, bytesPerRow }`.
+  private func emitVideoFrame(
+    sampleBuffer: CMSampleBuffer,
+    pixelBuffer: CVPixelBuffer,
+    width: Int,
+    height: Int,
+    sink: @escaping FlutterEventSink,
+  ) {
+    CVPixelBufferLockBaseAddress(pixelBuffer, .readOnly)
+    defer { CVPixelBufferUnlockBaseAddress(pixelBuffer, .readOnly) }
+    guard let base = CVPixelBufferGetBaseAddress(pixelBuffer) else { return }
+    let bytesPerRow = CVPixelBufferGetBytesPerRow(pixelBuffer)
+    let size = bytesPerRow * height
+
+    let pts = CMSampleBufferGetPresentationTimeStamp(sampleBuffer)
+    let ptsUs: Int = pts.isValid
+      ? Int(CMTimeGetSeconds(pts) * 1_000_000.0)
+      : 0
+
+    let bytes = Data(bytes: base, count: size)
+    sink([
+      "codec": "raw",
+      "bytes": FlutterStandardTypedData(bytes: bytes),
+      "width": width,
+      "height": height,
+      "ptsUs": ptsUs,
+      "isKeyframe": true,
+      "bytesPerRow": bytesPerRow,
+    ] as [String: Any])
+  }
+
+  // MARK: - Encoding helpers
+
+  /// Maps an iOS `DeviceType` to the wire-string name Dart uses (`DeviceKind`).
+  /// Mirrors `MetaWearablesDatPlugin.kindName(for:)`.
+  static func wireKindName(for deviceType: DeviceType?) -> String {
+    switch deviceType {
+    case .rayBanMeta?, .rayBanMetaOptics?: return "rayBanMeta"
+    case .metaRayBanDisplay?: return "rayBanDisplay"
+    case .oakleyMetaHSTN?, .oakleyMetaVanguard?: return "oakleyMeta"
+    case .unknown?, .none: return "unknown"
+    @unknown default: return "unknown"
+    }
+  }
+
+  private static func encode(_ state: StreamState) -> Int {
+    switch state {
+    case .stopped: return 0
+    case .waitingForDevice: return 1
+    case .starting: return 2
+    case .streaming: return 3
+    case .paused: return 4
+    case .stopping: return 5
+    @unknown default: return 0
+    }
+  }
+
+  /// Maps a `StreamError` (DAT 0.7.0 renamed `StreamSessionError`) to a
+  /// typed sub-code that Dart's `SessionError.is*` getters key on.
+  ///
+  /// We derive the code from `String(describing:)` rather than switching on
+  /// concrete enum cases so the bridge keeps compiling if Meta adds or
+  /// renames cases between SDK releases.
+  private static func encode(_ error: StreamError) -> [String: Any] {
+    let raw = String(describing: error)
+    let token = raw.split(separator: "(").first.map(String.init) ?? raw
+    let code: String
+    switch token {
+    case "permissionDenied": code = "permissionDenied"
+    case "hingesClosed", "hingeClosed": code = "hingesClosed"
+    case "thermalCritical": code = "thermalCritical"
+    case "videoStreamingError", "streamError": code = "videoStreamingError"
+    case "timeout": code = "timeout"
+    case "deviceNotFound", "deviceNotConnected", "deviceDisconnected":
+      code = "deviceDisconnected"
+    case "internalError": code = "internalError"
+    default: code = "sessionError"
+    }
+    return ["code": code, "message": raw]
+  }
+
+  private static func encodeDeviceSessionState(_ state: DeviceSessionState) -> Int {
+    switch state {
+    case .idle: return 0
+    case .starting: return 1
+    case .started: return 2
+    case .paused: return 3
+    case .stopping: return 4
+    case .stopped: return 5
+    @unknown default: return 0
+    }
+  }
+
+  /// Maps `DeviceSessionError` cases to typed sub-codes for the Dart
+  /// `DeviceSessionError.is*` getters.
+  ///
+  /// Derived from `String(describing:)` so the bridge keeps compiling across
+  /// SDK releases that add cases (DAT 0.7.0 added
+  /// `datAppOnTheGlassesUpdateRequired`). The `.unexpectedError` associated
+  /// description is preserved for the message when present.
+  private static func encodeDeviceSessionError(_ error: DeviceSessionError) -> [String: Any] {
+    let raw = String(describing: error)
+    let token = raw.split(separator: "(").first.map(String.init) ?? raw
+    let code: String
+    switch token {
+    case "noEligibleDevice": code = "noEligibleDevice"
+    case "sessionAlreadyStopped": code = "sessionAlreadyStopped"
+    case "sessionAlreadyExists": code = "sessionAlreadyExists"
+    case "sessionIdle": code = "sessionIdle"
+    case "capabilityAlreadyActive": code = "capabilityAlreadyActive"
+    case "capabilityNotFound": code = "capabilityNotFound"
+    case "datAppOnTheGlassesUpdateRequired": code = "datAppUpdateRequired"
+    default: code = "unexpectedError"
+    }
+    let message: String
+    if case let .unexpectedError(description) = error {
+      message = description
+    } else {
+      message = raw
+    }
+    return ["code": code, "message": message]
+  }
+
+  /// Wires DeviceSession-level state and error publishers to the matching
+  /// Flutter event sinks. Called from `startSession` once a session has
+  /// been created. Tokens are torn down in `stopSession`.
+  private func observeDeviceSession(_ session: DeviceSession) {
+    // The DeviceSession's `stateStream()` is an AsyncSequence; iterate in a
+    // detached Task so we don't block the main caller.
+    deviceStateTask?.cancel()
+    deviceStateTask = Task { @MainActor [weak self] in
+      // Seed the current state for late subscribers.
+      self?.deviceSessionStateSink?(
+        MetaSessionManager.encodeDeviceSessionState(session.state)
+      )
+      for await state in session.stateStream() {
+        if Task.isCancelled { break }
+        self?.deviceSessionStateSink?(
+          MetaSessionManager.encodeDeviceSessionState(state)
+        )
+      }
+    }
+    deviceErrorTask?.cancel()
+    deviceErrorTask = Task { @MainActor [weak self] in
+      for await error in session.errorStream() {
+        if Task.isCancelled { break }
+        self?.deviceSessionErrorSink?(
+          MetaSessionManager.encodeDeviceSessionError(error)
+        )
+      }
+    }
+  }
+
+  /// Polls `session.state` until it reaches `.started`, or throws once
+  /// `timeoutNs` elapses or the session transitions straight to
+  /// `.stopped`. Implemented as a simple polling loop rather than a
+  /// task-group race against `session.stateStream()` because the SDK
+  /// `DeviceSession` is not `Sendable`, and crossing it into a child
+  /// task tripped the Swift compiler's SILGen pass on Xcode 16+.
+  /// 250 ms polling at 30 fps is essentially free.
+  private static func waitForDeviceSessionStarted(
+    _ session: DeviceSession,
+    timeoutNs: UInt64,
+  ) async throws {
+    let pollIntervalNs: UInt64 = 250_000_000
+    let maxIterations = max(1, Int(timeoutNs / pollIntervalNs))
+    for _ in 0..<maxIterations {
+      if session.state == .started { return }
+      if session.state == .stopped {
+        throw NSError(
+          domain: "meta_wearables_dat_flutter",
+          code: -2,
+          userInfo: [
+            NSLocalizedDescriptionKey:
+              "DeviceSession stopped before reaching .started",
+          ],
+        )
+      }
+      try? await Task.sleep(nanoseconds: pollIntervalNs)
+    }
+    // Timeout. Stop the half-built session so the next call starts clean.
+    session.stop()
+    throw NSError(
+      domain: "meta_wearables_dat_flutter",
+      code: -12,
+      userInfo: [
+        NSLocalizedDescriptionKey:
+          "Glasses did not connect in time. Take them out of the case " +
+          "and put them on, then try again.",
+      ],
+    )
+  }
+
+  /// Filters paired device ids by the optional kinds set. Hoisted out
+  /// of `startSession` so the type checker has less work to do inside
+  /// the async function body (Xcode 16's SILGen pass crashes on some
+  /// nested-closure shapes inside large async functions).
+  private static func filterDevices(
+    _ allIds: [DeviceIdentifier],
+    deviceKinds: Set<String>?,
+  ) -> [DeviceIdentifier] {
+    guard let kinds = deviceKinds, !kinds.isEmpty else { return allIds }
+    return allIds.filter { id in
+      let kindName = MetaSessionManager.wireKindName(
+        for: Wearables.shared.deviceForIdentifier(id)?.deviceType(),
+      )
+      return kinds.contains(kindName)
+    }
+  }
+
+  /// Picks the best paired device from `ids`, preferring `.connected`,
+  /// then `.connecting`, then any paired id. Returns `nil` when `ids`
+  /// is empty.
+  private static func pickBestDevice(
+    from ids: [DeviceIdentifier],
+  ) -> DeviceIdentifier? {
+    if let connected = ids.first(where: { id in
+      Wearables.shared.deviceForIdentifier(id)?.linkState == .connected
+    }) { return connected }
+    if let connecting = ids.first(where: { id in
+      Wearables.shared.deviceForIdentifier(id)?.linkState == .connecting
+    }) { return connecting }
+    return ids.first
+  }
+
+  // MARK: - EventSink wiring (called from the plugin)
+
+  func setSessionStateSink(_ sink: FlutterEventSink?) { sessionStateSink = sink }
+  func setSessionErrorSink(_ sink: FlutterEventSink?) { sessionErrorSink = sink }
+  func setDeviceSessionStateSink(_ sink: FlutterEventSink?) {
+    deviceSessionStateSink = sink
+  }
+  func setDeviceSessionErrorSink(_ sink: FlutterEventSink?) {
+    deviceSessionErrorSink = sink
+  }
+  func setVideoSizeSink(_ sink: FlutterEventSink?) { videoStreamSizeSink = sink }
+  func setVideoFramesSink(_ sink: FlutterEventSink?) { videoFramesSink = sink }
+
+  /// Tells the manager whether background streaming is currently
+  /// enabled. When `true`, the next session that selects `.hvc1` will
+  /// build its `VTDecompressionSession` in software-only mode so the
+  /// decoder survives backgrounding. Live sessions are rebuilt lazily;
+  /// in-flight decoders are invalidated so the next frame triggers a
+  /// rebuild with the new flag.
+  func setBackgroundStreamingEnabled(_ enabled: Bool) {
+    hevcPipeline?.softwareOnly = enabled
+  }
+
+  // MARK: - Still capture (background-safe)
+
+  /// Software (CPU) CoreImage context reused across still captures. Software
+  /// rendering is required so encoding survives app backgrounding, when the
+  /// GPU/Metal render path is unavailable.
+  private static let stillEncodeContext =
+    CIContext(options: [.useSoftwareRenderer: true])
+
+  /// Encodes the most recent decoded frame (`latestPixelBuffer`) to JPEG on
+  /// the CPU.
+  ///
+  /// Unlike the Flutter texture rasterizer (`ui.Scene.toImage(textureId)`),
+  /// this does **not** depend on the app being foregrounded or on the GPU
+  /// raster pipeline, so it keeps producing viewable frames while the app is
+  /// backgrounded (the SDK's native frame callback keeps `latestPixelBuffer`
+  /// fresh). Reads the buffer under `bufferLock`; encodes it via a software
+  /// CoreImage context.
+  func captureLatestFrameJpeg(quality: CGFloat) -> Data? {
+    bufferLock.lock()
+    let buffer = latestPixelBuffer
+    bufferLock.unlock()
+    guard let pixelBuffer = buffer else { return nil }
+
+    let ciImage = CIImage(cvPixelBuffer: pixelBuffer)
+    let extent = ciImage.extent
+    guard extent.width > 0, extent.height > 0 else { return nil }
+    guard let cgImage = MetaSessionManager.stillEncodeContext.createCGImage(
+      ciImage,
+      from: extent,
+    ) else { return nil }
+    return UIImage(cgImage: cgImage).jpegData(compressionQuality: quality)
+  }
+}
+
+extension MetaSessionManager: FlutterTexture {
+  nonisolated func copyPixelBuffer() -> Unmanaged<CVPixelBuffer>? {
+    bufferLock.lock()
+    defer { bufferLock.unlock() }
+    guard let buffer = latestPixelBuffer else { return nil }
+    return Unmanaged.passRetained(buffer)
+  }
+}

--- a/app/third_party/meta_wearables_dat_flutter/ios/meta_wearables_dat_flutter/Sources/meta_wearables_dat_flutter/MetaWearablesDatPlugin.swift
+++ b/app/third_party/meta_wearables_dat_flutter/ios/meta_wearables_dat_flutter/Sources/meta_wearables_dat_flutter/MetaWearablesDatPlugin.swift
@@ -1,0 +1,1305 @@
+// `meta_wearables_dat_flutter` iOS plugin.
+//
+// Bridges Meta's MWDATCore / MWDATCamera (and optional MWDATMockDevice)
+// frameworks to a Dart MethodChannel + EventChannel surface. Responsibilities:
+//   * Configure `Wearables` once per process.
+//   * Registration: startRegistration, startUnregistration, handleUrl,
+//     plus EventChannels for registration_state and active_device.
+//   * Streaming: startStreamSession (returns a Flutter TextureRegistry id),
+//     stop/pause/resume, plus EventChannels for session_state,
+//     session_errors and video_stream_size.
+//   * Diagnostics: dumpDiagnostics returns a structured Info.plist + SDK
+//     state snapshot for use in host-app debug UI.
+//   * Optional: Mock Device Kit pass-throughs when MWDATMockDevice is linked.
+
+import Flutter
+import UIKit
+
+#if !canImport(MWDATCore)
+#error("Missing MWDATCore. Enable Flutter's Swift Package Manager support: `flutter config --enable-swift-package-manager` and use Xcode 15.4+.")
+#endif
+
+#if !canImport(MWDATCamera)
+#error("Missing MWDATCamera. Enable Flutter's Swift Package Manager support: `flutter config --enable-swift-package-manager` and use Xcode 15.4+.")
+#endif
+
+import MWDATCore
+import MWDATCamera
+#if canImport(MWDATMockDevice)
+import MWDATMockDevice
+#endif
+
+// MARK: - Plugin registration
+
+public class MetaWearablesDatPlugin: NSObject, FlutterPlugin {
+  // `Wearables.configure()` is global; ensure exactly-once across hot
+  // restarts by tracking it in a static.
+  private static var didConfigure = false
+
+  // Stream handlers retained on the plugin instance so their cancellation
+  // tokens survive past `register(with:)`.
+  private let registrationStateHandler = RegistrationStateStreamHandler()
+  private let activeDeviceHandler = ActiveDeviceStreamHandler()
+  private let devicesHandler = DevicesStreamHandler()
+  private let compatibilityHandler = CompatibilityStreamHandler()
+
+  // Streaming. Manager is created lazily on first session start because we
+  // need the texture registry from the registrar.
+  private var sessionManager: MetaSessionManager?
+  private let streamSessionStateHandler = PassthroughStreamHandler()
+  private let streamSessionErrorHandler = PassthroughStreamHandler()
+  private let deviceSessionStateHandler = PassthroughStreamHandler()
+  private let deviceSessionErrorHandler = PassthroughStreamHandler()
+  private let videoSizeHandler = PassthroughStreamHandler()
+  private let videoFramesHandler = PassthroughStreamHandler()
+  private weak var pluginRegistrar: FlutterPluginRegistrar?
+
+  // Mock Device Kit. Lazily created on first use.
+  private var mockManager: MetaMockDeviceManager?
+  private let mockDevicesHandler = PassthroughStreamHandler()
+
+  // Display (MWDATDisplay). Lazily created on first use.
+  private var displayManager: MetaDisplayManager?
+  private let displayStateHandler = PassthroughStreamHandler()
+  private let displayEventsHandler = PassthroughStreamHandler()
+
+  public static func register(with registrar: FlutterPluginRegistrar) {
+    if !didConfigure {
+      do {
+        try Wearables.configure()
+        didConfigure = true
+      } catch {
+        // Configuration may legitimately fail in unit-test bundles or when
+        // the host app's Info.plist `MWDAT` dict is missing. We log instead
+        // of crashing so the host app can still call non-DAT APIs.
+        print("[meta_wearables_dat_flutter] Wearables.configure() failed: \(error)")
+      }
+    }
+
+    let methodChannel = FlutterMethodChannel(
+      name: "meta_wearables_dat_flutter",
+      binaryMessenger: registrar.messenger()
+    )
+
+    let registrationStateChannel = FlutterEventChannel(
+      name: "meta_wearables_dat_flutter/registration_state",
+      binaryMessenger: registrar.messenger()
+    )
+
+    let activeDeviceChannel = FlutterEventChannel(
+      name: "meta_wearables_dat_flutter/active_device",
+      binaryMessenger: registrar.messenger()
+    )
+
+    let devicesChannel = FlutterEventChannel(
+      name: "meta_wearables_dat_flutter/devices",
+      binaryMessenger: registrar.messenger()
+    )
+
+    let compatibilityChannel = FlutterEventChannel(
+      name: "meta_wearables_dat_flutter/compatibility",
+      binaryMessenger: registrar.messenger()
+    )
+
+    let streamSessionStateChannel = FlutterEventChannel(
+      name: "meta_wearables_dat_flutter/stream_session_state",
+      binaryMessenger: registrar.messenger()
+    )
+    let streamSessionErrorChannel = FlutterEventChannel(
+      name: "meta_wearables_dat_flutter/stream_session_errors",
+      binaryMessenger: registrar.messenger()
+    )
+    let deviceSessionStateChannel = FlutterEventChannel(
+      name: "meta_wearables_dat_flutter/device_session_state",
+      binaryMessenger: registrar.messenger()
+    )
+    let deviceSessionErrorChannel = FlutterEventChannel(
+      name: "meta_wearables_dat_flutter/device_session_errors",
+      binaryMessenger: registrar.messenger()
+    )
+    let videoSizeChannel = FlutterEventChannel(
+      name: "meta_wearables_dat_flutter/video_stream_size",
+      binaryMessenger: registrar.messenger()
+    )
+    let videoFramesChannel = FlutterEventChannel(
+      name: "meta_wearables_dat_flutter/video_frames",
+      binaryMessenger: registrar.messenger()
+    )
+    let mockDevicesChannel = FlutterEventChannel(
+      name: "meta_wearables_dat_flutter/mock_devices",
+      binaryMessenger: registrar.messenger()
+    )
+    let displayStateChannel = FlutterEventChannel(
+      name: "meta_wearables_dat_flutter/display_state",
+      binaryMessenger: registrar.messenger()
+    )
+    let displayEventsChannel = FlutterEventChannel(
+      name: "meta_wearables_dat_flutter/display_events",
+      binaryMessenger: registrar.messenger()
+    )
+
+    let instance = MetaWearablesDatPlugin()
+    instance.pluginRegistrar = registrar
+    registrar.addMethodCallDelegate(instance, channel: methodChannel)
+    // Register as a UIApplication delegate so we can auto-forward the
+    // Meta AI registration callback URL to `Wearables.shared.handleUrl`.
+    // Host apps that use the classic AppDelegate lifecycle (no
+    // `UIApplicationSceneManifest` in Info.plist) need no extra wiring —
+    // iOS delivers the URL to `application(_:open:options:)` below.
+    registrar.addApplicationDelegate(instance)
+    // Host apps that DO use a scene manifest need to forward URL events
+    // themselves because iOS delivers them via the scene delegate, not
+    // the app delegate. The example app's SceneDelegate posts
+    // `MetaWearablesDatHandleURL` whenever a URL arrives; we observe it
+    // here and feed it to the SDK. Decouples the example (and any host
+    // app following the same convention) from `MWDATCore`.
+    NotificationCenter.default.addObserver(
+      instance,
+      selector: #selector(handleURLNotification(_:)),
+      name: Notification.Name("MetaWearablesDatHandleURL"),
+      object: nil,
+    )
+    registrationStateChannel.setStreamHandler(instance.registrationStateHandler)
+    activeDeviceChannel.setStreamHandler(instance.activeDeviceHandler)
+    devicesChannel.setStreamHandler(instance.devicesHandler)
+    compatibilityChannel.setStreamHandler(instance.compatibilityHandler)
+    streamSessionStateChannel.setStreamHandler(instance.streamSessionStateHandler)
+    streamSessionErrorChannel.setStreamHandler(instance.streamSessionErrorHandler)
+    deviceSessionStateChannel.setStreamHandler(instance.deviceSessionStateHandler)
+    deviceSessionErrorChannel.setStreamHandler(instance.deviceSessionErrorHandler)
+    videoSizeChannel.setStreamHandler(instance.videoSizeHandler)
+    videoFramesChannel.setStreamHandler(instance.videoFramesHandler)
+    mockDevicesChannel.setStreamHandler(instance.mockDevicesHandler)
+    instance.mockDevicesHandler.onSinkChange = { [weak instance] sink in
+      Task { @MainActor in
+        instance?.ensureMockManager().setMockDevicesSink(sink)
+      }
+    }
+    displayStateChannel.setStreamHandler(instance.displayStateHandler)
+    displayEventsChannel.setStreamHandler(instance.displayEventsHandler)
+    instance.displayStateHandler.onSinkChange = { [weak instance] sink in
+      Task { @MainActor in
+        instance?.ensureDisplayManager().setDisplayStateSink(sink)
+      }
+    }
+    instance.displayEventsHandler.onSinkChange = { [weak instance] sink in
+      Task { @MainActor in
+        instance?.ensureDisplayManager().setDisplayEventsSink(sink)
+      }
+    }
+  }
+
+  @MainActor
+  private func ensureDisplayManager() -> MetaDisplayManager {
+    if let manager = displayManager { return manager }
+    let manager = MetaDisplayManager()
+    displayManager = manager
+    return manager
+  }
+
+  @MainActor
+  private func ensureMockManager() -> MetaMockDeviceManager {
+    if let manager = mockManager { return manager }
+    let manager = MetaMockDeviceManager()
+    mockManager = manager
+    return manager
+  }
+
+  /// Lazily builds the session manager on first use and wires its EventSinks
+  /// to the matching stream handlers.
+  @MainActor
+  private func ensureSessionManager() throws -> MetaSessionManager {
+    if let manager = sessionManager { return manager }
+    guard let registrar = pluginRegistrar else {
+      throw NSError(
+        domain: "meta_wearables_dat_flutter",
+        code: -10,
+        userInfo: [NSLocalizedDescriptionKey: "Plugin registrar is gone"]
+      )
+    }
+    let manager = MetaSessionManager(registry: registrar.textures())
+    streamSessionStateHandler.onSinkChange = { [weak manager] sink in
+      manager?.setSessionStateSink(sink)
+    }
+    streamSessionErrorHandler.onSinkChange = { [weak manager] sink in
+      manager?.setSessionErrorSink(sink)
+    }
+    deviceSessionStateHandler.onSinkChange = { [weak manager] sink in
+      manager?.setDeviceSessionStateSink(sink)
+    }
+    deviceSessionErrorHandler.onSinkChange = { [weak manager] sink in
+      manager?.setDeviceSessionErrorSink(sink)
+    }
+    videoSizeHandler.onSinkChange = { [weak manager] sink in
+      manager?.setVideoSizeSink(sink)
+    }
+    videoFramesHandler.onSinkChange = { [weak manager] sink in
+      manager?.setVideoFramesSink(sink)
+    }
+    sessionManager = manager
+    return manager
+  }
+
+  public func handle(
+    _ call: FlutterMethodCall,
+    result: @escaping FlutterResult
+  ) {
+    switch call.method {
+    case "getPlatformVersion":
+      result("iOS \(UIDevice.current.systemVersion)")
+
+    case "requestAndroidPermissions":
+      // Documented no-op on iOS: iOS uses Info.plist usage strings, not
+      // runtime permission grants. Lets host apps call the API
+      // unconditionally.
+      result(true)
+
+    case "dumpDiagnostics":
+      // FlutterPlugin's `handle` is invoked on the main thread by the
+      // engine; assume isolation so we can call the @MainActor
+      // dumpDiagnostics() synchronously without spawning a Task.
+      result(MainActor.assumeIsolated { Self.dumpDiagnostics() })
+
+    case "startRegistration":
+      // Log the same diagnostics the `dumpDiagnostics` method returns so the
+      // Xcode console always carries the preflight state when registration
+      // fails. Cheap (single bundle read + canOpenURL). Use print() (stderr)
+      // so the line surfaces in `flutter run`; NSLog goes to ASL and is
+      // silently dropped by the device-log adapter on physical devices.
+      let preflight = MainActor.assumeIsolated { Self.dumpDiagnostics() }
+      print("[meta_wearables_dat_flutter] startRegistration preflight:\n" +
+        Self.prettyPrint(preflight))
+
+      Task { @MainActor in
+        do {
+          print("[meta_wearables_dat_flutter] startRegistration -> calling Wearables.shared.startRegistration()")
+          try await Wearables.shared.startRegistration()
+          print("[meta_wearables_dat_flutter] startRegistration -> SDK returned without throwing")
+          result(nil)
+        } catch let error as RegistrationError {
+          let caseName = Self.registrationErrorCaseName(error)
+          print("[meta_wearables_dat_flutter] startRegistration FAILED: " +
+            "\(caseName) (raw=\(error.rawValue))")
+          result(FlutterError(
+            code: "REGISTRATION_ERROR",
+            message: caseName,
+            details: [
+              "rawValue": error.rawValue,
+              "case": caseName,
+              "description": String(describing: error),
+              "preflight": preflight,
+            ]
+          ))
+        } catch {
+          print("[meta_wearables_dat_flutter] startRegistration FAILED (non-RegistrationError): " +
+            String(describing: error))
+          result(FlutterError(
+            code: "REGISTRATION_ERROR",
+            message: error.localizedDescription,
+            details: [
+              "type": String(describing: type(of: error)),
+              "description": String(describing: error),
+              "preflight": preflight,
+            ]
+          ))
+        }
+      }
+
+    case "startUnregistration":
+      Task { @MainActor in
+        do {
+          try await Wearables.shared.startUnregistration()
+          result(nil)
+        } catch let error as UnregistrationError {
+          let caseName = Self.unregistrationErrorCaseName(error)
+          result(FlutterError(
+            code: "UNREGISTRATION_ERROR",
+            message: caseName,
+            details: [
+              "case": caseName,
+              "rawValue": error.rawValue,
+              "description": String(describing: error),
+            ]
+          ))
+        } catch {
+          result(FlutterError(
+            code: "UNREGISTRATION_ERROR",
+            message: error.localizedDescription,
+            details: nil
+          ))
+        }
+      }
+
+    case "handleUrl":
+      guard
+        let args = call.arguments as? [String: Any?],
+        let urlString = args["url"] as? String,
+        let url = URL(string: urlString)
+      else {
+        result(FlutterError(
+          code: "INVALID_ARGUMENT",
+          message: "handleUrl requires { url: String }",
+          details: nil
+        ))
+        return
+      }
+      print("[meta_wearables_dat_flutter] handleUrl <- received: \(urlString)")
+      Task { @MainActor in
+        do {
+          let consumed = try await Wearables.shared.handleUrl(url)
+          print("[meta_wearables_dat_flutter] handleUrl -> SDK consumed=\(consumed)")
+          result(consumed)
+        } catch let error as WearablesHandleURLError {
+          let caseName = Self.handleUrlErrorCaseName(error)
+          print("[meta_wearables_dat_flutter] handleUrl FAILED: \(caseName) (raw=\(error.rawValue))")
+          result(FlutterError(
+            code: "HANDLE_URL_ERROR",
+            message: caseName,
+            details: [
+              "case": caseName,
+              "rawValue": error.rawValue,
+              "description": String(describing: error),
+            ]
+          ))
+        } catch let error as RegistrationError {
+          let caseName = Self.registrationErrorCaseName(error)
+          print("[meta_wearables_dat_flutter] handleUrl FAILED: \(caseName) (raw=\(error.rawValue))")
+          result(FlutterError(
+            code: "REGISTRATION_ERROR",
+            message: caseName,
+            details: [
+              "case": caseName,
+              "rawValue": error.rawValue,
+              "description": String(describing: error),
+            ]
+          ))
+        } catch {
+          print("[meta_wearables_dat_flutter] handleUrl FAILED (non-typed): \(error)")
+          result(FlutterError(
+            code: "HANDLE_URL_ERROR",
+            message: error.localizedDescription,
+            details: nil
+          ))
+        }
+      }
+
+    case "getRegistrationState":
+      result(Wearables.shared.registrationState.rawValue)
+
+    case "requestCameraPermission":
+      Task { @MainActor in
+        do {
+          let status = try await Wearables.shared.requestPermission(.camera)
+          result(status == .granted)
+        } catch let error as PermissionError {
+          result(FlutterError(
+            code: "PERMISSION_ERROR",
+            message: String(describing: error),
+            details: nil
+          ))
+        } catch {
+          result(FlutterError(
+            code: "PERMISSION_ERROR",
+            message: error.localizedDescription,
+            details: nil
+          ))
+        }
+      }
+
+    case "getCameraPermissionStatus":
+      Task { @MainActor in
+        do {
+          let status = try await Wearables.shared.checkPermissionStatus(.camera)
+          result(status == .granted)
+        } catch let error as PermissionError {
+          result(FlutterError(
+            code: "PERMISSION_ERROR",
+            message: String(describing: error),
+            details: nil
+          ))
+        } catch {
+          result(FlutterError(
+            code: "PERMISSION_ERROR",
+            message: error.localizedDescription,
+            details: nil
+          ))
+        }
+      }
+
+    case "startStreamSession":
+      let args = call.arguments as? [String: Any?]
+      let deviceUUID = args?["deviceUuid"] as? String
+      let fps = (args?["fps"] as? Int) ?? 30
+      let qualityRaw = (args?["quality"] as? String) ?? "high"
+      let deviceKinds = (args?["deviceKinds"] as? [String]).map(Set.init)
+      let videoCodecRaw = (args?["videoCodec"] as? String) ?? "raw"
+      let videoCodec: VideoCodec =
+        (videoCodecRaw == "hvc1") ? .hvc1 : .raw
+      let quality: StreamingResolution = {
+        switch qualityRaw {
+        case "low": return .low
+        case "medium": return .medium
+        default: return .high
+        }
+      }()
+      Task { @MainActor in
+        let diag = Self.dumpDiagnostics()
+        print("[meta_wearables_dat_flutter] startStreamSession " +
+          "deviceUuid=\(deviceUUID ?? "<auto>") fps=\(fps) " +
+          "quality=\(qualityRaw) kinds=\(deviceKinds ?? []) " +
+          "codec=\(videoCodecRaw)")
+        print("[meta_wearables_dat_flutter] startStreamSession devices=" +
+          String(describing: diag["devices"] ?? [:]))
+        do {
+          let manager = try ensureSessionManager()
+          let id = try await manager.startSession(
+            deviceUUID: deviceUUID,
+            fps: fps,
+            quality: quality,
+            deviceKinds: deviceKinds,
+            videoCodec: videoCodec,
+          )
+          print("[meta_wearables_dat_flutter] startStreamSession -> textureId=\(id)")
+          result(id)
+        } catch let dse as DeviceSessionError {
+          let caseName = Self.deviceSessionErrorCaseName(dse)
+          print("[meta_wearables_dat_flutter] startStreamSession FAILED: " +
+            "DeviceSessionError.\(caseName)")
+          result(FlutterError(
+            code: "SESSION_ERROR",
+            message: caseName,
+            details: [
+              "case": caseName,
+              "description": String(describing: dse),
+              "errorDescription": dse.errorDescription ?? "",
+              "devices": diag["devices"] ?? [:],
+            ]
+          ))
+        } catch {
+          print("[meta_wearables_dat_flutter] startStreamSession FAILED: \(error)")
+          result(FlutterError(
+            code: "SESSION_ERROR",
+            message: error.localizedDescription,
+            details: [
+              "type": String(describing: type(of: error)),
+              "description": String(describing: error),
+              "devices": diag["devices"] ?? [:],
+            ]
+          ))
+        }
+      }
+
+    case "getDevices":
+      Task { @MainActor in
+        result(Self.encodeAllDevices())
+      }
+
+    case "openFirmwareUpdate":
+      Task { @MainActor in
+        do {
+          try await Wearables.shared.openFirmwareUpdate()
+          result(nil)
+        } catch {
+          result(FlutterError(
+            code: "FIRMWARE_UPDATE_ERROR",
+            message: error.localizedDescription,
+            details: nil
+          ))
+        }
+      }
+
+    case "openDATGlassesAppUpdate":
+      Task { @MainActor in
+        do {
+          try await Wearables.shared.openDATGlassesAppUpdate()
+          result(nil)
+        } catch {
+          result(FlutterError(
+            code: "DAT_GLASSES_APP_UPDATE_ERROR",
+            message: error.localizedDescription,
+            details: nil
+          ))
+        }
+      }
+
+    case "stopStreamSession":
+      Task { @MainActor in
+        await sessionManager?.stopSession()
+        result(nil)
+      }
+
+    case "pauseStreamSession":
+      Task { @MainActor in
+        await sessionManager?.pauseSession()
+        result(nil)
+      }
+
+    case "resumeStreamSession":
+      Task { @MainActor in
+        await sessionManager?.resumeSession()
+        result(nil)
+      }
+
+    case "startDisplaySession":
+      let args = call.arguments as? [String: Any?]
+      let deviceUUID = args?["deviceUuid"] as? String
+      Task { @MainActor in
+        do {
+          try await ensureDisplayManager().startDisplaySession(
+            deviceUUID: deviceUUID,
+          )
+          result(nil)
+        } catch let dse as DeviceSessionError {
+          result(FlutterError(
+            code: "DEVICE_SESSION_ERROR",
+            message: Self.deviceSessionErrorCaseName(dse),
+            details: ["description": String(describing: dse)]
+          ))
+        } catch {
+          result(FlutterError(
+            code: "DEVICE_SESSION_ERROR",
+            message: error.localizedDescription,
+            details: ["description": String(describing: error)]
+          ))
+        }
+      }
+
+    case "sendDisplayView":
+      let args = call.arguments as? [String: Any?]
+      let view = (args?["view"] as? [String: Any]) ?? [:]
+      Task { @MainActor in
+        do {
+          try await ensureDisplayManager().sendDisplayView(view)
+          result(nil)
+        } catch {
+          result(FlutterError(
+            code: "DEVICE_SESSION_ERROR",
+            message: error.localizedDescription,
+            details: ["description": String(describing: error)]
+          ))
+        }
+      }
+
+    case "stopDisplaySession":
+      Task { @MainActor in
+        await displayManager?.stopDisplaySession()
+        result(nil)
+      }
+
+    case "enableMockDevice":
+      let args = call.arguments as? [String: Any?]
+      let initiallyRegistered = (args?["initiallyRegistered"] as? Bool) ?? true
+      let initialPermissionsGranted =
+        (args?["initialPermissionsGranted"] as? Bool) ?? true
+      Task { @MainActor in
+        ensureMockManager().enable(
+          initiallyRegistered: initiallyRegistered,
+          initialPermissionsGranted: initialPermissionsGranted,
+        )
+        result(nil)
+      }
+
+    case "disableMockDevice":
+      Task { @MainActor in
+        ensureMockManager().disable()
+        result(nil)
+      }
+
+    case "isMockDeviceEnabled":
+      Task { @MainActor in
+        result(ensureMockManager().isEnabled())
+      }
+
+    case "pairMockRayBanMeta":
+      Task { @MainActor in
+        let uuid = ensureMockManager().pairRayBanMeta()
+        result(uuid)
+      }
+
+    case "pairedMockDevices":
+      Task { @MainActor in
+        result(ensureMockManager().pairedDevices())
+      }
+
+    case "unpairMockDevice":
+      let args = call.arguments as? [String: Any?]
+      let uuid = args?["uuid"] as? String ?? ""
+      Task { @MainActor in
+        do {
+          try ensureMockManager().unpair(uuid: uuid)
+          result(nil)
+        } catch {
+          result(FlutterError(
+            code: "MOCK_ERROR",
+            message: error.localizedDescription,
+            details: nil
+          ))
+        }
+      }
+
+    case "mockPowerOn", "mockPowerOff", "mockDon", "mockDoff", "mockFold", "mockUnfold":
+      let args = call.arguments as? [String: Any?]
+      let uuid = args?["uuid"] as? String ?? ""
+      let methodName = call.method
+      Task { @MainActor in
+        do {
+          let manager = ensureMockManager()
+          switch methodName {
+          case "mockPowerOn": try manager.powerOn(uuid: uuid)
+          case "mockPowerOff": try manager.powerOff(uuid: uuid)
+          case "mockDon": try manager.don(uuid: uuid)
+          case "mockDoff": try manager.doff(uuid: uuid)
+          case "mockFold": try manager.fold(uuid: uuid)
+          case "mockUnfold": try manager.unfold(uuid: uuid)
+          default: break
+          }
+          result(nil)
+        } catch {
+          result(FlutterError(
+            code: "MOCK_ERROR",
+            message: error.localizedDescription,
+            details: nil
+          ))
+        }
+      }
+
+    case "setMockCameraFacing":
+      let args = call.arguments as? [String: Any?]
+      let uuid = args?["uuid"] as? String ?? ""
+      let facingRaw = (args?["facing"] as? String) ?? "rear"
+      let facing: CameraFacing = (facingRaw == "front") ? .front : .back
+      Task { @MainActor in
+        do {
+          try await ensureMockManager().setCameraFacing(uuid: uuid, facing: facing)
+          result(nil)
+        } catch {
+          result(FlutterError(
+            code: "MOCK_ERROR",
+            message: error.localizedDescription,
+            details: nil
+          ))
+        }
+      }
+
+    case "setMockCameraFeed":
+      let args = call.arguments as? [String: Any?]
+      let uuid = args?["uuid"] as? String ?? ""
+      let path = args?["filePath"] as? String
+      Task { @MainActor in
+        do {
+          try await ensureMockManager().setCameraFeed(uuid: uuid, filePath: path)
+          result(nil)
+        } catch {
+          result(FlutterError(
+            code: "MOCK_ERROR",
+            message: error.localizedDescription,
+            details: nil
+          ))
+        }
+      }
+
+    case "setMockCapturedImage":
+      let args = call.arguments as? [String: Any?]
+      let uuid = args?["uuid"] as? String ?? ""
+      let path = args?["filePath"] as? String
+      Task { @MainActor in
+        do {
+          try await ensureMockManager().setCapturedImage(uuid: uuid, filePath: path)
+          result(nil)
+        } catch {
+          result(FlutterError(
+            code: "MOCK_ERROR",
+            message: error.localizedDescription,
+            details: nil
+          ))
+        }
+      }
+
+    case "setMockPermission", "setMockPermissionRequestResult":
+      let args = call.arguments as? [String: Any?]
+      let perm = args?["permission"] as? String ?? ""
+      let status = args?["status"] as? String ?? ""
+      let methodName = call.method
+      Task { @MainActor in
+        do {
+          let manager = ensureMockManager()
+          if methodName == "setMockPermission" {
+            try manager.setPermission(permission: perm, status: status)
+          } else {
+            try manager.setPermissionRequestResult(
+              permission: perm,
+              status: status,
+            )
+          }
+          result(nil)
+        } catch {
+          result(FlutterError(
+            code: "MOCK_ERROR",
+            message: error.localizedDescription,
+            details: nil
+          ))
+        }
+      }
+
+    case "enableBackgroundStreaming":
+      Task { @MainActor in
+        do {
+          try BackgroundStreamingController.shared.enable()
+          // Hand the software-only flag to the session manager, if any.
+          sessionManager?.setBackgroundStreamingEnabled(true)
+          result(nil)
+        } catch {
+          result(FlutterError(
+            code: "SESSION_ERROR",
+            message: "Failed to enable background streaming: " +
+              error.localizedDescription,
+            details: nil,
+          ))
+        }
+      }
+
+    case "disableBackgroundStreaming":
+      Task { @MainActor in
+        BackgroundStreamingController.shared.disable()
+        sessionManager?.setBackgroundStreamingEnabled(false)
+        result(nil)
+      }
+
+    case "capturePhoto":
+      let args = call.arguments as? [String: Any?]
+      let formatRaw = (args?["format"] as? String) ?? "jpeg"
+      let format: PhotoCaptureFormat = (formatRaw == "heic") ? .heic : .jpeg
+      Task { @MainActor in
+        do {
+          guard let manager = sessionManager else {
+            throw NSError(
+              domain: "meta_wearables_dat_flutter",
+              code: -30,
+              userInfo: [
+                NSLocalizedDescriptionKey:
+                  "No stream session - call startStreamSession first",
+              ],
+            )
+          }
+          let photo = try await manager.capturePhoto(format: format)
+          let outFormat = (photo.format == .heic) ? "heic" : "jpeg"
+          result([
+            "bytes": FlutterStandardTypedData(bytes: photo.data),
+            "format": outFormat,
+          ] as [String: Any])
+        } catch {
+          result(FlutterError(
+            code: "CAPTURE_ERROR",
+            message: error.localizedDescription,
+            details: nil
+          ))
+        }
+      }
+
+    case "captureLatestFrame":
+      let args = call.arguments as? [String: Any?]
+      let quality = (args?["quality"] as? Double).map { CGFloat($0) } ?? 0.8
+      Task { @MainActor in
+        guard let manager = sessionManager else {
+          print("[MetaGlassStreamDiag] captureLatestFrame: no session manager")
+          result(nil)
+          return
+        }
+        guard let data = manager.captureLatestFrameJpeg(quality: quality) else {
+          print("[MetaGlassStreamDiag] captureLatestFrame: no buffer yet")
+          result(nil)
+          return
+        }
+        print("[MetaGlassStreamDiag] captureLatestFrame: jpeg \(data.count) bytes")
+        result(FlutterStandardTypedData(bytes: data))
+      }
+
+    default:
+      result(FlutterMethodNotImplemented)
+    }
+  }
+
+  // MARK: - UIApplicationDelegate (deep-link forwarding)
+
+  /// Auto-forwards the Meta AI registration-callback URL to the SDK.
+  ///
+  /// When the host app calls `MetaWearablesDat.startRegistration()`, Meta
+  /// AI opens its permission UI and (on approval) redirects back to the
+  /// host app via its declared URL scheme (e.g.
+  /// `metawearablesdatexample://...`). Without this hook the host app
+  /// would have to wire its own deep-link plumbing to call
+  /// `MetaWearablesDat.handleUrl(url)`. Because the plugin already owns
+  /// `Wearables.shared`, we can do it transparently — the existing
+  /// `registrationStateStream` and `activeDeviceStream` observers pick
+  /// up the resulting state change and surface it to Dart without any
+  /// host-app code.
+  ///
+  /// Returns `true` when the SDK consumed the URL so the system stops
+  /// the AppDelegate chain; otherwise `false` so other plugins / the
+  /// host app's own AppDelegate get a shot.
+  public func application(
+    _ application: UIApplication,
+    open url: URL,
+    options: [UIApplication.OpenURLOptionsKey: Any] = [:]
+  ) -> Bool {
+    print("[meta_wearables_dat_flutter] application(open:) <- \(url)")
+    consumeUrl(url, source: "application(open:)")
+    return true
+  }
+
+  /// Notification-based URL bridge used by host apps with a
+  /// `UISceneDelegate`. They post `MetaWearablesDatHandleURL` from
+  /// `scene(_:openURLContexts:)` with a `url: URL` in `userInfo`.
+  @objc private func handleURLNotification(_ notification: Notification) {
+    guard let url = notification.userInfo?["url"] as? URL else {
+      print("[meta_wearables_dat_flutter] handleURLNotification missing url")
+      return
+    }
+    print("[meta_wearables_dat_flutter] handleURLNotification <- \(url)")
+    consumeUrl(url, source: "handleURLNotification")
+  }
+
+  /// Forwards the URL to the SDK in a `Task` so we can return synchronously
+  /// to the UIApplication / scene delegate callers.
+  private func consumeUrl(_ url: URL, source: String) {
+    Task { @MainActor in
+      do {
+        let consumed = try await Wearables.shared.handleUrl(url)
+        print("[meta_wearables_dat_flutter] \(source) consumed=\(consumed)")
+      } catch {
+        print("[meta_wearables_dat_flutter] \(source) handleUrl FAILED: \(error)")
+      }
+    }
+  }
+
+  // MARK: - Diagnostics
+
+  /// Returns a structured snapshot of everything the iOS DAT SDK validates
+  /// at `startRegistration()` time. Surfaced through the `dumpDiagnostics`
+  /// method channel call so host apps can show it in their UI when a
+  /// registration error happens, and also `print`-ed on every
+  /// `startRegistration` call. Pure read; no side effects.
+  ///
+  /// Marked `@MainActor` because `Wearables.shared.devices` /
+  /// `deviceForIdentifier` / `Device.linkState` are all main-actor
+  /// isolated by the SDK.
+  @MainActor
+  static func dumpDiagnostics() -> [String: Any] {
+    let info = Bundle.main.infoDictionary ?? [:]
+    let mwdat = info["MWDAT"] as? [String: Any] ?? [:]
+    let queries = info["LSApplicationQueriesSchemes"] as? [String] ?? []
+    let urlTypes = info["CFBundleURLTypes"] as? [[String: Any]] ?? []
+    let urlSchemes = urlTypes
+      .compactMap { $0["CFBundleURLSchemes"] as? [String] }
+      .flatMap { $0 }
+
+    let fbViewappURL = URL(string: "fb-viewapp://")!
+    let canOpenFbViewapp = UIApplication.shared.canOpenURL(fbViewappURL)
+    // `fb-viewapp` is the scheme the SDK preflights when opening Meta AI.
+    // If `canOpenURL` returns false, the most common cause is a missing
+    // `LSApplicationQueriesSchemes` entry, but it can also mean Meta AI
+    // is not installed.
+
+    let regState = Wearables.shared.registrationState
+    let regStateName: String
+    switch regState {
+    case .unavailable: regStateName = "unavailable"
+    case .available: regStateName = "available"
+    case .registering: regStateName = "registering"
+    case .registered: regStateName = "registered"
+    @unknown default: regStateName = "unknown(\(regState.rawValue))"
+    }
+
+    // Devices the SDK currently knows about and the state of their
+    // BLE link. `noEligibleDevice` from `startStreamSession` almost
+    // always means every device here has `linkState != connected`.
+    // Surface enough info that the app UI can tell the user what to
+    // do (turn glasses on, take them out of the case, don them).
+    let deviceIds = Wearables.shared.devices
+    var deviceDumps: [[String: Any]] = []
+    for id in deviceIds {
+      let device = Wearables.shared.deviceForIdentifier(id)
+      let linkStateName: String
+      switch device?.linkState {
+      case .disconnected?: linkStateName = "disconnected"
+      case .connecting?: linkStateName = "connecting"
+      case .connected?: linkStateName = "connected"
+      case nil: linkStateName = "unknown"
+      @unknown default: linkStateName = "unknown"
+      }
+      let kindName: String
+      switch device?.deviceType() {
+      case .rayBanMeta?, .rayBanMetaOptics?: kindName = "rayBanMeta"
+      case .metaRayBanDisplay?: kindName = "rayBanDisplay"
+      case .oakleyMetaHSTN?, .oakleyMetaVanguard?: kindName = "oakleyMeta"
+      case .unknown?, .none: kindName = "unknown"
+      @unknown default: kindName = "unknown"
+      }
+      deviceDumps.append([
+        "id": id,
+        "name": device?.nameOrId() ?? id,
+        "kind": kindName,
+        "linkState": linkStateName,
+      ])
+    }
+
+    return [
+      "platform": "iOS",
+      "iosVersion": UIDevice.current.systemVersion,
+      "bundleId": Bundle.main.bundleIdentifier ?? "<unknown>",
+      "bundleVersion": (info["CFBundleShortVersionString"] as? String) ?? "",
+      "wearablesConfigured": Self.didConfigure,
+      "registrationState": [
+        "raw": regState.rawValue,
+        "name": regStateName,
+      ],
+      "devices": [
+        "count": deviceDumps.count,
+        "list": deviceDumps,
+        "anyConnected": deviceDumps.contains { ($0["linkState"] as? String) == "connected" },
+      ] as [String: Any],
+      "infoPlist": [
+        "MWDAT": mwdat,
+        "LSApplicationQueriesSchemes": queries,
+        "CFBundleURLSchemes": urlSchemes,
+      ],
+      "preflight": [
+        "canOpenFbViewapp": canOpenFbViewapp,
+        "fbViewappInQueriesSchemes": queries.contains("fb-viewapp"),
+        "mwdatHasMetaAppID":
+          (mwdat["MetaAppID"] as? String).map { !$0.isEmpty } ?? false,
+        "mwdatHasAppLinkURLScheme":
+          (mwdat["AppLinkURLScheme"] as? String).map { !$0.isEmpty } ?? false,
+        "mwdatHasEmptyClientToken":
+          (mwdat["ClientToken"] as? String) == "",
+        "mwdatHasEmptyTeamID":
+          (mwdat["TeamID"] as? String) == "",
+      ],
+    ]
+  }
+
+  /// Pretty-prints a `[String: Any]` (one level deep is enough for our
+  /// needs) for `NSLog`. Avoids JSONSerialization because some values
+  /// (Bool, NSDictionary) round-trip oddly through it; we just want a
+  /// readable string in the Xcode console.
+  static func prettyPrint(_ dict: [String: Any]) -> String {
+    return dict
+      .sorted { $0.key < $1.key }
+      .map { (k, v) in "\n  \(k) = \(v)" }
+      .joined()
+  }
+
+  /// String name of a `RegistrationError` enum case. Mirrored on the Dart
+  /// side as `details["case"]`. We don't rely on `String(describing:)`
+  /// directly because it can include the enum's namespace prefix on some
+  /// builds.
+  /// String name of a `DeviceSessionError` case. Mirrored on the Dart
+  /// side as `details["case"]`. Keeps the unexpectedError payload in the
+  /// caseName so downstream UI can show the SDK's free-form reason
+  /// without parsing `errorDescription`.
+  static func deviceSessionErrorCaseName(_ error: DeviceSessionError) -> String {
+    // Derived from `String(describing:)` so this keeps compiling across SDK
+    // releases that add cases (DAT 0.7.0 added
+    // `datAppOnTheGlassesUpdateRequired`). The raw value is already a readable
+    // case label, e.g. `noEligibleDevice` or `unexpectedError(...)`.
+    return String(describing: error)
+  }
+
+  static func registrationErrorCaseName(_ error: RegistrationError) -> String {
+    switch error {
+    case .alreadyRegistered: return "alreadyRegistered"
+    case .configurationInvalid: return "configurationInvalid"
+    case .metaAINotInstalled: return "metaAINotInstalled"
+    case .networkUnavailable: return "networkUnavailable"
+    case .unknown: return "unknown"
+    @unknown default: return "unknown(\(error.rawValue))"
+    }
+  }
+
+  /// String name of an `UnregistrationError` case, used as the typed
+  /// sub-code on the Dart side.
+  static func unregistrationErrorCaseName(_ error: UnregistrationError) -> String {
+    switch error {
+    case .alreadyUnregistered: return "alreadyUnregistered"
+    case .configurationInvalid: return "configurationInvalid"
+    case .metaAINotInstalled: return "metaAINotInstalled"
+    case .unknown: return "unknown"
+    @unknown default: return "unknown(\(error.rawValue))"
+    }
+  }
+
+  /// String name of a `WearablesHandleURLError` case, used as the typed
+  /// sub-code on the Dart side.
+  static func handleUrlErrorCaseName(_ error: WearablesHandleURLError) -> String {
+    switch error {
+    case .registrationError: return "registrationError"
+    case .unregistrationError: return "unregistrationError"
+    @unknown default: return "unknown(\(error.rawValue))"
+    }
+  }
+
+  /// Returns a list of `DeviceInfo` maps for every paired device the SDK
+  /// currently knows about. Shape matches `DeviceInfo.fromMap` on Dart.
+  @MainActor
+  static func encodeAllDevices() -> [[String: Any]] {
+    return Wearables.shared.devices.map { id in
+      let device = Wearables.shared.deviceForIdentifier(id)
+      let name = device?.nameOrId() ?? id
+      return [
+        "uuid": id,
+        "name": name,
+        "kind": Self.kindName(for: device?.deviceType()),
+        "linkState": Self.linkStateName(for: device?.linkState),
+      ]
+    }
+  }
+
+  @MainActor
+  static func linkStateName(for linkState: LinkState?) -> String {
+    switch linkState {
+    case .connected?: return "connected"
+    case .connecting?: return "connecting"
+    case .disconnected?: return "disconnected"
+    case nil: return "unknown"
+    }
+  }
+
+  @MainActor
+  static func kindName(for deviceType: DeviceType?) -> String {
+    switch deviceType {
+    case .rayBanMeta?, .rayBanMetaOptics?: return "rayBanMeta"
+    case .metaRayBanDisplay?: return "rayBanDisplay"
+    case .oakleyMetaHSTN?, .oakleyMetaVanguard?: return "oakleyMeta"
+    case .unknown?, .none: return "unknown"
+    @unknown default: return "unknown"
+    }
+  }
+}
+
+// MARK: - Passthrough stream handler
+
+/// Tiny `FlutterStreamHandler` that simply hands its EventSink to a callback.
+/// Used by the streaming pipeline so the session manager - rather than this
+/// handler - owns when to emit values.
+///
+/// Re-fires `onSinkChange` whenever the callback is re-assigned so the
+/// session manager catches up on listeners that subscribed before it was
+/// lazily built.
+private final class PassthroughStreamHandler: NSObject, FlutterStreamHandler {
+  var onSinkChange: ((FlutterEventSink?) -> Void)? {
+    didSet { onSinkChange?(sink) }
+  }
+  private var sink: FlutterEventSink?
+
+  func onListen(
+    withArguments arguments: Any?,
+    eventSink events: @escaping FlutterEventSink
+  ) -> FlutterError? {
+    sink = events
+    onSinkChange?(events)
+    return nil
+  }
+
+  func onCancel(withArguments arguments: Any?) -> FlutterError? {
+    sink = nil
+    onSinkChange?(nil)
+    return nil
+  }
+}
+
+// MARK: - Stream handlers
+
+/// Forwards `Wearables.shared.registrationStateStream()` events to a Flutter
+/// EventSink as `Int` values matching `RegistrationState.fromInt` on the
+/// Dart side. Seeds the initial value so a brand-new listener does not need
+/// to wait for the next state change.
+private final class RegistrationStateStreamHandler: NSObject, FlutterStreamHandler {
+  private var task: Task<Void, Never>?
+
+  func onListen(
+    withArguments arguments: Any?,
+    eventSink events: @escaping FlutterEventSink
+  ) -> FlutterError? {
+    task?.cancel()
+    task = Task { @MainActor in
+      // Seed the current value first so UI built on `StreamBuilder` shows
+      // the correct state on initial subscribe.
+      events(Wearables.shared.registrationState.rawValue)
+      for await state in Wearables.shared.registrationStateStream() {
+        if Task.isCancelled { break }
+        events(state.rawValue)
+      }
+    }
+    return nil
+  }
+
+  func onCancel(withArguments arguments: Any?) -> FlutterError? {
+    task?.cancel()
+    task = nil
+    return nil
+  }
+}
+
+/// Forwards `AutoDeviceSelector` events to a Flutter EventSink as either
+/// a serialised `DeviceInfo` map or `nil` when no device is active.
+/// Long-lived: created once and held by the plugin instance.
+private final class ActiveDeviceStreamHandler: NSObject, FlutterStreamHandler {
+  private var task: Task<Void, Never>?
+  private var selector: AutoDeviceSelector?
+
+  func onListen(
+    withArguments arguments: Any?,
+    eventSink events: @escaping FlutterEventSink
+  ) -> FlutterError? {
+    task?.cancel()
+    let auto = AutoDeviceSelector(wearables: Wearables.shared)
+    selector = auto
+
+    task = Task { @MainActor in
+      // Seed the current value to avoid the "stuck waiting for first event"
+      // case when a device is already attached at subscribe time.
+      events(Self.encode(auto.activeDevice))
+      for await deviceId in auto.activeDeviceStream() {
+        if Task.isCancelled { break }
+        events(Self.encode(deviceId))
+      }
+    }
+    return nil
+  }
+
+  func onCancel(withArguments arguments: Any?) -> FlutterError? {
+    task?.cancel()
+    task = nil
+    selector = nil
+    return nil
+  }
+
+  /// Serialises a `DeviceIdentifier` (typealias for `String`) to the map
+  /// shape that `DeviceInfo.fromMap` expects on the Dart side. Returns
+  /// `NSNull` so the Flutter codec emits a Dart `null` when no device is
+  /// active.
+  @MainActor
+  private static func encode(_ id: DeviceIdentifier?) -> Any {
+    guard let id else { return NSNull() }
+    let device = Wearables.shared.deviceForIdentifier(id)
+    let name = device?.nameOrId() ?? id
+    return [
+      "uuid": id,
+      "name": name,
+      "kind": MetaWearablesDatPlugin.kindName(for: device?.deviceType()),
+      "linkState": MetaWearablesDatPlugin.linkStateName(for: device?.linkState),
+    ] as [String: Any]
+  }
+}
+
+/// Forwards `Wearables.shared.devicesStream()` events as the full list of
+/// paired devices (active or not) on the
+/// `meta_wearables_dat_flutter/devices` channel. Seeds the current value so
+/// fresh subscribers do not need to wait for the next change.
+private final class DevicesStreamHandler: NSObject, FlutterStreamHandler {
+  private var task: Task<Void, Never>?
+
+  func onListen(
+    withArguments arguments: Any?,
+    eventSink events: @escaping FlutterEventSink
+  ) -> FlutterError? {
+    task?.cancel()
+    task = Task { @MainActor in
+      events(MetaWearablesDatPlugin.encodeAllDevices())
+      for await _ in Wearables.shared.devicesStream() {
+        if Task.isCancelled { break }
+        events(MetaWearablesDatPlugin.encodeAllDevices())
+      }
+    }
+    return nil
+  }
+
+  func onCancel(withArguments arguments: Any?) -> FlutterError? {
+    task?.cancel()
+    task = nil
+    return nil
+  }
+}
+
+/// Forwards per-device `Compatibility` updates on the
+/// `meta_wearables_dat_flutter/compatibility` channel. Listens to
+/// `Wearables.shared.devicesStream()` for the paired-device set and attaches
+/// `Device.addCompatibilityListener` to each new device, dropping the
+/// listener when a device disappears. Seeds the current verdict for every
+/// already-paired device.
+private final class CompatibilityStreamHandler: NSObject, FlutterStreamHandler {
+  private var task: Task<Void, Never>?
+  private var tokens: [DeviceIdentifier: any AnyListenerToken] = [:]
+
+  func onListen(
+    withArguments arguments: Any?,
+    eventSink events: @escaping FlutterEventSink
+  ) -> FlutterError? {
+    task?.cancel()
+    task = Task { @MainActor [weak self] in
+      // Seed for every currently-known device.
+      self?.refreshListeners(events: events)
+      for await _ in Wearables.shared.devicesStream() {
+        if Task.isCancelled { break }
+        self?.refreshListeners(events: events)
+      }
+    }
+    return nil
+  }
+
+  func onCancel(withArguments arguments: Any?) -> FlutterError? {
+    task?.cancel()
+    task = nil
+    Task { @MainActor [tokens] in
+      for token in tokens.values { await token.cancel() }
+    }
+    tokens = [:]
+    return nil
+  }
+
+  @MainActor
+  private func refreshListeners(events: @escaping FlutterEventSink) {
+    let live = Set(Wearables.shared.devices)
+    // Drop listeners for devices that are no longer paired.
+    for id in tokens.keys where !live.contains(id) {
+      if let token = tokens.removeValue(forKey: id) {
+        Task { await token.cancel() }
+      }
+    }
+    // Attach a listener for each new device, seeding its current verdict.
+    for id in live where tokens[id] == nil {
+      guard let device = Wearables.shared.deviceForIdentifier(id) else { continue }
+      events(CompatibilityStreamHandler.encode(
+        deviceUuid: id,
+        compatibility: device.compatibility(),
+      ))
+      tokens[id] = device.addCompatibilityListener { [weak self] compat in
+        Task { @MainActor in
+          _ = self
+          events(CompatibilityStreamHandler.encode(
+            deviceUuid: id,
+            compatibility: compat,
+          ))
+        }
+      }
+    }
+  }
+
+  private static func encode(
+    deviceUuid: String,
+    compatibility: Compatibility,
+  ) -> [String: Any] {
+    let name: String
+    switch compatibility {
+    case .compatible: name = "compatible"
+    case .deviceUpdateRequired: name = "deviceUpdateRequired"
+    case .sdkUpdateRequired: name = "sdkUpdateRequired"
+    case .undefined: name = "unknown"
+    @unknown default: name = "unknown"
+    }
+    return [
+      "deviceUuid": deviceUuid,
+      "compatibility": name,
+    ]
+  }
+}

--- a/app/third_party/meta_wearables_dat_flutter/ios/meta_wearables_dat_flutter/Sources/meta_wearables_dat_flutter/VTDecompressionPipeline.swift
+++ b/app/third_party/meta_wearables_dat_flutter/ios/meta_wearables_dat_flutter/Sources/meta_wearables_dat_flutter/VTDecompressionPipeline.swift
@@ -1,0 +1,265 @@
+// HEVC (`hvc1`) → BGRA decoding pipeline.
+//
+// When `videoCodec: .hvc1` is selected on iOS, the MWDATCamera SDK emits
+// compressed `CMSampleBuffer`s carrying HEVC NAL units. This pipeline:
+//
+//   - Lazily builds a `VTDecompressionSession` keyed on the
+//     `CMVideoFormatDescription` of the first incoming sample buffer,
+//     output pixel format `kCVPixelFormatType_32BGRA`.
+//   - Decodes each sample synchronously so the resulting `CVPixelBuffer`
+//     can be handed to Flutter's texture path on the same frame.
+//   - Optionally surfaces the compressed NAL bytes (with VPS/SPS/PPS
+//     prepended on every keyframe, in Annex-B form) so host apps can
+//     forward them to an `mp4` muxer or to disk through
+//     `videoFramesStream`.
+//
+// Software-only fallback is requested at build time via
+// `kVTVideoDecoderSpecification_EnableHardwareAcceleratedVideoDecoder = false`
+// when the caller flags `softwareOnly` — that path is used in slice H
+// when background streaming is active (hardware decoders are killed by
+// the OS as soon as the app backgrounds).
+
+import Foundation
+import VideoToolbox
+import CoreMedia
+import CoreVideo
+
+@MainActor
+final class VTDecompressionPipeline {
+  /// Output pixel format. Matches the format the regular `.raw` capture
+  /// path produces so downstream texture code doesn't need to special-case.
+  private let outputPixelFormat: OSType = kCVPixelFormatType_32BGRA
+
+  /// When true, build the `VTDecompressionSession` with hardware
+  /// acceleration disabled. Costs a bit of CPU but is required while the
+  /// app is backgrounded.
+  var softwareOnly: Bool = false {
+    didSet { if oldValue != softwareOnly { invalidate() } }
+  }
+
+  /// Session is rebuilt whenever the format description changes (e.g.
+  /// resolution change mid-stream). We compare by identity since
+  /// CoreMedia recycles `CMFormatDescriptionRef`s for identical descs.
+  private var session: VTDecompressionSession?
+  private var formatDescription: CMFormatDescription?
+
+  init() {}
+
+  deinit {
+    if let session = session {
+      VTDecompressionSessionInvalidate(session)
+    }
+  }
+
+  /// Releases the underlying `VTDecompressionSession`. The next
+  /// `decode(...)` call will rebuild it.
+  func invalidate() {
+    if let session = session {
+      VTDecompressionSessionInvalidate(session)
+      self.session = nil
+    }
+    formatDescription = nil
+  }
+
+  /// Synchronously decodes one HEVC `CMSampleBuffer` to a BGRA
+  /// `CVPixelBuffer`. Returns `nil` when the session could not be
+  /// built or the decode itself failed; the caller should log and
+  /// continue rather than crash.
+  func decode(_ sampleBuffer: CMSampleBuffer) -> CVPixelBuffer? {
+    guard let desc = CMSampleBufferGetFormatDescription(sampleBuffer) else {
+      return nil
+    }
+    if !ensureSession(for: desc) {
+      return nil
+    }
+    guard let session = session else { return nil }
+
+    var decoded: CVPixelBuffer?
+    // Bit 0 of VTDecodeFrameFlags is "enable async decompression"; the
+    // Swift bridging name has changed across SDKs so we use the raw
+    // bitmask directly.
+    let flags = VTDecodeFrameFlags(rawValue: 1)
+    var infoFlags = VTDecodeInfoFlags()
+    let status = VTDecompressionSessionDecodeFrame(
+      session,
+      sampleBuffer: sampleBuffer,
+      flags: flags,
+      infoFlagsOut: &infoFlags,
+      outputHandler: { _, _, buffer, _, _ in
+        decoded = buffer
+      },
+    )
+    if status != noErr {
+      print("[meta_wearables_dat_flutter] VTDecompressionSessionDecodeFrame " +
+        "failed status=\(status)")
+      return nil
+    }
+    // Wait briefly for the async output handler. In practice the
+    // decoder runs on a dedicated thread and completes in a few hundred
+    // microseconds for HEVC at 720p.
+    VTDecompressionSessionWaitForAsynchronousFrames(session)
+    return decoded
+  }
+
+  /// (Re-)builds the `VTDecompressionSession` when the format
+  /// description changes. Returns `true` if a session is ready for
+  /// decoding.
+  private func ensureSession(for desc: CMFormatDescription) -> Bool {
+    if let existing = formatDescription,
+       CFEqual(existing, desc),
+       session != nil {
+      return true
+    }
+    if let stale = session {
+      VTDecompressionSessionInvalidate(stale)
+      session = nil
+    }
+    formatDescription = desc
+
+    let dims = CMVideoFormatDescriptionGetDimensions(desc)
+    var imageBufferAttrs: [String: Any] = [
+      kCVPixelBufferPixelFormatTypeKey as String: outputPixelFormat,
+      kCVPixelBufferWidthKey as String: Int(dims.width),
+      kCVPixelBufferHeightKey as String: Int(dims.height),
+      kCVPixelBufferIOSurfacePropertiesKey as String: [:] as [String: Any],
+    ]
+    if softwareOnly {
+      imageBufferAttrs[
+        kCVPixelBufferOpenGLCompatibilityKey as String] = false
+    }
+
+    var spec: [String: Any] = [:]
+    if softwareOnly {
+      spec[
+        kVTVideoDecoderSpecification_EnableHardwareAcceleratedVideoDecoder
+          as String] = false
+    } else {
+      spec[
+        kVTVideoDecoderSpecification_EnableHardwareAcceleratedVideoDecoder
+          as String] = true
+    }
+
+    var newSession: VTDecompressionSession?
+    let status = VTDecompressionSessionCreate(
+      allocator: kCFAllocatorDefault,
+      formatDescription: desc,
+      decoderSpecification: spec as CFDictionary,
+      imageBufferAttributes: imageBufferAttrs as CFDictionary,
+      outputCallback: nil,
+      decompressionSessionOut: &newSession,
+    )
+    if status != noErr {
+      print("[meta_wearables_dat_flutter] VTDecompressionSessionCreate " +
+        "failed status=\(status) software=\(softwareOnly)")
+      session = nil
+      return false
+    }
+    session = newSession
+    return true
+  }
+
+  /// Extracts the HEVC `VPS`, `SPS`, and `PPS` parameter sets from a
+  /// `CMVideoFormatDescription` and returns them as Annex-B encoded
+  /// NAL units (i.e. each prefixed with the `00 00 00 01` start code).
+  /// Returns `nil` when the format description does not carry HEVC
+  /// parameter sets (e.g. for `kCMVideoCodecType_H264`).
+  static func annexBParameterSets(
+    from desc: CMFormatDescription,
+  ) -> Data? {
+    var count = 0
+    let probe = CMVideoFormatDescriptionGetHEVCParameterSetAtIndex(
+      desc,
+      parameterSetIndex: 0,
+      parameterSetPointerOut: nil,
+      parameterSetSizeOut: nil,
+      parameterSetCountOut: &count,
+      nalUnitHeaderLengthOut: nil,
+    )
+    if probe != noErr || count == 0 { return nil }
+
+    var out = Data()
+    for i in 0..<count {
+      var pointer: UnsafePointer<UInt8>?
+      var size = 0
+      let status = CMVideoFormatDescriptionGetHEVCParameterSetAtIndex(
+        desc,
+        parameterSetIndex: i,
+        parameterSetPointerOut: &pointer,
+        parameterSetSizeOut: &size,
+        parameterSetCountOut: nil,
+        nalUnitHeaderLengthOut: nil,
+      )
+      if status == noErr, let pointer = pointer, size > 0 {
+        out.append(contentsOf: [0x00, 0x00, 0x00, 0x01])
+        out.append(pointer, count: size)
+      }
+    }
+    return out.isEmpty ? nil : out
+  }
+
+  /// Reads the (length-prefixed AVCC-style) NAL bytes from a sample
+  /// buffer's underlying `CMBlockBuffer` and returns them as an
+  /// Annex-B encoded `Data` (start codes between NAL units instead of
+  /// 4-byte length prefixes).
+  static func annexBNalBytes(
+    from sampleBuffer: CMSampleBuffer,
+  ) -> Data? {
+    guard let block = CMSampleBufferGetDataBuffer(sampleBuffer) else {
+      return nil
+    }
+    var totalLength = 0
+    var rawPointer: UnsafeMutablePointer<Int8>?
+    let status = CMBlockBufferGetDataPointer(
+      block,
+      atOffset: 0,
+      lengthAtOffsetOut: nil,
+      totalLengthOut: &totalLength,
+      dataPointerOut: &rawPointer,
+    )
+    if status != noErr || rawPointer == nil { return nil }
+
+    let bytes = UnsafeMutableRawPointer(rawPointer!).assumingMemoryBound(
+      to: UInt8.self,
+    )
+    var out = Data()
+    out.reserveCapacity(totalLength + 16)
+    var offset = 0
+    while offset + 4 <= totalLength {
+      // AVCC NAL units are prefixed with a 4-byte big-endian length.
+      let length = (UInt32(bytes[offset]) << 24) |
+        (UInt32(bytes[offset + 1]) << 16) |
+        (UInt32(bytes[offset + 2]) << 8) |
+        UInt32(bytes[offset + 3])
+      offset += 4
+      if length == 0 || offset + Int(length) > totalLength { break }
+      out.append(contentsOf: [0x00, 0x00, 0x00, 0x01])
+      out.append(bytes + offset, count: Int(length))
+      offset += Int(length)
+    }
+    return out.isEmpty ? nil : out
+  }
+
+  /// Reports whether a sample buffer's primary attachment marks it as a
+  /// keyframe (i.e. independent of any other frame).
+  static func isKeyframe(_ sampleBuffer: CMSampleBuffer) -> Bool {
+    guard
+      let attachments = CMSampleBufferGetSampleAttachmentsArray(
+        sampleBuffer,
+        createIfNecessary: false,
+      ) as? [[CFString: Any]],
+      let first = attachments.first
+    else {
+      // No attachments → assume keyframe (matches Apple's behaviour for
+      // single-NAL CMSampleBuffers).
+      return true
+    }
+    if let dependsOnOthers = first[kCMSampleAttachmentKey_DependsOnOthers]
+      as? Bool {
+      return !dependsOnOthers
+    }
+    if let notSync = first[kCMSampleAttachmentKey_NotSync] as? Bool {
+      return !notSync
+    }
+    return true
+  }
+}

--- a/app/third_party/meta_wearables_dat_flutter/lib/meta_wearables_dat_flutter.dart
+++ b/app/third_party/meta_wearables_dat_flutter/lib/meta_wearables_dat_flutter.dart
@@ -1,0 +1,539 @@
+/// `meta_wearables_dat_flutter` is an unofficial Flutter plugin bridging
+/// Meta's official iOS and Android Wearables Device Access Toolkit (DAT)
+/// SDKs. It is not affiliated with Meta Platforms, Inc.
+///
+/// Public entry point: [MetaWearablesDat]. All methods on the facade are
+/// static; lifecycle is managed by the plugin internally and shared across
+/// the entire Flutter engine.
+library;
+
+import 'package:meta_wearables_dat_flutter/src/meta_wearables_dat_platform_interface.dart';
+import 'package:meta_wearables_dat_flutter/src/models/background_notification.dart';
+import 'package:meta_wearables_dat_flutter/src/models/camera_facing.dart';
+import 'package:meta_wearables_dat_flutter/src/models/device_compatibility.dart';
+import 'package:meta_wearables_dat_flutter/src/models/device_info.dart';
+import 'package:meta_wearables_dat_flutter/src/models/device_session_state.dart';
+import 'package:meta_wearables_dat_flutter/src/models/display/display_components.dart';
+import 'package:meta_wearables_dat_flutter/src/models/display/display_state.dart';
+import 'package:meta_wearables_dat_flutter/src/models/frame_data.dart';
+import 'package:meta_wearables_dat_flutter/src/models/mock_permission.dart';
+import 'package:meta_wearables_dat_flutter/src/models/photo_result.dart';
+import 'package:meta_wearables_dat_flutter/src/models/registration_state.dart';
+import 'package:meta_wearables_dat_flutter/src/models/stream_quality.dart';
+import 'package:meta_wearables_dat_flutter/src/models/stream_session_state.dart';
+import 'package:meta_wearables_dat_flutter/src/models/video_frame.dart';
+import 'package:meta_wearables_dat_flutter/src/models/video_stream_size.dart';
+
+export 'package:meta_wearables_dat_flutter/src/models/background_notification.dart';
+export 'package:meta_wearables_dat_flutter/src/models/camera_facing.dart';
+export 'package:meta_wearables_dat_flutter/src/models/dat_error.dart';
+export 'package:meta_wearables_dat_flutter/src/models/device_compatibility.dart';
+export 'package:meta_wearables_dat_flutter/src/models/device_info.dart';
+export 'package:meta_wearables_dat_flutter/src/models/device_session_state.dart';
+export 'package:meta_wearables_dat_flutter/src/models/display/display_components.dart';
+export 'package:meta_wearables_dat_flutter/src/models/display/display_playback_event.dart';
+export 'package:meta_wearables_dat_flutter/src/models/display/display_state.dart';
+export 'package:meta_wearables_dat_flutter/src/models/frame_data.dart';
+export 'package:meta_wearables_dat_flutter/src/models/mock_permission.dart';
+export 'package:meta_wearables_dat_flutter/src/models/photo_result.dart';
+export 'package:meta_wearables_dat_flutter/src/models/registration_state.dart';
+// ignore: deprecated_member_use_from_same_package
+export 'package:meta_wearables_dat_flutter/src/models/session_state.dart';
+export 'package:meta_wearables_dat_flutter/src/models/stream_quality.dart';
+export 'package:meta_wearables_dat_flutter/src/models/stream_session_state.dart';
+export 'package:meta_wearables_dat_flutter/src/models/video_frame.dart';
+export 'package:meta_wearables_dat_flutter/src/models/video_stream_size.dart';
+
+/// Static facade for the entire plugin.
+///
+/// **Lifecycle order** (see `doc/getting_started.md`):
+///
+/// 1. [requestAndroidPermissions] (Android only; safe no-op on iOS).
+/// 2. [startRegistration] + [handleUrl] (host app forwards inbound deep
+///    links to [handleUrl]).
+/// 3. [requestCameraPermission] (Meta AI bottom sheet).
+/// 4. [startStreamSession] returns a Flutter texture id; render with
+///    `Texture(textureId: id)`.
+/// 5. [stopStreamSession] when done.
+abstract final class MetaWearablesDat {
+  // --- Diagnostics ----------------------------------------------------------
+
+  /// Returns a short string identifying the host platform.
+  static Future<String?> getPlatformVersion() {
+    return MetaWearablesDatPlatform.instance.getPlatformVersion();
+  }
+
+  /// Returns a structured snapshot of everything Meta's SDK validates at
+  /// `startRegistration` time on the host platform.
+  static Future<Map<String, Object?>> dumpDiagnostics() {
+    return MetaWearablesDatPlatform.instance.dumpDiagnostics();
+  }
+
+  // --- Permissions ----------------------------------------------------------
+
+  /// Requests the Android runtime permissions Meta's SDK requires
+  /// (`BLUETOOTH_CONNECT` and `INTERNET`).
+  ///
+  /// Returns `true` if every required permission ends up granted, `false`
+  /// otherwise. On iOS this method is a documented no-op and always
+  /// resolves to `true` immediately.
+  static Future<bool> requestAndroidPermissions() {
+    return MetaWearablesDatPlatform.instance.requestAndroidPermissions();
+  }
+
+  /// Requests the wearable-side camera permission by deep-linking into
+  /// the Meta AI app and showing its standard permission bottom sheet.
+  ///
+  /// Throws [PermissionError] when the request cannot be initiated.
+  static Future<bool> requestCameraPermission() {
+    return MetaWearablesDatPlatform.instance.requestCameraPermission();
+  }
+
+  /// Returns the current wearable-side camera permission status without
+  /// triggering the Meta AI bottom sheet.
+  static Future<bool> getCameraPermissionStatus() {
+    return MetaWearablesDatPlatform.instance.getCameraPermissionStatus();
+  }
+
+  // --- Registration ---------------------------------------------------------
+
+  /// Starts the device registration flow.
+  ///
+  /// Both [appId] and [urlScheme] are vestigial: every value the SDK
+  /// needs is read from the host app's `Info.plist` (`MWDAT` dict) on
+  /// iOS and `AndroidManifest.xml` `<meta-data>` on Android. Passing
+  /// them here has **no effect** on either platform and they will be
+  /// removed in v0.2.0.
+  ///
+  /// Throws [RegistrationError] if registration cannot be initiated.
+  static Future<void> startRegistration({
+    @Deprecated(
+      'Vestigial parameter. The iOS SDK reads MetaAppID from '
+      'Info.plist.MWDAT and the Android SDK reads APPLICATION_ID from '
+      '<meta-data>. Will be removed in v0.2.0.',
+    )
+    String? appId,
+    @Deprecated(
+      'Vestigial parameter. The iOS SDK reads AppLinkURLScheme from '
+      'Info.plist.MWDAT (and that value must end with "://", because '
+      'Meta AI literally concatenates it with the callback query '
+      'string). Android reads the scheme from the activity '
+      '<intent-filter>. Will be removed in v0.2.0.',
+    )
+    String? urlScheme,
+  }) {
+    return MetaWearablesDatPlatform.instance.startRegistration(
+      appId: appId,
+      urlScheme: urlScheme,
+    );
+  }
+
+  /// Forwards an inbound deep-link URL to the SDK.
+  ///
+  /// Throws [HandleUrlError] if the URL was not a registration callback.
+  static Future<bool> handleUrl(String url) {
+    return MetaWearablesDatPlatform.instance.handleUrl(url);
+  }
+
+  /// Starts an unregistration flow for the currently registered device.
+  ///
+  /// Throws [UnregistrationError] if it cannot be initiated.
+  static Future<void> startUnregistration() {
+    return MetaWearablesDatPlatform.instance.startUnregistration();
+  }
+
+  /// Returns the current [RegistrationState].
+  static Future<RegistrationState> getRegistrationState() {
+    return MetaWearablesDatPlatform.instance.getRegistrationState();
+  }
+
+  /// Broadcast stream of [RegistrationState] changes.
+  static Stream<RegistrationState> registrationStateStream() {
+    return MetaWearablesDatPlatform.instance.registrationStateStream();
+  }
+
+  /// Broadcast stream of the currently active device, or `null` when no
+  /// device is paired or the registered device disconnects.
+  static Stream<DeviceInfo?> activeDeviceStream() {
+    return MetaWearablesDatPlatform.instance.activeDeviceStream();
+  }
+
+  /// Broadcast stream of every paired device (active or not). Mirrors
+  /// `Wearables.shared.devicesStream()` on iOS and the equivalent
+  /// `Wearables.devices` flow on Android.
+  static Stream<List<DeviceInfo>> devicesStream() {
+    return MetaWearablesDatPlatform.instance.devicesStream();
+  }
+
+  /// One-shot snapshot of every paired device known to the SDK.
+  static Future<List<DeviceInfo>> getDevices() {
+    return MetaWearablesDatPlatform.instance.getDevices();
+  }
+
+  /// Broadcast stream of per-device compatibility verdicts (e.g. "your
+  /// glasses firmware needs an update"). Mirrors iOS
+  /// `Device.addCompatibilityListener` / Android
+  /// `Wearables.devicesMetadata[id].compatibility`.
+  static Stream<DeviceCompatibilityEvent> compatibilityStream() {
+    return MetaWearablesDatPlatform.instance.compatibilityStream();
+  }
+
+  /// Opens the Meta AI firmware update flow for glasses that report
+  /// [DeviceCompatibility.deviceUpdateRequired].
+  static Future<void> openFirmwareUpdate() {
+    return MetaWearablesDatPlatform.instance.openFirmwareUpdate();
+  }
+
+  /// Opens the Meta AI DAT glasses-app update flow for glasses that report
+  /// [DeviceCompatibility.sdkUpdateRequired].
+  static Future<void> openDATGlassesAppUpdate() {
+    return MetaWearablesDatPlatform.instance.openDATGlassesAppUpdate();
+  }
+
+  // --- Streaming ------------------------------------------------------------
+
+  /// Starts a video stream from the active wearable and returns a Flutter
+  /// `textureId` you can render with `Texture(textureId: id)`.
+  ///
+  /// When [deviceKinds] is set, only devices whose `kind` is in the set
+  /// are considered by the underlying `AutoDeviceSelector` filter (or
+  /// equivalent enumeration on iOS). Pass `null` to accept any kind.
+  ///
+  /// [videoCodec] picks the codec used for [videoFramesStream] payloads
+  /// (see [VideoCodec]). The texture preview path always sees raw frames
+  /// regardless of this setting on iOS; on Android the texture preview is
+  /// disabled when [VideoCodec.hvc1] is selected (see `doc/streaming.md`).
+  ///
+  /// Throws [SessionError] (or [DeviceSessionError]) if the session
+  /// cannot be started.
+  static Future<int> startStreamSession({
+    String? deviceUUID,
+    int fps = 30,
+    StreamQuality quality = StreamQuality.medium,
+    Set<DeviceKind>? deviceKinds,
+    VideoCodec videoCodec = VideoCodec.raw,
+  }) {
+    return MetaWearablesDatPlatform.instance.startStreamSession(
+      deviceUUID: deviceUUID,
+      fps: fps,
+      quality: quality,
+      deviceKinds: deviceKinds,
+      videoCodec: videoCodec,
+    );
+  }
+
+  /// Stops the active stream session and unregisters the texture.
+  static Future<void> stopStreamSession({String? deviceUUID}) {
+    return MetaWearablesDatPlatform.instance.stopStreamSession(
+      deviceUUID: deviceUUID,
+    );
+  }
+
+  /// Pauses the active stream session.
+  static Future<void> pauseStreamSession({String? deviceUUID}) {
+    return MetaWearablesDatPlatform.instance.pauseStreamSession(
+      deviceUUID: deviceUUID,
+    );
+  }
+
+  /// Resumes a paused stream session.
+  static Future<void> resumeStreamSession({String? deviceUUID}) {
+    return MetaWearablesDatPlatform.instance.resumeStreamSession(
+      deviceUUID: deviceUUID,
+    );
+  }
+
+  /// Broadcast stream of [StreamSessionState] changes.
+  static Stream<StreamSessionState> streamSessionStateStream() {
+    return MetaWearablesDatPlatform.instance.streamSessionStateStream();
+  }
+
+  /// Broadcast stream of stream-level session errors. Events are typed
+  /// [SessionError] subclasses with `is*` getters such as
+  /// `isThermalCritical` and `isHingesClosed`.
+  static Stream<Object> streamSessionErrorStream() {
+    return MetaWearablesDatPlatform.instance.streamSessionErrorStream();
+  }
+
+  /// Broadcast stream of [DeviceSessionState] changes — the underlying
+  /// long-lived connection to a paired wearable.
+  static Stream<DeviceSessionState> deviceSessionStateStream() {
+    return MetaWearablesDatPlatform.instance.deviceSessionStateStream();
+  }
+
+  /// Broadcast stream of [DeviceSessionError] events from the underlying
+  /// device session (separate from the stream-level errors emitted by
+  /// [streamSessionErrorStream]).
+  static Stream<Object> deviceSessionErrorStream() {
+    return MetaWearablesDatPlatform.instance.deviceSessionErrorStream();
+  }
+
+  /// **Deprecated** — alias for [streamSessionStateStream]. Will be removed
+  /// in v0.2.0.
+  @Deprecated('Use streamSessionStateStream() instead.')
+  static Stream<StreamSessionState> sessionStateStream() {
+    return MetaWearablesDatPlatform.instance.streamSessionStateStream();
+  }
+
+  /// **Deprecated** — alias for [streamSessionErrorStream]. Will be removed
+  /// in v0.2.0.
+  @Deprecated('Use streamSessionErrorStream() instead.')
+  static Stream<Object> sessionErrorStream() {
+    return MetaWearablesDatPlatform.instance.streamSessionErrorStream();
+  }
+
+  /// Broadcast stream of [VideoStreamSize] updates emitted once per
+  /// resolution change. Use the latest value to drive an `AspectRatio`
+  /// around the texture widget.
+  static Stream<VideoStreamSize> videoStreamSizeStream() {
+    return MetaWearablesDatPlatform.instance.videoStreamSizeStream();
+  }
+
+  /// Broadcast stream of every video frame produced by the active stream
+  /// session, suitable for recording / OCR / ML pipelines.
+  ///
+  /// Payloads are large (≈3.7 MB per 720p raw BGRA frame); the native side
+  /// only does the per-frame copy when at least one Dart subscriber is
+  /// attached. See `doc/frame_processing.md` for budget guidance.
+  static Stream<VideoFrame> videoFramesStream() {
+    return MetaWearablesDatPlatform.instance.videoFramesStream();
+  }
+
+  /// Keeps frames flowing through device sleep / screen lock / app
+  /// backgrounding.
+  ///
+  /// On iOS this activates `AVAudioSession` with `.playAndRecord` /
+  /// `.videoRecording`, registers interruption + route-change observers
+  /// (so AVAudioSession is re-activated on recovery), and flips the
+  /// VTDecompression pipeline into software-only mode so frames keep
+  /// decoding while the app is backgrounded. The host app must declare
+  /// the matching `UIBackgroundModes` keys (`audio`, `bluetooth-central`,
+  /// `bluetooth-peripheral`, `external-accessory`) in its `Info.plist`.
+  ///
+  /// On Android this starts a foreground service of type
+  /// `FOREGROUND_SERVICE_TYPE_CONNECTED_DEVICE` showing
+  /// [androidNotification]'s details, acquires a partial wake lock, and
+  /// runtime-requests `POST_NOTIFICATIONS` on API 33+. Throws
+  /// [DatError] when [androidNotification] is null on Android.
+  static Future<void> enableBackgroundStreaming({
+    BackgroundNotification? androidNotification,
+  }) {
+    return MetaWearablesDatPlatform.instance.enableBackgroundStreaming(
+      androidNotification: androidNotification,
+    );
+  }
+
+  /// Reverses [enableBackgroundStreaming]: deactivates the iOS
+  /// `AVAudioSession`, stops the Android foreground service, and
+  /// releases the wake lock.
+  static Future<void> disableBackgroundStreaming() {
+    return MetaWearablesDatPlatform.instance.disableBackgroundStreaming();
+  }
+
+  // --- Capture --------------------------------------------------------------
+
+  /// Captures a single frame from a live texture in pure Dart, without
+  /// touching the platform channel for the pixel data.
+  static Future<FrameData?> captureStreamFrame(
+    int textureId, {
+    FrameFormat format = FrameFormat.rawRgba,
+  }) {
+    return MetaWearablesDatPlatform.instance.captureStreamFrame(
+      textureId,
+      format: format,
+    );
+  }
+
+  /// Captures the most recent streamed frame as JPEG bytes, encoded natively
+  /// on the CPU from the SDK's latest decoded pixel buffer.
+  ///
+  /// Unlike [captureStreamFrame] (which rasterizes the Flutter texture via
+  /// `ui.Scene.toImage` and therefore only works while the app is foregrounded
+  /// and the GPU raster pipeline is live), this keeps producing viewable frames
+  /// while the app is backgrounded — the SDK's native frame callback keeps the
+  /// source buffer fresh and the encode runs on the CPU. Prefer this for
+  /// background/continuous capture. [quality] is the JPEG quality (0.0–1.0).
+  static Future<FrameData?> captureLatestFrame({double quality = 0.8}) {
+    return MetaWearablesDatPlatform.instance.captureLatestFrame(
+      quality: quality,
+    );
+  }
+
+  /// Captures a high-resolution still mid-stream.
+  ///
+  /// Throws [CaptureError] if the device is disconnected, no session is
+  /// active, a capture is already in progress, or the SDK reports a
+  /// hardware-side capture failure.
+  static Future<PhotoResult> capturePhoto({
+    String? deviceUUID,
+    PhotoFormat format = PhotoFormat.jpeg,
+  }) {
+    return MetaWearablesDatPlatform.instance.capturePhoto(
+      deviceUUID: deviceUUID,
+      format: format,
+    );
+  }
+
+  // --- Display --------------------------------------------------------------
+
+  /// Attaches the display capability to a Ray-Ban Display device and starts
+  /// it, so [sendDisplayView] can render content on the glasses.
+  ///
+  /// Pass [deviceUUID] to target a specific paired device; otherwise the SDK
+  /// auto-selects the best display-capable device. Observe progress via
+  /// [displayStateStream] (the display is ready once it reaches
+  /// [DisplayState.started]).
+  ///
+  /// Throws [DeviceSessionError] if the session cannot be started (e.g.
+  /// `isDatAppUpdateRequired` when the on-glasses DAT app is too old).
+  static Future<void> startDisplaySession({String? deviceUUID}) {
+    return MetaWearablesDatPlatform.instance.startDisplaySession(
+      deviceUUID: deviceUUID,
+    );
+  }
+
+  /// Renders [view] on the glasses display, replacing whatever was shown
+  /// before.
+  ///
+  /// Build [view] declaratively with [FlexBox], [DisplayText], [DisplayImage],
+  /// [DisplayButton], [DisplayIcon] and [VideoPlayer]. Tap / click / playback
+  /// handlers attached to the tree are invoked when the user interacts with
+  /// the rendered content.
+  ///
+  /// If no display session is active yet this will attach one on demand on
+  /// platforms that support it; otherwise call [startDisplaySession] first.
+  static Future<void> sendDisplayView(DisplayView view) {
+    return MetaWearablesDatPlatform.instance.sendDisplayView(view);
+  }
+
+  /// Detaches the display capability and tears down its device session.
+  static Future<void> stopDisplaySession() {
+    return MetaWearablesDatPlatform.instance.stopDisplaySession();
+  }
+
+  /// Broadcast stream of [DisplayState] changes for the display capability.
+  static Stream<DisplayState> displayStateStream() {
+    return MetaWearablesDatPlatform.instance.displayStateStream();
+  }
+
+  // --- Mock Device Kit ------------------------------------------------------
+
+  /// Enables Meta's Mock Device Kit so [pairMockRayBanMeta] and friends can
+  /// be used to develop without real glasses.
+  ///
+  /// [initiallyRegistered] / [initialPermissionsGranted] map to
+  /// `MockDeviceKit.shared.enable(config:)` on iOS (and the equivalent
+  /// Android API).
+  static Future<void> enableMockDevice({
+    bool initiallyRegistered = true,
+    bool initialPermissionsGranted = true,
+  }) {
+    return MetaWearablesDatPlatform.instance.enableMockDevice(
+      initiallyRegistered: initiallyRegistered,
+      initialPermissionsGranted: initialPermissionsGranted,
+    );
+  }
+
+  /// Disables the Mock Device Kit and unpairs all simulated devices.
+  static Future<void> disableMockDevice() {
+    return MetaWearablesDatPlatform.instance.disableMockDevice();
+  }
+
+  /// Returns `true` if the Mock Device Kit is currently enabled.
+  static Future<bool> isMockDeviceEnabled() {
+    return MetaWearablesDatPlatform.instance.isMockDeviceEnabled();
+  }
+
+  /// Pairs a simulated Ray-Ban Meta device. Returns the UUID assigned to it.
+  static Future<String> pairMockRayBanMeta() {
+    return MetaWearablesDatPlatform.instance.pairMockRayBanMeta();
+  }
+
+  /// Returns the list of currently-paired mock devices.
+  static Future<List<DeviceInfo>> pairedMockDevices() {
+    return MetaWearablesDatPlatform.instance.pairedMockDevices();
+  }
+
+  /// Unpairs a previously-paired mock device.
+  static Future<void> unpairMockDevice(String uuid) {
+    return MetaWearablesDatPlatform.instance.unpairMockDevice(uuid);
+  }
+
+  /// Powers a mock device on.
+  static Future<void> mockPowerOn(String uuid) {
+    return MetaWearablesDatPlatform.instance.mockPowerOn(uuid);
+  }
+
+  /// Powers a mock device off.
+  static Future<void> mockPowerOff(String uuid) {
+    return MetaWearablesDatPlatform.instance.mockPowerOff(uuid);
+  }
+
+  /// Marks the mock device as worn ("donned").
+  static Future<void> mockDon(String uuid) {
+    return MetaWearablesDatPlatform.instance.mockDon(uuid);
+  }
+
+  /// Marks the mock device as removed ("doffed").
+  static Future<void> mockDoff(String uuid) {
+    return MetaWearablesDatPlatform.instance.mockDoff(uuid);
+  }
+
+  /// Folds the mock device (sleep-like state for displayless glasses).
+  static Future<void> mockFold(String uuid) {
+    return MetaWearablesDatPlatform.instance.mockFold(uuid);
+  }
+
+  /// Unfolds the mock device.
+  static Future<void> mockUnfold(String uuid) {
+    return MetaWearablesDatPlatform.instance.mockUnfold(uuid);
+  }
+
+  /// Picks which of the host phone's cameras feeds the simulated device.
+  static Future<void> setMockCameraFacing(String uuid, CameraFacing facing) {
+    return MetaWearablesDatPlatform.instance.setMockCameraFacing(uuid, facing);
+  }
+
+  /// Sets a video file (or content URI on Android) as the mock device's
+  /// camera feed. Pass `null` for [filePath] to clear it.
+  static Future<void> setMockCameraFeed(String uuid, String? filePath) {
+    return MetaWearablesDatPlatform.instance.setMockCameraFeed(uuid, filePath);
+  }
+
+  /// Sets a still image file as what the mock device returns from
+  /// [capturePhoto] requests. Pass `null` for [filePath] to clear it.
+  static Future<void> setMockCapturedImage(String uuid, String? filePath) {
+    return MetaWearablesDatPlatform.instance.setMockCapturedImage(
+      uuid,
+      filePath,
+    );
+  }
+
+  /// Sets the current permission status reported by the Mock Device Kit
+  /// for [permission].
+  static Future<void> setMockPermission(
+    MockPermission permission,
+    MockPermissionStatus status,
+  ) {
+    return MetaWearablesDatPlatform.instance.setMockPermission(
+      permission.value,
+      status.value,
+    );
+  }
+
+  /// Sets what the **next** `requestPermission` call resolves to.
+  static Future<void> setMockPermissionRequestResult(
+    MockPermission permission,
+    MockPermissionStatus status,
+  ) {
+    return MetaWearablesDatPlatform.instance.setMockPermissionRequestResult(
+      permission.value,
+      status.value,
+    );
+  }
+
+  /// Broadcast stream of currently paired mock devices.
+  static Stream<List<DeviceInfo>> mockDevicesStream() {
+    return MetaWearablesDatPlatform.instance.mockDevicesStream();
+  }
+}

--- a/app/third_party/meta_wearables_dat_flutter/lib/src/meta_wearables_dat_method_channel.dart
+++ b/app/third_party/meta_wearables_dat_flutter/lib/src/meta_wearables_dat_method_channel.dart
@@ -1,0 +1,885 @@
+import 'dart:async';
+import 'dart:ui' as ui;
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:meta_wearables_dat_flutter/src/meta_wearables_dat_platform_interface.dart';
+import 'package:meta_wearables_dat_flutter/src/models/background_notification.dart';
+import 'package:meta_wearables_dat_flutter/src/models/camera_facing.dart';
+import 'package:meta_wearables_dat_flutter/src/models/dat_error.dart';
+import 'package:meta_wearables_dat_flutter/src/models/device_compatibility.dart';
+import 'package:meta_wearables_dat_flutter/src/models/device_info.dart';
+import 'package:meta_wearables_dat_flutter/src/models/device_session_state.dart';
+import 'package:meta_wearables_dat_flutter/src/models/display/display_components.dart';
+import 'package:meta_wearables_dat_flutter/src/models/display/display_state.dart';
+import 'package:meta_wearables_dat_flutter/src/models/frame_data.dart';
+import 'package:meta_wearables_dat_flutter/src/models/photo_result.dart';
+import 'package:meta_wearables_dat_flutter/src/models/registration_state.dart';
+import 'package:meta_wearables_dat_flutter/src/models/stream_quality.dart';
+import 'package:meta_wearables_dat_flutter/src/models/stream_session_state.dart';
+import 'package:meta_wearables_dat_flutter/src/models/video_frame.dart';
+import 'package:meta_wearables_dat_flutter/src/models/video_stream_size.dart';
+
+/// Default [MetaWearablesDatPlatform] implementation that forwards every call
+/// across a single `MethodChannel` plus the topic-specific `EventChannel`s
+/// described in `AGENTS.md`.
+class MethodChannelMetaWearablesDat extends MetaWearablesDatPlatform {
+  /// Method channel used for request/response calls.
+  @visibleForTesting
+  final MethodChannel methodChannel = const MethodChannel(
+    'meta_wearables_dat_flutter',
+  );
+
+  /// Event channel for `registrationStateStream`.
+  @visibleForTesting
+  final EventChannel registrationStateChannel = const EventChannel(
+    'meta_wearables_dat_flutter/registration_state',
+  );
+
+  /// Event channel for `activeDeviceStream`.
+  @visibleForTesting
+  final EventChannel activeDeviceChannel = const EventChannel(
+    'meta_wearables_dat_flutter/active_device',
+  );
+
+  /// Event channel for `devicesStream`.
+  @visibleForTesting
+  final EventChannel devicesChannel = const EventChannel(
+    'meta_wearables_dat_flutter/devices',
+  );
+
+  /// Event channel for `compatibilityStream`.
+  @visibleForTesting
+  final EventChannel compatibilityChannel = const EventChannel(
+    'meta_wearables_dat_flutter/compatibility',
+  );
+
+  /// Event channel for `streamSessionStateStream`.
+  @visibleForTesting
+  final EventChannel streamSessionStateChannel = const EventChannel(
+    'meta_wearables_dat_flutter/stream_session_state',
+  );
+
+  /// Event channel for `streamSessionErrorStream`.
+  @visibleForTesting
+  final EventChannel streamSessionErrorsChannel = const EventChannel(
+    'meta_wearables_dat_flutter/stream_session_errors',
+  );
+
+  /// Event channel for `deviceSessionStateStream`.
+  @visibleForTesting
+  final EventChannel deviceSessionStateChannel = const EventChannel(
+    'meta_wearables_dat_flutter/device_session_state',
+  );
+
+  /// Event channel for `deviceSessionErrorStream`.
+  @visibleForTesting
+  final EventChannel deviceSessionErrorsChannel = const EventChannel(
+    'meta_wearables_dat_flutter/device_session_errors',
+  );
+
+  /// Event channel for `videoStreamSizeStream`.
+  @visibleForTesting
+  final EventChannel videoStreamSizeChannel = const EventChannel(
+    'meta_wearables_dat_flutter/video_stream_size',
+  );
+
+  /// Event channel for `videoFramesStream`.
+  @visibleForTesting
+  final EventChannel videoFramesChannel = const EventChannel(
+    'meta_wearables_dat_flutter/video_frames',
+  );
+
+  /// Event channel for `mockDevicesStream`.
+  @visibleForTesting
+  final EventChannel mockDevicesChannel = const EventChannel(
+    'meta_wearables_dat_flutter/mock_devices',
+  );
+
+  /// Event channel for `displayStateStream`.
+  @visibleForTesting
+  final EventChannel displayStateChannel = const EventChannel(
+    'meta_wearables_dat_flutter/display_state',
+  );
+
+  /// Event channel carrying display tap / click / playback callbacks back to
+  /// Dart. Each event is `{callbackId, type, [event]}`.
+  @visibleForTesting
+  final EventChannel displayEventsChannel = const EventChannel(
+    'meta_wearables_dat_flutter/display_events',
+  );
+
+  // Cached broadcast streams so multiple Dart-side listeners share a single
+  // platform-channel subscription.
+  Stream<RegistrationState>? _registrationStateStream;
+  Stream<DeviceInfo?>? _activeDeviceStream;
+  Stream<List<DeviceInfo>>? _devicesStream;
+  Stream<DeviceCompatibilityEvent>? _compatibilityStream;
+  Stream<StreamSessionState>? _streamSessionStateStream;
+  Stream<Object>? _streamSessionErrorStream;
+  Stream<DeviceSessionState>? _deviceSessionStateStream;
+  Stream<Object>? _deviceSessionErrorStream;
+  Stream<VideoStreamSize>? _videoStreamSizeStream;
+  Stream<VideoFrame>? _videoFramesStream;
+  Stream<List<DeviceInfo>>? _mockDevicesStream;
+  Stream<DisplayState>? _displayStateStream;
+
+  /// Callback table for the view currently shown on the glasses display.
+  /// Rebuilt on every [sendDisplayView]; dispatched to from the
+  /// `display_events` channel.
+  DisplayCallbackTable? _displayCallbacks;
+
+  /// Long-lived subscription to the `display_events` channel. Lives for the
+  /// lifetime of the plugin singleton (like the cached broadcast streams
+  /// above), so it is intentionally never cancelled.
+  // ignore: cancel_subscriptions
+  StreamSubscription<dynamic>? _displayEventsSubscription;
+
+  /// Latest [VideoStreamSize] observed on the `video_stream_size` channel.
+  VideoStreamSize? _lastVideoStreamSize;
+
+  // --- Diagnostics ----------------------------------------------------------
+
+  @override
+  Future<String?> getPlatformVersion() {
+    return methodChannel.invokeMethod<String>('getPlatformVersion');
+  }
+
+  @override
+  Future<Map<String, Object?>> dumpDiagnostics() async {
+    final raw = await methodChannel.invokeMethod<Map<Object?, Object?>>('dumpDiagnostics');
+    return _deepStringKeyed(raw) ?? <String, Object?>{};
+  }
+
+  Map<String, Object?>? _deepStringKeyed(Object? value) {
+    if (value is Map) {
+      final result = <String, Object?>{};
+      value.forEach((k, v) {
+        result['$k'] = _deepConvert(v);
+      });
+      return result;
+    }
+    return null;
+  }
+
+  Object? _deepConvert(Object? value) {
+    if (value is Map) {
+      return _deepStringKeyed(value);
+    }
+    if (value is List) {
+      return value.map(_deepConvert).toList(growable: false);
+    }
+    return value;
+  }
+
+  // --- Permissions ----------------------------------------------------------
+
+  @override
+  Future<bool> requestAndroidPermissions() async {
+    final granted = await methodChannel.invokeMethod<bool>(
+      'requestAndroidPermissions',
+    );
+    return granted ?? false;
+  }
+
+  @override
+  Future<bool> requestCameraPermission() async {
+    try {
+      final granted = await methodChannel.invokeMethod<bool>(
+        'requestCameraPermission',
+      );
+      return granted ?? false;
+    } on PlatformException catch (e) {
+      throw _mapPlatformException(e);
+    }
+  }
+
+  @override
+  Future<bool> getCameraPermissionStatus() async {
+    try {
+      final granted = await methodChannel.invokeMethod<bool>(
+        'getCameraPermissionStatus',
+      );
+      return granted ?? false;
+    } on PlatformException catch (e) {
+      throw _mapPlatformException(e);
+    }
+  }
+
+  // --- Registration ---------------------------------------------------------
+
+  @override
+  Future<void> startRegistration({String? appId, String? urlScheme}) async {
+    try {
+      await methodChannel.invokeMethod<void>(
+        'startRegistration',
+        <String, Object?>{
+          if (appId != null) 'appId': appId,
+          if (urlScheme != null) 'urlScheme': urlScheme,
+        },
+      );
+    } on PlatformException catch (e) {
+      throw _mapPlatformException(e);
+    }
+  }
+
+  @override
+  Future<bool> handleUrl(String url) async {
+    try {
+      final consumed = await methodChannel.invokeMethod<bool>(
+        'handleUrl',
+        <String, Object?>{'url': url},
+      );
+      return consumed ?? false;
+    } on PlatformException catch (e) {
+      throw _mapPlatformException(e);
+    }
+  }
+
+  @override
+  Future<void> startUnregistration() async {
+    try {
+      await methodChannel.invokeMethod<void>('startUnregistration');
+    } on PlatformException catch (e) {
+      throw _mapPlatformException(e);
+    }
+  }
+
+  @override
+  Future<RegistrationState> getRegistrationState() async {
+    final raw = await methodChannel.invokeMethod<int>('getRegistrationState');
+    return RegistrationState.fromInt(raw);
+  }
+
+  // --- Registration streams -------------------------------------------------
+
+  @override
+  Stream<RegistrationState> registrationStateStream() {
+    return _registrationStateStream ??=
+        registrationStateChannel.receiveBroadcastStream().map((event) => RegistrationState.fromInt(event as int?));
+  }
+
+  @override
+  Stream<DeviceInfo?> activeDeviceStream() {
+    return _activeDeviceStream ??= activeDeviceChannel.receiveBroadcastStream().map((event) {
+      if (event == null) return null;
+      return DeviceInfo.fromMap(event as Map<Object?, Object?>);
+    });
+  }
+
+  @override
+  Stream<List<DeviceInfo>> devicesStream() {
+    return _devicesStream ??= devicesChannel.receiveBroadcastStream().map((
+      event,
+    ) {
+      final list = (event as List<Object?>?) ?? const [];
+      return list.map((e) => DeviceInfo.fromMap(e! as Map<Object?, Object?>)).toList(growable: false);
+    });
+  }
+
+  @override
+  Future<List<DeviceInfo>> getDevices() async {
+    try {
+      final raw = await methodChannel.invokeMethod<List<Object?>>('getDevices');
+      if (raw == null) return const [];
+      return raw.map((e) => DeviceInfo.fromMap(e! as Map<Object?, Object?>)).toList(growable: false);
+    } on PlatformException catch (e) {
+      throw _mapPlatformException(e);
+    }
+  }
+
+  @override
+  Stream<DeviceCompatibilityEvent> compatibilityStream() {
+    return _compatibilityStream ??= compatibilityChannel.receiveBroadcastStream().map(
+          (event) => DeviceCompatibilityEvent.fromMap(
+            event as Map<Object?, Object?>,
+          ),
+        );
+  }
+
+  @override
+  Future<void> openFirmwareUpdate() {
+    return methodChannel.invokeMethod<void>('openFirmwareUpdate');
+  }
+
+  @override
+  Future<void> openDATGlassesAppUpdate() {
+    return methodChannel.invokeMethod<void>('openDATGlassesAppUpdate');
+  }
+
+  // --- Streaming ------------------------------------------------------------
+
+  @override
+  Future<int> startStreamSession({
+    String? deviceUUID,
+    int fps = 30,
+    StreamQuality quality = StreamQuality.medium,
+    Set<DeviceKind>? deviceKinds,
+    VideoCodec videoCodec = VideoCodec.raw,
+  }) async {
+    try {
+      final id = await methodChannel.invokeMethod<int>(
+        'startStreamSession',
+        <String, Object?>{
+          if (deviceUUID != null) 'deviceUuid': deviceUUID,
+          'fps': fps,
+          'quality': quality.name,
+          if (deviceKinds != null && deviceKinds.isNotEmpty) 'deviceKinds': deviceKinds.map((k) => k.wireName).toList(),
+          'videoCodec': videoCodec.name,
+        },
+      );
+      if (id == null) {
+        throw const SessionError(
+          code: DatErrorCodes.session,
+          message: 'startStreamSession returned null',
+        );
+      }
+      return id;
+    } on PlatformException catch (e) {
+      throw _mapPlatformException(e);
+    }
+  }
+
+  @override
+  Future<void> stopStreamSession({String? deviceUUID}) async {
+    try {
+      await methodChannel.invokeMethod<void>(
+        'stopStreamSession',
+        <String, Object?>{
+          if (deviceUUID != null) 'deviceUuid': deviceUUID,
+        },
+      );
+    } on PlatformException catch (e) {
+      throw _mapPlatformException(e);
+    }
+  }
+
+  @override
+  Future<void> pauseStreamSession({String? deviceUUID}) async {
+    try {
+      await methodChannel.invokeMethod<void>(
+        'pauseStreamSession',
+        <String, Object?>{
+          if (deviceUUID != null) 'deviceUuid': deviceUUID,
+        },
+      );
+    } on PlatformException catch (e) {
+      throw _mapPlatformException(e);
+    }
+  }
+
+  @override
+  Future<void> resumeStreamSession({String? deviceUUID}) async {
+    try {
+      await methodChannel.invokeMethod<void>(
+        'resumeStreamSession',
+        <String, Object?>{
+          if (deviceUUID != null) 'deviceUuid': deviceUUID,
+        },
+      );
+    } on PlatformException catch (e) {
+      throw _mapPlatformException(e);
+    }
+  }
+
+  // --- Streaming streams ----------------------------------------------------
+
+  @override
+  Stream<StreamSessionState> streamSessionStateStream() {
+    return _streamSessionStateStream ??=
+        streamSessionStateChannel.receiveBroadcastStream().map((event) => StreamSessionState.fromInt(event as int?));
+  }
+
+  @override
+  Stream<Object> streamSessionErrorStream() {
+    return _streamSessionErrorStream ??=
+        streamSessionErrorsChannel.receiveBroadcastStream().map(_mapStreamSessionError);
+  }
+
+  @override
+  Stream<DeviceSessionState> deviceSessionStateStream() {
+    return _deviceSessionStateStream ??=
+        deviceSessionStateChannel.receiveBroadcastStream().map((event) => DeviceSessionState.fromInt(event as int?));
+  }
+
+  @override
+  Stream<Object> deviceSessionErrorStream() {
+    return _deviceSessionErrorStream ??=
+        deviceSessionErrorsChannel.receiveBroadcastStream().map(_mapDeviceSessionError);
+  }
+
+  @override
+  Stream<VideoStreamSize> videoStreamSizeStream() {
+    return _videoStreamSizeStream ??= videoStreamSizeChannel
+        .receiveBroadcastStream()
+        .map((event) => VideoStreamSize.fromMap(event as Map<Object?, Object?>))
+        .map((size) {
+      _lastVideoStreamSize = size;
+      return size;
+    });
+  }
+
+  @override
+  Stream<VideoFrame> videoFramesStream() {
+    return _videoFramesStream ??=
+        videoFramesChannel.receiveBroadcastStream().map((event) => VideoFrame.fromMap(event as Map<Object?, Object?>));
+  }
+
+  @override
+  Future<void> enableBackgroundStreaming({
+    BackgroundNotification? androidNotification,
+  }) async {
+    try {
+      await methodChannel.invokeMethod<void>(
+        'enableBackgroundStreaming',
+        <String, Object?>{
+          if (androidNotification != null) 'androidNotification': androidNotification.toMap(),
+        },
+      );
+    } on PlatformException catch (e) {
+      throw _mapPlatformException(e);
+    }
+  }
+
+  @override
+  Future<void> disableBackgroundStreaming() async {
+    try {
+      await methodChannel.invokeMethod<void>('disableBackgroundStreaming');
+    } on PlatformException catch (e) {
+      throw _mapPlatformException(e);
+    }
+  }
+
+  // --- Display --------------------------------------------------------------
+
+  @override
+  Future<void> startDisplaySession({String? deviceUUID}) async {
+    _ensureDisplayEventsListening();
+    try {
+      await methodChannel.invokeMethod<void>(
+        'startDisplaySession',
+        <String, Object?>{
+          if (deviceUUID != null) 'deviceUuid': deviceUUID,
+        },
+      );
+    } on PlatformException catch (e) {
+      throw _mapPlatformException(e);
+    }
+  }
+
+  @override
+  Future<void> sendDisplayView(DisplayView view) async {
+    _ensureDisplayEventsListening();
+    final table = DisplayCallbackTable();
+    final json = view.toJson(table);
+    // Replace the live callback table so events for the previous view stop
+    // resolving once the new view is on screen.
+    _displayCallbacks = table;
+    try {
+      await methodChannel.invokeMethod<void>(
+        'sendDisplayView',
+        <String, Object?>{'view': json},
+      );
+    } on PlatformException catch (e) {
+      throw _mapPlatformException(e);
+    }
+  }
+
+  @override
+  Future<void> stopDisplaySession() async {
+    try {
+      await methodChannel.invokeMethod<void>('stopDisplaySession');
+    } on PlatformException catch (e) {
+      throw _mapPlatformException(e);
+    }
+    _displayCallbacks = null;
+  }
+
+  @override
+  Stream<DisplayState> displayStateStream() {
+    return _displayStateStream ??=
+        displayStateChannel.receiveBroadcastStream().map((event) => DisplayState.fromInt(event as int?));
+  }
+
+  /// Lazily subscribes to the `display_events` channel and forwards every
+  /// event to the live [DisplayCallbackTable]. Idempotent.
+  void _ensureDisplayEventsListening() {
+    _displayEventsSubscription ??= displayEventsChannel.receiveBroadcastStream().listen((event) {
+      if (event is Map) {
+        _displayCallbacks?.dispatch(event.cast<Object?, Object?>());
+      }
+    });
+  }
+
+  // --- Photo capture --------------------------------------------------------
+
+  @override
+  Future<PhotoResult> capturePhoto({
+    String? deviceUUID,
+    PhotoFormat format = PhotoFormat.jpeg,
+  }) async {
+    try {
+      final result = await methodChannel.invokeMethod<Map<Object?, Object?>>('capturePhoto', <String, Object?>{
+        if (deviceUUID != null) 'deviceUuid': deviceUUID,
+        'format': format.name,
+      });
+      if (result == null) {
+        throw const CaptureError(
+          code: DatErrorCodes.capture,
+          message: 'capturePhoto returned null',
+        );
+      }
+      final bytes = result['bytes'];
+      final formatName = result['format'] as String? ?? format.name;
+      final byteList = switch (bytes) {
+        final Uint8List u => u,
+        final List<int> l => Uint8List.fromList(l),
+        _ => Uint8List(0),
+      };
+      return PhotoResult(
+        bytes: byteList,
+        format: formatName == 'heic' ? PhotoFormat.heic : PhotoFormat.jpeg,
+      );
+    } on PlatformException catch (e) {
+      throw _mapPlatformException(e);
+    }
+  }
+
+  // --- Frame capture --------------------------------------------------------
+
+  @override
+  Future<FrameData?> captureStreamFrame(
+    int textureId, {
+    FrameFormat format = FrameFormat.rawRgba,
+  }) async {
+    final size = _lastVideoStreamSize ?? const VideoStreamSize(width: 1280, height: 720);
+    final width = size.width;
+    final height = size.height;
+    if (width <= 0 || height <= 0) return null;
+
+    ui.Scene? scene;
+    ui.Image? image;
+    try {
+      final builder = ui.SceneBuilder()
+        ..pushOffset(0, 0)
+        ..addTexture(
+          textureId,
+          width: width.toDouble(),
+          height: height.toDouble(),
+        )
+        ..pop();
+      scene = builder.build();
+      image = await scene.toImage(width, height);
+
+      final byteFormat = switch (format) {
+        FrameFormat.png => ui.ImageByteFormat.png,
+        FrameFormat.rawStraightRgba => ui.ImageByteFormat.rawStraightRgba,
+        FrameFormat.rawRgba => ui.ImageByteFormat.rawRgba,
+        // JPEG is only produced by the native captureLatestFrame path; the
+        // Dart texture rasterizer cannot emit JPEG, so fall back to PNG.
+        FrameFormat.jpeg => ui.ImageByteFormat.png,
+      };
+      final byteData = await image.toByteData(format: byteFormat);
+      if (byteData == null) {
+        throw const CaptureError(
+          code: DatErrorCodes.capture,
+          message: 'ui.Image.toByteData returned null',
+        );
+      }
+      return FrameData(
+        bytes: byteData.buffer.asUint8List(
+          byteData.offsetInBytes,
+          byteData.lengthInBytes,
+        ),
+        width: width,
+        height: height,
+        format: format,
+      );
+    } catch (e) {
+      if (e is DatError) rethrow;
+      throw CaptureError(
+        code: DatErrorCodes.capture,
+        message: 'captureStreamFrame failed: $e',
+      );
+    } finally {
+      image?.dispose();
+      scene?.dispose();
+    }
+  }
+
+  @override
+  Future<FrameData?> captureLatestFrame({double quality = 0.8}) async {
+    try {
+      final bytes = await methodChannel.invokeMethod<Uint8List>(
+        'captureLatestFrame',
+        <String, Object?>{'quality': quality},
+      );
+      if (bytes == null || bytes.isEmpty) return null;
+      final size = _lastVideoStreamSize;
+      return FrameData(
+        bytes: bytes,
+        width: size?.width ?? 0,
+        height: size?.height ?? 0,
+        format: FrameFormat.jpeg,
+      );
+    } on PlatformException catch (e) {
+      throw CaptureError(
+        code: DatErrorCodes.capture,
+        message: 'captureLatestFrame failed: ${e.message}',
+      );
+    }
+  }
+
+  // --- Mock device control --------------------------------------------------
+
+  @override
+  Future<void> enableMockDevice({
+    bool initiallyRegistered = true,
+    bool initialPermissionsGranted = true,
+  }) async {
+    try {
+      await methodChannel.invokeMethod<void>(
+        'enableMockDevice',
+        <String, Object?>{
+          'initiallyRegistered': initiallyRegistered,
+          'initialPermissionsGranted': initialPermissionsGranted,
+        },
+      );
+    } on PlatformException catch (e) {
+      throw _mapPlatformException(e);
+    }
+  }
+
+  @override
+  Future<void> disableMockDevice() async {
+    try {
+      await methodChannel.invokeMethod<void>('disableMockDevice');
+    } on PlatformException catch (e) {
+      throw _mapPlatformException(e);
+    }
+  }
+
+  @override
+  Future<bool> isMockDeviceEnabled() async {
+    try {
+      final enabled = await methodChannel.invokeMethod<bool>(
+        'isMockDeviceEnabled',
+      );
+      return enabled ?? false;
+    } on PlatformException catch (e) {
+      throw _mapPlatformException(e);
+    }
+  }
+
+  @override
+  Future<String> pairMockRayBanMeta() async {
+    try {
+      final uuid = await methodChannel.invokeMethod<String>('pairMockRayBanMeta');
+      return uuid ?? '';
+    } on PlatformException catch (e) {
+      throw _mapPlatformException(e);
+    }
+  }
+
+  @override
+  Future<List<DeviceInfo>> pairedMockDevices() async {
+    try {
+      final raw = await methodChannel.invokeMethod<List<Object?>>(
+        'pairedMockDevices',
+      );
+      if (raw == null) return const [];
+      return raw.map((e) => DeviceInfo.fromMap(e! as Map<Object?, Object?>)).toList(growable: false);
+    } on PlatformException catch (e) {
+      throw _mapPlatformException(e);
+    }
+  }
+
+  @override
+  Future<void> unpairMockDevice(String uuid) async {
+    try {
+      await methodChannel.invokeMethod<void>(
+        'unpairMockDevice',
+        <String, Object?>{'uuid': uuid},
+      );
+    } on PlatformException catch (e) {
+      throw _mapPlatformException(e);
+    }
+  }
+
+  @override
+  Future<void> mockPowerOn(String uuid) async {
+    await _mockUuidVoid('mockPowerOn', uuid);
+  }
+
+  @override
+  Future<void> mockPowerOff(String uuid) async {
+    await _mockUuidVoid('mockPowerOff', uuid);
+  }
+
+  @override
+  Future<void> mockDon(String uuid) async {
+    await _mockUuidVoid('mockDon', uuid);
+  }
+
+  @override
+  Future<void> mockDoff(String uuid) async {
+    await _mockUuidVoid('mockDoff', uuid);
+  }
+
+  @override
+  Future<void> mockFold(String uuid) async {
+    await _mockUuidVoid('mockFold', uuid);
+  }
+
+  @override
+  Future<void> mockUnfold(String uuid) async {
+    await _mockUuidVoid('mockUnfold', uuid);
+  }
+
+  Future<void> _mockUuidVoid(String method, String uuid) async {
+    try {
+      await methodChannel.invokeMethod<void>(
+        method,
+        <String, Object?>{'uuid': uuid},
+      );
+    } on PlatformException catch (e) {
+      throw _mapPlatformException(e);
+    }
+  }
+
+  @override
+  Future<void> setMockCameraFacing(String uuid, CameraFacing facing) async {
+    try {
+      await methodChannel.invokeMethod<void>(
+        'setMockCameraFacing',
+        <String, Object?>{'uuid': uuid, 'facing': facing.name},
+      );
+    } on PlatformException catch (e) {
+      throw _mapPlatformException(e);
+    }
+  }
+
+  @override
+  Future<void> setMockCameraFeed(String uuid, String? filePath) async {
+    try {
+      await methodChannel.invokeMethod<void>(
+        'setMockCameraFeed',
+        <String, Object?>{'uuid': uuid, 'filePath': filePath},
+      );
+    } on PlatformException catch (e) {
+      throw _mapPlatformException(e);
+    }
+  }
+
+  @override
+  Future<void> setMockCapturedImage(String uuid, String? filePath) async {
+    try {
+      await methodChannel.invokeMethod<void>(
+        'setMockCapturedImage',
+        <String, Object?>{'uuid': uuid, 'filePath': filePath},
+      );
+    } on PlatformException catch (e) {
+      throw _mapPlatformException(e);
+    }
+  }
+
+  @override
+  Future<void> setMockPermission(String permission, String status) async {
+    try {
+      await methodChannel.invokeMethod<void>(
+        'setMockPermission',
+        <String, Object?>{'permission': permission, 'status': status},
+      );
+    } on PlatformException catch (e) {
+      throw _mapPlatformException(e);
+    }
+  }
+
+  @override
+  Future<void> setMockPermissionRequestResult(
+    String permission,
+    String status,
+  ) async {
+    try {
+      await methodChannel.invokeMethod<void>(
+        'setMockPermissionRequestResult',
+        <String, Object?>{'permission': permission, 'status': status},
+      );
+    } on PlatformException catch (e) {
+      throw _mapPlatformException(e);
+    }
+  }
+
+  // --- Mock devices stream --------------------------------------------------
+
+  @override
+  Stream<List<DeviceInfo>> mockDevicesStream() {
+    return _mockDevicesStream ??= mockDevicesChannel.receiveBroadcastStream().map((event) {
+      final list = (event as List<Object?>?) ?? const [];
+      return list.map((e) => DeviceInfo.fromMap(e! as Map<Object?, Object?>)).toList(growable: false);
+    });
+  }
+
+  // --- Helpers --------------------------------------------------------------
+
+  /// Maps a [PlatformException] thrown from the platform channel to the
+  /// most specific [DatError] subclass we have for its `code`. Anything
+  /// unrecognised passes through as a base [DatError].
+  static DatError _mapPlatformException(PlatformException e) {
+    final code = e.code;
+    final message = e.message ?? '';
+    final details = e.details;
+    switch (code) {
+      case DatErrorCodes.registration:
+        return RegistrationError(
+          code: code,
+          message: message,
+          details: details,
+        );
+      case DatErrorCodes.unregistration:
+        return UnregistrationError(
+          code: code,
+          message: message,
+          details: details,
+        );
+      case DatErrorCodes.handleUrl:
+        return HandleUrlError(code: code, message: message, details: details);
+      case DatErrorCodes.permission:
+      case DatErrorCodes.missingFragmentActivity:
+        return PermissionError(code: code, message: message, details: details);
+      case DatErrorCodes.deviceSession:
+        return DeviceSessionError(
+          code: code,
+          message: message,
+          details: details,
+        );
+      case DatErrorCodes.session:
+        return SessionError(code: code, message: message, details: details);
+      case DatErrorCodes.capture:
+        return CaptureError(code: code, message: message, details: details);
+      case _:
+        return DatError(code: code, message: message, details: details);
+    }
+  }
+
+  /// Maps a `stream_session_errors` channel event into a typed
+  /// [SessionError]. The map shape is `{code, message, details?}` where
+  /// `code` is the typed sub-code (e.g. `thermalCritical`).
+  static DatError _mapStreamSessionError(Object? event) {
+    final map = event as Map<Object?, Object?>? ?? const {};
+    final code = map['code'] as String? ?? DatErrorCodes.session;
+    final message = map['message'] as String? ?? '';
+    final details = map['details'];
+    return SessionError(code: code, message: message, details: details);
+  }
+
+  /// Maps a `device_session_errors` channel event into a typed
+  /// [DeviceSessionError].
+  static DatError _mapDeviceSessionError(Object? event) {
+    final map = event as Map<Object?, Object?>? ?? const {};
+    final code = map['code'] as String? ?? DatErrorCodes.unexpectedError;
+    final message = map['message'] as String? ?? '';
+    final details = map['details'];
+    return DeviceSessionError(code: code, message: message, details: details);
+  }
+}

--- a/app/third_party/meta_wearables_dat_flutter/lib/src/meta_wearables_dat_platform_interface.dart
+++ b/app/third_party/meta_wearables_dat_flutter/lib/src/meta_wearables_dat_platform_interface.dart
@@ -1,0 +1,390 @@
+import 'package:meta_wearables_dat_flutter/src/meta_wearables_dat_method_channel.dart';
+import 'package:meta_wearables_dat_flutter/src/models/background_notification.dart';
+import 'package:meta_wearables_dat_flutter/src/models/camera_facing.dart';
+import 'package:meta_wearables_dat_flutter/src/models/device_compatibility.dart';
+import 'package:meta_wearables_dat_flutter/src/models/device_info.dart';
+import 'package:meta_wearables_dat_flutter/src/models/device_session_state.dart';
+import 'package:meta_wearables_dat_flutter/src/models/display/display_components.dart';
+import 'package:meta_wearables_dat_flutter/src/models/display/display_state.dart';
+import 'package:meta_wearables_dat_flutter/src/models/frame_data.dart';
+import 'package:meta_wearables_dat_flutter/src/models/photo_result.dart';
+import 'package:meta_wearables_dat_flutter/src/models/registration_state.dart';
+import 'package:meta_wearables_dat_flutter/src/models/stream_quality.dart';
+import 'package:meta_wearables_dat_flutter/src/models/stream_session_state.dart';
+import 'package:meta_wearables_dat_flutter/src/models/video_frame.dart';
+import 'package:meta_wearables_dat_flutter/src/models/video_stream_size.dart';
+import 'package:plugin_platform_interface/plugin_platform_interface.dart';
+
+/// Platform interface for `meta_wearables_dat_flutter`.
+///
+/// Concrete implementations subclass [MetaWearablesDatPlatform] and override
+/// the methods they implement. The shipped default,
+/// [MethodChannelMetaWearablesDat], forwards every call across a single
+/// `MethodChannel` and the topic-specific `EventChannel`s described in
+/// `AGENTS.md`.
+///
+/// Tests can substitute their own subclass with `MockPlatformInterfaceMixin`.
+abstract class MetaWearablesDatPlatform extends PlatformInterface {
+  /// Constructs a [MetaWearablesDatPlatform].
+  MetaWearablesDatPlatform() : super(token: _token);
+
+  static final Object _token = Object();
+
+  static MetaWearablesDatPlatform _instance = MethodChannelMetaWearablesDat();
+
+  /// The current default platform implementation.
+  static MetaWearablesDatPlatform get instance => _instance;
+
+  /// Sets the platform implementation (used by tests).
+  static set instance(MetaWearablesDatPlatform instance) {
+    PlatformInterface.verifyToken(instance, _token);
+    _instance = instance;
+  }
+
+  // --- Diagnostics ----------------------------------------------------------
+
+  /// Returns a short string identifying the host platform.
+  Future<String?> getPlatformVersion() {
+    throw UnimplementedError('getPlatformVersion() has not been implemented.');
+  }
+
+  /// Implements `MetaWearablesDat.dumpDiagnostics`.
+  Future<Map<String, Object?>> dumpDiagnostics() {
+    throw UnimplementedError('dumpDiagnostics() has not been implemented.');
+  }
+
+  // --- Permissions ----------------------------------------------------------
+
+  /// Implements `MetaWearablesDat.requestAndroidPermissions`.
+  Future<bool> requestAndroidPermissions() {
+    throw UnimplementedError(
+      'requestAndroidPermissions() has not been implemented.',
+    );
+  }
+
+  /// Implements `MetaWearablesDat.requestCameraPermission`.
+  Future<bool> requestCameraPermission() {
+    throw UnimplementedError(
+      'requestCameraPermission() has not been implemented.',
+    );
+  }
+
+  /// Implements `MetaWearablesDat.getCameraPermissionStatus`.
+  Future<bool> getCameraPermissionStatus() {
+    throw UnimplementedError(
+      'getCameraPermissionStatus() has not been implemented.',
+    );
+  }
+
+  // --- Registration ---------------------------------------------------------
+
+  /// Implements `MetaWearablesDat.startRegistration`.
+  Future<void> startRegistration({String? appId, String? urlScheme}) {
+    throw UnimplementedError('startRegistration() has not been implemented.');
+  }
+
+  /// Implements `MetaWearablesDat.handleUrl`.
+  Future<bool> handleUrl(String url) {
+    throw UnimplementedError('handleUrl() has not been implemented.');
+  }
+
+  /// Implements `MetaWearablesDat.startUnregistration`.
+  Future<void> startUnregistration() {
+    throw UnimplementedError(
+      'startUnregistration() has not been implemented.',
+    );
+  }
+
+  /// Implements `MetaWearablesDat.getRegistrationState`.
+  Future<RegistrationState> getRegistrationState() {
+    throw UnimplementedError(
+      'getRegistrationState() has not been implemented.',
+    );
+  }
+
+  /// Implements `MetaWearablesDat.registrationStateStream`.
+  Stream<RegistrationState> registrationStateStream() {
+    throw UnimplementedError(
+      'registrationStateStream() has not been implemented.',
+    );
+  }
+
+  /// Implements `MetaWearablesDat.activeDeviceStream`.
+  Stream<DeviceInfo?> activeDeviceStream() {
+    throw UnimplementedError('activeDeviceStream() has not been implemented.');
+  }
+
+  /// Implements `MetaWearablesDat.devicesStream`.
+  Stream<List<DeviceInfo>> devicesStream() {
+    throw UnimplementedError('devicesStream() has not been implemented.');
+  }
+
+  /// Implements `MetaWearablesDat.getDevices`.
+  Future<List<DeviceInfo>> getDevices() {
+    throw UnimplementedError('getDevices() has not been implemented.');
+  }
+
+  /// Implements `MetaWearablesDat.compatibilityStream`.
+  Stream<DeviceCompatibilityEvent> compatibilityStream() {
+    throw UnimplementedError('compatibilityStream() has not been implemented.');
+  }
+
+  /// Implements `MetaWearablesDat.openFirmwareUpdate`.
+  Future<void> openFirmwareUpdate() {
+    throw UnimplementedError('openFirmwareUpdate() has not been implemented.');
+  }
+
+  /// Implements `MetaWearablesDat.openDATGlassesAppUpdate`.
+  Future<void> openDATGlassesAppUpdate() {
+    throw UnimplementedError(
+      'openDATGlassesAppUpdate() has not been implemented.',
+    );
+  }
+
+  // --- Streaming ------------------------------------------------------------
+
+  /// Implements `MetaWearablesDat.startStreamSession`.
+  Future<int> startStreamSession({
+    String? deviceUUID,
+    int fps = 30,
+    StreamQuality quality = StreamQuality.medium,
+    Set<DeviceKind>? deviceKinds,
+    VideoCodec videoCodec = VideoCodec.raw,
+  }) {
+    throw UnimplementedError('startStreamSession() has not been implemented.');
+  }
+
+  /// Implements `MetaWearablesDat.stopStreamSession`.
+  Future<void> stopStreamSession({String? deviceUUID}) {
+    throw UnimplementedError('stopStreamSession() has not been implemented.');
+  }
+
+  /// Implements `MetaWearablesDat.pauseStreamSession`.
+  Future<void> pauseStreamSession({String? deviceUUID}) {
+    throw UnimplementedError('pauseStreamSession() has not been implemented.');
+  }
+
+  /// Implements `MetaWearablesDat.resumeStreamSession`.
+  Future<void> resumeStreamSession({String? deviceUUID}) {
+    throw UnimplementedError(
+      'resumeStreamSession() has not been implemented.',
+    );
+  }
+
+  /// Implements `MetaWearablesDat.streamSessionStateStream`.
+  Stream<StreamSessionState> streamSessionStateStream() {
+    throw UnimplementedError(
+      'streamSessionStateStream() has not been implemented.',
+    );
+  }
+
+  /// Implements `MetaWearablesDat.streamSessionErrorStream`.
+  Stream<Object> streamSessionErrorStream() {
+    throw UnimplementedError(
+      'streamSessionErrorStream() has not been implemented.',
+    );
+  }
+
+  /// Implements `MetaWearablesDat.deviceSessionStateStream`.
+  Stream<DeviceSessionState> deviceSessionStateStream() {
+    throw UnimplementedError(
+      'deviceSessionStateStream() has not been implemented.',
+    );
+  }
+
+  /// Implements `MetaWearablesDat.deviceSessionErrorStream`.
+  Stream<Object> deviceSessionErrorStream() {
+    throw UnimplementedError(
+      'deviceSessionErrorStream() has not been implemented.',
+    );
+  }
+
+  /// Implements `MetaWearablesDat.videoStreamSizeStream`.
+  Stream<VideoStreamSize> videoStreamSizeStream() {
+    throw UnimplementedError(
+      'videoStreamSizeStream() has not been implemented.',
+    );
+  }
+
+  /// Implements `MetaWearablesDat.videoFramesStream`.
+  Stream<VideoFrame> videoFramesStream() {
+    throw UnimplementedError('videoFramesStream() has not been implemented.');
+  }
+
+  /// Implements `MetaWearablesDat.enableBackgroundStreaming`.
+  Future<void> enableBackgroundStreaming({
+    BackgroundNotification? androidNotification,
+  }) {
+    throw UnimplementedError(
+      'enableBackgroundStreaming() has not been implemented.',
+    );
+  }
+
+  /// Implements `MetaWearablesDat.disableBackgroundStreaming`.
+  Future<void> disableBackgroundStreaming() {
+    throw UnimplementedError(
+      'disableBackgroundStreaming() has not been implemented.',
+    );
+  }
+
+  // --- Display --------------------------------------------------------------
+
+  /// Implements `MetaWearablesDat.startDisplaySession`.
+  Future<void> startDisplaySession({String? deviceUUID}) {
+    throw UnimplementedError('startDisplaySession() has not been implemented.');
+  }
+
+  /// Implements `MetaWearablesDat.sendDisplayView`.
+  Future<void> sendDisplayView(DisplayView view) {
+    throw UnimplementedError('sendDisplayView() has not been implemented.');
+  }
+
+  /// Implements `MetaWearablesDat.stopDisplaySession`.
+  Future<void> stopDisplaySession() {
+    throw UnimplementedError('stopDisplaySession() has not been implemented.');
+  }
+
+  /// Implements `MetaWearablesDat.displayStateStream`.
+  Stream<DisplayState> displayStateStream() {
+    throw UnimplementedError('displayStateStream() has not been implemented.');
+  }
+
+  // --- Capture --------------------------------------------------------------
+
+  /// Implements `MetaWearablesDat.captureStreamFrame`.
+  Future<FrameData?> captureStreamFrame(
+    int textureId, {
+    FrameFormat format = FrameFormat.rawRgba,
+  }) {
+    throw UnimplementedError(
+      'captureStreamFrame() has not been implemented.',
+    );
+  }
+
+  /// Implements `MetaWearablesDat.captureLatestFrame`.
+  Future<FrameData?> captureLatestFrame({double quality = 0.8}) {
+    throw UnimplementedError(
+      'captureLatestFrame() has not been implemented.',
+    );
+  }
+
+  /// Implements `MetaWearablesDat.capturePhoto`.
+  Future<PhotoResult> capturePhoto({
+    String? deviceUUID,
+    PhotoFormat format = PhotoFormat.jpeg,
+  }) {
+    throw UnimplementedError('capturePhoto() has not been implemented.');
+  }
+
+  // --- Mock Device ----------------------------------------------------------
+
+  /// Implements `MetaWearablesDat.enableMockDevice`.
+  Future<void> enableMockDevice({
+    bool initiallyRegistered = true,
+    bool initialPermissionsGranted = true,
+  }) {
+    throw UnimplementedError('enableMockDevice() has not been implemented.');
+  }
+
+  /// Implements `MetaWearablesDat.disableMockDevice`.
+  Future<void> disableMockDevice() {
+    throw UnimplementedError('disableMockDevice() has not been implemented.');
+  }
+
+  /// Implements `MetaWearablesDat.isMockDeviceEnabled`.
+  Future<bool> isMockDeviceEnabled() {
+    throw UnimplementedError(
+      'isMockDeviceEnabled() has not been implemented.',
+    );
+  }
+
+  /// Implements `MetaWearablesDat.pairMockRayBanMeta`.
+  Future<String> pairMockRayBanMeta() {
+    throw UnimplementedError('pairMockRayBanMeta() has not been implemented.');
+  }
+
+  /// Implements `MetaWearablesDat.pairedMockDevices`.
+  Future<List<DeviceInfo>> pairedMockDevices() {
+    throw UnimplementedError(
+      'pairedMockDevices() has not been implemented.',
+    );
+  }
+
+  /// Implements `MetaWearablesDat.unpairMockDevice`.
+  Future<void> unpairMockDevice(String uuid) {
+    throw UnimplementedError('unpairMockDevice() has not been implemented.');
+  }
+
+  /// Implements `MetaWearablesDat.mockPowerOn`.
+  Future<void> mockPowerOn(String uuid) {
+    throw UnimplementedError('mockPowerOn() has not been implemented.');
+  }
+
+  /// Implements `MetaWearablesDat.mockPowerOff`.
+  Future<void> mockPowerOff(String uuid) {
+    throw UnimplementedError('mockPowerOff() has not been implemented.');
+  }
+
+  /// Implements `MetaWearablesDat.mockDon`.
+  Future<void> mockDon(String uuid) {
+    throw UnimplementedError('mockDon() has not been implemented.');
+  }
+
+  /// Implements `MetaWearablesDat.mockDoff`.
+  Future<void> mockDoff(String uuid) {
+    throw UnimplementedError('mockDoff() has not been implemented.');
+  }
+
+  /// Implements `MetaWearablesDat.mockFold`.
+  Future<void> mockFold(String uuid) {
+    throw UnimplementedError('mockFold() has not been implemented.');
+  }
+
+  /// Implements `MetaWearablesDat.mockUnfold`.
+  Future<void> mockUnfold(String uuid) {
+    throw UnimplementedError('mockUnfold() has not been implemented.');
+  }
+
+  /// Implements `MetaWearablesDat.setMockCameraFacing`.
+  Future<void> setMockCameraFacing(String uuid, CameraFacing facing) {
+    throw UnimplementedError(
+      'setMockCameraFacing() has not been implemented.',
+    );
+  }
+
+  /// Implements `MetaWearablesDat.setMockCameraFeed`. [filePath] may be
+  /// `null` to clear the previously-set feed.
+  Future<void> setMockCameraFeed(String uuid, String? filePath) {
+    throw UnimplementedError('setMockCameraFeed() has not been implemented.');
+  }
+
+  /// Implements `MetaWearablesDat.setMockCapturedImage`. [filePath] may be
+  /// `null` to clear the previously-set image.
+  Future<void> setMockCapturedImage(String uuid, String? filePath) {
+    throw UnimplementedError(
+      'setMockCapturedImage() has not been implemented.',
+    );
+  }
+
+  /// Implements `MetaWearablesDat.setMockPermission`.
+  Future<void> setMockPermission(String permission, String status) {
+    throw UnimplementedError(
+      'setMockPermission() has not been implemented.',
+    );
+  }
+
+  /// Implements `MetaWearablesDat.setMockPermissionRequestResult`.
+  Future<void> setMockPermissionRequestResult(
+    String permission,
+    String status,
+  ) {
+    throw UnimplementedError(
+      'setMockPermissionRequestResult() has not been implemented.',
+    );
+  }
+
+  /// Implements `MetaWearablesDat.mockDevicesStream`.
+  Stream<List<DeviceInfo>> mockDevicesStream() {
+    throw UnimplementedError('mockDevicesStream() has not been implemented.');
+  }
+}

--- a/app/third_party/meta_wearables_dat_flutter/lib/src/models/background_notification.dart
+++ b/app/third_party/meta_wearables_dat_flutter/lib/src/models/background_notification.dart
@@ -1,0 +1,51 @@
+/// Foreground-service notification metadata required by Android when
+/// enabling background streaming.
+///
+/// Android prohibits silent foreground services: if your app keeps a
+/// stream alive in the background, the OS requires a persistent
+/// notification visible to the user. This object is forwarded to
+/// `BackgroundStreamingService` and used to build the notification
+/// channel + `Notification` shown while the service is running.
+///
+/// iOS has no equivalent requirement; pass `null` to
+/// [MetaWearablesDat.enableBackgroundStreaming] on iOS.
+class BackgroundNotification {
+  /// Creates a [BackgroundNotification].
+  const BackgroundNotification({
+    required this.title,
+    required this.text,
+    required this.channelId,
+    required this.channelName,
+    this.iconResourceName,
+  });
+
+  /// Title text on the notification.
+  final String title;
+
+  /// Body text on the notification.
+  final String text;
+
+  /// Notification channel id. Apps may reuse an existing channel id;
+  /// the plugin only creates a channel when one with this id does not
+  /// already exist.
+  final String channelId;
+
+  /// Notification channel display name (shown in Android Settings >
+  /// Apps > Notifications).
+  final String channelName;
+
+  /// Optional Android drawable resource name (no extension) used as
+  /// the notification's small icon. When `null`, the plugin falls back
+  /// to the app's launcher icon.
+  final String? iconResourceName;
+
+  /// Serialises to the platform-channel argument map consumed by the
+  /// Android side.
+  Map<String, Object?> toMap() => <String, Object?>{
+        'title': title,
+        'text': text,
+        'channelId': channelId,
+        'channelName': channelName,
+        if (iconResourceName != null) 'iconResourceName': iconResourceName,
+      };
+}

--- a/app/third_party/meta_wearables_dat_flutter/lib/src/models/camera_facing.dart
+++ b/app/third_party/meta_wearables_dat_flutter/lib/src/models/camera_facing.dart
@@ -1,0 +1,17 @@
+/// Camera facing for the Mock Device Kit
+/// ([MetaWearablesDat.setMockCameraFacing]).
+///
+/// Only meaningful for mock devices; real Meta wearables expose a single
+/// outward-facing camera and ignore this setting.
+enum CameraFacing {
+  /// Front-facing (selfie) camera on the host phone.
+  front('front'),
+
+  /// Back-facing (world) camera on the host phone.
+  back('back');
+
+  const CameraFacing(this.value);
+
+  /// String value used on the platform channel.
+  final String value;
+}

--- a/app/third_party/meta_wearables_dat_flutter/lib/src/models/dat_error.dart
+++ b/app/third_party/meta_wearables_dat_flutter/lib/src/models/dat_error.dart
@@ -1,0 +1,340 @@
+/// Base class for all errors raised by `meta_wearables_dat_flutter`.
+///
+/// The plugin maps native [PlatformException]s with known DAT codes to one of
+/// the typed subclasses below ([RegistrationError], [UnregistrationError],
+/// [HandleUrlError], [PermissionError], [DeviceSessionError],
+/// [SessionError] (== `StreamSessionError`), [CaptureError]) so host apps
+/// can `try` / `on` against the concrete category. Anything the plugin does
+/// not recognise is surfaced as the base [DatError].
+class DatError implements Exception {
+  /// Creates a [DatError].
+  const DatError({
+    required this.code,
+    required this.message,
+    this.details,
+  });
+
+  /// Machine-readable code, mirroring the upstream SDK's error category.
+  final String code;
+
+  /// Human-readable message. Safe to show to developers; not safe to show
+  /// to end users without translation.
+  final String message;
+
+  /// Optional structured payload that accompanies some errors.
+  final Object? details;
+
+  @override
+  String toString() => 'DatError(code: $code, message: $message)';
+}
+
+/// An error raised by the registration flow
+/// ([MetaWearablesDat.startRegistration],
+/// [MetaWearablesDat.startUnregistration], [MetaWearablesDat.handleUrl]).
+///
+/// Use the `is*` convenience getters to inspect specific cases without
+/// hardcoding the [code] string in host code.
+class RegistrationError extends DatError {
+  /// Creates a [RegistrationError].
+  const RegistrationError({
+    required super.code,
+    required super.message,
+    super.details,
+  });
+
+  /// True when the host app's `Info.plist` / `AndroidManifest.xml`
+  /// validation failed (e.g. missing `MWDAT` keys, invalid URL scheme).
+  bool get isConfigurationInvalid => code == DatErrorCodes.configurationInvalid;
+
+  /// True when the Meta AI companion app is not installed (or is too old).
+  bool get isMetaAiNotInstalled => code == DatErrorCodes.metaAiNotInstalled;
+
+  /// True when the host app is already registered for this device.
+  bool get isAlreadyRegistered => code == DatErrorCodes.alreadyRegistered;
+
+  /// True when the registration handshake required an internet connection
+  /// that was unavailable.
+  bool get isNetworkUnavailable => code == DatErrorCodes.networkUnavailable;
+
+  @override
+  String toString() => 'RegistrationError(code: $code, message: $message)';
+}
+
+/// An error raised by [MetaWearablesDat.startUnregistration].
+class UnregistrationError extends DatError {
+  /// Creates an [UnregistrationError].
+  const UnregistrationError({
+    required super.code,
+    required super.message,
+    super.details,
+  });
+
+  /// True when the host app is not currently registered, so there is
+  /// nothing to unregister.
+  bool get isNotRegistered => code == DatErrorCodes.notRegistered;
+
+  @override
+  String toString() => 'UnregistrationError(code: $code, message: $message)';
+}
+
+/// An error raised by [MetaWearablesDat.handleUrl].
+class HandleUrlError extends DatError {
+  /// Creates a [HandleUrlError].
+  const HandleUrlError({
+    required super.code,
+    required super.message,
+    super.details,
+  });
+
+  /// True when the URL handed to `handleUrl` did not belong to a
+  /// registration callback.
+  bool get isInvalidUrl => code == DatErrorCodes.invalidUrl;
+
+  @override
+  String toString() => 'HandleUrlError(code: $code, message: $message)';
+}
+
+/// An error raised when a permission cannot be requested or has been denied.
+///
+/// Includes both Android runtime permissions (Bluetooth, Internet) and the
+/// Meta-AI-bottom-sheet-driven on-device camera permission.
+class PermissionError extends DatError {
+  /// Creates a [PermissionError].
+  const PermissionError({
+    required super.code,
+    required super.message,
+    super.details,
+  });
+
+  /// True when the host activity does not extend `FlutterFragmentActivity`
+  /// / `ComponentActivity` (Android only).
+  bool get isMissingFragmentActivity => code == DatErrorCodes.missingFragmentActivity;
+
+  /// True when the user denied the permission via the Meta AI bottom sheet.
+  bool get isDenied => code == DatErrorCodes.permissionDenied;
+
+  @override
+  String toString() => 'PermissionError(code: $code, message: $message)';
+}
+
+/// An error raised by the underlying `DeviceSession` (separate from
+/// stream-level errors).
+///
+/// Surfaced by [MetaWearablesDat.deviceSessionErrorStream]. Mirrors the
+/// `DeviceSessionError` enum in Meta's iOS / Android DAT SDKs.
+class DeviceSessionError extends DatError {
+  /// Creates a [DeviceSessionError].
+  const DeviceSessionError({
+    required super.code,
+    required super.message,
+    super.details,
+  });
+
+  /// True when the SDK could not find any device eligible to host a
+  /// session (no paired glasses, none connected, none donned).
+  bool get isNoEligibleDevice => code == DatErrorCodes.noEligibleDevice;
+
+  /// True when a `stop()` was issued against a session that was already
+  /// stopped.
+  bool get isSessionAlreadyStopped => code == DatErrorCodes.sessionAlreadyStopped;
+
+  /// True when `createSession()` was called while a session already exists
+  /// for the same selector.
+  bool get isSessionAlreadyExists => code == DatErrorCodes.sessionAlreadyExists;
+
+  /// True when an operation required the session to be started but the
+  /// session is idle.
+  bool get isSessionIdle => code == DatErrorCodes.sessionIdle;
+
+  /// True when `addStream()` was called for a capability that is already
+  /// active.
+  bool get isCapabilityAlreadyActive => code == DatErrorCodes.capabilityAlreadyActive;
+
+  /// True when the requested capability is not available on the connected
+  /// device.
+  bool get isCapabilityNotFound => code == DatErrorCodes.capabilityNotFound;
+
+  /// True when the DAT app running on the glasses is too old to host the
+  /// requested session and must be updated (added in DAT 0.7.0).
+  bool get isDatAppUpdateRequired => code == DatErrorCodes.datAppUpdateRequired;
+
+  /// True for any error the plugin could not map to a known case.
+  bool get isUnexpectedError => code == DatErrorCodes.unexpectedError;
+
+  @override
+  String toString() => 'DeviceSessionError(code: $code, message: $message)';
+}
+
+/// An error raised by a streaming session
+/// ([MetaWearablesDat.startStreamSession], [MetaWearablesDat.stopStreamSession],
+/// etc.). Also accessible under the alias [StreamSessionError].
+class SessionError extends DatError {
+  /// Creates a [SessionError].
+  const SessionError({
+    required super.code,
+    required super.message,
+    super.details,
+  });
+
+  /// True when the device entered a thermally-critical state and the
+  /// stream was paused or stopped.
+  bool get isThermalCritical => code == DatErrorCodes.thermalCritical;
+
+  /// True when the glasses' hinges closed mid-stream.
+  bool get isHingesClosed => code == DatErrorCodes.hingesClosed;
+
+  /// True when the device-side camera permission was not granted (or was
+  /// revoked).
+  bool get isPermissionDenied => code == DatErrorCodes.permissionDenied;
+
+  /// True when the underlying device disconnected during streaming.
+  bool get isDeviceDisconnected => code == DatErrorCodes.deviceDisconnected;
+
+  /// True when the SDK reported `videoStreamingError`.
+  bool get isVideoStreamingError => code == DatErrorCodes.videoStreamingError;
+
+  /// True when the SDK reported an internal error.
+  bool get isInternalError => code == DatErrorCodes.internalError;
+
+  /// True when the SDK timed out waiting for a device-side response.
+  bool get isTimeout => code == DatErrorCodes.timeout;
+
+  @override
+  String toString() => 'SessionError(code: $code, message: $message)';
+}
+
+/// Alias matching Meta SDK naming (`StreamSessionError`).
+typedef StreamSessionError = SessionError;
+
+/// An error raised by a still-capture call ([MetaWearablesDat.capturePhoto]
+/// or [MetaWearablesDat.captureStreamFrame]).
+class CaptureError extends DatError {
+  /// Creates a [CaptureError].
+  const CaptureError({
+    required super.code,
+    required super.message,
+    super.details,
+  });
+
+  /// True when the underlying device disconnected mid-capture.
+  bool get isDeviceDisconnected => code == DatErrorCodes.deviceDisconnected;
+
+  /// True when another capture was already in flight.
+  bool get isCaptureInProgress => code == DatErrorCodes.captureInProgress;
+
+  /// True when the device-side capture pipeline failed.
+  bool get isCaptureFailed => code == DatErrorCodes.captureFailed;
+
+  /// True when `capturePhoto` was called without an active stream session.
+  bool get isNotStreaming => code == DatErrorCodes.notStreaming;
+
+  @override
+  String toString() => 'CaptureError(code: $code, message: $message)';
+}
+
+/// Well-known error codes used by [DatError.code]. Mirrors the categories
+/// emitted by Meta's iOS / Android typed `*Error` enums.
+abstract final class DatErrorCodes {
+  // --- Category codes (used by PlatformException.code) --------------------
+
+  /// The registration flow could not be started or completed.
+  static const String registration = 'REGISTRATION_ERROR';
+
+  /// The unregistration flow could not be started or completed.
+  static const String unregistration = 'UNREGISTRATION_ERROR';
+
+  /// `handleUrl` failed to consume the inbound URL.
+  static const String handleUrl = 'HANDLE_URL_ERROR';
+
+  /// A wearable-side permission (e.g. camera) is not granted.
+  static const String permission = 'PERMISSION_ERROR';
+
+  /// A `DeviceSession` operation failed.
+  static const String deviceSession = 'DEVICE_SESSION_ERROR';
+
+  /// A streaming session failed to start, was interrupted, or could not
+  /// be torn down cleanly.
+  static const String session = 'SESSION_ERROR';
+
+  /// A photo or frame capture failed.
+  static const String capture = 'CAPTURE_ERROR';
+
+  /// The Android host activity does not extend `FlutterFragmentActivity` /
+  /// `ComponentActivity`.
+  static const String missingFragmentActivity = 'MISSING_FRAGMENT_ACTIVITY';
+
+  // --- Sub-codes (used by typed event channels for is* getters) -----------
+
+  /// RegistrationError.configurationInvalid
+  static const String configurationInvalid = 'configurationInvalid';
+
+  /// RegistrationError.metaAINotInstalled
+  static const String metaAiNotInstalled = 'metaAiNotInstalled';
+
+  /// RegistrationError.alreadyRegistered
+  static const String alreadyRegistered = 'alreadyRegistered';
+
+  /// RegistrationError.networkUnavailable
+  static const String networkUnavailable = 'networkUnavailable';
+
+  /// UnregistrationError.notRegistered
+  static const String notRegistered = 'notRegistered';
+
+  /// HandleUrlError.invalidUrl
+  static const String invalidUrl = 'invalidUrl';
+
+  /// PermissionError.permissionDenied
+  static const String permissionDenied = 'permissionDenied';
+
+  /// DeviceSessionError.noEligibleDevice
+  static const String noEligibleDevice = 'noEligibleDevice';
+
+  /// DeviceSessionError.sessionAlreadyStopped
+  static const String sessionAlreadyStopped = 'sessionAlreadyStopped';
+
+  /// DeviceSessionError.sessionAlreadyExists
+  static const String sessionAlreadyExists = 'sessionAlreadyExists';
+
+  /// DeviceSessionError.sessionIdle
+  static const String sessionIdle = 'sessionIdle';
+
+  /// DeviceSessionError.capabilityAlreadyActive
+  static const String capabilityAlreadyActive = 'capabilityAlreadyActive';
+
+  /// DeviceSessionError.capabilityNotFound
+  static const String capabilityNotFound = 'capabilityNotFound';
+
+  /// DeviceSessionError.datAppUpdateRequired — the on-glasses DAT app must
+  /// be updated before a session can start (added in DAT 0.7.0).
+  static const String datAppUpdateRequired = 'datAppUpdateRequired';
+
+  /// DeviceSessionError.unexpectedError (fallback bucket).
+  static const String unexpectedError = 'unexpectedError';
+
+  /// SessionError.thermalCritical
+  static const String thermalCritical = 'thermalCritical';
+
+  /// SessionError.hingesClosed
+  static const String hingesClosed = 'hingesClosed';
+
+  /// SessionError.deviceDisconnected
+  static const String deviceDisconnected = 'deviceDisconnected';
+
+  /// SessionError.videoStreamingError
+  static const String videoStreamingError = 'videoStreamingError';
+
+  /// SessionError.internalError
+  static const String internalError = 'internalError';
+
+  /// SessionError.timeout
+  static const String timeout = 'timeout';
+
+  /// CaptureError.captureInProgress
+  static const String captureInProgress = 'captureInProgress';
+
+  /// CaptureError.captureFailed
+  static const String captureFailed = 'captureFailed';
+
+  /// CaptureError.notStreaming
+  static const String notStreaming = 'notStreaming';
+}

--- a/app/third_party/meta_wearables_dat_flutter/lib/src/models/device_compatibility.dart
+++ b/app/third_party/meta_wearables_dat_flutter/lib/src/models/device_compatibility.dart
@@ -1,0 +1,68 @@
+/// Compatibility state reported by Meta's SDK for a paired device.
+///
+/// Mirrors `MWDATCore.Compatibility` on iOS and
+/// `com.meta.wearable.dat.core.types.DeviceCompatibility` on Android.
+enum DeviceCompatibility {
+  /// Device and SDK versions are compatible; streaming should work.
+  compatible,
+
+  /// The glasses firmware needs to be updated before the SDK can talk
+  /// to the device. Surface this to the user with instructions to open
+  /// Meta AI / the companion app.
+  deviceUpdateRequired,
+
+  /// The host app embeds an older `MWDAT*` SDK than the firmware
+  /// expects. Surface this as "please update the app".
+  sdkUpdateRequired,
+
+  /// SDK has not yet reported a compatibility verdict for this device,
+  /// or the SDK doesn't know how to classify it.
+  unknown;
+
+  /// Maps a wire string (`compatible`, `deviceUpdateRequired`,
+  /// `sdkUpdateRequired`, `unknown`, `undefined`) to a [DeviceCompatibility].
+  static DeviceCompatibility fromRaw(String? raw) {
+    switch (raw) {
+      case 'compatible':
+        return DeviceCompatibility.compatible;
+      case 'deviceUpdateRequired':
+        return DeviceCompatibility.deviceUpdateRequired;
+      case 'sdkUpdateRequired':
+        return DeviceCompatibility.sdkUpdateRequired;
+      case _:
+        return DeviceCompatibility.unknown;
+    }
+  }
+}
+
+/// One `compatibility` event from the native side.
+///
+/// Emitted by `MetaWearablesDat.compatibilityStream()` whenever the SDK
+/// recomputes its verdict for a paired device.
+class DeviceCompatibilityEvent {
+  /// Creates a [DeviceCompatibilityEvent].
+  const DeviceCompatibilityEvent({
+    required this.deviceUuid,
+    required this.compatibility,
+  });
+
+  /// Parses a platform-channel map into a [DeviceCompatibilityEvent].
+  factory DeviceCompatibilityEvent.fromMap(Map<Object?, Object?> map) {
+    return DeviceCompatibilityEvent(
+      deviceUuid: map['deviceUuid'] as String? ?? '',
+      compatibility: DeviceCompatibility.fromRaw(
+        map['compatibility'] as String?,
+      ),
+    );
+  }
+
+  /// The device this event refers to. Matches `DeviceInfo.uuid`.
+  final String deviceUuid;
+
+  /// The current compatibility state.
+  final DeviceCompatibility compatibility;
+
+  @override
+  String toString() => 'DeviceCompatibilityEvent(deviceUuid: $deviceUuid, '
+      'compatibility: $compatibility)';
+}

--- a/app/third_party/meta_wearables_dat_flutter/lib/src/models/device_info.dart
+++ b/app/third_party/meta_wearables_dat_flutter/lib/src/models/device_info.dart
@@ -1,0 +1,122 @@
+/// Identifies a paired Meta wearable device.
+///
+/// Surfaced by [MetaWearablesDat.activeDeviceStream] and consumed by
+/// session methods that accept a `deviceUUID` parameter.
+class DeviceInfo {
+  /// Creates a [DeviceInfo].
+  const DeviceInfo({
+    required this.uuid,
+    required this.name,
+    required this.kind,
+    this.linkState = DeviceLinkState.unknown,
+  });
+
+  /// Constructs a [DeviceInfo] from a platform-channel map.
+  ///
+  /// Tolerant of missing fields: anything absent falls back to a sensible
+  /// default ([DeviceKind.unknown] / empty strings).
+  factory DeviceInfo.fromMap(Map<Object?, Object?> map) {
+    return DeviceInfo(
+      uuid: map['uuid'] as String? ?? '',
+      name: map['name'] as String? ?? '',
+      kind: DeviceKind.fromRaw(map['kind'] as String?),
+      linkState: DeviceLinkState.fromRaw(map['linkState'] as String?),
+    );
+  }
+
+  /// Stable per-device identifier assigned by Meta's SDK.
+  final String uuid;
+
+  /// Human-readable device name as reported by the SDK.
+  final String name;
+
+  /// Coarse-grained device family. Useful for UI and capability gating.
+  final DeviceKind kind;
+
+  /// Live Bluetooth link state as reported by `Device.linkState`. Paired
+  /// devices that are powered off / out of range / not yet set up in Meta AI
+  /// report [DeviceLinkState.disconnected] — sessions against them fail.
+  final DeviceLinkState linkState;
+
+  @override
+  String toString() => 'DeviceInfo(uuid: $uuid, name: $name, kind: $kind, linkState: $linkState)';
+}
+
+/// Bluetooth link state of a paired Meta wearable. Mirrors
+/// `MWDATCore.LinkState`.
+enum DeviceLinkState {
+  /// Paired but not currently reachable.
+  disconnected,
+
+  /// Link negotiation in progress.
+  connecting,
+
+  /// Live and usable for sessions.
+  connected,
+
+  /// The platform did not report a link state (older plugin native side).
+  unknown;
+
+  /// Maps a wire string to a [DeviceLinkState].
+  static DeviceLinkState fromRaw(String? raw) {
+    switch (raw) {
+      case 'connected':
+        return DeviceLinkState.connected;
+      case 'connecting':
+        return DeviceLinkState.connecting;
+      case 'disconnected':
+        return DeviceLinkState.disconnected;
+      case _:
+        return DeviceLinkState.unknown;
+    }
+  }
+}
+
+/// Coarse-grained Meta wearable family.
+///
+/// The native side may report richer model information (e.g. "Ray-Ban Meta
+/// Skyler"); we map those to the closest [DeviceKind] for cross-platform
+/// consistency. New families should extend this enum in additive releases.
+enum DeviceKind {
+  /// Ray-Ban Meta (Gen 1 and Gen 2).
+  rayBanMeta,
+
+  /// Ray-Ban Display.
+  rayBanDisplay,
+
+  /// Oakley Meta (HSTN, Vanguard, ...).
+  oakleyMeta,
+
+  /// Anything the SDK reports that the plugin doesn't recognise yet.
+  unknown;
+
+  /// Maps a raw kind string from the platform channel to a [DeviceKind].
+  static DeviceKind fromRaw(String? raw) {
+    switch (raw) {
+      case 'rayBanMeta':
+        return DeviceKind.rayBanMeta;
+      case 'rayBanDisplay':
+        return DeviceKind.rayBanDisplay;
+      case 'oakleyMeta':
+        return DeviceKind.oakleyMeta;
+      case _:
+        return DeviceKind.unknown;
+    }
+  }
+
+  /// Wire value matching the native-side raw kind string (the inverse of
+  /// [fromRaw]). Used when forwarding a deviceKinds filter to Meta's
+  /// `AutoDeviceSelector`.
+  String get wireName {
+    switch (this) {
+      case DeviceKind.rayBanMeta:
+        return 'rayBanMeta';
+      case DeviceKind.rayBanDisplay:
+        return 'rayBanDisplay';
+      case DeviceKind.oakleyMeta:
+        return 'oakleyMeta';
+      case DeviceKind.unknown:
+        return 'unknown';
+    }
+  }
+}

--- a/app/third_party/meta_wearables_dat_flutter/lib/src/models/device_session_state.dart
+++ b/app/third_party/meta_wearables_dat_flutter/lib/src/models/device_session_state.dart
@@ -1,0 +1,55 @@
+/// Lifecycle state of an underlying [DeviceSession].
+///
+/// Distinct from `StreamSessionState`: the `DeviceSession` is the long-lived
+/// connection to a specific paired wearable that the plugin owns on your
+/// behalf. A `StreamSession` is one capability attached to that device
+/// session (video streaming, in this plugin).
+///
+/// Surfaced by `MetaWearablesDat.deviceSessionStateStream()`. Mirrors the
+/// `DeviceSessionState` enum in Meta's iOS / Android DAT SDKs.
+enum DeviceSessionState {
+  /// Created but not yet started.
+  idle(0),
+
+  /// `start()` has been called; the SDK is still negotiating with the
+  /// device.
+  starting(1),
+
+  /// The device session is live; streams can be added.
+  started(2),
+
+  /// Temporarily paused (e.g. hinges closed, thermal limit).
+  paused(3),
+
+  /// `stop()` has been called; the device session is tearing down.
+  stopping(4),
+
+  /// Terminal state — a fresh `createSession()` is required to use the
+  /// device again.
+  stopped(5);
+
+  const DeviceSessionState(this.value);
+
+  /// The integer used on the platform channel.
+  final int value;
+
+  /// Maps a platform-channel integer to a [DeviceSessionState].
+  static DeviceSessionState fromInt(int? value) {
+    switch (value) {
+      case 0:
+        return DeviceSessionState.idle;
+      case 1:
+        return DeviceSessionState.starting;
+      case 2:
+        return DeviceSessionState.started;
+      case 3:
+        return DeviceSessionState.paused;
+      case 4:
+        return DeviceSessionState.stopping;
+      case 5:
+        return DeviceSessionState.stopped;
+      case _:
+        return DeviceSessionState.idle;
+    }
+  }
+}

--- a/app/third_party/meta_wearables_dat_flutter/lib/src/models/display/display_components.dart
+++ b/app/third_party/meta_wearables_dat_flutter/lib/src/models/display/display_components.dart
@@ -1,0 +1,456 @@
+import 'package:meta_wearables_dat_flutter/src/models/display/display_playback_event.dart';
+
+/// Layout direction of a [FlexBox]'s children.
+enum DisplayDirection {
+  /// Lay children out horizontally.
+  row('row'),
+
+  /// Lay children out vertically.
+  column('column');
+
+  const DisplayDirection(this.wireName);
+
+  /// The string used on the platform channel.
+  final String wireName;
+}
+
+/// Main-axis / cross-axis alignment of a [FlexBox]'s children.
+///
+/// Used for both `alignment` (main axis) and `crossAlignment` (cross axis).
+enum DisplayAlignment {
+  /// Pack children towards the start.
+  start('start'),
+
+  /// Center children.
+  center('center'),
+
+  /// Pack children towards the end.
+  end('end'),
+
+  /// Distribute free space between children.
+  spaceBetween('spaceBetween'),
+
+  /// Distribute free space around children.
+  spaceAround('spaceAround'),
+
+  /// Distribute free space evenly around children.
+  spaceEvenly('spaceEvenly');
+
+  const DisplayAlignment(this.wireName);
+
+  /// The string used on the platform channel.
+  final String wireName;
+}
+
+/// Typographic style of a [DisplayText].
+enum DisplayTextStyle {
+  /// Prominent heading text.
+  heading('heading'),
+
+  /// Default body text.
+  body('body'),
+
+  /// De-emphasised metadata text.
+  meta('meta');
+
+  const DisplayTextStyle(this.wireName);
+
+  /// The string used on the platform channel.
+  final String wireName;
+}
+
+/// Color role of a [DisplayText].
+enum DisplayTextColor {
+  /// The primary (default) text color.
+  primary('primary'),
+
+  /// A de-emphasised secondary text color.
+  secondary('secondary');
+
+  const DisplayTextColor(this.wireName);
+
+  /// The string used on the platform channel.
+  final String wireName;
+}
+
+/// Sizing preset for a [DisplayImage].
+enum DisplayImageSize {
+  /// Fill the available width, preserving aspect ratio.
+  fill('fill');
+
+  const DisplayImageSize(this.wireName);
+
+  /// The string used on the platform channel.
+  final String wireName;
+}
+
+/// Corner-radius preset applied to a [DisplayImage] or [FlexBox].
+enum DisplayCornerRadius {
+  /// Square corners.
+  none('none'),
+
+  /// A small corner radius.
+  small('small'),
+
+  /// A medium corner radius.
+  medium('medium'),
+
+  /// A large corner radius.
+  large('large');
+
+  const DisplayCornerRadius(this.wireName);
+
+  /// The string used on the platform channel.
+  final String wireName;
+}
+
+/// Visual style of a [DisplayButton].
+enum DisplayButtonStyle {
+  /// The primary, high-emphasis button style.
+  primary('primary'),
+
+  /// The secondary, lower-emphasis button style.
+  secondary('secondary');
+
+  const DisplayButtonStyle(this.wireName);
+
+  /// The string used on the platform channel.
+  final String wireName;
+}
+
+/// Built-in glyph rendered by a [DisplayIcon] or shown inside a
+/// [DisplayButton].
+///
+/// Names mirror Meta's `IconName` (Android) / `Icon` (iOS) enums; the wire
+/// token is normalised to camelCase and mapped back to each platform's enum
+/// natively.
+enum DisplayIconName {
+  /// A checkmark glyph.
+  checkmark('checkmark'),
+
+  /// A video-camera glyph.
+  videoCamera('videoCamera'),
+
+  /// A left-pointing triangle (with a vertical line).
+  triangleLeftVerticalLine('triangleLeftVerticalLine'),
+
+  /// A right-pointing triangle (with a vertical line).
+  triangleRightVerticalLine('triangleRightVerticalLine');
+
+  const DisplayIconName(this.wireName);
+
+  /// The string used on the platform channel.
+  final String wireName;
+}
+
+/// Container background preset for a [FlexBox].
+enum FlexBoxBackground {
+  /// No background.
+  none('none'),
+
+  /// The standard "card" surface background.
+  card('card');
+
+  const FlexBoxBackground(this.wireName);
+
+  /// The string used on the platform channel.
+  final String wireName;
+}
+
+/// Container codec hint for a [VideoPlayer].
+enum DisplayVideoCodec {
+  /// An MP4-contained video.
+  mp4('mp4');
+
+  const DisplayVideoCodec(this.wireName);
+
+  /// The string used on the platform channel.
+  final String wireName;
+}
+
+/// Collects the callbacks attached to a display view tree and assigns each a
+/// stable id so they can be serialized and later dispatched from native
+/// tap / click / playback events.
+///
+/// One table is built per `sendDisplayView` call; ids are only meaningful for
+/// the view currently shown on the glasses.
+class DisplayCallbackTable {
+  final Map<String, void Function()> _voidCallbacks = <String, void Function()>{};
+  final Map<String, void Function(DisplayPlaybackEvent)> _playbackCallbacks =
+      <String, void Function(DisplayPlaybackEvent)>{};
+  int _next = 0;
+
+  /// Registers a no-argument [callback] (a tap / click) and returns its id, or
+  /// `null` when [callback] is `null`.
+  String? registerTap(void Function()? callback) {
+    if (callback == null) return null;
+    final id = 'cb${_next++}';
+    _voidCallbacks[id] = callback;
+    return id;
+  }
+
+  /// Registers a playback [callback] and returns its id, or `null` when
+  /// [callback] is `null`.
+  String? registerPlayback(void Function(DisplayPlaybackEvent)? callback) {
+    if (callback == null) return null;
+    final id = 'cb${_next++}';
+    _playbackCallbacks[id] = callback;
+    return id;
+  }
+
+  /// Whether no callbacks were registered.
+  bool get isEmpty => _voidCallbacks.isEmpty && _playbackCallbacks.isEmpty;
+
+  /// The total number of registered callbacks.
+  int get length => _voidCallbacks.length + _playbackCallbacks.length;
+
+  /// Dispatches a `display_events` channel [event] to the matching callback.
+  void dispatch(Map<Object?, Object?> event) {
+    final id = event['callbackId'] as String?;
+    if (id == null) return;
+    final playback = _playbackCallbacks[id];
+    if (playback != null) {
+      playback(DisplayPlaybackEvent.fromMap(event));
+      return;
+    }
+    _voidCallbacks[id]?.call();
+  }
+}
+
+/// Base class for every node in a display view tree sent to the glasses with
+/// `MetaWearablesDat.sendDisplayView`.
+///
+/// A tree is built declaratively, e.g.:
+///
+/// ```dart
+/// FlexBox(
+///   direction: DisplayDirection.column,
+///   spacing: 12,
+///   children: [
+///     DisplayText('Hello', style: DisplayTextStyle.heading),
+///     DisplayButton(label: 'OK', onClick: () => print('tapped')),
+///   ],
+/// )
+/// ```
+sealed class DisplayNode {
+  /// Const base constructor.
+  const DisplayNode();
+
+  /// Serializes this node (and its subtree) to a platform-channel map.
+  ///
+  /// When [callbacks] is provided, any attached tap / click / playback
+  /// handlers are registered into it and the resulting ids are embedded in the
+  /// returned map. When `null`, callbacks are omitted (useful for inspection
+  /// and tests).
+  Map<String, Object?> toJson([DisplayCallbackTable? callbacks]);
+}
+
+/// The root of a display view tree. Any [DisplayNode] may be a root, but in
+/// practice this is a [FlexBox] or a [VideoPlayer].
+typedef DisplayView = DisplayNode;
+
+/// A flexbox container that arranges its [children] along a [direction].
+///
+/// Mirrors Meta's `FlexBox` (iOS) / `flexBox { }` (Android) builder, including
+/// the `padding`, `background`, `flexGrow` and `onTap` modifiers.
+class FlexBox extends DisplayNode {
+  /// Creates a [FlexBox].
+  const FlexBox({
+    this.children = const <DisplayNode>[],
+    this.direction = DisplayDirection.column,
+    this.spacing = 0,
+    this.padding,
+    this.background,
+    this.alignment,
+    this.crossAlignment,
+    this.cornerRadius,
+    this.wrap,
+    this.flexGrow,
+    this.onTap,
+  });
+
+  /// The child nodes laid out inside this container.
+  final List<DisplayNode> children;
+
+  /// The axis children are laid out along.
+  final DisplayDirection direction;
+
+  /// The gap between adjacent children, in logical pixels.
+  final int spacing;
+
+  /// Optional uniform inner padding, in logical pixels.
+  final int? padding;
+
+  /// Optional background preset.
+  final FlexBoxBackground? background;
+
+  /// Optional main-axis alignment.
+  final DisplayAlignment? alignment;
+
+  /// Optional cross-axis alignment.
+  final DisplayAlignment? crossAlignment;
+
+  /// Optional corner-radius preset.
+  final DisplayCornerRadius? cornerRadius;
+
+  /// Whether children may wrap onto multiple lines.
+  final bool? wrap;
+
+  /// Optional flex-grow factor relative to sibling [FlexBox]es.
+  final double? flexGrow;
+
+  /// Optional tap handler for the whole container.
+  final void Function()? onTap;
+
+  @override
+  Map<String, Object?> toJson([DisplayCallbackTable? callbacks]) {
+    return <String, Object?>{
+      'type': 'flexBox',
+      'direction': direction.wireName,
+      'spacing': spacing,
+      if (padding != null) 'padding': padding,
+      if (background != null) 'background': background!.wireName,
+      if (alignment != null) 'alignment': alignment!.wireName,
+      if (crossAlignment != null) 'crossAlignment': crossAlignment!.wireName,
+      if (cornerRadius != null) 'cornerRadius': cornerRadius!.wireName,
+      if (wrap != null) 'wrap': wrap,
+      if (flexGrow != null) 'flexGrow': flexGrow,
+      if (callbacks?.registerTap(onTap) case final String id) 'onTapId': id,
+      'children': children.map((child) => child.toJson(callbacks)).toList(growable: false),
+    };
+  }
+}
+
+/// A run of text rendered on the glasses display.
+class DisplayText extends DisplayNode {
+  /// Creates a [DisplayText].
+  const DisplayText(this.text, {this.style, this.color});
+
+  /// The text to render.
+  final String text;
+
+  /// Optional typographic style.
+  final DisplayTextStyle? style;
+
+  /// Optional color role.
+  final DisplayTextColor? color;
+
+  @override
+  Map<String, Object?> toJson([DisplayCallbackTable? callbacks]) {
+    return <String, Object?>{
+      'type': 'text',
+      'text': text,
+      if (style != null) 'style': style!.wireName,
+      if (color != null) 'color': color!.wireName,
+    };
+  }
+}
+
+/// A remote image rendered on the glasses display.
+class DisplayImage extends DisplayNode {
+  /// Creates a [DisplayImage].
+  const DisplayImage(this.uri, {this.sizePreset, this.cornerRadius});
+
+  /// The image URL.
+  final String uri;
+
+  /// Optional sizing preset.
+  final DisplayImageSize? sizePreset;
+
+  /// Optional corner-radius preset.
+  final DisplayCornerRadius? cornerRadius;
+
+  @override
+  Map<String, Object?> toJson([DisplayCallbackTable? callbacks]) {
+    return <String, Object?>{
+      'type': 'image',
+      'uri': uri,
+      if (sizePreset != null) 'sizePreset': sizePreset!.wireName,
+      if (cornerRadius != null) 'cornerRadius': cornerRadius!.wireName,
+    };
+  }
+}
+
+/// A tappable button rendered on the glasses display.
+class DisplayButton extends DisplayNode {
+  /// Creates a [DisplayButton].
+  const DisplayButton({
+    required this.label,
+    this.style,
+    this.iconName,
+    this.onClick,
+  });
+
+  /// The button's text label.
+  final String label;
+
+  /// Optional visual style.
+  final DisplayButtonStyle? style;
+
+  /// Optional leading icon.
+  final DisplayIconName? iconName;
+
+  /// Optional click handler.
+  final void Function()? onClick;
+
+  @override
+  Map<String, Object?> toJson([DisplayCallbackTable? callbacks]) {
+    return <String, Object?>{
+      'type': 'button',
+      'label': label,
+      if (style != null) 'style': style!.wireName,
+      if (iconName != null) 'iconName': iconName!.wireName,
+      if (callbacks?.registerTap(onClick) case final String id) 'onClickId': id,
+    };
+  }
+}
+
+/// A standalone built-in glyph rendered on the glasses display.
+class DisplayIcon extends DisplayNode {
+  /// Creates a [DisplayIcon].
+  const DisplayIcon(this.name);
+
+  /// The glyph to render.
+  final DisplayIconName name;
+
+  @override
+  Map<String, Object?> toJson([DisplayCallbackTable? callbacks]) {
+    return <String, Object?>{
+      'type': 'icon',
+      'iconName': name.wireName,
+    };
+  }
+}
+
+/// A video player rendered on the glasses display.
+///
+/// Playback transitions are delivered to [onPlaybackEvent] (e.g. when the
+/// video ends), mirroring Meta's `VideoPlayer.state` (Android) /
+/// `Display.onPlaybackEvent` (iOS).
+class VideoPlayer extends DisplayNode {
+  /// Creates a [VideoPlayer] sourced from a remote [uri].
+  const VideoPlayer(
+    this.uri, {
+    this.codec = DisplayVideoCodec.mp4,
+    this.onPlaybackEvent,
+  });
+
+  /// The video URL.
+  final String uri;
+
+  /// The container codec hint.
+  final DisplayVideoCodec codec;
+
+  /// Optional playback-event handler.
+  final void Function(DisplayPlaybackEvent)? onPlaybackEvent;
+
+  @override
+  Map<String, Object?> toJson([DisplayCallbackTable? callbacks]) {
+    return <String, Object?>{
+      'type': 'videoPlayer',
+      'uri': uri,
+      'codec': codec.wireName,
+      if (callbacks?.registerPlayback(onPlaybackEvent) case final String id) 'onPlaybackEventId': id,
+    };
+  }
+}

--- a/app/third_party/meta_wearables_dat_flutter/lib/src/models/display/display_playback_event.dart
+++ b/app/third_party/meta_wearables_dat_flutter/lib/src/models/display/display_playback_event.dart
@@ -1,0 +1,57 @@
+/// The kind of a [DisplayPlaybackEvent] emitted by a `VideoPlayer` rendered
+/// on the glasses display.
+///
+/// Mirrors the playback states reported by Meta's DAT SDKs
+/// (`VideoPlayerState` on Android, the `onPlaybackEvent` callback on iOS).
+enum DisplayPlaybackEventType {
+  /// Playback has begun (or resumed).
+  playing('playing'),
+
+  /// Playback has been paused.
+  paused('paused'),
+
+  /// Playback reached the end of the media.
+  ended('ended'),
+
+  /// Playback was stopped before completing.
+  stopped('stopped'),
+
+  /// The player reported an error.
+  error('error'),
+
+  /// An event the plugin did not recognise.
+  unknown('unknown');
+
+  const DisplayPlaybackEventType(this.wireName);
+
+  /// The string used on the platform channel.
+  final String wireName;
+
+  /// Maps a platform-channel string to a [DisplayPlaybackEventType].
+  static DisplayPlaybackEventType fromWire(String? wire) {
+    for (final value in DisplayPlaybackEventType.values) {
+      if (value.wireName == wire) return value;
+    }
+    return DisplayPlaybackEventType.unknown;
+  }
+}
+
+/// A playback event delivered to a `VideoPlayer`'s `onPlaybackEvent`
+/// callback while it is rendered on the glasses display.
+class DisplayPlaybackEvent {
+  /// Creates a [DisplayPlaybackEvent].
+  const DisplayPlaybackEvent({required this.type});
+
+  /// Builds a [DisplayPlaybackEvent] from a platform-channel map.
+  factory DisplayPlaybackEvent.fromMap(Map<Object?, Object?> map) {
+    return DisplayPlaybackEvent(
+      type: DisplayPlaybackEventType.fromWire(map['event'] as String?),
+    );
+  }
+
+  /// The kind of playback transition this event represents.
+  final DisplayPlaybackEventType type;
+
+  @override
+  String toString() => 'DisplayPlaybackEvent(type: ${type.wireName})';
+}

--- a/app/third_party/meta_wearables_dat_flutter/lib/src/models/display/display_state.dart
+++ b/app/third_party/meta_wearables_dat_flutter/lib/src/models/display/display_state.dart
@@ -1,0 +1,38 @@
+/// Lifecycle state of the [Display] capability attached to a `DeviceSession`.
+///
+/// Surfaced by `MetaWearablesDat.displayStateStream()`. Mirrors the
+/// `DisplayState` enum in Meta's iOS / Android DAT SDKs (added in DAT 0.7.0).
+enum DisplayState {
+  /// The display capability has been requested and is being set up.
+  starting(0),
+
+  /// The display is ready; views can be sent with `sendDisplayView`.
+  started(1),
+
+  /// The display is being torn down.
+  stopping(2),
+
+  /// The display is no longer attached.
+  stopped(3);
+
+  const DisplayState(this.value);
+
+  /// The integer used on the platform channel.
+  final int value;
+
+  /// Maps a platform-channel integer to a [DisplayState].
+  static DisplayState fromInt(int? value) {
+    switch (value) {
+      case 0:
+        return DisplayState.starting;
+      case 1:
+        return DisplayState.started;
+      case 2:
+        return DisplayState.stopping;
+      case 3:
+        return DisplayState.stopped;
+      case _:
+        return DisplayState.stopped;
+    }
+  }
+}

--- a/app/third_party/meta_wearables_dat_flutter/lib/src/models/frame_data.dart
+++ b/app/third_party/meta_wearables_dat_flutter/lib/src/models/frame_data.dart
@@ -1,0 +1,45 @@
+import 'dart:typed_data';
+
+/// A single frame snapshot returned by [MetaWearablesDat.captureStreamFrame].
+///
+/// Frames are produced on demand from Flutter's texture registry, not pushed
+/// every video frame. At 720x1280 the raw RGBA payload is roughly 3.7 MB;
+/// budget your sampling rate accordingly (200-500 ms is a good starting point
+/// for OCR / ML pipelines).
+class FrameData {
+  /// Creates a [FrameData].
+  const FrameData({
+    required this.bytes,
+    required this.width,
+    required this.height,
+    required this.format,
+  });
+
+  /// Raw pixel bytes.
+  final Uint8List bytes;
+
+  /// Pixel width.
+  final int width;
+
+  /// Pixel height.
+  final int height;
+
+  /// Pixel format of [bytes].
+  final FrameFormat format;
+}
+
+/// Pixel format of a [FrameData] payload.
+enum FrameFormat {
+  /// 32-bit per pixel, RGBA (red, green, blue, alpha) with **premultiplied
+  /// alpha**. This is what `ui.Image.toByteData()` returns by default.
+  rawRgba,
+
+  /// 32-bit per pixel, RGBA with **straight (un-premultiplied) alpha**.
+  rawStraightRgba,
+
+  /// PNG-encoded bytes.
+  png,
+
+  /// JPEG-encoded bytes.
+  jpeg,
+}

--- a/app/third_party/meta_wearables_dat_flutter/lib/src/models/mock_permission.dart
+++ b/app/third_party/meta_wearables_dat_flutter/lib/src/models/mock_permission.dart
@@ -1,0 +1,24 @@
+/// A wearable-side permission that the Mock Device Kit can pre-populate.
+enum MockPermission {
+  /// Camera permission (Meta AI camera-access bottom sheet on real devices).
+  camera('camera');
+
+  const MockPermission(this.value);
+
+  /// String passed to the native side over the method channel.
+  final String value;
+}
+
+/// The status the Mock Device Kit should report for a given [MockPermission].
+enum MockPermissionStatus {
+  /// Permission is granted.
+  granted('granted'),
+
+  /// Permission has been denied.
+  denied('denied');
+
+  const MockPermissionStatus(this.value);
+
+  /// String passed to the native side over the method channel.
+  final String value;
+}

--- a/app/third_party/meta_wearables_dat_flutter/lib/src/models/photo_result.dart
+++ b/app/third_party/meta_wearables_dat_flutter/lib/src/models/photo_result.dart
@@ -1,0 +1,24 @@
+import 'dart:typed_data';
+
+/// A high-resolution still captured by [MetaWearablesDat.capturePhoto].
+class PhotoResult {
+  /// Creates a [PhotoResult].
+  const PhotoResult({required this.bytes, required this.format});
+
+  /// The encoded image bytes.
+  final Uint8List bytes;
+
+  /// Encoding of [bytes].
+  final PhotoFormat format;
+}
+
+/// Encoded image format produced by [MetaWearablesDat.capturePhoto].
+enum PhotoFormat {
+  /// JPEG. Available on both iOS and Android.
+  jpeg,
+
+  /// HEIC / HEIF. Available on iOS; on Android availability depends on the
+  /// device generation. Prefer [PhotoFormat.jpeg] for cross-platform
+  /// portability.
+  heic,
+}

--- a/app/third_party/meta_wearables_dat_flutter/lib/src/models/registration_state.dart
+++ b/app/third_party/meta_wearables_dat_flutter/lib/src/models/registration_state.dart
@@ -1,0 +1,43 @@
+/// State of the registration lifecycle between a host app and the Meta AI app.
+///
+/// Mirrors `RegistrationState` from Meta's iOS DAT SDK and Android DAT SDK so
+/// that values transit the platform channel as plain integers without lossy
+/// translation. Surfaced by [MetaWearablesDat.registrationStateStream] and
+/// [MetaWearablesDat.getRegistrationState].
+enum RegistrationState {
+  /// The Meta AI app is not installed, or Developer Mode is disabled. The
+  /// host app cannot start registration in this state.
+  unavailable(0),
+
+  /// The Meta AI app is installed and Developer Mode is enabled, but the
+  /// host app has not yet registered a device.
+  available(1),
+
+  /// Registration is in progress. The user has been deep-linked into the
+  /// Meta AI app and has not yet returned.
+  registering(2),
+
+  /// A device is registered and ready to use.
+  registered(3);
+
+  const RegistrationState(this.value);
+
+  /// The integer used on the platform channel.
+  final int value;
+
+  /// Maps a platform-channel integer to a [RegistrationState].
+  static RegistrationState fromInt(int? value) {
+    switch (value) {
+      case 0:
+        return RegistrationState.unavailable;
+      case 1:
+        return RegistrationState.available;
+      case 2:
+        return RegistrationState.registering;
+      case 3:
+        return RegistrationState.registered;
+      case _:
+        return RegistrationState.unavailable;
+    }
+  }
+}

--- a/app/third_party/meta_wearables_dat_flutter/lib/src/models/session_state.dart
+++ b/app/third_party/meta_wearables_dat_flutter/lib/src/models/session_state.dart
@@ -1,0 +1,14 @@
+/// Backward-compatible alias for [StreamSessionState].
+///
+/// Kept for one release after v0.1.0 so existing host apps can upgrade
+/// incrementally. New code should use [StreamSessionState] directly.
+@Deprecated('Use StreamSessionState instead — this alias will be removed in v0.2.0.')
+library;
+
+import 'package:meta_wearables_dat_flutter/src/models/stream_session_state.dart';
+
+/// Backward-compatible alias for [StreamSessionState].
+///
+/// Use [StreamSessionState] in new code.
+@Deprecated('Use StreamSessionState instead — this alias will be removed in v0.2.0.')
+typedef SessionState = StreamSessionState;

--- a/app/third_party/meta_wearables_dat_flutter/lib/src/models/stream_quality.dart
+++ b/app/third_party/meta_wearables_dat_flutter/lib/src/models/stream_quality.dart
@@ -1,0 +1,42 @@
+/// Quality preset for [MetaWearablesDat.startStreamSession].
+///
+/// Each preset corresponds to a fixed resolution that Meta's SDK accepts on
+/// both Ray-Ban Meta and Oakley Meta. Higher quality means more bandwidth
+/// over Bluetooth and higher CPU on the I420 -> ARGB conversion path on
+/// Android.
+///
+/// Frame rate is independent of [StreamQuality]. Pick from
+/// [StreamQuality.fpsValues].
+///
+/// | Quality | Resolution (W x H) |
+/// | ------- | ------------------ |
+/// | low     | 360 x 640          |
+/// | medium  | 504 x 896          |
+/// | high    | 720 x 1280         |
+enum StreamQuality {
+  /// 360 x 640.
+  low(0, 360, 640),
+
+  /// 504 x 896. Default.
+  medium(1, 504, 896),
+
+  /// 720 x 1280. Highest CPU and bandwidth cost.
+  high(2, 720, 1280);
+
+  const StreamQuality(this.value, this.width, this.height);
+
+  /// The integer used on the platform channel.
+  final int value;
+
+  /// Pixel width of frames at this quality.
+  final int width;
+
+  /// Pixel height of frames at this quality.
+  final int height;
+
+  /// Allowed values for the `fps` argument to
+  /// [MetaWearablesDat.startStreamSession]. The SDK accepts only this
+  /// discrete set; values outside the list are clamped to the closest
+  /// supported FPS by Meta's SDK.
+  static const List<int> fpsValues = [2, 7, 15, 24, 30];
+}

--- a/app/third_party/meta_wearables_dat_flutter/lib/src/models/stream_session_state.dart
+++ b/app/third_party/meta_wearables_dat_flutter/lib/src/models/stream_session_state.dart
@@ -1,0 +1,52 @@
+/// State of an active [StreamSession] (the video-streaming capability
+/// attached to a `DeviceSession`).
+///
+/// Surfaced by `MetaWearablesDat.streamSessionStateStream()`. Mirrors the
+/// underlying `StreamSessionState` from Meta's DAT SDKs.
+enum StreamSessionState {
+  /// No stream is active.
+  stopped(0),
+
+  /// The stream has been requested but the SDK is still waiting for the
+  /// device to be ready (e.g. paired but not yet connected).
+  waitingForDevice(1),
+
+  /// The stream has been opened and is configuring.
+  starting(2),
+
+  /// Frames are flowing.
+  streaming(3),
+
+  /// The stream is paused. Pauses can be initiated by the SDK (thermal,
+  /// hinges closed, app backgrounded) and may not be triggerable from the
+  /// host app on every device generation.
+  paused(4),
+
+  /// The stream is being torn down.
+  stopping(5);
+
+  const StreamSessionState(this.value);
+
+  /// The integer used on the platform channel.
+  final int value;
+
+  /// Maps a platform-channel integer to a [StreamSessionState].
+  static StreamSessionState fromInt(int? value) {
+    switch (value) {
+      case 0:
+        return StreamSessionState.stopped;
+      case 1:
+        return StreamSessionState.waitingForDevice;
+      case 2:
+        return StreamSessionState.starting;
+      case 3:
+        return StreamSessionState.streaming;
+      case 4:
+        return StreamSessionState.paused;
+      case 5:
+        return StreamSessionState.stopping;
+      case _:
+        return StreamSessionState.stopped;
+    }
+  }
+}

--- a/app/third_party/meta_wearables_dat_flutter/lib/src/models/video_frame.dart
+++ b/app/third_party/meta_wearables_dat_flutter/lib/src/models/video_frame.dart
@@ -1,0 +1,85 @@
+import 'dart:typed_data';
+
+/// Codec of a [VideoFrame] payload emitted on the
+/// `meta_wearables_dat_flutter/video_frames` channel.
+///
+/// - [raw] is platform-defined raw planar pixel data: BGRA on iOS (with
+///   row-stride encoded in [VideoFrame.bytesPerRow]) and I420
+///   (Y/U/V concatenated to `width * height * 3/2`) on Android.
+/// - [hvc1] is HEVC NAL bytes prefixed with VPS/SPS/PPS on each keyframe.
+///   Wired by Slice G of the v0.2 implementation plan. iOS only; on
+///   Android the texture path is not available for `hvc1` because
+///   surfacing the compressed frame back into a preview requires a
+///   `MediaCodec` decoder host apps must wire themselves.
+enum VideoCodec {
+  /// Uncompressed BGRA (iOS) / I420 (Android) bytes.
+  raw,
+
+  /// HEVC (`hvc1`) NAL bytes with embedded VPS/SPS/PPS on keyframes.
+  hvc1,
+}
+
+/// One video frame pushed onto the `videoFramesStream`.
+///
+/// At 720p the raw BGRA payload is roughly 3.7 MB per frame; subscribe
+/// only while you actually need every frame. When no Dart subscriber is
+/// attached, the native side skips the per-frame serialisation
+/// entirely (see `doc/frame_processing.md`).
+class VideoFrame {
+  /// Creates a [VideoFrame].
+  const VideoFrame({
+    required this.codec,
+    required this.bytes,
+    required this.width,
+    required this.height,
+    required this.ptsUs,
+    required this.isKeyframe,
+    this.bytesPerRow,
+  });
+
+  /// Codec of [bytes].
+  final VideoCodec codec;
+
+  /// Raw payload. Format depends on [codec] / platform — see [VideoCodec].
+  final Uint8List bytes;
+
+  /// Pixel width of the frame.
+  final int width;
+
+  /// Pixel height of the frame.
+  final int height;
+
+  /// Presentation timestamp in microseconds, monotonic from session start.
+  final int ptsUs;
+
+  /// True when this is a keyframe (I-frame). Always true for [VideoCodec.raw]
+  /// frames; meaningful for [VideoCodec.hvc1].
+  final bool isKeyframe;
+
+  /// Row stride in bytes. Only set for iOS [VideoCodec.raw] frames (BGRA
+  /// row padding may differ from `width * 4`). Always `null` for Android
+  /// raw frames (I420 planes are tightly packed) and for [VideoCodec.hvc1]
+  /// frames.
+  final int? bytesPerRow;
+
+  /// Reads a [VideoFrame] from the platform-channel map.
+  factory VideoFrame.fromMap(Map<Object?, Object?> map) {
+    final codecRaw = map['codec'];
+    final codec = codecRaw == 'hvc1' ? VideoCodec.hvc1 : VideoCodec.raw;
+    final bytes = map['bytes'];
+    final bytesList = switch (bytes) {
+      final Uint8List u => u,
+      final List<int> l => Uint8List.fromList(l),
+      _ => Uint8List(0),
+    };
+    return VideoFrame(
+      codec: codec,
+      bytes: bytesList,
+      width: (map['width'] as int?) ?? 0,
+      height: (map['height'] as int?) ?? 0,
+      ptsUs: (map['ptsUs'] as int?) ?? 0,
+      isKeyframe: (map['isKeyframe'] as bool?) ?? true,
+      bytesPerRow: map['bytesPerRow'] as int?,
+    );
+  }
+}

--- a/app/third_party/meta_wearables_dat_flutter/lib/src/models/video_stream_size.dart
+++ b/app/third_party/meta_wearables_dat_flutter/lib/src/models/video_stream_size.dart
@@ -1,0 +1,37 @@
+/// Resolution of the active video stream.
+///
+/// Emitted by [MetaWearablesDat.videoStreamSizeStream] once per resolution
+/// change so a host app can size its `Texture` widget correctly:
+///
+/// ```dart
+/// final size = await stream.first;
+/// AspectRatio(
+///   aspectRatio: size.width / size.height,
+///   child: Texture(textureId: textureId),
+/// );
+/// ```
+class VideoStreamSize {
+  /// Creates a [VideoStreamSize].
+  const VideoStreamSize({required this.width, required this.height});
+
+  /// Constructs a [VideoStreamSize] from a platform-channel map.
+  factory VideoStreamSize.fromMap(Map<Object?, Object?> map) {
+    return VideoStreamSize(
+      width: (map['width'] as num?)?.toInt() ?? 0,
+      height: (map['height'] as num?)?.toInt() ?? 0,
+    );
+  }
+
+  /// Pixel width.
+  final int width;
+
+  /// Pixel height.
+  final int height;
+
+  /// Convenience for `width / height`. Returns `0` when `height` is zero
+  /// rather than `NaN`.
+  double get aspectRatio => height == 0 ? 0 : width / height;
+
+  @override
+  String toString() => 'VideoStreamSize(${width}x$height)';
+}

--- a/app/third_party/meta_wearables_dat_flutter/pubspec.yaml
+++ b/app/third_party/meta_wearables_dat_flutter/pubspec.yaml
@@ -1,0 +1,38 @@
+name: meta_wearables_dat_flutter
+description: >-
+  Unofficial Flutter plugin bridging Meta's Wearables Device Access Toolkit
+  (DAT) for Ray-Ban Meta, Oakley Meta, and Ray-Ban Display glasses.
+version: 0.7.1
+homepage: https://github.com/iSee-Labs/meta-wearables-dat-flutter
+repository: https://github.com/iSee-Labs/meta-wearables-dat-flutter
+issue_tracker: https://github.com/iSee-Labs/meta-wearables-dat-flutter/issues
+
+topics:
+  - meta
+  - wearables
+  - glasses
+  - dat
+  - flutter-plugin
+
+environment:
+  sdk: ^3.5.0
+  flutter: ">=3.32.0"
+
+dependencies:
+  flutter:
+    sdk: flutter
+  plugin_platform_interface: ^2.1.8
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  very_good_analysis: ^7.0.0
+
+flutter:
+  plugin:
+    platforms:
+      android:
+        package: com.iseelabs.meta_wearables_dat_flutter
+        pluginClass: MetaWearablesDatPlugin
+      ios:
+        pluginClass: MetaWearablesDatPlugin

--- a/app/third_party/meta_wearables_dat_flutter/test/display_test.dart
+++ b/app/third_party/meta_wearables_dat_flutter/test/display_test.dart
@@ -1,0 +1,129 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:meta_wearables_dat_flutter/meta_wearables_dat_flutter.dart';
+
+void main() {
+  group('display models', () {
+    test('DisplayState maps cleanly to and from ints', () {
+      expect(DisplayState.fromInt(0), DisplayState.starting);
+      expect(DisplayState.fromInt(1), DisplayState.started);
+      expect(DisplayState.fromInt(2), DisplayState.stopping);
+      expect(DisplayState.fromInt(3), DisplayState.stopped);
+      expect(DisplayState.fromInt(null), DisplayState.stopped);
+      expect(DisplayState.started.value, 1);
+    });
+
+    test('DisplayPlaybackEventType round-trips through the wire token', () {
+      expect(
+        DisplayPlaybackEventType.fromWire('ended'),
+        DisplayPlaybackEventType.ended,
+      );
+      expect(
+        DisplayPlaybackEventType.fromWire('bogus'),
+        DisplayPlaybackEventType.unknown,
+      );
+      final event = DisplayPlaybackEvent.fromMap(<Object?, Object?>{
+        'event': 'stopped',
+      });
+      expect(event.type, DisplayPlaybackEventType.stopped);
+    });
+
+    test('leaf nodes serialize without callbacks', () {
+      expect(
+        const DisplayText('Hi', style: DisplayTextStyle.heading).toJson(),
+        <String, Object?>{
+          'type': 'text',
+          'text': 'Hi',
+          'style': 'heading',
+        },
+      );
+      expect(
+        const DisplayImage(
+          'https://x/y.png',
+          sizePreset: DisplayImageSize.fill,
+          cornerRadius: DisplayCornerRadius.medium,
+        ).toJson(),
+        <String, Object?>{
+          'type': 'image',
+          'uri': 'https://x/y.png',
+          'sizePreset': 'fill',
+          'cornerRadius': 'medium',
+        },
+      );
+      expect(
+        const DisplayIcon(DisplayIconName.videoCamera).toJson(),
+        <String, Object?>{'type': 'icon', 'iconName': 'videoCamera'},
+      );
+    });
+
+    test('FlexBox serializes its modifiers and nested children', () {
+      const tree = FlexBox(
+        direction: DisplayDirection.row,
+        spacing: 12,
+        padding: 24,
+        background: FlexBoxBackground.card,
+        alignment: DisplayAlignment.center,
+        crossAlignment: DisplayAlignment.center,
+        flexGrow: 7,
+        children: [
+          DisplayText('Title', style: DisplayTextStyle.body),
+        ],
+      );
+      final json = tree.toJson();
+      expect(json['type'], 'flexBox');
+      expect(json['direction'], 'row');
+      expect(json['spacing'], 12);
+      expect(json['padding'], 24);
+      expect(json['background'], 'card');
+      expect(json['alignment'], 'center');
+      expect(json['crossAlignment'], 'center');
+      expect(json['flexGrow'], 7);
+      final children = json['children']! as List<Object?>;
+      expect(children, hasLength(1));
+      expect((children.first! as Map)['text'], 'Title');
+    });
+
+    test('callbacks are registered with ids and dispatched by id', () {
+      var tapped = false;
+      var clicked = false;
+      DisplayPlaybackEvent? playback;
+
+      final tree = FlexBox(
+        onTap: () => tapped = true,
+        children: [
+          DisplayButton(label: 'Go', onClick: () => clicked = true),
+          VideoPlayer(
+            'https://x/v.mp4',
+            onPlaybackEvent: (e) => playback = e,
+          ),
+        ],
+      );
+
+      final table = DisplayCallbackTable();
+      final json = tree.toJson(table);
+      expect(table.length, 3);
+
+      final onTapId = json['onTapId']! as String;
+      final children = json['children']! as List<Object?>;
+      final buttonId = (children[0]! as Map)['onClickId']! as String;
+      final videoId = (children[1]! as Map)['onPlaybackEventId']! as String;
+
+      table
+        ..dispatch(<Object?, Object?>{'callbackId': onTapId, 'type': 'tap'})
+        ..dispatch(<Object?, Object?>{'callbackId': buttonId})
+        ..dispatch(<Object?, Object?>{
+          'callbackId': videoId,
+          'type': 'playback',
+          'event': 'ended',
+        });
+
+      expect(tapped, isTrue);
+      expect(clicked, isTrue);
+      expect(playback?.type, DisplayPlaybackEventType.ended);
+    });
+
+    test('toJson without a table omits callback ids', () {
+      final json = FlexBox(onTap: () {}).toJson();
+      expect(json.containsKey('onTapId'), isFalse);
+    });
+  });
+}

--- a/app/third_party/meta_wearables_dat_flutter/test/meta_wearables_dat_flutter_test.dart
+++ b/app/third_party/meta_wearables_dat_flutter/test/meta_wearables_dat_flutter_test.dart
@@ -1,0 +1,448 @@
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:meta_wearables_dat_flutter/meta_wearables_dat_flutter.dart';
+import 'package:meta_wearables_dat_flutter/src/meta_wearables_dat_method_channel.dart';
+import 'package:meta_wearables_dat_flutter/src/meta_wearables_dat_platform_interface.dart';
+import 'package:plugin_platform_interface/plugin_platform_interface.dart';
+
+class _UnoverriddenPlatform extends MetaWearablesDatPlatform with MockPlatformInterfaceMixin {}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('models', () {
+    test('DeviceInfo can be constructed and round-tripped through fromMap', () {
+      const direct = DeviceInfo(
+        uuid: 'abc',
+        name: 'Ray-Ban Meta',
+        kind: DeviceKind.rayBanMeta,
+      );
+      expect(direct.uuid, 'abc');
+      expect(direct.kind, DeviceKind.rayBanMeta);
+
+      final parsed = DeviceInfo.fromMap(<Object?, Object?>{
+        'uuid': 'abc',
+        'name': 'Ray-Ban Meta',
+        'kind': 'rayBanMeta',
+      });
+      expect(parsed.uuid, 'abc');
+      expect(parsed.kind, DeviceKind.rayBanMeta);
+    });
+
+    test('Enums map cleanly to and from platform-channel ints / strings', () {
+      expect(RegistrationState.fromInt(3), RegistrationState.registered);
+      expect(StreamSessionState.fromInt(3), StreamSessionState.streaming);
+      expect(DeviceSessionState.fromInt(2), DeviceSessionState.started);
+      expect(DeviceSessionState.fromInt(5), DeviceSessionState.stopped);
+      expect(StreamQuality.high.width, 720);
+      expect(StreamQuality.high.height, 1280);
+      expect(StreamQuality.fpsValues, contains(30));
+      expect(DeviceKind.fromRaw('unknown_value'), DeviceKind.unknown);
+      expect(CameraFacing.front.value, 'front');
+      expect(MockPermission.camera.value, 'camera');
+      expect(MockPermissionStatus.granted.value, 'granted');
+    });
+
+    test('DatError subclasses preserve code and message', () {
+      const err = SessionError(code: 'X', message: 'boom');
+      expect(err, isA<DatError>());
+      expect(err.code, 'X');
+      expect(err.toString(), contains('SessionError'));
+      expect(err.toString(), contains('boom'));
+    });
+
+    test('SessionError is* getters key off typed sub-codes', () {
+      const thermal = SessionError(
+        code: DatErrorCodes.thermalCritical,
+        message: 'too hot',
+      );
+      expect(thermal.isThermalCritical, isTrue);
+      expect(thermal.isHingesClosed, isFalse);
+      expect(thermal.isPermissionDenied, isFalse);
+      expect(thermal.isDeviceDisconnected, isFalse);
+
+      const hinges = SessionError(
+        code: DatErrorCodes.hingesClosed,
+        message: 'hinges',
+      );
+      expect(hinges.isHingesClosed, isTrue);
+      expect(hinges.isThermalCritical, isFalse);
+    });
+
+    test('CaptureError is* getters key off typed sub-codes', () {
+      const inflight = CaptureError(
+        code: DatErrorCodes.captureInProgress,
+        message: 'already capturing',
+      );
+      expect(inflight.isCaptureInProgress, isTrue);
+      expect(inflight.isDeviceDisconnected, isFalse);
+      expect(inflight.isCaptureFailed, isFalse);
+      expect(inflight.isNotStreaming, isFalse);
+    });
+
+    test('RegistrationError is* getters key off typed sub-codes', () {
+      const config = RegistrationError(
+        code: DatErrorCodes.configurationInvalid,
+        message: 'missing MWDAT',
+      );
+      expect(config.isConfigurationInvalid, isTrue);
+      expect(config.isMetaAiNotInstalled, isFalse);
+      expect(config.isAlreadyRegistered, isFalse);
+
+      const noMetaAi = RegistrationError(
+        code: DatErrorCodes.metaAiNotInstalled,
+        message: 'no Meta AI',
+      );
+      expect(noMetaAi.isMetaAiNotInstalled, isTrue);
+      expect(noMetaAi.isConfigurationInvalid, isFalse);
+    });
+
+    test('DeviceSessionError is* getters key off typed sub-codes', () {
+      const noDevice = DeviceSessionError(
+        code: DatErrorCodes.noEligibleDevice,
+        message: 'no glasses',
+      );
+      expect(noDevice.isNoEligibleDevice, isTrue);
+      expect(noDevice.isUnexpectedError, isFalse);
+
+      const exists = DeviceSessionError(
+        code: DatErrorCodes.sessionAlreadyExists,
+        message: 'already exists',
+      );
+      expect(exists.isSessionAlreadyExists, isTrue);
+      expect(exists.isNoEligibleDevice, isFalse);
+    });
+
+    test('FrameData and PhotoResult hold their bytes', () {
+      final frame = FrameData(
+        bytes: Uint8List.fromList([1, 2, 3]),
+        width: 4,
+        height: 4,
+        format: FrameFormat.rawRgba,
+      );
+      expect(frame.bytes.length, 3);
+      expect(frame.format, FrameFormat.rawRgba);
+
+      final photo = PhotoResult(
+        bytes: Uint8List.fromList([0xff, 0xd8]),
+        format: PhotoFormat.jpeg,
+      );
+      expect(photo.format, PhotoFormat.jpeg);
+    });
+
+    test('VideoStreamSize parses platform-channel maps', () {
+      final size = VideoStreamSize.fromMap(<Object?, Object?>{
+        'width': 720,
+        'height': 1280,
+      });
+      expect(size.width, 720);
+      expect(size.height, 1280);
+      expect(size.toString(), 'VideoStreamSize(720x1280)');
+    });
+
+    test('VideoFrame parses raw + hvc1 platform-channel maps', () {
+      final raw = VideoFrame.fromMap(<Object?, Object?>{
+        'codec': 'raw',
+        'bytes': Uint8List.fromList([1, 2, 3, 4]),
+        'width': 1280,
+        'height': 720,
+        'ptsUs': 33333,
+        'isKeyframe': true,
+        'bytesPerRow': 5120,
+      });
+      expect(raw.codec, VideoCodec.raw);
+      expect(raw.bytes.length, 4);
+      expect(raw.width, 1280);
+      expect(raw.height, 720);
+      expect(raw.ptsUs, 33333);
+      expect(raw.isKeyframe, isTrue);
+      expect(raw.bytesPerRow, 5120);
+
+      final hvc1 = VideoFrame.fromMap(<Object?, Object?>{
+        'codec': 'hvc1',
+        'bytes': <int>[0, 0, 0, 1, 0x40],
+        'width': 1280,
+        'height': 720,
+        'ptsUs': 66666,
+        'isKeyframe': false,
+      });
+      expect(hvc1.codec, VideoCodec.hvc1);
+      expect(hvc1.bytes.length, 5);
+      expect(hvc1.isKeyframe, isFalse);
+      expect(hvc1.bytesPerRow, isNull);
+    });
+
+    test('BackgroundNotification serialises through toMap()', () {
+      const notif = BackgroundNotification(
+        title: 'Streaming',
+        text: 'Stay open',
+        channelId: 'ch',
+        channelName: 'Channel',
+        iconResourceName: 'ic_stream',
+      );
+      final map = notif.toMap();
+      expect(map['title'], 'Streaming');
+      expect(map['text'], 'Stay open');
+      expect(map['channelId'], 'ch');
+      expect(map['channelName'], 'Channel');
+      expect(map['iconResourceName'], 'ic_stream');
+
+      const minimal = BackgroundNotification(
+        title: 't',
+        text: 'b',
+        channelId: 'c',
+        channelName: 'C',
+      );
+      final minimalMap = minimal.toMap();
+      expect(minimalMap.containsKey('iconResourceName'), isFalse);
+    });
+
+    test('DeviceCompatibility maps wire strings to enum cases', () {
+      expect(
+        DeviceCompatibility.fromRaw('compatible'),
+        DeviceCompatibility.compatible,
+      );
+      expect(
+        DeviceCompatibility.fromRaw('deviceUpdateRequired'),
+        DeviceCompatibility.deviceUpdateRequired,
+      );
+      expect(
+        DeviceCompatibility.fromRaw('sdkUpdateRequired'),
+        DeviceCompatibility.sdkUpdateRequired,
+      );
+      expect(
+        DeviceCompatibility.fromRaw('garbage'),
+        DeviceCompatibility.unknown,
+      );
+
+      final event = DeviceCompatibilityEvent.fromMap(<Object?, Object?>{
+        'deviceUuid': 'aaaa-bbbb',
+        'compatibility': 'compatible',
+      });
+      expect(event.deviceUuid, 'aaaa-bbbb');
+      expect(event.compatibility, DeviceCompatibility.compatible);
+    });
+  });
+
+  group('platform interface', () {
+    test('default instance is the MethodChannel implementation', () {
+      expect(
+        MetaWearablesDatPlatform.instance,
+        isInstanceOf<MethodChannelMetaWearablesDat>(),
+      );
+    });
+
+    test('unimplemented members throw UnimplementedError', () {
+      MetaWearablesDatPlatform.instance = _UnoverriddenPlatform();
+      addTearDown(() {
+        MetaWearablesDatPlatform.instance = MethodChannelMetaWearablesDat();
+      });
+
+      expect(
+        MetaWearablesDat.requestAndroidPermissions,
+        throwsA(isA<UnimplementedError>()),
+      );
+      expect(
+        MetaWearablesDat.startRegistration,
+        throwsA(isA<UnimplementedError>()),
+      );
+      expect(
+        () => MetaWearablesDat.handleUrl('x'),
+        throwsA(isA<UnimplementedError>()),
+      );
+      expect(
+        MetaWearablesDat.startUnregistration,
+        throwsA(isA<UnimplementedError>()),
+      );
+      expect(
+        MetaWearablesDat.startStreamSession,
+        throwsA(isA<UnimplementedError>()),
+      );
+      expect(
+        MetaWearablesDat.capturePhoto,
+        throwsA(isA<UnimplementedError>()),
+      );
+      expect(
+        MetaWearablesDat.enableMockDevice,
+        throwsA(isA<UnimplementedError>()),
+      );
+      expect(
+        MetaWearablesDat.enableBackgroundStreaming,
+        throwsA(isA<UnimplementedError>()),
+      );
+      expect(
+        MetaWearablesDat.disableBackgroundStreaming,
+        throwsA(isA<UnimplementedError>()),
+      );
+      expect(
+        MetaWearablesDat.getDevices,
+        throwsA(isA<UnimplementedError>()),
+      );
+      expect(
+        MetaWearablesDat.videoFramesStream,
+        throwsA(isA<UnimplementedError>()),
+      );
+    });
+
+    test('fake platform implementation drives every facade method', () async {
+      final fake = _FakePlatform();
+      MetaWearablesDatPlatform.instance = fake;
+      addTearDown(() {
+        MetaWearablesDatPlatform.instance = MethodChannelMetaWearablesDat();
+      });
+
+      expect(await MetaWearablesDat.getPlatformVersion(), 'fake 1.2.3');
+      expect(await MetaWearablesDat.requestAndroidPermissions(), isTrue);
+      await MetaWearablesDat.startRegistration();
+      expect(await MetaWearablesDat.handleUrl('mywearables://callback'), isTrue);
+      expect(
+        (await MetaWearablesDat.getDevices()).first.uuid,
+        'mock-device',
+      );
+
+      // Mock kit
+      await MetaWearablesDat.enableMockDevice();
+      final uuid = await MetaWearablesDat.pairMockRayBanMeta();
+      expect(uuid, 'mock-uuid');
+      await MetaWearablesDat.setMockPermission(
+        MockPermission.camera,
+        MockPermissionStatus.granted,
+      );
+
+      // Streaming
+      final id = await MetaWearablesDat.startStreamSession(
+        deviceKinds: {DeviceKind.rayBanMeta},
+        videoCodec: VideoCodec.hvc1,
+      );
+      expect(id, 42);
+      expect(fake.lastDeviceKinds, {DeviceKind.rayBanMeta});
+      expect(fake.lastVideoCodec, VideoCodec.hvc1);
+
+      // Background streaming
+      await MetaWearablesDat.enableBackgroundStreaming(
+        androidNotification: const BackgroundNotification(
+          title: 't',
+          text: 'b',
+          channelId: 'c',
+          channelName: 'C',
+        ),
+      );
+      expect(fake.backgroundEnabled, isTrue);
+      await MetaWearablesDat.disableBackgroundStreaming();
+      expect(fake.backgroundEnabled, isFalse);
+
+      // Streams
+      expect(
+        await MetaWearablesDat.devicesStream().first,
+        hasLength(1),
+      );
+      expect(
+        (await MetaWearablesDat.compatibilityStream().first).compatibility,
+        DeviceCompatibility.compatible,
+      );
+      expect(
+        (await MetaWearablesDat.videoFramesStream().first).codec,
+        VideoCodec.raw,
+      );
+    });
+  });
+}
+
+/// Fake [MetaWearablesDatPlatform] used to make sure the facade plumbing
+/// (every static method delegates to the instance, the argument bag is
+/// forwarded faithfully) actually works without spinning up a platform
+/// channel. Mirrors the "mock-platform test" mentioned in the v0.1 plan.
+class _FakePlatform extends MetaWearablesDatPlatform with MockPlatformInterfaceMixin {
+  Set<DeviceKind>? lastDeviceKinds;
+  VideoCodec? lastVideoCodec;
+  bool backgroundEnabled = false;
+
+  @override
+  Future<String?> getPlatformVersion() async => 'fake 1.2.3';
+
+  @override
+  Future<bool> requestAndroidPermissions() async => true;
+
+  @override
+  Future<void> startRegistration({String? appId, String? urlScheme}) async {}
+
+  @override
+  Future<bool> handleUrl(String url) async => true;
+
+  @override
+  Future<List<DeviceInfo>> getDevices() async => const [
+        DeviceInfo(
+          uuid: 'mock-device',
+          name: 'Mock',
+          kind: DeviceKind.rayBanMeta,
+        ),
+      ];
+
+  @override
+  Stream<List<DeviceInfo>> devicesStream() => Stream.value(const [
+        DeviceInfo(
+          uuid: 'mock-device',
+          name: 'Mock',
+          kind: DeviceKind.rayBanMeta,
+        ),
+      ]);
+
+  @override
+  Stream<DeviceCompatibilityEvent> compatibilityStream() => Stream.value(
+        const DeviceCompatibilityEvent(
+          deviceUuid: 'mock-device',
+          compatibility: DeviceCompatibility.compatible,
+        ),
+      );
+
+  @override
+  Stream<VideoFrame> videoFramesStream() => Stream.value(
+        VideoFrame(
+          codec: VideoCodec.raw,
+          bytes: Uint8List(0),
+          width: 1280,
+          height: 720,
+          ptsUs: 0,
+          isKeyframe: true,
+          bytesPerRow: 5120,
+        ),
+      );
+
+  @override
+  Future<void> enableMockDevice({
+    bool initiallyRegistered = true,
+    bool initialPermissionsGranted = true,
+  }) async {}
+
+  @override
+  Future<String> pairMockRayBanMeta() async => 'mock-uuid';
+
+  @override
+  Future<void> setMockPermission(String permission, String status) async {}
+
+  @override
+  Future<int> startStreamSession({
+    String? deviceUUID,
+    int fps = 30,
+    StreamQuality quality = StreamQuality.medium,
+    Set<DeviceKind>? deviceKinds,
+    VideoCodec videoCodec = VideoCodec.raw,
+  }) async {
+    lastDeviceKinds = deviceKinds;
+    lastVideoCodec = videoCodec;
+    return 42;
+  }
+
+  @override
+  Future<void> enableBackgroundStreaming({
+    BackgroundNotification? androidNotification,
+  }) async {
+    backgroundEnabled = true;
+  }
+
+  @override
+  Future<void> disableBackgroundStreaming() async {
+    backgroundEnabled = false;
+  }
+}


### PR DESCRIPTION
Theory
Meta glasses capture failed because the app lacked a checked-in DAT bridge plus app-level registration, queue, watchdog, and capture-cache contracts. #9084 mixed that with docs/examples/auth/device-list work, so this PR keeps only the runtime path.

Scope
- Adds local Meta Wearables DAT Flutter bridge runtime only.
- Adds Meta glasses page, provider, capture queue/watchdog/diagnostics, onboarding step, and photo cache handoff.
- Adds iOS remote-command gesture bridge for glasses tap gestures.
- Adds l10n keys needed by the UI.

Cut from #9084
- Meta reference docs and plugin example app.
- Auth env changes.
- Unrelated multi-device saved-device work.
- On-device transcription quality gate.
- Generated iOS ephemeral files.

Tests
- Red first: `flutter test test/unit/meta_glasses_relay_queue_test.dart` failed before DAT/runtime files existed.
- Green: Meta focused batch passed, including relay queue, health, display, runtime regression, session pause, watchdog, continuous vision, background stream contract, contract behavior, sanitize, onboarding widget.

Notes
- Draft PR. Surgical replacement for the Meta glasses slice of #9084.
- Low overlap with #9181; this branch does not touch `app/lib/pages/home/page.dart`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9310?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

