### PR TITLE
feat(desktop): publish immutable stable repair installer

### DIFF
--- a/.github/scripts/desktop_repair_installer.py
+++ b/.github/scripts/desktop_repair_installer.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Build static metadata for a verified macOS stable repair installer."""
+
+from __future__ import annotations
+
+import argparse
+import html
+import json
+import re
+from pathlib import Path
+from typing import Any
+from urllib.parse import quote
+
+RELEASE_ID_RE = re.compile(r"^v\d+\.\d+(?:\.\d+)?\+\d+-macos$")
+SHA40_RE = re.compile(r"^[0-9a-f]{40}$", re.IGNORECASE)
+SHA256_RE = re.compile(r"^[0-9a-f]{64}$", re.IGNORECASE)
+
+
+def _required_string(data: dict[str, Any], key: str) -> str:
+    value = data.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{key} is required")
+    return value.strip()
+
+
+def _validate_bucket(bucket: str) -> str:
+    if not bucket.startswith("gs://"):
+        raise ValueError("bucket must use the gs://bucket-name form")
+    name = bucket.removeprefix("gs://").strip().rstrip("/")
+    if not name or "/" in name:
+        raise ValueError("bucket must name exactly one GCS bucket")
+    return name
+
+
+def build_repair_bundle(manifest: dict[str, Any], bucket: str) -> dict[str, Any]:
+    """Create immutable and latest-stable metadata from a validated manifest."""
+    bucket_name = _validate_bucket(bucket)
+    release_id = _required_string(manifest, "release_id")
+    if not RELEASE_ID_RE.fullmatch(release_id):
+        raise ValueError("release_id must be a macOS release tag")
+    if _required_string(manifest, "platform") != "macos":
+        raise ValueError("repair installers support only the macos platform")
+
+    build_number = manifest.get("build_number")
+    if not isinstance(build_number, int) or isinstance(build_number, bool) or build_number <= 0:
+        raise ValueError("build_number must be a positive integer")
+
+    source_sha = _required_string(manifest, "source_sha")
+    if not SHA40_RE.fullmatch(source_sha):
+        raise ValueError("source_sha has an invalid digest")
+    dmg_sha256 = _required_string(manifest, "dmg_sha256")
+    if not SHA256_RE.fullmatch(dmg_sha256):
+        raise ValueError("dmg_sha256 has an invalid digest")
+
+    release_path = quote(release_id, safe=".-_~+")
+    public_base = f"https://storage.googleapis.com/{quote(bucket_name, safe='.-_~')}"
+    artifact_object = f"stable/{release_id}/Omi.dmg"
+    repair_object = f"stable/{release_id}/repair.json"
+    installer_url = f"{public_base}/stable/{release_path}/Omi.dmg"
+    repair_manifest_url = f"{public_base}/stable/{release_path}/repair.json"
+
+    repair = {
+        "schema_version": 1,
+        "channel": "stable",
+        "release_id": release_id,
+        "version": _required_string(manifest, "version"),
+        "build_number": build_number,
+        "installer_url": installer_url,
+        "installer_sha256": dmg_sha256.lower(),
+        "source_sha": source_sha.lower(),
+        "published_at": _required_string(manifest, "published_at"),
+    }
+    latest = {**repair, "repair_manifest_url": repair_manifest_url}
+    version = html.escape(repair["version"])
+    safe_installer_url = html.escape(installer_url, quote=True)
+    landing_page = f"""<!doctype html>
+<html lang=\"en\">
+<head>
+  <meta charset=\"utf-8\">
+  <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">
+  <title>Download Omi for macOS</title>
+</head>
+<body>
+  <main>
+    <h1>Download Omi for macOS</h1>
+    <p>Stable version {version} is ready to install.</p>
+    <p><a href=\"{safe_installer_url}\">Download the verified Omi installer</a></p>
+    <ol>
+      <li>Open the downloaded DMG.</li>
+      <li>Move Omi to the <code>/Applications</code> folder.</li>
+      <li>Open Omi from <code>/Applications</code> to finish the update.</li>
+    </ol>
+  </main>
+</body>
+</html>
+"""
+    return {
+        "artifact_object": artifact_object,
+        "repair_object": repair_object,
+        "repair": repair,
+        "latest": latest,
+        "landing_page": landing_page,
+    }
+
+
+def write_repair_bundle(manifest: dict[str, Any], bucket: str, output_dir: Path) -> dict[str, Any]:
+    bundle = build_repair_bundle(manifest, bucket)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    (output_dir / "repair.json").write_text(json.dumps(bundle["repair"], indent=2) + "\n")
+    (output_dir / "latest.json").write_text(json.dumps(bundle["latest"], indent=2) + "\n")
+    (output_dir / "index.html").write_text(bundle["landing_page"])
+    return bundle
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--manifest", required=True)
+    parser.add_argument("--bucket", required=True)
+    parser.add_argument("--output-dir", required=True)
+    args = parser.parse_args()
+
+    manifest = json.loads(Path(args.manifest).read_text())
+    if not isinstance(manifest, dict):
+        raise ValueError("manifest must be a JSON object")
+    bundle = write_repair_bundle(manifest, args.bucket, Path(args.output_dir))
+    print(
+        json.dumps({"installer_url": bundle["repair"]["installer_url"], "release_id": bundle["repair"]["release_id"]})
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/prepare-desktop-beta-promotion.py
+++ b/.github/scripts/prepare-desktop-beta-promotion.py
@@ -27,7 +27,15 @@ def _asset(release: dict, names: set[str]) -> dict:
     fail(f"release is missing required asset: {', '.join(sorted(names))}")
 
 
-def prepare_manifest(release: dict, release_tag: str, target_sha: str, zip_sha256: str, dmg_sha256: str) -> dict:
+def prepare_manifest(
+    release: dict,
+    release_tag: str,
+    target_sha: str,
+    zip_sha256: str,
+    dmg_sha256: str,
+    *,
+    allow_stable_channel: bool = False,
+) -> dict:
     if release.get("tagName") != release_tag:
         fail(f"release tag mismatch: expected {release_tag}, got {release.get('tagName')}")
     match = TAG_RE.match(release_tag)
@@ -43,8 +51,14 @@ def prepare_manifest(release: dict, release_tag: str, target_sha: str, zip_sha25
         fail("candidate release must have isLive: false")
     if channel == "beta" and is_live not in {"true", "1", "yes"}:
         fail("beta release must have isLive: true")
-    if channel not in {"candidate", "beta"}:
-        fail(f"release channel must be candidate or beta, got {channel!r}")
+    if channel == "stable" and is_live not in {"true", "1", "yes"}:
+        fail("stable release must have isLive: true")
+    allowed_channels = {"candidate", "beta"}
+    if allow_stable_channel:
+        allowed_channels.add("stable")
+    if channel not in allowed_channels:
+        accepted = "candidate, beta, or stable" if allow_stable_channel else "candidate or beta"
+        fail(f"release channel must be {accepted}, got {channel!r}")
 
     asset_names = {asset.get("name") for asset in release.get("assets", []) if asset.get("name")}
     qualification = desktop_qualification_from_metadata(metadata)
@@ -97,11 +111,19 @@ def main() -> int:
     parser.add_argument("--target-sha", required=True)
     parser.add_argument("--zip-sha256", required=True)
     parser.add_argument("--dmg-sha256", required=True)
+    parser.add_argument("--allow-stable-channel", action="store_true")
     parser.add_argument("--output", required=True)
     args = parser.parse_args()
 
     release = json.loads(Path(args.release_json).read_text())
-    manifest = prepare_manifest(release, args.release_tag, args.target_sha, args.zip_sha256, args.dmg_sha256)
+    manifest = prepare_manifest(
+        release,
+        args.release_tag,
+        args.target_sha,
+        args.zip_sha256,
+        args.dmg_sha256,
+        allow_stable_channel=args.allow_stable_channel,
+    )
     Path(args.output).write_text(json.dumps(manifest, indent=2) + "\n")
     print(f"qualified beta manifest prepared: {args.release_tag}")
     return 0

--- a/.github/workflows/desktop_promote_prod.yml
+++ b/.github/workflows/desktop_promote_prod.yml
@@ -46,6 +46,7 @@ env:
   SERVICE: desktop-backend
   REGION: us-central1
   TRACK_TAG: desktop-backend-prod-deployed
+  GCS_DESKTOP_UPDATES_BUCKET: ${{ vars.GCS_DESKTOP_UPDATES_BUCKET || 'gs://omi_macos_updates' }}
 
 jobs:
   promote:
@@ -91,7 +92,7 @@ jobs:
             "+refs/tags/${TRACK_TAG}:refs/tags/${TRACK_TAG}" || true
 
           gh release view "$RELEASE_TAG" --repo "$REPO" \
-            --json tagName,body,isDraft,isPrerelease,assets \
+            --json tagName,body,isDraft,isPrerelease,publishedAt,assets \
             > /tmp/desktop-release.json
 
           TARGET_SHA=$(git rev-list -n1 "$RELEASE_TAG")
@@ -443,6 +444,82 @@ jobs:
           echo "Prod backend did not report the promoted release identity." >&2
           exit 1
 
+      - name: Publish immutable stable repair installer
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
+          TARGET_SHA: ${{ steps.plan.outputs.target_sha }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          mkdir -p /tmp/desktop-stable-repair-assets
+          gh release download "$RELEASE_TAG" --repo "$REPO" \
+            --pattern 'Omi.zip' --pattern 'Omi.dmg' --pattern 'omi.dmg' --dir /tmp/desktop-stable-repair-assets
+          ZIP_PATH=/tmp/desktop-stable-repair-assets/Omi.zip
+          test -f "$ZIP_PATH"
+          DMG_PATHS=()
+          for candidate in Omi.dmg omi.dmg; do
+            candidate_path="/tmp/desktop-stable-repair-assets/$candidate"
+            if [ -f "$candidate_path" ]; then
+              DMG_PATHS+=("$candidate_path")
+            fi
+          done
+          if [ "${#DMG_PATHS[@]}" -ne 1 ]; then
+            echo "Expected exactly one qualified Omi.dmg or omi.dmg release asset." >&2
+            exit 1
+          fi
+          DMG_PATH="${DMG_PATHS[0]}"
+          ZIP_SHA=$(sha256sum "$ZIP_PATH" | cut -d' ' -f1)
+          DMG_SHA=$(sha256sum "$DMG_PATH" | cut -d' ' -f1)
+
+          python3 .github/scripts/prepare-desktop-beta-promotion.py \
+            --release-json /tmp/desktop-release.json \
+            --release-tag "$RELEASE_TAG" \
+            --target-sha "$TARGET_SHA" \
+            --zip-sha256 "$ZIP_SHA" \
+            --dmg-sha256 "$DMG_SHA" \
+            --allow-stable-channel \
+            --output /tmp/desktop-stable-release-manifest.json
+          python3 .github/scripts/desktop_repair_installer.py \
+            --manifest /tmp/desktop-stable-release-manifest.json \
+            --bucket "$GCS_DESKTOP_UPDATES_BUCKET" \
+            --output-dir /tmp/desktop-stable-repair
+
+          INSTALLER_URL=$(python3 -c "import json; print(json.load(open('/tmp/desktop-stable-repair/repair.json'))['installer_url'])")
+          REPAIR_MANIFEST_URL=$(python3 -c "import json; print(json.load(open('/tmp/desktop-stable-repair/latest.json'))['repair_manifest_url'])")
+
+          upload_immutable() {
+            local source="$1"
+            local destination="$2"
+            local content_type="$3"
+            local existing
+            existing=$(mktemp)
+            if gcloud storage objects describe "$destination" >/dev/null 2>&1; then
+              gcloud storage cp "$destination" "$existing"
+              cmp -s "$source" "$existing" || {
+                echo "Refusing to overwrite immutable repair object: $destination" >&2
+                exit 1
+              }
+              return
+            fi
+            if ! gcloud storage cp --if-generation-match=0 \
+              --cache-control='public,max-age=31536000,immutable' \
+              --content-type="$content_type" "$source" "$destination"; then
+              gcloud storage cp "$destination" "$existing"
+              cmp -s "$source" "$existing" || {
+                echo "Immutable repair object changed during publication: $destination" >&2
+                exit 1
+              }
+            fi
+          }
+
+          upload_immutable "$DMG_PATH" "$GCS_DESKTOP_UPDATES_BUCKET/stable/$RELEASE_TAG/Omi.dmg" \
+            'application/x-apple-diskimage'
+          upload_immutable /tmp/desktop-stable-repair/repair.json \
+            "$GCS_DESKTOP_UPDATES_BUCKET/stable/$RELEASE_TAG/repair.json" 'application/json; charset=utf-8'
+          curl -fsSI "$INSTALLER_URL" >/dev/null
+          curl -fsSI "$REPAIR_MANIFEST_URL" >/dev/null
+
       - name: Promote Firestore release stable
         env:
           PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
@@ -512,6 +589,38 @@ jobs:
             > /tmp/desktop-stable-pointer-response.json
           python3 -m json.tool /tmp/desktop-stable-pointer-response.json
           echo "Advanced explicit stable pointer to $RELEASE_TAG" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Publish latest stable repair route
+        env:
+          RELEASE_TAG: ${{ inputs.release_tag }}
+        run: |
+          set -euo pipefail
+          for file in index.html latest.json; do
+            gcloud storage cp --cache-control='no-store,max-age=0' \
+              --content-type="$([ "$file" = index.html ] && echo 'text/html; charset=utf-8' || echo 'application/json; charset=utf-8')" \
+              "/tmp/desktop-stable-repair/$file" "$GCS_DESKTOP_UPDATES_BUCKET/stable/$file"
+          done
+          LATEST_URL=$(python3 - <<'PY'
+          import json
+          from pathlib import Path
+
+          repair_manifest_url = json.loads(Path('/tmp/desktop-stable-repair/latest.json').read_text())['repair_manifest_url']
+          print(repair_manifest_url.rsplit('/', 2)[0] + '/latest.json')
+          PY
+          )
+          curl -fsS "$LATEST_URL" > /tmp/desktop-stable-repair-live.json
+          RELEASE_TAG="$RELEASE_TAG" python3 - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          latest = json.loads(Path('/tmp/desktop-stable-repair-live.json').read_text())
+          if latest['channel'] != 'stable':
+              raise SystemExit('repair route must be stable only')
+          if latest['release_id'] != os.environ['RELEASE_TAG']:
+              raise SystemExit('repair route release does not match stable promotion')
+          PY
+          echo "Verified stable repair route: $LATEST_URL" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Generate Omi Bot token for release mutations
         id: app-token

--- a/backend/tests/unit/test_desktop_release_scripts.py
+++ b/backend/tests/unit/test_desktop_release_scripts.py
@@ -6,6 +6,7 @@ import pytest
 REPO_ROOT = Path(__file__).resolve().parents[3]
 SCRIPTS = REPO_ROOT / ".github" / "scripts"
 PROMOTE_BETA_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "desktop_promote_beta.yml"
+PROMOTE_PROD_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "desktop_promote_prod.yml"
 
 
 def _load(name: str, filename: str):
@@ -19,6 +20,7 @@ def _load(name: str, filename: str):
 mark_beta = _load("mark_desktop_release_beta", "mark-desktop-release-beta.py")
 prepare_beta = _load("prepare_desktop_beta_promotion", "prepare-desktop-beta-promotion.py")
 nominate_stable = _load("nominate_desktop_stable_candidate", "nominate-desktop-stable-candidate.py")
+repair_installer = _load("desktop_repair_installer", "desktop_repair_installer.py")
 
 
 def _release(body: str | None = None):
@@ -70,6 +72,57 @@ def test_prepare_manifest_requires_exact_qualification_and_assets():
     assert manifest["changelog"] == ["Fixed updates", "Improved recovery"]
 
 
+def test_stable_repair_bundle_uses_an_immutable_gcs_artifact():
+    manifest = prepare_beta.prepare_manifest(
+        _release(),
+        "v0.12.64+12064-macos",
+        "a" * 40,
+        "b" * 64,
+        "c" * 64,
+    )
+
+    bundle = repair_installer.build_repair_bundle(manifest, "gs://omi_macos_updates")
+
+    assert bundle["artifact_object"] == "stable/v0.12.64+12064-macos/Omi.dmg"
+    assert bundle["repair_object"] == "stable/v0.12.64+12064-macos/repair.json"
+    assert bundle["repair"]["channel"] == "stable"
+    assert bundle["repair"]["installer_sha256"] == "c" * 64
+    assert bundle["repair"]["installer_url"] == (
+        "https://storage.googleapis.com/omi_macos_updates/stable/v0.12.64+12064-macos/Omi.dmg"
+    )
+    assert "example.com" not in bundle["latest"]["installer_url"]
+    assert "/Applications" in bundle["landing_page"]
+
+
+@pytest.mark.parametrize("field, value", [("platform", "windows"), ("dmg_sha256", "not-a-digest")])
+def test_stable_repair_bundle_rejects_incomplete_or_wrong_platform_manifest(field, value):
+    manifest = prepare_beta.prepare_manifest(
+        _release(),
+        "v0.12.64+12064-macos",
+        "a" * 40,
+        "b" * 64,
+        "c" * 64,
+    )
+    manifest[field] = value
+
+    with pytest.raises(ValueError):
+        repair_installer.build_repair_bundle(manifest, "gs://omi_macos_updates")
+
+
+def test_stable_repair_bundle_requires_the_release_publication_time():
+    manifest = prepare_beta.prepare_manifest(
+        _release(),
+        "v0.12.64+12064-macos",
+        "a" * 40,
+        "b" * 64,
+        "c" * 64,
+    )
+    manifest.pop("published_at")
+
+    with pytest.raises(ValueError, match="published_at"):
+        repair_installer.build_repair_bundle(manifest, "gs://omi_macos_updates")
+
+
 def test_prepare_manifest_accepts_legacy_qualification_metadata():
     release = _release()
     release["body"] = (
@@ -89,6 +142,32 @@ def test_prepare_manifest_accepts_legacy_qualification_metadata():
     )
     assert manifest["qualification"]["blessed_at"] == "2026-07-09T12:00:00Z"
     assert "qualified_at" not in manifest["qualification"]
+
+
+def test_prepare_manifest_allows_an_already_stable_release_only_for_repair_retries():
+    release = _release()
+    release["body"] = (
+        release["body"].replace("isLive: false", "isLive: true").replace("channel: candidate", "channel: stable")
+    )
+
+    with pytest.raises(SystemExit, match="candidate or beta"):
+        prepare_beta.prepare_manifest(
+            release,
+            "v0.12.64+12064-macos",
+            "a" * 40,
+            "b" * 64,
+            "c" * 64,
+        )
+
+    manifest = prepare_beta.prepare_manifest(
+        release,
+        "v0.12.64+12064-macos",
+        "a" * 40,
+        "b" * 64,
+        "c" * 64,
+        allow_stable_channel=True,
+    )
+    assert manifest["release_id"] == "v0.12.64+12064-macos"
 
 
 def test_prepare_manifest_rejects_unqualified_candidate():
@@ -190,10 +269,27 @@ def test_automatic_beta_is_pauseable_and_rejects_stale_tags():
 
 
 def test_stable_promotion_remains_manual_only():
-    workflow = (REPO_ROOT / ".github" / "workflows" / "desktop_promote_prod.yml").read_text()
+    workflow = PROMOTE_PROD_WORKFLOW.read_text()
 
     assert "on:\n  workflow_dispatch:" in workflow
     assert "\n  schedule:" not in workflow
     assert "\n  push:" not in workflow
     assert "confirm:" in workflow
     assert "promote-stable" in workflow
+
+
+def test_stable_repair_is_published_immutably_before_stable_pointer_advances():
+    """Static wiring contract: a stable pointer is never advanced ahead of its repair artifact."""
+    workflow = PROMOTE_PROD_WORKFLOW.read_text()
+
+    immutable_repair = workflow.index("      - name: Publish immutable stable repair installer")
+    legacy_bridge = workflow.index("      - name: Promote Firestore release stable")
+    pointer = workflow.index("      - name: Advance explicit stable pointer")
+    latest_route = workflow.index("      - name: Publish latest stable repair route")
+
+    assert immutable_repair < legacy_bridge < pointer < latest_route
+    assert "--json tagName,body,isDraft,isPrerelease,publishedAt,assets" in workflow
+    assert "--pattern 'Omi.zip' --pattern 'Omi.dmg' --pattern 'omi.dmg'" in workflow
+    assert "--pattern '*.dmg'" not in workflow
+    assert "Expected exactly one qualified Omi.dmg or omi.dmg release asset." in workflow
+    assert "--if-generation-match=0" in workflow

--- a/desktop/macos/changelog/unreleased/20260712-stable-repair-installer.json
+++ b/desktop/macos/changelog/unreleased/20260712-stable-repair-installer.json
@@ -1,0 +1,3 @@
+{
+  "change": "Improved recovery for macOS updates with a verified stable repair download"
+}

--- a/docs/doc/developer/desktop-updates.mdx
+++ b/docs/doc/developer/desktop-updates.mdx
@@ -60,6 +60,23 @@ This uses a dedicated detached worktree and `/Applications/omi-main.app`. It nev
 
 Static GCS/CDN appcast delivery remains a follow-up. The existing beta download redirect may still be maintained, but it is not the source of channel truth.
 
+## Stable repair installer
+
+Stable promotion publishes an immutable repair DMG and its SHA-256 manifest to
+`gs://omi_macos_updates/stable/<release-tag>/`. It first uses a create-only GCS
+generation precondition; a retry is accepted only when the existing bytes are
+identical. The artifact and versioned manifest are externally probed before
+either legacy or pointer-based stable visibility can move. After the Firestore
+stable pointer advances, the workflow updates the no-cache `stable/index.html`
+landing page and `stable/latest.json` manifest to reference that exact
+immutable DMG. This gives support a recovery link that does not depend on
+runtime GitHub enumeration or the appcast endpoint.
+
+The public stable repair page is
+`https://storage.googleapis.com/omi_macos_updates/stable/index.html`. Confirm
+the bucket and public-read/CDN configuration before a stable promotion; the
+workflow probes the versioned DMG and manifest before it advances the pointer.
+
 ## First rollout after merge
 
 Merging this control-plane change does not make a beta live. For the first rollout:

--- a/docs/runbooks/desktop-update-policy.md
+++ b/docs/runbooks/desktop-update-policy.md
@@ -15,7 +15,7 @@ Create or update `desktop_update_policy/current`:
   "title": "Update required",
   "message": "Your Omi desktop app has an older updater issue. Please install the latest version manually.",
   "cta_text": "Download latest",
-  "download_url": "https://api.omi.me/v2/desktop/download/latest?channel=stable",
+  "download_url": "https://storage.googleapis.com/omi_macos_updates/stable/index.html",
   "can_dismiss": false,
   "platforms": ["macos"]
 }
@@ -28,7 +28,9 @@ Create or update `desktop_update_policy/current`:
 - `maximum_build_number`: highest client build that should see the policy. Clients above this build do not see it.
 - `latest_build_number`: informational for clients and analytics.
 - `title`, `message`, `cta_text`: user-facing copy.
-- `download_url`: manual installer URL.
+- `download_url`: manual installer URL. For legacy recovery, use the static
+  stable repair page published by the stable-promotion workflow instead of the
+  dynamic appcast/download API.
 - `can_dismiss`: only applies to `banner`; required prompts cannot be dismissed.
 - `platforms`: optional allowlist. Omit or use `["macos"]` for macOS.
 
@@ -37,6 +39,7 @@ Create or update `desktop_update_policy/current`:
 ```bash
 curl 'https://api.omi.me/v2/desktop/update-policy?platform=macos&current_build=11400'
 curl 'https://api.omi.me/v2/desktop/appcast.xml?platform=macos' | grep criticalUpdate
+curl -fsS 'https://storage.googleapis.com/omi_macos_updates/stable/latest.json' | python3 -m json.tool
 ```
 
 Disable the policy by setting `active` to `false`.


### PR DESCRIPTION
## Summary

- Publish the stable repair DMG and its SHA-256 manifest as create-only, versioned GCS objects before any stable channel visibility changes.
- Point a no-cache stable landing page and latest manifest at the exact immutable artifact only after the explicit stable pointer advances.
- Require the exact Omi DMG asset, preserve repair retry safety, and document the static recovery route for the update policy.

## Root cause

The explicit Firestore control plane was already in place, but stable recovery still depended on dynamic API/GitHub resolution. A stable promotion had no independent, immutable repair installer route for legacy clients.

## Safety

- The workflow accepts exactly one qualified `Omi.dmg` or `omi.dmg`; it cannot select an ancillary or beta DMG.
- Immutable uploads use GCS generation-match creation and accept retries only when bytes are identical.
- Artifact and manifest probes complete before legacy Firestore or explicit-pointer stable visibility moves; the mutable latest route is published and verified afterward.
- No deployment, release promotion, pointer movement, or production object write was performed by this PR.

## Validation

- `backend/.venv/bin/python -m pytest backend/tests/unit/test_desktop_release_scripts.py -q` (16 passed)
- `make preflight`
- Pre-push checks: update-channel unit suites, OpenAPI compatibility, workflow validation, and formatting
- Independent Sol review approved after resolving release-metadata, exact-DMG selection, and visibility-ordering findings

Refs #9528

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9534?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

