### PR TITLE
fix(desktop): isolate ad-hoc named-bundle signing

### DIFF
--- a/desktop/macos/changelog/unreleased/20260712-adhoc-named-bundle-signing.json
+++ b/desktop/macos/changelog/unreleased/20260712-adhoc-named-bundle-signing.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed ad-hoc named development bundles failing to launch with embedded frameworks"
+}

--- a/desktop/macos/run.sh
+++ b/desktop/macos/run.sh
@@ -734,6 +734,12 @@ if [ -z "$SIGN_IDENTITY" ]; then
     fi
 fi
 
+"$(dirname "$0")/scripts/prepare-local-dev-entitlements.sh" \
+    --validate-identity \
+    "$SIGN_IDENTITY" \
+    "$IS_NAMED_BUNDLE" \
+    "${OMI_ALLOW_ADHOC_SIGN:-0}"
+
 if [ -n "$SIGN_IDENTITY" ]; then
     substep "Using identity: $SIGN_IDENTITY"
     if [ -d "$APP_BUNDLE/Contents/Frameworks/Sparkle.framework" ]; then
@@ -792,10 +798,17 @@ if [ -n "$SIGN_IDENTITY" ]; then
     fi
 
     if [ "$USE_FALLBACK_ENTITLEMENTS" = true ]; then
-        cp Desktop/Omi.entitlements /tmp/omi-local-dev.entitlements
-        /usr/libexec/PlistBuddy -c "Delete :com.apple.developer.applesignin" /tmp/omi-local-dev.entitlements 2>/dev/null || true
+        LOCAL_SIGNING_MODE="development"
+        if [ "$SIGN_IDENTITY" = "-" ]; then
+            LOCAL_SIGNING_MODE="adhoc"
+        fi
+        LOCAL_DEV_ENTITLEMENTS="$("$(dirname "$0")/scripts/prepare-local-dev-entitlements.sh" \
+            Desktop/Omi.entitlements \
+            "$OMI_DEV_DIR" \
+            "$BUNDLE_ID" \
+            "$LOCAL_SIGNING_MODE")"
         rm -f "$PROFILE_PATH"
-        EFFECTIVE_ENTITLEMENTS="/tmp/omi-local-dev.entitlements"
+        EFFECTIVE_ENTITLEMENTS="$LOCAL_DEV_ENTITLEMENTS"
     fi
     substep "Signing app bundle"
     codesign --force --options runtime --entitlements "$EFFECTIVE_ENTITLEMENTS" --sign "$SIGN_IDENTITY" "$APP_BUNDLE"

--- a/desktop/macos/scripts/prepare-local-dev-entitlements.sh
+++ b/desktop/macos/scripts/prepare-local-dev-entitlements.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "${1:-}" = "--validate-identity" ]; then
+    if [ "$#" -ne 4 ]; then
+        echo "Usage: $0 --validate-identity SIGN_IDENTITY true|false 0|1" >&2
+        exit 2
+    fi
+
+    SIGN_IDENTITY="$2"
+    IS_NAMED_BUNDLE="$3"
+    ALLOW_ADHOC="$4"
+    if [ "$SIGN_IDENTITY" = "-" ] \
+        && { [ "$IS_NAMED_BUNDLE" != "true" ] || [ "$ALLOW_ADHOC" != "1" ]; }; then
+        echo "Ad-hoc signing requires an explicitly opted-in named bundle" >&2
+        exit 2
+    fi
+    exit 0
+fi
+
+if [ "$#" -ne 4 ]; then
+    echo "Usage: $0 BASE_ENTITLEMENTS DEV_DIR BUNDLE_ID development|adhoc" >&2
+    exit 2
+fi
+
+BASE_ENTITLEMENTS="$1"
+DEV_DIR="$2"
+BUNDLE_ID="$3"
+SIGNING_MODE="$4"
+
+case "$SIGNING_MODE" in
+    development|adhoc) ;;
+    *)
+        echo "Unsupported local signing mode: $SIGNING_MODE" >&2
+        exit 2
+        ;;
+esac
+
+case "$BUNDLE_ID" in
+    ''|*[!A-Za-z0-9._-]*)
+        echo "Bundle ID contains unsupported path characters: $BUNDLE_ID" >&2
+        exit 2
+        ;;
+esac
+
+# The run.sh build lock serializes a checkout. Keeping generated entitlements
+# under that checkout's .dev directory and naming them by bundle also isolates
+# parallel worktrees and named apps from one another.
+OUTPUT_DIR="$DEV_DIR/local-signing"
+OUTPUT_ENTITLEMENTS="$OUTPUT_DIR/$BUNDLE_ID.entitlements"
+mkdir -p "$OUTPUT_DIR"
+TEMP_ENTITLEMENTS="$(mktemp "$OUTPUT_DIR/.$BUNDLE_ID.entitlements.XXXXXX")"
+cleanup() {
+    rm -f "$TEMP_ENTITLEMENTS"
+}
+trap cleanup EXIT
+cp "$BASE_ENTITLEMENTS" "$TEMP_ENTITLEMENTS"
+
+# Named bundles have no provisioning profile, so Sign in with Apple must not
+# be present in their local signature.
+/usr/libexec/PlistBuddy \
+    -c "Delete :com.apple.developer.applesignin" \
+    "$TEMP_ENTITLEMENTS" >/dev/null 2>&1 || true
+
+LIBRARY_VALIDATION_KEY="com.apple.security.cs.disable-library-validation"
+if [ "$SIGNING_MODE" = "adhoc" ]; then
+    # Hardened runtime rejects ad-hoc third-party frameworks even when the app
+    # and nested code are all ad-hoc signed. This exception is limited to the
+    # explicitly opted-in named-bundle path; real identities retain validation.
+    /usr/libexec/PlistBuddy \
+        -c "Add :$LIBRARY_VALIDATION_KEY bool true" \
+        "$TEMP_ENTITLEMENTS" >/dev/null 2>&1 || \
+        /usr/libexec/PlistBuddy \
+            -c "Set :$LIBRARY_VALIDATION_KEY true" \
+            "$TEMP_ENTITLEMENTS"
+else
+    /usr/libexec/PlistBuddy \
+        -c "Delete :$LIBRARY_VALIDATION_KEY" \
+        "$TEMP_ENTITLEMENTS" >/dev/null 2>&1 || true
+fi
+
+plutil -lint "$TEMP_ENTITLEMENTS" >/dev/null
+mv -fh "$TEMP_ENTITLEMENTS" "$OUTPUT_ENTITLEMENTS"
+printf '%s\n' "$OUTPUT_ENTITLEMENTS"

