### PR TITLE
fix(desktop): structured error_kind on chat_agent_error telemetry (#9342)

### DIFF
--- a/desktop/macos/Desktop/Sources/AnalyticsManager.swift
+++ b/desktop/macos/Desktop/Sources/AnalyticsManager.swift
@@ -634,10 +634,13 @@ class AnalyticsManager {
   }
 
   /// Track when the Claude agent bridge fails to start or errors
-  func chatAgentError(error: String, rawError: String? = nil) {
+  func chatAgentError(error: String, rawError: String? = nil, errorKind: String? = nil) {
     var props: [String: Any] = ["error": error]
     if let raw = rawError, raw != error {
       props["raw_error"] = String(raw.prefix(500))
+    }
+    if let errorKind {
+      props["error_kind"] = errorKind
     }
     PostHogManager.shared.track("chat_agent_error", properties: props)
   }

--- a/desktop/macos/Desktop/Sources/Chat/AgentBridge.swift
+++ b/desktop/macos/Desktop/Sources/Chat/AgentBridge.swift
@@ -553,6 +553,35 @@ enum BridgeError: LocalizedError {
     }
   }
 
+  /// Stable, low-cardinality category for `chat_agent_error` telemetry so the
+  /// opaque "bridge failed to start" bucket can be split into missing-install /
+  /// launch-failure / crash / provider-config buckets in PostHog (issue #9342).
+  static func telemetryKind(for error: Error) -> String {
+    if let bridgeError = error as? BridgeError {
+      switch bridgeError {
+      case .nodeNotFound: return "bridge.node_not_found"
+      case .bridgeScriptNotFound: return "bridge.script_not_found"
+      case .notRunning: return "bridge.not_running"
+      case .encodingError: return "bridge.encoding_error"
+      case .timeout: return "bridge.timeout"
+      case .processExited: return "bridge.process_exited"
+      case .outOfMemory: return "bridge.out_of_memory"
+      case .stopped: return "bridge.stopped"
+      case .restarting: return "bridge.restarting"
+      case .requestAlreadyActive: return "bridge.request_already_active"
+      case .agentError: return "bridge.agent_error"
+      case .agentRuntimeFailure: return "bridge.agent_runtime_failure"
+      case .quotaExceeded: return "bridge.quota_exceeded"
+      case .authMissing: return "bridge.auth_missing"
+      }
+    }
+    // Non-BridgeError launch failures (e.g. Process spawn errors) carry an
+    // NSError domain+code — POSIX ENOENT distinguishes a missing executable
+    // (install problem) from other launch failures. Bounded cardinality.
+    let nsError = error as NSError
+    return "\(nsError.domain).\(nsError.code)"
+  }
+
   private static func isSessionAuthenticationFailureMessage(_ message: String) -> Bool {
     let normalized = message.lowercased()
     if normalized.contains("invalid_token") || normalized.contains("please sign in") {

--- a/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
@@ -1384,7 +1384,11 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
                 currentError = card
                 errorMessage = nil
             } else {
-                AnalyticsManager.shared.chatAgentError(error: "AI not available: bridge failed to start", rawError: rawError)
+                AnalyticsManager.shared.chatAgentError(
+                    error: "AI not available: bridge failed to start",
+                    rawError: rawError,
+                    errorKind: BridgeError.telemetryKind(for: error)
+                )
                 errorMessage = "AI not available: \(error.localizedDescription)"
             }
             return false
@@ -4342,7 +4346,11 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
             } else {
                 rawError = "\(error)"
             }
-            AnalyticsManager.shared.chatAgentError(error: error.localizedDescription, rawError: rawError)
+            AnalyticsManager.shared.chatAgentError(
+                error: error.localizedDescription,
+                rawError: rawError,
+                errorKind: BridgeError.telemetryKind(for: error)
+            )
 
             // Track onboarding errors with full context
             if isOnboarding {

--- a/desktop/macos/Desktop/Tests/ChatErrorStateTests.swift
+++ b/desktop/macos/Desktop/Tests/ChatErrorStateTests.swift
@@ -50,6 +50,29 @@ final class ChatErrorStateMappingTests: XCTestCase {
       BridgeError.quotaExceeded(plan: "free", unit: "msg", used: 100, limit: 100, resetAtUnix: nil)
     ))
   }
