### PR TITLE
test(desktop): unit-test-lane coverage — SET-05 Sentry beforeSend + TASK-07 mirrored task arrays

### DIFF
--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/TasksPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/TasksPage.swift
@@ -912,6 +912,25 @@ class TasksViewModel: ObservableObject {
         return base + (itemIndex + 1) * spacing
     }
 
+    /// Rewrites `array`'s `sortOrder` for every task id named in `order`, using the
+    /// single `sortOrder` banding helper. `moveTask` applies this to each source array
+    /// the displayed list can be backed by (`store.incompleteTasks`,
+    /// `filteredFromDatabase`, `searchResults`) so they agree on the new order — a write
+    /// to only one diverges when filters/search are active. Ids not in `order` keep
+    /// their existing sortOrder. Extracted so the mirrored-array invariant is
+    /// unit-testable (TASK-07 / BL-030).
+    nonisolated static func applyReorder(
+        _ order: [String], categoryIndex: Int, to array: inout [TaskActionItem]
+    ) {
+        let itemCount = order.count
+        for (index, taskId) in order.enumerated() {
+            let newSortOrder = Self.sortOrder(categoryIndex: categoryIndex, itemIndex: index, itemCount: itemCount)
+            if let i = array.firstIndex(where: { $0.id == taskId }) {
+                array[i].sortOrder = newSortOrder
+            }
+        }
+    }
+
     /// Move a task within a category
     func moveTask(_ task: TaskActionItem, toIndex targetIndex: Int, inCategory category: TaskCategory) {
         log("REORDER: moveTask(\(task.id), toIndex: \(targetIndex), inCategory: \(category.rawValue))")
@@ -933,23 +952,13 @@ class TasksViewModel: ObservableObject {
         // reassignment fires its own @Published; recomputeAllCaches at the end folds
         // them all into categorizedTasks.
         let categoryIndex = TaskCategory.allCases.firstIndex(of: category) ?? 0
-        let itemCount = order.count
-
-        func applyOrder(to array: inout [TaskActionItem]) {
-            for (index, taskId) in order.enumerated() {
-                let newSortOrder = Self.sortOrder(categoryIndex: categoryIndex, itemIndex: index, itemCount: itemCount)
-                if let i = array.firstIndex(where: { $0.id == taskId }) {
-                    array[i].sortOrder = newSortOrder
-                }
-            }
-        }
 
         var incomplete = store.incompleteTasks
-        applyOrder(to: &incomplete)
+        Self.applyReorder(order, categoryIndex: categoryIndex, to: &incomplete)
         store.incompleteTasks = incomplete
 
-        applyOrder(to: &filteredFromDatabase)
-        applyOrder(to: &searchResults)
+        Self.applyReorder(order, categoryIndex: categoryIndex, to: &filteredFromDatabase)
+        Self.applyReorder(order, categoryIndex: categoryIndex, to: &searchResults)
 
         // Recompute caches immediately so the UI updates. Suppress the async
         // SQLite requery — when filters are active, the requery would otherwise

--- a/desktop/macos/Desktop/Sources/OmiApp.swift
+++ b/desktop/macos/Desktop/Sources/OmiApp.swift
@@ -393,76 +393,15 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
       // sustained freezes — the ones users actually feel — are reported.
       options.appHangTimeoutInterval = isDev ? 0 : 3.0
       options.beforeSend = { event in
-        // Allow user feedback through from all builds (dev + prod)
-        if event.message?.formatted.hasPrefix("User Report") == true { return event }
-        // Never send other events from dev builds — they pollute production Sentry data
-        if isDev { return nil }
-        // Filter out HTTP errors targeting dev/local URLs — noise when tunnels or local backends are down
-        if let urlTag = event.tags?["url"],
-          urlTag.contains("localhost") || urlTag.contains("127.0.0.1")
-            || urlTag.contains("trycloudflare.com")
-        {
-          return nil
-        }
-        // Filter out transient network/socket errors captured as exceptions —
-        // offline, timeouts, dropped connections, cancellations. These are not
-        // actionable app bugs and dominate event volume. (logError filters the
-        // message-event path; this covers SDK-auto and legacy exception captures.)
-        // NSURLErrorDomain: -999 cancelled, -1001 timeout, -1003/-1004 host/connect,
-        // -1005 lost, -1009 offline, -1011 bad response, -1020 not allowed.
-        // NSPOSIXErrorDomain: 54 reset, 57 not connected, 89 cancelled.
-        let transientNetworkCodes: [(domain: String, codes: [String])] = [
-          (
-            "NSURLErrorDomain",
-            ["-999", "-1001", "-1003", "-1004", "-1005", "-1009", "-1011", "-1020"]
-          ),
-          ("NSPOSIXErrorDomain", ["54", "57", "89"]),
-        ]
-        if let exceptions = event.exceptions,
-          exceptions.contains(where: { exc in
-            let value = exc.value
-            return transientNetworkCodes.contains { entry in
-              exc.type == entry.domain
-                && entry.codes.contains { value.contains("Code=\($0)") || value.contains("Code: \($0)") }
-            }
-          })
-        {
-          return nil
-        }
-        // Filter out backend Gemini key-expiry/auth failures. These mean the
-        // server-side API key needs rotation — a backend config issue, not a
-        // per-client bug. A single expired key otherwise floods Sentry with one
-        // event per request across every user.
-        if let message = event.message?.formatted {
-          let lower = message.lowercased()
-          if lower.contains("api key expired") || lower.contains("renew the api key")
-            || lower.contains("api_key_invalid")
-            // GeminiClient maps raw backend auth failures (unauthorized / permission denied /
-            // api key / forbidden) to this user-facing string before it reaches Sentry, so the
-            // raw-message checks above miss it. Same root cause (server-side key needs rotation),
-            // same flood (one bad key emits one event per task-extraction frame for every user).
-            || lower.contains("ai service authentication error")
-            // Backend rejects the auth header on batch (PTT) transcription with a 401
-            // INVALID_AUTH / "Invalid credentials." body — a transient stale-token or BYOK
-            // misconfig, not a per-client app bug. The 30s refresh timer recovers it; left
-            // unfiltered it floods Sentry (one event per failed batch). Same class as the
-            // AuthError.notSignedIn filter below.
-            || lower.contains("invalid_auth")
-          {
-            return nil
-          }
-        }
-        // Filter out AuthError.notSignedIn — this is thrown when token refresh transiently
-        // fails (network blip, expired token mid-refresh). The user is still signed in per
-        // UserDefaults; the 30s refresh timer will retry. Not actionable as a Sentry error.
-        if let exceptions = event.exceptions,
-          exceptions.contains(where: { exc in
-            exc.type == "Omi_Computer.AuthError" && exc.value.contains("notSignedIn")
-          })
-        {
-          return nil
-        }
-        return event
+        // The drop decision is extracted to the pure `shouldDropSentryEvent` so the
+        // filter list is unit-testable without constructing Sentry events (SET-05).
+        let drop = Self.shouldDropSentryEvent(
+          isUserReport: event.message?.formatted.hasPrefix("User Report") == true,
+          isDev: isDev,
+          urlTag: event.tags?["url"],
+          messageFormatted: event.message?.formatted,
+          exceptions: (event.exceptions ?? []).map { (type: $0.type, value: $0.value) })
+        return drop ? nil : event
       }
     }
     log(
@@ -1606,5 +1545,63 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
       guard !Task.isCancelled else { return }
       await SettingsSyncManager.shared.syncFromServer()
     }
+  }
+}
+
+extension AppDelegate {
+  /// Pure Sentry `beforeSend` triage (SET-05): decides whether an event must be
+  /// dropped (`beforeSend` returns nil). Extracted from the SDK closure so the drop
+  /// list is unit-testable; it takes only the event fields the closure inspects, so
+  /// no Sentry `Event` needs constructing in tests. Keep in lockstep with the
+  /// `options.beforeSend` closure in `applicationDidFinishLaunching`.
+  static func shouldDropSentryEvent(
+    isUserReport: Bool,
+    isDev: Bool,
+    urlTag: String?,
+    messageFormatted: String?,
+    exceptions: [(type: String, value: String)]
+  ) -> Bool {
+    // Always keep user feedback (dev + prod).
+    if isUserReport { return false }
+    // Never send other events from dev builds — they pollute production Sentry data.
+    if isDev { return true }
+    // Drop HTTP errors targeting dev/local URLs — noise when tunnels or local backends are down.
+    if let urlTag,
+      urlTag.contains("localhost") || urlTag.contains("127.0.0.1")
+        || urlTag.contains("trycloudflare.com")
+    {
+      return true
+    }
+    // Drop transient network/socket errors captured as exceptions (offline, timeouts,
+    // dropped connections, cancellations) — not actionable, dominate event volume.
+    let transientNetworkCodes: [(domain: String, codes: [String])] = [
+      ("NSURLErrorDomain", ["-999", "-1001", "-1003", "-1004", "-1005", "-1009", "-1011", "-1020"]),
+      ("NSPOSIXErrorDomain", ["54", "57", "89"]),
+    ]
+    if exceptions.contains(where: { exc in
+      transientNetworkCodes.contains { entry in
+        exc.type == entry.domain
+          && entry.codes.contains { exc.value.contains("Code=\($0)") || exc.value.contains("Code: \($0)") }
+      }
+    }) {
+      return true
+    }
+    // Drop backend Gemini key-expiry/auth failures — server-side key rotation, not a
+    // per-client bug; one bad key otherwise floods Sentry with one event per request.
+    if let lower = messageFormatted?.lowercased(),
+      lower.contains("api key expired") || lower.contains("renew the api key")
+        || lower.contains("api_key_invalid")
+        || lower.contains("ai service authentication error")
+        || lower.contains("invalid_auth")
+    {
+      return true
+    }
+    // Drop AuthError.notSignedIn — transient refresh failure; the 30s timer retries.
+    if exceptions.contains(where: {
+      $0.type == "Omi_Computer.AuthError" && $0.value.contains("notSignedIn")
+    }) {
+      return true
+    }
+    return false
   }
 }

