### PR TITLE
fix(app): surface failed private cloud sync writes instead of swallowing them (#9466)

### DIFF
--- a/app/lib/providers/user_provider.dart
+++ b/app/lib/providers/user_provider.dart
@@ -18,8 +18,15 @@ class UserProvider with ChangeNotifier {
   /// fetch so the loader can preserve the last known state. Injectable for tests.
   final Future<bool?> Function() _privateCloudSyncFetcher;
 
-  UserProvider({Future<bool?> Function()? privateCloudSyncFetcher})
-      : _privateCloudSyncFetcher = privateCloudSyncFetcher ?? getPrivateCloudSyncEnabled;
+  /// Persists the private-cloud-sync flag. Returns `false` when the write did
+  /// not take effect (no response / non-200 / status != ok). Injectable for tests.
+  final Future<bool> Function(bool value) _privateCloudSyncSetter;
+
+  UserProvider({
+    Future<bool?> Function()? privateCloudSyncFetcher,
+    Future<bool> Function(bool value)? privateCloudSyncSetter,
+  })  : _privateCloudSyncFetcher = privateCloudSyncFetcher ?? getPrivateCloudSyncEnabled,
+        _privateCloudSyncSetter = privateCloudSyncSetter ?? setPrivateCloudSyncEnabled;
 
   String _dataProtectionLevel = 'standard';
   bool _isLoading = false;
@@ -320,11 +327,16 @@ class UserProvider with ChangeNotifier {
 
   Future<void> setPrivateCloudSync(bool value) async {
     try {
-      final success = await setPrivateCloudSyncEnabled(value);
-      if (success) {
-        _privateCloudSyncEnabled = value;
-        notifyListeners();
+      final success = await _privateCloudSyncSetter(value);
+      // A rejected write (no response / non-200 / status != ok) must surface as
+      // an error, not be swallowed. Otherwise the caller shows a success message
+      // while the toggle snaps back to its old state — the user believes cloud
+      // storage is on and loses the recordings they meant to keep (#9466).
+      if (!success) {
+        throw Exception('Server rejected private cloud sync update');
       }
+      _privateCloudSyncEnabled = value;
+      notifyListeners();
     } catch (e, stackTrace) {
       Logger.error('Failed to set private cloud sync: $e\n$stackTrace');
       rethrow;

--- a/app/test/providers/user_provider_private_cloud_sync_test.dart
+++ b/app/test/providers/user_provider_private_cloud_sync_test.dart
@@ -47,4 +47,38 @@ void main() {
       expect(provider.privateCloudSyncEnabled, isTrue);
     });
   });
+
+  group('UserProvider private cloud sync writing', () {
+    test('applies the value on a successful write', () async {
+      final provider = UserProvider(privateCloudSyncSetter: (_) async => true);
+      addTearDown(provider.dispose);
+
+      await provider.setPrivateCloudSync(true);
+
+      expect(provider.privateCloudSyncEnabled, isTrue);
+    });
+
+    test('throws and keeps the old state when the write is rejected', () async {
+      // Regression for #9466 (write path): setPrivateCloudSyncEnabled returns
+      // false on a rejected write (no response / non-200 / status != ok). The
+      // provider used to swallow it, so the UI showed a success snackbar while
+      // the toggle snapped back off — the user believed cloud storage was on
+      // and lost recordings. A rejected write must surface as an error.
+      final provider = UserProvider(privateCloudSyncSetter: (_) async => false);
+      addTearDown(provider.dispose);
+
+      await expectLater(provider.setPrivateCloudSync(true), throwsException);
+      expect(provider.privateCloudSyncEnabled, isFalse);
+    });
+
+    test('rethrows when the write throws', () async {
+      final provider = UserProvider(
+        privateCloudSyncSetter: (_) async => throw Exception('network down'),
+      );
+      addTearDown(provider.dispose);
+
+      await expectLater(provider.setPrivateCloudSync(true), throwsException);
+      expect(provider.privateCloudSyncEnabled, isFalse);
+    });
+  });
 }


### PR DESCRIPTION
## What

Make `UserProvider.setPrivateCloudSync()` surface a failed write instead of silently swallowing it, so the "Store Audio on Cloud" toggle can no longer report success while actually staying off.

## Why (user report — issue #9466)

> "I enable the `Enable Audio Cloud` toggle, but later it becomes inactive again on its own. Because of that, recordings I wanted to keep are being lost."

**Root cause (write path):** `setPrivateCloudSync()` called `setPrivateCloudSyncEnabled()`, which returns `false` on a rejected write (no response / non-200 / `status != ok`). On `false` the provider did nothing — no state change, no thrown error. The page (`private_cloud_sync_page.dart`) only catches exceptions, so a rejected write showed the **green "Cloud storage enabled"** snackbar while the `CupertinoSwitch` snapped back off. The user believed cloud storage was on and lost recordings.

This is the **write-side mirror** of #9472, which closed only the *load* side of the same failure class (conflating a fetch/write error with the "disabled" state). The load side now preserves last-known state on error; the write side still dropped rejected writes silently.

## Fix (closes the failure class on both sides)

- `setPrivateCloudSync()` now throws when the write is rejected (`success == false`), so the page's `catch` branch surfaces the red "failed to update settings" snackbar and the toggle honestly reflects the unchanged server state.
- Added an injectable writer seam (`privateCloudSyncSetter`) mirroring the existing `privateCloudSyncFetcher` from #9472.
- Regression tests for the success, rejected-write, and throwing-write paths.

## Verified

- Traced the exact failing path: `private_cloud_sync_page.dart:28` (`setPrivateCloudSync`) → `user_provider.dart:setPrivateCloudSync` → `users.dart:setPrivateCloudSyncEnabled` (returns `false` on null/non-200/`status != ok`). Confirmed #9472 touched only the load path, leaving this gap.
- **UNVERIFIED at runtime:** no Flutter/Dart toolchain in this environment to run `flutter test` or exercise the app. Relying on CI (`flutter test` + analyzer ratchet) and review. The change is small and mirrors the merged #9472 pattern.

Auto-generated from issue feedback by the mini issues-improver. Review before merge.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9481?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

