### PR TITLE
feat(llm-gateway): add gateway-only model route overrides

### DIFF
--- a/backend/llm_gateway/config/README.md
+++ b/backend/llm_gateway/config/README.md
@@ -1,0 +1,10 @@
+# LLM Gateway Route Configuration
+
+`lanes.yaml`, `route_artifacts.yaml`, and `feature_bundles.yaml` define explicit gateway routes.
+
+`generated_route_overrides.yaml` changes only the gateway routes that are otherwise generated from
+`backend/utils/llm/model_config.py`. It must not be used to change legacy product routing: edits here
+are applied after the legacy profile is read and affect only `omi:auto:*` gateway lanes.
+
+Each override names one configured feature, selects its gateway provider/model, and may set
+provider request options such as `reasoning_effort` or Anthropic `effort`.

--- a/backend/llm_gateway/config/generated_route_overrides.yaml
+++ b/backend/llm_gateway/config/generated_route_overrides.yaml
@@ -1,0 +1,99 @@
+# Gateway-only model and reasoning policy. These overrides are applied after
+# model_config.py generates a lane, so legacy product routing remains unchanged.
+generated_route_overrides:
+  - feature: app_generator
+    primary: {provider: openai, model: gpt-5.6-luna}
+    provider_options: {reasoning_effort: medium}
+  - feature: chat_agent
+    primary: {provider: anthropic, model: claude-sonnet-5}
+    provider_options: {effort: medium}
+  - feature: chat_extraction
+    primary: {provider: openai, model: gpt-5.4-nano}
+    provider_options: {reasoning_effort: low}
+  - feature: chat_graph
+    primary: {provider: openai, model: gpt-5.4-nano}
+    provider_options: {reasoning_effort: low}
+  - feature: chat_responses
+    primary: {provider: openai, model: gpt-5.6-luna}
+    provider_options: {reasoning_effort: medium}
+  - feature: conv_action_items
+    primary: {provider: openai, model: gpt-5.6-luna}
+    provider_options: {reasoning_effort: low}
+  - feature: conv_app_result
+    primary: {provider: openai, model: gpt-5.6-luna}
+    provider_options: {reasoning_effort: low}
+  - feature: conv_app_select
+    primary: {provider: openai, model: gpt-5-nano}
+    provider_options: {reasoning_effort: low}
+  - feature: conv_discard
+    primary: {provider: openai, model: gpt-5-nano}
+    provider_options: {reasoning_effort: minimal}
+  - feature: conv_folder
+    primary: {provider: openai, model: gpt-5-nano}
+    provider_options: {reasoning_effort: minimal}
+  - feature: conv_structure
+    primary: {provider: openai, model: gpt-5.6-luna}
+    provider_options: {reasoning_effort: low}
+  - feature: daily_summary
+    primary: {provider: openai, model: gpt-5.6-luna}
+    provider_options: {reasoning_effort: low}
+  - feature: daily_summary_simple
+    primary: {provider: openai, model: gpt-5-nano}
+    provider_options: {reasoning_effort: minimal}
+  - feature: external_structure
+    primary: {provider: openai, model: gpt-5.4-nano}
+    provider_options: {reasoning_effort: low}
+  - feature: fair_use
+    primary: {provider: openai, model: gpt-5.6-luna}
+    provider_options: {reasoning_effort: medium}
+  - feature: goals
+    primary: {provider: openai, model: gpt-5.4-nano}
+    provider_options: {reasoning_effort: low}
+  - feature: goals_advice
+    primary: {provider: openai, model: gpt-5.6-luna}
+    provider_options: {reasoning_effort: medium}
+  - feature: knowledge_graph
+    primary: {provider: openai, model: gpt-5.4-nano}
+    provider_options: {reasoning_effort: low}
+  - feature: learnings
+    primary: {provider: openai, model: gpt-5.6-luna}
+    provider_options: {reasoning_effort: medium}
+  - feature: memories
+    primary: {provider: openai, model: gpt-5.4-nano}
+    provider_options: {reasoning_effort: low}
+  - feature: memory_category
+    primary: {provider: openai, model: gpt-5-nano}
+    provider_options: {reasoning_effort: minimal}
+  - feature: memory_conflict
+    primary: {provider: openai, model: gpt-5.4-nano}
+    provider_options: {reasoning_effort: low}
+  - feature: memory_l1
+    primary: {provider: openai, model: gpt-5.4-nano}
+    provider_options: {reasoning_effort: low}
+  - feature: memory_l2
+    primary: {provider: openai, model: gpt-5.4-nano}
+    provider_options: {reasoning_effort: medium}
+  - feature: notifications
+    primary: {provider: openai, model: gpt-5.6-luna}
+    provider_options: {reasoning_effort: low}
+  - feature: openglass
+    primary: {provider: openai, model: gpt-5.4-nano}
+    provider_options: {reasoning_effort: low}
+  - feature: persona_chat
+    primary: {provider: openai, model: gpt-5-nano}
+    provider_options: {reasoning_effort: low}
+  - feature: persona_chat_premium
+    primary: {provider: openai, model: gpt-5.6-luna}
+    provider_options: {reasoning_effort: medium}
+  - feature: persona_clone
+    primary: {provider: openai, model: gpt-5.6-luna}
+    provider_options: {reasoning_effort: medium}
+  - feature: proactive_notification
+    primary: {provider: openai, model: gpt-5.4-nano}
+    provider_options: {reasoning_effort: low}
+  - feature: smart_glasses
+    primary: {provider: openai, model: gpt-5-nano}
+    provider_options: {reasoning_effort: minimal}
+  - feature: what_matters_now
+    primary: {provider: openai, model: gpt-5.4-nano}
+    provider_options: {reasoning_effort: low}

