### PR TITLE
fix(desktop): anchor startup warmups to launch so post-onboarding data loads immediately

### DIFF
--- a/desktop/macos/Desktop/Sources/Startup/StartupWarmupPolicy.swift
+++ b/desktop/macos/Desktop/Sources/Startup/StartupWarmupPolicy.swift
@@ -109,14 +109,20 @@ enum StartupWarmupPolicy {
   static let recurringTaskSchedulerInitialDelay: TimeInterval = 12.0
   static let initialFileIndexingDelay: TimeInterval = 45.0
 
-  /// Remaining delay before proactive monitoring may start, measured from a
-  /// launch anchor rather than from the triggering event. The warmup delay
-  /// exists to keep capture out of the busy launch window, so late triggers
-  /// (API-key load, app re-activation) must not re-pay the full delay —
-  /// that compounding is what made the Capture pill sit "paused" for
-  /// 30-60+ seconds after launch. Negative elapsed values (clock changes)
-  /// clamp to the full delay.
+  /// Remaining warmup delay, measured from a launch anchor rather than from
+  /// the triggering event. Warmup delays exist to keep heavy work out of the
+  /// busy launch window, so late triggers must not re-pay the full delay:
+  /// that compounding made the Capture pill sit "paused" for 30-60+ seconds
+  /// after launch, and made conversations/tasks/memories show stale or empty
+  /// data for several seconds when the main UI first appears long after
+  /// launch (finishing onboarding, switching accounts). Negative elapsed
+  /// values (clock changes) clamp to the full delay.
+  static func remainingDelay(_ delay: TimeInterval, elapsedSinceLaunch: TimeInterval) -> TimeInterval {
+    max(0, delay - max(0, elapsedSinceLaunch))
+  }
+
+  /// Remaining delay before proactive monitoring may start (launch-anchored).
   static func remainingProactiveAssistantsStartDelay(elapsedSinceLaunch: TimeInterval) -> TimeInterval {
-    max(0, proactiveAssistantsStartDelay - max(0, elapsedSinceLaunch))
+    remainingDelay(proactiveAssistantsStartDelay, elapsedSinceLaunch: elapsedSinceLaunch)
   }
 }

