### PR TITLE
Fix mobile auth refresh 401 recovery loop

### DIFF
--- a/app/e2e/flows/ios-auth-refresh-canary.yaml
+++ b/app/e2e/flows/ios-auth-refresh-canary.yaml
@@ -1,0 +1,54 @@
+# Release canary: persisted TestFlight login -> forced refresh -> authenticated conversations
+
+version: 2
+name: ios-auth-refresh-canary
+description: Verify a persisted signed iOS session refreshes its Firebase token and loads conversations after relaunch
+app: com.friend.ios
+evidence:
+  video: true
+covers:
+  - app/lib/services/auth_service.dart
+  - app/lib/backend/http/shared.dart
+  - app/lib/backend/http/api/conversations.dart
+  - app/lib/providers/conversation_provider.dart
+  - app/lib/providers/auth_provider.dart
+  - app/lib/mobile/mobile_app.dart
+preconditions:
+  - Install the signed TestFlight release candidate on a physical iPhone
+  - Sign in and complete onboarding once with an account that has at least one conversation
+  - Force-quit the app before starting the canary
+
+steps:
+  - id: S1
+    name: Relaunch persisted session
+    do: "Launch the TestFlight app after the force-quit and wait for startup to complete. Startup forces a Firebase ID-token refresh for the restored user."
+    verify: true
+    expect:
+      - kind: interactive_count
+        min: 4
+    evidence:
+      - screenshot: step-S1.webp
+
+  - id: S2
+    name: Verify authenticated shell
+    do: "Verify the home screen is visible without showing Get Started or a sign-in prompt."
+    verify: true
+    evidence:
+      - screenshot: step-S2.webp
+
+  - id: S3
+    name: Verify conversation-list access
+    do: "Open the Conversations tab and verify at least one server-backed conversation appears. This proves the refreshed token authorized GET /v1/conversations."
+    verify: true
+    expect:
+      - kind: interactive_count
+        min: 4
+    evidence:
+      - screenshot: step-S3.webp
+
+  - id: S4
+    name: Verify stable refresh cadence
+    do: "Keep the app foregrounded for at least 45 seconds and verify the conversation list remains loaded with no repeated loading/reset cycle or sign-in transition."
+    verify: true
+    evidence:
+      - screenshot: step-S4.webp

--- a/app/integration_test/ios_auth_refresh_canary_test.dart
+++ b/app/integration_test/ios_auth_refresh_canary_test.dart
@@ -1,0 +1,59 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import 'package:omi/backend/http/api/conversations.dart';
+import 'package:omi/main.dart' as app;
+import 'package:omi/services/auth_service.dart';
+
+/// Signed-iOS auth canary for release candidates.
+///
+/// Preconditions: install the release candidate on an iPhone, sign in and
+/// complete onboarding once, then force-quit the app so Firebase must restore
+/// the persisted session on this run.
+///
+/// Run with `flutter test integration_test/ios_auth_refresh_canary_test.dart
+/// --flavor prod -d <physical-ios-device>` using the normal signed iOS setup.
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('persisted session refreshes and authorizes conversations', (
+    tester,
+  ) async {
+    expect(
+      Platform.isIOS,
+      isTrue,
+      reason: 'This release canary must run on signed iOS',
+    );
+
+    app.main();
+    for (var i = 0; i < 100; i++) {
+      await tester.pump(const Duration(milliseconds: 100));
+    }
+
+    expect(
+      AuthService.instance.isSignedIn(),
+      isTrue,
+      reason: 'The persisted Firebase session was not restored',
+    );
+
+    final token = await AuthService.instance.getIdToken();
+    expect(token, isNotNull, reason: 'Forced Firebase ID-token refresh failed');
+    expect(
+      token,
+      isNotEmpty,
+      reason: 'Forced Firebase ID-token refresh returned an empty token',
+    );
+
+    final conversations = await getConversationsResult(
+      limit: 1,
+      includeDiscarded: false,
+    );
+    expect(
+      conversations.ok,
+      isTrue,
+      reason: 'The refreshed session could not access /v1/conversations',
+    );
+  });
+}

--- a/app/lib/backend/http/shared.dart
+++ b/app/lib/backend/http/shared.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:flutter/foundation.dart';
 import 'package:http/http.dart' as http;
 import 'package:path/path.dart';
 
@@ -9,6 +10,7 @@ import 'package:omi/backend/http/clock_skew_detector.dart';
 import 'package:omi/backend/http/http_pool_manager.dart';
 import 'package:omi/backend/preferences.dart';
 import 'package:omi/env/env.dart';
+import 'package:omi/services/auth/auth_token_result.dart';
 import 'package:omi/services/auth_service.dart';
 import 'package:omi/utils/logger.dart';
 import 'package:omi/utils/platform/platform_manager.dart';
@@ -23,11 +25,11 @@ class ApiClient {
 }
 
 class AuthTokenUnavailableException implements Exception {
-  final String message;
-  AuthTokenUnavailableException([this.message = 'No auth token found']);
+  final AuthTokenResult result;
+  AuthTokenUnavailableException(this.result);
 
   @override
-  String toString() => 'AuthTokenUnavailableException: $message';
+  String toString() => 'AuthTokenUnavailableException(${result.runtimeType})';
 }
 
 // Normal-mode connectivity failures on mobile (no network, DNS failure,
@@ -52,8 +54,12 @@ bool _isTransientNetworkError(Object e) {
   return false;
 }
 