--- a/desktop/macos/tests/test-prepare-local-dev-entitlements.sh
+++ b/desktop/macos/tests/test-prepare-local-dev-entitlements.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MACOS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+PREPARE_SCRIPT="$MACOS_DIR/scripts/prepare-local-dev-entitlements.sh"
+BASE_ENTITLEMENTS="$MACOS_DIR/Desktop/Omi.entitlements"
+
+fail() {
+    echo "FAIL: $*" >&2
+    exit 1
+}
+
+has_key() {
+    /usr/libexec/PlistBuddy -c "Print :$2" "$1" >/dev/null 2>&1
+}
+
+assert_identity_policy() {
+    local expected="$1" identity="$2" named="$3" allow_adhoc="$4"
+    if "$PREPARE_SCRIPT" --validate-identity \
+        "$identity" "$named" "$allow_adhoc" >/dev/null 2>&1; then
+        [ "$expected" = "pass" ] || fail "unsafe identity policy was accepted"
+    else
+        [ "$expected" = "fail" ] || fail "safe identity policy was rejected"
+    fi
+}
+
+TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/omi-local-entitlements-test.XXXXXX")"
+cleanup() {
+    rm -rf "$TMP_ROOT"
+}
+trap cleanup EXIT
+
+adhoc_path="$TMP_ROOT/adhoc.path"
+development_path="$TMP_ROOT/development.path"
+
+# Prepare opposite signing modes concurrently, as parallel worktrees do.
+"$PREPARE_SCRIPT" \
+    "$BASE_ENTITLEMENTS" "$TMP_ROOT/worktree-a/.dev" \
+    com.omi.omi-bluetooth-quality adhoc >"$adhoc_path" &
+adhoc_pid=$!
+"$PREPARE_SCRIPT" \
+    "$BASE_ENTITLEMENTS" "$TMP_ROOT/worktree-b/.dev" \
+    com.omi.omi-other development >"$development_path" &
+development_pid=$!
+wait "$adhoc_pid"
+wait "$development_pid"
+
+adhoc_entitlements="$(<"$adhoc_path")"
+development_entitlements="$(<"$development_path")"
+[ "$adhoc_entitlements" != "$development_entitlements" ] \
+    || fail "parallel worktrees shared an entitlement path"
+
+has_key "$adhoc_entitlements" "com.apple.developer.applesignin" \
+    && fail "ad-hoc fallback retained Sign in with Apple"
+adhoc_library_validation="$(/usr/libexec/PlistBuddy \
+    -c "Print :com.apple.security.cs.disable-library-validation" \
+    "$adhoc_entitlements")"
+[ "$adhoc_library_validation" = "true" ] \
+    || fail "ad-hoc fallback did not disable library validation"
+
+has_key "$development_entitlements" "com.apple.developer.applesignin" \
+    && fail "development fallback retained Sign in with Apple"
+has_key "$development_entitlements" "com.apple.security.cs.disable-library-validation" \
+    && fail "real-identity fallback disabled library validation"
+
+# Named apps in one worktree also get distinct generated files.
+second_bundle_entitlements="$("$PREPARE_SCRIPT" \
+    "$BASE_ENTITLEMENTS" "$TMP_ROOT/worktree-a/.dev" \
+    com.omi.omi-second adhoc)"
+[ "$adhoc_entitlements" != "$second_bundle_entitlements" ] \
+    || fail "named bundles in one worktree shared an entitlement path"
+
+# Existing output symlinks are replaced atomically, never followed while the
+# plist is mutated.
+symlink_dev_dir="$TMP_ROOT/symlink-worktree/.dev"
+symlink_output_dir="$symlink_dev_dir/local-signing"
+symlink_output="$symlink_output_dir/com.omi.omi-symlink.entitlements"
+symlink_target="$TMP_ROOT/symlink-target.plist"
+mkdir -p "$symlink_output_dir"
+cp "$BASE_ENTITLEMENTS" "$symlink_target"
+ln -s "$symlink_target" "$symlink_output"
+prepared_symlink_output="$("$PREPARE_SCRIPT" \
+    "$BASE_ENTITLEMENTS" "$symlink_dev_dir" \
+    com.omi.omi-symlink adhoc)"
+[ ! -L "$prepared_symlink_output" ] || fail "generated output remained a symlink"
+has_key "$symlink_target" "com.apple.developer.applesignin" \
+    || fail "entitlement generation mutated a symlink target"
+
+directory_symlink_dev_dir="$TMP_ROOT/directory-symlink-worktree/.dev"
+directory_symlink_output_dir="$directory_symlink_dev_dir/local-signing"
+directory_symlink_output="$directory_symlink_output_dir/com.omi.omi-directory.entitlements"
+directory_symlink_target="$TMP_ROOT/external-directory"
+mkdir -p "$directory_symlink_output_dir" "$directory_symlink_target"
+ln -s "$directory_symlink_target" "$directory_symlink_output"
+prepared_directory_output="$("$PREPARE_SCRIPT" \
+    "$BASE_ENTITLEMENTS" "$directory_symlink_dev_dir" \
+    com.omi.omi-directory adhoc)"
+[ ! -L "$prepared_directory_output" ] \
+    || fail "generated output remained a directory symlink"
+[ -f "$prepared_directory_output" ] \
+    || fail "directory symlink was not replaced by a plist"
+[ -z "$(find "$directory_symlink_target" -mindepth 1 -maxdepth 1 -print -quit)" ] \
+    || fail "entitlement plist escaped into a symlinked directory"
+
+assert_identity_policy pass "Apple Development: Test" false 0
+assert_identity_policy pass - true 1
+assert_identity_policy fail - true 0
+assert_identity_policy fail - false 1
+
+# Preparing a named bundle must never mutate the checked-in source plist.
+has_key "$BASE_ENTITLEMENTS" "com.apple.developer.applesignin" \
+    || fail "source entitlements were mutated"
+
+if "$PREPARE_SCRIPT" \
+    "$BASE_ENTITLEMENTS" "$TMP_ROOT/invalid/.dev" \
+    com.omi.invalid invalid >/dev/null 2>&1; then
+    fail "invalid signing mode was accepted"
+fi
+if "$PREPARE_SCRIPT" \
+    "$BASE_ENTITLEMENTS" "$TMP_ROOT/invalid/.dev" \
+    '../escape' adhoc >/dev/null 2>&1; then
+    fail "unsafe bundle ID was accepted"
+fi
+
+echo "local dev entitlement tests passed"


