### PR TITLE
fix FormatException crash parsing cached app reviews with empty date strings

### DIFF
--- a/app/lib/backend/schema/app.dart
+++ b/app/lib/backend/schema/app.dart
@@ -24,6 +24,7 @@ class AppReview {
   });
 
   factory AppReview.fromJson(Map<String, dynamic> json) {
+    if (json['responded_at'] == '') json['responded_at'] = null;
     return AppReview.fromGenerated(
       wire.GeneratedAppReview.fromJson(json),
       updatedAt: (json['updated_at'] == "" || json['updated_at'] == null)
@@ -53,8 +54,8 @@ class AppReview {
       'review': review,
       'username': username,
       'response': response,
-      'updated_at': updatedAt?.toUtc().toIso8601String() ?? '',
-      'responded_at': respondedAt?.toUtc().toIso8601String() ?? '',
+      'updated_at': updatedAt?.toUtc().toIso8601String(),
+      'responded_at': respondedAt?.toUtc().toIso8601String(),
     };
   }
 
@@ -371,7 +372,25 @@ class App {
     return false;
   }
 
+  /// Legacy cached JSON (AppReview.toJson before the null-date fix) wrote null
+  /// review dates as '', which the strict generated parser rejects. Convert
+  /// them back to null so cached apps lists keep parsing.
+  static void _sanitizeLegacyReviewDates(Map<String, dynamic> json) {
+    void fixReview(dynamic review) {
+      if (review is Map) {
+        for (final key in const ['responded_at', 'updated_at']) {
+          if (review[key] == '') review[key] = null;
+        }
+      }
+    }
+
+    final reviews = json['reviews'];
+    if (reviews is List) reviews.forEach(fixReview);
+    fixReview(json['user_review']);
+  }
+
   factory App.fromJson(Map<String, dynamic> json) {
+    _sanitizeLegacyReviewDates(json);
     return App.fromGeneratedDetail(
       wire.GeneratedApp.fromJson(json),
       approvedFallback: json.containsKey('approved') ? null : true,

--- a/app/test/unit/app_review_legacy_date_test.dart
+++ b/app/test/unit/app_review_legacy_date_test.dart
@@ -1,0 +1,81 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:omi/backend/schema/app.dart';
+
+/// Regression tests for the cached apps-list crash:
+///
+/// FlutterError — FormatException: Invalid field: responded_at
+/// at _readFieldValue → GeneratedAppReview.fromJson → App.fromJson
+/// → SharedPreferencesUtil.appsList (startup, AnalyticsManager.identify).
+///
+/// AppReview.toJson used to serialize null updatedAt/respondedAt as '',
+/// which the strict generated wire parser rejects when the cached apps
+/// list is read back on the next launch.
+void main() {
+  Map<String, dynamic> minimalAppJson({List<Map<String, dynamic>>? reviews, Map<String, dynamic>? userReview}) {
+    return {
+      'id': 'app-1',
+      'name': 'Test App',
+      'author': 'Tester',
+      'category': 'productivity',
+      'description': 'desc',
+      'image': 'img.png',
+      'capabilities': <String>[],
+      if (reviews != null) 'reviews': reviews,
+      if (userReview != null) 'user_review': userReview,
+    };
+  }
+
+  Map<String, dynamic> reviewJson({dynamic respondedAt, dynamic updatedAt}) {
+    return {
+      'uid': 'user-1',
+      'rated_at': '2026-07-01T10:00:00.000Z',
+      'score': 4.0,
+      'review': 'nice app',
+      'responded_at': respondedAt,
+      'updated_at': updatedAt,
+    };
+  }
+
+  group('legacy cached apps list with empty-string review dates', () {
+    test('App.fromJson parses a review with responded_at == "" (crash case)', () {
+      final app = App.fromJson(minimalAppJson(reviews: [reviewJson(respondedAt: '', updatedAt: '')]));
+      expect(app.reviews, hasLength(1));
+      expect(app.reviews.first.respondedAt, isNull);
+    });
+
+    test('App.fromJson parses a user_review with responded_at == ""', () {
+      final app = App.fromJson(minimalAppJson(userReview: reviewJson(respondedAt: '', updatedAt: '')));
+      expect(app.userReview, isNotNull);
+      expect(app.userReview!.respondedAt, isNull);
+    });
+
+    test('App.fromJson still parses valid responded_at values', () {
+      final app = App.fromJson(minimalAppJson(reviews: [reviewJson(respondedAt: '2026-07-02T09:00:00.000Z')]));
+      expect(app.reviews.first.respondedAt, isNotNull);
+    });
+
+    test('AppReview.fromJson parses responded_at == ""', () {
+      final review = AppReview.fromJson(reviewJson(respondedAt: '', updatedAt: ''));
+      expect(review.respondedAt, isNull);
+      expect(review.updatedAt, isNull);
+    });
+  });
+
+  group('AppReview.toJson no longer writes empty-string dates', () {
+    test('null dates serialize as null and survive a cache round-trip', () {
+      final review = AppReview(
+        uid: 'user-1',
+        ratedAt: DateTime.utc(2026, 7, 1, 10),
+        score: 4.0,
+        review: 'nice app',
+      );
+      final json = review.toJson();
+      expect(json['responded_at'], isNull);
+      expect(json['updated_at'], isNull);
+
+      final roundTripped = App.fromJson(minimalAppJson(reviews: [json]));
+      expect(roundTripped.reviews.first.respondedAt, isNull);
+    });
+  });
+}


### PR DESCRIPTION
## Crash

._readFieldValue
io.flutter.plugins.firebase.crashlytics.FlutterError - FormatException: Invalid field: responded_at

package:omi/backend/schema/gen/action_items_folders_wire.g.dart:509

https://console.firebase.google.com/u/0/project/based-hardware/crashlytics/app/android:com.friend.ios/issues/c8d423d2e9373bbc08bb450cbc5c78db?time=7d&types=crash&sessionEventKey=6A5206750220000120B2EB2DC5CA9C43_2239638628582432000

Logs:

```
Fatal Exception: io.flutter.plugins.firebase.crashlytics.FlutterError: FormatException: Invalid field: responded_at
       at ._readFieldValue(action_items_folders_wire.g.dart:509)
       at new GeneratedAppReview.fromJson(apps_wire.g.dart:403)
       at ._readObjectList(apps_wire.g.dart:1491)
       at new GeneratedApp.fromJson.<fn>(apps_wire.g.dart:996)
       at ._readFieldValue(action_items_folders_wire.g.dart:507)
       at new GeneratedApp.fromJson(apps_wire.g.dart:996)
       at new App.fromJson(app.dart:376)
       at App.fromJsonList.<fn>(app.dart:615)
       at ListIterable.toList(dart:_internal)
       at App.fromJsonList(app.dart:615)
       at SharedPreferencesUtil.appsList(preferences.dart:462)
       at SharedPreferencesUtil.enabledAppsCount(preferences.dart:436)
       at AnalyticsManager.setPeopleValues(analytics_manager.dart:122)
       at AnalyticsManager.identify.<fn>(analytics_manager.dart:248)
       at PlatformService.executeIfSupported(platform_service.dart:20)
       at AnalyticsManager.identify(analytics_manager.dart:238)
       at ._init(main.dart:177)
       at main.<fn>(main.dart:222)
```

## Root cause

A cache round-trip poisons itself:

1. **Write side:** `AppReview.toJson()` serialized null `updatedAt`/`respondedAt` as `''` (empty string), and the apps list is cached to SharedPreferences via `App.toJson()` (which embeds `reviews` / `user_review`).
2. **Read side:** on the next launch, `SharedPreferencesUtil.appsList` re-parses the cached JSON through the strict generated wire parser. `_readFieldValue` sees `responded_at` present and non-null, but `_readDateTime('')` (`DateTime.tryParse('')`) returns null → `FormatException: Invalid field: responded_at`.

The crash fires during app init (`main` → `AnalyticsManager.identify` → `enabledAppsCount` → `appsList`), so affected users crash at every startup until the cache is overwritten.

## Fix

Both sides:

- **Write:** `AppReview.toJson()` now serializes null dates as `null` instead of `''`.
- **Read (heals already-poisoned caches):** `App.fromJson` normalizes legacy `''` values of `responded_at`/`updated_at` in `reviews` and `user_review` back to null before the strict generated parser runs; `AppReview.fromJson` gets the same guard for its direct call path.

The generated `.g.dart` wire files are untouched (never edited manually).

## Verification

- `flutter test test/unit/app_review_legacy_date_test.dart` — 5 new regression tests pass, covering the exact crash case (`responded_at: ''` in a cached review), `user_review`, the direct `AppReview.fromJson` path, valid dates still parsing, and the null round-trip.
- With the lib fix stashed, 4 of the 5 tests fail with the exact production error (`FormatException: Invalid field: responded_at`), confirming they are true regression tests.
- Full `bash app/test.sh` — 751 tests pass.
- Checked `web/app/src/` — it only declares `responded_at?: string` in a type; no strict parsing or prefs caching, so no parity change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9470?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

