### PR TITLE
Fix chat scroll-jump on load-earlier and PTT dropping repeated words (draft — needs local build)

### DIFF
--- a/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
@@ -1890,11 +1890,17 @@ extension PushToTalkManager: RealtimeOmniServiceDelegate {
       let trimmed = finalText.trimmingCharacters(in: .whitespacesAndNewlines)
       // Dedup by the provider's stable item id (a relay re-delivering the SAME
       // final), NOT by text — keying on text silently dropped legitimately
-      // repeated phrases within a turn ("yes. yes." → "yes"). No id ⇒ treat as
-      // distinct (unique key) so a genuine repeat is never lost.
-      let dedupKey = itemID ?? UUID().uuidString
-      if !trimmed.isEmpty && seenFinalSegmentIDs.insert(dedupKey).inserted {
-        transcriptSegments.append(trimmed)
+      // repeated phrases within a turn ("yes. yes." → "yes"). With no id a final
+      // can't be a relay re-delivery, so always keep it (a genuine repeat is
+      // never lost) rather than minting a throwaway key.
+      if !trimmed.isEmpty {
+        if let itemID {
+          if seenFinalSegmentIDs.insert(itemID).inserted {
+            transcriptSegments.append(trimmed)
+          }
+        } else {
+          transcriptSegments.append(trimmed)
+        }
       }
       lastInterimText = ""
       if state == .finalizing {

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
@@ -117,6 +117,11 @@ class PushToTalkManager: ObservableObject {
   private var silentMicRecoveryPolicy = PTTSilentMicRecoveryPolicy()
   private var micCaptureGeneration: UInt64 = 0
   private var transcriptSegments: [String] = []
+  // Stable provider item ids of finals already appended this turn. Dedup relay
+  // re-deliveries by id, never by text (INV-6: never dedupe by user text), so a
+  // legitimately repeated phrase within a turn is not silently dropped. Reset
+  // wherever transcriptSegments is reset.
+  private var seenFinalSegmentIDs: Set<String> = []
   private var lastInterimText: String = ""
   private var hasMicPermission: Bool = false
   private var isCurrentSessionFollowUp = false
@@ -433,6 +438,7 @@ class PushToTalkManager: ObservableObject {
     startActiveTracer()
     isCurrentSessionFollowUp = barState?.showingAIResponse == true
     transcriptSegments = []
+    seenFinalSegmentIDs.removeAll()
     lastInterimText = ""
     currentContextSnapshot = nil
 
@@ -495,6 +501,7 @@ class PushToTalkManager: ObservableObject {
     if transcriptionService == nil {
       if activeTracer == nil { startActiveTracer() }
       transcriptSegments = []
+      seenFinalSegmentIDs.removeAll()
       lastInterimText = ""
       currentContextSnapshot = nil
       let preOverlayImage = ScreenCaptureManager.captureScreenImage()
@@ -537,6 +544,7 @@ class PushToTalkManager: ObservableObject {
     }
     stopAudioTranscription()
     transcriptSegments = []
+    seenFinalSegmentIDs.removeAll()
     lastInterimText = ""
     currentContextSnapshot = nil
     batchAudioLock.lock()
@@ -1174,6 +1182,7 @@ class PushToTalkManager: ObservableObject {
     isCurrentSessionFollowUp = false
 
     transcriptSegments = []
+    seenFinalSegmentIDs.removeAll()
     lastInterimText = ""
     currentContextSnapshot = nil
 
@@ -1869,7 +1878,7 @@ extension PushToTalkManager: RealtimeOmniServiceDelegate {
     log("PushToTalkManager: omni STT connected")
   }
 
-  func omniDidReceiveInputTranscript(_ text: String, isFinal: Bool) {
+  func omniDidReceiveInputTranscript(_ text: String, isFinal: Bool, itemID: String?) {
     guard let turnID = omniTurnID,
       voiceTurnCoordinator.activeTurnID == turnID
     else { return }
@@ -1879,7 +1888,12 @@ extension PushToTalkManager: RealtimeOmniServiceDelegate {
     if isFinal {
       let finalText = text.isEmpty ? lastInterimText : text
       let trimmed = finalText.trimmingCharacters(in: .whitespacesAndNewlines)
-      if !trimmed.isEmpty && !transcriptSegments.contains(trimmed) {
+      // Dedup by the provider's stable item id (a relay re-delivering the SAME
+      // final), NOT by text — keying on text silently dropped legitimately
+      // repeated phrases within a turn ("yes. yes." → "yes"). No id ⇒ treat as
+      // distinct (unique key) so a genuine repeat is never lost.
+      let dedupKey = itemID ?? UUID().uuidString
+      if !trimmed.isEmpty && seenFinalSegmentIDs.insert(dedupKey).inserted {
         transcriptSegments.append(trimmed)
       }
       lastInterimText = ""

--- a/desktop/macos/Desktop/Sources/MainWindow/Components/ChatMessagesView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Components/ChatMessagesView.swift
@@ -424,8 +424,13 @@ struct ChatMessagesView<WelcomeContent: View>: View {
         guard let anchorId = prependAnchorId else { return }
         prependAnchorId = nil
 
-        // If the user scrolled during the load, don't override their position
-        guard scrollMode != .freeScrolling else { return }
+        // Only bail if the user is *physically* scrolling right now — not on
+        // scrollMode. Prepend ("Load earlier") only happens while reading history,
+        // i.e. scrollMode == .freeScrolling, so guarding on that mode made this
+        // restore (and the scrollTo below) dead code — the viewport jumped on every
+        // page-up. userIsScrolling is the real "don't fight the user's drag" signal
+        // (set by UserScrollDetector, auto-cleared 0.3s after the last wheel event).
+        guard !userIsScrolling else { return }
 
         // Verify the anchor message is still in the list
         let stillExists = messages.contains { $0.id == anchorId }
@@ -433,7 +438,7 @@ struct ChatMessagesView<WelcomeContent: View>: View {
 
         // Scroll anchor to top without animation
         let work = DispatchWorkItem { [self] in
-            guard self.scrollMode != .freeScrolling else { return }
+            guard !self.userIsScrolling else { return }
             proxy.scrollTo(anchorId, anchor: .top)
         }
         initialScrollWorkItems.append(work)

--- a/desktop/macos/Desktop/Sources/MainWindow/Components/ChatMessagesView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Components/ChatMessagesView.swift
@@ -429,7 +429,8 @@ struct ChatMessagesView<WelcomeContent: View>: View {
         // i.e. scrollMode == .freeScrolling, so guarding on that mode made this
         // restore (and the scrollTo below) dead code — the viewport jumped on every
         // page-up. userIsScrolling is the real "don't fight the user's drag" signal
-        // (set by UserScrollDetector, auto-cleared 0.3s after the last wheel event).
+        // (set by UserScrollDetector on any scroll interaction — wheel, drag, or
+        // keyboard scroll — and auto-cleared 0.3s after the last one).
         guard !userIsScrolling else { return }
 
         // Verify the anchor message is still in the list

--- a/desktop/macos/Desktop/Sources/RealtimeOmni/RealtimeOmniService.swift
+++ b/desktop/macos/Desktop/Sources/RealtimeOmni/RealtimeOmniService.swift
@@ -25,7 +25,10 @@ import Network
 @MainActor
 protocol RealtimeOmniServiceDelegate: AnyObject {
     func omniDidConnect()
-    func omniDidReceiveInputTranscript(_ text: String, isFinal: Bool)
+    /// `itemID` is the provider's stable per-utterance id (OpenAI `item_id`) when
+    /// available, else nil. Consumers dedup relay re-deliveries by this id, NOT by
+    /// text, so legitimately repeated phrases within a turn are not dropped.
+    func omniDidReceiveInputTranscript(_ text: String, isFinal: Bool, itemID: String?)
     func omniDidReceiveAudio(_ pcm24k: Data)
     func omniDidFinishTurn()
     func omniDidError(_ message: String)
@@ -328,9 +331,13 @@ final class RealtimeOmniService: NSObject {
         case "response.output_audio.delta":
             if let b64 = e["delta"] as? String, let d = Data(base64Encoded: b64) { delegate?.omniDidReceiveAudio(d) }
         case "conversation.item.input_audio_transcription.delta":
-            if let t = e["delta"] as? String { delegate?.omniDidReceiveInputTranscript(t, isFinal: false) }
+            if let t = e["delta"] as? String {
+                delegate?.omniDidReceiveInputTranscript(t, isFinal: false, itemID: e["item_id"] as? String)
+            }
         case "conversation.item.input_audio_transcription.completed":
-            if let t = e["transcript"] as? String { delegate?.omniDidReceiveInputTranscript(t, isFinal: true) }
+            if let t = e["transcript"] as? String {
+                delegate?.omniDidReceiveInputTranscript(t, isFinal: true, itemID: e["item_id"] as? String)
+            }
         case "response.done":
             delegate?.omniDidFinishTurn()
         case "error":
@@ -346,7 +353,8 @@ final class RealtimeOmniService: NSObject {
         if e["setupComplete"] != nil { markReady(); return }
         guard let sc = e["serverContent"] as? [String: Any] else { return }
         if let it = sc["inputTranscription"] as? [String: Any], let t = it["text"] as? String {
-            delegate?.omniDidReceiveInputTranscript(t, isFinal: false)
+            // Gemini input transcription carries no per-utterance id.
+            delegate?.omniDidReceiveInputTranscript(t, isFinal: false, itemID: nil)
         }
         if let parts = (sc["modelTurn"] as? [String: Any])?["parts"] as? [[String: Any]] {
             for p in parts {
@@ -358,7 +366,8 @@ final class RealtimeOmniService: NSObject {
             }
         }
         if (sc["turnComplete"] as? Bool) == true {
-            delegate?.omniDidReceiveInputTranscript("", isFinal: true)
+            // One final per Gemini turn; no id, so consumers treat it as distinct.
+            delegate?.omniDidReceiveInputTranscript("", isFinal: true, itemID: nil)
             delegate?.omniDidFinishTurn()
         }
     }

--- a/desktop/macos/Desktop/Sources/RealtimeOmni/RealtimeOmniTestHarness.swift
+++ b/desktop/macos/Desktop/Sources/RealtimeOmni/RealtimeOmniTestHarness.swift
@@ -73,7 +73,7 @@ final class RealtimeOmniTestHarness: NSObject, RealtimeOmniServiceDelegate {
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.03) { [weak self] in self?.pump() }
     }
 
-    func omniDidReceiveInputTranscript(_ text: String, isFinal: Bool) {
+    func omniDidReceiveInputTranscript(_ text: String, isFinal: Bool, itemID: String?) {
         if isFinal {
             if !text.isEmpty { finalText = text }
             finish(reason: "final_transcript")  // STT done — no need to wait for turn end

--- a/desktop/macos/changelog/unreleased/20260711-chat-surface-fixes.json
+++ b/desktop/macos/changelog/unreleased/20260711-chat-surface-fixes.json
@@ -1,0 +1,3 @@
+{
+    "change": "Fixed the chat view jumping instead of holding your place when loading earlier messages, and stopped push-to-talk from dropping a legitimately repeated word within a single utterance"
+}

--- a/desktop/macos/changelog/unreleased/20260711-chat-surface-fixes.json
+++ b/desktop/macos/changelog/unreleased/20260711-chat-surface-fixes.json
@@ -1,3 +1,3 @@
 {
-    "change": "Fixed the chat view jumping instead of holding your place when loading earlier messages, and stopped push-to-talk from dropping a legitimately repeated word within a single utterance"
+    "change": "Fixed the chat view jumping instead of holding your place when loading earlier messages, and stopped push-to-talk from dropping a legitimately repeated word within a single turn"
 }

--- a/desktop/macos/e2e/flows/ptt-lifecycle.yaml
+++ b/desktop/macos/e2e/flows/ptt-lifecycle.yaml
@@ -7,6 +7,8 @@ covers:
   - desktop/macos/Desktop/Sources/DefaultsKey.swift
   - desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
   - desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
+  - desktop/macos/Desktop/Sources/RealtimeOmni/RealtimeOmniService.swift
+  - desktop/macos/Desktop/Sources/RealtimeOmni/RealtimeOmniTestHarness.swift
   - desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
   - desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubSettings.swift
   - desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeVoiceTurnOutbox.swift


### PR DESCRIPTION
## Summary

Follow-up #2 of 3 from the macOS bug-sweep deferrals. Two independent chat-surface fixes (separate commits).

> **⚠️ Draft — needs a local build to verify.** Authored with no Swift toolchain, so **not compiled**. Both are chat-surface (INV-CHAT-1) changes; please build (`cd desktop/macos && xcrun swift build -c debug --package-path Desktop`) and, for the PTT change, run the continuity gauntlet (`./scripts/agent-continuity-gauntlet.sh --suite continuity --bundle-id com.omi.omi-gauntlet`) before merge.

## Fix 1 — dead prepend-anchor restore (`ChatMessagesView.swift`)
`restorePrependAnchor` guarded on `scrollMode != .freeScrolling`, but a prepend ("Load earlier messages") only happens while the user is reading history — which *is* `scrollMode == .freeScrolling` (the top button is only reachable after scrolling up). So the guard always bailed and `proxy.scrollTo(anchor, .top)` never ran: the viewport jumped on every page-up, defeating the scroll-preservation the function exists for. Now gated on `!userIsScrolling` (an in-progress physical scroll, set by `UserScrollDetector`, auto-cleared 0.3s after the last wheel event) — restore runs in the normal reading state while still not fighting an active drag.

## Fix 2 — PTT omni finals deduped by text (`PushToTalkManager.swift`, `RealtimeOmniService.swift`, `RealtimeOmniTestHarness.swift`)
`omniDidReceiveInputTranscript` dropped a final whenever its trimmed text equalled any segment already accumulated this turn. A single PTT turn emits multiple finals (one per utterance/VAD boundary), so a legitimately repeated phrase ("yes. yes.", "go go go") collapsed to one, silently corrupting the sent query — exactly the anti-pattern AGENTS.md INV-6 calls out ("never dedupe by user text"). Now the provider's stable per-utterance id (OpenAI `item_id`; nil for Gemini) is threaded through the delegate and finals are deduped by id via a `seenFinalSegmentIDs` set (reset alongside `transcriptSegments`). A relay re-delivering the same final (same id) is still suppressed; genuine repeats (distinct ids, or nil ⇒ unique) are preserved.

## Product invariants
- **INV-CHAT-1** — cited because the diff touches `MainWindow/Components/Chat*.swift` and `FloatingControlBar/**` (path globs). Fix 1 is pure scroll presentation; Fix 2 is PTT transcript assembly and *aligns* with INV-6 rule 3/10 (removes text-based dedup). Neither touches the `ChatProvider` write-path, kernel projection, floating viewport source-of-truth, or pill projection, so no continuity-DoD guard-test change is required — but the PTT change is a transcript-behavior change and should get a local continuity-gauntlet run (a PR/RC gate, not CI).

## Verification
- Static checkers pass at baseline; e2e coverage satisfied (`RealtimeOmniService.swift` + `RealtimeOmniTestHarness.swift` added to `ptt-lifecycle.yaml`).
- **Not compiled here.** Reviewer build is the gate. Fix 2 changes a protocol signature; all conformers (PTT + test harness) and all four service call sites were updated in the same commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RAxLsaxtwVNDTWAZFfJp9q)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9496?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

