### PR TITLE
fix(conversations): keep raw coordinates when the geocode lookup misses

### DIFF
--- a/backend/routers/developer.py
+++ b/backend/routers/developer.py
@@ -57,7 +57,7 @@ from utils.other.endpoints import with_rate_limit, get_current_user_uid
 from utils.notifications import send_action_item_data_message, sync_action_item_reminder
 from utils.conversations.process_conversation import process_conversation
 from utils.conversations import lifecycle as lifecycle_service
-from utils.conversations.location import get_google_maps_location, resolve_geolocation
+from utils.conversations.location import resolve_geolocation
 from utils.executors import postprocess_executor
 from utils.request_validation import HistoryDays
 from utils.llm.memories import identify_category_for_memory

--- a/backend/routers/developer.py
+++ b/backend/routers/developer.py
@@ -57,7 +57,7 @@ from utils.other.endpoints import with_rate_limit, get_current_user_uid
 from utils.notifications import send_action_item_data_message, sync_action_item_reminder
 from utils.conversations.process_conversation import process_conversation
 from utils.conversations import lifecycle as lifecycle_service
-from utils.conversations.location import get_google_maps_location
+from utils.conversations.location import get_google_maps_location, resolve_geolocation
 from utils.executors import postprocess_executor
 from utils.request_validation import HistoryDays
 from utils.llm.memories import identify_category_for_memory
