### PR TITLE
Fix macOS audio loss, BLE data race, memory-graph race, and legacy-migration data loss (bug sweep #4)

### DIFF
--- a/desktop/macos/Desktop/Sources/Bluetooth/Transports/BleTransport.swift
+++ b/desktop/macos/Desktop/Sources/Bluetooth/Transports/BleTransport.swift
@@ -29,11 +29,14 @@ final class BleTransport: NSObject, DeviceTransport {
     private let connectionStateSubject = PassthroughSubject<DeviceTransportState, Never>()
 
     private var discoveredServices: [CBService] = []
-    // Guards the two continuation maps below. read/writeCharacteristic() run on an
-    // arbitrary task executor while the CBPeripheralDelegate callbacks run on the
-    // CoreBluetooth (main) queue and disconnect()/dispose() drain from yet another
-    // context — Swift Dictionary is not thread-safe, so all access is serialized
-    // here. Continuations are always resumed OUTSIDE the lock.
+    // Guards every continuation field below. connect()/read/writeCharacteristic()
+    // run on an arbitrary task executor; the CBPeripheralDelegate callbacks run on
+    // the CoreBluetooth (main) queue; the NotificationCenter connection observers
+    // run on .main; and disconnect()/dispose() drain from yet another context.
+    // Swift Dictionary/Optional mutation is not thread-safe across those, and two
+    // contexts racing to resume the SAME CheckedContinuation traps (double-resume).
+    // So all access is serialized here: capture-and-nil the continuation UNDER the
+    // lock, then resume it OUTSIDE the lock (exactly one context wins the capture).
     private let continuationsLock = NSLock()
     private var characteristicContinuations: [CBUUID: CheckedContinuation<Data, Error>] = [:]
     private var writeContinuations: [CBUUID: CheckedContinuation<Void, Error>] = [:]
@@ -108,22 +111,29 @@ final class BleTransport: NSObject, DeviceTransport {
     }
 
     private func handleConnectionSuccess() {
-        connectionContinuation?.resume()
+        continuationsLock.lock()
+        let continuation = connectionContinuation
         connectionContinuation = nil
+        continuationsLock.unlock()
+        continuation?.resume()
     }
 
     private func handleConnectionFailure(error: Error?) {
         let transportError = DeviceTransportError.connectionFailed(error?.localizedDescription ?? "Unknown error")
-        connectionContinuation?.resume(throwing: transportError)
+        continuationsLock.lock()
+        let continuation = connectionContinuation
         connectionContinuation = nil
+        continuationsLock.unlock()
+        continuation?.resume(throwing: transportError)
         updateState(.disconnected)
     }
 
     private func handleDisconnection(error: Error?) {
-        if let continuation = connectionContinuation {
-            continuation.resume(throwing: DeviceTransportError.connectionFailed("Disconnected during connection"))
-            connectionContinuation = nil
-        }
+        continuationsLock.lock()
+        let continuation = connectionContinuation
+        connectionContinuation = nil
+        continuationsLock.unlock()
+        continuation?.resume(throwing: DeviceTransportError.connectionFailed("Disconnected during connection"))
         updateState(.disconnected)
     }
 
@@ -148,13 +158,17 @@ final class BleTransport: NSObject, DeviceTransport {
         do {
             // Connect to the peripheral
             try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+                continuationsLock.lock()
                 self.connectionContinuation = continuation
+                continuationsLock.unlock()
                 self.centralManager.connect(self.peripheral, options: nil)
             }
 
             // Discover services
             discoveredServices = try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<[CBService], Error>) in
+                continuationsLock.lock()
                 self.serviceDiscoveryContinuation = continuation
+                continuationsLock.unlock()
                 self.peripheral.discoverServices(nil)
             }
 
@@ -187,18 +201,22 @@ final class BleTransport: NSObject, DeviceTransport {
         }
         characteristicStreams.removeAll()
 
-        // Cancel pending continuations
-        connectionContinuation?.resume(throwing: CancellationError())
-        connectionContinuation = nil
-        serviceDiscoveryContinuation?.resume(throwing: CancellationError())
-        serviceDiscoveryContinuation = nil
-
+        // Cancel pending continuations. Capture-and-nil every continuation under
+        // the lock, then resume OUTSIDE it, so a concurrent connect callback or
+        // delegate cannot double-resume the same continuation.
         continuationsLock.lock()
+        let pendingConnection = connectionContinuation
+        connectionContinuation = nil
+        let pendingDiscovery = serviceDiscoveryContinuation
+        serviceDiscoveryContinuation = nil
         let pendingReads = characteristicContinuations
         let pendingWrites = writeContinuations
         characteristicContinuations.removeAll()
         writeContinuations.removeAll()
         continuationsLock.unlock()
+
+        pendingConnection?.resume(throwing: CancellationError())
+        pendingDiscovery?.resume(throwing: CancellationError())
 
         for (_, continuation) in pendingReads {
             continuation.resume(throwing: CancellationError())
@@ -360,12 +378,15 @@ final class BleTransport: NSObject, DeviceTransport {
 extension BleTransport: CBPeripheralDelegate {
 
     func peripheral(_ peripheral: CBPeripheral, didDiscoverServices error: Error?) {
-        if let error = error {
-            serviceDiscoveryContinuation?.resume(throwing: error)
-        } else {
-            serviceDiscoveryContinuation?.resume(returning: peripheral.services ?? [])
-        }
+        continuationsLock.lock()
+        let continuation = serviceDiscoveryContinuation
         serviceDiscoveryContinuation = nil
+        continuationsLock.unlock()
+        if let error = error {
+            continuation?.resume(throwing: error)
+        } else {
+            continuation?.resume(returning: peripheral.services ?? [])
+        }
     }
 
     func peripheral(_ peripheral: CBPeripheral, didDiscoverCharacteristicsFor service: CBService, error: Error?) {

--- a/desktop/macos/Desktop/Sources/Bluetooth/Transports/BleTransport.swift
+++ b/desktop/macos/Desktop/Sources/Bluetooth/Transports/BleTransport.swift
@@ -29,6 +29,12 @@ final class BleTransport: NSObject, DeviceTransport {
     private let connectionStateSubject = PassthroughSubject<DeviceTransportState, Never>()
 
     private var discoveredServices: [CBService] = []
+    // Guards the two continuation maps below. read/writeCharacteristic() run on an
+    // arbitrary task executor while the CBPeripheralDelegate callbacks run on the
+    // CoreBluetooth (main) queue and disconnect()/dispose() drain from yet another
+    // context — Swift Dictionary is not thread-safe, so all access is serialized
+    // here. Continuations are always resumed OUTSIDE the lock.
+    private let continuationsLock = NSLock()
     private var characteristicContinuations: [CBUUID: CheckedContinuation<Data, Error>] = [:]
     private var writeContinuations: [CBUUID: CheckedContinuation<Void, Error>] = [:]
     private var characteristicStreams: [String: CharacteristicStreamHandler] = [:]
@@ -187,15 +193,19 @@ final class BleTransport: NSObject, DeviceTransport {
         serviceDiscoveryContinuation?.resume(throwing: CancellationError())
         serviceDiscoveryContinuation = nil
 
-        for (_, continuation) in characteristicContinuations {
-            continuation.resume(throwing: CancellationError())
-        }
+        continuationsLock.lock()
+        let pendingReads = characteristicContinuations
+        let pendingWrites = writeContinuations
         characteristicContinuations.removeAll()
+        writeContinuations.removeAll()
+        continuationsLock.unlock()
 
-        for (_, continuation) in writeContinuations {
+        for (_, continuation) in pendingReads {
             continuation.resume(throwing: CancellationError())
         }
-        writeContinuations.removeAll()
+        for (_, continuation) in pendingWrites {
+            continuation.resume(throwing: CancellationError())
+        }
 
         // Disconnect
         centralManager.cancelPeripheralConnection(peripheral)
@@ -270,7 +280,12 @@ final class BleTransport: NSObject, DeviceTransport {
         }
 
         return try await withCheckedThrowingContinuation { continuation in
-            characteristicContinuations[characteristicUUID] = continuation
+            continuationsLock.lock()
+            let displaced = characteristicContinuations.updateValue(continuation, forKey: characteristicUUID)
+            continuationsLock.unlock()
+            // A concurrent read on the same characteristic would silently overwrite
+            // (and leak) the prior continuation — fail it instead of hanging forever.
+            displaced?.resume(throwing: DeviceTransportError.readFailed("superseded by a newer read"))
             peripheral.readValue(for: characteristic)
         }
     }
@@ -295,7 +310,10 @@ final class BleTransport: NSObject, DeviceTransport {
 
         if withResponse {
             try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
-                writeContinuations[characteristicUUID] = continuation
+                continuationsLock.lock()
+                let displaced = writeContinuations.updateValue(continuation, forKey: characteristicUUID)
+                continuationsLock.unlock()
+                displaced?.resume(throwing: DeviceTransportError.writeFailed("superseded by a newer write"))
                 peripheral.writeValue(data, for: characteristic, type: writeType)
             }
         } else {
@@ -362,7 +380,10 @@ extension BleTransport: CBPeripheralDelegate {
         let uuid = characteristic.uuid
 
         // Handle pending read continuation
-        if let continuation = characteristicContinuations.removeValue(forKey: uuid) {
+        continuationsLock.lock()
+        let readContinuation = characteristicContinuations.removeValue(forKey: uuid)
+        continuationsLock.unlock()
+        if let continuation = readContinuation {
             if let error = error {
                 continuation.resume(throwing: DeviceTransportError.readFailed(error.localizedDescription))
             } else {
@@ -381,7 +402,10 @@ extension BleTransport: CBPeripheralDelegate {
     func peripheral(_ peripheral: CBPeripheral, didWriteValueFor characteristic: CBCharacteristic, error: Error?) {
         let uuid = characteristic.uuid
 
-        if let continuation = writeContinuations.removeValue(forKey: uuid) {
+        continuationsLock.lock()
+        let writeContinuation = writeContinuations.removeValue(forKey: uuid)
+        continuationsLock.unlock()
+        if let continuation = writeContinuation {
             if let error = error {
                 continuation.resume(throwing: DeviceTransportError.writeFailed(error.localizedDescription))
             } else {

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryGraph/MemoryGraphPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryGraph/MemoryGraphPage.swift
@@ -338,6 +338,14 @@ class MemoryGraphViewModel: ObservableObject {
       let restoredLayout =
         loadCachedLayout(signature: signature).map { simulation.applyLayout($0) } ?? false
       if !restoredLayout {
+        // Suppress the render-driven simulation.tick() while the off-main physics
+        // run mutates the same node positions/velocities. The SceneKit delegate
+        // enqueues updateSimulation() on the main actor every frame; without this
+        // it would tick() concurrently with runSync() off-main — an unsynchronized
+        // read/write of non-atomic SIMD3 node state (torn positions, corrupt
+        // layout/camera). The post-layout block below re-enables animation once the
+        // detached run has completed.
+        isAnimating = false
         // Run initial layout off main thread for responsiveness
         await Task.detached(priority: .userInitiated) { [simulation] in
           simulation.runSync(ticks: 800)
@@ -532,6 +540,11 @@ class MemoryGraphViewModel: ObservableObject {
 
     let userName = AuthService.shared.displayName.isEmpty ? nil : AuthService.shared.givenName
     simulation.addNodesAndEdges(graphResponse: response, userNodeLabel: userName)
+
+    // Suppress the render-driven tick() while this off-main physics burst mutates
+    // the (already-live) scene's node state — same main-vs-detached data race as
+    // loadGraph. Re-enabled for the settle animation below, after the detached run.
+    isAnimating = false
 
     // Run a burst of physics to integrate new nodes
     await Task.detached(priority: .userInitiated) { [simulation] in

--- a/desktop/macos/Desktop/Sources/Rewind/Core/RewindDatabase.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/RewindDatabase.swift
@@ -501,6 +501,34 @@ actor RewindDatabase {
     /// Migrate data from the legacy shared path (Omi/) or from the anonymous fallback
     /// (Omi/users/anonymous/) to the per-user path (Omi/users/{userId}/).
     /// Handles both first-time migration (DB move) and partial re-runs (directory merges).
+    /// Fold a directory's `omi.db-wal` into its `omi.db` so committed-but-
+    /// uncheckpointed writes survive the migration cleanup that deletes WAL/SHM.
+    /// Returns `true` when there is nothing to checkpoint or the checkpoint
+    /// succeeded, and `false` when a non-empty WAL exists but could not be
+    /// checkpointed — the caller MUST abort (not delete the WAL) in that case to
+    /// avoid a silent rollback / data loss.
+    private func checkpointWALBeforeMigration(in dir: URL, label: String, fileManager: FileManager) -> Bool {
+        let db = dir.appendingPathComponent("omi.db")
+        let wal = dir.appendingPathComponent("omi.db-wal")
+        guard fileManager.fileExists(atPath: db.path),
+            fileManager.fileExists(atPath: wal.path)
+        else {
+            return true // no WAL to fold in — nothing can be lost by the cleanup loop
+        }
+        do {
+            let pool = try DatabasePool(path: db.path, configuration: Configuration())
+            try pool.write { db in
+                try db.execute(sql: "PRAGMA wal_checkpoint(TRUNCATE)")
+            }
+            try pool.close()
+            log("RewindDatabase: Checkpointed WAL at \(label) before migration")
+            return true
+        } catch {
+            log("RewindDatabase: \(label) WAL checkpoint failed, aborting migration to avoid data loss: \(error.localizedDescription)")
+            return false
+        }
+    }
+
     private func migrateFromLegacyPathIfNeeded(to userDir: URL) {
         let fileManager = FileManager.default
         let appSupport = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
@@ -547,49 +575,21 @@ actor RewindDatabase {
             "omi.db", "Screenshots", "Videos", "backups",
         ]
 
-        // Checkpoint WAL at destination before deleting — preserves recent writes
-        // (e.g. knowledge graph saved during onboarding, before app restart for permissions)
-        let destDB = userDir.appendingPathComponent("omi.db")
-        if fileManager.fileExists(atPath: destDB.path) {
-            let destWAL = userDir.appendingPathComponent("omi.db-wal")
-            if fileManager.fileExists(atPath: destWAL.path) {
-                do {
-                    let config = Configuration()
-                    let pool = try DatabasePool(path: destDB.path, configuration: config)
-                    try pool.write { db in
-                        try db.execute(sql: "PRAGMA wal_checkpoint(TRUNCATE)")
-                    }
-                    try pool.close()
-                    log("RewindDatabase: Checkpointed WAL at dest before migration")
-                } catch {
-                    log("RewindDatabase: WAL checkpoint failed: \(error.localizedDescription)")
-                }
-            }
-        }
-
-        // Checkpoint the SOURCE WAL into the source omi.db BEFORE deleting it, so
-        // committed-but-uncheckpointed transactions fold into omi.db and migrate
-        // with it. An unclean prior shutdown leaves a non-empty WAL (a clean close
-        // checkpoints and removes it); deleting that WAL outright — as the loop
-        // below does — would roll the DB back to its last checkpoint and silently
-        // drop up to wal_autocheckpoint (1000 pages, ~4MB) of recent writes. We
-        // still must not MOVE the path-bound WAL/SHM, only fold-then-delete.
-        let sourceDB = sourceDir.appendingPathComponent("omi.db")
-        let sourceWAL = sourceDir.appendingPathComponent("omi.db-wal")
-        if fileManager.fileExists(atPath: sourceDB.path),
-            fileManager.fileExists(atPath: sourceWAL.path)
-        {
-            do {
-                let pool = try DatabasePool(path: sourceDB.path, configuration: Configuration())
-                try pool.write { db in
-                    try db.execute(sql: "PRAGMA wal_checkpoint(TRUNCATE)")
-                }
-                try pool.close()
-                log("RewindDatabase: Checkpointed WAL at source before migration")
-            } catch {
-                log("RewindDatabase: Source WAL checkpoint failed: \(error.localizedDescription)")
-            }
-        }
+        // Fold each directory's WAL into its omi.db BEFORE the cleanup loop below
+        // deletes the path-bound WAL/SHM. An unclean prior shutdown leaves a
+        // non-empty WAL holding committed-but-uncheckpointed transactions (a clean
+        // close checkpoints and removes it); deleting that WAL outright would roll
+        // the DB back to its last checkpoint and silently drop up to
+        // wal_autocheckpoint (1000 pages, ~4MB) of recent writes:
+        //   - dest WAL: recent writes such as the knowledge graph saved during
+        //     onboarding, before the app restart for permissions.
+        //   - source WAL: the legacy data being migrated.
+        // If a checkpoint FAILS, those writes are still only in the WAL, so we must
+        // NOT proceed to delete it — abort the whole migration and leave source +
+        // dest intact. initialize() retries migration on the next launch, once the
+        // transient cause (locked DB, momentary IO error) has likely cleared.
+        guard checkpointWALBeforeMigration(in: userDir, label: "dest", fileManager: fileManager) else { return }
+        guard checkpointWALBeforeMigration(in: sourceDir, label: "source", fileManager: fileManager) else { return }
 
         // Delete WAL/SHM and running flag at source AND destination — do NOT migrate them.
         // Stale WAL/SHM at the destination (from a prior partial migration or crash) would

--- a/desktop/macos/Desktop/Sources/Rewind/Core/RewindDatabase.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/RewindDatabase.swift
@@ -567,6 +567,30 @@ actor RewindDatabase {
             }
         }
 
+        // Checkpoint the SOURCE WAL into the source omi.db BEFORE deleting it, so
+        // committed-but-uncheckpointed transactions fold into omi.db and migrate
+        // with it. An unclean prior shutdown leaves a non-empty WAL (a clean close
+        // checkpoints and removes it); deleting that WAL outright — as the loop
+        // below does — would roll the DB back to its last checkpoint and silently
+        // drop up to wal_autocheckpoint (1000 pages, ~4MB) of recent writes. We
+        // still must not MOVE the path-bound WAL/SHM, only fold-then-delete.
+        let sourceDB = sourceDir.appendingPathComponent("omi.db")
+        let sourceWAL = sourceDir.appendingPathComponent("omi.db-wal")
+        if fileManager.fileExists(atPath: sourceDB.path),
+            fileManager.fileExists(atPath: sourceWAL.path)
+        {
+            do {
+                let pool = try DatabasePool(path: sourceDB.path, configuration: Configuration())
+                try pool.write { db in
+                    try db.execute(sql: "PRAGMA wal_checkpoint(TRUNCATE)")
+                }
+                try pool.close()
+                log("RewindDatabase: Checkpointed WAL at source before migration")
+            } catch {
+                log("RewindDatabase: Source WAL checkpoint failed: \(error.localizedDescription)")
+            }
+        }
+
         // Delete WAL/SHM and running flag at source AND destination — do NOT migrate them.
         // Stale WAL/SHM at the destination (from a prior partial migration or crash) would
         // also cause SQLITE_IOERR_CORRUPTFS when SQLite opens the migrated DB.

--- a/desktop/macos/Desktop/Sources/WAL/WALService.swift
+++ b/desktop/macos/Desktop/Sources/WAL/WALService.swift
@@ -438,7 +438,9 @@ final class WALService: ObservableObject {
 
     /// Length-prefix encode frames into the on-disk WAL chunk byte layout
     /// (`UInt32 little-endian length + frame bytes`, repeated).
-    static func encodeFrames(_ frames: [Data]) -> Data {
+    /// `nonisolated`: pure byte transform, no actor state — callable synchronously
+    /// from the off-main disk-write path and from tests.
+    nonisolated static func encodeFrames(_ frames: [Data]) -> Data {
         var fileData = Data()
         for frame in frames {
             var length = UInt32(frame.count).littleEndian
@@ -452,7 +454,7 @@ final class WALService: ObservableObject {
     /// has content, the new frames EXTEND it — a duplicate WAL id (same
     /// device+second) must never atomically overwrite the earlier frames, which
     /// destroyed the previously-recorded audio.
-    static func frameFileBytes(existing: Data?, frames: [Data], append: Bool) -> Data {
+    nonisolated static func frameFileBytes(existing: Data?, frames: [Data], append: Bool) -> Data {
         let encoded = encodeFrames(frames)
         if append, let existing, !existing.isEmpty {
             return existing + encoded

--- a/desktop/macos/Desktop/Sources/WAL/WALService.swift
+++ b/desktop/macos/Desktop/Sources/WAL/WALService.swift
@@ -382,9 +382,14 @@ final class WALService: ObservableObject {
             totalFrames: currentFrames.count
         )
 
-        // Check for duplicate
-        if let existingIndex = wals.firstIndex(where: { $0.id == wal.id }) {
-            // Append to existing
+        // Check for duplicate. Two chunks can share a WAL id ("device_second", 1s
+        // resolution) when a second chunk is created within the same wall-clock
+        // second as a prior successful write. They share generateFileName(), so the
+        // duplicate write MUST extend the existing file (append: true below), not
+        // atomically overwrite it — overwriting truncated the earlier ~60s of audio
+        // to just the new buffer while totalFrames claimed the sum.
+        let existingIndex = wals.firstIndex(where: { $0.id == wal.id })
+        if let existingIndex {
             wals[existingIndex].totalFrames += currentFrames.count
             logger.debug("Appended \(self.currentFrames.count) frames to existing WAL")
         } else {
@@ -395,7 +400,8 @@ final class WALService: ObservableObject {
         let framesToWrite = currentFrames
         let syncedToWrite = currentFramesSynced
         frameWriteInProgress = true
-        writeFramesToDiskAsync(frames: framesToWrite, wal: wal) { [weak self] wrote in
+        writeFramesToDiskAsync(frames: framesToWrite, wal: wal, append: existingIndex != nil) {
+            [weak self] wrote in
             guard let self else { return }
             self.frameWriteInProgress = false
             guard wrote else {
@@ -430,9 +436,34 @@ final class WALService: ObservableObject {
         return true
     }
 
+    /// Length-prefix encode frames into the on-disk WAL chunk byte layout
+    /// (`UInt32 little-endian length + frame bytes`, repeated).
+    static func encodeFrames(_ frames: [Data]) -> Data {
+        var fileData = Data()
+        for frame in frames {
+            var length = UInt32(frame.count).littleEndian
+            fileData.append(Data(bytes: &length, count: 4))
+            fileData.append(frame)
+        }
+        return fileData
+    }
+
+    /// Bytes to write for a WAL chunk. When `append` is set and the file already
+    /// has content, the new frames EXTEND it — a duplicate WAL id (same
+    /// device+second) must never atomically overwrite the earlier frames, which
+    /// destroyed the previously-recorded audio.
+    static func frameFileBytes(existing: Data?, frames: [Data], append: Bool) -> Data {
+        let encoded = encodeFrames(frames)
+        if append, let existing, !existing.isEmpty {
+            return existing + encoded
+        }
+        return encoded
+    }
+
     private func writeFramesToDiskAsync(
         frames: [Data],
         wal: WALEntry,
+        append: Bool = false,
         completion: @escaping @MainActor (Bool) -> Void
     ) {
         guard let walDir = walDirectory else {
@@ -445,15 +476,13 @@ final class WALService: ObservableObject {
         let fileUrl = walDir.appendingPathComponent(fileName)
         let walId = wal.id
 
-        var fileData = Data()
-        for frame in frames {
-            var length = UInt32(frame.count).littleEndian
-            fileData.append(Data(bytes: &length, count: 4))
-            fileData.append(frame)
-        }
-
         let frameCount = frames.count
-        DispatchQueue.global(qos: .utility).async { [weak self, fileData] in
+        DispatchQueue.global(qos: .utility).async { [weak self, frames] in
+            // On a duplicate-id append, read the already-persisted frames off the
+            // main thread and extend them; a failed atomic write leaves the prior
+            // file untouched.
+            let existing = append ? try? Data(contentsOf: fileUrl) : nil
+            let fileData = Self.frameFileBytes(existing: existing, frames: frames, append: append)
             let succeeded: Bool
             let failureReason: String?
             do {

--- a/desktop/macos/Desktop/Tests/WALFrameAppendTests.swift
+++ b/desktop/macos/Desktop/Tests/WALFrameAppendTests.swift
@@ -1,0 +1,45 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// Regression test for the WAL duplicate-id data loss: two chunks sharing a WAL id
+/// ("device_second", 1s resolution) share the same on-disk filename, and the
+/// duplicate write atomically OVERWROTE the file with only the new buffer —
+/// destroying the earlier ~60s of recorded audio while totalFrames claimed the
+/// sum. A duplicate-id write must EXTEND the existing file instead.
+final class WALFrameAppendTests: XCTestCase {
+
+  func testEncodeFramesUsesLengthPrefixLayout() {
+    let frames = [Data([0xAA, 0xBB]), Data([0xCC])]
+    let encoded = WALService.encodeFrames(frames)
+    // UInt32-LE length + bytes, per frame: [2,0,0,0, AA,BB, 1,0,0,0, CC]
+    XCTAssertEqual(Array(encoded), [2, 0, 0, 0, 0xAA, 0xBB, 1, 0, 0, 0, 0xCC])
+  }
+
+  func testAppendExtendsExistingBytesInsteadOfOverwriting() {
+    let existing = WALService.encodeFrames([Data([0x01, 0x02])])
+    let newFrames = [Data([0x03])]
+
+    let appended = WALService.frameFileBytes(existing: existing, frames: newFrames, append: true)
+
+    // Prior frames are preserved and the new frame is appended after them.
+    XCTAssertEqual(appended.prefix(existing.count), existing)
+    XCTAssertEqual(appended, existing + WALService.encodeFrames(newFrames))
+    XCTAssertGreaterThan(appended.count, existing.count)
+  }
+
+  func testNonAppendOverwritesWithNewFramesOnly() {
+    let existing = WALService.encodeFrames([Data([0x01, 0x02])])
+    let newFrames = [Data([0x03])]
+
+    // append == false is the fresh-chunk path: only the new frames are written.
+    let bytes = WALService.frameFileBytes(existing: existing, frames: newFrames, append: false)
+    XCTAssertEqual(bytes, WALService.encodeFrames(newFrames))
+  }
+
+  func testAppendWithNoExistingFileWritesNewFramesOnly() {
+    let newFrames = [Data([0x03])]
+    let bytes = WALService.frameFileBytes(existing: nil, frames: newFrames, append: true)
+    XCTAssertEqual(bytes, WALService.encodeFrames(newFrames))
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260711-macos-bug-sweep-4.json
+++ b/desktop/macos/changelog/unreleased/20260711-macos-bug-sweep-4.json
@@ -1,0 +1,3 @@
+{
+    "change": "Fixed audio loss and data races on macOS: duplicate-id recordings no longer overwrite earlier audio, Bluetooth reads/writes no longer race, the Memory graph layout no longer corrupts during render, and legacy Rewind migration no longer drops recent writes"
+}


### PR DESCRIPTION
## Summary

Fourth batch of the macOS bug sweep. Four confirmed defects, each a distinct failure class (data loss on duplicate keys, unsynchronized cross-executor state, off-main mutation racing a render tick, and destructive migration). Each fix closes the class rather than the symptom.

## Fixes

### 1. WAL duplicate-id chunk overwrite destroyed recorded audio (`WALService.swift`)
Two chunks that resolve to the same WAL id (`device_second`, 1s resolution) share one on-disk filename. The duplicate write atomically **overwrote** the file with only the new buffer, destroying the earlier audio while `totalFrames` still claimed the sum. Now a duplicate-id write **extends** the existing frame file (length-prefixed append) instead of clobbering it.
- Testable seam: extracted static `WALService.encodeFrames(_:)` and `frameFileBytes(existing:frames:append:)`.
- Regression test: `WALFrameAppendTests` (length-prefix layout; append extends; non-append overwrites; append-with-no-existing writes new only).

### 2. `BleTransport` continuation dictionaries data-raced (`BleTransport.swift`)
`characteristicContinuations` / `writeContinuations` were read and mutated from both the caller executor and CoreBluetooth delegate callbacks with no synchronization — a torn-read / lost-wakeup hazard that could hang or crash a read/write. Guarded all six access points with an `NSLock`, always resuming continuations **outside** the lock. A continuation displaced by an overwrite now fails deterministically (`.readFailed` / `.writeFailed`) instead of leaking and hanging.

### 3. Memory graph layout corrupted by render tick racing off-main solve (`MemoryGraphPage.swift`)
The SceneKit `updateSimulation()` main-actor tick read/wrote node `SIMD3` positions/velocities while a detached `simulation.runSync(...)` mutated the same arrays off-main — an unsynchronized data race that could scramble node layout. Now `isAnimating` is cleared before each detached solve so the render tick stands down while the off-main run owns the arrays.

### 4. Legacy Rewind migration dropped uncheckpointed source WAL writes (`RewindDatabase.swift`)
`migrateFromLegacyPathIfNeeded` checkpointed the **destination** `omi.db-wal` before deleting it but deleted the **source** WAL outright. After an unclean prior shutdown the source WAL still holds committed-but-uncheckpointed transactions; deleting it rolls the DB back to its last checkpoint, silently losing up to `wal_autocheckpoint` (~4MB) of recent writes before the DB is migrated. Now the source WAL is folded into `omi.db` with `PRAGMA wal_checkpoint(TRUNCATE)` before the deletion loop, mirroring the destination checkpoint. Path-bound WAL/SHM are still deleted (not moved) — no `SQLITE_IOERR_CORRUPTFS` regression.

## Product invariants affected

- **INV-MEM-1** — cited because the diff touches a path glob under `MemoryGraphPage.swift`. The change is a render-race fix only; it does not alter the three-tier memory vocabulary, so no guard-test change is required.

## Verification

- Static checkers pass at baseline: `check_desktop_test_quality.py`, `check-sources-root-layout.py`, `check-async-after-ratchet.py`, `check-userdefaults-key-ratchet.py`, `desktop-flow-lint.py`, `check-e2e-flow-coverage.py --strict` (all 4 changed Swift files covered).
- `WALFrameAppendTests` added as hermetic regression coverage for fix #1.
- Swift compile/test gating relies on the macOS CI job (`desktop-swift-ci.yml`); the Swift toolchain is unavailable in this environment. Fixes #2–#4 are reasoning-verified against the production code paths; #2 and #4 are structural (lock discipline / checkpoint-before-delete) and #3 mirrors the existing `isAnimating` gating already used elsewhere in the file.

## Notes

Deliberately deferred (documented, not fixed here): the WAL retry-path `totalFrames` metadata overcount is metadata-only — file content is correct after the append fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RAxLsaxtwVNDTWAZFfJp9q)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9490?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

