### PR TITLE
fix(desktop/chat): surface "Response took too long" when the 180s stall watchdog fires

### DIFF
--- a/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
@@ -906,6 +906,14 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
     private var sendGeneration: Int = 0
     private var activeBridgeSendGeneration: Int?
 
+    /// Set to a send's generation when the 180s watchdog fires for it, *before*
+    /// the watchdog interrupts the bridge. `interrupt()` resumes the in-flight
+    /// request with `BridgeError.stopped`, which the send-loop catch would
+    /// otherwise treat as a silent user stop — so the catch checks this marker to
+    /// surface "Response took too long" instead of vanishing the turn. See the
+    /// watchdog in sendMessage() and the `.stopped` catch branch.
+    private var sendWatchdogFiredGeneration: Int?
+
     /// Set to true during onboarding so the ACP session ID is persisted for restart recovery.
     var isOnboarding = false
     @Published var sessionsLoadError: String?
@@ -3647,10 +3655,22 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
             let stillStuck = await MainActor.run { () -> Bool in
                 guard self.isSending, self.sendGeneration == sendGen else { return false }
                 log("ChatProvider: send watchdog fired at 180s — bridge is stuck; force-resetting")
+                // Mark this generation before interrupting: interrupt() resumes the
+                // in-flight request with `.stopped`, and the catch below uses this
+                // marker to surface the timeout instead of silently dropping the turn.
+                self.sendWatchdogFiredGeneration = sendGen
                 return true
             }
             guard stillStuck else { return }
             await self.resolvedAgentClient().interrupt()
+            // Fallback for the "stray turn_end" case where interrupt() does not
+            // route through the catch (no active request to resume): if the lock is
+            // somehow still held, force-release it and surface the timeout here.
+            // Deliberately does NOT clear sendWatchdogFiredGeneration — only the
+            // catch clears it, so if this fallback wins the race with the catch, the
+            // catch still sees the marker and surfaces the timeout instead of
+            // re-silencing the turn. A stale marker is harmless: generations only
+            // increase, so it never matches a later send.
             await MainActor.run {
                 guard self.isSending, self.sendGeneration == sendGen else { return }
                 _ = self.releaseSendLock(sendGeneration: sendGen)
@@ -4406,10 +4426,21 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
             // Both surfaces coexist — only one is active at a time per
             // turn.
             if let bridgeError = error as? BridgeError, case .stopped = bridgeError {
-                stoppedByUser = true
+                // `.stopped` normally means the user pressed Stop (silent). But if the
+                // 180s watchdog fired for THIS send, the `.stopped` came from the
+                // watchdog's own interrupt() — the turn timed out, so surface it
+                // instead of letting the turn vanish (the watchdog's own error-set
+                // races this catch and bails once `isSending` is released here).
+                let watchdogFired = (sendWatchdogFiredGeneration == sendGen)
+                sendWatchdogFiredGeneration = nil
                 currentError = nil
-                lastFailedPrompt = nil
-                errorMessage = nil
+                if let timeoutMessage = ChatProvider.stoppedTurnErrorMessage(watchdogFired: watchdogFired) {
+                    errorMessage = timeoutMessage
+                } else {
+                    stoppedByUser = true
+                    lastFailedPrompt = nil
+                    errorMessage = nil
+                }
             } else if let bridgeError = error as? BridgeError,
                       let card = ChatErrorState.from(bridgeError) {
                 currentError = card
@@ -4863,6 +4894,15 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
             return .completed
         }
         return .failed
+    }
+
+    /// The banner text to show when a turn ends with `BridgeError.stopped`.
+    /// A user-initiated Stop is silent (`nil`). But when the 180s send watchdog
+    /// fired for the turn, the `.stopped` came from the watchdog's own interrupt —
+    /// the turn timed out, so surface "Response took too long" rather than letting
+    /// it vanish. Extracted so the watchdog-vs-user-stop distinction is unit-tested.
+    nonisolated static func stoppedTurnErrorMessage(watchdogFired: Bool) -> String? {
+        watchdogFired ? "Response took too long. Try again." : nil
     }
 
     /// Map a `StallDetector.State` to the matching `ToolCallStatus`.

