### PR TITLE
fix(desktop): package LLM stub fixtures in backend image

### DIFF
--- a/desktop/macos/Backend-Rust/Dockerfile
+++ b/desktop/macos/Backend-Rust/Dockerfile
@@ -21,9 +21,10 @@ RUN mkdir src && echo "fn main() {}" > src/main.rs
 # Build dependencies only (cached layer)
 RUN cargo build --release --locked && rm -rf src
 
-# Copy actual source code and templates
+# Copy actual source code, templates, and compile-time fixtures.
 COPY src ./src
 COPY templates ./templates
+COPY fixtures ./fixtures
 
 # Build the application
 RUN touch src/main.rs && cargo build --release --locked

--- a/desktop/macos/Backend-Rust/tests/dockerfile_fixture_packaging.rs
+++ b/desktop/macos/Backend-Rust/tests/dockerfile_fixture_packaging.rs
@@ -1,0 +1,10 @@
+#[test]
+fn dockerfile_copies_llm_stub_fixtures() {
+    let dockerfile = std::fs::read_to_string(concat!(env!("CARGO_MANIFEST_DIR"), "/Dockerfile"))
+        .expect("read desktop backend Dockerfile");
+
+    assert!(
+        dockerfile.contains("COPY fixtures ./fixtures"),
+        "the Docker build must include fixtures used by include_str! in the LLM stub"
+    );
+}


### PR DESCRIPTION
## Summary

- include the Rust backend's compile-time fixture directory in the Docker builder image
- add a cargo integration test that prevents the fixture copy from being removed

## Root cause

`llm_stub.rs` embeds `fixtures/llm/default_stream.sse` with `include_str!`, but the backend Dockerfile copied only `src/` and `templates/`. The auto-development deploy therefore failed during `cargo build --release --locked` because the embedded fixture was missing from the image context.

## Validation

- `cargo test --manifest-path Cargo.toml --locked` (320 passed)
- `cargo build --manifest-path Cargo.toml --release --locked`
- targeted fixture-packaging regression test passed
- local `docker build` could not run because the OrbStack Docker daemon socket is unavailable; the change addresses the exact missing-path failure from the development deployment workflow


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9405?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

