### PR TITLE
Refactor V3 memory modules into package

### DIFF
--- a/.github/scripts/check_version_prefixed_filenames.py
+++ b/.github/scripts/check_version_prefixed_filenames.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Reject version-prefixed source filenames outside their version package."""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from collections.abc import Iterable
+from pathlib import PurePosixPath
+
+ISSUE_URL = "https://github.com/BasedHardware/omi/issues/9443"
+VERSIONED_FILENAME = re.compile(r"^(?P<version>v[0-9]+)_.+\.(?:py|swift|ts|rs)$")
+
+GRANDFATHERED_VIOLATIONS = {
+    "backend/scripts/v3_dev_cloud_proof.py",
+    "backend/scripts/v3_dev_cloud_readiness.py",
+    "backend/scripts/v3_f5_real_service_evidence_readiness.py",
+    "backend/scripts/v3_f6_pre_gcp_aggregate_readiness.py",
+    "backend/scripts/v3_limited_rollout_config.py",
+    "backend/testing/memory/v3_canary_approval.py",
+    "backend/testing/memory/v3_f5_evidence.py",
+    "backend/testing/memory/v3_f6/__init__.py",
+    "backend/testing/memory/v3_f6/_validation.py",
+    "backend/testing/memory/v3_f6/aggregate.py",
+    "backend/testing/memory/v3_f6/audit.py",
+    "backend/testing/memory/v3_f6/config.py",
+    "backend/testing/memory/v3_f6/fingerprints.py",
+    "backend/testing/memory/v3_f6/identity_iam.py",
+    "backend/testing/memory/v3_f6/local_defaults.py",
+    "backend/testing/memory/v3_f6/local_doubles.py",
+    "backend/testing/memory/v3_f6/local_smoke.py",
+    "backend/testing/memory/v3_f6/pre_gcp_aggregate.py",
+    "backend/testing/memory/v3_f6/protocol.py",
+    "backend/testing/memory/v3_f6/read_evidence.py",
+    "backend/testing/memory/v3_f6/readonly_contracts.py",
+    "backend/testing/memory/v3_f6/redaction.py",
+    "backend/testing/memory/v3_f6/run_context.py",
+    "backend/testing/memory/v3_f6/run_record.py",
+    "backend/testing/memory/v3_get_dependency_seam.py",
+    "backend/testing/memory/v3_get_runtime_snapshot.py",
+    "backend/testing/memory/v3_local_telemetry.py",
+    "backend/testing/memory/v3_route_planner.py",
+    "backend/tests/unit/v3_prod_read_probes/__init__.py",
+    "backend/tests/unit/v3_prod_read_probes/canary_approval_production.py",
+    "backend/tests/unit/v3_prod_read_probes/cursor_secret_production.py",
+    "backend/tests/unit/v3_prod_read_probes/projection_write_convergence.py",
+    "backend/tests/unit/v3_prod_read_probes/runtime_config_source.py",
+    "backend/tests/unit/v3_router_probes/__init__.py",
+    "backend/tests/unit/v3_router_probes/fail_closed_matrix.py",
+    "backend/tests/unit/v3_router_probes/fastapi_route_contract.py",
+    "backend/tests/unit/v3_router_probes/get_dependency_auth.py",
+    "backend/tests/unit/v3_router_probes/in_process.py",
+    "backend/tests/unit/v3_router_probes/real_router_dependency_map.py",
+    "backend/tests/unit/v3_router_probes/real_router_get_testclient.py",
+    "backend/tests/unit/v3_router_probes/route_signature_integration.py",
+    "backend/tests/unit/v3_router_probes/stubs.py",
+}
+
+
+def is_versioned_filename(path: str) -> bool:
+    return bool(VERSIONED_FILENAME.fullmatch(PurePosixPath(path).name))
+
+
+def is_in_versioned_package(path: str) -> bool:
+    match = VERSIONED_FILENAME.fullmatch(PurePosixPath(path).name)
+    return bool(match and match.group("version") in PurePosixPath(path).parts[:-1])
+
+
+def violations(paths: Iterable[str]) -> list[str]:
+    return sorted(
+        path
+        for path in paths
+        if is_versioned_filename(path) and not is_in_versioned_package(path) and path not in GRANDFATHERED_VIOLATIONS
+    )
+
+
+def tracked_paths() -> list[str]:
+    return subprocess.check_output(["git", "ls-files"], text=True).splitlines()
+
+
+def main() -> int:
+    invalid_paths = violations(tracked_paths())
+    if not invalid_paths:
+        print("OK: no new version-prefixed source filenames outside version packages.")
+        return 0
+
+    print(f"FAIL: version goes in the package path, not the filename — see {ISSUE_URL}.")
+    for path in invalid_paths:
+        print(f"  - {path}")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/test_check_version_prefixed_filenames.py
+++ b/.github/scripts/test_check_version_prefixed_filenames.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Unit tests for the version-prefixed filename lint."""
+
+from __future__ import annotations
+
+import io
+import unittest
+from unittest.mock import patch
+
+import check_version_prefixed_filenames as lint
+
+
+class VersionPrefixedFilenameTests(unittest.TestCase):
+    def test_detects_each_supported_source_suffix(self) -> None:
+        for suffix in (".py", ".swift", ".ts", ".rs"):
+            self.assertTrue(lint.is_versioned_filename(f"src/v4_reader{suffix}"))
+
+    def test_ignores_nonmatching_names_and_suffixes(self) -> None:
+        self.assertFalse(lint.is_versioned_filename("src/reader_v4.py"))
+        self.assertFalse(lint.is_versioned_filename("src/v4_reader.dart"))
+        self.assertFalse(lint.is_versioned_filename("src/v4_.py"))
+
+    def test_allows_versioned_filenames_inside_version_packages(self) -> None:
+        self.assertTrue(lint.is_in_versioned_package("backend/utils/memory/v4/v4_reader.py"))
+        self.assertEqual(lint.violations(["backend/utils/memory/v4/v4_reader.py"]), [])
+
+    def test_rejects_new_version_prefixed_filename_outside_package(self) -> None:
+        self.assertEqual(lint.violations(["backend/utils/memory/v4_reader.py"]), ["backend/utils/memory/v4_reader.py"])
+
+    def test_rejects_filename_in_a_different_version_package(self) -> None:
+        self.assertEqual(
+            lint.violations(["backend/utils/memory/v3/v4_reader.py"]), ["backend/utils/memory/v3/v4_reader.py"]
+        )
+
+    def test_allows_grandfathered_legacy_path(self) -> None:
+        self.assertEqual(lint.violations(["backend/scripts/v3_dev_cloud_proof.py"]), [])
+
+    def test_main_reports_issue_for_new_violation(self) -> None:
+        output = io.StringIO()
+        with patch.object(lint, "tracked_paths", return_value=["backend/utils/memory/v4_reader.py"]), patch(
+            "sys.stdout", output
+        ):
+            self.assertEqual(lint.main(), 1)
+
+        self.assertIn("version goes in the package path, not the filename", output.getvalue())
+        self.assertIn(lint.ISSUE_URL, output.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/repo-checks.yml
+++ b/.github/workflows/repo-checks.yml
@@ -100,6 +100,12 @@ jobs:
             --changed-files /tmp/changed-files.txt \
             --base "${{ needs.changes.outputs.diff_base }}"
 
+      - name: Test version-prefixed filename lint
+        run: python3 .github/scripts/test_check_version_prefixed_filenames.py
+
+      - name: Check version-prefixed filenames
+        run: python3 .github/scripts/check_version_prefixed_filenames.py
+
       - name: Check desktop changelog data
         if: github.event_name != 'pull_request'
         run: python3 .github/scripts/desktop-changelog.py validate

--- a/backend/database/memory_apply_store.py
+++ b/backend/database/memory_apply_store.py
@@ -26,7 +26,7 @@ from models.memory_apply import (
 )
 from models.memory_operations import MemoryOperation
 from models.product_memory import MemoryItemStatus, MemoryItem
-from utils.memory.v3_account_generation_source import (
+from utils.memory.v3.account_generation_source import (
     V3_TRUSTED_ACCOUNT_GENERATION_SCHEMA_VERSION,
     V3_TRUSTED_ACCOUNT_GENERATION_SOURCE,
 )

--- a/backend/database/memory_compatibility_projection.py
+++ b/backend/database/memory_compatibility_projection.py
@@ -16,7 +16,7 @@ from typing import Any, NoReturn, cast
 from google.cloud import firestore
 
 from database.memory_collections import MemoryCollections
-from utils.memory.v3_projection_reader_contract import (
+from utils.memory.v3.projection_reader_contract import (
     V3_COMPATIBILITY_PROJECTION_SCHEMA_VERSION,
     V3_COMPATIBILITY_PROJECTION_SOURCE,
     V3_COMPATIBILITY_PROJECTION_VERSION,

--- a/backend/routers/memories.py
+++ b/backend/routers/memories.py
@@ -21,8 +21,8 @@ from database.vector_db import (
 from models.memories import MemoryDB, Memory, MemoryCategory
 from models.memory_imports import MemoryImportBatchRequest, MemoryImportBatchResponse
 from utils.apps import update_personas_async
-from utils.memory.v3_composed_get_service import V3ComposedRequestParams, V3ComposedResponse
-from utils.memory.v3_production_runtime import build_v3_production_runtime
+from utils.memory.v3.composed_get_service import V3ComposedRequestParams, V3ComposedResponse
+from utils.memory.v3.production_runtime import build_v3_production_runtime
 from utils.memory.canonical_activation import canonical_read_enabled, canonical_write_decision, canonical_write_enabled
 from utils.memory.canonical_memory_adapter import (
     memory_item_to_memorydb,

--- a/backend/scripts/apply_first_user_v3_projection.py
+++ b/backend/scripts/apply_first_user_v3_projection.py
@@ -27,7 +27,7 @@ if str(BACKEND_DIR) not in sys.path:
 
 from database.google_credentials import prepare_google_credentials
 from database.memory_collections import MemoryCollections
-from utils.memory.v3_projection_reader_contract import (
+from utils.memory.v3.projection_reader_contract import (
     V3_COMPATIBILITY_PROJECTION_SCHEMA_VERSION,
     V3_COMPATIBILITY_PROJECTION_SOURCE,
     V3_COMPATIBILITY_PROJECTION_VERSION,

--- a/backend/scripts/enroll_canonical_memory_user.py
+++ b/backend/scripts/enroll_canonical_memory_user.py
@@ -26,7 +26,7 @@ from config.memory_rollout import MemoryRolloutMode, PASSED
 from database.google_credentials import prepare_google_credentials
 from database.memory_collections import MemoryCollections
 from utils.memory.default_read_rollout import DEFAULT_READ_ROLLOUT_SCHEMA_VERSION
-from utils.memory.v3_limited_rollout_config import GLOBAL_READ_GATE_PATH, WRITE_CONVERGENCE_GATE_PATH
+from utils.memory.v3.limited_rollout_config import GLOBAL_READ_GATE_PATH, WRITE_CONVERGENCE_GATE_PATH
 
 FIRST_USER_UID = "vi7SA9ckQCe4ccobWNxlbdcNdC23"
 DEFAULT_OWNER = "memory_platform"

--- a/backend/scripts/firestore_python_apply_emulator_test.py
+++ b/backend/scripts/firestore_python_apply_emulator_test.py
@@ -21,7 +21,7 @@ from models.memory_evidence import ArtifactPreservationState, MemoryEvidence
 from models.memory_apply import ApplyStatus, MemoryControlState
 from models.memory_contracts import DurablePatchDecision, LifecycleState
 from models.memory_operations import MemoryOperation, MemoryOperationType
-from utils.memory.v3_account_generation_source import read_memory_v3_trusted_account_generation
+from utils.memory.v3.account_generation_source import read_memory_v3_trusted_account_generation
 
 
 def _stored_model(model: Any) -> dict[str, Any]:

--- a/backend/scripts/first_user_memory_e2e_proof.py
+++ b/backend/scripts/first_user_memory_e2e_proof.py
@@ -28,7 +28,7 @@ if str(BACKEND_DIR) not in sys.path:
 
 from database.google_credentials import prepare_google_credentials
 from database.memory_collections import MemoryCollections
-from utils.memory.v3_limited_rollout_config import GLOBAL_READ_GATE_PATH, WRITE_CONVERGENCE_GATE_PATH
+from utils.memory.v3.limited_rollout_config import GLOBAL_READ_GATE_PATH, WRITE_CONVERGENCE_GATE_PATH
 
 FIRST_USER_UID = "vi7SA9ckQCe4ccobWNxlbdcNdC23"
 DEFAULT_PROJECT = "based-hardware"

--- a/backend/scripts/memory-continuity-gauntlet.py
+++ b/backend/scripts/memory-continuity-gauntlet.py
@@ -299,7 +299,7 @@ class HermeticRuntime:
                 lambda **_: trusted,
             ),
             patch(
-                "utils.memory.v3_account_generation_source.read_memory_v3_trusted_account_generation",
+                "utils.memory.v3.account_generation_source.read_memory_v3_trusted_account_generation",
                 lambda **_: trusted,
                 create=True,
             ),
@@ -367,7 +367,7 @@ class MemoryContinuityGauntlet:
         from config.memory_rollout import PASSED, MemoryRolloutMode, MemoryRolloutStageGate
         from tests.unit.fixtures.memory_adapter_fakes import enabled_rollout_doc
         from utils.memory.default_read_rollout import GLOBAL_READ_GATE_PATH
-        from utils.memory.v3_limited_rollout_config import WRITE_CONVERGENCE_GATE_PATH
+        from utils.memory.v3.limited_rollout_config import WRITE_CONVERGENCE_GATE_PATH
 
         def _set_gate(path: str, payload: dict[str, Any]) -> None:
             parts = path.split("/")
@@ -669,7 +669,7 @@ class MemoryContinuityGauntlet:
         )
 
         def failing_memory_service(_params, _adapters):
-            from utils.memory.v3_composed_get_service import V3ComposedResponse
+            from utils.memory.v3.composed_get_service import V3ComposedResponse
 
             return V3ComposedResponse.error(503, "infrastructure_failure")
 

--- a/backend/scripts/p1_3_v3_archive_short_term_visibility_readiness.py
+++ b/backend/scripts/p1_3_v3_archive_short_term_visibility_readiness.py
@@ -10,7 +10,7 @@ _BACKEND_ROOT = Path(__file__).resolve().parents[1]
 if str(_BACKEND_ROOT) not in sys.path:
     sys.path.insert(0, str(_BACKEND_ROOT))
 
-from utils.memory.v3_archive_visibility_readiness import evaluate_archive_short_term_visibility_readiness
+from utils.memory.v3.archive_visibility_readiness import evaluate_archive_short_term_visibility_readiness
 
 
 def main() -> int:

--- a/backend/scripts/p1_3_v3_control_reader_emulator_test.py
+++ b/backend/scripts/p1_3_v3_control_reader_emulator_test.py
@@ -19,13 +19,13 @@ from google.cloud import firestore
 
 from config.memory_rollout import MemoryRolloutMode, MemoryRolloutConfig
 from database.memory_collections import MemoryCollections
-from utils.memory.v3_control_reader_contract import (
+from utils.memory.v3.control_reader_contract import (
     V3ControlDecisionReason,
     V3ControlReaderRequest,
     V3ControlRouteFamily,
     decide_v3_control_route,
 )
-from utils.memory.v3_control_state_adapter import read_v3_control
+from utils.memory.v3.control_state_adapter import read_v3_control
 
 PROJECT_ID = os.environ.get("GCLOUD_PROJECT") or os.environ.get("FIREBASE_PROJECT") or "demo-memory"
 UID = "memory-v3-control-reader-emulator-user"

--- a/backend/scripts/p1_3_v3_projection_reader_emulator_test.py
+++ b/backend/scripts/p1_3_v3_projection_reader_emulator_test.py
@@ -19,7 +19,7 @@ from google.cloud import firestore
 
 from database.memory_collections import MemoryCollections
 from database.memory_compatibility_projection import read_v3_compatibility_projection_page
-from utils.memory.v3_projection_reader_contract import (
+from utils.memory.v3.projection_reader_contract import (
     V3_COMPATIBILITY_PROJECTION_SCHEMA_VERSION,
     V3ProjectionFailureReason,
     V3ProjectionReadError,

--- a/backend/scripts/v3_dev_cloud_proof.py
+++ b/backend/scripts/v3_dev_cloud_proof.py
@@ -12,7 +12,7 @@ from typing import Any, Iterable
 from config.memory_rollout import MemoryRolloutMode
 from database.memory_collections import MemoryCollections
 from utils.memory.default_read_rollout import DEFAULT_READ_ROLLOUT_SCHEMA_VERSION
-from utils.memory.v3_limited_rollout_config import GLOBAL_READ_GATE_PATH, WRITE_CONVERGENCE_GATE_PATH
+from utils.memory.v3.limited_rollout_config import GLOBAL_READ_GATE_PATH, WRITE_CONVERGENCE_GATE_PATH
 
 GATE_STATUS_BLOCKED = 'BLOCKED'
 GATE_STATUS_READY_TO_EXECUTE = 'READY_TO_EXECUTE_DEV_CLOUD_PROOF'

--- a/backend/scripts/v3_limited_rollout_config.py
+++ b/backend/scripts/v3_limited_rollout_config.py
@@ -17,7 +17,7 @@ BACKEND_DIR = Path(__file__).resolve().parents[1]
 if str(BACKEND_DIR) not in sys.path:
     sys.path.insert(0, str(BACKEND_DIR))
 
-from utils.memory.v3_limited_rollout_config import build_limited_rollout_config_bundle
+from utils.memory.v3.limited_rollout_config import build_limited_rollout_config_bundle
 
 
 def build_report(*, uid: str, account_generation: int) -> Dict[str, Any]:

--- a/backend/testing/e2e/test_canonical_memory_pipeline.py
+++ b/backend/testing/e2e/test_canonical_memory_pipeline.py
@@ -60,7 +60,7 @@ def _trusted_generation_patch(monkeypatch) -> None:
     )
     for target in (
         "utils.memory.canonical_memory_adapter.read_memory_v3_trusted_account_generation",
-        "utils.memory.v3_account_generation_source.read_memory_v3_trusted_account_generation",
+        "utils.memory.v3.account_generation_source.read_memory_v3_trusted_account_generation",
     ):
         monkeypatch.setattr(target, lambda **_: trusted, raising=False)
 
@@ -377,7 +377,7 @@ class TestCanonicalMemoryPipelineE2E:
         )
 
         def failing_memory_service(_params, _adapters):
-            from utils.memory.v3_composed_get_service import V3ComposedResponse
+            from utils.memory.v3.composed_get_service import V3ComposedResponse
 
             return V3ComposedResponse.error(503, "infrastructure_failure")
 

--- a/backend/testing/e2e/test_v3_memories_route.py
+++ b/backend/testing/e2e/test_v3_memories_route.py
@@ -92,7 +92,7 @@ def test_enrolled_memory_fake_success_maps_body_cursor_and_allowlisted_headers(c
     captured = []
 
     def fake_memory_service(params, _adapters):
-        from utils.memory.v3_composed_get_service import V3ComposedResponse
+        from utils.memory.v3.composed_get_service import V3ComposedResponse
 
         captured.append(params)
         composed_body = {
@@ -137,7 +137,7 @@ def test_enrolled_memory_fake_error_fails_closed_with_public_error_and_headers(c
     seed_memory("123", _memory_doc("legacy-not-fallback", "must not be returned"))
 
     def failing_memory_service(_params, _adapters):
-        from utils.memory.v3_composed_get_service import V3ComposedResponse
+        from utils.memory.v3.composed_get_service import V3ComposedResponse
 
         return V3ComposedResponse.error(503, "infrastructure_failure")
 

--- a/backend/testing/memory/v3_route_planner.py
+++ b/backend/testing/memory/v3_route_planner.py
@@ -8,17 +8,17 @@ from __future__ import annotations
 from dataclasses import dataclass, field, replace
 from typing import Any, Mapping, Sequence
 
-from utils.memory.v3_compatibility import V3CompatibilityReadPath
-from utils.memory.v3_memory_read_service import (
+from utils.memory.v3.compatibility import V3CompatibilityReadPath
+from utils.memory.v3.memory_read_service import (
     V3MemoryReadRequest,
     V3MemoryReadServiceInput,
     V3MemoryReadServiceResult,
     plan_v3_memory_read,
 )
-from utils.memory.v3_request_adapter import V3AdaptedRequest, adapt_v3_request_parameters
-from utils.memory.v3_response_adapter import V3MemoryResponse, adapt_v3_memory_response
-from utils.memory.v3_projection_readiness import V3ProjectionReadinessContext
-from utils.memory.v3_write_convergence import (
+from utils.memory.v3.request_adapter import V3AdaptedRequest, adapt_v3_request_parameters
+from utils.memory.v3.response_adapter import V3MemoryResponse, adapt_v3_memory_response
+from utils.memory.v3.projection_readiness import V3ProjectionReadinessContext
+from utils.memory.v3.write_convergence import (
     V3WriteConvergenceContext,
     V3WriteConvergenceDecision,
     decide_v3_write_convergence,

--- a/backend/tests/unit/test_inv_mem_1_guard.py
+++ b/backend/tests/unit/test_inv_mem_1_guard.py
@@ -27,7 +27,7 @@ from models.product_memory import (
     is_default_access_eligible,
 )
 from utils.memory.memory_read_api import query_default_product_memory_items
-from utils.memory.v3_control_reader_contract import (
+from utils.memory.v3.control_reader_contract import (
     V3ControlDecisionReason,
     V3ControlReadResult,
     V3ControlReaderRequest,

--- a/backend/tests/unit/test_memory_apply_store.py
+++ b/backend/tests/unit/test_memory_apply_store.py
@@ -11,7 +11,7 @@ import pytest
 from testing.import_isolation import load_module_fresh, stub_modules
 
 from models.memory_evidence import ArtifactPreservationState, MemoryEvidence, SourceState, SourceStateReason
-from utils.memory.v3_account_generation_source import read_memory_v3_trusted_account_generation
+from utils.memory.v3.account_generation_source import read_memory_v3_trusted_account_generation
 from models.memory_apply import ApplyStatus, MemoryControlState
 from models.memory_contracts import DurablePatchDecision, LifecycleState
 from models.memory_operations import MemoryOperation, MemoryOperationType

--- a/backend/tests/unit/test_memory_read_rollout_core_equivalence.py
+++ b/backend/tests/unit/test_memory_read_rollout_core_equivalence.py
@@ -1,7 +1,7 @@
 """Equivalence tests for shared memory read rollout decision core."""
 
-import utils.memory.v3_compatibility as v3_compatibility
-import utils.memory.v3_control_reader_contract as v3_control_reader_contract
+import utils.memory.v3.compatibility as v3_compatibility
+import utils.memory.v3.control_reader_contract as v3_control_reader_contract
 from config.memory_rollout import MemoryRolloutMode, PASSED, MemoryRolloutStageGate
 from utils.memory.default_read_rollout import (
     DEFAULT_READ_ROLLOUT_SCHEMA_VERSION,
@@ -20,8 +20,8 @@ from utils.memory.product_authorization import (
     ProductAuthorizationContext,
     authorize_memory_product_memory_route,
 )
-from utils.memory.v3_compatibility import V3CompatibilityContext, V3CompatibilityReadPath, decide_v3_compatibility
-from utils.memory.v3_control_reader_contract import (
+from utils.memory.v3.compatibility import V3CompatibilityContext, V3CompatibilityReadPath, decide_v3_compatibility
+from utils.memory.v3.control_reader_contract import (
     V3ControlDecisionReason,
     V3ControlReadResult,
     V3ControlReaderRequest,

--- a/backend/tests/unit/test_v3_account_generation_source.py
+++ b/backend/tests/unit/test_v3_account_generation_source.py
@@ -3,12 +3,12 @@ from datetime import datetime, timezone
 import pytest
 
 from database.memory_compatibility_projection import read_v3_compatibility_projection_page
-from utils.memory.v3_account_generation_source import (
+from utils.memory.v3.account_generation_source import (
     V3AccountGenerationFailureReason,
     V3TrustedAccountGenerationReadError,
     read_memory_v3_trusted_account_generation,
 )
-from utils.memory.v3_projection_reader_contract import (
+from utils.memory.v3.projection_reader_contract import (
     V3_COMPATIBILITY_PROJECTION_SCHEMA_VERSION,
     V3_COMPATIBILITY_PROJECTION_SOURCE,
     V3_COMPATIBILITY_PROJECTION_VERSION,

--- a/backend/tests/unit/test_v3_archive_visibility_readiness.py
+++ b/backend/tests/unit/test_v3_archive_visibility_readiness.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import pytest
 
-from utils.memory.v3_archive_visibility_readiness import (
+from utils.memory.v3.archive_visibility_readiness import (
     decide_default_visibility,
     evaluate_archive_short_term_visibility_readiness,
 )
@@ -207,11 +207,11 @@ def test_readiness_module_and_script_do_not_import_memories_router():
     import sys
 
     sys.modules.pop('routers.memories', None)
-    importlib.import_module('utils.memory.v3_archive_visibility_readiness')
+    importlib.import_module('utils.memory.v3.archive_visibility_readiness')
     importlib.import_module('scripts.p1_3_v3_archive_short_term_visibility_readiness')
 
     script_source = (ROOT / 'scripts' / 'p1_3_v3_archive_short_term_visibility_readiness.py').read_text()
-    utility_source = (ROOT / 'utils' / 'memory' / 'v3_archive_visibility_readiness.py').read_text()
+    utility_source = (ROOT / 'utils' / 'memory' / 'v3' / 'archive_visibility_readiness.py').read_text()
     assert 'routers.memories' not in sys.modules
     assert 'routers.memories' not in script_source
     assert 'routers.memories' not in utility_source

--- a/backend/tests/unit/test_v3_compatibility.py
+++ b/backend/tests/unit/test_v3_compatibility.py
@@ -1,6 +1,6 @@
 import inspect
 
-from utils.memory.v3_compatibility import (
+from utils.memory.v3.compatibility import (
     V3CompatibilityContext,
     V3CompatibilityDecision,
     V3CompatibilityReadPath,

--- a/backend/tests/unit/test_v3_compatibility_projection.py
+++ b/backend/tests/unit/test_v3_compatibility_projection.py
@@ -6,7 +6,7 @@ import pytest
 
 from database.memory_collections import MemoryCollections
 from database.memory_compatibility_projection import read_v3_compatibility_projection_page
-from utils.memory.v3_projection_reader_contract import (
+from utils.memory.v3.projection_reader_contract import (
     V3_COMPATIBILITY_PROJECTION_SCHEMA_VERSION,
     V3ProjectionCursor,
     V3ProjectionFailureReason,

--- a/backend/tests/unit/test_v3_composed_get_service.py
+++ b/backend/tests/unit/test_v3_composed_get_service.py
@@ -5,7 +5,7 @@ from dataclasses import replace
 
 import pytest
 
-from utils.memory.v3_composed_get_service import (
+from utils.memory.v3.composed_get_service import (
     V3ComposedAdapters,
     V3ComposedCursor,
     V3ComposedDependencyDecision,
@@ -354,7 +354,7 @@ def test_bounded_scan_read_counts_response_cap_and_offset_semantics():
 
 
 def test_static_import_checks_prohibit_fastapi_router_production_clients_and_telemetry():
-    source = inspect.getsource(__import__('utils.memory.v3_composed_get_service', fromlist=['']))
+    source = inspect.getsource(__import__('utils.memory.v3.composed_get_service', fromlist=['']))
     for forbidden in [
         'fastapi',
         'routers.memories',

--- a/backend/tests/unit/test_v3_control_reader_contract.py
+++ b/backend/tests/unit/test_v3_control_reader_contract.py
@@ -1,7 +1,7 @@
 import inspect
 
 from config.memory_rollout import MemoryRolloutMode
-from utils.memory.v3_control_reader_contract import (
+from utils.memory.v3.control_reader_contract import (
     V3ControlDecisionReason,
     V3ControlReadResult,
     V3ControlReaderRequest,
@@ -200,7 +200,7 @@ def test_control_reader_contract_is_pure_local_fake_injectable_and_has_stable_de
         'requires_legacy_reader',
     }.issubset(decision_fields)
 
-    source = inspect.getsource(__import__('utils.memory.v3_control_reader_contract', fromlist=['']))
+    source = inspect.getsource(__import__('utils.memory.v3.control_reader_contract', fromlist=['']))
     forbidden = [
         'routers.memories',
         'database.',

--- a/backend/tests/unit/test_v3_control_state_adapter.py
+++ b/backend/tests/unit/test_v3_control_state_adapter.py
@@ -3,13 +3,13 @@ from dataclasses import dataclass
 from config.memory_rollout import MemoryRolloutMode, MemoryRolloutConfig
 from database.memory_collections import MemoryCollections
 from utils.memory.default_read_rollout import DEFAULT_READ_ROLLOUT_TIMEOUT_SECONDS
-from utils.memory.v3_control_reader_contract import (
+from utils.memory.v3.control_reader_contract import (
     V3ControlDecisionReason,
     V3ControlReaderRequest,
     V3ControlRouteFamily,
     decide_v3_control_route,
 )
-from utils.memory.v3_control_state_adapter import read_v3_control, resolve_v3_effective_mode
+from utils.memory.v3.control_state_adapter import read_v3_control, resolve_v3_effective_mode
 
 
 @dataclass

--- a/backend/tests/unit/test_v3_cursor.py
+++ b/backend/tests/unit/test_v3_cursor.py
@@ -1,6 +1,6 @@
 import pytest
 
-from utils.memory.v3_cursor import (
+from utils.memory.v3.cursor import (
     V3CursorContext,
     V3CursorError,
     V3Keyset,

--- a/backend/tests/unit/test_v3_limited_rollout_config.py
+++ b/backend/tests/unit/test_v3_limited_rollout_config.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import pytest
 
 from config.memory_rollout import MemoryRolloutMode
-from utils.memory.v3_limited_rollout_config import (
+from utils.memory.v3.limited_rollout_config import (
     GLOBAL_READ_GATE_PATH,
     WRITE_CONVERGENCE_GATE_PATH,
     build_limited_rollout_config_bundle,

--- a/backend/tests/unit/test_v3_memory_read_service.py
+++ b/backend/tests/unit/test_v3_memory_read_service.py
@@ -1,13 +1,13 @@
 import inspect
 
-from utils.memory.v3_cursor import V3CursorContext, V3Keyset, create_v3_cursor
-from utils.memory.v3_memory_read_service import (
+from utils.memory.v3.cursor import V3CursorContext, V3Keyset, create_v3_cursor
+from utils.memory.v3.memory_read_service import (
     V3MemoryReadRequest,
     V3MemoryReadServiceInput,
     V3MemoryReadServiceResult,
     plan_v3_memory_read,
 )
-from utils.memory.v3_projection_readiness import DERIVED_COMPATIBILITY_PROJECTION_SOURCE
+from utils.memory.v3.projection_readiness import DERIVED_COMPATIBILITY_PROJECTION_SOURCE
 
 SECRET = b'unit-test-memory-v3-read-service-secret'
 
@@ -210,7 +210,7 @@ def test_read_service_is_pure_local_and_does_not_import_routers_database_or_netw
     assert 'include_archive_by_default' not in result_fields
     assert 'show_stale_short_term_by_default' not in result_fields
 
-    source = inspect.getsource(__import__('utils.memory.v3_memory_read_service', fromlist=['']))
+    source = inspect.getsource(__import__('utils.memory.v3.memory_read_service', fromlist=['']))
     forbidden = [
         'routers.memories',
         'database.',

--- a/backend/tests/unit/test_v3_production_runtime_wiring.py
+++ b/backend/tests/unit/test_v3_production_runtime_wiring.py
@@ -14,12 +14,12 @@ except Exception as exc:  # pragma: no cover - system pytest env without backend
 from config.memory_rollout import MemoryRolloutMode
 from database.memory_collections import MemoryCollections
 from utils.memory.default_read_rollout import DEFAULT_READ_ROLLOUT_SCHEMA_VERSION
-from utils.memory.v3_composed_get_service import (
+from utils.memory.v3.composed_get_service import (
     V3ComposedRequestParams,
     V3ComposedResponse,
     compose_v3_get,
 )
-from utils.memory.v3_production_runtime import build_v3_production_runtime
+from utils.memory.v3.production_runtime import build_v3_production_runtime
 
 
 @dataclass

--- a/backend/tests/unit/test_v3_projection_readiness.py
+++ b/backend/tests/unit/test_v3_projection_readiness.py
@@ -1,6 +1,6 @@
 import inspect
 
-from utils.memory.v3_projection_readiness import (
+from utils.memory.v3.projection_readiness import (
     V3ProjectionReadinessContext,
     V3ProjectionReadinessDecision,
     V3ProjectionReadinessState,

--- a/backend/tests/unit/test_v3_real_router_default_off_f4.py
+++ b/backend/tests/unit/test_v3_real_router_default_off_f4.py
@@ -16,7 +16,7 @@ try:
 except Exception as exc:  # pragma: no cover - exercised by minimal system pytest env
     pytest.skip(f'real FastAPI/TestClient proof requires backend venv dependencies: {exc}', allow_module_level=True)
 
-from utils.memory.v3_composed_get_service import V3ComposedResponse
+from utils.memory.v3.composed_get_service import V3ComposedResponse
 
 SENSITIVE_SENTINELS = [
     "secret-uid-123",

--- a/backend/tests/unit/test_v3_request_adapter.py
+++ b/backend/tests/unit/test_v3_request_adapter.py
@@ -1,6 +1,6 @@
 import pytest
 
-from utils.memory.v3_request_adapter import (
+from utils.memory.v3.request_adapter import (
     V3RequestAdapterError,
     adapt_v3_request_parameters,
 )

--- a/backend/tests/unit/test_v3_response_adapter.py
+++ b/backend/tests/unit/test_v3_response_adapter.py
@@ -2,11 +2,11 @@ import inspect
 
 import pytest
 
-from utils.memory.v3_memory_read_service import (
+from utils.memory.v3.memory_read_service import (
     V3CompatibilityReadPath,
     V3MemoryReadServiceResult,
 )
-from utils.memory.v3_response_adapter import (
+from utils.memory.v3.response_adapter import (
     V3ResponseShapeError,
     adapt_v3_memory_response,
 )
@@ -156,7 +156,7 @@ def test_archive_default_unavailable_and_stale_short_term_are_explicit_proof_fie
 
 
 def test_response_adapter_is_pure_local_and_has_no_route_database_cloud_or_testclient_dependency():
-    source = inspect.getsource(__import__('utils.memory.v3_response_adapter', fromlist=['']))
+    source = inspect.getsource(__import__('utils.memory.v3.response_adapter', fromlist=['']))
     forbidden = [
         'FastAPI',
         'TestClient',

--- a/backend/tests/unit/test_v3_route_planner.py
+++ b/backend/tests/unit/test_v3_route_planner.py
@@ -1,8 +1,8 @@
 import inspect
 
-from utils.memory.v3_projection_readiness import DERIVED_COMPATIBILITY_PROJECTION_SOURCE
+from utils.memory.v3.projection_readiness import DERIVED_COMPATIBILITY_PROJECTION_SOURCE
 from testing.memory.v3_route_planner import V3RoutePlanInput, plan_v3_memory_route
-from utils.memory.v3_write_convergence import V3ExternalWriteOperation, V3WriteConvergenceStatus
+from utils.memory.v3.write_convergence import V3ExternalWriteOperation, V3WriteConvergenceStatus
 
 
 def _projection_context(**overrides):

--- a/backend/tests/unit/test_v3_write_convergence.py
+++ b/backend/tests/unit/test_v3_write_convergence.py
@@ -1,6 +1,6 @@
 import inspect
 
-from utils.memory.v3_write_convergence import (
+from utils.memory.v3.write_convergence import (
     V3ExternalWriteOperation,
     V3WriteConvergenceContext,
     V3WriteConvergenceDecision,
@@ -180,7 +180,7 @@ def test_non_enrolled_legacy_primary_plan_only_and_no_enrolled_legacy_direct_wri
     assert forbidden_fields.isdisjoint(decision_fields)
     assert forbidden_fields.isdisjoint(context_fields)
 
-    source = inspect.getsource(__import__('utils.memory.v3_write_convergence', fromlist=['']))
+    source = inspect.getsource(__import__('utils.memory.v3.write_convergence', fromlist=['']))
     forbidden_tokens = [
         'routers.memories',
         'database.',

--- a/backend/tests/unit/v3_router_probes/fail_closed_matrix.py
+++ b/backend/tests/unit/v3_router_probes/fail_closed_matrix.py
@@ -26,7 +26,7 @@ BACKEND_DIR = Path(__file__).resolve().parents[3]
 if str(BACKEND_DIR) not in sys.path:
     sys.path.insert(0, str(BACKEND_DIR))
 
-from utils.memory.v3_projection_readiness import DERIVED_COMPATIBILITY_PROJECTION_SOURCE
+from utils.memory.v3.projection_readiness import DERIVED_COMPATIBILITY_PROJECTION_SOURCE
 from testing.memory.v3_route_planner import V3RouteExecutionPlan, V3RoutePlanInput, plan_v3_memory_route
 
 REAL_ROUTER_FAIL_CLOSED_MATRIX_PROOF = {

--- a/backend/tests/unit/v3_router_probes/get_dependency_auth.py
+++ b/backend/tests/unit/v3_router_probes/get_dependency_auth.py
@@ -148,7 +148,7 @@ __LEGACY_ITEM_BLOCK__
         memory_pkg.__path__ = ["utils/memory"]
         sys.modules["utils.memory"] = memory_pkg
         setattr(utils_pkg, "memory", memory_pkg)
-        production_runtime = types.ModuleType("utils.memory.v3_production_runtime")
+        production_runtime = types.ModuleType("utils.memory.v3.production_runtime")
         class ProductionV3GetRuntime:
             def __init__(self, enabled=False, source_decision="disabled", service=None, adapters=None, **kwargs):
                 self.enabled = enabled
@@ -161,10 +161,10 @@ __LEGACY_ITEM_BLOCK__
             return ProductionV3GetRuntime(enabled=False, source_decision="disabled")
         production_runtime.V3GetRuntime = ProductionV3GetRuntime
         production_runtime.build_v3_production_runtime = build_v3_production_runtime
-        sys.modules["utils.memory.v3_production_runtime"] = production_runtime
+        sys.modules["utils.memory.v3.production_runtime"] = production_runtime
         setattr(memory_pkg, "v3_production_runtime", production_runtime)
 
-        composed = types.ModuleType("utils.memory.v3_composed_get_service")
+        composed = types.ModuleType("utils.memory.v3.composed_get_service")
         class V3ComposedRequestParams:
             def __init__(self, limit=None, offset=None, cursor=None, include_archive=False, include_historical=False):
                 self.limit = limit
@@ -182,7 +182,7 @@ __LEGACY_ITEM_BLOCK__
                 self.decision = decision
         composed.V3ComposedRequestParams = V3ComposedRequestParams
         composed.V3ComposedResponse = V3ComposedResponse
-        sys.modules["utils.memory.v3_composed_get_service"] = composed
+        sys.modules["utils.memory.v3.composed_get_service"] = composed
         setattr(memory_pkg, "v3_composed_get_service", composed)
 
         memory_system_mod = types.ModuleType("utils.memory.memory_system")
@@ -279,11 +279,11 @@ __PIN_STUB_BLOCK__        surface_routing.pin_memory_system = pin_memory_system
         with_auth_response = client_with_override.get("/v3/memories")
 
         memory_adapter_modules = [
-            "utils.memory.v3_compatibility",
-            "utils.memory.v3_request_adapter",
+            "utils.memory.v3.compatibility",
+            "utils.memory.v3.request_adapter",
             "testing.memory.v3_route_planner",
-            "utils.memory.v3_memory_read_service",
-            "utils.memory.v3_response_adapter",
+            "utils.memory.v3.memory_read_service",
+            "utils.memory.v3.response_adapter",
         ]
         loaded_adapters = [name for name in memory_adapter_modules if name in sys.modules]
 

--- a/backend/tests/unit/v3_router_probes/in_process.py
+++ b/backend/tests/unit/v3_router_probes/in_process.py
@@ -11,9 +11,9 @@ from fastapi.testclient import TestClient
 from tests.unit.v3_router_probes.stubs import import_memories_router, install_router_import_stubs
 
 MEMORY_ADAPTER_MODULES = [
-    "utils.memory.v3_request_adapter",
+    "utils.memory.v3.request_adapter",
     "testing.memory.v3_route_planner",
-    "utils.memory.v3_response_adapter",
+    "utils.memory.v3.response_adapter",
 ]
 
 _STUB_MODULE_PREFIXES = (

--- a/backend/tests/unit/v3_router_probes/real_router_dependency_map.py
+++ b/backend/tests/unit/v3_router_probes/real_router_dependency_map.py
@@ -272,7 +272,7 @@ def _probe_code() -> str:
         memory_pkg.__path__ = ["utils/memory"]
         sys.modules["utils.memory"] = memory_pkg
         setattr(utils_pkg, "memory", memory_pkg)
-        production_runtime = types.ModuleType("utils.memory.v3_production_runtime")
+        production_runtime = types.ModuleType("utils.memory.v3.production_runtime")
         class ProductionV3GetRuntime:
             def __init__(self, enabled=False, source_decision="disabled", service=None, adapters=None, **kwargs):
                 self.enabled = enabled
@@ -285,10 +285,10 @@ def _probe_code() -> str:
             return ProductionV3GetRuntime(enabled=False, source_decision="disabled")
         production_runtime.V3GetRuntime = ProductionV3GetRuntime
         production_runtime.build_v3_production_runtime = build_v3_production_runtime
-        sys.modules["utils.memory.v3_production_runtime"] = production_runtime
+        sys.modules["utils.memory.v3.production_runtime"] = production_runtime
         setattr(memory_pkg, "v3_production_runtime", production_runtime)
 
-        composed = types.ModuleType("utils.memory.v3_composed_get_service")
+        composed = types.ModuleType("utils.memory.v3.composed_get_service")
         class V3ComposedRequestParams:
             def __init__(self, limit=None, offset=None, cursor=None, include_archive=False, include_historical=False):
                 self.limit = limit
@@ -306,7 +306,7 @@ def _probe_code() -> str:
                 self.decision = decision
         composed.V3ComposedRequestParams = V3ComposedRequestParams
         composed.V3ComposedResponse = V3ComposedResponse
-        sys.modules["utils.memory.v3_composed_get_service"] = composed
+        sys.modules["utils.memory.v3.composed_get_service"] = composed
         setattr(memory_pkg, "v3_composed_get_service", composed)
 
         memory_system_mod = types.ModuleType("utils.memory.memory_system")

--- a/backend/tests/unit/v3_router_probes/real_router_get_testclient.py
+++ b/backend/tests/unit/v3_router_probes/real_router_get_testclient.py
@@ -27,9 +27,9 @@ from tests.unit.v3_router_probes.real_router_dependency_map import (
 from tests.unit.v3_router_probes.stubs import legacy_memory_doc_factory_source, legacy_pin_stub_source
 
 MEMORY_ADAPTER_MODULES = [
-    "utils.memory.v3_request_adapter",
+    "utils.memory.v3.request_adapter",
     "testing.memory.v3_route_planner",
-    "utils.memory.v3_response_adapter",
+    "utils.memory.v3.response_adapter",
 ]
 
 
@@ -159,7 +159,7 @@ __LEGACY_ITEM_BLOCK__
         sys.modules["utils.memory"] = memory_pkg
         setattr(utils_pkg, "memory", memory_pkg)
 
-        composed = types.ModuleType("utils.memory.v3_composed_get_service")
+        composed = types.ModuleType("utils.memory.v3.composed_get_service")
         class V3ComposedRequestParams:
             def __init__(self, limit=None, offset=None, cursor=None, include_archive=False, include_historical=False):
                 self.limit = limit
@@ -177,10 +177,10 @@ __LEGACY_ITEM_BLOCK__
                 self.decision = decision
         composed.V3ComposedRequestParams = V3ComposedRequestParams
         composed.V3ComposedResponse = V3ComposedResponse
-        sys.modules["utils.memory.v3_composed_get_service"] = composed
+        sys.modules["utils.memory.v3.composed_get_service"] = composed
         setattr(memory_pkg, "v3_composed_get_service", composed)
 
-        production_runtime = types.ModuleType("utils.memory.v3_production_runtime")
+        production_runtime = types.ModuleType("utils.memory.v3.production_runtime")
         class ProductionV3GetRuntime:
             def __init__(self, enabled=False, source_decision="disabled", service=None, adapters=None, **kwargs):
                 self.enabled = enabled
@@ -193,7 +193,7 @@ __LEGACY_ITEM_BLOCK__
             return ProductionV3GetRuntime(enabled=False, source_decision="disabled")
         production_runtime.V3GetRuntime = ProductionV3GetRuntime
         production_runtime.build_v3_production_runtime = build_v3_production_runtime
-        sys.modules["utils.memory.v3_production_runtime"] = production_runtime
+        sys.modules["utils.memory.v3.production_runtime"] = production_runtime
         setattr(memory_pkg, "v3_production_runtime", production_runtime)
 
         memory_system_mod = types.ModuleType("utils.memory.memory_system")
@@ -283,9 +283,9 @@ __PIN_STUB_BLOCK__        surface_routing.pin_memory_system = pin_memory_system
                 route_refs.append(f"{method} {path}")
 
         memory_adapter_modules = [
-            "utils.memory.v3_request_adapter",
+            "utils.memory.v3.request_adapter",
             "testing.memory.v3_route_planner",
-            "utils.memory.v3_response_adapter",
+            "utils.memory.v3.response_adapter",
         ]
         loaded_adapters = [name for name in memory_adapter_modules if name in sys.modules]
 

--- a/backend/tests/unit/v3_router_probes/stubs.py
+++ b/backend/tests/unit/v3_router_probes/stubs.py
@@ -241,7 +241,7 @@ def install_router_import_stubs(
     sys.modules["database.memory_compatibility_projection"] = projection_db
     setattr(database_pkg, "memory_compatibility_projection", projection_db)
 
-    composed = types.ModuleType("utils.memory.v3_composed_get_service")
+    composed = types.ModuleType("utils.memory.v3.composed_get_service")
 
     class V3ComposedRequestParams:
         def __init__(self, limit=None, offset=None, cursor=None, include_archive=False, include_historical=False):
@@ -262,10 +262,10 @@ def install_router_import_stubs(
 
     composed.V3ComposedRequestParams = V3ComposedRequestParams
     composed.V3ComposedResponse = V3ComposedResponse
-    sys.modules["utils.memory.v3_composed_get_service"] = composed
+    sys.modules["utils.memory.v3.composed_get_service"] = composed
     setattr(memory_pkg, "v3_composed_get_service", composed)
 
-    production_runtime = types.ModuleType("utils.memory.v3_production_runtime")
+    production_runtime = types.ModuleType("utils.memory.v3.production_runtime")
 
     class ProductionV3GetRuntime:
         def __init__(self, enabled=False, source_decision="disabled", service=None, adapters=None, **kwargs):
@@ -281,7 +281,7 @@ def install_router_import_stubs(
 
     production_runtime.V3GetRuntime = ProductionV3GetRuntime
     production_runtime.build_v3_production_runtime = build_v3_production_runtime
-    sys.modules["utils.memory.v3_production_runtime"] = production_runtime
+    sys.modules["utils.memory.v3.production_runtime"] = production_runtime
     setattr(memory_pkg, "v3_production_runtime", production_runtime)
 
     canonical_adapter = types.ModuleType("utils.memory.canonical_memory_adapter")

--- a/backend/utils/memory/canonical_activation.py
+++ b/backend/utils/memory/canonical_activation.py
@@ -10,13 +10,13 @@ from typing import Any
 from config.memory_rollout import MemoryRolloutConfig, MemoryRolloutMode
 from utils.memory.memory_system import MemorySystem, list_canonical_cohort_uids
 from utils.memory.memory_system_pin import pin_memory_system
-from utils.memory.v3_account_generation_source import read_memory_v3_trusted_account_generation
-from utils.memory.v3_control_reader_contract import (
+from utils.memory.v3.account_generation_source import read_memory_v3_trusted_account_generation
+from utils.memory.v3.control_reader_contract import (
     V3ControlReaderRequest,
     V3ControlRouteFamily,
     decide_v3_control_route,
 )
-from utils.memory.v3_control_state_adapter import read_v3_control
+from utils.memory.v3.control_state_adapter import read_v3_control
 
 logger = logging.getLogger(__name__)
 

--- a/backend/utils/memory/canonical_memory_adapter.py
+++ b/backend/utils/memory/canonical_memory_adapter.py
@@ -53,7 +53,7 @@ from utils.memory.memory_system import MemorySystem, resolve_memory_system
 from utils.retrieval.hybrid import rrf_rerank
 from utils.memory.canonical_vector_sync import delete_canonical_memory_vector, sync_canonical_memory_vector
 from utils.memory.product_memory_read_service import fetch_authoritative_product_memory_items
-from utils.memory.v3_account_generation_source import read_memory_v3_trusted_account_generation
+from utils.memory.v3.account_generation_source import read_memory_v3_trusted_account_generation
 
 logger = logging.getLogger(__name__)
 

--- a/backend/utils/memory/memory_read_rollout_core.py
+++ b/backend/utils/memory/memory_read_rollout_core.py
@@ -1,7 +1,7 @@
 """Shared memory read rollout decision primitives.
 
 Both surface adapters (MCP/chat/developer via ``default_read_rollout``) and the
-external ``/v3`` GET stack (``v3_control_reader_contract`` / ``v3_compatibility``)
+external ``/v3`` GET stack (``v3.control_reader_contract`` / ``v3.compatibility``)
 normalize the same Firestore grant and operational-gate inputs. This module holds
 that shared core so grant resolution and enrolled read-mode gate evaluation stay
 aligned without collapsing surface-specific or v3-specific routing behavior.

--- a/backend/utils/memory/v3/__init__.py
+++ b/backend/utils/memory/v3/__init__.py
@@ -1,0 +1,1 @@
+"""V3 canonical memory-read implementation package."""

--- a/backend/utils/memory/v3/account_generation_source.py
+++ b/backend/utils/memory/v3/account_generation_source.py
@@ -1,6 +1,6 @@
-"""Canonical module for ``utils.memory.v3_account_generation_source`` (WS-G8b).
+"""Canonical module for ``utils.memory.v3.account_generation_source`` (WS-G8b).
 
-Neutral ``v3_account_generation_source`` is the source of truth. Legacy ``v3_account_generation_source`` remains an importable alias.
+This module owns the trusted V3 account-generation read contract.
 """
 
 from __future__ import annotations

--- a/backend/utils/memory/v3/archive_visibility_readiness.py
+++ b/backend/utils/memory/v3/archive_visibility_readiness.py
@@ -1,4 +1,4 @@
-"""Canonical module for ``utils.memory.v3_archive_visibility_readiness`` (WS-G8b)."""
+"""Canonical module for ``utils.memory.v3.archive_visibility_readiness`` (WS-G8b)."""
 
 from __future__ import annotations
 

--- a/backend/utils/memory/v3/compatibility.py
+++ b/backend/utils/memory/v3/compatibility.py
@@ -1,7 +1,7 @@
-"""Canonical module for ``utils.memory.v3_compatibility`` (WS-G8b).
+"""Canonical module for ``utils.memory.v3.compatibility`` (WS-G8b).
 
 Planner/test-path `/v3` compatibility decisions. Production GET routing uses
-``v3_control_reader_contract.decide_v3_control_route`` instead; this module
+``v3.control_reader_contract.decide_v3_control_route`` instead; this module
 remains for ``plan_v3_memory_read`` and equivalence tests that document
 intentional divergence (e.g. ``rollout_write_ready`` coupling, archive 404).
 """
@@ -17,8 +17,6 @@ from utils.memory.memory_read_rollout_core import (
     evaluate_enrolled_memory_read_gates,
     EnrolledMemoryReadGateContext,
 )
-
-# Neutral ``v3_compatibility`` is the source of truth. Legacy ``v3_compatibility`` remains an importable alias.
 
 
 class V3CompatibilityReadPath(str, Enum):

--- a/backend/utils/memory/v3/composed_get_service.py
+++ b/backend/utils/memory/v3/composed_get_service.py
@@ -1,6 +1,6 @@
-"""Canonical module for ``utils.memory.v3_composed_get_service`` (WS-G8b).
+"""Canonical module for ``utils.memory.v3.composed_get_service`` (WS-G8b).
 
-Neutral ``v3_composed_get_service`` is the source of truth. Legacy ``v3_composed_get_service`` remains an importable alias.
+This module owns the composed V3 GET pipeline.
 """
 
 from __future__ import annotations
@@ -8,7 +8,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any, Callable, Literal, cast
 
-from utils.memory.v3_archive_visibility_readiness import decide_default_visibility
+from utils.memory.v3.archive_visibility_readiness import decide_default_visibility
 
 DependencyStatus = Literal['enrolled_ready', 'legacy', 'fail']
 SnapshotStatus = Literal['ready', 'fail']

--- a/backend/utils/memory/v3/control_reader_contract.py
+++ b/backend/utils/memory/v3/control_reader_contract.py
@@ -1,6 +1,6 @@
-"""Canonical module for ``utils.memory.v3_control_reader_contract`` (WS-G8b).
+"""Canonical module for ``utils.memory.v3.control_reader_contract`` (WS-G8b).
 
-Neutral ``v3_control_reader_contract`` is the source of truth. Legacy ``v3_control_reader_contract`` remains an importable alias.
+This module owns the V3 control-document read contract.
 """
 
 from __future__ import annotations

--- a/backend/utils/memory/v3/control_state_adapter.py
+++ b/backend/utils/memory/v3/control_state_adapter.py
@@ -1,6 +1,6 @@
-"""Canonical module for ``utils.memory.v3_control_state_adapter`` (WS-G8b).
+"""Canonical module for ``utils.memory.v3.control_state_adapter`` (WS-G8b).
 
-Neutral ``v3_control_state_adapter`` is the source of truth. Legacy ``v3_control_state_adapter`` remains an importable alias.
+This module adapts persisted control state for the V3 read path.
 """
 
 from __future__ import annotations
@@ -22,7 +22,7 @@ from utils.memory.default_read_rollout import (
     read_write_convergence_gate,
 )
 from utils.memory.memory_read_rollout_core import extract_consumer_grants
-from utils.memory.v3_control_reader_contract import (
+from utils.memory.v3.control_reader_contract import (
     V3ControlDecisionReason,
     V3ControlReadResult,
     V3ControlState,

--- a/backend/utils/memory/v3/cursor.py
+++ b/backend/utils/memory/v3/cursor.py
@@ -1,6 +1,6 @@
-"""Canonical module for ``utils.memory.v3_cursor`` (WS-G8b).
+"""Canonical module for ``utils.memory.v3.cursor`` (WS-G8b).
 
-Neutral ``v3_cursor`` is the source of truth. Legacy ``v3_cursor`` remains an importable alias.
+This module owns signed V3 pagination cursors.
 """
 
 from __future__ import annotations
@@ -180,11 +180,3 @@ def validate_v3_cursor_request(*, limit: int, cursor: str | None, offset: int | 
     if limit < 1 or limit > _DEFAULT_MAX_LIMIT:
         raise V3CursorError('limit_out_of_range')
     return V3CursorPageRequest(limit=limit, cursor=cursor)
-
-
-# Neutral symbol aliases (memory names remain valid via shim)
-V3CursorError = V3CursorError
-V3Keyset = V3Keyset
-V3CursorContext = V3CursorContext
-V3CursorClaims = V3CursorClaims
-V3CursorPageRequest = V3CursorPageRequest

--- a/backend/utils/memory/v3/limited_rollout_config.py
+++ b/backend/utils/memory/v3/limited_rollout_config.py
@@ -1,6 +1,6 @@
-"""Canonical module for ``utils.memory.v3_limited_rollout_config`` (WS-G8b).
+"""Canonical module for ``utils.memory.v3.limited_rollout_config`` (WS-G8b).
 
-Neutral ``v3_limited_rollout_config`` is the source of truth. Legacy ``v3_limited_rollout_config`` remains an importable alias.
+This module owns V3 limited-rollout configuration.
 """
 
 from __future__ import annotations

--- a/backend/utils/memory/v3/memory_read_service.py
+++ b/backend/utils/memory/v3/memory_read_service.py
@@ -1,6 +1,6 @@
-"""Canonical module for ``utils.memory.v3_memory_read_service`` (WS-G8b).
+"""Canonical module for ``utils.memory.v3.memory_read_service`` (WS-G8b).
 
-Neutral ``v3_memory_read_service`` is the source of truth. Legacy ``v3_memory_read_service`` remains an importable alias.
+This module owns the canonical V3 memory-read service.
 """
 
 from __future__ import annotations
@@ -8,12 +8,12 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any
 
-from utils.memory.v3_compatibility import (
+from utils.memory.v3.compatibility import (
     V3CompatibilityContext,
     V3CompatibilityReadPath,
     decide_v3_compatibility,
 )
-from utils.memory.v3_cursor import (
+from utils.memory.v3.cursor import (
     V3CursorContext,
     V3CursorError,
     V3Keyset,
@@ -21,7 +21,7 @@ from utils.memory.v3_cursor import (
     parse_v3_cursor,
     validate_v3_cursor_request,
 )
-from utils.memory.v3_projection_readiness import (
+from utils.memory.v3.projection_readiness import (
     V3ProjectionReadinessContext,
     V3ProjectionReadinessState,
     decide_v3_projection_readiness,

--- a/backend/utils/memory/v3/production_runtime.py
+++ b/backend/utils/memory/v3/production_runtime.py
@@ -1,6 +1,6 @@
-"""Canonical module for ``utils.memory.v3_production_runtime`` (WS-G8b).
+"""Canonical module for ``utils.memory.v3.production_runtime`` (WS-G8b).
 
-Neutral ``v3_production_runtime`` is the source of truth. Legacy ``v3_production_runtime`` remains an importable alias.
+This module wires the V3 memory-read production runtime.
 """
 
 from __future__ import annotations
@@ -19,9 +19,9 @@ from config.memory_rollout import (
     rollout_v3_get_enabled_env_value,
 )
 from database import memory_compatibility_projection as projection_db
-from utils.memory.v3_account_generation_source import read_memory_v3_trusted_account_generation
-from utils.memory.v3_account_generation_source import V3TrustedAccountGenerationResult
-from utils.memory.v3_composed_get_service import (
+from utils.memory.v3.account_generation_source import read_memory_v3_trusted_account_generation
+from utils.memory.v3.account_generation_source import V3TrustedAccountGenerationResult
+from utils.memory.v3.composed_get_service import (
     V3ComposedAdapters,
     V3ComposedCursor,
     V3ComposedDependencyDecision,
@@ -34,21 +34,21 @@ from utils.memory.v3_composed_get_service import (
     V3ComposedSnapshotDecision,
     compose_v3_get,
 )
-from utils.memory.v3_control_reader_contract import (
+from utils.memory.v3.control_reader_contract import (
     V3ControlReaderRequest,
     V3ControlRouteFamily,
     decide_v3_control_route,
 )
-from utils.memory.v3_control_state_adapter import read_v3_control
-from utils.memory.v3_control_reader_contract import V3ControlReadResult
-from utils.memory.v3_cursor import (
+from utils.memory.v3.control_state_adapter import read_v3_control
+from utils.memory.v3.control_reader_contract import V3ControlReadResult
+from utils.memory.v3.cursor import (
     V3CursorContext,
     V3CursorError,
     V3Keyset,
     create_v3_cursor,
     parse_v3_cursor,
 )
-from utils.memory.v3_projection_reader_contract import V3ProjectionCursor, V3ProjectionPage, V3ProjectionReadRequest
+from utils.memory.v3.projection_reader_contract import V3ProjectionCursor, V3ProjectionPage, V3ProjectionReadRequest
 
 V3GetSourceDecision: TypeAlias = Literal['disabled', 'legacy_primary', 'memory_read']
 MemoryDbItem: TypeAlias = dict[str, Any]

--- a/backend/utils/memory/v3/projection_reader_contract.py
+++ b/backend/utils/memory/v3/projection_reader_contract.py
@@ -1,6 +1,6 @@
-"""Canonical module for ``utils.memory.v3_projection_reader_contract`` (WS-G8b).
+"""Canonical module for ``utils.memory.v3.projection_reader_contract`` (WS-G8b).
 
-Neutral ``v3_projection_reader_contract`` is the source of truth. Legacy ``v3_projection_reader_contract`` remains an importable alias.
+This module owns the V3 projection-reader contract.
 """
 
 from __future__ import annotations

--- a/backend/utils/memory/v3/projection_readiness.py
+++ b/backend/utils/memory/v3/projection_readiness.py
@@ -1,6 +1,6 @@
-"""Canonical module for ``utils.memory.v3_projection_readiness`` (WS-G8b).
+"""Canonical module for ``utils.memory.v3.projection_readiness`` (WS-G8b).
 
-Neutral ``v3_projection_readiness`` is the source of truth. Legacy ``v3_projection_readiness`` remains an importable alias.
+This module owns V3 projection serve-readiness decisions.
 """
 
 from __future__ import annotations

--- a/backend/utils/memory/v3/request_adapter.py
+++ b/backend/utils/memory/v3/request_adapter.py
@@ -1,6 +1,6 @@
-"""Canonical module for ``utils.memory.v3_request_adapter`` (WS-G8b).
+"""Canonical module for ``utils.memory.v3.request_adapter`` (WS-G8b).
 
-Neutral ``v3_request_adapter`` is the source of truth. Legacy ``v3_request_adapter`` remains an importable alias.
+This module adapts HTTP parameters for the V3 read path.
 """
 
 from __future__ import annotations
@@ -10,8 +10,8 @@ import json
 from dataclasses import dataclass, field
 from typing import Any, Mapping, cast
 
-from utils.memory.v3_cursor import validate_v3_cursor_request
-from utils.memory.v3_memory_read_service import V3_READ_MODE, V3_READ_SOURCE
+from utils.memory.v3.cursor import validate_v3_cursor_request
+from utils.memory.v3.memory_read_service import V3_READ_MODE, V3_READ_SOURCE
 
 LEGACY_V3_READ_SOURCE = 'legacy_users_uid_memories'
 LEGACY_V3_READ_MODE = 'legacy_primary'

--- a/backend/utils/memory/v3/response_adapter.py
+++ b/backend/utils/memory/v3/response_adapter.py
@@ -1,6 +1,6 @@
-"""Canonical module for ``utils.memory.v3_response_adapter`` (WS-G8b).
+"""Canonical module for ``utils.memory.v3.response_adapter`` (WS-G8b).
 
-Neutral ``v3_response_adapter`` is the source of truth. Legacy ``v3_response_adapter`` remains an importable alias.
+This module adapts V3 memory-read results into API responses.
 """
 
 from __future__ import annotations
@@ -8,8 +8,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any, Mapping, cast
 
-from utils.memory.v3_compatibility import V3CompatibilityReadPath
-from utils.memory.v3_memory_read_service import V3MemoryReadServiceResult
+from utils.memory.v3.compatibility import V3CompatibilityReadPath
+from utils.memory.v3.memory_read_service import V3MemoryReadServiceResult
 
 _ALLOWED_HEADER_NAMES = {
     'X-Omi-Memory-Read-Source',

--- a/backend/utils/memory/v3/write_convergence.py
+++ b/backend/utils/memory/v3/write_convergence.py
@@ -1,6 +1,6 @@
-"""Canonical module for ``utils.memory.v3_write_convergence`` (WS-G8b).
+"""Canonical module for ``utils.memory.v3.write_convergence`` (WS-G8b).
 
-Neutral ``v3_write_convergence`` is the source of truth. Legacy ``v3_write_convergence`` remains an importable alias.
+This module owns V3 write-convergence decisions.
 """
 
 from __future__ import annotations

--- a/docs/product/invariants/memory-canonical-fail-closed.md
+++ b/docs/product/invariants/memory-canonical-fail-closed.md
@@ -15,9 +15,9 @@ is unavailable.
 
 ## Surfaces
 
-- `utils.memory.v3_control_reader_contract` route decisions
+- `utils.memory.v3.control_reader_contract` route decisions
 - `utils.memory.default_read_rollout` rollout wiring
-- `utils.memory.v3_memory_read_service` canonical read service
+- `utils.memory.v3.memory_read_service` canonical read service
 
 ## Guard tests
 
@@ -27,10 +27,10 @@ is unavailable.
 
 ## Path globs
 
-- `backend/utils/memory/v3_control_reader_contract.py`
+- `backend/utils/memory/v3/control_reader_contract.py`
 - `backend/utils/memory/default_read_rollout.py`
-- `backend/utils/memory/v3_memory_read_service.py`
-- `backend/utils/memory/v3_production_runtime.py`
+- `backend/utils/memory/v3/memory_read_service.py`
+- `backend/utils/memory/v3/production_runtime.py`
 
 ## PR rule
 


### PR DESCRIPTION
## Summary

- Move the V3 memory-read modules into the `utils.memory.v3` package and update callers, tests, and invariant documentation.
- Remove the cursor module's redundant self-aliases.
- Add a CI ratchet for version-prefixed source filenames.

## Root cause

V3 used loose version-prefixed module names, which obscured package ownership and risked future version collisions.

## Product invariants affected

- INV-MEM-1
- INV-MEM-3

## Validation

- `bash backend/test.sh`
- Focused V3 suite: 346 passed, 9 skipped.
- `python backend/scripts/check_module_stub_pollution.py`
- `python backend/scripts/scan_import_time_side_effects.py`
- `python .github/scripts/test_check_version_prefixed_filenames.py`

Fixes #9443

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9451?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

