### PR TITLE
app: fix iOS 'failed to download audio' (missing sharePositionOrigin)

### DIFF
--- a/app/lib/pages/conversation_detail/page.dart
+++ b/app/lib/pages/conversation_detail/page.dart
@@ -468,6 +468,16 @@ class _ConversationDetailPageState extends State<ConversationDetailPage> with Ti
     HapticFeedback.lightImpact();
   }
 
+  // iOS requires a non-zero sharePositionOrigin (popover anchor); Share.shareXFiles
+  // throws a PlatformException without it.
+  Rect _shareSheetOrigin() {
+    final box = _shareButtonKey.currentContext?.findRenderObject() as RenderBox?;
+    if (box != null && box.hasSize && box.size.width > 0 && box.size.height > 0) {
+      return box.localToGlobal(Offset.zero) & box.size;
+    }
+    return const Rect.fromLTWH(0, 0, 100, 100);
+  }
+
   Future<void> _downloadAudio(BuildContext context, ConversationDetailProvider provider) async {
     if (!mounted) return;
 
@@ -541,7 +551,10 @@ class _ConversationDetailPageState extends State<ConversationDetailPage> with Ti
         }
 
         final mimeType = file.path.endsWith('.mp3') ? 'audio/mpeg' : 'audio/wav';
-        await Share.shareXFiles([XFile(file.path, mimeType: mimeType)]);
+        await Share.shareXFiles(
+          [XFile(file.path, mimeType: mimeType)],
+          sharePositionOrigin: _shareSheetOrigin(),
+        );
 
         // Track successful completion
         final durationSeconds = DateTime.now().difference(startTime).inSeconds;
@@ -830,17 +843,8 @@ class _ConversationDetailPageState extends State<ConversationDetailPage> with Ti
                                         conversation: provider.conversation,
                                         shareMethod: 'url_share',
                                       );
-                                      final RenderBox? box =
-                                          _shareButtonKey.currentContext?.findRenderObject() as RenderBox?;
-                                      final shareOrigin = box != null
-                                          ? Rect.fromLTWH(
-                                              box.localToGlobal(Offset.zero).dx,
-                                              box.localToGlobal(Offset.zero).dy,
-                                              box.size.width,
-                                              box.size.height,
-                                            )
-                                          : null;
-                                      shareConversationLink(provider.conversation, sharePositionOrigin: shareOrigin);
+                                      shareConversationLink(provider.conversation,
+                                          sharePositionOrigin: _shareSheetOrigin());
                                       // Small delay to let share sheet appear, then clear loading
                                       await Future.delayed(const Duration(milliseconds: 150));
                                       setState(() {


### PR DESCRIPTION
## Problem

Downloading/sharing a conversation's audio fails on iOS with "failed to download audio" — but the download actually **succeeds**; the iOS **share sheet** is what throws.

`_downloadAudio` downloads + combines the audio, then calls `Share.shareXFiles([XFile(...)])` at `conversation_detail/page.dart` **without `sharePositionOrigin`**. On `share_plus 11.0.0`, iOS requires a non-zero popover anchor, so it throws:

```
PlatformException(error, sharePositionOrigin: argument must be set, {{0,0},{0,0}} must be non-zero ...)
```

The catch block then shows the misleading `audioDownloadFailed` snackbar — the download bar completes, then it errors "at the very end," which is exactly what users report.

## Impact (PostHog, last 30 days)

- **423 "Audio Share Started" → 98 completed, 314 failed (~76% failure rate)**, overwhelmingly iOS (289 vs 25 Android).
- **~261 of the 314 failures (~83%)** are this exact `sharePositionOrigin` PlatformException.

## Fix

Add a `_shareSheetOrigin()` helper (anchored to the existing `_shareButtonKey`, with a non-zero fallback) and pass it to `Share.shareXFiles`. The sibling "share link" path already computed an origin inline — routed it through the same helper to DRY it and give it the same safe fallback.

Codebase already established this pattern (`developer.dart`, `wrapped_2025_page.dart`); the audio-download path had just missed it.

## Not included

- `utils/audio_player_utils.dart` (`shareAsAudio` for WAL/SD recordings) has the same missing-origin call but lives in a non-widget class with no render context and isn't a source of the tracked failures — separate follow-up.
- The secondary ~15% of failures (`Invalid WAV file: missing RIFF header`) is an artifact/combine issue, tracked separately.

## Verification
- `flutter analyze` on the file: no errors/warnings (only pre-existing `info` lints).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9334?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

