### PR TITLE
Fix SD-card sync 0 B/s readout, notification-metadata leak, Redis fail-open + CI manifest drift (bug sweep #7)

### DIFF
--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -111,3 +111,5 @@ exempt:
     reason: "deployment concurrency policy full-tree check, not diff-scoped"
   - path: "backend/scripts/check_app_client_openapi_compatibility.py"
     reason: "OpenAPI generation contract has component dependencies"
+  - path: ".github/scripts/check_isinstance_return_ratchet.py"
+    reason: "backend memory isinstance-return ratchet; full-tree baseline check, not diff-scoped"

--- a/desktop/macos/Backend-Rust/src/services/redis.rs
+++ b/desktop/macos/Backend-Rust/src/services/redis.rs
@@ -1,6 +1,7 @@
 // Redis service for conversation visibility
 // Mirrors the Python backend's redis_db.py functionality for sharing conversations
 
+use redis::aio::ConnectionManager;
 use redis::{AsyncCommands, Client, ConnectionAddr, ConnectionInfo, RedisConnectionInfo};
 use std::sync::Arc;
 use tokio::sync::RwLock;
@@ -8,7 +9,11 @@ use tokio::sync::RwLock;
 /// Redis service for conversation visibility and sharing
 pub struct RedisService {
     client: Client,
-    connection: Arc<RwLock<Option<redis::aio::MultiplexedConnection>>>,
+    // ConnectionManager (not a bare MultiplexedConnection) so a dropped link
+    // reconnects internally. A cached MultiplexedConnection stayed broken forever
+    // once the Redis link dropped, so every later command errored — which made the
+    // rate limiter fail open (unmetered) permanently until process restart.
+    connection: Arc<RwLock<Option<ConnectionManager>>>,
 }
 
 /// Review data stored in Redis
@@ -49,9 +54,13 @@ impl RedisService {
         })
     }
 
