### PR TITLE
fix crash appending frames to unmodifiable Wal.data list in local WAL sync

### DIFF
--- a/app/lib/services/wals/flash_page_wal_sync.dart
+++ b/app/lib/services/wals/flash_page_wal_sync.dart
@@ -19,7 +19,7 @@ class FlashPageWalSyncImpl implements FlashPageWalSync {
   static const int pagesPerChunk = 25;
   static const Duration _persistBatchDuration = Duration(seconds: 90);
 
-  List<Wal> _wals = const [];
+  List<Wal> _wals = [];
   BtDevice? _device;
   LocalWalSync? _localSync;
 

--- a/app/lib/services/wals/local_wal_sync.dart
+++ b/app/lib/services/wals/local_wal_sync.dart
@@ -80,7 +80,7 @@ List<Wal> nextSyncUploadBatch(
 }
 
 class LocalWalSyncImpl implements LocalWalSync {
-  List<Wal> _wals = const [];
+  List<Wal> _wals = [];
 
   List<WalFrame> _frames = [];
   List<bool> _frameSynced = [];

--- a/app/lib/services/wals/ring_storage_sync.dart
+++ b/app/lib/services/wals/ring_storage_sync.dart
@@ -33,7 +33,7 @@ import 'package:omi/services/wals/wal_interfaces.dart';
 /// On any failure (cancel, BLE drop, NOTIFY_DONE error status) the ring is left
 /// untouched — the next sync session resumes from the same read_seq.
 class RingStorageSyncImpl implements RingStorageSync {
-  List<Wal> _wals = const [];
+  List<Wal> _wals = [];
   BtDevice? _device;
 
   StreamSubscription? _notifyStream;

--- a/app/lib/services/wals/sdcard_wal_sync.dart
+++ b/app/lib/services/wals/sdcard_wal_sync.dart
@@ -15,7 +15,7 @@ import 'package:omi/services/wals/wal.dart';
 import 'package:omi/services/wals/wal_interfaces.dart';
 
 class SDCardWalSyncImpl implements SDCardWalSync {
-  List<Wal> _wals = const [];
+  List<Wal> _wals = [];
   BtDevice? _device;
 
   StreamSubscription? _storageStream;

--- a/app/lib/services/wals/storage_sync.dart
+++ b/app/lib/services/wals/storage_sync.dart
@@ -20,7 +20,7 @@ import 'package:omi/services/wals/wal_interfaces.dart';
 ///
 /// Closely follows the proven BLE sync pattern from PR #5905's sdcard_wal_sync changes.
 class StorageSyncImpl implements StorageSync {
-  List<Wal> _wals = const [];
+  List<Wal> _wals = [];
   BtDevice? _device;
 
   StreamSubscription? _storageStream;

--- a/app/lib/services/wals/wal.dart
+++ b/app/lib/services/wals/wal.dart
@@ -95,7 +95,7 @@ class Wal {
   WalStorage storage;
 
   String? filePath;
-  List<List<int>> data = [];
+  List<List<int>> data;
   int storageOffset = 0;
   int storageTotalBytes = 0;
   int fileNum = 1;
@@ -168,7 +168,7 @@ class Wal {
     this.storageOffset = 0,
     this.storageTotalBytes = 0,
     this.fileNum = 1,
-    this.data = const [],
+    List<List<int>>? data,
     this.totalFrames = 0,
     this.syncedFrameOffset = 0,
     this.originalStorage,
@@ -177,7 +177,7 @@ class Wal {
     this.lastRetryAt = 0,
     this.jobId,
     this.uploadedAt = 0,
-  }) {
+  }) : data = data ?? [] {
     frameSize = codec.getFrameSize();
   }
 

--- a/app/test/unit/local_wal_sync_test.dart
+++ b/app/test/unit/local_wal_sync_test.dart
@@ -453,6 +453,52 @@ void main() {
     });
   });
 
+  group('WAL lists are growable (regression: Cannot add to an unmodifiable list)', () {
+    // Crash: LocalWalSyncImpl._chunk called wal.data.addAll(chunk) on a WAL
+    // loaded from disk. Wal.fromJson never passed `data`, so the constructor
+    // default `const []` left an unmodifiable list that threw on addAll.
+    test('Wal.fromJson produces a growable data list that _chunk can append to', () {
+      final wal = Wal.fromJson({
+        'timer_start': 1700000000,
+        'codec': 'opus',
+        'seconds': 60,
+        'status': 'miss',
+        'storage': 'disk',
+      });
+
+      // The exact operation from _chunk that crashed in production:
+      wal.data.addAll([
+        [0xAA, 0xBB],
+        [0xCC, 0xDD],
+      ]);
+
+      expect(wal.data.length, 2);
+    });
+
+    test('Wal constructed without data has a growable data list', () {
+      final wal = Wal(timerStart: 1700000000, codec: BleAudioCodec.opus, seconds: 60);
+
+      wal.data.add([0x01]);
+
+      expect(wal.data, [
+        [0x01],
+      ]);
+    });
+
+    test('addExternalWal before _initializeWals completes does not throw on _wals', () async {
+      // Same failure class: `_wals = const []` was unmodifiable until
+      // _initializeWals replaced it, so an early addExternalWal crashed.
+      final freshListener = _MockListener();
+      final freshSync = LocalWalSyncImpl(freshListener);
+      // Old timerStart → backfill lane, so no fresh-upload network call runs.
+      final wal = Wal(timerStart: 1000, codec: BleAudioCodec.opus, seconds: 60);
+
+      await freshSync.addExternalWal(wal);
+
+      expect(freshSync.testWals.map((w) => w.id), contains(wal.id));
+    });
+  });
+
   group('syncWal — orphan WAL guard', () {
     // A WAL the user taps "sync" on may already be gone from `_wals` (a
     // concurrent delete/reload). Previously `.first` on the empty match list


### PR DESCRIPTION
## Summary

Fixes the Crashlytics fatal ([issue 8615e8ac](https://console.firebase.google.com/u/0/project/based-hardware/crashlytics/app/android:com.friend.ios/issues/8615e8ac419bd601ce2460ada92d482c)):

```
Fatal Exception: io.flutter.plugins.firebase.crashlytics.FlutterError: Unsupported operation: Cannot add to an unmodifiable list
       at UnmodifiableListMixin.addAll(dart:_internal)
       at LocalWalSyncImpl._chunk(local_wal_sync.dart:228)
```

## Root cause

`Wal`'s constructor defaulted `data: const []`, and `Wal.fromJson` never passes `data` — so every WAL loaded from disk at startup carried an **unmodifiable const list**. When `LocalWalSyncImpl._chunk` matched such a WAL (same `timerStart`/device/codec) and appended the new chunk via `wal.data.addAll(chunk)`, it threw the fatal.

## Failure class closed

The same `= const []` default existed on the mutated `_wals` fields of **all five** sync implementations (`local_wal_sync`, `sdcard_wal_sync`, `flash_page_wal_sync`, `ring_storage_sync`, `storage_sync`) — e.g. `addExternalWal` could hit `_wals.add` before `_initializeWals` replaced the const list. All are now growable lists, and the `Wal` constructor builds `data ?? []` so no code path can receive an unmodifiable `data`.

Durable guard: regression tests in `test/unit/local_wal_sync_test.dart` pin the growable-list contract at the shared boundary (`Wal` model), covering `fromJson` (the crash path), the bare constructor, and pre-init `addExternalWal`.

## Verification

- New regression tests: `Wal.fromJson(...).data.addAll(...)` (the exact crashing operation), growable default `data` on `Wal()`, `addExternalWal` before `_initializeWals` completes.
- `flutter test test/unit/local_wal_sync_test.dart` → 28 passed.
- `bash app/test.sh` → 749 passed.
- `app/scripts/analyze_ratchet.sh` fails identically with the change stashed — pre-existing local `build/ios/SourcePackages` noise, absent in CI's clean checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9475?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

