### PR TITLE
test(app-client): make raw decode fixture line-agnostic

### DIFF
--- a/backend/tests/unit/test_app_client_schema_inventory.py
+++ b/backend/tests/unit/test_app_client_schema_inventory.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -275,7 +276,7 @@ def test_inventory_strict_raw_decode_site_gate_fails_with_actionable_sites():
 
     assert result.returncode == 1
     assert 'Raw Dart decode sites:' in result.stdout
-    assert 'app/lib/backend/schema/app.dart:32' in result.stdout
+    assert re.search(r'app/lib/backend/schema/app\.dart:\d+ \(field_access\)', result.stdout)
 
 
 def test_inventory_openapi_route_response_decode_migration_complete():


### PR DESCRIPTION
## Summary
- replace the brittle exact `app.dart:32` assertion with a line-number-agnostic matcher
- keep checking the strict scanner’s non-zero exit, actionable-site heading, target schema file, and raw `field_access` classification

## Root cause and durable guard
[#9482](https://github.com/BasedHardware/omi/pull/9482) correctly identified that generated-code edits can shift a known raw-decode site without changing the scanner’s behavior. The exact source line made the gate fail whenever that happened.

This follow-up preserves the scanner contract while accepting any reported line number for the known `app.dart` raw `field_access` site.

Inspired by the proposed follow-up in closed PR #9482. The immediate `:31 → :32` repair was already incorporated into [#9462](https://github.com/BasedHardware/omi/pull/9462).

## Verification
- `BACKEND_UNIT_TEST_FILE_LIST=/tmp/omi-9482-followup-tests.txt bash backend/test.sh` — 9 passed
- `make preflight` — 12 deterministic checks passed

## Product invariants
No locked product invariants are affected (`scripts/pr-preflight --suggest`).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9539?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

