### PR TITLE
feat(desktop): non-prod quit_and_reopen bridge action (PERM-06)

### DIFF
--- a/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
+++ b/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
@@ -2698,6 +2698,40 @@ final class DesktopAutomationActionRegistry {
       }
       return ["blocking_main_thread_ms": "\(durationMs)"]
     }
+
+    // PERM-06: trigger the permission-flow "Quit & Reopen" restart — the exact
+    // AppState.restartApp() path used after granting Accessibility / Screen
+    // Recording — so a harness can prove the SAME bundle relaunches with the
+    // session intact. Distinct from `reset_onboarding`, which mutates onboarding
+    // state. The restart is scheduled after a short delay so this action's HTTP
+    // response flushes before restartApp() terminates the process. Non-prod only.
+    register(
+      name: "quit_and_reopen",
+      summary: "Trigger the permission-flow Quit & Reopen restart (AppState.restartApp) — relaunches the same bundle; auth/onboarding session persists. Non-prod only.",
+      params: ["delayMs"]
+    ) { params in
+      guard AppBuild.isNonProduction else {
+        return ["error": "quit_and_reopen is disabled on production bundles"]
+      }
+      guard let appState = AppState.current else {
+        return ["error": "app state unavailable"]
+      }
+      if UpdaterViewModel.isUpdateInProgress {
+        return ["error": "sparkle update in progress — restart is deferred to Sparkle"]
+      }
+      let bundleId = Bundle.main.bundleIdentifier ?? ""
+      let relaunchPath = Bundle.main.bundleURL.path
+      let delayMs = min(max(intParam(params["delayMs"], default: 400), 100), 5000)
+      DispatchQueue.main.asyncAfter(deadline: .now() + Double(delayMs) / 1000.0) {
+        appState.restartApp()
+      }
+      return [
+        "restarting": "true",
+        "bundle_id": bundleId,
+        "relaunch_path": relaunchPath,
+        "delay_ms": "\(delayMs)",
+      ]
+    }
   }
 }
 