--- a/desktop/macos/Desktop/Tests/ChatStallWatchdogTests.swift
+++ b/desktop/macos/Desktop/Tests/ChatStallWatchdogTests.swift
@@ -1,0 +1,77 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// CHAT-02: a stalled agent must surface "Response took too long" within the 180s
+/// send watchdog, not vanish silently.
+///
+/// The bug: the watchdog's own `interrupt()` resumes the in-flight request with
+/// `BridgeError.stopped`, which the send-loop catch treated as a *user stop*
+/// (silent) — releasing `isSending` before the watchdog could set its error. The
+/// fix marks the watchdog-fired generation so the catch surfaces the timeout for
+/// it while a genuine user Stop stays silent.
+///
+/// The full 180s race is a runtime path (Codex owns that proof). These lock in the
+/// load-bearing decision and its wiring hermetically.
+final class ChatStallWatchdogTests: XCTestCase {
+
+  // MARK: - Behavioral: the watchdog-vs-user-stop decision
+
+  func testWatchdogStoppedSurfacesTimeoutMessage() {
+    XCTAssertEqual(
+      ChatProvider.stoppedTurnErrorMessage(watchdogFired: true),
+      "Response took too long. Try again.")
+  }
+
+  func testUserStopStaysSilent() {
+    XCTAssertNil(ChatProvider.stoppedTurnErrorMessage(watchdogFired: false))
+  }
+
+  // MARK: - Source-invariant: the marker is set before interrupt() and consumed by the catch
+
+  func testWatchdogMarksGenerationBeforeInterrupting() throws {
+    let source = try chatProviderSource()
+    guard let watchdog = slice(
+      source, from: "send watchdog fired at 180s", to: "// Fallback for the")
+    else {
+      throw XCTSkip("send watchdog block not found")
+    }
+    guard let markIdx = watchdog.range(of: "self.sendWatchdogFiredGeneration = sendGen"),
+      let interruptIdx = watchdog.range(of: ".interrupt()")
+    else {
+      return XCTFail("watchdog must mark sendWatchdogFiredGeneration and call interrupt()")
+    }
+    XCTAssertTrue(
+      markIdx.lowerBound < interruptIdx.lowerBound,
+      "the watchdog must mark the generation BEFORE interrupt() resumes the request with .stopped")
+  }
+
+  func testStoppedCatchConsultsTheWatchdogMarker() throws {
+    let source = try chatProviderSource()
+    // The `.stopped` catch must gate on the marker and route through the shared
+    // helper — so a future refactor can't silently re-treat a timeout as a user stop.
+    XCTAssertTrue(
+      source.contains("let watchdogFired = (sendWatchdogFiredGeneration == sendGen)"),
+      "the .stopped catch must check the watchdog marker")
+    XCTAssertTrue(
+      source.contains("ChatProvider.stoppedTurnErrorMessage(watchdogFired: watchdogFired)"),
+      "the .stopped catch must derive its message from the shared helper")
+  }
+
+  // MARK: - Helpers
+
+  private func chatProviderSource() throws -> String {
+    let url = URL(fileURLWithPath: #filePath)
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+      .appendingPathComponent("Sources/Providers/ChatProvider.swift")
+    return try String(contentsOf: url, encoding: .utf8)
+  }
+
+  private func slice(_ source: String, from: String, to: String) -> String? {
+    guard let start = source.range(of: from),
+      let end = source[start.upperBound...].range(of: to)
+    else { return nil }
+    return String(source[start.lowerBound..<end.lowerBound])
+  }
+}

--- a/desktop/macos/Desktop/Tests/ChatStallWatchdogTests.swift
+++ b/desktop/macos/Desktop/Tests/ChatStallWatchdogTests.swift
@@ -30,31 +30,38 @@ final class ChatStallWatchdogTests: XCTestCase {
   // MARK: - Source-invariant: the marker is set before interrupt() and consumed by the catch
 
   func testWatchdogMarksGenerationBeforeInterrupting() throws {
+    // Anchored on the fix's own code tokens (not comment prose) and fails loudly
+    // (never skips) if they drift. Whitespace-tolerant regex so auto-format churn
+    // can't break the invariant.
     let source = try chatProviderSource()
-    guard let watchdog = slice(
-      source, from: "send watchdog fired at 180s", to: "// Fallback for the")
+    guard let mark = source.range(
+      of: #"sendWatchdogFiredGeneration\s*=\s*sendGen"#, options: .regularExpression)
     else {
-      throw XCTSkip("send watchdog block not found")
+      return XCTFail("watchdog must mark the generation (sendWatchdogFiredGeneration = sendGen)")
     }
-    guard let markIdx = watchdog.range(of: "self.sendWatchdogFiredGeneration = sendGen"),
-      let interruptIdx = watchdog.range(of: ".interrupt()")
+    // The interrupt that must come AFTER the mark is the watchdog's own call.
+    // Searching from just past the mark proves the mark precedes it.
+    guard source[mark.upperBound...].range(
+      of: #"resolvedAgentClient\(\)\s*\.\s*interrupt\(\)"#, options: .regularExpression) != nil
     else {
-      return XCTFail("watchdog must mark sendWatchdogFiredGeneration and call interrupt()")
+      return XCTFail("watchdog must call interrupt() AFTER marking the generation")
     }
-    XCTAssertTrue(
-      markIdx.lowerBound < interruptIdx.lowerBound,
-      "the watchdog must mark the generation BEFORE interrupt() resumes the request with .stopped")
   }
 
   func testStoppedCatchConsultsTheWatchdogMarker() throws {
     let source = try chatProviderSource()
     // The `.stopped` catch must gate on the marker and route through the shared
-    // helper — so a future refactor can't silently re-treat a timeout as a user stop.
-    XCTAssertTrue(
-      source.contains("let watchdogFired = (sendWatchdogFiredGeneration == sendGen)"),
+    // helper — so a future refactor can't silently re-treat a timeout as a user
+    // stop. Whitespace-tolerant regex so formatting changes don't false-fail.
+    XCTAssertNotNil(
+      source.range(
+        of: #"watchdogFired\s*=\s*\(\s*sendWatchdogFiredGeneration\s*==\s*sendGen\s*\)"#,
+        options: .regularExpression),
       "the .stopped catch must check the watchdog marker")
-    XCTAssertTrue(
-      source.contains("ChatProvider.stoppedTurnErrorMessage(watchdogFired: watchdogFired)"),
+    XCTAssertNotNil(
+      source.range(
+        of: #"stoppedTurnErrorMessage\(\s*watchdogFired:\s*watchdogFired\s*\)"#,
+        options: .regularExpression),
       "the .stopped catch must derive its message from the shared helper")
   }
 
@@ -66,12 +73,5 @@ final class ChatStallWatchdogTests: XCTestCase {
       .deletingLastPathComponent()
       .appendingPathComponent("Sources/Providers/ChatProvider.swift")
     return try String(contentsOf: url, encoding: .utf8)
-  }
-
-  private func slice(_ source: String, from: String, to: String) -> String? {
-    guard let start = source.range(of: from),
-      let end = source[start.upperBound...].range(of: to)
-    else { return nil }
-    return String(source[start.lowerBound..<end.lowerBound])
   }
 }

--- a/desktop/macos/changelog/unreleased/20260709-chat-stall-timeout-error.json
+++ b/desktop/macos/changelog/unreleased/20260709-chat-stall-timeout-error.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed a stalled AI chat response silently ending with no message — it now shows \"Response took too long. Try again.\" so you know to retry"
+}


### PR DESCRIPTION
## The bug
When an AI chat turn stalls, a 180s "send watchdog" is supposed to force-release `isSending` and show **"Response took too long. Try again."** Instead the turn was ending **silently** with no error.

Root cause: the watchdog calls `resolvedAgentClient().interrupt()` *before* setting its error. `AgentRuntimeProcess.interrupt()` resumes the in-flight ACP request with `BridgeError.stopped` **immediately, Swift-side** (it does not wait for the agent). So the send-loop's `catch` runs first — its `.stopped` branch treated it as a **user Stop** (silent, `errorMessage=nil`) and released `isSending`. The watchdog's own error-set then bailed on `guard self.isSending` (already false). Net: the stalled turn vanished with `has_error=false`.

This affects **any** genuine 180s stall, not just a test hook — a real user whose agent hangs would see the response silently disappear with no way to know to retry.

## The fix
- Mark the watchdog-fired generation (`sendWatchdogFiredGeneration = sendGen`) **before** `interrupt()`.
- The `.stopped` catch surfaces **"Response took too long. Try again."** for that generation via a new `nonisolated static stoppedTurnErrorMessage(watchdogFired:)`; a genuine user Stop (which sets `isStopping` and bumps the generation, and never sets the marker) stays silent.
- Only the catch clears the marker, so if the watchdog's own fallback wins the MainActor race it can't re-silence the turn. A stale marker is harmless (generations are monotonic).

## Invariants
Touches `desktop/macos/Desktop/Sources/Providers/ChatProvider.swift`, covered by **INV-CHAT-1** (one shared transcript across surfaces) and **INV-AUTH-1** (desktop Firebase session truth). Both are upheld: the change adds no transcript store and no per-surface history — it only sets the shared provider's existing `errorMessage`/`currentError` UI state when the 180s watchdog fires — and it does not touch session identity or the send-time auth path (only the `.stopped`-vs-timeout classification in the send catch).

## Tests / verification
- **`ChatStallWatchdogTests` (4)** — the helper's user-stop-vs-timeout contract, plus source-invariants that the watchdog marks the generation *before* `interrupt()` and the catch consults the marker.
- **Runtime** on a named bundle: an induced 185s stall (`suspend_agent_stream`) now leaves **both** chat surfaces `has_error=true` + "Response took too long. Try again." + `is_sending=false`; `resume_agent_stream` + a new ask recovers cleanly. (Before the fix: `has_error=false`, silent.)
- Independent code-review: correct, no blocking issues — both MainActor race orderings end in the timeout state; no user-stop regression.

Changelog fragment included (user-visible error behavior change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)