### PR TITLE
fix(conversations): 404 on out-of-range segment_idx in segment assign

### DIFF
--- a/backend/routers/conversations.py
+++ b/backend/routers/conversations.py
@@ -821,6 +821,14 @@ def set_assignee_conversation_segment(
     conversation = _get_valid_conversation_by_id(uid, conversation_id)
     conversation = deserialize_conversation(conversation)
 
+    # Bound-check segment_idx before indexing. Same class as the events / action-items
+    # handlers above (0 <= idx < len): an out-of-range idx (e.g. a stale client after
+    # reprocess/merge shrank the segments) otherwise raises IndexError -> HTTP 500, and a
+    # negative idx would silently mutate the wrong segment. This is a single-target route,
+    # so a missing segment is a 404 rather than a skip.
+    if not (0 <= segment_idx < len(conversation.transcript_segments)):
+        raise HTTPException(status_code=404, detail="Segment not found")
+
     if value == 'null':
         value = None
 

--- a/backend/tests/unit/test_conversation_events_bounds.py
+++ b/backend/tests/unit/test_conversation_events_bounds.py
@@ -12,6 +12,13 @@ The fix rejects a length mismatch with 422 and bounds-checks both ends
 corrupting data or 500ing. This test loads the conversations router fresh against stubbed heavy
 dependencies (the router pulls in clients that construct at import time -- typesense, pinecone,
 firebase -- so the fakes must precede the import) and calls the handler directly.
+
+The same index-bounds class also affected PATCH /v1/conversations/{id}/segments/{segment_idx}/assign
+(set_assignee_conversation_segment), which indexed transcript_segments[segment_idx] with no bound at
+all: an out-of-range idx 500ed (IndexError) and a negative idx silently mutated the wrong segment.
+Because that route targets a single named segment rather than a batch of parallel arrays, the fix
+returns 404 for a missing segment instead of skipping. Those regression tests live alongside the
+events ones below since they share the fixture and the same failure class.
 """
 
 import hashlib
@@ -23,6 +30,7 @@ from types import ModuleType, SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
+from fastapi import HTTPException
 from pydantic import ValidationError
 
 from testing.import_isolation import AutoMockModule, load_module_fresh, stub_modules
@@ -223,3 +231,77 @@ def test_valid_index_still_updates(router):
 
     assert events[1].created is True
     assert events[0].created is False
+
+
+class _FakeSegment:
+    """Minimal transcript segment: assignable (.is_user / .person_id) and model_dump-able."""
+
+    def __init__(self):
+        self.is_user = False
+        self.person_id = None
+
+    def model_dump(self):
+        return {"is_user": self.is_user, "person_id": self.person_id}
+
+
+def _fake_conversation_with_segments(count):
+    segments = [_FakeSegment() for _ in range(count)]
+    return SimpleNamespace(transcript_segments=segments), segments
+
+
+def _segment_assign_handler(conv):
+    """Return the real segments/{segment_idx}/assign handler off its APIRoute.
+
+    Two functions share the name ``set_assignee_conversation_segment`` in the module -- the second
+    (the ``assign-speaker/{speaker_id}`` route) rebinds the module global -- so the module attribute
+    points at the wrong one. The registered route captured the correct function object at decoration
+    time, so pull the handler from ``router.routes`` by path instead.
+    """
+    target = "/v1/conversations/{conversation_id}/segments/{segment_idx}/assign"
+    for route in conv.router.routes:
+        if getattr(route, "path", None) == target and "PATCH" in getattr(route, "methods", set()):
+            return route.endpoint
+    raise AssertionError("segments/{segment_idx}/assign route is not registered")
+
+
+def test_segment_assign_out_of_range_returns_404(router):
+    """An out-of-range segment_idx must raise 404, not IndexError -> HTTP 500."""
+    convo, segments = _fake_conversation_with_segments(2)
+    handler = _segment_assign_handler(router.conv)
+    with patch.object(router.conv, "_get_valid_conversation_by_id", return_value={"id": "c1"}), patch.object(
+        router.conv, "deserialize_conversation", return_value=convo
+    ):
+        with pytest.raises(HTTPException) as exc:
+            handler("c1", 999, "is_user", uid="u1")
+
+    assert exc.value.status_code == 404
+    # Nothing mutated: the guard fired before any assignment.
+    assert all(seg.is_user is False and seg.person_id is None for seg in segments)
+
+
+def test_segment_assign_negative_index_returns_404(router):
+    """A negative segment_idx (-1) must 404 instead of silently mutating the last segment."""
+    convo, segments = _fake_conversation_with_segments(2)
+    handler = _segment_assign_handler(router.conv)
+    with patch.object(router.conv, "_get_valid_conversation_by_id", return_value={"id": "c1"}), patch.object(
+        router.conv, "deserialize_conversation", return_value=convo
+    ):
+        with pytest.raises(HTTPException) as exc:
+            handler("c1", -1, "person_id", value="person-9", uid="u1")
+
+    assert exc.value.status_code == 404
+    assert segments[-1].person_id is None  # last segment untouched
+
+
+def test_segment_assign_valid_index_still_updates(router):
+    """Sanity: an in-range index still applies the assignment (fix must not break the happy path)."""
+    convo, segments = _fake_conversation_with_segments(2)
+    handler = _segment_assign_handler(router.conv)
+    with patch.object(router.conv, "_get_valid_conversation_by_id", return_value={"id": "c1"}), patch.object(
+        router.conv, "deserialize_conversation", return_value=convo
+    ):
+        result = handler("c1", 1, "is_user", value="true", uid="u1")
+
+    assert segments[1].is_user is True
+    assert segments[0].is_user is False  # untouched
+    assert result is convo


### PR DESCRIPTION
## What

PATCH /v1/conversations/{conversation_id}/segments/{segment_idx}/assign indexed `conversation.transcript_segments[segment_idx]` directly, with no bounds check on `segment_idx` (an unconstrained int path parameter).

Two problems followed:

1. An out-of-range `segment_idx` raised `IndexError`, which is unhandled and surfaces as HTTP 500. This is reachable from a normal authenticated client: after `POST /reprocess` or `POST /merge` shrinks or replaces the segment list, a previously valid index the client still holds is now out of range, and a conversation with an empty `transcript_segments` list 500s for any index.
2. A negative `segment_idx` (for example `-1`) passed straight through and silently mutated the wrong segment via Python negative indexing, returning 200 with the wrong data changed.

## Fix

Add the same `0 <= idx < len(...)` guard the sibling handlers in this router already use (`set_conversation_events_state` and `set_action_item_status`). Because this route targets a single named segment rather than a batch of parallel arrays, a missing segment returns 404 ("Segment not found") instead of being skipped.

## Failure class

This is the same unbounded-index-into-a-conversation-sublist class that was already closed for the events and action-items PATCH handlers in this router. The segment assign handler was missed. The guard here closes the remaining instance, and the regression tests for this class now live together in `tests/unit/test_conversation_events_bounds.py`.

## Testing

- `python -m pytest tests/unit/test_conversation_events_bounds.py` -> 6 passed. New cases: out-of-range idx returns 404, negative idx returns 404 with the last segment untouched, in-range idx still applies the assignment (happy path preserved).
- `python scripts/scan_async_blockers.py --dirs routers` -> 0 findings.
- `python scripts/check_module_stub_pollution.py` -> 0 violations.
- Exercised via the regression tests, which call the real handler directly against a stubbed conversation. The guard is pure request-validation logic, so the handler path is fully covered. I did not stand up a live server for this change.

No route signature, parameter, or response model changed, so the OpenAPI contract is unchanged.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9474?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

