### PR TITLE
chore(app): bump version to 1.0.543+981 for mobile release

### DIFF
--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -3,7 +3,7 @@ description: A new Flutter project.
 
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.542+980
+version: 1.0.543+981
 
 
 environment:


### PR DESCRIPTION
## Summary

- Bump app version from `1.0.542+980` to `1.0.543+981` for mobile release
- Pre-deployment test results: 13 PASS / 0 FAIL (all P0 + P1 pass)

## Release Checklist

- [x] Pre-deployment tests passed (issue #9307)
- [x] Bump version in `app/pubspec.yaml`
- [x] Create branch + PR for version bump
- [ ] Merge PR (no squash)
- [ ] Tag with `v1.0.543+981-mobile-cm` to trigger Codemagic build
- [ ] Verify Codemagic build completes

## Test Evidence

Full test results and evidence: #9307

_by AI for @beastoin_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9314?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

