### PR TITLE
Persist macOS chat drafts across restarts and updates

### DIFF
--- a/desktop/macos/Desktop/Sources/AuthService.swift
+++ b/desktop/macos/Desktop/Sources/AuthService.swift
@@ -2393,6 +2393,7 @@ class AuthService {
             SentrySDK.setUser(nil)
         }
 
+        let signingOutUserID = UserDefaults.standard.string(forKey: "auth_userId")
         try Auth.auth().signOut()
         // Reset coordinator only after Firebase sign-out succeeds so the state
         // transition is atomic — if signOut() throws (e.g. keychain error), the
@@ -2402,6 +2403,7 @@ class AuthService {
         isSignedIn = false
         CredentialHealthManager.shared.reset()
         APIKeyService.shared.clear()
+        ChatDraftStore.shared.clearAll(ownerID: signingOutUserID)
         // Clear saved auth state and tokens
         saveAuthState(isSignedIn: false, email: nil, userId: nil)
         clearTokens()

--- a/desktop/macos/Desktop/Sources/Chat/ChatDraftStore.swift
+++ b/desktop/macos/Desktop/Sources/Chat/ChatDraftStore.swift
@@ -1,0 +1,223 @@
+import Foundation
+
+/// Stable identity for unsent text in one conversational composer.
+///
+/// Drafts are deliberately separate from chat/session persistence: they are local UI
+/// intent and never become conversation history until a send is accepted.
+struct ChatDraftKey: Hashable, Sendable {
+    let scope: String
+    let contextID: String
+
+    static func mainChat(contextID: String = "default") -> Self {
+        Self(scope: "main_chat", contextID: contextID)
+    }
+
+    static let floatingMain = Self(scope: "floating_chat", contextID: "main")
+    static let onboardingMain = Self(scope: "onboarding_chat", contextID: "main")
+    static let onboardingFloating = Self(scope: "onboarding_chat", contextID: "floating")
+
+    static func floatingAgent(_ id: UUID) -> Self {
+        Self(scope: "floating_agent", contextID: id.uuidString.lowercased())
+    }
+
+    static func taskChat(_ taskID: String) -> Self {
+        Self(scope: "task_chat", contextID: taskID)
+    }
+}
+
+private struct ChatDraftRecord: Codable, Sendable {
+    let version: Int
+    let ownerID: String
+    let scope: String
+    let contextID: String
+    let text: String
+    let updatedAt: Date
+}
+
+/// Lightweight local persistence for conversational drafts.
+///
+/// Each draft is an independent, atomically replaced record under Application
+/// Support. Writes are coalesced on a serial background queue, so the typing path
+/// only updates in-memory UI state. A corrupt record cannot affect another draft.
+@MainActor
+final class ChatDraftStore {
+    static let shared = ChatDraftStore()
+
+    private struct StorageID: Hashable, Sendable {
+        let ownerID: String
+        let key: ChatDraftKey
+    }
+
+    private let rootURL: URL
+    private let fileManager: FileManager
+    private let writeDelay: TimeInterval
+    private let ownerIDProvider: () -> String?
+    private let persistenceQueue = DispatchQueue(label: "com.omi.desktop.chat-drafts", qos: .utility)
+
+    private var cache: [StorageID: String] = [:]
+    private var loaded: Set<StorageID> = []
+    private var pendingWrites: [StorageID: DispatchWorkItem] = [:]
+    private var writeGenerations: [StorageID: Int] = [:]
+
+    init(
+        rootURL: URL? = nil,
+        fileManager: FileManager = .default,
+        writeDelay: TimeInterval = 0.2,
+        ownerIDProvider: @escaping () -> String? = {
+            UserDefaults.standard.string(forKey: "auth_userId")
+        }
+    ) {
+        self.fileManager = fileManager
+        self.writeDelay = writeDelay
+        self.ownerIDProvider = ownerIDProvider
+
+        if let rootURL {
+            self.rootURL = rootURL
+        } else {
+            let applicationSupport = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
+                ?? fileManager.homeDirectoryForCurrentUser.appendingPathComponent("Library/Application Support")
+            let bundleID = Bundle.main.bundleIdentifier ?? "com.omi.desktop"
+            self.rootURL = applicationSupport
+                .appendingPathComponent(bundleID, isDirectory: true)
+                .appendingPathComponent("Drafts/v1", isDirectory: true)
+        }
+    }
+
+    func text(for key: ChatDraftKey, ownerID: String? = nil) -> String {
+        let id = storageID(for: key, ownerID: ownerID)
+        if loaded.contains(id) {
+            return cache[id] ?? ""
+        }
+
+        loaded.insert(id)
+        guard let data = try? Data(contentsOf: fileURL(for: id)),
+              let record = try? JSONDecoder().decode(ChatDraftRecord.self, from: data),
+              record.version == 1,
+              record.ownerID == id.ownerID,
+              record.scope == key.scope,
+              record.contextID == key.contextID else {
+            cache[id] = ""
+            return ""
+        }
+
+        cache[id] = record.text
+        return record.text
+    }
+
+    func setText(_ text: String, for key: ChatDraftKey, ownerID: String? = nil) {
+        let id = storageID(for: key, ownerID: ownerID)
+        loaded.insert(id)
+        cache[id] = text
+        scheduleWrite(for: id, text: text)
+    }
+
+    func clear(_ key: ChatDraftKey, ownerID: String? = nil) {
+        setText("", for: key, ownerID: ownerID)
+    }
+
+    /// Synchronously persists the latest in-memory values. Used for orderly app
+    /// termination and tests; normal edits remain off the main thread.
+    func flush() {
+        let snapshots = pendingWrites.keys.map { id in (id, cache[id] ?? "") }
+        pendingWrites.values.forEach { $0.cancel() }
+        pendingWrites.removeAll()
+        persistenceQueue.sync {
+            for (id, text) in snapshots {
+                Self.persist(text: text, id: id, rootURL: rootURL, fileManager: fileManager)
+            }
+        }
+    }
+
+    /// Explicit sign-out is destructive for that account's drafts. Light auth
+    /// invalidation intentionally does not call this, so reauthentication retains text.
+    func clearAll(ownerID: String?) {
+        let normalizedOwnerID = Self.normalizedOwnerID(ownerID)
+        let matchingIDs = Set(cache.keys.filter { $0.ownerID == normalizedOwnerID })
+        for id in matchingIDs {
+            pendingWrites[id]?.cancel()
+            pendingWrites[id] = nil
+            cache[id] = nil
+            loaded.remove(id)
+        }
+
+        let ownerURL = rootURL.appendingPathComponent(Self.fileNameComponent(normalizedOwnerID), isDirectory: true)
+        persistenceQueue.sync {
+            try? fileManager.removeItem(at: ownerURL)
+        }
+    }
+
+    private func storageID(for key: ChatDraftKey, ownerID: String?) -> StorageID {
+        StorageID(
+            ownerID: Self.normalizedOwnerID(ownerID ?? ownerIDProvider()),
+            key: key
+        )
+    }
+
+    private func fileURL(for id: StorageID) -> URL {
+        let ownerURL = rootURL.appendingPathComponent(Self.fileNameComponent(id.ownerID), isDirectory: true)
+        let key = "\(id.key.scope)\u{0}\(id.key.contextID)"
+        return ownerURL.appendingPathComponent(Self.fileNameComponent(key)).appendingPathExtension("json")
+    }
+
+    private func scheduleWrite(for id: StorageID, text: String) {
+        pendingWrites[id]?.cancel()
+        let generation = (writeGenerations[id] ?? 0) + 1
+        writeGenerations[id] = generation
+        let rootURL = rootURL
+        let fileManager = fileManager
+        let workItem = DispatchWorkItem { [weak self] in
+            Self.persist(text: text, id: id, rootURL: rootURL, fileManager: fileManager)
+            Task { @MainActor [weak self] in
+                guard let self, self.writeGenerations[id] == generation else { return }
+                self.pendingWrites[id] = nil
+            }
+        }
+        pendingWrites[id] = workItem
+        persistenceQueue.asyncAfter(deadline: .now() + writeDelay, execute: workItem)
+    }
+
+    private static func persist(
+        text: String,
+        id: StorageID,
+        rootURL: URL,
+        fileManager: FileManager
+    ) {
+        let ownerURL = rootURL.appendingPathComponent(fileNameComponent(id.ownerID), isDirectory: true)
+        let key = "\(id.key.scope)\u{0}\(id.key.contextID)"
+        let url = ownerURL.appendingPathComponent(fileNameComponent(key)).appendingPathExtension("json")
+
+        if text.isEmpty {
+            try? fileManager.removeItem(at: url)
+            return
+        }
+
+        do {
+            try fileManager.createDirectory(at: ownerURL, withIntermediateDirectories: true)
+            let record = ChatDraftRecord(
+                version: 1,
+                ownerID: id.ownerID,
+                scope: id.key.scope,
+                contextID: id.key.contextID,
+                text: text,
+                updatedAt: Date()
+            )
+            let data = try JSONEncoder().encode(record)
+            try data.write(to: url, options: .atomic)
+        } catch {
+            // Draft contents are private user text, so never include them in logs.
+            logError("ChatDraftStore: failed to persist \(id.key.scope) draft", error: error)
+        }
+    }
+
+    private static func normalizedOwnerID(_ ownerID: String?) -> String {
+        let trimmed = ownerID?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return trimmed.isEmpty ? "local" : trimmed
+    }
+
+    private static func fileNameComponent(_ value: String) -> String {
+        Data(value.utf8).base64EncodedString()
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "=", with: "")
+    }
+}

