### PR TITLE
fix(desktop): keep Neo above free-tier desktop floor

### DIFF
--- a/backend/tests/unit/test_lazy_conversation_processing.py
+++ b/backend/tests/unit/test_lazy_conversation_processing.py
@@ -70,6 +70,9 @@ class TestShouldDeferDesktopProcessing:
     def _sub_with_plan(self, plan):
         s = MagicMock()
         s.plan = plan
+        # Model an ordinary post-policy Neo renewal. A missing period-start is
+        # intentionally grandfathered by production code for webhook safety.
+        s.current_period_start = self._sub.NEO_DESKTOP_GRANDFATHER_CUTOFF + 1
         return s
 
     def test_basic_plan_is_deferred(self):

--- a/backend/tests/unit/test_neo_desktop_grandfather.py
+++ b/backend/tests/unit/test_neo_desktop_grandfather.py
@@ -18,10 +18,18 @@ import pytest
 
 # Import database before utils.subscription to satisfy the circular import.
 import database.users  # noqa: F401
+import utils.subscription as subscription_mod
 
 from models.users import PlanType, Subscription  # noqa: E402
 from utils.subscription import (  # noqa: E402
     NEO_DESKTOP_GRANDFATHER_CUTOFF,
+    DESKTOP_ACCESS_TIER_ARCHITECT,
+    DESKTOP_ACCESS_TIER_FREE,
+    DESKTOP_ACCESS_TIER_FULL,
+    desktop_trial_paywall_eligible,
+    effective_desktop_access_tier,
+    get_remaining_transcription_seconds,
+    is_trial_paywalled,
     neo_grandfather_until,
     plan_grants_desktop,
 )
@@ -86,6 +94,48 @@ class TestPlanGrantsDesktop:
         # who happens to be on Neo when the caller didn't look at the sub.
         assert plan_grants_desktop(PlanType.unlimited) is False
         assert plan_grants_desktop(PlanType.unlimited, None) is False
+
+
+class TestEffectiveDesktopAccessTier:
+    """Every plan resolves to a usable Desktop tier; Neo never resolves to none."""
+
+    def test_free_neo_operator_and_architect_resolve_to_expected_tiers(self):
+        post_cutoff_neo = Subscription(plan=PlanType.unlimited, current_period_start=POST_CUTOFF)
+
+        assert effective_desktop_access_tier(PlanType.basic) == DESKTOP_ACCESS_TIER_FREE
+        assert effective_desktop_access_tier(PlanType.unlimited, post_cutoff_neo) == DESKTOP_ACCESS_TIER_FREE
+        assert effective_desktop_access_tier(PlanType.operator) == DESKTOP_ACCESS_TIER_FULL
+        assert effective_desktop_access_tier(PlanType.architect) == DESKTOP_ACCESS_TIER_ARCHITECT
+
+    def test_only_free_is_eligible_for_account_age_paywall(self):
+        post_cutoff_neo = Subscription(plan=PlanType.unlimited, current_period_start=POST_CUTOFF)
+
+        assert desktop_trial_paywall_eligible(PlanType.basic) is True
+        assert desktop_trial_paywall_eligible(PlanType.unlimited, post_cutoff_neo) is False
+        assert desktop_trial_paywall_eligible(PlanType.operator) is False
+        assert desktop_trial_paywall_eligible(PlanType.architect) is False
+
+    def test_post_cutoff_neo_cannot_receive_zero_desktop_audio_credits(self, monkeypatch):
+        """Exercise the same resolver used by /v4/listen admission and refresh."""
+        post_cutoff_neo = Subscription(plan=PlanType.unlimited, current_period_start=POST_CUTOFF)
+        cache_values = iter((True, None))
+        cleared_cache_keys = []
+
+        def clear_cache(key):
+            cleared_cache_keys.append(key)
+
+        monkeypatch.setattr(subscription_mod, 'TRIAL_PAYWALL_ENABLED', True)
+        monkeypatch.setattr(subscription_mod.users_db, 'get_user_valid_subscription', lambda _uid: post_cutoff_neo)
+        monkeypatch.setattr(subscription_mod.users_db, 'is_byok_active', lambda _uid: False)
+        monkeypatch.setattr(subscription_mod, '_request_has_all_byok_keys', lambda: False)
+        monkeypatch.setattr(subscription_mod.redis_db, 'get_generic_cache', lambda _key: next(cache_values))
+        monkeypatch.setattr(subscription_mod.redis_db, 'set_generic_cache', lambda *_args, **_kwargs: None)
+        monkeypatch.setattr(subscription_mod.redis_db, 'delete_generic_cache', clear_cache)
+        monkeypatch.setattr(subscription_mod, 'record_fallback', lambda **_kwargs: None)
+
+        assert is_trial_paywalled('neo-uid', 'desktop') is False
+        assert get_remaining_transcription_seconds('neo-uid', source='desktop') is None
+        assert cleared_cache_keys == ['trial_paywall:expired:neo-uid']
 
 
 class TestNeoGrandfatherUntil:

