### PR TITLE
fix(desktop): prevent ghost auth sessions across updates

### DIFF
--- a/.github/actions/detect-changes/action.yml
+++ b/.github/actions/detect-changes/action.yml
@@ -92,7 +92,7 @@ runs:
         has_desktop_rust=$(echo "$FILES" | grep -qE '^desktop/macos/Backend-Rust/|^\.github/workflows/(repo-checks|desktop-checks)\.yml$|^\.github/actions/detect-changes/' && echo true || echo false)
         has_desktop_defaults_ratchet=$(echo "$FILES" | grep -qE '^desktop/macos/Desktop/Sources/.*\.swift$|^desktop/macos/scripts/check-userdefaults-key-ratchet\.py$|^\.github/workflows/(repo-checks|desktop-checks)\.yml$|^\.github/actions/detect-changes/' && echo true || echo false)
         has_desktop_async_after_ratchet=$(echo "$FILES" | grep -qE '^desktop/macos/Desktop/Sources/FloatingControlBar/.*\.swift$|^desktop/macos/scripts/check-async-after-ratchet\.py$|^\.github/workflows/(repo-checks|desktop-checks)\.yml$|^\.github/actions/detect-changes/' && echo true || echo false)
-        has_desktop_auth_session_ratchet=$(echo "$FILES" | grep -qE '^desktop/macos/Desktop/Sources/(APIClient|AuthService|AuthSessionCoordinator)\.swift$|^\.github/scripts/check_desktop_auth_session\.py$|^\.github/workflows/(repo-checks|desktop-checks)\.yml$|^\.github/actions/detect-changes/' && echo true || echo false)
+        has_desktop_auth_session_ratchet=$(echo "$FILES" | grep -qE '^desktop/macos/Desktop/Sources/(APIClient|AuthService|AuthSessionCoordinator|DesktopKeychainStore|OmiApp)\.swift$|^desktop/macos/Desktop/Sources/Auth/.*\.swift$|^desktop/macos/scripts/smoke-signed-desktop-artifact\.sh$|^codemagic\.yaml$|^\.github/scripts/check_desktop_auth_session\.py$|^\.github/workflows/(repo-checks|desktop-checks)\.yml$|^\.github/actions/detect-changes/' && echo true || echo false)
 
         {
           echo "has_dart=$has_dart"

--- a/.github/scripts/check_desktop_auth_session.py
+++ b/.github/scripts/check_desktop_auth_session.py
@@ -9,6 +9,10 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
 API_CLIENT = ROOT / "desktop/macos/Desktop/Sources/APIClient.swift"
+AUTH_SERVICE = ROOT / "desktop/macos/Desktop/Sources/AuthService.swift"
+OMI_APP = ROOT / "desktop/macos/Desktop/Sources/OmiApp.swift"
+CODEMAGIC = ROOT / "codemagic.yaml"
+SIGNED_SMOKE = ROOT / "desktop/macos/scripts/smoke-signed-desktop-artifact.sh"
 
 # Handlers that intentionally preserve the session on 401 (document each).
 SESSION_PRESERVING_MARKERS = (
@@ -25,6 +29,10 @@ def main() -> int:
         return 1
 
     text = API_CLIENT.read_text(encoding="utf-8")
+    auth_text = AUTH_SERVICE.read_text(encoding="utf-8")
+    app_text = OMI_APP.read_text(encoding="utf-8")
+    codemagic_text = CODEMAGIC.read_text(encoding="utf-8")
+    smoke_text = SIGNED_SMOKE.read_text(encoding="utf-8")
     failures: list[str] = []
 
     if "invalidateSessionAfterUnauthorized" not in text:
@@ -35,6 +43,23 @@ def main() -> int:
 
     if "AuthBackoffTracker" in text:
         failures.append("AuthBackoffTracker must not return — use session invalidation")
+
+    if "self.isSignedIn = savedSignedIn" in app_text:
+        failures.append("persisted auth boolean must remain a restore hint, not runtime auth authority")
+    if "self.sessionPhase = savedSignedIn ? .restoring : .signedOut" not in app_text:
+        failures.append("AuthState must gate saved sessions in restoring until validation")
+    if "persistKeychainTokensTransactionally" not in auth_text:
+        failures.append("Keychain persistence must use write + exact read-back verification")
+    stored_tokens_start = auth_text.find("private func storedTokens()")
+    stored_tokens_end = auth_text.find("private var storedIdToken", stored_tokens_start)
+    if stored_tokens_start < 0 or stored_tokens_end < 0:
+        failures.append("could not locate storedTokens migration implementation")
+    elif "clearUserDefaultsTokens()" in auth_text[stored_tokens_start:stored_tokens_end]:
+        failures.append("credential migration must not delete its legacy source before refresh commit")
+    if "--auth-storage-canary" not in codemagic_text:
+        failures.append("Codemagic must run the signed-app Keychain canary before publishing beta")
+    if "run_auth_storage_canary" not in smoke_text:
+        failures.append("signed artifact smoke must implement the in-app Keychain canary")
 
     # Each 401 branch must mention invalidation or an explicit session-preserving opt-out nearby.
     for match in UNAUTHORIZED_HANDLER.finditer(text):

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -2654,12 +2654,14 @@ workflows:
 
       - name: Smoke signed desktop artifact
         script: |
+          OMI_SIGNED_ARTIFACT_SMOKE_ALLOW_PRODUCTION_LAUNCH=1 \
           scripts/smoke-signed-desktop-artifact.sh \
             --app "$APP_BUNDLE" \
             --zip "$SPARKLE_ZIP_PATH" \
             --dmg "$DMG_PATH" \
             --tag "$CM_TAG" \
             --expected-channel beta \
+            --auth-storage-canary \
             --result-json "$BUILD_DIR/desktop-smoke-result.json"
 
       - name: Create GitHub release

--- a/desktop/macos/AGENTS.md
+++ b/desktop/macos/AGENTS.md
@@ -37,14 +37,14 @@ Merging `desktop/macos/**` changes to `main` triggers a beta desktop release:
    - Builds universal binary (arm64 + x86_64)
    - Signs with Developer ID, notarizes with Apple
    - Creates DMG + Sparkle ZIP
-   - Runs `scripts/smoke-signed-desktop-artifact.sh` on the signed app, Sparkle ZIP, and DMG before publishing
+   - Runs `scripts/smoke-signed-desktop-artifact.sh` on the signed app, Sparkle ZIP, and DMG before publishing, including a mandatory in-app synthetic Keychain write/read/delete canary
    - Publishes GitHub release, uploads to GCS, registers in Firestore
 3. **Sparkle beta update** delivers the new version to beta users
 
 Signed artifact smoke scope:
 - Always-on release audit covers bundle identity, version/tag alignment, signing/Keychain entitlements, Sparkle metadata, backend URL leakage, helper/runtime packaging, artifact readability, and local storage package surface.
 - Codemagic uploads `build/desktop-smoke-result.json` with artifact digests and completed checks; promotion tooling should compare this result to the exact release asset before changing channels.
-- Optional live probes (`--launch --network --auth --chat --permissions --storage`) require an isolated release runner and explicit canary env vars; production-bundle launch is fail-closed unless `OMI_SIGNED_ARTIFACT_SMOKE_ALLOW_PRODUCTION_LAUNCH=1`, and `--auth` requires `OMI_SIGNED_ARTIFACT_SMOKE_AUTH_PROOF_COMMAND` to prove app-level persistence rather than a raw bearer-token curl.
+- The synthetic `--auth-storage-canary` is mandatory before beta publication and runs inside the exact signed app without real credentials. Optional broader live probes (`--launch --network --auth --chat --permissions --storage`) require an isolated release runner and explicit canary env vars; production-bundle launch is fail-closed unless `OMI_SIGNED_ARTIFACT_SMOKE_ALLOW_PRODUCTION_LAUNCH=1`, and `--auth` requires `OMI_SIGNED_ARTIFACT_SMOKE_AUTH_PROOF_COMMAND` to prove app-level persistence rather than a raw bearer-token curl.
 - Future release gating should split artifact creation from user visibility: create/upload the immutable artifact first, run the live smoke against that artifact, then flip beta/stable appcast/Firestore visibility only after the digest-matched smoke passes.
 
 Stable/prod is manual:

--- a/desktop/macos/Desktop/Sources/Auth/AuthStorageCanary.swift
+++ b/desktop/macos/Desktop/Sources/Auth/AuthStorageCanary.swift
@@ -1,0 +1,76 @@
+import AppKit
+import Foundation
+
+/// Distribution-only, synthetic Keychain proof executed by the signed artifact
+/// before Codemagic publishes it. It never handles a real user credential.
+enum AuthStorageCanary {
+  private static let argumentPrefix = "--auth-storage-canary-result="
+  private static let account = "signed-artifact-auth-storage-canary"
+
+  struct Hooks {
+    var set: (_ value: String, _ service: String, _ account: String) -> Bool
+    var read: (_ service: String, _ account: String) -> String?
+    var delete: (_ service: String, _ account: String) -> Void
+
+    static let live = Hooks(
+      set: { value, service, account in
+        DesktopKeychainStore.setString(value, service: service, account: account)
+      },
+      read: { service, account in
+        DesktopKeychainStore.string(service: service, account: account)
+      },
+      delete: { service, account in
+        DesktopKeychainStore.delete(service: service, account: account)
+      }
+    )
+  }
+
+  struct Result: Codable, Equatable {
+    let success: Bool
+    let stage: String
+  }
+
+  static var requestedResultPath: String? {
+    CommandLine.arguments.first(where: { $0.hasPrefix(argumentPrefix) })
+      .map { String($0.dropFirst(argumentPrefix.count)) }
+      .flatMap { $0.isEmpty ? nil : $0 }
+  }
+
+  static var isRequested: Bool { requestedResultPath != nil }
+
+  static func execute(hooks: Hooks = .live) -> Result {
+    let service = DesktopKeychainStore.scopedService(DesktopKeychainStore.legacyAuthTokenService)
+    let sentinel = "omi-auth-canary-\(UUID().uuidString)"
+
+    hooks.delete(service, account)
+    guard hooks.set(sentinel, service, account) else {
+      return Result(success: false, stage: "write")
+    }
+    guard hooks.read(service, account) == sentinel else {
+      hooks.delete(service, account)
+      return Result(success: false, stage: "read_back")
+    }
+    hooks.delete(service, account)
+    guard hooks.read(service, account) == nil else {
+      return Result(success: false, stage: "delete")
+    }
+    return Result(success: true, stage: "complete")
+  }
+
+  /// Returns true when canary mode consumed this launch.
+  static func runIfRequested() -> Bool {
+    guard let resultPath = requestedResultPath else { return false }
+    let result = execute()
+    do {
+      let data = try JSONEncoder().encode(result)
+      try data.write(to: URL(fileURLWithPath: resultPath), options: .atomic)
+    } catch {
+      NSLog("OMI AUTH CANARY: failed to write result: %@", error.localizedDescription)
+    }
+    NSLog("OMI AUTH CANARY: stage=%@ success=%@", result.stage, result.success ? "true" : "false")
+    DispatchQueue.main.async {
+      NSApplication.shared.terminate(nil)
+    }
+    return true
+  }
+}

--- a/desktop/macos/Desktop/Sources/Auth/SessionRecoveryView.swift
+++ b/desktop/macos/Desktop/Sources/Auth/SessionRecoveryView.swift
@@ -1,0 +1,54 @@
+import SwiftUI
+
+/// Shown when credentials still exist but launch-time validation could not
+/// complete (for example, offline or a temporarily locked Keychain).
+/// Authenticated product surfaces remain gated until Retry succeeds.
+struct SessionRecoveryView: View {
+  @State private var isRetrying = false
+
+  var body: some View {
+    VStack(spacing: 16) {
+      Image(systemName: "lock.rotation")
+        .font(.system(size: 34, weight: .medium))
+        .foregroundStyle(.white)
+
+      Text("We couldn't verify your session")
+        .font(.title3.weight(.semibold))
+        .foregroundStyle(.white)
+
+      Text("Your local data and setup are safe. Check your connection and retry, or sign in again.")
+        .font(.body)
+        .foregroundStyle(.secondary)
+        .multilineTextAlignment(.center)
+        .frame(maxWidth: 420)
+
+      HStack(spacing: 12) {
+        Button("Sign In Again") {
+          AuthService.shared.invalidateSession(reason: .manual)
+        }
+        .buttonStyle(.bordered)
+        .accessibilityIdentifier("auth_recovery_sign_in")
+
+        Button {
+          isRetrying = true
+          Task {
+            await AuthService.shared.retryRestoredSession()
+            isRetrying = false
+          }
+        } label: {
+          if isRetrying {
+            ProgressView()
+              .controlSize(.small)
+          } else {
+            Text("Retry")
+          }
+        }
+        .buttonStyle(.borderedProminent)
+        .disabled(isRetrying)
+        .accessibilityIdentifier("auth_recovery_retry")
+      }
+    }
+    .padding(32)
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
+  }
+}

--- a/desktop/macos/Desktop/Sources/AuthService.swift
+++ b/desktop/macos/Desktop/Sources/AuthService.swift
@@ -415,7 +415,7 @@ class AuthService {
 
     var isSignedIn: Bool {
         get { authState.isSignedIn }
-        set { authState.isSignedIn = newValue }
+        set { authState.transition(to: newValue ? .authenticated : .signedOut) }
     }
     var isLoading: Bool {
         get { authState.isLoading }
@@ -485,7 +485,7 @@ class AuthService {
         DesktopKeychainStore.scopedService(DesktopKeychainStore.legacyAuthTokenService)
     }
 
-    private struct StoredAuthTokens: Codable {
+    private struct StoredAuthTokens: Codable, Equatable {
         let idToken: String
         let refreshToken: String
         let expiryTime: TimeInterval
@@ -508,15 +508,11 @@ class AuthService {
         var deleteKeychainString: (_ service: String, _ account: String) -> Void
         var recordsFallbackTelemetry: Bool
 
-        // Security invariant: auth tokens live in the Keychain on EVERY build — including
-        // dev and the Sparkle-distributed beta — and the plaintext UserDefaults write
-        // fallback is OFF. The file-based Keychain write now works on all builds (see
-        // DesktopKeychainStore), so a fallback that spills OAuth/refresh tokens into
-        // UserDefaults (plaintext on disk, included in backups, readable by any process with
-        // disk access) is pure risk with no correctness benefit. If a Keychain write fails we
-        // surface it via AuthError.keychainTokenStorageUnavailable instead of leaking secrets.
-        // The UserDefaults *read* path in storedTokens() is intentionally retained only to
-        // migrate pre-existing tokens into the Keychain on first launch, then clear them.
+        // Security invariant: new auth tokens live in the Keychain on EVERY build,
+        // including Sparkle beta. Plaintext UserDefaults fallback is disabled for new
+        // sign-ins. The read path remains only for transactional migration of older
+        // installs: keep that already-existing copy until Keychain read-back plus a
+        // forced refresh commit the new store.
         static let live = TokenStorageHooks(
             usesKeychainTokenStorage: { true },
             allowsUserDefaultsFallback: { false },
@@ -615,9 +611,7 @@ class AuthService {
     /// Internal hook for `AuthSessionCoordinator` — not a user-facing sign-out.
     func performLightSessionInvalidation() {
         clearTokens()
-        isSignedIn = false
         AuthState.shared.userEmail = nil
-        AuthState.shared.isRestoringAuth = false
         saveAuthState(isSignedIn: false, email: nil, userId: nil)
         // Also clear the Firebase SDK session so that restoreAuthState() and the
         // auth-state listener do not re-create the ghost session on the next
@@ -641,14 +635,13 @@ class AuthService {
         // Timeout: if auth isn't restored within 5 seconds, stop showing loading
         DispatchQueue.main.asyncAfter(deadline: .now() + 5.0) {
             if AuthState.shared.isRestoringAuth {
-                NSLog("OMI AUTH: Auth restore timed out after 5s, clearing loading state")
-                AuthState.shared.isRestoringAuth = false
+                NSLog("OMI AUTH: Auth restore timed out after 5s, entering recoverable state")
+                AuthState.shared.transition(to: .recoveryRequired)
             }
         }
     }
 
     func bootstrapLocalHarnessAuthIfNeeded() async {
-        defer { AuthState.shared.isRestoringAuth = false }
         guard let email = DesktopLocalProfile.selectedEmail,
               let password = DesktopLocalProfile.selectedPassword,
               let selectedUser = DesktopLocalProfile.selectedUser else {
@@ -684,7 +677,7 @@ class AuthService {
         } catch {
             logError("OMI AUTH LOCAL: sign-in failed for \(email)", error: error)
             self.error = "Local Auth emulator sign-in failed for \(email): \(error.localizedDescription)"
-            isSignedIn = false
+            AuthState.shared.transition(to: .recoveryRequired)
         }
     }
 
@@ -759,69 +752,74 @@ class AuthService {
         // creating a race window where the Firebase auth state listener can fire first
         // with user=nil and flip isSignedIn to false before we restore it.
         if savedSignedIn {
-            // Check if Firebase also has a current user (session might still be valid)
-            if let currentUser = Auth.auth().currentUser {
-                NSLog("OMI AUTH: Restored auth state from Firebase - uid: %@", currentUser.uid)
-                self.isSignedIn = true
-                AuthState.shared.userEmail = currentUser.email ?? savedEmail
-                AuthState.shared.isRestoringAuth = false
-                self.loadNameFromBackendIfNeeded()
-            } else {
-                // Firebase doesn't have user, but we have saved state
-                // This can happen with ad-hoc signing where Keychain doesn't persist
-                NSLog("OMI AUTH: Restored auth state from UserDefaults (Firebase session expired)")
+            AuthState.shared.transition(to: .restoring)
+            AuthState.shared.userEmail = Auth.auth().currentUser?.email ?? savedEmail
 
-                // Migration: Fix empty userId by extracting from stored idToken
-                let savedUserId = UserDefaults.standard.string(forKey: .authUserId) ?? ""
-                if savedUserId.isEmpty, let storedToken = storedIdToken {
-                    if let payload = decodeJWT(storedToken),
-                       let userId = payload["user_id"] as? String ?? payload["sub"] as? String {
-                        NSLog("OMI AUTH: Migrating empty userId - extracted from JWT: %@", userId)
-                        UserDefaults.standard.set(userId, forKey: .authUserId)
-                    }
+            // Migration: Fix empty userId by extracting from stored idToken.
+            let savedUserId = UserDefaults.standard.string(forKey: .authUserId) ?? ""
+            if savedUserId.isEmpty, let storedToken = storedIdToken {
+                if let payload = decodeJWT(storedToken),
+                   let userId = payload["user_id"] as? String ?? payload["sub"] as? String {
+                    NSLog("OMI AUTH: Migrating empty userId - extracted from JWT: %@", userId)
+                    UserDefaults.standard.set(userId, forKey: .authUserId)
                 }
-
-                self.isSignedIn = true
-                AuthState.shared.userEmail = savedEmail
-                validateRestoredUserDefaultsSession()
             }
+
+            // A persisted boolean and Firebase's cached currentUser are restore hints,
+            // never proof of a usable session. Keep every authenticated surface gated
+            // until a forced refresh succeeds.
+            validateRestoredSession()
         } else {
             NSLog("OMI AUTH: No saved auth state found")
-            AuthState.shared.isRestoringAuth = false
+            AuthState.shared.transition(to: .signedOut)
         }
     }
 
-    private func validateRestoredUserDefaultsSession() {
+    private func validateRestoredSession() {
         Task { [weak self] in
             guard let self else { return }
-            defer { AuthState.shared.isRestoringAuth = false }
+            await self.validateRestoredSessionNow()
+        }
+    }
 
-            guard self.storedRefreshToken != nil || self.storedIdToken != nil else {
-                NSLog("OMI AUTH: Restored UserDefaults session has no tokens — invalidating")
-                self.invalidateSession(reason: .restoredSessionInvalid)
-                return
-            }
+    func retryRestoredSession() async {
+        guard UserDefaults.standard.bool(forKey: .authIsSignedIn) else {
+            AuthState.shared.transition(to: .signedOut)
+            return
+        }
+        AuthState.shared.transition(to: .restoring)
+        await validateRestoredSessionNow()
+    }
 
-            do {
-                _ = try await self.sessionCoordinator.refreshSingleFlight(auth: self)
-                NSLog("OMI AUTH: Restored UserDefaults session validated via forced refresh")
-                self.sessionCoordinator.resetAfterSuccessfulSignIn()
-                APIKeyService.shared.startFetchingKeys()
-                Task { await FloatingBarUsageLimiter.shared.fetchPlan() }
-            } catch AuthError.notSignedIn {
-                if self.storedIdToken == nil || self.storedRefreshToken == nil {
-                    NSLog("OMI AUTH: Restored UserDefaults session validation — tokens cleared, invalidating")
-                    self.invalidateSession(reason: .restoredSessionInvalid)
-                } else {
-                    // Transient/race while tokens survive — keep restored session for retry.
-                    NSLog("OMI AUTH: Restored UserDefaults session validation deferred - preserving restored session")
-                }
-            } catch {
-                NSLog(
-                    "OMI AUTH: Restored UserDefaults session validation deferred (transient): %@",
-                    error.localizedDescription
-                )
+    private func validateRestoredSessionNow() async {
+        let hasFirebaseUser = !DesktopLocalProfile.isEnabled && Auth.auth().currentUser != nil
+
+        guard storedRefreshToken != nil || storedIdToken != nil || hasFirebaseUser else {
+            NSLog("OMI AUTH: Restored session has no credentials — invalidating")
+            invalidateSession(reason: .restoredSessionInvalid)
+            return
+        }
+
+        do {
+            _ = try await sessionCoordinator.refreshSingleFlight(auth: self)
+            NSLog("OMI AUTH: Restored session validated via forced refresh")
+            let userId = storedTokenUserId ?? Auth.auth().currentUser?.uid
+            saveAuthState(isSignedIn: true, email: AuthState.shared.userEmail, userId: userId)
+            sessionCoordinator.resetAfterSuccessfulSignIn()
+            loadNameFromBackendIfNeeded()
+            APIKeyService.shared.startFetchingKeys()
+            Task { await FloatingBarUsageLimiter.shared.fetchPlan() }
+        } catch AuthError.notSignedIn {
+            if sessionCoordinator.phase == .needsReauth || (storedIdToken == nil && storedRefreshToken == nil && !hasFirebaseUser) {
+                NSLog("OMI AUTH: Restored session validation proved credentials absent")
+                invalidateSession(reason: .restoredSessionInvalid)
+            } else {
+                NSLog("OMI AUTH: Restored session validation deferred - preserving credentials for retry")
+                AuthState.shared.transition(to: .recoveryRequired)
             }
+        } catch {
+            NSLog("OMI AUTH: Restored session validation deferred (transient): %@", error.localizedDescription)
+            AuthState.shared.transition(to: .recoveryRequired)
         }
     }
 
@@ -831,22 +829,19 @@ class AuthService {
         authStateHandle = Auth.auth().addStateDidChangeListener { [weak self] _, user in
             Task { @MainActor in
                 if user != nil {
-                    // Firebase has a user - trust it
-                    log("AUTH_LISTENER: Firebase user present (uid=\(user?.uid ?? "nil")), setting isSignedIn=true")
-                    self?.isSignedIn = true
+                    // Firebase currentUser is cached identity, not proof that the
+                    // credential can refresh. Only enrich an already validated session;
+                    // launch restoration remains owned by validateRestoredSessionNow().
+                    log("AUTH_LISTENER: Firebase user present (uid=\(user?.uid ?? "nil")), phase=\(String(describing: self?.sessionCoordinator.phase))")
                     AuthState.shared.userEmail = user?.email
-                    AuthState.shared.isRestoringAuth = false
-                    self?.saveAuthState(isSignedIn: true, email: user?.email, userId: user?.uid)
-                    // Configure database for the signed-in user immediately so any code
-                    // that touches the DB during onboarding (e.g. save_knowledge_graph)
-                    // writes to the correct per-user path instead of "anonymous".
-                    if let uid = user?.uid {
-                        Task { await RewindDatabase.shared.configure(userId: uid) }
+                    if self?.sessionCoordinator.phase == .authenticated {
+                        self?.saveAuthState(isSignedIn: true, email: user?.email, userId: user?.uid)
+                        if let uid = user?.uid {
+                            Task { await RewindDatabase.shared.configure(userId: uid) }
+                        }
+                        self?.loadNameFromBackendIfNeeded()
+                        Task { await SettingsSyncManager.shared.syncFromServer() }
                     }
-                    // Load name from backend profile (Firestore), then Firebase Auth as fallback
-                    self?.loadNameFromBackendIfNeeded()
-                    // Sync assistant settings from backend (fire-and-forget)
-                    Task { await SettingsSyncManager.shared.syncFromServer() }
                 } else {
                     // Firebase has no user - check if we have a saved session (for dev builds where Keychain doesn't persist)
                     let savedSignedIn = UserDefaults.standard.bool(forKey: .authIsSignedIn)
@@ -854,9 +849,8 @@ class AuthService {
                     if !savedSignedIn {
                         // No saved session either - user is truly signed out
                         log("AUTH_LISTENER: No saved session - setting isSignedIn=false")
-                        self?.isSignedIn = false
+                        AuthState.shared.transition(to: .signedOut)
                         AuthState.shared.userEmail = nil
-                        AuthState.shared.isRestoringAuth = false
                     } else {
                         log("AUTH_LISTENER: Firebase user nil with saved session — validating REST tokens")
                         await self?.validateSavedSessionAfterFirebaseNil()
@@ -873,7 +867,10 @@ class AuthService {
             log("AUTH_LISTENER: skipping REST validation while launch restore is in flight")
             return
         }
-        guard storedRefreshToken != nil else { return }
+        guard storedRefreshToken != nil else {
+            invalidateSession(reason: .restoredSessionInvalid)
+            return
+        }
         do {
             _ = try await sessionCoordinator.refreshSingleFlight(auth: self)
             sessionCoordinator.resetAfterSuccessfulSignIn()
@@ -883,6 +880,7 @@ class AuthService {
             invalidateSession(reason: .definitiveRefreshFailure)
         } catch {
             log("AUTH_LISTENER: saved REST session validation deferred: \(error.localizedDescription)")
+            AuthState.shared.transition(to: .recoveryRequired)
         }
     }
 
@@ -1893,20 +1891,35 @@ class AuthService {
             tokenUserId: userId
         )
         if usesKeychainTokenStorage {
-            if saveKeychainTokens(tokens) {
+            let legacyMigrationSource = loadUserDefaultsTokens()
+            let hasLegacyMigrationSource = legacyMigrationSource.map {
+                $0.tokenUserId.isEmpty || $0.tokenUserId == userId
+            } ?? false
+            if persistKeychainTokensTransactionally(tokens) {
                 clearUserDefaultsTokens()
-            } else if allowsUserDefaultsTokenFallback {
+                cachedStoredTokens = tokens
+                cachedStoredTokensLoaded = true
+            } else if hasLegacyMigrationSource || allowsUserDefaultsTokenFallback {
+                // Migration-only continuity: these secrets were already present in
+                // UserDefaults before the Keychain migration started. Updating that
+                // existing copy is safer than deleting the only refresh credential.
+                // New sign-ins still fail closed when no legacy source exists.
                 saveUserDefaultsTokens(idToken: idToken, refreshToken: refreshToken, expiryTime: expiryTime, userId: userId)
-                log("AuthService: Keychain token storage failed; falling back to UserDefaults for desktop auth continuity")
-                recordTokenStorageFallback(reason: "keychain_write_failed")
+                cachedStoredTokens = tokens
+                cachedStoredTokensLoaded = true
+                log("AuthService: Keychain token persistence deferred; preserving legacy migration source")
+                recordTokenStorageFallback(reason: "keychain_migration_deferred")
             } else {
-                clearUserDefaultsTokens()
+                // Do not clear any prior credential on a failed write. The caller has
+                // not committed the new signed-in state yet, so the old session remains
+                // the only safe rollback point.
                 throw AuthError.keychainTokenStorageUnavailable
             }
         } else {
             saveUserDefaultsTokens(idToken: idToken, refreshToken: refreshToken, expiryTime: expiryTime, userId: userId)
+            cachedStoredTokens = tokens
+            cachedStoredTokensLoaded = true
         }
-        invalidateStoredTokensCache()
         NSLog("OMI AUTH: Saved tokens for user %@, expires at %@", userId, expiryTime.description)
     }
 
@@ -1942,14 +1955,52 @@ class AuthService {
 
     private func recordTokenStorageFallback(reason: String) {
         guard tokenStorageHooks.recordsFallbackTelemetry else { return }
-        AnalyticsManager.shared.desktopHealthEvent(
-            name: "auth_token_storage_fallback",
-            properties: [
-                "storage": "user_defaults",
-                "reason": reason,
+        DesktopDiagnosticsManager.shared.recordFallback(
+            area: "other",
+            from: "keychain",
+            to: "user_defaults",
+            reason: "other",
+            outcome: .degraded,
+            extra: [
+                "detail": reason,
                 "update_channel": AppBuild.currentUpdateChannel,
             ]
         )
+    }
+
+    /// Keychain writes are not committed until the running signed app can read
+    /// back the exact payload it wrote. Callers must retain the previous
+    /// credential source until this returns true.
+    private func persistKeychainTokensTransactionally(_ tokens: StoredAuthTokens) -> Bool {
+        let previousPayload = tokenStorageHooks.readKeychainString(
+            authTokenKeychainService,
+            authTokenKeychainAccount
+        )
+        guard saveKeychainTokens(tokens) else { return false }
+        guard let verified = loadKeychainTokens(), verified == tokens else {
+            log("AuthService: Keychain token read-back verification failed; retaining previous credential source")
+            if let previousPayload {
+                let restored = tokenStorageHooks.writeKeychainString(
+                    previousPayload,
+                    authTokenKeychainService,
+                    authTokenKeychainAccount
+                )
+                let restoredPayload = tokenStorageHooks.readKeychainString(
+                    authTokenKeychainService,
+                    authTokenKeychainAccount
+                )
+                if !restored || restoredPayload != previousPayload {
+                    log("AuthService: failed to restore previous Keychain payload after verification failure")
+                }
+            } else {
+                // The attempted write created the first item but did not verify.
+                // Remove that partial value so a later retry is not mistaken for
+                // a committed credential.
+                tokenStorageHooks.deleteKeychainString(authTokenKeychainService, authTokenKeychainAccount)
+            }
+            return false
+        }
+        return true
     }
 
     private func saveKeychainTokens(_ tokens: StoredAuthTokens) -> Bool {
@@ -2012,25 +2063,30 @@ class AuthService {
 
         let tokens: StoredAuthTokens?
         if usesKeychainTokenStorage {
-            if let keychainTokens = loadKeychainTokens() {
-                tokens = keychainTokens
-            } else if let defaultsTokens = loadUserDefaultsTokens() {
-                if saveKeychainTokens(defaultsTokens) {
-                    clearUserDefaultsTokens()
-                    log("AuthService: migrated production auth tokens from UserDefaults to Keychain")
-                    tokens = defaultsTokens
-                } else if allowsUserDefaultsTokenFallback {
-                    log("AuthService: keeping UserDefaults auth tokens after Keychain migration failed")
-                    recordTokenStorageFallback(reason: "keychain_migration_write_failed")
-                    tokens = defaultsTokens
-                } else {
-                    clearUserDefaultsTokens()
-                    log("AuthService: failed to migrate production auth tokens from UserDefaults to Keychain")
-                    tokens = nil
-                }
-            } else {
-                tokens = nil
+            let keychainTokens = loadKeychainTokens()
+            let defaultsTokens = loadUserDefaultsTokens()
+            let expectedUserId = UserDefaults.standard.string(forKey: .authUserId)
+
+            let candidates = [keychainTokens, defaultsTokens].compactMap { $0 }
+            let exactOwnerMatches = candidates.filter {
+                guard let expectedUserId, !expectedUserId.isEmpty else { return false }
+                return $0.tokenUserId == expectedUserId
             }
+            let eligible = exactOwnerMatches.isEmpty ? candidates : exactOwnerMatches
+            let preferred = eligible.max { $0.expiryTime < $1.expiryTime }
+
+            if let defaultsTokens, preferred == defaultsTokens {
+                // Stage the copy, but do not delete the legacy source here. The
+                // forced refresh performed by restore validation will persist the
+                // refreshed token and only then clear UserDefaults.
+                if persistKeychainTokensTransactionally(defaultsTokens) {
+                    log("AuthService: staged legacy auth tokens in Keychain; awaiting refresh validation before cleanup")
+                } else {
+                    log("AuthService: Keychain migration deferred; retaining legacy auth tokens")
+                    recordTokenStorageFallback(reason: "keychain_migration_deferred")
+                }
+            }
+            tokens = preferred
         } else {
             tokens = loadUserDefaultsTokens()
         }

--- a/desktop/macos/Desktop/Sources/AuthSessionCoordinator.swift
+++ b/desktop/macos/Desktop/Sources/AuthSessionCoordinator.swift
@@ -12,6 +12,7 @@ extension Notification.Name {
 enum AuthSessionPhase: Equatable, Sendable {
     case restoring
     case authenticated
+    case recoveryRequired
     case needsReauth
     case signedOut
 }
@@ -93,30 +94,18 @@ final class AuthSessionCoordinator {
         case bridgeAuthMissing
     }
 
-    private(set) var phase: AuthSessionPhase = .signedOut
+    var phase: AuthSessionPhase { AuthState.shared.sessionPhase }
     private var refreshFlight: Task<String, Error>?
     private var lastProactiveValidation: Date?
 
     private init() {}
-
-    func syncPhaseFromAuthState(isSignedIn: Bool, isRestoringAuth: Bool) {
-        if isRestoringAuth {
-            phase = .restoring
-        } else if isSignedIn {
-            phase = .authenticated
-        } else if phase == .needsReauth {
-            // Preserve needsReauth until explicit sign-in or nuclear sign-out.
-        } else {
-            phase = .signedOut
-        }
-    }
 
     /// Light session invalidation: clears credentials and signed-in UI state without
     /// the nuclear teardown performed by `AuthService.signOut()`.
     func invalidateSession(reason: InvalidateReason, auth: AuthService) {
         NSLog("OMI AUTH: invalidateSession reason=%@", reason.rawValue)
         auth.performLightSessionInvalidation()
-        phase = .needsReauth
+        AuthState.shared.transition(to: .needsReauth)
         NotificationCenter.default.post(
             name: .sessionDidInvalidate,
             object: nil,
@@ -139,13 +128,8 @@ final class AuthSessionCoordinator {
 
     /// Returns true when the session has a usable ID token after optional refresh.
     func ensureValidSession(trigger: EnsureValidSessionTrigger, auth: AuthService) async -> Bool {
-        syncPhaseFromAuthState(
-            isSignedIn: auth.isSignedIn,
-            isRestoringAuth: AuthState.shared.isRestoringAuth
-        )
         guard phase != .restoring, phase != .needsReauth else { return false }
-        guard auth.isSignedIn else {
-            phase = .signedOut
+        guard phase == .authenticated || phase == .recoveryRequired else {
             return false
         }
         let forceRefresh = trigger == .appBecameActive
@@ -155,13 +139,17 @@ final class AuthSessionCoordinator {
             } else {
                 _ = try await auth.getIdToken(forceRefresh: false)
             }
-            phase = .authenticated
+            AuthState.shared.transition(to: .authenticated)
             return true
         } catch AuthError.notSignedIn {
             NSLog("OMI AUTH: ensureValidSession(%@) session not signed in", trigger.rawValue)
+            if phase != .needsReauth {
+                AuthState.shared.transition(to: .recoveryRequired)
+            }
             return false
         } catch {
             NSLog("OMI AUTH: ensureValidSession(%@) deferred: %@", trigger.rawValue, error.localizedDescription)
+            AuthState.shared.transition(to: .recoveryRequired)
             return false
         }
     }
@@ -172,7 +160,7 @@ final class AuthSessionCoordinator {
         auth: AuthService,
         minInterval: TimeInterval = 30
     ) async {
-        guard phase != .restoring, phase != .needsReauth else { return }
+        guard phase != .restoring, phase != .needsReauth, phase != .signedOut else { return }
         let now = Date()
         if let last = lastProactiveValidation, now.timeIntervalSince(last) < minInterval {
             return
@@ -195,11 +183,11 @@ final class AuthSessionCoordinator {
     func resetAfterNuclearSignOut() {
         refreshFlight?.cancel()
         refreshFlight = nil
-        phase = .signedOut
+        AuthState.shared.transition(to: .signedOut)
     }
 
     func resetAfterSuccessfulSignIn() {
         refreshFlight = nil
-        phase = .authenticated
+        AuthState.shared.transition(to: .authenticated)
     }
 }

--- a/desktop/macos/Desktop/Sources/DesktopKeychainStore.swift
+++ b/desktop/macos/Desktop/Sources/DesktopKeychainStore.swift
@@ -147,9 +147,11 @@ enum DesktopKeychainStore {
     }
     if !isMissing(updateStatus) {
       if isAuthUnavailable(updateStatus) {
-        // Existing item is unreadable/unwritable under silent auth. Do not prompt; try a
-        // fresh add after a silent delete. If delete also fails, fail closed.
-        delete(service: service, account: account)
+        // Never delete an existing credential merely because a write is temporarily
+        // unavailable. Delete-then-add can turn a recoverable locked-Keychain or ACL
+        // condition into permanent session loss if the subsequent add also fails.
+        log("DesktopKeychainStore: update unavailable; preserving existing item for \(service)/\(account) (status \(updateStatus))")
+        return false
       } else {
         log("DesktopKeychainStore: update failed for \(service)/\(account) (status \(updateStatus))")
         return false

--- a/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
@@ -82,6 +82,11 @@ struct DesktopHomeView: View {
         .onAppear {
           log("DesktopHomeView: Showing auth loading splash")
         }
+      } else if authState.sessionPhase == .recoveryRequired {
+        SessionRecoveryView()
+          .onAppear {
+            log("DesktopHomeView: Showing recoverable auth state")
+          }
       } else if !authState.isSignedIn {
         // State 1: Not signed in - show sign in
         SignInView(authState: authState)
@@ -564,6 +569,7 @@ struct DesktopHomeView: View {
 
   private var currentAppStateLabel: String {
     if authState.isRestoringAuth { return "restoring_auth" }
+    if authState.sessionPhase == .recoveryRequired { return "auth_recovery" }
     if !authState.isSignedIn { return "signed_out" }
     if !appState.hasCompletedOnboarding { return "onboarding" }
     return "main"

--- a/desktop/macos/Desktop/Sources/MainWindow/RewindOnlyView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/RewindOnlyView.swift
@@ -24,6 +24,11 @@ struct RewindOnlyView: View {
                         .tint(.white.opacity(0.6))
                 }
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else if authState.sessionPhase == .recoveryRequired {
+                SessionRecoveryView()
+                    .onAppear {
+                        log("RewindOnlyView: Showing recoverable auth state")
+                    }
             } else if !authState.isSignedIn {
                 // Not signed in - show sign in view
                 SignInView(authState: authState)

--- a/desktop/macos/Desktop/Sources/OmiApp.swift
+++ b/desktop/macos/Desktop/Sources/OmiApp.swift
@@ -40,11 +40,13 @@ class AuthState: ObservableObject {
   private static let kAuthUserEmail = "auth_userEmail"
   private static let kAuthUserId = "auth_userId"
 
-  @Published var isSignedIn: Bool
+  @Published private(set) var sessionPhase: AuthSessionPhase
   @Published var isLoading: Bool = false
-  @Published var isRestoringAuth: Bool = true
   @Published var error: String?
   @Published var userEmail: String?
+
+  var isSignedIn: Bool { sessionPhase == .authenticated }
+  var isRestoringAuth: Bool { sessionPhase == .restoring }
 
   private init() {
     BundleEnvironment.loadIfNeeded()
@@ -55,13 +57,13 @@ class AuthState: ObservableObject {
 
     if DesktopLocalProfile.isEnabled {
       // Harness-owned emulator auth replaces any persisted cloud session.
-      self.isSignedIn = false
+      self.sessionPhase = .restoring
       self.userEmail = nil
-      self.isRestoringAuth = true
     } else {
-      self.isSignedIn = savedSignedIn
+      // `auth_isSignedIn` is only a restore hint. Never expose authenticated UI
+      // until AuthService has validated a usable credential for this launch.
+      self.sessionPhase = savedSignedIn ? .restoring : .signedOut
       self.userEmail = savedEmail
-      self.isRestoringAuth = savedSignedIn
     }
     NSLog(
       "OMI AuthState: Initialized localProfile=%@ savedSignedIn=%@ email=%@ isRestoringAuth=%@",
@@ -71,8 +73,14 @@ class AuthState: ObservableObject {
   }
 
   func update(isSignedIn: Bool, userEmail: String? = nil) {
-    self.isSignedIn = isSignedIn
+    transition(to: isSignedIn ? .authenticated : .signedOut)
     self.userEmail = userEmail
+  }
+
+  func transition(to phase: AuthSessionPhase) {
+    guard sessionPhase != phase else { return }
+    sessionPhase = phase
+    NSLog("OMI AUTH: session phase -> %@", String(describing: phase))
   }
 
   /// Get the user's Firebase UID from UserDefaults (fallback when Firebase SDK auth fails)
@@ -244,6 +252,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
   private var initialSettingsSyncTask: Task<Void, Never>?
 
   func applicationWillFinishLaunching(_ notification: Notification) {
+    if AuthStorageCanary.isRequested { return }
     // Single-instance guard: a second live copy of the same bundle id + launch mode
     // would race the first against the shared Rewind SQLite DB
     // (~/Library/Application Support/Omi/…) and the bundle-id UserDefaults domain,
@@ -259,6 +268,11 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
       ViewExporter.run()
       return
     }
+
+    // The release pipeline launches the exact signed artifact in this isolated
+    // mode before publication. Run before installer, database, defaults, or
+    // background-service startup so the probe has no product side effects.
+    if AuthStorageCanary.runIfRequested() { return }
 
     // Running from the mounted DMG / a translocated mount breaks TCC permissions
     // and Sparkle updates — install to /Applications and relaunch before any
@@ -460,14 +474,14 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
 
     if DesktopLocalProfile.isEnabled {
       log("Local harness: skipping Firebase SDK configure; bootstrapping Auth emulator via REST")
-      AuthState.shared.isRestoringAuth = true
+      AuthState.shared.transition(to: .restoring)
       Task { @MainActor in
         await AuthService.shared.bootstrapLocalHarnessAuthIfNeeded()
       }
       DispatchQueue.main.asyncAfter(deadline: .now() + 10.0) {
         if AuthState.shared.isRestoringAuth {
           log("Local harness auth watchdog: clearing stuck restoring_auth splash")
-          AuthState.shared.isRestoringAuth = false
+          AuthState.shared.transition(to: .recoveryRequired)
         }
       }
     } else if let path = plistPath,

--- a/desktop/macos/Desktop/Tests/AuthSessionCoordinatorTests.swift
+++ b/desktop/macos/Desktop/Tests/AuthSessionCoordinatorTests.swift
@@ -113,11 +113,45 @@ final class AuthSessionCoordinatorTests: XCTestCase {
 
   func testRestoreValidationUsesRefreshSingleFlight() throws {
     let source = try sourceFile("AuthService.swift")
-    let validationRange = source.range(of: "private func validateRestoredUserDefaultsSession()")
+    let validationRange = source.range(of: "private func validateRestoredSessionNow() async")
     XCTAssertNotNil(validationRange)
-    let snippet = String(source[validationRange!.lowerBound...]).prefix(800)
+    let snippet = String(source[validationRange!.lowerBound...]).prefix(1800)
     XCTAssertTrue(snippet.contains("refreshSingleFlight(auth: self)"))
-    XCTAssertTrue(snippet.contains("defer { AuthState.shared.isRestoringAuth = false }"))
+    XCTAssertTrue(snippet.contains("transition(to: .recoveryRequired)"))
+    XCTAssertTrue(snippet.contains("resetAfterSuccessfulSignIn()"))
+  }
+
+  func testOnlyAuthenticatedPhaseReportsSignedIn() {
+    let state = AuthState.shared
+    let original = state.sessionPhase
+    defer { state.transition(to: original) }
+
+    state.transition(to: .restoring)
+    XCTAssertFalse(state.isSignedIn)
+    XCTAssertTrue(state.isRestoringAuth)
+
+    state.transition(to: .recoveryRequired)
+    XCTAssertFalse(state.isSignedIn)
+    XCTAssertFalse(state.isRestoringAuth)
+
+    state.transition(to: .needsReauth)
+    XCTAssertFalse(state.isSignedIn)
+
+    state.transition(to: .authenticated)
+    XCTAssertTrue(state.isSignedIn)
+  }
+
+  func testPersistedSignedInBooleanIsOnlyARestoreHint() throws {
+    let app = try sourceFile("OmiApp.swift")
+    XCTAssertTrue(app.contains("self.sessionPhase = savedSignedIn ? .restoring : .signedOut"))
+    XCTAssertFalse(app.contains("self.isSignedIn = savedSignedIn"))
+
+    let home = try sourceFile("MainWindow/DesktopHomeView.swift")
+    let recovery = home.range(of: "authState.sessionPhase == .recoveryRequired")
+    let main = home.range(of: "// State 3: Signed in and onboarded")
+    XCTAssertNotNil(recovery)
+    XCTAssertNotNil(main)
+    XCTAssertLessThan(recovery!.lowerBound, main!.lowerBound)
   }
 
   func testProactiveEnsureValidSessionOnBecomeActive() throws {

--- a/desktop/macos/Desktop/Tests/AuthStorageCanaryTests.swift
+++ b/desktop/macos/Desktop/Tests/AuthStorageCanaryTests.swift
@@ -1,0 +1,40 @@
+import XCTest
+
+@testable import Omi_Computer
+
+final class AuthStorageCanaryTests: XCTestCase {
+  func testCanaryProvesWriteReadAndDelete() {
+    var value: String?
+    let result = AuthStorageCanary.execute(
+      hooks: .init(
+        set: { newValue, _, _ in value = newValue; return true },
+        read: { _, _ in value },
+        delete: { _, _ in value = nil }
+      ))
+
+    XCTAssertEqual(result, .init(success: true, stage: "complete"))
+    XCTAssertNil(value)
+  }
+
+  func testCanaryFailsWhenSignedArtifactCannotWriteKeychain() {
+    let result = AuthStorageCanary.execute(
+      hooks: .init(
+        set: { _, _, _ in false },
+        read: { _, _ in nil },
+        delete: { _, _ in }
+      ))
+
+    XCTAssertEqual(result, .init(success: false, stage: "write"))
+  }
+
+  func testCanaryFailsWhenReadBackDoesNotMatch() {
+    let result = AuthStorageCanary.execute(
+      hooks: .init(
+        set: { _, _, _ in true },
+        read: { _, _ in "different" },
+        delete: { _, _ in }
+      ))
+
+    XCTAssertEqual(result, .init(success: false, stage: "read_back"))
+  }
+}

--- a/desktop/macos/Desktop/Tests/AuthTokenStorageTests.swift
+++ b/desktop/macos/Desktop/Tests/AuthTokenStorageTests.swift
@@ -85,6 +85,132 @@ final class AuthTokenStorageTests: XCTestCase {
     XCTAssertEqual(UserDefaults.standard.string(forKey: .authUserId), "existing-default-user")
   }
 
+  func testMigrationFailurePreservesLegacyTokensWhenFallbackIsDisabled() async throws {
+    let auth = AuthService()
+    auth.tokenStorageHooks = AuthService.TokenStorageHooks(
+      usesKeychainTokenStorage: { true },
+      allowsUserDefaultsFallback: { false },
+      readKeychainString: { _, _ in nil },
+      writeKeychainString: { _, _, _ in false },
+      deleteKeychainString: { _, _ in },
+      recordsFallbackTelemetry: false
+    )
+
+    UserDefaults.standard.set("legacy-id-token", forKey: .authIdToken)
+    UserDefaults.standard.set("legacy-refresh-token", forKey: .authRefreshToken)
+    UserDefaults.standard.set(Date().addingTimeInterval(3600).timeIntervalSince1970, forKey: .authTokenExpiry)
+    UserDefaults.standard.set("legacy-user", forKey: .authTokenUserId)
+    UserDefaults.standard.set("legacy-user", forKey: .authUserId)
+
+    let idToken = try await auth.getIdToken()
+    XCTAssertEqual(idToken, "legacy-id-token")
+    XCTAssertEqual(UserDefaults.standard.string(forKey: .authRefreshToken), "legacy-refresh-token")
+  }
+
+  func testKeychainReadBackMismatchNeverDeletesLegacyMigrationSource() async throws {
+    var keychainPayload: String?
+    let auth = AuthService()
+    auth.tokenStorageHooks = AuthService.TokenStorageHooks(
+      usesKeychainTokenStorage: { true },
+      allowsUserDefaultsFallback: { false },
+      readKeychainString: { _, _ in keychainPayload },
+      writeKeychainString: { _, _, _ in
+        keychainPayload = #"{"idToken":"wrong","refreshToken":"wrong","expiryTime":0,"tokenUserId":"legacy-user"}"#
+        return true
+      },
+      deleteKeychainString: { _, _ in keychainPayload = nil },
+      recordsFallbackTelemetry: false
+    )
+
+    UserDefaults.standard.set("legacy-id-token", forKey: .authIdToken)
+    UserDefaults.standard.set("legacy-refresh-token", forKey: .authRefreshToken)
+    UserDefaults.standard.set(Date().addingTimeInterval(3600).timeIntervalSince1970, forKey: .authTokenExpiry)
+    UserDefaults.standard.set("legacy-user", forKey: .authTokenUserId)
+    UserDefaults.standard.set("legacy-user", forKey: .authUserId)
+
+    let idToken = try await auth.getIdToken()
+    XCTAssertEqual(idToken, "legacy-id-token")
+    XCTAssertEqual(UserDefaults.standard.string(forKey: .authIdToken), "legacy-id-token")
+    XCTAssertEqual(UserDefaults.standard.string(forKey: .authRefreshToken), "legacy-refresh-token")
+  }
+
+  func testKeychainReadBackMismatchRestoresPreviousKeychainOnlySession() {
+    let previousPayload = #"{"idToken":"old-id-token","refreshToken":"old-refresh-token","expiryTime":4102444800,"tokenUserId":"old-user"}"#
+    var keychainPayload: String? = previousPayload
+    var isFirstWrite = true
+    let auth = AuthService()
+    auth.tokenStorageHooks = AuthService.TokenStorageHooks(
+      usesKeychainTokenStorage: { true },
+      allowsUserDefaultsFallback: { false },
+      readKeychainString: { _, _ in keychainPayload },
+      writeKeychainString: { value, _, _ in
+        if isFirstWrite {
+          isFirstWrite = false
+          keychainPayload = #"{"idToken":"wrong","refreshToken":"wrong","expiryTime":0,"tokenUserId":"new-user"}"#
+        } else {
+          keychainPayload = value
+        }
+        return true
+      },
+      deleteKeychainString: { _, _ in keychainPayload = nil },
+      recordsFallbackTelemetry: false
+    )
+
+    XCTAssertThrowsError(
+      try auth.saveTokens(idToken: "new-id-token", refreshToken: "new-refresh-token", expiresIn: 3600, userId: "new-user")
+    )
+    XCTAssertEqual(keychainPayload, previousPayload)
+  }
+
+  func testRefreshPersistenceFailureUpdatesSameUserLegacySource() async throws {
+    let auth = AuthService()
+    auth.tokenStorageHooks = AuthService.TokenStorageHooks(
+      usesKeychainTokenStorage: { true },
+      allowsUserDefaultsFallback: { false },
+      readKeychainString: { _, _ in nil },
+      writeKeychainString: { _, _, _ in false },
+      deleteKeychainString: { _, _ in },
+      recordsFallbackTelemetry: false
+    )
+
+    UserDefaults.standard.set("old-id-token", forKey: .authIdToken)
+    UserDefaults.standard.set("old-refresh-token", forKey: .authRefreshToken)
+    UserDefaults.standard.set(Date().addingTimeInterval(60).timeIntervalSince1970, forKey: .authTokenExpiry)
+    UserDefaults.standard.set("same-user", forKey: .authTokenUserId)
+    UserDefaults.standard.set("same-user", forKey: .authUserId)
+
+    XCTAssertNoThrow(
+      try auth.saveTokens(idToken: "new-id-token", refreshToken: "new-refresh-token", expiresIn: 3600, userId: "same-user")
+    )
+    XCTAssertEqual(UserDefaults.standard.string(forKey: .authIdToken), "new-id-token")
+    XCTAssertEqual(UserDefaults.standard.string(forKey: .authRefreshToken), "new-refresh-token")
+  }
+
+  func testFailedAccountSwitchDoesNotOverwritePreviousUsersLegacyTokens() {
+    let auth = AuthService()
+    auth.tokenStorageHooks = AuthService.TokenStorageHooks(
+      usesKeychainTokenStorage: { true },
+      allowsUserDefaultsFallback: { false },
+      readKeychainString: { _, _ in nil },
+      writeKeychainString: { _, _, _ in false },
+      deleteKeychainString: { _, _ in },
+      recordsFallbackTelemetry: false
+    )
+
+    UserDefaults.standard.set("old-id-token", forKey: .authIdToken)
+    UserDefaults.standard.set("old-refresh-token", forKey: .authRefreshToken)
+    UserDefaults.standard.set(Date().addingTimeInterval(3600).timeIntervalSince1970, forKey: .authTokenExpiry)
+    UserDefaults.standard.set("old-user", forKey: .authTokenUserId)
+    UserDefaults.standard.set("old-user", forKey: .authUserId)
+
+    XCTAssertThrowsError(
+      try auth.saveTokens(idToken: "new-id-token", refreshToken: "new-refresh-token", expiresIn: 3600, userId: "new-user")
+    )
+    XCTAssertEqual(UserDefaults.standard.string(forKey: .authIdToken), "old-id-token")
+    XCTAssertEqual(UserDefaults.standard.string(forKey: .authRefreshToken), "old-refresh-token")
+    XCTAssertEqual(UserDefaults.standard.string(forKey: .authTokenUserId), "old-user")
+  }
+
   func testKeychainSuccessClearsUserDefaultsFallbackTokensAndRetrievesFromKeychain() async throws {
     var keychainPayload: String?
     let auth = AuthService()

--- a/desktop/macos/Desktop/Tests/ChatErrorStateTests.swift
+++ b/desktop/macos/Desktop/Tests/ChatErrorStateTests.swift
@@ -286,16 +286,16 @@ final class ChatErrorStateTests: XCTestCase {
   func testSavedUserDefaultsSessionIsValidatedBeforeUse() throws {
     let source = try sourceFile("AuthService.swift")
 
-    XCTAssertTrue(source.contains("validateRestoredUserDefaultsSession()"))
+    XCTAssertTrue(source.contains("validateRestoredSession()"))
     XCTAssertTrue(source.contains("refreshSingleFlight(auth: self)"))
-    XCTAssertTrue(source.contains("Restored UserDefaults session validated via forced refresh"))
-    XCTAssertTrue(source.contains("Restored UserDefaults session validation deferred - preserving restored session"))
+    XCTAssertTrue(source.contains("Restored session validated via forced refresh"))
+    XCTAssertTrue(source.contains("Restored session validation deferred - preserving credentials for retry"))
     XCTAssertFalse(source.contains("cached ID token expired"))
   }
 
   func testRestoredSessionValidationDoesNotClearPersistedTokensOnTransientFailure() throws {
     let source = try sourceFile("AuthService.swift")
-    let validationBlockRange = source.range(of: "Restored UserDefaults session validation deferred - preserving restored session")
+    let validationBlockRange = source.range(of: "Restored session validation deferred - preserving credentials for retry")
     XCTAssertNotNil(validationBlockRange)
     let snippet = String(source[validationBlockRange!.lowerBound...])
     let catchBlock = String(snippet[..<(snippet.range(of: "} catch {")?.lowerBound ?? snippet.endIndex)])
@@ -305,11 +305,11 @@ final class ChatErrorStateTests: XCTestCase {
 
   func testRestoredSessionInvalidatesWhenValidationClearedTokens() throws {
     let source = try sourceFile("AuthService.swift")
-    let range = source.range(of: "Restored UserDefaults session validation — tokens cleared, invalidating")
+    let range = source.range(of: "Restored session validation proved credentials absent")
     XCTAssertNotNil(range)
     let snippet = String(source[range!.lowerBound...]).prefix(200)
     XCTAssertTrue(snippet.contains("invalidateSession(reason: .restoredSessionInvalid)"))
-    let methodStart = source.range(of: "private func validateRestoredUserDefaultsSession()")
+    let methodStart = source.range(of: "private func validateRestoredSessionNow() async")
     XCTAssertNotNil(methodStart)
     let method = String(source[methodStart!.lowerBound...]).prefix(1200)
     XCTAssertTrue(method.contains("storedIdToken == nil") || method.contains("storedRefreshToken == nil"))
@@ -317,7 +317,7 @@ final class ChatErrorStateTests: XCTestCase {
 
   func testRestoredSessionValidationForceRefreshesOnLaunch() throws {
     let source = try sourceFile("AuthService.swift")
-    let validationRange = source.range(of: "private func validateRestoredUserDefaultsSession()")
+    let validationRange = source.range(of: "private func validateRestoredSessionNow() async")
     XCTAssertNotNil(validationRange)
     let snippet = String(source[validationRange!.lowerBound...])
 

--- a/desktop/macos/Desktop/Tests/FailLoudConfigTests.swift
+++ b/desktop/macos/Desktop/Tests/FailLoudConfigTests.swift
@@ -176,18 +176,20 @@ final class FailLoudConfigTests: XCTestCase {
   func testAuthTokensUseKeychainStorageOnAllBuilds() throws {
     let src = try source(relativePath: "Sources/AuthService.swift")
 
-    // Security invariant: the live config stores auth tokens in the Keychain on EVERY build
-    // (dev, beta, and production) with the plaintext UserDefaults write fallback disabled.
+    // Security invariant: new auth tokens use Keychain on every build. The only
+    // UserDefaults continuity path updates an already-existing same-user legacy
+    // migration source until signed-app Keychain persistence succeeds.
     XCTAssertTrue(src.contains("usesKeychainTokenStorage: { true }"))
     XCTAssertFalse(src.contains("!AppBuild.isNonProduction"))
     XCTAssertTrue(src.contains("allowsUserDefaultsFallback: { false }"))
     XCTAssertTrue(src.contains("DesktopKeychainStore.setString("))
-    XCTAssertTrue(src.contains("migrated production auth tokens from UserDefaults to Keychain"))
+    XCTAssertTrue(src.contains("persistKeychainTokensTransactionally"))
     XCTAssertTrue(src.contains("clearUserDefaultsTokens()"))
     XCTAssertTrue(src.contains("allowsUserDefaultsTokenFallback"))
-    XCTAssertTrue(src.contains("AuthService: Keychain token storage failed; falling back to UserDefaults for desktop auth continuity"))
+    XCTAssertTrue(src.contains("Keychain token persistence deferred; preserving legacy migration source"))
     XCTAssertTrue(src.contains("\"update_channel\": AppBuild.currentUpdateChannel"))
-    XCTAssertTrue(src.contains("failed to migrate production auth tokens from UserDefaults to Keychain"))
+    XCTAssertTrue(src.contains("Keychain migration deferred; retaining legacy auth tokens"))
+    XCTAssertTrue(src.contains("DesktopDiagnosticsManager.shared.recordFallback"))
     XCTAssertTrue(src.contains("cachedStoredTokens"))
   }
 

--- a/desktop/macos/changelog/unreleased/20260709-transactional-auth-recovery.json
+++ b/desktop/macos/changelog/unreleased/20260709-transactional-auth-recovery.json
@@ -1,0 +1,3 @@
+{
+  "change": "Protected signed-in sessions across app updates and added a clear recovery screen when credentials cannot be verified"
+}

--- a/desktop/macos/e2e/flows/harness-smoke.yaml
+++ b/desktop/macos/e2e/flows/harness-smoke.yaml
@@ -7,6 +7,8 @@ covers:
   - desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
   - desktop/macos/Desktop/Sources/AuthService.swift
   - desktop/macos/Desktop/Sources/AuthSessionCoordinator.swift
+  - desktop/macos/Desktop/Sources/Auth/SessionRecoveryView.swift
+  - desktop/macos/Desktop/Sources/Auth/AuthStorageCanary.swift
   - desktop/macos/Desktop/Sources/DesktopKeychainStore.swift
   - desktop/macos/Desktop/Sources/ClientDeviceService.swift
   - desktop/macos/Desktop/Sources/LocalAgentAPIServer.swift

--- a/desktop/macos/scripts/smoke-signed-desktop-artifact.sh
+++ b/desktop/macos/scripts/smoke-signed-desktop-artifact.sh
@@ -14,6 +14,7 @@ EXPECTED_TEAM_ID="${OMI_SIGNED_ARTIFACT_SMOKE_TEAM_ID:-9536L8KLMP}"
 RUN_LAUNCH=false
 RUN_NETWORK=false
 RUN_AUTH=false
+RUN_AUTH_STORAGE_CANARY=false
 RUN_CHAT=false
 RUN_PERMISSIONS=false
 RUN_STORAGE=false
@@ -45,6 +46,7 @@ Options:
   --launch                   Launch the app and assert it stays alive briefly
   --network                  Probe configured backend/appcast URLs
   --auth                     Run auth persistence probe (requires env below)
+  --auth-storage-canary      Run synthetic Keychain round trip in the signed app
   --chat                     Run minimal chat probe (requires --auth env)
   --permissions             Verify permission surface/fail-graceful live path
   --storage                  Verify local storage opens in live path
@@ -69,6 +71,7 @@ Optional live-probe environment:
 Smoke paths covered:
   - Launch + identity
   - Auth persistence
+  - Signed Keychain canary
   - Backend routing
   - Sparkle/update metadata
   - Native helper/runtime bundle integrity
@@ -124,6 +127,7 @@ parse_args() {
       --launch) RUN_LAUNCH=true; shift ;;
       --network) RUN_NETWORK=true; shift ;;
       --auth) RUN_AUTH=true; shift ;;
+      --auth-storage-canary) RUN_AUTH_STORAGE_CANARY=true; shift ;;
       --chat) RUN_CHAT=true; shift ;;
       --permissions) RUN_PERMISSIONS=true; shift ;;
       --storage) RUN_STORAGE=true; shift ;;
@@ -168,7 +172,7 @@ extract_zip_if_needed() {
 }
 
 maybe_copy_for_launch() {
-  [[ "$RUN_LAUNCH" == true ]] || return 0
+  [[ "$RUN_LAUNCH" == true || "$RUN_AUTH_STORAGE_CANARY" == true ]] || return 0
   [[ -n "$INSTALL_DIR" ]] || INSTALL_DIR="$(mktemp -d "${TMPDIR:-/tmp}/omi-signed-smoke-install.XXXXXX")"
   mkdir -p "$INSTALL_DIR"
 
@@ -496,6 +500,52 @@ run_auth_probe() {
   pass "Auth persistence app-level proof command passed"
 }
 
+run_auth_storage_canary() {
+  [[ "${OMI_SIGNED_ARTIFACT_SMOKE_ALLOW_PRODUCTION_LAUNCH:-}" == "1" ]] \
+    || fail "--auth-storage-canary for production bundle requires OMI_SIGNED_ARTIFACT_SMOKE_ALLOW_PRODUCTION_LAUNCH=1"
+
+  local result_path executable started_at canary_pid
+  result_path="$(mktemp "${TMPDIR:-/tmp}/omi-auth-storage-canary.XXXXXX")"
+  rm -f "$result_path"
+  executable="$APP_BUNDLE/Contents/MacOS/$(plist_read CFBundleExecutable)"
+  [[ -x "$executable" ]] || fail "executable missing before auth storage canary"
+
+  "$executable" "--auth-storage-canary-result=$result_path" \
+    >/tmp/omi-auth-storage-canary.out 2>/tmp/omi-auth-storage-canary.err &
+  canary_pid=$!
+
+  started_at=$SECONDS
+  while [[ ! -s "$result_path" && $((SECONDS - started_at)) -lt "$TIMEOUT_SECONDS" ]]; do
+    sleep 1
+  done
+  [[ -s "$result_path" ]] || {
+    cat /tmp/omi-auth-storage-canary.err >&2 || true
+    kill "$canary_pid" >/dev/null 2>&1 || true
+    wait "$canary_pid" >/dev/null 2>&1 || true
+    fail "signed app auth storage canary did not produce a result"
+  }
+
+  python3 - "$result_path" <<'PY' || fail "signed app auth storage canary failed"
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as handle:
+    result = json.load(handle)
+if result.get("success") is not True or result.get("stage") != "complete":
+    raise SystemExit(f"auth storage canary result: {result}")
+PY
+  started_at=$SECONDS
+  while kill -0 "$canary_pid" >/dev/null 2>&1 && $((SECONDS - started_at)) -lt 5; do
+    sleep 1
+  done
+  if kill -0 "$canary_pid" >/dev/null 2>&1; then
+    kill "$canary_pid" >/dev/null 2>&1 || true
+  fi
+  wait "$canary_pid" >/dev/null 2>&1 || true
+  rm -f "$result_path"
+  pass "Signed artifact Keychain write/read/delete canary passed"
+}
+
 run_chat_probe() {
   local auth_header="${OMI_SIGNED_ARTIFACT_SMOKE_AUTH_HEADER:-}"
   local chat_url="${OMI_SIGNED_ARTIFACT_SMOKE_CHAT_URL:-https://api.omi.me/v2/chat/completions}"
@@ -544,6 +594,7 @@ main() {
 
   maybe_copy_for_launch
   [[ "$RUN_NETWORK" == true ]] && run_network_probes
+  [[ "$RUN_AUTH_STORAGE_CANARY" == true ]] && run_auth_storage_canary
   [[ "$RUN_LAUNCH" == true ]] && run_launch_probe
   [[ "$RUN_AUTH" == true ]] && run_auth_probe
   [[ "$RUN_CHAT" == true ]] && run_chat_probe

--- a/desktop/macos/tests/test-signed-artifact-smoke.sh
+++ b/desktop/macos/tests/test-signed-artifact-smoke.sh
@@ -27,6 +27,7 @@ fi
 for required in \
   "Launch + identity" \
   "Auth persistence" \
+  "Signed Keychain canary" \
   "Backend routing" \
   "Sparkle/update metadata" \
   "Native helper/runtime bundle integrity" \

--- a/docs/product/invariants/auth-session.md
+++ b/docs/product/invariants/auth-session.md
@@ -5,6 +5,10 @@
 of Firebase session death. Definitive credential loss must invalidate the light
 session (tokens + signed-in UI) without nuclear sign-out teardown.
 
+Persisted auth booleans and Firebase `currentUser` are restore hints only. The
+runtime may expose authenticated surfaces only after a credential validates for
+the current launch.
+
 ## MUST NOT
 
 - Preserve `isSignedIn=true` when refresh and post-refresh HTTP 401 prove the
@@ -15,26 +19,42 @@ session (tokens + signed-in UI) without nuclear sign-out teardown.
   invalidation for session-scoped HTTP 401s.
 - Invalidate the Firebase session for BYOK/provider credential 401s or voice-only
   credential failures (`CredentialHealthManager` scope).
+- Treat `auth_isSignedIn=true` or cached Firebase identity as sufficient proof
+  that the runtime is authenticated.
+- Delete a legacy credential until the replacement Keychain payload has been
+  written, read back exactly, and committed by a successful forced refresh.
+- Publish a beta artifact without running its signed-app Keychain canary.
 
 ## Surfaces
 
 - `AuthSessionCoordinator`, `AuthService` restore/refresh/listener paths
+- `AuthState` phase and `SessionRecoveryView` authenticated-surface gate
+- `DesktopKeychainStore` and legacy credential migration
 - `APIClient` session-scoped 401 handling
 - `ChatProvider` bridge-start and send-time auth UX
+- Codemagic signed-artifact smoke before beta publication
 
 ## Guard tests
 
 - `desktop/macos/Desktop/Tests/AuthSessionCoordinatorTests.swift`
 - `desktop/macos/Desktop/Tests/APIClientAuthRecoveryTests.swift`
 - `desktop/macos/Desktop/Tests/ChatErrorStateTests.swift`
+- `desktop/macos/Desktop/Tests/AuthTokenStorageTests.swift`
+- `desktop/macos/Desktop/Tests/AuthStorageCanaryTests.swift`
+- `desktop/macos/tests/test-signed-artifact-smoke.sh`
 - `.github/scripts/check_desktop_auth_session.py` — ratchet on 401 handlers
 
 ## Path globs
 
 - `desktop/macos/Desktop/Sources/AuthService.swift`
 - `desktop/macos/Desktop/Sources/AuthSessionCoordinator.swift`
+- `desktop/macos/Desktop/Sources/Auth/*.swift`
+- `desktop/macos/Desktop/Sources/DesktopKeychainStore.swift`
+- `desktop/macos/Desktop/Sources/OmiApp.swift`
 - `desktop/macos/Desktop/Sources/APIClient.swift`
 - `desktop/macos/Desktop/Sources/Providers/ChatProvider.swift`
+- `desktop/macos/scripts/smoke-signed-desktop-artifact.sh`
+- `codemagic.yaml`
 
 ## PR rule
 


### PR DESCRIPTION
## Root cause

- Launch restoration treated the persisted auth_isSignedIn boolean and Firebase cached currentUser as proof of a usable session, so authenticated UI could appear before credentials were validated.
- The scoped-Keychain migration could clear the legacy credential after a failed write/read path. A beta update could therefore strand a valid onboarding-complete user with no usable credential until manual logout/login.
- Release checks inspected signing and entitlements but did not execute a Keychain operation from the exact signed artifact, so distribution-only Keychain failures could escape local and unit coverage.

## What changed

- Made AuthSessionPhase the runtime authority. Persisted state is now only a restoration hint; signed-in surfaces stay gated until a forced refresh succeeds.
- Added a recoverable session screen for transient network/Keychain failures. Retry revalidates preserved credentials; Sign In Again remains available for deliberate recovery.
- Made Keychain persistence transactional: write, exact read-back, and rollback to the previous payload on mismatch. Legacy UserDefaults credentials survive until a refreshed credential commits successfully, and account switches cannot overwrite another users rollback source.
- Removed the destructive delete-then-add Keychain fallback.
- Added a synthetic write/read/delete canary that runs inside the exact signed app. Codemagic now requires it before beta publication; stable/prod promotion reuses that same immutable release artifact.
- Expanded INV-AUTH-1, CI change detection, regression tests, e2e coverage metadata, release docs, and changelog.

## Verification

- xcrun swift test - package auth/session/storage/chat/config filters: 63 tests passed.
- Clean arm64 release compile passed.
- INV-AUTH-1 ratchet, signed-artifact smoke tests, e2e coverage check, changelog validation, shell syntax, and git diff checks passed.
- Repository pre-push checks passed, including Swift compile, Rust check, workflow contracts, 96 agent tests, and 103 tool-surface tests.
- Real named bundle omi-auth-recovery:
  - seeded legacy credentials upgraded and reached appState main with isSignedIn true;
  - in-app Keychain canary returned stage complete / success true;
  - forced transient refresh failure reached appState auth_recovery with onboarding preserved and isSignedIn false;
  - normal relaunch returned automatically to appState main with isSignedIn true, without logout/login.
- Signing inspection confirmed an Apple Development signature, hardened runtime, expected team ID, and no app sandbox.

## Full-suite note

The unfiltered desktop Swift suite is not currently green because APIClientRoutingTests.testDeleteConversationRoutesToPython expects cascade=true from an unmodified APIClient path, and a later order-dependent LiveNotesMonitor run can hit Firebase-not-configured after that failure. The routing test fails in isolation; LiveNotesMonitorTests pass in isolation. Neither touched surface is part of this change.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9344?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

