### PR TITLE
fix(chat): exclude reported messages from the chat-message count stat

### DIFF
--- a/backend/database/chat.py
+++ b/backend/database/chat.py
@@ -254,10 +254,20 @@ def get_messages(
 
 
 def get_message_count(uid: str) -> int:
-    """Return the total number of chat messages for a user."""
-    user_ref = db.collection('users').document(uid)
-    docs = user_ref.collection('messages').count().get()
-    return int(docs[0][0].value) if docs and docs[0] else 0
+    """Return the number of chat messages visible to the user.
+
+    Reported messages are hidden from every chat view (``get_messages`` and ``get_app_messages``
+    skip ``reported == True``), so this stat excludes them too; otherwise it would exceed the number
+    of messages the user can actually see anywhere. Uses count() aggregation (total minus the
+    reported subset) rather than streaming every message. A ``reported == False`` count would be
+    wrong because legacy messages may omit the field.
+    """
+    messages_ref = db.collection('users').document(uid).collection('messages')
+    total_res = messages_ref.count().get()
+    total = int(total_res[0][0].value) if total_res and total_res[0] else 0
+    reported_res = messages_ref.where(filter=FieldFilter('reported', '==', True)).count().get()
+    reported = int(reported_res[0][0].value) if reported_res and reported_res[0] else 0
+    return max(0, total - reported)
 
 
 def iter_all_messages(uid: str, batch_size: int = 1000) -> Iterator[Dict[str, Any]]:

--- a/backend/tests/unit/test_chat_message_count.py
+++ b/backend/tests/unit/test_chat_message_count.py
@@ -1,0 +1,58 @@
+"""Unit test for get_message_count (GET /v1/users/stats/chat-messages).
+
+Reported messages are hidden from every chat view (get_messages / get_app_messages skip
+reported == True), so the total-messages stat must exclude them too; otherwise the stat exceeds
+the number of messages the user can actually see anywhere. Pinned against a fake Firestore, no
+live services.
+"""
+
+import os
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+os.environ.setdefault(
+    "ENCRYPTION_SECRET",
+    "omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv",
+)
+
+import database.chat as chat_db  # noqa: E402
+
+
+def _count(value):
+    # Firestore aggregation returns [[AggregationResult(value=...)]].
+    return [[SimpleNamespace(value=value)]]
+
+
+def _messages_ref(fake_db):
+    return fake_db.collection.return_value.document.return_value.collection.return_value
+
+
+def test_message_count_excludes_reported():
+    fake_db = MagicMock()
+    messages_ref = _messages_ref(fake_db)
+    messages_ref.count.return_value.get.return_value = _count(3)  # total incl reported
+    messages_ref.where.return_value.count.return_value.get.return_value = _count(1)  # reported subset
+
+    with patch.object(chat_db, "db", fake_db):
+        assert chat_db.get_message_count("u1") == 2  # 3 total - 1 reported = 2 visible
+
+
+def test_message_count_no_reported():
+    fake_db = MagicMock()
+    messages_ref = _messages_ref(fake_db)
+    messages_ref.count.return_value.get.return_value = _count(4)
+    messages_ref.where.return_value.count.return_value.get.return_value = _count(0)
+
+    with patch.object(chat_db, "db", fake_db):
+        assert chat_db.get_message_count("u1") == 4
+
+
+def test_message_count_never_negative():
+    # Defensive: eventually-consistent aggregations could momentarily report reported > total.
+    fake_db = MagicMock()
+    messages_ref = _messages_ref(fake_db)
+    messages_ref.count.return_value.get.return_value = _count(1)
+    messages_ref.where.return_value.count.return_value.get.return_value = _count(3)
+
+    with patch.object(chat_db, "db", fake_db):
+        assert chat_db.get_message_count("u1") == 0


### PR DESCRIPTION
## What

GET /v1/users/stats/chat-messages -> `get_message_count` counted the raw `users/{uid}/messages` collection with no filter. But reported messages are hidden from every chat view: both `get_messages` and `get_app_messages` skip `if message.get('reported') is True`. When a user reports a message (POST /v2/messages/{id}/report sets `reported: true`) it disappears from their chat, yet the stat still counts it.

So the total-messages stat could exceed the number of messages the user can actually see anywhere. This is the only production caller of `get_message_count`, and it is a display stat (message quota is enforced separately via `record_chat_quota_question`), so it should reflect the visible set.

## Fix

Subtract the reported subset from the count aggregation: `total - count(reported == True)`. This keeps the efficient `count()` aggregation (no streaming) and matches the list's skip. A `reported == False` count would be wrong because legacy messages may omit the field, so they would be dropped from the visible total.

## Testing

- `python -m pytest tests/unit/test_chat_message_count.py` -> 3 passed: excludes reported, no-reported passthrough, and a never-negative clamp. Pinned against a fake Firestore via `patch.object(database.chat, "db", ...)`, no live services.

No route signature, parameter, or response model changed, so the OpenAPI contract is unchanged.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9479?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

