### PR TITLE
fix(notifications-job): strip literal env vars overshadowing Secret Manager binds

### DIFF
--- a/.github/workflows/gcp_notifications_job.yml
+++ b/.github/workflows/gcp_notifications_job.yml
@@ -114,16 +114,8 @@ jobs:
           image: gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}:${{ steps.image-tag.outputs.short_sha }}
           env_vars: ${{ steps.runtime-env.outputs.notifications_job_env_vars }}
           secrets: ${{ steps.runtime-env.outputs.notifications_job_secrets }}
-          # Remove retired canonical-maintenance bindings, and strip any
-          # plain-literal env var whose name is now bound to Secret Manager on
-          # this job — Cloud Run rejects updates when a name is bound as both
-          # env-var and secret, so a stale literal (from an earlier deploy that
-          # hard-coded a secret value into env) silently blocks the secret ref
-          # from taking effect. `notifications_job_secret_names` is a
-          # comma-separated list of exactly the names in `secrets:` above, so
-          # `--remove-env-vars` on them is a no-op on a clean target and a
-          # cleanup on a polluted one. The live job carries additional
-          # notification/X-sync env that must survive this deploy.
+          # Strip retired maintenance keys, plus any literal shadowing a
+          # Secret Manager binding (no-op on a clean target).
           flags: >-
             --remove-env-vars=MEMORY_MODE,MEMORY_ENABLED_USERS,MEMORY_V3_GET_ENABLED,MEMORY_CANONICAL_PROMOTION_CRON_ENABLED,MEMORY_CANONICAL_PROMOTION_FAST_TRACK_ENABLED,MEMORY_CANONICAL_CONSOLIDATION_ENABLED,MEMORY_TYPESENSE_COLLECTION,TYPESENSE_HOST,TYPESENSE_HOST_PORT,TYPESENSE_API_KEY,${{ steps.runtime-env.outputs.notifications_job_secret_names }}
 

--- a/.github/workflows/gcp_notifications_job.yml
+++ b/.github/workflows/gcp_notifications_job.yml
@@ -114,10 +114,18 @@ jobs:
           image: gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}:${{ steps.image-tag.outputs.short_sha }}
           env_vars: ${{ steps.runtime-env.outputs.notifications_job_env_vars }}
           secrets: ${{ steps.runtime-env.outputs.notifications_job_secrets }}
-          # Remove only retired canonical-maintenance bindings. The live job has
-          # additional notification/X-sync env that must survive this deploy.
+          # Remove retired canonical-maintenance bindings, and strip any
+          # plain-literal env var whose name is now bound to Secret Manager on
+          # this job — Cloud Run rejects updates when a name is bound as both
+          # env-var and secret, so a stale literal (from an earlier deploy that
+          # hard-coded a secret value into env) silently blocks the secret ref
+          # from taking effect. `notifications_job_secret_names` is a
+          # comma-separated list of exactly the names in `secrets:` above, so
+          # `--remove-env-vars` on them is a no-op on a clean target and a
+          # cleanup on a polluted one. The live job carries additional
+          # notification/X-sync env that must survive this deploy.
           flags: >-
-            --remove-env-vars=MEMORY_MODE,MEMORY_ENABLED_USERS,MEMORY_V3_GET_ENABLED,MEMORY_CANONICAL_PROMOTION_CRON_ENABLED,MEMORY_CANONICAL_PROMOTION_FAST_TRACK_ENABLED,MEMORY_CANONICAL_CONSOLIDATION_ENABLED,MEMORY_TYPESENSE_COLLECTION,TYPESENSE_HOST,TYPESENSE_HOST_PORT,TYPESENSE_API_KEY
+            --remove-env-vars=MEMORY_MODE,MEMORY_ENABLED_USERS,MEMORY_V3_GET_ENABLED,MEMORY_CANONICAL_PROMOTION_CRON_ENABLED,MEMORY_CANONICAL_PROMOTION_FAST_TRACK_ENABLED,MEMORY_CANONICAL_CONSOLIDATION_ENABLED,MEMORY_TYPESENSE_COLLECTION,TYPESENSE_HOST,TYPESENSE_HOST_PORT,TYPESENSE_API_KEY,${{ steps.runtime-env.outputs.notifications_job_secret_names }}
 
       # If required, use the Cloud Run url output in later steps
       - name: Show Output

--- a/backend/scripts/render_backend_runtime_env.py
+++ b/backend/scripts/render_backend_runtime_env.py
@@ -38,6 +38,7 @@ def main() -> int:
         output_prefix = _output_prefix(service)
         _emit_output(f'{output_prefix}_env_vars', _render_env_vars(service_config.get('env', {})))
         _emit_output(f'{output_prefix}_secrets', _render_secrets(service_config.get('secrets', {})))
+        _emit_output(f'{output_prefix}_secret_names', _render_secret_names(service_config.get('secrets', {})))
     jobs = _as_config_dict(cloud_run.get('jobs')) or {}
     for job, raw_job_config in jobs.items():
         job_config = _as_config_dict(raw_job_config)
