### PR TITLE
chore(app): bump whisper_flutter_new for context cache

### DIFF
--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -2481,8 +2481,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: af6b457cca4cdd6c97cc2dfa8557333ee09c81f1
-      resolved-ref: af6b457cca4cdd6c97cc2dfa8557333ee09c81f1
+      ref: "00bc62694782075b7f9982a4c497e7145ba7bde0"
+      resolved-ref: "00bc62694782075b7f9982a4c497e7145ba7bde0"
       url: "https://github.com/BasedHardware/whisper_flutter_new.git"
     source: git
     version: "1.0.1"

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -125,7 +125,7 @@ dependencies:
   whisper_flutter_new:
     git:
       url: https://github.com/BasedHardware/whisper_flutter_new.git
-      ref: af6b457cca4cdd6c97cc2dfa8557333ee09c81f1
+      ref: 00bc62694782075b7f9982a4c497e7145ba7bde0
   disk_space_2: ^1.0.11
   pasteboard: ^0.4.0
   vector_math: ^2.2.0


### PR DESCRIPTION
## Summary

Bumps `whisper_flutter_new` from `af6b457…` → `00bc626…` so the app picks up:

- process-global **native context cache** (no full model reload every buffer flush)
- `Whisper.releaseModel()` API

## Blocked on

**Do not merge until** https://github.com/BasedHardware/whisper_flutter_new/pull/3 is merged into `BasedHardware/whisper_flutter_new` and commit `00bc62694782075b7f9982a4c497e7145ba7bde0` exists on that repo.

If #3 is **squash-merged**, update `app/pubspec.yaml` + lock `ref` / `resolved-ref` to the new main SHA and re-run `flutter pub get`.

## Related

- Plugin: https://github.com/BasedHardware/whisper_flutter_new/pull/3
- Composite race fix: https://github.com/BasedHardware/omi/pull/9438

## Test plan

- [ ] #3 merged (or point temporarily at `andreayres/whisper_flutter_new` for local test)
- [ ] `cd app && flutter pub get`
- [ ] On-device: enable on-device Whisper; speak 2–3 short utterances
- [ ] Logs: first buffer may still pay model load; subsequent buffers should be much faster (wall time closer to audio length)
- [ ] Stop recording: no spurious `Primary socket closed (code: null)` if #9438 is also present

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9439?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

