### PR TITLE
Fix SwiftUI settings accessibility and filtering

### DIFF
--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-providers.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-providers.json
@@ -1,11 +1,11 @@
 {
   "files": {
     "desktop/macos/Desktop/Sources/Providers/ChatProvider.swift": 6269,
-    "desktop/macos/Desktop/Sources/Providers/ChatToolExecutor.swift": 2912
+    "desktop/macos/Desktop/Sources/Providers/ChatToolExecutor.swift": 2913
   },
   "raise_justifications": {
     "desktop/macos/Desktop/Sources/Providers/ChatProvider.swift": "ACP authentication terminalizes the active turn with an explicit disposition instead of awaiting OAuth, and failed bridge starts consume typed runtime diagnostics at the sole user-facing error surface to avoid a duplicate Sentry event; a component split is tracked follow-up.",
-    "desktop/macos/Desktop/Sources/Providers/ChatToolExecutor.swift": "update_action_item accepts the realtime `id` alias and backend task writes refresh TasksStore so agent-created tasks appear immediately; already-granted permissions still gate their Settings/drag-card opens behind the granted result."
+    "desktop/macos/Desktop/Sources/Providers/ChatToolExecutor.swift": "update_action_item accepts the realtime `id` alias and backend task writes refresh TasksStore so agent-created tasks appear immediately; already-granted permissions still gate their Settings/drag-card opens behind the granted result. Swift 6: explicit @preconcurrency import ApplicationServices for AX APIs used by tool execution path."
   },
   "threshold": 1500
 }

--- a/desktop/macos/Desktop/Sources/AppState/AppState+Permissions.swift
+++ b/desktop/macos/Desktop/Sources/AppState/AppState+Permissions.swift
@@ -1,4 +1,5 @@
 @preconcurrency import AVFoundation
+@preconcurrency import ApplicationServices
 import Combine
 import SwiftUI
 @preconcurrency import UserNotifications
@@ -565,7 +566,6 @@ extension AppState {
       "ACCESSIBILITY_TRIGGER: User clicked Grant Access — bundleId=\(bundleId), macOS \(osVersion.majorVersion).\(osVersion.minorVersion).\(osVersion.patchVersion)"
     )
 