@@ -46,6 +47,7 @@ def main() -> int:
         output_prefix = _output_prefix(job)
         _emit_output(f'{output_prefix}_env_vars', _render_env_vars(job_config.get('env', {})))
         _emit_output(f'{output_prefix}_secrets', _render_secrets(job_config.get('secrets', {})))
+        _emit_output(f'{output_prefix}_secret_names', _render_secret_names(job_config.get('secrets', {})))
     return 0
 
 
@@ -80,6 +82,16 @@ def _render_secrets(secret_entries: ConfigDict) -> str:
         version = entry.get('version', 'latest')
         lines.append(f'{name}={entry["secret"]}:{version}')
     return '\n'.join(lines)
+
+
+def _render_secret_names(secret_entries: ConfigDict) -> str:
+    # Comma-separated list of names bound to Secret Manager for this target.
+    # Consumers pass this to `--remove-env-vars=` so any stale plain-literal env
+    # var with the same name (from an earlier deploy) is stripped before the
+    # secret binding is applied — Cloud Run rejects updates when a name is bound
+    # as both env-var and secret. `--remove-env-vars` on a name that isn't set
+    # is a no-op, so this is safe even on a clean target.
+    return ','.join(secret_entries.keys())
 
 
 def _render_flags(flag_entries: ConfigDict) -> str:

--- a/backend/scripts/render_backend_runtime_env.py
+++ b/backend/scripts/render_backend_runtime_env.py
@@ -85,12 +85,6 @@ def _render_secrets(secret_entries: ConfigDict) -> str:
 
 
 def _render_secret_names(secret_entries: ConfigDict) -> str:
-    # Comma-separated list of names bound to Secret Manager for this target.
-    # Consumers pass this to `--remove-env-vars=` so any stale plain-literal env
-    # var with the same name (from an earlier deploy) is stripped before the
-    # secret binding is applied — Cloud Run rejects updates when a name is bound
-    # as both env-var and secret. `--remove-env-vars` on a name that isn't set
-    # is a no-op, so this is safe even on a clean target.
     return ','.join(secret_entries.keys())
 
 

--- a/backend/tests/unit/test_render_backend_runtime_env.py
+++ b/backend/tests/unit/test_render_backend_runtime_env.py
@@ -96,6 +96,22 @@ def test_render_dev_emits_memory_maintenance_job_outputs(capsys, monkeypatch):
         'OPENAI_API_KEY=OPENAI_API_KEY:latest',
         'PINECONE_API_KEY=PINECONE_API_KEY:latest',
     }
+    # `_secret_names` mirrors the keys of `_secrets` and is consumed by the
+    # workflow's `--remove-env-vars=` flag so any stale plain-literal env var
+    # bearing the same name gets stripped before Secret Manager binding is
+    # applied. Cloud Run rejects updates when a name is bound as both env-var
+    # and secret, which is what silently broke OPENAI_API_KEY on the live
+    # notifications-job after an earlier deploy hard-coded it as a literal.
+    secret_names_marker = '__BACKEND_RUNTIME_ENV_notifications_job_secret_names__'
+    names_start = out.index(f'notifications_job_secret_names<<{secret_names_marker}')
+    names_body_start = out.index('\n', names_start) + 1
+    names_body_end = out.index(secret_names_marker, names_body_start)
+    assert set(out[names_body_start:names_body_end].strip().split(',')) == {
+        'SERVICE_ACCOUNT_JSON',
+        'ENCRYPTION_SECRET',
+        'OPENAI_API_KEY',
+        'PINECONE_API_KEY',
+    }
 
 
 def test_render_prod_keeps_memory_maintenance_job_promotion_off(capsys, monkeypatch):

--- a/backend/tests/unit/test_render_backend_runtime_env.py
+++ b/backend/tests/unit/test_render_backend_runtime_env.py
@@ -96,12 +96,6 @@ def test_render_dev_emits_memory_maintenance_job_outputs(capsys, monkeypatch):
         'OPENAI_API_KEY=OPENAI_API_KEY:latest',
         'PINECONE_API_KEY=PINECONE_API_KEY:latest',
     }
-    # `_secret_names` mirrors the keys of `_secrets` and is consumed by the
-    # workflow's `--remove-env-vars=` flag so any stale plain-literal env var
-    # bearing the same name gets stripped before Secret Manager binding is
-    # applied. Cloud Run rejects updates when a name is bound as both env-var
-    # and secret, which is what silently broke OPENAI_API_KEY on the live
-    # notifications-job after an earlier deploy hard-coded it as a literal.
     secret_names_marker = '__BACKEND_RUNTIME_ENV_notifications_job_secret_names__'
     names_start = out.index(f'notifications_job_secret_names<<{secret_names_marker}')
     names_body_start = out.index('\n', names_start) + 1


### PR DESCRIPTION
## Summary

