### PR TITLE
Fix macOS off-main AppleScript, BLE continuation crash, memory delete pagination skip, task reorder flicker (bug sweep #5)

### DIFF
--- a/desktop/macos/Desktop/Sources/AppState/AppState+Permissions.swift
+++ b/desktop/macos/Desktop/Sources/AppState/AppState+Permissions.swift
@@ -111,42 +111,49 @@ extension AppState {
 
   /// Trigger automation permission by attempting to use Apple Events
   nonisolated func triggerAutomationPermission() {
-    // Run a simple AppleScript to trigger the permission prompt
-    // This must be done on a background thread since it's nonisolated
+    // NSAppleScript is main-thread-only; each build+execute below runs on the
+    // main actor. The scripts are tiny (executeAndReturnError blocks only
+    // briefly) and the delays between them stay off-main. Keeping the NSDictionary
+    // error local to each MainActor.run block also avoids crossing a non-Sendable
+    // value back to this detached task.
     Task.detached {
       // First, ensure System Events is running — without it, the TCC prompt won't appear
       // and checkAutomationPermission returns -600 (procNotFound)
-      let launchScript = NSAppleScript(
-        source: """
-              launch application "System Events"
-          """)
-      var launchError: NSDictionary?
-      launchScript?.executeAndReturnError(&launchError)
-      if let launchError = launchError {
-        log("AUTOMATION_TRIGGER: Failed to launch System Events: \(launchError)")
-      } else {
-        log("AUTOMATION_TRIGGER: System Events launched successfully")
+      await MainActor.run {
+        let launchScript = NSAppleScript(
+          source: """
+                launch application "System Events"
+            """)
+        var launchError: NSDictionary?
+        launchScript?.executeAndReturnError(&launchError)
+        if let launchError = launchError {
+          log("AUTOMATION_TRIGGER: Failed to launch System Events: \(launchError)")
+        } else {
+          log("AUTOMATION_TRIGGER: System Events launched successfully")
+        }
       }
 
       // Small delay to let System Events initialize
       try? await Task.sleep(nanoseconds: 500_000_000)
 
       // Now trigger the actual TCC prompt
-      let script = NSAppleScript(
-        source: """
-              tell application "System Events"
-                  return name of first process whose frontmost is true
-              end tell
-          """)
-      var error: NSDictionary?
-      script?.executeAndReturnError(&error)
+      await MainActor.run {
+        let script = NSAppleScript(
+          source: """
+                tell application "System Events"
+                    return name of first process whose frontmost is true
+                end tell
+            """)
+        var error: NSDictionary?
+        script?.executeAndReturnError(&error)
 
-      if let error = error {
-        let errorNum = error[NSAppleScript.errorNumber] as? Int ?? 0
-        let errorMsg = error[NSAppleScript.errorMessage] as? String ?? "unknown"
-        log("AUTOMATION_TRIGGER: AppleScript failed: \(errorNum) - \(errorMsg)")
-      } else {
-        log("AUTOMATION_TRIGGER: AppleScript succeeded, permission may have been granted")
+        if let error = error {
+          let errorNum = error[NSAppleScript.errorNumber] as? Int ?? 0
+          let errorMsg = error[NSAppleScript.errorMessage] as? String ?? "unknown"
+          log("AUTOMATION_TRIGGER: AppleScript failed: \(errorNum) - \(errorMsg)")
+        } else {
+          log("AUTOMATION_TRIGGER: AppleScript succeeded, permission may have been granted")
+        }
       }
 
       // Re-check permission status after the TCC dialog
@@ -394,9 +401,12 @@ extension AppState {
       // -600 (procNotFound) = System Events not running — try to launch it and retry
       if status == -600 {
         log("AUTOMATION_CHECK: status=-600 (procNotFound), launching System Events and retrying...")
-        let launchScript = NSAppleScript(source: "launch application \"System Events\"")
-        var launchError: NSDictionary?
-        launchScript?.executeAndReturnError(&launchError)
+        // NSAppleScript is main-thread-only — build+execute on the main actor.
+        await MainActor.run {
+          let launchScript = NSAppleScript(source: "launch application \"System Events\"")
+          var launchError: NSDictionary?
+          launchScript?.executeAndReturnError(&launchError)
+        }
 
         // Wait for System Events to initialize
         try? await Task.sleep(nanoseconds: 1_000_000_000)

--- a/desktop/macos/Desktop/Sources/Bluetooth/Connections/LimitlessDeviceConnection.swift
+++ b/desktop/macos/Desktop/Sources/Bluetooth/Connections/LimitlessDeviceConnection.swift
@@ -45,8 +45,17 @@ final class LimitlessDeviceConnection: BaseDeviceConnection {
     private var lastAcknowledgedIndex = -1
 
     private var firstFlashPageTimestampMs: Int64?
+    // getStorageStatus() stores its continuation here and it is resumed from two
+    // unsynchronized executors — the 3s timeout Task and the RX parser Task — which
+    // without a lock can BOTH resume the same CheckedContinuation (double-resume
+    // trap / crash) or leak a displaced one. All three fields are guarded by
+    // storageStateLock: capture-and-nil the continuation UNDER the lock, resume it
+    // OUTSIDE (exactly one context wins). The generation tag lets a timeout resume
+    // only its OWN pending call, never a newer one that displaced it.
+    private let storageStateLock = NSLock()
     private var storageState: [String: Int]?
     private var storageStateCompletion: CheckedContinuation<[String: Int]?, Never>?
+    private var storageStateGeneration = 0
     private var lastLedBrightness: Int?
 
     // MARK: - Initialization
@@ -621,9 +630,12 @@ final class LimitlessDeviceConnection: BaseDeviceConnection {
                         guard statusLength >= 5, statusLength <= 500, innerPos + statusLength <= data.count else { return }
 
                         if let state = parseStorageStateFromDeviceStatus(data, start: innerPos, end: innerPos + statusLength) {
+                            storageStateLock.lock()
                             storageState = state
-                            storageStateCompletion?.resume(returning: state)
+                            let completion = storageStateCompletion
                             storageStateCompletion = nil
+                            storageStateLock.unlock()
+                            completion?.resume(returning: state)
                         }
                         return
                     }
@@ -863,14 +875,30 @@ final class LimitlessDeviceConnection: BaseDeviceConnection {
 
             // Wait for response with timeout
             return await withCheckedContinuation { continuation in
+                storageStateLock.lock()
+                let displaced = storageStateCompletion
+                storageStateGeneration += 1
+                let myGeneration = storageStateGeneration
                 storageStateCompletion = continuation
+                storageStateLock.unlock()
+                // A prior in-flight getStorageStatus would otherwise be leaked (its
+                // continuation overwritten, never resumed) — resolve it with nil.
+                displaced?.resume(returning: nil)
 
                 Task {
                     try? await Task.sleep(nanoseconds: 3_000_000_000)
-                    if storageStateCompletion != nil {
-                        storageStateCompletion?.resume(returning: storageState)
+                    storageStateLock.lock()
+                    var timedOut: CheckedContinuation<[String: Int]?, Never>?
+                    var snapshot: [String: Int]?
+                    // Only fire if OUR call is still the pending one (a newer call
+                    // would have bumped the generation and owns the slot now).
+                    if storageStateGeneration == myGeneration, let completion = storageStateCompletion {
+                        timedOut = completion
                         storageStateCompletion = nil
+                        snapshot = storageState
                     }
+                    storageStateLock.unlock()
+                    timedOut?.resume(returning: snapshot)
                 }
             }
         } catch {

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoriesPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoriesPage.swift
@@ -1179,6 +1179,16 @@ class MemoriesViewModel: ObservableObject {
       undoTimeRemaining = 4
     }
 
+    // The soft-delete above immediately drops this row from getLocalMemories(), so
+    // the SQLite paging cursor is now one position too high — the next loadMore()
+    // would skip the item that shifted into the old cursor slot. Back the
+    // visible/cache cursor off by one. (rawBackendOffset is adjusted separately in
+    // performActualDelete, only after the backend row is actually removed, because
+    // the backend still holds the row during the undo window.) Undo and
+    // delete-failure both call reloadForCurrentLayerFilter(), which recomputes
+    // currentOffset from offset 0, so this decrement safely unwinds.
+    currentOffset = max(0, currentOffset - 1)
+
     // Start countdown timer
     deleteTask = Task {
       // Update countdown every 100ms
@@ -1242,6 +1252,12 @@ class MemoriesViewModel: ObservableObject {
     do {
       try await APIClient.shared.deleteMemory(id: memory.id)
       AnalyticsManager.shared.memoryDeleted(conversationId: memory.id)
+      // The backend row is now gone, so the raw backend paging cursor is one
+      // position too high — decrement it so the next API-backed loadMore() doesn't
+      // skip the item that shifted into the old cursor slot. Done here rather than
+      // in the optimistic block because the backend still holds the row during the
+      // undo window; decrementing earlier would re-fetch and duplicate it.
+      rawBackendOffset = max(0, rawBackendOffset - 1)
     } catch {
       logError("Failed to delete memory", error: error)
       do {

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/TasksPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/TasksPage.swift
@@ -727,6 +727,14 @@ class TasksViewModel: ObservableObject {
     private let loadMoreThrottleInterval: TimeInterval = 0.5
     /// Guards against transient DB re-query flicker during optimistic bulk updates.
     private var suppressDatabaseRequery = false
+    /// Ownership token for `suppressDatabaseRequery`. Each drag/reorder that sets
+    /// suppression bumps this; the async sync that clears suppression captures the
+    /// token and only clears if it still matches. Without it, an earlier sync's
+    /// post-await `defer` clears suppression that a newer, still-pending drag needs,
+    /// letting a stale SQLite requery overwrite the newer order (flicker). A plain
+    /// depth counter cannot be used because scheduleSortOrderSync cancels
+    /// intermediate sync tasks, so set/clear pairs would be unbalanced.
+    private var suppressRequeryGeneration = 0
 
     /// Automation-only (TASK-06): counts real SQLite requeries so a harness can
     /// prove a server-push recompute during an active drag is suppressed.
@@ -967,6 +975,7 @@ class TasksViewModel: ObservableObject {
         // (debounced 500ms) writes the new sortOrders to SQLite. The flag is
         // cleared via defer inside syncSortOrders once SQLite is fresh.
         suppressDatabaseRequery = true
+        suppressRequeryGeneration += 1
         recomputeDisplayCaches()
 
         // Schedule debounced sync to SQLite + backend
@@ -1207,13 +1216,19 @@ class TasksViewModel: ObservableObject {
     /// Collect current sort orders from all categories and write to SQLite + backend
     private func syncSortOrders() async {
         // moveTask sets suppressDatabaseRequery=true to block stale SQLite requeries
-        // during the debounce window. Always reset on exit (incl. errors / cancellation)
-        // so we don't leave the flag stuck on for unrelated callers.
+        // during the debounce window. Capture the ownership token at entry and only
+        // clear if it still matches — a newer drag that bumped the generation while
+        // we were awaiting owns suppression now, and clearing it here would let a
+        // stale requery revert the newer order. Always reset otherwise (incl.
+        // errors / cancellation) so we don't leave the flag stuck on.
+        let gen = suppressRequeryGeneration
         defer {
-            suppressDatabaseRequery = false
+            if gen == suppressRequeryGeneration {
+                suppressDatabaseRequery = false
+            }
             // Recompute caches after syncing sort orders. When non-status filters are
-            // active, recomputeAllCaches will now re-query SQLite (the flag is cleared)
-            // and pick up any membership changes that happened during the debounce window.
+            // active, recomputeAllCaches will now re-query SQLite (if the flag is
+            // cleared) and pick up any membership changes from the debounce window.
             recomputeAllCaches()
         }
         let updates = collectSortOrderUpdates()
@@ -1307,8 +1322,13 @@ class TasksViewModel: ObservableObject {
                 return
             }
             self.suppressDatabaseRequery = true
+            self.suppressRequeryGeneration += 1
+            let gen = self.suppressRequeryGeneration
             defer {
-                self.suppressDatabaseRequery = false
+                // Only clear if a newer drag hasn't taken ownership (see syncSortOrders).
+                if gen == self.suppressRequeryGeneration {
+                    self.suppressDatabaseRequery = false
+                }
                 self.recomputeAllCaches()
             }
             await self.syncSortOrderUpdates(updates)

--- a/desktop/macos/Desktop/Sources/Providers/ChatToolExecutor.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatToolExecutor.swift
@@ -1693,18 +1693,24 @@ class ChatToolExecutor {
 
   private static func triggerAutomationPermissionDirectly() {
     Task.detached {
-      let launchScript = NSAppleScript(source: "launch application \"System Events\"")
-      var launchError: NSDictionary?
-      launchScript?.executeAndReturnError(&launchError)
+      // NSAppleScript is main-thread-only — build+execute each script on the main
+      // actor; the delay between them stays off-main.
+      await MainActor.run {
+        let launchScript = NSAppleScript(source: "launch application \"System Events\"")
+        var launchError: NSDictionary?
+        launchScript?.executeAndReturnError(&launchError)
+      }
       try? await Task.sleep(nanoseconds: 500_000_000)
-      let script = NSAppleScript(
-        source: """
-          tell application "System Events"
-            return name of first process whose frontmost is true
-          end tell
-          """)
-      var error: NSDictionary?
-      script?.executeAndReturnError(&error)
+      await MainActor.run {
+        let script = NSAppleScript(
+          source: """
+            tell application "System Events"
+              return name of first process whose frontmost is true
+            end tell
+            """)
+        var error: NSDictionary?
+        script?.executeAndReturnError(&error)
+      }
       if let url = URL(
         string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Automation")
       {

--- a/desktop/macos/changelog/unreleased/20260711-macos-bug-sweep-5.json
+++ b/desktop/macos/changelog/unreleased/20260711-macos-bug-sweep-5.json
@@ -1,0 +1,3 @@
+{
+    "change": "Fixed more macOS defects: the Automation permission prompt is now reliably triggered on the main thread, deleting a memory no longer skips one memory the next time the list pages, rapid task reordering no longer briefly flickers back to the old order, and a Limitless storage-status check no longer risks a crash"
+}

--- a/desktop/macos/e2e/flows/screen-recording-permission.yaml
+++ b/desktop/macos/e2e/flows/screen-recording-permission.yaml
@@ -9,6 +9,7 @@ covers:
   - desktop/macos/Desktop/Sources/ScreenCaptureService.swift
   - desktop/macos/Desktop/Sources/MainWindow/Pages/PermissionsPage.swift
   - desktop/macos/Desktop/Sources/AppState/AppState+SystemActions.swift
+  - desktop/macos/Desktop/Sources/AppState/AppState+Permissions.swift
   - desktop/macos/Desktop/Sources/AppState/AppState+TrialPaywall.swift
   - desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Components/SettingsContentView+BillingHelpers.swift
   - desktop/macos/Desktop/Sources/MainWindow/RewindOnlyView.swift


### PR DESCRIPTION
## Summary

Fifth batch of the macOS bug sweep, working through the previously-deferred findings. Four confirmed defects, each fixed at the failure boundary. The remaining deferrals are re-scoped into focused follow-ups (see below) because they need a local build or carry wide blast radius — not appropriate to land blind here (this environment has no Swift toolchain; macOS CI is the compile/test gate).

## Fixes

### 1. NSAppleScript run off the main thread (`AppState+Permissions.swift`, `ChatToolExecutor.swift`)
`triggerAutomationPermission`, `checkAutomationPermission`, and `ChatToolExecutor.triggerAutomationPermissionDirectly` all built and executed `NSAppleScript` inside `Task.detached` on a background cooperative thread. `NSAppleScript` is main-thread-only; off-main execution is undefined behavior, and since these paths are exactly what raises the Automation (Apple Events) TCC prompt, it can make the prompt silently fail to appear. Each `NSAppleScript` build+`executeAndReturnError` now runs in `await MainActor.run`; the inter-script delays and the thread-safe `AEDeterminePermissionToAutomateTarget` queries stay off-main. The `NSDictionary` error stays local to each block so no non-Sendable value crosses back to the detached task.

### 2. Limitless storage-status continuation double-resume (`LimitlessDeviceConnection.swift`)
`getStorageStatus` stored its `CheckedContinuation` in an unsynchronized `var` on a non-actor class and resumed it from two parallel executors — the 3s timeout `Task` and the RX parser `Task`. Both could resume the same continuation (double-resume trap → crash), and an overlapping call leaked the first continuation (hang). Guarded `storageState`/`storageStateCompletion` with an `NSLock` using the same capture-under-lock / resume-outside single-winner pattern as `BleTransport`, plus a generation tag so a timeout only resolves its own pending call and a displaced continuation is resumed with `nil` instead of leaked.

### 3. Memory pagination skipped one item per delete (`MemoriesPage.swift`)
Deleting a memory soft-deleted it in SQLite immediately (excluded from `getLocalMemories`) and removed it from the visible arrays, but never adjusted the paging cursors, so the next `loadMore()` skipped the item that shifted into the old cursor slot — one memory silently vanished from pagination per delete. Now `currentOffset` is decremented in the optimistic block (SQLite soft-delete is immediate) and `rawBackendOffset` in `performActualDelete` after the backend DELETE succeeds (the backend still holds the row during the undo window, so decrementing earlier would re-fetch and duplicate it). Undo and delete-failure both call `reloadForCurrentLayerFilter()`, which recomputes `currentOffset` from offset 0, so the decrement unwinds safely.

### 4. Task reorder flicker from shared suppression flag (`TasksPage.swift`)
`suppressDatabaseRequery` is a single boolean set by a reorder but cleared by a different, later-running async sync's post-`await` `defer`. Two reorders within the debounce+network window collide: reorder #2 re-sets the flag, then reorder #1's earlier sync clears it while #2 is still pending, and the ensuing filtered SQLite requery overwrites the display with #1's stale order. Added a monotonic `suppressRequeryGeneration` bumped at each suppress site; the async sync clears only if its captured token still matches, so only the newest suppressor lifts suppression. A depth counter can't be used because `scheduleSortOrderSync` cancels intermediate sync tasks (unbalanced set/clear). The automation harness manages the flag directly and is unaffected.

## Not a bug (verified, no change)
- **AppState+Transcription `guard !isTranscribing` / `isTranscribing = true`** — investigated as a possible TOCTOU; it is safe. The function is `@MainActor` and synchronous with no `await` between the check and the set, so it's atomic. No fix.

## Product invariants
- **INV-CHAT-1** — cited because the diff touches `ChatToolExecutor.swift` (a path glob). The change there is the off-main→main-thread move of the Automation-permission AppleScript trigger; it does not touch the chat write-path, kernel projection, floating viewport, or agent timeline identity, so no continuity-DoD guard-test change is required.

## Deliberately deferred to focused follow-ups (not fixed here)
These are confirmed real, but each needs more than a blind edit in a no-toolchain environment:
- **TaskAgentManager `activeSessions`/`pollingTasks` data race** — real (background polling `Task` reads the dictionaries off-main while main-actor Stop removes entries). The correct fix marks the class `@MainActor` and makes the five `waitUntilExit` subprocess helpers `nonisolated`/off-main — a whole-class isolation refactor that should be built and run locally (and exercised via `agent-logic-harness.sh`) before landing. Tracking separately.
- **PushToTalkManager text-based transcript dedup** + **ChatMessagesView prepend-anchor restore** — both real and both INV-CHAT-1 chat-surface changes that warrant a maintainer continuity-gauntlet run, which needs a live named bundle unavailable here.
- **RewindDatabase stale-pool-after-recovery** — real; 10 storage actors cache `_dbQueue` and only invalidate on sign-out, not on the corruption/maintenance recovery paths. The generation-revalidation fix touches ~11 files of DB access and deserves its own reviewable PR with a local run.

## Verification
- Static checkers pass at baseline: `check_desktop_test_quality.py`, `check-sources-root-layout.py`, `check-async-after-ratchet.py`, `check-userdefaults-key-ratchet.py`, `desktop-flow-lint.py`, `check-e2e-flow-coverage.py --strict` (all 5 changed Swift files covered; added `AppState+Permissions.swift` to `screen-recording-permission.yaml`).
- Swift compile/test gates on macOS CI (`desktop-swift-ci.yml`); no Swift toolchain in this environment. Fixes are reasoning-verified against the production paths, and #2/#4 reuse patterns already proven in this codebase (BleTransport lock discipline; generation-token ownership). #1 and #2 close crash/UB classes; #3 is a two-site cursor adjustment matching the existing raw-vs-visible cursor semantics; #4 mirrors the existing debounce/defer structure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RAxLsaxtwVNDTWAZFfJp9q)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9492?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

