### PR TITLE
feat(desktop): Linux support (X11 + Wayland via XWayland)

### DIFF
--- a/desktop/windows/LINUX.md
+++ b/desktop/windows/LINUX.md
@@ -1,0 +1,65 @@
+# Omi on Linux
+
+Status: **MVP + screen-reading working** — builds, full test suite green (530
+passed), launches and renders on X11, app-usage tracking works, and **screen
+OCR ("what's on my screen") works** via a Tesseract-backed helper.
+
+## Run from source
+```bash
+cd desktop/windows
+cp .env.example .env          # public Firebase/PostHog config; sign-in works as-is
+npm install
+npm run dev                   # launch on an X11 session (DISPLAY set)
+```
+
+## Runtime dependencies (Debian/Ubuntu)
+```bash
+sudo apt-get install -y x11-utils tesseract-ocr tesseract-ocr-eng
+```
+- `x11-utils` provides `xprop` — used for active-window detection (usage-tracking,
+  and the OCR helper's window-info op).
+- `tesseract-ocr` (+ the `eng` language pack) backs screen OCR. Without it, screen
+  reading degrades gracefully (the helper returns an error frame; the rest of the
+  app is unaffected).
+- Headless/CI: run under `xvfb-run` and pass `--no-sandbox`.
+
+## Wayland
+
+The app targets X11. On a Wayland session it defaults to **XWayland**
+(`ozone-platform=x11`) because a native Wayland surface breaks Electron global
+shortcuts (push-to-talk / overlay summon) and the X11 active-window path. To run
+native Wayland anyway, set `OMI_OZONE=wayland` (accepting those limitations).
+
+Screen capture on Wayland goes through the desktop portal, which asks
+"Share screen?" for consent — and Electron has no persisted-consent path, so
+*continuous* Rewind capture would re-prompt every frame. Therefore, on a Wayland
+session, **continuous Rewind capture defaults OFF** (`XDG_SESSION_TYPE=wayland`);
+on-demand "what's on my screen" still works (one Share prompt), and you can enable
+continuous capture explicitly. X11 sessions keep continuous Rewind on by default.
+
+## What works / what's next
+- ✅ Sign-in, mic → cloud transcription, chat, memory (inherited, cross-platform)
+- ✅ App-usage tracking (X11 active-window via `linuxForeground.ts`; poll-driven, 15s)
+- ✅ Screen OCR / "what's on my screen" (Rewind capture → `omi-ocr-helper` → Tesseract)
+- ✅ Wayland sessions via XWayland (shortcuts + active-window work; continuous Rewind
+  off by default — see the Wayland section)
+- ⏳ Pendant BLE, Glass video, native-Wayland capture, packaging.
+
+## Implementation notes
+- `src/main/usage/linuxForeground.ts` — X11 active-window (xprop + /proc/<pid>/exe).
+- `src/main/usage/nativeForeground.ts` — Linux branch delegates to the above; the
+  Windows (koffi) path is unchanged.
+- `src/main/automation/foregroundTargetLogic.ts` — uses `path.win32.basename` so
+  exe-path comparison is correct on both Windows and Linux.
+- `resources/linux-ocr-helper/omi-ocr-helper` — a Node-script helper (executable,
+  `#!/usr/bin/env node`) that speaks the exact `ocr/helperProtocol.ts` stdio frame
+  protocol as `win-ocr-helper.exe`, backed by the `tesseract` CLI for OCR and
+  `xprop`/`/proc` for window info.
+- `src/main/ocr/resolveHelperPath.ts` — returns the Linux helper path on Linux;
+  the Windows path is unchanged. `electron-builder.yml` already unpacks
+  `resources/**`, so packaged Linux builds ship the helper.
+
+### Future enhancement
+For one-shot "look at my screen now" questions, a vision model (Claude vision, or
+the moondream path used by the Glasses) would understand UI/images better than OCR.
+OCR is used here for parity with Omi's continuous, local, searchable Rewind model.

--- a/desktop/windows/LINUX.md
+++ b/desktop/windows/LINUX.md
@@ -1,8 +1,9 @@
 # Omi on Linux
 
-Status: **MVP + screen-reading working** — builds, full test suite green (530
-passed), launches and renders on X11, app-usage tracking works, and **screen
-OCR ("what's on my screen") works** via a Tesseract-backed helper.
+Status: **MVP + screen-reading working** — builds, the full test suite passes
+(reproduce with `cd desktop/windows && npm test`), launches and renders on X11,
+app-usage tracking works, and **screen OCR ("what's on my screen") works** via a
+Tesseract-backed helper.
 
 ## Run from source
 ```bash
@@ -51,13 +52,17 @@ continuous capture explicitly. X11 sessions keep continuous Rewind on by default
   Windows (koffi) path is unchanged.
 - `src/main/automation/foregroundTargetLogic.ts` — uses `path.win32.basename` so
   exe-path comparison is correct on both Windows and Linux.
-- `resources/linux-ocr-helper/omi-ocr-helper` — a Node-script helper (executable,
-  `#!/usr/bin/env node`) that speaks the exact `ocr/helperProtocol.ts` stdio frame
-  protocol as `win-ocr-helper.exe`, backed by the `tesseract` CLI for OCR and
-  `xprop`/`/proc` for window info.
+- `resources/linux-ocr-helper/omi-ocr-helper` — a Node-script helper that speaks
+  the exact `ocr/helperProtocol.ts` stdio frame protocol as `win-ocr-helper.exe`,
+  backed by the `tesseract` CLI for OCR and `xprop`/`/proc` for window info.
+  `ocr/helperProcess.ts` spawns it with **Electron's bundled Node**
+  (`process.execPath` + `ELECTRON_RUN_AS_NODE=1`), so it needs no system `node`
+  in packaged AppImage/deb builds.
 - `src/main/ocr/resolveHelperPath.ts` — returns the Linux helper path on Linux;
-  the Windows path is unchanged. `electron-builder.yml` already unpacks
-  `resources/**`, so packaged Linux builds ship the helper.
+  the Windows path is unchanged. `electron-builder.yml` unpacks `resources/**`,
+  so packaged Linux builds ship the helper.
+- `electron-builder.yml` — Linux targets are **AppImage + deb** (snap omitted:
+  strict confinement blocks `xprop`/`tesseract`/`/proc`).
 
 ### Future enhancement
 For one-shot "look at my screen now" questions, a vision model (Claude vision, or

--- a/desktop/windows/electron-builder.yml
+++ b/desktop/windows/electron-builder.yml
@@ -62,9 +62,12 @@ mac:
 dmg:
   artifactName: ${name}-${version}.${ext}
 linux:
+  # snap intentionally omitted: its default strict confinement blocks xprop,
+  # tesseract, and /proc/<pid>/exe, silently degrading active-window detection
+  # and OCR. Ship AppImage + deb (unconfined); revisit snap with classic
+  # confinement or explicit plugs if needed.
   target:
     - AppImage
-    - snap
     - deb
   maintainer: Based Hardware <team@basedhardware.com>
   category: Utility

--- a/desktop/windows/resources/linux-ocr-helper/omi-ocr-helper
+++ b/desktop/windows/resources/linux-ocr-helper/omi-ocr-helper
@@ -1,0 +1,91 @@
+#!/usr/bin/env node
+/*
+ * Linux OCR + window-info helper for Omi.
+ * Drop-in replacement for win-ocr-helper.exe, speaking the same stdio protocol
+ * (src/main/ocr/helperProtocol.ts):
+ *   Request : [uint32 LE length][1 byte opcode][payload]
+ *   Response: [uint32 LE length][UTF-8 JSON]
+ *   OP_OCR=1    payload=JPEG bytes -> {"ok":true,"fullText","lines":[]}
+ *                                  or {"ok":false,"code","message"}
+ *   OP_WINDOW=2 payload=empty      -> {"app","title","pid","processName"}
+ * Backed by the `tesseract` CLI for OCR and `xprop`/`/proc` for window info.
+ * One request at a time (the supervisor serializes), never throws.
+ */
+'use strict'
+const { execFileSync } = require('child_process')
+const { writeFileSync, unlinkSync, readlinkSync } = require('fs')
+const { tmpdir } = require('os')
+const { join, basename } = require('path')
+
+const OP_OCR = 1
+const OP_WINDOW = 2
+
+let seq = 0
+function ocr(jpeg) {
+  const tmp = join(tmpdir(), `omi-ocr-${process.pid}-${seq++}.jpg`)
+  try {
+    writeFileSync(tmp, jpeg)
+    // --psm 6: assume a uniform block of text; good default for screen content.
+    const out = execFileSync('tesseract', [tmp, 'stdout', '--psm', '6'], {
+      encoding: 'utf8',
+      timeout: 4000,
+      maxBuffer: 16 * 1024 * 1024
+    })
+    return { ok: true, fullText: out.replace(/\s+$/g, ''), lines: [] }
+  } catch (e) {
+    return { ok: false, code: 'HELPER_ERROR', message: String(e && e.message || e) }
+  } finally {
+    try { unlinkSync(tmp) } catch (_) { /* ignore */ }
+  }
+}
+
+function xprop(args) {
+  return execFileSync('xprop', args, { encoding: 'utf8', timeout: 600 })
+}
+function windowInfo() {
+  let title = '', pid = 0, processName = '', app = ''
+  try {
+    const idm = xprop(['-root', '_NET_ACTIVE_WINDOW']).match(/window id # (0x[0-9a-fA-F]+)/)
+    const win = idm && !/^0x0+$/.test(idm[1]) ? idm[1] : null
+    if (win) {
+      const nm = xprop(['-id', win, '_NET_WM_NAME']).match(/_NET_WM_NAME\([^)]*\) = "((?:[^"\\]|\\.)*)"/)
+      if (nm) title = nm[1].replace(/\\(["\\])/g, '$1')
+      const pm = xprop(['-id', win, '_NET_WM_PID']).match(/_NET_WM_PID\(CARDINAL\) = (\d+)/)
+      if (pm) {
+        pid = Number(pm[1])
+        try {
+          const exe = readlinkSync(`/proc/${pid}/exe`)
+          processName = basename(exe)
+          app = processName
+        } catch (_) { /* process gone / perm */ }
+      }
+    }
+  } catch (_) { /* X unavailable */ }
+  return { app: app || processName, title, pid, processName }
+}
+
+function writeFrame(obj) {
+  const json = Buffer.from(JSON.stringify(obj), 'utf8')
+  const header = Buffer.alloc(4)
+  header.writeUInt32LE(json.length, 0)
+  process.stdout.write(Buffer.concat([header, json]))
+}
+
+// Decode incoming request frames and respond one-for-one, in order.
+let buf = Buffer.alloc(0)
+process.stdin.on('data', (chunk) => {
+  buf = Buffer.concat([buf, chunk])
+  for (;;) {
+    if (buf.length < 4) return
+    const len = buf.readUInt32LE(0)
+    if (buf.length < 4 + len) return
+    const opcode = buf[4]
+    const payload = buf.subarray(5, 4 + len)
+    buf = buf.subarray(4 + len)
+    if (opcode === OP_OCR) writeFrame(ocr(payload))
+    else if (opcode === OP_WINDOW) writeFrame(windowInfo())
+    else writeFrame({ ok: false, code: 'HELPER_ERROR', message: `bad opcode ${opcode}` })
+  }
+})
+process.stdin.on('end', () => process.exit(0))
+process.stdin.resume()

--- a/desktop/windows/src/main/index.ts
+++ b/desktop/windows/src/main/index.ts
@@ -144,6 +144,16 @@ if (sandbox && process.env.OMI_BENCH !== '1') {
   app.setPath('userData', join(app.getPath('appData'), `omi-windows-sandbox-${suffix}`))
 }
 
+// Linux: default to XWayland (x11 ozone). On a native Wayland session Electron
+// cannot register global shortcuts (push-to-talk / overlay summon) and the X11
+// active-window path is blind, so XWayland gives the fullest experience. Set
+// OMI_OZONE=wayland to run natively (accepting those limitations). Also enable
+// the PipeWire capturer so on-demand screen capture works through the portal.
+if (process.platform === 'linux') {
+  app.commandLine.appendSwitch('ozone-platform', process.env.OMI_OZONE || 'x11')
+  app.commandLine.appendSwitch('enable-features', 'WebRTCPipeWireCapturer')
+}
+
 const icon = nativeImage.createFromPath(iconPath)
 import {
   remapConversationId,

--- a/desktop/windows/src/main/ocr/helperProcess.ts
+++ b/desktop/windows/src/main/ocr/helperProcess.ts
@@ -32,7 +32,17 @@ class HelperProcess {
     if (this.child || this.starting || this.unavailable) return
     this.starting = true
     const exe = resolveHelperPath()
-    const child = spawn(exe, [], { stdio: ['pipe', 'pipe', 'pipe'] })
+    // The Linux helper is a Node script. Run it with Electron's OWN bundled Node
+    // (ELECTRON_RUN_AS_NODE) rather than relying on the `#!/usr/bin/env node`
+    // shebang finding a system `node` — which a packaged AppImage/deb user may
+    // not have installed. The Windows helper is a native .exe, spawned directly.
+    const child =
+      process.platform === 'linux'
+        ? spawn(process.execPath, [exe], {
+            stdio: ['pipe', 'pipe', 'pipe'],
+            env: { ...process.env, ELECTRON_RUN_AS_NODE: '1' }
+          })
+        : spawn(exe, [], { stdio: ['pipe', 'pipe', 'pipe'] })
     this.child = child
     this.starting = false
 

--- a/desktop/windows/src/main/ocr/resolveHelperPath.ts
+++ b/desktop/windows/src/main/ocr/resolveHelperPath.ts
@@ -13,6 +13,22 @@ import { existsSync } from 'fs'
  * 3. Dev (electron-vite): `<appPath>/resources/win-ocr-helper/win-ocr-helper.exe`
  */
 export function resolveHelperPath(): string {
+  // Linux: a Node-script helper backed by the `tesseract` CLI, speaking the same
+  // stdio frame protocol as the Windows helper. Spawned directly (it is +x with a
+  // `#!/usr/bin/env node` shebang).
+  if (process.platform === 'linux') {
+    const bin = 'omi-ocr-helper'
+    const linux = [
+      join(process.resourcesPath, 'app.asar.unpacked', 'resources', 'linux-ocr-helper', bin),
+      join(process.resourcesPath, 'linux-ocr-helper', bin),
+      join(app.getAppPath(), 'resources', 'linux-ocr-helper', bin)
+    ]
+    for (const c of linux) {
+      if (existsSync(c)) return c
+    }
+    return linux[linux.length - 1]
+  }
+
   const exe = 'win-ocr-helper.exe'
   const candidates = [
     join(process.resourcesPath, 'app.asar.unpacked', 'resources', 'win-ocr-helper', exe),

--- a/desktop/windows/src/main/rewind/rewindSettings.ts
+++ b/desktop/windows/src/main/rewind/rewindSettings.ts
@@ -19,6 +19,15 @@ function file(): string {
   return join(app.getPath('userData'), 'rewind-settings.json')
 }
 
+// On a Wayland session, continuous capture would re-trigger the desktop portal's
+// "Share screen?" prompt on every frame (Electron exposes no persisted-consent
+// path), so a fresh install defaults capture OFF there. On-demand "what's on my
+// screen" is unaffected, and the user can still enable continuous capture
+// explicitly (one prompt per session). X11 sessions keep the default-on behavior.
+export function defaultCaptureEnabled(): boolean {
+  return process.env.XDG_SESSION_TYPE !== 'wayland'
+}
+
 // Coerce a partial/untrusted settings object into a fully-valid one.
 function sanitize(raw: Partial<RewindSettings>): RewindSettings {
   const intervalMs =
@@ -52,7 +61,7 @@ export function getPersistedRewindSettings(): RewindSettings {
   try {
     return sanitize(JSON.parse(readFileSync(file(), 'utf-8')) as Partial<RewindSettings>)
   } catch {
-    return { ...DEFAULTS }
+    return { ...DEFAULTS, captureEnabled: DEFAULTS.captureEnabled && defaultCaptureEnabled() }
   }
 }
 

--- a/desktop/windows/src/main/rewind/rewindSettings.wayland.test.ts
+++ b/desktop/windows/src/main/rewind/rewindSettings.wayland.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+
+// app.getPath isn't available under vitest; the Wayland default is pure env
+// logic, so a light electron stub is enough for the module to import.
+vi.mock('electron', () => ({ app: { getPath: () => '/tmp' } }))
+
+import { defaultCaptureEnabled } from './rewindSettings'
+
+const original = process.env.XDG_SESSION_TYPE
+afterEach(() => {
+  if (original === undefined) delete process.env.XDG_SESSION_TYPE
+  else process.env.XDG_SESSION_TYPE = original
+})
+
+describe('defaultCaptureEnabled (Wayland gating)', () => {
+  it('is false on a Wayland session (avoids the per-frame portal prompt)', () => {
+    process.env.XDG_SESSION_TYPE = 'wayland'
+    expect(defaultCaptureEnabled()).toBe(false)
+  })
+  it('is true on an X11 session', () => {
+    process.env.XDG_SESSION_TYPE = 'x11'
+    expect(defaultCaptureEnabled()).toBe(true)
+  })
+  it('is true when the session type is unset (non-Linux / unknown)', () => {
+    delete process.env.XDG_SESSION_TYPE
+    expect(defaultCaptureEnabled()).toBe(true)
+  })
+})

--- a/desktop/windows/src/main/usage/linuxForeground.test.ts
+++ b/desktop/windows/src/main/usage/linuxForeground.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest'
+import {
+  parseActiveWindowId,
+  parsePidFromXprop,
+  parseWindowTitle,
+  exePathForPid
+} from './linuxForeground'
+
+describe('parseActiveWindowId', () => {
+  it('extracts the hex window id', () => {
+    expect(parseActiveWindowId('_NET_ACTIVE_WINDOW(WINDOW): window id # 0x3c00007')).toBe(
+      '0x3c00007'
+    )
+  })
+  it('returns null when no window is active', () => {
+    expect(parseActiveWindowId('_NET_ACTIVE_WINDOW(WINDOW): window id # 0x0')).toBeNull()
+  })
+  it('returns null on unrelated output', () => {
+    expect(parseActiveWindowId('garbage')).toBeNull()
+  })
+})
+
+describe('parsePidFromXprop', () => {
+  it('extracts the pid', () => {
+    expect(parsePidFromXprop('_NET_WM_PID(CARDINAL) = 4242')).toBe(4242)
+  })
+  it('returns null when absent', () => {
+    expect(parsePidFromXprop('_NET_WM_PID:  not found.')).toBeNull()
+  })
+})
+
+describe('parseWindowTitle', () => {
+  it('extracts a quoted UTF-8 title', () => {
+    expect(parseWindowTitle('_NET_WM_NAME(UTF8_STRING) = "Inbox — Firefox"')).toBe(
+      'Inbox — Firefox'
+    )
+  })
+  it('unescapes embedded quotes and backslashes', () => {
+    expect(parseWindowTitle('_NET_WM_NAME(UTF8_STRING) = "a \\"b\\" \\\\ c"')).toBe('a "b" \\ c')
+  })
+  it('returns null when absent', () => {
+    expect(parseWindowTitle('_NET_WM_NAME:  not found.')).toBeNull()
+  })
+})
+
+describe('exePathForPid', () => {
+  it('reads /proc/<pid>/exe via the injected reader', () => {
+    const read = (p: string): string => (p === '/proc/4242/exe' ? '/usr/bin/firefox' : '')
+    expect(exePathForPid(4242, read)).toBe('/usr/bin/firefox')
+  })
+  it('returns null when the reader throws', () => {
+    const read = (): string => {
+      throw new Error('ENOENT')
+    }
+    expect(exePathForPid(4242, read)).toBeNull()
+  })
+  it('returns null for a null pid', () => {
+    expect(exePathForPid(null, () => '/x')).toBeNull()
+  })
+})

--- a/desktop/windows/src/main/usage/linuxForeground.ts
+++ b/desktop/windows/src/main/usage/linuxForeground.ts
@@ -1,0 +1,86 @@
+// Linux active-window support. Pure parsers (tested) + thin shell wrappers
+// (untested by design, mirroring userAssistRegistry.ts). Never throws; returns
+// degraded values when X11 / xdotool / xprop are unavailable.
+import type { ForegroundWindowInfo } from './nativeForeground'
+import { execFileSync } from 'child_process'
+import { readlinkSync } from 'fs'
+
+// "_NET_ACTIVE_WINDOW(WINDOW): window id # 0x3c00007" -> "0x3c00007"; 0x0 -> null.
+export function parseActiveWindowId(out: string): string | null {
+  const m = out.match(/window id # (0x[0-9a-fA-F]+)/)
+  if (!m) return null
+  return /^0x0+$/.test(m[1]) ? null : m[1]
+}
+
+// "_NET_WM_PID(CARDINAL) = 4242" -> 4242; missing -> null.
+export function parsePidFromXprop(out: string): number | null {
+  const m = out.match(/_NET_WM_PID\(CARDINAL\) = (\d+)/)
+  return m ? Number(m[1]) : null
+}
+
+// '_NET_WM_NAME(UTF8_STRING) = "title"' -> 'title' (xprop C-escapes " and \).
+export function parseWindowTitle(out: string): string | null {
+  const m = out.match(/_NET_WM_NAME\([^)]*\) = "((?:[^"\\]|\\.)*)"/)
+  if (!m) return null
+  return m[1].replace(/\\(["\\])/g, '$1')
+}
+
+// Pure + injectable so it's testable without a real /proc.
+export function exePathForPid(pid: number | null, read: (p: string) => string): string | null {
+  if (pid == null) return null
+  try {
+    const target = read(`/proc/${pid}/exe`)
+    return target || null
+  } catch {
+    return null
+  }
+}
+
+function xprop(args: string[]): string {
+  return execFileSync('xprop', args, { encoding: 'utf8', timeout: 600 })
+}
+
+export function linuxAvailable(): boolean {
+  if (!process.env.DISPLAY) return false
+  try {
+    execFileSync('xprop', ['-root', '_NET_SUPPORTED'], { timeout: 600, stdio: 'ignore' })
+    return true
+  } catch {
+    return false
+  }
+}
+
+function activeWindowId(): string | null {
+  try {
+    return parseActiveWindowId(xprop(['-root', '_NET_ACTIVE_WINDOW']))
+  } catch {
+    return null
+  }
+}
+
+export function getLinuxForegroundInfo(): ForegroundWindowInfo {
+  const win = activeWindowId()
+  if (!win) return { handle: null, exePath: null, className: null }
+  let pid: number | null = null
+  try {
+    pid = parsePidFromXprop(xprop(['-id', win, '_NET_WM_PID']))
+  } catch {
+    pid = null
+  }
+  const exePath = exePathForPid(pid, (p) => readlinkSync(p))
+  return { handle: win, exePath, className: null }
+}
+
+export function getLinuxForegroundExePath(): string | null {
+  return getLinuxForegroundInfo().exePath
+}
+
+export function getLinuxForegroundTitle(): string | null {
+  const win = activeWindowId()
+  if (!win) return null
+  try {
+    return parseWindowTitle(xprop(['-id', win, '_NET_WM_NAME']))
+  } catch {
+    return null
+  }
+}

--- a/desktop/windows/src/main/usage/nativeForeground.degrade.test.ts
+++ b/desktop/windows/src/main/usage/nativeForeground.degrade.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi } from 'vitest'
+
+// Force the non-win32 path regardless of the host OS the test runs on.
+vi.stubGlobal('process', { ...process, platform: 'linux' })
+
+// Linux X11 must read as unavailable here so the linux branch falls through to
+// the degraded contract this test pins.
+vi.mock('./linuxForeground', () => ({
+  linuxAvailable: () => false,
+  getLinuxForegroundExePath: () => null,
+  getLinuxForegroundInfo: () => ({ handle: null, exePath: null, className: null }),
+  getLinuxForegroundTitle: () => null
+}))
+
+import {
+  getForegroundExePath,
+  getForegroundWindowInfo,
+  getForegroundWindowTitle,
+  subscribeForegroundChange
+} from './nativeForeground'
+
+describe('nativeForeground off-Windows degradation', () => {
+  it('getForegroundExePath returns null, never throws', () => {
+    expect(() => getForegroundExePath()).not.toThrow()
+    expect(getForegroundExePath()).toBeNull()
+  })
+  it('getForegroundWindowInfo returns an all-null shape', () => {
+    expect(getForegroundWindowInfo()).toEqual({ handle: null, exePath: null, className: null })
+  })
+  it('getForegroundWindowTitle returns null', () => {
+    expect(getForegroundWindowTitle()).toBeNull()
+  })
+  it('subscribeForegroundChange returns a no-op unsubscribe', () => {
+    const off = subscribeForegroundChange(() => {})
+    expect(typeof off).toBe('function')
+    expect(() => off()).not.toThrow()
+  })
+})

--- a/desktop/windows/src/main/usage/nativeForeground.linux.test.ts
+++ b/desktop/windows/src/main/usage/nativeForeground.linux.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.stubGlobal('process', { ...process, platform: 'linux' })
+
+// Mock the Linux unit so the test needs no real X server.
+vi.mock('./linuxForeground', () => ({
+  linuxAvailable: () => true,
+  getLinuxForegroundExePath: () => '/usr/bin/code',
+  getLinuxForegroundInfo: () => ({ handle: '0x1', exePath: '/usr/bin/code', className: null }),
+  getLinuxForegroundTitle: () => 'plan.md — Code'
+}))
+
+beforeEach(() => vi.resetModules())
+
+describe('nativeForeground on linux with X11 available', () => {
+  it('returns the real exe path', async () => {
+    const m = await import('./nativeForeground')
+    expect(m.getForegroundExePath()).toBe('/usr/bin/code')
+  })
+  it('returns the real window info', async () => {
+    const m = await import('./nativeForeground')
+    expect(m.getForegroundWindowInfo()).toEqual({
+      handle: '0x1',
+      exePath: '/usr/bin/code',
+      className: null
+    })
+  })
+  it('returns the real title', async () => {
+    const m = await import('./nativeForeground')
+    expect(m.getForegroundWindowTitle()).toBe('plan.md — Code')
+  })
+})

--- a/desktop/windows/src/main/usage/nativeForeground.ts
+++ b/desktop/windows/src/main/usage/nativeForeground.ts
@@ -1,4 +1,10 @@
 import koffi from 'koffi'
+import {
+  linuxAvailable,
+  getLinuxForegroundExePath,
+  getLinuxForegroundInfo,
+  getLinuxForegroundTitle
+} from './linuxForeground'
 
 // PROCESS_QUERY_LIMITED_INFORMATION — enough to read the image path, and works
 // for processes at higher integrity than ours (unlike QUERY_INFORMATION).
@@ -190,6 +196,9 @@ function load(): Win32 | null {
 // unavailable (no foreground window, permission edge, or koffi failed to load).
 // Never throws.
 export function getForegroundExePath(): string | null {
+  if (process.platform === 'linux') {
+    return linuxAvailable() ? getLinuxForegroundExePath() : null
+  }
   if (process.platform !== 'win32') return null
   try {
     return load()?.getForegroundExePath() ?? null
@@ -202,6 +211,11 @@ export function getForegroundExePath(): string | null {
 // Returns the current foreground window's HWND (decimal string) + owning exe
 // path, or nulls when unavailable. Never throws.
 export function getForegroundWindowInfo(): ForegroundWindowInfo {
+  if (process.platform === 'linux') {
+    return linuxAvailable()
+      ? getLinuxForegroundInfo()
+      : { handle: null, exePath: null, className: null }
+  }
   if (process.platform !== 'win32') return { handle: null, exePath: null, className: null }
   try {
     return load()?.getForegroundWindowInfo() ?? { handle: null, exePath: null, className: null }
@@ -214,6 +228,9 @@ export function getForegroundWindowInfo(): ForegroundWindowInfo {
 // Returns the current foreground window's title text, or null when unavailable.
 // Never throws.
 export function getForegroundWindowTitle(): string | null {
+  if (process.platform === 'linux') {
+    return linuxAvailable() ? getLinuxForegroundTitle() : null
+  }
   if (process.platform !== 'win32') return null
   try {
     return load()?.getForegroundWindowTitle() ?? null


### PR DESCRIPTION
## What changed and why

Enables the Electron desktop app on **Linux**, alongside the Windows/macOS targets it already builds for (`build:linux` is already in `electron-builder.yml`). The Windows/koffi paths are untouched. Adds X11 active-window detection, a Tesseract-backed OCR helper that speaks the existing `win-ocr-helper` stdio protocol, and Wayland-session handling.

- `linuxForeground.ts` — X11 active-window via `xprop` + `/proc/<pid>/exe`; pure parsers unit-tested, never throws, degrades when X11/xprop are absent.
- `nativeForeground.ts` — adds a `process.platform === 'linux'` branch; win32 path unchanged.
- Linux OCR helper (`resources/linux-ocr-helper/omi-ocr-helper`) — Node script speaking the exact `ocr/helperProtocol.ts` frame protocol, backed by the `tesseract` CLI; `resolveHelperPath` returns it on Linux.
- `index.ts` — on Linux, default to XWayland (`ozone-platform=x11`) so global shortcuts + the X11 active-window path work on Wayland sessions; `OMI_OZONE=wayland` to override. Enables the PipeWire capturer for portal-based capture.
- `rewindSettings.ts` — on a Wayland session, continuous Rewind capture defaults **off** (the desktop portal re-prompts for consent every frame; Electron exposes no persisted-consent path). On-demand "what's on my screen" still works with one Share prompt.
- `LINUX.md` — build/run/deps (`xprop`, `tesseract-ocr`) + Wayland behavior.

## Product invariants affected

None. No invariant in `docs/product/invariants/` globs `desktop/windows/src/main/{usage,ocr,rewind}` or `index.ts`.

## How it was verified

Built and launched on **Ubuntu 24 / GNOME, on both X11 and Wayland sessions**, and exercised the real user-facing paths:

- Sign-in, mic → cloud transcription, and chat work (inherited, cross-platform).
- **App-usage tracking** attributes time to real Linux exe paths (via `xprop` active-window).
- **"What's on my screen" OCR** returns live screen text (Rewind frame → `omi-ocr-helper` → Tesseract), verified by feeding a real desktop capture through the helper over the frame protocol.
- On **native Wayland**, Electron global shortcuts failed 8× (push-to-talk / overlay summon) and the window was invisible to X11 tooling; **forcing XWayland fixed both (0 failures)**. Continuous Rewind is defaulted off on Wayland to avoid per-frame portal prompts; on-demand OCR still works with a single Share consent.

`cd desktop/windows && npm test` → **571 passed / 3 skipped**; `npm run typecheck` and `npx eslint` clean.

## Tests

- `linuxForeground.test.ts` — xprop output parsers + `/proc/<pid>/exe` resolver.
- `nativeForeground.linux.test.ts` / `nativeForeground.degrade.test.ts` — the Linux branch returns real data when X11 is available, and the off-platform contract still degrades to nulls/no-ops.
- `rewindSettings.wayland.test.ts` — continuous-capture default is off on Wayland, on elsewhere.

## Scoped cleanups

None.

---

Follow-ups (intentionally **not** in this PR, to keep it focused): system-tray/Quit affordance on Linux, native-Wayland screen capture (portal restore-token so continuous Rewind can run without per-frame prompts), and packaging polish. Happy to split further or open a tracking issue if maintainers prefer.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9503?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

