### PR TITLE
Bump build number to 990 for mobile release

### DIFF
--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -3,7 +3,7 @@ description: A new Flutter project.
 
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.543+981
+version: 1.0.543+990
 
 
 environment:


### PR DESCRIPTION
## Summary

- Bump build from 981 → 990
- Build 981 was rejected: TestFlight already has 981-989, Google Play internal has 989
- New build 990 = max(TestFlight 989, Play 989) + 1
- Verified by mon (ops)

## Context

- Release issue: #9307
- Previous version bump PR: #9314 (build 981 — too low)

_by AI for @beastoin_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9321?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