--- a/desktop/macos/Desktop/Tests/QuitAndReopenActionTests.swift
+++ b/desktop/macos/Desktop/Tests/QuitAndReopenActionTests.swift
@@ -1,0 +1,81 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// PERM-06: the `quit_and_reopen` bridge action must trigger the real
+/// permission-flow "Quit & Reopen" restart (`AppState.restartApp()`) so a harness
+/// can prove the same bundle relaunches with the session intact — NOT the
+/// onboarding-mutating `reset_onboarding` path.
+///
+/// `restartApp()` spawns a relaunch and terminates the process, so it can't be
+/// unit-run (it would kill the test host). These source-invariant guards pin the
+/// action's registration, the non-prod gate, and that it drives the
+/// session-preserving restart with the response-flush delay. The same-bundle /
+/// session-intact runtime proof is the e2e / Codex lane (SKILL §2i).
+final class QuitAndReopenActionTests: XCTestCase {
+  private let actionName = "quit_and_reopen"
+
+  func testActionIsRegisteredAndNonProdGated() throws {
+    let source = try bridgeSource()
+    XCTAssertTrue(
+      source.contains("name: \"\(actionName)\""),
+      "quit_and_reopen must be registered under its stable name")
+    let block = try actionBlock()
+    XCTAssertTrue(
+      block.contains("guard AppBuild.isNonProduction"),
+      "quit_and_reopen must refuse to run on production bundles")
+  }
+
+  func testTriggersTheSessionPreservingRestartNotOnboardingReset() throws {
+    let block = try actionBlock()
+    // The real permission-flow Quit & Reopen path is AppState.restartApp() — it
+    // relaunches the same bundle without touching auth/onboarding.
+    XCTAssertTrue(
+      block.contains("appState.restartApp()"),
+      "quit_and_reopen must drive AppState.restartApp() (the session-preserving restart)")
+    // Must NOT use the onboarding-mutating restart, which is a different criterion.
+    XCTAssertFalse(
+      block.contains("resetOnboardingAndRestart"),
+      "quit_and_reopen must not mutate onboarding state")
+  }
+
+  func testDelaysRestartSoTheResponseFlushesFirst() throws {
+    let block = try actionBlock()
+    // restartApp() terminates the process; schedule it after a delay so the HTTP
+    // response is sent before the app dies — otherwise the caller sees a dropped
+    // connection instead of the restart acknowledgement.
+    guard let scheduleIdx = block.range(of: "asyncAfter"),
+      let restartIdx = block.range(of: "appState.restartApp()")
+    else {
+      return XCTFail("quit_and_reopen must schedule restartApp() via asyncAfter")
+    }
+    XCTAssertTrue(
+      scheduleIdx.lowerBound < restartIdx.lowerBound,
+      "restartApp() must be scheduled (asyncAfter) rather than called inline")
+    XCTAssertTrue(
+      block.contains("\"restarting\": \"true\"") && block.contains("\"bundle_id\""),
+      "quit_and_reopen must acknowledge the restart with the bundle id for before/after assertions")
+  }
+
+  // MARK: - Helpers
+
+  private func actionBlock() throws -> String {
+    let source = try bridgeSource()
+    guard let start = source.range(of: "name: \"\(actionName)\"") else {
+      throw XCTSkip("\(actionName) registration not found")
+    }
+    let tail = source[start.lowerBound...]
+    if let next = tail.dropFirst().range(of: "\n    register(") {
+      return String(tail[..<next.lowerBound])
+    }
+    return String(tail)
+  }
+
+  private func bridgeSource() throws -> String {
+    let url = URL(fileURLWithPath: #filePath)
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+      .appendingPathComponent("Sources/DesktopAutomationBridge.swift")
+    return try String(contentsOf: url, encoding: .utf8)
+  }
+}

--- a/desktop/macos/e2e/SKILL.md
+++ b/desktop/macos/e2e/SKILL.md
@@ -228,6 +228,25 @@ cd desktop/macos
 Typed flow: `scripts/omi-harness run e2e/flows/bridge-state-wedge-fallback.yaml --lane bridge`.
 Hermetic ratchet for the timeout itself: `xcrun swift test --package-path Desktop --filter AwaitWithTimeoutTests`.
 
+### 2i. Prove Quit & Reopen relaunches the same bundle, session intact (PERM-06)
+The permission "Quit & Reopen" flow (shown after granting Accessibility / Screen Recording)
+calls `AppState.restartApp()` — relaunch the same bundle, keep the auth/onboarding session.
+`quit_and_reopen` (non-prod) triggers that exact path (not the onboarding-mutating
+`reset_onboarding`), delayed so the action's HTTP response flushes before the process
+terminates. Because the relaunch is `open <bundle>`, the reopened app derives its own
+automation port — read it from the app log (`DesktopAutomationBridge: listening on …`).
+```bash
+cd desktop/macos
+# record before-state, trigger the restart, then verify the reopened bundle
+./scripts/omi-ctl state | python3 -c 'import json,sys; d=json.load(sys.stdin)["result"]; print("before", d["bundleIdentifier"], d["isSignedIn"], d["hasCompletedOnboarding"])'
+./scripts/omi-ctl action quit_and_reopen        # {restarting:true, bundle_id, relaunch_path}
+sleep 8                                          # terminate + relaunch + boot
+NEWPORT=$(grep -oE 'listening on http://127.0.0.1:[0-9]+' /private/tmp/omi-dev.log | tail -1 | grep -oE '[0-9]+$')
+OMI_AUTOMATION_PORT=$NEWPORT ./scripts/omi-ctl wait-ready | python3 -c 'import json,sys; d=json.load(sys.stdin)["result"]; print("after", d["bundleIdentifier"], d["isSignedIn"], d["hasCompletedOnboarding"])'
+#   assert: same bundleIdentifier, isSignedIn=true, hasCompletedOnboarding=true (session intact)
+```
+Hermetic ratchet: `xcrun swift test --package-path Desktop --filter QuitAndReopenActionTests`.
+
 ### The full loop
 ```bash
 cd desktop/macos

--- a/desktop/macos/e2e/SKILL.md
+++ b/desktop/macos/e2e/SKILL.md
@@ -239,7 +239,7 @@ automation port — read it from the app log (`DesktopAutomationBridge: listenin
 cd desktop/macos
 # record before-state, trigger the restart, then verify the reopened bundle
 ./scripts/omi-ctl state | python3 -c 'import json,sys; d=json.load(sys.stdin)["result"]; print("before", d["bundleIdentifier"], d["isSignedIn"], d["hasCompletedOnboarding"])'
-./scripts/omi-ctl action quit_and_reopen        # {restarting:true, bundle_id, relaunch_path}
+./scripts/omi-ctl action quit_and_reopen        # detail (all string values): {"restarting":"true", "bundle_id":…, "relaunch_path":…, "delay_ms":"400"}
 sleep 8                                          # terminate + relaunch + boot
 NEWPORT=$(grep -oE 'listening on http://127.0.0.1:[0-9]+' /private/tmp/omi-dev.log | tail -1 | grep -oE '[0-9]+$')
 OMI_AUTOMATION_PORT=$NEWPORT ./scripts/omi-ctl wait-ready | python3 -c 'import json,sys; d=json.load(sys.stdin)["result"]; print("after", d["bundleIdentifier"], d["isSignedIn"], d["hasCompletedOnboarding"])'


### PR DESCRIPTION
## What
The permission **Quit & Reopen** flow (shown after granting Accessibility / Screen Recording) calls `AppState.restartApp()` — relaunch the same bundle, keep the auth/onboarding session. There was no automation-bridge action to trigger *that* path directly (only `reset_onboarding`, which mutates onboarding — a different criterion), so the PERM-06 acceptance ("Quit & Reopen relaunches same bundle, session intact") couldn't be exercised headlessly.

Add **`quit_and_reopen`** (non-prod only): it drives the real `AppState.restartApp()` path, scheduled after a short `asyncAfter` delay so the action's HTTP response flushes before `restartApp()` terminates the process, and returns `{restarting, bundle_id, relaunch_path, delay_ms}`. It refuses when a Sparkle update owns the relaunch (`UpdaterViewModel.isUpdateInProgress`) so it can't falsely claim `restarting:true`.

## Tests / verification
- **`QuitAndReopenActionTests` (3)** — source-invariant (restartApp terminates the process, so it can't be unit-run): registered + non-prod gated (fails, not skips, on deletion), drives `restartApp()` **not** the onboarding-mutating `resetOnboardingAndRestart`, and schedules via `asyncAfter` before restarting.
- **Runtime** on a named bundle: before = signed-in `com.omi.omi-perm06` (onboarded); after `quit_and_reopen` the **same** bundle relaunched (new pid) still `isSignedIn=true` + `hasCompletedOnboarding=true`. SKILL §2i documents the recipe.
- Independent code-review: clean, no blocking issues (response flushes ~400ms before terminate; guard chain can't lie; drives the session-preserving path).

no-changelog-needed: non-prod dev/QA automation tooling, not user-visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9374?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