--- a/backend/tests/unit/test_subscription_restructure.py
+++ b/backend/tests/unit/test_subscription_restructure.py
@@ -309,6 +309,8 @@ def test_plan_features_differentiate_operator_neo(monkeypatch, load_subscription
 
     assert "600 chat questions per month" in op_features
     assert "300 chat questions per month" in neo_features
+    assert "Desktop capture with Free-tier allowance" in neo_features
+    assert "No desktop access" not in neo_features
 
 
 def test_plan_display_names(load_subscription):

--- a/backend/tests/unit/test_trial_metadata.py
+++ b/backend/tests/unit/test_trial_metadata.py
@@ -16,12 +16,12 @@ Validates:
 import os
 import time
 from pathlib import Path
-from typing import Any, cast
+from typing import Any, Optional, cast
 from unittest.mock import patch, MagicMock
 
 import pytest
 
-from models.users import TrialMetadata, PlanType
+from models.users import TrialMetadata, PlanType, Subscription
 
 # ── Source-level tests: verify the endpoint and function exist correctly ──────
 
@@ -111,6 +111,10 @@ def _get_trial_metadata_fn():
     func_start = source.index('def get_trial_metadata(')
     next_func = source.index('\ndef ', func_start + 1)
     func_source = source[func_start:next_func]
+    tier_start = source.index('def effective_desktop_access_tier(')
+    tier_source = source[tier_start : source.index('\ndef ', tier_start + 1)]
+    eligibility_start = source.index('def desktop_trial_paywall_eligible(')
+    eligibility_source = source[eligibility_start : source.index('\ndef ', eligibility_start + 1)]
 
     # Need the TRIAL_FEATURES constant too
     features_start = source.index('TRIAL_FEATURES = [')
@@ -123,7 +127,9 @@ def _get_trial_metadata_fn():
 
     namespace: dict[str, Any] = {
         'PlanType': PlanType,
+        'Subscription': Subscription,
         'TrialMetadata': TrialMetadata,
+        'Optional': Optional,
         'time': time,
         'os': os,
         'users_db': MagicMock(),
@@ -132,6 +138,10 @@ def _get_trial_metadata_fn():
         'get_plan_display_name': lambda p: 'Free' if p == PlanType.basic else p.value.capitalize(),
         'FREE_CHAT_QUESTIONS_PER_MONTH': 30,
         '_request_has_all_byok_keys': lambda: False,
+        'DESKTOP_ACCESS_TIER_FREE': 'desktop_free',
+        'DESKTOP_ACCESS_TIER_FULL': 'desktop_full',
+        'DESKTOP_ACCESS_TIER_ARCHITECT': 'desktop_architect',
+        'PAID_PLAN_TYPES': {PlanType.unlimited, PlanType.operator, PlanType.architect},
         # These tests exercise the trial-expiry computation, which only runs when the
         # paywall is enabled (it's OFF by default in prod / freemium).
         'TRIAL_PAYWALL_ENABLED': True,
@@ -147,6 +157,8 @@ def _get_trial_metadata_fn():
         return False
 
     namespace['plan_grants_desktop'] = _plan_grants_desktop_stub
+    exec(compile(tier_source, '<subscription.py>', 'exec'), namespace)
+    exec(compile(eligibility_source, '<subscription.py>', 'exec'), namespace)
     # _get_user wraps firebase_auth.get_user — subscription.py extracts it
     # into a module-level helper for type safety. cast is used for type narrowing.
     namespace['_get_user'] = lambda uid: namespace['firebase_auth'].get_user(uid)
@@ -239,6 +251,20 @@ class TestGetTrialMetadataBehavior:
         sub = MagicMock()
         sub.plan = PlanType.unlimited
         sub.current_period_start = None
+        self.ns['users_db'].get_user_valid_subscription.return_value = sub
+        self.ns['users_db'].is_byok_active.return_value = False
+
+        result = self.fn('uid_test')
+
+        assert result.trial_expired is False
+        assert result.trial_started_at is None
+        self.ns['firebase_auth'].get_user.assert_not_called()
+
+    def test_active_neo_after_grandfather_cutoff_is_not_trial_paywalled(self):
+        """Neo keeps its usable Free Desktop floor after full access expires."""
+        sub = MagicMock()
+        sub.plan = PlanType.unlimited
+        sub.current_period_start = self.ns['NEO_DESKTOP_GRANDFATHER_CUTOFF'] + 1
         self.ns['users_db'].get_user_valid_subscription.return_value = sub
         self.ns['users_db'].is_byok_active.return_value = False
 

--- a/backend/utils/subscription.py
+++ b/backend/utils/subscription.py
@@ -14,6 +14,7 @@ from database.announcements import compare_versions
 from models.users import PlanType, SubscriptionStatus, Subscription, PlanLimits, TrialMetadata
 from utils.byok import get_byok_key, get_byok_keys
 from utils.log_sanitizer import sanitize
+from utils.observability.fallback import record_fallback
 import logging
 
 logger = logging.getLogger(__name__)
@@ -25,12 +26,18 @@ def _get_user(uid: str) -> Any:
 
 PAID_PLAN_TYPES = {PlanType.unlimited, PlanType.architect, PlanType.operator}
 
-# Plans that unlock the desktop (macOS) app. Neo (unlimited) is a mobile/web
-# plan — it does NOT include desktop access, so on desktop a Neo subscriber is
-# treated like basic for the trial paywall. Operator and Architect include the
-# desktop app. Keep this in sync with the per-plan feature copy + the mobile
-# plans sheet (Operator shows "Desktop app", Neo shows "No desktop access").
+# Plans that unlock the full desktop (macOS) experience. This is deliberately
+# narrower than basic desktop usability: every plan, including Neo, has at
+# least the Free desktop tier. Operator and Architect add full desktop access.
+# Keep this in sync with the per-plan feature copy and the mobile plans sheet.
 DESKTOP_ENTITLED_PLAN_TYPES = {PlanType.operator, PlanType.architect}
+
+# Effective desktop tiers are used for Desktop-specific admission decisions.
+# Never use DESKTOP_ENTITLED_PLAN_TYPES as a zero-access check: it represents
+# full Desktop entitlement, while ``desktop_free`` is a valid usable floor.
+DESKTOP_ACCESS_TIER_FREE = "desktop_free"
+DESKTOP_ACCESS_TIER_FULL = "desktop_full"
+DESKTOP_ACCESS_TIER_ARCHITECT = "desktop_architect"
 
 # Grandfather: Neo subscriptions whose current billing period started before
 # this cutoff retain desktop access until that period ends. At their next
@@ -60,6 +67,32 @@ def plan_grants_desktop(plan: PlanType, subscription: Optional[Subscription] = N
     return False
 
 
+def effective_desktop_access_tier(plan: PlanType, subscription: Optional[Subscription] = None) -> str:
+    """Return the usable Desktop tier for a subscription.
+
+    Free is the minimum Desktop tier. A Neo (``unlimited``) subscriber who is
+    not in the full-Desktop grandfather period therefore receives
+    ``desktop_free`` rather than no Desktop access. Operator and grandfathered
+    Neo receive ``desktop_full``; Architect receives its separate premium tier.
+    """
+    if plan == PlanType.architect:
+        return DESKTOP_ACCESS_TIER_ARCHITECT
+    if plan_grants_desktop(plan, subscription):
+        return DESKTOP_ACCESS_TIER_FULL
+    return DESKTOP_ACCESS_TIER_FREE
+
+
+def desktop_trial_paywall_eligible(plan: PlanType, subscription: Optional[Subscription] = None) -> bool:
+    """Whether a plan can be blocked by the Desktop account-age trial paywall.
+
+    The account-age paywall is only for users on the Free tier. Neo is mapped
+    to the usable Free Desktop tier when it lacks full Desktop entitlement, but
+    it is still an active paid plan and must never be converted into zero audio,
+    chat, or realtime access.
+    """
+    return effective_desktop_access_tier(plan, subscription) == DESKTOP_ACCESS_TIER_FREE and plan not in PAID_PLAN_TYPES
+
+
 def neo_grandfather_until(subscription: Optional[Subscription]) -> Optional[int]:
     """If the subscriber is currently grandfathered onto Neo desktop, return
     the unix-seconds timestamp when that access ends (their current period end).
@@ -74,9 +107,11 @@ def neo_grandfather_until(subscription: Optional[Subscription]) -> Optional[int]
 
 
 def should_defer_desktop_processing(uid: str) -> bool:
-    """True for desktop users on a non-desktop-entitled plan (basic / Neo) without active
-    BYOK — their conversations are stored as raw transcript on capture and the expensive LLM
-    enrichment is deferred until they first open the conversation (freemium cost cut).
+    """True for Desktop users on the Free effective tier without active BYOK.
+
+    Free and non-grandfathered Neo users store a raw transcript on capture and
+    defer expensive LLM enrichment until the first open. This cost policy must
+    not be interpreted as a no-Desktop-access policy.
 
     Operator / Architect (desktop-entitled) and BYOK users (who pay their own LLM bill) are
     processed normally. The caller restricts this to `source == desktop`. Fails safe to False
@@ -88,7 +123,7 @@ def should_defer_desktop_processing(uid: str) -> bool:
             return False
         subscription = users_db.get_user_valid_subscription(uid)
         plan = subscription.plan if subscription else PlanType.basic
-        return plan not in DESKTOP_ENTITLED_PLAN_TYPES
+        return effective_desktop_access_tier(plan, subscription) == DESKTOP_ACCESS_TIER_FREE
     except Exception as e:
         logger.warning("should_defer_desktop_processing lookup failed for uid=%s: %s", uid, e)
         return False
@@ -145,14 +180,15 @@ def _request_has_all_byok_keys() -> bool:
 def _is_trial_expired_uncached(uid: str) -> bool:
     """Is this user past their 3-day desktop trial?
 
-    The trial applies to anyone without a desktop-entitled plan (basic OR Neo);
-    BYOK users are bypassed (they're paying their own LLM/STT bill). Returns
-    False on any lookup error so a Firebase blip never paywalls a paying user.
+    The trial applies only to the Free Desktop tier. Neo may use that tier for
+    non-premium capabilities, but is paid and must never be reduced to zero
+    access. BYOK users are also bypassed. Returns False on any lookup error so
+    a Firebase blip never paywalls a paying user.
     """
     try:
         subscription = users_db.get_user_valid_subscription(uid)
         plan = subscription.plan if subscription else PlanType.basic
-        if plan_grants_desktop(plan, subscription):
+        if not desktop_trial_paywall_eligible(plan, subscription):
             return False
         if users_db.is_byok_active(uid):
             return False
@@ -179,6 +215,38 @@ def _is_trial_expired_cached(uid: str) -> bool:
     cache_key = f"trial_paywall:expired:{uid}"
     cached = redis_db.get_generic_cache(cache_key)
     if cached is not None:
+        # A cache entry may have been written before an entitlement correction
+        # or a plan migration. Revalidate a positive value so a paid Neo user
+        # is not left with a zero-access decision until this key's TTL expires.
+        if cached:
+            try:
+                subscription = users_db.get_user_valid_subscription(uid)
+                plan = subscription.plan if subscription else PlanType.basic
+                if not desktop_trial_paywall_eligible(plan, subscription):
+                    clear_trial_paywall_cache(uid)
+                    record_fallback(
+                        component='other',
+                        from_mode='trial_paywall',
+                        to_mode=effective_desktop_access_tier(plan, subscription),
+                        reason='local_heal',
+                        outcome='recovered',
+                        log=logger,
+                    )
+                    return False
+            except Exception as e:
+                # Match the uncached lookup's fail-open behavior. An
+                # entitlement lookup outage must not preserve a zero-access
+                # decision for a paid subscriber from stale cache state.
+                logger.warning("trial paywall cache revalidation failed for uid=%s: %s", uid, e)
+                record_fallback(
+                    component='other',
+                    from_mode='trial_paywall',
+                    to_mode='fail_open',
+                    reason='policy',
+                    outcome='degraded',
+                    log=logger,
+                )
+                return False
         return bool(cached)
     expired = _is_trial_expired_uncached(uid)
     try:
@@ -232,13 +300,17 @@ def get_trial_metadata(uid: str) -> TrialMetadata:
         subscription = users_db.get_user_valid_subscription(uid)
         plan = subscription.plan if subscription else PlanType.basic
 
-        # Desktop-entitled (Operator / Architect) or BYOK users: trial is moot —
-        # they have full desktop access. Neo (unlimited) is mobile/web only, so
-        # it falls through to the trial computation just like basic.
+        # Any plan that is not eligible for the Free account-age trial, plus
+        # BYOK users, has usable Desktop access. In particular, Neo's Free
+        # Desktop tier is a floor, not a trial-only or zero-access state.
         # Same request-level escape hatch as `_is_trial_expired_cached`: a request
         # carrying all 4 BYOK provider headers is treated as BYOK-active even if
         # Firestore hasn't caught up yet.
-        if plan_grants_desktop(plan, subscription) or users_db.is_byok_active(uid) or _request_has_all_byok_keys():
+        if (
+            not desktop_trial_paywall_eligible(plan, subscription)
+            or users_db.is_byok_active(uid)
+            or _request_has_all_byok_keys()
+        ):
             return TrialMetadata(
                 trial_expired=False,
                 trial_duration_seconds=TRIAL_LENGTH_SECONDS,
@@ -784,8 +856,7 @@ def get_plan_features(plan: PlanType, simplified: bool = False) -> List[str]:
             f"{NEO_CHAT_QUESTIONS_PER_MONTH} chat questions per month",
             "Unlimited listening and transcription",
             "Unlimited memories and insights",
-            # Neo is mobile/web only — no desktop app (see DESKTOP_ENTITLED_PLAN_TYPES).
-            "Available on mobile and web",
+            "Desktop capture with Free-tier allowance",
         ]
 
     # Basic plan

--- a/desktop/macos/Desktop/Sources/DefaultsKey.swift
+++ b/desktop/macos/Desktop/Sources/DefaultsKey.swift
@@ -42,6 +42,7 @@ enum DefaultsKey: String {
     case chatScreenshotSharingEnabled = "chatScreenshotSharingEnabled"
     /// Test hook: forces TTS playback start to report failure (non-prod gauntlets).
     case forceTTSPlaybackStartFalse = "forceTTSPlaybackStartFalse"
+    case desktopIsPaywalled = "desktop_isPaywalled"
 }
 
 /// Compile-checked owner-scoped defaults keys whose final storage key is

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingBarUsageLimiter.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingBarUsageLimiter.swift
@@ -51,6 +51,14 @@ final class FloatingBarUsageLimiter: ObservableObject {
     /// Update cached plan directly from an already-fetched subscription (no extra API call).
     func applyPlan(plan: SubscriptionPlanType, status: SubscriptionStatusType) {
         hasPaidPlan = plan != .basic && status == .active
+        // A verified active subscription is authoritative over a stale
+        // trial/usage flag. Neo uses the Free Desktop floor for non-premium
+        // features, but it is still paid and must never remain blocked from
+        // audio capture while the app waits for another trial-metadata poll.
+        if hasPaidPlan {
+            AppState.current?.isPaywalled = false
+            UserDefaults.standard.set(false, forKey: .desktopIsPaywalled)
+        }
         if hasPaidPlan, serverQuota?.planType == SubscriptionPlanType.basic.rawValue {
             serverQuota = nil
             optimisticDelta = 0

--- a/desktop/macos/Desktop/Tests/NeoDesktopPaywallTests.swift
+++ b/desktop/macos/Desktop/Tests/NeoDesktopPaywallTests.swift
@@ -1,0 +1,28 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// Active Neo is paid even when its non-premium Desktop capabilities use the
+/// Free-tier floor. It must clear a stale trial flag before audio admission.
+@MainActor
+final class NeoDesktopPaywallTests: XCTestCase {
+  private let paywallKey = "desktop_isPaywalled"
+
+  override func tearDown() {
+    UserDefaults.standard.removeObject(forKey: paywallKey)
+    super.tearDown()
+  }
+
+  func testActiveNeoClearsStickyPaywallBeforeAudioStartAdmission() {
+    let state = AppState()
+    state.isPaywalled = true
+    XCTAssertTrue(state.blockIfPaywalled(), "setup: stale paywall blocks audio admission")
+
+    let limiter = FloatingBarUsageLimiter()
+    limiter.applyPlan(plan: .unlimited, status: .active)
+
+    XCTAssertFalse(state.isPaywalled)
+    XCTAssertFalse(UserDefaults.standard.bool(forKey: paywallKey))
+    XCTAssertFalse(state.blockIfPaywalled(), "active Neo must pass the audio-start paywall guard")
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260710-neo-desktop-free-floor.json
+++ b/desktop/macos/changelog/unreleased/20260710-neo-desktop-free-floor.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed Neo subscribers being blocked from Desktop audio by stale trial paywall state"
+}

--- a/desktop/macos/e2e/flows/audio-recording.yaml
+++ b/desktop/macos/e2e/flows/audio-recording.yaml
@@ -8,6 +8,7 @@ covers:
   - desktop/Desktop/Sources/AudioCaptureService.swift
   - desktop/Desktop/Sources/Audio/AudioSourceManager.swift
   - desktop/Desktop/Sources/AppState.swift
+  - desktop/macos/Desktop/Sources/FloatingControlBar/FloatingBarUsageLimiter.swift
 preconditions:
   - auth_ready
 


### PR DESCRIPTION
## Summary

- resolve an effective Desktop tier so Neo retains the Free-tier usability floor while Operator and Architect keep their premium tiers
- exempt active Neo from every Desktop account-age trial paywall path and heal stale positive Redis paywall entries immediately
- clear stale macOS paywall state as soon as the billing API confirms any active paid plan, including Neo
- correct Neo plan copy and add backend/macOS regressions for audio admission

Closes #9416.

## Product invariants affected

- INV-CHAT-1: the shared floating-bar usage limiter only clears a stale capture paywall after a verified billing response; it does not add a transcript, session, or chat-state store.

## Verification

- `cd backend && bash test.sh`
- `cd backend && ./.venv/bin/pytest -q tests/unit/test_trial_metadata.py tests/unit/test_neo_desktop_grandfather.py tests/unit/test_lazy_conversation_processing.py tests/unit/test_subscription_restructure.py` — 91 passed
- `cd backend && ./.venv/bin/python scripts/scan_import_time_side_effects.py`
- `cd backend && ./.venv/bin/python scripts/scan_async_blockers.py --dirs routers utils`
- `cd backend && ./.venv/bin/python scripts/check_module_stub_pollution.py`
- `cd desktop/macos && xcrun swift test --package-path Desktop`
- Built, signed, and launched the isolated `omi-neo-desktop-free-floor` bundle with the local automation bridge; exercised its transcription-toggle entry point.

## Follow-up validation

This Mac has no signed-in active Neo test account, so the required deployed-backend smoke must still be performed against both stable and beta with an active Neo subscription before closing the issue.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9418?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