--- a/desktop/macos/Desktop/Tests/SentryBeforeSendScrubTests.swift
+++ b/desktop/macos/Desktop/Tests/SentryBeforeSendScrubTests.swift
@@ -1,0 +1,91 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// SET-05: the Sentry `beforeSend` drop list must scrub known-noisy / non-actionable
+/// events — dev-build events, localhost/tunnel-tagged HTTP errors, transient network
+/// codes, backend key-expiry messages, and transient `AuthError.notSignedIn` — while
+/// letting genuine production errors and user feedback through.
+///
+/// Pins `AppDelegate.shouldDropSentryEvent`, the pure decision extracted from the
+/// SDK `options.beforeSend` closure. `true` = the event is dropped (`beforeSend`
+/// returns nil).
+final class SentryBeforeSendScrubTests: XCTestCase {
+
+  private func drop(
+    isUserReport: Bool = false,
+    isDev: Bool = false,
+    url: String? = nil,
+    message: String? = nil,
+    exceptions: [(type: String, value: String)] = []
+  ) -> Bool {
+    AppDelegate.shouldDropSentryEvent(
+      isUserReport: isUserReport,
+      isDev: isDev,
+      urlTag: url,
+      messageFormatted: message,
+      exceptions: exceptions)
+  }
+
+  func testKeepsGenuineProductionEvent() {
+    XCTAssertFalse(drop(message: "TasksStore: failed to persist reorder"),
+      "a genuine prod error must reach Sentry")
+    XCTAssertFalse(drop(exceptions: [("Omi_Computer.SomeError", "boom")]),
+      "an unrecognized exception must reach Sentry")
+  }
+
+  func testUserReportIsKeptFromEveryBuildIncludingDev() {
+    XCTAssertFalse(drop(isUserReport: true, isDev: true),
+      "user feedback must reach Sentry even from dev builds")
+  }
+
+  func testDropsNonReportDevBuildEvents() {
+    XCTAssertTrue(drop(isDev: true, message: "dev crash noise"),
+      "non-report dev events pollute production Sentry data and must be dropped")
+  }
+
+  func testDropsLocalAndTunnelUrlTaggedErrors() {
+    for u in [
+      "http://localhost:8080/v1/x", "https://127.0.0.1:9000/y",
+      "https://abc-def.trycloudflare.com/z",
+    ] {
+      XCTAssertTrue(drop(url: u), "\(u) is a local/tunnel URL → drop")
+    }
+    XCTAssertFalse(drop(url: "https://api.omi.me/v1/tasks"),
+      "a real backend URL must not be dropped")
+  }
+
+  func testDropsTransientNetworkExceptionsByDomainAndCode() {
+    XCTAssertTrue(drop(exceptions: [("NSURLErrorDomain", "The request timed out. Code=-1001")]))
+    XCTAssertTrue(drop(exceptions: [("NSURLErrorDomain", "offline (Code: -1009)")]),
+      "both `Code=` and `Code: ` spellings must match")
+    XCTAssertTrue(drop(exceptions: [("NSPOSIXErrorDomain", "Connection reset Code=54")]))
+    XCTAssertFalse(drop(exceptions: [("NSURLErrorDomain", "SSL error Code=-1200")]),
+      "an unlisted URL error code must not be dropped")
+    XCTAssertFalse(drop(exceptions: [("NSPOSIXErrorDomain", "Code=-1001")]),
+      "a code only counts within its own error domain")
+  }
+
+  func testDropsBackendKeyExpiryAndAuthFailureMessages() {
+    for m in [
+      "Gemini API key expired", "please renew the api key", "reason: API_KEY_INVALID",
+      "AI service authentication error", "backend returned invalid_auth on batch",
+    ] {
+      XCTAssertTrue(drop(message: m), "\"\(m)\" is a server-side key issue → drop")
+    }
+  }
+
+  func testDropsTransientNotSignedInAuthErrorOnly() {
+    XCTAssertTrue(drop(exceptions: [("Omi_Computer.AuthError", "notSignedIn")]),
+      "notSignedIn is a transient refresh failure the 30s timer recovers")
+    XCTAssertFalse(drop(exceptions: [("Omi_Computer.AuthError", "keychainWriteFailed")]),
+      "other AuthError cases are actionable and must reach Sentry")
+  }
+
+  func testDropOrderKeepsUserReportAboveTheDevGate() {
+    // User reports are checked before the dev gate, so a dev-build user report survives.
+    XCTAssertFalse(drop(isUserReport: true, isDev: true, message: "User Report: broken"))
+    // And a dev-build non-report is still dropped even if it looks otherwise genuine.
+    XCTAssertTrue(drop(isUserReport: false, isDev: true, message: "genuine-looking error"))
+  }
+}

