### PR TITLE
Bump build number to 992 for mobile release

### DIFF
--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -3,7 +3,7 @@ description: A new Flutter project.
 
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.543+990
+version: 1.0.543+992
 
 
 environment:


### PR DESCRIPTION
## Summary

- Bump build from 990 → 992
- Build 990 landed on iOS TestFlight but Play Store internal already has 991 (from concurrent android-internal-auto)
- New build 992 = max(TestFlight 990, Play 991) + 1

## Context

- Release issue: #9307
- Build 981 PR: #9314 (too low)
- Build 990 PR: #9321 (iOS OK, Android rejected)

_by AI for @beastoin_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9329?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

