### PR TITLE
docs(app): update e2e skill for current navigation and iOS device automation

### DIFF
--- a/app/e2e/SKILL.md
+++ b/app/e2e/SKILL.md
@@ -39,6 +39,34 @@ agent-flutter snapshot -i --json    # see what's on screen
 - **App must be authenticated and connected to the correct backend** (local, dev, or prod — depends on the task)
 - Marionette already integrated: `marionette_flutter: ^0.3.0` in pubspec.yaml
 
+### Setup (iOS physical device)
+
+Verified 2026-07-11 on an iPhone XR (iOS 18.7.9), app 1.0.543, prod-flavor debug build, agent-flutter CLI + marionette MCP. iOS Simulator has no BLE — use a physical device for anything beyond onboarding/UI checks (see also iOS Simulator Known Limitations below).
+
+```bash
+# 1. Get the physical device id
+flutter devices
+
+# 2. Run in debug mode with stdout captured — prod flavor (dev flavor can fail codesigning on a
+#    fresh worktree: "provisioning profile doesn't support the App Groups capability")
+cd app && flutter run -d <device-id> --flavor prod > /tmp/omi-flutter.log 2>&1 &
+# Wait for "A Dart VM Service ... is available" in the log
+
+# 3. Connect agent-flutter — auto-detects the ws URI from the log
+AGENT_FLUTTER_LOG=/tmp/omi-flutter.log agent-flutter connect
+agent-flutter snapshot -i --json
+```
+
+**Gotchas:**
+- **Fresh git worktrees need real prod config seeded from the primary checkout** before building the `prod` flavor: copy `app/.env`, `app/lib/firebase_options_prod.dart`, `app/ios/Config/Prod/GoogleService-Info.plist`, `app/lib/env/prod_env.g.dart`. The `test.sh` bootstrap seeds dev-placeholder versions that point at the wrong Firebase project.
+- **adb-backed commands do NOT work on iOS**: `back`, `press x y`, `dismiss`, `text --press`, `text --fill`. Use in-app back buttons (find the top-left `IconButton` ref) and marionette ref presses only.
+- **`fill @ref` can silently no-op on keyless `TextField`s on iOS** — it reports success but the controller stays empty. Verify via the marionette MCP `get_interactive_elements` (shows the `TextEditingController` contents). Durable fix: add a `ValueKey` to the field, hot reload (sheet state survives), then enter text by key.
+- **`snapshot` labels are empty with `marionette_flutter` 0.3.0** on iOS. Primary orientation/assertion tool is `agent-flutter text` (semantic text dump) — assert outcomes by text presence (e.g. the copy snackbar text). Target elements by type + bounds from `snapshot -i`.
+- `agent-flutter screenshot` output path must be under `/tmp`.
+- Check behavior via the run log: `grep -iE 'exception|error' /tmp/omi-flutter.log` after each flow. A `PlatformException` 4001 (Intercom push token, notifications not granted) is benign.
+- iOS terminates the debug connection if the app is backgrounded/locked too long ("The OS has terminated the Flutter debug connection for being inactive") — keep the device unlocked; reconnecting requires relaunching `flutter run`.
+- General key guidance (same as Android): prefer `find key "name"`; when a control can't be targeted, add a `ValueKey` in source + hot reload rather than fighting coordinates.
+
 ### Commands
 
 | Command | Purpose | Example |
@@ -62,6 +90,7 @@ agent-flutter snapshot -i --json    # see what's on screen
 - `AGENT_FLUTTER_LOG` must point to `flutter run` stdout (not logcat).
 - After hot restart: `disconnect` → wait 3s → `connect`.
 - Widget text labels are often null — use `type`, `flutterType`, or `bounds` to identify.