--- a/desktop/macos/Desktop/Tests/TaskReorderMirroredArraysTests.swift
+++ b/desktop/macos/Desktop/Tests/TaskReorderMirroredArraysTests.swift
@@ -1,0 +1,86 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// TASK-07: a reorder must keep the three source arrays the displayed task list can
+/// be backed by — `store.incompleteTasks`, `filteredFromDatabase`, `searchResults` —
+/// in agreement. `TasksViewModel.moveTask` writes the new sortOrders to all three via
+/// the single `applyReorder` helper; writing to only one diverges when filters/search
+/// are active (BL-030, fixed in #9121). These pin that helper's guarantees: the same
+/// order yields identical sortOrders for shared ids, monotonic with position, disjoint
+/// per category band, and leaves ids outside the order untouched.
+final class TaskReorderMirroredArraysTests: XCTestCase {
+
+  private func item(_ id: String, sortOrder: Int? = nil) -> TaskActionItem {
+    TaskActionItem(
+      id: id, description: id, completed: false,
+      createdAt: Date(timeIntervalSince1970: 0), dueAt: nil, sortOrder: sortOrder)
+  }
+
+  private func sortOrder(_ arr: [TaskActionItem], _ id: String) -> Int? {
+    arr.first { $0.id == id }?.sortOrder
+  }
+
+  func testSharedIdsGetIdenticalSortOrderAcrossArrays() {
+    // The three arrays hold overlapping-but-different subsets in shuffled positions,
+    // exactly the filters/search-active case BL-030 was about.
+    let order = ["a", "b", "c", "d"]
+    let categoryIndex = 1
+    var incomplete = [item("d"), item("a"), item("b"), item("c")]  // full set, shuffled
+    var filtered = [item("b"), item("a")]  // subset
+    var search = [item("c"), item("d"), item("a")]  // different subset
+
+    TasksViewModel.applyReorder(order, categoryIndex: categoryIndex, to: &incomplete)
+    TasksViewModel.applyReorder(order, categoryIndex: categoryIndex, to: &filtered)
+    TasksViewModel.applyReorder(order, categoryIndex: categoryIndex, to: &search)
+
+    for id in order {
+      let values = [
+        sortOrder(incomplete, id), sortOrder(filtered, id), sortOrder(search, id),
+      ].compactMap { $0 }
+      guard let first = values.first else { continue }
+      XCTAssertTrue(
+        values.allSatisfy { $0 == first },
+        "id \(id) must have the SAME sortOrder in every array that holds it; got \(values)")
+    }
+  }
+
+  func testSortOrderIsMonotonicAndUniqueWithOrderPosition() {
+    let order = ["a", "b", "c", "d"]
+    var arr = [item("c"), item("a"), item("d"), item("b")]
+    TasksViewModel.applyReorder(order, categoryIndex: 0, to: &arr)
+
+    let orders = order.compactMap { sortOrder(arr, $0) }
+    XCTAssertEqual(orders.count, order.count, "every reordered id gets a sortOrder")
+    XCTAssertEqual(
+      orders, orders.sorted(),
+      "sortOrder must increase with position in `order` so the displayed order matches")
+    XCTAssertEqual(Set(orders).count, orders.count, "sortOrders within a category must be unique")
+  }
+
+  func testIdsAbsentFromOrderKeepTheirSortOrder() {
+    // A task not part of the reordered category must not be re-banded — the reorder is
+    // scoped to `order`, so a stale/other-category row is left alone.
+    let order = ["a", "b"]
+    var arr = [item("a"), item("b"), item("z", sortOrder: 12345)]
+    TasksViewModel.applyReorder(order, categoryIndex: 2, to: &arr)
+
+    XCTAssertEqual(sortOrder(arr, "z"), 12345, "an id outside `order` must keep its sortOrder")
+    XCTAssertNotNil(sortOrder(arr, "a"), "an id in `order` is assigned a sortOrder")
+    XCTAssertNotNil(sortOrder(arr, "b"))
+  }
+
+  func testDifferentCategoriesBandIntoDisjointRanges() {
+    // categoryIndex bands sortOrders so categories never interleave; two arrays under
+    // different category indices must not collide.
+    let order = ["a", "b", "c"]
+    var cat0 = [item("a"), item("b"), item("c")]
+    var cat1 = [item("a"), item("b"), item("c")]
+    TasksViewModel.applyReorder(order, categoryIndex: 0, to: &cat0)
+    TasksViewModel.applyReorder(order, categoryIndex: 1, to: &cat1)
+
+    let cat0Max = cat0.compactMap { $0.sortOrder }.max() ?? .max
+    let cat1Min = cat1.compactMap { $0.sortOrder }.min() ?? .min
+    XCTAssertLessThan(cat0Max, cat1Min, "category 0's band must sit entirely below category 1's")
+  }
+}

