### PR TITLE
test(app-client): make the raw-decode-site gate line-agnostic

### DIFF
--- a/backend/tests/unit/test_app_client_schema_inventory.py
+++ b/backend/tests/unit/test_app_client_schema_inventory.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -275,7 +276,10 @@ def test_inventory_strict_raw_decode_site_gate_fails_with_actionable_sites():
 
     assert result.returncode == 1
     assert 'Raw Dart decode sites:' in result.stdout
-    assert 'app/lib/backend/schema/app.dart:32' in result.stdout
+    # Match the known app.dart raw-decode site by file with any line number (and either path
+    # separator), so a future edit that shifts the line (as #9470 did, :31 -> :32) does not re-break
+    # this gate on unrelated PRs.
+    assert re.search(r'app[/\\]lib[/\\]backend[/\\]schema[/\\]app\.dart:\d+', result.stdout), result.stdout
 
 
 def test_inventory_openapi_route_response_decode_migration_complete():


### PR DESCRIPTION
## What

The app-client schema-inventory gate hardcodes the raw-decode site's line number:

    assert 'app/lib/backend/schema/app.dart:32' in result.stdout

That is brittle: any edit shifting that line in app.dart re-breaks the gate for every backend PR whose changed-file set pulls in this test, even though nothing about the raw-decode contract changed. That is exactly what happened when #9470 shifted the site from line 31 to 32 (pinned to :32 in #9462); it will happen again on the next shift.

## Fix

Assert the known app.dart raw-decode site by file with any line number (and either path separator), so a future line shift does not re-break the gate:

    assert re.search(r'app[/\]lib[/\]backend[/\]schema[/\]app\.dart:\d+', result.stdout)

The gate still verifies the scanner returns non-zero, prints the `Raw Dart decode sites:` listing, and reports app.dart as a raw-decode site. This is the sturdier follow-up discussed on #9482, applied on top of #9462's line pin (it generalizes that assertion, no conflict).

## Testing

- python -m pytest tests/unit/test_app_client_schema_inventory.py::test_inventory_strict_raw_decode_site_gate_fails_with_actionable_sites -> passes (line-agnostic).
- black clean.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9540?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

