### PR TITLE
Memory confidence ladder: INV-MEM guards, pipeline E2E, gauntlet, Gate 2 tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -245,3 +245,4 @@ builds-snapshot.md
 
 .hermes/
 backend/.venv
+backend/.harness/

--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -142,6 +142,22 @@ bash test.sh             # Run all tests (CI source of truth)
 
 Pre-mock heavy deps before importing the module under test. Use `patch.object(target_module, "func")` not string-based `patch("module.func")` — the string form silently patches the wrong reference if the function was already imported. When modules construct objects at import time, use lazy getters to avoid triggering heavy init in tests.
 
+### Memory continuity gauntlet gates
+
+Do not confuse these gates — a green live gauntlet does **not** prove hermetic
+pipeline invariants, and hermetic tests do **not** prove deployed-backend continuity.
+
+| Gate | What it covers | What it does **not** cover |
+| --- | --- | --- |
+| **Hermetic pipeline E2E** (`testing/e2e/test_canonical_memory_pipeline.py`) | capture→consolidate→promote→read, archive excluded from default reads, surface default-access matrix, projection fail-closed without legacy bleed | Deployed revision identity, prod IAM/index deltas, live LLM consolidation |
+| **Gauntlet `--self-check`** | Required files, `canonical_memory_pipeline` workflow registration, suite/nonce wiring in `memory-continuity-gauntlet.py` | Any memory write or HTTP probe |
+| **Live gauntlet** (`memory-continuity-gauntlet.sh` with `ADMIN_KEY` + reachable backend) | Structural `/v3/memories` probes per suite on a running backend | Full Gate 2 synthetic matrix or Gate 3 prod activation |
+| **Gate 2 dev-cloud proof** (`v3_dev_cloud_proof.py` + deployed branch revision) | Multi-user synthetic matrix, indexes, IAM, auth, rollback on dev-cloud | Local hermetic fakes; not production activation |
+| **Gate 3 production proof** (`docs/rollout/memory-v3-proof-order.md`) | Prod-specific deltas after Gate 2 GO + independent review | Substitute for hermetic pipeline E2E or gauntlet self-check |
+
+CI runs `python3 backend/scripts/memory-continuity-gauntlet.py --self-check` only.
+Live suites record `NOT_RUN` when credentials/backend are unavailable — never fake `GO`.
+
 ## Self-Testing a Change (run the real path)
 
 A passing unit test is not the same as exercising the endpoint. Before putting a change in a PR:

--- a/backend/scripts/cutover_evidence_readiness.py
+++ b/backend/scripts/cutover_evidence_readiness.py
@@ -5,7 +5,19 @@ import argparse
 import json
 import sys
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any, Dict, Sequence
+
+SCRIPTS_DIR = Path(__file__).resolve().parent
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+from readiness_gate_common import (
+    add_require_go_arg,
+    collect_gates_from_artifact,
+    evaluate_gates,
+    exit_code_for_status,
+)
 
 CUTOVER_GATE_STATUS_BLOCKED = "BLOCKED"
 CUTOVER_GATE_STATUS_NOT_RUN = "NOT_RUN"
