### PR TITLE
fix(task-integrations): return 400 on invalid due_date instead of 500

### DIFF
--- a/backend/routers/task_integrations.py
+++ b/backend/routers/task_integrations.py
@@ -363,7 +363,10 @@ async def create_task_via_integration(
     # Parse due date if provided
     due_date = None
     if request.due_date:
-        due_date = datetime.fromisoformat(request.due_date.replace('Z', '+00:00'))
+        try:
+            due_date = datetime.fromisoformat(request.due_date.replace('Z', '+00:00'))
+        except ValueError:
+            raise HTTPException(status_code=400, detail="Invalid due_date; expected an ISO 8601 date string")
 
     result = await create_task_internal(
         uid=uid,

--- a/backend/tests/unit/test_task_integration_due_date_validation.py
+++ b/backend/tests/unit/test_task_integration_due_date_validation.py
@@ -1,0 +1,74 @@
+"""Regression test for POST /v1/task-integrations/{app_key}/tasks due_date validation.
+
+CreateTaskRequest.due_date is a free-form Optional[str] with no format validator. Before the fix,
+a malformed value made datetime.fromisoformat(...) raise an unhandled ValueError, returning HTTP 500.
+The handler now catches it and returns HTTP 400, mirroring the same guard in routers/conversations.py
+and routers/integration.py. These tests mount the task-integrations router and exercise the HTTP layer
+with the auth dependency overridden and the Firestore/external calls stubbed (no live services).
+"""
+
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture(scope="module")
+def app_client():
+    # conftest sets OPENAI_API_KEY / ENCRYPTION_SECRET before collection, so the router imports cleanly.
+    from routers import task_integrations as ti
+    from utils.other import endpoints as auth
+
+    app = FastAPI()
+    app.include_router(ti.router)
+    app.dependency_overrides[auth.get_current_user_uid] = lambda: "test-uid"
+    return TestClient(app, raise_server_exceptions=False), ti
+
+
+def _connected(uid, app_key):
+    return {"connected": True, "access_token": "tok"}
+
+
+def test_invalid_due_date_returns_400(app_client, monkeypatch):
+    """A non-ISO due_date must return 400, not an unhandled 500."""
+    client, ti = app_client
+    monkeypatch.setattr(ti.users_db, "get_task_integration", _connected)
+    # Stub the external creation so a regression that slips past the guard cannot reach a real call.
+    monkeypatch.setattr(ti, "create_task_internal", AsyncMock(return_value={"success": True}))
+
+    resp = client.post("/v1/task-integrations/todoist/tasks", json={"title": "buy milk", "due_date": "not-a-date"})
+
+    assert resp.status_code == 400
+    assert "due_date" in resp.json()["detail"]
+
+
+def test_valid_due_date_reaches_creation(app_client, monkeypatch):
+    """A valid ISO due_date (with Z suffix) is parsed and forwarded; the happy path is preserved."""
+    client, ti = app_client
+    monkeypatch.setattr(ti.users_db, "get_task_integration", _connected)
+    created = AsyncMock(return_value={"success": True, "external_task_id": "ext-1"})
+    monkeypatch.setattr(ti, "create_task_internal", created)
+
+    resp = client.post(
+        "/v1/task-integrations/todoist/tasks",
+        json={"title": "buy milk", "due_date": "2026-07-11T10:00:00Z"},
+    )
+
+    assert resp.status_code == 200
+    assert resp.json()["success"] is True
+    assert created.await_count == 1
+    assert created.await_args.kwargs["due_date"] is not None  # parsed datetime, not the raw string
+
+
+def test_missing_due_date_is_allowed(app_client, monkeypatch):
+    """No due_date is valid and must not 400."""
+    client, ti = app_client
+    monkeypatch.setattr(ti.users_db, "get_task_integration", _connected)
+    created = AsyncMock(return_value={"success": True, "external_task_id": "ext-2"})
+    monkeypatch.setattr(ti, "create_task_internal", created)
+
+    resp = client.post("/v1/task-integrations/todoist/tasks", json={"title": "no due date"})
+
+    assert resp.status_code == 200
+    assert created.await_args.kwargs["due_date"] is None


### PR DESCRIPTION
## What

POST /v1/task-integrations/{app_key}/tasks parsed the request `due_date` with `datetime.fromisoformat()` and no guard:

```py
due_date = None
if request.due_date:
    due_date = datetime.fromisoformat(request.due_date.replace('Z', '+00:00'))
```

`CreateTaskRequest.due_date` is a free-form `Optional[str]` with no format validator, so any string passes request validation and reaches the handler. A malformed value (for example `"tomorrow"` or `"2026-13-40"`) makes `fromisoformat` raise `ValueError`, which is unhandled and surfaces as HTTP 500. The correct status is 400. The error is raised before `create_task_internal`, so no external provider is involved.

Reachable by any authenticated user who has connected a task integration (Todoist, Asana, Google Tasks, ClickUp) and sends a non-ISO `due_date`.

## Fix

Wrap the parse in `try/except ValueError` and return `HTTPException(status_code=400, ...)`, mirroring the identical guard already applied to ISO date parsing in `routers/conversations.py` (search date range) and `routers/integration.py`. This closes the last unguarded instance of that class.

## Testing

- `python -m pytest tests/unit/test_task_integration_due_date_validation.py` -> 3 passed. Cases: an invalid due_date returns 400 (previously an unhandled 500), a valid ISO due_date is parsed and forwarded to the creation call, and a missing due_date is allowed. The test mounts the router with the auth dependency overridden and the Firestore lookup plus external create stubbed (no live services).
- `python scripts/scan_async_blockers.py --dirs routers` -> 0 findings.
- `python scripts/check_module_stub_pollution.py` -> 0 violations.

No route signature, parameter, or response model changed, so the OpenAPI contract is unchanged.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9478?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

