### PR TITLE
feat(app): preserve multiple saved devices

### DIFF
--- a/app/lib/backend/preferences.dart
+++ b/app/lib/backend/preferences.dart
@@ -49,16 +49,70 @@ class SharedPreferencesUtil {
 
   set btDevice(BtDevice value) {
     saveString('btDevice', jsonEncode(value.toJson()));
+    if (value.id.isNotEmpty) {
+      final devices = _upsertBtDevice(value);
+      saveStringList('btDevices', devices.map((device) => jsonEncode(device.toJson())).toList());
+    }
   }
 
   Future<void> btDeviceSet(BtDevice value) async {
     await saveString('btDevice', jsonEncode(value.toJson()));
+    await btDeviceAdd(value);
   }
 
   BtDevice get btDevice {
-    final String device = getString('btDevice') ?? '';
+    final String device = getString('btDevice');
     if (device.isEmpty) return BtDevice(id: '', name: '', type: DeviceType.omi, rssi: 0);
     return BtDevice.fromJson(jsonDecode(device));
+  }
+
+  List<BtDevice> get btDevices {
+    final devices = <BtDevice>[];
+    for (final encodedDevice in getStringList('btDevices')) {
+      try {
+        final decoded = jsonDecode(encodedDevice);
+        if (decoded is Map<String, dynamic>) {
+          final device = BtDevice.fromJson(decoded);
+          if (device.id.isNotEmpty && !devices.any((savedDevice) => savedDevice.id == device.id)) {
+            devices.add(device);
+          }
+        }
+      } catch (e) {
+        Logger.debug('Error decoding saved device: $e');
+      }
+    }
+
+    final legacyDevice = btDevice;
+    if (devices.isEmpty && legacyDevice.id.isNotEmpty) {
+      devices.add(legacyDevice);
+    }
+    return devices;
+  }
+
+  Future<void> btDeviceAdd(BtDevice value) async {
+    if (value.id.isEmpty) return;
+    final devices = _upsertBtDevice(value);
+    await saveStringList('btDevices', devices.map((device) => jsonEncode(device.toJson())).toList());
+    await saveString('btDevice', jsonEncode(value.toJson()));
+  }
+
+  Future<void> btDeviceRemove(String id) async {
+    final devices = btDevices.where((device) => device.id != id).toList();
+    await saveStringList('btDevices', devices.map((device) => jsonEncode(device.toJson())).toList());
+    if (btDevice.id == id) {
+      await remove('btDevice');
+    }
+  }
+
+  List<BtDevice> _upsertBtDevice(BtDevice value) {
+    final devices = btDevices;
+    final index = devices.indexWhere((device) => device.id == value.id);
+    if (index >= 0) {
+      devices[index] = value;
+    } else {
+      devices.add(value);
+    }
+    return devices;
   }
 
   set deviceName(String value) => saveString('deviceName', value);

--- a/app/lib/backend/preferences.dart
+++ b/app/lib/backend/preferences.dart
@@ -96,14 +96,6 @@ class SharedPreferencesUtil {
     await saveString('btDevice', jsonEncode(value.toJson()));
   }
 
-  Future<void> btDeviceRemove(String id) async {
-    final devices = btDevices.where((device) => device.id != id).toList();
-    await saveStringList('btDevices', devices.map((device) => jsonEncode(device.toJson())).toList());
-    if (btDevice.id == id) {
-      await remove('btDevice');
-    }
-  }
-
   List<BtDevice> _upsertBtDevice(BtDevice value) {
     final devices = btDevices;
     final index = devices.indexWhere((device) => device.id == value.id);

--- a/app/lib/pages/onboarding/find_device/found_devices.dart
+++ b/app/lib/pages/onboarding/find_device/found_devices.dart
@@ -206,7 +206,7 @@ class _FoundDevicesState extends State<FoundDevices> {
 
     if (!isCritical) {
       final prefKey = 'firmware_warning_acknowledged_${device.type.toString()}';
-      final alreadyAcknowledged = SharedPreferencesUtil().getBool(prefKey) ?? false;
+      final alreadyAcknowledged = SharedPreferencesUtil().getBool(prefKey);
       if (alreadyAcknowledged) {
         return; // User already acknowledged this warning
       }
@@ -248,6 +248,7 @@ class _FoundDevicesState extends State<FoundDevices> {
   Widget build(BuildContext context) {
     return Consumer<OnboardingProvider>(
       builder: (context, provider, child) {
+        final visibleDevices = provider.visibleDeviceList;
         return MessageListener<OnboardingProvider>(
           showError: (error) {
             ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(error), backgroundColor: Colors.red));
@@ -271,21 +272,21 @@ class _FoundDevicesState extends State<FoundDevices> {
             children: [
               !provider.isConnected
                   ? Text(
-                      provider.deviceList.isEmpty
+                      visibleDevices.isEmpty
                           ? context.l10n.searchingForDevices
-                          : context.l10n.devicesFoundNearby(provider.deviceList.length),
+                          : context.l10n.devicesFoundNearby(visibleDevices.length),
                       style: const TextStyle(fontWeight: FontWeight.w400, fontSize: 14, color: Color(0x66FFFFFF)),
                     )
                   : Text(
                       context.l10n.pairingSuccessful,
                       style: const TextStyle(fontWeight: FontWeight.w400, fontSize: 12, color: Color(0x66FFFFFF)),
                     ),
-              if (provider.deviceList.isNotEmpty) const SizedBox(height: 16),
+              if (visibleDevices.isNotEmpty) const SizedBox(height: 16),
               if (!provider.isConnected) ..._devicesList(provider),
               if (provider.isConnected)
                 Text(
                   () {
-                    final sameNameCount = provider.deviceList.where((d) => d.name == provider.deviceName).length;
+                    final sameNameCount = provider.visibleDeviceList.where((d) => d.name == provider.deviceName).length;
                     return sameNameCount > 1
                         ? '${provider.deviceName} (${BtDevice.shortId(provider.deviceId)})'
                         : provider.deviceName;
@@ -318,7 +319,7 @@ class _FoundDevicesState extends State<FoundDevices> {
   }
 
   _devicesList(OnboardingProvider provider) {
-    return (provider.deviceList.mapIndexed((index, device) {
+    return (provider.visibleDeviceList.mapIndexed((index, device) {
       bool isConnecting = provider.connectingToDeviceId == device.id;
 
       return GestureDetector(
@@ -368,34 +369,44 @@ class _FoundDevicesState extends State<FoundDevices> {
               Expanded(
                 child: Padding(
                   padding: const EdgeInsets.symmetric(vertical: 16.0),
-                  child: Stack(
+                  child: Row(
                     children: [
-                      Align(
-                        alignment: Alignment.centerLeft,
+                      Expanded(
                         child: Text(
                           () {
-                            final sameNameCount = provider.deviceList.where((d) => d.name == device.name).length;
+                            final sameNameCount = provider.visibleDeviceList.where((d) => d.name == device.name).length;
                             return sameNameCount > 1 ? '${device.name} (${device.getShortId()})' : device.name;
                           }(),
                           textAlign: TextAlign.left,
+                          overflow: TextOverflow.ellipsis,
                           style: const TextStyle(fontWeight: FontWeight.w500, fontSize: 18, color: Colors.black),
                         ),
                       ),
-                      Align(
-                        alignment: Alignment.centerRight,
-                        child: Padding(
-                          padding: const EdgeInsets.only(right: 16.0),
-                          child: isConnecting
-                              ? const SizedBox(
-                                  height: 20,
-                                  width: 20,
-                                  child: CircularProgressIndicator(
-                                    strokeWidth: 2,
-                                    valueColor: AlwaysStoppedAnimation<Color>(Colors.black),
-                                  ),
-                                )
-                              : const SizedBox.shrink(),
+                      if (provider.isSavedDevice(device))
+                        Container(
+                          margin: const EdgeInsets.only(left: 8, right: 12),
+                          padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                          decoration: BoxDecoration(
+                            color: const Color(0xFFEFEFEF),
+                            borderRadius: BorderRadius.circular(8),
+                          ),
+                          child: Text(
+                            context.l10n.saved,
+                            style: const TextStyle(fontWeight: FontWeight.w600, fontSize: 12, color: Colors.black54),
+                          ),
                         ),
+                      Padding(
+                        padding: const EdgeInsets.only(right: 16.0),
+                        child: isConnecting
+                            ? const SizedBox(
+                                height: 20,
+                                width: 20,
+                                child: CircularProgressIndicator(
+                                  strokeWidth: 2,
+                                  valueColor: AlwaysStoppedAnimation<Color>(Colors.black),
+                                ),
+                              )
+                            : const SizedBox.shrink(),
                       ),
                     ],
                   ),

--- a/app/lib/pages/onboarding/find_device/found_devices.dart
+++ b/app/lib/pages/onboarding/find_device/found_devices.dart
@@ -272,9 +272,9 @@ class _FoundDevicesState extends State<FoundDevices> {
             children: [
               !provider.isConnected
                   ? Text(
-                      visibleDevices.isEmpty
+                      provider.nearbyDeviceCount == 0
                           ? context.l10n.searchingForDevices
-                          : context.l10n.devicesFoundNearby(visibleDevices.length),
+                          : context.l10n.devicesFoundNearby(provider.nearbyDeviceCount),
                       style: const TextStyle(fontWeight: FontWeight.w400, fontSize: 14, color: Color(0x66FFFFFF)),
                     )
                   : Text(
@@ -321,10 +321,20 @@ class _FoundDevicesState extends State<FoundDevices> {
   _devicesList(OnboardingProvider provider) {
     return (provider.visibleDeviceList.mapIndexed((index, device) {
       bool isConnecting = provider.connectingToDeviceId == device.id;
+      final isOfflineSavedDevice = provider.isSavedDevice(device) && !provider.isDeviceOnline(device);
 
       return GestureDetector(
         onTap: !provider.isClicked
             ? () async {
+                if (isOfflineSavedDevice) {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    SnackBar(
+                      content: Text(context.l10n.offline),
+                      action: SnackBarAction(label: context.l10n.retry, onPressed: () {}),
+                    ),
+                  );
+                  return;
+                }
                 if (device.type == DeviceType.appleWatch) {
                   await _handleAppleWatchOnboarding(device, provider);
                 } else if (device.type == DeviceType.raybanMeta) {
@@ -391,7 +401,7 @@ class _FoundDevicesState extends State<FoundDevices> {
                             borderRadius: BorderRadius.circular(8),
                           ),
                           child: Text(
-                            context.l10n.saved,
+                            isOfflineSavedDevice ? context.l10n.offline : context.l10n.saved,
                             style: const TextStyle(fontWeight: FontWeight.w600, fontSize: 12, color: Colors.black54),
                           ),
                         ),

--- a/app/lib/providers/onboarding_provider.dart
+++ b/app/lib/providers/onboarding_provider.dart
@@ -58,6 +58,10 @@ class OnboardingProvider extends BaseProvider with MessageNotifierMixin implemen
 
   bool isSavedDevice(BtDevice device) => savedDeviceList.any((savedDevice) => savedDevice.id == device.id);
 
+  bool isDeviceOnline(BtDevice device) => foundDevicesMap.containsKey(device.id);
+
+  int get nearbyDeviceCount => deviceList.length;
+
   void _syncSavedDevices() {
     savedDeviceList = SharedPreferencesUtil().btDevices.where((device) => device.id.isNotEmpty).toList();
   }

--- a/app/lib/providers/onboarding_provider.dart
+++ b/app/lib/providers/onboarding_provider.dart
@@ -33,9 +33,34 @@ class OnboardingProvider extends BaseProvider with MessageNotifierMixin implemen
   String deviceId = '';
   String? connectingToDeviceId;
   List<BtDevice> deviceList = [];
-  late Timer _didNotMakeItTimer;
+  List<BtDevice> savedDeviceList = [];
+  Timer? _didNotMakeItTimer;
   bool enableInstructions = false;
   Map<String, BtDevice> foundDevicesMap = {};
+
+  OnboardingProvider() {
+    _syncSavedDevices();
+  }
+
+  List<BtDevice> get visibleDeviceList {
+    final visibleDevices = <BtDevice>[];
+    for (final savedDevice in savedDeviceList) {
+      final onlineDevice = foundDevicesMap[savedDevice.id];
+      visibleDevices.add(onlineDevice ?? savedDevice);
+    }
+    for (final device in deviceList) {
+      if (!visibleDevices.any((visibleDevice) => visibleDevice.id == device.id)) {
+        visibleDevices.add(device);
+      }
+    }
+    return visibleDevices;
+  }
+
+  bool isSavedDevice(BtDevice device) => savedDeviceList.any((savedDevice) => savedDevice.id == device.id);
+
+  void _syncSavedDevices() {
+    savedDeviceList = SharedPreferencesUtil().btDevices.where((device) => device.id.isNotEmpty).toList();
+  }
 
   //----------------- Onboarding Permissions -----------------
   bool hasBluetoothPermission = false;
@@ -197,6 +222,7 @@ class OnboardingProvider extends BaseProvider with MessageNotifierMixin implemen
       Logger.debug('Connected to device: ${device.name}');
       deviceId = device.id;
       await SharedPreferencesUtil().btDeviceSet(device);
+      _syncSavedDevices();
       deviceName = device.name;
       deviceType = device.type;
       var cDevice = await _getConnectedDevice(deviceId);
@@ -214,6 +240,7 @@ class OnboardingProvider extends BaseProvider with MessageNotifierMixin implemen
       notifyListeners();
       await Future.delayed(const Duration(seconds: 2));
       SharedPreferencesUtil().btDevice = connectedDevice!;
+      _syncSavedDevices();
       SharedPreferencesUtil().deviceName = connectedDevice.name;
 
       foundDevicesMap.clear();
@@ -225,8 +252,10 @@ class OnboardingProvider extends BaseProvider with MessageNotifierMixin implemen
       }
     } catch (e) {
       Logger.debug('Error connecting to device: $e');
-      foundDevicesMap.remove(device.id);
-      deviceList.removeWhere((element) => element.id == device.id);
+      if (!isSavedDevice(device)) {
+        foundDevicesMap.remove(device.id);
+        deviceList.removeWhere((element) => element.id == device.id);
+      }
       isClicked = false; // Allow clicks again after finishing the operation
       connectingToDeviceId = null; // Reset the connecting device
       deviceProvider!.setIsConnected(false);
@@ -293,7 +322,7 @@ class OnboardingProvider extends BaseProvider with MessageNotifierMixin implemen
 
   @override
   void dispose() {
-    _didNotMakeItTimer.cancel();
+    _didNotMakeItTimer?.cancel();
     ServiceManager.instance().device.unsubscribe(this);
     super.dispose();
   }
@@ -305,6 +334,7 @@ class OnboardingProvider extends BaseProvider with MessageNotifierMixin implemen
 
   @override
   void onDevices(List<BtDevice> devices) {
+    _syncSavedDevices();
     List<BtDevice> foundDevices = devices;
 
     // Update foundDevicesMap with new devices and remove the ones not found anymore
@@ -322,10 +352,10 @@ class OnboardingProvider extends BaseProvider with MessageNotifierMixin implemen
 
     // Convert the values of the map back to a list
     List<BtDevice> orderedDevices = foundDevicesMap.values.toList();
-    if (orderedDevices.isNotEmpty) {
-      deviceList = orderedDevices;
+    deviceList = orderedDevices;
+    if (orderedDevices.isNotEmpty || savedDeviceList.isNotEmpty) {
       notifyListeners();
-      _didNotMakeItTimer.cancel();
+      _didNotMakeItTimer?.cancel();
     }
   }
 

--- a/app/test/providers/onboarding_provider_multi_device_test.dart
+++ b/app/test/providers/onboarding_provider_multi_device_test.dart
@@ -51,5 +51,20 @@ void main() {
       expect(provider.visibleDeviceList[1].name, 'Saved Online');
       expect(provider.visibleDeviceList[1].rssi, -30);
     });
+
+    test('nearby count and online state ignore saved devices that are not advertising', () async {
+      final savedOffline = _device(id: 'AA:AA:AA:AA:AA:01', name: 'Saved Offline');
+      final liveNew = _device(id: 'AA:AA:AA:AA:AA:02', name: 'New Nearby', rssi: -45);
+
+      await SharedPreferencesUtil().btDeviceSet(savedOffline);
+
+      final provider = OnboardingProvider();
+      provider.onDevices([liveNew]);
+
+      expect(provider.visibleDeviceList.map((device) => device.id), [savedOffline.id, liveNew.id]);
+      expect(provider.nearbyDeviceCount, 1);
+      expect(provider.isDeviceOnline(savedOffline), isFalse);
+      expect(provider.isDeviceOnline(liveNew), isTrue);
+    });
   });
 }

--- a/app/test/providers/onboarding_provider_multi_device_test.dart
+++ b/app/test/providers/onboarding_provider_multi_device_test.dart
@@ -1,0 +1,55 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:omi/backend/preferences.dart';
+import 'package:omi/backend/schema/bt_device/bt_device.dart';
+import 'package:omi/providers/onboarding_provider.dart';
+
+BtDevice _device({
+  required String id,
+  required String name,
+  DeviceType type = DeviceType.omi,
+  int rssi = -60,
+}) =>
+    BtDevice(id: id, name: name, type: type, rssi: rssi);
+
+void main() {
+  setUp(() async {
+    TestWidgetsFlutterBinding.ensureInitialized();
+    SharedPreferences.setMockInitialValues({});
+    await SharedPreferencesUtil.init();
+  });
+
+  group('multi-device saved devices', () {
+    test('btDeviceSet appends unique saved devices without dropping the active device', () async {
+      final first = _device(id: 'AA:AA:AA:AA:AA:01', name: 'Omi One');
+      final second = _device(id: 'AA:AA:AA:AA:AA:02', name: 'Omi Two', rssi: -40);
+
+      await SharedPreferencesUtil().btDeviceSet(first);
+      await SharedPreferencesUtil().btDeviceSet(second);
+      await SharedPreferencesUtil().btDeviceSet(second.copyWith(name: 'Omi Two Nearby', rssi: -35));
+
+      expect(SharedPreferencesUtil().btDevice.id, second.id);
+      expect(SharedPreferencesUtil().btDevices.map((device) => device.id), [first.id, second.id]);
+      expect(SharedPreferencesUtil().btDevices.last.name, 'Omi Two Nearby');
+    });
+
+    test('visibleDeviceList keeps offline saved devices and replaces them with live scan data', () async {
+      final savedOffline = _device(id: 'AA:AA:AA:AA:AA:01', name: 'Saved Offline');
+      final savedOnline = _device(id: 'AA:AA:AA:AA:AA:02', name: 'Saved Old', rssi: -80);
+      final liveOnline = savedOnline.copyWith(name: 'Saved Online', rssi: -30);
+      final liveNew = _device(id: 'AA:AA:AA:AA:AA:03', name: 'New Nearby', rssi: -45);
+
+      await SharedPreferencesUtil().btDeviceSet(savedOffline);
+      await SharedPreferencesUtil().btDeviceSet(savedOnline);
+
+      final provider = OnboardingProvider();
+      provider.onDevices([liveOnline, liveNew]);
+
+      expect(provider.savedDeviceList.map((device) => device.id), [savedOffline.id, savedOnline.id]);
+      expect(provider.visibleDeviceList.map((device) => device.id), [savedOffline.id, savedOnline.id, liveNew.id]);
+      expect(provider.visibleDeviceList[1].name, 'Saved Online');
+      expect(provider.visibleDeviceList[1].rssi, -30);
+    });
+  });
+}


### PR DESCRIPTION
Theory
Multi-device support failed because the app persisted one active BLE device and the onboarding scanner rendered only live scan results. A second saved device displaced the first, and offline saved devices disappeared from the connect flow.

Scope
- Adds `SharedPreferencesUtil.btDevices` list storage with legacy `btDevice` fallback.
- Keeps `btDeviceSet` updating active device while preserving unique saved devices.
- Adds `OnboardingProvider.savedDeviceList` and `visibleDeviceList`.
- Updates Find Devices UI to render saved offline devices and replace them with live scan data when seen.

Cut from #9084
- Meta glasses provider/page/runtime.
- On-device transcription.
- Android/iOS native recording churn.
- Docs/plugin examples/auth changes.

Tests
- Red first: `flutter test test/providers/onboarding_provider_multi_device_test.dart` failed on missing `btDevices`, `savedDeviceList`, and `visibleDeviceList`.
- Green: `flutter test test/providers/onboarding_provider_multi_device_test.dart`.
- Green: `dart analyze lib/backend/preferences.dart lib/providers/onboarding_provider.dart lib/pages/onboarding/find_device/found_devices.dart test/providers/onboarding_provider_multi_device_test.dart`.

Notes
- Draft PR. Surgical generic multi-device persistence/UI slice of #9084.
- Low overlap with #9181; this branch does not touch `app/lib/pages/home/page.dart`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9311?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