-    /// Get or create a connection
-    async fn get_connection(&self) -> Result<redis::aio::MultiplexedConnection, redis::RedisError> {
-        // Check if we have a cached connection
+    /// Get or create a connection.
+    ///
+    /// Returns a clone of a shared `ConnectionManager`, which transparently
+    /// re-establishes the underlying link after a transient failure, so a dropped
+    /// Redis connection recovers on the next command instead of erroring forever.
+    async fn get_connection(&self) -> Result<ConnectionManager, redis::RedisError> {
+        // Check if we have a cached connection manager
         {
             let conn = self.connection.read().await;
             if let Some(c) = conn.as_ref() {
@@ -59,12 +68,15 @@ impl RedisService {
             }
         }
 
-        // Create new connection
-        let conn = self.client.get_multiplexed_async_connection().await?;
+        // Create a new connection manager
+        let conn = ConnectionManager::new(self.client.clone()).await?;
 
-        // Cache it
+        // Cache it (double-check under the write lock in case another task raced us)
         {
             let mut cached = self.connection.write().await;
+            if let Some(existing) = cached.as_ref() {
+                return Ok(existing.clone());
+            }
             *cached = Some(conn.clone());
         }
 

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/NotificationService.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/NotificationService.swift
@@ -96,6 +96,24 @@ class NotificationService: NSObject, UNUserNotificationCenterDelegate {
     /// Key: notification identifier, Value: (title, assistantId)
     private var notificationMetadata: [String: (title: String, assistantId: String)] = [:]
 
+    /// Insertion order of `notificationMetadata` keys, used to evict the oldest entries.
+    /// Metadata is only removed on user interaction (`didReceive`); a functional banner
+    /// the user never touches (ages out / is cleared without a dismiss action) would
+    /// otherwise leak its entry for the life of the process. Bounded FIFO eviction caps
+    /// the growth.
+    private var notificationMetadataOrder: [String] = []
+    private static let maxNotificationMetadata = 200
+
+    /// Evict oldest ids from `order`/`store` until `order.count <= max`.
+    /// `nonisolated static` + generic so the FIFO eviction policy is synchronously
+    /// unit-testable without hopping the main actor.
+    nonisolated static func evictOldestMetadata<V>(order: inout [String], store: inout [String: V], max: Int) {
+        guard order.count > max else { return }
+        let removeCount = order.count - max
+        for id in order.prefix(removeCount) { store.removeValue(forKey: id) }
+        order.removeFirst(removeCount)
+    }
+
     /// Last time we triggered a notification repair (debounce to avoid hammering lsregister)
     private var lastRepairAttempt: Date?
 
@@ -226,6 +244,7 @@ class NotificationService: NSObject, UNUserNotificationCenterDelegate {
 
             // Clean up metadata
             self.notificationMetadata.removeValue(forKey: notificationId)
+            self.notificationMetadataOrder.removeAll { $0 == notificationId }
         }
 
         completionHandler()
@@ -427,8 +446,15 @@ class NotificationService: NSObject, UNUserNotificationCenterDelegate {
             trigger: nil // Deliver immediately
         )
 
-        // Store metadata for later retrieval in delegate callbacks
+        // Store metadata for later retrieval in delegate callbacks, capping growth so
+        // never-interacted banners cannot leak entries unboundedly.
         notificationMetadata[notificationId] = (title: title, assistantId: assistantId)
+        notificationMetadataOrder.append(notificationId)
+        Self.evictOldestMetadata(
+            order: &notificationMetadataOrder,
+            store: &notificationMetadata,
+            max: Self.maxNotificationMetadata
+        )
 
         // Play custom sound manually (SPM resources aren't found by UNNotificationSound)
         sound.playCustomSound()
@@ -441,6 +467,7 @@ class NotificationService: NSObject, UNUserNotificationCenterDelegate {
                 // Clean up metadata on error
                 Task { @MainActor in
                     self?.notificationMetadata.removeValue(forKey: notificationId)
+                    self?.notificationMetadataOrder.removeAll { $0 == notificationId }
                 }
             } else {
                 print("Notification sent successfully")

--- a/desktop/macos/Desktop/Sources/WAL/StorageSyncService.swift
+++ b/desktop/macos/Desktop/Sources/WAL/StorageSyncService.swift
@@ -47,6 +47,7 @@ final class StorageSyncService: ObservableObject {
     private var downloadedFrames: [Data] = []
     private var totalBytesDownloaded = 0
     private var lastProgressUpdate = Date()
+    private var lastProgressBytes = 0
 
     // MARK: - Initialization
 
@@ -101,6 +102,8 @@ final class StorageSyncService: ObservableObject {
         errorMessage = nil
         downloadedFrames = []
         totalBytesDownloaded = 0
+        lastProgressUpdate = Date()
+        lastProgressBytes = 0
 
         // Create WAL for this sync
         currentWal = walService.createSdCardWal(
@@ -142,6 +145,7 @@ final class StorageSyncService: ObservableObject {
         currentWal = nil
         downloadedFrames = []
         totalBytesDownloaded = 0
+        lastProgressBytes = 0
 
         logger.info("Sync stopped")
     }
@@ -324,13 +328,25 @@ final class StorageSyncService: ObservableObject {
         }
     }
 
+    /// Throughput over an interval. `nonisolated static` so it is synchronously
+    /// unit-testable without hopping the main actor.
+    nonisolated static func bytesPerSecond(bytesDelta: Int, interval: TimeInterval) -> Double {
+        interval > 0 ? Double(bytesDelta) / interval : 0
+    }
+
     private func updateProgress() {
         let now = Date()
-        guard now.timeIntervalSince(lastProgressUpdate) >= 0.5 else { return }
-        lastProgressUpdate = now
+        let interval = now.timeIntervalSince(lastProgressUpdate)
+        guard interval >= 0.5 else { return }
 
-        let elapsed = now.timeIntervalSince(lastProgressUpdate)
-        let bytesPerSecond = elapsed > 0 ? Double(totalBytesDownloaded) / elapsed : 0
+        // Rate over the elapsed interval since the last update, using the bytes
+        // downloaded in that window. The previous code reassigned lastProgressUpdate
+        // to `now` before computing `elapsed = now - lastProgressUpdate`, so `elapsed`
+        // was always 0 and the reported speed was always 0 B/s.
+        let bytesDelta = totalBytesDownloaded - lastProgressBytes
+        let bytesPerSecond = Self.bytesPerSecond(bytesDelta: bytesDelta, interval: interval)
+        lastProgressUpdate = now
+        lastProgressBytes = totalBytesDownloaded
 
         Task { @MainActor in
             progress = SyncProgress(

--- a/desktop/macos/Desktop/Tests/NotificationMetadataEvictionTests.swift
+++ b/desktop/macos/Desktop/Tests/NotificationMetadataEvictionTests.swift
@@ -1,0 +1,52 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// Regression coverage for the notification-metadata FIFO cap.
+///
+/// `notificationMetadata` is only removed on user interaction (`didReceive`); a
+/// functional banner the user never touches leaks its entry for the life of the
+/// process. `evictOldestMetadata` bounds the growth by dropping the oldest ids once
+/// the tracked order exceeds the cap. These tests pin that policy.
+final class NotificationMetadataEvictionTests: XCTestCase {
+    func testEvictsOldestBeyondCap() {
+        var order: [String] = []
+        var store: [String: Int] = [:]
+        for i in 0..<250 {
+            let id = "n\(i)"
+            order.append(id)
+            store[id] = i
+        }
+        NotificationService.evictOldestMetadata(order: &order, store: &store, max: 200)
+
+        XCTAssertEqual(order.count, 200)
+        XCTAssertEqual(store.count, 200)
+        // Oldest 50 (n0...n49) evicted; newest retained.
+        XCTAssertNil(store["n0"])
+        XCTAssertNil(store["n49"])
+        XCTAssertEqual(store["n50"], 50)
+        XCTAssertEqual(store["n249"], 249)
+        XCTAssertEqual(order.first, "n50")
+        XCTAssertEqual(order.last, "n249")
+    }
+
+    func testNoEvictionUnderCap() {
+        var order = ["a", "b", "c"]
+        var store = ["a": 1, "b": 2, "c": 3]
+        NotificationService.evictOldestMetadata(order: &order, store: &store, max: 200)
+        XCTAssertEqual(order.count, 3)
+        XCTAssertEqual(store.count, 3)
+    }
+
+    func testEvictsExactlyToCap() {
+        var order: [String] = []
+        var store: [String: Int] = [:]
+        for i in 0..<10 {
+            order.append("n\(i)")
+            store["n\(i)"] = i
+        }
+        NotificationService.evictOldestMetadata(order: &order, store: &store, max: 3)
+        XCTAssertEqual(order, ["n7", "n8", "n9"])
+        XCTAssertEqual(Set(store.keys), Set(["n7", "n8", "n9"]))
+    }
+}

--- a/desktop/macos/Desktop/Tests/StorageSyncThroughputTests.swift
+++ b/desktop/macos/Desktop/Tests/StorageSyncThroughputTests.swift
@@ -1,0 +1,30 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// Regression coverage for SD-card sync throughput reporting.
+///
+/// `updateProgress` previously reassigned `lastProgressUpdate = now` *before* computing
+/// `elapsed = now - lastProgressUpdate`, so `elapsed` was always 0 and the reported
+/// speed was always 0 B/s. The rate math is now a pure function over an explicit
+/// (bytesDelta, interval); these tests pin that it produces a real, non-zero rate.
+final class StorageSyncThroughputTests: XCTestCase {
+    func testBytesPerSecondComputesRealRate() {
+        // 500 KB downloaded over a 0.5s interval → 1,000,000 B/s.
+        XCTAssertEqual(
+            StorageSyncService.bytesPerSecond(bytesDelta: 500_000, interval: 0.5),
+            1_000_000,
+            accuracy: 1e-6
+        )
+    }
+
+    func testBytesPerSecondIsNonZeroForNonZeroDelta() {
+        XCTAssertGreaterThan(
+            StorageSyncService.bytesPerSecond(bytesDelta: 1, interval: 0.5), 0)
+    }
+
+    func testBytesPerSecondGuardsZeroAndNegativeInterval() {
+        XCTAssertEqual(StorageSyncService.bytesPerSecond(bytesDelta: 100, interval: 0), 0)
+        XCTAssertEqual(StorageSyncService.bytesPerSecond(bytesDelta: 100, interval: -1), 0)
+    }
+}

--- a/desktop/macos/changelog/unreleased/20260712-sdcard-sync-speed-readout.json
+++ b/desktop/macos/changelog/unreleased/20260712-sdcard-sync-speed-readout.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed the SD-card sync screen always showing 0 B/s instead of the real download speed"
+}


### PR DESCRIPTION
## Summary

Batch 7 of the macOS bug sweep — clearing the confirmed low-severity deferrals surfaced by the batch-6 second-pass hunt, each personally re-verified against the source. Three fixes, each low-risk with a regression test where a hermetic seam exists.

This is likely the last substantive sweep PR: a fresh deep review of the previously-unswept surfaces (onboarding, settings, Sparkle/update, MCP OAuth, menu-bar/window lifecycle) turned up **no** confirmed user-affecting bugs, and the BYOK-vs-session-401 suspicion resolved to a **false alarm** (the Python backend returns 403, never 401, for BYOK failures) — so the findings are converging.

## Fixes

### 1. SD-card sync always showed 0 B/s
`StorageSyncService.updateProgress` reassigned `lastProgressUpdate = now` on the line *before* computing `elapsed = now - lastProgressUpdate`, so `elapsed` was always 0 and `bytesPerSecond` always 0 — the SD-card sync UI never showed a real speed/ETA. Now computes the rate over the real elapsed interval using the bytes downloaded in that window (via a pure `bytesPerSecond(bytesDelta:interval:)` seam), tracking `lastProgressBytes` and resetting it with the rest of the progress state at sync start/stop.

### 2. Notification metadata grew unbounded
`NotificationService.notificationMetadata` added one entry per delivered functional banner but only removed it in the `didReceive` delegate, which fires solely on user interaction. A banner the user never touches leaked its entry for the life of the process. Now tracks insertion order and FIFO-evicts past a 200-entry cap (pure generic `evictOldestMetadata`), with matching removal from the order list on the interaction/error paths.

### 3. Redis rate limiter failed open permanently after a link drop (Rust)
`RedisService` cached a bare `MultiplexedConnection` and returned that clone forever with no reconnect path. Once the Redis link dropped, every command errored, and the rate limiter (fail-open by design) stopped enforcing limits entirely until restart. Now caches a `ConnectionManager` (the `connection-manager` feature was already enabled), which transparently reconnects after a transient failure. Command call sites unchanged.

## Root cause & durable guards

- #1 read-after-write ordering on the interval timestamp → pure testable rate function + regression tests (real-rate / non-zero / zero-and-negative interval).
- #2 a side-table whose only removal path depended on optional user action → bounded FIFO eviction + regression tests (evict-beyond-cap / no-eviction-under-cap / exact-to-cap).
- #3 a permanently-cached connection with no invalidation → `ConnectionManager` auto-reconnect. No hermetic seam for live reconnection without a Redis server, so no unit test; verified with `cargo build` + `cargo test` (328 passed).

## Testing

- `cargo test` (Backend-Rust) — 328 passed, 0 failed.
- `python3 scripts/check_desktop_test_quality.py` — OK (debt decreased).
- `python3 scripts/check-sources-root-layout.py` — OK.
- `python3 scripts/check-e2e-flow-coverage.py --strict` — both changed Swift files covered.
- `scripts/pr-preflight` — 13 checks pass.
- No Swift toolchain in this environment; the new XCTest cases compile/run on macOS CI (`desktop-swift-ci.yml`). Opened as a **draft** for local verification before landing.

## Product invariants affected

- none (no locked-invariant path globs touched).

## Deferred / tracked (not fixed here)

- **BYOK→session-401 contract hardening (latent, not an active bug).** The WAL upload attaches BYOK keys under the session-invalidating `.default` policy, which violates the documented `AGENTS.md` "Session 401 vs BYOK/provider 401" contract. It is currently unreachable (the backend returns 403, never 401, for BYOK failures), so it is *not* an active bug. The contract-aligned fix (route the upload through `.providerCredentialBoundary`, mirroring `synthesizeSpeech`) changes real session-invalidation behavior and was deliberately kept out of this low-risk PR — tracked as defense-in-depth for a focused follow-up.
- Remaining low/suspected batch-6 findings: `WALService.totalFrames` double-count on repeated failed writes; audio stop-path converter release ordering; `RealtimeOmniService.pendingAudio` uncap; `RewindIndexer` rebuild over-count; deferred-update install overwrite edge case.

## Also included: pre-existing CI unblock

A separate commit registers `check_isinstance_return_ratchet.py` in `.github/checks-manifest.yaml`. That script is run by `repo-checks.yml` but was never added to the manifest when #9458 unified checks, so the manifest drift-guard fails on `main` and blocks every PR's `pr-preflight`/Hygiene. Pre-existing breakage, not caused by the batch-7 fixes; added here to unblock this (and every) PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RAxLsaxtwVNDTWAZFfJp9q

---
_Generated by [Claude Code](https://claude.ai/code/session_01RAxLsaxtwVNDTWAZFfJp9q)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9522?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

