### PR TITLE
fix(desktop/perm-06): re-pass automation port on non-prod Quit & Reopen relaunch

### DIFF
--- a/desktop/macos/Desktop/Sources/AppState/AppState+SystemActions.swift
+++ b/desktop/macos/Desktop/Sources/AppState/AppState+SystemActions.swift
@@ -77,7 +77,13 @@ extension AppState {
     // Use a shell script to wait briefly, then relaunch the app
     let task = Process()
     task.executableURL = URL(fileURLWithPath: "/bin/sh")
-    task.arguments = ["-c", "sleep 0.5 && open \"\(relaunchURL.path)\""]
+    task.arguments = [
+      "-c",
+      Self.relaunchCommand(
+        appPath: relaunchURL.path,
+        isNonProduction: AppBuild.isNonProduction,
+        automationPort: DesktopAutomationLaunchOptions.port),
+    ]
 
     do {
       try task.run()
@@ -90,6 +96,28 @@ extension AppState {
     } catch {
       log("Failed to schedule restart: \(error)")
     }
+  }
+
+  /// Builds the `/bin/sh -c` payload that relaunches the app after a short delay.
+  ///
+  /// On **non-production** builds the automation port is re-passed as an argv
+  /// (`--automation-port=`) so the reopened bundle rebinds the SAME port the harness
+  /// launched with. A plain `open <bundle>` carries no argv and no env, so on its own
+  /// the reopened app would fall back to a launchd-session-inherited
+  /// `OMI_AUTOMATION_PORT` (or the default port), and the automation harness, still
+  /// polling the pre-quit port, would find nothing after Quit & Reopen (PERM-06). argv
+  /// is the highest-precedence port source, so it wins over any inherited env. The
+  /// production relaunch stays a plain `open` and is unchanged.
+  nonisolated static func relaunchCommand(
+    appPath: String,
+    isNonProduction: Bool,
+    automationPort: UInt16
+  ) -> String {
+    var openCommand = "open \"\(appPath)\""
+    if isNonProduction {
+      openCommand += " --args \(DesktopAutomationLaunchOptions.portPrefix)\(automationPort)"
+    }
+    return "sleep 0.5 && \(openCommand)"
   }
 
   /// Reset onboarding state for the current app only, then restart.

--- a/desktop/macos/Desktop/Tests/RestartRelaunchCommandTests.swift
+++ b/desktop/macos/Desktop/Tests/RestartRelaunchCommandTests.swift
@@ -1,0 +1,58 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// PERM-06: after a Quit & Reopen the reopened bundle must stay reachable on the
+/// harness's *original* automation port.
+///
+/// The bug (Codex Wave 18 FAIL): `AppState.restartApp()` relaunches via a bare
+/// `open <bundle>` — no argv, no env. The bridge resolves its port argv → env →
+/// default, so the reopened app fell back to whatever `OMI_AUTOMATION_PORT` the
+/// launchd session carried (or 47777), NOT the port the harness launched with
+/// (e.g. 47894 via `--automation-port=`). The harness kept polling the pre-quit
+/// port, found no listener, and could not prove signed-in/onboarded continuity.
+///
+/// The fix re-passes the port as an argv on the non-prod relaunch, since argv is
+/// the highest-precedence port source and beats any inherited env. These pin the
+/// command the relaunch runs; the live stall→reopen path is the e2e / Codex lane
+/// (SKILL §2i). `restartApp()` itself can't be unit-run (it terminates the host).
+final class RestartRelaunchCommandTests: XCTestCase {
+
+  func testNonProdRelaunchRePassesTheAutomationPort() {
+    let cmd = AppState.relaunchCommand(
+      appPath: "/Applications/omi-perm06v.app", isNonProduction: true, automationPort: 47894)
+    XCTAssertTrue(
+      cmd.contains("open \"/Applications/omi-perm06v.app\""),
+      "must open the resolved bundle path")
+    XCTAssertTrue(
+      cmd.contains("--args --automation-port=47894"),
+      "non-prod relaunch must re-pass the port so the reopened bundle rebinds it")
+  }
+
+  func testProdRelaunchIsBareOpenWithNoAutomationArgs() {
+    let cmd = AppState.relaunchCommand(
+      appPath: "/Applications/Omi.app", isNonProduction: false, automationPort: 47894)
+    XCTAssertEqual(
+      cmd, "sleep 0.5 && open \"/Applications/Omi.app\"",
+      "production relaunch must stay a plain `open` — no automation args, byte-identical to before")
+  }
+
+  func testDelayPrecedesOpenSoTheRestartResponseFlushes() {
+    // restartApp() terminates the process; the relaunch must be scheduled after the
+    // `sleep` so the in-flight HTTP/UI action completes before the app dies.
+    let cmd = AppState.relaunchCommand(
+      appPath: "/Applications/omi-x.app", isNonProduction: true, automationPort: 1)
+    guard let sleepIdx = cmd.range(of: "sleep"), let openIdx = cmd.range(of: "open") else {
+      return XCTFail("relaunch command must both sleep and open")
+    }
+    XCTAssertTrue(sleepIdx.lowerBound < openIdx.lowerBound, "the delay must precede the open")
+  }
+
+  func testPortFlagMatchesTheBridgesOwnPrefix() {
+    // The re-passed flag must be the exact one the bridge parses, so DRY on the
+    // single source of truth rather than a hardcoded string that could drift.
+    let cmd = AppState.relaunchCommand(
+      appPath: "/Applications/omi-x.app", isNonProduction: true, automationPort: 40000)
+    XCTAssertTrue(cmd.contains("\(DesktopAutomationLaunchOptions.portPrefix)40000"))
+  }
+}

--- a/desktop/macos/e2e/SKILL.md
+++ b/desktop/macos/e2e/SKILL.md
@@ -233,19 +233,43 @@ The permission "Quit & Reopen" flow (shown after granting Accessibility / Screen
 calls `AppState.restartApp()` — relaunch the same bundle, keep the auth/onboarding session.
 `quit_and_reopen` (non-prod) triggers that exact path (not the onboarding-mutating
 `reset_onboarding`), delayed so the action's HTTP response flushes before the process
-terminates. Because the relaunch is `open <bundle>`, the reopened app derives its own
-automation port — read it from the app log (`DesktopAutomationBridge: listening on …`).
+terminates. The relaunch is `open <bundle>` and drops argv/env — but on non-prod builds
+`restartApp()` re-passes `--automation-port=<current port>` as an argv, so the reopened
+app **rebinds the SAME port** you launched with (argv beats any launchd-inherited
+`OMI_AUTOMATION_PORT`). Keep polling the original `OMI_AUTOMATION_PORT`; no rediscovery.
+
+Two traps make a naive `wait-ready` lie, so the recipe below guards against both:
+- **Wait for a *new* listener pid.** `quit_and_reopen` returns immediately and only
+  schedules the restart ~`delay_ms` later; the pre-quit process is still alive and
+  answering for ~1s. Poll until the pid *listening on the port* differs from the one
+  you captured before, or you'll assert the OLD process's state (false PASS). Track the
+  listener via `lsof -tiTCP:$PORT -sTCP:LISTEN`, not `pgrep` — a `pgrep -f` pattern also
+  matches the shell running this recipe.
+- **Poll with *fresh* `omi-ctl` calls.** The relaunch is a fresh process, so it mints a
+  new bridge auth token and writes it to the same port-keyed token file. A single
+  long-lived `omi-ctl` process caches the token from its first read, so it would keep
+  presenting the *stale* token and 401 forever (false FAIL). Each `./scripts/omi-ctl`
+  invocation is a fresh process that re-reads the token file — so loop over separate
+  calls, don't reuse one `wait-ready`.
 ```bash
 cd desktop/macos
-# record before-state, trigger the restart, then verify the reopened bundle
+export OMI_AUTOMATION_PORT=47894           # whatever port you launched the bundle with
+BEFORE_PID=$(lsof -tiTCP:$OMI_AUTOMATION_PORT -sTCP:LISTEN 2>/dev/null | head -1)
 ./scripts/omi-ctl state | python3 -c 'import json,sys; d=json.load(sys.stdin)["result"]; print("before", d["bundleIdentifier"], d["isSignedIn"], d["hasCompletedOnboarding"])'
-./scripts/omi-ctl action quit_and_reopen        # detail (all string values): {"restarting":"true", "bundle_id":…, "relaunch_path":…, "delay_ms":"400"}
-sleep 8                                          # terminate + relaunch + boot
-NEWPORT=$(grep -oE 'listening on http://127.0.0.1:[0-9]+' /private/tmp/omi-dev.log | tail -1 | grep -oE '[0-9]+$')
-OMI_AUTOMATION_PORT=$NEWPORT ./scripts/omi-ctl wait-ready | python3 -c 'import json,sys; d=json.load(sys.stdin)["result"]; print("after", d["bundleIdentifier"], d["isSignedIn"], d["hasCompletedOnboarding"])'
-#   assert: same bundleIdentifier, isSignedIn=true, hasCompletedOnboarding=true (session intact)
+./scripts/omi-ctl action quit_and_reopen        # detail: {"restarting":"true", "bundle_id":…, "relaunch_path":…, "delay_ms":"400"}
+# wait for the OLD listener to be replaced by a NEW one on the SAME port (fresh omi-ctl each try)
+for i in $(seq 1 60); do
+  PID=$(lsof -tiTCP:$OMI_AUTOMATION_PORT -sTCP:LISTEN 2>/dev/null | head -1)
+  if [ -n "$PID" ] && [ "$PID" != "$BEFORE_PID" ] && ./scripts/omi-ctl state >/dev/null 2>&1; then break; fi
+  sleep 1
+done
+./scripts/omi-ctl state | python3 -c 'import json,sys; d=json.load(sys.stdin)["result"]; print("after", d["bundleIdentifier"], d["isSignedIn"], d["hasCompletedOnboarding"], d["bridgePort"])'
+#   assert: same bundleIdentifier, isSignedIn=true, hasCompletedOnboarding=true, bridgePort=47894 (session intact, SAME port)
+# the reopened process's own argv carries the re-passed port (proves the fix):
+#   ps -o command= -p "$(lsof -tiTCP:$OMI_AUTOMATION_PORT -sTCP:LISTEN | head -1)"  → …/Omi Computer --automation-port=47894
 ```
-Hermetic ratchet: `xcrun swift test --package-path Desktop --filter QuitAndReopenActionTests`.
+Hermetic ratchets: `xcrun swift test --package-path Desktop --filter QuitAndReopenActionTests`
+and `--filter RestartRelaunchCommandTests` (non-prod relaunch re-passes the port as argv).
 
 ### The full loop
 ```bash


### PR DESCRIPTION
## What

The non-prod automation bridge exposes a `quit_and_reopen` action (PERM-06) that
drives the real permission-flow restart, `AppState.restartApp()`. That relaunch is a
bare `/bin/sh -c "sleep 0.5 && open \"<bundle>\""` — **no argv, no env**. The reopened
app therefore resolves its automation port from whatever `OMI_AUTOMATION_PORT` the
launchd user session happens to carry (or the default 47777), **not** the port the
harness launched with (e.g. 47894 via `--automation-port=`). A harness polling the
original port sees no listener after Quit & Reopen, `wait-ready` times out, and
same-bundle signed-in / onboarded continuity can't be proven.

## Fix

`AppState.restartApp()` now builds its relaunch command via a pure
`relaunchCommand(appPath:isNonProduction:automationPort:)`. On **non-prod** builds it
re-passes the current automation port as an argv:

```
open "<bundle>" --args --automation-port=<port>
```

argv is the highest-precedence port source in the bridge's resolver, so the reopened
bundle rebinds the **same** port the harness used — overriding any launchd-inherited
`OMI_AUTOMATION_PORT`. The **production** relaunch is untouched: `relaunchCommand`
returns the byte-identical `sleep 0.5 && open "<path>"` for `isNonProduction == false`.

## Why this shape (an earlier persist-based attempt was wrong)

I first tried persisting the last-bound port in UserDefaults and falling back to it in
the bridge's port resolver. Runtime testing disproved it: the launchd session here
carried `OMI_AUTOMATION_PORT=47812` (set out-of-band — no script does `launchctl
setenv`), and **env outranks a persisted value**, so the bare-`open` relaunch inherited
47812 and shadowed the persisted 47894. Only re-passing the port as argv — which
outranks the inherited env — reliably pins the reopened port. That approach was fully
reverted; this is the task's Option A.

## Tests

- `RestartRelaunchCommandTests` (new, 4): non-prod re-passes `--automation-port=<port>`;
  prod is byte-identical bare `open` (no automation args); the `sleep` precedes the
  `open`; the flag equals the bridge's own `portPrefix` (DRY, no drift). Pure helper —
  fails if the fix is reverted. (`restartApp()` itself can't be unit-run — it
  terminates the host — so the pure-command builder is the testability seam.)
- Full Desktop suite: 1749/1750 pass; the sole failure is
  `ActionItemsFTSRepairTests/testRepairToleratesMissingActionItemsFTSShadowTable`,
  already in `scripts/swift-test-skips.json` (macOS-26 system SQLite rejects
  `DELETE FROM sqlite_master`) and skipped in CI — unrelated.

## Verification (exercised, not just compiled)

Named bundle `omi-perm06v`, with the launchd session deliberately left carrying a
**different** port (`OMI_AUTOMATION_PORT=47812`) to prove the override:

1. Launched via `run.sh --yolo OMI_AUTOMATION_PORT=47894` → `open --args --automation-port=47894`; bridge on 47894, gate-0 `/state` signedIn+onboarded.
2. `quit_and_reopen` → `{restarting:true, relaunch_path:/Applications/omi-perm06v.app}`.
3. Listener on 47894 changes pid (18506 → 24479); the **reopened process's own argv** is `…/Omi Computer --automation-port=47894` — the re-pass, visible in `ps`.
4. **Env-override control:** port 47812 (launchd env) has zero omi listeners afterward — the old bare-`open` code would have bound 47812.
5. After `/state` (47894): same bundle, signedIn=true, onboarded=true, bridgePort=47894 — session intact on the same port.

## Invariants

Touches `desktop/macos/Desktop/Sources/**` → **INV-UI-1** (no purple): adds zero purple
literals; brand ratchet unaffected.

## Scope

Non-prod automation-bridge / dev-harness only; no user-facing behavior → `no-changelog-needed`.
Does not claim the PERM-06 acceptance row PASS — post-merge runtime re-verification is the Codex lane.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9391?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

