### PR TITLE
fix(desktop): enforce managed/local agent boundaries

### DIFF
--- a/desktop/macos/agent/src/adapters/interface.ts
+++ b/desktop/macos/agent/src/adapters/interface.ts
@@ -25,6 +25,7 @@ export interface SessionOpts {
   model?: string;
   systemPrompt?: string;
   mcpServers?: Record<string, unknown>[];
+  executionRole?: "coordinator" | "leaf";
 }
 
 /**
@@ -163,8 +164,11 @@ export interface AdapterCapabilityExpectation {
 export interface AdapterCapabilityMatrixEntry {
   readonly adapterId: string;
   readonly productionAdapter: boolean;
+  readonly credentialScope: AdapterCredentialScope;
   readonly expectations: Record<AdapterCapabilityKey, AdapterCapabilityExpectation>;
 }
+
+export type AdapterCredentialScope = "managed_cloud" | "local_user";
 
 const required = (reason: string): AdapterCapabilityExpectation => ({ status: "required", reason });
 const unsupported = (reason: string): AdapterCapabilityExpectation => ({ status: "unsupported", reason });
@@ -195,6 +199,7 @@ export const ADAPTER_CAPABILITY_MATRIX = {
   acp: {
     adapterId: "acp",
     productionAdapter: true,
+    credentialScope: "local_user",
     // Production ACP: native session ids survive adapter process restarts.
     expectations: {
       nativeResume: required("ACP exposes native session ids and session/resume."),
@@ -210,6 +215,7 @@ export const ADAPTER_CAPABILITY_MATRIX = {
   "pi-mono": {
     adapterId: "pi-mono",
     productionAdapter: true,
+    credentialScope: "managed_cloud",
     // Production pi-mono: native ids are process-local and require worker pinning.
     expectations: {
       nativeResume: unsupported("pi-mono session ids are process-local and are stale after daemon restart."),
@@ -225,6 +231,7 @@ export const ADAPTER_CAPABILITY_MATRIX = {
   hermes: {
     adapterId: "hermes",
     productionAdapter: true,
+    credentialScope: "local_user",
     expectations: {
       // Hermes ACP sessions are tracked by the running server's in-memory
       // session manager and are only valid for that process. After a restart
@@ -243,6 +250,7 @@ export const ADAPTER_CAPABILITY_MATRIX = {
   openclaw: {
     adapterId: "openclaw",
     productionAdapter: true,
+    credentialScope: "local_user",
     expectations: {
       nativeResume: required("OpenClaw ACP exposes native sessions through the Gateway-backed ACP bridge."),
       cancellationDispatch: required("OpenClaw ACP accepts cancellation through the shared ACP interrupt path."),
@@ -257,6 +265,7 @@ export const ADAPTER_CAPABILITY_MATRIX = {
   a2a: {
     adapterId: "a2a",
     productionAdapter: false,
+    credentialScope: "managed_cloud",
     expectations: placeholderExpectations("A2A", "TICKET-a2a-adapter"),
   },
 } as const satisfies Record<string, AdapterCapabilityMatrixEntry>;
@@ -299,6 +308,10 @@ export function adapterCapabilitiesFor(adapterId: ProductionAdapterId): AdapterC
     supportsTools: expectations.toolSupport.status === "required",
     restartBehavior: restartBehaviorFor(expectations),
   };
+}
+
+export function adapterCredentialScopeFor(adapterId: ProductionAdapterId): AdapterCredentialScope {
+  return ADAPTER_CAPABILITY_MATRIX[adapterId].credentialScope;
 }
 
 export interface OpenBindingInput {

--- a/desktop/macos/agent/src/adapters/pi-mono.ts
+++ b/desktop/macos/agent/src/adapters/pi-mono.ts
@@ -135,6 +135,16 @@ function requiredAgentControlFailure(toolName: string, output: string): string |
   return undefined;
 }
 
+function requiredControlOperationKey(toolName: string, input: Record<string, unknown> | undefined): string {
+  const ignored = new Set(["adapterId", "provider", "defaultAdapterId", "requestId", "clientId"]);
+  const normalized = Object.fromEntries(
+    Object.entries(input ?? {})
+      .filter(([key]) => !ignored.has(key))
+      .sort(([left], [right]) => left.localeCompare(right)),
+  );
+  return `${toolName}:${JSON.stringify(normalized)}`;
+}
+
 /**
  * PiMonoAdapter spawns pi-mono in RPC mode and translates its events
  * into the normalized bridge protocol.
@@ -232,8 +242,9 @@ export class PiMonoAdapter implements HarnessAdapter {
   private nextRequestId = 1;
   private eventHandler: EventCallback | null = null;
   private toolExecutor: ToolExecutor | null = null;
-  /** A failed required agent-control operation must not become a green parent completion. */
-  private requiredAgentControlFailure: string | undefined;
+  /** Unresolved required control obligations for the active turn. */
+  private requiredAgentControlFailures = new Map<string, string>();
+  private requiredControlInputs = new Map<string, Record<string, unknown>>();
   private currentAbortController: AbortController | null = null;
   private piPath: string;
   private extensionPath: string;
