### PR TITLE
Fix TaskAgentManager activeSessions data race via @MainActor isolation (draft — needs local build)

### DIFF
--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskAgent/TaskAgentManager.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskAgent/TaskAgentManager.swift
@@ -1,7 +1,17 @@
 import Foundation
 import Combine
 
-/// Manages Claude Code agent sessions for code-related tasks
+/// Manages Claude Code agent sessions for code-related tasks.
+///
+/// Isolated to `@MainActor`: `activeSessions` (`@Published`, drives SwiftUI) and
+/// `pollingTasks` were previously mutated on the main actor but READ off-main from
+/// the background polling `Task`, an unsynchronized `Dictionary` data race that
+/// could crash when Stop/restart removed an entry while a poll read it. Making the
+/// whole type main-actor-isolated gives both collections a single executor. The
+/// blocking `tmux`/`Process` helpers are marked `nonisolated` and their call sites
+/// hop off-main (`Task.detached`) so the subprocess `waitUntilExit()` never blocks
+/// the main thread.
+@MainActor
 class TaskAgentManager: ObservableObject {
     static let shared = TaskAgentManager()
 
@@ -132,7 +142,9 @@ class TaskAgentManager: ObservableObject {
             return
         }
         logMessage("TaskAgentManager: Opening terminal for \(session.sessionName)")
-        openTmuxSessionInTerminal(sessionName: session.sessionName)
+        // Runs blocking Process work — hop off the main actor.
+        let sessionName = session.sessionName
+        Task.detached { self.openTmuxSessionInTerminal(sessionName: sessionName) }
     }
 
     /// Update prompt and restart agent
