### PR TITLE
Fix desktop explicit web search intent routing

### DIFF
--- a/desktop/macos/Backend-Rust/src/routes/chat_completions.rs
+++ b/desktop/macos/Backend-Rust/src/routes/chat_completions.rs
@@ -24,6 +24,10 @@ use crate::AppState;
 
 use super::llm_stub::{llm_stub_enabled, stub_chat_completions_response};
 use super::rate_limit::RateDecision;
+use super::retrieval_policy::{
+    caller_disabled_tools, prepend_latest_user_instruction, retrieval_policy, RetrievalSource,
+    REQUIRED_WEB_SEARCH_INSTRUCTION,
+};
 
 fn response_or_500(builder: axum::http::response::Builder, body: Body) -> Response {
     crate::routes::response_or_500("chat_completions", builder, body)
@@ -132,6 +136,7 @@ fn compute_cost(usage: &AnthropicUsage, upstream_model: &str) -> f64 {
 
 // ── OpenAI → Anthropic request translation ──────────────────────────────────
 
+#[cfg(test)]
 fn translate_request(
     req: &ChatCompletionRequest,
     upstream_model: &str,
@@ -144,6 +149,7 @@ fn translate_request_inner(
     upstream_model: &str,
     enable_web_search: bool,
 ) -> Result<AnthropicRequest, String> {
+    let policy = retrieval_policy(&req.messages);
     let mut system_prompt: Option<String> = None;
     let mut anthropic_messages: Vec<AnthropicMessage> = Vec::new();
 
@@ -233,13 +239,26 @@ fn translate_request_inner(
     // keeps the tools array byte-stable for the prompt-cache prefix.
     // Haiku is excluded: web_search_20260209 is not supported there, and a
     // tools-bearing haiku request would 400 with it attached.
-    let inject_web_search = enable_web_search && !upstream_model.starts_with("claude-haiku");
-    let anthropic_tools = req.tools.as_ref().map(|tools| {
-        let mut defs: Vec<AnthropicToolDef> = Vec::with_capacity(tools.len() + 1);
-        if inject_web_search && !tools.is_empty() {
+    let web_search_supported = enable_web_search && !upstream_model.starts_with("claude-haiku");
+    let force_web_search =
+        policy.requires(RetrievalSource::PublicWeb) && !caller_disabled_tools(req);
+    if force_web_search && !web_search_supported {
+        return Err(
+            "required public web search is unavailable for this model or deployment".to_string(),
+        );
+    }
+    let client_tools = req.tools.as_deref().unwrap_or(&[]);
+    let inject_web_search = web_search_supported
+        && !policy.prohibits(RetrievalSource::PublicWeb)
+        && (!client_tools.is_empty() || force_web_search);
+    let anthropic_tools = if client_tools.is_empty() && !inject_web_search {
+        req.tools.as_ref().map(|_| Vec::new())
+    } else {
+        let mut defs: Vec<AnthropicToolDef> = Vec::with_capacity(client_tools.len() + 1);
+        if inject_web_search {
             defs.push(web_search_tool_def());
         }
-        defs.extend(tools.iter().map(|t| {
+        defs.extend(client_tools.iter().map(|t| {
             AnthropicToolDef::Custom(AnthropicTool {
                 name: t.function.name.clone(),
                 description: t.function.description.clone(),
@@ -250,8 +269,23 @@ fn translate_request_inner(
                     .unwrap_or(json!({"type": "object", "properties": {}})),
             })
         }));
-        defs
-    });
+        Some(defs)
+    };
+
+    if force_web_search {
+        prepend_latest_user_instruction(&mut anthropic_messages, REQUIRED_WEB_SEARCH_INSTRUCTION);
+    }
+
+    tracing::info!(
+        event = "retrieval_policy",
+        required_web = policy.requires(RetrievalSource::PublicWeb),
+        required_private = policy.requires(RetrievalSource::OmiPrivate),
+        prohibited_web = policy.prohibits(RetrievalSource::PublicWeb),
+        reason = policy.reason(),
+        web_search_exposed = inject_web_search,
+        web_search_forced = force_web_search,
+        "chat_retrieval_policy"
+    );
 
     let max_tokens = req
         .max_completion_tokens
@@ -266,7 +300,11 @@ fn translate_request_inner(
         &req.tool_choice,
         Some(serde_json::Value::String(s)) if s == "none"
     );
-    let anthropic_tool_choice = translate_tool_choice(&req.tool_choice)?;
+    let anthropic_tool_choice = if force_web_search {
+        Some(json!({"type": "tool", "name": "web_search"}))
+    } else {
+        translate_tool_choice(&req.tool_choice)?
+    };
 
     // ── Prompt caching ──────────────────────────────────────────────────────
     // Breakpoint 1: emit the system prompt as a content block carrying an
@@ -631,6 +669,37 @@ async fn chat_completions(
         StatusCode::BAD_REQUEST
     })?;
 
+    let web_search_enabled = web_search_enabled();
+    let policy = retrieval_policy(&req.messages);
+    if policy.requires(RetrievalSource::PublicWeb)
+        && !caller_disabled_tools(&req)
+        && (!web_search_enabled || route.upstream_model.starts_with("claude-haiku"))
+    {
+        tracing::warn!(
+            event = "retrieval_policy",
+            required_web = true,
+            reason = policy.reason(),
+            web_search_exposed = false,
+            web_search_forced = false,
+            "required public web search is unavailable"
+        );
+        return Ok(response_or_500(
+            Response::builder()
+                .status(StatusCode::SERVICE_UNAVAILABLE)
+                .header("content-type", "application/json"),
+            Body::from(
+                json!({
+                    "error": {
+                        "message": "Public web search is temporarily unavailable. Please try again.",
+                        "type": "web_search_unavailable",
+                        "code": 503
+                    }
+                })
+                .to_string(),
+            ),
+        ));
+    }
+
     // BYOK: check for user-provided Anthropic API key (issue #7357).
     // When present, use the user's key and skip server-key rate limiting.
     let byok_anthropic_key =
@@ -682,10 +751,11 @@ async fn chat_completions(
     };
 
     // Translate request
-    let anthropic_req = translate_request(&req, route.upstream_model).map_err(|e| {
-        tracing::warn!("chat_completions: request translation error: {}", e);
-        StatusCode::BAD_REQUEST
-    })?;
+    let anthropic_req = translate_request_inner(&req, route.upstream_model, web_search_enabled)
+        .map_err(|e| {
+            tracing::warn!("chat_completions: request translation error: {}", e);
+            StatusCode::BAD_REQUEST
+        })?;
 
     // Bound connection establishment so a network blip can't hang the request; the
     // total-response timeout is applied per-call (non-streaming only) inside the retry
@@ -1202,6 +1272,16 @@ mod tests {
     fn user_message(text: &str) -> ChatMessage {
         ChatMessage {
             role: "user".to_string(),
+            content: Some(json!(text)),
+            name: None,
+            tool_calls: None,
+            tool_call_id: None,
+        }
+    }
+
+    fn assistant_message(text: &str) -> ChatMessage {
+        ChatMessage {
+            role: "assistant".to_string(),
             content: Some(json!(text)),
             name: None,
             tool_calls: None,
@@ -1979,6 +2059,59 @@ mod tests {
         assert_eq!(tools.len(), 1);
         let only = serde_json::to_value(&tools[0]).unwrap();
         assert_eq!(only["name"], "get_weather");
+    }
+
+    #[test]
+    fn test_translate_request_forces_required_web_search_without_client_tools() {
+        let req = test_request(vec![
+            user_message("I'm working on humanpost.co now"),
+            assistant_message("Is HumanPost separate from Vost or part of it?"),
+            user_message("look it up"),
+        ]);
+
+        let result = translate_request_inner(&req, "claude-sonnet-4-6", true).unwrap();
+        let tools = result.tools.unwrap();
+        assert_eq!(tools.len(), 1);
+        assert_eq!(
+            serde_json::to_value(&tools[0]).unwrap()["name"],
+            "web_search"
+        );
+        assert_eq!(
+            result.tool_choice,
+            Some(json!({"type": "tool", "name": "web_search"}))
+        );
+        let latest = result.messages.last().unwrap().content.to_string();
+        assert!(latest.contains("Public web search is required"));
+        assert!(latest.contains("look it up"));
+    }
+
+    #[test]
+    fn test_translate_request_required_web_search_fails_closed_when_disabled() {
+        let req = test_request(vec![user_message("Search the web for HumanPost")]);
+        let error = translate_request_inner(&req, "claude-sonnet-4-6", false).unwrap_err();
+        assert!(error.contains("required public web search is unavailable"));
+    }
+
+    #[test]
+    fn test_translate_request_private_lookup_excludes_server_web_search() {
+        let mut req = test_request(vec![user_message("Search my conversations for HumanPost")]);
+        req.tools = Some(vec![ToolDefinition {
+            tool_type: "function".to_string(),
+            function: FunctionDefinition {
+                name: "search_conversations".to_string(),
+                description: Some("Search private conversations".to_string()),
+                parameters: None,
+            },
+        }]);
+
+        let result = translate_request_inner(&req, "claude-sonnet-4-6", true).unwrap();
+        let tools = result.tools.unwrap();
+        assert_eq!(tools.len(), 1);
+        assert_eq!(
+            serde_json::to_value(&tools[0]).unwrap()["name"],
+            "search_conversations"
+        );
+        assert!(result.tool_choice.is_none());
     }
 
     #[test]

--- a/desktop/macos/Backend-Rust/src/routes/mod.rs
+++ b/desktop/macos/Backend-Rust/src/routes/mod.rs
@@ -11,6 +11,7 @@ pub mod llm_stub;
 pub mod proxy;
 pub mod rate_limit;
 pub mod realtime;
+mod retrieval_policy;
 pub mod screen_activity;
 pub mod tts;
 pub mod updates;

--- a/desktop/macos/Backend-Rust/src/routes/retrieval_policy.rs
+++ b/desktop/macos/Backend-Rust/src/routes/retrieval_policy.rs
@@ -1,0 +1,354 @@
+use serde_json::json;
+
+use crate::models::chat_completions::{AnthropicMessage, ChatCompletionRequest, ChatMessage};
+
+pub(crate) const REQUIRED_WEB_SEARCH_INSTRUCTION: &str = "<omi_retrieval_policy>\n\
+Public web search is required for this turn. Call web_search before answering. Build the query only from the user's latest request and public entities in the recent exchange. Do not include private memories, conversations, screen history, tasks, or other personal context unless the user explicitly asked to relate that private context to public information.\n\
+</omi_retrieval_policy>";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RetrievalSource {
+    PublicWeb,
+    OmiPrivate,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RetrievalReason {
+    ExplicitWeb,
+    Freshness,
+    AnaphoricLookup,
+    ExplicitPrivate,
+    Mixed,
+    Auto,
+}
+
+impl RetrievalReason {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::ExplicitWeb => "explicit_web",
+            Self::Freshness => "freshness",
+            Self::AnaphoricLookup => "anaphoric_lookup",
+            Self::ExplicitPrivate => "explicit_private",
+            Self::Mixed => "mixed",
+            Self::Auto => "auto",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RetrievalPolicy {
+    required_sources: Vec<RetrievalSource>,
+    prohibited_sources: Vec<RetrievalSource>,
+    reason: RetrievalReason,
+}
+
+impl RetrievalPolicy {
+    fn auto() -> Self {
+        Self {
+            required_sources: Vec::new(),
+            prohibited_sources: Vec::new(),
+            reason: RetrievalReason::Auto,
+        }
+    }
+
+    pub(crate) fn requires(&self, source: RetrievalSource) -> bool {
+        self.required_sources.contains(&source)
+    }
+
+    pub(crate) fn prohibits(&self, source: RetrievalSource) -> bool {
+        self.prohibited_sources.contains(&source)
+    }
+
+    pub(crate) fn reason(&self) -> &'static str {
+        self.reason.as_str()
+    }
+}
+
+const EXPLICIT_WEB_PHRASES: &[&str] = &[
+    "search the web",
+    "search web",
+    "search the internet",
+    "search online",
+    "look it up online",
+    "look this up online",
+    "look that up online",
+    "find it online",
+    "find this online",
+    "find that online",
+    "google it",
+    "google this",
+    "google that",
+    "browse the web",
+    "web search",
+    "internet search",
+];
+
+const EXPLICIT_PRIVATE_PHRASES: &[&str] = &[
+    "my conversations",
+    "our conversations",
+    "my memories",
+    "your memory of me",
+    "my screen history",
+    "my screen activity",
+    "my calendar",
+    "your calendar",
+    "my email",
+    "your email",
+    "my files",
+    "your files",
+    "my tasks",
+    "your tasks",
+    "my action items",
+    "my notes",
+    "your notes",
+    "what did i say",
+    "what have i said",
+    "when did i",
+    "what was i doing",
+    "what do you remember about me",
+];
+
+const FRESH_PUBLIC_PHRASES: &[&str] = &[
+    "latest news",
+    "latest on",
+    "what's the latest",
+    "what is the latest",
+    "current weather",
+    "weather right now",
+    "current price",
+    "price right now",
+    "current score",
+    "score right now",
+    "current president",
+    "current ceo",
+    "who is the current",
+    "today's news",
+    "news today",
+];
+
+const ANAPHORIC_LOOKUP_PHRASES: &[&str] = &[
+    "look it up",
+    "look this up",
+    "look that up",
+    "can you look it up",
+    "please look it up",
+    "research it",
+    "research this",
+    "research that",
+    "check it out",
+    "find out",
+];
+
+fn contains_any(text: &str, phrases: &[&str]) -> bool {
+    phrases.iter().any(|phrase| text.contains(phrase))
+}
+
+pub(crate) fn caller_disabled_tools(req: &ChatCompletionRequest) -> bool {
+    matches!(
+        &req.tool_choice,
+        Some(serde_json::Value::String(value)) if value == "none"
+    )
+}
+
+fn extract_text_content(content: &Option<serde_json::Value>) -> String {
+    match content {
+        Some(serde_json::Value::String(text)) => text.clone(),
+        Some(serde_json::Value::Array(blocks)) => blocks
+            .iter()
+            .filter_map(|block| {
+                (block.get("type").and_then(|value| value.as_str()) == Some("text"))
+                    .then(|| block.get("text").and_then(|value| value.as_str()))
+                    .flatten()
+            })
+            .collect::<Vec<_>>()
+            .join("\n"),
+        _ => String::new(),
+    }
+}
+
+fn normalized_lookup_text(text: &str) -> String {
+    text.trim()
+        .trim_matches(|ch: char| !ch.is_alphanumeric())
+        .to_ascii_lowercase()
+}
+
+fn previous_assistant_text(messages: &[ChatMessage]) -> String {
+    messages
+        .iter()
+        .rev()
+        .skip_while(|message| message.role != "user")
+        .skip(1)
+        .find(|message| message.role == "assistant")
+        .map(|message| extract_text_content(&message.content).to_ascii_lowercase())
+        .unwrap_or_default()
+}
+
+pub(crate) fn retrieval_policy(messages: &[ChatMessage]) -> RetrievalPolicy {
+    // Only classify a fresh user turn. During a client-tool continuation the
+    // latest OpenAI message has role=tool; reapplying a forced web choice there
+    // would search repeatedly and prevent the agent from consuming tool results.
+    let Some(latest_user) = messages.last().filter(|message| message.role == "user") else {
+        return RetrievalPolicy::auto();
+    };
+    let latest = normalized_lookup_text(&extract_text_content(&latest_user.content));
+    let explicit_web = contains_any(&latest, EXPLICIT_WEB_PHRASES);
+    let explicit_private = contains_any(&latest, EXPLICIT_PRIVATE_PHRASES);
+
+    if explicit_web && explicit_private {
+        return RetrievalPolicy {
+            required_sources: vec![RetrievalSource::PublicWeb, RetrievalSource::OmiPrivate],
+            prohibited_sources: Vec::new(),
+            reason: RetrievalReason::Mixed,
+        };
+    }
+    if explicit_web {
+        return RetrievalPolicy {
+            required_sources: vec![RetrievalSource::PublicWeb],
+            prohibited_sources: Vec::new(),
+            reason: RetrievalReason::ExplicitWeb,
+        };
+    }
+    if explicit_private {
+        return RetrievalPolicy {
+            required_sources: vec![RetrievalSource::OmiPrivate],
+            prohibited_sources: vec![RetrievalSource::PublicWeb],
+            reason: RetrievalReason::ExplicitPrivate,
+        };
+    }
+    if contains_any(&latest, FRESH_PUBLIC_PHRASES) {
+        return RetrievalPolicy {
+            required_sources: vec![RetrievalSource::PublicWeb],
+            prohibited_sources: Vec::new(),
+            reason: RetrievalReason::Freshness,
+        };
+    }
+    if ANAPHORIC_LOOKUP_PHRASES.contains(&latest.as_str()) {
+        let previous = previous_assistant_text(messages);
+        if contains_any(&previous, EXPLICIT_PRIVATE_PHRASES) {
+            return RetrievalPolicy {
+                required_sources: vec![RetrievalSource::OmiPrivate],
+                prohibited_sources: vec![RetrievalSource::PublicWeb],
+                reason: RetrievalReason::ExplicitPrivate,
+            };
+        }
+        return RetrievalPolicy {
+            required_sources: vec![RetrievalSource::PublicWeb],
+            prohibited_sources: Vec::new(),
+            reason: RetrievalReason::AnaphoricLookup,
+        };
+    }
+
+    RetrievalPolicy::auto()
+}
+
+pub(crate) fn prepend_latest_user_instruction(
+    messages: &mut [AnthropicMessage],
+    instruction: &str,
+) {
+    let Some(latest_user) = messages
+        .iter_mut()
+        .rev()
+        .find(|message| message.role == "user")
+    else {
+        return;
+    };
+    match &mut latest_user.content {
+        serde_json::Value::String(text) => {
+            *text = format!("{instruction}\n\n{text}");
+        }
+        serde_json::Value::Array(blocks) => {
+            blocks.insert(0, json!({"type": "text", "text": instruction}));
+        }
+        _ => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn message(role: &str, text: &str) -> ChatMessage {
+        ChatMessage {
+            role: role.to_string(),
+            content: Some(json!(text)),
+            name: None,
+            tool_calls: None,
+            tool_call_id: None,
+        }
+    }
+
+    #[test]
+    fn requires_web_for_explicit_request() {
+        let policy = retrieval_policy(&[message("user", "Search the web for HumanPost")]);
+        assert!(policy.requires(RetrievalSource::PublicWeb));
+        assert!(!policy.requires(RetrievalSource::OmiPrivate));
+        assert_eq!(policy.reason, RetrievalReason::ExplicitWeb);
+    }
+
+    #[test]
+    fn resolves_public_anaphoric_lookup_from_history() {
+        let policy = retrieval_policy(&[
+            message("user", "I'm working on humanpost.co now"),
+            message(
+                "assistant",
+                "Is HumanPost separate from Vost or part of it?",
+            ),
+            message("user", "look it up"),
+        ]);
+        assert!(policy.requires(RetrievalSource::PublicWeb));
+        assert_eq!(policy.reason, RetrievalReason::AnaphoricLookup);
+    }
+
+    #[test]
+    fn keeps_private_anaphoric_lookup_inside_omi() {
+        let policy = retrieval_policy(&[
+            message("user", "What did I decide about pricing?"),
+            message("assistant", "I can check your conversations and memories."),
+            message("user", "look it up"),
+        ]);
+        assert!(policy.requires(RetrievalSource::OmiPrivate));
+        assert!(policy.prohibits(RetrievalSource::PublicWeb));
+        assert_eq!(policy.reason, RetrievalReason::ExplicitPrivate);
+    }
+
+    #[test]
+    fn requires_web_for_high_confidence_freshness() {
+        let policy =
+            retrieval_policy(&[message("user", "What's the latest news about Anthropic?")]);
+        assert!(policy.requires(RetrievalSource::PublicWeb));
+        assert_eq!(policy.reason, RetrievalReason::Freshness);
+    }
+
+    #[test]
+    fn supports_mixed_public_and_private_sources() {
+        let policy = retrieval_policy(&[message(
+            "user",
+            "Search the web and my conversations for HumanPost",
+        )]);
+        assert!(policy.requires(RetrievalSource::PublicWeb));
+        assert!(policy.requires(RetrievalSource::OmiPrivate));
+        assert_eq!(policy.reason, RetrievalReason::Mixed);
+    }
+
+    #[test]
+    fn leaves_ordinary_questions_on_auto() {
+        assert_eq!(
+            retrieval_policy(&[message("user", "Help me name this project")]),
+            RetrievalPolicy::auto()
+        );
+    }
+
+    #[test]
+    fn does_not_reforce_web_during_tool_continuation() {
+        let mut tool_result = message("tool", "search result");
+        tool_result.tool_call_id = Some("call_123".to_string());
+        assert_eq!(
+            retrieval_policy(&[
+                message("user", "Search the web and my conversations for HumanPost"),
+                message("assistant", "I'll check both."),
+                tool_result,
+            ]),
+            RetrievalPolicy::auto()
+        );
+    }
+}

--- a/desktop/macos/Desktop/Sources/Chat/ChatDraftStore.swift
+++ b/desktop/macos/Desktop/Sources/Chat/ChatDraftStore.swift
@@ -64,7 +64,7 @@ final class ChatDraftStore {
         fileManager: FileManager = .default,
         writeDelay: TimeInterval = 0.2,
         ownerIDProvider: @escaping () -> String? = {
-            UserDefaults.standard.string(forKey: "auth_userId")
+            UserDefaults.standard.string(forKey: .authUserId)
         }
     ) {
         self.fileManager = fileManager

--- a/desktop/macos/Desktop/Sources/Chat/ChatPrompts.swift
+++ b/desktop/macos/Desktop/Sources/Chat/ChatPrompts.swift
@@ -58,6 +58,16 @@ struct ChatPrompts {
     3. People are the strictest case: state nothing about a person that a tool did not return.
     </critical_accuracy_rules>
 
+    <retrieval_source_rules>
+    Choose the source that matches the user's request:
+    - Public internet, external companies/products/people, current facts, news, weather, prices, or explicit requests to search online → use web_search.
+    - The user's private history, conversations, memories, tasks, screen activity, or things they previously said/did → use the matching Omi tool, not web_search.
+    - A direct URL → read that URL before answering.
+    - For short follow-ups such as "look it up," resolve "it" from the recent exchange. If it is a public entity, search the web. If it refers to the user's private history, search Omi.
+    - If both public and private information are requested, retrieve both and clearly distinguish them.
+    Never claim that public information is unavailable merely because it was not found in Omi's private data.
+    </retrieval_source_rules>
+
     <tools>
     \(DesktopCapabilityRegistry.desktopToolPrompt)
 

--- a/desktop/macos/Desktop/Tests/ChatDiscoverabilityTests.swift
+++ b/desktop/macos/Desktop/Tests/ChatDiscoverabilityTests.swift
@@ -101,6 +101,15 @@ final class ChatDiscoverabilityTests: XCTestCase {
         XCTAssertFalse(prompt.contains("You have \(DesktopCapabilityRegistry.desktopToolNames.count) Omi tools"))
     }
 
+    func testDesktopPromptDistinguishesPublicWebFromPrivateOmiRetrieval() {
+        let prompt = ChatPrompts.desktopChat
+        XCTAssertTrue(prompt.contains("Public internet, external companies/products/people"))
+        XCTAssertTrue(prompt.contains("use web_search"))
+        XCTAssertTrue(prompt.contains("private history, conversations, memories"))
+        XCTAssertTrue(prompt.contains("For short follow-ups such as \"look it up,\""))
+        XCTAssertTrue(prompt.contains("Never claim that public information is unavailable"))
+    }
+
     func testToolPromptListsSearchTasksInWhenToUse() {
         let prompt = ChatPrompts.desktopChat
         XCTAssertTrue(prompt.contains("find tasks about shopping"))

--- a/desktop/macos/changelog/unreleased/20260710-explicit-web-intent.json
+++ b/desktop/macos/changelog/unreleased/20260710-explicit-web-intent.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed requests like “look it up” searching Omi history instead of the public web"
+}

--- a/desktop/macos/e2e/flows/chat-hermetic.yaml
+++ b/desktop/macos/e2e/flows/chat-hermetic.yaml
@@ -19,6 +19,7 @@ covers:
   - desktop/macos/Desktop/Sources/Chat/ScreenContextTelemetry.swift
   - desktop/macos/Desktop/Sources/Chat/ChatStreamingBuffer.swift
   - desktop/macos/Desktop/Sources/Chat/ChatErrorState.swift
+  - desktop/macos/Desktop/Sources/Chat/ChatPrompts.swift
   - desktop/macos/Desktop/Sources/Chat/TypingIndicator.swift
   - desktop/macos/Desktop/Sources/MainWindow/Components/ChatBubble.swift
   - desktop/macos/Desktop/Sources/MainWindow/Components/ChatMessagesView.swift


### PR DESCRIPTION
## Summary

- add a typed, deterministic retrieval policy that distinguishes required public web search from private Omi retrieval
- force Anthropic web_search before generation for explicit, freshness-sensitive, and public anaphoric requests such as “look it up”
- suppress public web search for explicitly private lookups and constrain generated search queries to public context unless the user requests a mixed lookup
- add source-selection prompt guidance, structured routing telemetry, regression coverage, and a desktop changelog fragment
- migrate the adjacent chat-draft owner lookup to its existing typed UserDefaults key, repairing a pre-existing repository ratchet failure in a separate commit

## Why

The desktop proxy previously exposed server-side web search only when the client already supplied tools, then left selection on automatic. At the same time, the desktop prompt strongly emphasized private Omi sources. A short follow-up such as “look it up” could therefore be interpreted as a private-history lookup and incorrectly report that nothing was found without ever searching the public internet.

This PR turns high-confidence retrieval intent into an enforceable pre-generation contract while preserving automatic behavior for ordinary questions and respecting an explicit tool_choice=none.

## Verification

- cargo test: 319 passed
- xcrun swift test --package-path Desktop --filter ChatDiscoverabilityTests: 22 passed
- xcrun swift test --package-path Desktop --filter ChatDraftStoreTests: 9 passed
- ./scripts/agent-logic-harness.sh: passed all four stages
- repository pre-push checks: passed, including full desktop Swift build, Rust check, changelog validation, and UserDefaults ratchet
- isolated omi-web-intent named bundle built, installed, and launched with ad-hoc signing

A signed-in live chat E2E was not completed: this worktree had no seeded Omi Dev session, and the local harness was unavailable without Docker and provider credentials. The routing and translation boundary is covered by deterministic regression tests.

## Product invariants affected

- INV-CHAT-1 checked and unchanged: this does not alter chat persistence, canonical write paths, or timeline projection behavior.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9384?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
