### PR TITLE
feat(advice): add GET /v1/advice/count for an unread badge

### DIFF
--- a/backend/database/advice.py
+++ b/backend/database/advice.py
@@ -45,6 +45,24 @@ def create_advice(uid: str, content: str, category: str = 'other', **kwargs: Any
     return doc
 
 
+def get_advice_counts(uid: str) -> Dict[str, int]:
+    """Return total and unread advice counts for a badge/summary.
+
+    Matches the default list visibility (get_advice hides is_dismissed): ``total`` counts
+    non-dismissed advice, ``unread`` counts non-dismissed advice with is_read False. Unread
+    items are typically few, so they are streamed and filtered rather than requiring a
+    (is_read, is_dismissed) composite index.
+    """
+    col = _user_col(uid, 'advice')
+    total = int(col.where(filter=FieldFilter('is_dismissed', '==', False)).count().get()[0][0].value)
+    unread = 0
+    for doc in col.where(filter=FieldFilter('is_read', '==', False)).stream():
+        data = doc.to_dict() or {}
+        if not data.get('is_dismissed'):
+            unread += 1
+    return {'total': total, 'unread': unread}
+
+
 def get_advice(
     uid: str, category: Optional[str] = None, limit: int = 50, offset: int = 0, include_dismissed: bool = False
 ) -> List[Dict[str, Any]]:

--- a/backend/route_policy_manifest.yaml
+++ b/backend/route_policy_manifest.yaml
@@ -1033,3 +1033,27 @@ routes:
       deprecation:
         state: active
       owner: backend
+
+  - route_type: http
+    method: GET
+    path: /v1/advice/count
+    policy:
+      review_status: reviewed
+      auth:
+        mechanisms:
+          - firebase_id_token
+        placement: dependency
+        scopes: []
+      byok: not_applicable
+      rate_limit:
+        policy_name: none
+        key_subject: none
+        enforcement: none
+        placement: none
+      timeout_class: default_method
+      surface: first_party_app
+      visibility: first_party
+      data_domain: unknown
+      deprecation:
+        state: active
+      owner: backend

--- a/backend/routers/advice.py
+++ b/backend/routers/advice.py
@@ -31,6 +31,11 @@ class UpdateAdviceRequest(BaseModel):
     is_dismissed: bool | None = None
 
 
+class AdviceCountResponse(BaseModel):
+    total: int = Field(description="Non-dismissed advice count (matches the default list)")
+    unread: int = Field(description="Non-dismissed, unread advice count (badge value)")
+
+
 # ============================================================================
 # ENDPOINTS
 # ============================================================================
@@ -62,6 +67,12 @@ def get_advice(
     uid: str = Depends(auth.get_current_user_uid),
 ):
     return advice_db.get_advice(uid, limit=limit, offset=offset, category=category, include_dismissed=include_dismissed)
+
+
+@router.get('/v1/advice/count', tags=['advice'], response_model=AdviceCountResponse)
+def get_advice_count(uid: str = Depends(auth.get_current_user_uid)):
+    """Total and unread advice counts for a badge, matching the default list visibility."""
+    return advice_db.get_advice_counts(uid)
 
 
 @router.patch('/v1/advice/{advice_id}', tags=['advice'], response_model=Advice)

--- a/backend/tests/unit/test_advice_count.py
+++ b/backend/tests/unit/test_advice_count.py
@@ -1,0 +1,53 @@
+"""Unit test for get_advice_counts (GET /v1/advice/count).
+
+The count matches the default list visibility (get_advice hides is_dismissed): total counts
+non-dismissed advice, unread counts non-dismissed advice with is_read False. Pinned against a fake
+Firestore via patch.object on the db proxy, no live services.
+"""
+
+import os
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+os.environ.setdefault(
+    "ENCRYPTION_SECRET",
+    "omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv",
+)
+
+import database.advice as advice_db  # noqa: E402
+
+
+def _count(value):
+    return [[SimpleNamespace(value=value)]]
+
+
+def _unread_doc(is_dismissed):
+    doc = MagicMock()
+    doc.to_dict.return_value = {"is_read": False, "is_dismissed": is_dismissed}
+    return doc
+
+
+def test_get_advice_counts_matches_visible_set():
+    fake_db = MagicMock()
+    col = fake_db.collection.return_value.document.return_value.collection.return_value
+    # total = count(is_dismissed == False) aggregation
+    col.where.return_value.count.return_value.get.return_value = _count(3)
+    # unread = stream(is_read == False) then exclude dismissed: 2 unread streamed, 1 dismissed -> 1 visible
+    col.where.return_value.stream.return_value = [_unread_doc(is_dismissed=False), _unread_doc(is_dismissed=True)]
+
+    with patch.object(advice_db, "db", fake_db):
+        result = advice_db.get_advice_counts("u1")
+
+    assert result == {"total": 3, "unread": 1}
+
+
+def test_get_advice_counts_no_unread():
+    fake_db = MagicMock()
+    col = fake_db.collection.return_value.document.return_value.collection.return_value
+    col.where.return_value.count.return_value.get.return_value = _count(5)
+    col.where.return_value.stream.return_value = []  # nothing unread
+
+    with patch.object(advice_db, "db", fake_db):
+        result = advice_db.get_advice_counts("u1")
+
+    assert result == {"total": 5, "unread": 0}


### PR DESCRIPTION
## What

`/v1/advice` has a list (`GET /v1/advice`) and `POST /v1/advice/mark-all-read`, but no count, so a client cannot render an unread badge without paging every item.

Add `GET /v1/advice/count` returning `{total, unread}`:
- `total` counts non-dismissed advice (matching the default list, which hides `is_dismissed`).
- `unread` counts non-dismissed advice with `is_read == False` (the badge value).

The count matches the visible set on purpose. Unread items are typically few, so they are streamed and filtered on `is_dismissed` rather than requiring a `(is_read, is_dismissed)` composite index; `total` uses a `count()` aggregation.

## Testing

- `python -m pytest tests/unit/test_advice_count.py` -> 2 passed (mixed unread/dismissed, and no-unread), pinned against a fake Firestore via `patch.object`.
- `route_policy_inventory --enforce-missing-baseline` -> `new_missing_manifest_entries: 0` (route added to the manifest).
- `export_openapi --check` on the app-client and developer surfaces -> both up to date (advice is a first-party route, not part of those surfaces).
- pyright clean on the changed router/db files.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9485?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

