### PR TITLE
fix(desktop): auto-reconnect Redis after dropped connection (#9524)

### DIFF
--- a/desktop/macos/Backend-Rust/src/services/redis.rs
+++ b/desktop/macos/Backend-Rust/src/services/redis.rs
@@ -8,7 +8,15 @@ use tokio::sync::RwLock;
 /// Redis service for conversation visibility and sharing
 pub struct RedisService {
     client: Client,
-    connection: Arc<RwLock<Option<redis::aio::MultiplexedConnection>>>,
+    // Cache a `ConnectionManager` rather than a raw `MultiplexedConnection`.
+    // A `MultiplexedConnection` is never re-established after a transport
+    // failure, so a single broken pipe (observed on prod desktop-backend after
+    // ~31h of uptime, issue #9524) makes every metered path — TTS, rate limits —
+    // fail-closed forever until the process restarts. `ConnectionManager`
+    // transparently reconnects on the next command; it does NOT retry the
+    // in-flight command, so non-idempotent ops (INCR/ZADD rate limits) are never
+    // duplicated.
+    connection: Arc<RwLock<Option<redis::aio::ConnectionManager>>>,
 }
 
 /// Review data stored in Redis
@@ -49,8 +57,12 @@ impl RedisService {
         })
     }
 
-    /// Get or create a connection
-    async fn get_connection(&self) -> Result<redis::aio::MultiplexedConnection, redis::RedisError> {
+    /// Get or create a self-healing connection.
+    ///
+    /// The returned `ConnectionManager` is cheap to clone (it shares an inner
+    /// `Arc`) and reconnects on its own after a dropped/broken connection, so a
+    /// stale cache no longer requires a process restart to recover.
+    async fn get_connection(&self) -> Result<redis::aio::ConnectionManager, redis::RedisError> {
         // Check if we have a cached connection
         {
             let conn = self.connection.read().await;
@@ -60,7 +72,7 @@ impl RedisService {
         }
 
         // Create new connection
-        let conn = self.client.get_multiplexed_async_connection().await?;
+        let conn = redis::aio::ConnectionManager::new(self.client.clone()).await?;
 
         // Cache it
         {

--- a/desktop/macos/changelog/unreleased/20260712-redis-auto-reconnect.json
+++ b/desktop/macos/changelog/unreleased/20260712-redis-auto-reconnect.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed text-to-speech and other rate-limited features failing until the app backend restarted after a dropped Redis connection"
+}


### PR DESCRIPTION
## Bug (#9524, part 1 — stale Redis connection)

The Rust desktop backend caches one `redis::aio::MultiplexedConnection` and never invalidates it. The redis crate does not re-establish a `MultiplexedConnection` after its multiplexed pipe dies, so a single transport failure (broken pipe) makes **every** metered path fail-closed **until the process restarts**.

Prod evidence from the issue: revision `desktop-backend-00883-tcp` produced ≥74 `POST /v1/tts/synthesize` 503s over ~27 min, each paired with `tts_synthesize: Redis rate-limit error ... broken pipe`. The first broken pipe appeared ~31h after deploy; only redeploying (fresh connection) restored TTS.

## Root cause

`RedisService::get_connection()` (`desktop/macos/Backend-Rust/src/services/redis.rs`) caches a `MultiplexedConnection`. Once its underlying connection drops, all clones of it keep returning the same transport error forever — no reconnect path exists.

## Fix

Cache a `redis::aio::ConnectionManager` instead (the `connection-manager` crate feature is already enabled). `ConnectionManager` transparently reconnects on the next command after a dropped/broken connection, so recovery no longer needs a process restart.

Crucially, in redis 0.25 `ConnectionManager` **does not retry the in-flight command** — on a connection-dropped error it kicks off a background reconnect and returns the error for the current call. So:
- the request that hit the dead connection still errors (fail-closed preserved — metering is never bypassed), and
- non-idempotent rate-limit ops (`INCR`/`ZADD` in the TTS/Gemini Lua scripts) are **never duplicated**.

Every command method is unchanged — `ConnectionManager` implements `AsyncCommands` and works with `query_async`, so the diff is confined to the struct field, `get_connection()`, and a comment.

## Scope / what this does NOT do

This closes part 1 (stale Redis connection) with the smallest correct change. It intentionally does **not** implement the rest of #9524's epic (explicit error classification + bounded-jitter reconnect owner, per-op telemetry, readiness/dependency state, the Gemini 90s-timeout isolation, and the full fault-injection suite). Those remain open on #9524.

## Verification

- `cargo check` passes; `rustfmt --edition 2021` clean.
- **Not** exercised against a live Redis in this environment. A true reconnect regression test (kill an established connection mid-flight, assert recovery without process restart) requires a live-Redis fault harness — it is non-hermetic and is exactly the fault-injection work scoped in #9524. **Please build + add that integration test before merging.**

🤖 automated by hourly watchdog; opened for review, not merged.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9541?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