### PR DESCRIPTION
## Summary

- make the documented ad-hoc signing path launch Hardened Runtime named bundles with third-party frameworks
- reject ad-hoc signing unless the bundle is both named and explicitly opted in
- generate fallback entitlements atomically at a per-worktree, per-bundle path instead of a shared `/tmp` file
- add behavioral policy, concurrency, path-validation, and hostile-symlink coverage

## Root cause and durable guard

`OMI_ALLOW_ADHOC_SIGN=1` could sign a named bundle, but macOS Library Validation still rejected ad-hoc Sparkle at launch. The fallback plist was also generated at one global path, so parallel worktrees with real and ad-hoc identities could race, and a stale symlink could redirect plist mutation outside the worktree. An explicit `OMI_SIGN_IDENTITY=-` bypassed the named-bundle opt-in entirely.

The new helper centralizes the local signing policy. Ad-hoc identity is accepted only for an explicitly opted-in named bundle; real identities retain Library Validation. Generated plists live below the worktree's `.dev/local-signing/` directory, are separated by bundle ID, are assembled in a same-directory temporary file, linted, and atomically moved with destination-symlink protection.

## Behavior and risk

- production, beta, and canonical Omi Dev bundles cannot enter the ad-hoc path
- `com.apple.security.cs.disable-library-validation` is added only to opted-in ad-hoc named bundles
- Sign in with Apple remains stripped from all named-bundle fallback signatures
- real Apple Development and Developer ID signing behavior is unchanged
- no release, notarization, provisioning-profile, or shipped entitlement changes are involved

## Verification

- `desktop/macos/test.sh` — launcher scripts, 328 Rust tests, and 238 isolated Swift suites passed
- helper regression — opposite signing modes in parallel worktrees, multiple named bundles, invalid modes/paths, and file/directory symlink attacks passed
- `bash -n` and `shellcheck` on the new helper and test
- fresh `omi-signing-quality` bundle built through `run.sh --yolo`, signed ad-hoc with Hardened Runtime, installed, launched, and answered the automation bridge on port 47895
- generated installed-app entitlements contain the scoped Library Validation exception and no Sign in with Apple entitlement
- `make preflight`
- independent agent review approved

## Product invariants

None affected (`scripts/pr-preflight --suggest`).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9546?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

