### PR TITLE
ci: make Hygiene contracts agent-passable before PR open

### DIFF
--- a/.github/scripts/check_product_invariants.py
+++ b/.github/scripts/check_product_invariants.py
@@ -61,7 +61,24 @@ def parse_args() -> argparse.Namespace:
         action="store_true",
         help="Print matched invariants and exit 0.",
     )
+    parser.add_argument(
+        "--suggest",
+        action="store_true",
+        help="Print a paste-ready 'Product invariants affected' markdown block and exit 0.",
+    )
     return parser.parse_args()
+
+
+def format_suggest_block(hits: list[dict]) -> str:
+    """Return a paste-ready PR-body section for the required invariant IDs."""
+    lines = ["## Product invariants affected", ""]
+    if not hits:
+        lines.append("none")
+    else:
+        for hit in hits:
+            lines.append(f"- {hit['id']}")
+    lines.append("")
+    return "\n".join(lines)
 
 
 def load_pr_body(args: argparse.Namespace) -> str:
@@ -169,26 +186,8 @@ def matched_invariants(changed: list[str], invariants: list[dict]) -> list[dict]
     return hits
 
 
-def main() -> int:
-    args = parse_args()
-    root = Path(args.root).resolve()
-    changed_path = Path(args.changed_files)
-    changed = [line.strip() for line in changed_path.read_text(encoding="utf-8").splitlines() if line.strip()]
-    invariants = load_locked_invariants(root)
-    hits = matched_invariants(changed, invariants)
-    pr_body = load_pr_body(args)
-
-    if args.print_only:
-        if not hits:
-            print("No locked invariants matched changed files.")
-            return 0
-        for hit in hits:
-            print(f"{hit['id']}: {len(hit['matched_files'])} file(s) ({hit['path']})")
-            for f in hit["matched_files"][:20]:
-                print(f"  - {f}")
-        return 0
-
-    still_missing = []
+def missing_invariant_hits(hits: list[dict], pr_body: str) -> list[dict]:
+    still_missing: list[dict] = []
     for hit in hits:
         inv_id = hit["id"]
         if pr_body_cites_id(inv_id, pr_body):
@@ -201,6 +200,33 @@ def main() -> int:
             if "agent-control-plane" in pr_body.lower():
                 continue
         still_missing.append(hit)
+    return still_missing
+
+
+def main() -> int:
+    args = parse_args()
+    root = Path(args.root).resolve()
+    changed_path = Path(args.changed_files)
+    changed = [line.strip() for line in changed_path.read_text(encoding="utf-8").splitlines() if line.strip()]
+    invariants = load_locked_invariants(root)
+    hits = matched_invariants(changed, invariants)
+    pr_body = load_pr_body(args)
+
+    if args.suggest:
+        print(format_suggest_block(hits), end="")
+        return 0
+
+    if args.print_only:
+        if not hits:
+            print("No locked invariants matched changed files.")
+            return 0
+        for hit in hits:
+            print(f"{hit['id']}: {len(hit['matched_files'])} file(s) ({hit['path']})")
+            for f in hit["matched_files"][:20]:
+                print(f"  - {f}")
+        return 0
+
+    still_missing = missing_invariant_hits(hits, pr_body)
 
     if not still_missing:
         if hits:
@@ -219,6 +245,10 @@ def main() -> int:
             print(f"    - {f}")
         if len(hit["matched_files"]) > 15:
             print(f"    … and {len(hit['matched_files']) - 15} more")
+    print("\nPaste this into the PR body (or a draft for --pr-body-file / OMI_PR_BODY_FILE):")
+    print()
+    print(format_suggest_block(hits), end="")
+    print("Then re-run: scripts/pr-preflight --pr-body-file <draft.md>")
     return 1
 
 

--- a/.github/scripts/pr_preflight.py
+++ b/.github/scripts/pr_preflight.py
@@ -58,13 +58,20 @@ def resolve_pr_metadata(
     repository: str | None,
     pr_number: int | None,
 ) -> PullRequestMetadata | None:
+    if body_file is None:
+        env_body = os.getenv("OMI_PR_BODY_FILE", "").strip()
+        if env_body:
+            body_file = Path(env_body)
     if body_file:
+        resolved = body_file.expanduser()
+        if not resolved.is_file():
+            raise RuntimeError(f"PR body file not found: {resolved}")
         return PullRequestMetadata(
             number=0,
-            body=body_file.read_text(encoding="utf-8"),
+            body=resolved.read_text(encoding="utf-8"),
             updated_at="local file",
             labels=(),
-            source=str(body_file.resolve()),
+            source=str(resolved.resolve()),
         )
     if repository and pr_number:
         return load_from_api(repository, pr_number, os.getenv("GITHUB_TOKEN", ""))
@@ -72,7 +79,8 @@ def resolve_pr_metadata(
         return load_from_gh(root)
     except RuntimeError as exc:
         print(f"PR metadata: unavailable ({exc})")
-        print("If invariant citations are required, rerun with --pr-body-file <draft.md>.")
+        print("If invariant citations are required, rerun with --pr-body-file <draft.md>")
+        print("or set OMI_PR_BODY_FILE, or run: scripts/pr-preflight --suggest")
         return None
 
 
@@ -148,6 +156,11 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--pr-number", type=int, help="Load current PR metadata through the GitHub API")
     parser.add_argument("--head-branch", help="PR head branch, used for release-changelog policy")
     parser.add_argument("--list", action="store_true", help="Print selected checks without running them")
+    parser.add_argument(
+        "--suggest",
+        action="store_true",
+        help="Print a paste-ready product-invariants PR body section for the diff and exit 0",
+    )
     parser.add_argument("--root", type=Path)
     return parser.parse_args()
 
@@ -166,36 +179,60 @@ def main() -> int:
         print(f"FAIL: could not resolve preflight diff: {exc.stderr.strip()}", file=sys.stderr)
         return 1
     checks = select_checks(files)
-    print(f"PR preflight: base={args.base} ({merge_base[:12]}) head={args.head} files={len(files)}")
-    for check in checks:
-        print(f"  SELECTED {check.name}: {check.reason}")
+    summary = f"PR preflight: base={args.base} ({merge_base[:12]}) head={args.head} files={len(files)}"
+    selected_lines = [f"  SELECTED {check.name}: {check.reason}" for check in checks]
+    if args.suggest:
+        print(summary, file=sys.stderr)
+        for line in selected_lines:
+            print(line, file=sys.stderr)
+    else:
+        print(summary)
+        for line in selected_lines:
+            print(line)
     if args.list:
         return 0
-
-    try:
-        metadata = resolve_pr_metadata(root, args.pr_body_file, args.repository, args.pr_number)
-    except RuntimeError as exc:
-        print(f"FAIL: {exc}", file=sys.stderr)
-        return 1
-    labels = metadata.labels if metadata else ()
-    head_branch = args.head_branch or os.getenv("GITHUB_HEAD_REF", "")
-    if not head_branch:
-        head_branch = subprocess.run(
-            ["git", "symbolic-ref", "--short", "-q", "HEAD"],
-            cwd=root,
-            check=False,
-            stdout=subprocess.PIPE,
-            text=True,
-        ).stdout.strip()
-    skip_changelog = "no-changelog-needed" in labels or head_branch.startswith("changelog/v")
-    if metadata:
-        print(f"PR metadata: {metadata.source}, updated_at={metadata.updated_at}")
 
     with tempfile.TemporaryDirectory(prefix="omi-pr-preflight-") as temp_dir:
         temp = Path(temp_dir)
         files_path = temp / "changed-files.txt"
-        body_path = temp / "pr-body.txt"
         files_path.write_text("".join(f"{path}\n" for path in files), encoding="utf-8")
+
+        if args.suggest:
+            suggest = subprocess.run(
+                [
+                    sys.executable,
+                    ".github/scripts/check_product_invariants.py",
+                    "--changed-files",
+                    str(files_path),
+                    "--suggest",
+                ],
+                cwd=root,
+                check=False,
+            )
+            return suggest.returncode
+
+        try:
+            metadata = resolve_pr_metadata(root, args.pr_body_file, args.repository, args.pr_number)
+        except RuntimeError as exc:
+            print(f"FAIL: {exc}", file=sys.stderr)
+            return 1
+        labels = metadata.labels if metadata else ()
+        head_branch = args.head_branch or os.getenv("GITHUB_HEAD_REF", "")
+        if not head_branch:
+            head_branch = subprocess.run(
+                ["git", "symbolic-ref", "--short", "-q", "HEAD"],
+                cwd=root,
+                check=False,
+                stdout=subprocess.PIPE,
+                text=True,
+            ).stdout.strip()
+        skip_changelog = "no-changelog-needed" in labels or head_branch.startswith("changelog/v")
+        if metadata:
+            print(f"PR metadata: {metadata.source}, updated_at={metadata.updated_at}")
+        elif any(check.name == "product-invariants" for check in checks):
+            print("PR metadata: none (product-invariants will use an empty body)")
+
+        body_path = temp / "pr-body.txt"
         body_path.write_text(metadata.body if metadata else "", encoding="utf-8")
         failures: list[str] = []
         for check in checks:
@@ -216,6 +253,11 @@ def main() -> int:
     elapsed = time.monotonic() - started
     if failures:
         print(f"PR preflight failed in {elapsed:.2f}s: {', '.join(failures)}", file=sys.stderr)
+        if "product-invariants" in failures:
+            print(
+                "Remediation: scripts/pr-preflight --suggest  # paste into PR body / draft, then re-run",
+                file=sys.stderr,
+            )
         return 1
     print(f"PR preflight passed: {len(checks)} checks in {elapsed:.2f}s.")
     return 0

--- a/.github/scripts/test_check_product_invariants.py
+++ b/.github/scripts/test_check_product_invariants.py
@@ -3,11 +3,14 @@
 
 from __future__ import annotations
 
+import subprocess
+import sys
 import tempfile
 import unittest
 from pathlib import Path
 
 from check_product_invariants import (
+    format_suggest_block,
     matched_invariants,
     parse_invariant,
     path_matches,
@@ -152,6 +155,78 @@ class CitationTokenTests(unittest.TestCase):
             "INV-CHAT-1"
         )
         self.assertTrue(pr_body_cites_id("INV-CHAT-1", template_body))
+
+
+class SuggestTests(unittest.TestCase):
+    def test_suggest_block_lists_ids(self) -> None:
+        block = format_suggest_block(
+            [
+                {"id": "INV-AUTH-1"},
+                {"id": "INV-CHAT-1"},
+            ]
+        )
+        self.assertEqual(
+            block,
+            "## Product invariants affected\n\n- INV-AUTH-1\n- INV-CHAT-1\n",
+        )
+
+    def test_suggest_block_none_when_empty(self) -> None:
+        self.assertEqual(format_suggest_block([]), "## Product invariants affected\n\nnone\n")
+
+    def test_suggest_cli_prints_paste_ready_block(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            changed = Path(tmp) / "changed.txt"
+            changed.write_text(
+                "desktop/macos/Desktop/Sources/Providers/ChatProvider.swift\n",
+                encoding="utf-8",
+            )
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    ".github/scripts/check_product_invariants.py",
+                    "--changed-files",
+                    str(changed),
+                    "--suggest",
+                ],
+                cwd=Path(__file__).resolve().parents[1].parent,
+                check=False,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+            )
+            self.assertEqual(result.returncode, 0, result.stdout)
+            self.assertIn("## Product invariants affected", result.stdout)
+            self.assertIn("- INV-AUTH-1", result.stdout)
+            self.assertIn("- INV-CHAT-1", result.stdout)
+
+    def test_failure_includes_suggest_block(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            changed = Path(tmp) / "changed.txt"
+            body = Path(tmp) / "body.md"
+            changed.write_text(
+                "desktop/macos/Desktop/Sources/Providers/ChatProvider.swift\n",
+                encoding="utf-8",
+            )
+            body.write_text("## Product invariants affected\n\nnone\n", encoding="utf-8")
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    ".github/scripts/check_product_invariants.py",
+                    "--changed-files",
+                    str(changed),
+                    "--pr-body-file",
+                    str(body),
+                ],
+                cwd=Path(__file__).resolve().parents[1].parent,
+                check=False,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+            )
+            self.assertEqual(result.returncode, 1, result.stdout)
+            self.assertIn("Paste this into the PR body", result.stdout)
+            self.assertIn("- INV-AUTH-1", result.stdout)
+            self.assertIn("- INV-CHAT-1", result.stdout)
 
 
 class FailClosedTests(unittest.TestCase):

