### PR TITLE
fix(app): suppress spurious close during intentional composite socket teardown

### DIFF
--- a/app/lib/services/sockets/composite_transcription_socket.dart
+++ b/app/lib/services/sockets/composite_transcription_socket.dart
@@ -90,9 +90,13 @@ class CompositeTranscriptionSocket implements IPureSocket {
     CustomSttLogService.instance.info('Composite', 'Disconnecting...');
     DebugLogManager.logEvent('composite_socket_disconnecting', {});
 
+    // Mark disconnected before touching the children: their disconnect()
+    // fires onClosed, which would otherwise hit _onSocketClosed while the
+    // composite still looks connected and trigger a spurious
+    // "socket closed unexpectedly" teardown on top of this intentional one.
+    _status = PureSocketStatus.disconnected;
     await _disconnectBothQuietly();
 
-    _status = PureSocketStatus.disconnected;
     onClosed();
   }
 
@@ -101,9 +105,9 @@ class CompositeTranscriptionSocket implements IPureSocket {
     CustomSttLogService.instance.info('Composite', 'Stopping...');
     DebugLogManager.logEvent('composite_socket_stopping', {});
 
-    await Future.wait([primarySocket.stop(), secondarySocket.stop()]);
-
+    // Same ordering requirement as disconnect().
     _status = PureSocketStatus.disconnected;
+    await Future.wait([primarySocket.stop(), secondarySocket.stop()]);
   }
 
   /// Called when either socket closes unexpectedly


### PR DESCRIPTION
## Summary

`CompositeTranscriptionSocket.stop()` / `disconnect()` tore down child sockets while `_status` was still `connected`, so each child's `onClosed` re-entered `_onSocketClosed` as an **unexpected** close:

- Misleading log: `Primary socket closed (code: null)`
- Double-disconnect of both children
- False `onClosed` to `CaptureProvider` → reconnect snackbar + keep-alive churn on every intentional teardown (including every BLE reconnect)

## Fix

Set `_status = disconnected` **before** stopping/disconnecting children so `_onSocketClosed`'s guard treats those callbacks as expected.

## Context

Seen with custom STT + on-device Whisper composite mode: device BLE flaps cause intentional composite teardown; the spurious close path made each flap look like a transcription outage and triggered unnecessary reconnect UI.

Related plugin work (context cache so reconnects are cheaper): https://github.com/BasedHardware/whisper_flutter_new/pull/3

## Test plan

- [ ] Enable composite / on-device Whisper STT
- [ ] Start recording, stop recording → no `Primary socket closed (code: null)` warning for intentional stop
- [ ] Simulate BLE disconnect/reconnect while recording (or toggle device) → no false reconnect snackbar solely from composite teardown race
- [ ] Intentional transcription settings change still reconnects cleanly

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9438?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