+- `back`, `press x y`, `dismiss`, and the `--adb`/`--press`/`--fill` text flags are ADB-backed — Android only. On a physical iOS device use marionette ref-based commands instead (see Setup (iOS physical device) above).
 
 ### Recovery
 ```bash
@@ -91,35 +120,37 @@ Onboarding (wrapper.dart) — 11-step wizard
 └── 10: Complete (complete_screen.dart)
 
 Home (page.dart) — main app after auth
-├── [top bar] Connect Device | Search | History | Settings gear
+├── [top bar] Connect Device | Search | History | Settings icon
 ├── [center] Daily Score card → Add Goal
-├── [Ask Omi button] → Chat (chat/page.dart)
-│   └── Text input, voice recorder, AI responses, message actions
+├── ["Ask Omi anything…" input bar] → Chat (chat/page.dart) — full-width bar above bottom nav, not a button/tab
+│   └── Message history, "Ask anything" field, AI responses, message actions
 ├── [record button] → Conversation Capturing (conversation_capturing/page.dart)
 │   └── Live transcript, waveform, stop button
 │
-├── [tab 0] Conversations (conversations_page.dart)
+├── [tab 0] Conversations (conversations_page.dart) — bottom-nav slot 1
 │   ├── Folder tabs (All, Starred, custom folders)
 │   ├── Daily summaries toggle
 │   ├── Today's tasks widget
-│   └── Conversation item → Detail (conversation_detail/page.dart)
-│       └── Transcript, Summary, Action Items tabs, share, audio
+│   └── Conversation item (GestureDetector row) → Detail (conversation_detail/page.dart)
+│       ├── Transcript, Summary, Action Items tabs, share, audio
+│       └── Back via in-app top-left IconButton — not the OS/adb back gesture
 │
-├── [tab 1] Action Items (action_items_page.dart)
+├── [tab 1] Action Items (action_items_page.dart) — bottom-nav slot 2
 │   ├── Categories: Today, Tomorrow, Later, No Deadline, Overdue
 │   ├── FAB → Create task sheet (action_item_form_sheet.dart)
 │   ├── Task checkboxes, drag-drop reorder
 │   └── Task → Goal linking
 │
-├── [tab 2] Memories (memories/page.dart)
+├── [tab 2] Memories (memories/page.dart) — bottom-nav slot 3, also reachable via Settings → Memories
 │   ├── Search bar, graph button, management button
-│   ├── FAB → Add memory dialog
+│   ├── FAB (bottom-right) → New Memory sheet (memory_dialog.dart) — the "Create new memory" text row
+│   │   is NOT tappable, only the FAB is; field/button ValueKeys `memory_content_field` / `memory_save_button` (PR #9484)
 │   ├── Category chips filter
 │   ├── Memory item → Quick edit sheet (memory_edit_sheet.dart)
 │   ├── Graph → Memory Graph (memory_graph_page.dart)
 │   └── Management → Category management sheet
 │
-├── [tab 3] Apps (apps/page.dart)
+├── [tab 3] Apps (apps/page.dart) — bottom-nav slot 4 ("Search 1500+ Apps" / "Featured")
 │   ├── Search, filter, create buttons
 │   ├── Popular apps (horizontal scroll)
 │   ├── Category sections → Category apps page
@@ -127,7 +158,7 @@ Home (page.dart) — main app after auth
 │   │   └── Reviews, capabilities, install/enable
 │   └── Create → Custom app or MCP server
 │
-└── [settings gear] → Settings Drawer (settings_drawer.dart)
+└── [settings icon] → Settings sheet (settings_drawer.dart)
     ├── Profile (profile.dart)
     │   ├── Name → Change name dialog
     │   ├── Email (read-only)
@@ -154,6 +185,8 @@ Home (page.dart) — main app after auth
     │   └── Double tap action picker
     ├── Integrations (integrations_page.dart) — BETA
     │   └── Google Calendar, Gmail, Apple Health
+    ├── Permissions (permissions_page.dart) — Microphone, Bluetooth, Location, Background Activity
+    ├── Memories → jumps to Memories tab (bottom-nav slot 3)
     ├── Phone Calls (phone_call_settings_page.dart)
     │   └── Verified numbers list, delete button
     ├── Transcription Settings (transcription_settings_page.dart)
@@ -190,13 +223,20 @@ Speech Profile (speech_profile/page.dart)
 ### Widget Patterns
 
 **Bottom navigation bar:**
-- 4 `InkWell` widgets at `bounds.y > 780`, sorted left-to-right by `bounds.x`
+- Android: 4 `InkWell` widgets at `bounds.y > 780`, sorted left-to-right by `bounds.x`
 - Detect with: `snapshot -i --json` → filter `flutterType == 'InkWell'` and `bounds.y > 780`
 - Navigate home: press the leftmost one
+- iOS (verified 2026-07-11, iPhone XR, 414pt-wide screen): 4 slots at y≈816, x=20/114/207/300, each w=94.
+  Slot 1 = Conversations/home (folder tabs All/Starred/…), slot 4 = Apps marketplace ("Search 1500+ Apps" / "Featured")
+
+**Chat entry point (not a bottom-nav tab):**
+- Open chat by tapping the "Ask Omi anything…" input bar on the home screen — a full-width gesture
+  element directly above the bottom nav (~y=756, w≈382 on a 414pt-wide screen; verified iOS 2026-07-11)
 
 **Settings gear:**
-- Rightmost `button` widget in the top bar
-- Detect with: sort buttons by `bounds.x` descending, take first
+- Android: rightmost `button` widget in the top bar; detect by sorting buttons by `bounds.x` descending, take first
+- iOS (verified 2026-07-11): single top-right icon on home at ~x=362, y=58 → Settings sheet (Profile,
+  Notifications, Offline Sync, Permissions, Memories, Developer Settings, …, Sign Out)
 
 **Settings rows:**
 - `gesture` widgets with `bounds.width > 300`
@@ -210,6 +250,14 @@ Speech Profile (speech_profile/page.dart)
 - Open when you press a settings row
 - Language items appear as `gesture` rows with `bounds.y > 380`
 - Many items — use scroll if needed
+
+**Conversation feed rows (iOS, verified 2026-07-11):**
+- `GestureDetector` widgets, h≈84–96; detail opens on tap
+- Go back with the in-app top-left `IconButton` (x=8, y=56, w=40) — not the OS/adb back gesture
+
+**Chat AI-message actions (iOS, verified 2026-07-11):**
+- Four small `InkWell`s (w≈12–14) under each AI message at x≈22/54/88/122; the first is copy —
+  pressing it shows the "✨ Message copied to clipboard" snackbar
 
 ### Changing Locale
 ```bash
