### PR TITLE
fix BtDevice.fromJson crash - type 'String' is not a subtype of type 'int'

### DIFF
--- a/app/lib/backend/schema/bt_device/bt_device.dart
+++ b/app/lib/backend/schema/bt_device/bt_device.dart
@@ -655,17 +655,21 @@ class BtDevice {
 
   // from json
   static fromJson(Map<String, dynamic> json) {
+    // Persisted values may be missing or mistyped (e.g. rssi stored as a
+    // String by an older app version) — never throw during deserialization.
+    final rawRssi = json['rssi'];
+    final rssi = rawRssi is int ? rawRssi : (rawRssi is num ? rawRssi.toInt() : int.tryParse('$rawRssi') ?? 0);
     return BtDevice(
-      name: json['name'],
-      id: json['id'],
+      name: json['name'] is String ? json['name'] : '',
+      id: json['id'] is String ? json['id'] : '',
       type: _deviceTypeFromJson(json['type']),
-      rssi: json['rssi'],
-      locator: json['locator'] != null ? DeviceLocator.fromJson(json['locator']) : null,
-      modelNumber: json['modelNumber'],
-      firmwareRevision: json['firmwareRevision'],
-      hardwareRevision: json['hardwareRevision'],
-      manufacturerName: json['manufacturerName'],
-      serialNumber: json['serialNumber'],
+      rssi: rssi,
+      locator: json['locator'] is Map<String, dynamic> ? DeviceLocator.fromJson(json['locator']) : null,
+      modelNumber: json['modelNumber'] is String ? json['modelNumber'] : null,
+      firmwareRevision: json['firmwareRevision'] is String ? json['firmwareRevision'] : null,
+      hardwareRevision: json['hardwareRevision'] is String ? json['hardwareRevision'] : null,
+      manufacturerName: json['manufacturerName'] is String ? json['manufacturerName'] : null,
+      serialNumber: json['serialNumber'] is String ? json['serialNumber'] : null,
     );
   }
 

--- a/app/test/unit/bt_device_from_json_test.dart
+++ b/app/test/unit/bt_device_from_json_test.dart
@@ -1,0 +1,38 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:omi/backend/schema/bt_device/bt_device.dart';
+
+void main() {
+  group('BtDevice.fromJson', () {
+    test('parses a well-formed json round-trip', () {
+      final device = BtDevice(id: 'AA:BB:CC', name: 'Omi', type: DeviceType.omi, rssi: -60);
+      final restored = BtDevice.fromJson(device.toJson());
+      expect(restored.id, 'AA:BB:CC');
+      expect(restored.name, 'Omi');
+      expect(restored.type, DeviceType.omi);
+      expect(restored.rssi, -60);
+    });
+
+    // Regression: Crashlytics f47896e23d3d0823 — persisted rssi stored as a
+    // String crashed fromJson with "type 'String' is not a subtype of type 'int'".
+    test('does not throw when rssi is persisted as a String', () {
+      final restored = BtDevice.fromJson({'name': 'Omi', 'id': 'AA:BB:CC', 'type': 'omi', 'rssi': '-60'});
+      expect(restored.rssi, -60);
+    });
+
+    test('falls back to safe defaults for missing or mistyped fields', () {
+      final restored = BtDevice.fromJson({
+        'name': null,
+        'id': 42,
+        'type': 'omi',
+        'rssi': 'garbage',
+        'locator': 'not-a-map',
+        'modelNumber': 1,
+      });
+      expect(restored.name, '');
+      expect(restored.id, '');
+      expect(restored.rssi, 0);
+      expect(restored.locator, isNull);
+      expect(restored.modelNumber, 'Unknown');
+    });
+  });
+}


### PR DESCRIPTION
BtDevice.fromJson
FlutterError - type 'String' is not a subtype of type 'int'
package:omi/backend/schema/bt_device/bt_device.dart:65

https://console.firebase.google.com/u/0/project/based-hardware/crashlytics/app/ios:com.friend-app-with-wearable.ios12/issues/f47896e23d3d08230aa13d74bdeac58e?time=7d&types=crash&sessionEventKey=a09037c5c8ca4da2840d5b21dd66610f_2238885897443369172

Logs:

```
Fatal Exception: FlutterError
0  ???                            0x0 BtDevice.fromJson + 652 (bt_device.dart:652)
1  ???                            0x0 SharedPreferencesUtil.btDevice + 50 (preferences.dart:50)
2  ???                            0x0 DeviceProvider.initiateConnection + 278 (device_provider.dart:278)
3  ???                            0x0 _HomePageWrapperState.initState.<fn> + 91 (page.dart:91)
4  ???                            0x0 SchedulerBinding._invokeFrameCallback + 1434 (binding.dart:1434)
5  ???                            0x0 SchedulerBinding.handleDrawFrame + 1361 (binding.dart:1361)
6  ???                            0x0 SchedulerBinding.scheduleWarmUpFrame.<fn> + 1057 (binding.dart:1057)
7  ???                            0x0 _CustomZone.bindCallback.<fn> (dart:async)
8  ???                            0x0 TickerFuture.whenCompleteOrCancel.thunk + 450 (ticker.dart:450)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9331?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

