### PR TITLE
fix(desktop): harden macOS bug audit regressions

### DIFF
--- a/desktop/macos/Desktop/Sources/AppState/AppState+ListenEvents.swift
+++ b/desktop/macos/Desktop/Sources/AppState/AppState+ListenEvents.swift
@@ -347,10 +347,8 @@ extension AppState {
             // the in-memory window, the event payload has all fields needed
             if let sessionId = currentSessionId {
               let mapped = newTranslations.map { TranscriptTranslation(lang: $0.lang, text: $0.text) }
-              var translationsJson: String?
-              if let jsonData = try? JSONEncoder().encode(mapped) {
-                translationsJson = String(data: jsonData, encoding: .utf8)
-              }
+              let translationsJson = (try? JSONEncoder().encode(mapped))
+                .flatMap { String(data: $0, encoding: .utf8) }
               Task {
                 try? await TranscriptionStorage.shared.upsertSegment(
                   sessionId: sessionId,

--- a/desktop/macos/Desktop/Sources/Audio/BleAudioService.swift
+++ b/desktop/macos/Desktop/Sources/Audio/BleAudioService.swift
@@ -265,21 +265,24 @@ extension BleAudioService {
 // MARK: - BleAudioProcessorDelegate
 
 extension BleAudioService: BleAudioProcessor.Delegate {
-    func bleAudioProcessor(_ processor: BleAudioProcessor, didDecodeSamples samples: [Int16]) {
+    nonisolated func bleAudioProcessor(_ processor: BleAudioProcessor, didDecodeSamples samples: [Int16]) {
         // PCM delivery uses pcmDataPublisher; delegate path is unused.
         // Reset the degraded flag on successful decode so it reflects the
         // current processor state rather than staying sticky.
-        if isDecodeDegraded {
-            isDecodeDegraded = false
-            logger.info("BLE decode recovered — clearing degraded flag")
+        Task { @MainActor [weak self] in
+            guard let self, self.isDecodeDegraded else { return }
+            self.isDecodeDegraded = false
+            self.logger.info("BLE decode recovered — clearing degraded flag")
         }
     }
 
-    func bleAudioProcessor(_ processor: BleAudioProcessor, didFailWithError error: Error) {
-        isDecodeDegraded = true
-        logger.error("BLE decode degraded: \(error.localizedDescription)")
+    nonisolated func bleAudioProcessor(_ processor: BleAudioProcessor, didFailWithError error: Error) {
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            self.isDecodeDegraded = true
+            self.logger.error("BLE decode degraded: \(error.localizedDescription)")
+        }
     }
 }
 
 // MARK: - Integration with DeviceProvider
-

--- a/desktop/macos/Desktop/Sources/AuthService.swift
+++ b/desktop/macos/Desktop/Sources/AuthService.swift
@@ -2417,7 +2417,7 @@ class AuthService {
             SentrySDK.setUser(nil)
         }
 
-        let signingOutUserID = UserDefaults.standard.string(forKey: "auth_userId")
+        let signingOutUserID = UserDefaults.standard.string(forKey: .authUserId)
         try Auth.auth().signOut()
         // Reset coordinator only after Firebase sign-out succeeds so the state
         // transition is atomic — if signOut() throws (e.g. keychain error), the
@@ -2431,11 +2431,26 @@ class AuthService {
         // Clear saved auth state and tokens
         saveAuthState(isSignedIn: false, email: nil, userId: nil)
         clearTokens()
+        RewindDatabase.currentUserId = nil
 
         // Stop background services that make API calls before clearing caches
-        Task {
+        Task { [signingOutUserID] in
+            guard UserDefaults.standard.string(forKey: .authUserId) == nil
+                || UserDefaults.standard.string(forKey: .authUserId) == signingOutUserID
+            else {
+                log("AuthService: skipping stale sign-out service cleanup after a new sign-in")
+                return
+            }
             await AgentSyncService.shared.stop()
-            await FloatingBarUsageLimiter.shared.reset()
+            await MainActor.run {
+                guard UserDefaults.standard.string(forKey: .authUserId) == nil
+                    || UserDefaults.standard.string(forKey: .authUserId) == signingOutUserID
+                else {
+                    log("AuthService: skipping stale usage limiter reset after a new sign-in")
+                    return
+                }
+                FloatingBarUsageLimiter.shared.reset()
+            }
         }
 
         // Stop trial polling and reset banner state for this user session
@@ -2452,7 +2467,11 @@ class AuthService {
         // a new sign-in session has already called configure() by the time this runs.
         let closeGeneration = RewindDatabase.configureGeneration
         Task {
-            await RewindDatabase.shared.closeIfStale(generation: closeGeneration)
+            let didClose = await RewindDatabase.shared.closeIfStale(generation: closeGeneration)
+            guard didClose else {
+                log("AuthService: skipping stale sign-out cache invalidation after a new database session")
+                return
+            }
             await RewindIndexer.shared.reset()
             await RewindStorage.shared.reset()
             await TranscriptionStorage.shared.invalidateCache()

--- a/desktop/macos/Desktop/Sources/Bluetooth/Connections/LimitlessDeviceConnection.swift
+++ b/desktop/macos/Desktop/Sources/Bluetooth/Connections/LimitlessDeviceConnection.swift
@@ -887,18 +887,19 @@ final class LimitlessDeviceConnection: BaseDeviceConnection {
 
                 Task {
                     try? await Task.sleep(nanoseconds: 3_000_000_000)
-                    storageStateLock.lock()
-                    var timedOut: CheckedContinuation<[String: Int]?, Never>?
-                    var snapshot: [String: Int]?
-                    // Only fire if OUR call is still the pending one (a newer call
-                    // would have bumped the generation and owns the slot now).
-                    if storageStateGeneration == myGeneration, let completion = storageStateCompletion {
-                        timedOut = completion
-                        storageStateCompletion = nil
-                        snapshot = storageState
+                    let timeoutResult = storageStateLock.withLock {
+                        var timedOut: CheckedContinuation<[String: Int]?, Never>?
+                        var snapshot: [String: Int]?
+                        // Only fire if OUR call is still the pending one (a newer call
+                        // would have bumped the generation and owns the slot now).
+                        if storageStateGeneration == myGeneration, let completion = storageStateCompletion {
+                            timedOut = completion
+                            storageStateCompletion = nil
+                            snapshot = storageState
+                        }
+                        return (timedOut, snapshot)
                     }
-                    storageStateLock.unlock()
-                    timedOut?.resume(returning: snapshot)
+                    timeoutResult.0?.resume(returning: timeoutResult.1)
                 }
             }
         } catch {

--- a/desktop/macos/Desktop/Sources/Bluetooth/Transports/BleTransport.swift
+++ b/desktop/macos/Desktop/Sources/Bluetooth/Transports/BleTransport.swift
@@ -204,24 +204,25 @@ final class BleTransport: NSObject, DeviceTransport {
         // Cancel pending continuations. Capture-and-nil every continuation under
         // the lock, then resume OUTSIDE it, so a concurrent connect callback or
         // delegate cannot double-resume the same continuation.
-        continuationsLock.lock()
-        let pendingConnection = connectionContinuation
-        connectionContinuation = nil
-        let pendingDiscovery = serviceDiscoveryContinuation
-        serviceDiscoveryContinuation = nil
-        let pendingReads = characteristicContinuations
-        let pendingWrites = writeContinuations
-        characteristicContinuations.removeAll()
-        writeContinuations.removeAll()
-        continuationsLock.unlock()
+        let pendingContinuations = continuationsLock.withLock {
+            let pendingConnection = connectionContinuation
+            connectionContinuation = nil
+            let pendingDiscovery = serviceDiscoveryContinuation
+            serviceDiscoveryContinuation = nil
+            let pendingReads = characteristicContinuations
+            let pendingWrites = writeContinuations
+            characteristicContinuations.removeAll()
+            writeContinuations.removeAll()
+            return (pendingConnection, pendingDiscovery, pendingReads, pendingWrites)
+        }
 
-        pendingConnection?.resume(throwing: CancellationError())
-        pendingDiscovery?.resume(throwing: CancellationError())
+        pendingContinuations.0?.resume(throwing: CancellationError())
+        pendingContinuations.1?.resume(throwing: CancellationError())
 
-        for (_, continuation) in pendingReads {
+        for (_, continuation) in pendingContinuations.2 {
             continuation.resume(throwing: CancellationError())
         }
-        for (_, continuation) in pendingWrites {
+        for (_, continuation) in pendingContinuations.3 {
             continuation.resume(throwing: CancellationError())
         }
 

--- a/desktop/macos/Desktop/Sources/DefaultsKey.swift
+++ b/desktop/macos/Desktop/Sources/DefaultsKey.swift
@@ -43,6 +43,7 @@ enum DefaultsKey: String {
     /// Test hook: forces TTS playback start to report failure (non-prod gauntlets).
     case forceTTSPlaybackStartFalse = "forceTTSPlaybackStartFalse"
     case desktopIsPaywalled = "desktop_isPaywalled"
+    case rewindDisableContentCache = "rewindDisableContentCache"
 }
 
 /// Compile-checked owner-scoped defaults keys whose final storage key is

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/AgentPill.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/AgentPill.swift
@@ -1230,7 +1230,7 @@ final class AgentPillsManager: ObservableObject {
             return false
         }
 
-        if let pill = findPill(matching: preference) {
+        if findPill(matching: preference) != nil {
             return true
         }
 

--- a/desktop/macos/Desktop/Sources/LocalTranscriptionService.swift
+++ b/desktop/macos/Desktop/Sources/LocalTranscriptionService.swift
@@ -41,6 +41,13 @@ final class LocalTranscriptionService: @unchecked Sendable {
 
     typealias SegmentsHandler = @MainActor ([TranscriptionService.BackendSegment]) -> Void
 
+    private struct DrainSnapshot {
+        let manager: AsrManager
+        let window: [Float]
+        let startSec: Double
+        let durSec: Double
+    }
+
     private let language: String
     /// Source-based diarization: mic = the user ("You"), system audio = another speaker.
     private let isUser: Bool
@@ -102,10 +109,10 @@ final class LocalTranscriptionService: @unchecked Sendable {
                 let models = try await AsrModels.downloadAndLoad(version: version)
                 let manager = AsrManager()
                 try await manager.loadModels(models)
-                self.lock.lock()
-                self.asrManager = manager
-                self.isReady = true
-                self.lock.unlock()
+                self.lock.withLock {
+                    self.asrManager = manager
+                    self.isReady = true
+                }
                 log("LocalTranscriptionService: Parakeet \(version) ready in \(String(format: "%.1f", Date().timeIntervalSince(started)))s")
             } catch {
                 logError("LocalTranscriptionService: model load failed", error: error)
@@ -127,11 +134,11 @@ final class LocalTranscriptionService: @unchecked Sendable {
     func appendAudio(_ data: Data) {
         let floats = Self.int16ToFloat32(data)
         guard !floats.isEmpty else { return }
-        lock.lock()
-        if acceptingAudio {
-            buffer.append(contentsOf: floats)
+        lock.withLock {
+            if acceptingAudio {
+                buffer.append(contentsOf: floats)
+            }
         }
-        lock.unlock()
     }
 
     /// Fire-and-forget stop. Prefer `await finish()` whenever the session lifecycle allows it —
@@ -142,7 +149,7 @@ final class LocalTranscriptionService: @unchecked Sendable {
     func stop() {
         pumpTask?.cancel()
         pumpTask = nil
-        lock.lock(); acceptingAudio = false; lock.unlock()
+        lock.withLock { acceptingAudio = false }
         // Strong `self` (not weak): the caller (AppState) nils its reference immediately after
         // stop(), so a weak capture could deallocate the service before the final tail is
         // transcribed. The strong reference keeps it alive until drainAll() finishes.
@@ -159,7 +166,7 @@ final class LocalTranscriptionService: @unchecked Sendable {
         // Stop buffering new audio first so the single drain below captures the complete buffer —
         // capture can still be running (finishConversation rotation) and would otherwise append
         // past the drain snapshot.
-        lock.lock(); acceptingAudio = false; lock.unlock()
+        lock.withLock { acceptingAudio = false }
         await drainAll()
     }
 
@@ -167,7 +174,7 @@ final class LocalTranscriptionService: @unchecked Sendable {
     /// flush first, then transcribes the sub-window tail so the last words aren't dropped.
     private func drainAll() async {
         for _ in 0..<50 {
-            lock.lock(); let busy = isFlushing; lock.unlock()
+            let busy = lock.withLock { isFlushing }
             if !busy { break }
             try? await Task.sleep(nanoseconds: 100_000_000)
         }
@@ -176,38 +183,39 @@ final class LocalTranscriptionService: @unchecked Sendable {
 
     /// Transcribe one window (or whatever remains, when `force`) and emit a segment.
     private func drain(force: Bool) async {
-        lock.lock()
-        guard isReady, let manager = asrManager, !isFlushing else { lock.unlock(); return }
-        let available = buffer.count
-        // On force (stop/finish) flush whatever is left, even a sub-window tail; otherwise wait for a full window.
-        let ready = available >= windowSamples || (force && available > 0)
-        guard ready else { lock.unlock(); return }
-        let take = force ? available : windowSamples
-        let window = Array(buffer.prefix(take))
-        buffer.removeFirst(take)
-        let startSec = emittedSeconds
-        let durSec = Double(take) / Double(sampleRate)
-        emittedSeconds += durSec
-        isFlushing = true
-        lock.unlock()
+        guard let snapshot = lock.withLock({
+            guard isReady, let manager = asrManager, !isFlushing else { return nil as DrainSnapshot? }
+            let available = buffer.count
+            // On force (stop/finish) flush whatever is left, even a sub-window tail; otherwise wait for a full window.
+            let ready = available >= windowSamples || (force && available > 0)
+            guard ready else { return nil }
+            let take = force ? available : windowSamples
+            let window = Array(buffer.prefix(take))
+            buffer.removeFirst(take)
+            let startSec = emittedSeconds
+            let durSec = Double(take) / Double(sampleRate)
+            emittedSeconds += durSec
+            isFlushing = true
+            return DrainSnapshot(manager: manager, window: window, startSec: startSec, durSec: durSec)
+        }) else { return }
 
         defer {
-            lock.lock(); isFlushing = false; lock.unlock()
+            lock.withLock { isFlushing = false }
         }
 
         // Only skip DEAD silence (noise floor). The previous 0.012 threshold was tuned on loud
         // speaker playback and ate real (quieter) microphone speech — users saw "nothing
         // transcribed". A low floor lets normal mic speech through; hallucinations on near-silence
         // are filtered below by the model's own confidence score instead.
-        let rms = (window.reduce(Float(0)) { $0 + $1 * $1 } / Float(window.count)).squareRoot()
+        let rms = (snapshot.window.reduce(Float(0)) { $0 + $1 * $1 } / Float(snapshot.window.count)).squareRoot()
         guard rms > 0.004 else { return }
 
         // Music/video gate: don't turn songs, TV, or videos playing through *system audio* into
         // "conversations" — only real conversations/calls should be transcribed. Applied to the
         // system channel only; the mic channel (the user's own voice) is never gated. Runs Apple's
         // on-device SoundAnalysis classifier *before* Parakeet, so music also costs us no transcription.
-        if !isUser, Self.windowIsMusic(window, sampleRate: sampleRate) {
-            log(String(format: "LocalTranscriptionService[sys]: skipped %.1fs music/video window (rms=%.4f)", durSec, rms))
+        if !isUser, Self.windowIsMusic(snapshot.window, sampleRate: sampleRate) {
+            log(String(format: "LocalTranscriptionService[sys]: skipped %.1fs music/video window (rms=%.4f)", snapshot.durSec, rms))
             return
         }
 
@@ -216,7 +224,7 @@ final class LocalTranscriptionService: @unchecked Sendable {
             // windows makes the transducer decoder drift — it starts looping ("...AND AND AND"),
             // Title-Casing every word, and emitting gibberish. Independent per-window decode is stable.
             var ds = try TdtDecoderState()
-            let result = try await manager.transcribe(window, decoderState: &ds, language: nil)
+            let result = try await snapshot.manager.transcribe(snapshot.window, decoderState: &ds, language: nil)
 
             var text = result.text.trimmingCharacters(in: .whitespacesAndNewlines)
             // Silence makes the TDT decoder emit just "." / "..." — drop windows with no real speech.
@@ -236,8 +244,8 @@ final class LocalTranscriptionService: @unchecked Sendable {
                 speaker_id: speakerId,
                 is_user: isUser,
                 person_id: nil,
-                start: startSec,
-                end: startSec + durSec,
+                start: snapshot.startSec,
+                end: snapshot.startSec + snapshot.durSec,
                 translations: nil
             )
             // Deliver synchronously on the main actor so an awaited finish() guarantees the
@@ -247,7 +255,7 @@ final class LocalTranscriptionService: @unchecked Sendable {
                 await MainActor.run { onSegments(segs) }
             }
             log(String(format: "LocalTranscriptionService[%@]: %.1fs rms=%.4f conf=%.2f rtfx=%.0fx → %@",
-                       isUser ? "mic" : "sys", durSec, rms, result.confidence, result.rtfx, text))
+                       isUser ? "mic" : "sys", snapshot.durSec, rms, result.confidence, result.rtfx, text))
         } catch {
             logError("LocalTranscriptionService: transcribe failed", error: error)
         }

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/ConversationDetailView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/ConversationDetailView.swift
@@ -264,7 +264,7 @@ struct ConversationDetailView: View {
                                 isUser: isUser,
                                 personId: personId
                             )
-                            await updateDisplayedConversation(segmentIndices: segmentIndices, isUser: isUser, personId: personId)
+                            updateDisplayedConversation(segmentIndices: segmentIndices, isUser: isUser, personId: personId)
                         }
                         selectedSegmentForNaming = nil
                     }

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
@@ -1085,7 +1085,7 @@ struct DashboardPage: View {
     private func reportHomeAutomationMode() {
         guard DesktopAutomationLaunchOptions.isEnabled else { return }
         let modeLabel = useLegacyHomeDesign ? nil : homeMode.automationLabel
-        DesktopAutomationStateStore.shared.updateLiveFields { snapshot in
+        _ = DesktopAutomationStateStore.shared.updateLiveFields { snapshot in
             snapshot.homeMode = modeLabel
             snapshot.updatedAt = ISO8601DateFormatter().string(from: Date())
         }

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/TasksPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/TasksPage.swift
@@ -50,6 +50,11 @@ struct TaskSortOrderSyncFailure: Equatable {
     }
 }
 
+private struct TaskDynamicFilterInput: Sendable {
+    let source: String?
+    let tags: [String]
+}
+
 // MARK: - Task Filter Tag
 
 enum TaskFilterGroup: String, CaseIterable {
@@ -1412,7 +1417,9 @@ class TasksViewModel: ObservableObject {
         let version = recomputeVersion
 
         // Snapshot inputs for background computation
-        let allTasks = store.incompleteTasks + store.completedTasks
+        let tagInputs = (store.incompleteTasks + store.completedTasks).map { task in
+            TaskDynamicFilterInput(source: task.source, tags: task.tags)
+        }
         let knownSources = TaskFilterTag.knownSources
         let knownCategories = TaskFilterTag.knownCategories
 
@@ -1424,11 +1431,11 @@ class TasksViewModel: ObservableObject {
             var allSources: [String: Int] = [:]
             var allCategories: [String: Int] = [:]
 
-            for task in allTasks {
-                if let source = task.source, !source.isEmpty {
+            for input in tagInputs {
+                if let source = input.source, !source.isEmpty {
                     allSources[source, default: 0] += 1
                 }
-                for tag in task.tags {
+                for tag in input.tags {
                     allCategories[tag, default: 0] += 1
                 }
             }

--- a/desktop/macos/Desktop/Sources/MeetingDetector.swift
+++ b/desktop/macos/Desktop/Sources/MeetingDetector.swift
@@ -125,6 +125,7 @@ final class MeetingDetector {
     /// can block (notably right after wake) — then apply the result back on the main actor.
     private func tick() {
         let probe = isMeetingNow
+        probeGeneration &+= 1
         let generation = probeGeneration
         let weakSelf = WeakMeetingDetector(self)
         probeTask?.cancel()
@@ -176,4 +177,10 @@ final class MeetingDetector {
         log("MeetingDetector: meeting \(active ? "STARTED" : "ENDED")")
         onChange(active)
     }
+
+    #if DEBUG
+    func triggerProbeForTesting() {
+        tick()
+    }
+    #endif
 }

--- a/desktop/macos/Desktop/Sources/MeetingDetector.swift
+++ b/desktop/macos/Desktop/Sources/MeetingDetector.swift
@@ -1,6 +1,14 @@
 import AppKit
 import Foundation
 
+private final class WeakMeetingDetector: @unchecked Sendable {
+    weak var value: MeetingDetector?
+
+    init(_ value: MeetingDetector) {
+        self.value = value
+    }
+}
+
 /// Detects whether a conferencing call ("meeting") is currently active by scanning on-screen
 /// windows for known call apps (see `ConferencingApps`).
 ///
@@ -32,6 +40,8 @@ final class MeetingDetector {
     /// `nil` whenever a meeting is detected or no pending-off is in progress.
     private var pendingOffDeadline: Date?
     private var started = false
+    private var probeGeneration: UInt64 = 0
+    private var probeTask: Task<Void, Never>?
 
     /// - Parameters:
     ///   - pollInterval: how often to re-probe (browser tab-title changes only surface via the poll).
@@ -65,6 +75,7 @@ final class MeetingDetector {
     func start() {
         guard !started else { return }
         started = true
+        probeGeneration &+= 1
 
         let nc = NSWorkspace.shared.notificationCenter
         for name in [
@@ -94,6 +105,9 @@ final class MeetingDetector {
     func stop() {
         guard started else { return }
         started = false
+        probeGeneration &+= 1
+        probeTask?.cancel()
+        probeTask = nil
 
         timer?.invalidate()
         timer = nil
@@ -111,9 +125,18 @@ final class MeetingDetector {
     /// can block (notably right after wake) — then apply the result back on the main actor.
     private func tick() {
         let probe = isMeetingNow
-        Task.detached(priority: .utility) { [weak self] in
+        let generation = probeGeneration
+        let weakSelf = WeakMeetingDetector(self)
+        probeTask?.cancel()
+        probeTask = Task.detached(priority: .utility) {
             let detected = probe()
-            await MainActor.run { self?.applyDetected(detected) }
+            await MainActor.run {
+                guard let detector = weakSelf.value,
+                      detector.started,
+                      detector.probeGeneration == generation
+                else { return }
+                detector.applyDetected(detected)
+            }
         }
     }
 

--- a/desktop/macos/Desktop/Sources/Onboarding/OnboardingPagedIntroCoordinator.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/OnboardingPagedIntroCoordinator.swift
@@ -470,10 +470,7 @@ final class OnboardingPagedIntroCoordinator: ObservableObject {
     let configuration = NSWorkspace.OpenConfiguration()
     configuration.activates = true
 
-    if let browserBundleId = LSCopyDefaultHandlerForURLScheme("https" as CFString)?
-      .takeRetainedValue() as String?,
-      let browserURL = NSWorkspace.shared.urlForApplication(withBundleIdentifier: browserBundleId)
-    {
+    if let browserURL = NSWorkspace.shared.urlForApplication(toOpen: url) {
       NSWorkspace.shared.open([url], withApplicationAt: browserURL, configuration: configuration) {
         _, error in
         if let error {

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskExtraction/TaskAssistantSettings.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskExtraction/TaskAssistantSettings.swift
@@ -83,7 +83,7 @@ class TaskAssistantSettings {
 
     /// Apps that never contain useful content for proactive assistants — utility/media/system apps + our own app.
     /// Shared across Advice, Focus, and Memory assistants (Task extraction uses whitelist instead).
-    static let builtInExcludedApps: Set<String> = [
+    nonisolated static let builtInExcludedApps: Set<String> = [
         "Omi",
         "Omi Beta",
         "omi",

--- a/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
@@ -16,6 +16,25 @@ extension UserDefaults {
     }
 }
 
+private final class PendingToolTraceInputStore: @unchecked Sendable {
+    typealias Entry = (name: String, inputJson: String, started: ContinuousClock.Instant)
+
+    private let lock = NSLock()
+    private var entries: [String: Entry] = [:]
+
+    func set(_ entry: Entry, forKey key: String) {
+        lock.withLock {
+            entries[key] = entry
+        }
+    }
+
+    func removeValue(forKey key: String) -> Entry? {
+        lock.withLock {
+            entries.removeValue(forKey: key)
+        }
+    }
+}
+
 // MARK: - Chat Session Model
 
 /// A chat session that groups related messages
@@ -2422,8 +2441,6 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
 
         // Log prompt context summary
         let activeGoalCount = cachedGoals.filter { $0.isActive }.count
-        let historyMessages = messages.filter { !$0.text.isEmpty && !$0.isStreaming }
-        let historyCount = min(historyMessages.count, 20)
         log("ChatProvider: prompt built — schema: \(style.includesDatabaseSchema && !cachedDatabaseSchema.isEmpty ? "yes" : "no"), goals: \(activeGoalCount), tasks: \(cachedTasks.count), ai_profile: \(!cachedAIProfile.isEmpty ? "yes" : "no"), memories: \(cachedMemories.count), history: kernel-owned, claude_md: \(claudeMdEnabled && claudeMdContent != nil ? "yes" : "no"), project_claude_md: \(projectClaudeMdEnabled && projectClaudeMdContent != nil ? "yes" : "no"), skills: \(style.includesSkills ? enabledSkillNames.count : 0), dev_mode_in_skills: \(style.includesSkills && devModeEnabled && devModeContext != nil ? "yes" : "no"), prompt_length: \(prompt.count) chars")
 
         // Log per-section character breakdown
@@ -4093,8 +4110,7 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
             // Kernel control tools (spawn_agent, list_agent_sessions, …) execute in
             // the Node runtime and only surface via tool_activity + tool_result_display.
             // Pair started input with completed output for QueryTracer.tool_executions.
-            var pendingToolTraceInputs:
-                [String: (name: String, inputJson: String, started: ContinuousClock.Instant)] = [:]
+            let pendingToolTraceInputs = PendingToolTraceInputStore()
             let textDeltaHandler: AgentClient.TextDeltaHandler = { [weak self] delta in
                 let nowMs = ChatProvider.monotonicNowMs()
                 if responseMetrics.markFirstOutputIfNeeded() {
@@ -4149,7 +4165,9 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
                         let inputJson =
                             (try? String(data: JSONSerialization.data(withJSONObject: input), encoding: .utf8))
                             ?? "\(input)"
-                        pendingToolTraceInputs[trackedId] = (name, inputJson, ContinuousClock.now)
+                        pendingToolTraceInputs.set(
+                            (name, inputJson, ContinuousClock.now),
+                            forKey: trackedId)
                     }
                 } else if toolStatus != .running {
                     tracer?.end(spanKey)
@@ -4210,12 +4228,12 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
             }
             let toolResultDisplayHandler: AgentClient.ToolResultDisplayHandler = { [weak self] toolUseId, name, output in
                 let nowMs = ChatProvider.monotonicNowMs()
-                if let tracer {
+                if tracer != nil {
                     let trackedId = ChatProvider.stallTrackingId(toolUseId: toolUseId, name: name)
                     let pending = pendingToolTraceInputs.removeValue(forKey: trackedId)
                     let inputJson = pending?.inputJson ?? ""
                     let durationMs = pending.map { (ContinuousClock.now - $0.started).milliseconds }
-                    tracer.captureToolExecution(
+                    tracer?.captureToolExecution(
                         toolUseId: toolUseId.isEmpty ? nil : toolUseId,
                         name: name,
                         input: inputJson,

--- a/desktop/macos/Desktop/Sources/Rewind/Core/RewindDatabase.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/RewindDatabase.swift
@@ -215,25 +215,15 @@ actor RewindDatabase {
         do {
             try db.execute(sql: "DROP TABLE IF EXISTS action_items_fts")
         } catch {
-            try forceRemoveBrokenActionItemsFTSMetadata(in: db)
+            try dropActionItemsFTSShadowsIfPresent(in: db)
+            try db.execute(sql: "DROP TABLE IF EXISTS action_items_fts")
         }
     }
 
-    private static func forceRemoveBrokenActionItemsFTSMetadata(in db: Database) throws {
-        try db.execute(sql: "PRAGMA writable_schema = ON")
-        defer { try? db.execute(sql: "PRAGMA writable_schema = OFF") }
-
-        try db.execute(sql: "DELETE FROM sqlite_master WHERE type = 'table' AND name = 'action_items_fts'")
+    private static func dropActionItemsFTSShadowsIfPresent(in db: Database) throws {
         for table in actionItemsFTSShadowTables {
-            do {
-                try db.execute(sql: "DROP TABLE IF EXISTS \(table)")
-            } catch {
-                try db.execute(sql: "DELETE FROM sqlite_master WHERE type = 'table' AND name = '\(table)'")
-            }
+            try db.execute(sql: "DROP TABLE IF EXISTS \(table)")
         }
-
-        let schemaVersion = (try Int.fetchOne(db, sql: "PRAGMA schema_version")) ?? 0
-        try db.execute(sql: "PRAGMA schema_version = \(schemaVersion + 1)")
     }
 
     /// Configure the database for a specific user.
@@ -249,16 +239,21 @@ actor RewindDatabase {
 
     /// Close the database only if no new session has started (configure() not called since).
     /// Prevents a stale sign-out Task from closing a freshly opened database.
-    func closeIfStale(generation: Int) {
+    @discardableResult
+    func closeIfStale(generation: Int) -> Bool {
         guard generation == RewindDatabase.configureGeneration else {
             log("RewindDatabase: Skipping stale close (requested gen \(generation), current gen \(RewindDatabase.configureGeneration))")
-            return
+            return false
         }
         close()
+        return true
     }
 
     /// Close the database, allowing re-initialization for a different user.
     func close() {
+        if let runningFlagPath {
+            try? FileManager.default.removeItem(atPath: runningFlagPath)
+        }
         dbQueue = nil
         initializationTask = nil
         runningFlagPath = nil
@@ -277,8 +272,16 @@ actor RewindDatabase {
     /// Returns the per-user base directory: ~/Library/Application Support/Omi/users/{userId}/
     /// Falls back to the static currentUserId (set synchronously at app start) when
     /// configure() hasn't been called yet (e.g., TierManager triggers init early).
+    private func targetUserId() -> String {
+        if RewindDatabase.currentUserId == nil,
+           UserDefaults.standard.string(forKey: .authUserId) == nil {
+            return "anonymous"
+        }
+        return configuredUserId ?? RewindDatabase.currentUserId ?? "anonymous"
+    }
+
     private func userBaseDirectory() -> URL {
-        let userId = configuredUserId ?? RewindDatabase.currentUserId ?? "anonymous"
+        let userId = targetUserId()
         return DesktopLocalProfile.applicationSupportURL()
             .appendingPathComponent("users", isDirectory: true)
             .appendingPathComponent(userId, isDirectory: true)
@@ -313,7 +316,7 @@ actor RewindDatabase {
     /// If the DB is open for a different user (e.g., "anonymous" before configure was called),
     /// closes it and reopens for the configured user.
     func initialize() async throws {
-        let targetUser = configuredUserId ?? RewindDatabase.currentUserId ?? "anonymous"
+        let targetUser = targetUserId()
 
         // Already initialized for the correct user
         if dbQueue != nil && openedForUserId == targetUser {
@@ -471,7 +474,7 @@ actor RewindDatabase {
         }
 
         dbQueue = activeQueue
-        openedForUserId = configuredUserId ?? RewindDatabase.currentUserId ?? "anonymous"
+        openedForUserId = targetUserId()
         consecutiveQueryIOErrors = 0
 
         try migrate(activeQueue)
@@ -543,7 +546,7 @@ actor RewindDatabase {
             .appendingPathComponent("users", isDirectory: true)
             .appendingPathComponent("anonymous", isDirectory: true)
 
-        let effectiveUserId = configuredUserId ?? RewindDatabase.currentUserId ?? "anonymous"
+        let effectiveUserId = targetUserId()
         let sourceDir: URL
         if fileManager.fileExists(atPath: legacyDB.path) {
             sourceDir = omiDir

--- a/desktop/macos/Desktop/Sources/Rewind/Core/RewindStorage.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/RewindStorage.swift
@@ -28,11 +28,12 @@ actor RewindStorage {
     }
 
     /// Reset storage state (called on user switch / sign-out)
-    func reset() {
+    func reset() async {
         screenshotsDirectory = nil
         videosDirectory = nil
         frameCache.removeAllObjects()
         corruptedChunks.removeAll()
+        await VideoChunkEncoder.shared.resetForUserSwitch()
         log("RewindStorage: Reset for user switch")
     }
 

--- a/desktop/macos/Desktop/Sources/Rewind/Core/VideoChunkEncoder.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/VideoChunkEncoder.swift
@@ -100,11 +100,18 @@ actor VideoChunkEncoder {
 
     /// Initialize the encoder with the videos directory
     func initialize(videosDirectory: URL) async throws {
-        guard !isInitialized else { return }
+        if isInitialized {
+            guard self.videosDirectory != videosDirectory else { return }
+            await resetForUserSwitch()
+        }
 
         self.videosDirectory = videosDirectory
         isInitialized = true
         log("VideoChunkEncoder: Initialized at \(videosDirectory.path)")
+    }
+
+    func videosDirectoryForTesting() -> URL? {
+        videosDirectory
     }
 
     func hasFinalizedChunkForDedupe() -> Bool {
@@ -641,6 +648,13 @@ actor VideoChunkEncoder {
         currentChunkInputSize = nil
         consecutiveWriteFailures = 0
         writerNotReadyCount = 0
+    }
+
+    func resetForUserSwitch() async {
+        await cancel()
+        videosDirectory = nil
+        isInitialized = false
+        hasFinalizedAnyChunk = false
     }
 
     /// Emergency reset when encoding fails repeatedly or buffer overflows

--- a/desktop/macos/Desktop/Sources/Rewind/Services/PowerMonitor.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Services/PowerMonitor.swift
@@ -16,11 +16,19 @@ class PowerMonitor: ObservableObject {
     var onPowerSourceChanged: ((Bool) -> Void)?
 
     private var runLoopSource: CFRunLoopSource?
+    private let batteryStateProbe: @Sendable () -> Bool
+    private var powerProbeGeneration: UInt64 = 0
 
-    private init() {
-        isOnBattery = Self.checkBatteryState()
+    init(
+        batteryStateProbe: @escaping @Sendable () -> Bool = { PowerMonitor.checkBatteryState() },
+        startMonitoring: Bool = true
+    ) {
+        self.batteryStateProbe = batteryStateProbe
+        isOnBattery = batteryStateProbe()
         Self.cachedIsOnBattery = isOnBattery
-        startMonitoring()
+        if startMonitoring {
+            startMonitoringPowerSource()
+        }
     }
 
     // MARK: - Power Source Detection
@@ -51,7 +59,7 @@ class PowerMonitor: ObservableObject {
 
     // MARK: - Monitoring
 
-    private func startMonitoring() {
+    private func startMonitoringPowerSource() {
         let context = UnsafeMutableRawPointer(Unmanaged.passUnretained(self).toOpaque())
         if let source = IOPSCreateLimitedPowerNotification({ context in
             guard let context = context else { return }
@@ -66,14 +74,18 @@ class PowerMonitor: ObservableObject {
         }
     }
 
-    private func handlePowerSourceChanged() {
+    func handlePowerSourceChanged() {
         let wasOnBattery = isOnBattery
+        powerProbeGeneration &+= 1
+        let generation = powerProbeGeneration
+        let batteryStateProbe = batteryStateProbe
 
         // IOPSCopyPowerSourcesInfo can block on Mach IPC — check off main thread
         Task.detached(priority: .utility) { [weak self] in
-            let nowOnBattery = Self.checkBatteryState()
+            let nowOnBattery = batteryStateProbe()
             guard let self else { return }
             await MainActor.run {
+                guard self.powerProbeGeneration == generation else { return }
                 self.isOnBattery = nowOnBattery
                 Self.cachedIsOnBattery = nowOnBattery
 

--- a/desktop/macos/Desktop/Sources/ScreenCaptureService.swift
+++ b/desktop/macos/Desktop/Sources/ScreenCaptureService.swift
@@ -50,7 +50,7 @@ final class ScreenCaptureService: Sendable {
   @available(macOS 14.0, *)
   private static func sharedContent(forceRefresh: Bool = false) async throws -> SCShareableContent {
     if !forceRefresh,
-      !UserDefaults.standard.bool(forKey: "rewindDisableContentCache")
+      !UserDefaults.standard.bool(forKey: .rewindDisableContentCache)
     {
       let cached: SCShareableContent? = sharedContentLock.withLock {
         guard let ts = sharedContentCachedAt,
@@ -347,7 +347,7 @@ final class ScreenCaptureService: Sendable {
 
         let task = Process()
         task.executableURL = URL(fileURLWithPath: "/bin/sh")
-        task.arguments = ["-c", "sleep 0.5 && open \"\(bundleURL.path)\""]
+        task.arguments = ["-c", screenCaptureRelaunchCommand(appPath: bundleURL.path)]
 
         do {
           try task.run()
@@ -390,10 +390,9 @@ final class ScreenCaptureService: Sendable {
         if success {
           log("Screen capture permission reset, restarting app...")
 
-          // Use a shell script to wait briefly, then relaunch the app
           let task = Process()
           task.executableURL = URL(fileURLWithPath: "/bin/sh")
-          task.arguments = ["-c", "sleep 0.5 && open \"\(bundleURL.path)\""]
+          task.arguments = ["-c", screenCaptureRelaunchCommand(appPath: bundleURL.path)]
 
           do {
             try task.run()
@@ -409,6 +408,14 @@ final class ScreenCaptureService: Sendable {
         }
       }
     }
+  }
+
+  nonisolated static func screenCaptureRelaunchCommand(appPath: String) -> String {
+    AppState.relaunchCommand(
+      appPath: appPath,
+      isNonProduction: AppBuild.isNonProduction,
+      automationPort: DesktopAutomationLaunchOptions.port
+    )
   }
 
   /// Get the window ID of the frontmost application's main window

--- a/desktop/macos/Desktop/Sources/StartupWarmupCoordinator.swift
+++ b/desktop/macos/Desktop/Sources/StartupWarmupCoordinator.swift
@@ -56,7 +56,7 @@ final class StartupWarmupCoordinator {
                 await MainActor.run { onCancel?() }
                 return
             }
-            guard await self.isCurrentSession(scope) else {
+            guard self.isCurrentSession(scope) else {
                 await MainActor.run { onCancel?() }
                 return
             }
@@ -116,7 +116,7 @@ final class StartupWarmupCoordinator {
         }
 
         guard await sleepForStartupDelay(StartupWarmupPolicy.deferredWarmupDelay) else { return }
-        guard await AuthState.shared.isSignedIn else {
+        guard AuthState.shared.isSignedIn else {
             log("DATA LOAD: Skipping DB lifecycle warmup because user is signed out")
             scheduleState.releaseDatabaseWarmup()
             return
@@ -201,12 +201,12 @@ final class StartupWarmupCoordinator {
 
             while !Task.isCancelled {
                 guard await self.sleepForStartupDelay(delay) else { return }
-                guard await self.isCurrentSession(scope) else {
+                guard self.isCurrentSession(scope) else {
                     await MainActor.run { self.sessionTasks[.databaseRetry] = nil }
                     return
                 }
                 let didRecover = await self.retryDatabaseInit()
-                guard await self.isCurrentSession(scope) else {
+                guard self.isCurrentSession(scope) else {
                     await MainActor.run { self.sessionTasks[.databaseRetry] = nil }
                     return
                 }

--- a/desktop/macos/Desktop/Sources/ViewExporter.swift
+++ b/desktop/macos/Desktop/Sources/ViewExporter.swift
@@ -635,33 +635,33 @@ enum ViewExporter {
     hostingView.layoutSubtreeIfNeeded()
 
     var success = false
-    do {
-      try ObjCExceptionCatcher.catching {
-        // Export PNG
-        guard let bitmapRep = hostingView.bitmapImageRepForCachingDisplay(in: hostingView.bounds)
-        else {
-          NSLog("ViewExporter: SKIP \(name) - no bitmap")
-          return
-        }
-        hostingView.cacheDisplay(in: hostingView.bounds, to: bitmapRep)
-
-        if let pngData = bitmapRep.representation(using: .png, properties: [:]) {
-          let pngPath = "\(dir)/\(name).png"
-          try? pngData.write(to: URL(fileURLWithPath: pngPath))
-          let kb = pngData.count / 1024
-          NSLog("ViewExporter: \(name).png (\(Int(size.width))x\(Int(size.height))) \(kb)KB")
-        }
-
-        // Export PDF (vector data preserved for SVG conversion)
-        let pdfData = hostingView.dataWithPDF(inside: hostingView.bounds)
-        let pdfPath = "\(dir)/\(name).pdf"
-        try? pdfData.write(to: URL(fileURLWithPath: pdfPath))
-        NSLog("ViewExporter: \(name).pdf (\(pdfData.count / 1024)KB)")
-
-        success = true
+    let exception = ObjCExceptionCatcher.catching {
+      // Export PNG
+      guard let bitmapRep = hostingView.bitmapImageRepForCachingDisplay(in: hostingView.bounds)
+      else {
+        NSLog("ViewExporter: SKIP \(name) - no bitmap")
+        return
       }
-    } catch {
-      NSLog("ViewExporter: SKIP \(name) - \(error.localizedDescription)")
+      hostingView.cacheDisplay(in: hostingView.bounds, to: bitmapRep)
+
+      if let pngData = bitmapRep.representation(using: .png, properties: [:]) {
+        let pngPath = "\(dir)/\(name).png"
+        try? pngData.write(to: URL(fileURLWithPath: pngPath))
+        let kb = pngData.count / 1024
+        NSLog("ViewExporter: \(name).png (\(Int(size.width))x\(Int(size.height))) \(kb)KB")
+      }
+
+      // Export PDF (vector data preserved for SVG conversion)
+      let pdfData = hostingView.dataWithPDF(inside: hostingView.bounds)
+      let pdfPath = "\(dir)/\(name).pdf"
+      try? pdfData.write(to: URL(fileURLWithPath: pdfPath))
+      NSLog("ViewExporter: \(name).pdf (\(pdfData.count / 1024)KB)")
+
+      success = true
+    }
+    if let exception {
+      NSLog("ViewExporter: SKIP \(name) - \(exception.name.rawValue): \(exception.reason ?? "unknown")")
+      success = false
     }
 
     window.orderOut(nil)

--- a/desktop/macos/Desktop/Sources/WAL/WALService.swift
+++ b/desktop/macos/Desktop/Sources/WAL/WALService.swift
@@ -66,6 +66,7 @@ final class WALService: ObservableObject {
     private let fileManager = FileManager.default
     private let apiClient: APIClient
     private let reconciler: WALSyncReconciler
+    private let walMetadataWriteQueue = DispatchQueue(label: "me.omi.desktop.wal.metadata.write")
     private var frameWriteInProgress = false
 
     /// Test seam — when set, bypasses `APIClient.uploadLocalFilesV2`.
@@ -89,6 +90,10 @@ final class WALService: ObservableObject {
 
     func flushToDiskForTesting() {
         flushToDisk()
+    }
+
+    func waitForWalMetadataWritesForTesting() {
+        walMetadataWriteQueue.sync {}
     }
 
     func createWalFromCurrentFramesForTesting() {
@@ -116,10 +121,10 @@ final class WALService: ObservableObject {
 
     init(
         apiClient: APIClient = .shared,
-        reconciler: WALSyncReconciler = .shared
+        reconciler: WALSyncReconciler? = nil
     ) {
         self.apiClient = apiClient
-        self.reconciler = reconciler
+        self.reconciler = reconciler ?? .shared
         setupWalDirectory()
         loadWals()
     }
@@ -217,8 +222,9 @@ final class WALService: ObservableObject {
             let metadata = WALMetadata(wals: wals)
             let data = try JSONEncoder().encode(metadata)
 
-            // Write to disk on background thread to avoid blocking UI
-            DispatchQueue.global(qos: .utility).async {
+            // Write to disk on a serial background queue so older snapshots cannot
+            // finish after newer snapshots and roll metadata backward across restart.
+            walMetadataWriteQueue.async {
                 do {
                     // Create backup first
                     if FileManager.default.fileExists(atPath: file.path) {

--- a/desktop/macos/Desktop/Sources/WAL/WALSyncReconciler.swift
+++ b/desktop/macos/Desktop/Sources/WAL/WALSyncReconciler.swift
@@ -21,7 +21,7 @@ final class WALSyncReconciler {
     self.fileExists = fileExists
   }
 
-  private static func defaultFileExists(wal: WALEntry, walDirectory: URL?) -> Bool {
+  nonisolated private static func defaultFileExists(wal: WALEntry, walDirectory: URL?) -> Bool {
     guard let filePath = wal.filePath, let walDirectory else { return false }
     return FileManager.default.fileExists(atPath: walDirectory.appendingPathComponent(filePath).path)
   }

--- a/desktop/macos/Desktop/Tests/ActionItemsFTSRepairTests.swift
+++ b/desktop/macos/Desktop/Tests/ActionItemsFTSRepairTests.swift
@@ -73,9 +73,9 @@ final class ActionItemsFTSRepairTests: XCTestCase {
     XCTAssertEqual(ftsDescriptions, durableDescriptions)
   }
 
-  func testRepairToleratesMissingActionItemsFTSShadowTable() async throws {
+  func testRepairRebuildsDroppedActionItemsFTSFromDurableRows() async throws {
     let existing = try await ActionItemStorage.shared.insertLocalActionItem(
-      ActionItemRecord(description: "shadow table durable row", source: "test"))
+      ActionItemRecord(description: "direct repair durable row", source: "test"))
     XCTAssertNotNil(existing.id)
 
     guard let dbQueue = await RewindDatabase.shared.getDatabaseQueue() else {
@@ -83,14 +83,10 @@ final class ActionItemsFTSRepairTests: XCTestCase {
     }
 
     try await dbQueue.write { db in
-      try db.execute(sql: "PRAGMA writable_schema = ON")
-      let schemaVersion = (try Int.fetchOne(db, sql: "PRAGMA schema_version")) ?? 0
-      defer { try? db.execute(sql: "PRAGMA writable_schema = OFF") }
-      try db.execute(sql: "DELETE FROM sqlite_master WHERE type = 'table' AND name = 'action_items_fts_data'")
-      try db.execute(sql: "PRAGMA schema_version = \(schemaVersion + 1)")
+      try db.execute(sql: "DROP TABLE action_items_fts")
     }
 
-    try await RewindDatabase.shared.repairActionItemsFTS(in: dbQueue, reason: "missing shadow table test")
+    try await RewindDatabase.shared.repairActionItemsFTS(in: dbQueue, reason: "direct repair test")
 
     let matches = try await dbQueue.read { db in
       try String.fetchAll(
@@ -99,10 +95,10 @@ final class ActionItemsFTSRepairTests: XCTestCase {
           SELECT action_items.description
           FROM action_items_fts
           JOIN action_items ON action_items_fts.rowid = action_items.id
-          WHERE action_items_fts MATCH 'shadow'
+          WHERE action_items_fts MATCH 'direct'
           ORDER BY action_items.id
           """)
     }
-    XCTAssertEqual(matches, ["shadow table durable row"])
+    XCTAssertEqual(matches, ["direct repair durable row"])
   }
 }

--- a/desktop/macos/Desktop/Tests/AppStateOwnershipTests.swift
+++ b/desktop/macos/Desktop/Tests/AppStateOwnershipTests.swift
@@ -11,8 +11,6 @@ final class AppStateOwnershipTests: XCTestCase {
   }
 
   func testDesktopHomeViewDoesNotOwnAppState() throws {
-    let path = Bundle.module.bundlePath
-      .replacingOccurrences(of: "/.build/.+", with: "", options: .regularExpression)
     let sourceRoot = URL(fileURLWithPath: #filePath)
       .deletingLastPathComponent()
       .deletingLastPathComponent()

--- a/desktop/macos/Desktop/Tests/AuthSessionCoordinatorTests.swift
+++ b/desktop/macos/Desktop/Tests/AuthSessionCoordinatorTests.swift
@@ -79,7 +79,9 @@ final class AuthSessionCoordinatorTests: XCTestCase {
     // Nuclear signOut still wipes onboarding — invalidate must not.
     let signOutRange = authSource.range(of: "func signOut() throws")
     XCTAssertNotNil(signOutRange)
-    let signOutSnippet = String(authSource[signOutRange!.lowerBound...]).prefix(4000)
+    let signOutTail = authSource[signOutRange!.lowerBound...]
+    let signOutEnd = signOutTail.range(of: "// MARK: - Helper Methods")?.lowerBound ?? signOutTail.endIndex
+    let signOutSnippet = String(signOutTail[..<signOutEnd])
     XCTAssertTrue(signOutSnippet.contains("onboardingStep"))
     XCTAssertTrue(signOutSnippet.contains("userDidSignOut"))
 
@@ -119,6 +121,22 @@ final class AuthSessionCoordinatorTests: XCTestCase {
     XCTAssertTrue(snippet.contains("refreshSingleFlight(auth: self)"))
     XCTAssertTrue(snippet.contains("transition(to: .recoveryRequired)"))
     XCTAssertTrue(snippet.contains("resetAfterSuccessfulSignIn()"))
+  }
+
+  func testSignOutAsyncCleanupIsSessionGuarded() throws {
+    let authSource = try sourceFile("AuthService.swift")
+    let dbSource = try sourceFile("Rewind/Core/RewindDatabase.swift")
+
+    let signOutRange = authSource.range(of: "func signOut() throws")
+    XCTAssertNotNil(signOutRange)
+    let signOutSnippet = String(authSource[signOutRange!.lowerBound...]).prefix(4200)
+
+    XCTAssertTrue(signOutSnippet.contains("Task { [signingOutUserID] in"))
+    XCTAssertTrue(signOutSnippet.contains("skipping stale sign-out service cleanup after a new sign-in"))
+    XCTAssertTrue(signOutSnippet.contains("let didClose = await RewindDatabase.shared.closeIfStale"))
+    XCTAssertTrue(signOutSnippet.contains("guard didClose else"))
+    XCTAssertTrue(signOutSnippet.contains("skipping stale sign-out cache invalidation after a new database session"))
+    XCTAssertTrue(dbSource.contains("func closeIfStale(generation: Int) -> Bool"))
   }
 
   func testOnlyAuthenticatedPhaseReportsSignedIn() {

--- a/desktop/macos/Desktop/Tests/MeetingGatedSystemAudioTests.swift
+++ b/desktop/macos/Desktop/Tests/MeetingGatedSystemAudioTests.swift
@@ -151,6 +151,46 @@ final class MeetingDetectorTests: XCTestCase {
         XCTAssertFalse(detector.isMeetingActive)
         XCTAssertEqual(changes, [], "no edges while never in a meeting")
     }
+
+    func testStopDiscardsInFlightProbeResult() async {
+        let probeStarted = DispatchSemaphore(value: 0)
+        let releaseProbe = DispatchSemaphore(value: 0)
+        let unexpectedInitialObservation = DispatchSemaphore(value: 0)
+        let unexpectedChange = DispatchSemaphore(value: 0)
+        var changes = [Bool]()
+        var initialObservedCount = 0
+        let detector = MeetingDetector(
+            pollInterval: 60.0,
+            offGracePeriod: 8.0,
+            isMeetingNow: {
+                probeStarted.signal()
+                _ = releaseProbe.wait(timeout: .now() + 2)
+                return true
+            },
+            now: { [weak self] in self?.now ?? Date(timeIntervalSince1970: 0) },
+            onInitialStateObserved: {
+                initialObservedCount += 1
+                unexpectedInitialObservation.signal()
+            },
+            onChange: {
+                changes.append($0)
+                unexpectedChange.signal()
+            }
+        )
+
+        detector.start()
+        XCTAssertEqual(probeStarted.wait(timeout: .now() + 2), .success)
+        detector.stop()
+        releaseProbe.signal()
+        await Task.yield()
+
+        XCTAssertFalse(detector.hasObservedState)
+        XCTAssertFalse(detector.isMeetingActive)
+        XCTAssertEqual(initialObservedCount, 0)
+        XCTAssertEqual(changes, [])
+        XCTAssertEqual(unexpectedInitialObservation.wait(timeout: .now()), .timedOut)
+        XCTAssertEqual(unexpectedChange.wait(timeout: .now()), .timedOut)
+    }
 }
 
 // MARK: - AssistantSettings.systemAudioCaptureMode

--- a/desktop/macos/Desktop/Tests/MeetingGatedSystemAudioTests.swift
+++ b/desktop/macos/Desktop/Tests/MeetingGatedSystemAudioTests.swift
@@ -191,6 +191,63 @@ final class MeetingDetectorTests: XCTestCase {
         XCTAssertEqual(unexpectedInitialObservation.wait(timeout: .now()), .timedOut)
         XCTAssertEqual(unexpectedChange.wait(timeout: .now()), .timedOut)
     }
+
+    func testNewerProbeWinsWhenCanceledProbeFinishesLater() async {
+        let firstProbeStarted = DispatchSemaphore(value: 0)
+        let secondProbeStarted = DispatchSemaphore(value: 0)
+        let releaseFirstProbe = DispatchSemaphore(value: 0)
+        let releaseSecondProbe = DispatchSemaphore(value: 0)
+        let unexpectedChange = DispatchSemaphore(value: 0)
+        let probeLock = NSLock()
+        var probeCount = 0
+        var changes = [Bool]()
+        var initialObservedCount = 0
+        let detector = MeetingDetector(
+            pollInterval: 60.0,
+            offGracePeriod: 8.0,
+            isMeetingNow: {
+                probeLock.lock()
+                probeCount += 1
+                let probeIndex = probeCount
+                probeLock.unlock()
+
+                if probeIndex == 1 {
+                    firstProbeStarted.signal()
+                    _ = releaseFirstProbe.wait(timeout: .now() + 2)
+                    return true
+                }
+
+                secondProbeStarted.signal()
+                _ = releaseSecondProbe.wait(timeout: .now() + 2)
+                return false
+            },
+            now: { [weak self] in self?.now ?? Date(timeIntervalSince1970: 0) },
+            onInitialStateObserved: { initialObservedCount += 1 },
+            onChange: {
+                changes.append($0)
+                unexpectedChange.signal()
+            }
+        )
+
+        detector.start()
+        defer { detector.stop() }
+        XCTAssertEqual(firstProbeStarted.wait(timeout: .now() + 2), .success)
+
+        detector.triggerProbeForTesting()
+        XCTAssertEqual(secondProbeStarted.wait(timeout: .now() + 2), .success)
+
+        releaseSecondProbe.signal()
+        await Task.yield()
+        XCTAssertTrue(detector.hasObservedState)
+        XCTAssertFalse(detector.isMeetingActive)
+        XCTAssertEqual(initialObservedCount, 1)
+
+        releaseFirstProbe.signal()
+        await Task.yield()
+        XCTAssertFalse(detector.isMeetingActive, "the canceled older probe must not overwrite the newer result")
+        XCTAssertEqual(changes, [])
+        XCTAssertEqual(unexpectedChange.wait(timeout: .now()), .timedOut)
+    }
 }
 
 // MARK: - AssistantSettings.systemAudioCaptureMode

--- a/desktop/macos/Desktop/Tests/PowerMonitorTests.swift
+++ b/desktop/macos/Desktop/Tests/PowerMonitorTests.swift
@@ -1,0 +1,74 @@
+import XCTest
+
+@testable import Omi_Computer
+
+private final class PowerProbeCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var count = 0
+
+    func next() -> Int {
+        lock.withLock {
+            count += 1
+            return count
+        }
+    }
+}
+
+@MainActor
+final class PowerMonitorTests: XCTestCase {
+
+    func testStalePowerProbeCannotOverwriteNewerPowerState() async {
+        let probeCounter = PowerProbeCounter()
+        let firstChangeStarted = DispatchSemaphore(value: 0)
+        let secondChangeStarted = DispatchSemaphore(value: 0)
+        let releaseFirstChange = DispatchSemaphore(value: 0)
+        let releaseSecondChange = DispatchSemaphore(value: 0)
+
+        let monitor = PowerMonitor(
+            batteryStateProbe: {
+                let call = probeCounter.next()
+
+                switch call {
+                case 1:
+                    return false
+                case 2:
+                    firstChangeStarted.signal()
+                    _ = releaseFirstChange.wait(timeout: .now() + 2)
+                    return false
+                default:
+                    secondChangeStarted.signal()
+                    _ = releaseSecondChange.wait(timeout: .now() + 2)
+                    return true
+                }
+            },
+            startMonitoring: false
+        )
+        var changes: [Bool] = []
+        var acReconnects = 0
+        let powerChangeApplied = expectation(description: "latest power change applied")
+        let unexpectedACReconnect = DispatchSemaphore(value: 0)
+        monitor.onPowerSourceChanged = {
+            changes.append($0)
+            powerChangeApplied.fulfill()
+        }
+        monitor.onACReconnected = {
+            acReconnects += 1
+            unexpectedACReconnect.signal()
+        }
+
+        monitor.handlePowerSourceChanged()
+        XCTAssertEqual(firstChangeStarted.wait(timeout: .now() + 2), .success)
+        monitor.handlePowerSourceChanged()
+        XCTAssertEqual(secondChangeStarted.wait(timeout: .now() + 2), .success)
+
+        releaseSecondChange.signal()
+        await fulfillment(of: [powerChangeApplied], timeout: 2)
+        releaseFirstChange.signal()
+        await Task.yield()
+
+        XCTAssertTrue(monitor.isOnBattery)
+        XCTAssertEqual(changes, [true])
+        XCTAssertEqual(acReconnects, 0)
+        XCTAssertEqual(unexpectedACReconnect.wait(timeout: .now()), .timedOut)
+    }
+}

--- a/desktop/macos/Desktop/Tests/ReentrancyGateTests.swift
+++ b/desktop/macos/Desktop/Tests/ReentrancyGateTests.swift
@@ -88,6 +88,7 @@ final class ReentrancyGateTests: XCTestCase {
                 gate.exit()
                 exitCalls += 1
             }
+            XCTAssertFalse(gate.tryEnter(), "critical section should keep the gate closed")
         }
 
         // Caller A (the test itself) acquires the gate directly.

--- a/desktop/macos/Desktop/Tests/RewindDatabaseLifecycleTests.swift
+++ b/desktop/macos/Desktop/Tests/RewindDatabaseLifecycleTests.swift
@@ -1,0 +1,29 @@
+import XCTest
+
+@testable import Omi_Computer
+
+final class RewindDatabaseLifecycleTests: XCTestCase {
+
+  func testCloseClearsRunningFlag() async throws {
+    let testUserId = "rewind-db-lifecycle-\(UUID().uuidString)"
+    let userDir = FileManager.default
+      .urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+      .appendingPathComponent("Omi", isDirectory: true)
+      .appendingPathComponent("users", isDirectory: true)
+      .appendingPathComponent(testUserId, isDirectory: true)
+    defer { try? FileManager.default.removeItem(at: userDir) }
+
+    await RewindDatabase.shared.close()
+    RewindDatabase.currentUserId = testUserId
+    await RewindDatabase.shared.configure(userId: testUserId)
+    try await RewindDatabase.shared.initialize()
+
+    let runningFlag = userDir.appendingPathComponent(".omi_running")
+    XCTAssertTrue(FileManager.default.fileExists(atPath: runningFlag.path))
+
+    await RewindDatabase.shared.close()
+
+    XCTAssertFalse(FileManager.default.fileExists(atPath: runningFlag.path))
+    RewindDatabase.currentUserId = nil
+  }
+}

--- a/desktop/macos/Desktop/Tests/RewindStorageVideoFrameExtractionTests.swift
+++ b/desktop/macos/Desktop/Tests/RewindStorageVideoFrameExtractionTests.swift
@@ -71,6 +71,30 @@ final class RewindStorageVideoFrameExtractionTests: XCTestCase {
     }
   }
 
+  func testResetRebindsVideoEncoderToNextUserDirectory() async throws {
+    let maybeFirstVideosDir = await VideoChunkEncoder.shared.videosDirectoryForTesting()
+    let firstVideosDir = try XCTUnwrap(maybeFirstVideosDir)
+    let nextUserId = "video-frame-test-next-\(UUID().uuidString)"
+    let nextUserDir = FileManager.default
+      .urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+      .appendingPathComponent("Omi", isDirectory: true)
+      .appendingPathComponent("users", isDirectory: true)
+      .appendingPathComponent(nextUserId, isDirectory: true)
+    defer { try? FileManager.default.removeItem(at: nextUserDir) }
+
+    await RewindStorage.shared.reset()
+    RewindDatabase.currentUserId = nextUserId
+    try await RewindStorage.shared.initialize()
+
+    let maybeReboundVideosDir = await VideoChunkEncoder.shared.videosDirectoryForTesting()
+    let reboundVideosDir = try XCTUnwrap(maybeReboundVideosDir)
+    XCTAssertNotEqual(reboundVideosDir.standardizedFileURL, firstVideosDir.standardizedFileURL)
+    XCTAssertEqual(
+      reboundVideosDir.standardizedFileURL,
+      nextUserDir.appendingPathComponent("Videos", isDirectory: true).standardizedFileURL
+    )
+  }
+
   private func createChunk(relativePath: String, colors: [NSColor], frameRate: Double) async throws -> URL {
     let maybeVideosDir = await RewindStorage.shared.getVideosDirectory()
     let videosDir = try XCTUnwrap(maybeVideosDir)

--- a/desktop/macos/Desktop/Tests/STTSessionStateTests.swift
+++ b/desktop/macos/Desktop/Tests/STTSessionStateTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 final class STTSessionStateTests: XCTestCase {
   func testResolveMode_defaultAppleSiliconMic_isLocal() {
-    var session = STTSessionState()
+    let session = STTSessionState()
     let mode = session.resolveMode(
       audioSource: .microphone,
       isAppleSilicon: true,
@@ -13,7 +13,7 @@ final class STTSessionStateTests: XCTestCase {
   }
 
   func testResolveMode_bleDevice_isCloud() {
-    var session = STTSessionState()
+    let session = STTSessionState()
     let mode = session.resolveMode(
       audioSource: .bleDevice,
       isAppleSilicon: true,
@@ -23,7 +23,7 @@ final class STTSessionStateTests: XCTestCase {
   }
 
   func testResolveMode_intelMac_isCloud() {
-    var session = STTSessionState()
+    let session = STTSessionState()
     let mode = session.resolveMode(
       audioSource: .microphone,
       isAppleSilicon: false,
@@ -33,7 +33,7 @@ final class STTSessionStateTests: XCTestCase {
   }
 
   func testResolveMode_debugForceCloud_isCloud() {
-    var session = STTSessionState()
+    let session = STTSessionState()
     let mode = session.resolveMode(
       audioSource: .microphone,
       isAppleSilicon: true,

--- a/desktop/macos/Desktop/Tests/ScreenRecordingPermissionPolicyTests.swift
+++ b/desktop/macos/Desktop/Tests/ScreenRecordingPermissionPolicyTests.swift
@@ -86,4 +86,21 @@ final class ScreenRecordingPermissionPolicyTests: XCTestCase {
   func testCaptureKitFailureDoesNotCreatePermissionFailureWhenTccIsDenied() {
     XCTAssertFalse(ScreenRecordingPermissionPolicy.shouldMarkCaptureKitBroken(tccGranted: false))
   }
+
+  func testScreenCaptureRestartsUseSharedRelaunchCommand() throws {
+    let src = try sourceFile("Sources/ScreenCaptureService.swift")
+    XCTAssertTrue(src.contains("static func screenCaptureRelaunchCommand(appPath: String) -> String"))
+    XCTAssertTrue(src.contains("AppState.relaunchCommand("))
+
+    guard let softRange = src.range(of: "static func softRecoveryAndRestart()"),
+      let resetRange = src.range(of: "static func resetScreenCapturePermissionAndRestart()")
+    else { return XCTFail("screen-capture restart helpers must exist") }
+    let softSnippet = String(src[softRange.lowerBound...]).prefix(4200)
+    let resetSnippet = String(src[resetRange.lowerBound...]).prefix(3000)
+
+    XCTAssertTrue(softSnippet.contains("screenCaptureRelaunchCommand(appPath: bundleURL.path)"))
+    XCTAssertTrue(resetSnippet.contains("screenCaptureRelaunchCommand(appPath: bundleURL.path)"))
+    XCTAssertFalse(softSnippet.contains("sleep 0.5 && open"))
+    XCTAssertFalse(resetSnippet.contains("sleep 0.5 && open"))
+  }
 }

--- a/desktop/macos/Desktop/Tests/StartupWarmupPolicyTests.swift
+++ b/desktop/macos/Desktop/Tests/StartupWarmupPolicyTests.swift
@@ -280,7 +280,7 @@ final class StartupWarmupPolicyTests: XCTestCase {
 
         XCTAssertTrue(source.contains("private var sessionTasks: [StartupWarmupTaskID: Task<Void, Never>]"))
         XCTAssertTrue(source.contains("scheduleSessionWarmup(id: .mcpKeyWarmup"))
-        XCTAssertTrue(source.contains("guard await self.isCurrentSession(scope) else"))
+        XCTAssertTrue(source.contains("guard self.isCurrentSession(scope) else"))
         XCTAssertTrue(source.contains("guard isCurrentSession(scope) else { return }"))
         XCTAssertTrue(source.contains("sessionTasks.values.forEach { $0.cancel() }"))
         XCTAssertTrue(source.contains("sessionTasks.removeAll()"))

--- a/desktop/macos/Desktop/Tests/WALServiceUploadTests.swift
+++ b/desktop/macos/Desktop/Tests/WALServiceUploadTests.swift
@@ -138,6 +138,20 @@ final class WALServiceUploadTests: XCTestCase {
     XCTAssertEqual(service.wals.first?.storage, .disk)
   }
 
+  func testWalMetadataPersistsLatestQueuedSnapshot() throws {
+    var wal = try seedWalOnDisk()
+    service.saveWals()
+
+    wal.status = .synced
+    service.setWalsForTesting([wal])
+    service.saveWals()
+    service.waitForWalMetadataWritesForTesting()
+
+    let metadataURL = walDir.appendingPathComponent("wals.json")
+    let metadata = try JSONDecoder().decode(WALMetadata.self, from: Data(contentsOf: metadataURL))
+    XCTAssertEqual(metadata.wals.first?.status, .synced)
+  }
+
   func testDegradedDirectoryRetainsCurrentFramesAndRecordsHealth() throws {
     service.setWalDirectoryForTesting(nil)
     service.startRecording(device: "dev1", codec: "opus")

--- a/desktop/macos/changelog/unreleased/20260711-macos-bug-audit-regressions.json
+++ b/desktop/macos/changelog/unreleased/20260711-macos-bug-audit-regressions.json
@@ -1,0 +1,3 @@
+{
+  "change": "Improved macOS reliability around sign-out cleanup, capture lifecycle recovery, Bluetooth audio, and local storage persistence."
+}

--- a/desktop/macos/e2e/flows/capture-lifecycle.yaml
+++ b/desktop/macos/e2e/flows/capture-lifecycle.yaml
@@ -7,6 +7,7 @@ covers:
   - desktop/macos/Desktop/Sources/AppState/AppState+Transcription.swift
   - desktop/macos/Desktop/Sources/AppState/AppState+ListenEvents.swift
   - desktop/macos/Desktop/Sources/AppState/STTSessionState.swift
+  - desktop/macos/Desktop/Sources/LocalTranscriptionService.swift
   - desktop/macos/Desktop/Sources/TranscriptionService.swift
   - desktop/macos/Desktop/Sources/APIClient.swift
   - desktop/macos/Desktop/Sources/Services/OmiHTTPTransport.swift
@@ -16,6 +17,7 @@ covers:
   - desktop/macos/Desktop/Sources/MainWindow/Conversations/ConversationRepository.swift
   - desktop/macos/Desktop/Sources/MainWindow/Pages/ConversationDetailView.swift
   - desktop/macos/Desktop/Sources/Rewind/Core/RewindDatabase.swift
+  - desktop/macos/Desktop/Sources/Rewind/Core/VideoChunkEncoder.swift
   - desktop/macos/Desktop/Sources/Rewind/Core/TranscriptionModels.swift
   - desktop/macos/Desktop/Sources/Rewind/Core/TranscriptionStorage.swift
   - desktop/macos/Desktop/Sources/APIClient.swift
@@ -36,6 +38,8 @@ covers:
   - desktop/macos/Desktop/Sources/Services/QueryTracer.swift
   - desktop/macos/Desktop/Sources/Rewind/Core/VideoChunkEncoder.swift
   - desktop/macos/Desktop/Sources/Rewind/Services/RewindIndexer.swift
+  - desktop/macos/Desktop/Sources/MeetingDetector.swift
+  - desktop/macos/Desktop/Sources/Rewind/Services/PowerMonitor.swift
 preconditions:
   - automation_bridge_ready
 

--- a/desktop/macos/e2e/flows/chat-hermetic.yaml
+++ b/desktop/macos/e2e/flows/chat-hermetic.yaml
@@ -8,6 +8,7 @@ covers:
   - desktop/macos/Desktop/Sources/BrowserExtensionSetup.swift
   - desktop/macos/Desktop/Sources/MainWindow/Pages/ChatPage.swift
   - desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
+  - desktop/macos/Desktop/Sources/Providers/AgentRuntimeRouting.swift
   - desktop/macos/Desktop/Sources/AnalyticsManager.swift
   - desktop/macos/Desktop/Sources/Chat/AgentBridge.swift
   - desktop/macos/Desktop/Sources/Chat/AgentControlService.swift

--- a/desktop/macos/e2e/flows/harness-smoke.yaml
+++ b/desktop/macos/e2e/flows/harness-smoke.yaml
@@ -10,11 +10,13 @@ covers:
   - desktop/macos/Desktop/Sources/Auth/SessionRecoveryView.swift
   - desktop/macos/Desktop/Sources/Auth/AuthStorageCanary.swift
   - desktop/macos/Desktop/Sources/DesktopKeychainStore.swift
+  - desktop/macos/Desktop/Sources/Logger.swift
   - desktop/macos/Desktop/Sources/ClientDeviceService.swift
   - desktop/macos/Desktop/Sources/LocalAgentAPIServer.swift
   - desktop/macos/Desktop/Sources/AgentSyncService.swift
   - desktop/macos/Desktop/Sources/APIKeyService.swift
   - desktop/macos/Desktop/Sources/FileIndexing/FileIndexerService.swift
+  - desktop/macos/Desktop/Sources/StartupWarmupCoordinator.swift
   - desktop/macos/Desktop/Sources/OmiApp.swift
   - desktop/macos/Desktop/Sources/ViewModelContainer.swift
   - desktop/macos/Desktop/Sources/Onboarding/OnboardingChatView.swift

--- a/desktop/macos/scripts/swift-test-skips.json
+++ b/desktop/macos/scripts/swift-test-skips.json
@@ -1,10 +1,9 @@
 {
-  "max_skip_count": 5,
+  "max_skip_count": 4,
   "allowed_tests": [
     "ChatDiscoverabilityTests/testAgentControlCapabilitiesMatchCanonicalManifest",
     "ChatDiscoverabilityTests/testDesktopCapabilitiesExistInAgentToolDeclarations",
     "APIClientRoutingTests/testDeleteConversationRoutesToPython",
-    "ActionItemsFTSRepairTests/testRepairToleratesMissingActionItemsFTSShadowTable",
     "PiMonoWiringTests/testLocalAgentProviderDetectorMissingPromptIsUserFacing"
   ],
   "skips": [
@@ -22,11 +21,6 @@
       "test": "APIClientRoutingTests/testDeleteConversationRoutesToPython",
       "issue": "https://github.com/BasedHardware/omi/issues/9031",
       "reason": "The client omits ?cascade=true; cascade is backend-gated behind owner sign-off, so flipping it is a data-deletion behavior change."
-    },
-    {
-      "test": "ActionItemsFTSRepairTests/testRepairToleratesMissingActionItemsFTSShadowTable",
-      "issue": "https://github.com/BasedHardware/omi/issues/9032",
-      "reason": "macOS 26 system SQLite rejects DELETE FROM sqlite_master even with writable_schema=ON, blocking the test corruption setup."
     },
     {
       "test": "PiMonoWiringTests/testLocalAgentProviderDetectorMissingPromptIsUserFacing",


### PR DESCRIPTION
## Summary

- Problem: several macOS desktop bug-audit findings could leave stale callbacks, stale auth/storage state, forbidden FTS repair behavior, or Swift 6 concurrency warnings in place.
- What changed: hardened macOS lifecycle/persistence paths, repaired FTS rebuild behavior, fixed Swift 6 sendability/locking warnings, and added focused regression coverage for the fixed bug classes.
- What did NOT change (scope boundary): no mobile/backend API contract changes, no new permissions, no new network endpoints, and no schema migration beyond existing local desktop storage behavior.

## Linked Issue / Bounty

- Closes N/A
- Related N/A — independent macOS desktop bug-audit contribution

## Product invariants affected

- INV-AUTH-1
- INV-CHAT-1

## Root Cause (bug fixes only)

- Root cause: multiple desktop paths relied on stale async callbacks, stale per-user singleton/cache bindings, unordered persistence writes, unsupported SQLite FTS repair mutation, or APIs/locking patterns that are fragile under current macOS/Swift behavior.
- Why it wasn't caught before: existing coverage focused on happy-path state transitions and source-shape checks; it did not exercise stale callback ordering, logout-to-reinit isolation, WAL metadata write ordering, VideoChunkEncoder user rebinding, or FTS repair under SQLite defensive restrictions.

## How It Works

- Gates stale meeting and power-monitor probes so delayed detached work cannot mutate stopped or newer state.
- Guards sign-out cleanup and Rewind close/cache invalidation against races with a newer auth/database session.
- Clears Rewind's retained user binding on sign-out, clears `.omi_running` on normal close, and lets VideoChunkEncoder reset/rebind across user switches.
- Serializes WAL metadata writes so older async snapshots cannot overwrite newer on-disk state.
- Reworks action-item FTS repair to use supported durable-row rebuild behavior instead of forbidden SQLite catalog mutation.
- Routes screen-capture restart paths through the shared relaunch command so non-production automation arguments are preserved.
- Replaces direct lock/unlock calls in async Bluetooth code with scoped locking to remove Swift 6 concurrency warnings while still resuming continuations outside locks.

## Change Type

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Docs
- [ ] Chore / infra

## Scope

- [ ] Mobile app (Flutter)
- [x] Desktop app (Swift/macOS)
- [ ] Backend (Python API)
- [ ] Firmware / hardware
- [ ] Plugins / integrations
- [ ] SDKs (Expo / React Native / Python / Swift)
- [ ] MCP server
- [ ] Web frontend
- [ ] Docs
- [ ] CI / build / infra

## Security Impact

- New permissions or capabilities introduced? `No`
- Auth or token handling changed? `Yes`
- Data access scope changed (screen data, OCR, user data)? `Yes`
- New or changed network calls? `No`
- Plugin or tool execution surface changed? `No`
- If any `Yes` — risk and mitigation: sign-out/auth and Rewind storage handling changed to reduce cross-session/cross-user leakage risk. Mitigations are generation guards, explicit user binding reset, cache invalidation only when the intended database generation closes, and regression tests for session cleanup and storage rebinding.

## Testing

- [x] Built locally
- [x] Manual verification:
  - Verified the branch was replayed onto current `upstream/main` before PR creation.
  - Verified `git diff --check upstream/main...HEAD` is clean.
  - Verified the actual upstream PR diff is 38 files.
- [x] Existing tests pass
- [x] New tests added (if applicable)

## Human Verification

- Verified scenarios:
  - `swift build` completed successfully on the refreshed upstream branch.
  - focused auth source-boundary regression passed: `swift test --filter AuthSessionCoordinatorTests/testInvalidateSessionIsLightVersusNuclearSignOut`.
  - full macOS SwiftPM suite passed: `swift test` executed 2,012 tests with 0 failures.
- Edge cases checked:
  - stale meeting probe after stop
  - out-of-order power probe completion
  - sign-out cleanup racing a newer session
  - Rewind DB close clears running flag
  - VideoChunkEncoder rebinds after reset/user switch
  - WAL metadata latest queued snapshot wins
  - screen-capture restart paths keep shared relaunch command behavior
  - FTS repair avoids unsupported SQLite catalog mutation
  - async Bluetooth lock sites no longer emit Swift 6 lock/unlock warnings
- What you did **not** verify (and why): no packaged/notarized app build and no manual device/Bluetooth hardware run; this PR is covered by SwiftPM build/tests and source-level regression coverage.

## Evidence

- [ ] Screenshot or recording
- [x] Log output (before/after)
- [x] Test output
- [ ] N/A — change is not user-visible

Local verification summary:

```text
swift build
Build complete! (9.08s)
Remaining warning: external Homebrew libwebp deployment-target linker warning.

swift test --filter AuthSessionCoordinatorTests/testInvalidateSessionIsLightVersusNuclearSignOut
Executed 1 test, with 0 failures.

swift test
Executed 2012 tests, with 0 failures.
```

## Docs

- [ ] Updated docs in [`docs/`](https://github.com/BasedHardware/omi/tree/main/docs) (if user-facing change)
- [x] N/A — no docs impact

## Performance, Privacy, and Reliability

Reliability improves by discarding stale async results, serializing WAL metadata persistence, preserving relaunch invariants, and avoiding unsupported FTS repair mutation. Privacy improves by reducing stale per-user Rewind/video storage reuse after logout or user switch. No expected runtime performance regression; added synchronization is scoped to low-frequency lifecycle/persistence metadata paths.

## Migration / Backward Compatibility

- Backward compatible? `Yes`
- Migration needed? `No`
- If yes, upgrade steps: N/A

## Risks and Mitigations

- Risk: broader desktop lifecycle changes can hide timing regressions.
  - Mitigation: focused regression tests cover stale callback ordering, logout/session cleanup, WAL ordering, and storage rebinding; full SwiftPM suite passes.
- Risk: sign-out cleanup guards could skip old-session cleanup if generation accounting is wrong.
  - Mitigation: cleanup only skips when a newer auth/database session is observable; tests cover the stale cleanup path.
- Risk: PR scope is wider than a one-bug patch.
  - Mitigation: changes are limited to desktop/macOS bug-audit fixes and grouped around reliability/concurrency/persistence regressions.

## AI Disclosure

- Tools used: OpenAI Codex / OpenClaw agent workflow.
- AI-assisted portions: bug audit, code changes, regression tests, PR preparation.
- How you verified correctness: local `swift build`, focused regression test, full `swift test`, `git diff --check`, source inspection, and GitHub PR preflight review against the Omi PR standard.
