### PR TITLE
Fix storage actors using stale DB pool after recovery (draft — needs local build)

### DIFF
--- a/desktop/macos/Desktop/Sources/FileIndexing/KnowledgeGraphStorage.swift
+++ b/desktop/macos/Desktop/Sources/FileIndexing/KnowledgeGraphStorage.swift
@@ -6,17 +6,20 @@ actor KnowledgeGraphStorage {
     static let shared = KnowledgeGraphStorage()
 
     private var _dbQueue: DatabasePool?
+    private var _dbGeneration = -1
 
     private init() {}
 
     private func ensureDB() async throws -> DatabasePool {
-        if let db = _dbQueue { return db }
+        if let db = _dbQueue, await RewindDatabase.shared.poolGeneration() == _dbGeneration { return db }
 
         try await RewindDatabase.shared.initialize()
-        guard let db = await RewindDatabase.shared.getDatabaseQueue() else {
+        let (queue, generation) = await RewindDatabase.shared.getDatabaseQueueWithGeneration()
+        guard let db = queue else {
             throw NSError(domain: "KnowledgeGraphStorage", code: 1, userInfo: [NSLocalizedDescriptionKey: "Database not initialized"])
         }
         _dbQueue = db
+        _dbGeneration = generation
         return db
     }
 

--- a/desktop/macos/Desktop/Sources/LiveNotes/NoteStorage.swift
+++ b/desktop/macos/Desktop/Sources/LiveNotes/NoteStorage.swift
@@ -7,6 +7,7 @@ actor NoteStorage {
     static let shared = NoteStorage()
 
     private var _dbQueue: DatabasePool?
+    private var _dbGeneration = -1
     private var isInitialized = false
 
     private init() {}
@@ -19,7 +20,7 @@ actor NoteStorage {
 
     /// Ensure database is initialized before use
     private func ensureInitialized() async throws -> DatabasePool {
-        if let db = _dbQueue {
+        if let db = _dbQueue, await RewindDatabase.shared.poolGeneration() == _dbGeneration {
             return db
         }
 
@@ -31,11 +32,13 @@ actor NoteStorage {
             throw error
         }
 
-        guard let db = await RewindDatabase.shared.getDatabaseQueue() else {
+        let (queue, generation) = await RewindDatabase.shared.getDatabaseQueueWithGeneration()
+        guard let db = queue else {
             throw LiveNoteError.databaseNotInitialized
         }
 
         _dbQueue = db
+        _dbGeneration = generation
         isInitialized = true
         return db
     }

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/AIUserProfileService.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/AIUserProfileService.swift
@@ -41,6 +41,7 @@ actor AIUserProfileService {
 
     /// Cached database pool
     private var _dbQueue: DatabasePool?
+    private var _dbGeneration = -1
 
     /// Invalidate cached DB queue (called on user switch / sign-out)
     func invalidateCache() {
@@ -50,12 +51,14 @@ actor AIUserProfileService {
     // MARK: - Database Access
 
     private func ensureDB() async throws -> DatabasePool {
-        if let db = _dbQueue { return db }
+        if let db = _dbQueue, await RewindDatabase.shared.poolGeneration() == _dbGeneration { return db }
         try await RewindDatabase.shared.initialize()
-        guard let db = await RewindDatabase.shared.getDatabaseQueue() else {
+        let (queue, generation) = await RewindDatabase.shared.getDatabaseQueueWithGeneration()
+        guard let db = queue else {
             throw ProfileError.databaseNotAvailable
         }
         _dbQueue = db
+        _dbGeneration = generation
         return db
     }
 

--- a/desktop/macos/Desktop/Sources/Rewind/Core/ActionItemStorage.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/ActionItemStorage.swift
@@ -7,6 +7,7 @@ actor ActionItemStorage {
     static let shared = ActionItemStorage()
 
     private var _dbQueue: DatabasePool?
+    private var _dbGeneration = -1
     private var isInitialized = false
 
     private init() {}
@@ -19,7 +20,7 @@ actor ActionItemStorage {
 
     /// Ensure database is initialized before use
     private func ensureInitialized() async throws -> DatabasePool {
-        if let db = _dbQueue {
+        if let db = _dbQueue, await RewindDatabase.shared.poolGeneration() == _dbGeneration {
             return db
         }
 
@@ -31,11 +32,13 @@ actor ActionItemStorage {
             throw error
         }
 
-        guard let db = await RewindDatabase.shared.getDatabaseQueue() else {
+        let (queue, generation) = await RewindDatabase.shared.getDatabaseQueueWithGeneration()
+        guard let db = queue else {
             throw ActionItemStorageError.databaseNotInitialized
         }
 
         _dbQueue = db
+        _dbGeneration = generation
         isInitialized = true
         return db
     }

--- a/desktop/macos/Desktop/Sources/Rewind/Core/GoalStorage.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/GoalStorage.swift
@@ -26,6 +26,7 @@ actor GoalStorage {
     static let shared = GoalStorage()
 
     private var _dbQueue: DatabasePool?
+    private var _dbGeneration = -1
     private var isInitialized = false
 
     private init() {}
@@ -38,16 +39,18 @@ actor GoalStorage {
 
     /// Ensure database is initialized before use
     private func ensureInitialized() async throws -> DatabasePool {
-        if let db = _dbQueue {
+        if let db = _dbQueue, await RewindDatabase.shared.poolGeneration() == _dbGeneration {
             return db
         }
 
         try await RewindDatabase.shared.initialize()
-        guard let db = await RewindDatabase.shared.getDatabaseQueue() else {
+        let (queue, generation) = await RewindDatabase.shared.getDatabaseQueueWithGeneration()
+        guard let db = queue else {
             throw GoalStorageError.databaseNotInitialized
         }
 
         _dbQueue = db
+        _dbGeneration = generation
         isInitialized = true
         return db
     }

--- a/desktop/macos/Desktop/Sources/Rewind/Core/MemoryStorage.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/MemoryStorage.swift
@@ -7,6 +7,7 @@ actor MemoryStorage {
     static let shared = MemoryStorage()
 
     private var _dbQueue: DatabasePool?
+    private var _dbGeneration = -1
     private var isInitialized = false
 
     private init() {}
@@ -19,7 +20,7 @@ actor MemoryStorage {
 
     /// Ensure database is initialized before use
     private func ensureInitialized() async throws -> DatabasePool {
-        if let db = _dbQueue {
+        if let db = _dbQueue, await RewindDatabase.shared.poolGeneration() == _dbGeneration {
             return db
         }
 
@@ -31,11 +32,13 @@ actor MemoryStorage {
             throw error
         }
 
-        guard let db = await RewindDatabase.shared.getDatabaseQueue() else {
+        let (queue, generation) = await RewindDatabase.shared.getDatabaseQueueWithGeneration()
+        guard let db = queue else {
             throw MemoryStorageError.databaseNotInitialized
         }
 
         _dbQueue = db
+        _dbGeneration = generation
         isInitialized = true
         return db
     }

--- a/desktop/macos/Desktop/Sources/Rewind/Core/ProactiveStorage.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/ProactiveStorage.swift
@@ -7,6 +7,7 @@ actor ProactiveStorage {
     static let shared = ProactiveStorage()
 
     private var _dbQueue: DatabasePool?
+    private var _dbGeneration = -1
     private var isInitialized = false
 
     private init() {}
@@ -19,7 +20,7 @@ actor ProactiveStorage {
 
     /// Ensure database is initialized before use
     private func ensureInitialized() async throws -> DatabasePool {
-        if let db = _dbQueue {
+        if let db = _dbQueue, await RewindDatabase.shared.poolGeneration() == _dbGeneration {
             return db
         }
 
@@ -31,11 +32,13 @@ actor ProactiveStorage {
             throw error
         }
 
-        guard let db = await RewindDatabase.shared.getDatabaseQueue() else {
+        let (queue, generation) = await RewindDatabase.shared.getDatabaseQueueWithGeneration()
+        guard let db = queue else {
             throw ProactiveStorageError.databaseNotInitialized
         }
 
         _dbQueue = db
+        _dbGeneration = generation
         isInitialized = true
         return db
     }

--- a/desktop/macos/Desktop/Sources/Rewind/Core/RewindDatabase.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/RewindDatabase.swift
@@ -51,6 +51,20 @@ actor RewindDatabase {
         return dbQueue
     }
 
+    /// Monotonic epoch of the current `dbQueue`. Bumped on every close and every
+    /// pool (re)open, so a storage actor that cached a pool can detect a swap
+    /// (corruption/maintenance recovery replaces the pool) and drop its stale
+    /// reference instead of reading/writing a closed or unlinked file.
+    func poolGeneration() -> Int {
+        return initGeneration
+    }
+
+    /// Atomically read the current pool and its epoch together, so a caching
+    /// storage actor stores a consistent (pool, generation) pair.
+    func getDatabaseQueueWithGeneration() -> (pool: DatabasePool?, generation: Int) {
+        return (dbQueue, initGeneration)
+    }
+
     /// Report a query error from a storage actor or subsystem.
     /// Tracks consecutive SQLITE_IOERR/CORRUPT errors. When the threshold is reached,
     /// closes the database so the next initialize() call triggers recovery.
@@ -471,6 +485,10 @@ actor RewindDatabase {
         }
 
         dbQueue = activeQueue
+        // Bump the epoch on every pool (re)open so storage actors that cached the
+        // previous pool revalidate and drop it — recovery may have replaced the
+        // underlying omi.db file, leaving the old pool pointing at a stale inode.
+        initGeneration += 1
         openedForUserId = configuredUserId ?? RewindDatabase.currentUserId ?? "anonymous"
         consecutiveQueryIOErrors = 0
 

--- a/desktop/macos/Desktop/Sources/Rewind/Core/RewindDatabase.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/RewindDatabase.swift
@@ -23,8 +23,17 @@ actor RewindDatabase {
     /// The user ID that was actually used to open the current database
     private var openedForUserId: String?
 
-    /// Generation counter — incremented on close() so stale task completions don't corrupt state
+    /// Generation counter — incremented on close() so stale task completions don't corrupt state.
+    /// NOTE: `initialize()` captures this before `performInitialization()` and clears
+    /// `initializationTask` only if it is unchanged afterward, so it MUST NOT be bumped
+    /// during a normal open. Pool-swap detection uses the separate `poolEpoch` below.
     private var initGeneration: Int = 0
+
+    /// Epoch of the current `dbQueue`, bumped on every close AND every pool (re)open.
+    /// Storage actors cache this alongside the pool and revalidate to detect a swap
+    /// (recovery replaces the pool) — kept distinct from `initGeneration` so bumping it
+    /// on open does not break the in-flight-close detection in `initialize()`.
+    private var poolEpoch: Int = 0
 
     /// Static user ID for nonisolated markCleanShutdown (set by configure(userId:))
     nonisolated(unsafe) static var currentUserId: String?
@@ -56,13 +65,13 @@ actor RewindDatabase {
     /// (corruption/maintenance recovery replaces the pool) and drop its stale
     /// reference instead of reading/writing a closed or unlinked file.
     func poolGeneration() -> Int {
-        return initGeneration
+        return poolEpoch
     }
 
     /// Atomically read the current pool and its epoch together, so a caching
     /// storage actor stores a consistent (pool, generation) pair.
     func getDatabaseQueueWithGeneration() -> (pool: DatabasePool?, generation: Int) {
-        return (dbQueue, initGeneration)
+        return (dbQueue, poolEpoch)
     }
 
     /// Report a query error from a storage actor or subsystem.
@@ -278,7 +287,8 @@ actor RewindDatabase {
         runningFlagPath = nil
         openedForUserId = nil
         initGeneration += 1
-        log("RewindDatabase: Closed database (generation \(initGeneration))")
+        poolEpoch += 1
+        log("RewindDatabase: Closed database (generation \(initGeneration), pool epoch \(poolEpoch))")
     }
 
     /// Switch to a different user's database.
@@ -485,10 +495,13 @@ actor RewindDatabase {
         }
 
         dbQueue = activeQueue
-        // Bump the epoch on every pool (re)open so storage actors that cached the
+        // Bump the pool epoch on every (re)open so storage actors that cached the
         // previous pool revalidate and drop it — recovery may have replaced the
         // underlying omi.db file, leaving the old pool pointing at a stale inode.
-        initGeneration += 1
+        // This is `poolEpoch`, NOT `initGeneration`: initialize() relies on
+        // initGeneration staying unchanged across a normal open to clear its
+        // initializationTask.
+        poolEpoch += 1
         openedForUserId = configuredUserId ?? RewindDatabase.currentUserId ?? "anonymous"
         consecutiveQueryIOErrors = 0
 

--- a/desktop/macos/Desktop/Sources/Rewind/Core/StagedTaskStorage.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/StagedTaskStorage.swift
@@ -13,6 +13,7 @@ actor StagedTaskStorage {
     static let shared = StagedTaskStorage()
 
     private var _dbQueue: DatabasePool?
+    private var _dbGeneration = -1
     private var isInitialized = false
 
     private init() {}
@@ -23,7 +24,7 @@ actor StagedTaskStorage {
     }
 
     private func ensureInitialized() async throws -> DatabasePool {
-        if let db = _dbQueue {
+        if let db = _dbQueue, await RewindDatabase.shared.poolGeneration() == _dbGeneration {
             return db
         }
 
@@ -34,11 +35,13 @@ actor StagedTaskStorage {
             throw error
         }
 
-        guard let db = await RewindDatabase.shared.getDatabaseQueue() else {
+        let (queue, generation) = await RewindDatabase.shared.getDatabaseQueueWithGeneration()
+        guard let db = queue else {
             throw ActionItemStorageError.databaseNotInitialized
         }
 
         _dbQueue = db
+        _dbGeneration = generation
         isInitialized = true
         return db
     }

--- a/desktop/macos/Desktop/Sources/Rewind/Core/TaskChatMessageStorage.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/TaskChatMessageStorage.swift
@@ -113,6 +113,7 @@ actor TaskChatMessageStorage {
     static let shared = TaskChatMessageStorage()
 
     private var _dbQueue: DatabasePool?
+    private var _dbGeneration = -1
     private var isInitialized = false
 
     private init() {}
@@ -123,7 +124,7 @@ actor TaskChatMessageStorage {
     }
 
     private func ensureInitialized() async throws -> DatabasePool {
-        if let db = _dbQueue {
+        if let db = _dbQueue, await RewindDatabase.shared.poolGeneration() == _dbGeneration {
             return db
         }
 
@@ -134,11 +135,13 @@ actor TaskChatMessageStorage {
             throw error
         }
 
-        guard let db = await RewindDatabase.shared.getDatabaseQueue() else {
+        let (queue, generation) = await RewindDatabase.shared.getDatabaseQueueWithGeneration()
+        guard let db = queue else {
             throw TaskChatMessageStorageError.databaseNotInitialized
         }
 
         _dbQueue = db
+        _dbGeneration = generation
         isInitialized = true
         return db
     }

--- a/desktop/macos/Desktop/Sources/Rewind/Core/TranscriptionStorage.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/TranscriptionStorage.swift
@@ -18,6 +18,7 @@ actor TranscriptionStorage {
     static let shared = TranscriptionStorage()
 
     private var _dbQueue: DatabasePool?
+    private var _dbGeneration = -1
     private var isInitialized = false
 
     private init() {}
@@ -30,7 +31,7 @@ actor TranscriptionStorage {
 
     /// Ensure database is initialized before use
     private func ensureInitialized() async throws -> DatabasePool {
-        if let db = _dbQueue {
+        if let db = _dbQueue, await RewindDatabase.shared.poolGeneration() == _dbGeneration {
             return db
         }
 
@@ -42,11 +43,13 @@ actor TranscriptionStorage {
             throw error
         }
 
-        guard let db = await RewindDatabase.shared.getDatabaseQueue() else {
+        let (queue, generation) = await RewindDatabase.shared.getDatabaseQueueWithGeneration()
+        guard let db = queue else {
             throw TranscriptionStorageError.databaseNotInitialized
         }
 
         _dbQueue = db
+        _dbGeneration = generation
         isInitialized = true
         return db
     }

--- a/desktop/macos/changelog/unreleased/20260711-rewinddb-stale-pool.json
+++ b/desktop/macos/changelog/unreleased/20260711-rewinddb-stale-pool.json
@@ -1,0 +1,3 @@
+{
+    "change": "Fixed local storage continuing to use a stale database connection after an automatic corruption recovery, which could hide recent data or repeat errors until the next restart"
+}

--- a/desktop/macos/e2e/flows/capture-lifecycle.yaml
+++ b/desktop/macos/e2e/flows/capture-lifecycle.yaml
@@ -18,6 +18,10 @@ covers:
   - desktop/macos/Desktop/Sources/Rewind/Core/RewindDatabase.swift
   - desktop/macos/Desktop/Sources/Rewind/Core/TranscriptionModels.swift
   - desktop/macos/Desktop/Sources/Rewind/Core/TranscriptionStorage.swift
+  - desktop/macos/Desktop/Sources/Rewind/Core/ProactiveStorage.swift
+  - desktop/macos/Desktop/Sources/LiveNotes/NoteStorage.swift
+  - desktop/macos/Desktop/Sources/FileIndexing/KnowledgeGraphStorage.swift
+  - desktop/macos/Desktop/Sources/ProactiveAssistants/Services/AIUserProfileService.swift
   - desktop/macos/Desktop/Sources/APIClient.swift
   - desktop/macos/Desktop/Sources/OmiWAL/WALModel.swift
   - desktop/macos/Desktop/Sources/WAL/StorageSyncService.swift


### PR DESCRIPTION
## Summary

Follow-up #3 of 3 from the macOS bug-sweep deferrals. Fixes storage actors continuing to use a **stale `DatabasePool`** after an automatic database recovery.

> **⚠️ Draft — needs a local build to verify.** Authored with no Swift toolchain, so **not compiled**. Please build (`cd desktop/macos && xcrun swift build -c debug --package-path Desktop`) and exercise the corruption/recovery path before merge.

## The bug

Ten storage actors each cache `RewindDatabase`'s `DatabasePool` in `_dbQueue` and return it forever:

```swift
if let db = _dbQueue { return db }   // never re-consults RewindDatabase
```

When runtime corruption (`reportQueryError` threshold) or the maintenance path recovers the DB, `RewindDatabase` deletes/recreates `omi.db` and opens a **new** pool. The actors keep using the **old** pool, whose file descriptors point at the unlinked/replaced inode — reads see stale data, writes land in a ghost file the new pool never sees, or the corrupt pages keep throwing `IOERR`, defeating the very recovery that just ran. `invalidateCache()` was only ever called from sign-out, never from recovery, so the staleness persisted until app restart.

## The fix

- `RewindDatabase` exposes a monotonic pool epoch **`poolGeneration()`** (bumped on every `close()` and every pool (re)open) and an atomic **`getDatabaseQueueWithGeneration()`**.
- Each of the 10 storage actors caches the generation next to the pool, revalidates it on the fast path (`_dbQueue != nil && poolGeneration() == _dbGeneration`), and re-fetches on mismatch — dropping the stale pool. The atomic accessor stores a consistent `(pool, generation)` pair so a swap racing initialization can't leave a mismatched cache.

Files: `RewindDatabase.swift` + the 10 consumers (`ActionItemStorage`, `MemoryStorage`, `TranscriptionStorage`, `ProactiveStorage`, `GoalStorage`, `StagedTaskStorage`, `TaskChatMessageStorage`, `NoteStorage`, `KnowledgeGraphStorage`, `AIUserProfileService`).

## Product invariants
- **INV-CHAT-1** (touches `Rewind/Core/TaskChatMessageStorage.swift`) and **INV-MEM-1** (touches `Rewind/Core/MemoryStorage.swift`) — both cited on a path-glob basis only. The change is DB-pool-lifecycle plumbing (cache invalidation on recovery); it does not alter chat continuity write-path/projection or the memory-tier vocabulary, so no guard-test change is required.

## Trade-off
The fast path now makes one extra actor hop (`poolGeneration()`) per DB access — cheap (no IO), and the correctness win (no split-brain after recovery) is worth it. `invalidateCache()` (sign-out) is unchanged and still works: it nils `_dbQueue`, forcing a fresh fetch that re-reads the generation.

## Verification
- Static checkers pass at baseline; e2e coverage satisfied (4 storage actors added to `capture-lifecycle.yaml`).
- **Not compiled here.** The change is uniform across all 10 consumers (each: add `_dbGeneration`, generation-guard the fast path, atomic tuple fetch + store); the full diff was reviewed for consistency. Reviewer build + a recovery-path exercise is the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RAxLsaxtwVNDTWAZFfJp9q)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9498?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

