### PR TITLE
feat: replace notifications loading spinner with shimmer

### DIFF
--- a/app/lib/pages/settings/notifications_settings_page.dart
+++ b/app/lib/pages/settings/notifications_settings_page.dart
@@ -5,12 +5,58 @@ import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:omi/backend/http/api/users.dart';
 import 'package:omi/backend/preferences.dart';
 import 'package:omi/utils/l10n_extensions.dart';
+import 'package:omi/widgets/shimmer_with_timeout.dart';
 
 class NotificationsSettingsPage extends StatefulWidget {
   const NotificationsSettingsPage({super.key});
 
   @override
   State<NotificationsSettingsPage> createState() => _NotificationsSettingsPageState();
+}
+
+class NotificationsSettingsLoadingShimmer extends StatelessWidget {
+  const NotificationsSettingsLoadingShimmer({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final placeholderColor = Colors.grey.shade800;
+
+    Widget placeholder({required double height, double? width, double radius = 8}) {
+      return Container(
+        width: width,
+        height: height,
+        decoration: BoxDecoration(color: placeholderColor, borderRadius: BorderRadius.circular(radius)),
+      );
+    }
+
+    return SingleChildScrollView(
+      padding: const EdgeInsets.all(20),
+      child: ShimmerWithTimeout(
+        baseColor: placeholderColor,
+        highlightColor: Colors.grey.shade600,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            placeholder(width: 190, height: 24),
+            const SizedBox(height: 12),
+            placeholder(height: 14),
+            const SizedBox(height: 8),
+            placeholder(width: 250, height: 14),
+            const SizedBox(height: 16),
+            placeholder(height: 172, radius: 20),
+            const SizedBox(height: 32),
+            placeholder(width: 150, height: 24),
+            const SizedBox(height: 12),
+            placeholder(height: 14),
+            const SizedBox(height: 8),
+            placeholder(width: 220, height: 14),
+            const SizedBox(height: 16),
+            placeholder(height: 145, radius: 20),
+          ],
+        ),
+      ),
+    );
+  }
 }
 
 class _NotificationsSettingsPageState extends State<NotificationsSettingsPage> {
@@ -204,7 +250,7 @@ class _NotificationsSettingsPageState extends State<NotificationsSettingsPage> {
         elevation: 0,
       ),
       body: _isLoading
-          ? const Center(child: CircularProgressIndicator(color: Colors.white))
+          ? const NotificationsSettingsLoadingShimmer()
           : SingleChildScrollView(
               padding: const EdgeInsets.all(20),
               child: Column(

--- a/app/test/widgets/notifications_settings_loading_test.dart
+++ b/app/test/widgets/notifications_settings_loading_test.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shimmer/shimmer.dart';
+
+import 'package:omi/pages/settings/notifications_settings_page.dart';
+
+void main() {
+  testWidgets('shows a shimmer skeleton instead of a progress spinner', (tester) async {
+    tester.view.physicalSize = const Size(1179, 2556);
+    tester.view.devicePixelRatio = 3;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData.dark(),
+        home: const Scaffold(
+          backgroundColor: Color(0xFF000000),
+          body: NotificationsSettingsLoadingShimmer(),
+        ),
+      ),
+    );
+
+    expect(find.byType(Shimmer), findsOneWidget);
+    expect(find.byType(CircularProgressIndicator), findsNothing);
+  });
+}


### PR DESCRIPTION
## What changed and why

Replaced the circular loading indicator on Settings → Notifications with a shimmer skeleton that mirrors the loaded page structure. This was requested directly by a maintainer; there is no associated GitHub issue.

## Product invariants affected

none

## How it was verified

- Rendered the production loading widget at an iPhone-sized viewport on macOS and visually inspected the result.
- Confirmed the shimmer displays without overflow and replaces the circular progress indicator.
- Ran the targeted notification and shimmer widget tests; all 3 passed.
- Ran the full Flutter suite on both this branch and the exact pre-change commit. Both produced the same 8 unrelated existing failures.
- The full user-facing navigation path was not exercised on a physical device because iOS Developer Mode could not be enabled.

## Tests

Added `app/test/widgets/notifications_settings_loading_test.dart`, which verifies that the loading state displays a shimmer and does not contain a `CircularProgressIndicator`.

The existing `app/test/widgets/shimmer_with_timeout_test.dart` also verifies the shared shimmer timeout and disposal behavior.

## Root cause and durable guard (bug fixes)

N/A — this is a requested loading-state UX improvement, not a bug fix. The new widget test guards against replacing the shimmer with a circular progress indicator in the future.

## Scoped cleanups 

none

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9547?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

