### PR TITLE
fix(desktop): deferred bug-sweep follow-ups — data integrity, recovery, INV-CHAT-1, open-redirect

### DIFF
--- a/desktop/macos/Backend-Rust/src/routes/auth.rs
+++ b/desktop/macos/Backend-Rust/src/routes/auth.rs
@@ -208,39 +208,45 @@ async fn apple_domain_association() -> impl IntoResponse {
 /// Whether a client-supplied `redirect_uri` is allowed to receive the OAuth code.
 ///
 /// The desktop app only ever uses two forms: its loopback callback server
-/// (`http://127.0.0.1:<port>/...` or `localhost`) and its custom app scheme deep
-/// link (e.g. `omi-computer://auth/callback`). Everything else — in particular
-/// any `https://…` or non-loopback `http://…` — is rejected, because the callback
-/// page redirects the freshly minted auth code to this URI; without an allowlist
-/// an attacker could set `redirect_uri=https://evil.example/cb`, have a victim
-/// complete sign-in, and receive the victim's code (open redirect → code theft).
+/// (`http://127.0.0.1:<port>/...` or `localhost`) and its app-owned custom scheme
+/// deep link. Every desktop build registers an `omi-…` scheme (prod
+/// `omi-computer`, dev `omi-computer-dev`, named bundles `omi-<slug>`), so custom
+/// schemes are restricted to that prefix. Everything else — any `https://…`,
+/// non-loopback `http://…`, or foreign scheme (`ftp://`, `file://`, `attacker://`)
+/// — is rejected, because the callback page navigates the browser to
+/// `redirect_uri?code=…`; without a tight allowlist an attacker could set
+/// `redirect_uri` to a target they control and receive the victim's code (open
+/// redirect → code theft).
 fn is_allowed_redirect_uri(uri: &str) -> bool {
     let trimmed = uri.trim();
     if trimmed.is_empty() {
         return false;
     }
 
-    // Loopback HTTP callback server (any port).
+    // Loopback HTTP callback server (any port). Parse the authority as everything
+    // between "http://" and the first '/', '?' or '#'. Reject any userinfo ('@'):
+    // "http://127.0.0.1:80@evil.example/" has authority host `evil.example`, so a
+    // naive "split on ':' and match 127.0.0.1" would wrongly allow it.
     if let Some(rest) = trimmed.strip_prefix("http://") {
-        let host = rest.split(['/', ':', '?', '#']).next().unwrap_or("");
+        let authority = rest.split(['/', '?', '#']).next().unwrap_or("");
+        if authority.contains('@') {
+            return false;
+        }
+        let host = authority.split(':').next().unwrap_or("");
         return host == "127.0.0.1" || host == "localhost";
     }
 
-    // Any other http/https is an open-redirect vector.
+    // Any https:// is an open-redirect vector.
     if trimmed.starts_with("https://") {
         return false;
     }
 
-    // Custom app-scheme deep link: "<scheme>://…" where scheme is a valid,
-    // non-http URL scheme (ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )).
+    // App-owned custom scheme deep link only: "omi-…://…". Allowing arbitrary
+    // schemes (ftp://, file://, foo://) would still let the callback navigate the
+    // browser to an attacker-controlled target carrying the code.
     if let Some(scheme_end) = trimmed.find("://") {
-        let scheme = &trimmed[..scheme_end];
-        let mut chars = scheme.chars();
-        let first_ok = chars.next().map_or(false, |c| c.is_ascii_alphabetic());
-        let rest_ok = scheme
-            .chars()
-            .all(|c| c.is_ascii_alphanumeric() || c == '+' || c == '-' || c == '.');
-        return first_ok && rest_ok;
+        let scheme = trimmed[..scheme_end].to_ascii_lowercase();
+        return scheme.starts_with("omi-");
     }
 
     false
@@ -921,14 +927,13 @@ mod tests {
 
     #[test]
     fn redirect_uri_allowlist_accepts_desktop_forms() {
-        // Loopback callback server (any port) and the custom app scheme.
+        // Loopback callback server (any port).
         assert!(is_allowed_redirect_uri("http://127.0.0.1:52001/callback"));
         assert!(is_allowed_redirect_uri("http://localhost:8080/callback"));
+        // App-owned custom schemes: prod, dev, and named-bundle (omi-<slug>).
         assert!(is_allowed_redirect_uri("omi-computer://auth/callback"));
-        // Named/dev bundles use their own custom scheme — still allowed.
-        assert!(is_allowed_redirect_uri(
-            "com.omi.desktop-dev://auth/callback"
-        ));
+        assert!(is_allowed_redirect_uri("omi-computer-dev://auth/callback"));
+        assert!(is_allowed_redirect_uri("omi-fix-rewind://auth/callback"));
     }
 
     #[test]
@@ -942,6 +947,27 @@ mod tests {
         assert!(!is_allowed_redirect_uri("   "));
         assert!(!is_allowed_redirect_uri("not-a-uri"));
         assert!(!is_allowed_redirect_uri("://missing-scheme"));
+    }
+
+    #[test]
+    fn redirect_uri_allowlist_rejects_userinfo_and_foreign_scheme_bypasses() {
+        // Userinfo authority trick: real host is evil.example, not 127.0.0.1.
+        assert!(!is_allowed_redirect_uri(
+            "http://127.0.0.1:80@evil.example/cb"
+        ));
+        assert!(!is_allowed_redirect_uri("http://127.0.0.1@evil.example/cb"));
+        assert!(!is_allowed_redirect_uri("http://localhost@evil.example/cb"));
+        // Foreign / non-http network schemes must not be treated as app deep links.
+        assert!(!is_allowed_redirect_uri("ftp://evil.example/cb"));
+        assert!(!is_allowed_redirect_uri("file:///etc/passwd"));
+        assert!(!is_allowed_redirect_uri("attacker://evil.example/cb"));
+        assert!(!is_allowed_redirect_uri("javascript://alert(1)"));
+        // A scheme that merely contains "omi-" but doesn't start with it is foreign.
+        assert!(!is_allowed_redirect_uri("evil-omi-://x"));
+        // A '@' in the path (not the authority) is harmless and still allowed.
+        assert!(is_allowed_redirect_uri(
+            "http://127.0.0.1:52001/callback@ok"
+        ));
     }
 
     #[test]

--- a/desktop/macos/Backend-Rust/src/routes/auth.rs
+++ b/desktop/macos/Backend-Rust/src/routes/auth.rs
@@ -205,6 +205,47 @@ async fn apple_domain_association() -> impl IntoResponse {
     ""
 }
 
+/// Whether a client-supplied `redirect_uri` is allowed to receive the OAuth code.
+///
+/// The desktop app only ever uses two forms: its loopback callback server
+/// (`http://127.0.0.1:<port>/...` or `localhost`) and its custom app scheme deep
+/// link (e.g. `omi-computer://auth/callback`). Everything else — in particular
+/// any `https://…` or non-loopback `http://…` — is rejected, because the callback
+/// page redirects the freshly minted auth code to this URI; without an allowlist
+/// an attacker could set `redirect_uri=https://evil.example/cb`, have a victim
+/// complete sign-in, and receive the victim's code (open redirect → code theft).
+fn is_allowed_redirect_uri(uri: &str) -> bool {
+    let trimmed = uri.trim();
+    if trimmed.is_empty() {
+        return false;
+    }
+
+    // Loopback HTTP callback server (any port).
+    if let Some(rest) = trimmed.strip_prefix("http://") {
+        let host = rest.split(['/', ':', '?', '#']).next().unwrap_or("");
+        return host == "127.0.0.1" || host == "localhost";
+    }
+
+    // Any other http/https is an open-redirect vector.
+    if trimmed.starts_with("https://") {
+        return false;
+    }
+
+    // Custom app-scheme deep link: "<scheme>://…" where scheme is a valid,
+    // non-http URL scheme (ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )).
+    if let Some(scheme_end) = trimmed.find("://") {
+        let scheme = &trimmed[..scheme_end];
+        let mut chars = scheme.chars();
+        let first_ok = chars.next().map_or(false, |c| c.is_ascii_alphabetic());
+        let rest_ok = scheme
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '+' || c == '-' || c == '.');
+        return first_ok && rest_ok;
+    }
+
+    false
+}
+
 /// Start OAuth flow
 async fn auth_authorize(
     State(state): State<AuthState>,
@@ -214,6 +255,14 @@ async fn auth_authorize(
         return Err(ErrorResponse {
             error: "invalid_provider".to_string(),
             message: "Unsupported provider. Use 'google' or 'apple'.".to_string(),
+        });
+    }
+
+    if !is_allowed_redirect_uri(&params.redirect_uri) {
+        return Err(ErrorResponse {
+            error: "invalid_redirect_uri".to_string(),
+            message: "redirect_uri must be the app's loopback callback or custom scheme."
+                .to_string(),
         });
     }
 
@@ -868,6 +917,31 @@ mod tests {
             js_string_escape("http://127.0.0.1:52001/callback"),
             "http:\\/\\/127.0.0.1:52001\\/callback"
         );
+    }
+
+    #[test]
+    fn redirect_uri_allowlist_accepts_desktop_forms() {
+        // Loopback callback server (any port) and the custom app scheme.
+        assert!(is_allowed_redirect_uri("http://127.0.0.1:52001/callback"));
+        assert!(is_allowed_redirect_uri("http://localhost:8080/callback"));
+        assert!(is_allowed_redirect_uri("omi-computer://auth/callback"));
+        // Named/dev bundles use their own custom scheme — still allowed.
+        assert!(is_allowed_redirect_uri(
+            "com.omi.desktop-dev://auth/callback"
+        ));
+    }
+
+    #[test]
+    fn redirect_uri_allowlist_rejects_open_redirect_vectors() {
+        // The phishing vector: code delivered to an attacker HTTPS URL.
+        assert!(!is_allowed_redirect_uri("https://evil.example/cb"));
+        assert!(!is_allowed_redirect_uri("http://evil.example/cb"));
+        assert!(!is_allowed_redirect_uri("http://127.0.0.1.evil.com/cb"));
+        assert!(!is_allowed_redirect_uri("https://127.0.0.1/cb"));
+        assert!(!is_allowed_redirect_uri(""));
+        assert!(!is_allowed_redirect_uri("   "));
+        assert!(!is_allowed_redirect_uri("not-a-uri"));
+        assert!(!is_allowed_redirect_uri("://missing-scheme"));
     }
 
     #[test]

--- a/desktop/macos/Desktop/Sources/Chat/KernelTurnProjection.swift
+++ b/desktop/macos/Desktop/Sources/Chat/KernelTurnProjection.swift
@@ -9,6 +9,12 @@ final class KernelTurnProjection {
   /// Continuity keys already committed from kernel `turn_recorded` (or promoted
   /// optimistic stages). Prevents double-append of the same logical turn.
   private var appliedKernelTurnKeys = Set<String>()
+  /// Insertion order of `appliedKernelTurnKeys`, so eviction drops the OLDEST
+  /// keys rather than an arbitrary hash-ordered subset (see
+  /// rememberAppliedKernelTurnKey).
+  private var appliedKernelTurnKeyOrder: [String] = []
+  private let appliedKernelTurnKeysCap = 64
+  private let appliedKernelTurnKeysTrimTo = 32
 
   init(host: ChatProvider) {
     self.host = host
@@ -100,9 +106,20 @@ final class KernelTurnProjection {
   }
 
   private func rememberAppliedKernelTurnKey(_ key: String) {
-    appliedKernelTurnKeys.insert(key)
-    if appliedKernelTurnKeys.count > 64 {
-      appliedKernelTurnKeys = Set(Array(appliedKernelTurnKeys).suffix(32))
+    // Track first-seen order so eviction can drop the OLDEST keys. The previous
+    // `Set(Array(set).suffix(32))` operated on a hash-ordered array, so it kept an
+    // ARBITRARY 32 keys — a just-applied key could be evicted while a stale one
+    // survived, letting a re-delivered turn_recorded (durable-outbox replay or
+    // bridge reattach) slip past the dedup guard and double-append the same
+    // logical turn (INV-6 rule 4).
+    guard appliedKernelTurnKeys.insert(key).inserted else { return }
+    appliedKernelTurnKeyOrder.append(key)
+    if appliedKernelTurnKeyOrder.count > appliedKernelTurnKeysCap {
+      let evictCount = appliedKernelTurnKeyOrder.count - appliedKernelTurnKeysTrimTo
+      for evicted in appliedKernelTurnKeyOrder.prefix(evictCount) {
+        appliedKernelTurnKeys.remove(evicted)
+      }
+      appliedKernelTurnKeyOrder.removeFirst(evictCount)
     }
   }
 

--- a/desktop/macos/Desktop/Sources/FileIndexing/FileIndexerService.swift
+++ b/desktop/macos/Desktop/Sources/FileIndexing/FileIndexerService.swift
@@ -146,6 +146,11 @@ actor FileIndexerService {
         // For incremental scans, load existing index for O(1) lookup
         let existingIndex: [String: Date?] = incremental ? loadExistingIndex(from: db) : [:]
         var scannedPaths = Set<String>()
+        // ~-relative prefixes of directories whose enumeration FAILED (permission
+        // revoked, transient I/O). Files under these were not scanned, but that is
+        // a read error — not deletion — so they must be excluded from the retention
+        // diff (otherwise a single unreadable folder purges its whole index subtree).
+        var failedDirectories = Set<String>()
 
         if incremental {
             log("FileIndexer: Loaded \(existingIndex.count) existing paths for incremental scan")
@@ -178,7 +183,8 @@ actor FileIndexerService {
                 totalFiles: &totalFiles,
                 db: db,
                 existingIndex: existingIndex,
-                scannedPaths: &scannedPaths
+                scannedPaths: &scannedPaths,
+                failedDirectories: &failedDirectories
             )
         }
 
@@ -189,7 +195,12 @@ actor FileIndexerService {
 
         // For incremental scans, remove files that no longer exist on disk
         if incremental && !existingIndex.isEmpty {
-            deleteRemovedFiles(scannedPaths: scannedPaths, existingPaths: Set(existingIndex.keys), db: db)
+            deleteRemovedFiles(
+                scannedPaths: scannedPaths,
+                existingPaths: Set(existingIndex.keys),
+                protectedPrefixes: failedDirectories,
+                db: db
+            )
         }
 
         return totalFiles
@@ -206,7 +217,8 @@ actor FileIndexerService {
         totalFiles: inout Int,
         db: DatabasePool,
         existingIndex: [String: Date?],
-        scannedPaths: inout Set<String>
+        scannedPaths: inout Set<String>,
+        failedDirectories: inout Set<String>
     ) {
         guard scanPolicy.shouldScanDirectory(atDepth: depth) else { return }
 
@@ -218,6 +230,10 @@ actor FileIndexerService {
                 options: [.skipsHiddenFiles]
             )
         } catch {
+            // Enumeration failure is a read error, not deletion. Record this
+            // directory so its previously-indexed files are NOT purged by the
+            // retention diff (see deleteRemovedFiles / failedDirectories).
+            failedDirectories.insert(scanPolicy.relativePath(for: url, homePath: homePath))
             log("FileIndexer: Cannot read \(url.lastPathComponent): \(error.localizedDescription)")
             return
         }
@@ -269,7 +285,8 @@ actor FileIndexerService {
                         totalFiles: &totalFiles,
                         db: db,
                         existingIndex: existingIndex,
-                        scannedPaths: &scannedPaths
+                        scannedPaths: &scannedPaths,
+                        failedDirectories: &failedDirectories
                     )
                     continue
                 }
@@ -357,8 +374,32 @@ actor FileIndexerService {
     }
 
     /// Delete files from the index that no longer exist on disk
-    private func deleteRemovedFiles(scannedPaths: Set<String>, existingPaths: Set<String>, db: DatabasePool) {
-        let removed = existingPaths.subtracting(scannedPaths)
+    /// Paths that are genuinely gone from disk (present in the index, not seen this
+    /// scan, and NOT under a directory whose enumeration failed). Pure + static so
+    /// the retention diff can be tested without a database or filesystem.
+    static func pathsToDelete(
+        scannedPaths: Set<String>,
+        existingPaths: Set<String>,
+        protectedPrefixes: Set<String>
+    ) -> Set<String> {
+        existingPaths.subtracting(scannedPaths).filter { path in
+            !protectedPrefixes.contains { prefix in
+                path == prefix || path.hasPrefix(prefix + "/")
+            }
+        }
+    }
+
+    private func deleteRemovedFiles(
+        scannedPaths: Set<String>,
+        existingPaths: Set<String>,
+        protectedPrefixes: Set<String>,
+        db: DatabasePool
+    ) {
+        let removed = Self.pathsToDelete(
+            scannedPaths: scannedPaths,
+            existingPaths: existingPaths,
+            protectedPrefixes: protectedPrefixes
+        )
         guard !removed.isEmpty else { return }
 
         log("FileIndexer: Removing \(removed.count) deleted files from index")

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskExtraction/TaskAssistant.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskExtraction/TaskAssistant.swift
@@ -451,7 +451,7 @@ actor TaskAssistant: ProactiveAssistant {
             let embedding = try await EmbeddingService.shared.embed(text: text)
             let data = await EmbeddingService.shared.floatsToData(embedding)
             try await StagedTaskStorage.shared.updateEmbedding(id: id, embedding: data)
-            await EmbeddingService.shared.addToIndex(id: id, embedding: embedding)
+            await EmbeddingService.shared.addToIndex(source: .staged, id: id, embedding: embedding)
             log("Task: Generated embedding for staged task \(id)")
         } catch {
             logError("Task: Failed to generate embedding for staged task \(id)", error: error)
@@ -1444,35 +1444,42 @@ actor TaskAssistant: ProactiveAssistant {
             let vectorResults = await EmbeddingService.shared.searchSimilar(query: queryEmbedding, topK: 10)
 
             for result in vectorResults where result.similarity > 0.3 {
-                if let record = try await ActionItemStorage.shared.getActionItem(id: result.id) {
-                    let status: String
-                    if record.deleted { status = "deleted" }
-                    else if record.completed { status = "completed" }
-                    else { status = "active" }
+                // Resolve against the exact table the embedding came from — the
+                // index key now carries its source, so no more guessing/fallback
+                // that returned an unrelated task on a rowid collision.
+                switch result.source {
+                case .actionItem:
+                    if let record = try await ActionItemStorage.shared.getActionItem(id: result.id) {
+                        let status: String
+                        if record.deleted { status = "deleted" }
+                        else if record.completed { status = "completed" }
+                        else { status = "active" }
 
-                    results.append(TaskSearchResult(
-                        id: result.id,
-                        description: record.description,
-                        status: status,
-                        similarity: Double(result.similarity),
-                        matchType: "vector",
-                        relevanceScore: record.relevanceScore
-                    ))
-                } else if let staged = try await StagedTaskStorage.shared.getStagedTask(id: result.id) {
-                    // Fallback: ID belongs to a staged task (shared embedding index)
-                    let status: String
-                    if staged.deleted { status = "deleted" }
-                    else if staged.completed { status = "completed" }
-                    else { status = "active" }
+                        results.append(TaskSearchResult(
+                            id: result.id,
+                            description: record.description,
+                            status: status,
+                            similarity: Double(result.similarity),
+                            matchType: "vector",
+                            relevanceScore: record.relevanceScore
+                        ))
+                    }
+                case .staged:
+                    if let staged = try await StagedTaskStorage.shared.getStagedTask(id: result.id) {
+                        let status: String
+                        if staged.deleted { status = "deleted" }
+                        else if staged.completed { status = "completed" }
+                        else { status = "active" }
 
-                    results.append(TaskSearchResult(
-                        id: result.id,
-                        description: staged.description,
-                        status: status,
-                        similarity: Double(result.similarity),
-                        matchType: "vector",
-                        relevanceScore: staged.relevanceScore
-                    ))
+                        results.append(TaskSearchResult(
+                            id: result.id,
+                            description: staged.description,
+                            status: status,
+                            similarity: Double(result.similarity),
+                            matchType: "vector",
+                            relevanceScore: staged.relevanceScore
+                        ))
+                    }
                 }
             }
         } catch {

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/EmbeddingService.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/EmbeddingService.swift
@@ -1,6 +1,22 @@
 import Accelerate
 import Foundation
 
+/// Which table an embedding-index entry came from. `action_items` and
+/// `staged_tasks` are separate SQLite tables whose autoincrement rowids both
+/// start at 1, so a raw-`Int64`-keyed index silently collides low ids across the
+/// two tables. Carrying the source makes the key unique and lets search results
+/// be resolved against the correct table deterministically.
+enum TaskEmbeddingSource: String, Sendable {
+  case actionItem
+  case staged
+}
+
+/// Composite key for the in-memory task-embedding index (source + row id).
+struct TaskEmbeddingKey: Hashable, Sendable {
+  let source: TaskEmbeddingSource
+  let id: Int64
+}
+
 /// Actor-based service for embeddings using Gemini (3072-dim)
 actor EmbeddingService {
   static let shared = EmbeddingService()
@@ -9,8 +25,10 @@ actor EmbeddingService {
   static let embeddingDimension = 3072
   static var modelName: String { ModelQoS.Gemini.embedding }
 
-  /// In-memory index: action_item.id -> normalized embedding
-  private var index: [Int64: [Float]] = [:]
+  /// In-memory index: (source, row id) -> normalized embedding. Keyed by source
+  /// so action_items and staged_tasks with the same rowid never overwrite each
+  /// other (see TaskEmbeddingSource).
+  private var index: [TaskEmbeddingKey: [Float]] = [:]
   private var isIndexLoaded = false
 
   /// Cap in-memory embeddings to limit memory (~12KB each, 5000 = ~60MB max)
@@ -134,8 +152,18 @@ actor EmbeddingService {
       throw EmbeddingError.invalidResponse
     }
 
-    return embeddings.compactMap { embedding in
-      guard let values = embedding["values"] as? [Double] else { return nil }
+    // Gemini returns embeddings 1:1 in request order. Callers zip results back to
+    // their input texts by position (backfill, OCR indexing), so a dropped or
+    // extra entry would silently persist an embedding onto the WRONG task. Fail
+    // the batch on any count mismatch or malformed entry instead of compactMap-ing
+    // (which would shift every subsequent embedding by one).
+    guard embeddings.count == texts.count else {
+      throw EmbeddingError.invalidResponse
+    }
+    return try embeddings.map { embedding in
+      guard let values = embedding["values"] as? [Double] else {
+        throw EmbeddingError.invalidResponse
+      }
       return normalize(values.map { Float($0) })
     }
   }
@@ -150,7 +178,7 @@ actor EmbeddingService {
       // Only keep the most recent embeddings (suffix = highest IDs = newest)
       for (id, data) in rows.suffix(maxIndexSize) {
         if let floats = dataToFloats(data) {
-          index[id] = floats
+          index[TaskEmbeddingKey(source: .actionItem, id: id)] = floats
         }
       }
       let actionCount = index.count
@@ -161,7 +189,7 @@ actor EmbeddingService {
         let stagedRows = try await StagedTaskStorage.shared.getAllEmbeddings()
         for (id, data) in stagedRows.suffix(remaining) {
           if let floats = dataToFloats(data) {
-            index[id] = floats
+            index[TaskEmbeddingKey(source: .staged, id: id)] = floats
           }
         }
       }
@@ -175,32 +203,39 @@ actor EmbeddingService {
     }
   }
 
-  /// Add a single embedding to the in-memory index (respects maxIndexSize)
-  func addToIndex(id: Int64, embedding: [Float]) {
+  /// Add a single embedding to the in-memory index (respects maxIndexSize).
+  /// `source` disambiguates action_items vs staged_tasks so colliding rowids do
+  /// not overwrite each other.
+  func addToIndex(source: TaskEmbeddingSource, id: Int64, embedding: [Float]) {
+    let key = TaskEmbeddingKey(source: source, id: id)
     // If at capacity and this is a new key, evict the oldest (lowest ID)
-    if index[id] == nil && index.count >= maxIndexSize {
-      if let oldestKey = index.keys.min() {
+    if index[key] == nil && index.count >= maxIndexSize {
+      if let oldestKey = index.keys.min(by: { $0.id < $1.id }) {
         index.removeValue(forKey: oldestKey)
       }
     }
-    index[id] = embedding
+    index[key] = embedding
   }
 
   /// Remove an entry from the index
-  func removeFromIndex(id: Int64) {
-    index.removeValue(forKey: id)
+  func removeFromIndex(source: TaskEmbeddingSource, id: Int64) {
+    index.removeValue(forKey: TaskEmbeddingKey(source: source, id: id))
   }
 
-  /// Search for similar items using cosine similarity via Accelerate/vDSP
-  func searchSimilar(query: [Float], topK: Int = 10) -> [(id: Int64, similarity: Float)] {
+  /// Search for similar items using cosine similarity via Accelerate/vDSP.
+  /// Each result carries its `source` so the caller resolves it against the
+  /// correct table (action_items vs staged_tasks) instead of guessing.
+  func searchSimilar(query: [Float], topK: Int = 10)
+    -> [(source: TaskEmbeddingSource, id: Int64, similarity: Float)]
+  {
     guard !index.isEmpty else { return [] }
 
-    var results: [(id: Int64, similarity: Float)] = []
+    var results: [(source: TaskEmbeddingSource, id: Int64, similarity: Float)] = []
     results.reserveCapacity(index.count)
 
-    for (id, stored) in index {
+    for (key, stored) in index {
       let sim = cosineSimilarity(query, stored)
-      results.append((id, sim))
+      results.append((key.source, key.id, sim))
     }
 
     // Sort descending by similarity and take topK
@@ -234,7 +269,7 @@ actor EmbeddingService {
           let item = items[i]
           let data = floatsToData(embedding)
           try await ActionItemStorage.shared.updateEmbedding(id: item.id, embedding: data)
-          addToIndex(id: item.id, embedding: embedding)
+          addToIndex(source: .actionItem, id: item.id, embedding: embedding)
         }
 
         totalProcessed += items.count
@@ -256,7 +291,7 @@ actor EmbeddingService {
           let item = items[i]
           let data = floatsToData(embedding)
           try await StagedTaskStorage.shared.updateEmbedding(id: item.id, embedding: data)
-          addToIndex(id: item.id, embedding: embedding)
+          addToIndex(source: .staged, id: item.id, embedding: embedding)
         }
 
         totalProcessed += items.count

--- a/desktop/macos/Desktop/Sources/Providers/ChatToolExecutor.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatToolExecutor.swift
@@ -1344,11 +1344,10 @@ class ChatToolExecutor {
         return "Error: embedding index failed to load. Task vector search is unavailable."
       }
 
-      // Embed the query text
-      // EmbeddingService uses a shared Int64-keyed index for both action_items and staged_tasks.
-      // loadIndex() loads action_items first, then staged_tasks — so for colliding IDs, the
-      // staged_task embedding overwrites the action_item one. We check staged_tasks first to
-      // match the actual embedding owner, then fall back to action_items for non-colliding IDs.
+      // Embed the query text. The in-memory index is keyed by (source, id), so
+      // each search result resolves deterministically against its own table
+      // instead of the old staged-first/action-fallback guessing that returned an
+      // unrelated task when action_item and staged_task rowids collided.
       let queryEmbedding = try await EmbeddingService.shared.embed(
         text: query, taskType: "RETRIEVAL_QUERY")
 
@@ -1360,9 +1359,11 @@ class ChatToolExecutor {
       var count = 0
 
       for result in vectorResults where result.similarity > 0.3 {
-        // Try staged_tasks first (their embeddings overwrite action_items on ID collision),
-        // then fall back to action_items
-        if let staged = try? await StagedTaskStorage.shared.getStagedTask(id: result.id) {
+        switch result.source {
+        case .staged:
+          guard let staged = try? await StagedTaskStorage.shared.getStagedTask(id: result.id) else {
+            continue
+          }
           if staged.deleted { continue }
           if !includeCompleted && staged.completed { continue }
           count += 1
@@ -1371,7 +1372,10 @@ class ChatToolExecutor {
           lines.append(
             "\(count). \(check) \(staged.description) (similarity: \(sim), id: \(result.id), source: staged_tasks)"
           )
-        } else if let record = try? await ActionItemStorage.shared.getActionItem(id: result.id) {
+        case .actionItem:
+          guard let record = try? await ActionItemStorage.shared.getActionItem(id: result.id) else {
+            continue
+          }
           if record.deleted { continue }
           if !includeCompleted && record.completed { continue }
           count += 1

--- a/desktop/macos/Desktop/Sources/Rewind/Core/RewindStorage.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/RewindStorage.swift
@@ -721,7 +721,10 @@ actor RewindStorage {
 
         var chunks: [VideoChunkInfo] = []
 
-        // Enumerate all .hevc files in videos directory (including subdirectories)
+        // Enumerate all video chunk files in the videos directory (recursively).
+        // The encoder writes .mp4 chunks (VideoChunkEncoder.generateChunkPath);
+        // .hevc is only matched for legacy installs. Filtering on .hevc alone made
+        // "Rebuild Index" recover ZERO frames from a store full of .mp4 chunks.
         let enumerator = fileManager.enumerator(
             at: videosDirectory,
             includingPropertiesForKeys: [.isRegularFileKey, .creationDateKey],
@@ -729,7 +732,8 @@ actor RewindStorage {
         )
 
         while let fileURL = enumerator?.nextObject() as? URL {
-            guard fileURL.pathExtension == "hevc" else { continue }
+            let ext = fileURL.pathExtension.lowercased()
+            guard ext == "mp4" || ext == "hevc" else { continue }
 
             // Get relative path from videos directory
             let relativePath = fileURL.path.replacingOccurrences(of: videosDirectory.path + "/", with: "")

--- a/desktop/macos/Desktop/Sources/Rewind/Core/VideoChunkEncoder.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/VideoChunkEncoder.swift
@@ -203,18 +203,12 @@ actor VideoChunkEncoder {
             }
         }
 
-        // Record timestamp only (CGImage is not retained - memory optimization)
-        frameTimestamps.append(timestamp)
-
-        let frameInfo = EncodedFrame(
-            videoChunkPath: currentChunkPath!,
-            frameOffset: frameOffsetInChunk,
-            timestamp: timestamp
-        )
-
-        frameOffsetInChunk += 1
-
-        // Write frame to the encoder immediately (CGImage not stored after this)
+        // Write frame to the encoder FIRST (CGImage not stored after this). Only a
+        // successful write may consume a frame index: if the write throws, the
+        // caller skips the DB insert for this frame, so advancing frameOffsetInChunk
+        // / appending a timestamp here would desync every later frame in the chunk
+        // by one (DB frameOffset N pointing at real sample N-1, and the last record
+        // pointing past the end of the video). Record the frame only after success.
         do {
             try await writeFrame(image: image)
             consecutiveWriteFailures = 0 // Reset on successful write
@@ -229,6 +223,18 @@ actor VideoChunkEncoder {
             }
             throw error
         }
+
+        // Write succeeded — now record the timestamp (CGImage is not retained) and
+        // claim this frame's offset, so offsets match real encoded sample indices.
+        frameTimestamps.append(timestamp)
+
+        let frameInfo = EncodedFrame(
+            videoChunkPath: currentChunkPath!,
+            frameOffset: frameOffsetInChunk,
+            timestamp: timestamp
+        )
+
+        frameOffsetInChunk += 1
 
         // Check if chunk duration exceeded.
         // First chunk uses the shorter `firstChunkDuration` so Rewind starts showing

--- a/desktop/macos/Desktop/Sources/Rewind/Services/RewindIndexer.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Services/RewindIndexer.swift
@@ -701,9 +701,9 @@ actor RewindIndexer {
 
     /// Extract frame metadata from a video chunk
     private func extractFramesFromChunk(_ chunkInfo: VideoChunkInfo) async throws -> [FrameMetadata] {
-        // Parse the chunk filename to extract timestamp info
-        // Format: chunk_YYYYMMDD_HHMMSS.hevc
-        guard let timestamp = parseChunkTimestamp(chunkInfo.filename) else {
+        // Parse the chunk's capture time from its relative path (the day lives in
+        // the parent directory: "<yyyy-MM-dd>/chunk_HHmmss.mp4").
+        guard let timestamp = Self.parseChunkTimestamp(relativePath: chunkInfo.relativePath) else {
             return []
         }
 
@@ -725,8 +725,45 @@ actor RewindIndexer {
         return frames
     }
 
-    /// Parse timestamp from chunk filename
-    private func parseChunkTimestamp(_ filename: String) -> Date? {
+    /// Parse a chunk's capture timestamp from its stored relative path.
+    ///
+    /// New format (VideoChunkEncoder.generateChunkPath):
+    ///   "<yyyy-MM-dd>/chunk_<HHmmss>.<ext>" — day directory + time-only filename.
+    /// Legacy flat format: "chunk_<YYYYMMDD>_<HHMMSS>.hevc".
+    ///
+    /// The encoder wrote both parts with local-time DateFormatters, so parse in the
+    /// current time zone to round-trip. Pure + static so rebuild parsing is testable.
+    static func parseChunkTimestamp(relativePath: String) -> Date? {
+        let parts = relativePath.split(separator: "/").map(String.init)
+        let filename = parts.last ?? relativePath
+
+        // New format: day directory + "chunk_HHmmss.<ext>".
+        if parts.count >= 2, let time = timeComponentFromChunkFilename(filename) {
+            let dayStr = parts[parts.count - 2]
+            let formatter = DateFormatter()
+            formatter.locale = Locale(identifier: "en_US_POSIX")
+            formatter.timeZone = .current
+            formatter.dateFormat = "yyyy-MM-dd'T'HHmmss"
+            if let date = formatter.date(from: "\(dayStr)T\(time)") {
+                return date
+            }
+        }
+
+        // Legacy flat format: chunk_YYYYMMDD_HHMMSS.hevc
+        return parseLegacyChunkTimestamp(filename)
+    }
+
+    /// Extract the "HHmmss" component from "chunk_HHmmss.<ext>", or nil if the
+    /// filename doesn't match the time-only chunk shape.
+    private static func timeComponentFromChunkFilename(_ filename: String) -> String? {
+        guard filename.hasPrefix("chunk_") else { return nil }
+        let afterPrefix = filename.dropFirst("chunk_".count)
+        let stem = afterPrefix.split(separator: ".").first.map(String.init) ?? String(afterPrefix)
+        guard stem.count == 6, stem.allSatisfy({ $0.isNumber }) else { return nil }
+        return stem
+    }
+
+    private static func parseLegacyChunkTimestamp(_ filename: String) -> Date? {
         // Expected format: chunk_YYYYMMDD_HHMMSS.hevc
         guard filename.hasPrefix("chunk_"),
               filename.hasSuffix(".hevc"),
@@ -745,6 +782,7 @@ actor RewindIndexer {
               timeStr.allSatisfy({ $0.isNumber }) else { return nil }
 
         let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
         formatter.dateFormat = "yyyyMMddHHmmss"
         return formatter.date(from: dateStr + timeStr)
     }

--- a/desktop/macos/Desktop/Tests/EmbeddingIndexSourceTests.swift
+++ b/desktop/macos/Desktop/Tests/EmbeddingIndexSourceTests.swift
@@ -1,0 +1,59 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// Regression test for the embedding-index rowid collision: `action_items` and
+/// `staged_tasks` are separate tables whose autoincrement rowids both start at 1.
+/// The old index was keyed by raw `Int64`, so a staged task and an action item
+/// with the same id overwrote each other, and search results resolved to the
+/// wrong table (the two consumers even guessed in opposite orders). The index is
+/// now keyed by (source, id), so colliding ids coexist and resolve deterministically.
+final class EmbeddingIndexSourceTests: XCTestCase {
+
+  /// A 3072-dim one-hot unit vector (matches Gemini's embedding dimension).
+  private func oneHot(_ index: Int) -> [Float] {
+    var v = [Float](repeating: 0, count: EmbeddingService.embeddingDimension)
+    v[index] = 1
+    return v
+  }
+
+  private let collidingID: Int64 = 987_654_321
+
+  override func tearDown() async throws {
+    // Clean up the shared singleton's index so we don't leak into other tests.
+    await EmbeddingService.shared.removeFromIndex(source: .actionItem, id: collidingID)
+    await EmbeddingService.shared.removeFromIndex(source: .staged, id: collidingID)
+    try await super.tearDown()
+  }
+
+  func testSameRowidDifferentSourceDoNotOverwrite() async {
+    let svc = EmbeddingService.shared
+    let sizeBefore = await svc.indexSize
+
+    // Same rowid, different source — the classic collision.
+    await svc.addToIndex(source: .actionItem, id: collidingID, embedding: oneHot(0))
+    await svc.addToIndex(source: .staged, id: collidingID, embedding: oneHot(1))
+
+    let sizeAfter = await svc.indexSize
+    XCTAssertEqual(
+      sizeAfter - sizeBefore, 2,
+      "colliding action_item/staged rowids must coexist, not overwrite")
+  }
+
+  func testSearchResolvesToTheCorrectSource() async {
+    let svc = EmbeddingService.shared
+    let actionVec = oneHot(0)
+    let stagedVec = oneHot(1)  // orthogonal to actionVec
+
+    await svc.addToIndex(source: .actionItem, id: collidingID, embedding: actionVec)
+    await svc.addToIndex(source: .staged, id: collidingID, embedding: stagedVec)
+
+    // Querying with the action_item's own vector must surface the action_item
+    // entry for this id (similarity 1.0) ahead of the staged one (similarity 0).
+    let byAction = await svc.searchSimilar(query: actionVec, topK: EmbeddingService.embeddingDimension)
+    XCTAssertEqual(byAction.first { $0.id == collidingID }?.source, .actionItem)
+
+    let byStaged = await svc.searchSimilar(query: stagedVec, topK: EmbeddingService.embeddingDimension)
+    XCTAssertEqual(byStaged.first { $0.id == collidingID }?.source, .staged)
+  }
+}

--- a/desktop/macos/Desktop/Tests/FileIndexerRetentionTests.swift
+++ b/desktop/macos/Desktop/Tests/FileIndexerRetentionTests.swift
@@ -1,0 +1,63 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// Regression test for the FileIndexer fail-open delete: an incremental rescan
+/// treated an unreadable directory (permission revoked / transient I/O) as "all
+/// its files were deleted" and purged every indexed row under it. The retention
+/// diff must exclude files under any directory whose enumeration failed.
+final class FileIndexerRetentionTests: XCTestCase {
+
+  func testFilesUnderAFailedDirectoryAreNotDeleted() {
+    let existing: Set<String> = [
+      "~/Documents/report.pdf",
+      "~/Documents/notes/todo.txt",
+      "~/Downloads/installer.dmg",
+    ]
+    // Documents failed to enumerate this scan (so none of its files were seen),
+    // but Downloads scanned fine and installer.dmg is genuinely gone.
+    let scanned: Set<String> = []
+    let protectedPrefixes: Set<String> = ["~/Documents"]
+
+    let toDelete = FileIndexerService.pathsToDelete(
+      scannedPaths: scanned,
+      existingPaths: existing,
+      protectedPrefixes: protectedPrefixes
+    )
+
+    XCTAssertEqual(toDelete, ["~/Downloads/installer.dmg"])
+    XCTAssertFalse(toDelete.contains("~/Documents/report.pdf"))
+    XCTAssertFalse(toDelete.contains("~/Documents/notes/todo.txt"))
+  }
+
+  func testGenuinelyRemovedFilesAreStillDeleted() {
+    // No failed directories: a previously-indexed file not seen this scan is a
+    // real deletion and must be purged.
+    let existing: Set<String> = ["~/Documents/old.txt", "~/Documents/kept.txt"]
+    let scanned: Set<String> = ["~/Documents/kept.txt"]
+
+    let toDelete = FileIndexerService.pathsToDelete(
+      scannedPaths: scanned,
+      existingPaths: existing,
+      protectedPrefixes: []
+    )
+
+    XCTAssertEqual(toDelete, ["~/Documents/old.txt"])
+  }
+
+  func testPrefixMatchDoesNotOverMatchSiblingDirectories() {
+    // "~/Documents" must not protect "~/Documents2/..." (prefix must be a path
+    // boundary, not a raw string prefix).
+    let existing: Set<String> = ["~/Documents2/file.txt"]
+    let scanned: Set<String> = []
+    let protectedPrefixes: Set<String> = ["~/Documents"]
+
+    let toDelete = FileIndexerService.pathsToDelete(
+      scannedPaths: scanned,
+      existingPaths: existing,
+      protectedPrefixes: protectedPrefixes
+    )
+
+    XCTAssertEqual(toDelete, ["~/Documents2/file.txt"])
+  }
+}

--- a/desktop/macos/Desktop/Tests/KernelTurnRecordedProjectionTests.swift
+++ b/desktop/macos/Desktop/Tests/KernelTurnRecordedProjectionTests.swift
@@ -111,6 +111,55 @@ final class KernelTurnRecordedProjectionTests: XCTestCase {
     XCTAssertEqual(provider.messages.filter { $0.sender == .ai }.count, 1)
   }
 
+  /// Regression: the applied-key cache evicted an ARBITRARY 32 keys (hash-ordered
+  /// `suffix(32)` over an unordered Set), so after the cache exceeded its cap a
+  /// re-delivered turn_recorded whose key was randomly dropped could double-append.
+  /// Eviction now drops OLDEST-first, so keys that are still among the most-recent
+  /// survivors keep deduping. This applies enough distinct turns to force an
+  /// eviction, then re-delivers a band of keys the oldest-first policy guarantees
+  /// are retained — asserting zero duplicate appends.
+  func testDedupSurvivesEvictionOfMostRecentKeys() {
+    let provider = ChatProvider()
+    let projection = provider.kernelTurnProjection
+    let surface = provider.mainChatSurfaceReference()
+
+    func makeTurn(_ index: Int) -> AgentRuntimeProcess.KernelTurnRecorded {
+      .init(
+        conversationId: "conv-evict",
+        surfaceKind: surface.surfaceKind,
+        externalRefKind: surface.externalRefKind,
+        externalRefId: surface.externalRefId,
+        userText: "user-\(index)",
+        assistantText: "reply-\(index)",
+        origin: "realtime_voice",
+        interrupted: false,
+        idempotencyKey: "evict-key-\(index)",
+        userTurnId: nil,
+        assistantTurnId: nil
+      )
+    }
+
+    // 96 distinct turns exceeds the 64 cap → at least one eviction fires (trim to
+    // the most-recent 32). Under oldest-first eviction, keys 33..95 all remain
+    // tracked afterward.
+    let total = 96
+    for i in 0..<total {
+      projection.apply(makeTurn(i))
+    }
+    XCTAssertEqual(provider.messages.filter { $0.sender == .user }.count, total)
+
+    // Re-deliver keys 33..64 — the band that straddles the trim boundary and that
+    // the hash-ordered `suffix(32)` could have evicted, but oldest-first keeps.
+    for i in 33...64 {
+      projection.apply(makeTurn(i))
+    }
+
+    XCTAssertEqual(
+      provider.messages.filter { $0.sender == .user }.count, total,
+      "re-delivered turns whose keys are still tracked must not double-append")
+    XCTAssertEqual(provider.messages.filter { $0.sender == .ai }.count, total)
+  }
+
   func testRapidPTTRoleProjectionsShowEveryUserTurnBeforeFinalReply() {
     let provider = ChatProvider()
     let projection = provider.kernelTurnProjection

--- a/desktop/macos/Desktop/Tests/RewindChunkTimestampParseTests.swift
+++ b/desktop/macos/Desktop/Tests/RewindChunkTimestampParseTests.swift
@@ -1,0 +1,49 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// Regression test for the dead Rewind "Rebuild Index" recovery path: the encoder
+/// writes chunks as "<yyyy-MM-dd>/chunk_HHmmss.mp4", but rebuild scanned for
+/// ".hevc" and parsed a flat "chunk_YYYYMMDD_HHMMSS.hevc" (26-char) name — so it
+/// recovered ZERO frames and silently reported success. The parser must read the
+/// day from the path directory and accept the real .mp4 chunk shape.
+final class RewindChunkTimestampParseTests: XCTestCase {
+
+  private func localString(_ date: Date) -> String {
+    let f = DateFormatter()
+    f.locale = Locale(identifier: "en_US_POSIX")
+    f.timeZone = .current
+    f.dateFormat = "yyyy-MM-dd HH:mm:ss"
+    return f.string(from: date)
+  }
+
+  func testParsesNewMp4ChunkPathWithDayDirectory() throws {
+    // The exact shape VideoChunkEncoder.generateChunkPath produces.
+    let date = try XCTUnwrap(
+      RewindIndexer.parseChunkTimestamp(relativePath: "2026-04-09/chunk_143022.mp4"))
+    XCTAssertEqual(localString(date), "2026-04-09 14:30:22")
+  }
+
+  func testRoundTripsWithLegacyHevcExtensionInNewLayout() throws {
+    // A legacy .hevc file still stored under the day-directory layout.
+    let date = try XCTUnwrap(
+      RewindIndexer.parseChunkTimestamp(relativePath: "2026-01-02/chunk_000501.hevc"))
+    XCTAssertEqual(localString(date), "2026-01-02 00:05:01")
+  }
+
+  func testParsesLegacyFlatHevcName() throws {
+    let date = try XCTUnwrap(
+      RewindIndexer.parseChunkTimestamp(relativePath: "chunk_20260409_143022.hevc"))
+    let f = DateFormatter()
+    f.locale = Locale(identifier: "en_US_POSIX")
+    f.dateFormat = "yyyy-MM-dd HH:mm:ss"
+    XCTAssertEqual(f.string(from: date), "2026-04-09 14:30:22")
+  }
+
+  func testRejectsMalformedNames() {
+    XCTAssertNil(RewindIndexer.parseChunkTimestamp(relativePath: "2026-04-09/notachunk.mp4"))
+    XCTAssertNil(RewindIndexer.parseChunkTimestamp(relativePath: "2026-04-09/chunk_14302.mp4"))  // 5 digits
+    XCTAssertNil(RewindIndexer.parseChunkTimestamp(relativePath: "2026-04-09/chunk_1430aa.mp4"))  // non-numeric
+    XCTAssertNil(RewindIndexer.parseChunkTimestamp(relativePath: "chunk_143022.mp4"))  // no day dir, no legacy match
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260711-macos-bug-sweep-2.json
+++ b/desktop/macos/changelog/unreleased/20260711-macos-bug-sweep-2.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed more reliability issues: Rewind's 'Rebuild Index' recovery now actually restores your video history, task search no longer returns the wrong task, screen-file indexing no longer drops your files when a folder is temporarily unreadable, and voice turns can't be duplicated in chat"
+}

--- a/desktop/macos/e2e/flows/capture-lifecycle.yaml
+++ b/desktop/macos/e2e/flows/capture-lifecycle.yaml
@@ -34,6 +34,8 @@ covers:
   - desktop/macos/Desktop/Sources/Audio/BleAudioService.swift
   - desktop/macos/Desktop/Sources/Rewind/Core/RewindStorage.swift
   - desktop/macos/Desktop/Sources/Services/QueryTracer.swift
+  - desktop/macos/Desktop/Sources/Rewind/Core/VideoChunkEncoder.swift
+  - desktop/macos/Desktop/Sources/Rewind/Services/RewindIndexer.swift
 preconditions:
   - automation_bridge_ready
 

--- a/desktop/macos/e2e/flows/harness-smoke.yaml
+++ b/desktop/macos/e2e/flows/harness-smoke.yaml
@@ -13,6 +13,7 @@ covers:
   - desktop/macos/Desktop/Sources/ClientDeviceService.swift
   - desktop/macos/Desktop/Sources/LocalAgentAPIServer.swift
   - desktop/macos/Desktop/Sources/APIKeyService.swift
+  - desktop/macos/Desktop/Sources/FileIndexing/FileIndexerService.swift
   - desktop/macos/Desktop/Sources/OmiApp.swift
   - desktop/macos/Desktop/Sources/ViewModelContainer.swift
   - desktop/macos/Desktop/Sources/Onboarding/OnboardingChatView.swift

--- a/desktop/macos/e2e/flows/tasks.yaml
+++ b/desktop/macos/e2e/flows/tasks.yaml
@@ -21,6 +21,7 @@ covers:
   - desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskExtraction/ScreenCandidateAdapter.swift
   - desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskExtraction/TaskAssistant.swift
   - desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/Insight/InsightAssistant.swift
+  - desktop/macos/Desktop/Sources/ProactiveAssistants/Services/EmbeddingService.swift
   - desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskExtraction/TaskAssistantSettings.swift
   - desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskExtraction/TaskDeduplicationService.swift
   - desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskExtraction/TaskModels.swift


### PR DESCRIPTION
## What changed and why

Follow-up to #9459: the higher-blast-radius fixes deliberately deferred from that PR, each verified against the violated contract with a regression test where a hermetic seam exists. Covers data-integrity, cross-account/recovery correctness, a chat-continuity dedup bug, and the OAuth open-redirect that pairs with the callback-XSS fix already merged.

## Product invariants affected

- **INV-CHAT-1** — `Chat/KernelTurnProjection.swift` is touched (path-based). The change only makes the applied-turn dedup cache evict oldest-first instead of an arbitrary hash-ordered subset; it preserves the single `turn_recorded` apply gate, keyed idempotent dedup, and single message store (INV-6 rules 2/4). The invariant's guard test (`KernelTurnRecordedProjectionTests`) is extended with `testDedupSurvivesEvictionOfMostRecentKeys`.

## How it was verified

- **Rust:** `cd desktop/macos/Backend-Rust && cargo test` → **327 passed** (incl. new redirect_uri allowlist tests).
- **Swift compile/tests:** macOS CI (`desktop-swift-ci.yml`); Linux container has no Swift toolchain, so the local pre-push Swift compile was skipped via the hook's documented `PRE_PUSH_SKIP_DESKTOP_SWIFT=1`.
- **Static ratchets + e2e-flow coverage:** pass locally.
- **Not hermetically exercised** (stated per commit): the VideoChunkEncoder mid-write-failure reorder (needs an AVAssetWriter fake) and the embedBatch alignment throw (needs a fake HTTP layer) — verified by control-flow reasoning.

### Fixes
- **Embedding index rowid collision (Swift)** — action_items and staged_tasks share one index keyed by raw Int64, so colliding rowids overwrote each other and search resolved to the wrong table (the two consumers even guessed in opposite orders). Keyed by (source, id); search returns the source.
- **Batch-embed misalignment (Swift)** — `embedBatch` compactMap'd out malformed entries while callers zip results to inputs by position, persisting embeddings onto the wrong task. Now requires 1:1 count or throws.
- **FileIndexer fail-open delete (Swift)** — an unreadable directory was treated as "all files deleted" and its index subtree purged. Failed-enumeration prefixes are now excluded from the retention diff.
- **KernelTurnProjection duplicate turns (Swift, INV-CHAT-1)** — `suffix(32)` over an unordered Set kept arbitrary keys, so a re-delivered `turn_recorded` could double-append. Now evicts oldest-first.
- **VideoChunkEncoder frame-offset desync (Swift)** — a failed encoder write still consumed a frame offset, shifting every later frame in the chunk. Write first; claim the offset only on success.
- **Rewind "Rebuild Index" recovered nothing (Swift)** — scanned `.hevc` and parsed a flat name, but chunks are `<day>/chunk_HHmmss.mp4`. Now scans `.mp4` (+ legacy) and parses the day from the path.
- **OAuth redirect_uri open-redirect (Rust)** — `/v1/auth/authorize` accepted any redirect_uri and delivered the code to it. Now allowlisted to loopback + custom app schemes; `https://evil` and non-loopback `http` are rejected. **Access-control change — wants explicit maintainer sign-off before merge.**

## Tests

New: `EmbeddingIndexSourceTests`, `FileIndexerRetentionTests`, `RewindChunkTimestampParseTests`, `KernelTurnRecordedProjectionTests.testDedupSurvivesEvictionOfMostRecentKeys`, and Rust `redirect_uri_allowlist_*`.

## Root cause and durable guard (bug fixes)

Each fix replaces the ambiguous state with a typed/ordered contract: a (source,id) index key, a strict batch-count invariant, a failed-directory exclusion set, an ordered eviction ring, write-before-commit ordering, a path-directory-aware parser, and a redirect_uri allowlist. All are unit- or reasoning-verified; none re-opens a class fixed elsewhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RAxLsaxtwVNDTWAZFfJp9q)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9476?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

