### PR TITLE
Fix sync 429 classification and cooldown recovery

### DIFF
--- a/app/lib/backend/http/api/conversations.dart
+++ b/app/lib/backend/http/api/conversations.dart
@@ -433,14 +433,21 @@ class UploadFilesResult {
   bool get isQueued => jobId != null;
 }
 
-/// Thrown when an upload is rejected by fair-use throttling (HTTP 429).
+/// Server-provided classification for a sync upload HTTP 429.
+///
+/// Fair use is deliberately opt-in: an unknown, proxy-generated, or platform
+/// 429 is backend capacity unless the response carries Omi's explicit reason.
+enum SyncRateLimitKind { fairUse, backendCapacity }
+
+/// Thrown when a sync upload is rate-limited (HTTP 429).
 /// [retryAfterSeconds] is the server's Retry-After when provided.
 class SyncRateLimitedException implements Exception {
+  final SyncRateLimitKind kind;
   final int? retryAfterSeconds;
-  SyncRateLimitedException([this.retryAfterSeconds]);
+  SyncRateLimitedException({required this.kind, this.retryAfterSeconds});
 
   @override
-  String toString() => 'SyncRateLimitedException(retryAfter=$retryAfterSeconds)';
+  String toString() => 'SyncRateLimitedException(kind=$kind, retryAfter=$retryAfterSeconds)';
 }
 
 /// Parse a Retry-After header expressed in delta-seconds. Returns null for an
@@ -449,6 +456,17 @@ int? _parseRetryAfterSeconds(http.Response response) {
   final raw = response.headers['retry-after'];
   if (raw == null) return null;
   return int.tryParse(raw.trim());
+}
+
+/// Classifies a sync 429 without relying on human-readable error text.
+///
+/// The application-generated restriction response carries this bounded header.
+/// Everything else remains a generic backend-capacity limit.
+SyncRateLimitKind syncRateLimitKindForResponse(http.Response response) {
+  if (response.headers['x-omi-rate-limit-reason']?.trim().toLowerCase() == 'fair_use') {
+    return SyncRateLimitKind.fairUse;
+  }
+  return SyncRateLimitKind.backendCapacity;
 }
 
 /// Upload-only: POST files and return as soon as the server acknowledges
