### PR TITLE
fix(backend): transcript segment-text edit lost-update — wrap in Firestore transaction (#9392)

### DIFF
--- a/backend/database/conversations.py
+++ b/backend/database/conversations.py
@@ -595,16 +595,16 @@ def update_conversation_summary(uid: str, conversation_id: str, app_id: Optional
     return 'ok'
 
 
-def update_conversation_segment_text(uid: str, conversation_id: str, segment_id: str, text: str) -> str:
-    """
-    Update a single segment's text in a conversation.
+@firestore.transactional
+def _update_segment_text_transaction(transaction, doc_ref, uid: str, segment_id: str, text: str) -> str:
+    """Atomic read-modify-write of a single transcript segment's text.
 
-    Returns:
-        'ok' on success, 'not_found' if conversation missing, 'locked' if conversation is locked,
-        'segment_not_found' if segment_id not found.
+    The whole ``transcript_segments`` array is rewritten, so the read must happen
+    inside the transaction — otherwise two concurrent edits to *different* segments
+    both read the pre-edit array and the later write silently clobbers the earlier
+    one (lost update). The transaction retries on contention.
     """
-    doc_ref = db.collection('users').document(uid).collection(conversations_collection).document(conversation_id)
-    doc_snapshot = doc_ref.get()
+    doc_snapshot = doc_ref.get(transaction=transaction)
     if not doc_snapshot.exists:
         return 'not_found'
 
@@ -629,8 +629,24 @@ def update_conversation_segment_text(uid: str, conversation_id: str, segment_id:
 
     doc_level = conversation_data.get('data_protection_level', 'standard')
     prepared_payload = _prepare_conversation_for_write({'transcript_segments': segments}, uid, doc_level)
-    doc_ref.update(prepared_payload)
+    transaction.update(doc_ref, prepared_payload)
     return 'ok'
+
+
+def update_conversation_segment_text(uid: str, conversation_id: str, segment_id: str, text: str) -> str:
+    """
+    Update a single segment's text in a conversation.
+
+    Runs as a Firestore transaction so concurrent edits to different segments of
+    the same conversation cannot lose-update each other.
+
+    Returns:
+        'ok' on success, 'not_found' if conversation missing, 'locked' if conversation is locked,
+        'segment_not_found' if segment_id not found.
+    """
+    doc_ref = db.collection('users').document(uid).collection(conversations_collection).document(conversation_id)
+    transaction = db.transaction()
+    return _update_segment_text_transaction(transaction, doc_ref, uid, segment_id, text)
 
 
 def delete_conversation_photos(uid: str, conversation_id: str) -> int:

--- a/backend/tests/unit/test_update_conversation_segment_text_transaction.py
+++ b/backend/tests/unit/test_update_conversation_segment_text_transaction.py
@@ -1,0 +1,163 @@
+"""update_conversation_segment_text is a Firestore transaction (lost-update guard).
+
+Regression for #9392: the old implementation did a bare ``doc_ref.get()`` then
+``doc_ref.update()`` (rewriting the whole ``transcript_segments`` array). Two
+concurrent edits to *different* segments both read the pre-edit array and the
+later write clobbered the earlier one. The read-modify-write must run inside a
+Firestore transaction so the read is bound to the transaction and it retries on
+contention.
+
+database.conversations binds ``db`` at import (``from ._client import db``) and
+pulls the ``google.cloud.firestore`` chain at top level, so the fake modules must
+be active before the module is exec'd — the sanctioned Tier-2 "fake must precede
+import" case (see backend/docs/test_isolation.md).
+"""
+
+import json
+import os
+import zlib
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import MagicMock
+
+import pytest
+
+from testing.import_isolation import load_module_fresh, stub_modules
+
+_BACKEND = Path(__file__).resolve().parents[2]
+
+
+@pytest.fixture(scope="module")
+def conversations_db():
+    client_stub = ModuleType("database._client")
+    client_stub.db = MagicMock(name="db")
+    client_stub.document_id_from_seed = MagicMock(name="document_id_from_seed")
+
+    firestore_stub = ModuleType("google.cloud.firestore")
+    firestore_stub.transactional = lambda func: func
+
+    google_pkg = ModuleType("google")
+    google_pkg.__path__ = []  # type: ignore[attr-defined]
+    google_cloud_pkg = ModuleType("google.cloud")
+    google_cloud_pkg.__path__ = []  # type: ignore[attr-defined]
+
+    api_core_pkg = ModuleType("google.api_core")
+    api_core_pkg.__path__ = []  # type: ignore[attr-defined]
+    api_core_exceptions = ModuleType("google.api_core.exceptions")
+    for _name in ("AlreadyExists", "Conflict", "NotFound"):
+        setattr(api_core_exceptions, _name, type(_name, (Exception,), {}))
+
+    fv1_stub = ModuleType("google.cloud.firestore_v1")
+    fv1_stub.FieldFilter = MagicMock()
+    fv1_stub.transactional = lambda func: func
+
+    fakes = {
+        "database._client": client_stub,
+        "google": google_pkg,
+        "google.cloud": google_cloud_pkg,
+        "google.cloud.firestore": firestore_stub,
+        "google.api_core": api_core_pkg,
+        "google.api_core.exceptions": api_core_exceptions,
+        "google.cloud.firestore_v1": fv1_stub,
+        "firebase_admin": MagicMock(),
+        "firebase_admin.auth": MagicMock(),
+    }
+    with stub_modules(fakes):
+        module = load_module_fresh(
+            "database.conversations",
+            os.path.join(str(_BACKEND), "database", "conversations.py"),
+        )
+        yield module
+
+
+class _FakeSnapshot:
+    def __init__(self, data, exists=True):
+        self._data = data
+        self.exists = exists
+
+    def to_dict(self):
+        return self._data
+
+
+class _FakeDocRef:
+    def __init__(self, data, exists=True):
+        self._data = data
+        self._exists = exists
+        self.get_transaction = "unset"
+
+    def get(self, transaction=None, **kwargs):
+        # Record how the read was issued — a lost-update fix must read inside the txn.
+        self.get_transaction = transaction
+        return _FakeSnapshot(self._data, exists=self._exists)
+
+
+class _FakeTransaction:
+    def __init__(self):
+        self.updated_ref = None
+        self.updated_data = None
+
+    def update(self, doc_ref, update_data):
+        self.updated_ref = doc_ref
+        self.updated_data = update_data
+
+
+def _standard_conversation(segments):
+    return {
+        "id": "conv-1",
+        "data_protection_level": "standard",
+        "transcript_segments": segments,
+    }
+
+
+def _decode_written_segments(payload):
+    raw = payload["transcript_segments"]
+    return json.loads(zlib.decompress(raw).decode("utf-8"))
+
+
+def test_reads_inside_transaction_and_edits_target_segment(conversations_db):
+    data = _standard_conversation([{"id": "s1", "text": "hello"}, {"id": "s2", "text": "world"}])
+    doc_ref = _FakeDocRef(data)
+    transaction = _FakeTransaction()
+
+    result = conversations_db._update_segment_text_transaction(transaction, doc_ref, "uid-1", "s2", "WORLD")
+
+    assert result == "ok"
+    # The read must be bound to the transaction (the actual lost-update fix).
+    assert doc_ref.get_transaction is transaction
+    # The write goes through the transaction, not a bare doc_ref.update().
+    assert transaction.updated_ref is doc_ref
+    written = _decode_written_segments(transaction.updated_data)
+    assert written == [{"id": "s1", "text": "hello"}, {"id": "s2", "text": "WORLD"}]
+
+
+def test_missing_conversation_returns_not_found(conversations_db):
+    doc_ref = _FakeDocRef({}, exists=False)
+    transaction = _FakeTransaction()
+
+    result = conversations_db._update_segment_text_transaction(transaction, doc_ref, "uid-1", "s1", "x")
+
+    assert result == "not_found"
+    assert transaction.updated_data is None
+
+
+def test_locked_conversation_is_not_written(conversations_db):
+    data = _standard_conversation([{"id": "s1", "text": "hi"}])
+    data["is_locked"] = True
+    doc_ref = _FakeDocRef(data)
+    transaction = _FakeTransaction()
+
+    result = conversations_db._update_segment_text_transaction(transaction, doc_ref, "uid-1", "s1", "x")
+
+    assert result == "locked"
+    assert transaction.updated_data is None
+
+
+def test_unknown_segment_returns_segment_not_found(conversations_db):
+    data = _standard_conversation([{"id": "s1", "text": "hi"}])
+    doc_ref = _FakeDocRef(data)
+    transaction = _FakeTransaction()
+
+    result = conversations_db._update_segment_text_transaction(transaction, doc_ref, "uid-1", "does-not-exist", "x")
+
+    assert result == "segment_not_found"
+    assert transaction.updated_data is None


### PR DESCRIPTION
## Bug (#9392, item 1)

`update_conversation_segment_text` (`backend/database/conversations.py`) did a **non-transactional read-modify-write**:

`doc_ref.get()` → mutate one segment in the decoded `transcript_segments` array → `doc_ref.update()` that rewrites the **whole** array.

Two concurrent edits — even to *different* segments of the same conversation — both read the pre-edit array, so the later write silently clobbers the earlier one (**lost update**). Both requests return 200. Repro in the issue: edit two different segments in two tabs within the same ~200ms window → one edit disappears. These endpoints are shared by all clients, so the web client-side serialization mitigation in #9353 can't cover the cross-tab/cross-client case.

## Fix

Wrap the read-modify-write in a Firestore transaction, mirroring the existing `upsert_conversation` pattern in the same file (`db.transaction()` + `@firestore.transactional`). The read is now bound to the transaction and Firestore retries the whole read-modify-write on contention, so concurrent different-segment edits are serialized and no longer lost.

Extracted the body into a module-level `@firestore.transactional` helper (`_update_segment_text_transaction`) so it is unit-testable, exactly like `database.users._add_sample_transaction`.

## Test

Added `backend/tests/unit/test_update_conversation_segment_text_transaction.py` — asserts the read is issued **with** the transaction and the write goes through `transaction.update(...)` (the old bare `doc_ref.get()`/`doc_ref.update()` path would fail both assertions), plus the `not_found` / `locked` / `segment_not_found` branches write nothing.

## Verification

Backend deps weren't installable in the watchdog sandbox, so I exercised the **real function source** (extracted via AST, identity transactional decorator) against a fake transaction + docref for all four scenarios:
- `ok`: read bound to txn ✅, write via `txn.update` ✅, only the target segment's text changed ✅
- `not_found` / `locked` / `segment_not_found`: correct return code, no write ✅

The pytest file uses the sanctioned `load_module_fresh` isolation pattern and runs in CI.

## Scope

Only #9392 **item 1** (the primary lost-update). Item 2 (reprocess overwriting from a stale snapshot) and the `update_conversation_segments` speaker-assign variant span the live transcription pipeline (many callers pass full segment arrays intentionally) and need a per-caller change — left for a focused follow-up rather than risking the streaming path here.

🤖 automated by hourly watchdog; opened for review.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9426?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

