### PR TITLE
Use pill UI for draggable floating bar

### DIFF
--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
@@ -163,6 +163,7 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
     private var pttHintCancellable: AnyCancellable?
     private var agentPillsCancellable: AnyCancellable?
     private var voiceResponseGlowCancellable: AnyCancellable?
+    private var draggableBarCancellable: AnyCancellable?
     private var previousVoiceResponseGlowActive = false
     private var resizeWorkItem: DispatchWorkItem?
     /// Saved center point from before chat opened, used to restore position on close.
@@ -189,7 +190,11 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
         state.isVoiceListening || state.isThinking || state.isVoiceResponseGlowActive
     }
     private var notchModeEnabled: Bool {
-        Self.screenHasCameraHousing(screenForPlacement) || barWantsActiveIsland
+        Self.shouldUseNotchIsland(
+            displayHasCameraHousing: Self.screenHasCameraHousing(screenForPlacement),
+            hasActiveIsland: barWantsActiveIsland,
+            draggableBarEnabled: ShortcutSettings.shared.draggableBarEnabled
+        )
     }
     /// Hardware-only notch detection (ignores the transient active-island state) —
     /// "does this display physically have a camera housing".
@@ -312,11 +317,17 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
         contentRect: NSRect, styleMask style: NSWindow.StyleMask,
         backing backingStoreType: NSWindow.BackingStoreType = .buffered, defer flag: Bool = false
     ) {
-        let initialSize = FloatingControlBarWindow.screenHasCameraHousing(NSScreen.main ?? NSScreen.screens.first)
+        let initialScreen = NSScreen.main ?? NSScreen.screens.first
+        let initialUsesNotchIsland = FloatingControlBarWindow.shouldUseNotchIsland(
+            displayHasCameraHousing: FloatingControlBarWindow.screenHasCameraHousing(initialScreen),
+            hasActiveIsland: false,
+            draggableBarEnabled: ShortcutSettings.shared.draggableBarEnabled
+        )
+        let initialSize = initialUsesNotchIsland
             ? NSSize(
-                width: FloatingControlBarWindow.notchHiddenCenterWidth(for: NSScreen.main ?? NSScreen.screens.first)
+                width: FloatingControlBarWindow.notchHiddenCenterWidth(for: initialScreen)
                     + FloatingControlBarWindow.notchCompactSideWidth * 2,
-                height: FloatingControlBarWindow.notchChromeHeight(for: NSScreen.main ?? NSScreen.screens.first)
+                height: FloatingControlBarWindow.notchChromeHeight(for: initialScreen)
             )
             : FloatingControlBarWindow.minBarSize
         let initialRect = NSRect(origin: .zero, size: initialSize)
@@ -332,9 +343,7 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
         self.isOpaque = false
         self.backgroundColor = .clear
         self.hasShadow = false
-        self.level = FloatingControlBarWindow.screenHasCameraHousing(NSScreen.main ?? NSScreen.screens.first)
-            ? .statusBar
-            : .floating
+        self.level = initialUsesNotchIsland ? .statusBar : .floating
         self.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
         self.isMovableByWindowBackground = false
         self.acceptsMouseMovedEvents = true
@@ -403,6 +412,16 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
         return false
     }
 
+    /// A physical notch is fixed to the display, so the movable-bar preference
+    /// always opts into the pill presentation instead.
+    static func shouldUseNotchIsland(
+        displayHasCameraHousing: Bool,
+        hasActiveIsland: Bool,
+        draggableBarEnabled: Bool
+    ) -> Bool {
+        !draggableBarEnabled && (displayHasCameraHousing || hasActiveIsland)
+    }
+
     static func notchChromeHeight(for screen: NSScreen?) -> CGFloat {
         guard let screen else { return notchChromeHeight }
         if #available(macOS 12.0, *) {
@@ -465,6 +484,21 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
             state.notchRevealProgress = 1
         }
         level = usesNotch ? .statusBar : .floating