@@ -417,6 +465,8 @@ After making changes, verify them in the live app:
 | Non-English IME breaks text input | Set system locale to English: `adb shell "settings put system system_locales en-US"` |
 
 ## iOS Simulator Known Limitations
+
+For a physical iOS device (has BLE, avoids most limitations below), see **Setup (iOS physical device)** under How to Explore the App.
 
 | Issue | Workaround |
 |-------|-----------|


### PR DESCRIPTION
## What

Updates `app/e2e/SKILL.md` — the agent-facing guide for driving the mobile app — to match the current app and add iOS physical-device coverage. Docs only, one commit.

- **Corrected stale navigation facts**: chat opens from the "Ask Omi anything…" input bar on home (not a button/tab); bottom-nav slots labeled; conversation detail back is the in-app IconButton (not OS/adb back); Memories creation is via the FAB (the "Create new memory" text row is not tappable), with the ValueKeys added in #9484; Settings sheet entries (incl. Permissions) filled in.
- **New "Setup (iOS physical device)" section**: run/connect commands, fresh-worktree prod-config seeding, dev-flavor codesigning gotcha, adb-backed commands that don't work on iOS (`back`, `press x y`, `dismiss`, `text --press/--fill`), keyless-TextField `fill` silently no-oping (with the ValueKey + hot-reload fix), empty `snapshot` labels on marionette_flutter 0.3.0 (use `agent-flutter text` for assertions), screenshot path restriction, log-grep verification, and the iOS background-inactivity debug-connection kill.

## Why

An agent session verifying #9484 on a physical iPhone XR hit every one of these as an undocumented surprise; the chat entry point in the doc was simply wrong (the user had to intervene). Per AGENTS.md ("when a defect ships because guidance was misread or missing, tighten the guidance"), this writes the findings down where the next agent will read them first.

## Verification

Docs-only. All new claims were verified live on 2026-07-11 (iPhone XR, iOS 18.7.9, app 1.0.543 prod-flavor debug build, agent-flutter CLI + marionette MCP) during the #9484 device smoke; the diff was reviewed against that session's actual command transcripts. Existing Android/emulator content, the flow-walker graph, and verified-flows table are untouched. `git diff` touches only `app/e2e/SKILL.md`.

## Product invariants affected

none (`scripts/pr-preflight --suggest`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9487?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