@@ -1467,14 +1467,8 @@ def create_conversation(
     if finished_at < started_at:
         raise HTTPException(status_code=422, detail="finished_at must be after started_at")
 
-    # Process geolocation if provided
-    geolocation = request.geolocation
-    if geolocation and not geolocation.google_place_id:
-        try:
-            geolocation = get_google_maps_location(geolocation.latitude, geolocation.longitude)
-        except Exception as e:
-            logger.error(f"Error enriching geolocation: {e}")
-            # Continue with original geolocation if enrichment fails
+    # Process geolocation if provided (keeps the raw coordinates when the geocode lookup misses)
+    geolocation = resolve_geolocation(request.geolocation)
 
     # Language defaults
     language_code = request.language or 'en'
@@ -1653,14 +1647,8 @@ def _create_conversation_from_segments(
     if finished_at <= started_at:
         raise HTTPException(status_code=422, detail="finished_at must be after started_at")
 
-    # Process geolocation if provided
-    geolocation = request.geolocation
-    if geolocation and not geolocation.google_place_id:
-        try:
-            geolocation = get_google_maps_location(geolocation.latitude, geolocation.longitude)
-        except Exception as e:
-            logger.error(f"Error enriching geolocation: {e}")
-            # Continue with original geolocation if enrichment fails
+    # Process geolocation if provided (keeps the raw coordinates when the geocode lookup misses)
+    geolocation = resolve_geolocation(request.geolocation)
 
     # Language defaults
     language_code = request.language or 'en'

--- a/backend/tests/unit/test_developer_from_segments_idempotency.py
+++ b/backend/tests/unit/test_developer_from_segments_idempotency.py
@@ -5,6 +5,8 @@ from pathlib import Path
 from types import ModuleType
 from unittest.mock import MagicMock
 
+import pytest
+
 os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
 os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv')
 
@@ -141,6 +143,15 @@ from models.conversation import Conversation, CreateConversation  # noqa: E402
 from models.conversation_enums import ConversationStatus  # noqa: E402
 
 NOW = datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+
+@pytest.fixture(autouse=True)
+def _passthrough_resolve_geolocation(monkeypatch):
+    # utils.conversations.location is stubbed with an AutoMockModule here, so the imported
+    # resolve_geolocation is a MagicMock that returns a MagicMock (not None) for a None geolocation,
+    # which would fail CreateConversation validation. Patch it to a passthrough so the geolocation flows
+    # through unchanged, matching production for the None / already-resolved cases these tests exercise.
+    monkeypatch.setattr(developer, 'resolve_geolocation', lambda g: g)
 
 
 def _segment():

--- a/backend/tests/unit/test_geolocation_resolve.py
+++ b/backend/tests/unit/test_geolocation_resolve.py
@@ -1,0 +1,72 @@
+"""Regression: resolve_geolocation must not drop the user's coordinates on a geocode miss.
+
+get_google_maps_location / async_get_google_maps_location return None when Google reports ZERO_RESULTS,
+OVER_QUERY_LIMIT, REQUEST_DENIED, or no place_id. Callers in routers/developer.py and routers/pusher.py
+assigned that return directly, so a lookup miss overwrote the real lat/long with None and the conversation
+was stored with no location. resolve_geolocation keeps the original coordinates on a None return (and on an
+error), matching the fix already applied inline in routers/integration.py. Pinned against a fake geocoder,
+no live services.
+"""
+
+import os
+from unittest.mock import AsyncMock, patch
+
+os.environ.setdefault(
+    "ENCRYPTION_SECRET",
+    "omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv",
+)
+
+import asyncio  # noqa: E402
+
+from models.geolocation import Geolocation  # noqa: E402
+
+import utils.conversations.location as loc  # noqa: E402
+
+
+def _raw():
+    return Geolocation(latitude=37.78, longitude=-122.41)  # coordinates, no google_place_id
+
+
+def test_resolve_geolocation_keeps_enrichment():
+    enriched = Geolocation(latitude=37.78, longitude=-122.41, google_place_id="ChIJ_test", address="1 St")
+    with patch.object(loc, "get_google_maps_location", return_value=enriched):
+        assert loc.resolve_geolocation(_raw()).google_place_id == "ChIJ_test"
+
+
+def test_resolve_geolocation_keeps_raw_on_miss():
+    with patch.object(loc, "get_google_maps_location", return_value=None):  # ZERO_RESULTS / no place_id
+        raw = _raw()
+        assert loc.resolve_geolocation(raw) is raw  # coordinates preserved, not dropped to None
+
+
+def test_resolve_geolocation_keeps_raw_on_error():
+    with patch.object(loc, "get_google_maps_location", side_effect=RuntimeError("maps unavailable")):
+        raw = _raw()
+        assert loc.resolve_geolocation(raw) is raw  # a geocoder error must not drop the location
+
+
+def test_resolve_geolocation_skips_when_place_id_present():
+    with patch.object(loc, "get_google_maps_location") as geo:
+        already = Geolocation(latitude=1.0, longitude=2.0, google_place_id="ChIJ_existing")
+        assert loc.resolve_geolocation(already) is already
+        geo.assert_not_called()  # already enriched -> no geocoder call
+
+
+def test_resolve_geolocation_none_passthrough():
+    with patch.object(loc, "get_google_maps_location") as geo:
+        assert loc.resolve_geolocation(None) is None
+        geo.assert_not_called()
+
+
+def test_async_resolve_geolocation_keeps_enrichment():
+    enriched = Geolocation(latitude=37.78, longitude=-122.41, google_place_id="ChIJ_async")
+    with patch.object(loc, "async_get_google_maps_location", new=AsyncMock(return_value=enriched)):
+        result = asyncio.run(loc.async_resolve_geolocation(_raw()))
+    assert result.google_place_id == "ChIJ_async"
+
+
+def test_async_resolve_geolocation_keeps_raw_on_miss():
+    with patch.object(loc, "async_get_google_maps_location", new=AsyncMock(return_value=None)):
+        raw = _raw()
+        result = asyncio.run(loc.async_resolve_geolocation(raw))
+    assert result is raw  # cached coordinates preserved on a miss, not dropped to None

--- a/backend/utils/conversations/finalizer.py
+++ b/backend/utils/conversations/finalizer.py
@@ -15,7 +15,7 @@ from models.conversation_enums import ConversationStatus
 from models.geolocation import Geolocation
 from utils.app_integrations import trigger_external_integrations
 from utils.conversations.factory import deserialize_conversation
-from utils.conversations.location import async_get_google_maps_location
+from utils.conversations.location import async_resolve_geolocation
 from utils.conversations.process_conversation import process_conversation
 from utils.conversations import lifecycle as lifecycle_service
 from utils.executors import db_executor, postprocess_executor, run_blocking
@@ -83,7 +83,8 @@ async def finalize_persisted_conversation(
         geolocation = await run_blocking(db_executor, get_cached_user_geolocation, uid)
         if geolocation:
             geolocation = Geolocation(**geolocation)
-            conversation.geolocation = await async_get_google_maps_location(geolocation.latitude, geolocation.longitude)
+            # Keep the cached coordinates when the geocode lookup misses instead of dropping them.
+            conversation.geolocation = await async_resolve_geolocation(geolocation)
 
         # The post-processing bulkhead preserves request context (including
         # validated live BYOK keys) while isolating this expensive sync path

--- a/backend/utils/conversations/location.py
+++ b/backend/utils/conversations/location.py
@@ -61,6 +61,23 @@ def get_google_maps_location(latitude: float, longitude: float) -> Optional[Geol
     return geo
 
 
+def resolve_geolocation(geolocation: Optional[Geolocation]) -> Optional[Geolocation]:
+    """Enrich a raw geolocation via Google Places, keeping the original coordinates when the lookup
+    misses (returns None) or errors, so a geocode miss/failure never drops the user's location.
+
+    Only a geolocation that has coordinates but no google_place_id yet is enriched; anything else is
+    returned unchanged. Callers should assign the return value once (do not overwrite it afterward).
+    """
+    if not geolocation or geolocation.google_place_id:
+        return geolocation
+    try:
+        enriched = get_google_maps_location(geolocation.latitude, geolocation.longitude)
+    except Exception as e:
+        logger.error('resolve_geolocation enrichment failed: %s', e)
+        return geolocation
+    return enriched or geolocation
+
+
 async def async_get_google_maps_location(latitude: float, longitude: float) -> Optional[Geolocation]:
     """Async version of get_google_maps_location using httpx.AsyncClient."""
     logger.info(f'async_get_google_maps_location {latitude} {longitude}')
@@ -112,3 +129,16 @@ async def async_get_google_maps_location(latitude: float, longitude: float) -> O
         logging.warning('Failed to cache geocode for key %s: %s', cache_key, e)
 
     return geo
+
+
+async def async_resolve_geolocation(geolocation: Optional[Geolocation]) -> Optional[Geolocation]:
+    """Async variant of resolve_geolocation: enrich via async_get_google_maps_location, keeping the
+    original coordinates when the lookup misses (returns None) or errors."""
+    if not geolocation or geolocation.google_place_id:
+        return geolocation
+    try:
+        enriched = await async_get_google_maps_location(geolocation.latitude, geolocation.longitude)
+    except Exception as e:
+        logger.error('async_resolve_geolocation enrichment failed: %s', e)
+        return geolocation
+    return enriched or geolocation


### PR DESCRIPTION
## What

This closes the geolocation-drop-on-miss failure class across the remaining conversation-create paths, following the same fix landed inline in routers/integration.py (#9504).

`get_google_maps_location` / `async_get_google_maps_location` return None when Google reports ZERO_RESULTS, OVER_QUERY_LIMIT, REQUEST_DENIED, or a result with no place_id. Three sites assigned that return directly to the conversation's geolocation:

- routers/developer.py: two create-conversation handlers (`geolocation = get_google_maps_location(...)` inside a try/except that only catches thrown exceptions, not a None return)
- routers/pusher.py: post-processing enrichment (`conversation.geolocation = await async_get_google_maps_location(...)`)

On a geocode miss the real user coordinates were overwritten with None, so the conversation was stored with no location even though the client sent valid lat/long.

## Fix

Add `resolve_geolocation` / `async_resolve_geolocation` to utils/conversations/location.py (the shared boundary, next to the geocoders). Each enriches a geolocation that has coordinates but no place_id yet, and keeps the original coordinates when the lookup returns None or errors. Route all three sites through it. Behavior on success is unchanged; a miss now preserves the coordinates instead of dropping them.

## Testing

- tests/unit/test_geolocation_resolve.py (added): resolve_geolocation and async_resolve_geolocation keep the enrichment on success, keep the raw coordinates on a None miss and on a geocoder error, skip the lookup when a place_id is already present, and pass through None. Pinned against a fake geocoder, no live services.
- 7 passed. black, pyright (0 errors on location.py), check_module_stub_pollution (0) clean.

Note: CI here is red only on the pre-existing tests/unit/test_app_client_schema_inventory.py gate (the #9470 app.dart line shift, fixed in #9482); this PR does not touch that path and its own tests pass.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9510?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