--- a/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
+++ b/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
@@ -1166,6 +1166,61 @@ final class DesktopAutomationActionRegistry {
     }
 
     register(
+      name: "set_chat_drafts",
+      summary: "Set main and floating composer drafts without sending (non-prod persistence harness)",
+      params: ["main", "floating"],
+      category: "chat",
+      surfaces: ["main_chat", "ask_omi"],
+      safety: "local",
+      sideEffects: ["local_storage"],
+      examples: ["./scripts/omi-ctl action set_chat_drafts main=main-draft floating=notch-draft"]
+    ) { params in
+      guard AppBuild.isNonProduction else {
+        return ["error": "set_chat_drafts is disabled on production bundles"]
+      }
+      if let main = params["main"] {
+        if let provider = ChatProvider.mainInstance {
+          provider.draftText = main
+        } else {
+          ChatDraftStore.shared.setText(main, for: .mainChat(contextID: "omi:default"))
+        }
+      }
+      if let floating = params["floating"] {
+        if let barState = FloatingControlBarManager.shared.barState {
+          barState.switchAIDraft(to: .floatingMain)
+          barState.aiInputText = floating
+        } else {
+          ChatDraftStore.shared.setText(floating, for: .floatingMain)
+        }
+      }
+      ChatDraftStore.shared.flush()
+      return [
+        "main": ChatProvider.mainInstance?.draftText
+          ?? ChatDraftStore.shared.text(for: .mainChat(contextID: "omi:default")),
+        "floating": FloatingControlBarManager.shared.barState?.aiInputText
+          ?? ChatDraftStore.shared.text(for: .floatingMain),
+      ]
+    }
+
+    register(
+      name: "chat_drafts_snapshot",
+      summary: "Read current main and floating composer drafts (non-prod persistence harness)",
+      category: "chat",
+      surfaces: ["main_chat", "ask_omi"],
+      safety: "read_only"
+    ) { _ in
+      guard AppBuild.isNonProduction else {
+        return ["error": "chat_drafts_snapshot is disabled on production bundles"]
+      }
+      return [
+        "main": ChatProvider.mainInstance?.draftText
+          ?? ChatDraftStore.shared.text(for: .mainChat(contextID: "omi:default")),
+        "floating": FloatingControlBarManager.shared.barState?.aiInputText
+          ?? ChatDraftStore.shared.text(for: .floatingMain),
+      ]
+    }
+
+    register(
       name: "clear_owner_surface_state",
       summary: "Clear kernel main_chat turns for the active owner (non-prod continuity harness hygiene)",
       params: ["chatId"]

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/AIResponseView.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/AIResponseView.swift
@@ -8,7 +8,7 @@ struct AIResponseView: View {
     @Binding var isLoading: Bool
     let currentMessage: ChatMessage?
     @State private var isQuestionExpanded = false
-    @State private var followUpText: String = ""
+    @Binding var followUpText: String
     @State private var attachments: [ChatAttachment] = []
     @State private var isDropTargeted = false
     @FocusState private var isFollowUpFocused: Bool
@@ -584,7 +584,7 @@ struct AIResponseView: View {
         let trimmed = followUpText.trimmingCharacters(in: .whitespacesAndNewlines)
         let staged = attachments
         guard !trimmed.isEmpty || !staged.isEmpty else { return }
-        followUpText = ""
+        followUpText = trimmed
         attachments = []
         if !staged.isEmpty {
             FloatingControlBarManager.shared.sharedFloatingProvider?.addAttachments(staged)

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/AskAIInputView.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/AskAIInputView.swift
@@ -7,7 +7,6 @@ import OmiTheme
 struct AskAIInputView: View {
     @EnvironmentObject var state: FloatingControlBarState
     @Binding var userInput: String
-    @State private var localInput: String = ""
     @State private var textHeight: CGFloat = 40
     @State private var hasMarkedText = false
     @State private var attachments: [ChatAttachment] = []
@@ -21,7 +20,7 @@ struct AskAIInputView: View {
 
     private let minHeight: CGFloat = 40
     private let maxHeight: CGFloat = 200
-    private var trimmedInput: String { localInput.trimmingCharacters(in: .whitespacesAndNewlines) }
+    private var trimmedInput: String { userInput.trimmingCharacters(in: .whitespacesAndNewlines) }
     private var canSend: Bool {
         !hasMarkedText && (!trimmedInput.isEmpty || !attachments.isEmpty)
     }
@@ -60,7 +59,7 @@ struct AskAIInputView: View {
 
             HStack(spacing: 6) {
                 ZStack(alignment: .topLeading) {
-                    if localInput.isEmpty && !hasMarkedText {
+                    if userInput.isEmpty && !hasMarkedText {
                         Text("Ask a question...")
                             .scaledFont(size: 13)
                             .foregroundColor(.secondary)
@@ -69,7 +68,7 @@ struct AskAIInputView: View {
                     }
 
                     OmiTextEditor(
-                        text: $localInput,
+                        text: $userInput,
                         lineFragmentPadding: 8,
                         onSubmit: {
                             guard canSend else { return }
@@ -86,12 +85,6 @@ struct AskAIInputView: View {
                             }
                         }
                     )
-                    .onChange(of: localInput) { _, newValue in
-                        userInput = newValue
-                    }
-                    .onAppear {
-                        localInput = userInput
-                    }
                 }
                 .padding(.horizontal, 4)
                 .frame(height: textHeight)
@@ -123,8 +116,7 @@ struct AskAIInputView: View {
         let text = trimmedInput
         let staged = attachments
         guard !text.isEmpty || !staged.isEmpty else { return }
-        localInput = ""
-        userInput = ""
+        userInput = text
         attachments = []
         if !staged.isEmpty {
             FloatingControlBarManager.shared.sharedFloatingProvider?.addAttachments(staged)

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarState.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarState.swift
@@ -163,7 +163,13 @@ class FloatingControlBarState: NSObject, ObservableObject {
     @Published var showingAIConversation: Bool = false
     @Published var showingAIResponse: Bool = false
     @Published var isAILoading: Bool = true
-    @Published var aiInputText: String = ""
+    @Published var aiInputText: String = "" {
+        didSet {
+            guard !isRestoringAIDraft else { return }
+            aiDraftRevision &+= 1
+            ChatDraftStore.shared.setText(aiInputText, for: activeAIDraftKey)
+        }
+    }
     /// Optimistic pending user text shown before/while the provider turn resolves.
     @Published var displayedQuery: String = ""
     @Published var inputViewHeight: CGFloat = 120
@@ -179,6 +185,42 @@ class FloatingControlBarState: NSObject, ObservableObject {
     @Published var lastConversationActivityAt: Date? = nil
     @Published var activeAgentChatPillID: UUID? = nil
     @Published var conversationSurface: FloatingConversationSurface = .closed
+    private var activeAIDraftKey = ChatDraftKey.floatingMain
+    private var isRestoringAIDraft = false
+    private var aiDraftRevision: UInt64 = 0
+    private var submittedAIDraft: (key: ChatDraftKey, text: String, revision: UInt64)?
+
+    override init() {
+        super.init()
+        isRestoringAIDraft = true
+        aiInputText = ChatDraftStore.shared.text(for: activeAIDraftKey)
+        isRestoringAIDraft = false
+    }
+
+    /// Onboarding demos reuse the real floating window but must not overwrite the
+    /// user's normal notch draft. Switching scopes restores each independently.
+    func switchAIDraft(to key: ChatDraftKey) {
+        guard key != activeAIDraftKey else { return }
+        activeAIDraftKey = key
+        aiDraftRevision &+= 1
+        isRestoringAIDraft = true
+        aiInputText = ChatDraftStore.shared.text(for: key)
+        isRestoringAIDraft = false
+    }
+
+    func markAIDraftSubmitted(_ text: String) {
+        submittedAIDraft = (activeAIDraftKey, text, aiDraftRevision)
+    }
+
+    func clearSubmittedAIDraftIfUnchanged(_ text: String) {
+        guard let submittedAIDraft,
+              submittedAIDraft.key == activeAIDraftKey,
+              submittedAIDraft.text == text,
+              submittedAIDraft.revision == aiDraftRevision,
+              aiInputText == text else { return }
+        self.submittedAIDraft = nil
+        aiInputText = ""
+    }
 
     /// Subagent switcher visibility state, shared by both display modes.
     /// On notched displays the menu opens on hover over the notch; on

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift
@@ -790,7 +790,6 @@ struct FloatingControlBarView: View {
             withAnimation(agentChatSwitchTransition) {
                 state.present(.agent(pill.id))
                 state.isAILoading = false
-                state.aiInputText = ""
             }
             barWindow?.resizeForActiveAgentChatPublic(pillID: pill.id, animated: !wasShowingConversation)
             completion?(true)
@@ -1383,6 +1382,10 @@ struct FloatingControlBarView: View {
                 set: { state.isAILoading = $0 }
             ),
             currentMessage: state.currentAIMessage(from: provider),
+            followUpText: Binding(
+                get: { state.aiInputText },
+                set: { state.aiInputText = $0 }
+            ),
             userInput: state.displayedQuery,
             chatHistory: state.derivedChatHistory(from: provider),
             isVoiceFollowUp: Binding(
@@ -1634,10 +1637,25 @@ private struct AgentMainChatView: View {
     let onEscape: () -> Void
     let onSpawnSibling: (UUID) -> Void
 
-    @State private var followUpText = ""
+    @State private var followUpText: String
     @State private var attachments: [ChatAttachment] = []
     @State private var isDropTargeted = false
     @FocusState private var isFollowUpFocused: Bool
+
+    init(
+        pill: AgentPill,
+        manager: AgentPillsManager,
+        onBackToAgentRows: @escaping () -> Void,
+        onEscape: @escaping () -> Void,
+        onSpawnSibling: @escaping (UUID) -> Void
+    ) {
+        self.pill = pill
+        self.manager = manager
+        self.onBackToAgentRows = onBackToAgentRows
+        self.onEscape = onEscape
+        self.onSpawnSibling = onSpawnSibling
+        _followUpText = State(initialValue: ChatDraftStore.shared.text(for: .floatingAgent(pill.id)))
+    }
 
     private var isRecording: Bool {
         manager.recordingPillID == pill.id
@@ -2094,6 +2112,9 @@ private struct AgentMainChatView: View {
             }
         }
         .onDrop(of: [UTType.fileURL], isTargeted: $isDropTargeted, perform: handleAttachmentDrop)
+        .onChange(of: followUpText) { _, text in
+            ChatDraftStore.shared.setText(text, for: .floatingAgent(pill.id))
+        }
     }
 
     private var canSend: Bool {

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
@@ -491,6 +491,11 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
 
         guard state.showingAIConversation else { return }
 
+        if !state.aiInputText.isEmpty {
+            state.aiInputText = ""
+            return
+        }
+
         if state.hasVisibleConversation {
             clearVisibleConversationFromUI()
         } else {
@@ -1062,7 +1067,6 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
             // treats the dead agent surface as restorable and the next Ask Omi open
             // restores into a blank response panel instead of a fresh input.
             state.conversationSurface = .closed
-            state.aiInputText = ""
             state.isVoiceFollowUp = false
             state.voiceFollowUpTranscript = ""
             state.isAILoading = false
@@ -1165,7 +1169,6 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
             withAnimation(.easeOut(duration: 0.08)) {
                 state.present(.mainResponse)
                 state.isAILoading = false
-                state.aiInputText = ""
             }
             resizeToResponseHeight(animated: true)
             // Mid-stream close cancels the floating binder; re-subscribe so the
@@ -1188,7 +1191,6 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
             withAnimation(.easeOut(duration: Self.askOmiAnimationDuration)) {
                 state.present(.mainInput)
                 state.isAILoading = false
-                state.aiInputText = ""
                 state.setLocalAnswerOverride(nil)
                 // Match the explicit resize height so the observer doesn't immediately override it
                 state.inputViewHeight = inputPanelHeight
@@ -2213,7 +2215,6 @@ class FloatingControlBarManager {
             withAnimation(.easeOut(duration: 0.10)) {
                 window.state.present(.agent(pillID))
                 window.state.isAILoading = false
-                window.state.aiInputText = ""
             }
             window.resizeForActiveAgentChatPublic(pillID: pillID, animated: true)
             completion?(true)
@@ -2554,7 +2555,6 @@ class FloatingControlBarManager {
         }
         window.state.present(.mainInput)
         window.state.isAILoading = false
-        window.state.aiInputText = ""
         window.resizeToResponseHeightPublic(animated: false)
         window.state.present(.mainInput)
         return [
@@ -2578,7 +2578,6 @@ class FloatingControlBarManager {
         withAnimation(.easeOut(duration: 0.10)) {
             window.state.present(.agent(pill.id))
             window.state.isAILoading = false
-            window.state.aiInputText = ""
         }
         window.resizeForActiveAgentChatPublic(pillID: pill.id, animated: false)
         guard wait else {
@@ -3362,7 +3361,6 @@ class FloatingControlBarManager {
         case .visible:
             chatCancellable?.cancel()
             chatCancellable = nil
-            barWindow.state.aiInputText = ""
             barWindow.state.displayedQuery = ""
             barWindow.state.bindQuestionMessageId(nil)
             barWindow.state.setLocalAnswerOverride(message)
@@ -3443,7 +3441,7 @@ class FloatingControlBarManager {
     ) {
         chatCancellable?.cancel()
         chatCancellable = nil
-        barWindow.state.aiInputText = ""
+        barWindow.state.clearSubmittedAIDraftIfUnchanged(userText)
         barWindow.state.displayedQuery = userText
         // Provider timeline is SoT: enrich the existing message in place (e.g. spawn_agent
         // tool block), then bindAnswerMessage only. localAnswerOverride is reserved for
@@ -3869,7 +3867,6 @@ class FloatingControlBarManager {
 
         window.state.present(.mainResponse)
         window.state.isAILoading = false
-        window.state.aiInputText = ""
         if !shouldRestoreVisibleConversation {
             window.state.clearViewport()
         }
@@ -4198,7 +4195,10 @@ class FloatingControlBarManager {
             surfaceRef: provider.mainChatSurfaceReference(),
             imageData: screenshotData,
             turnOwner: chatTurnOwner(for: .visible(fromVoice: queryFromVoice)),
-            clientTurnId: clientTurnId
+            clientTurnId: clientTurnId,
+            onAccepted: { [weak barWindow] in
+                barWindow?.state.clearSubmittedAIDraftIfUnchanged(message)
+            }
         )
 
         if await dispatchPendingQueryIfNeeded(barWindow: barWindow, provider: provider) {
@@ -4446,7 +4446,7 @@ extension FloatingControlBarWindow {
     func beginVisibleMainQuery(_ message: String, fromVoice: Bool, animated: Bool = true) {
         cancelInputHeightObserver()
         state.currentQueryFromVoice = fromVoice
-        state.aiInputText = ""
+        state.markAIDraftSubmitted(message)
         state.displayedQuery = message
         state.clearCurrentAnswerAnchors()
         // clearCurrentAnswerAnchors keeps archived exchanges; sendAIQuery binds the real turn id.

--- a/desktop/macos/Desktop/Sources/MainWindow/Components/ChatInputView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Components/ChatInputView.swift
@@ -192,7 +192,6 @@ struct ChatInputView: View {
         guard canSend else { return }
         guard !isSending else { return }
         let text = inputText
-        inputText = ""
         onSend(text)
     }
 

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/ChatPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/ChatPage.swift
@@ -457,7 +457,7 @@ struct ChatPage: View {
       onSend: { text in
         AnalyticsManager.shared.chatMessageSent(
           messageLength: text.count, hasSelectedAppContext: selectedApp != nil, source: "main_chat")
-        Task { await chatProvider.sendMessage(text) }
+        Task { await chatProvider.sendMainDraft(text) }
       },
       onStop: {
         chatProvider.stopAgent(owner: .mainChat)

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
@@ -546,7 +546,7 @@ struct DashboardPage: View {
                         hasSelectedAppContext: selectedApp != nil,
                         source: "dashboard_chat"
                     )
-                    Task { await chatProvider.sendMessage(text) }
+                    Task { await chatProvider.sendMainDraft(text) }
                 },
                 onStop: {
                     chatProvider.stopAgent(owner: .mainChat)
@@ -1049,11 +1049,11 @@ struct DashboardPage: View {
     }
 
     private func sendFromHomeAskBar() {
-        let text = chatProvider.draftText.trimmingCharacters(in: .whitespacesAndNewlines)
+        let draft = chatProvider.draftText
+        let text = draft.trimmingCharacters(in: .whitespacesAndNewlines)
         // Text is required — ChatProvider.sendMessage no-ops on empty text, so
         // an attachment-only "send" would silently drop the turn.
         guard !text.isEmpty else { return }
-        chatProvider.draftText = ""
         openHomeChat(focusInput: false)
         AnalyticsManager.shared.chatMessageSent(
             messageLength: text.count,
@@ -1063,7 +1063,7 @@ struct DashboardPage: View {
         if chatProvider.isSending {
             return
         } else {
-            Task { await chatProvider.sendMessage(text) }
+            Task { await chatProvider.sendMainDraft(draft) }
         }
     }
 

--- a/desktop/macos/Desktop/Sources/Onboarding/OnboardingChatView.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/OnboardingChatView.swift
@@ -92,6 +92,7 @@ struct OnboardingChatView: View {
   var onSkip: () -> Void
 
   @State private var inputText: String = ""
+  @State private var inputRevision: UInt64 = 0
   @State private var hasStarted: Bool = false
   @State private var onboardingCompleted: Bool = false
   @State private var quickReplyOptions: [String] = []
@@ -425,7 +426,12 @@ struct OnboardingChatView: View {
       .padding(.vertical, 16)
     }
     .onAppear {
+      inputText = ChatDraftStore.shared.text(for: .onboardingMain)
       startChat()
+    }
+    .onChange(of: inputText) { _, text in
+      inputRevision &+= 1
+      ChatDraftStore.shared.setText(text, for: .onboardingMain)
     }
     .onReceive(permissionCheckTimer) { _ in
       appState.checkScreenRecordingPermission()
@@ -572,6 +578,7 @@ struct OnboardingChatView: View {
 
     // Set up floating bar so permission help notifications can be shown
     FloatingControlBarManager.shared.setup(appState: appState, chatProvider: chatProvider)
+    FloatingControlBarManager.shared.barState?.switchAIDraft(to: .onboardingFloating)
     FloatingControlBarManager.shared.showTemporarily()
 
     // Wire up onboarding tools
@@ -756,9 +763,10 @@ struct OnboardingChatView: View {
   private func sendMessage() {
     guard canSend else { return }
 
-    let text = inputText.trimmingCharacters(in: .whitespacesAndNewlines)
+    let draft = inputText
+    let submittedRevision = inputRevision
+    let text = draft.trimmingCharacters(in: .whitespacesAndNewlines)
     guard !text.isEmpty else { return }
-    inputText = ""
 
     // Clear quick replies and unblock any pending ask_followup
     quickReplyOptions = []
@@ -774,7 +782,11 @@ struct OnboardingChatView: View {
         await maybeCreateTask(from: text, source: "typed")
         awaitingDailyTaskInput = false
       }
-      await chatProvider.sendMessage(text)
+      await chatProvider.sendMessage(text, onAccepted: {
+        if inputRevision == submittedRevision, inputText == draft {
+          inputText = ""
+        }
+      })
     }
   }
 

--- a/desktop/macos/Desktop/Sources/Onboarding/OnboardingFloatingBarDemoView.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/OnboardingFloatingBarDemoView.swift
@@ -115,6 +115,7 @@ struct OnboardingFloatingBarDemoView: View {
         .onAppear {
             // Set up the real floating bar (creates the window if needed)
             FloatingControlBarManager.shared.setup(appState: appState, chatProvider: chatProvider)
+            FloatingControlBarManager.shared.barState?.switchAIDraft(to: .onboardingFloating)
             // Use the same global shortcut flow as the normal app so onboarding
             // behaves like production when the user presses Cmd+Enter.
             GlobalShortcutManager.shared.registerShortcuts()

--- a/desktop/macos/Desktop/Sources/Onboarding/OnboardingView.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/OnboardingView.swift
@@ -476,6 +476,9 @@ struct OnboardingView: View {
     // Clean up onboarding state and persisted chat data
     chatProvider.isOnboarding = false
     OnboardingChatPersistence.clear()
+    ChatDraftStore.shared.clear(.onboardingMain)
+    ChatDraftStore.shared.clear(.onboardingFloating)
+    FloatingControlBarManager.shared.barState?.switchAIDraft(to: .floatingMain)
 
     if let onComplete = onComplete {
       onComplete()

--- a/desktop/macos/Desktop/Sources/Onboarding/OnboardingVoiceDemoView.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/OnboardingVoiceDemoView.swift
@@ -106,6 +106,7 @@ struct OnboardingVoiceDemoView: View {
         .background(OmiColors.backgroundPrimary)
         .onAppear {
             FloatingControlBarManager.shared.setup(appState: appState, chatProvider: chatProvider)
+            FloatingControlBarManager.shared.barState?.switchAIDraft(to: .onboardingFloating)
             resetFloatingBarConversation()
             refreshOutputReadiness()
             if let barState = FloatingControlBarManager.shared.barState {

--- a/desktop/macos/Desktop/Sources/Onboarding/OnboardingVoiceShortcutStepView.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/OnboardingVoiceShortcutStepView.swift
@@ -97,6 +97,7 @@ struct OnboardingVoiceShortcutStepView: View {
         .background(OmiColors.backgroundPrimary)
         .onAppear {
             FloatingControlBarManager.shared.setup(appState: appState, chatProvider: chatProvider)
+            FloatingControlBarManager.shared.barState?.switchAIDraft(to: .onboardingFloating)
             resetFloatingBarConversation()
             FloatingControlBarManager.shared.hide()
             PushToTalkManager.shared.cleanup()

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskAgent/TaskChatState.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskAgent/TaskChatState.swift
@@ -10,7 +10,9 @@ class TaskChatState: ObservableObject {
     @Published var messages: [ChatMessage] = []
     @Published var isSending = false
     @Published var isStopping = false
-    @Published var draftText = ""
+    @Published var draftText: String {
+        didSet { ChatDraftStore.shared.setText(draftText, for: .taskChat(taskId)) }
+    }
     @Published var errorMessage: String?
     @Published var chatMode: ChatMode = .act
     /// Monotonic token that increments each time the local user sends a message
@@ -39,6 +41,7 @@ class TaskChatState: ObservableObject {
     init(taskId: String, workspacePath: String) {
         self.taskId = taskId
         self.workspacePath = workspacePath
+        self.draftText = ChatDraftStore.shared.text(for: .taskChat(taskId))
     }
 
     // MARK: - Persistence
@@ -125,6 +128,9 @@ class TaskChatState: ObservableObject {
         )
         messages.append(userMessage)
         persistMessage(userMessage)
+        if draftText == text {
+            draftText = ""
+        }
 
         // Create placeholder AI message
         let aiMessageId = UUID().uuidString

--- a/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
@@ -1269,9 +1269,14 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
             forName: NSApplication.willTerminateNotification,
             object: nil, queue: .main
         ) { [weak self] _ in
+            // The notification is delivered on the main queue, so force the
+            // latest coalesced draft writes to disk before this callback can
+            // return and the process exits (including Sparkle relaunches).
+            MainActor.assumeIsolated {
+                ChatDraftStore.shared.flush()
+            }
             guard let self else { return }
             Task { @MainActor in
-                ChatDraftStore.shared.flush()
                 await self.resolvedAgentClient().stop()
             }
         }

--- a/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
@@ -845,12 +845,20 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
 
     // MARK: - Published State
     @Published var chatMode: ChatMode = .act
-    @Published var draftText = ""
+    @Published var draftText = "" {
+        didSet {
+            guard !isRestoringDraft else { return }
+            draftRevision &+= 1
+            ChatDraftStore.shared.setText(draftText, for: activeDraftKey)
+        }
+    }
     /// Files staged for attachment to the next message. Cleared when the message is sent.
     @Published var pendingAttachments: [ChatAttachment] = []
     @Published var messages: [ChatMessage] = []
     @Published var sessions: [ChatSession] = []
-    @Published var currentSession: ChatSession?
+    @Published var currentSession: ChatSession? {
+        didSet { restoreDraftForCurrentContextIfNeeded() }
+    }
     @Published var isLoading = false
     @Published var isLoadingSessions = true  // Start true since we load sessions on init
     @Published var isSending = false
@@ -901,7 +909,9 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
     /// Set to true during onboarding so the ACP session ID is persisted for restart recovery.
     var isOnboarding = false
     @Published var sessionsLoadError: String?
-    @Published var selectedAppId: String?
+    @Published var selectedAppId: String? {
+        didSet { restoreDraftForCurrentContextIfNeeded() }
+    }
     @Published var hasMoreMessages = false
     @Published var isLoadingMoreMessages = false
     @Published var showStarredOnly = false
@@ -934,6 +944,9 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
     /// This lets a single pill run Hermes/OpenClaw without changing the user's
     /// global chat provider preference stored in `chatBridgeMode`.
     private let bridgeHarnessOverride: AgentHarnessMode?
+    private var activeDraftKey = ChatDraftKey.mainChat(contextID: "omi:default")
+    private var isRestoringDraft = false
+    private var draftRevision: UInt64 = 0
 
     var hasBridgeHarnessOverride: Bool {
         bridgeHarnessOverride != nil
@@ -1120,6 +1133,9 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
 
     init(bridgeHarnessOverride: AgentHarnessMode? = nil) {
         self.bridgeHarnessOverride = bridgeHarnessOverride
+        isRestoringDraft = true
+        draftText = ChatDraftStore.shared.text(for: activeDraftKey)
+        isRestoringDraft = false
         log("ChatProvider initialized, will start Claude bridge on first use")
 
         // When the last in-flight save completes, re-run any poll cycle
@@ -1185,6 +1201,7 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
                         self.agentBridgeStarted = false
                     }
                     self.resetSessionStateForAuthChange()
+                    self.resetDraftAfterSignOut()
                     AgentRuntimeStatusStore.shared.reset()
                 }
             }
@@ -1254,12 +1271,35 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
         ) { [weak self] _ in
             guard let self else { return }
             Task { @MainActor in
+                ChatDraftStore.shared.flush()
                 await self.resolvedAgentClient().stop()
             }
         }
     }
 
     private var terminationObserver: NSObjectProtocol?
+
+    private var currentDraftKey: ChatDraftKey {
+        let appContext = selectedAppId?.isEmpty == false ? selectedAppId! : "omi"
+        let chatContext = currentSession?.id ?? "default"
+        return .mainChat(contextID: "\(appContext):\(chatContext)")
+    }
+
+    private func restoreDraftForCurrentContextIfNeeded() {
+        let nextKey = currentDraftKey
+        guard nextKey != activeDraftKey else { return }
+        activeDraftKey = nextKey
+        isRestoringDraft = true
+        draftText = ChatDraftStore.shared.text(for: nextKey)
+        isRestoringDraft = false
+    }
+
+    private func resetDraftAfterSignOut() {
+        activeDraftKey = .mainChat(contextID: "omi:default")
+        isRestoringDraft = true
+        draftText = ""
+        isRestoringDraft = false
+    }
 
     /// Pre-start the active bridge so the first query doesn't wait for process launch
     func warmupBridge() async {
@@ -3495,7 +3535,8 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
         surfaceRef: AgentSurfaceReference? = nil,
         imageData: Data? = nil,
         turnOwner: ChatTurnOwner = .mainChat,
-        clientTurnId: String = UUID().uuidString
+        clientTurnId: String = UUID().uuidString,
+        onAccepted: (@MainActor () -> Void)? = nil
     ) async -> String? {
         let trimmedText = text.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmedText.isEmpty else { return nil }
@@ -3541,9 +3582,7 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
         guard await ensureBridgeStarted() else {
             tracer?.end("bridge_ensure", metadata: ["error": "bridge_failed"])
             tracer?.finalize(tokenCount: 0, model: model ?? modelOverride)
-            if currentError == .authRequired {
-                draftText = trimmedText
-            } else if currentError == nil, errorMessage?.isEmpty ?? true {
+            if currentError == nil, errorMessage?.isEmpty ?? true {
                 errorMessage = "AI not available"
             }
             releaseSendLock(sendGeneration: sendGen)
@@ -3699,6 +3738,7 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
         // Signal to ChatMessagesView after the local user row exists so
         // it anchors the new turn, not the previous one.
         localSendToken = LocalSendToken(generation: sendGeneration)
+        onAccepted?()
 
         // Track onboarding user messages with full content
         if isOnboarding {
@@ -4369,9 +4409,6 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
                       let card = ChatErrorState.from(bridgeError) {
                 currentError = card
                 lastFailedPrompt = trimmedText
-                if card == .authRequired {
-                    draftText = trimmedText
-                }
                 errorMessage = nil
             } else {
                 errorMessage = error.localizedDescription
@@ -4386,6 +4423,20 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
         }
 
         return completedResponseText
+    }
+
+    /// Sends the active main-chat composer and clears only the exact draft that
+    /// was accepted into the timeline. Preflight failures leave it untouched,
+    /// and typing a new draft while acceptance is pending is never overwritten.
+    @discardableResult
+    func sendMainDraft(_ text: String) async -> String? {
+        let submittedRevision = draftRevision
+        return await sendMessage(text, onAccepted: { [weak self] in
+            guard let self,
+                  self.draftRevision == submittedRevision,
+                  self.draftText == text else { return }
+            self.draftText = ""
+        })
     }
 
     @discardableResult

--- a/desktop/macos/Desktop/Tests/ChatDraftStoreTests.swift
+++ b/desktop/macos/Desktop/Tests/ChatDraftStoreTests.swift
@@ -1,0 +1,155 @@
+import XCTest
+@testable import Omi_Computer
+
+@MainActor
+final class ChatDraftStoreTests: XCTestCase {
+    private var rootURL: URL!
+
+    override func setUp() async throws {
+        rootURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ChatDraftStoreTests-\(UUID().uuidString)", isDirectory: true)
+    }
+
+    override func tearDown() async throws {
+        try? FileManager.default.removeItem(at: rootURL)
+        rootURL = nil
+    }
+
+    func testDraftsRoundTripIndependentlyAcrossRelaunch() {
+        let first = makeStore(ownerID: "user-a")
+        first.setText("main draft\nwith detail", for: .mainChat(contextID: "omi:default"))
+        first.setText("notch draft", for: .floatingMain)
+        first.setText("task draft", for: .taskChat("task-1"))
+        first.flush()
+
+        let relaunched = makeStore(ownerID: "user-a")
+        XCTAssertEqual(relaunched.text(for: .mainChat(contextID: "omi:default")), "main draft\nwith detail")
+        XCTAssertEqual(relaunched.text(for: .floatingMain), "notch draft")
+        XCTAssertEqual(relaunched.text(for: .taskChat("task-1")), "task draft")
+        XCTAssertEqual(relaunched.text(for: .taskChat("task-2")), "")
+    }
+
+    func testLatestEditWinsWhenWritesAreCoalesced() {
+        let store = makeStore(ownerID: "user-a")
+        store.setText("first", for: .floatingMain)
+        store.setText("second", for: .floatingMain)
+        store.setText("latest", for: .floatingMain)
+        store.flush()
+
+        XCTAssertEqual(makeStore(ownerID: "user-a").text(for: .floatingMain), "latest")
+    }
+
+    func testDraftsAreIsolatedByAccount() {
+        let firstUser = makeStore(ownerID: "user-a")
+        firstUser.setText("Alice's draft", for: .floatingMain)
+        firstUser.flush()
+
+        let secondUser = makeStore(ownerID: "user-b")
+        XCTAssertEqual(secondUser.text(for: .floatingMain), "")
+        secondUser.setText("Bob's draft", for: .floatingMain)
+        secondUser.flush()
+
+        XCTAssertEqual(makeStore(ownerID: "user-a").text(for: .floatingMain), "Alice's draft")
+        XCTAssertEqual(makeStore(ownerID: "user-b").text(for: .floatingMain), "Bob's draft")
+    }
+
+    func testExplicitSignOutClearsOnlyThatAccountsDrafts() {
+        let firstUser = makeStore(ownerID: "user-a")
+        firstUser.setText("remove me", for: .floatingMain)
+        firstUser.flush()
+
+        let secondUser = makeStore(ownerID: "user-b")
+        secondUser.setText("keep me", for: .floatingMain)
+        secondUser.flush()
+
+        firstUser.clearAll(ownerID: "user-a")
+
+        XCTAssertEqual(makeStore(ownerID: "user-a").text(for: .floatingMain), "")
+        XCTAssertEqual(makeStore(ownerID: "user-b").text(for: .floatingMain), "keep me")
+    }
+
+    func testClearingDraftDeletesItsPersistedRecord() {
+        let store = makeStore(ownerID: "user-a")
+        store.setText("temporary", for: .floatingMain)
+        store.flush()
+        store.clear(.floatingMain)
+        store.flush()
+
+        XCTAssertEqual(makeStore(ownerID: "user-a").text(for: .floatingMain), "")
+        XCTAssertTrue(allJSONFiles().isEmpty)
+    }
+
+    func testCorruptRecordDoesNotAffectOtherDrafts() throws {
+        let store = makeStore(ownerID: "user-a")
+        store.setText("main unique value", for: .mainChat(contextID: "omi:default"))
+        store.setText("notch survives", for: .floatingMain)
+        store.flush()
+
+        let mainFile = try XCTUnwrap(allJSONFiles().first { url in
+            (try? String(contentsOf: url, encoding: .utf8))?.contains("main unique value") == true
+        })
+        try Data("not-json".utf8).write(to: mainFile, options: .atomic)
+
+        let relaunched = makeStore(ownerID: "user-a")
+        XCTAssertEqual(relaunched.text(for: .mainChat(contextID: "omi:default")), "")
+        XCTAssertEqual(relaunched.text(for: .floatingMain), "notch survives")
+    }
+
+    func testDraftPersistenceHarnessActionsAreDiscoverable() {
+        let registry = DesktopAutomationActionRegistry.shared
+        registry.registerBuiltins()
+        let names = Set(registry.descriptors().map(\.name))
+
+        XCTAssertTrue(names.contains("set_chat_drafts"))
+        XCTAssertTrue(names.contains("chat_drafts_snapshot"))
+    }
+
+    func testAcceptedFloatingDraftClearsWhenUnchanged() {
+        let state = FloatingControlBarState()
+        state.switchAIDraft(to: .onboardingFloating)
+        defer {
+            ChatDraftStore.shared.clear(.onboardingFloating)
+            ChatDraftStore.shared.flush()
+        }
+
+        state.aiInputText = "submitted"
+        state.markAIDraftSubmitted("submitted")
+        state.clearSubmittedAIDraftIfUnchanged("submitted")
+
+        XCTAssertEqual(state.aiInputText, "")
+    }
+
+    func testAcceptedFloatingDraftDoesNotClearNewSameTextRevision() {
+        let state = FloatingControlBarState()
+        state.switchAIDraft(to: .onboardingFloating)
+        defer {
+            ChatDraftStore.shared.clear(.onboardingFloating)
+            ChatDraftStore.shared.flush()
+        }
+
+        state.aiInputText = "submitted"
+        state.markAIDraftSubmitted("submitted")
+        state.aiInputText = "new draft"
+        state.aiInputText = "submitted"
+        state.clearSubmittedAIDraftIfUnchanged("submitted")
+
+        XCTAssertEqual(state.aiInputText, "submitted")
+    }
+
+    private func makeStore(ownerID: String) -> ChatDraftStore {
+        ChatDraftStore(
+            rootURL: rootURL,
+            writeDelay: 60,
+            ownerIDProvider: { ownerID }
+        )
+    }
+
+    private func allJSONFiles() -> [URL] {
+        guard let enumerator = FileManager.default.enumerator(
+            at: rootURL,
+            includingPropertiesForKeys: nil,
+            options: [.skipsHiddenFiles]
+        ) else { return [] }
+        return enumerator.compactMap { $0 as? URL }.filter { $0.pathExtension == "json" }
+    }
+}

--- a/desktop/macos/Desktop/Tests/ChatErrorStateTests.swift
+++ b/desktop/macos/Desktop/Tests/ChatErrorStateTests.swift
@@ -238,10 +238,13 @@ final class ChatErrorStateTests: XCTestCase {
     XCTAssertFalse(snippet.contains("\"AI not available: Please sign in"))
   }
 
-  func testSendPreservesDraftOnAuthRequiredBridgeFailure() throws {
+  func testSendPreservesDraftUntilTurnIsAccepted() throws {
     let source = try sourceFile("Providers/ChatProvider.swift")
-    XCTAssertTrue(source.contains("if currentError == .authRequired"))
-    XCTAssertTrue(source.contains("draftText = trimmedText"))
+    XCTAssertTrue(source.contains("onAccepted: (@MainActor () -> Void)? = nil"))
+    XCTAssertTrue(source.contains("onAccepted?()"))
+    XCTAssertTrue(source.contains("self.draftRevision == submittedRevision"))
+    XCTAssertTrue(source.contains("self.draftText == text else { return }"))
+    XCTAssertFalse(source.contains("draftText = trimmedText"))
   }
 
   func testSignInRecoveryRetriesAfterOAuth() throws {

--- a/desktop/macos/Desktop/Tests/ChatErrorStateTests.swift
+++ b/desktop/macos/Desktop/Tests/ChatErrorStateTests.swift
@@ -247,6 +247,19 @@ final class ChatErrorStateTests: XCTestCase {
     XCTAssertFalse(source.contains("draftText = trimmedText"))
   }
 
+  func testTerminationFlushesDraftsBeforeAsyncAgentShutdown() throws {
+    let source = try sourceFile("Providers/ChatProvider.swift")
+    let observerStart = try XCTUnwrap(source.range(of: "terminationObserver = NotificationCenter.default.addObserver"))
+    let observerTail = String(source[observerStart.lowerBound...])
+    let observerEnd = try XCTUnwrap(observerTail.range(of: "private var terminationObserver"))
+    let observer = String(observerTail[..<observerEnd.lowerBound])
+    let flush = try XCTUnwrap(observer.range(of: "ChatDraftStore.shared.flush()"))
+    let asyncShutdown = try XCTUnwrap(observer.range(of: "Task { @MainActor in"))
+
+    XCTAssertTrue(observer.contains("MainActor.assumeIsolated"))
+    XCTAssertLessThan(flush.lowerBound, asyncShutdown.lowerBound)
+  }
+
   func testSignInRecoveryRetriesAfterOAuth() throws {
     let source = try sourceFile("Providers/ChatProvider.swift")
     let range = source.range(of: "ChatErrorCard: .signIn recovery")

--- a/desktop/macos/changelog/unreleased/20260709-persist-chat-drafts.json
+++ b/desktop/macos/changelog/unreleased/20260709-persist-chat-drafts.json
@@ -1,0 +1,3 @@
+{
+  "change": "Preserved unsent chat drafts separately across the main app, notch, agents, tasks, restarts, and updates"
+}

--- a/desktop/macos/e2e/flows/floating-bar-functional.yaml
+++ b/desktop/macos/e2e/flows/floating-bar-functional.yaml
@@ -4,7 +4,9 @@ tier: 2
 description: Ask Omi open + stubbed typed turn on the floating bar (distinct from perf benchmarks)
 app: non-prod
 covers:
+  - desktop/macos/Desktop/Sources/Chat/ChatDraftStore.swift
   - desktop/macos/Desktop/Sources/FloatingControlBar/AIResponseView.swift
+  - desktop/macos/Desktop/Sources/FloatingControlBar/AskAIInputView.swift
   - desktop/macos/Desktop/Sources/FloatingControlBar/AgentPill.swift
   - desktop/macos/Desktop/Sources/FloatingControlBar/FloatingBarLaunchPolicy.swift
   - desktop/macos/Desktop/Sources/FloatingControlBar/FloatingBarVoicePlaybackService.swift


### PR DESCRIPTION
## Summary

- add a lightweight, account-scoped local draft store with atomic per-draft records and coalesced background writes
- preserve independent drafts for main chat/session contexts, the notch, onboarding, task chats, and floating agents
- clear a composer only after its turn is accepted, retain drafts through close/restart/update and transient failures, and clear the signed-out account's drafts on explicit sign-out
- remove the notch input mirror state and add non-production persistence harness actions plus regression coverage

## Product invariants affected

- `INV-CHAT-1` remains intact: drafts are unsent local UI state, not chat transcript/session/history persistence. A draft enters the shared timeline only after a send is accepted.
- `INV-AUTH-1` remains intact: explicit sign-out deletes only the departing account's local drafts after Firebase sign-out succeeds; session authority and auth-failure transitions are unchanged.

## Verification

- `OMI_SWIFT_TEST_SUITE_WORKERS=4 ./test.sh` — launcher checks, 309 Rust tests, and 182 isolated Swift suites passed
- `./scripts/agent-logic-harness.sh` — all checks passed
- focused `ChatDraftStoreTests` — 9 passed; focused `ChatErrorStateTests` — 27 passed
- `python3 scripts/check-e2e-flow-coverage.py --strict` — 17/17 covered
- pre-push gate — macOS target compiled and all fast checks passed
- named `omi-chat-drafts` bundle — independent main/notch markers survived process relaunch and a same-bundle rebuild/reinstall; markers were cleared after verification

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9366?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
