### PR TITLE
fix(backend): daily recap suppressed on all platforms by desktop trial paywall (#9357)

### DIFF
--- a/backend/tests/unit/test_daily_summary_race_condition.py
+++ b/backend/tests/unit/test_daily_summary_race_condition.py
@@ -231,8 +231,9 @@ models_notif.NotificationMessage = mock_notification_message
 models_convo = sys.modules["models.conversation"]
 models_convo.Conversation = MagicMock()
 
-# utils.executors / utils.subscription are imported by notifications.py and pull firebase_admin
-# transitively; stub them (neither is used by _send_summary_notification).
+# utils.executors is imported by notifications.py and pulls firebase_admin transitively; stub it.
+# utils.subscription is stubbed defensively in case a transitive import reaches it — the daily
+# recap itself no longer references it (the desktop paywall gate was removed, #9357).
 exec_mod = _stub_module("utils.executors")
 exec_mod.postprocess_executor = MagicMock()
 exec_mod.run_blocking = MagicMock()
@@ -474,3 +475,49 @@ class TestSendSummaryNotificationLockIntegration:
         # Lock denied, so no downstream work
         convos_db.get_conversations.assert_not_called()
         gen_mock.assert_not_called()
+
+
+class TestDailyRecapNotDesktopPaywalled:
+    """#9357: the daily recap is a cross-platform, server-initiated cron that does not know the
+    originating platform. It must NOT be gated on the *desktop* trial paywall — doing so (via a
+    hardcoded 'macos' platform) suppressed the recap on mobile/web for any trial-expired user."""
+
+    def test_send_summary_does_not_gate_on_trial_paywall(self):
+        import inspect
+
+        # Ignore comments (the fix documents *why* the gate was removed); only executable code counts.
+        code_lines = [
+            line
+            for line in inspect.getsource(_send_summary_notification).splitlines()
+            if not line.strip().startswith('#')
+        ]
+        assert not any(
+            'is_trial_paywalled' in line for line in code_lines
+        ), "daily recap must not gate on the desktop trial paywall (regressed #9357)"
+
+    def test_module_no_longer_imports_desktop_paywall(self):
+        # The import was removed with the gate; re-adding it would signal the gate is back.
+        assert not hasattr(notifications_module, 'is_trial_paywalled')
+
+    @patch.object(notifications_module, 'try_acquire_daily_summary_lock', return_value=True)
+    def test_trial_expired_user_still_gets_recap(self, mock_lock):
+        convos_db = _CONVERSATIONS_DB
+        convos_db.get_conversations = MagicMock(return_value=[{'id': 'c1'}])
+
+        gen_mock = _GENERATE_COMPREHENSIVE_DAILY_SUMMARY
+        gen_mock.return_value = {'day_emoji': '!', 'headline': 'Test', 'overview': 'Summary'}
+
+        daily_db = _DAILY_SUMMARIES_DB
+        daily_db.get_daily_summary_by_date = MagicMock(return_value=None)
+        daily_db.create_daily_summary = MagicMock(return_value='summary-123')
+
+        send_mock = _SEND_NOTIFICATION
+        send_mock.reset_mock()
+
+        # Even if this user's desktop trial has expired, the recap must still be generated + sent.
+        user_data = ('uid1', ['token1'], 'America/New_York')
+        _send_summary_notification(user_data)
+
+        gen_mock.assert_called_once()
+        daily_db.create_daily_summary.assert_called_once()
+        send_mock.assert_called_once()

--- a/backend/utils/other/notifications.py
+++ b/backend/utils/other/notifications.py
@@ -15,7 +15,6 @@ from models.notification_message import NotificationMessage
 from utils.conversations.factory import deserialize_conversation
 from utils.llm.external_integrations import generate_comprehensive_daily_summary
 from utils.notifications import send_bulk_notification, send_notification
-from utils.subscription import is_trial_paywalled
 from utils.webhooks import day_summary_webhook
 import database.daily_summaries as daily_summaries_db
 import logging
@@ -80,16 +79,12 @@ def _send_summary_notification(user_data: Tuple[Any, ...]) -> None:
     uid = user_data[0]
     user_tz_name = user_data[2] if len(user_data) > 2 else None
 
-    # Trial paywall: skip the daily-summary LLM job entirely for paywalled
-    # desktop users. We don't know the originating platform here (this is a
-    # server-initiated cron), so we conservatively check both desktop and
-    # macos — if either trips the paywall, skip. Mobile users with the same
-    # uid still get their daily summary because `is_trial_paywalled` requires
-    # the platform check to pass; passing `macos` is the right gate here
-    # because the desktop trial is the paid-tier we're enforcing.
-    if is_trial_paywalled(uid, 'macos'):
-        logger.info(f'trial paywall: skipping daily summary for uid={uid}')
-        return
+    # NOTE: The daily recap is a cross-platform feature delivered by a
+    # server-initiated cron that does not know the originating platform.
+    # It must NOT be gated on the desktop trial paywall: passing a hardcoded
+    # 'macos' to is_trial_paywalled() made the gate trip for any trial-expired
+    # user, suppressing their recap on mobile/web too (#9357). The desktop
+    # trial only gates desktop features, not the recap the mobile app renders.
 
     # Calculate local day boundaries for conversation fetching
     # date_str is set based on current hour:


### PR DESCRIPTION
## Bug

Users stopped receiving their **daily recap** — e.g. #9357 (no daily recap on Android since June 30, 2026).

## Root cause

`send_daily_summary_notification` is a **server-initiated cron** that generates the recap for a user regardless of platform (it's rendered in the mobile app at `/daily-summary/<id>`). In `_send_summary_notification` it gated on the **desktop** trial paywall with a hardcoded platform:

```python
if is_trial_paywalled(uid, 'macos'):
    return
```

`is_trial_paywalled(uid, platform)` only checks the platform token, then returns the user's trial-expired state:

```python
if not platform or platform.lower() not in _TRIAL_PAYWALL_DESKTOP_TOKENS:  # {"macos", "desktop"}
    return False
return _is_trial_expired_cached(uid)
```

Passing `'macos'` **passes** the desktop-token check, so the gate trips for **any** trial-expired user and their recap is suppressed on **every** platform, including mobile/web. The in-code comment claimed "Mobile users with the same uid still get their daily summary" — that reasoning is false, because `'macos'` is itself a desktop token. Once the trial paywall took effect for a cohort of users (trial expiry / rollout), their recaps silently stopped — matching the #9357 timeline.

## Fix

Remove the desktop-paywall gate (and its now-unused import) from the recap cron. The desktop trial only gates desktop features; it must not suppress the cross-platform recap. Restores the recap for trial-expired mobile/web users.

## Tests

Added regression tests in `test_daily_summary_race_condition.py`:
- `test_send_summary_does_not_gate_on_trial_paywall` — asserts the executable body no longer references the desktop paywall (would have caught the original gate).
- `test_module_no_longer_imports_desktop_paywall` — guards against re-adding the import.
- `test_trial_expired_user_still_gets_recap` — a trial-expired user still gets the summary generated + sent.

```
$ python3 -m pytest tests/unit/test_daily_summary_race_condition.py -q
16 passed
```

(Local env lacks `pytz`/black in the bare Python 3.9 used here; the CI venv (3.11) runs the full suite. Sibling `test_daily_summary_regenerate.py` also passes locally.)

🤖 automated by hourly watchdog; opened for review, not merged.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9387?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

