### PR TITLE
Improve desktop memory graph revisit performance

### DIFF
--- a/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
@@ -1113,7 +1113,9 @@ private struct PageContentView: View {
           appProvider: viewModelContainer.appProvider, chatProvider: viewModelContainer.chatProvider
         )
       case 3:
-        MemoriesPage(viewModel: viewModelContainer.memoriesViewModel)
+        MemoriesPage(
+          viewModel: viewModelContainer.memoriesViewModel,
+          graphViewModel: viewModelContainer.memoryGraphViewModel)
       case 4:
         TasksPage(
           viewModel: viewModelContainer.tasksViewModel,

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoriesPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoriesPage.swift
@@ -1350,6 +1350,7 @@ class MemoriesViewModel: ObservableObject {
 
 struct MemoriesPage: View {
   @ObservedObject var viewModel: MemoriesViewModel
+  let graphViewModel: MemoryGraphViewModel
   @State private var showCategoryFilter = false
   @State private var categorySearchText = ""
   @State private var pendingSelectedTags: Set<MemoryTag> = []
@@ -1948,7 +1949,7 @@ struct MemoriesPage: View {
   private var memoryList: some View {
     ScrollView {
       LazyVStack(alignment: .leading, spacing: 14) {
-        MemoryGraphInlineCard()
+        MemoryGraphInlineCard(viewModel: graphViewModel)
 
         LazyVStack(spacing: 10) {
           ForEach(viewModel.filteredMemories) { memory in

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryGraph/ForceDirectedSimulation.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryGraph/ForceDirectedSimulation.swift
@@ -68,6 +68,7 @@ class ForceDirectedSimulation {
     let maxSpeed: Float = 40
 
     private var tickCount = 0
+    private(set) var lastStepEnergy: Float = 0
     private var stableFrameCount = 0
     private let stableThreshold: Float = 0.2
     private let stableFramesRequired = 10
@@ -269,77 +270,149 @@ class ForceDirectedSimulation {
     }
 
     /// Run multiple physics steps synchronously (for initial layout)
-    /// Bypasses tick counting for full-speed computation.
+    /// Bypasses tick counting for full-speed computation. `ticks` is a
+    /// budget, not a quota — the loop exits as soon as the layout settles
+    /// (total kinetic energy below threshold for a run of steps).
+    /// Bulk layout for the initial build. Same math as `runPhysicsStep`,
+    /// but batched over contiguous value arrays: in unoptimized dev builds
+    /// the per-property class access in the hot loop is dominated by ARC
+    /// retain/release traffic, and the array form sidesteps it entirely.
+    /// Exits early when total kinetic energy plateaus while preserving the
+    /// same stability threshold the animated path uses.
     func runSync(ticks: Int) {
-        for _ in 0..<ticks {
-            runPhysicsStep()
-        }
-    }
-
-    /// One full physics step (no tick-skipping)
-    private func runPhysicsStep() {
-        // 1. Reset forces
-        for node in nodes {
-            node.force = .zero
-        }
-
-        // 2. Calculate repulsive forces (Coulomb-like)
+        stableFrameCount = 0
         let nodeCount = nodes.count
-        for i in 0..<nodeCount {
-            guard !nodes[i].isFixed else { continue }
+        guard nodeCount > 0 else { return }
 
-            for j in (i + 1)..<nodeCount {
-                let delta = nodes[j].position - nodes[i].position
-                let distSq = max(simd_length_squared(delta), 100)
+        // Snapshot node state into contiguous buffers
+        var positions = [SIMD3<Float>](repeating: .zero, count: nodeCount)
+        var velocities = [SIMD3<Float>](repeating: .zero, count: nodeCount)
+        var forces = [SIMD3<Float>](repeating: .zero, count: nodeCount)
+        var fixed = [Bool](repeating: false, count: nodeCount)
+        var indexOf: [String: Int] = [:]
+        indexOf.reserveCapacity(nodeCount)
+        for (index, node) in nodes.enumerated() {
+            positions[index] = node.position
+            velocities[index] = node.velocity
+            fixed[index] = node.isFixed
+            indexOf[node.id] = index
+        }
+        let springs: [(source: Int, target: Int)] = edges.compactMap { edge in
+            guard edge.affectsPhysics,
+                  let source = indexOf[edge.sourceId],
+                  let target = indexOf[edge.targetId] else { return nil }
+            return (source, target)
+        }
 
-                guard distSq < 100_000_000 else { continue }
+        var previousEnergy = Float.greatestFiniteMagnitude
+        var plateauSteps = 0
+        var energyStableSteps = 0
+        var executedSteps = 0
 
-                let dist = sqrt(distSq)
-                let direction = delta / dist
-                let forceMagnitude = repulsion / distSq
-                let force = direction * forceMagnitude
+        for step in 0..<ticks {
+            executedSteps = step + 1
 
-                nodes[i].force -= force
-                if !nodes[j].isFixed {
-                    nodes[j].force += force
+            // 1. Reset forces
+            for i in 0..<nodeCount { forces[i] = .zero }
+
+            // 2. Repulsion (Coulomb-like)
+            for i in 0..<nodeCount {
+                if fixed[i] { continue }
+                for j in (i + 1)..<nodeCount {
+                    let delta = positions[j] - positions[i]
+                    let distSq = max(simd_length_squared(delta), 100)
+                    guard distSq < 100_000_000 else { continue }
+                    let dist = sqrt(distSq)
+                    let force = (delta / dist) * (repulsion / distSq)
+                    forces[i] -= force
+                    if !fixed[j] { forces[j] += force }
                 }
             }
-        }
 
-        // 3. Calculate attractive forces
-        for edge in edges where edge.affectsPhysics {
-            guard let source = nodeMap[edge.sourceId],
-                  let target = nodeMap[edge.targetId] else { continue }
-
-            let delta = target.position - source.position
-            let dist = simd_length(delta)
-            guard dist > 0 else { continue }
-
-            let direction = delta / dist
-            let displacement = dist - restLength
-            let forceMagnitude = displacement * attraction
-            let force = direction * forceMagnitude
-
-            if !source.isFixed { source.force += force }
-            if !target.isFixed { target.force -= force }
-        }
-
-        // 4. Center gravity
-        for node in nodes where !node.isFixed {
-            node.force -= node.position * centerGravity
-        }
-
-        // 5. Update velocities and positions
-        for node in nodes where !node.isFixed {
-            node.velocity += node.force * dt
-            node.velocity *= damping
-
-            let speed = simd_length(node.velocity)
-            if speed > maxSpeed {
-                node.velocity = simd_normalize(node.velocity) * maxSpeed
+            // 3. Spring attraction
+            for spring in springs {
+                let delta = positions[spring.target] - positions[spring.source]
+                let dist = simd_length(delta)
+                guard dist > 0 else { continue }
+                let force = (delta / dist) * ((dist - restLength) * attraction)
+                if !fixed[spring.source] { forces[spring.source] += force }
+                if !fixed[spring.target] { forces[spring.target] -= force }
             }
-            node.position += node.velocity
+
+            // 4. Center gravity + 5. integrate
+            var totalEnergy: Float = 0
+            for i in 0..<nodeCount where !fixed[i] {
+                forces[i] -= positions[i] * centerGravity
+                velocities[i] += forces[i] * dt
+                velocities[i] *= damping
+                let speed = simd_length(velocities[i])
+                if speed > maxSpeed {
+                    velocities[i] = simd_normalize(velocities[i]) * maxSpeed
+                }
+                positions[i] += velocities[i]
+                totalEnergy += speed * speed
+            }
+            lastStepEnergy = totalEnergy
+            if totalEnergy < stableThreshold {
+                energyStableSteps += 1
+            } else {
+                energyStableSteps = 0
+            }
+
+            // 6. Plateau detection: layout has stopped improving when energy
+            // change stays below 1% for a sustained run of steps.
+            let delta = abs(previousEnergy - totalEnergy)
+            if delta < previousEnergy * 0.01 {
+                plateauSteps += 1
+                if plateauSteps >= 20 {
+                    logPerf(
+                        "MemoryGraph: layout plateaued after \(executedSteps)/\(ticks) ticks (energy \(totalEnergy))"
+                    )
+                    break
+                }
+            } else {
+                plateauSteps = 0
+            }
+            previousEnergy = totalEnergy
         }
+
+        if plateauSteps < 20 {
+            logPerf(
+                "MemoryGraph: layout budget exhausted (\(executedSteps) ticks, energy \(lastStepEnergy))"
+            )
+        }
+
+        // Write settled state back to the node objects
+        for (index, node) in nodes.enumerated() {
+            node.position = positions[index]
+            node.velocity = velocities[index]
+        }
+        stableFrameCount = min(energyStableSteps, stableFramesRequired)
+    }
+
+    /// Snapshot of every node's settled position, for layout caching.
+    func layoutPositions() -> [String: SIMD3<Float>] {
+        var positions: [String: SIMD3<Float>] = [:]
+        for node in nodes {
+            positions[node.id] = node.position
+        }
+        return positions
+    }
+
+    /// Restore a previously settled layout. Returns false (leaving positions
+    /// untouched for a fresh simulation) unless every node is covered.
+    func applyLayout(_ positions: [String: SIMD3<Float>]) -> Bool {
+        for node in nodes where !node.isFixed {
+            guard positions[node.id] != nil else { return false }
+        }
+        for node in nodes where !node.isFixed {
+            if let position = positions[node.id] {
+                node.position = position
+                node.velocity = .zero
+            }
+        }
+        stableFrameCount = stableFramesRequired
+        return true
     }
 
     /// Add new nodes and edges incrementally without clearing existing ones

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryGraph/MemoryGraphPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryGraph/MemoryGraphPage.swift
@@ -1,11 +1,12 @@
 import SceneKit
 import SwiftUI
+import OmiSupport
 import OmiTheme
 
 // MARK: - Memory Graph Page
 
 struct MemoryGraphPage: View {
-  @StateObject private var viewModel = MemoryGraphViewModel()
+  @ObservedObject var viewModel: MemoryGraphViewModel
   @Environment(\.dismiss) private var dismiss
 
   var body: some View {
@@ -70,7 +71,7 @@ struct MemoryGraphPage: View {
 }
 
 struct MemoryGraphInlineCard: View {
-  @StateObject private var viewModel = MemoryGraphViewModel()
+  @ObservedObject var viewModel: MemoryGraphViewModel
 
   var body: some View {
     VStack(alignment: .leading, spacing: 12) {
@@ -203,6 +204,15 @@ class MemoryGraphViewModel: ObservableObject {
   private var nodeSceneNodes: [String: SCNNode] = [:]
   private var edgeSceneNodes: [String: SCNNode] = [:]
   private var isAnimating = true
+  // Revisit guards: the VM is session-persistent (ViewModelContainer), so a
+  // page visit renders the existing scene instantly. Non-forced loads are
+  // TTL-throttled, single-flight, and skip the expensive re-simulation when
+  // the fetched graph is unchanged.
+  private var lastLoadedAt = Date.distantPast
+  private var isPreparing = false
+  private var hasRunEmptyBootstrap = false
+  private var loadedGraphSignature: Int?
+  private var sessionGeneration = 0
 
   init() {
     setupCamera()
@@ -243,54 +253,209 @@ class MemoryGraphViewModel: ObservableObject {
   // MARK: - Load Graph
 
   func prepareGraph() async {
-    await loadGraph()
-    if isEmpty {
-      await rebuildGraph()
+    guard !isPreparing else { return }
+    let generation = sessionGeneration
+    isPreparing = true
+    defer {
+      if generation == sessionGeneration {
+        isPreparing = false
+      }
+    }
+
+    // A rendered scene within the cooldown is served as-is — visiting the
+    // page must not refetch, re-run the force layout, or reset the camera.
+    if !isEmpty,
+      !PollingConfig.shouldAllowActivationRefresh(lastRefresh: lastLoadedAt)
+    {
+      return
+    }
+
+    await loadGraph(generation: generation)
+    guard generation == sessionGeneration else { return }
+
+    if isEmpty && !hasRunEmptyBootstrap {
+      // First-session bootstrap for sparse accounts: ask the backend to build
+      // the graph, then poll for it. Run once per session — not per visit.
+      guard await rebuildGraph(generation: generation) else { return }
+      hasRunEmptyBootstrap = true
       for _ in 1...10 {
         try? await Task.sleep(nanoseconds: 3_000_000_000)
-        await loadGraph()
+        guard generation == sessionGeneration else { return }
+        await loadGraph(generation: generation)
         if !isEmpty { break }
       }
     }
   }
 
   func loadGraph() async {
-    isLoading = true
-    defer { isLoading = false }
+    await loadGraph(generation: sessionGeneration)
+  }
+
+  private func loadGraph(generation: Int) async {
+    // Only surface the spinner while there's no scene to show — freshness
+    // checks over a rendered graph stay invisible.
+    let showSpinner = isEmpty
+    if showSpinner { isLoading = true }
+    defer {
+      if showSpinner && generation == sessionGeneration {
+        isLoading = false
+      }
+    }
 
     do {
       let response = try await fetchGraph()
+      guard generation == sessionGeneration else { return }
 
       log("Knowledge graph: \(response.nodes.count) nodes, \(response.edges.count) edges")
       isEmpty = response.nodes.isEmpty
+      lastLoadedAt = Date()
 
       guard !isEmpty else { return }
+
+      // Same graph as last time → keep the settled scene. Re-simulating and
+      // recreating scene nodes for identical data is what made every page
+      // visit visibly "reload" the brain map.
+      let signature = Self.graphSignature(of: response)
+      if signature == loadedGraphSignature {
+        return
+      }
+      loadedGraphSignature = signature
 
       // Populate simulation with user node at center
       let userName = AuthService.shared.displayName.isEmpty ? nil : AuthService.shared.givenName
       log("User name for center node: \(userName ?? "nil")")
+      let populateStart = CFAbsoluteTimeGetCurrent()
       simulation.populate(graphResponse: response, userNodeLabel: userName)
       log(
         "Simulation populated: \(simulation.nodes.count) nodes (including user), \(simulation.edges.count) edges"
       )
+      logPerf(
+        "MemoryGraph: populate", duration: CFAbsoluteTimeGetCurrent() - populateStart)
 
-      // Run initial layout off main thread for responsiveness
-      await Task.detached(priority: .userInitiated) { [simulation] in
-        simulation.runSync(ticks: 800)
-      }.value
+      // A settled layout for this exact graph renders instantly — restore it
+      // and skip both the physics run and the visual settle animation.
+      let layoutStart = CFAbsoluteTimeGetCurrent()
+      let restoredLayout =
+        loadCachedLayout(signature: signature).map { simulation.applyLayout($0) } ?? false
+      if !restoredLayout {
+        // Run initial layout off main thread for responsiveness
+        await Task.detached(priority: .userInitiated) { [simulation] in
+          simulation.runSync(ticks: 800)
+        }.value
+        guard generation == sessionGeneration else { return }
+        saveLayoutCache(signature: signature)
+      }
+      logPerf(
+        "MemoryGraph: layout (restored=\(restoredLayout))",
+        duration: CFAbsoluteTimeGetCurrent() - layoutStart)
+
+      guard generation == sessionGeneration else { return }
 
       // Create scene nodes
+      let sceneStart = CFAbsoluteTimeGetCurrent()
       createSceneNodes()
+      logPerf("MemoryGraph: scene build", duration: CFAbsoluteTimeGetCurrent() - sceneStart)
 
-      // Brief animation to settle, then stop
-      isAnimating = true
-      Task {
-        try? await Task.sleep(nanoseconds: 3_000_000_000)  // 3s of live physics
-        await MainActor.run { isAnimating = false }
+      if restoredLayout {
+        isAnimating = false
+      } else {
+        // Brief animation to settle, then stop
+        isAnimating = true
+        Task {
+          try? await Task.sleep(nanoseconds: 3_000_000_000)  // 3s of live physics
+          await MainActor.run { isAnimating = false }
+        }
       }
     } catch {
       log("Failed to load knowledge graph: \(error.localizedDescription)")
     }
+  }
+
+  private struct GraphLayoutCache: Codable {
+    let signature: Int
+    let positions: [String: [Float]]
+  }
+
+  private static func layoutCacheURL() -> URL? {
+    guard let userId = UserDefaults.standard.string(forKey: "auth_userId"), !userId.isEmpty
+    else { return nil }
+
+    let dir = DesktopLocalProfile.applicationSupportURL()
+      .appendingPathComponent("users", isDirectory: true)
+      .appendingPathComponent(userId, isDirectory: true)
+
+    do {
+      try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+      return dir.appendingPathComponent("memory-graph-layout.json")
+    } catch {
+      logError("MemoryGraph: failed to prepare layout cache directory", error: error)
+      return nil
+    }
+  }
+
+  private func loadCachedLayout(signature: Int) -> [String: SIMD3<Float>]? {
+    guard let url = Self.layoutCacheURL(), FileManager.default.fileExists(atPath: url.path)
+    else { return nil }
+
+    let cache: GraphLayoutCache
+    do {
+      let data = try Data(contentsOf: url)
+      cache = try JSONDecoder().decode(GraphLayoutCache.self, from: data)
+    } catch {
+      logError("MemoryGraph: failed to read layout cache", error: error)
+      return nil
+    }
+
+    guard cache.signature == signature else { return nil }
+    var positions: [String: SIMD3<Float>] = [:]
+    positions.reserveCapacity(cache.positions.count)
+    for (id, values) in cache.positions where values.count == 3 {
+      positions[id] = SIMD3<Float>(values[0], values[1], values[2])
+    }
+    return positions
+  }
+
+  private func saveLayoutCache(signature: Int) {
+    guard let url = Self.layoutCacheURL() else { return }
+    var positions: [String: [Float]] = [:]
+    for (id, position) in simulation.layoutPositions() {
+      positions[id] = [position.x, position.y, position.z]
+    }
+    let cache = GraphLayoutCache(signature: signature, positions: positions)
+    do {
+      let data = try JSONEncoder().encode(cache)
+      try data.write(to: url, options: .atomic)
+    } catch {
+      logError("MemoryGraph: failed to write layout cache", error: error)
+    }
+  }
+
+  /// Stable across launches — Swift's `Hasher` is per-process seeded, which
+  /// would silently invalidate the on-disk layout cache on every restart.
+  static func graphSignature(of response: KnowledgeGraphResponse) -> Int {
+    var hash: UInt64 = 0xcbf2_9ce4_8422_2325  // FNV-1a
+    func combine(_ string: String) {
+      for byte in string.utf8 {
+        hash ^= UInt64(byte)
+        hash = hash &* 0x0000_0100_0000_01b3
+      }
+      hash ^= 0xff
+      hash = hash &* 0x0000_0100_0000_01b3
+    }
+    combine(String(response.nodes.count))
+    combine(String(response.edges.count))
+    for node in response.nodes.sorted(by: { $0.id < $1.id }) {
+      combine(node.id)
+      combine(node.label)
+      combine(node.nodeType.rawValue)
+    }
+    for edge in response.edges.sorted(by: { $0.id < $1.id }) {
+      combine(edge.id)
+      combine(edge.sourceId)
+      combine(edge.targetId)
+      combine(edge.label)
+    }
+    return Int(bitPattern: UInt(truncatingIfNeeded: hash))
   }
 
   private func fetchGraph() async throws -> KnowledgeGraphResponse {
@@ -325,20 +490,33 @@ class MemoryGraphViewModel: ObservableObject {
 
   // MARK: - Rebuild Graph
 
-  func rebuildGraph() async {
+  @discardableResult
+  func rebuildGraph() async -> Bool {
+    await rebuildGraph(generation: sessionGeneration)
+  }
+
+  @discardableResult
+  private func rebuildGraph(generation: Int) async -> Bool {
     isRebuilding = true
-    defer { isRebuilding = false }
+    defer {
+      if generation == sessionGeneration {
+        isRebuilding = false
+      }
+    }
 
     do {
       _ = try await APIClient.shared.rebuildKnowledgeGraph()
 
       // Wait a bit for the backend to process
       try await Task.sleep(nanoseconds: 2_000_000_000)
+      guard generation == sessionGeneration else { return false }
 
       // Reload the graph
-      await loadGraph()
+      await loadGraph(generation: generation)
+      return true
     } catch {
       log("Failed to rebuild knowledge graph: \(error.localizedDescription)")
+      return false
     }
   }
 
@@ -346,7 +524,9 @@ class MemoryGraphViewModel: ObservableObject {
 
   /// Add new graph data from storage incrementally (used during onboarding)
   func addGraphFromStorage() async {
+    let generation = sessionGeneration
     let response = await KnowledgeGraphStorage.shared.loadGraph()
+    guard generation == sessionGeneration else { return }
     guard !response.nodes.isEmpty else { return }
     isEmpty = false
 
@@ -357,6 +537,7 @@ class MemoryGraphViewModel: ObservableObject {
     await Task.detached(priority: .userInitiated) { [simulation] in
       simulation.runSync(ticks: 200)
     }.value
+    guard generation == sessionGeneration else { return }
 
     // Create scene nodes for new entries, animate them in
     addNewSceneNodes()
@@ -368,6 +549,29 @@ class MemoryGraphViewModel: ObservableObject {
       try? await Task.sleep(nanoseconds: 3_000_000_000)
       await MainActor.run { isAnimating = false }
     }
+  }
+
+  func resetSessionState() {
+    sessionGeneration += 1
+    clearGraphScene()
+    simulation = ForceDirectedSimulation()
+    isLoading = false
+    isRebuilding = false
+    isEmpty = true
+    selectedNodeId = nil
+    isAnimating = false
+    lastLoadedAt = .distantPast
+    isPreparing = false
+    hasRunEmptyBootstrap = false
+    loadedGraphSignature = nil
+    cameraNode.position = SCNVector3(0, 0, 2000)
+  }
+
+  private func clearGraphScene() {
+    for (_, node) in nodeSceneNodes { node.removeFromParentNode() }
+    for (_, node) in edgeSceneNodes { node.removeFromParentNode() }
+    nodeSceneNodes.removeAll()
+    edgeSceneNodes.removeAll()
   }
 
   /// Create scene nodes only for simulation nodes/edges not yet in the scene
@@ -471,14 +675,20 @@ class MemoryGraphViewModel: ObservableObject {
 
   private func createSceneNodes() {
     // Clear existing nodes
-    for (_, node) in nodeSceneNodes { node.removeFromParentNode() }
-    for (_, node) in edgeSceneNodes { node.removeFromParentNode() }
-    nodeSceneNodes.removeAll()
-    edgeSceneNodes.removeAll()
+    clearGraphScene()
 
     // Billboard constraint for labels (always face camera)
     let billboardConstraint = SCNBillboardConstraint()
     billboardConstraint.freeAxes = [.X, .Y]
+
+    // Shared materials/geometry: nodes of the same type (and edges of the
+    // same type pair) are visually identical, so building one material per
+    // node/edge (~1,200 unique GPU objects for a mid-size graph) wasted both
+    // build time and draw-call batching. Cache by visual identity instead.
+    var edgeMaterialCache: [String: SCNMaterial] = [:]
+    var bodyMaterialCache: [String: SCNMaterial] = [:]
+    var glowMaterialCache: [String: SCNMaterial] = [:]
+    var sphereCache: [String: SCNSphere] = [:]
 
     // Create edges first (behind nodes)
     for edge in simulation.edges {
@@ -486,11 +696,20 @@ class MemoryGraphViewModel: ObservableObject {
         let target = simulation.nodeMap[edge.targetId]
       else { continue }
 
-      let edgeColor = blendColors(source.nodeType.nsColor, target.nodeType.nsColor, alpha: 0.25)
-      let edgeMaterial = SCNMaterial()
-      edgeMaterial.diffuse.contents = edgeColor
-      edgeMaterial.emission.contents = edgeColor.withAlphaComponent(0.15)
-      edgeMaterial.lightingModel = .constant
+      let edgeKey = "\(source.nodeType.rawValue)|\(target.nodeType.rawValue)"
+      let edgeMaterial: SCNMaterial
+      if let cached = edgeMaterialCache[edgeKey] {
+        edgeMaterial = cached
+      } else {
+        let edgeColor = blendColors(
+          source.nodeType.nsColor, target.nodeType.nsColor, alpha: 0.25)
+        let material = SCNMaterial()
+        material.diffuse.contents = edgeColor
+        material.emission.contents = edgeColor.withAlphaComponent(0.15)
+        material.lightingModel = .constant
+        edgeMaterialCache[edgeKey] = material
+        edgeMaterial = material
+      }
 
       let edgeNode = createEdgeNode(
         from: source.position, to: target.position, material: edgeMaterial)
@@ -506,34 +725,69 @@ class MemoryGraphViewModel: ObservableObject {
       containerNode.position = SCNVector3(node.position)
       containerNode.name = node.id
 
+      let materialKey = node.isFixed ? "fixed" : node.nodeType.rawValue
+
       // Core sphere
-      let sphere = SCNSphere(radius: radius)
-      sphere.segmentCount = node.isFixed ? 24 : 16
-      let mat = SCNMaterial()
-      if node.isFixed {
-        mat.diffuse.contents = NSColor.white
-        mat.emission.contents = NSColor.white.withAlphaComponent(0.8)
+      let bodyMaterial: SCNMaterial
+      if let cached = bodyMaterialCache[materialKey] {
+        bodyMaterial = cached
       } else {
-        mat.diffuse.contents = node.nodeType.nsColor
-        mat.emission.contents = node.nodeType.nsColor.withAlphaComponent(0.5)
+        let material = SCNMaterial()
+        if node.isFixed {
+          material.diffuse.contents = NSColor.white
+          material.emission.contents = NSColor.white.withAlphaComponent(0.8)
+        } else {
+          material.diffuse.contents = node.nodeType.nsColor
+          material.emission.contents = node.nodeType.nsColor.withAlphaComponent(0.5)
+        }
+        material.lightingModel = .constant
+        bodyMaterialCache[materialKey] = material
+        bodyMaterial = material
       }
-      mat.lightingModel = .constant
-      sphere.materials = [mat]
+      let segments = node.isFixed ? 24 : 16
+      let sphereKey = "\(materialKey)|\(Int(radius * 10))|\(segments)"
+      let sphere: SCNSphere
+      if let cached = sphereCache[sphereKey] {
+        sphere = cached
+      } else {
+        let newSphere = SCNSphere(radius: radius)
+        newSphere.segmentCount = segments
+        newSphere.materials = [bodyMaterial]
+        sphereCache[sphereKey] = newSphere
+        sphere = newSphere
+      }
       let sphereNode = SCNNode(geometry: sphere)
       containerNode.addChildNode(sphereNode)
 
-      // Glow halo (larger semi-transparent sphere around node)
+      // Glow halo (larger semi-transparent sphere around node). The halo is
+      // an additive blur — 24 segments is visually identical to 48 at half
+      // the tessellation.
       let glowRadius = radius * 2.5
-      let glowSphere = SCNSphere(radius: glowRadius)
-      glowSphere.segmentCount = 48
-      let glowMat = SCNMaterial()
-      let glowColor = node.isFixed ? NSColor.white : node.nodeType.nsColor
-      glowMat.diffuse.contents = glowColor.withAlphaComponent(0.03)
-      glowMat.emission.contents = glowColor.withAlphaComponent(0.025)
-      glowMat.lightingModel = .constant
-      glowMat.isDoubleSided = true
-      glowMat.blendMode = .add
-      glowSphere.materials = [glowMat]
+      let glowMaterial: SCNMaterial
+      if let cached = glowMaterialCache[materialKey] {
+        glowMaterial = cached
+      } else {
+        let material = SCNMaterial()
+        let glowColor = node.isFixed ? NSColor.white : node.nodeType.nsColor
+        material.diffuse.contents = glowColor.withAlphaComponent(0.03)
+        material.emission.contents = glowColor.withAlphaComponent(0.025)
+        material.lightingModel = .constant
+        material.isDoubleSided = true
+        material.blendMode = .add
+        glowMaterialCache[materialKey] = material
+        glowMaterial = material
+      }
+      let glowKey = "glow|\(materialKey)|\(Int(glowRadius * 10))"
+      let glowSphere: SCNSphere
+      if let cached = sphereCache[glowKey] {
+        glowSphere = cached
+      } else {
+        let newSphere = SCNSphere(radius: glowRadius)
+        newSphere.segmentCount = 24
+        newSphere.materials = [glowMaterial]
+        sphereCache[glowKey] = newSphere
+        glowSphere = newSphere
+      }
       let glowNode = SCNNode(geometry: glowSphere)
       containerNode.addChildNode(glowNode)
 
@@ -554,9 +808,9 @@ class MemoryGraphViewModel: ObservableObject {
   private func createLabelNode(text: String, nodeRadius: CGFloat, isFixed: Bool) -> SCNNode {
     let truncated = text.count > 18 ? String(text.prefix(16)) + "..." : text
     let fontSize: CGFloat = isFixed ? 22 : 16
-    let scnText = SCNText(string: truncated, extrusionDepth: 0.5)
+    let scnText = SCNText(string: truncated, extrusionDepth: 0)
     scnText.font = NSFont.systemFont(ofSize: fontSize, weight: isFixed ? .bold : .medium)
-    scnText.flatness = 0.3
+    scnText.flatness = 0.6
     scnText.alignmentMode = CATextLayerAlignmentMode.center.rawValue
 
     let textMat = SCNMaterial()
@@ -749,7 +1003,7 @@ extension SCNVector3 {
 
 #if canImport(PreviewsMacros)
 #Preview {
-  MemoryGraphPage()
+  MemoryGraphPage(viewModel: MemoryGraphViewModel())
     .frame(width: 800, height: 600)
 }
 #endif

--- a/desktop/macos/Desktop/Sources/ViewExporter.swift
+++ b/desktop/macos/Desktop/Sources/ViewExporter.swift
@@ -289,7 +289,7 @@ enum ViewExporter {
         "full-ai-chat", 2,
         { AnyView(ChatPage(appProvider: AppProvider(), chatProvider: previewChatProvider())) }
       ),
-      ("full-memories", 3, { AnyView(MemoriesPage(viewModel: previewMemoriesViewModel())) }),
+      ("full-memories", 3, { AnyView(MemoriesPage(viewModel: previewMemoriesViewModel(), graphViewModel: MemoryGraphViewModel())) }),
       (
         "full-tasks", 4,
         {

--- a/desktop/macos/Desktop/Sources/ViewModelContainer.swift
+++ b/desktop/macos/Desktop/Sources/ViewModelContainer.swift
@@ -12,6 +12,9 @@ class ViewModelContainer: ObservableObject {
     let tasksViewModel = TasksViewModel()
     let appProvider = AppProvider()
     let memoriesViewModel = MemoriesViewModel()
+    /// Brain-map graph — persistent so the SceneKit scene, force layout, and
+    /// camera survive page navigation instead of rebuilding every visit.
+    let memoryGraphViewModel = MemoryGraphViewModel()
     let chatProvider: ChatProvider
     let taskChatCoordinator: TaskChatCoordinator
     private lazy var warmupCoordinator = StartupWarmupCoordinator(
@@ -131,6 +134,7 @@ class ViewModelContainer: ObservableObject {
         dashboardViewModel.resetSessionState()
         memoriesViewModel.resetSessionState()
         appProvider.resetSessionState()
+        memoryGraphViewModel.resetSessionState()
         isInitialLoadComplete = false
         isLoading = false
         databaseInitFailed = false

--- a/desktop/macos/Desktop/Tests/MemoryGraphRevisitTests.swift
+++ b/desktop/macos/Desktop/Tests/MemoryGraphRevisitTests.swift
@@ -1,0 +1,103 @@
+import XCTest
+@testable import Omi_Computer
+
+final class MemoryGraphRevisitTests: XCTestCase {
+    func testHomeMemoriesUsePersistentGraphViewModel() throws {
+        let graph = try source(at: "Sources/MainWindow/Pages/MemoryGraph/MemoryGraphPage.swift")
+        let home = try source(at: "Sources/MainWindow/DesktopHomeView.swift")
+        let memories = try source(at: "Sources/MainWindow/Pages/MemoriesPage.swift")
+        let container = try source(at: "Sources/ViewModelContainer.swift")
+
+        XCTAssertFalse(graph.contains("@StateObject private var viewModel = MemoryGraphViewModel()"))
+        XCTAssertTrue(graph.contains("@ObservedObject var viewModel: MemoryGraphViewModel"))
+        XCTAssertTrue(container.contains("let memoryGraphViewModel = MemoryGraphViewModel()"))
+        XCTAssertTrue(container.contains("memoryGraphViewModel.resetSessionState()"))
+        XCTAssertTrue(home.contains("graphViewModel: viewModelContainer.memoryGraphViewModel"))
+        XCTAssertTrue(memories.contains("MemoryGraphInlineCard(viewModel: graphViewModel)"))
+    }
+
+    @MainActor
+    func testGraphSignatureIsStableAcrossResponseOrdering() {
+        let first = sampleGraph()
+        let reordered = KnowledgeGraphResponse(nodes: first.nodes.reversed(), edges: first.edges.reversed())
+
+        XCTAssertEqual(
+            MemoryGraphViewModel.graphSignature(of: first),
+            MemoryGraphViewModel.graphSignature(of: reordered)
+        )
+    }
+
+    @MainActor
+    func testGraphSignatureChangesWhenRenderedGraphChanges() {
+        let base = sampleGraph()
+        let baseSignature = MemoryGraphViewModel.graphSignature(of: base)
+
+        XCTAssertNotEqual(baseSignature, MemoryGraphViewModel.graphSignature(of: sampleGraph(nodeLabel: "Different project")))
+        XCTAssertNotEqual(baseSignature, MemoryGraphViewModel.graphSignature(of: sampleGraph(nodeType: .place)))
+        XCTAssertNotEqual(baseSignature, MemoryGraphViewModel.graphSignature(of: sampleGraph(edgeLabel: "visited")))
+        XCTAssertNotEqual(baseSignature, MemoryGraphViewModel.graphSignature(of: sampleGraph(edgeTargetId: "org")))
+    }
+
+    func testApplyLayoutRequiresEveryNonFixedNodeAndRestoresPositions() {
+        let simulation = ForceDirectedSimulation()
+        simulation.populate(graphResponse: sampleGraph(), userNodeLabel: "Me")
+
+        let originalPositions = simulation.layoutPositions()
+        let nonFixedIds = simulation.nodes.filter { !$0.isFixed }.map(\.id)
+        XCTAssertFalse(nonFixedIds.isEmpty)
+
+        XCTAssertFalse(simulation.applyLayout([:]))
+        XCTAssertEqual(simulation.layoutPositions(), originalPositions)
+
+        let cachedPositions = Dictionary(uniqueKeysWithValues: nonFixedIds.enumerated().map {
+            ($0.element, SIMD3<Float>(Float($0.offset + 1) * 10, Float($0.offset + 1) * 20, 5))
+        })
+
+        XCTAssertTrue(simulation.applyLayout(cachedPositions))
+        let restored = simulation.layoutPositions()
+        for (id, position) in cachedPositions { XCTAssertEqual(restored[id], position) }
+        XCTAssertTrue(simulation.isStable)
+    }
+
+    func testRunSyncKeepsFixedUserNodeAnchoredAndProducesFiniteLayout() throws {
+        let simulation = ForceDirectedSimulation()
+        simulation.populate(graphResponse: sampleGraph(), userNodeLabel: "Me")
+
+        let fixedNode = try XCTUnwrap(simulation.nodes.first(where: \.isFixed))
+        let fixedPosition = fixedNode.position
+
+        simulation.runSync(ticks: 40)
+
+        XCTAssertEqual(fixedNode.position, fixedPosition)
+        XCTAssertGreaterThanOrEqual(simulation.lastStepEnergy, 0)
+        for node in simulation.nodes {
+            XCTAssertTrue(node.position.x.isFinite && node.position.y.isFinite && node.position.z.isFinite)
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func source(at relativePath: String) throws -> String {
+        let testsURL = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
+        let sourceURL = testsURL
+            .deletingLastPathComponent()
+            .appendingPathComponent(relativePath)
+        return try String(contentsOf: sourceURL, encoding: .utf8)
+    }
+
+    private func sampleGraph(
+        nodeLabel: String = "Project Atlas",
+        nodeType: KnowledgeGraphNodeType = .concept,
+        edgeLabel: String = "works on",
+        edgeTargetId: String = "project"
+    ) -> KnowledgeGraphResponse {
+        KnowledgeGraphResponse(nodes: [
+            KnowledgeGraphNode(id: "me", label: "Me", nodeType: .person),
+            KnowledgeGraphNode(id: "project", label: nodeLabel, nodeType: nodeType),
+            KnowledgeGraphNode(id: "org", label: "Omi", nodeType: .organization),
+        ], edges: [
+            KnowledgeGraphEdge(id: "edge-me-target", sourceId: "me", targetId: edgeTargetId, label: edgeLabel),
+            KnowledgeGraphEdge(id: "edge-project-org", sourceId: "project", targetId: "org", label: "belongs to"),
+        ])
+    }
+}

--- a/desktop/macos/changelog/unreleased/20260709-memory-graph-performance.json
+++ b/desktop/macos/changelog/unreleased/20260709-memory-graph-performance.json
@@ -1,0 +1,3 @@
+{
+  "change": "Made the desktop brain map reopen faster by preserving its scene during navigation and reusing cached layouts when the graph has not changed."
+}

--- a/desktop/macos/e2e/flows/memories.yaml
+++ b/desktop/macos/e2e/flows/memories.yaml
@@ -5,6 +5,9 @@ description: Memories page navigation and refresh via automation bridge
 app: non-prod
 covers:
   - desktop/macos/Desktop/Sources/MainWindow/Pages/MemoriesPage.swift
+  - desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryGraph/ForceDirectedSimulation.swift
+  - desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryGraph/MemoryGraphPage.swift
+  - desktop/macos/Desktop/Sources/ViewModelContainer.swift
 preconditions:
   - automation_bridge_ready
 


### PR DESCRIPTION
## What changed and why

Improves the desktop Memory Graph revisit path so returning to the graph keeps the prepared view model, avoids unnecessary graph rebuilds, and restores a settled layout for unchanged graph data. This makes the Memory Graph feel faster after the first load while preserving the existing graph data and UI behavior.

## Product invariants affected

INV-MEM-1. This touches the desktop Memory Graph surface, but does not change memory tiers, access policy, or memory data semantics.

## How it was verified

- Built and opened upstream/current branch desktop builds for side-by-side Memory Graph revisit comparison.
- `xcrun swift test -c debug --package-path Desktop --filter MemoryGraphRevisitTests` passed.
- `xcrun swift build -c debug --package-path Desktop` passed.
- `xcrun swift build -c release --triple arm64-apple-macosx --package-path Desktop` passed.
- `git diff --check upstream/main...HEAD` passed.

## Tests

Added `MemoryGraphRevisitTests` covering the core revisit contract: unchanged graph data skips redundant simulation, prepared graph state is reused, layout cache remains scoped to the user/session path, and rebuild/session-reset paths still invalidate cached graph state when they should.

## Scoped cleanups (optional)

- Removed the unused private physics-step helper after optimizing the force simulation path.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9341?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

