### PR TITLE
ci: make PR preflight deterministic and observable

### DIFF
--- a/.github/scripts/pr_metadata.py
+++ b/.github/scripts/pr_metadata.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Load current pull-request metadata without trusting a stale event payload."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable
+
+
+@dataclass(frozen=True)
+class PullRequestMetadata:
+    number: int
+    body: str
+    updated_at: str
+    labels: tuple[str, ...]
+    source: str
+
+
+def _parse_metadata(data: dict, source: str) -> PullRequestMetadata:
+    labels = data.get("labels") or []
+    label_names = tuple(
+        sorted(
+            label["name"] if isinstance(label, dict) else str(label)
+            for label in labels
+            if (isinstance(label, str) and label) or (isinstance(label, dict) and label.get("name"))
+        )
+    )
+    number = data.get("number")
+    if not isinstance(number, int):
+        raise RuntimeError(f"PR metadata from {source} did not include a numeric PR number")
+    return PullRequestMetadata(
+        number=number,
+        body=str(data.get("body") or ""),
+        updated_at=str(data.get("updated_at") or data.get("updatedAt") or "unknown"),
+        labels=label_names,
+        source=source,
+    )
+
+
+def load_from_api(
+    repository: str,
+    number: int,
+    token: str,
+    *,
+    opener: Callable[..., object] = urllib.request.urlopen,
+) -> PullRequestMetadata:
+    if not token:
+        raise RuntimeError("GITHUB_TOKEN is required to read current PR metadata")
+    url = f"https://api.github.com/repos/{repository}/pulls/{number}"
+    request = urllib.request.Request(
+        url,
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
+            "X-GitHub-Api-Version": "2022-11-28",
+            "User-Agent": "omi-pr-preflight",
+        },
+    )
+    try:
+        with opener(request, timeout=15) as response:  # type: ignore[attr-defined]
+            payload = json.load(response)
+    except urllib.error.HTTPError as exc:
+        raise RuntimeError(f"GitHub API returned HTTP {exc.code} while reading PR #{number}") from exc
+    except urllib.error.URLError as exc:
+        raise RuntimeError(f"GitHub API request failed while reading PR #{number}: {exc.reason}") from exc
+    if not isinstance(payload, dict):
+        raise RuntimeError(f"GitHub API returned invalid metadata for PR #{number}")
+    return _parse_metadata(payload, f"GitHub API PR #{number}")
+
+
+def load_from_gh(root: Path) -> PullRequestMetadata:
+    try:
+        result = subprocess.run(
+            ["gh", "pr", "view", "--json", "number,body,updatedAt,labels"],
+            cwd=root,
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+    except FileNotFoundError as exc:
+        raise RuntimeError("gh is not installed; pass --pr-body-file before the first push") from exc
+    except subprocess.CalledProcessError as exc:
+        detail = exc.stderr.strip() or "no pull request is associated with this branch"
+        raise RuntimeError(f"could not discover the current PR with gh: {detail}") from exc
+    payload = json.loads(result.stdout)
+    if not isinstance(payload, dict):
+        raise RuntimeError("gh returned invalid PR metadata")
+    return _parse_metadata(payload, "gh current PR")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repository", required=True, help="GitHub repository as owner/name")
+    parser.add_argument("--pr-number", required=True, type=int)
+    parser.add_argument("--output", required=True, type=Path, help="File to receive the current PR body")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        metadata = load_from_api(args.repository, args.pr_number, os.getenv("GITHUB_TOKEN", ""))
+    except RuntimeError as exc:
+        print(f"FAIL: {exc}", file=sys.stderr)
+        return 1
+    args.output.write_text(metadata.body, encoding="utf-8")
+    print(f"Loaded {metadata.source}, updated_at={metadata.updated_at}.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/pr_preflight.py
+++ b/.github/scripts/pr_preflight.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""Run fast, deterministic pull-request contract checks."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+import tempfile
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+from pr_metadata import PullRequestMetadata, load_from_gh
+
+
+@dataclass(frozen=True)
+class Check:
+    name: str
+    reason: str
+
+
+def run_git(root: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=root,
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def changed_files(root: Path, base: str, head: str) -> list[str]:
+    output = run_git(root, "diff", "--name-only", "--diff-filter=ACMR", f"{base}...{head}")
+    return [line for line in output.splitlines() if line]
+
+
+def select_checks(files: list[str]) -> list[Check]:
+    checks = [
+        Check("diff-hygiene", "all PRs"),
+        Check("architecture-guardrails", "all PRs"),
+        Check("product-invariants", "all PRs; changed paths determine required citations"),
+        Check("desktop-changelog-data", "repository-wide changelog schema contract"),
+    ]
+    if any(path.startswith("desktop/macos/") for path in files):
+        checks.append(Check("desktop-changelog-entry", "desktop files changed"))
+    if any(path.startswith("desktop/macos/Desktop/Sources/") and path.endswith(".swift") for path in files):
+        checks.append(Check("desktop-e2e-flow-coverage", "desktop Swift sources changed"))
+    return checks
+
+
+def resolve_pr_metadata(root: Path, body_file: Path | None) -> PullRequestMetadata | None:
+    if body_file:
+        return PullRequestMetadata(
+            number=0,
+            body=body_file.read_text(encoding="utf-8"),
+            updated_at="local file",
+            labels=(),
+            source=str(body_file.resolve()),
+        )
+    try:
+        return load_from_gh(root)
+    except RuntimeError as exc:
+        print(f"PR metadata: unavailable ({exc})")
+        print("If invariant citations are required, rerun with --pr-body-file <draft.md>.")
+        return None
+
+
+def command_for_check(
+    check: Check,
+    files_path: Path,
+    base: str,
+    head: str,
+    body_path: Path,
+    labels: tuple[str, ...],
+) -> list[str]:
+    python = sys.executable
+    commands = {
+        "architecture-guardrails": [
+            python,
+            ".github/scripts/check_arch_guardrails.py",
+            "--changed-files",
+            str(files_path),
+        ],
+        "product-invariants": [
+            python,
+            ".github/scripts/check_product_invariants.py",
+            "--changed-files",
+            str(files_path),
+            "--pr-body-file",
+            str(body_path),
+        ],
+        "desktop-changelog-data": [python, ".github/scripts/desktop-changelog.py", "validate"],
+        "desktop-changelog-entry": [
+            python,
+            ".github/scripts/check-desktop-changelog.py",
+            "--base",
+            base,
+            "--head",
+            head,
+            *(["--skip"] if "no-changelog-needed" in labels else []),
+        ],
+        "desktop-e2e-flow-coverage": [
+            python,
+            "desktop/macos/scripts/check-e2e-flow-coverage.py",
+            "--strict",
+            *files_path.read_text(encoding="utf-8").splitlines(),
+        ],
+    }
+    return commands[check.name]
+
+
+def check_diff_hygiene(root: Path, base: str, head: str, files: list[str]) -> int:
+    diff_check = subprocess.run(["git", "diff", "--check", f"{base}...{head}"], cwd=root, check=False)
+    if diff_check.returncode:
+        return diff_check.returncode
+    failed = False
+    for path in files:
+        result = subprocess.run(
+            ["git", "grep", "-n", "-I", "-E", "^(<<<<<<<|>>>>>>>)", head, "--", path],
+            cwd=root,
+            check=False,
+        )
+        if result.returncode == 0:
+            failed = True
+    if failed:
+        print("FAIL: unresolved merge conflict markers found in changed files", file=sys.stderr)
+        return 1
+    return 0
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base", default="origin/main")
+    parser.add_argument("--head", default="HEAD")
+    parser.add_argument("--pr-body-file", type=Path)
+    parser.add_argument("--list", action="store_true", help="Print selected checks without running them")
+    parser.add_argument("--root", type=Path)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    root = (args.root or Path(run_git(Path.cwd(), "rev-parse", "--show-toplevel"))).resolve()
+    started = time.monotonic()
+    try:
+        merge_base = run_git(root, "merge-base", args.base, args.head)
+        files = changed_files(root, args.base, args.head)
+    except subprocess.CalledProcessError as exc:
+        print(f"FAIL: could not resolve preflight diff: {exc.stderr.strip()}", file=sys.stderr)
+        return 1
+    checks = select_checks(files)
+    print(f"PR preflight: base={args.base} ({merge_base[:12]}) head={args.head} files={len(files)}")
+    for check in checks:
+        print(f"  SELECTED {check.name}: {check.reason}")
+    if args.list:
+        return 0
+
+    metadata = resolve_pr_metadata(root, args.pr_body_file)
+    labels = metadata.labels if metadata else ()
+    if metadata:
+        print(f"PR metadata: {metadata.source}, updated_at={metadata.updated_at}")
+
+    with tempfile.TemporaryDirectory(prefix="omi-pr-preflight-") as temp_dir:
+        temp = Path(temp_dir)
+        files_path = temp / "changed-files.txt"
+        body_path = temp / "pr-body.txt"
+        files_path.write_text("".join(f"{path}\n" for path in files), encoding="utf-8")
+        body_path.write_text(metadata.body if metadata else "", encoding="utf-8")
+        failures: list[str] = []
+        for check in checks:
+            phase_started = time.monotonic()
+            print(f"==> {check.name}", flush=True)
+            if check.name == "diff-hygiene":
+                returncode = check_diff_hygiene(root, args.base, args.head, files)
+            else:
+                command = command_for_check(check, files_path, args.base, args.head, body_path, labels)
+                returncode = subprocess.run(command, cwd=root, check=False).returncode
+            elapsed = time.monotonic() - phase_started
+            status = "PASS" if returncode == 0 else "FAIL"
+            print(f"<== {status} {check.name} ({elapsed:.2f}s)", flush=True)
+            if returncode:
+                failures.append(check.name)
+                break
+
+    elapsed = time.monotonic() - started
+    if failures:
+        print(f"PR preflight failed in {elapsed:.2f}s: {', '.join(failures)}", file=sys.stderr)
+        return 1
+    print(f"PR preflight passed: {len(checks)} checks in {elapsed:.2f}s.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/pr_preflight.py
+++ b/.github/scripts/pr_preflight.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import os
 import subprocess
 import sys
 import tempfile
@@ -11,7 +12,7 @@ import time
 from dataclasses import dataclass
 from pathlib import Path
 
-from pr_metadata import PullRequestMetadata, load_from_gh
+from pr_metadata import PullRequestMetadata, load_from_api, load_from_gh
 
 
 @dataclass(frozen=True)
@@ -51,7 +52,12 @@ def select_checks(files: list[str]) -> list[Check]:
     return checks
 
 
-def resolve_pr_metadata(root: Path, body_file: Path | None) -> PullRequestMetadata | None:
+def resolve_pr_metadata(
+    root: Path,
+    body_file: Path | None,
+    repository: str | None,
+    pr_number: int | None,
+) -> PullRequestMetadata | None:
     if body_file:
         return PullRequestMetadata(
             number=0,
@@ -60,6 +66,8 @@ def resolve_pr_metadata(root: Path, body_file: Path | None) -> PullRequestMetada
             labels=(),
             source=str(body_file.resolve()),
         )
+    if repository and pr_number:
+        return load_from_api(repository, pr_number, os.getenv("GITHUB_TOKEN", ""))
     try:
         return load_from_gh(root)
     except RuntimeError as exc:
@@ -74,7 +82,7 @@ def command_for_check(
     base: str,
     head: str,
     body_path: Path,
-    labels: tuple[str, ...],
+    skip_changelog: bool,
 ) -> list[str]:
     python = sys.executable
     commands = {
@@ -100,7 +108,7 @@ def command_for_check(
             base,
             "--head",
             head,
-            *(["--skip"] if "no-changelog-needed" in labels else []),
+            *(["--skip"] if skip_changelog else []),
         ],
         "desktop-e2e-flow-coverage": [
             python,
@@ -136,6 +144,9 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--base", default="origin/main")
     parser.add_argument("--head", default="HEAD")
     parser.add_argument("--pr-body-file", type=Path)
+    parser.add_argument("--repository", help="GitHub repository as owner/name; requires --pr-number")
+    parser.add_argument("--pr-number", type=int, help="Load current PR metadata through the GitHub API")
+    parser.add_argument("--head-branch", help="PR head branch, used for release-changelog policy")
     parser.add_argument("--list", action="store_true", help="Print selected checks without running them")
     parser.add_argument("--root", type=Path)
     return parser.parse_args()
@@ -143,6 +154,9 @@ def parse_args() -> argparse.Namespace:
 
 def main() -> int:
     args = parse_args()
+    if bool(args.repository) != bool(args.pr_number):
+        print("FAIL: --repository and --pr-number must be supplied together", file=sys.stderr)
+        return 2
     root = (args.root or Path(run_git(Path.cwd(), "rev-parse", "--show-toplevel"))).resolve()
     started = time.monotonic()
     try:
@@ -158,8 +172,22 @@ def main() -> int:
     if args.list:
         return 0
 
-    metadata = resolve_pr_metadata(root, args.pr_body_file)
+    try:
+        metadata = resolve_pr_metadata(root, args.pr_body_file, args.repository, args.pr_number)
+    except RuntimeError as exc:
+        print(f"FAIL: {exc}", file=sys.stderr)
+        return 1
     labels = metadata.labels if metadata else ()
+    head_branch = args.head_branch or os.getenv("GITHUB_HEAD_REF", "")
+    if not head_branch:
+        head_branch = subprocess.run(
+            ["git", "symbolic-ref", "--short", "-q", "HEAD"],
+            cwd=root,
+            check=False,
+            stdout=subprocess.PIPE,
+            text=True,
+        ).stdout.strip()
+    skip_changelog = "no-changelog-needed" in labels or head_branch.startswith("changelog/v")
     if metadata:
         print(f"PR metadata: {metadata.source}, updated_at={metadata.updated_at}")
 
@@ -176,7 +204,7 @@ def main() -> int:
             if check.name == "diff-hygiene":
                 returncode = check_diff_hygiene(root, args.base, args.head, files)
             else:
-                command = command_for_check(check, files_path, args.base, args.head, body_path, labels)
+                command = command_for_check(check, files_path, args.base, args.head, body_path, skip_changelog)
                 returncode = subprocess.run(command, cwd=root, check=False).returncode
             elapsed = time.monotonic() - phase_started
             status = "PASS" if returncode == 0 else "FAIL"

--- a/.github/scripts/preflight_runner.py
+++ b/.github/scripts/preflight_runner.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env python3
+"""Run a command single-flight with observable per-worktree state and logs."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import shutil
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+POLL_SECONDS = 0.2
+STATUS_INTERVAL_SECONDS = 5.0
+
+
+def atomic_json(path: Path, value: dict) -> None:
+    temporary = path.with_suffix(path.suffix + f".{os.getpid()}.tmp")
+    temporary.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    os.replace(temporary, path)
+
+
+def read_json(path: Path) -> dict:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+        return value if isinstance(value, dict) else {}
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return {}
+
+
+def process_exists(pid: int) -> bool:
+    if pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+        return True
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+
+
+def default_state_dir(root: Path, name: str) -> Path:
+    override = os.getenv("OMI_PREFLIGHT_STATE_DIR")
+    if override:
+        return Path(override).resolve() / name
+    git_dir = subprocess.check_output(["git", "rev-parse", "--absolute-git-dir"], cwd=root, text=True).strip()
+    return Path(git_dir) / "omi-preflight" / name
+
+
+def fingerprint(root: Path, command: list[str], stdin_data: str) -> str:
+    head = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=root,
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        text=True,
+    ).stdout.strip()
+    digest = hashlib.sha256()
+    for value in (str(root.resolve()), head, "\0".join(command), stdin_data):
+        digest.update(value.encode("utf-8"))
+        digest.update(b"\0")
+    return digest.hexdigest()
+
+
+def acquire(lock_dir: Path, owner: dict) -> bool:
+    try:
+        lock_dir.mkdir()
+    except FileExistsError:
+        return False
+    atomic_json(lock_dir / "owner.json", owner)
+    return True
+
+
+def remove_stale_lock(lock_dir: Path, expected_pid: int) -> bool:
+    owner = read_json(lock_dir / "owner.json")
+    if int(owner.get("pid") or 0) != expected_pid:
+        return False
+    if process_exists(expected_pid):
+        return False
+    try:
+        shutil.rmtree(lock_dir)
+        return True
+    except FileNotFoundError:
+        return True
+
+
+def join_existing(state_dir: Path, wanted_fingerprint: str) -> int | None:
+    lock_dir = state_dir / "lock"
+    owner = read_json(lock_dir / "owner.json")
+    if not owner:
+        try:
+            lock_age = time.time() - lock_dir.stat().st_mtime
+        except FileNotFoundError:
+            return None
+        if lock_age > 2:
+            shutil.rmtree(lock_dir, ignore_errors=True)
+        else:
+            time.sleep(POLL_SECONDS)
+        return None
+    active_pid = int(owner.get("pid") or 0)
+    active_fingerprint = str(owner.get("fingerprint") or "")
+    if not process_exists(active_pid):
+        if remove_stale_lock(lock_dir, active_pid):
+            return None
+    log_path = state_dir / "preflight.log"
+    status_path = state_dir / "status.json"
+    if active_fingerprint != wanted_fingerprint:
+        status = read_json(status_path)
+        phase = status.get("phase", "starting")
+        print(
+            f"FAIL: preflight PID {active_pid} is already running different input "
+            f"(phase={phase}, log={log_path}). Retry after it finishes.",
+            file=sys.stderr,
+        )
+        return 75
+
+    print(f"Joining identical preflight PID {active_pid}; live log: {log_path}")
+    next_status = 0.0
+    while lock_dir.exists():
+        if not process_exists(active_pid):
+            remove_stale_lock(lock_dir, active_pid)
+            break
+        now = time.monotonic()
+        if now >= next_status:
+            status = read_json(status_path)
+            elapsed = max(0.0, time.time() - float(status.get("started_at_epoch") or time.time()))
+            print(
+                f"  active phase={status.get('phase', 'starting')} elapsed={elapsed:.1f}s",
+                flush=True,
+            )
+            next_status = now + STATUS_INTERVAL_SECONDS
+        time.sleep(POLL_SECONDS)
+    result = read_json(state_dir / "result.json")
+    if result.get("fingerprint") != wanted_fingerprint:
+        print("FAIL: joined preflight ended without a matching result; retry the push.", file=sys.stderr)
+        return 1
+    return int(result.get("exit_code", 1))
+
+
+def run_owned(
+    state_dir: Path,
+    lock_dir: Path,
+    wanted_fingerprint: str,
+    command: list[str],
+    stdin_data: str,
+    root: Path,
+) -> int:
+    log_path = state_dir / "preflight.log"
+    status_path = state_dir / "status.json"
+    result_path = state_dir / "result.json"
+    started = time.monotonic()
+    started_wall = time.time()
+    phase = "starting"
+    child: subprocess.Popen[str] | None = None
+
+    def write_status() -> None:
+        atomic_json(
+            status_path,
+            {
+                "pid": os.getpid(),
+                "fingerprint": wanted_fingerprint,
+                "phase": phase,
+                "elapsed_seconds": round(time.monotonic() - started, 1),
+                "log": str(log_path),
+                "started_at_epoch": started_wall,
+            },
+        )
+
+    def forward_signal(signum: int, _frame: object) -> None:
+        if child is not None and child.poll() is None:
+            try:
+                os.killpg(child.pid, signum)
+            except ProcessLookupError:
+                pass
+
+    previous_handlers = {
+        signum: signal.signal(signum, forward_signal) for signum in (signal.SIGINT, signal.SIGTERM, signal.SIGHUP)
+    }
+    exit_code = 1
+    try:
+        print(f"Pre-push single-flight log: {log_path}")
+        log_path.write_text("", encoding="utf-8")
+        os.chmod(log_path, 0o600)
+        write_status()
+        child = subprocess.Popen(
+            command,
+            cwd=root,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            bufsize=1,
+            start_new_session=True,
+        )
+        if child.stdin:
+            child.stdin.write(stdin_data)
+            child.stdin.close()
+        assert child.stdout is not None
+        with log_path.open("a", encoding="utf-8") as log:
+            for line in child.stdout:
+                sys.stdout.write(line)
+                sys.stdout.flush()
+                log.write(line)
+                log.flush()
+                if line.startswith("==> "):
+                    phase = line[4:].strip()
+                    write_status()
+        exit_code = child.wait()
+        phase = "passed" if exit_code == 0 else "failed"
+        write_status()
+        atomic_json(
+            result_path,
+            {
+                "exit_code": exit_code,
+                "fingerprint": wanted_fingerprint,
+                "elapsed_seconds": round(time.monotonic() - started, 1),
+                "finished_at_epoch": time.time(),
+                "log": str(log_path),
+            },
+        )
+        return exit_code
+    finally:
+        for signum, handler in previous_handlers.items():
+            signal.signal(signum, handler)
+        shutil.rmtree(lock_dir, ignore_errors=True)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--name", default="pre-push")
+    parser.add_argument("command", nargs=argparse.REMAINDER)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    command = list(args.command)
+    if command and command[0] == "--":
+        command = command[1:]
+    if not command:
+        print("FAIL: preflight runner requires a command after --", file=sys.stderr)
+        return 2
+    root = Path(subprocess.check_output(["git", "rev-parse", "--show-toplevel"], text=True).strip()).resolve()
+    # Git supplies ref updates on a pipe. Manual preflight runs inherit a TTY;
+    # treating that as empty input avoids waiting forever for an interactive EOF.
+    stdin_data = "" if sys.stdin.isatty() else sys.stdin.read()
+    wanted_fingerprint = fingerprint(root, command, stdin_data)
+    state_dir = default_state_dir(root, args.name)
+    state_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+    os.chmod(state_dir, 0o700)
+    lock_dir = state_dir / "lock"
+    owner = {"pid": os.getpid(), "fingerprint": wanted_fingerprint, "started_at_epoch": time.time()}
+
+    while not acquire(lock_dir, owner):
+        joined = join_existing(state_dir, wanted_fingerprint)
+        if joined is not None:
+            return joined
+    return run_owned(state_dir, lock_dir, wanted_fingerprint, command, stdin_data, root)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/run-pre-push.sh
+++ b/.github/scripts/run-pre-push.sh
@@ -10,4 +10,4 @@ set -euo pipefail
 cd "$(dirname "$0")/../.."
 
 REMOTE="${1:-origin}"
-exec scripts/pre-push "$REMOTE"
+exec scripts/pre-push-singleflight "$REMOTE"

--- a/.github/scripts/test_pr_preflight.py
+++ b/.github/scripts/test_pr_preflight.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+"""Regression tests for PR metadata, check selection, and single-flight execution."""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+from pr_metadata import load_from_api
+from pr_preflight import select_checks
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+RUNNER = SCRIPT_DIR / "preflight_runner.py"
+REPO_ROOT = SCRIPT_DIR.parents[1]
+
+
+class FakeResponse(io.BytesIO):
+    def __enter__(self) -> "FakeResponse":
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        self.close()
+
+
+class MetadataTests(unittest.TestCase):
+    def test_api_loader_uses_current_body_and_records_provenance(self) -> None:
+        captured = {}
+
+        def opener(request: object, timeout: int) -> FakeResponse:
+            captured["url"] = request.full_url  # type: ignore[attr-defined]
+            captured["authorization"] = request.headers["Authorization"]  # type: ignore[attr-defined]
+            captured["timeout"] = timeout
+            return FakeResponse(
+                json.dumps(
+                    {
+                        "number": 9402,
+                        "body": "INV-AUTH-1\nINV-CHAT-1\nINV-AGENT-*",
+                        "updated_at": "2026-07-10T21:17:00Z",
+                        "labels": [{"name": "no-changelog-needed"}],
+                    }
+                ).encode()
+            )
+
+        metadata = load_from_api("BasedHardware/omi", 9402, "test-token", opener=opener)
+        self.assertEqual(metadata.number, 9402)
+        self.assertIn("INV-CHAT-1", metadata.body)
+        self.assertEqual(metadata.updated_at, "2026-07-10T21:17:00Z")
+        self.assertEqual(metadata.labels, ("no-changelog-needed",))
+        self.assertEqual(captured["url"], "https://api.github.com/repos/BasedHardware/omi/pulls/9402")
+        self.assertEqual(captured["authorization"], "Bearer test-token")
+        self.assertEqual(captured["timeout"], 15)
+
+
+class SelectionTests(unittest.TestCase):
+    def test_9402_equivalent_diff_selects_invariants_changelog_and_e2e(self) -> None:
+        checks = select_checks(
+            [
+                "desktop/macos/Desktop/Sources/Providers/ChatProvider.swift",
+                "desktop/macos/agent/src/runtime/control-tools.ts",
+            ]
+        )
+        names = {check.name for check in checks}
+        self.assertIn("product-invariants", names)
+        self.assertIn("desktop-changelog-entry", names)
+        self.assertIn("desktop-e2e-flow-coverage", names)
+
+    def test_docs_diff_keeps_contract_small(self) -> None:
+        names = {check.name for check in select_checks(["docs/doc/developer/Contribution.mdx"])}
+        self.assertEqual(
+            names,
+            {"diff-hygiene", "architecture-guardrails", "product-invariants", "desktop-changelog-data"},
+        )
+
+    def test_9402_equivalent_fixture_fails_missing_invariants_and_flow_coverage(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            temp = Path(tmp)
+            changed = temp / "changed.txt"
+            body = temp / "body.md"
+            changed.write_text(
+                "desktop/macos/Desktop/Sources/Providers/ChatProvider.swift\n"
+                "desktop/macos/Desktop/Sources/Providers/UncoveredRoutingSurface.swift\n"
+                "desktop/macos/agent/src/runtime/control-tools.ts\n",
+                encoding="utf-8",
+            )
+            body.write_text("## Product invariants affected\n\nnone\n", encoding="utf-8")
+            invariant = subprocess.run(
+                [
+                    sys.executable,
+                    ".github/scripts/check_product_invariants.py",
+                    "--changed-files",
+                    str(changed),
+                    "--pr-body-file",
+                    str(body),
+                ],
+                cwd=REPO_ROOT,
+                check=False,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+            )
+            coverage = subprocess.run(
+                [
+                    sys.executable,
+                    "desktop/macos/scripts/check-e2e-flow-coverage.py",
+                    "--strict",
+                    "desktop/macos/Desktop/Sources/Providers/UncoveredRoutingSurface.swift",
+                ],
+                cwd=REPO_ROOT,
+                check=False,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+            )
+            self.assertEqual(invariant.returncode, 1, invariant.stdout)
+            self.assertIn("INV-AUTH-1", invariant.stdout)
+            self.assertIn("INV-CHAT-1", invariant.stdout)
+            self.assertIn("INV-AGENT-*", invariant.stdout)
+            self.assertEqual(coverage.returncode, 1, coverage.stdout)
+            self.assertIn("UNCOVERED", coverage.stdout)
+
+
+class SingleFlightTests(unittest.TestCase):
+    def run_runner(
+        self,
+        state_root: Path,
+        command: list[str],
+    ) -> subprocess.Popen[str]:
+        env = {**os.environ, "OMI_PREFLIGHT_STATE_DIR": str(state_root)}
+        return subprocess.Popen(
+            [sys.executable, str(RUNNER), "--name", "test", "--", *command],
+            cwd=REPO_ROOT,
+            env=env,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+
+    def wait_for_lock(self, state_root: Path) -> None:
+        lock = state_root / "test" / "lock" / "owner.json"
+        deadline = time.monotonic() + 5
+        while not lock.exists() and time.monotonic() < deadline:
+            time.sleep(0.02)
+        self.assertTrue(lock.exists(), "runner did not acquire its lock")
+
+    def test_identical_processes_join_and_execute_once(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            temp = Path(tmp)
+            counter = temp / "counter"
+            code = (
+                "from pathlib import Path; import time; "
+                f"p=Path({str(counter)!r}); p.write_text(p.read_text()+'x' if p.exists() else 'x'); "
+                "print('==> focused-tests', flush=True); time.sleep(.5)"
+            )
+            command = [sys.executable, "-c", code]
+            first = self.run_runner(temp, command)
+            assert first.stdin is not None
+            first.stdin.write("same\n")
+            first.stdin.close()
+            self.wait_for_lock(temp)
+            second = self.run_runner(temp, command)
+            assert second.stdin is not None
+            second.stdin.write("same\n")
+            second.stdin.close()
+            first_output = first.stdout.read() if first.stdout else ""
+            second_output = second.stdout.read() if second.stdout else ""
+            self.assertEqual(first.wait(), 0, first_output)
+            self.assertEqual(second.wait(), 0, second_output)
+            if first.stdout:
+                first.stdout.close()
+            if second.stdout:
+                second.stdout.close()
+            self.assertEqual(counter.read_text(), "x")
+            self.assertIn("Joining identical preflight", second_output)
+            status = json.loads((temp / "test" / "status.json").read_text())
+            self.assertEqual(status["phase"], "passed")
+            self.assertTrue((temp / "test" / "preflight.log").exists())
+
+    def test_different_input_is_rejected_while_active(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            temp = Path(tmp)
+            command = [sys.executable, "-c", "import time; print('==> slow', flush=True); time.sleep(.5)"]
+            first = self.run_runner(temp, command)
+            assert first.stdin is not None
+            first.stdin.write("first\n")
+            first.stdin.close()
+            self.wait_for_lock(temp)
+            second = self.run_runner(temp, command)
+            assert second.stdin is not None
+            second.stdin.write("second\n")
+            second.stdin.close()
+            second_output = second.stdout.read() if second.stdout else ""
+            self.assertEqual(second.wait(), 75, second_output)
+            if second.stdout:
+                second.stdout.close()
+            self.assertIn("already running different input", second_output)
+            if first.stdout:
+                first.stdout.read()
+                first.stdout.close()
+            self.assertEqual(first.wait(), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/repo-checks.yml
+++ b/.github/workflows/repo-checks.yml
@@ -56,6 +56,7 @@ jobs:
           cat /tmp/changed-files.txt
 
       - name: Check merge conflict markers
+        if: github.event_name != 'pull_request'
         run: |
           failed=0
           while IFS= read -r file; do
@@ -70,6 +71,7 @@ jobs:
           fi
 
       - name: Architecture guardrail warnings
+        if: github.event_name != 'pull_request'
         run: python3 .github/scripts/check_arch_guardrails.py --changed-files /tmp/changed-files.txt
 
       - name: Test product invariant PR-body checker
@@ -78,21 +80,18 @@ jobs:
       - name: Test PR preflight contracts
         run: python3 .github/scripts/test_pr_preflight.py
 
-      - name: Test brand UI ratchet helper
-        run: python3 .github/scripts/test_check_brand_ui.py
-
-      - name: Check product invariant citations
+      - name: Run shared PR contract preflight
         if: github.event_name == 'pull_request'
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
-          python3 .github/scripts/pr_metadata.py \
+          scripts/pr-preflight \
+            --base "${{ needs.changes.outputs.diff_base }}" \
             --repository "${{ github.repository }}" \
-            --pr-number "${{ github.event.pull_request.number }}" \
-            --output /tmp/pr-body.txt
-          python3 .github/scripts/check_product_invariants.py \
-            --changed-files /tmp/changed-files.txt \
-            --pr-body-file /tmp/pr-body.txt
+            --pr-number "${{ github.event.pull_request.number }}"
+
+      - name: Test brand UI ratchet helper
+        run: python3 .github/scripts/test_check_brand_ui.py
 
       - name: Check brand UI purple ratchet (INV-UI-1)
         if: github.event_name == 'pull_request'
@@ -102,20 +101,8 @@ jobs:
             --base "${{ needs.changes.outputs.diff_base }}"
 
       - name: Check desktop changelog data
+        if: github.event_name != 'pull_request'
         run: python3 .github/scripts/desktop-changelog.py validate
-
-      - name: Check desktop changelog entry
-        if: github.event_name == 'pull_request' && !startsWith(github.head_ref, 'changelog/v')
-        run: |
-          SKIP_FLAG=""
-          if [ "${{ contains(github.event.pull_request.labels.*.name, 'no-changelog-needed') }}" = "true" ]; then
-            SKIP_FLAG="--skip"
-          fi
-
-          python3 .github/scripts/check-desktop-changelog.py \
-            --base "origin/${{ github.base_ref }}" \
-            --head HEAD \
-            $SKIP_FLAG
 
       - name: Check desktop prod promotion policy
         run: python3 .github/scripts/check-desktop-prod-promotion-policy.py

--- a/.github/workflows/repo-checks.yml
+++ b/.github/workflows/repo-checks.yml
@@ -5,6 +5,11 @@ on:
     branches: main
   pull_request:
     branches: main
+    types: [opened, synchronize, reopened, edited, labeled, unlabeled]
+
+permissions:
+  contents: read
+  pull-requests: read
 
 concurrency:
   group: repo-checks-${{ github.event.pull_request.number || github.ref }}
@@ -70,15 +75,21 @@ jobs:
       - name: Test product invariant PR-body checker
         run: python3 .github/scripts/test_check_product_invariants.py
 
+      - name: Test PR preflight contracts
+        run: python3 .github/scripts/test_pr_preflight.py
+
       - name: Test brand UI ratchet helper
         run: python3 .github/scripts/test_check_brand_ui.py
 
       - name: Check product invariant citations
         if: github.event_name == 'pull_request'
         env:
-          PR_BODY: ${{ github.event.pull_request.body }}
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
-          printf '%s' "$PR_BODY" > /tmp/pr-body.txt
+          python3 .github/scripts/pr_metadata.py \
+            --repository "${{ github.repository }}" \
+            --pr-number "${{ github.event.pull_request.number }}" \
+            --output /tmp/pr-body.txt
           python3 .github/scripts/check_product_invariants.py \
             --changed-files /tmp/changed-files.txt \
             --pr-body-file /tmp/pr-body.txt

--- a/docs/doc/developer/Contribution.mdx
+++ b/docs/doc/developer/Contribution.mdx
@@ -26,7 +26,8 @@ Maintainers declining a PR for direction or taste will cite an invariant ID or o
     Clone your fork, create a branch, and implement your changes.
   </Step>
   <Step title="Test Your Changes">
-    Add focused tests and include the commands or manual steps you used to verify the change.
+    Add focused tests and include the commands or manual steps you used to verify the change. Before pushing, run
+    `scripts/pr-preflight --pr-body-file /path/to/draft-pr-body.md` to catch PR contract issues locally.
   </Step>
   <Step title="Create a Pull Request">
     Submit a PR and specify which issue it relates to. Name any product invariants your change affects.
@@ -45,6 +46,8 @@ Good PRs are easy to review and come with evidence that the change works.
 - **Show your verification.** List the commands you ran and what they showed in the PR description. "It compiles" is not evidence — exercising the real user-facing path is.
 - **Tests that run in CI must be hermetic** — no live services, no network. Validation against a live service is welcome as extra evidence, but it can never be the only proof a PR works.
 - **Product invariants** — if you touch paths listed on a locked invariant, name the ID (for example `INV-CHAT-1`) in the PR body.
+- **Fast local PR contract check** — run `scripts/pr-preflight --pr-body-file /path/to/draft-pr-body.md`. Once the
+  branch has a PR, `scripts/pr-preflight` reads its current body automatically with `gh`.
 
 ### Contributing with an AI agent
 

--- a/scripts/install-git-hooks.sh
+++ b/scripts/install-git-hooks.sh
@@ -20,12 +20,15 @@ set -euo pipefail
 
 ROOT="$(git rev-parse --show-toplevel)"
 HOOK_NAME="$(basename "$0")"
+if [ "$HOOK_NAME" = "pre-push" ]; then
+  exec "$ROOT/scripts/pre-push-singleflight" "$@"
+fi
 exec "$ROOT/scripts/$HOOK_NAME" "$@"
 HOOK
   chmod +x "$hook_path"
 }
 
-chmod +x "$ROOT/scripts/pre-commit" "$ROOT/scripts/pre-push"
+chmod +x "$ROOT/scripts/pre-commit" "$ROOT/scripts/pre-push" "$ROOT/scripts/pre-push-singleflight" "$ROOT/scripts/pr-preflight"
 install_dispatch_hook pre-commit
 install_dispatch_hook pre-push
 

--- a/scripts/pr-preflight
+++ b/scripts/pr-preflight
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+cd "$ROOT"
+exec python3 .github/scripts/pr_preflight.py "$@"

--- a/scripts/pre-push
+++ b/scripts/pre-push
@@ -97,8 +97,13 @@ if [[ ! -x "$BACKEND_PYTHON" ]]; then
 fi
 
 run_step() {
+  local started
+  local elapsed
+  started=$SECONDS
   echo "==> $*"
   "$@"
+  elapsed=$((SECONDS - started))
+  echo "<== PASS $* (${elapsed}s)"
 }
 
 changed_matches() {

--- a/scripts/pre-push-singleflight
+++ b/scripts/pre-push-singleflight
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+cd "$ROOT"
+exec python3 .github/scripts/preflight_runner.py --name pre-push -- scripts/pre-push "$@"


### PR DESCRIPTION
## What changed and why

Closes #9408.

Adds one fast PR-contract engine shared by local development and GitHub Hygiene. It selects checks from the exact base/head diff, validates current PR metadata, and reports per-phase timings and remediation. Hygiene now fetches the current PR body through the GitHub API, including on body edits and reruns.

Pre-push execution is now single-flight per worktree and exact input fingerprint. Identical concurrent pushes join one run; different input fails with the active PID, phase, and stable log path. Hook-owned child process groups and locks are cleaned up without touching unrelated Git or app processes.

The fast contract path remains separate from expensive builds and tests. On this 11-file PR it completed in 0.43 seconds.

## Product invariants affected

none

## How it was verified

- `python3 .github/scripts/test_pr_preflight.py` — 6 tests passed, including a PR #9402-equivalent missing-invariant/missing-flow fixture and two-process single-flight coverage.
- `python3 .github/scripts/test_check_product_invariants.py` — 14 tests passed.
- `python3 .github/scripts/test_check_brand_ui.py` — 6 tests passed.
- `actionlint -shellcheck '' .github/workflows/repo-checks.yml` — passed.
- `scripts/pr-preflight --pr-body-file .github/PULL_REQUEST_TEMPLATE.md` — 4 selected contract checks passed in 0.43 seconds after the final rebase.
- Live GitHub API check against PR #9402 — loaded the current body and `updated_at`, then passed the selected contract checks in 0.99 seconds.
- `.github/scripts/run-pre-push.sh` and the real `git push` hook — passed workflow contracts, OpenAPI generation, backend type checking, Swift debug build, Rust `cargo check`, ratchets, and formatting checks. Stable phase/status/log artifacts were inspected during the run.

## Tests

Regression coverage lives in `.github/scripts/test_pr_preflight.py`. It covers current-body parsing/provenance, deterministic check selection, the original #9402 failure modes, identical-run joining, different-input rejection, result propagation, and observable state/log files.

## Scoped cleanups (optional)

None.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9410?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

