### PR TITLE
fix(app): treat benign 404 as recovery in processInProgressConversation (#9241)

### DIFF
--- a/app/lib/backend/http/api/conversations.dart
+++ b/app/lib/backend/http/api/conversations.dart
@@ -13,6 +13,16 @@ import 'package:omi/utils/debug_log_manager.dart';
 import 'package:omi/utils/logger.dart';
 import 'package:omi/utils/platform/platform_manager.dart';
 
+/// Whether a non-200 response from POST /v1/conversations (process in-progress
+/// conversation) is a benign race rather than a failure worth crash-reporting.
+///
+/// The backend returns 404 when there is no in-progress conversation to
+/// process — which happens when the WS auto-finalize path already consumed the
+/// in-progress conversation and cleared its Redis pointer before this
+/// client-initiated create ran. Nothing to recover; the conversation is
+/// already finalized. Reporting it floods crash reporting with noise.
+bool isBenignInProgressConversationCreateStatus(int statusCode) => statusCode == 404;
+
 Future<CreateConversationResponse?> processInProgressConversation() async {
   var response = await makeApiCall(
     url: '${Env.apiBaseUrl}v1/conversations',
@@ -24,8 +34,9 @@ Future<CreateConversationResponse?> processInProgressConversation() async {
   Logger.debug('createConversationServer: ${response.body}');
   if (response.statusCode == 200) {
     return CreateConversationResponse.fromGeneratedWireJson(jsonDecode(response.body) as Map<String, dynamic>);
+  } else if (isBenignInProgressConversationCreateStatus(response.statusCode)) {
+    Logger.debug('processInProgressConversation: no in-progress conversation (already finalized), skipping');
   } else {
-    // TODO: Server returns 304 doesn't recover
     PlatformManager.instance.crashReporter.reportCrash(
       Exception('Failed to create conversation'),
       StackTrace.current,

--- a/app/test/unit/process_in_progress_conversation_test.dart
+++ b/app/test/unit/process_in_progress_conversation_test.dart
@@ -1,0 +1,30 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:omi/backend/http/api/conversations.dart';
+
+/// Regression test for #9241: processInProgressConversation() used to
+/// crash-report every non-200 response from POST /v1/conversations. A benign
+/// 404 — raised when the WS auto-finalize path already consumed the
+/// in-progress conversation and cleared its Redis pointer before this
+/// client-initiated create ran — flooded crash reporting for a race with no
+/// user-visible impact (the conversation was already finalized).
+///
+/// The production code branches on isBenignInProgressConversationCreateStatus,
+/// so exercising that predicate covers the crash-vs-skip decision without the
+/// non-injectable makeApiCall / crashReporter singletons.
+void main() {
+  group('isBenignInProgressConversationCreateStatus', () {
+    test('404 is benign (WS already finalized the conversation) — no crash', () {
+      expect(isBenignInProgressConversationCreateStatus(404), isTrue);
+    });
+
+    test('genuine failures still report a crash', () {
+      for (final status in [304, 400, 401, 409, 429, 500, 502, 503]) {
+        expect(
+          isBenignInProgressConversationCreateStatus(status),
+          isFalse,
+          reason: 'status $status should not be treated as benign',
+        );
+      }
+    });
+  });
+}


### PR DESCRIPTION
## What

`processInProgressConversation()` in `app/lib/backend/http/api/conversations.dart` used to crash-report **every** non-200 response from `POST /v1/conversations`. A benign **404** now short-circuits to a debug log instead of a crash report; all other non-200 statuses still report a crash.

## Why

The backend endpoint (`backend/routers/conversations.py:162-165`) raises `404 "Conversation in progress not found"` when there is no in-progress conversation to process:

```python
conversation = retrieve_in_progress_conversation(uid)
if not conversation:
    raise HTTPException(status_code=404, detail="Conversation in progress not found")
redis_db.remove_in_progress_conversation_id(uid)
```

This is exactly the race described in the issue:

> Flutter crashes/reports when processInProgressConversation gets a benign 404 due to race with WS auto-finalize.

When the WS auto-finalize path finalizes the in-progress conversation and clears its Redis pointer first, a client-initiated create that races in finds nothing to process → 404. The conversation is already finalized, so there is nothing to recover — but the old code reported it as `Exception('Failed to create conversation')`, flooding crash reporting with noise that has no user-visible impact. The caller in `capture_controller.dart` already recovers gracefully on a `null` return (it removes the `'0'` processing placeholder).

## Change

- 404 → `Logger.debug(...)` and return `null` (benign, already-finalized).
- Every other non-200 → unchanged crash report.
- Extracted `isBenignInProgressConversationCreateStatus(int)` so the crash-vs-skip decision is covered by a hermetic regression test (the `makeApiCall` / `crashReporter` singletons aren't injectable — this mirrors the existing `sync_response_handling_test.dart` pattern of testing branching logic via a minimal abstraction).

## Verified

- Traced the exact backend 404 source and confirmed the caller already handles `null` without side effects.
- Added `app/test/unit/process_in_progress_conversation_test.dart` asserting 404 is benign and 304/400/401/409/429/5xx still report.
- **Could not run `app/test.sh` in this environment** — the build machine has no Flutter/Dart SDK. CI (`app` tests) will exercise the new unit test. The change is a single status-code branch with no visual surface.

Auto-generated from issue feedback by the mini issues-improver. Review before merge.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9340?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