-    // This will prompt the user if not already trusted
     let options =
       ["AXTrustedCheckOptionPrompt": true] as CFDictionary
     let trusted = AXIsProcessTrustedWithOptions(options)

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Components/AppRuleEditorView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Components/AppRuleEditorView.swift
@@ -6,7 +6,7 @@ struct ExcludedAppRow: View {
   let appName: String
   let onRemove: () -> Void
 
-  @State var isHovered = false
+  @State private var isHovered = false
 
   var body: some View {
     HStack(spacing: OmiSpacing.md) {
@@ -18,12 +18,11 @@ struct ExcludedAppRow: View {
 
       Spacer()
 
-      Button(action: onRemove) {
-        Image(systemName: "xmark.circle.fill")
-          .scaledFont(size: OmiType.subheading)
-          .foregroundColor(isHovered ? OmiColors.error : OmiColors.textTertiary)
-      }
-      .buttonStyle(.plain)
+      Button("Remove \(appName)", systemImage: "xmark.circle.fill", action: onRemove)
+        .labelStyle(.iconOnly)
+        .scaledFont(size: OmiType.subheading)
+        .foregroundColor(isHovered ? OmiColors.error : OmiColors.textTertiary)
+        .buttonStyle(.plain)
     }
     .padding(.horizontal, OmiSpacing.md)
     .padding(.vertical, OmiSpacing.sm)
@@ -45,8 +44,8 @@ struct AppRuleEditorView: View {
   let builtInApps: Set<String>
   let onAdd: (String) -> Void
 
-  @State var newAppName: String = ""
-  @State var runningApps: [String] = []
+  @State private var newAppName: String = ""
+  @State private var runningApps: [String] = []
 
   var body: some View {
     VStack(alignment: .leading, spacing: OmiSpacing.md) {
@@ -70,17 +69,14 @@ struct AppRuleEditorView: View {
             .scaledFont(size: OmiType.caption, weight: .medium)
             .foregroundColor(OmiColors.textTertiary)
           Spacer()
-          Button {
-            refreshRunningApps()
-          } label: {
-            Image(systemName: "arrow.clockwise")
-              .scaledFont(size: OmiType.caption)
-              .foregroundColor(OmiColors.textTertiary)
-          }
-          .buttonStyle(.plain)
+          Button("Refresh running apps", systemImage: "arrow.clockwise", action: refreshRunningApps)
+            .labelStyle(.iconOnly)
+            .scaledFont(size: OmiType.caption)
+            .foregroundColor(OmiColors.textTertiary)
+            .buttonStyle(.plain)
         }
 
-        ScrollView(.horizontal, showsIndicators: false) {
+        ScrollView(.horizontal) {
           HStack(spacing: OmiSpacing.sm) {
             ForEach(
               runningApps.filter { !existingApps.contains($0) && !builtInApps.contains($0) },
@@ -92,6 +88,7 @@ struct AppRuleEditorView: View {
             }
           }
         }
+        .scrollIndicators(.hidden)
       }
       .padding(.top, OmiSpacing.xxs)
     }
@@ -121,14 +118,14 @@ struct BrowserKeywordListView: View {
   let onAdd: (String) -> Void
   let onRemove: (String) -> Void
 
-  @State var newKeyword: String = ""
-  @State var filterText: String = ""
+  @State private var newKeyword: String = ""
+  @State private var filterText: String = ""
 
   var filteredKeywords: [String] {
     if filterText.isEmpty {
       return keywords
     }
-    return keywords.filter { $0.lowercased().contains(filterText.lowercased()) }
+    return keywords.filter { $0.localizedStandardContains(filterText) }
   }
 
   var body: some View {
@@ -142,13 +139,12 @@ struct BrowserKeywordListView: View {
           .textFieldStyle(.plain)
           .scaledFont(size: OmiType.caption)
         if !filterText.isEmpty {
-          Button {
+          Button("Clear keyword filter", systemImage: "xmark.circle.fill") {
             filterText = ""
-          } label: {
-            Image(systemName: "xmark.circle.fill")
-              .scaledFont(size: OmiType.caption)
-              .foregroundColor(OmiColors.textTertiary)
           }
+          .labelStyle(.iconOnly)
+          .scaledFont(size: OmiType.caption)
+          .foregroundColor(OmiColors.textTertiary)
           .buttonStyle(.plain)
         }
       }
@@ -165,13 +161,12 @@ struct BrowserKeywordListView: View {
               Text(keyword)
                 .scaledFont(size: OmiType.caption)
                 .foregroundColor(OmiColors.textPrimary)
-              Button {
+              Button("Remove \(keyword)", systemImage: "xmark") {
                 onRemove(keyword)
-              } label: {
-                Image(systemName: "xmark")
-                  .scaledFont(size: 8, weight: .bold)
-                  .foregroundColor(OmiColors.textTertiary)
               }
+              .labelStyle(.iconOnly)
+              .scaledFont(size: 8, weight: .bold)
+              .foregroundColor(OmiColors.textTertiary)
               .buttonStyle(.plain)
             }
             .padding(.horizontal, OmiSpacing.sm)
@@ -215,7 +210,7 @@ struct RunningAppChip: View {
   let appName: String
   let onTap: () -> Void
 
-  @State var isHovered = false
+  @State private var isHovered = false
 
   var body: some View {
     Button(action: onTap) {

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+FloatingBarAndChat.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+FloatingBarAndChat.swift
@@ -480,17 +480,17 @@ extension SettingsContentView {
             ScrollView {
               let filteredSkills = allSkills.enumerated().filter { _, item in
                 skillSearchQuery.isEmpty
-                  || item.skill.name.localizedCaseInsensitiveContains(skillSearchQuery)
-                  || item.skill.description.localizedCaseInsensitiveContains(skillSearchQuery)
+                  || item.skill.name.localizedStandardContains(skillSearchQuery)
+                  || item.skill.description.localizedStandardContains(skillSearchQuery)
               }
 
               VStack(spacing: 0) {
-                ForEach(Array(filteredSkills.enumerated()), id: \.offset) { filteredIndex, item in
+                ForEach(filteredSkills, id: \.element.skill.path) { item in
                   let skill = item.element.skill
                   let origin = item.element.origin
                   HStack(spacing: OmiSpacing.sm) {
                     Toggle(
-                      "",
+                      "Enable \(skill.name)",
                       isOn: Binding(
                         get: { !aiChatDisabledSkills.contains(skill.name) },
                         set: { enabled in
@@ -551,7 +551,7 @@ extension SettingsContentView {
                   .padding(.vertical, OmiSpacing.xs)
                   .padding(.horizontal, OmiSpacing.xxs)
 
-                  if filteredIndex < filteredSkills.count - 1 {
+                  if item.offset != filteredSkills.last?.offset {
                     Divider()
                       .opacity(0.3)
                   }

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskExtraction/TaskAssistantSettings.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskExtraction/TaskAssistantSettings.swift
@@ -401,13 +401,11 @@ class TaskAssistantSettings {
     guard TaskAssistantSettings.isBrowser(appName) else { return true }
     guard let title = windowTitle, !title.isEmpty else { return false }
 
-    let lowercaseTitle = title.lowercased()
-    for keyword in browserKeywords {
-      if lowercaseTitle.contains(keyword.lowercased()) {
-        return true
-      }
-    }
-    return false
+    return TaskAssistantSettings.windowTitle(title, matchesAny: browserKeywords)
+  }
+
+  nonisolated static func windowTitle(_ title: String, matchesAny keywords: [String]) -> Bool {
+    keywords.contains { title.localizedStandardContains($0) }
   }
 
   /// Add an app to the allowed list

--- a/desktop/macos/Desktop/Sources/Providers/ChatToolExecutor.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatToolExecutor.swift
@@ -1,5 +1,6 @@
 @preconcurrency import AVFoundation
 import AppKit
+@preconcurrency import ApplicationServices
 import Foundation
 @preconcurrency import GRDB
 @preconcurrency import UserNotifications

--- a/desktop/macos/Desktop/Tests/TaskAssistantPromptTests.swift
+++ b/desktop/macos/Desktop/Tests/TaskAssistantPromptTests.swift
@@ -3,6 +3,15 @@ import XCTest
 @testable import Omi_Computer
 
 final class TaskAssistantPromptTests: XCTestCase {
+  func testBrowserKeywordMatchingUsesUserLocaleRules() {
+    XCTAssertTrue(
+      TaskAssistantSettings.windowTitle("Résumé – Safari", matchesAny: ["resume"])
+    )
+    XCTAssertFalse(
+      TaskAssistantSettings.windowTitle("Calendar – Safari", matchesAny: ["resume"])
+    )
+  }
+
   @MainActor
   func testDefaultPromptSkipsPublicChannelRequestsNotDirectedAtUser() {
     let prompt = TaskAssistantSettings.defaultAnalysisPrompt

--- a/desktop/macos/changelog/unreleased/20260711-swiftui-settings-corrections.json
+++ b/desktop/macos/changelog/unreleased/20260711-swiftui-settings-corrections.json
@@ -1,0 +1,3 @@
+{
+  "change": "Improved settings accessibility and made skill and keyword filtering more reliable"
+}

--- a/desktop/macos/e2e/flows/settings-basic.yaml
+++ b/desktop/macos/e2e/flows/settings-basic.yaml
@@ -5,6 +5,7 @@ description: Settings navigation smoke — open Settings via gear icon, navigate
 app: com.omi.computer-macos
 covers:
   - desktop/macos/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
+  - desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Components/AppRuleEditorView.swift
   - desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+General.swift
   - desktop/macos/Desktop/Sources/MainWindow/SettingsSidebar.swift
 preconditions:


### PR DESCRIPTION
## Summary

- give icon-only App Rules controls native accessibility labels while preserving their visual appearance
- keep filtered AI Chat skill rows tied to stable skill paths and make skill search locale-aware
- use the same locale-aware matching for browser task keywords, with a regression test

## Root cause and durable guard

The settings views exposed several image-only controls without semantic labels, keyed filtered skill rows by their temporary list position, and implemented browser matching with manual lowercasing. Those choices made VoiceOver controls ambiguous, allowed SwiftUI row identity to shift as search results changed, and missed locale/diacritic-equivalent text.

The fix uses native labeled controls, stable skill-path identity, and `localizedStandardContains`. The browser matching helper is exercised by a regression test proving `resume` matches `Résumé` while unrelated titles do not. No broader settings migration is included.

## Verification

- `OMI_SWIFT_TEST_SUITE_WORKERS=4 bash test.sh` — all desktop tests passed
- `python3 desktop/macos/scripts/check_desktop_test_quality.py` — passed
- `python3 desktop/macos/scripts/check-e2e-flow-coverage.py --strict` — all 3 changed Swift source files covered
- `git diff --check` — passed

## Product invariants affected

- INV-AUTH-1
- INV-CHAT-1
- INV-DATA-1
- INV-INT-1

## Failure class (fixes)

Failure-Class: none
