### PR TITLE
Enforce lifecycle headers for rollout scaffolding

### DIFF
--- a/.github/lifecycle-header-baseline.txt
+++ b/.github/lifecycle-header-baseline.txt
@@ -1,0 +1,20 @@
+# Existing designated files without lifecycle headers. This list is a frozen
+# debt census: edits to any listed file must add a valid header instead.
+backend/scripts/app_key_memory_grant_assignment_readiness.py
+backend/scripts/firestore_rules_iam_proof.py
+backend/scripts/first_user_memory_e2e_proof.py
+backend/scripts/mcp_api_key_scope_readiness.py
+backend/scripts/p1_3_v3_archive_short_term_visibility_readiness.py
+backend/scripts/p1_5_tools_fastapi_testclient_readiness.py
+backend/scripts/pinecone_repair_validation_readiness.py
+backend/scripts/rollout_schema_readiness.py
+backend/scripts/shared_ns2_legacy_isolation_readiness.py
+backend/scripts/v3_dev_cloud_readiness.py
+backend/scripts/vector_repair_outbox_oidc_iam_proof.py
+backend/scripts/vector_search_provider_readiness.py
+backend/utils/memory/default_read_rollout.py
+backend/utils/memory/memory_read_rollout_core.py
+backend/utils/memory/v3_compatibility.py
+backend/utils/memory/v3_limited_rollout_config.py
+backend/utils/memory_ingestion/rollout.py
+backend/utils/memory_ingestion/rollout_cli.py

