### PR TITLE
Fix stale test_lock_bypass_fixes patch of removed is_trial_paywalled (#9357 drift)

### DIFF
--- a/backend/tests/unit/test_lock_bypass_fixes.py
+++ b/backend/tests/unit/test_lock_bypass_fixes.py
@@ -1062,18 +1062,19 @@ class TestScheduledDailySummaryLockFilter:
         unlocked_conv = _make_conversation(locked=False, conversation_id='conv-2')
         conversations_db.get_conversations = MagicMock(return_value=[locked_conv, unlocked_conv])
 
-        with patch('utils.other.notifications.is_trial_paywalled', return_value=False):
-            with patch('utils.other.notifications.try_acquire_daily_summary_lock', return_value=True):
-                with patch(
-                    'utils.other.notifications.generate_comprehensive_daily_summary',
-                    return_value={'headline': 'Test', 'day_emoji': '📅', 'overview': 'ok'},
-                ) as mock_gen:
-                    daily_summaries_db.create_daily_summary = MagicMock(return_value='summary-1')
-                    daily_summaries_db.get_daily_summary_by_date = MagicMock(return_value=None)
-                    with patch('utils.other.notifications.send_notification'):
-                        from utils.other.notifications import _send_summary_notification
+        # The daily recap is no longer gated on is_trial_paywalled (#9357 removed that call from
+        # _send_summary_notification), so this test only exercises the locked-conversation filter.
+        with patch('utils.other.notifications.try_acquire_daily_summary_lock', return_value=True):
+            with patch(
+                'utils.other.notifications.generate_comprehensive_daily_summary',
+                return_value={'headline': 'Test', 'day_emoji': '📅', 'overview': 'ok'},
+            ) as mock_gen:
+                daily_summaries_db.create_daily_summary = MagicMock(return_value='summary-1')
+                daily_summaries_db.get_daily_summary_by_date = MagicMock(return_value=None)
+                with patch('utils.other.notifications.send_notification'):
+                    from utils.other.notifications import _send_summary_notification
 
-                        _send_summary_notification(('test-uid', 'token', 'UTC'))
+                    _send_summary_notification(('test-uid', 'token', 'UTC'))
 
         # generate_comprehensive_daily_summary must be called only with unlocked conversations
         mock_gen.assert_called_once()
@@ -1089,12 +1090,13 @@ class TestScheduledDailySummaryLockFilter:
         conversations_db.get_conversations = MagicMock(return_value=[_make_conversation(locked=True)])
         daily_summaries_db.get_daily_summary_by_date = MagicMock(return_value=None)
 
-        with patch('utils.other.notifications.is_trial_paywalled', return_value=False):
-            with patch('utils.other.notifications.try_acquire_daily_summary_lock', return_value=True):
-                with patch('utils.other.notifications.generate_comprehensive_daily_summary') as mock_gen:
-                    from utils.other.notifications import _send_summary_notification
+        # Recap is no longer gated on is_trial_paywalled (#9357); only the all-locked early return
+        # is under test here.
+        with patch('utils.other.notifications.try_acquire_daily_summary_lock', return_value=True):
+            with patch('utils.other.notifications.generate_comprehensive_daily_summary') as mock_gen:
+                from utils.other.notifications import _send_summary_notification
 
-                    _send_summary_notification(('test-uid', 'token', 'UTC'))
+                _send_summary_notification(('test-uid', 'token', 'UTC'))
 
         # Should not call LLM when no unlocked conversations remain
         mock_gen.assert_not_called()


### PR DESCRIPTION
## Summary

`tests/unit/test_lock_bypass_fixes.py::TestScheduledDailySummaryLockFilter` fails on current `main` (in isolation and in the full unit suite), which reds the Backend unit suite on any full-suite PR.

## Root cause

#9357 ("stop gating the daily recap on the desktop trial paywall") removed the `is_trial_paywalled` call from `_send_summary_notification` in `utils/other/notifications.py`, so `utils.other.notifications` no longer exposes `is_trial_paywalled`. Both tests still did `patch('utils.other.notifications.is_trial_paywalled', ...)`, which raises `AttributeError: <module 'utils.other.notifications'> does not have the attribute 'is_trial_paywalled'`.

## Change

Remove the vestigial `is_trial_paywalled` patch from `test_scheduled_summary_excludes_locked` and `test_scheduled_summary_skips_when_all_locked`. The tests still cover the locked-conversation filtering behavior, which is their actual purpose.

## Testing

- `tests/unit/test_lock_bypass_fixes.py`: 61 passed (was 2 failed + 59 passed).
- The failure reproduces on plain `origin/main` and is fixed by this change.
- Ran black, py_compile, and check_module_stub_pollution; all clean.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9394?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