--- a/backend/llm_gateway/config/route_artifacts.yaml
+++ b/backend/llm_gateway/config/route_artifacts.yaml
@@ -1,14 +1,16 @@
 route_artifacts:
   - route_artifact_id: route.chat_structured.2026_06_27.001
-    artifact_digest: sha256:271229622698025cd7f496f3d0cb3cb505306c2e7b5d6ce32a35d059b1908094
+    artifact_digest: sha256:d9ab75d4eb53c029028c7a2ebccee8d273d043d6d7553a8e8c9f9897d28bfb6a
     lane_id: omi:auto:chat-structured
     surface: openai.chat_completions
     primary:
       provider: openai
-      model: gpt-4.1-mini
+      model: gpt-5.4-nano
     fallbacks:
       - provider: openai
-        model: gpt-4.1-mini
+        model: gpt-5.4-nano
+    provider_options:
+      reasoning_effort: low
     timeouts:
       request_ms: 30000
     retry:
@@ -56,17 +58,17 @@ route_artifacts:
         - invalid_config
 
   - route_artifact_id: route.chat_structured.2026_06_20.001
-    artifact_digest: sha256:70492be577ce8833273a58f04802aafa251d7981c0ad4c7a818a895fb5d1d9fc
+    artifact_digest: sha256:70f61658ab9f0283514d86ce3438bdcd89ed3f15dd8d42533648384840894e67
     lane_id: omi:auto:chat-structured
     surface: openai.chat_completions
-    # LKG primary must match the legacy `chat_extraction` model (gpt-4.1-mini) so
-    # that while the pilot's active route is shadow-only, serving this route is a
-    # no-user-visible behavior match instead of silently swapping gpt-4.1-mini
-    # for gpt-4o-mini and changing classifier behavior for 100% of pilot calls.
+    # The gateway LKG mirrors the active model so shadow serving and fallback use
+    # the same gateway-only model policy without changing legacy chat extraction.
     primary:
       provider: openai
-      model: gpt-4.1-mini
+      model: gpt-5.4-nano
     fallbacks: []
+    provider_options:
+      reasoning_effort: low
     timeouts:
       request_ms: 30000
     retry:

--- a/backend/llm_gateway/gateway/config_loader.py
+++ b/backend/llm_gateway/gateway/config_loader.py
@@ -8,7 +8,7 @@ from typing import Any, TypeAlias, cast
 import yaml
 from pydantic import BaseModel, ConfigDict
 
