### PR TITLE
fix(app): auto-reveal completed tasks when all action items are done

### DIFF
--- a/app/lib/providers/action_items_provider.dart
+++ b/app/lib/providers/action_items_provider.dart
@@ -166,6 +166,9 @@ class ActionItemsProvider extends ChangeNotifier {
     notifyListeners();
   }
 
+  static bool shouldAutoRevealCompleted(List<ActionItemWithMetadata> items) =>
+      items.isNotEmpty && items.every((item) => item.completed);
+
   Future<void> fetchActionItems({bool showShimmer = false}) async {
     if (showShimmer) {
       setLoading(true);
@@ -184,6 +187,10 @@ class ActionItemsProvider extends ChangeNotifier {
 
       _actionItems = response.actionItems;
       _hasMore = response.hasMore;
+
+      if (!_showCompletedView && shouldAutoRevealCompleted(_actionItems)) {
+        _showCompletedView = true;
+      }
     } catch (e) {
       Logger.debug('Error fetching action items: $e');
     } finally {

--- a/app/test/unit/action_items_auto_reveal_completed_test.dart
+++ b/app/test/unit/action_items_auto_reveal_completed_test.dart
@@ -1,0 +1,41 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:omi/backend/schema/action_item.dart';
+import 'package:omi/backend/schema/gen/action_items_folders_wire.g.dart' as wire;
+import 'package:omi/providers/action_items_provider.dart';
+
+ActionItemWithMetadata _item({required bool completed, String id = 'task'}) {
+  return wire.GeneratedActionItemResponse(
+    id: id,
+    description: 'Do the thing',
+    completed: completed,
+  );
+}
+
+void main() {
+  group('ActionItemsProvider.shouldAutoRevealCompleted', () {
+    test('reveals completed view when every task is completed', () {
+      final items = [
+        _item(completed: true, id: 'a'),
+        _item(completed: true, id: 'b'),
+      ];
+      expect(ActionItemsProvider.shouldAutoRevealCompleted(items), isTrue);
+    });
+
+    test('keeps active view when at least one task is incomplete', () {
+      final items = [
+        _item(completed: true, id: 'a'),
+        _item(completed: false, id: 'b'),
+      ];
+      expect(ActionItemsProvider.shouldAutoRevealCompleted(items), isFalse);
+    });
+
+    test('keeps active view when all tasks are incomplete', () {
+      final items = [_item(completed: false, id: 'a')];
+      expect(ActionItemsProvider.shouldAutoRevealCompleted(items), isFalse);
+    });
+
+    test('does not reveal for a genuine empty list', () {
+      expect(ActionItemsProvider.shouldAutoRevealCompleted(const []), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## Problem

Reported on prod: one user's Tasks page showed the cold-start **"No Tasks Yet"** empty state even though the backend returned their action items. Root cause — that user's 29 action items were all `completed = true`. The Tasks page's default view filters completed items out client-side (`_categorizeItems`, `action_items_page.dart:363`), so every visible category was empty and the page fell through to `_buildEmptyTasksList()`. Nothing on that screen hinted a "Show completed" toggle existed, so the finished tasks were effectively invisible.

The data was already loaded, so this was purely a display-default problem, not a fetch/parse problem:
- `fetchActionItems` requests with `completed: null` (no server filter — `_includeCompleted` defaults to `true`), so completed items are in memory.
- `toggleShowCompletedView()` only flips a client-side flag and calls `notifyListeners()` — no refetch.

## Fix

`ActionItemsProvider.fetchActionItems` now lands on the completed view when the loaded set has no active items but at least one completed item:

```dart
if (!_showCompletedView && shouldAutoRevealCompleted(_actionItems)) {
  _showCompletedView = true;
}
```

The page reads `provider.showCompletedView` for categorization, the empty-state check, the FAB, and the "Show/Hide completed" menu label — so flipping it in the provider keeps all four consistent with **no page change**. Genuine zero-task accounts (`_actionItems.isEmpty`) still get the cold-start empty state.

The decision is a pure static method so it is hermetically testable:

```dart
static bool shouldAutoRevealCompleted(List<ActionItemWithMetadata> items) =>
    items.isNotEmpty && items.every((item) => item.completed);
```

## Tests

New regression test `app/test/unit/action_items_auto_reveal_completed_test.dart` — 4 cases: all-completed → reveal; mixed → keep active; all-incomplete → keep active; empty → no reveal.

## Verification

- `flutter test test/unit/action_items_auto_reveal_completed_test.dart` → 4/4 pass.
- `flutter analyze lib/providers/action_items_provider.dart test/unit/action_items_auto_reveal_completed_test.dart` → No issues found.
- `bash test.sh` (full app suite): my test passes. The full-suite failures are pre-existing, non-deterministic cross-file contamination (7–8 fails across consecutive runs) in unrelated widget files (`fair_use_page_test.dart`, `transcript_test.dart`) — both pass in isolation and are untouched by this change.
- Not exercised on a live all-completed-account render (would need that account or a seeded repro); the logic and the provider→page wiring are verified by the test and by code read.

## Scope

Only `action_items_provider.dart` + the new test are in this PR. Unrelated local working-tree edits (`env.dart`, `pubspec.lock`, etc.) are intentionally excluded.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9461?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