@@ -244,6 +255,7 @@ export class PiMonoAdapter implements HarnessAdapter {
   /** Current system prompt baked into the spawned pi process via --system-prompt.
    *  Pi has no set_system_prompt RPC, so changing this requires a subprocess restart. */
   private currentSystemPrompt: string | undefined;
+  private currentExecutionRole: "coordinator" | "leaf" = "coordinator";
   private readonly sessionPrefix: string;
   /** True when a token refresh was deferred because a prompt was active */
   private pendingTokenRefresh = false;
@@ -324,6 +336,7 @@ export class PiMonoAdapter implements HarnessAdapter {
       env.OMI_API_BASE_URL = this.config.omiApiBaseUrl;
     }
     env.OMI_ADAPTER_ID = "pi-mono";
+    env.OMI_EXECUTION_ROLE = this.currentExecutionRole;
     env.OMI_CONTEXT_FILE = this.contextFilePath;
     // Forward OMI_BRIDGE_PIPE so the extension can register omi-tools
     // (execute_sql, semantic_search, etc.) that forward to Swift.
@@ -396,6 +409,7 @@ export class PiMonoAdapter implements HarnessAdapter {
 
   async createSession(opts: SessionOpts): Promise<string> {
     const mapped = opts.model ? mapModel(opts.model) : undefined;
+    await this.setExecutionRole(opts.executionRole ?? "coordinator");
 
     // Pi bakes the system prompt at spawn time via --system-prompt. If the
     // caller requested a different prompt than the currently-running process,
@@ -427,6 +441,14 @@ export class PiMonoAdapter implements HarnessAdapter {
     return sessionId;
   }
 
+  async setExecutionRole(role: "coordinator" | "leaf"): Promise<void> {
+    if (role === this.currentExecutionRole) return;
+    this.currentExecutionRole = role;
+    if (this.process) {
+      await this.stop();
+    }
+  }
+
   async sendPrompt(
     sessionId: string,
     prompt: PromptBlock[],
@@ -449,7 +471,8 @@ export class PiMonoAdapter implements HarnessAdapter {
 
     this.eventHandler = onEvent;
     this.toolExecutor = onToolCall;
-    this.requiredAgentControlFailure = undefined;
+    this.requiredAgentControlFailures.clear();
+    this.requiredControlInputs.clear();
     this.currentAbortController = new AbortController();
     this.writeRelayContext(relayContext);
 
@@ -827,6 +850,9 @@ export class PiMonoAdapter implements HarnessAdapter {
   private handleToolStart(event: PiRpcEvent): void {
     const name = event.toolName as string;
     const toolCallId = event.toolCallId as string;
+    if (REQUIRED_AGENT_CONTROL_TOOLS.has(name)) {
+      this.requiredControlInputs.set(toolCallId, (event.args as Record<string, unknown> | undefined) ?? {});
+    }
     this.eventHandler?.({
       type: "tool_activity",
       name,
@@ -848,15 +874,17 @@ export class PiMonoAdapter implements HarnessAdapter {
       .join("") || "";
 
     if (REQUIRED_AGENT_CONTROL_TOOLS.has(name)) {
+      const operationKey = requiredControlOperationKey(name, this.requiredControlInputs.get(toolCallId));
+      this.requiredControlInputs.delete(toolCallId);
       const failure = requiredAgentControlFailure(name, output);
       if (failure) {
-        this.requiredAgentControlFailure = failure;
+        this.requiredAgentControlFailures.set(operationKey, failure);
       } else {
-        // A successful retry of any required agent-control operation resolves
-        // the pending operation failure for this turn.
+        // Only a successful retry of the same logical operation resolves its
+        // obligation; unrelated control success cannot erase a prior failure.
         try {
           if ((JSON.parse(output) as { ok?: unknown }).ok === true) {
-            this.requiredAgentControlFailure = undefined;
+            this.requiredAgentControlFailures.delete(operationKey);
           }
         } catch {
           // Non-canonical output cannot clear a prior control-operation failure.
@@ -931,8 +959,8 @@ export class PiMonoAdapter implements HarnessAdapter {
       return;
     }
 
-    if (this.requiredAgentControlFailure) {
-      const controlFailure = this.requiredAgentControlFailure;
+    const controlFailure = this.requiredAgentControlFailures.values().next().value as string | undefined;
+    if (controlFailure) {
       this.eventHandler?.({
         type: "error",
         message: controlFailure,
@@ -1004,11 +1032,13 @@ export class PiMonoRuntimeAdapter implements RuntimeAdapter {
       model: input.model,
       systemPrompt: input.systemPrompt,
       mcpServers: input.mcpServers,
+      executionRole: input.metadata?.executionRole === "leaf" ? "leaf" : "coordinator",
     });
     return this.binding(input, adapterNativeSessionId);
   }
 
   async resumeBinding(input: ResumeBindingInput): Promise<OpenedBinding> {
+    await this.harness.setExecutionRole(input.metadata?.executionRole === "leaf" ? "leaf" : "coordinator");
     await this.start();
     // pi-mono has no native resume after daemon/process loss, but while this
     // RuntimeAdapter instance is alive the opaque session id is still usable as

--- a/desktop/macos/agent/src/index.ts
+++ b/desktop/macos/agent/src/index.ts
@@ -85,6 +85,7 @@ import { OmiArtifactStorage, defaultArtifactRoot } from "./runtime/artifact-stor
 import { configuredPiMonoMaxWorkers } from "./runtime/worker-pool.js";
 import { failureFromError } from "./runtime/failures.js";
 import type { ConversationTurnImportEntry } from "./runtime/conversation-turns.js";
+import { providerBoundaryForAdapter } from "./runtime/execution-policy.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -292,10 +293,12 @@ function startOmiToolsRelay(): Promise<string> {
                     requestKey: controlRequestKey({ requestId, clientId }),
                     ownerIdForRequest: (requestKey) => activeControlToolOwnersByRequest.get(requestKey),
                   });
+                  const activeSession = controlSessionPolicy(resolvedCorrelation.sessionId, controlOwnerId);
                   const controlToolContext = agentControlToolContext
                     ? {
                         ...agentControlToolContext,
-                        canSpawnAgents: !isLeafWorkerSession(resolvedCorrelation.sessionId, controlOwnerId),
+                        executionRole: activeSession?.executionRole ?? "coordinator",
+                        providerBoundary: activeSession?.providerBoundary,
                         getOwnerId: () => controlOwnerId,
                       }
                     : undefined;
@@ -639,6 +642,10 @@ function buildMcpServers(
     if (context?.screenContext === true) {
       omiToolsEnv.push({ name: "OMI_SCREEN_CONTEXT", value: "true" });
     }
+    omiToolsEnv.push({
+      name: "OMI_EXECUTION_ROLE",
+      value: context?.executionRole === "leaf" ? "leaf" : "coordinator",
+    });
     servers.push({
       name: "omi-tools",
       command: process.execPath,
@@ -704,14 +711,11 @@ function controlRunAdapterId(name: string, input: Record<string, unknown>, defau
   return adapterId ?? defaultFromInput ?? defaultAdapterId;
 }
 
-function isLeafWorkerSession(sessionId: string | undefined, ownerId: string | undefined): boolean {
-  if (!sessionId || !ownerId || !agentControlToolContext) return false;
-  const session = agentControlToolContext.kernel
+function controlSessionPolicy(sessionId: string | undefined, ownerId: string | undefined) {
+  if (!sessionId || !ownerId || !agentControlToolContext) return undefined;
+  return agentControlToolContext.kernel
     .listSessions({ ownerId, limit: 200 })
     .find((candidate) => candidate.session.sessionId === sessionId)?.session;
-  return session?.surfaceKind === "delegated_agent"
-    || session?.surfaceKind === "background_agent"
-    || (session?.surfaceKind === "floating_bar" && session.externalRefKind === "pill");
 }
 
 function isLongLivedControlRun(name: string, input: Record<string, unknown>): boolean {
@@ -985,6 +989,8 @@ async function main(): Promise<void> {
   agentControlToolContext = {
     kernel,
     defaultAdapterId,
+    providerBoundary: providerBoundaryForAdapter(defaultAdapterId),
+    executionRole: "coordinator",
     getOwnerId: () => currentOwnerId,
     buildMcpServers,
     recoverRunInput,

--- a/desktop/macos/agent/src/index.ts
+++ b/desktop/macos/agent/src/index.ts
@@ -293,21 +293,38 @@ function startOmiToolsRelay(): Promise<string> {
                     requestKey: controlRequestKey({ requestId, clientId }),
                     ownerIdForRequest: (requestKey) => activeControlToolOwnersByRequest.get(requestKey),
                   });
-                  const activeSession = controlSessionPolicy(resolvedCorrelation.sessionId, controlOwnerId);
-                  const controlToolContext = agentControlToolContext
-                    ? {
+                  let result: string;
+                  try {
+                    if (!agentControlToolContext) {
+                      throw new Error("Agent runtime kernel is not ready");
+                    }
+                    const activeSession = requireControlSessionPolicy(
+                      resolvedCorrelation.sessionId,
+                      controlOwnerId,
+                    );
+                    result = await handleAgentControlToolCall(
+                      {
                         ...agentControlToolContext,
-                        executionRole: activeSession?.executionRole ?? "coordinator",
-                        providerBoundary: activeSession?.providerBoundary,
+                        callerSessionId: resolvedCorrelation.sessionId,
+                        executionRole: activeSession.executionRole,
+                        providerBoundary: activeSession.providerBoundary,
+                        defaultAdapterId: activeSession.defaultAdapterId,
                         getOwnerId: () => controlOwnerId,
-                      }
-                    : undefined;
-                  const result = controlToolContext
-                    ? await handleAgentControlToolCall(controlToolContext, msg.name, msg.input ?? {})
-                    : JSON.stringify({
-                        ok: false,
-                        error: { code: "runtime_not_ready", message: "Agent runtime kernel is not ready" },
-                      });
+                      },
+                      msg.name,
+                      msg.input ?? {},
+                    );
+                  } catch (error) {
+                    result = JSON.stringify({
+                      ok: false,
+                      error: {
+                        code: error instanceof Error && error.message === "Agent runtime kernel is not ready"
+                          ? "runtime_not_ready"
+                          : "control_tool_failed",
+                        message: error instanceof Error ? error.message : String(error),
+                      },
+                    });
+                  }
                   try {
                     client.write(
                       JSON.stringify({
@@ -711,11 +728,11 @@ function controlRunAdapterId(name: string, input: Record<string, unknown>, defau
   return adapterId ?? defaultFromInput ?? defaultAdapterId;
 }
 
-function controlSessionPolicy(sessionId: string | undefined, ownerId: string | undefined) {
-  if (!sessionId || !ownerId || !agentControlToolContext) return undefined;
-  return agentControlToolContext.kernel
-    .listSessions({ ownerId, limit: 200 })
-    .find((candidate) => candidate.session.sessionId === sessionId)?.session;
+function requireControlSessionPolicy(sessionId: string | undefined, ownerId: string | undefined) {
+  if (!sessionId || !ownerId || !agentControlToolContext) {
+    throw new Error("missing active control session policy");
+  }
+  return agentControlToolContext.kernel.executionPolicyForOwnedSession(sessionId, ownerId);
 }
 
 function isLongLivedControlRun(name: string, input: Record<string, unknown>): boolean {

--- a/desktop/macos/agent/src/omi-tools-stdio.ts
+++ b/desktop/macos/agent/src/omi-tools-stdio.ts
@@ -169,13 +169,15 @@ async function requestSwiftTool(
 
 const isOnboarding = process.env.OMI_ONBOARDING === "true";
 const hasScreenContext = process.env.OMI_SCREEN_CONTEXT === "true";
+const executionRole = process.env.OMI_EXECUTION_ROLE === "leaf" ? "leaf" : "coordinator";
+const projectionContext = { onboarding: isOnboarding, screenContext: hasScreenContext, executionRole } as const;
 
 // Tool order is owned by the canonical manifest projection.
-const ADVERTISED_TOOLS = toolsForAdapter("omi-tools-stdio", { onboarding: isOnboarding, screenContext: hasScreenContext });
+const ADVERTISED_TOOLS = toolsForAdapter("omi-tools-stdio", projectionContext);
 const ADVERTISED_CANONICAL_TOOL_NAMES = new Set(ADVERTISED_TOOLS.map((tool) => tool.name));
 // Filter tools based on session type: onboarding sessions get onboarding tools,
 // regular sessions exclude them
-const TOOLS = mcpToolDefinitionsForAdapter("omi-tools-stdio", { onboarding: isOnboarding, screenContext: hasScreenContext });
+const TOOLS = mcpToolDefinitionsForAdapter("omi-tools-stdio", projectionContext);
 
 // --- JSON-RPC handling ---
 

--- a/desktop/macos/agent/src/runtime/adapter-registry.ts
+++ b/desktop/macos/agent/src/runtime/adapter-registry.ts
@@ -1,10 +1,12 @@
 import {
   assertAdapterAttemptResultContract,
   assertAdapterBindingContract,
+  isProductionAdapterId,
   isPlaceholderAdapterId,
 } from "../adapters/interface.js";
 import type { RuntimeAdapter } from "../adapters/interface.js";
 import { AdapterWorkerPool, configuredMaxWorkers } from "./worker-pool.js";
+import { assertProductionAdapterScopeDeclared } from "./execution-policy.js";
 
 export type RuntimeAdapterFactory = () => RuntimeAdapter;
 
@@ -20,6 +22,9 @@ export class AdapterRegistry {
       throw new Error(
         `Adapter ${adapterId} is a placeholder and cannot be registered as a production adapter without an implementation factory`
       );
+    }
+    if (isProductionAdapterId(adapterId)) {
+      assertProductionAdapterScopeDeclared(adapterId);
     }
     if (this.pools.has(adapterId)) {
       throw new Error(`Adapter already registered: ${adapterId}`);

--- a/desktop/macos/agent/src/runtime/control-tools.ts
+++ b/desktop/macos/agent/src/runtime/control-tools.ts
@@ -14,6 +14,12 @@ import type {
   WorkstreamContinuationCheckpoint,
   WorkstreamProductContext,
 } from "./workstream-continuity.js";
+import {
+  providerBoundaryForAdapter,
+  resolveAdapterWithinBoundary,
+  type AgentExecutionRole,
+  type ProviderBoundary,
+} from "./execution-policy.js";
 
 const sessionStatusSchema = z.enum(["open", "archived", "closed"]);
 const agentSurfaceKindSchema = z.enum([
@@ -421,7 +427,10 @@ export interface AgentControlToolContext {
    * must inherit this route rather than silently selecting a local provider.
    */
   defaultAdapterId?: string;
-  /** Leaf/background workers may complete assigned work, but cannot fan out more agents. */
+  /** Kernel-owned provider and role policy for the active control caller. */
+  providerBoundary?: ProviderBoundary;
+  executionRole?: AgentExecutionRole;
+  /** @deprecated Compatibility for older direct callers; use executionRole. */
   canSpawnAgents?: boolean;
   trustedUserControl?: boolean;
   getOwnerId?: () => string;
@@ -448,25 +457,19 @@ function defaultControlAdapterId(context: AgentControlToolContext): string {
 }
 
 function assertAdapterAllowedForControlRun(context: AgentControlToolContext, adapterId: string): void {
+  if (!context.defaultAdapterId && !context.providerBoundary) {
+    return;
+  }
   const owningAdapterId = defaultControlAdapterId(context);
-  // A managed desktop surface must never let a control-tool argument switch
-  // execution to any locally credentialed adapter.  Keep this allowlist
-  // explicit: adding a new cloud-managed adapter requires adding it here,
-  // while unknown (and therefore potentially local) adapters fail closed.
-  const managedCloudAdapters = new Set(["pi-mono"]);
-  // ACP is the user's locally authenticated Claude Code process. It remains
-  // available only when the owning desktop surface explicitly selected User
-  // Claude mode; the same rule preserves explicit local Hermes/OpenClaw modes.
-  if (adapterId === "acp" && owningAdapterId !== "acp") {
-    throw new Error("Local Claude is available only when the User Claude mode is selected.");
-  }
-  if (managedCloudAdapters.has(owningAdapterId) && !managedCloudAdapters.has(adapterId)) {
-    throw new Error("Managed Omi agents can only use Omi cloud routing.");
-  }
+  resolveAdapterWithinBoundary({
+    providerBoundary: context.providerBoundary ?? providerBoundaryForAdapter(owningAdapterId),
+    defaultAdapterId: owningAdapterId,
+    requestedAdapterId: adapterId,
+  });
 }
 
 function assertAgentSpawningAllowed(context: AgentControlToolContext): void {
-  if (context.canSpawnAgents === false) {
+  if (context.executionRole === "leaf" || context.canSpawnAgents === false) {
     throw new Error("Background agents are leaf workers and cannot start additional agents.");
   }
 }
@@ -740,7 +743,8 @@ export async function handleAgentControlToolCall(
       }
       case "send_agent_message": {
         const parsed = agentControlToolSchemas.send_agent_message.parse(input);
-        const adapterId = parsed.adapterId ?? context.kernel.defaultAdapterIdForSession(parsed.sessionId);
+        const targetPolicy = context.kernel.executionPolicyForSession(parsed.sessionId);
+        const adapterId = parsed.adapterId ?? targetPolicy.defaultAdapterId;
         assertAdapterAllowedForControlRun(context, adapterId);
         rejectSynchronousNestedRun(context, adapterId, parsed.sessionId);
         const ownerId = effectiveControlToolOwnerId(context, parsed.ownerId);
@@ -759,6 +763,7 @@ export async function handleAgentControlToolCall(
             clientId: parsed.clientId,
             adapterId,
             screenContext: true,
+            executionRole: targetPolicy.executionRole,
           }),
         });
         return stringifyToolResult({
@@ -795,6 +800,7 @@ export async function handleAgentControlToolCall(
             clientId: parsed.clientId,
             adapterId,
             screenContext: true,
+            executionRole: "leaf",
           }),
         });
         return stringifyToolResult({
@@ -814,10 +820,10 @@ export async function handleAgentControlToolCall(
         const adapterId =
           parsed.adapterId ??
           (parsed.provider === "openclaw" ? "openclaw" : parsed.provider === "hermes" ? "hermes" : undefined) ??
-          (parsed.parentRunId ? undefined : defaultControlAdapterId(context));
-        if (adapterId) {
-          assertAdapterAllowedForControlRun(context, adapterId);
-        }
+          (parsed.parentRunId
+            ? context.kernel.defaultAdapterIdForRun(parsed.parentRunId)
+            : defaultControlAdapterId(context));
+        assertAdapterAllowedForControlRun(context, adapterId);
         const visiblePillExternalRefId = parsed.visible
           ? (parsed.externalRefId ?? randomUUID())
           : parsed.externalRefId;
@@ -834,6 +840,7 @@ export async function handleAgentControlToolCall(
           externalRefKind: childExternalRefKind,
           externalRefId: visiblePillExternalRefId,
           screenContext: true,
+          executionRole: "leaf",
         });
         if (parsed.parentRunId) {
           const result = await context.kernel.delegateAgent({
@@ -924,6 +931,7 @@ export async function handleAgentControlToolCall(
             clientId: parsed.clientId,
             adapterId,
             screenContext: true,
+            executionRole: "leaf",
           }),
         });
         return stringifyToolResult({
@@ -1236,6 +1244,7 @@ function buildControlRunMcpServers(
     externalRefKind?: string;
     externalRefId?: string;
     screenContext?: boolean;
+    executionRole?: AgentExecutionRole;
   }
 ): Record<string, unknown>[] | undefined {
   if (!context.buildMcpServers) {
@@ -1252,6 +1261,7 @@ function buildControlRunMcpServers(
     externalRefId: input.externalRefId,
     includeSwiftBackedTools: true,
     screenContext: input.screenContext === true,
+    executionRole: input.executionRole,
   });
   return servers;
 }
@@ -1502,6 +1512,8 @@ function serializeSession(session: AgentSession): Record<string, unknown> {
     title: session.title,
     status: session.status,
     surfaceKind: session.surfaceKind,
+    executionRole: session.executionRole,
+    providerBoundary: session.providerBoundary,
     externalRefKind: session.externalRefKind,
     externalRefId: session.externalRefId,
     defaultAdapterId: session.defaultAdapterId,

--- a/desktop/macos/agent/src/runtime/control-tools.ts
+++ b/desktop/macos/agent/src/runtime/control-tools.ts
@@ -15,6 +15,8 @@ import type {
   WorkstreamProductContext,
 } from "./workstream-continuity.js";
 import {
+  executionRoleAllowsTool,
+  LEAF_AGENT_CONTROL_TOOLS,
   providerBoundaryForAdapter,
   resolveAdapterWithinBoundary,
   type AgentExecutionRole,
@@ -430,6 +432,8 @@ export interface AgentControlToolContext {
   /** Kernel-owned provider and role policy for the active control caller. */
   providerBoundary?: ProviderBoundary;
   executionRole?: AgentExecutionRole;
+  /** Persisted caller session used for kernel-level spawn authority checks. */
+  callerSessionId?: string;
   /** @deprecated Compatibility for older direct callers; use executionRole. */
   canSpawnAgents?: boolean;
   trustedUserControl?: boolean;
@@ -472,6 +476,29 @@ function assertAgentSpawningAllowed(context: AgentControlToolContext): void {
   if (context.executionRole === "leaf" || context.canSpawnAgents === false) {
     throw new Error("Background agents are leaf workers and cannot start additional agents.");
   }
+}
+
+function assertLeafControlToolsAllowed(context: AgentControlToolContext, name: string): void {
+  if (!LEAF_AGENT_CONTROL_TOOLS.has(name)) return;
+  if (!executionRoleAllowsTool(context.executionRole ?? "coordinator", name)) {
+    throw new Error(
+      name === "send_agent_message"
+        ? "Leaf workers cannot continue agent sessions."
+        : "Background agents are leaf workers and cannot start additional agents.",
+    );
+  }
+}
+
+function backgroundSpawnAuthority(
+  context: AgentControlToolContext,
+): { callerSessionId?: string; trustedUserSpawn?: boolean } {
+  if (context.callerSessionId) {
+    return { callerSessionId: context.callerSessionId };
+  }
+  if (context.trustedUserControl === true || context.executionRole !== "leaf") {
+    return { trustedUserSpawn: true };
+  }
+  return {};
 }
 
 export interface ActiveControlToolOwnerInput {
@@ -600,6 +627,7 @@ export async function handleAgentControlToolCall(
   }
 
   try {
+    assertLeafControlToolsAllowed(context, name);
     switch (name) {
       case "list_agent_sessions": {
         const parsed = agentControlToolSchemas.list_agent_sessions.parse(input);
@@ -786,6 +814,7 @@ export async function handleAgentControlToolCall(
         const result = await context.kernel.spawnBackgroundAgent({
           ...parsed,
           ...controlRunRecovery(context, adapterId),
+          ...backgroundSpawnAuthority(context),
           adapterId,
           defaultAdapterId: adapterId,
           ownerId,
@@ -872,6 +901,7 @@ export async function handleAgentControlToolCall(
         }
         const result = await context.kernel.spawnBackgroundAgent({
           ...controlRunRecovery(context, adapterId ?? defaultControlAdapterId(context)),
+          ...backgroundSpawnAuthority(context),
           ownerId,
           clientId: parsed.clientId,
           requestId,

--- a/desktop/macos/agent/src/runtime/execution-policy.ts
+++ b/desktop/macos/agent/src/runtime/execution-policy.ts
@@ -1,0 +1,85 @@
+import {
+  adapterCredentialScopeFor,
+  isProductionAdapterId,
+  type AdapterCredentialScope,
+  type ProductionAdapterId,
+} from "../adapters/interface.js";
+
+export type AgentExecutionRole = "coordinator" | "leaf";
+export type ProviderBoundary = "managed_cloud" | `local_user:${string}`;
+
+export const LEAF_AGENT_CONTROL_TOOLS = new Set([
+  "send_agent_message",
+  "spawn_background_agent",
+  "spawn_agent",
+  "run_agent_and_wait",
+]);
+
+export function providerBoundaryForAdapter(adapterId: string): ProviderBoundary {
+  if (isProductionAdapterId(adapterId) && adapterCredentialScopeFor(adapterId) === "managed_cloud") {
+    return "managed_cloud";
+  }
+  return `local_user:${adapterId}`;
+}
+
+export function credentialScopeForBoundary(boundary: ProviderBoundary): AdapterCredentialScope {
+  return boundary === "managed_cloud" ? "managed_cloud" : "local_user";
+}
+
+export function resolveAdapterWithinBoundary(input: {
+  providerBoundary: ProviderBoundary;
+  defaultAdapterId: string;
+  requestedAdapterId?: string;
+}): string {
+  const requestedAdapterId = input.requestedAdapterId ?? input.defaultAdapterId;
+  if (!isProductionAdapterId(input.defaultAdapterId)) {
+    // Test/development adapters are deliberately outside the production
+    // registry. They may only keep their current adapter identity.
+    if (requestedAdapterId !== input.defaultAdapterId) {
+      throw new Error(`Adapter ${requestedAdapterId} is outside the owning execution boundary.`);
+    }
+    return requestedAdapterId;
+  }
+  if (!isProductionAdapterId(requestedAdapterId)) {
+    throw new Error(`Unknown production adapter: ${requestedAdapterId}`);
+  }
+  if (requestedAdapterId === "acp" && input.providerBoundary !== "local_user:acp") {
+    throw new Error("Local Claude is available only when the User Claude mode is selected.");
+  }
+  if (input.providerBoundary === "managed_cloud") {
+    if (adapterCredentialScopeFor(requestedAdapterId) !== "managed_cloud") {
+      throw new Error("Managed Omi agents can only use Omi cloud routing.");
+    }
+    return requestedAdapterId;
+  }
+  const pinnedAdapterId = input.providerBoundary.slice("local_user:".length);
+  if (requestedAdapterId !== pinnedAdapterId) {
+    if (requestedAdapterId === "acp") {
+      throw new Error("Local Claude is available only when the User Claude mode is selected.");
+    }
+    throw new Error(`Local provider mode is pinned to ${pinnedAdapterId}.`);
+  }
+  return requestedAdapterId;
+}
+
+export function assertProductionAdapterScopeDeclared(adapterId: ProductionAdapterId): void {
+  const scope = adapterCredentialScopeFor(adapterId);
+  if (scope !== "managed_cloud" && scope !== "local_user") {
+    throw new Error(`Production adapter ${adapterId} is missing credentialScope`);
+  }
+}
+
+export function executionRoleAllowsTool(role: AgentExecutionRole, toolName: string): boolean {
+  return role !== "leaf" || !LEAF_AGENT_CONTROL_TOOLS.has(toolName);
+}
+
+export function executionRoleForSurface(input: {
+  surfaceKind: string;
+  externalRefKind?: string | null;
+}): AgentExecutionRole {
+  return input.surfaceKind === "delegated_agent"
+    || input.surfaceKind === "background_agent"
+    || (input.surfaceKind === "floating_bar" && input.externalRefKind === "pill")
+    ? "leaf"
+    : "coordinator";
+}

--- a/desktop/macos/agent/src/runtime/jsonl-transport.ts
+++ b/desktop/macos/agent/src/runtime/jsonl-transport.ts
@@ -19,6 +19,7 @@ import { serializeArtifact } from "./artifact-serialization.js";
 import { failureFromError, type RuntimeFailure } from "./failures.js";
 import type { AgentEvent, RunMode } from "./types.js";
 import { AgentRuntimeKernel, type ExecuteAgentRunInput } from "./kernel.js";
+import { executionRoleForSurface } from "./execution-policy.js";
 
 export type JsonlTransportSend = (message: OutboundMessageDraft) => void;
 export type JsonlTransportLog = (message: string) => void;
@@ -37,6 +38,7 @@ export interface McpServerBuildContext {
   adapterId?: string;
   includeSwiftBackedTools?: boolean;
   screenContext?: boolean;
+  executionRole?: "coordinator" | "leaf";
 }
 
 export type McpServerBuilder = (
@@ -450,11 +452,13 @@ export class JsonlTransport {
     const hint = this.warmupHints.get(warmupKey);
     const cwd = message.cwd ?? hint?.cwd ?? this.defaultCwd();
     const ownerId = message.ownerId ?? this.ownerId;
+    const executionRole = executionRoleForSurface(message);
 
     return {
       ownerId,
       sessionId: message.sessionId,
       surfaceKind: message.surfaceKind,
+      executionRole,
       externalRefKind: message.externalRefKind,
       externalRefId: message.externalRefId,
       defaultAdapterId: requestedAdapterId,
@@ -474,6 +478,7 @@ export class JsonlTransport {
         protocolVersion: PROTOCOL_VERSION,
         sessionId: message.sessionId,
         adapterId: requestedAdapterId,
+        executionRole,
       }),
       maxAttempts: this.maxRecoverableRetries > 0 ? this.maxRecoverableRetries + 1 : undefined,
       recoverAfterError: this.recoverAfterError(requestedAdapterId),

--- a/desktop/macos/agent/src/runtime/kernel-core.ts
+++ b/desktop/macos/agent/src/runtime/kernel-core.ts
@@ -134,6 +134,7 @@ import type {
   AgentRuntimeKernelOptions,
 } from "./kernel-types.js";
 import { StaleAdapterBindingError } from "./kernel-types.js";
+import { providerBoundaryForAdapter, resolveAdapterWithinBoundary } from "./execution-policy.js";
 import type { SurfaceRef } from "./surface-session.js";
 import type { BuiltDesktopContextPacket } from "./desktop-context-packet.js";
 
@@ -174,6 +175,11 @@ export class KernelCore {
   protected createAcceptedRun(input: ExecuteAgentRunInput): { session: AgentSession; run: AgentRun } {
     return this.withTransaction(() => {
       const session = this.resolveSession(input);
+      resolveAdapterWithinBoundary({
+        providerBoundary: session.providerBoundary,
+        defaultAdapterId: session.defaultAdapterId,
+        requestedAdapterId: input.adapterId ?? session.defaultAdapterId,
+      });
       const run = this.store.insertRun({
         sessionId: session.sessionId,
         parentRunId: input.parentRunId ?? null,
@@ -346,6 +352,7 @@ export class KernelCore {
           sessionId: accepted.session.sessionId,
           conversationId,
           surfaceRef,
+          executionRole: accepted.session.executionRole,
           userText: input.prompt,
           attachmentMetadataJson: input.attachmentMetadataJson,
           surfaceContextJson: input.surfaceContextJson,
@@ -742,6 +749,8 @@ export class KernelCore {
             externalRefId: input.externalRefId,
           },
           defaultAdapterId: input.defaultAdapterId,
+          executionRole: input.executionRole,
+          providerBoundary: input.providerBoundary,
           title: input.title ?? null,
         },
         () => Date.now(),
@@ -769,6 +778,9 @@ export class KernelCore {
       externalRefId: input.externalRefId ?? null,
       title: input.title ?? null,
       defaultAdapterId: input.defaultAdapterId ?? "acp",
+      executionRole: input.executionRole ?? "coordinator",
+      providerBoundary:
+        input.providerBoundary ?? providerBoundaryForAdapter(input.defaultAdapterId ?? "acp"),
     });
     this.appendEvent({
       sessionId: session.sessionId,
@@ -960,6 +972,11 @@ export class KernelCore {
         model: input.input.model ?? binding.modelId ?? undefined,
         systemPrompt: input.input.systemPrompt,
         mcpServers: mcpServersForBinding(input.input.mcpServers ?? [], input.session.sessionId, input.adapterId, this.runtimeNodeId),
+        metadata: {
+          ...(input.input.metadata ?? {}),
+          executionRole: input.session.executionRole,
+          providerBoundary: input.session.providerBoundary,
+        },
       });
       this.withTransaction(() => {
         this.updateBinding(binding.bindingId, {
@@ -1012,7 +1029,11 @@ export class KernelCore {
       model: input.input.model,
       systemPrompt: input.input.systemPrompt,
       mcpServers: mcpServersForBinding(input.input.mcpServers ?? [], input.session.sessionId, input.adapterId, this.runtimeNodeId),
-      metadata: input.input.metadata,
+      metadata: {
+        ...(input.input.metadata ?? {}),
+        executionRole: input.session.executionRole,
+        providerBoundary: input.session.providerBoundary,
+      },
     });
     const binding = this.withTransaction(() => {
       this.closeConflictingNativeBinding(

--- a/desktop/macos/agent/src/runtime/kernel-runs.ts
+++ b/desktop/macos/agent/src/runtime/kernel-runs.ts
@@ -165,6 +165,7 @@ export class KernelRuns extends KernelCore {
     const runInput: ExecuteAgentRunInput = {
       ownerId: input.ownerId,
       surfaceKind: input.surfaceKind ?? "floating_bar",
+      executionRole: "leaf",
       externalRefKind: input.externalRefKind,
       externalRefId: input.externalRefId,
       title: input.title ?? `Background: ${input.prompt.slice(0, 80)}`,
@@ -198,6 +199,9 @@ export class KernelRuns extends KernelCore {
     this.assertDelegationConstraints(input);
     const parentRun = this.readRun(input.parentRunId);
     const parentSession = this.readSession(parentRun.sessionId);
+    if (parentSession.executionRole === "leaf") {
+      throw new Error("Leaf workers cannot create delegated agents.");
+    }
     if (input.ownerId && parentSession.ownerId !== input.ownerId) {
       throw new Error(`Parent run ${input.parentRunId} does not belong to owner ${input.ownerId}`);
     }
@@ -207,6 +211,8 @@ export class KernelRuns extends KernelCore {
       ownerId,
       sessionId: input.mode === "continue" ? requiredChildSessionId(input.childSessionId) : input.childSessionId,
       surfaceKind: input.childSurfaceKind ?? "delegated_agent",
+      executionRole: "leaf",
+      providerBoundary: parentSession.providerBoundary,
       externalRefKind: input.childExternalRefKind,
       externalRefId: input.childExternalRefId,
       title: input.childTitle ?? `Delegated: ${input.objective.slice(0, 80)}`,

--- a/desktop/macos/agent/src/runtime/kernel-runs.ts
+++ b/desktop/macos/agent/src/runtime/kernel-runs.ts
@@ -162,6 +162,15 @@ export class KernelRuns extends KernelCore {
   }
 
   async spawnBackgroundAgent(input: SpawnBackgroundAgentInput): Promise<SpawnBackgroundAgentResult> {
+    if (input.callerSessionId) {
+      const callerSession = this.readSession(input.callerSessionId);
+      this.assertSessionOwner(callerSession, input.ownerId);
+      if (callerSession.executionRole === "leaf") {
+        throw new Error("Leaf workers cannot create background agents.");
+      }
+    } else if (!input.trustedUserSpawn) {
+      throw new Error("Background agent spawn requires a coordinator caller session.");
+    }
     const runInput: ExecuteAgentRunInput = {
       ownerId: input.ownerId,
       surfaceKind: input.surfaceKind ?? "floating_bar",

--- a/desktop/macos/agent/src/runtime/kernel-sessions.ts
+++ b/desktop/macos/agent/src/runtime/kernel-sessions.ts
@@ -153,6 +153,19 @@ export class KernelSessions extends KernelArtifacts {
     };
   }
 
+  executionPolicyForOwnedSession(
+    sessionId: string,
+    ownerId: string,
+  ): Pick<AgentSession, "executionRole" | "providerBoundary" | "defaultAdapterId"> {
+    const session = this.readSession(sessionId);
+    this.assertSessionOwner(session, ownerId);
+    return {
+      executionRole: session.executionRole,
+      providerBoundary: session.providerBoundary,
+      defaultAdapterId: session.defaultAdapterId,
+    };
+  }
+
   listSessions(input: ListSessionsInput = {}): KernelSessionSummary[] {
     const where: string[] = [];
     const values: unknown[] = [];

--- a/desktop/macos/agent/src/runtime/kernel-sessions.ts
+++ b/desktop/macos/agent/src/runtime/kernel-sessions.ts
@@ -144,6 +144,15 @@ import { StaleAdapterBindingError } from "./kernel-types.js";
 import { KernelArtifacts } from "./kernel-artifacts.js";
 
 export class KernelSessions extends KernelArtifacts {
+  executionPolicyForSession(sessionId: string): Pick<AgentSession, "executionRole" | "providerBoundary" | "defaultAdapterId"> {
+    const session = this.readSession(sessionId);
+    return {
+      executionRole: session.executionRole,
+      providerBoundary: session.providerBoundary,
+      defaultAdapterId: session.defaultAdapterId,
+    };
+  }
+
   listSessions(input: ListSessionsInput = {}): KernelSessionSummary[] {
     const where: string[] = [];
     const values: unknown[] = [];

--- a/desktop/macos/agent/src/runtime/kernel-support.ts
+++ b/desktop/macos/agent/src/runtime/kernel-support.ts
@@ -396,6 +396,8 @@ export function sessionFromRow(row: Record<string, unknown>): AgentSession {
     title: nullableText(row.title),
     status: text(row.status) as AgentSession["status"],
     surfaceKind: text(row.surface_kind),
+    executionRole: text(row.execution_role) as AgentSession["executionRole"],
+    providerBoundary: text(row.provider_boundary) as AgentSession["providerBoundary"],
     externalRefKind: nullableText(row.external_ref_kind),
     externalRefId: nullableText(row.external_ref_id),
     defaultAdapterId: text(row.default_adapter_id),

--- a/desktop/macos/agent/src/runtime/kernel-types.ts
+++ b/desktop/macos/agent/src/runtime/kernel-types.ts
@@ -262,6 +262,13 @@ export interface SpawnBackgroundAgentInput {
   externalRefId?: string;
   adapterId?: string;
   defaultAdapterId?: string;
+  /** When set, the caller session must be a coordinator owned by ownerId. */
+  callerSessionId?: string;
+  /**
+   * Trusted desktop/user control may spawn without a caller session.
+   * Agent-originated spawns must supply callerSessionId instead.
+   */
+  trustedUserSpawn?: boolean;
   cwd?: string;
   model?: string;
   mcpServers?: Record<string, unknown>[];

--- a/desktop/macos/agent/src/runtime/kernel-types.ts
+++ b/desktop/macos/agent/src/runtime/kernel-types.ts
@@ -12,6 +12,8 @@ import type {
   NewAgentGrant,
   RunAttempt,
   RunMode,
+  AgentExecutionRole,
+  ProviderBoundary,
   RunStatus,
   DelegationMode,
 } from "./types.js";
@@ -37,6 +39,8 @@ export interface KernelSessionResolutionInput {
   sessionId?: string;
   ownerId: string;
   surfaceKind: string;
+  executionRole?: AgentExecutionRole;
+  providerBoundary?: ProviderBoundary;
   externalRefKind?: string;
   externalRefId?: string;
   title?: string;

--- a/desktop/macos/agent/src/runtime/omi-tool-manifest.ts
+++ b/desktop/macos/agent/src/runtime/omi-tool-manifest.ts
@@ -9,6 +9,7 @@ export type OmiToolCondition =
   | "always"
   | "onboardingOnly"
   | "nonOnboarding"
+  | "coordinatorOnly"
   | "screenContext"
   | "screenContextOrOnboarding";
 export type OmiToolExecutorKind = "swiftTool" | "runtimeControl" | "nodeTool" | "localApiOnly";
@@ -97,6 +98,7 @@ interface OmiToolSurfacePatch {
 export interface OmiToolProjectionContext {
   onboarding?: boolean;
   screenContext?: boolean;
+  executionRole?: "coordinator" | "leaf";
 }
 
 export interface OmiToolAvailabilitySnapshot {
@@ -1404,10 +1406,16 @@ const controlVoicePatches: Partial<Record<AgentControlManifestTool["name"], OmiT
 };
 
 function controlEntry(tool: AgentControlManifestTool): OmiToolManifestEntry {
+  const coordinatorOnly = new Set([
+    "send_agent_message",
+    "spawn_background_agent",
+    "spawn_agent",
+    "run_agent_and_wait",
+  ]);
   const adapters =
     tool.name === "resolve_desktop_dispatch" || tool.name === "spawn_background_agent"
       ? trustedDirectControlOnly()
-      : piAndStdio();
+      : piAndStdio(coordinatorOnly.has(tool.name) ? "coordinatorOnly" : "always");
   return {
     name: tool.name,
     label: tool.label,
@@ -1448,6 +1456,7 @@ export function isToolAvailableForContext(
   if (!availability?.advertised) return false;
   if (availability.condition === "onboardingOnly") return context.onboarding === true;
   if (availability.condition === "nonOnboarding") return context.onboarding !== true;
+  if (availability.condition === "coordinatorOnly") return context.executionRole !== "leaf";
   if (availability.condition === "screenContext") return context.screenContext === true;
   if (availability.condition === "screenContextOrOnboarding") return context.screenContext === true || context.onboarding === true;
   return true;

--- a/desktop/macos/agent/src/runtime/sqlite-store.ts
+++ b/desktop/macos/agent/src/runtime/sqlite-store.ts
@@ -39,6 +39,7 @@ import type {
   RunAttempt,
   StartupReconciliationResult,
 } from "./types.js";
+import { providerBoundaryForAdapter } from "./execution-policy.js";
 
 const DATABASE_FILENAME = "omi-agentd.sqlite3";
 const PHASE_1_MIGRATION_VERSION = 1;
@@ -54,6 +55,7 @@ const SURFACE_CONVERSATIONS_MIGRATION_VERSION = 10;
 const CONVERSATION_TURNS_MIGRATION_VERSION = 11;
 const BINDING_TURN_DELIVERY_MIGRATION_VERSION = 12;
 const WORKSTREAM_CONTINUITY_MIGRATION_VERSION = 13;
+const SESSION_EXECUTION_POLICY_MIGRATION_VERSION = 14;
 
 const ACTIVE_ATTEMPT_STATUSES = ["queued", "starting", "running", "waiting_input", "waiting_approval", "cancelling"] as const;
 const TERMINAL_ATTEMPT_STATUSES = ["succeeded", "failed", "cancelled", "timed_out", "orphaned"] as const;
@@ -351,6 +353,7 @@ export function probeNodeSqliteRuntime(options: NodeSqliteProbeOptions = {}): vo
     runConversationTurnsMigration(db, Date.now());
     runBindingTurnDeliveryMigration(db, Date.now());
     runWorkstreamContinuityMigration(db, Date.now());
+    runSessionExecutionPolicyMigration(db, Date.now());
     runTransaction(db, () => {
       db?.prepare("INSERT INTO sessions (session_id, owner_id, status, surface_kind, default_adapter_id, created_at_ms, updated_at_ms, last_activity_at_ms) VALUES (?, ?, ?, ?, ?, ?, ?, ?)").run(
         "ses_probe",
@@ -440,6 +443,9 @@ export class SqliteAgentStore implements AgentStore {
     }
     if (!this.hasMigration(WORKSTREAM_CONTINUITY_MIGRATION_VERSION)) {
       runWorkstreamContinuityMigration(this.db, this.nowMs());
+    }
+    if (!this.hasMigration(SESSION_EXECUTION_POLICY_MIGRATION_VERSION)) {
+      runSessionExecutionPolicyMigration(this.db, this.nowMs());
     }
   }
 
@@ -736,6 +742,8 @@ export class SqliteAgentStore implements AgentStore {
       title: input.title ?? null,
       status: input.status ?? "open",
       surfaceKind: input.surfaceKind,
+      executionRole: input.executionRole ?? "coordinator",
+      providerBoundary: input.providerBoundary ?? providerBoundaryForAdapter(input.defaultAdapterId),
       externalRefKind: input.externalRefKind ?? null,
       externalRefId: input.externalRefId ?? null,
       defaultAdapterId: input.defaultAdapterId,
@@ -748,11 +756,11 @@ export class SqliteAgentStore implements AgentStore {
     };
     this.db.prepare(
       `INSERT INTO sessions (
-        session_id, owner_id, agent_definition_id, title, status, surface_kind,
+        session_id, owner_id, agent_definition_id, title, status, surface_kind, execution_role, provider_boundary,
         external_ref_kind, external_ref_id, legacy_client_scope, legacy_session_key,
         default_adapter_id, default_cwd, model_profile, metadata_json,
         created_at_ms, updated_at_ms, last_activity_at_ms
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     ).run(...sessionValues(session));
     return session;
   }
@@ -1967,6 +1975,33 @@ function runActiveAttemptAuthorityMigration(db: Pick<DatabaseSync, "exec" | "pre
   });
 }
 
+function runSessionExecutionPolicyMigration(db: Pick<DatabaseSync, "exec" | "prepare" | "isTransaction">, appliedAtMs: number): void {
+  runTransaction(db, () => {
+    db.exec(`
+      ALTER TABLE sessions
+        ADD COLUMN execution_role TEXT NOT NULL DEFAULT 'coordinator'
+        CHECK (execution_role IN ('coordinator', 'leaf'));
+      ALTER TABLE sessions
+        ADD COLUMN provider_boundary TEXT NOT NULL DEFAULT 'local_user:acp';
+      UPDATE sessions
+      SET execution_role = CASE
+        WHEN surface_kind IN ('delegated_agent', 'background_agent')
+          OR (surface_kind = 'floating_bar' AND external_ref_kind = 'pill')
+        THEN 'leaf'
+        ELSE 'coordinator'
+      END,
+      provider_boundary = CASE
+        WHEN default_adapter_id = 'pi-mono' THEN 'managed_cloud'
+        ELSE 'local_user:' || default_adapter_id
+      END;
+    `);
+    db.prepare("INSERT INTO schema_migrations (version, applied_at_ms) VALUES (?, ?)").run(
+      SESSION_EXECUTION_POLICY_MIGRATION_VERSION,
+      appliedAtMs,
+    );
+  });
+}
+
 function runTransaction<T>(db: Pick<DatabaseSync, "exec" | "isTransaction">, work: () => T): T {
   if (db.isTransaction) {
     return work();
@@ -2013,6 +2048,8 @@ function sessionValues(session: AgentSession): SQLInputValue[] {
     session.title,
     session.status,
     session.surfaceKind,
+    session.executionRole,
+    session.providerBoundary,
     session.externalRefKind,
     session.externalRefId,
     null,

--- a/desktop/macos/agent/src/runtime/surface-session.ts
+++ b/desktop/macos/agent/src/runtime/surface-session.ts
@@ -1,5 +1,5 @@
 import { generateAgentId } from "./sqlite-store.js";
-import type { AgentStore } from "./types.js";
+import type { AgentExecutionRole, AgentStore, ProviderBoundary } from "./types.js";
 
 export interface SurfaceRef {
   surfaceKind: string;
@@ -11,6 +11,8 @@ export interface ResolveSurfaceSessionInput {
   ownerId: string;
   surfaceRef: SurfaceRef;
   defaultAdapterId?: string;
+  executionRole?: AgentExecutionRole;
+  providerBoundary?: ProviderBoundary;
   title?: string | null;
 }
 
@@ -153,6 +155,8 @@ export function resolveSurfaceSession(
         externalRefId: input.surfaceRef.externalRefId,
         title: input.title ?? null,
         defaultAdapterId: input.defaultAdapterId ?? "acp",
+        executionRole: input.executionRole,
+        providerBoundary: input.providerBoundary,
       });
       return createSurfaceConversationMapping(store, input, session.sessionId, now);
     } catch (error) {

--- a/desktop/macos/agent/src/runtime/turn-context.ts
+++ b/desktop/macos/agent/src/runtime/turn-context.ts
@@ -18,6 +18,7 @@ import type { AgentArtifact, AgentStore, ConversationTurn } from "./types.js";
 import type { SurfaceRef } from "./surface-session.js";
 import { surfaceRefKey as surfaceKeyFor } from "./surface-session.js";
 import type { KernelSessionSummary } from "./kernel.js";
+import type { AgentExecutionRole } from "./execution-policy.js";
 
 const COMPLETION_DELTA_MAX_AGE_MS = 30 * 60 * 1_000;
 
@@ -58,6 +59,7 @@ export interface AssembleTurnContextInput {
   sessionId: string;
   conversationId: string | null;
   surfaceRef: SurfaceRef;
+  executionRole?: AgentExecutionRole;
   userText: string;
   attachmentMetadataJson?: string | null;
   surfaceContextJson?: string | null;
@@ -74,8 +76,11 @@ export function isLeafWorkerSurface(surfaceRef: SurfaceRef): boolean {
     || (surfaceRef.surfaceKind === "floating_bar" && surfaceRef.externalRefKind === "pill");
 }
 
-export function leafWorkerExecutionBoundary(surfaceRef: SurfaceRef): string | null {
-  if (!isLeafWorkerSurface(surfaceRef)) return null;
+export function leafWorkerExecutionBoundary(
+  surfaceRef: SurfaceRef,
+  executionRole: AgentExecutionRole = isLeafWorkerSurface(surfaceRef) ? "leaf" : "coordinator",
+): string | null {
+  if (executionRole !== "leaf") return null;
   return `# Execution Boundary
 
 You are a leaf background worker. Complete the assigned objective yourself and report the result to your parent. Do not call spawn_agent, spawn_background_agent, or run_agent_and_wait; background agents cannot create more agents.`;
@@ -197,7 +202,7 @@ export function assembleTurnContext(input: AssembleTurnContextInput): AssembledT
     }
   }
 
-  const leafWorkerBoundary = leafWorkerExecutionBoundary(input.surfaceRef);
+  const leafWorkerBoundary = leafWorkerExecutionBoundary(input.surfaceRef, input.executionRole);
   if (leafWorkerBoundary) {
     sections.push(leafWorkerBoundary);
   }

--- a/desktop/macos/agent/src/runtime/types.ts
+++ b/desktop/macos/agent/src/runtime/types.ts
@@ -17,6 +17,10 @@ export type AttemptStatus = RunStatus;
 
 export type RunMode = "ask" | "act";
 
+export type AgentExecutionRole = "coordinator" | "leaf";
+
+export type ProviderBoundary = "managed_cloud" | `local_user:${string}`;
+
 export type ResumeFidelity = "native" | "reconstructed" | "none";
 
 export type AdapterBindingStatus = "active" | "stale" | "invalid" | "closed";
@@ -141,6 +145,8 @@ export interface AgentSession {
   title: string | null;
   status: SessionStatus;
   surfaceKind: string;
+  executionRole: AgentExecutionRole;
+  providerBoundary: ProviderBoundary;
   externalRefKind: string | null;
   externalRefId: string | null;
   defaultAdapterId: string;

--- a/desktop/macos/agent/tests/control-tools.test.ts
+++ b/desktop/macos/agent/tests/control-tools.test.ts
@@ -1537,7 +1537,7 @@ describe("agent control tools", () => {
     store.close();
   });
 
-  it("lets invalid adapter ids reach kernel adapter-not-registered handling", async () => {
+  it("fails closed for an unknown adapter before starting a control run", async () => {
     const { store, kernel } = createKernelHarness(newDatabasePath(), "fake", 1);
     const first = await kernel.executeRun(baseRunInput);
 
@@ -1552,14 +1552,12 @@ describe("agent control tools", () => {
     );
 
     expect(failed).toMatchObject({
-      ok: true,
-      terminalStatus: "failed",
-      run: {
-        status: "failed",
-        errorCode: "adapter_not_registered",
+      ok: false,
+      error: {
+        code: "control_tool_failed",
+        message: "Adapter missing-adapter is outside the owning execution boundary.",
       },
     });
-    expect(failed.run.errorMessage).toContain("Adapter not registered: missing-adapter");
     store.close();
   });
 
@@ -1755,11 +1753,16 @@ describe("agent control tools", () => {
       defaultAdapterId: "pi-mono",
     });
 
-    for (const provider of ["hermes", "openclaw"] as const) {
+    for (const provider of ["acp", "hermes", "openclaw", "unknown-adapter"] as const) {
+      const expectedMessage = provider === "acp"
+        ? "Local Claude is available only when the User Claude mode is selected."
+        : provider === "unknown-adapter"
+          ? "Unknown production adapter: unknown-adapter"
+          : "Managed Omi agents can only use Omi cloud routing.";
       const spawned = parseToolResult(
         await handleAgentControlToolCall(context, "spawn_agent", {
           objective: `do not route to ${provider}`,
-          provider,
+          adapterId: provider,
           requestId: `managed-provider-${provider}`,
           clientId: "managed-routing",
           ownerId: "owner",
@@ -1767,7 +1770,7 @@ describe("agent control tools", () => {
       );
       expect(spawned).toMatchObject({
         ok: false,
-        error: { code: "control_tool_failed", message: "Managed Omi agents can only use Omi cloud routing." },
+        error: { code: "control_tool_failed", message: expectedMessage },
       });
 
       const background = parseToolResult(
@@ -1781,7 +1784,7 @@ describe("agent control tools", () => {
       );
       expect(background).toMatchObject({
         ok: false,
-        error: { code: "control_tool_failed", message: "Managed Omi agents can only use Omi cloud routing." },
+        error: { code: "control_tool_failed", message: expectedMessage },
       });
 
       const continued = parseToolResult(
@@ -1796,7 +1799,7 @@ describe("agent control tools", () => {
       );
       expect(continued).toMatchObject({
         ok: false,
-        error: { code: "control_tool_failed", message: "Managed Omi agents can only use Omi cloud routing." },
+        error: { code: "control_tool_failed", message: expectedMessage },
       });
 
       const delegated = parseToolResult(
@@ -1811,7 +1814,7 @@ describe("agent control tools", () => {
       );
       expect(delegated).toMatchObject({
         ok: false,
-        error: { code: "control_tool_failed", message: "Managed Omi agents can only use Omi cloud routing." },
+        error: { code: "control_tool_failed", message: expectedMessage },
       });
     }
 
@@ -1843,6 +1846,39 @@ describe("agent control tools", () => {
       },
     });
     expect(store.allRows("SELECT * FROM runs")).toHaveLength(0);
+    store.close();
+  });
+
+  it("denies every nested-agent creation entry point for a leaf role", async () => {
+    const { store, kernel } = createKernelHarness(newDatabasePath(), "pi-mono");
+    const parent = await kernel.executeRun({
+      ...baseRunInput,
+      adapterId: "pi-mono",
+      defaultAdapterId: "pi-mono",
+    });
+    const context = {
+      ...ownerContext(kernel),
+      defaultAdapterId: "pi-mono",
+      providerBoundary: "managed_cloud" as const,
+      executionRole: "leaf" as const,
+    };
+    const calls = [
+      ["spawn_agent", { objective: "nested", visible: false }],
+      ["spawn_background_agent", { prompt: "nested" }],
+      ["run_agent_and_wait", { objective: "nested", parentRunId: parent.run.runId }],
+    ] as const;
+
+    for (const [name, input] of calls) {
+      const result = parseToolResult(await handleAgentControlToolCall(context, name, input));
+      expect(result).toMatchObject({
+        ok: false,
+        error: {
+          code: "control_tool_failed",
+          message: "Background agents are leaf workers and cannot start additional agents.",
+        },
+      });
+    }
+    expect(store.allRows("SELECT * FROM runs")).toHaveLength(1);
     store.close();
   });
 
@@ -1932,6 +1968,10 @@ describe("agent control tools", () => {
       protocolVersion: 2,
       includeSwiftBackedTools: true,
       screenContext: true,
+      executionRole: "leaf",
+      surfaceKind: undefined,
+      externalRefKind: undefined,
+      externalRefId: undefined,
     });
     expect(toolNamesForAdapter("omi-tools-stdio", { screenContext: true })).toEqual(
       expect.arrayContaining(["get_work_context", "request_permission", "check_permission_status", "capture_screen"]),
@@ -1985,6 +2025,10 @@ describe("agent control tools", () => {
       protocolVersion: 2,
       includeSwiftBackedTools: true,
       screenContext: true,
+      executionRole: "leaf",
+      surfaceKind: undefined,
+      externalRefKind: undefined,
+      externalRefId: undefined,
     });
     store.close();
   });
@@ -2163,13 +2207,14 @@ describe("agent control tools", () => {
       ownerId: "owner",
       requestId: "delegate-spawn-1",
       clientId: "delegate-client",
-      adapterId: "acp",
+      adapterId: "fake",
       protocolVersion: 2,
       surfaceKind: "delegated_agent",
       externalRefKind: undefined,
       externalRefId: undefined,
       includeSwiftBackedTools: true,
       screenContext: true,
+      executionRole: "leaf",
     });
     await waitUntil(() => adapter.executed.length === 2);
 

--- a/desktop/macos/agent/tests/control-tools.test.ts
+++ b/desktop/macos/agent/tests/control-tools.test.ts
@@ -1861,24 +1861,84 @@ describe("agent control tools", () => {
       defaultAdapterId: "pi-mono",
       providerBoundary: "managed_cloud" as const,
       executionRole: "leaf" as const,
+      callerSessionId: parent.session.sessionId,
     };
     const calls = [
-      ["spawn_agent", { objective: "nested", visible: false }],
-      ["spawn_background_agent", { prompt: "nested" }],
-      ["run_agent_and_wait", { objective: "nested", parentRunId: parent.run.runId }],
+      ["spawn_agent", { objective: "nested", visible: false }, "Background agents are leaf workers and cannot start additional agents."],
+      ["spawn_background_agent", { prompt: "nested" }, "Background agents are leaf workers and cannot start additional agents."],
+      ["run_agent_and_wait", { objective: "nested", parentRunId: parent.run.runId }, "Background agents are leaf workers and cannot start additional agents."],
+      ["send_agent_message", { sessionId: parent.session.sessionId, prompt: "continue" }, "Leaf workers cannot continue agent sessions."],
     ] as const;
 
-    for (const [name, input] of calls) {
+    for (const [name, input, message] of calls) {
       const result = parseToolResult(await handleAgentControlToolCall(context, name, input));
       expect(result).toMatchObject({
         ok: false,
         error: {
           code: "control_tool_failed",
-          message: "Background agents are leaf workers and cannot start additional agents.",
+          message,
         },
       });
     }
     expect(store.allRows("SELECT * FROM runs")).toHaveLength(1);
+    store.close();
+  });
+
+  it("rejects kernel background spawns from leaf callers without trusted authority", async () => {
+    const { store, kernel } = createKernelHarness(newDatabasePath(), "pi-mono");
+    const leaf = store.insertSession({
+      ownerId: "owner",
+      surfaceKind: "background_agent",
+      executionRole: "leaf",
+      providerBoundary: "managed_cloud",
+      defaultAdapterId: "pi-mono",
+    });
+
+    await expect(
+      kernel.spawnBackgroundAgent({
+        ownerId: "owner",
+        clientId: "client",
+        requestId: "leaf-bypass",
+        prompt: "should fail",
+        adapterId: "pi-mono",
+        defaultAdapterId: "pi-mono",
+        callerSessionId: leaf.sessionId,
+      }),
+    ).rejects.toThrow("Leaf workers cannot create background agents.");
+
+    await expect(
+      kernel.spawnBackgroundAgent({
+        ownerId: "owner",
+        clientId: "client",
+        requestId: "unscoped-bypass",
+        prompt: "should fail",
+        adapterId: "pi-mono",
+        defaultAdapterId: "pi-mono",
+      }),
+    ).rejects.toThrow("Background agent spawn requires a coordinator caller session.");
+
+    expect(store.allRows("SELECT * FROM runs")).toHaveLength(0);
+    store.close();
+  });
+
+  it("loads owned session execution policy by id instead of a bounded list", () => {
+    const { store, kernel } = createKernelHarness(newDatabasePath(), "pi-mono");
+    const leaf = store.insertSession({
+      ownerId: "owner",
+      surfaceKind: "background_agent",
+      executionRole: "leaf",
+      providerBoundary: "managed_cloud",
+      defaultAdapterId: "pi-mono",
+    });
+
+    expect(kernel.executionPolicyForOwnedSession(leaf.sessionId, "owner")).toEqual({
+      executionRole: "leaf",
+      providerBoundary: "managed_cloud",
+      defaultAdapterId: "pi-mono",
+    });
+    expect(() => kernel.executionPolicyForOwnedSession(leaf.sessionId, "other-owner")).toThrow(
+      "Agent session is not visible to the active owner",
+    );
     store.close();
   });
 

--- a/desktop/macos/agent/tests/execution-policy.test.ts
+++ b/desktop/macos/agent/tests/execution-policy.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  executionRoleAllowsTool,
   providerBoundaryForAdapter,
   resolveAdapterWithinBoundary,
 } from "../src/runtime/execution-policy.js";
@@ -32,6 +33,18 @@ describe("agent execution policy", () => {
         defaultAdapterId: "pi-mono",
         requestedAdapterId: adapterId,
       })).toThrow();
+    }
+  });
+
+  it("denies every leaf-restricted control tool for leaf roles", () => {
+    for (const toolName of [
+      "send_agent_message",
+      "spawn_background_agent",
+      "spawn_agent",
+      "run_agent_and_wait",
+    ]) {
+      expect(executionRoleAllowsTool("leaf", toolName)).toBe(false);
+      expect(executionRoleAllowsTool("coordinator", toolName)).toBe(true);
     }
   });
 });

--- a/desktop/macos/agent/tests/execution-policy.test.ts
+++ b/desktop/macos/agent/tests/execution-policy.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import {
+  providerBoundaryForAdapter,
+  resolveAdapterWithinBoundary,
+} from "../src/runtime/execution-policy.js";
+
+describe("agent execution policy", () => {
+  it("derives the declared production credential boundary", () => {
+    expect(providerBoundaryForAdapter("pi-mono")).toBe("managed_cloud");
+    expect(providerBoundaryForAdapter("acp")).toBe("local_user:acp");
+    expect(providerBoundaryForAdapter("hermes")).toBe("local_user:hermes");
+    expect(providerBoundaryForAdapter("openclaw")).toBe("local_user:openclaw");
+  });
+
+  it("pins local-user surfaces to the exact selected adapter", () => {
+    expect(resolveAdapterWithinBoundary({
+      providerBoundary: "local_user:acp",
+      defaultAdapterId: "acp",
+      requestedAdapterId: "acp",
+    })).toBe("acp");
+    expect(() => resolveAdapterWithinBoundary({
+      providerBoundary: "local_user:acp",
+      defaultAdapterId: "acp",
+      requestedAdapterId: "hermes",
+    })).toThrow("Local provider mode is pinned to acp");
+  });
+
+  it("fails closed for local and unknown overrides from managed execution", () => {
+    for (const adapterId of ["acp", "hermes", "openclaw", "unknown-adapter"]) {
+      expect(() => resolveAdapterWithinBoundary({
+        providerBoundary: "managed_cloud",
+        defaultAdapterId: "pi-mono",
+        requestedAdapterId: adapterId,
+      })).toThrow();
+    }
+  });
+});

--- a/desktop/macos/agent/tests/fixtures/tool-manifest.json
+++ b/desktop/macos/agent/tests/fixtures/tool-manifest.json
@@ -2164,10 +2164,12 @@
     ],
     "adapters": {
       "pi-mono": {
-        "advertised": true
+        "advertised": true,
+        "condition": "coordinatorOnly"
       },
       "omi-tools-stdio": {
-        "advertised": true
+        "advertised": true,
+        "condition": "coordinatorOnly"
       }
     }
   },
@@ -2557,10 +2559,12 @@
     ],
     "adapters": {
       "pi-mono": {
-        "advertised": true
+        "advertised": true,
+        "condition": "coordinatorOnly"
       },
       "omi-tools-stdio": {
-        "advertised": true
+        "advertised": true,
+        "condition": "coordinatorOnly"
       }
     }
   },
@@ -2733,10 +2737,12 @@
     ],
     "adapters": {
       "pi-mono": {
-        "advertised": true
+        "advertised": true,
+        "condition": "coordinatorOnly"
       },
       "omi-tools-stdio": {
-        "advertised": true
+        "advertised": true,
+        "condition": "coordinatorOnly"
       }
     }
   },

--- a/desktop/macos/agent/tests/jsonl-transport.test.ts
+++ b/desktop/macos/agent/tests/jsonl-transport.test.ts
@@ -331,6 +331,7 @@ describe("JsonlTransport", () => {
       requestId: "shared-request",
       clientId: "client-hermes",
       externalRefId: "task-hermes",
+      prompt: "hermes correlation",
     });
     const openclawRun = kernel.executeRun({
       ...baseRunInput,
@@ -339,6 +340,7 @@ describe("JsonlTransport", () => {
       requestId: "shared-request",
       clientId: "client-openclaw",
       externalRefId: "task-openclaw",
+      prompt: "openclaw correlation",
     });
     await waitUntil(() => hermes.executed.length === 1 && openclaw.executed.length === 1);
 
@@ -436,6 +438,7 @@ describe("JsonlTransport", () => {
       protocolVersion: 2,
       sessionId: "session-mcp",
       adapterId: "fake",
+      executionRole: "coordinator",
     });
     store.close();
   });
@@ -1093,6 +1096,7 @@ describe("JsonlTransport", () => {
         requestId: "request-acp",
         clientId: "client-acp",
         adapterId: "acp",
+        externalRefId: "task-acp",
       }),
       facade.handleQuery({
         ...v2Query({ prompt: "use pi" }),
@@ -1100,6 +1104,7 @@ describe("JsonlTransport", () => {
         requestId: "request-pi",
         clientId: "client-pi",
         adapterId: "pi-mono",
+        externalRefId: "task-pi",
       }),
     ]);
 

--- a/desktop/macos/agent/tests/omi-tool-manifest.test.ts
+++ b/desktop/macos/agent/tests/omi-tool-manifest.test.ts
@@ -9,6 +9,16 @@ import {
 } from "../src/runtime/omi-tool-manifest.js";
 
 describe("omi tool manifest", () => {
+  it("projects agent-management tools out of leaf worker contexts", () => {
+    for (const adapterId of ["pi-mono", "omi-tools-stdio"] as const) {
+      const names = toolNamesForAdapter(adapterId, { executionRole: "leaf", screenContext: true });
+      expect(names).not.toContain("spawn_agent");
+      expect(names).not.toContain("spawn_background_agent");
+      expect(names).not.toContain("run_agent_and_wait");
+      expect(names).not.toContain("send_agent_message");
+    }
+  });
+
   it("has unique canonical names", () => {
     const names = omiToolManifest.map((tool) => tool.name);
     expect(new Set(names).size).toBe(names.length);

--- a/desktop/macos/agent/tests/pi-mono-adapter.test.ts
+++ b/desktop/macos/agent/tests/pi-mono-adapter.test.ts
@@ -411,6 +411,43 @@ describe("PiMonoAdapter prompt correlation", () => {
     await expect(prompt).resolves.toMatchObject({ text: "child created" });
   });
 
+  it("does not let an unrelated control success erase a failed obligation", async () => {
+    const { adapter } = createAdapter();
+    seedSessions(adapter, "session-1");
+    const prompt = adapter.sendPrompt(
+      "session-1",
+      [{ type: "text", text: "create both children" }],
+      [],
+      "act",
+      () => {},
+      async () => "",
+    );
+
+    (adapter as any).handleToolStart({
+      toolName: "spawn_agent",
+      toolCallId: "tool-child-a",
+      args: { objective: "child A" },
+    });
+    (adapter as any).handleToolEnd({
+      toolName: "spawn_agent",
+      toolCallId: "tool-child-a",
+      result: { content: [{ type: "text", text: JSON.stringify({ ok: false, error: { message: "failed A" } }) }] },
+    });
+    (adapter as any).handleToolStart({
+      toolName: "spawn_agent",
+      toolCallId: "tool-child-b",
+      args: { objective: "child B" },
+    });
+    (adapter as any).handleToolEnd({
+      toolName: "spawn_agent",
+      toolCallId: "tool-child-b",
+      result: { content: [{ type: "text", text: JSON.stringify({ ok: true }) }] },
+    });
+    (adapter as any).handleTurnEnd(makeTurnEndEvent("child B created"));
+
+    await expect(prompt).rejects.toThrow("failed A");
+  });
+
   it("resolves abort before turn_end and drops the late completion", async () => {
     const { adapter, events } = createAdapter();
     seedSessions(adapter, "session-1");

--- a/desktop/macos/agent/tests/runtime-adapter.test.ts
+++ b/desktop/macos/agent/tests/runtime-adapter.test.ts
@@ -508,6 +508,15 @@ describe("adapter capability matrix", () => {
     );
     expect(PRODUCTION_ADAPTER_IDS).toEqual(["acp", "pi-mono", "hermes", "openclaw"]);
     expect(PLACEHOLDER_ADAPTER_IDS).toEqual(["a2a"]);
+    expect(Object.fromEntries(PRODUCTION_ADAPTER_IDS.map((adapterId) => [
+      adapterId,
+      ADAPTER_CAPABILITY_MATRIX[adapterId].credentialScope,
+    ]))).toEqual({
+      acp: "local_user",
+      "pi-mono": "managed_cloud",
+      hermes: "local_user",
+      openclaw: "local_user",
+    });
 
     expect(ADAPTER_CAPABILITY_MATRIX.acp.expectations).toMatchObject({
       nativeResume: { status: "required" },
@@ -568,6 +577,7 @@ describe("adapter capability matrix", () => {
       const entry = ADAPTER_CAPABILITY_MATRIX[adapterId];
 
       expect(entry.productionAdapter).toBe(true);
+      expect(["managed_cloud", "local_user"]).toContain(entry.credentialScope);
       expect(entry.adapterId).toBe(adapterId);
       expect(Object.keys(entry.expectations).sort()).toEqual([
         "artifactEmission",

--- a/desktop/macos/agent/tests/sqlite-store.test.ts
+++ b/desktop/macos/agent/tests/sqlite-store.test.ts
@@ -19,7 +19,7 @@ describe("SqliteAgentStore", () => {
     store.migrate();
     store.migrate();
 
-    expect(store.getRow("SELECT COUNT(*) AS count FROM schema_migrations").count).toBe(13);
+    expect(store.getRow("SELECT COUNT(*) AS count FROM schema_migrations").count).toBe(14);
     expect(tableNames(store)).toEqual([
       "adapter_bindings",
       "artifacts",
@@ -90,6 +90,30 @@ describe("SqliteAgentStore", () => {
       expect.objectContaining({ attempt_no: 1, status: "running" }),
       expect.objectContaining({ attempt_no: 3, status: "failed" }),
     ]);
+    store.close();
+  });
+
+  it("persists execution role and provider boundary on sessions", () => {
+    const store = newStore({ reconcileOnOpen: false });
+    const managedLeaf = store.insertSession({
+      ownerId: "owner",
+      surfaceKind: "background_agent",
+      executionRole: "leaf",
+      providerBoundary: "managed_cloud",
+      defaultAdapterId: "pi-mono",
+    });
+
+    expect(managedLeaf).toMatchObject({
+      executionRole: "leaf",
+      providerBoundary: "managed_cloud",
+    });
+    expect(store.getRow(
+      "SELECT execution_role, provider_boundary FROM sessions WHERE session_id = ?",
+      [managedLeaf.sessionId],
+    )).toMatchObject({
+      execution_role: "leaf",
+      provider_boundary: "managed_cloud",
+    });
     store.close();
   });
 

--- a/desktop/macos/agent/tests/workstream-continuity.test.ts
+++ b/desktop/macos/agent/tests/workstream-continuity.test.ts
@@ -119,7 +119,7 @@ describe("workstream continuity", () => {
       delivery_status: "blocked",
       status: "rejected",
     });
-    expect(store.getRow("SELECT COUNT(*) AS count FROM schema_migrations").count).toBe(13);
+    expect(store.getRow("SELECT COUNT(*) AS count FROM schema_migrations").count).toBe(14);
     store.close();
   });
 

--- a/desktop/macos/changelog/unreleased/20260710-agent-provider-boundaries.json
+++ b/desktop/macos/changelog/unreleased/20260710-agent-provider-boundaries.json
@@ -1,0 +1,3 @@
+{
+  "change": "Agent provider boundaries and worker roles are now enforced by the desktop runtime: managed work stays on Omi cloud routing, local modes stay pinned to their selected provider, leaf workers cannot create more agents, and failed required control actions cannot appear as successful completion."
+}

--- a/desktop/macos/pi-mono-extension/index.test.ts
+++ b/desktop/macos/pi-mono-extension/index.test.ts
@@ -23,6 +23,7 @@ import {
   appendAudit,
   __resetAuditWarnedForTest,
   OMI_TOOLS,
+  omiToolsForExecutionRole,
   OMI_TOOL_TIMEOUT_MS,
   OMI_LONG_CONTROL_TOOL_TIMEOUT_MS,
   isSafeSkillName,
@@ -995,6 +996,14 @@ test("OMI_TOOLS: exact pi-mono projection from canonical manifest", () => {
     OMI_TOOLS.map((tool) => tool.name),
     toolNamesForAdapter("pi-mono"),
   );
+});
+
+test("OMI_TOOLS: leaf projection omits every agent-management tool", () => {
+  const names = omiToolsForExecutionRole("leaf").map((tool) => tool.name);
+  assert.ok(!names.includes("spawn_agent"));
+  assert.ok(!names.includes("spawn_background_agent"));
+  assert.ok(!names.includes("run_agent_and_wait"));
+  assert.ok(!names.includes("send_agent_message"));
 });
 
 test("OMI_TOOLS: all tools preserve canonical pi-mono projection metadata and schema shape", () => {

--- a/desktop/macos/pi-mono-extension/index.ts
+++ b/desktop/macos/pi-mono-extension/index.ts
@@ -690,9 +690,16 @@ function loadSkillTool() {
   });
 }
 
-export const OMI_TOOLS = toolsForAdapter("pi-mono").map((tool) => (
-  tool.executor.kind === "nodeTool" ? loadSkillTool() : omiManifestTool(tool)
-));
+const executionRole = process.env.OMI_EXECUTION_ROLE === "leaf" ? "leaf" : "coordinator";
+const projectionContext = { executionRole } as const;
+
+export function omiToolsForExecutionRole(role: "coordinator" | "leaf") {
+  return toolsForAdapter("pi-mono", { executionRole: role }).map((tool) => (
+    tool.executor.kind === "nodeTool" ? loadSkillTool() : omiManifestTool(tool)
+  ));
+}
+
+export const OMI_TOOLS = omiToolsForExecutionRole(executionRole);
 
 async function registerOmiTools(pi: ExtensionAPI): Promise<void> {
   const pipePath = process.env.OMI_BRIDGE_PIPE;
@@ -709,7 +716,7 @@ async function registerOmiTools(pi: ExtensionAPI): Promise<void> {
   for (const tool of OMI_TOOLS) {
     pi.registerTool(tool);
   }
-  const snapshot = buildToolAvailabilitySnapshot("pi-mono");
+  const snapshot = buildToolAvailabilitySnapshot("pi-mono", projectionContext);
   if (process.env.OMI_TOOL_AVAILABILITY_SNAPSHOT_PATH) {
     try {
       await writeFile(process.env.OMI_TOOL_AVAILABILITY_SNAPSHOT_PATH, `${JSON.stringify(snapshot, null, 2)}\n`);

--- a/docs/doc/developer/agent-control-plane-invariants.mdx
+++ b/docs/doc/developer/agent-control-plane-invariants.mdx
@@ -169,6 +169,51 @@ Guard surface:
 - `runtime-adapter.test.ts` verifies production expectations and ticketed known
   limitations.
 
+### Adapter credential scope is explicit and inherited
+
+Every production adapter declares `managed_cloud` or `local_user` in
+`ADAPTER_CAPABILITY_MATRIX`. Sessions persist a provider boundary when the
+kernel creates them. Managed sessions may select only managed-cloud adapters;
+local-user sessions are pinned to the exact selected local adapter. Missing
+adapter arguments inherit that boundary, while unknown adapters fail closed.
+
+Guard surface:
+
+- `execution-policy.ts` is the shared resolver used by control tools and the
+  kernel run-acceptance path.
+- `runtime-adapter.test.ts`, `execution-policy.test.ts`, and
+  `control-tools.test.ts` exhaust production declarations and managed routing.
+
+### Execution role owns agent-management authority
+
+Sessions persist `coordinator` or `leaf`. Background, delegated, and floating
+pill sessions are created as leaves. Leaf tool projections omit agent creation
+and continuation tools, while the control relay and kernel delegation path
+independently reject stale or forged calls. Surface-derived role exists only in
+the creation/legacy migration boundary; persisted kernel state is authoritative
+afterward.
+
+Guard surface:
+
+- `omi-tool-manifest.test.ts` verifies leaf capability projection.
+- `control-tools.test.ts` verifies server denial for every nested creation
+  entry point.
+- `sqlite-store.test.ts` verifies role and provider-boundary persistence.
+
+### Required control failures cannot become successful runs
+
+Required spawn, delegate, and continuation operations remain unresolved after
+failure until the same logical operation succeeds. Transport correlation and
+adapter-selection fields do not define logical identity, so a corrected retry
+can resolve the obligation; an unrelated successful operation cannot.
+
+Guard surface:
+
+- `pi-mono-adapter.test.ts` covers terminal failure, matching retry success,
+  and unrelated-success denial.
+- The kernel remains the only component that persists run and attempt terminal
+  state; adapter outcomes are inputs to that transition, not an alternate store.
+
 ## Persistence
 
 Lifecycle state transitions and their durable events should commit in the same

--- a/docs/doc/developer/agent-control-plane-invariants.mdx
+++ b/docs/doc/developer/agent-control-plane-invariants.mdx
@@ -188,16 +188,19 @@ Guard surface:
 
 Sessions persist `coordinator` or `leaf`. Background, delegated, and floating
 pill sessions are created as leaves. Leaf tool projections omit agent creation
-and continuation tools, while the control relay and kernel delegation path
-independently reject stale or forged calls. Surface-derived role exists only in
-the creation/legacy migration boundary; persisted kernel state is authoritative
-afterward.
+and continuation tools, while the control relay and kernel independently reject
+stale or forged calls for every leaf-restricted tool (including
+`send_agent_message`). The relay loads the caller's persisted policy by session
+id with an owner check and fails closed when that lookup cannot complete;
+surface-derived role exists only in the creation/legacy migration boundary.
+Persisted kernel state is authoritative afterward. `spawnBackgroundAgent`
+requires a coordinator caller session or an explicit trusted-user spawn.
 
 Guard surface:
 
 - `omi-tool-manifest.test.ts` verifies leaf capability projection.
-- `control-tools.test.ts` verifies server denial for every nested creation
-  entry point.
+- `control-tools.test.ts` verifies server denial for every nested creation and
+  continuation entry point, plus kernel spawn authority checks.
 - `sqlite-store.test.ts` verifies role and provider-boundary persistence.
 
 ### Required control failures cannot become successful runs

--- a/docs/product/invariants/agent-control-plane.md
+++ b/docs/product/invariants/agent-control-plane.md
@@ -15,11 +15,15 @@ must name the invariant they affect and update the matching guard test.
   authority for this runtime's run/attempt status.
 - Keep a local task Candidate in an independent review state after a canonical
   backend receipt exists.
+- Select an adapter outside the session's persisted provider boundary.
+- Grant leaf workers agent-management tools or nested-agent authority.
+- Persist a successful run while a required control operation remains failed.
 
 ## Surfaces
 
 - Desktop TypeScript agent runtime (`desktop/macos/agent/src/runtime`)
 - Adapter bindings, control tools, request-scoped relay, startup reconciliation
+- Adapter credential scopes, session execution roles, and terminal control obligations
 
 ## Guard tests
 


### PR DESCRIPTION
## Summary

- make adapter credential scope declarative in the production adapter registry and persist each session's provider boundary
- persist coordinator/leaf execution roles, project agent-management tools out of leaf runtimes, and retain relay/kernel denial for stale or forged calls
- fail closed for every managed control entry point against local or unknown adapters, while pinning local-user sessions to their exact selected provider
- track required control retries by logical operation so unrelated success cannot erase a failed obligation
- document the durable control-plane invariants and add the session execution-policy migration

## Design

Sessions now carry two kernel-owned fields:

- `providerBoundary`: `managed_cloud` or `local_user:<adapter>`
- `executionRole`: `coordinator` or `leaf`

Tool arguments request an adapter but never authorize it. The shared execution-policy resolver is called from both control-tool handling and kernel run acceptance. Background, delegated, and floating-pill sessions are created as leaves; pi-mono and MCP tool projections omit agent-management tools for those sessions, while server checks remain authoritative.

This follows the containment work merged in #9402 and replaces its adapter-name allowlist / surface-only inference with persisted policy.

## Product invariants

- INV-AGENT-* — provider boundary, execution role, leaf authority, and required-control terminal semantics
- INV-CHAT-1 — the kernel remains the source of run/attempt terminal truth
- INV-AUTH-1 — managed execution cannot select locally credentialed adapters

Migration: session execution policy is schema migration 14, following workstream continuity migration 13.

## Verification

- `cd desktop/macos/agent && npm run build`
- `cd desktop/macos/agent && npm test` — 393 passed
- focused execution-policy/routing/leaf/terminal suite — 210 passed
- `cd desktop/macos/pi-mono-extension && npm test` — 104 passed
- `cd desktop/macos && ./scripts/agent-logic-harness.sh --skip-install` — passed (Swift lifecycle, agent runtime, exact extension tests)
- checked-in `scripts/pre-push origin` — passed; the installed hook dispatcher references removed `scripts/pre-push-singleflight`, so the push used `--no-verify` only after running the current hook script directly
- named bundle `omi-provider-boundaries` built, installed, ad-hoc re-signed, launched, and reported automation state under `com.omi.omi-provider-boundaries`

The named bundle was cold-signed-out because the local Omi Dev profile had no auth session, so a live managed-background network turn was unavailable. The packaged runtime, exhaustive adapter/control matrix, leaf projection, and terminal retry paths are covered by the passing suites above.

Closes #9407

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9411?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

