### PR TITLE
fix(chat): return 404 not 500 when reporting a non-existent message

### DIFF
--- a/backend/routers/chat.py
+++ b/backend/routers/chat.py
@@ -430,9 +430,10 @@ def send_message(
 
 @router.post('/v2/messages/{message_id}/report', tags=['chat'], response_model=MessageReportResponse)
 def report_message(message_id: str, uid: str = Depends(auth.get_current_user_uid)):
-    message, msg_doc_id = chat_db.get_message(uid, message_id)
-    if message is None:
+    result = chat_db.get_message(uid, message_id)
+    if result is None:
         raise HTTPException(status_code=404, detail='Message not found')
+    message, msg_doc_id = result
     if message.sender != 'ai':
         raise HTTPException(status_code=400, detail='Only AI messages can be reported')
     if message.reported:
@@ -1160,9 +1161,10 @@ def upload_file_chat(
 
 @router.post('/v1/messages/{message_id}/report', tags=['chat'], response_model=dict)
 def report_message(message_id: str, uid: str = Depends(auth.get_current_user_uid)):
-    message, msg_doc_id = chat_db.get_message(uid, message_id)
-    if message is None:
+    result = chat_db.get_message(uid, message_id)
+    if result is None:
         raise HTTPException(status_code=404, detail='Message not found')
+    message, msg_doc_id = result
     if message.sender != 'ai':
         raise HTTPException(status_code=400, detail='Only AI messages can be reported')
     if message.reported:

--- a/backend/tests/unit/test_report_missing_message.py
+++ b/backend/tests/unit/test_report_missing_message.py
@@ -6,9 +6,10 @@ exist. The report handlers used to unpack it unconditionally
 missing id instead of the intended 404 (the following `if message is None` guard was
 unreachable). They now check the result before unpacking.
 
-routers.chat has a heavy import graph (typesense/pinecone/langchain/etc.), so it is
+routers.chat has a heavy import graph (typesense/pinecone/langchain/etc.). It is
 imported under a stub finder that auto-mocks those namespaces (fastapi/pydantic stay
-real). Doing it at module scope keeps the cost out of the test's call phase.
+real). The stubbing lives inside a module-scoped fixture (not at module scope) so it
+does not pollute global import state, and its cost stays out of the test call phase.
 """
 
 import importlib.abc
@@ -19,6 +20,7 @@ import types
 from unittest.mock import MagicMock, patch
 
 import pytest
+from fastapi import HTTPException
 
 os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
 os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv')
@@ -72,29 +74,35 @@ class _Finder(importlib.abc.MetaPathFinder, importlib.abc.Loader):
         pass
 
 
-_f = _Finder()
-_saved = {n: m for n, m in sys.modules.items() if _is_stubbed(n)}
-for n in list(sys.modules):
-    if _is_stubbed(n):
-        sys.modules.pop(n, None)
-sys.meta_path.insert(0, _f)
-try:
-    from routers import chat as mod
-finally:
-    sys.meta_path.remove(_f)
+@pytest.fixture(scope="module")
+def chat_router():
+    """Import routers.chat under a stub finder, restoring sys.modules afterwards.
+
+    Kept inside a fixture (function scope, not module scope) so it never leaves global
+    import state mutated for other test files.
+    """
+    finder = _Finder()
+    saved = {n: m for n, m in sys.modules.items() if _is_stubbed(n)}
     for n in list(sys.modules):
-        if _is_stubbed(n) and n not in _saved:
+        if _is_stubbed(n):
             sys.modules.pop(n, None)
-    sys.modules.update(_saved)
+    sys.meta_path.insert(0, finder)
+    try:
+        from routers import chat as mod
+    finally:
+        sys.meta_path.remove(finder)
+        for n in list(sys.modules):
+            if _is_stubbed(n) and n not in saved:
+                sys.modules.pop(n, None)
+        sys.modules.update(saved)
+    return mod
 
-from fastapi import HTTPException  # noqa: E402
 
-
-def test_report_missing_message_returns_404_not_500():
+def test_report_missing_message_returns_404_not_500(chat_router):
     # get_message returns None for an unknown id; the handler must translate that into a
     # 404, not crash trying to unpack None into (message, doc_id).
-    with patch.object(mod.chat_db, "get_message", return_value=None):
+    with patch.object(chat_router.chat_db, "get_message", return_value=None):
         with pytest.raises(HTTPException) as exc:
-            mod.report_message(message_id="does-not-exist", uid="u1")
+            chat_router.report_message(message_id="does-not-exist", uid="u1")
 
     assert exc.value.status_code == 404

--- a/backend/tests/unit/test_report_missing_message.py
+++ b/backend/tests/unit/test_report_missing_message.py
@@ -1,0 +1,100 @@
+"""Regression test for reporting a non-existent chat message.
+
+database.chat.get_message returns None (not a tuple) when the message id does not
+exist. The report handlers used to unpack it unconditionally
+(`message, msg_doc_id = get_message(...)`), which raised TypeError -> HTTP 500 on a
+missing id instead of the intended 404 (the following `if message is None` guard was
+unreachable). They now check the result before unpacking.
+
+routers.chat has a heavy import graph (typesense/pinecone/langchain/etc.), so it is
+imported under a stub finder that auto-mocks those namespaces (fastapi/pydantic stay
+real). Doing it at module scope keeps the cost out of the test's call phase.
+"""
+
+import importlib.abc
+import importlib.machinery
+import os
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
+os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv')
+
+_STUB = (
+    'database',
+    'utils',
+    'firebase_admin',
+    'google',
+    'pinecone',
+    'opuslib',
+    'pydub',
+    'redis',
+    'langchain',
+    'stripe',
+    'openai',
+    'anthropic',
+    'modal',
+    'ulid',
+    'sentry_sdk',
+    'requests',
+    'typesense',
+    'pusher',
+    'multipart',
+)
+
+
+def _is_stubbed(n):
+    return any(n == p or n.startswith(p + '.') for p in _STUB)
+
+
+class _AutoMock(types.ModuleType):
+    __path__ = []
+
+    def __getattr__(self, name):
+        if name.startswith('__') and name.endswith('__'):
+            raise AttributeError(name)
+        m = MagicMock()
+        setattr(self, name, m)
+        return m
+
+
+class _Finder(importlib.abc.MetaPathFinder, importlib.abc.Loader):
+    def find_spec(self, name, path=None, target=None):
+        return importlib.machinery.ModuleSpec(name, self, is_package=True) if _is_stubbed(name) else None
+
+    def create_module(self, spec):
+        return _AutoMock(spec.name)
+
+    def exec_module(self, module):
+        pass
+
+
+_f = _Finder()
+_saved = {n: m for n, m in sys.modules.items() if _is_stubbed(n)}
+for n in list(sys.modules):
+    if _is_stubbed(n):
+        sys.modules.pop(n, None)
+sys.meta_path.insert(0, _f)
+try:
+    from routers import chat as mod
+finally:
+    sys.meta_path.remove(_f)
+    for n in list(sys.modules):
+        if _is_stubbed(n) and n not in _saved:
+            sys.modules.pop(n, None)
+    sys.modules.update(_saved)
+
+from fastapi import HTTPException  # noqa: E402
+
+
+def test_report_missing_message_returns_404_not_500():
+    # get_message returns None for an unknown id; the handler must translate that into a
+    # 404, not crash trying to unpack None into (message, doc_id).
+    with patch.object(mod.chat_db, "get_message", return_value=None):
+        with pytest.raises(HTTPException) as exc:
+            mod.report_message(message_id="does-not-exist", uid="u1")
+
+    assert exc.value.status_code == 404


### PR DESCRIPTION
## Summary

database.chat.get_message returns None (not a tuple) when the message id does not exist. Both report handlers unpacked the result unconditionally:

```python
message, msg_doc_id = chat_db.get_message(uid, message_id)
if message is None:
    raise HTTPException(status_code=404, detail='Message not found')
```

For a missing id, unpacking None raises TypeError, which surfaces as a 500, and the 404 guard on the next line is unreachable. So POST /v2/messages/{message_id}/report and POST /v1/messages/{message_id}/report return 500 instead of 404 for an unknown message id.

## Fix

Check the result before unpacking:

```python
result = chat_db.get_message(uid, message_id)
if result is None:
    raise HTTPException(status_code=404, detail='Message not found')
message, msg_doc_id = result
```

Applied to both report handlers. The other three get_message call sites already guard the result before unpacking, so they were unaffected.

## Testing

- tests/unit/test_report_missing_message.py: reports a non-existent id and asserts 404 (previously this raised TypeError). Passes locally. routers.chat is imported under the existing stub-finder pattern so the heavy import graph does not run in the test call phase.

No API contract change (behavior fix only), so no manifest or generated-client changes.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9473?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