+
+  /// `chat_agent_error` telemetry categorization (issue #9342): the generic
+  /// "bridge failed to start" bucket must be split into distinct, stable
+  /// `error_kind` values so PostHog can tell missing-install / launch-failure /
+  /// crash / provider-config failures apart. Distinct causes → distinct kinds.
+  func testTelemetryKindDistinguishesFailureModes() {
+    XCTAssertEqual(BridgeError.telemetryKind(for: BridgeError.nodeNotFound), "bridge.node_not_found")
+    XCTAssertEqual(BridgeError.telemetryKind(for: BridgeError.bridgeScriptNotFound), "bridge.script_not_found")
+    XCTAssertEqual(BridgeError.telemetryKind(for: BridgeError.processExited), "bridge.process_exited")
+    XCTAssertEqual(BridgeError.telemetryKind(for: BridgeError.outOfMemory), "bridge.out_of_memory")
+    XCTAssertEqual(BridgeError.telemetryKind(for: BridgeError.agentError("boom")), "bridge.agent_error")
+
+    // Non-BridgeError launch failures (e.g. Process spawn ENOENT = missing
+    // executable) surface the NSError domain+code, not the opaque bucket.
+    let spawnError = NSError(domain: NSPOSIXErrorDomain, code: 2)
+    XCTAssertEqual(BridgeError.telemetryKind(for: spawnError), "\(NSPOSIXErrorDomain).2")
+
+    // A missing binary and a crash must NOT collapse to the same kind.
+    XCTAssertNotEqual(
+      BridgeError.telemetryKind(for: BridgeError.bridgeScriptNotFound),
+      BridgeError.telemetryKind(for: BridgeError.processExited)
+    )
+  }
 }
 
 final class ChatErrorStateTests: XCTestCase {


### PR DESCRIPTION
## Bug
Issue #9342 (p1, reliability): macOS beta chat requests fail with **`AI not available: bridge failed to start`** — the dominant beta chat error (~21.8% of active beta/newer users in the last 24h). Acceptance criterion #3 asks for telemetry structured enough to *distinguish missing install, launch failure, crash, and provider/config errors*.

## Root cause (observability gap)
In `ChatProvider`'s two `chat_agent_error` emit paths, every failure that isn't rendered as a `ChatErrorState` card is flattened into a single opaque `error` string. This bucket mixes:
- non-`BridgeError` launch failures (the actual `Process` spawn errors behind "bridge failed to start"), and
- `BridgeError` cases that `ChatErrorState.from()` maps to `nil`: `.agentError`, `.agentRuntimeFailure`, `.quotaExceeded`, `.encodingError`, `.requestAlreadyActive`, `.stopped`.

So PostHog can't tell a missing install from a launch failure, a crash, or a provider/config error — exactly what the issue needs to triage this p1.

## Fix
- Add `BridgeError.telemetryKind(for:)` — a stable, low-cardinality category for any `Error`. `BridgeError` cases map to `bridge.*` kinds; non-`BridgeError` launch failures surface the `NSError` domain+code (e.g. POSIX `ENOENT` = missing executable / install problem, distinct from a crash).
- Attach it as an `error_kind` property on both `chat_agent_error` emit sites via a new optional `chatAgentError(errorKind:)` param.
- The existing `error` / `raw_error` fields are unchanged, so current dashboards keep working.

No user-facing behavior change — telemetry enrichment only.

## Tests / verification
- New regression test `testTelemetryKindDistinguishesFailureModes` (distinct causes → distinct kinds; missing-binary ≠ crash).
- `xcrun swift build -c debug --package-path Desktop` → **Build complete**.
- `xcrun swift test --filter ChatErrorStateMappingTests` → **3/3 pass**.

🤖 automated by hourly watchdog; opened for review, not merged. This is a diagnostics change — it does not itself resolve the underlying bridge-start failure, so it is intentionally not auto-merged.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9348?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

