### PR TITLE
feat(desktop): show which BYOK keys are still missing in developer settings

### DIFF
--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+DeveloperKeys.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+DeveloperKeys.swift
@@ -4,6 +4,17 @@ import SwiftUI
 import UniformTypeIdentifiers
 import WebKit
 
+/// Users often paste one key and miss the banner saying all four are required
+/// at the same time. Non-nil while 1–3 keys (in `BYOKProvider.allCases` order)
+/// are entered, listing the ones still missing.
+func byokMissingKeysHint(_ keys: [String]) -> String? {
+  let missing = zip(BYOKProvider.allCases, keys).filter { $0.1.isEmpty }.map(\.0.displayName)
+  guard !missing.isEmpty, missing.count < keys.count else { return nil }
+  return
+    "Still missing: \(missing.joined(separator: ", ")). All 4 keys must be entered at the same time to activate the free plan."
+}
+
+
 extension SettingsContentView {
   var developerKeysSubsection: some View {
     VStack(spacing: OmiSpacing.xl) {
@@ -41,16 +52,12 @@ extension SettingsContentView {
         value: $devDeepgramKey
       )
 
+      if let byokIncompleteHint {
+        byokWarningCard(byokIncompleteHint, settingId: "advanced.devkeys.incomplete")
+      }
+
       if let byokActivationError {
-        settingsCard(settingId: "advanced.devkeys.error") {
-          HStack(spacing: OmiSpacing.sm) {
-            Image(systemName: "exclamationmark.triangle.fill")
-              .foregroundColor(OmiColors.warning)
-            Text(byokActivationError)
-              .scaledFont(size: OmiType.caption)
-              .foregroundColor(OmiColors.warning)
-          }
-        }
+        byokWarningCard(byokActivationError, settingId: "advanced.devkeys.error")
       }
 
       if hasAnyBYOKKey {
@@ -72,6 +79,23 @@ extension SettingsContentView {
     .onChange(of: devAnthropicKey) { _, _ in refreshBYOKActivation() }
     .onChange(of: devGeminiKey) { _, _ in refreshBYOKActivation() }
     .onChange(of: devDeepgramKey) { _, _ in refreshBYOKActivation() }
+  }
+
+
+  var byokIncompleteHint: String? {
+    byokMissingKeysHint([devOpenAIKey, devAnthropicKey, devGeminiKey, devDeepgramKey])
+  }
+
+  func byokWarningCard(_ text: String, settingId: String) -> some View {
+    settingsCard(settingId: settingId) {
+      HStack(spacing: OmiSpacing.sm) {
+        Image(systemName: "exclamationmark.triangle.fill")
+          .foregroundColor(OmiColors.warning)
+        Text(text)
+          .scaledFont(size: OmiType.caption)
+          .foregroundColor(OmiColors.warning)
+      }
+    }
   }
 
   var hasAnyBYOKKey: Bool {

--- a/desktop/macos/Desktop/Tests/BYOKIncompleteHintTests.swift
+++ b/desktop/macos/Desktop/Tests/BYOKIncompleteHintTests.swift
@@ -1,0 +1,18 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// The developer-keys section hints which BYOK keys are still missing while
+/// only some of the four are entered, so someone who pastes a single key
+/// learns the free plan needs all four at the same time.
+final class BYOKIncompleteHintTests: XCTestCase {
+  func testHintOnlyForPartiallyFilledKeySet() {
+    let hint = byokMissingKeysHint(["sk-test", "", "", ""])
+    XCTAssertEqual(
+      hint,
+      "Still missing: Anthropic, Gemini, Deepgram. All 4 keys must be entered at the same time to activate the free plan."
+    )
+    XCTAssertNil(byokMissingKeysHint(["", "", "", ""]), "blank form shows no hint")
+    XCTAssertNil(byokMissingKeysHint(["a", "b", "c", "d"]), "complete form shows no hint")
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260711-byok-incomplete-keys-hint.json
+++ b/desktop/macos/changelog/unreleased/20260711-byok-incomplete-keys-hint.json
@@ -1,0 +1,3 @@
+{
+  "change": "Added a hint under the developer key fields listing which keys are still missing, so entering a single key makes it clear all four are required at the same time"
+}

--- a/desktop/macos/e2e/flows/settings-basic.yaml
+++ b/desktop/macos/e2e/flows/settings-basic.yaml
@@ -4,6 +4,7 @@ tier: manual
 description: Settings navigation smoke — open Settings via gear icon, navigate all 9 sections (v0.12.119+ redesign)
 app: com.omi.computer-macos
 covers:
+  - desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+DeveloperKeys.swift
   - desktop/macos/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
   - desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+General.swift
   - desktop/macos/Desktop/Sources/MainWindow/SettingsSidebar.swift


### PR DESCRIPTION
## What

Settings → Advanced → Developer keys: while the user has entered 1–3 of the four BYOK keys, show a warning card (same shape as the existing "Rejected by provider" activation-error card) listing which providers are still missing, e.g. "Still missing: Anthropic, Gemini, Deepgram. All 4 keys must be entered at the same time to activate the free plan."

## Why

Users who paste a single key often miss the top info banner saying all four keys are required at the same time, then wonder why the free plan never activates. The hint appears as soon as one key is entered and disappears on a blank form (deleting the last key returns the section to normal) or a complete one.

## How

- `byokMissingKeysHint(_ keys:)` — small pure function mapping the four field values to the hint text (nil for blank/complete forms), kept free-standing so it is hermetically testable.
- `byokWarningCard(_:settingId:)` — extracted the warning-card layout now shared by the new hint and the existing activation-error card.

## Verification

- `xcrun swift build -c debug --package-path Desktop` — Build complete
- `xcrun swift test --package-path Desktop --filter BYOKIncompleteHintTests` — 1 test, 0 failures (hint lists the three missing providers with one key entered; nil on blank and complete forms)
- Exercised live in named bundle `omi-byok-hint` (Settings → Advanced with a single OpenAI key set); hint verified working

## Product invariants

none (per `scripts/pr-preflight --suggest`)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9505?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



## Failure class
Failure-Class: none

(Fix commit addresses developer-settings BYOK error-state UI; no registered semantic failure class covers it.)