-from llm_gateway.gateway.schemas import FeatureBundle, LaneConfig, RouteArtifact
+from llm_gateway.gateway.schemas import FeatureBundle, GeneratedRouteOverride, LaneConfig, RouteArtifact
 from utils.llm.gateway_client import feature_auto_lane_id
 from utils.llm.model_config import (
     get_all_configured_features,
@@ -20,6 +20,7 @@ from utils.llm.model_config import (
 
 DEFAULT_CONFIG_DIR = Path(__file__).resolve().parents[1] / 'config'
 PROD_ENV_VAR = 'OMI_LLM_GATEWAY_PROD'
+GENERATED_ROUTE_OVERRIDES_FILE = 'generated_route_overrides.yaml'
 ConfigItem: TypeAlias = dict[str, Any]
 
 
@@ -43,7 +44,10 @@ def load_gateway_config(config_dir: str | Path | None = None, *, prod_mode: bool
     artifact_items = _load_config_list(resolved_config_dir / 'route_artifacts.yaml', 'route_artifacts')
     bundle_items = _load_config_list(resolved_config_dir / 'feature_bundles.yaml', 'feature_bundles')
 
-    generated_lane_items, generated_artifact_items, generated_bundle_items = _generated_feature_route_items()
+    generated_route_overrides = load_generated_route_overrides(resolved_config_dir)
+    generated_lane_items, generated_artifact_items, generated_bundle_items = _generated_feature_route_items(
+        generated_route_overrides
+    )
 
     lanes = _parse_lanes([*generated_lane_items, *lane_items])
     route_artifacts = _parse_route_artifacts([*generated_artifact_items, *artifact_items], prod_mode=resolved_prod_mode)
@@ -53,6 +57,26 @@ def load_gateway_config(config_dir: str | Path | None = None, *, prod_mode: bool
     _validate_feature_bundles(feature_bundles, lanes)
 
     return GatewayConfig(lanes=lanes, route_artifacts=route_artifacts, feature_bundles=feature_bundles)
+
+
+def load_generated_route_overrides(
+    config_dir: str | Path | None = None,
+) -> dict[str, GeneratedRouteOverride]:
+    resolved_config_dir = Path(config_dir) if config_dir is not None else DEFAULT_CONFIG_DIR
+    items = _load_optional_config_list(
+        resolved_config_dir / GENERATED_ROUTE_OVERRIDES_FILE,
+        'generated_route_overrides',
+    )
+    configured_features = get_all_configured_features()
+    overrides: dict[str, GeneratedRouteOverride] = {}
+    for item in items:
+        override = GeneratedRouteOverride.model_validate(item)
+        if override.feature not in configured_features:
+            raise ConfigValidationError(f'gateway route override references unknown feature: {override.feature}')
+        if override.feature in overrides:
+            raise ConfigValidationError(f'duplicate gateway route override: {override.feature}')
+        overrides[override.feature] = override
+    return overrides
 
 
 def _resolve_prod_mode(prod_mode: bool | None) -> bool:
@@ -86,6 +110,12 @@ def _load_config_list(path: Path, top_level_key: str) -> list[ConfigItem]:
         if not isinstance(item, Mapping):
             raise ConfigValidationError(f'{path} {top_level_key} entries must be mappings')
     return [dict(cast(Mapping[str, Any], item)) for item in items]
+
+
+def _load_optional_config_list(path: Path, top_level_key: str) -> list[ConfigItem]:
+    if not path.exists():
+        return []
+    return _load_config_list(path, top_level_key)
 
 
 def _parse_lanes(items: list[ConfigItem]) -> dict[str, LaneConfig]:
@@ -169,13 +199,18 @@ def feature_lane_id(feature: str) -> str:
     return feature_auto_lane_id(feature)
 
 
-def _generated_feature_route_items() -> tuple[list[dict[str, Any]], list[dict[str, Any]], list[dict[str, Any]]]:
+def _generated_feature_route_items(
+    route_overrides: Mapping[str, GeneratedRouteOverride],
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]], list[dict[str, Any]]]:
     lanes: list[dict[str, Any]] = []
     artifacts: list[dict[str, Any]] = []
     bundles: list[dict[str, Any]] = []
     for feature in sorted(get_all_configured_features()):
-        model = get_model(feature)
-        provider = get_provider(feature)
+        legacy_model = get_model(feature)
+        legacy_provider = get_provider(feature)
+        override = route_overrides.get(feature)
+        model = override.primary.model if override is not None else legacy_model
+        provider = override.primary.provider if override is not None else legacy_provider
         lane_id = feature_lane_id(feature)
         route_id = f"route.{feature}.model_config.001"
         capabilities = _capabilities_for_feature(feature)
@@ -194,6 +229,8 @@ def _generated_feature_route_items() -> tuple[list[dict[str, Any]], list[dict[st
         )
         primary = {'provider': provider, 'model': _provider_model_name(provider, model)}
         provider_options = get_route_options(feature, model, provider)
+        if override is not None:
+            provider_options.update(override.provider_options)
         artifacts.append(
             {
                 'route_artifact_id': route_id,

--- a/backend/llm_gateway/gateway/schemas.py
+++ b/backend/llm_gateway/gateway/schemas.py
@@ -83,6 +83,14 @@ class ProviderRef(StrictBaseModel):
     model: str = Field(min_length=1)
 
 
+class GeneratedRouteOverride(StrictBaseModel):
+    """Gateway-only route selection for a lane generated from the legacy profile."""
+
+    feature: str = Field(min_length=1)
+    primary: ProviderRef
+    provider_options: dict[str, Any] = Field(default_factory=dict)
+
+
 class TimeoutPolicy(StrictBaseModel):
     request_ms: int = Field(gt=0)
 
@@ -209,4 +217,9 @@ def compute_route_artifact_digest(artifact: RouteArtifact | dict[str, Any]) -> s
     return f'sha256:{hashlib.sha256(canonical.encode("utf-8")).hexdigest()}'
 
 
-ConfigFileName = Literal['lanes.yaml', 'route_artifacts.yaml', 'feature_bundles.yaml']
+ConfigFileName = Literal[
+    'lanes.yaml',
+    'route_artifacts.yaml',
+    'feature_bundles.yaml',
+    'generated_route_overrides.yaml',
+]

--- a/backend/llm_gateway/routers/anthropic_messages.py
+++ b/backend/llm_gateway/routers/anthropic_messages.py
@@ -13,6 +13,7 @@ from fastapi.responses import JSONResponse, StreamingResponse
 
 from llm_gateway.gateway.auth import ServiceAuthDependency
 from llm_gateway.gateway.config_loader import GatewayConfig
+from llm_gateway.gateway.schemas import RouteArtifact
 from llm_gateway.routers.dependencies import get_gateway_config
 
 router = APIRouter()
@@ -41,8 +42,9 @@ async def create_anthropic_message(
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail='request body must be an object')
 
     body = cast(dict[str, Any], request_body)
-    provider_model = _resolve_lane_provider_model(config, body.get('model'))
-    body['model'] = provider_model
+    route = _resolve_lane_route(config, body.get('model'))
+    body['model'] = route.primary.model
+    body.update(route.provider_options)
 
     api_key = _resolve_anthropic_api_key(request)
     if not api_key:
@@ -69,7 +71,7 @@ async def create_anthropic_message(
     return JSONResponse(status_code=response.status_code, content=_response_json_or_error(response))
 
 
-def _resolve_lane_provider_model(config: GatewayConfig, model: object) -> str:
+def _resolve_lane_route(config: GatewayConfig, model: object) -> RouteArtifact:
     if not isinstance(model, str) or not model.strip():
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail='model is required')
     lane_id = model.strip()
@@ -93,7 +95,7 @@ def _resolve_lane_provider_model(config: GatewayConfig, model: object) -> str:
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=f'lane {lane_id} is not an anthropic messages lane',
         )
-    return provider_ref.model
+    return route
 
 
 def _resolve_anthropic_api_key(request: Request) -> str | None:

--- a/backend/tests/unit/test_llm_gateway_anthropic_passthrough.py
+++ b/backend/tests/unit/test_llm_gateway_anthropic_passthrough.py
@@ -100,7 +100,7 @@ def test_anthropic_messages_passthrough_preserves_cache_control(_reset_anthropic
     fake: _FakeAsyncClient = _reset_anthropic_client
     fake._post_response = httpx.Response(
         200,
-        json={'id': 'msg_1', 'type': 'message', 'role': 'assistant', 'content': [], 'model': 'claude-sonnet-4-6'},
+        json={'id': 'msg_1', 'type': 'message', 'role': 'assistant', 'content': [], 'model': 'claude-sonnet-5'},
     )
 
     response = TestClient(app).post('/v1/messages', json=_agentic_request(), headers=_auth_headers())
@@ -108,7 +108,8 @@ def test_anthropic_messages_passthrough_preserves_cache_control(_reset_anthropic
     assert response.status_code == 200
     assert len(fake.post_calls) == 1
     forwarded = fake.post_calls[0]['json']
-    assert forwarded['model'] == 'claude-sonnet-4-6'
+    assert forwarded['model'] == 'claude-sonnet-5'
+    assert forwarded['effort'] == 'medium'
     assert forwarded['system'][0]['cache_control'] == {'type': 'ephemeral', 'ttl': '1h'}
     assert forwarded['tools'][0]['name'] == 'get_memories_tool'
     assert fake.post_calls[0]['headers']['x-api-key'] == 'anthropic-test-key'

--- a/backend/tests/unit/test_llm_gateway_config.py
+++ b/backend/tests/unit/test_llm_gateway_config.py
@@ -6,7 +6,7 @@ import pytest
 import yaml
 
 from llm_gateway.gateway.config_loader import ConfigValidationError, load_gateway_config
-from utils.llm.model_config import get_all_configured_features
+from utils.llm.model_config import get_all_configured_features, get_model
 
 LANE_ID = 'omi:auto:chat-structured'
 ACTIVE_ROUTE = 'route.chat_structured.2026_06_27.001'
@@ -23,6 +23,36 @@ def test_loads_default_gateway_config():
     assert lane.last_known_good == LKG_ROUTE
     assert config.route_artifacts[ACTIVE_ROUTE].content_digest.startswith('sha256:')
     assert config.feature_bundles['chat_extraction.requires_context'].lane_id == LANE_ID
+    assert config.route_artifacts[ACTIVE_ROUTE].primary.model == 'gpt-5.4-nano'
+    assert config.route_artifacts[ACTIVE_ROUTE].provider_options['reasoning_effort'] == 'low'
+
+
+def test_gateway_route_overrides_do_not_change_the_legacy_model_profile():
+    config = load_gateway_config(prod_mode=True)
+
+    assert get_model('conv_discard') == 'gpt-4.1-nano'
+    assert get_model('memories') == 'gpt-4.1-mini'
+    assert get_model('fair_use') == 'gpt-5.1'
+    assert get_model('chat_agent') == 'claude-sonnet-4-6'
+
+    assert config.route_artifacts['route.conv_discard.model_config.001'].primary.model == 'gpt-5-nano'
+    assert config.route_artifacts['route.memories.model_config.001'].primary.model == 'gpt-5.4-nano'
+    assert config.route_artifacts['route.fair_use.model_config.001'].primary.model == 'gpt-5.6-luna'
+    assert config.route_artifacts['route.chat_agent.model_config.001'].primary.model == 'claude-sonnet-5'
+    assert config.route_artifacts['route.memory_l2.model_config.001'].provider_options['reasoning_effort'] == 'medium'
+    assert config.route_artifacts['route.chat_agent.model_config.001'].provider_options['effort'] == 'medium'
+
+
+def test_unknown_gateway_route_override_fails(tmp_path):
+    write_config(
+        tmp_path,
+        generated_route_overrides=[
+            {'feature': 'not_a_configured_feature', 'primary': {'provider': 'openai', 'model': 'gpt-5-nano'}}
+        ],
+    )
+
+    with pytest.raises(ConfigValidationError, match='gateway route override references unknown feature'):
+        load_gateway_config(tmp_path, prod_mode=False)
 
 
 def test_chat_structured_routes_have_background_shadow_timeout_budget():
@@ -132,6 +162,7 @@ def write_config(
     active_overrides: dict | None = None,
     lkg_overrides: dict | None = None,
     route_artifacts: list[dict] | None = None,
+    generated_route_overrides: list[dict] | None = None,
 ) -> None:
     config_dir.mkdir(parents=True, exist_ok=True)
     lane = {
@@ -167,6 +198,10 @@ def write_config(
     write_yaml(config_dir / 'lanes.yaml', {'lanes': [lane]})
     write_yaml(config_dir / 'route_artifacts.yaml', {'route_artifacts': route_artifacts})
     write_yaml(config_dir / 'feature_bundles.yaml', {'feature_bundles': [feature_bundle]})
+    if generated_route_overrides is not None:
+        write_yaml(
+            config_dir / 'generated_route_overrides.yaml', {'generated_route_overrides': generated_route_overrides}
+        )
 
 
 def capabilities(structured_output: str = 'json_schema') -> dict:

--- a/backend/tests/unit/test_llm_gateway_coverage_guardrails.py
+++ b/backend/tests/unit/test_llm_gateway_coverage_guardrails.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import yaml
 import pytest
 
-from llm_gateway.gateway.config_loader import feature_lane_id, load_gateway_config
+from llm_gateway.gateway.config_loader import feature_lane_id, load_gateway_config, load_generated_route_overrides
 from utils.llm.model_config import get_all_configured_features, get_route_options, get_model, get_provider
 
 BACKEND_DIR = Path(__file__).resolve().parents[2]
@@ -88,15 +88,25 @@ def test_every_model_config_feature_has_inventory_and_gateway_lane():
     assert missing_lanes == []
 
 
-def test_generated_gateway_lanes_preserve_model_config_route_options():
+def test_generated_gateway_lanes_apply_only_declared_gateway_route_overrides():
     config = load_gateway_config(prod_mode=True)
+    overrides = load_generated_route_overrides()
 
     for feature in get_all_configured_features():
-        model = get_model(feature)
-        provider = get_provider(feature)
+        override = overrides.get(feature)
+        model = override.primary.model if override is not None else get_model(feature)
+        provider = override.primary.provider if override is not None else get_provider(feature)
         route = config.route_artifacts[f'route.{feature}.model_config.001']
 
-        assert route.provider_options == get_route_options(feature, model, provider)
+        expected_options = get_route_options(feature, model, provider)
+        if override is not None:
+            expected_options.update(override.provider_options)
+        expected_provider_model = (
+            f'google/{model}' if provider == 'openrouter' and model.startswith('gemini') else model
+        )
+        assert route.primary.model == expected_provider_model
+        assert route.primary.provider == provider
+        assert route.provider_options == expected_options
 
 
 def test_anthropic_generated_lanes_do_not_advertise_streaming_without_adapter_support():

--- a/backend/tests/unit/test_llm_gateway_executor.py
+++ b/backend/tests/unit/test_llm_gateway_executor.py
@@ -38,10 +38,10 @@ async def test_executor_success_uses_active_primary_and_exposes_lane_model():
     assert result.response['choices'][0]['message']['content'] == '{"answer":"primary"}'
     assert result.selected_route_artifact_id == ACTIVE_ROUTE
     assert result.selected_provider == 'openai'
-    assert result.selected_model == 'gpt-4.1-mini'
+    assert result.selected_model == 'gpt-5.4-nano'
     assert not result.fallback_used
     assert not result.used_lkg
-    assert provider.calls[0].request['model'] == 'gpt-4.1-mini'
+    assert provider.calls[0].request['model'] == 'gpt-5.4-nano'
     assert provider.calls[0].request['stream'] is False
 
 
@@ -60,7 +60,7 @@ async def test_executor_forwards_prompt_parser_request_without_response_format()
         ProviderRegistry({'openai': provider}),
     )
 
-    assert provider.calls[0].request['model'] == 'gpt-4.1-mini'
+    assert provider.calls[0].request['model'] == 'gpt-5.4-nano'
     assert 'response_format' not in provider.calls[0].request
 
 
@@ -134,7 +134,7 @@ async def test_executor_retries_provider_up_to_max_attempts_before_fallback():
     )
 
     # Primary tried 3 times (max_attempts), then fallback once
-    assert [call.model for call in provider.calls] == ['gpt-4.1-mini', 'gpt-4.1-mini', 'gpt-4.1-mini', 'gpt-4o-mini']
+    assert [call.model for call in provider.calls] == ['gpt-5.4-nano', 'gpt-5.4-nano', 'gpt-5.4-nano', 'gpt-4o-mini']
     assert result.response['choices'][0]['message']['content'] == '{"answer":"fallback"}'
 
 
@@ -201,7 +201,7 @@ async def test_executor_uses_active_route_fallback_for_policy_allowed_failures(f
     assert result.fallback_used
     assert result.fallback_reason == failure_class
     assert not result.used_lkg
-    assert [call.model for call in provider.calls] == ['gpt-4.1-mini', 'gpt-4o-mini']
+    assert [call.model for call in provider.calls] == ['gpt-5.4-nano', 'gpt-4o-mini']
 
 
 @pytest.mark.asyncio
@@ -252,11 +252,11 @@ async def test_executor_uses_lkg_only_when_active_route_policy_allows():
 
     assert result.response['model'] == LANE_ID
     assert result.selected_route_artifact_id == LKG_ROUTE
-    assert result.selected_model == 'gpt-4.1-mini'
+    assert result.selected_model == 'gpt-5.4-nano'
     assert result.fallback_used
     assert result.fallback_reason == FailureClass.TIMEOUT_BEFORE_OUTPUT
     assert result.used_lkg
-    assert [call.model for call in provider.calls] == ['gpt-4.1-mini', 'gpt-4.1-mini']
+    assert [call.model for call in provider.calls] == ['gpt-5.4-nano', 'gpt-5.4-nano']
 
 
 @pytest.mark.asyncio
@@ -380,9 +380,8 @@ async def test_shadow_active_route_serves_lkg_not_active():
     config = config_with_active_route(shadow_route)
     resolved = resolve_chat_completion_route(config, valid_request())
 
-    # Provider should be called with the LKG model (gpt-4.1-mini, which now
-    # matches the legacy chat_extraction model). The LKG is aligned with the
-    # legacy route by design so the shadow pilot is a no-user-visible match.
+    # Provider should be called with the gateway LKG model (gpt-5.4-nano).
+    # The gateway route is intentionally independent from legacy chat extraction.
     provider = FakeChatCompletionProvider(
         [fake_success_response(resolved.last_known_good_route.primary, content='{"answer":"lkg"}')]
     )
@@ -394,9 +393,9 @@ async def test_shadow_active_route_serves_lkg_not_active():
     )
 
     assert result.selected_route_artifact_id == LKG_ROUTE
-    assert result.selected_model == 'gpt-4.1-mini'
+    assert result.selected_model == 'gpt-5.4-nano'
     assert result.used_lkg
-    assert provider.calls[0].request['model'] == 'gpt-4.1-mini'
+    assert provider.calls[0].request['model'] == 'gpt-5.4-nano'
     assert selected_serving_route_artifact_id(resolved) == LKG_ROUTE
 
 
@@ -421,7 +420,7 @@ async def test_disabled_active_route_serves_lkg_not_active():
     )
 
     assert result.selected_route_artifact_id == LKG_ROUTE
-    assert result.selected_model == 'gpt-4.1-mini'
+    assert result.selected_model == 'gpt-5.4-nano'
     assert result.used_lkg
 
 

--- a/backend/tests/unit/test_llm_gateway_openai_compatible.py
+++ b/backend/tests/unit/test_llm_gateway_openai_compatible.py
@@ -43,11 +43,11 @@ def test_chat_completions_success_uses_lane_model_and_hides_route_metadata(monke
     assert 'selected_provider' not in body
     assert 'selected_route_artifact_id' not in body
     # The checked-in active route is in shadow rollout (percent 0), so live
-    # traffic is served by the last-known-good route. The LKG primary matches
-    # the legacy `chat_extraction` model (gpt-4.1-mini) so enabling the pilot
-    # is a no-user-visible behavior match while shadow-only.
-    assert provider.calls[0].model == 'gpt-4.1-mini'
-    assert provider.calls[0].request['model'] == 'gpt-4.1-mini'
+    # traffic is served by the last-known-good route. The LKG primary uses the
+    # gateway-only chat_extraction policy (gpt-5.4-nano), leaving the legacy
+    # product route unchanged while shadow-only.
+    assert provider.calls[0].model == 'gpt-5.4-nano'
+    assert provider.calls[0].request['model'] == 'gpt-5.4-nano'
     assert provider.calls[0].request['temperature'] == 0
     assert provider.calls[0].request['max_completion_tokens'] == 64
     assert 'metadata' not in provider.calls[0].request


### PR DESCRIPTION
## Summary

- Add gateway-local model and reasoning overrides without changing shared legacy routing.
- Move configured OpenAI and Anthropic gateway lanes to the agreed model policy, including newly introduced what_matters_now.
- Apply the Anthropic route effort through the native Messages proxy and cover override validation plus transport behavior.

## Why

Generated gateway lanes previously inherited the shared model configuration, so changing them could affect legacy product routes.

## Validation

- cd backend && bash test.sh
- Focused gateway tests: 55 passed
- Repository runner: test_llm_gateway_openai_compatible.py, 12 passed
- Import-time side-effect, module-stub pollution, and async-blocker checks passed
- Gateway configuration assertion: 40 lanes; all requested legacy model IDs replaced only in gateway routes

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9441?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

