### PR TITLE
fix(backend): use http:// for parakeet ILB URL in Cloud Run services

### DIFF
--- a/backend/deploy/runtime_env.yaml
+++ b/backend/deploy/runtime_env.yaml
@@ -568,7 +568,7 @@ environments:
               value: prod
               category: runtime_identity
             HOSTED_PARAKEET_API_URL:
-              value: https://parakeet.omi.me
+              value: http://parakeet.omi.me
               category: service_discovery
             POSTHOG_HOST:
               value: https://app.posthog.com
@@ -648,7 +648,7 @@ environments:
               value: prod
               category: runtime_identity
             HOSTED_PARAKEET_API_URL:
-              value: https://parakeet.omi.me
+              value: http://parakeet.omi.me
               category: service_discovery
             POSTHOG_HOST:
               value: https://app.posthog.com
@@ -703,7 +703,7 @@ environments:
               value: prod
               category: runtime_identity
             HOSTED_PARAKEET_API_URL:
-              value: https://parakeet.omi.me
+              value: http://parakeet.omi.me
               category: service_discovery
             POSTHOG_HOST:
               value: https://app.posthog.com

--- a/backend/tests/unit/test_backend_runtime_env_validator.py
+++ b/backend/tests/unit/test_backend_runtime_env_validator.py
@@ -1191,17 +1191,26 @@ def test_repo_ilb_endpoints_use_http_scheme(env_name):
     env_config = validator._get_env_config(manifest, env_name)
 
     violations = []
-    for surface in ('gke', 'cloud_run'):
-        surface_cfg = env_config.get(surface, {})
-        services = surface_cfg.get('services', {})
-        for svc_name, svc_cfg in services.items():
-            env_vars = svc_cfg.get('env', {})
-            for var_name in _ILB_ENV_VARS:
-                if var_name not in env_vars:
-                    continue
-                value = env_vars[var_name]
-                url = value.get('value', '') if isinstance(value, dict) else value
-                if url.startswith('https://'):
-                    violations.append(f'{env_name}/{surface}/{svc_name}: {var_name}={url}')
+
+    def _check_service(surface, svc_name, svc_cfg):
+        env_vars = svc_cfg.get('env', {})
+        for var_name in _ILB_ENV_VARS:
+            if var_name not in env_vars:
+                continue
+            value = env_vars[var_name]
+            url = value.get('value', '') if isinstance(value, dict) else value
+            if url.startswith('https://'):
+                violations.append(f'{env_name}/{surface}/{svc_name}: {var_name}={url}')
+
+    # cloud_run: nested under 'services' key
+    cloud_run_cfg = env_config.get('cloud_run', {})
+    for svc_name, svc_cfg in cloud_run_cfg.get('services', {}).items():
+        _check_service('cloud_run', svc_name, svc_cfg)
+
+    # gke: service entries are direct children (not under 'services')
+    gke_cfg = env_config.get('gke', {})
+    for svc_name, svc_cfg in gke_cfg.items():
+        if isinstance(svc_cfg, dict) and 'env' in svc_cfg:
+            _check_service('gke', svc_name, svc_cfg)
 
     assert violations == [], f'ILB endpoints must use http:// (no TLS): {violations}'

--- a/backend/tests/unit/test_backend_runtime_env_validator.py
+++ b/backend/tests/unit/test_backend_runtime_env_validator.py
@@ -799,7 +799,7 @@ def test_provisional_prod_endpoint_requires_presence_but_not_exact_value(tmp_pat
                                         'value': 'TBD_STABLE_PRIVATE_ENDPOINT',
                                         'provisional': True,
                                     },
