### PR TITLE
fix(desktop): keep managed agents on cloud routing

### DIFF
--- a/desktop/macos/Desktop/Sources/Chat/StallDetector.swift
+++ b/desktop/macos/Desktop/Sources/Chat/StallDetector.swift
@@ -97,6 +97,15 @@ actor StallDetector {
     toolStates
   }
 
+  /// IDs of tools that have exceeded a hard execution budget.  The caller owns
+  /// the recovery action (for example, interrupting the bridge); the detector
+  /// remains pure and does not perform side effects itself.
+  func toolIdsExceeding(durationMs: Int, atMs: Int) -> [String] {
+    toolStartedAtMs.compactMap { id, startedAt in
+      atMs - startedAt >= durationMs ? id : nil
+    }
+  }
+
   // MARK: - Observation
 
   /// Record an event at simulated time `atMs` and return any state

--- a/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
@@ -1408,17 +1408,12 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
             await resolvedAgentClient().setGlobalAuthHandlers(
                 onAuthRequired: { [weak self] methods, authUrl in
                     Task { @MainActor [weak self] in
-                        self?.claudeAuthMethods = methods
-                        self?.claudeAuthUrl = authUrl
-                        self?.isClaudeAuthRequired = true
-                        self?.startClaudeAuth()
+                        self?.handleClaudeAuthRequired(methods: methods, authUrl: authUrl)
                     }
                 },
                 onAuthSuccess: { [weak self] in
                     Task { @MainActor [weak self] in
-                        self?.isClaudeAuthRequired = false
-                        self?.claudeAuthLaunchRequested = false
-                        self?.checkClaudeConnectionStatus()
+                        self?.handleClaudeAuthSuccess()
                     }
                 }
             )
@@ -1680,15 +1675,81 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
         guard isUserClaudeMode else { return }
         guard !claudeAuthLaunchRequested else { return }
 
-        if let urlString = claudeAuthUrl, let url = URL(string: urlString) {
-            claudeAuthLaunchRequested = true
-            log("ChatProvider: Opening Claude OAuth URL in browser")
-            NSWorkspace.shared.open(url)
-        } else {
-            logError("ChatProvider: No auth URL available from bridge")
+        guard let url = Self.validatedClaudeOAuthURL(claudeAuthUrl) else {
+            logError("ChatProvider: Bridge supplied an invalid Claude OAuth URL")
             isClaudeAuthRequired = false
             claudeAuthLaunchRequested = false
+            errorMessage = "Unable to start Claude sign-in. Try again."
+            return
         }
+
+        claudeAuthLaunchRequested = true
+        log("ChatProvider: Opening validated Claude OAuth URL in browser")
+        NSWorkspace.shared.open(url)
+    }
+
+    private func handleClaudeAuthRequired(methods: [[String: Any]], authUrl: String?) {
+        // A fresh bridge-issued authorization URL represents a new OAuth
+        // attempt (for example after the bounded callback timeout). Reset the
+        // launch latch so a retry can open the new URL, while duplicate events
+        // for the same in-flight flow still open at most one browser tab.
+        if Self.isNewClaudeOAuthAttempt(previousAuthURL: claudeAuthUrl, nextAuthURL: authUrl) {
+            claudeAuthLaunchRequested = false
+        }
+        claudeAuthMethods = methods
+        claudeAuthUrl = authUrl
+        isClaudeAuthRequired = true
+        startClaudeAuth()
+    }
+
+    private func handleClaudeAuthSuccess() {
+        isClaudeAuthRequired = false
+        claudeAuthLaunchRequested = false
+        claudeAuthUrl = nil
+        checkClaudeConnectionStatus()
+    }
+
+    nonisolated static func validatedClaudeOAuthURL(_ urlString: String?) -> URL? {
+        guard
+            let urlString,
+            let components = URLComponents(string: urlString),
+            components.scheme?.lowercased() == "https",
+            components.host?.lowercased() == "claude.ai",
+            components.port == nil,
+            components.path == "/oauth/authorize",
+            components.user == nil,
+            components.password == nil,
+            components.fragment == nil
+        else {
+            return nil
+        }
+
+        let queryItems = components.queryItems ?? []
+        func queryValue(_ name: String) -> String? {
+            let values = queryItems.compactMap { $0.name == name ? $0.value : nil }
+            guard values.count == 1, let value = values.first, !value.isEmpty else { return nil }
+            return value
+        }
+        guard
+            queryValue("response_type") == "code",
+            queryValue("client_id") != nil,
+            queryValue("state") != nil,
+            queryValue("code_challenge") != nil,
+            queryValue("code_challenge_method") == "S256",
+            let redirectURLString = queryValue("redirect_uri"),
+            let redirectURL = URLComponents(string: redirectURLString),
+            redirectURL.scheme?.lowercased() == "http",
+            redirectURL.host?.lowercased() == "localhost",
+            redirectURL.port != nil,
+            redirectURL.path == "/callback"
+        else {
+            return nil
+        }
+        return components.url
+    }
+
+    nonisolated static func isNewClaudeOAuthAttempt(previousAuthURL: String?, nextAuthURL: String?) -> Bool {
+        previousAuthURL != nextAuthURL
     }
 
     /// Check whether a cached Claude OAuth token exists (config file or Keychain)
@@ -4226,17 +4287,12 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
                 onToolResultDisplay: toolResultDisplayHandler,
                 onAuthRequired: { [weak self] methods, authUrl in
                     Task { @MainActor [weak self] in
-                        self?.claudeAuthMethods = methods
-                        self?.claudeAuthUrl = authUrl
-                        self?.isClaudeAuthRequired = true
-                        self?.startClaudeAuth()
+                        self?.handleClaudeAuthRequired(methods: methods, authUrl: authUrl)
                     }
                 },
                 onAuthSuccess: { [weak self] in
                     Task { @MainActor [weak self] in
-                        self?.isClaudeAuthRequired = false
-                        self?.claudeAuthLaunchRequested = false
-                        self?.checkClaudeConnectionStatus()
+                        self?.handleClaudeAuthSuccess()
                     }
                 }
             )

--- a/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
@@ -914,6 +914,12 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
     /// watchdog in sendMessage() and the `.stopped` catch branch.
     private var sendWatchdogFiredGeneration: Int?
 
+    /// A per-tool guard fires before the whole-turn watchdog when an adapter
+    /// leaves a tool request active without making forward progress.
+    private var sendToolStallAbortGeneration: Int?
+
+    private static let perToolStallAbortMs = 90_000
+
     /// Set to true during onboarding so the ACP session ID is persisted for restart recovery.
     var isOnboarding = false
     @Published var sessionsLoadError: String?
@@ -1038,6 +1044,8 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
     @Published var claudeAuthMethods: [[String: Any]] = []
     /// OAuth URL to open in browser (sent by bridge when auth is needed)
     @Published var claudeAuthUrl: String?
+    /// Prevent duplicate browser launches for the same explicit User Claude flow.
+    private var claudeAuthLaunchRequested = false
     /// Whether the user has a cached Claude OAuth token
     @Published var isClaudeConnected = false
     /// Cumulative tokens used in the current session via Omi account
@@ -1403,11 +1411,13 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
                         self?.claudeAuthMethods = methods
                         self?.claudeAuthUrl = authUrl
                         self?.isClaudeAuthRequired = true
+                        self?.startClaudeAuth()
                     }
                 },
                 onAuthSuccess: { [weak self] in
                     Task { @MainActor [weak self] in
                         self?.isClaudeAuthRequired = false
+                        self?.claudeAuthLaunchRequested = false
                         self?.checkClaudeConnectionStatus()
                     }
                 }
@@ -1668,13 +1678,16 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
     /// credential storage, and ACP subprocess restart.
     func startClaudeAuth() {
         guard isUserClaudeMode else { return }
+        guard !claudeAuthLaunchRequested else { return }
 
         if let urlString = claudeAuthUrl, let url = URL(string: urlString) {
+            claudeAuthLaunchRequested = true
             log("ChatProvider: Opening Claude OAuth URL in browser")
             NSWorkspace.shared.open(url)
         } else {
             logError("ChatProvider: No auth URL available from bridge")
             isClaudeAuthRequired = false
+            claudeAuthLaunchRequested = false
         }
     }
 
