### PR TITLE
app: make the device onboarding tour skippable at any stage

### DIFF
--- a/app/lib/pages/onboarding/interactive_device_onboarding/interactive_device_onboarding_wrapper.dart
+++ b/app/lib/pages/onboarding/interactive_device_onboarding/interactive_device_onboarding_wrapper.dart
@@ -15,10 +15,10 @@ import 'package:omi/pages/onboarding/interactive_device_onboarding/widgets/onboa
 import 'package:omi/utils/analytics/analytics_manager.dart';
 
 class InteractiveDeviceOnboardingWrapper extends StatefulWidget {
-  // When true (e.g. re-opened from Settings → Device Tutorial after completing
-  // it once), the flow is dismissible: a back arrow is shown and the system back
-  // gesture works. The forced first-run (auto-triggered on device connect) leaves
-  // this false so the tutorial stays non-skippable.
+  // True when re-opened from Settings → Device Tutorial. The flow is always
+  // dismissible (a hardware/BLE hiccup mid-tutorial must never soft-lock the
+  // app); leaving on the first run persists completion so it doesn't re-fire,
+  // and the tutorial stays reachable from device settings.
   final bool allowExit;
 
   const InteractiveDeviceOnboardingWrapper({super.key, this.allowExit = false});
@@ -101,12 +101,28 @@ class _InteractiveDeviceOnboardingWrapperState extends State<InteractiveDeviceOn
     Navigator.of(context).pop();
   }
 
