### PR TITLE
fix(ci): serialize Cloud Run and GKE deploy writers

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -4,6 +4,21 @@ These rules apply to GitHub Actions workflows and custom actions under `.github/
 
 ## CI/CD Deploy Safety
 
+- Every workflow that mutates a persistent Cloud Run service/job, GKE Helm
+  release, or traffic/promotion state must use a workflow-level concurrency
+  group scoped to the exact target and logical environment. Manual and
+  automatic entry points for the same target must resolve to the same group.
+- Deployment group names are a cross-workflow API. Keep them aligned with
+  `.github/scripts/check-deployment-concurrency.py`; use
+  `cancel-in-progress: false` so a newer run cannot interrupt a remote mutation
+  or a staged validation/traffic promotion.
+- `deploy-backend-stack-<environment>` intentionally covers the four backend
+  Cloud Run services, traffic repair, backend-listen, LLM gateway, and
+  backend-secrets. Those paths share mutable releases, while unrelated services
+  retain their own groups and may deploy in parallel.
+- GitHub concurrency is serialization, not a FIFO queue: only one pending run is
+  retained and ordering is not guaranteed. Deploy workflows must not assume
+  that every intermediate commit will run.
 - Use immutable image tags for deploys. Build and push the short SHA tag, then deploy that exact tag.
 - Do not deploy Cloud Run services from an untagged image path; use `image:...:${SHORT_SHA}` so revisions show the source commit.
 - Do not let Helm chart-only deploys reset GKE workloads to `latest`. Preserve the currently deployed immutable tag or require an explicit tag input.

--- a/.github/scripts/check-deployment-concurrency.py
+++ b/.github/scripts/check-deployment-concurrency.py
@@ -1,0 +1,304 @@
+#!/usr/bin/env python3
+"""Enforce target-scoped serialization for persistent Cloud Run/GKE writers.
+
+This is intentionally a narrow, stdlib-only structural policy check. Actionlint
+validates workflow syntax, but it cannot prove that separate workflow entry
+points which mutate the same remote resource resolve to the same concurrency
+group.
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOWS = ROOT / ".github" / "workflows"
+
+
+@dataclass(frozen=True)
+class LockContract:
+    group: str
+
+
+# Group strings are a deployment API: manual and automatic entry points for a
+# shared target must keep resolving to the same value. Keep this explicit so a
+# new deploy writer cannot silently bypass the audited lock graph.
+LOCK_CONTRACTS = {
+    "desktop_backend_auto_dev.yml": LockContract("desktop-backend-auto-dev"),
+    "desktop_promote_prod.yml": LockContract("desktop-backend-promote-prod"),
+    "gcp_admin.yml": LockContract(
+        "deploy-cloud-run-omi-admin-dashboard-${{ github.ref == 'refs/heads/development' && 'development' || github.ref == 'refs/heads/main' && 'prod' || format('nondeploy-{0}', github.run_id) }}"
+    ),
+    "gcp_app.yml": LockContract(
+        "deploy-cloud-run-omi-web-app-${{ github.ref == 'refs/heads/development' && 'development' || github.ref == 'refs/heads/main' && 'prod' || format('nondeploy-{0}', github.run_id) }}"
+    ),
+    "gcp_apps_js.yml": LockContract(
+        "deploy-cloud-run-apps-js-${{ github.event_name == 'workflow_dispatch' && github.event.inputs.environment || github.ref == 'refs/heads/development' && 'development' || github.ref == 'refs/heads/main' && 'prod' || format('nondeploy-{0}', github.run_id) }}"
+    ),
+    "gcp_backend.yml": LockContract("deploy-backend-stack-${{ github.event.inputs.environment }}"),
+    "gcp_backend_agent_proxy.yml": LockContract(
+        "deploy-gke-agent-proxy-${{ github.event.inputs.environment }}"
+    ),
+    "gcp_backend_agent_proxy_auto_deploy.yml": LockContract("deploy-gke-agent-proxy-development"),
+    "gcp_backend_auto_dev.yml": LockContract("deploy-backend-stack-development"),
+    "gcp_backend_listen_helm.yml": LockContract(
+        "deploy-backend-stack-${{ github.event.inputs.environment || 'development' }}"
+    ),
+    "gcp_backend_pusher.yml": LockContract(
+        "${{ (github.event.inputs.service || 'pusher') == 'llm-gateway' && format('deploy-backend-stack-{0}', github.event.inputs.environment) || format('deploy-gke-pusher-{0}', github.event.inputs.environment) }}"
+    ),
+    "gcp_backend_pusher_auto_deploy.yml": LockContract("deploy-gke-pusher-development"),
+    "gcp_diarizer.yml": LockContract("deploy-gke-diarizer-${{ github.event.inputs.environment }}"),
+    "gcp_frontend.yml": LockContract(
+        "deploy-cloud-run-frontend-${{ github.event_name == 'workflow_dispatch' && github.event.inputs.environment || github.ref == 'refs/heads/development' && 'development' || github.ref == 'refs/heads/main' && 'prod' || format('nondeploy-{0}', github.run_id) }}"
+    ),
+    "gcp_llm_gateway.yml": LockContract("deploy-backend-stack-${{ github.event.inputs.environment }}"),
+    "gcp_llm_gateway_auto_dev.yml": LockContract("deploy-backend-stack-development"),
+    "gcp_memory_maintenance_job.yml": LockContract(
+        "deploy-cloud-run-memory-maintenance-job-${{ github.event.inputs.environment }}"
+    ),
+    "gcp_memory_maintenance_job_auto_dev.yml": LockContract(
+        "deploy-cloud-run-memory-maintenance-job-development"
+    ),
+    "gcp_models.yml": LockContract("deploy-gke-vad-${{ github.event.inputs.environment }}"),
+    "gcp_nllb_translation.yml": LockContract(
+        "deploy-gke-nllb-translation-${{ github.event.inputs.environment }}"
+    ),
+    "gcp_notifications_job.yml": LockContract(
+        "deploy-cloud-run-notifications-job-${{ github.event.inputs.environment }}"
+    ),
+    "gcp_parakeet.yml": LockContract("deploy-gke-parakeet-${{ github.event.inputs.environment }}"),
+    "gcp_personas.yml": LockContract(
+        "deploy-cloud-run-omi-web-${{ github.event_name == 'workflow_dispatch' && github.event.inputs.environment || github.ref == 'refs/heads/development' && 'development' || github.ref == 'refs/heads/main' && 'prod' || format('nondeploy-{0}', github.run_id) }}"
+    ),
+    "gcp_plugins.yml": LockContract("deploy-cloud-run-plugins-${{ github.event.inputs.environment }}"),
+}
+
+
+# This workflow writes a run-ID-scoped Kubernetes Job and does not mutate the
+# persistent Parakeet release. The required marker makes the exemption fail
+# closed if that isolation is removed.
+RUN_SCOPED_EXEMPTIONS = {
+    "parakeet_gpu_tests.yml": "JOB_NAME: parakeet-gpu-test-${{ github.run_id }}",
+}
+
+# The manual pusher workflow routes its default pusher service and its
+# llm-gateway compatibility mode to different lock domains. The default pusher
+# development rendering is asserted explicitly rather than trying to evaluate
+# the full GitHub expression with a partial string replacement.
+DEVELOPMENT_GROUP_OVERRIDES = {
+    "gcp_backend_pusher.yml": "deploy-gke-pusher-development",
+}
+
+
+WRITER_MARKERS = (
+    "google-github-actions/deploy-cloudrun@",
+    "google-github-actions/get-gke-credentials@",
+    "gcloud run services update-traffic",
+    "gcloud run services update ",
+    "gcloud run deploy ",
+    "gcloud run jobs deploy ",
+    "gcloud run jobs update ",
+)
+
+
+class PolicyError(ValueError):
+    pass
+
+
+def parse_top_level_concurrency(text: str) -> dict[str, str] | None:
+    """Return scalar fields from a workflow-level concurrency mapping."""
+
+    lines = text.splitlines()
+    try:
+        start = next(index for index, line in enumerate(lines) if line == "concurrency:")
+    except StopIteration:
+        return None
+
+    fields: dict[str, str] = {}
+    for line in lines[start + 1 :]:
+        if not line.strip() or line.lstrip().startswith("#"):
+            continue
+        if not line.startswith(" "):
+            break
+        if not line.startswith("  ") or line.startswith("    ") or ":" not in line:
+            continue
+        key, value = line.strip().split(":", 1)
+        fields[key] = value.strip()
+    return fields
+
+
+def validate_lock(name: str, text: str, contract: LockContract) -> list[str]:
+    errors: list[str] = []
+    concurrency = parse_top_level_concurrency(text)
+    if concurrency is None:
+        return [f"{name}: missing workflow-level concurrency block"]
+
+    actual_group = concurrency.get("group")
+    if actual_group != contract.group:
+        errors.append(f"{name}: concurrency group must be {contract.group!r}, got {actual_group!r}")
+    if concurrency.get("cancel-in-progress") != "false":
+        errors.append(f"{name}: deploy locks must use cancel-in-progress: false")
+    return errors
+
+
+def is_persistent_writer(text: str) -> bool:
+    return any(marker in text for marker in WRITER_MARKERS)
+
+
+def resolve_environment(group: str, environment: str) -> str:
+    return group.replace(
+        "${{ github.event.inputs.environment || 'development' }}", environment
+    ).replace("${{ github.event.inputs.environment }}", environment)
+
+
+def development_group(name: str, group: str) -> str:
+    return DEVELOPMENT_GROUP_OVERRIDES.get(name, resolve_environment(group, "development"))
+
+
+def validate_shared_families(groups: dict[str, str]) -> list[str]:
+    errors: list[str] = []
+
+    family_pairs = (
+        ("gcp_backend.yml", "gcp_backend_auto_dev.yml"),
+        ("gcp_backend_listen_helm.yml", "gcp_backend_auto_dev.yml"),
+        ("gcp_llm_gateway.yml", "gcp_llm_gateway_auto_dev.yml"),
+        ("gcp_llm_gateway.yml", "gcp_backend_auto_dev.yml"),
+        ("gcp_memory_maintenance_job.yml", "gcp_memory_maintenance_job_auto_dev.yml"),
+        ("gcp_backend_agent_proxy.yml", "gcp_backend_agent_proxy_auto_deploy.yml"),
+        ("gcp_backend_pusher.yml", "gcp_backend_pusher_auto_deploy.yml"),
+    )
+    for manual, automatic in family_pairs:
+        manual_dev = development_group(manual, groups[manual])
+        if manual_dev != groups[automatic]:
+            errors.append(
+                f"{manual} development lock {manual_dev!r} does not match {automatic} lock {groups[automatic]!r}"
+            )
+
+    environment_scoped = (
+        "gcp_backend.yml",
+        "gcp_backend_agent_proxy.yml",
+        "gcp_backend_listen_helm.yml",
+        "gcp_diarizer.yml",
+        "gcp_llm_gateway.yml",
+        "gcp_memory_maintenance_job.yml",
+        "gcp_models.yml",
+        "gcp_nllb_translation.yml",
+        "gcp_notifications_job.yml",
+        "gcp_parakeet.yml",
+        "gcp_plugins.yml",
+    )
+    for name in environment_scoped:
+        if resolve_environment(groups[name], "development") == resolve_environment(groups[name], "prod"):
+            errors.append(f"{name}: development and prod must resolve to different lock groups")
+
+    return errors
+
+
+def check_repository() -> list[str]:
+    errors: list[str] = []
+    workflow_text = {
+        path.name: path.read_text()
+        for pattern in ("*.yml", "*.yaml")
+        for path in WORKFLOWS.glob(pattern)
+    }
+
+    detected = {name for name, text in workflow_text.items() if is_persistent_writer(text)}
+    expected = set(LOCK_CONTRACTS) | set(RUN_SCOPED_EXEMPTIONS)
+    for name in sorted(detected - expected):
+        errors.append(f"{name}: persistent Cloud Run/GKE writer is missing from the lock policy")
+    for name in sorted(expected - detected):
+        errors.append(f"{name}: lock policy entry no longer contains a recognized deploy writer")
+
+    groups: dict[str, str] = {}
+    for name, contract in LOCK_CONTRACTS.items():
+        text = workflow_text.get(name)
+        if text is None:
+            errors.append(f"{name}: audited deploy workflow is missing")
+            continue
+        errors.extend(validate_lock(name, text, contract))
+        concurrency = parse_top_level_concurrency(text)
+        if concurrency and concurrency.get("group"):
+            groups[name] = concurrency["group"]
+
+    if set(groups) == set(LOCK_CONTRACTS):
+        errors.extend(validate_shared_families(groups))
+
+    for name, marker in RUN_SCOPED_EXEMPTIONS.items():
+        text = workflow_text.get(name, "")
+        if marker not in text:
+            errors.append(f"{name}: run-scoped deploy-lock exemption lost required marker {marker!r}")
+
+    identity_markers = (
+        'SHORT_SHA="$(git rev-parse --short=7 HEAD)"',
+        'revision_suffix=${SHORT_SHA}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}',
+    )
+    for name in ("gcp_backend.yml", "gcp_backend_auto_dev.yml"):
+        text = workflow_text.get(name, "")
+        for marker in identity_markers:
+            if marker not in text:
+                errors.append(f"{name}: backend revision identity must include {marker!r}")
+
+    return errors
+
+
+def run_self_test() -> None:
+    good = """name: fixture
+concurrency:
+  group: deploy-fixture-development
+  cancel-in-progress: false
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+"""
+    contract = LockContract("deploy-fixture-development")
+    if validate_lock("fixture.yml", good, contract):
+        raise PolicyError("valid workflow-level lock was rejected")
+
+    job_only = """name: fixture
+jobs:
+  deploy:
+    concurrency:
+      group: deploy-fixture-development
+      cancel-in-progress: false
+"""
+    if not any("workflow-level" in error for error in validate_lock("fixture.yml", job_only, contract)):
+        raise PolicyError("job-level-only lock satisfied the workflow-level contract")
+
+    wrong_group = good.replace("deploy-fixture-development", "deploy-other-development")
+    if not any("group must be" in error for error in validate_lock("fixture.yml", wrong_group, contract)):
+        raise PolicyError("mismatched group satisfied the contract")
+
+    canceling = good.replace("cancel-in-progress: false", "cancel-in-progress: true")
+    if not any("cancel-in-progress" in error for error in validate_lock("fixture.yml", canceling, contract)):
+        raise PolicyError("cancel-in-progress: true satisfied the deploy contract")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--self-test", action="store_true")
+    args = parser.parse_args()
+
+    if args.self_test:
+        run_self_test()
+        print("deployment concurrency policy self-test OK")
+        return 0
+
+    errors = check_repository()
+    if errors:
+        for error in errors:
+            print(f"FAIL: {error}")
+        return 1
+
+    print(
+        f"deployment concurrency policy OK ({len(LOCK_CONTRACTS)} persistent writers, "
+        f"{len(RUN_SCOPED_EXEMPTIONS)} run-scoped exemption)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/desktop_backend_auto_dev.yml
+++ b/.github/workflows/desktop_backend_auto_dev.yml
@@ -14,7 +14,8 @@ env:
 
 concurrency:
   group: desktop-backend-auto-dev
-  cancel-in-progress: true
+  # Do not interrupt the Cloud Run mutation or its traffic verification.
+  cancel-in-progress: false
 
 jobs:
   deploy:

--- a/.github/workflows/gcp_admin.yml
+++ b/.github/workflows/gcp_admin.yml
@@ -12,6 +12,12 @@ env:
   REGION: us-central1
   GCP_PROJECT: based-hardware
 
+# Serialize writes to the same Cloud Run service. Non-deploy refs get an
+# isolated group because this workflow's job is intentionally skipped there.
+concurrency:
+  group: deploy-cloud-run-omi-admin-dashboard-${{ github.ref == 'refs/heads/development' && 'development' || github.ref == 'refs/heads/main' && 'prod' || format('nondeploy-{0}', github.run_id) }}
+  cancel-in-progress: false
+
 jobs:
   deploy:
     if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/development'
@@ -23,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Google Auth
         id: auth
@@ -49,7 +55,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Build and Push Docker image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v6
         with:
           context: web/admin
           push: true

--- a/.github/workflows/gcp_app.yml
+++ b/.github/workflows/gcp_app.yml
@@ -16,6 +16,12 @@ env:
   SERVICE: omi-web-app
   REGION: us-central1
 
+# Serialize writes to the same Cloud Run service. A dispatch from a non-deploy
+# ref gets an isolated group rather than sharing a production deployment lock.
+concurrency:
+  group: deploy-cloud-run-omi-web-app-${{ github.ref == 'refs/heads/development' && 'development' || github.ref == 'refs/heads/main' && 'prod' || format('nondeploy-{0}', github.run_id) }}
+  cancel-in-progress: false
+
 jobs:
   deploy:
     environment: ${{ (github.ref == 'refs/heads/development' && 'development') || (github.ref == 'refs/heads/main' && 'prod') }}
@@ -26,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Google Auth
         id: auth

--- a/.github/workflows/gcp_apps_js.yml
+++ b/.github/workflows/gcp_apps_js.yml
@@ -20,6 +20,11 @@ env:
   SERVICE: apps-js
   REGION: us-central1
 
+# Serialize writes to the same Cloud Run service while allowing dev and prod to proceed independently.
+concurrency:
+  group: deploy-cloud-run-apps-js-${{ github.event_name == 'workflow_dispatch' && github.event.inputs.environment || github.ref == 'refs/heads/development' && 'development' || github.ref == 'refs/heads/main' && 'prod' || format('nondeploy-{0}', github.run_id) }}
+  cancel-in-progress: false
+
 jobs:
   deploy:
     environment: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.environment || (github.ref == 'refs/heads/development' && 'development') || (github.ref == 'refs/heads/main' && 'prod') }}

--- a/.github/workflows/gcp_backend.yml
+++ b/.github/workflows/gcp_backend.yml
@@ -36,6 +36,12 @@ on:
           - all
           - cloud-run-only
 
+# Cloud Run revision promotion/traffic repair and the shared backend GKE resources
+# are one environment-scoped mutation domain across the backend deploy workflows.
+concurrency:
+  group: deploy-backend-stack-${{ github.event.inputs.environment }}
+  cancel-in-progress: false
+
 env:
   SERVICE: backend
   REGION: us-central1
@@ -137,8 +143,9 @@ jobs:
       - name: Compute short SHA
         id: image-tag
         run: |
-          echo "short_sha=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
-          echo "revision_suffix=${GITHUB_SHA::7}-${GITHUB_RUN_ATTEMPT}" >> "$GITHUB_OUTPUT"
+          SHORT_SHA="$(git rev-parse --short=7 HEAD)"
+          echo "short_sha=${SHORT_SHA}" >> "$GITHUB_OUTPUT"
+          echo "revision_suffix=${SHORT_SHA}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}" >> "$GITHUB_OUTPUT"
 
       - name: Install Python deps for deploy scripts
         run: python3 -m pip install -q pyyaml

--- a/.github/workflows/gcp_backend_agent_proxy.yml
+++ b/.github/workflows/gcp_backend_agent_proxy.yml
@@ -12,6 +12,11 @@ on:
         required: true
         default: 'main'
 
+# Serialize Helm writers to this environment's agent-proxy release.
+concurrency:
+  group: deploy-gke-agent-proxy-${{ github.event.inputs.environment }}
+  cancel-in-progress: false
+
 env:
   SERVICE: agent-proxy
   REGION: us-central1

--- a/.github/workflows/gcp_backend_agent_proxy_auto_deploy.yml
+++ b/.github/workflows/gcp_backend_agent_proxy_auto_deploy.yml
@@ -7,6 +7,11 @@ on:
       - 'backend/agent-proxy/**'
       - 'backend/charts/agent-proxy/**'
 
+# Share the development agent-proxy lock with manual deployments.
+concurrency:
+  group: deploy-gke-agent-proxy-development
+  cancel-in-progress: false
+
 env:
   SERVICE: agent-proxy
   REGION: us-central1

--- a/.github/workflows/gcp_backend_auto_dev.yml
+++ b/.github/workflows/gcp_backend_auto_dev.yml
@@ -6,6 +6,12 @@ on:
     paths:
       - 'backend/**'
 
+# Share the development backend mutation domain with manual deploys, traffic
+# repair, backend-listen, and LLM Gateway's shared backend-secrets updates.
+concurrency:
+  group: deploy-backend-stack-development
+  cancel-in-progress: false
+
 env:
   SERVICE: backend
   REGION: us-central1
@@ -44,8 +50,9 @@ jobs:
       - name: Compute short SHA
         id: image-tag
         run: |
-          echo "short_sha=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
-          echo "revision_suffix=${GITHUB_SHA::7}-${GITHUB_RUN_ATTEMPT}" >> "$GITHUB_OUTPUT"
+          SHORT_SHA="$(git rev-parse --short=7 HEAD)"
+          echo "short_sha=${SHORT_SHA}" >> "$GITHUB_OUTPUT"
+          echo "revision_suffix=${SHORT_SHA}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}" >> "$GITHUB_OUTPUT"
 
       - name: Install Python deps for deploy scripts
         run: python3 -m pip install -q pyyaml

--- a/.github/workflows/gcp_backend_listen_helm.yml
+++ b/.github/workflows/gcp_backend_listen_helm.yml
@@ -19,6 +19,12 @@ on:
         required: true
         default: 'main'
 
+# This chart path mutates backend-listen and shared backend-secrets, which are
+# also applied by the full backend deploy for the same environment.
+concurrency:
+  group: deploy-backend-stack-${{ github.event.inputs.environment || 'development' }}
+  cancel-in-progress: false
+
 env:
   REGION: us-central1
 

--- a/.github/workflows/gcp_backend_pusher.yml
+++ b/.github/workflows/gcp_backend_pusher.yml
@@ -24,6 +24,12 @@ on:
         required: false
         default: 'pusher'
 
+# The LLM Gateway path reapplies shared backend-secrets; standalone pusher only
+# mutates its own GKE release and therefore keeps a separate environment lock.
+concurrency:
+  group: ${{ (github.event.inputs.service || 'pusher') == 'llm-gateway' && format('deploy-backend-stack-{0}', github.event.inputs.environment) || format('deploy-gke-pusher-{0}', github.event.inputs.environment) }}
+  cancel-in-progress: false
+
 env:
   SERVICE: ${{ github.event.inputs.service || 'pusher' }}
   REGION: us-central1

--- a/.github/workflows/gcp_backend_pusher_auto_deploy.yml
+++ b/.github/workflows/gcp_backend_pusher_auto_deploy.yml
@@ -7,6 +7,11 @@ on:
       - 'backend/pusher/**'
       - 'backend/charts/pusher/**'
 
+# Share the development pusher lock with manual deployments.
+concurrency:
+  group: deploy-gke-pusher-development
+  cancel-in-progress: false
+
 env:
   SERVICE: pusher
   REGION: us-central1

--- a/.github/workflows/gcp_diarizer.yml
+++ b/.github/workflows/gcp_diarizer.yml
@@ -20,6 +20,11 @@ on:
         required: false
         default: ''
 
+# Serialize Helm writers to this environment's diarizer release.
+concurrency:
+  group: deploy-gke-diarizer-${{ github.event.inputs.environment }}
+  cancel-in-progress: false
+
 env:
   SERVICE: diarizer
   REGION: us-central1

--- a/.github/workflows/gcp_frontend.yml
+++ b/.github/workflows/gcp_frontend.yml
@@ -24,6 +24,11 @@ env:
   SERVICE: frontend
   REGION: us-central1
 
+# Serialize writes to the same Cloud Run service while allowing dev and prod to proceed independently.
+concurrency:
+  group: deploy-cloud-run-frontend-${{ github.event_name == 'workflow_dispatch' && github.event.inputs.environment || github.ref == 'refs/heads/development' && 'development' || github.ref == 'refs/heads/main' && 'prod' || format('nondeploy-{0}', github.run_id) }}
+  cancel-in-progress: false
+
 jobs:
   deploy:
     environment: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.environment || (github.ref == 'refs/heads/development' && 'development') || (github.ref == 'refs/heads/main' && 'prod') }}

--- a/.github/workflows/gcp_llm_gateway.yml
+++ b/.github/workflows/gcp_llm_gateway.yml
@@ -12,6 +12,12 @@ on:
         required: true
         default: 'main'
 
+# LLM Gateway deployment reapplies shared backend-secrets, so it joins the
+# full backend mutation domain for the selected environment.
+concurrency:
+  group: deploy-backend-stack-${{ github.event.inputs.environment }}
+  cancel-in-progress: false
+
 env:
   SERVICE: llm-gateway
   REGION: us-central1

--- a/.github/workflows/gcp_llm_gateway_auto_dev.yml
+++ b/.github/workflows/gcp_llm_gateway_auto_dev.yml
@@ -14,6 +14,12 @@ on:
       - 'backend/Dockerfile'
       - '.github/workflows/gcp_llm_gateway*.yml'
 
+# LLM Gateway deployment reapplies development backend-secrets, so it shares
+# the full development backend mutation domain instead of racing that deploy.
+concurrency:
+  group: deploy-backend-stack-development
+  cancel-in-progress: false
+
 env:
   SERVICE: llm-gateway
   REGION: us-central1

--- a/.github/workflows/gcp_memory_maintenance_job.yml
+++ b/.github/workflows/gcp_memory_maintenance_job.yml
@@ -22,6 +22,11 @@ env:
   SERVICE: memory-maintenance-job
   REGION: us-central1
 
+# Share the development lock with the auto-deploy workflow that writes this Cloud Run job.
+concurrency:
+  group: deploy-cloud-run-memory-maintenance-job-${{ github.event.inputs.environment }}
+  cancel-in-progress: false
+
 jobs:
   deploy:
     environment: ${{ github.event.inputs.environment }}

--- a/.github/workflows/gcp_memory_maintenance_job_auto_dev.yml
+++ b/.github/workflows/gcp_memory_maintenance_job_auto_dev.yml
@@ -12,6 +12,11 @@ env:
   SERVICE: memory-maintenance-job
   REGION: us-central1
 
+# Share the lock with manual development deploys of this Cloud Run job.
+concurrency:
+  group: deploy-cloud-run-memory-maintenance-job-development
+  cancel-in-progress: false
+
 jobs:
   deploy:
     environment: development

--- a/.github/workflows/gcp_models.yml
+++ b/.github/workflows/gcp_models.yml
@@ -22,6 +22,11 @@ on:
         required: false
         default: ''
 
+# This workflow's Helm target is VAD; serialize writers to that release.
+concurrency:
+  group: deploy-gke-vad-${{ github.event.inputs.environment }}
+  cancel-in-progress: false
+
 env:
   SERVICE: models
   REGION: us-central1

--- a/.github/workflows/gcp_nllb_translation.yml
+++ b/.github/workflows/gcp_nllb_translation.yml
@@ -16,6 +16,11 @@ on:
         required: false
         default: ''
 
+# Serialize Helm writers to this environment's NLLB translation release.
+concurrency:
+  group: deploy-gke-nllb-translation-${{ github.event.inputs.environment }}
+  cancel-in-progress: false
+
 env:
   SERVICE: nllb-translation
   SERVICE_UNDERSCORE: nllb_translation

--- a/.github/workflows/gcp_notifications_job.yml
+++ b/.github/workflows/gcp_notifications_job.yml
@@ -26,6 +26,11 @@ env:
   SERVICE: notifications-job
   REGION: us-central1
 
+# Serialize writes to the selected Cloud Run job environment.
+concurrency:
+  group: deploy-cloud-run-notifications-job-${{ github.event.inputs.environment }}
+  cancel-in-progress: false
+
 jobs:
   deploy:
     environment: ${{ github.event.inputs.environment }}

--- a/.github/workflows/gcp_parakeet.yml
+++ b/.github/workflows/gcp_parakeet.yml
@@ -16,6 +16,11 @@ on:
         required: false
         default: ''
 
+# Serialize Helm writers to this environment's Parakeet release.
+concurrency:
+  group: deploy-gke-parakeet-${{ github.event.inputs.environment }}
+  cancel-in-progress: false
+
 env:
   SERVICE: parakeet
   REGION: us-central1

--- a/.github/workflows/gcp_personas.yml
+++ b/.github/workflows/gcp_personas.yml
@@ -21,6 +21,11 @@ env:
   SERVICE: omi-web
   REGION: us-central1
 
+# Serialize writes to the same Cloud Run service while allowing dev and prod to proceed independently.
+concurrency:
+  group: deploy-cloud-run-omi-web-${{ github.event_name == 'workflow_dispatch' && github.event.inputs.environment || github.ref == 'refs/heads/development' && 'development' || github.ref == 'refs/heads/main' && 'prod' || format('nondeploy-{0}', github.run_id) }}
+  cancel-in-progress: false
+
 jobs:
   deploy:
     environment: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.environment || (github.ref == 'refs/heads/development' && 'development') || (github.ref == 'refs/heads/main' && 'prod') }}

--- a/.github/workflows/gcp_plugins.yml
+++ b/.github/workflows/gcp_plugins.yml
@@ -22,6 +22,11 @@ env:
   SERVICE: plugins
   REGION: us-central1
 
+# Serialize writes to the selected Cloud Run service environment.
+concurrency:
+  group: deploy-cloud-run-plugins-${{ github.event.inputs.environment }}
+  cancel-in-progress: false
+
 jobs:
   deploy:
     environment: ${{ github.event.inputs.environment }}

--- a/.github/workflows/repo-checks.yml
+++ b/.github/workflows/repo-checks.yml
@@ -107,6 +107,12 @@ jobs:
       - name: Check desktop prod promotion policy
         run: python3 .github/scripts/check-desktop-prod-promotion-policy.py
 
+      - name: Test deployment concurrency policy
+        run: python3 .github/scripts/check-deployment-concurrency.py --self-test
+
+      - name: Check deployment concurrency policy
+        run: python3 .github/scripts/check-deployment-concurrency.py
+
       - name: Check desktop release terminology
         run: python3 .github/scripts/check-desktop-release-terminology.py
 

--- a/scripts/pre-push
+++ b/scripts/pre-push
@@ -787,6 +787,8 @@ else
 fi
 
 run_step python3 .github/scripts/check-desktop-prod-promotion-policy.py
+run_step python3 .github/scripts/check-deployment-concurrency.py --self-test
+run_step python3 .github/scripts/check-deployment-concurrency.py
 run_step check_backend_runtime_env_if_needed
 run_step check_backend_async_blockers_if_needed
 run_step check_module_stub_pollution_if_needed


### PR DESCRIPTION
## Summary
- serialize every persistent Cloud Run/GKE deployment writer by target and logical environment
- make the shared backend deployment paths use one `deploy-backend-stack-<environment>` lock and prevent cancellation during staged revision validation/traffic promotion
- add a repository-native deployment-concurrency policy checker, CI/pre-push enforcement, and workflow-agent documentation so future deploy writers cannot bypass the audited lock graph

## Root cause / recurrence guard
A dev backend deploy lost Cloud Run's optimistic-concurrency race (`ABORTED` stale resource version) while another writer mutated the same service. Its newly created revisions were retired and the prior revision retained traffic. The generic manual backend workflow also supports production and had the same no-traffic → validate → traffic-shift pattern without serialization.

This PR closes the failure class rather than retrying one command:
- workflow-level locks use `cancel-in-progress: false`, so a run cannot be stopped between a no-traffic deploy and its verification/promotion;
- manual and auto paths for the same target resolve to the same lock;
- revision suffixes for the backend workflow include the source SHA, GitHub run ID, and attempt;
- `.github/scripts/check-deployment-concurrency.py` fails if a persistent Cloud Run/GKE writer lacks its lock, if shared entry points diverge, or if a documented run-scoped exception loses its isolation marker.

The audit found 24 persistent writers. Independent services/environments retain separate locks; only paths that share backend stack state (`backend-secrets` or the four backend Cloud Run services) use the intentionally broader backend-stack lock.

## Validation
- `python3 .github/scripts/check-deployment-concurrency.py --self-test`
- `python3 .github/scripts/check-deployment-concurrency.py`
- `python3 -m py_compile .github/scripts/check-deployment-concurrency.py`
- `git diff --check`
- `actionlint .github/workflows/*.yml` (ran; existing unrelated repository-wide actionlint findings remain, including legacy action versions and shellcheck findings)

## Review
An independent review caught two policy defects before commit: two Cloud Run writers omitted their actual lock blocks, and the manual/auto pusher pair was not cross-checked. Both are included in the final checker and verified by the commands above.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9506?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

