### PR TITLE
fix(desktop/chat): off-actor SIGCONT so stall recovery can't deadlock (CHAT-02)

### DIFF
--- a/desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift
+++ b/desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift
@@ -1,6 +1,71 @@
 import Foundation
 import OmiSupport
 
+/// Thread-safe, actor-independent holder for the debug suspend/resume (SIGSTOP /
+/// SIGCONT) state used by the non-prod stall harness.
+///
+/// `AgentRuntimeProcess.sendJson()` does a *blocking* stdin write. If the agent is
+/// frozen (SIGSTOP) and a query fills the ~64KB pipe buffer, that write blocks the
+/// actor — so if the resume (SIGCONT) were also actor-isolated it could never run,
+/// deadlocking the agent permanently. Routing the SIGCONT through this lock-guarded
+/// holder keeps it off the actor, so resume/auto-resume always fire even while the
+/// actor is stuck writing to the frozen process. Generation-guarded so a stale
+/// auto-resume can't SIGCONT after an explicit resume or a newer suspend.
+final class DebugSuspendControl: @unchecked Sendable {
+  private let lock = NSLock()
+  private var pid: pid_t?
+  private var generation: UInt64 = 0
+  /// Injectable so the generation-guard logic is unit-testable without sending
+  /// real signals; defaults to SIGCONT in production.
+  private let sendContinue: (pid_t) -> Void
+
+  init(sendContinue: @escaping (pid_t) -> Void = { kill($0, SIGCONT) }) {
+    self.sendContinue = sendContinue
+  }
+
+  /// Record a SIGSTOP; returns the generation for its safety auto-resume timer.
+  func arm(pid: pid_t) -> UInt64 {
+    lock.lock()
+    defer { lock.unlock() }
+    self.pid = pid
+    generation &+= 1
+    return generation
+  }
+
+  /// Explicit resume: SIGCONT the armed pid and advance the generation (cancelling
+  /// the pending auto-resume). Returns the resumed pid, or nil if nothing was armed.
+  func resume() -> pid_t? {
+    lock.lock()
+    defer { lock.unlock() }
+    guard let pid else { return nil }
+    sendContinue(pid)
+    generation &+= 1
+    self.pid = nil
+    return pid
+  }
+
+  /// Safety auto-resume: SIGCONT only if this generation is still the armed one.
+  func autoResume(generation: UInt64) -> pid_t? {
+    lock.lock()
+    defer { lock.unlock() }
+    guard generation == self.generation, let pid else { return nil }
+    sendContinue(pid)
+    self.pid = nil
+    return pid
+  }
+
+  /// Clear on process teardown so a later resume can't SIGCONT a reused pid.
+  /// `closePipes()` calls this on every teardown/relaunch path; the only residual
+  /// window (OS reaping the pid before teardown runs) is benign — SIGCONT to a
+  /// process that isn't stopped is a no-op — and the whole flow is non-prod only.
+  func disarm() {
+    lock.lock()
+    defer { lock.unlock() }
+    pid = nil
+    generation &+= 1
+  }
+}
+
 actor AgentRuntimeProcess {
   static let shared = AgentRuntimeProcess()
 
@@ -176,6 +241,10 @@ actor AgentRuntimeProcess {
   private var stdoutLineBuffer = Data()
   private var isRunning = false
   private var processGeneration: UInt64 = 0
+
+  /// Debug suspend/resume state, held off-actor so SIGCONT never deadlocks behind
+  /// an actor blocked writing to the frozen process. See DebugSuspendControl.
+  private nonisolated let debugSuspend = DebugSuspendControl()
   private var lastExitWasOOM = false
   private var clients: [String: ClientRegistration] = [:]
   private var activeRequests: [RuntimeMessage.RequestKey: ActiveRequest] = [:]
@@ -592,10 +661,6 @@ actor AgentRuntimeProcess {
 
   // MARK: - Automation stall hook (non-production only)
 
-  /// Generation guard so a late auto-resume from an earlier suspend can't
-  /// SIGCONT a process that a newer suspend is deliberately holding.
-  private var debugSuspendGeneration: UInt64 = 0
-
   /// Freeze the agent's stdio stream by sending SIGSTOP to the node bridge
   /// process. With the process paused it emits no further events, so an in-flight
   /// chat send stalls exactly like a hung ACP subprocess — driving the
@@ -614,58 +679,37 @@ actor AgentRuntimeProcess {
     guard kill(pid, SIGSTOP) == 0 else {
       return ["error": "SIGSTOP failed for pid \(pid) (errno \(errno))"]
     }
-    debugSuspendGeneration &+= 1
-    let generation = debugSuspendGeneration
+    // Arm the off-actor control so resume/auto-resume can SIGCONT even if the
+    // actor later blocks writing to this now-frozen process.
+    let generation = debugSuspend.arm(pid: pid)
     // Cap the freeze window so a forgotten resume can't wedge the agent.
     let cappedMs = max(1_000, min(durationMs, 300_000))
     log("AgentRuntimeProcess: DEBUG suspended stream pid=\(pid) for \(cappedMs)ms (gen \(generation))")
-    Task { [weak self] in
+    // The safety auto-resume runs off the actor (via the control), so a wedged
+    // actor — e.g. one blocked writing to this frozen process — can't starve it.
+    Task { [debugSuspend] in
       try? await Task.sleep(nanoseconds: UInt64(cappedMs) * 1_000_000)
-      await self?.autoResumeStream(pid: pid, generation: generation)
+      if let resumed = debugSuspend.autoResume(generation: generation) {
+        log("AgentRuntimeProcess: DEBUG auto-resumed stream pid=\(resumed) (gen \(generation))")
+      }
     }
     return ["suspended": "true", "pid": "\(pid)", "durationMs": "\(cappedMs)"]
   }
 
   /// SIGCONT the agent process immediately (early clear of a debug suspend).
-  func debugResumeStream() -> [String: String] {
+  /// `nonisolated` and routed through the off-actor control so it runs even when
+  /// the actor is blocked writing to the frozen process — otherwise the very
+  /// resume that would unblock that write could never fire, deadlocking the agent.
+  nonisolated func debugResumeStream() -> [String: String] {
     guard AppBuild.isNonProduction else {
       return ["error": "resume_agent_stream is disabled on production bundles"]
     }
-    guard let process, process.isRunning, process.processIdentifier > 0 else {
-      return ["error": "no running agent process to resume"]
+    guard let pid = debugSuspend.resume() else {
+      return ["error": "no suspended agent to resume"]
     }
-    let pid = process.processIdentifier
-    guard kill(pid, SIGCONT) == 0 else {
-      // SIGCONT failed (pid raced to exit, or an unexpected errno). Do NOT bump
-      // the generation here: leaving the pending auto-resume armed is the safe
-      // choice, so a still-frozen process can't stay stuck until app restart.
-      return ["error": "SIGCONT failed for pid \(pid) (errno \(errno))"]
-    }
-    // Only cancel the pending safety auto-resume once the explicit resume
-    // actually succeeded.
-    debugSuspendGeneration &+= 1
     log("AgentRuntimeProcess: DEBUG resumed stream pid=\(pid)")
     return ["resumed": "true", "pid": "\(pid)"]
   }
-
-  private func autoResumeStream(pid: pid_t, generation: UInt64) {
-    // Only the suspend that scheduled this auto-resume may clear it; a newer
-    // suspend or an explicit resume has already moved the generation on.
-    guard generation == debugSuspendGeneration else { return }
-    // Only resume if the SAME process is still alive. A stored Process that has
-    // already exited can still report its original pid (which the OS may have
-    // reused), so require isRunning as well as a pid match — never SIGCONT a
-    // reused pid. restart()/stop() already SIGKILL the old process, so a
-    // torn-down/relaunched agent has nothing to resume here.
-    guard let process, process.isRunning, process.processIdentifier == pid else { return }
-    _ = kill(pid, SIGCONT)
-    log("AgentRuntimeProcess: DEBUG auto-resumed stream pid=\(pid) (gen \(generation))")
-  }
-  // Caveat: autoResumeStream is actor-isolated, so it can only run once the
-  // actor is idle. The intended stall flow writes only the tiny 180s interrupt
-  // to the frozen process (far below the stdin pipe buffer), so the actor never
-  // blocks on a write while suspended; do not push large stdin payloads to a
-  // suspended agent or the auto-resume could be delayed until the actor frees.
 
   func interrupt(clientId: String, requestId: String) {
     let requestKey = RuntimeMessage.RequestKey(clientId: clientId, requestId: requestId)
@@ -1542,6 +1586,9 @@ actor AgentRuntimeProcess {
   }
 
   private func closePipes() {
+    // Process is going away/reset — clear the suspend control so a pending resume
+    // or auto-resume can't SIGCONT a reused pid.
+    debugSuspend.disarm()
     if let stdinPipe {
       try? stdinPipe.fileHandleForWriting.close()
       try? stdinPipe.fileHandleForReading.close()

--- a/desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift
+++ b/desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift
@@ -15,11 +15,11 @@ final class DebugSuspendControl: @unchecked Sendable {
   private let lock = NSLock()
   private var pid: pid_t?
   private var generation: UInt64 = 0
-  /// Injectable so the generation-guard logic is unit-testable without sending
-  /// real signals; defaults to SIGCONT in production.
-  private let sendContinue: (pid_t) -> Void
+  /// Sends SIGCONT and reports success. Injectable so the generation-guard logic
+  /// is unit-testable without real signals; defaults to `kill(pid, SIGCONT) == 0`.
+  private let sendContinue: (pid_t) -> Bool
 
-  init(sendContinue: @escaping (pid_t) -> Void = { kill($0, SIGCONT) }) {
+  init(sendContinue: @escaping (pid_t) -> Bool = { kill($0, SIGCONT) == 0 }) {
     self.sendContinue = sendContinue
   }
 
@@ -32,26 +32,39 @@ final class DebugSuspendControl: @unchecked Sendable {
     return generation
   }
 
-  /// Explicit resume: SIGCONT the armed pid and advance the generation (cancelling
-  /// the pending auto-resume). Returns the resumed pid, or nil if nothing was armed.
+  /// Explicit resume: SIGCONT the armed pid and, on success, advance the
+  /// generation (cancelling the pending auto-resume). Returns the resumed pid, or
+  /// nil if nothing was armed or the SIGCONT failed. On failure the state stays
+  /// armed so the safety auto-resume can still recover the process. The signal is
+  /// sent OUTSIDE the lock — never invoke the injectable closure while holding it.
   func resume() -> pid_t? {
     lock.lock()
+    let armed = pid
+    lock.unlock()
+    guard let armed, sendContinue(armed) else { return nil }
+    lock.lock()
     defer { lock.unlock() }
-    guard let pid else { return nil }
-    sendContinue(pid)
-    generation &+= 1
-    self.pid = nil
-    return pid
+    // A newer suspend/disarm may have moved on; only clear the pid we resumed.
+    if pid == armed {
+      pid = nil
+      generation &+= 1
+    }
+    return armed
   }
 
   /// Safety auto-resume: SIGCONT only if this generation is still the armed one.
+  /// Signal sent outside the lock; state cleared only on a successful send.
   func autoResume(generation: UInt64) -> pid_t? {
     lock.lock()
+    let armed = (generation == self.generation) ? pid : nil
+    lock.unlock()
+    guard let armed, sendContinue(armed) else { return nil }
+    lock.lock()
     defer { lock.unlock() }
-    guard generation == self.generation, let pid else { return nil }
-    sendContinue(pid)
-    self.pid = nil
-    return pid
+    if pid == armed, self.generation == generation {
+      pid = nil
+    }
+    return armed
   }
 
   /// Clear on process teardown so a later resume can't SIGCONT a reused pid.

--- a/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
+++ b/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
@@ -1378,7 +1378,9 @@ final class DesktopAutomationActionRegistry {
       guard AppBuild.isNonProduction else {
         return ["error": "resume_agent_stream is disabled on production bundles"]
       }
-      return await AgentRuntimeProcess.shared.debugResumeStream()
+      // debugResumeStream is nonisolated (off-actor SIGCONT) so it returns promptly
+      // even when the actor is blocked writing to the frozen process.
+      return AgentRuntimeProcess.shared.debugResumeStream()
     }
 
     register(

--- a/desktop/macos/Desktop/Tests/AgentRuntimeProcessTests.swift
+++ b/desktop/macos/Desktop/Tests/AgentRuntimeProcessTests.swift
@@ -14,8 +14,9 @@ final class AgentRuntimeProcessTests: XCTestCase {
     XCTAssertNotNil(result["error"])
   }
 
-  func testResumeStreamNoOpsWithoutProcess() async {
-    let result = await AgentRuntimeProcess.shared.debugResumeStream()
+  func testResumeStreamNoOpsWithoutProcess() {
+    // debugResumeStream is nonisolated now (off-actor SIGCONT) — no await needed.
+    let result = AgentRuntimeProcess.shared.debugResumeStream()
     XCTAssertNotEqual(result["resumed"], "true")
     XCTAssertNotNil(result["error"])
   }
@@ -33,9 +34,9 @@ final class AgentRuntimeProcessTests: XCTestCase {
       "guard AppBuild.isNonProduction else",
       "process.isRunning, process.processIdentifier > 0",
       "kill(pid, SIGSTOP)",
-      "kill(pid, SIGCONT)",
+      "kill($0, SIGCONT)",
       "min(durationMs, 300_000)",
-      "generation == debugSuspendGeneration",
+      "generation == self.generation",
     ] {
       XCTAssertTrue(processSource.contains(needle), "AgentRuntimeProcess missing stall-hook invariant: \(needle)")
     }

--- a/desktop/macos/Desktop/Tests/ChatStallRecoveryTests.swift
+++ b/desktop/macos/Desktop/Tests/ChatStallRecoveryTests.swift
@@ -19,49 +19,65 @@ final class ChatStallRecoveryTests: XCTestCase {
 
   // MARK: - DebugSuspendControl behavior (hermetic; signal injected)
 
-  private func makeControl() -> (DebugSuspendControl, () -> [pid_t]) {
+  private func makeControl() -> (DebugSuspendControl, SignalBox) {
     let box = SignalBox()
     let control = DebugSuspendControl(sendContinue: { box.record($0) })
-    return (control, { box.signalled })
+    return (control, box)
   }
 
   func testResumeSignalsArmedPidThenClears() {
-    let (control, signalled) = makeControl()
+    let (control, box) = makeControl()
     _ = control.arm(pid: 42)
     XCTAssertEqual(control.resume(), 42)
-    XCTAssertEqual(signalled(), [42], "resume must SIGCONT the armed pid")
+    XCTAssertEqual(box.signalled, [42], "resume must SIGCONT the armed pid")
     XCTAssertNil(control.resume(), "a second resume with nothing armed returns nil")
   }
 
   func testAutoResumeRespectsGeneration() {
-    let (control, signalled) = makeControl()
+    let (control, box) = makeControl()
     let gen = control.arm(pid: 7)
     XCTAssertEqual(control.autoResume(generation: gen), 7)
-    XCTAssertEqual(signalled(), [7])
+    XCTAssertEqual(box.signalled, [7])
   }
 
   func testStaleAutoResumeDoesNotSignal() {
-    let (control, signalled) = makeControl()
+    let (control, box) = makeControl()
     let old = control.arm(pid: 7)
     _ = control.arm(pid: 8)  // newer suspend advances the generation
     XCTAssertNil(control.autoResume(generation: old), "a stale auto-resume must no-op")
-    XCTAssertEqual(signalled(), [], "no SIGCONT for a superseded generation")
+    XCTAssertEqual(box.signalled, [], "no SIGCONT for a superseded generation")
   }
 
   func testExplicitResumeCancelsPendingAutoResume() {
-    let (control, signalled) = makeControl()
+    let (control, box) = makeControl()
     let gen = control.arm(pid: 5)
     XCTAssertEqual(control.resume(), 5)          // advances generation
     XCTAssertNil(control.autoResume(generation: gen), "auto-resume after explicit resume must no-op")
-    XCTAssertEqual(signalled(), [5], "only the explicit resume signals")
+    XCTAssertEqual(box.signalled, [5], "only the explicit resume signals")
   }
 
   func testDisarmPreventsResumeSignalingAReusedPid() {
-    let (control, signalled) = makeControl()
+    let (control, box) = makeControl()
     _ = control.arm(pid: 9)
     control.disarm()  // process torn down
     XCTAssertNil(control.resume())
-    XCTAssertEqual(signalled(), [], "a disarmed control must not SIGCONT a (possibly reused) pid")
+    XCTAssertEqual(box.signalled, [], "a disarmed control must not SIGCONT a (possibly reused) pid")
+  }
+
+  func testFailedSigcontLeavesStateArmedForAutoResume() {
+    // If the SIGCONT fails (e.g. pid raced to exit), resume must NOT report success
+    // and must NOT cancel the pending auto-resume — the process could still be
+    // frozen, and the safety auto-resume is its last recovery path.
+    let box = SignalBox()
+    box.succeed = false
+    let control = DebugSuspendControl(sendContinue: { box.record($0) })
+    let gen = control.arm(pid: 3)
+    XCTAssertNil(control.resume(), "a failed SIGCONT must not report a resume")
+    XCTAssertEqual(box.signalled, [3], "resume attempted the SIGCONT")
+    box.succeed = true
+    XCTAssertEqual(
+      control.autoResume(generation: gen), 3,
+      "the same-generation auto-resume must still fire after a failed explicit resume")
   }
 
   // MARK: - Source-invariant: the SIGCONT resume path is off the actor
@@ -104,9 +120,13 @@ final class ChatStallRecoveryTests: XCTestCase {
 private final class SignalBox: @unchecked Sendable {
   private let lock = NSLock()
   private var pids: [pid_t] = []
-  func record(_ pid: pid_t) {
+  /// Controls the SIGCONT success reported to DebugSuspendControl.
+  var succeed = true
+  /// Records the pid and returns whether the (simulated) SIGCONT succeeded.
+  func record(_ pid: pid_t) -> Bool {
     lock.lock(); defer { lock.unlock() }
     pids.append(pid)
+    return succeed
   }
   var signalled: [pid_t] {
     lock.lock(); defer { lock.unlock() }

--- a/desktop/macos/Desktop/Tests/ChatStallRecoveryTests.swift
+++ b/desktop/macos/Desktop/Tests/ChatStallRecoveryTests.swift
@@ -1,0 +1,115 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// CHAT-02 recovery: after a watchdog-fired stall, `resume_agent_stream` must
+/// return promptly and a follow-up ask must complete.
+///
+/// The bug: `AgentRuntimeProcess` is an actor and `sendJson()` does a blocking
+/// stdin write; when the agent is frozen (SIGSTOP) and a query fills the pipe, the
+/// actor blocks on that write — and the resume/auto-resume SIGCONT, being
+/// actor-isolated, could never run, deadlocking the agent permanently. The fix
+/// routes the SIGCONT through an off-actor `DebugSuspendControl` and makes
+/// `debugResumeStream` `nonisolated`.
+///
+/// These tests pin the control's generation/disarm logic hermetically (injected
+/// signal, no real `kill`) and pin the off-actor wiring via source invariants. The
+/// full stall→resume→recover runtime path is the e2e / Codex lane (SKILL §2e).
+final class ChatStallRecoveryTests: XCTestCase {
+
+  // MARK: - DebugSuspendControl behavior (hermetic; signal injected)
+
+  private func makeControl() -> (DebugSuspendControl, () -> [pid_t]) {
+    let box = SignalBox()
+    let control = DebugSuspendControl(sendContinue: { box.record($0) })
+    return (control, { box.signalled })
+  }
+
+  func testResumeSignalsArmedPidThenClears() {
+    let (control, signalled) = makeControl()
+    _ = control.arm(pid: 42)
+    XCTAssertEqual(control.resume(), 42)
+    XCTAssertEqual(signalled(), [42], "resume must SIGCONT the armed pid")
+    XCTAssertNil(control.resume(), "a second resume with nothing armed returns nil")
+  }
+
+  func testAutoResumeRespectsGeneration() {
+    let (control, signalled) = makeControl()
+    let gen = control.arm(pid: 7)
+    XCTAssertEqual(control.autoResume(generation: gen), 7)
+    XCTAssertEqual(signalled(), [7])
+  }
+
+  func testStaleAutoResumeDoesNotSignal() {
+    let (control, signalled) = makeControl()
+    let old = control.arm(pid: 7)
+    _ = control.arm(pid: 8)  // newer suspend advances the generation
+    XCTAssertNil(control.autoResume(generation: old), "a stale auto-resume must no-op")
+    XCTAssertEqual(signalled(), [], "no SIGCONT for a superseded generation")
+  }
+
+  func testExplicitResumeCancelsPendingAutoResume() {
+    let (control, signalled) = makeControl()
+    let gen = control.arm(pid: 5)
+    XCTAssertEqual(control.resume(), 5)          // advances generation
+    XCTAssertNil(control.autoResume(generation: gen), "auto-resume after explicit resume must no-op")
+    XCTAssertEqual(signalled(), [5], "only the explicit resume signals")
+  }
+
+  func testDisarmPreventsResumeSignalingAReusedPid() {
+    let (control, signalled) = makeControl()
+    _ = control.arm(pid: 9)
+    control.disarm()  // process torn down
+    XCTAssertNil(control.resume())
+    XCTAssertEqual(signalled(), [], "a disarmed control must not SIGCONT a (possibly reused) pid")
+  }
+
+  // MARK: - Source-invariant: the SIGCONT resume path is off the actor
+
+  func testResumeIsNonisolatedAndRoutedThroughTheControl() throws {
+    let source = try agentRuntimeSource()
+    XCTAssertTrue(
+      source.contains("nonisolated func debugResumeStream"),
+      "debugResumeStream must be nonisolated so it isn't starved by a blocked actor")
+    XCTAssertTrue(
+      source.contains("debugSuspend.resume()"),
+      "debugResumeStream must resume via the off-actor control")
+  }
+
+  func testAutoResumeRunsOffActorAndTeardownDisarms() throws {
+    let source = try agentRuntimeSource()
+    XCTAssertTrue(
+      source.contains("debugSuspend.autoResume(generation:"),
+      "the safety auto-resume must go through the off-actor control, not an actor-isolated method")
+    // No actor-isolated autoResumeStream should remain to be starved.
+    XCTAssertFalse(
+      source.contains("func autoResumeStream"),
+      "the actor-isolated autoResumeStream must be gone")
+    XCTAssertTrue(
+      source.contains("debugSuspend.disarm()"),
+      "process teardown (closePipes) must disarm the control so resume can't hit a reused pid")
+  }
+
+  // MARK: - Helpers
+
+  private func agentRuntimeSource() throws -> String {
+    let url = URL(fileURLWithPath: #filePath)
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+      .appendingPathComponent("Sources/Chat/AgentRuntimeProcess.swift")
+    return try String(contentsOf: url, encoding: .utf8)
+  }
+}
+
+private final class SignalBox: @unchecked Sendable {
+  private let lock = NSLock()
+  private var pids: [pid_t] = []
+  func record(_ pid: pid_t) {
+    lock.lock(); defer { lock.unlock() }
+    pids.append(pid)
+  }
+  var signalled: [pid_t] {
+    lock.lock(); defer { lock.unlock() }
+    return pids
+  }
+}


### PR DESCRIPTION
## The bug (CHAT-02 recovery half)
After the 180s watchdog surfaces a stall (#9363), the recovery path failed: `resume_agent_stream` timed out (~20s) and the agent stayed frozen, so a follow-up ask latched `is_sending=true` with no reply.

Root cause (runtime-confirmed via `sample`): `AgentRuntimeProcess` is an `actor`, and `sendJson()` does a **blocking** `NSFileHandle.write` to the node's stdin pipe. When the node is frozen (SIGSTOP, via the non-prod `suspend_agent_stream` stall harness) and a query fills the ~64 KB pipe buffer, that write **blocks the actor** (`sample`: 1560/1560 in `NSFileHandle.write → write`). `debugResumeStream()` and `autoResumeStream()` — the SIGCONT that would un-freeze the node — were **also actor-isolated**, so they could never run → permanent self-deadlock (the `durationMs` auto-resume was starved too).

## The fix
Route the SIGCONT off the actor:
- New `DebugSuspendControl` — an `NSLock`-guarded holder of `pid` + `generation` with an injectable `sendContinue` (defaults to `kill($0, SIGCONT)`).
- `debugSuspendStream` (actor) arms it after SIGSTOP; the safety auto-resume runs off-actor via the control.
- `debugResumeStream` is now **`nonisolated`** → `debugSuspend.resume()`, so SIGCONT fires even while the actor is blocked in `sendJson`'s write, which then unblocks the write and frees the actor.
- `closePipes()` disarms on every teardown path so a resume can't SIGCONT a reused pid.

## Invariants
Touches `desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift`, covered by **INV-CHAT-1** (one shared transcript across surfaces) — upheld: this only changes the debug suspend/resume *signal* path (SIGSTOP/SIGCONT process control); it does not touch session identity, transcript storage, or continuity.

## Tests / verification
- **`ChatStallRecoveryTests` (7)** — `DebugSuspendControl` arm/resume/autoResume/disarm + generation-guard with an injected signal recorder (hermetic, no real `kill`), plus source-invariants that resume is `nonisolated`/off-actor, the auto-resume is off-actor, and teardown disarms. Updated the stale `AgentRuntimeProcessTests` stall-hook invariants to the new shape. No regression on `ChatStallWatchdogTests` (user-Stop stays silent, #9363).
- **Runtime**: with the actor blocked on a 96 KB write to a frozen node, `resume_agent_stream` returned `resumed:true` promptly (was TIMEOUT), un-froze the node, drained the write, and the query completed. The full 182s watchdog→resume→recovery-ask flow now completes with an assistant reply.
- Independent code-review: the deadlock is genuinely broken; concurrency + generation logic sound. (It caught a stale pre-existing test invariant, now fixed.)

no-changelog-needed: non-prod stall harness recovery, not user-visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9378?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

