### PR TITLE
feat(web): inline transcript segment editing

### DIFF
--- a/web/app/src/components/conversations/ConversationDetailPanel.tsx
+++ b/web/app/src/components/conversations/ConversationDetailPanel.tsx
@@ -17,6 +17,7 @@ import {
   Volume2,
   ChevronDown,
   ChevronUp,
+  RefreshCw,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { formatTime, formatDuration } from '@/lib/utils';
@@ -29,7 +30,13 @@ import { SpeakerTagSheet } from './SpeakerTagSheet';
 import { ManagePeopleModal } from './ManagePeopleModal';
 import { AudioPlayer, AudioPlayerRef } from './AudioPlayer';
 import { usePeople } from '@/hooks/usePeople';
-import { precacheConversationAudio, getConversationAudioUrls } from '@/lib/api';
+import {
+  precacheConversationAudio,
+  getConversationAudioUrls,
+  updateSegmentText,
+  reprocessConversation,
+} from '@/lib/api';
+import { MixpanelManager } from '@/lib/analytics/mixpanel';
 import type {
   Conversation,
   AppResponse,
@@ -58,6 +65,10 @@ interface ConversationDetailPanelProps {
   onConversationUpdate?: (conversation: Conversation) => void;
   onDelete?: () => void;
 }
+
+// Give a reprocess this long before we stop waiting and surface a failure, so a
+// hung request can't leave the UI stuck on "Reprocessing…" indefinitely.
+const REPROCESS_TIMEOUT_MS = 90_000;
 
 type TabId = 'summary' | 'actions' | 'transcript';
 
@@ -403,8 +414,54 @@ export function ConversationDetailPanel({
   const [selectedSegment, setSelectedSegment] = useState<TranscriptSegment | null>(null);
   const [showTagSheet, setShowTagSheet] = useState(false);
   const [showManagePeople, setShowManagePeople] = useState(false);
+  // Whether a transcript segment was edited this session (derived summary/search
+  // is now stale until the conversation is reprocessed — see the nudge banner).
+  const [transcriptEdited, setTranscriptEdited] = useState(false);
+  const [isReprocessing, setIsReprocessing] = useState(false);
+  // Set when a reprocess errors or times out, so the failure is surfaced to the
+  // user (not just console) and they can retry — the summary stays stale.
+  const [reprocessFailed, setReprocessFailed] = useState(false);
+  // Serialized transcript-edit save queue. Segment edits are persisted one at a
+  // time so concurrent PATCHes can't lose-update the backend's read-modify-write
+  // of the whole segments array (each save reads the state left by the previous
+  // one). `saveBatch` drives the "Saving X of N" progress UI.
+  const saveQueueRef = useRef<
+    Array<{ segmentId: string; text: string; prevText: string }>
+  >([]);
+  const processingRef = useRef(false);
+  const [saveBatch, setSaveBatch] = useState<{
+    total: number;
+    done: number;
+    savingId: string | null;
+    failed: number;
+  }>({ total: 0, done: 0, savingId: null, failed: 0 });
   const router = useRouter();
   const { people } = usePeople();
+
+  // Refs holding the *currently displayed* conversation id and object, so async
+  // completions (segment saves, reprocess) can (a) build optimistic updates from
+  // the latest state and (b) bail out if the user switched conversations while a
+  // request was in flight — otherwise a stale response would clobber the new
+  // conversation's UI (displayed id vs. request id divergence).
+  const convIdRef = useRef(conversationId);
+  const conversationRef = useRef(conversation);
+  useEffect(() => {
+    convIdRef.current = conversationId;
+    conversationRef.current = conversation;
+  }, [conversationId, conversation]);
+
+  // Reset all edit/save state when switching to a different conversation so
+  // nothing leaks across (queued saves, progress, "edited" nudge, reprocessing).
+  useEffect(() => {
+    saveQueueRef.current = [];
+    processingRef.current = false;
+    setSaveBatch({ total: 0, done: 0, savingId: null, failed: 0 });
+    setTranscriptEdited(false);
+    setIsReprocessing(false);
+    setReprocessFailed(false);
+  }, [conversationId]);
+
+  const isSavingSegments = saveBatch.total > saveBatch.done;
 
   // Audio state
   const audioPlayerRef = useRef<AudioPlayerRef>(null);
@@ -522,6 +579,128 @@ export function ConversationDetailPanel({
     },
     [conversation, onConversationUpdate],
   );
+
+  // Immutably patch a single segment's text from the *latest* conversation state
+  // (via ref, not a stale closure) so overlapping edits don't drop each other.
+  const applyOptimisticText = useCallback(
+    (segmentId: string, text: string) => {
+      const latest = conversationRef.current;
+      if (!latest || !onConversationUpdate) return;
+      onConversationUpdate({
+        ...latest,
+        transcript_segments: (latest.transcript_segments ?? []).map((seg) =>
+          seg.id === segmentId ? { ...seg, text } : seg,
+        ),
+      });
+    },
+    [onConversationUpdate],
+  );
+
+  // Drain the save queue one PATCH at a time. Serializing is the correctness fix:
+  // the backend rewrites the whole segments array, so concurrent writes lose-update
+  // — running them sequentially means each save reads the previous one's result.
+  const processSaveQueue = useCallback(async () => {
+    if (processingRef.current) return;
+    processingRef.current = true;
+    const convId = convIdRef.current;
+    try {
+      while (saveQueueRef.current.length > 0) {
+        // Abandon the batch if the user navigated to another conversation.
+        if (convIdRef.current !== convId) {
+          saveQueueRef.current = [];
+          break;
+        }
+        const task = saveQueueRef.current.shift()!;
+        setSaveBatch((s) => ({ ...s, savingId: task.segmentId }));
+        try {
+          await updateSegmentText(convId, task.segmentId, task.text);
+          if (convIdRef.current === convId) {
+            setTranscriptEdited(true);
+            MixpanelManager.track('Transcript Segment Edited', {
+              conversation_id: convId,
+              segment_id: task.segmentId,
+            });
+          }
+        } catch (error) {
+          console.error('Failed to save transcript segment edit:', error);
+          // Revert the optimistic change so the UI reflects the persisted truth.
+          if (convIdRef.current === convId)
+            applyOptimisticText(task.segmentId, task.prevText);
+          setSaveBatch((s) => ({ ...s, failed: s.failed + 1 }));
+        } finally {
+          setSaveBatch((s) => ({ ...s, done: s.done + 1, savingId: null }));
+        }
+      }
+    } finally {
+      processingRef.current = false;
+      // Collapse the progress counters once the queue is fully drained (keep the
+      // failure count so the error banner persists until the next edit).
+      if (saveQueueRef.current.length === 0) {
+        setSaveBatch((s) => ({ total: 0, done: 0, savingId: null, failed: s.failed }));
+      }
+    }
+  }, [applyOptimisticText]);
+
+  // Enqueue a segment edit: show it optimistically now, persist it in order.
+  const enqueueSegmentSave = useCallback(
+    (segmentId: string, text: string) => {
+      const latest = conversationRef.current;
+      if (!latest) return;
+      const prevText =
+        (latest.transcript_segments ?? []).find((seg) => seg.id === segmentId)?.text ??
+        '';
+      const trimmed = text.trim();
+      if (!trimmed || trimmed === prevText) return;
+
+      applyOptimisticText(segmentId, trimmed);
+      saveQueueRef.current.push({ segmentId, text: trimmed, prevText });
+      // A new edit while the queue is idle starts a fresh batch (clears old errors).
+      setSaveBatch((s) => {
+        const fresh = s.total === s.done;
+        return {
+          total: (fresh ? 0 : s.total) + 1,
+          done: fresh ? 0 : s.done,
+          savingId: s.savingId,
+          failed: fresh ? 0 : s.failed,
+        };
+      });
+      void processSaveQueue();
+    },
+    [applyOptimisticText, processSaveQueue],
+  );
+
+  // Reprocess the conversation to refresh summary/search after transcript edits.
+  // Reprocessing is heavy; race it against a timeout so a hung request can't leave
+  // the UI stuck on "Reprocessing…", and surface failures to the user (not console).
+  const handleReprocessAfterEdit = useCallback(async () => {
+    const convId = convIdRef.current;
+    setIsReprocessing(true);
+    setReprocessFailed(false);
+    try {
+      const updated = await Promise.race([
+        reprocessConversation(convId),
+        new Promise<never>((_, reject) =>
+          setTimeout(
+            () => reject(new Error('Reprocess timed out')),
+            REPROCESS_TIMEOUT_MS,
+          ),
+        ),
+      ]);
+      // Ignore the response if the user has since switched conversations.
+      if (convIdRef.current === convId) {
+        onConversationUpdate?.(updated);
+        setTranscriptEdited(false);
+        MixpanelManager.track('Conversation Reprocessed After Edit', {
+          conversation_id: convId,
+        });
+      }
+    } catch (error) {
+      console.error('Failed to reprocess conversation after edit:', error);
+      if (convIdRef.current === convId) setReprocessFailed(true);
+    } finally {
+      if (convIdRef.current === convId) setIsReprocessing(false);
+    }
+  }, [onConversationUpdate]);
 
   // Handle title change - update conversation with new title
   const handleTitleChange = useCallback(
@@ -744,6 +923,73 @@ export function ConversationDetailPanel({
                     <span>Loading audio...</span>
                   </div>
                 )}
+                {/* Save-queue progress: edits persist one at a time (serialized) */}
+                {isSavingSegments && (
+                  <div className="flex items-center gap-3 p-3 rounded-xl bg-bg-tertiary border border-bg-quaternary/50 text-sm text-text-secondary">
+                    <div className="w-4 h-4 border-2 border-text-quaternary border-t-transparent rounded-full animate-spin flex-shrink-0" />
+                    <span>
+                      Saving edit {Math.min(saveBatch.done + 1, saveBatch.total)} of{' '}
+                      {saveBatch.total}…
+                    </span>
+                  </div>
+                )}
+                {/* Failed-save banner (edits were reverted to their saved value) */}
+                {!isSavingSegments && saveBatch.failed > 0 && (
+                  <div className="flex items-center gap-2 p-3 rounded-xl bg-error/10 border border-error/20 text-sm text-error">
+                    <span>
+                      Couldn&apos;t save {saveBatch.failed} edit
+                      {saveBatch.failed > 1 ? 's' : ''} — reverted to the saved text.
+                      Please try again.
+                    </span>
+                  </div>
+                )}
+                {/* Reprocess failed/timed out — surface it and let the user retry */}
+                {reprocessFailed && !isReprocessing && !conversation.discarded && (
+                  <div className="flex items-center justify-between gap-3 p-3 rounded-xl bg-error/10 border border-error/20">
+                    <span className="text-sm text-error">
+                      Reprocessing failed — the summary and search may be out of date.
+                    </span>
+                    <button
+                      onClick={handleReprocessAfterEdit}
+                      className={cn(
+                        'flex items-center gap-1.5 flex-shrink-0 px-3 py-1.5 rounded-lg text-sm font-medium',
+                        'bg-white text-bg-primary hover:bg-white/90 transition-colors',
+                      )}
+                    >
+                      <RefreshCw className="w-3.5 h-3.5" />
+                      <span>Retry</span>
+                    </button>
+                  </div>
+                )}
+                {/* Nudge to refresh derived summary/search after edits (once saved) */}
+                {transcriptEdited &&
+                  !conversation.discarded &&
+                  !isSavingSegments &&
+                  saveBatch.failed === 0 &&
+                  !reprocessFailed && (
+                    <div className="flex items-center justify-between gap-3 p-3 rounded-xl bg-bg-tertiary border border-bg-quaternary/50">
+                      <div className="flex items-center gap-2 text-sm text-text-secondary">
+                        <Sparkles className="w-4 h-4 text-text-secondary flex-shrink-0" />
+                        <span>
+                          Transcript edited. Reprocess to update the summary and search.
+                        </span>
+                      </div>
+                      <button
+                        onClick={handleReprocessAfterEdit}
+                        disabled={isReprocessing}
+                        className={cn(
+                          'flex items-center gap-1.5 flex-shrink-0 px-3 py-1.5 rounded-lg text-sm font-medium',
+                          'bg-white text-bg-primary hover:bg-white/90 transition-colors',
+                          'disabled:opacity-60',
+                        )}
+                      >
+                        <RefreshCw
+                          className={cn('w-3.5 h-3.5', isReprocessing && 'animate-spin')}
+                        />
+                        <span>{isReprocessing ? 'Reprocessing…' : 'Reprocess'}</span>
+                      </button>
+                    </div>
+                  )}
                 <TranscriptView
                   segments={transcript_segments}
                   userName={userName}
@@ -751,6 +997,9 @@ export function ConversationDetailPanel({
                   people={people}
                   editable={true}
                   onSpeakerClick={handleSpeakerClick}
+                  onSegmentTextChange={enqueueSegmentSave}
+                  savingSegmentId={saveBatch.savingId}
+                  editingDisabled={isReprocessing}
                   currentTime={currentPlaybackTime}
                   hasAudio={audioAvailable}
                   onSeekTo={handleSeekTo}

--- a/web/app/src/components/conversations/TranscriptView.tsx
+++ b/web/app/src/components/conversations/TranscriptView.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { useMemo, useRef, useEffect } from 'react';
-import { Tag, HelpCircle, Play } from 'lucide-react';
+import { useMemo, useRef, useEffect, useState, useCallback } from 'react';
+import { Tag, HelpCircle, Play, Pencil, Check, Loader2 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import type { TranscriptSegment } from '@/types/conversation';
 import type { Person } from '@/types/user';
@@ -13,6 +13,16 @@ interface TranscriptViewProps {
   people?: Person[];
   editable?: boolean;
   onSpeakerClick?: (segment: TranscriptSegment) => void;
+  /**
+   * Queue an edit to a single segment's text. Fire-and-forget: the parent shows
+   * the change optimistically and persists it (serialized). When omitted, text
+   * editing is disabled and only the speaker remains editable.
+   */
+  onSegmentTextChange?: (segmentId: string, text: string) => void;
+  /** Id of the segment whose save is currently in flight (shows a spinner). */
+  savingSegmentId?: string | null;
+  /** When true, text editing is suppressed (e.g. while reprocessing). */
+  editingDisabled?: boolean;
   /** Current audio playback time in seconds */
   currentTime?: number;
   /** Whether audio is available for this conversation */
@@ -114,6 +124,89 @@ function isActiveGroup(
   return currentTime >= firstSegment.start && currentTime <= lastSegment.end;
 }
 
+/**
+ * Inline editor for a single transcript segment's text.
+ *
+ * The transcript is displayed as merged same-speaker blocks, but the backend
+ * edits one segment at a time (keyed by `segment.id`). So in edit mode each
+ * underlying segment gets its own field — the edit granularity matches the API.
+ * Mirrors the `EditableTitle` interaction: Enter / blur saves, Escape cancels.
+ */
+function SegmentTextEditor({
+  segment,
+  onEnqueueSave,
+  onExitEdit,
+}: {
+  segment: TranscriptSegment;
+  onEnqueueSave: (segmentId: string, text: string) => void;
+  onExitEdit: () => void;
+}) {
+  const [draft, setDraft] = useState(segment.text);
+  // Guard so Enter/Done (which close the editor) don't also commit a second time
+  // via the blur that firing focus-loss triggers as the field unmounts.
+  const committedRef = useRef(false);
+
+  const canEdit = Boolean(segment.id);
+
+  // Queue the edit (if changed) and close. The parent persists it serially and
+  // owns the saving/error UI, so the editor stays intentionally lightweight.
+  const commit = useCallback(() => {
+    if (committedRef.current) return;
+    committedRef.current = true;
+    const trimmed = draft.trim();
+    if (segment.id && trimmed && trimmed !== segment.text) {
+      onEnqueueSave(segment.id, trimmed);
+    }
+    onExitEdit();
+  }, [draft, segment.id, segment.text, onEnqueueSave, onExitEdit]);
+
+  const cancel = useCallback(() => {
+    committedRef.current = true; // stop the blur handler from committing
+    onExitEdit();
+  }, [onExitEdit]);
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    // Enter commits & closes; Shift+Enter inserts a newline; Escape cancels.
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      commit();
+    } else if (e.key === 'Escape') {
+      e.preventDefault();
+      cancel();
+    }
+  };
+
+  if (!canEdit) {
+    // Segments without an id cannot be targeted by the edit API.
+    return (
+      <p
+        className="text-text-primary leading-relaxed opacity-60"
+        title="This segment can't be edited"
+      >
+        {segment.text}
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-1">
+      <textarea
+        value={draft}
+        onChange={(e) => setDraft(e.target.value)}
+        onKeyDown={handleKeyDown}
+        onBlur={commit}
+        rows={Math.min(6, Math.max(2, Math.ceil(draft.length / 60)))}
+        className={cn(
+          'w-full resize-y rounded-lg px-3 py-2 text-sm leading-relaxed',
+          'bg-bg-secondary border border-bg-quaternary text-text-primary',
+          'outline-none focus:ring-2 focus:ring-white/20',
+        )}
+      />
+      <div className="text-xs text-text-quaternary">Enter to save · Esc to cancel</div>
+    </div>
+  );
+}
+
 export function TranscriptView({
   segments,
   userName,
@@ -121,12 +214,27 @@ export function TranscriptView({
   people,
   editable = false,
   onSpeakerClick,
+  onSegmentTextChange,
+  savingSegmentId,
+  editingDisabled = false,
   currentTime,
   hasAudio = false,
   onSeekTo,
 }: TranscriptViewProps) {
   const groupedSegments = useMemo(() => groupSegmentsBySpeaker(segments), [segments]);
   const activeGroupRef = useRef<HTMLDivElement>(null);
+  const [editingGroupIndex, setEditingGroupIndex] = useState<number | null>(null);
+
+  const textEditable =
+    editable &&
+    Boolean(conversationId) &&
+    Boolean(onSegmentTextChange) &&
+    !editingDisabled;
+
+  // Close any open editor if text editing gets disabled (e.g. reprocess starts).
+  useEffect(() => {
+    if (editingDisabled) setEditingGroupIndex(null);
+  }, [editingDisabled]);
 
   // Auto-scroll to keep active segment in view during playback
   useEffect(() => {
@@ -171,13 +279,16 @@ export function TranscriptView({
           ? 0
           : ((firstSegment.speaker_id ?? 0) % (SPEAKER_COLORS.length - 1)) + 1;
         const isActive = groupIndex === activeGroupIndex;
+        const isEditingGroup = editingGroupIndex === groupIndex;
+        const isSavingGroup =
+          savingSegmentId != null && group.some((s) => s.id === savingSegmentId);
 
         return (
           <div
             key={groupIndex}
             ref={isActive ? activeGroupRef : undefined}
             className={cn(
-              'rounded-xl p-4 transition-all duration-200',
+              'group/segment rounded-xl p-4 transition-all duration-200',
               isUser
                 ? 'bg-purple-primary/10 border border-purple-primary/20'
                 : 'bg-bg-tertiary',
@@ -228,33 +339,85 @@ export function TranscriptView({
                 )}
               </div>
 
-              {/* Timestamp - clickable when audio is available */}
-              {hasAudio && onSeekTo ? (
-                <button
-                  onClick={() => onSeekTo(firstSegment.start)}
-                  className={cn(
-                    'flex items-center gap-1.5 text-xs',
-                    'text-text-quaternary hover:text-purple-primary transition-colors',
-                    'group',
-                  )}
-                  title="Click to play from here"
-                >
-                  <Play className="w-3 h-3 opacity-0 group-hover:opacity-100 transition-opacity" />
-                  <span>
+              <div className="flex items-center gap-2">
+                {/* Timestamp - clickable when audio is available */}
+                {hasAudio && onSeekTo ? (
+                  <button
+                    onClick={() => onSeekTo(firstSegment.start)}
+                    className={cn(
+                      'flex items-center gap-1.5 text-xs',
+                      'text-text-quaternary hover:text-purple-primary transition-colors',
+                      'group',
+                    )}
+                    title="Click to play from here"
+                  >
+                    <Play className="w-3 h-3 opacity-0 group-hover:opacity-100 transition-opacity" />
+                    <span>
+                      {formatTimestamp(firstSegment.start)} -{' '}
+                      {formatTimestamp(lastSegment.end)}
+                    </span>
+                  </button>
+                ) : (
+                  <span className="text-xs text-text-quaternary">
                     {formatTimestamp(firstSegment.start)} -{' '}
                     {formatTimestamp(lastSegment.end)}
                   </span>
-                </button>
-              ) : (
-                <span className="text-xs text-text-quaternary">
-                  {formatTimestamp(firstSegment.start)} -{' '}
-                  {formatTimestamp(lastSegment.end)}
-                </span>
-              )}
+                )}
+
+                {/* Per-segment saving indicator (this block's edit is in flight) */}
+                {isSavingGroup && (
+                  <span className="flex items-center gap-1 text-xs text-text-quaternary">
+                    <Loader2 className="w-3.5 h-3.5 animate-spin" />
+                    <span>Saving…</span>
+                  </span>
+                )}
+
+                {/* Edit transcript text toggle */}
+                {textEditable &&
+                  (isEditingGroup ? (
+                    <button
+                      onClick={() => setEditingGroupIndex(null)}
+                      className={cn(
+                        'flex items-center gap-1 text-xs font-medium',
+                        'text-text-secondary hover:text-text-primary transition-colors',
+                      )}
+                      title="Done editing"
+                    >
+                      <Check className="w-3.5 h-3.5" />
+                      <span>Done</span>
+                    </button>
+                  ) : (
+                    <button
+                      onClick={() => setEditingGroupIndex(groupIndex)}
+                      className={cn(
+                        'p-1 rounded-md text-text-quaternary',
+                        'opacity-0 group-hover/segment:opacity-100 focus:opacity-100',
+                        'hover:text-text-primary hover:bg-bg-quaternary/50 transition-all',
+                      )}
+                      title="Edit transcript text"
+                      aria-label="Edit transcript text"
+                    >
+                      <Pencil className="w-3.5 h-3.5" />
+                    </button>
+                  ))}
+              </div>
             </div>
 
             {/* Transcript text */}
-            <p className="text-text-primary leading-relaxed">{combinedText}</p>
+            {isEditingGroup && onSegmentTextChange ? (
+              <div className="space-y-2">
+                {group.map((segment, i) => (
+                  <SegmentTextEditor
+                    key={segment.id ?? `${groupIndex}-${i}`}
+                    segment={segment}
+                    onEnqueueSave={onSegmentTextChange}
+                    onExitEdit={() => setEditingGroupIndex(null)}
+                  />
+                ))}
+              </div>
+            ) : (
+              <p className="text-text-primary leading-relaxed">{combinedText}</p>
+            )}
           </div>
         );
       })}

--- a/web/app/src/lib/api.ts
+++ b/web/app/src/lib/api.ts
@@ -1557,6 +1557,49 @@ export async function assignBulkTranscriptSegments(
 }
 
 /**
+ * Error thrown when editing a transcript segment requires a paid plan
+ * (backend returns HTTP 402 for `/segments/text` on gated accounts).
+ */
+export class SegmentEditPlanRequiredError extends Error {
+  constructor(message = 'Editing the transcript requires the Unlimited plan.') {
+    super(message);
+    this.name = 'SegmentEditPlanRequiredError';
+  }
+}
+
+/**
+ * Update the text of a single transcript segment.
+ *
+ * Mirrors the backend `PATCH /v1/conversations/{id}/segments/text`
+ * (`UpdateSegmentTextRequest`), which identifies the segment by its `id` and
+ * rewrites just that segment's text. The response is a bare `{status}`, so
+ * callers must optimistically patch their local `transcript_segments`.
+ *
+ * @param conversationId - The conversation ID
+ * @param segmentId - The `id` of the segment to edit (non-empty)
+ * @param text - New segment text (1–10000 chars, enforced by the backend)
+ * @throws SegmentEditPlanRequiredError when the account is plan-gated (402)
+ */
+export async function updateSegmentText(
+  conversationId: string,
+  segmentId: string,
+  text: string,
+): Promise<void> {
+  try {
+    await fetchWithAuth(`/v1/conversations/${conversationId}/segments/text`, {
+      method: 'PATCH',
+      body: JSON.stringify({ segment_id: segmentId, text }),
+    });
+  } catch (error) {
+    // fetchWithAuth surfaces the status in the thrown message (`API error: 402 ...`).
+    if (error instanceof Error && error.message.includes('402')) {
+      throw new SegmentEditPlanRequiredError();
+    }
+    throw error;
+  }
+}
+
+/**
  * Delete account permanently
  */
 export async function deleteAccount(): Promise<void> {


### PR DESCRIPTION
## What changed and why

Adds inline transcript editing to the web app (app.omi.me) so users can correct mistranscribed names/entities. Each transcript block gets a pencil affordance that opens per-segment inline text editors, saving via the existing `PATCH /v1/conversations/{id}/segments/text`. After an edit, a nudge offers to reprocess the conversation so the summary/search reflect the change.

**Part of #4095.** That issue is coupled (edit transcript **and** conversation title). The conversation-title half already appears implemented (`EditableTitle`), so this PR completes the **transcript-segment-editing** half, for the **web** surface. Mobile/desktop remain out of scope here. Related: #4044.

Discussed with the team in Discord: https://discord.com/channels/1192313062041067520/1231903583717425153/1522531112709263441

Interaction:
- Hover a transcript block → pencil → per-segment editable fields.
- **Enter** saves & closes, **Esc** cancels & closes, **Done** exits.
- Merged same-speaker blocks split into per-segment fields so each edit maps 1:1 to the one-segment-at-a-time API.

## Concurrency hardening (from PR review)

A reviewer flagged three real races. Addressed as follows (single-client fully covered; the cross-client/backend root causes are tracked in **#9392**):

1. **Concurrent segment saves overwriting each other** — saves now run through a **serialized queue** (one PATCH in flight at a time), so the backend's read-modify-write of the whole segments array can't lose-update between a client's own saves. Shown as a "Saving X of N" banner + per-segment spinner; a failed save reverts to the persisted text. *Cross-tab/cross-client still needs the backend transaction — see #9392.*
2. **Edit erased during Reprocess** — editing and reprocess are now **mutually exclusive** (pencils disabled while reprocessing; Reprocess disabled while a save is pending). *Reprocess's stale-snapshot write root cause is in #9392.*
3. **Switching conversations mid-request corrupting UI** — **fully fixed**: every async completion is guarded by the conversation id captured at request time, and optimistic updates read the latest state via refs, so a stale response can't overwrite the newly displayed conversation.

## Product invariants affected

None binding. `INV-CHAT-1`'s path globs are desktop-only; this writes to the single backend-owned transcript, honoring its single-source-of-truth spirit. `INV-UI-1`: no new purple — verified with `.github/scripts/check_brand_ui.py` (neutral/white tokens only).

## How it was verified

- `tsc --noEmit`: clean. Prettier: clean.
- `INV-UI-1` ratchet (`check_brand_ui.py --base upstream/main`): no purple increase.
- **Exercised the real user path against the production backend**: opened conversations, edited segments — `PATCH .../segments/text` returned `200`, edits persisted across reload. Verified serialized "Saving X of N", per-segment spinner, edit↔reprocess mutual exclusion, and the conversation-switch guard in the running app.

## Tests

`web/app` currently has no test runner (it relied on `next lint`, removed in Next 16), so there is no hermetic suite to extend. Verified via typecheck + driving the real UI as above. Happy to add a runner (e.g. Vitest) in a follow-up if maintainers want one.

## Follow-up

Backend concurrency root causes (non-transactional segment write + reprocess stale-snapshot overwrite) are tracked in **#9392** — the durable, cross-client fix. Happy to take that PR too if wanted.