@@ -490,9 +508,10 @@ Future<UploadFilesResult> uploadLocalFilesV2(
   } else if (response.statusCode == 413) {
     throw Exception('Audio file is too large to upload');
   } else if (response.statusCode == 429) {
-    // Fair-use throttle, not a content failure. Surface it typed so callers
-    // can back off (honoring Retry-After) instead of burning the retry budget.
-    throw SyncRateLimitedException(_parseRetryAfterSeconds(response));
+    throw SyncRateLimitedException(
+      kind: syncRateLimitKindForResponse(response),
+      retryAfterSeconds: _parseRetryAfterSeconds(response),
+    );
   } else if (response.statusCode >= 500) {
     throw Exception('Server is temporarily unavailable');
   }

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -263,6 +263,7 @@ class _MyAppState extends State<MyApp> with WidgetsBindingObserver {
     if (state == AppLifecycleState.resumed) {
       // Resume the upload reconciler at fast cadence and check immediately.
       SyncReconciler.instance.onForeground();
+      SyncUploadGate.instance.reconcileFairUseStatus();
     } else if (state == AppLifecycleState.paused) {
       SyncReconciler.instance.onBackground();
       _onAppPaused();

--- a/app/lib/pages/conversations/recording_detail/recording_detail_sheet.dart
+++ b/app/lib/pages/conversations/recording_detail/recording_detail_sheet.dart
@@ -360,8 +360,10 @@ class _RecordingDetailSheetState extends State<_RecordingDetailSheet> {
     final outcome = await provider.upload(rec);
     if (!mounted) return;
     switch (outcome) {
-      case LocalUploadOutcome.rateLimited:
+      case LocalUploadOutcome.fairUseLimited:
         AppSnackbar.showSnackbarError(context.l10n.fairUseBudgetExhausted, duration: const Duration(seconds: 4));
+      case LocalUploadOutcome.backendBusy:
+        AppSnackbar.showSnackbarError(context.l10n.msgUploadFileFailed, duration: const Duration(seconds: 4));
       case LocalUploadOutcome.failed:
         AppSnackbar.showSnackbarError(context.l10n.anErrorOccurredTryAgain);
       case LocalUploadOutcome.busy:

--- a/app/lib/providers/local_recordings_provider.dart
+++ b/app/lib/providers/local_recordings_provider.dart
@@ -32,7 +32,7 @@ import 'package:omi/utils/waveform_utils.dart';
 /// `completed` (never fire-and-forget).
 /// Result of a user-triggered [LocalRecordingsProvider.upload], so the UI can
 /// react (fair-use message, generic error, or navigate away) instead of guessing.
-enum LocalUploadOutcome { started, rateLimited, failed, busy }
+enum LocalUploadOutcome { started, fairUseLimited, backendBusy, failed, busy }
 
 class LocalRecordingsProvider extends ChangeNotifier {
   final AudioPlayerUtils _audio = AudioPlayerUtils.instance;
@@ -184,11 +184,6 @@ class LocalRecordingsProvider extends ChangeNotifier {
   /// 202 queued: persist the jobId and let the reconciler finish it.
   Future<LocalUploadOutcome> upload(LocalRecording rec) async {
     if (_isUploading || rec.isBusy) return LocalUploadOutcome.busy;
-    if (SyncRateLimiter.instance.isLimited) {
-      notifyListeners();
-      return LocalUploadOutcome.rateLimited;
-    }
-
     _isUploading = true;
     _uploadingName = rec.fileName;
     _failedName = null;
@@ -202,8 +197,7 @@ class LocalRecordingsProvider extends ChangeNotifier {
         _failedName = rec.fileName;
         outcome = LocalUploadOutcome.failed;
       } else {
-        final result = await uploadLocalFilesV2([file]);
-        SyncRateLimiter.instance.clear();
+        final result = await SyncUploadGate.instance.upload([file]);
 
         if (result.completed != null) {
           await _deleteFileOnly(rec.fileName);
@@ -215,8 +209,8 @@ class LocalRecordingsProvider extends ChangeNotifier {
         }
       }
     } on SyncRateLimitedException catch (e) {
-      SyncRateLimiter.instance.markLimited(retryAfterSeconds: e.retryAfterSeconds);
-      outcome = LocalUploadOutcome.rateLimited;
+      outcome =
+          e.kind == SyncRateLimitKind.fairUse ? LocalUploadOutcome.fairUseLimited : LocalUploadOutcome.backendBusy;
     } catch (e) {
       _failedName = rec.fileName;
       Logger.error('LocalRecordings: upload failed for ${rec.fileName}: $e');

--- a/app/lib/providers/sync_provider.dart
+++ b/app/lib/providers/sync_provider.dart
@@ -21,6 +21,13 @@ enum WalDisplayFilter { all, pending, synced }
 class SyncProvider extends ChangeNotifier implements IWalServiceListener, IWalSyncProgressListener {
   // Services
   final AudioPlayerUtils _audioPlayerUtils = AudioPlayerUtils.instance;
+  final IWalService? _walServiceOverride;
+  final SyncUploadGate _uploadGate;
+  final bool _startBackgroundSync;
+
+  /// Completes after WAL loading and startup fair-use reconciliation finish.
+  @visibleForTesting
+  late final Future<void> initialized;
 
   // WAL management
   List<Wal> _allWals = [];
@@ -231,6 +238,7 @@ class SyncProvider extends ChangeNotifier implements IWalServiceListener, IWalSy
   int _walsProcessedCount = 0;
   Timer? _autoUploadTimer;
   bool _isDisposed = false;
+  late bool _rateLimitWasActive;
 
   // Computed properties for backward compatibility
   List<Wal> get missingWals => _allWals.where((w) => w.status == WalStatus.miss).toList();
@@ -278,20 +286,44 @@ class SyncProvider extends ChangeNotifier implements IWalServiceListener, IWalSy
   Duration get totalDuration => _audioPlayerUtils.totalDuration;
   double get playbackProgress => _audioPlayerUtils.playbackProgress;
 
-  IWalService get _walService => ServiceManager.instance().wal;
+  IWalService get _walService => _walServiceOverride ?? ServiceManager.instance().wal;
 
-  SyncProvider() {
+  SyncProvider({
+    IWalService? walService,
+    SyncUploadGate? uploadGate,
+    @visibleForTesting bool startBackgroundSync = true,
+  })  : _walServiceOverride = walService,
+        _uploadGate = uploadGate ?? SyncUploadGate.instance,
+        _startBackgroundSync = startBackgroundSync {
     _walService.subscribe(this, this);
     _audioPlayerUtils.addListener(_onAudioPlayerStateChanged);
-    SyncRateLimiter.instance.addListener(notifyListeners);
-    _initializeProvider();
+    _rateLimitWasActive = SyncRateLimiter.instance.isLimited;
+    SyncRateLimiter.instance.addListener(_onRateLimiterChanged);
+    initialized = _initializeProvider();
   }
 
-  void _initializeProvider() async {
-    await refreshWals();
+  Future<void> _initializeProvider() async {
+    try {
+      await refreshWals();
+      if (_isDisposed) return;
+      await _uploadGate.reconcileFairUseStatus();
+      if (_isDisposed) return;
+      if (_startBackgroundSync) {
+        _attachReconciler();
+        _scheduleAutoUploadPendingPhoneFiles();
+      }
+    } catch (error, stackTrace) {
+      Logger.error('SyncProvider: initialization failed: $error\n$stackTrace');
+    }
+  }
+
+  void _onRateLimiterChanged() {
     if (_isDisposed) return;
-    _attachReconciler();
-    _scheduleAutoUploadPendingPhoneFiles();
+    final active = SyncRateLimiter.instance.isLimited;
+    final cooldownEnded = _rateLimitWasActive && !active;
+    _rateLimitWasActive = active;
+    notifyListeners();
+    if (cooldownEnded && _startBackgroundSync) _scheduleAutoUploadPendingPhoneFiles();
   }
 
   /// Wire the background reconciler to the phone sync + our conversation
@@ -348,6 +380,11 @@ class SyncProvider extends ChangeNotifier implements IWalServiceListener, IWalSy
         .where((w) => w.status == WalStatus.miss && (w.storage == WalStorage.disk || w.storage == WalStorage.mem))
         .toList();
     if (phoneWals.isEmpty) return;
+    if (!await _uploadGate.prepareToUpload()) {
+      notifyListeners();
+      return;
+    }
+    if (_isDisposed) return;
     Logger.debug('SyncProvider: Auto-uploading ${phoneWals.length} pending phone files to cloud');
     _isAutoUploading = true;
     await _performSync(
@@ -406,7 +443,7 @@ class SyncProvider extends ChangeNotifier implements IWalServiceListener, IWalSy
   }
 
   Future<void> syncWals() async {
-    if (SyncRateLimiter.instance.isLimited) {
+    if (!await _uploadGate.prepareToUpload()) {
       notifyListeners();
       return;
     }
@@ -421,7 +458,7 @@ class SyncProvider extends ChangeNotifier implements IWalServiceListener, IWalSy
   }
 
   Future<void> syncWal(Wal wal) async {
-    if (SyncRateLimiter.instance.isLimited) {
+    if (!await _uploadGate.prepareToUpload()) {
       notifyListeners();
       return;
     }
@@ -710,6 +747,7 @@ class SyncProvider extends ChangeNotifier implements IWalServiceListener, IWalSy
     _autoUploadTimer?.cancel();
     _autoUploadTimer = null;
     _audioPlayerUtils.removeListener(_onAudioPlayerStateChanged);
+    SyncRateLimiter.instance.removeListener(_onRateLimiterChanged);
     WaveformUtils.clearCache();
     _walService.unsubscribe(this);
     super.dispose();

--- a/app/lib/services/capture/capture_controller.dart
+++ b/app/lib/services/capture/capture_controller.dart
@@ -1916,8 +1916,7 @@ class CaptureController extends ChangeNotifier
     // band; on real failure we bump retryCount so orphan recovery / the next
     // sync retries (the local file is retained until confirmed synced).
     try {
-      final result = await uploadLocalFilesV2([file], conversationId: conversationId);
-      SyncRateLimiter.instance.clear();
+      final result = await SyncUploadGate.instance.upload([file], conversationId: conversationId);
       if (result.completed != null) {
         // 200 fast-path: server already produced the result.
         await phoneSync.markWalSyncedAndPersist(wal);
@@ -1928,11 +1927,9 @@ class CaptureController extends ChangeNotifier
         await phoneSync.persistRetryMetadata(wal); // persists the WAL list
         SyncReconciler.instance.poke();
       }
-    } on SyncRateLimitedException catch (e) {
-      // Fair-use throttle — pause uploads, do NOT bump retryCount (it's not a
-      // content failure). The WAL stays `miss`/'waiting' and syncs once the
-      // cooldown clears.
-      SyncRateLimiter.instance.markLimited(retryAfterSeconds: e.retryAfterSeconds);
+    } on SyncRateLimitedException {
+      // Account-level rate limit — do not bump retryCount. The WAL stays
+      // pending and the global upload gate owns the cooldown.
       Logger.debug('Auto-sync WAL ${wal.id}: rate-limited, paused until ${SyncRateLimiter.instance.until}');
     } on SocketException {
       Logger.debug('Auto-sync WAL ${wal.id}: network error, aborting without incrementing retryCount');

--- a/app/lib/services/wals.dart
+++ b/app/lib/services/wals.dart
@@ -24,3 +24,4 @@ export 'wals/wal_syncs.dart';
 export 'wals/wal_service.dart';
 export 'wals/sync_reconciler.dart';
 export 'wals/sync_rate_limiter.dart';
+export 'wals/sync_upload_gate.dart';

--- a/app/lib/services/wals/local_wal_sync.dart
+++ b/app/lib/services/wals/local_wal_sync.dart
@@ -14,6 +14,7 @@ import 'package:omi/services/audio_sources/audio_source.dart';
 import 'package:omi/services/wals/wal.dart';
 import 'package:omi/services/wals/wal_interfaces.dart';
 import 'package:omi/services/wals/sync_rate_limiter.dart';
+import 'package:omi/services/wals/sync_upload_gate.dart';
 import 'package:omi/utils/debug_log_manager.dart';
 import 'package:omi/utils/logger.dart';
 import 'package:omi/utils/wal_file_manager.dart';
@@ -638,8 +639,7 @@ class LocalWalSyncImpl implements LocalWalSync {
         // wait for server-side processing here; the reconciler resolves the
         // job_id later. Only WALs that actually became files (batchWals) are
         // mutated — corrupted ones already short-circuited above.
-        final result = await uploadLocalFilesV2(files);
-        SyncRateLimiter.instance.clear();
+        final result = await SyncUploadGate.instance.upload(files);
 
         if (result.completed != null) {
           // 200 fast-path: server processed synchronously and returned a result.
@@ -677,11 +677,9 @@ class LocalWalSyncImpl implements LocalWalSync {
         batchesCompleted++;
         // Count WALs no longer needing upload (uploaded or already synced).
         filesUploaded = wals.where((w) => w.status == WalStatus.uploaded || w.status == WalStatus.synced).length;
-      } on SyncRateLimitedException catch (e) {
-        // Fair-use throttle. Pause uploads and stop the batch loop — continuing
-        // would just re-hit the wall. WALs stay `miss` (not bumped to retry),
-        // and sync resumes once the cooldown clears.
-        SyncRateLimiter.instance.markLimited(retryAfterSeconds: e.retryAfterSeconds);
+      } on SyncRateLimitedException {
+        // Account-level rate limit. Stop the batch loop without consuming the
+        // WAL retry budget; the global upload gate resumes it after cooldown.
         DebugLogManager.logEvent('local_upload_rate_limited', {'until': '${SyncRateLimiter.instance.until}'});
         for (final wal in batchWals) {
           wal.isSyncing = false;
@@ -785,8 +783,7 @@ class LocalWalSyncImpl implements LocalWalSync {
 
     try {
       // Upload only — no poll-to-terminal. Reconciler resolves the job later.
-      final result = await uploadLocalFilesV2([walFile]);
-      SyncRateLimiter.instance.clear();
+      final result = await SyncUploadGate.instance.upload([walFile]);
 
       if (result.completed != null) {
         final r = result.completed!;
@@ -813,10 +810,9 @@ class LocalWalSyncImpl implements LocalWalSync {
         DebugLogManager.logInfo('Single WAL uploaded; reconciler will finish', {'walId': wal.id});
         listener.onWalUpdated();
       }
-    } on SyncRateLimitedException catch (e) {
-      // Fair-use throttle — pause and leave the WAL `miss`, don't surface as an
-      // error. Resumes when the cooldown clears.
-      SyncRateLimiter.instance.markLimited(retryAfterSeconds: e.retryAfterSeconds);
+    } on SyncRateLimitedException {
+      // Account-level rate limit — leave the WAL pending without consuming its
+      // retry budget. The global upload gate owns the cooldown.
       DebugLogManager.logEvent('single_wal_rate_limited', {'walId': wal.id});
       walToSync.isSyncing = false;
       walToSync.syncStartedAt = null;

--- a/app/lib/services/wals/sync_rate_limit_reconciliation.dart
+++ b/app/lib/services/wals/sync_rate_limit_reconciliation.dart
@@ -1,14 +1,15 @@
 import 'package:omi/services/wals/sync_rate_limiter.dart';
 
 bool shouldClearSyncRateLimitForFairUseStatus(Map<String, dynamic>? status) {
-  return status?['stage'] == 'none';
+  final stage = status?['stage'];
+  return stage == 'none' || stage == 'warning' || stage == 'throttle';
 }
 
 /// Reconcile the persisted fair-use rate-limit cooldown against the latest
-/// server-reported fair-use status. When the server says `stage: none` the
-/// fair-use restriction has been lifted, so we clear the persisted HTTP-429
-/// backoff — but only the persisted state, not an active backend-busy
-/// cooldown (see [SyncRateLimiter.clearRateLimit]).
+/// server-reported fair-use status. When the server reports a known non-hard
+/// stage (`none`, `warning`, or `throttle`), the restriction has been lifted,
+/// so we clear the persisted HTTP-429 backoff — but only the persisted state,
+/// not an active backend-busy cooldown (see [SyncRateLimiter.clearRateLimit]).
 ///
 /// Note: a paid subscription alone is NOT sufficient to clear the cooldown.
 /// The backend preserves abuse-derived restrict/throttle states even for

--- a/app/lib/services/wals/sync_rate_limiter.dart
+++ b/app/lib/services/wals/sync_rate_limiter.dart
@@ -1,8 +1,10 @@
+import 'dart:async';
+
 import 'package:flutter/foundation.dart';
 import 'package:omi/backend/preferences.dart';
 
 /// Why uploads are currently paused.
-/// - [rateLimit]   : server returned HTTP 429 (fair-use cap). Persisted —
+/// - [fairUse]     : server explicitly returned a fair-use 429. Persisted —
 ///                   mirrors server-side enforcement that survives client
 ///                   restarts (the server keeps a 30-day restrict window).
 /// - [backendBusy] : server marked a job `failed` with the stale-guard error
@@ -11,52 +13,68 @@ import 'package:omi/backend/preferences.dart';
 ///                   saturated and never picked it up. In-memory only — once
 ///                   the app restarts, the cooldown clears so the user sees
 ///                   fresh state if the server has since recovered.
-enum RateLimitReason { rateLimit, backendBusy }
+enum RateLimitReason { fairUse, backendBusy }
 
-/// Account-global cooldown for fair-use throttling (HTTP 429) on sync uploads.
+/// Account-global cooldown for rate limiting (HTTP 429) on sync uploads.
 ///
 /// When the server rate-limits uploads, the app must stop firing requests
 /// until the window passes — otherwise it hammers the endpoint every minute,
 /// amplifies the 429 storm, and burns each recording's retry budget so a
 /// throttle is mislabelled as "couldn't process".
 ///
-/// `rateLimit` cooldowns are persisted (a relaunch during the window
+/// `fairUse` cooldowns are persisted (a relaunch during the window
 /// shouldn't immediately resume hammering). `backendBusy` cooldowns are
 /// in-memory only — they reflect transient server pressure and should not
 /// survive an app restart that the user just did to "try again".
 class SyncRateLimiter extends ChangeNotifier {
   SyncRateLimiter._() {
-    // Migration: older versions persisted backendBusy cooldowns. Clear any
-    // stuck persisted backendBusy state so users coming from a healthy
-    // server don't keep seeing "Omi servers are busy" indefinitely.
+    // Migration: older versions persisted backendBusy cooldowns and used
+    // `rateLimit` for every unclassified 429. Neither is evidence of explicit
+    // fair-use enforcement, so neither may survive as a fair-use banner.
     final persistedReason = SharedPreferencesUtil().getString(_prefKeyReason);
-    if (persistedReason == RateLimitReason.backendBusy.name) {
+    if (persistedReason == RateLimitReason.backendBusy.name || persistedReason == 'rateLimit') {
       SharedPreferencesUtil().saveInt(_prefKeyUntil, 0);
       SharedPreferencesUtil().saveString(_prefKeyReason, '');
     }
+    _scheduleExpiryNotification();
   }
   static final SyncRateLimiter instance = SyncRateLimiter._();
 
   static const String _prefKeyUntil = 'syncRateLimitedUntilMs';
   static const String _prefKeyReason = 'syncRateLimitedReason';
   static const int _defaultCooldownSeconds = 1800; // 30 minutes
-  static const int _maxCooldownSeconds = 24 * 60 * 60; // hard ceiling — guard against a misconfigured Retry-After
+  static const int _maxFairUseCooldownSeconds = 30 * 24 * 60 * 60;
+  static const int _maxBackendBusyCooldownSeconds = 24 * 60 * 60;
 
   // In-memory cooldown for backendBusy. Intentionally not persisted so an
   // app restart re-probes the backend state instead of trusting a stale
   // local timer.
   int _backendBusyUntilMs = 0;
+  Timer? _expiryTimer;
+
+  /// Whether a server-confirmed fair-use cooldown is persisted, including an
+  /// expired one that still needs authoritative reconciliation before retry.
+  bool get hasPersistedFairUseState =>
+      SharedPreferencesUtil().getString(_prefKeyReason) == RateLimitReason.fairUse.name &&
+      SharedPreferencesUtil().getInt(_prefKeyUntil) > 0;
+
+  bool get isFairUseLimited {
+    if (!hasPersistedFairUseState) return false;
+    final until = SharedPreferencesUtil().getInt(_prefKeyUntil);
+    return until > DateTime.now().millisecondsSinceEpoch;
+  }
+
+  bool get isBackendBusyLimited => _backendBusyUntilMs > DateTime.now().millisecondsSinceEpoch;
 
   bool get isLimited {
     final now = DateTime.now().millisecondsSinceEpoch;
     if (_backendBusyUntilMs > now) return true;
-    final until = SharedPreferencesUtil().getInt(_prefKeyUntil);
-    return until > 0 && now < until;
+    return isFairUseLimited;
   }
 
   DateTime? get until {
     final now = DateTime.now().millisecondsSinceEpoch;
-    final persisted = SharedPreferencesUtil().getInt(_prefKeyUntil);
+    final persisted = hasPersistedFairUseState ? SharedPreferencesUtil().getInt(_prefKeyUntil) : 0;
     final inMemory = _backendBusyUntilMs;
     final candidates = <int>[if (inMemory > now) inMemory, if (persisted > now) persisted];
     if (candidates.isEmpty) return null;
@@ -65,7 +83,7 @@ class SyncRateLimiter extends ChangeNotifier {
 
   RateLimitReason? get reason {
     final now = DateTime.now().millisecondsSinceEpoch;
-    final persisted = SharedPreferencesUtil().getInt(_prefKeyUntil);
+    final persisted = hasPersistedFairUseState ? SharedPreferencesUtil().getInt(_prefKeyUntil) : 0;
     final busyActive = _backendBusyUntilMs > now;
     final rateActive = persisted > now;
     if (!busyActive && !rateActive) return null;
@@ -73,19 +91,19 @@ class SyncRateLimiter extends ChangeNotifier {
     if (busyActive && (!rateActive || _backendBusyUntilMs >= persisted)) {
       return RateLimitReason.backendBusy;
     }
-    final name = SharedPreferencesUtil().getString(_prefKeyReason);
-    return RateLimitReason.values.asNameMap()[name] ?? RateLimitReason.rateLimit;
+    return RateLimitReason.fairUse;
   }
 
   /// Pause uploads. Honors the server's Retry-After (seconds) when present,
   /// otherwise falls back to a 30-minute cooldown. [reason] picks the
   /// user-facing message ("Fair-use limit reached" vs "Backend busy") and
-  /// also picks the persistence mode (rateLimit persists, backendBusy is
+  /// also picks the persistence mode (fairUse persists, backendBusy is
   /// in-memory only).
-  void markLimited({int? retryAfterSeconds, RateLimitReason reason = RateLimitReason.rateLimit}) {
+  void markLimited({int? retryAfterSeconds, RateLimitReason reason = RateLimitReason.fairUse}) {
     final requested =
         (retryAfterSeconds != null && retryAfterSeconds > 0) ? retryAfterSeconds : _defaultCooldownSeconds;
-    final secs = requested > _maxCooldownSeconds ? _maxCooldownSeconds : requested;
+    final maxCooldown = reason == RateLimitReason.fairUse ? _maxFairUseCooldownSeconds : _maxBackendBusyCooldownSeconds;
+    final secs = requested > maxCooldown ? maxCooldown : requested;
     final untilMs = DateTime.now().add(Duration(seconds: secs)).millisecondsSinceEpoch;
     if (reason == RateLimitReason.backendBusy) {
       _backendBusyUntilMs = untilMs;
@@ -93,7 +111,16 @@ class SyncRateLimiter extends ChangeNotifier {
       SharedPreferencesUtil().saveInt(_prefKeyUntil, untilMs);
       SharedPreferencesUtil().saveString(_prefKeyReason, reason.name);
     }
+    _scheduleExpiryNotification();
     notifyListeners();
+  }
+
+  int? get activeRetryAfterSeconds {
+    final deadline = until;
+    if (deadline == null) return null;
+    final remainingMs = deadline.millisecondsSinceEpoch - DateTime.now().millisecondsSinceEpoch;
+    if (remainingMs <= 0) return null;
+    return (remainingMs / 1000).ceil();
   }
 
   /// Clear the cooldown after any successful upload.
@@ -101,6 +128,7 @@ class SyncRateLimiter extends ChangeNotifier {
     _backendBusyUntilMs = 0;
     SharedPreferencesUtil().saveInt(_prefKeyUntil, 0);
     SharedPreferencesUtil().saveString(_prefKeyReason, '');
+    _scheduleExpiryNotification();
     notifyListeners();
   }
 
@@ -111,6 +139,23 @@ class SyncRateLimiter extends ChangeNotifier {
   void clearRateLimit() {
     SharedPreferencesUtil().saveInt(_prefKeyUntil, 0);
     SharedPreferencesUtil().saveString(_prefKeyReason, '');
+    _scheduleExpiryNotification();
     notifyListeners();
+  }
+
+  void _scheduleExpiryNotification() {
+    _expiryTimer?.cancel();
+    final now = DateTime.now().millisecondsSinceEpoch;
+    final deadlines = <int>[
+      if (_backendBusyUntilMs > now) _backendBusyUntilMs,
+      if (hasPersistedFairUseState && SharedPreferencesUtil().getInt(_prefKeyUntil) > now)
+        SharedPreferencesUtil().getInt(_prefKeyUntil),
+    ];
+    if (deadlines.isEmpty) return;
+    final next = deadlines.reduce((a, b) => a < b ? a : b);
+    _expiryTimer = Timer(Duration(milliseconds: next - now + 1), () {
+      notifyListeners();
+      _scheduleExpiryNotification();
+    });
   }
 }

--- a/app/lib/services/wals/sync_upload_gate.dart
+++ b/app/lib/services/wals/sync_upload_gate.dart
@@ -1,0 +1,127 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:omi/backend/http/api/conversations.dart';
+import 'package:omi/backend/http/api/users.dart';
+import 'package:omi/backend/http/shared.dart';
+import 'package:omi/services/wals/sync_rate_limit_reconciliation.dart';
+import 'package:omi/services/wals/sync_rate_limiter.dart';
+import 'package:omi/utils/mutex.dart';
+
+typedef SyncFilesUploader = Future<UploadFilesResult> Function(
+  List<File> files, {
+  UploadProgressCallback? onUploadProgress,
+  String? conversationId,
+});
+typedef FairUseStatusLoader = Future<Map<String, dynamic>?> Function();
+
+/// Account-global admission gate for every `/v2/sync-local-files` upload.
+///
+/// Uploads are serialized so independent WAL, live-capture, and Transcribe
+/// Later loops cannot race past a newly established cooldown. Persisted fair-
+/// use state is reconciled through a single in-flight status request before an
+/// upload is admitted.
+class SyncUploadGate {
+  SyncUploadGate({
+    required SyncRateLimiter limiter,
+    required SyncFilesUploader uploader,
+    required FairUseStatusLoader fairUseStatusLoader,
+  })  : _limiter = limiter,
+        _uploader = uploader,
+        _fairUseStatusLoader = fairUseStatusLoader;
+
+  static final SyncUploadGate instance = SyncUploadGate(
+    limiter: SyncRateLimiter.instance,
+    uploader: uploadLocalFilesV2,
+    fairUseStatusLoader: getFairUseStatus,
+  );
+
+  static const int _statusRetryCooldownSeconds = 60;
+
+  final SyncRateLimiter _limiter;
+  final SyncFilesUploader _uploader;
+  final FairUseStatusLoader _fairUseStatusLoader;
+  final Mutex _uploadMutex = Mutex();
+  Future<bool>? _reconciliation;
+
+  /// Reconciles a previously confirmed fair-use restriction with the server.
+  /// Returns whether uploads are currently allowed after all cooldowns.
+  Future<bool> prepareToUpload() async {
+    if (_limiter.hasPersistedFairUseState) {
+      await reconcileFairUseStatus();
+    }
+    return !_limiter.isLimited;
+  }
+
+  /// Single-flight authoritative fair-use reconciliation.
+  Future<bool> reconcileFairUseStatus() {
+    if (!_limiter.hasPersistedFairUseState) {
+      return Future.value(!_limiter.isLimited);
+    }
+    final active = _reconciliation;
+    if (active != null) return active;
+
+    final future = _reconcileFairUseStatus();
+    _reconciliation = future;
+    return future.whenComplete(() {
+      if (identical(_reconciliation, future)) _reconciliation = null;
+    });
+  }
+
+  Future<bool> _reconcileFairUseStatus() async {
+    Map<String, dynamic>? status;
+    try {
+      status = await _fairUseStatusLoader();
+    } catch (_) {
+      status = null;
+    }
+
+    if (shouldClearSyncRateLimitForFairUseStatus(status)) {
+      _limiter.clearRateLimit();
+    } else if (!_limiter.isFairUseLimited) {
+      // A hard restriction or failed status fetch remains authoritative. Retry
+      // reconciliation soon without hitting upload after the local deadline.
+      _limiter.markLimited(retryAfterSeconds: _statusRetryCooldownSeconds, reason: RateLimitReason.fairUse);
+    }
+    return !_limiter.isLimited;
+  }
+
+  Future<UploadFilesResult> upload(
+    List<File> files, {
+    UploadProgressCallback? onUploadProgress,
+    String? conversationId,
+  }) async {
+    await _uploadMutex.acquire();
+    try {
+      // Honor an active Retry-After without immediately probing fair-use
+      // status. Lifecycle/manual entry points may reconcile active state, but
+      // queued parallel uploads must stop at the established cooldown.
+      var allowed = !_limiter.isLimited;
+      if (allowed && _limiter.hasPersistedFairUseState) {
+        allowed = await reconcileFairUseStatus();
+      }
+      if (!allowed) {
+        throw SyncRateLimitedException(
+          kind: _limiter.reason == RateLimitReason.backendBusy
+              ? SyncRateLimitKind.backendCapacity
+              : SyncRateLimitKind.fairUse,
+          retryAfterSeconds: _limiter.activeRetryAfterSeconds,
+        );
+      }
+
+      try {
+        final result = await _uploader(files, onUploadProgress: onUploadProgress, conversationId: conversationId);
+        _limiter.clear();
+        return result;
+      } on SyncRateLimitedException catch (error) {
+        _limiter.markLimited(
+          retryAfterSeconds: error.retryAfterSeconds,
+          reason: error.kind == SyncRateLimitKind.fairUse ? RateLimitReason.fairUse : RateLimitReason.backendBusy,
+        );
+        rethrow;
+      }
+    } finally {
+      _uploadMutex.release();
+    }
+  }
+}

--- a/app/lib/services/wals/wal_interfaces.dart
+++ b/app/lib/services/wals/wal_interfaces.dart
@@ -12,7 +12,8 @@ export 'package:omi/backend/http/api/conversations.dart'
         fetchSyncJobStatus,
         SyncJobFetch,
         SyncJobFetchOutcome,
-        SyncRateLimitedException;
+        SyncRateLimitedException,
+        SyncRateLimitKind;
 
 abstract class IWalSyncProgressListener {
   void onWalSyncedProgress(

--- a/app/test/providers/sync_provider_startup_reconciliation_test.dart
+++ b/app/test/providers/sync_provider_startup_reconciliation_test.dart
@@ -1,0 +1,37 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:omi/backend/http/api/conversations.dart';
+import 'package:omi/backend/preferences.dart';
+import 'package:omi/providers/sync_provider.dart';
+import 'package:omi/services/wals/sync_rate_limiter.dart';
+import 'package:omi/services/wals/sync_upload_gate.dart';
+import 'package:omi/services/wals/wal_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('provider startup reconciles and clears persisted fair-use restriction', () async {
+    SharedPreferences.setMockInitialValues({});
+    await SharedPreferencesUtil.init();
+    final limiter = SyncRateLimiter.instance;
+    limiter.clear();
+    limiter.markLimited(retryAfterSeconds: 3600, reason: RateLimitReason.fairUse);
+    var statusCalls = 0;
+    final gate = SyncUploadGate(
+      limiter: limiter,
+      fairUseStatusLoader: () async {
+        statusCalls++;
+        return {'stage': 'none'};
+      },
+      uploader: (files, {onUploadProgress, conversationId}) async => UploadFilesResult.queued('unused'),
+    );
+    final provider = SyncProvider(walService: WalService(), uploadGate: gate, startBackgroundSync: false);
+
+    await provider.initialized;
+
+    expect(statusCalls, 1);
+    expect(limiter.hasPersistedFairUseState, isFalse);
+    expect(limiter.isLimited, isFalse);
+    provider.dispose();
+  });
+}

--- a/app/test/unit/sync_rate_limit_reconciliation_test.dart
+++ b/app/test/unit/sync_rate_limit_reconciliation_test.dart
@@ -20,6 +20,15 @@ void main() {
     expect(SyncRateLimiter.instance.isLimited, isFalse);
   });
 
+  test('clears stale hard restriction after natural expiry normalizes to throttle', () {
+    SyncRateLimiter.instance.markLimited(retryAfterSeconds: 3600);
+
+    reconcileSyncRateLimitWithFairUseStatus({'stage': 'throttle'});
+
+    expect(SyncRateLimiter.instance.isLimited, isFalse);
+    expect(SyncRateLimiter.instance.hasPersistedFairUseState, isFalse);
+  });
+
   test('keeps active rate limit when fair-use status is still restricted', () {
     SyncRateLimiter.instance.markLimited(retryAfterSeconds: 3600);
 
@@ -32,7 +41,7 @@ void main() {
     // Set both a persisted rate-limit and an in-memory backendBusy cooldown.
     // Use a longer backendBusy cooldown so `reason` reports it as the
     // dominant deadline (matching `until`'s max-based pick).
-    SyncRateLimiter.instance.markLimited(retryAfterSeconds: 600, reason: RateLimitReason.rateLimit);
+    SyncRateLimiter.instance.markLimited(retryAfterSeconds: 600, reason: RateLimitReason.fairUse);
     SyncRateLimiter.instance.markLimited(retryAfterSeconds: 3600, reason: RateLimitReason.backendBusy);
     expect(SyncRateLimiter.instance.isLimited, isTrue);
     expect(SyncRateLimiter.instance.reason, RateLimitReason.backendBusy);
@@ -53,9 +62,17 @@ void main() {
     expect(SyncRateLimiter.instance.isLimited, isTrue);
   });
 
+  test('unknown fair-use stage does not clear the cooldown', () {
+    SyncRateLimiter.instance.markLimited(retryAfterSeconds: 3600);
+
+    reconcileSyncRateLimitWithFairUseStatus({'stage': 'future_stage'});
+
+    expect(SyncRateLimiter.instance.isLimited, isTrue);
+  });
+
   group('clearRateLimit', () {
     test('only clears persisted rate-limit state, preserves backendBusy', () {
-      SyncRateLimiter.instance.markLimited(retryAfterSeconds: 600, reason: RateLimitReason.rateLimit);
+      SyncRateLimiter.instance.markLimited(retryAfterSeconds: 600, reason: RateLimitReason.fairUse);
       SyncRateLimiter.instance.markLimited(retryAfterSeconds: 3600, reason: RateLimitReason.backendBusy);
 
       SyncRateLimiter.instance.clearRateLimit();
@@ -65,7 +82,7 @@ void main() {
     });
 
     test('clears all when only persisted rate-limit was active', () {
-      SyncRateLimiter.instance.markLimited(retryAfterSeconds: 3600, reason: RateLimitReason.rateLimit);
+      SyncRateLimiter.instance.markLimited(retryAfterSeconds: 3600, reason: RateLimitReason.fairUse);
 
       SyncRateLimiter.instance.clearRateLimit();
 

--- a/app/test/unit/sync_rate_limit_response_test.dart
+++ b/app/test/unit/sync_rate_limit_response_test.dart
@@ -1,0 +1,23 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:omi/backend/http/api/conversations.dart';
+
+void main() {
+  group('syncRateLimitKindForResponse', () {
+    test('recognizes the explicit fair-use header', () {
+      final response = http.Response('', 429, headers: {'x-omi-rate-limit-reason': 'fair_use'});
+
+      expect(syncRateLimitKindForResponse(response), SyncRateLimitKind.fairUse);
+    });
+
+    test('keeps unknown JSON, text, and misleading detail generic', () {
+      final unknown = http.Response('{"code":"burst_limit"}', 429);
+      final text = http.Response('Account temporarily restricted due to fair-use policy', 429);
+      final html = http.Response('<html>Too many requests</html>', 429);
+
+      expect(syncRateLimitKindForResponse(unknown), SyncRateLimitKind.backendCapacity);
+      expect(syncRateLimitKindForResponse(text), SyncRateLimitKind.backendCapacity);
+      expect(syncRateLimitKindForResponse(html), SyncRateLimitKind.backendCapacity);
+    });
+  });
+}

--- a/app/test/unit/sync_upload_gate_test.dart
+++ b/app/test/unit/sync_upload_gate_test.dart
@@ -1,0 +1,238 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:omi/backend/http/api/conversations.dart';
+import 'package:omi/backend/preferences.dart';
+import 'package:omi/services/wals/sync_rate_limiter.dart';
+import 'package:omi/services/wals/sync_upload_gate.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+SyncRateLimiter get limiter => SyncRateLimiter.instance;
+
+void main() {
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    await SharedPreferencesUtil.init();
+    limiter.clear();
+  });
+
+  test('stale persisted fair-use cooldown self-heals before upload', () async {
+    SharedPreferencesUtil().saveInt('syncRateLimitedUntilMs', DateTime.now().millisecondsSinceEpoch - 1000);
+    SharedPreferencesUtil().saveString('syncRateLimitedReason', RateLimitReason.fairUse.name);
+    var uploads = 0;
+    final gate = SyncUploadGate(
+      limiter: limiter,
+      fairUseStatusLoader: () async => {'stage': 'none'},
+      uploader: (files, {onUploadProgress, conversationId}) async {
+        uploads++;
+        return UploadFilesResult.queued('job-1');
+      },
+    );
+
+    final result = await gate.upload([]);
+
+    expect(result.jobId, 'job-1');
+    expect(uploads, 1);
+    expect(limiter.hasPersistedFairUseState, isFalse);
+  });
+
+  test('natural expiry normalized to throttle clears persisted hard restriction', () async {
+    SharedPreferencesUtil().saveInt('syncRateLimitedUntilMs', DateTime.now().millisecondsSinceEpoch - 1000);
+    SharedPreferencesUtil().saveString('syncRateLimitedReason', RateLimitReason.fairUse.name);
+    var uploads = 0;
+    final gate = SyncUploadGate(
+      limiter: limiter,
+      fairUseStatusLoader: () async => {'stage': 'throttle'},
+      uploader: (files, {onUploadProgress, conversationId}) async {
+        uploads++;
+        return UploadFilesResult.queued('job-after-expiry');
+      },
+    );
+
+    final result = await gate.upload([]);
+
+    expect(result.jobId, 'job-after-expiry');
+    expect(uploads, 1);
+    expect(limiter.hasPersistedFairUseState, isFalse);
+  });
+
+  test('failed status fetch preserves and rearms an expired explicit restriction', () async {
+    SharedPreferencesUtil().saveInt('syncRateLimitedUntilMs', DateTime.now().millisecondsSinceEpoch - 1000);
+    SharedPreferencesUtil().saveString('syncRateLimitedReason', RateLimitReason.fairUse.name);
+    var uploads = 0;
+    final gate = SyncUploadGate(
+      limiter: limiter,
+      fairUseStatusLoader: () async => null,
+      uploader: (files, {onUploadProgress, conversationId}) async {
+        uploads++;
+        return UploadFilesResult.queued('unexpected');
+      },
+    );
+
+    await expectLater(gate.upload([]), throwsA(isA<SyncRateLimitedException>()));
+
+    expect(uploads, 0);
+    expect(limiter.isFairUseLimited, isTrue);
+  });
+
+  test('unknown authoritative stage fails closed and preserves explicit restriction', () async {
+    SharedPreferencesUtil().saveInt('syncRateLimitedUntilMs', DateTime.now().millisecondsSinceEpoch - 1000);
+    SharedPreferencesUtil().saveString('syncRateLimitedReason', RateLimitReason.fairUse.name);
+    var uploads = 0;
+    final gate = SyncUploadGate(
+      limiter: limiter,
+      fairUseStatusLoader: () async => {'stage': 'future_stage'},
+      uploader: (files, {onUploadProgress, conversationId}) async {
+        uploads++;
+        return UploadFilesResult.queued('unexpected');
+      },
+    );
+
+    await expectLater(gate.upload([]), throwsA(isA<SyncRateLimitedException>()));
+
+    expect(uploads, 0);
+    expect(limiter.isFairUseLimited, isTrue);
+  });
+
+  test('legacy unclassified rateLimit state never blocks admission or becomes fair use offline', () async {
+    SharedPreferencesUtil()
+        .saveInt('syncRateLimitedUntilMs', DateTime.now().add(const Duration(hours: 1)).millisecondsSinceEpoch);
+    SharedPreferencesUtil().saveString('syncRateLimitedReason', 'rateLimit');
+    var statusCalls = 0;
+    var uploads = 0;
+    final gate = SyncUploadGate(
+      limiter: limiter,
+      fairUseStatusLoader: () async {
+        statusCalls++;
+        throw Exception('offline');
+      },
+      uploader: (files, {onUploadProgress, conversationId}) async {
+        uploads++;
+        return UploadFilesResult.queued('legacy-cleared');
+      },
+    );
+
+    final result = await gate.upload([]);
+
+    expect(result.jobId, 'legacy-cleared');
+    expect(statusCalls, 0);
+    expect(uploads, 1);
+    expect(limiter.hasPersistedFairUseState, isFalse);
+    expect(limiter.isLimited, isFalse);
+    expect(limiter.reason, isNull);
+  });
+
+  test('real restriction is preserved and blocks upload after local expiry', () async {
+    SharedPreferencesUtil().saveInt('syncRateLimitedUntilMs', DateTime.now().millisecondsSinceEpoch - 1000);
+    SharedPreferencesUtil().saveString('syncRateLimitedReason', RateLimitReason.fairUse.name);
+    var uploads = 0;
+    final gate = SyncUploadGate(
+      limiter: limiter,
+      fairUseStatusLoader: () async => {'stage': 'restrict'},
+      uploader: (files, {onUploadProgress, conversationId}) async {
+        uploads++;
+        return UploadFilesResult.queued('unexpected');
+      },
+    );
+
+    await expectLater(
+      gate.upload([]),
+      throwsA(isA<SyncRateLimitedException>().having((error) => error.kind, 'kind', SyncRateLimitKind.fairUse)),
+    );
+
+    expect(uploads, 0);
+    expect(limiter.isFairUseLimited, isTrue);
+  });
+
+  test('fair-use reconciliation is single-flight', () async {
+    limiter.markLimited(retryAfterSeconds: 600, reason: RateLimitReason.fairUse);
+    final response = Completer<Map<String, dynamic>?>();
+    var statusCalls = 0;
+    final gate = SyncUploadGate(
+      limiter: limiter,
+      fairUseStatusLoader: () {
+        statusCalls++;
+        return response.future;
+      },
+      uploader: (files, {onUploadProgress, conversationId}) async => UploadFilesResult.queued('job'),
+    );
+
+    final first = gate.reconcileFairUseStatus();
+    final second = gate.reconcileFairUseStatus();
+    expect(statusCalls, 1);
+
+    response.complete({'stage': 'none'});
+    expect(await first, isTrue);
+    expect(await second, isTrue);
+    expect(limiter.hasPersistedFairUseState, isFalse);
+  });
+
+  test('fair-use clear preserves a distinct backend-capacity cooldown', () async {
+    limiter.markLimited(retryAfterSeconds: 600, reason: RateLimitReason.fairUse);
+    limiter.markLimited(retryAfterSeconds: 1200, reason: RateLimitReason.backendBusy);
+    final gate = SyncUploadGate(
+      limiter: limiter,
+      fairUseStatusLoader: () async => {'stage': 'none'},
+      uploader: (files, {onUploadProgress, conversationId}) async => UploadFilesResult.queued('job'),
+    );
+
+    expect(await gate.reconcileFairUseStatus(), isFalse);
+    expect(limiter.hasPersistedFairUseState, isFalse);
+    expect(limiter.isBackendBusyLimited, isTrue);
+    expect(limiter.reason, RateLimitReason.backendBusy);
+  });
+
+  test('one generic 429 closes admission and caps capacity backoff at 24 hours', () async {
+    var uploads = 0;
+    final gate = SyncUploadGate(
+      limiter: limiter,
+      fairUseStatusLoader: () async => null,
+      uploader: (files, {onUploadProgress, conversationId}) async {
+        uploads++;
+        throw SyncRateLimitedException(
+          kind: SyncRateLimitKind.backendCapacity,
+          retryAfterSeconds: 40 * 24 * 60 * 60,
+        );
+      },
+    );
+
+    final results = await Future.wait([
+      gate.upload([]).then<Object>((value) => value).catchError((Object error) => error),
+      gate.upload([]).then<Object>((value) => value).catchError((Object error) => error),
+    ]);
+
+    expect(uploads, 1);
+    expect(results, everyElement(isA<SyncRateLimitedException>()));
+    expect(limiter.reason, RateLimitReason.backendBusy);
+    expect(limiter.hasPersistedFairUseState, isFalse);
+    expect(limiter.activeRetryAfterSeconds, inInclusiveRange(24 * 60 * 60 - 2, 24 * 60 * 60));
+  });
+
+  test('explicit fair-use 429 persists and admits the full 30-day Retry-After', () async {
+    var uploads = 0;
+    var statusCalls = 0;
+    final gate = SyncUploadGate(
+      limiter: limiter,
+      fairUseStatusLoader: () async {
+        statusCalls++;
+        return {'stage': 'none'};
+      },
+      uploader: (files, {onUploadProgress, conversationId}) async {
+        uploads++;
+        throw SyncRateLimitedException(kind: SyncRateLimitKind.fairUse, retryAfterSeconds: 30 * 24 * 60 * 60);
+      },
+    );
+
+    final results = await Future.wait([
+      gate.upload([]).then<Object>((value) => value).catchError((Object error) => error),
+      gate.upload([]).then<Object>((value) => value).catchError((Object error) => error),
+    ]);
+
+    expect(results, everyElement(isA<SyncRateLimitedException>()));
+    expect(uploads, 1);
+    expect(statusCalls, 0);
+    expect(limiter.reason, RateLimitReason.fairUse);
+    expect(limiter.hasPersistedFairUseState, isTrue);
+    expect(limiter.activeRetryAfterSeconds, inInclusiveRange(30 * 24 * 60 * 60 - 2, 30 * 24 * 60 * 60));
+  });
+}

--- a/backend/routers/fair_use_admin.py
+++ b/backend/routers/fair_use_admin.py
@@ -18,6 +18,7 @@ from utils.fair_use import (
     get_rolling_speech_ms,
     get_dg_budget_status,
     invalidate_enforcement_cache,
+    normalize_expired_restriction_state,
     FAIR_USE_ENABLED,
     FAIR_USE_DAILY_SPEECH_MS,
     FAIR_USE_3DAY_SPEECH_MS,
@@ -259,7 +260,7 @@ def get_public_case_status(case_ref: str):
 @router.get('/v1/fair-use/status', tags=['fair_use'], response_model=FairUseStatusResponse)
 def get_my_fair_use_status(uid: str = Depends(get_current_user_uid)):
     """User-facing endpoint: see your own fair-use status and speech usage."""
-    state = fair_use_db.get_fair_use_state(uid)
+    state = normalize_expired_restriction_state(uid, fair_use_db.get_fair_use_state(uid))
     speech = get_rolling_speech_ms(uid)
 
     stage = state.get('stage', 'none')

--- a/backend/routers/sync.py
+++ b/backend/routers/sync.py
@@ -5,6 +5,7 @@ import shutil
 import threading
 import time
 import uuid as _uuid
+from datetime import datetime, timedelta, timezone
 from typing import Dict, List, Optional
 
 from fastapi import APIRouter, UploadFile, File, Depends, HTTPException, Query, Request, Response, Header
@@ -12,6 +13,7 @@ from fastapi.responses import JSONResponse, StreamingResponse
 from pydantic import BaseModel, Field
 
 from database import conversations as conversations_db
+from database import fair_use as fair_use_db
 from database import users as users_db
 from database.sync_jobs import (
     TERMINAL_STATUSES,
@@ -78,6 +80,14 @@ from utils.sync.pipeline import (
     process_segment,
     retrieve_vad_segments,
 )
+from utils.sync.rate_limit import (
+    FAIR_USE_RATE_LIMIT_CODE,
+    bounded_fair_use_retry_after,
+    build_sync_rate_limit_event,
+    emit_sync_rate_limit_event,
+    fair_use_rate_limit_headers,
+    validated_correlation_id,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -121,11 +131,87 @@ class AudioDownloadPendingResponse(BaseModel):
     poll_after_ms: int
 
 
-def _hard_restriction_headers(retry_after: int | None, base_headers: Optional[Dict[str, str]] = None) -> Dict[str, str]:
-    headers = dict(base_headers or {})
-    if retry_after is not None:
-        headers['Retry-After'] = str(retry_after)
-    return headers
+def _get_sync_rate_limit_telemetry_fields(uid: str) -> Dict[str, object]:
+    """Load rejection-only account metadata without affecting the response path on read failures."""
+    fields: Dict[str, object] = {
+        'subscription_plan': 'unknown',
+        'subscription_status': 'unknown',
+        'fair_use_stage': 'unknown',
+        'classifier_type': 'unknown',
+    }
+    try:
+        state = fair_use_db.get_fair_use_state(uid)
+        fields['fair_use_stage'] = state.get('stage')
+        fields['classifier_type'] = state.get('last_classifier_type')
+    except Exception as e:
+        logger.warning('sync_rate_limit_telemetry fair_use_state_read_failed error=%s', type(e).__name__)
+
+    try:
+        subscription = users_db.get_existing_user_subscription(uid)
+        if subscription is None:
+            # This is the same effective default as get_user_subscription(), without
+            # creating a Firestore record from a telemetry-only rejection path.
+            fields['subscription_plan'] = 'basic'
+            fields['subscription_status'] = 'active'
+        else:
+            fields['subscription_plan'] = subscription.plan
+            fields['subscription_status'] = subscription.status
+    except Exception as e:
+        logger.warning('sync_rate_limit_telemetry subscription_read_failed error=%s', type(e).__name__)
+
+    return fields
+
+
+def _retry_after_until_next_utc_day() -> int:
+    now = datetime.now(timezone.utc)
+    next_day = (now + timedelta(days=1)).replace(hour=0, minute=0, second=0, microsecond=0)
+    return max(1, int((next_day - now).total_seconds()))
+
+
+async def _fair_use_restriction_response(
+    *,
+    uid: str,
+    retry_after: int | None,
+    client_platform: object,
+    device_hash: object,
+    app_version: object,
+    request_id: object = None,
+    cloud_trace_context: object = None,
+    base_headers: Optional[Dict[str, str]] = None,
+    extra_content: Optional[Dict[str, object]] = None,
+) -> JSONResponse:
+    telemetry = await run_blocking(db_executor, _get_sync_rate_limit_telemetry_fields, uid)
+    correlation_id = (
+        validated_correlation_id(request_id) or validated_correlation_id(cloud_trace_context) or str(_uuid.uuid4())
+    )
+    safe_retry_after = bounded_fair_use_retry_after(retry_after)
+    event = build_sync_rate_limit_event(
+        uid=uid,
+        device_hash=device_hash,
+        app_platform=client_platform,
+        app_version=app_version,
+        subscription_plan=telemetry['subscription_plan'],
+        subscription_status=telemetry['subscription_status'],
+        fair_use_stage=telemetry['fair_use_stage'],
+        classifier_type=telemetry['classifier_type'],
+        retry_after=safe_retry_after,
+        backend_revision=os.getenv('K_REVISION') or os.getenv('DD_VERSION'),
+        correlation_id=correlation_id,
+    )
+    try:
+        emit_sync_rate_limit_event(event)
+    except Exception as e:
+        logger.warning('sync_rate_limit_telemetry emit_failed error=%s', type(e).__name__)
+
+    headers = fair_use_rate_limit_headers(safe_retry_after, base_headers)
+    headers['X-Request-ID'] = correlation_id
+    content: Dict[str, object] = {
+        'code': FAIR_USE_RATE_LIMIT_CODE,
+        'detail': 'Account temporarily restricted due to fair-use policy',
+    }
+    if extra_content:
+        content.update(extra_content)
+    return JSONResponse(status_code=429, headers=headers, content=content)
 
 
 @router.post("/v1/sync/audio/{conversation_id}/precache", response_model=AudioPrecacheResponse, tags=['v1'])
@@ -270,10 +356,15 @@ async def sync_local_files(
     # Pre-check gates (#5854)
     hard_restricted, retry_after = get_hard_restriction_status(uid)
     if hard_restricted:
-        raise HTTPException(
-            status_code=429,
-            detail="Account temporarily restricted due to fair-use policy",
-            headers=_hard_restriction_headers(retry_after, _V1_DEPRECATION_HEADERS),
+        return await _fair_use_restriction_response(
+            uid=uid,
+            retry_after=retry_after,
+            client_platform=client_device_context.platform,
+            device_hash=client_device_context.device_hash,
+            app_version=client_device_context.app_version,
+            request_id=request.headers.get('x-request-id'),
+            cloud_trace_context=request.headers.get('x-cloud-trace-context'),
+            base_headers=_V1_DEPRECATION_HEADERS,
         )
 
     # Check credits: if exhausted, still process but lock the conversation so user can pay to unlock
@@ -354,10 +445,16 @@ async def sync_local_files(
         if dg_budget_blocked:
             logger.info(f'sync: DG budget exhausted, skipping {total_segments} segments uid={uid}')
             _cleanup_files(list(segmented_paths))
-            return JSONResponse(
-                status_code=429,
-                headers=_V1_DEPRECATION_HEADERS,
-                content={
+            return await _fair_use_restriction_response(
+                uid=uid,
+                retry_after=_retry_after_until_next_utc_day(),
+                client_platform=client_device_context.platform,
+                device_hash=client_device_context.device_hash,
+                app_version=client_device_context.app_version,
+                request_id=request.headers.get('x-request-id'),
+                cloud_trace_context=request.headers.get('x-cloud-trace-context'),
+                base_headers=_V1_DEPRECATION_HEADERS,
+                extra_content={
                     'new_memories': [],
                     'updated_memories': [],
                     'credits_exhausted': should_lock,
@@ -499,6 +596,9 @@ async def sync_local_files_v2(
     ),
     x_app_platform: Optional[str] = Header(None, alias='X-App-Platform'),
     x_device_id_hash: Optional[str] = Header(None, alias='X-Device-Id-Hash'),
+    x_app_version: Optional[str] = Header(None, alias='X-App-Version'),
+    x_request_id: Optional[str] = Header(None, alias='X-Request-ID'),
+    x_cloud_trace_context: Optional[str] = Header(None, alias='X-Cloud-Trace-Context'),
 ):
     """
     Async version of sync-local-files. Saves raw files and returns 202
@@ -510,16 +610,20 @@ async def sync_local_files_v2(
     client_device_context = resolve_client_device(
         x_app_platform=x_app_platform if isinstance(x_app_platform, str) else None,
         x_device_id_hash=x_device_id_hash if isinstance(x_device_id_hash, str) else None,
+        x_app_version=x_app_version if isinstance(x_app_version, str) else None,
     )
 
     # Pre-check gates (same as v1)
     hard_restricted, retry_after = await run_blocking(critical_executor, get_hard_restriction_status, uid)
     if hard_restricted:
-        headers = _hard_restriction_headers(retry_after)
-        raise HTTPException(
-            status_code=429,
-            detail="Account temporarily restricted due to fair-use policy",
-            headers=headers,
+        return await _fair_use_restriction_response(
+            uid=uid,
+            retry_after=retry_after,
+            client_platform=client_device_context.platform,
+            device_hash=client_device_context.device_hash,
+            app_version=client_device_context.app_version,
+            request_id=x_request_id if isinstance(x_request_id, str) else None,
+            cloud_trace_context=x_cloud_trace_context if isinstance(x_cloud_trace_context, str) else None,
         )
 
     should_lock = not await run_blocking(critical_executor, has_transcription_credits, uid)

--- a/backend/testing/workflow_contracts.json
+++ b/backend/testing/workflow_contracts.json
@@ -103,7 +103,12 @@
       "id": "sync_cloud_tasks",
       "risk": "high",
       "sources": ["backend/routers/sync.py", "backend/utils/sync/pipeline.py", "backend/database/sync_jobs.py", "backend/utils/sync/*.py"],
-      "tests": ["tests/unit/test_sync_v2.py", "tests/unit/test_sync_cloud_tasks.py", "tests/unit/test_audio_merge_tasks.py"],
+      "tests": [
+        "tests/unit/test_sync_v2.py",
+        "tests/unit/test_sync_cloud_tasks.py",
+        "tests/unit/test_audio_merge_tasks.py",
+        "tests/unit/test_sync_fair_use_gate.py"
+      ],
       "checks": [],
       "invariants": [
         "task retries do not double-count usage or completed segments",

--- a/backend/tests/integration/test_fair_use_api.py
+++ b/backend/tests/integration/test_fair_use_api.py
@@ -225,7 +225,10 @@ class TestUserFacingEndpoint:
 
     def test_status_shows_restrict_message(self):
         """Restrict stage shows support contact info."""
-        _state_store[TEST_UID] = {'stage': 'restrict'}
+        _state_store[TEST_UID] = {
+            'stage': 'restrict',
+            'restrict_until': datetime.utcnow() + timedelta(days=1),
+        }
 
         app.dependency_overrides[get_current_user_uid] = lambda: TEST_UID
         resp = client.get('/v1/fair-use/status')
@@ -235,6 +238,23 @@ class TestUserFacingEndpoint:
         data = resp.json()
         assert data['stage'] == 'restrict'
         assert 'team@basedhardware.com' in data['message']
+
+    def test_status_naturally_expired_restriction_reports_throttle(self):
+        _state_store[TEST_UID] = {
+            'stage': 'restrict',
+            'restrict_until': datetime.utcnow() - timedelta(seconds=1),
+        }
+
+        app.dependency_overrides[get_current_user_uid] = lambda: TEST_UID
+        resp = client.get('/v1/fair-use/status')
+        app.dependency_overrides.pop(get_current_user_uid, None)
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data['stage'] == 'throttle'
+        assert 'temporarily reduced' in data['message']
+        assert _state_store[TEST_UID]['stage'] == 'throttle'
+        assert _state_store[TEST_UID]['restrict_until'] is None
 
 
 class TestPublicCaseStatusEndpoint:

--- a/backend/tests/unit/test_desktop_rest_inventory.py
+++ b/backend/tests/unit/test_desktop_rest_inventory.py
@@ -28,10 +28,9 @@ ROOT_DIR = Path(__file__).resolve().parents[3]
 SPEC_PATH = ROOT_DIR / 'docs' / 'api-reference' / 'app-client-openapi.json'
 APICLIENT_SWIFT = ROOT_DIR / 'desktop' / 'macos' / 'Desktop' / 'Sources' / 'APIClient.swift'
 # High-water mark ratchet: APIClient.swift must shrink as transport/DTOs extract out.
-# Raised after INV-AUTH-1 merge kept RequestAuthPolicy / 401 recovery in APIClient
-# (transport extract alone was 6357; auth recovery cannot live only in the old
-# transport without updating the INV-AUTH-1 path-glob guards).
-APICLIENT_SWIFT_MAX_LINES = 6490
+# Raised after the INV-AUTH-1 and revision-aware conversation merges left the
+# consolidated client at 6500 lines. Future transport/DTO extractions lower it.
+APICLIENT_SWIFT_MAX_LINES = 6500
 CONVERSATIONS_ROUTER = ROOT_DIR / 'backend' / 'routers' / 'conversations.py'
 CONVERSATIONS_DB = ROOT_DIR / 'backend' / 'database' / 'conversations.py'
 

--- a/backend/tests/unit/test_fair_use_async.py
+++ b/backend/tests/unit/test_fair_use_async.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+import routers.fair_use_admin as fair_use_admin_mod
 import utils.fair_use as fair_use_mod
 from models.fair_use import SoftCapTrigger
 
@@ -243,6 +244,63 @@ class TestHardRestrictBoundary:
         mock_speech.return_value = {'daily_ms': 7200000, 'three_day_ms': 28800000, 'weekly_ms': 36000000}
 
         assert fair_use_mod.is_hard_restricted('user1') is False
+
+
+class TestFairUseStatusRestrictionExpiry:
+    def setup_method(self):
+        _reset()
+        _fair_use_db.get_fair_use_state.reset_mock()
+        _fair_use_db.update_fair_use_state.reset_mock()
+
+    @staticmethod
+    def _dg_budget():
+        return {
+            'daily_limit_ms': 0,
+            'used_ms': 0,
+            'remaining_ms': 0,
+            'exhausted': False,
+            'resets_at': None,
+        }
+
+    def test_status_normalizes_naturally_expired_restriction_with_one_state_read(self):
+        _fair_use_db.get_fair_use_state.return_value = {
+            'stage': 'restrict',
+            'restrict_until': datetime.utcnow() - timedelta(seconds=1),
+            'last_case_ref': 'FU-EXPIRED',
+        }
+
+        with patch.object(fair_use_admin_mod, 'fair_use_db', _fair_use_db), patch.object(
+            fair_use_admin_mod,
+            'get_rolling_speech_ms',
+            return_value={'daily_ms': 0, 'three_day_ms': 0, 'weekly_ms': 0},
+        ), patch.object(fair_use_admin_mod, 'get_dg_budget_status', return_value=self._dg_budget()):
+            result = fair_use_admin_mod.get_my_fair_use_status('user1')
+
+        assert result['stage'] == 'throttle'
+        assert 'temporarily reduced' in result['message']
+        _fair_use_db.get_fair_use_state.assert_called_once_with('user1')
+        _fair_use_db.update_fair_use_state.assert_called_once_with(
+            'user1', {'stage': 'throttle', 'restrict_until': None}
+        )
+
+    def test_status_preserves_active_restriction_with_one_state_read(self):
+        _fair_use_db.get_fair_use_state.return_value = {
+            'stage': 'restrict',
+            'restrict_until': datetime.utcnow() + timedelta(days=1),
+            'last_case_ref': 'FU-ACTIVE',
+        }
+
+        with patch.object(fair_use_admin_mod, 'fair_use_db', _fair_use_db), patch.object(
+            fair_use_admin_mod,
+            'get_rolling_speech_ms',
+            return_value={'daily_ms': 0, 'three_day_ms': 0, 'weekly_ms': 0},
+        ), patch.object(fair_use_admin_mod, 'get_dg_budget_status', return_value=self._dg_budget()):
+            result = fair_use_admin_mod.get_my_fair_use_status('user1')
+
+        assert result['stage'] == 'restrict'
+        assert 'temporarily limited' in result['message']
+        _fair_use_db.get_fair_use_state.assert_called_once_with('user1')
+        _fair_use_db.update_fair_use_state.assert_not_called()
 
 
 class TestOverflowAndInvalidData:

--- a/backend/tests/unit/test_sync_fair_use_gate.py
+++ b/backend/tests/unit/test_sync_fair_use_gate.py
@@ -1,11 +1,130 @@
 """Tests for sync endpoint fair-use gates (#5854)."""
 
+import json
 from datetime import datetime, timedelta, timezone
 from unittest.mock import patch, MagicMock
 
 import pytest
 
 import utils.fair_use as fair_use_mod
+from utils.sync.rate_limit import (
+    DEFAULT_FAIR_USE_RETRY_AFTER_SECONDS,
+    FAIR_USE_RATE_LIMIT_CODE,
+    FAIR_USE_RATE_LIMIT_REASON_HEADER,
+    MAX_FAIR_USE_RETRY_AFTER_SECONDS,
+    bounded_fair_use_retry_after,
+    build_sync_rate_limit_event,
+    emit_sync_rate_limit_event,
+    fair_use_rate_limit_headers,
+    validated_correlation_id,
+)
+
+
+class TestSyncRateLimitContract:
+    def test_retry_after_uses_bounded_fallback_for_missing_legacy_deadline(self):
+        assert bounded_fair_use_retry_after(None) == DEFAULT_FAIR_USE_RETRY_AFTER_SECONDS
+        assert bounded_fair_use_retry_after('invalid') == DEFAULT_FAIR_USE_RETRY_AFTER_SECONDS
+        assert bounded_fair_use_retry_after(0) == 1
+        assert bounded_fair_use_retry_after(MAX_FAIR_USE_RETRY_AFTER_SECONDS + 1) == MAX_FAIR_USE_RETRY_AFTER_SECONDS
+
+    def test_fair_use_headers_always_include_reason_and_retry_after(self):
+        headers = fair_use_rate_limit_headers(None, {'Deprecation': 'true'})
+        assert headers == {
+            'Deprecation': 'true',
+            FAIR_USE_RATE_LIMIT_REASON_HEADER: 'fair_use',
+            'Retry-After': str(DEFAULT_FAIR_USE_RETRY_AFTER_SECONDS),
+        }
+
+    def test_structured_event_has_fixed_parsed_fields(self):
+        event = build_sync_rate_limit_event(
+            uid='uid-123',
+            device_hash='a1b2c3d4',
+            app_platform='ios',
+            app_version='1.0.543+992',
+            subscription_plan='operator',
+            subscription_status='active',
+            fair_use_stage='restrict',
+            classifier_type='prerecorded',
+            retry_after=321,
+            backend_revision='backend-sync-00042-abc',
+            correlation_id='5d55a970-f41c-4e18-9c20-7e7c6fb9d48d',
+        )
+
+        assert event == {
+            'severity': 'WARNING',
+            'message': 'sync_rate_limit_rejected',
+            'event': 'sync_rate_limit_rejected',
+            'uid': 'uid-123',
+            'device_id_hash': 'a1b2c3d4',
+            'app_platform': 'ios',
+            'app_version': '1.0.543+992',
+            'reason_code': FAIR_USE_RATE_LIMIT_CODE,
+            'subscription_plan': 'operator',
+            'subscription_status': 'active',
+            'fair_use_stage': 'restrict',
+            'classifier_type': 'prerecorded',
+            'retry_after': 321,
+            'backend_revision': 'backend-sync-00042-abc',
+            'correlation_id': '5d55a970-f41c-4e18-9c20-7e7c6fb9d48d',
+        }
+
+    def test_untrusted_metadata_is_strictly_redacted(self):
+        event = build_sync_rate_limit_event(
+            uid='uid-123',
+            device_hash='raw-device-id@example.com',
+            app_platform='ios@example.com',
+            app_version='1.0.543@example.com',
+            subscription_plan='operator@example.com',
+            subscription_status='active@example.com',
+            fair_use_stage='restrict@example.com',
+            classifier_type='prerecorded@example.com',
+            retry_after=None,
+            backend_revision='backend-sync@example.com',
+            correlation_id='person@example.com',
+        )
+
+        serialized = json.dumps(event)
+        assert 'example.com' not in serialized
+        for key in (
+            'device_id_hash',
+            'app_platform',
+            'app_version',
+            'subscription_plan',
+            'subscription_status',
+            'fair_use_stage',
+            'classifier_type',
+            'backend_revision',
+            'correlation_id',
+        ):
+            assert event[key] == 'unknown'
+        assert event['retry_after'] == DEFAULT_FAIR_USE_RETRY_AFTER_SECONDS
+
+    def test_correlation_accepts_only_uuid_or_cloud_trace_format(self):
+        request_id = '5d55a970-f41c-4e18-9c20-7e7c6fb9d48d'
+        cloud_trace = '105445aa7843bc8bf206b12000100000/1;o=1'
+        assert validated_correlation_id(request_id) == request_id
+        assert validated_correlation_id(cloud_trace) == cloud_trace
+        assert validated_correlation_id('request-123') is None
+        assert validated_correlation_id('person@example.com') is None
+
+    def test_emitter_writes_exact_json_object(self, capsys):
+        event = build_sync_rate_limit_event(
+            uid='uid-123',
+            device_hash='a1b2c3d4',
+            app_platform='android',
+            app_version='1.0.543+992',
+            subscription_plan='basic',
+            subscription_status='active',
+            fair_use_stage='restrict',
+            classifier_type='free_exhausted',
+            retry_after=None,
+            backend_revision='backend-sync-00042-abc',
+            correlation_id='5d55a970-f41c-4e18-9c20-7e7c6fb9d48d',
+        )
+        emit_sync_rate_limit_event(event)
+        output = capsys.readouterr().out
+        assert json.loads(output) == event
+        assert output.count('\n') == 1
 
 
 class TestRecordSpeechMsSource:
@@ -411,12 +530,20 @@ class TestSyncEndpointCodeStructure:
         assert 'get_hard_restriction_status(uid)' in source
 
     def test_hard_restricted_429_uses_retry_after_headers(self):
-        """Hard-restricted sync responses must expose Retry-After for client cooldowns."""
+        """Hard-restricted sync responses share an explicit machine-readable contract."""
         source = self._read_sync_source()
         assert 'get_hard_restriction_retry_after_seconds' not in source
-        assert 'headers=_hard_restriction_headers(retry_after, _V1_DEPRECATION_HEADERS)' in source
-        assert 'headers=headers' in self._function_body(source, 'async def sync_local_files_v2(')
-        assert 'run_blocking(critical_executor, _hard_restriction_headers' not in source
+        assert 'FAIR_USE_RATE_LIMIT_CODE' in source
+        assert 'headers = fair_use_rate_limit_headers(safe_retry_after, base_headers)' in source
+        assert source.count('return await _fair_use_restriction_response(') >= 3
+        assert 'retry_after=retry_after' in self._function_body(source, 'async def sync_local_files_v2(')
+        assert 'run_blocking(critical_executor, fair_use_rate_limit_headers' not in source
+
+    def test_v2_propagates_app_version_into_rejection_telemetry(self):
+        source = self._function_body(self._read_sync_source(), 'async def sync_local_files_v2(')
+        assert "x_app_version: Optional[str] = Header(None, alias='X-App-Version')" in source
+        assert 'x_app_version=x_app_version if isinstance(x_app_version, str) else None' in source
+        assert 'app_version=client_device_context.app_version' in source
 
     def test_zero_speech_skips_recording(self):
         """Verify zero-speech guard in code: only records when total_speech_ms > 0."""

--- a/backend/utils/fair_use.py
+++ b/backend/utils/fair_use.py
@@ -456,6 +456,29 @@ def _retry_after_seconds_from_restrict_until(restrict_until: Any) -> int | None:
     return max(seconds, 1) if seconds > 0 else None
 
 
+def normalize_expired_restriction_state(
+    uid: str, state: Dict[str, Any], *, now: datetime | None = None
+) -> Dict[str, Any]:
+    """Return effective state, persisting the existing restrict→throttle expiry transition."""
+    normalized_state = dict(state)
+    if normalized_state.get('stage', 'none') != 'restrict':
+        return normalized_state
+
+    restrict_until_raw = normalized_state.get('restrict_until')
+    if not isinstance(restrict_until_raw, datetime):
+        return normalized_state
+
+    restrict_until = _as_utc(restrict_until_raw)
+    effective_now = _as_utc(now) if now is not None else datetime.now(timezone.utc)
+    if effective_now <= restrict_until:
+        return normalized_state
+
+    fair_use_db.update_fair_use_state(uid, {'stage': 'throttle', 'restrict_until': None})
+    invalidate_enforcement_cache(uid)
+    normalized_state.update({'stage': 'throttle', 'restrict_until': None})
+    return normalized_state
+
+
 def get_hard_restriction_status(uid: str) -> tuple[bool, int | None]:
     """Return whether the user is hard-restricted and, when known, the retry window in seconds."""
     if not FAIR_USE_ENABLED or FAIR_USE_KILL_SWITCH:
@@ -465,23 +488,12 @@ def get_hard_restriction_status(uid: str) -> tuple[bool, int | None]:
 
     # Single Firestore read — get_enforcement_stage uses cache, but we need
     # restrict_until too, so read the full state once and check stage from it.
-    state = fair_use_db.get_fair_use_state(uid)
+    state = normalize_expired_restriction_state(uid, fair_use_db.get_fair_use_state(uid))
     stage = state.get('stage', 'none')
     if stage != 'restrict':
         return False, None
 
-    # Check if restriction has expired
-    restrict_until_raw = state.get('restrict_until')
-    if restrict_until_raw and isinstance(restrict_until_raw, datetime):
-        # Normalize to aware UTC for comparison (Firestore may return naive datetimes)
-        restrict_until = _as_utc(restrict_until_raw)
-        if datetime.now(timezone.utc) > restrict_until:
-            # Restriction expired, reset to throttle
-            fair_use_db.update_fair_use_state(uid, {'stage': 'throttle', 'restrict_until': None})
-            invalidate_enforcement_cache(uid)
-            return False, None
-    else:
-        restrict_until = restrict_until_raw
+    restrict_until = state.get('restrict_until')
 
     # Check if speech is over hard cap
     speech = get_rolling_speech_ms(uid)

--- a/backend/utils/sync/rate_limit.py
+++ b/backend/utils/sync/rate_limit.py
@@ -1,0 +1,119 @@
+"""Privacy-safe response and telemetry primitives for sync rate limits."""
+
+import json
+import re
+import sys
+from typing import Any, Dict, Optional
+
+FAIR_USE_RATE_LIMIT_CODE = 'fair_use_restricted'
+FAIR_USE_RATE_LIMIT_REASON = 'fair_use'
+FAIR_USE_RATE_LIMIT_REASON_HEADER = 'X-Omi-Rate-Limit-Reason'
+
+# A missing/invalid legacy restriction deadline must not create a retry storm.
+# Retry hourly so clients still reconcile and self-heal without waiting forever.
+DEFAULT_FAIR_USE_RETRY_AFTER_SECONDS = 60 * 60
+MAX_FAIR_USE_RETRY_AFTER_SECONDS = 30 * 24 * 60 * 60
+
+_PLATFORMS = frozenset({'android', 'ios', 'linux', 'macos', 'web', 'windows'})
+_FAIR_USE_STAGES = frozenset({'none', 'warning', 'throttle', 'restrict'})
+_CLASSIFIER_TYPES = frozenset(
+    {'none', 'audiobook', 'podcast', 'prerecorded', 'tv_movie', 'commercial', 'unknown', 'free_exhausted'}
+)
+_SUBSCRIPTION_PLANS = frozenset({'basic', 'unlimited', 'operator', 'architect'})
+_SUBSCRIPTION_STATUSES = frozenset({'active', 'inactive'})
+_APP_VERSION_PATTERN = re.compile(r'^[0-9]{1,4}(?:\.[0-9]{1,6}){1,3}(?:\+[A-Za-z0-9._-]{1,32})?$')
+_REQUEST_ID_PATTERN = re.compile(
+    r'^(?:[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}'
+    r'|[0-9a-fA-F]{32}/[0-9]{1,20}(?:;o=[01])?)$'
+)
+_UID_PATTERN = re.compile(r'^[A-Za-z0-9_-]{1,128}$')
+_REVISION_PATTERN = re.compile(r'^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$')
+
+
+def bounded_fair_use_retry_after(value: object) -> int:
+    """Return a positive, bounded retry interval; legacy missing deadlines retry hourly."""
+    try:
+        seconds = int(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError, OverflowError):
+        return DEFAULT_FAIR_USE_RETRY_AFTER_SECONDS
+    return min(max(seconds, 1), MAX_FAIR_USE_RETRY_AFTER_SECONDS)
+
+
+def fair_use_rate_limit_headers(retry_after: object, base_headers: Optional[Dict[str, str]] = None) -> Dict[str, str]:
+    headers = dict(base_headers or {})
+    headers[FAIR_USE_RATE_LIMIT_REASON_HEADER] = FAIR_USE_RATE_LIMIT_REASON
+    headers['Retry-After'] = str(bounded_fair_use_retry_after(retry_after))
+    return headers
+
+
+def validated_correlation_id(value: object) -> Optional[str]:
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip()
+    return normalized if _REQUEST_ID_PATTERN.fullmatch(normalized) else None
+
+
+def _validated_member(value: object, allowed: frozenset[str]) -> str:
+    normalized = str(getattr(value, 'value', value) or '').strip().lower()
+    return normalized if normalized in allowed else 'unknown'
+
+
+def _validated_device_hash(value: object) -> str:
+    if not isinstance(value, str):
+        return 'unknown'
+    normalized = value.strip().lower()
+    return normalized if re.fullmatch(r'[a-f0-9]{8}', normalized) else 'unknown'
+
+
+def _validated_app_version(value: object) -> str:
+    if not isinstance(value, str):
+        return 'unknown'
+    normalized = value.strip()
+    return normalized if _APP_VERSION_PATTERN.fullmatch(normalized) else 'unknown'
+
+
+def _validated_pattern(value: object, pattern: re.Pattern[str]) -> str:
+    if not isinstance(value, str):
+        return 'unknown'
+    normalized = value.strip()
+    return normalized if pattern.fullmatch(normalized) else 'unknown'
+
+
+def build_sync_rate_limit_event(
+    *,
+    uid: object,
+    device_hash: object,
+    app_platform: object,
+    app_version: object,
+    subscription_plan: object,
+    subscription_status: object,
+    fair_use_stage: object,
+    classifier_type: object,
+    retry_after: object,
+    backend_revision: object,
+    correlation_id: object,
+) -> Dict[str, Any]:
+    """Build a fixed-shape event containing only allowlisted or validated values."""
+    return {
+        'severity': 'WARNING',
+        'message': 'sync_rate_limit_rejected',
+        'event': 'sync_rate_limit_rejected',
+        'uid': _validated_pattern(uid, _UID_PATTERN),
+        'device_id_hash': _validated_device_hash(device_hash),
+        'app_platform': _validated_member(app_platform, _PLATFORMS),
+        'app_version': _validated_app_version(app_version),
+        'reason_code': FAIR_USE_RATE_LIMIT_CODE,
+        'subscription_plan': _validated_member(subscription_plan, _SUBSCRIPTION_PLANS),
+        'subscription_status': _validated_member(subscription_status, _SUBSCRIPTION_STATUSES),
+        'fair_use_stage': _validated_member(fair_use_stage, _FAIR_USE_STAGES),
+        'classifier_type': _validated_member(classifier_type, _CLASSIFIER_TYPES),
+        'retry_after': bounded_fair_use_retry_after(retry_after),
+        'backend_revision': _validated_pattern(backend_revision, _REVISION_PATTERN),
+        'correlation_id': validated_correlation_id(correlation_id) or 'unknown',
+    }
+
+
+def emit_sync_rate_limit_event(event: Dict[str, Any]) -> None:
+    """Write one exact JSON object so Cloud Logging ingests it as jsonPayload."""
+    sys.stdout.write(json.dumps(event, separators=(',', ':'), sort_keys=True) + '\n')
+    sys.stdout.flush()

--- a/docs/api-reference/app-client-openapi.json
+++ b/docs/api-reference/app-client-openapi.json
@@ -44297,19 +44297,51 @@
           },
           {
             "in": "header",
-            "name": "authorization",
+            "name": "X-App-Version",
             "required": false,
             "schema": {
-              "title": "Authorization",
+              "title": "X-App-Version",
               "type": "string"
             }
           },
           {
             "in": "header",
-            "name": "X-App-Version",
+            "name": "X-Request-ID",
             "required": false,
             "schema": {
-              "title": "X-App-Version",
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Request-Id"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Cloud-Trace-Context",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Cloud-Trace-Context"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "title": "Authorization",
               "type": "string"
             }
           }


### PR DESCRIPTION
## Summary
- mark application fair-use sync rejections with an explicit response code/header, bounded `Retry-After`, and privacy-safe structured telemetry
- keep generic/backend-capacity 429s distinct on mobile, serialize account-wide uploads, and prevent parallel retry storms
- reconcile explicit persisted fair-use state at startup, resume, manual sync, and cooldown expiry; normalize naturally expired backend restrictions
- migrate legacy ambiguous rate-limit state without showing false fair-use messaging

## Root cause
The mobile client treated every sync 429 as fair-use and persisted that classification. Reconciliation was limited to Settings, so stale state could survive restarts while concurrent upload paths continued to fan out retries.

## Validation
- Flutter test suite: **672 passed**
- focused mobile cooldown/startup/classification tests: **21 passed**
- targeted Dart analysis: **no issues**
- backend fair-use/sync suite: **269 passed**
- pre-push backend tests: **64 passed**, with the fair-use API marker selection skipped because no tests matched that marker
- backend async-blocker, import-side-effect, and module-stub scanners: **0 violations in changed scope**
- OpenAPI and generated mobile wire contracts: **up to date**
- independent backend and mobile reviews: **approved**
- iOS build was attempted but stopped before project compilation by this machine's Xcode framework mismatch; completing `xcodebuild -runFirstLaunch` requires administrator authorization, and no simulator runtime/physical device is installed
- desktop REST inventory regression test: **9 passed**
- fresh GitHub CI: **15 successful, 5 intentionally skipped, 0 failed**

Closes #9373

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9379?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