@@ -151,6 +163,7 @@ NON_CLAIMS = [
 @dataclass(frozen=True)
 class CutoverEvidenceReadinessConfig:
     execute: bool
+    require_go: bool = False
 
 
 def parse_args(argv: Sequence[str]) -> argparse.Namespace:
@@ -160,11 +173,15 @@ def parse_args(argv: Sequence[str]) -> argparse.Namespace:
     parser.add_argument(
         "--execute", action="store_true", help="Emit the same read-only checklist; does not call providers."
     )
+    add_require_go_arg(parser)
     return parser.parse_args(argv)
 
 
 def config_from_args(args: argparse.Namespace) -> CutoverEvidenceReadinessConfig:
-    return CutoverEvidenceReadinessConfig(execute=bool(args.execute))
+    return CutoverEvidenceReadinessConfig(
+        execute=bool(args.execute),
+        require_go=bool(args.require_go),
+    )
 
 
 def build_readiness_artifact(config: CutoverEvidenceReadinessConfig) -> Dict[str, Any]:
@@ -188,7 +205,11 @@ def build_readiness_artifact(config: CutoverEvidenceReadinessConfig) -> Dict[str
 
 def main(argv: Sequence[str] | None = None) -> int:
     config = config_from_args(parse_args(argv or sys.argv[1:]))
-    print(json.dumps(build_readiness_artifact(config), indent=2, sort_keys=True))
+    artifact = build_readiness_artifact(config)
+    print(json.dumps(artifact, indent=2, sort_keys=True))
+    if config.require_go:
+        overall_status, _ = evaluate_gates(collect_gates_from_artifact(artifact))
+        return exit_code_for_status(overall_status, require_go=True)
     return 0
 
 

--- a/backend/scripts/memory-continuity-gauntlet.py
+++ b/backend/scripts/memory-continuity-gauntlet.py
@@ -745,14 +745,18 @@ class MemoryContinuityGauntlet:
 
         try:
             for suite in sorted(self.suites):
-                suite_mode = mode if self.request_live else "hermetic"
-                if self.request_live and mode != "live":
-                    suite_mode = "not_run"
-                self.run_suite(suite, suite_mode, api_url)
+                self.run_suite(suite, mode, api_url)
         finally:
             if self._runtime is not None:
                 self._runtime.stop()
                 self._runtime = None
+
+        # Prerequisites (e.g. promote running capture internally) may leave
+        # non-selected suites stuck as RUNNING; mark them GO since they
+        # completed without raising.
+        for name, result in list(self.suite_results.items()):
+            if name not in self.suites and result.status == "RUNNING":
+                result.status = "GO"
 
         self.manifest["finished_at"] = datetime.now(timezone.utc).isoformat()
         self.manifest["suite_results"] = {
@@ -767,7 +771,13 @@ class MemoryContinuityGauntlet:
         }
         self.manifest["failures"] = self.failures
         self.manifest["warnings"] = self.warnings
-        self.manifest["passed"] = not self.failures
+        # A run where no selected suite reached GO (e.g. all NOT_RUN because
+        # the live environment was unavailable) must not be marked green even
+        # when there are zero failures.
+        at_least_one_go = any(
+            self.suite_results.get(s) is not None and self.suite_results[s].status == "GO" for s in self.suites
+        )
+        self.manifest["passed"] = not self.failures and at_least_one_go
         write_json(self.run_dir / "manifest.json", self.manifest)
         finalize_evidence_hygiene(self.run_dir, passed=self.manifest["passed"], git_sha_value=self.manifest["git"])
 

--- a/backend/scripts/memory-continuity-gauntlet.py
+++ b/backend/scripts/memory-continuity-gauntlet.py
@@ -1,0 +1,847 @@
+#!/usr/bin/env python3
+"""Driver for the backend memory continuity gauntlet (INV-MEM)."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import secrets
+import shutil
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, Callable
+from unittest.mock import patch
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+BACKEND_DIR = SCRIPT_DIR.parent
+REPO_DIR = BACKEND_DIR.parent
+GAUNTLET_ROOT = BACKEND_DIR / ".harness" / "memory-continuity-gauntlet"
+PRUNE_ABORTED_BUNDLE_DAYS = 7
+
+WORKFLOW_ID = "canonical_memory_pipeline"
+WORKFLOW_TEST_PATH = "testing/e2e/test_canonical_memory_pipeline.py"
+REQUIRED_SELF_CHECK_PATHS = (
+    "backend/scripts/memory-continuity-gauntlet.py",
+    "backend/scripts/memory-continuity-gauntlet.sh",
+    "backend/testing/e2e/test_canonical_memory_pipeline.py",
+    "backend/tests/unit/test_inv_mem_1_guard.py",
+    "backend/testing/workflow_contracts.json",
+)
+
+SUITE_NAMES = frozenset({"capture", "promote", "recall", "archive", "surfaces", "resilience"})
+SUITE_ALIASES: dict[str, frozenset[str]] = {
+    "all": SUITE_NAMES,
+    "pipeline": frozenset({"capture", "promote", "recall", "archive"}),
+}
+NONCE_KINDS = ("CAPTURE", "PROMOTE", "ARCHIVE")
+
+if str(BACKEND_DIR) not in sys.path:
+    sys.path.insert(0, str(BACKEND_DIR))
+
+
+def now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+
+def nonce_for(run_id: str, kind: str) -> str:
+    if kind not in NONCE_KINDS:
+        raise ValueError(f"unknown nonce kind {kind!r}")
+    return f"MEMGAUNTLET-{run_id}-{secrets.token_hex(4)}-{kind}"
+
+
+def write_json(path: Path, data: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def parse_manifest_timestamp(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def git_sha() -> str:
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(REPO_DIR), "rev-parse", "--short", "HEAD"],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+        )
+        return result.stdout.strip()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return "unknown"
+
+
+def finalize_evidence_hygiene(run_dir: Path, *, passed: bool, git_sha_value: str) -> None:
+    GAUNTLET_ROOT.mkdir(parents=True, exist_ok=True)
+    if passed:
+        latest = GAUNTLET_ROOT / "latest-green"
+        if latest.is_symlink() or latest.exists():
+            latest.unlink()
+        latest.symlink_to(run_dir.name, target_is_directory=True)
+        index_path = GAUNTLET_ROOT / "INDEX.md"
+        line = f"- `{run_dir.name}` — `{git_sha_value[:12]}` — green\n"
+        existing = index_path.read_text(encoding="utf-8") if index_path.exists() else ""
+        if line not in existing:
+            with index_path.open("a", encoding="utf-8") as handle:
+                if not existing:
+                    handle.write("# Memory continuity gauntlet evidence index\n\n")
+                handle.write(line)
+    prune_aborted_bundles(GAUNTLET_ROOT, keep_dir=run_dir, max_age_days=PRUNE_ABORTED_BUNDLE_DAYS)
+
+
+def prune_aborted_bundles(root: Path, *, keep_dir: Path, max_age_days: int) -> None:
+    cutoff = datetime.now(timezone.utc) - timedelta(days=max_age_days)
+    if not root.is_dir():
+        return
+    for entry in root.iterdir():
+        if not entry.is_dir():
+            continue
+        if entry.resolve() == keep_dir.resolve():
+            continue
+        manifest_path = entry / "manifest.json"
+        if not manifest_path.is_file():
+            continue
+        try:
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            continue
+        if manifest.get("passed") is True:
+            continue
+        stamp = parse_manifest_timestamp(manifest.get("finished_at")) or parse_manifest_timestamp(
+            manifest.get("started_at")
+        )
+        if stamp is None or stamp >= cutoff:
+            continue
+        shutil.rmtree(entry, ignore_errors=True)
+
+
+def expand_suites(raw: str) -> set[str]:
+    enabled: set[str] = set()
+    for token in raw.split(","):
+        token = token.strip().lower()
+        if not token:
+            continue
+        if token in SUITE_ALIASES:
+            enabled |= set(SUITE_ALIASES[token])
+        elif token in SUITE_NAMES:
+            enabled.add(token)
+        else:
+            known = sorted(SUITE_NAMES | set(SUITE_ALIASES))
+            raise SystemExit(f"unknown suite {token!r}; choose from {known}")
+    return enabled or set(SUITE_ALIASES["all"])
+
+
+def load_workflow_contract() -> dict[str, Any] | None:
+    contracts_path = BACKEND_DIR / "testing" / "workflow_contracts.json"
+    if not contracts_path.is_file():
+        return None
+    contracts = json.loads(contracts_path.read_text(encoding="utf-8"))
+    for workflow in contracts.get("workflows", []):
+        if workflow.get("id") == WORKFLOW_ID:
+            return workflow
+    return None
+
+
+def self_check() -> int:
+    failures: list[str] = []
+    for rel_path in REQUIRED_SELF_CHECK_PATHS:
+        if not (REPO_DIR / rel_path).is_file():
+            failures.append(f"missing required file {rel_path}")
+
+    shell_script = SCRIPT_DIR / "memory-continuity-gauntlet.sh"
+    if shell_script.is_file():
+        shell_text = shell_script.read_text(encoding="utf-8")
+        if "memory-continuity-gauntlet.py" not in shell_text:
+            failures.append("shell wrapper must exec memory-continuity-gauntlet.py")
+        if "exec python3" not in shell_text:
+            failures.append("shell wrapper must exec python3 driver")
+
+    driver_source = (SCRIPT_DIR / "memory-continuity-gauntlet.py").read_text(encoding="utf-8")
+    for flag in ("--self-check", "def self_check(", "GAUNTLET_ROOT"):
+        if flag not in driver_source:
+            failures.append(f"driver missing {flag!r} wiring")
+
+    for suite in sorted(SUITE_NAMES):
+        if f'"{suite}"' not in driver_source and f"'{suite}'" not in driver_source:
+            failures.append(f"driver missing suite token {suite!r}")
+
+    for kind in NONCE_KINDS:
+        if kind not in driver_source:
+            failures.append(f"driver missing nonce kind {kind!r}")
+
+    workflow = load_workflow_contract()
+    if workflow is None:
+        failures.append(f"workflow_contracts.json missing workflow id {WORKFLOW_ID!r}")
+    else:
+        tests = workflow.get("tests") or []
+        if WORKFLOW_TEST_PATH not in tests:
+            failures.append(f"{WORKFLOW_ID} workflow must register tests path {WORKFLOW_TEST_PATH!r}; got {tests!r}")
+
+    if failures:
+        for failure in failures:
+            print(f"self-check failed: {failure}", file=sys.stderr)
+        return 1
+
+    print("self-check passed " f"(files + {WORKFLOW_ID} workflow + suite wiring + nonce contract + --self-check)")
+    return 0
+
+
+def live_env_probe() -> tuple[bool, str, str]:
+    if os.environ.get("MEM_GAUNTLET_FORCE_HERMETIC", "").lower() in {"1", "true", "yes"}:
+        return False, "forced_hermetic", ""
+    api_url = (
+        os.environ.get("MEM_GAUNTLET_API_URL") or os.environ.get("OMI_DESKTOP_API_URL") or "http://127.0.0.1:8080"
+    ).rstrip("/")
+    admin_key = os.environ.get("ADMIN_KEY", "").strip()
+    if not admin_key:
+        return False, "missing_ADMIN_KEY", api_url
+    request = urllib.request.Request(f"{api_url}/health", method="GET", headers={"Accept": "application/json"})
+    try:
+        with urllib.request.urlopen(request, timeout=5) as response:
+            if response.status != 200:
+                return False, f"health_http_{response.status}", api_url
+    except (urllib.error.URLError, TimeoutError, OSError) as exc:
+        return False, f"health_unreachable:{exc}", api_url
+    return True, "ok", api_url
+
+
+def http_get_json(url: str, headers: dict[str, str]) -> tuple[int, Any]:
+    request = urllib.request.Request(url, method="GET", headers={"Accept": "application/json", **headers})
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            raw = response.read().decode("utf-8")
+            try:
+                body = json.loads(raw) if raw else None
+            except json.JSONDecodeError:
+                body = {"raw_length": len(raw)}
+            return response.status, body
+    except urllib.error.HTTPError as exc:
+        raw = exc.read().decode("utf-8", errors="replace")
+        try:
+            body = json.loads(raw) if raw else None
+        except json.JSONDecodeError:
+            body = {"raw_length": len(raw)}
+        return exc.code, body
+
+
+@dataclass
+class SuiteResult:
+    status: str
+    mode: str
+    steps: list[dict[str, Any]] = field(default_factory=list)
+    reason: str | None = None
+    nonces: dict[str, str] = field(default_factory=dict)
+
+
+@dataclass
+class HermeticState:
+    uid: str
+    db: Any
+    client: Any | None = None
+    memory_id: str | None = None
+    capture_nonce: str | None = None
+    promote_nonce: str | None = None
+    archive_nonce: str | None = None
+
+
+class HermeticRuntime:
+    """Keeps e2e fakes + cohort patches alive for the full gauntlet run."""
+
+    def __init__(self, uid: str) -> None:
+        self.uid = uid
+        self._patchers: list[Any] = []
+        self.db: Any = None
+        self.client: Any = None
+
+    def start(self) -> HermeticState:
+        e2e_dir = BACKEND_DIR / "testing" / "e2e"
+        if str(e2e_dir) not in sys.path:
+            sys.path.insert(0, str(e2e_dir))
+
+        import testing.e2e.conftest as e2e_conftest  # noqa: WPS433 — gauntlet bootstrap
+        from fakes.firestore import setup_fake_firestore
+        from fakes.redis import setup_fake_redis
+        from fakes.storage import setup_fake_storage
+        from fastapi.testclient import TestClient
+        from tests.unit.canonical_cohort_test_helpers import set_canonical_cohort
+
+        e2e_conftest._set_e2e_env()
+        fake_firestore = setup_fake_firestore()
+        fake_redis = setup_fake_redis()
+        fake_storage = setup_fake_storage()
+        app = e2e_conftest._create_backend_app(fake_firestore, fake_redis, fake_storage)
+        self.client = TestClient(app)
+        self.db = fake_firestore
+        set_canonical_cohort(_GauntletMonkeypatch(), self.uid)
+        self._patchers.extend(self._start_canonical_patches())
+        return HermeticState(uid=self.uid, db=self.db, client=self.client)
+
+    def _start_canonical_patches(self) -> list[Any]:
+        trusted = SimpleNamespace(account_generation=3, head_commit_id="head0", read_error_reason=None)
+        from utils.memory.canonical_kg_promotion import CanonicalKgPromotionResult
+
+        patchers = [
+            patch(
+                "utils.memory.canonical_memory_adapter.read_memory_v3_trusted_account_generation",
+                lambda **_: trusted,
+            ),
+            patch(
+                "utils.memory.v3_account_generation_source.read_memory_v3_trusted_account_generation",
+                lambda **_: trusted,
+                create=True,
+            ),
+            patch(
+                "utils.memory.short_term_promotion.extract_kg_for_promoted_memory",
+                lambda *args, **kwargs: CanonicalKgPromotionResult(attempted=False, success=True),
+            ),
+            patch(
+                "utils.memory.canonical_consolidation.query_memory_vector_candidates",
+                lambda *args, **kwargs: SimpleNamespace(hits=[], rejected_count=0),
+            ),
+            patch("utils.memory.short_term_promotion.promotion_batch_threshold", lambda: 1),
+            patch("utils.memory.canonical_consolidation.consolidation_batch_threshold", lambda: 1),
+        ]
+        for patcher in patchers:
+            patcher.start()
+        return patchers
+
+    def stop(self) -> None:
+        if self.client is not None:
+            self.client.close()
+            self.client = None
+        for patcher in reversed(self._patchers):
+            patcher.stop()
+        self._patchers.clear()
+
+
+class MemoryContinuityGauntlet:
+    def __init__(self, args: argparse.Namespace) -> None:
+        self.args = args
+        self.run_id = args.run_id or now_iso()
+        self.run_dir = Path(args.run_dir or (GAUNTLET_ROOT / self.run_id))
+        self.suites = expand_suites(args.suite)
+        self.request_live = bool(args.live)
+        self.failures: list[str] = []
+        self.warnings: list[str] = []
+        self.suite_results: dict[str, SuiteResult] = {}
+        self.markers = {kind.lower(): nonce_for(self.run_id, kind) for kind in NONCE_KINDS}
+        self.manifest: dict[str, Any] = {}
+        self._hermetic: HermeticState | None = None
+        self._runtime: HermeticRuntime | None = None
+
+    def fail(self, message: str) -> None:
+        self.failures.append(message)
+
+    def warn(self, message: str) -> None:
+        self.warnings.append(message)
+
+    def record_step(self, suite: str, name: str, **details: Any) -> None:
+        result = self.suite_results.setdefault(suite, SuiteResult(status="RUNNING", mode="unknown"))
+        result.steps.append({"name": name, **details})
+
+    def suite_not_run(self, suite: str, reason: str) -> None:
+        self.suite_results[suite] = SuiteResult(status="NOT_RUN", mode="live", reason=reason)
+
+    def resolve_mode(self) -> tuple[str, str, str]:
+        live_ok, reason, api_url = live_env_probe()
+        if self.request_live:
+            return ("live" if live_ok else "not_run", reason, api_url)
+        if live_ok and os.environ.get("MEM_GAUNTLET_PREFER_LIVE", "").lower() in {"1", "true", "yes"}:
+            return "live", reason, api_url
+        return "hermetic", reason, api_url
+
+    def _seed_rollout(self, db: Any, uid: str, *, grant_consumer: str = "omi_chat") -> None:
+        from config.memory_rollout import PASSED, MemoryRolloutMode, MemoryRolloutStageGate
+        from tests.unit.fixtures.memory_adapter_fakes import enabled_rollout_doc
+        from utils.memory.default_read_rollout import GLOBAL_READ_GATE_PATH
+        from utils.memory.v3_limited_rollout_config import WRITE_CONVERGENCE_GATE_PATH
+
+        def _set_gate(path: str, payload: dict[str, Any]) -> None:
+            parts = path.split("/")
+            ref = db.collection(parts[0]).document(parts[1])
+            for index in range(2, len(parts), 2):
+                ref = ref.collection(parts[index]).document(parts[index + 1])
+            ref.set(payload)
+
+        _set_gate(GLOBAL_READ_GATE_PATH, {"memory_reads_enabled": True, "kill_switch_active": False})
+        _set_gate(
+            WRITE_CONVERGENCE_GATE_PATH,
+            {
+                "durable_outbox_enabled": True,
+                "dual_write_projection_ready": True,
+                "delete_convergence_ready": True,
+                "idempotency_contract_ready": True,
+            },
+        )
+        rollout = enabled_rollout_doc(uid, grant_consumer=grant_consumer)
+        rollout["mode"] = MemoryRolloutMode.read.value
+        rollout["stage_gates"] = {
+            MemoryRolloutStageGate.shadow.value: PASSED,
+            MemoryRolloutStageGate.write.value: PASSED,
+            MemoryRolloutStageGate.read.value: PASSED,
+        }
+        db.collection("users").document(uid).collection("memory_control").document("state").set(rollout)
+
+    def _seed_apply_control(self, db: Any, uid: str) -> None:
+        from models.memory_apply import MemoryControlState
+
+        control = MemoryControlState(
+            uid=uid,
+            head_commit_id="head0",
+            account_generation=3,
+            source_generation=1,
+        ).model_dump(mode="json")
+        db.collection("users").document(uid).collection("memory_state").document("apply_control").set(control)
+
+    def _ensure_hermetic(self) -> HermeticState:
+        if self._hermetic is not None:
+            return self._hermetic
+        uid = f"mem-gauntlet-{self.run_id.lower()}"
+        self._runtime = HermeticRuntime(uid)
+        state = self._runtime.start()
+        self._seed_apply_control(state.db, uid)
+        self._seed_rollout(state.db, uid)
+        self._hermetic = state
+        return self._hermetic
+
+    def run_capture_hermetic(self, state: HermeticState) -> None:
+        from models.memories import MemoryCategory
+        from tests.unit.test_ws_i_write_convergence import _sample_memory_payload
+        from utils.memory.canonical_memory_adapter import write_canonical_extraction_memory
+
+        capture_nonce = self.markers["capture"]
+        payload = _sample_memory_payload(
+            uid=state.uid,
+            conversation_id=f"gauntlet-{self.run_id}",
+            content=f"Gauntlet capture probe {capture_nonce}",
+        )
+        payload["category"] = MemoryCategory.system.value
+        memory_id = write_canonical_extraction_memory(state.uid, payload, db_client=state.db)
+        item_ref = state.db.collection("users").document(state.uid).collection("memory_items").document(memory_id)
+        snapshot = item_ref.get().to_dict()
+        assert snapshot["tier"] == "short_term", snapshot
+        assert capture_nonce in snapshot.get("content", ""), snapshot
+        state.memory_id = memory_id
+        state.capture_nonce = capture_nonce
+        self.record_step(
+            "capture",
+            "write_short_term",
+            memory_id=memory_id,
+            tier=snapshot["tier"],
+            nonce=capture_nonce,
+        )
+
+    def run_promote_hermetic(self, state: HermeticState) -> None:
+        from utils.memory.canonical_consolidation import ConsolidationAgentBatch
+        from utils.memory.short_term_promotion import run_canonical_short_term_maintenance
+
+        if state.memory_id is None:
+            self.run_capture_hermetic(state)
+        promote_nonce = self.markers["promote"]
+        item_ref = state.db.collection("users").document(state.uid).collection("memory_items").document(state.memory_id)
+        prior = dict(item_ref.get().to_dict())
+        prior["content"] = f"{prior.get('content', '')} {promote_nonce}"
+        item_ref.set(prior)
+
+        def scripted_llm(_prompt: str) -> str:
+            return json.dumps(ConsolidationAgentBatch(decisions=[], reasoning="no_changes").model_dump(mode="json"))
+
+        now = datetime(2026, 6, 24, 12, 0, tzinfo=timezone.utc)
+        maintenance = run_canonical_short_term_maintenance(
+            state.uid,
+            db_client=state.db,
+            now=now,
+            run_id=f"gauntlet-{self.run_id}",
+            llm_invoke=scripted_llm,
+        )
+        promoted = item_ref.get().to_dict()
+        assert maintenance.promotion.promoted_count >= 1, maintenance
+        assert promoted["tier"] == "long_term", promoted
+        assert promote_nonce in promoted.get("content", ""), promoted
+        state.promote_nonce = promote_nonce
+        self.record_step(
+            "promote",
+            "short_term_maintenance",
+            memory_id=state.memory_id,
+            tier=promoted["tier"],
+            promoted_count=maintenance.promotion.promoted_count,
+            nonce=promote_nonce,
+        )
+
+    def run_recall_hermetic(self, state: HermeticState) -> None:
+        from utils.memory.chat_memory_adapter import search_memory_default_chat_memories_text
+        from utils.memory.memory_service import MemoryService
+
+        if state.memory_id is None:
+            self.run_promote_hermetic(state)
+        now = datetime(2026, 6, 24, 12, 0, tzinfo=timezone.utc)
+        service = MemoryService(db_client=state.db)
+        read_ids = {memory.id for memory in service.read(state.uid, limit=50)}
+        assert state.memory_id in read_ids, read_ids
+        query_token = state.promote_nonce or state.capture_nonce or self.markers["promote"]
+        chat_text = search_memory_default_chat_memories_text(
+            uid=state.uid,
+            query=query_token,
+            limit=10,
+            db_client=state.db,
+            now=now,
+        )
+        assert chat_text is not None, "chat search returned None"
+        assert query_token in chat_text, chat_text
+        self.record_step(
+            "recall",
+            "default_read_and_chat_search",
+            memory_id=state.memory_id,
+            query_token=query_token,
+            read_count=len(read_ids),
+        )
+
+    def run_archive_hermetic(self, state: HermeticState) -> None:
+        from datetime import datetime, timezone
+
+        from models.product_memory import MemoryAccessPolicy, MemoryTier
+        from tests.unit.fixtures.memory_adapter_fakes import memory_item, stored_item
+        from utils.memory.canonical_visibility_filter import filter_canonical_default_visible_items
+        from utils.memory.product_memory_read_service import fetch_authoritative_product_memory_items
+
+        now = datetime(2026, 6, 24, 12, 0, tzinfo=timezone.utc)
+        archive_nonce = self.markers["archive"]
+        archive_item = memory_item(
+            f"archive-{self.run_id}",
+            uid=state.uid,
+            tier=MemoryTier.archive,
+            now=now,
+            content=f"archive hidden {archive_nonce}",
+            quote_text="archive quote",
+        )
+        visible_item = memory_item(
+            f"visible-{self.run_id}",
+            uid=state.uid,
+            tier=MemoryTier.long_term,
+            now=now,
+            content="visible long term gauntlet fact",
+            quote_text="visible quote",
+        )
+        items_ref = state.db.collection("users").document(state.uid).collection("memory_items")
+        items_ref.document(archive_item.memory_id).set(stored_item(archive_item))
+        items_ref.document(visible_item.memory_id).set(stored_item(visible_item))
+        state.archive_nonce = archive_nonce
+
+        policy = MemoryAccessPolicy.for_omi_chat(archive_capability=False)
+        visible = filter_canonical_default_visible_items(
+            fetch_authoritative_product_memory_items(uid=state.uid, db_client=state.db),
+            policy=policy,
+            now=now,
+        )
+        visible_ids = {item.memory_id for item in visible}
+        assert archive_item.memory_id not in visible_ids, visible_ids
+        assert visible_item.memory_id in visible_ids, visible_ids
+        if state.memory_id is not None:
+            assert state.memory_id in visible_ids, visible_ids
+        self.record_step(
+            "archive",
+            "default_read_excludes_archive",
+            archive_id=archive_item.memory_id,
+            visible_id=visible_item.memory_id,
+            nonce=archive_nonce,
+            visible_count=len(visible_ids),
+        )
+
+    def run_surfaces_hermetic(self, state: HermeticState) -> None:
+        from datetime import datetime, timezone
+
+        from models.product_memory import MemoryAccessPolicy, MemoryConsumer, MemoryTier, ProcessingState
+        from tests.unit.fixtures.memory_adapter_fakes import memory_item, stored_item
+        from utils.memory.chat_memory_adapter import (
+            list_default_chat_memories_decision_text,
+            search_memory_default_chat_memories_text,
+        )
+        from utils.memory.default_read_rollout import MemoryReadDecision, read_default_read_rollout
+        from utils.memory.developer_memory_adapter import search_memory_default_developer_memories
+        from utils.memory.product_memory_read_service import fetch_default_product_memory_search
+        from utils.retrieval.tool_services import memories as tool_memories_service
+
+        now = datetime(2026, 6, 24, 12, 0, tzinfo=timezone.utc)
+        archive_nonce = state.archive_nonce or self.markers["archive"]
+        items_ref = state.db.collection("users").document(state.uid).collection("memory_items")
+        seeded = (
+            memory_item(
+                f"surface-fresh-{self.run_id}",
+                uid=state.uid,
+                now=now,
+                content="coffee fresh short term",
+                quote_text="fresh quote",
+                processing_state=ProcessingState.processed,
+            ),
+            memory_item(
+                f"surface-long-{self.run_id}",
+                uid=state.uid,
+                tier=MemoryTier.long_term,
+                now=now,
+                content="surface visible coffee preference",
+                quote_text="long quote",
+            ),
+            memory_item(
+                f"surface-archive-{self.run_id}",
+                uid=state.uid,
+                tier=MemoryTier.archive,
+                now=now,
+                content=f"surface archive {archive_nonce}",
+                quote_text="surface archive quote",
+            ),
+        )
+        for item in seeded:
+            items_ref.document(item.memory_id).set(stored_item(item))
+
+        rollout = read_default_read_rollout(uid=state.uid, db_client=state.db, consumer="omi_chat")
+        assert rollout.read_decision == MemoryReadDecision.USE_MEMORY
+        policy = MemoryAccessPolicy(
+            consumer=MemoryConsumer.omi_chat,
+            app_has_default_memory_grant=True,
+            archive_capability=False,
+        )
+
+        surfaces: dict[str, Callable[[], Any]] = {
+            "chat_text": lambda: search_memory_default_chat_memories_text(
+                uid=state.uid, query="coffee", limit=10, db_client=state.db, now=now
+            ),
+            "chat_list": lambda: list_default_chat_memories_decision_text(
+                uid=state.uid, limit=10, offset=0, db_client=state.db
+            ).text,
+            "developer": lambda: search_memory_default_developer_memories(
+                uid=state.uid,
+                query="coffee",
+                limit=10,
+                offset=0,
+                db_client=state.db,
+                rollout_decision=rollout,
+                now=now,
+            ).memories,
+            "agent_tools": lambda: tool_memories_service.get_memories_text(uid=state.uid, limit=50),
+            "product_search": lambda: fetch_default_product_memory_search(
+                uid=state.uid,
+                query="coffee",
+                db_client=state.db,
+                policy=policy,
+                now=now,
+            )["items"],
+        }
+
+        for surface_name, reader in surfaces.items():
+            payload = reader()
+            serialized = json.dumps(payload, default=str)
+            assert archive_nonce not in serialized, surface_name
+            assert (
+                "surface visible coffee preference" in serialized or "coffee fresh short term" in serialized
+            ), surface_name
+            self.record_step(
+                "surfaces",
+                surface_name,
+                archive_excluded=True,
+                visible_present=True,
+            )
+
+    def run_resilience_hermetic(self, state: HermeticState) -> None:
+        from fakes.firestore import seed_memory
+        from testing.e2e.test_canonical_memory_pipeline import _override_memory_runtime, _runtime
+
+        seed_memory(
+            state.uid,
+            {
+                "id": "legacy-must-not-bleed-gauntlet",
+                "content": "legacy memory must not leak on canonical projection failure",
+                "category": "manual",
+                "visibility": "public",
+            },
+        )
+
+        def failing_memory_service(_params, _adapters):
+            from utils.memory.v3_composed_get_service import V3ComposedResponse
+
+            return V3ComposedResponse.error(503, "infrastructure_failure")
+
+        assert state.client is not None
+        auth_headers = {"Authorization": "Bearer dev-token"}
+        with _override_memory_runtime(
+            state.client,
+            _runtime(enabled=True, source_decision="memory_read", service=failing_memory_service),
+        ):
+            resp = state.client.get("/v3/memories", headers=auth_headers)
+        assert resp.status_code == 503, resp.text
+        assert resp.json() == {"detail": "infrastructure_failure"}
+        assert resp.headers.get("x-omi-memory-read-source") == "none"
+        assert "legacy-must-not-bleed-gauntlet" not in resp.text
+        self.record_step(
+            "resilience",
+            "projection_failure_fail_closed",
+            status_code=resp.status_code,
+            legacy_bleed=False,
+        )
+
+    def run_suite_live(self, suite: str, api_url: str) -> None:
+        admin_key = os.environ["ADMIN_KEY"].strip()
+        uid = os.environ.get("MEM_GAUNTLET_UID", "mem-gauntlet-live").strip()
+        headers = {"Authorization": f"Bearer {admin_key}{uid}"}
+        status, body = http_get_json(f"{api_url}/v3/memories", headers)
+        self.record_step(suite, "live_v3_memories_probe", http_status=status, body_summary=_summarize_body(body))
+        if status not in {200, 403, 503}:
+            raise AssertionError(f"unexpected /v3/memories status {status}")
+
+    def run_suite(self, suite: str, mode: str, api_url: str) -> None:
+        if mode == "not_run":
+            self.suite_not_run(suite, "live_requested_but_env_unavailable")
+            return
+        self.suite_results[suite] = SuiteResult(status="RUNNING", mode=mode, nonces=dict(self.markers))
+        try:
+            if mode == "live":
+                self.run_suite_live(suite, api_url)
+            else:
+                state = self._ensure_hermetic()
+                runner = {
+                    "capture": self.run_capture_hermetic,
+                    "promote": self.run_promote_hermetic,
+                    "recall": self.run_recall_hermetic,
+                    "archive": self.run_archive_hermetic,
+                    "surfaces": self.run_surfaces_hermetic,
+                    "resilience": self.run_resilience_hermetic,
+                }[suite]
+                runner(state)
+            self.suite_results[suite].status = "GO"
+        except Exception as exc:  # noqa: BLE001 — gauntlet records failure evidence
+            self.suite_results[suite].status = "FAIL"
+            self.fail(f"{suite}: {exc}")
+            self.record_step(suite, "error", message=str(exc))
+
+    def run(self) -> int:
+        self.run_dir.mkdir(parents=True, exist_ok=True)
+        mode, mode_reason, api_url = self.resolve_mode()
+        effective_mode = "live" if mode == "live" else "hermetic" if mode == "hermetic" else "not_run"
+
+        self.manifest = {
+            "run_id": self.run_id,
+            "started_at": datetime.now(timezone.utc).isoformat(),
+            "git": git_sha(),
+            "requested_suites": sorted(self.suites),
+            "markers": self.markers,
+            "mode": effective_mode,
+            "mode_reason": mode_reason,
+            "api_url": api_url,
+            "live_requested": self.request_live,
+        }
+        write_json(self.run_dir / "manifest.json", self.manifest)
+
+        try:
+            for suite in sorted(self.suites):
+                suite_mode = mode if self.request_live else "hermetic"
+                if self.request_live and mode != "live":
+                    suite_mode = "not_run"
+                self.run_suite(suite, suite_mode, api_url)
+        finally:
+            if self._runtime is not None:
+                self._runtime.stop()
+                self._runtime = None
+
+        self.manifest["finished_at"] = datetime.now(timezone.utc).isoformat()
+        self.manifest["suite_results"] = {
+            name: {
+                "status": result.status,
+                "mode": result.mode,
+                "reason": result.reason,
+                "steps": result.steps,
+                "nonces": result.nonces,
+            }
+            for name, result in self.suite_results.items()
+        }
+        self.manifest["failures"] = self.failures
+        self.manifest["warnings"] = self.warnings
+        self.manifest["passed"] = not self.failures
+        write_json(self.run_dir / "manifest.json", self.manifest)
+        finalize_evidence_hygiene(self.run_dir, passed=self.manifest["passed"], git_sha_value=self.manifest["git"])
+
+        if self.failures:
+            for failure in self.failures:
+                print(f"FAIL: {failure}", file=sys.stderr)
+            print(f"evidence: {self.run_dir}", file=sys.stderr)
+            return 1
+
+        print(
+            f"memory-continuity-gauntlet passed mode={effective_mode} "
+            f"suites={','.join(sorted(self.suites))} evidence={self.run_dir}"
+        )
+        return 0
+
+
+class _GauntletMonkeypatch:
+    """Minimal monkeypatch shim for canonical_cohort_test_helpers outside pytest."""
+
+    def setattr(self, target, name, value, raising=True):  # noqa: ARG002
+        if isinstance(target, str):
+            if "." in target:
+                module_path, attr = target.rsplit(".", 1)
+                module = __import__(module_path, fromlist=[attr])
+                setattr(module, attr, value)
+            else:
+                module = __import__(target, fromlist=[name])
+                setattr(module, name, value)
+            return
+        setattr(target, name, value)
+
+    def setenv(self, name, value) -> None:
+        os.environ[name] = value
+
+    def delenv(self, name, raising=True) -> None:  # noqa: ARG002
+        os.environ.pop(name, None)
+
+
+def _summarize_body(body: Any) -> Any:
+    if isinstance(body, dict):
+        if "items" in body and isinstance(body["items"], list):
+            return {"items_count": len(body["items"])}
+        if "detail" in body:
+            return {"detail": body["detail"]}
+    if isinstance(body, list):
+        return {"list_count": len(body)}
+    return body
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Backend memory continuity gauntlet (INV-MEM)")
+    parser.add_argument("--run-id", default=None)
+    parser.add_argument("--run-dir", default=None)
+    parser.add_argument(
+        "--suite",
+        default="all",
+        help="Comma-separated suites: capture, promote, recall, archive, surfaces, resilience, "
+        "pipeline (capture→archive), all (default).",
+    )
+    parser.add_argument(
+        "--live",
+        action="store_true",
+        help="Require live backend (ADMIN_KEY + reachable /health). Suites record NOT_RUN when unavailable.",
+    )
+    parser.add_argument("--self-check", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    if args.self_check:
+        return self_check()
+    return MemoryContinuityGauntlet(args).run()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/scripts/memory-continuity-gauntlet.sh
+++ b/backend/scripts/memory-continuity-gauntlet.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Memory continuity gauntlet — standing INV-MEM smoke test for canonical memory tiers.
+#
+# HERMETIC pipeline rules (capture→promote→recall, archive exclusion, surface
+# default-access, fail-closed resilience) also live in
+# testing/e2e/test_canonical_memory_pipeline.py + gauntlet --self-check.
+# See backend/AGENTS.md → "Memory continuity gauntlet gates".
+#
+# LIVE suites exercise a running backend with ADMIN_KEY when available.
+# Without credentials the driver falls back to hermetic fakes / TestClient, or
+# records suites as NOT_RUN when --live is requested.
+#
+# Evidence bundle (timestamped under backend/.harness/memory-continuity-gauntlet/):
+#   manifest.json with per-suite status, mode, structural assertions, nonces.
+#
+# Usage:
+#   python3 backend/scripts/memory-continuity-gauntlet.py --self-check
+#   ./backend/scripts/memory-continuity-gauntlet.sh
+#   ./backend/scripts/memory-continuity-gauntlet.sh --suite capture,promote,recall
+#   MEM_GAUNTLET_API_URL=http://127.0.0.1:8080 ./backend/scripts/memory-continuity-gauntlet.sh --live
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+BACKEND_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+exec python3 "$SCRIPT_DIR/memory-continuity-gauntlet.py" "$@"

--- a/backend/scripts/pinecone_repair_validation_readiness.py
+++ b/backend/scripts/pinecone_repair_validation_readiness.py
@@ -6,7 +6,19 @@ import json
 import os
 import sys
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any, Dict, List, Sequence
+
+SCRIPTS_DIR = Path(__file__).resolve().parent
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+from readiness_gate_common import (
+    add_require_go_arg,
+    collect_gates_from_artifact,
+    evaluate_gates,
+    exit_code_for_status,
+)
 
 DEFAULT_SHARED_NAMESPACE = "ns2"
 MIN_SAFE_PREFIX_LEN = 12
@@ -60,6 +72,7 @@ class PineconeRepairValidationConfig:
     throwaway_prefix: str
     confirm_throwaway_prefix: str
     shared_ns2_readonly: bool
+    require_go: bool = False
 
 
 def parse_args(argv: Sequence[str]) -> argparse.Namespace:
@@ -87,12 +100,14 @@ def parse_args(argv: Sequence[str]) -> argparse.Namespace:
     parser.add_argument("--api-key", default=os.getenv("PINECONE_API_KEY", ""))
     parser.add_argument("--index-name", default=os.getenv("PINECONE_INDEX_NAME", ""))
     parser.add_argument("--index-host", default=os.getenv("PINECONE_INDEX_HOST", ""))
+    add_require_go_arg(parser)
     return parser.parse_args(argv)
 
 
 def config_from_args(args: argparse.Namespace) -> PineconeRepairValidationConfig:
     return PineconeRepairValidationConfig(
         execute=bool(args.execute),
+        require_go=bool(args.require_go),
         allow_throwaway_mutation=bool(args.allow_throwaway_mutation),
         api_key=str(args.api_key or ""),
         index_name=str(args.index_name or ""),
@@ -176,6 +191,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     print(json.dumps(artifact, indent=2, sort_keys=True))
     if config.execute and artifact["prerequisites"]:
         return 2
+    if config.require_go:
+        overall_status, _ = evaluate_gates(collect_gates_from_artifact(artifact))
+        return exit_code_for_status(overall_status, require_go=True)
     return 0
 
 

--- a/backend/scripts/readiness_gate_common.py
+++ b/backend/scripts/readiness_gate_common.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Shared helpers for memory readiness scripts with optional fail-closed --require-go."""
+
+from __future__ import annotations
+
+import argparse
+from typing import Any
+
+GATE_STATUS_GO = "GO"
+GATE_STATUS_BLOCKED = "BLOCKED"
+GATE_STATUS_NOT_RUN = "NOT_RUN"
+
+
+def evaluate_gates(gates: dict[str, Any]) -> tuple[str, list[str]]:
+    """Return overall status and blockers for gate dicts with per-gate ``status`` keys."""
+    if not gates:
+        return GATE_STATUS_NOT_RUN, ["no_gates_defined"]
+
+    blockers: list[str] = []
+    non_go_statuses: list[str] = []
+
+    for gate_name, gate in gates.items():
+        if isinstance(gate, dict):
+            status = str(gate.get("status", GATE_STATUS_NOT_RUN))
+        else:
+            status = GATE_STATUS_NOT_RUN
+        if status != GATE_STATUS_GO:
+            blockers.append(f"{gate_name}:{status}")
+            non_go_statuses.append(status)
+
+    if not blockers:
+        return GATE_STATUS_GO, []
+
+    if GATE_STATUS_BLOCKED in non_go_statuses:
+        overall = GATE_STATUS_BLOCKED
+    elif GATE_STATUS_NOT_RUN in non_go_statuses:
+        overall = GATE_STATUS_NOT_RUN
+    else:
+        overall = non_go_statuses[0]
+
+    return overall, blockers
+
+
+def exit_code_for_status(status: str, require_go: bool) -> int:
+    """Inventory mode always exits 0; --require-go exits 0 only when status is GO."""
+    if not require_go:
+        return 0
+    return 0 if status == GATE_STATUS_GO else 1
+
+
+def add_require_go_arg(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--require-go",
+        action="store_true",
+        help="Fail closed: exit non-zero unless every evaluated gate status is GO.",
+    )
+
+
+def collect_gates_from_artifact(artifact: dict[str, Any]) -> dict[str, Any]:
+    """Collect gate-like status entries from a readiness artifact payload."""
+    gates: dict[str, Any] = {}
+    artifact_gates = artifact.get("gates")
+    if isinstance(artifact_gates, dict):
+        gates.update(artifact_gates)
+    elif "status" in artifact:
+        gates["overall"] = {"status": artifact["status"]}
+
+    proof_cases = artifact.get("proof_cases")
+    if isinstance(proof_cases, dict):
+        for name, case in proof_cases.items():
+            if isinstance(case, dict) and "status" in case:
+                gates[f"proof_case:{name}"] = case
+
+    return gates

--- a/backend/scripts/readiness_gate_common.py
+++ b/backend/scripts/readiness_gate_common.py
@@ -57,13 +57,18 @@ def add_require_go_arg(parser: argparse.ArgumentParser) -> None:
 
 
 def collect_gates_from_artifact(artifact: dict[str, Any]) -> dict[str, Any]:
-    """Collect gate-like status entries from a readiness artifact payload."""
+    """Collect gate-like status entries from a readiness artifact payload.
+
+    The overall artifact ``status`` is always collected as an ``overall`` gate so
+    that fail-closed ``--require-go`` behavior is not bypassed when a payload
+    also carries a ``gates`` dict.
+    """
     gates: dict[str, Any] = {}
+    if "status" in artifact:
+        gates["overall"] = {"status": artifact["status"]}
     artifact_gates = artifact.get("gates")
     if isinstance(artifact_gates, dict):
         gates.update(artifact_gates)
-    elif "status" in artifact:
-        gates["overall"] = {"status": artifact["status"]}
 
     proof_cases = artifact.get("proof_cases")
     if isinstance(proof_cases, dict):

--- a/backend/scripts/rollout_schema_readiness.py
+++ b/backend/scripts/rollout_schema_readiness.py
@@ -9,10 +9,18 @@ from pathlib import Path
 from typing import Any, Dict, Sequence
 
 BACKEND_DIR = Path(__file__).resolve().parents[1]
-if str(BACKEND_DIR) not in sys.path:
-    sys.path.insert(0, str(BACKEND_DIR))
+SCRIPTS_DIR = Path(__file__).resolve().parent
+for path in (BACKEND_DIR, SCRIPTS_DIR):
+    if str(path) not in sys.path:
+        sys.path.insert(0, str(path))
 
 from config.memory_rollout import PASSED, MemoryRolloutMode, MemoryRolloutStageGate
+from readiness_gate_common import (
+    add_require_go_arg,
+    collect_gates_from_artifact,
+    evaluate_gates,
+    exit_code_for_status,
+)
 from utils.memory.default_read_rollout import DEFAULT_READ_ROLLOUT_SCHEMA_VERSION
 
 ROLLLOUT_READINESS_STATUS_NOT_RUN = "NOT_RUN"
@@ -44,6 +52,7 @@ NON_CLAIMS = [
 @dataclass(frozen=True)
 class RolloutSchemaReadinessConfig:
     execute: bool
+    require_go: bool = False
 
 
 def _base_schema_v1_doc(uid: str = "memory-schema-readiness-user") -> Dict[str, Any]:
@@ -156,11 +165,15 @@ def parse_args(argv: Sequence[str]) -> argparse.Namespace:
     parser.add_argument(
         "--execute", action="store_true", help="Emit the same read-only local inventory; no provider calls."
     )
+    add_require_go_arg(parser)
     return parser.parse_args(argv)
 
 
 def config_from_args(args: argparse.Namespace) -> RolloutSchemaReadinessConfig:
-    return RolloutSchemaReadinessConfig(execute=bool(args.execute))
+    return RolloutSchemaReadinessConfig(
+        execute=bool(args.execute),
+        require_go=bool(args.require_go),
+    )
 
 
 def build_readiness_artifact(config: RolloutSchemaReadinessConfig) -> Dict[str, Any]:
@@ -199,7 +212,11 @@ def build_readiness_artifact(config: RolloutSchemaReadinessConfig) -> Dict[str, 
 
 def main(argv: Sequence[str] | None = None) -> int:
     config = config_from_args(parse_args(argv or sys.argv[1:]))
-    print(json.dumps(build_readiness_artifact(config), indent=2, sort_keys=True))
+    artifact = build_readiness_artifact(config)
+    print(json.dumps(artifact, indent=2, sort_keys=True))
+    if config.require_go:
+        overall_status, _ = evaluate_gates(collect_gates_from_artifact(artifact))
+        return exit_code_for_status(overall_status, require_go=True)
     return 0
 
 

--- a/backend/scripts/select_backend_unit_tests.py
+++ b/backend/scripts/select_backend_unit_tests.py
@@ -207,20 +207,26 @@ AREA_TESTS = (
 )
 
 
-def discover_all_tests() -> list[str]:
+def discover_unit_tests() -> list[str]:
     tests: set[Path] = set()
     for root in FULL_TEST_ROOTS:
         tests.update(root.rglob('test_*.py'))
     for root in FULL_TEST_GLOBS:
         tests.update(root.glob('test_*.py'))
-    for path in EXTRA_DISCOVERABLE_TESTS:
-        if path.is_file():
-            tests.add(path)
     return sorted(
         test_path
         for test_path in (_backend_relative(path) for path in tests if path.is_file())
         if test_path not in LEGACY_UNLISTED_TESTS
     )
+
+
+def discover_all_tests() -> list[str]:
+    """Unit tests plus workflow-contract extras (e2e) for PR path selection only."""
+    tests = {Path(BACKEND_DIR / path) for path in discover_unit_tests()}
+    for path in EXTRA_DISCOVERABLE_TESTS:
+        if path.is_file():
+            tests.add(path)
+    return sorted(_backend_relative(path) for path in tests if path.is_file())
 
 
 def _backend_relative(path: Path) -> str:
@@ -360,7 +366,7 @@ def main() -> None:
     all_tests = discover_all_tests()
     reason = 'full backend unit suite'
     if args.all:
-        selected = all_tests
+        selected = discover_unit_tests()
     elif args.from_test_list:
         selected = existing_tests(read_lines(args.from_test_list), all_tests)
         reason = 'using provided backend unit test list'

--- a/backend/scripts/select_backend_unit_tests.py
+++ b/backend/scripts/select_backend_unit_tests.py
@@ -19,9 +19,11 @@ FULL_TEST_ROOTS = (
     BACKEND_DIR / 'tests' / 'unit',
     BACKEND_DIR / 'tests' / 'services',
     BACKEND_DIR / 'tests' / 'routers',
-    BACKEND_DIR / 'testing' / 'e2e',
 )
 FULL_TEST_GLOBS = (BACKEND_DIR / 'tests',)
+
+# Hermetic e2e tests selected by workflow contracts / memory policy core — not part of --all.
+EXTRA_DISCOVERABLE_TESTS = (BACKEND_DIR / 'testing' / 'e2e' / 'test_canonical_memory_pipeline.py',)
 
 LEGACY_UNLISTED_TESTS = {
     'tests/test_cache_manager.py',
@@ -64,6 +66,20 @@ FULL_RUN_GLOBS = (
     'backend/utils/http_client.py',
     'backend/utils/async_tasks.py',
     'backend/utils/encryption.py',
+)
+
+MEMORY_POLICY_CORE_PATH_PREFIXES = ('backend/utils/memory/',)
+
+MEMORY_POLICY_CORE_PATH_GLOBS = (
+    'backend/database/memory_*.py',
+    'backend/models/product_memory.py',
+    'backend/models/memory_search_gateway.py',
+    'backend/routers/memory_*.py',
+)
+
+MEMORY_POLICY_CORE_TESTS = (
+    'tests/unit/test_inv_mem_1_guard.py',
+    'testing/e2e/test_canonical_memory_pipeline.py',
 )
 
 AREA_TESTS = (
@@ -197,6 +213,9 @@ def discover_all_tests() -> list[str]:
         tests.update(root.rglob('test_*.py'))
     for root in FULL_TEST_GLOBS:
         tests.update(root.glob('test_*.py'))
+    for path in EXTRA_DISCOVERABLE_TESTS:
+        if path.is_file():
+            tests.add(path)
     return sorted(
         test_path
         for test_path in (_backend_relative(path) for path in tests if path.is_file())
@@ -243,6 +262,12 @@ def is_selectable_backend_path(path: str) -> bool:
 
 def path_matches(path: str, pattern: str) -> bool:
     return PurePosixPath(path).match(pattern)
+
+
+def is_memory_policy_core_path(path: str) -> bool:
+    if any(path.startswith(prefix) for prefix in MEMORY_POLICY_CORE_PATH_PREFIXES):
+        return True
+    return any(path_matches(path, pattern) for pattern in MEMORY_POLICY_CORE_PATH_GLOBS)
 
 
 def load_workflow_contracts() -> List[Dict[str, Any]]:
@@ -294,6 +319,9 @@ def tests_for_changed_paths(changed_paths: list[str], all_tests: list[str]) -> t
                 path_matches(path, pattern) for pattern in source_globs
             ):
                 selected.update(match_tests(all_tests, test_globs))
+
+    if any(is_memory_policy_core_path(path) for path in backend_paths):
+        selected.update(test for test in MEMORY_POLICY_CORE_TESTS if test in all_tests)
 
     if not backend_paths:
         return [], 'no backend files changed'

--- a/backend/scripts/select_backend_unit_tests.py
+++ b/backend/scripts/select_backend_unit_tests.py
@@ -75,6 +75,7 @@ MEMORY_POLICY_CORE_PATH_GLOBS = (
     'backend/models/product_memory.py',
     'backend/models/memory_search_gateway.py',
     'backend/routers/memory_*.py',
+    'backend/routers/memories.py',
 )
 
 MEMORY_POLICY_CORE_TESTS = (

--- a/backend/scripts/select_backend_unit_tests.py
+++ b/backend/scripts/select_backend_unit_tests.py
@@ -19,6 +19,7 @@ FULL_TEST_ROOTS = (
     BACKEND_DIR / 'tests' / 'unit',
     BACKEND_DIR / 'tests' / 'services',
     BACKEND_DIR / 'tests' / 'routers',
+    BACKEND_DIR / 'testing' / 'e2e',
 )
 FULL_TEST_GLOBS = (BACKEND_DIR / 'tests',)
 

--- a/backend/scripts/shared_ns2_legacy_isolation_readiness.py
+++ b/backend/scripts/shared_ns2_legacy_isolation_readiness.py
@@ -6,7 +6,19 @@ import json
 import os
 import sys
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any, Dict, List, Sequence
+
+SCRIPTS_DIR = Path(__file__).resolve().parent
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+from readiness_gate_common import (
+    add_require_go_arg,
+    collect_gates_from_artifact,
+    evaluate_gates,
+    exit_code_for_status,
+)
 
 SHARED_NAMESPACE = "ns2"
 
@@ -75,6 +87,7 @@ class SharedNs2LegacyIsolationConfig:
     api_key: str
     index_name: str
     index_host: str
+    require_go: bool = False
 
 
 def parse_args(argv: Sequence[str]) -> argparse.Namespace:
@@ -87,12 +100,14 @@ def parse_args(argv: Sequence[str]) -> argparse.Namespace:
     parser.add_argument("--api-key", default=os.getenv("PINECONE_API_KEY", ""))
     parser.add_argument("--index-name", default=os.getenv("PINECONE_INDEX_NAME", ""))
     parser.add_argument("--index-host", default=os.getenv("PINECONE_INDEX_HOST", ""))
+    add_require_go_arg(parser)
     return parser.parse_args(argv)
 
 
 def config_from_args(args: argparse.Namespace) -> SharedNs2LegacyIsolationConfig:
     return SharedNs2LegacyIsolationConfig(
         execute=bool(args.execute),
+        require_go=bool(args.require_go),
         api_key=str(args.api_key or ""),
         index_name=str(args.index_name or ""),
         index_host=str(args.index_host or ""),
@@ -143,6 +158,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     print(json.dumps(artifact, indent=2, sort_keys=True))
     if config.execute and artifact["prerequisites"]:
         return 2
+    if config.require_go:
+        overall_status, _ = evaluate_gates(collect_gates_from_artifact(artifact))
+        return exit_code_for_status(overall_status, require_go=True)
     return 0
 
 

--- a/backend/scripts/v3_dev_cloud_readiness.py
+++ b/backend/scripts/v3_dev_cloud_readiness.py
@@ -28,6 +28,11 @@ from v3_dev_cloud_proof import (
     build_target_preflight_report,
     write_prepared_bundle,
 )
+from readiness_gate_common import (
+    add_require_go_arg,
+    evaluate_gates,
+    exit_code_for_status,
+)
 
 
 def parse_args() -> argparse.Namespace:
@@ -40,6 +45,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument('--fixture-only', action='store_true')
     parser.add_argument('--proof-matrix-only', action='store_true')
     parser.add_argument('--candidate-manifest-only', action='store_true')
+    add_require_go_arg(parser)
     return parser.parse_args()
 
 
@@ -64,6 +70,9 @@ def main() -> int:
     else:
         result = build_target_preflight_report(env)
     print(json.dumps(result, indent=2, sort_keys=True, default=str))
+    if args.require_go:
+        overall_status, _ = evaluate_gates({'preflight': {'status': result.get('status', 'NOT_RUN')}})
+        return exit_code_for_status(overall_status, require_go=True)
     return 0
 
 

--- a/backend/scripts/vector_search_provider_readiness.py
+++ b/backend/scripts/vector_search_provider_readiness.py
@@ -6,7 +6,19 @@ import json
 import os
 import sys
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any, Dict, List, Sequence
+
+SCRIPTS_DIR = Path(__file__).resolve().parent
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+from readiness_gate_common import (
+    add_require_go_arg,
+    collect_gates_from_artifact,
+    evaluate_gates,
+    exit_code_for_status,
+)
 
 SHARED_NAMESPACE = "ns2"
 
@@ -153,6 +165,7 @@ class VectorSearchProviderReadinessConfig:
     firestore_project: str
     proof_uid: str
     proof_namespace: str
+    require_go: bool = False
 
 
 def parse_args(argv: Sequence[str]) -> argparse.Namespace:
@@ -166,12 +179,14 @@ def parse_args(argv: Sequence[str]) -> argparse.Namespace:
     parser.add_argument("--firestore-project", default=os.getenv("MEMORY_PROVIDER_PROOF_FIRESTORE_PROJECT", ""))
     parser.add_argument("--proof-uid", default=os.getenv("MEMORY_PROVIDER_PROOF_UID", ""))
     parser.add_argument("--proof-namespace", default=os.getenv("MEMORY_PROVIDER_PROOF_NAMESPACE", SHARED_NAMESPACE))
+    add_require_go_arg(parser)
     return parser.parse_args(argv)
 
 
 def config_from_args(args: argparse.Namespace) -> VectorSearchProviderReadinessConfig:
     return VectorSearchProviderReadinessConfig(
         execute=bool(args.execute),
+        require_go=bool(args.require_go),
         pinecone_api_key=str(args.pinecone_api_key or ""),
         pinecone_index_name=str(args.pinecone_index_name or ""),
         pinecone_index_host=str(args.pinecone_index_host or ""),
@@ -235,6 +250,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     print(json.dumps(artifact, indent=2, sort_keys=True))
     if config.execute and artifact["prerequisites"]:
         return 2
+    if config.require_go:
+        overall_status, _ = evaluate_gates(collect_gates_from_artifact(artifact))
+        return exit_code_for_status(overall_status, require_go=True)
     return 0
 
 

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -52,7 +52,9 @@ fi
 
 selected_tests=()
 while IFS= read -r test_path; do
-  [[ -n "$test_path" ]] && selected_tests+=("$test_path")
+  if [[ -n "$test_path" && "$test_path" != testing/e2e/* ]]; then
+    selected_tests+=("$test_path")
+  fi
 done < "$test_list_file"
 
 if [[ ${#selected_tests[@]} -eq 0 ]]; then

--- a/backend/testing/e2e/test_canonical_memory_pipeline.py
+++ b/backend/testing/e2e/test_canonical_memory_pipeline.py
@@ -27,13 +27,11 @@ from tests.unit.fixtures.memory_adapter_fakes import (
     memory_item,
     stored_item,
 )
-from tests.unit.test_ws_i_write_convergence import (
-    _sample_memory_payload,
-    extraction_memory_id,
-)
+from tests.unit.test_ws_i_write_convergence import _sample_memory_payload
 from utils.memory.canonical_consolidation import ConsolidationAgentBatch
 from utils.memory.canonical_memory_adapter import (
     delete_canonical_memory,
+    extraction_memory_id,
     neutral_vector_id_for_memory,
     write_canonical_extraction_memory,
 )
@@ -400,7 +398,7 @@ def _vector_store(fake_index, namespace: str = "ns2") -> dict:
     return fake_index._vectors[namespace]
 
 
-def _invoke_surface_reader(surface_name, grant_consumer, *, uid, db, rollout, policy, now):
+def _invoke_surface_reader(surface_name, *, uid, db, rollout, policy, now):
     if surface_name == "chat_text":
         return search_memory_default_chat_memories_text(uid=uid, query="coffee", limit=10, db_client=db, now=now)
     if surface_name == "chat_list":
@@ -505,7 +503,6 @@ class TestSurfaceDefaultAccessMatrix:
         )
         result = _invoke_surface_reader(
             surface_name,
-            grant_consumer,
             uid=uid,
             db=db,
             rollout=rollout,

--- a/backend/testing/e2e/test_canonical_memory_pipeline.py
+++ b/backend/testing/e2e/test_canonical_memory_pipeline.py
@@ -1,0 +1,549 @@
+"""Hermetic canonical memory pipeline E2E and surface default-access matrix."""
+
+from __future__ import annotations
+
+import json
+from contextlib import contextmanager
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+import pytest
+
+from config.memory_rollout import PASSED, MemoryRolloutMode, MemoryRolloutStageGate
+from fakes.firestore import seed_conversation
+from fakes.vector_search import install_vector_search_fakes
+from models.memories import MemoryCategory
+from models.memory_apply import MemoryControlState
+from models.product_memory import (
+    MemoryAccessPolicy,
+    MemoryConsumer,
+    MemoryItemStatus,
+    MemoryTier,
+    ProcessingState,
+)
+from tests.unit.canonical_cohort_test_helpers import set_canonical_cohort
+from tests.unit.fixtures.memory_adapter_fakes import (
+    FirestoreFake,
+    enabled_rollout_doc,
+    memory_item,
+    stored_item,
+)
+from tests.unit.test_ws_i_write_convergence import (
+    _sample_memory_payload,
+    extraction_memory_id,
+)
+from utils.memory.canonical_consolidation import ConsolidationAgentBatch
+from utils.memory.canonical_memory_adapter import (
+    delete_canonical_memory,
+    neutral_vector_id_for_memory,
+    write_canonical_extraction_memory,
+)
+from utils.memory.chat_memory_adapter import (
+    list_default_chat_memories_decision_text,
+    search_memory_default_chat_memories_text,
+)
+from utils.memory.default_read_rollout import GLOBAL_READ_GATE_PATH, MemoryReadDecision
+from utils.memory.developer_memory_adapter import search_memory_default_developer_memories
+from utils.memory.memory_service import MemoryService
+from utils.memory.product_memory_read_service import fetch_default_product_memory_search
+from utils.memory.short_term_promotion import run_canonical_short_term_maintenance
+from utils.retrieval.tool_services import memories as tool_memories_service
+
+NOW = datetime(2026, 6, 24, 12, 0, tzinfo=timezone.utc)
+PIPELINE_UID = "123"
+CONV_ID = "canonical-pipeline-conv-001"
+PIPELINE_CONTENT = "User prefers hermetic canonical memory pipeline coverage."
+
+
+def _trusted_generation_patch(monkeypatch) -> None:
+    trusted = SimpleNamespace(
+        account_generation=3,
+        head_commit_id="head0",
+        read_error_reason=None,
+    )
+    for target in (
+        "utils.memory.canonical_memory_adapter.read_memory_v3_trusted_account_generation",
+        "utils.memory.v3_account_generation_source.read_memory_v3_trusted_account_generation",
+    ):
+        monkeypatch.setattr(target, lambda **_: trusted, raising=False)
+
+
+def _promotion_side_effect_patches(monkeypatch) -> None:
+    from utils.memory.canonical_kg_promotion import CanonicalKgPromotionResult
+
+    monkeypatch.setattr(
+        "utils.memory.short_term_promotion.extract_kg_for_promoted_memory",
+        lambda *args, **kwargs: CanonicalKgPromotionResult(attempted=False, success=True),
+    )
+    monkeypatch.setattr(
+        "utils.memory.canonical_consolidation.query_memory_vector_candidates",
+        lambda *args, **kwargs: SimpleNamespace(hits=[], rejected_count=0),
+        raising=False,
+    )
+
+
+def _seed_apply_control(db, uid: str, *, account_generation: int = 3) -> None:
+    control = MemoryControlState(
+        uid=uid,
+        head_commit_id="head0",
+        account_generation=account_generation,
+        source_generation=1,
+    ).model_dump(mode="json")
+    (db.collection("users").document(uid).collection("memory_state").document("apply_control").set(control))
+
+
+def _seed_rollout_readiness(db, uid: str, *, grant_consumer: str) -> None:
+    db.collection("memory_control").document("global_read_gate").set(
+        {"memory_reads_enabled": True, "kill_switch_active": False}
+    )
+    db.collection("memory_control").document("write_convergence_gate").set(
+        {
+            "durable_outbox_enabled": True,
+            "dual_write_projection_ready": True,
+            "delete_convergence_ready": True,
+            "idempotency_contract_ready": True,
+        }
+    )
+    rollout = enabled_rollout_doc(uid, grant_consumer=grant_consumer)
+    rollout["mode"] = MemoryRolloutMode.read.value
+    rollout["stage_gates"] = {
+        MemoryRolloutStageGate.shadow.value: PASSED,
+        MemoryRolloutStageGate.write.value: PASSED,
+        MemoryRolloutStageGate.read.value: PASSED,
+    }
+    db.collection("users").document(uid).collection("memory_control").document("state").set(rollout)
+
+
+def _seed_memory_item_doc(db, item: MemoryItem) -> None:
+    (
+        db.collection("users")
+        .document(item.uid)
+        .collection("memory_items")
+        .document(item.memory_id)
+        .set(stored_item(item))
+    )
+
+
+def _read_memory_item(db, uid: str, memory_id: str) -> dict:
+    snapshot = db.collection("users").document(uid).collection("memory_items").document(memory_id).get()
+    assert snapshot.exists, f"missing memory item {memory_id}"
+    return snapshot.to_dict()
+
+
+def _list_outbox_records(db, uid: str) -> list[dict]:
+    records = []
+    for snapshot in db.collection("users").document(uid).collection("memory_outbox").stream():
+        if snapshot.exists:
+            records.append(snapshot.to_dict())
+    return records
+
+
+def _scripted_consolidation_llm(_prompt: str) -> str:
+    return json.dumps(ConsolidationAgentBatch(decisions=[], reasoning="no_changes").model_dump(mode="json"))
+
+
+def _enroll_canonical_pipeline(monkeypatch, uid: str = PIPELINE_UID) -> None:
+    set_canonical_cohort(monkeypatch, uid)
+    monkeypatch.setenv("MEMORY_CANONICAL_CONSOLIDATION_BATCH_THRESHOLD", "1")
+    monkeypatch.setattr("utils.memory.short_term_promotion.promotion_batch_threshold", lambda: 1)
+    monkeypatch.setattr("utils.memory.canonical_consolidation.consolidation_batch_threshold", lambda: 1)
+    monkeypatch.setattr("utils.other.endpoints._enforce_rate_limit", lambda *args, **kwargs: None)
+    _trusted_generation_patch(monkeypatch)
+    _promotion_side_effect_patches(monkeypatch)
+
+
+def _write_short_term_via_conversation_ingress(client, auth_headers, monkeypatch, *, db) -> str:
+    conv_data = {
+        "id": CONV_ID,
+        "created_at": "2025-01-15T12:00:00Z",
+        "started_at": "2025-01-15T12:00:00Z",
+        "finished_at": "2025-01-15T12:05:00Z",
+        "source": "omi",
+        "language": "en",
+        "structured": {
+            "title": "",
+            "overview": "",
+            "emoji": "🧠",
+            "category": "other",
+            "action_items": [],
+            "events": [],
+        },
+        "transcript_segments": [
+            {
+                "id": "seg-1",
+                "text": PIPELINE_CONTENT,
+                "speaker": "SPEAKER_00",
+                "is_user": True,
+                "start": 0.0,
+                "end": 2.0,
+            }
+        ],
+        "discarded": False,
+        "status": "completed",
+        "is_locked": False,
+        "data_protection_level": "standard",
+    }
+    seed_conversation(PIPELINE_UID, conv_data)
+    _seed_apply_control(db, PIPELINE_UID)
+
+    def fake_process_conversation(uid, language_code, conversation, **kwargs):
+        payload = _sample_memory_payload(
+            uid=uid,
+            conversation_id=conversation.id,
+            content=PIPELINE_CONTENT,
+        )
+        payload["category"] = MemoryCategory.system.value
+        memory_id = write_canonical_extraction_memory(uid, payload, db_client=db)
+        import database.conversations as conversations_db
+
+        structured = conversation.structured.model_dump() if hasattr(conversation.structured, "model_dump") else {}
+        structured.update(
+            {
+                "title": "Canonical pipeline capture",
+                "overview": PIPELINE_CONTENT,
+                "category": "work",
+            }
+        )
+        conversations_db.update_conversation(
+            uid,
+            conversation.id,
+            {"structured": structured, "status": "completed"},
+        )
+        refreshed = conversations_db.get_conversation(uid, conversation.id)
+        from utils.conversations.factory import deserialize_conversation
+
+        assert memory_id == payload["id"]
+        return deserialize_conversation(refreshed)
+
+    import routers.conversations as conversations_router
+
+    monkeypatch.setattr(conversations_router, "process_conversation", fake_process_conversation)
+
+    resp = client.post(f"/v1/conversations/{CONV_ID}/reprocess", headers=auth_headers)
+    assert resp.status_code == 200, resp.text
+    return extraction_memory_id(uid=PIPELINE_UID, source_id=CONV_ID, content=PIPELINE_CONTENT)
+
+
+@contextmanager
+def _override_memory_runtime(client, runtime):
+    import routers.memories as memories_router
+
+    client.app.dependency_overrides[memories_router.get_v3_get_runtime] = lambda: runtime
+    try:
+        yield
+    finally:
+        client.app.dependency_overrides.pop(memories_router.get_v3_get_runtime, None)
+
+
+def _runtime(*, enabled: bool, source_decision: str, service=None):
+    import routers.memories as memories_router
+
+    return memories_router.V3GetRuntime(
+        enabled=enabled,
+        source_decision=source_decision,
+        service=service,
+        adapters=object(),
+    )
+
+
+class TestCanonicalMemoryPipelineE2E:
+    def test_capture_consolidate_promote_read_archive_excluded_vectors_and_delete_outbox(
+        self, client, auth_headers, fake_firestore, monkeypatch
+    ):
+        import database.vector_db as vector_db
+
+        _enroll_canonical_pipeline(monkeypatch)
+        fake_index, _embeddings = install_vector_search_fakes(monkeypatch, vector_db)
+        db = fake_firestore
+        _seed_rollout_readiness(db, PIPELINE_UID, grant_consumer="omi_chat")
+
+        memory_id = _write_short_term_via_conversation_ingress(client, auth_headers, monkeypatch, db=db)
+        short_term = _read_memory_item(db, PIPELINE_UID, memory_id)
+        assert short_term["tier"] == MemoryTier.short_term.value
+        assert short_term["status"] == MemoryItemStatus.active.value
+
+        maintenance = run_canonical_short_term_maintenance(
+            PIPELINE_UID,
+            db_client=db,
+            now=NOW,
+            run_id="e2e-canonical-pipeline",
+            llm_invoke=_scripted_consolidation_llm,
+        )
+        assert maintenance.skipped_reason is None
+        assert maintenance.consolidation.skipped_reason is None
+        assert maintenance.promotion.promoted_count == 1
+        assert maintenance.promotion.vector_sync_failures == 0
+
+        promoted = _read_memory_item(db, PIPELINE_UID, memory_id)
+        assert promoted["memory_id"] == memory_id
+        assert promoted["tier"] == MemoryTier.long_term.value
+
+        vectors = _vector_store(fake_index)
+        assert memory_id in vectors, "promotion should upsert canonical vector using memory_id"
+        assert vectors[memory_id]["metadata"]["memory_id"] == memory_id
+        assert vectors[memory_id]["metadata"]["memory_layer"] == MemoryTier.long_term.value
+
+        from utils.memory.product_memory_read_service import fetch_authoritative_product_memory_items
+        from database.vector_db import upsert_canonical_memory_vector
+        from models.product_memory import MemoryItem
+
+        promoted_item = MemoryItem(**promoted)
+        projection_commit_id = promoted_item.ledger_commit_id or "head0"
+        assert upsert_canonical_memory_vector(promoted_item, projection_commit_id=projection_commit_id) is not None
+        authoritative_items = {
+            item.memory_id: item for item in fetch_authoritative_product_memory_items(uid=PIPELINE_UID, db_client=db)
+        }
+        assert memory_id in authoritative_items
+        assert authoritative_items[memory_id].content == promoted_item.content
+        assert vectors[memory_id]["id"] == memory_id
+
+        archive_item = memory_item(
+            "archive-hidden",
+            uid=PIPELINE_UID,
+            tier=MemoryTier.archive,
+            now=NOW,
+            content="archive should stay hidden",
+            quote_text="archive quote",
+        )
+        visible_item = memory_item(
+            "visible-long-term",
+            uid=PIPELINE_UID,
+            tier=MemoryTier.long_term,
+            now=NOW,
+            content="visible long term fact",
+            quote_text="visible quote",
+        )
+        _seed_memory_item_doc(db, archive_item)
+        _seed_memory_item_doc(db, visible_item)
+
+        service = MemoryService(db_client=db)
+        read_ids = {memory.id for memory in service.read(PIPELINE_UID, limit=50)}
+        assert memory_id in read_ids
+        assert "archive-hidden" not in read_ids
+        assert "visible-long-term" in read_ids
+
+        chat_text = search_memory_default_chat_memories_text(
+            uid=PIPELINE_UID,
+            query="visible",
+            limit=10,
+            db_client=db,
+            now=NOW,
+        )
+        assert chat_text is not None
+        assert "archive-hidden" not in chat_text
+        assert "visible long term fact" in chat_text
+
+        product_policy = MemoryAccessPolicy(
+            consumer=MemoryConsumer.omi_chat,
+            app_has_default_memory_grant=True,
+            archive_capability=False,
+        )
+        product = fetch_default_product_memory_search(
+            uid=PIPELINE_UID,
+            query="visible",
+            db_client=db,
+            policy=product_policy,
+            now=NOW,
+        )
+        product_ids = {row["memory_id"] for row in product["items"]}
+        assert "archive-hidden" not in product_ids
+        assert "visible-long-term" in product_ids
+
+        delete_canonical_memory(PIPELINE_UID, memory_id, db_client=db)
+        tombstoned = _read_memory_item(db, PIPELINE_UID, memory_id)
+        assert tombstoned["status"] == MemoryItemStatus.tombstoned.value
+
+        outbox_records = _list_outbox_records(db, PIPELINE_UID)
+        purge_records = [
+            record
+            for record in outbox_records
+            if record.get("memory_id") == memory_id and record.get("event_type") == "vector_repair_purge"
+        ]
+        assert purge_records, "delete should enqueue vector repair outbox records"
+        assert purge_records[0]["vector_id"] == neutral_vector_id_for_memory(memory_id)
+        assert purge_records[0]["reason"] == "canonical_memory_delete"
+
+    def test_dual_stack_projection_failure_fails_closed_without_legacy_bleed(
+        self, client, auth_headers, fake_firestore, monkeypatch
+    ):
+        from fakes.firestore import seed_memory
+
+        _enroll_canonical_pipeline(monkeypatch)
+        seed_memory(
+            PIPELINE_UID,
+            {
+                "id": "legacy-must-not-bleed",
+                "content": "legacy memory must not leak on canonical projection failure",
+                "category": "manual",
+                "visibility": "public",
+            },
+        )
+
+        def failing_memory_service(_params, _adapters):
+            from utils.memory.v3_composed_get_service import V3ComposedResponse
+
+            return V3ComposedResponse.error(503, "infrastructure_failure")
+
+        with _override_memory_runtime(
+            client,
+            _runtime(enabled=True, source_decision="memory_read", service=failing_memory_service),
+        ):
+            resp = client.get("/v3/memories", headers=auth_headers)
+
+        assert resp.status_code == 503
+        assert resp.json() == {"detail": "infrastructure_failure"}
+        assert resp.headers["x-omi-memory-read-source"] == "none"
+        assert resp.headers["x-omi-memory-read-decision"] == "infrastructure_failure"
+        assert "legacy-must-not-bleed" not in resp.text
+
+
+def _vector_store(fake_index, namespace: str = "ns2") -> dict:
+    return fake_index._vectors[namespace]
+
+
+def _invoke_surface_reader(surface_name, grant_consumer, *, uid, db, rollout, policy, now):
+    if surface_name == "chat_text":
+        return search_memory_default_chat_memories_text(uid=uid, query="coffee", limit=10, db_client=db, now=now)
+    if surface_name == "chat_list":
+        return list_default_chat_memories_decision_text(uid=uid, limit=10, offset=0, db_client=db).text
+    if surface_name == "developer":
+        return search_memory_default_developer_memories(
+            uid=uid,
+            query="coffee",
+            limit=10,
+            offset=0,
+            db_client=db,
+            rollout_decision=rollout,
+            now=now,
+        ).memories
+    if surface_name == "agent_tools":
+        return tool_memories_service.get_memories_text(uid=uid, limit=50)
+    if surface_name == "mcp":
+        return MemoryService(db_client=db).search_mcp(uid, "coffee", limit=10)
+    if surface_name == "product_search":
+        return fetch_default_product_memory_search(
+            uid=uid,
+            query="coffee",
+            db_client=db,
+            policy=policy,
+            now=now,
+        )["items"]
+    raise AssertionError(f"unknown surface {surface_name}")
+
+
+SURFACE_MATRIX_CASES = [
+    pytest.param("chat_text", "omi_chat", id="chat_text"),
+    pytest.param("chat_list", "omi_chat", id="chat_list"),
+    pytest.param("developer", "developer_api", id="developer"),
+    pytest.param("agent_tools", "omi_chat", id="agent_tools"),
+    pytest.param("mcp", "mcp", id="mcp"),
+    pytest.param("product_search", "omi_chat", id="product_search"),
+]
+
+
+class TestSurfaceDefaultAccessMatrix:
+    @pytest.mark.parametrize("surface_name,grant_consumer", SURFACE_MATRIX_CASES)
+    def test_surface_excludes_archive_and_respects_grants(
+        self, fake_firestore, monkeypatch, surface_name, grant_consumer
+    ):
+        from utils.memory.default_read_rollout import read_default_read_rollout
+
+        uid = f"uid-surface-{surface_name}"
+        set_canonical_cohort(monkeypatch, uid)
+        _trusted_generation_patch(monkeypatch)
+        monkeypatch.setattr(
+            "utils.memory.memory_service.canonical_read_enabled",
+            lambda uid, **kwargs: True,
+        )
+        if surface_name in {"mcp", "agent_tools"}:
+            import database.vector_db as vector_db
+
+            install_vector_search_fakes(monkeypatch, vector_db)
+        db = fake_firestore
+        _seed_apply_control(db, uid)
+        _seed_rollout_readiness(db, uid, grant_consumer=grant_consumer)
+
+        fresh_short = memory_item(
+            "fresh-short",
+            uid=uid,
+            now=NOW,
+            content="coffee fresh short term",
+            quote_text="fresh quote",
+            processing_state=ProcessingState.processed,
+        )
+        long_term = memory_item(
+            "long-term",
+            uid=uid,
+            tier=MemoryTier.long_term,
+            now=NOW,
+            content="coffee long term",
+            quote_text="long quote",
+        )
+        archive = memory_item(
+            "archive-item",
+            uid=uid,
+            tier=MemoryTier.archive,
+            now=NOW,
+            content="coffee archive memory",
+            quote_text="archive quote",
+        )
+        for item in (archive, fresh_short, long_term):
+            _seed_memory_item_doc(db, item)
+
+        if surface_name == "mcp":
+            from database.vector_db import upsert_canonical_memory_vector
+
+            for item in (fresh_short, long_term):
+                upsert_canonical_memory_vector(item, projection_commit_id="projection-1")
+
+        rollout = read_default_read_rollout(uid=uid, db_client=db, consumer=grant_consumer)
+        assert rollout.read_decision == MemoryReadDecision.USE_MEMORY
+
+        policy = MemoryAccessPolicy(
+            consumer=MemoryConsumer(grant_consumer),
+            app_has_default_memory_grant=True,
+            archive_capability=False,
+        )
+        result = _invoke_surface_reader(
+            surface_name,
+            grant_consumer,
+            uid=uid,
+            db=db,
+            rollout=rollout,
+            policy=policy,
+            now=NOW,
+        )
+
+        if surface_name == "product_search":
+            ids = [row["memory_id"] for row in result]
+            assert "archive-item" not in ids
+            assert set(ids) == {"fresh-short", "long-term"}
+        elif surface_name == "developer":
+            ids = [row["id"] for row in result]
+            assert "archive-item" not in ids
+            assert set(ids) == {"fresh-short", "long-term"}
+        elif surface_name == "mcp":
+            ids = {row["id"] for row in result}
+            assert "archive-item" not in ids
+            assert "long-term" in ids
+        elif surface_name == "agent_tools":
+            assert "archive-item" not in (result or "")
+            assert "coffee archive memory" not in (result or "")
+            assert "coffee fresh short term" in (result or "")
+        else:
+            text = result or ""
+            assert "archive-item" not in text
+            assert "coffee archive memory" not in text
+            assert "coffee fresh short term" in text or "coffee long term" in text
+
+        grantless_rollout = read_default_read_rollout(
+            uid=uid,
+            db_client=FirestoreFake(
+                {
+                    GLOBAL_READ_GATE_PATH: {"memory_reads_enabled": True, "kill_switch_active": False},
+                    f"users/{uid}/memory_control/state": enabled_rollout_doc(uid, grant_consumer=grant_consumer)
+                    | {"grants": {grant_consumer: {}}},
+                }
+            ),
+            consumer=grant_consumer,
+        )
+        assert grantless_rollout.read_decision == MemoryReadDecision.DENY_MEMORY

--- a/backend/testing/workflow_contracts.json
+++ b/backend/testing/workflow_contracts.json
@@ -191,11 +191,10 @@
       "risk": "high",
       "sources": [
         "backend/utils/memory/**",
-        "backend/utils/memory_ingestion/**",
-        "backend/testing/e2e/test_canonical_memory_pipeline.py"
+        "backend/utils/memory_ingestion/**"
       ],
       "tests": ["testing/e2e/test_canonical_memory_pipeline.py"],
-      "checks": [],
+      "checks": ["no_large_tuple_results"],
       "invariants": [
         "capture→consolidate→promote→read with archive excluded from default reads",
         "canonical fail-closed without legacy bleed"

--- a/backend/testing/workflow_contracts.json
+++ b/backend/testing/workflow_contracts.json
@@ -187,6 +187,21 @@
       ]
     },
     {
+      "id": "canonical_memory_pipeline",
+      "risk": "high",
+      "sources": [
+        "backend/utils/memory/**",
+        "backend/utils/memory_ingestion/**",
+        "backend/testing/e2e/test_canonical_memory_pipeline.py"
+      ],
+      "tests": ["testing/e2e/test_canonical_memory_pipeline.py"],
+      "checks": [],
+      "invariants": [
+        "capture→consolidate→promote→read with archive excluded from default reads",
+        "canonical fail-closed without legacy bleed"
+      ]
+    },
+    {
       "id": "listen_pusher_pipeline",
       "risk": "high",
       "sources": [

--- a/backend/tests/.single_process_safe_subset
+++ b/backend/tests/.single_process_safe_subset
@@ -51,6 +51,7 @@ tests/unit/test_mcp_oauth.py
 tests/unit/test_async_webhooks.py
 tests/unit/test_people_conversations_500s.py
 tests/unit/test_v3_account_generation_source.py
+tests/unit/test_inv_mem_1_guard.py
 tests/unit/test_memory_apply_store.py
 tests/unit/test_memory_evidence_persistence.py
 tests/unit/test_memory_ledger.py

--- a/backend/tests/fast_unit_duration_allowlist.txt
+++ b/backend/tests/fast_unit_duration_allowlist.txt
@@ -169,3 +169,5 @@ tests/unit/test_sync_cloud_tasks.py::test_sync_post_enqueue_cleanup_does_not_uns
 # File-isolation amortizes router/STT/VAD imports across different node IDs per run.
 tests/unit/test_sync_cloud_tasks.py
 tests/unit/test_fallback_observability.py
+tests/unit/test_inv_mem_1_guard.py::TestInvMemSourceRatchet::test_no_non_canonical_product_tier_literals_in_memory_paths
+tests/unit/test_inv_mem_1_guard.py::TestInvMemSourceRatchet::test_default_read_paths_do_not_include_archive_without_explicit_mode

--- a/backend/tests/unit/test_inv_mem_1_guard.py
+++ b/backend/tests/unit/test_inv_mem_1_guard.py
@@ -1,0 +1,464 @@
+"""INV-MEM-1/2/3 — Product memory tier, vector hydration, and canonical fail-closed guards.
+
+Behavioral characterization plus source ratchet (no NEW violations) over memory
+invariant path globs. See docs/product/invariants/memory-*.md.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import List, Set, Tuple
+
+import pytest
+
+from config.memory_rollout import MemoryRolloutMode
+from database.memory_collections import MemoryCollections
+from models.memory_evidence import ArtifactPreservationState, MemoryEvidence, SourceState
+from models.memory_search_gateway import SearchDecision, SearchMode, SearchVectorHit, hydrate_and_filter_vector_hits
+from models.product_memory import (
+    MemoryAccessPolicy,
+    MemoryItemStatus,
+    MemoryTier,
+    ProcessingState,
+    MemoryItem,
+    is_default_access_eligible,
+)
+from utils.memory.memory_read_api import query_default_product_memory_items
+from utils.memory.v3_control_reader_contract import (
+    V3ControlDecisionReason,
+    V3ControlReadResult,
+    V3ControlReaderRequest,
+    V3ControlRouteFamily,
+    V3ControlState,
+    decide_v3_control_route,
+)
+
+BACKEND_DIR = Path(__file__).resolve().parents[2]
+
+PRODUCT_TIERS = frozenset({"short_term", "long_term", "archive"})
+
+# Frozen allowlist of existing MemoryCollections @property names. Any new property
+# is a ratchet violation (INV-MEM-1: one canonical product-memory collection).
+_ALLOWED_MEMORY_COLLECTIONS_PROPERTIES = frozenset(
+    {
+        "user_root",
+        "memory_items",
+        "memory_operations",
+        "memory_outbox",
+        "memory_control_state",
+        "memory_apply_control_state",
+        "memory_lineage",
+        "memory_evidence",
+        "memory_runs",
+        "memory_import_runs",
+        "memory_import_artifacts",
+        "memory_import_candidates",
+        "non_active_memory_routes",
+        "short_term_lifecycle_transitions",
+        "legacy_fallback",
+        "memory_commits",
+        "memory_state",
+        "memory_state_head",
+        "v3_compatibility_projection_state",
+        "v3_compatibility_projection_items",
+        "all_collection_paths",
+    }
+)
+
+# Per-line markers that indicate archive is used only on explicit archive paths.
+_ARCHIVE_EXPLICIT_MARKERS = (
+    "archive_explicit",
+    "archive_capability",
+    "archive_requested",
+    "archive_allowed",
+    "is_archive_access_eligible",
+    "query_archive_product_memory_items",
+    "build_archive_memory_vector_filter",
+    "SearchMode.archive_explicit",
+    "archive_requires_explicit_query",
+    "archive_explicit_allowed",
+    "explicit_archive_memory",
+    "not_archive",
+)
+
+# Known legacy/debt: existing occurrences exempt from the archive-default-read ratchet.
+_ARCHIVE_DEFAULT_READ_LINE_ALLOWLIST: Tuple[Tuple[str, int], ...] = (("database/memory_vector_metadata.py", 119),)
+
+# Scan roots for INV-MEM source ratchet.
+_RATchet_SCAN_GLOBS = (
+    "database/memory_*.py",
+    "utils/memory/**/*.py",
+    "models/product_memory.py",
+    "models/memory_search_gateway.py",
+)
+
+
+def _evidence() -> MemoryEvidence:
+    return MemoryEvidence(
+        evidence_id="ev_guard",
+        source_id="conv_guard",
+        source_type="conversation",
+        source_version="v1",
+        artifact_preservation=ArtifactPreservationState.preserved,
+    )
+
+
+def _item(
+    memory_id: str,
+    *,
+    tier: MemoryTier = MemoryTier.short_term,
+    content: str = "memory content",
+    expires_at: datetime | None = None,
+) -> MemoryItem:
+    now = datetime.now(timezone.utc)
+    if expires_at is None and tier == MemoryTier.short_term:
+        expires_at = now + timedelta(days=30)
+    return MemoryItem(
+        memory_id=memory_id,
+        uid="u_guard",
+        version=1,
+        tier=tier,
+        status=MemoryItemStatus.active,
+        processing_state=ProcessingState.processed,
+        content=content,
+        evidence=[_evidence()],
+        source_state=SourceState.active,
+        sensitivity_labels=[],
+        visibility="private",
+        user_asserted=False,
+        captured_at=now - timedelta(days=1),
+        updated_at=now,
+        expires_at=expires_at,
+        ledger_commit_id="commit_lt" if tier == MemoryTier.long_term else None,
+        ledger_sequence=1 if tier == MemoryTier.long_term else None,
+        item_revision=1,
+        source_commit_id=f"source-{memory_id}",
+        content_hash=f"hash-{memory_id}",
+        account_generation=0,
+    )
+
+
+def _vector_hit(item: MemoryItem, *, score: float = 0.9) -> SearchVectorHit:
+    return SearchVectorHit(
+        memory_id=item.memory_id,
+        score=score,
+        projection_commit_id="commit_proj",
+        vector_updated_at=item.updated_at,
+        uid=item.uid,
+        account_generation=item.account_generation,
+        item_revision=item.item_revision,
+        source_commit_id=item.source_commit_id,
+        content_hash=item.content_hash,
+    )
+
+
+def _v3_request(**overrides) -> V3ControlReaderRequest:
+    values = {
+        "uid": "uid-guard",
+        "expected_account_generation": 7,
+        "cursor_memory_read_requested": False,
+        "cursor_secret_config_present": True,
+        "archive_requested": False,
+    }
+    values.update(overrides)
+    return V3ControlReaderRequest(**values)
+
+
+def _v3_state(**overrides) -> V3ControlState:
+    values = {
+        "uid": "uid-guard",
+        "schema_version": 1,
+        "configured_mode": MemoryRolloutMode.read,
+        "persisted_mode": MemoryRolloutMode.read,
+        "effective_mode": MemoryRolloutMode.read,
+        "mode_epoch": 1,
+        "cutover_epoch": 1,
+        "account_generation": 7,
+        "default_memory_grant": True,
+        "archive_allowed": False,
+        "rollout_write_ready": True,
+        "projection_ready": True,
+        "global_read_gate_open": True,
+        "write_convergence_ready": True,
+    }
+    values.update(overrides)
+    return V3ControlState(**values)
+
+
+def _v3_result(**overrides) -> V3ControlReadResult:
+    values = {
+        "cohort_enrolled": True,
+        "source_path": "users/uid-guard/memory_control/state",
+        "state": _v3_state(),
+        "read_error_reason": None,
+    }
+    values.update(overrides)
+    return V3ControlReadResult(**values)
+
+
+def _iter_ratchet_python_files() -> List[Path]:
+    files: Set[Path] = set()
+    for pattern in _RATchet_SCAN_GLOBS:
+        for path in BACKEND_DIR.glob(pattern):
+            if path.is_file() and path.suffix == ".py":
+                files.add(path)
+    return sorted(files)
+
+
+def _relative_backend_path(path: Path) -> str:
+    return path.relative_to(BACKEND_DIR).as_posix()
+
+
+def _memory_collections_unlisted_properties(tree: ast.Module) -> List[str]:
+    offenders: List[str] = []
+    for node in tree.body:
+        if not isinstance(node, ast.ClassDef) or node.name != "MemoryCollections":
+            continue
+        for child in node.body:
+            if not isinstance(child, ast.FunctionDef):
+                continue
+            is_property = any(
+                isinstance(decorator, ast.Name) and decorator.id == "property" for decorator in child.decorator_list
+            )
+            if not is_property:
+                continue
+            if child.name not in _ALLOWED_MEMORY_COLLECTIONS_PROPERTIES:
+                offenders.append(child.name)
+    return offenders
+
+
+def _tier_assignment_offenders(tree: ast.Module, *, rel_path: str) -> List[str]:
+    offenders: List[str] = []
+
+    def _check_tier_value(value_node: ast.AST, context: str) -> None:
+        if isinstance(value_node, ast.Constant) and isinstance(value_node.value, str):
+            if value_node.value not in PRODUCT_TIERS:
+                offenders.append(f"{rel_path}: {context} uses tier literal {value_node.value!r}")
+        elif isinstance(value_node, ast.Attribute) and isinstance(value_node.value, ast.Name):
+            enum_name = value_node.value.id
+            member = value_node.attr
+            if enum_name in {"MemoryTier", "MemoryLayer"} and member not in PRODUCT_TIERS:
+                offenders.append(f"{rel_path}: {context} uses {enum_name}.{member}")
+
+    class _TierVisitor(ast.NodeVisitor):
+        def visit_Assign(self, node: ast.Assign) -> None:
+            for target in node.targets:
+                if isinstance(target, ast.Name) and target.id in {"tier", "memory_tier"}:
+                    _check_tier_value(node.value, f"tier assignment at line {node.lineno}")
+                elif isinstance(target, ast.Attribute) and target.attr in {"tier", "memory_tier"}:
+                    _check_tier_value(node.value, f"tier assignment at line {node.lineno}")
+            self.generic_visit(node)
+
+        def visit_AnnAssign(self, node: ast.AnnAssign) -> None:
+            if isinstance(node.target, ast.Name) and node.target.id in {"tier", "memory_tier"} and node.value:
+                _check_tier_value(node.value, f"annotated tier at line {node.lineno}")
+            self.generic_visit(node)
+
+        def visit_Compare(self, node: ast.Compare) -> None:
+            for comparator in node.comparators:
+                if isinstance(comparator, ast.Attribute) and isinstance(comparator.value, ast.Name):
+                    if comparator.value.id in {"MemoryTier", "MemoryLayer"} and comparator.attr not in PRODUCT_TIERS:
+                        offenders.append(
+                            f"{rel_path}: tier comparison at line {node.lineno} uses "
+                            f"{comparator.value.id}.{comparator.attr}"
+                        )
+            self.generic_visit(node)
+
+        def visit_Call(self, node: ast.Call) -> None:
+            for keyword in node.keywords:
+                if keyword.arg in {"tier", "memory_tier"}:
+                    _check_tier_value(keyword.value, f"keyword {keyword.arg} at line {node.lineno}")
+            self.generic_visit(node)
+
+    _TierVisitor().visit(tree)
+    return offenders
+
+
+def _archive_default_read_offenders(path: Path, text: str) -> List[str]:
+    rel_path = _relative_backend_path(path)
+    offenders: List[str] = []
+    lines = text.splitlines()
+    archive_line_re = re.compile(r"Memory(?:Tier|Layer)\.archive\b")
+
+    for index, line in enumerate(lines, start=1):
+        if (rel_path, index) in _ARCHIVE_DEFAULT_READ_LINE_ALLOWLIST:
+            continue
+        if not archive_line_re.search(line):
+            continue
+
+        window_start = max(0, index - 8)
+        window_end = min(len(lines), index + 8)
+        window = "\n".join(lines[window_start:window_end])
+        if any(marker in window for marker in _ARCHIVE_EXPLICIT_MARKERS):
+            continue
+        offenders.append(f"{rel_path}:{index}: archive tier without explicit archive context")
+    return offenders
+
+
+class TestInvMem1DefaultAccessAndCanonicalCollection:
+    """INV-MEM-1: three tiers, default access is short_term + long_term only."""
+
+    def test_default_access_policy_allows_short_and_long_term_only(self):
+        now = datetime.now(timezone.utc)
+        policy = MemoryAccessPolicy.for_omi_chat()
+        short = _item("mem_st", tier=MemoryTier.short_term, content="short term fact")
+        long_term = _item(
+            "mem_lt",
+            tier=MemoryTier.long_term,
+            content="long term fact",
+            expires_at=None,
+        )
+        archive = _item(
+            "mem_ar",
+            tier=MemoryTier.archive,
+            content="archived fact",
+            expires_at=None,
+        )
+
+        assert is_default_access_eligible(short, policy, now=now).allowed is True
+        assert is_default_access_eligible(long_term, policy, now=now).allowed is True
+        assert is_default_access_eligible(archive, policy, now=now).allowed is False
+        assert is_default_access_eligible(archive, policy, now=now).reason == "archive_requires_explicit_query"
+
+    def test_query_default_product_memory_items_excludes_archive(self):
+        now = datetime.now(timezone.utc)
+        policy = MemoryAccessPolicy.for_omi_chat()
+        items = [
+            _item("mem_st", tier=MemoryTier.short_term, content="coffee short"),
+            _item("mem_lt", tier=MemoryTier.long_term, content="coffee long", expires_at=None),
+            _item("mem_ar", tier=MemoryTier.archive, content="coffee archive", expires_at=None),
+        ]
+
+        results = query_default_product_memory_items("coffee", items, policy=policy, now=now)
+        result_ids = {entry["memory_id"] for entry in results}
+
+        assert result_ids == {"mem_st", "mem_lt"}
+        assert "mem_ar" not in result_ids
+
+    def test_memory_collections_canonical_product_memory_path_is_memory_items(self):
+        paths = MemoryCollections(uid="u_guard")
+
+        assert paths.memory_items == "users/u_guard/memory_items"
+        assert paths.memory_items in paths.all_collection_paths()
+        assert "memory_short_term" not in paths.all_collection_paths()
+        assert "memory_archive" not in paths.all_collection_paths()
+
+
+class TestInvMem2VectorHydrationFailClosed:
+    """INV-MEM-2: vector hits are candidate IDs only; hydration is authoritative."""
+
+    def test_missing_authoritative_items_are_excluded_with_repair_candidates(self):
+        present = _item("mem_present", tier=MemoryTier.long_term, content="present", expires_at=None)
+        hits = [
+            _vector_hit(present, score=0.95),
+            SearchVectorHit(
+                memory_id="mem_missing",
+                score=0.9,
+                projection_commit_id="commit_proj",
+                vector_updated_at=present.updated_at,
+            ),
+        ]
+
+        result = hydrate_and_filter_vector_hits(
+            hits=hits,
+            authoritative_items={"mem_present": present},
+            policy=MemoryAccessPolicy.for_omi_chat(),
+            mode=SearchMode.default,
+            required_projection_commit_id="commit_proj",
+            required_account_generation=0,
+        )
+
+        assert [entry.item.memory_id for entry in result.results] == ["mem_present"]
+        assert result.decisions["mem_missing"] == SearchDecision.missing_authoritative_item
+        assert result.repair_purge_candidates
+        assert any(candidate["memory_id"] == "mem_missing" for candidate in result.repair_purge_candidates)
+
+    def test_stale_projection_fails_closed_with_empty_results(self):
+        item = _item("mem_stale", tier=MemoryTier.long_term, content="stale", expires_at=None)
+        hits = [_vector_hit(item, score=0.9)]
+        hits[0] = hits[0].model_copy(update={"projection_commit_id": "stale_commit"})
+
+        result = hydrate_and_filter_vector_hits(
+            hits=hits,
+            authoritative_items={"mem_stale": item},
+            policy=MemoryAccessPolicy.for_omi_chat(),
+            mode=SearchMode.default,
+            required_projection_commit_id="commit_proj",
+            required_account_generation=0,
+        )
+
+        assert result.results == []
+        assert result.decisions["mem_stale"] == SearchDecision.stale_projection
+        assert result.repair_purge_candidates
+
+    def test_archive_hits_denied_in_default_mode_without_repair_candidates(self):
+        archive = _item("mem_arch", tier=MemoryTier.archive, content="archived", expires_at=None)
+        hits = [_vector_hit(archive, score=0.9)]
+
+        result = hydrate_and_filter_vector_hits(
+            hits=hits,
+            authoritative_items={"mem_arch": archive},
+            policy=MemoryAccessPolicy.for_omi_chat(),
+            mode=SearchMode.default,
+            required_projection_commit_id="commit_proj",
+            required_account_generation=0,
+        )
+
+        assert result.results == []
+        assert result.decisions["mem_arch"] == SearchDecision.access_denied
+        assert result.repair_purge_candidates == []
+
+
+class TestInvMem3CanonicalFailClosedNoLegacyFallback:
+    """INV-MEM-3: enrolled read-mode never falls back to legacy on failure."""
+
+    @pytest.mark.parametrize(
+        ("control_result", "expected_reason"),
+        [
+            (_v3_result(state=None), V3ControlDecisionReason.MISSING_CONTROL_DOC),
+            (_v3_result(state=_v3_state(account_generation=6)), V3ControlDecisionReason.STALE_GENERATION),
+            (_v3_result(state=_v3_state(projection_ready=False)), V3ControlDecisionReason.PROJECTION_NOT_READY),
+        ],
+    )
+    def test_enrolled_read_mode_fail_closed_without_legacy_fallback(self, control_result, expected_reason):
+        decision = decide_v3_control_route(_v3_request(), control_result)
+
+        assert decision.route_family == V3ControlRouteFamily.FAIL_CLOSED
+        assert decision.allowed is False
+        assert decision.reason == expected_reason
+        assert decision.fallback_to_legacy_allowed is False
+        assert decision.requires_legacy_reader is False
+
+
+class TestInvMemSourceRatchet:
+    """Source ratchet: forbid NEW violations in memory invariant path globs."""
+
+    def test_scan_paths_are_non_empty(self):
+        files = _iter_ratchet_python_files()
+        assert files, "INV-MEM ratchet scan found no Python files"
+
+    def test_memory_collections_has_no_new_collection_path_properties(self):
+        offenders: List[str] = []
+        collections_path = BACKEND_DIR / "database" / "memory_collections.py"
+        tree = ast.parse(collections_path.read_text(encoding="utf-8"))
+        for name in _memory_collections_unlisted_properties(tree):
+            offenders.append(f"database/memory_collections.py: unlisted MemoryCollections property {name!r}")
+        assert offenders == [], "INV-MEM-1 unlisted MemoryCollections properties:\n" + "\n".join(offenders)
+
+    def test_no_non_canonical_product_tier_literals_in_memory_paths(self):
+        offenders: List[str] = []
+        for path in _iter_ratchet_python_files():
+            rel_path = _relative_backend_path(path)
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+            offenders.extend(_tier_assignment_offenders(tree, rel_path=rel_path))
+        assert offenders == [], "INV-MEM-1 forbidden product tier literals:\n" + "\n".join(offenders)
+
+    def test_default_read_paths_do_not_include_archive_without_explicit_mode(self):
+        offenders: List[str] = []
+        for path in _iter_ratchet_python_files():
+            text = path.read_text(encoding="utf-8")
+            offenders.extend(_archive_default_read_offenders(path, text))
+        assert offenders == [], "INV-MEM-1 forbidden archive in default-read paths:\n" + "\n".join(offenders)

--- a/backend/tests/unit/test_inv_mem_1_guard.py
+++ b/backend/tests/unit/test_inv_mem_1_guard.py
@@ -199,6 +199,24 @@ def _v3_result(**overrides) -> V3ControlReadResult:
     return V3ControlReadResult(**values)
 
 
+_RATchet_PARSE_CACHE: dict[str, ast.Module] = {}
+_RATchet_TEXT_CACHE: dict[str, str] = {}
+
+
+def _file_text(path: Path) -> str:
+    key = path.as_posix()
+    if key not in _RATchet_TEXT_CACHE:
+        _RATchet_TEXT_CACHE[key] = path.read_text(encoding="utf-8")
+    return _RATchet_TEXT_CACHE[key]
+
+
+def _parsed_tree(path: Path) -> ast.Module:
+    key = path.as_posix()
+    if key not in _RATchet_PARSE_CACHE:
+        _RATchet_PARSE_CACHE[key] = ast.parse(_file_text(path))
+    return _RATchet_PARSE_CACHE[key]
+
+
 def _iter_ratchet_python_files() -> List[Path]:
     files: Set[Path] = set()
     for pattern in _RATchet_SCAN_GLOBS:
@@ -452,13 +470,13 @@ class TestInvMemSourceRatchet:
         offenders: List[str] = []
         for path in _iter_ratchet_python_files():
             rel_path = _relative_backend_path(path)
-            tree = ast.parse(path.read_text(encoding="utf-8"))
+            tree = _parsed_tree(path)
             offenders.extend(_tier_assignment_offenders(tree, rel_path=rel_path))
         assert offenders == [], "INV-MEM-1 forbidden product tier literals:\n" + "\n".join(offenders)
 
     def test_default_read_paths_do_not_include_archive_without_explicit_mode(self):
         offenders: List[str] = []
         for path in _iter_ratchet_python_files():
-            text = path.read_text(encoding="utf-8")
+            text = _file_text(path)
             offenders.extend(_archive_default_read_offenders(path, text))
         assert offenders == [], "INV-MEM-1 forbidden archive in default-read paths:\n" + "\n".join(offenders)

--- a/backend/tests/unit/test_memory_system_cohort.py
+++ b/backend/tests/unit/test_memory_system_cohort.py
@@ -12,10 +12,6 @@ os.environ.setdefault(
 )
 
 from tests.unit.canonical_cohort_test_helpers import clear_canonical_cohort, set_canonical_cohort
-from tests.unit.memory_import_isolation import ensure_utils_memory_packages_importable
-
-ensure_utils_memory_packages_importable()
-
 from utils.memory.memory_system import (
     CANONICAL_MEMORY_USERS,
     MemorySystem,

--- a/backend/tests/unit/test_readiness_require_go.py
+++ b/backend/tests/unit/test_readiness_require_go.py
@@ -1,0 +1,133 @@
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[2] / "scripts"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+from readiness_gate_common import (
+    GATE_STATUS_BLOCKED,
+    GATE_STATUS_GO,
+    GATE_STATUS_NOT_RUN,
+    collect_gates_from_artifact,
+    evaluate_gates,
+    exit_code_for_status,
+)
+
+
+def _load_module(name: str, script_name: str):
+    script_path = SCRIPTS_DIR / script_name
+    spec = importlib.util.spec_from_file_location(name, script_path)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_evaluate_gates_all_go():
+    gates = {
+        "gate_a": {"status": GATE_STATUS_GO},
+        "gate_b": {"status": GATE_STATUS_GO},
+    }
+    status, blockers = evaluate_gates(gates)
+    assert status == GATE_STATUS_GO
+    assert blockers == []
+
+
+def test_evaluate_gates_blocked_over_not_run():
+    gates = {
+        "blocked_gate": {"status": GATE_STATUS_BLOCKED},
+        "not_run_gate": {"status": GATE_STATUS_NOT_RUN},
+    }
+    status, blockers = evaluate_gates(gates)
+    assert status == GATE_STATUS_BLOCKED
+    assert blockers == ["blocked_gate:BLOCKED", "not_run_gate:NOT_RUN"]
+
+
+def test_evaluate_gates_empty_is_not_run():
+    status, blockers = evaluate_gates({})
+    assert status == GATE_STATUS_NOT_RUN
+    assert blockers == ["no_gates_defined"]
+
+
+def test_exit_code_for_status_inventory_mode_always_zero():
+    assert exit_code_for_status(GATE_STATUS_GO, require_go=False) == 0
+    assert exit_code_for_status(GATE_STATUS_BLOCKED, require_go=False) == 0
+    assert exit_code_for_status(GATE_STATUS_NOT_RUN, require_go=False) == 0
+
+
+def test_exit_code_for_status_require_go_only_passes_on_go():
+    assert exit_code_for_status(GATE_STATUS_GO, require_go=True) == 0
+    assert exit_code_for_status(GATE_STATUS_BLOCKED, require_go=True) == 1
+    assert exit_code_for_status(GATE_STATUS_NOT_RUN, require_go=True) == 1
+    assert exit_code_for_status("READY_TO_EXECUTE_DEV_CLOUD_PROOF", require_go=True) == 1
+
+
+def test_collect_gates_from_artifact_includes_proof_cases():
+    artifact = {
+        "status": GATE_STATUS_NOT_RUN,
+        "proof_cases": {
+            "case_a": {"status": GATE_STATUS_NOT_RUN},
+            "case_b": {"status": GATE_STATUS_BLOCKED},
+        },
+    }
+    gates = collect_gates_from_artifact(artifact)
+    assert gates["overall"]["status"] == GATE_STATUS_NOT_RUN
+    assert gates["proof_case:case_b"]["status"] == GATE_STATUS_BLOCKED
+
+
+@pytest.mark.parametrize(
+    "script_name",
+    [
+        "cutover_evidence_readiness.py",
+        "vector_search_provider_readiness.py",
+        "rollout_schema_readiness.py",
+        "shared_ns2_legacy_isolation_readiness.py",
+        "pinecone_repair_validation_readiness.py",
+        "v3_dev_cloud_readiness.py",
+    ],
+)
+def test_readiness_scripts_default_exit_zero(script_name: str):
+    result = subprocess.run(
+        [sys.executable, str(SCRIPTS_DIR / script_name)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.parametrize(
+    "script_name",
+    [
+        "cutover_evidence_readiness.py",
+        "vector_search_provider_readiness.py",
+        "rollout_schema_readiness.py",
+        "shared_ns2_legacy_isolation_readiness.py",
+        "pinecone_repair_validation_readiness.py",
+        "v3_dev_cloud_readiness.py",
+    ],
+)
+def test_readiness_scripts_require_go_exits_nonzero(script_name: str):
+    result = subprocess.run(
+        [sys.executable, str(SCRIPTS_DIR / script_name), "--require-go"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 1, result.stderr
+
+
+def test_cutover_require_go_uses_gate_inventory():
+    module = _load_module("cutover_evidence_readiness_test", "cutover_evidence_readiness.py")
+    config = module.CutoverEvidenceReadinessConfig(execute=False, require_go=True)
+    artifact = module.build_readiness_artifact(config)
+    status, blockers = evaluate_gates(collect_gates_from_artifact(artifact))
+    assert status == GATE_STATUS_BLOCKED
+    assert any("milestone_oracle_final_approval:BLOCKED" in blocker for blocker in blockers)

--- a/backend/tests/unit/test_workflow_contracts.py
+++ b/backend/tests/unit/test_workflow_contracts.py
@@ -25,6 +25,7 @@ def test_workflow_contract_sources_select_adjacent_tests():
     }
     selected_cases = {
         "backend/utils/memory/legacy_backfill.py": "tests/unit/test_ws_c_backfill.py",
+        "backend/utils/memory/canonical_memory_adapter.py": "testing/e2e/test_canonical_memory_pipeline.py",
         "backend/services/users/account_deletion.py": "tests/services/users/test_account_deletion.py",
         "backend/routers/sync.py": "tests/unit/test_sync_v2.py",
         "backend/routers/transcribe.py": "tests/unit/test_listen_pipeline.py",

--- a/backend/tests/unit/test_workflow_contracts.py
+++ b/backend/tests/unit/test_workflow_contracts.py
@@ -13,6 +13,19 @@ def _load_script(name: str):
     return module
 
 
+def test_memory_policy_core_change_selects_inv_mem_guard():
+    """Narrow memory policy PRs always pull INV-MEM guard tests."""
+    selector = _load_script("select_backend_unit_tests")
+    all_tests = selector.discover_all_tests()
+
+    selected, reason = selector.tests_for_changed_paths(
+        ["backend/utils/memory/chat_memory_adapter.py"],
+        all_tests,
+    )
+    assert "tests/unit/test_inv_mem_1_guard.py" in selected
+    assert reason == "selected backend unit tests from changed paths and workflow contracts"
+
+
 def test_workflow_contract_sources_select_adjacent_tests():
     selector = _load_script("select_backend_unit_tests")
     all_tests = selector.discover_all_tests()

--- a/docs/operational/memory_readiness_evidence_markers.md
+++ b/docs/operational/memory_readiness_evidence_markers.md
@@ -6,6 +6,8 @@ Full Oracle milestone reviews and implementation journals live in the benchmark 
 
 **Status:** production rollout remains **BLOCKED / NO-GO**; `production_rollout_approved=false`.
 
+Readiness scripts default to read-only inventory mode (exit `0`, JSON on stdout). For CI or gate checks that must fail closed, pass `--require-go` so the script exits non-zero unless every evaluated gate status is `GO`. This does not change reported gate statuses or claim production approval.
+
 ---
 
 ## Rollout schema (P1-1)

--- a/docs/product/invariants/README.md
+++ b/docs/product/invariants/README.md
@@ -17,6 +17,8 @@ rules stay in [`AGENTS.md`](../../../AGENTS.md). Product north star:
 |----|-------|--------|-----|
 | INV-CHAT-1 | One shared transcript across surfaces | locked | [chat-continuity.md](./chat-continuity.md) |
 | INV-MEM-1 | Exactly three product memory tiers | locked | [memory-tiers.md](./memory-tiers.md) |
+| INV-MEM-2 | Vector hydration fail-closed | locked | [memory-vector-hydration.md](./memory-vector-hydration.md) |
+| INV-MEM-3 | No legacy fallback after canonical selection | locked | [memory-canonical-fail-closed.md](./memory-canonical-fail-closed.md) |
 | INV-AGENT-* | Agent control-plane contracts | locked | [agent-control-plane.md](./agent-control-plane.md) |
 | INV-INT-1 | Integrations harness over heuristics | locked | [integrations.md](./integrations.md) |
 | INV-UI-1 | No purple; neutral accents | locked | [brand-ui.md](./brand-ui.md) |

--- a/docs/product/invariants/memory-canonical-fail-closed.md
+++ b/docs/product/invariants/memory-canonical-fail-closed.md
@@ -1,0 +1,43 @@
+# INV-MEM-3: No legacy fallback after canonical selection
+
+**Status:** locked
+**Statement:** After canonical memory rollout selection places a user in enrolled
+read-mode, control/projection/generation failures must fail closed. Legacy
+memory readers must not be used as a fallback when the canonical projection path
+is unavailable.
+
+## MUST NOT
+
+- Fall back to legacy memory reads for enrolled read-mode users when control doc
+  read, generation, gate, projection, or cursor checks fail.
+- Treat legacy fallback as a recovery path for projection-not-ready or stale
+  generation in enrolled read-mode.
+
+## Surfaces
+
+- `utils.memory.v3_control_reader_contract` route decisions
+- `utils.memory.default_read_rollout` rollout wiring
+- `utils.memory.v3_memory_read_service` canonical read service
+
+## Guard tests
+
+- `backend/tests/unit/test_inv_mem_1_guard.py` — behavioral tests for
+  `decide_v3_control_route` (missing control doc, stale generation, projection
+  not ready) asserting `FAIL_CLOSED` and `fallback_to_legacy_allowed=False`
+
+## Path globs
+
+- `backend/utils/memory/v3_control_reader_contract.py`
+- `backend/utils/memory/default_read_rollout.py`
+- `backend/utils/memory/v3_memory_read_service.py`
+- `backend/utils/memory/v3_production_runtime.py`
+
+## PR rule
+
+Name `INV-MEM-3` in the PR body if you touch the path globs above.
+
+## Related
+
+- [memory-tiers.md](./memory-tiers.md) — INV-MEM-1 tier vocabulary
+- [memory-vector-hydration.md](./memory-vector-hydration.md) — INV-MEM-2 vector
+  hydration fail-closed

--- a/docs/product/invariants/memory-tiers.md
+++ b/docs/product/invariants/memory-tiers.md
@@ -20,9 +20,11 @@ default access policy of Short-term + Long-term.
 
 ## Guard tests
 
-- Normative architecture and domain model are the contract; backend unit/contract
-  tests that pin tier vocabulary and default access must stay green when those
-  paths change. See linked docs for the authoritative schema and policy.
+- `backend/tests/unit/test_inv_mem_1_guard.py` — default access policy
+  (`short_term` + `long_term` only), canonical `memory_items` collection path,
+  source ratchet against new tier-store collections and non-canonical tier literals
+- Normative architecture and domain model remain the contract; see linked docs for
+  authoritative schema and policy
 
 ## Path globs
 

--- a/docs/product/invariants/memory-vector-hydration.md
+++ b/docs/product/invariants/memory-vector-hydration.md
@@ -1,0 +1,45 @@
+# INV-MEM-2: Vector hydration fail-closed
+
+**Status:** locked
+**Statement:** Vector search hits are candidate memory IDs only. Every hit
+must hydrate against an authoritative `memory_items` record and pass projection
+freshness and access checks before it may appear in user-visible results.
+Missing or stale hydration fails closed (empty or filtered results plus repair
+candidates), never raw vector IDs.
+
+## MUST NOT
+
+- Return vector hits directly without authoritative hydration.
+- Treat Pinecone/vector metadata as the source of truth for product memory content.
+- Fail open when hydration rejects a hit (silent drop without repair telemetry is
+  allowed only when access policy denies the item, not when the item is missing
+  or stale).
+
+## Surfaces
+
+- `models.memory_search_gateway` hydration gateway
+- `utils.memory.vector_search_service` vector search orchestration
+- Vector repair outbox and metadata adapters under `database/memory_vector_*`
+
+## Guard tests
+
+- `backend/tests/unit/test_inv_mem_1_guard.py` — behavioral tests for
+  `hydrate_and_filter_vector_hits` (missing authoritative items, stale projection,
+  archive denied in default mode without repair candidates)
+- `backend/tests/unit/test_memory_search_gateway.py` — extended hydration gateway cases
+
+## Path globs
+
+- `backend/models/memory_search_gateway.py`
+- `backend/utils/memory/vector_search_service.py`
+- `backend/database/memory_vector_*.py`
+
+## PR rule
+
+Name `INV-MEM-2` in the PR body if you touch the path globs above.
+
+## Related
+
+- [memory-tiers.md](./memory-tiers.md) — INV-MEM-1 default access policy
+- [memory-canonical-fail-closed.md](./memory-canonical-fail-closed.md) — INV-MEM-3
+  enrolled read routing


### PR DESCRIPTION
## Summary

Builds a layered memory confidence gate matrix (like chat continuity):

- **INV-MEM-1/2/3** locked invariants with behavioral guards + backend source ratchet (`test_inv_mem_1_guard.py`)
- **Hermetic pipeline E2E** (`test_canonical_memory_pipeline.py`): capture→consolidate→promote→read, surface default-access matrix, enrolled fail-closed negative
- **PR adjacency**: memory policy path changes always pull INV-MEM guard + pipeline E2E
- **Memory continuity gauntlet** (`memory-continuity-gauntlet.py --self-check`) with evidence bundles
- **Gate 2 tooling**: `--require-go` fail-closed on readiness scripts (no GO claimed, no allowlist expansion)

Touches invariant path globs: **INV-MEM-1**, **INV-MEM-2**, **INV-MEM-3**

## Gate matrix

| Gate | Covers | Does not cover |
| ---- | ------ | -------------- |
| INV-MEM guards + ratchet | Tier policy, collection path, hydration/fail-closed routing | Live LLM extraction quality |
| Hermetic pipeline E2E | Full capture→promote→read with fakes | Production Firestore/IAM |
| Gauntlet `--self-check` | Wiring + workflow registration | Any live turn |
| Live gauntlet (`--suite all`) | Structural hermetic path today; live when creds available | Write-path unit invariants |
| `--require-go` readiness | Executable BLOCKED/NOT_RUN enforcement | Does not claim Gate 2 GO |

## Test plan

- [x] `pytest tests/unit/test_inv_mem_1_guard.py -v` (13 passed)
- [x] `bash testing/e2e/run.sh -k canonical_memory` (8 passed)
- [x] `python3 backend/scripts/memory-continuity-gauntlet.py --self-check`
- [x] `pytest tests/unit/test_readiness_require_go.py -q` (19 passed)
- [x] `pytest tests/unit/test_workflow_contracts.py -q` (7 passed)
- [x] Pre-push unit selection + duration guard green locally

## Milestone commits

| Milestone | SHA |
| --------- | --- |
| A — INV-MEM guards | `81a2735f4d` |
| B — Hermetic pipeline E2E | `8d0814d0a8` |
| E — Isolation / adjacency | `ad68fb8257` |
| C — Memory gauntlet | `5808caf130` |
| D — Gate 2 `--require-go` | `037b4d0467` |
| Push fix (ratchet duration) | `HEAD` |

**Not claimed:** Gate 2 GO, production `CANONICAL_MEMORY_USERS` expansion, or dev-cloud proof evidence.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9328?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