--- a/desktop/macos/Desktop/Tests/TaskReorderMirroredArraysTests.swift
+++ b/desktop/macos/Desktop/Tests/TaskReorderMirroredArraysTests.swift
@@ -83,4 +83,25 @@ final class TaskReorderMirroredArraysTests: XCTestCase {
     let cat1Min = cat1.compactMap { $0.sortOrder }.min() ?? .min
     XCTAssertLessThan(cat0Max, cat1Min, "category 0's band must sit entirely below category 1's")
   }
+
+  /// BL-030 regression guard: `moveTask` must fan the reorder out to ALL THREE mirrored
+  /// arrays — dropping any one diverges when filters/search are active. `moveTask` is
+  /// `@MainActor` and needs the full store/state, so the fan-out is source-pinned by the
+  /// exact call sites (the helper's own correctness is covered behaviourally above).
+  func testMoveTaskFansReorderOutToAllThreeMirroredArrays() throws {
+    let source = try tasksPageSource()
+    for target in ["&incomplete", "&filteredFromDatabase", "&searchResults"] {
+      XCTAssertTrue(
+        source.contains("Self.applyReorder(order, categoryIndex: categoryIndex, to: \(target))"),
+        "moveTask must apply the reorder to \(target) so all three mirrored arrays agree (BL-030)")
+    }
+  }
+
+  private func tasksPageSource() throws -> String {
+    let url = URL(fileURLWithPath: #filePath)
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+      .appendingPathComponent("Sources/MainWindow/Pages/TasksPage.swift")
+    return try String(contentsOf: url, encoding: .utf8)
+  }
 }