+    }
+
+    private func refreshPresentationForDraggableBarPreference() {
+        let wasUsingNotchIsland = state.usesNotchIsland
+        updateNotchIslandState()
+        guard wasUsingNotchIsland != state.usesNotchIsland,
+              let screen = screenForPlacement
+        else { return }
+
+        let targetFrame = frameForCurrentState(on: screen, usesNotchIsland: state.usesNotchIsland)
+        resizeToFrame(
+            targetFrame,
+            makeResizable: state.showingAIConversation && state.showingAIResponse,
+            animated: isVisible
+        )
     }
 
     override var canBecomeKey: Bool { true }
@@ -584,6 +618,14 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
                 self?.performSpacesTransitionGrowIn()
             }
         }
+
+        draggableBarCancellable = ShortcutSettings.shared.$draggableBarEnabled
+            .dropFirst()
+            .sink { [weak self] _ in
+                Task { @MainActor in
+                    self?.refreshPresentationForDraggableBarPreference()
+                }
+            }
 
         // Follow cursor across monitors — poll mouse position to move bar instantly
         startCursorScreenTracking()
@@ -1950,7 +1992,7 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
             self.center()
             return
         }
-        if Self.screenHasCameraHousing(screen) {
+        if notchModeEnabled {
             let targetFrame = frameForCurrentState(on: screen, usesNotchIsland: true)
             self.setFrame(targetFrame, display: true, animate: false)
             log("FloatingControlBarWindow: centered notch island at \(targetFrame.origin) on screen \(screen.frame)")

--- a/desktop/macos/Desktop/Tests/FloatingBarGeometryTests.swift
+++ b/desktop/macos/Desktop/Tests/FloatingBarGeometryTests.swift
@@ -20,6 +20,30 @@ final class FloatingBarGeometryTests: XCTestCase {
         XCTAssertEqual(frame.size, compactSize)
     }
 
+    func testDraggableBarForcesPillPresentationOnNotchedDisplays() {
+        XCTAssertFalse(
+            FloatingControlBarWindow.shouldUseNotchIsland(
+                displayHasCameraHousing: true,
+                hasActiveIsland: false,
+                draggableBarEnabled: true
+            )
+        )
+        XCTAssertFalse(
+            FloatingControlBarWindow.shouldUseNotchIsland(
+                displayHasCameraHousing: true,
+                hasActiveIsland: true,
+                draggableBarEnabled: true
+            )
+        )
+        XCTAssertTrue(
+            FloatingControlBarWindow.shouldUseNotchIsland(
+                displayHasCameraHousing: true,
+                hasActiveIsland: false,
+                draggableBarEnabled: false
+            )
+        )
+    }
+
     func testTopCenterExpansionKeepsTopEdgeAndHorizontalCenterFixed() {
         let compactFrame = NSRect(x: 586, y: 876, width: 268, height: 58)
         let expandedFrame = FloatingControlBarGeometry.topCenterAnchoredFrame(

--- a/desktop/macos/changelog/unreleased/20260709-draggable-floating-bar-pill.json
+++ b/desktop/macos/changelog/unreleased/20260709-draggable-floating-bar-pill.json
@@ -1,0 +1,3 @@
+{
+  "change": "Made the draggable floating bar use the movable pill layout on notched Macs"
+}


### PR DESCRIPTION
## Summary

- Make the draggable floating-bar preference select the movable pill presentation, including on Macs with a camera notch.
- Refresh the live floating-bar presentation when the preference changes, and initialize the window with the correct shape and window level.
- Add regression coverage for notched and active-island states, plus a desktop changelog fragment.

## Root cause

Notch presentation was derived only from display hardware and active voice state. The draggable preference was not part of that decision, leaving notched displays fixed in place.

## Product invariants affected

- `INV-CHAT-1` — this changes only the visual presentation selected for the existing floating control bar; it does not alter session identity, transcript storage, or continuity between chat surfaces.

## Validation

- `cd desktop/macos && xcrun swift test --package-path Desktop --filter FloatingBarGeometryTests` (16 passed)
- Named `omi-draggable-pill` development bundle built and launched against a local Auth-emulator user.
- Repository pre-push checks passed, including the clean desktop Swift build.

`xcrun swift test --package-path Desktop` was also attempted, but the full suite currently fails outside this change in `APIClientRoutingTests.testDeleteConversationRoutesToPython`, then aborts when a later test initializes Firebase Auth without configuring Firebase.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9362?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