@@ -146,8 +158,8 @@ class TaskAgentManager: ObservableObject {
         pollingTasks[taskId]?.cancel()
         pollingTasks[taskId] = nil
 
-        // Kill existing session
-        killTmuxSession(sessionName: sessionName)
+        // Kill existing session off the main actor.
+        await Task.detached { self.killTmuxSession(sessionName: sessionName) }.value
 
         // Update session directly in activeSessions
         await MainActor.run {
@@ -181,8 +193,9 @@ class TaskAgentManager: ObservableObject {
         pollingTasks[taskId]?.cancel()
         pollingTasks[taskId] = nil
 
-        // Kill tmux session
-        killTmuxSession(sessionName: session.sessionName)
+        // Kill tmux session off the main actor (best-effort, fire-and-forget).
+        let sessionName = session.sessionName
+        Task.detached { self.killTmuxSession(sessionName: sessionName) }
 
         // Remove from active sessions
         activeSessions.removeValue(forKey: taskId)
@@ -211,7 +224,8 @@ class TaskAgentManager: ObservableObject {
         TaskAgentSettings.shared.buildTaskPrompt(for: task)
     }
 
-    private func launchTmuxSession(sessionName: String, prompt: String, workingDir: String) async throws {
+    // nonisolated: blocking Process/waitUntilExit work must run off the main actor.
+    nonisolated private func launchTmuxSession(sessionName: String, prompt: String, workingDir: String) async throws {
         // Kill any stale tmux session with the same name (e.g. survived an app restart)
         killTmuxSession(sessionName: sessionName)
 
@@ -307,7 +321,8 @@ class TaskAgentManager: ObservableObject {
 
                 guard !Task.isCancelled else { break }
 
-                let rawOutput = self.readTmuxOutput(sessionName: sessionName)
+                // Offload the blocking tmux capture off the main actor.
+                let rawOutput = await Task.detached { self.readTmuxOutput(sessionName: sessionName) }.value
                 // Cap stored output to 100KB — tmux scrollback can grow very large
                 let maxOutputSize = 100_000
                 let output = rawOutput.count > maxOutputSize
@@ -370,8 +385,9 @@ class TaskAgentManager: ObservableObject {
                     }
                 }
 
-                // Check if session still exists
-                if !self.isSessionAlive(sessionName: sessionName) {
+                // Check if session still exists (blocking tmux query off the main actor)
+                let sessionAlive = await Task.detached { self.isSessionAlive(sessionName: sessionName) }.value
+                if !sessionAlive {
                     await MainActor.run {
                         let status = self.activeSessions[taskId]?.status
                         if status == .processing || status == .editing {
@@ -394,7 +410,8 @@ class TaskAgentManager: ObservableObject {
         pollingTasks[taskId] = task
     }
 
-    private func readTmuxOutput(sessionName: String) -> String {
+    // nonisolated: blocking Process/waitUntilExit — call off the main actor.
+    nonisolated private func readTmuxOutput(sessionName: String) -> String {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/bin/zsh")
         process.arguments = ["-c", "source ~/.zprofile 2>/dev/null; tmux capture-pane -t '\(sessionName)' -p -S -500 2>/dev/null"]
@@ -409,7 +426,8 @@ class TaskAgentManager: ObservableObject {
         return String(data: data, encoding: .utf8) ?? ""
     }
 
-    private func isSessionAlive(sessionName: String) -> Bool {
+    // nonisolated: blocking Process/waitUntilExit — call off the main actor.
+    nonisolated private func isSessionAlive(sessionName: String) -> Bool {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/bin/zsh")
         process.arguments = ["-c", "source ~/.zprofile 2>/dev/null; tmux has-session -t '\(sessionName)' 2>/dev/null"]
@@ -488,7 +506,8 @@ class TaskAgentManager: ObservableObject {
         return String(output.suffix(2000))
     }
 
-    private func openTmuxSessionInTerminal(sessionName: String) {
+    // nonisolated: blocking Process work (isSessionAlive) — call off the main actor.
+    nonisolated private func openTmuxSessionInTerminal(sessionName: String) {
         // Check if session is alive before opening terminal
         guard isSessionAlive(sessionName: sessionName) else {
             logMessage("TaskAgentManager: Cannot open terminal - session '\(sessionName)' does not exist")
@@ -519,7 +538,8 @@ class TaskAgentManager: ObservableObject {
         }
     }
 
-    private func killTmuxSession(sessionName: String) {
+    // nonisolated: blocking Process/waitUntilExit — call off the main actor.
+    nonisolated private func killTmuxSession(sessionName: String) {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/bin/zsh")
         process.arguments = ["-c", "source ~/.zprofile 2>/dev/null; tmux kill-session -t '\(sessionName)' 2>/dev/null"]
@@ -528,7 +548,8 @@ class TaskAgentManager: ObservableObject {
         process.waitUntilExit()
     }
 
-    private func logMessage(_ message: String) {
+    // nonisolated: pure logging shim, safe to call from the nonisolated helpers.
+    nonisolated private func logMessage(_ message: String) {
         log(message)
     }
 
@@ -606,12 +627,13 @@ class TaskAgentManager: ObservableObject {
                     editedFiles: record.agentEditedFiles
                 )
 
-                if isSessionAlive(sessionName: sessionName) {
+                let sessionAlive = await Task.detached { self.isSessionAlive(sessionName: sessionName) }.value
+                if sessionAlive {
                     // Check if the session is actually idle (Claude waiting at prompt)
-                    // by reading output twice with a short delay
-                    let output1 = readTmuxOutput(sessionName: sessionName)
+                    // by reading output twice with a short delay (blocking reads off-main)
+                    let output1 = await Task.detached { self.readTmuxOutput(sessionName: sessionName) }.value
                     try? await Task.sleep(nanoseconds: 2_000_000_000) // 2 seconds
-                    let output2 = readTmuxOutput(sessionName: sessionName)
+                    let output2 = await Task.detached { self.readTmuxOutput(sessionName: sessionName) }.value
 
                     if output1 == output2 && !output1.isEmpty {
                         // Output unchanged — session is idle, mark completed without polling

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskAgent/TaskAgentManager.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskAgent/TaskAgentManager.swift
@@ -116,7 +116,7 @@ class TaskAgentManager: ObservableObject {
 
         // Launch tmux session with Claude
         do {
-            try await launchTmuxSession(sessionName: sessionName, prompt: prompt, workingDir: context.workingDirectory)
+            try await Self.launchTmuxSession(sessionName: sessionName, prompt: prompt, workingDir: context.workingDirectory)
 
             await MainActor.run {
                 activeSessions[task.id]?.status = .processing
@@ -144,7 +144,7 @@ class TaskAgentManager: ObservableObject {
         logMessage("TaskAgentManager: Opening terminal for \(session.sessionName)")
         // Runs blocking Process work — hop off the main actor.
         let sessionName = session.sessionName
-        Task.detached { self.openTmuxSessionInTerminal(sessionName: sessionName) }
+        Task.detached { Self.openTmuxSessionInTerminal(sessionName: sessionName) }
     }
 
     /// Update prompt and restart agent
@@ -159,7 +159,7 @@ class TaskAgentManager: ObservableObject {
         pollingTasks[taskId] = nil
 
         // Kill existing session off the main actor.
-        await Task.detached { self.killTmuxSession(sessionName: sessionName) }.value
+        await Task.detached { Self.killTmuxSession(sessionName: sessionName) }.value
 
         // Update session directly in activeSessions
         await MainActor.run {
@@ -173,7 +173,7 @@ class TaskAgentManager: ObservableObject {
         }
         if let s = activeSessions[taskId] { persistSession(s) }
 
-        try await launchTmuxSession(sessionName: sessionName, prompt: newPrompt, workingDir: context.workingDirectory)
+        try await Self.launchTmuxSession(sessionName: sessionName, prompt: newPrompt, workingDir: context.workingDirectory)
 
         await MainActor.run {
             activeSessions[taskId]?.status = .processing
@@ -195,7 +195,7 @@ class TaskAgentManager: ObservableObject {
 
         // Kill tmux session off the main actor (best-effort, fire-and-forget).
         let sessionName = session.sessionName
-        Task.detached { self.killTmuxSession(sessionName: sessionName) }
+        Task.detached { Self.killTmuxSession(sessionName: sessionName) }
 
         // Remove from active sessions
         activeSessions.removeValue(forKey: taskId)
@@ -224,8 +224,10 @@ class TaskAgentManager: ObservableObject {
         TaskAgentSettings.shared.buildTaskPrompt(for: task)
     }
 
-    // nonisolated: blocking Process/waitUntilExit work must run off the main actor.
-    nonisolated private func launchTmuxSession(sessionName: String, prompt: String, workingDir: String) async throws {
+    // static + nonisolated: blocking Process/waitUntilExit work runs off the main
+    // actor, and being static means Task.detached call sites capture only Sendable
+    // values (never the main-actor-isolated `self`).
+    nonisolated private static func launchTmuxSession(sessionName: String, prompt: String, workingDir: String) async throws {
         // Kill any stale tmux session with the same name (e.g. survived an app restart)
         killTmuxSession(sessionName: sessionName)
 
@@ -287,11 +289,11 @@ class TaskAgentManager: ObservableObject {
 
         guard process.terminationStatus == 0 else {
             let output = String(data: pipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
-            logMessage("TaskAgentManager: tmux launch failed - \(output)")
+            log("TaskAgentManager: tmux launch failed - \(output)")
             throw AgentError.launchFailed(output)
         }
 
-        logMessage("TaskAgentManager: Launched tmux session '\(sessionName)'")
+        log("TaskAgentManager: Launched tmux session '\(sessionName)'")
 
         // Wait for Claude to initialize
         try await Task.sleep(nanoseconds: 3_000_000_000) // 3 seconds
@@ -322,7 +324,7 @@ class TaskAgentManager: ObservableObject {
                 guard !Task.isCancelled else { break }
 
                 // Offload the blocking tmux capture off the main actor.
-                let rawOutput = await Task.detached { self.readTmuxOutput(sessionName: sessionName) }.value
+                let rawOutput = await Task.detached { Self.readTmuxOutput(sessionName: sessionName) }.value
                 // Cap stored output to 100KB — tmux scrollback can grow very large
                 let maxOutputSize = 100_000
                 let output = rawOutput.count > maxOutputSize
@@ -386,7 +388,7 @@ class TaskAgentManager: ObservableObject {
                 }
 
                 // Check if session still exists (blocking tmux query off the main actor)
-                let sessionAlive = await Task.detached { self.isSessionAlive(sessionName: sessionName) }.value
+                let sessionAlive = await Task.detached { Self.isSessionAlive(sessionName: sessionName) }.value
                 if !sessionAlive {
                     await MainActor.run {
                         let status = self.activeSessions[taskId]?.status
@@ -410,8 +412,8 @@ class TaskAgentManager: ObservableObject {
         pollingTasks[taskId] = task
     }
 
-    // nonisolated: blocking Process/waitUntilExit — call off the main actor.
-    nonisolated private func readTmuxOutput(sessionName: String) -> String {
+    // static + nonisolated: blocking Process/waitUntilExit — off-main, Sendable-capture-safe.
+    nonisolated private static func readTmuxOutput(sessionName: String) -> String {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/bin/zsh")
         process.arguments = ["-c", "source ~/.zprofile 2>/dev/null; tmux capture-pane -t '\(sessionName)' -p -S -500 2>/dev/null"]
@@ -426,8 +428,8 @@ class TaskAgentManager: ObservableObject {
         return String(data: data, encoding: .utf8) ?? ""
     }
 
-    // nonisolated: blocking Process/waitUntilExit — call off the main actor.
-    nonisolated private func isSessionAlive(sessionName: String) -> Bool {
+    // static + nonisolated: blocking Process/waitUntilExit — off-main, Sendable-capture-safe.
+    nonisolated private static func isSessionAlive(sessionName: String) -> Bool {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/bin/zsh")
         process.arguments = ["-c", "source ~/.zprofile 2>/dev/null; tmux has-session -t '\(sessionName)' 2>/dev/null"]
@@ -506,11 +508,11 @@ class TaskAgentManager: ObservableObject {
         return String(output.suffix(2000))
     }
 
-    // nonisolated: blocking Process work (isSessionAlive) — call off the main actor.
-    nonisolated private func openTmuxSessionInTerminal(sessionName: String) {
+    // static + nonisolated: blocking Process work (isSessionAlive) — off-main, Sendable-capture-safe.
+    nonisolated private static func openTmuxSessionInTerminal(sessionName: String) {
         // Check if session is alive before opening terminal
         guard isSessionAlive(sessionName: sessionName) else {
-            logMessage("TaskAgentManager: Cannot open terminal - session '\(sessionName)' does not exist")
+            log("TaskAgentManager: Cannot open terminal - session '\(sessionName)' does not exist")
             return
         }
 
@@ -530,7 +532,7 @@ class TaskAgentManager: ObservableObject {
         process.arguments = ["-e", script]
 
         try? process.run()
-        logMessage("TaskAgentManager: Opened terminal for session '\(sessionName)'")
+        log("TaskAgentManager: Opened terminal for session '\(sessionName)'")
 
         // Remove flag file after Terminal has started (delay to ensure .zshrc has been sourced)
         DispatchQueue.global().asyncAfter(deadline: .now() + 3.0) {
@@ -538,8 +540,8 @@ class TaskAgentManager: ObservableObject {
         }
     }
 
-    // nonisolated: blocking Process/waitUntilExit — call off the main actor.
-    nonisolated private func killTmuxSession(sessionName: String) {
+    // static + nonisolated: blocking Process/waitUntilExit — off-main, Sendable-capture-safe.
+    nonisolated private static func killTmuxSession(sessionName: String) {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/bin/zsh")
         process.arguments = ["-c", "source ~/.zprofile 2>/dev/null; tmux kill-session -t '\(sessionName)' 2>/dev/null"]
@@ -627,13 +629,13 @@ class TaskAgentManager: ObservableObject {
                     editedFiles: record.agentEditedFiles
                 )
 
-                let sessionAlive = await Task.detached { self.isSessionAlive(sessionName: sessionName) }.value
+                let sessionAlive = await Task.detached { Self.isSessionAlive(sessionName: sessionName) }.value
                 if sessionAlive {
                     // Check if the session is actually idle (Claude waiting at prompt)
                     // by reading output twice with a short delay (blocking reads off-main)
-                    let output1 = await Task.detached { self.readTmuxOutput(sessionName: sessionName) }.value
+                    let output1 = await Task.detached { Self.readTmuxOutput(sessionName: sessionName) }.value
                     try? await Task.sleep(nanoseconds: 2_000_000_000) // 2 seconds
-                    let output2 = await Task.detached { self.readTmuxOutput(sessionName: sessionName) }.value
+                    let output2 = await Task.detached { Self.readTmuxOutput(sessionName: sessionName) }.value
 
                     if output1 == output2 && !output1.isEmpty {
                         // Output unchanged — session is idle, mark completed without polling

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskAgent/TaskAgentSettings.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskAgent/TaskAgentSettings.swift
@@ -89,6 +89,10 @@ class TaskAgentSettings: ObservableObject {
     }
 
     /// Legacy tmux prompt builder retained until Ticket 14 removes that path.
+    /// `@MainActor` because it reads `TaskAgentManager.shared.getSession`, which is
+    /// now main-actor-isolated; the sole caller (`TaskAgentManager.buildPrompt`) is
+    /// already on the main actor.
+    @MainActor
     func buildTaskPrompt(for task: TaskActionItem) -> String {
         var prompt = buildCanonicalTaskPrompt(for: task)
 

--- a/desktop/macos/changelog/unreleased/20260711-taskagent-mainactor-race.json
+++ b/desktop/macos/changelog/unreleased/20260711-taskagent-mainactor-race.json
@@ -1,0 +1,3 @@
+{
+    "change": "Fixed a rare crash when stopping or restarting a running task agent while it was being polled for progress"
+}

--- a/desktop/macos/e2e/flows/tasks.yaml
+++ b/desktop/macos/e2e/flows/tasks.yaml
@@ -14,6 +14,7 @@ covers:
   - desktop/macos/Desktop/Sources/MainWindow/Tasks/SuggestedTasksSection.swift
   - desktop/macos/Desktop/Sources/MainWindow/Tasks/SuggestedTasksStore.swift
   - desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskAgent/TaskAgentSettings.swift
+  - desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskAgent/TaskAgentManager.swift
   - desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskAgent/TaskChatCoordinator.swift
   - desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskAgent/TaskChatRuntime.swift
   - desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskAgent/TaskThreadProjection.swift


### PR DESCRIPTION
## Summary

Follow-up #1 of 3 from the macOS bug-sweep deferrals. Fixes the `TaskAgentManager` `activeSessions`/`pollingTasks` data race by isolating the type to `@MainActor`.

> **⚠️ Draft — needs a local build to verify.** This was authored in an environment with no Swift toolchain, so it has **not been compiled**. The `@MainActor` isolation change can surface additional cross-file adjustments the compiler will flag. Please build (`cd desktop/macos && xcrun swift build -c debug --package-path Desktop`) and exercise via `./scripts/agent-logic-harness.sh` before merge.

## The bug

`TaskAgentManager` is an `ObservableObject` (not `@MainActor`). `activeSessions` (`@Published`, drives SwiftUI) and `pollingTasks` were **written** on the main actor (each write wrapped in `await MainActor.run`) but **read off-main** from the background polling `Task` (e.g. `self.activeSessions[taskId]?.status`, `if let session = self.activeSessions[taskId]`). A `Dictionary` read on the polling executor concurrent with a main-actor `removeValue` (Stop button / restart) is a data race — torn read, over-release, or `EXC_BAD_ACCESS`. The `MainActor.run` wrapping gave false safety: it serialized writes against each other but did nothing for the reads.

## The fix

- Mark the whole type **`@MainActor`** so `activeSessions` and `pollingTasks` share one executor; the background polling `Task` inherits main-actor isolation, so its reads are now serialized.
- Mark the five blocking `tmux`/`Process` helpers (`launchTmuxSession`, `readTmuxOutput`, `isSessionAlive`, `killTmuxSession`, `openTmuxSessionInTerminal`) and the `logMessage` shim **`nonisolated`**, and hop their call sites **off-main** via `Task.detached` so `process.waitUntilExit()` never blocks the main thread (the pollers run every 5s).
- `TaskAgentSettings.buildTaskPrompt` is marked `@MainActor` for its now-main-actor `getSession` read; its only caller (`TaskAgentManager.buildPrompt`) is already on the main actor.

## Product invariants
- **INV-CHAT-1** — cited because the diff touches `ProactiveAssistants/Assistants/TaskAgent/**` (path globs). The change is thread-safety only; it does not alter agent identity/open, the chat write-path, kernel projection, floating viewport, or pill projection, so no continuity-DoD guard-test change is required.

## Verification
- Static checkers pass at baseline; e2e coverage satisfied (`TaskAgentManager.swift` added to `tasks.yaml`).
- **Not compiled here** (no Swift toolchain). Reviewer build + `agent-logic-harness.sh` is the gate. The data race itself is closed by construction (single executor); the off-main offloads preserve the existing non-blocking-main behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RAxLsaxtwVNDTWAZFfJp9q)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9495?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