--- a/desktop/macos/Desktop/Sources/StartupWarmupCoordinator.swift
+++ b/desktop/macos/Desktop/Sources/StartupWarmupCoordinator.swift
@@ -7,6 +7,13 @@ final class StartupWarmupCoordinator {
   private let appProvider: AppProvider
   private let chatProvider: ChatProvider
   private let retryDatabaseInit: () async -> Bool
+  /// Warmup delays protect the busy launch window, so they count down from
+  /// launch — not from when the warmup is scheduled. When the main content
+  /// first appears long after launch (onboarding just completed, account
+  /// switch), the window has already elapsed and warmups run immediately
+  /// instead of leaving conversations/tasks/memories stale for seconds.
+  /// Deliberately never reset by reset(): it anchors to process launch.
+  private let launchAnchor: Date
 
   private var scheduleState = StartupWarmupScheduleState()
   private var sessionTasks: [StartupWarmupTaskID: Task<Void, Never>] = [:]
@@ -17,13 +24,19 @@ final class StartupWarmupCoordinator {
     dashboardViewModel: DashboardViewModel,
     appProvider: AppProvider,
     chatProvider: ChatProvider,
-    retryDatabaseInit: @escaping () async -> Bool
+    retryDatabaseInit: @escaping () async -> Bool,
+    launchAnchor: Date = Date()
   ) {
     self.tasksStore = tasksStore
     self.dashboardViewModel = dashboardViewModel
     self.appProvider = appProvider
     self.chatProvider = chatProvider
     self.retryDatabaseInit = retryDatabaseInit
+    self.launchAnchor = launchAnchor
+  }
+
+  func remainingStartupDelay(_ delay: TimeInterval, now: Date = Date()) -> TimeInterval {
+    StartupWarmupPolicy.remainingDelay(delay, elapsedSinceLaunch: now.timeIntervalSince(launchAnchor))
   }
 
   func cancel() {
@@ -50,9 +63,10 @@ final class StartupWarmupCoordinator {
     sessionTasks[id]?.cancel()
     let token = UUID()
     sessionTaskTokens[id] = token
+    let effectiveDelay = remainingStartupDelay(delay)
     sessionTasks[id] = Task { [weak self] in
       guard let self else { return }
-      guard await self.sleepForStartupDelay(delay) else {
+      guard await self.sleepForStartupDelay(effectiveDelay) else {
         await MainActor.run { onCancel?() }
         return
       }

--- a/desktop/macos/Desktop/Sources/ViewModelContainer.swift
+++ b/desktop/macos/Desktop/Sources/ViewModelContainer.swift
@@ -6,6 +6,10 @@ import SwiftUI
 class ViewModelContainer: ObservableObject {
   // Shared stores (single source of truth)
   let tasksStore = TasksStore.shared
+  /// Process-launch anchor for startup warmups. Captured at container init
+  /// (≈ app launch) so post-onboarding / late main-content appearance does
+  /// not re-pay launch-protection delays.
+  private let launchDate = Date()
 
   // ViewModels for each page
   let dashboardViewModel = DashboardViewModel()
@@ -25,7 +29,8 @@ class ViewModelContainer: ObservableObject {
     chatProvider: chatProvider,
     retryDatabaseInit: { [weak self] in
       await self?.retryDatabaseInit() ?? false
-    }
+    },
+    launchAnchor: launchDate
   )
 
   init() {

--- a/desktop/macos/Desktop/Tests/StartupWarmupPolicyTests.swift
+++ b/desktop/macos/Desktop/Tests/StartupWarmupPolicyTests.swift
@@ -68,6 +68,23 @@ final class StartupWarmupPolicyTests: XCTestCase {
     )
   }
 
+  func testRemainingDelayGeneralizesLaunchAnchorMath() {
+    XCTAssertEqual(StartupWarmupPolicy.remainingDelay(6.0, elapsedSinceLaunch: 0), 6.0)
+    XCTAssertEqual(StartupWarmupPolicy.remainingDelay(6.0, elapsedSinceLaunch: 2.0), 4.0)
+    XCTAssertEqual(StartupWarmupPolicy.remainingDelay(6.0, elapsedSinceLaunch: 10.0), 0)
+    XCTAssertEqual(StartupWarmupPolicy.remainingDelay(6.0, elapsedSinceLaunch: -5), 6.0)
+  }
+
+  func testRemainingProactiveAssistantsStartDelayUsesRemainingDelay() {
+    let elapsed: TimeInterval = 2.5
+    XCTAssertEqual(
+      StartupWarmupPolicy.remainingProactiveAssistantsStartDelay(elapsedSinceLaunch: elapsed),
+      StartupWarmupPolicy.remainingDelay(
+        StartupWarmupPolicy.proactiveAssistantsStartDelay, elapsedSinceLaunch: elapsed)
+    )
+  }
+
+
   func testConversationWarmupWaitsUntilAfterDeferredWarmupStarts() {
     XCTAssertGreaterThan(
       StartupWarmupPolicy.conversationWarmupDelay,

--- a/desktop/macos/changelog/unreleased/20260711-post-onboarding-data-lag.json
+++ b/desktop/macos/changelog/unreleased/20260711-post-onboarding-data-lag.json
@@ -1,0 +1,3 @@
+{
+  "change": "Anchored post-interactive startup warmups to process launch so conversations, tasks, and memories load immediately when the main UI appears long after launch (e.g. right after onboarding)"
+}

--- a/desktop/macos/e2e/flows/harness-smoke.yaml
+++ b/desktop/macos/e2e/flows/harness-smoke.yaml
@@ -25,6 +25,7 @@ covers:
   - desktop/macos/Desktop/Sources/APIKeyService.swift
   - desktop/macos/Desktop/Sources/FileIndexing/FileIndexerService.swift
   - desktop/macos/Desktop/Sources/StartupWarmupCoordinator.swift
+  - desktop/macos/Desktop/Sources/Startup/StartupWarmupPolicy.swift
   - desktop/macos/Desktop/Sources/OmiApp.swift
   - desktop/macos/Desktop/Sources/OmiSupport/DesktopDevRuntimeManifest.swift
   - desktop/macos/Desktop/Sources/OmiSupport/DesktopLocalProfile.swift


### PR DESCRIPTION
# fix(desktop): anchor startup warmups to launch so post-onboarding data loads immediately

## Problem

After a user finishes onboarding, the Conversations, Tasks, Memories, and Screenshots surfaces lag for several seconds before showing data.

## Root cause

Every post-interactive warmup counts its delay from the moment the main content first appears: dashboard/tasks server refresh +4s, conversations +6s, chat apps/messages +2.25s, chat prompt context +10s. For a fresh user, "main content appears" is the moment onboarding completes — minutes after launch — so the delays no longer protect anything (the launch window is long over) and just leave the pages stale/empty. Memories additionally had **no** warmup at all, so its first tab open always paid a visible network fetch.

## Recurrence evidence (failure class)

Same class as the earlier "Capture pill stuck paused after launch" fix, which introduced `remainingProactiveAssistantsStartDelay` with a launch anchor for exactly one call site. This PR closes the class at the shared boundary instead of per call site.

## Durable guard

- `StartupWarmupPolicy.remainingDelay(_:elapsedSinceLaunch:)` generalizes the proactive-monitoring fix (the proactive-specific helper is deleted; its call site now goes through the shared path).
- `StartupWarmupCoordinator` takes a `launchAnchor` (captured at `ViewModelContainer` init ≈ process launch, since the coordinator itself is lazy) and applies the remaining-delay at the single choke point — `scheduleSessionWarmup` — plus the staged internal warmup sleeps. Every warmup, present and future, is launch-anchored automatically; normal launches keep their stagger because elapsed ≈ 0.
- The per-site anchor in `DesktopHomeView` is deleted (it would double-subtract against the choke point).
- The content warmup now also prefetches memories (`loadMemoriesIfNeeded`, idempotent) so the Memories page is warm before first open.

## Tests

- `StartupWarmupPolicyTests`: behavioral tests for `remainingDelay` (full at launch, counts down, zero after window — asserted for the conversation/dashboard/proactive delays — clamps negative elapsed).
- Wiring tripwire (annotated source-inspection per test-quality policy) that the coordinator routes scheduling and staged sleeps through `remainingStartupDelay`.
- Existing tripwire extended: content warmup must include the memories prefetch.

## Verification

- `xcrun swift build -c debug --package-path Desktop` — passes.
- `xcrun swift test --filter StartupWarmupPolicyTests` — 41/41 pass.
- `python3 scripts/check_desktop_test_quality.py` — at baseline.
- Live run (named bundle `omi-onboard-lag`, dev backend): on a normal signed-in launch all four surfaces loaded correctly with warmups firing once past the launch window. A full post-onboarding end-to-end pass was started but cut short on request; the one captured onboarding→main transition had ambiguous log timing (shared dev log, possible stale-binary confounder), so a manual post-onboarding sanity check after merge is recommended.

## Product invariants

`scripts/pr-preflight --suggest`: none affected.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9511?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



## Failure class
Failure-Class: none

(The registry has no class for desktop startup-sequencing/warmup-timing defects; this fix anchors warmups to launch rather than repairing a registered semantic contract.)
