### PR TITLE
fix(desktop): make Conversations repository authoritative

### DIFF
--- a/app/lib/backend/schema/gen/conversation_wire.g.dart
+++ b/app/lib/backend/schema/gen/conversation_wire.g.dart
@@ -442,6 +442,7 @@ class GeneratedConversation {
   final bool privateCloudSyncEnabled;
   final String? processingConversationId;
   final String? processingMemoryId;
+  final String? revision;
   final String? source;
   final bool starred;
   final DateTime? startedAt;
@@ -450,6 +451,7 @@ class GeneratedConversation {
   final List<String> suggestedSummarizationApps;
   final List<GeneratedTranscriptSegment> transcriptSegments;
   final bool? transcriptSegmentsCompressed;
+  final DateTime? updatedAt;
   final String visibility;
 
   const GeneratedConversation({
@@ -476,6 +478,7 @@ class GeneratedConversation {
     this.privateCloudSyncEnabled = false,
     this.processingConversationId,
     this.processingMemoryId,
+    this.revision,
     this.source = "omi",
     this.starred = false,
     required this.startedAt,
@@ -484,6 +487,7 @@ class GeneratedConversation {
     this.suggestedSummarizationApps = const [],
     this.transcriptSegments = const [],
     this.transcriptSegmentsCompressed = false,
+    this.updatedAt,
     this.visibility = "private",
   });
 
@@ -512,6 +516,7 @@ class GeneratedConversation {
       privateCloudSyncEnabled: _required(_readFieldValue<bool>(_readField(json, const ["private_cloud_sync_enabled"]), "private_cloud_sync_enabled", _readBool, requiredField: false, nullable: false, defaultValue: false), "private_cloud_sync_enabled"),
       processingConversationId: _readFieldValue<String>(_readField(json, const ["processing_conversation_id"]), "processing_conversation_id", _readString, requiredField: false, nullable: true),
       processingMemoryId: _readFieldValue<String>(_readField(json, const ["processing_memory_id"]), "processing_memory_id", _readString, requiredField: false, nullable: true),
+      revision: _readFieldValue<String>(_readField(json, const ["revision"]), "revision", _readString, requiredField: false, nullable: true),
       source: _readFieldValue<String>(_readField(json, const ["source"]), "source", _readString, requiredField: false, nullable: true, defaultValue: "omi"),
       starred: _required(_readFieldValue<bool>(_readField(json, const ["starred"]), "starred", _readBool, requiredField: false, nullable: false, defaultValue: false), "starred"),
       startedAt: _readFieldValue<DateTime>(_readField(json, const ["started_at"]), "started_at", _readDateTime, requiredField: true, nullable: true),
@@ -520,6 +525,7 @@ class GeneratedConversation {
       suggestedSummarizationApps: _required(_readFieldValue<List<String>>(_readField(json, const ["suggested_summarization_apps"]), "suggested_summarization_apps", _readStringList, requiredField: false, nullable: false, defaultValue: const []), "suggested_summarization_apps"),
       transcriptSegments: _required(_readFieldValue<List<GeneratedTranscriptSegment>>(_readField(json, const ["transcript_segments"]), "transcript_segments", (value) => _readObjectList(value, GeneratedTranscriptSegment.fromJson), requiredField: false, nullable: false, defaultValue: const []), "transcript_segments"),
       transcriptSegmentsCompressed: _readFieldValue<bool>(_readField(json, const ["transcript_segments_compressed"]), "transcript_segments_compressed", _readBool, requiredField: false, nullable: true, defaultValue: false),
+      updatedAt: _readFieldValue<DateTime>(_readField(json, const ["updated_at"]), "updated_at", _readDateTime, requiredField: false, nullable: true),
       visibility: _required(_readFieldValue<String>(_readField(json, const ["visibility"]), "visibility", _readString, requiredField: false, nullable: false, defaultValue: "private"), "visibility"),
     );
   }
@@ -549,6 +555,7 @@ class GeneratedConversation {
       'private_cloud_sync_enabled': privateCloudSyncEnabled,
       'processing_conversation_id': processingConversationId,
       'processing_memory_id': processingMemoryId,
+      'revision': revision,
       'source': source,
       'starred': starred,
       'started_at': startedAt?.toUtc().toIso8601String(),
@@ -557,6 +564,7 @@ class GeneratedConversation {
       'suggested_summarization_apps': suggestedSummarizationApps,
       'transcript_segments': transcriptSegments.map((value) => value.toJson()).toList(),
       'transcript_segments_compressed': transcriptSegmentsCompressed,
+      'updated_at': updatedAt?.toUtc().toIso8601String(),
       'visibility': visibility,
     };
   }

--- a/backend/database/conversation_projection.py
+++ b/backend/database/conversation_projection.py
@@ -1,0 +1,46 @@
+from typing import Any, Dict, Optional
+
+CONVERSATION_LIST_FIELDS = (
+    'id',
+    'created_at',
+    'started_at',
+    'finished_at',
+    'structured',
+    'source',
+    'language',
+    'status',
+    'discarded',
+    'deleted',
+    'is_locked',
+    'starred',
+    'folder_id',
+    'client_device_id',
+    'deferred',
+    'visibility',
+    'data_protection_level',
+)
+
+
+def apply_conversation_list_field_mask(query):
+    """Restrict a Firestore query to the desktop list projection."""
+    return query.select(CONVERSATION_LIST_FIELDS)
+
+
+def conversation_snapshot_data(snapshot) -> Optional[Dict[str, Any]]:
+    """Project a Firestore snapshot with server-owned freshness metadata.
+
+    Firestore ``update_time`` is an opaque server version. Keeping this small
+    projection pure makes the authority contract easy to test without importing
+    database clients or constructing infrastructure at test collection time.
+    """
+    if snapshot is None or not getattr(snapshot, 'exists', False):
+        return None
+    data = snapshot.to_dict()
+    if data is None:
+        return None
+    data.setdefault('id', snapshot.id)
+    update_time = getattr(snapshot, 'update_time', None)
+    if update_time is not None:
+        data['updated_at'] = update_time
+        data['revision'] = update_time.isoformat()
+    return data

--- a/backend/database/conversation_projection.py
+++ b/backend/database/conversation_projection.py
@@ -1,5 +1,7 @@
 from typing import Any, Dict, Optional
 
+from models.conversation_version import server_version_data
+
 CONVERSATION_LIST_FIELDS = (
     'id',
     'created_at',
@@ -41,6 +43,7 @@ def conversation_snapshot_data(snapshot) -> Optional[Dict[str, Any]]:
     data.setdefault('id', snapshot.id)
     update_time = getattr(snapshot, 'update_time', None)
     if update_time is not None:
-        data['updated_at'] = update_time
-        data['revision'] = update_time.isoformat()
+        updated_at, revision = server_version_data(update_time)
+        data['updated_at'] = updated_at
+        data['revision'] = revision
     return data

--- a/backend/database/conversations.py
+++ b/backend/database/conversations.py
@@ -11,6 +11,10 @@ from google.cloud.firestore_v1 import FieldFilter
 
 import utils.other.hume as hume
 from database import users as users_db
+from database.conversation_projection import (
+    apply_conversation_list_field_mask,
+    conversation_snapshot_data,
+)
 from models.audio_file import AudioFile
 from models.conversation_enums import ConversationStatus, PostProcessingModel, PostProcessingStatus
 from models.conversation_photo import ConversationPhoto
@@ -195,8 +199,19 @@ def create_conversation_if_absent(uid: str, conversation_data: dict) -> bool:
 def get_conversation(uid, conversation_id):
     user_ref = db.collection('users').document(uid)
     conversation_ref = user_ref.collection(conversations_collection).document(conversation_id)
-    conversation_data = conversation_ref.get().to_dict()
-    return conversation_data
+    return conversation_snapshot_data(conversation_ref.get())
+
+
+def get_conversation_access_state(uid: str, conversation_id: str) -> Optional[Dict[str, Any]]:
+    """Read only the fields needed to authorize a mutation."""
+    conversation_ref = (
+        db.collection('users').document(uid).collection(conversations_collection).document(conversation_id)
+    )
+    snapshot = conversation_ref.get(field_paths=['is_locked'])
+    if not snapshot.exists:
+        return None
+    data = snapshot.to_dict() or {}
+    return {'id': conversation_id, 'is_locked': bool(data.get('is_locked', False))}
 
 
 @prepare_for_read(decrypt_func=_prepare_conversation_for_read)
@@ -242,7 +257,8 @@ def get_conversations(
     # Limits
     conversations_ref = conversations_ref.limit(limit).offset(offset)
 
-    conversations = [doc.to_dict() for doc in conversations_ref.stream()]
+    conversations = [conversation_snapshot_data(doc) for doc in conversations_ref.stream()]
+    conversations = [conversation for conversation in conversations if conversation is not None]
     return conversations
 
 
@@ -290,6 +306,7 @@ def get_conversations_without_photos(
     categories: Optional[List[str]] = None,
     folder_id: Optional[str] = None,
     starred: Optional[bool] = None,
+    list_projection: bool = False,
 ):
     """
     Same as get_conversations but without loading photos.
@@ -322,7 +339,11 @@ def get_conversations_without_photos(
     # Limits
     conversations_ref = conversations_ref.limit(limit).offset(offset)
 
-    conversations = [doc.to_dict() for doc in conversations_ref.stream()]
+    if list_projection:
+        conversations_ref = apply_conversation_list_field_mask(conversations_ref)
+
+    conversations = [conversation_snapshot_data(doc) for doc in conversations_ref.stream()]
+    conversations = [conversation for conversation in conversations if conversation is not None]
     return conversations
 
 
@@ -454,11 +475,7 @@ def update_conversation_title(uid: str, conversation_id: str, title: str):
     user_ref = db.collection('users').document(uid)
     conversation_ref = user_ref.collection(conversations_collection).document(conversation_id)
 
-    doc_snapshot = conversation_ref.get()
-    if not doc_snapshot.exists:
-        return
-
-    conversation_ref.update({'structured.title': title})
+    return conversation_ref.update({'structured.title': title})
 
 
 def update_conversation_summary(uid: str, conversation_id: str, app_id: Optional[str], content: str) -> str:
@@ -616,10 +633,12 @@ def _get_conversations_by_id(uid, conversation_ids, include_discarded: bool = Fa
     conversations_by_id = {}
     for doc in docs:
         if doc.exists:
-            data = doc.to_dict()
-            if data.get('discarded') and not include_discarded:
+            data = conversation_snapshot_data(doc)
+            if data is None:
                 continue
             data.setdefault('id', doc.id)
+            if data.get('discarded') and not include_discarded:
+                continue
             conversations_by_id[str(data['id'])] = data
 
     return [
@@ -987,7 +1006,7 @@ def set_conversation_visibility(uid: str, conversation_id: str, visibility: str)
 def set_conversation_starred(uid: str, conversation_id: str, starred: bool):
     user_ref = db.collection('users').document(uid)
     conversation_ref = user_ref.collection(conversations_collection).document(conversation_id)
-    conversation_ref.update({'starred': starred})
+    return conversation_ref.update({'starred': starred})
 
 
 def unlock_all_conversations(uid: str):

--- a/backend/database/folders.py
+++ b/backend/database/folders.py
@@ -283,20 +283,20 @@ def move_conversation_to_folder(
     uid: str,
     conversation_id: str,
     folder_id: Optional[str],
-) -> bool:
+) -> Any:
     """Move a conversation to a different folder."""
     user_ref = db.collection('users').document(uid)
     conv_ref = user_ref.collection('conversations').document(conversation_id)
 
     # Get the old folder_id to update counts
-    conv_doc = conv_ref.get()
+    conv_doc = conv_ref.get(field_paths=['folder_id'])
     if not getattr(conv_doc, "exists", False):
         return False
 
     old_folder_id = _typed_doc(conv_doc).get('folder_id')
 
     # Update the conversation's folder_id
-    conv_ref.update({'folder_id': folder_id})
+    write_result = conv_ref.update({'folder_id': folder_id})
 
     # Update folder counts
     if old_folder_id:
@@ -304,7 +304,7 @@ def move_conversation_to_folder(
     if folder_id:
         update_folder_conversation_count(uid, folder_id)
 
-    return True
+    return write_result
 
 
 def bulk_move_conversations_to_folder(

--- a/backend/models/conversation.py
+++ b/backend/models/conversation.py
@@ -15,6 +15,7 @@ from models.conversation_enums import (
     PostProcessingStatus,
 )
 from models.conversation_photo import ConversationPhoto
+from models.conversation_version import server_version_data
 from models.geolocation import Geolocation
 from models.other import Person
 from models.structured import Structured
@@ -51,10 +52,11 @@ __all__ = [
 def conversation_mutation_data(conversation_id: str, write_result) -> dict:
     """Project the opaque server version from a Firestore write result."""
     update_time = getattr(write_result, 'update_time', None)
+    updated_at, revision = server_version_data(update_time)
     return {
         'id': conversation_id,
-        'updated_at': update_time,
-        'revision': update_time.isoformat() if update_time is not None else None,
+        'updated_at': updated_at,
+        'revision': revision,
     }
 
 

--- a/backend/models/conversation.py
+++ b/backend/models/conversation.py
@@ -28,6 +28,7 @@ __all__ = [
     'CalendarEventLink',
     'Conversation',
     'ConversationPostProcessing',
+    'conversation_mutation_data',
     'CreateConversation',
     'CreateConversationResponse',
     'CreateMemoryResponse',
@@ -45,6 +46,16 @@ __all__ = [
     'UpdateSegmentTextRequest',
     'UpdateSummaryRequest',
 ]
+
+
+def conversation_mutation_data(conversation_id: str, write_result) -> dict:
+    """Project the opaque server version from a Firestore write result."""
+    update_time = getattr(write_result, 'update_time', None)
+    return {
+        'id': conversation_id,
+        'updated_at': update_time,
+        'revision': update_time.isoformat() if update_time is not None else None,
+    }
 
 
 class UpdateConversation(BaseModel):
@@ -86,6 +97,13 @@ class Conversation(BaseModel):
     created_at: datetime
     started_at: Optional[datetime]
     finished_at: Optional[datetime]
+    # Server-owned freshness metadata. ``revision`` is opaque to clients and is
+    # currently derived from Firestore's document update_time, so it advances
+    # whenever any cached conversation field changes. ``updated_at`` is exposed
+    # for freshness ordering. Clients treat revision as an identity token and
+    # compare updated_at only against another server-owned updated_at value.
+    updated_at: Optional[datetime] = None
+    revision: Optional[str] = None
 
     source: Optional[ConversationSource] = ConversationSource.omi
     language: Optional[str] = None  # applies only to Friend # TODO: once released migrate db to default 'en'

--- a/backend/models/conversation_version.py
+++ b/backend/models/conversation_version.py
@@ -1,0 +1,39 @@
+from datetime import datetime, timedelta, timezone
+from typing import Any, Optional
+
+
+def normalize_server_update_time(value: Any) -> Optional[datetime]:
+    """Normalize Firestore and protobuf timestamps to an aware datetime."""
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value if value.tzinfo is not None else value.replace(tzinfo=timezone.utc)
+
+    to_datetime = getattr(value, 'ToDatetime', None)
+    if callable(to_datetime):
+        try:
+            normalized = to_datetime(tzinfo=timezone.utc)
+        except TypeError:
+            normalized = to_datetime()
+        if not isinstance(normalized, datetime):
+            raise TypeError(f'Unsupported server update_time conversion result: {type(normalized)!r}')
+        return normalized if normalized.tzinfo is not None else normalized.replace(tzinfo=timezone.utc)
+
+    seconds = getattr(value, 'seconds', None)
+    nanos = getattr(value, 'nanos', None)
+    if seconds is not None and nanos is not None:
+        whole_seconds = int(seconds)
+        if isinstance(nanos, str):
+            # fake-firestore stores the fractional digits from a float rather than
+            # protobuf's integer nanosecond count.
+            microseconds = int((nanos + '000000')[:6])
+        else:
+            microseconds = int(nanos) // 1_000
+        return datetime.fromtimestamp(whole_seconds, tz=timezone.utc) + timedelta(microseconds=microseconds)
+
+    raise TypeError(f'Unsupported server update_time type: {type(value)!r}')
+
+
+def server_version_data(update_time: Any) -> tuple[Optional[datetime], Optional[str]]:
+    normalized = normalize_server_update_time(update_time)
+    return normalized, normalized.isoformat() if normalized is not None else None

--- a/backend/route_policy_manifest.yaml
+++ b/backend/route_policy_manifest.yaml
@@ -7,6 +7,29 @@ schema_version: 1
 service: backend-main
 routes:
   - route_type: http
+    method: GET
+    path: /v1/conversations/list
+    policy:
+      review_status: reviewed
+      auth:
+        mechanisms:
+          - firebase_id_token
+        placement: dependency
+        scopes: []
+      byok: not_applicable
+      rate_limit:
+        policy_name: none
+        key_subject: none
+        enforcement: none
+        placement: none
+      timeout_class: default_method
+      surface: first_party_app
+      visibility: first_party
+      data_domain: conversations
+      deprecation:
+        state: active
+      owner: backend
+  - route_type: http
     method: POST
     path: /v1/users/account-deletion-wipes/run
     policy:

--- a/backend/routers/conversations.py
+++ b/backend/routers/conversations.py
@@ -17,6 +17,7 @@ from models.conversation import (
     BulkAssignSegmentsRequest,
     CalendarEventLink,
     Conversation,
+    conversation_mutation_data,
     CreateConversationResponse,
     DeleteActionItemRequest,
     MergeConversationsRequest,
@@ -80,6 +81,14 @@ def _get_valid_conversation_by_id(uid: str, conversation_id: str) -> dict:
     return conversation
 
 
+def _ensure_mutable_conversation(uid: str, conversation_id: str) -> None:
+    conversation = conversations_db.get_conversation_access_state(uid, conversation_id)
+    if conversation is None:
+        raise HTTPException(status_code=404, detail="Conversation not found")
+    if conversation.get('is_locked', False):
+        raise HTTPException(status_code=402, detail="A paid plan is required to access this conversation.")
+
+
 def _enrich_deferred_conversation(uid: str, conversation: dict) -> dict:
     """First open of a lazily-deferred desktop conversation. The LLM enrichment (summary, action
     items, memories, embeddings, app results) takes ~10s, so we run it in the BACKGROUND and return
@@ -128,6 +137,12 @@ class SearchConversationsResponse(BaseModel):
 
 class ConversationStatusResponse(BaseModel):
     status: str
+
+
+class ConversationMutationResponse(ConversationStatusResponse):
+    id: str
+    updated_at: Optional[datetime] = None
+    revision: Optional[str] = None
 
 
 class ConversationsCountResponse(BaseModel):
@@ -318,6 +333,44 @@ def get_conversations(
     return conversations
 
 
+@router.get(
+    '/v1/conversations/list',
+    response_model=List[Conversation],
+    response_model_exclude={'__all__': {'transcript_segments'}},
+    tags=['conversations'],
+    description="Explicit lightweight list projection. Detail-only transcript_segments are omitted.",
+)
+def get_conversation_list_projection(
+    limit: PositiveLimit = 100,
+    offset: NonNegativeOffset = 0,
+    statuses: Optional[str] = "processing,completed",
+    include_discarded: bool = True,
+    start_date: Optional[datetime] = Query(None),
+    end_date: Optional[datetime] = Query(None),
+    folder_id: Optional[str] = Query(None),
+    starred: Optional[bool] = Query(None),
+    uid: str = Depends(auth.get_current_user_uid),
+):
+    if start_date is not None and end_date is not None and _ensure_aware(start_date) > _ensure_aware(end_date):
+        raise HTTPException(status_code=400, detail="start_date must be earlier than or equal to end_date")
+    if not statuses:
+        statuses = "processing,completed"
+    conversations = conversations_db.get_conversations_without_photos(
+        uid,
+        limit,
+        offset,
+        include_discarded=include_discarded,
+        statuses=statuses.split(","),
+        start_date=start_date,
+        end_date=end_date,
+        folder_id=folder_id,
+        starred=starred,
+        list_projection=True,
+    )
+    redact_conversations_for_list(conversations)
+    return conversations
+
+
 @router.get('/v1/conversations/count', tags=['conversations'], response_model=ConversationsCountResponse)
 def get_conversations_count(
     statuses: Optional[str] = Query(None, description="Comma-separated status filter (e.g. processing,completed)"),
@@ -373,12 +426,14 @@ def get_conversation_by_id(conversation_id: str, uid: str = Depends(auth.get_cur
 
 
 @router.patch(
-    "/v1/conversations/{conversation_id}/title", tags=['conversations'], response_model=ConversationStatusResponse
+    "/v1/conversations/{conversation_id}/title", tags=['conversations'], response_model=ConversationMutationResponse
 )
 def patch_conversation_title(conversation_id: str, title: str, uid: str = Depends(auth.get_current_user_uid)):
-    _get_valid_conversation_by_id(uid, conversation_id)
-    conversations_db.update_conversation_title(uid, conversation_id, title)
-    return {'status': 'Ok'}
+    _ensure_mutable_conversation(uid, conversation_id)
+    write_result = conversations_db.update_conversation_title(uid, conversation_id, title)
+    if write_result is None:
+        raise HTTPException(status_code=404, detail="Conversation not found")
+    return {'status': 'Ok', **conversation_mutation_data(conversation_id, write_result)}
 
 
 @router.delete(
@@ -1011,13 +1066,13 @@ def set_conversation_visibility(
 
 
 @router.patch(
-    '/v1/conversations/{conversation_id}/starred', tags=['conversations'], response_model=ConversationStatusResponse
+    '/v1/conversations/{conversation_id}/starred', tags=['conversations'], response_model=ConversationMutationResponse
 )
 def set_conversation_starred(conversation_id: str, starred: bool, uid: str = Depends(auth.get_current_user_uid)):
     logger.info(f'update_conversation_starred {conversation_id} {starred} {uid}')
-    _get_valid_conversation_by_id(uid, conversation_id)
-    conversations_db.set_conversation_starred(uid, conversation_id, starred)
-    return {"status": "Ok"}
+    _ensure_mutable_conversation(uid, conversation_id)
+    write_result = conversations_db.set_conversation_starred(uid, conversation_id, starred)
+    return {"status": "Ok", **conversation_mutation_data(conversation_id, write_result)}
 
 
 @router.get(

--- a/backend/routers/folders.py
+++ b/backend/routers/folders.py
@@ -1,8 +1,9 @@
 import logging
+from datetime import datetime
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from typing import List, Optional
-from pydantic import ValidationError
+from pydantic import BaseModel, ValidationError
 
 import database.folders as folders_db
 import database.conversations as conversations_db
@@ -16,13 +17,20 @@ from models.folder import (
     FolderMutationResponse,
     BulkMoveConversationsResponse,
 )
-from models.conversation import Conversation
+from models.conversation import Conversation, conversation_mutation_data
 from utils.conversations.render import redact_conversations_for_list
 from utils.other import endpoints as auth
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
+
+
+class ConversationFolderMutationResponse(BaseModel):
+    status: str
+    id: str
+    updated_at: Optional[datetime] = None
+    revision: Optional[str] = None
 
 
 @router.get('/v1/folders', response_model=List[Folder], tags=['folders'])
@@ -144,12 +152,16 @@ def get_folder_conversations(
     return valid_conversations
 
 
-@router.patch('/v1/conversations/{conversation_id}/folder', response_model=FolderMutationResponse, tags=['folders'])
+@router.patch(
+    '/v1/conversations/{conversation_id}/folder',
+    response_model=ConversationFolderMutationResponse,
+    tags=['folders'],
+)
 def move_conversation_to_folder(
     conversation_id: str, request: MoveConversationRequest, uid: str = Depends(auth.get_current_user_uid)
 ):
     """Move a conversation to a different folder."""
-    conversation = conversations_db.get_conversation(uid, conversation_id)
+    conversation = conversations_db.get_conversation_access_state(uid, conversation_id)
     if not conversation:
         raise HTTPException(status_code=404, detail="Conversation not found")
     if conversation.get('is_locked', False):
@@ -160,8 +172,10 @@ def move_conversation_to_folder(
         if not folder:
             raise HTTPException(status_code=404, detail="Folder not found")
 
-    folders_db.move_conversation_to_folder(uid, conversation_id, request.folder_id)
-    return {"status": "ok"}
+    write_result = folders_db.move_conversation_to_folder(uid, conversation_id, request.folder_id)
+    if write_result is False or write_result is None:
+        raise HTTPException(status_code=404, detail="Conversation not found")
+    return {"status": "ok", **conversation_mutation_data(conversation_id, write_result)}
 
 
 @router.post(

--- a/backend/scripts/export_openapi.py
+++ b/backend/scripts/export_openapi.py
@@ -109,6 +109,10 @@ UNDOCUMENTED_PUBLIC_ROUTES: dict[tuple[str, str], str] = {
     ): 'Firebase-authenticated first-party app route; public docs expose Developer API key conversation listing.',
     (
         'GET',
+        '/v1/conversations/list',
+    ): 'Firebase-authenticated lightweight first-party app projection; not part of the Developer API key contract.',
+    (
+        'GET',
         '/v1/conversations/count',
     ): 'Firebase-authenticated first-party app route; not part of the Developer API key contract.',
     (

--- a/backend/testing/e2e/conftest.py
+++ b/backend/testing/e2e/conftest.py
@@ -275,6 +275,12 @@ def _create_backend_app(fake_firestore_instance, fake_redis_instance, fake_stora
     old_r = redis_db.r
     db_client.db = fake_firestore_instance
     redis_db.r = fake_redis_instance
+    # Redis Script objects retain the client used at registration time. Rebind
+    # them explicitly so a module imported before the boundary patch cannot
+    # leak rate-limit calls to a developer's local Redis instance.
+    for script_name in ('_RATE_LIMIT_LUA', '_TTS_RATE_LIMIT_LUA'):
+        script = getattr(redis_db, script_name)
+        setattr(redis_db, script_name, fake_redis_instance.register_script(script.script))
     for module in list(sys.modules.values()):
         if module is None:
             continue

--- a/backend/testing/e2e/fakes/firestore.py
+++ b/backend/testing/e2e/fakes/firestore.py
@@ -13,10 +13,12 @@ from typing import Optional
 
 from fake_firestore import MockFirestore
 from fake_firestore.document import FakeDocumentReference, NotFound, apply_transformations, get_by_path
+from fake_firestore._helpers import Timestamp
 
 # Module-level singleton — set by conftest.py before backend imports.
 _mock_store: Optional[MockFirestore] = None
 _original_document_set = None
+_original_document_update = None
 
 
 def _patch_document_merge_preserves_subcollections():
@@ -26,11 +28,20 @@ def _patch_document_merge_preserves_subcollections():
     collections inside the parent dict and can overwrite them on merge sets
     when the parent document was not explicitly written yet.
     """
-    global _original_document_set
+    global _original_document_set, _original_document_update
     if _original_document_set is not None:
         return
 
     _original_document_set = FakeDocumentReference.set
+    _original_document_update = FakeDocumentReference.update
+
+    def _update(self, data: dict, timeout: Optional[float] = None):
+        _original_document_update(self, data, timeout=timeout)
+        # Match google-cloud-firestore's update contract so mutation routes can
+        # return the authoritative server revision they use in production.
+        return type('FakeWriteResult', (), {'update_time': Timestamp.from_now()})()
+
+    FakeDocumentReference.update = _update
 
     def _set(self, data: dict, merge: bool = False, timeout: Optional[float] = None) -> None:
         if not merge:

--- a/backend/testing/e2e/test_harness_guards.py
+++ b/backend/testing/e2e/test_harness_guards.py
@@ -55,11 +55,11 @@ def test_network_guard_blocks_sendto_three_arg_form():
 
 
 def test_backend_storage_client_is_fake_after_app_import(client):
-    """The backend storage module should hold the fake GCS client, not google's real client."""
+    """The backend's lazy storage getter should construct the fake GCS client."""
     from fakes.storage import FakeStorageClient
     import utils.other.storage as storage_helpers
 
-    assert isinstance(storage_helpers.storage_client, FakeStorageClient)
+    assert isinstance(storage_helpers._get_storage_client(), FakeStorageClient)
 
 
 def test_backend_database_globals_are_fake_after_app_import(client, fake_firestore, fake_redis):
@@ -72,5 +72,7 @@ def test_backend_database_globals_are_fake_after_app_import(client, fake_firesto
 
     assert db_client.db is fake_firestore
     assert redis_db.r is fake_redis
+    assert redis_db._RATE_LIMIT_LUA.registered_client is fake_redis
+    assert redis_db._TTS_RATE_LIMIT_LUA.registered_client is fake_redis
     assert webhook_health.r is fake_redis
     assert fair_use.redis_client is fake_redis

--- a/backend/tests/unit/test_conversation_revision_contract.py
+++ b/backend/tests/unit/test_conversation_revision_contract.py
@@ -1,5 +1,7 @@
 from datetime import datetime, timezone
 
+from google.protobuf.timestamp_pb2 import Timestamp
+
 from database.conversation_projection import (
     CONVERSATION_LIST_FIELDS,
     apply_conversation_list_field_mask,
@@ -30,6 +32,30 @@ def test_firestore_update_time_is_exposed_as_opaque_conversation_revision():
     assert data['updated_at'] == _Snapshot.update_time
     assert data['revision'] == '2026-07-09T12:30:00+00:00'
     assert Conversation.model_validate(data).revision == data['revision']
+
+
+def test_protobuf_update_time_is_normalized_with_subsecond_precision():
+    update_time = Timestamp()
+    expected = datetime(2026, 7, 9, 21, 52, 19, 342802, tzinfo=timezone.utc)
+    update_time.FromDatetime(expected)
+    snapshot = _Snapshot()
+    snapshot.update_time = update_time
+
+    data = conversation_snapshot_data(snapshot)
+
+    assert data['updated_at'] == expected
+    assert data['revision'] == '2026-07-09T21:52:19.342802+00:00'
+
+
+def test_firestore_fake_timestamp_shape_is_normalized_with_subsecond_precision():
+    update_time = type('FakeTimestamp', (), {'seconds': '1783633939', 'nanos': '342802'})()
+    snapshot = _Snapshot()
+    snapshot.update_time = update_time
+
+    data = conversation_snapshot_data(snapshot)
+
+    assert data['updated_at'] == datetime(2026, 7, 9, 21, 52, 19, 342802, tzinfo=timezone.utc)
+    assert data['revision'] == '2026-07-09T21:52:19.342802+00:00'
 
 
 def test_missing_snapshot_has_no_conversation_projection():

--- a/backend/tests/unit/test_conversation_revision_contract.py
+++ b/backend/tests/unit/test_conversation_revision_contract.py
@@ -1,0 +1,71 @@
+from datetime import datetime, timezone
+
+from database.conversation_projection import (
+    CONVERSATION_LIST_FIELDS,
+    apply_conversation_list_field_mask,
+    conversation_snapshot_data,
+)
+from models.conversation import Conversation, conversation_mutation_data
+
+
+class _Snapshot:
+    exists = True
+    id = 'conversation-1'
+    update_time = datetime(2026, 7, 9, 12, 30, tzinfo=timezone.utc)
+
+    def to_dict(self):
+        return {
+            'id': self.id,
+            'created_at': datetime(2026, 7, 9, 12, 0, tzinfo=timezone.utc),
+            'started_at': datetime(2026, 7, 9, 12, 0, tzinfo=timezone.utc),
+            'finished_at': datetime(2026, 7, 9, 12, 5, tzinfo=timezone.utc),
+            'structured': {},
+            'transcript_segments': [],
+        }
+
+
+def test_firestore_update_time_is_exposed_as_opaque_conversation_revision():
+    data = conversation_snapshot_data(_Snapshot())
+
+    assert data['updated_at'] == _Snapshot.update_time
+    assert data['revision'] == '2026-07-09T12:30:00+00:00'
+    assert Conversation.model_validate(data).revision == data['revision']
+
+
+def test_missing_snapshot_has_no_conversation_projection():
+    snapshot = _Snapshot()
+    snapshot.exists = False
+
+    assert conversation_snapshot_data(snapshot) is None
+
+
+def test_write_result_produces_lightweight_mutation_revision():
+    result = type('WriteResult', (), {'update_time': _Snapshot.update_time})()
+
+    data = conversation_mutation_data('conversation-1', result)
+
+    assert data == {
+        'id': 'conversation-1',
+        'updated_at': _Snapshot.update_time,
+        'revision': '2026-07-09T12:30:00+00:00',
+    }
+
+
+def test_list_projection_allowlist_never_hydrates_transcript_payload():
+    assert 'transcript_segments' not in CONVERSATION_LIST_FIELDS
+    assert {'id', 'created_at', 'structured', 'status', 'is_locked'} <= set(CONVERSATION_LIST_FIELDS)
+
+
+def test_list_projection_applies_firestore_field_mask():
+    class Query:
+        selected = None
+
+        def select(self, fields):
+            self.selected = tuple(fields)
+            return self
+
+    query = Query()
+    result = apply_conversation_list_field_mask(query)
+
+    assert result is query
+    assert query.selected == CONVERSATION_LIST_FIELDS

--- a/backend/tests/unit/test_lock_bypass_fixes.py
+++ b/backend/tests/unit/test_lock_bypass_fixes.py
@@ -1558,6 +1558,55 @@ class TestConversationListRedaction:
         assert len(unlocked[0]['transcript_segments']) == 1
 
 
+class TestConversationMutationCanonicalResponse:
+    """Desktop mutations acknowledge a lightweight server-owned revision."""
+
+    def test_title_mutation_returns_canonical_conversation(self):
+        import database.conversations as conversations_db
+        from routers.conversations import patch_conversation_title
+
+        conversations_db.get_conversation_access_state = MagicMock(return_value={'id': 'conv-1', 'is_locked': False})
+        conversations_db.update_conversation_title = MagicMock()
+
+        result = patch_conversation_title('conv-1', 'Canonical title', uid='test-uid')
+
+        assert result['id'] == 'conv-1'
+
+    def test_star_mutation_returns_canonical_conversation(self):
+        import database.conversations as conversations_db
+        from routers.conversations import set_conversation_starred
+
+        conversations_db.get_conversation_access_state = MagicMock(return_value={'id': 'conv-1', 'is_locked': False})
+        conversations_db.set_conversation_starred = MagicMock()
+
+        result = set_conversation_starred('conv-1', True, uid='test-uid')
+
+        assert result['id'] == 'conv-1'
+
+
+class TestConversationListProjection:
+    def test_explicit_list_route_requests_firestore_projection(self):
+        import database.conversations as conversations_db
+        from routers.conversations import get_conversation_list_projection
+
+        conversations_db.get_conversations_without_photos = MagicMock(return_value=[])
+
+        result = get_conversation_list_projection(
+            limit=100,
+            offset=0,
+            statuses='processing,completed',
+            include_discarded=False,
+            start_date=None,
+            end_date=None,
+            folder_id=None,
+            starred=None,
+            uid='test-uid',
+        )
+
+        assert result == []
+        assert conversations_db.get_conversations_without_photos.call_args.kwargs['list_projection'] is True
+
+
 # =============================================================================
 # Test suggest_goal excludes locked memories
 # =============================================================================
@@ -1793,7 +1842,7 @@ class TestFolderMoveLockEnforcement:
     def test_move_conversation_rejects_locked(self):
         import database.conversations as conversations_db
 
-        conversations_db.get_conversation = MagicMock(return_value=_make_conversation(locked=True))
+        conversations_db.get_conversation_access_state = MagicMock(return_value={'id': 'conv-1', 'is_locked': True})
 
         from routers.folders import move_conversation_to_folder, MoveConversationRequest
 
@@ -1808,7 +1857,7 @@ class TestFolderMoveLockEnforcement:
         import database.conversations as conversations_db
         import database.folders as folders_db
 
-        conversations_db.get_conversation = MagicMock(return_value=_make_conversation(locked=False))
+        conversations_db.get_conversation_access_state = MagicMock(return_value={'id': 'conv-1', 'is_locked': False})
         folders_db.get_folder = MagicMock(return_value={'id': 'folder-1', 'name': 'Test'})
         folders_db.move_conversation_to_folder = MagicMock()
 
@@ -1816,7 +1865,8 @@ class TestFolderMoveLockEnforcement:
 
         request = MoveConversationRequest(folder_id='folder-1')
         result = move_conversation_to_folder('conv-1', request, uid='test-uid')
-        assert result == {"status": "ok"}
+        assert result["status"] == "ok"
+        assert result["id"] == "conv-1"
 
     def test_bulk_move_rejects_if_any_locked(self):
         import database.conversations as conversations_db

--- a/backend/tests/unit/test_lock_bypass_fixes.py
+++ b/backend/tests/unit/test_lock_bypass_fixes.py
@@ -1519,14 +1519,18 @@ class TestIntegrationListLockRedaction:
 class TestConversationListRedaction:
     """get_conversations router endpoint must redact locked conversation content."""
 
-    def test_conversation_list_redacts_locked(self):
+    def test_conversation_list_redacts_locked(self, monkeypatch):
         """Main conversation list must clear action_items/events/transcript for locked."""
         import database.conversations as conversations_db
 
         locked_conv = _make_conversation(locked=True)
         unlocked_conv = _make_conversation(locked=False, conversation_id='conv-2')
 
-        conversations_db.get_conversations_without_photos = MagicMock(return_value=[locked_conv, unlocked_conv])
+        monkeypatch.setattr(
+            conversations_db,
+            'get_conversations_without_photos',
+            MagicMock(return_value=[locked_conv, unlocked_conv]),
+        )
 
         with patch('routers.conversations.auth') as mock_auth:
             mock_auth.get_current_user_uid = MagicMock(return_value='test-uid')
@@ -1561,23 +1565,39 @@ class TestConversationListRedaction:
 class TestConversationMutationCanonicalResponse:
     """Desktop mutations acknowledge a lightweight server-owned revision."""
 
-    def test_title_mutation_returns_canonical_conversation(self):
+    def test_title_mutation_returns_canonical_conversation(self, monkeypatch):
         import database.conversations as conversations_db
         from routers.conversations import patch_conversation_title
 
-        conversations_db.get_conversation_access_state = MagicMock(return_value={'id': 'conv-1', 'is_locked': False})
-        conversations_db.update_conversation_title = MagicMock()
+        monkeypatch.setattr(
+            conversations_db,
+            'get_conversation_access_state',
+            MagicMock(return_value={'id': 'conv-1', 'is_locked': False}),
+        )
+        monkeypatch.setattr(
+            conversations_db,
+            'update_conversation_title',
+            MagicMock(return_value=SimpleNamespace(update_time=datetime(2026, 7, 9, tzinfo=timezone.utc))),
+        )
 
         result = patch_conversation_title('conv-1', 'Canonical title', uid='test-uid')
 
         assert result['id'] == 'conv-1'
 
-    def test_star_mutation_returns_canonical_conversation(self):
+    def test_star_mutation_returns_canonical_conversation(self, monkeypatch):
         import database.conversations as conversations_db
         from routers.conversations import set_conversation_starred
 
-        conversations_db.get_conversation_access_state = MagicMock(return_value={'id': 'conv-1', 'is_locked': False})
-        conversations_db.set_conversation_starred = MagicMock()
+        monkeypatch.setattr(
+            conversations_db,
+            'get_conversation_access_state',
+            MagicMock(return_value={'id': 'conv-1', 'is_locked': False}),
+        )
+        monkeypatch.setattr(
+            conversations_db,
+            'set_conversation_starred',
+            MagicMock(return_value=SimpleNamespace(update_time=datetime(2026, 7, 9, tzinfo=timezone.utc))),
+        )
 
         result = set_conversation_starred('conv-1', True, uid='test-uid')
 
@@ -1585,11 +1605,12 @@ class TestConversationMutationCanonicalResponse:
 
 
 class TestConversationListProjection:
-    def test_explicit_list_route_requests_firestore_projection(self):
+    def test_explicit_list_route_requests_firestore_projection(self, monkeypatch):
         import database.conversations as conversations_db
         from routers.conversations import get_conversation_list_projection
 
-        conversations_db.get_conversations_without_photos = MagicMock(return_value=[])
+        get_conversations = MagicMock(return_value=[])
+        monkeypatch.setattr(conversations_db, 'get_conversations_without_photos', get_conversations)
 
         result = get_conversation_list_projection(
             limit=100,
@@ -1604,7 +1625,7 @@ class TestConversationListProjection:
         )
 
         assert result == []
-        assert conversations_db.get_conversations_without_photos.call_args.kwargs['list_projection'] is True
+        assert get_conversations.call_args.kwargs['list_projection'] is True
 
 
 # =============================================================================
@@ -1839,10 +1860,14 @@ class TestMcpSseMemoryLockEnforcement:
 class TestFolderMoveLockEnforcement:
     """Gap 10 + bonus: Folder move must reject locked conversations."""
 
-    def test_move_conversation_rejects_locked(self):
+    def test_move_conversation_rejects_locked(self, monkeypatch):
         import database.conversations as conversations_db
 
-        conversations_db.get_conversation_access_state = MagicMock(return_value={'id': 'conv-1', 'is_locked': True})
+        monkeypatch.setattr(
+            conversations_db,
+            'get_conversation_access_state',
+            MagicMock(return_value={'id': 'conv-1', 'is_locked': True}),
+        )
 
         from routers.folders import move_conversation_to_folder, MoveConversationRequest
 
@@ -1853,13 +1878,21 @@ class TestFolderMoveLockEnforcement:
         except Exception as e:
             assert e.status_code == 402
 
-    def test_move_conversation_allows_unlocked(self):
+    def test_move_conversation_allows_unlocked(self, monkeypatch):
         import database.conversations as conversations_db
         import database.folders as folders_db
 
-        conversations_db.get_conversation_access_state = MagicMock(return_value={'id': 'conv-1', 'is_locked': False})
-        folders_db.get_folder = MagicMock(return_value={'id': 'folder-1', 'name': 'Test'})
-        folders_db.move_conversation_to_folder = MagicMock()
+        monkeypatch.setattr(
+            conversations_db,
+            'get_conversation_access_state',
+            MagicMock(return_value={'id': 'conv-1', 'is_locked': False}),
+        )
+        monkeypatch.setattr(folders_db, 'get_folder', MagicMock(return_value={'id': 'folder-1', 'name': 'Test'}))
+        monkeypatch.setattr(
+            folders_db,
+            'move_conversation_to_folder',
+            MagicMock(return_value=SimpleNamespace(update_time=datetime(2026, 7, 9, tzinfo=timezone.utc))),
+        )
 
         from routers.folders import move_conversation_to_folder, MoveConversationRequest
 
@@ -1868,17 +1901,21 @@ class TestFolderMoveLockEnforcement:
         assert result["status"] == "ok"
         assert result["id"] == "conv-1"
 
-    def test_bulk_move_rejects_if_any_locked(self):
+    def test_bulk_move_rejects_if_any_locked(self, monkeypatch):
         import database.conversations as conversations_db
         import database.folders as folders_db
 
-        conversations_db.get_conversation = MagicMock(
-            side_effect=[
-                _make_conversation(locked=False, conversation_id='conv-1'),
-                _make_conversation(locked=True, conversation_id='conv-2'),
-            ]
+        monkeypatch.setattr(
+            conversations_db,
+            'get_conversation',
+            MagicMock(
+                side_effect=[
+                    _make_conversation(locked=False, conversation_id='conv-1'),
+                    _make_conversation(locked=True, conversation_id='conv-2'),
+                ]
+            ),
         )
-        folders_db.get_folder = MagicMock(return_value={'id': 'folder-1', 'name': 'Test'})
+        monkeypatch.setattr(folders_db, 'get_folder', MagicMock(return_value={'id': 'folder-1', 'name': 'Test'}))
 
         from routers.folders import bulk_move_conversations, BulkMoveConversationsRequest
 
@@ -1889,18 +1926,22 @@ class TestFolderMoveLockEnforcement:
         except Exception as e:
             assert e.status_code == 402
 
-    def test_bulk_move_allows_all_unlocked(self):
+    def test_bulk_move_allows_all_unlocked(self, monkeypatch):
         import database.conversations as conversations_db
         import database.folders as folders_db
 
-        conversations_db.get_conversation = MagicMock(
-            side_effect=[
-                _make_conversation(locked=False, conversation_id='conv-1'),
-                _make_conversation(locked=False, conversation_id='conv-2'),
-            ]
+        monkeypatch.setattr(
+            conversations_db,
+            'get_conversation',
+            MagicMock(
+                side_effect=[
+                    _make_conversation(locked=False, conversation_id='conv-1'),
+                    _make_conversation(locked=False, conversation_id='conv-2'),
+                ]
+            ),
         )
-        folders_db.get_folder = MagicMock(return_value={'id': 'folder-1', 'name': 'Test'})
-        folders_db.bulk_move_conversations_to_folder = MagicMock(return_value=2)
+        monkeypatch.setattr(folders_db, 'get_folder', MagicMock(return_value={'id': 'folder-1', 'name': 'Test'}))
+        monkeypatch.setattr(folders_db, 'bulk_move_conversations_to_folder', MagicMock(return_value=2))
 
         from routers.folders import bulk_move_conversations, BulkMoveConversationsRequest
 

--- a/desktop/macos/AGENTS.md
+++ b/desktop/macos/AGENTS.md
@@ -120,6 +120,13 @@ storage before UI) and wire `import` + `public` on the extracted target's API.
 - **Redis**: Caching
 - **Typesense**: Search
 
+### Conversations Read/Write Authority
+- `ConversationRepository` is the account-scoped owner for desktop conversation list, search, detail, and user mutations. UI surfaces observe entities by conversation ID; they must not independently reconcile API values with `TranscriptionStorage` rows.
+- `ConversationCacheStorage` is the offline read model. It records projection completeness (`list`, `detail`, `transcript`) so a partial list response cannot erase richer cached detail.
+- Backend `revision` / `updated_at` values are the freshness authority. Never compare a local wall clock with `finished_at` to choose a winner.
+- Title, star, and folder writes are staged in the repository's durable pending-mutation journal and drained serially per conversation, then cleared only by the matching lightweight server revision acknowledgment. New conversation mutations should follow that path and add a deterministic behavioral test.
+- `TranscriptionStorage` owns capture finalization, crash recovery, and retry. Its legacy server fields exist only for finalization and one-time cache migration, not as a Conversations UI cache.
+
 ### User Subcollections (Firestore)
 - `users/{uid}/conversations` - Has `source` field (omi, desktop, phone, etc.)
 - `users/{uid}/action_items` - Tasks (no platform tracking)

--- a/desktop/macos/Desktop/Sources/APIClient.swift
+++ b/desktop/macos/Desktop/Sources/APIClient.swift
@@ -627,6 +627,45 @@ extension APIClient {
     return try await get(endpoint)
   }
 
+  /// Fetches the explicit lightweight list projection used by the repository.
+  /// Detail-only transcript data is omitted by contract.
+  func getConversationList(
+    limit: Int = 50,
+    offset: Int = 0,
+    statuses: [ConversationStatus] = [],
+    includeDiscarded: Bool = false,
+    startDate: Date? = nil,
+    endDate: Date? = nil,
+    folderId: String? = nil,
+    starred: Bool? = nil
+  ) async throws -> [ServerConversation] {
+    var queryItems = ["limit=\(limit)", "offset=\(offset)"]
+    queryItems += Self.conversationFilterQueryItems(
+      statuses: statuses,
+      includeDiscarded: includeDiscarded,
+      startDate: startDate,
+      endDate: endDate,
+      folderId: folderId,
+      starred: starred
+    )
+    do {
+      return try await get("v1/conversations/list?\(queryItems.joined(separator: "&"))")
+    } catch APIError.httpError(let statusCode, _) where statusCode == 404 {
+      // During a rolling backend deploy, an older instance treats `list` as a
+      // conversation ID. Fall back once to the compatible list route.
+      return try await getConversations(
+        limit: limit,
+        offset: offset,
+        statuses: statuses,
+        includeDiscarded: includeDiscarded,
+        startDate: startDate,
+        endDate: endDate,
+        folderId: folderId,
+        starred: starred
+      )
+    }
+  }
+
   /// Fetches a single conversation by ID
   func getConversation(id: String) async throws -> ServerConversation {
     return try await get("v1/conversations/\(id)")
@@ -639,19 +678,21 @@ extension APIClient {
   }
 
   /// Updates the starred status of a conversation
-  func setConversationStarred(id: String, starred: Bool) async throws {
+  func setConversationStarred(id: String, starred: Bool) async throws -> ConversationMutationAcknowledgement {
     let url = URL(string: baseURL + "v1/conversations/\(id)/starred?starred=\(starred)")!
     var request = URLRequest(url: url)
     request.httpMethod = "PATCH"
     request.allHTTPHeaderFields = try await buildHeaders(requireAuth: true)
 
-    let (_, response) = try await session.data(for: request)
-    guard let httpResponse = response as? HTTPURLResponse,
-      (200...299).contains(httpResponse.statusCode)
-    else {
-      throw APIError.httpError(statusCode: (response as? HTTPURLResponse)?.statusCode ?? 0)
-    }
+    let response: ConversationMutationEnvelope = try await performRequest(request)
     invalidateConversationsCountCache()
+    return ConversationMutationAcknowledgement(
+      id: response.id ?? id,
+      updatedAt: response.updatedAt,
+      revision: response.revision,
+      value: .starred(starred),
+      conversation: response.conversation
+    )
   }
 
   /// Sets the visibility of a conversation for sharing
@@ -685,7 +726,7 @@ extension APIClient {
   }
 
   /// Updates the title of a conversation
-  func updateConversationTitle(id: String, title: String) async throws {
+  func updateConversationTitle(id: String, title: String) async throws -> ConversationMutationAcknowledgement {
     var components = URLComponents(string: baseURL + "v1/conversations/\(id)/title")!
     components.queryItems = [URLQueryItem(name: "title", value: title)]
     let url = components.url!
@@ -693,12 +734,14 @@ extension APIClient {
     request.httpMethod = "PATCH"
     request.allHTTPHeaderFields = try await buildHeaders(requireAuth: true)
 
-    let (_, response) = try await session.data(for: request)
-    guard let httpResponse = response as? HTTPURLResponse,
-      (200...299).contains(httpResponse.statusCode)
-    else {
-      throw APIError.httpError(statusCode: (response as? HTTPURLResponse)?.statusCode ?? 0)
-    }
+    let response: ConversationMutationEnvelope = try await performRequest(request)
+    return ConversationMutationAcknowledgement(
+      id: response.id ?? id,
+      updatedAt: response.updatedAt,
+      revision: response.revision,
+      value: .title(title),
+      conversation: response.conversation
+    )
   }
 
   /// Searches conversations with a query
@@ -867,7 +910,9 @@ extension APIClient {
   }
 
   /// Moves a conversation to a folder
-  func moveConversationToFolder(conversationId: String, folderId: String?) async throws {
+  func moveConversationToFolder(conversationId: String, folderId: String?) async throws
+    -> ConversationMutationAcknowledgement
+  {
     let body = MoveToFolderRequest(folderId: folderId)
     let url = URL(string: baseURL + "v1/conversations/\(conversationId)/folder")!
     var request = URLRequest(url: url)
@@ -875,13 +920,15 @@ extension APIClient {
     request.allHTTPHeaderFields = try await buildHeaders(requireAuth: true)
     request.httpBody = try JSONEncoder().encode(body)
 
-    let (_, response) = try await session.data(for: request)
-    guard let httpResponse = response as? HTTPURLResponse,
-      (200...299).contains(httpResponse.statusCode)
-    else {
-      throw APIError.httpError(statusCode: (response as? HTTPURLResponse)?.statusCode ?? 0)
-    }
+    let response: ConversationMutationEnvelope = try await performRequest(request)
     invalidateConversationsCountCache()
+    return ConversationMutationAcknowledgement(
+      id: response.id ?? conversationId,
+      updatedAt: response.updatedAt,
+      revision: response.revision,
+      value: .folder(folderId),
+      conversation: response.conversation
+    )
   }
 
 }
@@ -894,6 +941,22 @@ enum ConversationStatus: String, Codable {
   case merging = "merging"
   case completed = "completed"
   case failed = "failed"
+}
+
+private struct ConversationMutationEnvelope: Decodable {
+  let status: String
+  let id: String?
+  let updatedAt: Date?
+  let revision: String?
+  /// Optional during the rolling backend deployment. Older servers only
+  /// return `{ "status": "ok" }`; the successful requested field is still
+  /// acknowledged without triggering the detail endpoint's lazy enrichment.
+  let conversation: ServerConversation?
+
+  enum CodingKeys: String, CodingKey {
+    case status, id, revision, conversation
+    case updatedAt = "updated_at"
+  }
 }
 
 enum ConversationSource: String, Codable {
@@ -929,7 +992,7 @@ enum TranscriptPresenceState: Equatable {
   case includedNonEmpty
 }
 
-struct ServerConversation: Codable, Identifiable, Equatable {
+struct ServerConversation: Codable, Identifiable, Equatable, @unchecked Sendable {
   static func == (lhs: ServerConversation, rhs: ServerConversation) -> Bool {
     lhs.id == rhs.id && lhs.createdAt == rhs.createdAt && lhs.startedAt == rhs.startedAt
       && lhs.finishedAt == rhs.finishedAt && lhs.structured == rhs.structured
@@ -937,12 +1000,18 @@ struct ServerConversation: Codable, Identifiable, Equatable {
       && lhs.isLocked == rhs.isLocked && lhs.starred == rhs.starred && lhs.folderId == rhs.folderId
       && lhs.source == rhs.source
       && lhs.transcriptSegmentsIncluded == rhs.transcriptSegmentsIncluded
+      && lhs.revision == rhs.revision
   }
 
   let id: String
   let createdAt: Date
   let startedAt: Date?
   let finishedAt: Date?
+  /// Server-owned freshness metadata. Revision is an opaque identity token;
+  /// updatedAt can be ordered only against another server-owned updatedAt.
+  /// Neither may be compared with local clocks or recording timestamps.
+  let updatedAt: Date?
+  let revision: String?
 
   var structured: Structured
   var transcriptSegments: [TranscriptSegment]
@@ -970,6 +1039,8 @@ struct ServerConversation: Codable, Identifiable, Equatable {
     case createdAt = "created_at"
     case startedAt = "started_at"
     case finishedAt = "finished_at"
+    case updatedAt = "updated_at"
+    case revision
     case structured
     case transcriptSegments = "transcript_segments"
     case geolocation
@@ -983,7 +1054,7 @@ struct ServerConversation: Codable, Identifiable, Equatable {
     case isLocked = "is_locked"
     case starred
     case folderId = "folder_id"
-    case inputDeviceName = "input_device_name"
+    case inputDeviceName = "client_device_id"
     case deferred
   }
 
@@ -999,7 +1070,10 @@ struct ServerConversation: Codable, Identifiable, Equatable {
     createdAt = try Self.parseDate(wire.createdAt, decoder: decoder)
     startedAt = try Self.parseOptionalDate(wire.startedAt, decoder: decoder)
     finishedAt = try Self.parseOptionalDate(wire.finishedAt, decoder: decoder)
-    structured = Structured(wire.structured ?? OmiAPI.Structured(actionItems: nil, category: nil, emoji: nil, events: nil, overview: nil, title: nil))
+    updatedAt = try Self.parseOptionalDate(
+      try container.decodeIfPresent(String.self, forKey: .updatedAt), decoder: decoder)
+    revision = try container.decodeIfPresent(String.self, forKey: .revision)
+    structured = Structured(wire.structured)
     // container.contains distinguishes `"transcript_segments": null` (present,
     // empty) from the key being absent (omitted). wire.transcriptSegments is
     // nil for both, so we must check the container directly.
@@ -1012,7 +1086,7 @@ struct ServerConversation: Codable, Identifiable, Equatable {
     language = wire.language
     status = wire.status.map { ConversationStatus(rawValue: $0.rawValue) ?? .completed } ?? .completed
     discarded = wire.discarded ?? false
-    deleted = false  // backend REST Conversation schema does not expose deleted
+    deleted = try container.decodeIfPresent(Bool.self, forKey: .deleted) ?? false
     isLocked = wire.isLocked ?? false
     starred = wire.starred ?? false
     folderId = wire.folderId
@@ -1062,12 +1136,16 @@ struct ServerConversation: Codable, Identifiable, Equatable {
     starred: Bool,
     folderId: String?,
     inputDeviceName: String?,
-    deferred: Bool = false
+    deferred: Bool = false,
+    updatedAt: Date? = nil,
+    revision: String? = nil
   ) {
     self.id = id
     self.createdAt = createdAt
     self.startedAt = startedAt
     self.finishedAt = finishedAt
+    self.updatedAt = updatedAt
+    self.revision = revision
     self.structured = structured
     self.transcriptSegments = transcriptSegments
     self.transcriptSegmentsIncluded = transcriptSegmentsIncluded

--- a/desktop/macos/Desktop/Sources/APIClient.swift
+++ b/desktop/macos/Desktop/Sources/APIClient.swift
@@ -23,6 +23,7 @@ actor APIClient {
 
   let session: URLSession
   private let decoder: JSONDecoder
+  private let conversationListFallbackRecorder: @Sendable () -> Void
 
   /// When set, `buildHeaders` uses this instead of calling AuthService (test-only).
   var testAuthHeader: String?
@@ -40,12 +41,32 @@ actor APIClient {
     self.session = URLSession(configuration: config)
 
     self.decoder = Self.makeDecoder()
+    self.conversationListFallbackRecorder = { APIClient.recordConversationListFallback() }
   }
 
   /// Test-only initializer that accepts a custom URLSession for request interception.
-  init(session: URLSession) {
+  init(
+    session: URLSession,
+    conversationListFallbackRecorder: (@Sendable () -> Void)? = nil
+  ) {
     self.session = session
     self.decoder = Self.makeDecoder()
+    self.conversationListFallbackRecorder = conversationListFallbackRecorder
+      ?? { APIClient.recordConversationListFallback() }
+  }
+
+  private nonisolated static func recordConversationListFallback() {
+    DesktopDiagnosticsManager.shared.recordFallback(
+      area: "other",
+      from: "conversation_list_projection",
+      to: "conversation_full_list",
+      reason: "other",
+      outcome: .degraded,
+      extra: [
+        "detail": "rolling_deploy_route_missing",
+        "http_status_code": 404,
+      ]
+    )
   }
 
   private static func makeDecoder() -> JSONDecoder {
@@ -653,6 +674,7 @@ extension APIClient {
     } catch APIError.httpError(let statusCode, _) where statusCode == 404 {
       // During a rolling backend deploy, an older instance treats `list` as a
       // conversation ID. Fall back once to the compatible list route.
+      conversationListFallbackRecorder()
       return try await getConversations(
         limit: limit,
         offset: offset,

--- a/desktop/macos/Desktop/Sources/AppState.swift
+++ b/desktop/macos/Desktop/Sources/AppState.swift
@@ -224,7 +224,8 @@ class AppState: ObservableObject {
   @Published var conversationsError: String? = nil
   @Published var totalConversationsCount: Int? = nil  // Unfiltered total count for dashboard metrics.
   @Published var filteredConversationsCount: Int? = nil  // Count matching the active conversations filters.
-  var pendingConversationMutations: [String: ConversationPendingMutation] = [:]
+  let conversationRepository = ConversationRepository.shared
+  var conversationRepositoryCancellables = Set<AnyCancellable>()
 
   // Conversation filters
   @Published var showStarredOnly: Bool = false
@@ -434,6 +435,31 @@ class AppState: ObservableObject {
   init() {
     // Register as the current instance so background services can check recording state
     AppState.current = self
+
+    // AppState remains a compatibility projection for dashboard/automation
+    // consumers while ConversationRepository is the single data owner.
+    conversationRepository.$conversationIds
+      .combineLatest(conversationRepository.$entitiesById)
+      .map { ids, entities in ids.compactMap { entities[$0] } }
+      .sink { [weak self] conversations in self?.conversations = conversations }
+      .store(in: &conversationRepositoryCancellables)
+    conversationRepository.$isLoading
+      .sink { [weak self] value in
+        self?.isLoadingConversations = value
+        if !value, self?.conversationRepository.conversationIds.isEmpty == false {
+          NotificationCenter.default.post(name: .conversationsPageDidLoad, object: nil)
+        }
+      }
+      .store(in: &conversationRepositoryCancellables)
+    conversationRepository.$error
+      .sink { [weak self] value in self?.conversationsError = value }
+      .store(in: &conversationRepositoryCancellables)
+    conversationRepository.$totalCount
+      .sink { [weak self] value in self?.totalConversationsCount = value }
+      .store(in: &conversationRepositoryCancellables)
+    conversationRepository.$filteredCount
+      .sink { [weak self] value in self?.filteredConversationsCount = value }
+      .store(in: &conversationRepositoryCancellables)
 
     // Restore paywall flag from prior session so toggles + auto-restart respect
     // it before any backend call has a chance to refresh state — but never for

--- a/desktop/macos/Desktop/Sources/AppState/AppState+DataLoading.swift
+++ b/desktop/macos/Desktop/Sources/AppState/AppState+DataLoading.swift
@@ -1,317 +1,32 @@
-import AVFoundation
-import Combine
-import SwiftUI
-import UserNotifications
-
-private struct LocalConversationCacheTimeout: Error {}
+import Foundation
 
 @MainActor
 extension AppState {
-
-  func updateConversationCount(_ count: Int, filtered: Bool) {
-    if filtered {
-      if filteredConversationsCount != count {
-        filteredConversationsCount = count
-      }
-    } else {
-      if totalConversationsCount != count {
-        totalConversationsCount = count
-      }
-      if filteredConversationsCount != nil {
-        filteredConversationsCount = nil
-      }
-    }
-  }
-
-  /// Load conversations - first from local cache (instant), then from API (background refresh)
   func loadConversations() async {
-    guard !isLoadingConversations else { return }
-
-    isLoadingConversations = true
-    conversationsError = nil
-
-    let requestShowStarredOnly = showStarredOnly
-    let requestSelectedDateFilter = selectedDateFilter
-    let requestSelectedFolderId = selectedFolderId
-    let requestHasActiveFilters = hasActiveConversationFilters
-
-    func requestFiltersAreCurrent() -> Bool {
-      showStarredOnly == requestShowStarredOnly
-        && selectedDateFilter == requestSelectedDateFilter
-        && selectedFolderId == requestSelectedFolderId
-    }
-
-    // Step 1: Load from local cache first (instant display)
-    // Use timeout to avoid blocking UI if database is initializing (e.g. recovery).
-    // The local cache currently supports starred/folder filters but not server date ranges;
-    // skip it for date-filtered views so the visible list and total count share semantics.
-    if requestSelectedDateFilter == nil {
-      do {
-        let cachedConversations = try await withThrowingTaskGroup(of: [ServerConversation].self) { group in
-          group.addTask {
-            try await TranscriptionStorage.shared.getLocalConversations(
-              limit: 50,
-              starredOnly: requestShowStarredOnly,
-              folderId: requestSelectedFolderId
-            )
-          }
-          group.addTask {
-            try await Task.sleep(nanoseconds: 3_000_000_000)  // 3 second timeout
-            throw LocalConversationCacheTimeout()
-          }
-          let result = try await group.next()!
-          group.cancelAll()
-          return result
-        }
-
-        if !cachedConversations.isEmpty && requestFiltersAreCurrent() {
-          conversations = cachedConversations
-          log("Conversations: Loaded \(cachedConversations.count) from local cache (instant)")
-
-          // Get local count
-          let localCount = try await TranscriptionStorage.shared.getLocalConversationsCount(
-            starredOnly: requestShowStarredOnly,
-            folderId: requestSelectedFolderId)
-          updateConversationCount(localCount, filtered: requestHasActiveFilters)
-
-          // Stop loading state so UI shows cached data immediately
-          isLoadingConversations = false
-          // Notify sidebar immediately so loading indicator clears with cached data
-          NotificationCenter.default.post(name: .conversationsPageDidLoad, object: nil)
-        }
-      } catch is LocalConversationCacheTimeout {
-        log("Conversations: Local cache load timed out, falling back to API")
-      } catch is CancellationError {
-        log("Conversations: Local cache load cancelled")
-        return
-      } catch {
-        log("Conversations: Local cache unavailable, falling back to API")
-        // Continue to API fetch even if local fails
-      }
-    } else {
-      conversations = []
-      filteredConversationsCount = 0
-    }
-
-    // Step 2: Fetch from API in background to get fresh data
-    // Calculate date range if date filter is set
-    let startDate: Date?
-    let endDate: Date?
-    if let filterDate = requestSelectedDateFilter {
-      let calendar = Calendar.current
-      startDate = calendar.startOfDay(for: filterDate)
-      endDate = calendar.date(byAdding: .day, value: 1, to: startDate!)
-    } else {
-      startDate = nil
-      endDate = nil
-    }
-
-    // Fetch conversations and count in parallel
-    async let conversationsTask = APIClient.shared.getConversations(
-      limit: 50,
-      offset: 0,
-      statuses: [.completed, .processing],
-      includeDiscarded: false,
-      startDate: startDate,
-      endDate: endDate,
-      folderId: requestSelectedFolderId,
-      starred: requestShowStarredOnly ? true : nil
-    )
-    async let countTask = APIClient.shared.getConversationsCount(
-      includeDiscarded: false,
-      statuses: [.completed, .processing],
-      startDate: startDate,
-      endDate: endDate,
-      folderId: requestSelectedFolderId,
-      starred: requestShowStarredOnly ? true : nil
-    )
-
-    do {
-      let fetchedConversations = try await conversationsTask
-      if requestFiltersAreCurrent() {
-        let reconciliation = ConversationReconciliationPolicy.mergeList(
-          server: fetchedConversations,
-          current: conversations,
-          pendingMutations: pendingConversationMutations
-        )
-        pendingConversationMutations = reconciliation.pendingMutations
-        conversations = reconciliation.conversations
-      } else {
-        log("Conversations: Ignoring stale response for superseded filters")
-      }
-      log(
-        "Conversations: Refreshed \(fetchedConversations.count) from API (starred=\(requestShowStarredOnly), date=\(requestSelectedDateFilter?.description ?? "nil"))"
+    await conversationRepository.load(
+      query: ConversationQuery(
+        showStarredOnly: showStarredOnly,
+        selectedDate: selectedDateFilter,
+        folderId: selectedFolderId
       )
-
-      // DEBUG: Log any conversations with empty titles
-      for conv in fetchedConversations where conv.structured.title.isEmpty {
-        log(
-          "DEBUG: Conversation \(conv.id) has EMPTY title"
-        )
-      }
-
-      // Sync conversations to local database in background
-      Task.detached(priority: .background) {
-        var syncedCount = 0
-        for conversation in fetchedConversations {
-          do {
-            try await TranscriptionStorage.shared.syncServerConversation(conversation)
-            syncedCount += 1
-          } catch {
-            log(
-              "Conversations: Failed to sync \(conversation.id) to local DB: \(error.localizedDescription)"
-            )
-          }
-        }
-        log("Conversations: Synced \(syncedCount)/\(fetchedConversations.count) to local database")
-      }
-    } catch {
-      logError("Conversations: API fetch failed", error: error)
-      // Only set error if we don't have cached data
-      if conversations.isEmpty {
-        conversationsError = error.localizedDescription
-      } else {
-        log("Conversations: Using cached data after API failure")
-      }
-    }
-
-    // Update total count from API (more accurate than local)
-    do {
-      let count = try await countTask
-      if requestFiltersAreCurrent() {
-        updateConversationCount(count, filtered: requestHasActiveFilters)
-        log("Conversations: Count from API = \(count) (filtered=\(requestHasActiveFilters))")
-      } else {
-        log("Conversations: Ignoring stale count for superseded filters")
-      }
-    } catch {
-      logError("Conversations: Failed to get count from API", error: error)
-      // Keep local count if API fails
-    }
-
-    isLoadingConversations = false
+    )
     NotificationCenter.default.post(name: .conversationsPageDidLoad, object: nil)
-    if !requestFiltersAreCurrent() {
-      await loadConversations()
-    }
   }
 
-  /// Refresh conversations silently (for app-activation and Cmd+R event-driven refreshes).
-  /// Fetches from API only, merges in-place, and only triggers @Published if data actually changed.
   func refreshConversations() async {
-    // Skip if user is signed out (tokens are cleared)
-    guard AuthState.shared.isSignedIn else { return }
-    // Skip if currently doing a full load
-    guard !isLoadingConversations else { return }
-
-    let requestShowStarredOnly = showStarredOnly
-    let requestSelectedDateFilter = selectedDateFilter
-    let requestSelectedFolderId = selectedFolderId
-    let requestHasActiveFilters = hasActiveConversationFilters
-
-    func requestFiltersAreCurrent() -> Bool {
-      showStarredOnly == requestShowStarredOnly
-        && selectedDateFilter == requestSelectedDateFilter
-        && selectedFolderId == requestSelectedFolderId
-    }
-
-    // Calculate date range if date filter is set
-    let startDate: Date?
-    let endDate: Date?
-    if let filterDate = requestSelectedDateFilter {
-      let calendar = Calendar.current
-      startDate = calendar.startOfDay(for: filterDate)
-      endDate = calendar.date(byAdding: .day, value: 1, to: startDate!)
-    } else {
-      startDate = nil
-      endDate = nil
-    }
-
-    do {
-      let fetchedConversations = try await APIClient.shared.getConversations(
-        limit: 50,
-        offset: 0,
-        statuses: [.completed, .processing],
-        includeDiscarded: false,
-        startDate: startDate,
-        endDate: endDate,
-        folderId: requestSelectedFolderId,
-        starred: requestShowStarredOnly ? true : nil
-      )
-
-      if requestFiltersAreCurrent() {
-        let reconciliation = ConversationReconciliationPolicy.mergeList(
-          server: fetchedConversations,
-          current: conversations,
-          pendingMutations: pendingConversationMutations
-        )
-        pendingConversationMutations = reconciliation.pendingMutations
-        if reconciliation.conversations != conversations {
-          conversations = reconciliation.conversations
-          log("Conversations: Auto-refresh updated (\(reconciliation.conversations.count) items)")
-        }
-      } else {
-        log("Conversations: Ignoring stale auto-refresh response for superseded filters")
-      }
-
-      // Sync to local database in background
-      Task.detached(priority: .background) {
-        for conversation in fetchedConversations {
-          _ = try? await TranscriptionStorage.shared.syncServerConversation(conversation)
-        }
-      }
-    } catch {
-      // Silently ignore errors during auto-refresh — cached data stays visible.
-      // Auth errors (notSignedIn) are transient: token refresh may fail momentarily
-      // while the user is still signed in. Don't send these to Sentry.
-      if case AuthError.notSignedIn = error {
-        log("Conversations: Auto-refresh skipped (auth token temporarily unavailable)")
-      } else {
-        logError("Conversations: Auto-refresh failed", error: error)
-      }
-    }
-
-    do {
-      let count = try await APIClient.shared.getConversationsCount(
-        includeDiscarded: false,
-        statuses: [.completed, .processing],
-        startDate: startDate,
-        endDate: endDate,
-        folderId: requestSelectedFolderId,
-        starred: requestShowStarredOnly ? true : nil
-      )
-      if requestFiltersAreCurrent() {
-        updateConversationCount(count, filtered: requestHasActiveFilters)
-      }
-    } catch {
-      // Keep existing count
-    }
+    await conversationRepository.refresh()
   }
 
-  /// Update the starred status of a conversation locally after a successful mutation.
-  func setConversationStarred(_ conversationId: String, starred: Bool) {
-    var mutation = pendingConversationMutations[conversationId] ?? ConversationPendingMutation()
-    mutation.setStarred(starred)
-    pendingConversationMutations[conversationId] = mutation
-
-    if let index = conversations.firstIndex(where: { $0.id == conversationId }) {
-      conversations[index].starred = starred
-    }
-  }
-
-  /// Toggle starred filter and reload conversations
   func toggleStarredFilter() async {
     showStarredOnly.toggle()
     await loadConversations()
   }
 
-  /// Set date filter and reload conversations
   func setDateFilter(_ date: Date?) async {
     selectedDateFilter = date
     await loadConversations()
   }
 
-  /// Clear all filters and reload conversations
   func clearFilters() async {
     showStarredOnly = false
     selectedDateFilter = nil
@@ -319,7 +34,6 @@ extension AppState {
     await loadConversations()
   }
 
-  /// Set folder filter and reload conversations
   func setFolderFilter(_ folderId: String?) async {
     selectedFolderId = folderId
     await loadConversations()
@@ -327,31 +41,27 @@ extension AppState {
 
   // MARK: - Folder Management
 
-  /// Load folders from API
   func loadFolders() async {
     guard !isLoadingFolders else { return }
-
     isLoadingFolders = true
+    defer { isLoadingFolders = false }
 
     do {
-      let fetchedFolders = try await APIClient.shared.getFolders()
-      folders = fetchedFolders
-      log("Folders: Loaded \(fetchedFolders.count) folders")
+      folders = try await APIClient.shared.getFolders()
+      log("Folders: Loaded \(folders.count) folders")
     } catch {
       logError("Folders: Failed to load", error: error)
     }
-
-    isLoadingFolders = false
   }
 
-  /// Create a new folder
-  func createFolder(name: String, description: String? = nil, color: String? = nil) async -> Folder?
-  {
+  func createFolder(name: String, description: String? = nil, color: String? = nil) async -> Folder? {
     do {
       let folder = try await APIClient.shared.createFolder(
-        name: name, description: description, color: color)
+        name: name,
+        description: description,
+        color: color
+      )
       folders.append(folder)
-      log("Folders: Created folder '\(name)'")
       return folder
     } catch {
       logError("Folders: Failed to create folder", error: error)
@@ -359,101 +69,57 @@ extension AppState {
     }
   }
 
-  /// Delete a folder
   func deleteFolder(_ folderId: String, moveToFolderId: String? = nil) async {
     do {
       try await APIClient.shared.deleteFolder(id: folderId, moveToFolderId: moveToFolderId)
       folders.removeAll { $0.id == folderId }
       if selectedFolderId == folderId {
         selectedFolderId = nil
+        await loadConversations()
       }
-      log("Folders: Deleted folder \(folderId)")
     } catch {
       logError("Folders: Failed to delete folder", error: error)
     }
   }
 
-  /// Update a folder
   func updateFolder(_ folderId: String, name: String?, description: String?, color: String?) async {
     do {
       let updated = try await APIClient.shared.updateFolder(
-        id: folderId, name: name, description: description, color: color)
+        id: folderId,
+        name: name,
+        description: description,
+        color: color
+      )
       if let index = folders.firstIndex(where: { $0.id == folderId }) {
         folders[index] = updated
       }
-      log("Folders: Updated folder \(folderId)")
     } catch {
       logError("Folders: Failed to update folder", error: error)
     }
   }
 
-  /// Move a conversation to a folder
   func moveConversationToFolder(_ conversationId: String, folderId: String?) async {
     do {
-      try await APIClient.shared.moveConversationToFolder(
-        conversationId: conversationId, folderId: folderId)
-
-      var mutation = pendingConversationMutations[conversationId] ?? ConversationPendingMutation()
-      mutation.setFolderId(folderId)
-      pendingConversationMutations[conversationId] = mutation
-
-      // Sync to local SQLite cache so reload doesn't revert the change. A cache write failure
-      // should not roll back the already-successful backend move or block UI reconciliation.
-      do {
-        try await TranscriptionStorage.shared.updateFolderByBackendId(
-          conversationId, folderId: folderId)
-      } catch {
-        logError("Folders: Failed to update local folder cache", error: error)
-      }
-
-      // Update local state
-      if conversations.contains(where: { $0.id == conversationId }) {
-        // Reload to get updated conversation
-        await loadConversations()
-      }
-      log("Folders: Moved conversation \(conversationId) to folder \(folderId ?? "none")")
+      try await conversationRepository.moveToFolder(id: conversationId, folderId: folderId)
     } catch {
       logError("Folders: Failed to move conversation to folder", error: error)
     }
   }
 
-  /// Delete a conversation locally (after successful API call)
-  func deleteConversationLocally(_ conversationId: String) {
-    withAnimation {
-      conversations.removeAll { $0.id == conversationId }
-    }
-  }
-
-  /// Update a conversation title locally after a successful mutation.
-  func updateConversationTitle(_ conversationId: String, title: String) {
-    var mutation = pendingConversationMutations[conversationId] ?? ConversationPendingMutation()
-    mutation.setTitle(title)
-    pendingConversationMutations[conversationId] = mutation
-
-    if let index = conversations.firstIndex(where: { $0.id == conversationId }) {
-      conversations[index].structured.title = title
-    }
-  }
-
   // MARK: - People (Speaker Profiles)
 
-  /// Fetches all people from the OMI API
   func fetchPeople() async {
     do {
-      let fetchedPeople = try await APIClient.shared.getPeople()
-      people = fetchedPeople
-      log("People: Loaded \(fetchedPeople.count) people")
+      people = try await APIClient.shared.getPeople()
     } catch {
       logError("People: Failed to load", error: error)
     }
   }
 
-  /// Creates a new person and adds to local cache
   func createPerson(name: String) async -> Person? {
     do {
       let person = try await APIClient.shared.createPerson(name: name)
       people.append(person)
-      log("People: Created person '\(name)' with id \(person.id)")
       return person
     } catch {
       logError("People: Failed to create person", error: error)
@@ -461,7 +127,6 @@ extension AppState {
     }
   }
 
-  /// Assigns segments to a person or user via bulk API
   func assignSpeakerToSegments(
     conversationId: String,
     segmentIds: [String],
@@ -475,42 +140,17 @@ extension AppState {
         isUser: isUser,
         personId: personId
       )
-      log("People: Assigned \(segmentIds.count) segments in conversation \(conversationId)")
-      // Update in-memory conversations list so the prop is fresh on next open
-      let idSet = Set(segmentIds)
-      if let idx = conversations.firstIndex(where: { $0.id == conversationId }) {
-        for segIdx in conversations[idx].transcriptSegments.indices
-          where idSet.contains(conversations[idx].transcriptSegments[segIdx].id) {
-          let old = conversations[idx].transcriptSegments[segIdx]
-          conversations[idx].transcriptSegments[segIdx] = TranscriptSegment(
-            id: old.id,
-            backendId: old.backendId,
-            text: old.text,
-            speaker: old.speaker,
-            isUser: isUser,
-            personId: isUser ? nil : personId,
-            start: old.start,
-            end: old.end,
-            translations: old.translations
-          )
-        }
-      }
-      // Also update local SQLite cache so changes persist across app restarts
       try? await TranscriptionStorage.shared.updateSegmentSpeakerAssignment(
         backendConversationId: conversationId,
         segmentIds: segmentIds,
         personId: personId,
         isUser: isUser
       )
+      await conversationRepository.loadDetail(id: conversationId)
       return true
     } catch {
       logError("People: Failed to assign segments", error: error)
       return false
     }
   }
-
-  // MARK: - Backend Segment Handling
-
-  /// Handle incoming transcript segments from Python backend `/v4/listen`.
-  /// Backend sends pre-merged segments with speaker attribution — no client-side word merging needed.
 }

--- a/desktop/macos/Desktop/Sources/ConversationReconciliationPolicy.swift
+++ b/desktop/macos/Desktop/Sources/ConversationReconciliationPolicy.swift
@@ -8,7 +8,7 @@ import Foundation
 ///
 /// Each field carries its own `recordedAt` so that a later star or folder change
 /// does not accidentally refresh the TTL of an older title overlay (and vice-versa).
-struct ConversationPendingMutation: Equatable {
+struct ConversationPendingMutation: Codable, Equatable, Sendable {
   var title: String?
   var starred: Bool?
   var titleRecordedAt: Date?
@@ -71,6 +71,23 @@ struct ConversationPendingMutation: Equatable {
       folderId = nil
       hasFolderIdMutation = false
       folderIdRecordedAt = nil
+    }
+  }
+
+  mutating func clearAcknowledged(_ value: ConversationMutationValue) {
+    switch value {
+    case .title(let acknowledged) where title == acknowledged:
+      title = nil
+      titleRecordedAt = nil
+    case .starred(let acknowledged) where starred == acknowledged:
+      starred = nil
+      starredRecordedAt = nil
+    case .folder(let acknowledged) where hasFolderIdMutation && folderId == acknowledged:
+      folderId = nil
+      hasFolderIdMutation = false
+      folderIdRecordedAt = nil
+    default:
+      break
     }
   }
 }
@@ -162,7 +179,9 @@ enum ConversationReconciliationPolicy {
       starred: mutation.starred ?? serverConversation.starred,
       folderId: mutation.hasFolderIdMutation ? mutation.folderId : serverConversation.folderId,
       inputDeviceName: serverConversation.inputDeviceName,
-      deferred: serverConversation.deferred
+      deferred: serverConversation.deferred,
+      updatedAt: serverConversation.updatedAt,
+      revision: serverConversation.revision
     )
   }
 

--- a/desktop/macos/Desktop/Sources/Conversations/ConversationCacheStorage.swift
+++ b/desktop/macos/Desktop/Sources/Conversations/ConversationCacheStorage.swift
@@ -555,7 +555,27 @@ actor ConversationCacheStorage: ConversationCachePersisting {
 
   private static func decoder() -> JSONDecoder {
     let decoder = JSONDecoder()
-    decoder.dateDecodingStrategy = .iso8601
+    decoder.dateDecodingStrategy = .custom { decoder in
+      let container = try decoder.singleValueContainer()
+      let value = try container.decode(String.self)
+
+      let fractionalFormatter = ISO8601DateFormatter()
+      fractionalFormatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+      if let date = fractionalFormatter.date(from: value) {
+        return date
+      }
+
+      let formatter = ISO8601DateFormatter()
+      formatter.formatOptions = [.withInternetDateTime]
+      if let date = formatter.date(from: value) {
+        return date
+      }
+
+      throw DecodingError.dataCorruptedError(
+        in: container,
+        debugDescription: "Expected an ISO 8601 date with optional fractional seconds."
+      )
+    }
     return decoder
   }
 }

--- a/desktop/macos/Desktop/Sources/Conversations/ConversationCacheStorage.swift
+++ b/desktop/macos/Desktop/Sources/Conversations/ConversationCacheStorage.swift
@@ -1,0 +1,499 @@
+import Foundation
+import GRDB
+
+struct ConversationCompleteness: OptionSet, Codable, Equatable, Sendable {
+  let rawValue: Int
+
+  static let list = ConversationCompleteness(rawValue: 1 << 0)
+  static let detail = ConversationCompleteness(rawValue: 1 << 1)
+  static let transcript = ConversationCompleteness(rawValue: 1 << 2)
+}
+
+struct ConversationQuery: Equatable, Sendable {
+  let showStarredOnly: Bool
+  let selectedDate: Date?
+  let folderId: String?
+  let limit: Int
+
+  init(
+    showStarredOnly: Bool = false,
+    selectedDate: Date? = nil,
+    folderId: String? = nil,
+    limit: Int = 50
+  ) {
+    self.showStarredOnly = showStarredOnly
+    self.selectedDate = selectedDate
+    self.folderId = folderId
+    self.limit = limit
+  }
+
+  var key: String {
+    let day = selectedDate.map { Calendar.current.startOfDay(for: $0).timeIntervalSince1970.description } ?? "all"
+    return "starred=\(showStarredOnly);day=\(day);folder=\(folderId ?? "all");limit=\(limit)"
+  }
+}
+
+struct ConversationCacheEntry: Equatable, Sendable {
+  let conversation: ServerConversation
+  let completeness: ConversationCompleteness
+  let cacheWrittenAt: Date
+  let listFetchedAt: Date?
+  let detailFetchedAt: Date?
+  let transcriptFetchedAt: Date?
+
+  init(
+    conversation: ServerConversation,
+    completeness: ConversationCompleteness,
+    cacheWrittenAt: Date,
+    listFetchedAt: Date? = nil,
+    detailFetchedAt: Date? = nil,
+    transcriptFetchedAt: Date? = nil
+  ) {
+    self.conversation = conversation
+    self.completeness = completeness
+    self.cacheWrittenAt = cacheWrittenAt
+    self.listFetchedAt = listFetchedAt ?? (completeness.contains(.list) ? cacheWrittenAt : nil)
+    self.detailFetchedAt = detailFetchedAt ?? (completeness.contains(.detail) ? cacheWrittenAt : nil)
+    self.transcriptFetchedAt = transcriptFetchedAt ?? (completeness.contains(.transcript) ? cacheWrittenAt : nil)
+  }
+}
+
+protocol ConversationCachePersisting: Sendable {
+  func load(query: ConversationQuery, accountId: String) async throws -> [ConversationCacheEntry]
+  func load(id: String, accountId: String) async throws -> ConversationCacheEntry?
+  func isEmpty(accountId: String) async throws -> Bool
+  func applyServerSnapshot(
+    _ conversations: [ServerConversation],
+    query: ConversationQuery,
+    fetchedAt: Date,
+    accountId: String
+  ) async throws
+  func upsertServerConversation(
+    _ conversation: ServerConversation,
+    completeness: ConversationCompleteness,
+    fetchedAt: Date,
+    accountId: String,
+    preserveProjectionFreshness: Bool
+  ) async throws
+  func remove(id: String, accountId: String) async throws
+  func loadPendingMutations(accountId: String) async throws -> [String: ConversationPendingMutation]
+  func savePendingMutation(
+    _ mutation: ConversationPendingMutation?,
+    conversationId: String,
+    accountId: String
+  ) async throws
+  func invalidateCache() async
+}
+
+private enum ConversationCacheScopeError: Error {
+  case accountChanged
+}
+
+private struct ConversationCacheRecord: Codable, FetchableRecord, PersistableRecord {
+  static let databaseTableName = "conversation_cache"
+
+  let id: String
+  let payload: Data
+  let serverRevision: String?
+  let serverUpdatedAt: Date?
+  let cacheWrittenAt: Date
+  let listFetchedAt: Date?
+  let detailFetchedAt: Date?
+  let transcriptFetchedAt: Date?
+  let completeness: Int
+  let createdAt: Date
+  let starred: Bool
+  let folderId: String?
+  let status: String
+  let discarded: Bool
+  let deleted: Bool
+}
+
+private struct ConversationQuerySnapshotRecord: Codable, FetchableRecord, PersistableRecord {
+  static let databaseTableName = "conversation_query_snapshots"
+
+  let queryKey: String
+  let conversationIdsJson: String
+  let fetchedAt: Date
+}
+
+private struct ConversationPendingMutationRecord: Codable, FetchableRecord, PersistableRecord {
+  static let databaseTableName = "conversation_pending_mutations"
+
+  let conversationId: String
+  let payload: Data
+  let updatedAt: Date
+}
+
+enum ConversationProjectionMerge {
+  static func isProvablyOlder(incoming: ServerConversation, than cached: ServerConversation) -> Bool {
+    guard let incomingUpdatedAt = incoming.updatedAt, let cachedUpdatedAt = cached.updatedAt else {
+      return false
+    }
+    return incomingUpdatedAt < cachedUpdatedAt
+  }
+
+  static func merge(
+    incoming: ServerConversation,
+    incomingCompleteness: ConversationCompleteness,
+    cached: ConversationCacheEntry?,
+    fetchedAt: Date = Date()
+  ) -> ConversationCacheEntry {
+    guard let cached else {
+      return ConversationCacheEntry(
+        conversation: incoming,
+        completeness: incomingCompleteness,
+        cacheWrittenAt: fetchedAt
+      )
+    }
+
+    // Known server ordering wins first: a delayed revocation must not undo a
+    // newer unlock/restore. An unversioned revocation remains fail-closed.
+    if isProvablyOlder(incoming: incoming, than: cached.conversation) {
+      return cached
+    }
+
+    // A current or unversioned lock/discard/delete response revokes locally
+    // cached detail. Never resurrect sensitive fields from an older projection.
+    if incoming.isLocked || incoming.deleted || incoming.discarded {
+      return ConversationCacheEntry(
+        conversation: incoming,
+        completeness: incomingCompleteness,
+        cacheWrittenAt: fetchedAt
+      )
+    }
+
+    if incoming.updatedAt == nil, cached.conversation.updatedAt != nil {
+      return cached
+    }
+
+    let mergedCompleteness = cached.completeness.union(incomingCompleteness)
+    guard !incomingCompleteness.contains(.detail), cached.completeness.contains(.detail) else {
+      return ConversationCacheEntry(
+        conversation: incoming,
+        completeness: mergedCompleteness,
+        cacheWrittenAt: fetchedAt,
+        listFetchedAt: incomingCompleteness.contains(.list) ? fetchedAt : cached.listFetchedAt,
+        detailFetchedAt: incomingCompleteness.contains(.detail) ? fetchedAt : cached.detailFetchedAt,
+        transcriptFetchedAt: incomingCompleteness.contains(.transcript) ? fetchedAt : cached.transcriptFetchedAt
+      )
+    }
+
+    let cachedConversation = cached.conversation
+    let preserveTranscript = !incomingCompleteness.contains(.transcript)
+      && cached.completeness.contains(.transcript)
+    let structured = Structured(
+      title: incoming.structured.title,
+      overview: incoming.structured.overview,
+      emoji: incoming.structured.emoji,
+      category: incoming.structured.category,
+      actionItems: cachedConversation.structured.actionItems,
+      events: cachedConversation.structured.events
+    )
+
+    let merged = ServerConversation(
+      id: incoming.id,
+      createdAt: incoming.createdAt,
+      startedAt: incoming.startedAt,
+      finishedAt: incoming.finishedAt,
+      structured: structured,
+      transcriptSegments: preserveTranscript
+        ? cachedConversation.transcriptSegments : incoming.transcriptSegments,
+      transcriptSegmentsIncluded: preserveTranscript
+        ? cachedConversation.transcriptSegmentsIncluded : incoming.transcriptSegmentsIncluded,
+      geolocation: cachedConversation.geolocation,
+      photos: cachedConversation.photos,
+      appsResults: cachedConversation.appsResults,
+      source: incoming.source,
+      language: incoming.language,
+      status: incoming.status,
+      discarded: incoming.discarded,
+      deleted: incoming.deleted,
+      isLocked: incoming.isLocked,
+      starred: incoming.starred,
+      folderId: incoming.folderId,
+      inputDeviceName: incoming.inputDeviceName,
+      deferred: incoming.deferred,
+      updatedAt: incoming.updatedAt,
+      revision: incoming.revision
+    )
+    return ConversationCacheEntry(
+      conversation: merged,
+      completeness: mergedCompleteness,
+      cacheWrittenAt: fetchedAt,
+      listFetchedAt: incomingCompleteness.contains(.list) ? fetchedAt : cached.listFetchedAt,
+      detailFetchedAt: incomingCompleteness.contains(.detail) ? fetchedAt : cached.detailFetchedAt,
+      transcriptFetchedAt: incomingCompleteness.contains(.transcript) ? fetchedAt : cached.transcriptFetchedAt
+    )
+  }
+}
+
+actor ConversationCacheStorage: ConversationCachePersisting {
+  static let shared = ConversationCacheStorage()
+
+  private init() {}
+
+  func invalidateCache() async {}
+
+  private func db(accountId: String) async throws -> DatabasePool {
+    // RewindDatabase owns account scoping. Resolve its current pool on every
+    // operation so a delayed sign-out task can never leave this actor holding
+    // the previous account's DatabasePool.
+    guard Self.currentAccountId == accountId else {
+      throw ConversationCacheScopeError.accountChanged
+    }
+    try await RewindDatabase.shared.initialize()
+    guard Self.currentAccountId == accountId else {
+      throw ConversationCacheScopeError.accountChanged
+    }
+    guard let queue = await RewindDatabase.shared.getDatabaseQueue() else {
+      throw TranscriptionStorageError.databaseNotInitialized
+    }
+    return queue
+  }
+
+  private static var currentAccountId: String {
+    RewindDatabase.currentUserId ?? "anonymous"
+  }
+
+  func isEmpty(accountId: String) async throws -> Bool {
+    let queue = try await db(accountId: accountId)
+    return try await queue.read { db in
+      try ConversationCacheRecord.fetchCount(db) == 0
+    }
+  }
+
+  func load(query: ConversationQuery, accountId: String) async throws -> [ConversationCacheEntry] {
+    let queue = try await db(accountId: accountId)
+    let records = try await queue.read { db -> [ConversationCacheRecord] in
+      if let snapshot = try ConversationQuerySnapshotRecord.fetchOne(db, key: query.key),
+         let data = snapshot.conversationIdsJson.data(using: .utf8),
+         let ids = try? JSONDecoder().decode([String].self, from: data) {
+        let byId = Dictionary(
+          uniqueKeysWithValues: try ConversationCacheRecord
+            .filter(ids.contains(Column("id")))
+            .fetchAll(db)
+            .map { ($0.id, $0) }
+        )
+        return ids.compactMap { byId[$0] }.filter { Self.matches($0, query: query) }
+      }
+
+      var request = ConversationCacheRecord
+        .filter(Column("deleted") == false)
+        .filter(Column("discarded") == false)
+      if query.showStarredOnly {
+        request = request.filter(Column("starred") == true)
+      }
+      if let folderId = query.folderId {
+        request = request.filter(Column("folderId") == folderId)
+      }
+      if let selectedDate = query.selectedDate {
+        let start = Calendar.current.startOfDay(for: selectedDate)
+        let end = Calendar.current.date(byAdding: .day, value: 1, to: start)!
+        request = request
+          .filter(Column("createdAt") >= start)
+          .filter(Column("createdAt") < end)
+      }
+      return try request.order(Column("createdAt").desc).limit(query.limit).fetchAll(db)
+    }
+    return try records.map(Self.decode)
+  }
+
+  func load(id: String, accountId: String) async throws -> ConversationCacheEntry? {
+    let queue = try await db(accountId: accountId)
+    guard let record = try await queue.read({ db in
+      try ConversationCacheRecord.fetchOne(db, key: id)
+    }) else { return nil }
+    return try Self.decode(record)
+  }
+
+  func applyServerSnapshot(
+    _ conversations: [ServerConversation],
+    query: ConversationQuery,
+    fetchedAt: Date,
+    accountId: String
+  ) async throws {
+    let queue = try await db(accountId: accountId)
+    let idsData = try JSONEncoder().encode(conversations.map(\.id))
+    let idsJson = String(decoding: idsData, as: UTF8.self)
+    var records: [ConversationCacheRecord] = []
+    for conversation in conversations {
+      let incomingCompleteness = Self.listCompleteness(for: conversation)
+      let cachedRecord = try await queue.read { db in
+        try ConversationCacheRecord.fetchOne(db, key: conversation.id)
+      }
+      let cached = try cachedRecord.map(Self.decode)
+      let merged = ConversationProjectionMerge.merge(
+        incoming: conversation,
+        incomingCompleteness: incomingCompleteness,
+        cached: cached,
+        fetchedAt: fetchedAt
+      )
+      records.append(try Self.record(from: merged, writtenAt: fetchedAt))
+    }
+    let recordsToSave = records
+    try await queue.write { db in
+      for record in recordsToSave {
+        try record.save(db)
+      }
+      try ConversationQuerySnapshotRecord(
+        queryKey: query.key,
+        conversationIdsJson: idsJson,
+        fetchedAt: fetchedAt
+      ).save(db)
+    }
+  }
+
+  func upsertServerConversation(
+    _ conversation: ServerConversation,
+    completeness: ConversationCompleteness,
+    fetchedAt: Date,
+    accountId: String,
+    preserveProjectionFreshness: Bool = false
+  ) async throws {
+    let queue = try await db(accountId: accountId)
+    let cachedRecord = try await queue.read { db in
+      try ConversationCacheRecord.fetchOne(db, key: conversation.id)
+    }
+    let cached = try cachedRecord.map(Self.decode)
+    var merged = ConversationProjectionMerge.merge(
+      incoming: conversation,
+      incomingCompleteness: completeness,
+      cached: cached,
+      fetchedAt: fetchedAt
+    )
+    if preserveProjectionFreshness, let cached {
+      merged = ConversationCacheEntry(
+        conversation: merged.conversation,
+        completeness: merged.completeness,
+        cacheWrittenAt: fetchedAt,
+        listFetchedAt: cached.listFetchedAt,
+        detailFetchedAt: cached.detailFetchedAt,
+        transcriptFetchedAt: cached.transcriptFetchedAt
+      )
+    }
+    let updated = try Self.record(from: merged, writtenAt: fetchedAt)
+    try await queue.write { db in
+      try updated.save(db)
+    }
+  }
+
+  func remove(id: String, accountId: String) async throws {
+    let queue = try await db(accountId: accountId)
+    try await queue.write { db in
+      _ = try ConversationCacheRecord.deleteOne(db, key: id)
+      let snapshots = try ConversationQuerySnapshotRecord.fetchAll(db)
+      for snapshot in snapshots {
+        guard let data = snapshot.conversationIdsJson.data(using: .utf8),
+              var ids = try? JSONDecoder().decode([String].self, from: data),
+              ids.contains(id)
+        else { continue }
+        ids.removeAll { $0 == id }
+        let encoded = try JSONEncoder().encode(ids)
+        try ConversationQuerySnapshotRecord(
+          queryKey: snapshot.queryKey,
+          conversationIdsJson: String(decoding: encoded, as: UTF8.self),
+          fetchedAt: snapshot.fetchedAt
+        ).save(db)
+      }
+    }
+  }
+
+  func loadPendingMutations(accountId: String) async throws -> [String: ConversationPendingMutation] {
+    let queue = try await db(accountId: accountId)
+    let records = try await queue.read { db in
+      try ConversationPendingMutationRecord.fetchAll(db)
+    }
+    return Dictionary(uniqueKeysWithValues: try records.map { record in
+      (record.conversationId, try Self.decoder().decode(ConversationPendingMutation.self, from: record.payload))
+    })
+  }
+
+  func savePendingMutation(
+    _ mutation: ConversationPendingMutation?,
+    conversationId: String,
+    accountId: String
+  ) async throws {
+    let queue = try await db(accountId: accountId)
+    let payload = try mutation.map { try Self.encoder().encode($0) }
+    try await queue.write { db in
+      guard let mutation, !mutation.isEmpty, let payload else {
+        _ = try ConversationPendingMutationRecord.deleteOne(db, key: conversationId)
+        return
+      }
+      try ConversationPendingMutationRecord(
+        conversationId: conversationId,
+        payload: payload,
+        updatedAt: Date()
+      ).save(db)
+    }
+  }
+
+  private static func listCompleteness(for conversation: ServerConversation) -> ConversationCompleteness {
+    var completeness: ConversationCompleteness = [.list]
+    if conversation.transcriptSegmentsIncluded {
+      completeness.insert(.transcript)
+    }
+    return completeness
+  }
+
+  private static func matches(_ record: ConversationCacheRecord, query: ConversationQuery) -> Bool {
+    guard !record.deleted, !record.discarded else { return false }
+    if query.showStarredOnly, !record.starred { return false }
+    if let folderId = query.folderId, record.folderId != folderId { return false }
+    if let selectedDate = query.selectedDate {
+      let start = Calendar.current.startOfDay(for: selectedDate)
+      guard let end = Calendar.current.date(byAdding: .day, value: 1, to: start),
+            record.createdAt >= start, record.createdAt < end
+      else { return false }
+    }
+    return true
+  }
+
+  private static func decode(_ record: ConversationCacheRecord) throws -> ConversationCacheEntry {
+    var conversation = try decoder().decode(ServerConversation.self, from: record.payload)
+    let completeness = ConversationCompleteness(rawValue: record.completeness)
+    conversation.transcriptSegmentsIncluded = completeness.contains(.transcript)
+    return ConversationCacheEntry(
+      conversation: conversation,
+      completeness: completeness,
+      cacheWrittenAt: record.cacheWrittenAt,
+      listFetchedAt: record.listFetchedAt,
+      detailFetchedAt: record.detailFetchedAt,
+      transcriptFetchedAt: record.transcriptFetchedAt
+    )
+  }
+
+  private static func record(from entry: ConversationCacheEntry, writtenAt: Date) throws -> ConversationCacheRecord {
+    let conversation = entry.conversation
+    return ConversationCacheRecord(
+      id: conversation.id,
+      payload: try encoder().encode(conversation),
+      serverRevision: conversation.revision,
+      serverUpdatedAt: conversation.updatedAt,
+      cacheWrittenAt: writtenAt,
+      listFetchedAt: entry.listFetchedAt,
+      detailFetchedAt: entry.detailFetchedAt,
+      transcriptFetchedAt: entry.transcriptFetchedAt,
+      completeness: entry.completeness.rawValue,
+      createdAt: conversation.createdAt,
+      starred: conversation.starred,
+      folderId: conversation.folderId,
+      status: conversation.status.rawValue,
+      discarded: conversation.discarded,
+      deleted: conversation.deleted
+    )
+  }
+
+  private static func encoder() -> JSONEncoder {
+    let encoder = JSONEncoder()
+    encoder.dateEncodingStrategy = .iso8601
+    return encoder
+  }
+
+  private static func decoder() -> JSONDecoder {
+    let decoder = JSONDecoder()
+    decoder.dateDecodingStrategy = .iso8601
+    return decoder
+  }
+}

--- a/desktop/macos/Desktop/Sources/Conversations/ConversationCacheStorage.swift
+++ b/desktop/macos/Desktop/Sources/Conversations/ConversationCacheStorage.swift
@@ -96,6 +96,7 @@ private struct ConversationCacheRecord: Codable, FetchableRecord, PersistableRec
   let payload: Data
   let serverRevision: String?
   let serverUpdatedAt: Date?
+  let serverUpdatedAtEpoch: Double?
   let cacheWrittenAt: Date
   let listFetchedAt: Date?
   let detailFetchedAt: Date?
@@ -231,7 +232,31 @@ enum ConversationProjectionMerge {
 actor ConversationCacheStorage: ConversationCachePersisting {
   static let shared = ConversationCacheStorage()
 
-  private init() {}
+  private let currentAccountIdProvider: @Sendable () async -> String
+  private let initializeDatabase: @Sendable () async throws -> Void
+  private let databaseQueueProvider: @Sendable () async -> DatabasePool?
+  private let beforeMergeTransaction: @Sendable (String) -> Void
+  private let afterCachedRecordRead: @Sendable (String) -> Void
+
+  init(
+    currentAccountIdProvider: @escaping @Sendable () async -> String = {
+      RewindDatabase.currentUserId ?? "anonymous"
+    },
+    initializeDatabase: @escaping @Sendable () async throws -> Void = {
+      try await RewindDatabase.shared.initialize()
+    },
+    databaseQueueProvider: @escaping @Sendable () async -> DatabasePool? = {
+      RewindDatabase.shared.getDatabaseQueue()
+    },
+    beforeMergeTransaction: @escaping @Sendable (String) -> Void = { _ in },
+    afterCachedRecordRead: @escaping @Sendable (String) -> Void = { _ in }
+  ) {
+    self.currentAccountIdProvider = currentAccountIdProvider
+    self.initializeDatabase = initializeDatabase
+    self.databaseQueueProvider = databaseQueueProvider
+    self.beforeMergeTransaction = beforeMergeTransaction
+    self.afterCachedRecordRead = afterCachedRecordRead
+  }
 
   func invalidateCache() async {}
 
@@ -239,21 +264,20 @@ actor ConversationCacheStorage: ConversationCachePersisting {
     // RewindDatabase owns account scoping. Resolve its current pool on every
     // operation so a delayed sign-out task can never leave this actor holding
     // the previous account's DatabasePool.
-    guard Self.currentAccountId == accountId else {
+    guard await currentAccountIdProvider() == accountId else {
       throw ConversationCacheScopeError.accountChanged
     }
-    try await RewindDatabase.shared.initialize()
-    guard Self.currentAccountId == accountId else {
+    try await initializeDatabase()
+    guard await currentAccountIdProvider() == accountId else {
       throw ConversationCacheScopeError.accountChanged
     }
-    guard let queue = await RewindDatabase.shared.getDatabaseQueue() else {
+    guard let queue = await databaseQueueProvider() else {
       throw TranscriptionStorageError.databaseNotInitialized
     }
+    guard await currentAccountIdProvider() == accountId else {
+      throw ConversationCacheScopeError.accountChanged
+    }
     return queue
-  }
-
-  private static var currentAccountId: String {
-    RewindDatabase.currentUserId ?? "anonymous"
   }
 
   func isEmpty(accountId: String) async throws -> Bool {
@@ -316,25 +340,21 @@ actor ConversationCacheStorage: ConversationCachePersisting {
     let queue = try await db(accountId: accountId)
     let idsData = try JSONEncoder().encode(conversations.map(\.id))
     let idsJson = String(decoding: idsData, as: UTF8.self)
-    var records: [ConversationCacheRecord] = []
-    for conversation in conversations {
-      let incomingCompleteness = Self.listCompleteness(for: conversation)
-      let cachedRecord = try await queue.read { db in
-        try ConversationCacheRecord.fetchOne(db, key: conversation.id)
-      }
-      let cached = try cachedRecord.map(Self.decode)
-      let merged = ConversationProjectionMerge.merge(
-        incoming: conversation,
-        incomingCompleteness: incomingCompleteness,
-        cached: cached,
-        fetchedAt: fetchedAt
-      )
-      records.append(try Self.record(from: merged, writtenAt: fetchedAt))
-    }
-    let recordsToSave = records
+    let beforeMergeTransaction = self.beforeMergeTransaction
+    let afterCachedRecordRead = self.afterCachedRecordRead
+    conversations.forEach { beforeMergeTransaction($0.id) }
     try await queue.write { db in
-      for record in recordsToSave {
-        try record.save(db)
+      for conversation in conversations {
+        let cachedRecord = try ConversationCacheRecord.fetchOne(db, key: conversation.id)
+        afterCachedRecordRead(conversation.id)
+        let cached = try cachedRecord.map(Self.decode)
+        let merged = ConversationProjectionMerge.merge(
+          incoming: conversation,
+          incomingCompleteness: Self.listCompleteness(for: conversation),
+          cached: cached,
+          fetchedAt: fetchedAt
+        )
+        try Self.record(from: merged, writtenAt: fetchedAt).save(db)
       }
       try ConversationQuerySnapshotRecord(
         queryKey: query.key,
@@ -352,29 +372,29 @@ actor ConversationCacheStorage: ConversationCachePersisting {
     preserveProjectionFreshness: Bool = false
   ) async throws {
     let queue = try await db(accountId: accountId)
-    let cachedRecord = try await queue.read { db in
-      try ConversationCacheRecord.fetchOne(db, key: conversation.id)
-    }
-    let cached = try cachedRecord.map(Self.decode)
-    var merged = ConversationProjectionMerge.merge(
-      incoming: conversation,
-      incomingCompleteness: completeness,
-      cached: cached,
-      fetchedAt: fetchedAt
-    )
-    if preserveProjectionFreshness, let cached {
-      merged = ConversationCacheEntry(
-        conversation: merged.conversation,
-        completeness: merged.completeness,
-        cacheWrittenAt: fetchedAt,
-        listFetchedAt: cached.listFetchedAt,
-        detailFetchedAt: cached.detailFetchedAt,
-        transcriptFetchedAt: cached.transcriptFetchedAt
-      )
-    }
-    let updated = try Self.record(from: merged, writtenAt: fetchedAt)
+    beforeMergeTransaction(conversation.id)
+    let afterCachedRecordRead = self.afterCachedRecordRead
     try await queue.write { db in
-      try updated.save(db)
+      let cachedRecord = try ConversationCacheRecord.fetchOne(db, key: conversation.id)
+      afterCachedRecordRead(conversation.id)
+      let cached = try cachedRecord.map(Self.decode)
+      var merged = ConversationProjectionMerge.merge(
+        incoming: conversation,
+        incomingCompleteness: completeness,
+        cached: cached,
+        fetchedAt: fetchedAt
+      )
+      if preserveProjectionFreshness, let cached {
+        merged = ConversationCacheEntry(
+          conversation: merged.conversation,
+          completeness: merged.completeness,
+          cacheWrittenAt: fetchedAt,
+          listFetchedAt: cached.listFetchedAt,
+          detailFetchedAt: cached.detailFetchedAt,
+          transcriptFetchedAt: cached.transcriptFetchedAt
+        )
+      }
+      try Self.record(from: merged, writtenAt: fetchedAt).save(db)
     }
   }
 
@@ -452,6 +472,11 @@ actor ConversationCacheStorage: ConversationCachePersisting {
 
   private static func decode(_ record: ConversationCacheRecord) throws -> ConversationCacheEntry {
     var conversation = try decoder().decode(ServerConversation.self, from: record.payload)
+    conversation = restoringServerVersion(
+      conversation,
+      updatedAt: record.serverUpdatedAtEpoch.map { Date(timeIntervalSince1970: $0) } ?? record.serverUpdatedAt,
+      revision: record.serverRevision
+    )
     let completeness = ConversationCompleteness(rawValue: record.completeness)
     conversation.transcriptSegmentsIncluded = completeness.contains(.transcript)
     return ConversationCacheEntry(
@@ -470,7 +495,8 @@ actor ConversationCacheStorage: ConversationCachePersisting {
       id: conversation.id,
       payload: try encoder().encode(conversation),
       serverRevision: conversation.revision,
-      serverUpdatedAt: conversation.updatedAt,
+      serverUpdatedAt: nil,
+      serverUpdatedAtEpoch: conversation.updatedAt?.timeIntervalSince1970,
       cacheWrittenAt: writtenAt,
       listFetchedAt: entry.listFetchedAt,
       detailFetchedAt: entry.detailFetchedAt,
@@ -485,9 +511,45 @@ actor ConversationCacheStorage: ConversationCachePersisting {
     )
   }
 
+  private static func restoringServerVersion(
+    _ conversation: ServerConversation,
+    updatedAt: Date?,
+    revision: String?
+  ) -> ServerConversation {
+    ServerConversation(
+      id: conversation.id,
+      createdAt: conversation.createdAt,
+      startedAt: conversation.startedAt,
+      finishedAt: conversation.finishedAt,
+      structured: conversation.structured,
+      transcriptSegments: conversation.transcriptSegments,
+      transcriptSegmentsIncluded: conversation.transcriptSegmentsIncluded,
+      geolocation: conversation.geolocation,
+      photos: conversation.photos,
+      appsResults: conversation.appsResults,
+      source: conversation.source,
+      language: conversation.language,
+      status: conversation.status,
+      discarded: conversation.discarded,
+      deleted: conversation.deleted,
+      isLocked: conversation.isLocked,
+      starred: conversation.starred,
+      folderId: conversation.folderId,
+      inputDeviceName: conversation.inputDeviceName,
+      deferred: conversation.deferred,
+      updatedAt: updatedAt,
+      revision: revision
+    )
+  }
+
   private static func encoder() -> JSONEncoder {
     let encoder = JSONEncoder()
-    encoder.dateEncodingStrategy = .iso8601
+    encoder.dateEncodingStrategy = .custom { date, encoder in
+      let formatter = ISO8601DateFormatter()
+      formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+      var container = encoder.singleValueContainer()
+      try container.encode(formatter.string(from: date))
+    }
     return encoder
   }
 

--- a/desktop/macos/Desktop/Sources/Conversations/ConversationRepository.swift
+++ b/desktop/macos/Desktop/Sources/Conversations/ConversationRepository.swift
@@ -56,6 +56,16 @@ struct ConversationEntityMetadata: Sendable, Equatable {
   }
 }
 
+private enum MutationDrainWakeup {
+  case retry
+  case completed(Result<Bool, Error>)
+}
+
+private struct MutationDrainWaiter {
+  let value: ConversationMutationValue
+  let continuation: CheckedContinuation<MutationDrainWakeup, Never>
+}
+
 protocol ConversationRemoteServing: Sendable {
   func list(query: ConversationQuery) async throws -> [ServerConversation]
   func count(query: ConversationQuery) async throws -> Int
@@ -166,11 +176,15 @@ final class ConversationRepository: ObservableObject {
   private let cache: any ConversationCachePersisting
   private let now: @Sendable () -> Date
   private let accountIdProvider: @MainActor () -> String
+  private let onMutationWaiterRegistered: @MainActor (String, ConversationMutationValue) -> Void
   private var pendingMutations: [String: ConversationPendingMutation] = [:]
+  private var pendingMutationVersions: [String: UInt64] = [:]
   private var currentQuery = ConversationQuery()
+  private var activeQuerySnapshotIds: [String] = []
   private var generation: UInt64 = 0
   private var searchGeneration: UInt64 = 0
   private var mutationDrainTokens: [String: UUID] = [:]
+  private var mutationDrainWaiters: [String: [MutationDrainWaiter]] = [:]
   private var didAttemptLegacyMigration = false
   private let legacyMigrationEnabled: Bool
 
@@ -181,12 +195,14 @@ final class ConversationRepository: ObservableObject {
     accountIdProvider: @escaping @MainActor () -> String = {
       RewindDatabase.currentUserId ?? "anonymous"
     },
+    onMutationWaiterRegistered: @escaping @MainActor (String, ConversationMutationValue) -> Void = { _, _ in },
     legacyMigrationEnabled: Bool = true
   ) {
     self.remote = remote
     self.cache = cache
     self.now = now
     self.accountIdProvider = accountIdProvider
+    self.onMutationWaiterRegistered = onMutationWaiterRegistered
     self.legacyMigrationEnabled = legacyMigrationEnabled
   }
 
@@ -199,23 +215,40 @@ final class ConversationRepository: ObservableObject {
   }
 
   func seed(_ conversation: ServerConversation) {
-    if let existing = entitiesById[conversation.id],
-       let existingUpdatedAt = existing.updatedAt,
-       let incomingUpdatedAt = conversation.updatedAt,
-       existingUpdatedAt > incomingUpdatedAt {
-      return
-    }
-    entitiesById[conversation.id] = applyPending(to: conversation)
-    let completeness: ConversationCompleteness = conversation.transcriptSegmentsIncluded
+    let incomingCompleteness: ConversationCompleteness = conversation.transcriptSegmentsIncluded
       ? [.list, .detail, .transcript] : [.list]
     let seededAt = now()
+    let existingMetadata = metadataById[conversation.id]
+    let existingEntry = entitiesById[conversation.id].map { existing in
+      ConversationCacheEntry(
+        conversation: existing,
+        completeness: existingMetadata?.completeness ?? [.list],
+        cacheWrittenAt: existingMetadata?.fetchedAt ?? seededAt,
+        listFetchedAt: existingMetadata?.listFetchedAt,
+        detailFetchedAt: existingMetadata?.detailFetchedAt,
+        transcriptFetchedAt: existingMetadata?.transcriptFetchedAt
+      )
+    }
+    let merged = ConversationProjectionMerge.merge(
+      incoming: conversation,
+      incomingCompleteness: incomingCompleteness,
+      cached: existingEntry,
+      fetchedAt: seededAt
+    )
+    let displayed = applyPending(to: merged.conversation)
+    if let existing = entitiesById[conversation.id],
+       Self.hasIdenticalProjectionContent(existing, displayed),
+       existingMetadata?.completeness == merged.completeness {
+      return
+    }
+    entitiesById[conversation.id] = displayed
     metadataById[conversation.id] = ConversationEntityMetadata(
-      completeness: completeness,
-      source: .seeded,
-      fetchedAt: seededAt,
-      listFetchedAt: seededAt,
-      detailFetchedAt: completeness.contains(.detail) ? seededAt : nil,
-      transcriptFetchedAt: completeness.contains(.transcript) ? seededAt : nil,
+      completeness: merged.completeness,
+      source: existingMetadata?.source ?? .seeded,
+      fetchedAt: merged.cacheWrittenAt,
+      listFetchedAt: merged.listFetchedAt,
+      detailFetchedAt: merged.detailFetchedAt,
+      transcriptFetchedAt: merged.transcriptFetchedAt,
       syncState: pendingMutations[conversation.id] == nil ? .synced : .pending
     )
   }
@@ -231,11 +264,12 @@ final class ConversationRepository: ObservableObject {
     await migrateLegacyCacheIfNeeded(query: query, accountId: accountId, requestGeneration: requestGeneration)
 
     do {
+      let pendingVersions = pendingMutationVersions
       async let cachedTask = cache.load(query: query, accountId: accountId)
       async let pendingTask = cache.loadPendingMutations(accountId: accountId)
       let (cached, pending) = try await (cachedTask, pendingTask)
       guard requestGeneration == generation, accountId == accountIdProvider() else { return }
-      pendingMutations = pending
+      mergeLoadedPendingMutations(pending, versionsAtLoadStart: pendingVersions)
       publish(cached.map(\.conversation), ids: cached.map { $0.conversation.id })
       publishMetadata(cached, source: .cache)
       if !cached.isEmpty {
@@ -267,6 +301,7 @@ final class ConversationRepository: ObservableObject {
       guard requestGeneration == generation, query == currentQuery, accountId == accountIdProvider() else { return }
       publish(cached.map(\.conversation), ids: cached.map { $0.conversation.id })
       publishMetadata(cached, source: .server)
+      error = nil
 
       do {
         let count = try await countTask
@@ -301,6 +336,7 @@ final class ConversationRepository: ObservableObject {
         guard requestGeneration == generation, accountId == accountIdProvider() else { return }
         entitiesById[id] = applyPending(to: cached.conversation)
         metadataById[id] = metadata(for: cached, source: .cache)
+        reconcileVisibleMembership(for: id)
       }
     } catch {
       logError("ConversationRepository: cached detail load failed", error: error)
@@ -327,6 +363,7 @@ final class ConversationRepository: ObservableObject {
         guard requestGeneration == generation, accountId == accountIdProvider() else { return }
         metadataById[id] = metadata(for: entry, source: .server)
       }
+      reconcileVisibleMembership(for: id)
     } catch {
       guard requestGeneration == generation else { return }
       if case APIError.httpError(let statusCode, _) = error, statusCode == 404 {
@@ -334,6 +371,7 @@ final class ConversationRepository: ObservableObject {
         guard requestGeneration == generation, accountId == accountIdProvider() else { return }
         entitiesById.removeValue(forKey: id)
         metadataById.removeValue(forKey: id)
+        activeQuerySnapshotIds.removeAll { $0 == id }
         conversationIds.removeAll { $0 == id }
         searchResultIds.removeAll { $0 == id }
         return
@@ -359,6 +397,7 @@ final class ConversationRepository: ObservableObject {
           listFetchedAt: redactedAt,
           syncState: .synced
         )
+        reconcileVisibleMembership(for: id)
         return
       }
       logError("ConversationRepository: detail refresh failed", error: error)
@@ -422,43 +461,67 @@ final class ConversationRepository: ObservableObject {
   func updateTitle(id: String, title: String) async throws {
     let requestGeneration = generation
     let accountId = accountIdProvider()
-    var mutation = pendingMutations[id] ?? ConversationPendingMutation()
-    mutation.setTitle(title)
-    try await stage(
-      mutation: mutation,
-      conversationId: id,
-      accountId: accountId,
-      requestGeneration: requestGeneration
+    let value = ConversationMutationValue.title(title)
+    if !pendingMutation(value, matches: pendingMutations[id]) {
+      var mutation = pendingMutations[id] ?? ConversationPendingMutation()
+      mutation.setTitle(title)
+      try await stage(
+        mutation: mutation,
+        conversationId: id,
+        accountId: accountId,
+        requestGeneration: requestGeneration
+      )
+    }
+    _ = try await drainMutation(
+      id: id,
+      value: value,
+      requestGeneration: requestGeneration,
+      accountId: accountId
     )
-    try await drainMutations(id: id, requestGeneration: requestGeneration, accountId: accountId)
   }
 
   func updateStarred(id: String, starred: Bool) async throws {
     let requestGeneration = generation
     let accountId = accountIdProvider()
-    var mutation = pendingMutations[id] ?? ConversationPendingMutation()
-    mutation.setStarred(starred)
-    try await stage(
-      mutation: mutation,
-      conversationId: id,
-      accountId: accountId,
-      requestGeneration: requestGeneration
+    let value = ConversationMutationValue.starred(starred)
+    if !pendingMutation(value, matches: pendingMutations[id]) {
+      var mutation = pendingMutations[id] ?? ConversationPendingMutation()
+      mutation.setStarred(starred)
+      try await stage(
+        mutation: mutation,
+        conversationId: id,
+        accountId: accountId,
+        requestGeneration: requestGeneration
+      )
+    }
+    _ = try await drainMutation(
+      id: id,
+      value: value,
+      requestGeneration: requestGeneration,
+      accountId: accountId
     )
-    try await drainMutations(id: id, requestGeneration: requestGeneration, accountId: accountId)
   }
 
   func moveToFolder(id: String, folderId: String?) async throws {
     let requestGeneration = generation
     let accountId = accountIdProvider()
-    var mutation = pendingMutations[id] ?? ConversationPendingMutation()
-    mutation.setFolderId(folderId)
-    try await stage(
-      mutation: mutation,
-      conversationId: id,
-      accountId: accountId,
-      requestGeneration: requestGeneration
+    let value = ConversationMutationValue.folder(folderId)
+    if !pendingMutation(value, matches: pendingMutations[id]) {
+      var mutation = pendingMutations[id] ?? ConversationPendingMutation()
+      mutation.setFolderId(folderId)
+      try await stage(
+        mutation: mutation,
+        conversationId: id,
+        accountId: accountId,
+        requestGeneration: requestGeneration
+      )
+    }
+    _ = try await drainMutation(
+      id: id,
+      value: value,
+      requestGeneration: requestGeneration,
+      accountId: accountId
     )
-    try await drainMutations(id: id, requestGeneration: requestGeneration, accountId: accountId)
   }
 
   func delete(id: String) async throws {
@@ -470,9 +533,10 @@ final class ConversationRepository: ObservableObject {
         throw CancellationError()
       }
       try await cache.remove(id: id, accountId: accountId)
-      pendingMutations.removeValue(forKey: id)
+      setPendingMutation(nil, for: id)
       try await cache.savePendingMutation(nil, conversationId: id, accountId: accountId)
       entitiesById.removeValue(forKey: id)
+      activeQuerySnapshotIds.removeAll { $0 == id }
       conversationIds.removeAll { $0 == id }
       searchResultIds.removeAll { $0 == id }
     } catch {
@@ -503,7 +567,13 @@ final class ConversationRepository: ObservableObject {
     conversationIds = []
     searchResultIds = []
     pendingMutations = [:]
+    pendingMutationVersions = [:]
     mutationDrainTokens = [:]
+    mutationDrainWaiters.values.flatMap { $0 }.forEach {
+      $0.continuation.resume(returning: .completed(.failure(CancellationError())))
+    }
+    mutationDrainWaiters = [:]
+    activeQuerySnapshotIds = []
     totalCount = nil
     filteredCount = nil
     isLoading = false
@@ -525,7 +595,8 @@ final class ConversationRepository: ObservableObject {
     for conversation in conversations {
       entitiesById[conversation.id] = applyPending(to: conversation)
     }
-    conversationIds = ids.filter { id in
+    activeQuerySnapshotIds = ids
+    conversationIds = activeQuerySnapshotIds.filter { id in
       guard let conversation = entitiesById[id] else { return false }
       return matchesCurrentQuery(conversation)
     }
@@ -573,20 +644,9 @@ final class ConversationRepository: ObservableObject {
   }
 
   private func reconcileVisibleMembership(for id: String) {
-    guard let conversation = entitiesById[id] else {
-      conversationIds.removeAll { $0 == id }
-      return
-    }
-    if matchesCurrentQuery(conversation) {
-      if !conversationIds.contains(id) { conversationIds.append(id) }
-      conversationIds.sort {
-        (entitiesById[$0]?.createdAt ?? .distantPast) > (entitiesById[$1]?.createdAt ?? .distantPast)
-      }
-      if conversationIds.count > currentQuery.limit {
-        conversationIds = Array(conversationIds.prefix(currentQuery.limit))
-      }
-    } else {
-      conversationIds.removeAll { $0 == id }
+    conversationIds = activeQuerySnapshotIds.filter { candidateId in
+      guard let conversation = entitiesById[candidateId] else { return false }
+      return matchesCurrentQuery(conversation)
     }
   }
 
@@ -595,6 +655,29 @@ final class ConversationRepository: ObservableObject {
       mutation: pendingMutations[conversation.id],
       to: conversation
     )
+  }
+
+  private func setPendingMutation(_ mutation: ConversationPendingMutation?, for id: String) {
+    let normalized = mutation.flatMap { $0.isEmpty ? nil : $0 }
+    guard pendingMutations[id] != normalized else { return }
+    if let normalized {
+      pendingMutations[id] = normalized
+    } else {
+      pendingMutations.removeValue(forKey: id)
+    }
+    pendingMutationVersions[id, default: 0] &+= 1
+  }
+
+  private func mergeLoadedPendingMutations(
+    _ loaded: [String: ConversationPendingMutation],
+    versionsAtLoadStart: [String: UInt64]
+  ) {
+    let ids = Set(loaded.keys).union(pendingMutations.keys).union(versionsAtLoadStart.keys)
+    for id in ids where pendingMutationVersions[id, default: 0] == versionsAtLoadStart[id, default: 0] {
+      if pendingMutations[id] == nil, let loadedMutation = loaded[id] {
+        setPendingMutation(loadedMutation, for: id)
+      }
+    }
   }
 
   private func stage(
@@ -606,8 +689,17 @@ final class ConversationRepository: ObservableObject {
     guard requestGeneration == generation, accountId == accountIdProvider() else {
       throw CancellationError()
     }
-    pendingMutations[conversationId] = mutation
-    try await cache.savePendingMutation(mutation, conversationId: conversationId, accountId: accountId)
+    let previous = pendingMutations[conversationId]
+    setPendingMutation(mutation, for: conversationId)
+    let stagedVersion = pendingMutationVersions[conversationId, default: 0]
+    do {
+      try await cache.savePendingMutation(mutation, conversationId: conversationId, accountId: accountId)
+    } catch {
+      if pendingMutationVersions[conversationId, default: 0] == stagedVersion {
+        setPendingMutation(previous, for: conversationId)
+      }
+      throw error
+    }
     guard requestGeneration == generation, accountId == accountIdProvider() else {
       throw CancellationError()
     }
@@ -659,10 +751,10 @@ final class ConversationRepository: ObservableObject {
       mutation?.clearResolvedFields(matching: canonical)
     }
     if let mutation, !mutation.isEmpty {
-      pendingMutations[canonical.id] = mutation
+      setPendingMutation(mutation, for: canonical.id)
       try await cache.savePendingMutation(mutation, conversationId: canonical.id, accountId: accountId)
     } else {
-      pendingMutations.removeValue(forKey: canonical.id)
+      setPendingMutation(nil, for: canonical.id)
       try await cache.savePendingMutation(nil, conversationId: canonical.id, accountId: accountId)
     }
     entitiesById[canonical.id] = applyPending(to: mergedCanonical)
@@ -672,68 +764,126 @@ final class ConversationRepository: ObservableObject {
     reconcileVisibleMembership(for: canonical.id)
   }
 
-  private func drainMutations(
+  private func drainMutation(
     id: String,
+    value: ConversationMutationValue,
     requestGeneration: UInt64,
     accountId: String
-  ) async throws {
-    guard mutationDrainTokens[id] == nil else { return }
+  ) async throws -> Bool {
+    if mutationDrainTokens[id] != nil {
+      onMutationWaiterRegistered(id, value)
+      let wakeup = await withCheckedContinuation { continuation in
+        mutationDrainWaiters[id, default: []].append(
+          MutationDrainWaiter(value: value, continuation: continuation)
+        )
+      }
+      switch wakeup {
+      case .completed(let result):
+        return try result.get()
+      case .retry:
+        guard requestGeneration == generation, accountId == accountIdProvider() else {
+          throw CancellationError()
+        }
+        return try await drainMutation(
+          id: id,
+          value: value,
+          requestGeneration: requestGeneration,
+          accountId: accountId
+        )
+      }
+    }
+
     let drainToken = UUID()
     mutationDrainTokens[id] = drainToken
-    defer {
-      if mutationDrainTokens[id] == drainToken {
-        mutationDrainTokens.removeValue(forKey: id)
-      }
+    do {
+      let result = try await performMutationDrain(
+        id: id,
+        value: value,
+        requestGeneration: requestGeneration,
+        accountId: accountId
+      )
+      finishMutationDrain(id: id, value: value, token: drainToken, result: .success(result))
+      return result
+    } catch {
+      finishMutationDrain(id: id, value: value, token: drainToken, result: .failure(error))
+      throw error
     }
-    var firstPermanentFailure: Error?
+  }
 
-    while let mutation = pendingMutations[id], !mutation.isEmpty {
-      guard requestGeneration == generation, accountId == accountIdProvider() else {
-        throw CancellationError()
+  private func performMutationDrain(
+    id: String,
+    value: ConversationMutationValue,
+    requestGeneration: UInt64,
+    accountId: String
+  ) async throws -> Bool {
+    guard requestGeneration == generation, accountId == accountIdProvider() else {
+      throw CancellationError()
+    }
+    guard pendingMutation(value, matches: pendingMutations[id]) else { return true }
+
+    do {
+      let acknowledgement: ConversationMutationAcknowledgement
+      switch value {
+      case .title(let title):
+        acknowledgement = try await remote.updateTitle(id: id, title: title)
+      case .starred(let starred):
+        acknowledgement = try await remote.updateStarred(id: id, starred: starred)
+      case .folder(let folderId):
+        acknowledgement = try await remote.moveToFolder(id: id, folderId: folderId)
       }
-      let attemptedValue: ConversationMutationValue
-      if let title = mutation.title {
-        attemptedValue = .title(title)
-      } else if let starred = mutation.starred {
-        attemptedValue = .starred(starred)
-      } else if mutation.hasFolderIdMutation {
-        attemptedValue = .folder(mutation.folderId)
+      return try await acceptAcknowledgement(
+        acknowledgement,
+        requestGeneration: requestGeneration,
+        accountId: accountId
+      )
+    } catch {
+      try await handleMutationFailure(
+        error,
+        attemptedValue: value,
+        id: id,
+        requestGeneration: requestGeneration,
+        accountId: accountId
+      )
+      throw error
+    }
+  }
+
+  private func finishMutationDrain(
+    id: String,
+    value: ConversationMutationValue,
+    token: UUID,
+    result: Result<Bool, Error>
+  ) {
+    guard mutationDrainTokens[id] == token else { return }
+    mutationDrainTokens.removeValue(forKey: id)
+    let waiters = mutationDrainWaiters.removeValue(forKey: id) ?? []
+    for waiter in waiters {
+      if waiter.value == value {
+        waiter.continuation.resume(returning: .completed(result))
       } else {
-        return
-      }
-      do {
-        let acknowledgement: ConversationMutationAcknowledgement
-        switch attemptedValue {
-        case .title(let title):
-          acknowledgement = try await remote.updateTitle(id: id, title: title)
-        case .starred(let starred):
-          acknowledgement = try await remote.updateStarred(id: id, starred: starred)
-        case .folder(let folderId):
-          acknowledgement = try await remote.moveToFolder(id: id, folderId: folderId)
-        }
-        let confirmed = try await acceptAcknowledgement(
-          acknowledgement,
-          requestGeneration: requestGeneration,
-          accountId: accountId
-        )
-        if !confirmed { return }
-      } catch {
-        let permanent = Self.isPermanentMutationFailure(error)
-        try await handleMutationFailure(
-          error,
-          attemptedValue: attemptedValue,
-          id: id,
-          requestGeneration: requestGeneration,
-          accountId: accountId
-        )
-        if permanent {
-          if firstPermanentFailure == nil { firstPermanentFailure = error }
-          continue
-        }
-        throw error
+        waiter.continuation.resume(returning: .retry)
       }
     }
-    if let firstPermanentFailure { throw firstPermanentFailure }
+  }
+
+  private func pendingMutation(
+    _ value: ConversationMutationValue,
+    matches mutation: ConversationPendingMutation?
+  ) -> Bool {
+    guard let mutation else { return false }
+    switch value {
+    case .title(let title): return mutation.title == title
+    case .starred(let starred): return mutation.starred == starred
+    case .folder(let folderId): return mutation.hasFolderIdMutation && mutation.folderId == folderId
+    }
+  }
+
+  private func nextPendingMutation(for id: String) -> ConversationMutationValue? {
+    guard let mutation = pendingMutations[id] else { return nil }
+    if let title = mutation.title { return .title(title) }
+    if let starred = mutation.starred { return .starred(starred) }
+    if mutation.hasFolderIdMutation { return .folder(mutation.folderId) }
+    return nil
   }
 
   private func acceptAcknowledgement(
@@ -760,26 +910,32 @@ final class ConversationRepository: ObservableObject {
       return false
     }
 
-    guard let current = entitiesById[acknowledgement.id] else { return true }
+    let current = entitiesById[acknowledgement.id]
+    let cached = try await cache.load(id: acknowledgement.id, accountId: accountId)
+    guard current != nil || cached != nil else { return true }
     var acknowledgedMutation = ConversationPendingMutation()
     switch acknowledgement.value {
     case .title(let title): acknowledgedMutation.setTitle(title)
     case .starred(let starred): acknowledgedMutation.setStarred(starred)
     case .folder(let folderId): acknowledgedMutation.setFolderId(folderId)
     }
-    let acknowledged = Self.withServerVersion(
-      ConversationReconciliationPolicy.apply(mutation: acknowledgedMutation, to: current),
-      updatedAt: acknowledgement.updatedAt,
-      revision: acknowledgement.revision
-    )
-    let cached = try await cache.load(id: acknowledgement.id, accountId: accountId)
-    try await cache.upsertServerConversation(
-      acknowledged,
-      completeness: cached?.completeness ?? [.list],
-      fetchedAt: now(),
-      accountId: accountId,
-      preserveProjectionFreshness: true
-    )
+    if let cached {
+      let acknowledged = Self.withServerVersion(
+        ConversationReconciliationPolicy.apply(
+          mutation: acknowledgedMutation,
+          to: cached.conversation
+        ),
+        updatedAt: acknowledgement.updatedAt,
+        revision: acknowledgement.revision
+      )
+      try await cache.upsertServerConversation(
+        acknowledged,
+        completeness: cached.completeness,
+        fetchedAt: now(),
+        accountId: accountId,
+        preserveProjectionFreshness: true
+      )
+    }
     guard requestGeneration == generation, accountId == accountIdProvider() else {
       throw CancellationError()
     }
@@ -787,14 +943,14 @@ final class ConversationRepository: ObservableObject {
     var pending = pendingMutations[acknowledgement.id]
     pending?.clearAcknowledged(acknowledgement.value)
     if let pending, !pending.isEmpty {
-      pendingMutations[acknowledgement.id] = pending
+      setPendingMutation(pending, for: acknowledgement.id)
       try await cache.savePendingMutation(
         pending,
         conversationId: acknowledgement.id,
         accountId: accountId
       )
     } else {
-      pendingMutations.removeValue(forKey: acknowledgement.id)
+      setPendingMutation(nil, for: acknowledgement.id)
       try await cache.savePendingMutation(nil, conversationId: acknowledgement.id, accountId: accountId)
     }
     let merged = try await cache.load(id: acknowledgement.id, accountId: accountId)
@@ -804,6 +960,15 @@ final class ConversationRepository: ObservableObject {
     if let merged {
       entitiesById[acknowledgement.id] = applyPending(to: merged.conversation)
       metadataById[acknowledgement.id] = metadata(for: merged, source: .server)
+      reconcileVisibleMembership(for: acknowledgement.id)
+    } else if let current {
+      entitiesById[acknowledgement.id] = applyPending(
+        to: Self.withServerVersion(
+          current,
+          updatedAt: acknowledgement.updatedAt,
+          revision: acknowledgement.revision
+        )
+      )
       reconcileVisibleMembership(for: acknowledgement.id)
     }
     return true
@@ -835,10 +1000,10 @@ final class ConversationRepository: ObservableObject {
     var pending = pendingMutations[id]
     pending?.clearAcknowledged(attemptedValue)
     if let pending, !pending.isEmpty {
-      pendingMutations[id] = pending
+      setPendingMutation(pending, for: id)
       try await cache.savePendingMutation(pending, conversationId: id, accountId: accountId)
     } else {
-      pendingMutations.removeValue(forKey: id)
+      setPendingMutation(nil, for: id)
       try await cache.savePendingMutation(nil, conversationId: id, accountId: accountId)
     }
     await loadDetail(id: id)
@@ -873,10 +1038,10 @@ final class ConversationRepository: ObservableObject {
       }
       mutation.clearResolvedFields(matching: conversation)
       if mutation.isEmpty {
-        pendingMutations.removeValue(forKey: conversation.id)
+        setPendingMutation(nil, for: conversation.id)
         try await cache.savePendingMutation(nil, conversationId: conversation.id, accountId: accountId)
       } else {
-        pendingMutations[conversation.id] = mutation
+        setPendingMutation(mutation, for: conversation.id)
         try await cache.savePendingMutation(mutation, conversationId: conversation.id, accountId: accountId)
       }
     }
@@ -885,6 +1050,20 @@ final class ConversationRepository: ObservableObject {
   private static func isPermanentMutationFailure(_ error: Error) -> Bool {
     guard case APIError.httpError(let statusCode, _) = error else { return false }
     return (400..<500).contains(statusCode) && ![408, 425, 429].contains(statusCode)
+  }
+
+  private static func hasIdenticalProjectionContent(
+    _ lhs: ServerConversation,
+    _ rhs: ServerConversation
+  ) -> Bool {
+    // ServerConversation.== is intentionally list-oriented and omits rich
+    // detail fields. Seed idempotence must include transcript/speaker changes.
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.sortedKeys]
+    guard let lhsData = try? encoder.encode(lhs),
+          let rhsData = try? encoder.encode(rhs)
+    else { return false }
+    return lhsData == rhsData
   }
 
   private static func withServerVersion(
@@ -954,11 +1133,20 @@ final class ConversationRepository: ObservableObject {
 
   private func retryPendingMutations(requestGeneration: UInt64, accountId: String) async {
     for id in Array(pendingMutations.keys) {
-      guard requestGeneration == generation, accountId == accountIdProvider() else { return }
-      do {
-        try await drainMutations(id: id, requestGeneration: requestGeneration, accountId: accountId)
-      } catch {
-        logError("ConversationRepository: pending mutation retry failed", error: error)
+      while let value = nextPendingMutation(for: id) {
+        guard requestGeneration == generation, accountId == accountIdProvider() else { return }
+        do {
+          let confirmed = try await drainMutation(
+            id: id,
+            value: value,
+            requestGeneration: requestGeneration,
+            accountId: accountId
+          )
+          if !confirmed { break }
+        } catch {
+          logError("ConversationRepository: pending mutation retry failed", error: error)
+          if !Self.isPermanentMutationFailure(error) { break }
+        }
       }
     }
   }

--- a/desktop/macos/Desktop/Sources/Conversations/ConversationRepository.swift
+++ b/desktop/macos/Desktop/Sources/Conversations/ConversationRepository.swift
@@ -1,0 +1,1004 @@
+import Combine
+import Foundation
+
+enum ConversationMutationValue: Sendable, Equatable {
+  case title(String)
+  case starred(Bool)
+  case folder(String?)
+}
+
+struct ConversationMutationAcknowledgement: Sendable {
+  let id: String
+  let updatedAt: Date?
+  let revision: String?
+  let value: ConversationMutationValue
+  let conversation: ServerConversation?
+}
+
+enum ConversationEntitySource: Sendable, Equatable {
+  case cache
+  case server
+  case mixed
+  case seeded
+}
+
+enum ConversationSyncState: Sendable, Equatable {
+  case synced
+  case pending
+  case failed(String)
+}
+
+struct ConversationEntityMetadata: Sendable, Equatable {
+  let completeness: ConversationCompleteness
+  let source: ConversationEntitySource
+  let fetchedAt: Date
+  let listFetchedAt: Date?
+  let detailFetchedAt: Date?
+  let transcriptFetchedAt: Date?
+  let syncState: ConversationSyncState
+
+  init(
+    completeness: ConversationCompleteness,
+    source: ConversationEntitySource,
+    fetchedAt: Date,
+    listFetchedAt: Date? = nil,
+    detailFetchedAt: Date? = nil,
+    transcriptFetchedAt: Date? = nil,
+    syncState: ConversationSyncState
+  ) {
+    self.completeness = completeness
+    self.source = source
+    self.fetchedAt = fetchedAt
+    self.listFetchedAt = listFetchedAt
+    self.detailFetchedAt = detailFetchedAt
+    self.transcriptFetchedAt = transcriptFetchedAt
+    self.syncState = syncState
+  }
+}
+
+protocol ConversationRemoteServing: Sendable {
+  func list(query: ConversationQuery) async throws -> [ServerConversation]
+  func count(query: ConversationQuery) async throws -> Int
+  func detail(id: String) async throws -> ServerConversation
+  func search(query: String, limit: Int) async throws -> [ServerConversation]
+  func updateTitle(id: String, title: String) async throws -> ConversationMutationAcknowledgement
+  func updateStarred(id: String, starred: Bool) async throws -> ConversationMutationAcknowledgement
+  func moveToFolder(id: String, folderId: String?) async throws -> ConversationMutationAcknowledgement
+  func delete(id: String) async throws
+}
+
+actor LiveConversationRemote: ConversationRemoteServing {
+  static let shared = LiveConversationRemote()
+
+  private let api: APIClient
+
+  init(api: APIClient = .shared) {
+    self.api = api
+  }
+
+  func list(query: ConversationQuery) async throws -> [ServerConversation] {
+    let range = Self.dateRange(for: query.selectedDate)
+    return try await api.getConversationList(
+      limit: query.limit,
+      offset: 0,
+      statuses: [.completed, .processing],
+      includeDiscarded: false,
+      startDate: range?.start,
+      endDate: range?.end,
+      folderId: query.folderId,
+      starred: query.showStarredOnly ? true : nil
+    )
+  }
+
+  func count(query: ConversationQuery) async throws -> Int {
+    let range = Self.dateRange(for: query.selectedDate)
+    return try await api.getConversationsCount(
+      includeDiscarded: false,
+      statuses: [.completed, .processing],
+      startDate: range?.start,
+      endDate: range?.end,
+      folderId: query.folderId,
+      starred: query.showStarredOnly ? true : nil
+    )
+  }
+
+  func detail(id: String) async throws -> ServerConversation {
+    try await api.getConversation(id: id)
+  }
+
+  func search(query: String, limit: Int) async throws -> [ServerConversation] {
+    try await api.searchConversations(
+      query: query,
+      page: 1,
+      perPage: limit,
+      includeDiscarded: false
+    ).items
+  }
+
+  func updateTitle(id: String, title: String) async throws -> ConversationMutationAcknowledgement {
+    try await api.updateConversationTitle(id: id, title: title)
+  }
+
+  func updateStarred(id: String, starred: Bool) async throws -> ConversationMutationAcknowledgement {
+    try await api.setConversationStarred(id: id, starred: starred)
+  }
+
+  func moveToFolder(id: String, folderId: String?) async throws -> ConversationMutationAcknowledgement {
+    try await api.moveConversationToFolder(conversationId: id, folderId: folderId)
+  }
+
+  func delete(id: String) async throws {
+    try await api.deleteConversation(id: id)
+  }
+
+  private static func dateRange(for date: Date?) -> (start: Date, end: Date)? {
+    guard let date else { return nil }
+    let start = Calendar.current.startOfDay(for: date)
+    guard let end = Calendar.current.date(byAdding: .day, value: 1, to: start) else { return nil }
+    return (start, end)
+  }
+}
+
+@MainActor
+final class ConversationRepository: ObservableObject {
+  static let shared = ConversationRepository()
+
+  @Published private(set) var entitiesById: [String: ServerConversation] = [:]
+  @Published private(set) var metadataById: [String: ConversationEntityMetadata] = [:]
+  @Published private(set) var conversationIds: [String] = []
+  @Published private(set) var searchResultIds: [String] = []
+  @Published private(set) var isLoading = false
+  @Published private(set) var isSearching = false
+  @Published private(set) var error: String?
+  @Published private(set) var searchError: String?
+  @Published private(set) var totalCount: Int?
+  @Published private(set) var filteredCount: Int?
+
+  var conversations: [ServerConversation] {
+    conversationIds.compactMap { entitiesById[$0] }
+  }
+
+  var searchResults: [ServerConversation] {
+    searchResultIds.compactMap { entitiesById[$0] }
+  }
+
+  private let remote: any ConversationRemoteServing
+  private let cache: any ConversationCachePersisting
+  private let now: @Sendable () -> Date
+  private let accountIdProvider: @MainActor () -> String
+  private var pendingMutations: [String: ConversationPendingMutation] = [:]
+  private var currentQuery = ConversationQuery()
+  private var generation: UInt64 = 0
+  private var searchGeneration: UInt64 = 0
+  private var mutationDrainTokens: [String: UUID] = [:]
+  private var didAttemptLegacyMigration = false
+  private let legacyMigrationEnabled: Bool
+
+  init(
+    remote: any ConversationRemoteServing = LiveConversationRemote.shared,
+    cache: any ConversationCachePersisting = ConversationCacheStorage.shared,
+    now: @escaping @Sendable () -> Date = { Date() },
+    accountIdProvider: @escaping @MainActor () -> String = {
+      RewindDatabase.currentUserId ?? "anonymous"
+    },
+    legacyMigrationEnabled: Bool = true
+  ) {
+    self.remote = remote
+    self.cache = cache
+    self.now = now
+    self.accountIdProvider = accountIdProvider
+    self.legacyMigrationEnabled = legacyMigrationEnabled
+  }
+
+  func conversation(id: String) -> ServerConversation? {
+    entitiesById[id]
+  }
+
+  func metadata(id: String) -> ConversationEntityMetadata? {
+    metadataById[id]
+  }
+
+  func seed(_ conversation: ServerConversation) {
+    if let existing = entitiesById[conversation.id],
+       let existingUpdatedAt = existing.updatedAt,
+       let incomingUpdatedAt = conversation.updatedAt,
+       existingUpdatedAt > incomingUpdatedAt {
+      return
+    }
+    entitiesById[conversation.id] = applyPending(to: conversation)
+    let completeness: ConversationCompleteness = conversation.transcriptSegmentsIncluded
+      ? [.list, .detail, .transcript] : [.list]
+    let seededAt = now()
+    metadataById[conversation.id] = ConversationEntityMetadata(
+      completeness: completeness,
+      source: .seeded,
+      fetchedAt: seededAt,
+      listFetchedAt: seededAt,
+      detailFetchedAt: completeness.contains(.detail) ? seededAt : nil,
+      transcriptFetchedAt: completeness.contains(.transcript) ? seededAt : nil,
+      syncState: pendingMutations[conversation.id] == nil ? .synced : .pending
+    )
+  }
+
+  func load(query: ConversationQuery) async {
+    currentQuery = query
+    generation &+= 1
+    let requestGeneration = generation
+    let accountId = accountIdProvider()
+    isLoading = true
+    error = nil
+
+    await migrateLegacyCacheIfNeeded(query: query, accountId: accountId, requestGeneration: requestGeneration)
+
+    do {
+      async let cachedTask = cache.load(query: query, accountId: accountId)
+      async let pendingTask = cache.loadPendingMutations(accountId: accountId)
+      let (cached, pending) = try await (cachedTask, pendingTask)
+      guard requestGeneration == generation, accountId == accountIdProvider() else { return }
+      pendingMutations = pending
+      publish(cached.map(\.conversation), ids: cached.map { $0.conversation.id })
+      publishMetadata(cached, source: .cache)
+      if !cached.isEmpty {
+        isLoading = false
+      }
+    } catch {
+      guard requestGeneration == generation, accountId == accountIdProvider() else { return }
+      logError("ConversationRepository: cache-first load failed", error: error)
+    }
+
+    await refresh(query: query, requestGeneration: requestGeneration, accountId: accountId)
+  }
+
+  func refresh() async {
+    generation &+= 1
+    await refresh(query: currentQuery, requestGeneration: generation, accountId: accountIdProvider())
+  }
+
+  private func refresh(query: ConversationQuery, requestGeneration: UInt64, accountId: String) async {
+    do {
+      async let listTask = remote.list(query: query)
+      async let countTask = remote.count(query: query)
+      let server = try await listTask
+      guard requestGeneration == generation, query == currentQuery, accountId == accountIdProvider() else { return }
+
+      try await reconcilePendingMutations(with: server, accountId: accountId)
+      try await cache.applyServerSnapshot(server, query: query, fetchedAt: now(), accountId: accountId)
+      let cached = try await cache.load(query: query, accountId: accountId)
+      guard requestGeneration == generation, query == currentQuery, accountId == accountIdProvider() else { return }
+      publish(cached.map(\.conversation), ids: cached.map { $0.conversation.id })
+      publishMetadata(cached, source: .server)
+
+      do {
+        let count = try await countTask
+        guard requestGeneration == generation, accountId == accountIdProvider() else { return }
+        if query.showStarredOnly || query.selectedDate != nil || query.folderId != nil {
+          filteredCount = count
+        } else {
+          totalCount = count
+          filteredCount = nil
+        }
+      } catch {
+        logError("ConversationRepository: count refresh failed", error: error)
+      }
+
+      isLoading = false
+      await retryPendingMutations(requestGeneration: requestGeneration, accountId: accountId)
+    } catch {
+      guard requestGeneration == generation, query == currentQuery, accountId == accountIdProvider() else { return }
+      if conversations.isEmpty {
+        self.error = error.localizedDescription
+      }
+      isLoading = false
+      logError("ConversationRepository: server refresh failed", error: error)
+    }
+  }
+
+  func loadDetail(id: String) async {
+    let requestGeneration = generation
+    let accountId = accountIdProvider()
+    do {
+      if let cached = try await cache.load(id: id, accountId: accountId) {
+        guard requestGeneration == generation, accountId == accountIdProvider() else { return }
+        entitiesById[id] = applyPending(to: cached.conversation)
+        metadataById[id] = metadata(for: cached, source: .cache)
+      }
+    } catch {
+      logError("ConversationRepository: cached detail load failed", error: error)
+    }
+
+    do {
+      let detail = try await remote.detail(id: id)
+      guard requestGeneration == generation, accountId == accountIdProvider() else { return }
+      var completeness: ConversationCompleteness = [.list, .detail]
+      if detail.transcriptSegmentsIncluded {
+        completeness.insert(.transcript)
+      }
+      try await cache.upsertServerConversation(
+        detail,
+        completeness: completeness,
+        fetchedAt: now(),
+        accountId: accountId,
+        preserveProjectionFreshness: false
+      )
+      let merged = try await cache.load(id: id, accountId: accountId)?.conversation ?? detail
+      guard requestGeneration == generation, accountId == accountIdProvider() else { return }
+      entitiesById[id] = applyPending(to: merged)
+      if let entry = try await cache.load(id: id, accountId: accountId) {
+        guard requestGeneration == generation, accountId == accountIdProvider() else { return }
+        metadataById[id] = metadata(for: entry, source: .server)
+      }
+    } catch {
+      guard requestGeneration == generation else { return }
+      if case APIError.httpError(let statusCode, _) = error, statusCode == 404 {
+        try? await cache.remove(id: id, accountId: accountId)
+        guard requestGeneration == generation, accountId == accountIdProvider() else { return }
+        entitiesById.removeValue(forKey: id)
+        metadataById.removeValue(forKey: id)
+        conversationIds.removeAll { $0 == id }
+        searchResultIds.removeAll { $0 == id }
+        return
+      }
+      if case APIError.httpError(let statusCode, _) = error,
+         [402, 403].contains(statusCode),
+         let current = entitiesById[id] {
+        let redacted = Self.redactedLockedConversation(current)
+        let redactedAt = now()
+        try? await cache.upsertServerConversation(
+          redacted,
+          completeness: [.list],
+          fetchedAt: redactedAt,
+          accountId: accountId,
+          preserveProjectionFreshness: false
+        )
+        guard requestGeneration == generation, accountId == accountIdProvider() else { return }
+        entitiesById[id] = redacted
+        metadataById[id] = ConversationEntityMetadata(
+          completeness: [.list],
+          source: .server,
+          fetchedAt: redactedAt,
+          listFetchedAt: redactedAt,
+          syncState: .synced
+        )
+        return
+      }
+      logError("ConversationRepository: detail refresh failed", error: error)
+    }
+  }
+
+  func search(_ query: String, limit: Int = 50) async {
+    searchGeneration &+= 1
+    let requestSearchGeneration = searchGeneration
+    guard !query.isEmpty else {
+      searchResultIds = []
+      isSearching = false
+      return
+    }
+    let requestGeneration = generation
+    let accountId = accountIdProvider()
+    isSearching = true
+    searchError = nil
+    do {
+      let results = try await remote.search(query: query, limit: limit)
+      guard requestGeneration == generation, requestSearchGeneration == searchGeneration,
+            accountId == accountIdProvider() else { return }
+      for result in results {
+        try await cache.upsertServerConversation(
+          result,
+          completeness: result.transcriptSegmentsIncluded ? [.list, .transcript] : [.list],
+          fetchedAt: now(),
+          accountId: accountId,
+          preserveProjectionFreshness: false
+        )
+        guard requestGeneration == generation, requestSearchGeneration == searchGeneration,
+              accountId == accountIdProvider() else { return }
+        let merged = try await cache.load(id: result.id, accountId: accountId)?.conversation ?? result
+        guard requestGeneration == generation, requestSearchGeneration == searchGeneration,
+              accountId == accountIdProvider() else { return }
+        entitiesById[result.id] = applyPending(to: merged)
+        if let entry = try await cache.load(id: result.id, accountId: accountId) {
+          guard requestGeneration == generation, requestSearchGeneration == searchGeneration,
+                accountId == accountIdProvider() else { return }
+          metadataById[result.id] = metadata(for: entry, source: .server)
+        }
+      }
+      searchResultIds = results.map(\.id)
+      isSearching = false
+      searchError = nil
+    } catch {
+      guard requestGeneration == generation, requestSearchGeneration == searchGeneration else { return }
+      searchError = error.localizedDescription
+      isSearching = false
+      logError("ConversationRepository: search failed", error: error)
+    }
+  }
+
+  func clearSearch() {
+    searchGeneration &+= 1
+    searchResultIds = []
+    isSearching = false
+    searchError = nil
+  }
+
+  func updateTitle(id: String, title: String) async throws {
+    let requestGeneration = generation
+    let accountId = accountIdProvider()
+    var mutation = pendingMutations[id] ?? ConversationPendingMutation()
+    mutation.setTitle(title)
+    try await stage(
+      mutation: mutation,
+      conversationId: id,
+      accountId: accountId,
+      requestGeneration: requestGeneration
+    )
+    try await drainMutations(id: id, requestGeneration: requestGeneration, accountId: accountId)
+  }
+
+  func updateStarred(id: String, starred: Bool) async throws {
+    let requestGeneration = generation
+    let accountId = accountIdProvider()
+    var mutation = pendingMutations[id] ?? ConversationPendingMutation()
+    mutation.setStarred(starred)
+    try await stage(
+      mutation: mutation,
+      conversationId: id,
+      accountId: accountId,
+      requestGeneration: requestGeneration
+    )
+    try await drainMutations(id: id, requestGeneration: requestGeneration, accountId: accountId)
+  }
+
+  func moveToFolder(id: String, folderId: String?) async throws {
+    let requestGeneration = generation
+    let accountId = accountIdProvider()
+    var mutation = pendingMutations[id] ?? ConversationPendingMutation()
+    mutation.setFolderId(folderId)
+    try await stage(
+      mutation: mutation,
+      conversationId: id,
+      accountId: accountId,
+      requestGeneration: requestGeneration
+    )
+    try await drainMutations(id: id, requestGeneration: requestGeneration, accountId: accountId)
+  }
+
+  func delete(id: String) async throws {
+    let requestGeneration = generation
+    let accountId = accountIdProvider()
+    do {
+      try await remote.delete(id: id)
+      guard requestGeneration == generation, accountId == accountIdProvider() else {
+        throw CancellationError()
+      }
+      try await cache.remove(id: id, accountId: accountId)
+      pendingMutations.removeValue(forKey: id)
+      try await cache.savePendingMutation(nil, conversationId: id, accountId: accountId)
+      entitiesById.removeValue(forKey: id)
+      conversationIds.removeAll { $0 == id }
+      searchResultIds.removeAll { $0 == id }
+    } catch {
+      guard requestGeneration == generation, accountId == accountIdProvider() else {
+        throw CancellationError()
+      }
+      self.error = error.localizedDescription
+      if let existing = metadataById[id] {
+        metadataById[id] = ConversationEntityMetadata(
+          completeness: existing.completeness,
+          source: existing.source,
+          fetchedAt: existing.fetchedAt,
+          listFetchedAt: existing.listFetchedAt,
+          detailFetchedAt: existing.detailFetchedAt,
+          transcriptFetchedAt: existing.transcriptFetchedAt,
+          syncState: .failed(error.localizedDescription)
+        )
+      }
+      throw error
+    }
+  }
+
+  func resetSession() {
+    generation &+= 1
+    searchGeneration &+= 1
+    entitiesById = [:]
+    metadataById = [:]
+    conversationIds = []
+    searchResultIds = []
+    pendingMutations = [:]
+    mutationDrainTokens = [:]
+    totalCount = nil
+    filteredCount = nil
+    isLoading = false
+    isSearching = false
+    error = nil
+    searchError = nil
+    currentQuery = ConversationQuery()
+    didAttemptLegacyMigration = false
+    Task { await cache.invalidateCache() }
+  }
+
+  /// Compatibility setter used while AppState callers migrate. It updates the
+  /// single repository projection rather than creating a second owner.
+  func replaceVisibleConversations(_ conversations: [ServerConversation]) {
+    publish(conversations, ids: conversations.map(\.id))
+  }
+
+  private func publish(_ conversations: [ServerConversation], ids: [String]) {
+    for conversation in conversations {
+      entitiesById[conversation.id] = applyPending(to: conversation)
+    }
+    conversationIds = ids.filter { id in
+      guard let conversation = entitiesById[id] else { return false }
+      return matchesCurrentQuery(conversation)
+    }
+  }
+
+  private func publishMetadata(
+    _ entries: [ConversationCacheEntry],
+    source: ConversationEntitySource
+  ) {
+    for entry in entries {
+      metadataById[entry.conversation.id] = metadata(for: entry, source: source)
+    }
+  }
+
+  private func metadata(
+    for entry: ConversationCacheEntry,
+    source: ConversationEntitySource
+  ) -> ConversationEntityMetadata {
+    let hasOlderRichProjection = source == .server && (
+      entry.detailFetchedAt.map { $0 < (entry.listFetchedAt ?? entry.cacheWrittenAt) } == true
+        || entry.transcriptFetchedAt.map { $0 < (entry.listFetchedAt ?? entry.cacheWrittenAt) } == true
+    )
+    return ConversationEntityMetadata(
+      completeness: entry.completeness,
+      source: hasOlderRichProjection ? .mixed : source,
+      fetchedAt: entry.listFetchedAt ?? entry.cacheWrittenAt,
+      listFetchedAt: entry.listFetchedAt,
+      detailFetchedAt: entry.detailFetchedAt,
+      transcriptFetchedAt: entry.transcriptFetchedAt,
+      syncState: pendingMutations[entry.conversation.id] == nil ? .synced : .pending
+    )
+  }
+
+  private func matchesCurrentQuery(_ conversation: ServerConversation) -> Bool {
+    guard !conversation.deleted, !conversation.discarded else { return false }
+    if currentQuery.showStarredOnly, !conversation.starred { return false }
+    if let folderId = currentQuery.folderId, conversation.folderId != folderId { return false }
+    if let selectedDate = currentQuery.selectedDate {
+      let start = Calendar.current.startOfDay(for: selectedDate)
+      guard let end = Calendar.current.date(byAdding: .day, value: 1, to: start),
+            conversation.createdAt >= start, conversation.createdAt < end
+      else { return false }
+    }
+    return true
+  }
+
+  private func reconcileVisibleMembership(for id: String) {
+    guard let conversation = entitiesById[id] else {
+      conversationIds.removeAll { $0 == id }
+      return
+    }
+    if matchesCurrentQuery(conversation) {
+      if !conversationIds.contains(id) { conversationIds.append(id) }
+      conversationIds.sort {
+        (entitiesById[$0]?.createdAt ?? .distantPast) > (entitiesById[$1]?.createdAt ?? .distantPast)
+      }
+      if conversationIds.count > currentQuery.limit {
+        conversationIds = Array(conversationIds.prefix(currentQuery.limit))
+      }
+    } else {
+      conversationIds.removeAll { $0 == id }
+    }
+  }
+
+  private func applyPending(to conversation: ServerConversation) -> ServerConversation {
+    ConversationReconciliationPolicy.apply(
+      mutation: pendingMutations[conversation.id],
+      to: conversation
+    )
+  }
+
+  private func stage(
+    mutation: ConversationPendingMutation,
+    conversationId: String,
+    accountId: String,
+    requestGeneration: UInt64
+  ) async throws {
+    guard requestGeneration == generation, accountId == accountIdProvider() else {
+      throw CancellationError()
+    }
+    pendingMutations[conversationId] = mutation
+    try await cache.savePendingMutation(mutation, conversationId: conversationId, accountId: accountId)
+    guard requestGeneration == generation, accountId == accountIdProvider() else {
+      throw CancellationError()
+    }
+    guard let current = entitiesById[conversationId] else { return }
+    let optimistic = ConversationReconciliationPolicy.apply(mutation: mutation, to: current)
+    entitiesById[conversationId] = optimistic
+    let existingMetadata = metadataById[conversationId]
+    metadataById[conversationId] = ConversationEntityMetadata(
+      completeness: existingMetadata?.completeness ?? [.list],
+      source: existingMetadata?.source ?? .cache,
+      fetchedAt: existingMetadata?.fetchedAt ?? now(),
+      listFetchedAt: existingMetadata?.listFetchedAt,
+      detailFetchedAt: existingMetadata?.detailFetchedAt,
+      transcriptFetchedAt: existingMetadata?.transcriptFetchedAt,
+      syncState: .pending
+    )
+    reconcileVisibleMembership(for: conversationId)
+  }
+
+  private func acceptCanonical(
+    _ canonical: ServerConversation,
+    requestGeneration: UInt64,
+    accountId: String
+  ) async throws {
+    guard requestGeneration == generation, accountId == accountIdProvider() else {
+      throw CancellationError()
+    }
+    var completeness: ConversationCompleteness = [.list, .detail]
+    if canonical.transcriptSegmentsIncluded {
+      completeness.insert(.transcript)
+    }
+    let prior = try await cache.load(id: canonical.id, accountId: accountId)
+    try await cache.upsertServerConversation(
+      canonical,
+      completeness: completeness,
+      fetchedAt: now(),
+      accountId: accountId,
+      preserveProjectionFreshness: false
+    )
+    let mergedCanonical = try await cache.load(id: canonical.id, accountId: accountId)?.conversation ?? canonical
+    guard requestGeneration == generation, accountId == accountIdProvider() else {
+      throw CancellationError()
+    }
+
+    var mutation = pendingMutations[canonical.id]
+    let canonicalCanConfirmMutation = canonical.updatedAt != nil || canonical.revision != nil
+      || (prior?.conversation.updatedAt == nil && prior?.conversation.revision == nil)
+    if canonicalCanConfirmMutation {
+      mutation?.clearResolvedFields(matching: canonical)
+    }
+    if let mutation, !mutation.isEmpty {
+      pendingMutations[canonical.id] = mutation
+      try await cache.savePendingMutation(mutation, conversationId: canonical.id, accountId: accountId)
+    } else {
+      pendingMutations.removeValue(forKey: canonical.id)
+      try await cache.savePendingMutation(nil, conversationId: canonical.id, accountId: accountId)
+    }
+    entitiesById[canonical.id] = applyPending(to: mergedCanonical)
+    if let entry = try await cache.load(id: canonical.id, accountId: accountId) {
+      metadataById[canonical.id] = metadata(for: entry, source: .server)
+    }
+    reconcileVisibleMembership(for: canonical.id)
+  }
+
+  private func drainMutations(
+    id: String,
+    requestGeneration: UInt64,
+    accountId: String
+  ) async throws {
+    guard mutationDrainTokens[id] == nil else { return }
+    let drainToken = UUID()
+    mutationDrainTokens[id] = drainToken
+    defer {
+      if mutationDrainTokens[id] == drainToken {
+        mutationDrainTokens.removeValue(forKey: id)
+      }
+    }
+    var firstPermanentFailure: Error?
+
+    while let mutation = pendingMutations[id], !mutation.isEmpty {
+      guard requestGeneration == generation, accountId == accountIdProvider() else {
+        throw CancellationError()
+      }
+      let attemptedValue: ConversationMutationValue
+      if let title = mutation.title {
+        attemptedValue = .title(title)
+      } else if let starred = mutation.starred {
+        attemptedValue = .starred(starred)
+      } else if mutation.hasFolderIdMutation {
+        attemptedValue = .folder(mutation.folderId)
+      } else {
+        return
+      }
+      do {
+        let acknowledgement: ConversationMutationAcknowledgement
+        switch attemptedValue {
+        case .title(let title):
+          acknowledgement = try await remote.updateTitle(id: id, title: title)
+        case .starred(let starred):
+          acknowledgement = try await remote.updateStarred(id: id, starred: starred)
+        case .folder(let folderId):
+          acknowledgement = try await remote.moveToFolder(id: id, folderId: folderId)
+        }
+        let confirmed = try await acceptAcknowledgement(
+          acknowledgement,
+          requestGeneration: requestGeneration,
+          accountId: accountId
+        )
+        if !confirmed { return }
+      } catch {
+        let permanent = Self.isPermanentMutationFailure(error)
+        try await handleMutationFailure(
+          error,
+          attemptedValue: attemptedValue,
+          id: id,
+          requestGeneration: requestGeneration,
+          accountId: accountId
+        )
+        if permanent {
+          if firstPermanentFailure == nil { firstPermanentFailure = error }
+          continue
+        }
+        throw error
+      }
+    }
+    if let firstPermanentFailure { throw firstPermanentFailure }
+  }
+
+  private func acceptAcknowledgement(
+    _ acknowledgement: ConversationMutationAcknowledgement,
+    requestGeneration: UInt64,
+    accountId: String
+  ) async throws -> Bool {
+    guard requestGeneration == generation, accountId == accountIdProvider() else {
+      throw CancellationError()
+    }
+    if let conversation = acknowledgement.conversation {
+      try await acceptCanonical(
+        conversation,
+        requestGeneration: requestGeneration,
+        accountId: accountId
+      )
+      return true
+    }
+
+    guard acknowledgement.updatedAt != nil || acknowledgement.revision != nil else {
+      // A legacy status-only 2xx proves request acceptance but not which
+      // projection/version a mixed rollout will serve next. Keep the durable
+      // overlay until a list response contains the requested value.
+      return false
+    }
+
+    guard let current = entitiesById[acknowledgement.id] else { return true }
+    var acknowledgedMutation = ConversationPendingMutation()
+    switch acknowledgement.value {
+    case .title(let title): acknowledgedMutation.setTitle(title)
+    case .starred(let starred): acknowledgedMutation.setStarred(starred)
+    case .folder(let folderId): acknowledgedMutation.setFolderId(folderId)
+    }
+    let acknowledged = Self.withServerVersion(
+      ConversationReconciliationPolicy.apply(mutation: acknowledgedMutation, to: current),
+      updatedAt: acknowledgement.updatedAt,
+      revision: acknowledgement.revision
+    )
+    let cached = try await cache.load(id: acknowledgement.id, accountId: accountId)
+    try await cache.upsertServerConversation(
+      acknowledged,
+      completeness: cached?.completeness ?? [.list],
+      fetchedAt: now(),
+      accountId: accountId,
+      preserveProjectionFreshness: true
+    )
+    guard requestGeneration == generation, accountId == accountIdProvider() else {
+      throw CancellationError()
+    }
+
+    var pending = pendingMutations[acknowledgement.id]
+    pending?.clearAcknowledged(acknowledgement.value)
+    if let pending, !pending.isEmpty {
+      pendingMutations[acknowledgement.id] = pending
+      try await cache.savePendingMutation(
+        pending,
+        conversationId: acknowledgement.id,
+        accountId: accountId
+      )
+    } else {
+      pendingMutations.removeValue(forKey: acknowledgement.id)
+      try await cache.savePendingMutation(nil, conversationId: acknowledgement.id, accountId: accountId)
+    }
+    let merged = try await cache.load(id: acknowledgement.id, accountId: accountId)
+    guard requestGeneration == generation, accountId == accountIdProvider() else {
+      throw CancellationError()
+    }
+    if let merged {
+      entitiesById[acknowledgement.id] = applyPending(to: merged.conversation)
+      metadataById[acknowledgement.id] = metadata(for: merged, source: .server)
+      reconcileVisibleMembership(for: acknowledgement.id)
+    }
+    return true
+  }
+
+  private func handleMutationFailure(
+    _ failure: Error,
+    attemptedValue: ConversationMutationValue,
+    id: String,
+    requestGeneration: UInt64,
+    accountId: String
+  ) async throws {
+    guard requestGeneration == generation, accountId == accountIdProvider() else {
+      throw CancellationError()
+    }
+    let message = failure.localizedDescription
+    let existingMetadata = metadataById[id]
+    metadataById[id] = ConversationEntityMetadata(
+      completeness: existingMetadata?.completeness ?? [.list],
+      source: existingMetadata?.source ?? .cache,
+      fetchedAt: existingMetadata?.fetchedAt ?? now(),
+      listFetchedAt: existingMetadata?.listFetchedAt,
+      detailFetchedAt: existingMetadata?.detailFetchedAt,
+      transcriptFetchedAt: existingMetadata?.transcriptFetchedAt,
+      syncState: Self.isPermanentMutationFailure(failure) ? .failed(message) : .pending
+    )
+    guard Self.isPermanentMutationFailure(failure) else { return }
+
+    var pending = pendingMutations[id]
+    pending?.clearAcknowledged(attemptedValue)
+    if let pending, !pending.isEmpty {
+      pendingMutations[id] = pending
+      try await cache.savePendingMutation(pending, conversationId: id, accountId: accountId)
+    } else {
+      pendingMutations.removeValue(forKey: id)
+      try await cache.savePendingMutation(nil, conversationId: id, accountId: accountId)
+    }
+    await loadDetail(id: id)
+    if entitiesById[id] != nil {
+      let refreshedMetadata = metadataById[id]
+      metadataById[id] = ConversationEntityMetadata(
+        completeness: refreshedMetadata?.completeness ?? [.list],
+        source: refreshedMetadata?.source ?? .server,
+        fetchedAt: refreshedMetadata?.fetchedAt ?? now(),
+        listFetchedAt: refreshedMetadata?.listFetchedAt,
+        detailFetchedAt: refreshedMetadata?.detailFetchedAt,
+        transcriptFetchedAt: refreshedMetadata?.transcriptFetchedAt,
+        syncState: .failed(message)
+      )
+    }
+  }
+
+  private func reconcilePendingMutations(
+    with server: [ServerConversation],
+    accountId: String
+  ) async throws {
+    for conversation in server {
+      guard var mutation = pendingMutations[conversation.id] else { continue }
+      if let current = entitiesById[conversation.id] {
+        if ConversationProjectionMerge.isProvablyOlder(incoming: conversation, than: current) {
+          continue
+        }
+        if conversation.updatedAt == nil, conversation.revision == nil,
+           current.updatedAt != nil || current.revision != nil {
+          continue
+        }
+      }
+      mutation.clearResolvedFields(matching: conversation)
+      if mutation.isEmpty {
+        pendingMutations.removeValue(forKey: conversation.id)
+        try await cache.savePendingMutation(nil, conversationId: conversation.id, accountId: accountId)
+      } else {
+        pendingMutations[conversation.id] = mutation
+        try await cache.savePendingMutation(mutation, conversationId: conversation.id, accountId: accountId)
+      }
+    }
+  }
+
+  private static func isPermanentMutationFailure(_ error: Error) -> Bool {
+    guard case APIError.httpError(let statusCode, _) = error else { return false }
+    return (400..<500).contains(statusCode) && ![408, 425, 429].contains(statusCode)
+  }
+
+  private static func withServerVersion(
+    _ conversation: ServerConversation,
+    updatedAt: Date?,
+    revision: String?
+  ) -> ServerConversation {
+    ServerConversation(
+      id: conversation.id,
+      createdAt: conversation.createdAt,
+      startedAt: conversation.startedAt,
+      finishedAt: conversation.finishedAt,
+      structured: conversation.structured,
+      transcriptSegments: conversation.transcriptSegments,
+      transcriptSegmentsIncluded: conversation.transcriptSegmentsIncluded,
+      geolocation: conversation.geolocation,
+      photos: conversation.photos,
+      appsResults: conversation.appsResults,
+      source: conversation.source,
+      language: conversation.language,
+      status: conversation.status,
+      discarded: conversation.discarded,
+      deleted: conversation.deleted,
+      isLocked: conversation.isLocked,
+      starred: conversation.starred,
+      folderId: conversation.folderId,
+      inputDeviceName: conversation.inputDeviceName,
+      deferred: conversation.deferred,
+      updatedAt: updatedAt ?? conversation.updatedAt,
+      revision: revision ?? conversation.revision
+    )
+  }
+
+  private static func redactedLockedConversation(_ conversation: ServerConversation) -> ServerConversation {
+    ServerConversation(
+      id: conversation.id,
+      createdAt: conversation.createdAt,
+      startedAt: conversation.startedAt,
+      finishedAt: conversation.finishedAt,
+      structured: Structured(
+        title: conversation.structured.title,
+        overview: conversation.structured.overview,
+        emoji: conversation.structured.emoji,
+        category: conversation.structured.category,
+        actionItems: [],
+        events: []
+      ),
+      transcriptSegments: [],
+      transcriptSegmentsIncluded: true,
+      geolocation: nil,
+      photos: [],
+      appsResults: [],
+      source: conversation.source,
+      language: conversation.language,
+      status: conversation.status,
+      discarded: conversation.discarded,
+      deleted: conversation.deleted,
+      isLocked: true,
+      starred: conversation.starred,
+      folderId: conversation.folderId,
+      inputDeviceName: conversation.inputDeviceName,
+      deferred: conversation.deferred,
+      updatedAt: conversation.updatedAt,
+      revision: conversation.revision
+    )
+  }
+
+  private func retryPendingMutations(requestGeneration: UInt64, accountId: String) async {
+    for id in Array(pendingMutations.keys) {
+      guard requestGeneration == generation, accountId == accountIdProvider() else { return }
+      do {
+        try await drainMutations(id: id, requestGeneration: requestGeneration, accountId: accountId)
+      } catch {
+        logError("ConversationRepository: pending mutation retry failed", error: error)
+      }
+    }
+  }
+
+  private func migrateLegacyCacheIfNeeded(
+    query: ConversationQuery,
+    accountId: String,
+    requestGeneration: UInt64
+  ) async {
+    guard legacyMigrationEnabled, !didAttemptLegacyMigration else { return }
+    didAttemptLegacyMigration = true
+    do {
+      guard try await cache.isEmpty(accountId: accountId) else { return }
+      let legacy = try await TranscriptionStorage.shared.getLocalConversations(
+        limit: query.limit,
+        starredOnly: query.showStarredOnly,
+        folderId: query.folderId
+      )
+      guard !legacy.isEmpty else { return }
+      guard requestGeneration == generation, accountId == accountIdProvider() else { return }
+      try await cache.applyServerSnapshot(legacy, query: query, fetchedAt: now(), accountId: accountId)
+      for conversation in legacy {
+        guard let session = try await TranscriptionStorage.shared.getSessionByBackendId(conversation.id),
+              let sessionId = session.id
+        else { continue }
+        let segments = try await TranscriptionStorage.shared.getSegments(sessionId: sessionId)
+        guard !segments.isEmpty else { continue }
+        var migrated = conversation
+        migrated.transcriptSegments = segments.map { $0.toTranscriptSegment() }
+        migrated.transcriptSegmentsIncluded = true
+        try await cache.upsertServerConversation(
+          migrated,
+          completeness: [.list, .transcript],
+          fetchedAt: now(),
+          accountId: accountId,
+          preserveProjectionFreshness: false
+        )
+      }
+    } catch {
+      logError("ConversationRepository: legacy cache migration failed", error: error)
+    }
+  }
+}

--- a/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
+++ b/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
@@ -1401,17 +1401,13 @@ final class DesktopAutomationActionRegistry {
       guard let id = params["id"], !id.isEmpty else {
         return ["error": "missing 'id'"]
       }
-      try await APIClient.shared.deleteConversation(id: id)
+      try await ConversationRepository.shared.delete(id: id)
       await MainActor.run {
-        if let appState = AppState.current {
-          appState.deleteConversationLocally(id)
-        } else {
-          NotificationCenter.default.post(
-            name: .conversationDeleted,
-            object: nil,
-            userInfo: ["conversationId": id]
-          )
-        }
+        NotificationCenter.default.post(
+          name: .conversationDeleted,
+          object: nil,
+          userInfo: ["conversationId": id]
+        )
       }
       return ["deleted": id]
     }

--- a/desktop/macos/Desktop/Sources/Generated/OmiApi.generated.swift
+++ b/desktop/macos/Desktop/Sources/Generated/OmiApi.generated.swift
@@ -341,6 +341,7 @@ public enum OmiAPI {
     public let privateCloudSyncEnabled: Bool?
     public let processingConversationId: String?
     public let processingMemoryId: String?
+    public let revision: String?
     public let source: ConversationSource?
     public let starred: Bool?
     public let startedAt: String?
@@ -349,6 +350,7 @@ public enum OmiAPI {
     public let suggestedSummarizationApps: [String]?
     public let transcriptSegments: [TranscriptSegment]?
     public let transcriptSegmentsCompressed: Bool?
+    public let updatedAt: String?
     public let visibility: ConversationVisibility?
 
     private enum CodingKeys: String, CodingKey {
@@ -375,6 +377,7 @@ public enum OmiAPI {
       case privateCloudSyncEnabled = "private_cloud_sync_enabled"
       case processingConversationId = "processing_conversation_id"
       case processingMemoryId = "processing_memory_id"
+      case revision
       case source
       case starred
       case startedAt = "started_at"
@@ -383,6 +386,7 @@ public enum OmiAPI {
       case suggestedSummarizationApps = "suggested_summarization_apps"
       case transcriptSegments = "transcript_segments"
       case transcriptSegmentsCompressed = "transcript_segments_compressed"
+      case updatedAt = "updated_at"
       case visibility
     }
 
@@ -411,6 +415,7 @@ public enum OmiAPI {
       privateCloudSyncEnabled = try c.decodeIfPresent(Bool.self, forKey: .privateCloudSyncEnabled)
       processingConversationId = try c.decodeIfPresent(String.self, forKey: .processingConversationId)
       processingMemoryId = try c.decodeIfPresent(String.self, forKey: .processingMemoryId)
+      revision = try c.decodeIfPresent(String.self, forKey: .revision)
       source = try c.decodeIfPresent(ConversationSource.self, forKey: .source)
       starred = try c.decodeIfPresent(Bool.self, forKey: .starred)
       startedAt = try c.decodeIfPresent(String.self, forKey: .startedAt)
@@ -419,10 +424,11 @@ public enum OmiAPI {
       suggestedSummarizationApps = try c.decodeIfPresent([String].self, forKey: .suggestedSummarizationApps)
       transcriptSegments = try c.decodeIfPresent([TranscriptSegment].self, forKey: .transcriptSegments)
       transcriptSegmentsCompressed = try c.decodeIfPresent(Bool.self, forKey: .transcriptSegmentsCompressed)
+      updatedAt = try c.decodeIfPresent(String.self, forKey: .updatedAt)
       visibility = try c.decodeIfPresent(ConversationVisibility.self, forKey: .visibility)
     }
 
-    public init(appId: String?, appsResults: [AppResult]?, audioFiles: [AudioFile]?, calendarEvent: CalendarEventLink?, callId: String?, clientDeviceId: String?, clientPlatform: String?, createdAt: String, dataProtectionLevel: String?, deferred: Bool?, discarded: Bool?, externalData: [String: OmiAnyCodable]?, finishedAt: String?, folderId: String?, geolocation: Geolocation?, id: String, isLocked: Bool?, language: String?, photos: [ConversationPhoto]?, pluginsResults: [PluginResult]?, privateCloudSyncEnabled: Bool?, processingConversationId: String?, processingMemoryId: String?, source: ConversationSource?, starred: Bool?, startedAt: String?, status: ConversationStatus?, structured: Structured, suggestedSummarizationApps: [String]?, transcriptSegments: [TranscriptSegment]?, transcriptSegmentsCompressed: Bool?, visibility: ConversationVisibility?) {
+    public init(appId: String?, appsResults: [AppResult]?, audioFiles: [AudioFile]?, calendarEvent: CalendarEventLink?, callId: String?, clientDeviceId: String?, clientPlatform: String?, createdAt: String, dataProtectionLevel: String?, deferred: Bool?, discarded: Bool?, externalData: [String: OmiAnyCodable]?, finishedAt: String?, folderId: String?, geolocation: Geolocation?, id: String, isLocked: Bool?, language: String?, photos: [ConversationPhoto]?, pluginsResults: [PluginResult]?, privateCloudSyncEnabled: Bool?, processingConversationId: String?, processingMemoryId: String?, revision: String?, source: ConversationSource?, starred: Bool?, startedAt: String?, status: ConversationStatus?, structured: Structured, suggestedSummarizationApps: [String]?, transcriptSegments: [TranscriptSegment]?, transcriptSegmentsCompressed: Bool?, updatedAt: String?, visibility: ConversationVisibility?) {
       self.appId = appId
       self.appsResults = appsResults
       self.audioFiles = audioFiles
@@ -446,6 +452,7 @@ public enum OmiAPI {
       self.privateCloudSyncEnabled = privateCloudSyncEnabled
       self.processingConversationId = processingConversationId
       self.processingMemoryId = processingMemoryId
+      self.revision = revision
       self.source = source
       self.starred = starred
       self.startedAt = startedAt
@@ -454,6 +461,7 @@ public enum OmiAPI {
       self.suggestedSummarizationApps = suggestedSummarizationApps
       self.transcriptSegments = transcriptSegments
       self.transcriptSegmentsCompressed = transcriptSegmentsCompressed
+      self.updatedAt = updatedAt
       self.visibility = visibility
     }
   }
@@ -2970,6 +2978,51 @@ public enum OmiAPI {
       throw OmiApiError.httpError(status: http.statusCode, data: data)
     }
     return try JSONDecoder().decode(OmiAnyCodable.self, from: data)
+  }
+
+  public static func getConversationListProjectionV1ConversationsListGet(client: OmiApiClient, limit: Int? = nil, offset: Int? = nil, statuses: String? = nil, includeDiscarded: Bool? = nil, startDate: String? = nil, endDate: String? = nil, folderId: String? = nil, starred: Bool? = nil) async throws -> [Conversation] {
+    let _path = "/v1/conversations/list"
+    guard var components = URLComponents(string: client.baseURL + _path) else {
+      throw OmiApiError.invalidURL
+    }
+    var queryItems: [URLQueryItem] = []
+    if let limit {
+      queryItems.append(URLQueryItem(name: "limit", value: String(limit)))
+    }
+    if let offset {
+      queryItems.append(URLQueryItem(name: "offset", value: String(offset)))
+    }
+    if let statuses {
+      queryItems.append(URLQueryItem(name: "statuses", value: String(statuses)))
+    }
+    if let includeDiscarded {
+      queryItems.append(URLQueryItem(name: "include_discarded", value: String(includeDiscarded)))
+    }
+    if let startDate {
+      queryItems.append(URLQueryItem(name: "start_date", value: String(startDate)))
+    }
+    if let endDate {
+      queryItems.append(URLQueryItem(name: "end_date", value: String(endDate)))
+    }
+    if let folderId {
+      queryItems.append(URLQueryItem(name: "folder_id", value: String(folderId)))
+    }
+    if let starred {
+      queryItems.append(URLQueryItem(name: "starred", value: String(starred)))
+    }
+    if !queryItems.isEmpty { components.queryItems = queryItems }
+    guard let url = components.url else { throw OmiApiError.invalidURL }
+    var req = URLRequest(url: url)
+    req.httpMethod = "GET"
+    if let token = client.token {
+      req.setValue("Bearer " + token, forHTTPHeaderField: "Authorization")
+    }
+    let (data, resp) = try await URLSession.shared.data(for: req)
+    guard let http = resp as? HTTPURLResponse else { throw OmiApiError.invalidURL }
+    guard (200..<300).contains(http.statusCode) else {
+      throw OmiApiError.httpError(status: http.statusCode, data: data)
+    }
+    return try JSONDecoder().decode([Conversation].self, from: data)
   }
 
   public static func mergeConversationsV1ConversationsMergePost(client: OmiApiClient, body: OmiAnyCodable) async throws -> OmiAnyCodable {
@@ -8561,5 +8614,5 @@ public enum OmiAPI {
     return try JSONDecoder().decode(OmiAnyCodable.self, from: data)
   }
 
-  // Total: 343 Swift client methods generated.
+  // Total: 344 Swift client methods generated.
 }

--- a/desktop/macos/Desktop/Sources/MainWindow/Components/ConversationRowView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Components/ConversationRowView.swift
@@ -84,6 +84,28 @@ struct ConversationRowView: View {
     return folders.first(where: { $0.id == folderId })?.name
   }
 
+  @ViewBuilder
+  private var syncStatusIndicator: some View {
+    if let metadata = appState.conversationRepository.metadata(id: conversation.id) {
+      switch metadata.syncState {
+      case .synced:
+        EmptyView()
+      case .pending:
+        Image(systemName: "arrow.triangle.2.circlepath")
+          .scaledFont(size: 10)
+          .foregroundColor(OmiColors.textTertiary)
+          .help("Change queued for sync")
+          .accessibilityLabel("Change queued for sync")
+      case .failed(let message):
+        Image(systemName: "exclamationmark.triangle.fill")
+          .scaledFont(size: 10)
+          .foregroundColor(OmiColors.error)
+          .help("Could not sync change: \(message)")
+          .accessibilityLabel("Could not sync change")
+      }
+    }
+  }
+
   /// Label for the conversation source
   private var sourceLabel: String {
     switch conversation.source {
@@ -109,15 +131,10 @@ struct ConversationRowView: View {
     let newStarred = !conversation.starred
 
     do {
-      try await APIClient.shared.setConversationStarred(id: conversation.id, starred: newStarred)
-
-      // Sync to local SQLite cache so reload doesn't revert the change
-      try await TranscriptionStorage.shared.updateStarredByBackendId(
-        conversation.id, starred: newStarred)
-
-      await MainActor.run {
-        appState.setConversationStarred(conversation.id, starred: newStarred)
-      }
+      try await appState.conversationRepository.updateStarred(
+        id: conversation.id,
+        starred: newStarred
+      )
     } catch {
       log("Failed to update starred status: \(error)")
     }
@@ -166,18 +183,8 @@ struct ConversationRowView: View {
     guard !isDeleting else { return }
     isDeleting = true
 
-    // Soft-delete in SQLite immediately so reload doesn't restore it
     do {
-      try await TranscriptionStorage.shared.deleteByBackendId(conversation.id)
-    } catch {
-      log("Failed to soft-delete conversation locally: \(error)")
-    }
-
-    do {
-      try await APIClient.shared.deleteConversation(id: conversation.id)
-      await MainActor.run {
-        appState.deleteConversationLocally(conversation.id)
-      }
+      try await appState.conversationRepository.delete(id: conversation.id)
       log("Deleted conversation \(conversation.id)")
     } catch {
       log("Failed to delete conversation: \(error)")
@@ -191,15 +198,10 @@ struct ConversationRowView: View {
     isUpdatingTitle = true
 
     do {
-      try await APIClient.shared.updateConversationTitle(id: conversation.id, title: editedTitle)
-
-      // Sync to local SQLite cache so reload doesn't revert the change
-      try await TranscriptionStorage.shared.updateTitleByBackendId(
-        conversation.id, title: editedTitle)
-
-      await MainActor.run {
-        appState.updateConversationTitle(conversation.id, title: editedTitle)
-      }
+      try await appState.conversationRepository.updateTitle(
+        id: conversation.id,
+        title: editedTitle
+      )
       log("Updated conversation title to: \(editedTitle)")
     } catch {
       log("Failed to update title: \(error)")
@@ -332,6 +334,8 @@ struct ConversationRowView: View {
           Text(conversation.formattedDuration)
             .scaledFont(size: 12)
             .foregroundColor(OmiColors.textTertiary)
+
+          syncStatusIndicator
         }
       }
 
@@ -419,6 +423,8 @@ struct ConversationRowView: View {
           Text(conversation.formattedDuration)
             .scaledFont(size: 12)
             .foregroundColor(OmiColors.textTertiary)
+
+          syncStatusIndicator
         }
       }
 

--- a/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
@@ -298,7 +298,7 @@ struct DesktopHomeView: View {
                 "DesktopHomeView: userDidSignOut — resetting hasCompletedOnboarding and stopping transcription"
               )
               resetSessionScopedStartupWarmups(preserveCrispReadState: false)
-              appState.conversations = []
+              appState.conversationRepository.resetSession()
               appState.folders = []
               appState.selectedFolderId = nil
               appState.selectedDateFilter = nil
@@ -1161,10 +1161,10 @@ private struct PageContentView: View {
 /// so tapping a row navigates to the detail view.
 private struct ConversationsPageHost: View {
   let appState: AppState
-  @State private var selectedConversation: ServerConversation? = nil
+  @State private var selectedConversationId: String? = nil
 
   var body: some View {
-    ConversationsPage(appState: appState, selectedConversation: $selectedConversation)
+    ConversationsPage(appState: appState, selectedConversationId: $selectedConversationId)
   }
 }
 

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/ChatPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/ChatPage.swift
@@ -84,7 +84,6 @@ struct ChatPage: View {
     }
     .background(OmiColors.backgroundPrimary)
     .sheet(item: $citedConversation) { conversation in
-      let _ = ConversationRepository.shared.seed(conversation)
       ConversationDetailView(
         conversationId: conversation.id,
         repository: ConversationRepository.shared,
@@ -511,6 +510,7 @@ struct ChatPage: View {
     Task {
       await ConversationRepository.shared.loadDetail(id: citation.id)
       if let conversation = ConversationRepository.shared.conversation(id: citation.id) {
+        ConversationRepository.shared.seed(conversation)
         citedConversation = conversation
       } else {
         selectedCitation = nil

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/ChatPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/ChatPage.swift
@@ -84,8 +84,10 @@ struct ChatPage: View {
     }
     .background(OmiColors.backgroundPrimary)
     .sheet(item: $citedConversation) { conversation in
+      let _ = ConversationRepository.shared.seed(conversation)
       ConversationDetailView(
-        conversation: conversation,
+        conversationId: conversation.id,
+        repository: ConversationRepository.shared,
         onBack: {
           citedConversation = nil
           selectedCitation = nil
@@ -504,21 +506,16 @@ struct ChatPage: View {
     selectedCitation = citation
     isLoadingCitation = true
 
-    // Fetch the full conversation
+    // Resolve through the shared repository so every detail surface observes
+    // the same entity and completeness state.
     Task {
-      do {
-        let conversation = try await APIClient.shared.getConversation(id: citation.id)
-        await MainActor.run {
-          citedConversation = conversation
-          isLoadingCitation = false
-        }
-      } catch {
-        logError("Failed to fetch cited conversation", error: error)
-        await MainActor.run {
-          isLoadingCitation = false
-          selectedCitation = nil
-        }
+      await ConversationRepository.shared.loadDetail(id: citation.id)
+      if let conversation = ConversationRepository.shared.conversation(id: citation.id) {
+        citedConversation = conversation
+      } else {
+        selectedCitation = nil
       }
+      isLoadingCitation = false
     }
   }
 }

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/ConversationDetailView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/ConversationDetailView.swift
@@ -3,12 +3,12 @@ import OmiTheme
 
 /// Full detail view for a single conversation
 struct ConversationDetailView: View {
-    let conversation: ServerConversation
+    let conversationId: String
+    @ObservedObject var repository: ConversationRepository
     let onBack: () -> Void
     var folders: [Folder] = []
     var onMoveToFolder: ((String, String?) async -> Void)?
     var onDelete: (() -> Void)?
-    var onTitleUpdated: ((String) -> Void)?
 
     // People (speaker naming)
     var people: [Person] = []
@@ -27,8 +27,6 @@ struct ConversationDetailView: View {
     // Entry animation
     @State private var hasAppeared = false
 
-    // Full conversation loaded from API (with transcript segments)
-    @State private var loadedConversation: ServerConversation?
     @State private var isLoadingConversation = false
     // True while a lazily-deferred conversation is being enriched (polled) on first open.
     @State private var isEnrichingDeferred = false
@@ -61,9 +59,44 @@ struct ConversationDetailView: View {
         return (targets, backendIds, fallbackOrders)
     }
 
-    /// The conversation to display - use loaded version if available, otherwise use prop
+    private var conversation: ServerConversation {
+        repository.conversation(id: conversationId) ?? Self.unavailableConversation(id: conversationId)
+    }
+
+    private static func unavailableConversation(id: String) -> ServerConversation {
+        ServerConversation(
+            id: id,
+            createdAt: .distantPast,
+            startedAt: nil,
+            finishedAt: nil,
+            structured: Structured(
+                title: "Conversation unavailable",
+                overview: "This conversation is no longer available.",
+                emoji: "",
+                category: "other",
+                actionItems: [],
+                events: []
+            ),
+            transcriptSegments: [],
+            transcriptSegmentsIncluded: true,
+            geolocation: nil,
+            photos: [],
+            appsResults: [],
+            source: nil,
+            language: nil,
+            status: .failed,
+            discarded: false,
+            deleted: true,
+            isLocked: false,
+            starred: false,
+            folderId: nil,
+            inputDeviceName: nil
+        )
+    }
+
+    /// The repository projection is the only detail owner.
     private var displayConversation: ServerConversation {
-        loadedConversation ?? conversation
+        conversation
     }
 
     /// The date to display (prefer startedAt, fall back to createdAt)
@@ -174,64 +207,27 @@ struct ConversationDetailView: View {
         .task {
             await appProvider.fetchApps()
             await onFetchPeople?()
-            AnalyticsManager.shared.conversationDetailOpened(conversationId: conversation.id)
+            AnalyticsManager.shared.conversationDetailOpened(conversationId: conversationId)
+
+            isLoadingConversation = true
+            await repository.loadDetail(id: conversationId)
+            isLoadingConversation = false
 
             // Lazy processing: a deferred conversation (status=processing, only its raw transcript)
             // enriches in the background on first open. The first fetch kicks it off and returns
             // immediately (instant open); we then poll until status flips to completed, showing a
             // loader meanwhile. Capped at ~30s so the loader never spins forever (e.g. on error).
-            if conversation.deferred || conversation.status == .processing {
+            if let current = repository.conversation(id: conversationId),
+               current.deferred || current.status == .processing {
                 isEnrichingDeferred = true
                 var attempts = 0
                 while attempts < 15 {
-                    do {
-                        let fetched = try await APIClient.shared.getConversation(id: conversation.id)
-                        loadedConversation = fetched
-                        if fetched.status != .processing { break }
-                    } catch {
-                        logError("ConversationDetail: failed to enrich deferred conversation", error: error)
-                        break
-                    }
+                    await repository.loadDetail(id: conversationId)
+                    guard repository.conversation(id: conversationId)?.status == .processing else { break }
                     attempts += 1
                     try? await Task.sleep(nanoseconds: 2_000_000_000)
                 }
                 isEnrichingDeferred = false
-                return
-            }
-
-            // Load detail-only transcript data only when the list response omitted it.
-            // An explicit empty transcript means either genuinely empty or locked/redacted;
-            // do not refetch forever just because the decoded array is empty.
-            if conversation.shouldFetchDetailForTranscript {
-                isLoadingConversation = true
-                do {
-                    // First try local database (faster, works offline)
-                    if let session = try await TranscriptionStorage.shared.getSessionByBackendId(conversation.id) {
-                        let segmentRecords = try await TranscriptionStorage.shared.getSegments(sessionId: session.id!)
-                        if !segmentRecords.isEmpty {
-                            // Convert local records to TranscriptSegments and update conversation
-                            let segments = segmentRecords.map { $0.toTranscriptSegment() }
-                            var updatedConversation = conversation
-                            updatedConversation.transcriptSegments = segments
-                            updatedConversation.transcriptSegmentsIncluded = true
-                            loadedConversation = updatedConversation
-                            log("ConversationDetail: Loaded \(segments.count) segments from local database")
-                        } else {
-                            // No local segments, fetch from API
-                            let fullConversation = try await APIClient.shared.getConversation(id: conversation.id)
-                            loadedConversation = fullConversation
-                            log("ConversationDetail: Loaded \(fullConversation.transcriptSegments.count) segments from API")
-                        }
-                    } else {
-                        // No local session found, fetch from API
-                        let fullConversation = try await APIClient.shared.getConversation(id: conversation.id)
-                        loadedConversation = fullConversation
-                        log("ConversationDetail: Loaded \(fullConversation.transcriptSegments.count) segments from API (no local session)")
-                    }
-                } catch {
-                    logError("ConversationDetail: Failed to load conversation segments", error: error)
-                }
-                isLoadingConversation = false
             }
         }
         .onReceive(
@@ -543,8 +539,7 @@ struct ConversationDetailView: View {
         defer { isUpdatingTitle = false }
 
         do {
-            try await APIClient.shared.updateConversationTitle(id: conversation.id, title: editedTitle)
-            onTitleUpdated?(editedTitle)
+            try await repository.updateTitle(id: conversationId, title: editedTitle)
         } catch {
             logError("Failed to update title", error: error)
         }
@@ -555,14 +550,9 @@ struct ConversationDetailView: View {
         defer { isDeleting = false }
 
         do {
-            let conversationId = conversation.id
-            try await APIClient.shared.deleteConversation(id: conversationId)
-            await MainActor.run {
-                // Always purge local conversation + memory cache; onDelete is nav/UI only.
-                AppState.current?.deleteConversationLocally(conversationId)
-                onDelete?()
-                onBack()
-            }
+            try await repository.delete(id: conversationId)
+            onDelete?()
+            onBack()
         } catch {
             logError("Failed to delete conversation", error: error)
         }
@@ -691,7 +681,7 @@ struct ConversationDetailView: View {
             .background(OmiColors.backgroundTertiary.opacity(0.5))
 
             // Drawer content
-            if displayConversation.transcriptPresenceState == .lockedOrRedacted && !isLoadingConversation {
+            if displayConversation.transcriptPresenceState == .lockedOrRedacted {
                 VStack(spacing: 12) {
                     Image(systemName: "lock")
                         .scaledFont(size: 40)
@@ -702,7 +692,17 @@ struct ConversationDetailView: View {
                         .foregroundColor(OmiColors.textTertiary)
                 }
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
-            } else if displayConversation.transcriptSegments.isEmpty && !isLoadingConversation {
+            } else if displayConversation.transcriptSegments.isEmpty && isLoadingConversation {
+                VStack(spacing: 12) {
+                    ProgressView()
+                        .scaleEffect(0.8)
+
+                    Text("Loading transcript...")
+                        .scaledFont(size: 14)
+                        .foregroundColor(OmiColors.textTertiary)
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else if displayConversation.transcriptSegments.isEmpty {
                 // Empty state
                 VStack(spacing: 12) {
                     Image(systemName: "text.quote")
@@ -710,17 +710,6 @@ struct ConversationDetailView: View {
                         .foregroundColor(OmiColors.textTertiary.opacity(0.5))
 
                     Text("No transcript available")
-                        .scaledFont(size: 14)
-                        .foregroundColor(OmiColors.textTertiary)
-                }
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-            } else if isLoadingConversation {
-                // Loading state
-                VStack(spacing: 12) {
-                    ProgressView()
-                        .scaleEffect(0.8)
-
-                    Text("Loading transcript...")
                         .scaledFont(size: 14)
                         .foregroundColor(OmiColors.textTertiary)
                 }
@@ -776,7 +765,7 @@ struct ConversationDetailView: View {
                 translations: oldSegment.translations
             )
         }
-        loadedConversation = updatedConversation
+        repository.seed(updatedConversation)
     }
 
     private func persistSpeakerAssignment(
@@ -1065,8 +1054,10 @@ struct ConversationDetailView: View {
 
 #if canImport(PreviewsMacros)
 #Preview {
+    let _ = ConversationRepository.shared.seed(ServerConversation.preview)
     ConversationDetailView(
-        conversation: ServerConversation.preview,
+        conversationId: ServerConversation.preview.id,
+        repository: ConversationRepository.shared,
         onBack: { }
     )
     .frame(width: 600, height: 800)

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/ConversationDetailView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/ConversationDetailView.swift
@@ -765,6 +765,7 @@ struct ConversationDetailView: View {
                 translations: oldSegment.translations
             )
         }
+        guard repository.conversation(id: updatedConversation.id) != nil else { return }
         repository.seed(updatedConversation)
     }
 

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/ConversationsPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/ConversationsPage.swift
@@ -28,7 +28,8 @@ class SearchDebouncer: ObservableObject {
 
 struct ConversationsPage: View {
   @ObservedObject var appState: AppState
-  @Binding var selectedConversation: ServerConversation?
+  @ObservedObject private var conversationRepository = ConversationRepository.shared
+  @Binding var selectedConversationId: String?
 
   /// When true, renders without internal ScrollViews (for embedding in an outer ScrollView)
   var embedded: Bool = false
@@ -38,10 +39,11 @@ struct ConversationsPage: View {
 
   // Search state
   @State private var searchQuery: String = ""
-  @State private var searchResults: [ServerConversation] = []
-  @State private var isSearching: Bool = false
-  @State private var searchError: String? = nil
   @StateObject private var searchDebouncer = SearchDebouncer()
+
+  private var searchResults: [ServerConversation] { conversationRepository.searchResults }
+  private var isSearching: Bool { conversationRepository.isSearching }
+  private var searchError: String? { conversationRepository.searchError }
 
   // Date picker state
   @State private var showDatePicker: Bool = false
@@ -64,11 +66,13 @@ struct ConversationsPage: View {
 
   var body: some View {
     Group {
-      if let selected = selectedConversation {
+      if let selectedConversationId,
+         conversationRepository.conversation(id: selectedConversationId) != nil {
         // Detail view for selected conversation
         ConversationDetailView(
-          conversation: selected,
-          onBack: { selectedConversation = nil },
+          conversationId: selectedConversationId,
+          repository: conversationRepository,
+          onBack: { self.selectedConversationId = nil },
           folders: appState.folders,
           onMoveToFolder: { conversationId, folderId in
             await appState.moveConversationToFolder(conversationId, folderId: folderId)
@@ -77,14 +81,6 @@ struct ConversationsPage: View {
             // Cascade is owned by ConversationDetailView; refresh list after dismiss.
             Task {
               await appState.refreshConversations()
-            }
-          },
-          onTitleUpdated: { _ in
-            // Refresh to get updated data if conversation still exists
-            if appState.conversations.contains(where: { $0.id == selected.id }) {
-              Task {
-                await appState.refreshConversations()
-              }
             }
           },
           people: appState.people,
@@ -153,7 +149,7 @@ struct ConversationsPage: View {
     let showTranscript = notification.userInfo?["showTranscript"] as? Bool ?? false
 
     func present(_ conversation: ServerConversation) {
-      selectedConversation = conversation
+      selectedConversationId = conversation.id
       guard showTranscript else { return }
       DispatchQueue.main.asyncAfter(deadline: .now() + 0.35) {
         NotificationCenter.default.post(
@@ -260,8 +256,7 @@ struct ConversationsPage: View {
             Button(action: {
               searchQuery = ""
               searchDebouncer.inputQuery = ""
-              searchResults = []
-              searchError = nil
+              conversationRepository.clearSearch()
             }) {
               Image(systemName: "xmark.circle.fill")
                 .scaledFont(size: 13)
@@ -307,7 +302,7 @@ struct ConversationsPage: View {
             isCompactView: isCompactView,
             onSelect: { conversation in
               AnalyticsManager.shared.memoryListItemClicked(conversationId: conversation.id)
-              selectedConversation = conversation
+              selectedConversationId = conversation.id
             },
             onRefresh: {
               Task {
@@ -399,7 +394,7 @@ struct ConversationsPage: View {
           conversation: conversation,
           onTap: {
             AnalyticsManager.shared.memoryListItemClicked(conversationId: conversation.id)
-            selectedConversation = conversation
+            selectedConversationId = conversation.id
           },
           folders: appState.folders,
           onMoveToFolder: { conversationId, folderId in
@@ -435,33 +430,15 @@ struct ConversationsPage: View {
 
   private func performSearch(query: String) {
     guard !query.isEmpty else {
-      searchResults = []
-      searchError = nil
+      conversationRepository.clearSearch()
       return
     }
 
-    isSearching = true
-    searchError = nil
     log("Search: Starting search for '\(query)'")
     AnalyticsManager.shared.searchQueryEntered(query: query)
 
     Task {
-      do {
-        let result = try await APIClient.shared.searchConversations(
-          query: query,
-          page: 1,
-          perPage: 50,
-          includeDiscarded: false
-        )
-        log("Search: Found \(result.items.count) results")
-        searchResults = result.items
-        isSearching = false
-      } catch {
-        logError("Search: Failed", error: error)
-        searchError = error.localizedDescription
-        searchResults = []
-        isSearching = false
-      }
+      await conversationRepository.search(query, limit: 50)
     }
   }
 
@@ -794,7 +771,7 @@ private struct TranscriptNotesDivider: View {
 
 #if canImport(PreviewsMacros)
 #Preview {
-  ConversationsPage(appState: AppState(), selectedConversation: .constant(nil))
+  ConversationsPage(appState: AppState(), selectedConversationId: .constant(nil))
     .frame(width: 600, height: 800)
     .background(OmiColors.backgroundSecondary)
 }

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
@@ -379,8 +379,10 @@ struct DashboardPage: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(useLegacyHomeDesign ? Color.clear : HomePalette.paper)
         .sheet(item: $citedConversation) { conversation in
+            let _ = ConversationRepository.shared.seed(conversation)
             ConversationDetailView(
-                conversation: conversation,
+                conversationId: conversation.id,
+                repository: ConversationRepository.shared,
                 onBack: {
                     citedConversation = nil
                 }
@@ -1656,18 +1658,9 @@ struct DashboardPage: View {
         isLoadingCitation = true
 
         Task {
-            do {
-                let conversation = try await APIClient.shared.getConversation(id: citation.id)
-                await MainActor.run {
-                    citedConversation = conversation
-                    isLoadingCitation = false
-                }
-            } catch {
-                logError("Failed to fetch cited conversation", error: error)
-                await MainActor.run {
-                    isLoadingCitation = false
-                }
-            }
+            await ConversationRepository.shared.loadDetail(id: citation.id)
+            citedConversation = ConversationRepository.shared.conversation(id: citation.id)
+            isLoadingCitation = false
         }
     }
 

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
@@ -379,7 +379,6 @@ struct DashboardPage: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(useLegacyHomeDesign ? Color.clear : HomePalette.paper)
         .sheet(item: $citedConversation) { conversation in
-            let _ = ConversationRepository.shared.seed(conversation)
             ConversationDetailView(
                 conversationId: conversation.id,
                 repository: ConversationRepository.shared,

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoriesPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoriesPage.swift
@@ -1356,7 +1356,6 @@ struct MemoriesPage: View {
     Group {
       if let conversation = viewModel.linkedConversation {
         // Show conversation detail view
-        let _ = ConversationRepository.shared.seed(conversation)
         ConversationDetailView(
           conversationId: conversation.id,
           repository: ConversationRepository.shared,

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoriesPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoriesPage.swift
@@ -1333,11 +1333,8 @@ class MemoriesViewModel: ObservableObject {
 
   func navigateToConversation(id: String) async {
     isLoadingConversation = true
-    do {
-      linkedConversation = try await APIClient.shared.getConversation(id: id)
-    } catch {
-      logError("Failed to load conversation", error: error)
-    }
+    await ConversationRepository.shared.loadDetail(id: id)
+    linkedConversation = ConversationRepository.shared.conversation(id: id)
     isLoadingConversation = false
   }
 
@@ -1359,8 +1356,10 @@ struct MemoriesPage: View {
     Group {
       if let conversation = viewModel.linkedConversation {
         // Show conversation detail view
+        let _ = ConversationRepository.shared.seed(conversation)
         ConversationDetailView(
-          conversation: conversation,
+          conversationId: conversation.id,
+          repository: ConversationRepository.shared,
           onBack: { viewModel.dismissConversation() }
         )
       } else {

--- a/desktop/macos/Desktop/Sources/Rewind/Core/RewindDatabase.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/RewindDatabase.swift
@@ -2367,6 +2367,15 @@ actor RewindDatabase {
             }
         }
 
+        // Keep server ordering at sub-millisecond precision. The legacy
+        // datetime column remains readable for developer databases created by
+        // the earlier unreleased migration.
+        migrator.registerMigration("addConversationServerUpdatedAtEpoch") { db in
+            try db.alter(table: "conversation_cache") { t in
+                t.add(column: "serverUpdatedAtEpoch", .double)
+            }
+        }
+
         try migrator.migrate(queue)
     }
 

--- a/desktop/macos/Desktop/Sources/Rewind/Core/RewindDatabase.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/RewindDatabase.swift
@@ -2319,6 +2319,54 @@ actor RewindDatabase {
             try db.execute(sql: "ALTER TABLE task_chat_messages ADD COLUMN resourcesJson TEXT")
         }
 
+        // Conversations use a dedicated read model instead of overloading
+        // transcription_sessions (the crash-recovery/finalization journal).
+        // Payloads retain the complete domain model while indexed columns keep
+        // cache-first list/filter reads cheap and deterministic.
+        migrator.registerMigration("createConversationReadModel") { db in
+            try db.create(table: "conversation_cache") { t in
+                t.column("id", .text).primaryKey()
+                t.column("payload", .blob).notNull()
+                t.column("serverRevision", .text)
+                t.column("serverUpdatedAt", .datetime)
+                t.column("cacheWrittenAt", .datetime).notNull()
+                t.column("completeness", .integer).notNull().defaults(to: 1)
+                t.column("createdAt", .datetime).notNull()
+                t.column("starred", .boolean).notNull().defaults(to: false)
+                t.column("folderId", .text)
+                t.column("status", .text).notNull()
+                t.column("discarded", .boolean).notNull().defaults(to: false)
+                t.column("deleted", .boolean).notNull().defaults(to: false)
+            }
+            try db.create(
+                index: "idx_conversation_cache_list",
+                on: "conversation_cache",
+                columns: ["deleted", "discarded", "createdAt"]
+            )
+
+            try db.create(table: "conversation_query_snapshots") { t in
+                t.column("queryKey", .text).primaryKey()
+                t.column("conversationIdsJson", .text).notNull()
+                t.column("fetchedAt", .datetime).notNull()
+            }
+
+            try db.create(table: "conversation_pending_mutations") { t in
+                t.column("conversationId", .text).primaryKey()
+                t.column("payload", .blob).notNull()
+                t.column("updatedAt", .datetime).notNull()
+            }
+        }
+
+        // Kept separate from createConversationReadModel so developer builds
+        // that exercised the unreleased first migration can upgrade in place.
+        migrator.registerMigration("addConversationProjectionFreshness") { db in
+            try db.alter(table: "conversation_cache") { t in
+                t.add(column: "listFetchedAt", .datetime)
+                t.add(column: "detailFetchedAt", .datetime)
+                t.add(column: "transcriptFetchedAt", .datetime)
+            }
+        }
+
         try migrator.migrate(queue)
     }
 

--- a/desktop/macos/Desktop/Sources/Rewind/Core/TranscriptionModels.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/TranscriptionModels.swift
@@ -40,7 +40,8 @@ enum LocalConversationStatus: String, Codable, CaseIterable {
 
 /// Database record for transcription recording sessions
 /// Stores metadata about a transcription session for crash recovery and retry
-/// Also serves as local cache for conversations synced from backend
+/// Server fields are retained only for capture finalization/retry and a one-time
+/// migration into ConversationCacheStorage. This table is not a Conversations UI read model.
 struct TranscriptionSessionRecord: Codable, FetchableRecord, PersistableRecord, Identifiable {
     var id: Int64?
     var startedAt: Date

--- a/desktop/macos/Desktop/Sources/ViewExporter.swift
+++ b/desktop/macos/Desktop/Sources/ViewExporter.swift
@@ -73,7 +73,7 @@ enum ViewExporter {
 
       (
         "04-conversations",
-        { AnyView(ConversationsPage(appState: AppState(), selectedConversation: .constant(nil))) },
+        { AnyView(ConversationsPage(appState: AppState(), selectedConversationId: .constant(nil))) },
         CGSize(width: 900, height: 700)
       ),
 

--- a/desktop/macos/Desktop/Tests/APIClientRoutingTests.swift
+++ b/desktop/macos/Desktop/Tests/APIClientRoutingTests.swift
@@ -18,6 +18,7 @@ private final class URLCapture: URLProtocol, @unchecked Sendable {
     private static var _requests: [CapturedRequest] = []
     private static var _statusCode = 403
     private static var _responseBody = Data("{\"detail\":\"test\"}".utf8)
+    private static var _queuedResponses: [(Int, Data)] = []
 
     static var capturedRequests: [CapturedRequest] {
         lock.lock()
@@ -30,6 +31,7 @@ private final class URLCapture: URLProtocol, @unchecked Sendable {
         _requests.removeAll()
         _statusCode = 403
         _responseBody = Data("{\"detail\":\"test\"}".utf8)
+        _queuedResponses = []
         lock.unlock()
     }
 
@@ -37,6 +39,12 @@ private final class URLCapture: URLProtocol, @unchecked Sendable {
         lock.lock()
         _statusCode = statusCode
         _responseBody = body
+        lock.unlock()
+    }
+
+    static func setResponses(_ responses: [(statusCode: Int, body: Data)]) {
+        lock.lock()
+        _queuedResponses = responses.map { ($0.statusCode, $0.body) }
         lock.unlock()
     }
 
@@ -101,6 +109,9 @@ private final class URLCapture: URLProtocol, @unchecked Sendable {
     private static func response() -> (Int, Data) {
         lock.lock()
         defer { lock.unlock() }
+        if !_queuedResponses.isEmpty {
+            return _queuedResponses.removeFirst()
+        }
         return (_statusCode, _responseBody)
     }
 }
@@ -351,6 +362,30 @@ final class APIClientRoutingTests: XCTestCase {
                      label: "getConversation")
     }
 
+    func testGetConversationListUsesExplicitLightweightProjection() async {
+        let client = await makeTestClient()
+        _ = try? await client.getConversationList(limit: 50)
+        assertRoutes(URLCapture.capturedRequests, host: "python-test", port: 9001,
+                     pathContains: "v1/conversations/list", method: "GET",
+                     label: "getConversationList")
+    }
+
+    func testConversationListFallsBackOnceDuringRollingBackendDeployment() async throws {
+        URLCapture.setResponses([
+            (404, Data("{\"detail\":\"Conversation not found\"}".utf8)),
+            (200, Data("[]".utf8)),
+        ])
+        let client = await makeTestClient()
+
+        let result = try await client.getConversationList(limit: 50)
+
+        XCTAssertTrue(result.isEmpty)
+        let requests = URLCapture.capturedRequests
+        XCTAssertEqual(requests.count, 2)
+        XCTAssertTrue(requests[0].url.absoluteString.contains("v1/conversations/list?"))
+        XCTAssertTrue(requests[1].url.absoluteString.contains("v1/conversations?"))
+    }
+
     func testDeleteConversationRoutesToPython() async {
         let client = await makeTestClient()
         try? await client.deleteConversation(id: "conv-456")
@@ -363,7 +398,7 @@ final class APIClientRoutingTests: XCTestCase {
 
     func testSetConversationStarredRoutesToPython() async {
         let client = await makeTestClient()
-        try? await client.setConversationStarred(id: "c1", starred: true)
+        _ = try? await client.setConversationStarred(id: "c1", starred: true)
         assertRoutes(URLCapture.capturedRequests, host: "python-test", port: 9001,
                      pathContains: "v1/conversations/c1/starred", method: "PATCH",
                      label: "setConversationStarred")
@@ -371,10 +406,21 @@ final class APIClientRoutingTests: XCTestCase {
 
     func testUpdateConversationTitleRoutesToPython() async {
         let client = await makeTestClient()
-        try? await client.updateConversationTitle(id: "c2", title: "New")
+        _ = try? await client.updateConversationTitle(id: "c2", title: "New")
         assertRoutes(URLCapture.capturedRequests, host: "python-test", port: 9001,
                      pathContains: "v1/conversations/c2", method: "PATCH",
                      label: "updateConversationTitle")
+    }
+
+    func testStatusOnlyMutationDoesNotTriggerDetailEnrichmentDuringBackendRollout() async {
+        URLCapture.setResponse(statusCode: 200, body: Data("{\"status\":\"Ok\"}".utf8))
+        let client = await makeTestClient()
+
+        _ = try? await client.updateConversationTitle(id: "c2", title: "New")
+
+        let requests = URLCapture.capturedRequests
+        XCTAssertEqual(requests.map(\.method), ["PATCH"])
+        XCTAssertTrue(requests.allSatisfy { $0.url.absoluteString.contains("v1/conversations/c2") })
     }
 
     // -- Folders (GET → Python) --
@@ -602,7 +648,7 @@ final class APIClientRoutingTests: XCTestCase {
 
     func testMoveConversationToFolderRoutesToPython() async {
         let client = await makeTestClient()
-        try? await client.moveConversationToFolder(conversationId: "c4", folderId: "f1")
+        _ = try? await client.moveConversationToFolder(conversationId: "c4", folderId: "f1")
         assertRoutes(URLCapture.capturedRequests, host: "python-test", port: 9001,
                      pathContains: "v1/conversations/c4/folder", method: "PATCH",
                      label: "moveConversationToFolder")

--- a/desktop/macos/Desktop/Tests/APIClientRoutingTests.swift
+++ b/desktop/macos/Desktop/Tests/APIClientRoutingTests.swift
@@ -116,6 +116,23 @@ private final class URLCapture: URLProtocol, @unchecked Sendable {
     }
 }
 
+private final class FallbackRecorderSpy: @unchecked Sendable {
+    private let lock = NSLock()
+    private var count = 0
+
+    func record() {
+        lock.lock()
+        count += 1
+        lock.unlock()
+    }
+
+    var recordedCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return count
+    }
+}
+
 // MARK: - Assertion helpers
 
 private func assertRoutes(
@@ -329,11 +346,16 @@ final class APIClientRoutingTests: XCTestCase {
 
     // MARK: - Routing behavior: Python-routed endpoints (default baseURL)
 
-    private func makeTestClient() async -> APIClient {
+    private func makeTestClient(
+        conversationListFallbackRecorder: @escaping @Sendable () -> Void = {}
+    ) async -> APIClient {
         let config = URLSessionConfiguration.ephemeral
         config.protocolClasses = [URLCapture.self]
         let session = URLSession(configuration: config)
-        let client = APIClient(session: session)
+        let client = APIClient(
+            session: session,
+            conversationListFallbackRecorder: conversationListFallbackRecorder
+        )
         await client.setTestAuthHeader("Bearer test-token")
         return client
     }
@@ -375,7 +397,10 @@ final class APIClientRoutingTests: XCTestCase {
             (404, Data("{\"detail\":\"Conversation not found\"}".utf8)),
             (200, Data("[]".utf8)),
         ])
-        let client = await makeTestClient()
+        let fallbackRecorder = FallbackRecorderSpy()
+        let client = await makeTestClient {
+            fallbackRecorder.record()
+        }
 
         let result = try await client.getConversationList(limit: 50)
 
@@ -384,6 +409,7 @@ final class APIClientRoutingTests: XCTestCase {
         XCTAssertEqual(requests.count, 2)
         XCTAssertTrue(requests[0].url.absoluteString.contains("v1/conversations/list?"))
         XCTAssertTrue(requests[1].url.absoluteString.contains("v1/conversations?"))
+        XCTAssertEqual(fallbackRecorder.recordedCount, 1)
     }
 
     func testDeleteConversationRoutesToPython() async {

--- a/desktop/macos/Desktop/Tests/ConversationCacheStorageTests.swift
+++ b/desktop/macos/Desktop/Tests/ConversationCacheStorageTests.swift
@@ -1,0 +1,180 @@
+import XCTest
+import OmiSupport
+@testable import Omi_Computer
+
+final class ConversationCacheStorageTests: XCTestCase {
+  private var testUserId = ""
+  private var userDirectories: [URL] = []
+
+  override func setUp() async throws {
+    try await super.setUp()
+    testUserId = "conversation-cache-test-\(UUID().uuidString)"
+    await RewindDatabase.shared.close()
+    await ConversationCacheStorage.shared.invalidateCache()
+    RewindDatabase.currentUserId = testUserId
+    await RewindDatabase.shared.configure(userId: testUserId)
+    try await RewindDatabase.shared.initialize()
+    userDirectories = [directory(for: testUserId)]
+  }
+
+  override func tearDown() async throws {
+    await ConversationCacheStorage.shared.invalidateCache()
+    await RewindDatabase.shared.close()
+    RewindDatabase.currentUserId = nil
+    for userDirectory in userDirectories { try? FileManager.default.removeItem(at: userDirectory) }
+    try await super.tearDown()
+  }
+
+  func testRealDatabaseMigrationPreservesDetailAcrossPartialListRefresh() async throws {
+    let detail = conversation(
+      title: "Cached detail",
+      overview: "Cached overview",
+      revision: "2",
+      updatedAt: Date(timeIntervalSince1970: 2),
+      transcript: [segment("complete transcript")],
+      transcriptIncluded: true
+    )
+    try await ConversationCacheStorage.shared.upsertServerConversation(
+      detail,
+      completeness: [.list, .detail, .transcript],
+      fetchedAt: Date(timeIntervalSince1970: 2),
+      accountId: testUserId
+    )
+
+    let list = conversation(
+      title: "Fresh list title",
+      overview: "Fresh overview",
+      revision: "3",
+      updatedAt: Date(timeIntervalSince1970: 3)
+    )
+    try await ConversationCacheStorage.shared.applyServerSnapshot(
+      [list],
+      query: ConversationQuery(),
+      fetchedAt: Date(timeIntervalSince1970: 3),
+      accountId: testUserId
+    )
+
+    let loaded = try await ConversationCacheStorage.shared.load(id: "c1", accountId: testUserId)
+    let cached = try XCTUnwrap(loaded)
+    XCTAssertEqual(cached.conversation.structured.title, "Fresh list title")
+    XCTAssertEqual(cached.conversation.structured.overview, "Fresh overview")
+    XCTAssertEqual(cached.conversation.transcriptSegments.map(\.text), ["complete transcript"])
+    XCTAssertTrue(cached.completeness.contains(.detail))
+    XCTAssertTrue(cached.completeness.contains(.transcript))
+    XCTAssertEqual(cached.listFetchedAt, Date(timeIntervalSince1970: 3))
+    XCTAssertEqual(cached.detailFetchedAt, Date(timeIntervalSince1970: 2))
+    XCTAssertEqual(cached.transcriptFetchedAt, Date(timeIntervalSince1970: 2))
+  }
+
+  func testPendingMutationAndFilteredQuerySurviveStorageRoundTrip() async throws {
+    let starred = conversation(
+      title: "Starred",
+      overview: "Overview",
+      revision: "1",
+      updatedAt: Date(timeIntervalSince1970: 1),
+      starred: true
+    )
+    let query = ConversationQuery(showStarredOnly: true)
+    try await ConversationCacheStorage.shared.applyServerSnapshot(
+      [starred],
+      query: query,
+      fetchedAt: Date(timeIntervalSince1970: 1),
+      accountId: testUserId
+    )
+    var mutation = ConversationPendingMutation()
+    mutation.setStarred(false)
+    try await ConversationCacheStorage.shared.savePendingMutation(
+      mutation,
+      conversationId: "c1",
+      accountId: testUserId
+    )
+    let visible = try await ConversationCacheStorage.shared.load(query: query, accountId: testUserId)
+    let pending = try await ConversationCacheStorage.shared.loadPendingMutations(accountId: testUserId)
+
+    XCTAssertEqual(visible.map { $0.conversation.id }, ["c1"])
+    XCTAssertEqual(pending["c1"]?.starred, false)
+  }
+
+  func testAccountSwitchCannotReadPreviousAccountsConversationCache() async throws {
+    let firstAccountConversation = conversation(
+      title: "First account only",
+      overview: "Private",
+      revision: "1",
+      updatedAt: Date(timeIntervalSince1970: 1)
+    )
+    try await ConversationCacheStorage.shared.upsertServerConversation(
+      firstAccountConversation,
+      completeness: [.list],
+      fetchedAt: Date(timeIntervalSince1970: 1),
+      accountId: testUserId
+    )
+
+    let secondUserId = "conversation-cache-test-\(UUID().uuidString)"
+    userDirectories.append(directory(for: secondUserId))
+    try await RewindDatabase.shared.switchUser(to: secondUserId)
+
+    let leaked = try await ConversationCacheStorage.shared.load(id: "c1", accountId: secondUserId)
+
+    XCTAssertNil(leaked)
+  }
+
+  private func conversation(
+    title: String,
+    overview: String,
+    revision: String,
+    updatedAt: Date,
+    transcript: [TranscriptSegment] = [],
+    transcriptIncluded: Bool = false,
+    starred: Bool = false
+  ) -> ServerConversation {
+    let createdAt = Date(timeIntervalSince1970: 1_000)
+    return ServerConversation(
+      id: "c1",
+      createdAt: createdAt,
+      startedAt: createdAt,
+      finishedAt: createdAt.addingTimeInterval(60),
+      structured: Structured(
+        title: title,
+        overview: overview,
+        emoji: "💬",
+        category: "other",
+        actionItems: [],
+        events: []
+      ),
+      transcriptSegments: transcript,
+      transcriptSegmentsIncluded: transcriptIncluded,
+      geolocation: nil,
+      photos: [],
+      appsResults: [],
+      source: .desktop,
+      language: "en",
+      status: .completed,
+      discarded: false,
+      deleted: false,
+      isLocked: false,
+      starred: starred,
+      folderId: nil,
+      inputDeviceName: nil,
+      updatedAt: updatedAt,
+      revision: revision
+    )
+  }
+
+  private func segment(_ text: String) -> TranscriptSegment {
+    TranscriptSegment(
+      id: "segment-1",
+      text: text,
+      speaker: "SPEAKER_00",
+      isUser: true,
+      personId: nil,
+      start: 0,
+      end: 1
+    )
+  }
+
+  private func directory(for userId: String) -> URL {
+    DesktopLocalProfile.applicationSupportURL()
+      .appendingPathComponent("users", isDirectory: true)
+      .appendingPathComponent(userId, isDirectory: true)
+  }
+}

--- a/desktop/macos/Desktop/Tests/ConversationCacheStorageTests.swift
+++ b/desktop/macos/Desktop/Tests/ConversationCacheStorageTests.swift
@@ -2,6 +2,79 @@ import XCTest
 import OmiSupport
 @testable import Omi_Computer
 
+private actor ConversationCacheAccountScope {
+  private var accountId: String
+
+  init(_ accountId: String) {
+    self.accountId = accountId
+  }
+
+  func current() -> String { accountId }
+  func switchTo(_ accountId: String) { self.accountId = accountId }
+}
+
+private final class ConversationCacheMergeRaceGate: @unchecked Sendable {
+  private let lock = NSLock()
+  private let releaseFirstRead = DispatchSemaphore(value: 0)
+  private var reads = 0
+  private var firstReadObserved = false
+  private var secondAttemptObserved = false
+  private var firstReadWaiters: [CheckedContinuation<Void, Never>] = []
+  private var secondAttemptWaiters: [CheckedContinuation<Void, Never>] = []
+
+  func afterRead() {
+    lock.lock()
+    reads += 1
+    let isFirst = reads == 1
+    if isFirst {
+      firstReadObserved = true
+      firstReadWaiters.forEach { $0.resume() }
+      firstReadWaiters.removeAll()
+    }
+    lock.unlock()
+    guard isFirst else { return }
+    releaseFirstRead.wait()
+  }
+
+  func waitUntilFirstRead() async {
+    await withCheckedContinuation { continuation in
+      lock.lock()
+      if firstReadObserved {
+        lock.unlock()
+        continuation.resume()
+      } else {
+        firstReadWaiters.append(continuation)
+        lock.unlock()
+      }
+    }
+  }
+
+  func signalSecondAttempt() {
+    lock.lock()
+    secondAttemptObserved = true
+    secondAttemptWaiters.forEach { $0.resume() }
+    secondAttemptWaiters.removeAll()
+    lock.unlock()
+  }
+
+  func waitUntilSecondAttempted() async {
+    await withCheckedContinuation { continuation in
+      lock.lock()
+      if secondAttemptObserved {
+        lock.unlock()
+        continuation.resume()
+      } else {
+        secondAttemptWaiters.append(continuation)
+        lock.unlock()
+      }
+    }
+  }
+
+  func release() {
+    releaseFirstRead.signal()
+  }
+}
+
 final class ConversationCacheStorageTests: XCTestCase {
   private var testUserId = ""
   private var userDirectories: [URL] = []
@@ -116,6 +189,163 @@ final class ConversationCacheStorageTests: XCTestCase {
     let leaked = try await ConversationCacheStorage.shared.load(id: "c1", accountId: secondUserId)
 
     XCTAssertNil(leaked)
+
+    do {
+      _ = try await ConversationCacheStorage.shared.load(id: "c1", accountId: testUserId)
+      XCTFail("an operation carrying the previous account scope must be rejected")
+    } catch {
+      // Expected: the cache refuses to pair an old account token with the new pool.
+    }
+  }
+
+  func testAccountSwitchDuringPoolLookupRejectsOldScopeBeforeRead() async throws {
+    let queueValue = await RewindDatabase.shared.getDatabaseQueue()
+    let firstAccountQueue = try XCTUnwrap(queueValue)
+    let secondUserId = "conversation-cache-test-\(UUID().uuidString)"
+    let accountScope = ConversationCacheAccountScope(testUserId)
+    let storage = ConversationCacheStorage(
+      currentAccountIdProvider: { await accountScope.current() },
+      initializeDatabase: {},
+      databaseQueueProvider: {
+        await accountScope.switchTo(secondUserId)
+        return firstAccountQueue
+      }
+    )
+
+    do {
+      _ = try await storage.load(id: "c1", accountId: testUserId)
+      XCTFail("the old account scope must be rechecked after pool lookup")
+    } catch {
+      // Expected: the pool was resolved while the account scope changed.
+    }
+  }
+
+  func testConcurrentMergeTransactionCannotLetDelayedOlderResponseWin() async throws {
+    let baseline = conversation(
+      title: "Baseline",
+      overview: "Initial",
+      revision: "1",
+      updatedAt: Date(timeIntervalSince1970: 1)
+    )
+    try await ConversationCacheStorage.shared.upsertServerConversation(
+      baseline,
+      completeness: [.list],
+      fetchedAt: Date(timeIntervalSince1970: 1),
+      accountId: testUserId
+    )
+
+    let gate = ConversationCacheMergeRaceGate()
+    let delayedStorage = ConversationCacheStorage(
+      afterCachedRecordRead: { _ in gate.afterRead() }
+    )
+    let newerStorage = ConversationCacheStorage(
+      beforeMergeTransaction: { _ in gate.signalSecondAttempt() }
+    )
+    let delayedOlder = conversation(
+      title: "Delayed older",
+      overview: "Must not win",
+      revision: "2",
+      updatedAt: Date(timeIntervalSince1970: 2)
+    )
+    let newer = conversation(
+      title: "Newer",
+      overview: "Canonical",
+      revision: "3",
+      updatedAt: Date(timeIntervalSince1970: 3)
+    )
+
+    let olderTask = Task {
+      try await delayedStorage.upsertServerConversation(
+        delayedOlder,
+        completeness: [.list],
+        fetchedAt: Date(timeIntervalSince1970: 2),
+        accountId: testUserId
+      )
+    }
+    await gate.waitUntilFirstRead()
+    let newerTask = Task {
+      try await newerStorage.upsertServerConversation(
+        newer,
+        completeness: [.list],
+        fetchedAt: Date(timeIntervalSince1970: 3),
+        accountId: testUserId
+      )
+    }
+    await gate.waitUntilSecondAttempted()
+    gate.release()
+    try await olderTask.value
+    try await newerTask.value
+
+    let loadedValue = try await newerStorage.load(id: "c1", accountId: testUserId)
+    let loaded = try XCTUnwrap(loadedValue)
+    XCTAssertEqual(loaded.conversation.structured.title, "Newer")
+    XCTAssertEqual(loaded.conversation.revision, "3")
+  }
+
+  func testSelectedDateQueryStillMatchesDateEncodedCacheRows() async throws {
+    let cached = conversation(
+      title: "Selected day",
+      overview: "Date-filtered",
+      revision: "1",
+      updatedAt: Date(timeIntervalSince1970: 1)
+    )
+    try await ConversationCacheStorage.shared.upsertServerConversation(
+      cached,
+      completeness: [.list],
+      fetchedAt: Date(timeIntervalSince1970: 1),
+      accountId: testUserId
+    )
+
+    let selectedDate = Date(timeIntervalSince1970: 1_000)
+    let loaded = try await ConversationCacheStorage.shared.load(
+      query: ConversationQuery(selectedDate: selectedDate),
+      accountId: testUserId
+    )
+
+    XCTAssertEqual(loaded.map { $0.conversation.id }, ["c1"])
+  }
+
+  func testSameSecondOlderSnapshotCannotOverwriteNewerCachedVersion() async throws {
+    let newerTime = Date(timeIntervalSince1970: 1_000.9009)
+    let olderTime = Date(timeIntervalSince1970: 1_000.9005)
+    let newer = conversation(
+      title: "Newer",
+      overview: "Canonical",
+      revision: "newer",
+      updatedAt: newerTime
+    )
+    try await ConversationCacheStorage.shared.upsertServerConversation(
+      newer,
+      completeness: [.list],
+      fetchedAt: newerTime,
+      accountId: testUserId
+    )
+
+    let roundTrippedValue = try await ConversationCacheStorage.shared.load(id: "c1", accountId: testUserId)
+    let roundTripped = try XCTUnwrap(roundTrippedValue)
+    XCTAssertEqual(
+      try XCTUnwrap(roundTripped.conversation.updatedAt).timeIntervalSince1970,
+      newerTime.timeIntervalSince1970,
+      accuracy: 0.000_001
+    )
+
+    let delayedOlder = conversation(
+      title: "Older",
+      overview: "Must not win",
+      revision: "older",
+      updatedAt: olderTime
+    )
+    try await ConversationCacheStorage.shared.applyServerSnapshot(
+      [delayedOlder],
+      query: ConversationQuery(),
+      fetchedAt: Date(timeIntervalSince1970: 2_000),
+      accountId: testUserId
+    )
+
+    let loadedValue = try await ConversationCacheStorage.shared.load(id: "c1", accountId: testUserId)
+    let loaded = try XCTUnwrap(loadedValue)
+    XCTAssertEqual(loaded.conversation.structured.title, "Newer")
+    XCTAssertEqual(loaded.conversation.revision, "newer")
   }
 
   private func conversation(

--- a/desktop/macos/Desktop/Tests/ConversationRepositoryTests.swift
+++ b/desktop/macos/Desktop/Tests/ConversationRepositoryTests.swift
@@ -1,0 +1,1062 @@
+import XCTest
+@testable import Omi_Computer
+
+private actor ConversationTestGate {
+  private var released = false
+  private var waiters: [CheckedContinuation<Void, Never>] = []
+  private var observers: [CheckedContinuation<Void, Never>] = []
+
+  func wait() async {
+    observers.forEach { $0.resume() }
+    observers.removeAll()
+    guard !released else { return }
+    await withCheckedContinuation { waiters.append($0) }
+  }
+
+  func waitUntilBlocked() async {
+    guard !released, waiters.isEmpty else { return }
+    await withCheckedContinuation { observers.append($0) }
+  }
+
+  func release() {
+    released = true
+    waiters.forEach { $0.resume() }
+    waiters.removeAll()
+    observers.forEach { $0.resume() }
+    observers.removeAll()
+  }
+}
+
+private enum ConversationRemoteStubError: Error {
+  case mutationFailed
+}
+
+private actor ConversationRemoteStub: ConversationRemoteServing {
+  var listResult: [ServerConversation]
+  var detailById: [String: ServerConversation]
+  var detailError: Error?
+  var titleResult: ServerConversation?
+  var starredResult: ServerConversation?
+  var folderResult: ServerConversation?
+  var mutationError: Error?
+  let listGate: ConversationTestGate?
+  let searchResults: [String: [ServerConversation]]
+  let searchGates: [String: ConversationTestGate]
+  let titleResults: [String: ServerConversation]
+  let titleGates: [String: ConversationTestGate]
+  let deleteGate: ConversationTestGate?
+  let titleErrors: [String: Error]
+  let lightweightAcks: Bool
+  let statusOnlyAcks: Bool
+  private var titleRequests: [String] = []
+
+  init(
+    list: [ServerConversation],
+    detailById: [String: ServerConversation] = [:],
+    detailError: Error? = nil,
+    titleResult: ServerConversation? = nil,
+    starredResult: ServerConversation? = nil,
+    folderResult: ServerConversation? = nil,
+    mutationError: Error? = nil,
+    listGate: ConversationTestGate? = nil,
+    searchResults: [String: [ServerConversation]] = [:],
+    searchGates: [String: ConversationTestGate] = [:],
+    titleResults: [String: ServerConversation] = [:],
+    titleGates: [String: ConversationTestGate] = [:],
+    deleteGate: ConversationTestGate? = nil,
+    titleErrors: [String: Error] = [:],
+    lightweightAcks: Bool = false,
+    statusOnlyAcks: Bool = false
+  ) {
+    listResult = list
+    self.detailById = detailById
+    self.detailError = detailError
+    self.titleResult = titleResult
+    self.starredResult = starredResult
+    self.folderResult = folderResult
+    self.mutationError = mutationError
+    self.listGate = listGate
+    self.searchResults = searchResults
+    self.searchGates = searchGates
+    self.titleResults = titleResults
+    self.titleGates = titleGates
+    self.deleteGate = deleteGate
+    self.titleErrors = titleErrors
+    self.lightweightAcks = lightweightAcks
+    self.statusOnlyAcks = statusOnlyAcks
+  }
+
+  func list(query: ConversationQuery) async throws -> [ServerConversation] {
+    await listGate?.wait()
+    return listResult
+  }
+
+  func count(query: ConversationQuery) async throws -> Int { listResult.count }
+
+  func detail(id: String) async throws -> ServerConversation {
+    if let detailError { throw detailError }
+    return detailById[id] ?? listResult.first { $0.id == id }!
+  }
+
+  func search(query: String, limit: Int) async throws -> [ServerConversation] {
+    await searchGates[query]?.wait()
+    return searchResults[query] ?? listResult
+  }
+
+  func updateTitle(id: String, title: String) async throws -> ConversationMutationAcknowledgement {
+    titleRequests.append(title)
+    await titleGates[title]?.wait()
+    if let error = titleErrors[title] { throw error }
+    if let mutationError { throw mutationError }
+    let conversation = titleResults[title] ?? titleResult ?? listResult.first { $0.id == id }!
+    return ConversationMutationAcknowledgement(
+      id: id,
+      updatedAt: statusOnlyAcks ? nil : conversation.updatedAt,
+      revision: statusOnlyAcks ? nil : conversation.revision,
+      value: .title(title),
+      conversation: (lightweightAcks || statusOnlyAcks) ? nil : conversation
+    )
+  }
+
+  func updateStarred(id: String, starred: Bool) async throws -> ConversationMutationAcknowledgement {
+    if let mutationError { throw mutationError }
+    let conversation = starredResult ?? listResult.first { $0.id == id }!
+    return ConversationMutationAcknowledgement(
+      id: id,
+      updatedAt: statusOnlyAcks ? nil : conversation.updatedAt,
+      revision: statusOnlyAcks ? nil : conversation.revision,
+      value: .starred(starred),
+      conversation: (lightweightAcks || statusOnlyAcks) ? nil : conversation
+    )
+  }
+
+  func moveToFolder(id: String, folderId: String?) async throws -> ConversationMutationAcknowledgement {
+    if let mutationError { throw mutationError }
+    let conversation = folderResult ?? listResult.first { $0.id == id }!
+    return ConversationMutationAcknowledgement(
+      id: id,
+      updatedAt: statusOnlyAcks ? nil : conversation.updatedAt,
+      revision: statusOnlyAcks ? nil : conversation.revision,
+      value: .folder(folderId),
+      conversation: (lightweightAcks || statusOnlyAcks) ? nil : conversation
+    )
+  }
+
+  func delete(id: String) async throws {
+    await deleteGate?.wait()
+    if let mutationError { throw mutationError }
+  }
+
+  func requestedTitles() -> [String] { titleRequests }
+}
+
+private actor ConversationCacheStub: ConversationCachePersisting {
+  private var entries: [String: ConversationCacheEntry]
+  private var order: [String]
+  private var pending: [String: ConversationPendingMutation]
+  private let idLoadGate: ConversationTestGate?
+  private let listLoadGate: ConversationTestGate?
+  private var serverUpsertAccounts: [String] = []
+
+  init(
+    entries: [ConversationCacheEntry] = [],
+    pending: [String: ConversationPendingMutation] = [:],
+    idLoadGate: ConversationTestGate? = nil,
+    listLoadGate: ConversationTestGate? = nil
+  ) {
+    self.entries = Dictionary(uniqueKeysWithValues: entries.map { ($0.conversation.id, $0) })
+    order = entries.map { $0.conversation.id }
+    self.pending = pending
+    self.idLoadGate = idLoadGate
+    self.listLoadGate = listLoadGate
+  }
+
+  func load(query: ConversationQuery, accountId: String) async throws -> [ConversationCacheEntry] {
+    await listLoadGate?.wait()
+    return order.compactMap { entries[$0] }.filter { entry in
+      (!query.showStarredOnly || entry.conversation.starred)
+        && (query.folderId == nil || entry.conversation.folderId == query.folderId)
+    }
+  }
+
+  func load(id: String, accountId: String) async throws -> ConversationCacheEntry? {
+    await idLoadGate?.wait()
+    return entries[id]
+  }
+  func isEmpty(accountId: String) async throws -> Bool { entries.isEmpty }
+
+  func applyServerSnapshot(
+    _ conversations: [ServerConversation],
+    query: ConversationQuery,
+    fetchedAt: Date,
+    accountId: String
+  ) async throws {
+    serverUpsertAccounts.append(accountId)
+    for conversation in conversations {
+      let cached = entries[conversation.id]
+      var completeness: ConversationCompleteness = [.list]
+      if conversation.transcriptSegmentsIncluded { completeness.insert(.transcript) }
+      entries[conversation.id] = ConversationProjectionMerge.merge(
+        incoming: conversation,
+        incomingCompleteness: completeness,
+        cached: cached,
+        fetchedAt: fetchedAt
+      )
+    }
+    order = conversations.map(\.id)
+  }
+
+  func upsertServerConversation(
+    _ conversation: ServerConversation,
+    completeness: ConversationCompleteness,
+    fetchedAt: Date,
+    accountId: String,
+    preserveProjectionFreshness: Bool = false
+  ) async throws {
+    serverUpsertAccounts.append(accountId)
+    let previous = entries[conversation.id]
+    entries[conversation.id] = ConversationProjectionMerge.merge(
+      incoming: conversation,
+      incomingCompleteness: completeness,
+      cached: entries[conversation.id],
+      fetchedAt: fetchedAt
+    )
+    if preserveProjectionFreshness, let previous, let merged = entries[conversation.id] {
+      entries[conversation.id] = ConversationCacheEntry(
+        conversation: merged.conversation,
+        completeness: merged.completeness,
+        cacheWrittenAt: fetchedAt,
+        listFetchedAt: previous.listFetchedAt,
+        detailFetchedAt: previous.detailFetchedAt,
+        transcriptFetchedAt: previous.transcriptFetchedAt
+      )
+    }
+    if !order.contains(conversation.id) { order.append(conversation.id) }
+  }
+
+  func remove(id: String, accountId: String) async throws {
+    entries.removeValue(forKey: id)
+    order.removeAll { $0 == id }
+  }
+
+  func loadPendingMutations(accountId: String) async throws -> [String: ConversationPendingMutation] { pending }
+
+  func savePendingMutation(
+    _ mutation: ConversationPendingMutation?,
+    conversationId: String,
+    accountId: String
+  ) async throws {
+    if let mutation, !mutation.isEmpty {
+      pending[conversationId] = mutation
+    } else {
+      pending.removeValue(forKey: conversationId)
+    }
+  }
+
+  func invalidateCache() async {}
+
+  func recordedServerUpsertAccounts() -> [String] { serverUpsertAccounts }
+}
+
+@MainActor
+final class ConversationRepositoryTests: XCTestCase {
+  func testCacheRendersBeforeBlockedServerRefreshThenReconciles() async throws {
+    let cached = makeConversation(id: "c1", title: "Cached", overview: "old", revision: "1")
+    let server = makeConversation(id: "c1", title: "Server", overview: "fresh", revision: "2")
+    let cache = ConversationCacheStub(entries: [entry(cached)])
+    let gate = ConversationTestGate()
+    let remote = ConversationRemoteStub(list: [server], listGate: gate)
+    let repository = ConversationRepository(
+      remote: remote,
+      cache: cache,
+      legacyMigrationEnabled: false
+    )
+
+    let load = Task { await repository.load(query: ConversationQuery()) }
+    await gate.waitUntilBlocked()
+
+    XCTAssertEqual(repository.conversations.first?.structured.title, "Cached")
+    XCTAssertFalse(repository.isLoading, "cached first paint should clear the blocking loading state")
+
+    await gate.release()
+    await load.value
+
+    XCTAssertEqual(repository.conversations.first?.structured.title, "Server")
+    XCTAssertEqual(repository.conversations.first?.structured.overview, "fresh")
+  }
+
+  func testListProjectionCannotEraseCompleteCachedTranscript() {
+    let cached = makeConversation(
+      id: "c1",
+      title: "Cached",
+      overview: "old",
+      revision: "1",
+      transcript: [makeSegment(text: "offline transcript")],
+      transcriptIncluded: true
+    )
+    let incoming = makeConversation(
+      id: "c1",
+      title: "Server",
+      overview: "fresh",
+      revision: "2",
+      transcript: [],
+      transcriptIncluded: false
+    )
+
+    let merged = ConversationProjectionMerge.merge(
+      incoming: incoming,
+      incomingCompleteness: [.list],
+      cached: ConversationCacheEntry(
+        conversation: cached,
+        completeness: [.list, .detail, .transcript],
+        cacheWrittenAt: Date(timeIntervalSince1970: 1)
+      )
+    )
+
+    XCTAssertEqual(merged.conversation.structured.overview, "fresh")
+    XCTAssertEqual(merged.conversation.transcriptSegments.map(\.text), ["offline transcript"])
+    XCTAssertTrue(merged.completeness.contains(.transcript))
+  }
+
+  func testFailedMutationSurvivesRestartAndClearsOnlyAfterCanonicalAck() async throws {
+    let original = makeConversation(id: "c1", title: "Original", revision: "1")
+    let cache = ConversationCacheStub(entries: [entry(original)])
+    let failingRemote = ConversationRemoteStub(
+      list: [original],
+      mutationError: ConversationRemoteStubError.mutationFailed
+    )
+    let firstRepository = ConversationRepository(
+      remote: failingRemote,
+      cache: cache,
+      legacyMigrationEnabled: false
+    )
+    firstRepository.seed(original)
+
+    do {
+      try await firstRepository.updateTitle(id: "c1", title: "Durable title")
+      XCTFail("mutation should fail")
+    } catch {}
+
+    XCTAssertEqual(firstRepository.conversation(id: "c1")?.structured.title, "Durable title")
+    let pendingAfterFailure = try await cache.loadPendingMutations(accountId: "anonymous")
+    XCTAssertEqual(pendingAfterFailure["c1"]?.title, "Durable title")
+
+    let acknowledged = makeConversation(id: "c1", title: "Durable title", revision: "2")
+    let recoveringRemote = ConversationRemoteStub(list: [original], titleResult: acknowledged)
+    let secondRepository = ConversationRepository(
+      remote: recoveringRemote,
+      cache: cache,
+      legacyMigrationEnabled: false
+    )
+
+    await secondRepository.load(query: ConversationQuery())
+
+    XCTAssertEqual(secondRepository.conversation(id: "c1")?.structured.title, "Durable title")
+    let pendingAfterRecovery = try await cache.loadPendingMutations(accountId: "anonymous")
+    XCTAssertNil(pendingAfterRecovery["c1"])
+  }
+
+  func testAccountResetRejectsResponseFromPreviousGeneration() async {
+    let server = makeConversation(id: "old-account", revision: "2")
+    let gate = ConversationTestGate()
+    let repository = ConversationRepository(
+      remote: ConversationRemoteStub(list: [server], listGate: gate),
+      cache: ConversationCacheStub(),
+      legacyMigrationEnabled: false
+    )
+
+    let load = Task { await repository.load(query: ConversationQuery()) }
+    await gate.waitUntilBlocked()
+    repository.resetSession()
+    await gate.release()
+    await load.value
+
+    XCTAssertTrue(repository.conversations.isEmpty)
+    XCTAssertNil(repository.conversation(id: "old-account"))
+  }
+
+  func testAccountChangeCannotPublishBlockedCacheReadBeforeResetOrdering() async {
+    let accountA = makeConversation(id: "account-a-only", revision: "1")
+    let gate = ConversationTestGate()
+    var accountId = "account-a"
+    let repository = ConversationRepository(
+      remote: ConversationRemoteStub(list: []),
+      cache: ConversationCacheStub(entries: [entry(accountA)], listLoadGate: gate),
+      accountIdProvider: { accountId },
+      legacyMigrationEnabled: false
+    )
+
+    let load = Task { await repository.load(query: ConversationQuery()) }
+    await gate.waitUntilBlocked()
+    accountId = "account-b"
+    await gate.release()
+    await load.value
+
+    XCTAssertNil(repository.conversation(id: "account-a-only"))
+    XCTAssertTrue(repository.conversations.isEmpty)
+  }
+
+  func testOlderSearchCannotReplaceNewerSearchResults() async {
+    let oldResult = makeConversation(id: "old", title: "Old result", revision: "1")
+    let newResult = makeConversation(id: "new", title: "New result", revision: "2")
+    let oldSearchGate = ConversationTestGate()
+    let repository = ConversationRepository(
+      remote: ConversationRemoteStub(
+        list: [],
+        searchResults: ["old": [oldResult], "new": [newResult]],
+        searchGates: ["old": oldSearchGate]
+      ),
+      cache: ConversationCacheStub(),
+      legacyMigrationEnabled: false
+    )
+
+    let oldSearch = Task { await repository.search("old") }
+    await oldSearchGate.waitUntilBlocked()
+    await repository.search("new")
+    await oldSearchGate.release()
+    await oldSearch.value
+
+    XCTAssertEqual(repository.searchResults.map(\.id), ["new"])
+    XCTAssertFalse(repository.isSearching)
+  }
+
+  func testPersistedOptimisticMutationRespectsActiveFilterAfterRestart() async {
+    let starred = makeConversation(id: "c1", revision: "1", starred: true)
+    var pending = ConversationPendingMutation()
+    pending.setStarred(false)
+    let gate = ConversationTestGate()
+    let repository = ConversationRepository(
+      remote: ConversationRemoteStub(
+        list: [starred],
+        mutationError: ConversationRemoteStubError.mutationFailed,
+        listGate: gate
+      ),
+      cache: ConversationCacheStub(entries: [entry(starred)], pending: ["c1": pending]),
+      legacyMigrationEnabled: false
+    )
+
+    let load = Task { await repository.load(query: ConversationQuery(showStarredOnly: true)) }
+    await gate.waitUntilBlocked()
+
+    XCTAssertTrue(repository.conversations.isEmpty)
+
+    await gate.release()
+    await load.value
+    XCTAssertTrue(repository.conversations.isEmpty)
+  }
+
+  func testOlderMutationAckCannotOverwriteNewerCanonicalRevision() async throws {
+    let original = makeConversation(id: "c1", title: "Original", revision: "1")
+    let firstAck = makeConversation(id: "c1", title: "First", revision: "2")
+    let secondAck = makeConversation(id: "c1", title: "Second", revision: "3")
+    let firstGate = ConversationTestGate()
+    let cache = ConversationCacheStub(entries: [entry(original)])
+    let remote = ConversationRemoteStub(
+      list: [original],
+      titleResults: ["First": firstAck, "Second": secondAck],
+      titleGates: ["First": firstGate]
+    )
+    let repository = ConversationRepository(
+      remote: remote,
+      cache: cache,
+      legacyMigrationEnabled: false
+    )
+    repository.seed(original)
+
+    let first = Task { try await repository.updateTitle(id: "c1", title: "First") }
+    await firstGate.waitUntilBlocked()
+    let requestsWhileFirstBlocked = await remote.requestedTitles()
+    XCTAssertEqual(requestsWhileFirstBlocked, ["First"])
+    try await repository.updateTitle(id: "c1", title: "Second")
+    let requestsAfterSecondIntent = await remote.requestedTitles()
+    XCTAssertEqual(requestsAfterSecondIntent, ["First"])
+    await firstGate.release()
+    try await first.value
+
+    XCTAssertEqual(repository.conversation(id: "c1")?.structured.title, "Second")
+    let completedRequests = await remote.requestedTitles()
+    XCTAssertEqual(completedRequests, ["First", "Second"])
+    let pending = try await cache.loadPendingMutations(accountId: "anonymous")
+    XCTAssertNil(pending["c1"])
+  }
+
+  func testLockedListProjectionPurgesCachedSensitiveDetail() {
+    let cached = makeConversation(
+      id: "c1",
+      revision: "1",
+      transcript: [makeSegment(text: "sensitive cached transcript")],
+      transcriptIncluded: true
+    )
+    let locked = makeConversation(id: "c1", revision: "2", isLocked: true)
+
+    let merged = ConversationProjectionMerge.merge(
+      incoming: locked,
+      incomingCompleteness: [.list],
+      cached: ConversationCacheEntry(
+        conversation: cached,
+        completeness: [.list, .detail, .transcript],
+        cacheWrittenAt: Date(timeIntervalSince1970: 1)
+      )
+    )
+
+    XCTAssertTrue(merged.conversation.isLocked)
+    XCTAssertTrue(merged.conversation.transcriptSegments.isEmpty)
+    XCTAssertFalse(merged.completeness.contains(.detail))
+    XCTAssertFalse(merged.completeness.contains(.transcript))
+  }
+
+  func testOlderDetailResponseCannotRegressNewerCachedRevision() async {
+    let newer = makeConversation(id: "c1", title: "Newer", revision: "3")
+    let older = makeConversation(id: "c1", title: "Older", revision: "2")
+    let repository = ConversationRepository(
+      remote: ConversationRemoteStub(list: [older], detailById: ["c1": older]),
+      cache: ConversationCacheStub(entries: [entry(newer)]),
+      legacyMigrationEnabled: false
+    )
+
+    await repository.loadDetail(id: "c1")
+
+    XCTAssertEqual(repository.conversation(id: "c1")?.structured.title, "Newer")
+    XCTAssertEqual(repository.conversation(id: "c1")?.revision, "3")
+  }
+
+  func testOldAccountMutationAckCannotWriteOrPublishAfterReset() async {
+    let original = makeConversation(id: "c1", title: "Original", revision: "1")
+    let acknowledged = makeConversation(id: "c1", title: "Old account", revision: "2")
+    let gate = ConversationTestGate()
+    let cache = ConversationCacheStub(entries: [entry(original)])
+    let remote = ConversationRemoteStub(
+      list: [original],
+      titleResults: ["Old account": acknowledged],
+      titleGates: ["Old account": gate]
+    )
+    var accountId = "account-a"
+    let repository = ConversationRepository(
+      remote: remote,
+      cache: cache,
+      accountIdProvider: { accountId },
+      legacyMigrationEnabled: false
+    )
+    repository.seed(original)
+
+    let mutation = Task { try? await repository.updateTitle(id: "c1", title: "Old account") }
+    await gate.waitUntilBlocked()
+    repository.resetSession()
+    accountId = "account-b"
+    await gate.release()
+    await mutation.value
+
+    XCTAssertTrue(repository.conversations.isEmpty)
+    XCTAssertNil(repository.conversation(id: "c1"))
+    let serverAccounts = await cache.recordedServerUpsertAccounts()
+    XCTAssertTrue(serverAccounts.isEmpty)
+  }
+
+  func testOldAccountCachedDetailCannotPublishAfterReset() async {
+    let cached = makeConversation(id: "c1", title: "Account A", revision: "1")
+    let gate = ConversationTestGate()
+    let cache = ConversationCacheStub(entries: [entry(cached)], idLoadGate: gate)
+    var accountId = "account-a"
+    let repository = ConversationRepository(
+      remote: ConversationRemoteStub(list: [cached]),
+      cache: cache,
+      accountIdProvider: { accountId },
+      legacyMigrationEnabled: false
+    )
+
+    let detail = Task { await repository.loadDetail(id: "c1") }
+    await gate.waitUntilBlocked()
+    repository.resetSession()
+    accountId = "account-b"
+    await gate.release()
+    await detail.value
+
+    XCTAssertNil(repository.conversation(id: "c1"))
+  }
+
+  func testPermanentMutationFailureRollsBackAndStopsRetrying() async throws {
+    let original = makeConversation(id: "c1", title: "Original", revision: "1")
+    let cache = ConversationCacheStub(entries: [entry(original)])
+    let repository = ConversationRepository(
+      remote: ConversationRemoteStub(
+        list: [original],
+        detailById: ["c1": original],
+        mutationError: APIError.httpError(statusCode: 400, detail: "invalid title")
+      ),
+      cache: cache,
+      legacyMigrationEnabled: false
+    )
+    repository.seed(original)
+
+    do {
+      try await repository.updateTitle(id: "c1", title: "Rejected")
+      XCTFail("permanent failure should surface")
+    } catch {}
+
+    XCTAssertEqual(repository.conversation(id: "c1")?.structured.title, "Original")
+    let pending = try await cache.loadPendingMutations(accountId: "anonymous")
+    XCTAssertNil(pending["c1"])
+    guard case .failed = repository.metadata(id: "c1")?.syncState else {
+      return XCTFail("permanent failure should remain visible on the entity")
+    }
+  }
+
+  func testRejectedOlderTitleDoesNotEraseNewerQueuedIntent() async throws {
+    let original = makeConversation(id: "c1", title: "Original", revision: "1")
+    let accepted = makeConversation(id: "c1", title: "Second", revision: "3")
+    let firstGate = ConversationTestGate()
+    let cache = ConversationCacheStub(entries: [entry(original)])
+    let remote = ConversationRemoteStub(
+      list: [original],
+      detailById: ["c1": original],
+      titleResults: ["Second": accepted],
+      titleGates: ["First": firstGate],
+      titleErrors: ["First": APIError.httpError(statusCode: 400, detail: "invalid title")]
+    )
+    let repository = ConversationRepository(remote: remote, cache: cache, legacyMigrationEnabled: false)
+    repository.seed(original)
+
+    let first = Task { try? await repository.updateTitle(id: "c1", title: "First") }
+    await firstGate.waitUntilBlocked()
+    try await repository.updateTitle(id: "c1", title: "Second")
+    await firstGate.release()
+    await first.value
+
+    XCTAssertEqual(repository.conversation(id: "c1")?.structured.title, "Second")
+    let requests = await remote.requestedTitles()
+    let pending = try await cache.loadPendingMutations(accountId: "anonymous")
+    XCTAssertEqual(requests, ["First", "Second"])
+    XCTAssertNil(pending["c1"])
+  }
+
+  func testMissingFolderFailureDoesNotDeleteConversation() async throws {
+    let original = makeConversation(id: "c1", title: "Original", revision: "1")
+    let cache = ConversationCacheStub(entries: [entry(original)])
+    let repository = ConversationRepository(
+      remote: ConversationRemoteStub(
+        list: [original],
+        detailById: ["c1": original],
+        mutationError: APIError.httpError(statusCode: 404, detail: "Folder not found")
+      ),
+      cache: cache,
+      legacyMigrationEnabled: false
+    )
+    repository.seed(original)
+
+    do {
+      try await repository.moveToFolder(id: "c1", folderId: "missing")
+      XCTFail("missing folder should surface")
+    } catch {}
+
+    XCTAssertEqual(repository.conversation(id: "c1")?.id, "c1")
+    XCTAssertNil(repository.conversation(id: "c1")?.folderId)
+    let cached = try await cache.load(id: "c1", accountId: "anonymous")
+    let pending = try await cache.loadPendingMutations(accountId: "anonymous")
+    XCTAssertNotNil(cached)
+    XCTAssertNil(pending["c1"])
+  }
+
+  func testPermanentFailureWithOfflineDetailRollsBackFromCanonicalCacheAcrossRestart() async throws {
+    let original = makeConversation(id: "c1", title: "Original", revision: "1")
+    let cache = ConversationCacheStub(entries: [entry(original)])
+    let failingRemote = ConversationRemoteStub(
+      list: [original],
+      detailError: ConversationRemoteStubError.mutationFailed,
+      mutationError: APIError.httpError(statusCode: 400, detail: "invalid title")
+    )
+    let firstRepository = ConversationRepository(remote: failingRemote, cache: cache, legacyMigrationEnabled: false)
+    firstRepository.seed(original)
+
+    do {
+      try await firstRepository.updateTitle(id: "c1", title: "Rejected")
+      XCTFail("permanent failure should surface")
+    } catch {}
+
+    XCTAssertEqual(firstRepository.conversation(id: "c1")?.structured.title, "Original")
+    let pending = try await cache.loadPendingMutations(accountId: "anonymous")
+    XCTAssertNil(pending["c1"])
+
+    let restartGate = ConversationTestGate()
+    let restarted = ConversationRepository(
+      remote: ConversationRemoteStub(list: [original], listGate: restartGate),
+      cache: cache,
+      legacyMigrationEnabled: false
+    )
+    let load = Task { await restarted.load(query: ConversationQuery()) }
+    await restartGate.waitUntilBlocked()
+    XCTAssertEqual(restarted.conversation(id: "c1")?.structured.title, "Original")
+    await restartGate.release()
+    await load.value
+  }
+
+  func testLightweightMutationAckAdvancesRevisionAndClearsOnlyAcknowledgedField() async throws {
+    let original = makeConversation(id: "c1", title: "Original", revision: "1")
+    let titleAck = makeConversation(id: "c1", title: "Renamed", revision: "2")
+    let cache = ConversationCacheStub(entries: [entry(original)])
+    let repository = ConversationRepository(
+      remote: ConversationRemoteStub(
+        list: [original],
+        titleResult: titleAck,
+        lightweightAcks: true
+      ),
+      cache: cache,
+      legacyMigrationEnabled: false
+    )
+    repository.seed(original)
+
+    try await repository.updateTitle(id: "c1", title: "Renamed")
+
+    XCTAssertEqual(repository.conversation(id: "c1")?.structured.title, "Renamed")
+    XCTAssertEqual(repository.conversation(id: "c1")?.revision, "2")
+    let pending = try await cache.loadPendingMutations(accountId: "anonymous")
+    XCTAssertNil(pending["c1"])
+    XCTAssertEqual(repository.metadata(id: "c1")?.syncState, .synced)
+    let cached = try await cache.load(id: "c1", accountId: "anonymous")
+    XCTAssertEqual(cached?.listFetchedAt, Date(timeIntervalSince1970: 1))
+  }
+
+  func testStatusOnlyAckKeepsOverlayUntilListConfirmsRequestedValue() async throws {
+    let original = makeConversation(id: "c1", title: "Original", revision: "1")
+    let cache = ConversationCacheStub(entries: [entry(original)])
+    let repository = ConversationRepository(
+      remote: ConversationRemoteStub(list: [original], statusOnlyAcks: true),
+      cache: cache,
+      legacyMigrationEnabled: false
+    )
+    repository.seed(original)
+
+    try await repository.updateTitle(id: "c1", title: "Pending rename")
+    await repository.load(query: ConversationQuery())
+
+    XCTAssertEqual(repository.conversation(id: "c1")?.structured.title, "Pending rename")
+    let pending = try await cache.loadPendingMutations(accountId: "anonymous")
+    XCTAssertEqual(pending["c1"]?.title, "Pending rename")
+    XCTAssertEqual(repository.metadata(id: "c1")?.syncState, .pending)
+  }
+
+  func testStatusOnlyAckClearsAfterVersionedListConfirmsRequestedValue() async throws {
+    let original = makeConversation(id: "c1", title: "Original", revision: "1")
+    let confirmed = makeConversation(id: "c1", title: "Pending rename", revision: "2")
+    let cache = ConversationCacheStub(entries: [entry(original)])
+    let repository = ConversationRepository(
+      remote: ConversationRemoteStub(list: [confirmed], statusOnlyAcks: true),
+      cache: cache,
+      legacyMigrationEnabled: false
+    )
+    repository.seed(original)
+
+    try await repository.updateTitle(id: "c1", title: "Pending rename")
+    await repository.load(query: ConversationQuery())
+
+    XCTAssertEqual(repository.conversation(id: "c1")?.structured.title, "Pending rename")
+    let pending = try await cache.loadPendingMutations(accountId: "anonymous")
+    XCTAssertNil(pending["c1"])
+    XCTAssertEqual(repository.metadata(id: "c1")?.syncState, .synced)
+  }
+
+  func testMatchingUnversionedListCannotClearOverlayOnVersionedCache() async throws {
+    let original = makeConversation(id: "c1", title: "Original", revision: "1")
+    let confirmedWithoutVersion = withoutServerVersion(
+      makeConversation(id: "c1", title: "Pending rename", revision: "2")
+    )
+    let cache = ConversationCacheStub(entries: [entry(original)])
+    let repository = ConversationRepository(
+      remote: ConversationRemoteStub(list: [confirmedWithoutVersion], statusOnlyAcks: true),
+      cache: cache,
+      legacyMigrationEnabled: false
+    )
+    repository.seed(original)
+
+    try await repository.updateTitle(id: "c1", title: "Pending rename")
+    await repository.load(query: ConversationQuery())
+
+    XCTAssertEqual(repository.conversation(id: "c1")?.structured.title, "Pending rename")
+    let pending = try await cache.loadPendingMutations(accountId: "anonymous")
+    XCTAssertEqual(pending["c1"]?.title, "Pending rename")
+  }
+
+  func testUnversionedListCannotOverwriteVersionedCache() {
+    let versioned = makeConversation(id: "c1", title: "Versioned", revision: "2")
+    var unversioned = makeConversation(id: "c1", title: "Old instance", revision: "1")
+    unversioned = ServerConversation(
+      id: unversioned.id,
+      createdAt: unversioned.createdAt,
+      startedAt: unversioned.startedAt,
+      finishedAt: unversioned.finishedAt,
+      structured: unversioned.structured,
+      transcriptSegments: unversioned.transcriptSegments,
+      transcriptSegmentsIncluded: unversioned.transcriptSegmentsIncluded,
+      geolocation: unversioned.geolocation,
+      photos: unversioned.photos,
+      appsResults: unversioned.appsResults,
+      source: unversioned.source,
+      language: unversioned.language,
+      status: unversioned.status,
+      discarded: unversioned.discarded,
+      deleted: unversioned.deleted,
+      isLocked: unversioned.isLocked,
+      starred: unversioned.starred,
+      folderId: unversioned.folderId,
+      inputDeviceName: unversioned.inputDeviceName,
+      updatedAt: nil,
+      revision: nil
+    )
+
+    let merged = ConversationProjectionMerge.merge(
+      incoming: unversioned,
+      incomingCompleteness: [.list],
+      cached: entry(versioned)
+    )
+
+    XCTAssertEqual(merged.conversation.structured.title, "Versioned")
+    XCTAssertEqual(merged.conversation.revision, "2")
+  }
+
+  func testDelayedOlderLockCannotPurgeNewerUnlockedDetail() {
+    let unlocked = makeConversation(
+      id: "c1",
+      revision: "3",
+      transcript: [makeSegment(text: "newer detail")],
+      transcriptIncluded: true
+    )
+    let staleLocked = makeConversation(id: "c1", revision: "2", isLocked: true)
+
+    let merged = ConversationProjectionMerge.merge(
+      incoming: staleLocked,
+      incomingCompleteness: [.list],
+      cached: entry(unlocked)
+    )
+
+    XCTAssertFalse(merged.conversation.isLocked)
+    XCTAssertEqual(merged.conversation.transcriptSegments.map(\.text), ["newer detail"])
+    XCTAssertTrue(merged.completeness.contains(.detail))
+  }
+
+  func testDelayedOlderTombstoneCannotOverrideNewerRestore() {
+    let restored = makeConversation(id: "c1", revision: "3")
+    let staleDeleted = makeConversation(id: "c1", revision: "2", deleted: true)
+
+    let merged = ConversationProjectionMerge.merge(
+      incoming: staleDeleted,
+      incomingCompleteness: [.list],
+      cached: entry(restored)
+    )
+
+    XCTAssertFalse(merged.conversation.deleted)
+    XCTAssertEqual(merged.conversation.revision, "3")
+  }
+
+  func testUnversionedLockStillPurgesCachedSensitiveDetailFailClosed() {
+    let cached = makeConversation(
+      id: "c1",
+      revision: "3",
+      transcript: [makeSegment(text: "sensitive")],
+      transcriptIncluded: true
+    )
+    let unversionedLock = withoutServerVersion(makeConversation(id: "c1", revision: "4", isLocked: true))
+
+    let merged = ConversationProjectionMerge.merge(
+      incoming: unversionedLock,
+      incomingCompleteness: [.list],
+      cached: entry(cached)
+    )
+
+    XCTAssertTrue(merged.conversation.isLocked)
+    XCTAssertTrue(merged.conversation.transcriptSegments.isEmpty)
+    XCTAssertFalse(merged.completeness.contains(.detail))
+  }
+
+  func testOlderVersionedListCannotClearNewerPendingIntent() async throws {
+    let current = makeConversation(id: "c1", title: "Current", revision: "3")
+    let staleMatching = makeConversation(id: "c1", title: "Desired", revision: "2")
+    let cache = ConversationCacheStub(entries: [entry(current)])
+    let repository = ConversationRepository(
+      remote: ConversationRemoteStub(list: [staleMatching], statusOnlyAcks: true),
+      cache: cache,
+      legacyMigrationEnabled: false
+    )
+    repository.seed(current)
+
+    try await repository.updateTitle(id: "c1", title: "Desired")
+    await repository.load(query: ConversationQuery())
+
+    XCTAssertEqual(repository.conversation(id: "c1")?.structured.title, "Desired")
+    let pending = try await cache.loadPendingMutations(accountId: "anonymous")
+    XCTAssertEqual(pending["c1"]?.title, "Desired")
+  }
+
+  func testStaleDeleteFailureCannotMarkNewSessionEntityFailed() async {
+    let original = makeConversation(id: "c1", revision: "1")
+    let gate = ConversationTestGate()
+    var accountId = "account-a"
+    let repository = ConversationRepository(
+      remote: ConversationRemoteStub(
+        list: [original],
+        mutationError: APIError.httpError(statusCode: 500, detail: "delete failed"),
+        deleteGate: gate
+      ),
+      cache: ConversationCacheStub(entries: [entry(original)]),
+      accountIdProvider: { accountId },
+      legacyMigrationEnabled: false
+    )
+    repository.seed(original)
+
+    let deletion = Task { try? await repository.delete(id: "c1") }
+    await gate.waitUntilBlocked()
+    repository.resetSession()
+    accountId = "account-b"
+    await gate.release()
+    await deletion.value
+
+    XCTAssertNil(repository.conversation(id: "c1"))
+    XCTAssertNil(repository.metadata(id: "c1"))
+    XCTAssertNil(repository.error)
+  }
+
+  func testServerListMetadataReportsMixedProjectionFreshness() async {
+    let detail = makeConversation(
+      id: "c1",
+      title: "Cached detail",
+      revision: "2",
+      transcript: [makeSegment(text: "rich")],
+      transcriptIncluded: true
+    )
+    let list = makeConversation(id: "c1", title: "Fresh list", revision: "3")
+    let cached = ConversationCacheEntry(
+      conversation: detail,
+      completeness: [.list, .detail, .transcript],
+      cacheWrittenAt: Date(timeIntervalSince1970: 2)
+    )
+    let repository = ConversationRepository(
+      remote: ConversationRemoteStub(list: [list]),
+      cache: ConversationCacheStub(entries: [cached]),
+      now: { Date(timeIntervalSince1970: 3) },
+      legacyMigrationEnabled: false
+    )
+
+    await repository.load(query: ConversationQuery())
+
+    let metadata = repository.metadata(id: "c1")
+    XCTAssertEqual(metadata?.source, .mixed)
+    XCTAssertEqual(metadata?.listFetchedAt, Date(timeIntervalSince1970: 3))
+    XCTAssertEqual(metadata?.detailFetchedAt, Date(timeIntervalSince1970: 2))
+    XCTAssertEqual(metadata?.transcriptFetchedAt, Date(timeIntervalSince1970: 2))
+  }
+
+  func testConversationCacheCodableRoundTripPreservesProjectionMetadata() throws {
+    let original = makeConversation(
+      id: "c1",
+      revision: "2",
+      transcript: [makeSegment(text: "cached transcript")],
+      transcriptIncluded: true,
+      deleted: true,
+      inputDeviceName: "MacBook Microphone"
+    )
+    let encoder = JSONEncoder()
+    encoder.dateEncodingStrategy = .iso8601
+    let decoder = JSONDecoder()
+    decoder.dateDecodingStrategy = .iso8601
+
+    let decoded = try decoder.decode(ServerConversation.self, from: encoder.encode(original))
+
+    XCTAssertEqual(decoded.revision, original.revision)
+    XCTAssertEqual(decoded.updatedAt, original.updatedAt)
+    XCTAssertEqual(decoded.inputDeviceName, "MacBook Microphone")
+    XCTAssertTrue(decoded.deleted)
+    XCTAssertTrue(decoded.transcriptSegmentsIncluded)
+    XCTAssertEqual(decoded.transcriptSegments.map(\.text), ["cached transcript"])
+  }
+
+  private func entry(_ conversation: ServerConversation) -> ConversationCacheEntry {
+    ConversationCacheEntry(
+      conversation: conversation,
+      completeness: conversation.transcriptSegmentsIncluded ? [.list, .detail, .transcript] : [.list],
+      cacheWrittenAt: Date(timeIntervalSince1970: 1)
+    )
+  }
+
+  private func makeConversation(
+    id: String,
+    title: String = "Title",
+    overview: String = "Overview",
+    revision: String,
+    starred: Bool = false,
+    transcript: [TranscriptSegment] = [],
+    transcriptIncluded: Bool = false,
+    deleted: Bool = false,
+    inputDeviceName: String? = nil,
+    isLocked: Bool = false
+  ) -> ServerConversation {
+    let createdAt = Date(timeIntervalSince1970: 1_000)
+    return ServerConversation(
+      id: id,
+      createdAt: createdAt,
+      startedAt: createdAt,
+      finishedAt: createdAt.addingTimeInterval(60),
+      structured: Structured(
+        title: title,
+        overview: overview,
+        emoji: "💬",
+        category: "other",
+        actionItems: [],
+        events: []
+      ),
+      transcriptSegments: transcript,
+      transcriptSegmentsIncluded: transcriptIncluded,
+      geolocation: nil,
+      photos: [],
+      appsResults: [],
+      source: .desktop,
+      language: "en",
+      status: .completed,
+      discarded: false,
+      deleted: deleted,
+      isLocked: isLocked,
+      starred: starred,
+      folderId: nil,
+      inputDeviceName: inputDeviceName,
+      updatedAt: Date(timeIntervalSince1970: Double(revision) ?? 1),
+      revision: revision
+    )
+  }
+
+  private func withoutServerVersion(_ conversation: ServerConversation) -> ServerConversation {
+    ServerConversation(
+      id: conversation.id,
+      createdAt: conversation.createdAt,
+      startedAt: conversation.startedAt,
+      finishedAt: conversation.finishedAt,
+      structured: conversation.structured,
+      transcriptSegments: conversation.transcriptSegments,
+      transcriptSegmentsIncluded: conversation.transcriptSegmentsIncluded,
+      geolocation: conversation.geolocation,
+      photos: conversation.photos,
+      appsResults: conversation.appsResults,
+      source: conversation.source,
+      language: conversation.language,
+      status: conversation.status,
+      discarded: conversation.discarded,
+      deleted: conversation.deleted,
+      isLocked: conversation.isLocked,
+      starred: conversation.starred,
+      folderId: conversation.folderId,
+      inputDeviceName: conversation.inputDeviceName,
+      deferred: conversation.deferred,
+      updatedAt: nil,
+      revision: nil
+    )
+  }
+
+  private func makeSegment(text: String) -> TranscriptSegment {
+    TranscriptSegment(
+      id: UUID().uuidString,
+      text: text,
+      speaker: "SPEAKER_00",
+      isUser: true,
+      personId: nil,
+      start: 0,
+      end: 1
+    )
+  }
+
+}

--- a/desktop/macos/Desktop/Tests/ConversationRepositoryTests.swift
+++ b/desktop/macos/Desktop/Tests/ConversationRepositoryTests.swift
@@ -1,3 +1,4 @@
+import Combine
 import XCTest
 @testable import Omi_Computer
 
@@ -33,6 +34,7 @@ private enum ConversationRemoteStubError: Error {
 
 private actor ConversationRemoteStub: ConversationRemoteServing {
   var listResult: [ServerConversation]
+  var listError: Error?
   var detailById: [String: ServerConversation]
   var detailError: Error?
   var titleResult: ServerConversation?
@@ -44,14 +46,17 @@ private actor ConversationRemoteStub: ConversationRemoteServing {
   let searchGates: [String: ConversationTestGate]
   let titleResults: [String: ServerConversation]
   let titleGates: [String: ConversationTestGate]
+  let starredGate: ConversationTestGate?
   let deleteGate: ConversationTestGate?
   let titleErrors: [String: Error]
+  let starredError: Error?
   let lightweightAcks: Bool
   let statusOnlyAcks: Bool
   private var titleRequests: [String] = []
 
   init(
     list: [ServerConversation],
+    listError: Error? = nil,
     detailById: [String: ServerConversation] = [:],
     detailError: Error? = nil,
     titleResult: ServerConversation? = nil,
@@ -63,12 +68,15 @@ private actor ConversationRemoteStub: ConversationRemoteServing {
     searchGates: [String: ConversationTestGate] = [:],
     titleResults: [String: ServerConversation] = [:],
     titleGates: [String: ConversationTestGate] = [:],
+    starredGate: ConversationTestGate? = nil,
     deleteGate: ConversationTestGate? = nil,
     titleErrors: [String: Error] = [:],
+    starredError: Error? = nil,
     lightweightAcks: Bool = false,
     statusOnlyAcks: Bool = false
   ) {
     listResult = list
+    self.listError = listError
     self.detailById = detailById
     self.detailError = detailError
     self.titleResult = titleResult
@@ -80,14 +88,17 @@ private actor ConversationRemoteStub: ConversationRemoteServing {
     self.searchGates = searchGates
     self.titleResults = titleResults
     self.titleGates = titleGates
+    self.starredGate = starredGate
     self.deleteGate = deleteGate
     self.titleErrors = titleErrors
+    self.starredError = starredError
     self.lightweightAcks = lightweightAcks
     self.statusOnlyAcks = statusOnlyAcks
   }
 
   func list(query: ConversationQuery) async throws -> [ServerConversation] {
     await listGate?.wait()
+    if let listError { throw listError }
     return listResult
   }
 
@@ -119,6 +130,8 @@ private actor ConversationRemoteStub: ConversationRemoteServing {
   }
 
   func updateStarred(id: String, starred: Bool) async throws -> ConversationMutationAcknowledgement {
+    await starredGate?.wait()
+    if let starredError { throw starredError }
     if let mutationError { throw mutationError }
     let conversation = starredResult ?? listResult.first { $0.id == id }!
     return ConversationMutationAcknowledgement(
@@ -148,27 +161,42 @@ private actor ConversationRemoteStub: ConversationRemoteServing {
   }
 
   func requestedTitles() -> [String] { titleRequests }
+
+  func setListError(_ error: Error?) { listError = error }
 }
 
 private actor ConversationCacheStub: ConversationCachePersisting {
+  private struct PendingTitleObserver {
+    let conversationId: String
+    let title: String
+    let continuation: CheckedContinuation<Void, Never>
+  }
+
   private var entries: [String: ConversationCacheEntry]
   private var order: [String]
   private var pending: [String: ConversationPendingMutation]
   private let idLoadGate: ConversationTestGate?
   private let listLoadGate: ConversationTestGate?
+  private let pendingLoadGate: ConversationTestGate?
+  private let pendingSaveError: Error?
   private var serverUpsertAccounts: [String] = []
+  private var pendingTitleObservers: [PendingTitleObserver] = []
 
   init(
     entries: [ConversationCacheEntry] = [],
     pending: [String: ConversationPendingMutation] = [:],
     idLoadGate: ConversationTestGate? = nil,
-    listLoadGate: ConversationTestGate? = nil
+    listLoadGate: ConversationTestGate? = nil,
+    pendingLoadGate: ConversationTestGate? = nil,
+    pendingSaveError: Error? = nil
   ) {
     self.entries = Dictionary(uniqueKeysWithValues: entries.map { ($0.conversation.id, $0) })
     order = entries.map { $0.conversation.id }
     self.pending = pending
     self.idLoadGate = idLoadGate
     self.listLoadGate = listLoadGate
+    self.pendingLoadGate = pendingLoadGate
+    self.pendingSaveError = pendingSaveError
   }
 
   func load(query: ConversationQuery, accountId: String) async throws -> [ConversationCacheEntry] {
@@ -239,23 +267,48 @@ private actor ConversationCacheStub: ConversationCachePersisting {
     order.removeAll { $0 == id }
   }
 
-  func loadPendingMutations(accountId: String) async throws -> [String: ConversationPendingMutation] { pending }
+  func loadPendingMutations(accountId: String) async throws -> [String: ConversationPendingMutation] {
+    let snapshot = pending
+    await pendingLoadGate?.wait()
+    return snapshot
+  }
 
   func savePendingMutation(
     _ mutation: ConversationPendingMutation?,
     conversationId: String,
     accountId: String
   ) async throws {
+    if let pendingSaveError { throw pendingSaveError }
     if let mutation, !mutation.isEmpty {
       pending[conversationId] = mutation
     } else {
       pending.removeValue(forKey: conversationId)
     }
+    let ready = pendingTitleObservers.filter {
+      $0.conversationId == conversationId && pending[conversationId]?.title == $0.title
+    }
+    pendingTitleObservers.removeAll { observer in
+      ready.contains { $0.conversationId == observer.conversationId && $0.title == observer.title }
+    }
+    ready.forEach { $0.continuation.resume() }
   }
 
   func invalidateCache() async {}
 
   func recordedServerUpsertAccounts() -> [String] { serverUpsertAccounts }
+
+  func waitUntilPendingTitle(_ title: String, conversationId: String) async {
+    if pending[conversationId]?.title == title { return }
+    await withCheckedContinuation { continuation in
+      pendingTitleObservers.append(
+        PendingTitleObserver(
+          conversationId: conversationId,
+          title: title,
+          continuation: continuation
+        )
+      )
+    }
+  }
 }
 
 @MainActor
@@ -316,6 +369,121 @@ final class ConversationRepositoryTests: XCTestCase {
     XCTAssertEqual(merged.conversation.structured.overview, "fresh")
     XCTAssertEqual(merged.conversation.transcriptSegments.map(\.text), ["offline transcript"])
     XCTAssertTrue(merged.completeness.contains(.transcript))
+  }
+
+  func testSeedIsIdempotentAndCannotDowngradeEqualVersionDetail() {
+    let rich = makeConversation(
+      id: "c1",
+      title: "Canonical",
+      revision: "2",
+      transcript: [makeSegment(text: "complete transcript")],
+      transcriptIncluded: true
+    )
+    let listProjection = makeConversation(id: "c1", title: "Canonical", revision: "2")
+    let repository = ConversationRepository(
+      remote: ConversationRemoteStub(list: []),
+      cache: ConversationCacheStub(),
+      legacyMigrationEnabled: false
+    )
+    repository.seed(rich)
+    var notifications = 0
+    let cancellable = repository.objectWillChange.sink { notifications += 1 }
+
+    repository.seed(listProjection)
+
+    XCTAssertEqual(repository.conversation(id: "c1")?.transcriptSegments.map(\.text), ["complete transcript"])
+    XCTAssertTrue(repository.metadata(id: "c1")?.completeness.contains(.detail) == true)
+    XCTAssertEqual(notifications, 0)
+    withExtendedLifetime(cancellable) {}
+  }
+
+  func testSeedPublishesSameVersionTranscriptSpeakerChanges() {
+    let originalSegment = TranscriptSegment(
+      id: "segment-1",
+      text: "Speaker text",
+      speaker: "SPEAKER_00",
+      isUser: false,
+      personId: nil,
+      start: 0,
+      end: 1
+    )
+    let reassignedSegment = TranscriptSegment(
+      id: "segment-1",
+      text: "Speaker text",
+      speaker: "SPEAKER_00",
+      isUser: true,
+      personId: "person-1",
+      start: 0,
+      end: 1
+    )
+    let original = makeConversation(
+      id: "c1",
+      revision: "2",
+      transcript: [originalSegment],
+      transcriptIncluded: true
+    )
+    let reassigned = makeConversation(
+      id: "c1",
+      revision: "2",
+      transcript: [reassignedSegment],
+      transcriptIncluded: true
+    )
+    let repository = ConversationRepository(
+      remote: ConversationRemoteStub(list: []),
+      cache: ConversationCacheStub(),
+      legacyMigrationEnabled: false
+    )
+    repository.seed(original)
+    var notifications = 0
+    let cancellable = repository.objectWillChange.sink { notifications += 1 }
+
+    repository.seed(reassigned)
+
+    XCTAssertGreaterThan(notifications, 0)
+    XCTAssertEqual(repository.conversation(id: "c1")?.transcriptSegments.first?.personId, "person-1")
+    XCTAssertTrue(repository.conversation(id: "c1")?.transcriptSegments.first?.isUser == true)
+    withExtendedLifetime(cancellable) {}
+  }
+
+  func testPendingJournalLoadCannotEraseConcurrentlyStagedIntent() async throws {
+    let original = makeConversation(id: "c1", title: "Original", revision: "1")
+    let gate = ConversationTestGate()
+    let cache = ConversationCacheStub(entries: [entry(original)], pendingLoadGate: gate)
+    let repository = ConversationRepository(
+      remote: ConversationRemoteStub(list: [original], statusOnlyAcks: true),
+      cache: cache,
+      legacyMigrationEnabled: false
+    )
+
+    let load = Task { await repository.load(query: ConversationQuery()) }
+    await gate.waitUntilBlocked()
+    try await repository.updateTitle(id: "c1", title: "Durable rename")
+    await gate.release()
+    await load.value
+
+    XCTAssertEqual(repository.conversation(id: "c1")?.structured.title, "Durable rename")
+    let pending = try await cache.loadPendingMutations(accountId: "anonymous")
+    XCTAssertEqual(pending["c1"]?.title, "Durable rename")
+  }
+
+  func testJournalSaveFailureRestoresInMemoryIntentAndNeverCallsRemote() async throws {
+    let original = makeConversation(id: "c1", title: "Original", revision: "1")
+    let cache = ConversationCacheStub(
+      entries: [entry(original)],
+      pendingSaveError: ConversationRemoteStubError.mutationFailed
+    )
+    let remote = ConversationRemoteStub(list: [original])
+    let repository = ConversationRepository(remote: remote, cache: cache, legacyMigrationEnabled: false)
+    repository.seed(original)
+
+    do {
+      try await repository.updateTitle(id: "c1", title: "Must not linger")
+      XCTFail("journal failure should surface")
+    } catch {}
+
+    XCTAssertEqual(repository.conversation(id: "c1")?.structured.title, "Original")
+    let requestedTitles = await remote.requestedTitles()
+    XCTAssertTrue(requestedTitles.isEmpty)
   }
 
   func testFailedMutationSurvivesRestartAndClearsOnlyAfterCanonicalAck() async throws {
@@ -467,11 +635,13 @@ final class ConversationRepositoryTests: XCTestCase {
     await firstGate.waitUntilBlocked()
     let requestsWhileFirstBlocked = await remote.requestedTitles()
     XCTAssertEqual(requestsWhileFirstBlocked, ["First"])
-    try await repository.updateTitle(id: "c1", title: "Second")
+    let second = Task { try await repository.updateTitle(id: "c1", title: "Second") }
+    await cache.waitUntilPendingTitle("Second", conversationId: "c1")
     let requestsAfterSecondIntent = await remote.requestedTitles()
     XCTAssertEqual(requestsAfterSecondIntent, ["First"])
     await firstGate.release()
     try await first.value
+    try await second.value
 
     XCTAssertEqual(repository.conversation(id: "c1")?.structured.title, "Second")
     let completedRequests = await remote.requestedTitles()
@@ -618,9 +788,11 @@ final class ConversationRepositoryTests: XCTestCase {
 
     let first = Task { try? await repository.updateTitle(id: "c1", title: "First") }
     await firstGate.waitUntilBlocked()
-    try await repository.updateTitle(id: "c1", title: "Second")
+    let second = Task { try await repository.updateTitle(id: "c1", title: "Second") }
+    await cache.waitUntilPendingTitle("Second", conversationId: "c1")
     await firstGate.release()
     await first.value
+    try await second.value
 
     XCTAssertEqual(repository.conversation(id: "c1")?.structured.title, "Second")
     let requests = await remote.requestedTitles()
@@ -713,6 +885,179 @@ final class ConversationRepositoryTests: XCTestCase {
     XCTAssertEqual(repository.metadata(id: "c1")?.syncState, .synced)
     let cached = try await cache.load(id: "c1", accountId: "anonymous")
     XCTAssertEqual(cached?.listFetchedAt, Date(timeIntervalSince1970: 1))
+  }
+
+  func testConcurrentMutationFailureReturnsToItsCallerWithoutLeakingOverlayIntoCanonicalCache() async throws {
+    let original = makeConversation(id: "c1", title: "Original", revision: "1", starred: false)
+    let starredAck = makeConversation(id: "c1", title: "Original", revision: "2", starred: true)
+    let starredGate = ConversationTestGate()
+    let cache = ConversationCacheStub(entries: [entry(original)])
+    let remote = ConversationRemoteStub(
+      list: [original],
+      detailError: ConversationRemoteStubError.mutationFailed,
+      starredResult: starredAck,
+      starredGate: starredGate,
+      titleErrors: ["Rejected": APIError.httpError(statusCode: 400, detail: "invalid title")],
+      lightweightAcks: true
+    )
+    let repository = ConversationRepository(remote: remote, cache: cache, legacyMigrationEnabled: false)
+    repository.seed(original)
+
+    let starTask = Task { try await repository.updateStarred(id: "c1", starred: true) }
+    await starredGate.waitUntilBlocked()
+    let titleTask = Task { try await repository.updateTitle(id: "c1", title: "Rejected") }
+    await cache.waitUntilPendingTitle("Rejected", conversationId: "c1")
+    await starredGate.release()
+
+    try await starTask.value
+    do {
+      try await titleTask.value
+      XCTFail("the rejected title caller must receive its own failure")
+    } catch {}
+
+    let cachedCanonical = try await cache.load(id: "c1", accountId: "anonymous")
+    let canonical = try XCTUnwrap(cachedCanonical)
+    XCTAssertEqual(canonical.conversation.structured.title, "Original")
+    XCTAssertTrue(canonical.conversation.starred)
+
+    let restartGate = ConversationTestGate()
+    let restarted = ConversationRepository(
+      remote: ConversationRemoteStub(list: [starredAck], listGate: restartGate),
+      cache: cache,
+      legacyMigrationEnabled: false
+    )
+    let load = Task { await restarted.load(query: ConversationQuery()) }
+    await restartGate.waitUntilBlocked()
+    XCTAssertEqual(restarted.conversation(id: "c1")?.structured.title, "Original")
+    XCTAssertTrue(restarted.conversation(id: "c1")?.starred == true)
+    await restartGate.release()
+    await load.value
+  }
+
+  func testConcurrentDuplicateMutationCallersSharePermanentFailure() async throws {
+    let original = makeConversation(id: "c1", title: "Original", revision: "1")
+    let gate = ConversationTestGate()
+    let remote = ConversationRemoteStub(
+      list: [original],
+      detailById: ["c1": original],
+      titleGates: ["Rejected": gate],
+      titleErrors: ["Rejected": APIError.httpError(statusCode: 400, detail: "invalid title")]
+    )
+    let waiterRegistered = expectation(description: "duplicate caller joined the in-flight mutation")
+    let repository = ConversationRepository(
+      remote: remote,
+      cache: ConversationCacheStub(entries: [entry(original)]),
+      onMutationWaiterRegistered: { id, value in
+        if id == "c1", value == .title("Rejected") { waiterRegistered.fulfill() }
+      },
+      legacyMigrationEnabled: false
+    )
+    repository.seed(original)
+
+    let first = Task { try await repository.updateTitle(id: "c1", title: "Rejected") }
+    await gate.waitUntilBlocked()
+    let second = Task { try await repository.updateTitle(id: "c1", title: "Rejected") }
+    await fulfillment(of: [waiterRegistered], timeout: 1)
+    await gate.release()
+
+    for task in [first, second] {
+      do {
+        try await task.value
+        XCTFail("every caller of the rejected intent must receive the permanent failure")
+      } catch {}
+    }
+    let requestedTitles = await remote.requestedTitles()
+    XCTAssertEqual(requestedTitles, ["Rejected"])
+    XCTAssertEqual(repository.conversation(id: "c1")?.structured.title, "Original")
+  }
+
+  func testStarredFilterMembershipReturnsAfterPermanentRollback() async throws {
+    let original = makeConversation(id: "c1", revision: "1", starred: true)
+    let repository = ConversationRepository(
+      remote: ConversationRemoteStub(
+        list: [original],
+        detailById: ["c1": original],
+        starredError: APIError.httpError(statusCode: 400, detail: "rejected")
+      ),
+      cache: ConversationCacheStub(entries: [entry(original)]),
+      legacyMigrationEnabled: false
+    )
+    await repository.load(query: ConversationQuery(showStarredOnly: true))
+
+    do {
+      try await repository.updateStarred(id: "c1", starred: false)
+      XCTFail("permanent failure should surface")
+    } catch {}
+
+    XCTAssertEqual(repository.conversationIds, ["c1"])
+    XCTAssertTrue(repository.conversation(id: "c1")?.starred == true)
+  }
+
+  func testFolderFilterMembershipReturnsAfterPermanentRollback() async throws {
+    let original = makeConversation(id: "c1", revision: "1", folderId: "inbox")
+    let repository = ConversationRepository(
+      remote: ConversationRemoteStub(
+        list: [original],
+        detailById: ["c1": original],
+        mutationError: APIError.httpError(statusCode: 404, detail: "folder missing")
+      ),
+      cache: ConversationCacheStub(entries: [entry(original)]),
+      legacyMigrationEnabled: false
+    )
+    await repository.load(query: ConversationQuery(folderId: "inbox"))
+
+    do {
+      try await repository.moveToFolder(id: "c1", folderId: "missing")
+      XCTFail("permanent failure should surface")
+    } catch {}
+
+    XCTAssertEqual(repository.conversationIds, ["c1"])
+    XCTAssertEqual(repository.conversation(id: "c1")?.folderId, "inbox")
+  }
+
+  func testMutatingSearchOnlyEntityCannotInjectItIntoActiveListSnapshot() async throws {
+    let listed = makeConversation(id: "listed", revision: "1")
+    let searched = makeConversation(id: "searched", title: "Search result", revision: "2")
+    let renamed = makeConversation(id: "searched", title: "Renamed", revision: "3")
+    let repository = ConversationRepository(
+      remote: ConversationRemoteStub(
+        list: [listed],
+        searchResults: ["needle": [searched]],
+        titleResults: ["Renamed": renamed],
+        lightweightAcks: true
+      ),
+      cache: ConversationCacheStub(entries: [entry(listed)]),
+      legacyMigrationEnabled: false
+    )
+    await repository.load(query: ConversationQuery(limit: 1))
+    await repository.search("needle")
+
+    try await repository.updateTitle(id: "searched", title: "Renamed")
+
+    XCTAssertEqual(repository.conversationIds, ["listed"])
+    XCTAssertEqual(repository.conversation(id: "searched")?.structured.title, "Renamed")
+  }
+
+  func testSuccessfulRefreshClearsStaleRepositoryError() async {
+    let original = makeConversation(id: "c1", revision: "1")
+    let remote = ConversationRemoteStub(
+      list: [original],
+      listError: ConversationRemoteStubError.mutationFailed
+    )
+    let repository = ConversationRepository(
+      remote: remote,
+      cache: ConversationCacheStub(),
+      legacyMigrationEnabled: false
+    )
+
+    await repository.load(query: ConversationQuery())
+    XCTAssertNotNil(repository.error)
+
+    await remote.setListError(nil)
+    await repository.refresh()
+
+    XCTAssertNil(repository.error)
+    XCTAssertEqual(repository.conversationIds, ["c1"])
   }
 
   func testStatusOnlyAckKeepsOverlayUntilListConfirmsRequestedValue() async throws {
@@ -981,6 +1326,7 @@ final class ConversationRepositoryTests: XCTestCase {
     overview: String = "Overview",
     revision: String,
     starred: Bool = false,
+    folderId: String? = nil,
     transcript: [TranscriptSegment] = [],
     transcriptIncluded: Bool = false,
     deleted: Bool = false,
@@ -1013,7 +1359,7 @@ final class ConversationRepositoryTests: XCTestCase {
       deleted: deleted,
       isLocked: isLocked,
       starred: starred,
-      folderId: nil,
+      folderId: folderId,
       inputDeviceName: inputDeviceName,
       updatedAt: Date(timeIntervalSince1970: Double(revision) ?? 1),
       revision: revision

--- a/desktop/macos/changelog/unreleased/20260709-conversation-reliability.json
+++ b/desktop/macos/changelog/unreleased/20260709-conversation-reliability.json
@@ -1,0 +1,3 @@
+{
+  "change": "Improved Conversations reliability with faster cached loading and safer cross-device updates"
+}

--- a/desktop/macos/e2e/flows/capture-lifecycle.yaml
+++ b/desktop/macos/e2e/flows/capture-lifecycle.yaml
@@ -8,6 +8,7 @@ covers:
   - desktop/macos/Desktop/Sources/AppState/AppState+ListenEvents.swift
   - desktop/macos/Desktop/Sources/APIClient.swift
   - desktop/macos/Desktop/Sources/ConversationFinalizationService.swift
+  - desktop/macos/Desktop/Sources/Rewind/Core/RewindDatabase.swift
   - desktop/macos/Desktop/Sources/Rewind/Core/TranscriptionModels.swift
   - desktop/macos/Desktop/Sources/Rewind/Core/TranscriptionStorage.swift
   - desktop/macos/Desktop/Sources/APIClient.swift

--- a/desktop/macos/e2e/flows/dashboard.yaml
+++ b/desktop/macos/e2e/flows/dashboard.yaml
@@ -4,6 +4,11 @@ tier: 2
 description: Dashboard load and refresh via automation bridge
 app: non-prod
 covers:
+  - desktop/macos/Desktop/Sources/ConversationReconciliationPolicy.swift
+  - desktop/macos/Desktop/Sources/Conversations/ConversationCacheStorage.swift
+  - desktop/macos/Desktop/Sources/Conversations/ConversationRepository.swift
+  - desktop/macos/Desktop/Sources/MainWindow/Components/ConversationRowView.swift
+  - desktop/macos/Desktop/Sources/MainWindow/Pages/ConversationDetailView.swift
   - desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
   - desktop/macos/Desktop/Sources/AppState/AppState+DataLoading.swift
   - desktop/macos/Desktop/Sources/Stores/DashboardTaskRefreshService.swift

--- a/desktop/windows/src/renderer/src/lib/omiApi.generated.ts
+++ b/desktop/windows/src/renderer/src/lib/omiApi.generated.ts
@@ -779,6 +779,7 @@ export interface Conversation {
   private_cloud_sync_enabled?: boolean;
   processing_conversation_id?: string | null;
   processing_memory_id?: string | null;
+  revision?: string | null;
   source?: ConversationSource | null;
   starred?: boolean;
   started_at: string | null;
@@ -787,6 +788,7 @@ export interface Conversation {
   suggested_summarization_apps?: Array<string>;
   transcript_segments?: Array<TranscriptSegment>;
   transcript_segments_compressed?: boolean | null;
+  updated_at?: string | null;
   visibility?: ConversationVisibility;
 }
 
@@ -804,6 +806,20 @@ export interface ConversationCreateResponse {
   discarded: boolean;
   id: string;
   status: string;
+}
+
+export interface ConversationFolderMutationResponse {
+  id: string;
+  revision?: string | null;
+  status: string;
+  updated_at?: string | null;
+}
+
+export interface ConversationMutationResponse {
+  id: string;
+  revision?: string | null;
+  status: string;
+  updated_at?: string | null;
 }
 
 export interface ConversationPhoto {
@@ -2268,6 +2284,7 @@ export interface SharedConversationResponse {
   private_cloud_sync_enabled?: boolean;
   processing_conversation_id?: string | null;
   processing_memory_id?: string | null;
+  revision?: string | null;
   source?: ConversationSource | null;
   starred?: boolean;
   started_at: string | null;
@@ -2276,6 +2293,7 @@ export interface SharedConversationResponse {
   suggested_summarization_apps?: Array<string>;
   transcript_segments?: Array<TranscriptSegment>;
   transcript_segments_compressed?: boolean | null;
+  updated_at?: string | null;
   visibility?: ConversationVisibility;
   [key: string]: unknown;
 }
@@ -2988,6 +3006,8 @@ export interface OmiApiSchemas {
   "ConversationActionItemsDeleteResponse": ConversationActionItemsDeleteResponse;
   "ConversationActionItemsResponse": ConversationActionItemsResponse;
   "ConversationCreateResponse": ConversationCreateResponse;
+  "ConversationFolderMutationResponse": ConversationFolderMutationResponse;
+  "ConversationMutationResponse": ConversationMutationResponse;
   "ConversationPhoto": ConversationPhoto;
   "ConversationRecordingResponse": ConversationRecordingResponse;
   "ConversationSource": ConversationSource;
@@ -4121,6 +4141,16 @@ export interface OmiApiPaths {
       };
     };
   };
+  "/v1/conversations/list": {
+    get: {
+      operationId: "get_conversation_list_projection_v1_conversations_list_get";
+      responses: {
+        "200": Array<Conversation>;
+        "401": void;
+        "422": HTTPValidationError;
+      };
+    };
+  };
   "/v1/conversations/merge": {
     post: {
       operationId: "merge_conversations_v1_conversations_merge_post";
@@ -4266,7 +4296,7 @@ export interface OmiApiPaths {
     patch: {
       operationId: "move_conversation_to_folder_v1_conversations__conversation_id__folder_patch";
       responses: {
-        "200": FolderMutationResponse;
+        "200": ConversationFolderMutationResponse;
         "401": void;
         "404": void;
         "422": HTTPValidationError;
@@ -4352,7 +4382,7 @@ export interface OmiApiPaths {
     patch: {
       operationId: "set_conversation_starred_v1_conversations__conversation_id__starred_patch";
       responses: {
-        "200": ConversationStatusResponse;
+        "200": ConversationMutationResponse;
         "401": void;
         "404": void;
         "422": HTTPValidationError;
@@ -4395,7 +4425,7 @@ export interface OmiApiPaths {
     patch: {
       operationId: "patch_conversation_title_v1_conversations__conversation_id__title_patch";
       responses: {
-        "200": ConversationStatusResponse;
+        "200": ConversationMutationResponse;
         "401": void;
         "404": void;
         "422": HTTPValidationError;
@@ -8131,6 +8161,24 @@ export async function create_conversation_from_segments_user_v1_conversations_fr
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
+export async function get_conversation_list_projection_v1_conversations_list_get(query: { limit?: number, offset?: number, statuses?: string | null, include_discarded?: boolean, start_date?: string | null, end_date?: string | null, folder_id?: string | null, starred?: boolean | null }, init?: OmiApiClientInit): Promise<Array<Conversation>> {
+  const _base = init?.baseURL ?? "";
+  const _path = `/v1/conversations/list`;
+  const _params = query ? Object.entries(query)
+    .filter(([, v]) => v !== undefined && v !== null)
+    .map(([k, v]) => `${k}=${encodeURIComponent(String(v))}`).join('&') : '';
+  const _search = _params ? `?${_params}` : "";
+  const _res = await fetch(`${_base}${_path}${_search}`, {
+    method: "GET",
+    headers: {
+      ...(init?.token ? { Authorization: `Bearer ${init.token}` } : {}),
+      ...init?.headers,
+    },
+  });
+  if (!_res.ok) throw new OmiApiError(_res.status, _res);
+  return _res.status === 204 ? (undefined as any) : await _res.json();
+}
+
 export async function merge_conversations_v1_conversations_merge_post(body: MergeConversationsRequest, init?: OmiApiClientInit): Promise<MergeConversationsResponse> {
   const _base = init?.baseURL ?? "";
   const _path = `/v1/conversations/merge`;
@@ -8361,7 +8409,7 @@ export async function finalize_conversation_v1_conversations__conversation_id__f
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
-export async function move_conversation_to_folder_v1_conversations__conversation_id__folder_patch(path: { conversation_id: string }, body: MoveConversationRequest, init?: OmiApiClientInit): Promise<FolderMutationResponse> {
+export async function move_conversation_to_folder_v1_conversations__conversation_id__folder_patch(path: { conversation_id: string }, body: MoveConversationRequest, init?: OmiApiClientInit): Promise<ConversationFolderMutationResponse> {
   const _base = init?.baseURL ?? "";
   const _path = `/v1/conversations/${path.conversation_id}/folder`;
   const _search = "";
@@ -8493,7 +8541,7 @@ export async function get_shared_conversation_by_id_v1_conversations__conversati
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
-export async function set_conversation_starred_v1_conversations__conversation_id__starred_patch(path: { conversation_id: string }, query: { starred: boolean }, init?: OmiApiClientInit): Promise<ConversationStatusResponse> {
+export async function set_conversation_starred_v1_conversations__conversation_id__starred_patch(path: { conversation_id: string }, query: { starred: boolean }, init?: OmiApiClientInit): Promise<ConversationMutationResponse> {
   const _base = init?.baseURL ?? "";
   const _path = `/v1/conversations/${path.conversation_id}/starred`;
   const _params = query ? Object.entries(query)
@@ -8560,7 +8608,7 @@ export async function test_prompt_v1_conversations__conversation_id__test_prompt
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
-export async function patch_conversation_title_v1_conversations__conversation_id__title_patch(path: { conversation_id: string }, query: { title: string }, init?: OmiApiClientInit): Promise<ConversationStatusResponse> {
+export async function patch_conversation_title_v1_conversations__conversation_id__title_patch(path: { conversation_id: string }, query: { title: string }, init?: OmiApiClientInit): Promise<ConversationMutationResponse> {
   const _base = init?.baseURL ?? "";
   const _path = `/v1/conversations/${path.conversation_id}/title`;
   const _params = query ? Object.entries(query)
@@ -12366,4 +12414,4 @@ export async function get_speech_profile_v4_speech_profile_get(init?: OmiApiClie
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
-// Total: 343 client methods generated.
+// Total: 344 client methods generated.

--- a/docs/api-reference/app-client-openapi.json
+++ b/docs/api-reference/app-client-openapi.json
@@ -4652,6 +4652,17 @@
             ],
             "title": "Processing Memory Id"
           },
+          "revision": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Revision"
+          },
           "source": {
             "anyOf": [
               {
@@ -4721,6 +4732,18 @@
             ],
             "default": false,
             "title": "Transcript Segments Compressed"
+          },
+          "updated_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Updated At"
           },
           "visibility": {
             "$ref": "#/components/schemas/ConversationVisibility",
@@ -4797,6 +4820,88 @@
           "discarded"
         ],
         "title": "ConversationCreateResponse",
+        "type": "object"
+      },
+      "ConversationFolderMutationResponse": {
+        "properties": {
+          "id": {
+            "title": "Id",
+            "type": "string"
+          },
+          "revision": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Revision"
+          },
+          "status": {
+            "title": "Status",
+            "type": "string"
+          },
+          "updated_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Updated At"
+          }
+        },
+        "required": [
+          "status",
+          "id"
+        ],
+        "title": "ConversationFolderMutationResponse",
+        "type": "object"
+      },
+      "ConversationMutationResponse": {
+        "properties": {
+          "id": {
+            "title": "Id",
+            "type": "string"
+          },
+          "revision": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Revision"
+          },
+          "status": {
+            "title": "Status",
+            "type": "string"
+          },
+          "updated_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Updated At"
+          }
+        },
+        "required": [
+          "status",
+          "id"
+        ],
+        "title": "ConversationMutationResponse",
         "type": "object"
       },
       "ConversationPhoto": {
@@ -13176,6 +13281,17 @@
             ],
             "title": "Processing Memory Id"
           },
+          "revision": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Revision"
+          },
           "source": {
             "anyOf": [
               {
@@ -13245,6 +13361,18 @@
             ],
             "default": false,
             "title": "Transcript Segments Compressed"
+          },
+          "updated_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Updated At"
           },
           "visibility": {
             "$ref": "#/components/schemas/ConversationVisibility",
@@ -24295,6 +24423,204 @@
         ]
       }
     },
+    "/v1/conversations/list": {
+      "get": {
+        "description": "Explicit lightweight list projection. Detail-only transcript_segments are omitted.",
+        "operationId": "get_conversation_list_projection_v1_conversations_list_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 100,
+              "maximum": 1000,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "minimum": 0,
+              "title": "Offset",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "statuses",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": "processing,completed",
+              "title": "Statuses"
+            }
+          },
+          {
+            "in": "query",
+            "name": "include_discarded",
+            "required": false,
+            "schema": {
+              "default": true,
+              "title": "Include Discarded",
+              "type": "boolean"
+            }
+          },
+          {
+            "in": "query",
+            "name": "start_date",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "format": "date-time",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Start Date"
+            }
+          },
+          {
+            "in": "query",
+            "name": "end_date",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "format": "date-time",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "End Date"
+            }
+          },
+          {
+            "in": "query",
+            "name": "folder_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Folder Id"
+            }
+          },
+          {
+            "in": "query",
+            "name": "starred",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Starred"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "title": "Authorization",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-App-Platform",
+            "required": false,
+            "schema": {
+              "title": "X-App-Platform",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Device-Id-Hash",
+            "required": false,
+            "schema": {
+              "title": "X-Device-Id-Hash",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-App-Version",
+            "required": false,
+            "schema": {
+              "title": "X-App-Version",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/Conversation"
+                  },
+                  "title": "Response Get Conversation List Projection V1 Conversations List Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "401": {
+            "$ref": "#/components/responses/Error401"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "firebaseBearer": []
+          }
+        ],
+        "summary": "Get Conversation List Projection",
+        "tags": [
+          "conversations"
+        ]
+      }
+    },
     "/v1/conversations/merge": {
       "post": {
         "description": "Merge multiple conversations into a new conversation (async).\n\nFlow:\n1. Validates conversations (locked? completed?)\n2. Returns immediately with 200 OK\n3. Background task creates new merged conversation\n4. Background task deletes source conversations\n5. FCM notification sent on completion\n\nThe merged conversation will have:\n- A new ID (source conversations are deleted)\n- Merged transcript segments with adjusted timestamps\n- Copied audio chunks\n- Regenerated title, summary, action items, memories via process_conversation()",
@@ -25698,7 +26024,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/FolderMutationResponse"
+                  "$ref": "#/components/schemas/ConversationFolderMutationResponse"
                 }
               }
             },
@@ -26475,7 +26801,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ConversationStatusResponse"
+                  "$ref": "#/components/schemas/ConversationMutationResponse"
                 }
               }
             },
@@ -26857,7 +27183,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ConversationStatusResponse"
+                  "$ref": "#/components/schemas/ConversationMutationResponse"
                 }
               }
             },

--- a/web/admin/lib/services/omi-api/omiApi.generated.ts
+++ b/web/admin/lib/services/omi-api/omiApi.generated.ts
@@ -779,6 +779,7 @@ export interface Conversation {
   private_cloud_sync_enabled?: boolean;
   processing_conversation_id?: string | null;
   processing_memory_id?: string | null;
+  revision?: string | null;
   source?: ConversationSource | null;
   starred?: boolean;
   started_at: string | null;
@@ -787,6 +788,7 @@ export interface Conversation {
   suggested_summarization_apps?: Array<string>;
   transcript_segments?: Array<TranscriptSegment>;
   transcript_segments_compressed?: boolean | null;
+  updated_at?: string | null;
   visibility?: ConversationVisibility;
 }
 
@@ -804,6 +806,20 @@ export interface ConversationCreateResponse {
   discarded: boolean;
   id: string;
   status: string;
+}
+
+export interface ConversationFolderMutationResponse {
+  id: string;
+  revision?: string | null;
+  status: string;
+  updated_at?: string | null;
+}
+
+export interface ConversationMutationResponse {
+  id: string;
+  revision?: string | null;
+  status: string;
+  updated_at?: string | null;
 }
 
 export interface ConversationPhoto {
@@ -2268,6 +2284,7 @@ export interface SharedConversationResponse {
   private_cloud_sync_enabled?: boolean;
   processing_conversation_id?: string | null;
   processing_memory_id?: string | null;
+  revision?: string | null;
   source?: ConversationSource | null;
   starred?: boolean;
   started_at: string | null;
@@ -2276,6 +2293,7 @@ export interface SharedConversationResponse {
   suggested_summarization_apps?: Array<string>;
   transcript_segments?: Array<TranscriptSegment>;
   transcript_segments_compressed?: boolean | null;
+  updated_at?: string | null;
   visibility?: ConversationVisibility;
   [key: string]: unknown;
 }
@@ -2988,6 +3006,8 @@ export interface OmiApiSchemas {
   "ConversationActionItemsDeleteResponse": ConversationActionItemsDeleteResponse;
   "ConversationActionItemsResponse": ConversationActionItemsResponse;
   "ConversationCreateResponse": ConversationCreateResponse;
+  "ConversationFolderMutationResponse": ConversationFolderMutationResponse;
+  "ConversationMutationResponse": ConversationMutationResponse;
   "ConversationPhoto": ConversationPhoto;
   "ConversationRecordingResponse": ConversationRecordingResponse;
   "ConversationSource": ConversationSource;
@@ -4121,6 +4141,16 @@ export interface OmiApiPaths {
       };
     };
   };
+  "/v1/conversations/list": {
+    get: {
+      operationId: "get_conversation_list_projection_v1_conversations_list_get";
+      responses: {
+        "200": Array<Conversation>;
+        "401": void;
+        "422": HTTPValidationError;
+      };
+    };
+  };
   "/v1/conversations/merge": {
     post: {
       operationId: "merge_conversations_v1_conversations_merge_post";
@@ -4266,7 +4296,7 @@ export interface OmiApiPaths {
     patch: {
       operationId: "move_conversation_to_folder_v1_conversations__conversation_id__folder_patch";
       responses: {
-        "200": FolderMutationResponse;
+        "200": ConversationFolderMutationResponse;
         "401": void;
         "404": void;
         "422": HTTPValidationError;
@@ -4352,7 +4382,7 @@ export interface OmiApiPaths {
     patch: {
       operationId: "set_conversation_starred_v1_conversations__conversation_id__starred_patch";
       responses: {
-        "200": ConversationStatusResponse;
+        "200": ConversationMutationResponse;
         "401": void;
         "404": void;
         "422": HTTPValidationError;
@@ -4395,7 +4425,7 @@ export interface OmiApiPaths {
     patch: {
       operationId: "patch_conversation_title_v1_conversations__conversation_id__title_patch";
       responses: {
-        "200": ConversationStatusResponse;
+        "200": ConversationMutationResponse;
         "401": void;
         "404": void;
         "422": HTTPValidationError;
@@ -8131,6 +8161,24 @@ export async function create_conversation_from_segments_user_v1_conversations_fr
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
+export async function get_conversation_list_projection_v1_conversations_list_get(query: { limit?: number, offset?: number, statuses?: string | null, include_discarded?: boolean, start_date?: string | null, end_date?: string | null, folder_id?: string | null, starred?: boolean | null }, init?: OmiApiClientInit): Promise<Array<Conversation>> {
+  const _base = init?.baseURL ?? "";
+  const _path = `/v1/conversations/list`;
+  const _params = query ? Object.entries(query)
+    .filter(([, v]) => v !== undefined && v !== null)
+    .map(([k, v]) => `${k}=${encodeURIComponent(String(v))}`).join('&') : '';
+  const _search = _params ? `?${_params}` : "";
+  const _res = await fetch(`${_base}${_path}${_search}`, {
+    method: "GET",
+    headers: {
+      ...(init?.token ? { Authorization: `Bearer ${init.token}` } : {}),
+      ...init?.headers,
+    },
+  });
+  if (!_res.ok) throw new OmiApiError(_res.status, _res);
+  return _res.status === 204 ? (undefined as any) : await _res.json();
+}
+
 export async function merge_conversations_v1_conversations_merge_post(body: MergeConversationsRequest, init?: OmiApiClientInit): Promise<MergeConversationsResponse> {
   const _base = init?.baseURL ?? "";
   const _path = `/v1/conversations/merge`;
@@ -8361,7 +8409,7 @@ export async function finalize_conversation_v1_conversations__conversation_id__f
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
-export async function move_conversation_to_folder_v1_conversations__conversation_id__folder_patch(path: { conversation_id: string }, body: MoveConversationRequest, init?: OmiApiClientInit): Promise<FolderMutationResponse> {
+export async function move_conversation_to_folder_v1_conversations__conversation_id__folder_patch(path: { conversation_id: string }, body: MoveConversationRequest, init?: OmiApiClientInit): Promise<ConversationFolderMutationResponse> {
   const _base = init?.baseURL ?? "";
   const _path = `/v1/conversations/${path.conversation_id}/folder`;
   const _search = "";
@@ -8493,7 +8541,7 @@ export async function get_shared_conversation_by_id_v1_conversations__conversati
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
-export async function set_conversation_starred_v1_conversations__conversation_id__starred_patch(path: { conversation_id: string }, query: { starred: boolean }, init?: OmiApiClientInit): Promise<ConversationStatusResponse> {
+export async function set_conversation_starred_v1_conversations__conversation_id__starred_patch(path: { conversation_id: string }, query: { starred: boolean }, init?: OmiApiClientInit): Promise<ConversationMutationResponse> {
   const _base = init?.baseURL ?? "";
   const _path = `/v1/conversations/${path.conversation_id}/starred`;
   const _params = query ? Object.entries(query)
@@ -8560,7 +8608,7 @@ export async function test_prompt_v1_conversations__conversation_id__test_prompt
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
-export async function patch_conversation_title_v1_conversations__conversation_id__title_patch(path: { conversation_id: string }, query: { title: string }, init?: OmiApiClientInit): Promise<ConversationStatusResponse> {
+export async function patch_conversation_title_v1_conversations__conversation_id__title_patch(path: { conversation_id: string }, query: { title: string }, init?: OmiApiClientInit): Promise<ConversationMutationResponse> {
   const _base = init?.baseURL ?? "";
   const _path = `/v1/conversations/${path.conversation_id}/title`;
   const _params = query ? Object.entries(query)
@@ -12366,4 +12414,4 @@ export async function get_speech_profile_v4_speech_profile_get(init?: OmiApiClie
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
-// Total: 343 client methods generated.
+// Total: 344 client methods generated.

--- a/web/app/src/lib/omiApi.generated.ts
+++ b/web/app/src/lib/omiApi.generated.ts
@@ -779,6 +779,7 @@ export interface Conversation {
   private_cloud_sync_enabled?: boolean;
   processing_conversation_id?: string | null;
   processing_memory_id?: string | null;
+  revision?: string | null;
   source?: ConversationSource | null;
   starred?: boolean;
   started_at: string | null;
@@ -787,6 +788,7 @@ export interface Conversation {
   suggested_summarization_apps?: Array<string>;
   transcript_segments?: Array<TranscriptSegment>;
   transcript_segments_compressed?: boolean | null;
+  updated_at?: string | null;
   visibility?: ConversationVisibility;
 }
 
@@ -804,6 +806,20 @@ export interface ConversationCreateResponse {
   discarded: boolean;
   id: string;
   status: string;
+}
+
+export interface ConversationFolderMutationResponse {
+  id: string;
+  revision?: string | null;
+  status: string;
+  updated_at?: string | null;
+}
+
+export interface ConversationMutationResponse {
+  id: string;
+  revision?: string | null;
+  status: string;
+  updated_at?: string | null;
 }
 
 export interface ConversationPhoto {
@@ -2268,6 +2284,7 @@ export interface SharedConversationResponse {
   private_cloud_sync_enabled?: boolean;
   processing_conversation_id?: string | null;
   processing_memory_id?: string | null;
+  revision?: string | null;
   source?: ConversationSource | null;
   starred?: boolean;
   started_at: string | null;
@@ -2276,6 +2293,7 @@ export interface SharedConversationResponse {
   suggested_summarization_apps?: Array<string>;
   transcript_segments?: Array<TranscriptSegment>;
   transcript_segments_compressed?: boolean | null;
+  updated_at?: string | null;
   visibility?: ConversationVisibility;
   [key: string]: unknown;
 }
@@ -2988,6 +3006,8 @@ export interface OmiApiSchemas {
   "ConversationActionItemsDeleteResponse": ConversationActionItemsDeleteResponse;
   "ConversationActionItemsResponse": ConversationActionItemsResponse;
   "ConversationCreateResponse": ConversationCreateResponse;
+  "ConversationFolderMutationResponse": ConversationFolderMutationResponse;
+  "ConversationMutationResponse": ConversationMutationResponse;
   "ConversationPhoto": ConversationPhoto;
   "ConversationRecordingResponse": ConversationRecordingResponse;
   "ConversationSource": ConversationSource;
@@ -4121,6 +4141,16 @@ export interface OmiApiPaths {
       };
     };
   };
+  "/v1/conversations/list": {
+    get: {
+      operationId: "get_conversation_list_projection_v1_conversations_list_get";
+      responses: {
+        "200": Array<Conversation>;
+        "401": void;
+        "422": HTTPValidationError;
+      };
+    };
+  };
   "/v1/conversations/merge": {
     post: {
       operationId: "merge_conversations_v1_conversations_merge_post";
@@ -4266,7 +4296,7 @@ export interface OmiApiPaths {
     patch: {
       operationId: "move_conversation_to_folder_v1_conversations__conversation_id__folder_patch";
       responses: {
-        "200": FolderMutationResponse;
+        "200": ConversationFolderMutationResponse;
         "401": void;
         "404": void;
         "422": HTTPValidationError;
@@ -4352,7 +4382,7 @@ export interface OmiApiPaths {
     patch: {
       operationId: "set_conversation_starred_v1_conversations__conversation_id__starred_patch";
       responses: {
-        "200": ConversationStatusResponse;
+        "200": ConversationMutationResponse;
         "401": void;
         "404": void;
         "422": HTTPValidationError;
@@ -4395,7 +4425,7 @@ export interface OmiApiPaths {
     patch: {
       operationId: "patch_conversation_title_v1_conversations__conversation_id__title_patch";
       responses: {
-        "200": ConversationStatusResponse;
+        "200": ConversationMutationResponse;
         "401": void;
         "404": void;
         "422": HTTPValidationError;
@@ -8131,6 +8161,24 @@ export async function create_conversation_from_segments_user_v1_conversations_fr
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
+export async function get_conversation_list_projection_v1_conversations_list_get(query: { limit?: number, offset?: number, statuses?: string | null, include_discarded?: boolean, start_date?: string | null, end_date?: string | null, folder_id?: string | null, starred?: boolean | null }, init?: OmiApiClientInit): Promise<Array<Conversation>> {
+  const _base = init?.baseURL ?? "";
+  const _path = `/v1/conversations/list`;
+  const _params = query ? Object.entries(query)
+    .filter(([, v]) => v !== undefined && v !== null)
+    .map(([k, v]) => `${k}=${encodeURIComponent(String(v))}`).join('&') : '';
+  const _search = _params ? `?${_params}` : "";
+  const _res = await fetch(`${_base}${_path}${_search}`, {
+    method: "GET",
+    headers: {
+      ...(init?.token ? { Authorization: `Bearer ${init.token}` } : {}),
+      ...init?.headers,
+    },
+  });
+  if (!_res.ok) throw new OmiApiError(_res.status, _res);
+  return _res.status === 204 ? (undefined as any) : await _res.json();
+}
+
 export async function merge_conversations_v1_conversations_merge_post(body: MergeConversationsRequest, init?: OmiApiClientInit): Promise<MergeConversationsResponse> {
   const _base = init?.baseURL ?? "";
   const _path = `/v1/conversations/merge`;
@@ -8361,7 +8409,7 @@ export async function finalize_conversation_v1_conversations__conversation_id__f
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
-export async function move_conversation_to_folder_v1_conversations__conversation_id__folder_patch(path: { conversation_id: string }, body: MoveConversationRequest, init?: OmiApiClientInit): Promise<FolderMutationResponse> {
+export async function move_conversation_to_folder_v1_conversations__conversation_id__folder_patch(path: { conversation_id: string }, body: MoveConversationRequest, init?: OmiApiClientInit): Promise<ConversationFolderMutationResponse> {
   const _base = init?.baseURL ?? "";
   const _path = `/v1/conversations/${path.conversation_id}/folder`;
   const _search = "";
@@ -8493,7 +8541,7 @@ export async function get_shared_conversation_by_id_v1_conversations__conversati
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
-export async function set_conversation_starred_v1_conversations__conversation_id__starred_patch(path: { conversation_id: string }, query: { starred: boolean }, init?: OmiApiClientInit): Promise<ConversationStatusResponse> {
+export async function set_conversation_starred_v1_conversations__conversation_id__starred_patch(path: { conversation_id: string }, query: { starred: boolean }, init?: OmiApiClientInit): Promise<ConversationMutationResponse> {
   const _base = init?.baseURL ?? "";
   const _path = `/v1/conversations/${path.conversation_id}/starred`;
   const _params = query ? Object.entries(query)
@@ -8560,7 +8608,7 @@ export async function test_prompt_v1_conversations__conversation_id__test_prompt
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
-export async function patch_conversation_title_v1_conversations__conversation_id__title_patch(path: { conversation_id: string }, query: { title: string }, init?: OmiApiClientInit): Promise<ConversationStatusResponse> {
+export async function patch_conversation_title_v1_conversations__conversation_id__title_patch(path: { conversation_id: string }, query: { title: string }, init?: OmiApiClientInit): Promise<ConversationMutationResponse> {
   const _base = init?.baseURL ?? "";
   const _path = `/v1/conversations/${path.conversation_id}/title`;
   const _params = query ? Object.entries(query)
@@ -12366,4 +12414,4 @@ export async function get_speech_profile_v4_speech_profile_get(init?: OmiApiClie
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
-// Total: 343 client methods generated.
+// Total: 344 client methods generated.

--- a/web/personas-open-source/src/lib/omiApi.generated.ts
+++ b/web/personas-open-source/src/lib/omiApi.generated.ts
@@ -779,6 +779,7 @@ export interface Conversation {
   private_cloud_sync_enabled?: boolean;
   processing_conversation_id?: string | null;
   processing_memory_id?: string | null;
+  revision?: string | null;
   source?: ConversationSource | null;
   starred?: boolean;
   started_at: string | null;
@@ -787,6 +788,7 @@ export interface Conversation {
   suggested_summarization_apps?: Array<string>;
   transcript_segments?: Array<TranscriptSegment>;
   transcript_segments_compressed?: boolean | null;
+  updated_at?: string | null;
   visibility?: ConversationVisibility;
 }
 
@@ -804,6 +806,20 @@ export interface ConversationCreateResponse {
   discarded: boolean;
   id: string;
   status: string;
+}
+
+export interface ConversationFolderMutationResponse {
+  id: string;
+  revision?: string | null;
+  status: string;
+  updated_at?: string | null;
+}
+
+export interface ConversationMutationResponse {
+  id: string;
+  revision?: string | null;
+  status: string;
+  updated_at?: string | null;
 }
 
 export interface ConversationPhoto {
@@ -2268,6 +2284,7 @@ export interface SharedConversationResponse {
   private_cloud_sync_enabled?: boolean;
   processing_conversation_id?: string | null;
   processing_memory_id?: string | null;
+  revision?: string | null;
   source?: ConversationSource | null;
   starred?: boolean;
   started_at: string | null;
@@ -2276,6 +2293,7 @@ export interface SharedConversationResponse {
   suggested_summarization_apps?: Array<string>;
   transcript_segments?: Array<TranscriptSegment>;
   transcript_segments_compressed?: boolean | null;
+  updated_at?: string | null;
   visibility?: ConversationVisibility;
   [key: string]: unknown;
 }
@@ -2988,6 +3006,8 @@ export interface OmiApiSchemas {
   "ConversationActionItemsDeleteResponse": ConversationActionItemsDeleteResponse;
   "ConversationActionItemsResponse": ConversationActionItemsResponse;
   "ConversationCreateResponse": ConversationCreateResponse;
+  "ConversationFolderMutationResponse": ConversationFolderMutationResponse;
+  "ConversationMutationResponse": ConversationMutationResponse;
   "ConversationPhoto": ConversationPhoto;
   "ConversationRecordingResponse": ConversationRecordingResponse;
   "ConversationSource": ConversationSource;
@@ -4121,6 +4141,16 @@ export interface OmiApiPaths {
       };
     };
   };
+  "/v1/conversations/list": {
+    get: {
+      operationId: "get_conversation_list_projection_v1_conversations_list_get";
+      responses: {
+        "200": Array<Conversation>;
+        "401": void;
+        "422": HTTPValidationError;
+      };
+    };
+  };
   "/v1/conversations/merge": {
     post: {
       operationId: "merge_conversations_v1_conversations_merge_post";
@@ -4266,7 +4296,7 @@ export interface OmiApiPaths {
     patch: {
       operationId: "move_conversation_to_folder_v1_conversations__conversation_id__folder_patch";
       responses: {
-        "200": FolderMutationResponse;
+        "200": ConversationFolderMutationResponse;
         "401": void;
         "404": void;
         "422": HTTPValidationError;
@@ -4352,7 +4382,7 @@ export interface OmiApiPaths {
     patch: {
       operationId: "set_conversation_starred_v1_conversations__conversation_id__starred_patch";
       responses: {
-        "200": ConversationStatusResponse;
+        "200": ConversationMutationResponse;
         "401": void;
         "404": void;
         "422": HTTPValidationError;
@@ -4395,7 +4425,7 @@ export interface OmiApiPaths {
     patch: {
       operationId: "patch_conversation_title_v1_conversations__conversation_id__title_patch";
       responses: {
-        "200": ConversationStatusResponse;
+        "200": ConversationMutationResponse;
         "401": void;
         "404": void;
         "422": HTTPValidationError;
@@ -8131,6 +8161,24 @@ export async function create_conversation_from_segments_user_v1_conversations_fr
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
+export async function get_conversation_list_projection_v1_conversations_list_get(query: { limit?: number, offset?: number, statuses?: string | null, include_discarded?: boolean, start_date?: string | null, end_date?: string | null, folder_id?: string | null, starred?: boolean | null }, init?: OmiApiClientInit): Promise<Array<Conversation>> {
+  const _base = init?.baseURL ?? "";
+  const _path = `/v1/conversations/list`;
+  const _params = query ? Object.entries(query)
+    .filter(([, v]) => v !== undefined && v !== null)
+    .map(([k, v]) => `${k}=${encodeURIComponent(String(v))}`).join('&') : '';
+  const _search = _params ? `?${_params}` : "";
+  const _res = await fetch(`${_base}${_path}${_search}`, {
+    method: "GET",
+    headers: {
+      ...(init?.token ? { Authorization: `Bearer ${init.token}` } : {}),
+      ...init?.headers,
+    },
+  });
+  if (!_res.ok) throw new OmiApiError(_res.status, _res);
+  return _res.status === 204 ? (undefined as any) : await _res.json();
+}
+
 export async function merge_conversations_v1_conversations_merge_post(body: MergeConversationsRequest, init?: OmiApiClientInit): Promise<MergeConversationsResponse> {
   const _base = init?.baseURL ?? "";
   const _path = `/v1/conversations/merge`;
@@ -8361,7 +8409,7 @@ export async function finalize_conversation_v1_conversations__conversation_id__f
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
-export async function move_conversation_to_folder_v1_conversations__conversation_id__folder_patch(path: { conversation_id: string }, body: MoveConversationRequest, init?: OmiApiClientInit): Promise<FolderMutationResponse> {
+export async function move_conversation_to_folder_v1_conversations__conversation_id__folder_patch(path: { conversation_id: string }, body: MoveConversationRequest, init?: OmiApiClientInit): Promise<ConversationFolderMutationResponse> {
   const _base = init?.baseURL ?? "";
   const _path = `/v1/conversations/${path.conversation_id}/folder`;
   const _search = "";
@@ -8493,7 +8541,7 @@ export async function get_shared_conversation_by_id_v1_conversations__conversati
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
-export async function set_conversation_starred_v1_conversations__conversation_id__starred_patch(path: { conversation_id: string }, query: { starred: boolean }, init?: OmiApiClientInit): Promise<ConversationStatusResponse> {
+export async function set_conversation_starred_v1_conversations__conversation_id__starred_patch(path: { conversation_id: string }, query: { starred: boolean }, init?: OmiApiClientInit): Promise<ConversationMutationResponse> {
   const _base = init?.baseURL ?? "";
   const _path = `/v1/conversations/${path.conversation_id}/starred`;
   const _params = query ? Object.entries(query)
@@ -8560,7 +8608,7 @@ export async function test_prompt_v1_conversations__conversation_id__test_prompt
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
-export async function patch_conversation_title_v1_conversations__conversation_id__title_patch(path: { conversation_id: string }, query: { title: string }, init?: OmiApiClientInit): Promise<ConversationStatusResponse> {
+export async function patch_conversation_title_v1_conversations__conversation_id__title_patch(path: { conversation_id: string }, query: { title: string }, init?: OmiApiClientInit): Promise<ConversationMutationResponse> {
   const _base = init?.baseURL ?? "";
   const _path = `/v1/conversations/${path.conversation_id}/title`;
   const _params = query ? Object.entries(query)
@@ -12366,4 +12414,4 @@ export async function get_speech_profile_v4_speech_profile_get(init?: OmiApiClie
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
-// Total: 343 client methods generated.
+// Total: 344 client methods generated.


### PR DESCRIPTION
Closes #8197

## Summary

- Add one account-scoped `ConversationRepository` as the authoritative desktop read/mutation boundary, with cache-first delivery, ID-based observation, and separate list/detail/transcript completeness and freshness.
- Admit server responses by version, generation, and revocation state so stale searches, details, deletes, locks, or previous-account requests cannot resurrect or overwrite newer state.
- Centralize durable title/star/folder mutations with coalescing, persisted pending intent, confirmation, retry, rollback, canonical-cache protection, and correct per-caller failure delivery.
- Preserve sub-millisecond Firestore revisions through SQLite, serialize projection merges in one transaction, and fail account-pool changes closed.
- Add lightweight versioned backend list/mutation contracts, real Firestore projections, minimal authorization reads, and an instrumented one-shot legacy endpoint fallback for rolling deploys.
- Separate capture/finalization persistence from conversation read authority and migrate desktop UI consumers to the repository.
- Add deterministic real-database, concurrency, rollback, account-isolation, and hermetic backend regression coverage.

## Architecture direction

This is the intended 80/20 move toward the platonic model: one authoritative repository per signed-in account; the backend owns version truth; views observe IDs instead of carrying divergent object snapshots; mutation intent is durable and reconciled centrally; and tests exercise deterministic state transitions without live services or timing sleeps.

The remaining complexity is concentrated at the boundary—rollout compatibility, persistence, and reconciliation—instead of being repeated across views.

## Product invariants affected

- `INV-AUTH-1` — account-scoped repository generations and cache guards preserve session isolation across sign-out/account changes.
- `INV-CHAT-1` — citation navigation now observes repository IDs while preserving the shared chat thread and citation-detail continuity.

## Verification

- Independent subagent review: **approved; no actionable findings remain after final re-review**
- Desktop Swift suites: **183 suites passed in isolated shards**
- `ConversationRepositoryTests`: **38 passed**
- Real SQLite `ConversationCacheStorageTests`: **7 passed**
- Targeted backend lock/projection suites: **69 passed**
- Backend hermetic E2E: **103 passed, 3 skipped**
- Backend runtime-env validator: **21 passed**
- Desktop strict e2e-flow coverage: **17/17 changed Swift files covered**
- Import-purity, async-blocker, module-stub-pollution, route-policy, formatting, typecheck (0 errors), OpenAPI, generated-client, and pre-push checks passed
- Named ad-hoc bundle `omi-conversation-repository-ci` built, launched, passed dependency audit, exposed a healthy automation bridge, and passed the tier-1 desktop harness (harness-smoke + navigation)

## Manual-test limitation

The signed-in Conversations UI could not be exercised locally because the available Omi Dev profile contained no reusable auth session or Keychain credentials. The named bundle was exercised through its real automation bridge and tier-1 harness in signed-out mode; signed-in repository/UI behavior is covered by the deterministic repository and real-SQLite regression suites above.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9365?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->