### PR TITLE
feat(nllb-translation): add internal LB ingress and standardize *.omi.me domains

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,6 +159,7 @@ backend (main.py)
   ├── ──────► vad (modal/)
   ├── ──────► deepgram (self-hosted or cloud)
   ├── ──────► parakeet (parakeet/)
+  ├── ──────► nllb-translation (nllb_translation/)
   └── ──────► llm-gateway (llm_gateway/main.py)
 
 pusher
@@ -179,9 +180,9 @@ memory-maintenance-job (modal/memory_maintenance_job.py)  [cron]
 agent-vm-reaper (backend/charts/agent-vm-reaper)  [cron]
 ```
 
-Helm charts: `backend/charts/{agent-proxy,agent-vm-reaper,backend-listen,backend-secrets,deepgram-self-hosted,diarizer,llm-gateway,monitoring,parakeet,pusher,vad}/`
+Helm charts: `backend/charts/{agent-proxy,agent-vm-reaper,backend-listen,backend-secrets,deepgram-self-hosted,diarizer,llm-gateway,monitoring,nllb-translation,parakeet,pusher,vad}/`
 
-- **backend** (`main.py`) — REST API. Streams audio to pusher via WebSocket (`utils/pusher.py`). Calls diarizer for speaker embeddings (`utils/stt/speaker_embedding.py`). Calls vad for voice activity detection and speaker identification (`utils/stt/vad.py`, `utils/stt/speech_profile.py`). Calls deepgram or parakeet for STT (`HOSTED_PARAKEET_API_URL`, `utils/stt/streaming.py`).
+- **backend** (`main.py`) — REST API. Streams audio to pusher via WebSocket (`utils/pusher.py`). Calls diarizer for speaker embeddings (`utils/stt/speaker_embedding.py`). Calls vad for voice activity detection and speaker identification (`utils/stt/vad.py`, `utils/stt/speech_profile.py`). Calls deepgram or parakeet for STT (`HOSTED_PARAKEET_API_URL`, `utils/stt/streaming.py`). Calls NLLB translation when `HOSTED_TRANSLATION_API_URL` is set and NLLB is selected (`utils/translation.py`).
 - **hosted MCP OAuth** (`routers/mcp_sse.py`) — Provider-neutral OAuth for `/v1/mcp/sse`. Configure public or confidential clients with `MCP_OAUTH_CLIENTS_JSON`; allowlist the exact connector callback URI from the provider. The temporary `MCP_OAUTH_CHATGPT_*` envs still define the legacy confidential ChatGPT test client, and `MCP_OAUTH_PUBLIC_*` can expose a no-secret PKCE public client. Also set `MCP_AUTHORIZATION_SERVER_URL`, optional `MCP_RESOURCE_URL`, and token TTL env vars.
 - **llm-gateway** (`llm_gateway/main.py`) — Internal FastAPI service for Omi-managed LLM auto lanes. Called by backend with service auth for `omi:auto:*` chat-completions routes; not exposed to clients.
 - **pusher** (`pusher/main.py`) — Receives audio via binary WebSocket protocol. Calls diarizer and deepgram for speaker sample extraction (`utils/speaker_identification.py` → `utils/speaker_sample.py`).
@@ -190,6 +191,7 @@ Helm charts: `backend/charts/{agent-proxy,agent-vm-reaper,backend-listen,backend
 - **vad** (`modal/main.py`) — GPU. `/v1/vad` and `/v1/speaker-identification`. Called by backend only.
 - **deepgram** — STT. Streaming uses self-hosted (`DEEPGRAM_SELF_HOSTED_URL`) or cloud based on `DEEPGRAM_SELF_HOSTED_ENABLED`. Pre-recorded always uses Deepgram cloud. Called by backend and pusher.
 - **parakeet** (`parakeet/`) — GPU STT service for streaming and pre-recorded transcription. Called by backend when `HOSTED_PARAKEET_API_URL` is set and parakeet is selected.
+- **nllb-translation** (`nllb_translation/`) — GPU translation service. Called by backend when `HOSTED_TRANSLATION_API_URL` is set and NLLB is selected.
 - **backend-sync** (`main.py`, same image as backend) — Cloud Run admission service for `/v2/sync-local-files`. The server classifies whole batches: recordings no more than six hours old enter `sync-jobs` (fresh), while older or untrusted batches enter `sync-backfill` and the scale-to-zero **backend-sync-backfill** worker. Fresh keeps its bounded inline fallback; backfill never falls into fresh/inline capacity. Backfill defaults to one in-flight job per UID, four processed speech hours per UID/day, 555 processed speech hours globally/day, a 30-day lookback, and four queue workers. Live fair-use reads only `realtime + sync_fresh`; `sync_backfill` is separately metered. A 45-day Firestore content ledger protects transcription and usage side effects across job expiry and re-upload. Audio playback merges (`/v1/sync/audio/*`) follow the same pattern via queue `audio-merge` building 30-day MP3 artifacts under `playback/` (`AUDIO_MERGE_DISPATCH_MODE`) — per-part files plus one dense per-conversation `conversation.mp3` whose spans manifest + audio_files fingerprint are stamped on the conversation doc (`conversation_audio`); a fingerprint mismatch after late chunks re-enqueues the build. Account deletion uses `ACCOUNT_DELETION_DISPATCH_MODE=cloud_tasks` to enqueue durable wipes to queue `account-deletion`, which posts `/v1/users/account-deletion-wipes/run`; API success is returned only after the deletion marker is persisted and the wipe task is durably enqueued.
 - **notifications-job** (`modal/job.py`) — Cron job, reads Firestore/Redis, sends push notifications and runs X connector sync. It has no canonical maintenance flags or Typesense secrets; its deploy workflow removes only those retired bindings and preserves unrelated notification/X-sync env.
 - **memory-maintenance-job** (`modal/memory_maintenance_job.py`) — Cloud Run Job and sole host for canonical ST→LT maintenance (TTL → consolidation → promotion). Manual deploy via `.github/workflows/gcp_memory_maintenance_job.yml`; auto-dev on push to `main` via `gcp_memory_maintenance_job_auto_dev.yml`. Enablement is a multi-var contract (`MEMORY_MODE`, `MEMORY_ENABLED_USERS`, cron/fast-track/consolidation flags) enforced by `backend/scripts/validate-backend-runtime-env.py`; prod stays `MEMORY_MODE=off` until Gate 3.

--- a/backend/charts/backend-listen/dev_omi_backend_listen_values.yaml
+++ b/backend/charts/backend-listen/dev_omi_backend_listen_values.yaml
@@ -180,7 +180,7 @@ env:
   - name: HOSTED_SPEAKER_EMBEDDING_API_URL
     value: "http://diarizer.omiapi.com:80"
   - name: HOSTED_TRANSLATION_API_URL
-    value: "http://dev-omi-nllb-translation:8080"
+    value: "http://nllb.omiapi.com"
   - name: TRANSLATION_SERVICE_MODELS
     value: "nllb,google"
   - name: PINECONE_API_KEY
@@ -218,7 +218,7 @@ env:
         name: dev-omi-backend-secrets
         key: STT_PRERECORDED_MODEL
   - name: HOSTED_PARAKEET_API_URL
-    value: "http://dev-omi-parakeet.dev-omi-backend.svc.cluster.local:8080"
+    value: "http://parakeet.omiapi.com"
   - name: NO_SOCKET_TIMEOUT
     value: "true"
   - name: HOSTED_PUSHER_API_URL

--- a/backend/charts/backend-listen/prod_omi_backend_listen_values.yaml
+++ b/backend/charts/backend-listen/prod_omi_backend_listen_values.yaml
@@ -298,9 +298,9 @@ env:
         name: prod-omi-backend-secrets
         key: STT_PRERECORDED_MODEL
   - name: HOSTED_PARAKEET_API_URL
-    value: "http://prod-omi-parakeet.prod-omi-backend.svc.cluster.local:8080"
+    value: "http://parakeet.omi.me"
   - name: HOSTED_TRANSLATION_API_URL
-    value: "http://prod-omi-nllb-translation.prod-omi-backend.svc.cluster.local:8080"
+    value: "http://nllb.omi.me"
   - name: TRANSLATION_SERVICE_MODELS
     value: "nllb,google"
   - name: ENCRYPTION_SECRET

--- a/backend/charts/nllb-translation/dev_omi_nllb_translation_values.yaml
+++ b/backend/charts/nllb-translation/dev_omi_nllb_translation_values.yaml
@@ -16,7 +16,20 @@ service:
   port: 8080
 
 ingress:
-  enabled: false
+  enabled: true
+  className: ""
+  annotations:
+    kubernetes.io/ingress.class: "gce-internal"
+    kubernetes.io/ingress.regional-static-ip-name: "dev-nllb-translation-ilb-ip-address"
+    kubernetes.io/ingress.allow-http: "true"
+  hosts:
+    - host: nllb.omiapi.com
+      paths:
+        - path: /v1/translate
+          pathType: Prefix
+        - path: /health
+          pathType: Prefix
+  tls: []
 
 env:
   - name: NLLB_MODEL_DIR

--- a/backend/charts/nllb-translation/prod_omi_nllb_translation_values.yaml
+++ b/backend/charts/nllb-translation/prod_omi_nllb_translation_values.yaml
@@ -16,7 +16,20 @@ service:
   port: 8080
 
 ingress:
-  enabled: false
+  enabled: true
+  className: ""
+  annotations:
+    kubernetes.io/ingress.class: "gce-internal"
+    kubernetes.io/ingress.regional-static-ip-name: "prod-nllb-translation-ilb-ip-address"
+    kubernetes.io/ingress.allow-http: "true"
+  hosts:
+    - host: nllb.omi.me
+      paths:
+        - path: /v1/translate
+          pathType: Prefix
+        - path: /health
+          pathType: Prefix
+  tls: []
 
 env:
   - name: NLLB_MODEL_DIR

--- a/backend/charts/nllb-translation/templates/ingress.yaml
+++ b/backend/charts/nllb-translation/templates/ingress.yaml
@@ -1,0 +1,43 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "nllb-translation.fullname" . }}
+  labels:
+    {{- include "nllb-translation.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- with .pathType }}
+            pathType: {{ . }}
+            {{- end }}
+            backend:
+              service:
+                name: {{ include "nllb-translation.fullname" $ }}
+                port:
+                  number: {{ $.Values.service.port }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/backend/charts/nllb-translation/templates/service.yaml
+++ b/backend/charts/nllb-translation/templates/service.yaml
@@ -1,9 +1,28 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: cloud.google.com/v1
+kind: BackendConfig
+metadata:
+  name: nllb-translation-backend-config
+spec:
+  healthCheck:
+    checkIntervalSec: 10
+    timeoutSec: 5
+    port: {{ .Values.service.port }}
+    type: HTTP
+    requestPath: /health
+---
+{{- end }}
 apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "nllb-translation.fullname" . }}
   labels:
     {{- include "nllb-translation.labels" . | nindent 4 }}
+  {{- if .Values.ingress.enabled }}
+  annotations:
+    cloud.google.com/neg: '{"ingress": true}'
+    cloud.google.com/backend-config: '{"default": "nllb-translation-backend-config"}'
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/backend/deploy/runtime_env.yaml
+++ b/backend/deploy/runtime_env.yaml
@@ -35,6 +35,9 @@ environments:
           HOSTED_PARAKEET_API_URL:
             value: http://dev-omi-parakeet.dev-omi-backend.svc.cluster.local:8080
             category: service_discovery
+          HOSTED_TRANSLATION_API_URL:
+            value: http://dev-omi-nllb-translation:8080
+            category: service_discovery
           OMI_LLM_GATEWAY_FEATURE_MODE:
             value: gateway
             category: rollout
@@ -497,7 +500,10 @@ environments:
               name: prod-omi-backend-secrets
               key: MODULATE_API_KEY
           HOSTED_PARAKEET_API_URL:
-            value: http://prod-omi-parakeet.prod-omi-backend.svc.cluster.local:8080
+            value: http://parakeet.omi.me
+            category: service_discovery
+          HOSTED_TRANSLATION_API_URL:
+            value: http://nllb.omi.me
             category: service_discovery
           SERVICE_ACCOUNT_JSON:
             secret:

--- a/backend/deploy/runtime_env.yaml
+++ b/backend/deploy/runtime_env.yaml
@@ -33,10 +33,10 @@ environments:
               name: dev-omi-backend-secrets
               key: MODULATE_API_KEY
           HOSTED_PARAKEET_API_URL:
-            value: http://dev-omi-parakeet.dev-omi-backend.svc.cluster.local:8080
+            value: http://parakeet.omiapi.com
             category: service_discovery
           HOSTED_TRANSLATION_API_URL:
-            value: http://dev-omi-nllb-translation:8080
+            value: http://nllb.omiapi.com
             category: service_discovery
           OMI_LLM_GATEWAY_FEATURE_MODE:
             value: gateway


### PR DESCRIPTION
## Summary

- Adds `gce-internal` Ingress to NLLB translation Helm chart for both **prod** (`nllb.omi.me`) and **dev** (`nllb.omiapi.com`)
- Adds BackendConfig with `/health` health check and NEG annotations to Service
- Updates `backend-listen` env vars to use internal LB domains:
  - **Prod**: `HOSTED_PARAKEET_API_URL` → `http://parakeet.omi.me`, `HOSTED_TRANSLATION_API_URL` → `http://nllb.omi.me`
  - **Dev**: `HOSTED_PARAKEET_API_URL` → `http://parakeet.omiapi.com`, `HOSTED_TRANSLATION_API_URL` → `http://nllb.omiapi.com`
- Aligns AGENTS.md service map, runtime_env.yaml for both environments

Follows the same pattern as VAD (`vad.omi.me` / `vad.omiapi.com`) and parakeet (`parakeet.omi.me` / `parakeet.omiapi.com`).

## Deploy prerequisites

### Prod
1. Reserve static internal IP: `gcloud compute addresses create prod-nllb-translation-ilb-ip-address --region us-central1 --subnet default --purpose SHARED_LOADBALANCING_VIP`
2. Deploy NLLB chart → creates Ingress + BackendConfig
3. Create internal DNS: `nllb.omi.me` → ILB IP
4. Deploy backend-listen chart (switches env vars)

### Dev
1. Reserve static internal IP: `gcloud compute addresses create dev-nllb-translation-ilb-ip-address --region us-central1 --subnet default --purpose SHARED_LOADBALANCING_VIP --project based-hardware-dev`
2. Deploy NLLB chart → creates Ingress + BackendConfig
3. Create internal DNS: `nllb.omiapi.com` → ILB IP
4. Deploy backend-listen chart (switches env vars)

## Risks

- **DNS ordering**: env var change depends on domain resolving. Translation service has Google fallback (`TRANSLATION_SERVICE_MODELS=nllb,google`), so requests won't fail — they'll use Google during transition.
- **Parakeet URL change**: ingress already exists for both prod/dev. The svc.cluster.local URL also works, so rollback is safe.
- **Static IPs**: must be reserved before Helm deploy or GCP assigns ephemeral IPs.

## Test plan

- [x] `helm lint` passes for nllb-translation chart (prod + dev values)
- [x] `helm template` renders correct Ingress/BackendConfig/NEG for prod and dev
- [x] `helm lint` passes for backend-listen chart (prod + dev values)
- [x] `helm upgrade --dry-run` succeeds against prod-omi-gke cluster
- [x] validate-backend-runtime-env.py passes for prod and dev
- [ ] Post-deploy: `kubectl get ingress` shows NLLB ingress with ILB IP
- [ ] Post-DNS: `curl http://nllb.omi.me/health` / `curl http://nllb.omiapi.com/health`

Closes #9536

_by AI for @beastoin_