### PR TITLE
fix null-check crash in language settings auto-translation toggle

### DIFF
--- a/app/lib/pages/settings/language_settings_page.dart
+++ b/app/lib/pages/settings/language_settings_page.dart
@@ -177,7 +177,7 @@ class _LanguageSettingsPageState extends State<LanguageSettingsPage> {
                   value: isAutoTranslationEnabled,
                   onChanged: (value) async {
                     final success = await userProvider.setSingleLanguageMode(!value);
-                    if (success && context.mounted) {
+                    if (success && mounted) {
                       context.read<CaptureProvider>().onTranscriptionSettingsChanged();
                     }
                   },


### PR DESCRIPTION
## Problem

Crashlytics fatal ([issue 55abf5ca](https://console.firebase.google.com/u/0/project/based-hardware/crashlytics/app/android:com.friend.ios/issues/55abf5ca8619f2dda3b77da91de60d20)):

```
Fatal Exception: io.flutter.plugins.firebase.crashlytics.FlutterError: Null check operator used on a null value
       at State.context(framework.dart:959)
       at _LanguageSettingsPageState._buildSpeechTranscriptionCard.<fn>(language_settings_page.dart:180)
```

## Cause

The auto-translation `Switch.onChanged` closure awaits `setSingleLanguageMode(...)` and then checks `context.mounted`. Inside a `State`, `context` resolves to `State.context`, whose getter is `_element!` — so if the user leaves the page while the request is in flight, merely **accessing** `context` to evaluate `.mounted` throws the null-check error before the mounted check can run.

## Fix

Check the State's own `mounted` property instead of `context.mounted` (one line). The nearby language-update handler at line 328 already uses this pattern.

## Verification

Reproduced with a widget test that taps the switch, disposes the page while the request is pending, then completes it: the test failed with the old code (`Null check operator used on a null value`) and passed with the fix. The test was not kept in the PR per reviewer request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9319?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

