### PR TITLE
fix RangeError crash in SD card WAL sync packet parsing

### DIFF
--- a/app/lib/services/wals/sdcard_wal_sync.dart
+++ b/app/lib/services/wals/sdcard_wal_sync.dart
@@ -36,6 +36,16 @@ class SDCardWalSyncImpl implements SDCardWalSync {
 
   static final Version _timestampMarkerMinVersion = Version.parse("3.0.16");
 
+  /// Parses an 83-byte SD card packet: byte 3 is the frame length, frame data starts at byte 4.
+  /// Returns null when the length byte is corrupted (frame would exceed the packet bounds).
+  static List<int>? parseLegacyPacketFrame(List<int> value) {
+    final amount = value[3];
+    if (amount <= 0 || 4 + amount > value.length) {
+      return null;
+    }
+    return value.sublist(4, 4 + amount);
+  }
+
   SDCardWalSyncImpl(this.listener);
 
   bool _supportsTimestampMarkers() {
@@ -306,8 +316,12 @@ class SDCardWalSyncImpl implements SDCardWalSync {
         }
 
         if (value.length == 83) {
-          var amount = value[3];
-          bytesData.add(value.sublist(4, 4 + amount));
+          final frame = parseLegacyPacketFrame(value);
+          if (frame != null) {
+            bytesData.add(frame);
+          } else {
+            Logger.debug('Skipping corrupted SD card packet: invalid frame length ${value[3]}');
+          }
           offset += 80;
         } else if (value.length == 440) {
           var packageOffset = 0;
@@ -441,8 +455,12 @@ class SDCardWalSyncImpl implements SDCardWalSync {
         }
 
         if (value.length == 83) {
-          var amount = value[3];
-          bytesData.add(value.sublist(4, 4 + amount));
+          final frame = parseLegacyPacketFrame(value);
+          if (frame != null) {
+            bytesData.add(frame);
+          } else {
+            Logger.debug('Skipping corrupted SD card packet: invalid frame length ${value[3]}');
+          }
           offset += 80;
         } else if (value.length == 440) {
           var packageOffset = 0;

--- a/app/test/unit/sdcard_wal_sync_packet_test.dart
+++ b/app/test/unit/sdcard_wal_sync_packet_test.dart
@@ -1,0 +1,43 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:omi/services/wals/sdcard_wal_sync.dart';
+
+/// Regression tests for the 83-byte SD card packet parser.
+///
+/// Crash: FlutterError — RangeError (end): Invalid value: Not in inclusive
+/// range 4..83: 217 in SDCardWalSyncImpl._readStorageBytesToFileLegacy.
+/// A corrupted length byte (value[3]) larger than the packet payload made
+/// `value.sublist(4, 4 + amount)` throw.
+void main() {
+  List<int> packet(int amount, {int length = 83}) {
+    final p = List<int>.filled(length, 0xAB);
+    p[3] = amount;
+    return p;
+  }
+
+  group('SDCardWalSyncImpl.parseLegacyPacketFrame', () {
+    test('returns the frame for a valid length byte', () {
+      final frame = SDCardWalSyncImpl.parseLegacyPacketFrame(packet(79));
+      expect(frame, isNotNull);
+      expect(frame!.length, 79);
+    });
+
+    test('returns a partial frame when length byte is under the max', () {
+      final frame = SDCardWalSyncImpl.parseLegacyPacketFrame(packet(40));
+      expect(frame, isNotNull);
+      expect(frame!.length, 40);
+    });
+
+    test('returns null instead of throwing for a corrupted length byte (crash case: 217)', () {
+      expect(SDCardWalSyncImpl.parseLegacyPacketFrame(packet(217)), isNull);
+    });
+
+    test('returns null when the frame would exceed the packet by one byte', () {
+      expect(SDCardWalSyncImpl.parseLegacyPacketFrame(packet(80)), isNull);
+    });
+
+    test('returns null for a zero length byte', () {
+      expect(SDCardWalSyncImpl.parseLegacyPacketFrame(packet(0)), isNull);
+    });
+  });
+}


### PR DESCRIPTION
## Crash

SDCardWalSyncImpl._readStorageBytesToFileLegacy.<fn>
FlutterError - RangeError (end): Invalid value: Not in inclusive range 4..83: 217

package:omi/services/wals/sdcard_wal_sync.dart:379

https://console.firebase.google.com/u/0/project/based-hardware/crashlytics/app/ios:com.friend-app-with-wearable.ios12/issues/04f72c0237bef6ebab6a2a064bb94a5d?time=7d&types=crash&sessionEventKey=80a4b452f842462ca427a389fe4b5c16_2239228293514945503

Logs:

```
Fatal Exception: FlutterError
0  ???                            0x0 _TypedIntListMixin.sublist (dart:typed_data)
1  ???                            0x0 SDCardWalSyncImpl._readStorageBytesToFileLegacy.<fn> + 310 (sdcard_wal_sync.dart:310)
2  ???                            0x0 OmiGlassConnection.performGetBleAudioBytesListener.<fn> + 122 (omiglass_connection.dart:122)
```

## Root cause

In an 83-byte SD card BLE packet, byte 3 is the frame length and the frame data starts at byte 4. The parser trusted the length byte unconditionally: `value.sublist(4, 4 + amount)`. When the device sends a corrupted length byte (here `217`), the sublist end exceeds the packet bounds and throws a fatal `RangeError`, killing the SD card sync. The same unguarded pattern existed in both `_readStorageBytesToFileLegacy` and `_readStorageBytesToFileWithMarkers`.

## Fix

- Extracted a validated `SDCardWalSyncImpl.parseLegacyPacketFrame` helper that returns `null` when the length byte is out of range (`amount <= 0` or `4 + amount > value.length`) instead of throwing.
- Both read paths now skip the corrupted packet (logged) while still advancing the storage offset by 80 bytes, so sync progresses past the corrupted packet instead of crashing.

## Verification

- `flutter test test/unit/sdcard_wal_sync_packet_test.dart` — 5 new regression tests pass, including the exact crash case (`amount = 217`), the off-by-one boundary (`amount = 80`), and the zero-length case.
- Full `bash app/test.sh` — 747 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9450?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