@@ -4144,14 +4157,37 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
             // gaps when no bridge events arrive. Cancelled via defer on
             // scope exit (success or throw).
             let stallTickTask = Task { [weak self] in
+                var issuedToolStallAbort = false
                 while !Task.isCancelled {
                     try? await Task.sleep(nanoseconds: 500_000_000)  // 500ms
                     if Task.isCancelled { break }
                     let nowMs = ChatProvider.monotonicNowMs()
                     let transitions = await stallDetector.tick(atMs: nowMs)
-                    if transitions.isEmpty { continue }
-                    await MainActor.run { [weak self] in
-                        self?.applyStallTransitions(messageId: aiMessageId, transitions: transitions)
+                    if !transitions.isEmpty {
+                        await MainActor.run { [weak self] in
+                            self?.applyStallTransitions(messageId: aiMessageId, transitions: transitions)
+                        }
+                    }
+                    if !issuedToolStallAbort {
+                        let overdueToolIds = await stallDetector.toolIdsExceeding(
+                            durationMs: Self.perToolStallAbortMs,
+                            atMs: nowMs
+                        )
+                        if !overdueToolIds.isEmpty {
+                            issuedToolStallAbort = true
+                            let shouldInterrupt = await MainActor.run { () -> Bool in
+                                guard let self, self.isSending, self.sendGeneration == sendGen else { return false }
+                                self.sendToolStallAbortGeneration = sendGen
+                                log(
+                                    "ChatProvider: tool stall guard fired at \\(Self.perToolStallAbortMs / 1_000)s "
+                                        + "(active_tools=\\(overdueToolIds.count)); interrupting bridge"
+                                )
+                                return true
+                            }
+                            if shouldInterrupt {
+                                await self?.resolvedAgentClient().interrupt()
+                            }
+                        }
                     }
                 }
             }
@@ -4193,11 +4229,13 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
                         self?.claudeAuthMethods = methods
                         self?.claudeAuthUrl = authUrl
                         self?.isClaudeAuthRequired = true
+                        self?.startClaudeAuth()
                     }
                 },
                 onAuthSuccess: { [weak self] in
                     Task { @MainActor [weak self] in
                         self?.isClaudeAuthRequired = false
+                        self?.claudeAuthLaunchRequested = false
                         self?.checkClaudeConnectionStatus()
                     }
                 }
@@ -4501,9 +4539,14 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
                 // instead of letting the turn vanish (the watchdog's own error-set
                 // races this catch and bails once `isSending` is released here).
                 let watchdogFired = (sendWatchdogFiredGeneration == sendGen)
+                let toolStallAbortFired = (sendToolStallAbortGeneration == sendGen)
                 sendWatchdogFiredGeneration = nil
+                sendToolStallAbortGeneration = nil
                 currentError = nil
