### PR TITLE
test(desktop/chat-05): non-prod usage-limiter reset/snapshot hook + reset test

### DIFF
--- a/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
+++ b/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
@@ -688,6 +688,42 @@ final class DesktopAutomationActionRegistry {
       return nil
     }
 
+    // CHAT-05: read the free-tier monthly chat usage-limiter state so a harness can
+    // prove the counter is deterministic without spending LLM calls. Read-only.
+    register(
+      name: "usage_limiter_snapshot",
+      summary: "Read the free-tier monthly chat usage-limiter state (deterministic counter) — CHAT-05 harness read."
+    ) { _ in
+      await MainActor.run {
+        let limiter = FloatingBarUsageLimiter.shared
+        return [
+          "is_limit_reached": limiter.isLimitReached ? "true" : "false",
+          "remaining_queries": "\(limiter.remainingQueries)",
+          "limit_description": limiter.limitDescription,
+        ]
+      }
+    }
+
+    // CHAT-05: reset the usage-limiter counter so a harness can prove it is
+    // dev-resettable (the criterion's second half) without driving real LLM usage.
+    register(
+      name: "reset_usage_limiter",
+      summary: "Reset the free-tier monthly chat usage-limiter counter (dev-resettable proof) — CHAT-05. Non-prod only."
+    ) { _ in
+      guard AppBuild.isNonProduction else {
+        return ["error": "reset_usage_limiter is disabled on production bundles"]
+      }
+      return await MainActor.run {
+        let limiter = FloatingBarUsageLimiter.shared
+        limiter.reset()
+        return [
+          "reset": "true",
+          "is_limit_reached": limiter.isLimitReached ? "true" : "false",
+          "remaining_queries": "\(limiter.remainingQueries)",
+        ]
+      }
+    }
+
     register(
       name: "task_capture_fixture",
       summary: "Evaluate canonical screen-capture policy facts without screenshot bytes",

--- a/desktop/macos/Desktop/Tests/FloatingBarUsageLimiterTests.swift
+++ b/desktop/macos/Desktop/Tests/FloatingBarUsageLimiterTests.swift
@@ -181,4 +181,21 @@ final class FloatingBarUsageLimiterTests: XCTestCase {
     limiter.applyPlan(plan: .operator, status: .inactive)
     XCTAssertFalse(limiter.hasPaidPlan)
   }
+
+  // MARK: - Reset (CHAT-05: dev-resettable)
+
+  func testResetClearsLimitReachedState() throws {
+    // CHAT-05's second half: a dev bundle can reset the counter. Driving to the
+    // limit then resetting must return to the unblocked baseline — the behavior the
+    // non-prod `reset_usage_limiter` bridge action exposes so a harness can prove it
+    // without spending real LLM calls.
+    let limiter = FloatingBarUsageLimiter()
+    limiter.applyQuota(try makeQuota(plan: "Free", used: 30, limit: 30, percent: 100, allowed: true))
+    XCTAssertTrue(limiter.isLimitReached, "an at-limit quota blocks")
+
+    limiter.reset()
+
+    XCTAssertFalse(limiter.isLimitReached, "reset clears the reached limit (dev-resettable)")
+    XCTAssertEqual(limiter.remainingQueries, .max, "reset returns to the no-quota baseline")
+  }
 }

