### PR TITLE
fix(desktop): stabilize notch floating-bar hover expansion

### DIFF
--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift
@@ -306,15 +306,14 @@ struct FloatingControlBarView: View {
         .contentShape(Rectangle())
         .contextMenu { barContextMenu }
         .onHover(perform: handleBarHover)
-        .animation(.spring(response: 0.22, dampingFraction: 0.9), value: state.showingAIConversation)
-        .animation(.spring(response: 0.18, dampingFraction: 0.9), value: shouldShowNotchHoverMenu)
         .onChange(of: shouldShowNotchHoverMenu) { _, visible in
-            (window as? FloatingControlBarWindow)?.resizeForAgentSwitcher(visible: visible)
-            // Open: a graceful unfurl. Close: furl faster than the panel collapses so the
-            // dots are back in the notch before the surface shrinks (no stranded dots).
+            // NSPanel owns geometry. This value only fades/morphs the row
+            // contents, using a monotonic curve so it cannot overshoot
+            // vertically. Match the window's expand/collapse durations exactly
+            // so the rows and the panel finish together (no post-expand slide).
             let morphAnim: Animation = visible
-                ? .spring(response: 0.34, dampingFraction: 0.86)
-                : .spring(response: 0.18, dampingFraction: 0.92)
+                ? .easeOut(duration: FloatingControlBarWindow.notchHoverMenuExpandDuration)
+                : .easeOut(duration: FloatingControlBarWindow.notchHoverMenuCollapseDuration)
             withAnimation(morphAnim) {
                 notchSwitcherProgress = visible ? 1 : 0
             }

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
@@ -130,6 +130,14 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
     static let pttHintRowHeight: CGFloat = 30
     private static let askOmiAnimationDuration: TimeInterval = 0.14
     private static let askOmiSettleDelay: TimeInterval = 0.16
+    /// Hover-menu (agent switcher) expand/collapse timing. The NSPanel frame
+    /// animation and the SwiftUI content morph (`notchSwitcherProgress`) MUST
+    /// share these durations so the panel and its rows finish together. A
+    /// slower window (the previous 0.3s default) made the surface keep sliding
+    /// open for ~0.14s after the rows had already settled — read as the bar
+    /// "expanding, then sliding".
+    static let notchHoverMenuExpandDuration: TimeInterval = 0.16
+    static let notchHoverMenuCollapseDuration: TimeInterval = 0.10
     private static let frameNoopEpsilon: CGFloat = 0.5
     private static let startupDisplayRevalidationDelays: [TimeInterval] = [0.2, 0.8, 2.0]
     private static let topInset: CGFloat = 40
@@ -253,12 +261,13 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
     private func responseGlowWindowSizeForCurrentScreen(forSurfaceSize size: NSSize) -> NSSize {
         responseGlowWindowSize(forSurfaceSize: size, usesNotchIsland: notchModeEnabled)
     }
-    private func notchHoverMenuWindowSize(agentCount: Int) -> NSSize {
+    /// Bare hover-menu surface size. `resizeAnchored` adds the transparent glow
+    /// outsets exactly once when converting this to an NSPanel frame.
+    private func notchHoverMenuSurfaceSize(agentCount: Int) -> NSSize {
         NSSize(
             width: max(collapsedBarSize.width, Self.notchExpandedWidth),
             height: notchChromeHeightForCurrentScreen
                 + Self.notchHoverMenuHeight(agentCount: agentCount)
-                + Self.notchGlowOutsetBottom
         )
     }
     private func currentResponseSurfaceHeight(usesNotchIsland: Bool? = nil) -> CGFloat {
@@ -586,8 +595,15 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
     private func performSpacesTransitionGrowIn() {
         updateNotchIslandState()
         guard notchModeEnabled, isVisible else { return }
+        // The panel already lives on every Space (.canJoinAllSpaces), so switching
+        // Spaces must NOT replay the reveal "pop" — doing so re-zoomed the island on
+        // every desktop/app switch, which felt excessive. Keep it fully revealed and
+        // only re-assert the resting frame if the current one has actually drifted
+        // (e.g. the active screen's notch geometry changed).
+        state.notchRevealProgress = 1
         let targetFrame = defaultFrameForCurrentState()
-        animateGrowOutFromNotch(to: targetFrame)
+        guard !Self.framesEquivalent(frame, targetFrame) else { return }
+        resizeToFrame(targetFrame, makeResizable: styleMask.contains(.resizable), animated: false)
     }
 
     private func defaultFrameForCurrentState() -> NSRect {
@@ -780,13 +796,11 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
         let allowed = visible && state.canShowNotchHoverMenu
         guard state.notchHoverMenuOpen != allowed else { return }
 
-        if allowed {
-            resizeForAgentSwitcher(visible: true)
-            state.setNotchHoverMenuOpen(true)
-        } else {
-            state.setNotchHoverMenuOpen(false)
-            resizeForAgentSwitcher(visible: false)
-        }
+        // Update content and frame from one authority. The menu is inserted
+        // before expansion so it is progressively revealed by the top-anchored
+        // NSPanel resize; on close it disappears before the panel contracts.
+        state.setNotchHoverMenuOpen(allowed)
+        resizeForAgentSwitcher(visible: allowed)
     }
 
     fileprivate func acceptsMouseHit(inContentPoint point: NSPoint) -> Bool {
@@ -843,7 +857,7 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
                 } else if self.state.isAgentSwitcherExpanded && !AgentPillsManager.shared.pills.isEmpty {
                     // Keep the notch switcher expanded so pinned/hover-open rows
                     // are not clipped when pills are added or removed.
-                    targetSize = self.notchHoverMenuWindowSize(agentCount: AgentPillsManager.shared.pills.count)
+                    targetSize = self.notchHoverMenuSurfaceSize(agentCount: AgentPillsManager.shared.pills.count)
                 } else {
                     targetSize = self.collapsedBarSize
                 }
@@ -1339,9 +1353,6 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
 
     /// Top-center: keeps top edge fixed, centers horizontally (used by chat expand/collapse).
     private func originForTopCenterAnchor(newSize: NSSize) -> NSPoint {
-        if notchModeEnabled {
-            return defaultTopCenteredOrigin(for: newSize)
-        }
         return FloatingControlBarGeometry.topCenterAnchoredFrame(currentFrame: frame, targetSize: newSize).origin
     }
 
@@ -1368,17 +1379,6 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
             : originForCenterAnchor(newSize: constrainedSize)
 
         let targetFrame = NSRect(origin: newOrigin, size: constrainedSize)
-        if animated, anchorTop, notchModeEnabled {
-            let currentTopCenteredFrame = NSRect(
-                origin: originForTopCenterAnchor(newSize: frame.size),
-                size: frame.size
-            )
-            if abs(frame.midX - targetFrame.midX) > 0.5
-                || abs(currentTopCenteredFrame.minY - frame.minY) > 0.5
-            {
-                setFrame(currentTopCenteredFrame, display: true, animate: false)
-            }
-        }
         resizeToFrame(
             targetFrame,
             makeResizable: makeResizable,
@@ -1528,7 +1528,7 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
         guard notchModeEnabled || !state.isNotchHoverMenuVisible else { return false }
         guard !notchModeEnabled else {
             let targetSize = expanded
-                ? notchHoverMenuWindowSize(agentCount: AgentPillsManager.shared.pills.count)
+                ? notchHoverMenuSurfaceSize(agentCount: AgentPillsManager.shared.pills.count)
                 : collapsedBarSize
             resizeAnchored(
                 to: targetSize,
@@ -1622,15 +1622,32 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
 
         if visible {
             let expandedSize = notchModeEnabled
-                ? notchHoverMenuWindowSize(agentCount: AgentPillsManager.shared.pills.count)
+                ? notchHoverMenuSurfaceSize(agentCount: AgentPillsManager.shared.pills.count)
                 : pillAgentListWindowSize(agentCount: AgentPillsManager.shared.pills.count)
-            resizeAnchored(to: expandedSize, makeResizable: false, animated: true, anchorTop: true)
+            resizeAnchored(
+                to: expandedSize,
+                makeResizable: false,
+                animated: true,
+                animationDuration: Self.notchHoverMenuExpandDuration,
+                anchorTop: true
+            )
         } else if notchModeEnabled {
-            resizeAnchored(to: collapsedBarSize, makeResizable: false, animated: true, anchorTop: true)
+            resizeAnchored(
+                to: collapsedBarSize,
+                makeResizable: false,
+                animated: true,
+                animationDuration: Self.notchHoverMenuCollapseDuration,
+                anchorTop: true
+            )
         } else {
             // Collapse to the canonical pill position, not the current midX —
             // see canonicalCollapsedPillFrame.
-            resizeToFrame(canonicalCollapsedPillFrame(), makeResizable: false, animated: true)
+            resizeToFrame(
+                canonicalCollapsedPillFrame(),
+                makeResizable: false,
+                animated: true,
+                animationDuration: Self.notchHoverMenuCollapseDuration
+            )
         }
     }
 

--- a/desktop/macos/Desktop/Tests/AgentPillLifecycleTests.swift
+++ b/desktop/macos/Desktop/Tests/AgentPillLifecycleTests.swift
@@ -419,8 +419,15 @@ final class AgentPillLifecycleTests: XCTestCase {
     XCTAssertTrue(source.contains("static func quadraticBezier(from start: CGPoint, control: CGPoint, to end: CGPoint, progress: CGFloat) -> CGPoint"))
     XCTAssertTrue(source.contains("let rowRevealProgress = NotchAgentStackMetrics.smoothStep((progress - 0.38) / 0.62)"))
     XCTAssertTrue(source.contains("let logoPlaceholderProgress = NotchAgentStackMetrics.smoothStep(progress / 0.42)"))
-    XCTAssertTrue(source.contains("? .spring(response: 0.34, dampingFraction: 0.86)"))
-    XCTAssertTrue(source.contains(": .spring(response: 0.18, dampingFraction: 0.92)"))
+    // The hover-menu content morph must share the window's expand/collapse
+    // durations (see notchHoverMenuExpand/CollapseDuration) so the rows and the
+    // NSPanel finish together — a duration mismatch made the surface keep
+    // sliding open after the rows settled ("expands, then slides").
+    XCTAssertTrue(source.contains("? .easeOut(duration: FloatingControlBarWindow.notchHoverMenuExpandDuration)"))
+    XCTAssertTrue(source.contains(": .easeOut(duration: FloatingControlBarWindow.notchHoverMenuCollapseDuration)"))
+    XCTAssertEqual(FloatingControlBarWindow.notchHoverMenuExpandDuration, 0.16, accuracy: 0.0001)
+    XCTAssertEqual(FloatingControlBarWindow.notchHoverMenuCollapseDuration, 0.10, accuracy: 0.0001)
+    XCTAssertFalse(source.contains(".animation(.spring(response: 0.18, dampingFraction: 0.9), value: shouldShowNotchHoverMenu)"))
     XCTAssertTrue(source.contains(".transition(.identity)"))
     XCTAssertTrue(source.contains("notchOmiChatRow\n                            .frame(width: notchHoverRowWidth, height: FloatingControlBarWindow.notchAgentListRowHeight)"))
     XCTAssertTrue(source.contains(".allowsHitTesting(!shouldUseOmiChatOverlayHitTarget && notchSwitcherProgress > 0.6)"))
@@ -475,8 +482,8 @@ final class AgentPillLifecycleTests: XCTestCase {
     XCTAssertFalse(source.contains(".strokeBorder(Color.white.opacity(0.10 * Double(progress)), lineWidth: 0.6)"))
     XCTAssertTrue(windowSource.contains("private static let askOmiAnimationDuration: TimeInterval = 0.14"))
     XCTAssertTrue(windowSource.contains("private static let askOmiSettleDelay: TimeInterval = 0.16"))
-    XCTAssertTrue(windowSource.contains("let currentTopCenteredFrame = NSRect("))
-    XCTAssertTrue(windowSource.contains("abs(frame.midX - targetFrame.midX) > 0.5"))
+    XCTAssertTrue(windowSource.contains("FloatingControlBarGeometry.topCenterAnchoredFrame(currentFrame: frame, targetSize: newSize).origin"))
+    XCTAssertFalse(windowSource.contains("let currentTopCenteredFrame = NSRect("))
     XCTAssertTrue(windowSource.contains("let keepVoiceResponseAlive = state.isVoiceResponseGlowActive"))
     XCTAssertTrue(windowSource.contains("FloatingControlBarManager.shared.cancelChat(keepVoiceAlive: keepVoiceResponseAlive)"))
     XCTAssertTrue(windowSource.contains("static func notchAgentListHeight(agentCount: Int) -> CGFloat"))
@@ -485,6 +492,47 @@ final class AgentPillLifecycleTests: XCTestCase {
     XCTAssertTrue(windowSource.contains("func resizeForAgentSwitcher(visible: Bool)"))
     XCTAssertTrue(windowSource.contains("max(collapsedBarSize.width, Self.notchExpandedWidth)"))
     XCTAssertTrue(windowSource.contains("if state.showingAIConversation {\n                return\n            }"))
+  }
+
+  func testSpacesTransitionDoesNotReplayNotchRevealPop() throws {
+    let windowSource = try floatingControlBarWindowSource()
+
+    guard let start = windowSource.range(of: "private func performSpacesTransitionGrowIn()"),
+      let end = windowSource.range(of: "private func defaultFrameForCurrentState()")
+    else {
+      return XCTFail("Expected performSpacesTransitionGrowIn section")
+    }
+    let body = String(windowSource[start.lowerBound..<end.lowerBound])
+
+    // Switching Spaces must NOT replay the reveal "pop": animateGrowOutFromNotch
+    // resets notchRevealProgress to 0.001 and re-zooms the island. The panel
+    // already lives on every Space (.canJoinAllSpaces), so a Space switch should
+    // keep it fully revealed and only re-assert the frame if it drifted.
+    XCTAssertFalse(body.contains("animateGrowOutFromNotch"))
+    XCTAssertTrue(body.contains("state.notchRevealProgress = 1"))
+    XCTAssertTrue(body.contains("guard !Self.framesEquivalent(frame, targetFrame) else { return }"))
+  }
+
+  func testAgentSwitcherResizeMatchesContentMorphDurations() throws {
+    let windowSource = try floatingControlBarWindowSource()
+
+    // The hover-menu window resize must animate with the same durations as the
+    // SwiftUI content morph, or the panel keeps sliding after the rows settle.
+    XCTAssertTrue(windowSource.contains("static let notchHoverMenuExpandDuration: TimeInterval = 0.16"))
+    XCTAssertTrue(windowSource.contains("static let notchHoverMenuCollapseDuration: TimeInterval = 0.10"))
+
+    guard let start = windowSource.range(of: "func resizeForAgentSwitcher(visible: Bool)"),
+      let end = windowSource.range(of: "private func pillAgentListWindowSize(")
+    else {
+      return XCTFail("Expected resizeForAgentSwitcher section")
+    }
+    let body = String(windowSource[start.lowerBound..<end.lowerBound])
+
+    XCTAssertTrue(body.contains("animationDuration: Self.notchHoverMenuExpandDuration"))
+    XCTAssertTrue(body.contains("animationDuration: Self.notchHoverMenuCollapseDuration"))
+    // No bare animated resize (which defaults to the slow 0.3s) may remain in
+    // the hover-menu expand/collapse path.
+    XCTAssertFalse(body.contains("animated: true, anchorTop: true)"))
   }
 
   func testFloatingBarExplicitSpawnCompletesParentTurn() throws {

--- a/desktop/macos/Desktop/Tests/FloatingBarGeometryTests.swift
+++ b/desktop/macos/Desktop/Tests/FloatingBarGeometryTests.swift
@@ -20,6 +20,18 @@ final class FloatingBarGeometryTests: XCTestCase {
         XCTAssertEqual(frame.size, compactSize)
     }
 
+    func testTopCenterExpansionKeepsTopEdgeAndHorizontalCenterFixed() {
+        let compactFrame = NSRect(x: 586, y: 876, width: 268, height: 58)
+        let expandedFrame = FloatingControlBarGeometry.topCenterAnchoredFrame(
+            currentFrame: compactFrame,
+            targetSize: NSSize(width: 430, height: 110)
+        )
+
+        XCTAssertEqual(expandedFrame.midX, compactFrame.midX)
+        XCTAssertEqual(expandedFrame.maxY, compactFrame.maxY)
+        XCTAssertEqual(expandedFrame.size, NSSize(width: 430, height: 110))
+    }
+
     func testPTTExpansionKeepsCompactPillCenter() {
         let compactFrame = FloatingControlBarGeometry.defaultPillFrame(
             size: compactSize,

--- a/desktop/macos/changelog/unreleased/20260708-stabilize-floating-bar-expansion.json
+++ b/desktop/macos/changelog/unreleased/20260708-stabilize-floating-bar-expansion.json
@@ -1,0 +1,3 @@
+{
+  "change": "Smoothed the notch bar's hover expansion so it no longer hops, keeps sliding after opening, or re-zooms when switching Spaces"
+}


### PR DESCRIPTION
## What

Fixes three animation glitches in the macOS notch floating bar's hover-expand / Space-switch behavior:

1. **Vertical hop on expand** — the hover-menu window size double-counted the bottom glow outset (added here *and* again in `resizeAnchored`), so the surface overshot and bounced. Renamed to `notchHoverMenuSurfaceSize` and let `resizeAnchored` own the outset; replaced the overshooting spring content morph with a monotonic `easeOut`.
2. **"Expands, then slides"** — the NSPanel frame animated over the default `0.3s` while the SwiftUI content morph ran `0.16s`, so the panel kept sliding open after the rows had settled. Added shared `notchHoverMenuExpandDuration` / `notchHoverMenuCollapseDuration` constants (0.16 / 0.10) used by **both** the window resize and the content morph so they finish together.
3. **Re-zoom on Space switch** — `performSpacesTransitionGrowIn` replayed the reveal "pop" (`notchRevealProgress` 0.001 → 1) on every desktop/app switch, even though the panel already lives on all Spaces (`.canJoinAllSpaces`). It now stays fully revealed and only re-asserts the frame if it actually drifted.

## Verification

- `xcrun swift build -c debug` — clean on this PR's base (`main`).
- New/updated regression tests pass:
  - `testSpacesTransitionDoesNotReplayNotchRevealPop`
  - `testAgentSwitcherResizeMatchesContentMorphDurations`
  - `testNotchAgentIndicatorUsesOmiDotsAndStackedList` (updated for the shared duration constants)
- Exercised live in a forced-notch (`OMI_FORCE_NOTCH`) named build with seeded subagents: collapsed island and hover-expanded agent menu render correctly; the expanded frame stays horizontally centered (`midX` constant) and top-anchored (`maxY` constant) throughout — no horizontal slide.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9315?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
## Demo — before / after

Recorded on a forced-notch build with seeded subagents.

**Before** (`prev`): on hover the panel keeps sliding open after the rows settle, and it re-zooms when switching Spaces.

https://github.com/user-attachments/assets/f06ff2fb-afc3-4948-a39c-0543805c2850

**After** (`after`): the panel and its rows expand together in one motion; no post-expand slide, no Space-switch re-zoom.

https://github.com/user-attachments/assets/cbde3dfe-5bb9-41ba-808b-6a570a74973f