--- a/.github/scripts/check_lifecycle_headers.py
+++ b/.github/scripts/check_lifecycle_headers.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""Enforce lifecycle headers for rollout and operational scaffolding."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+BASELINE_PATH = ".github/lifecycle-header-baseline.txt"
+HEADER_LINE_LIMIT = 32
+LIFECYCLE_VALUES = {"one-time", "permanent"}
+ISSUE_URL_RE = re.compile(r"https://github\.com/[^/\s]+/[^/\s]+/issues/\d+(?:[?#][^\s]*)?$")
+INVARIANT_ID_RE = re.compile(r"INV-[A-Z0-9]+-\d+$")
+SKIP_DIRECTORY_NAMES = {"__pycache__"}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--changed-files", required=True, help="File containing changed repository-relative paths.")
+    parser.add_argument("--baseline", default=BASELINE_PATH, help="Repository-relative lifecycle baseline path.")
+    parser.add_argument("--root", default=".", help="Repository root.")
+    return parser.parse_args()
+
+
+def is_designated_path(path: str) -> bool:
+    normalized = path.replace("\\", "/")
+    parts = Path(normalized).parts
+    name = Path(normalized).name.lower()
+    if normalized.startswith("backend/scripts/"):
+        return any(marker in name for marker in ("readiness", "gauntlet", "proof"))
+    return normalized.startswith("backend/utils/") and any(
+        marker in part.lower() for marker in ("rollout", "compat") for part in parts[2:]
+    )
+
+
+def header_values(text: str, name: str) -> list[str]:
+    pattern = re.compile(rf"^\s*(?:#|//)\s*{re.escape(name)}:\s*(.*?)\s*$")
+    values: list[str] = []
+    for line in text.splitlines()[:HEADER_LINE_LIMIT]:
+        match = pattern.match(line)
+        if match:
+            values.append(match.group(1))
+    return values
+
+
+def parse_lifecycle_header(path: Path) -> tuple[str | None, str | None]:
+    try:
+        text = path.read_text(encoding="utf-8")
+    except UnicodeDecodeError:
+        return None, "must be UTF-8 text to carry a lifecycle header"
+    except OSError as exc:
+        return None, f"could not read file: {exc}"
+
+    lifecycles = header_values(text, "LIFECYCLE")
+    if not lifecycles:
+        return None, None
+    if len(lifecycles) != 1:
+        return None, "must declare exactly one LIFECYCLE header near the top"
+
+    lifecycle = lifecycles[0]
+    if lifecycle not in LIFECYCLE_VALUES:
+        return None, "LIFECYCLE must be one-time or permanent"
+
+    delete_after = header_values(text, "DELETE-AFTER")
+    if lifecycle == "permanent":
+        if delete_after:
+            return None, "permanent files must not declare DELETE-AFTER"
+        return lifecycle, None
+
+    if len(delete_after) != 1:
+        return None, "one-time files must declare exactly one DELETE-AFTER reference"
+    target = delete_after[0]
+    if not (ISSUE_URL_RE.fullmatch(target) or INVARIANT_ID_RE.fullmatch(target)):
+        return None, "DELETE-AFTER must be a GitHub issue URL or product invariant ID (for example INV-MEM-3)"
+    return lifecycle, None
+
+
+def load_baseline(path: Path) -> tuple[set[str], list[str]]:
+    entries: set[str] = set()
+    errors: list[str] = []
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError as exc:
+        return set(), [f"could not read lifecycle baseline {path}: {exc}"]
+
+    for line_number, line in enumerate(lines, start=1):
+        entry = line.strip()
+        if not entry or entry.startswith("#"):
+            continue
+        if entry in entries:
+            errors.append(f"{path}: duplicate baseline entry on line {line_number}: {entry}")
+        elif not is_designated_path(entry):
+            errors.append(f"{path}: non-designated baseline entry on line {line_number}: {entry}")
+        else:
+            entries.add(entry)
+    return entries, errors
+
+
+def iter_designated_files(root: Path):
+    for path in root.joinpath("backend").rglob("*"):
+        if path.is_file() and not any(part in SKIP_DIRECTORY_NAMES for part in path.relative_to(root).parts):
+            relative_path = path.relative_to(root).as_posix()
+            if is_designated_path(relative_path):
+                yield relative_path, path
+
+
+def validate(root: Path, changed_paths: list[str], baseline_path: Path) -> list[str]:
+    errors: list[str] = []
+    baseline, baseline_errors = load_baseline(baseline_path)
+    errors.extend(baseline_errors)
+
+    headerless: set[str] = set()
+    parsed_headers: dict[str, str | None] = {}
+    for relative_path, path in iter_designated_files(root):
+        lifecycle, header_error = parse_lifecycle_header(path)
+        parsed_headers[relative_path] = lifecycle
+        if header_error:
+            errors.append(f"{relative_path}: {header_error}")
+        elif lifecycle is None:
+            headerless.add(relative_path)
+
+    if headerless != baseline:
+        missing_from_baseline = sorted(headerless - baseline)
+        stale_baseline_entries = sorted(baseline - headerless)
+        errors.append("lifecycle baseline must exactly match the current headerless designated files")
+        for path in missing_from_baseline:
+            errors.append(f"  add a valid header (preferred) or record existing legacy debt: {path}")
+        for path in stale_baseline_entries:
+            errors.append(f"  remove stale lifecycle baseline entry: {path}")
+
+    for relative_path in changed_paths:
+        normalized = relative_path.replace("\\", "/")
+        if not is_designated_path(normalized):
+            continue
+        path = root / normalized
+        if not path.is_file():
+            continue
+        if parsed_headers.get(normalized) is None:
+            errors.append(
+                f"{normalized}: changed designated files require a valid lifecycle header near the top "
+                "(# LIFECYCLE: permanent or one-time)."
+            )
+    return errors
+
+
+def main() -> int:
+    args = parse_args()
+    root = Path(args.root).resolve()
+    changed_file = Path(args.changed_files)
+    if not changed_file.is_absolute():
+        changed_file = root / changed_file
+    baseline_path = Path(args.baseline)
+    if not baseline_path.is_absolute():
+        baseline_path = root / baseline_path
+
+    try:
+        changed_paths = [line.strip() for line in changed_file.read_text(encoding="utf-8").splitlines() if line.strip()]
+    except OSError as exc:
+        print(f"FAIL: could not read changed-files input: {exc}")
+        return 1
+
+    errors = validate(root, changed_paths, baseline_path)
+    if errors:
+        print("FAIL: lifecycle header policy")
+        for error in errors:
+            print(f"- {error}")
+        return 1
+
+    print("OK: lifecycle headers and frozen baseline are valid.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/test_check_lifecycle_headers.py
+++ b/.github/scripts/test_check_lifecycle_headers.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Unit tests for check_lifecycle_headers.py (stdlib unittest)."""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from check_lifecycle_headers import is_designated_path, parse_lifecycle_header, validate
+
+PERMANENT = "# LIFECYCLE: permanent\n\nprint('ok')\n"
+ONE_TIME = "# LIFECYCLE: one-time\n# DELETE-AFTER: INV-MEM-3\n\nprint('ok')\n"
+
+
+def write(root: Path, relative_path: str, content: str) -> Path:
+    path = root / relative_path
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+class DesignatedPathTests(unittest.TestCase):
+    def test_designated_paths_match_initial_policy(self) -> None:
+        self.assertTrue(is_designated_path("backend/scripts/example_readiness.py"))
+        self.assertTrue(is_designated_path("backend/scripts/rollout-proof.sh"))
+        self.assertTrue(is_designated_path("backend/utils/memory/compatibility.py"))
+        self.assertTrue(is_designated_path("backend/utils/memory/rollout/config.py"))
+        self.assertFalse(is_designated_path("backend/scripts/deploy.py"))
+        self.assertFalse(is_designated_path("backend/routers/rollout.py"))
+
+
+class HeaderTests(unittest.TestCase):
+    def test_accepts_permanent_header(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = write(Path(tmp), "permanent.py", PERMANENT)
+            self.assertEqual(parse_lifecycle_header(path), ("permanent", None))
+
+    def test_accepts_one_time_header_with_issue_url(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = write(
+                Path(tmp),
+                "one_time.py",
+                "# LIFECYCLE: one-time\n# DELETE-AFTER: https://github.com/BasedHardware/omi/issues/123\n",
+            )
+            self.assertEqual(parse_lifecycle_header(path), ("one-time", None))
+
+    def test_rejects_one_time_header_without_delete_after(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = write(Path(tmp), "one_time.py", "# LIFECYCLE: one-time\n")
+            lifecycle, error = parse_lifecycle_header(path)
+            self.assertIsNone(lifecycle)
+            self.assertIn("DELETE-AFTER", error or "")
+
+    def test_rejects_permanent_header_with_delete_after(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = write(Path(tmp), "permanent.py", PERMANENT.replace("\n\n", "\n# DELETE-AFTER: INV-MEM-3\n\n"))
+            lifecycle, error = parse_lifecycle_header(path)
+            self.assertIsNone(lifecycle)
+            self.assertIn("must not", error or "")
+
+
+class ValidationTests(unittest.TestCase):
+    def test_new_unlabeled_designated_file_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            path = "backend/scripts/new_readiness.py"
+            write(root, path, "print('missing header')\n")
+            baseline = write(root, ".github/lifecycle-header-baseline.txt", "")
+            errors = validate(root, [path], baseline)
+            self.assertTrue(any("require a valid lifecycle header" in error for error in errors))
+
+    def test_changed_baseline_file_requires_a_header(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            path = "backend/scripts/legacy_readiness.py"
+            write(root, path, "print('legacy')\n")
+            baseline = write(root, ".github/lifecycle-header-baseline.txt", f"{path}\n")
+            errors = validate(root, [path], baseline)
+            self.assertTrue(any("require a valid lifecycle header" in error for error in errors))
+
+    def test_frozen_baseline_allows_unchanged_legacy_file(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            path = "backend/scripts/legacy_readiness.py"
+            write(root, path, "print('legacy')\n")
+            baseline = write(root, ".github/lifecycle-header-baseline.txt", f"{path}\n")
+            self.assertEqual(validate(root, [], baseline), [])
+
+    def test_unbaselined_legacy_file_fails_the_debt_census(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            write(root, "backend/scripts/legacy_readiness.py", "print('legacy')\n")
+            baseline = write(root, ".github/lifecycle-header-baseline.txt", "")
+            errors = validate(root, [], baseline)
+            self.assertTrue(any("baseline must exactly match" in error for error in errors))
+
+    def test_valid_headers_are_not_baselined(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            permanent = "backend/scripts/permanent_gauntlet.py"
+            one_time = "backend/utils/memory/one_time_rollout.py"
+            write(root, permanent, PERMANENT)
+            write(root, one_time, ONE_TIME)
+            baseline = write(root, ".github/lifecycle-header-baseline.txt", "")
+            self.assertEqual(validate(root, [permanent, one_time], baseline), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/repo-checks.yml
+++ b/.github/workflows/repo-checks.yml
@@ -93,6 +93,12 @@ jobs:
       - name: Test brand UI ratchet helper
         run: python3 .github/scripts/test_check_brand_ui.py
 
+      - name: Test lifecycle header checker
+        run: python3 .github/scripts/test_check_lifecycle_headers.py
+
+      - name: Check lifecycle headers for rollout scaffolding
+        run: python3 .github/scripts/check_lifecycle_headers.py --changed-files /tmp/changed-files.txt
+
       - name: Check brand UI purple ratchet (INV-UI-1)
         if: github.event_name == 'pull_request'
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,6 +91,7 @@ Improve the code you touch — within your blast radius:
 
 - New `TODO`, `FIXME`, and `HACK` comments must reference a tracking issue or be resolved before merge.
 - Existing markers are legacy debt; only delete or annotate them when the owner and next action are clear.
+- Designated rollout scaffolding (`backend/scripts/*readiness*`, `*gauntlet*`, `*proof*`, and `backend/utils/**/*rollout*`, `*compat*`) needs a near-top `LIFECYCLE: permanent|one-time` header; one-time files also need `DELETE-AFTER: <GitHub issue URL or invariant ID>`. `.github/scripts/check_lifecycle_headers.py` enforces this with `.github/lifecycle-header-baseline.txt` as the frozen legacy census.
 
 ### Fallback / resilience telemetry
 

--- a/backend/scripts/cutover_evidence_readiness.py
+++ b/backend/scripts/cutover_evidence_readiness.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+# LIFECYCLE: one-time
+# DELETE-AFTER: INV-MEM-3
+
 from __future__ import annotations
 
 import argparse

--- a/backend/scripts/memory-continuity-gauntlet.py
+++ b/backend/scripts/memory-continuity-gauntlet.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# LIFECYCLE: permanent
 """Driver for the backend memory continuity gauntlet (INV-MEM)."""
 
 from __future__ import annotations

--- a/backend/scripts/memory-continuity-gauntlet.sh
+++ b/backend/scripts/memory-continuity-gauntlet.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# LIFECYCLE: permanent
 # Memory continuity gauntlet — standing INV-MEM smoke test for canonical memory tiers.
 #
 # HERMETIC pipeline rules (capture→promote→recall, archive exclusion, surface

--- a/backend/scripts/readiness_gate_common.py
+++ b/backend/scripts/readiness_gate_common.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 """Shared helpers for memory readiness scripts with optional fail-closed --require-go."""
 
+# LIFECYCLE: permanent
+
 from __future__ import annotations
 
 import argparse

--- a/backend/scripts/v3_dev_cloud_proof.py
+++ b/backend/scripts/v3_dev_cloud_proof.py
@@ -1,5 +1,8 @@
 """Dev-cloud proof helpers for memory ``/v3`` readiness scripts and tests."""
 
+# LIFECYCLE: one-time
+# DELETE-AFTER: INV-MEM-3
+
 from __future__ import annotations
 
 import hashlib

--- a/backend/scripts/v3_f5_real_service_evidence_readiness.py
+++ b/backend/scripts/v3_f5_real_service_evidence_readiness.py
@@ -6,6 +6,9 @@ performs no network/provider/Firestore calls, imports no production app/router,
 and leaves all readiness decisions BLOCKED/NO_GO.
 """
 
+# LIFECYCLE: one-time
+# DELETE-AFTER: INV-MEM-3
+
 from __future__ import annotations
 
 import argparse

--- a/backend/scripts/v3_f6_pre_gcp_aggregate_readiness.py
+++ b/backend/scripts/v3_f6_pre_gcp_aggregate_readiness.py
@@ -7,6 +7,9 @@ PRE_GCP_READY result means the branch is locally ready to move to a host with
 GCP access; it does not approve dev/prod evidence execution or any rollout.
 """
 
+# LIFECYCLE: one-time
+# DELETE-AFTER: INV-MEM-3
+
 from __future__ import annotations
 from typing import Any, Dict
 

--- a/backend/utils/task_intelligence/rollout.py
+++ b/backend/utils/task_intelligence/rollout.py
@@ -5,6 +5,8 @@ separate axes. The pure composer accepts both for hermetic tests; the production
 resolver obtains cohort membership from the canonical memory owner.
 """
 
+# LIFECYCLE: permanent
+
 from models.task_intelligence import TaskIntelligenceRolloutDecision, TaskWorkflowMode
 from utils.memory.memory_system import MemorySystem, resolve_memory_system
 


### PR DESCRIPTION
## Summary

- add a stdlib lifecycle-header checker for designated rollout/readiness scaffolding and run it from Repo Checks
- freeze the current legacy census in an explicit baseline while requiring every changed designated file to carry a valid header
- mark the named memory rollout evidence scripts as one-time and the standing gauntlet/shared rollout helpers as permanent

## Root cause and durable guard

Operational rollout proof code had no machine-readable lifecycle contract, so milestone-specific scripts could drift indefinitely. The checker now validates the full headerless census against the baseline and rejects any changed designated file without a valid `LIFECYCLE` header; one-time files additionally require a GitHub issue URL or product invariant ID in `DELETE-AFTER`.

The four memory evidence scripts use `INV-MEM-3` as their deletion target because no dedicated F5/F6/dev-cloud GitHub expiry issue exists; it is the locked invariant those rollout proofs enforce.

## Validation

- `python3 .github/scripts/test_check_lifecycle_headers.py`
- `python3 .github/scripts/check_lifecycle_headers.py --changed-files <(scripts/changed-files origin/main...HEAD)`
- `black --check --line-length 120 --skip-string-normalization .github/scripts/check_lifecycle_headers.py .github/scripts/test_check_lifecycle_headers.py`
- `actionlint -shellcheck '' .github/workflows/repo-checks.yml`
- `scripts/pr-preflight --base origin/main --head HEAD --pr-body-file /tmp/omi-9444-pr-body.md`

## Product invariants affected

none

Closes #9444


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9449?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

