### PR TITLE
fix(app): stop private cloud sync toggle from resetting itself off (#9466)

### DIFF
--- a/app/lib/backend/http/api/users.dart
+++ b/app/lib/backend/http/api/users.dart
@@ -171,21 +171,25 @@ Future<bool> setPrivateCloudSyncEnabled(bool value) async {
   return data.status == 'ok';
 }
 
-Future<bool> getPrivateCloudSyncEnabled() async {
+/// Returns the server's private-cloud-sync flag, or `null` when the value
+/// could not be fetched (no response / non-200). Never coerce a fetch failure
+/// into `false` — callers must preserve the last known state instead of
+/// silently flipping the toggle off on a transient network error.
+Future<bool?> getPrivateCloudSyncEnabled() async {
   var response = await makeApiCall(
     url: '${Env.apiBaseUrl}v1/users/private-cloud-sync',
     headers: {},
     method: 'GET',
     body: '',
   );
-  if (response == null) return false;
+  if (response == null) return null;
   Logger.debug('getPrivateCloudSyncEnabled response: ${response.body}');
   if (response.statusCode == 200) {
     return wire.GeneratedPrivateCloudSyncResponse.fromJson(
       jsonDecode(response.body) as Map<String, dynamic>,
     ).privateCloudSyncEnabled;
   }
-  return false;
+  return null;
 }
 
 Future<Person?> createPerson(String name) async {

--- a/app/lib/providers/user_provider.dart
+++ b/app/lib/providers/user_provider.dart
@@ -14,6 +14,13 @@ import 'package:omi/utils/logger.dart';
 class UserProvider with ChangeNotifier {
   static const int _migrationNotificationId = 1337;
 
+  /// Fetches the server's private-cloud-sync flag. Returns `null` on a failed
+  /// fetch so the loader can preserve the last known state. Injectable for tests.
+  final Future<bool?> Function() _privateCloudSyncFetcher;
+
+  UserProvider({Future<bool?> Function()? privateCloudSyncFetcher})
+      : _privateCloudSyncFetcher = privateCloudSyncFetcher ?? getPrivateCloudSyncEnabled;
+
   String _dataProtectionLevel = 'standard';
   bool _isLoading = false;
   bool _privateCloudSyncEnabled = false;
@@ -179,15 +186,23 @@ class UserProvider with ChangeNotifier {
     prefs.cachedTranscriptionVocabulary = _transcriptionVocabulary;
   }
 
+  @visibleForTesting
+  Future<void> loadPrivateCloudSyncStatus() => _loadPrivateCloudSyncStatus(_sessionGeneration);
+
   Future<void> _loadPrivateCloudSyncStatus(int generation) async {
     try {
-      final enabled = await getPrivateCloudSyncEnabled();
+      final enabled = await _privateCloudSyncFetcher();
       if (generation != _sessionGeneration) return;
-      _privateCloudSyncEnabled = enabled;
+      // A failed fetch returns null — keep the last known state instead of
+      // flipping the toggle off, which would misreport cloud sync as disabled
+      // (and lose recordings the user meant to keep) on a transient error.
+      if (enabled != null) {
+        _privateCloudSyncEnabled = enabled;
+      }
     } catch (e) {
       if (generation != _sessionGeneration) return;
       Logger.error('Failed to load private cloud sync status: $e');
-      _privateCloudSyncEnabled = false;
+      // Keep the cached value on error, don't reset.
     }
   }
 

--- a/app/test/providers/user_provider_private_cloud_sync_test.dart
+++ b/app/test/providers/user_provider_private_cloud_sync_test.dart
@@ -1,0 +1,50 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:omi/providers/user_provider.dart';
+
+void main() {
+  group('UserProvider private cloud sync loading', () {
+    test('applies the fetched value on success', () async {
+      final provider = UserProvider(privateCloudSyncFetcher: () async => true);
+      addTearDown(provider.dispose);
+
+      await provider.loadPrivateCloudSyncStatus();
+
+      expect(provider.privateCloudSyncEnabled, isTrue);
+    });
+
+    test('preserves the enabled state when a fetch fails (returns null)', () async {
+      // Regression for #9466: a transient GET failure returned false, silently
+      // flipping the cloud-sync toggle off even though it was still enabled.
+      bool? result = true;
+      final provider = UserProvider(privateCloudSyncFetcher: () async => result);
+      addTearDown(provider.dispose);
+
+      await provider.loadPrivateCloudSyncStatus();
+      expect(provider.privateCloudSyncEnabled, isTrue);
+
+      // Next load fails (no response / non-200) — must not turn the toggle off.
+      result = null;
+      await provider.loadPrivateCloudSyncStatus();
+
+      expect(provider.privateCloudSyncEnabled, isTrue);
+    });
+
+    test('preserves the enabled state when the fetch throws', () async {
+      var shouldThrow = false;
+      final provider = UserProvider(privateCloudSyncFetcher: () async {
+        if (shouldThrow) throw Exception('network down');
+        return true;
+      });
+      addTearDown(provider.dispose);
+
+      await provider.loadPrivateCloudSyncStatus();
+      expect(provider.privateCloudSyncEnabled, isTrue);
+
+      shouldThrow = true;
+      await provider.loadPrivateCloudSyncStatus();
+
+      expect(provider.privateCloudSyncEnabled, isTrue);
+    });
+  });
+}


### PR DESCRIPTION
## Bug
[#9466](https://github.com/BasedHardware/omi/issues/9466) — the **Store Audio on Cloud** (`Enable Audio Cloud`) toggle keeps turning itself off on its own, causing users to lose recordings they wanted to keep.

## Root cause
`getPrivateCloudSyncEnabled()` returned `false` whenever the GET failed (null response **or** non-200), and `UserProvider._loadPrivateCloudSyncStatus` blindly assigned that result on every `initialize()` (app launch, session refresh). So a single transient network blip flipped the local toggle to **OFF** even though private cloud sync was still enabled server-side — the client and the backend (`get_user_private_cloud_sync_enabled`, which defaults to `True`) silently disagreed. That is exactly the reported "turns itself off on its own" behavior.

## Fix
Closes the failure class of conflating *fetch-error* with *disabled*:
- `getPrivateCloudSyncEnabled()` now returns `bool?` and yields `null` on any fetch failure instead of coercing to `false`.
- The loader preserves the last known state on `null`/exception instead of resetting — mirroring the existing `_loadTranscriptionPreferences` convention ("keep cached values on error").
- Added an injectable fetcher on `UserProvider` (same seam as `FolderProvider.foldersFetcher`) plus a regression test covering the success, null-fetch, and throwing-fetch paths.

## Verification
- **UNVERIFIED locally** — the watchdog environment has no Flutter toolchain, so `flutter test` / real-app exercise could not be run here. Relying on CI (`flutter test` + analyzer ratchet) and review. Regression test `app/test/providers/user_provider_private_cloud_sync_test.dart` asserts the toggle stays enabled across failed fetches.

🤖 automated by hourly watchdog; opened for review, not merged.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9472?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

