### PR TITLE
Activate Smart Tasks for David's dogfood account

### DIFF
--- a/backend/scripts/activate_task_intelligence_dogfood_user.py
+++ b/backend/scripts/activate_task_intelligence_dogfood_user.py
@@ -1,0 +1,464 @@
+#!/usr/bin/env python3
+"""Safely activate Smart Tasks for the single approved dogfood account.
+
+The default is a dry-run.  An apply is deliberately limited to the existing
+canonical-memory dogfood UID, requires explicit UID/mode/generation
+confirmations, and writes only that user's task-intelligence control document.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
+
+try:
+    from google.cloud import firestore
+except ImportError:  # pragma: no cover - exercised when cloud dependencies are unavailable
+    firestore = None
+
+BACKEND_DIR = Path(__file__).resolve().parents[1]
+if str(BACKEND_DIR) not in sys.path:
+    sys.path.insert(0, str(BACKEND_DIR))
+
+from database.google_credentials import prepare_google_credentials
+from models.task_intelligence import TaskWorkflowControl, TaskWorkflowMode
+from utils.memory.memory_system import CANONICAL_MEMORY_USERS
+
+TASK_INTELLIGENCE_DOGFOOD_UID = 'vi7SA9ckQCe4ccobWNxlbdcNdC23'
+CONTROL_PATH_TEMPLATE = 'users/{uid}/task_intelligence_control/state'
+DEFAULT_FIRESTORE_RPC_TIMEOUT_SECONDS = 20.0
+GCLOUD_USER_CREDENTIAL_SOURCE = 'gcloud-user'
+APPLICATION_DEFAULT_CREDENTIAL_SOURCE = 'application-default'
+
+
+@dataclass(frozen=True)
+class ActivationPlan:
+    uid: str
+    document_path: str
+    current_control: dict[str, Any]
+    target_control: dict[str, Any]
+    canonical_memory_whitelisted: bool
+
+
+@dataclass(frozen=True)
+class FirestoreControlSnapshot:
+    control: TaskWorkflowControl
+    exists: bool
+    update_time: str | None
+
+
+class FirestoreRestError(RuntimeError):
+    def __init__(self, status_code: int):
+        super().__init__(f'Firestore REST request failed with status {status_code}')
+        self.status_code = status_code
+
+
+def control_path(uid: str) -> str:
+    return CONTROL_PATH_TEMPLATE.format(uid=uid)
+
+
+def require_dogfood_uid(uid: str) -> None:
+    if uid != TASK_INTELLIGENCE_DOGFOOD_UID:
+        raise ValueError('this operator tool is restricted to the approved Smart Tasks dogfood UID')
+    if uid not in CANONICAL_MEMORY_USERS:
+        raise RuntimeError('approved Smart Tasks dogfood UID is not in the canonical-memory code whitelist')
+
+
+def _snapshot_control(snapshot: Any) -> TaskWorkflowControl:
+    if snapshot is None or getattr(snapshot, 'exists', False) is False:
+        return TaskWorkflowControl()
+    payload = snapshot.to_dict()
+    if not isinstance(payload, dict):
+        raise RuntimeError('task-intelligence control document must be an object')
+    return TaskWorkflowControl.model_validate(payload)
+
+
+def read_control(
+    db_client: Any,
+    *,
+    uid: str,
+    rpc_timeout_seconds: float = DEFAULT_FIRESTORE_RPC_TIMEOUT_SECONDS,
+) -> TaskWorkflowControl:
+    require_dogfood_uid(uid)
+    return _snapshot_control(db_client.document(control_path(uid)).get(timeout=rpc_timeout_seconds))
+
+
+def _gcloud_user_access_token(*, rpc_timeout_seconds: float) -> str:
+    try:
+        result = subprocess.run(
+            ['gcloud', 'auth', 'print-access-token'],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=rpc_timeout_seconds,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        raise RuntimeError('unable to obtain a gcloud user access token') from exc
+    token = result.stdout.strip()
+    if not token:
+        raise RuntimeError('gcloud returned an empty user access token')
+    return token
+
+
+def _firestore_rest_url(*, firestore_project: str, uid: str) -> str:
+    return (
+        f'https://firestore.googleapis.com/v1/projects/{firestore_project}/databases/(default)/documents/'
+        f'{control_path(uid)}'
+    )
+
+
+def _firestore_rest_request(
+    *,
+    method: str,
+    url: str,
+    access_token: str,
+    rpc_timeout_seconds: float,
+    payload: dict[str, Any] | None = None,
+    http_open=None,
+) -> dict[str, Any]:
+    data = json.dumps(payload).encode('utf-8') if payload is not None else None
+    request = Request(
+        url,
+        data=data,
+        method=method,
+        headers={
+            'Authorization': f'Bearer {access_token}',
+            'Content-Type': 'application/json',
+        },
+    )
+    try:
+        with (http_open or urlopen)(request, timeout=rpc_timeout_seconds) as response:
+            raw = response.read()
+    except HTTPError as exc:
+        raise FirestoreRestError(exc.code) from exc
+    except URLError as exc:
+        raise RuntimeError('Firestore REST transport failed') from exc
+    if not raw:
+        return {}
+    decoded = json.loads(raw.decode('utf-8'))
+    if not isinstance(decoded, dict):
+        raise RuntimeError('Firestore REST response must be an object')
+    return decoded
+
+
+def _firestore_value(value: object) -> object:
+    if not isinstance(value, dict) or len(value) != 1:
+        raise RuntimeError('Firestore control field is malformed')
+    kind, raw = next(iter(value.items()))
+    if kind == 'stringValue' and isinstance(raw, str):
+        return raw
+    if kind == 'integerValue' and isinstance(raw, str) and raw.isdigit():
+        return int(raw)
+    raise RuntimeError('Firestore control field has an unsupported type')
+
+
+def _control_snapshot_from_firestore_document(payload: dict[str, Any]) -> FirestoreControlSnapshot:
+    fields = payload.get('fields')
+    update_time = payload.get('updateTime')
+    if not isinstance(fields, dict) or not isinstance(update_time, str) or not update_time:
+        raise RuntimeError('Firestore control document is malformed')
+    return FirestoreControlSnapshot(
+        control=TaskWorkflowControl.model_validate({key: _firestore_value(value) for key, value in fields.items()}),
+        exists=True,
+        update_time=update_time,
+    )
+
+
+def read_control_with_gcloud_user_token(
+    *,
+    firestore_project: str,
+    uid: str,
+    rpc_timeout_seconds: float,
+    http_open=None,
+    access_token: str | None = None,
+) -> FirestoreControlSnapshot:
+    require_dogfood_uid(uid)
+    token = access_token or _gcloud_user_access_token(rpc_timeout_seconds=rpc_timeout_seconds)
+    try:
+        payload = _firestore_rest_request(
+            method='GET',
+            url=_firestore_rest_url(firestore_project=firestore_project, uid=uid),
+            access_token=token,
+            rpc_timeout_seconds=rpc_timeout_seconds,
+            http_open=http_open,
+        )
+    except FirestoreRestError as exc:
+        if exc.status_code == 404:
+            return FirestoreControlSnapshot(control=TaskWorkflowControl(), exists=False, update_time=None)
+        raise
+    return _control_snapshot_from_firestore_document(payload)
+
+
+def build_activation_plan(uid: str, current: TaskWorkflowControl) -> ActivationPlan:
+    require_dogfood_uid(uid)
+    target = TaskWorkflowControl(
+        workflow_mode=TaskWorkflowMode.read,
+        account_generation=current.account_generation,
+    )
+    return ActivationPlan(
+        uid=uid,
+        document_path=control_path(uid),
+        current_control=current.model_dump(mode='json'),
+        target_control=target.model_dump(mode='json'),
+        canonical_memory_whitelisted=True,
+    )
+
+
+def apply_activation(
+    db_client: Any,
+    *,
+    uid: str,
+    expected_account_generation: int,
+    rpc_timeout_seconds: float = DEFAULT_FIRESTORE_RPC_TIMEOUT_SECONDS,
+) -> bool:
+    """Write the `read` control only if the observed generation remains current.
+
+    The transaction retries on concurrent Firestore changes.  It never changes
+    the account generation: an existing generation is preserved and a missing
+    control document is explicitly initialized at the valid default of zero.
+    """
+
+    require_dogfood_uid(uid)
+    if expected_account_generation < 0:
+        raise ValueError('expected account generation must be nonnegative')
+    if firestore is None:
+        raise RuntimeError('google-cloud-firestore is required to apply Smart Tasks activation')
+
+    ref = db_client.document(control_path(uid))
+
+    @firestore.transactional
+    def activate(transaction) -> bool:
+        current = _snapshot_control(ref.get(transaction=transaction, timeout=rpc_timeout_seconds))
+        if current.account_generation != expected_account_generation:
+            raise RuntimeError(
+                'refusing activation because account generation changed: '
+                f'expected {expected_account_generation}, found {current.account_generation}'
+            )
+        target = TaskWorkflowControl(
+            workflow_mode=TaskWorkflowMode.read,
+            account_generation=current.account_generation,
+        )
+        if current == target:
+            return False
+        transaction.set(ref, target.model_dump(mode='json'))
+        return True
+
+    return activate(db_client.transaction())
+
+
+def _firestore_control_fields(control: TaskWorkflowControl) -> dict[str, dict[str, str]]:
+    return {
+        'workflow_mode': {'stringValue': control.workflow_mode.value},
+        'account_generation': {'integerValue': str(control.account_generation)},
+    }
+
+
+def apply_activation_with_gcloud_user_token(
+    *,
+    firestore_project: str,
+    uid: str,
+    expected_account_generation: int,
+    current: FirestoreControlSnapshot,
+    rpc_timeout_seconds: float,
+    http_open=None,
+    access_token: str | None = None,
+) -> bool:
+    require_dogfood_uid(uid)
+    if current.control.account_generation != expected_account_generation:
+        raise RuntimeError(
+            'refusing activation because account generation changed: '
+            f'expected {expected_account_generation}, found {current.control.account_generation}'
+        )
+    target = TaskWorkflowControl(
+        workflow_mode=TaskWorkflowMode.read,
+        account_generation=current.control.account_generation,
+    )
+    if current.control == target:
+        return False
+
+    token = access_token or _gcloud_user_access_token(rpc_timeout_seconds=rpc_timeout_seconds)
+    precondition = (
+        {'currentDocument.updateTime': current.update_time}
+        if current.exists and current.update_time
+        else {'currentDocument.exists': 'false'}
+    )
+    query = urlencode(
+        {
+            **precondition,
+            'updateMask.fieldPaths': ['workflow_mode', 'account_generation'],
+        },
+        doseq=True,
+    )
+    _firestore_rest_request(
+        method='PATCH',
+        url=f'{_firestore_rest_url(firestore_project=firestore_project, uid=uid)}?{query}',
+        access_token=token,
+        rpc_timeout_seconds=rpc_timeout_seconds,
+        payload={
+            'name': f'projects/{firestore_project}/databases/(default)/documents/{control_path(uid)}',
+            'fields': _firestore_control_fields(target),
+        },
+        http_open=http_open,
+    )
+    return True
+
+
+def _load_firestore_client(*, firestore_project: str):
+    if firestore is None:
+        raise RuntimeError('google-cloud-firestore is required to inspect or apply Smart Tasks activation')
+    prepare_google_credentials()
+    return firestore.Client(project=firestore_project)
+
+
+def build_report(
+    *,
+    plan: ActivationPlan,
+    firestore_project: str | None,
+    credential_source: str,
+    applied: bool | None,
+    verified_control: TaskWorkflowControl | None,
+) -> dict[str, Any]:
+    return {
+        'artifact': 'task_intelligence_dogfood_activation',
+        'dry_run': applied is None,
+        'firestore_project': firestore_project,
+        'credential_source': credential_source,
+        'plan': asdict(plan),
+        'applied': applied,
+        'verified_control': verified_control.model_dump(mode='json') if verified_control is not None else None,
+        'operator_notes': [
+            'This tool is restricted to the one approved Smart Tasks dogfood UID.',
+            'It writes only users/{uid}/task_intelligence_control/state when --apply is supplied.',
+            'It does not change the canonical-memory cohort, runtime environment, or any other user.',
+            'The transaction preserves account_generation and rejects a stale expected generation.',
+            'The gcloud-user source obtains a short-lived token without including it in output or reports.',
+        ],
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description='Dry-run/apply Smart Tasks read mode for the approved dogfood UID.')
+    parser.add_argument('--uid', default=TASK_INTELLIGENCE_DOGFOOD_UID)
+    parser.add_argument('--firestore-project', help='Required for --inspect-existing or --apply.')
+    parser.add_argument(
+        '--credential-source',
+        choices=(APPLICATION_DEFAULT_CREDENTIAL_SOURCE, GCLOUD_USER_CREDENTIAL_SOURCE),
+        default=APPLICATION_DEFAULT_CREDENTIAL_SOURCE,
+        help='Use application-default credentials or an explicit gcloud user token.',
+    )
+    parser.add_argument('--inspect-existing', action='store_true', help='Read the existing control document.')
+    parser.add_argument('--expected-account-generation', type=int)
+    parser.add_argument(
+        '--rpc-timeout-seconds',
+        type=float,
+        default=DEFAULT_FIRESTORE_RPC_TIMEOUT_SECONDS,
+        help='Bound each Firestore RPC; defaults to 20 seconds.',
+    )
+    parser.add_argument('--apply', action='store_true', help='Write the explicit read-mode control document.')
+    parser.add_argument('--confirm-uid', help='Required with --apply; must exactly match --uid.')
+    parser.add_argument(
+        '--confirm-workflow-mode',
+        help='Required with --apply; must exactly equal read.',
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    require_dogfood_uid(args.uid)
+    if args.expected_account_generation is not None and args.expected_account_generation < 0:
+        raise SystemExit('--expected-account-generation must be nonnegative')
+    if args.rpc_timeout_seconds <= 0:
+        raise SystemExit('--rpc-timeout-seconds must be positive')
+    if args.apply:
+        if args.confirm_uid != args.uid:
+            raise SystemExit('--confirm-uid must exactly match --uid when --apply is used')
+        if args.confirm_workflow_mode != TaskWorkflowMode.read.value:
+            raise SystemExit('--confirm-workflow-mode must exactly equal read when --apply is used')
+        if args.expected_account_generation is None:
+            raise SystemExit('--expected-account-generation is required when --apply is used')
+    if (args.inspect_existing or args.apply) and not args.firestore_project:
+        raise SystemExit('--firestore-project is required for inspection or apply')
+
+    current = TaskWorkflowControl()
+    current_snapshot = None
+    db_client = None
+    if args.inspect_existing or args.apply:
+        if args.credential_source == GCLOUD_USER_CREDENTIAL_SOURCE:
+            current_snapshot = read_control_with_gcloud_user_token(
+                firestore_project=args.firestore_project,
+                uid=args.uid,
+                rpc_timeout_seconds=args.rpc_timeout_seconds,
+            )
+            current = current_snapshot.control
+        else:
+            db_client = _load_firestore_client(firestore_project=args.firestore_project)
+            current = read_control(db_client, uid=args.uid, rpc_timeout_seconds=args.rpc_timeout_seconds)
+    if args.expected_account_generation is not None and current.account_generation != args.expected_account_generation:
+        raise SystemExit(
+            'expected account generation does not match inspected control: '
+            f'expected {args.expected_account_generation}, found {current.account_generation}'
+        )
+
+    plan = build_activation_plan(args.uid, current)
+    applied = None
+    verified_control = None
+    if args.apply:
+        if args.credential_source == GCLOUD_USER_CREDENTIAL_SOURCE:
+            if current_snapshot is None:
+                raise RuntimeError('gcloud-user activation requires an inspected control snapshot')
+            applied = apply_activation_with_gcloud_user_token(
+                firestore_project=args.firestore_project,
+                uid=args.uid,
+                expected_account_generation=args.expected_account_generation,
+                current=current_snapshot,
+                rpc_timeout_seconds=args.rpc_timeout_seconds,
+            )
+            verified_control = read_control_with_gcloud_user_token(
+                firestore_project=args.firestore_project,
+                uid=args.uid,
+                rpc_timeout_seconds=args.rpc_timeout_seconds,
+            ).control
+        else:
+            applied = apply_activation(
+                db_client,
+                uid=args.uid,
+                expected_account_generation=args.expected_account_generation,
+                rpc_timeout_seconds=args.rpc_timeout_seconds,
+            )
+            verified_control = read_control(
+                db_client,
+                uid=args.uid,
+                rpc_timeout_seconds=args.rpc_timeout_seconds,
+            )
+        if verified_control != TaskWorkflowControl(
+            workflow_mode=TaskWorkflowMode.read,
+            account_generation=current.account_generation,
+        ):
+            raise RuntimeError('post-apply control verification did not match the requested read-mode control')
+    print(
+        json.dumps(
+            build_report(
+                plan=plan,
+                firestore_project=args.firestore_project,
+                credential_source=args.credential_source,
+                applied=applied,
+                verified_control=verified_control,
+            ),
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/backend/tests/unit/test_activate_task_intelligence_dogfood_user.py
+++ b/backend/tests/unit/test_activate_task_intelligence_dogfood_user.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / 'scripts/activate_task_intelligence_dogfood_user.py'
+
+
+def load_script():
+    spec = importlib.util.spec_from_file_location('activate_task_intelligence_dogfood_user', SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class _Snapshot:
+    def __init__(self, data=None):
+        self._data = data
+        self.exists = data is not None
+
+    def to_dict(self):
+        return self._data
+
+
+class _Document:
+    def __init__(self, db, path):
+        self._db = db
+        self._path = path
+
+    def get(self, transaction=None, timeout=None):
+        del transaction
+        self._db.read_timeouts.append(timeout)
+        return _Snapshot(self._db.docs.get(self._path))
+
+
+class _Transaction:
+    def __init__(self, db):
+        self._db = db
+
+    def set(self, ref, payload):
+        self._db.writes.append((ref._path, payload))
+        self._db.docs[ref._path] = dict(payload)
+
+
+class _Db:
+    def __init__(self, docs=None):
+        self.docs = docs or {}
+        self.read_timeouts = []
+        self.writes = []
+
+    def document(self, path):
+        return _Document(self, path)
+
+    def transaction(self):
+        return _Transaction(self)
+
+
+class _Firestore:
+    @staticmethod
+    def transactional(function):
+        return function
+
+
+class _HttpResponse:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        del exc_type
+        del exc_value
+        del traceback
+        return False
+
+    def read(self):
+        return json.dumps(self._payload).encode('utf-8')
+
+
+def test_missing_control_plans_explicit_read_at_default_generation():
+    script = load_script()
+    db = _Db()
+
+    current = script.read_control(db, uid=script.TASK_INTELLIGENCE_DOGFOOD_UID)
+    plan = script.build_activation_plan(script.TASK_INTELLIGENCE_DOGFOOD_UID, current)
+
+    assert plan.current_control == {'workflow_mode': 'off', 'account_generation': 0}
+    assert plan.target_control == {'workflow_mode': 'read', 'account_generation': 0}
+    assert plan.canonical_memory_whitelisted is True
+    assert db.read_timeouts == [script.DEFAULT_FIRESTORE_RPC_TIMEOUT_SECONDS]
+
+
+def test_activation_preserves_existing_generation_and_is_idempotent(monkeypatch):
+    script = load_script()
+    monkeypatch.setattr(script, 'firestore', _Firestore())
+    path = script.control_path(script.TASK_INTELLIGENCE_DOGFOOD_UID)
+    db = _Db({path: {'workflow_mode': 'off', 'account_generation': 7}})
+
+    assert script.apply_activation(
+        db,
+        uid=script.TASK_INTELLIGENCE_DOGFOOD_UID,
+        expected_account_generation=7,
+    )
+    assert db.docs[path] == {'workflow_mode': 'read', 'account_generation': 7}
+    assert not script.apply_activation(
+        db,
+        uid=script.TASK_INTELLIGENCE_DOGFOOD_UID,
+        expected_account_generation=7,
+    )
+    assert len(db.writes) == 1
+
+
+def test_activation_rejects_stale_generation_without_a_write(monkeypatch):
+    script = load_script()
+    monkeypatch.setattr(script, 'firestore', _Firestore())
+    path = script.control_path(script.TASK_INTELLIGENCE_DOGFOOD_UID)
+    db = _Db({path: {'workflow_mode': 'off', 'account_generation': 3}})
+
+    with pytest.raises(RuntimeError, match='account generation changed'):
+        script.apply_activation(
+            db,
+            uid=script.TASK_INTELLIGENCE_DOGFOOD_UID,
+            expected_account_generation=2,
+        )
+
+    assert db.writes == []
+    assert db.docs[path] == {'workflow_mode': 'off', 'account_generation': 3}
+
+
+def test_tool_rejects_any_non_dogfood_uid():
+    script = load_script()
+
+    with pytest.raises(ValueError, match='restricted'):
+        script.build_activation_plan('another-user', script.TaskWorkflowControl())
+
+
+def test_gcloud_user_transport_uses_current_document_precondition_and_never_reports_token():
+    script = load_script()
+    requests = []
+    current_document = {
+        'fields': {
+            'workflow_mode': {'stringValue': 'off'},
+            'account_generation': {'integerValue': '7'},
+        },
+        'updateTime': '2026-07-12T00:00:00.000000Z',
+    }
+
+    def http_open(request, timeout):
+        requests.append((request, timeout))
+        return _HttpResponse(current_document)
+
+    snapshot = script.read_control_with_gcloud_user_token(
+        firestore_project='based-hardware',
+        uid=script.TASK_INTELLIGENCE_DOGFOOD_UID,
+        rpc_timeout_seconds=5,
+        http_open=http_open,
+        access_token='short-lived-token',
+    )
+    assert snapshot.control == script.TaskWorkflowControl(workflow_mode='off', account_generation=7)
+
+    assert script.apply_activation_with_gcloud_user_token(
+        firestore_project='based-hardware',
+        uid=script.TASK_INTELLIGENCE_DOGFOOD_UID,
+        expected_account_generation=7,
+        current=snapshot,
+        rpc_timeout_seconds=5,
+        http_open=http_open,
+        access_token='short-lived-token',
+    )
+
+    patch_request, timeout = requests[-1]
+    assert patch_request.method == 'PATCH'
+    assert timeout == 5
+    assert 'currentDocument.updateTime=2026-07-12T00%3A00%3A00.000000Z' in patch_request.full_url
+    assert b'"workflow_mode": {"stringValue": "read"}' in patch_request.data
+    assert b'"account_generation": {"integerValue": "7"}' in patch_request.data
+    assert b'short-lived-token' not in patch_request.data

--- a/docs/doc/developer/backend/task_candidate_lifecycle.mdx
+++ b/docs/doc/developer/backend/task_candidate_lifecycle.mdx
@@ -37,6 +37,49 @@ The per-user universal-contract mode controls compatibility behavior:
 - `read`: Candidates and canonical tasks are authoritative; staged endpoints are compatibility projections and
   never write `staged_tasks`.
 
+## Single-user Smart Tasks dogfood activation
+
+The task-intelligence control remains independently scoped from the canonical-memory cohort. The approved
+dogfood account is already the only active canonical-memory whitelist member; to make Smart Tasks fully active,
+an operator must explicitly create `users/{uid}/task_intelligence_control/state` in `read` mode. Do not change
+the canonical-memory list, runtime cohort environment, or any other user's control as part of this operation.
+
+Use the repo-tracked operator tool from a checkout containing the merged activation change. It defaults to a
+dry-run and is permanently restricted to the approved dogfood UID. First inspect the existing state and record
+its account generation (a missing document is the safe default: `off`, generation `0`):
+
+```bash
+cd backend
+python scripts/activate_task_intelligence_dogfood_user.py \
+  --credential-source gcloud-user \
+  --firestore-project based-hardware \
+  --inspect-existing \
+  --expected-account-generation 0
+```
+
+After reviewing that redacted control-only report, run the exact same command with `--apply`, the exact UID
+confirmation, and the `read` acknowledgement. The tool re-reads and transactionally fences the generation, so
+an account reset or concurrent control change fails closed rather than activating stale state:
+
+```bash
+cd backend
+python scripts/activate_task_intelligence_dogfood_user.py \
+  --credential-source gcloud-user \
+  --firestore-project based-hardware \
+  --inspect-existing \
+  --expected-account-generation 0 \
+  --apply \
+  --confirm-uid vi7SA9ckQCe4ccobWNxlbdcNdC23 \
+  --confirm-workflow-mode read
+```
+
+The tool writes only `workflow_mode: read` and the unchanged `account_generation`; rerunning after a successful
+activation is a no-op. The explicit `gcloud-user` source obtains a short-lived local user token without printing
+or persisting it, and sends the PATCH with the inspected Firestore document revision as a precondition. It does
+not deploy backend code or mutate production merely by merging this PR. Verify
+the live account's `workflow_mode=read`, matching generation, canonical-memory eligibility, and enabled
+intelligence product/evaluation surfaces before resuming dogfood.
+
 Staged reconciliation is resumable by checkpoint. It imports active rows as pending Candidates and terminal
 promotion history as accepted, rejected, or expired without replaying task mutations or notifications. Reports
 contain stable IDs and counts only—never task content.


### PR DESCRIPTION
## Summary

Adds a repo-tracked, dry-run-first Smart Tasks activation tool for David's already canonical-memory-whitelisted dogfood account.

The tool is hard-restricted to David's Firebase UID and can only write `users/{uid}/task_intelligence_control/state` as `workflow_mode=read`. Its application-default path uses a Firestore transaction; the explicit `gcloud-user` path obtains a short-lived user token without outputting it and PATCHes only after a Firestore document-revision precondition. Both preserve the existing account generation, reject stale state, and are no-ops once the account is already active.

It does not change canonical-memory membership, runtime environment, any other account, or task-chat continuity.

## Live activation

Applied in this dogfood session using the audited `gcloud-user` path:

- David only: `off → read`
- Account generation: preserved at `0`
- Immediate independent read-back: `workflow_mode=read`, generation `0`
- No cohort, runtime environment, or other account changed

## Root cause and durable guard

Smart Tasks correctly defaults missing per-user workflow control to `off` at generation `0`, but the rollout had no audited operator path to create the explicit `read` control document. The new tool supplies that path with exact UID/mode confirmations, a transactional or document-revision generation fence, and tests for default-off, generation-preserving, no-op, non-target refusal, and bounded gcloud-user transport.

## Verification

- `cd backend && .venv/bin/python -m pytest -q tests/unit/test_activate_task_intelligence_dogfood_user.py tests/unit/test_task_intelligence_rollout.py` — 16 passed
- `cd backend && python scripts/check_module_stub_pollution.py` — 0 violations
- `cd backend && python scripts/scan_import_time_side_effects.py` — 0 violations
- PR preflight and pre-push contracts passed
- Live dry-run, apply, and separate read-back all passed

## Invariants

`scripts/pr-preflight --suggest` reports no invariant IDs for this control-only script and lifecycle runbook change.

Related to #9530 (unblocks the per-account control write; does not complete dogfood).