### PR TITLE
fix(backend): offload listen WebSocket connect-time blocking reads (#9239)

### DIFF
--- a/backend/routers/transcribe.py
+++ b/backend/routers/transcribe.py
@@ -802,8 +802,10 @@ async def _stream_handler(
         MessageServiceStatusEvent(event_type="service_status", status="initiating", status_text="Service Starting")
     )
 
-    # Create or get conversation ID early for audio chunk storage
-    private_cloud_sync_enabled = user_db.get_user_private_cloud_sync_enabled(uid)
+    # Create or get conversation ID early for audio chunk storage.
+    # These are synchronous Firestore/GCS reads on the connect path — offload them so a slow
+    # backend read cannot block the event loop for every other live connection (#9239).
+    private_cloud_sync_enabled = await run_blocking(db_executor, user_db.get_user_private_cloud_sync_enabled, uid)
 
     # Enable speaker identification when user has speech profile or private cloud sync
     has_speech_profile = False
@@ -812,7 +814,7 @@ async def _stream_handler(
         is_multi_channel=is_multi_channel,
         include_speech_profile=include_speech_profile,
     ):
-        has_speech_profile = get_user_has_speech_profile(uid)
+        has_speech_profile = await run_blocking(storage_executor, get_user_has_speech_profile, uid)
     session.speaker_id_enabled = should_enable_speaker_identification(
         use_custom_stt=use_custom_stt,
         private_cloud_sync_enabled=private_cloud_sync_enabled,

--- a/backend/tests/unit/test_transcribe_connect_offload_async.py
+++ b/backend/tests/unit/test_transcribe_connect_offload_async.py
@@ -1,0 +1,86 @@
+"""Structural test: the listen WebSocket handler offloads its connect-time blocking reads.
+
+_stream_handler in routers/transcribe.py is the async handler for the /listen WebSocket, so it sits
+on the real-time audio path shared by every live connection. At connect time it read the user's
+private-cloud-sync preference through the synchronous user_db.get_user_private_cloud_sync_enabled
+(a Firestore call in database/) and its speech-profile presence through get_user_has_speech_profile
+(a GCS blob existence check), both of which block the event loop (#9239). This test parses the
+source (no import) and asserts both are routed through an awaited run_blocking(executor, ...) and
+never called directly. The await check guards against a dangling coroutine (offloaded but not
+awaited).
+"""
+
+import ast
+from pathlib import Path
+
+BACKEND_DIR = Path(__file__).resolve().parents[2]
+TRANSCRIBE = BACKEND_DIR / 'routers' / 'transcribe.py'
+TARGET_FN = '_stream_handler'
+# blocking call -> executor pool it must be offloaded to (Firestore -> db, GCS/file -> storage)
+BLOCKING_CALLS = {
+    'get_user_private_cloud_sync_enabled': 'db_executor',
+    'get_user_has_speech_profile': 'storage_executor',
+}
+
+
+def _load_function(name):
+    tree = ast.parse(TRANSCRIBE.read_text(encoding='utf-8'))
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef)) and node.name == name:
+            return node
+    raise AssertionError(f'{name} not found in {TRANSCRIBE}')
+
+
+def _ref_name(node):
+    """Name for an ast.Name (.id) or ast.Attribute (.attr); None otherwise."""
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        return node.attr
+    return None
+
+
+def _direct_calls(fn_node, callee):
+    return [n for n in ast.walk(fn_node) if isinstance(n, ast.Call) and _ref_name(n.func) == callee]
+
+
+def _awaited_run_blocking_offloads(fn_node):
+    """Yield (executor_name, target_name) for each AWAITED run_blocking(executor, target, ...) call.
+
+    Only awaited calls count: a bare run_blocking(...) without await is a dangling coroutine that
+    never runs, so the offload would silently do nothing.
+    """
+    for node in ast.walk(fn_node):
+        if not isinstance(node, ast.Await):
+            continue
+        call = node.value
+        if not isinstance(call, ast.Call) or _ref_name(call.func) != 'run_blocking':
+            continue
+        if len(call.args) >= 2:
+            yield _ref_name(call.args[0]), _ref_name(call.args[1])
+
+
+def test_connect_reads_are_not_called_directly():
+    fn = _load_function(TARGET_FN)
+    for callee in BLOCKING_CALLS:
+        assert (
+            _direct_calls(fn, callee) == []
+        ), f'{callee} is called directly in {TARGET_FN}; it must be offloaded via run_blocking'
+
+
+def test_connect_reads_are_offloaded_and_awaited():
+    fn = _load_function(TARGET_FN)
+    targets = [target for _executor, target in _awaited_run_blocking_offloads(fn)]
+    for callee in BLOCKING_CALLS:
+        assert callee in targets, (
+            f'{callee} must be offloaded via an AWAITED run_blocking(..., {callee}, ...); '
+            f'awaited run_blocking targets found: {targets}'
+        )
+
+
+def test_offloads_use_expected_executor():
+    fn = _load_function(TARGET_FN)
+    for executor, target in _awaited_run_blocking_offloads(fn):
+        if target in BLOCKING_CALLS:
+            expected = BLOCKING_CALLS[target]
+            assert executor == expected, f'{target} must be offloaded to {expected}, not {executor}'


### PR DESCRIPTION
## What
The `/listen` WebSocket handler (`_stream_handler` in `backend/routers/transcribe.py`) performed two blocking reads **directly on the event loop** at connect time:

- `user_db.get_user_private_cloud_sync_enabled(uid)` — a synchronous Firestore `.get()` (`database/users.py`)
- `get_user_has_speech_profile(uid)` — a synchronous GCS blob `.exists()` check (`utils/other/storage.py`)

Both are now routed through an awaited `run_blocking(...)` on the appropriate pool (`db_executor` for Firestore, `storage_executor` for GCS).

## Why
From the issue (#9239):

> The listen WebSocket handler blocks the event loop on a synchronous Firestore preference read at connect time instead of offloading via run_blocking.

`backend/AGENTS.md` is explicit: *"Never call sync DB/storage/file functions directly inside `async def` — wrap with `await run_blocking(executor, func, args)`."* A slow Firestore/GCS read on the connect path blocks the event loop for **every other live connection** on that worker, not just the connecting user. The rest of the handler already follows this pattern (e.g. `get_user_speaker_embedding`, `get_profile_audio_if_exists`); these two connect-time reads were missed.

## What I verified
- Added `backend/tests/unit/test_transcribe_connect_offload_async.py` — an AST structural test (same pattern as the existing `test_phone_twiml_async.py`) asserting neither read is called directly and both are offloaded to the correct executor pool.
- **Regression check:** the new test **fails on pre-fix code** (2/3 assertions fail) and **passes after the fix** (3/3).
- `python3 -m py_compile routers/transcribe.py` — OK.
- Ran `tests/unit/test_transcribe_decisions.py` + `test_transcribe_connect_offload_async.py` — pass. (Two unrelated pre-existing failures in `test_listen_session_bootstrap.py` reproduce on clean `origin/main` and are untouched by this change.)

Behavior is unchanged for users — the same values are computed; they are now read off the event loop.

Auto-generated from issue feedback by the mini issues-improver. Review before merge.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9393?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

