### PR TITLE
Fix macOS e2e coverage base selection

### DIFF
--- a/desktop/macos/changelog/unreleased/20260711-e2e-coverage-mainline.json
+++ b/desktop/macos/changelog/unreleased/20260711-e2e-coverage-mainline.json
@@ -1,0 +1,3 @@
+{
+  "change": "Improved macOS desktop test coverage checks so stale fork refs no longer create false coverage failures."
+}

--- a/desktop/macos/scripts/check-e2e-flow-coverage.py
+++ b/desktop/macos/scripts/check-e2e-flow-coverage.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import os
 import subprocess
 import sys
 from dataclasses import dataclass
@@ -13,6 +14,7 @@ from typing import Iterable
 
 DESKTOP_SWIFT_ROOT = Path("desktop/macos/Desktop/Sources")
 DEFAULT_FLOWS_DIR = Path("desktop/macos/e2e/flows")
+GIT_ENV_DROP = {"GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE"}
 
 
 @dataclass(frozen=True)
@@ -37,6 +39,10 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
+def git_env() -> dict[str, str]:
+    return {key: value for key, value in os.environ.items() if key not in GIT_ENV_DROP}
+
+
 def repo_root(explicit: str | None) -> Path:
     if explicit:
         return Path(explicit).resolve()
@@ -47,6 +53,7 @@ def repo_root(explicit: str | None) -> Path:
             stdout=subprocess.PIPE,
             stderr=subprocess.DEVNULL,
             text=True,
+            env=git_env(),
         )
         return Path(result.stdout.strip()).resolve()
     except (subprocess.CalledProcessError, FileNotFoundError):
@@ -61,6 +68,7 @@ def run_git(root: Path, args: list[str]) -> list[str]:
         stdout=subprocess.PIPE,
         stderr=subprocess.DEVNULL,
         text=True,
+        env=git_env(),
     )
     if result.returncode != 0:
         return []
@@ -68,7 +76,8 @@ def run_git(root: Path, args: list[str]) -> list[str]:
 
 
 def default_base(root: Path) -> str | None:
-    for candidate in ("origin/main", "main"):
+    best: tuple[int, str] | None = None
+    for candidate in ("upstream/main", "origin/main", "main"):
         result = subprocess.run(
             ["git", "merge-base", candidate, "HEAD"],
             cwd=root,
@@ -76,10 +85,29 @@ def default_base(root: Path) -> str | None:
             stdout=subprocess.PIPE,
             stderr=subprocess.DEVNULL,
             text=True,
+            env=git_env(),
         )
-        if result.returncode == 0 and result.stdout.strip():
-            return result.stdout.strip()
-    return None
+        merge_base = result.stdout.strip()
+        if result.returncode != 0 or not merge_base:
+            continue
+        distance_result = subprocess.run(
+            ["git", "rev-list", "--count", f"{merge_base}..HEAD"],
+            cwd=root,
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            env=git_env(),
+        )
+        if distance_result.returncode != 0:
+            continue
+        try:
+            distance = int(distance_result.stdout.strip())
+        except ValueError:
+            continue
+        if best is None or distance < best[0]:
+            best = (distance, merge_base)
+    return best[1] if best else None
 
 
 def changed_files_from_git(root: Path, base: str | None, staged: bool) -> list[str]:

--- a/desktop/macos/tests/test-e2e-flow-coverage.sh
+++ b/desktop/macos/tests/test-e2e-flow-coverage.sh
@@ -40,4 +40,60 @@ if "$SCRIPT" --root "$TMPDIR" --strict "$covered" "$uncovered" >"$TMPDIR/strict.
 fi
 grep -q "FAIL: uncovered changed desktop Swift files found" "$TMPDIR/strict.err" || fail "strict failure was not explained"
 
