### PR TITLE
fix Pro badge missing in settings after in-session re-login

### DIFF
--- a/app/lib/pages/onboarding/wrapper.dart
+++ b/app/lib/pages/onboarding/wrapper.dart
@@ -26,6 +26,7 @@ import 'package:omi/pages/onboarding/user_review_page.dart';
 import 'package:omi/providers/home_provider.dart';
 import 'package:omi/providers/onboarding_provider.dart';
 import 'package:omi/providers/speech_profile_provider.dart';
+import 'package:omi/providers/usage_provider.dart';
 import 'package:omi/services/auth_service.dart';
 import 'package:omi/utils/analytics/intercom.dart';
 import 'package:omi/utils/l10n_extensions.dart';
@@ -271,6 +272,10 @@ class _OnboardingWrapperState extends State<OnboardingWrapper> with TickerProvid
           if (!mounted) return;
           PlatformManager.instance.analytics.onboardingStepCompleted('Auth');
           context.read<HomeProvider>().setupHasSpeakerProfile();
+          // Refresh subscription on sign-in: AppShell only fetches it on mount,
+          // so an in-session re-login would otherwise leave it null until the
+          // Plan & Usage page is opened (missing Pro badge).
+          context.read<UsageProvider>().fetchSubscription();
           IntercomManager.instance.loginIdentifiedUser(SharedPreferencesUtil().uid);
           // Consent is checked first regardless of server-side onboarding
           // state so a returning user signing in on a fresh install still

