### PR TITLE
ci(desktop): run release candidate daily

### DIFF
--- a/.github/workflows/desktop_auto_release.yml
+++ b/.github/workflows/desktop_auto_release.yml
@@ -2,8 +2,8 @@ name: Build Desktop Release Candidate
 
 on:
   schedule:
-    # One weekday candidate at most. Developers use scripts/omi-main for head.
-    - cron: '17 10 * * 1-5'
+    # One daily candidate at most. Developers use scripts/omi-main for head.
+    - cron: '17 10 * * *'
   workflow_dispatch:
     inputs:
       release_mode:

--- a/docs/doc/developer/desktop-updates.mdx
+++ b/docs/doc/developer/desktop-updates.mdx
@@ -21,7 +21,7 @@ Prometheus exposes the selected source, fallback reason, pointer/LKG age, feed v
 
 ## Release lifecycle
 
-The weekday/manual candidate workflow batches changes on `main` and tags one candidate. Codemagic builds, signs, notarizes, smoke-tests, and uploads the candidate with `isLive: false` and `channel: candidate`.
+The daily/manual candidate workflow batches changes on `main` and tags one candidate. Codemagic builds, signs, notarizes, smoke-tests, and uploads the candidate with `isLive: false` and `channel: candidate`.
 
 Run:
 


### PR DESCRIPTION
## Summary
- run the desktop release-candidate planner every day at 10:17 UTC, instead of Monday–Friday only
- update the desktop-update architecture documentation to match

## Validation
- Ruby YAML parse asserts the schedule is `17 10 * * *`
- `git diff --check`

Refs #9350

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9376?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