-                if let timeoutMessage = ChatProvider.stoppedTurnErrorMessage(watchdogFired: watchdogFired) {
+                if let timeoutMessage = ChatProvider.stoppedTurnErrorMessage(
+                    watchdogFired: watchdogFired,
+                    toolStallAbortFired: toolStallAbortFired
+                ) {
                     errorMessage = timeoutMessage
                 } else {
                     stoppedByUser = true
@@ -4970,8 +5013,14 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
     /// fired for the turn, the `.stopped` came from the watchdog's own interrupt —
     /// the turn timed out, so surface "Response took too long" rather than letting
     /// it vanish. Extracted so the watchdog-vs-user-stop distinction is unit-tested.
-    nonisolated static func stoppedTurnErrorMessage(watchdogFired: Bool) -> String? {
-        watchdogFired ? "Response took too long. Try again." : nil
+    nonisolated static func stoppedTurnErrorMessage(
+        watchdogFired: Bool,
+        toolStallAbortFired: Bool = false
+    ) -> String? {
+        if toolStallAbortFired {
+            return "A tool took too long. Try again."
+        }
+        return watchdogFired ? "Response took too long. Try again." : nil
     }
 
     /// Map a `StallDetector.State` to the matching `ToolCallStatus`.

--- a/desktop/macos/Desktop/Tests/ChatProviderOAuthURLTests.swift
+++ b/desktop/macos/Desktop/Tests/ChatProviderOAuthURLTests.swift
@@ -1,0 +1,42 @@
+import XCTest
+
+@testable import Omi_Computer
+
+final class ChatProviderOAuthURLTests: XCTestCase {
+  func testAcceptsClaudePKCELoopbackAuthorizeURL() {
+    let url = ChatProvider.validatedClaudeOAuthURL(
+      "https://claude.ai/oauth/authorize?response_type=code&client_id=test-client&redirect_uri=http%3A%2F%2Flocalhost%3A43123%2Fcallback&state=test-state&code_challenge=test-challenge&code_challenge_method=S256"
+    )
+
+    XCTAssertEqual(url?.host, "claude.ai")
+    XCTAssertEqual(url?.path, "/oauth/authorize")
+  }
+
+  func testRejectsUnexpectedOAuthHostsPathsAndPKCEParameters() {
+    let invalidURLs = [
+      "https://evil.example/oauth/authorize?response_type=code&client_id=test-client&redirect_uri=http%3A%2F%2Flocalhost%3A43123%2Fcallback&state=test-state&code_challenge=test-challenge&code_challenge_method=S256",
+      "https://claude.ai/other?response_type=code&client_id=test-client&redirect_uri=http%3A%2F%2Flocalhost%3A43123%2Fcallback&state=test-state&code_challenge=test-challenge&code_challenge_method=S256",
+      "https://claude.ai/oauth/authorize?response_type=code&client_id=test-client&redirect_uri=http%3A%2F%2Flocalhost%3A43123%2Fcallback&state=test-state&code_challenge=test-challenge",
+      "https://claude.ai/oauth/authorize?response_type=code&client_id=test-client&redirect_uri=https%3A%2F%2Fexample.com%2Fcallback&state=test-state&code_challenge=test-challenge&code_challenge_method=S256",
+    ]
+
+    for url in invalidURLs {
+      XCTAssertNil(ChatProvider.validatedClaudeOAuthURL(url), "Expected rejected OAuth URL: \(url)")
+    }
+  }
+
+  func testFreshOAuthURLResetsTheOneLaunchPerAttemptLatch() {
+    XCTAssertFalse(
+      ChatProvider.isNewClaudeOAuthAttempt(
+        previousAuthURL: "https://claude.ai/oauth/authorize?state=current",
+        nextAuthURL: "https://claude.ai/oauth/authorize?state=current"
+      )
+    )
+    XCTAssertTrue(
+      ChatProvider.isNewClaudeOAuthAttempt(
+        previousAuthURL: "https://claude.ai/oauth/authorize?state=expired",
+        nextAuthURL: "https://claude.ai/oauth/authorize?state=retry"
+      )
+    )
+  }
+}

--- a/desktop/macos/Desktop/Tests/ChatStallWatchdogTests.swift
+++ b/desktop/macos/Desktop/Tests/ChatStallWatchdogTests.swift
@@ -27,6 +27,12 @@ final class ChatStallWatchdogTests: XCTestCase {
     XCTAssertNil(ChatProvider.stoppedTurnErrorMessage(watchdogFired: false))
   }
 
+  func testToolStallStopSurfacesToolTimeoutMessage() {
+    XCTAssertEqual(
+      ChatProvider.stoppedTurnErrorMessage(watchdogFired: false, toolStallAbortFired: true),
+      "A tool took too long. Try again.")
+  }
+
   // MARK: - Source-invariant: the marker is set before interrupt() and consumed by the catch
 
   func testWatchdogMarksGenerationBeforeInterrupting() throws {
@@ -60,9 +66,22 @@ final class ChatStallWatchdogTests: XCTestCase {
       "the .stopped catch must check the watchdog marker")
     XCTAssertNotNil(
       source.range(
-        of: #"stoppedTurnErrorMessage\(\s*watchdogFired:\s*watchdogFired\s*\)"#,
+        of: #"stoppedTurnErrorMessage\(\s*watchdogFired:\s*watchdogFired[\s\S]*?toolStallAbortFired:\s*toolStallAbortFired\s*\)"#,
         options: .regularExpression),
       "the .stopped catch must derive its message from the shared helper")
+  }
+
+  func testToolStallGuardMarksGenerationBeforeInterrupting() throws {
+    let source = try chatProviderSource()
+    guard let mark = source.range(
+      of: #"sendToolStallAbortGeneration\s*=\s*sendGen"#, options: .regularExpression)
+    else {
+      return XCTFail("tool stall guard must mark the active generation")
+    }
+    XCTAssertNotNil(
+      source[mark.upperBound...].range(
+        of: #"resolvedAgentClient\(\)\s*\.\s*interrupt\(\)"#, options: .regularExpression),
+      "tool stall guard must interrupt after marking its generation")
   }
 
   // MARK: - Helpers

--- a/desktop/macos/Desktop/Tests/StallDetectorTests.swift
+++ b/desktop/macos/Desktop/Tests/StallDetectorTests.swift
@@ -172,6 +172,20 @@ final class StallDetectorTests: XCTestCase {
     )
   }
 
+  func testToolIdsExceedingReportsOnlyOverdueInFlightTools() async {
+    let detector = StallDetector(thresholds: thresholds, startedAtMs: 0)
+    _ = await detector.step(kind: .toolStarted(id: "slow"), atMs: 0)
+    _ = await detector.step(kind: .toolStarted(id: "fresh"), atMs: 50_000)
+
+    let firstOverdue = await detector.toolIdsExceeding(durationMs: 90_000, atMs: 90_000)
+    XCTAssertEqual(firstOverdue, ["slow"])
+
+    _ = await detector.step(kind: .toolCompleted(id: "slow"), atMs: 90_001)
+    let remainingOverdue = await detector.toolIdsExceeding(durationMs: 90_000, atMs: 200_000)
+    XCTAssertTrue(remainingOverdue.contains("fresh"))
+    XCTAssertFalse(remainingOverdue.contains("slow"))
+  }
+
   // MARK: - Threshold guard
 
   func testThresholdsPreconditionRejectsInvalidValues() {

--- a/desktop/macos/agent/src/adapters/acp.ts
+++ b/desktop/macos/agent/src/adapters/acp.ts
@@ -109,6 +109,41 @@ export class AcpError extends Error {
   }
 }
 
+const RECOVERABLE_AUTH_ERROR_MARKERS = [
+  "authentication_error",
+  "authentication_failed",
+  "failed to authenticate",
+  "invalid authentication credentials",
+  "oauth token has been revoked",
+  "not logged in",
+  "please run /login",
+] as const;
+
+/**
+ * Detect ACP authentication failures that should re-enter the login flow.
+ *
+ * Claude ACP reports missing credentials with the canonical -32000 code, but
+ * provider 401s during session/prompt are wrapped as -32603 internal errors.
+ * Restrict wrapped-error matching to known auth markers so unrelated internal
+ * errors remain terminal instead of opening a surprise login flow.
+ */
+export function isRecoverableAcpAuthError(error: unknown): boolean {
+  if (!(error instanceof AcpError)) return false;
+  if (error.code === -32000) return true;
+  if (error.code !== -32603) return false;
+
+  let data = "";
+  if (error.data !== undefined) {
+    try {
+      data = typeof error.data === "string" ? error.data : JSON.stringify(error.data);
+    } catch {
+      // The message remains authoritative when error data is not serializable.
+    }
+  }
+  const searchable = `${error.message}\n${data}`.toLowerCase();
+  return RECOVERABLE_AUTH_ERROR_MARKERS.some((marker) => searchable.includes(marker));
+}
+
 const MAX_RECENT_STDERR_CHARS = 2_000;
 
 function appendRecentStderr(current: string, next: string): string {

--- a/desktop/macos/agent/src/adapters/pi-mono.ts
+++ b/desktop/macos/agent/src/adapters/pi-mono.ts
@@ -112,6 +112,29 @@ interface PiUsage {
   };
 }
 
+const REQUIRED_AGENT_CONTROL_TOOLS = new Set([
+  "send_agent_message",
+  "spawn_background_agent",
+  "spawn_agent",
+  "run_agent_and_wait",
+]);
+
+function requiredAgentControlFailure(toolName: string, output: string): string | undefined {
+  if (!REQUIRED_AGENT_CONTROL_TOOLS.has(toolName)) return undefined;
+  if (output.startsWith("Error:")) return output;
+  try {
+    const parsed = JSON.parse(output) as { ok?: unknown; error?: { message?: unknown } };
+    if (parsed.ok === false) {
+      const detail = typeof parsed.error?.message === "string" ? parsed.error.message : output;
+      return `Required ${toolName} operation failed: ${detail}`;
+    }
+  } catch {
+    // A successful control tool always returns the canonical JSON envelope.
+    // Preserve a prior failure until an explicit successful retry clears it.
+  }
+  return undefined;
+}
+
 /**
  * PiMonoAdapter spawns pi-mono in RPC mode and translates its events
  * into the normalized bridge protocol.
@@ -209,6 +232,8 @@ export class PiMonoAdapter implements HarnessAdapter {
   private nextRequestId = 1;
   private eventHandler: EventCallback | null = null;
   private toolExecutor: ToolExecutor | null = null;
+  /** A failed required agent-control operation must not become a green parent completion. */
+  private requiredAgentControlFailure: string | undefined;
   private currentAbortController: AbortController | null = null;
   private piPath: string;
   private extensionPath: string;
@@ -424,6 +449,7 @@ export class PiMonoAdapter implements HarnessAdapter {
 
     this.eventHandler = onEvent;
     this.toolExecutor = onToolCall;
+    this.requiredAgentControlFailure = undefined;
     this.currentAbortController = new AbortController();
     this.writeRelayContext(relayContext);
 
@@ -821,6 +847,23 @@ export class PiMonoAdapter implements HarnessAdapter {
       .map((c) => c.text || "")
       .join("") || "";
 
+    if (REQUIRED_AGENT_CONTROL_TOOLS.has(name)) {
+      const failure = requiredAgentControlFailure(name, output);
+      if (failure) {
+        this.requiredAgentControlFailure = failure;
+      } else {
+        // A successful retry of any required agent-control operation resolves
+        // the pending operation failure for this turn.
+        try {
+          if ((JSON.parse(output) as { ok?: unknown }).ok === true) {
+            this.requiredAgentControlFailure = undefined;
+          }
+        } catch {
+          // Non-canonical output cannot clear a prior control-operation failure.
+        }
+      }
+    }
+
     this.eventHandler?.({
       type: "tool_activity",
       name,
@@ -885,6 +928,21 @@ export class PiMonoAdapter implements HarnessAdapter {
       process.stderr.write(
         `[pi-mono] intermediate turn_end (${stopReason}) — keeping prompt alive\n`
       );
+      return;
+    }
+
+    if (this.requiredAgentControlFailure) {
+      const controlFailure = this.requiredAgentControlFailure;
+      this.eventHandler?.({
+        type: "error",
+        message: controlFailure,
+        adapterSessionId: pending.sessionId,
+      });
+      this.pendingRequests.delete(generation);
+      this.activePromptGeneration = 0;
+      pending.reject(new Error(controlFailure));
+      this.eventHandler = null;
+      this.toolExecutor = null;
       return;
     }
 

--- a/desktop/macos/agent/src/index.ts
+++ b/desktop/macos/agent/src/index.ts
@@ -833,10 +833,29 @@ async function main(): Promise<void> {
 
   const store = new SqliteAgentStore({ stateDir: agentStateDir() });
   const registry = new AdapterRegistry();
-  registry.register("acp", () => acpAdapter, 1);
+  // ACP reads the user's local Claude Code credential.  Do not even expose it
+  // to managed Omi runs; switching to User Claude restarts the bridge with
+  // `defaultAdapterId === "acp"` and registers it there.
+  if (defaultAdapterId === "acp") {
+    registry.register("acp", () => acpAdapter, 1);
+  }
   const artifactStorage = new OmiArtifactStorage({ rootDir: agentArtifactsDir() });
   logErr(`Omi artifact root: ${artifactStorage.rootDir}`);
-  const kernel = new AgentRuntimeKernel({ store, registry, artifactStorage });
+  const recoverRunInput = (adapterId: string) => {
+    if (adapterId !== "acp") return {};
+    let recoveries = 0;
+    return {
+      maxAttempts: 3,
+      recoverAfterError: async (error: unknown) => {
+        if (recoveries >= 2 || !isRecoverableAcpAuthError(error)) return false;
+        recoveries += 1;
+        logErr("ACP auth required during run; starting OAuth flow before retry");
+        await startAuthFlow();
+        return true;
+      },
+    };
+  };
+  const kernel = new AgentRuntimeKernel({ store, registry, artifactStorage, recoverRunInput });
   kernel.subscribe((event) => {
     if (!event.runId) return;
     if (event.type === "run.queued") {
@@ -952,8 +971,10 @@ async function main(): Promise<void> {
   }
   agentControlToolContext = {
     kernel,
+    defaultAdapterId,
     getOwnerId: () => currentOwnerId,
     buildMcpServers,
+    recoverRunInput,
   };
   const transport = new JsonlTransport({
     kernel,

--- a/desktop/macos/agent/src/index.ts
+++ b/desktop/macos/agent/src/index.ts
@@ -56,7 +56,7 @@ import { PROTOCOL_VERSION, ensureOutboundProtocolVersion } from "./protocol.js";
 import { startOAuthFlow, type OAuthFlowHandle } from "./oauth-flow.js";
 import type { PromptBlock, RuntimeAdapter } from "./adapters/interface.js";
 import { detectImageMimeType } from "./mime-detect.js";
-import { AcpError, AcpRuntimeAdapter } from "./adapters/acp.js";
+import { AcpError, AcpRuntimeAdapter, isRecoverableAcpAuthError } from "./adapters/acp.js";
 import { AdapterRegistry } from "./runtime/adapter-registry.js";
 import { JsonlTransport, type McpServerBuildContext } from "./runtime/jsonl-transport.js";
 import { AgentRuntimeKernel } from "./runtime/kernel.js";
@@ -961,8 +961,9 @@ async function main(): Promise<void> {
     log: logErr,
     defaultAdapterId,
     buildMcpServers,
-    isRecoverableError: (error) => error instanceof AcpError && error.code === -32000,
-    onRecoverableError: async () => {
+    isRecoverableError: (error, adapterId) => adapterId === "acp" && isRecoverableAcpAuthError(error),
+    onRecoverableError: async (_error, adapterId) => {
+      if (adapterId !== "acp") return;
       logErr("ACP auth required during query; starting OAuth flow before retry");
       await startAuthFlow();
     },

--- a/desktop/macos/agent/src/index.ts
+++ b/desktop/macos/agent/src/index.ts
@@ -288,14 +288,15 @@ function startOmiToolsRelay(): Promise<string> {
               }
               if (isAgentControlToolName(msg.name)) {
                 void (async () => {
+                  const controlOwnerId = activeControlToolOwnerId({
+                    requestKey: controlRequestKey({ requestId, clientId }),
+                    ownerIdForRequest: (requestKey) => activeControlToolOwnersByRequest.get(requestKey),
+                  });
                   const controlToolContext = agentControlToolContext
                     ? {
                         ...agentControlToolContext,
-                        getOwnerId: () =>
-                          activeControlToolOwnerId({
-                            requestKey: controlRequestKey({ requestId, clientId }),
-                            ownerIdForRequest: (requestKey) => activeControlToolOwnersByRequest.get(requestKey),
-                          }),
+                        canSpawnAgents: !isLeafWorkerSession(resolvedCorrelation.sessionId, controlOwnerId),
+                        getOwnerId: () => controlOwnerId,
                       }
                     : undefined;
                   const result = controlToolContext
@@ -701,6 +702,16 @@ function controlRunAdapterId(name: string, input: Record<string, unknown>, defau
   const defaultFromInput =
     typeof input.defaultAdapterId === "string" && input.defaultAdapterId.trim() ? input.defaultAdapterId.trim() : undefined;
   return adapterId ?? defaultFromInput ?? defaultAdapterId;
+}
+
+function isLeafWorkerSession(sessionId: string | undefined, ownerId: string | undefined): boolean {
+  if (!sessionId || !ownerId || !agentControlToolContext) return false;
+  const session = agentControlToolContext.kernel
+    .listSessions({ ownerId, limit: 200 })
+    .find((candidate) => candidate.session.sessionId === sessionId)?.session;
+  return session?.surfaceKind === "delegated_agent"
+    || session?.surfaceKind === "background_agent"
+    || (session?.surfaceKind === "floating_bar" && session.externalRefKind === "pill");
 }
 
 function isLongLivedControlRun(name: string, input: Record<string, unknown>): boolean {

--- a/desktop/macos/agent/src/oauth-flow.ts
+++ b/desktop/macos/agent/src/oauth-flow.ts
@@ -29,6 +29,7 @@ const SUCCESS_URL = "https://console.anthropic.com/oauth/code/success?app=claude
 const SCOPES = "user:inference";
 const KEYCHAIN_SERVICE = "Claude Code-credentials";
 const TOKEN_EXPIRY_SECONDS = 31536000; // 1 year
+const CALLBACK_TIMEOUT_MS = 2 * 60 * 1000;
 
 // --- PKCE Helpers ---
 
@@ -155,9 +156,9 @@ function waitForCallback(
 ): Promise<string> {
   return new Promise((resolve, reject) => {
     const timeout = setTimeout(() => {
-      reject(new Error("OAuth callback timed out (10 minutes)"));
+      reject(new Error("OAuth callback timed out (2 minutes)"));
       server.close();
-    }, 10 * 60 * 1000);
+    }, CALLBACK_TIMEOUT_MS);
 
     server.on("request", (req: IncomingMessage, res: ServerResponse) => {
       const parsed = new URL(req.url || "", `http://localhost`);

--- a/desktop/macos/agent/src/runtime/control-tools.ts
+++ b/desktop/macos/agent/src/runtime/control-tools.ts
@@ -355,12 +355,20 @@ function defaultControlAdapterId(context: AgentControlToolContext): string {
 }
 
 function assertAdapterAllowedForControlRun(context: AgentControlToolContext, adapterId: string): void {
-  // ACP is the user's locally authenticated Claude Code process.  A managed
-  // Omi session must never drift into it merely because a control-tool input
-  // omitted an adapter id.  Local ACP remains available only when the parent
-  // desktop surface explicitly selected the User Claude harness.
-  if (adapterId === "acp" && defaultControlAdapterId(context) !== "acp") {
+  const owningAdapterId = defaultControlAdapterId(context);
+  // A managed desktop surface must never let a control-tool argument switch
+  // execution to any locally credentialed adapter.  Keep this allowlist
+  // explicit: adding a new cloud-managed adapter requires adding it here,
+  // while unknown (and therefore potentially local) adapters fail closed.
+  const managedCloudAdapters = new Set(["pi-mono"]);
+  // ACP is the user's locally authenticated Claude Code process. It remains
+  // available only when the owning desktop surface explicitly selected User
+  // Claude mode; the same rule preserves explicit local Hermes/OpenClaw modes.
+  if (adapterId === "acp" && owningAdapterId !== "acp") {
     throw new Error("Local Claude is available only when the User Claude mode is selected.");
+  }
+  if (managedCloudAdapters.has(owningAdapterId) && !managedCloudAdapters.has(adapterId)) {
+    throw new Error("Managed Omi agents can only use Omi cloud routing.");
   }
 }
 
@@ -640,6 +648,7 @@ export async function handleAgentControlToolCall(
       case "send_agent_message": {
         const parsed = agentControlToolSchemas.send_agent_message.parse(input);
         const adapterId = parsed.adapterId ?? context.kernel.defaultAdapterIdForSession(parsed.sessionId);
+        assertAdapterAllowedForControlRun(context, adapterId);
         rejectSynchronousNestedRun(context, adapterId, parsed.sessionId);
         const ownerId = effectiveControlToolOwnerId(context, parsed.ownerId);
         const requestId = parsed.requestId ?? `send-${Date.now()}-${Math.random().toString(16).slice(2)}`;
@@ -796,6 +805,7 @@ export async function handleAgentControlToolCall(
         const ownerId = effectiveControlToolOwnerId(context, parsed.ownerId);
         const requestId = parsed.requestId ?? `run-and-wait-${Date.now()}-${Math.random().toString(16).slice(2)}`;
         const adapterId = parsed.adapterId ?? context.kernel.defaultAdapterIdForRun(parsed.parentRunId);
+        assertAdapterAllowedForControlRun(context, adapterId);
         const result = await context.kernel.delegateAgent({
           ...controlRunRecovery(context, adapterId),
           mode: "call",

--- a/desktop/macos/agent/src/runtime/control-tools.ts
+++ b/desktop/macos/agent/src/runtime/control-tools.ts
@@ -328,6 +328,8 @@ export interface AgentControlToolContext {
    * must inherit this route rather than silently selecting a local provider.
    */
   defaultAdapterId?: string;
+  /** Leaf/background workers may complete assigned work, but cannot fan out more agents. */
+  canSpawnAgents?: boolean;
   trustedUserControl?: boolean;
   getOwnerId?: () => string;
   recoverRunInput?: (
@@ -359,6 +361,12 @@ function assertAdapterAllowedForControlRun(context: AgentControlToolContext, ada
   // desktop surface explicitly selected the User Claude harness.
   if (adapterId === "acp" && defaultControlAdapterId(context) !== "acp") {
     throw new Error("Local Claude is available only when the User Claude mode is selected.");
+  }
+}
+
+function assertAgentSpawningAllowed(context: AgentControlToolContext): void {
+  if (context.canSpawnAgents === false) {
+    throw new Error("Background agents are leaf workers and cannot start additional agents.");
   }
 }
 
@@ -662,6 +670,7 @@ export async function handleAgentControlToolCall(
         });
       }
       case "spawn_background_agent": {
+        assertAgentSpawningAllowed(context);
         const parsed = agentControlToolSchemas.spawn_background_agent.parse(input);
         const ownerId = effectiveControlToolOwnerId(context, parsed.ownerId);
         const requestId = parsed.requestId ?? `background-${Date.now()}-${Math.random().toString(16).slice(2)}`;
@@ -693,6 +702,7 @@ export async function handleAgentControlToolCall(
         });
       }
       case "spawn_agent": {
+        assertAgentSpawningAllowed(context);
         const parsed = agentControlToolSchemas.spawn_agent.parse(input);
         if (parsed.parentRunId) {
           assertCanonicalRunId(parsed.parentRunId, "parentRunId");
@@ -780,6 +790,7 @@ export async function handleAgentControlToolCall(
         });
       }
       case "run_agent_and_wait": {
+        assertAgentSpawningAllowed(context);
         const parsed = agentControlToolSchemas.run_agent_and_wait.parse(input);
         assertCanonicalRunId(parsed.parentRunId, "parentRunId");
         const ownerId = effectiveControlToolOwnerId(context, parsed.ownerId);

--- a/desktop/macos/agent/src/runtime/control-tools.ts
+++ b/desktop/macos/agent/src/runtime/control-tools.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { z } from "zod";
 import type { AgentArtifact, AgentDelegation, AgentEvent, AgentRun, AgentSession, AdapterBinding, RunAttempt } from "./types.js";
-import { AgentRuntimeKernel, type DesktopAwarenessSnapshot } from "./kernel.js";
+import { AgentRuntimeKernel, type DesktopAwarenessSnapshot, type ExecuteAgentRunInput } from "./kernel.js";
 import { serializeArtifact } from "./artifact-serialization.js";
 import { agentControlCapabilityManifest, agentControlInputSchema } from "./control-tool-manifest.js";
 import type { McpServerBuildContext } from "./jsonl-transport.js";
@@ -323,14 +323,43 @@ export const agentControlToolDefinitions: AgentControlToolDefinition[] = agentCo
 
 export interface AgentControlToolContext {
   kernel: AgentRuntimeKernel;
+  /**
+   * The adapter selected by the owning desktop surface.  New background work
+   * must inherit this route rather than silently selecting a local provider.
+   */
+  defaultAdapterId?: string;
   trustedUserControl?: boolean;
   getOwnerId?: () => string;
+  recoverRunInput?: (
+    adapterId: string,
+  ) => Pick<ExecuteAgentRunInput, "maxAttempts" | "recoverAfterError">;
   buildMcpServers?: (
     mode: "ask" | "act",
     cwd: string | undefined,
     sessionKey: string | undefined,
     context: McpServerBuildContext
   ) => Record<string, unknown>[];
+}
+
+function controlRunRecovery(
+  context: AgentControlToolContext,
+  adapterId: string,
+): Pick<ExecuteAgentRunInput, "maxAttempts" | "recoverAfterError"> {
+  return context.recoverRunInput?.(adapterId) ?? {};
+}
+
+function defaultControlAdapterId(context: AgentControlToolContext): string {
+  return context.defaultAdapterId ?? "acp";
+}
+
+function assertAdapterAllowedForControlRun(context: AgentControlToolContext, adapterId: string): void {
+  // ACP is the user's locally authenticated Claude Code process.  A managed
+  // Omi session must never drift into it merely because a control-tool input
+  // omitted an adapter id.  Local ACP remains available only when the parent
+  // desktop surface explicitly selected the User Claude harness.
+  if (adapterId === "acp" && defaultControlAdapterId(context) !== "acp") {
+    throw new Error("Local Claude is available only when the User Claude mode is selected.");
+  }
 }
 
 export interface ActiveControlToolOwnerInput {
@@ -608,6 +637,7 @@ export async function handleAgentControlToolCall(
         const requestId = parsed.requestId ?? `send-${Date.now()}-${Math.random().toString(16).slice(2)}`;
         const result = await context.kernel.sendAgentMessage({
           ...parsed,
+          ...controlRunRecovery(context, adapterId),
           ownerId,
           requestId,
           metadata: { ...(parsed.metadata ?? {}) },
@@ -635,9 +665,11 @@ export async function handleAgentControlToolCall(
         const parsed = agentControlToolSchemas.spawn_background_agent.parse(input);
         const ownerId = effectiveControlToolOwnerId(context, parsed.ownerId);
         const requestId = parsed.requestId ?? `background-${Date.now()}-${Math.random().toString(16).slice(2)}`;
-        const adapterId = parsed.adapterId ?? parsed.defaultAdapterId ?? "acp";
+        const adapterId = parsed.adapterId ?? parsed.defaultAdapterId ?? defaultControlAdapterId(context);
+        assertAdapterAllowedForControlRun(context, adapterId);
         const result = await context.kernel.spawnBackgroundAgent({
           ...parsed,
+          ...controlRunRecovery(context, adapterId),
           adapterId,
           defaultAdapterId: adapterId,
           ownerId,
@@ -670,7 +702,10 @@ export async function handleAgentControlToolCall(
         const adapterId =
           parsed.adapterId ??
           (parsed.provider === "openclaw" ? "openclaw" : parsed.provider === "hermes" ? "hermes" : undefined) ??
-          (parsed.parentRunId ? undefined : "acp");
+          (parsed.parentRunId ? undefined : defaultControlAdapterId(context));
+        if (adapterId) {
+          assertAdapterAllowedForControlRun(context, adapterId);
+        }
         const visiblePillExternalRefId = parsed.visible
           ? (parsed.externalRefId ?? randomUUID())
           : parsed.externalRefId;
@@ -682,7 +717,7 @@ export async function handleAgentControlToolCall(
           ownerId,
           requestId,
           clientId: parsed.clientId,
-          adapterId: adapterId ?? "acp",
+          adapterId: adapterId ?? defaultControlAdapterId(context),
           surfaceKind: childSurfaceKind,
           externalRefKind: childExternalRefKind,
           externalRefId: visiblePillExternalRefId,
@@ -690,6 +725,7 @@ export async function handleAgentControlToolCall(
         });
         if (parsed.parentRunId) {
           const result = await context.kernel.delegateAgent({
+            ...controlRunRecovery(context, adapterId ?? defaultControlAdapterId(context)),
             mode: "spawn",
             parentRunId: parsed.parentRunId,
             objective: parsed.objective,
@@ -716,6 +752,7 @@ export async function handleAgentControlToolCall(
           });
         }
         const result = await context.kernel.spawnBackgroundAgent({
+          ...controlRunRecovery(context, adapterId ?? defaultControlAdapterId(context)),
           ownerId,
           clientId: parsed.clientId,
           requestId,
@@ -749,6 +786,7 @@ export async function handleAgentControlToolCall(
         const requestId = parsed.requestId ?? `run-and-wait-${Date.now()}-${Math.random().toString(16).slice(2)}`;
         const adapterId = parsed.adapterId ?? context.kernel.defaultAdapterIdForRun(parsed.parentRunId);
         const result = await context.kernel.delegateAgent({
+          ...controlRunRecovery(context, adapterId),
           mode: "call",
           parentRunId: parsed.parentRunId,
           objective: parsed.objective,

--- a/desktop/macos/agent/src/runtime/jsonl-transport.ts
+++ b/desktop/macos/agent/src/runtime/jsonl-transport.ts
@@ -46,8 +46,8 @@ export type McpServerBuilder = (
   context: McpServerBuildContext
 ) => Record<string, unknown>[];
 
-export type RecoverableErrorPredicate = (error: unknown) => boolean;
-export type RecoverableErrorHandler = (error: unknown) => Promise<void>;
+export type RecoverableErrorPredicate = (error: unknown, adapterId: string) => boolean;
+export type RecoverableErrorHandler = (error: unknown, adapterId: string) => Promise<void>;
 
 export interface JsonlTransportOptions {
   kernel: AgentRuntimeKernel;
@@ -476,7 +476,7 @@ export class JsonlTransport {
         adapterId: requestedAdapterId,
       }),
       maxAttempts: this.maxRecoverableRetries > 0 ? this.maxRecoverableRetries + 1 : undefined,
-      recoverAfterError: this.recoverAfterError(),
+      recoverAfterError: this.recoverAfterError(requestedAdapterId),
       attachmentMetadataJson: message.attachmentMetadataJson ?? null,
       surfaceContextJson: message.surfaceContextJson ?? null,
       imagePresent: Boolean(message.imageBase64),
@@ -631,17 +631,17 @@ export class JsonlTransport {
     return undefined;
   }
 
-  private recoverAfterError(): ExecuteAgentRunInput["recoverAfterError"] | undefined {
+  private recoverAfterError(adapterId: string): ExecuteAgentRunInput["recoverAfterError"] | undefined {
     if (!this.isRecoverableError || !this.onRecoverableError || this.maxRecoverableRetries === 0) {
       return undefined;
     }
     let recoveries = 0;
     return async (error) => {
-      if (recoveries >= this.maxRecoverableRetries || !this.isRecoverableError?.(error)) {
+      if (recoveries >= this.maxRecoverableRetries || !this.isRecoverableError?.(error, adapterId)) {
         return false;
       }
       recoveries += 1;
-      await this.onRecoverableError?.(error);
+      await this.onRecoverableError?.(error, adapterId);
       return true;
     };
   }

--- a/desktop/macos/agent/src/runtime/kernel-core.ts
+++ b/desktop/macos/agent/src/runtime/kernel-core.ts
@@ -151,6 +151,7 @@ export class KernelCore {
   protected readonly registry: AdapterRegistry;
   protected readonly runtimeNodeId: string;
   protected readonly artifactStorage?: OmiArtifactStorage;
+  protected readonly recoverRunInput?: AgentRuntimeKernelOptions["recoverRunInput"];
   protected readonly subscribers = new Set<KernelEventSubscriber>();
   protected readonly activeExecutions = new Map<string, ActiveExecution>();
   protected readonly bindingResolutionLocks = new Map<string, Promise<void>>();
@@ -162,6 +163,7 @@ export class KernelCore {
     this.registry = options.registry;
     this.runtimeNodeId = options.runtimeNodeId ?? "desktop-local";
     this.artifactStorage = options.artifactStorage;
+    this.recoverRunInput = options.recoverRunInput;
   }
 
   subscribe(subscriber: KernelEventSubscriber): () => void {
@@ -204,6 +206,16 @@ export class KernelCore {
   ): Promise<KernelRunResult> {
 
     const adapterId = input.adapterId ?? accepted.session.defaultAdapterId;
+    if (!input.recoverAfterError) {
+      const recovery = this.recoverRunInput?.(adapterId);
+      if (recovery) {
+        input = {
+          ...input,
+          maxAttempts: input.maxAttempts ?? recovery.maxAttempts,
+          recoverAfterError: recovery.recoverAfterError,
+        };
+      }
+    }
     const maxAttempts = Math.max(1, input.maxAttempts ?? 2);
     let retryReason: string | null = null;
     let resumeFromAttemptId: string | null = null;

--- a/desktop/macos/agent/src/runtime/kernel-runs.ts
+++ b/desktop/macos/agent/src/runtime/kernel-runs.ts
@@ -155,6 +155,8 @@ export class KernelRuns extends KernelCore {
       cwd: input.cwd ?? session.defaultCwd ?? undefined,
       model: input.model,
       mcpServers: input.mcpServers,
+      maxAttempts: input.maxAttempts,
+      recoverAfterError: input.recoverAfterError,
       metadata: input.metadata,
     });
   }
@@ -175,6 +177,8 @@ export class KernelRuns extends KernelCore {
       cwd: input.cwd,
       model: input.model,
       mcpServers: input.mcpServers,
+      maxAttempts: input.maxAttempts,
+      recoverAfterError: input.recoverAfterError,
       metadata: {
         ...(input.metadata ?? {}),
         spawnKind: "background_agent",
@@ -215,6 +219,8 @@ export class KernelRuns extends KernelCore {
       cwd: input.cwd ?? parentRun.cwd ?? parentSession.defaultCwd ?? undefined,
       model: input.model,
       mcpServers: input.mcpServers,
+      maxAttempts: input.maxAttempts,
+      recoverAfterError: input.recoverAfterError,
       parentRunId: parentRun.runId,
       metadata: {
         ...(input.metadata ?? {}),

--- a/desktop/macos/agent/src/runtime/kernel-types.ts
+++ b/desktop/macos/agent/src/runtime/kernel-types.ts
@@ -242,6 +242,8 @@ export interface SendAgentMessageInput {
   cwd?: string;
   model?: string;
   mcpServers?: Record<string, unknown>[];
+  maxAttempts?: number;
+  recoverAfterError?: (error: unknown) => Promise<boolean>;
   metadata?: Record<string, unknown>;
 }
 
@@ -260,6 +262,8 @@ export interface SpawnBackgroundAgentInput {
   model?: string;
   mcpServers?: Record<string, unknown>[];
   mode?: RunMode;
+  maxAttempts?: number;
+  recoverAfterError?: (error: unknown) => Promise<boolean>;
   metadata?: Record<string, unknown>;
 }
 
@@ -290,6 +294,8 @@ export interface DelegateAgentInput {
   context?: string;
   maxDepth?: number;
   maxBudgetUsd?: number;
+  maxAttempts?: number;
+  recoverAfterError?: (error: unknown) => Promise<boolean>;
   metadata?: Record<string, unknown>;
 }
 
@@ -317,6 +323,11 @@ export interface DelegateAgentResult {
 
 export type KernelEventSubscriber = (event: AgentEvent) => void;
 
+/** Adapter-scoped recovery applied by the kernel to every run entry point. */
+export type KernelRunRecoveryPolicy = (
+  adapterId: string,
+) => Pick<ExecuteAgentRunInput, "maxAttempts" | "recoverAfterError">;
+
 export class StaleAdapterBindingError extends Error {
   constructor(message = "Adapter binding is stale") {
     super(message);
@@ -329,4 +340,5 @@ export interface AgentRuntimeKernelOptions {
   registry: AdapterRegistry;
   runtimeNodeId?: string;
   artifactStorage?: OmiArtifactStorage;
+  recoverRunInput?: KernelRunRecoveryPolicy;
 }

--- a/desktop/macos/agent/src/runtime/turn-context.ts
+++ b/desktop/macos/agent/src/runtime/turn-context.ts
@@ -68,6 +68,19 @@ export interface AssembleTurnContextInput {
   nowMs?: number;
 }
 
+export function isLeafWorkerSurface(surfaceRef: SurfaceRef): boolean {
+  return surfaceRef.surfaceKind === "delegated_agent"
+    || surfaceRef.surfaceKind === "background_agent"
+    || (surfaceRef.surfaceKind === "floating_bar" && surfaceRef.externalRefKind === "pill");
+}
+
+export function leafWorkerExecutionBoundary(surfaceRef: SurfaceRef): string | null {
+  if (!isLeafWorkerSurface(surfaceRef)) return null;
+  return `# Execution Boundary
+
+You are a leaf background worker. Complete the assigned objective yourself and report the result to your parent. Do not call spawn_agent, spawn_background_agent, or run_agent_and_wait; background agents cannot create more agents.`;
+}
+
 export interface AssembledTurnContext {
   prompt: string;
   promptBlocks?: PromptBlock[];
@@ -179,6 +192,11 @@ export function assembleTurnContext(input: AssembleTurnContextInput): AssembledT
         sections.push(transcript);
       }
     }
+  }
+
+  const leafWorkerBoundary = leafWorkerExecutionBoundary(input.surfaceRef);
+  if (leafWorkerBoundary) {
+    sections.push(leafWorkerBoundary);
   }
 
   sections.push(`# User Message\n\n${input.userText}`);

--- a/desktop/macos/agent/tests/control-tools.test.ts
+++ b/desktop/macos/agent/tests/control-tools.test.ts
@@ -1565,6 +1565,33 @@ describe("agent control tools", () => {
     store.close();
   });
 
+  it("prevents leaf background workers from spawning more agents", async () => {
+    const { store, kernel } = createKernelHarness(newDatabasePath(), "pi-mono");
+    const result = parseToolResult(
+      await handleAgentControlToolCall(
+        { ...ownerContext(kernel), defaultAdapterId: "pi-mono", canSpawnAgents: false },
+        "spawn_agent",
+        {
+          objective: "fan out more work",
+          visible: true,
+          requestId: "leaf-worker-spawn-1",
+          clientId: "spawn-client",
+          ownerId: "owner",
+        },
+      ),
+    );
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: {
+        code: "control_tool_failed",
+        message: "Background agents are leaf workers and cannot start additional agents.",
+      },
+    });
+    expect(store.allRows("SELECT * FROM runs")).toHaveLength(0);
+    store.close();
+  });
+
   it("delegates call mode with distinct parent and child sessions linked by a delegation row", async () => {
     const { store, kernel } = createKernelHarness(newDatabasePath());
     const parent = await kernel.executeRun(baseRunInput);

--- a/desktop/macos/agent/tests/control-tools.test.ts
+++ b/desktop/macos/agent/tests/control-tools.test.ts
@@ -1565,6 +1565,79 @@ describe("agent control tools", () => {
     store.close();
   });
 
+  it("keeps every managed control entry point on Omi cloud routing", async () => {
+    const { store, kernel } = createKernelHarness(newDatabasePath(), "pi-mono");
+    const context = { ...ownerContext(kernel), defaultAdapterId: "pi-mono" };
+    const parent = await kernel.executeRun({
+      ...baseRunInput,
+      adapterId: "pi-mono",
+      defaultAdapterId: "pi-mono",
+    });
+
+    for (const provider of ["hermes", "openclaw"] as const) {
+      const spawned = parseToolResult(
+        await handleAgentControlToolCall(context, "spawn_agent", {
+          objective: `do not route to ${provider}`,
+          provider,
+          requestId: `managed-provider-${provider}`,
+          clientId: "managed-routing",
+          ownerId: "owner",
+        }),
+      );
+      expect(spawned).toMatchObject({
+        ok: false,
+        error: { code: "control_tool_failed", message: "Managed Omi agents can only use Omi cloud routing." },
+      });
+
+      const background = parseToolResult(
+        await handleAgentControlToolCall(context, "spawn_background_agent", {
+          prompt: `do not route to ${provider}`,
+          adapterId: provider,
+          requestId: `managed-background-${provider}`,
+          clientId: "managed-routing",
+          ownerId: "owner",
+        }),
+      );
+      expect(background).toMatchObject({
+        ok: false,
+        error: { code: "control_tool_failed", message: "Managed Omi agents can only use Omi cloud routing." },
+      });
+
+      const continued = parseToolResult(
+        await handleAgentControlToolCall(context, "send_agent_message", {
+          sessionId: parent.session.sessionId,
+          prompt: `do not route to ${provider}`,
+          adapterId: provider,
+          requestId: `managed-continue-${provider}`,
+          clientId: "managed-routing",
+          ownerId: "owner",
+        }),
+      );
+      expect(continued).toMatchObject({
+        ok: false,
+        error: { code: "control_tool_failed", message: "Managed Omi agents can only use Omi cloud routing." },
+      });
+
+      const delegated = parseToolResult(
+        await handleAgentControlToolCall(context, "run_agent_and_wait", {
+          parentRunId: parent.run.runId,
+          objective: `do not route to ${provider}`,
+          adapterId: provider,
+          requestId: `managed-delegate-${provider}`,
+          clientId: "managed-routing",
+          ownerId: "owner",
+        }),
+      );
+      expect(delegated).toMatchObject({
+        ok: false,
+        error: { code: "control_tool_failed", message: "Managed Omi agents can only use Omi cloud routing." },
+      });
+    }
+
+    expect(store.allRows("SELECT * FROM runs")).toHaveLength(1);
+    store.close();
+  });
+
   it("prevents leaf background workers from spawning more agents", async () => {
     const { store, kernel } = createKernelHarness(newDatabasePath(), "pi-mono");
     const result = parseToolResult(

--- a/desktop/macos/agent/tests/control-tools.test.ts
+++ b/desktop/macos/agent/tests/control-tools.test.ts
@@ -1512,6 +1512,59 @@ describe("agent control tools", () => {
     store.close();
   });
 
+  it("inherits the managed adapter for background agents instead of local ACP", async () => {
+    const { store, adapter, kernel } = createKernelHarness(newDatabasePath(), "pi-mono");
+    const spawned = parseToolResult(
+      await handleAgentControlToolCall(
+        { ...ownerContext(kernel), defaultAdapterId: "pi-mono" },
+        "spawn_agent",
+        {
+          objective: "research managed routing",
+          visible: true,
+          requestId: "spawn-managed-routing-1",
+          clientId: "spawn-client",
+          ownerId: "owner",
+        },
+      ),
+    );
+
+    await waitUntil(() => {
+      const row = store.getRow("SELECT status FROM runs WHERE run_id = ?", [spawned.run.runId]);
+      return row.status === "succeeded";
+    });
+    expect(spawned.session.defaultAdapterId).toBe("pi-mono");
+    expect(adapter.executed).toHaveLength(1);
+    store.close();
+  });
+
+  it("rejects an explicit local ACP override from a managed agent", async () => {
+    const { store, kernel } = createKernelHarness(newDatabasePath(), "pi-mono");
+    const result = parseToolResult(
+      await handleAgentControlToolCall(
+        { ...ownerContext(kernel), defaultAdapterId: "pi-mono" },
+        "spawn_agent",
+        {
+          objective: "do not use local credentials",
+          visible: true,
+          adapterId: "acp",
+          requestId: "spawn-managed-local-acp-1",
+          clientId: "spawn-client",
+          ownerId: "owner",
+        },
+      ),
+    );
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: {
+        code: "control_tool_failed",
+        message: "Local Claude is available only when the User Claude mode is selected.",
+      },
+    });
+    expect(store.allRows("SELECT * FROM runs")).toHaveLength(0);
+    store.close();
+  });
+
   it("delegates call mode with distinct parent and child sessions linked by a delegation row", async () => {
     const { store, kernel } = createKernelHarness(newDatabasePath());
     const parent = await kernel.executeRun(baseRunInput);
@@ -1756,6 +1809,51 @@ describe("agent control tools", () => {
         latestActivity: expect.stringContaining("spawn bridge failed after acceptance"),
       }),
     );
+    store.close();
+  });
+
+  it("retries an accepted ACP spawn after control-tool credential recovery", async () => {
+    const authError = new Error("Invalid authentication credentials");
+    let recoveries = 0;
+    const { store, adapter, kernel } = createKernelHarness(
+      newDatabasePath(),
+      "acp",
+      4,
+      undefined,
+      (adapterId) =>
+        adapterId === "acp"
+          ? {
+              maxAttempts: 2,
+              recoverAfterError: async (error) => {
+                recoveries += 1;
+                return error === authError;
+              },
+            }
+          : {},
+    );
+    adapter.failNextExecutionError = authError;
+
+    const spawned = parseToolResult(
+      await handleAgentControlToolCall(ownerContext(kernel), "spawn_agent", {
+        objective: "research PXMX",
+        visible: true,
+        requestId: "spawn-auth-recovery-1",
+        clientId: "spawn-client",
+        ownerId: "owner",
+      }),
+    );
+
+    await waitUntil(() => {
+      const row = store.getRow("SELECT status FROM runs WHERE run_id = ?", [spawned.run.runId]);
+      return row.status === "succeeded";
+    });
+    expect(recoveries).toBe(1);
+    expect(store.allRows("SELECT attempt_no, retry_reason, status FROM run_attempts WHERE run_id = ? ORDER BY attempt_no", [
+      spawned.run.runId,
+    ])).toEqual([
+      expect.objectContaining({ attempt_no: 1, retry_reason: null, status: "failed" }),
+      expect.objectContaining({ attempt_no: 2, retry_reason: "recoverable_error", status: "succeeded" }),
+    ]);
     store.close();
   });
 

--- a/desktop/macos/agent/tests/jsonl-transport.test.ts
+++ b/desktop/macos/agent/tests/jsonl-transport.test.ts
@@ -1356,6 +1356,33 @@ describe("JsonlTransport", () => {
     store.close();
   });
 
+  it("passes the selected adapter to auth recovery without conflating providers", async () => {
+    const { store, adapter, kernel } = createKernelHarness(newDatabasePath());
+    const seen: string[] = [];
+    const authError = Object.assign(new Error("auth required during prompt"), { code: -32000 });
+    adapter.failNextExecutionError = authError;
+    const facade = new JsonlTransport({
+      kernel,
+      send: () => {},
+      defaultAdapterId: "fake",
+      defaultCwd: () => "/tmp/default",
+      isRecoverableError: (error, adapterId) => {
+        seen.push(`predicate:${adapterId}`);
+        return error === authError && adapterId === "fake";
+      },
+      onRecoverableError: async (_error, adapterId) => {
+        seen.push(`handler:${adapterId}`);
+      },
+      maxRecoverableRetries: 2,
+    });
+
+    await facade.handleQuery(v2Query({ requestId: "request-auth-adapter-scope" }));
+
+    expect(seen).toEqual(["predicate:fake", "handler:fake"]);
+    expect(adapter.executed).toHaveLength(2);
+    store.close();
+  });
+
   it("fails terminally when recoverable error handling fails", async () => {
     const { store, adapter, kernel } = createKernelHarness(newDatabasePath());
     const sent: OutboundMessage[] = [];

--- a/desktop/macos/agent/tests/kernel-fakes.ts
+++ b/desktop/macos/agent/tests/kernel-fakes.ts
@@ -199,13 +199,17 @@ export function createKernelHarness(
   databasePath: string,
   adapterId = "fake",
   maxWorkers = 4,
-  artifactStorage?: OmiArtifactStorage
+  artifactStorage?: OmiArtifactStorage,
+  recoverRunInput?: (adapterId: string) => {
+    maxAttempts?: number;
+    recoverAfterError?: (error: unknown) => Promise<boolean>;
+  },
 ): KernelHarness {
   const store = new SqliteAgentStore({ databasePath, reconcileOnOpen: false });
   const adapter = new FakeRuntimeAdapter(adapterId);
   const registry = new AdapterRegistry();
   registry.register(adapterId, () => adapter, maxWorkers);
-  const kernel = new AgentRuntimeKernel({ store, registry, artifactStorage });
+  const kernel = new AgentRuntimeKernel({ store, registry, artifactStorage, recoverRunInput });
   return { store, adapter, kernel };
 }
 

--- a/desktop/macos/agent/tests/pi-mono-adapter.test.ts
+++ b/desktop/macos/agent/tests/pi-mono-adapter.test.ts
@@ -346,6 +346,71 @@ describe("PiMonoAdapter prompt correlation", () => {
     );
   });
 
+  it("does not report success after a required agent-control operation fails", async () => {
+    const { adapter, events } = createAdapter();
+    seedSessions(adapter, "session-1");
+
+    const prompt = adapter.sendPrompt(
+      "session-1",
+      [{ type: "text", text: "create a child" }],
+      [],
+      "act",
+      (event) => events.push(event),
+      async () => ""
+    );
+
+    (adapter as any).handleToolEnd({
+      toolName: "spawn_agent",
+      toolCallId: "tool-spawn",
+      result: {
+        content: [{
+          type: "text",
+          text: JSON.stringify({
+            ok: false,
+            error: { code: "missing_request_context", message: "missing active Omi request context" },
+          }),
+        }],
+      },
+    });
+    (adapter as any).handleTurnEnd(makeTurnEndEvent("I could not create the child, but I am done."));
+
+    await expect(prompt).rejects.toThrow("Required spawn_agent operation failed");
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: "error",
+        message: expect.stringContaining("missing active Omi request context"),
+      })
+    );
+  });
+
+  it("allows a successful required-control retry to complete the parent turn", async () => {
+    const { adapter } = createAdapter();
+    seedSessions(adapter, "session-1");
+
+    const prompt = adapter.sendPrompt(
+      "session-1",
+      [{ type: "text", text: "create a child" }],
+      [],
+      "act",
+      () => {},
+      async () => ""
+    );
+
+    (adapter as any).handleToolEnd({
+      toolName: "spawn_agent",
+      toolCallId: "tool-spawn-1",
+      result: { content: [{ type: "text", text: JSON.stringify({ ok: false, error: { message: "temporary failure" } }) }] },
+    });
+    (adapter as any).handleToolEnd({
+      toolName: "spawn_agent",
+      toolCallId: "tool-spawn-2",
+      result: { content: [{ type: "text", text: JSON.stringify({ ok: true }) }] },
+    });
+    (adapter as any).handleTurnEnd(makeTurnEndEvent("child created"));
+
+    await expect(prompt).resolves.toMatchObject({ text: "child created" });
+  });
+
   it("resolves abort before turn_end and drops the late completion", async () => {
     const { adapter, events } = createAdapter();
     seedSessions(adapter, "session-1");

--- a/desktop/macos/agent/tests/runtime-adapter.test.ts
+++ b/desktop/macos/agent/tests/runtime-adapter.test.ts
@@ -2,7 +2,7 @@ import { PassThrough } from "node:stream";
 import { EventEmitter } from "node:events";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { spawn } from "child_process";
-import { AcpRuntimeAdapter } from "../src/adapters/acp.js";
+import { AcpError, AcpRuntimeAdapter, isRecoverableAcpAuthError } from "../src/adapters/acp.js";
 import {
   PiMonoAdapter,
   PiMonoRuntimeAdapter,
@@ -86,6 +86,34 @@ function fakeAdapter(adapterId = "fake"): RuntimeAdapter {
     }),
   };
 }
+
+describe("ACP authentication recovery classification", () => {
+  it("accepts the canonical ACP auth-required error", () => {
+    expect(isRecoverableAcpAuthError(new AcpError("Authentication required", -32000))).toBe(true);
+  });
+
+  it("accepts the wrapped provider 401 returned during session/prompt", () => {
+    const error = new AcpError(
+      'Internal error: Failed to authenticate. API Error: 401 {"type":"error","error":{"type":"authentication_error","message":"Invalid authentication credentials"}}',
+      -32603,
+    );
+
+    expect(isRecoverableAcpAuthError(error)).toBe(true);
+  });
+
+  it("accepts structured auth failure data when the message is generic", () => {
+    const error = new AcpError("Internal error", -32603, {
+      error: { type: "authentication_error", message: "token rejected" },
+    });
+
+    expect(isRecoverableAcpAuthError(error)).toBe(true);
+  });
+
+  it("leaves unrelated internal and non-ACP errors terminal", () => {
+    expect(isRecoverableAcpAuthError(new AcpError("Internal error: database unavailable", -32603))).toBe(false);
+    expect(isRecoverableAcpAuthError(new Error("Invalid authentication credentials"))).toBe(false);
+  });
+});
 
 describe("AcpRuntimeAdapter process spawning", () => {
   beforeEach(() => {

--- a/desktop/macos/agent/tests/turn-context.test.ts
+++ b/desktop/macos/agent/tests/turn-context.test.ts
@@ -16,6 +16,8 @@ import {
   getVoiceSeedContext,
   getVoiceSeedSnapshot,
   isExplicitAgentControlToolTurn,
+  isLeafWorkerSurface,
+  leafWorkerExecutionBoundary,
   shouldInjectCoordinatorRoute,
   shouldInjectCompletedAgentDelta,
   turnSourceAttribution,
@@ -39,6 +41,18 @@ describe("turn-context", () => {
       rmSync(cleanupDir, { recursive: true, force: true });
       cleanupDir = undefined;
     }
+  });
+
+  it("gives floating-pill workers a leaf-only execution boundary", () => {
+    const surfaceRef = { surfaceKind: "floating_bar", externalRefKind: "pill", externalRefId: "pill-1" };
+    expect(isLeafWorkerSurface(surfaceRef)).toBe(true);
+    expect(leafWorkerExecutionBoundary(surfaceRef)).toContain("cannot create more agents");
+  });
+
+  it("keeps main-chat coordinators able to create background work", () => {
+    const surfaceRef = { surfaceKind: "main_chat", externalRefKind: "chat", externalRefId: "chat-1" };
+    expect(isLeafWorkerSurface(surfaceRef)).toBe(false);
+    expect(leafWorkerExecutionBoundary(surfaceRef)).toBeNull();
   });
 
   it("does not inject undelivered transcript delta when native binding has seen all turns", () => {

--- a/desktop/macos/changelog/unreleased/20260710-agent-auth-recovery.json
+++ b/desktop/macos/changelog/unreleased/20260710-agent-auth-recovery.json
@@ -1,3 +1,3 @@
 {
-  "change": "Fixed background agents failing instead of asking you to reconnect when their Claude credentials expire"
+  "change": "Background agents now stay on Omi's managed cloud route, while explicit User Claude sign-in is bounded and opens its reconnect flow automatically. Stalled tool calls now stop before a chat can hang for three minutes."
 }

--- a/desktop/macos/changelog/unreleased/20260710-agent-auth-recovery.json
+++ b/desktop/macos/changelog/unreleased/20260710-agent-auth-recovery.json
@@ -1,3 +1,3 @@
 {
-  "change": "Background agents now stay on Omi's managed cloud route, while explicit User Claude sign-in is bounded and opens its reconnect flow automatically. Stalled tool calls now stop before a chat can hang for three minutes."
+  "change": "Background agents now stay on Omi's managed cloud route and operate as leaf workers, while explicit User Claude sign-in is bounded and opens its reconnect flow automatically. Stalled tool calls now stop before a chat can hang for three minutes."
 }

--- a/desktop/macos/changelog/unreleased/20260710-agent-auth-recovery.json
+++ b/desktop/macos/changelog/unreleased/20260710-agent-auth-recovery.json
@@ -1,3 +1,3 @@
 {
-  "change": "Background agents now stay on Omi's managed cloud route and operate as leaf workers, while explicit User Claude sign-in is bounded and opens its reconnect flow automatically. Stalled tool calls now stop before a chat can hang for three minutes."
+  "change": "Background agents now stay on Omi's managed cloud route and operate as leaf workers. Explicit User Claude sign-in uses a validated, bounded reconnect flow, and failed agent-control actions show as failures instead of misleading completion. Stalled tool calls now stop before a chat can hang for three minutes."
 }

--- a/desktop/macos/changelog/unreleased/20260710-agent-auth-recovery.json
+++ b/desktop/macos/changelog/unreleased/20260710-agent-auth-recovery.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed background agents failing instead of asking you to reconnect when their Claude credentials expire"
+}

--- a/desktop/macos/e2e/flows/chat-hermetic.yaml
+++ b/desktop/macos/e2e/flows/chat-hermetic.yaml
@@ -18,6 +18,7 @@ covers:
   - desktop/macos/Desktop/Sources/Chat/RuntimeOwnerIdentity.swift
   - desktop/macos/Desktop/Sources/Chat/ScreenContextTelemetry.swift
   - desktop/macos/Desktop/Sources/Chat/ChatStreamingBuffer.swift
+  - desktop/macos/Desktop/Sources/Chat/StallDetector.swift
   - desktop/macos/Desktop/Sources/Chat/ChatErrorState.swift
   - desktop/macos/Desktop/Sources/Chat/ChatPrompts.swift
   - desktop/macos/Desktop/Sources/Chat/TypingIndicator.swift


### PR DESCRIPTION
## Summary

- Managed background and delegated agents inherit the Omi cloud route and reject every local adapter override (ACP, Hermes, or OpenClaw).
- Background agents are leaf workers: prompt context prohibits nested spawning, runtime control tools reject it, and a failed required control operation fails the parent instead of misleadingly showing Done.
- Explicit User Claude OAuth is adapter-scoped, opens at most once per attempt, accepts only validated Claude PKCE loopback URLs, and unlocks a new browser launch after a fresh retry URL.
- A 90-second per-tool guard interrupts stalled turns before the 180-second whole-chat watchdog.

## Root cause

Background control paths defaulted omitted adapters to local ACP even though the desktop was in managed piMono mode. The initial guard only covered ACP, leaving equivalent local Hermes/OpenClaw overrides available in other control paths. Separately, a background-agent smoke test could report a green parent completion after its nested spawn had failed at the tool relay.

## Guardrails

- Managed routing has no implicit or explicit local-provider fallback; unknown adapters fail closed.
- Local adapters remain usable only from a desktop surface that explicitly selected that local mode.
- Floating-pill, delegated, and background sessions are leaf workers.
- Failed required child-control operations become terminal parent failures unless a later control retry succeeds.
- OAuth browser launches require the expected Claude PKCE loopback authorization URL.

## Product invariants affected

- INV-AUTH-1 — ChatProvider's User Claude recovery remains scoped to an explicit local-provider flow; managed-provider 401s never invalidate the Omi Firebase session.
- INV-CHAT-1 — The shared kernel transcript remains authoritative; failed required control operations now terminate the shared run rather than creating a false-success projection.
- INV-AGENT-* — Control-tool authority and run lifecycle remain kernel-owned; managed routes fail closed and required control-operation failures are terminal.

## Validation

- npm run build
- Focused managed-routing, local-ACP-rejection, leaf-worker, parent-failure, and retry tests
- ./scripts/agent-logic-harness.sh --node-only --skip-install (agent runtime focused tests plus 103 exact pi-mono-extension tests)
- xcrun swift test --package-path Desktop --filter ChatProviderOAuthURLTests|StallDetectorTests|ChatStallWatchdogTests (25 passing)
- python3 desktop/macos/scripts/check-e2e-flow-coverage.py --strict --base origin/main
- Named bundle /Applications/omi-agent-auth-recovery.app smoke test completed on pi-mono, with no ACP launch or 401.

## Note

The broad agent TypeScript suite still has seven unrelated existing failures in migration/event-ordering and pi-mono concurrency cases; targeted coverage and the harness pass.