### PR TITLE
test(app-client): fix main-red raw-decode gate after #9470 shifted app.dart

### DIFF
--- a/backend/tests/unit/test_app_client_schema_inventory.py
+++ b/backend/tests/unit/test_app_client_schema_inventory.py
@@ -275,7 +275,9 @@ def test_inventory_strict_raw_decode_site_gate_fails_with_actionable_sites():
 
     assert result.returncode == 1
     assert 'Raw Dart decode sites:' in result.stdout
-    assert 'app/lib/backend/schema/app.dart:31' in result.stdout
+    # AppReview.fromGenerated's updatedAt raw decode: #9470 added an empty-string date guard above
+    # it, shifting this known site from :31 to :32. Keep this pinned to the actual generated line.
+    assert 'app/lib/backend/schema/app.dart:32' in result.stdout
 
 
 def test_inventory_openapi_route_response_decode_migration_complete():


### PR DESCRIPTION
## What

The Backend unit suite is currently red on `main`: `test_inventory_strict_raw_decode_site_gate_fails_with_actionable_sites` asserts the raw-decode-site scanner reports `app/lib/backend/schema/app.dart:31`, but the actual site is now at `:32`.

Root cause: #9470 ("fix FormatException crash parsing cached app reviews with empty date strings") added an empty-string date guard to `AppReview.fromGenerated`, shifting the `updatedAt` raw decode (`json['updated_at']` in `DateTime.parse(...)`) down one line from `:31` to `:32`. The strict gate test's hardcoded expectation was not updated, so the suite fails on every PR built against current `main`.

## Fix

Update the assertion to `app.dart:32` to match the regenerated file. The gate's other checks (returncode 1, the "Raw Dart decode sites:" listing) are unchanged, so it still detects that known raw decode site.

## Verification

Ran the exact scanner the test invokes:

```
python scripts/inventory_app_client_schemas.py --fail-on-raw-dart-decode-sites
```

returncode is 1, the output contains `app/lib/backend/schema/app.dart:32` and no longer `:31`. Confirmed on a pure `origin/main` checkout that the pre-fix assertion fails and this change makes it pass.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9482?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