+  /// Leave the tutorial from any point. Persists completion so the forced
+  /// first-run never re-fires (redo anytime via Settings → Device Tutorial);
+  /// dispose() records the abandoned step for analytics.
+  void _skipOnboarding() {
+    SharedPreferencesUtil().deviceOnboardingCompleted = true;
+    updateUserOnboardingState(deviceOnboardingCompleted: true);
+    Navigator.of(context).pop();
+  }
+
   @override
   Widget build(BuildContext context) {
     return ChangeNotifierProvider.value(
       value: _onboardingProvider,
       child: PopScope(
-        canPop: widget.allowExit,
+        // Intercept system back so leaving mid-tutorial persists completion —
+        // otherwise the forced flow re-fires on next launch. _completeOnboarding
+        // and _skipOnboarding pop directly (didPop == true) and skip this path.
+        canPop: false,
+        onPopInvokedWithResult: (didPop, _) {
+          if (didPop) return;
+          _skipOnboarding();
+        },
         child: Scaffold(
           backgroundColor: Colors.transparent,
           body: Container(
@@ -123,25 +139,23 @@ class _InteractiveDeviceOnboardingWrapperState extends State<InteractiveDeviceOn
                 child: _showIntro
                     ? OnboardingIntroScreen(
                         key: const ValueKey('intro'),
-                        allowExit: widget.allowExit,
                         onStart: _startTutorial,
+                        onSkip: _skipOnboarding,
                       )
                     : Column(
                         key: const ValueKey('steps'),
                         children: [
-                          // Back affordance only when the flow is dismissible (re-opened
-                          // from Settings); reserves a small top gap otherwise.
+                          // Always dismissible: a stuck step (e.g. the mic-test
+                          // waiting on a response) must never trap the user.
                           SizedBox(
-                            height: widget.allowExit ? 48 : 16,
-                            child: widget.allowExit
-                                ? Align(
-                                    alignment: Alignment.centerLeft,
-                                    child: IconButton(
-                                      icon: const Icon(Icons.arrow_back_ios_new, color: Colors.white, size: 20),
-                                      onPressed: () => Navigator.of(context).maybePop(),
-                                    ),
-                                  )
-                                : null,
+                            height: 48,
+                            child: Align(
+                              alignment: Alignment.centerLeft,
+                              child: IconButton(
+                                icon: const Icon(Icons.arrow_back_ios_new, color: Colors.white, size: 20),
+                                onPressed: _skipOnboarding,
+                              ),
+                            ),
                           ),
                           // Persistent progress indicator — stays fixed and animates the
                           // active dot in place while only the content below transitions.

--- a/app/lib/pages/onboarding/interactive_device_onboarding/widgets/onboarding_intro_screen.dart
+++ b/app/lib/pages/onboarding/interactive_device_onboarding/widgets/onboarding_intro_screen.dart
@@ -6,9 +6,9 @@ import 'package:omi/utils/l10n_extensions.dart';
 
 class OnboardingIntroScreen extends StatefulWidget {
   final VoidCallback onStart;
-  final bool allowExit;
+  final VoidCallback? onSkip;
 
-  const OnboardingIntroScreen({super.key, required this.onStart, this.allowExit = false});
+  const OnboardingIntroScreen({super.key, required this.onStart, this.onSkip});
 
   @override
   State<OnboardingIntroScreen> createState() => _OnboardingIntroScreenState();
@@ -43,15 +43,13 @@ class _OnboardingIntroScreenState extends State<OnboardingIntroScreen> with Sing
             children: [
               SizedBox(
                 height: 48,
-                child: widget.allowExit
-                    ? Align(
-                        alignment: Alignment.centerLeft,
-                        child: IconButton(
-                          icon: const Icon(Icons.arrow_back_ios_new, color: Colors.white, size: 20),
-                          onPressed: () => Navigator.of(context).maybePop(),
-                        ),
-                      )
-                    : null,
+                child: Align(
+                  alignment: Alignment.centerLeft,
+                  child: IconButton(
+                    icon: const Icon(Icons.arrow_back_ios_new, color: Colors.white, size: 20),
+                    onPressed: widget.onSkip ?? () => Navigator.of(context).maybePop(),
+                  ),
+                ),
               ),
               const Spacer(flex: 2),
               SizedBox(
@@ -104,7 +102,16 @@ class _OnboardingIntroScreenState extends State<OnboardingIntroScreen> with Sing
               ),
               const Spacer(flex: 3),
               OnboardingContinueButton(label: context.l10n.getStarted, onPressed: widget.onStart),
-              const SizedBox(height: 24),
+              const SizedBox(height: 8),
+              TextButton(
+                key: const Key('device_onboarding_skip_button'),
+                onPressed: widget.onSkip ?? () => Navigator.of(context).maybePop(),
+                child: Text(
+                  context.l10n.skipForNow,
+                  style: const TextStyle(color: Color(0xFF9E9E9E), fontSize: 15),
+                ),
+              ),
+              const SizedBox(height: 8),
             ],
           ),
         ),

--- a/app/test/widgets/onboarding_intro_skip_test.dart
+++ b/app/test/widgets/onboarding_intro_skip_test.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:omi/l10n/app_localizations.dart';
+import 'package:omi/pages/onboarding/interactive_device_onboarding/widgets/onboarding_intro_screen.dart';
+
+Widget _app(Widget child) {
+  return MaterialApp(
+    localizationsDelegates: const [
+      AppLocalizations.delegate,
+      GlobalMaterialLocalizations.delegate,
+      GlobalWidgetsLocalizations.delegate,
+      GlobalCupertinoLocalizations.delegate,
+    ],
+    supportedLocales: AppLocalizations.supportedLocales,
+    home: Scaffold(body: child),
+  );
+}
+
+void main() {
+  // Regression: the forced first-run tour soft-locked users when a step hung
+  // (e.g. the mic-test "processing your question"). The intro must always
+  // offer a skip, and the back arrow must always be present.
+  testWidgets('intro screen shows Skip for now below Get Started and fires onSkip', (tester) async {
+    var started = false;
+    var skipped = false;
+    await tester.pumpWidget(_app(OnboardingIntroScreen(
+      onStart: () => started = true,
+      onSkip: () => skipped = true,
+    )));
+    await tester.pump();
+
+    final skipFinder = find.byKey(const Key('device_onboarding_skip_button'));
+    expect(skipFinder, findsOneWidget);
+
+    // Back arrow is always visible (no allowExit gating anymore).
+    expect(find.byIcon(Icons.arrow_back_ios_new), findsOneWidget);
+
+    await tester.tap(skipFinder);
+    expect(skipped, isTrue);
+    expect(started, isFalse);
+  });
+
+  testWidgets('back arrow fires onSkip', (tester) async {
+    var skipped = false;
+    await tester.pumpWidget(_app(OnboardingIntroScreen(
+      onStart: () {},
+      onSkip: () => skipped = true,
+    )));
+    await tester.pump();
+
+    await tester.tap(find.byIcon(Icons.arrow_back_ios_new));
+    expect(skipped, isTrue);
+  });
+}


### PR DESCRIPTION
## Problem

User report (Android, new pendant): the mandatory "Get to Know Your Omi" tour soft-locks at the mic-test step ("processing your question"). The forced first-run had `PopScope(canPop: false)` and the back arrow gated on `allowExit` — no way out when a step hangs.

## Fix

The tour is now always leavable, from any point:

- **Intro screen**: "Skip for now" text button below Get Started (reuses the existing `skipForNow` l10n key, translated in all locales) + always-visible back arrow.
- **Every step**: back arrow always shown (previously Settings-reopen only).
- **System back**: intercepted via `PopScope.onPopInvokedWithResult` so leaving persists `deviceOnboardingCompleted` — the forced flow never re-fires on next launch, and the abandoned step is still tracked in analytics (existing dispose path).
- Skipping is not a dead end: the tutorial stays reachable from Settings → Device Tutorial (`allowExit` remains only as the analytics source flag).

## Tests

`test/widgets/onboarding_intro_skip_test.dart`: skip button visible + fires onSkip without starting; back arrow fires onSkip. Full `test/widgets/` + `test/unit/`: **537 passed**. Analyzer: no errors/warnings on touched files.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9389?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