+REPO="$TMPDIR/repo"
+mkdir -p "$REPO/desktop/macos/e2e/flows" "$REPO/desktop/macos/Desktop/Sources/MainWindow/Pages"
+repo_git() {
+  env -u GIT_DIR -u GIT_WORK_TREE -u GIT_INDEX_FILE git -C "$REPO" "$@"
+}
+repo_git init -q
+repo_git config user.email "desktop-tests@example.com"
+repo_git config user.name "Desktop Tests"
+repo_git config core.hooksPath /dev/null
+
+cat >"$REPO/desktop/macos/e2e/flows/chat.yaml" <<'YAML'
+version: 2
+name: chat
+covers:
+  - desktop/Desktop/Sources/MainWindow/Pages/ChatPage.swift
+YAML
+echo "old" >"$REPO/desktop/macos/Desktop/Sources/MainWindow/Pages/StaleMainOnly.swift"
+repo_git add .
+repo_git commit -q -m "old origin main"
+repo_git branch origin/main
+
+echo "fresh" >"$REPO/desktop/macos/Desktop/Sources/MainWindow/Pages/StaleMainOnly.swift"
+repo_git commit -q -am "fresh upstream main"
+repo_git branch upstream/main
+
+repo_git checkout -q -b feature
+echo "feature" >"$REPO/desktop/macos/Desktop/Sources/MainWindow/Pages/ChatPage.swift"
+repo_git add .
+repo_git commit -q -m "feature change"
+
+if ! "$SCRIPT" --root "$REPO" --strict >"$TMPDIR/stale-ref.out" 2>"$TMPDIR/stale-ref.err"; then
+  cat "$TMPDIR/stale-ref.out"
+  cat "$TMPDIR/stale-ref.err" >&2
+  fail "strict coverage check should use the closest main ref when origin/main is stale"
+fi
+grep -q "Changed desktop Swift files: 1" "$TMPDIR/stale-ref.out" || \
+  fail "stale origin/main caused unrelated upstream changes to be counted"
+grep -q "COVERED   desktop/macos/Desktop/Sources/MainWindow/Pages/ChatPage.swift" "$TMPDIR/stale-ref.out" || \
+  fail "feature change was not checked against e2e coverage"
+if grep -q "StaleMainOnly.swift" "$TMPDIR/stale-ref.out"; then
+  fail "stale origin/main-only file appeared in coverage report"
+fi
+
+POISONED_GIT_DIR="$(git -C "$MACOS_DIR/../.." rev-parse --git-dir 2>/dev/null || true)"
+if [ -n "$POISONED_GIT_DIR" ]; then
+  if ! env GIT_DIR="$POISONED_GIT_DIR" "$SCRIPT" --root "$REPO" --strict >"$TMPDIR/poisoned-env.out" 2>"$TMPDIR/poisoned-env.err"; then
+    cat "$TMPDIR/poisoned-env.out"
+    cat "$TMPDIR/poisoned-env.err" >&2
+    fail "strict coverage check should ignore inherited Git environment"
+  fi
+  grep -q "Changed desktop Swift files: 1" "$TMPDIR/poisoned-env.out" || \
+    fail "inherited Git environment caused unrelated changes to be counted"
+  grep -q "COVERED   desktop/macos/Desktop/Sources/MainWindow/Pages/ChatPage.swift" "$TMPDIR/poisoned-env.out" || \
+    fail "inherited Git environment prevented feature change coverage detection"
+fi
+
 echo "e2e flow coverage tests passed"


### PR DESCRIPTION
## What changed and why

The desktop e2e coverage checker now chooses the closest available mainline merge-base from `upstream/main`, `origin/main`, and `main` instead of accepting the first stale ref. Its internal Git calls also ignore inherited `GIT_DIR`, `GIT_WORK_TREE`, and `GIT_INDEX_FILE` values from hooks. This prevents stale fork refs or hook-exported Git environment from making upstream-only Swift files look like uncovered local changes.

## Product invariants affected

none

## How it was verified

- `bash desktop/macos/tests/test-e2e-flow-coverage.sh` passed.
- `python3 desktop/macos/scripts/check-e2e-flow-coverage.py --strict` passed and reported no changed desktop Swift source files.

## Tests

- Added a regression case in `desktop/macos/tests/test-e2e-flow-coverage.sh` that creates stale `origin/main` and fresher `upstream/main` refs, then verifies only the feature Swift file is counted.
- Added a poisoned Git-environment regression check so inherited hook variables cannot redirect coverage checks into the caller repository.

## Root cause and durable guard (bug fixes)

Root cause: the coverage checker treated ref priority as truth, so a stale `origin/main` could be selected even when `upstream/main` was closer to `HEAD`. Its Git subprocesses also trusted inherited Git environment, which can be set by hooks. The violated contract is that PR-local Swift coverage should be measured against the requested repository root and current mainline base, not a stale fork ref or caller Git context.

The durable guard is the new synthetic Git-history regression test, which recreates the stale-ref failure mode and requires the checker to select the closest valid merge-base, plus a poisoned-environment assertion that verifies `--root` remains authoritative.

## Scoped cleanups (optional)

- Added a desktop changelog fragment for the improved coverage-check reliability.