--- a/desktop/macos/Desktop/Tests/TasksSortOrderBandingTests.swift
+++ b/desktop/macos/Desktop/Tests/TasksSortOrderBandingTests.swift
@@ -123,8 +123,12 @@ final class TasksSortOrderBandingTests: XCTestCase {
         return try String(contentsOf: sourceURL)
     }
 
-    /// Both reorder sites must route through the shared helper, and the fixed
+    /// Both reorder sites must band through the shared helper, and the fixed
     /// `(index + 1) * 1000` / `(index + 1) * 1000` literals must be gone.
+    ///
+    /// The drag path bands via `applyReorder` (which `moveTask` delegates to so it
+    /// rewrites every mirrored array — see `TaskReorderMirroredArraysTests`); the sync
+    /// path bands via `collectSortOrderUpdates`. Both call `Self.sortOrder`.
     func testBothSortSitesUseSharedHelper() throws {
         let source = try tasksPageSource()
 
@@ -132,11 +136,17 @@ final class TasksSortOrderBandingTests: XCTestCase {
             source.contains("static func sortOrder(categoryIndex: Int, itemIndex: Int, itemCount: Int) -> Int"),
             "the shared sortOrder helper must exist so both sort sites agree (BL-016)")
 
-        // moveTask + collectSortOrderUpdates → two call sites.
+        // applyReorder (drag path) + collectSortOrderUpdates (sync path) → two call sites.
         let callSites = source.components(separatedBy: "Self.sortOrder(categoryIndex:").count - 1
         XCTAssertGreaterThanOrEqual(
             callSites, 2,
-            "both moveTask and collectSortOrderUpdates must call the shared helper (BL-016)")
+            "both reorder sites (applyReorder + collectSortOrderUpdates) must call the shared helper (BL-016)")
+
+        // moveTask must route its reorder through applyReorder, so its banding — and the
+        // mirrored-array agreement it guarantees — goes through the shared helper too.
+        XCTAssertTrue(
+            source.contains("Self.applyReorder("),
+            "moveTask must band via applyReorder rather than an inline scheme (BL-016 / TASK-07)")
 
         XCTAssertFalse(
             source.contains("categoryOffset + (index + 1) * 1000"),


### PR DESCRIPTION
## What

Closes the two remaining **unit-test-lane** acceptance rows in the macOS hardening
matrix — both were BLOCKED only because the invariant lived in code with no test seam,
not because of a runtime rig. Each is a behaviour-preserving extraction of a pure
helper plus a hermetic test.

### SET-05 — Sentry `beforeSend` scrub list is unit-tested
The `options.beforeSend` closure drops noisy / non-actionable events (dev-build events,
localhost/tunnel-tagged HTTP errors, transient `NSURLErrorDomain`/`NSPOSIXErrorDomain`
codes, backend key-expiry messages, transient `AuthError.notSignedIn`) while keeping
genuine errors and user feedback. The drop decision is now a pure
`AppDelegate.shouldDropSentryEvent(isUserReport:isDev:urlTag:messageFormatted:exceptions:)`;
the closure adapts the Sentry `Event` into those primitives and calls it. Tested by
`SentryBeforeSendScrubTests` (8) — every drop category, plus keep-genuine and
keep-user-report-even-in-dev — with no Sentry `Event` construction required.

### TASK-07 — the 3 mirrored task arrays agree after a reorder
`TasksViewModel.moveTask` must rewrite the sortOrder of every source array the displayed
list can be backed by — `store.incompleteTasks`, `filteredFromDatabase`, `searchResults`
— or they diverge when filters/search are active (BL-030, fixed #9121). The inline
`applyOrder` closure is extracted to a pure
`TasksViewModel.applyReorder(_ order:categoryIndex:to:)`; `moveTask` calls it for each
array. Tested by `TaskReorderMirroredArraysTests` (4): shared ids get identical
sortOrders across arrays, monotonic-and-unique with order position, disjoint category
bands, and ids outside the order are left untouched.

## Behaviour preservation

Both are pure extractions — no logic changed. `moveTask` still rewrites all three arrays
in the same order; the Sentry closure still drops exactly the same events. The BL-016
source-invariant `testBothSortSitesUseSharedHelper` was updated to follow the extraction:
it now also asserts `moveTask` bands via `Self.applyReorder(`, so both reorder sites
still provably route through the shared `sortOrder` helper (no inline scheme).

## Tests / verification

- New: `SentryBeforeSendScrubTests` (8), `TaskReorderMirroredArraysTests` (4).
- Updated: `TasksSortOrderBandingTests` BL-016 invariant (follows the refactor).
- Full Desktop suite: 1762 tests, 1 failure — the pre-existing CI-skipped
  `ActionItemsFTSRepairTests` (macOS-26 system SQLite rejects `DELETE FROM sqlite_master`,
  listed in `scripts/swift-test-skips.json`). Unrelated to this change.

## Product invariants affected

Touched source files fall under two invariant globs; both are **unaffected** — the
change is behaviour-preserving test coverage plus pure extractions:
- **INV-UI-1** (no purple; `Sources/**`): adds zero purple literals; brand ratchet unaffected.
- **INV-AUTH-1** (auth-session; matches `OmiApp.swift`): no auth/session/token logic
  changes. The `OmiApp.swift` edit only extracts the Sentry `beforeSend` drop-filter into
  a pure helper; the `AuthError.notSignedIn` drop is reproduced identically and the
  Firebase/`AuthService` bootstrap below it is untouched.

## Scope

Test coverage + behaviour-preserving pure extractions; no user-facing behaviour →
`no-changelog-needed`. Does not claim the SET-05/TASK-07 acceptance rows PASS —
matrix disposition is the intel lane.
