### PR TITLE
fix(desktop): restore notch after screen transition

### DIFF
--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
@@ -2083,6 +2083,38 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
 
     // MARK: - NSWindowDelegate
 
+    /// A floating panel can move between displays when macOS changes Spaces or
+    /// reassigns windows, without emitting a display-configuration change. Keep
+    /// the SwiftUI presentation flag and frame in lockstep with the panel's
+    /// actual screen so an idle bar cannot render as the legacy pill inside a
+    /// notch-sized window (which is visually hidden by the camera housing).
+    func windowDidChangeScreen(_ notification: Notification) {
+        guard !isUserDragging, let screen = screenForPlacement else { return }
+
+        let previousUsesNotchIsland = state.usesNotchIsland
+        updateNotchIslandState()
+
+        // An open chat owns its user-resizable response dimensions. Updating
+        // the render mode is sufficient here; rebuilding its frame from the
+        // compact-bar defaults would discard that size (and can double-count
+        // an active voice-response glow).
+        guard !state.showingAIConversation else { return }
+
+        let targetFrame = frameForCurrentState(on: screen, usesNotchIsland: state.usesNotchIsland)
+        let requiresFrameRefresh = !Self.framesEquivalent(frame, targetFrame)
+        guard previousUsesNotchIsland != state.usesNotchIsland || requiresFrameRefresh else { return }
+
+        resizeToFrame(
+            targetFrame,
+            makeResizable: state.showingAIConversation && state.showingAIResponse,
+            animated: false
+        )
+        log(
+            "FloatingControlBarWindow: reconciled screen change to \(screen.localizedName) "
+                + "usesNotch=\(state.usesNotchIsland)"
+        )
+    }
+
     func windowDidResignKey(_ notification: Notification) {
         // Only dismiss when the user physically clicks away.
         // Programmatic focus changes — e.g. the AI agent activating a browser

--- a/desktop/macos/Desktop/Tests/FloatingBarGeometryTests.swift
+++ b/desktop/macos/Desktop/Tests/FloatingBarGeometryTests.swift
@@ -44,6 +44,30 @@ final class FloatingBarGeometryTests: XCTestCase {
         )
     }
 
+    func testScreenChangeReconcilesTheFloatingBarPresentationAndFrame() throws {
+        // omi-test-quality: source-inspection -- static contract: AppKit delegate callback must retain the reconciliation wiring
+        let source = try String(
+            contentsOf: URL(fileURLWithPath: #filePath)
+                .deletingLastPathComponent()
+                .deletingLastPathComponent()
+                .appendingPathComponent("Sources/FloatingControlBar/FloatingControlBarWindow.swift"),
+            encoding: .utf8
+        )
+        guard let methodStart = source.range(of: "func windowDidChangeScreen(_ notification: Notification)") else {
+            return XCTFail("Expected the floating bar to reconcile direct window screen changes")
+        }
+        guard let nextMethod = source.range(of: "func windowDidResignKey", range: methodStart.upperBound..<source.endIndex) else {
+            return XCTFail("Expected windowDidChangeScreen to precede the next window delegate method")
+        }
+
+        let method = String(source[methodStart.lowerBound..<nextMethod.lowerBound])
+        XCTAssertTrue(method.contains("let previousUsesNotchIsland = state.usesNotchIsland"))
+        XCTAssertTrue(method.contains("updateNotchIslandState()"))
+        XCTAssertTrue(method.contains("guard !state.showingAIConversation else { return }"))
+        XCTAssertTrue(method.contains("frameForCurrentState(on: screen, usesNotchIsland: state.usesNotchIsland)"))
+        XCTAssertTrue(method.contains("resizeToFrame("))
+    }
+
     func testTopCenterExpansionKeepsTopEdgeAndHorizontalCenterFixed() {
         let compactFrame = NSRect(x: 586, y: 876, width: 268, height: 58)
         let expandedFrame = FloatingControlBarGeometry.topCenterAnchoredFrame(

--- a/desktop/macos/changelog/unreleased/20260711-fix-notch-screen-transition.json
+++ b/desktop/macos/changelog/unreleased/20260711-fix-notch-screen-transition.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed the floating notch disappearing after macOS moves it between displays or Spaces"
+}


### PR DESCRIPTION
## Summary

- Reconcile the floating bar’s notch presentation whenever macOS moves its panel between screens or Spaces.
- Preserve open-chat response geometry while refreshing the underlying presentation mode.
- Add regression coverage and a desktop changelog entry.

## Root cause

The SwiftUI surface used a cached notch-mode flag that could become stale after a direct panel screen reassignment. The compact legacy pill then rendered inside a notch-sized window and was visually obscured by the camera housing until a hover, chat, or PTT resize refreshed it.

## Testing

- `cd desktop/macos && xcrun swift test -c debug --package-path Desktop --filter FloatingBarGeometryTests`
- `cd desktop/macos && ./scripts/agent-logic-harness.sh`
- Pre-push and PR preflight checks

## Product invariants affected

- INV-CHAT-1

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9447?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