-                                    'HOSTED_PARAKEET_API_URL': {'value': 'https://parakeet.omi.me'},
+                                    'HOSTED_PARAKEET_API_URL': {'value': 'http://parakeet.omi.me'},
                                 },
                                 'secrets': {
                                     'OMI_LLM_GATEWAY_SERVICE_TOKEN': {
@@ -831,7 +831,7 @@ def test_provisional_prod_endpoint_requires_presence_but_not_exact_value(tmp_pat
     "backend": {
         "env": [
           {"name": "OMI_LLM_GATEWAY_URL", "value": "http://stable-private-endpoint"},
-          {"name": "HOSTED_PARAKEET_API_URL", "value": "https://parakeet.omi.me"},
+          {"name": "HOSTED_PARAKEET_API_URL", "value": "http://parakeet.omi.me"},
           {"name": "OMI_LLM_GATEWAY_SERVICE_TOKEN", "valueFrom": {"secretKeyRef": {"name": "OMI_LLM_GATEWAY_SERVICE_TOKEN"}}},
           {"name": "STT_PRERECORDED_MODEL", "valueFrom": {"secretKeyRef": {"name": "STT_PRERECORDED_MODEL"}}},
           {"name": "DEEPGRAM_API_KEY", "valueFrom": {"secretKeyRef": {"name": "DEEPGRAM_API_KEY"}}},
@@ -1178,3 +1178,30 @@ def test_sync_backfill_co_deploy_is_required_per_workflow(tmp_path):
     assert not any(
         str(complete) in error.scope and 'without backend-sync-backfill' in error.message for error in errors
     )
+
+
+_ILB_ENV_VARS = ['HOSTED_PARAKEET_API_URL', 'HOSTED_TRANSLATION_API_URL']
+
+
+@pytest.mark.parametrize('env_name', ['dev', 'prod'])
+def test_repo_ilb_endpoints_use_http_scheme(env_name):
+    """ILB endpoints are HTTP-only (no TLS) — https:// causes timeouts."""
+    validator = load_validator()
+    manifest = validator._load_yaml(validator.DEFAULT_MANIFEST)
+    env_config = validator._get_env_config(manifest, env_name)
+
+    violations = []
+    for surface in ('gke', 'cloud_run'):
+        surface_cfg = env_config.get(surface, {})
+        services = surface_cfg.get('services', {})
+        for svc_name, svc_cfg in services.items():
+            env_vars = svc_cfg.get('env', {})
+            for var_name in _ILB_ENV_VARS:
+                if var_name not in env_vars:
+                    continue
+                value = env_vars[var_name]
+                url = value.get('value', '') if isinstance(value, dict) else value
+                if url.startswith('https://'):
+                    violations.append(f'{env_name}/{surface}/{svc_name}: {var_name}={url}')
+
+    assert violations == [], f'ILB endpoints must use http:// (no TLS): {violations}'


### PR DESCRIPTION
Fixes #9548

## Summary

- Reverts `https://` → `http://` for `HOSTED_PARAKEET_API_URL` in prod Cloud Run services (backend, backend-sync, backend-integration) in `runtime_env.yaml`
- The parakeet ILB (`parakeet.omi.me`) serves HTTP-only on port 80 (no TLS termination) — `https://` causes connection timeouts on all voice message transcription
- Adds `test_repo_ilb_endpoints_use_http_scheme` regression test that validates all ILB endpoint env vars use `http://` scheme across all environments
- Fixes test fixtures that incorrectly used `https://parakeet.omi.me`

## Root Cause

PR #9437 (commit c70d19dc26, "harden backend runtime") changed the scheme to `https://` for all 3 prod Cloud Run entries. The GKE backend-listen entry was unaffected (uses ClusterIP).

## Changes

| File | Change |
|------|--------|
| `backend/deploy/runtime_env.yaml` | `https://parakeet.omi.me` → `http://parakeet.omi.me` for 3 Cloud Run services |
| `backend/tests/unit/test_backend_runtime_env_validator.py` | Add ILB scheme validation test + fix `https://` in test fixtures |

## Audit

Checked all `*.omi.me` and `*.omiapi.com` ILB URLs in `runtime_env.yaml`:
- `parakeet.omi.me` — **fixed** (3 Cloud Run entries: http)
- `nllb.omi.me` — already http (correct)
- No diarizer/vad/pusher ILB URLs in runtime_env (they use ClusterIP within GKE)
- All dev URLs (`*.omiapi.com`) — already http (correct)

## Security

No new exposure. `parakeet.omi.me` resolves to private `172.16.x.x` ILB. Cloud Run uses VPC egress `private-ranges-only`. The ILB is intentionally HTTP-only (`gce-internal`, `allow-http: true`, no TLS block in Helm values).

## Impact

Voice message transcription via parakeet broken on all 3 prod Cloud Run services since 01:13 UTC today.

## Testing

- `cd backend && python3 -m pytest tests/unit/test_backend_runtime_env_validator.py tests/unit/test_render_backend_runtime_env.py -q` → 43 passed
- `python3 backend/scripts/validate-backend-runtime-env.py --env prod --check-rendered-cloud-run` → passed

## Test Plan

- [ ] Verify Cloud Run services can reach `http://parakeet.omi.me/health` after deploy
- [ ] Verify voice message transcription works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)