### PR TITLE
fix(conversations): geocoder returns None on failure instead of 500

### DIFF
--- a/backend/tests/unit/test_geocode_location_resilience.py
+++ b/backend/tests/unit/test_geocode_location_resilience.py
@@ -1,0 +1,56 @@
+"""Regression: get_google_maps_location returns None (not raise) on a geocoding failure.
+
+The sync geocoder did a bare httpx.get() + response.json(). A connect/read timeout, a Google 5xx
+HTML error page, or any non-JSON body raised out of the helper, which 500ed conversation create /
+finalize (and, in finalize, stranded the conversation in 'processing' since the status is set before
+the geocode call). The async twin already returns None on these; this gives the sync path the same
+contract. No live services.
+"""
+
+from unittest.mock import MagicMock
+
+import httpx
+
+from utils.conversations import location
+
+
+def test_geocode_transport_error_returns_none(monkeypatch):
+    monkeypatch.setenv("GOOGLE_MAPS_API_KEY", "k")
+    monkeypatch.setattr(location.r, "get", lambda *a, **k: None)  # cache miss
+
+    def boom(*a, **k):
+        raise httpx.ConnectError("maps down")
+
+    monkeypatch.setattr(location.httpx, "get", boom)
+
+    assert location.get_google_maps_location(37.78, -122.40) is None
+
+
+def test_geocode_non_json_body_returns_none(monkeypatch):
+    monkeypatch.setenv("GOOGLE_MAPS_API_KEY", "k")
+    monkeypatch.setattr(location.r, "get", lambda *a, **k: None)
+
+    resp = MagicMock()
+    resp.json.side_effect = ValueError("Expecting value")  # json.JSONDecodeError subclasses ValueError
+
+    monkeypatch.setattr(location.httpx, "get", lambda *a, **k: resp)
+
+    assert location.get_google_maps_location(37.78, -122.40) is None
+
+
+def test_geocode_success_still_returns_geolocation(monkeypatch):
+    # Happy path preserved: a valid geocode response is parsed into a Geolocation.
+    monkeypatch.setenv("GOOGLE_MAPS_API_KEY", "k")
+    monkeypatch.setattr(location.r, "get", lambda *a, **k: None)
+    monkeypatch.setattr(location.r, "set", lambda *a, **k: None)
+
+    resp = MagicMock()
+    resp.json.return_value = {
+        "status": "OK",
+        "results": [{"place_id": "abc123", "formatted_address": "1 Main St", "types": ["street_address"]}],
+    }
+    monkeypatch.setattr(location.httpx, "get", lambda *a, **k: resp)
+
+    geo = location.get_google_maps_location(37.78, -122.40)
+    assert geo is not None
+    assert geo.google_place_id == "abc123"

--- a/backend/utils/conversations/location.py
+++ b/backend/utils/conversations/location.py
@@ -30,8 +30,14 @@ def get_google_maps_location(latitude: float, longitude: float) -> Optional[Geol
 
     key = os.getenv('GOOGLE_MAPS_API_KEY')
     url = f"https://maps.googleapis.com/maps/api/geocode/json?latlng={latitude},{longitude}&key={key}"
-    response = httpx.get(url)
-    data = response.json()
+    try:
+        response = httpx.get(url)
+        data = response.json()
+    except Exception as e:
+        # Transport failure (timeout/connect) or a non-JSON body (e.g. a Google 5xx HTML error page).
+        # Return None like the async twin instead of 500ing conversation create/finalize.
+        logger.error(f'get_google_maps_location error: {e}')
+        return None
     if data.get('status') != 'OK' or not data.get('results'):
         return None
     place = data['results'][0]


### PR DESCRIPTION
## What

`get_google_maps_location` did a bare `httpx.get()` + `response.json()` with no error handling:

```py
response = httpx.get(url)
data = response.json()
```

A connect/read timeout, a Google 5xx HTML error page, or any non-JSON body raises out of the helper. It is called unguarded from `POST /v1/conversations` (`conversations.py:180`), the finalize endpoint (`conversations.py:236`), and the external-integration create path (`integration.py:131`), so a geocoding hiccup surfaces as HTTP 500. In finalize it is worse: the conversation status is compare-and-set to `processing` before the geocode call, so a 500 there leaves the conversation stuck and a later retry early-returns without reprocessing (no summary/memories).

## Fix

Wrap the HTTP call + `json()` in `try/except -> return None`, matching the async twin `async_get_google_maps_location` in the same file, which already returns None on a geocode failure. Returning None is the established contract (callers treat "no location" as fine). Internal-only: no route, response model, OpenAPI spec, or generated client changes.

## Testing

- `python -m pytest tests/unit/test_geocode_location_resilience.py` -> 3 passed: a transport error returns None, a non-JSON body returns None, and a valid response still parses into a Geolocation. Monkeypatches `httpx.get` and the redis cache read; no live services.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9483?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

