### PR TITLE
Fix macOS Rewind blank capture, Bee audio crash, ~6 dB system-audio loss, hub timer leak, sync data loss (bug sweep #6)

### DIFF
--- a/desktop/macos/Desktop/Sources/Audio/AudioCodecDecoder.swift
+++ b/desktop/macos/Desktop/Sources/Audio/AudioCodecDecoder.swift
@@ -331,27 +331,48 @@ final class AACAudioDecoder: AudioCodecDecoder {
         logger.debug("AAC decoder initialized")
     }
 
+    /// Validates an ADTS frame header and returns the raw-AAC payload subrange
+    /// (past the 7-byte header) in `data`'s own index space, or nil when the frame
+    /// is malformed or incomplete.
+    ///
+    /// Two trap sources are guarded here: (1) a decoded `frameLength <= headerSize`
+    /// would form an invalid `header..<frameLength` range and crash the process on
+    /// corrupt BLE audio; (2) all reads are `startIndex`-relative, so a `Data` slice
+    /// with a non-zero `startIndex` does not trap absolute `[0]`/`subdata` access.
+    /// `static` so it is synchronously unit-testable without an initialized converter.
+    static func adtsRawAACRange(in data: Data) -> Range<Data.Index>? {
+        let headerSize = 7
+        guard data.count >= headerSize else { return nil }
+
+        let base = data.startIndex
+
+        // Validate ADTS sync word
+        guard data[base] == 0xFF, (data[base + 1] & 0xF0) == 0xF0 else { return nil }
+
+        // Extract frame length from ADTS header (13 bits → 0...8191)
+        let frameLength = (Int(data[base + 3] & 0x03) << 11) |
+            (Int(data[base + 4]) << 3) |
+            (Int(data[base + 5] & 0xE0) >> 5)
+
+        // frameLength counts the whole ADTS frame including its 7-byte header. A value
+        // that does not extend past the header is malformed (no payload / corrupt) and
+        // must not be turned into a subdata range.
+        guard frameLength > headerSize, data.count >= frameLength else { return nil }
+
+        return (base + headerSize)..<(base + frameLength)
+    }
+
     func decode(_ data: Data) -> [Int16]? {
         guard isInitialized, let converter = audioConverter else {
             logger.warning("AAC decoder not initialized")
             return nil
         }
 
-        guard data.count >= 7 else { return nil }
-
-        // Validate ADTS sync word
-        guard data[0] == 0xFF, (data[1] & 0xF0) == 0xF0 else {
-            logger.debug("Invalid ADTS sync word")
-            return nil
-        }
-
-        // Extract frame length from ADTS header
-        let frameLength = (Int(data[3] & 0x03) << 11) |
-                         (Int(data[4]) << 3) |
-                         (Int(data[5] & 0xE0) >> 5)
-
-        guard data.count >= frameLength else {
-            logger.debug("Incomplete ADTS frame: have \(data.count), need \(frameLength)")
+        // Extract the raw-AAC payload range, guarding against a malformed frame
+        // length that would otherwise form an invalid subdata range and trap the
+        // process (see adtsRawAACRange).
+        guard let rawAACRange = Self.adtsRawAACRange(in: data) else {
+            logger.debug("Malformed or incomplete ADTS frame (count \(data.count))")
             return nil
         }
 
@@ -360,9 +381,7 @@ final class AACAudioDecoder: AudioCodecDecoder {
         var outputSamples = [Int16](repeating: 0, count: aacFrameSize * outputChannels)
         let outputSize = UInt32(outputSamples.count * 2)
 
-        // Prepare input packet description (skip 7-byte ADTS header for raw AAC)
-        let rawAACOffset = 7
-        let rawAACData = data.subdata(in: rawAACOffset..<frameLength)
+        let rawAACData = data.subdata(in: rawAACRange)
 
         var packetDescription = AudioStreamPacketDescription(
             mStartOffset: 0,

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RawWebSocket.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RawWebSocket.swift
@@ -236,6 +236,13 @@ final class RawWebSocket {
           reason = String(data: payload.subdata(in: (payload.startIndex + 2)..<payload.endIndex), encoding: .utf8) ?? ""
         }
         closed = true
+        // Cancel the keepalive timer on a server-initiated close, exactly like close()
+        // and fail() do. Without this, a resumed DispatchSourceTimer outlives the
+        // deallocated socket and keeps firing its wakeup forever. Gemini idle-closes
+        // the warm hub socket with a 1008 close frame (opcode 0x8) every ~2.5 min, so
+        // this path leaked one zombie 20s timer per re-warm across the app's lifetime.
+        pingTimer?.cancel()
+        pingTimer = nil
         onClose?(code, reason)
         conn?.cancel(); conn = nil
       case 0x9:  // ping → pong
@@ -261,5 +268,12 @@ final class RawWebSocket {
     pingTimer = nil
     onError?(message)
     conn?.cancel(); conn = nil
+  }
+
+  deinit {
+    // A resumed DispatchSourceTimer keeps firing (and is leaked) if it is released
+    // without being cancelled. Every teardown path cancels pingTimer, but guard the
+    // release regardless so no future path can reintroduce a zombie keepalive timer.
+    pingTimer?.cancel()
   }
 }

--- a/desktop/macos/Desktop/Sources/Rewind/Core/VideoChunkEncoder.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/VideoChunkEncoder.swift
@@ -368,6 +368,14 @@ actor VideoChunkEncoder {
         SentrySDK.addBreadcrumb(breadcrumb)
     }
 
+    /// Presentation timestamp (in seconds) for the frame at `frameOffset` within a chunk.
+    /// Callers pass the offset of the frame being written now; the writer requires strictly
+    /// increasing timestamps, so this must be a strictly increasing function of frameOffset
+    /// for 0, 1, 2, … `nonisolated static` so it is synchronously unit-testable.
+    nonisolated static func framePresentationSeconds(frameOffset: Int, frameRate: Double) -> Double {
+        Double(max(0, frameOffset)) / frameRate
+    }
+
     private func writeFrame(image: CGImage) async throws {
         guard let input = writerInput,
               let adaptor = pixelBufferAdaptor,
@@ -391,7 +399,18 @@ actor VideoChunkEncoder {
             try createPixelBuffer(from: image, size: outputSize, adaptor: adaptor)
         }
 
-        let presentationTime = CMTime(seconds: Double(max(0, frameOffsetInChunk - 1)) / frameRate, preferredTimescale: 600)
+        // frameOffsetInChunk is the index of the frame being written RIGHT NOW; it is
+        // incremented in addFrame only AFTER this write succeeds (so a failed write does
+        // not consume an offset). The presentation timestamp must therefore be derived
+        // from the current offset directly. A stale `- 1` here (left over from when the
+        // offset was pre-incremented before writeFrame) makes frame 0 and frame 1 both
+        // resolve to PTS 0, and AVAssetWriterInputPixelBufferAdaptor.append requires
+        // strictly increasing timestamps — so every chunk's second frame is rejected,
+        // failures cascade to an emergency reset, and no video chunk is ever persisted.
+        let presentationTime = CMTime(
+            seconds: Self.framePresentationSeconds(frameOffset: frameOffsetInChunk, frameRate: frameRate),
+            preferredTimescale: 600
+        )
         guard adaptor.append(pixelBuffer, withPresentationTime: presentationTime) else {
             if let writerError = assetWriter?.error {
                 throw RewindError.storageWriteFailed("Failed to append frame to HEVC writer", underlying: writerError)

--- a/desktop/macos/Desktop/Sources/SystemAudioCaptureService.swift
+++ b/desktop/macos/Desktop/Sources/SystemAudioCaptureService.swift
@@ -179,13 +179,8 @@ class SystemAudioCaptureService: @unchecked Sendable {
         sourceSampleRate = format.mSampleRate
         log("SystemAudioCapture: Source format - \(format.mSampleRate)Hz, \(format.mChannelsPerFrame) channels, \(format.mBitsPerChannel) bits")
 
-        // 5. Create AVAudioFormat for conversion
-        guard let inputFmt = AVAudioFormat(
-            commonFormat: .pcmFormatFloat32,
-            sampleRate: format.mSampleRate,
-            channels: AVAudioChannelCount(format.mChannelsPerFrame),
-            interleaved: false
-        ) else {
+        // 5. Create AVAudioFormat for conversion (see makeConverterInputFormat — MONO).
+        guard let inputFmt = Self.makeConverterInputFormat(sampleRate: format.mSampleRate) else {
             cleanup()
             throw SystemAudioCaptureError.formatError
         }
@@ -295,6 +290,23 @@ class SystemAudioCaptureService: @unchecked Sendable {
         )
 
         return status == noErr ? format : nil
+    }
+
+    /// Builds the converter input format. It is ALWAYS mono: `handleAudioInput`
+    /// down-mixes stereo source frames into a single channel (channel 0) and never
+    /// fills a second channel, so the converter must see a mono input and perform only
+    /// sample-rate conversion. Declaring the source channel count here made the
+    /// converter run its own stereo→mono downmix against the unwritten channel 1,
+    /// averaging our real mix against silence (~6 dB attenuation of all system audio
+    /// fed to transcription). The microphone path (AudioCaptureService) likewise builds
+    /// its input format with channels: 1. `static` so the mono contract is unit-testable.
+    static func makeConverterInputFormat(sampleRate: Double) -> AVAudioFormat? {
+        AVAudioFormat(
+            commonFormat: .pcmFormatFloat32,
+            sampleRate: sampleRate,
+            channels: 1,
+            interleaved: false
+        )
     }
 
     /// Handle incoming audio data from the tap

--- a/desktop/macos/Desktop/Sources/WAL/WALCloudSyncLogic.swift
+++ b/desktop/macos/Desktop/Sources/WAL/WALCloudSyncLogic.swift
@@ -22,6 +22,45 @@ enum WALCloudSyncLogic {
     }
   }
 
+  /// Re-apply reconciled WAL transitions onto the current live array by id.
+  ///
+  /// `reconcileUploadedWals` runs per-job network `await`s on the main actor, so it
+  /// operates on a value-type SNAPSHOT of `wals` taken before those suspensions. During
+  /// the awaits, other main-actor work (the chunk timer's `createWalFromCurrentFrames`,
+  /// SD/WiFi `createSdCardWal`, write-completion mutations) can append new WALs to the
+  /// live array. Assigning the snapshot back wholesale (`wals = workingWals`) silently
+  /// drops those appended WALs — permanent data loss for an in-progress recording.
+  ///
+  /// This merges only the fields reconcile owns (`status`, `jobId`, `uploadedAt`),
+  /// matched by id, and only when reconcile actually changed them. Entries present in
+  /// `live` but absent from `snapshot`/`reconciled` (appended during the awaits) are
+  /// preserved, and concurrent updates to other fields of untouched entries are not
+  /// clobbered.
+  static func mergeReconciledUploads(
+    live: [WALEntry],
+    snapshot: [WALEntry],
+    reconciled: [WALEntry]
+  ) -> [WALEntry] {
+    var snapshotById: [String: WALEntry] = [:]
+    for wal in snapshot { snapshotById[wal.id] = wal }
+    var reconciledById: [String: WALEntry] = [:]
+    for wal in reconciled { reconciledById[wal.id] = wal }
+
+    var result = live
+    for index in result.indices {
+      let id = result[index].id
+      guard let updated = reconciledById[id], let original = snapshotById[id] else { continue }
+      guard updated.status != original.status
+        || updated.jobId != original.jobId
+        || updated.uploadedAt != original.uploadedAt
+      else { continue }
+      result[index].status = updated.status
+      result[index].jobId = updated.jobId
+      result[index].uploadedAt = updated.uploadedAt
+    }
+    return result
+  }
+
   /// Reconcile one job's WAL members after a status fetch. Returns whether any WAL changed.
   @discardableResult
   static func applyReconcileFetch(

--- a/desktop/macos/Desktop/Sources/WAL/WALService.swift
+++ b/desktop/macos/Desktop/Sources/WAL/WALService.swift
@@ -742,9 +742,14 @@ final class WALService: ObservableObject {
             }
         }
 
-        var workingWals = wals
+        // Reconcile operates on a pre-await snapshot because it runs per-job network
+        // awaits on the main actor; merge its id-keyed transitions back onto the live
+        // array so WALs appended during those awaits are not dropped (see
+        // WALCloudSyncLogic.mergeReconciledUploads).
+        let snapshot = wals
+        var workingWals = snapshot
         if await reconciler.reconcileUploadedWals(wals: &workingWals, walDirectory: walDirectory) {
-            wals = workingWals
+            wals = WALCloudSyncLogic.mergeReconciledUploads(live: wals, snapshot: snapshot, reconciled: workingWals)
             updatePendingWals()
             saveWals()
         }

--- a/desktop/macos/Desktop/Tests/AACAudioDecoderFrameLengthTests.swift
+++ b/desktop/macos/Desktop/Tests/AACAudioDecoderFrameLengthTests.swift
@@ -1,0 +1,78 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// Regression coverage for ADTS frame-length parsing in `AACAudioDecoder`.
+///
+/// Bee-device audio is AAC and arrives over BLE, where payloads can be corrupt or
+/// truncated. A malformed ADTS header whose 13-bit frame-length field decoded to a
+/// value `<= 7` (the header size) previously reached `data.subdata(in: 7..<frameLength)`,
+/// forming an invalid `Range` (`lowerBound > upperBound`) and trapping the whole
+/// process. These tests pin that such frames are rejected (nil) rather than crashing,
+/// and that well-formed frames still yield the correct payload range — including for
+/// `Data` slices whose `startIndex` is not zero.
+final class AACAudioDecoderFrameLengthTests: XCTestCase {
+    /// Builds a minimal ADTS frame header (7 bytes) encoding `frameLength`, padded so
+    /// the returned `Data` has at least `totalCount` bytes.
+    private func makeADTSFrame(frameLength: Int, totalCount: Int, validSync: Bool = true) -> Data {
+        var bytes = [UInt8](repeating: 0, count: max(7, totalCount))
+        bytes[0] = validSync ? 0xFF : 0x00
+        bytes[1] = validSync ? 0xF0 : 0x00
+        // frameLength is 13 bits split across byte 3 (high 2), byte 4 (mid 8), byte 5 (low 3).
+        bytes[3] = UInt8((frameLength >> 11) & 0x03)
+        bytes[4] = UInt8((frameLength >> 3) & 0xFF)
+        bytes[5] = UInt8((frameLength & 0x07) << 5)
+        return Data(bytes)
+    }
+
+    func testMalformedShortFrameLengthReturnsNilInsteadOfTrapping() {
+        // frameLength values 0...7 do not extend past the 7-byte header. Each of these
+        // would have produced an invalid `7..<frameLength` range before the fix.
+        for frameLength in 0...7 {
+            let frame = makeADTSFrame(frameLength: frameLength, totalCount: 16)
+            XCTAssertNil(
+                AACAudioDecoder.adtsRawAACRange(in: frame),
+                "frameLength \(frameLength) must be rejected, not turned into a subdata range"
+            )
+        }
+    }
+
+    func testWellFormedFrameReturnsPayloadRange() {
+        let frameLength = 20
+        let frame = makeADTSFrame(frameLength: frameLength, totalCount: frameLength)
+        let range = AACAudioDecoder.adtsRawAACRange(in: frame)
+        XCTAssertEqual(range, 7..<20)
+    }
+
+    func testIncompleteFrameReturnsNil() {
+        // Header claims 40 bytes but only 16 are present.
+        let frame = makeADTSFrame(frameLength: 40, totalCount: 16)
+        XCTAssertNil(AACAudioDecoder.adtsRawAACRange(in: frame))
+    }
+
+    func testInvalidSyncWordReturnsNil() {
+        let frame = makeADTSFrame(frameLength: 20, totalCount: 20, validSync: false)
+        XCTAssertNil(AACAudioDecoder.adtsRawAACRange(in: frame))
+    }
+
+    func testTooShortDataReturnsNil() {
+        XCTAssertNil(AACAudioDecoder.adtsRawAACRange(in: Data([0xFF, 0xF0, 0x00])))
+    }
+
+    func testNonZeroStartIndexSliceIsHandledWithoutTrapping() {
+        // A Data slice whose startIndex != 0 must be parsed in its own index space.
+        let frameLength = 20
+        let full = Data([0x11, 0x22, 0x33]) + makeADTSFrame(frameLength: frameLength, totalCount: frameLength)
+        let slice = full.suffix(from: full.startIndex + 3) // startIndex == 3
+        XCTAssertNotEqual(slice.startIndex, 0)
+        let range = AACAudioDecoder.adtsRawAACRange(in: slice)
+        XCTAssertEqual(range, (slice.startIndex + 7)..<(slice.startIndex + frameLength))
+    }
+
+    func testMalformedShortFrameLengthOnSliceReturnsNil() {
+        // The crash case, but on a non-zero-startIndex slice.
+        let full = Data([0x11, 0x22, 0x33]) + makeADTSFrame(frameLength: 5, totalCount: 16)
+        let slice = full.suffix(from: full.startIndex + 3)
+        XCTAssertNil(AACAudioDecoder.adtsRawAACRange(in: slice))
+    }
+}

--- a/desktop/macos/Desktop/Tests/SystemAudioConverterFormatTests.swift
+++ b/desktop/macos/Desktop/Tests/SystemAudioConverterFormatTests.swift
@@ -12,6 +12,7 @@ import XCTest
 /// attenuating all system audio fed to transcription by ~6 dB. This test pins the mono
 /// contract at the production format factory, independent of any source channel count.
 final class SystemAudioConverterFormatTests: XCTestCase {
+    @available(macOS 14.4, *)
     func testConverterInputFormatIsAlwaysMono() {
         for sampleRate in [16000.0, 44100.0, 48000.0] {
             let format = SystemAudioCaptureService.makeConverterInputFormat(sampleRate: sampleRate)

--- a/desktop/macos/Desktop/Tests/SystemAudioConverterFormatTests.swift
+++ b/desktop/macos/Desktop/Tests/SystemAudioConverterFormatTests.swift
@@ -1,0 +1,24 @@
+import AVFoundation
+import XCTest
+
+@testable import Omi_Computer
+
+/// Regression coverage for the system-audio converter input format.
+///
+/// `handleAudioInput` down-mixes stereo source frames into a single channel and never
+/// fills a second channel, so the converter input format MUST be mono. Declaring the
+/// source channel count (e.g. 2) instead made the converter run its own stereo→mono
+/// downmix against the unwritten channel 1, averaging real audio against silence and
+/// attenuating all system audio fed to transcription by ~6 dB. This test pins the mono
+/// contract at the production format factory, independent of any source channel count.
+final class SystemAudioConverterFormatTests: XCTestCase {
+    func testConverterInputFormatIsAlwaysMono() {
+        for sampleRate in [16000.0, 44100.0, 48000.0] {
+            let format = SystemAudioCaptureService.makeConverterInputFormat(sampleRate: sampleRate)
+            XCTAssertNotNil(format, "format factory should succeed for \(sampleRate)Hz")
+            XCTAssertEqual(format?.channelCount, 1, "input format must be mono (\(sampleRate)Hz)")
+            XCTAssertEqual(format?.sampleRate, sampleRate)
+            XCTAssertEqual(format?.commonFormat, .pcmFormatFloat32)
+        }
+    }
+}

--- a/desktop/macos/Desktop/Tests/VideoChunkEncoderPresentationTimeTests.swift
+++ b/desktop/macos/Desktop/Tests/VideoChunkEncoderPresentationTimeTests.swift
@@ -1,0 +1,47 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// Regression coverage for the frame presentation-timestamp calculation in
+/// `VideoChunkEncoder`. `AVAssetWriterInputPixelBufferAdaptor.append` requires
+/// strictly increasing presentation timestamps; a stale `- 1` offset once made
+/// frame 0 and frame 1 both resolve to PTS 0, so every chunk's second frame was
+/// rejected and no video was ever persisted. These tests pin the contract that
+/// the PTS is a strictly increasing function of the (post-increment-deferred)
+/// frame offset that `addFrame` passes in.
+final class VideoChunkEncoderPresentationTimeTests: XCTestCase {
+    func testConsecutiveFrameOffsetsProduceStrictlyIncreasingTimestamps() {
+        // frameRate for the default 3s capture interval is 1/3 fps; use a couple of
+        // representative rates so the monotonicity holds regardless of cadence.
+        for frameRate in [1.0 / 3.0, 0.5, 1.0, 2.0] {
+            var previous = -Double.infinity
+            for offset in 0..<10 {
+                let pts = VideoChunkEncoder.framePresentationSeconds(frameOffset: offset, frameRate: frameRate)
+                XCTAssertGreaterThan(
+                    pts, previous,
+                    "PTS must strictly increase (frameRate=\(frameRate), offset=\(offset))"
+                )
+                previous = pts
+            }
+        }
+    }
+
+    func testFirstTwoFramesDoNotCollideAtZero() {
+        // The exact regression: frame 0 and frame 1 must not share PTS 0.
+        let frameRate = 1.0 / 3.0
+        let pts0 = VideoChunkEncoder.framePresentationSeconds(frameOffset: 0, frameRate: frameRate)
+        let pts1 = VideoChunkEncoder.framePresentationSeconds(frameOffset: 1, frameRate: frameRate)
+        XCTAssertEqual(pts0, 0.0, accuracy: 1e-9)
+        XCTAssertNotEqual(pts1, pts0)
+        XCTAssertGreaterThan(pts1, pts0)
+    }
+
+    func testOffsetMapsToItsOwnTimeSlot() {
+        // Frame N sits at N / frameRate seconds — matching the real encoded sample index.
+        let frameRate = 2.0
+        for offset in 0..<5 {
+            let pts = VideoChunkEncoder.framePresentationSeconds(frameOffset: offset, frameRate: frameRate)
+            XCTAssertEqual(pts, Double(offset) / frameRate, accuracy: 1e-9)
+        }
+    }
+}

--- a/desktop/macos/Desktop/Tests/WALCloudSyncLogicTests.swift
+++ b/desktop/macos/Desktop/Tests/WALCloudSyncLogicTests.swift
@@ -126,4 +126,89 @@ final class WALCloudSyncLogicTests: XCTestCase {
     XCTAssertNil(wals[0].jobId)
     XCTAssertEqual(wals[0].uploadedAt, 0)
   }
+
+  // MARK: - mergeReconciledUploads
+
+  private func makeWal(timerStart: Int, status: WALStatus, jobId: String? = nil) -> WALEntry {
+    var wal = WALEntry(
+      timerStart: timerStart,
+      codec: "opus",
+      status: status,
+      storage: .disk,
+      filePath: "audio_\(timerStart).bin",
+      seconds: 60,
+      device: "dev1",
+      deviceModel: "Omi"
+    )
+    wal.jobId = jobId
+    return wal
+  }
+
+  func testMergePreservesWalAppendedDuringReconcile() {
+    // Snapshot taken before reconcile's network await: one uploaded WAL.
+    let uploaded = makeWal(timerStart: 1_700_000_000, status: .uploaded, jobId: "job-1")
+    let snapshot = [uploaded]
+
+    // Reconcile marks it synced (operating on the snapshot copy).
+    var reconciled = snapshot
+    reconciled[0].status = .synced
+    reconciled[0].jobId = nil
+    reconciled[0].uploadedAt = 0
+
+    // Meanwhile the live array gained a brand-new WAL (chunk timer fired during await).
+    let appended = makeWal(timerStart: 1_700_000_500, status: .memory)
+    let live = [uploaded, appended]
+
+    let merged = WALCloudSyncLogic.mergeReconciledUploads(
+      live: live, snapshot: snapshot, reconciled: reconciled)
+
+    // The reconciled transition is applied...
+    XCTAssertEqual(merged.count, 2)
+    let mergedUploaded = merged.first { $0.id == uploaded.id }
+    XCTAssertEqual(mergedUploaded?.status, .synced)
+    XCTAssertNil(mergedUploaded?.jobId ?? nil)
+    // ...and the WAL appended during the await is NOT dropped (the regression).
+    let mergedAppended = merged.first { $0.id == appended.id }
+    XCTAssertNotNil(mergedAppended, "WAL appended during reconcile must survive the merge")
+    XCTAssertEqual(mergedAppended?.status, .memory)
+  }
+
+  func testMergeDoesNotClobberConcurrentFieldUpdateOnUntouchedEntry() {
+    // Snapshot: two WALs, only one is being reconciled.
+    let reconciledWal = makeWal(timerStart: 1_700_000_000, status: .uploaded, jobId: "job-1")
+    let otherWal = makeWal(timerStart: 1_700_000_500, status: .uploaded, jobId: "job-2")
+    let snapshot = [reconciledWal, otherWal]
+
+    // Reconcile only changed the first WAL.
+    var reconciled = snapshot
+    reconciled[0].status = .synced
+    reconciled[0].jobId = nil
+
+    // Live array: the second WAL was concurrently transitioned by another path
+    // (e.g. its own job completed) — merge must not roll that back to the snapshot.
+    var liveOther = otherWal
+    liveOther.status = .synced
+    liveOther.jobId = nil
+    let live = [reconciledWal, liveOther]
+
+    let merged = WALCloudSyncLogic.mergeReconciledUploads(
+      live: live, snapshot: snapshot, reconciled: reconciled)
+
+    XCTAssertEqual(merged.first { $0.id == reconciledWal.id }?.status, .synced)
+    // The untouched entry keeps its concurrent update, not the stale snapshot value.
+    XCTAssertEqual(merged.first { $0.id == otherWal.id }?.status, .synced)
+    XCTAssertNil(merged.first { $0.id == otherWal.id }?.jobId ?? nil)
+  }
+
+  func testMergeIsNoOpWhenNothingReconciled() {
+    let a = makeWal(timerStart: 1_700_000_000, status: .uploaded, jobId: "job-1")
+    let snapshot = [a]
+    let reconciled = snapshot // unchanged
+    let live = [a]
+    let merged = WALCloudSyncLogic.mergeReconciledUploads(
+      live: live, snapshot: snapshot, reconciled: reconciled)
+    XCTAssertEqual(merged.count, 1)
+    XCTAssertEqual(merged[0].status, .uploaded)
+    XCTAssertEqual(merged[0].jobId, "job-1")
+  }
 }

--- a/desktop/macos/Desktop/Tests/WALCloudSyncLogicTests.swift
+++ b/desktop/macos/Desktop/Tests/WALCloudSyncLogicTests.swift
@@ -156,7 +156,7 @@ final class WALCloudSyncLogicTests: XCTestCase {
     reconciled[0].uploadedAt = 0
 
     // Meanwhile the live array gained a brand-new WAL (chunk timer fired during await).
-    let appended = makeWal(timerStart: 1_700_000_500, status: .memory)
+    let appended = makeWal(timerStart: 1_700_000_500, status: .inProgress)
     let live = [uploaded, appended]
 
     let merged = WALCloudSyncLogic.mergeReconciledUploads(
@@ -170,7 +170,7 @@ final class WALCloudSyncLogicTests: XCTestCase {
     // ...and the WAL appended during the await is NOT dropped (the regression).
     let mergedAppended = merged.first { $0.id == appended.id }
     XCTAssertNotNil(mergedAppended, "WAL appended during reconcile must survive the merge")
-    XCTAssertEqual(mergedAppended?.status, .memory)
+    XCTAssertEqual(mergedAppended?.status, .inProgress)
   }
 
   func testMergeDoesNotClobberConcurrentFieldUpdateOnUntouchedEntry() {

--- a/desktop/macos/changelog/unreleased/20260712-bee-audio-crash-guard.json
+++ b/desktop/macos/changelog/unreleased/20260712-bee-audio-crash-guard.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed a crash that could occur when a Bee device sent a corrupted audio frame"
+}

--- a/desktop/macos/changelog/unreleased/20260712-realtime-hub-timer-leak.json
+++ b/desktop/macos/changelog/unreleased/20260712-realtime-hub-timer-leak.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed a background timer leak that accumulated wakeups over time when the voice assistant hub reconnected, reducing battery drain"
+}

--- a/desktop/macos/changelog/unreleased/20260712-rewind-video-capture-restored.json
+++ b/desktop/macos/changelog/unreleased/20260712-rewind-video-capture-restored.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed Rewind capturing no video (every recorded chunk was discarded), restoring the Rewind timeline"
+}

--- a/desktop/macos/changelog/unreleased/20260712-system-audio-transcription-level.json
+++ b/desktop/macos/changelog/unreleased/20260712-system-audio-transcription-level.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed system audio being captured ~6 dB too quiet, improving transcription accuracy for meetings and calls"
+}

--- a/desktop/macos/changelog/unreleased/20260712-wal-sync-recording-dropped.json
+++ b/desktop/macos/changelog/unreleased/20260712-wal-sync-recording-dropped.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed a rare race where a recording started during a cloud sync could be dropped and never uploaded"
+}

--- a/desktop/macos/e2e/flows/audio-recording.yaml
+++ b/desktop/macos/e2e/flows/audio-recording.yaml
@@ -10,6 +10,7 @@ covers:
   - desktop/Desktop/Sources/AppState.swift
   - desktop/macos/Desktop/Sources/FloatingControlBar/FloatingBarUsageLimiter.swift
   - desktop/macos/Desktop/Sources/Bluetooth/Transports/BleTransport.swift
+  - desktop/macos/Desktop/Sources/Audio/AudioCodecDecoder.swift
   - desktop/macos/Desktop/Sources/Bluetooth/Connections/BeeDeviceConnection.swift
   - desktop/macos/Desktop/Sources/Bluetooth/Connections/PlaudDeviceConnection.swift
   - desktop/macos/Desktop/Sources/Bluetooth/Connections/LimitlessDeviceConnection.swift

--- a/desktop/macos/e2e/flows/ptt-lifecycle.yaml
+++ b/desktop/macos/e2e/flows/ptt-lifecycle.yaml
@@ -7,6 +7,7 @@ covers:
   - desktop/macos/Desktop/Sources/DefaultsKey.swift
   - desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
   - desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
+  - desktop/macos/Desktop/Sources/FloatingControlBar/RawWebSocket.swift
   - desktop/macos/Desktop/Sources/RealtimeOmni/RealtimeOmniService.swift
   - desktop/macos/Desktop/Sources/RealtimeOmni/RealtimeOmniTestHarness.swift
   - desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift


### PR DESCRIPTION
## Summary

Batch 6 of the macOS bug sweep — a second-pass hunt fanned six reviewers across subsystems not deeply swept before (audio pipeline, sync layer, auth/session, realtime voice-turn hub, Rewind capture, Rust backend + notifications). Each finding below was personally re-verified against the source before any code changed. This PR lands the five confirmed crash / data-loss / correctness / leak fixes, each with a pure, hermetic regression test where a testable seam exists.

All five are **live on `main`** today.

## Fixes

### 1. Rewind captured no video at all (CRITICAL regression)
`VideoChunkEncoder.writeFrame` derived the frame presentation timestamp as `max(0, frameOffsetInChunk - 1) / frameRate`. The `- 1` compensated for a pre-increment that the earlier desync fix (`02f0b41da`) moved to *after* `writeFrame`. Post-fix, frame 0 and frame 1 both resolve to PTS 0; `AVAssetWriterInputPixelBufferAdaptor.append` requires strictly increasing timestamps, so every chunk's second frame was rejected, five failures forced an emergency reset that discarded the in-progress `.mp4`, no chunk ever finalized, and the Rewind timeline stayed permanently empty. Fixed by mapping frame N → N / frameRate via a testable `framePresentationSeconds` seam.

### 2. Crash on malformed Bee ADTS audio frame
`AACAudioDecoder.decode` formed `data.subdata(in: 7..<frameLength)` with no guard that `frameLength > 7`. A corrupted BLE frame decoding to `frameLength <= 7` produced an invalid `Range` and terminated the process. Fixed with a slice-safe `adtsRawAACRange(in:)` parser that rejects malformed/incomplete frames.

### 3. System audio captured ~6 dB too quiet
The system-audio converter input format declared the source channel count (stereo) while the fill loop only writes a manually down-mixed channel 0. The converter then averaged the real mix against an unwritten channel 1, attenuating all transcription input ~6 dB. Fixed to declare mono, matching the microphone path.

### 4. Leaked keepalive timer on every hub reconnect
`RawWebSocket`'s server-close-frame path (opcode 0x8) never cancelled the 20s keepalive `DispatchSourceTimer`, unlike `close()`/`fail()`. Gemini idle-closes the warm hub socket (1008) ~every 2.5 min, so each re-warm orphaned a resumed timer that fired forever. Fixed to cancel in the 0x8 path plus a `deinit` backstop.

### 5. Recording started during sync could be dropped (data loss)
`syncToCloud` snapshotted `wals`, passed the copy to a reconciler that runs per-job network `await`s on the main actor, then reassigned the snapshot back wholesale. WALs appended by the chunk timer / SD / WiFi paths during the awaits were silently dropped and never uploaded. Fixed with a pure id-keyed `mergeReconciledUploads` that preserves appended WALs and only applies the fields reconcile owns.

## Root cause & durable guards

Each fix records its root cause and ships a durable guard:
- #1, #2, #3, #5 extract the buggy logic into pure, synchronously testable seams with regression tests that reproduce the exact failure (frame-0/1 PTS collision; `frameLength` 0–7 and non-zero-`startIndex` slices; mono channel contract; appended-WAL survival + no-clobber of concurrent updates).
- #4 is a socket + GCD-timer lifecycle fix with no hermetic seam (a live `NWConnection` receive loop is required to reach the 0x8 branch); it ships with the `deinit` backstop and no unit test, stated explicitly.

## Testing

- `python3 scripts/check_desktop_test_quality.py` — OK (no new source-inspection/wall-clock debt).
- `python3 scripts/check-sources-root-layout.py` — OK.
- `python3 scripts/check-e2e-flow-coverage.py --strict` — all 6 changed Swift files covered.
- No Swift toolchain in this environment; the new XCTest cases compile/run on macOS CI (`desktop-swift-ci.yml`). Opened as a **draft** so it can be built and verified locally before landing.

## Product invariants affected

- INV-CHAT-1 — path-based match only (`FloatingControlBar/RawWebSocket.swift`). The change cancels a leaked keepalive `DispatchSourceTimer` on the socket teardown path; it does not touch the chat write-path, kernel projection, floating viewport, or turn identity, so the invariant's behavior is unchanged and its guard tests are unaffected.

## Deferred (lower-severity findings from the same sweep, tracked for follow-up)

Confirmed-but-low or suspected findings not in this PR: `StorageSyncService.updateProgress` computes `elapsed == 0` (SD-card B/s always 0, display-only); `WALService` `totalFrames` double-count on repeated failed writes under the same WAL id; audio stop-path converter release ordering (suspected race); `NotificationService.notificationMetadata` unbounded growth for un-interacted banners; Rust `RedisService` never invalidates a broken cached connection (rate limiter fails open until restart); BYOK-vs-Firebase-session 401 conflation on the default request path (needs backend 401 semantics confirmation); `RealtimeOmniService.pendingAudio` uncapped while connecting; `RewindIndexer` rebuild frame over-count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RAxLsaxtwVNDTWAZFfJp9q

---
_Generated by [Claude Code](https://claude.ai/code/session_01RAxLsaxtwVNDTWAZFfJp9q)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9514?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

