### PR TITLE
fix(desktop): refresh storage pools after recovery

### DIFF
--- a/desktop/macos/Desktop/Sources/FileIndexing/KnowledgeGraphStorage.swift
+++ b/desktop/macos/Desktop/Sources/FileIndexing/KnowledgeGraphStorage.swift
@@ -6,17 +6,20 @@ actor KnowledgeGraphStorage {
     static let shared = KnowledgeGraphStorage()
 
     private var _dbQueue: DatabasePool?
+    private var _dbGeneration = -1
 
     private init() {}
 
     private func ensureDB() async throws -> DatabasePool {
-        if let db = _dbQueue { return db }
+        if let db = _dbQueue, await RewindDatabase.shared.poolGeneration() == _dbGeneration { return db }
 
         try await RewindDatabase.shared.initialize()
-        guard let db = await RewindDatabase.shared.getDatabaseQueue() else {
+        let (queue, generation) = await RewindDatabase.shared.getDatabaseQueueWithGeneration()
+        guard let db = queue else {
             throw NSError(domain: "KnowledgeGraphStorage", code: 1, userInfo: [NSLocalizedDescriptionKey: "Database not initialized"])
         }
         _dbQueue = db
+        _dbGeneration = generation
         return db
     }
 

--- a/desktop/macos/Desktop/Sources/LiveNotes/NoteStorage.swift
+++ b/desktop/macos/Desktop/Sources/LiveNotes/NoteStorage.swift
@@ -7,6 +7,7 @@ actor NoteStorage {
     static let shared = NoteStorage()
 
     private var _dbQueue: DatabasePool?
+    private var _dbGeneration = -1
     private var isInitialized = false
 
     private init() {}
@@ -19,7 +20,7 @@ actor NoteStorage {
 
     /// Ensure database is initialized before use
     private func ensureInitialized() async throws -> DatabasePool {
-        if let db = _dbQueue {
+        if let db = _dbQueue, await RewindDatabase.shared.poolGeneration() == _dbGeneration {
             return db
         }
 
@@ -31,11 +32,13 @@ actor NoteStorage {
             throw error
         }
 
-        guard let db = await RewindDatabase.shared.getDatabaseQueue() else {
+        let (queue, generation) = await RewindDatabase.shared.getDatabaseQueueWithGeneration()
+        guard let db = queue else {
             throw LiveNoteError.databaseNotInitialized
         }
 
         _dbQueue = db
+        _dbGeneration = generation
         isInitialized = true
         return db
     }

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/AIUserProfileService.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/AIUserProfileService.swift
@@ -41,6 +41,7 @@ actor AIUserProfileService {
 
     /// Cached database pool
     private var _dbQueue: DatabasePool?
+    private var _dbGeneration = -1
 
     /// Invalidate cached DB queue (called on user switch / sign-out)
     func invalidateCache() {
@@ -50,12 +51,14 @@ actor AIUserProfileService {
     // MARK: - Database Access
 
     private func ensureDB() async throws -> DatabasePool {
-        if let db = _dbQueue { return db }
+        if let db = _dbQueue, await RewindDatabase.shared.poolGeneration() == _dbGeneration { return db }
         try await RewindDatabase.shared.initialize()
-        guard let db = await RewindDatabase.shared.getDatabaseQueue() else {
+        let (queue, generation) = await RewindDatabase.shared.getDatabaseQueueWithGeneration()
+        guard let db = queue else {
             throw ProfileError.databaseNotAvailable
         }
         _dbQueue = db
+        _dbGeneration = generation
         return db
     }
 

--- a/desktop/macos/Desktop/Sources/Rewind/Core/ActionItemStorage.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/ActionItemStorage.swift
@@ -7,6 +7,7 @@ actor ActionItemStorage {
     static let shared = ActionItemStorage()
 
     private var _dbQueue: DatabasePool?
+    private var _dbGeneration = -1
     private var isInitialized = false
 
     private init() {}
@@ -19,7 +20,7 @@ actor ActionItemStorage {
 
     /// Ensure database is initialized before use
     private func ensureInitialized() async throws -> DatabasePool {
-        if let db = _dbQueue {
+        if let db = _dbQueue, await RewindDatabase.shared.poolGeneration() == _dbGeneration {
             return db
         }
 
@@ -31,11 +32,13 @@ actor ActionItemStorage {
             throw error
         }
 
-        guard let db = await RewindDatabase.shared.getDatabaseQueue() else {
+        let (queue, generation) = await RewindDatabase.shared.getDatabaseQueueWithGeneration()
+        guard let db = queue else {
             throw ActionItemStorageError.databaseNotInitialized
         }
 
         _dbQueue = db
+        _dbGeneration = generation
         isInitialized = true
         return db
     }

--- a/desktop/macos/Desktop/Sources/Rewind/Core/GoalStorage.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/GoalStorage.swift
@@ -26,6 +26,7 @@ actor GoalStorage {
     static let shared = GoalStorage()
 
     private var _dbQueue: DatabasePool?
+    private var _dbGeneration = -1
     private var isInitialized = false
 
     private init() {}
@@ -38,16 +39,18 @@ actor GoalStorage {
 
     /// Ensure database is initialized before use
     private func ensureInitialized() async throws -> DatabasePool {
-        if let db = _dbQueue {
+        if let db = _dbQueue, await RewindDatabase.shared.poolGeneration() == _dbGeneration {
             return db
         }
 
         try await RewindDatabase.shared.initialize()
-        guard let db = await RewindDatabase.shared.getDatabaseQueue() else {
+        let (queue, generation) = await RewindDatabase.shared.getDatabaseQueueWithGeneration()
+        guard let db = queue else {
             throw GoalStorageError.databaseNotInitialized
         }
 
         _dbQueue = db
+        _dbGeneration = generation
         isInitialized = true
         return db
     }

--- a/desktop/macos/Desktop/Sources/Rewind/Core/MemoryStorage.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/MemoryStorage.swift
@@ -7,6 +7,7 @@ actor MemoryStorage {
     static let shared = MemoryStorage()
 
     private var _dbQueue: DatabasePool?
+    private var _dbGeneration = -1
     private var isInitialized = false
 
     private init() {}
@@ -19,7 +20,7 @@ actor MemoryStorage {
 
     /// Ensure database is initialized before use
     private func ensureInitialized() async throws -> DatabasePool {
-        if let db = _dbQueue {
+        if let db = _dbQueue, await RewindDatabase.shared.poolGeneration() == _dbGeneration {
             return db
         }
 
@@ -31,11 +32,13 @@ actor MemoryStorage {
             throw error
         }
 
-        guard let db = await RewindDatabase.shared.getDatabaseQueue() else {
+        let (queue, generation) = await RewindDatabase.shared.getDatabaseQueueWithGeneration()
+        guard let db = queue else {
             throw MemoryStorageError.databaseNotInitialized
         }
 
         _dbQueue = db
+        _dbGeneration = generation
         isInitialized = true
         return db
     }

--- a/desktop/macos/Desktop/Sources/Rewind/Core/ProactiveStorage.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/ProactiveStorage.swift
@@ -7,6 +7,7 @@ actor ProactiveStorage {
     static let shared = ProactiveStorage()
 
     private var _dbQueue: DatabasePool?
+    private var _dbGeneration = -1
     private var isInitialized = false
 
     private init() {}
@@ -19,7 +20,7 @@ actor ProactiveStorage {
 
     /// Ensure database is initialized before use
     private func ensureInitialized() async throws -> DatabasePool {
-        if let db = _dbQueue {
+        if let db = _dbQueue, await RewindDatabase.shared.poolGeneration() == _dbGeneration {
             return db
         }
 
@@ -31,11 +32,13 @@ actor ProactiveStorage {
             throw error
         }
 
-        guard let db = await RewindDatabase.shared.getDatabaseQueue() else {
+        let (queue, generation) = await RewindDatabase.shared.getDatabaseQueueWithGeneration()
+        guard let db = queue else {
             throw ProactiveStorageError.databaseNotInitialized
         }
 
         _dbQueue = db
+        _dbGeneration = generation
         isInitialized = true
         return db
     }

--- a/desktop/macos/Desktop/Sources/Rewind/Core/RewindDatabase.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/RewindDatabase.swift
@@ -51,6 +51,20 @@ actor RewindDatabase {
         return dbQueue
     }
 
+    /// Monotonic epoch of the current `dbQueue`. Bumped on every close and every
+    /// pool (re)open, so a storage actor that cached a pool can detect a swap
+    /// (corruption/maintenance recovery replaces the pool) and drop its stale
+    /// reference instead of reading/writing a closed or unlinked file.
+    func poolGeneration() -> Int {
+        return initGeneration
+    }
+
+    /// Atomically read the current pool and its epoch together, so a caching
+    /// storage actor stores a consistent (pool, generation) pair.
+    func getDatabaseQueueWithGeneration() -> (pool: DatabasePool?, generation: Int) {
+        return (dbQueue, initGeneration)
+    }
+
     /// Report a query error from a storage actor or subsystem.
     /// Tracks consecutive SQLITE_IOERR/CORRUPT errors. When the threshold is reached,
     /// closes the database so the next initialize() call triggers recovery.
@@ -471,6 +485,10 @@ actor RewindDatabase {
         }
 
         dbQueue = activeQueue
+        // Bump the epoch on every pool (re)open so storage actors that cached the
+        // previous pool revalidate and drop it — recovery may have replaced the
+        // underlying omi.db file, leaving the old pool pointing at a stale inode.
+        initGeneration += 1
         openedForUserId = configuredUserId ?? RewindDatabase.currentUserId ?? "anonymous"
         consecutiveQueryIOErrors = 0
 

--- a/desktop/macos/Desktop/Sources/Rewind/Core/RewindDatabase.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/RewindDatabase.swift
@@ -23,8 +23,17 @@ actor RewindDatabase {
     /// The user ID that was actually used to open the current database
     private var openedForUserId: String?
 
-    /// Generation counter — incremented on close() so stale task completions don't corrupt state
+    /// Generation counter — incremented on close() so stale task completions don't corrupt state.
+    /// NOTE: `initialize()` captures this before `performInitialization()` and clears
+    /// `initializationTask` only if it is unchanged afterward, so it MUST NOT be bumped
+    /// during a normal open. Pool-swap detection uses the separate `poolEpoch` below.
     private var initGeneration: Int = 0
+
+    /// Epoch of the current `dbQueue`, bumped on every close AND every pool (re)open.
+    /// Storage actors cache this alongside the pool and revalidate to detect a swap
+    /// (recovery replaces the pool) — kept distinct from `initGeneration` so bumping it
+    /// on open does not break the in-flight-close detection in `initialize()`.
+    private var poolEpoch: Int = 0
 
     /// Static user ID for nonisolated markCleanShutdown (set by configure(userId:))
     nonisolated(unsafe) static var currentUserId: String?
@@ -56,13 +65,13 @@ actor RewindDatabase {
     /// (corruption/maintenance recovery replaces the pool) and drop its stale
     /// reference instead of reading/writing a closed or unlinked file.
     func poolGeneration() -> Int {
-        return initGeneration
+        return poolEpoch
     }
 
     /// Atomically read the current pool and its epoch together, so a caching
     /// storage actor stores a consistent (pool, generation) pair.
     func getDatabaseQueueWithGeneration() -> (pool: DatabasePool?, generation: Int) {
-        return (dbQueue, initGeneration)
+        return (dbQueue, poolEpoch)
     }
 
     /// Report a query error from a storage actor or subsystem.
@@ -278,7 +287,8 @@ actor RewindDatabase {
         runningFlagPath = nil
         openedForUserId = nil
         initGeneration += 1
-        log("RewindDatabase: Closed database (generation \(initGeneration))")
+        poolEpoch += 1
+        log("RewindDatabase: Closed database (generation \(initGeneration), pool epoch \(poolEpoch))")
     }
 
     /// Switch to a different user's database.
@@ -485,10 +495,13 @@ actor RewindDatabase {
         }
 
         dbQueue = activeQueue
-        // Bump the epoch on every pool (re)open so storage actors that cached the
+        // Bump the pool epoch on every (re)open so storage actors that cached the
         // previous pool revalidate and drop it — recovery may have replaced the
         // underlying omi.db file, leaving the old pool pointing at a stale inode.
-        initGeneration += 1
+        // This is `poolEpoch`, NOT `initGeneration`: initialize() relies on
+        // initGeneration staying unchanged across a normal open to clear its
+        // initializationTask.
+        poolEpoch += 1
         openedForUserId = configuredUserId ?? RewindDatabase.currentUserId ?? "anonymous"
         consecutiveQueryIOErrors = 0
 

--- a/desktop/macos/Desktop/Sources/Rewind/Core/StagedTaskStorage.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/StagedTaskStorage.swift
@@ -13,6 +13,7 @@ actor StagedTaskStorage {
     static let shared = StagedTaskStorage()
 
     private var _dbQueue: DatabasePool?
+    private var _dbGeneration = -1
     private var isInitialized = false
 
     private init() {}
@@ -23,7 +24,7 @@ actor StagedTaskStorage {
     }
 
     private func ensureInitialized() async throws -> DatabasePool {
-        if let db = _dbQueue {
+        if let db = _dbQueue, await RewindDatabase.shared.poolGeneration() == _dbGeneration {
             return db
         }
 
@@ -34,11 +35,13 @@ actor StagedTaskStorage {
             throw error
         }
 
-        guard let db = await RewindDatabase.shared.getDatabaseQueue() else {
+        let (queue, generation) = await RewindDatabase.shared.getDatabaseQueueWithGeneration()
+        guard let db = queue else {
             throw ActionItemStorageError.databaseNotInitialized
         }
 
         _dbQueue = db
+        _dbGeneration = generation
         isInitialized = true
         return db
     }

--- a/desktop/macos/Desktop/Sources/Rewind/Core/TaskChatMessageStorage.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/TaskChatMessageStorage.swift
@@ -113,6 +113,7 @@ actor TaskChatMessageStorage {
     static let shared = TaskChatMessageStorage()
 
     private var _dbQueue: DatabasePool?
+    private var _dbGeneration = -1
     private var isInitialized = false
 
     private init() {}
@@ -123,7 +124,7 @@ actor TaskChatMessageStorage {
     }
 
     private func ensureInitialized() async throws -> DatabasePool {
-        if let db = _dbQueue {
+        if let db = _dbQueue, await RewindDatabase.shared.poolGeneration() == _dbGeneration {
             return db
         }
 
@@ -134,11 +135,13 @@ actor TaskChatMessageStorage {
             throw error
         }
 
-        guard let db = await RewindDatabase.shared.getDatabaseQueue() else {
+        let (queue, generation) = await RewindDatabase.shared.getDatabaseQueueWithGeneration()
+        guard let db = queue else {
             throw TaskChatMessageStorageError.databaseNotInitialized
         }
 
         _dbQueue = db
+        _dbGeneration = generation
         isInitialized = true
         return db
     }

--- a/desktop/macos/Desktop/Sources/Rewind/Core/TranscriptionStorage.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/TranscriptionStorage.swift
@@ -18,6 +18,7 @@ actor TranscriptionStorage {
     static let shared = TranscriptionStorage()
 
     private var _dbQueue: DatabasePool?
+    private var _dbGeneration = -1
     private var isInitialized = false
 
     private init() {}
@@ -30,7 +31,7 @@ actor TranscriptionStorage {
 
     /// Ensure database is initialized before use
     private func ensureInitialized() async throws -> DatabasePool {
-        if let db = _dbQueue {
+        if let db = _dbQueue, await RewindDatabase.shared.poolGeneration() == _dbGeneration {
             return db
         }
 
@@ -42,11 +43,13 @@ actor TranscriptionStorage {
             throw error
         }
 
-        guard let db = await RewindDatabase.shared.getDatabaseQueue() else {
+        let (queue, generation) = await RewindDatabase.shared.getDatabaseQueueWithGeneration()
+        guard let db = queue else {
             throw TranscriptionStorageError.databaseNotInitialized
         }
 
         _dbQueue = db
+        _dbGeneration = generation
         isInitialized = true
         return db
     }

--- a/desktop/macos/Desktop/Tests/RewindDatabaseLifecycleTests.swift
+++ b/desktop/macos/Desktop/Tests/RewindDatabaseLifecycleTests.swift
@@ -45,6 +45,13 @@ final class RewindDatabaseLifecycleTests: XCTestCase {
     XCTAssertNotNil(first.pool)
 
     await RewindDatabase.shared.close()
+    let closedGeneration = await RewindDatabase.shared.poolGeneration()
+    XCTAssertGreaterThan(
+      closedGeneration,
+      first.generation,
+      "closing the database must invalidate cached storage pools"
+    )
+
     await RewindDatabase.shared.configure(userId: testUserId)
     try await RewindDatabase.shared.initialize()
 
@@ -52,8 +59,8 @@ final class RewindDatabaseLifecycleTests: XCTestCase {
     XCTAssertNotNil(reopened.pool)
     XCTAssertGreaterThan(
       reopened.generation,
-      first.generation,
-      "storage actors use this generation to drop stale cached pools after recovery or reopen"
+      closedGeneration,
+      "reopening the database must invalidate caches independently from close()"
     )
 
     await RewindDatabase.shared.close()

--- a/desktop/macos/changelog/unreleased/20260711-rewinddb-stale-pool.json
+++ b/desktop/macos/changelog/unreleased/20260711-rewinddb-stale-pool.json
@@ -1,0 +1,3 @@
+{
+    "change": "Fixed local storage continuing to use a stale database connection after an automatic corruption recovery, which could hide recent data or repeat errors until the next restart"
+}

--- a/desktop/macos/e2e/flows/capture-lifecycle.yaml
+++ b/desktop/macos/e2e/flows/capture-lifecycle.yaml
@@ -18,6 +18,10 @@ covers:
   - desktop/macos/Desktop/Sources/Rewind/Core/RewindDatabase.swift
   - desktop/macos/Desktop/Sources/Rewind/Core/TranscriptionModels.swift
   - desktop/macos/Desktop/Sources/Rewind/Core/TranscriptionStorage.swift
+  - desktop/macos/Desktop/Sources/Rewind/Core/ProactiveStorage.swift
+  - desktop/macos/Desktop/Sources/LiveNotes/NoteStorage.swift
+  - desktop/macos/Desktop/Sources/FileIndexing/KnowledgeGraphStorage.swift
+  - desktop/macos/Desktop/Sources/ProactiveAssistants/Services/AIUserProfileService.swift
   - desktop/macos/Desktop/Sources/APIClient.swift
   - desktop/macos/Desktop/Sources/OmiWAL/WALModel.swift
   - desktop/macos/Desktop/Sources/WAL/StorageSyncService.swift


### PR DESCRIPTION
## Summary

Supersedes #9498 with the same stale-DatabasePool recovery fix rebased onto current main after #9497, #9495, and #9496 merged.

This keeps #9497's user-binding lifecycle changes in `RewindDatabase` while adding #9498's pool-generation invalidation. Storage actors now cache a `(DatabasePool, generation)` pair and revalidate against `RewindDatabase.poolGeneration()` before reusing the cached pool, so recovery/reopen paths do not leave them writing to a stale SQLite pool.

## Changes

- Add `poolGeneration()` and `getDatabaseQueueWithGeneration()` to `RewindDatabase`.
- Bump the pool epoch on every close and every successful pool open/reopen.
- Update the 10 storage actors from #9498 to cache and revalidate the pool generation.
- Preserve #9497's `openedForUserId = targetUserId()` conflict resolution.
- Add a regression test that verifies pool generation advances across reopen.
- Keep the e2e coverage mapping for the affected storage/recovery paths.

## Verification

- `git diff --check`
- `xcrun swift test --package-path Desktop --filter RewindDatabaseLifecycleTests` — 2 tests, 0 failures
- `xcrun swift build -c debug --package-path Desktop`
- `python3 scripts/check-e2e-flow-coverage.py --strict`

## Notes

Original #9498 standalone head built, but conflicted with current `main` after #9497. This PR resolves that conflict and is the mergeable replacement path.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9508?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

## Product invariants affected

- INV-CHAT-1
- INV-MEM-1
