### PR TITLE
fix(app): add context to iOS rage-click telemetry

### DIFF
--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -73,10 +73,12 @@ import 'package:omi/services/services.dart';
 import 'package:omi/services/wals.dart';
 import 'package:omi/utils/debug_log_manager.dart';
 import 'package:omi/utils/debugging/crashlytics_manager.dart';
+import 'package:omi/utils/analytics/rage_click_context_tracker.dart';
 import 'package:omi/utils/l10n_extensions.dart';
 import 'package:omi/utils/environment_detector.dart';
 import 'package:omi/pages/settings/developer.dart';
 import 'package:omi/utils/logger.dart';
+import 'package:omi/utils/platform/platform_service.dart';
 import 'package:omi/utils/platform/platform_manager.dart';
 
 /// Background message handler for FCM data messages
@@ -404,9 +406,10 @@ class _MyAppState extends State<MyApp> with WidgetsBindingObserver {
               ErrorWidget.builder = (errorDetails) {
                 return CustomErrorWidget(errorMessage: errorDetails.exceptionAsString());
               };
+              Widget content;
               if (Env.isUsingStagingApi) {
                 final topPadding = MediaQuery.of(context).padding.top;
-                return Column(
+                content = Column(
                   children: [
                     GestureDetector(
                       onTap: () {
@@ -435,8 +438,12 @@ class _MyAppState extends State<MyApp> with WidgetsBindingObserver {
                     ),
                   ],
                 );
+              } else {
+                content = child!;
               }
-              return child!;
+              return PlatformService.isIOS && Env.posthogApiKey != null
+                  ? RageClickContextTracker(child: content)
+                  : content;
             },
             home: TalkerWrapper(
               talker: Logger.instance.talker,

--- a/app/lib/utils/analytics/adapters/posthog_adapter.dart
+++ b/app/lib/utils/analytics/adapters/posthog_adapter.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:posthog_flutter/posthog_flutter.dart';
 
 import 'package:omi/utils/analytics/analytics_adapter.dart';
@@ -17,6 +19,7 @@ class PostHogAnalyticsAdapter implements AnalyticsAdapter {
   final bool debug;
 
   bool _initialized = false;
+  Timer? _targetExpiry;
 
   @override
   bool get isInitialized => _initialized;
@@ -55,6 +58,24 @@ class PostHogAnalyticsAdapter implements AnalyticsAdapter {
   }
 
   @override
+  void setInteractionContext({String? screenName, required String target}) {
+    if (!_initialized) return;
+
+    // Native iOS rage-click capture runs before Flutter receives the current
+    // pointer. Registering every pointer's context means a qualifying third
+    // tap inherits the matching context recorded by the first two taps.
+    if (screenName != null && screenName.isNotEmpty) {
+      unawaited(Posthog().register(r'$screen_name', screenName));
+      unawaited(Posthog().register('screen', screenName));
+    }
+    unawaited(Posthog().register('target', target));
+    _targetExpiry?.cancel();
+    _targetExpiry = Timer(const Duration(seconds: 2), () {
+      if (_initialized) unawaited(Posthog().unregister('target'));
+    });
+  }
+
+  @override
   void enable() {
     if (!_initialized) return;
     Posthog().enable();
@@ -69,6 +90,8 @@ class PostHogAnalyticsAdapter implements AnalyticsAdapter {
   @override
   void reset() {
     if (!_initialized) return;
+    _targetExpiry?.cancel();
+    _targetExpiry = null;
     Posthog().reset();
   }
 }

--- a/app/lib/utils/analytics/analytics_adapter.dart
+++ b/app/lib/utils/analytics/analytics_adapter.dart
@@ -23,6 +23,12 @@ abstract class AnalyticsAdapter {
   /// Capture a single event with optional properties.
   void track({required String eventName, Map<String, Object>? properties});
 
+  /// Attach the current Flutter interaction context to native SDK events.
+  ///
+  /// Native integrations such as iOS rage-click capture run outside Dart, so
+  /// they cannot otherwise identify the Flutter screen or control involved.
+  void setInteractionContext({String? screenName, required String target}) {}
+
   /// Resume capture after a previous `disable()`.
   void enable();
 

--- a/app/lib/utils/analytics/analytics_manager.dart
+++ b/app/lib/utils/analytics/analytics_manager.dart
@@ -106,6 +106,15 @@ class AnalyticsManager {
     track(eventName, properties: properties);
   }
 
+  void setInteractionContext({String? screenName, required String target}) =>
+      PlatformService.executeIfSupported(PlatformService.isAnalyticsSupported, () {
+        final adapter = _adapter;
+        if (adapter == null || !adapter.isInitialized) return;
+        try {
+          adapter.setInteractionContext(screenName: screenName, target: target);
+        } catch (_) {}
+      });
+
   setPeopleValues() {
     _setUserPropertiesBatch({
       'Notifications Enabled': _preferences.notificationsEnabled,
@@ -409,7 +418,10 @@ class AnalyticsManager {
         },
       );
 
-  void pageOpened(String name) => track('$name Opened');
+  void pageOpened(String name) {
+    setInteractionContext(screenName: name, target: 'screen');
+    track('$name Opened');
+  }
 
   void appEnabled(String appId) {
     track('App Enabled', properties: {'app_id': appId});
@@ -505,7 +517,10 @@ class AnalyticsManager {
 
   void calendarSelected() => track('Calendar Selected');
 
-  void bottomNavigationTabClicked(String tab) => track('Bottom Navigation Tab Clicked', properties: {'tab': tab});
+  void bottomNavigationTabClicked(String tab) {
+    setInteractionContext(screenName: tab, target: 'bottom_navigation');
+    track('Bottom Navigation Tab Clicked', properties: {'tab': tab});
+  }
 
   void deviceConnected() => track('Device Connected', properties: {..._preferences.btDevice.toJson()});
 

--- a/app/lib/utils/analytics/rage_click_context_tracker.dart
+++ b/app/lib/utils/analytics/rage_click_context_tracker.dart
@@ -1,0 +1,172 @@
+import 'package:flutter/rendering.dart';
+import 'package:flutter/widgets.dart';
+
+import 'package:omi/utils/analytics/analytics_manager.dart';
+
+typedef RageClickContextCallback = void Function({String? screenName, required String target});
+
+/// Adds Flutter screen and control context to native iOS rage-click events.
+///
+/// PostHog's iOS detector sees Flutter as one `FlutterView`, so its native
+/// element hierarchy cannot name the Dart widget that was tapped. This widget
+/// resolves each pointer against Flutter's semantics tree and registers the
+/// result as PostHog super properties. A rage click is detected on the third
+/// nearby tap, so the matching context from the earlier taps is already native.
+class RageClickContextTracker extends StatefulWidget {
+  const RageClickContextTracker({super.key, required this.child, this.onContext});
+
+  final Widget child;
+  final RageClickContextCallback? onContext;
+
+  @override
+  State<RageClickContextTracker> createState() => _RageClickContextTrackerState();
+}
+
+class _RageClickContextTrackerState extends State<RageClickContextTracker> {
+  late final SemanticsHandle _semanticsHandle;
+
+  @override
+  void initState() {
+    super.initState();
+    _semanticsHandle = SemanticsBinding.instance.ensureSemantics();
+  }
+
+  @override
+  void dispose() {
+    _semanticsHandle.dispose();
+    super.dispose();
+  }
+
+  void _onPointerDown(PointerDownEvent event) {
+    final context = resolveRageClickContext(event.position, viewId: event.viewId);
+    if (context == null) return;
+
+    final callback = widget.onContext ?? AnalyticsManager().setInteractionContext;
+    callback(screenName: context.screenName, target: context.target);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Listener(behavior: HitTestBehavior.translucent, onPointerDown: _onPointerDown, child: widget.child);
+  }
+}
+
+@immutable
+class RageClickContext {
+  const RageClickContext({required this.screenName, required this.target});
+
+  final String? screenName;
+  final String target;
+}
+
+@visibleForTesting
+RageClickContext? resolveRageClickContext(Offset position, {required int viewId}) {
+  RenderView? matchingView;
+  for (final renderView in RendererBinding.instance.renderViews) {
+    if (renderView.flutterView.viewId == viewId) {
+      matchingView = renderView;
+      break;
+    }
+  }
+
+  final root = matchingView?.owner?.semanticsOwner?.rootSemanticsNode;
+  if (root == null) return null;
+
+  // Pointer events use logical pixels while the root semantics node uses the
+  // physical view coordinate space.
+  final semanticsPosition = position * matchingView!.flutterView.devicePixelRatio;
+  final hitNode = _deepestNodeAt(root, semanticsPosition);
+  if (hitNode == null) return null;
+
+  final routeScope = _nearestRouteScope(hitNode);
+  final screenName = _findRouteName(routeScope ?? root);
+  final target = _findTarget(hitNode, stopAt: routeScope?.parent) ?? 'unlabeled_surface';
+  return RageClickContext(screenName: screenName, target: target);
+}
+
+SemanticsNode? _deepestNodeAt(SemanticsNode node, Offset positionInParent) {
+  var localPosition = positionInParent;
+  final transform = node.transform;
+  if (transform != null) {
+    final inverse = Matrix4.identity();
+    if (inverse.copyInverse(transform) == 0) return null;
+    localPosition = MatrixUtils.transformPoint(inverse, positionInParent);
+  }
+
+  if (!node.rect.contains(localPosition) || node.flagsCollection.isHidden) return null;
+
+  final children = <SemanticsNode>[];
+  node.visitChildren((child) {
+    children.add(child);
+    return true;
+  });
+  for (final child in children.reversed) {
+    final hit = _deepestNodeAt(child, localPosition);
+    if (hit != null) return hit;
+  }
+  return node;
+}
+
+SemanticsNode? _nearestRouteScope(SemanticsNode node) {
+  SemanticsNode? current = node;
+  while (current != null) {
+    if (current.flagsCollection.scopesRoute) return current;
+    current = current.parent;
+  }
+  return null;
+}
+
+String? _findRouteName(SemanticsNode root) {
+  final data = root.getSemanticsData();
+  if (data.flagsCollection.namesRoute) {
+    final name = _normalize(data.label);
+    if (name != null) return name;
+  }
+
+  String? result;
+  root.visitChildren((child) {
+    result ??= _findRouteName(child);
+    return result == null;
+  });
+  return result;
+}
+
+String? _findTarget(SemanticsNode node, {SemanticsNode? stopAt}) {
+  SemanticsNode? current = node;
+  while (current != null && current != stopAt) {
+    final data = current.getSemanticsData();
+    final identifier = _normalize(data.identifier);
+    if (identifier != null) return identifier;
+
+    final label = _normalize(data.label);
+    if (label != null &&
+        (data.hasAction(SemanticsAction.tap) ||
+            data.flagsCollection.isButton ||
+            data.flagsCollection.isLink ||
+            data.flagsCollection.isTextField)) {
+      return label;
+    }
+
+    final tooltip = _normalize(data.tooltip);
+    if (tooltip != null) return tooltip;
+    current = current.parent;
+  }
+
+  current = node;
+  while (current != null && current != stopAt) {
+    final data = current.getSemanticsData();
+    if (data.flagsCollection.isButton) return 'button';
+    if (data.flagsCollection.isLink) return 'link';
+    if (data.flagsCollection.isTextField) return 'text_field';
+    if (data.flagsCollection.isSlider) return 'slider';
+    if (data.hasAction(SemanticsAction.tap)) return 'tap_target';
+    current = current.parent;
+  }
+  return null;
+}
+
+String? _normalize(String value) {
+  final normalized = value.replaceAll(RegExp(r'\s+'), ' ').trim();
+  if (normalized.isEmpty) return null;
+  return normalized.length <= 80 ? normalized : '${normalized.substring(0, 77)}...';
+}

--- a/app/test/unit/analytics_manager_fail_open_test.dart
+++ b/app/test/unit/analytics_manager_fail_open_test.dart
@@ -46,6 +46,16 @@ void main() {
     expect(AnalyticsManager.queuedEventCountForTesting, 0);
   });
 
+  test('page opens register context for native interaction events', () async {
+    final adapter = _FakeAnalyticsAdapter();
+    AnalyticsManager.configure(adapter);
+    await AnalyticsManager.init();
+
+    AnalyticsManager().pageOpened('Settings');
+
+    expect(adapter.interactionContexts, [const _InteractionContext(screenName: 'Settings', target: 'screen')]);
+  });
+
   test('track retries adapter failures without throwing through the caller', () async {
     final adapter = _FakeAnalyticsAdapter(trackFailuresBeforeSuccess: 1);
     AnalyticsManager.configure(adapter);
@@ -91,6 +101,7 @@ class _FakeAnalyticsAdapter implements AnalyticsAdapter {
   final bool hangInit;
   int trackFailuresBeforeSuccess;
   final List<_RecordedEvent> events = [];
+  final List<_InteractionContext> interactionContexts = [];
   bool _initialized = false;
 
   @override
@@ -120,6 +131,11 @@ class _FakeAnalyticsAdapter implements AnalyticsAdapter {
   }
 
   @override
+  void setInteractionContext({String? screenName, required String target}) {
+    interactionContexts.add(_InteractionContext(screenName: screenName, target: target));
+  }
+
+  @override
   void enable() {}
 
   @override
@@ -134,4 +150,18 @@ class _RecordedEvent {
 
   final String eventName;
   final Map<String, Object> properties;
+}
+
+class _InteractionContext {
+  const _InteractionContext({required this.screenName, required this.target});
+
+  final String? screenName;
+  final String target;
+
+  @override
+  bool operator ==(Object other) =>
+      other is _InteractionContext && other.screenName == screenName && other.target == target;
+
+  @override
+  int get hashCode => Object.hash(screenName, target);
 }

--- a/app/test/widgets/rage_click_context_tracker_test.dart
+++ b/app/test/widgets/rage_click_context_tracker_test.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:omi/utils/analytics/rage_click_context_tracker.dart';
+
+void main() {
+  testWidgets('captures the Flutter route and tapped control for native rage clicks', (tester) async {
+    RageClickContext? captured;
+
+    await tester.pumpWidget(
+      RageClickContextTracker(
+        onContext: ({screenName, required target}) {
+          captured = RageClickContext(screenName: screenName, target: target);
+        },
+        child: MaterialApp(
+          home: Scaffold(
+            appBar: AppBar(title: const Text('Settings')),
+            body: Center(
+              child: ElevatedButton(onPressed: () {}, child: const Text('Retry sync')),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Retry sync'));
+
+    expect(captured?.screenName, 'Settings');
+    expect(captured?.target, 'Retry sync');
+  });
+
+  testWidgets('falls back safely when a tapped surface has no semantic label', (tester) async {
+    RageClickContext? captured;
+
+    await tester.pumpWidget(
+      RageClickContextTracker(
+        onContext: ({screenName, required target}) {
+          captured = RageClickContext(screenName: screenName, target: target);
+        },
+        child: MaterialApp(
+          home: Scaffold(
+            body: GestureDetector(onTap: () {}, child: const SizedBox.expand()),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tapAt(const Offset(20, 20));
+
+    expect(captured, isNotNull);
+    expect(captured!.target, anyOf('tap_target', 'unlabeled_surface'));
+  });
+}


### PR DESCRIPTION
## Summary

- resolve iOS rage-click taps through Flutter's semantics tree and register the active screen and control as PostHog context
- seed the same context from existing page-open and bottom-navigation analytics paths
- expire the tapped-control property after two seconds so unrelated analytics events are not permanently enriched

## Root cause

PostHog iOS 3.61+ enables native rage-click capture by default. Its UIKit integration sees the Flutter UI as a single `FlutterView`, while the Flutter bridge disables native screen views, leaving emitted `$rageclick` events without usable screen/control context.

## Validation

- `cd app && bash test.sh` (657 tests passed)
- `cd app && flutter test test/unit/analytics_manager_fail_open_test.dart test/widgets/rage_click_context_tracker_test.dart`
- `cd app && flutter analyze lib/main.dart lib/utils/analytics test/unit/analytics_manager_fail_open_test.dart test/widgets/rage_click_context_tracker_test.dart` (only an existing info-level warning in `main.dart`)
- iOS compile attempted after `pod install`; this machine lacks the Xcode iOS platform/simulator runtime, so Xcode could not select an iOS destination.

Closes #9343

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9347?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