-Future<String> getAuthHeader() async {
-  DateTime? expiry = DateTime.fromMillisecondsSinceEpoch(SharedPreferencesUtil().tokenExpirationTime);
+Future<String> getAuthHeader({bool expireTerminalSession = true}) async {
+  if (!AuthService.instance.isSignedIn()) {
+    throw AuthTokenUnavailableException(const AuthTokenMissingUser());
+  }
+
+  final expiry = DateTime.fromMillisecondsSinceEpoch(SharedPreferencesUtil().tokenExpirationTime);
   bool hasAuthToken = SharedPreferencesUtil().authToken.isNotEmpty;
 
   bool isExpirationDateValid = !(expiry.isBefore(DateTime.now()) ||
@@ -61,25 +67,40 @@ Future<String> getAuthHeader() async {
       (expiry.isBefore(DateTime.now().add(const Duration(minutes: 5))) && expiry.isAfter(DateTime.now())));
 
   if (!hasAuthToken || !isExpirationDateValid) {
-    final refreshedToken = await AuthService.instance.getIdToken();
-    if (refreshedToken != null) {
-      SharedPreferencesUtil().authToken = refreshedToken;
-    } else if (expiry.isBefore(DateTime.now())) {
-      // Refresh failed AND token is already expired — clear the stale cached
-      // token so we don't keep retrying with an invalid bearer. Only clear
-      // truly expired tokens, not near-expiry ones in the 5-min buffer.
-      SharedPreferencesUtil().authToken = '';
+    final refreshResult = await AuthService.instance.refreshIdToken();
+    switch (refreshResult) {
+      case AuthTokenSuccess(:final token):
+        SharedPreferencesUtil().authToken = token;
+        break;
+      case AuthTokenTransientFailure():
+        if (expiry.isBefore(DateTime.now())) {
+          // Preserve a still-valid token during transient refresh trouble, but
+          // never reuse one whose expiration has already passed.
+          SharedPreferencesUtil().authToken = '';
+        }
+        break;
+      case AuthTokenMissingUser():
+        throw AuthTokenUnavailableException(refreshResult);
+      case AuthTokenMissingToken():
+        if (expireTerminalSession) {
+          await AuthService.instance.expireSession(
+            const AuthSessionExpiredEvent(reason: AuthSessionExpirationReason.missingToken),
+          );
+        }
+        throw AuthTokenUnavailableException(refreshResult);
+      case AuthTokenTerminalFailure(:final code):
+        if (expireTerminalSession) {
+          await AuthService.instance.expireSession(
+            AuthSessionExpiredEvent(reason: AuthSessionExpirationReason.terminalTokenFailure, code: code),
+          );
+        }
+        throw AuthTokenUnavailableException(refreshResult);
     }
     hasAuthToken = SharedPreferencesUtil().authToken.isNotEmpty;
+    if (!hasAuthToken) throw AuthTokenUnavailableException(refreshResult);
   }
 
-  if (!hasAuthToken) {
-    if (AuthService.instance.isSignedIn()) {
-      // should only throw if the user is signed in but the token is not found
-      // if the user is not signed in, the token will always be empty
-      throw AuthTokenUnavailableException('No auth token found');
-    }
-  }
+  if (!hasAuthToken) throw AuthTokenUnavailableException(const AuthTokenMissingToken());
   return 'Bearer ${SharedPreferencesUtil().authToken}';
 }
 
@@ -89,6 +110,7 @@ Future<String> getAuthHeader() async {
 Future<Map<String, String>> buildHeaders({
   required bool requireAuthCheck,
   Map<String, String> fromHeaders = const {},
+  bool expireTerminalSession = true,
 }) async {
   final headers = <String, String>{
     'X-Request-Start-Time': (DateTime.now().millisecondsSinceEpoch / 1000).toString(),
@@ -99,18 +121,9 @@ Future<Map<String, String>> buildHeaders({
   };
 
   if (requireAuthCheck) {
-    try {
-      headers['Authorization'] = await getAuthHeader();
-    } on AuthTokenUnavailableException {
-      // Signed-in user has no usable token (refresh returned null for a
-      // transient or degraded reason). Proceed without Authorization; the
-      // downstream HTTP 401 path in makeApiCall already calls
-      // AuthService.signOut(), so recovery runs where it was already wired.
-      // We avoid forcing sign-out here because getIdToken() treats generic
-      // failures as transient (e.g. offline / platform hiccups) and leaves
-      // currentUser intact.
-      Logger.debug('No auth token available for request, proceeding without Authorization header');
-    }
+    // Authenticated requests must never degrade into anonymous traffic. A
+    // typed exception stops the request before it reaches the network.
+    headers['Authorization'] = await getAuthHeader(expireTerminalSession: expireTerminalSession);
   }
 
   return headers;
@@ -130,14 +143,124 @@ Future<http.StreamedResponse> makeRawApiCall({
   required String method,
   Map<String, String> headers = const {},
 }) async {
-  final builtHeaders = await buildHeaders(requireAuthCheck: _isRequiredAuthCheck(url), fromHeaders: headers);
-  var request = http.Request(method, Uri.parse(url));
-  request.headers.addAll(builtHeaders);
-  return HttpPoolManager.instance.sendStreaming(request);
+  final requireAuthCheck = _isRequiredAuthCheck(url);
+  try {
+    var builtHeaders = await buildHeaders(requireAuthCheck: requireAuthCheck, fromHeaders: headers);
+    var request = http.Request(method, Uri.parse(url));
+    request.headers.addAll(builtHeaders);
+    var response = await HttpPoolManager.instance.sendStreaming(request);
+    if (requireAuthCheck && response.statusCode == 401) {
+      response = await refreshAndReplayAfter401(
+        firstResponse: response,
+        statusCode: (value) => value.statusCode,
+        disposeUnauthorizedResponse: _drainStreamedResponse,
+        expireTerminalSession: true,
+        replay: () async {
+          builtHeaders = await buildHeaders(requireAuthCheck: true, fromHeaders: headers);
+          request = http.Request(method, Uri.parse(url));
+          request.headers.addAll(builtHeaders);
+          return HttpPoolManager.instance.sendStreaming(request);
+        },
+      );
+      if (response.statusCode == 401) return _authUnavailableStreamedResponse();
+    }
+    return response;
+  } on AuthTokenUnavailableException catch (e) {
+    await _handleAuthUnavailable(e, expireTerminalSession: true);
+    Logger.debug('Authenticated raw request blocked before send: ${e.result.runtimeType}');
+    return _authUnavailableStreamedResponse();
+  }
 }
+
+Future<void> _drainStreamedResponse(http.StreamedResponse response) async {
+  try {
+    await response.stream.drain<void>();
+  } catch (e) {
+    Logger.debug('Failed to drain unauthorized response: ${e.runtimeType}');
+  }
+}
+
+http.StreamedResponse _authUnavailableStreamedResponse() =>
+    http.StreamedResponse(const Stream<List<int>>.empty(), 401, reasonPhrase: 'Authentication unavailable');
 
 void _checkClockSkewResponse(http.Response response) {
   ClockSkewDetector.instance.checkResponse(response);
+}
+
+Future<void> _handleAuthUnavailable(
+  AuthTokenUnavailableException exception, {
+  required bool expireTerminalSession,
+}) async {
+  if (!expireTerminalSession) return;
+  final event = switch (exception.result) {
+    AuthTokenMissingUser() => null,
+    AuthTokenMissingToken() => const AuthSessionExpiredEvent(reason: AuthSessionExpirationReason.missingToken),
+    AuthTokenTerminalFailure(:final code) => AuthSessionExpiredEvent(
+        reason: AuthSessionExpirationReason.terminalTokenFailure,
+        code: code,
+      ),
+    _ => null,
+  };
+  if (event != null) await AuthService.instance.expireSession(event);
+}
+
+@visibleForTesting
+Future<T> refreshAndReplayAfter401<T>({
+  required T firstResponse,
+  required int Function(T response) statusCode,
+  required Future<T> Function() replay,
+  required bool expireTerminalSession,
+  Future<void> Function(T response)? disposeUnauthorizedResponse,
+  AuthService? authService,
+}) async {
+  final service = authService ?? AuthService.instance;
+  await disposeUnauthorizedResponse?.call(firstResponse);
+  final refresh = await service.refreshIdToken();
+  switch (refresh) {
+    case AuthTokenSuccess():
+      late T replayed;
+      try {
+        replayed = await replay();
+      } catch (_) {
+        service.recordAuthenticatedRequest401(recovered: false, outcome: 'replay_failed');
+        rethrow;
+      }
+      final recovered = statusCode(replayed) != 401;
+      if (!recovered) await disposeUnauthorizedResponse?.call(replayed);
+      service.recordAuthenticatedRequest401(
+        recovered: recovered,
+        outcome: recovered ? 'refresh_succeeded' : 'backend_rejected_refreshed_token',
+      );
+      if (!recovered && expireTerminalSession) {
+        await service.expireSession(
+          const AuthSessionExpiredEvent(reason: AuthSessionExpirationReason.backendRejectedRefreshedToken),
+        );
+      }
+      return replayed;
+    case AuthTokenTransientFailure():
+      service.recordAuthenticatedRequest401(recovered: false, outcome: 'refresh_transient_failure');
+      return firstResponse;
+    case AuthTokenMissingUser():
+      service.recordAuthenticatedRequest401(recovered: false, outcome: 'missing_user');
+      if (expireTerminalSession) {
+        await service.expireSession(const AuthSessionExpiredEvent(reason: AuthSessionExpirationReason.missingUser));
+      }
+      return firstResponse;
+    case AuthTokenMissingToken():
+      service.recordAuthenticatedRequest401(recovered: false, outcome: 'missing_token');
+      if (expireTerminalSession) {
+        await service.expireSession(const AuthSessionExpiredEvent(reason: AuthSessionExpirationReason.missingToken));
+      }
+      return firstResponse;
+    case AuthTokenTerminalFailure(:final code):
+      service.recordAuthenticatedRequest401(recovered: false, outcome: 'terminal_token_failure');
+      if (expireTerminalSession) {
+        await service.expireSession(
+          AuthSessionExpiredEvent(reason: AuthSessionExpirationReason.terminalTokenFailure, code: code),
+        );
+      }
+      return firstResponse;
+  }
 }
 
 Future<http.Response?> makeApiCall({
@@ -151,7 +274,11 @@ Future<http.Response?> makeApiCall({
 }) async {
   try {
     final bool requireAuthCheck = _isRequiredAuthCheck(url);
-    Map<String, String> builtHeaders = await buildHeaders(requireAuthCheck: requireAuthCheck, fromHeaders: headers);
+    Map<String, String> builtHeaders = await buildHeaders(
+      requireAuthCheck: requireAuthCheck,
+      fromHeaders: headers,
+      expireTerminalSession: signOutOn401,
+    );
 
     final effectiveTimeout =
         timeout ?? (method == 'GET' ? ApiClient.requestTimeoutRead : ApiClient.requestTimeoutWrite);
@@ -164,36 +291,31 @@ Future<http.Response?> makeApiCall({
     );
 
     if (requireAuthCheck && response.statusCode == 401) {
-      Logger.log('Token expired on 1st attempt');
-      SharedPreferencesUtil().authToken = await AuthService.instance.getIdToken() ?? '';
-      if (SharedPreferencesUtil().authToken.isNotEmpty) {
-        builtHeaders = await buildHeaders(requireAuthCheck: requireAuthCheck, fromHeaders: headers);
-        response = await HttpPoolManager.instance.send(
-          () => _buildRequest(url, builtHeaders, body, method),
-          timeout: effectiveTimeout,
-          retries: 0,
-        );
-        Logger.log('Token refreshed and request retried');
-        if (response.statusCode == 401 && signOutOn401) {
-          await AuthService.instance.signOut();
-          Logger.handle(
-            Exception('Authentication failed. Please sign in again.'),
-            StackTrace.current,
-            message: 'Authentication failed. Please sign in again.',
+      response = await refreshAndReplayAfter401(
+        firstResponse: response,
+        statusCode: (value) => value.statusCode,
+        expireTerminalSession: signOutOn401,
+        replay: () async {
+          builtHeaders = await buildHeaders(
+            requireAuthCheck: true,
+            fromHeaders: headers,
+            expireTerminalSession: signOutOn401,
           );
-        }
-      } else if (signOutOn401) {
-        await AuthService.instance.signOut();
-        Logger.handle(
-          Exception('Authentication failed. Please sign in again.'),
-          StackTrace.current,
-          message: 'Authentication failed. Please sign in again.',
-        );
-      }
+          return HttpPoolManager.instance.send(
+            () => _buildRequest(url, builtHeaders, body, method),
+            timeout: effectiveTimeout,
+            retries: 0,
+          );
+        },
+      );
     }
 
     _checkClockSkewResponse(response);
     return response;
+  } on AuthTokenUnavailableException catch (e) {
+    await _handleAuthUnavailable(e, expireTerminalSession: signOutOn401);
+    Logger.debug('Authenticated HTTP request blocked before send: ${e.result.runtimeType}');
+    return null;
   } catch (e, stackTrace) {
     Logger.debug('HTTP request failed: $e, $stackTrace');
     if (!_isTransientNetworkError(e)) {
@@ -307,41 +429,32 @@ Future<http.Response> makeMultipartApiCall({
     var response = await http.Response.fromStream(streamedResponse);
 
     if (requireAuthCheck && response.statusCode == 401) {
-      Logger.log('Token expired on 1st multipart attempt');
-      SharedPreferencesUtil().authToken = await AuthService.instance.getIdToken() ?? '';
-      if (SharedPreferencesUtil().authToken.isNotEmpty) {
-        builtHeaders = await buildHeaders(requireAuthCheck: requireAuthCheck, fromHeaders: headers);
-        request = await _buildMultipartRequest(
-          url: url,
-          files: files,
-          headers: builtHeaders,
-          fields: fields,
-          fileFieldName: fileFieldName,
-          method: method,
-        );
-        streamedResponse = await _sendMultipartWithProgress(request, onUploadProgress);
-        response = await http.Response.fromStream(streamedResponse);
-        Logger.log('Token refreshed and multipart request retried');
-        if (response.statusCode == 401) {
-          await AuthService.instance.signOut();
-          Logger.handle(
-            Exception('Authentication failed. Please sign in again.'),
-            StackTrace.current,
-            message: 'Authentication failed. Please sign in again.',
+      response = await refreshAndReplayAfter401(
+        firstResponse: response,
+        statusCode: (value) => value.statusCode,
+        expireTerminalSession: true,
+        replay: () async {
+          builtHeaders = await buildHeaders(requireAuthCheck: true, fromHeaders: headers);
+          request = await _buildMultipartRequest(
+            url: url,
+            files: files,
+            headers: builtHeaders,
+            fields: fields,
+            fileFieldName: fileFieldName,
+            method: method,
           );
-        }
-      } else {
-        await AuthService.instance.signOut();
-        Logger.handle(
-          Exception('Authentication failed. Please sign in again.'),
-          StackTrace.current,
-          message: 'Authentication failed. Please sign in again.',
-        );
-      }
+          streamedResponse = await _sendMultipartWithProgress(request, onUploadProgress);
+          return http.Response.fromStream(streamedResponse);
+        },
+      );
     }
 
     _checkClockSkewResponse(response);
     return response;
+  } on AuthTokenUnavailableException catch (e) {
+    await _handleAuthUnavailable(e, expireTerminalSession: true);
+    Logger.debug('Authenticated multipart request blocked before send: ${e.result.runtimeType}');
+    return http.Response('', 401, reasonPhrase: 'Authentication unavailable');
   } catch (e, stackTrace) {
     Logger.debug('Multipart HTTP request failed: $e, $stackTrace');
     if (!_isTransientNetworkError(e)) {
@@ -381,42 +494,33 @@ Future<http.Response> makeMultipartApiCallUnpooled({
     var response = await http.Response.fromStream(streamedResponse);
 
     if (requireAuthCheck && response.statusCode == 401) {
-      Logger.log('Token expired on 1st unpooled multipart attempt');
-      SharedPreferencesUtil().authToken = await AuthService.instance.getIdToken() ?? '';
-      if (SharedPreferencesUtil().authToken.isNotEmpty) {
-        builtHeaders = await buildHeaders(requireAuthCheck: requireAuthCheck, fromHeaders: headers);
-        request = await _buildMultipartRequest(
-          url: url,
-          files: files,
-          headers: builtHeaders,
-          fields: fields,
-          fileFieldName: fileFieldName,
-          method: method,
-        );
-        HttpPoolManager.stampRequestTime(request);
-        streamedResponse = await client.send(request).timeout(const Duration(minutes: 10));
-        response = await http.Response.fromStream(streamedResponse);
-        Logger.log('Token refreshed and unpooled multipart request retried');
-        if (response.statusCode == 401) {
-          await AuthService.instance.signOut();
-          Logger.handle(
-            Exception('Authentication failed. Please sign in again.'),
-            StackTrace.current,
-            message: 'Authentication failed. Please sign in again.',
+      response = await refreshAndReplayAfter401(
+        firstResponse: response,
+        statusCode: (value) => value.statusCode,
+        expireTerminalSession: true,
+        replay: () async {
+          builtHeaders = await buildHeaders(requireAuthCheck: true, fromHeaders: headers);
+          request = await _buildMultipartRequest(
+            url: url,
+            files: files,
+            headers: builtHeaders,
+            fields: fields,
+            fileFieldName: fileFieldName,
+            method: method,
           );
-        }
-      } else {
-        await AuthService.instance.signOut();
-        Logger.handle(
-          Exception('Authentication failed. Please sign in again.'),
-          StackTrace.current,
-          message: 'Authentication failed. Please sign in again.',
-        );
-      }
+          HttpPoolManager.stampRequestTime(request);
+          streamedResponse = await client.send(request).timeout(const Duration(minutes: 10));
+          return http.Response.fromStream(streamedResponse);
+        },
+      );
     }
 
     _checkClockSkewResponse(response);
     return response;
+  } on AuthTokenUnavailableException catch (e) {
+    await _handleAuthUnavailable(e, expireTerminalSession: true);
+    Logger.debug('Authenticated unpooled multipart request blocked before send: ${e.result.runtimeType}');
+    return http.Response('', 401, reasonPhrase: 'Authentication unavailable');
   } catch (e, stackTrace) {
     Logger.debug('Unpooled multipart HTTP request failed: $e, $stackTrace');
     if (!_isTransientNetworkError(e)) {
@@ -435,7 +539,8 @@ Stream<String> makeStreamingApiCall({
   String method = 'POST',
 }) async* {
   try {
-    final builtHeaders = await buildHeaders(requireAuthCheck: _isRequiredAuthCheck(url), fromHeaders: headers);
+    final requireAuthCheck = _isRequiredAuthCheck(url);
+    var builtHeaders = await buildHeaders(requireAuthCheck: requireAuthCheck, fromHeaders: headers);
 
     var request = http.Request(method, Uri.parse(url));
     request.headers.addAll(builtHeaders);
@@ -446,6 +551,26 @@ Stream<String> makeStreamingApiCall({
     }
 
     var streamedResponse = await HttpPoolManager.instance.sendStreaming(request);
+
+    if (requireAuthCheck && streamedResponse.statusCode == 401) {
+      streamedResponse = await refreshAndReplayAfter401(
+        firstResponse: streamedResponse,
+        statusCode: (value) => value.statusCode,
+        disposeUnauthorizedResponse: _drainStreamedResponse,
+        expireTerminalSession: true,
+        replay: () async {
+          builtHeaders = await buildHeaders(requireAuthCheck: true, fromHeaders: headers);
+          request = http.Request(method, Uri.parse(url));
+          request.headers.addAll(builtHeaders);
+          if (body.isNotEmpty) {
+            request.headers['Content-Type'] = 'application/json';
+            request.body = body;
+          }
+          return HttpPoolManager.instance.sendStreaming(request);
+        },
+      );
+      if (streamedResponse.statusCode == 401) return;
+    }
 
     if (streamedResponse.statusCode != 200) {
       Logger.error('Streaming request failed: ${streamedResponse.statusCode}');
@@ -482,6 +607,9 @@ Stream<String> makeStreamingApiCall({
     if (remainder.isNotEmpty) {
       yield remainder;
     }
+  } on AuthTokenUnavailableException catch (e) {
+    await _handleAuthUnavailable(e, expireTerminalSession: true);
+    Logger.debug('Authenticated streaming request blocked before send: ${e.result.runtimeType}');
   } catch (e, stackTrace) {
     Logger.error('Streaming request error: $e');
     if (!_isTransientNetworkError(e)) {
@@ -513,38 +641,25 @@ Stream<String> makeMultipartStreamingApiCall({
     var response = await HttpPoolManager.instance.sendStreaming(request);
 
     if (requireAuthCheck && response.statusCode == 401) {
-      Logger.log('Token expired on 1st multipart streaming attempt');
-      SharedPreferencesUtil().authToken = await AuthService.instance.getIdToken() ?? '';
-      if (SharedPreferencesUtil().authToken.isNotEmpty) {
-        builtHeaders = await buildHeaders(requireAuthCheck: requireAuthCheck, fromHeaders: headers);
-        request = await _buildMultipartRequest(
-          url: url,
-          files: files,
-          headers: builtHeaders,
-          fields: fields,
-          fileFieldName: fileFieldName,
-          method: 'POST',
-        );
-        response = await HttpPoolManager.instance.sendStreaming(request);
-        Logger.log('Token refreshed and multipart streaming request retried');
-        if (response.statusCode == 401) {
-          await AuthService.instance.signOut();
-          Logger.handle(
-            Exception('Authentication failed. Please sign in again.'),
-            StackTrace.current,
-            message: 'Authentication failed. Please sign in again.',
+      response = await refreshAndReplayAfter401(
+        firstResponse: response,
+        statusCode: (value) => value.statusCode,
+        disposeUnauthorizedResponse: _drainStreamedResponse,
+        expireTerminalSession: true,
+        replay: () async {
+          builtHeaders = await buildHeaders(requireAuthCheck: true, fromHeaders: headers);
+          request = await _buildMultipartRequest(
+            url: url,
+            files: files,
+            headers: builtHeaders,
+            fields: fields,
+            fileFieldName: fileFieldName,
+            method: 'POST',
           );
-          return;
-        }
-      } else {
-        await AuthService.instance.signOut();
-        Logger.handle(
-          Exception('Authentication failed. Please sign in again.'),
-          StackTrace.current,
-          message: 'Authentication failed. Please sign in again.',
-        );
-        return;
-      }
+          return HttpPoolManager.instance.sendStreaming(request);
+        },
+      );
+      if (response.statusCode == 401) return;
     }
 
     if (response.statusCode != 200) {
@@ -576,6 +691,9 @@ Stream<String> makeMultipartStreamingApiCall({
     if (remainder.isNotEmpty) {
       yield remainder;
     }
+  } on AuthTokenUnavailableException catch (e) {
+    await _handleAuthUnavailable(e, expireTerminalSession: true);
+    Logger.debug('Authenticated multipart streaming request blocked before send: ${e.result.runtimeType}');
   } catch (e, stackTrace) {
     Logger.error('Multipart streaming request error: $e');
     if (!_isTransientNetworkError(e)) {

--- a/app/lib/backend/preferences.dart
+++ b/app/lib/backend/preferences.dart
@@ -527,13 +527,18 @@ class SharedPreferencesUtil {
 
   // Pending memories - memories created offline that need to be synced
   List<Memory> get pendingMemories {
-    final memories = getStringList('pendingMemories');
-    return memories.map((e) => Memory.fromJson(jsonDecode(e))).toList();
+    final ownerUid = uid;
+    if (ownerUid.isEmpty) return [];
+    _scopeLegacyUserData(ownerUid);
+    final memories = getStringList(_userScopedKey('pendingMemories', ownerUid));
+    return memories.map((e) => Memory.fromJson(jsonDecode(e))).where((memory) => memory.uid == ownerUid).toList();
   }
 
   set pendingMemories(List<Memory> value) {
+    final ownerUid = uid;
+    if (ownerUid.isEmpty) return;
     final List<String> memories = value.map((e) => jsonEncode(e.toJson())).toList();
-    saveStringList('pendingMemories', memories);
+    saveStringList(_userScopedKey('pendingMemories', ownerUid), memories);
   }
 
   void addPendingMemory(Memory memory) {
@@ -542,14 +547,22 @@ class SharedPreferencesUtil {
     pendingMemories = memories;
   }
 
-  void removePendingMemory(String memoryId) {
-    final List<Memory> memories = pendingMemories;
+  void removePendingMemory(String memoryId, {String? ownerUid}) {
+    final owner = ownerUid ?? uid;
+    if (owner.isEmpty) return;
+    final encoded = getStringList(_userScopedKey('pendingMemories', owner));
+    final memories = encoded.map((e) => Memory.fromJson(jsonDecode(e))).toList();
     memories.removeWhere((m) => m.id == memoryId);
-    pendingMemories = memories;
+    saveStringList(
+      _userScopedKey('pendingMemories', owner),
+      memories.map((memory) => jsonEncode(memory.toJson())).toList(),
+    );
   }
 
   void clearPendingMemories() {
-    saveStringList('pendingMemories', []);
+    final ownerUid = uid;
+    if (ownerUid.isEmpty) return;
+    saveStringList(_userScopedKey('pendingMemories', ownerUid), []);
   }
 
   List<Person> get cachedPeople {
@@ -632,6 +645,76 @@ class SharedPreferencesUtil {
   set familyName(String value) => saveString('familyName', value);
 
   String get fullName => '$givenName $familyName'.trim();
+
+  /// Clears persisted user identity and server-backed display caches while
+  /// preserving device, onboarding, permissions, and offline recording state.
+  void clearUserDisplayCache() {
+    final ownerUid = uid;
+    if (ownerUid.isNotEmpty) _scopeLegacyUserData(ownerUid);
+    authToken = '';
+    tokenExpirationTime = 0;
+    uid = '';
+    email = '';
+    givenName = '';
+    familyName = '';
+    cachedConversations = <ServerConversation>[];
+    cachedMessages = <ServerMessage>[];
+    cachedPeople = <Person>[];
+    appsList = <App>[];
+    modifiedConversationDetails = null;
+    cachedSingleLanguageMode = false;
+    cachedTranscriptionVocabulary = <String>[];
+    userPrimaryLanguage = '';
+    hasSetPrimaryLanguage = false;
+    hasSpeakerProfile = false;
+    selectedChatAppId = 'no_selected';
+    lastUsedSummarizationAppId = '';
+    preferredSummarizationAppId = '';
+    calendarEnabled = false;
+    _preferences?.remove('cachedMemories');
+  }
+
+  String _userScopedKey(String baseKey, String ownerUid) => '$baseKey:$ownerUid';
+
+  void scopeLegacyUserDataForCurrentUser() {
+    final ownerUid = uid;
+    if (ownerUid.isNotEmpty) _scopeLegacyUserData(ownerUid);
+  }
+
+  void _scopeLegacyUserData(String ownerUid) {
+    final preferences = _preferences;
+    if (preferences == null || ownerUid.isEmpty) return;
+
+    final pendingKey = _userScopedKey('pendingMemories', ownerUid);
+    final legacyPending = preferences.getStringList('pendingMemories');
+    if (legacyPending != null) {
+      final scopedPending = preferences.getStringList(pendingKey) ?? const <String>[];
+      preferences.setStringList(pendingKey, {...scopedPending, ...legacyPending}.toList());
+    }
+    preferences.remove('pendingMemories');
+
+    final goalsKey = _userScopedKey('goals_tracker_local_goals', ownerUid);
+    final legacyGoals = preferences.getString('goals_tracker_local_goals');
+    if (legacyGoals != null) {
+      final scopedGoals = preferences.getString(goalsKey);
+      preferences.setString(goalsKey, _mergeJsonLists(scopedGoals, legacyGoals));
+    }
+    preferences.remove('goals_tracker_local_goals');
+  }
+
+  String _mergeJsonLists(String? existing, String legacy) {
+    try {
+      final existingItems = existing == null ? <dynamic>[] : jsonDecode(existing) as List<dynamic>;
+      final legacyItems = jsonDecode(legacy) as List<dynamic>;
+      final merged = <String, dynamic>{};
+      for (final item in [...existingItems, ...legacyItems]) {
+        merged[jsonEncode(item)] = item;
+      }
+      return jsonEncode(merged.values.toList());
+    } catch (_) {
+      return existing ?? legacy;
+    }
+  }
 
   String get foundOmiSource => getString('foundOmiSource');
 

--- a/app/lib/l10n/app_ar.arb
+++ b/app/lib/l10n/app_ar.arb
@@ -1,5 +1,6 @@
 {
     "@@locale": "ar",
+    "sessionExpiredSignInAgain": "انتهت صلاحية الجلسة — سجّل الدخول مرة أخرى.",
     "appTitle": "Omi",
     "conversationTab": "المحادثة",
     "transcriptTab": "النص المكتوب",

--- a/app/lib/l10n/app_be.arb
+++ b/app/lib/l10n/app_be.arb
@@ -1,5 +1,6 @@
 {
     "@@locale": "be",
+    "sessionExpiredSignInAgain": "Сеанс скончыўся — увайдзіце зноў.",
     "@@last_modified": "2024-12-26",
     "appTitle": "Omi",
     "@appTitle": {

--- a/app/lib/l10n/app_bg.arb
+++ b/app/lib/l10n/app_bg.arb
@@ -1,5 +1,6 @@
 {
     "@@locale": "bg",
+    "sessionExpiredSignInAgain": "Сесията изтече — влезте отново.",
     "appTitle": "Omi",
     "conversationTab": "Разговор",
     "transcriptTab": "Транскрипт",

--- a/app/lib/l10n/app_bn.arb
+++ b/app/lib/l10n/app_bn.arb
@@ -1,5 +1,6 @@
 {
     "@@locale": "bn",
+    "sessionExpiredSignInAgain": "সেশনের মেয়াদ শেষ হয়েছে — আবার সাইন ইন করুন।",
     "@@last_modified": "2024-12-26",
     "appTitle": "Omi",
     "@appTitle": {

--- a/app/lib/l10n/app_bs.arb
+++ b/app/lib/l10n/app_bs.arb
@@ -1,5 +1,6 @@
 {
     "@@locale": "bs",
+    "sessionExpiredSignInAgain": "Sesija je istekla — prijavite se ponovo.",
     "@@last_modified": "2024-12-26",
     "appTitle": "Omi",
     "@appTitle": {

--- a/app/lib/l10n/app_ca.arb
+++ b/app/lib/l10n/app_ca.arb
@@ -1,5 +1,6 @@
 {
     "@@locale": "ca",
+    "sessionExpiredSignInAgain": "La sessió ha caducat — torna a iniciar la sessió.",
     "appTitle": "Omi",
     "conversationTab": "Conversa",
     "transcriptTab": "Transcripció",

--- a/app/lib/l10n/app_cs.arb
+++ b/app/lib/l10n/app_cs.arb
@@ -1,5 +1,6 @@
 {
     "@@locale": "cs",
+    "sessionExpiredSignInAgain": "Platnost relace vypršela — přihlaste se znovu.",
     "appTitle": "Omi",
     "conversationTab": "Konverzace",
     "transcriptTab": "Přepis",

--- a/app/lib/l10n/app_da.arb
+++ b/app/lib/l10n/app_da.arb
@@ -1,5 +1,6 @@
 {
     "@@locale": "da",
+    "sessionExpiredSignInAgain": "Sessionen er udløbet — log ind igen.",
     "appTitle": "Omi",
     "conversationTab": "Samtale",
     "transcriptTab": "Udskrift",

--- a/app/lib/l10n/app_de.arb
+++ b/app/lib/l10n/app_de.arb
@@ -1,5 +1,6 @@
 {
     "@@locale": "de",
+    "sessionExpiredSignInAgain": "Deine Sitzung ist abgelaufen — melde dich erneut an.",
     "appTitle": "Omi",
     "conversationTab": "Unterhaltung",
     "transcriptTab": "Transkript",

--- a/app/lib/l10n/app_el.arb
+++ b/app/lib/l10n/app_el.arb
@@ -1,5 +1,6 @@
 {
     "@@locale": "el",
+    "sessionExpiredSignInAgain": "Η συνεδρία έληξε — συνδεθείτε ξανά.",
     "appTitle": "Omi",
     "conversationTab": "Συνομιλία",
     "transcriptTab": "Απομαγνητοφώνηση",

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -1,5 +1,9 @@
 {
     "@@locale": "en",
+    "sessionExpiredSignInAgain": "Session expired — sign in again.",
+    "@sessionExpiredSignInAgain": {
+        "description": "Message shown after an expired authenticated session returns the user to sign-in"
+    },
     "@@last_modified": "2024-12-26",
     "appTitle": "Omi",
     "@appTitle": {

--- a/app/lib/l10n/app_es.arb
+++ b/app/lib/l10n/app_es.arb
@@ -1,5 +1,6 @@
 {
     "@@locale": "es",
+    "sessionExpiredSignInAgain": "La sesión ha caducado — vuelve a iniciar sesión.",
     "appTitle": "Omi",
     "conversationTab": "Conversación",
     "transcriptTab": "Transcripción",

--- a/app/lib/l10n/app_et.arb
+++ b/app/lib/l10n/app_et.arb
@@ -1,5 +1,6 @@
 {
     "@@locale": "et",
+    "sessionExpiredSignInAgain": "Seanss aegus — logige uuesti sisse.",
     "appTitle": "Omi",
     "conversationTab": "Vestlus",
     "transcriptTab": "Transkriptsioon",

--- a/app/lib/l10n/app_fa.arb
+++ b/app/lib/l10n/app_fa.arb
@@ -1,5 +1,6 @@
 {
     "@@locale": "fa",
+    "sessionExpiredSignInAgain": "جلسه منقضی شد — دوباره وارد شوید.",
     "@@last_modified": "2024-12-26",
     "appTitle": "Omi",
     "@appTitle": {

--- a/app/lib/l10n/app_fi.arb
+++ b/app/lib/l10n/app_fi.arb
@@ -1,5 +1,6 @@
 {
     "@@locale": "fi",
+    "sessionExpiredSignInAgain": "Istunto on vanhentunut — kirjaudu uudelleen.",
     "appTitle": "Omi",
     "conversationTab": "Keskustelu",
     "transcriptTab": "Litterointi",

--- a/app/lib/l10n/app_fr.arb
+++ b/app/lib/l10n/app_fr.arb
@@ -1,5 +1,6 @@
 {
     "@@locale": "fr",
+    "sessionExpiredSignInAgain": "La session a expiré — reconnectez-vous.",
     "appTitle": "Omi",
     "conversationTab": "Conversation",
     "transcriptTab": "Transcription",

--- a/app/lib/l10n/app_he.arb
+++ b/app/lib/l10n/app_he.arb
@@ -1,5 +1,6 @@
 {
     "@@locale": "he",
+    "sessionExpiredSignInAgain": "ההפעלה פגה — יש להתחבר שוב.",
     "@@last_modified": "2024-12-26",
     "appTitle": "Omi",
     "@appTitle": {

--- a/app/lib/l10n/app_hi.arb
+++ b/app/lib/l10n/app_hi.arb
@@ -1,5 +1,6 @@
 {
     "@@locale": "hi",
+    "sessionExpiredSignInAgain": "सत्र की समय-सीमा समाप्त हो गई — फिर से साइन इन करें।",
     "appTitle": "ओमी",
     "conversationTab": "बातचीत",
     "transcriptTab": "प्रतिलेख",

--- a/app/lib/l10n/app_hr.arb
+++ b/app/lib/l10n/app_hr.arb
@@ -1,5 +1,6 @@
 {
     "@@locale": "hr",
+    "sessionExpiredSignInAgain": "Sesija je istekla — prijavite se ponovno.",
     "@@last_modified": "2024-12-26",
     "appTitle": "Omi",
     "@appTitle": {

--- a/app/lib/l10n/app_hu.arb
+++ b/app/lib/l10n/app_hu.arb
@@ -1,5 +1,6 @@
 {
     "@@locale": "hu",
+    "sessionExpiredSignInAgain": "A munkamenet lejárt — jelentkezz be újra.",
     "appTitle": "Omi",
     "conversationTab": "Beszélgetés",
     "transcriptTab": "Átirat",

--- a/app/lib/l10n/app_id.arb
+++ b/app/lib/l10n/app_id.arb
@@ -1,5 +1,6 @@
 {
     "@@locale": "id",
+    "sessionExpiredSignInAgain": "Sesi berakhir — masuk lagi.",
     "appTitle": "Omi",
     "conversationTab": "Percakapan",
     "transcriptTab": "Transkrip",

--- a/app/lib/l10n/app_it.arb
+++ b/app/lib/l10n/app_it.arb
@@ -1,5 +1,6 @@
 {
     "@@locale": "it",
+    "sessionExpiredSignInAgain": "La sessione è scaduta — accedi di nuovo.",
     "appTitle": "Omi",
     "conversationTab": "Conversazione",
     "transcriptTab": "Trascrizione",

--- a/app/lib/l10n/app_ja.arb
+++ b/app/lib/l10n/app_ja.arb
@@ -1,5 +1,6 @@
 {
     "@@locale": "ja",
+    "sessionExpiredSignInAgain": "セッションの有効期限が切れました。もう一度サインインしてください。",
     "appTitle": "Omi",
     "conversationTab": "会話",
     "transcriptTab": "文字起こし",

--- a/app/lib/l10n/app_kn.arb
+++ b/app/lib/l10n/app_kn.arb
@@ -1,5 +1,6 @@
 {
     "@@locale": "kn",
+    "sessionExpiredSignInAgain": "ಸೆಷನ್ ಅವಧಿ ಮುಗಿದಿದೆ — ಮತ್ತೆ ಸೈನ್ ಇನ್ ಮಾಡಿ.",
     "@@last_modified": "2024-12-26",
     "appTitle": "ಓಮಿ",
     "@appTitle": {

--- a/app/lib/l10n/app_ko.arb
+++ b/app/lib/l10n/app_ko.arb
@@ -1,5 +1,6 @@
 {
     "@@locale": "ko",
+    "sessionExpiredSignInAgain": "세션이 만료되었습니다. 다시 로그인하세요.",
     "appTitle": "Omi",
     "conversationTab": "대화",
     "transcriptTab": "녹취록",

--- a/app/lib/l10n/app_localizations.dart
+++ b/app/lib/l10n/app_localizations.dart
@@ -189,6 +189,12 @@ abstract class AppLocalizations {
     Locale('zh')
   ];
 
+  /// Message shown after an expired authenticated session returns the user to sign-in
+  ///
+  /// In en, this message translates to:
+  /// **'Session expired — sign in again.'**
+  String get sessionExpiredSignInAgain;
+
   /// The app title displayed in various places
   ///
   /// In en, this message translates to:

--- a/app/lib/l10n/app_localizations_ar.dart
+++ b/app/lib/l10n/app_localizations_ar.dart
@@ -9,6 +9,9 @@ class AppLocalizationsAr extends AppLocalizations {
   AppLocalizationsAr([String locale = 'ar']) : super(locale);
 
   @override
+  String get sessionExpiredSignInAgain => 'انتهت صلاحية الجلسة — سجّل الدخول مرة أخرى.';
+
+  @override
   String get appTitle => 'Omi';
 
   @override

--- a/app/lib/l10n/app_localizations_be.dart
+++ b/app/lib/l10n/app_localizations_be.dart
@@ -9,6 +9,9 @@ class AppLocalizationsBe extends AppLocalizations {
   AppLocalizationsBe([String locale = 'be']) : super(locale);
 
   @override
+  String get sessionExpiredSignInAgain => 'Сеанс скончыўся — увайдзіце зноў.';
+
+  @override
   String get appTitle => 'Omi';
 
   @override

--- a/app/lib/l10n/app_localizations_bg.dart
+++ b/app/lib/l10n/app_localizations_bg.dart
@@ -9,6 +9,9 @@ class AppLocalizationsBg extends AppLocalizations {
   AppLocalizationsBg([String locale = 'bg']) : super(locale);
 
   @override
+  String get sessionExpiredSignInAgain => 'Сесията изтече — влезте отново.';
+
+  @override
   String get appTitle => 'Omi';
 
   @override

--- a/app/lib/l10n/app_localizations_bn.dart
+++ b/app/lib/l10n/app_localizations_bn.dart
@@ -9,6 +9,9 @@ class AppLocalizationsBn extends AppLocalizations {
   AppLocalizationsBn([String locale = 'bn']) : super(locale);
 
   @override
+  String get sessionExpiredSignInAgain => 'সেশনের মেয়াদ শেষ হয়েছে — আবার সাইন ইন করুন।';
+
+  @override
   String get appTitle => 'Omi';
 
   @override

--- a/app/lib/l10n/app_localizations_bs.dart
+++ b/app/lib/l10n/app_localizations_bs.dart
@@ -9,6 +9,9 @@ class AppLocalizationsBs extends AppLocalizations {
   AppLocalizationsBs([String locale = 'bs']) : super(locale);
 
   @override
+  String get sessionExpiredSignInAgain => 'Sesija je istekla — prijavite se ponovo.';
+
+  @override
   String get appTitle => 'Omi';
 
   @override

--- a/app/lib/l10n/app_localizations_ca.dart
+++ b/app/lib/l10n/app_localizations_ca.dart
@@ -9,6 +9,9 @@ class AppLocalizationsCa extends AppLocalizations {
   AppLocalizationsCa([String locale = 'ca']) : super(locale);
 
   @override
+  String get sessionExpiredSignInAgain => 'La sessió ha caducat — torna a iniciar la sessió.';
+
+  @override
   String get appTitle => 'Omi';
 
   @override

--- a/app/lib/l10n/app_localizations_cs.dart
+++ b/app/lib/l10n/app_localizations_cs.dart
@@ -9,6 +9,9 @@ class AppLocalizationsCs extends AppLocalizations {
   AppLocalizationsCs([String locale = 'cs']) : super(locale);
 
   @override
+  String get sessionExpiredSignInAgain => 'Platnost relace vypršela — přihlaste se znovu.';
+
+  @override
   String get appTitle => 'Omi';
 
   @override

--- a/app/lib/l10n/app_localizations_da.dart
+++ b/app/lib/l10n/app_localizations_da.dart
@@ -9,6 +9,9 @@ class AppLocalizationsDa extends AppLocalizations {
   AppLocalizationsDa([String locale = 'da']) : super(locale);
 
   @override
+  String get sessionExpiredSignInAgain => 'Sessionen er udløbet — log ind igen.';
+
+  @override
   String get appTitle => 'Omi';
 
   @override

--- a/app/lib/l10n/app_localizations_de.dart
+++ b/app/lib/l10n/app_localizations_de.dart
@@ -9,6 +9,9 @@ class AppLocalizationsDe extends AppLocalizations {
   AppLocalizationsDe([String locale = 'de']) : super(locale);
 
   @override
+  String get sessionExpiredSignInAgain => 'Deine Sitzung ist abgelaufen — melde dich erneut an.';
+
+  @override
   String get appTitle => 'Omi';
 
   @override

--- a/app/lib/l10n/app_localizations_el.dart
+++ b/app/lib/l10n/app_localizations_el.dart
@@ -9,6 +9,9 @@ class AppLocalizationsEl extends AppLocalizations {
   AppLocalizationsEl([String locale = 'el']) : super(locale);
 
   @override
+  String get sessionExpiredSignInAgain => 'Η συνεδρία έληξε — συνδεθείτε ξανά.';
+
+  @override
   String get appTitle => 'Omi';
 
   @override

--- a/app/lib/l10n/app_localizations_en.dart
+++ b/app/lib/l10n/app_localizations_en.dart
@@ -9,6 +9,9 @@ class AppLocalizationsEn extends AppLocalizations {
   AppLocalizationsEn([String locale = 'en']) : super(locale);
 
   @override
+  String get sessionExpiredSignInAgain => 'Session expired — sign in again.';
+
+  @override
   String get appTitle => 'Omi';
 
   @override

--- a/app/lib/l10n/app_localizations_es.dart
+++ b/app/lib/l10n/app_localizations_es.dart
@@ -9,6 +9,9 @@ class AppLocalizationsEs extends AppLocalizations {
   AppLocalizationsEs([String locale = 'es']) : super(locale);
 
   @override
+  String get sessionExpiredSignInAgain => 'La sesión ha caducado — vuelve a iniciar sesión.';
+
+  @override
   String get appTitle => 'Omi';
 
   @override

--- a/app/lib/l10n/app_localizations_et.dart
+++ b/app/lib/l10n/app_localizations_et.dart
@@ -9,6 +9,9 @@ class AppLocalizationsEt extends AppLocalizations {
   AppLocalizationsEt([String locale = 'et']) : super(locale);
 
   @override
+  String get sessionExpiredSignInAgain => 'Seanss aegus — logige uuesti sisse.';
+
+  @override
   String get appTitle => 'Omi';
 
   @override

--- a/app/lib/l10n/app_localizations_fa.dart
+++ b/app/lib/l10n/app_localizations_fa.dart
@@ -9,6 +9,9 @@ class AppLocalizationsFa extends AppLocalizations {
   AppLocalizationsFa([String locale = 'fa']) : super(locale);
 
   @override
+  String get sessionExpiredSignInAgain => 'جلسه منقضی شد — دوباره وارد شوید.';
+
+  @override
   String get appTitle => 'Omi';
 
   @override

--- a/app/lib/l10n/app_localizations_fi.dart
+++ b/app/lib/l10n/app_localizations_fi.dart
@@ -9,6 +9,9 @@ class AppLocalizationsFi extends AppLocalizations {
   AppLocalizationsFi([String locale = 'fi']) : super(locale);
 
   @override
+  String get sessionExpiredSignInAgain => 'Istunto on vanhentunut — kirjaudu uudelleen.';
+
+  @override
   String get appTitle => 'Omi';
 
   @override

--- a/app/lib/l10n/app_localizations_fr.dart
+++ b/app/lib/l10n/app_localizations_fr.dart
@@ -9,6 +9,9 @@ class AppLocalizationsFr extends AppLocalizations {
   AppLocalizationsFr([String locale = 'fr']) : super(locale);
 
   @override
+  String get sessionExpiredSignInAgain => 'La session a expiré — reconnectez-vous.';
+
+  @override
   String get appTitle => 'Omi';
 
   @override

--- a/app/lib/l10n/app_localizations_he.dart
+++ b/app/lib/l10n/app_localizations_he.dart
@@ -9,6 +9,9 @@ class AppLocalizationsHe extends AppLocalizations {
   AppLocalizationsHe([String locale = 'he']) : super(locale);
 
   @override
+  String get sessionExpiredSignInAgain => 'ההפעלה פגה — יש להתחבר שוב.';
+
+  @override
   String get appTitle => 'Omi';
 
   @override

--- a/app/lib/l10n/app_localizations_hi.dart
+++ b/app/lib/l10n/app_localizations_hi.dart
@@ -9,6 +9,9 @@ class AppLocalizationsHi extends AppLocalizations {
   AppLocalizationsHi([String locale = 'hi']) : super(locale);
 
   @override
+  String get sessionExpiredSignInAgain => 'सत्र की समय-सीमा समाप्त हो गई — फिर से साइन इन करें।';
+
+  @override
   String get appTitle => 'ओमी';
 
   @override

--- a/app/lib/l10n/app_localizations_hr.dart
+++ b/app/lib/l10n/app_localizations_hr.dart
@@ -9,6 +9,9 @@ class AppLocalizationsHr extends AppLocalizations {
   AppLocalizationsHr([String locale = 'hr']) : super(locale);
 
   @override
+  String get sessionExpiredSignInAgain => 'Sesija je istekla — prijavite se ponovno.';
+
+  @override
   String get appTitle => 'Omi';
 
   @override

--- a/app/lib/l10n/app_localizations_hu.dart
+++ b/app/lib/l10n/app_localizations_hu.dart
@@ -9,6 +9,9 @@ class AppLocalizationsHu extends AppLocalizations {
   AppLocalizationsHu([String locale = 'hu']) : super(locale);
 
   @override
+  String get sessionExpiredSignInAgain => 'A munkamenet lejárt — jelentkezz be újra.';
+
+  @override
   String get appTitle => 'Omi';
 
   @override

--- a/app/lib/l10n/app_localizations_id.dart
+++ b/app/lib/l10n/app_localizations_id.dart
@@ -9,6 +9,9 @@ class AppLocalizationsId extends AppLocalizations {
   AppLocalizationsId([String locale = 'id']) : super(locale);
 
   @override
+  String get sessionExpiredSignInAgain => 'Sesi berakhir — masuk lagi.';
+
+  @override
   String get appTitle => 'Omi';
 
   @override

--- a/app/lib/l10n/app_localizations_it.dart
+++ b/app/lib/l10n/app_localizations_it.dart
@@ -9,6 +9,9 @@ class AppLocalizationsIt extends AppLocalizations {
   AppLocalizationsIt([String locale = 'it']) : super(locale);
 
   @override
+  String get sessionExpiredSignInAgain => 'La sessione è scaduta — accedi di nuovo.';
+
+  @override
   String get appTitle => 'Omi';
 
   @override

--- a/app/lib/l10n/app_localizations_ja.dart
+++ b/app/lib/l10n/app_localizations_ja.dart
@@ -9,6 +9,9 @@ class AppLocalizationsJa extends AppLocalizations {
   AppLocalizationsJa([String locale = 'ja']) : super(locale);
 
   @override
+  String get sessionExpiredSignInAgain => 'セッションの有効期限が切れました。もう一度サインインしてください。';
+
+  @override
   String get appTitle => 'Omi';
 
   @override

--- a/app/lib/l10n/app_localizations_kn.dart
+++ b/app/lib/l10n/app_localizations_kn.dart
@@ -9,6 +9,9 @@ class AppLocalizationsKn extends AppLocalizations {
   AppLocalizationsKn([String locale = 'kn']) : super(locale);
 
   @override
+  String get sessionExpiredSignInAgain => 'ಸೆಷನ್ ಅವಧಿ ಮುಗಿದಿದೆ — ಮತ್ತೆ ಸೈನ್ ಇನ್ ಮಾಡಿ.';
+
+  @override
   String get appTitle => 'ಓಮಿ';
 
   @override

--- a/app/lib/l10n/app_localizations_ko.dart
+++ b/app/lib/l10n/app_localizations_ko.dart
@@ -9,6 +9,9 @@ class AppLocalizationsKo extends AppLocalizations {
   AppLocalizationsKo([String locale = 'ko']) : super(locale);
 
   @override
+  String get sessionExpiredSignInAgain => '세션이 만료되었습니다. 다시 로그인하세요.';
+
+  @override
   String get appTitle => 'Omi';
 
   @override

--- a/app/lib/l10n/app_localizations_lt.dart
+++ b/app/lib/l10n/app_localizations_lt.dart
@@ -9,6 +9,9 @@ class AppLocalizationsLt extends AppLocalizations {
   AppLocalizationsLt([String locale = 'lt']) : super(locale);
 
   @override
+  String get sessionExpiredSignInAgain => 'Seanso laikas baigėsi — prisijunkite dar kartą.';
+
+  @override
   String get appTitle => 'Omi';
 
   @override

--- a/app/lib/l10n/app_localizations_lv.dart
+++ b/app/lib/l10n/app_localizations_lv.dart
@@ -9,6 +9,9 @@ class AppLocalizationsLv extends AppLocalizations {
   AppLocalizationsLv([String locale = 'lv']) : super(locale);
 
   @override
+  String get sessionExpiredSignInAgain => 'Sesija ir beigusies — pierakstieties vēlreiz.';
+
+  @override
   String get appTitle => 'Omi';
 
   @override

--- a/app/lib/l10n/app_localizations_mk.dart
+++ b/app/lib/l10n/app_localizations_mk.dart
@@ -9,6 +9,9 @@ class AppLocalizationsMk extends AppLocalizations {
   AppLocalizationsMk([String locale = 'mk']) : super(locale);
 
   @override
+  String get sessionExpiredSignInAgain => 'Сесијата истече — најавете се повторно.';
+
+  @override
   String get appTitle => 'Omi';
 
   @override

--- a/app/lib/l10n/app_localizations_mr.dart
+++ b/app/lib/l10n/app_localizations_mr.dart
@@ -9,6 +9,9 @@ class AppLocalizationsMr extends AppLocalizations {
   AppLocalizationsMr([String locale = 'mr']) : super(locale);
 
   @override
+  String get sessionExpiredSignInAgain => 'सत्राची मुदत संपली — पुन्हा साइन इन करा.';
+
+  @override
   String get appTitle => 'Omi';
 
   @override

--- a/app/lib/l10n/app_localizations_ms.dart
+++ b/app/lib/l10n/app_localizations_ms.dart
@@ -9,6 +9,9 @@ class AppLocalizationsMs extends AppLocalizations {
   AppLocalizationsMs([String locale = 'ms']) : super(locale);
 
   @override
+  String get sessionExpiredSignInAgain => 'Sesi tamat tempoh — log masuk semula.';
+
+  @override
   String get appTitle => 'Omi';
 
   @override

--- a/app/lib/l10n/app_localizations_nl.dart
+++ b/app/lib/l10n/app_localizations_nl.dart
@@ -9,6 +9,9 @@ class AppLocalizationsNl extends AppLocalizations {
   AppLocalizationsNl([String locale = 'nl']) : super(locale);
 
   @override
+  String get sessionExpiredSignInAgain => 'De sessie is verlopen — log opnieuw in.';
+
+  @override
   String get appTitle => 'Omi';
 
   @override

--- a/app/lib/l10n/app_localizations_no.dart
+++ b/app/lib/l10n/app_localizations_no.dart
@@ -9,6 +9,9 @@ class AppLocalizationsNo extends AppLocalizations {
   AppLocalizationsNo([String locale = 'no']) : super(locale);
 
   @override
+  String get sessionExpiredSignInAgain => 'Økten er utløpt — logg på igjen.';
+
+  @override
   String get appTitle => 'Omi';
 
   @override

--- a/app/lib/l10n/app_localizations_pl.dart
+++ b/app/lib/l10n/app_localizations_pl.dart
@@ -9,6 +9,9 @@ class AppLocalizationsPl extends AppLocalizations {
   AppLocalizationsPl([String locale = 'pl']) : super(locale);
 
   @override
+  String get sessionExpiredSignInAgain => 'Sesja wygasła — zaloguj się ponownie.';
+
+  @override
   String get appTitle => 'Omi';
 
   @override

--- a/app/lib/l10n/app_localizations_pt.dart
+++ b/app/lib/l10n/app_localizations_pt.dart
@@ -9,6 +9,9 @@ class AppLocalizationsPt extends AppLocalizations {
   AppLocalizationsPt([String locale = 'pt']) : super(locale);
 
   @override
+  String get sessionExpiredSignInAgain => 'A sessão expirou — inicie sessão novamente.';
+
+  @override
   String get appTitle => 'Omi';
 
   @override

--- a/app/lib/l10n/app_localizations_ro.dart
+++ b/app/lib/l10n/app_localizations_ro.dart
@@ -9,6 +9,9 @@ class AppLocalizationsRo extends AppLocalizations {
   AppLocalizationsRo([String locale = 'ro']) : super(locale);
 
   @override
+  String get sessionExpiredSignInAgain => 'Sesiunea a expirat — autentifică-te din nou.';
+
+  @override
   String get appTitle => 'Omi';
 
   @override

--- a/app/lib/l10n/app_localizations_ru.dart
+++ b/app/lib/l10n/app_localizations_ru.dart
@@ -9,6 +9,9 @@ class AppLocalizationsRu extends AppLocalizations {
   AppLocalizationsRu([String locale = 'ru']) : super(locale);
 
   @override
+  String get sessionExpiredSignInAgain => 'Сеанс истёк — войдите снова.';
+
+  @override
   String get appTitle => 'Omi';
 
   @override

--- a/app/lib/l10n/app_localizations_sk.dart
+++ b/app/lib/l10n/app_localizations_sk.dart
@@ -9,6 +9,9 @@ class AppLocalizationsSk extends AppLocalizations {
   AppLocalizationsSk([String locale = 'sk']) : super(locale);
 
   @override
+  String get sessionExpiredSignInAgain => 'Platnosť relácie vypršala — prihláste sa znova.';
+
+  @override
   String get appTitle => 'Omi';
 
   @override

--- a/app/lib/l10n/app_localizations_sl.dart
+++ b/app/lib/l10n/app_localizations_sl.dart
@@ -9,6 +9,9 @@ class AppLocalizationsSl extends AppLocalizations {
   AppLocalizationsSl([String locale = 'sl']) : super(locale);
 
   @override
+  String get sessionExpiredSignInAgain => 'Seja je potekla — znova se prijavite.';
+
+  @override
   String get appTitle => 'Omi';
 
   @override

--- a/app/lib/l10n/app_localizations_sr.dart
+++ b/app/lib/l10n/app_localizations_sr.dart
@@ -9,6 +9,9 @@ class AppLocalizationsSr extends AppLocalizations {
   AppLocalizationsSr([String locale = 'sr']) : super(locale);
 
   @override
+  String get sessionExpiredSignInAgain => 'Сесија је истекла — пријавите се поново.';
+
+  @override
   String get appTitle => 'Omi';
 
   @override

--- a/app/lib/l10n/app_localizations_sv.dart
+++ b/app/lib/l10n/app_localizations_sv.dart
@@ -9,6 +9,9 @@ class AppLocalizationsSv extends AppLocalizations {
   AppLocalizationsSv([String locale = 'sv']) : super(locale);
 
   @override
+  String get sessionExpiredSignInAgain => 'Sessionen har gått ut — logga in igen.';
+
+  @override
   String get appTitle => 'Omi';
 
   @override

--- a/app/lib/l10n/app_localizations_ta.dart
+++ b/app/lib/l10n/app_localizations_ta.dart
@@ -9,6 +9,9 @@ class AppLocalizationsTa extends AppLocalizations {
   AppLocalizationsTa([String locale = 'ta']) : super(locale);
 
   @override
+  String get sessionExpiredSignInAgain => 'அமர்வு காலாவதியானது — மீண்டும் உள்நுழையவும்.';
+
+  @override
   String get appTitle => 'Omi';
 
   @override

--- a/app/lib/l10n/app_localizations_te.dart
+++ b/app/lib/l10n/app_localizations_te.dart
@@ -9,6 +9,9 @@ class AppLocalizationsTe extends AppLocalizations {
   AppLocalizationsTe([String locale = 'te']) : super(locale);
 
   @override
+  String get sessionExpiredSignInAgain => 'సెషన్ గడువు ముగిసింది — మళ్లీ సైన్ ఇన్ చేయండి.';
+
+  @override
   String get appTitle => 'Omi';
 
   @override

--- a/app/lib/l10n/app_localizations_th.dart
+++ b/app/lib/l10n/app_localizations_th.dart
@@ -9,6 +9,9 @@ class AppLocalizationsTh extends AppLocalizations {
   AppLocalizationsTh([String locale = 'th']) : super(locale);
 
   @override
+  String get sessionExpiredSignInAgain => 'เซสชันหมดอายุ — ลงชื่อเข้าใช้อีกครั้ง';
+
+  @override
   String get appTitle => 'Omi';
 
   @override

--- a/app/lib/l10n/app_localizations_tl.dart
+++ b/app/lib/l10n/app_localizations_tl.dart
@@ -9,6 +9,9 @@ class AppLocalizationsTl extends AppLocalizations {
   AppLocalizationsTl([String locale = 'tl']) : super(locale);
 
   @override
+  String get sessionExpiredSignInAgain => 'Nag-expire ang session — mag-sign in ulit.';
+
+  @override
   String get appTitle => 'Omi';
 
   @override

--- a/app/lib/l10n/app_localizations_tr.dart
+++ b/app/lib/l10n/app_localizations_tr.dart
@@ -9,6 +9,9 @@ class AppLocalizationsTr extends AppLocalizations {
   AppLocalizationsTr([String locale = 'tr']) : super(locale);
 
   @override
+  String get sessionExpiredSignInAgain => 'Oturumun süresi doldu — tekrar giriş yapın.';
+
+  @override
   String get appTitle => 'Omi';
 
   @override

--- a/app/lib/l10n/app_localizations_uk.dart
+++ b/app/lib/l10n/app_localizations_uk.dart
@@ -9,6 +9,9 @@ class AppLocalizationsUk extends AppLocalizations {
   AppLocalizationsUk([String locale = 'uk']) : super(locale);
 
   @override
+  String get sessionExpiredSignInAgain => 'Сеанс завершено — увійдіть знову.';
+
+  @override
   String get appTitle => 'Omi';
 
   @override

--- a/app/lib/l10n/app_localizations_ur.dart
+++ b/app/lib/l10n/app_localizations_ur.dart
@@ -9,6 +9,9 @@ class AppLocalizationsUr extends AppLocalizations {
   AppLocalizationsUr([String locale = 'ur']) : super(locale);
 
   @override
+  String get sessionExpiredSignInAgain => 'سیشن کی میعاد ختم ہو گئی — دوبارہ سائن ان کریں۔';
+
+  @override
   String get appTitle => 'Omi';
 
   @override

--- a/app/lib/l10n/app_localizations_vi.dart
+++ b/app/lib/l10n/app_localizations_vi.dart
@@ -9,6 +9,9 @@ class AppLocalizationsVi extends AppLocalizations {
   AppLocalizationsVi([String locale = 'vi']) : super(locale);
 
   @override
+  String get sessionExpiredSignInAgain => 'Phiên đã hết hạn — hãy đăng nhập lại.';
+
+  @override
   String get appTitle => 'Omi';
 
   @override

--- a/app/lib/l10n/app_localizations_zh.dart
+++ b/app/lib/l10n/app_localizations_zh.dart
@@ -9,6 +9,9 @@ class AppLocalizationsZh extends AppLocalizations {
   AppLocalizationsZh([String locale = 'zh']) : super(locale);
 
   @override
+  String get sessionExpiredSignInAgain => '会话已过期，请重新登录。';
+
+  @override
   String get appTitle => 'Omi';
 
   @override

--- a/app/lib/l10n/app_lt.arb
+++ b/app/lib/l10n/app_lt.arb
@@ -1,5 +1,6 @@
 {
     "@@locale": "lt",
+    "sessionExpiredSignInAgain": "Seanso laikas baigėsi — prisijunkite dar kartą.",
     "@captureRecordingError": {
         "placeholders": {
             "error": {

--- a/app/lib/l10n/app_lv.arb
+++ b/app/lib/l10n/app_lv.arb
@@ -1,5 +1,6 @@
 {
     "@@locale": "lv",
+    "sessionExpiredSignInAgain": "Sesija ir beigusies — pierakstieties vēlreiz.",
     "appTitle": "Omi",
     "conversationTab": "Saruna",
     "transcriptTab": "Transkripcija",

--- a/app/lib/l10n/app_mk.arb
+++ b/app/lib/l10n/app_mk.arb
@@ -1,5 +1,6 @@
 {
     "@@locale": "mk",
+    "sessionExpiredSignInAgain": "Сесијата истече — најавете се повторно.",
     "@@last_modified": "2024-12-26",
     "appTitle": "Omi",
     "@appTitle": {

--- a/app/lib/l10n/app_mr.arb
+++ b/app/lib/l10n/app_mr.arb
@@ -1,5 +1,6 @@
 {
     "@@locale": "mr",
+    "sessionExpiredSignInAgain": "सत्राची मुदत संपली — पुन्हा साइन इन करा.",
     "@@last_modified": "2024-12-26",
     "appTitle": "Omi",
     "@appTitle": {

--- a/app/lib/l10n/app_ms.arb
+++ b/app/lib/l10n/app_ms.arb
@@ -1,5 +1,6 @@
 {
     "@@locale": "ms",
+    "sessionExpiredSignInAgain": "Sesi tamat tempoh — log masuk semula.",
     "appTitle": "Omi",
     "conversationTab": "Perbualan",
     "transcriptTab": "Transkrip",

--- a/app/lib/l10n/app_nl.arb
+++ b/app/lib/l10n/app_nl.arb
@@ -1,5 +1,6 @@
 {
     "@@locale": "nl",
+    "sessionExpiredSignInAgain": "De sessie is verlopen — log opnieuw in.",
     "appTitle": "Omi",
     "conversationTab": "Gesprek",
     "transcriptTab": "Transcriptie",

--- a/app/lib/l10n/app_no.arb
+++ b/app/lib/l10n/app_no.arb
@@ -1,5 +1,6 @@
 {
     "@@locale": "no",
+    "sessionExpiredSignInAgain": "Økten er utløpt — logg på igjen.",
     "appTitle": "Omi",
     "conversationTab": "Samtale",
     "transcriptTab": "Transkripsjon",

--- a/app/lib/l10n/app_pl.arb
+++ b/app/lib/l10n/app_pl.arb
@@ -1,5 +1,6 @@
 {
     "@@locale": "pl",
+    "sessionExpiredSignInAgain": "Sesja wygasła — zaloguj się ponownie.",
     "appTitle": "Omi",
     "conversationTab": "Rozmowa",
     "transcriptTab": "Transkrypcja",

--- a/app/lib/l10n/app_pt.arb
+++ b/app/lib/l10n/app_pt.arb
@@ -1,5 +1,6 @@
 {
     "@@locale": "pt",
+    "sessionExpiredSignInAgain": "A sessão expirou — inicie sessão novamente.",
     "appTitle": "Omi",
     "conversationTab": "Conversa",
     "transcriptTab": "Transcrição",

--- a/app/lib/l10n/app_ro.arb
+++ b/app/lib/l10n/app_ro.arb
@@ -1,5 +1,6 @@
 {
     "@@locale": "ro",
+    "sessionExpiredSignInAgain": "Sesiunea a expirat — autentifică-te din nou.",
     "appTitle": "Omi",
     "conversationTab": "Conversație",
     "transcriptTab": "Transcriere",

--- a/app/lib/l10n/app_ru.arb
+++ b/app/lib/l10n/app_ru.arb
@@ -1,5 +1,6 @@
 {
     "@@locale": "ru",
+    "sessionExpiredSignInAgain": "Сеанс истёк — войдите снова.",
     "appTitle": "Omi",
     "conversationTab": "Разговор",
     "transcriptTab": "Расшифровка",

--- a/app/lib/l10n/app_sk.arb
+++ b/app/lib/l10n/app_sk.arb
@@ -1,5 +1,6 @@
 {
     "@@locale": "sk",
+    "sessionExpiredSignInAgain": "Platnosť relácie vypršala — prihláste sa znova.",
     "appTitle": "Omi",
     "conversationTab": "Konverzácia",
     "transcriptTab": "Prepis",

--- a/app/lib/l10n/app_sl.arb
+++ b/app/lib/l10n/app_sl.arb
@@ -1,5 +1,6 @@
 {
     "@@locale": "sl",
+    "sessionExpiredSignInAgain": "Seja je potekla — znova se prijavite.",
     "@@last_modified": "2024-12-26",
     "appTitle": "Omi",
     "@appTitle": {

--- a/app/lib/l10n/app_sr.arb
+++ b/app/lib/l10n/app_sr.arb
@@ -1,5 +1,6 @@
 {
     "@@locale": "sr",
+    "sessionExpiredSignInAgain": "Сесија је истекла — пријавите се поново.",
     "@@last_modified": "2024-12-26",
     "appTitle": "Omi",
     "@appTitle": {

--- a/app/lib/l10n/app_sv.arb
+++ b/app/lib/l10n/app_sv.arb
@@ -1,5 +1,6 @@
 {
     "@@locale": "sv",
+    "sessionExpiredSignInAgain": "Sessionen har gått ut — logga in igen.",
     "appTitle": "Omi",
     "conversationTab": "Konversation",
     "transcriptTab": "Transkription",

--- a/app/lib/l10n/app_ta.arb
+++ b/app/lib/l10n/app_ta.arb
@@ -1,5 +1,6 @@
 {
     "@@locale": "ta",
+    "sessionExpiredSignInAgain": "அமர்வு காலாவதியானது — மீண்டும் உள்நுழையவும்.",
     "@@last_modified": "2024-12-26",
     "appTitle": "Omi",
     "@appTitle": {

--- a/app/lib/l10n/app_te.arb
+++ b/app/lib/l10n/app_te.arb
@@ -1,5 +1,6 @@
 {
     "@@locale": "te",
+    "sessionExpiredSignInAgain": "సెషన్ గడువు ముగిసింది — మళ్లీ సైన్ ఇన్ చేయండి.",
     "@@last_modified": "2024-12-26",
     "appTitle": "Omi",
     "@appTitle": {

--- a/app/lib/l10n/app_th.arb
+++ b/app/lib/l10n/app_th.arb
@@ -1,5 +1,6 @@
 {
     "@@locale": "th",
+    "sessionExpiredSignInAgain": "เซสชันหมดอายุ — ลงชื่อเข้าใช้อีกครั้ง",
     "appTitle": "Omi",
     "conversationTab": "บทสนทนา",
     "transcriptTab": "บันทึกเสียง",

--- a/app/lib/l10n/app_tl.arb
+++ b/app/lib/l10n/app_tl.arb
@@ -1,5 +1,6 @@
 {
     "@@locale": "tl",
+    "sessionExpiredSignInAgain": "Nag-expire ang session — mag-sign in ulit.",
     "@@last_modified": "2024-12-26",
     "appTitle": "Omi",
     "@appTitle": {

--- a/app/lib/l10n/app_tr.arb
+++ b/app/lib/l10n/app_tr.arb
@@ -1,5 +1,6 @@
 {
     "@@locale": "tr",
+    "sessionExpiredSignInAgain": "Oturumun süresi doldu — tekrar giriş yapın.",
     "appTitle": "Omi",
     "conversationTab": "Konuşma",
     "transcriptTab": "Transkript",

--- a/app/lib/l10n/app_uk.arb
+++ b/app/lib/l10n/app_uk.arb
@@ -1,5 +1,6 @@
 {
     "@@locale": "uk",
+    "sessionExpiredSignInAgain": "Сеанс завершено — увійдіть знову.",
     "appTitle": "Omi",
     "conversationTab": "Розмова",
     "transcriptTab": "Транскрипція",

--- a/app/lib/l10n/app_ur.arb
+++ b/app/lib/l10n/app_ur.arb
@@ -1,5 +1,6 @@
 {
     "@@locale": "ur",
+    "sessionExpiredSignInAgain": "سیشن کی میعاد ختم ہو گئی — دوبارہ سائن ان کریں۔",
     "@@last_modified": "2024-12-26",
     "appTitle": "Omi",
     "@appTitle": {

--- a/app/lib/l10n/app_vi.arb
+++ b/app/lib/l10n/app_vi.arb
@@ -1,5 +1,6 @@
 {
     "@@locale": "vi",
+    "sessionExpiredSignInAgain": "Phiên đã hết hạn — hãy đăng nhập lại.",
     "appTitle": "Omi",
     "conversationTab": "Cuộc trò chuyện",
     "transcriptTab": "Bản ghi",

--- a/app/lib/l10n/app_zh.arb
+++ b/app/lib/l10n/app_zh.arb
@@ -1,5 +1,6 @@
 {
     "@@locale": "zh",
+    "sessionExpiredSignInAgain": "会话已过期，请重新登录。",
     "appTitle": "Omi",
     "conversationTab": "对话",
     "transcriptTab": "转录",

--- a/app/lib/mobile/mobile_app.dart
+++ b/app/lib/mobile/mobile_app.dart
@@ -9,14 +9,36 @@ import 'package:omi/pages/onboarding/device_selection.dart';
 import 'package:omi/pages/onboarding/permissions/permissions_checker.dart';
 import 'package:omi/pages/onboarding/wrapper.dart';
 import 'package:omi/providers/auth_provider.dart';
+import 'package:omi/utils/alerts/app_snackbar.dart';
+import 'package:omi/utils/l10n_extensions.dart';
 
-class MobileApp extends StatelessWidget {
+class MobileApp extends StatefulWidget {
   const MobileApp({super.key});
+
+  @override
+  State<MobileApp> createState() => _MobileAppState();
+}
+
+class _MobileAppState extends State<MobileApp> {
+  int _lastPresentedSessionExpiration = 0;
+
+  void _presentSessionExpiration(int generation) {
+    if (generation <= _lastPresentedSessionExpiration) return;
+    _lastPresentedSessionExpiration = generation;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      AppSnackbar.showSnackbarError(context.l10n.sessionExpiredSignInAgain);
+    });
+  }
 
   @override
   Widget build(BuildContext context) {
     return Consumer<AuthenticationProvider>(
       builder: (context, authProvider, child) {
+        if (authProvider.requiresReauthentication) {
+          _presentSessionExpiration(authProvider.sessionExpirationGeneration);
+          return const OnboardingWrapper(forceAuthPage: true);
+        }
         if (authProvider.isSignedIn()) {
           // Returning users who haven't yet given consent under the new
           // model must see the consent screen before any AI processing

--- a/app/lib/pages/onboarding/wrapper.dart
+++ b/app/lib/pages/onboarding/wrapper.dart
@@ -34,7 +34,9 @@ import 'package:omi/utils/other/temp.dart';
 import 'package:omi/widgets/device_widget.dart';
 
 class OnboardingWrapper extends StatefulWidget {
-  const OnboardingWrapper({super.key});
+  const OnboardingWrapper({super.key, this.forceAuthPage = false});
+
+  final bool forceAuthPage;
 
   @override
   State<OnboardingWrapper> createState() => _OnboardingWrapperState();
@@ -56,7 +58,21 @@ class _OnboardingWrapperState extends State<OnboardingWrapper> with TickerProvid
   static const int kCompletePage = 11; // "You're all set" completion screen
 
   // Special index values used in comparisons
-  static const List<int> kHiddenHeaderPages = [-1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11];
+  static const List<int> kHiddenHeaderPages = [
+    -1,
+    0,
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    7,
+    8,
+    9,
+    10,
+    11,
+  ];
 
   TabController? _controller;
   late AnimationController _backgroundAnimationController;
@@ -68,7 +84,9 @@ class _OnboardingWrapperState extends State<OnboardingWrapper> with TickerProvid
 
   @override
   void initState() {
-    _speechProfileProvider = SpeechProfileProvider();
+    if (!widget.forceAuthPage) {
+      _speechProfileProvider = SpeechProfileProvider();
+    }
     _controller = TabController(
       length: 12,
       vsync: this,
@@ -81,18 +99,25 @@ class _OnboardingWrapperState extends State<OnboardingWrapper> with TickerProvid
       // Precache next image for smoother transitions
       _precacheNextImage(_controller!.index);
       if (_controller!.index == kSpeechProfilePage && _knowledgeGraphPrebuildFuture == null) {
-        _knowledgeGraphPrebuildFuture = _prebuildKnowledgeGraph().catchError((_) {});
+        _knowledgeGraphPrebuildFuture = _prebuildKnowledgeGraph().catchError(
+          (_) {},
+        );
       }
     });
 
     // Initialize animation controllers
-    _backgroundAnimationController = AnimationController(duration: const Duration(milliseconds: 500), vsync: this);
+    _backgroundAnimationController = AnimationController(
+      duration: const Duration(milliseconds: 500),
+      vsync: this,
+    );
 
     // Initialize animations
-    _backgroundFadeAnimation = Tween<double>(
-      begin: 0.0,
-      end: 1.0,
-    ).animate(CurvedAnimation(parent: _backgroundAnimationController, curve: Curves.easeInOut));
+    _backgroundFadeAnimation = Tween<double>(begin: 0.0, end: 1.0).animate(
+      CurvedAnimation(
+        parent: _backgroundAnimationController,
+        curve: Curves.easeInOut,
+      ),
+    );
 
     // Start initial animations
     _backgroundAnimationController.forward();
@@ -102,7 +127,7 @@ class _OnboardingWrapperState extends State<OnboardingWrapper> with TickerProvid
       //   context.read<OnboardingProvider>().updatePermissions();
       // }
 
-      if (AuthService.instance.isSignedIn()) {
+      if (!widget.forceAuthPage && AuthService.instance.isSignedIn()) {
         // && !SharedPreferencesUtil().onboardingCompleted
         if (mounted) {
           context.read<HomeProvider>().setupHasSpeakerProfile();
@@ -138,7 +163,11 @@ class _OnboardingWrapperState extends State<OnboardingWrapper> with TickerProvid
       final granted = await arePermissionsGranted();
       if (!granted) {
         if (context.mounted) {
-          routeToPage(context, const PermissionsInterstitialPage(), replace: true);
+          routeToPage(
+            context,
+            const PermissionsInterstitialPage(),
+            replace: true,
+          );
         }
         return;
       }
@@ -276,7 +305,9 @@ class _OnboardingWrapperState extends State<OnboardingWrapper> with TickerProvid
           // so an in-session re-login would otherwise leave it null until the
           // Plan & Usage page is opened (missing Pro badge).
           context.read<UsageProvider>().fetchSubscription();
-          IntercomManager.instance.loginIdentifiedUser(SharedPreferencesUtil().uid);
+          IntercomManager.instance.loginIdentifiedUser(
+            SharedPreferencesUtil().uid,
+          );
           // Consent is checked first regardless of server-side onboarding
           // state so a returning user signing in on a fresh install still
           // sees the consent screen before any AI processing begins.
@@ -293,7 +324,9 @@ class _OnboardingWrapperState extends State<OnboardingWrapper> with TickerProvid
         onAgree: () async {
           if (!mounted) return;
           SharedPreferencesUtil().aiConsentGiven = true;
-          PlatformManager.instance.analytics.onboardingStepCompleted('AI Consent');
+          PlatformManager.instance.analytics.onboardingStepCompleted(
+            'AI Consent',
+          );
           // If the server says this user already completed onboarding, jump
           // straight to home — their first-time onboarding ran in a previous
           // session and we don't want to re-run it.
@@ -318,47 +351,63 @@ class _OnboardingWrapperState extends State<OnboardingWrapper> with TickerProvid
       PrimaryLanguageWidget(
         goNext: () {
           _goNext(); // Go to Found Omi page
-          PlatformManager.instance.analytics.onboardingStepCompleted('Primary Language');
+          PlatformManager.instance.analytics.onboardingStepCompleted(
+            'Primary Language',
+          );
         },
       ),
       FoundOmiWidget(
         goNext: () {
           _goNext(); // Go to Permissions page
-          PlatformManager.instance.analytics.onboardingStepCompleted('Acquisition Source');
+          PlatformManager.instance.analytics.onboardingStepCompleted(
+            'Acquisition Source',
+          );
         },
       ),
       PermissionsWidget(
         goNext: () {
           _goNext(); // Go to User Review page
-          PlatformManager.instance.analytics.onboardingStepCompleted('Permissions');
+          PlatformManager.instance.analytics.onboardingStepCompleted(
+            'Permissions',
+          );
         },
       ),
       UserReviewPage(
         goNext: () {
           // Go directly to Speech Profile (skip device steps - we use phone mic now)
           _controller!.animateTo(kSpeechProfilePage);
-          PlatformManager.instance.analytics.onboardingStepCompleted('User Review');
+          PlatformManager.instance.analytics.onboardingStepCompleted(
+            'User Review',
+          );
         },
       ),
       // Placeholder pages - not used in new flow but kept for index consistency
       Container(), // WelcomePage placeholder
       Container(), // FindDevicesPage placeholder
-      ChangeNotifierProvider.value(
-        value: _speechProfileProvider!,
-        child: SpeechProfileWidget(
-          goNext: () {
-            PlatformManager.instance.analytics.onboardingStepCompleted('Speech Profile');
-            _controller!.animateTo(kKnowledgeGraphPage);
-          },
-          onSkip: () {
-            PlatformManager.instance.analytics.onboardingStepCompleted('Speech Profile Skipped');
-            _controller!.animateTo(kKnowledgeGraphPage);
-          },
-        ),
-      ),
+      widget.forceAuthPage
+          ? const SizedBox.shrink()
+          : ChangeNotifierProvider.value(
+              value: _speechProfileProvider!,
+              child: SpeechProfileWidget(
+                goNext: () {
+                  PlatformManager.instance.analytics.onboardingStepCompleted(
+                    'Speech Profile',
+                  );
+                  _controller!.animateTo(kKnowledgeGraphPage);
+                },
+                onSkip: () {
+                  PlatformManager.instance.analytics.onboardingStepCompleted(
+                    'Speech Profile Skipped',
+                  );
+                  _controller!.animateTo(kKnowledgeGraphPage);
+                },
+              ),
+            ),
       OnboardingKnowledgeGraphStep(
         onContinue: () {
-          PlatformManager.instance.analytics.onboardingStepCompleted('Knowledge Graph');
+          PlatformManager.instance.analytics.onboardingStepCompleted(
+            'Knowledge Graph',
+          );
           _controller!.animateTo(kCompletePage);
         },
       ),
@@ -426,9 +475,15 @@ class _OnboardingWrapperState extends State<OnboardingWrapper> with TickerProvid
                               image: DecorationImage(
                                 image: ResizeImage(
                                   AssetImage(_currentBackgroundImage),
-                                  width: (MediaQuery.of(context).size.width * MediaQuery.of(context).devicePixelRatio)
+                                  width: (MediaQuery.of(context).size.width *
+                                          MediaQuery.of(
+                                            context,
+                                          ).devicePixelRatio)
                                       .round(),
-                                  height: (MediaQuery.of(context).size.height * MediaQuery.of(context).devicePixelRatio)
+                                  height: (MediaQuery.of(context).size.height *
+                                          MediaQuery.of(
+                                            context,
+                                          ).devicePixelRatio)
                                       .round(),
                                 ),
                                 fit: BoxFit.cover,
@@ -470,8 +525,10 @@ class _OnboardingWrapperState extends State<OnboardingWrapper> with TickerProvid
                               width: 36,
                               height: 36,
                               margin: const EdgeInsets.all(8),
-                              decoration:
-                                  BoxDecoration(color: Colors.grey.withValues(alpha: 0.3), shape: BoxShape.circle),
+                              decoration: BoxDecoration(
+                                color: Colors.grey.withValues(alpha: 0.3),
+                                shape: BoxShape.circle,
+                              ),
                               child: IconButton(
                                 padding: EdgeInsets.zero,
                                 onPressed: () {
@@ -482,7 +539,11 @@ class _OnboardingWrapperState extends State<OnboardingWrapper> with TickerProvid
                                     _controller!.animateTo(_controller!.index - 1);
                                   }
                                 },
-                                icon: FaIcon(FontAwesomeIcons.arrowLeft, size: 16.0, color: Colors.white),
+                                icon: FaIcon(
+                                  FontAwesomeIcons.arrowLeft,
+                                  size: 16.0,
+                                  color: Colors.white,
+                                ),
                               ),
                             ),
                           ),
@@ -511,10 +572,15 @@ class _OnboardingWrapperState extends State<OnboardingWrapper> with TickerProvid
                               kHiddenHeaderPages.contains(_controller?.index)
                                   ? const SizedBox.shrink()
                                   : Padding(
-                                      padding: const EdgeInsets.symmetric(horizontal: 16),
+                                      padding: const EdgeInsets.symmetric(
+                                        horizontal: 16,
+                                      ),
                                       child: Text(
                                         context.l10n.personalGrowthJourney,
-                                        style: TextStyle(color: Colors.grey.shade300, fontSize: 24),
+                                        style: TextStyle(
+                                          color: Colors.grey.shade300,
+                                          fontSize: 24,
+                                        ),
                                         textAlign: TextAlign.center,
                                       ),
                                     ),
@@ -523,14 +589,22 @@ class _OnboardingWrapperState extends State<OnboardingWrapper> with TickerProvid
                                     (_controller!.index == kFindDevicesPage || _controller!.index == kSpeechProfilePage)
                                         ? max(
                                             MediaQuery.of(context).size.height - 500 - 10,
-                                            maxHeightWithTextScale(context, _controller!.index),
+                                            maxHeightWithTextScale(
+                                              context,
+                                              _controller!.index,
+                                            ),
                                           )
                                         : max(
                                             MediaQuery.of(context).size.height - 500 - 30,
-                                            maxHeightWithTextScale(context, _controller!.index),
+                                            maxHeightWithTextScale(
+                                              context,
+                                              _controller!.index,
+                                            ),
                                           ),
                                 child: Padding(
-                                  padding: EdgeInsets.only(bottom: MediaQuery.sizeOf(context).height <= 700 ? 10 : 64),
+                                  padding: EdgeInsets.only(
+                                    bottom: MediaQuery.sizeOf(context).height <= 700 ? 10 : 64,
+                                  ),
                                   child: TabBarView(
                                     controller: _controller,
                                     physics: const NeverScrollableScrollPhysics(),
@@ -561,10 +635,16 @@ class _OnboardingWrapperState extends State<OnboardingWrapper> with TickerProvid
                                       _speechProfileProvider?.close();
                                       _controller!.animateTo(kUserReviewPage);
                                     } else if (_controller!.index > kNamePage) {
-                                      _controller!.animateTo(_controller!.index - 1);
+                                      _controller!.animateTo(
+                                        _controller!.index - 1,
+                                      );
                                     }
                                   },
-                                  icon: FaIcon(FontAwesomeIcons.arrowLeft, size: 16.0, color: Colors.white),
+                                  icon: FaIcon(
+                                    FontAwesomeIcons.arrowLeft,
+                                    size: 16.0,
+                                    color: Colors.white,
+                                  ),
                                 ),
                               ),
                             ),
@@ -577,7 +657,9 @@ class _OnboardingWrapperState extends State<OnboardingWrapper> with TickerProvid
                               children: List.generate(7, (index) {
                                 int pageIndex = index + 2; // Name=2, Lang=3, ..., Speech=8
                                 return Container(
-                                  margin: const EdgeInsets.symmetric(horizontal: 4.0),
+                                  margin: const EdgeInsets.symmetric(
+                                    horizontal: 4.0,
+                                  ),
                                   width: pageIndex == _controller!.index ? 12.0 : 8.0,
                                   height: pageIndex == _controller!.index ? 12.0 : 8.0,
                                   decoration: BoxDecoration(

--- a/app/lib/pages/payments/payment_method_provider.dart
+++ b/app/lib/pages/payments/payment_method_provider.dart
@@ -35,6 +35,7 @@ class PaymentMethodProvider extends ChangeNotifier {
   String _searchQuery = '';
 
   PayPalDetails? paypalDetails;
+  int _sessionGeneration = 0;
 
   List<Map<String, dynamic>> get supportedCountries => _supportedCountries;
   List<Map<String, dynamic>> get filteredCountries => _filteredCountries;
@@ -48,8 +49,10 @@ class PaymentMethodProvider extends ChangeNotifier {
   bool get isLoading => _isLoading;
 
   Future getSupportedCountries() async {
+    final generation = _sessionGeneration;
     _isLoading = true;
     var res = await getStripeSupportedCountries();
+    if (generation != _sessionGeneration) return;
     _isLoading = false;
     if (res != null) {
       _supportedCountries = res.cast<Map<String, dynamic>>();
@@ -73,8 +76,10 @@ class PaymentMethodProvider extends ChangeNotifier {
   }
 
   void setActiveMethod(PaymentMethodType method) async {
+    final generation = _sessionGeneration;
     _isLoading = true;
     var res = await setDefaultPaymentMethod(method.name);
+    if (generation != _sessionGeneration) return;
     _isLoading = false;
     if (res) {
       _activeMethod = method;
@@ -85,9 +90,11 @@ class PaymentMethodProvider extends ChangeNotifier {
   }
 
   Future getPaymentMethodsStatus() async {
+    final generation = _sessionGeneration;
     _isLoading = true;
     notifyListeners();
     var res = await fetchPaymentMethodsStatus();
+    if (generation != _sessionGeneration) return;
     _isLoading = false;
     if (res != null) {
       _payPalConnectionState = getPaymentConnectionState(res['paypal']);
@@ -106,7 +113,9 @@ class PaymentMethodProvider extends ChangeNotifier {
   }
 
   Future getPayPalDetails() async {
+    final generation = _sessionGeneration;
     var res = await fetchPayPalDetails();
+    if (generation != _sessionGeneration) return;
     if (res != null) {
       paypalDetails = res;
       notifyListeners();
@@ -122,7 +131,9 @@ class PaymentMethodProvider extends ChangeNotifier {
   }
 
   Future<String?> connectStripe() async {
+    final generation = _sessionGeneration;
     var res = await getStripeAccountLink(_selectedCountryId);
+    if (generation != _sessionGeneration) return null;
     if (res != null) {
       return res['url'];
     }
@@ -130,7 +141,9 @@ class PaymentMethodProvider extends ChangeNotifier {
   }
 
   Future<bool> checkStripeConnectionStatus() async {
+    final generation = _sessionGeneration;
     var res = await isStripeOnboardingComplete();
+    if (generation != _sessionGeneration) return false;
     _stripeConnectionState = res ? PaymentConnectionState.connected : PaymentConnectionState.inComplete;
     notifyListeners();
     return res;
@@ -157,7 +170,9 @@ class PaymentMethodProvider extends ChangeNotifier {
   }
 
   Future<void> connectPayPal(String email, String link) async {
+    final generation = _sessionGeneration;
     var res = await savePayPalDetails(email, link);
+    if (generation != _sessionGeneration) return;
     if (!res) {
       AppSnackbar.showSnackbarError(globalNavigatorKey.currentContext!.l10n.paymentFailedToSavePaypal);
       return;
@@ -166,6 +181,20 @@ class PaymentMethodProvider extends ChangeNotifier {
     if (!isStripeConnected) {
       _activeMethod = PaymentMethodType.paypal;
     }
+    notifyListeners();
+  }
+
+  void clearUserData() {
+    _sessionGeneration++;
+    _activeMethod = null;
+    _isStripePolling = false;
+    _isLoading = false;
+    _stripeConnectionState = PaymentConnectionState.notConnected;
+    _payPalConnectionState = PaymentConnectionState.notConnected;
+    _filteredCountries = _supportedCountries;
+    _searchQuery = '';
+    _selectedCountryId = null;
+    paypalDetails = null;
     notifyListeners();
   }
 }

--- a/app/lib/pages/settings/delete_account.dart
+++ b/app/lib/pages/settings/delete_account.dart
@@ -2,13 +2,15 @@ import 'package:omi/utils/platform/platform_manager.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
-import 'package:firebase_auth/firebase_auth.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 
 import 'package:omi/backend/http/api/users.dart';
 import 'package:omi/backend/preferences.dart';
 import 'package:omi/core/app_shell.dart';
+import 'package:omi/services/auth_service.dart';
 import 'package:omi/utils/alerts/app_snackbar.dart';
+import 'package:omi/utils/auth/clear_user_state.dart';
+import 'package:omi/utils/auth/clear_deleted_account_session.dart';
 import 'package:omi/utils/l10n_extensions.dart';
 import 'package:omi/utils/other/temp.dart';
 import 'package:omi/utils/wal_file_manager.dart';
@@ -104,9 +106,12 @@ class _DeleteAccountState extends State<DeleteAccount> {
         details: details,
       );
       PlatformManager.instance.analytics.deleteUser();
-      await WalFileManager.clearAll();
-      await SharedPreferencesUtil().clear();
-      await FirebaseAuth.instance.signOut();
+      await clearDeletedAccountSession(
+        authService: AuthService.instance,
+        clearUserState: () => clearAllUserState(context),
+        clearWal: WalFileManager.clearAll,
+        clearPreferences: SharedPreferencesUtil().clear,
+      );
       if (!mounted) return;
       routeToPage(context, const AppShell(), replace: true);
     } catch (_) {

--- a/app/lib/providers/auth_provider.dart
+++ b/app/lib/providers/auth_provider.dart
@@ -1,6 +1,5 @@
+import 'dart:async';
 import 'dart:io';
-
-import 'package:flutter/material.dart';
 
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:url_launcher/url_launcher.dart';
@@ -11,7 +10,9 @@ import 'package:omi/env/env.dart';
 import 'package:omi/app_globals.dart';
 import 'package:omi/providers/base_provider.dart';
 import 'package:omi/services/auth_service.dart';
+import 'package:omi/services/auth/auth_token_result.dart';
 import 'package:omi/services/notifications.dart';
+import 'package:omi/utils/auth/clear_user_state.dart';
 import 'package:omi/utils/alerts/app_snackbar.dart';
 import 'package:omi/utils/l10n_extensions.dart';
 import 'package:omi/utils/logger.dart';
@@ -24,11 +25,18 @@ class AuthenticationProvider extends BaseProvider {
   User? user;
   String? authToken;
   bool _loading = false;
+  bool _requiresReauthentication = false;
+  int _sessionExpirationGeneration = 0;
+  StreamSubscription<User?>? _authStateSubscription;
+  StreamSubscription<User?>? _idTokenSubscription;
+  StreamSubscription<AuthSessionExpiredEvent>? _sessionExpiredSubscription;
   @override
   bool get loading => _loading;
+  bool get requiresReauthentication => _requiresReauthentication;
+  int get sessionExpirationGeneration => _sessionExpirationGeneration;
 
-  AuthenticationProvider() {
-    _initializeAuthListeners();
+  AuthenticationProvider({bool initializeListeners = true}) {
+    if (initializeListeners) _initializeAuthListeners();
   }
 
   void _initializeAuthListeners() {
@@ -38,7 +46,8 @@ class AuthenticationProvider extends BaseProvider {
     );
 
     Future.microtask(() {
-      _auth.authStateChanges().distinct((p, n) => p?.uid == n?.uid).listen((User? user) {
+      _authStateSubscription = _auth.authStateChanges().distinct((p, n) => p?.uid == n?.uid).listen((User? user) {
+        AuthService.instance.handleAuthUserChanged(user?.uid);
         Logger.debug(
           'DEBUG AuthProvider: authStateChanges fired - user=${user?.uid}, isAnonymous=${user?.isAnonymous}',
         );
@@ -50,19 +59,29 @@ class AuthenticationProvider extends BaseProvider {
           SharedPreferencesUtil().email = user.email ?? '';
           SharedPreferencesUtil().givenName = user.displayName?.split(' ')[0] ?? '';
         }
+        notifyListeners();
       });
-      _auth.idTokenChanges().distinct((p, n) => p?.uid == n?.uid).listen((User? user) async {
+      _idTokenSubscription = _auth.idTokenChanges().distinct((p, n) => p?.uid == n?.uid).listen((User? user) async {
+        AuthService.instance.handleAuthUserChanged(user?.uid);
         if (user == null) {
-          Logger.debug('User is currently signed out or the token has been revoked!');
+          Logger.debug(
+            'User is currently signed out or the token has been revoked!',
+          );
           SharedPreferencesUtil().authToken = '';
           SharedPreferencesUtil().tokenExpirationTime = 0;
           authToken = null;
         } else {
-          Logger.debug('User is signed in at ${DateTime.now()} with user ${user.uid}');
+          Logger.debug(
+            'User is signed in at ${DateTime.now()} with user ${user.uid}',
+          );
           try {
-            if (SharedPreferencesUtil().authToken.isEmpty ||
+            if (_requiresReauthentication ||
+                SharedPreferencesUtil().authToken.isEmpty ||
                 DateTime.now().millisecondsSinceEpoch > SharedPreferencesUtil().tokenExpirationTime) {
               authToken = await AuthService.instance.getIdToken();
+            }
+            if (authToken != null && authToken!.isNotEmpty) {
+              _requiresReauthentication = false;
             }
           } catch (e) {
             authToken = null;
@@ -71,11 +90,32 @@ class AuthenticationProvider extends BaseProvider {
         }
         notifyListeners();
       });
+      _sessionExpiredSubscription = AuthService.instance.sessionExpiredEvents.listen((event) {
+        _requiresReauthentication = true;
+        _sessionExpirationGeneration++;
+        user = null;
+        authToken = null;
+        final rootContext = globalNavigatorKey.currentContext;
+        if (rootContext != null && rootContext.mounted) {
+          clearAllUserState(rootContext);
+        }
+        notifyListeners();
+      });
     });
   }
 
   bool isSignedIn() {
-    return _auth.currentUser != null && !_auth.currentUser!.isAnonymous;
+    return !_requiresReauthentication && _auth.currentUser != null && !_auth.currentUser!.isAnonymous;
+  }
+
+  bool get _hasFirebaseUser => _auth.currentUser != null && !_auth.currentUser!.isAnonymous;
+
+  @override
+  void dispose() {
+    _authStateSubscription?.cancel();
+    _idTokenSubscription?.cancel();
+    _sessionExpiredSubscription?.cancel();
+    super.dispose();
   }
 
   void setLoading(bool value) {
@@ -92,10 +132,12 @@ class AuthenticationProvider extends BaseProvider {
         if (PlatformService.isMobile && !useWebAuth) {
           credential = await AuthService.instance.signInWithGoogleMobile();
         } else {
-          credential = await AuthService.instance.authenticateWithProvider('google');
+          credential = await AuthService.instance.authenticateWithProvider(
+            'google',
+          );
         }
-        if (credential != null && isSignedIn()) {
-          _signIn(onSignIn);
+        if (credential != null && _hasFirebaseUser) {
+          await _signIn(onSignIn);
         } else {
           AppSnackbar.showSnackbarError(
             globalNavigatorKey.currentContext?.l10n.authFailedToSignInWithGoogle ??
@@ -121,10 +163,12 @@ class AuthenticationProvider extends BaseProvider {
         if (PlatformService.isMobile && !useWebAuth && !Platform.isAndroid) {
           credential = await AuthService.instance.signInWithAppleMobile();
         } else {
-          credential = await AuthService.instance.authenticateWithProvider('apple');
+          credential = await AuthService.instance.authenticateWithProvider(
+            'apple',
+          );
         }
-        if (credential != null && isSignedIn()) {
-          _signIn(onSignIn);
+        if (credential != null && _hasFirebaseUser) {
+          await _signIn(onSignIn);
         } else {
           AppSnackbar.showSnackbarError(
             globalNavigatorKey.currentContext?.l10n.authFailedToSignInWithApple ??
@@ -146,7 +190,7 @@ class AuthenticationProvider extends BaseProvider {
       final token = await AuthService.instance.getIdToken();
       NotificationService.instance.saveNotificationToken();
 
-      Logger.debug('Token: $token');
+      Logger.debug('Firebase token retrieved successfully');
       return token;
     } catch (e, stackTrace) {
       AppSnackbar.showSnackbarError(
@@ -159,13 +203,13 @@ class AuthenticationProvider extends BaseProvider {
     }
   }
 
-  void _signIn(Function() onSignIn) async {
-    String? token = await _getIdToken();
+  Future<void> _signIn(Function() onSignIn) async {
+    final token = await _getIdToken();
 
     if (token != null) {
-      User user;
+      User currentUser;
       try {
-        user = FirebaseAuth.instance.currentUser!;
+        currentUser = FirebaseAuth.instance.currentUser!;
       } catch (e, stackTrace) {
         AppSnackbar.showSnackbarError(
           globalNavigatorKey.currentContext?.l10n.authUnexpectedErrorFirebase ??
@@ -175,9 +219,13 @@ class AuthenticationProvider extends BaseProvider {
         PlatformManager.instance.crashReporter.reportCrash(e, stackTrace);
         return;
       }
-      String newUid = user.uid;
+      final newUid = currentUser.uid;
       SharedPreferencesUtil().uid = newUid;
+      user = currentUser;
+      authToken = token;
+      _requiresReauthentication = false;
       PlatformManager.instance.analytics.identify();
+      notifyListeners();
       onSignIn();
     } else {
       AppSnackbar.showSnackbarError(
@@ -238,7 +286,9 @@ class AuthenticationProvider extends BaseProvider {
     try {
       final appleProvider = AppleAuthProvider();
       try {
-        await FirebaseAuth.instance.currentUser?.linkWithProvider(appleProvider);
+        await FirebaseAuth.instance.currentUser?.linkWithProvider(
+          appleProvider,
+        );
       } catch (e) {
         if (e is FirebaseAuthException && e.code == 'credential-already-in-use') {
           // Get existing user credentials
@@ -246,11 +296,13 @@ class AuthenticationProvider extends BaseProvider {
           final oldUserId = FirebaseAuth.instance.currentUser?.uid;
 
           // Sign out current anonymous user
+          AuthService.instance.handleAuthUserChanged(null);
           await FirebaseAuth.instance.signOut();
 
           // Sign in with existing account
           await FirebaseAuth.instance.signInWithCredential(existingCred!);
           final newUserId = FirebaseAuth.instance.currentUser?.uid;
+          if (newUserId != null) AuthService.instance.markAuthenticatedUser(newUserId);
           await AuthService.instance.getIdToken();
 
           SharedPreferencesUtil().onboardingCompleted = false;

--- a/app/lib/providers/conversation_provider.dart
+++ b/app/lib/providers/conversation_provider.dart
@@ -9,8 +9,19 @@ import 'package:omi/backend/preferences.dart';
 import 'package:omi/backend/schema/conversation.dart';
 import 'package:omi/backend/schema/structured.dart';
 import 'package:omi/services/app_review_service.dart';
+import 'package:omi/services/auth_service.dart';
 import 'package:omi/services/notifications/merge_notification_handler.dart';
 import 'package:omi/utils/logger.dart';
+
+typedef ConversationListFetcher = Future<({List<ServerConversation> items, bool ok})> Function();
+typedef DailySummariesChecker = Future<bool> Function();
+typedef ConversationSearchFetcher = Future<(List<ServerConversation>, int, int)> Function(
+  String query, {
+  int? page,
+  int? limit,
+  required bool includeDiscarded,
+  String? speakerId,
+});
 
 class ConversationProvider extends ChangeNotifier {
   List<ServerConversation> conversations = [];
@@ -59,6 +70,7 @@ class ConversationProvider extends ChangeNotifier {
   bool conversationsLoadFailed = false;
   Timer? _initialFetchRetryTimer;
   int _initialFetchRetryCount = 0;
+  int _sessionGeneration = 0;
   static const int _maxInitialFetchRetries = 4;
   // After the fast backoff budget is spent we keep retrying on a slow fixed
   // interval rather than giving up — otherwise a prolonged outage latches the
@@ -71,7 +83,20 @@ class ConversationProvider extends ChangeNotifier {
   bool get isAwaitingInitialFetchRetry => _initialFetchRetryTimer?.isActive ?? false;
   bool get hasActiveSearch => previousQuery.isNotEmpty || selectedSpeakerId != null;
 
-  ConversationProvider() {
+  final ConversationListFetcher? _conversationListFetcher;
+  final DailySummariesChecker? _dailySummariesChecker;
+  final ConversationSearchFetcher _conversationSearchFetcher;
+  final bool Function() _isSignedIn;
+
+  ConversationProvider({
+    ConversationListFetcher? conversationListFetcher,
+    DailySummariesChecker? dailySummariesChecker,
+    ConversationSearchFetcher? conversationSearchFetcher,
+    bool Function()? isSignedIn,
+  })  : _conversationListFetcher = conversationListFetcher,
+        _dailySummariesChecker = dailySummariesChecker,
+        _conversationSearchFetcher = conversationSearchFetcher ?? searchConversationsServer,
+        _isSignedIn = isSignedIn ?? AuthService.instance.isSignedIn {
     _setupMergeListener();
     _loadSettings();
   }
@@ -94,6 +119,7 @@ class ConversationProvider extends ChangeNotifier {
   }
 
   void clearUserData() {
+    _sessionGeneration++;
     conversations = [];
     searchedConversations = [];
     groupedConversations = {};
@@ -141,6 +167,7 @@ class ConversationProvider extends ChangeNotifier {
   }
 
   Future<void> searchConversations(String query, {bool showShimmer = false}) async {
+    if (!_isSignedIn()) return;
     if (query.isEmpty && selectedSpeakerId == null) {
       previousQuery = "";
       currentSearchPage = 0;
@@ -150,6 +177,7 @@ class ConversationProvider extends ChangeNotifier {
       return;
     }
 
+    final generation = _sessionGeneration;
     if (showShimmer) {
       setLoadingConversations(true);
     } else {
@@ -157,11 +185,12 @@ class ConversationProvider extends ChangeNotifier {
     }
 
     previousQuery = query;
-    var (convos, current, total) = await searchConversationsServer(
+    var (convos, current, total) = await _conversationSearchFetcher(
       query,
       includeDiscarded: showDiscardedConversations,
       speakerId: selectedSpeakerId,
     );
+    if (generation != _sessionGeneration || !_isSignedIn()) return;
     convos.sort((a, b) => (b.startedAt ?? b.createdAt).compareTo(a.startedAt ?? a.createdAt));
     searchedConversations = convos;
     currentSearchPage = current;
@@ -183,16 +212,19 @@ class ConversationProvider extends ChangeNotifier {
   }
 
   Future<void> searchMoreConversations() async {
+    if (!_isSignedIn()) return;
     if (totalSearchPages < currentSearchPage + 1) {
       return;
     }
+    final generation = _sessionGeneration;
     setLoadingConversations(true);
-    var (newConvos, current, total) = await searchConversationsServer(
+    var (newConvos, current, total) = await _conversationSearchFetcher(
       previousQuery,
       page: currentSearchPage + 1,
       includeDiscarded: showDiscardedConversations,
       speakerId: selectedSpeakerId,
     );
+    if (generation != _sessionGeneration || !_isSignedIn()) return;
     searchedConversations.addAll(newConvos);
     searchedConversations.sort((a, b) => (b.startedAt ?? b.createdAt).compareTo(a.startedAt ?? a.createdAt));
     totalSearchPages = total;
@@ -301,10 +333,15 @@ class ConversationProvider extends ChangeNotifier {
   }
 
   /// Check if user has any daily summaries
-  Future<void> checkHasDailySummaries() async {
-    final summaries = await getDailySummaries(limit: 1, offset: 0);
-    hasDailySummaries = summaries.isNotEmpty;
+  Future<bool> checkHasDailySummaries() async {
+    if (!_isSignedIn()) return false;
+    final generation = _sessionGeneration;
+    final hasSummaries = await (_dailySummariesChecker?.call() ??
+        getDailySummaries(limit: 1, offset: 0).then((items) => items.isNotEmpty));
+    if (generation != _sessionGeneration || !_isSignedIn()) return false;
+    hasDailySummaries = hasSummaries;
     notifyListeners();
+    return true;
   }
 
   /// Filter conversations by folder
@@ -360,8 +397,15 @@ class ConversationProvider extends ChangeNotifier {
   }
 
   Future _fetchNewConversations() async {
+    if (!_isSignedIn()) return;
+    final generation = _sessionGeneration;
     setLoadingConversations(true);
     final result = await _getConversationsFromServer();
+    if (generation != _sessionGeneration) return;
+    if (!_isSignedIn()) {
+      setLoadingConversations(false);
+      return;
+    }
     setLoadingConversations(false);
 
     // A background/debounced refresh failed (transient network error, token
@@ -405,7 +449,13 @@ class ConversationProvider extends ChangeNotifier {
     notifyListeners();
   }
 
-  Future fetchConversations() async {
+  Future<bool> fetchConversations() async {
+    if (!_isSignedIn()) {
+      _cancelInitialFetchRetry();
+      conversationsLoadFailed = false;
+      return false;
+    }
+    final generation = _sessionGeneration;
     previousQuery = "";
     currentSearchPage = 0;
     totalSearchPages = 0;
@@ -413,6 +463,15 @@ class ConversationProvider extends ChangeNotifier {
 
     setLoadingConversations(true);
     final result = await _getConversationsFromServer();
+    if (generation != _sessionGeneration) {
+      _cancelInitialFetchRetry();
+      return false;
+    }
+    if (!_isSignedIn()) {
+      setLoadingConversations(false);
+      _cancelInitialFetchRetry();
+      return false;
+    }
     setLoadingConversations(false);
 
     if (!result.ok) {
@@ -431,7 +490,7 @@ class ConversationProvider extends ChangeNotifier {
       _groupConversationsByDateWithoutNotify();
       notifyListeners();
       _scheduleInitialFetchRetry();
-      return;
+      return false;
     }
 
     conversationsLoadFailed = false;
@@ -458,9 +517,14 @@ class ConversationProvider extends ChangeNotifier {
     _groupConversationsByDateWithoutNotify();
 
     notifyListeners();
+    return true;
   }
 
   void _scheduleInitialFetchRetry() {
+    if (!_isSignedIn()) {
+      _cancelInitialFetchRetry();
+      return;
+    }
     _initialFetchRetryTimer?.cancel();
     final int delaySeconds;
     if (_initialFetchRetryCount < _maxInitialFetchRetries) {
@@ -474,16 +538,22 @@ class ConversationProvider extends ChangeNotifier {
       delaySeconds = _slowFetchRetryIntervalSeconds;
     }
     _initialFetchRetryTimer = Timer(Duration(seconds: delaySeconds), () {
-      if (conversationsLoadFailed) fetchConversations();
+      if (conversationsLoadFailed && _isSignedIn()) fetchConversations();
     });
   }
 
-  Future getInitialConversations() async {
+  void _cancelInitialFetchRetry() {
+    _initialFetchRetryTimer?.cancel();
+    _initialFetchRetryTimer = null;
+    _initialFetchRetryCount = 0;
+  }
+
+  Future<void> getInitialConversations() async {
     // A manual/initial entry gets a fresh retry budget so pull-to-refresh
     // can recover even after the auto-retries were exhausted.
-    _initialFetchRetryTimer?.cancel();
-    _initialFetchRetryCount = 0;
-    await fetchConversations();
+    _cancelInitialFetchRetry();
+    final fetched = await fetchConversations();
+    if (!fetched || !_isSignedIn()) return;
     await checkHasDailySummaries();
   }
 
@@ -624,6 +694,9 @@ class ConversationProvider extends ChangeNotifier {
   }
 
   Future<({List<ServerConversation> items, bool ok})> _getConversationsFromServer() async {
+    final fetcher = _conversationListFetcher;
+    if (fetcher != null) return fetcher();
+
     final (startDate, endDate) = _getDateFilterRange();
 
     return await getConversationsResult(

--- a/app/lib/providers/folder_provider.dart
+++ b/app/lib/providers/folder_provider.dart
@@ -6,11 +6,17 @@ import 'package:omi/backend/http/api/folders.dart';
 import 'package:omi/backend/schema/folder.dart';
 import 'package:omi/utils/logger.dart';
 
+typedef FoldersFetcher = Future<List<Folder>> Function();
+
 class FolderProvider extends ChangeNotifier {
   List<Folder> _folders = [];
   String? _selectedFolderId;
   bool _isLoading = false;
   String? _error;
+  int _sessionGeneration = 0;
+  final FoldersFetcher _foldersFetcher;
+
+  FolderProvider({FoldersFetcher? foldersFetcher}) : _foldersFetcher = foldersFetcher ?? getFolders;
 
   List<Folder> get folders => _folders;
 
@@ -27,18 +33,23 @@ class FolderProvider extends ChangeNotifier {
   List<Folder> get customFolders => _folders.where((f) => !f.isSystem).toList();
 
   Future<void> loadFolders() async {
+    final generation = _sessionGeneration;
     _isLoading = true;
     _error = null;
     notifyListeners();
 
     try {
-      _folders = await getFolders();
+      final folders = await _foldersFetcher();
+      if (generation != _sessionGeneration) return;
+      _folders = folders;
       _folders.sort((a, b) => a.order.compareTo(b.order));
     } catch (e) {
+      if (generation != _sessionGeneration) return;
       Logger.debug('Error loading folders: $e');
       _error = 'Failed to load folders';
     }
 
+    if (generation != _sessionGeneration) return;
     _isLoading = false;
     notifyListeners();
   }
@@ -54,8 +65,10 @@ class FolderProvider extends ChangeNotifier {
   }
 
   Future<Folder?> createFolder({required String name, String? description, String? color, String? icon}) async {
+    final generation = _sessionGeneration;
     try {
       final folder = await createFolderApi(name: name, description: description, color: color, icon: icon);
+      if (generation != _sessionGeneration) return null;
       if (folder != null) {
         _folders.add(folder);
         _folders.sort((a, b) => a.order.compareTo(b.order));
@@ -63,6 +76,7 @@ class FolderProvider extends ChangeNotifier {
         return folder;
       }
     } catch (e) {
+      if (generation != _sessionGeneration) return null;
       Logger.debug('Error creating folder: $e');
       _error = 'Failed to create folder';
       notifyListeners();
@@ -77,6 +91,7 @@ class FolderProvider extends ChangeNotifier {
     String? color,
     String? icon,
   }) async {
+    final generation = _sessionGeneration;
     try {
       final updatedFolder = await updateFolderApi(
         folderId,
@@ -85,6 +100,7 @@ class FolderProvider extends ChangeNotifier {
         color: color,
         icon: icon,
       );
+      if (generation != _sessionGeneration) return null;
       if (updatedFolder != null) {
         final index = _folders.indexWhere((f) => f.id == folderId);
         if (index >= 0) {
@@ -94,6 +110,7 @@ class FolderProvider extends ChangeNotifier {
         return updatedFolder;
       }
     } catch (e) {
+      if (generation != _sessionGeneration) return null;
       Logger.debug('Error updating folder: $e');
       _error = 'Failed to update folder';
       notifyListeners();
@@ -102,6 +119,7 @@ class FolderProvider extends ChangeNotifier {
   }
 
   Future<bool> deleteFolder(String folderId, {String? moveToFolderId}) async {
+    final generation = _sessionGeneration;
     _folders.removeWhere((f) => f.id == folderId);
     if (_selectedFolderId == folderId) {
       _selectedFolderId = moveToFolderId;
@@ -109,6 +127,7 @@ class FolderProvider extends ChangeNotifier {
     notifyListeners();
     try {
       final success = await deleteFolderApi(folderId, moveToFolderId: moveToFolderId);
+      if (generation != _sessionGeneration) return false;
       if (success) {
         loadFolders();
         return true;
@@ -118,6 +137,7 @@ class FolderProvider extends ChangeNotifier {
         notifyListeners();
       }
     } catch (e) {
+      if (generation != _sessionGeneration) return false;
       Logger.debug('Error deleting folder: $e');
       await loadFolders();
       _error = 'Failed to delete folder';
@@ -127,13 +147,16 @@ class FolderProvider extends ChangeNotifier {
   }
 
   Future<bool> moveConversation(String conversationId, String? folderId) async {
+    final generation = _sessionGeneration;
     try {
       final success = await moveConversationToFolderApi(conversationId, folderId);
+      if (generation != _sessionGeneration) return false;
       if (success) {
         await loadFolders();
         return true;
       }
     } catch (e) {
+      if (generation != _sessionGeneration) return false;
       Logger.debug('Error moving conversation: $e');
       _error = 'Failed to move conversation';
       notifyListeners();
@@ -142,13 +165,16 @@ class FolderProvider extends ChangeNotifier {
   }
 
   Future<int> bulkMoveConversations(List<String> conversationIds, String folderId) async {
+    final generation = _sessionGeneration;
     try {
       final movedCount = await bulkMoveConversationsToFolderApi(folderId, conversationIds);
+      if (generation != _sessionGeneration) return 0;
       if (movedCount > 0) {
         await loadFolders();
       }
       return movedCount;
     } catch (e) {
+      if (generation != _sessionGeneration) return 0;
       Logger.debug('Error bulk moving conversations: $e');
       _error = 'Failed to move conversations';
       notifyListeners();
@@ -157,8 +183,10 @@ class FolderProvider extends ChangeNotifier {
   }
 
   Future<bool> reorderFolders(List<String> folderIds) async {
+    final generation = _sessionGeneration;
     try {
       final success = await reorderFoldersApi(folderIds);
+      if (generation != _sessionGeneration) return false;
       if (success) {
         // Update local order
         for (int i = 0; i < folderIds.length; i++) {
@@ -172,6 +200,7 @@ class FolderProvider extends ChangeNotifier {
         return true;
       }
     } catch (e) {
+      if (generation != _sessionGeneration) return false;
       Logger.debug('Error reordering folders: $e');
       _error = 'Failed to reorder folders';
       notifyListeners();
@@ -186,6 +215,15 @@ class FolderProvider extends ChangeNotifier {
 
   /// Get the default folder
   Folder? get defaultFolder => _folders.firstWhereOrNull((f) => f.isDefault);
+
+  void clearUserData() {
+    _sessionGeneration++;
+    _folders = [];
+    _selectedFolderId = null;
+    _isLoading = false;
+    _error = null;
+    notifyListeners();
+  }
 
   void clearError() {
     _error = null;

--- a/app/lib/providers/goals_provider.dart
+++ b/app/lib/providers/goals_provider.dart
@@ -6,15 +6,17 @@ import 'package:flutter/scheduler.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:omi/backend/http/api/goals.dart';
+import 'package:omi/backend/preferences.dart';
 
 class GoalsProvider extends ChangeNotifier {
-  static const String _goalsStorageKey = 'goals_tracker_local_goals';
+  static const String _legacyGoalsStorageKey = 'goals_tracker_local_goals';
 
   List<Goal> _goals = [];
   bool _isLoading = true;
 
   // Track last goal deletion to prevent API sync from resurrecting deleted goals
   DateTime? _lastGoalDeletion;
+  int _sessionGeneration = 0;
 
   List<Goal> get goals => _goals;
   bool get isLoading => _isLoading;
@@ -26,14 +28,17 @@ class GoalsProvider extends ChangeNotifier {
 
   /// Load goals from local storage first, then sync with API
   Future<void> loadGoals() async {
+    final generation = _sessionGeneration;
     _isLoading = true;
     notifyListeners();
 
     // Load from local storage first (most up-to-date with recent deletions/changes)
-    await _loadFromLocalStorage();
+    await _loadFromLocalStorage(generation);
+    if (generation != _sessionGeneration) return;
 
     // Then sync with API in the background
-    await _syncWithApi();
+    await _syncWithApi(generation);
+    if (generation != _sessionGeneration) return;
 
     _isLoading = false;
     _notifyAfterFrame();
@@ -43,10 +48,14 @@ class GoalsProvider extends ChangeNotifier {
     SchedulerBinding.instance.addPostFrameCallback((_) => notifyListeners());
   }
 
-  Future<void> _loadFromLocalStorage() async {
+  Future<void> _loadFromLocalStorage(int generation) async {
     try {
       final prefs = await SharedPreferences.getInstance();
-      final goalsJson = prefs.getString(_goalsStorageKey);
+      if (generation != _sessionGeneration) return;
+      SharedPreferencesUtil().scopeLegacyUserDataForCurrentUser();
+      final storageKey = _goalsStorageKey;
+      if (storageKey == null) return;
+      final goalsJson = prefs.getString(storageKey);
       if (goalsJson != null) {
         final List<dynamic> decoded = jsonDecode(goalsJson);
         _goals = decoded.map((e) => Goal.fromJson(e)).toList();
@@ -55,7 +64,7 @@ class GoalsProvider extends ChangeNotifier {
     } catch (_) {}
   }
 
-  Future<void> _syncWithApi() async {
+  Future<void> _syncWithApi(int generation) async {
     // Skip if we just deleted a goal to prevent resurrecting it
     final now = DateTime.now();
     final skipApiSync = _lastGoalDeletion != null && now.difference(_lastGoalDeletion!) < const Duration(seconds: 3);
@@ -64,6 +73,7 @@ class GoalsProvider extends ChangeNotifier {
 
     try {
       final goals = await getAllGoals();
+      if (generation != _sessionGeneration) return;
       if (goals.isNotEmpty) {
         _goals = goals;
         await _saveToLocalStorage();
@@ -74,10 +84,25 @@ class GoalsProvider extends ChangeNotifier {
 
   Future<void> _saveToLocalStorage() async {
     try {
+      final storageKey = _goalsStorageKey;
+      if (storageKey == null) return;
       final prefs = await SharedPreferences.getInstance();
       final goalsJson = jsonEncode(_goals.map((g) => g.toJson()).toList());
-      await prefs.setString(_goalsStorageKey, goalsJson);
+      await prefs.setString(storageKey, goalsJson);
     } catch (_) {}
+  }
+
+  String? get _goalsStorageKey {
+    final ownerUid = SharedPreferencesUtil().uid;
+    return ownerUid.isEmpty ? null : '$_legacyGoalsStorageKey:$ownerUid';
+  }
+
+  void clearUserData() {
+    _sessionGeneration++;
+    _goals = [];
+    _isLoading = false;
+    _lastGoalDeletion = null;
+    notifyListeners();
   }
 
   /// Create a new goal
@@ -90,6 +115,7 @@ class GoalsProvider extends ChangeNotifier {
     double maxValue = 10,
     String? unit,
   }) async {
+    final generation = _sessionGeneration;
     final goal = await createGoalApi(
       title: title,
       goalType: goalType,
@@ -99,6 +125,7 @@ class GoalsProvider extends ChangeNotifier {
       maxValue: maxValue,
       unit: unit,
     );
+    if (generation != _sessionGeneration) return null;
 
     if (goal != null) {
       _goals.add(goal);
@@ -119,6 +146,7 @@ class GoalsProvider extends ChangeNotifier {
     double? maxValue,
     String? unit,
   }) async {
+    final generation = _sessionGeneration;
     final updatedGoal = await updateGoalApi(
       goalId,
       title: title,
@@ -128,6 +156,7 @@ class GoalsProvider extends ChangeNotifier {
       maxValue: maxValue,
       unit: unit,
     );
+    if (generation != _sessionGeneration) return null;
 
     if (updatedGoal != null) {
       final index = _goals.indexWhere((g) => g.id == goalId);
@@ -143,7 +172,9 @@ class GoalsProvider extends ChangeNotifier {
 
   /// Update goal progress only
   Future<Goal?> updateGoalProgress(String goalId, double currentValue) async {
+    final generation = _sessionGeneration;
     final updatedGoal = await updateGoalProgressApi(goalId, currentValue);
+    if (generation != _sessionGeneration) return null;
 
     if (updatedGoal != null) {
       final index = _goals.indexWhere((g) => g.id == goalId);

--- a/app/lib/providers/home_provider.dart
+++ b/app/lib/providers/home_provider.dart
@@ -34,6 +34,7 @@ const multiLanguageSupported = {
 };
 
 class HomeProvider extends ChangeNotifier {
+  int _sessionGeneration = 0;
   int selectedIndex = 0;
   Function(int idx)? onSelectedIndexChanged;
   final FocusNode chatFieldFocusNode = FocusNode();
@@ -132,6 +133,25 @@ class HomeProvider extends ChangeNotifier {
     memoriesSearchFieldFocusNode.addListener(_onFocusChange);
   }
 
+  void clearUserData() {
+    _sessionGeneration++;
+    selectedIndex = 0;
+    isAppsSearchFieldFocused = false;
+    isChatFieldFocused = false;
+    isConvoSearchFieldFocused = false;
+    isMemoriesSearchFieldFocused = false;
+    showConvoSearchBar = false;
+    hasSpeakerProfile = false;
+    isLoading = false;
+    userPrimaryLanguage = '';
+    hasSetPrimaryLanguage = false;
+    chatFieldFocusNode.unfocus();
+    appsSearchFieldFocusNode.unfocus();
+    convoSearchFieldFocusNode.unfocus();
+    memoriesSearchFieldFocusNode.unfocus();
+    notifyListeners();
+  }
+
   void _onFocusChange() {
     isChatFieldFocused = chatFieldFocusNode.hasFocus;
     isAppsSearchFieldFocused = appsSearchFieldFocusNode.hasFocus;
@@ -186,8 +206,10 @@ class HomeProvider extends ChangeNotifier {
   }
 
   Future setupHasSpeakerProfile() async {
+    final generation = _sessionGeneration;
     setIsLoading(true);
     var res = await userHasSpeakerProfile();
+    if (generation != _sessionGeneration) return;
     setSpeakerProfile(res);
     SharedPreferencesUtil().hasSpeakerProfile = res;
     Logger.debug('_setupHasSpeakerProfile: ${SharedPreferencesUtil().hasSpeakerProfile}');
@@ -202,8 +224,10 @@ class HomeProvider extends ChangeNotifier {
       return;
     }
 
+    final generation = _sessionGeneration;
     try {
       final language = await getUserPrimaryLanguage();
+      if (generation != _sessionGeneration) return;
       if (language == null) {
         // User hasn't set a primary language yet
         userPrimaryLanguage = '';
@@ -211,7 +235,7 @@ class HomeProvider extends ChangeNotifier {
 
         // Show language dialog after a short delay to ensure UI is ready
         Future.delayed(const Duration(milliseconds: 500), () {
-          if (globalNavigatorKey.currentContext != null) {
+          if (generation == _sessionGeneration && globalNavigatorKey.currentContext != null) {
             showLanguageDialogIfNeeded(globalNavigatorKey.currentContext!);
           }
         });
@@ -224,6 +248,7 @@ class HomeProvider extends ChangeNotifier {
       }
       Logger.debug('setupUserPrimaryLanguage: $language, hasSet: $hasSetPrimaryLanguage');
     } catch (e) {
+      if (generation != _sessionGeneration) return;
       Logger.debug('Error setting up user primary language: $e');
       userPrimaryLanguage = '';
       hasSetPrimaryLanguage = false;

--- a/app/lib/providers/integration_provider.dart
+++ b/app/lib/providers/integration_provider.dart
@@ -9,17 +9,20 @@ class IntegrationProvider extends ChangeNotifier {
   final Map<String, bool> _integrations = {};
   bool _isLoading = false;
   bool _hasLoaded = false;
+  int _sessionGeneration = 0;
 
   Map<String, bool> get integrations => _integrations;
   bool get isLoading => _isLoading;
   bool get hasLoaded => _hasLoaded;
 
   Future<void> loadFromBackend() async {
+    final generation = _sessionGeneration;
     _isLoading = true;
     notifyListeners();
 
     try {
       final responses = await Future.wait([getIntegration('google_calendar')]);
+      if (generation != _sessionGeneration) return;
 
       _integrations['google_calendar'] = responses[0]?.connected ?? false;
       _integrations['gmail'] = false;
@@ -31,16 +34,21 @@ class IntegrationProvider extends ChangeNotifier {
 
       _hasLoaded = true;
     } catch (e) {
+      if (generation != _sessionGeneration) return;
       Logger.debug('Error loading integrations from backend: $e');
     } finally {
-      _isLoading = false;
-      notifyListeners();
+      if (generation == _sessionGeneration) {
+        _isLoading = false;
+        notifyListeners();
+      }
     }
   }
 
   Future<bool> saveConnection(String appKey, Map<String, dynamic> details) async {
+    final generation = _sessionGeneration;
     try {
       final success = await saveIntegration(appKey, details);
+      if (generation != _sessionGeneration) return false;
       if (success) {
         _integrations[appKey] = true;
         notifyListeners();
@@ -53,8 +61,10 @@ class IntegrationProvider extends ChangeNotifier {
   }
 
   Future<bool> deleteConnection(String appKey) async {
+    final generation = _sessionGeneration;
     try {
       final success = await deleteIntegration(appKey);
+      if (generation != _sessionGeneration) return false;
       if (success) {
         _integrations[appKey] = false;
         notifyListeners();
@@ -75,5 +85,15 @@ class IntegrationProvider extends ChangeNotifier {
       case IntegrationApp.gmail:
         return _integrations['gmail'] ?? false;
     }
+  }
+
+  void clearUserData() {
+    _sessionGeneration++;
+    _integrations.clear();
+    _isLoading = false;
+    _hasLoaded = false;
+    SharedPreferencesUtil().saveBool('google_calendar_connected', false);
+    SharedPreferencesUtil().saveBool('gmail_connected', false);
+    notifyListeners();
   }
 }

--- a/app/lib/providers/mcp_provider.dart
+++ b/app/lib/providers/mcp_provider.dart
@@ -12,23 +12,31 @@ class McpProvider with ChangeNotifier {
 
   String? _error;
   String? get error => _error;
+  int _sessionGeneration = 0;
 
   Future<void> fetchKeys() async {
+    final generation = _sessionGeneration;
     _isLoading = true;
     _error = null;
     notifyListeners();
 
     try {
-      _keys = await McpApi.getMcpApiKeys();
+      final keys = await McpApi.getMcpApiKeys();
+      if (generation != _sessionGeneration) return;
+      _keys = keys;
     } catch (e) {
+      if (generation != _sessionGeneration) return;
       _error = e.toString();
     } finally {
-      _isLoading = false;
-      notifyListeners();
+      if (generation == _sessionGeneration) {
+        _isLoading = false;
+        notifyListeners();
+      }
     }
   }
 
   Future<McpApiKeyCreated?> createKey(String name) async {
+    final generation = _sessionGeneration;
     // The dialog handles its own loading state. We don't set _isLoading here
     // to avoid a loading indicator on the main list view while creating.
     _error = null;
@@ -36,20 +44,21 @@ class McpProvider with ChangeNotifier {
     McpApiKeyCreated? newKey;
     try {
       newKey = await McpApi.createMcpApiKey(name);
-      if (newKey != null) {
-        // Add the new key to the top of the list, as the API returns keys sorted by creation date.
-        _keys.insert(0, McpApiKey.fromJson(newKey.toJson()));
-      }
+      if (generation != _sessionGeneration) return null;
+      // Add the new key to the top of the list, as the API returns keys sorted by creation date.
+      _keys.insert(0, McpApiKey.fromJson(newKey.toJson()));
     } catch (e) {
+      if (generation != _sessionGeneration) return null;
       _error = e.toString();
     } finally {
       // Notify listeners to rebuild the UI with the new key or to reflect an error state.
-      notifyListeners();
+      if (generation == _sessionGeneration) notifyListeners();
     }
     return newKey;
   }
 
   Future<void> deleteKey(String keyId) async {
+    final generation = _sessionGeneration;
     // Optimistically remove the key from the UI
     final keyIndex = _keys.indexWhere((key) => key.id == keyId);
     if (keyIndex == -1) return;
@@ -60,11 +69,21 @@ class McpProvider with ChangeNotifier {
 
     try {
       await McpApi.deleteMcpApiKey(keyId);
+      if (generation != _sessionGeneration) return;
     } catch (e) {
+      if (generation != _sessionGeneration) return;
       // If deletion fails, add the key back and show an error
       _keys.insert(keyIndex, keyToRemove);
       _error = e.toString();
       notifyListeners();
     }
+  }
+
+  void clearUserData() {
+    _sessionGeneration++;
+    _keys = [];
+    _isLoading = false;
+    _error = null;
+    notifyListeners();
   }
 }

--- a/app/lib/providers/memories_provider.dart
+++ b/app/lib/providers/memories_provider.dart
@@ -31,6 +31,7 @@ class MemoriesProvider extends ChangeNotifier {
   // Connectivity handling for offline sync
   ConnectivityProvider? _connectivityProvider;
   bool _isSyncing = false;
+  int _sessionGeneration = 0;
 
   List<Memory> get memories => _memories;
   bool get loading => _loading;
@@ -129,9 +130,19 @@ class MemoriesProvider extends ChangeNotifier {
   }
 
   void clearUserData() {
+    _sessionGeneration++;
     _memories = [];
     _selectedCategories = {};
     _showOnlyManual = false;
+    _searchQuery = '';
+    _filterThisDeviceOnly = false;
+    categories = [];
+    selectedCategory = null;
+    _loading = false;
+    _isSyncing = false;
+    _cancelDeletionTimer();
+    _lastDeletedMemory = null;
+    _pendingDeletionId = null;
     notifyListeners();
   }
 
@@ -150,9 +161,13 @@ class MemoriesProvider extends ChangeNotifier {
   }
 
   Future<void> init() async {
+    final generation = _sessionGeneration;
     await _ensureClientDeviceInitialized();
+    if (generation != _sessionGeneration) return;
     await _loadFilter();
+    if (generation != _sessionGeneration) return;
     await loadMemories();
+    if (generation != _sessionGeneration) return;
     // Try to sync any pending memories on init
     await syncPendingMemories();
   }
@@ -199,14 +214,17 @@ class MemoriesProvider extends ChangeNotifier {
   }
 
   Future<void> loadMemories({int limit = 100}) async {
+    final generation = _sessionGeneration;
     _loading = true;
     notifyListeners();
 
     if (_filterThisDeviceOnly) {
       await _ensureClientDeviceInitialized();
+      if (generation != _sessionGeneration) return;
     }
 
     final result = await getMemoriesResult(limit: limit, thisDeviceOnly: _filterThisDeviceOnly);
+    if (generation != _sessionGeneration) return;
     _memories = result.memories;
     _deviceScopeSupported = result.deviceScopeSupported;
 
@@ -225,32 +243,40 @@ class MemoriesProvider extends ChangeNotifier {
   /// Sync pending memories to server when online
   Future<void> syncPendingMemories() async {
     if (_isSyncing) return;
+    final generation = _sessionGeneration;
+    final ownerUid = SharedPreferencesUtil().uid;
+    if (ownerUid.isEmpty) return;
 
-    final pendingMemories = SharedPreferencesUtil().pendingMemories;
+    final pendingMemories = SharedPreferencesUtil().pendingMemories.where((memory) => memory.uid == ownerUid).toList();
     if (pendingMemories.isEmpty) return;
 
     _isSyncing = true;
     Logger.debug('MemoriesProvider: Syncing ${pendingMemories.length} pending memories...');
 
     for (var memory in List.from(pendingMemories)) {
+      if (generation != _sessionGeneration) return;
       try {
         final serverMemory = await createMemoryServer(memory.content, memory.visibility.name, memory.category.name);
 
         if (serverMemory != null) {
-          SharedPreferencesUtil().removePendingMemory(memory.id);
+          SharedPreferencesUtil().removePendingMemory(memory.id, ownerUid: ownerUid);
+          if (generation != _sessionGeneration) return;
           final idx = _memories.indexWhere((m) => m.id == memory.id);
           if (idx != -1) {
             _memories[idx].id = serverMemory.id;
           }
         }
+        if (generation != _sessionGeneration) return;
       } catch (e) {
         Logger.debug('MemoriesProvider: Failed to sync memory ${memory.id}: $e');
         // Keep in pending list for next sync attempt
       }
     }
 
-    _isSyncing = false;
-    notifyListeners();
+    if (generation == _sessionGeneration) {
+      _isSyncing = false;
+      notifyListeners();
+    }
   }
 
   Memory? _lastDeletedMemory;
@@ -342,10 +368,13 @@ class MemoriesProvider extends ChangeNotifier {
     MemoryVisibility visibility = MemoryVisibility.public,
     MemoryCategory category = MemoryCategory.manual,
   ]) async {
+    final generation = _sessionGeneration;
+    final ownerUid = SharedPreferencesUtil().uid;
+    if (ownerUid.isEmpty) return false;
     // Create the memory object first
     final newMemory = Memory(
       id: const Uuid().v4(),
-      uid: SharedPreferencesUtil().uid,
+      uid: ownerUid,
       content: content,
       category: category,
       createdAt: DateTime.now(),
@@ -368,13 +397,16 @@ class MemoriesProvider extends ChangeNotifier {
     final serverMemory = await createMemoryServer(content, visibility.name, category.name);
 
     if (serverMemory != null) {
-      // Remove from pending and update local memory with server ID
-      SharedPreferencesUtil().removePendingMemory(newMemory.id);
+      // Remove from the original account's pending queue even if the visible
+      // session changed while the request was in flight.
+      SharedPreferencesUtil().removePendingMemory(newMemory.id, ownerUid: ownerUid);
+      if (generation != _sessionGeneration) return true;
       final idx = _memories.indexWhere((m) => m.id == newMemory.id);
       if (idx != -1) {
         _memories[idx].id = serverMemory.id;
       }
     }
+    if (generation != _sessionGeneration) return true;
 
     // Return true since memory is saved locally regardless of server sync
     return true;

--- a/app/lib/providers/phone_call_provider.dart
+++ b/app/lib/providers/phone_call_provider.dart
@@ -15,6 +15,7 @@ import 'package:omi/backend/preferences.dart';
 import 'package:omi/backend/schema/phone_call.dart';
 import 'package:omi/backend/schema/transcript_segment.dart';
 import 'package:omi/models/audio_route.dart';
+import 'package:omi/services/auth/auth_token_result.dart';
 import 'package:omi/services/phone_call_service.dart';
 import 'package:omi/utils/logger.dart';
 
@@ -94,6 +95,8 @@ class PhoneCallProvider extends ChangeNotifier {
 
   Future<void>? _initialLoad;
   Future<void> get initialLoad => _initialLoad ?? Future.value();
+  int _sessionGeneration = 0;
+  bool _sessionEnabled = true;
 
   PhoneCallProvider() {
     _nativeService.onCallStateChanged = _onCallStateChanged;
@@ -110,14 +113,21 @@ class PhoneCallProvider extends ChangeNotifier {
   // ************************************************
 
   Future<void> loadVerifiedNumbers() async {
+    _sessionEnabled = true;
+    final generation = _sessionGeneration;
     try {
-      _verifiedNumbers = await api.getVerifiedPhoneNumbers();
+      final numbers = await api.getVerifiedPhoneNumbers();
+      if (generation != _sessionGeneration) return;
+      _verifiedNumbers = numbers;
     } catch (e) {
+      if (generation != _sessionGeneration) return;
       print('PhoneCallProvider: failed to load verified numbers: $e');
       _verifiedNumbers = [];
     } finally {
-      _numbersLoaded = true;
-      notifyListeners();
+      if (generation == _sessionGeneration) {
+        _numbersLoaded = true;
+        notifyListeners();
+      }
     }
   }
 
@@ -128,6 +138,7 @@ class PhoneCallProvider extends ChangeNotifier {
   String? get verificationStatus => _verificationStatus;
 
   Future<bool> startVerification(String phoneNumber) async {
+    final generation = _sessionGeneration;
     _isLoading = true;
     _error = null;
     _validationCode = null;
@@ -137,6 +148,7 @@ class PhoneCallProvider extends ChangeNotifier {
     PlatformManager.instance.analytics.phoneCallVerificationStarted();
 
     var result = await api.verifyPhoneNumber(phoneNumber);
+    if (generation != _sessionGeneration) return false;
     _isLoading = false;
 
     if (result == null) {
@@ -158,7 +170,9 @@ class PhoneCallProvider extends ChangeNotifier {
   }
 
   Future<bool> checkVerification(String phoneNumber) async {
+    final generation = _sessionGeneration;
     var result = await api.checkPhoneVerification(phoneNumber);
+    if (generation != _sessionGeneration) return false;
     if (result == null) return false;
 
     bool verified = result['verified'] == true;
@@ -170,7 +184,9 @@ class PhoneCallProvider extends ChangeNotifier {
   }
 
   Future<bool> deleteNumber(String phoneNumberId) async {
+    final generation = _sessionGeneration;
     var success = await api.deleteVerifiedPhoneNumber(phoneNumberId);
+    if (generation != _sessionGeneration) return false;
     if (success) {
       _verifiedNumbers.removeWhere((n) => n.id == phoneNumberId);
       notifyListeners();
@@ -183,6 +199,8 @@ class PhoneCallProvider extends ChangeNotifier {
   // ************************************************
 
   Future<bool> startCall(String phoneNumber) async {
+    _sessionEnabled = true;
+    final generation = _sessionGeneration;
     if (_callState != PhoneCallState.idle) {
       _error = 'A call is already in progress';
       notifyListeners();
@@ -202,6 +220,7 @@ class PhoneCallProvider extends ChangeNotifier {
 
     // Request mic permission first, before any SDK initialization
     var micStatus = await Permission.microphone.request();
+    if (generation != _sessionGeneration) return false;
     if (!micStatus.isGranted) {
       _callState = PhoneCallState.idle;
       _error = 'Microphone permission is required to make calls';
@@ -211,9 +230,11 @@ class PhoneCallProvider extends ChangeNotifier {
 
     // Resolve contact name from device contacts
     _contactName = await _resolveContactName(phoneNumber);
+    if (generation != _sessionGeneration) return false;
 
     // Get Twilio token
     var token = await api.getPhoneCallToken();
+    if (generation != _sessionGeneration) return false;
     if (token == null) {
       _callState = PhoneCallState.idle;
       _error = 'Failed to get call token. Verify your phone number first.';
@@ -223,6 +244,7 @@ class PhoneCallProvider extends ChangeNotifier {
 
     // Initialize native Twilio SDK
     var initialized = await _nativeService.initialize(token.accessToken);
+    if (generation != _sessionGeneration) return false;
     if (!initialized) {
       _callState = PhoneCallState.idle;
       _error = 'Failed to initialize call service';
@@ -240,6 +262,10 @@ class PhoneCallProvider extends ChangeNotifier {
       callId: callId,
       contactName: _contactName,
     );
+    if (generation != _sessionGeneration) {
+      if (callStarted) unawaited(_nativeService.endCall());
+      return false;
+    }
 
     if (!callStarted) {
       _callState = PhoneCallState.idle;
@@ -270,12 +296,17 @@ class PhoneCallProvider extends ChangeNotifier {
   }
 
   Future<void> loadAudioRoutes() async {
-    _availableRoutes = await _nativeService.getAudioRoutes();
+    final generation = _sessionGeneration;
+    final routes = await _nativeService.getAudioRoutes();
+    if (generation != _sessionGeneration) return;
+    _availableRoutes = routes;
     notifyListeners();
   }
 
   Future<void> selectAudioRoute(AudioRoute route) async {
+    final generation = _sessionGeneration;
     var success = await _nativeService.selectAudioRoute(route.id);
+    if (generation != _sessionGeneration) return;
     if (success) {
       _selectedRoute = route;
       _isSpeakerOn = route.type == AudioRouteType.speaker;
@@ -303,6 +334,7 @@ class PhoneCallProvider extends ChangeNotifier {
   // ************************************************
 
   void _onCallStateChanged(PhoneCallState state) {
+    if (!_sessionEnabled) return;
     _callState = state;
     if (state == PhoneCallState.active && _callStartTime == null) {
       _callStartTime = DateTime.now();
@@ -316,6 +348,7 @@ class PhoneCallProvider extends ChangeNotifier {
   }
 
   void _onAudioData(Uint8List audioData, int channel) {
+    if (!_sessionEnabled) return;
     var socket = _transcriptionSocket;
 
     // Buffer audio during WebSocket reconnect
@@ -392,17 +425,21 @@ class PhoneCallProvider extends ChangeNotifier {
 
   void _scheduleTokenRefresh(int ttlSeconds) {
     _tokenRefreshTimer?.cancel();
+    final generation = _sessionGeneration;
     // Refresh 3 minutes before expiry (or half TTL if TTL < 6 min)
     var refreshInSeconds = ttlSeconds > 360 ? ttlSeconds - 180 : ttlSeconds ~/ 2;
     if (refreshInSeconds <= 0) return;
 
     Logger.info('PhoneCallProvider: scheduling token refresh in ${refreshInSeconds}s');
     _tokenRefreshTimer = Timer(Duration(seconds: refreshInSeconds), () async {
+      if (generation != _sessionGeneration || !_sessionEnabled) return;
       if (_callState != PhoneCallState.active && _callState != PhoneCallState.ringing) return;
       Logger.info('PhoneCallProvider: refreshing call token');
       var token = await api.getPhoneCallToken();
+      if (generation != _sessionGeneration || !_sessionEnabled) return;
       if (token != null) {
         await _nativeService.initialize(token.accessToken);
+        if (generation != _sessionGeneration || !_sessionEnabled) return;
         _scheduleTokenRefresh(token.ttl);
       } else {
         Logger.error('PhoneCallProvider: token refresh failed, retrying in 30s');
@@ -431,7 +468,8 @@ class PhoneCallProvider extends ChangeNotifier {
   // ************************************************
 
   Future<void> _connectTranscriptionSocket() async {
-    if (_currentCallId == null) return;
+    if (_currentCallId == null || !_sessionEnabled) return;
+    final generation = _sessionGeneration;
 
     _wsReconnectTimer?.cancel();
     _wsReconnectTimer = null;
@@ -450,6 +488,7 @@ class PhoneCallProvider extends ChangeNotifier {
 
     try {
       var headers = await buildHeaders(requireAuthCheck: true);
+      if (generation != _sessionGeneration || !_sessionEnabled) return;
       _transcriptionSocket = IOWebSocketChannel.connect(
         wsUrl,
         headers: headers,
@@ -457,6 +496,7 @@ class PhoneCallProvider extends ChangeNotifier {
       );
       _transcriptionSocket!.stream.listen(
         (message) {
+          if (generation != _sessionGeneration || !_sessionEnabled) return;
           if (_transcriptionStatus != TranscriptionStatus.active) {
             _transcriptionStatus = TranscriptionStatus.active;
             notifyListeners();
@@ -466,17 +506,28 @@ class PhoneCallProvider extends ChangeNotifier {
           }
         },
         onError: (error) {
+          if (generation != _sessionGeneration || !_sessionEnabled) return;
           Logger.error('PhoneCallProvider: WebSocket error: $error');
           _transcriptionSocket = null;
           _scheduleReconnect();
         },
         onDone: () {
+          if (generation != _sessionGeneration || !_sessionEnabled) return;
           Logger.info('PhoneCallProvider: WebSocket closed');
           _transcriptionSocket = null;
           _scheduleReconnect();
         },
       );
       _wsReconnectAttempts = 0;
+    } on AuthTokenUnavailableException catch (e) {
+      Logger.debug('PhoneCallProvider: authenticated WebSocket blocked before connect: ${e.result.runtimeType}');
+      _transcriptionSocket = null;
+      if (e.result is AuthTokenTransientFailure) {
+        _scheduleReconnect();
+      } else {
+        _transcriptionStatus = TranscriptionStatus.failed;
+        notifyListeners();
+      }
     } catch (e) {
       Logger.error('PhoneCallProvider: failed to connect WebSocket: $e');
       _transcriptionSocket = null;
@@ -485,7 +536,7 @@ class PhoneCallProvider extends ChangeNotifier {
   }
 
   void _scheduleReconnect() {
-    if (_callState != PhoneCallState.active) return;
+    if (_callState != PhoneCallState.active || !_sessionEnabled) return;
     if (_wsReconnectAttempts >= _maxWsReconnectAttempts) {
       Logger.error('PhoneCallProvider: max reconnect attempts reached, giving up');
       _transcriptionStatus = TranscriptionStatus.failed;
@@ -590,5 +641,34 @@ class PhoneCallProvider extends ChangeNotifier {
     _tokenRefreshTimer?.cancel();
     _nativeService.dispose();
     super.dispose();
+  }
+
+  void clearUserData() {
+    _sessionGeneration++;
+    _sessionEnabled = false;
+    if (_callState != PhoneCallState.idle) unawaited(_nativeService.endCall());
+    _stopDurationTimer();
+    _disconnectTranscriptionSocket();
+    _tokenRefreshTimer?.cancel();
+    _tokenRefreshTimer = null;
+    _callState = PhoneCallState.idle;
+    _currentCallId = null;
+    _remoteNumber = null;
+    _contactName = null;
+    _callStartTime = null;
+    _callDuration = Duration.zero;
+    _transcriptSegments.clear();
+    _availableRoutes = [];
+    _selectedRoute = null;
+    _audioBuffer.clear();
+    _verifiedNumbers = [];
+    _numbersLoaded = false;
+    _validationCode = null;
+    _verificationStatus = null;
+    _transcriptionStatus = TranscriptionStatus.idle;
+    _isLoading = false;
+    _error = null;
+    _lastError = null;
+    notifyListeners();
   }
 }

--- a/app/lib/providers/task_integration_provider.dart
+++ b/app/lib/providers/task_integration_provider.dart
@@ -17,6 +17,7 @@ class TaskIntegrationProvider extends ChangeNotifier {
   bool _hasLoaded = false;
   bool _appleRemindersPermission = false;
   bool _appleRemindersPermissionManuallySet = false;
+  int _sessionGeneration = 0;
 
   TaskIntegrationProvider()
       : _selectedApp = PlatformService.isApple ? TaskIntegrationApp.appleReminders : TaskIntegrationApp.googleTasks;
@@ -28,11 +29,13 @@ class TaskIntegrationProvider extends ChangeNotifier {
 
   /// Load default app and connection details from backend
   Future<void> loadFromBackend() async {
+    final generation = _sessionGeneration;
     _isLoading = true;
     // Don't notify listeners immediately to avoid setState during build
 
     try {
       final response = await getTaskIntegrations();
+      if (generation != _sessionGeneration) return;
       if (response != null) {
         _connectionDetails = response.integrations;
 
@@ -55,6 +58,7 @@ class TaskIntegrationProvider extends ChangeNotifier {
 
         if (PlatformService.isApple && !_appleRemindersPermissionManuallySet) {
           _appleRemindersPermission = await AppleRemindersService().hasPermission();
+          if (generation != _sessionGeneration) return;
           // Ensure backend has connected status for Apple Reminders if permission is granted
           if (_appleRemindersPermission && _connectionDetails['apple_reminders']?['connected'] != true) {
             await saveConnectionDetails('apple_reminders', {'connected': true});
@@ -70,11 +74,14 @@ class TaskIntegrationProvider extends ChangeNotifier {
         }
       }
     } catch (e) {
+      if (generation != _sessionGeneration) return;
       Logger.debug('Error loading task integrations from backend: $e');
     } finally {
-      _isLoading = false;
-      _hasLoaded = true;
-      notifyListeners();
+      if (generation == _sessionGeneration) {
+        _isLoading = false;
+        _hasLoaded = true;
+        notifyListeners();
+      }
     }
   }
 
@@ -92,8 +99,10 @@ class TaskIntegrationProvider extends ChangeNotifier {
 
   /// Save connection details to backend
   Future<bool> saveConnectionDetails(String appKey, Map<String, dynamic> details) async {
+    final generation = _sessionGeneration;
     try {
       final success = await saveTaskIntegration(appKey, details);
+      if (generation != _sessionGeneration) return false;
       if (success) {
         _connectionDetails[appKey] = details;
         notifyListeners();
@@ -108,8 +117,10 @@ class TaskIntegrationProvider extends ChangeNotifier {
 
   /// Delete connection details from backend
   Future<bool> deleteConnection(String appKey) async {
+    final generation = _sessionGeneration;
     try {
       final success = await deleteTaskIntegration(appKey);
+      if (generation != _sessionGeneration) return false;
       if (success) {
         _connectionDetails.remove(appKey);
         notifyListeners();
@@ -141,13 +152,16 @@ class TaskIntegrationProvider extends ChangeNotifier {
   }
 
   Future<void> updateAppleRemindersPermission({bool? granted}) async {
+    final generation = _sessionGeneration;
     if (PlatformService.isApple) {
       if (granted != null) {
         _appleRemindersPermission = granted;
         _appleRemindersPermissionManuallySet = true;
       } else {
         _appleRemindersPermission = await AppleRemindersService().hasPermission();
+        if (generation != _sessionGeneration) return;
       }
+      if (generation != _sessionGeneration) return;
       notifyListeners();
     }
   }
@@ -160,5 +174,20 @@ class TaskIntegrationProvider extends ChangeNotifier {
   /// Trigger a refresh (called after OAuth completes)
   void refresh() {
     loadFromBackend();
+  }
+
+  void clearUserData() {
+    _sessionGeneration++;
+    _selectedApp = PlatformService.isApple ? TaskIntegrationApp.appleReminders : TaskIntegrationApp.googleTasks;
+    _connectionDetails = {};
+    _isLoading = false;
+    _hasLoaded = false;
+    _appleRemindersPermission = false;
+    _appleRemindersPermissionManuallySet = false;
+    TodoistService().setAuthenticated(false);
+    AsanaService().setAuthenticated(false);
+    GoogleTasksService().setAuthenticated(false);
+    ClickUpService().setAuthenticated(false);
+    notifyListeners();
   }
 }

--- a/app/lib/providers/user_provider.dart
+++ b/app/lib/providers/user_provider.dart
@@ -1,10 +1,8 @@
 import 'package:flutter/material.dart';
 
 import 'package:awesome_notifications/awesome_notifications.dart';
-import 'package:geolocator/geolocator.dart';
 
 import 'package:omi/backend/http/api/privacy.dart';
-import 'package:omi/backend/http/api/users.dart' as users_api;
 import 'package:omi/backend/http/api/users.dart';
 import 'package:omi/backend/preferences.dart';
 import 'package:omi/backend/schema/geolocation.dart';
@@ -42,6 +40,7 @@ class UserProvider with ChangeNotifier {
   // Loading states for transcription settings
   bool _isUpdatingSingleLanguageMode = false;
   bool _isUpdatingVocabulary = false;
+  int _sessionGeneration = 0;
 
   // Transcription preferences getters
   bool get singleLanguageMode => _singleLanguageMode;
@@ -61,6 +60,29 @@ class UserProvider with ChangeNotifier {
   String get migrationMessage => _migrationMessage;
   String get sourceLevel => _sourceLevel;
   String get targetLevel => _targetLevel;
+
+  void clearUserData() {
+    _sessionGeneration++;
+    _dataProtectionLevel = 'standard';
+    _isLoading = false;
+    _privateCloudSyncEnabled = false;
+    _trainingDataOptedIn = false;
+    _trainingDataStatus = null;
+    _isMigrating = false;
+    _migrationFailed = false;
+    _migrationQueue = [];
+    _processedCount = 0;
+    _migrationMessage = '';
+    _sourceLevel = '';
+    _targetLevel = '';
+    _startTime = null;
+    _lastKnownLocation = null;
+    _singleLanguageMode = false;
+    _transcriptionVocabulary = [];
+    _isUpdatingSingleLanguageMode = false;
+    _isUpdatingVocabulary = false;
+    notifyListeners();
+  }
 
   String get migrationETA {
     final ctx = globalNavigatorKey.currentContext;
@@ -102,6 +124,7 @@ class UserProvider with ChangeNotifier {
   }
 
   Future<void> initialize() async {
+    final generation = _sessionGeneration;
     _isLoading = true;
 
     // Preload from SharedPreferences for instant UI
@@ -110,29 +133,37 @@ class UserProvider with ChangeNotifier {
 
     try {
       final userProfile = await PrivacyApi.getUserProfile();
+      if (generation != _sessionGeneration) return;
       _dataProtectionLevel = userProfile['data_protection_level'] ?? 'standard';
 
       // Load private cloud sync status
-      await _loadPrivateCloudSyncStatus();
+      await _loadPrivateCloudSyncStatus(generation);
+      if (generation != _sessionGeneration) return;
 
       // Load training data opt-in status
-      await _loadTrainingDataOptIn();
+      await _loadTrainingDataOptIn(generation);
+      if (generation != _sessionGeneration) return;
 
       // Load transcription preferences (will sync with API and update cache)
-      await _loadTranscriptionPreferences();
+      await _loadTranscriptionPreferences(generation);
+      if (generation != _sessionGeneration) return;
 
       final migrationStatus = userProfile['migration_status'];
       if (migrationStatus != null && migrationStatus['status'] == 'in_progress') {
         final targetLevel = migrationStatus['target_level'];
         if (targetLevel != null) {
-          Future.microtask(() => updateDataProtectionLevel(targetLevel));
+          Future.microtask(() {
+            if (generation == _sessionGeneration) updateDataProtectionLevel(targetLevel);
+          });
         }
       }
     } catch (e, stackTrace) {
       Logger.error('Failed to initialize UserProvider: $e\n$stackTrace');
     } finally {
-      _isLoading = false;
-      notifyListeners();
+      if (generation == _sessionGeneration) {
+        _isLoading = false;
+        notifyListeners();
+      }
     }
   }
 
@@ -148,18 +179,22 @@ class UserProvider with ChangeNotifier {
     prefs.cachedTranscriptionVocabulary = _transcriptionVocabulary;
   }
 
-  Future<void> _loadPrivateCloudSyncStatus() async {
+  Future<void> _loadPrivateCloudSyncStatus(int generation) async {
     try {
-      _privateCloudSyncEnabled = await getPrivateCloudSyncEnabled();
+      final enabled = await getPrivateCloudSyncEnabled();
+      if (generation != _sessionGeneration) return;
+      _privateCloudSyncEnabled = enabled;
     } catch (e) {
+      if (generation != _sessionGeneration) return;
       Logger.error('Failed to load private cloud sync status: $e');
       _privateCloudSyncEnabled = false;
     }
   }
 
-  Future<void> _loadTranscriptionPreferences() async {
+  Future<void> _loadTranscriptionPreferences(int generation) async {
     try {
       final prefs = await getTranscriptionPreferences();
+      if (generation != _sessionGeneration) return;
       if (prefs != null) {
         _singleLanguageMode = prefs['single_language_mode'] ?? false;
         _transcriptionVocabulary = List<String>.from(prefs['vocabulary'] ?? []);
@@ -167,17 +202,20 @@ class UserProvider with ChangeNotifier {
         notifyListeners();
       }
     } catch (e) {
+      if (generation != _sessionGeneration) return;
       Logger.error('Failed to load transcription preferences: $e');
       // Keep cached values on error, don't reset
     }
   }
 
-  Future<void> _loadTrainingDataOptIn() async {
+  Future<void> _loadTrainingDataOptIn(int generation) async {
     try {
       final data = await getTrainingDataOptIn();
+      if (generation != _sessionGeneration) return;
       _trainingDataOptedIn = data['opted_in'] ?? false;
       _trainingDataStatus = data['status'];
     } catch (e) {
+      if (generation != _sessionGeneration) return;
       Logger.error('Failed to load training data opt-in status: $e');
       _trainingDataOptedIn = false;
       _trainingDataStatus = null;

--- a/app/lib/services/auth/auth_token_result.dart
+++ b/app/lib/services/auth/auth_token_result.dart
@@ -1,0 +1,78 @@
+sealed class AuthTokenResult {
+  const AuthTokenResult();
+
+  String? get tokenOrNull => switch (this) {
+        AuthTokenSuccess(:final token) => token,
+        _ => null,
+      };
+}
+
+final class AuthTokenSuccess extends AuthTokenResult {
+  const AuthTokenSuccess({required this.token, required this.expirationTime});
+
+  final String token;
+  final DateTime? expirationTime;
+}
+
+final class AuthTokenTransientFailure extends AuthTokenResult {
+  const AuthTokenTransientFailure({required this.failureClass, this.code});
+
+  final String failureClass;
+  final String? code;
+}
+
+final class AuthTokenMissingUser extends AuthTokenResult {
+  const AuthTokenMissingUser();
+}
+
+final class AuthTokenMissingToken extends AuthTokenResult {
+  const AuthTokenMissingToken();
+}
+
+final class AuthTokenTerminalFailure extends AuthTokenResult {
+  const AuthTokenTerminalFailure({required this.code});
+
+  final String code;
+}
+
+enum AuthSessionExpirationReason {
+  missingUser,
+  missingToken,
+  terminalTokenFailure,
+  backendRejectedRefreshedToken,
+  accountDeleted
+}
+
+final class AuthSessionExpiredEvent {
+  const AuthSessionExpiredEvent({required this.reason, this.code});
+
+  final AuthSessionExpirationReason reason;
+  final String? code;
+}
+
+final class AuthUserSnapshot {
+  const AuthUserSnapshot({required this.uid, this.email, this.displayName});
+
+  final String uid;
+  final String? email;
+  final String? displayName;
+}
+
+final class RefreshedAuthToken {
+  const RefreshedAuthToken({required this.token, required this.expirationTime});
+
+  final String? token;
+  final DateTime? expirationTime;
+}
+
+abstract interface class AuthTokenGateway {
+  AuthUserSnapshot? get currentUser;
+
+  Future<RefreshedAuthToken?> forceRefresh();
+
+  Future<void> signOut();
+}
+
+typedef AuthRefreshDelay = Future<void> Function(Duration duration);
+typedef AuthTelemetryRecorder = void Function(String eventName, Map<String, dynamic> properties);
+typedef AuthTelemetryContextProvider = Map<String, dynamic> Function();

--- a/app/lib/services/auth_service.dart
+++ b/app/lib/services/auth_service.dart
@@ -16,13 +16,85 @@ import 'package:url_launcher/url_launcher.dart';
 import 'package:omi/backend/http/api/users.dart';
 import 'package:omi/backend/preferences.dart';
 import 'package:omi/env/env.dart';
+import 'package:omi/flavors.dart';
+import 'package:omi/services/auth/auth_token_result.dart';
 import 'package:omi/utils/logger.dart';
+import 'package:omi/utils/platform/platform_manager.dart';
+
+final class _FirebaseAuthTokenGateway implements AuthTokenGateway {
+  @override
+  AuthUserSnapshot? get currentUser {
+    final user = FirebaseAuth.instance.currentUser;
+    if (user == null) return null;
+    return AuthUserSnapshot(uid: user.uid, email: user.email, displayName: user.displayName);
+  }
+
+  @override
+  Future<RefreshedAuthToken?> forceRefresh() async {
+    final result = await FirebaseAuth.instance.currentUser?.getIdTokenResult(true);
+    if (result == null) return null;
+    return RefreshedAuthToken(token: result.token, expirationTime: result.expirationTime);
+  }
+
+  @override
+  Future<void> signOut() => FirebaseAuth.instance.signOut();
+}
 
 class AuthService {
   static final AuthService _instance = AuthService._internal();
   static AuthService get instance => _instance;
 
-  AuthService._internal();
+  AuthService._internal()
+      : _tokenGateway = _FirebaseAuthTokenGateway(),
+        _refreshDelay = _defaultRefreshDelay,
+        _recordTelemetry = _recordProductionTelemetry,
+        _telemetryContextProvider = _productionTelemetryContext;
+
+  @visibleForTesting
+  AuthService.forTesting({
+    required AuthTokenGateway tokenGateway,
+    AuthRefreshDelay? refreshDelay,
+    AuthTelemetryRecorder? recordTelemetry,
+    AuthTelemetryContextProvider? telemetryContextProvider,
+  })  : _tokenGateway = tokenGateway,
+        _refreshDelay = refreshDelay ?? _defaultRefreshDelay,
+        _recordTelemetry = recordTelemetry ?? ((eventName, properties) {}),
+        _telemetryContextProvider = telemetryContextProvider ?? (() => const {});
+
+  static const int _maxRefreshAttempts = 3;
+  static const List<Duration> _refreshRetryDelays = [Duration(milliseconds: 200), Duration(milliseconds: 500)];
+  static const Set<String> _terminalTokenErrorCodes = {
+    'invalid-user-token',
+    'user-disabled',
+    'user-not-found',
+    'user-token-expired',
+  };
+
+  static Future<void> _defaultRefreshDelay(Duration duration) => Future<void>.delayed(duration);
+
+  final AuthTokenGateway _tokenGateway;
+  final AuthRefreshDelay _refreshDelay;
+  final AuthTelemetryRecorder _recordTelemetry;
+  final AuthTelemetryContextProvider _telemetryContextProvider;
+  final StreamController<AuthSessionExpiredEvent> _sessionExpiredController =
+      StreamController<AuthSessionExpiredEvent>.broadcast(sync: true);
+  Future<AuthTokenResult>? _refreshInFlight;
+  Future<void>? _expireSessionInFlight;
+  bool _sessionExpired = false;
+  int _sessionGeneration = 0;
+  String? _refreshUserUid;
+
+  Stream<AuthSessionExpiredEvent> get sessionExpiredEvents => _sessionExpiredController.stream;
+
+  static void _recordProductionTelemetry(String eventName, Map<String, dynamic> properties) {
+    PlatformManager.instance.analytics.track(eventName, properties: properties);
+  }
+
+  static Map<String, dynamic> _productionTelemetryContext() => {
+        'platform': PlatformManager.instance.platform,
+        'app_version': PlatformManager.instance.appVersion,
+        'release_channel': Env.isTestFlight ? 'testflight' : (F.env == Environment.prod ? 'app_store' : 'dev'),
+      };
 
   bool isSignedIn() => FirebaseAuth.instance.currentUser != null && !FirebaseAuth.instance.currentUser!.isAnonymous;
 
@@ -75,6 +147,7 @@ class AuthService {
     try {
       // Sign out the current user first
       Logger.debug('Signing out current user...');
+      handleAuthUserChanged(null);
       await FirebaseAuth.instance.signOut();
       Logger.debug('User signed out successfully.');
 
@@ -140,8 +213,26 @@ class AuthService {
   }
 
   Future<void> signOut() async {
-    _clearCachedAuth();
-    await FirebaseAuth.instance.signOut();
+    _invalidateRefreshes();
+    _clearCachedIdentityAndAuth();
+    await _tokenGateway.signOut();
+  }
+
+  void _invalidateRefreshes() {
+    _sessionGeneration++;
+    _refreshInFlight = null;
+  }
+
+  void handleAuthUserChanged(String? uid) {
+    if (_refreshUserUid == uid) return;
+    _refreshUserUid = uid;
+    _invalidateRefreshes();
+  }
+
+  void markAuthenticatedUser(String uid) {
+    _refreshUserUid = uid;
+    _sessionExpired = false;
+    _invalidateRefreshes();
   }
 
   void _clearCachedAuth() {
@@ -149,44 +240,177 @@ class AuthService {
     SharedPreferencesUtil().tokenExpirationTime = 0;
   }
 
-  Future<String?> getIdToken() async {
-    try {
-      if (FirebaseAuth.instance.currentUser == null) {
-        Logger.debug('getIdToken: currentUser is null, clearing cached token');
-        _clearCachedAuth();
-        return null;
-      }
-      IdTokenResult? newToken = await FirebaseAuth.instance.currentUser?.getIdTokenResult(true);
-      if (newToken?.token != null) {
-        var user = FirebaseAuth.instance.currentUser!;
-        SharedPreferencesUtil().uid = user.uid;
-        SharedPreferencesUtil().tokenExpirationTime = newToken?.expirationTime?.millisecondsSinceEpoch ?? 0;
-        SharedPreferencesUtil().authToken = newToken?.token ?? '';
-        if (SharedPreferencesUtil().email.isEmpty) {
-          SharedPreferencesUtil().email = user.email ?? '';
-        }
+  void _clearCachedIdentityAndAuth() {
+    SharedPreferencesUtil().clearUserDisplayCache();
+  }
 
-        if (SharedPreferencesUtil().givenName.isEmpty) {
-          SharedPreferencesUtil().givenName = user.displayName?.split(' ')[0] ?? '';
-          if ((user.displayName?.split(' ').length ?? 0) > 1) {
-            SharedPreferencesUtil().familyName = user.displayName?.split(' ')[1] ?? '';
-          } else {
-            SharedPreferencesUtil().familyName = '';
-          }
+  /// Compatibility for sign-in/onboarding callers that only need the token.
+  /// Authenticated HTTP must use [refreshIdToken] so failure classes are kept.
+  Future<String?> getIdToken() async {
+    final result = await refreshIdToken();
+    switch (result) {
+      case AuthTokenSuccess(:final token):
+        return token;
+      case AuthTokenMissingToken():
+        await expireSession(const AuthSessionExpiredEvent(reason: AuthSessionExpirationReason.missingToken));
+        break;
+      case AuthTokenTerminalFailure(:final code):
+        await expireSession(
+          AuthSessionExpiredEvent(reason: AuthSessionExpirationReason.terminalTokenFailure, code: code),
+        );
+        break;
+      case AuthTokenMissingUser():
+        break;
+      case AuthTokenTransientFailure():
+        break;
+    }
+    return null;
+  }
+
+  Future<AuthTokenResult> refreshIdToken() {
+    if (_sessionExpired) {
+      return Future<AuthTokenResult>.value(const AuthTokenMissingUser());
+    }
+    final currentUid = _tokenGateway.currentUser?.uid;
+    if (_refreshUserUid != currentUid) {
+      _refreshUserUid = currentUid;
+      _invalidateRefreshes();
+    }
+    final inFlight = _refreshInFlight;
+    if (inFlight != null) return inFlight;
+
+    final generation = _sessionGeneration;
+    final refresh = _refreshIdTokenWithRetries(generation, currentUid);
+    _refreshInFlight = refresh;
+    unawaited(
+      refresh.then<void>(
+        (result) {
+          if (identical(_refreshInFlight, refresh)) _refreshInFlight = null;
+        },
+        onError: (Object error, StackTrace stackTrace) {
+          if (identical(_refreshInFlight, refresh)) _refreshInFlight = null;
+        },
+      ),
+    );
+    return refresh;
+  }
+
+  Future<AuthTokenResult> _refreshIdTokenWithRetries(int generation, String? expectedUid) async {
+    if (generation != _sessionGeneration) return const AuthTokenMissingUser();
+    if (expectedUid == null || _tokenGateway.currentUser?.uid != expectedUid) {
+      Logger.debug('refreshIdToken: currentUser is null');
+      _clearCachedAuth();
+      return const AuthTokenMissingUser();
+    }
+
+    AuthTokenResult? lastRetryableFailure;
+    for (var attempt = 0; attempt < _maxRefreshAttempts; attempt++) {
+      if (generation != _sessionGeneration) return const AuthTokenMissingUser();
+      final result = await _refreshIdTokenOnce(generation, expectedUid);
+      if (result is! AuthTokenTransientFailure && result is! AuthTokenMissingToken) {
+        if (result is AuthTokenTerminalFailure) {
+          _recordRefreshFailure(failureClass: 'terminal', code: result.code);
         }
-        return newToken?.token;
+        return result;
       }
-      Logger.debug('getIdToken: token refresh returned null');
-      return null;
-    } on FirebaseAuthException catch (e) {
-      Logger.debug('getIdToken: FirebaseAuthException: ${e.code} - $e');
-      if (e.code == 'user-not-found' || e.code == 'user-disabled' || e.code == 'user-token-expired') {
+      lastRetryableFailure = result;
+      if (attempt < _refreshRetryDelays.length) {
+        await _refreshDelay(_refreshRetryDelays[attempt]);
+      }
+    }
+    if (lastRetryableFailure is AuthTokenTransientFailure) {
+      _recordRefreshFailure(failureClass: lastRetryableFailure.failureClass, code: lastRetryableFailure.code);
+    } else if (lastRetryableFailure is AuthTokenMissingToken) {
+      _recordRefreshFailure(failureClass: 'missing_token');
+    }
+    return lastRetryableFailure!;
+  }
+
+  Future<AuthTokenResult> _refreshIdTokenOnce(int generation, String expectedUid) async {
+    try {
+      final refreshed = await _tokenGateway.forceRefresh();
+      if (generation != _sessionGeneration || _tokenGateway.currentUser?.uid != expectedUid) {
+        return const AuthTokenMissingUser();
+      }
+      final token = refreshed?.token;
+      if (token == null || token.isEmpty) {
+        Logger.debug('refreshIdToken: token refresh returned no token');
+        return const AuthTokenMissingToken();
+      }
+
+      final user = _tokenGateway.currentUser;
+      if (user == null || user.uid != expectedUid) {
         _clearCachedAuth();
+        return const AuthTokenMissingUser();
       }
-      return null;
+
+      SharedPreferencesUtil().uid = user.uid;
+      SharedPreferencesUtil().tokenExpirationTime = refreshed?.expirationTime?.millisecondsSinceEpoch ?? 0;
+      SharedPreferencesUtil().authToken = token;
+      if (SharedPreferencesUtil().email.isEmpty) {
+        SharedPreferencesUtil().email = user.email ?? '';
+      }
+      if (SharedPreferencesUtil().givenName.isEmpty) {
+        final nameParts = user.displayName?.split(' ') ?? const <String>[];
+        SharedPreferencesUtil().givenName = nameParts.isEmpty ? '' : nameParts.first;
+        SharedPreferencesUtil().familyName = nameParts.length > 1 ? nameParts[1] : '';
+      }
+      _sessionExpired = false;
+      return AuthTokenSuccess(token: token, expirationTime: refreshed?.expirationTime);
+    } on FirebaseAuthException catch (e) {
+      if (generation != _sessionGeneration) return const AuthTokenMissingUser();
+      Logger.debug('refreshIdToken: FirebaseAuthException: ${e.code}');
+      if (_terminalTokenErrorCodes.contains(e.code)) {
+        _clearCachedAuth();
+        return AuthTokenTerminalFailure(code: e.code);
+      }
+      return AuthTokenTransientFailure(failureClass: 'firebase_transient', code: e.code);
     } catch (e) {
-      Logger.debug('getIdToken: token refresh failed (transient): $e');
-      return null;
+      if (generation != _sessionGeneration) return const AuthTokenMissingUser();
+      Logger.debug('refreshIdToken: token refresh failed transiently: ${e.runtimeType}');
+      return const AuthTokenTransientFailure(failureClass: 'transient');
+    }
+  }
+
+  void _recordRefreshFailure({required String failureClass, String? code}) {
+    _recordTelemetry('auth_token_refresh_failed', {
+      'failure_class': failureClass,
+      'code': code ?? failureClass,
+      ..._telemetryContextProvider(),
+    });
+  }
+
+  void recordAuthenticatedRequest401({required bool recovered, required String outcome}) {
+    _recordTelemetry('authenticated_request_401', {
+      'recovered': recovered,
+      'outcome': outcome,
+      ..._telemetryContextProvider(),
+    });
+  }
+
+  Future<void> expireSession(AuthSessionExpiredEvent event) {
+    final inFlight = _expireSessionInFlight;
+    if (_sessionExpired) return inFlight ?? Future<void>.value();
+
+    _sessionExpired = true;
+    _invalidateRefreshes();
+    _clearCachedIdentityAndAuth();
+    _sessionExpiredController.add(event);
+    final expiration = _runSessionExpiration();
+    _expireSessionInFlight = expiration;
+    return expiration;
+  }
+
+  Future<void> _runSessionExpiration() async {
+    try {
+      await _tokenGateway.signOut();
+    } catch (e) {
+      // Local session state is already terminal and cleared. A platform sign-
+      // out failure must not escape back into request handling or restore the
+      // stale authenticated shell.
+      Logger.debug('expireSession: Firebase sign-out failed: ${e.runtimeType}');
+    } finally {
+      _expireSessionInFlight = null;
     }
   }
 
@@ -374,6 +598,7 @@ class AuthService {
     try {
       final user = result.user;
       if (user == null) return;
+      markAuthenticatedUser(user.uid);
 
       // Update UID and basic user info
       SharedPreferencesUtil().uid = user.uid;
@@ -667,11 +892,13 @@ class AuthService {
     final existingCred = e.credential;
 
     // Sign out current anonymous user
+    handleAuthUserChanged(null);
     await FirebaseAuth.instance.signOut();
 
     // Sign in with existing account
     final result = await FirebaseAuth.instance.signInWithCredential(existingCred!);
     final newUserId = FirebaseAuth.instance.currentUser?.uid;
+    if (newUserId != null) markAuthenticatedUser(newUserId);
     await getIdToken();
 
     SharedPreferencesUtil().onboardingCompleted = false;

--- a/app/lib/services/sockets/pure_socket.dart
+++ b/app/lib/services/sockets/pure_socket.dart
@@ -39,6 +39,8 @@ class PureSocketMessage {
   String? raw;
 }
 
+typedef SocketHeadersProvider = Future<Map<String, String>> Function();
+
 class PureSocket implements IPureSocket {
   WebSocketChannel? _channel;
   WebSocketChannel get channel {
@@ -55,9 +57,12 @@ class PureSocket implements IPureSocket {
   IPureSocketListener? _listener;
 
   String url;
+  final SocketHeadersProvider _headersProvider;
 
-  PureSocket(this.url);
+  PureSocket(this.url, {SocketHeadersProvider? headersProvider})
+      : _headersProvider = headersProvider ?? (() => buildHeaders(requireAuthCheck: true));
 
+  @override
   void setListener(IPureSocketListener listener) {
     _listener = listener;
   }
@@ -68,8 +73,15 @@ class PureSocket implements IPureSocket {
       return false;
     }
 
-    Logger.debug("request wss ${url}");
-    final headers = await buildHeaders(requireAuthCheck: true);
+    Logger.debug("request wss $url");
+    final Map<String, String> headers;
+    try {
+      headers = await _headersProvider();
+    } on AuthTokenUnavailableException catch (e) {
+      Logger.debug('[Socket] Connect blocked before send: ${e.result.runtimeType}');
+      _status = PureSocketStatus.notConnected;
+      return false;
+    }
 
     _channel = IOWebSocketChannel.connect(
       url,

--- a/app/lib/utils/auth/clear_deleted_account_session.dart
+++ b/app/lib/utils/auth/clear_deleted_account_session.dart
@@ -1,0 +1,25 @@
+import 'package:omi/services/auth/auth_token_result.dart';
+import 'package:omi/services/auth_service.dart';
+
+Future<void> clearDeletedAccountSession({
+  required AuthService authService,
+  required void Function() clearUserState,
+  required Future<void> Function() clearWal,
+  required Future<void> Function() clearPreferences,
+}) async {
+  clearUserState();
+  await authService.expireSession(const AuthSessionExpiredEvent(reason: AuthSessionExpirationReason.accountDeleted));
+  try {
+    await clearWal();
+  } catch (_) {
+    // Preferences still contain the primary identity/auth material and must
+    // be cleared even when local audio cleanup fails.
+  } finally {
+    try {
+      await clearPreferences();
+    } catch (_) {
+      // Best-effort cleanup: do not turn a completed server deletion into a
+      // misleading failure screen because local storage is already degraded.
+    }
+  }
+}

--- a/app/lib/utils/auth/clear_user_state.dart
+++ b/app/lib/utils/auth/clear_user_state.dart
@@ -5,10 +5,19 @@ import 'package:omi/providers/action_items_provider.dart';
 import 'package:omi/providers/app_provider.dart';
 import 'package:omi/providers/capture_provider.dart';
 import 'package:omi/providers/conversation_provider.dart';
+import 'package:omi/providers/folder_provider.dart';
+import 'package:omi/providers/goals_provider.dart';
+import 'package:omi/providers/home_provider.dart';
+import 'package:omi/providers/integration_provider.dart';
 import 'package:omi/providers/memories_provider.dart';
 import 'package:omi/providers/message_provider.dart';
 import 'package:omi/providers/people_provider.dart';
+import 'package:omi/providers/mcp_provider.dart';
+import 'package:omi/providers/phone_call_provider.dart';
+import 'package:omi/providers/task_integration_provider.dart';
 import 'package:omi/providers/usage_provider.dart';
+import 'package:omi/providers/user_provider.dart';
+import 'package:omi/pages/payments/payment_method_provider.dart';
 
 /// Wipes in-memory user-scoped state from every provider so a subsequent
 /// login (different account) doesn't briefly render the previous user's
@@ -22,4 +31,13 @@ void clearAllUserState(BuildContext context) {
   context.read<PeopleProvider>().clearUserData();
   context.read<ActionItemsProvider>().clearUserData();
   context.read<UsageProvider>().clearUserData();
+  context.read<UserProvider>().clearUserData();
+  context.read<FolderProvider>().clearUserData();
+  context.read<HomeProvider>().clearUserData();
+  context.read<GoalsProvider>().clearUserData();
+  context.read<PhoneCallProvider>().clearUserData();
+  context.read<TaskIntegrationProvider>().clearUserData();
+  context.read<IntegrationProvider>().clearUserData();
+  context.read<McpProvider>().clearUserData();
+  context.read<PaymentMethodProvider>().clearUserData();
 }

--- a/app/test/providers/conversation_provider_auth_retry_test.dart
+++ b/app/test/providers/conversation_provider_auth_retry_test.dart
@@ -1,0 +1,148 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:omi/backend/preferences.dart';
+import 'package:omi/backend/schema/conversation.dart';
+import 'package:omi/backend/schema/structured.dart';
+import 'package:omi/providers/conversation_provider.dart';
+
+void main() {
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    await SharedPreferencesUtil.init();
+  });
+
+  test('signed-out failure does not retry or request daily summaries', () async {
+    var signedIn = true;
+    var fetchCalls = 0;
+    var dailySummaryCalls = 0;
+    final response = Completer<({List<ServerConversation> items, bool ok})>();
+    final provider = ConversationProvider(
+      conversationListFetcher: () {
+        fetchCalls++;
+        return response.future;
+      },
+      dailySummariesChecker: () async {
+        dailySummaryCalls++;
+        return false;
+      },
+      isSignedIn: () => signedIn,
+    );
+    addTearDown(provider.dispose);
+
+    final initialFetch = provider.getInitialConversations();
+    signedIn = false;
+    response.complete((items: <ServerConversation>[], ok: false));
+    await initialFetch;
+
+    expect(fetchCalls, 1);
+    expect(dailySummaryCalls, 0);
+    expect(provider.isAwaitingInitialFetchRetry, isFalse);
+  });
+
+  test('clearUserData invalidates an in-flight failure before it can retry', () async {
+    final response = Completer<({List<ServerConversation> items, bool ok})>();
+    var dailySummaryCalls = 0;
+    final provider = ConversationProvider(
+      conversationListFetcher: () => response.future,
+      dailySummariesChecker: () async {
+        dailySummaryCalls++;
+        return false;
+      },
+      isSignedIn: () => true,
+    );
+    addTearDown(provider.dispose);
+
+    final initialFetch = provider.getInitialConversations();
+    provider.clearUserData();
+    response.complete((items: <ServerConversation>[], ok: false));
+    await initialFetch;
+
+    expect(dailySummaryCalls, 0);
+    expect(provider.conversationsLoadFailed, isFalse);
+    expect(provider.isAwaitingInitialFetchRetry, isFalse);
+  });
+
+  test('signed-in transient failure keeps the existing retry behavior', () async {
+    var dailySummaryCalls = 0;
+    final provider = ConversationProvider(
+      conversationListFetcher: () async => (items: <ServerConversation>[], ok: false),
+      dailySummariesChecker: () async {
+        dailySummaryCalls++;
+        return false;
+      },
+      isSignedIn: () => true,
+    );
+    addTearDown(provider.dispose);
+
+    await provider.getInitialConversations();
+
+    expect(dailySummaryCalls, 0);
+    expect(provider.conversationsLoadFailed, isTrue);
+    expect(provider.isAwaitingInitialFetchRetry, isTrue);
+  });
+
+  test('successful initial fetch still checks daily summaries', () async {
+    var dailySummaryCalls = 0;
+    final provider = ConversationProvider(
+      conversationListFetcher: () async => (items: <ServerConversation>[], ok: true),
+      dailySummariesChecker: () async {
+        dailySummaryCalls++;
+        return true;
+      },
+      isSignedIn: () => true,
+    );
+    addTearDown(provider.dispose);
+
+    await provider.getInitialConversations();
+
+    expect(dailySummaryCalls, 1);
+    expect(provider.hasDailySummaries, isTrue);
+    expect(provider.isAwaitingInitialFetchRetry, isFalse);
+  });
+
+  test('clearUserData invalidates an in-flight search result', () async {
+    final response = Completer<(List<ServerConversation>, int, int)>();
+    final provider = ConversationProvider(
+      conversationSearchFetcher: (query, {page, limit, required includeDiscarded, speakerId}) => response.future,
+      isSignedIn: () => true,
+    );
+    addTearDown(provider.dispose);
+
+    final search = provider.searchConversations('old account');
+    provider.clearUserData();
+    response.complete(([_conversation('old-search-result')], 1, 1));
+    await search;
+
+    expect(provider.searchedConversations, isEmpty);
+    expect(provider.groupedConversations, isEmpty);
+  });
+
+  test('clearUserData invalidates an in-flight search pagination result', () async {
+    final response = Completer<(List<ServerConversation>, int, int)>();
+    final provider = ConversationProvider(
+      conversationSearchFetcher: (query, {page, limit, required includeDiscarded, speakerId}) => response.future,
+      isSignedIn: () => true,
+    );
+    addTearDown(provider.dispose);
+    provider.previousQuery = 'old account';
+    provider.currentSearchPage = 1;
+    provider.totalSearchPages = 2;
+
+    final searchMore = provider.searchMoreConversations();
+    provider.clearUserData();
+    response.complete(([_conversation('old-page-result')], 2, 2));
+    await searchMore;
+
+    expect(provider.searchedConversations, isEmpty);
+    expect(provider.groupedConversations, isEmpty);
+  });
+}
+
+ServerConversation _conversation(String id) => ServerConversation(
+      id: id,
+      createdAt: DateTime.utc(2026),
+      structured: Structured('Old account', 'Must not reappear'),
+    );

--- a/app/test/providers/folder_provider_session_generation_test.dart
+++ b/app/test/providers/folder_provider_session_generation_test.dart
@@ -1,0 +1,36 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:omi/backend/schema/folder.dart';
+import 'package:omi/providers/folder_provider.dart';
+
+void main() {
+  test('clearUserData invalidates an older in-flight folder load', () async {
+    final response = Completer<List<Folder>>();
+    final provider = FolderProvider(foldersFetcher: () => response.future);
+    addTearDown(provider.dispose);
+
+    final load = provider.loadFolders();
+    provider.clearUserData();
+    response.complete([_folder('old-account')]);
+    await load;
+
+    expect(provider.folders, isEmpty);
+    expect(provider.isLoading, isFalse);
+    expect(provider.error, isNull);
+  });
+}
+
+Folder _folder(String id) => Folder(
+      id: id,
+      name: 'Old account',
+      color: '#FFFFFF',
+      icon: 'folder',
+      createdAt: DateTime.utc(2026),
+      updatedAt: DateTime.utc(2026),
+      order: 0,
+      isDefault: false,
+      isSystem: false,
+      conversationCount: 1,
+    );

--- a/app/test/unit/auth_service_token_result_test.dart
+++ b/app/test/unit/auth_service_token_result_test.dart
@@ -1,0 +1,359 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:omi/backend/preferences.dart';
+import 'package:omi/backend/schema/memory.dart';
+import 'package:omi/services/auth/auth_token_result.dart';
+import 'package:omi/services/auth_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    await SharedPreferencesUtil.init();
+  });
+
+  test('successful refresh returns typed token and updates cache', () async {
+    final gateway = _FakeTokenGateway(
+      results: [RefreshedAuthToken(token: 'fresh-token', expirationTime: DateTime.fromMillisecondsSinceEpoch(123456))],
+    );
+    final service = _service(gateway);
+
+    final result = await service.refreshIdToken();
+
+    expect(result, isA<AuthTokenSuccess>());
+    expect(result.tokenOrNull, 'fresh-token');
+    expect(SharedPreferencesUtil().authToken, 'fresh-token');
+    expect(SharedPreferencesUtil().tokenExpirationTime, 123456);
+    expect(SharedPreferencesUtil().uid, 'user-1');
+  });
+
+  test('concurrent refreshes share one in-flight SDK call', () async {
+    final completer = Completer<RefreshedAuthToken?>();
+    final gateway = _FakeTokenGateway(refreshCompleter: completer);
+    final service = _service(gateway);
+
+    final first = service.refreshIdToken();
+    final second = service.refreshIdToken();
+    completer.complete(RefreshedAuthToken(token: 'shared-token', expirationTime: DateTime.now()));
+
+    expect(await first, isA<AuthTokenSuccess>());
+    expect(await second, isA<AuthTokenSuccess>());
+    expect(gateway.refreshCalls, 1);
+  });
+
+  test('terminal expiration invalidates an older in-flight refresh', () async {
+    SharedPreferencesUtil().authToken = 'old-token';
+    SharedPreferencesUtil().uid = 'old-user';
+    final completer = Completer<RefreshedAuthToken?>();
+    final gateway = _FakeTokenGateway(refreshCompleter: completer);
+    final service = _service(gateway);
+
+    final refresh = service.refreshIdToken();
+    await service.expireSession(
+      const AuthSessionExpiredEvent(reason: AuthSessionExpirationReason.backendRejectedRefreshedToken),
+    );
+    completer.complete(RefreshedAuthToken(token: 'stale-new-token', expirationTime: DateTime.now()));
+
+    expect(await refresh, isA<AuthTokenMissingUser>());
+    expect(SharedPreferencesUtil().authToken, isEmpty);
+    expect(SharedPreferencesUtil().uid, isEmpty);
+    expect(gateway.signOutCalls, 1);
+  });
+
+  test('account switch cannot reuse or cache the previous user refresh', () async {
+    final oldRefresh = Completer<RefreshedAuthToken?>();
+    final gateway = _FakeTokenGateway(refreshCompleter: oldRefresh);
+    final service = _service(gateway);
+
+    final first = service.refreshIdToken();
+    gateway.user = const AuthUserSnapshot(uid: 'user-2');
+    gateway.refreshCompleter = null;
+    service.handleAuthUserChanged('user-2');
+    final second = service.refreshIdToken();
+    oldRefresh.complete(RefreshedAuthToken(token: 'user-1-token', expirationTime: DateTime.now()));
+
+    expect(await first, isA<AuthTokenMissingUser>());
+    expect((await second).tokenOrNull, 'default-token');
+    expect(SharedPreferencesUtil().uid, 'user-2');
+    expect(SharedPreferencesUtil().authToken, 'default-token');
+    expect(gateway.refreshCalls, 2);
+  });
+
+  test('observed Firebase user events cannot unlock a terminal session', () async {
+    final gateway = _FakeTokenGateway();
+    final service = _service(gateway);
+
+    await service.expireSession(const AuthSessionExpiredEvent(reason: AuthSessionExpirationReason.accountDeleted));
+    service.handleAuthUserChanged(null);
+    service.handleAuthUserChanged('user-1');
+
+    expect(await service.refreshIdToken(), isA<AuthTokenMissingUser>());
+    expect(gateway.refreshCalls, 0);
+    service.markAuthenticatedUser('user-1');
+    expect((await service.refreshIdToken()).tokenOrNull, 'default-token');
+    expect(gateway.refreshCalls, 1);
+  });
+
+  test('transient refresh is bounded and does not sign out', () async {
+    final gateway = _FakeTokenGateway(error: StateError('network unavailable'));
+    final delays = <Duration>[];
+    final events = <_TelemetryEvent>[];
+    final service = _service(
+      gateway,
+      refreshDelay: (delay) async => delays.add(delay),
+      recordTelemetry: (name, properties) => events.add(_TelemetryEvent(name, properties)),
+    );
+
+    final result = await service.refreshIdToken();
+
+    expect(result, isA<AuthTokenTransientFailure>());
+    expect(gateway.refreshCalls, 3);
+    expect(delays, [const Duration(milliseconds: 200), const Duration(milliseconds: 500)]);
+    expect(gateway.signOutCalls, 0);
+    expect(events, hasLength(1));
+    expect(events, everyElement(predicate<_TelemetryEvent>((event) => event.properties['code'] == 'transient')));
+  });
+
+  test('null token consumes bounded retries without signing out', () async {
+    final gateway = _FakeTokenGateway(
+      results: List<RefreshedAuthToken?>.filled(3, RefreshedAuthToken(token: null, expirationTime: DateTime.now())),
+    );
+    final events = <_TelemetryEvent>[];
+    final service = _service(
+      gateway,
+      recordTelemetry: (name, properties) => events.add(_TelemetryEvent(name, properties)),
+    );
+
+    final result = await service.refreshIdToken();
+
+    expect(result, isA<AuthTokenMissingToken>());
+    expect(gateway.refreshCalls, 3);
+    expect(gateway.signOutCalls, 0, reason: 'an SDK null-token result is not itself a terminal session decision');
+    expect(events, hasLength(1));
+    expect(events, everyElement(predicate<_TelemetryEvent>((event) => event.properties['code'] == 'missing_token')));
+  });
+
+  test('one null-token SDK result can recover on the next bounded attempt', () async {
+    final gateway = _FakeTokenGateway(
+      results: [
+        RefreshedAuthToken(token: null, expirationTime: DateTime.now()),
+        RefreshedAuthToken(token: 'recovered-token', expirationTime: DateTime.now()),
+      ],
+    );
+    final service = _service(gateway);
+
+    final result = await service.refreshIdToken();
+
+    expect(result, isA<AuthTokenSuccess>());
+    expect(result.tokenOrNull, 'recovered-token');
+    expect(gateway.refreshCalls, 2);
+    expect(gateway.signOutCalls, 0);
+  });
+
+  test('legacy token caller expires session only after null-token budget is exhausted', () async {
+    final gateway = _FakeTokenGateway(
+      results: List<RefreshedAuthToken?>.filled(3, RefreshedAuthToken(token: null, expirationTime: DateTime.now())),
+    );
+    final service = _service(gateway);
+
+    final token = await service.getIdToken();
+
+    expect(token, isNull);
+    expect(gateway.refreshCalls, 3);
+    expect(gateway.signOutCalls, 1);
+  });
+
+  test('missing Firebase user is distinct and clears only cached auth', () async {
+    SharedPreferencesUtil().authToken = 'stale';
+    SharedPreferencesUtil().tokenExpirationTime = 99;
+    final gateway = _FakeTokenGateway(user: null);
+    final service = _service(gateway);
+
+    final result = await service.refreshIdToken();
+
+    expect(result, isA<AuthTokenMissingUser>());
+    expect(gateway.refreshCalls, 0);
+    expect(SharedPreferencesUtil().authToken, isEmpty);
+    expect(SharedPreferencesUtil().tokenExpirationTime, 0);
+  });
+
+  test('terminal Firebase error is typed and telemetry contains only safe context', () async {
+    final events = <_TelemetryEvent>[];
+    final gateway = _FakeTokenGateway(error: FirebaseAuthException(code: 'user-disabled'));
+    final service = _service(
+      gateway,
+      recordTelemetry: (name, properties) => events.add(_TelemetryEvent(name, properties)),
+    );
+
+    final result = await service.refreshIdToken();
+
+    expect(result, isA<AuthTokenTerminalFailure>());
+    expect((result as AuthTokenTerminalFailure).code, 'user-disabled');
+    expect(events, hasLength(1));
+    expect(events.single.name, 'auth_token_refresh_failed');
+    expect(events.single.properties, {
+      'failure_class': 'terminal',
+      'code': 'user-disabled',
+      'platform': 'ios',
+      'app_version': '1.2.3+456',
+      'release_channel': 'testflight',
+    });
+    for (final forbidden in <String>['token', 'uid', 'email', 'request_body']) {
+      expect(events.single.properties.containsKey(forbidden), isFalse);
+    }
+  });
+
+  test('expireSession is idempotent, emits once, and clears only user display caches', () async {
+    final pendingMemory = Memory(
+      id: 'pending-1',
+      uid: 'user-1',
+      content: 'unsynced',
+      category: MemoryCategory.manual,
+      createdAt: DateTime.utc(2026),
+      updatedAt: DateTime.utc(2026),
+      visibility: MemoryVisibility.private,
+    );
+    SharedPreferences.setMockInitialValues({
+      'authToken': 'secret',
+      'tokenExpirationTime': 123,
+      'uid': 'user-1',
+      'email': 'person@example.com',
+      'givenName': 'Person',
+      'familyName': 'Example',
+      'cachedConversations': <String>['conversation'],
+      'cachedMemories': <String>['legacy-memory'],
+      'cachedMessages': <String>['message'],
+      'cachedPeople': <String>['person'],
+      'appsList': <String>['app'],
+      'modifiedConversationDetails': 'conversation-detail',
+      'cachedSingleLanguageMode': true,
+      'cachedTranscriptionVocabulary': <String>['private phrase'],
+      'userPrimaryLanguage': 'en',
+      'hasSetPrimaryLanguage': true,
+      'hasSpeakerProfile': true,
+      'selectedChatAppId2': 'old-app',
+      'lastUsedSummarizationAppId': 'old-summary-app',
+      'preferredSummarizationAppId': 'old-preferred-app',
+      'calendarEnabled': true,
+      'pendingMemories': <String>[jsonEncode(pendingMemory.toJson())],
+      'goals_tracker_local_goals': '[{"id":"old-goal"}]',
+      'btDevice': 'preserve-device',
+      'onboardingCompleted': true,
+      'offlineRecordingMarker': 'preserve-recording',
+    });
+    await SharedPreferencesUtil.init();
+    final gateway = _FakeTokenGateway();
+    final service = _service(gateway);
+    final events = <AuthSessionExpiredEvent>[];
+    service.sessionExpiredEvents.listen(events.add);
+
+    const event = AuthSessionExpiredEvent(reason: AuthSessionExpirationReason.backendRejectedRefreshedToken);
+    await Future.wait([service.expireSession(event), service.expireSession(event)]);
+
+    final raw = await SharedPreferences.getInstance();
+    expect(gateway.signOutCalls, 1);
+    expect(events, hasLength(1));
+    expect(SharedPreferencesUtil().authToken, isEmpty);
+    expect(SharedPreferencesUtil().uid, isEmpty);
+    expect(SharedPreferencesUtil().email, isEmpty);
+    expect(SharedPreferencesUtil().givenName, isEmpty);
+    expect(SharedPreferencesUtil().familyName, isEmpty);
+    expect(raw.getStringList('cachedConversations'), isEmpty);
+    expect(raw.containsKey('cachedMemories'), isFalse);
+    expect(raw.getStringList('cachedMessages'), isEmpty);
+    expect(raw.getStringList('cachedPeople'), isEmpty);
+    expect(raw.getStringList('appsList'), isEmpty);
+    expect(raw.getString('modifiedConversationDetails'), isEmpty);
+    expect(SharedPreferencesUtil().cachedSingleLanguageMode, isFalse);
+    expect(SharedPreferencesUtil().cachedTranscriptionVocabulary, isEmpty);
+    expect(SharedPreferencesUtil().userPrimaryLanguage, isEmpty);
+    expect(SharedPreferencesUtil().hasSetPrimaryLanguage, isFalse);
+    expect(SharedPreferencesUtil().hasSpeakerProfile, isFalse);
+    expect(SharedPreferencesUtil().selectedChatAppId, 'no_selected');
+    expect(SharedPreferencesUtil().lastUsedSummarizationAppId, isEmpty);
+    expect(SharedPreferencesUtil().preferredSummarizationAppId, isEmpty);
+    expect(SharedPreferencesUtil().calendarEnabled, isFalse);
+    expect(raw.getString('btDevice'), 'preserve-device');
+    expect(raw.getBool('onboardingCompleted'), isTrue);
+    expect(raw.getString('offlineRecordingMarker'), 'preserve-recording');
+    expect(raw.containsKey('pendingMemories'), isFalse);
+    expect(raw.getStringList('pendingMemories:user-1'), hasLength(1));
+    expect(raw.containsKey('goals_tracker_local_goals'), isFalse);
+    expect(raw.getString('goals_tracker_local_goals:user-1'), '[{"id":"old-goal"}]');
+    expect(SharedPreferencesUtil().pendingMemories, isEmpty);
+    SharedPreferencesUtil().uid = 'new-user';
+    expect(SharedPreferencesUtil().pendingMemories, isEmpty);
+    SharedPreferencesUtil().uid = 'user-1';
+    expect(SharedPreferencesUtil().pendingMemories.single.id, 'pending-1');
+  });
+}
+
+AuthService _service(
+  _FakeTokenGateway gateway, {
+  AuthRefreshDelay? refreshDelay,
+  AuthTelemetryRecorder? recordTelemetry,
+}) =>
+    AuthService.forTesting(
+      tokenGateway: gateway,
+      refreshDelay: refreshDelay ?? (_) async {},
+      recordTelemetry: recordTelemetry,
+      telemetryContextProvider: () => const {
+        'platform': 'ios',
+        'app_version': '1.2.3+456',
+        'release_channel': 'testflight',
+      },
+    );
+
+final class _FakeTokenGateway implements AuthTokenGateway {
+  _FakeTokenGateway({
+    this.user = const AuthUserSnapshot(
+      uid: 'user-1',
+      email: 'person@example.com',
+      displayName: 'Person Example',
+    ),
+    this.results = const [],
+    this.error,
+    this.refreshCompleter,
+  });
+
+  AuthUserSnapshot? user;
+  final List<RefreshedAuthToken?> results;
+  final Object? error;
+  Completer<RefreshedAuthToken?>? refreshCompleter;
+  int refreshCalls = 0;
+  int signOutCalls = 0;
+
+  @override
+  AuthUserSnapshot? get currentUser => user;
+
+  @override
+  Future<RefreshedAuthToken?> forceRefresh() async {
+    refreshCalls++;
+    if (error != null) throw error!;
+    final pendingRefresh = refreshCompleter;
+    if (pendingRefresh != null) return pendingRefresh.future;
+    if (results.isEmpty) {
+      return RefreshedAuthToken(token: 'default-token', expirationTime: DateTime.now());
+    }
+    final index = refreshCalls <= results.length ? refreshCalls - 1 : results.length - 1;
+    return results[index];
+  }
+
+  @override
+  Future<void> signOut() async {
+    signOutCalls++;
+  }
+}
+
+final class _TelemetryEvent {
+  const _TelemetryEvent(this.name, this.properties);
+
+  final String name;
+  final Map<String, dynamic> properties;
+}

--- a/app/test/unit/authenticated_request_401_test.dart
+++ b/app/test/unit/authenticated_request_401_test.dart
@@ -1,0 +1,273 @@
+import 'dart:async';
+
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:omi/backend/http/shared.dart';
+import 'package:omi/backend/preferences.dart';
+import 'package:omi/services/auth/auth_token_result.dart';
+import 'package:omi/services/auth_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    await SharedPreferencesUtil.init();
+  });
+
+  test('401 refreshes once, replays once, and records recovery', () async {
+    final gateway = _Gateway(results: [_token('fresh')]);
+    final telemetry = <_Event>[];
+    final service = _service(gateway, telemetry);
+    var replayCalls = 0;
+
+    final response = await refreshAndReplayAfter401(
+      firstResponse: http.Response('', 401),
+      statusCode: (value) => value.statusCode,
+      replay: () async {
+        replayCalls++;
+        return http.Response('ok', 200);
+      },
+      expireTerminalSession: true,
+      authService: service,
+    );
+
+    expect(response.statusCode, 200);
+    expect(gateway.refreshCalls, 1);
+    expect(replayCalls, 1);
+    expect(gateway.signOutCalls, 0);
+    expect(_request401Events(telemetry).single.properties, containsPair('recovered', true));
+    expect(_request401Events(telemetry).single.properties, containsPair('outcome', 'refresh_succeeded'));
+  });
+
+  test('transient refresh failure does not replay or sign out', () async {
+    final gateway = _Gateway(error: StateError('offline'));
+    final telemetry = <_Event>[];
+    final service = _service(gateway, telemetry);
+    var replayCalls = 0;
+
+    final response = await refreshAndReplayAfter401(
+      firstResponse: http.Response('', 401),
+      statusCode: (value) => value.statusCode,
+      replay: () async {
+        replayCalls++;
+        return http.Response('', 200);
+      },
+      expireTerminalSession: true,
+      authService: service,
+    );
+
+    expect(response.statusCode, 401);
+    expect(gateway.refreshCalls, 3);
+    expect(replayCalls, 0);
+    expect(gateway.signOutCalls, 0);
+    expect(_request401Events(telemetry).single.properties, containsPair('outcome', 'refresh_transient_failure'));
+  });
+
+  test('null-token refresh is exhausted before terminal session expiration', () async {
+    final gateway = _Gateway(results: [_token(null), _token(null), _token(null)]);
+    final telemetry = <_Event>[];
+    final service = _service(gateway, telemetry);
+
+    final response = await refreshAndReplayAfter401(
+      firstResponse: http.Response('', 401),
+      statusCode: (value) => value.statusCode,
+      replay: () async => http.Response('', 200),
+      expireTerminalSession: true,
+      authService: service,
+    );
+
+    expect(response.statusCode, 401);
+    expect(gateway.refreshCalls, 3);
+    expect(gateway.signOutCallsDuringRefresh, everyElement(0));
+    expect(gateway.signOutCalls, 1, reason: 'session expires only after the bounded null-token budget is exhausted');
+    expect(_request401Events(telemetry).single.properties, containsPair('outcome', 'missing_token'));
+  });
+
+  test('second 401 after successful refresh expires session exactly once', () async {
+    final gateway = _Gateway(results: [_token('fresh')]);
+    final telemetry = <_Event>[];
+    final service = _service(gateway, telemetry);
+    final sessionEvents = <AuthSessionExpiredEvent>[];
+    service.sessionExpiredEvents.listen(sessionEvents.add);
+
+    final response = await refreshAndReplayAfter401(
+      firstResponse: http.Response('', 401),
+      statusCode: (value) => value.statusCode,
+      replay: () async => http.Response('', 401),
+      expireTerminalSession: true,
+      authService: service,
+    );
+
+    expect(response.statusCode, 401);
+    expect(gateway.signOutCalls, 1);
+    expect(sessionEvents.single.reason, AuthSessionExpirationReason.backendRejectedRefreshedToken);
+    expect(_request401Events(telemetry).single.properties, {
+      'recovered': false,
+      'outcome': 'backend_rejected_refreshed_token',
+      'platform': 'ios',
+      'app_version': '1.2.3+456',
+      'release_channel': 'testflight',
+    });
+  });
+
+  test('streaming 401 responses are drained before replay and expiration', () async {
+    final gateway = _Gateway(results: [_token('fresh')]);
+    final service = _service(gateway, <_Event>[]);
+    final drainedStatuses = <int>[];
+
+    final response = await refreshAndReplayAfter401(
+      firstResponse: http.StreamedResponse(Stream.value(<int>[1, 2]), 401),
+      statusCode: (value) => value.statusCode,
+      disposeUnauthorizedResponse: (value) async {
+        await value.stream.drain<void>();
+        drainedStatuses.add(value.statusCode);
+      },
+      replay: () async => http.StreamedResponse(Stream.value(<int>[3, 4]), 401),
+      expireTerminalSession: true,
+      authService: service,
+    );
+
+    expect(response.statusCode, 401);
+    expect(drainedStatuses, [401, 401]);
+    expect(gateway.signOutCalls, 1);
+  });
+
+  test('terminal refresh failure expires session without replay', () async {
+    final gateway = _Gateway(error: FirebaseAuthException(code: 'user-token-expired'));
+    final telemetry = <_Event>[];
+    final service = _service(gateway, telemetry);
+    var replayCalls = 0;
+
+    final response = await refreshAndReplayAfter401(
+      firstResponse: http.Response('', 401),
+      statusCode: (value) => value.statusCode,
+      replay: () async {
+        replayCalls++;
+        return http.Response('', 200);
+      },
+      expireTerminalSession: true,
+      authService: service,
+    );
+
+    expect(response.statusCode, 401);
+    expect(gateway.refreshCalls, 1);
+    expect(replayCalls, 0);
+    expect(gateway.signOutCalls, 1);
+    expect(_request401Events(telemetry).single.properties, containsPair('outcome', 'terminal_token_failure'));
+  });
+
+  test('failed replay records an unrecovered 401 outcome before rethrowing', () async {
+    final gateway = _Gateway(results: [_token('fresh')]);
+    final telemetry = <_Event>[];
+    final service = _service(gateway, telemetry);
+
+    await expectLater(
+      refreshAndReplayAfter401(
+        firstResponse: http.Response('', 401),
+        statusCode: (value) => value.statusCode,
+        replay: () async => throw TimeoutException('offline'),
+        expireTerminalSession: true,
+        authService: service,
+      ),
+      throwsA(isA<TimeoutException>()),
+    );
+
+    expect(_request401Events(telemetry).single.properties, containsPair('recovered', false));
+    expect(_request401Events(telemetry).single.properties, containsPair('outcome', 'replay_failed'));
+    expect(gateway.signOutCalls, 0);
+  });
+
+  test('signOutOn401 false preserves graceful endpoint behavior on second 401', () async {
+    final gateway = _Gateway(results: [_token('fresh')]);
+    final service = _service(gateway, <_Event>[]);
+
+    final response = await refreshAndReplayAfter401(
+      firstResponse: http.Response('', 401),
+      statusCode: (value) => value.statusCode,
+      replay: () async => http.Response('', 401),
+      expireTerminalSession: false,
+      authService: service,
+    );
+
+    expect(response.statusCode, 401);
+    expect(gateway.signOutCalls, 0);
+  });
+
+  test('concurrent backend-rejected refreshed tokens share refresh and terminal signout', () async {
+    final refreshCompleter = Completer<RefreshedAuthToken?>();
+    final gateway = _Gateway(refreshCompleter: refreshCompleter);
+    final service = _service(gateway, <_Event>[]);
+
+    Future<http.Response> execute() => refreshAndReplayAfter401(
+          firstResponse: http.Response('', 401),
+          statusCode: (value) => value.statusCode,
+          replay: () async => http.Response('', 401),
+          expireTerminalSession: true,
+          authService: service,
+        );
+
+    final first = execute();
+    final second = execute();
+    refreshCompleter.complete(_token('fresh'));
+    await Future.wait([first, second]);
+
+    expect(gateway.refreshCalls, 1);
+    expect(gateway.signOutCalls, 1);
+  });
+}
+
+List<_Event> _request401Events(List<_Event> events) =>
+    events.where((event) => event.name == 'authenticated_request_401').toList();
+
+RefreshedAuthToken _token(String? token) => RefreshedAuthToken(token: token, expirationTime: DateTime.now());
+
+AuthService _service(_Gateway gateway, List<_Event> telemetry) => AuthService.forTesting(
+      tokenGateway: gateway,
+      refreshDelay: (_) async {},
+      recordTelemetry: (name, properties) => telemetry.add(_Event(name, properties)),
+      telemetryContextProvider: () => const {
+        'platform': 'ios',
+        'app_version': '1.2.3+456',
+        'release_channel': 'testflight',
+      },
+    );
+
+final class _Gateway implements AuthTokenGateway {
+  _Gateway({this.results = const [], this.error, this.refreshCompleter});
+
+  final List<RefreshedAuthToken?> results;
+  final Object? error;
+  final Completer<RefreshedAuthToken?>? refreshCompleter;
+  int refreshCalls = 0;
+  int signOutCalls = 0;
+  final List<int> signOutCallsDuringRefresh = [];
+
+  @override
+  AuthUserSnapshot? get currentUser => const AuthUserSnapshot(uid: 'user-1');
+
+  @override
+  Future<RefreshedAuthToken?> forceRefresh() async {
+    refreshCalls++;
+    signOutCallsDuringRefresh.add(signOutCalls);
+    if (error != null) throw error!;
+    if (refreshCompleter != null) return refreshCompleter!.future;
+    final index = refreshCalls <= results.length ? refreshCalls - 1 : results.length - 1;
+    return results[index];
+  }
+
+  @override
+  Future<void> signOut() async {
+    signOutCalls++;
+  }
+}
+
+final class _Event {
+  const _Event(this.name, this.properties);
+
+  final String name;
+  final Map<String, dynamic> properties;
+}

--- a/app/test/unit/backend/http/shared_test.dart
+++ b/app/test/unit/backend/http/shared_test.dart
@@ -1,21 +1,20 @@
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:omi/backend/http/shared.dart';
+import 'package:omi/services/auth/auth_token_result.dart';
 
 Future<String> simulateGetAuthHeader({required bool isSignedIn, required String token}) async {
   if (token.isEmpty && isSignedIn) {
-    throw AuthTokenUnavailableException('No auth token found');
+    throw AuthTokenUnavailableException(const AuthTokenMissingToken());
   }
   return 'Bearer $token';
 }
 
 Future<Map<String, String>> simulateBuildHeaders({required Future<String> Function() getAuthHeader}) async {
   final headers = <String, String>{};
-  try {
-    headers['Authorization'] = await getAuthHeader();
-  } on AuthTokenUnavailableException {
-    // Mirrors buildHeaders() behavior in shared.dart: continue without auth header.
-  }
+  // Mirrors buildHeaders(): auth failure aborts header construction so no
+  // authenticated request can degrade into anonymous traffic.
+  headers['Authorization'] = await getAuthHeader();
   return headers;
 }
 
@@ -25,12 +24,11 @@ void main() {
       expect(() => simulateGetAuthHeader(isSignedIn: true, token: ''), throwsA(isA<AuthTokenUnavailableException>()));
     });
 
-    test('caller guard catches AuthTokenUnavailableException and omits Authorization header', () async {
-      final headers = await simulateBuildHeaders(
-        getAuthHeader: () => simulateGetAuthHeader(isSignedIn: true, token: ''),
+    test('header construction propagates AuthTokenUnavailableException instead of omitting auth', () async {
+      expect(
+        () => simulateBuildHeaders(getAuthHeader: () => simulateGetAuthHeader(isSignedIn: true, token: '')),
+        throwsA(isA<AuthTokenUnavailableException>()),
       );
-
-      expect(headers.containsKey('Authorization'), isFalse);
     });
 
     test('includes Authorization header on happy path', () async {

--- a/app/test/unit/clear_deleted_account_session_test.dart
+++ b/app/test/unit/clear_deleted_account_session_test.dart
@@ -1,0 +1,94 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:omi/backend/preferences.dart';
+import 'package:omi/services/auth/auth_token_result.dart';
+import 'package:omi/services/auth_service.dart';
+import 'package:omi/utils/auth/clear_deleted_account_session.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('account deletion invalidates late refresh and clears provider state before storage', () async {
+    SharedPreferences.setMockInitialValues({'uid': 'user-1', 'authToken': 'old-token'});
+    await SharedPreferencesUtil.init();
+    final pendingRefresh = Completer<RefreshedAuthToken?>();
+    final gateway = _DeletionGateway(pendingRefresh);
+    final service = AuthService.forTesting(tokenGateway: gateway, refreshDelay: (_) async {});
+    final order = <String>[];
+
+    final refresh = service.refreshIdToken();
+    await clearDeletedAccountSession(
+      authService: service,
+      clearUserState: () => order.add('providers'),
+      clearWal: () async => order.add('wal'),
+      clearPreferences: () async {
+        order.add('preferences');
+        await SharedPreferencesUtil().clear();
+      },
+    );
+    pendingRefresh.complete(RefreshedAuthToken(token: 'late-token', expirationTime: DateTime.now()));
+
+    expect(await refresh, isA<AuthTokenMissingUser>());
+    expect(order, ['providers', 'wal', 'preferences']);
+    expect(gateway.signOutCalls, 1);
+    expect(SharedPreferencesUtil().uid, isEmpty);
+    expect(SharedPreferencesUtil().authToken, isEmpty);
+    expect(await service.refreshIdToken(), isA<AuthTokenMissingUser>());
+    expect(gateway.refreshCalls, 1, reason: 'the deleted Firebase user must not start another refresh');
+  });
+
+  test('account deletion clears WAL and preferences when Firebase sign-out fails', () async {
+    SharedPreferences.setMockInitialValues({'uid': 'user-1', 'authToken': 'old-token'});
+    await SharedPreferencesUtil.init();
+    final gateway = _DeletionGateway(Completer<RefreshedAuthToken?>(), failSignOut: true);
+    final service = AuthService.forTesting(tokenGateway: gateway, refreshDelay: (_) async {});
+    final order = <String>[];
+
+    await clearDeletedAccountSession(
+      authService: service,
+      clearUserState: () => order.add('providers'),
+      clearWal: () async {
+        order.add('wal');
+        throw StateError('disk unavailable');
+      },
+      clearPreferences: () async {
+        order.add('preferences');
+        await SharedPreferencesUtil().clear();
+      },
+    );
+
+    expect(order, ['providers', 'wal', 'preferences']);
+    expect(gateway.signOutCalls, 1);
+    expect(SharedPreferencesUtil().uid, isEmpty);
+    expect(SharedPreferencesUtil().authToken, isEmpty);
+    expect(await service.refreshIdToken(), isA<AuthTokenMissingUser>());
+    expect(gateway.refreshCalls, 0, reason: 'failed platform sign-out must still leave the old user locally terminal');
+  });
+}
+
+final class _DeletionGateway implements AuthTokenGateway {
+  _DeletionGateway(this.pendingRefresh, {this.failSignOut = false});
+
+  final Completer<RefreshedAuthToken?> pendingRefresh;
+  final bool failSignOut;
+  int signOutCalls = 0;
+  int refreshCalls = 0;
+
+  @override
+  AuthUserSnapshot? get currentUser => const AuthUserSnapshot(uid: 'user-1');
+
+  @override
+  Future<RefreshedAuthToken?> forceRefresh() {
+    refreshCalls++;
+    return pendingRefresh.future;
+  }
+
+  @override
+  Future<void> signOut() async {
+    signOutCalls++;
+    if (failSignOut) throw StateError('Firebase sign-out failed');
+  }
+}

--- a/app/test/unit/multipart_401_retry_test.dart
+++ b/app/test/unit/multipart_401_retry_test.dart
@@ -5,8 +5,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
 import 'package:path/path.dart' as path;
 
-/// Tests the 401→refresh→retry→signout logic pattern used in
-/// makeMultipartApiCall() and makeMultipartStreamingApiCall().
+/// Tests multipart request rebuilding around a 401 replay. Typed auth policy
+/// itself is covered against production code in authenticated_request_401_test.
 ///
 /// The production code in shared.dart uses singletons (HttpPoolManager,
 /// SharedPreferencesUtil, AuthService) that aren't injectable, so this
@@ -46,7 +46,7 @@ Future<http.MultipartRequest> buildMultipartRequest({
   return request;
 }
 
-/// Mirrors the exact 401 retry logic from makeMultipartApiCall() in shared.dart.
+/// Models the multipart request-rebuild portion of makeMultipartApiCall().
 /// Returns the final http.Response and whether signOut was called.
 Future<http.Response> makeMultipartApiCallWithRetry({
   required String url,
@@ -88,8 +88,6 @@ Future<http.Response> makeMultipartApiCallWithRetry({
       if (response.statusCode == 401) {
         await deps.signOut();
       }
-    } else {
-      await deps.signOut();
     }
   }
 
@@ -225,7 +223,7 @@ void main() {
       expect(signOutCalled, true);
     });
 
-    test('401 → refresh fails (empty token) → signs out immediately without retry', () async {
+    test('401 → one transient empty refresh → does not sign out or replay', () async {
       int sendCount = 0;
       bool refreshCalled = false;
       bool signOutCalled = false;
@@ -258,7 +256,7 @@ void main() {
       expect(response.statusCode, 401);
       expect(sendCount, 1); // no retry when refresh fails
       expect(refreshCalled, true);
-      expect(signOutCalled, true);
+      expect(signOutCalled, false, reason: 'a single unavailable refresh is not terminal');
     });
 
     test('401 with requireAuthCheck=false returns 401 without retry', () async {

--- a/app/test/unit/pure_socket_auth_test.dart
+++ b/app/test/unit/pure_socket_auth_test.dart
@@ -1,0 +1,21 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:omi/backend/http/shared.dart';
+import 'package:omi/services/auth/auth_token_result.dart';
+import 'package:omi/services/sockets/pure_socket.dart';
+
+void main() {
+  test('unavailable auth blocks a socket before opening the network', () async {
+    final socket = PureSocket(
+      'wss://example.invalid',
+      headersProvider: () async {
+        throw AuthTokenUnavailableException(
+          const AuthTokenTransientFailure(failureClass: 'offline'),
+        );
+      },
+    );
+
+    expect(await socket.connect(), isFalse);
+    expect(socket.status, PureSocketStatus.notConnected);
+  });
+}

--- a/app/test/widgets/session_expired_reauthentication_test.dart
+++ b/app/test/widgets/session_expired_reauthentication_test.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+
+import 'package:omi/app_globals.dart';
+import 'package:omi/l10n/app_localizations.dart';
+import 'package:omi/mobile/mobile_app.dart';
+import 'package:omi/pages/home/page.dart';
+import 'package:omi/pages/onboarding/wrapper.dart';
+import 'package:omi/providers/auth_provider.dart';
+
+class _ExpiredAuthenticationProvider extends AuthenticationProvider {
+  _ExpiredAuthenticationProvider() : super(initializeListeners: false);
+
+  @override
+  bool get requiresReauthentication => true;
+
+  @override
+  int get sessionExpirationGeneration => 1;
+
+  @override
+  bool isSignedIn() => false;
+}
+
+void main() {
+  testWidgets(
+    'expired session replaces the home shell with reauthentication UI and a clear message',
+    (tester) async {
+      final authProvider = _ExpiredAuthenticationProvider();
+      addTearDown(authProvider.dispose);
+
+      await tester.pumpWidget(
+        ChangeNotifierProvider<AuthenticationProvider>.value(
+          value: authProvider,
+          child: MaterialApp(
+            navigatorKey: globalNavigatorKey,
+            localizationsDelegates: const [
+              AppLocalizations.delegate,
+              GlobalMaterialLocalizations.delegate,
+              GlobalWidgetsLocalizations.delegate,
+              GlobalCupertinoLocalizations.delegate,
+            ],
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: const MobileApp(),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      expect(find.byType(OnboardingWrapper), findsOneWidget);
+      expect(find.byType(HomePageWrapper), findsNothing);
+      expect(find.text('Session expired — sign in again.'), findsOneWidget);
+
+      await tester.pumpAndSettle();
+    },
+  );
+}


### PR DESCRIPTION
Fixes #9375

This PR fixes the mobile auth-refresh failure that caused repeated 401 conversation requests and a misleading signed-in shell.

- Adds typed, bounded, UID-bound Firebase token refresh outcomes.
- Prevents authenticated requests from degrading into anonymous traffic and handles 401 refresh/replay once.
- Terminates dead sessions exactly once, cancels stale conversation/provider work, clears user-scoped state, and routes to localized reauthentication UI.
- Adds privacy-safe auth telemetry, UID-scoped offline memory/goal storage, account-deletion teardown coverage, and a signed iOS/TestFlight canary.

Verification:
- `cd app && flutter test --no-pub` — 704 tests passed.
- `flutter gen-l10n` — zero untranslated-message warnings.
- Targeted analysis had no compile errors.
- Independent review gate approved.

The physical signed iOS canary was added but could not be run locally because no iOS device or simulator was available.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9397?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->