### PR TITLE
ci: fix android compile smoke running out of disk space

### DIFF
--- a/.github/workflows/mobile-app-checks.yml
+++ b/.github/workflows/mobile-app-checks.yml
@@ -91,6 +91,16 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Free runner disk space
+        # ubuntu-latest ships with ~14GB free; the Gradle build runs out of
+        # space during stripDebugSymbols. Remove unused preinstalled toolchains
+        # (keep /usr/local/lib/android — the build needs the Android SDK).
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/.ghcup /opt/hostedtoolcache/CodeQL \
+            /usr/local/share/boost /usr/local/share/chromium /usr/local/lib/node_modules
+          sudo docker image prune --all --force
+          df -h /
+
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
@@ -134,4 +144,6 @@ jobs:
           CM_KEYSTORE_PASSWORD: android
           CM_KEY_ALIAS: androiddebugkey
           CM_KEY_PASSWORD: android
-        run: flutter build apk --debug --flavor dev
+        # Single ABI: a compile smoke doesn't need arm + arm64 + x86_64 native
+        # libs, and the extra ABIs double disk usage during stripDebugSymbols.
+        run: flutter build apk --debug --flavor dev --target-platform android-arm64


### PR DESCRIPTION
## Problem

The **Android Compile Smoke** job fails with `No space left on device` during Gradle's `stripDevDebugDebugSymbols` task ([example failure](https://github.com/BasedHardware/omi/actions)):

```
LLVM ERROR: IO failure on output stream: No space left on device
> .../merged_native_libs/.../libflutter.so -> .../stripped_native_libs/...: No space left on device
```

`ubuntu-latest` runners start with only ~14GB free, and the Flutter SDK + Gradle caches + native libs for three ABIs exhaust it right at the final step.

## Fix

1. **Free runner disk space before the build** — remove unused preinstalled toolchains (.NET ~12GB, GHC ~6GB, CodeQL ~5.5GB, boost, chromium, global node_modules) and prune prebaked Docker images (~4GB), recovering ~25–30GB. Deliberately keeps `/usr/local/lib/android` since the build installs Android SDK Platform 33 there. Ends with `df -h /` so every run logs its headroom.
2. **Build a single ABI** (`--target-platform android-arm64`) — a compile smoke only proves the code compiles; the default arm + arm64 + x86_64 build triples the merged/stripped native-lib intermediates that hit the disk limit, and building one ABI is also faster.

## Verification

- YAML validated locally (`ruby -ryaml`).
- The workflow file is in `detect-changes`' `has_app_compile_smoke` trigger paths, so **this PR's own Android Compile Smoke run exercises the fix end-to-end** — check the `df -h` output and a green build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9345?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

