### PR TITLE
fix(conversations): clamp unbounded page/per_page in conversation search

### DIFF
--- a/backend/routers/conversations.py
+++ b/backend/routers/conversations.py
@@ -1106,9 +1106,12 @@ def search_conversations_endpoint(
     conversations = [conversation for conversation in conversations if not conversation.get('is_locked')]
     redact_conversations_for_list(conversations)
     search_results['items'] = conversations
-    search_results['total_pages'] = (
-        search_request.page + 1 if len(conversations) >= search_request.per_page else search_request.page
-    )
+    # Recompute total_pages from the effective (clamped) pagination the search actually ran with, not the
+    # raw request: search_request.page/per_page are optional and unbounded, so a null/0/huge value here
+    # would 500 (None + 1 / len(...) >= None). search_conversations returns clamped current_page/per_page.
+    effective_page = search_results.get('current_page', 1)
+    effective_per_page = search_results.get('per_page', 10)
+    search_results['total_pages'] = effective_page + 1 if len(conversations) >= effective_per_page else effective_page
     return search_results
 
 

--- a/backend/tests/unit/test_conversation_search_date_validation.py
+++ b/backend/tests/unit/test_conversation_search_date_validation.py
@@ -236,6 +236,18 @@ def test_valid_date_is_accepted_and_calls_search():
         assert mock_search.called
 
 
+def test_null_per_page_does_not_500():
+    # per_page is Optional and unbounded on SearchRequest. Before the fix the total_pages recompute did
+    # `len(conversations) >= search_request.per_page`, so a client sending per_page: null raised TypeError
+    # -> HTTP 500. The handler now derives pagination from search_conversations' clamped return.
+    with patch.object(
+        conv, 'search_conversations', return_value={'items': [], 'total_pages': 1, 'current_page': 1, 'per_page': 10}
+    ):
+        client = _client()
+        resp = client.post('/v1/conversations/search', json={'query': 'hi', 'per_page': None})
+    assert resp.status_code == 200
+
+
 def test_named_speaker_is_validated_and_forwarded():
     with (
         patch.object(conv.users_db, 'get_person', return_value={'id': 'person-1'}) as mock_get_person,

--- a/backend/tests/unit/test_conversation_search_pagination_clamp.py
+++ b/backend/tests/unit/test_conversation_search_pagination_clamp.py
@@ -1,0 +1,63 @@
+"""Regression: search_conversations clamps unbounded/None page and per_page instead of 500ing.
+
+SearchRequest.page/per_page are Optional and unbounded, so a client sending null, 0, a negative, or a
+huge value reached search_conversations and either raised TypeError (len(...) >= per_page, page + 1) or
+forwarded an out-of-range value to Typesense (RequestMalformed), surfacing as HTTP 500 on both
+POST /v1/conversations/search and the integration conversation search. The util now clamps page to >= 1
+and per_page to [1, 250] at the shared boundary. Pinned against a fake Typesense client, no live services.
+"""
+
+import os
+
+os.environ.setdefault(
+    "ENCRYPTION_SECRET",
+    "omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv",
+)
+# The Typesense client is constructed at import time and validates its config, so give it inert values.
+# It never connects in these tests: the client attribute is replaced with a fake before any call.
+os.environ.setdefault("TYPESENSE_HOST", "localhost")
+os.environ.setdefault("TYPESENSE_HOST_PORT", "8108")
+os.environ.setdefault("TYPESENSE_PROTOCOL", "http")
+os.environ.setdefault("TYPESENSE_API_KEY", "test-key")
+
+from unittest.mock import MagicMock  # noqa: E402
+
+import pytest  # noqa: E402
+
+import utils.conversations.search as search_mod  # noqa: E402
+
+
+def _fake_client(recorder):
+    fake = MagicMock()
+    fake.collections.__getitem__.return_value.documents.search.side_effect = lambda params: recorder.update(
+        params=dict(params)
+    ) or {"hits": []}
+    return fake
+
+
+@pytest.mark.parametrize(
+    "page,per_page,exp_page,exp_per_page",
+    [
+        (None, None, 1, 10),  # nullable -> defaults, no TypeError
+        (0, 0, 1, 10),  # zero -> floor / default
+        (-5, -5, 1, 1),  # negative -> floor to 1
+        (3, 100000, 3, 250),  # huge per_page -> Typesense 250-hit cap
+    ],
+)
+def test_search_conversations_clamps_pagination(monkeypatch, page, per_page, exp_page, exp_per_page):
+    rec = {}
+    monkeypatch.setattr(search_mod, "client", _fake_client(rec))
+    # Before the fix each of these either raised TypeError or forwarded an out-of-range value to Typesense.
+    result = search_mod.search_conversations(uid="u1", query="hi", page=page, per_page=per_page)
+    assert rec["params"]["page"] == exp_page  # what Typesense actually received
+    assert rec["params"]["per_page"] == exp_per_page
+    assert result["current_page"] == exp_page
+    assert result["per_page"] == exp_per_page
+
+
+def test_search_conversations_empty_query_branch_is_also_clamped(monkeypatch):
+    # The empty-query early return echoes page/per_page; it must be clamped too (never None).
+    monkeypatch.setattr(search_mod, "client", _fake_client({}))
+    result = search_mod.search_conversations(uid="u1", query="", per_page=None, page=None)
+    assert result["per_page"] == 10
+    assert result["current_page"] == 1

--- a/backend/utils/conversations/search.py
+++ b/backend/utils/conversations/search.py
@@ -71,6 +71,12 @@ def search_conversations(
     end_date: Optional[int] = None,
     speaker_id: Optional[str] = None,
 ) -> Dict[str, Any]:
+    # page/per_page arrive from SearchRequest where both are Optional and unbounded, so None, 0,
+    # negative, or a huge value would otherwise TypeError here (len(...) >= per_page / page + 1) or trip
+    # Typesense RequestMalformed and 500 the request. Clamp at this shared boundary, mirroring the
+    # clamps in routers/memories.py and routers/mcp.py. Typesense caps a single page at 250 hits.
+    page = max(1, page or 1)
+    per_page = max(1, min(per_page or 10, 250))
     try:
         stripped_query = query.strip() if query else ''
         has_filter_only_browse = bool(speaker_id) or start_date is not None or end_date is not None


### PR DESCRIPTION
## What

`SearchRequest.page` and `per_page` (models/conversation.py) are `Optional[int]` with no bounds, and they flow unclamped into `search_conversations` from two endpoints: `POST /v1/conversations/search` and `POST /v2/integrations/{app_id}/search/conversations`. With a null, zero, negative, or very large value the request 500s:

- `per_page: null` -> `has_more = len(memories) >= per_page` raises `TypeError` (int >= None) inside `search_conversations`, and the `/v1/conversations/search` handler also recomputes `total_pages` with `len(conversations) >= search_request.per_page`, so it TypeErrors there too.
- `page: 0` / negative / huge `per_page` -> forwarded verbatim to Typesense -> `RequestMalformed`.

Both are caught only for the transient-unavailable case, so everything else surfaces as HTTP 500 instead of a bounded result.

## Fix

Clamp at the shared boundary, mirroring routers/memories.py and routers/mcp.py:

- `utils/conversations/search.py`: at the top of `search_conversations`, `page = max(1, page or 1)` and `per_page = max(1, min(per_page or 10, 250))` (Typesense caps a page at 250 hits). This fixes the util-internal crash and the integration endpoint, which uses the util's returned pagination.
- `routers/conversations.py`: the `/v1/conversations/search` handler recomputes `total_pages` from the util's clamped `current_page`/`per_page` return instead of the raw request values.

No request/response schema change (fields stay `Optional[int]`), so released clients are unaffected; the endpoint just returns a bounded page instead of 500ing.

## Testing

- `tests/unit/test_conversation_search_pagination_clamp.py` (new): drives `search_conversations` against a fake Typesense client and asserts page/per_page are clamped to >=1 / [1,250] for null, 0, negative, and huge inputs, including the empty-query early-return branch.
- `tests/unit/test_conversation_search_date_validation.py`: added a case asserting `POST /v1/conversations/search {"per_page": null}` returns 200 rather than 500.
- Both files: 16 passed. black, pyright (0 errors on utils/conversations/search.py), and check_module_stub_pollution (0) clean.

Note: CI here is red only on the pre-existing `tests/unit/test_app_client_schema_inventory.py::test_inventory_strict_raw_decode_site_gate` (the main breakage from #9470, app.dart raw-decode line :31 -> :32; one-line fix is up as #9482). This PR does not touch that path and its own tests pass.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9502?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