--- a/.github/scripts/test_pr_preflight.py
+++ b/.github/scripts/test_pr_preflight.py
@@ -125,6 +125,52 @@ class SelectionTests(unittest.TestCase):
             self.assertEqual(coverage.returncode, 1, coverage.stdout)
             self.assertIn("UNCOVERED", coverage.stdout)
 
+    def test_suggest_flag_prints_paste_ready_invariants(self) -> None:
+        result = subprocess.run(
+            [
+                sys.executable,
+                ".github/scripts/pr_preflight.py",
+                "--base",
+                "HEAD",
+                "--head",
+                "HEAD",
+                "--suggest",
+            ],
+            cwd=REPO_ROOT,
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+        self.assertEqual(result.returncode, 0, result.stdout)
+        self.assertIn("## Product invariants affected", result.stdout)
+
+    def test_pr_body_file_env_is_honored(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            temp = Path(tmp)
+            body = temp / "body.md"
+            body.write_text("## Product invariants affected\n\nnone\n", encoding="utf-8")
+            env = {**os.environ, "OMI_PR_BODY_FILE": str(body)}
+            # Empty diff vs itself: product-invariants should pass with any body.
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    ".github/scripts/pr_preflight.py",
+                    "--base",
+                    "HEAD",
+                    "--head",
+                    "HEAD",
+                ],
+                cwd=REPO_ROOT,
+                env=env,
+                check=False,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+            )
+            self.assertEqual(result.returncode, 0, result.stdout)
+            self.assertIn(str(body.resolve()), result.stdout)
+
 
 class SingleFlightTests(unittest.TestCase):
     def run_runner(

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,7 @@ Every change must satisfy this checklist before it is committed or put in a PR. 
 4. **Verification evidence is written down** — the commands you ran and what they showed, in the commit message or PR description.
 5. **No orphaned deferrals** — new `TODO`/`FIXME`/`HACK` comments reference a tracking issue or are resolved before merge.
 6. **Docs moved with the code** — if you changed setup, test commands, service boundaries, env vars, or agent-relevant behavior, the matching doc (this file, a component `AGENTS.md`, or `docs/doc/developer/`) is updated in the same PR. Product-direction or invariant changes update `PRODUCT.md` / `docs/product/invariants/` in the same PR.
+7. **PR contracts pass before opening the PR** — draft the PR body to a file, then run `scripts/pr-preflight --pr-body-file /tmp/pr-body.md` (or `scripts/pr-preflight --suggest` to get the paste-ready invariant IDs). Pre-push runs the same cheap contracts; Hygiene will fail if you skip this.
 
 ## Leave It Better Than You Found It
 
@@ -55,7 +56,8 @@ Improve the code you touch — within your blast radius:
 ### Product invariants
 
 - Read [`PRODUCT.md`](PRODUCT.md) before changing product behavior. Locked rules live in [`docs/product/invariants/`](docs/product/invariants/) (shared chat continuity, memory tiers, agent control plane, integrations harness, brand UI).
-- If you touch a locked invariant’s path globs, name the invariant ID in the PR and update its guard test when behavior changes.
+- If you touch a locked invariant’s path globs, name **every** matched invariant ID in the PR body (path-based, not intent-based — e.g. touching `ChatProvider.swift` requires `INV-AUTH-1` even when the diff is not about auth). Discover IDs with `scripts/pr-preflight --suggest`; do not invent a partial list.
+- Update the invariant’s guard test when behavior changes.
 - Do not paste product essays into this file — keep the registry as the SSOT and link here.
 
 ### UI / Design (all platforms)

--- a/docs/doc/developer/Contribution.mdx
+++ b/docs/doc/developer/Contribution.mdx
@@ -26,8 +26,8 @@ Maintainers declining a PR for direction or taste will cite an invariant ID or o
     Clone your fork, create a branch, and implement your changes.
   </Step>
   <Step title="Test Your Changes">
-    Add focused tests and include the commands or manual steps you used to verify the change. Before pushing, run
-    `scripts/pr-preflight --pr-body-file /path/to/draft-pr-body.md` to catch PR contract issues locally.
+    Add focused tests and include the commands or manual steps you used to verify the change. Before pushing, draft the PR body and run
+    `scripts/pr-preflight --pr-body-file /path/to/draft-pr-body.md` (use `scripts/pr-preflight --suggest` to get the paste-ready invariant ID block). Pre-push runs the same cheap contracts.
   </Step>
   <Step title="Create a Pull Request">
     Submit a PR and specify which issue it relates to. Name any product invariants your change affects.
@@ -46,8 +46,10 @@ Good PRs are easy to review and come with evidence that the change works.
 - **Show your verification.** List the commands you ran and what they showed in the PR description. "It compiles" is not evidence — exercising the real user-facing path is.
 - **Tests that run in CI must be hermetic** — no live services, no network. Validation against a live service is welcome as extra evidence, but it can never be the only proof a PR works.
 - **Product invariants** — if you touch paths listed on a locked invariant, name the ID (for example `INV-CHAT-1`) in the PR body.
-- **Fast local PR contract check** — run `scripts/pr-preflight --pr-body-file /path/to/draft-pr-body.md`. Once the
-  branch has a PR, `scripts/pr-preflight` reads its current body automatically with `gh`.
+- **Fast local PR contract check** — draft the body, then run `scripts/pr-preflight --pr-body-file /path/to/draft-pr-body.md`.
+  Use `scripts/pr-preflight --suggest` when you need the paste-ready invariant section. Once the branch has a PR,
+  `scripts/pr-preflight` reads its current body automatically with `gh` (or set `OMI_PR_BODY_FILE`). Pre-push runs these
+  same cheap contracts.
 
 ### Contributing with an AI agent
 

--- a/scripts/pre-push
+++ b/scripts/pre-push
@@ -143,6 +143,20 @@ check_arch_guardrails() {
   python3 .github/scripts/check_arch_guardrails.py --changed-files "$CHANGED_FILES_LIST"
 }
 
+check_pr_preflight() {
+  if [ "${PRE_PUSH_SKIP_PR_PREFLIGHT:-}" = "1" ]; then
+    echo "Skipping shared PR preflight because PRE_PUSH_SKIP_PR_PREFLIGHT=1."
+    return
+  fi
+
+  # Same cheap contracts Hygiene runs (invariants, e2e covers, changelog schema, …).
+  # Draft a PR body first when invariants are required:
+  #   scripts/pr-preflight --suggest
+  #   scripts/pr-preflight --pr-body-file /tmp/pr-body.md
+  # or: OMI_PR_BODY_FILE=/tmp/pr-body.md git push
+  scripts/pr-preflight --base "$BASE_REF" --head HEAD --head-branch "$CURRENT_BRANCH"
+}
+
 check_optional_formatters() {
   local -a dart_files=()
   local -a python_files=()
@@ -692,6 +706,7 @@ check_gauntlet_evidence_if_needed() {
 
 run_step check_merge_conflicts
 run_step check_arch_guardrails
+run_step check_pr_preflight
 run_step python3 .github/scripts/desktop-changelog.py validate
 
 if [[ "$CURRENT_BRANCH" == changelog/v* ]]; then


### PR DESCRIPTION
## What changed and why

Make Hygiene's shared PR contracts discoverable and enforceable for agents before they open a PR: document the mechanical preflight step in AGENTS.md, add `--suggest` for paste-ready invariant IDs, and run the same cheap contracts in pre-push so product-invariants / e2e covers fail locally instead of only in CI.

## Product invariants affected

none

## How it was verified

- `python3 .github/scripts/test_check_product_invariants.py` — 18 passed
- `python3 .github/scripts/test_pr_preflight.py` — 8 passed
- `scripts/pr-preflight --suggest` — paste-ready block on stdout
- ChatProvider fixture: `--suggest` body passes; `none` body fails with paste-ready remediation
- `scripts/pr-preflight --pr-body-file /tmp/pr-body-hygiene.md` — passed for this PR's diff
- Pre-push `check_pr_preflight` ran and passed on push (with `OMI_PR_BODY_FILE`)

## Tests

- Added `SuggestTests` for format/CLI/failure remediation
- Added pr-preflight `--suggest` and `OMI_PR_BODY_FILE` coverage

## Test plan

- [ ] Confirm Hygiene passes on this PR
- [ ] On a branch that touches `ChatProvider.swift`, run `scripts/pr-preflight --suggest` and confirm it lists `INV-AUTH-1` + `INV-CHAT-1`
- [ ] Confirm pre-push fails (with paste-ready remediation) when required invariant IDs are missing from the PR body / `OMI_PR_BODY_FILE`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9436?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