--- a/desktop/macos/Desktop/Tests/UsageLimiterActionTests.swift
+++ b/desktop/macos/Desktop/Tests/UsageLimiterActionTests.swift
@@ -1,0 +1,64 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// CHAT-05: the free-tier monthly chat usage limiter must be deterministic and
+/// dev-resettable. The counter + reset behavior are covered by
+/// `FloatingBarUsageLimiterTests`; these pin the non-prod bridge actions that let a
+/// harness read the counter and reset it WITHOUT spending real LLM calls (the matrix
+/// blocker), so the "dev-resettable" half becomes runtime-provable.
+///
+/// The actions can't be unit-run (they hop to the `@MainActor` shared limiter through
+/// the registry), so these are source-invariant guards on the wiring; the behavior is
+/// the e2e / Codex lane (SKILL §2j).
+final class UsageLimiterActionTests: XCTestCase {
+
+  func testSnapshotActionReadsTheDeterministicCounter() throws {
+    let block = try actionBlock("usage_limiter_snapshot")
+    XCTAssertTrue(
+      block.contains("FloatingBarUsageLimiter.shared"),
+      "snapshot must read the shared limiter")
+    for key in ["is_limit_reached", "remaining_queries", "limit_description"] {
+      XCTAssertTrue(block.contains("\"\(key)\""), "snapshot must expose \(key)")
+    }
+    XCTAssertTrue(
+      block.contains("isLimitReached") && block.contains("remainingQueries"),
+      "snapshot must surface the deterministic counter fields")
+  }
+
+  func testResetActionIsNonProdGatedAndCallsReset() throws {
+    let block = try actionBlock("reset_usage_limiter")
+    XCTAssertTrue(
+      block.contains("guard AppBuild.isNonProduction"),
+      "reset must refuse to run on production bundles")
+    XCTAssertTrue(
+      block.contains("FloatingBarUsageLimiter.shared") && block.contains(".reset()"),
+      "reset must call the shared limiter's reset()")
+    XCTAssertTrue(
+      block.contains("\"reset\"") && block.contains("\"is_limit_reached\""),
+      "reset must acknowledge and return the post-reset state for before/after assertion")
+  }
+
+  // MARK: - Helpers
+
+  private func actionBlock(_ name: String) throws -> String {
+    let source = try bridgeSource()
+    guard let start = source.range(of: "name: \"\(name)\"") else {
+      throw XCTSkip("\(name) registration not found")
+    }
+    let tail = source[start.lowerBound...]
+    if let next = tail.dropFirst().range(of: "\n    register(") {
+      return String(tail[..<next.lowerBound])
+    }
+    return String(tail)
+  }
+
+  private func bridgeSource() throws -> String {
+    let url = URL(fileURLWithPath: #filePath)
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+      .appendingPathComponent("Sources/DesktopAutomationBridge.swift")
+    // omi-test-quality: source-inspection -- static contract: the non-prod usage-limiter actions must stay registered and reset_usage_limiter must keep its AppBuild.isNonProduction gate; the actions hop to the @MainActor shared limiter through the registry and can't be behaviorally unit-run in the test host (their gate depends on the host's non-prod identity). Behavior is covered by FloatingBarUsageLimiterTests.
+    return try String(contentsOf: url, encoding: .utf8)
+  }
+}

--- a/desktop/macos/e2e/SKILL.md
+++ b/desktop/macos/e2e/SKILL.md
@@ -271,6 +271,26 @@ done
 Hermetic ratchets: `xcrun swift test --package-path Desktop --filter QuitAndReopenActionTests`
 and `--filter RestartRelaunchCommandTests` (non-prod relaunch re-passes the port as argv).
 
+### 2j. Prove the chat usage limiter is deterministic + dev-resettable (CHAT-05)
+The free-tier monthly chat limiter (`FloatingBarUsageLimiter`, 30 messages/month) is
+deterministic and dev-resettable. Driving it to the limit through real chat would burn
+LLM calls, so two non-prod bridge actions expose the counter directly: `usage_limiter_snapshot`
+(read `is_limit_reached` / `remaining_queries` / `limit_description`) and `reset_usage_limiter`
+(reset the counter). No LLM spend. Note: `reset_usage_limiter` is the sign-out-style
+`FloatingBarUsageLimiter.reset()` — it clears the cached quota **and** cached-plan state
+(and its `UserDefaults` key) on the non-prod bundle; the next subscription poll repopulates
+it. Assert on `is_limit_reached` (not `remaining_queries`, which reads `Int.max` when no
+quota is loaded).
+```bash
+cd desktop/macos
+./scripts/omi-ctl action usage_limiter_snapshot   # {"is_limit_reached":…, "remaining_queries":…, "limit_description":…}
+./scripts/omi-ctl action reset_usage_limiter      # {"reset":"true","is_limit_reached":"false","remaining_queries":…}
+./scripts/omi-ctl action usage_limiter_snapshot   # assert is_limit_reached=false after reset (dev-resettable proven)
+```
+Hermetic ratchets: `xcrun swift test --package-path Desktop --filter FloatingBarUsageLimiterTests`
+(deterministic counter + `testResetClearsLimitReachedState`) and `--filter UsageLimiterActionTests`
+(the non-prod actions wire to the limiter and the reset is prod-gated).
+
 ### The full loop
 ```bash
 cd desktop/macos


### PR DESCRIPTION
## What

Unblocks the **CHAT-05** hardening row (free-tier monthly chat usage limiter is
deterministic + dev-resettable). It was BLOCKED because driving the limiter to its
30-message cap through real chat burns LLM calls, and there was no dev hook to read or
reset the counter. The counter itself is already unit-tested
(`FloatingBarUsageLimiterTests`) and `FloatingBarUsageLimiter.reset()` already exists —
the only missing piece was a non-prod harness seam.

## Change

Two **non-prod** automation-bridge actions that wrap the existing limiter API so a
harness can prove both halves with **zero LLM spend**:
- `usage_limiter_snapshot` (read-only) → `is_limit_reached` / `remaining_queries` / `limit_description`.
- `reset_usage_limiter` (non-prod-gated via `guard AppBuild.isNonProduction`) → resets the counter and returns the post-reset state.

Both hop to the `@MainActor` shared limiter via `await MainActor.run`. The whole bridge
already runs non-prod only; `reset` adds the explicit gate as a defense-in-depth mirror
of the other state-mutating actions.

## Tests

- `FloatingBarUsageLimiterTests.testResetClearsLimitReachedState` (new, behavioral):
  drive to the limit → `reset()` → assert unblocked + back to the no-quota baseline.
  Pins `reset()`, which the existing suite didn't cover.
- `UsageLimiterActionTests` (new, source-invariant): both actions are registered and
  wire to `FloatingBarUsageLimiter`; `reset_usage_limiter` is non-prod-gated. (The
  actions hop to the `@MainActor` shared singleton through the registry and can't be
  unit-run; the counter behavior is covered above.)
- Full Desktop suite green (sole failure = the pre-existing CI-skipped
  `ActionItemsFTSRepairTests`).

## Verification

Runtime proof of the two actions is the **runtime lane** (SKILL §2j:
`omi-ctl action usage_limiter_snapshot` / `reset_usage_limiter`). It's intentionally
**not** run here to avoid a concurrent named-bundle collision with the parallel PERM-06
runtime harvest. The behavior these actions expose is hermetically covered by the two
test suites above.

## Invariants

Touches `desktop/macos/Desktop/Sources/**` → **INV-UI-1** (no purple): adds zero purple
literals; brand ratchet unaffected. (`DesktopAutomationBridge.swift` is not under any
auth/chat invariant glob.)

## Scope

Non-prod automation-bridge / dev-harness only; no user-facing behavior →
`no-changelog-needed`. Does not claim CHAT-05 PASS — the matrix flip is the runtime/intel
lane after a §2j run.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9457?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

