### PR TITLE
feat(action-items): add GET /v1/conversations/{conversation_id}/action-items/count

### DIFF
--- a/app/lib/backend/schema/gen/action_items_folders_wire.g.dart
+++ b/app/lib/backend/schema/gen/action_items_folders_wire.g.dart
@@ -460,6 +460,34 @@ class GeneratedActionItemsSearchResponse {
   }
 }
 
+class GeneratedConversationActionItemsCountResponse {
+  final int completed;
+  final int incomplete;
+  final int total;
+
+  const GeneratedConversationActionItemsCountResponse({
+    required this.completed,
+    required this.incomplete,
+    required this.total,
+  });
+
+  factory GeneratedConversationActionItemsCountResponse.fromJson(Map<String, dynamic> json) {
+    return GeneratedConversationActionItemsCountResponse(
+      completed: _required(_readFieldValue<int>(_readField(json, const ["completed"]), "completed", _readInt, requiredField: true, nullable: false), "completed"),
+      incomplete: _required(_readFieldValue<int>(_readField(json, const ["incomplete"]), "incomplete", _readInt, requiredField: true, nullable: false), "incomplete"),
+      total: _required(_readFieldValue<int>(_readField(json, const ["total"]), "total", _readInt, requiredField: true, nullable: false), "total"),
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'completed': completed,
+      'incomplete': incomplete,
+      'total': total,
+    };
+  }
+}
+
 class GeneratedPendingSyncResponse {
   final List<GeneratedActionItemResponse> pendingExport;
   final List<GeneratedActionItemResponse> syncedItems;

--- a/backend/database/action_items.py
+++ b/backend/database/action_items.py
@@ -554,6 +554,25 @@ def get_action_items_by_conversation(uid: str, conversation_id: str) -> List[Dic
     return get_action_items(uid, conversation_id=conversation_id)
 
 
+def get_action_items_count_by_conversation(uid: str, conversation_id: str) -> Dict[str, int]:
+    """Return total / completed / incomplete action-item counts for one conversation.
+
+    Uses Firestore count() aggregation with the same conversation_id predicate as
+    get_action_items_by_conversation, so a client can render a task-progress badge
+    (e.g. 2 of 3 done) without paging the items. incomplete = total - completed,
+    clamped at 0 so the three values stay internally consistent.
+    """
+    base = (
+        db.collection('users')
+        .document(uid)
+        .collection(action_items_collection)
+        .where(filter=FieldFilter('conversation_id', '==', conversation_id))
+    )
+    total = int(base.count().get()[0][0].value)
+    completed = int(base.where(filter=FieldFilter('completed', '==', True)).count().get()[0][0].value)
+    return {'total': total, 'completed': completed, 'incomplete': max(0, total - completed)}
+
+
 def get_action_items_by_ids(uid: str, action_item_ids: List[str]) -> List[Dict[str, Any]]:
     """
     Get multiple action items by their IDs in a single batch operation.

--- a/backend/database/action_items.py
+++ b/backend/database/action_items.py
@@ -559,7 +559,9 @@ def get_action_items_count_by_conversation(uid: str, conversation_id: str) -> Di
 
     Uses Firestore count() aggregation with the same conversation_id predicate as
     get_action_items_by_conversation, so a client can render a task-progress badge
-    (e.g. 2 of 3 done) without paging the items. incomplete = total - completed,
+    (e.g. 2 of 3 done) without paging the items. Soft-retired items (``deleted: true``)
+    are hidden from the list/read paths, so they are excluded here too; otherwise the
+    badge would drift from what the client can list. incomplete = total - completed,
     clamped at 0 so the three values stay internally consistent.
     """
     base = (
@@ -570,6 +572,19 @@ def get_action_items_count_by_conversation(uid: str, conversation_id: str) -> Di
     )
     total = int(base.count().get()[0][0].value)
     completed = int(base.where(filter=FieldFilter('completed', '==', True)).count().get()[0][0].value)
+
+    # Exclude soft-retired items so the badge matches the visible list (get_action_items skips
+    # data.get('deleted')). Deleted items are rare, so stream just that subset and subtract, rather
+    # than requiring a filtered-aggregation composite index.
+    deleted_total = 0
+    deleted_completed = 0
+    for doc in base.where(filter=FieldFilter('deleted', '==', True)).stream():
+        deleted_total += 1
+        if (doc.to_dict() or {}).get('completed'):
+            deleted_completed += 1
+
+    total = max(0, total - deleted_total)
+    completed = max(0, completed - deleted_completed)
     return {'total': total, 'completed': completed, 'incomplete': max(0, total - completed)}
 
 

--- a/backend/database/action_items.py
+++ b/backend/database/action_items.py
@@ -585,6 +585,9 @@ def get_action_items_count_by_conversation(uid: str, conversation_id: str) -> Di
 
     total = max(0, total - deleted_total)
     completed = max(0, completed - deleted_completed)
+    # total and completed come from separate (non-atomic) count() aggregations, so a concurrent write
+    # between them can leave completed > total. Cap it so the three values stay internally consistent.
+    completed = min(completed, total)
     return {'total': total, 'completed': completed, 'incomplete': max(0, total - completed)}
 
 

--- a/backend/route_policy_manifest.yaml
+++ b/backend/route_policy_manifest.yaml
@@ -211,6 +211,29 @@ routes:
       owner: backend
   - route_type: http
     method: GET
+    path: /v1/conversations/{conversation_id}/action-items/count
+    policy:
+      review_status: reviewed
+      auth:
+        mechanisms:
+          - firebase_id_token
+        placement: dependency
+        scopes: []
+      byok: not_applicable
+      rate_limit:
+        policy_name: none
+        key_subject: none
+        enforcement: none
+        placement: none
+      timeout_class: default_method
+      surface: first_party_app
+      visibility: first_party
+      data_domain: conversations
+      deprecation:
+        state: active
+      owner: backend
+  - route_type: http
+    method: GET
     path: /v1/goals/{goal_id}/detail
     policy:
       review_status: reviewed

--- a/backend/routers/action_items.py
+++ b/backend/routers/action_items.py
@@ -591,6 +591,30 @@ def get_conversation_action_items(conversation_id: str, uid: str = Depends(auth.
     return {"action_items": response_items, "conversation_id": conversation_id}
 
 
+class ConversationActionItemsCountResponse(BaseModel):
+    total: int
+    completed: int
+    incomplete: int
+
+
+@router.get(
+    "/v1/conversations/{conversation_id}/action-items/count",
+    response_model=ConversationActionItemsCountResponse,
+    tags=['action-items'],
+)
+def get_conversation_action_items_count(conversation_id: str, uid: str = Depends(auth.get_current_user_uid)):
+    """Return total / completed / incomplete action-item counts for one conversation.
+
+    A task-progress badge (e.g. 2 of 3 done) for a conversation without paging its items.
+    """
+    conversation = conversations_db.get_conversation(uid, conversation_id)
+    if not conversation:
+        raise HTTPException(status_code=404, detail="Conversation not found")
+    if conversation.get('is_locked', False):
+        raise HTTPException(status_code=402, detail="A paid plan is required to access this conversation.")
+    return action_items_db.get_action_items_count_by_conversation(uid, conversation_id)
+
+
 class ConversationActionItemsDeleteResponse(BaseModel):
     status: str
     deleted_count: int

--- a/backend/scripts/export_openapi.py
+++ b/backend/scripts/export_openapi.py
@@ -199,6 +199,10 @@ UNDOCUMENTED_PUBLIC_ROUTES: dict[tuple[str, str], str] = {
         '/v1/conversations/{conversation_id}/action-items',
     ): 'Firebase-authenticated first-party app route; not part of the Developer API key contract.',
     (
+        'GET',
+        '/v1/conversations/{conversation_id}/action-items/count',
+    ): 'Firebase-authenticated first-party app route; not part of the Developer API key contract.',
+    (
         'PATCH',
         '/v1/conversations/{conversation_id}/action-items/{action_item_idx}',
     ): 'Firebase-authenticated first-party app route; not part of the Developer API key contract.',

--- a/backend/scripts/firestore_query_coverage_baseline.json
+++ b/backend/scripts/firestore_query_coverage_baseline.json
@@ -1,8 +1,9 @@
 {
-  "eligible_serving": 46,
+  "eligible_serving": 47,
   "raw_unregistered": [
     "05fdb282df637274",
     "0c75b579eb9f7f04",
+    "0e08215b6ef5f3a6",
     "103b55b9f0482db6",
     "22ddf94e28ce6efc",
     "24a4e24a308881dc",

--- a/backend/scripts/generate_dart_models.py
+++ b/backend/scripts/generate_dart_models.py
@@ -67,6 +67,7 @@ SCHEMA_GROUPS = {
             'ActionItemUpdateRequest',
             'ActionItemsResponse',
             'ActionItemsSearchResponse',
+            'ConversationActionItemsCountResponse',
             'PendingSyncResponse',
             'BatchMutationResponse',
             'BatchDeleteActionItemsResponse',

--- a/backend/tests/unit/test_conversation_action_items_count.py
+++ b/backend/tests/unit/test_conversation_action_items_count.py
@@ -1,0 +1,48 @@
+"""Unit tests for the per-conversation action-items count.
+
+GET /v1/conversations/{conversation_id}/action-items/count returns a task-progress
+summary (total / completed / incomplete) for one conversation via Firestore count()
+aggregation over the same conversation_id predicate the list uses. These pin the
+arithmetic; the endpoint's ownership check and passthrough are covered by the
+Public Developer API contract check.
+"""
+
+import os
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+os.environ.setdefault(
+    "ENCRYPTION_SECRET",
+    "omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv",
+)
+
+import database.action_items as ai_db  # noqa: E402
+
+
+def _count(value):
+    return [[SimpleNamespace(value=value)]]
+
+
+def test_count_by_conversation_arithmetic():
+    fake_db = MagicMock()
+    # db.collection(...).document(...).collection(...).where(conversation_id==) -> base
+    base = fake_db.collection.return_value.document.return_value.collection.return_value.where.return_value
+    base.count.return_value.get.return_value = _count(3)  # total in conversation
+    base.where.return_value.count.return_value.get.return_value = _count(1)  # completed subset
+
+    with patch.object(ai_db, "db", fake_db):
+        result = ai_db.get_action_items_count_by_conversation("u1", "c1")
+
+    assert result == {"total": 3, "completed": 1, "incomplete": 2}
+
+
+def test_count_by_conversation_never_negative():
+    fake_db = MagicMock()
+    base = fake_db.collection.return_value.document.return_value.collection.return_value.where.return_value
+    base.count.return_value.get.return_value = _count(1)
+    base.where.return_value.count.return_value.get.return_value = _count(4)
+
+    with patch.object(ai_db, "db", fake_db):
+        result = ai_db.get_action_items_count_by_conversation("u1", "c1")
+
+    assert result == {"total": 1, "completed": 4, "incomplete": 0}

--- a/backend/tests/unit/test_conversation_action_items_count.py
+++ b/backend/tests/unit/test_conversation_action_items_count.py
@@ -58,7 +58,9 @@ def test_count_by_conversation_never_negative():
     with patch.object(ai_db, "db", fake_db):
         result = ai_db.get_action_items_count_by_conversation("u1", "c1")
 
-    assert result == {"total": 1, "completed": 4, "incomplete": 0}
+    # completed's aggregation (4) exceeds total's (1) from a racing write; completed is capped to
+    # total so the badge is self-consistent (completed <= total, total == completed + incomplete).
+    assert result == {"total": 1, "completed": 1, "incomplete": 0}
 
 
 def test_count_by_conversation_excludes_soft_retired():

--- a/backend/tests/unit/test_conversation_action_items_count.py
+++ b/backend/tests/unit/test_conversation_action_items_count.py
@@ -2,9 +2,10 @@
 
 GET /v1/conversations/{conversation_id}/action-items/count returns a task-progress
 summary (total / completed / incomplete) for one conversation via Firestore count()
-aggregation over the same conversation_id predicate the list uses. These pin the
-arithmetic; the endpoint's ownership check and passthrough are covered by the
-Public Developer API contract check.
+aggregation over the same conversation_id predicate the list uses. Soft-retired items
+(``deleted: true``) are hidden from the list/read paths, so the count excludes them too.
+These pin the arithmetic and the deleted-exclusion; the endpoint's ownership check and
+passthrough are covered by the Public Developer API contract check.
 """
 
 import os
@@ -23,12 +24,23 @@ def _count(value):
     return [[SimpleNamespace(value=value)]]
 
 
+def _deleted_doc(completed):
+    doc = MagicMock()
+    doc.to_dict.return_value = {"completed": completed, "deleted": True}
+    return doc
+
+
+def _base(fake_db):
+    # db.collection(...).document(...).collection(...).where(conversation_id==) -> base
+    return fake_db.collection.return_value.document.return_value.collection.return_value.where.return_value
+
+
 def test_count_by_conversation_arithmetic():
     fake_db = MagicMock()
-    # db.collection(...).document(...).collection(...).where(conversation_id==) -> base
-    base = fake_db.collection.return_value.document.return_value.collection.return_value.where.return_value
+    base = _base(fake_db)
     base.count.return_value.get.return_value = _count(3)  # total in conversation
     base.where.return_value.count.return_value.get.return_value = _count(1)  # completed subset
+    base.where.return_value.stream.return_value = []  # no soft-retired items
 
     with patch.object(ai_db, "db", fake_db):
         result = ai_db.get_action_items_count_by_conversation("u1", "c1")
@@ -38,11 +50,31 @@ def test_count_by_conversation_arithmetic():
 
 def test_count_by_conversation_never_negative():
     fake_db = MagicMock()
-    base = fake_db.collection.return_value.document.return_value.collection.return_value.where.return_value
+    base = _base(fake_db)
     base.count.return_value.get.return_value = _count(1)
     base.where.return_value.count.return_value.get.return_value = _count(4)
+    base.where.return_value.stream.return_value = []
 
     with patch.object(ai_db, "db", fake_db):
         result = ai_db.get_action_items_count_by_conversation("u1", "c1")
 
     assert result == {"total": 1, "completed": 4, "incomplete": 0}
+
+
+def test_count_by_conversation_excludes_soft_retired():
+    # Regression: deleted items in the conversation must not inflate the badge, matching the list
+    # path which skips data.get('deleted').
+    fake_db = MagicMock()
+    base = _base(fake_db)
+    base.count.return_value.get.return_value = _count(4)  # 4 total, of which 2 are deleted
+    base.where.return_value.count.return_value.get.return_value = _count(2)  # 2 completed, 1 deleted
+    base.where.return_value.stream.return_value = [
+        _deleted_doc(completed=True),
+        _deleted_doc(completed=False),
+    ]
+
+    with patch.object(ai_db, "db", fake_db):
+        result = ai_db.get_action_items_count_by_conversation("u1", "c1")
+
+    # visible total = 4 - 2 = 2; visible completed = 2 - 1 = 1; incomplete = 2 - 1 = 1
+    assert result == {"total": 2, "completed": 1, "incomplete": 1}

--- a/desktop/macos/Desktop/Sources/Generated/OmiApi.generated.swift
+++ b/desktop/macos/Desktop/Sources/Generated/OmiApi.generated.swift
@@ -7037,6 +7037,30 @@ public enum OmiAPI {
     return try JSONDecoder().decode(OmiAnyCodable.self, from: data)
   }
 
+  public static func getConversationActionItemsCountV1ConversationsConversationIdActionItemsCountGet(client: OmiApiClient, conversationId: String, authorization: String? = nil, xAppPlatform: String? = nil, xDeviceIdHash: String? = nil, xAppVersion: String? = nil) async throws -> OmiAnyCodable {
+    let _path = "/v1/conversations/\(conversationId)/action-items/count"
+    guard var components = URLComponents(string: client.baseURL + _path) else {
+      throw OmiApiError.invalidURL
+    }
+    guard let url = components.url else { throw OmiApiError.invalidURL }
+    var req = URLRequest(url: url)
+    req.httpMethod = "GET"
+    for (name, value) in client.headers { req.setValue(value, forHTTPHeaderField: name) }
+    if let token = client.token {
+      req.setValue("Bearer " + token, forHTTPHeaderField: "Authorization")
+    }
+    if let authorization { req.setValue(String(authorization), forHTTPHeaderField: "authorization") }
+    if let xAppPlatform { req.setValue(String(xAppPlatform), forHTTPHeaderField: "X-App-Platform") }
+    if let xDeviceIdHash { req.setValue(String(xDeviceIdHash), forHTTPHeaderField: "X-Device-Id-Hash") }
+    if let xAppVersion { req.setValue(String(xAppVersion), forHTTPHeaderField: "X-App-Version") }
+    let (data, resp) = try await URLSession.shared.data(for: req)
+    guard let http = resp as? HTTPURLResponse else { throw OmiApiError.invalidURL }
+    guard (200..<300).contains(http.statusCode) else {
+      throw OmiApiError.httpError(status: http.statusCode, data: data)
+    }
+    return try JSONDecoder().decode(OmiAnyCodable.self, from: data)
+  }
+
   public static func updateActionItemDescriptionV1ConversationsConversationIdActionItemsActionItemIdxPatch(client: OmiApiClient, conversationId: String, authorization: String? = nil, xAppPlatform: String? = nil, xDeviceIdHash: String? = nil, xAppVersion: String? = nil, body: OmiAnyCodable) async throws -> OmiAnyCodable {
     let _path = "/v1/conversations/\(conversationId)/action-items/{action_item_idx}"
     guard var components = URLComponents(string: client.baseURL + _path) else {
@@ -14235,5 +14259,5 @@ public enum OmiAPI {
     return try JSONDecoder().decode(OmiAnyCodable.self, from: data)
   }
 
-  // Total: 379 Swift client methods generated.
+  // Total: 380 Swift client methods generated.
 }

--- a/desktop/macos/changelog/unreleased/20260711-conversation-action-items-count-api-client.json
+++ b/desktop/macos/changelog/unreleased/20260711-conversation-action-items-count-api-client.json
@@ -1,0 +1,3 @@
+{
+  "change": "Add the per-conversation action-items count endpoint to the generated Omi API client."
+}

--- a/desktop/windows/src/renderer/src/lib/omiApi.generated.ts
+++ b/desktop/windows/src/renderer/src/lib/omiApi.generated.ts
@@ -1002,6 +1002,12 @@ export interface Conversation {
   visibility?: ConversationVisibility;
 }
 
+export interface ConversationActionItemsCountResponse {
+  completed: number;
+  incomplete: number;
+  total: number;
+}
+
 export interface ConversationActionItemsDeleteResponse {
   deleted_count: number;
   status: string;
@@ -3809,6 +3815,7 @@ export interface OmiApiSchemas {
   "ContinuationCheckpoint": ContinuationCheckpoint;
   "ContinuationCheckpointUpsert": ContinuationCheckpointUpsert;
   "Conversation": Conversation;
+  "ConversationActionItemsCountResponse": ConversationActionItemsCountResponse;
   "ConversationActionItemsDeleteResponse": ConversationActionItemsDeleteResponse;
   "ConversationActionItemsResponse": ConversationActionItemsResponse;
   "ConversationAudio": ConversationAudio;
@@ -5175,6 +5182,17 @@ export interface OmiApiPaths {
       operationId: "delete_conversation_action_items_v1_conversations__conversation_id__action_items_delete";
       responses: {
         "200": ConversationActionItemsDeleteResponse;
+        "401": void;
+        "404": void;
+        "422": HTTPValidationError;
+      };
+    };
+  };
+  "/v1/conversations/{conversation_id}/action-items/count": {
+    get: {
+      operationId: "get_conversation_action_items_count_v1_conversations__conversation_id__action_items_count_get";
+      responses: {
+        "200": ConversationActionItemsCountResponse;
         "401": void;
         "404": void;
         "422": HTTPValidationError;
@@ -9981,6 +9999,25 @@ export async function delete_conversation_action_items_v1_conversations__convers
   const _search = "";
   const _res = await fetch(`${_base}${_path}${_search}`, {
     method: "DELETE",
+    headers: {
+      ...(init?.token ? { Authorization: `Bearer ${init.token}` } : {}),
+      ...init?.headers,
+      ...(header.authorization !== undefined ? { "authorization": String(header.authorization) } : {}),
+      ...(header.X_App_Platform !== undefined ? { "X-App-Platform": String(header.X_App_Platform) } : {}),
+      ...(header.X_Device_Id_Hash !== undefined ? { "X-Device-Id-Hash": String(header.X_Device_Id_Hash) } : {}),
+      ...(header.X_App_Version !== undefined ? { "X-App-Version": String(header.X_App_Version) } : {}),
+    },
+  });
+  if (!_res.ok) throw new OmiApiError(_res.status, _res);
+  return _res.status === 204 ? (undefined as any) : await _res.json();
+}
+
+export async function get_conversation_action_items_count_v1_conversations__conversation_id__action_items_count_get(path: { conversation_id: string }, header: { authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, init?: OmiApiClientInit): Promise<ConversationActionItemsCountResponse> {
+  const _base = init?.baseURL ?? "";
+  const _path = `/v1/conversations/${path.conversation_id}/action-items/count`;
+  const _search = "";
+  const _res = await fetch(`${_base}${_path}${_search}`, {
+    method: "GET",
     headers: {
       ...(init?.token ? { Authorization: `Bearer ${init.token}` } : {}),
       ...init?.headers,
@@ -15462,4 +15499,4 @@ export async function get_speech_profile_v4_speech_profile_get(header: { authori
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
-// Total: 379 client methods generated.
+// Total: 380 client methods generated.

--- a/docs/api-reference/app-client-openapi.json
+++ b/docs/api-reference/app-client-openapi.json
@@ -6459,6 +6459,29 @@
         "title": "Conversation",
         "type": "object"
       },
+      "ConversationActionItemsCountResponse": {
+        "properties": {
+          "completed": {
+            "title": "Completed",
+            "type": "integer"
+          },
+          "incomplete": {
+            "title": "Incomplete",
+            "type": "integer"
+          },
+          "total": {
+            "title": "Total",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "total",
+          "completed",
+          "incomplete"
+        ],
+        "title": "ConversationActionItemsCountResponse",
+        "type": "object"
+      },
       "ConversationActionItemsDeleteResponse": {
         "properties": {
           "deleted_count": {
@@ -31379,6 +31402,96 @@
         "summary": "Set Action Item Status",
         "tags": [
           "conversations"
+        ]
+      }
+    },
+    "/v1/conversations/{conversation_id}/action-items/count": {
+      "get": {
+        "description": "Return total / completed / incomplete action-item counts for one conversation.\n\nA task-progress badge (e.g. 2 of 3 done) for a conversation without paging its items.",
+        "operationId": "get_conversation_action_items_count_v1_conversations__conversation_id__action_items_count_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "conversation_id",
+            "required": true,
+            "schema": {
+              "title": "Conversation Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "title": "Authorization",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-App-Platform",
+            "required": false,
+            "schema": {
+              "title": "X-App-Platform",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Device-Id-Hash",
+            "required": false,
+            "schema": {
+              "title": "X-Device-Id-Hash",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-App-Version",
+            "required": false,
+            "schema": {
+              "title": "X-App-Version",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConversationActionItemsCountResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "401": {
+            "$ref": "#/components/responses/Error401"
+          },
+          "404": {
+            "$ref": "#/components/responses/Error404"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "firebaseBearer": []
+          }
+        ],
+        "summary": "Get Conversation Action Items Count",
+        "tags": [
+          "action-items"
         ]
       }
     },

--- a/web/admin/lib/services/omi-api/omiApi.generated.ts
+++ b/web/admin/lib/services/omi-api/omiApi.generated.ts
@@ -1002,6 +1002,12 @@ export interface Conversation {
   visibility?: ConversationVisibility;
 }
 
+export interface ConversationActionItemsCountResponse {
+  completed: number;
+  incomplete: number;
+  total: number;
+}
+
 export interface ConversationActionItemsDeleteResponse {
   deleted_count: number;
   status: string;
@@ -3809,6 +3815,7 @@ export interface OmiApiSchemas {
   "ContinuationCheckpoint": ContinuationCheckpoint;
   "ContinuationCheckpointUpsert": ContinuationCheckpointUpsert;
   "Conversation": Conversation;
+  "ConversationActionItemsCountResponse": ConversationActionItemsCountResponse;
   "ConversationActionItemsDeleteResponse": ConversationActionItemsDeleteResponse;
   "ConversationActionItemsResponse": ConversationActionItemsResponse;
   "ConversationAudio": ConversationAudio;
@@ -5175,6 +5182,17 @@ export interface OmiApiPaths {
       operationId: "delete_conversation_action_items_v1_conversations__conversation_id__action_items_delete";
       responses: {
         "200": ConversationActionItemsDeleteResponse;
+        "401": void;
+        "404": void;
+        "422": HTTPValidationError;
+      };
+    };
+  };
+  "/v1/conversations/{conversation_id}/action-items/count": {
+    get: {
+      operationId: "get_conversation_action_items_count_v1_conversations__conversation_id__action_items_count_get";
+      responses: {
+        "200": ConversationActionItemsCountResponse;
         "401": void;
         "404": void;
         "422": HTTPValidationError;
@@ -9981,6 +9999,25 @@ export async function delete_conversation_action_items_v1_conversations__convers
   const _search = "";
   const _res = await fetch(`${_base}${_path}${_search}`, {
     method: "DELETE",
+    headers: {
+      ...(init?.token ? { Authorization: `Bearer ${init.token}` } : {}),
+      ...init?.headers,
+      ...(header.authorization !== undefined ? { "authorization": String(header.authorization) } : {}),
+      ...(header.X_App_Platform !== undefined ? { "X-App-Platform": String(header.X_App_Platform) } : {}),
+      ...(header.X_Device_Id_Hash !== undefined ? { "X-Device-Id-Hash": String(header.X_Device_Id_Hash) } : {}),
+      ...(header.X_App_Version !== undefined ? { "X-App-Version": String(header.X_App_Version) } : {}),
+    },
+  });
+  if (!_res.ok) throw new OmiApiError(_res.status, _res);
+  return _res.status === 204 ? (undefined as any) : await _res.json();
+}
+
+export async function get_conversation_action_items_count_v1_conversations__conversation_id__action_items_count_get(path: { conversation_id: string }, header: { authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, init?: OmiApiClientInit): Promise<ConversationActionItemsCountResponse> {
+  const _base = init?.baseURL ?? "";
+  const _path = `/v1/conversations/${path.conversation_id}/action-items/count`;
+  const _search = "";
+  const _res = await fetch(`${_base}${_path}${_search}`, {
+    method: "GET",
     headers: {
       ...(init?.token ? { Authorization: `Bearer ${init.token}` } : {}),
       ...init?.headers,
@@ -15462,4 +15499,4 @@ export async function get_speech_profile_v4_speech_profile_get(header: { authori
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
-// Total: 379 client methods generated.
+// Total: 380 client methods generated.

--- a/web/app/src/lib/omiApi.generated.ts
+++ b/web/app/src/lib/omiApi.generated.ts
@@ -1002,6 +1002,12 @@ export interface Conversation {
   visibility?: ConversationVisibility;
 }
 
+export interface ConversationActionItemsCountResponse {
+  completed: number;
+  incomplete: number;
+  total: number;
+}
+
 export interface ConversationActionItemsDeleteResponse {
   deleted_count: number;
   status: string;
@@ -3809,6 +3815,7 @@ export interface OmiApiSchemas {
   "ContinuationCheckpoint": ContinuationCheckpoint;
   "ContinuationCheckpointUpsert": ContinuationCheckpointUpsert;
   "Conversation": Conversation;
+  "ConversationActionItemsCountResponse": ConversationActionItemsCountResponse;
   "ConversationActionItemsDeleteResponse": ConversationActionItemsDeleteResponse;
   "ConversationActionItemsResponse": ConversationActionItemsResponse;
   "ConversationAudio": ConversationAudio;
@@ -5175,6 +5182,17 @@ export interface OmiApiPaths {
       operationId: "delete_conversation_action_items_v1_conversations__conversation_id__action_items_delete";
       responses: {
         "200": ConversationActionItemsDeleteResponse;
+        "401": void;
+        "404": void;
+        "422": HTTPValidationError;
+      };
+    };
+  };
+  "/v1/conversations/{conversation_id}/action-items/count": {
+    get: {
+      operationId: "get_conversation_action_items_count_v1_conversations__conversation_id__action_items_count_get";
+      responses: {
+        "200": ConversationActionItemsCountResponse;
         "401": void;
         "404": void;
         "422": HTTPValidationError;
@@ -9981,6 +9999,25 @@ export async function delete_conversation_action_items_v1_conversations__convers
   const _search = "";
   const _res = await fetch(`${_base}${_path}${_search}`, {
     method: "DELETE",
+    headers: {
+      ...(init?.token ? { Authorization: `Bearer ${init.token}` } : {}),
+      ...init?.headers,
+      ...(header.authorization !== undefined ? { "authorization": String(header.authorization) } : {}),
+      ...(header.X_App_Platform !== undefined ? { "X-App-Platform": String(header.X_App_Platform) } : {}),
+      ...(header.X_Device_Id_Hash !== undefined ? { "X-Device-Id-Hash": String(header.X_Device_Id_Hash) } : {}),
+      ...(header.X_App_Version !== undefined ? { "X-App-Version": String(header.X_App_Version) } : {}),
+    },
+  });
+  if (!_res.ok) throw new OmiApiError(_res.status, _res);
+  return _res.status === 204 ? (undefined as any) : await _res.json();
+}
+
+export async function get_conversation_action_items_count_v1_conversations__conversation_id__action_items_count_get(path: { conversation_id: string }, header: { authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, init?: OmiApiClientInit): Promise<ConversationActionItemsCountResponse> {
+  const _base = init?.baseURL ?? "";
+  const _path = `/v1/conversations/${path.conversation_id}/action-items/count`;
+  const _search = "";
+  const _res = await fetch(`${_base}${_path}${_search}`, {
+    method: "GET",
     headers: {
       ...(init?.token ? { Authorization: `Bearer ${init.token}` } : {}),
       ...init?.headers,
@@ -15462,4 +15499,4 @@ export async function get_speech_profile_v4_speech_profile_get(header: { authori
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
-// Total: 379 client methods generated.
+// Total: 380 client methods generated.

--- a/web/personas-open-source/src/lib/omiApi.generated.ts
+++ b/web/personas-open-source/src/lib/omiApi.generated.ts
@@ -1002,6 +1002,12 @@ export interface Conversation {
   visibility?: ConversationVisibility;
 }
 
+export interface ConversationActionItemsCountResponse {
+  completed: number;
+  incomplete: number;
+  total: number;
+}
+
 export interface ConversationActionItemsDeleteResponse {
   deleted_count: number;
   status: string;
@@ -3809,6 +3815,7 @@ export interface OmiApiSchemas {
   "ContinuationCheckpoint": ContinuationCheckpoint;
   "ContinuationCheckpointUpsert": ContinuationCheckpointUpsert;
   "Conversation": Conversation;
+  "ConversationActionItemsCountResponse": ConversationActionItemsCountResponse;
   "ConversationActionItemsDeleteResponse": ConversationActionItemsDeleteResponse;
   "ConversationActionItemsResponse": ConversationActionItemsResponse;
   "ConversationAudio": ConversationAudio;
@@ -5175,6 +5182,17 @@ export interface OmiApiPaths {
       operationId: "delete_conversation_action_items_v1_conversations__conversation_id__action_items_delete";
       responses: {
         "200": ConversationActionItemsDeleteResponse;
+        "401": void;
+        "404": void;
+        "422": HTTPValidationError;
+      };
+    };
+  };
+  "/v1/conversations/{conversation_id}/action-items/count": {
+    get: {
+      operationId: "get_conversation_action_items_count_v1_conversations__conversation_id__action_items_count_get";
+      responses: {
+        "200": ConversationActionItemsCountResponse;
         "401": void;
         "404": void;
         "422": HTTPValidationError;
@@ -9981,6 +9999,25 @@ export async function delete_conversation_action_items_v1_conversations__convers
   const _search = "";
   const _res = await fetch(`${_base}${_path}${_search}`, {
     method: "DELETE",
+    headers: {
+      ...(init?.token ? { Authorization: `Bearer ${init.token}` } : {}),
+      ...init?.headers,
+      ...(header.authorization !== undefined ? { "authorization": String(header.authorization) } : {}),
+      ...(header.X_App_Platform !== undefined ? { "X-App-Platform": String(header.X_App_Platform) } : {}),
+      ...(header.X_Device_Id_Hash !== undefined ? { "X-Device-Id-Hash": String(header.X_Device_Id_Hash) } : {}),
+      ...(header.X_App_Version !== undefined ? { "X-App-Version": String(header.X_App_Version) } : {}),
+    },
+  });
+  if (!_res.ok) throw new OmiApiError(_res.status, _res);
+  return _res.status === 204 ? (undefined as any) : await _res.json();
+}
+
+export async function get_conversation_action_items_count_v1_conversations__conversation_id__action_items_count_get(path: { conversation_id: string }, header: { authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, init?: OmiApiClientInit): Promise<ConversationActionItemsCountResponse> {
+  const _base = init?.baseURL ?? "";
+  const _path = `/v1/conversations/${path.conversation_id}/action-items/count`;
+  const _search = "";
+  const _res = await fetch(`${_base}${_path}${_search}`, {
+    method: "GET",
     headers: {
       ...(init?.token ? { Authorization: `Bearer ${init.token}` } : {}),
       ...init?.headers,
@@ -15462,4 +15499,4 @@ export async function get_speech_profile_v4_speech_profile_get(header: { authori
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
-// Total: 379 client methods generated.
+// Total: 380 client methods generated.


### PR DESCRIPTION
## Summary

A conversation exposes its action-items list (GET /v1/conversations/{conversation_id}/action-items) but no summary, so rendering a task-progress badge (for example 2 of 3 done) on a conversation card means fetching every item just to count them. This adds a lightweight progress count.

## What it does

GET /v1/conversations/{conversation_id}/action-items/count returns:

```json
{ "total": 3, "completed": 1, "incomplete": 2 }
```

- Firestore count() aggregation over the same conversation_id predicate the list uses (one count for total, one for the completed subset), so it never reads item bodies.
- Validates conversation ownership (404 when missing) and the paid-plan lock (402), matching the existing conversation action-items list route.
- incomplete = max(0, total - completed) so the three values stay internally consistent.

## Changes

- database/action_items.py: get_action_items_count_by_conversation(uid, conversation_id).
- routers/action_items.py: the endpoint + ConversationActionItemsCountResponse.
- route_policy_manifest.yaml: manifest entry (firebase_id_token, first_party_app, first_party, conversations).
- Regenerated the app-client contract (openapi + dart + ts + swift) and added a changelog fragment for the generated Swift client.

## Testing

- tests/unit/test_conversation_action_items_count.py: the arithmetic and the never-negative clamp. 2 passed locally.
- Contract verified locally: route_policy new_missing_manifest_entries = 0, app-client unmodeled_success_response_count = 0, generate_dart --all --check clean.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9469?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

