### PR TITLE
fix(desktop): recover dead mic on buffered PTT silent turns (#9081)

### DIFF
--- a/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
@@ -1466,6 +1466,10 @@ class PushToTalkManager: ObservableObject {
     if !Self.hubTurnHasSpeech(pcm16k: turnAudio) {
       let (peak, rms) = Self.audioEnergy(pcm16k: turnAudio)
       let dev = audioCaptureService?.currentDeviceDescription ?? "?"
+      // Mirror the primary hub path: repeated dead-mic turns must trip capture
+      // recovery here too, otherwise users whose turns land on the buffered
+      // warm-wait path get recovery_action=none forever (issue #9081).
+      let attemptRecovery = silentMicRecoveryPolicy.recordDiscardedTurn(totalSec: totalSec, peak: peak)
       DesktopDiagnosticsManager.shared.recordPTTSilentTurn(
         source: "buffered_hub",
         mode: finalizedMode,
@@ -1475,12 +1479,17 @@ class PushToTalkManager: ObservableObject {
         rms: rms,
         deviceDescription: dev,
         micPermissionGranted: hasMicPermission,
-        hubActive: true)
+        hubActive: true,
+        recoveryAction: attemptRecovery ? "capture_rebuild" : "none",
+        recoveryResult: attemptRecovery ? "attempted" : "not_attempted")
       log(
         "PushToTalkManager: discarding buffered hub turn — audio \(String(format: "%.2f", totalSec))s "
           + "peak=\(peak)/32767 rms=\(rms) device=[\(dev)] — not committing")
       if let turnID = currentVoiceTurnID {
         _ = RealtimeHubController.shared.cancelTurn(turnID: turnID)
+      }
+      if attemptRecovery {
+        requestCoreAudioCaptureRecovery(reason: "repeated dead-mic PTT turns", restartPTT: false, batchMode: false)
       }
       AnalyticsManager.shared.floatingBarPTTEnded(
         mode: finalizedMode, hadTranscript: false, transcriptLength: 0)
@@ -1501,6 +1510,7 @@ class PushToTalkManager: ObservableObject {
       transcribeBufferedWarmWaitAudio()
       return
     }
+    silentMicRecoveryPolicy.recordSuccessfulTurn()
     DesktopDiagnosticsManager.shared.recordPTTCommitted(mode: finalizedMode, hubActive: true)
     AnalyticsManager.shared.floatingBarPTTEnded(
       mode: finalizedMode, hadTranscript: true, transcriptLength: 0)
@@ -1516,6 +1526,9 @@ class PushToTalkManager: ObservableObject {
     let (totalSec, voicedSec) = Self.voicedAudioSeconds(pcm16k: audio)
     guard totalSec >= Self.minTurnAudioSeconds, voicedSec >= Self.minVoicedSeconds else {
       let (peak, rms) = Self.audioEnergy(pcm16k: audio)
+      // Same dead-mic recovery as the primary omni/batch path — the warm-wait
+      // fallback was previously the one silent-turn exit with no recovery (#9081).
+      let attemptRecovery = silentMicRecoveryPolicy.recordDiscardedTurn(totalSec: totalSec, peak: peak)
       DesktopDiagnosticsManager.shared.recordPTTSilentTurn(
         source: "warm_wait_fallback",
         mode: finalizedMode,
@@ -1525,11 +1538,16 @@ class PushToTalkManager: ObservableObject {
         rms: rms,
         deviceDescription: audioCaptureService?.currentDeviceDescription,
         micPermissionGranted: hasMicPermission,
-        hubActive: false)
+        hubActive: false,
+        recoveryAction: attemptRecovery ? "capture_rebuild" : "none",
+        recoveryResult: attemptRecovery ? "attempted" : "not_attempted")
       log(
         "PushToTalkManager: discarding warm-wait fallback turn (audio \(String(format: "%.2f", totalSec))s, voiced \(String(format: "%.2f", voicedSec))s)")
       AnalyticsManager.shared.floatingBarPTTEnded(
         mode: finalizedMode, hadTranscript: false, transcriptLength: 0)
+      if attemptRecovery {
+        requestCoreAudioCaptureRecovery(reason: "repeated dead-mic PTT turns", restartPTT: false, batchMode: true)
+      }
       if let turnID = currentVoiceTurnID {
         voiceTurnCoordinator.send(
           .finish(
@@ -1538,6 +1556,7 @@ class PushToTalkManager: ObservableObject {
       }
       return
     }
+    silentMicRecoveryPolicy.recordSuccessfulTurn()
     guard let turnID = currentVoiceTurnID else { return }
     voiceTurnCoordinator.send(.selectRoute(turnID: turnID, route: .deepgramBatch))
     voiceTurnCoordinator.send(.transcriptionStarted(turnID: turnID))

--- a/desktop/macos/Desktop/Tests/PTTSilentTurnRecoveryWiringTests.swift
+++ b/desktop/macos/Desktop/Tests/PTTSilentTurnRecoveryWiringTests.swift
@@ -49,6 +49,7 @@ final class PTTSilentTurnRecoveryWiringTests: XCTestCase {
       .deletingLastPathComponent()
       .deletingLastPathComponent()
       .appendingPathComponent("Sources/FloatingControlBar/PushToTalkManager.swift")
+    // omi-test-quality: source-inspection -- static contract: every recordPTTSilentTurn discard site must wire recovery; PushToTalkManager is a @MainActor singleton with no behavioral seam
     return try String(contentsOf: url, encoding: .utf8)
   }
 }

--- a/desktop/macos/Desktop/Tests/PTTSilentTurnRecoveryWiringTests.swift
+++ b/desktop/macos/Desktop/Tests/PTTSilentTurnRecoveryWiringTests.swift
@@ -1,0 +1,54 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// Regression for issue #9081: PTT hold turns on a dead mic reported
+/// `recovery_action=none / recovery_result=not_attempted` for hundreds of users.
+///
+/// Root cause: the two buffered silent-turn exits — `commitBufferedRealtimeHubTurn`
+/// (`source: "buffered_hub"`) and `transcribeBufferedWarmWaitAudio`
+/// (`source: "warm_wait_fallback"`) — discarded near-silent turns without ever
+/// feeding `silentMicRecoveryPolicy.recordDiscardedTurn` or requesting a CoreAudio
+/// capture rebuild, unlike the primary hub/omni/batch gates. A user whose turns
+/// landed on the warm-wait path could never accumulate toward recovery.
+///
+/// `PushToTalkManager` is a `@MainActor` singleton not constructible in a unit test,
+/// so this is a source-scrape guard (same pattern as `PTTAudioCaptureRaceTests`).
+/// The invariant: every `recordPTTSilentTurn` discard site reports a recovery
+/// decision and every discard is counted by the recovery policy.
+final class PTTSilentTurnRecoveryWiringTests: XCTestCase {
+  func testEverySilentTurnSiteWiresRecovery() throws {
+    let source = try managerSource()
+
+    // Every silent-turn record must carry an explicit recovery decision — no site
+    // may fall back to the `recoveryAction: "none"` default silently.
+    let silentTurnCalls = source.components(separatedBy: "recordPTTSilentTurn(").count - 1
+    let recoveryDecisions = source.components(separatedBy: "recoveryResult: attemptRecovery").count - 1
+    XCTAssertEqual(
+      silentTurnCalls, recoveryDecisions,
+      "Every recordPTTSilentTurn site must pass recoveryResult: attemptRecovery")
+
+    // Every discard must be counted toward the dead-mic threshold so recovery can
+    // eventually trip, and each site attempts a capture rebuild once tripped.
+    XCTAssertEqual(
+      source.components(separatedBy: "silentMicRecoveryPolicy.recordDiscardedTurn").count - 1,
+      silentTurnCalls,
+      "Every silent-turn discard must call recordDiscardedTurn")
+    XCTAssertEqual(
+      source.components(separatedBy: "requestCoreAudioCaptureRecovery(reason: \"repeated dead-mic PTT turns\"").count - 1,
+      silentTurnCalls,
+      "Every silent-turn discard must guard a capture rebuild")
+
+    // The two previously-unwired buffered paths must now participate.
+    XCTAssertTrue(source.contains("source: \"buffered_hub\""))
+    XCTAssertTrue(source.contains("source: \"warm_wait_fallback\""))
+  }
+
+  private func managerSource() throws -> String {
+    let url = URL(fileURLWithPath: #filePath)
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+      .appendingPathComponent("Sources/FloatingControlBar/PushToTalkManager.swift")
+    return try String(contentsOf: url, encoding: .utf8)
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260710-ptt-buffered-silent-turn-recovery.json
+++ b/desktop/macos/changelog/unreleased/20260710-ptt-buffered-silent-turn-recovery.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed push-to-talk not recovering the mic after repeated silent turns when the realtime hub was still warming up"
+}


### PR DESCRIPTION
## Bug (#9081)
Desktop telemetry showed `ptt_audio_capture_silent_turn` with `recovery_action=none` / `recovery_result=not_attempted` for **169 users on 0.12.0 in hold mode** — push-to-talk turns recorded silence and nothing was done to recover the mic.

## Root cause
There are four silent-turn discard sites in `PushToTalkManager`. The two **primary** gates (`finalize()` hub path and the omni/batch path) already run `silentMicRecoveryPolicy.recordDiscardedTurn(...)` and, once consecutive dead-mic turns cross the threshold, call `requestCoreAudioCaptureRecovery(...)` to rebuild CoreAudio capture.

The two **buffered** exits did not:
- `commitBufferedRealtimeHubTurn()` — `source: "buffered_hub"`
- `transcribeBufferedWarmWaitAudio()` — `source: "warm_wait_fallback"`

Both are taken when the user releases before the realtime hub has finished warming — the common hold-mode path. They discarded near-silent turns and passed no recovery args, so `recordPTTSilentTurn` fell back to its `recoveryAction: "none"` default and the dead-mic counter never advanced. A user stuck on this path could never trip recovery.

## Fix
Wire both buffered paths into the exact same dead-mic recovery the primary paths use:
- count each discard via `recordDiscardedTurn`,
- attempt a capture rebuild once the threshold trips,
- emit the real `recovery_action`/`recovery_result`,
- reset the counter on the buffered success paths so a recovered mic clears accumulated dead turns.

Surgical, mirrors the existing sibling pattern. `additions+deletions = 80` across 1 source file + 1 test + 1 changelog.

## Test
`PTTSilentTurnRecoveryWiringTests` — since `PushToTalkManager` is a `@MainActor` singleton not constructible in a unit test, this follows the repo's existing source-scrape pattern (`PTTAudioCaptureRaceTests`): asserts every `recordPTTSilentTurn` site wires recovery, so a future unwired site fails CI.

## Product invariants affected

INV-VOICE-1 — no behavior change to the invariant. `VoiceTurnCoordinator` remains the sole voice-turn lifecycle owner: this PR adds no parallel lifecycle enum, current-turn boolean, or completion timer. `PTTSilentMicRecoveryPolicy` is a pre-existing dead-mic *counter* already driven by the primary hub/omni/batch paths; the two buffered paths now feed the same counter. Turn terminalization still goes through the existing `voiceTurnCoordinator.send(.finish(...))` / `cancelTurn` calls, unchanged, and no turn is declared successful earlier than before. `requestCoreAudioCaptureRecovery` acts on the microphone as a physical driver, which is the layer INV-VOICE-1 assigns it to.

INV-CHAT-1 — no behavior change to the invariant. This PR touches `PushToTalkManager.swift` (a guarded path) but only wires the existing dead-mic recovery policy into two buffered silent-turn exits. It introduces no new transcript/session store, no per-surface continuity ring, and no change to turn identity or journal ownership: discarded turns were already discarded, they are now merely *counted* toward the existing recovery threshold and reported with a truthful `recovery_action`/`recovery_result`.

## Verification
- Rebased onto current `main` (`3e55052acc`); `PushToTalkManager.swift` moved a lot since this branch opened, so the fix was re-validated against it.
- `xcrun swift build -c debug --package-path Desktop` → **Build complete!** (132s) post-rebase.
- Post-rebase the file has 4 `recordPTTSilentTurn` sites and all 4 now wire `recordDiscardedTurn` / `recoveryResult` / `requestCoreAudioCaptureRecovery` (4/4/4/4), so the wiring test's invariant holds against the new code.
- **UNVERIFIED at runtime:** could not reproduce a physical dead-mic + hub-warm-wait turn end-to-end. The behavioral guard is `Desktop Swift Build & Tests` + the source-scrape wiring test.

🤖 automated by hourly watchdog.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9390?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


