### PR TITLE
fix(desktop): batch-3 reliability — deadlock, BLE crash, sync/pagination, hang, lost notice

### DIFF
--- a/desktop/macos/Desktop/Sources/AgentSyncService.swift
+++ b/desktop/macos/Desktop/Sources/AgentSyncService.swift
@@ -1,6 +1,14 @@
 import Foundation
 import GRDB
 
+/// A bound query parameter for the sync batch query. Kept as a small typed enum
+/// (rather than `any DatabaseValueConvertible`) so `buildBatchQuery` is pure and
+/// its output is `Equatable`-testable.
+enum SyncQueryArg: Equatable {
+    case int(Int64)
+    case text(String)
+}
+
 /// Polls the local GRDB database every 3 seconds for new/changed rows and
 /// POSTs them to the cloud agent VM's `/sync` endpoint.
 ///
@@ -253,6 +261,34 @@ actor AgentSyncService {
 
     // MARK: - Per-table sync
 
+    /// Build the batch SELECT for a table's next sync page.
+    ///
+    /// Append-only tables paginate by `id`. Mutable tables paginate by a COMPOUND
+    /// `(updatedAt, id)` cursor: a strict `updatedAt > ?` skips every row past the
+    /// first page when more than `batchSize` rows share the same `updatedAt`
+    /// (e.g. a bulk status update touching >100 rows in the same second), silently
+    /// diverging the VM's copy. The `OR (updatedAt = ? AND id > ?)` clause plus
+    /// `ORDER BY updatedAt ASC, id ASC` resumes correctly within such a run.
+    static func buildBatchQuery(
+        tableName: String,
+        selectCols: String,
+        appendOnly: Bool,
+        lastId: Int64,
+        lastUpdatedAt: String,
+        batchSize: Int
+    ) -> (sql: String, args: [SyncQueryArg]) {
+        if appendOnly {
+            return (
+                "SELECT \(selectCols) FROM \"\(tableName)\" WHERE id > ? ORDER BY id ASC LIMIT ?",
+                [.int(lastId), .int(Int64(batchSize))]
+            )
+        }
+        return (
+            "SELECT \(selectCols) FROM \"\(tableName)\" WHERE updatedAt > ? OR (updatedAt = ? AND id > ?) ORDER BY updatedAt ASC, id ASC LIMIT ?",
+            [.text(lastUpdatedAt), .text(lastUpdatedAt), .int(lastId), .int(Int64(batchSize))]
+        )
+    }
+
     private func syncTable(_ spec: TableSpec) async -> Int {
         guard let dbPool = await getDBPool() else { return 0 }
 
@@ -281,16 +317,21 @@ actor AgentSyncService {
 
         do {
             let selectCols = columns.map { "\"\($0)\"" }.joined(separator: ", ")
+            let batchSize = self.batchSize
             let rows: [[String: Any]] = try await dbPool.read { db in
-                let sql: String
-                let args: [any DatabaseValueConvertible]
-
-                if spec.appendOnly {
-                    sql = "SELECT \(selectCols) FROM \"\(spec.name)\" WHERE id > ? ORDER BY id ASC LIMIT ?"
-                    args = [cursor.lastId, self.batchSize]
-                } else {
-                    sql = "SELECT \(selectCols) FROM \"\(spec.name)\" WHERE updatedAt > ? ORDER BY updatedAt ASC LIMIT ?"
-                    args = [cursor.lastUpdatedAt, self.batchSize]
+                let (sql, queryArgs) = Self.buildBatchQuery(
+                    tableName: spec.name,
+                    selectCols: selectCols,
+                    appendOnly: spec.appendOnly,
+                    lastId: cursor.lastId,
+                    lastUpdatedAt: cursor.lastUpdatedAt,
+                    batchSize: batchSize
+                )
+                let args: [any DatabaseValueConvertible] = queryArgs.map { arg in
+                    switch arg {
+                    case .int(let v): return v
+                    case .text(let v): return v
+                    }
                 }
 
                 let dbRows = try Row.fetchAll(db, sql: sql, arguments: StatementArguments(args))
@@ -333,8 +374,13 @@ actor AgentSyncService {
                     }
                 } else {
                     if let lastUpdatedAt = rows.last?["updatedAt"] as? String {
+                        // Advance BOTH updatedAt and id so the compound cursor can
+                        // resume within a run of rows sharing the same updatedAt
+                        // (otherwise a >batchSize same-timestamp bulk update loses
+                        // every row past the first page).
+                        let lastRowId = (rows.last?["id"] as? Int64) ?? cursor.lastId
                         cursors[spec.name] = SyncCursor(
-                            lastId: cursor.lastId,
+                            lastId: lastRowId,
                             lastUpdatedAt: lastUpdatedAt
                         )
                     }

--- a/desktop/macos/Desktop/Sources/Bluetooth/Connections/LimitlessDeviceConnection.swift
+++ b/desktop/macos/Desktop/Sources/Bluetooth/Connections/LimitlessDeviceConnection.swift
@@ -311,7 +311,12 @@ final class LimitlessDeviceConnection: BaseDeviceConnection {
                 pos += 1
                 let (chunkLength, chunkPos) = decodeVarint(flashPageData, pos)
                 pos = chunkPos
-                let chunkEnd = pos + chunkLength
+                // Clamp every embedded length to the buffer end. A reassembled
+                // flash page can arrive truncated (a stale/lost BLE fragment, or an
+                // outer field already clamped upstream) while its inner length
+                // fields still over-claim, which would drive `pos` to `count` and
+                // trap on the subscripts below. Mirrors extractOpusFramesFromFlashPage.
+                let chunkEnd = min(pos + chunkLength, flashPageData.count)
 
                 while pos < chunkEnd - 1 {
                     let marker = flashPageData[pos]
@@ -321,7 +326,7 @@ final class LimitlessDeviceConnection: BaseDeviceConnection {
                         pos += 1
                         let (statusLength, statusPos) = decodeVarint(flashPageData, pos)
                         pos = statusPos
-                        let statusEnd = pos + statusLength
+                        let statusEnd = min(pos + statusLength, flashPageData.count)
 
                         while pos < statusEnd {
                             let statusMarker = flashPageData[pos]
@@ -343,7 +348,7 @@ final class LimitlessDeviceConnection: BaseDeviceConnection {
                         pos += 1
                         let (audioLength, audioPos) = decodeVarint(flashPageData, pos)
                         pos = audioPos
-                        let audioEnd = pos + audioLength
+                        let audioEnd = min(pos + audioLength, flashPageData.count)
 
                         while pos < audioEnd - 1 {
                             let audioMarker = flashPageData[pos]

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoriesPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoriesPage.swift
@@ -1083,7 +1083,12 @@ class MemoriesViewModel: ObservableObject {
       if !moreFromCache.isEmpty {
         let visibleMemories = displayCacheMemories(moreFromCache, for: token)
         memories.append(contentsOf: visibleMemories)
-        currentOffset += visibleMemories.count
+        // Advance the SQLite paging cursor by the RAW row count returned by the
+        // query, not the tier-filtered visible count. getLocalMemories(offset:)
+        // pages over raw rows, so advancing by the smaller filtered count makes the
+        // next page re-fetch the filtered-out rows — duplicate/stuck paging once
+        // hasMoreMemories (below) correctly stays true on a filtered page.
+        currentOffset += moreFromCache.count
         // Derive hasMoreMemories from the RAW cache count, not the tier-filtered
         // visible count. A full raw page whose visible subset is < pageSize still
         // has more cached rows to page; using the filtered count here disabled

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoriesPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoriesPage.swift
@@ -1084,7 +1084,12 @@ class MemoriesViewModel: ObservableObject {
         let visibleMemories = displayCacheMemories(moreFromCache, for: token)
         memories.append(contentsOf: visibleMemories)
         currentOffset += visibleMemories.count
-        hasMoreMemories = visibleMemories.count >= pageSize
+        // Derive hasMoreMemories from the RAW cache count, not the tier-filtered
+        // visible count. A full raw page whose visible subset is < pageSize still
+        // has more cached rows to page; using the filtered count here disabled
+        // scrolling and permanently hid those memories (the initial-load path
+        // already documents this exact raw-vs-filtered pagination rule).
+        hasMoreMemories = moreFromCache.count >= pageSize
         log(
           "MemoriesViewModel: Loaded \(visibleMemories.count) more from local cache (total: \(memories.count))"
         )

--- a/desktop/macos/Desktop/Sources/PipeProcessRunner.swift
+++ b/desktop/macos/Desktop/Sources/PipeProcessRunner.swift
@@ -95,10 +95,6 @@ enum PipeProcessRunner {
 
     do {
       try process.run()
-      if let stdinData {
-        stdinPipe.fileHandleForWriting.write(stdinData)
-        try? stdinPipe.fileHandleForWriting.close()
-      }
     } catch {
       stdoutPipe.fileHandleForReading.readabilityHandler = nil
       stderrPipe.fileHandleForReading.readabilityHandler = nil
@@ -106,7 +102,21 @@ enum PipeProcessRunner {
       throw PipeProcessRunnerError.launchFailed(error.localizedDescription)
     }
 
+    // Arm the timeout BEFORE the (potentially blocking) stdin write. Writing more
+    // than the pipe buffer (~64KB) to a child that hasn't started draining stdin
+    // blocks this thread; the timeout — which terminate()s the child and thereby
+    // unblocks the write via EPIPE — was previously scheduled only AFTER the write,
+    // so a stalled child hung the caller forever with the timeout never armed.
     DispatchQueue.global().asyncAfter(deadline: .now() + timeoutSeconds, execute: timeoutWork)
+
+    if let stdinData {
+      // Use the throwing write(contentsOf:) — the legacy write(_:) raises an
+      // uncatchable NSFileHandleOperationException on EPIPE, which is exactly what
+      // the timeout's terminate() triggers on a blocked write.
+      try? stdinPipe.fileHandleForWriting.write(contentsOf: stdinData)
+      try? stdinPipe.fileHandleForWriting.close()
+    }
+
     process.waitUntilExit()
     timeoutWork.cancel()
 

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/NotificationService.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/NotificationService.swift
@@ -263,12 +263,18 @@ class NotificationService: NSObject, UNUserNotificationCenterDelegate {
         // re-fires this on every session (soft-recovery + app restart), which buried
         // users in duplicate banners when a stale TCC csreq from an auto-update made
         // the capture path unrecoverable without a manual toggle in System Settings.
-        if title == Self.screenCaptureResetTitle {
-            if UserDefaults.standard.bool(forKey: Self.screenCaptureResetShownKey) {
-                log("NotificationService: suppressing duplicate screen capture reset notification")
-                return
-            }
-            UserDefaults.standard.set(true, forKey: Self.screenCaptureResetShownKey)
+        // NOTE: only READ the "already shown" flag here. The flag is SET at actual
+        // delivery time (just before showNotification below), NOT here — setting it
+        // before the snooze/enabled/frequency gates meant that if any gate suppressed
+        // this delivery (e.g. the user is snoozed when capture breaks), the flag was
+        // still persisted, and since it is only cleared on capture RECOVERY — which
+        // never happens while capture stays broken — every later retry hit this early
+        // return and the "screen recording needs reset" notice was never delivered.
+        if title == Self.screenCaptureResetTitle
+            && UserDefaults.standard.bool(forKey: Self.screenCaptureResetShownKey)
+        {
+            log("NotificationService: suppressing duplicate screen capture reset notification")
+            return
         }
 
         // Honor the floating-bar snooze for both the in-bar preview and the native
@@ -294,6 +300,13 @@ class NotificationService: NSObject, UNUserNotificationCenterDelegate {
         if respectFrequency && !shouldAllowProactiveNotification(assistantId: assistantId) {
             log("NotificationService: throttled \(assistantId) notification (frequency=\(Self.currentFrequencyLevel()))")
             return
+        }
+
+        // Mark the screen-capture reset notice as shown only now that it has passed
+        // every suppression gate and is actually being delivered — so a snoozed (or
+        // otherwise gated) attempt does not permanently suppress it for the episode.
+        if title == Self.screenCaptureResetTitle {
+            UserDefaults.standard.set(true, forKey: Self.screenCaptureResetShownKey)
         }
 
         FloatingControlBarManager.shared.showNotification(

--- a/desktop/macos/Desktop/Sources/SystemAudioCaptureService.swift
+++ b/desktop/macos/Desktop/Sources/SystemAudioCaptureService.swift
@@ -434,23 +434,26 @@ class SystemAudioCaptureService: @unchecked Sendable {
     }
 
     deinit {
-        // Use sync in deinit to ensure cleanup completes before deallocation
+        // Call the HAL teardown directly — do NOT `audioQueue.sync` here.
+        // deinit can run *on* audioQueue (the last strong reference is captured by
+        // the `audioQueue.async` block in startCapture and released when that block
+        // finishes), and dispatching sync to the current serial queue deadlocks it
+        // permanently. Mirrors AudioCaptureService.deinit. The object has no
+        // remaining references, so no concurrent audioQueue work can touch it, and
+        // these HAL calls are thread-safe — a direct call completes cleanup before
+        // deallocation (which `audioQueue.async` could not guarantee).
         let procID = self.ioProcID
         let aggDevID = self.aggregateDeviceID
         let tID = self.tapID
-        if procID != nil || aggDevID != kAudioObjectUnknown || tID != kAudioObjectUnknown {
-            audioQueue.sync {
-                if let procID = procID, aggDevID != kAudioObjectUnknown {
-                    AudioDeviceStop(aggDevID, procID)
-                    AudioDeviceDestroyIOProcID(aggDevID, procID)
-                }
-                if aggDevID != kAudioObjectUnknown {
-                    AudioHardwareDestroyAggregateDevice(aggDevID)
-                }
-                if tID != kAudioObjectUnknown {
-                    AudioHardwareDestroyProcessTap(tID)
-                }
-            }
+        if let procID = procID, aggDevID != kAudioObjectUnknown {
+            AudioDeviceStop(aggDevID, procID)
+            AudioDeviceDestroyIOProcID(aggDevID, procID)
+        }
+        if aggDevID != kAudioObjectUnknown {
+            AudioHardwareDestroyAggregateDevice(aggDevID)
+        }
+        if tID != kAudioObjectUnknown {
+            AudioHardwareDestroyProcessTap(tID)
         }
     }
 }

--- a/desktop/macos/Desktop/Tests/AgentSyncBatchQueryTests.swift
+++ b/desktop/macos/Desktop/Tests/AgentSyncBatchQueryTests.swift
@@ -1,0 +1,45 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// Regression test for the AgentSync mutable-table pagination skip: paging with a
+/// strict `updatedAt > ?` cursor drops every row past the first batch when more
+/// than `batchSize` rows share the same `updatedAt` (a bulk update touching >100
+/// rows in one second), silently diverging the VM's copy. Mutable tables must page
+/// on a compound `(updatedAt, id)` cursor.
+final class AgentSyncBatchQueryTests: XCTestCase {
+
+  func testMutableTableUsesCompoundCursor() {
+    let (sql, args) = AgentSyncService.buildBatchQuery(
+      tableName: "action_items",
+      selectCols: "\"id\", \"updatedAt\"",
+      appendOnly: false,
+      lastId: 42,
+      lastUpdatedAt: "2026-04-09T12:00:00",
+      batchSize: 100
+    )
+
+    // Must include the compound clause and id-tiebreaker ordering — not a bare
+    // strict `updatedAt > ?` that would skip same-timestamp rows.
+    XCTAssertTrue(sql.contains("updatedAt > ? OR (updatedAt = ? AND id > ?)"), sql)
+    XCTAssertTrue(sql.contains("ORDER BY updatedAt ASC, id ASC"), sql)
+    XCTAssertEqual(
+      args,
+      [.text("2026-04-09T12:00:00"), .text("2026-04-09T12:00:00"), .int(42), .int(100)])
+  }
+
+  func testAppendOnlyTablePagesById() {
+    let (sql, args) = AgentSyncService.buildBatchQuery(
+      tableName: "screenshots",
+      selectCols: "\"id\"",
+      appendOnly: true,
+      lastId: 7,
+      lastUpdatedAt: "1970-01-01T00:00:00",
+      batchSize: 100
+    )
+
+    XCTAssertTrue(sql.contains("WHERE id > ? ORDER BY id ASC"), sql)
+    XCTAssertFalse(sql.contains("updatedAt"), sql)
+    XCTAssertEqual(args, [.int(7), .int(100)])
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260711-macos-bug-sweep-3.json
+++ b/desktop/macos/changelog/unreleased/20260711-macos-bug-sweep-3.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed more reliability issues: a system-audio cleanup deadlock, a Bluetooth crash while syncing recordings from storage, a possible hang when importing large connector sessions, agent sync no longer skipping same-second bulk edits, and the 'screen recording needs reset' notice no longer being lost if you were snoozed"
+}

--- a/desktop/macos/e2e/flows/audio-recording.yaml
+++ b/desktop/macos/e2e/flows/audio-recording.yaml
@@ -12,6 +12,8 @@ covers:
   - desktop/macos/Desktop/Sources/Bluetooth/Transports/BleTransport.swift
   - desktop/macos/Desktop/Sources/Bluetooth/Connections/BeeDeviceConnection.swift
   - desktop/macos/Desktop/Sources/Bluetooth/Connections/PlaudDeviceConnection.swift
+  - desktop/macos/Desktop/Sources/Bluetooth/Connections/LimitlessDeviceConnection.swift
+  - desktop/macos/Desktop/Sources/SystemAudioCaptureService.swift
 preconditions:
   - auth_ready
 

--- a/desktop/macos/e2e/flows/connector-import.yaml
+++ b/desktop/macos/e2e/flows/connector-import.yaml
@@ -6,6 +6,7 @@ app: non-prod
 covers:
   - desktop/macos/Desktop/Sources/MainWindow/Pages/ConnectorImportOperations.swift
   - desktop/macos/Desktop/Sources/Onboarding/OnboardingMemoryLogImportService.swift
+  - desktop/macos/Desktop/Sources/PipeProcessRunner.swift
 preconditions:
   - automation_bridge_ready
 

--- a/desktop/macos/e2e/flows/harness-smoke.yaml
+++ b/desktop/macos/e2e/flows/harness-smoke.yaml
@@ -12,6 +12,7 @@ covers:
   - desktop/macos/Desktop/Sources/DesktopKeychainStore.swift
   - desktop/macos/Desktop/Sources/ClientDeviceService.swift
   - desktop/macos/Desktop/Sources/LocalAgentAPIServer.swift
+  - desktop/macos/Desktop/Sources/AgentSyncService.swift
   - desktop/macos/Desktop/Sources/APIKeyService.swift
   - desktop/macos/Desktop/Sources/FileIndexing/FileIndexerService.swift
   - desktop/macos/Desktop/Sources/OmiApp.swift


### PR DESCRIPTION
## What changed and why

Third batch of the macOS bug sweep (follow-up to #9459 and #9476): the remaining verified findings from the original subsystem review — a deadlock, a BLE crash, two silent data-divergence/loss paths, a hang, and a lost-notification bug. Each targets the violated contract; regression tests are added where a hermetic seam exists, and where none does (BLE/audio/process/view-model paths that need live hardware or un-constructable singletons) that is stated explicitly.

## Product invariants affected

- none (no locked-invariant path globs touched).

## How it was verified

- **Static ratchets + e2e-flow coverage:** pass locally (test-quality, sources-root, asyncAfter, UserDefaults-key, flow coverage).
- **Swift compile/tests:** macOS CI (`desktop-swift-ci.yml`); the Linux container has no Swift toolchain, so the local pre-push Swift compile was skipped via the hook's documented `PRE_PUSH_SKIP_DESKTOP_SWIFT=1`.

### Fixes
- **SystemAudioCaptureService deinit deadlock** — deinit `audioQueue.sync`'d, but deinit can run *on* audioQueue (last ref released inside the startCapture async block), deadlocking all future system-audio start/stop. Call HAL teardown directly, mirroring the already-fixed AudioCaptureService.deinit.
- **AgentSync same-second pagination skip** — mutable tables paged by strict `updatedAt > ?`, so a >100-row same-second bulk update lost every row past the first page (VM copy silently diverged). Now pages by a compound `(updatedAt, id)` cursor via a unit-tested `buildBatchQuery`.
- **MemoriesPage hides memories on a filtered page** — `loadMore` derived `hasMoreMemories` from the tier-filtered visible count instead of the raw cache page size, disabling scrolling and hiding cached memories. Now uses the raw count, matching the initial-load path's documented rule.
- **Screen-recording-reset notice lost after snooze** — the once-per-episode "shown" flag was set before the snooze gate, so a snoozed user permanently suppressed the notice for the whole broken-capture episode. Flag is now set at actual delivery, after every gate.
- **PipeProcessRunner hang on large stdin** — the stdin write ran before the timeout was armed, so a >64KB stdin to a stalled child blocked forever. Arm the timeout first; use the throwing `write(contentsOf:)` (EPIPE-safe when the timeout terminates the child).
- **Limitless flash-page OOB crash** — `chunkEnd`/`statusEnd`/`audioEnd` weren't clamped to the buffer, so an over-claiming length on a truncated reassembled page trapped mid storage-sync. Clamp each with `min(…, count)`, mirroring the sibling extractOpus guard.

## Tests

New: `AgentSyncBatchQueryTests` (compound-cursor query construction). The other five fixes have no hermetic seam here (deinit-on-queue deadlock, live BLE transport, un-constructable connection, real child process, async view-model over storage/network singletons) and are verified by reasoning / pattern-match to an already-fixed sibling, as noted in each commit.

## Root cause and durable guard (bug fixes)

Each fix replaces the failing contract: direct-teardown deinit (no self-queue dispatch), a compound non-unique-safe cursor, raw-count pagination, set-flag-at-delivery ordering, arm-timeout-before-blocking-write, and buffer-clamped length parsing. Where a fix mirrors a previously-fixed sibling (deinit deadlock, OOB clamp), it closes the same class in the second location.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RAxLsaxtwVNDTWAZFfJp9q)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9486?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