--- a/app/lib/providers/usage_provider.dart
+++ b/app/lib/providers/usage_provider.dart
@@ -48,6 +48,10 @@ class UsageProvider with ChangeNotifier {
 
   bool _forceOutOfCredits = false;
 
+  /// Bumped on [clearUserData] so responses from a previous session's
+  /// in-flight fetches are discarded instead of repopulating cleared state.
+  int _sessionGeneration = 0;
+
   // Chat quota derived from subscription response
   double get chatQuotaUsed => _subscription?.chatQuotaUsed ?? 0.0;
   String? get chatQuotaUnit => _subscription?.chatQuotaUnit;
@@ -122,6 +126,11 @@ class UsageProvider with ChangeNotifier {
     _availablePlans = null;
     _forceOutOfCredits = false;
     _error = null;
+    _sessionGeneration++;
+    _isSubscriptionLoading = false;
+    _isUsageLoading = false;
+    _isPaymentLoading = false;
+    _isLoadingPlans = false;
     notifyListeners();
   }
 
@@ -136,22 +145,28 @@ class UsageProvider with ChangeNotifier {
   Future<void> fetchSubscription() async {
     if (_isSubscriptionLoading) return;
 
+    final generation = _sessionGeneration;
     _isSubscriptionLoading = true;
     _error = null;
     notifyListeners();
 
     try {
-      _subscription = await getUserSubscription();
+      final subscription = await getUserSubscription();
+      if (generation != _sessionGeneration) return; // Session cleared mid-flight; discard stale response.
+      _subscription = subscription;
       if (_subscription != null) {
         PlatformManager.instance.analytics.setSubscriptionTier(_subscription!.subscription.plan.name);
       }
     } catch (e) {
+      if (generation != _sessionGeneration) return;
       _error = 'Failed to load subscription data. Please try again later.';
       Logger.debug('Failed to fetch subscription: $e');
     } finally {
-      _isSubscriptionLoading = false;
-      _forceOutOfCredits = false; // Reset optimistic flag
-      notifyListeners();
+      if (generation == _sessionGeneration) {
+        _isSubscriptionLoading = false;
+        _forceOutOfCredits = false; // Reset optimistic flag
+        notifyListeners();
+      }
     }
   }
 
@@ -161,12 +176,14 @@ class UsageProvider with ChangeNotifier {
   Future<void> fetchUsageStats({required String period}) async {
     if (_isUsageLoading) return;
 
+    final generation = _sessionGeneration;
     _isUsageLoading = true;
     _error = null;
     notifyListeners();
 
     try {
       final response = await getUserUsage(period: period);
+      if (generation != _sessionGeneration) return; // Session cleared mid-flight; discard stale response.
       if (response != null) {
         switch (period) {
           case 'today':
@@ -190,11 +207,14 @@ class UsageProvider with ChangeNotifier {
         _error = 'Failed to load usage data. Please try again later.';
       }
     } catch (e) {
+      if (generation != _sessionGeneration) return;
       _error = 'Failed to load usage data. Please try again later.';
       Logger.debug('Failed to fetch usage stats: $e');
     } finally {
-      _isUsageLoading = false;
-      notifyListeners();
+      if (generation == _sessionGeneration) {
+        _isUsageLoading = false;
+        notifyListeners();
+      }
     }
   }
 

--- a/app/lib/providers/usage_provider.dart
+++ b/app/lib/providers/usage_provider.dart
@@ -101,6 +101,30 @@ class UsageProvider with ChangeNotifier {
     return false;
   }
 
+  @visibleForTesting
+  void debugSetSubscription(UserSubscriptionResponse? value) {
+    _subscription = value;
+    notifyListeners();
+  }
+
+  /// Wipes user-scoped state on logout so the next account doesn't inherit
+  /// the previous account's subscription/usage (e.g. a stale Pro badge).
+  void clearUserData() {
+    _subscription = null;
+    _todayUsage = null;
+    _monthlyUsage = null;
+    _yearlyUsage = null;
+    _allTimeUsage = null;
+    _todayHistory = null;
+    _monthlyHistory = null;
+    _yearlyHistory = null;
+    _allTimeHistory = null;
+    _availablePlans = null;
+    _forceOutOfCredits = false;
+    _error = null;
+    notifyListeners();
+  }
+
   Future<void> markAsOutOfCreditsAndRefresh() async {
     if (!_forceOutOfCredits) {
       _forceOutOfCredits = true;

--- a/app/lib/utils/auth/clear_user_state.dart
+++ b/app/lib/utils/auth/clear_user_state.dart
@@ -8,6 +8,7 @@ import 'package:omi/providers/conversation_provider.dart';
 import 'package:omi/providers/memories_provider.dart';
 import 'package:omi/providers/message_provider.dart';
 import 'package:omi/providers/people_provider.dart';
+import 'package:omi/providers/usage_provider.dart';
 
 /// Wipes in-memory user-scoped state from every provider so a subsequent
 /// login (different account) doesn't briefly render the previous user's
@@ -20,4 +21,5 @@ void clearAllUserState(BuildContext context) {
   context.read<AppProvider>().clearUserData();
   context.read<PeopleProvider>().clearUserData();
   context.read<ActionItemsProvider>().clearUserData();
+  context.read<UsageProvider>().clearUserData();
 }

--- a/app/test/providers/usage_provider_test.dart
+++ b/app/test/providers/usage_provider_test.dart
@@ -1,0 +1,37 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:omi/models/subscription.dart';
+import 'package:omi/providers/usage_provider.dart';
+
+UserSubscriptionResponse _proSubscription() {
+  return UserSubscriptionResponse(
+    subscription: Subscription(plan: PlanType.unlimited, status: SubscriptionStatus.active),
+    transcriptionSecondsUsed: 0,
+    transcriptionSecondsLimit: 0,
+    wordsTranscribedUsed: 0,
+    wordsTranscribedLimit: 0,
+    insightsGainedUsed: 0,
+    insightsGainedLimit: 0,
+  );
+}
+
+void main() {
+  group('UsageProvider.clearUserData', () {
+    test('resets subscription state so the next login cannot inherit the previous account plan', () {
+      final provider = UsageProvider();
+      provider.debugSetSubscription(_proSubscription());
+      expect(provider.subscription, isNotNull);
+      expect(provider.canAccessPhoneCalls, isTrue);
+
+      var notified = false;
+      provider.addListener(() => notified = true);
+      provider.clearUserData();
+
+      expect(provider.subscription, isNull);
+      expect(provider.canAccessPhoneCalls, isFalse);
+      expect(provider.isOutOfCredits, isFalse);
+      expect(provider.error, isNull);
+      expect(notified, isTrue);
+    });
+  });
+}


### PR DESCRIPTION
## Problem
After logging out and logging back in within the same app session, the settings drawer doesn't show the Pro badge until the Plan & Usage page is opened once.

`fetchSubscription()` only runs in `AppShell` init (which mounts signed-out after logout and never re-runs) and in `UsagePage` — so after re-login the subscription stays `null`. The reverse also existed: `clearAllUserState()` didn't reset `UsageProvider`, so a new login could briefly inherit the previous account's Pro state.

## Fix
- Fetch subscription in the onboarding `onSignIn` callback, so plan state loads right after sign-in.
- Add `UsageProvider.clearUserData()` and call it from `clearAllUserState()` on logout.

## Testing
- New regression test `app/test/providers/usage_provider_test.dart` (seeded Pro subscription → `clearUserData()` → state reset).
- `bash app/test.sh` — all 651 tests passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9325?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

