### PR TITLE
fix(mcp): clamp pagination on MCP SSE tools to avoid 500 on bad limit/offset

### DIFF
--- a/backend/routers/mcp_sse.py
+++ b/backend/routers/mcp_sse.py
@@ -982,8 +982,11 @@ def execute_tool(
         end_date = arguments.get("end_date")
         raw_categories = arguments.get("categories", [])
         categories_list: List[Any] = cast(List[Any], raw_categories) if isinstance(raw_categories, list) else []
-        limit = arguments.get("limit", 20)
-        offset = arguments.get("offset", 0)
+        try:
+            limit = parse_mcp_int(arguments.get("limit"), "limit", default=20, minimum=1, maximum=1000)
+            offset = parse_mcp_int(arguments.get("offset"), "offset", default=0, minimum=0, maximum=100000)
+        except ValueError as e:
+            raise ToolExecutionError(str(e), code=-32602)
 
         # Parse dates
         start_dt = None
@@ -1113,7 +1116,10 @@ def execute_tool(
         if not query:
             raise ToolExecutionError("query is required")
 
-        limit = arguments.get("limit", 10)
+        try:
+            limit = parse_mcp_int(arguments.get("limit"), "limit", default=10, minimum=1, maximum=100)
+        except ValueError as e:
+            raise ToolExecutionError(str(e), code=-32602)
         start_date = arguments.get("start_date")
         end_date = arguments.get("end_date")
 
@@ -1163,7 +1169,10 @@ def execute_tool(
         query = arguments.get("query")
         if not query:
             raise ToolExecutionError("query is required")
-        limit = arguments.get("limit", 10)
+        try:
+            limit = parse_mcp_int(arguments.get("limit"), "limit", default=10, minimum=1, maximum=100)
+        except ValueError as e:
+            raise ToolExecutionError(str(e), code=-32602)
 
         matches = vector_db.find_similar_x_posts(user_id, query, limit=limit)
         if not matches:
@@ -1186,7 +1195,10 @@ def execute_tool(
         return {"posts": results}
 
     elif tool_name == "get_x_posts":
-        limit = arguments.get("limit", 50)
+        try:
+            limit = parse_mcp_int(arguments.get("limit"), "limit", default=50, minimum=1, maximum=200)
+        except ValueError as e:
+            raise ToolExecutionError(str(e), code=-32602)
         kind = arguments.get("kind")
         posts = x_posts_db.get_x_posts(user_id, limit=limit, kind=kind)
         results = [

--- a/backend/tests/unit/test_mcp_sse_pagination_bounds.py
+++ b/backend/tests/unit/test_mcp_sse_pagination_bounds.py
@@ -1,0 +1,95 @@
+"""Regression tests for pagination bounds on MCP SSE tools.
+
+Several paginated ``execute_tool`` handlers read ``limit`` / ``offset`` straight from the
+JSON-RPC ``arguments`` and passed them to the data layer without the ``parse_mcp_int`` clamp
+the sibling tools (``list_memories``, ``search_memories``, ``get_action_items``) already apply.
+Two problems followed:
+
+  1. A negative ``offset`` / ``limit`` reached Firestore ``.offset()`` / ``.limit()``
+     (``database/conversations.py``, ``database/x_posts.py``), which raises on a negative
+     argument. That exception is not a ``ToolExecutionError``, so it escaped ``execute_tool``
+     and surfaced as HTTP 500 -- the same failure ``database/memories.py`` documents and
+     clamps against.
+  2. A non-integer ``limit`` (e.g. ``"abc"``) raised deep in the query layer instead of a
+     clean ``-32602`` invalid-params error.
+
+The fix clamps ``get_conversations``, ``search_conversations``, ``search_x_posts`` and
+``get_x_posts`` with ``parse_mcp_int`` (the min guards fix the negative-argument crash; the
+generous maxes bound abuse without regressing realistic callers). ``search_action_items`` is
+intentionally not changed: its helper ``mcp_action_items.search_action_items`` already clamps.
+
+These call the real ``execute_tool`` with only the data layer stubbed (``conftest`` sets a fake
+``OPENAI_API_KEY`` before collection, so the router imports cleanly).
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture(scope="module")
+def mcp():
+    from routers import mcp_sse
+
+    return mcp_sse
+
+
+def test_get_conversations_negative_offset_is_clamped(mcp):
+    """offset=-1 must be clamped to 0 before reaching Firestore .offset() (which raises on negative)."""
+
+    def _firestore_like(uid, limit, offset, **kwargs):
+        # Mimic Firestore .offset(): a negative argument raises. See the clamp note in
+        # database/memories.py. Before the fix, offset=-1 reached here and this raised out of
+        # execute_tool as a 500.
+        if offset < 0:
+            raise ValueError("offset must be non-negative")
+        return []
+
+    with patch.object(mcp.conversations_db, "get_conversations", side_effect=_firestore_like) as fake:
+        result = mcp.execute_tool("test-uid", "get_conversations", {"offset": -1})
+
+    assert result == {"conversations": []}
+    assert fake.call_args.args[2] == 0  # offset clamped to 0, not -1
+
+
+def test_get_conversations_non_int_limit_returns_invalid_params(mcp):
+    """A non-integer limit must return a clean -32602, not crash in the query layer."""
+    with patch.object(mcp.conversations_db, "get_conversations", MagicMock(return_value=[])):
+        with pytest.raises(mcp.ToolExecutionError) as exc:
+            mcp.execute_tool("test-uid", "get_conversations", {"limit": "abc"})
+
+    assert exc.value.code == -32602
+
+
+def test_search_conversations_negative_limit_is_clamped(mcp):
+    """search_conversations must clamp the vector-search k (limit) to at least 1."""
+    captured = {}
+
+    def _query_vectors(query, uid, starts_at=None, ends_at=None, k=None):
+        captured["k"] = k
+        return []
+
+    with patch.object(mcp.vector_db, "query_vectors", side_effect=_query_vectors):
+        result = mcp.execute_tool("test-uid", "search_conversations", {"query": "hi", "limit": -5})
+
+    assert result == {"conversations": []}
+    assert captured["k"] == 1  # clamped up to the minimum
+
+
+def test_search_x_posts_non_int_limit_returns_invalid_params(mcp):
+    """search_x_posts must reject a non-integer limit with -32602 rather than crashing."""
+    with patch.object(mcp.vector_db, "find_similar_x_posts", MagicMock(return_value=[])):
+        with pytest.raises(mcp.ToolExecutionError) as exc:
+            mcp.execute_tool("test-uid", "search_x_posts", {"query": "hi", "limit": "abc"})
+
+    assert exc.value.code == -32602
+
+
+def test_get_x_posts_negative_limit_is_clamped(mcp):
+    """get_x_posts must clamp a negative limit before it reaches Firestore .limit(limit * 3)."""
+    fake = MagicMock(return_value=[])
+    with patch.object(mcp.x_posts_db, "get_x_posts", fake):
+        result = mcp.execute_tool("test-uid", "get_x_posts", {"limit": -5})
+
+    assert result == {"posts": []}
+    assert fake.call_args.kwargs["limit"] == 1  # clamped up to the minimum


### PR DESCRIPTION
## What

Four paginated tools in the MCP SSE handler (`execute_tool`) read `limit` / `offset` straight from the JSON-RPC `arguments` and passed them to the data layer without the `parse_mcp_int` clamp that the sibling tools (`list_memories`, `search_memories`, `get_action_items`) already apply:

- `get_conversations` (limit + offset)
- `search_conversations` (limit)
- `search_x_posts` (limit)
- `get_x_posts` (limit)

Two problems followed:

1. A negative `offset` / `limit` reached Firestore `.offset()` / `.limit()` (`database/conversations.py`, `database/x_posts.py`), which raises on a negative argument. That exception is not a `ToolExecutionError`, and the `tools/call` handler only catches `ToolExecutionError`, so it escaped `execute_tool` and surfaced as HTTP 500. This is the exact failure `database/memories.py` documents and clamps against: "Clamp pagination so an out-of-range value cannot reach Firestore .limit()/.offset(), which raises on a negative argument and would otherwise 500 the request."
2. A non-integer `limit` (for example `"abc"`) raised deep in the query layer instead of returning a clean `-32602` invalid-params error.

Reachable from any authenticated MCP client, for example `tools/call` with `{"name":"get_conversations","arguments":{"offset":-1}}`.

## Fix

Clamp all four tools with the existing `parse_mcp_int` helper, matching the sibling tools. The min guards fix the negative-argument crash, and the maxes are generous (limit caps 1000/100/100/200, offset cap 100000) so a realistic caller is never regressed while pathological values are bounded. Non-integer values now return `-32602`.

`search_action_items` is intentionally not changed: its helper `mcp_action_items.search_action_items` already does `int(limit)` and `max(1, min(limit, MAX_SEARCH_LIMIT))`, so it is already safe.

## Failure class

The codebase already applies `parse_mcp_int` to most paginated MCP tools; these four were the ones still reading the raw argument. This closes the class across the whole MCP SSE surface rather than only the one tool with a documented 500.

## Testing

- `python -m pytest tests/unit/test_mcp_sse_pagination_bounds.py` -> 5 passed. Cases: negative offset clamped to 0 before the DB call, non-int limit returns -32602, negative vector-search limit clamped to 1, and get_x_posts negative limit clamped. Each calls the real `execute_tool` with only the data layer stubbed.
- `python scripts/scan_async_blockers.py --dirs routers` -> 0 findings.
- `python scripts/check_module_stub_pollution.py` -> 0 violations.
- Exercised via the regression tests calling the real `execute_tool`; I did not stand up a live MCP server for this change.

No tool schema or route surface changed, so the OpenAPI and MCP tool contract is unchanged.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9477?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