Daily summaries silently stopped generating for every user on 2026-07-01. Root cause: the `notifications-job` Cloud Run Job's `OPENAI_API_KEY` was a **plain-literal env var** with a stale key value that OpenAI is now rejecting (`sk-proj-…wMAA` → `401 Unauthorized`). Every daily-summary run since caught the 401 in a broad `except Exception`, logged it, and returned without writing a summary or firing a push.

The underlying architectural issue: **Cloud Run rejects updates when the same name is bound as both a plain-literal env-var and a Secret Manager secret**. If any earlier deploy hard-coded `OPENAI_API_KEY` (or any other secret name) into env, the literal silently wins forever — subsequent workflow runs that render `OPENAI_API_KEY` as a secret ref via `notifications_job_secrets` can't take effect because the deploy step never removes the conflicting literal.

The `backend/deploy/runtime_env.yaml` manifest already correctly declares `OPENAI_API_KEY`, `PINECONE_API_KEY`, `SERVICE_ACCOUNT_JSON`, and `ENCRYPTION_SECRET` as Secret Manager binds on `notifications-job`. The workflow was just missing the cleanup step.

## How the intent was declared but never took effect

PR #9295 (2026-07-08) first added `notifications-job` to the runtime env contract — the manifest section with `OPENAI_API_KEY` as a Secret Manager binding, plus the render + `secrets:` output wiring in `.github/workflows/gcp_notifications_job.yml`. The same PR also introduced the workflow's `--remove-env-vars=…` flag, but only listed the retired canonical-maintenance and Typesense keys — not the newly-declared secret names. Subsequent tightening in #9296, #9308, and #9358 kept the same `--remove-env-vars=` list without adding the secret names to it.

Because `google-github-actions/deploy-cloudrun@v2` merges `secrets:` additively rather than removing overlapping env-vars, and Cloud Run silently keeps the pre-existing literal when a name is bound both ways, the secret ref for `OPENAI_API_KEY` was declared correctly but never actually replaced the (broken) literal. The literal was already broken as of 2026-07-01 01:06 UTC — Loki logs show a clean cutover from working summaries to `401 Unauthorized: invalid_api_key` at that timestamp, ~7 days before the Secret Manager binding was declared — so the July 8 change would have unblocked summaries immediately if it had also stripped the literal.

Not a blame-y point: this class of gap is easy to miss because the intent looks correct in code review — the manifest says "secret", the workflow reads `notifications_job_secrets`, and `deploy-cloudrun@v2` accepts it. The failure mode only surfaces on a target that already had a plain literal by the same name, which isn't visible from the PR diff alone. The mitigation is small and general (this PR).

## Change

- `render_backend_runtime_env.py` emits a new `<prefix>_secret_names` output per service/job — a comma-separated list of exactly the names in `secrets:`.
- `gcp_notifications_job.yml` appends that output to its existing `--remove-env-vars=…` flag. `--remove-env-vars` is a no-op on a clean target, so this is safe on healthy deployments and cleanup on polluted ones.
- Manifest stays the single source of truth — adding/removing a secret in `runtime_env.yaml` automatically flows both `--update-secrets` and the matching `--remove-env-vars` on the next deploy.

## Immediate live fix (already applied)

To unblock tonight's summaries without waiting for the workflow to run, the live job was updated manually:

```bash
gcloud run jobs update notifications-job \
  --project=based-hardware --region=us-central1 \
  --remove-env-vars=OPENAI_API_KEY \
  --update-secrets=OPENAI_API_KEY=OPENAI_API_KEY:latest
gcloud run jobs execute notifications-job --project=based-hardware --region=us-central1
```

Post-execution logs are clean — zero `invalid_api_key`, `Sending daily summary` firing normally across all timezones. This PR makes the fix durable so future deploys can't regress.

## Test plan

- [x] `pytest backend/tests/unit/test_render_backend_runtime_env.py` — 9 passed, includes new assertion that `notifications_job_secret_names` emits `{SERVICE_ACCOUNT_JSON, ENCRYPTION_SECRET, OPENAI_API_KEY, PINECONE_API_KEY}`.
- [x] Manual `python3 backend/scripts/render_backend_runtime_env.py --env prod` output verified.
- [x] Existing workflow-structure assertion (`test_notifications_job_workflow_passes_vpc_vars_and_checkout_sha`) still passes — the change is additive to the flag string.
- [ ] Trigger `gcp_notifications_job.yml` prod deploy and verify the live job's spec shows `OPENAI_API_KEY` as `secretKeyRef` (not `value`).

## Notes / follow-ups

- The live job carries several other historical literal env vars (`FAL_KEY`, `GROQ_API_KEY`, `SONIOX_API_KEY`, `DEEPGRAM_API_KEY`, `ADMIN_KEY`, `REDIS_DB_PASSWORD`, `GITHUB_TOKEN`, and more) that aren't declared in the manifest at all — the current manifest deliberately narrows `notifications-job` to just the 4 secrets it needs. Whether the extras should be added, removed, or ignored is a separate call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
