### PR TITLE
fix(desktop): restore local agent routing and yolo dev

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -202,7 +202,7 @@ The desktop app is a **Swift Package Manager** project (no Xcode project, no `.x
 #### Building & Running
 
 - `cd desktop/macos && ./run.sh` — full local dev (build Swift app + Rust backend + Cloudflare tunnel + launch).
-- `cd desktop/macos && ./run.sh --yolo` — quick start against the prod backend, no local services.
+- `cd desktop/macos && ./run.sh --yolo` — quick start against the dev backend, no local services.
 - `OMI_SKIP_BACKEND=1` — app only, use remote backend via `OMI_DESKTOP_API_URL`. `OMI_SKIP_TUNNEL=1` — no Cloudflare tunnel.
 - **Parallel worktrees auto-isolate.** `scripts/dev-instance.sh` derives a unique instance from each linked git worktree, so `run.sh` (and `backend/scripts/dev-serve.sh`) pick per-worktree ports (Rust 10201+, Python 8080+, automation 47777+) and bundle name (`omi-<worktree>`). Kills are pidfile-scoped (never the global `omi-desktop-backend` name), and a taken port fails loud instead of clobbering. The primary checkout is unchanged (`Omi Dev`, 10201/8080/47777). Override any of `OMI_INSTANCE` / `PORT` / `PYTHON_PORT` / `OMI_AUTOMATION_PORT` / `OMI_APP_NAME` to opt out.
 - **`run.sh` build lock is per-worktree, launch-phase only.** It serializes same-checkout builds that share `Desktop/.build/` + `build/$APP_NAME.app`, holds through install/seed/`open`, then releases before the long-running backend wait — never a per-user global mutex. Cross-worktree `./run.sh` must not block each other. Do not point two worktrees at the same explicit `OMI_APP_NAME` (shared `/Applications` path is not cross-locked).

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
@@ -33,6 +33,26 @@ extension Notification.Name {
   static let coreAudioCaptureRecoveryRequested = Notification.Name("coreAudioCaptureRecoveryRequested")
 }
 
+/// Consumes the one transition that hands a buffered PTT turn from a warming
+/// realtime hub to an active hub. Recording the new route before returning is
+/// critical: beginning the hub turn can synchronously publish another voice-turn
+/// snapshot, which must not resolve the same warm wait again.
+struct RealtimeHubWarmWaitResolutionGate {
+  private(set) var route: VoiceTurnRoute?
+
+  mutating func observe(_ nextRoute: VoiceTurnRoute?) -> Bool {
+    let wasWaitingForHub = route == .hubWarmWait
+    route = nextRoute
+    guard wasWaitingForHub else { return false }
+    if case .hub = nextRoute { return true }
+    return false
+  }
+
+  var isWaitingForHub: Bool {
+    route == .hubWarmWait
+  }
+}
+
 /// Push-to-talk manager for voice input via the Option (⌥) key.
 ///
 /// State machine:
@@ -57,7 +77,7 @@ class PushToTalkManager: ObservableObject {
   private let voiceTurnCoordinator = VoiceTurnCoordinator.shared
   private var currentVoiceTurnID: VoiceTurnID?
   private var finalizationTurnID: VoiceTurnID?
-  private var lastCoordinatorRoute: VoiceTurnRoute?
+  private var hubWarmWaitResolutionGate = RealtimeHubWarmWaitResolutionGate()
 
   // MARK: - Private Properties
 
@@ -216,11 +236,8 @@ class PushToTalkManager: ObservableObject {
       state = nextState
     }
 
-    let route = model.turn?.route
-    defer { lastCoordinatorRoute = route }
-    guard lastCoordinatorRoute == .hubWarmWait else { return }
-    if case .hub = route {
-      resolveRealtimeHubWarmWait(ready: true)
+    if hubWarmWaitResolutionGate.observe(model.turn?.route) {
+      resolveRealtimeHubWarmWait(ready: true, consumedReadyTransition: true)
     }
   }
 
@@ -1346,8 +1363,8 @@ class PushToTalkManager: ObservableObject {
     // with a typed session ID; expiry emits fallbackToTranscription.
   }
 
-  private func resolveRealtimeHubWarmWait(ready: Bool) {
-    guard lastCoordinatorRoute == .hubWarmWait else { return }
+  private func resolveRealtimeHubWarmWait(ready: Bool, consumedReadyTransition: Bool = false) {
+    guard consumedReadyTransition || hubWarmWaitResolutionGate.isWaitingForHub else { return }
     guard state == .listening || state == .lockedListening || state == .pendingLockDecision || state == .finalizing else {
       return
     }

--- a/desktop/macos/Desktop/Tests/VoiceTurnCoordinatorTests.swift
+++ b/desktop/macos/Desktop/Tests/VoiceTurnCoordinatorTests.swift
@@ -138,6 +138,32 @@ final class VoiceTurnCoordinatorTests: XCTestCase {
     XCTAssertEqual(snapshots.count, 3)
   }
 
+  func testHubReadyTransitionIsConsumedBeforeReentrantSnapshot() {
+    let coordinator = VoiceTurnCoordinator(scheduler: ManualVoiceTurnScheduler())
+    let sessionID = VoiceSessionID()
+    var gate = RealtimeHubWarmWaitResolutionGate()
+    var resolutions = 0
+    coordinator.setSnapshotHandler { model in
+      guard gate.observe(model.turn?.route) else { return }
+      resolutions += 1
+      guard let turnID = coordinator.activeTurnID else {
+        XCTFail("hub-ready transition must retain its active turn")
+        return
+      }
+      // RealtimeHubController.beginTurn clears its response glow synchronously,
+      // which publishes another snapshot. The consumed transition must not run
+      // the warm-wait resolver again.
+      coordinator.send(.responseActiveChanged(turnID: turnID, active: false))
+    }
+
+    let turnID = coordinator.begin(intent: .hold)
+    coordinator.send(.selectRoute(turnID: turnID, route: .hubWarmWait))
+    coordinator.send(.hubReady(turnID: turnID, sessionID: sessionID))
+
+    XCTAssertEqual(resolutions, 1)
+    XCTAssertEqual(gate.route, .hub(sessionID: sessionID))
+  }
+
   func testResetCancelsOutstandingDeadlinesAndReturnsPresentationToIdle() {
     let scheduler = ManualVoiceTurnScheduler()
     let coordinator = VoiceTurnCoordinator(scheduler: scheduler)

--- a/desktop/macos/README.md
+++ b/desktop/macos/README.md
@@ -23,9 +23,11 @@ Requires macOS 14.0+, Rust toolchain, and code signing with an Apple Developer I
 # Run an isolated named bundle for parallel testing
 OMI_APP_NAME="omi-subagent-test" ./run.sh
 
-# Run with the prod backend (skips local Rust + tunnel)
+# Run with the dev backend (skips local Rust + tunnel)
 ./run.sh --yolo
 ```
+
+`--yolo` targets the deployed development services. Those services currently use production Firebase identities and data stores, so use a named `omi-*` bundle for isolated desktop state and avoid treating it as an offline data sandbox.
 
 `run.sh` auto-detects an `Apple Development` or `Developer ID Application` signing identity from your login keychain. Override with `OMI_SIGN_IDENTITY="..." ./run.sh`.
 

--- a/desktop/macos/agent/src/runtime/control-tools.ts
+++ b/desktop/macos/agent/src/runtime/control-tools.ts
@@ -2,7 +2,16 @@ import { createHash, randomUUID } from "node:crypto";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { z } from "zod";
-import type { AgentArtifact, AgentDelegation, AgentEvent, AgentRun, AgentSession, AdapterBinding, RunAttempt } from "./types.js";
+import { isProductionAdapterId } from "../adapters/interface.js";
+import type {
+  AgentArtifact,
+  AgentDelegation,
+  AgentEvent,
+  AgentRun,
+  AgentSession,
+  AdapterBinding,
+  RunAttempt,
+} from "./types.js";
 import { AgentRuntimeKernel, type DesktopAwarenessSnapshot, type ExecuteAgentRunInput } from "./kernel.js";
 import { serializeArtifact } from "./artifact-serialization.js";
 import { agentControlCapabilityManifest, agentControlInputSchema } from "./control-tool-manifest.js";
@@ -296,7 +305,15 @@ const setDesktopAttentionOverrideSchema = strictObject({
 });
 
 const evidenceRefSchema = strictObject({
-  kind: z.enum(["conversation", "memory_item", "workstream_event", "artifact", "chat_message", "local_screen", "external"]),
+  kind: z.enum([
+    "conversation",
+    "memory_item",
+    "workstream_event",
+    "artifact",
+    "chat_message",
+    "local_screen",
+    "external",
+  ]),
   id: z.string().min(1),
   version: z.string().min(1).optional(),
   scope: z.enum(["canonical", "device_local"]),
@@ -315,28 +332,39 @@ const prepareWorkstreamContinuitySchema = strictObject({
     contextSummary: z.string().max(4_000),
     evidenceRefs: z.array(evidenceRefSchema).max(50).default([]),
     updatedAtMs: z.coerce.number().int().positive(),
-  }).nullable().optional(),
+  })
+    .nullable()
+    .optional(),
 });
 
 const persistWorkstreamContinuitySchema = strictObject({
   ownerId: z.string().min(1).optional(),
   workstreamId: z.string().min(1),
   context: z.record(z.string(), z.unknown()),
-  artifacts: z.array(strictObject({
-    logicalKey: z.string().min(1).max(256),
-    evidenceRefs: z.array(evidenceRefSchema).min(1).max(20),
-    kind: z.string().min(1),
-    role: z.enum(["input", "result", "checkpoint", "tool_output", "log", "other"]),
-    uri: z.string().min(1),
-    displayName: z.string().nullable().optional(),
-    mimeType: z.string().nullable().optional(),
-    contentHash: z.string().nullable().optional(),
-    sizeBytes: z.coerce.number().int().nonnegative().nullable().optional(),
-    runId: z.string().nullable().optional(),
-    attemptId: z.string().nullable().optional(),
-    sourceArtifactId: z.string().min(1),
-  })).max(50),
-  ttlMs: z.coerce.number().int().positive().max(7 * 24 * 60 * 60 * 1_000).default(7 * 24 * 60 * 60 * 1_000),
+  artifacts: z
+    .array(
+      strictObject({
+        logicalKey: z.string().min(1).max(256),
+        evidenceRefs: z.array(evidenceRefSchema).min(1).max(20),
+        kind: z.string().min(1),
+        role: z.enum(["input", "result", "checkpoint", "tool_output", "log", "other"]),
+        uri: z.string().min(1),
+        displayName: z.string().nullable().optional(),
+        mimeType: z.string().nullable().optional(),
+        contentHash: z.string().nullable().optional(),
+        sizeBytes: z.coerce.number().int().nonnegative().nullable().optional(),
+        runId: z.string().nullable().optional(),
+        attemptId: z.string().nullable().optional(),
+        sourceArtifactId: z.string().min(1),
+      }),
+    )
+    .max(50),
+  ttlMs: z.coerce
+    .number()
+    .int()
+    .positive()
+    .max(7 * 24 * 60 * 60 * 1_000)
+    .default(7 * 24 * 60 * 60 * 1_000),
 });
 
 const persistPreparedWorkstreamArtifactSchema = strictObject({
@@ -400,7 +428,9 @@ export const INTERNAL_AGENT_CONTROL_TOOL_NAMES = [
   "project_workstream_continuity",
 ] as const satisfies readonly AgentControlToolName[];
 
-export const AGENT_CONTROL_TOOL_NAMES = agentControlCapabilityManifest.map((tool) => tool.name) as AgentControlToolName[];
+export const AGENT_CONTROL_TOOL_NAMES = agentControlCapabilityManifest.map(
+  (tool) => tool.name,
+) as AgentControlToolName[];
 
 /** App-callable tools advertised to Swift; internal continuity RPCs stay out of model manifests. */
 export const SWIFT_ADVERTISED_AGENT_CONTROL_TOOL_NAMES = [
@@ -438,14 +468,12 @@ export interface AgentControlToolContext {
   canSpawnAgents?: boolean;
   trustedUserControl?: boolean;
   getOwnerId?: () => string;
-  recoverRunInput?: (
-    adapterId: string,
-  ) => Pick<ExecuteAgentRunInput, "maxAttempts" | "recoverAfterError">;
+  recoverRunInput?: (adapterId: string) => Pick<ExecuteAgentRunInput, "maxAttempts" | "recoverAfterError">;
   buildMcpServers?: (
     mode: "ask" | "act",
     cwd: string | undefined,
     sessionKey: string | undefined,
-    context: McpServerBuildContext
+    context: McpServerBuildContext,
   ) => Record<string, unknown>[];
 }
 
@@ -472,6 +500,58 @@ function assertAdapterAllowedForControlRun(context: AgentControlToolContext, ada
   });
 }
 
+/**
+ * A signed desktop action, or the explicit `provider` selector on the canonical
+ * top-level spawn_agent tool, may start a new local-provider session. The
+ * active bridge can still be pi-mono because it is only carrying the control
+ * RPC; it is not the owner of the new session's credentials.
+ *
+ * An adapterId alone does not get this exception, and neither does any
+ * parent-linked delegation. Those must stay inside the caller's persisted
+ * provider boundary.
+ */
+function assertAdapterAllowedForTopLevelLocalProviderSpawn(
+  context: AgentControlToolContext,
+  adapterId: string,
+  directedProvider?: "hermes" | "openclaw",
+): void {
+  const hasDirectedLocalProvider = directedProvider === adapterId;
+  if (!context.trustedUserControl && !hasDirectedLocalProvider) {
+    assertAdapterAllowedForControlRun(context, adapterId);
+    return;
+  }
+  if (!isProductionAdapterId(adapterId)) {
+    throw new Error(`Unknown production adapter: ${adapterId}`);
+  }
+  resolveAdapterWithinBoundary({
+    providerBoundary: providerBoundaryForAdapter(adapterId),
+    defaultAdapterId: adapterId,
+    requestedAdapterId: adapterId,
+  });
+}
+
+/**
+ * Signed direct control resumes the target session's persisted boundary. This
+ * keeps a user-selected Hermes/OpenClaw pill usable while the coordinator
+ * bridge itself is using Omi cloud routing, and still prevents adapter changes
+ * on either local or managed sessions.
+ */
+function assertAdapterAllowedForDirectSessionContinuation(
+  context: AgentControlToolContext,
+  adapterId: string,
+  targetPolicy: Pick<AgentSession, "providerBoundary" | "defaultAdapterId">,
+): void {
+  if (!context.trustedUserControl) {
+    assertAdapterAllowedForControlRun(context, adapterId);
+    return;
+  }
+  resolveAdapterWithinBoundary({
+    providerBoundary: targetPolicy.providerBoundary,
+    defaultAdapterId: targetPolicy.defaultAdapterId,
+    requestedAdapterId: adapterId,
+  });
+}
+
 function assertAgentSpawningAllowed(context: AgentControlToolContext): void {
   if (context.executionRole === "leaf" || context.canSpawnAgents === false) {
     throw new Error("Background agents are leaf workers and cannot start additional agents.");
@@ -489,9 +569,10 @@ function assertLeafControlToolsAllowed(context: AgentControlToolContext, name: s
   }
 }
 
-function backgroundSpawnAuthority(
-  context: AgentControlToolContext,
-): { callerSessionId?: string; trustedUserSpawn?: boolean } {
+function backgroundSpawnAuthority(context: AgentControlToolContext): {
+  callerSessionId?: string;
+  trustedUserSpawn?: boolean;
+} {
   if (context.callerSessionId) {
     return { callerSessionId: context.callerSessionId };
   }
@@ -566,9 +647,10 @@ export function resolveControlRequestContext(input: ControlRequestContextInput):
   if (input.requireActiveOwner && (!activeContextOwnerId || activeContextOwnerId === DEFAULT_LOCAL_OWNER_ID)) {
     throw new Error("missing active control owner");
   }
-  const activeOwnerId = activeContextOwnerId && activeContextOwnerId !== DEFAULT_LOCAL_OWNER_ID
-    ? activeContextOwnerId
-    : ownerGuard || activeContextOwnerId || DEFAULT_LOCAL_OWNER_ID;
+  const activeOwnerId =
+    activeContextOwnerId && activeContextOwnerId !== DEFAULT_LOCAL_OWNER_ID
+      ? activeContextOwnerId
+      : ownerGuard || activeContextOwnerId || DEFAULT_LOCAL_OWNER_ID;
   if (ownerGuard && ownerGuard !== activeOwnerId) {
     throw new Error("ownerId does not match active control owner");
   }
@@ -589,7 +671,7 @@ export function withDefaultOwnerGuard(input: Record<string, unknown>, ownerGuard
 export function withMergedOwnerGuard(
   input: Record<string, unknown>,
   ownerGuard: string | undefined,
-  defaultOwnerGuard: string
+  defaultOwnerGuard: string,
 ): Record<string, unknown> {
   if (!ownerGuard) {
     return withDefaultOwnerGuard(input, defaultOwnerGuard);
@@ -611,10 +693,16 @@ export function isAgentControlToolName(name: string): name is AgentControlToolNa
 export async function handleAgentControlToolCall(
   context: AgentControlToolContext,
   name: string,
-  input: Record<string, unknown>
+  input: Record<string, unknown>,
 ): Promise<string> {
   if (!isAgentControlToolName(name)) {
-    return JSON.stringify({ ok: false, error: { code: "unknown_control_tool", message: `Unknown control tool: ${name}` } });
+    return JSON.stringify({
+      ok: false,
+      error: {
+        code: "unknown_control_tool",
+        message: `Unknown control tool: ${name}`,
+      },
+    });
   }
   if (name === "resolve_desktop_dispatch" && !context.trustedUserControl) {
     return JSON.stringify({
@@ -653,7 +741,9 @@ export async function handleAgentControlToolCall(
           ...parsed,
           ownerId: effectiveControlToolOwnerId(context, parsed.ownerId),
         });
-        return stringifyToolResult({ snapshot: serializeAwarenessSnapshot(snapshot) });
+        return stringifyToolResult({
+          snapshot: serializeAwarenessSnapshot(snapshot),
+        });
       }
       case "list_desktop_action_queue": {
         const parsed = agentControlToolSchemas.list_desktop_action_queue.parse(input);
@@ -741,8 +831,15 @@ export async function handleAgentControlToolCall(
       case "cancel_agent_run": {
         const parsed = agentControlToolSchemas.cancel_agent_run.parse(input);
         const ownerId = effectiveControlToolOwnerId(context, parsed.ownerId);
-        const cancellation = await context.kernel.cancelRun(parsed.runId, { ownerId });
-        const details = context.kernel.getRun({ runId: parsed.runId, ownerId, includeEvents: true, eventLimit: 100 });
+        const cancellation = await context.kernel.cancelRun(parsed.runId, {
+          ownerId,
+        });
+        const details = context.kernel.getRun({
+          runId: parsed.runId,
+          ownerId,
+          includeEvents: true,
+          eventLimit: 100,
+        });
         return stringifyToolResult({
           cancellation,
           run: serializeRun(details.run),
@@ -755,7 +852,9 @@ export async function handleAgentControlToolCall(
           ...parsed,
           ownerId: effectiveControlToolOwnerId(context, parsed.ownerId),
         });
-        return stringifyToolResult({ artifacts: artifacts.map(serializeArtifact) });
+        return stringifyToolResult({
+          artifacts: artifacts.map(serializeArtifact),
+        });
       }
       case "update_agent_artifact_lifecycle": {
         const parsed = agentControlToolSchemas.update_agent_artifact_lifecycle.parse(input);
@@ -773,7 +872,7 @@ export async function handleAgentControlToolCall(
         const parsed = agentControlToolSchemas.send_agent_message.parse(input);
         const targetPolicy = context.kernel.executionPolicyForSession(parsed.sessionId);
         const adapterId = parsed.adapterId ?? targetPolicy.defaultAdapterId;
-        assertAdapterAllowedForControlRun(context, adapterId);
+        assertAdapterAllowedForDirectSessionContinuation(context, adapterId, targetPolicy);
         rejectSynchronousNestedRun(context, adapterId, parsed.sessionId);
         const ownerId = effectiveControlToolOwnerId(context, parsed.ownerId);
         const requestId = parsed.requestId ?? `send-${Date.now()}-${Math.random().toString(16).slice(2)}`;
@@ -810,7 +909,7 @@ export async function handleAgentControlToolCall(
         const ownerId = effectiveControlToolOwnerId(context, parsed.ownerId);
         const requestId = parsed.requestId ?? `background-${Date.now()}-${Math.random().toString(16).slice(2)}`;
         const adapterId = parsed.adapterId ?? parsed.defaultAdapterId ?? defaultControlAdapterId(context);
-        assertAdapterAllowedForControlRun(context, adapterId);
+        assertAdapterAllowedForTopLevelLocalProviderSpawn(context, adapterId);
         const result = await context.kernel.spawnBackgroundAgent({
           ...parsed,
           ...controlRunRecovery(context, adapterId),
@@ -846,16 +945,21 @@ export async function handleAgentControlToolCall(
         }
         const ownerId = effectiveControlToolOwnerId(context, parsed.ownerId);
         const requestId = parsed.requestId ?? `spawn-agent-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+        if (parsed.provider && parsed.adapterId && parsed.provider !== parsed.adapterId) {
+          throw new Error("provider and adapterId must match when both are supplied");
+        }
         const adapterId =
           parsed.adapterId ??
           (parsed.provider === "openclaw" ? "openclaw" : parsed.provider === "hermes" ? "hermes" : undefined) ??
           (parsed.parentRunId
             ? context.kernel.defaultAdapterIdForRun(parsed.parentRunId)
             : defaultControlAdapterId(context));
-        assertAdapterAllowedForControlRun(context, adapterId);
-        const visiblePillExternalRefId = parsed.visible
-          ? (parsed.externalRefId ?? randomUUID())
-          : parsed.externalRefId;
+        if (parsed.parentRunId) {
+          assertAdapterAllowedForControlRun(context, adapterId);
+        } else {
+          assertAdapterAllowedForTopLevelLocalProviderSpawn(context, adapterId, parsed.provider);
+        }
+        const visiblePillExternalRefId = parsed.visible ? (parsed.externalRefId ?? randomUUID()) : parsed.externalRefId;
         const childSurfaceKind = parsed.visible ? "floating_bar" : "delegated_agent";
         const childExternalRefKind = parsed.visible ? "pill" : undefined;
         const mcpServers = buildControlRunMcpServers(context, {
@@ -997,7 +1101,10 @@ export async function handleAgentControlToolCall(
         const ownerId = effectiveControlToolOwnerId(context, parsed.ownerId);
         const migration = context.kernel.migrateTaskSessionsToWorkstreams({
           ownerId,
-          mappings: parsed.taskIds.map((taskId) => ({ taskId, workstreamId: parsed.workstreamId })),
+          mappings: parsed.taskIds.map((taskId) => ({
+            taskId,
+            workstreamId: parsed.workstreamId,
+          })),
         });
         let importedSession = null;
         if (parsed.checkpoint) {
@@ -1026,27 +1133,35 @@ export async function handleAgentControlToolCall(
           };
           importedSession = context.kernel.importWorkstreamContinuationCheckpoint(checkpoint);
         }
-        const session = context.kernel.resolveWorkstreamSession({ ownerId, workstreamId: parsed.workstreamId });
-        const summary = context.kernel.listSessions({ ownerId, surfaceKind: "workstream", limit: 200 })
+        const session = context.kernel.resolveWorkstreamSession({
+          ownerId,
+          workstreamId: parsed.workstreamId,
+        });
+        const summary = context.kernel
+          .listSessions({ ownerId, surfaceKind: "workstream", limit: 200 })
           .find((candidate) => candidate.session.sessionId === session.agentSessionId);
         const run = summary?.activeRun ?? summary?.latestRun ?? null;
         return stringifyToolResult({
           migration,
           importedSession,
           session,
-          run: run ? {
-            runId: run.runId,
-            status: run.status,
-            statusText: run.finalText,
-            errorMessage: run.errorMessage,
-            updatedAtMs: run.updatedAtMs,
-            completedAtMs: run.completedAtMs,
-          } : null,
-          deliveries: context.kernel.listArtifactDeliveries({
-            ownerId,
-            targetRef: parsed.workstreamId,
-            statuses: ["pending", "failed", "retrying"],
-          }).map(serializeContinuityDelivery),
+          run: run
+            ? {
+                runId: run.runId,
+                status: run.status,
+                statusText: run.finalText,
+                errorMessage: run.errorMessage,
+                updatedAtMs: run.updatedAtMs,
+                completedAtMs: run.completedAtMs,
+              }
+            : null,
+          deliveries: context.kernel
+            .listArtifactDeliveries({
+              ownerId,
+              targetRef: parsed.workstreamId,
+              statuses: ["pending", "failed", "retrying"],
+            })
+            .map(serializeContinuityDelivery),
         });
       }
       case "persist_workstream_continuity": {
@@ -1058,25 +1173,27 @@ export async function handleAgentControlToolCall(
           objective: "Continue canonical workstream",
           context: parsed.context as unknown as WorkstreamProductContext,
         });
-        const artifactVersions = parsed.artifacts.map((artifact) => context.kernel.persistWorkstreamArtifactVersion({
-          ownerId,
-          workstreamId: parsed.workstreamId,
-          logicalKey: artifact.logicalKey,
-          evidenceRefs: artifact.evidenceRefs as EvidenceRef[],
-          sourceArtifactId: artifact.sourceArtifactId,
-          artifact: {
-            kind: artifact.kind,
-            role: artifact.role,
-            uri: artifact.uri,
-            displayName: artifact.displayName ?? null,
-            mimeType: artifact.mimeType ?? null,
-            contentHash: artifact.contentHash ?? null,
-            sizeBytes: artifact.sizeBytes ?? null,
-            runId: artifact.runId ?? null,
-            attemptId: artifact.attemptId ?? null,
-            metadataJson: "{}",
-          },
-        }));
+        const artifactVersions = parsed.artifacts.map((artifact) =>
+          context.kernel.persistWorkstreamArtifactVersion({
+            ownerId,
+            workstreamId: parsed.workstreamId,
+            logicalKey: artifact.logicalKey,
+            evidenceRefs: artifact.evidenceRefs as EvidenceRef[],
+            sourceArtifactId: artifact.sourceArtifactId,
+            artifact: {
+              kind: artifact.kind,
+              role: artifact.role,
+              uri: artifact.uri,
+              displayName: artifact.displayName ?? null,
+              mimeType: artifact.mimeType ?? null,
+              contentHash: artifact.contentHash ?? null,
+              sizeBytes: artifact.sizeBytes ?? null,
+              runId: artifact.runId ?? null,
+              attemptId: artifact.attemptId ?? null,
+              metadataJson: "{}",
+            },
+          }),
+        );
         const checkpoint = context.kernel.exportWorkstreamContinuationCheckpoint({
           ownerId,
           workstreamId: parsed.workstreamId,
@@ -1101,10 +1218,12 @@ export async function handleAgentControlToolCall(
             targetRef: parsed.workstreamId,
             contentHash,
             deliveryStatus: contentHash ? "pending" : "cancelled",
-            errorJson: contentHash ? null : JSON.stringify({
-              code: "local_only_artifact",
-              message: "Artifact has no content hash and is not a readable local file",
-            }),
+            errorJson: contentHash
+              ? null
+              : JSON.stringify({
+                  code: "local_only_artifact",
+                  message: "Artifact has no content hash and is not a readable local file",
+                }),
             receiptJson: JSON.stringify({
               kind: "artifact_descriptor",
               sourceArtifactId: parsed.artifacts[index]!.sourceArtifactId,
@@ -1120,12 +1239,19 @@ export async function handleAgentControlToolCall(
         const checkpointArtifactId = `artifact_${checkpoint.checkpointId}`;
         let checkpointArtifact;
         try {
-          checkpointArtifact = context.kernel.inspectArtifacts({ artifactId: checkpointArtifactId, ownerId, limit: 1 })[0];
+          checkpointArtifact = context.kernel.inspectArtifacts({
+            artifactId: checkpointArtifactId,
+            ownerId,
+            limit: 1,
+          })[0];
         } catch {
           checkpointArtifact = undefined;
         }
         if (!checkpointArtifact) {
-          const session = context.kernel.resolveWorkstreamSession({ ownerId, workstreamId: parsed.workstreamId });
+          const session = context.kernel.resolveWorkstreamSession({
+            ownerId,
+            workstreamId: parsed.workstreamId,
+          });
           checkpointArtifact = context.kernel.persistArtifact({
             artifactId: checkpointArtifactId,
             sessionId: session.agentSessionId,
@@ -1144,7 +1270,10 @@ export async function handleAgentControlToolCall(
           intendedSurface: "canonical_workstream",
           targetKind: "task_chat",
           targetRef: parsed.workstreamId,
-          receiptJson: JSON.stringify({ kind: "continuation_checkpoint", checkpoint }),
+          receiptJson: JSON.stringify({
+            kind: "continuation_checkpoint",
+            checkpoint,
+          }),
         });
         return stringifyToolResult({
           contextPacket: { packetId: contextPacket.packet.packetId },
@@ -1211,15 +1340,17 @@ export async function handleAgentControlToolCall(
             evidenceRefs: version.evidenceRefs,
             artifact: serializeArtifact(version.artifact),
           },
-          deliveries: delivery.deliveryStatus === "delivered" || delivery.deliveryStatus === "cancelled"
-            ? []
-            : [serializeContinuityDelivery(delivery)],
+          deliveries:
+            delivery.deliveryStatus === "delivered" || delivery.deliveryStatus === "cancelled"
+              ? []
+              : [serializeContinuityDelivery(delivery)],
         });
       }
       case "resolve_workstream_continuity_delivery": {
         const parsed = agentControlToolSchemas.resolve_workstream_continuity_delivery.parse(input);
         const ownerId = effectiveControlToolOwnerId(context, parsed.ownerId);
-        const current = context.kernel.listArtifactDeliveries({ ownerId, limit: 500 })
+        const current = context.kernel
+          .listArtifactDeliveries({ ownerId, limit: 500 })
           .find((delivery) => delivery.deliveryId === parsed.deliveryId);
         if (!current) throw new Error(`Unknown continuity delivery ${parsed.deliveryId}`);
         const delivery = context.kernel.updateArtifactDelivery(parsed.deliveryId, {
@@ -1230,7 +1361,9 @@ export async function handleAgentControlToolCall(
           errorJson: parsed.error ? JSON.stringify(parsed.error) : current.errorJson,
           deliveredAtMs: parsed.status === "delivered" ? Date.now() : null,
         });
-        return stringifyToolResult({ delivery: serializeContinuityDelivery(delivery) });
+        return stringifyToolResult({
+          delivery: serializeContinuityDelivery(delivery),
+        });
       }
       case "project_workstream_continuity": {
         const parsed = agentControlToolSchemas.project_workstream_continuity.parse(input);
@@ -1275,7 +1408,7 @@ function buildControlRunMcpServers(
     externalRefId?: string;
     screenContext?: boolean;
     executionRole?: AgentExecutionRole;
-  }
+  },
 ): Record<string, unknown>[] | undefined {
   if (!context.buildMcpServers) {
     return undefined;
@@ -1298,7 +1431,9 @@ function buildControlRunMcpServers(
 
 function assertCanonicalRunId(value: string, fieldName: string): void {
   if (!value.startsWith("run_")) {
-    throw new Error(`${fieldName} must be a canonical Omi run_id starting with "run_"; omit it for a top-level background agent`);
+    throw new Error(
+      `${fieldName} must be a canonical Omi run_id starting with "run_"; omit it for a top-level background agent`,
+    );
   }
 }
 
@@ -1348,7 +1483,7 @@ function rejectSynchronousNestedRun(context: AgentControlToolContext, adapterId:
     !context.kernel.hasExecutionCapacityForAdapter(adapterId)
   ) {
     throw new Error(
-      `Synchronous ${adapterId} control-tool runs are unavailable while that adapter is already executing; use spawn mode or retry after the current run finishes.`
+      `Synchronous ${adapterId} control-tool runs are unavailable while that adapter is already executing; use spawn mode or retry after the current run finishes.`,
     );
   }
 }
@@ -1394,7 +1529,9 @@ function canonicalCheckpointContext(context: WorkstreamProductContext): Workstre
 function hashReadableFileArtifact(uri: string): string | null {
   if (!uri.startsWith("file://")) return null;
   try {
-    return `sha256:${createHash("sha256").update(readFileSync(fileURLToPath(uri))).digest("hex")}`;
+    return `sha256:${createHash("sha256")
+      .update(readFileSync(fileURLToPath(uri)))
+      .digest("hex")}`;
   } catch {
     return null;
   }
@@ -1402,14 +1539,16 @@ function hashReadableFileArtifact(uri: string): string | null {
 
 function serializeAgentSessionsList(
   sessions: Parameters<typeof serializeSessionSummary>[0][],
-  overrides: { subjectKind: string; subjectId: string; dismissedAtMs?: number | null; hiddenUntilMs?: number | null }[],
+  overrides: {
+    subjectKind: string;
+    subjectId: string;
+    dismissedAtMs?: number | null;
+    hiddenUntilMs?: number | null;
+  }[],
 ): Record<string, unknown> {
   const dismissed = new Set(
     overrides
-      .filter(
-        (override) =>
-          override.dismissedAtMs != null || (override.hiddenUntilMs ?? 0) > Date.now(),
-      )
+      .filter((override) => override.dismissedAtMs != null || (override.hiddenUntilMs ?? 0) > Date.now())
       .map((override) => `${override.subjectKind}:${override.subjectId}`),
   );
   const summaries = sessions.map(serializeSessionSummary);

--- a/desktop/macos/agent/tests/control-tools.test.ts
+++ b/desktop/macos/agent/tests/control-tools.test.ts
@@ -62,49 +62,74 @@ describe("agent control tools", () => {
         redactedCanonicalSummary: "Draft ready for review",
         summarySensitivityTier: "low",
         latestEventSequence: 2,
-        selectedEvents: [{
-          eventId: "event-2",
-          type: "conversation",
-          summary: "Deadline moved to Friday",
-          occurredAtMs: 10,
-          evidenceRefs: [
-            { kind: "conversation", id: "conversation-1", scope: "canonical" },
-            { kind: "chat_message", id: "local-turn-1", scope: "device_local", device_id: "test-device" },
-          ],
-          sensitivityTier: "low",
-        }],
+        selectedEvents: [
+          {
+            eventId: "event-2",
+            type: "conversation",
+            summary: "Deadline moved to Friday",
+            occurredAtMs: 10,
+            evidenceRefs: [
+              {
+                kind: "conversation",
+                id: "conversation-1",
+                scope: "canonical",
+              },
+              {
+                kind: "chat_message",
+                id: "local-turn-1",
+                scope: "device_local",
+                device_id: "test-device",
+              },
+            ],
+            sensitivityTier: "low",
+          },
+        ],
         artifactHeads: [],
-        provenance: { snapshotVersion: "workstream:2", fetchedAtMs: 20, source: "canonical_backend" },
+        provenance: {
+          snapshotVersion: "workstream:2",
+          fetchedAtMs: 20,
+          source: "canonical_backend",
+        },
       },
-      artifacts: [{
-        logicalKey: "launch-email",
-        evidenceRefs: [{ kind: "conversation", id: "conversation-1", scope: "canonical" }],
-        kind: "markdown",
-        role: "result",
-        uri: "file:///tmp/launch-email.md",
-        contentHash: "sha256:1234567890abcdef",
-        sourceArtifactId: "source-artifact-1",
-      }, {
-        logicalKey: "provider-reference",
-        evidenceRefs: [{ kind: "conversation", id: "conversation-1", scope: "canonical" }],
-        kind: "provider_reference",
-        role: "result",
-        uri: "adapter://provider/reference-1",
-        sourceArtifactId: "source-artifact-local-only",
-      }],
+      artifacts: [
+        {
+          logicalKey: "launch-email",
+          evidenceRefs: [{ kind: "conversation", id: "conversation-1", scope: "canonical" }],
+          kind: "markdown",
+          role: "result",
+          uri: "file:///tmp/launch-email.md",
+          contentHash: "sha256:1234567890abcdef",
+          sourceArtifactId: "source-artifact-1",
+        },
+        {
+          logicalKey: "provider-reference",
+          evidenceRefs: [{ kind: "conversation", id: "conversation-1", scope: "canonical" }],
+          kind: "provider_reference",
+          role: "result",
+          uri: "adapter://provider/reference-1",
+          sourceArtifactId: "source-artifact-local-only",
+        },
+      ],
     };
     const first = parseToolResult(await handleAgentControlToolCall(context, "persist_workstream_continuity", input));
-    const firstDeliveries = first.deliveries as Array<{ deliveryId: string; payload: { kind: string } }>;
+    const firstDeliveries = first.deliveries as Array<{
+      deliveryId: string;
+      payload: { kind: string };
+    }>;
     const artifactDelivery = firstDeliveries.find((delivery) => delivery.payload.kind === "artifact_descriptor")!;
-    const delivered = parseToolResult(await handleAgentControlToolCall(
-      context,
-      "resolve_workstream_continuity_delivery",
-      { deliveryId: artifactDelivery.deliveryId, status: "delivered", receipt: { artifact_id: "backend-v1" } },
-    ));
+    const delivered = parseToolResult(
+      await handleAgentControlToolCall(context, "resolve_workstream_continuity_delivery", {
+        deliveryId: artifactDelivery.deliveryId,
+        status: "delivered",
+        receipt: { artifact_id: "backend-v1" },
+      }),
+    );
     const replay = parseToolResult(await handleAgentControlToolCall(context, "persist_workstream_continuity", input));
-    const projected = parseToolResult(await handleAgentControlToolCall(context, "project_workstream_continuity", {
-      workstreamId: "workstream-1",
-    }));
+    const projected = parseToolResult(
+      await handleAgentControlToolCall(context, "project_workstream_continuity", {
+        workstreamId: "workstream-1",
+      }),
+    );
     expect(first.ok).toBe(true);
     expect(firstDeliveries.map((delivery) => delivery.payload.kind).sort()).toEqual([
       "artifact_descriptor",
@@ -113,48 +138,53 @@ describe("agent control tools", () => {
     expect((delivered.delivery as { status: string }).status).toBe("delivered");
     expect((first.artifactVersions as Array<{ version: number }>)[0]?.version).toBe(1);
     expect((replay.artifactVersions as Array<{ version: number }>)[0]?.version).toBe(1);
-    expect(((projected.projection as { artifactVersions: unknown[] }).artifactVersions).length).toBe(2);
-    expect((replay.deliveries as Array<{ deliveryId: string }>).some(
-      (delivery) => delivery.deliveryId === artifactDelivery.deliveryId,
-    )).toBe(false);
+    expect((projected.projection as { artifactVersions: unknown[] }).artifactVersions.length).toBe(2);
+    expect(
+      (replay.deliveries as Array<{ deliveryId: string }>).some(
+        (delivery) => delivery.deliveryId === artifactDelivery.deliveryId,
+      ),
+    ).toBe(false);
     expect((first.checkpoint as { lastEventSequence: number }).lastEventSequence).toBe(2);
     expect((first.checkpoint as { evidenceRefs: Array<{ scope: string }> }).evidenceRefs).toEqual([
       expect.objectContaining({ scope: "canonical" }),
     ]);
     expect(store.getRow("SELECT COUNT(*) AS count FROM workstream_artifact_versions").count).toBe(2);
-    expect(store.getRow(
-      "SELECT COUNT(*) AS count FROM desktop_artifact_deliveries WHERE delivery_status = 'cancelled'",
-    ).count).toBe(1);
+    expect(
+      store.getRow("SELECT COUNT(*) AS count FROM desktop_artifact_deliveries WHERE delivery_status = 'cancelled'")
+        .count,
+    ).toBe(1);
   });
 
   it("persists prepared artifacts only with a scoped live grant and without replacing context", async () => {
     const { store, kernel } = createKernelHarness(newDatabasePath());
     const context = ownerContext(kernel);
-    const prepared = parseToolResult(await handleAgentControlToolCall(context, "prepare_workstream_continuity", {
-      workstreamId: "workstream-prepared",
-      taskIds: [],
-    }));
+    const prepared = parseToolResult(
+      await handleAgentControlToolCall(context, "prepare_workstream_continuity", {
+        workstreamId: "workstream-prepared",
+        taskIds: [],
+      }),
+    );
     const sessionId = (prepared.session as { agentSessionId: string }).agentSessionId;
     const capability = "desktop.workstream.artifact.prepare";
     const operation = "prepare_artifact";
     const resourceRef = "workstream:workstream-prepared";
     const expiresAtMs = Date.now() + 60_000;
-    const created = parseToolResult(await handleAgentControlToolCall(context, "create_desktop_dispatch", {
-      kind: "approval",
-      priority: 1,
-      title: "Prepare artifact",
-      decisionPrompt: "Allow this prepared artifact?",
-      sourceSessionId: sessionId,
-      capability,
-      operation,
-      resourceRef,
-      expiresAtMs,
-    }));
+    const created = parseToolResult(
+      await handleAgentControlToolCall(context, "create_desktop_dispatch", {
+        kind: "approval",
+        priority: 1,
+        title: "Prepare artifact",
+        decisionPrompt: "Allow this prepared artifact?",
+        sourceSessionId: sessionId,
+        capability,
+        operation,
+        resourceRef,
+        expiresAtMs,
+      }),
+    );
     const dispatchId = (created.dispatch as { dispatchId: string }).dispatchId;
-    const resolved = parseToolResult(await handleAgentControlToolCall(
-      trustedOwnerContext(kernel),
-      "resolve_desktop_dispatch",
-      {
+    const resolved = parseToolResult(
+      await handleAgentControlToolCall(trustedOwnerContext(kernel), "resolve_desktop_dispatch", {
         dispatchId,
         status: "resolved",
         resolution: { decision: "allow" },
@@ -167,18 +197,20 @@ describe("agent control tools", () => {
           source: "user",
           expiresAtMs,
         },
-      },
-    ));
+      }),
+    );
     const grantId = (resolved.grant as { grantId: string }).grantId;
     const input = {
       workstreamId: "workstream-prepared",
       logicalKey: "investor-email",
-      evidenceRefs: [{
-        kind: "local_screen",
-        id: "sha256:evidence",
-        scope: "device_local",
-        device_id: "device-1",
-      }],
+      evidenceRefs: [
+        {
+          kind: "local_screen",
+          id: "sha256:evidence",
+          scope: "device_local",
+          device_id: "device-1",
+        },
+      ],
       kind: "email_draft",
       uri: "file:///tmp/investor-email.artifact",
       contentHash: "sha256:1234567890abcdef",
@@ -188,15 +220,17 @@ describe("agent control tools", () => {
     const persisted = parseToolResult(
       await handleAgentControlToolCall(context, "persist_prepared_workstream_artifact", input),
     );
-    const rejected = parseToolResult(await handleAgentControlToolCall(
-      context,
-      "persist_prepared_workstream_artifact",
-      { ...input, sourceArtifactId: "prepared-source-2", grantId: "grant_missing" },
-    ));
+    const rejected = parseToolResult(
+      await handleAgentControlToolCall(context, "persist_prepared_workstream_artifact", {
+        ...input,
+        sourceArtifactId: "prepared-source-2",
+        grantId: "grant_missing",
+      }),
+    );
 
     expect(persisted.ok, JSON.stringify(persisted)).toBe(true);
     expect((persisted.artifactVersion as { version: number }).version).toBe(1);
-    expect((persisted.deliveries as unknown[])).toHaveLength(1);
+    expect(persisted.deliveries as unknown[]).toHaveLength(1);
     expect(rejected.ok).toBe(false);
     expect(store.getRow("SELECT COUNT(*) AS count FROM workstream_continuation_checkpoints").count).toBe(0);
     expect(store.getRow("SELECT COUNT(*) AS count FROM desktop_context_packets").count).toBe(0);
@@ -265,9 +299,11 @@ describe("agent control tools", () => {
     });
 
     expect(parsed.success).toBe(true);
-    expect(agentControlToolSchemas.spawn_background_agent.safeParse({
-      prompt: "",
-    }).success).toBe(false);
+    expect(
+      agentControlToolSchemas.spawn_background_agent.safeParse({
+        prompt: "",
+      }).success,
+    ).toBe(false);
   });
 
   it("declares coordinator policy metadata for every control tool", () => {
@@ -378,30 +414,34 @@ describe("agent control tools", () => {
       status: "waiting_approval",
       mode: "act",
     });
-    const created = parseToolResult(await handleAgentControlToolCall(ownerContext(kernel), "create_desktop_dispatch", {
-      kind: "approval",
-      priority: 100,
-      title: "Approve screenshot",
-      decisionPrompt: "Allow screenshot image bytes?",
-      sourceSessionId: session.sessionId,
-      sourceRunId: run.runId,
-      capability: "desktop.context.screenshot_image",
-      operation: "get_screenshot",
-      resourceRef: "screenshot:42",
-    }));
-
-    const resolved = parseToolResult(await handleAgentControlToolCall(trustedOwnerContext(kernel), "resolve_desktop_dispatch", {
-      dispatchId: created.dispatch.dispatchId,
-      status: "resolved",
-      resolution: { decision: "allow" },
-      grant: {
+    const created = parseToolResult(
+      await handleAgentControlToolCall(ownerContext(kernel), "create_desktop_dispatch", {
+        kind: "approval",
+        priority: 100,
+        title: "Approve screenshot",
+        decisionPrompt: "Allow screenshot image bytes?",
+        sourceSessionId: session.sessionId,
+        sourceRunId: run.runId,
         capability: "desktop.context.screenshot_image",
         operation: "get_screenshot",
-        resourcePattern: "screenshot:42",
-        effect: "allow",
-        expiresAtMs: Date.now() + 60_000,
-      },
-    }));
+        resourceRef: "screenshot:42",
+      }),
+    );
+
+    const resolved = parseToolResult(
+      await handleAgentControlToolCall(trustedOwnerContext(kernel), "resolve_desktop_dispatch", {
+        dispatchId: created.dispatch.dispatchId,
+        status: "resolved",
+        resolution: { decision: "allow" },
+        grant: {
+          capability: "desktop.context.screenshot_image",
+          operation: "get_screenshot",
+          resourcePattern: "screenshot:42",
+          effect: "allow",
+          expiresAtMs: Date.now() + 60_000,
+        },
+      }),
+    );
 
     expect(resolved).toMatchObject({
       ok: true,
@@ -417,7 +457,9 @@ describe("agent control tools", () => {
       },
       event: { type: "approval.resolved" },
     });
-    expect(store.getRow("SELECT COUNT(*) AS count FROM grants WHERE session_id = ?", [session.sessionId]).count).toBe(1);
+    expect(store.getRow("SELECT COUNT(*) AS count FROM grants WHERE session_id = ?", [session.sessionId]).count).toBe(
+      1,
+    );
     expect(store.getRow("SELECT COUNT(*) AS count FROM events WHERE type = ?", ["approval.resolved"]).count).toBe(1);
     store.close();
   });
@@ -441,26 +483,32 @@ describe("agent control tools", () => {
       resourceRef: "screenshot:42",
     });
 
-    const resolved = parseToolResult(await handleAgentControlToolCall(trustedOwnerContext(kernel), "resolve_desktop_dispatch", {
-      dispatchId: dispatch.dispatchId,
-      status: "resolved",
-      resolution: { decision: "allow" },
-      grant: {
-        capability: "desktop.context.local_read",
-        operation: "get_screenshot",
-        resourcePattern: "screenshot:42",
-        effect: "allow",
-        expiresAtMs: Date.now() + 60_000,
-      },
-    }));
+    const resolved = parseToolResult(
+      await handleAgentControlToolCall(trustedOwnerContext(kernel), "resolve_desktop_dispatch", {
+        dispatchId: dispatch.dispatchId,
+        status: "resolved",
+        resolution: { decision: "allow" },
+        grant: {
+          capability: "desktop.context.local_read",
+          operation: "get_screenshot",
+          resourcePattern: "screenshot:42",
+          effect: "allow",
+          expiresAtMs: Date.now() + 60_000,
+        },
+      }),
+    );
 
     expect(resolved).toMatchObject({
       ok: false,
       error: { code: "control_tool_failed" },
     });
     expect(String(resolved.error.message)).toContain("capability must match");
-    expect(store.getRow("SELECT COUNT(*) AS count FROM grants WHERE session_id = ?", [session.sessionId]).count).toBe(0);
-    expect(store.getRow("SELECT status FROM desktop_dispatches WHERE dispatch_id = ?", [dispatch.dispatchId]).status).toBe("pending");
+    expect(store.getRow("SELECT COUNT(*) AS count FROM grants WHERE session_id = ?", [session.sessionId]).count).toBe(
+      0,
+    );
+    expect(
+      store.getRow("SELECT status FROM desktop_dispatches WHERE dispatch_id = ?", [dispatch.dispatchId]).status,
+    ).toBe("pending");
     store.close();
   });
 
@@ -483,26 +531,32 @@ describe("agent control tools", () => {
       resourceRef: "route:1",
     });
 
-    const resolved = parseToolResult(await handleAgentControlToolCall(trustedOwnerContext(kernel), "resolve_desktop_dispatch", {
-      dispatchId: dispatch.dispatchId,
-      status: "resolved",
-      resolution: { decision: "allow" },
-      grant: {
-        capability: "desktop.agent_control.manage",
-        operation: "route_desktop_intent",
-        resourcePattern: "route:1",
-        effect: "allow",
-        expiresAtMs: Date.now() + 60_000,
-      },
-    }));
+    const resolved = parseToolResult(
+      await handleAgentControlToolCall(trustedOwnerContext(kernel), "resolve_desktop_dispatch", {
+        dispatchId: dispatch.dispatchId,
+        status: "resolved",
+        resolution: { decision: "allow" },
+        grant: {
+          capability: "desktop.agent_control.manage",
+          operation: "route_desktop_intent",
+          resourcePattern: "route:1",
+          effect: "allow",
+          expiresAtMs: Date.now() + 60_000,
+        },
+      }),
+    );
 
     expect(resolved).toMatchObject({
       ok: false,
       error: { code: "control_tool_failed" },
     });
     expect(String(resolved.error.message)).toContain("Only approval dispatches");
-    expect(store.getRow("SELECT COUNT(*) AS count FROM grants WHERE session_id = ?", [session.sessionId]).count).toBe(0);
-    expect(store.getRow("SELECT status FROM desktop_dispatches WHERE dispatch_id = ?", [dispatch.dispatchId]).status).toBe("pending");
+    expect(store.getRow("SELECT COUNT(*) AS count FROM grants WHERE session_id = ?", [session.sessionId]).count).toBe(
+      0,
+    );
+    expect(
+      store.getRow("SELECT status FROM desktop_dispatches WHERE dispatch_id = ?", [dispatch.dispatchId]).status,
+    ).toBe("pending");
     store.close();
   });
 
@@ -525,24 +579,28 @@ describe("agent control tools", () => {
       resourceRef: "screenshot:42",
     });
 
-    const resolved = parseToolResult(await handleAgentControlToolCall(ownerContext(kernel), "resolve_desktop_dispatch", {
-      dispatchId: dispatch.dispatchId,
-      status: "resolved",
-      resolution: { decision: "allow" },
-      grant: {
-        capability: "desktop.context.screenshot_image",
-        operation: "get_screenshot",
-        resourcePattern: "screenshot:42",
-        effect: "allow",
-        expiresAtMs: Date.now() + 60_000,
-      },
-    }));
+    const resolved = parseToolResult(
+      await handleAgentControlToolCall(ownerContext(kernel), "resolve_desktop_dispatch", {
+        dispatchId: dispatch.dispatchId,
+        status: "resolved",
+        resolution: { decision: "allow" },
+        grant: {
+          capability: "desktop.context.screenshot_image",
+          operation: "get_screenshot",
+          resourcePattern: "screenshot:42",
+          effect: "allow",
+          expiresAtMs: Date.now() + 60_000,
+        },
+      }),
+    );
 
     expect(resolved).toMatchObject({
       ok: false,
       error: { code: "policy_denied" },
     });
-    expect(store.getRow("SELECT COUNT(*) AS count FROM grants WHERE session_id = ?", [session.sessionId]).count).toBe(0);
+    expect(store.getRow("SELECT COUNT(*) AS count FROM grants WHERE session_id = ?", [session.sessionId]).count).toBe(
+      0,
+    );
     store.close();
   });
 
@@ -559,26 +617,28 @@ describe("agent control tools", () => {
       resourceRef: "screen:current",
     });
 
-    const unapproved = parseToolResult(await handleAgentControlToolCall(ownerContext(kernel), "build_desktop_context_packet", {
-      surfaceKind: "main_chat",
-      objective: "Inspect screen",
-      ttlMs: 60_000,
-      retentionClass: "ephemeral",
-      packetJson: {
-        snippets: [
-          {
-            snippetId: "screen",
-            sourceKind: "screen_current",
-            operation: "get_work_context",
-            provenance: { scope: "current" },
-            content: "Visible app title",
-            sensitivityTier: "sensitive",
-            policyDecision: "dispatch_created",
-            dispatchId: dispatch.dispatchId,
-          },
-        ],
-      },
-    }));
+    const unapproved = parseToolResult(
+      await handleAgentControlToolCall(ownerContext(kernel), "build_desktop_context_packet", {
+        surfaceKind: "main_chat",
+        objective: "Inspect screen",
+        ttlMs: 60_000,
+        retentionClass: "ephemeral",
+        packetJson: {
+          snippets: [
+            {
+              snippetId: "screen",
+              sourceKind: "screen_current",
+              operation: "get_work_context",
+              provenance: { scope: "current" },
+              content: "Visible app title",
+              sensitivityTier: "sensitive",
+              policyDecision: "dispatch_created",
+              dispatchId: dispatch.dispatchId,
+            },
+          ],
+        },
+      }),
+    );
     expect(unapproved).toMatchObject({
       ok: false,
       error: { code: "control_tool_failed" },
@@ -591,26 +651,28 @@ describe("agent control tools", () => {
       resolutionJson: JSON.stringify({ decision: "allow" }),
     });
 
-    const approved = parseToolResult(await handleAgentControlToolCall(ownerContext(kernel), "build_desktop_context_packet", {
-      surfaceKind: "main_chat",
-      objective: "Inspect screen",
-      ttlMs: 60_000,
-      retentionClass: "ephemeral",
-      packetJson: {
-        snippets: [
-          {
-            snippetId: "screen",
-            sourceKind: "screen_current",
-            operation: "get_work_context",
-            provenance: { scope: "current" },
-            content: "Visible app title",
-            sensitivityTier: "sensitive",
-            policyDecision: "dispatch_created",
-            dispatchId: dispatch.dispatchId,
-          },
-        ],
-      },
-    }));
+    const approved = parseToolResult(
+      await handleAgentControlToolCall(ownerContext(kernel), "build_desktop_context_packet", {
+        surfaceKind: "main_chat",
+        objective: "Inspect screen",
+        ttlMs: 60_000,
+        retentionClass: "ephemeral",
+        packetJson: {
+          snippets: [
+            {
+              snippetId: "screen",
+              sourceKind: "screen_current",
+              operation: "get_work_context",
+              provenance: { scope: "current" },
+              content: "Visible app title",
+              sensitivityTier: "sensitive",
+              policyDecision: "dispatch_created",
+              dispatchId: dispatch.dispatchId,
+            },
+          ],
+        },
+      }),
+    );
 
     expect(approved.ok).toBe(true);
     expect(approved.accessLogs[0]).toMatchObject({
@@ -761,11 +823,13 @@ describe("agent control tools", () => {
         clientId: "client-a",
       }),
     ).toThrow("ownerId does not match active control owner");
-    expect(controlRequestKey({ requestId: "request:a", clientId: "client" })).toBe(JSON.stringify(["client", "request:a"]));
-    expect(controlRequestKey({ requestId: "request", clientId: "client:a" })).toBe(JSON.stringify(["client:a", "request"]));
-    expect(controlRequestKey({ requestId: "request", clientId: "client" })).toBe(
-      JSON.stringify(["client", "request"]),
+    expect(controlRequestKey({ requestId: "request:a", clientId: "client" })).toBe(
+      JSON.stringify(["client", "request:a"]),
     );
+    expect(controlRequestKey({ requestId: "request", clientId: "client:a" })).toBe(
+      JSON.stringify(["client:a", "request"]),
+    );
+    expect(controlRequestKey({ requestId: "request", clientId: "client" })).toBe(JSON.stringify(["client", "request"]));
   });
 
   it("rejects direct control envelope owners before active owner context is cached", () => {
@@ -793,7 +857,10 @@ describe("agent control tools", () => {
 
   it("registers signed direct control envelopes when no request owner is active", () => {
     const ownersByRequest = new Map<string, string>();
-    const requestKey = controlRequestKey({ requestId: "realtime-request", clientId: "realtime-hub" });
+    const requestKey = controlRequestKey({
+      requestId: "realtime-request",
+      clientId: "realtime-hub",
+    });
 
     const inserted = registerSignedDirectControlOwner({
       requestKey,
@@ -858,7 +925,9 @@ describe("agent control tools", () => {
       runId: "run-a",
       ownerId: "owner-envelope",
     });
-    expect(withMergedOwnerGuard({ runId: "run-a", ownerId: " owner-envelope " }, "owner-envelope", "owner-active")).toEqual({
+    expect(
+      withMergedOwnerGuard({ runId: "run-a", ownerId: " owner-envelope " }, "owner-envelope", "owner-active"),
+    ).toEqual({
       runId: "run-a",
       ownerId: "owner-envelope",
     });
@@ -869,7 +938,11 @@ describe("agent control tools", () => {
 
   it("keeps concurrent control tool calls scoped to their active request owners", async () => {
     const { store, kernel } = createKernelHarness(newDatabasePath());
-    await kernel.executeRun({ ...baseRunInput, ownerId: "owner-a", requestId: "run-owner-a" });
+    await kernel.executeRun({
+      ...baseRunInput,
+      ownerId: "owner-a",
+      requestId: "run-owner-a",
+    });
     await kernel.executeRun({
       ...baseRunInput,
       ownerId: "owner-b",
@@ -943,13 +1016,18 @@ describe("agent control tools", () => {
         code: "control_tool_failed",
       },
     });
-    expect(result.error.message).toContain("Owner-scoped control tools require active request, run, or attempt context");
+    expect(result.error.message).toContain(
+      "Owner-scoped control tools require active request, run, or attempt context",
+    );
     store.close();
   });
 
   it("rejects run inspection, cancellation, and artifact inspection outside the active owner", async () => {
     const { store, kernel } = createKernelHarness(newDatabasePath());
-    const ownerRun = await kernel.executeRun({ ...baseRunInput, ownerId: "owner-from-context" });
+    const ownerRun = await kernel.executeRun({
+      ...baseRunInput,
+      ownerId: "owner-from-context",
+    });
     const otherRun = await kernel.executeRun({
       ...baseRunInput,
       ownerId: "other-owner",
@@ -1138,7 +1216,10 @@ describe("agent control tools", () => {
       sessionId: result.session.sessionId,
     });
 
-    const events = kernel.getRun({ runId: result.run.runId, includeEvents: true }).events;
+    const events = kernel.getRun({
+      runId: result.run.runId,
+      includeEvents: true,
+    }).events;
     expect(events.find((event: any) => event.type === "artifact.created")).toMatchObject({
       sessionId: result.session.sessionId,
       runId: result.run.runId,
@@ -1242,7 +1323,10 @@ describe("agent control tools", () => {
       "artifact.lifecycle_updated",
       "artifact.lifecycle_updated",
     ]);
-    expect(store.getRow("SELECT lifecycle_state FROM artifacts WHERE artifact_id = ?", [artifact.artifactId]).lifecycle_state).toBe("opened");
+    expect(
+      store.getRow("SELECT lifecycle_state FROM artifacts WHERE artifact_id = ?", [artifact.artifactId])
+        .lifecycle_state,
+    ).toBe("opened");
     store.close();
   });
 
@@ -1270,7 +1354,10 @@ describe("agent control tools", () => {
       uri: "omi-artifact://other-scope",
     });
 
-    const context: AgentControlToolContext = { kernel, getOwnerId: () => "owner" };
+    const context: AgentControlToolContext = {
+      kernel,
+      getOwnerId: () => "owner",
+    };
     const wrongOwner = parseToolResult(
       await handleAgentControlToolCall(context, "update_agent_artifact_lifecycle", {
         artifactId: otherArtifact.artifactId,
@@ -1296,8 +1383,14 @@ describe("agent control tools", () => {
     });
     expect(wrongScope.error.message).toContain("belongs to run");
 
-    expect(store.getRow("SELECT lifecycle_state FROM artifacts WHERE artifact_id = ?", [ownerArtifact.artifactId]).lifecycle_state).toBe("retained");
-    expect(store.getRow("SELECT lifecycle_state FROM artifacts WHERE artifact_id = ?", [otherArtifact.artifactId]).lifecycle_state).toBe("retained");
+    expect(
+      store.getRow("SELECT lifecycle_state FROM artifacts WHERE artifact_id = ?", [ownerArtifact.artifactId])
+        .lifecycle_state,
+    ).toBe("retained");
+    expect(
+      store.getRow("SELECT lifecycle_state FROM artifacts WHERE artifact_id = ?", [otherArtifact.artifactId])
+        .lifecycle_state,
+    ).toBe("retained");
     store.close();
   });
 
@@ -1433,16 +1526,18 @@ describe("agent control tools", () => {
   it("sends a follow-up message as a new run in an existing canonical session", async () => {
     const { store, adapter, kernel } = createKernelHarness(newDatabasePath());
     const first = await kernel.executeRun(baseRunInput);
-    adapter.nextArtifacts = [{
-      kind: "markdown",
-      role: "result",
-      uri: "adapter://fake/follow-up.md",
-      displayName: "follow-up.md",
-      mimeType: "text/markdown",
-      contentHash: "sha256:abc",
-      sizeBytes: 12,
-      metadata: { adapterArtifactId: "follow-up" },
-    }];
+    adapter.nextArtifacts = [
+      {
+        kind: "markdown",
+        role: "result",
+        uri: "adapter://fake/follow-up.md",
+        displayName: "follow-up.md",
+        mimeType: "text/markdown",
+        contentHash: "sha256:abc",
+        sizeBytes: 12,
+        metadata: { adapterArtifactId: "follow-up" },
+      },
+    ];
 
     const sent = parseToolResult(
       await handleAgentControlToolCall(ownerContext(kernel), "send_agent_message", {
@@ -1469,7 +1564,9 @@ describe("agent control tools", () => {
     ]);
     expect(adapter.executed).toHaveLength(2);
     expect(adapter.executed[1].sessionId).toBe(first.session.sessionId);
-    expect(adapter.executed[1].metadata).not.toMatchObject({ disableSwiftBackedTools: true });
+    expect(adapter.executed[1].metadata).not.toMatchObject({
+      disableSwiftBackedTools: true,
+    });
 
     const listed = parseToolResult(
       await handleAgentControlToolCall(ownerContext(kernel), "list_agent_sessions", { ownerId: "owner" }),
@@ -1481,18 +1578,17 @@ describe("agent control tools", () => {
 
   it("defaults send_agent_message to the active control context owner", async () => {
     const { store, adapter, kernel } = createKernelHarness(newDatabasePath());
-    const first = await kernel.executeRun({ ...baseRunInput, ownerId: "owner-from-context" });
+    const first = await kernel.executeRun({
+      ...baseRunInput,
+      ownerId: "owner-from-context",
+    });
 
     const sent = parseToolResult(
-      await handleAgentControlToolCall(
-        { kernel, getOwnerId: () => "owner-from-context" },
-        "send_agent_message",
-        {
-          sessionId: first.session.sessionId,
-          prompt: "follow up",
-          requestId: "request-context-owner",
-        },
-      ),
+      await handleAgentControlToolCall({ kernel, getOwnerId: () => "owner-from-context" }, "send_agent_message", {
+        sessionId: first.session.sessionId,
+        prompt: "follow up",
+        requestId: "request-context-owner",
+      }),
     );
 
     expect(sent.ok).toBe(true);
@@ -1633,7 +1729,8 @@ describe("agent control tools", () => {
     expect(adapter.executed).toHaveLength(3);
 
     adapter.resolveDeferred({
-      text: "done",      adapterSessionId: adapter.executed[1].binding.adapterNativeSessionId,
+      text: "done",
+      adapterSessionId: adapter.executed[1].binding.adapterNativeSessionId,
       terminalStatus: "succeeded",
     });
     await running;
@@ -1694,17 +1791,13 @@ describe("agent control tools", () => {
   it("inherits the managed adapter for background agents instead of local ACP", async () => {
     const { store, adapter, kernel } = createKernelHarness(newDatabasePath(), "pi-mono");
     const spawned = parseToolResult(
-      await handleAgentControlToolCall(
-        { ...ownerContext(kernel), defaultAdapterId: "pi-mono" },
-        "spawn_agent",
-        {
-          objective: "research managed routing",
-          visible: true,
-          requestId: "spawn-managed-routing-1",
-          clientId: "spawn-client",
-          ownerId: "owner",
-        },
-      ),
+      await handleAgentControlToolCall({ ...ownerContext(kernel), defaultAdapterId: "pi-mono" }, "spawn_agent", {
+        objective: "research managed routing",
+        visible: true,
+        requestId: "spawn-managed-routing-1",
+        clientId: "spawn-client",
+        ownerId: "owner",
+      }),
     );
 
     await waitUntil(() => {
@@ -1719,15 +1812,186 @@ describe("agent control tools", () => {
   it("rejects an explicit local ACP override from a managed agent", async () => {
     const { store, kernel } = createKernelHarness(newDatabasePath(), "pi-mono");
     const result = parseToolResult(
+      await handleAgentControlToolCall({ ...ownerContext(kernel), defaultAdapterId: "pi-mono" }, "spawn_agent", {
+        objective: "do not use local credentials",
+        visible: true,
+        adapterId: "acp",
+        requestId: "spawn-managed-local-acp-1",
+        clientId: "spawn-client",
+        ownerId: "owner",
+      }),
+    );
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: {
+        code: "control_tool_failed",
+        message: "Local Claude is available only when the User Claude mode is selected.",
+      },
+    });
+    expect(store.allRows("SELECT * FROM runs")).toHaveLength(0);
+    store.close();
+  });
+
+  it("lets signed desktop control start Hermes and OpenClaw as top-level local sessions", async () => {
+    for (const provider of ["hermes", "openclaw"] as const) {
+      const { store, adapter, kernel } = createKernelHarness(newDatabasePath(), provider);
+      const spawned = parseToolResult(
+        await handleAgentControlToolCall(
+          {
+            ...ownerContext(kernel),
+            defaultAdapterId: "pi-mono",
+            providerBoundary: "managed_cloud",
+            trustedUserControl: true,
+          },
+          "spawn_agent",
+          {
+            objective: `run this with ${provider}`,
+            provider,
+            visible: true,
+            requestId: `direct-${provider}-spawn`,
+            clientId: "desktop-floating-pill",
+            ownerId: "owner",
+          },
+        ),
+      );
+
+      await waitUntil(() => {
+        const row = store.getRow("SELECT status FROM runs WHERE run_id = ?", [spawned.run.runId]);
+        return row.status === "succeeded";
+      });
+      expect(spawned.session).toMatchObject({
+        defaultAdapterId: provider,
+        providerBoundary: `local_user:${provider}`,
+      });
+      expect(adapter.executed).toHaveLength(1);
+      store.close();
+    }
+  });
+
+  it("lets the canonical directed-provider tool start Hermes and OpenClaw from an Omi coordinator", async () => {
+    for (const provider of ["hermes", "openclaw"] as const) {
+      const { store, adapter, kernel } = createKernelHarness(newDatabasePath(), provider);
+      const spawned = parseToolResult(
+        await handleAgentControlToolCall(
+          {
+            ...ownerContext(kernel),
+            defaultAdapterId: "pi-mono",
+            providerBoundary: "managed_cloud",
+          },
+          "spawn_agent",
+          {
+            objective: `run this with ${provider}`,
+            provider,
+            visible: true,
+            requestId: `managed-directed-${provider}-spawn`,
+            clientId: "main-chat",
+            ownerId: "owner",
+          },
+        ),
+      );
+
+      await waitUntil(() => {
+        const row = store.getRow("SELECT status FROM runs WHERE run_id = ?", [spawned.run.runId]);
+        return row.status === "succeeded";
+      });
+      expect(spawned.session).toMatchObject({
+        defaultAdapterId: provider,
+        providerBoundary: `local_user:${provider}`,
+      });
+      expect(adapter.executed).toHaveLength(1);
+      store.close();
+    }
+  });
+
+  it("rejects a mismatched directed provider and adapter override", async () => {
+    const { store, kernel } = createKernelHarness(newDatabasePath(), "pi-mono");
+    const result = parseToolResult(
+      await handleAgentControlToolCall({ ...ownerContext(kernel), defaultAdapterId: "pi-mono" }, "spawn_agent", {
+        objective: "do not create an ambiguous provider session",
+        provider: "openclaw",
+        adapterId: "pi-mono",
+        requestId: "managed-mismatched-provider-spawn",
+        clientId: "main-chat",
+        ownerId: "owner",
+      }),
+    );
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: {
+        code: "control_tool_failed",
+        message: "provider and adapterId must match when both are supplied",
+      },
+    });
+    expect(store.allRows("SELECT * FROM runs")).toHaveLength(0);
+    store.close();
+  });
+
+  it("lets signed desktop control continue a local provider session through the Omi cloud bridge", async () => {
+    for (const provider of ["hermes", "openclaw"] as const) {
+      const { store, adapter, kernel } = createKernelHarness(newDatabasePath(), provider);
+      const initial = await kernel.executeRun({
+        ...baseRunInput,
+        adapterId: provider,
+        defaultAdapterId: provider,
+      });
+
+      const continued = parseToolResult(
+        await handleAgentControlToolCall(
+          {
+            ...ownerContext(kernel),
+            defaultAdapterId: "pi-mono",
+            providerBoundary: "managed_cloud",
+            trustedUserControl: true,
+          },
+          "send_agent_message",
+          {
+            sessionId: initial.session.sessionId,
+            prompt: "Say how it's going.",
+            requestId: `direct-${provider}-continue`,
+            clientId: "desktop-floating-pill",
+            ownerId: "owner",
+          },
+        ),
+      );
+
+      expect(continued).toMatchObject({
+        ok: true,
+        session: {
+          sessionId: initial.session.sessionId,
+          defaultAdapterId: provider,
+          providerBoundary: `local_user:${provider}`,
+        },
+      });
+      expect(adapter.executed).toHaveLength(2);
+      store.close();
+    }
+  });
+
+  it("does not let signed desktop control cross a managed parent run into a local provider", async () => {
+    const { store, kernel } = createKernelHarness(newDatabasePath(), "pi-mono");
+    const parent = await kernel.executeRun({
+      ...baseRunInput,
+      adapterId: "pi-mono",
+      defaultAdapterId: "pi-mono",
+    });
+
+    const result = parseToolResult(
       await handleAgentControlToolCall(
-        { ...ownerContext(kernel), defaultAdapterId: "pi-mono" },
+        {
+          ...ownerContext(kernel),
+          defaultAdapterId: "pi-mono",
+          providerBoundary: "managed_cloud",
+          trustedUserControl: true,
+        },
         "spawn_agent",
         {
-          objective: "do not use local credentials",
-          visible: true,
-          adapterId: "acp",
-          requestId: "spawn-managed-local-acp-1",
-          clientId: "spawn-client",
+          objective: "do not cross into OpenClaw",
+          provider: "openclaw",
+          parentRunId: parent.run.runId,
+          requestId: "direct-managed-parent-openclaw",
+          clientId: "desktop-floating-pill",
           ownerId: "owner",
         },
       ),
@@ -1737,7 +2001,39 @@ describe("agent control tools", () => {
       ok: false,
       error: {
         code: "control_tool_failed",
-        message: "Local Claude is available only when the User Claude mode is selected.",
+        message: "Managed Omi agents can only use Omi cloud routing.",
+      },
+    });
+    expect(store.allRows("SELECT * FROM runs")).toHaveLength(1);
+    store.close();
+  });
+
+  it("fails closed for an unknown adapter even from signed desktop control", async () => {
+    const { store, kernel } = createKernelHarness(newDatabasePath(), "pi-mono");
+    const result = parseToolResult(
+      await handleAgentControlToolCall(
+        {
+          ...ownerContext(kernel),
+          defaultAdapterId: "pi-mono",
+          providerBoundary: "managed_cloud",
+          trustedUserControl: true,
+        },
+        "spawn_agent",
+        {
+          objective: "do not create an unknown provider session",
+          adapterId: "unknown-adapter",
+          requestId: "direct-unknown-provider",
+          clientId: "desktop-floating-pill",
+          ownerId: "owner",
+        },
+      ),
+    );
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: {
+        code: "control_tool_failed",
+        message: "Unknown production adapter: unknown-adapter",
       },
     });
     expect(store.allRows("SELECT * FROM runs")).toHaveLength(0);
@@ -1754,11 +2050,12 @@ describe("agent control tools", () => {
     });
 
     for (const provider of ["acp", "hermes", "openclaw", "unknown-adapter"] as const) {
-      const expectedMessage = provider === "acp"
-        ? "Local Claude is available only when the User Claude mode is selected."
-        : provider === "unknown-adapter"
-          ? "Unknown production adapter: unknown-adapter"
-          : "Managed Omi agents can only use Omi cloud routing.";
+      const expectedMessage =
+        provider === "acp"
+          ? "Local Claude is available only when the User Claude mode is selected."
+          : provider === "unknown-adapter"
+            ? "Unknown production adapter: unknown-adapter"
+            : "Managed Omi agents can only use Omi cloud routing.";
       const spawned = parseToolResult(
         await handleAgentControlToolCall(context, "spawn_agent", {
           objective: `do not route to ${provider}`,
@@ -1826,7 +2123,11 @@ describe("agent control tools", () => {
     const { store, kernel } = createKernelHarness(newDatabasePath(), "pi-mono");
     const result = parseToolResult(
       await handleAgentControlToolCall(
-        { ...ownerContext(kernel), defaultAdapterId: "pi-mono", canSpawnAgents: false },
+        {
+          ...ownerContext(kernel),
+          defaultAdapterId: "pi-mono",
+          canSpawnAgents: false,
+        },
         "spawn_agent",
         {
           objective: "fan out more work",
@@ -1864,10 +2165,26 @@ describe("agent control tools", () => {
       callerSessionId: parent.session.sessionId,
     };
     const calls = [
-      ["spawn_agent", { objective: "nested", visible: false }, "Background agents are leaf workers and cannot start additional agents."],
-      ["spawn_background_agent", { prompt: "nested" }, "Background agents are leaf workers and cannot start additional agents."],
-      ["run_agent_and_wait", { objective: "nested", parentRunId: parent.run.runId }, "Background agents are leaf workers and cannot start additional agents."],
-      ["send_agent_message", { sessionId: parent.session.sessionId, prompt: "continue" }, "Leaf workers cannot continue agent sessions."],
+      [
+        "spawn_agent",
+        { objective: "nested", visible: false },
+        "Background agents are leaf workers and cannot start additional agents.",
+      ],
+      [
+        "spawn_background_agent",
+        { prompt: "nested" },
+        "Background agents are leaf workers and cannot start additional agents.",
+      ],
+      [
+        "run_agent_and_wait",
+        { objective: "nested", parentRunId: parent.run.runId },
+        "Background agents are leaf workers and cannot start additional agents.",
+      ],
+      [
+        "send_agent_message",
+        { sessionId: parent.session.sessionId, prompt: "continue" },
+        "Leaf workers cannot continue agent sessions.",
+      ],
     ] as const;
 
     for (const [name, input, message] of calls) {
@@ -1981,7 +2298,10 @@ describe("agent control tools", () => {
     expect(row.child_run_id).toBe(delegated.run.runId);
 
     const parentInspect = parseToolResult(
-      await handleAgentControlToolCall(ownerContext(kernel), "get_agent_run", { runId: parent.run.runId, ownerId: "owner" }),
+      await handleAgentControlToolCall(ownerContext(kernel), "get_agent_run", {
+        runId: parent.run.runId,
+        ownerId: "owner",
+      }),
     );
     expect(parentInspect.parentDelegations[0].delegationId).toBe(delegated.delegation.delegationId);
     const childInspect = parseToolResult(
@@ -2002,7 +2322,12 @@ describe("agent control tools", () => {
         name: "omi-tools",
         command: "node",
         args: ["omi-tools.js"],
-        env: [{ name: "OMI_CONTEXT_FILE", value: expect.stringContaining("omi-tools-context") }],
+        env: [
+          {
+            name: "OMI_CONTEXT_FILE",
+            value: expect.stringContaining("omi-tools-context"),
+          },
+        ],
       },
       { name: "playwright", command: "node", args: ["playwright.js"], env: [] },
     ]);
@@ -2041,16 +2366,28 @@ describe("agent control tools", () => {
         name: "omi-tools",
         command: "node",
         args: ["omi-tools.js"],
-        env: [{ name: "OMI_CONTEXT_FILE", value: expect.stringContaining("omi-tools-context") }],
+        env: [
+          {
+            name: "OMI_CONTEXT_FILE",
+            value: expect.stringContaining("omi-tools-context"),
+          },
+        ],
       },
       {
         name: "playwright",
         command: "node",
         args: ["playwright.js"],
-        env: [{ name: "OMI_CONTEXT_FILE", value: expect.stringContaining("omi-tools-context") }],
+        env: [
+          {
+            name: "OMI_CONTEXT_FILE",
+            value: expect.stringContaining("omi-tools-context"),
+          },
+        ],
       },
     ]);
-    expect(adapter.executed.at(-1)?.metadata).not.toMatchObject({ disableSwiftBackedTools: true });
+    expect(adapter.executed.at(-1)?.metadata).not.toMatchObject({
+      disableSwiftBackedTools: true,
+    });
     store.close();
   });
 
@@ -2131,9 +2468,7 @@ describe("agent control tools", () => {
       surfaceKind: "floating_bar",
       externalRefKind: "pill",
     });
-    expect(spawned.session.externalRefId).toMatch(
-      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
-    );
+    expect(spawned.session.externalRefId).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i);
     const row = store.getRow("SELECT external_ref_kind, external_ref_id FROM sessions WHERE session_id = ?", [
       spawned.session.sessionId,
     ]);
@@ -2200,21 +2535,16 @@ describe("agent control tools", () => {
   it("retries an accepted ACP spawn after control-tool credential recovery", async () => {
     const authError = new Error("Invalid authentication credentials");
     let recoveries = 0;
-    const { store, adapter, kernel } = createKernelHarness(
-      newDatabasePath(),
-      "acp",
-      4,
-      undefined,
-      (adapterId) =>
-        adapterId === "acp"
-          ? {
-              maxAttempts: 2,
-              recoverAfterError: async (error) => {
-                recoveries += 1;
-                return error === authError;
-              },
-            }
-          : {},
+    const { store, adapter, kernel } = createKernelHarness(newDatabasePath(), "acp", 4, undefined, (adapterId) =>
+      adapterId === "acp"
+        ? {
+            maxAttempts: 2,
+            recoverAfterError: async (error) => {
+              recoveries += 1;
+              return error === authError;
+            },
+          }
+        : {},
     );
     adapter.failNextExecutionError = authError;
 
@@ -2233,11 +2563,21 @@ describe("agent control tools", () => {
       return row.status === "succeeded";
     });
     expect(recoveries).toBe(1);
-    expect(store.allRows("SELECT attempt_no, retry_reason, status FROM run_attempts WHERE run_id = ? ORDER BY attempt_no", [
-      spawned.run.runId,
-    ])).toEqual([
-      expect.objectContaining({ attempt_no: 1, retry_reason: null, status: "failed" }),
-      expect.objectContaining({ attempt_no: 2, retry_reason: "recoverable_error", status: "succeeded" }),
+    expect(
+      store.allRows("SELECT attempt_no, retry_reason, status FROM run_attempts WHERE run_id = ? ORDER BY attempt_no", [
+        spawned.run.runId,
+      ]),
+    ).toEqual([
+      expect.objectContaining({
+        attempt_no: 1,
+        retry_reason: null,
+        status: "failed",
+      }),
+      expect.objectContaining({
+        attempt_no: 2,
+        retry_reason: "recoverable_error",
+        status: "succeeded",
+      }),
     ]);
     store.close();
   });
@@ -2288,11 +2628,14 @@ describe("agent control tools", () => {
     expect(running.childDelegations[0].delegationId).toBe(spawned.delegation.delegationId);
 
     adapter.resolveDeferred({
-      text: "spawn complete",      adapterSessionId: adapter.executed[1].binding.adapterNativeSessionId,
+      text: "spawn complete",
+      adapterSessionId: adapter.executed[1].binding.adapterNativeSessionId,
       terminalStatus: "succeeded",
     });
     await waitUntil(() => {
-      const row = store.getRow("SELECT status FROM delegations WHERE delegation_id = ?", [spawned.delegation.delegationId]);
+      const row = store.getRow("SELECT status FROM delegations WHERE delegation_id = ?", [
+        spawned.delegation.delegationId,
+      ]);
       return row.status === "succeeded";
     });
     store.close();
@@ -2316,7 +2659,9 @@ describe("agent control tools", () => {
 
     expect(spawned.ok).toBe(true);
     await waitUntil(() => {
-      const row = store.getRow("SELECT status FROM delegations WHERE delegation_id = ?", [spawned.delegation.delegationId]);
+      const row = store.getRow("SELECT status FROM delegations WHERE delegation_id = ?", [
+        spawned.delegation.delegationId,
+      ]);
       return row.status === "failed";
     });
     expect(store.getRow("SELECT status FROM runs WHERE run_id = ?", [spawned.run.runId]).status).toBe("failed");
@@ -2419,14 +2764,38 @@ describe("agent control tools", () => {
     const listed = parseToolResult((await sendToolUse(sockPath, "list_agent_sessions", { ownerId: "owner" })).result);
     expect(listed.sessions[0].activeRun.runId).toBe(runId);
 
-    const inspected = parseToolResult((await sendToolUse(sockPath, "get_agent_run", { runId, ownerId: "owner" })).result);
+    const inspected = parseToolResult(
+      (
+        await sendToolUse(sockPath, "get_agent_run", {
+          runId,
+          ownerId: "owner",
+        })
+      ).result,
+    );
     expect(inspected.run.status).toBe("running");
     expect(inspected.attempts[0].attemptId).toBe(attemptId);
 
-    const artifacts = parseToolResult((await sendToolUse(sockPath, "inspect_agent_artifacts", { runId, ownerId: "owner" })).result);
-    expect(artifacts.artifacts[0]).toMatchObject({ artifactId: "art_relay", uri: "omi-artifact://art_relay" });
+    const artifacts = parseToolResult(
+      (
+        await sendToolUse(sockPath, "inspect_agent_artifacts", {
+          runId,
+          ownerId: "owner",
+        })
+      ).result,
+    );
+    expect(artifacts.artifacts[0]).toMatchObject({
+      artifactId: "art_relay",
+      uri: "omi-artifact://art_relay",
+    });
 
-    const cancelled = parseToolResult((await sendToolUse(sockPath, "cancel_agent_run", { runId, ownerId: "owner" })).result);
+    const cancelled = parseToolResult(
+      (
+        await sendToolUse(sockPath, "cancel_agent_run", {
+          runId,
+          ownerId: "owner",
+        })
+      ).result,
+    );
     expect(cancelled.cancellation).toMatchObject({
       accepted: true,
       dispatchAttempted: true,
@@ -2438,7 +2807,8 @@ describe("agent control tools", () => {
     adapter.resolveDeferred({
       text: "relay cancelled",
       terminalStatus: "cancelled",
-      adapterSessionId: adapter.executed[0].binding.adapterNativeSessionId,    });
+      adapterSessionId: adapter.executed[0].binding.adapterNativeSessionId,
+    });
     await running;
     store.close();
   });
@@ -2483,7 +2853,13 @@ function startControlRelay(context: AgentControlToolContext): Promise<string> {
           };
           if (msg.type !== "tool_use" || !isAgentControlToolName(msg.name)) continue;
           void handleAgentControlToolCall(context, msg.name, msg.input).then((result) => {
-            client.write(JSON.stringify({ type: "tool_result", callId: msg.callId, result }) + "\n");
+            client.write(
+              JSON.stringify({
+                type: "tool_result",
+                callId: msg.callId,
+                result,
+              }) + "\n",
+            );
           });
         }
       });

--- a/desktop/macos/changelog/unreleased/20260710-local-agent-provider-routing.json
+++ b/desktop/macos/changelog/unreleased/20260710-local-agent-provider-routing.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed OpenClaw and Hermes agent pills and a voice-startup crash in development builds"
+}

--- a/desktop/macos/run.sh
+++ b/desktop/macos/run.sh
@@ -42,29 +42,31 @@ Examples:
   ./run.sh                                  # Full local dev (backend + tunnel + app)
   OMI_SKIP_BACKEND=1 ./run.sh               # App only (backend running elsewhere)
   OMI_SKIP_TUNNEL=1 ./run.sh                # No Cloudflare tunnel (use direct URL)
-  ./run.sh --yolo                            # Quick start: use prod backend, no local services
+  ./run.sh --yolo                            # Quick start: use dev backend, no local services
 USAGE
     exit 0
 fi
 
-# ─── YOLO mode: use prod backend, zero local setup ───────────────────
-# WARNING: Temporary shortcut while desktop dev setup is being cleaned up.
-# Will be removed once all desktop slop is fixed.
+# ─── YOLO mode: use dev backend, zero local setup ────────────────────
+# Keep these endpoint values aligned with DesktopBackendEnvironment's dev
+# defaults. The dev services currently mint prod Firebase identities, so this
+# is a service-revision target, not an isolated local-data harness.
 apply_yolo_env() {
     export OMI_SKIP_BACKEND=1
     export OMI_SKIP_TUNNEL=1
-    export OMI_DESKTOP_API_URL="https://desktop-backend-hhibjajaja-uc.a.run.app"
-    export OMI_PYTHON_API_URL="https://api.omi.me"
+    export OMI_DESKTOP_API_URL="https://desktop-backend-dt5lrfkkoa-uc.a.run.app"
+    export OMI_PYTHON_API_URL="https://api.omiapi.com"
     export FIREBASE_API_KEY="AIzaSyD9dzBdglc7IO9pPDIOvqnCoTis_xKkkC8"
 }
 
 if [ "$1" = "--yolo" ]; then
     echo ""
     echo "=========================================="
-    echo "  YOLO MODE — using production backend"
+    echo "  YOLO MODE — using development backend"
     echo "=========================================="
     echo ""
-    echo "  WARNING: This connects directly to the prod Cloud Run backend."
+    echo "  WARNING: This connects directly to the dev Cloud Run backends."
+    echo "  They currently use production Firebase identities and data stores."
     echo "  No local Rust backend, no local auth, no tunnel."
     echo "  This is a temporary shortcut — will be removed once"
     echo "  desktop dev setup friction is fully resolved."
@@ -336,7 +338,7 @@ if [ ! -f ".env" ] && [ "$1" != "--yolo" ]; then
     echo "  OMI_SKIP_BACKEND=1 ./run.sh"
     echo "  (set OMI_DESKTOP_API_URL and OMI_PYTHON_API_URL in .env.app to point to remote backends)"
     echo ""
-    echo "Or just use the production backend (no setup needed):"
+    echo "Or just use the development backend (no setup needed):"
     echo "  ./run.sh --yolo"
     echo "==========================="
     exit 1

--- a/desktop/macos/tests/test-yolo-dev-backend.sh
+++ b/desktop/macos/tests/test-yolo-dev-backend.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+RUN="$ROOT/run.sh"
+
+YOLO_FUNCTION="$(sed -n '/^apply_yolo_env()/,/^}/p' "$RUN")"
+
+if [[ -z "$YOLO_FUNCTION" ]]; then
+  echo "FAIL: apply_yolo_env is missing from $RUN" >&2
+  exit 1
+fi
+
+(
+  unset OMI_SKIP_BACKEND OMI_SKIP_TUNNEL OMI_DESKTOP_API_URL OMI_PYTHON_API_URL FIREBASE_API_KEY
+  eval "$YOLO_FUNCTION"
+  apply_yolo_env
+
+  test "$OMI_SKIP_BACKEND" = "1"
+  test "$OMI_SKIP_TUNNEL" = "1"
+  test "$OMI_DESKTOP_API_URL" = "https://desktop-backend-dt5lrfkkoa-uc.a.run.app"
+  test "$OMI_PYTHON_API_URL" = "https://api.omiapi.com"
+  test -n "$FIREBASE_API_KEY"
+)
+
+bash "$RUN" --help | grep -q 'Quick start: use dev backend, no local services'
+
+echo "PASS: --yolo targets the development backends"

--- a/docs/doc/developer/agent-control-plane-invariants.mdx
+++ b/docs/doc/developer/agent-control-plane-invariants.mdx
@@ -176,13 +176,21 @@ Every production adapter declares `managed_cloud` or `local_user` in
 kernel creates them. Managed sessions may select only managed-cloud adapters;
 local-user sessions are pinned to the exact selected local adapter. Missing
 adapter arguments inherit that boundary, while unknown adapters fail closed.
+Signed desktop control, and the canonical top-level `spawn_agent` tool's
+explicit `provider` selector for Hermes or OpenClaw, may establish a fresh
+local-provider session or resume an existing session against its persisted
+boundary, even when the control bridge itself uses managed-cloud routing. An
+adapter ID alone may not use that exception, and neither may cross a parent
+run's boundary or override an existing session's adapter.
 
 Guard surface:
 
 - `execution-policy.ts` is the shared resolver used by control tools and the
   kernel run-acceptance path.
 - `runtime-adapter.test.ts`, `execution-policy.test.ts`, and
-  `control-tools.test.ts` exhaust production declarations and managed routing.
+  `control-tools.test.ts` exhaust production declarations, managed routing,
+  directed and signed top-level local-provider starts, and signed local-session
+  resumption.
 
 ### Execution role owns agent-management authority
 


### PR DESCRIPTION
## Summary

- Restore OpenClaw and Hermes top-level sessions when the Omi cloud coordinator is active, while retaining fail-closed parent and adapter boundaries.
- Point --yolo at the deployed development backends and document their shared production Firebase/data contract.
- Prevent the named dev bundle's PTT startup crash by consuming the hub-warm transition before re-entrant coordinator snapshots.

## Root cause

The managed/local routing guard treated the cloud coordinator's provider boundary as the target session boundary. Separately, PTT stored the old hub-warm route in a defer block, so RealtimeHubController.beginTurn could synchronously re-enter the resolver until stack overflow.

## Validation

- desktop/macos/agent: npm run build; npm test (33 files, 402 tests)
- desktop/macos: ./scripts/test-tool-surfaces.sh; ./scripts/agent-logic-harness.sh --swift-only --skip-install
- desktop/macos: xcrun swift test --package-path Desktop --filter VoiceTurnCoordinatorTests (12 tests)
- desktop/macos: bash tests/test-yolo-dev-backend.sh; git diff --check
- Named bundle: OMI_APP_NAME=omi-yolo-dev-routing OMI_AUTOMATION_PORT=47920 ./run.sh --yolo; confirmed dev endpoints, signed-in app, Gemini Live connection, and healthy automation bridge with no new crash report.
- Repository pre-push gate passed in full.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9420?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
## Product invariants affected

- INV-AGENT-* — this PR changes the agent control tool routing contract while preserving fail-closed managed/local boundaries.
- INV-CHAT-1 — this PR changes the PTT/realtime hub transition path and retains the shared voice-turn coordinator state.