### PR TITLE
refactor(desktop): converge Bluetooth session ownership

### DIFF
--- a/desktop/macos/Desktop/Package.swift
+++ b/desktop/macos/Desktop/Package.swift
@@ -68,6 +68,7 @@ let package = Package(
         "Theme",
         "OmiSupport",
         "OmiWAL",
+        "Bluetooth/ARCHITECTURE.md",
       ],
       resources: [
         .process("GoogleService-Info.plist"),

--- a/desktop/macos/Desktop/Sources/Audio/AudioSourceManager.swift
+++ b/desktop/macos/Desktop/Sources/Audio/AudioSourceManager.swift
@@ -119,7 +119,7 @@ final class AudioSourceManager: ObservableObject {
             .store(in: &cancellables)
 
         // Monitor device connection state
-        deviceProvider.$isConnected
+        deviceProvider.isConnectedPublisher
             .receive(on: DispatchQueue.main)
             .sink { [weak self] isConnected in
                 self?.handleDeviceConnectionChanged(isConnected: isConnected)

--- a/desktop/macos/Desktop/Sources/Bluetooth/ARCHITECTURE.md
+++ b/desktop/macos/Desktop/Sources/Bluetooth/ARCHITECTURE.md
@@ -1,0 +1,83 @@
+# Bluetooth Architecture
+
+The Bluetooth stack separates physical CoreBluetooth events from the logical
+device session shown by the app. One type owns each kind of state:
+
+```
+BluetoothManager (central events and discovery)
+  -> BLEPhysicalDriving (CoreBluetooth side effects)
+  -> BleTransport (one physical transport generation)
+  -> BaseDeviceConnection (one device lifecycle generation)
+  -> DeviceSessionCoordinator (canonical logical session)
+  -> DeviceProvider (read-only UI projection)
+```
+
+## Ownership
+
+- `BluetoothManager` owns scanning, discovered peripherals, typed central
+  events, and per-peripheral connection leases. Connection lifecycle must not
+  be broadcast through `NotificationCenter`.
+- `BleTransport` owns characteristic discovery, reads, writes, notification
+  broadcasts, and physical disposal for one `sessionGeneration`.
+- `BaseDeviceConnection` owns the shared connect/prepare/teardown sequence.
+  Device subclasses implement only `prepareDeviceAfterConnect`,
+  `teardownDevice`, and (when needed) `performDeviceUnpair`.
+- `DeviceSessionCoordinator` is the sole authority for logical phases, pairing,
+  active connection identity, reconnect scheduling, and generation fencing.
+- `DeviceProvider` publishes the coordinator snapshot and display-oriented
+  battery/storage/firmware state. It must not maintain parallel connection
+  booleans, active-connection storage, or reconnect timers.
+
+## Reliability contracts
+
+1. Every logical connect attempt receives a monotonically increasing
+   generation. Callbacks from any older connection are ignored.
+   CoreBluetooth connection callbacks additionally carry a manager lease token;
+   a cancelled lease remains fenced until a terminal central callback or
+   explicit central reset, so a replacement transport cannot consume it.
+   Scheduled reconnects carry their generation and attempt back into the
+   coordinator for revalidation immediately before connection starts.
+   Only failures from a validated reconnect request schedule another retry;
+   an explicit selection failure never falls back to a previously paired
+   device.
+2. `DeviceOperationBroker` owns callback, timeout, cancellation, and disconnect
+   races. A handle includes both key and token; a key alone never completes an
+   operation. Callback completion drains the physical start task before the
+   waiter resumes, so a device response cannot outrun its BLE write callback.
+3. CoreBluetooth and several device protocols return only a characteristic or
+   command key, with no token. If such an operation terminates before its
+   callback arrives, `UncorrelatedOperationGate` poisons that key until teardown.
+   Retrying in the same physical session would let the old callback masquerade
+   as the new response.
+4. Adapter commands that share one BLE write characteristic run through
+   `DeviceCommandQueue`. Command IDs can correlate device responses, but they
+   cannot make simultaneous characteristic write callbacks distinguishable.
+   Teardown closes and drains the queue before response brokers are reset.
+5. Characteristic notifications are multicast with one continuation per
+   subscriber. Cancelling a consumer removes only that subscriber; later
+   subscribers can restart within the same physical session.
+6. Bee and PLAUD audio use `DeviceAudioStreamController`: the first subscriber
+   owns setup, the last subscriber leaving cancels and joins setup before a
+   compensating stop, and every subscriber receives every active-session frame.
+   Frames observed during setup or teardown are dropped. A stop that cannot be
+   confirmed fences the controller and disconnects the physical session; it
+   never layers a replacement recording over ambiguous state.
+7. A connection object represents exactly one session generation. Shared setup
+   runs once, and every explicit or unexpected teardown path joins one retained
+   teardown task through device cleanup and transport disposal.
+8. Disposal first claims the transport, then drains all waiters and streams,
+   requests physical disconnect exactly once, and finally detaches delegates.
+
+## Testing seams
+
+- Inject `DeviceOperationClock` to advance timeouts without wall-clock sleeps.
+- Inject `DeviceSessionScheduling` to drive reconnect policy deterministically.
+- Inject `BLEPhysicalDriving` to test transport disposal without Bluetooth
+  hardware or private CoreBluetooth initializers.
+- Use a fake `DeviceTransport` to exercise the production
+  `BaseDeviceConnection` template lifecycle.
+
+When adding a device, put device-specific protocol parsing in a connection
+subclass and keep lifecycle ownership in the base/coordinator layers. When a
+wire response cannot carry a correlation token, use the shared uncorrelated
+operation gate rather than a raw continuation dictionary or ad-hoc timeout.

--- a/desktop/macos/Desktop/Sources/Bluetooth/BluetoothManager.swift
+++ b/desktop/macos/Desktop/Sources/Bluetooth/BluetoothManager.swift
@@ -3,12 +3,10 @@ import CoreBluetooth
 import Foundation
 import os.log
 
-// MARK: - Notification Names for BLE Events
-
-extension Notification.Name {
-    static let bleDeviceConnected = Notification.Name("bleDeviceConnected")
-    static let bleDeviceDisconnected = Notification.Name("bleDeviceDisconnected")
-    static let bleDeviceFailedToConnect = Notification.Name("bleDeviceFailedToConnect")
+enum BluetoothCentralEvent: Equatable, Sendable {
+    case connected(lease: BluetoothConnectionLease)
+    case failedToConnect(lease: BluetoothConnectionLease, reason: String)
+    case disconnected(lease: BluetoothConnectionLease, reason: String?)
 }
 
 @MainActor
@@ -19,6 +17,7 @@ protocol DeviceBluetoothManaging: AnyObject {
     var bluetoothStatePublisher: AnyPublisher<CBManagerState, Never> { get }
     var isScanningPublisher: AnyPublisher<Bool, Never> { get }
     var discoveredDevicesPublisher: AnyPublisher<[BtDevice], Never> { get }
+    var centralEventPublisher: AnyPublisher<BluetoothCentralEvent, Never> { get }
 
     func prepareForStateUpdates()
     func startScanning(timeout: TimeInterval)
@@ -38,15 +37,17 @@ final class BluetoothManager: NSObject, ObservableObject {
 
     // MARK: - Private Properties
 
-    /// The underlying CBCentralManager (exposed for transport creation)
+    /// The underlying CBCentralManager
     /// Created lazily to avoid triggering Bluetooth permission dialog at app startup
-    private(set) lazy var centralManager: CBCentralManager = {
+    private lazy var centralManager: CBCentralManager = {
         let manager = CBCentralManager(delegate: nil, queue: nil)
         manager.delegate = self
         return manager
     }()
     private var scanTimer: Timer?
     private var discoveredPeripherals: [UUID: CBPeripheral] = [:]
+    private let centralEventSubject = PassthroughSubject<BluetoothCentralEvent, Never>()
+    private let connectionLeases = BluetoothConnectionLeaseRegistry()
 
     private let logger = Logger(subsystem: "me.omi.desktop", category: "BluetoothManager")
 
@@ -65,7 +66,7 @@ final class BluetoothManager: NSObject, ObservableObject {
     /// Start scanning for supported BLE devices
     /// - Parameter timeout: Scan duration in seconds (default: 5)
     func startScanning(timeout: TimeInterval = 5.0) {
-        guard bluetoothState == .poweredOn else {
+        guard centralManager.state == .poweredOn else {
             logger.warning("Cannot scan: Bluetooth not powered on (state: \(String(describing: self.bluetoothState)))")
             return
         }
@@ -125,38 +126,32 @@ final class BluetoothManager: NSObject, ObservableObject {
         return discoveredPeripherals[uuid]
     }
 
-    /// Connect to a device
-    /// - Parameter device: The device to connect to
-    func connect(to device: BtDevice) {
-        guard let peripheral = peripheral(for: device) else {
-            logger.error("Cannot connect: peripheral not found for device \(device.id)")
-            return
-        }
-
-        logger.info("Connecting to \(device.displayName) (\(device.id))")
-        centralManager.connect(peripheral, options: nil)
-    }
-
-    /// Disconnect from a device
-    /// - Parameter device: The device to disconnect from
-    func disconnect(from device: BtDevice) {
-        guard let peripheral = peripheral(for: device) else {
-            logger.warning("Cannot disconnect: peripheral not found for device \(device.id)")
-            return
-        }
-
-        logger.info("Disconnecting from \(device.displayName)")
-        centralManager.cancelPeripheralConnection(peripheral)
-    }
-
-    /// Cancel connection to a peripheral
-    func cancelConnection(_ peripheral: CBPeripheral) {
-        centralManager.cancelPeripheralConnection(peripheral)
-    }
-
     /// Check if Bluetooth is available and ready
     var isBluetoothReady: Bool {
         bluetoothState == .poweredOn
+    }
+
+    func beginConnection(
+        to peripheral: CBPeripheral,
+        sessionGeneration: UInt64
+    ) throws -> BluetoothConnectionLease {
+        guard bluetoothState == .poweredOn else {
+            throw BluetoothConnectionLeaseError.centralUnavailable
+        }
+        let lease = try connectionLeases.begin(
+            peripheralID: peripheral.identifier,
+            sessionGeneration: sessionGeneration
+        )
+        centralManager.connect(peripheral, options: nil)
+        return lease
+    }
+
+    func cancelConnection(
+        to peripheral: CBPeripheral,
+        lease: BluetoothConnectionLease
+    ) {
+        guard connectionLeases.requestCancellation(lease) else { return }
+        centralManager.cancelPeripheralConnection(peripheral)
     }
 
     /// Trigger the Bluetooth permission dialog by attempting to scan
@@ -200,7 +195,7 @@ final class BluetoothManager: NSObject, ObservableObject {
     }
 }
 
-extension BluetoothManager: DeviceBluetoothManaging {
+extension BluetoothManager: DeviceBluetoothManaging, BluetoothCentralConnectionControlling {
     var currentBluetoothState: CBManagerState { bluetoothState }
     var currentIsScanning: Bool { isScanning }
     var currentDiscoveredDevices: [BtDevice] { discoveredDevices }
@@ -212,6 +207,9 @@ extension BluetoothManager: DeviceBluetoothManaging {
     }
     var discoveredDevicesPublisher: AnyPublisher<[BtDevice], Never> {
         $discoveredDevices.eraseToAnyPublisher()
+    }
+    var centralEventPublisher: AnyPublisher<BluetoothCentralEvent, Never> {
+        centralEventSubject.eraseToAnyPublisher()
     }
 
     func prepareForStateUpdates() {
@@ -247,6 +245,15 @@ extension BluetoothManager: CBCentralManagerDelegate {
             // Stop scanning if Bluetooth becomes unavailable
             if central.state != .poweredOn && self.isScanning {
                 self.stopScanning()
+            }
+
+            if central.state != .poweredOn {
+                let reason = "Bluetooth central became \(newStateDesc)"
+                for lease in self.connectionLeases.reset() {
+                    self.centralEventSubject.send(
+                        .disconnected(lease: lease, reason: reason)
+                    )
+                }
             }
         }
     }
@@ -288,12 +295,20 @@ extension BluetoothManager: CBCentralManagerDelegate {
         Task { @MainActor in
             self.logger.info("Connected to \(peripheral.name ?? peripheral.identifier.uuidString)")
 
-            // Post notification for BleTransport to handle
-            NotificationCenter.default.post(
-                name: .bleDeviceConnected,
-                object: nil,
-                userInfo: ["peripheralId": peripheral.identifier]
+            guard let resolution = self.connectionLeases.markConnected(
+                peripheralID: peripheral.identifier
+            ) else {
+                self.logger.warning("Ignoring unleased CoreBluetooth connect callback for \(peripheral.identifier)")
+                central.cancelPeripheralConnection(peripheral)
+                return
+            }
+
+            self.centralEventSubject.send(
+                .connected(lease: resolution.lease)
             )
+            if resolution.shouldCancel {
+                central.cancelPeripheralConnection(peripheral)
+            }
         }
     }
 
@@ -305,14 +320,18 @@ extension BluetoothManager: CBCentralManagerDelegate {
         Task { @MainActor in
             self.logger.error("Failed to connect to \(peripheral.name ?? peripheral.identifier.uuidString): \(error?.localizedDescription ?? "unknown error")")
 
-            // Post notification for BleTransport to handle
-            NotificationCenter.default.post(
-                name: .bleDeviceFailedToConnect,
-                object: nil,
-                userInfo: [
-                    "peripheralId": peripheral.identifier,
-                    "error": error as Any
-                ]
+            guard let lease = self.connectionLeases.finish(
+                peripheralID: peripheral.identifier
+            ) else {
+                self.logger.warning("Ignoring unleased CoreBluetooth connection failure for \(peripheral.identifier)")
+                return
+            }
+
+            self.centralEventSubject.send(
+                .failedToConnect(
+                    lease: lease,
+                    reason: error?.localizedDescription ?? "Unknown error"
+                )
             )
         }
     }
@@ -329,14 +348,18 @@ extension BluetoothManager: CBCentralManagerDelegate {
                 self.logger.info("Disconnected from \(peripheral.name ?? peripheral.identifier.uuidString)")
             }
 
-            // Post notification for BleTransport to handle
-            NotificationCenter.default.post(
-                name: .bleDeviceDisconnected,
-                object: nil,
-                userInfo: [
-                    "peripheralId": peripheral.identifier,
-                    "error": error as Any
-                ]
+            guard let lease = self.connectionLeases.finish(
+                peripheralID: peripheral.identifier
+            ) else {
+                self.logger.warning("Ignoring unleased CoreBluetooth disconnect callback for \(peripheral.identifier)")
+                return
+            }
+
+            self.centralEventSubject.send(
+                .disconnected(
+                    lease: lease,
+                    reason: error?.localizedDescription
+                )
             )
         }
     }

--- a/desktop/macos/Desktop/Sources/Bluetooth/Connections/BeeDeviceConnection.swift
+++ b/desktop/macos/Desktop/Sources/Bluetooth/Connections/BeeDeviceConnection.swift
@@ -1,4 +1,3 @@
-import Combine
 import CoreBluetooth
 import Foundation
 import os.log
@@ -24,39 +23,58 @@ final class BeeDeviceConnection: BaseDeviceConnection {
     private let logger = Logger(subsystem: "me.omi.desktop", category: "BeeDeviceConnection")
 
     private var audioBuffer = [UInt8]()
-    private var audioStreamSubject = PassthroughSubject<Data, Error>()
     private var controlSubscription: Task<Void, Never>?
     private var audioSubscription: Task<Void, Never>?
-    private var responseCompleters: [UInt16: CheckedContinuation<[UInt8]?, Never>] = [:]
-    private var isRecording = false
+    private let responseOperations: DeviceOperationBroker<UInt16, Data>
+    private let responseGate = UncorrelatedOperationGate<UInt16>()
+    private let commandQueue = DeviceCommandQueue()
+    private var audioStartAttempted = false
+    private lazy var audioStreamController = DeviceAudioStreamController(
+        start: { [weak self] in
+            guard let self else { throw DeviceTransportError.disposed }
+            try await self.startAudioSession()
+        },
+        stop: { [weak self] in
+            guard let self else { return }
+            try await self.stopAudioSession()
+        }
+    )
 
     // MARK: - Initialization
 
-    override init(device: BtDevice, transport: DeviceTransport) {
-        super.init(device: device, transport: transport)
+    override init(
+        device: BtDevice,
+        transport: DeviceTransport,
+        operationClock: any DeviceOperationClock = ContinuousDeviceOperationClock()
+    ) {
+        self.responseOperations = DeviceOperationBroker(clock: operationClock)
+        super.init(
+            device: device,
+            transport: transport,
+            operationClock: operationClock
+        )
     }
 
     // MARK: - Connection
 
-    override func connect() async throws {
-        try await super.connect()
-        try? await Task.sleep(nanoseconds: 1_000_000_000)
+    override func prepareDeviceAfterConnect() async throws {
+        try await operationClock.sleep(for: .seconds(1))
 
         startControlListener()
         startAudioListener()
     }
 
-    override func disconnect() async {
-        if isRecording {
-            _ = try? await sendCommand(cmdId: Command.mute, payload: [0x00])
-        }
+    override func teardownDevice() async {
+        await audioStreamController.finish()
+        await commandQueue.close()
+        audioBuffer.removeAll(keepingCapacity: false)
 
         controlSubscription?.cancel()
         audioSubscription?.cancel()
         controlSubscription = nil
         audioSubscription = nil
-
-        await super.disconnect()
+        await responseOperations.cancelAll(reason: .disconnected)
+        responseGate.reset()
     }
 
     // MARK: - Listeners
@@ -88,7 +106,7 @@ final class BeeDeviceConnection: BaseDeviceConnection {
             do {
                 for try await data in stream {
                     if let frame = self?.processAudioPacket(Array(data)) {
-                        self?.audioStreamSubject.send(Data(frame))
+                        self?.audioStreamController.yield(Data(frame))
                     }
                 }
             } catch {
@@ -99,7 +117,9 @@ final class BeeDeviceConnection: BaseDeviceConnection {
 
     // MARK: - Response Handling
 
-    private func handleControlResponse(_ data: [UInt8]) {
+    /// Parses one physical control notification. Internal for deterministic
+    /// command-correlation tests without Bluetooth hardware.
+    func handleControlResponse(_ data: [UInt8]) {
         guard data.count >= 2 else { return }
 
         let responseCode = UInt16(data[0]) | (UInt16(data[1]) << 8)
@@ -110,18 +130,26 @@ final class BeeDeviceConnection: BaseDeviceConnection {
             let echoedCmd = UInt16(payload[0]) | (UInt16(payload[1]) << 8)
             let actualPayload = payload.count > 2 ? Array(payload.dropFirst(2)) : []
 
-            if let continuation = responseCompleters.removeValue(forKey: echoedCmd) {
-                continuation.resume(returning: actualPayload)
-            }
-        } else if let continuation = responseCompleters.removeValue(forKey: responseCode) {
-            continuation.resume(returning: payload)
+            completeResponse(commandID: echoedCmd, payload: actualPayload)
+        } else {
+            completeResponse(commandID: responseCode, payload: payload)
+        }
+    }
+
+    private func completeResponse(commandID: UInt16, payload: [UInt8]) {
+        guard let handle = responseGate.takeHandleForCallback(key: commandID) else { return }
+        Task {
+            await responseOperations.succeed(
+                handle: handle,
+                value: Data(payload)
+            )
         }
     }
 
     // MARK: - Audio Processing
 
     /// Process AAC audio packet with ADTS framing
-    private func processAudioPacket(_ data: [UInt8]) -> [UInt8]? {
+    func processAudioPacket(_ data: [UInt8]) -> [UInt8]? {
         guard data.count >= 2 else { return nil }
 
         audioBuffer.append(contentsOf: data.dropFirst(2))
@@ -140,7 +168,7 @@ final class BeeDeviceConnection: BaseDeviceConnection {
     /// at the head and every later packet re-hit it — audio went permanently
     /// silent while the buffer grew without bound. Treat `< 7` as a false sync and
     /// advance one byte so the scanner keeps making progress.
-    static func nextADTSFrame(from buffer: inout [UInt8]) -> [UInt8]? {
+    nonisolated static func nextADTSFrame(from buffer: inout [UInt8]) -> [UInt8]? {
         while buffer.count >= 7 {
             // Look for ADTS sync word (0xFF 0xFx)
             guard buffer[0] == 0xFF, (buffer[1] & 0xF0) == 0xF0 else {
@@ -172,24 +200,44 @@ final class BeeDeviceConnection: BaseDeviceConnection {
     // MARK: - Command Sending
 
     private func sendCommand(cmdId: UInt16, payload: [UInt8]) async throws -> [UInt8]? {
+        try await commandQueue.run { [weak self] in
+            guard let self else { throw DeviceTransportError.disposed }
+            return try await self.sendCommandSerially(cmdId: cmdId, payload: payload)
+        }
+    }
+
+    private func sendCommandSerially(cmdId: UInt16, payload: [UInt8]) async throws -> [UInt8]? {
+        guard responseGate.canStart(cmdId) else {
+            throw DeviceConnectionError.operationFailed(
+                "A previous command response is ambiguous; reconnect the device"
+            )
+        }
         let command: [UInt8] = [UInt8(cmdId & 0xFF), UInt8((cmdId >> 8) & 0xFF)] + payload
 
-        try await transport.writeCharacteristic(
-            data: Data(command),
-            serviceUUID: DeviceUUIDs.Bee.service,
-            characteristicUUID: CBUUID(string: Self.controlCharacteristicUUID),
-            withResponse: true
-        )
-
-        return await withCheckedContinuation { continuation in
-            responseCompleters[cmdId] = continuation
-
-            Task {
-                try? await Task.sleep(nanoseconds: 5_000_000_000) // 5 second timeout
-                if let cont = responseCompleters.removeValue(forKey: cmdId) {
-                    cont.resume(returning: nil)
+        do {
+            let response = try await responseOperations.perform(
+                key: cmdId,
+                timeout: .seconds(5),
+                onTerminal: { [weak self] handle, termination in
+                    self?.responseGate.terminal(handle: handle, termination: termination)
                 }
+            ) { [weak self] handle in
+                guard let self else { throw DeviceTransportError.disposed }
+                guard self.responseGate.register(handle) else {
+                    throw DeviceConnectionError.operationFailed(
+                        "Command callback identity is no longer trustworthy"
+                    )
+                }
+                try await self.transport.writeCharacteristic(
+                    data: Data(command),
+                    serviceUUID: DeviceUUIDs.Bee.service,
+                    characteristicUUID: CBUUID(string: Self.controlCharacteristicUUID),
+                    withResponse: true
+                )
             }
+            return Array(response)
+        } catch DeviceOperationBrokerError.timedOut {
+            return nil
         }
     }
 
@@ -228,7 +276,7 @@ final class BeeDeviceConnection: BaseDeviceConnection {
     override func getBatteryLevelStream() -> AsyncThrowingStream<Int, Error> {
         // Bee uses command-based battery retrieval, poll every 60 seconds
         return AsyncThrowingStream { [weak self] continuation in
-            Task { [weak self] in
+            let pollingTask = Task { [weak self] in
                 guard let self = self else {
                     continuation.finish()
                     return
@@ -245,7 +293,12 @@ final class BeeDeviceConnection: BaseDeviceConnection {
 
                 // Poll every 60 seconds
                 while await self.isConnected() {
-                    try? await Task.sleep(nanoseconds: 60_000_000_000)
+                    do {
+                        try await self.operationClock.sleep(for: .seconds(60))
+                    } catch {
+                        break
+                    }
+                    guard !Task.isCancelled else { break }
 
                     let level = await self.getBatteryLevel()
                     if level >= 0 && level != lastLevel {
@@ -255,6 +308,9 @@ final class BeeDeviceConnection: BaseDeviceConnection {
                 }
 
                 continuation.finish()
+            }
+            continuation.onTermination = { @Sendable _ in
+                pollingTask.cancel()
             }
         }
     }
@@ -266,37 +322,67 @@ final class BeeDeviceConnection: BaseDeviceConnection {
     }
 
     override func getAudioStream() -> AsyncThrowingStream<Data, Error> {
-        return AsyncThrowingStream { [weak self] continuation in
-            guard let self = self else {
-                continuation.finish()
-                return
-            }
+        audioStreamController.makeStream()
+    }
 
-            Task { [weak self] in
-                guard let self = self else {
-                    continuation.finish()
-                    return
-                }
+    private func startAudioSession() async throws {
+        audioBuffer.removeAll(keepingCapacity: true)
+        audioStartAttempted = true
+        guard try await sendCommand(cmdId: Command.unmute, payload: [0x01]) != nil else {
+            throw DeviceConnectionError.operationFailed("Bee did not acknowledge audio start")
+        }
+    }
 
-                // Send unmute command to start audio
-                _ = try? await self.sendCommand(cmdId: Command.unmute, payload: [0x01])
-                self.isRecording = true
+    private func stopAudioSession() async throws {
+        // Notifications can still arrive while the mute acknowledgement is in
+        // flight. Clear both before and after teardown so no partial AAC frame
+        // can cross the physical recording-session boundary.
+        defer { audioBuffer.removeAll(keepingCapacity: true) }
+        audioBuffer.removeAll(keepingCapacity: true)
+        guard audioStartAttempted else { return }
+        audioStartAttempted = false
 
-                let cancellable = self.audioStreamSubject
-                    .sink(
-                        receiveCompletion: { _ in continuation.finish() },
-                        receiveValue: { data in continuation.yield(data) }
+        if responseGate.canStart(Command.mute) {
+            do {
+                guard try await sendCommand(cmdId: Command.mute, payload: [0x00]) != nil else {
+                    throw DeviceConnectionError.operationFailed(
+                        "Bee did not acknowledge audio stop"
                     )
-
-                continuation.onTermination = { @Sendable _ in
-                    cancellable.cancel()
-                    Task { @MainActor in
-                        self.isRecording = false
-                        _ = try? await self.sendCommand(cmdId: Command.mute, payload: [0x00])
-                    }
                 }
+                return
+            } catch {
+                await transport.disconnect()
+                throw error
             }
         }
+
+        // Unmute and mute share one uncorrelated device command ID. If setup
+        // was cancelled after the unmute write, its response key is poisoned;
+        // issue the compensating mute directly on the still-valid BLE write
+        // channel, then retire the physical session rather than reopening that
+        // command ID and risking a late mute response aliasing a new unmute.
+        let command = [
+            UInt8(Command.mute & 0xFF),
+            UInt8((Command.mute >> 8) & 0xFF),
+            0x00,
+        ]
+        do {
+            try await commandQueue.run { [weak self] in
+                guard let self else { throw DeviceTransportError.disposed }
+                try await self.transport.writeCharacteristic(
+                    data: Data(command),
+                    serviceUUID: DeviceUUIDs.Bee.service,
+                    characteristicUUID: CBUUID(string: Self.controlCharacteristicUUID),
+                    withResponse: true
+                )
+            }
+        } catch {
+            logger.debug("Compensating Bee mute could not be confirmed: \(error.localizedDescription)")
+        }
+        await transport.disconnect()
+        throw DeviceConnectionError.operationFailed(
+            "Bee audio command identity is ambiguous; reconnect the device"
+        )
     }
 
     // MARK: - Unsupported Features

--- a/desktop/macos/Desktop/Sources/Bluetooth/Connections/DeviceConnection.swift
+++ b/desktop/macos/Desktop/Sources/Bluetooth/Connections/DeviceConnection.swift
@@ -3,15 +3,6 @@ import CoreBluetooth
 import Foundation
 import os.log
 
-// MARK: - Connection State
-
-/// Device connection state
-/// Ported from: omi/app/lib/services/devices.dart
-enum DeviceConnectionState: String, Sendable {
-    case connected
-    case disconnected
-}
-
 // MARK: - Connection Error
 
 /// Device connection errors
@@ -24,7 +15,7 @@ enum DeviceConnectionError: LocalizedError {
     var errorDescription: String? {
         switch self {
         case .alreadyConnected:
-            return "Connection already established. Disconnect before starting a new connection."
+            return "This connection session has already started"
         case .connectionFailed(let reason):
             return "Connection failed: \(reason)"
         case .notConnected:
@@ -76,6 +67,7 @@ struct AccelerometerData {
 // MARK: - Device Connection Delegate
 
 /// Delegate for device connection events
+@MainActor
 protocol DeviceConnectionDelegate: AnyObject {
     /// Called when device disconnects unexpectedly during an operation
     func deviceConnection(_ connection: DeviceConnection, didDisconnectUnexpectedly device: BtDevice)
@@ -88,6 +80,7 @@ protocol DeviceConnectionDelegate: AnyObject {
 
 /// Abstract protocol for device connections
 /// Ported from: omi/app/lib/services/devices/device_connection.dart
+@MainActor
 protocol DeviceConnection: AnyObject {
 
     // MARK: - Properties
@@ -98,11 +91,8 @@ protocol DeviceConnection: AnyObject {
     /// The underlying transport
     var transport: DeviceTransport { get }
 
-    /// Current connection state
-    var connectionState: DeviceConnectionState { get }
-
-    /// Publisher for connection state changes
-    var connectionStatePublisher: AnyPublisher<DeviceConnectionState, Never> { get }
+    /// Generation assigned by the canonical device-session coordinator.
+    var sessionGeneration: UInt64 { get }
 
     /// Last successful ping time
     var lastPongAt: Date? { get }
@@ -112,9 +102,6 @@ protocol DeviceConnection: AnyObject {
 
     /// Delegate for connection events
     var delegate: DeviceConnectionDelegate? { get set }
-
-    /// Alias for connectionState (Flutter compatibility)
-    var status: DeviceConnectionState { get }
 
     // MARK: - Connection Lifecycle
 
@@ -233,19 +220,15 @@ protocol DeviceConnection: AnyObject {
 
 /// Base class providing common device connection functionality
 /// Subclasses implement device-specific behavior
+@MainActor
 class BaseDeviceConnection: DeviceConnection {
 
     // MARK: - Properties
 
     var device: BtDevice
     let transport: DeviceTransport
-
-    private(set) var connectionState: DeviceConnectionState = .disconnected
-    private let connectionStateSubject = PassthroughSubject<DeviceConnectionState, Never>()
-
-    var connectionStatePublisher: AnyPublisher<DeviceConnectionState, Never> {
-        connectionStateSubject.eraseToAnyPublisher()
-    }
+    var sessionGeneration: UInt64 { transport.sessionGeneration }
+    let operationClock: any DeviceOperationClock
 
     private(set) var lastPongAt: Date?
     private(set) var cachedFeatures: OmiFeatures?
@@ -253,22 +236,28 @@ class BaseDeviceConnection: DeviceConnection {
     /// Delegate for connection events
     weak var delegate: DeviceConnectionDelegate?
 
-    /// Alias for connectionState (Flutter compatibility)
-    var status: DeviceConnectionState { connectionState }
-
     private var transportStateSubscription: AnyCancellable?
+    private var isReadyForCallbacks = false
+    private var didStartLifecycle = false
+    private var teardownTask: Task<Void, Never>?
     private let logger = Logger(subsystem: "me.omi.desktop", category: "DeviceConnection")
 
     // MARK: - Initialization
 
-    init(device: BtDevice, transport: DeviceTransport) {
+    init(
+        device: BtDevice,
+        transport: DeviceTransport,
+        operationClock: any DeviceOperationClock = ContinuousDeviceOperationClock()
+    ) {
         self.device = device
         self.transport = transport
+        self.operationClock = operationClock
 
-        // Listen to transport state changes
         transportStateSubscription = transport.connectionStatePublisher
             .sink { [weak self] transportState in
-                self?.handleTransportStateChange(transportState)
+                Task { @MainActor in
+                    self?.handleTransportStateChange(transportState)
+                }
             }
     }
 
@@ -277,61 +266,120 @@ class BaseDeviceConnection: DeviceConnection {
     }
 
     private func handleTransportStateChange(_ transportState: DeviceTransportState) {
-        let newState: DeviceConnectionState = transportState == .connected ? .connected : .disconnected
+        guard transportState == .disconnected,
+              isReadyForCallbacks,
+              teardownTask == nil else { return }
 
-        if connectionState != newState {
-            connectionState = newState
-            connectionStateSubject.send(newState)
-        }
+        beginTeardown(notifyUnexpectedDisconnect: true)
     }
 
     // MARK: - Connection Lifecycle
 
-    func unpair() async {
-        // Clear any cached pairing information
+    final func unpair() async {
         cachedFeatures = nil
         lastPongAt = nil
-
-        // Disconnect if connected
-        if await isConnected() {
-            await disconnect()
-        }
-
+        await beginTeardown(
+            notifyUnexpectedDisconnect: false,
+            performUnpair: true
+        ).value
         logger.info("Device unpaired: \(self.device.displayName)")
     }
 
-    func connect() async throws {
-        guard connectionState != .connected else {
+    final func connect() async throws {
+        guard !didStartLifecycle, teardownTask == nil else {
             throw DeviceConnectionError.alreadyConnected
         }
+        didStartLifecycle = true
 
         do {
             try await transport.connect()
+            try await ensureLifecycleIsActive()
 
             // Verify connection with ping
             let pingSuccess = await ping()
+            try await ensureLifecycleIsActive()
             if !pingSuccess {
                 logger.warning("Ping failed after connection, but continuing")
             }
 
             // Update device info
             await updateDeviceInfo()
-
-            connectionState = .connected
-            connectionStateSubject.send(.connected)
-
+            try await ensureLifecycleIsActive()
+            try await prepareDeviceAfterConnect()
+            try await ensureLifecycleIsActive()
+            isReadyForCallbacks = true
         } catch {
-            throw DeviceConnectionError.connectionFailed(error.localizedDescription)
+            await beginTeardown(notifyUnexpectedDisconnect: false).value
+            throw normalizedConnectionError(error)
         }
     }
 
-    func disconnect() async {
-        connectionState = .disconnected
-        connectionStateSubject.send(.disconnected)
+    final func disconnect() async {
+        await beginTeardown(notifyUnexpectedDisconnect: false).value
+    }
 
-        await transport.disconnect()
-        transportStateSubscription?.cancel()
-        transportStateSubscription = nil
+    /// Starts the session's single teardown operation or joins the one already in flight.
+    /// Keeping the task as the lifecycle boundary prevents an explicit disconnect from
+    /// returning while unexpected-disconnect cleanup is still draining the transport.
+    @discardableResult
+    private func beginTeardown(
+        notifyUnexpectedDisconnect: Bool,
+        performUnpair: Bool = false
+    ) -> Task<Void, Never> {
+        if let teardownTask {
+            return teardownTask
+        }
+
+        isReadyForCallbacks = false
+        let task = Task { @MainActor [self] in
+            if performUnpair {
+                await performDeviceUnpair()
+            }
+            await teardownDevice()
+            await transport.dispose()
+
+            if notifyUnexpectedDisconnect {
+                delegate?.deviceConnection(
+                    self,
+                    didDisconnectUnexpectedly: device
+                )
+            }
+        }
+        teardownTask = task
+        return task
+    }
+
+    /// Device-specific setup after the transport and shared metadata are ready.
+    /// The base lifecycle calls this exactly once per session generation.
+    func prepareDeviceAfterConnect() async throws {}
+
+    /// Device-specific cleanup before the transport is disposed.
+    /// The base lifecycle calls this at most once per session generation.
+    func teardownDevice() async {}
+
+    /// Optional device-side unpair command, invoked before teardown.
+    func performDeviceUnpair() async {}
+
+    private func ensureLifecycleIsActive() async throws {
+        guard teardownTask == nil else {
+            throw DeviceConnectionError.operationFailed("Connection was cancelled")
+        }
+        guard await transport.isConnected() else {
+            throw DeviceConnectionError.connectionFailed(
+                "Device disconnected during connection setup"
+            )
+        }
+    }
+
+    private func normalizedConnectionError(_ error: Error) -> DeviceConnectionError {
+        if let connectionError = error as? DeviceConnectionError {
+            return connectionError
+        }
+        if let transportError = error as? DeviceTransportError,
+           case .connectionFailed(let reason) = transportError {
+            return .connectionFailed(reason)
+        }
+        return .connectionFailed(error.localizedDescription)
     }
 
     func isConnected() async -> Bool {
@@ -410,7 +458,7 @@ class BaseDeviceConnection: DeviceConnection {
         )
 
         return AsyncThrowingStream { continuation in
-            Task {
+            let forwardingTask = Task {
                 do {
                     for try await data in stream {
                         if !data.isEmpty {
@@ -421,6 +469,9 @@ class BaseDeviceConnection: DeviceConnection {
                 } catch {
                     continuation.finish(throwing: error)
                 }
+            }
+            continuation.onTermination = { @Sendable _ in
+                forwardingTask.cancel()
             }
         }
     }
@@ -482,7 +533,7 @@ class BaseDeviceConnection: DeviceConnection {
         )
 
         return AsyncThrowingStream { continuation in
-            Task {
+            let forwardingTask = Task {
                 do {
                     for try await data in stream {
                         continuation.yield(Array(data))
@@ -491,6 +542,9 @@ class BaseDeviceConnection: DeviceConnection {
                 } catch {
                     continuation.finish(throwing: error)
                 }
+            }
+            continuation.onTermination = { @Sendable _ in
+                forwardingTask.cancel()
             }
         }
     }
@@ -581,7 +635,7 @@ class BaseDeviceConnection: DeviceConnection {
         )
 
         return AsyncThrowingStream { [weak self] continuation in
-            Task { [weak self] in
+            let forwardingTask = Task { [weak self] in
                 guard let self = self else {
                     continuation.finish()
                     return
@@ -637,6 +691,9 @@ class BaseDeviceConnection: DeviceConnection {
                 } catch {
                     continuation.finish(throwing: error)
                 }
+            }
+            continuation.onTermination = { @Sendable _ in
+                forwardingTask.cancel()
             }
         }
     }
@@ -723,10 +780,4 @@ class BaseDeviceConnection: DeviceConnection {
         AsyncThrowingStream { $0.finish() }
     }
 
-    // MARK: - Helper Methods
-
-    /// Notify delegate of unexpected disconnection
-    func notifyUnexpectedDisconnection() {
-        delegate?.deviceConnection(self, didDisconnectUnexpectedly: device)
-    }
 }

--- a/desktop/macos/Desktop/Sources/Bluetooth/Connections/DeviceConnectionFactory.swift
+++ b/desktop/macos/Desktop/Sources/Bluetooth/Connections/DeviceConnectionFactory.swift
@@ -1,3 +1,4 @@
+import Combine
 import CoreBluetooth
 import Foundation
 
@@ -9,40 +10,78 @@ struct DeviceConnectionFactory {
     /// - Parameters:
     ///   - device: The device to connect to
     ///   - peripheral: The CoreBluetooth peripheral
-    ///   - centralManager: The central manager (for transport)
+    ///   - connectionController: The central manager's leased connection boundary
     /// - Returns: A device connection, or nil if unsupported
+    @MainActor
     static func create(
         device: BtDevice,
         peripheral: CBPeripheral,
-        centralManager: CBCentralManager
+        connectionController: any BluetoothCentralConnectionControlling,
+        centralEvents: AnyPublisher<BluetoothCentralEvent, Never>,
+        sessionGeneration: UInt64,
+        operationClock: any DeviceOperationClock = ContinuousDeviceOperationClock()
     ) -> DeviceConnection? {
 
         // Create BLE transport
-        let transport = BleTransport(peripheral: peripheral, centralManager: centralManager)
+        let transport = BleTransport(
+            peripheral: peripheral,
+            connectionController: connectionController,
+            centralEvents: centralEvents,
+            sessionGeneration: sessionGeneration,
+            operationClock: operationClock
+        )
 
         // Create device-specific connection
         switch device.type {
         case .omi, .openglass:
-            return OmiDeviceConnection(device: device, transport: transport)
+            return OmiDeviceConnection(
+                device: device,
+                transport: transport,
+                operationClock: operationClock
+            )
 
         case .plaud:
-            return PlaudDeviceConnection(device: device, transport: transport)
+            return PlaudDeviceConnection(
+                device: device,
+                transport: transport,
+                operationClock: operationClock
+            )
 
         case .bee:
-            return BeeDeviceConnection(device: device, transport: transport)
+            return BeeDeviceConnection(
+                device: device,
+                transport: transport,
+                operationClock: operationClock
+            )
 
         case .fieldy:
-            return FieldyDeviceConnection(device: device, transport: transport)
+            return FieldyDeviceConnection(
+                device: device,
+                transport: transport,
+                operationClock: operationClock
+            )
 
         case .friendPendant:
-            return FriendPendantConnection(device: device, transport: transport)
+            return FriendPendantConnection(
+                device: device,
+                transport: transport,
+                operationClock: operationClock
+            )
 
         case .limitless:
-            return LimitlessDeviceConnection(device: device, transport: transport)
+            return LimitlessDeviceConnection(
+                device: device,
+                transport: transport,
+                operationClock: operationClock
+            )
 
         case .frame:
             // Frame uses Brilliant Labs SDK, but basic BLE fallback is available
-            return FrameDeviceConnection(device: device, transport: transport)
+            return FrameDeviceConnection(
+                device: device,
+                transport: transport,
+                operationClock: operationClock
+            )
 
         case .appleWatch:
             // Apple Watch uses WatchConnectivity, not BLE
@@ -55,7 +94,11 @@ struct DeviceConnectionFactory {
     /// - Parameter device: The device to connect to
     /// - Returns: A device connection, or nil if peripheral not found
     @MainActor
-    static func create(device: BtDevice) -> DeviceConnection? {
+    static func create(
+        device: BtDevice,
+        sessionGeneration: UInt64,
+        operationClock: any DeviceOperationClock = ContinuousDeviceOperationClock()
+    ) -> DeviceConnection? {
         let manager = BluetoothManager.shared
 
         guard let peripheral = manager.peripheral(for: device) else {
@@ -65,7 +108,10 @@ struct DeviceConnectionFactory {
         return create(
             device: device,
             peripheral: peripheral,
-            centralManager: manager.centralManager
+            connectionController: manager,
+            centralEvents: manager.centralEventPublisher,
+            sessionGeneration: sessionGeneration,
+            operationClock: operationClock
         )
     }
 }

--- a/desktop/macos/Desktop/Sources/Bluetooth/Connections/FieldyDeviceConnection.swift
+++ b/desktop/macos/Desktop/Sources/Bluetooth/Connections/FieldyDeviceConnection.swift
@@ -1,4 +1,3 @@
-import Combine
 import CoreBluetooth
 import Foundation
 import os.log
@@ -17,26 +16,25 @@ final class FieldyDeviceConnection: BaseDeviceConnection {
     // MARK: - Private Properties
 
     private let logger = Logger(subsystem: "me.omi.desktop", category: "FieldyDeviceConnection")
-    private var audioStreamSubject = PassthroughSubject<Data, Error>()
-    private var audioSubscription: Task<Void, Never>?
 
     // MARK: - Initialization
 
-    override init(device: BtDevice, transport: DeviceTransport) {
-        super.init(device: device, transport: transport)
+    override init(
+        device: BtDevice,
+        transport: DeviceTransport,
+        operationClock: any DeviceOperationClock = ContinuousDeviceOperationClock()
+    ) {
+        super.init(
+            device: device,
+            transport: transport,
+            operationClock: operationClock
+        )
     }
 
     // MARK: - Connection
 
-    override func connect() async throws {
-        try await super.connect()
-        try? await Task.sleep(nanoseconds: 1_000_000_000)
-    }
-
-    override func disconnect() async {
-        audioSubscription?.cancel()
-        audioSubscription = nil
-        await super.disconnect()
+    override func prepareDeviceAfterConnect() async throws {
+        try await operationClock.sleep(for: .seconds(1))
     }
 
     // MARK: - Battery
@@ -74,7 +72,7 @@ final class FieldyDeviceConnection: BaseDeviceConnection {
                 return
             }
 
-            self.audioSubscription = Task { [weak self] in
+            let forwardingTask = Task { [weak self] in
                 guard let self = self else {
                     continuation.finish()
                     return
@@ -116,8 +114,8 @@ final class FieldyDeviceConnection: BaseDeviceConnection {
                 }
             }
 
-            continuation.onTermination = { @Sendable [weak self] _ in
-                self?.audioSubscription?.cancel()
+            continuation.onTermination = { @Sendable _ in
+                forwardingTask.cancel()
             }
         }
     }

--- a/desktop/macos/Desktop/Sources/Bluetooth/Connections/FrameDeviceConnection.swift
+++ b/desktop/macos/Desktop/Sources/Bluetooth/Connections/FrameDeviceConnection.swift
@@ -1,4 +1,3 @@
-import Combine
 import CoreBluetooth
 import Foundation
 import os.log
@@ -10,25 +9,6 @@ import os.log
 /// Ported from: omi/app/lib/services/devices/frame_connection.dart
 final class FrameDeviceConnection: BaseDeviceConnection {
 
-    // MARK: - Constants
-
-    /// JPEG header used to prepend to raw image data from Frame
-    /// Frame sends raw JPEG data without the standard header
-    private static let photoHeader = Data(base64Encoded:
-        "/9j/4AAQSkZJRgABAgAAZABkAAD/2wBDACAWGBwYFCAcGhwkIiAmMFA0MCwsMGJGSjpQdGZ6" +
-        "eHJmcG6AkLicgIiuim5woNqirr7EztDOfJri8uDI8LjKzsb/2wBDASIkJDAqMF40NF7GhHCE" +
-        "xsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsb/wAAR" +
-        "CAIAAgADASIAAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAHwEA" +
-        "AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQR" +
-        "BRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RF" +
-        "RkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ip" +
-        "qrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAtREA" +
-        "AgECBAQDBAcFBAQAAQJ3AAECAxEEBSExBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYk" +
-        "NOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOE" +
-        "hYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk" +
-        "5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwA="
-    )!
-
     // MARK: - Properties
 
     private let logger = Logger(subsystem: "me.omi.desktop", category: "FrameDeviceConnection")
@@ -36,15 +16,21 @@ final class FrameDeviceConnection: BaseDeviceConnection {
 
     // MARK: - Initialization
 
-    override init(device: BtDevice, transport: DeviceTransport) {
-        super.init(device: device, transport: transport)
+    override init(
+        device: BtDevice,
+        transport: DeviceTransport,
+        operationClock: any DeviceOperationClock = ContinuousDeviceOperationClock()
+    ) {
+        super.init(
+            device: device,
+            transport: transport,
+            operationClock: operationClock
+        )
     }
 
     // MARK: - Connection
 
-    override func connect() async throws {
-        try await super.connect()
-
+    override func prepareDeviceAfterConnect() async throws {
         // Update device info
         device.firmwareRevision = "Frame"
         device.hardwareRevision = "Brilliant Labs Frame"
@@ -88,7 +74,7 @@ final class FrameDeviceConnection: BaseDeviceConnection {
         )
 
         return AsyncThrowingStream { [weak self] continuation in
-            Task { [weak self] in
+            let forwardingTask = Task { [weak self] in
                 guard let self = self else {
                     continuation.finish()
                     return
@@ -108,6 +94,9 @@ final class FrameDeviceConnection: BaseDeviceConnection {
                 } catch {
                     continuation.finish(throwing: error)
                 }
+            }
+            continuation.onTermination = { @Sendable _ in
+                forwardingTask.cancel()
             }
         }
     }

--- a/desktop/macos/Desktop/Sources/Bluetooth/Connections/FriendPendantConnection.swift
+++ b/desktop/macos/Desktop/Sources/Bluetooth/Connections/FriendPendantConnection.swift
@@ -12,8 +12,6 @@ final class FriendPendantConnection: BaseDeviceConnection {
     // MARK: - Constants
 
     private static let packetFooterSize = 5
-    private static let packetSize = 95
-    private static let lc3DataSize = 90  // 3 frames of 30 bytes each
     private static let lc3FrameSize = 30 // Single LC3 frame size
 
     // MARK: - Private Properties
@@ -21,32 +19,33 @@ final class FriendPendantConnection: BaseDeviceConnection {
     private let logger = Logger(subsystem: "me.omi.desktop", category: "FriendPendantConnection")
     private var audioStreamSubject = PassthroughSubject<Data, Error>()
     private var audioSubscription: Task<Void, Never>?
-    private var isRecording = false
 
     // MARK: - Initialization
 
-    override init(device: BtDevice, transport: DeviceTransport) {
-        super.init(device: device, transport: transport)
+    override init(
+        device: BtDevice,
+        transport: DeviceTransport,
+        operationClock: any DeviceOperationClock = ContinuousDeviceOperationClock()
+    ) {
+        super.init(
+            device: device,
+            transport: transport,
+            operationClock: operationClock
+        )
     }
 
     // MARK: - Connection
 
-    override func connect() async throws {
-        try await super.connect()
+    override func prepareDeviceAfterConnect() async throws {
+        try await operationClock.sleep(for: .seconds(1))
 
-        // Wait for connection to stabilize
-        try? await Task.sleep(nanoseconds: 1_000_000_000)
-
-        // Subscribe to audio stream
         startAudioListener()
     }
 
-    override func disconnect() async {
-        isRecording = false
+    override func teardownDevice() async {
         audioSubscription?.cancel()
         audioSubscription = nil
-
-        await super.disconnect()
+        audioStreamSubject.send(completion: .finished)
     }
 
     // MARK: - Audio Handling
@@ -101,18 +100,30 @@ final class FriendPendantConnection: BaseDeviceConnection {
     }
 
     override func getBatteryLevelStream() -> AsyncThrowingStream<Int, Error> {
-        return AsyncThrowingStream { continuation in
-            Task {
+        return AsyncThrowingStream { [weak self] continuation in
+            let pollingTask = Task { [weak self] in
+                guard let self else {
+                    continuation.finish()
+                    return
+                }
                 // Send initial battery level
                 continuation.yield(90)
 
                 // Send 90% every 30 seconds
                 while !Task.isCancelled {
-                    try? await Task.sleep(nanoseconds: 30_000_000_000)
+                    do {
+                        try await self.operationClock.sleep(for: .seconds(30))
+                    } catch {
+                        break
+                    }
+                    guard !Task.isCancelled else { break }
                     continuation.yield(90)
                 }
 
                 continuation.finish()
+            }
+            continuation.onTermination = { @Sendable _ in
+                pollingTask.cancel()
             }
         }
     }
@@ -130,8 +141,6 @@ final class FriendPendantConnection: BaseDeviceConnection {
                 return
             }
 
-            self.isRecording = true
-
             let cancellable = self.audioStreamSubject
                 .sink(
                     receiveCompletion: { _ in
@@ -144,9 +153,6 @@ final class FriendPendantConnection: BaseDeviceConnection {
 
             continuation.onTermination = { @Sendable _ in
                 cancellable.cancel()
-                Task { @MainActor in
-                    self.isRecording = false
-                }
             }
         }
     }

--- a/desktop/macos/Desktop/Sources/Bluetooth/Connections/LimitlessDeviceConnection.swift
+++ b/desktop/macos/Desktop/Sources/Bluetooth/Connections/LimitlessDeviceConnection.swift
@@ -26,7 +26,6 @@ final class LimitlessDeviceConnection: BaseDeviceConnection {
     private var requestId = 0
 
     private var audioStreamSubject = PassthroughSubject<Data, Error>()
-    private var flashPageSubject = PassthroughSubject<[String: Any], Never>()
     private var buttonStreamSubject = PassthroughSubject<[UInt8], Never>()
 
     private var rxSubscription: Task<Void, Never>?
@@ -45,49 +44,50 @@ final class LimitlessDeviceConnection: BaseDeviceConnection {
     private var lastAcknowledgedIndex = -1
 
     private var firstFlashPageTimestampMs: Int64?
-    // getStorageStatus() stores its continuation here and it is resumed from two
-    // unsynchronized executors — the 3s timeout Task and the RX parser Task — which
-    // without a lock can BOTH resume the same CheckedContinuation (double-resume
-    // trap / crash) or leak a displaced one. All three fields are guarded by
-    // storageStateLock: capture-and-nil the continuation UNDER the lock, resume it
-    // OUTSIDE (exactly one context wins). The generation tag lets a timeout resume
-    // only its OWN pending call, never a newer one that displaced it.
-    private let storageStateLock = NSLock()
+    private let storageStatusOperations: DeviceOperationBroker<String, [String: Int]>
+    private let storageStatusGate = UncorrelatedOperationGate<String>()
     private var storageState: [String: Int]?
-    private var storageStateCompletion: CheckedContinuation<[String: Int]?, Never>?
-    private var storageStateGeneration = 0
     private var lastLedBrightness: Int?
 
     // MARK: - Initialization
 
-    override init(device: BtDevice, transport: DeviceTransport) {
-        super.init(device: device, transport: transport)
+    override init(
+        device: BtDevice,
+        transport: DeviceTransport,
+        operationClock: any DeviceOperationClock = ContinuousDeviceOperationClock()
+    ) {
+        self.storageStatusOperations = DeviceOperationBroker(clock: operationClock)
+        super.init(
+            device: device,
+            transport: transport,
+            operationClock: operationClock
+        )
     }
 
     // MARK: - Connection
 
-    override func connect() async throws {
-        try await super.connect()
-        try? await Task.sleep(nanoseconds: 1_000_000_000)
+    override func prepareDeviceAfterConnect() async throws {
+        try await operationClock.sleep(for: .seconds(1))
 
         startRxListener()
 
-        try? await Task.sleep(nanoseconds: 1_000_000_000)
+        try await operationClock.sleep(for: .seconds(1))
 
         try await initialize()
     }
 
-    override func disconnect() async {
+    override func teardownDevice() async {
         rxSubscription?.cancel()
         rxSubscription = nil
         audioStreamSubject.send(completion: .finished)
+        buttonStreamSubject.send(completion: .finished)
         isBatchMode = false
-        await super.disconnect()
+        await storageStatusOperations.cancelAll(reason: .disconnected)
+        storageStatusGate.reset()
     }
 
-    override func unpair() async {
+    override func performDeviceUnpair() async {
         await unpairWithoutReset()
-        await super.unpair()
     }
 
     // MARK: - Initialization
@@ -101,7 +101,7 @@ final class LimitlessDeviceConnection: BaseDeviceConnection {
             characteristicUUID: DeviceUUIDs.Limitless.txCharacteristic,
             withResponse: true
         )
-        try? await Task.sleep(nanoseconds: 1_000_000_000)
+        try await operationClock.sleep(for: .seconds(1))
 
         // Command 2: Enable data streaming
         let dataStreamCmd = encodeEnableDataStream()
@@ -111,7 +111,7 @@ final class LimitlessDeviceConnection: BaseDeviceConnection {
             characteristicUUID: DeviceUUIDs.Limitless.txCharacteristic,
             withResponse: true
         )
-        try? await Task.sleep(nanoseconds: 1_000_000_000)
+        try await operationClock.sleep(for: .seconds(1))
 
         isInitialized = true
     }
@@ -288,8 +288,6 @@ final class LimitlessDeviceConnection: BaseDeviceConnection {
                         firstFlashPageTimestampMs = timestamp
                     }
                 }
-
-                flashPageSubject.send(flashPage)
             }
         }
     }
@@ -630,12 +628,17 @@ final class LimitlessDeviceConnection: BaseDeviceConnection {
                         guard statusLength >= 5, statusLength <= 500, innerPos + statusLength <= data.count else { return }
 
                         if let state = parseStorageStateFromDeviceStatus(data, start: innerPos, end: innerPos + statusLength) {
-                            storageStateLock.lock()
                             storageState = state
-                            let completion = storageStateCompletion
-                            storageStateCompletion = nil
-                            storageStateLock.unlock()
-                            completion?.resume(returning: state)
+                            if let handle = storageStatusGate.takeHandleForCallback(
+                                key: "storage-status"
+                            ) {
+                                Task {
+                                    await storageStatusOperations.succeed(
+                                        handle: handle,
+                                        value: state
+                                    )
+                                }
+                            }
                         }
                         return
                     }
@@ -863,45 +866,37 @@ final class LimitlessDeviceConnection: BaseDeviceConnection {
     /// Get storage status
     func getStorageStatus() async -> [String: Int]? {
         guard isInitialized else { return nil }
+        guard storageStatusGate.canStart("storage-status") else {
+            return storageState
+        }
 
         do {
-            let statusCmd = encodeGetDeviceStatus()
-            try await transport.writeCharacteristic(
-                data: Data(statusCmd),
-                serviceUUID: DeviceUUIDs.Limitless.service,
-                characteristicUUID: DeviceUUIDs.Limitless.txCharacteristic,
-                withResponse: true
-            )
-
-            // Wait for response with timeout
-            return await withCheckedContinuation { continuation in
-                storageStateLock.lock()
-                let displaced = storageStateCompletion
-                storageStateGeneration += 1
-                let myGeneration = storageStateGeneration
-                storageStateCompletion = continuation
-                storageStateLock.unlock()
-                // A prior in-flight getStorageStatus would otherwise be leaked (its
-                // continuation overwritten, never resumed) — resolve it with nil.
-                displaced?.resume(returning: nil)
-
-                Task {
-                    try? await Task.sleep(nanoseconds: 3_000_000_000)
-                    let timeoutResult = storageStateLock.withLock {
-                        var timedOut: CheckedContinuation<[String: Int]?, Never>?
-                        var snapshot: [String: Int]?
-                        // Only fire if OUR call is still the pending one (a newer call
-                        // would have bumped the generation and owns the slot now).
-                        if storageStateGeneration == myGeneration, let completion = storageStateCompletion {
-                            timedOut = completion
-                            storageStateCompletion = nil
-                            snapshot = storageState
-                        }
-                        return (timedOut, snapshot)
-                    }
-                    timeoutResult.0?.resume(returning: timeoutResult.1)
+            let status = try await storageStatusOperations.perform(
+                key: "storage-status",
+                timeout: .seconds(3),
+                onTerminal: { [weak self] handle, termination in
+                    self?.storageStatusGate.terminal(
+                        handle: handle,
+                        termination: termination
+                    )
                 }
+            ) { [weak self] handle in
+                guard let self else { throw DeviceTransportError.disposed }
+                guard self.storageStatusGate.register(handle) else {
+                    throw DeviceConnectionError.operationFailed(
+                        "Storage status callback identity is no longer trustworthy"
+                    )
+                }
+                try await self.transport.writeCharacteristic(
+                    data: Data(self.encodeGetDeviceStatus()),
+                    serviceUUID: DeviceUUIDs.Limitless.service,
+                    characteristicUUID: DeviceUUIDs.Limitless.txCharacteristic,
+                    withResponse: true
+                )
             }
+            return status
+        } catch DeviceOperationBrokerError.timedOut {
+            return storageState
         } catch {
             logger.debug("Error getting storage status: \(error.localizedDescription)")
             return nil
@@ -1054,7 +1049,10 @@ final class LimitlessDeviceConnection: BaseDeviceConnection {
             }
 
             let cancellable = self.buttonStreamSubject
-                .sink(receiveValue: { value in continuation.yield(value) })
+                .sink(
+                    receiveCompletion: { _ in continuation.finish() },
+                    receiveValue: { value in continuation.yield(value) }
+                )
 
             continuation.onTermination = { @Sendable _ in
                 cancellable.cancel()

--- a/desktop/macos/Desktop/Sources/Bluetooth/Connections/OmiDeviceConnection.swift
+++ b/desktop/macos/Desktop/Sources/Bluetooth/Connections/OmiDeviceConnection.swift
@@ -11,15 +11,21 @@ final class OmiDeviceConnection: BaseDeviceConnection {
 
     // MARK: - Initialization
 
-    override init(device: BtDevice, transport: DeviceTransport) {
-        super.init(device: device, transport: transport)
+    override init(
+        device: BtDevice,
+        transport: DeviceTransport,
+        operationClock: any DeviceOperationClock = ContinuousDeviceOperationClock()
+    ) {
+        super.init(
+            device: device,
+            transport: transport,
+            operationClock: operationClock
+        )
     }
 
     // MARK: - Connection
 
-    override func connect() async throws {
-        try await super.connect()
-
+    override func prepareDeviceAfterConnect() async throws {
         // Check if this is an OpenGlass device (has image streaming)
         if await hasPhotoStreaming() && device.type == .omi {
             device.type = .openglass
@@ -103,7 +109,7 @@ final class OmiDeviceConnection: BaseDeviceConnection {
         )
 
         return AsyncThrowingStream { continuation in
-            Task { [weak self] in
+            let forwardingTask = Task { [weak self] in
                 guard let self = self else {
                     continuation.finish()
                     return
@@ -196,6 +202,9 @@ final class OmiDeviceConnection: BaseDeviceConnection {
                 } catch {
                     continuation.finish(throwing: error)
                 }
+            }
+            continuation.onTermination = { @Sendable _ in
+                forwardingTask.cancel()
             }
         }
     }
@@ -325,31 +334,13 @@ final class OmiDeviceConnection: BaseDeviceConnection {
                 withResponse: true
             )
 
-            // Wait for response with timeout (5 seconds)
-            let timeoutTask = Task {
-                try await Task.sleep(nanoseconds: 5_000_000_000) // 5 seconds
-                return WifiSyncSetupResult.timeout()
-            }
-
-            let responseTask = Task { () -> WifiSyncSetupResult in
-                for try await data in responseStream {
-                    if !data.isEmpty {
-                        let responseCode = WifiSyncErrorCode.from(code: Int(data[0]))
-                        if responseCode.isSuccess {
-                            return .success()
-                        } else {
-                            return .failure(responseCode)
-                        }
-                    }
-                }
-                return .timeout()
-            }
-
-            // Race between timeout and response
-            let result = await withTaskGroup(of: WifiSyncSetupResult.self) { group in
+            // Race the response and timeout as structured child tasks so the
+            // losing stream/sleep is cancelled with the scope.
+            return await withTaskGroup(of: WifiSyncSetupResult.self) { [operationClock] group in
                 group.addTask {
                     do {
-                        return try await timeoutTask.value
+                        try await operationClock.sleep(for: .seconds(5))
+                        return .timeout()
                     } catch {
                         return .timeout()
                     }
@@ -357,22 +348,24 @@ final class OmiDeviceConnection: BaseDeviceConnection {
 
                 group.addTask {
                     do {
-                        return try await responseTask.value
+                        for try await data in responseStream {
+                            if !data.isEmpty {
+                                let responseCode = WifiSyncErrorCode.from(code: Int(data[0]))
+                                return responseCode.isSuccess
+                                    ? .success()
+                                    : .failure(responseCode)
+                            }
+                        }
+                        return .timeout()
                     } catch {
                         return .connectionFailed()
                     }
                 }
 
-                // Return the first completed result
                 let firstResult = await group.next() ?? .timeout()
-
-                // Cancel remaining tasks
                 group.cancelAll()
-
                 return firstResult
             }
-
-            return result
 
         } catch {
             logger.error("Failed to setup WiFi sync: \(error.localizedDescription)")
@@ -424,7 +417,7 @@ final class OmiDeviceConnection: BaseDeviceConnection {
         )
 
         return AsyncThrowingStream { continuation in
-            Task {
+            let forwardingTask = Task {
                 do {
                     for try await data in stream {
                         if !data.isEmpty {
@@ -435,6 +428,9 @@ final class OmiDeviceConnection: BaseDeviceConnection {
                 } catch {
                     continuation.finish(throwing: error)
                 }
+            }
+            continuation.onTermination = { @Sendable _ in
+                forwardingTask.cancel()
             }
         }
     }

--- a/desktop/macos/Desktop/Sources/Bluetooth/Connections/PlaudDeviceConnection.swift
+++ b/desktop/macos/Desktop/Sources/Bluetooth/Connections/PlaudDeviceConnection.swift
@@ -1,4 +1,3 @@
-import Combine
 import CoreBluetooth
 import Foundation
 import os.log
@@ -21,47 +20,55 @@ final class PlaudDeviceConnection: BaseDeviceConnection {
 
     private let logger = Logger(subsystem: "me.omi.desktop", category: "PlaudDeviceConnection")
 
-    private var commandQueues: [Int: PassthroughSubject<[UInt8], Never>] = [:]
-    private var audioStreamSubject = PassthroughSubject<Data, Error>()
+    private let commandOperations: DeviceOperationBroker<Int, Data>
+    private let commandGate = UncorrelatedOperationGate<Int>()
+    private let commandQueue = DeviceCommandQueue()
     private var notificationSubscription: Task<Void, Never>?
     private var sessionId: Int?
-    private var cancellables = Set<AnyCancellable>()
+    private var recordingSetupAttempted = false
+    private lazy var audioStreamController = DeviceAudioStreamController(
+        start: { [weak self] in
+            guard let self else { throw DeviceTransportError.disposed }
+            try await self.setupRecordingSession()
+        },
+        stop: { [weak self] in
+            guard let self else { return }
+            try await self.stopRecordingSession()
+        }
+    )
 
     // MARK: - Initialization
 
-    override init(device: BtDevice, transport: DeviceTransport) {
-        super.init(device: device, transport: transport)
+    override init(
+        device: BtDevice,
+        transport: DeviceTransport,
+        operationClock: any DeviceOperationClock = ContinuousDeviceOperationClock()
+    ) {
+        self.commandOperations = DeviceOperationBroker(clock: operationClock)
+        super.init(
+            device: device,
+            transport: transport,
+            operationClock: operationClock
+        )
     }
 
     // MARK: - Connection
 
-    override func connect() async throws {
-        try await super.connect()
+    override func prepareDeviceAfterConnect() async throws {
+        try await operationClock.sleep(for: .seconds(2))
 
-        // Wait for connection to stabilize
-        try? await Task.sleep(nanoseconds: 2_000_000_000)
-
-        // Subscribe to notifications
         startNotificationListener()
     }
 
-    override func disconnect() async {
-        // Stop recording if active
-        if let sessionId = sessionId {
-            do {
-                try await stopSync()
-                try await stopRecord(sessionId: sessionId)
-            } catch {
-                logger.debug("Error stopping recording during disconnect: \(error.localizedDescription)")
-            }
-        }
+    override func teardownDevice() async {
+        await audioStreamController.finish()
+        await commandQueue.close()
 
         notificationSubscription?.cancel()
         notificationSubscription = nil
-        commandQueues.removeAll()
+        await commandOperations.cancelAll(reason: .disconnected)
+        commandGate.reset()
         sessionId = nil
-
-        await super.disconnect()
     }
 
     // MARK: - Notification Handling
@@ -83,23 +90,32 @@ final class PlaudDeviceConnection: BaseDeviceConnection {
         }
     }
 
-    private func handleNotification(_ data: [UInt8]) {
+    /// Parses one physical notification. Kept internal so adapter-correlation
+    /// behavior can be verified without a real CoreBluetooth peripheral.
+    func handleNotification(_ data: [UInt8]) {
         guard !data.isEmpty else { return }
 
         if data[0] == 2 {
             // Audio data packet
             if let chunk = parseAudioChunk(Array(data.dropFirst())) {
-                audioStreamSubject.send(Data(chunk))
+                audioStreamController.yield(Data(chunk))
             }
         } else if data.count >= 3 {
             // Command response
             let cmdId = Int(data[1]) | (Int(data[2]) << 8)
             let payload = data.count > 3 ? Array(data.dropFirst(3)) : []
 
-            if commandQueues[cmdId] == nil {
-                commandQueues[cmdId] = PassthroughSubject<[UInt8], Never>()
-            }
-            commandQueues[cmdId]?.send(payload)
+            completeCommand(commandID: cmdId, payload: payload)
+        }
+    }
+
+    private func completeCommand(commandID: Int, payload: [UInt8]) {
+        guard let handle = commandGate.takeHandleForCallback(key: commandID) else { return }
+        Task {
+            await commandOperations.succeed(
+                handle: handle,
+                value: Data(payload)
+            )
         }
     }
 
@@ -117,51 +133,45 @@ final class PlaudDeviceConnection: BaseDeviceConnection {
 
     // MARK: - Command Sending
 
-    private func sendCommand(cmdId: Int, payload: [UInt8]) async throws -> [UInt8]? {
-        if commandQueues[cmdId] == nil {
-            commandQueues[cmdId] = PassthroughSubject<[UInt8], Never>()
+    func sendCommand(cmdId: Int, payload: [UInt8]) async throws -> [UInt8]? {
+        try await commandQueue.run { [weak self] in
+            guard let self else { throw DeviceTransportError.disposed }
+            return try await self.sendCommandSerially(cmdId: cmdId, payload: payload)
         }
+    }
 
+    private func sendCommandSerially(cmdId: Int, payload: [UInt8]) async throws -> [UInt8]? {
+        guard commandGate.canStart(cmdId) else {
+            throw DeviceConnectionError.operationFailed(
+                "A previous command response is ambiguous; reconnect the device"
+            )
+        }
         let command: [UInt8] = [1, UInt8(cmdId & 0xFF), UInt8((cmdId >> 8) & 0xFF)] + payload
 
-        try await transport.writeCharacteristic(
-            data: Data(command),
-            serviceUUID: DeviceUUIDs.PLAUD.service,
-            characteristicUUID: DeviceUUIDs.PLAUD.writeCharacteristic,
-            withResponse: true
-        )
-
-        // Wait for response with timeout.
-        //
-        // Both the timeout task and the response sink race to resume the same
-        // continuation, so a raw `continuation.resume` on each path double-resumes
-        // (a fatalError). Cancelling the timeout task does NOT prevent it either:
-        // `try? await Task.sleep` swallows the CancellationError and falls through
-        // to the resume. A lock-guarded one-shot ensures exactly one resume wins.
-        return await withCheckedContinuation { continuation in
-            let resumeLock = NSLock()
-            var didResume = false
-            func resumeOnce(_ value: [UInt8]?) {
-                resumeLock.lock()
-                defer { resumeLock.unlock() }
-                guard !didResume else { return }
-                didResume = true
-                continuation.resume(returning: value)
-            }
-
-            var cancellable: AnyCancellable?
-            let timeoutTask = Task {
-                try? await Task.sleep(nanoseconds: 10_000_000_000) // 10 seconds
-                cancellable?.cancel()
-                resumeOnce(nil)
-            }
-
-            cancellable = commandQueues[cmdId]?
-                .first()
-                .sink { response in
-                    timeoutTask.cancel()
-                    resumeOnce(response)
+        do {
+            let response = try await commandOperations.perform(
+                key: cmdId,
+                timeout: .seconds(10),
+                onTerminal: { [weak self] handle, termination in
+                    self?.commandGate.terminal(handle: handle, termination: termination)
                 }
+            ) { [weak self] handle in
+                guard let self else { throw DeviceTransportError.disposed }
+                guard self.commandGate.register(handle) else {
+                    throw DeviceConnectionError.operationFailed(
+                        "Command callback identity is no longer trustworthy"
+                    )
+                }
+                try await self.transport.writeCharacteristic(
+                    data: Data(command),
+                    serviceUUID: DeviceUUIDs.PLAUD.service,
+                    characteristicUUID: DeviceUUIDs.PLAUD.writeCharacteristic,
+                    withResponse: true
+                )
+            }
+            return Array(response)
+        } catch DeviceOperationBrokerError.timedOut {
+            return nil
         }
     }
 
@@ -182,7 +192,11 @@ final class PlaudDeviceConnection: BaseDeviceConnection {
 
     private func stopRecord(sessionId: Int) async throws {
         let payload = toBytes32(sessionId) + toBytes32(0)
-        _ = try await sendCommand(cmdId: Command.stopRecord, payload: payload)
+        guard try await sendCommand(cmdId: Command.stopRecord, payload: payload) != nil else {
+            throw DeviceConnectionError.operationFailed(
+                "PLAUD did not acknowledge STOP_RECORD"
+            )
+        }
     }
 
     private func startSync(sessionId: Int, start: Int) async throws -> Bool {
@@ -193,43 +207,78 @@ final class PlaudDeviceConnection: BaseDeviceConnection {
 
     private func stopSync() async throws {
         let command: [UInt8] = [1, UInt8(Command.stopSync & 0xFF), UInt8((Command.stopSync >> 8) & 0xFF), 1]
-        try await transport.writeCharacteristic(
-            data: Data(command),
-            serviceUUID: DeviceUUIDs.PLAUD.service,
-            characteristicUUID: DeviceUUIDs.PLAUD.writeCharacteristic,
-            withResponse: true
-        )
+        try await commandQueue.run { [weak self] in
+            guard let self else { throw DeviceTransportError.disposed }
+            try await self.transport.writeCharacteristic(
+                data: Data(command),
+                serviceUUID: DeviceUUIDs.PLAUD.service,
+                characteristicUUID: DeviceUUIDs.PLAUD.writeCharacteristic,
+                withResponse: true
+            )
+        }
     }
 
-    private func setupRecordingSession() async -> Bool {
+    private func setupRecordingSession() async throws {
+        recordingSetupAttempted = true
         let maxRetries = 3
+        var lastError: Error?
 
         for attempt in 0..<maxRetries {
+            try Task.checkCancellation()
             do {
                 if attempt > 0 {
                     logger.debug("Retry attempt \(attempt)/\(maxRetries)")
-                    try await Task.sleep(nanoseconds: UInt64(attempt) * 1_000_000_000)
+                    try await operationClock.sleep(for: .seconds(attempt))
                 }
 
                 try await stopRecord(sessionId: 0)
-                try await Task.sleep(nanoseconds: 500_000_000)
+                try await operationClock.sleep(for: .milliseconds(500))
 
                 guard let recordInfo = try await startRecord() else { continue }
 
                 sessionId = recordInfo.sessionId
 
-                try await Task.sleep(nanoseconds: 1_000_000_000)
+                try await operationClock.sleep(for: .seconds(1))
 
                 if try await startSync(sessionId: recordInfo.sessionId, start: recordInfo.startTime) {
                     logger.debug("Recording session setup successful")
-                    return true
+                    return
                 }
             } catch {
+                guard !Task.isCancelled else { throw CancellationError() }
+                lastError = error
                 logger.debug("Setup error (attempt \(attempt + 1)): \(error.localizedDescription)")
             }
         }
 
-        return false
+        throw lastError ?? DeviceConnectionError.operationFailed(
+            "PLAUD recording session setup failed"
+        )
+    }
+
+    private func stopRecordingSession() async throws {
+        guard recordingSetupAttempted else { return }
+        recordingSetupAttempted = false
+        let sessionToStop = sessionId ?? 0
+        var failures: [String] = []
+        do {
+            try await stopSync()
+        } catch {
+            failures.append(error.localizedDescription)
+        }
+        do {
+            try await stopRecord(sessionId: sessionToStop)
+        } catch {
+            failures.append(error.localizedDescription)
+        }
+        sessionId = nil
+
+        guard failures.isEmpty else {
+            let message = failures.joined(separator: "; ")
+            logger.debug("Error stopping recording session: \(message)")
+            await transport.disconnect()
+            throw DeviceConnectionError.operationFailed(message)
+        }
     }
 
     // MARK: - Battery
@@ -274,7 +323,7 @@ final class PlaudDeviceConnection: BaseDeviceConnection {
     override func getBatteryLevelStream() -> AsyncThrowingStream<Int, Error> {
         // PLAUD uses command-based battery retrieval, poll every 60 seconds
         return AsyncThrowingStream { [weak self] continuation in
-            Task { [weak self] in
+            let pollingTask = Task { [weak self] in
                 guard let self = self else {
                     continuation.finish()
                     return
@@ -289,7 +338,12 @@ final class PlaudDeviceConnection: BaseDeviceConnection {
                 // Poll every 60 seconds
                 var lastLevel = initialLevel
                 while await self.isConnected() {
-                    try? await Task.sleep(nanoseconds: 60_000_000_000)
+                    do {
+                        try await self.operationClock.sleep(for: .seconds(60))
+                    } catch {
+                        break
+                    }
+                    guard !Task.isCancelled else { break }
 
                     let level = await self.getBatteryLevel()
                     if level >= 0 && level != lastLevel {
@@ -299,6 +353,9 @@ final class PlaudDeviceConnection: BaseDeviceConnection {
                 }
 
                 continuation.finish()
+            }
+            continuation.onTermination = { @Sendable _ in
+                pollingTask.cancel()
             }
         }
     }
@@ -310,46 +367,28 @@ final class PlaudDeviceConnection: BaseDeviceConnection {
     }
 
     override func getAudioStream() -> AsyncThrowingStream<Data, Error> {
-        return AsyncThrowingStream { [weak self] continuation in
-            Task { [weak self] in
-                guard let self = self else {
-                    continuation.finish()
-                    return
-                }
-
-                // Setup recording session
-                guard await self.setupRecordingSession() else {
-                    self.logger.debug("Failed to setup recording session")
-                    continuation.finish()
-                    return
-                }
-
-                // Buffer for 80-byte chunking
+        let rawStream = audioStreamController.makeStream()
+        return AsyncThrowingStream { continuation in
+            let chunkingTask = Task { @MainActor in
                 var buffer = [UInt8]()
-                let chunkSize = 80
-
-                let cancellable = self.audioStreamSubject
-                    .sink(
-                        receiveCompletion: { _ in
-                            // Flush remaining buffer
-                            if !buffer.isEmpty {
-                                continuation.yield(Data(buffer))
-                            }
-                            continuation.finish()
-                        },
-                        receiveValue: { data in
-                            buffer.append(contentsOf: data)
-                            while buffer.count >= chunkSize {
-                                let chunk = Array(buffer.prefix(chunkSize))
-                                continuation.yield(Data(chunk))
-                                buffer.removeFirst(chunkSize)
-                            }
+                do {
+                    for try await data in rawStream {
+                        buffer.append(contentsOf: data)
+                        while buffer.count >= 80 {
+                            continuation.yield(Data(buffer.prefix(80)))
+                            buffer.removeFirst(80)
                         }
-                    )
-
-                continuation.onTermination = { @Sendable _ in
-                    cancellable.cancel()
+                    }
+                    if !buffer.isEmpty {
+                        continuation.yield(Data(buffer))
+                    }
+                    continuation.finish()
+                } catch {
+                    continuation.finish(throwing: error)
                 }
+            }
+            continuation.onTermination = { @Sendable _ in
+                chunkingTask.cancel()
             }
         }
     }

--- a/desktop/macos/Desktop/Sources/Bluetooth/Session/BluetoothConnectionLease.swift
+++ b/desktop/macos/Desktop/Sources/Bluetooth/Session/BluetoothConnectionLease.swift
@@ -1,0 +1,114 @@
+import CoreBluetooth
+import Foundation
+
+/// Manager-owned identity for one CoreBluetooth connection attempt.
+///
+/// CoreBluetooth delegate callbacks carry only a peripheral. The manager keeps
+/// a lease active until a terminal delegate callback (or central reset), so a
+/// later session cannot reuse that peripheral identity while an old callback is
+/// still possible.
+struct BluetoothConnectionLease: Equatable, Hashable, Sendable {
+    let peripheralID: UUID
+    let token: UInt64
+    let sessionGeneration: UInt64
+}
+
+enum BluetoothConnectionLeaseError: LocalizedError, Equatable {
+    case leaseAlreadyActive(BluetoothConnectionLease)
+    case centralUnavailable
+
+    var errorDescription: String? {
+        switch self {
+        case .leaseAlreadyActive:
+            return "A previous Bluetooth connection attempt is still draining"
+        case .centralUnavailable:
+            return "Bluetooth is not powered on"
+        }
+    }
+}
+
+@MainActor
+protocol BluetoothCentralConnectionControlling: AnyObject {
+    func beginConnection(
+        to peripheral: CBPeripheral,
+        sessionGeneration: UInt64
+    ) throws -> BluetoothConnectionLease
+
+    func cancelConnection(
+        to peripheral: CBPeripheral,
+        lease: BluetoothConnectionLease
+    )
+}
+
+@MainActor
+final class BluetoothConnectionLeaseRegistry {
+    private enum Phase: Equatable {
+        case connecting
+        case connected
+        case cancelling
+    }
+
+    private struct Entry {
+        let lease: BluetoothConnectionLease
+        var phase: Phase
+    }
+
+    private var nextToken: UInt64 = 0
+    private var entries: [UUID: Entry] = [:]
+
+    func begin(
+        peripheralID: UUID,
+        sessionGeneration: UInt64
+    ) throws -> BluetoothConnectionLease {
+        if let existing = entries[peripheralID]?.lease {
+            throw BluetoothConnectionLeaseError.leaseAlreadyActive(existing)
+        }
+
+        nextToken &+= 1
+        let lease = BluetoothConnectionLease(
+            peripheralID: peripheralID,
+            token: nextToken,
+            sessionGeneration: sessionGeneration
+        )
+        entries[peripheralID] = Entry(lease: lease, phase: .connecting)
+        return lease
+    }
+
+    /// Marks cancellation without releasing identity. The lease remains fenced
+    /// until CoreBluetooth reports failure/disconnect or the central resets.
+    @discardableResult
+    func requestCancellation(_ lease: BluetoothConnectionLease) -> Bool {
+        guard var entry = entries[lease.peripheralID], entry.lease == lease else {
+            return false
+        }
+        entry.phase = .cancelling
+        entries[lease.peripheralID] = entry
+        return true
+    }
+
+    func markConnected(
+        peripheralID: UUID
+    ) -> (lease: BluetoothConnectionLease, shouldCancel: Bool)? {
+        guard var entry = entries[peripheralID] else { return nil }
+        let shouldCancel = entry.phase == .cancelling
+        if !shouldCancel {
+            entry.phase = .connected
+            entries[peripheralID] = entry
+        }
+        return (entry.lease, shouldCancel)
+    }
+
+    func finish(peripheralID: UUID) -> BluetoothConnectionLease? {
+        entries.removeValue(forKey: peripheralID)?.lease
+    }
+
+    func reset() -> [BluetoothConnectionLease] {
+        let leases = entries.values.map(\.lease)
+        entries.removeAll()
+        return leases
+    }
+
+    func activeLease(for peripheralID: UUID) -> BluetoothConnectionLease? {
+        entries[peripheralID]?.lease
+    }
+}

--- a/desktop/macos/Desktop/Sources/Bluetooth/Session/DeviceAudioStreamController.swift
+++ b/desktop/macos/Desktop/Sources/Bluetooth/Session/DeviceAudioStreamController.swift
@@ -1,0 +1,185 @@
+import Foundation
+
+/// Owns the device-side lifetime behind a multicast audio stream.
+///
+/// The first subscriber starts the physical recording session. Every subscriber
+/// receives every active-session frame; setup and teardown frames are dropped.
+/// The last subscriber leaving cancels and joins in-flight setup before the stop
+/// action runs. This closes the race where a consumer could disappear during
+/// setup and recording would start afterward without an owner.
+@MainActor
+final class DeviceAudioStreamController {
+    typealias Continuation = AsyncThrowingStream<Data, Error>.Continuation
+    typealias StartAction = @MainActor @Sendable () async throws -> Void
+    typealias StopAction = @MainActor @Sendable () async throws -> Void
+
+    private enum Phase: Equatable {
+        case idle
+        case starting(UInt64)
+        case active(UInt64)
+        case stopping(UInt64)
+    }
+
+    private let startAction: StartAction
+    private let stopAction: StopAction
+    private var phase = Phase.idle
+    private var generation: UInt64 = 0
+    private var subscribers: [UUID: Continuation] = [:]
+    private var setupTask: Task<Void, Never>?
+    private var cleanupTask: Task<Void, Never>?
+    private var isClosed = false
+    private var terminalError: Error?
+
+    init(
+        start: @escaping StartAction,
+        stop: @escaping StopAction
+    ) {
+        self.startAction = start
+        self.stopAction = stop
+    }
+
+    func makeStream() -> AsyncThrowingStream<Data, Error> {
+        guard !isClosed else {
+            return AsyncThrowingStream { continuation in
+                if let terminalError {
+                    continuation.finish(throwing: terminalError)
+                } else {
+                    continuation.finish()
+                }
+            }
+        }
+
+        let subscriberID = UUID()
+        return AsyncThrowingStream { continuation in
+            subscribers[subscriberID] = continuation
+            continuation.onTermination = { @Sendable [weak self] _ in
+                Task { @MainActor [weak self] in
+                    self?.removeSubscriber(subscriberID)
+                }
+            }
+            startIfNeeded()
+        }
+    }
+
+    func yield(_ data: Data) {
+        guard case .active = phase else { return }
+
+        var terminatedSubscribers: [UUID] = []
+        for (subscriberID, continuation) in subscribers {
+            if case .terminated = continuation.yield(data) {
+                terminatedSubscribers.append(subscriberID)
+            }
+        }
+        for subscriberID in terminatedSubscribers {
+            removeSubscriber(subscriberID)
+        }
+    }
+
+    func finish(throwing error: Error? = nil) async {
+        if !isClosed {
+            isClosed = true
+            terminalError = error
+            finishSubscribers(throwing: error)
+        }
+        let cleanup = stopIfNeeded()
+        await cleanup?.value
+    }
+
+    private func startIfNeeded() {
+        guard !isClosed, !subscribers.isEmpty, phase == .idle else { return }
+
+        generation &+= 1
+        let setupGeneration = generation
+        phase = .starting(setupGeneration)
+        let task = Task { @MainActor [weak self] in
+            guard let self else { return }
+            do {
+                try Task.checkCancellation()
+                try await self.startAction()
+                self.completeStart(generation: setupGeneration, error: nil)
+            } catch {
+                self.completeStart(generation: setupGeneration, error: error)
+            }
+        }
+        setupTask = task
+    }
+
+    private func completeStart(generation setupGeneration: UInt64, error: Error?) {
+        guard phase == .starting(setupGeneration) else { return }
+        setupTask = nil
+
+        if let error {
+            // Setup may have completed some physical steps before failing.
+            // Treat it as active until the stop action has unwound them.
+            phase = .active(setupGeneration)
+            finishSubscribers(throwing: error)
+            _ = stopIfNeeded()
+            return
+        }
+
+        phase = .active(setupGeneration)
+    }
+
+    private func removeSubscriber(_ subscriberID: UUID) {
+        subscribers.removeValue(forKey: subscriberID)
+        if subscribers.isEmpty {
+            _ = stopIfNeeded()
+        }
+    }
+
+    @discardableResult
+    private func stopIfNeeded() -> Task<Void, Never>? {
+        switch phase {
+        case .idle:
+            return cleanupTask
+        case .stopping:
+            return cleanupTask
+        case .starting, .active:
+            generation &+= 1
+            let cleanupGeneration = generation
+            phase = .stopping(cleanupGeneration)
+
+            let setup = setupTask
+            setupTask = nil
+            setup?.cancel()
+            let task = Task { @MainActor [weak self] in
+                await setup?.value
+                guard let self else { return }
+                do {
+                    try await self.stopAction()
+                    self.completeStop(generation: cleanupGeneration, error: nil)
+                } catch {
+                    self.completeStop(generation: cleanupGeneration, error: error)
+                }
+            }
+            cleanupTask = task
+            return task
+        }
+    }
+
+    private func completeStop(generation cleanupGeneration: UInt64, error: Error?) {
+        guard phase == .stopping(cleanupGeneration) else { return }
+        cleanupTask = nil
+        phase = .idle
+
+        if let error {
+            terminalError = error
+            isClosed = true
+            finishSubscribers(throwing: error)
+            return
+        }
+        startIfNeeded()
+    }
+
+    private func finishSubscribers(throwing error: Error?) {
+        let currentSubscribers = Array(subscribers.values)
+        subscribers.removeAll()
+        for continuation in currentSubscribers {
+            if let error {
+                continuation.finish(throwing: error)
+            } else {
+                continuation.finish()
+            }
+        }
+    }
+}

--- a/desktop/macos/Desktop/Sources/Bluetooth/Session/DeviceCommandQueue.swift
+++ b/desktop/macos/Desktop/Sources/Bluetooth/Session/DeviceCommandQueue.swift
@@ -1,0 +1,70 @@
+import Foundation
+
+enum DeviceCommandQueueError: LocalizedError, Equatable {
+    case closed
+
+    var errorDescription: String? {
+        "The device command channel is closed"
+    }
+}
+
+/// Serializes adapter commands that share one uncorrelated BLE write channel.
+///
+/// Device command responses carry a command ID, but the physical write callback
+/// identifies only the characteristic. Keeping the whole request/response
+/// exchange serial prevents a second command from being rejected locally after
+/// its response gate was registered, and makes callback ownership explicit.
+@MainActor
+final class DeviceCommandQueue {
+    private var tail = Task<Void, Never> {}
+    private var nextToken: UInt64 = 0
+    private var cancellationActions: [UInt64: @MainActor () -> Void] = [:]
+    private var isClosed = false
+
+    func run<Value: Sendable>(
+        _ operation: @escaping @MainActor @Sendable () async throws -> Value
+    ) async throws -> Value {
+        guard !isClosed else { throw DeviceCommandQueueError.closed }
+
+        nextToken &+= 1
+        let token = nextToken
+        let predecessor = tail
+        let task = Task { @MainActor [weak self] in
+            await predecessor.value
+            guard let self, !self.isClosed else {
+                throw DeviceCommandQueueError.closed
+            }
+            try Task.checkCancellation()
+            return try await operation()
+        }
+        cancellationActions[token] = {
+            task.cancel()
+        }
+        tail = Task { @MainActor [weak self] in
+            _ = try? await task.value
+            self?.cancellationActions.removeValue(forKey: token)
+        }
+
+        return try await withTaskCancellationHandler {
+            try await task.value
+        } onCancel: {
+            task.cancel()
+        }
+    }
+
+    /// Permanently closes the one-session queue, cancels active and queued
+    /// commands, and joins the tail before adapter brokers are reset.
+    func close() async {
+        guard !isClosed else {
+            await tail.value
+            return
+        }
+
+        isClosed = true
+        let actions = Array(cancellationActions.values)
+        let drainingTail = tail
+        actions.forEach { $0() }
+        await drainingTail.value
+        cancellationActions.removeAll()
+    }
+}

--- a/desktop/macos/Desktop/Sources/Bluetooth/Session/DeviceOperationBroker.swift
+++ b/desktop/macos/Desktop/Sources/Bluetooth/Session/DeviceOperationBroker.swift
@@ -1,0 +1,358 @@
+import Foundation
+
+enum DeviceOperationBrokerError: LocalizedError, Equatable, Sendable {
+    case operationAlreadyPending
+    case timedOut
+    case cancelled
+    case disconnected
+    case failed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .operationAlreadyPending:
+            return "Another operation with the same identity is already pending"
+        case .timedOut:
+            return "Operation timed out"
+        case .cancelled:
+            return "Operation was cancelled"
+        case .disconnected:
+            return "Device disconnected before the operation completed"
+        case .failed(let reason):
+            return reason
+        }
+    }
+}
+
+struct DeviceOperationHandle<Key: Hashable & Sendable>: Hashable, Sendable {
+    fileprivate let key: Key
+    fileprivate let token: UInt64
+}
+
+enum DeviceOperationTermination: Equatable, Sendable {
+    case succeeded
+    case timedOut
+    case cancelled
+    case disconnected
+    case failed
+}
+
+/// Tracks operations whose physical callback identifies only a key, not the
+/// broker token. If such an operation terminates before its callback arrives,
+/// the key is poisoned until session teardown: starting another operation
+/// would let the old callback masquerade as the new operation's response.
+@MainActor
+final class UncorrelatedOperationGate<Key: Hashable & Sendable> {
+    private var handles: [Key: DeviceOperationHandle<Key>] = [:]
+    private var poisonedKeys: Set<Key> = []
+
+    func canStart(_ key: Key) -> Bool {
+        handles[key] == nil && !poisonedKeys.contains(key)
+    }
+
+    @discardableResult
+    func register(_ handle: DeviceOperationHandle<Key>) -> Bool {
+        guard canStart(handle.key) else { return false }
+        handles[handle.key] = handle
+        return true
+    }
+
+    func takeHandleForCallback(key: Key) -> DeviceOperationHandle<Key>? {
+        guard !poisonedKeys.contains(key) else { return nil }
+        return handles.removeValue(forKey: key)
+    }
+
+    func terminal(
+        handle: DeviceOperationHandle<Key>,
+        termination: DeviceOperationTermination
+    ) {
+        guard handles[handle.key] == handle else { return }
+        handles.removeValue(forKey: handle.key)
+        if termination != .succeeded {
+            poisonedKeys.insert(handle.key)
+        }
+    }
+
+    func reset() {
+        handles.removeAll()
+        poisonedKeys.removeAll()
+    }
+}
+
+protocol DeviceOperationClock: Sendable {
+    func sleep(for duration: Duration) async throws
+}
+
+struct ContinuousDeviceOperationClock: DeviceOperationClock {
+    func sleep(for duration: Duration) async throws {
+        try await ContinuousClock().sleep(for: duration)
+    }
+}
+
+/// Owns one pending operation per key and guarantees exactly one terminal result.
+///
+/// Device callbacks, timeouts, cancellation, and disconnect can all race. They
+/// converge here so only the first terminal event removes and resumes a pending
+/// continuation; every late event is an explicit no-op.
+actor DeviceOperationBroker<Key: Hashable & Sendable, Value: Sendable> {
+    private struct PendingOperation {
+        let handle: DeviceOperationHandle<Key>
+        let continuation: CheckedContinuation<Value, Error>
+        let onTerminal: @MainActor @Sendable (
+            DeviceOperationHandle<Key>,
+            DeviceOperationTermination
+        ) -> Void
+        var timeoutTask: Task<Void, Never>?
+        var startTask: Task<Result<Void, DeviceOperationBrokerError>, Never>?
+        var completionToken: UInt64?
+    }
+
+    private struct CompletionClaim {
+        let operation: PendingOperation
+        let token: UInt64
+    }
+
+    private let clock: any DeviceOperationClock
+    private var nextToken: UInt64 = 0
+    private var nextCompletionToken: UInt64 = 0
+    private var pending: [Key: PendingOperation] = [:]
+
+    init(clock: any DeviceOperationClock = ContinuousDeviceOperationClock()) {
+        self.clock = clock
+    }
+
+    func perform(
+        key: Key,
+        timeout: Duration? = nil,
+        onTerminal: @escaping @MainActor @Sendable (
+            DeviceOperationHandle<Key>,
+            DeviceOperationTermination
+        ) -> Void = { _, _ in },
+        start: @escaping @MainActor @Sendable (DeviceOperationHandle<Key>) async throws -> Void
+    ) async throws -> Value {
+        guard pending[key] == nil else {
+            throw DeviceOperationBrokerError.operationAlreadyPending
+        }
+        guard !Task.isCancelled else {
+            throw DeviceOperationBrokerError.cancelled
+        }
+
+        nextToken &+= 1
+        let handle = DeviceOperationHandle(key: key, token: nextToken)
+
+        return try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                var operation = PendingOperation(
+                    handle: handle,
+                    continuation: continuation,
+                    onTerminal: onTerminal,
+                    timeoutTask: nil,
+                    startTask: nil,
+                    completionToken: nil
+                )
+
+                if let timeout {
+                    operation.timeoutTask = Task { [clock] in
+                        do {
+                            try await clock.sleep(for: timeout)
+                        } catch {
+                            return
+                        }
+                        await self.finish(
+                            handle: handle,
+                            result: .failure(DeviceOperationBrokerError.timedOut)
+                        )
+                    }
+                }
+
+                pending[key] = operation
+                if Task.isCancelled {
+                    Task {
+                        await self.finish(
+                            handle: handle,
+                            result: .failure(DeviceOperationBrokerError.cancelled)
+                        )
+                    }
+                    return
+                }
+                let startTask = Task<Result<Void, DeviceOperationBrokerError>, Never> { @MainActor in
+                    guard !Task.isCancelled,
+                          await self.isPending(handle: handle) else {
+                        return Result.failure(DeviceOperationBrokerError.cancelled)
+                    }
+                    do {
+                        try await start(handle)
+                        return Result.success(())
+                    } catch {
+                        return Result.failure(
+                            DeviceOperationBrokerError.failed(error.localizedDescription)
+                        )
+                    }
+                }
+                pending[key]?.startTask = startTask
+                Task {
+                    guard case .failure(let error) = await startTask.value else { return }
+                    await self.finish(handle: handle, result: .failure(error))
+                }
+            }
+        } onCancel: {
+            Task {
+                await self.finish(
+                    handle: handle,
+                    result: .failure(DeviceOperationBrokerError.cancelled)
+                )
+            }
+        }
+    }
+
+    @discardableResult
+    func succeed(handle: DeviceOperationHandle<Key>, value: Value) async -> Bool {
+        guard let claim = claimPending(handle: handle) else { return false }
+        let operation = claim.operation
+        operation.timeoutTask?.cancel()
+        let startResult = await operation.startTask?.value
+        guard removePending(handle: handle, completionToken: claim.token) != nil else {
+            return false
+        }
+        if let startResult, case .failure(let error) = startResult {
+            await operation.onTerminal(handle, termination(for: error))
+            operation.continuation.resume(throwing: error)
+        } else {
+            await operation.onTerminal(handle, .succeeded)
+            operation.continuation.resume(returning: value)
+        }
+        return true
+    }
+
+    @discardableResult
+    func fail(handle: DeviceOperationHandle<Key>, reason: String) async -> Bool {
+        guard let claim = claimPending(handle: handle) else { return false }
+        let operation = claim.operation
+        operation.timeoutTask?.cancel()
+        if let startTask = operation.startTask {
+            _ = await startTask.value
+        }
+        guard removePending(handle: handle, completionToken: claim.token) != nil else {
+            return false
+        }
+        await operation.onTerminal(handle, .failed)
+        operation.continuation.resume(
+            throwing: DeviceOperationBrokerError.failed(reason)
+        )
+        return true
+    }
+
+    func cancelAll(reason: DeviceOperationBrokerError = .cancelled) async {
+        // Session shutdown deliberately supersedes even a callback that has
+        // already claimed completion. Claim every current entry before the
+        // first suspension so keys remain unavailable while physical starts
+        // drain, and so only this cancellation wave can resume them.
+        let handles = pending.values.map(\.handle)
+        let claims = handles.compactMap { handle in
+            claimPending(handle: handle, replacingExistingClaim: true)
+        }
+        for claim in claims {
+            let operation = claim.operation
+            operation.timeoutTask?.cancel()
+            operation.startTask?.cancel()
+            if let startTask = operation.startTask {
+                _ = await startTask.value
+            }
+            guard removePending(
+                handle: operation.handle,
+                completionToken: claim.token
+            ) != nil else {
+                continue
+            }
+            await operation.onTerminal(operation.handle, termination(for: reason))
+            operation.continuation.resume(throwing: reason)
+        }
+    }
+
+    func hasPendingOperation(for key: Key) -> Bool {
+        pending[key] != nil
+    }
+
+    var pendingCount: Int {
+        pending.count
+    }
+
+    private func finish(
+        handle: DeviceOperationHandle<Key>,
+        result: Result<Value, Error>
+    ) async {
+        // Ordinary terminal sources (timeout, caller cancellation, and start
+        // failure) may only claim an unclaimed operation. Once a physical
+        // callback owns completion, they are late signals and must not steal
+        // or double-resume the continuation while its start task drains.
+        guard let claim = claimPending(handle: handle) else { return }
+        let operation = claim.operation
+        operation.timeoutTask?.cancel()
+        operation.startTask?.cancel()
+        if let startTask = operation.startTask {
+            _ = await startTask.value
+        }
+        guard removePending(handle: handle, completionToken: claim.token) != nil else {
+            return
+        }
+        await operation.onTerminal(handle, termination(for: result))
+        operation.continuation.resume(with: result)
+    }
+
+    private func isPending(handle: DeviceOperationHandle<Key>) -> Bool {
+        pending[handle.key]?.handle == handle
+    }
+
+    private func removePending(
+        handle: DeviceOperationHandle<Key>,
+        completionToken: UInt64
+    ) -> PendingOperation? {
+        guard pending[handle.key]?.handle == handle,
+              pending[handle.key]?.completionToken == completionToken else {
+            return nil
+        }
+        return pending.removeValue(forKey: handle.key)
+    }
+
+    private func claimPending(
+        handle: DeviceOperationHandle<Key>,
+        replacingExistingClaim: Bool = false
+    ) -> CompletionClaim? {
+        guard var operation = pending[handle.key],
+              operation.handle == handle,
+              replacingExistingClaim || operation.completionToken == nil else {
+            return nil
+        }
+        nextCompletionToken &+= 1
+        operation.completionToken = nextCompletionToken
+        pending[handle.key] = operation
+        return CompletionClaim(operation: operation, token: nextCompletionToken)
+    }
+
+    private func termination(
+        for result: Result<Value, Error>
+    ) -> DeviceOperationTermination {
+        switch result {
+        case .success:
+            return .succeeded
+        case .failure(let error as DeviceOperationBrokerError):
+            return termination(for: error)
+        case .failure:
+            return .failed
+        }
+    }
+
+    private func termination(
+        for error: DeviceOperationBrokerError
+    ) -> DeviceOperationTermination {
+        switch error {
+        case .timedOut:
+            return .timedOut
+        case .cancelled:
+            return .cancelled
+        case .disconnected:
+            return .disconnected
+        case .operationAlreadyPending, .failed:
+            return .failed
+        }
+    }
+}

--- a/desktop/macos/Desktop/Sources/Bluetooth/Session/DeviceSessionCoordinator.swift
+++ b/desktop/macos/Desktop/Sources/Bluetooth/Session/DeviceSessionCoordinator.swift
@@ -1,0 +1,402 @@
+import Foundation
+
+enum DeviceSessionPhase: Equatable, Sendable {
+    case idle
+    case connecting
+    case ready
+    case disconnecting
+    case waitingToReconnect(attempt: Int)
+
+    var isConnecting: Bool {
+        if case .connecting = self { return true }
+        return false
+    }
+
+    var isReady: Bool {
+        if case .ready = self { return true }
+        return false
+    }
+
+    var allowsConnectionAttempt: Bool {
+        switch self {
+        case .idle, .waitingToReconnect:
+            return true
+        case .connecting, .ready, .disconnecting:
+            return false
+        }
+    }
+}
+
+struct DeviceSessionSnapshot: Equatable {
+    fileprivate(set) var generation: UInt64
+    fileprivate(set) var phase: DeviceSessionPhase
+    fileprivate(set) var pairedDevice: BtDevice?
+    fileprivate(set) var connectedDevice: BtDevice?
+    fileprivate(set) var failureMessage: String?
+
+    static func initial(pairedDevice: BtDevice?) -> DeviceSessionSnapshot {
+        DeviceSessionSnapshot(
+            generation: 0,
+            phase: .idle,
+            pairedDevice: pairedDevice,
+            connectedDevice: nil,
+            failureMessage: nil
+        )
+    }
+}
+
+struct DeviceReconnectRequest {
+    let device: BtDevice
+    fileprivate let generation: UInt64
+    fileprivate let attempt: Int
+}
+
+enum DeviceSessionCoordinatorError: LocalizedError, Equatable {
+    case connectionAlreadyActive
+    case connectionUnavailable
+    case superseded
+
+    var errorDescription: String? {
+        switch self {
+        case .connectionAlreadyActive:
+            return "A device connection is already active"
+        case .connectionUnavailable:
+            return "The device is not currently available over Bluetooth"
+        case .superseded:
+            return "The device connection was superseded"
+        }
+    }
+}
+
+@MainActor
+protocol DeviceSessionScheduledAction: AnyObject {
+    func cancel()
+}
+
+@MainActor
+protocol DeviceSessionScheduling: AnyObject {
+    func schedule(
+        after delay: Duration,
+        action: @escaping @MainActor () -> Void
+    ) -> any DeviceSessionScheduledAction
+}
+
+@MainActor
+final class DeviceSessionTaskScheduler: DeviceSessionScheduling {
+    private final class ScheduledAction: DeviceSessionScheduledAction {
+        let task: Task<Void, Never>
+
+        init(task: Task<Void, Never>) {
+            self.task = task
+        }
+
+        func cancel() {
+            task.cancel()
+        }
+    }
+
+    private let clock: any DeviceOperationClock
+
+    init(clock: any DeviceOperationClock = ContinuousDeviceOperationClock()) {
+        self.clock = clock
+    }
+
+    func schedule(
+        after delay: Duration,
+        action: @escaping @MainActor () -> Void
+    ) -> any DeviceSessionScheduledAction {
+        let task = Task { @MainActor [clock] in
+            do {
+                if delay > .zero {
+                    try await clock.sleep(for: delay)
+                }
+            } catch {
+                return
+            }
+            guard !Task.isCancelled else { return }
+            action()
+        }
+        return ScheduledAction(task: task)
+    }
+}
+
+/// Canonical owner for the logical lifecycle of one paired Bluetooth device.
+///
+/// Every connect attempt receives a monotonically increasing generation. The
+/// coordinator accepts callbacks only from the current connection object and
+/// generation, which makes late CoreBluetooth callbacks harmless.
+@MainActor
+final class DeviceSessionCoordinator: DeviceConnectionDelegate {
+    typealias ConnectionFactory = @MainActor (BtDevice, UInt64) -> DeviceConnection?
+
+    private let connectionFactory: ConnectionFactory
+    private let scheduler: any DeviceSessionScheduling
+    private let reconnectDelay: Duration
+    private let autoReconnectEnabled: Bool
+
+    private(set) var snapshot: DeviceSessionSnapshot
+    private(set) var activeConnection: DeviceConnection?
+
+    private var reconnectAttempt = 0
+    private var scheduledReconnect: (any DeviceSessionScheduledAction)?
+
+    var onSnapshotChanged: ((DeviceSessionSnapshot) -> Void)?
+    var onReconnectRequested: ((DeviceReconnectRequest) -> Void)?
+    var onDiscoveryRequested: (() -> Void)?
+    var onSessionEnded: (() -> Void)?
+    var onFallDetected: ((AccelerometerData) -> Void)?
+
+    init(
+        pairedDevice: BtDevice?,
+        connectionFactory: @escaping ConnectionFactory,
+        scheduler: any DeviceSessionScheduling,
+        reconnectDelay: Duration = .seconds(15),
+        autoReconnectEnabled: Bool = true
+    ) {
+        self.snapshot = .initial(pairedDevice: pairedDevice)
+        self.connectionFactory = connectionFactory
+        self.scheduler = scheduler
+        self.reconnectDelay = reconnectDelay
+        self.autoReconnectEnabled = autoReconnectEnabled
+    }
+
+    func connect(to device: BtDevice) async throws -> DeviceConnection {
+        try await connect(to: device, reconnectRequest: nil)
+    }
+
+    func reconnect(_ request: DeviceReconnectRequest) async throws -> DeviceConnection {
+        try await connect(to: request.device, reconnectRequest: request)
+    }
+
+    private func connect(
+        to device: BtDevice,
+        reconnectRequest: DeviceReconnectRequest?
+    ) async throws -> DeviceConnection {
+        let isReconnectAttempt = reconnectRequest != nil
+        if let reconnectRequest {
+            guard snapshot.generation == reconnectRequest.generation,
+                  snapshot.phase == .waitingToReconnect(attempt: reconnectRequest.attempt),
+                  snapshot.pairedDevice?.id == reconnectRequest.device.id else {
+                throw DeviceSessionCoordinatorError.superseded
+            }
+        } else {
+            guard snapshot.phase.allowsConnectionAttempt else {
+                throw DeviceSessionCoordinatorError.connectionAlreadyActive
+            }
+        }
+
+        cancelScheduledReconnect()
+        let generation = nextGeneration()
+        snapshot.phase = .connecting
+        snapshot.connectedDevice = nil
+        snapshot.failureMessage = nil
+        publishSnapshot()
+
+        guard let connection = connectionFactory(device, generation) else {
+            let error = DeviceSessionCoordinatorError.connectionUnavailable
+            recordConnectionFailure(error.localizedDescription)
+            if isReconnectAttempt {
+                scheduleReconnectIfNeeded(after: reconnectDelay)
+            }
+            throw error
+        }
+
+        activeConnection = connection
+        connection.delegate = self
+
+        do {
+            try await connection.connect()
+        } catch {
+            let wasCurrent = isCurrent(connection)
+            if wasCurrent {
+                activeConnection = nil
+                recordConnectionFailure(error.localizedDescription)
+                if isReconnectAttempt {
+                    scheduleReconnectIfNeeded(after: reconnectDelay)
+                }
+            }
+            await connection.disconnect()
+            guard wasCurrent else {
+                throw DeviceSessionCoordinatorError.superseded
+            }
+            throw error
+        }
+
+        guard isCurrent(connection), snapshot.phase.isConnecting else {
+            await connection.disconnect()
+            throw DeviceSessionCoordinatorError.superseded
+        }
+
+        reconnectAttempt = 0
+        snapshot.phase = .ready
+        snapshot.pairedDevice = connection.device
+        snapshot.connectedDevice = connection.device
+        snapshot.failureMessage = nil
+        publishSnapshot()
+        return connection
+    }
+
+    func disconnect(reconnectAfter delay: Duration? = .zero) async {
+        cancelScheduledReconnect()
+        guard let connection = activeConnection else {
+            if let delay {
+                scheduleReconnectIfNeeded(after: delay)
+            }
+            return
+        }
+
+        let teardownGeneration = nextGeneration()
+        snapshot.phase = .disconnecting
+        snapshot.connectedDevice = nil
+        snapshot.failureMessage = nil
+        publishSnapshot()
+
+        activeConnection = nil
+        await connection.disconnect()
+
+        guard snapshot.generation == teardownGeneration,
+              snapshot.phase == .disconnecting,
+              activeConnection == nil else {
+            return
+        }
+        snapshot.phase = .idle
+        publishSnapshot()
+        onSessionEnded?()
+
+        if let delay {
+            scheduleReconnectIfNeeded(after: delay)
+        }
+    }
+
+    func unpair() async {
+        cancelScheduledReconnect()
+        let teardownGeneration = nextGeneration()
+        let connection = activeConnection
+        activeConnection = nil
+
+        snapshot.phase = connection == nil ? .idle : .disconnecting
+        snapshot.connectedDevice = nil
+        snapshot.pairedDevice = nil
+        snapshot.failureMessage = nil
+        publishSnapshot()
+
+        if let connection {
+            await connection.unpair()
+
+            guard snapshot.generation == teardownGeneration,
+                  snapshot.phase == .disconnecting,
+                  activeConnection == nil,
+                  snapshot.pairedDevice == nil else {
+                return
+            }
+            onSessionEnded?()
+        }
+
+        snapshot.phase = .idle
+        publishSnapshot()
+    }
+
+    func startReconnecting() {
+        scheduleReconnectIfNeeded(after: .zero)
+    }
+
+    func stopReconnecting() {
+        cancelScheduledReconnect()
+        if case .waitingToReconnect = snapshot.phase {
+            snapshot.phase = .idle
+            publishSnapshot()
+        }
+    }
+
+    func isReady(generation: UInt64) -> Bool {
+        snapshot.generation == generation && snapshot.phase.isReady
+    }
+
+    func deviceConnection(
+        _ connection: DeviceConnection,
+        didDisconnectUnexpectedly device: BtDevice
+    ) {
+        guard isCurrent(connection) else { return }
+
+        activeConnection = nil
+        _ = nextGeneration()
+        snapshot.phase = .idle
+        snapshot.connectedDevice = nil
+        snapshot.failureMessage = "Device disconnected unexpectedly"
+        publishSnapshot()
+        onSessionEnded?()
+        scheduleReconnectIfNeeded(after: .zero)
+    }
+
+    func deviceConnection(
+        _ connection: DeviceConnection,
+        didDetectFall data: AccelerometerData
+    ) {
+        guard isCurrent(connection) else { return }
+        onFallDetected?(data)
+    }
+
+    private func isCurrent(_ connection: DeviceConnection) -> Bool {
+        activeConnection === connection
+            && connection.sessionGeneration == snapshot.generation
+    }
+
+    @discardableResult
+    private func nextGeneration() -> UInt64 {
+        snapshot.generation &+= 1
+        return snapshot.generation
+    }
+
+    private func recordConnectionFailure(_ message: String) {
+        snapshot.phase = .idle
+        snapshot.connectedDevice = nil
+        snapshot.failureMessage = message
+        publishSnapshot()
+    }
+
+    private func scheduleReconnectIfNeeded(after delay: Duration) {
+        guard autoReconnectEnabled, let pairedDevice = snapshot.pairedDevice else { return }
+        guard snapshot.phase.allowsConnectionAttempt else { return }
+
+        cancelScheduledReconnect()
+        reconnectAttempt += 1
+        let expectedGeneration = snapshot.generation
+        let expectedAttempt = reconnectAttempt
+        snapshot.phase = .waitingToReconnect(attempt: expectedAttempt)
+        publishSnapshot()
+
+        // A zero-delay attempt is the direct reconnect path. Preserve the
+        // manager's cached peripheral until that attempt has run; scanning
+        // clears the cache. If direct reconnect cannot build a connection,
+        // `connect` schedules the delayed path below, which starts discovery.
+        if delay > .zero {
+            onDiscoveryRequested?()
+        }
+
+        scheduledReconnect = scheduler.schedule(after: delay) { [weak self] in
+            guard let self else { return }
+            guard self.snapshot.generation == expectedGeneration,
+                  self.snapshot.phase == .waitingToReconnect(attempt: expectedAttempt),
+                  self.snapshot.pairedDevice?.id == pairedDevice.id else {
+                return
+            }
+            self.scheduledReconnect = nil
+            self.onReconnectRequested?(
+                DeviceReconnectRequest(
+                    device: pairedDevice,
+                    generation: expectedGeneration,
+                    attempt: expectedAttempt
+                )
+            )
+        }
+    }
+
+    private func cancelScheduledReconnect() {
+        scheduledReconnect?.cancel()
+        scheduledReconnect = nil
+    }
+
+    private func publishSnapshot() {
+        onSnapshotChanged?(snapshot)
+    }
+}

--- a/desktop/macos/Desktop/Sources/Bluetooth/Transports/BLEPhysicalDriver.swift
+++ b/desktop/macos/Desktop/Sources/Bluetooth/Transports/BLEPhysicalDriver.swift
@@ -1,0 +1,98 @@
+import CoreBluetooth
+import Foundation
+
+/// Narrow CoreBluetooth side-effect seam used by `BleTransport`.
+///
+/// Keeping the physical driver separate lets the transport's operation,
+/// timeout, and disposal contracts run deterministically in unit tests without
+/// constructing private CoreBluetooth objects or touching Bluetooth hardware.
+@MainActor
+protocol BLEPhysicalDriving: AnyObject {
+    var identifier: UUID { get }
+    var state: CBPeripheralState { get }
+    var delegate: CBPeripheralDelegate? { get set }
+
+    func connect(sessionGeneration: UInt64) throws -> BluetoothConnectionLease
+    func disconnect()
+    func discoverServices(_ serviceUUIDs: [CBUUID]?)
+    func discoverCharacteristics(_ characteristicUUIDs: [CBUUID]?, for service: CBService)
+    func readValue(for characteristic: CBCharacteristic)
+    func writeValue(
+        _ data: Data,
+        for characteristic: CBCharacteristic,
+        type: CBCharacteristicWriteType
+    )
+    func setNotifyValue(_ enabled: Bool, for characteristic: CBCharacteristic)
+    func readRSSI()
+}
+
+@MainActor
+final class CoreBluetoothPhysicalDriver: BLEPhysicalDriving {
+    private let peripheral: CBPeripheral
+    private let connectionController: any BluetoothCentralConnectionControlling
+    private var connectionLease: BluetoothConnectionLease?
+
+    init(
+        peripheral: CBPeripheral,
+        connectionController: any BluetoothCentralConnectionControlling
+    ) {
+        self.peripheral = peripheral
+        self.connectionController = connectionController
+    }
+
+    var identifier: UUID { peripheral.identifier }
+    var state: CBPeripheralState { peripheral.state }
+    var delegate: CBPeripheralDelegate? {
+        get { peripheral.delegate }
+        set { peripheral.delegate = newValue }
+    }
+
+    func connect(sessionGeneration: UInt64) throws -> BluetoothConnectionLease {
+        let lease = try connectionController.beginConnection(
+            to: peripheral,
+            sessionGeneration: sessionGeneration
+        )
+        connectionLease = lease
+        return lease
+    }
+
+    func disconnect() {
+        guard let connectionLease else { return }
+        connectionController.cancelConnection(
+            to: peripheral,
+            lease: connectionLease
+        )
+        self.connectionLease = nil
+    }
+
+    func discoverServices(_ serviceUUIDs: [CBUUID]?) {
+        peripheral.discoverServices(serviceUUIDs)
+    }
+
+    func discoverCharacteristics(
+        _ characteristicUUIDs: [CBUUID]?,
+        for service: CBService
+    ) {
+        peripheral.discoverCharacteristics(characteristicUUIDs, for: service)
+    }
+
+    func readValue(for characteristic: CBCharacteristic) {
+        peripheral.readValue(for: characteristic)
+    }
+
+    func writeValue(
+        _ data: Data,
+        for characteristic: CBCharacteristic,
+        type: CBCharacteristicWriteType
+    ) {
+        peripheral.writeValue(data, for: characteristic, type: type)
+    }
+
+    func setNotifyValue(_ enabled: Bool, for characteristic: CBCharacteristic) {
+        peripheral.setNotifyValue(enabled, for: characteristic)
+    }
+
+    func readRSSI() {
+        peripheral.readRSSI()
+    }
+}

--- a/desktop/macos/Desktop/Sources/Bluetooth/Transports/BleTransport.swift
+++ b/desktop/macos/Desktop/Sources/Bluetooth/Transports/BleTransport.swift
@@ -3,187 +3,181 @@ import CoreBluetooth
 import Foundation
 import os.log
 
-/// BLE transport implementation using CoreBluetooth
-/// Ported from: omi/app/lib/services/devices/transports/ble_transport.dart
+private enum BLESingletonOperation: String, Hashable, Sendable {
+    case value
+}
+
+private struct BLEDiscoveredServices: @unchecked Sendable {
+    let values: [CBService]
+}
+
+/// BLE transport implementation using CoreBluetooth.
+///
+/// CoreBluetooth remains the physical driver. Logical session identity belongs
+/// to `DeviceSessionCoordinator`; this transport accepts only events for its
+/// peripheral and carries that coordinator-assigned generation for fencing.
+@MainActor
 final class BleTransport: NSObject, DeviceTransport {
-
-    // MARK: - DeviceTransport Protocol
-
     let deviceId: String
+    let sessionGeneration: UInt64
 
-    var state: DeviceTransportState {
-        _state
-    }
-
+    var state: DeviceTransportState { transportState }
     var connectionStatePublisher: AnyPublisher<DeviceTransportState, Never> {
         connectionStateSubject.eraseToAnyPublisher()
     }
 
-    // MARK: - Private Properties
-
-    private let peripheral: CBPeripheral
-    private let centralManager: CBCentralManager
+    private let physicalDriver: any BLEPhysicalDriving
     private let logger = Logger(subsystem: "me.omi.desktop", category: "BleTransport")
 
-    private var _state: DeviceTransportState = .disconnected
+    private var transportState: DeviceTransportState = .disconnected
     private let connectionStateSubject = PassthroughSubject<DeviceTransportState, Never>()
-
     private var discoveredServices: [CBService] = []
-    // Guards every continuation field below. connect()/read/writeCharacteristic()
-    // run on an arbitrary task executor; the CBPeripheralDelegate callbacks run on
-    // the CoreBluetooth (main) queue; the NotificationCenter connection observers
-    // run on .main; and disconnect()/dispose() drain from yet another context.
-    // Swift Dictionary/Optional mutation is not thread-safe across those, and two
-    // contexts racing to resume the SAME CheckedContinuation traps (double-resume).
-    // So all access is serialized here: capture-and-nil the continuation UNDER the
-    // lock, then resume it OUTSIDE the lock (exactly one context wins the capture).
-    private let continuationsLock = NSLock()
-    private var characteristicContinuations: [CBUUID: CheckedContinuation<Data, Error>] = [:]
-    private var writeContinuations: [CBUUID: CheckedContinuation<Void, Error>] = [:]
-    private var characteristicStreams: [String: CharacteristicStreamHandler] = [:]
-
-    private var connectionContinuation: CheckedContinuation<Void, Error>?
-    private var serviceDiscoveryContinuation: CheckedContinuation<[CBService], Error>?
-
+    private var pendingCharacteristicServices: Set<ObjectIdentifier> = []
+    private var characteristicStreams: [String: CharacteristicStreamBroadcaster] = [:]
     private var isDisposed = false
-    // All block-based NotificationCenter observer tokens. Every token must be
-    // stored and removed individually in deinit: `removeObserver(self)` does NOT
-    // remove block-based observers (they are keyed by the returned token, not by
-    // `self`), so a discarded token leaks the observer and its closure for the
-    // process lifetime — and DeviceProvider recreates transports on every
-    // reconnect attempt, so leaks accumulate unboundedly.
-    private var connectionObservers: [NSObjectProtocol] = []
+    private var isConnectionInvalidated = false
+    private var didRequestPhysicalDisconnect = false
+    private var connectionLease: BluetoothConnectionLease?
 
-    // MARK: - Initialization
+    private var centralEventSubscription: AnyCancellable?
+    private var centralEventContinuation: AsyncStream<BluetoothCentralEvent>.Continuation?
+    private var centralEventTask: Task<Void, Never>?
 
-    init(peripheral: CBPeripheral, centralManager: CBCentralManager) {
-        self.peripheral = peripheral
-        self.centralManager = centralManager
-        self.deviceId = peripheral.identifier.uuidString
+    private let connectOperations: DeviceOperationBroker<BLESingletonOperation, Void>
+    private let serviceOperations: DeviceOperationBroker<BLESingletonOperation, BLEDiscoveredServices>
+    private let characteristicDiscoveryOperations: DeviceOperationBroker<BLESingletonOperation, Void>
+    private let readOperations: DeviceOperationBroker<String, Data>
+    private let writeOperations: DeviceOperationBroker<String, Void>
+
+    private var connectHandle: DeviceOperationHandle<BLESingletonOperation>?
+    private var serviceHandle: DeviceOperationHandle<BLESingletonOperation>?
+    private var characteristicDiscoveryHandle: DeviceOperationHandle<BLESingletonOperation>?
+    private let readGate = UncorrelatedOperationGate<String>()
+    private let writeGate = UncorrelatedOperationGate<String>()
+
+    convenience init(
+        peripheral: CBPeripheral,
+        connectionController: any BluetoothCentralConnectionControlling,
+        centralEvents: AnyPublisher<BluetoothCentralEvent, Never>,
+        sessionGeneration: UInt64,
+        operationClock: any DeviceOperationClock = ContinuousDeviceOperationClock()
+    ) {
+        self.init(
+            physicalDriver: CoreBluetoothPhysicalDriver(
+                peripheral: peripheral,
+                connectionController: connectionController
+            ),
+            centralEvents: centralEvents,
+            sessionGeneration: sessionGeneration,
+            operationClock: operationClock
+        )
+    }
+
+    init(
+        physicalDriver: any BLEPhysicalDriving,
+        centralEvents: AnyPublisher<BluetoothCentralEvent, Never>,
+        sessionGeneration: UInt64,
+        operationClock: any DeviceOperationClock = ContinuousDeviceOperationClock()
+    ) {
+        self.physicalDriver = physicalDriver
+        self.deviceId = physicalDriver.identifier.uuidString
+        self.sessionGeneration = sessionGeneration
+        self.connectOperations = DeviceOperationBroker(clock: operationClock)
+        self.serviceOperations = DeviceOperationBroker(clock: operationClock)
+        self.characteristicDiscoveryOperations = DeviceOperationBroker(clock: operationClock)
+        self.readOperations = DeviceOperationBroker(clock: operationClock)
+        self.writeOperations = DeviceOperationBroker(clock: operationClock)
         super.init()
-        peripheral.delegate = self
-        setupConnectionObserver()
-    }
 
-    private func setupConnectionObserver() {
-        // Observe connection state changes via NotificationCenter
-        // BluetoothManager posts these when CBCentralManagerDelegate methods fire
-        connectionObservers.append(
-            NotificationCenter.default.addObserver(
-                forName: .bleDeviceConnected,
-                object: nil,
-                queue: .main
-            ) { [weak self] notification in
-                guard let self = self,
-                      let peripheralId = notification.userInfo?["peripheralId"] as? UUID,
-                      peripheralId == self.peripheral.identifier else { return }
-
-                self.handleConnectionSuccess()
-            })
-
-        connectionObservers.append(
-            NotificationCenter.default.addObserver(
-                forName: .bleDeviceDisconnected,
-                object: nil,
-                queue: .main
-            ) { [weak self] notification in
-                guard let self = self,
-                      let peripheralId = notification.userInfo?["peripheralId"] as? UUID,
-                      peripheralId == self.peripheral.identifier else { return }
-
-                let error = notification.userInfo?["error"] as? Error
-                self.handleDisconnection(error: error)
-            })
-
-        connectionObservers.append(
-            NotificationCenter.default.addObserver(
-                forName: .bleDeviceFailedToConnect,
-                object: nil,
-                queue: .main
-            ) { [weak self] notification in
-                guard let self = self,
-                      let peripheralId = notification.userInfo?["peripheralId"] as? UUID,
-                      peripheralId == self.peripheral.identifier else { return }
-
-                let error = notification.userInfo?["error"] as? Error
-                self.handleConnectionFailure(error: error)
-            })
-    }
-
-    private func handleConnectionSuccess() {
-        continuationsLock.lock()
-        let continuation = connectionContinuation
-        connectionContinuation = nil
-        continuationsLock.unlock()
-        continuation?.resume()
-    }
-
-    private func handleConnectionFailure(error: Error?) {
-        let transportError = DeviceTransportError.connectionFailed(error?.localizedDescription ?? "Unknown error")
-        continuationsLock.lock()
-        let continuation = connectionContinuation
-        connectionContinuation = nil
-        continuationsLock.unlock()
-        continuation?.resume(throwing: transportError)
-        updateState(.disconnected)
-    }
-
-    private func handleDisconnection(error: Error?) {
-        continuationsLock.lock()
-        let continuation = connectionContinuation
-        connectionContinuation = nil
-        continuationsLock.unlock()
-        continuation?.resume(throwing: DeviceTransportError.connectionFailed("Disconnected during connection"))
-        updateState(.disconnected)
+        physicalDriver.delegate = self
+        let (eventStream, eventContinuation) = AsyncStream.makeStream(
+            of: BluetoothCentralEvent.self
+        )
+        centralEventContinuation = eventContinuation
+        centralEventSubscription = centralEvents.sink { event in
+            eventContinuation.yield(event)
+        }
+        centralEventTask = Task { @MainActor [weak self] in
+            for await event in eventStream {
+                guard let self else { return }
+                await self.handleCentralEvent(event)
+            }
+        }
     }
 
     deinit {
-        // Remove every block-based observer by its token (removeObserver(self)
-        // does not cover them). Missing any one leaks that observer + closure.
-        for observer in connectionObservers {
-            NotificationCenter.default.removeObserver(observer)
-        }
-        connectionObservers.removeAll()
-        NotificationCenter.default.removeObserver(self)
+        centralEventSubscription?.cancel()
+        centralEventContinuation?.finish()
+        centralEventTask?.cancel()
     }
-
-    // MARK: - Connection
 
     func connect() async throws {
         guard !isDisposed else { throw DeviceTransportError.disposed }
-        guard _state != .connected else { return }
+        guard !isConnectionInvalidated else {
+            throw DeviceTransportError.connectionFailed("Transport session must be recreated")
+        }
+        guard transportState != .connected else { return }
 
         updateState(.connecting)
-
         do {
-            // Connect to the peripheral
-            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
-                continuationsLock.lock()
-                self.connectionContinuation = continuation
-                continuationsLock.unlock()
-                self.centralManager.connect(self.peripheral, options: nil)
+            _ = try await connectOperations.perform(
+                key: .value,
+                timeout: .seconds(10),
+                onTerminal: { [weak self] handle, _ in
+                    guard self?.connectHandle == handle else { return }
+                    self?.connectHandle = nil
+                }
+            ) { [weak self] handle in
+                guard let self else { throw DeviceTransportError.disposed }
+                self.connectHandle = handle
+                self.connectionLease = try self.physicalDriver.connect(
+                    sessionGeneration: self.sessionGeneration
+                )
             }
+            try ensureConnectionIsValid()
 
-            // Discover services
-            discoveredServices = try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<[CBService], Error>) in
-                continuationsLock.lock()
-                self.serviceDiscoveryContinuation = continuation
-                continuationsLock.unlock()
-                self.peripheral.discoverServices(nil)
+            let services = try await serviceOperations.perform(
+                key: .value,
+                timeout: .seconds(10),
+                onTerminal: { [weak self] handle, _ in
+                    guard self?.serviceHandle == handle else { return }
+                    self?.serviceHandle = nil
+                }
+            ) { [weak self] handle in
+                guard let self else { throw DeviceTransportError.disposed }
+                self.serviceHandle = handle
+                self.physicalDriver.discoverServices(nil)
             }
+            try ensureConnectionIsValid()
+            discoveredServices = services.values
 
-            // Discover characteristics for each service
-            for service in discoveredServices {
-                peripheral.discoverCharacteristics(nil, for: service)
+            if !discoveredServices.isEmpty {
+                _ = try await characteristicDiscoveryOperations.perform(
+                    key: .value,
+                    timeout: .seconds(10),
+                    onTerminal: { [weak self] handle, _ in
+                        guard self?.characteristicDiscoveryHandle == handle else { return }
+                        self?.characteristicDiscoveryHandle = nil
+                    }
+                ) { [weak self] handle in
+                    guard let self else { throw DeviceTransportError.disposed }
+                    self.characteristicDiscoveryHandle = handle
+                    self.pendingCharacteristicServices = Set(
+                        self.discoveredServices.map(ObjectIdentifier.init)
+                    )
+                    for service in self.discoveredServices {
+                        self.physicalDriver.discoverCharacteristics(nil, for: service)
+                    }
+                }
             }
-
-            // Wait briefly for characteristic discovery
-            try await Task.sleep(nanoseconds: 500_000_000) // 0.5 seconds
+            try ensureConnectionIsValid()
 
             updateState(.connected)
-            logger.info("Connected to device \(self.deviceId)")
-
+            logger.info("Connected to device \(self.deviceId), generation \(self.sessionGeneration)")
         } catch {
+            isConnectionInvalidated = true
+            await cancelPendingOperations(reason: .cancelled)
+            requestPhysicalDisconnectIfNeeded()
             updateState(.disconnected)
             throw DeviceTransportError.connectionFailed(error.localizedDescription)
         }
@@ -191,97 +185,82 @@ final class BleTransport: NSObject, DeviceTransport {
 
     func disconnect() async {
         guard !isDisposed else { return }
-        guard _state != .disconnected else { return }
+        await drainSession()
+    }
 
-        updateState(.disconnecting)
+    func dispose() async {
+        guard !isDisposed else { return }
+        // Claim disposal before the first suspension so concurrent callers
+        // cannot start a second drain. `drainSession` deliberately has no
+        // disposed guard; disposal must still cancel every pending operation.
+        isDisposed = true
+        await drainSession()
+        centralEventSubscription?.cancel()
+        centralEventSubscription = nil
+        centralEventContinuation?.finish()
+        centralEventContinuation = nil
+        centralEventTask?.cancel()
+        centralEventTask = nil
+        physicalDriver.delegate = nil
+        readGate.reset()
+        writeGate.reset()
+        logger.debug("Transport disposed for device \(self.deviceId), generation \(self.sessionGeneration)")
+    }
 
-        // Cancel all characteristic streams
-        for handler in characteristicStreams.values {
-            handler.finish()
-        }
-        characteristicStreams.removeAll()
+    private func drainSession() async {
+        isConnectionInvalidated = true
 
-        // Cancel pending continuations. Capture-and-nil every continuation under
-        // the lock, then resume OUTSIDE it, so a concurrent connect callback or
-        // delegate cannot double-resume the same continuation.
-        let pendingContinuations = continuationsLock.withLock {
-            let pendingConnection = connectionContinuation
-            connectionContinuation = nil
-            let pendingDiscovery = serviceDiscoveryContinuation
-            serviceDiscoveryContinuation = nil
-            let pendingReads = characteristicContinuations
-            let pendingWrites = writeContinuations
-            characteristicContinuations.removeAll()
-            writeContinuations.removeAll()
-            return (pendingConnection, pendingDiscovery, pendingReads, pendingWrites)
-        }
-
-        pendingContinuations.0?.resume(throwing: CancellationError())
-        pendingContinuations.1?.resume(throwing: CancellationError())
-
-        for (_, continuation) in pendingContinuations.2 {
-            continuation.resume(throwing: CancellationError())
-        }
-        for (_, continuation) in pendingContinuations.3 {
-            continuation.resume(throwing: CancellationError())
+        if transportState != .disconnected {
+            updateState(.disconnecting)
         }
 
-        // Disconnect
-        centralManager.cancelPeripheralConnection(peripheral)
+        await cancelPendingOperations(reason: .cancelled)
+        finishCharacteristicStreams()
+        requestPhysicalDisconnectIfNeeded()
         updateState(.disconnected)
-
-        logger.info("Disconnected from device \(self.deviceId)")
+        logger.info("Disconnected from device \(self.deviceId), generation \(self.sessionGeneration)")
     }
 
     func isConnected() async -> Bool {
-        peripheral.state == .connected
+        physicalDriver.state == .connected && transportState == .connected
     }
 
     func ping() async -> Bool {
-        guard peripheral.state == .connected else { return false }
-        do {
-            _ = try await peripheral.readRSSIAsync()
-            return true
-        } catch {
-            logger.debug("Ping failed: \(error.localizedDescription)")
-            return false
-        }
+        guard physicalDriver.state == .connected else { return false }
+        physicalDriver.readRSSI()
+        return true
     }
-
-    // MARK: - Characteristic Operations
 
     func getCharacteristicStream(
         serviceUUID: CBUUID,
         characteristicUUID: CBUUID
     ) -> AsyncThrowingStream<Data, Error> {
-        let key = "\(serviceUUID.uuidString):\(characteristicUUID.uuidString)"
+        guard !isDisposed else {
+            return failedCharacteristicStream(error: DeviceTransportError.disposed)
+        }
+        guard transportState == .connected else {
+            return failedCharacteristicStream(error: DeviceTransportError.notConnected)
+        }
 
-        // Return existing stream if available
+        let key = streamKey(serviceUUID: serviceUUID, characteristicUUID: characteristicUUID)
         if let existing = characteristicStreams[key] {
-            return existing.stream
+            return existing.makeStream()
         }
 
-        // Create new stream handler
-        let handler = CharacteristicStreamHandler()
-        characteristicStreams[key] = handler
-
-        // Set up characteristic notification
-        Task {
-            do {
-                guard let characteristic = findCharacteristic(
-                    serviceUUID: serviceUUID,
-                    characteristicUUID: characteristicUUID
-                ) else {
-                    handler.finish(throwing: DeviceTransportError.characteristicNotFound(characteristicUUID))
-                    return
-                }
-
-                peripheral.setNotifyValue(true, for: characteristic)
-                logger.debug("Enabled notifications for \(characteristicUUID.uuidString)")
-            }
+        guard let characteristic = findCharacteristic(
+            serviceUUID: serviceUUID,
+            characteristicUUID: characteristicUUID
+        ) else {
+            return failedCharacteristicStream(
+                error: DeviceTransportError.characteristicNotFound(characteristicUUID)
+            )
         }
 
-        return handler.stream
+        let broadcaster = CharacteristicStreamBroadcaster()
+        characteristicStreams[key] = broadcaster
+        physicalDriver.setNotifyValue(true, for: characteristic)
+        logger.debug("Enabled notifications for \(characteristicUUID.uuidString)")
+        return broadcaster.makeStream()
     }
 
     func readCharacteristic(
@@ -289,8 +268,7 @@ final class BleTransport: NSObject, DeviceTransport {
         characteristicUUID: CBUUID
     ) async throws -> Data {
         guard !isDisposed else { throw DeviceTransportError.disposed }
-        guard _state == .connected else { throw DeviceTransportError.notConnected }
-
+        guard transportState == .connected else { throw DeviceTransportError.notConnected }
         guard let characteristic = findCharacteristic(
             serviceUUID: serviceUUID,
             characteristicUUID: characteristicUUID
@@ -298,14 +276,33 @@ final class BleTransport: NSObject, DeviceTransport {
             throw DeviceTransportError.characteristicNotFound(characteristicUUID)
         }
 
-        return try await withCheckedThrowingContinuation { continuation in
-            continuationsLock.lock()
-            let displaced = characteristicContinuations.updateValue(continuation, forKey: characteristicUUID)
-            continuationsLock.unlock()
-            // A concurrent read on the same characteristic would silently overwrite
-            // (and leak) the prior continuation — fail it instead of hanging forever.
-            displaced?.resume(throwing: DeviceTransportError.readFailed("superseded by a newer read"))
-            peripheral.readValue(for: characteristic)
+        let key = operationKey(
+            serviceUUIDString: serviceUUID.uuidString,
+            characteristicUUIDString: characteristicUUID.uuidString
+        )
+        guard readGate.canStart(key) else {
+            throw DeviceTransportError.readFailed(
+                "A previous read has an uncorrelated callback; reconnect the device"
+            )
+        }
+        do {
+            return try await readOperations.perform(
+                key: key,
+                timeout: .seconds(5),
+                onTerminal: { [weak self] handle, termination in
+                    self?.readGate.terminal(handle: handle, termination: termination)
+                }
+            ) { [weak self] handle in
+                guard let self else { throw DeviceTransportError.disposed }
+                guard self.readGate.register(handle) else {
+                    throw DeviceTransportError.readFailed(
+                        "Read callback identity is no longer trustworthy"
+                    )
+                }
+                self.physicalDriver.readValue(for: characteristic)
+            }
+        } catch let error as DeviceOperationBrokerError {
+            throw DeviceTransportError.readFailed(error.localizedDescription)
         }
     }
 
@@ -316,8 +313,7 @@ final class BleTransport: NSObject, DeviceTransport {
         withResponse: Bool
     ) async throws {
         guard !isDisposed else { throw DeviceTransportError.disposed }
-        guard _state == .connected else { throw DeviceTransportError.notConnected }
-
+        guard transportState == .connected else { throw DeviceTransportError.notConnected }
         guard let characteristic = findCharacteristic(
             serviceUUID: serviceUUID,
             characteristicUUID: characteristicUUID
@@ -326,167 +322,346 @@ final class BleTransport: NSObject, DeviceTransport {
         }
 
         let writeType: CBCharacteristicWriteType = withResponse ? .withResponse : .withoutResponse
+        guard withResponse else {
+            physicalDriver.writeValue(data, for: characteristic, type: writeType)
+            return
+        }
 
-        if withResponse {
-            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
-                continuationsLock.lock()
-                let displaced = writeContinuations.updateValue(continuation, forKey: characteristicUUID)
-                continuationsLock.unlock()
-                displaced?.resume(throwing: DeviceTransportError.writeFailed("superseded by a newer write"))
-                peripheral.writeValue(data, for: characteristic, type: writeType)
+        let key = operationKey(
+            serviceUUIDString: serviceUUID.uuidString,
+            characteristicUUIDString: characteristicUUID.uuidString
+        )
+        guard writeGate.canStart(key) else {
+            throw DeviceTransportError.writeFailed(
+                "A previous write has an uncorrelated callback; reconnect the device"
+            )
+        }
+        do {
+            _ = try await writeOperations.perform(
+                key: key,
+                timeout: .seconds(5),
+                onTerminal: { [weak self] handle, termination in
+                    self?.writeGate.terminal(handle: handle, termination: termination)
+                }
+            ) { [weak self] handle in
+                guard let self else { throw DeviceTransportError.disposed }
+                guard self.writeGate.register(handle) else {
+                    throw DeviceTransportError.writeFailed(
+                        "Write callback identity is no longer trustworthy"
+                    )
+                }
+                self.physicalDriver.writeValue(data, for: characteristic, type: writeType)
             }
-        } else {
-            peripheral.writeValue(data, for: characteristic, type: writeType)
+        } catch let error as DeviceOperationBrokerError {
+            throw DeviceTransportError.writeFailed(error.localizedDescription)
         }
     }
 
-    func dispose() async {
-        guard !isDisposed else { return }
-        isDisposed = true
+    var services: [CBService] { discoveredServices }
 
-        await disconnect()
-        logger.debug("Transport disposed for device \(self.deviceId)")
+    private func handleCentralEvent(_ event: BluetoothCentralEvent) async {
+        switch event {
+        case .connected(let lease):
+            guard lease == connectionLease else { return }
+            guard !isConnectionInvalidated else {
+                requestPhysicalDisconnectIfNeeded()
+                return
+            }
+            guard let handle = connectHandle else { return }
+            connectHandle = nil
+            await connectOperations.succeed(handle: handle, value: ())
+
+        case .failedToConnect(let lease, let reason):
+            guard lease == connectionLease else { return }
+            connectionLease = nil
+            isConnectionInvalidated = true
+            if let handle = connectHandle {
+                connectHandle = nil
+                await connectOperations.fail(handle: handle, reason: reason)
+            }
+            await cancelPendingOperations(reason: .disconnected)
+            updateState(.disconnected)
+
+        case .disconnected(let lease, let reason):
+            guard lease == connectionLease else { return }
+            connectionLease = nil
+            isConnectionInvalidated = true
+            if let handle = connectHandle {
+                connectHandle = nil
+                await connectOperations.fail(
+                    handle: handle,
+                    reason: reason ?? "Disconnected during connection"
+                )
+            }
+            await cancelPendingOperations(reason: .disconnected)
+            finishCharacteristicStreams(
+                throwing: reason.map(DeviceOperationBrokerError.failed)
+                    ?? DeviceOperationBrokerError.disconnected
+            )
+            updateState(.disconnected)
+        }
     }
 
-    // MARK: - Private Helpers
+    func didDiscoverServices(_ services: [CBService], error: Error?) async {
+        guard let handle = serviceHandle else { return }
+        serviceHandle = nil
+        if let error {
+            await serviceOperations.fail(handle: handle, reason: error.localizedDescription)
+        } else {
+            await serviceOperations.succeed(
+                handle: handle,
+                value: BLEDiscoveredServices(values: services)
+            )
+        }
+    }
+
+    func didDiscoverCharacteristics(for service: CBService, error: Error?) async {
+        if let error {
+            guard let handle = characteristicDiscoveryHandle else { return }
+            characteristicDiscoveryHandle = nil
+            pendingCharacteristicServices.removeAll()
+            await characteristicDiscoveryOperations.fail(
+                handle: handle,
+                reason: error.localizedDescription
+            )
+            return
+        }
+
+        pendingCharacteristicServices.remove(ObjectIdentifier(service))
+        logger.debug("Discovered \(service.characteristics?.count ?? 0) characteristics for \(service.uuid)")
+        guard pendingCharacteristicServices.isEmpty,
+              let handle = characteristicDiscoveryHandle else { return }
+        characteristicDiscoveryHandle = nil
+        await characteristicDiscoveryOperations.succeed(handle: handle, value: ())
+    }
+
+    func didUpdateValue(for characteristic: CBCharacteristic, error: Error?) async {
+        let characteristicKey = operationKey(
+            serviceUUIDString: characteristic.service?.uuid.uuidString ?? "",
+            characteristicUUIDString: characteristic.uuid.uuidString
+        )
+
+        if let handle = readGate.takeHandleForCallback(key: characteristicKey) {
+            if let error {
+                await readOperations.fail(
+                    handle: handle,
+                    reason: error.localizedDescription
+                )
+            } else {
+                await readOperations.succeed(
+                    handle: handle,
+                    value: characteristic.value ?? Data()
+                )
+            }
+            return
+        }
+
+        // CoreBluetooth uses the same delegate callback for explicit reads and
+        // subscribed notifications. A timed-out read poisons only the read
+        // operation identity; it must never suppress later notifications. A
+        // live read was resolved above, so only unclaimed values broadcast.
+        let notificationKey = streamKey(
+            serviceUUIDString: characteristic.service?.uuid.uuidString ?? "",
+            characteristicUUIDString: characteristic.uuid.uuidString
+        )
+        if error == nil, let value = characteristic.value {
+            characteristicStreams[notificationKey]?.yield(value)
+        }
+    }
+
+    func didWriteValue(for characteristic: CBCharacteristic, error: Error?) async {
+        let key = operationKey(
+            serviceUUIDString: characteristic.service?.uuid.uuidString ?? "",
+            characteristicUUIDString: characteristic.uuid.uuidString
+        )
+        guard let handle = writeGate.takeHandleForCallback(key: key) else { return }
+
+        if let error {
+            await writeOperations.fail(handle: handle, reason: error.localizedDescription)
+        } else {
+            await writeOperations.succeed(handle: handle, value: ())
+        }
+    }
+
+    private func cancelPendingOperations(reason: DeviceOperationBrokerError) async {
+        await connectOperations.cancelAll(reason: reason)
+        await serviceOperations.cancelAll(reason: reason)
+        await characteristicDiscoveryOperations.cancelAll(reason: reason)
+        await readOperations.cancelAll(reason: reason)
+        await writeOperations.cancelAll(reason: reason)
+        connectHandle = nil
+        serviceHandle = nil
+        characteristicDiscoveryHandle = nil
+        pendingCharacteristicServices.removeAll()
+    }
+
+    private func requestPhysicalDisconnectIfNeeded() {
+        guard !didRequestPhysicalDisconnect else { return }
+        didRequestPhysicalDisconnect = true
+        physicalDriver.disconnect()
+    }
+
+    private func ensureConnectionIsValid() throws {
+        guard !isDisposed, !isConnectionInvalidated else {
+            throw DeviceTransportError.connectionFailed("Connection was superseded")
+        }
+    }
+
+    private func finishCharacteristicStreams(throwing error: Error? = nil) {
+        for handler in characteristicStreams.values {
+            handler.finish(throwing: error)
+        }
+        characteristicStreams.removeAll()
+    }
 
     private func updateState(_ newState: DeviceTransportState) {
-        guard _state != newState else { return }
-        _state = newState
+        guard transportState != newState else { return }
+        transportState = newState
         connectionStateSubject.send(newState)
     }
 
-    private func findCharacteristic(serviceUUID: CBUUID, characteristicUUID: CBUUID) -> CBCharacteristic? {
+    private func findCharacteristic(
+        serviceUUID: CBUUID,
+        characteristicUUID: CBUUID
+    ) -> CBCharacteristic? {
         guard let service = discoveredServices.first(where: {
-            $0.uuid.uuidString.lowercased() == serviceUUID.uuidString.lowercased()
+            $0.uuid.uuidString.caseInsensitiveCompare(serviceUUID.uuidString) == .orderedSame
         }) else {
             return nil
         }
 
         return service.characteristics?.first(where: {
-            $0.uuid.uuidString.lowercased() == characteristicUUID.uuidString.lowercased()
+            $0.uuid.uuidString.caseInsensitiveCompare(characteristicUUID.uuidString) == .orderedSame
         })
     }
 
-    /// Get all discovered services
-    var services: [CBService] {
-        discoveredServices
+    private func streamKey(serviceUUID: CBUUID, characteristicUUID: CBUUID) -> String {
+        streamKey(
+            serviceUUIDString: serviceUUID.uuidString,
+            characteristicUUIDString: characteristicUUID.uuidString
+        )
+    }
+
+    private func streamKey(serviceUUIDString: String, characteristicUUIDString: String) -> String {
+        "\(serviceUUIDString.lowercased()):\(characteristicUUIDString.lowercased())"
+    }
+
+    private func operationKey(
+        serviceUUIDString: String,
+        characteristicUUIDString: String
+    ) -> String {
+        streamKey(
+            serviceUUIDString: serviceUUIDString,
+            characteristicUUIDString: characteristicUUIDString
+        )
+    }
+
+    private func failedCharacteristicStream(
+        error: Error
+    ) -> AsyncThrowingStream<Data, Error> {
+        AsyncThrowingStream { continuation in
+            continuation.finish(throwing: error)
+        }
     }
 }
-
-// MARK: - CBPeripheralDelegate
 
 extension BleTransport: CBPeripheralDelegate {
-
-    func peripheral(_ peripheral: CBPeripheral, didDiscoverServices error: Error?) {
-        continuationsLock.lock()
-        let continuation = serviceDiscoveryContinuation
-        serviceDiscoveryContinuation = nil
-        continuationsLock.unlock()
-        if let error = error {
-            continuation?.resume(throwing: error)
-        } else {
-            continuation?.resume(returning: peripheral.services ?? [])
+    nonisolated func peripheral(_ peripheral: CBPeripheral, didDiscoverServices error: Error?) {
+        let services = peripheral.services ?? []
+        Task { @MainActor [weak self] in
+            await self?.didDiscoverServices(services, error: error)
         }
     }
 
-    func peripheral(_ peripheral: CBPeripheral, didDiscoverCharacteristicsFor service: CBService, error: Error?) {
-        if let error = error {
-            logger.warning("Failed to discover characteristics for \(service.uuid): \(error.localizedDescription)")
-        } else {
-            logger.debug("Discovered \(service.characteristics?.count ?? 0) characteristics for \(service.uuid)")
+    nonisolated func peripheral(
+        _ peripheral: CBPeripheral,
+        didDiscoverCharacteristicsFor service: CBService,
+        error: Error?
+    ) {
+        Task { @MainActor [weak self] in
+            await self?.didDiscoverCharacteristics(for: service, error: error)
         }
     }
 
-    func peripheral(_ peripheral: CBPeripheral, didUpdateValueFor characteristic: CBCharacteristic, error: Error?) {
-        let uuid = characteristic.uuid
+    nonisolated func peripheral(
+        _ peripheral: CBPeripheral,
+        didUpdateValueFor characteristic: CBCharacteristic,
+        error: Error?
+    ) {
+        Task { @MainActor [weak self] in
+            await self?.didUpdateValue(for: characteristic, error: error)
+        }
+    }
 
-        // Handle pending read continuation
-        continuationsLock.lock()
-        let readContinuation = characteristicContinuations.removeValue(forKey: uuid)
-        continuationsLock.unlock()
-        if let continuation = readContinuation {
-            if let error = error {
-                continuation.resume(throwing: DeviceTransportError.readFailed(error.localizedDescription))
+    nonisolated func peripheral(
+        _ peripheral: CBPeripheral,
+        didWriteValueFor characteristic: CBCharacteristic,
+        error: Error?
+    ) {
+        Task { @MainActor [weak self] in
+            await self?.didWriteValue(for: characteristic, error: error)
+        }
+    }
+
+    nonisolated func peripheral(
+        _ peripheral: CBPeripheral,
+        didUpdateNotificationStateFor characteristic: CBCharacteristic,
+        error: Error?
+    ) {
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            if let error {
+                self.logger.warning("Failed to update notification state for \(characteristic.uuid): \(error.localizedDescription)")
             } else {
-                continuation.resume(returning: characteristic.value ?? Data())
-            }
-            return
-        }
-
-        // Handle stream notification
-        let key = "\(characteristic.service?.uuid.uuidString ?? ""):\(uuid.uuidString)"
-        if let handler = characteristicStreams[key], let value = characteristic.value {
-            handler.yield(value)
-        }
-    }
-
-    func peripheral(_ peripheral: CBPeripheral, didWriteValueFor characteristic: CBCharacteristic, error: Error?) {
-        let uuid = characteristic.uuid
-
-        continuationsLock.lock()
-        let writeContinuation = writeContinuations.removeValue(forKey: uuid)
-        continuationsLock.unlock()
-        if let continuation = writeContinuation {
-            if let error = error {
-                continuation.resume(throwing: DeviceTransportError.writeFailed(error.localizedDescription))
-            } else {
-                continuation.resume()
+                self.logger.debug("Notification state updated for \(characteristic.uuid): \(characteristic.isNotifying)")
             }
         }
-    }
-
-    func peripheral(_ peripheral: CBPeripheral, didUpdateNotificationStateFor characteristic: CBCharacteristic, error: Error?) {
-        if let error = error {
-            logger.warning("Failed to update notification state for \(characteristic.uuid): \(error.localizedDescription)")
-        } else {
-            logger.debug("Notification state updated for \(characteristic.uuid): \(characteristic.isNotifying)")
-        }
-    }
-
-    func peripheral(_ peripheral: CBPeripheral, didReadRSSI RSSI: NSNumber, error: Error?) {
-        // RSSI read completion - used for ping
     }
 }
 
-// MARK: - Characteristic Stream Handler
+@MainActor
+private final class CharacteristicStreamBroadcaster {
+    typealias Continuation = AsyncThrowingStream<Data, Error>.Continuation
 
-/// Helper class to manage AsyncThrowingStream for characteristic notifications
-private final class CharacteristicStreamHandler: @unchecked Sendable {
-    private var continuation: AsyncThrowingStream<Data, Error>.Continuation?
+    private var continuations: [UUID: Continuation] = [:]
 
-    let stream: AsyncThrowingStream<Data, Error>
-
-    init() {
-        var capturedContinuation: AsyncThrowingStream<Data, Error>.Continuation?
-        stream = AsyncThrowingStream { continuation in
-            capturedContinuation = continuation
+    func makeStream() -> AsyncThrowingStream<Data, Error> {
+        let subscriberID = UUID()
+        return AsyncThrowingStream { continuation in
+            continuations[subscriberID] = continuation
+            continuation.onTermination = { @Sendable [weak self] _ in
+                Task { @MainActor [weak self] in
+                    self?.removeSubscriber(subscriberID)
+                }
+            }
         }
-        self.continuation = capturedContinuation
     }
 
     func yield(_ data: Data) {
-        continuation?.yield(data)
+        var terminatedSubscribers: [UUID] = []
+        for (subscriberID, continuation) in continuations {
+            if case .terminated = continuation.yield(data) {
+                terminatedSubscribers.append(subscriberID)
+            }
+        }
+        for subscriberID in terminatedSubscribers {
+            continuations.removeValue(forKey: subscriberID)
+        }
     }
 
     func finish(throwing error: Error? = nil) {
-        if let error = error {
-            continuation?.finish(throwing: error)
-        } else {
-            continuation?.finish()
+        let currentContinuations = Array(continuations.values)
+        continuations.removeAll()
+        for continuation in currentContinuations {
+            if let error {
+                continuation.finish(throwing: error)
+            } else {
+                continuation.finish()
+            }
         }
-        continuation = nil
     }
-}
 
-// MARK: - CBPeripheral Extension for Async RSSI
-
-extension CBPeripheral {
-    func readRSSIAsync() async throws -> Int {
-        // Simple RSSI read - the delegate method handles the result
-        // For now, just trigger the read and return immediately
-        // A more robust implementation would use a continuation
-        self.readRSSI()
-        return 0 // Placeholder - ping uses this for connectivity check
+    private func removeSubscriber(_ subscriberID: UUID) {
+        continuations.removeValue(forKey: subscriberID)
     }
 }

--- a/desktop/macos/Desktop/Sources/Bluetooth/Transports/DeviceTransport.swift
+++ b/desktop/macos/Desktop/Sources/Bluetooth/Transports/DeviceTransport.swift
@@ -14,10 +14,14 @@ enum DeviceTransportState: String, Sendable {
 /// Abstract transport layer protocol for device communication
 /// Provides a unified interface for different communication protocols (BLE, etc.)
 /// Ported from: omi/app/lib/services/devices/transports/device_transport.dart
+@MainActor
 protocol DeviceTransport: AnyObject {
 
     /// Unique identifier for the connected device
     var deviceId: String { get }
+
+    /// Session generation that owns this physical transport.
+    var sessionGeneration: UInt64 { get }
 
     /// Current connection state
     var state: DeviceTransportState { get }

--- a/desktop/macos/Desktop/Sources/Providers/DeviceProvider.swift
+++ b/desktop/macos/Desktop/Sources/Providers/DeviceProvider.swift
@@ -20,7 +20,7 @@ final class DeviceProvider: ObservableObject {
     // MARK: - Singleton
 
     static let shared = DeviceProvider(bluetoothManager: BluetoothManager.shared)
-    typealias ConnectionFactory = @MainActor (BtDevice) -> DeviceConnection?
+    typealias ConnectionFactory = @MainActor (BtDevice, UInt64) -> DeviceConnection?
     typealias StorageDataChecker = @MainActor () async -> (totalBytes: Int, currentOffset: Int)?
 
     // MARK: - Published State
@@ -28,17 +28,20 @@ final class DeviceProvider: ObservableObject {
     /// Whether currently scanning for devices
     @Published private(set) var isScanning = false
 
-    /// Whether currently connecting to a device
-    @Published private(set) var isConnecting = false
+    /// The canonical Bluetooth lifecycle state. UI-facing convenience
+    /// properties below are read-only projections of this snapshot.
+    @Published private(set) var sessionSnapshot: DeviceSessionSnapshot
 
-    /// Whether a device is connected
-    @Published private(set) var isConnected = false
-
-    /// Currently connected device
-    @Published private(set) var connectedDevice: BtDevice?
-
-    /// Paired device (persisted across sessions)
-    @Published private(set) var pairedDevice: BtDevice?
+    var isConnecting: Bool { sessionSnapshot.phase.isConnecting }
+    var isConnected: Bool { sessionSnapshot.phase.isReady }
+    var connectedDevice: BtDevice? { sessionSnapshot.connectedDevice }
+    var pairedDevice: BtDevice? { sessionSnapshot.pairedDevice }
+    var isConnectedPublisher: AnyPublisher<Bool, Never> {
+        $sessionSnapshot
+            .map { $0.phase.isReady }
+            .removeDuplicates()
+            .eraseToAnyPublisher()
+    }
 
     /// Current battery level (0-100, or -1 if unavailable)
     @Published private(set) var batteryLevel: Int = -1
@@ -69,20 +72,19 @@ final class DeviceProvider: ObservableObject {
     private let bluetoothManager: DeviceBluetoothManaging
     private let userDefaults: UserDefaults
     private let notificationCenter: NotificationCenter
-    private let connectionFactory: ConnectionFactory
     private let storageDataChecker: StorageDataChecker
-    private let autoReconnectEnabled: Bool
-    /// The active device connection (internal for AudioSourceManager access)
-    private(set) var activeConnection: DeviceConnection?
+    private let sessionCoordinator: DeviceSessionCoordinator
+
+    /// The active connection is owned by the session coordinator. This
+    /// projection remains internal for AudioSourceManager access.
+    var activeConnection: DeviceConnection? { sessionCoordinator.activeConnection }
+
     private var batterySubscription: Task<Void, Never>?
     private var cancellables = Set<AnyCancellable>()
-    private var reconnectionTimer: Timer?
-    private var reconnectAt: Date?
     private var disconnectNotificationTimer: Timer?
     private var hasLowBatteryAlerted = false
 
     private let logger = Logger(subsystem: "me.omi.desktop", category: "DeviceProvider")
-    private let connectionCheckInterval: TimeInterval = 15.0
 
     // MARK: - UserDefaults Keys
 
@@ -100,18 +102,54 @@ final class DeviceProvider: ObservableObject {
         bluetoothManager: DeviceBluetoothManaging,
         userDefaults: UserDefaults = .standard,
         notificationCenter: NotificationCenter = .default,
-        connectionFactory: @escaping ConnectionFactory = { DeviceConnectionFactory.create(device: $0) },
+        connectionFactory: @escaping ConnectionFactory = {
+            DeviceConnectionFactory.create(device: $0, sessionGeneration: $1)
+        },
         storageDataChecker: @escaping StorageDataChecker = { await StorageSyncService.shared.checkForStorageData() },
+        sessionScheduler: (any DeviceSessionScheduling)? = nil,
+        reconnectDelay: Duration = .seconds(15),
         autoReconnectEnabled: Bool = true
     ) {
+        let persistedDevice = Self.loadPairedDevice(from: userDefaults)
+        let coordinator = DeviceSessionCoordinator(
+            pairedDevice: persistedDevice,
+            connectionFactory: connectionFactory,
+            scheduler: sessionScheduler ?? DeviceSessionTaskScheduler(),
+            reconnectDelay: reconnectDelay,
+            autoReconnectEnabled: autoReconnectEnabled
+        )
+
         self.bluetoothManager = bluetoothManager
         self.userDefaults = userDefaults
         self.notificationCenter = notificationCenter
-        self.connectionFactory = connectionFactory
         self.storageDataChecker = storageDataChecker
-        self.autoReconnectEnabled = autoReconnectEnabled
-        setupNotificationBindings()
-        loadPairedDevice()
+        self.sessionCoordinator = coordinator
+        self.sessionSnapshot = coordinator.snapshot
+
+        coordinator.onSnapshotChanged = { [weak self] snapshot in
+            self?.sessionSnapshot = snapshot
+        }
+        coordinator.onReconnectRequested = { [weak self] request in
+            Task { @MainActor in
+                await self?.connect(
+                    to: request.device,
+                    reconnectRequest: request
+                )
+            }
+        }
+        coordinator.onDiscoveryRequested = { [weak self] in
+            self?.startDiscovery(timeout: 5)
+        }
+        coordinator.onSessionEnded = { [weak self] in
+            self?.resetSessionPresentation()
+        }
+        coordinator.onFallDetected = { [weak self] data in
+            self?.sendFallDetectionNotification(data: data)
+        }
+
+        if let persistedDevice {
+            logger.info("Loaded paired device: \(persistedDevice.displayName)")
+        }
     }
 
     /// Initialize Bluetooth bindings - call this when Bluetooth features are needed
@@ -151,46 +189,24 @@ final class DeviceProvider: ObservableObject {
             .store(in: &cancellables)
     }
 
-    private func setupNotificationBindings() {
-
-        // Observe BLE connection events
-        notificationCenter.publisher(for: .bleDeviceConnected)
-            .receive(on: DispatchQueue.main)
-            .compactMap { $0.userInfo?["peripheralId"] as? UUID }
-            .sink { [weak self] peripheralId in
-                self?.handleDeviceConnected(peripheralId: peripheralId)
-            }
-            .store(in: &cancellables)
-
-        notificationCenter.publisher(for: .bleDeviceDisconnected)
-            .receive(on: DispatchQueue.main)
-            .compactMap { $0.userInfo?["peripheralId"] as? UUID }
-            .sink { [weak self] peripheralId in
-                self?.handleDeviceDisconnected(peripheralId: peripheralId)
-            }
-            .store(in: &cancellables)
-    }
-
     // MARK: - Persistence
 
-    private func loadPairedDevice() {
+    private static func loadPairedDevice(from userDefaults: UserDefaults) -> BtDevice? {
         guard let deviceId = userDefaults.string(forKey: UserDefaultsKeys.pairedDeviceId),
               !deviceId.isEmpty else {
-            return
+            return nil
         }
 
         let deviceName = userDefaults.string(forKey: UserDefaultsKeys.pairedDeviceName) ?? "Unknown Device"
         let deviceTypeRaw = userDefaults.string(forKey: UserDefaultsKeys.pairedDeviceType) ?? "omi"
         let deviceType = DeviceType(rawValue: deviceTypeRaw) ?? .omi
 
-        pairedDevice = BtDevice(
+        return BtDevice(
             id: deviceId,
             name: deviceName,
             type: deviceType,
             rssi: 0
         )
-
-        logger.info("Loaded paired device: \(deviceName) (\(deviceId))")
     }
 
     private func savePairedDevice(_ device: BtDevice?) {
@@ -234,51 +250,38 @@ final class DeviceProvider: ObservableObject {
     /// Connect to a device
     /// - Parameter device: The device to connect to
     func connect(to device: BtDevice) async {
-        guard !isConnecting else {
-            logger.warning("Already connecting to a device")
-            return
-        }
+        await connect(to: device, reconnectRequest: nil)
+    }
 
-        guard !isConnected else {
-            logger.warning("Already connected to a device")
-            return
-        }
-
-        isConnecting = true
+    private func connect(
+        to device: BtDevice,
+        reconnectRequest: DeviceReconnectRequest?
+    ) async {
         errorMessage = nil
 
         do {
-            // Create connection using factory
-            guard let connection = connectionFactory(device) else {
-                throw DeviceConnectionError.connectionFailed("Failed to create connection")
+            let connection: DeviceConnection
+            if let reconnectRequest {
+                connection = try await sessionCoordinator.reconnect(reconnectRequest)
+            } else {
+                connection = try await sessionCoordinator.connect(to: device)
             }
-
-            // Connect
-            try await connection.connect()
-
-            // Store the connection
-            activeConnection = connection
-
-            // Update state
-            connectedDevice = connection.device
-            pairedDevice = connection.device
-            isConnected = true
+            let generation = connection.sessionGeneration
 
             // Save as paired device
             savePairedDevice(connection.device)
 
             // Start battery monitoring
-            await startBatteryMonitoring()
+            await startBatteryMonitoring(connection: connection, generation: generation)
+            guard sessionCoordinator.isReady(generation: generation) else { return }
 
             // Check storage support
-            await checkStorageSupport()
+            await checkStorageSupport(connection: connection, generation: generation)
+            guard sessionCoordinator.isReady(generation: generation) else { return }
 
             // Check for firmware updates
-            await checkFirmwareUpdates()
-
-            // Cancel reconnection timer
-            reconnectionTimer?.invalidate()
-            reconnectionTimer = nil
+            await checkFirmwareUpdates(generation: generation)
+            guard sessionCoordinator.isReady(generation: generation) else { return }
 
             // Clear any pending disconnect notification
             disconnectNotificationTimer?.invalidate()
@@ -289,50 +292,42 @@ final class DeviceProvider: ObservableObject {
             // TODO: Track analytics when AnalyticsManager supports device events
             // AnalyticsManager.shared.deviceConnected(deviceType: device.type.rawValue, deviceName: device.name)
 
+        } catch DeviceSessionCoordinatorError.connectionAlreadyActive {
+            logger.debug("Ignored duplicate connection request for \(device.displayName)")
+        } catch DeviceSessionCoordinatorError.superseded {
+            logger.debug("Connection attempt for \(device.displayName) was superseded")
         } catch {
             logger.error("Failed to connect to \(device.displayName): \(error.localizedDescription)")
             errorMessage = "Failed to connect: \(error.localizedDescription)"
-            activeConnection = nil
         }
-
-        isConnecting = false
     }
 
     /// Disconnect from the current device
     func disconnect() async {
-        guard let connection = activeConnection else {
+        guard activeConnection != nil else {
             logger.warning("No active connection to disconnect")
             return
         }
 
-        await connection.disconnect()
-        handleDisconnection()
+        await sessionCoordinator.disconnect(reconnectAfter: .zero)
 
         logger.info("Disconnected from device")
     }
 
     /// Unpair the current device (disconnect and clear pairing)
     func unpair() async {
-        if let connection = activeConnection {
-            await connection.unpair()
-        }
-
-        handleDisconnection()
+        await sessionCoordinator.unpair()
+        resetSessionPresentation()
         savePairedDevice(nil)
-        pairedDevice = nil
 
         logger.info("Unpaired device")
     }
 
-    private func handleDisconnection() {
+    private func resetSessionPresentation() {
         // Cancel battery monitoring
         batterySubscription?.cancel()
         batterySubscription = nil
 
-        // Clear state
-        activeConnection = nil
-        connectedDevice = nil
-        isConnected = false
         batteryLevel = -1
         isDeviceStorageSupported = false
         hasFirmwareUpdate = false
@@ -343,101 +338,47 @@ final class DeviceProvider: ObservableObject {
 
         // Schedule disconnect notification
         scheduleDisconnectNotification()
-
-        // Start reconnection attempts
-        startReconnectionTimer()
     }
 
     // MARK: - Auto-Reconnection
 
-    /// Start periodic reconnection attempts
-    func startReconnectionTimer() {
-        guard autoReconnectEnabled else { return }
-        guard pairedDevice != nil else { return }
-        guard reconnectionTimer == nil else { return }
-
-        reconnectionTimer = Timer.scheduledTimer(
-            withTimeInterval: connectionCheckInterval,
-            repeats: true
-        ) { [weak self] _ in
-            Task { @MainActor in
-                await self?.attemptReconnection()
-            }
-        }
-
-        // Attempt immediately
-        Task {
-            await attemptReconnection()
-        }
+    /// Begin the coordinator-owned reconnection policy.
+    func startReconnecting() {
+        sessionCoordinator.startReconnecting()
     }
 
-    /// Stop reconnection attempts
-    func stopReconnectionTimer() {
-        reconnectionTimer?.invalidate()
-        reconnectionTimer = nil
-    }
-
-    private func attemptReconnection() async {
-        // Skip if already connected or connecting
-        guard !isConnected && !isConnecting else { return }
-
-        // Skip if reconnection is delayed
-        if let reconnectAt = reconnectAt, reconnectAt > Date() {
-            return
-        }
-
-        // Skip if no paired device
-        guard let pairedDevice = pairedDevice else {
-            stopReconnectionTimer()
-            return
-        }
-
-        logger.debug("Attempting reconnection to \(pairedDevice.displayName)")
-
-        // Try direct connection first
-        await connect(to: pairedDevice)
-
-        if isConnected {
-            stopReconnectionTimer()
-            return
-        }
-
-        // If direct connection failed, scan for the device
-        startDiscovery(timeout: 5.0)
-
-        // Wait for scan to complete
-        try? await Task.sleep(nanoseconds: 5_500_000_000)
-
-        // Check if device was found during scan
-        if let foundDevice = discoveredDevices.first(where: { $0.id == pairedDevice.id }) {
-            await connect(to: foundDevice)
-        }
+    /// Stop pending coordinator-owned reconnection work.
+    func stopReconnecting() {
+        sessionCoordinator.stopReconnecting()
     }
 
     // MARK: - Battery Monitoring
 
-    private func startBatteryMonitoring() async {
-        guard let connection = activeConnection else { return }
-
+    private func startBatteryMonitoring(
+        connection: DeviceConnection,
+        generation: UInt64
+    ) async {
         // Get initial battery level
         let level = await connection.getBatteryLevel()
-        if level >= 0 {
+        if sessionCoordinator.isReady(generation: generation), level >= 0 {
             batteryLevel = level
             checkLowBattery()
         }
+        guard sessionCoordinator.isReady(generation: generation) else { return }
 
         // Start listening for battery updates
         batterySubscription?.cancel()
-        batterySubscription = Task {
+        batterySubscription = Task { [weak self, weak connection] in
+            guard let connection else { return }
             do {
                 for try await level in connection.getBatteryLevelStream() {
-                    await MainActor.run {
-                        self.batteryLevel = level
-                        self.checkLowBattery()
-                    }
+                    guard !Task.isCancelled, let self else { return }
+                    guard self.sessionCoordinator.isReady(generation: generation) else { return }
+                    self.batteryLevel = level
+                    self.checkLowBattery()
                 }
             } catch {
-                logger.debug("Battery stream ended: \(error.localizedDescription)")
+                self?.logger.debug("Battery stream ended: \(error.localizedDescription)")
             }
         }
     }
@@ -469,26 +410,26 @@ final class DeviceProvider: ObservableObject {
 
     // MARK: - Storage Support
 
-    private func checkStorageSupport() async {
-        guard let connection = activeConnection else {
-            isDeviceStorageSupported = false
-            return
-        }
-
+    private func checkStorageSupport(
+        connection: DeviceConnection,
+        generation: UInt64
+    ) async {
         let storageList = await connection.getStorageList()
+        guard sessionCoordinator.isReady(generation: generation) else { return }
         isDeviceStorageSupported = !storageList.isEmpty
 
         // Check for pending storage data to sync
         if isDeviceStorageSupported {
-            await checkPendingStorageSync()
+            await checkPendingStorageSync(generation: generation)
         }
     }
 
     /// Check if device has pending storage data to sync
-    private func checkPendingStorageSync() async {
+    private func checkPendingStorageSync(generation: UInt64) async {
         guard let (totalBytes, currentOffset) = await storageDataChecker() else {
             return
         }
+        guard sessionCoordinator.isReady(generation: generation) else { return }
 
         let bytesToSync = totalBytes - currentOffset
 
@@ -509,8 +450,9 @@ final class DeviceProvider: ObservableObject {
 
     // MARK: - Firmware Updates
 
-    private func checkFirmwareUpdates() async {
+    private func checkFirmwareUpdates(generation: UInt64) async {
         guard !isFirmwareUpdateInProgress else { return }
+        guard sessionCoordinator.isReady(generation: generation) else { return }
         guard let device = connectedDevice else { return }
 
         // TODO: Implement firmware update check via API
@@ -535,10 +477,7 @@ final class DeviceProvider: ObservableObject {
     func prepareDFU() async {
         guard connectedDevice != nil else { return }
 
-        await disconnect()
-
-        // Delay reconnection to allow DFU
-        reconnectAt = Date().addingTimeInterval(30)
+        await sessionCoordinator.disconnect(reconnectAfter: .seconds(30))
     }
 
     // MARK: - Notifications
@@ -570,32 +509,21 @@ final class DeviceProvider: ObservableObject {
         UNUserNotificationCenter.current().add(request)
     }
 
-    // MARK: - Event Handlers
+    private func sendFallDetectionNotification(data: AccelerometerData) {
+        logger.warning("Fall detected! Magnitude: \(data.magnitude)")
 
-    private func handleDeviceConnected(peripheralId: UUID) {
-        // Check if this is our paired device
-        guard let pairedDevice = pairedDevice,
-              pairedDevice.id == peripheralId.uuidString else {
-            return
-        }
+        let content = UNMutableNotificationContent()
+        content.title = "Fall Detected"
+        content.body = "A potential fall was detected by your omi device."
+        content.sound = .default
 
-        // If we're not already handling the connection, connect now
-        if !isConnecting && !isConnected {
-            Task {
-                await connect(to: pairedDevice)
-            }
-        }
-    }
+        let request = UNNotificationRequest(
+            identifier: "fallDetected-\(Date().timeIntervalSince1970)",
+            content: content,
+            trigger: nil
+        )
 
-    private func handleDeviceDisconnected(peripheralId: UUID) {
-        // Check if this is our connected device
-        guard let connectedDevice = connectedDevice,
-              connectedDevice.id == peripheralId.uuidString else {
-            return
-        }
-
-        // Handle the disconnection
-        handleDisconnection()
+        UNUserNotificationCenter.current().add(request)
     }
 
     // MARK: - Audio Stream
@@ -693,39 +621,7 @@ final class DeviceProvider: ObservableObject {
     // MARK: - Cleanup
 
     deinit {
-        reconnectionTimer?.invalidate()
         disconnectNotificationTimer?.invalidate()
         batterySubscription?.cancel()
-    }
-}
-
-// MARK: - DeviceConnectionDelegate
-
-extension DeviceProvider: DeviceConnectionDelegate {
-    nonisolated func deviceConnection(_ connection: DeviceConnection, didDisconnectUnexpectedly device: BtDevice) {
-        Task { @MainActor in
-            logger.warning("Device disconnected unexpectedly: \(device.displayName)")
-            handleDisconnection()
-        }
-    }
-
-    nonisolated func deviceConnection(_ connection: DeviceConnection, didDetectFall data: AccelerometerData) {
-        Task { @MainActor in
-            logger.warning("Fall detected! Magnitude: \(data.magnitude)")
-
-            // Send fall detection notification
-            let content = UNMutableNotificationContent()
-            content.title = "Fall Detected"
-            content.body = "A potential fall was detected by your omi device."
-            content.sound = .default
-
-            let request = UNNotificationRequest(
-                identifier: "fallDetected-\(Date().timeIntervalSince1970)",
-                content: content,
-                trigger: nil
-            )
-
-            try? await UNUserNotificationCenter.current().add(request)
-        }
     }
 }

--- a/desktop/macos/Desktop/Tests/BaseDeviceConnectionLifecycleReliabilityTests.swift
+++ b/desktop/macos/Desktop/Tests/BaseDeviceConnectionLifecycleReliabilityTests.swift
@@ -1,0 +1,71 @@
+import Combine
+import CoreBluetooth
+import XCTest
+
+@testable import Omi_Computer
+
+@MainActor
+final class BaseDeviceConnectionLifecycleTests: XCTestCase {
+    func testTemplateLifecyclePreparesAndTearsDownExactlyOnce() async throws {
+        let transport = ReliabilityTestTransport(sessionGeneration: 11)
+        let connection = LifecycleHookConnection(
+            device: bluetoothReliabilityTestDevice,
+            transport: transport
+        )
+
+        try await connection.connect()
+        XCTAssertEqual(connection.prepareCallCount, 1)
+
+        do {
+            try await connection.connect()
+            XCTFail("A connection object represents exactly one session generation")
+        } catch let error as DeviceConnectionError {
+            guard case .alreadyConnected = error else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+        }
+
+        await connection.disconnect()
+        await connection.disconnect()
+        XCTAssertEqual(connection.teardownCallCount, 1)
+        XCTAssertEqual(transport.disposeCallCount, 1)
+    }
+
+    func testFailedPreparationStillTearsDownExactlyOnce() async {
+        let transport = ReliabilityTestTransport(sessionGeneration: 12)
+        let connection = LifecycleHookConnection(
+            device: bluetoothReliabilityTestDevice,
+            transport: transport
+        )
+        connection.prepareError = BluetoothReliabilityTestError.expected
+
+        do {
+            try await connection.connect()
+            XCTFail("Expected preparation failure")
+        } catch {}
+
+        XCTAssertEqual(connection.prepareCallCount, 1)
+        XCTAssertEqual(connection.teardownCallCount, 1)
+        XCTAssertEqual(transport.disposeCallCount, 1)
+    }
+
+    func testUnexpectedPhysicalDisconnectTearsDownAndDelegatesExactlyOnce() async throws {
+        let transport = ReliabilityTestTransport(sessionGeneration: 13)
+        let connection = LifecycleHookConnection(
+            device: bluetoothReliabilityTestDevice,
+            transport: transport
+        )
+        let delegate = ConnectionDelegateDouble()
+        connection.delegate = delegate
+        try await connection.connect()
+
+        transport.emitDisconnected()
+        await waitForBluetoothReliabilityCondition { delegate.unexpectedDisconnectCount == 1 }
+        transport.emitDisconnected()
+        await Task.yield()
+
+        XCTAssertEqual(connection.teardownCallCount, 1)
+        XCTAssertEqual(transport.disposeCallCount, 1)
+        XCTAssertEqual(delegate.unexpectedDisconnectCount, 1)
+    }
+}

--- a/desktop/macos/Desktop/Tests/BaseDeviceConnectionTeardownCoalescingTests.swift
+++ b/desktop/macos/Desktop/Tests/BaseDeviceConnectionTeardownCoalescingTests.swift
@@ -1,0 +1,187 @@
+import Combine
+import CoreBluetooth
+import XCTest
+
+@testable import Omi_Computer
+
+@MainActor
+final class BaseDeviceConnectionTeardownCoalescingTests: XCTestCase {
+    func testExplicitDisconnectAwaitsUnexpectedTeardownAndTransportDispose() async throws {
+        let transport = SuspendedDisposeTransport()
+        let connection = SuspendedTeardownConnection(
+            device: teardownTestDevice,
+            transport: transport
+        )
+        let delegate = TeardownConnectionDelegate()
+        let completion = TeardownCompletionProbe()
+        connection.delegate = delegate
+
+        try await connection.connect()
+        transport.emitUnexpectedDisconnect()
+        await waitForTeardownCondition { connection.teardownCallCount == 1 }
+
+        let explicitDisconnect = Task { @MainActor in
+            completion.didEnterExplicitDisconnect = true
+            await connection.disconnect()
+            completion.didFinishExplicitDisconnect = true
+        }
+        await waitForTeardownCondition { completion.didEnterExplicitDisconnect }
+
+        XCTAssertFalse(completion.didFinishExplicitDisconnect)
+        XCTAssertEqual(transport.disposeCallCount, 0)
+        XCTAssertEqual(delegate.unexpectedDisconnectCount, 0)
+
+        connection.resumeTeardown()
+        await waitForTeardownCondition { transport.disposeCallCount == 1 }
+
+        XCTAssertFalse(completion.didFinishExplicitDisconnect)
+        XCTAssertEqual(delegate.unexpectedDisconnectCount, 0)
+
+        transport.resumeDispose()
+        await explicitDisconnect.value
+
+        XCTAssertTrue(completion.didFinishExplicitDisconnect)
+        XCTAssertEqual(connection.teardownCallCount, 1)
+        XCTAssertEqual(transport.disposeCallCount, 1)
+        XCTAssertEqual(delegate.unexpectedDisconnectCount, 1)
+    }
+}
+
+private var teardownTestDevice: BtDevice {
+    BtDevice(
+        id: "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE",
+        name: "Teardown Test Omi",
+        type: .omi,
+        rssi: -50
+    )
+}
+
+@MainActor
+private func waitForTeardownCondition(
+    _ condition: @escaping @MainActor () -> Bool,
+    file: StaticString = #filePath,
+    line: UInt = #line
+) async {
+    for _ in 0..<500 {
+        if condition() { return }
+        await Task.yield()
+    }
+    XCTFail("Timed out waiting for teardown condition", file: file, line: line)
+}
+
+@MainActor
+private final class SuspendedTeardownConnection: BaseDeviceConnection {
+    private(set) var teardownCallCount = 0
+    private var teardownContinuation: CheckedContinuation<Void, Never>?
+
+    override func teardownDevice() async {
+        teardownCallCount += 1
+        await withCheckedContinuation { continuation in
+            teardownContinuation = continuation
+        }
+    }
+
+    func resumeTeardown() {
+        let continuation = teardownContinuation
+        teardownContinuation = nil
+        continuation?.resume()
+    }
+}
+
+@MainActor
+private final class SuspendedDisposeTransport: DeviceTransport {
+    let deviceId = teardownTestDevice.id
+    let sessionGeneration: UInt64 = 101
+    private(set) var state: DeviceTransportState = .disconnected
+    private let stateSubject = PassthroughSubject<DeviceTransportState, Never>()
+    var connectionStatePublisher: AnyPublisher<DeviceTransportState, Never> {
+        stateSubject.eraseToAnyPublisher()
+    }
+
+    private(set) var disposeCallCount = 0
+    private var disposeContinuation: CheckedContinuation<Void, Never>?
+
+    func connect() async throws {
+        state = .connected
+        stateSubject.send(.connected)
+    }
+
+    func disconnect() async {
+        state = .disconnected
+        stateSubject.send(.disconnected)
+    }
+
+    func isConnected() async -> Bool {
+        state == .connected
+    }
+
+    func ping() async -> Bool {
+        true
+    }
+
+    func getCharacteristicStream(
+        serviceUUID: CBUUID,
+        characteristicUUID: CBUUID
+    ) -> AsyncThrowingStream<Data, Error> {
+        AsyncThrowingStream { continuation in
+            continuation.finish()
+        }
+    }
+
+    func readCharacteristic(
+        serviceUUID: CBUUID,
+        characteristicUUID: CBUUID
+    ) async throws -> Data {
+        Data()
+    }
+
+    func writeCharacteristic(
+        data: Data,
+        serviceUUID: CBUUID,
+        characteristicUUID: CBUUID,
+        withResponse: Bool
+    ) async throws {}
+
+    func dispose() async {
+        disposeCallCount += 1
+        await withCheckedContinuation { continuation in
+            disposeContinuation = continuation
+        }
+        state = .disconnected
+        stateSubject.send(.disconnected)
+    }
+
+    func emitUnexpectedDisconnect() {
+        state = .disconnected
+        stateSubject.send(.disconnected)
+    }
+
+    func resumeDispose() {
+        let continuation = disposeContinuation
+        disposeContinuation = nil
+        continuation?.resume()
+    }
+}
+
+@MainActor
+private final class TeardownConnectionDelegate: DeviceConnectionDelegate {
+    private(set) var unexpectedDisconnectCount = 0
+
+    func deviceConnection(
+        _ connection: DeviceConnection,
+        didDisconnectUnexpectedly device: BtDevice
+    ) {
+        unexpectedDisconnectCount += 1
+    }
+
+    func deviceConnection(
+        _ connection: DeviceConnection,
+        didDetectFall data: AccelerometerData
+    ) {}
+}
+
+@MainActor
+private final class TeardownCompletionProbe {
+    var didEnterExplicitDisconnect = false
+    var didFinishExplicitDisconnect = false
+}

--- a/desktop/macos/Desktop/Tests/BleTransportLeaseReliabilityTests.swift
+++ b/desktop/macos/Desktop/Tests/BleTransportLeaseReliabilityTests.swift
@@ -1,0 +1,360 @@
+import Combine
+import CoreBluetooth
+import XCTest
+
+@testable import Omi_Computer
+
+@MainActor
+final class BleTransportLifecycleTests: XCTestCase {
+    func testDisposeDrainsPendingConnectAndRequestsPhysicalDisconnectExactlyOnce() async {
+        let physicalDriver = FakeBLEPhysicalDriver()
+        let centralEvents = PassthroughSubject<BluetoothCentralEvent, Never>()
+        let transport = BleTransport(
+            physicalDriver: physicalDriver,
+            centralEvents: centralEvents.eraseToAnyPublisher(),
+            sessionGeneration: 42
+        )
+
+        let connectTask = Task {
+            try await transport.connect()
+        }
+        await waitForBluetoothReliabilityCondition { physicalDriver.connectCallCount == 1 }
+
+        await transport.dispose()
+        do {
+            try await connectTask.value
+            XCTFail("Pending connect should be cancelled by disposal")
+        } catch {
+            // The precise public transport wrapping is not important here; the
+            // invariant is that the waiter terminates and the driver drains.
+        }
+
+        XCTAssertEqual(physicalDriver.disconnectCallCount, 1)
+        XCTAssertNil(physicalDriver.delegate)
+        XCTAssertEqual(transport.state, .disconnected)
+
+        await transport.dispose()
+        await transport.disconnect()
+        XCTAssertEqual(physicalDriver.disconnectCallCount, 1)
+    }
+
+    func testReplacementTransportIgnoresLateConnectedEventFromOldLease() async {
+        let clock = ManualDeviceOperationClock()
+        let centralEvents = PassthroughSubject<BluetoothCentralEvent, Never>()
+        let physicalA = FakeBLEPhysicalDriver(firstLeaseToken: 100)
+        let transportA = BleTransport(
+            physicalDriver: physicalA,
+            centralEvents: centralEvents.eraseToAnyPublisher(),
+            sessionGeneration: 1,
+            operationClock: clock
+        )
+        let connectA = Task { try await transportA.connect() }
+        await waitForBluetoothReliabilityCondition {
+            let sleeperCount = await clock.sleeperCount
+            return physicalA.issuedLeases.count == 1 && sleeperCount == 1
+        }
+        let leaseA = physicalA.issuedLeases[0]
+        await clock.advanceAll()
+        do { try await connectA.value } catch {}
+        await transportA.dispose()
+
+        let physicalB = FakeBLEPhysicalDriver(firstLeaseToken: 200)
+        let transportB = BleTransport(
+            physicalDriver: physicalB,
+            centralEvents: centralEvents.eraseToAnyPublisher(),
+            sessionGeneration: 2
+        )
+        let connectB = Task { try await transportB.connect() }
+        await waitForBluetoothReliabilityCondition { physicalB.issuedLeases.count == 1 }
+        let leaseB = physicalB.issuedLeases[0]
+
+        centralEvents.send(.connected(lease: leaseA))
+        await Task.yield()
+        await Task.yield()
+        XCTAssertEqual(physicalB.discoverServicesCallCount, 0)
+
+        centralEvents.send(.connected(lease: leaseB))
+        await waitForBluetoothReliabilityCondition { physicalB.discoverServicesCallCount == 1 }
+
+        await transportB.dispose()
+        do { try await connectB.value } catch {}
+    }
+
+    func testTimedOutReadDoesNotSuppressNotificationsOrAllowReadRetry() async throws {
+        let clock = ManualDeviceOperationClock()
+        let fixture = try await makeConnectedTransport(operationClock: clock)
+        let transport = fixture.transport
+        let physicalDriver = fixture.physicalDriver
+        let service = fixture.service
+        let characteristic = fixture.characteristic
+
+        let notifications = transport.getCharacteristicStream(
+            serviceUUID: service.uuid,
+            characteristicUUID: characteristic.uuid
+        )
+        let notification = Task { () -> Data? in
+            for try await value in notifications {
+                return value
+            }
+            return nil
+        }
+
+        let read = Task {
+            try await transport.readCharacteristic(
+                serviceUUID: service.uuid,
+                characteristicUUID: characteristic.uuid
+            )
+        }
+        await waitForBluetoothReliabilityCondition { physicalDriver.readValueCallCount == 1 }
+        await clock.advanceAll()
+        do {
+            _ = try await read.value
+            XCTFail("Expected read timeout")
+        } catch {
+            // The transport wraps broker timeout details in its public error.
+        }
+
+        characteristic.value = Data([64])
+        await transport.didUpdateValue(for: characteristic, error: nil)
+        let streamedValue = try await notification.value
+        XCTAssertEqual(streamedValue, Data([64]))
+
+        do {
+            _ = try await transport.readCharacteristic(
+                serviceUUID: service.uuid,
+                characteristicUUID: characteristic.uuid
+            )
+            XCTFail("A timed-out uncorrelated read must not be retried in-session")
+        } catch let error as DeviceTransportError {
+            guard case .readFailed = error else {
+                return XCTFail("Unexpected transport error: \(error)")
+            }
+        }
+        XCTAssertEqual(physicalDriver.readValueCallCount, 1)
+        await transport.dispose()
+    }
+
+    func testCharacteristicNotificationsBroadcastToEverySubscriber() async throws {
+        let fixture = try await makeConnectedTransport()
+        let firstStream = fixture.transport.getCharacteristicStream(
+            serviceUUID: fixture.service.uuid,
+            characteristicUUID: fixture.characteristic.uuid
+        )
+        let secondStream = fixture.transport.getCharacteristicStream(
+            serviceUUID: fixture.service.uuid,
+            characteristicUUID: fixture.characteristic.uuid
+        )
+        let firstReceived = Task { try await firstValue(from: firstStream) }
+        let secondReceived = Task { try await firstValue(from: secondStream) }
+
+        fixture.characteristic.value = Data([1, 2, 3])
+        await fixture.transport.didUpdateValue(
+            for: fixture.characteristic,
+            error: nil
+        )
+
+        let firstResult = try await firstReceived.value
+        let secondResult = try await secondReceived.value
+        XCTAssertEqual(firstResult, Data([1, 2, 3]))
+        XCTAssertEqual(secondResult, Data([1, 2, 3]))
+        await fixture.transport.dispose()
+    }
+
+    func testCancelledCharacteristicSubscriberCanResubscribeInSession() async throws {
+        let fixture = try await makeConnectedTransport()
+        let initialStream = fixture.transport.getCharacteristicStream(
+            serviceUUID: fixture.service.uuid,
+            characteristicUUID: fixture.characteristic.uuid
+        )
+        let initialConsumer = Task {
+            for try await _ in initialStream {}
+        }
+        await Task.yield()
+        initialConsumer.cancel()
+        _ = try? await initialConsumer.value
+
+        let replacementStream = fixture.transport.getCharacteristicStream(
+            serviceUUID: fixture.service.uuid,
+            characteristicUUID: fixture.characteristic.uuid
+        )
+        let replacementValue = Task {
+            try await firstValue(from: replacementStream)
+        }
+        fixture.characteristic.value = Data([9])
+        await fixture.transport.didUpdateValue(
+            for: fixture.characteristic,
+            error: nil
+        )
+
+        let replacementResult = try await replacementValue.value
+        XCTAssertEqual(replacementResult, Data([9]))
+        await fixture.transport.dispose()
+    }
+
+    func testBeeCancellationDuringPendingPhysicalWriteRecoversByDisconnecting() async throws {
+        let fixture = try await makeConnectedTransport(
+            serviceUUID: DeviceUUIDs.Bee.service,
+            characteristicUUID: CBUUID(
+                string: "05e1f93c-d8d0-5ed8-dd88-379e4c1a3e3e"
+            )
+        )
+        let connection = BeeDeviceConnection(
+            device: bluetoothReliabilityTestDevice,
+            transport: fixture.transport
+        )
+        let stream = connection.getAudioStream()
+        let consumer = Task {
+            for try await _ in stream {}
+        }
+        await waitForBluetoothReliabilityCondition { fixture.physicalDriver.writeValueCallCount == 1 }
+
+        consumer.cancel()
+        _ = try? await consumer.value
+        await waitForBluetoothReliabilityCondition { fixture.physicalDriver.disconnectCallCount == 1 }
+
+        // The cancelled write poisoned the characteristic callback identity,
+        // so a compensating write was not issued over the ambiguous channel.
+        XCTAssertEqual(fixture.physicalDriver.writeValueCallCount, 1)
+        XCTAssertEqual(fixture.transport.state, .disconnected)
+        await fixture.transport.dispose()
+        XCTAssertEqual(fixture.physicalDriver.disconnectCallCount, 1)
+    }
+
+    func testBeeResponseBeforeWriteAckDrainsPhysicalWriteBeforeQueueAdvances() async throws {
+        let fixture = try await makeConnectedTransport(
+            serviceUUID: DeviceUUIDs.Bee.service,
+            characteristicUUID: CBUUID(
+                string: "05e1f93c-d8d0-5ed8-dd88-379e4c1a3e3e"
+            )
+        )
+        let connection = BeeDeviceConnection(
+            device: bluetoothReliabilityTestDevice,
+            transport: fixture.transport
+        )
+        let stream = connection.getAudioStream()
+        let consumer = Task {
+            for try await _ in stream {}
+        }
+        await waitForBluetoothReliabilityCondition { fixture.physicalDriver.writeValueCallCount == 1 }
+
+        connection.handleControlResponse([0x06, 0xC0, 0x01])
+        for _ in 0..<10 { await Task.yield() }
+        XCTAssertEqual(fixture.physicalDriver.writeValueCallCount, 1)
+
+        await fixture.transport.didWriteValue(
+            for: fixture.characteristic,
+            error: nil
+        )
+        consumer.cancel()
+        _ = try? await consumer.value
+        await waitForBluetoothReliabilityCondition { fixture.physicalDriver.writeValueCallCount == 2 }
+
+        connection.handleControlResponse([0x06, 0xC0, 0x00])
+        for _ in 0..<10 { await Task.yield() }
+        XCTAssertEqual(fixture.physicalDriver.writeValueCallCount, 2)
+        await fixture.transport.didWriteValue(
+            for: fixture.characteristic,
+            error: nil
+        )
+
+        await connection.teardownDevice()
+        XCTAssertEqual(fixture.physicalDriver.disconnectCallCount, 0)
+        await fixture.transport.dispose()
+    }
+
+    private func makeConnectedTransport(
+        operationClock: any DeviceOperationClock = ContinuousDeviceOperationClock(),
+        serviceUUID: CBUUID = CBUUID(string: "180F"),
+        characteristicUUID: CBUUID = CBUUID(string: "2A19")
+    ) async throws -> (
+        transport: BleTransport,
+        physicalDriver: FakeBLEPhysicalDriver,
+        service: CBMutableService,
+        characteristic: CBMutableCharacteristic
+    ) {
+        let centralEvents = PassthroughSubject<BluetoothCentralEvent, Never>()
+        let physicalDriver = FakeBLEPhysicalDriver()
+        let service = CBMutableService(type: serviceUUID, primary: true)
+        let characteristic = CBMutableCharacteristic(
+            type: characteristicUUID,
+            properties: [.read, .notify],
+            value: nil,
+            permissions: [.readable]
+        )
+        service.characteristics = [characteristic]
+        let transport = BleTransport(
+            physicalDriver: physicalDriver,
+            centralEvents: centralEvents.eraseToAnyPublisher(),
+            sessionGeneration: 9,
+            operationClock: operationClock
+        )
+
+        let connect = Task { try await transport.connect() }
+        await waitForBluetoothReliabilityCondition { physicalDriver.issuedLeases.count == 1 }
+        centralEvents.send(.connected(lease: physicalDriver.issuedLeases[0]))
+        await waitForBluetoothReliabilityCondition { physicalDriver.discoverServicesCallCount == 1 }
+        await transport.didDiscoverServices([service], error: nil)
+        await waitForBluetoothReliabilityCondition { physicalDriver.discoverCharacteristicsCallCount == 1 }
+        await transport.didDiscoverCharacteristics(for: service, error: nil)
+        try await connect.value
+        return (transport, physicalDriver, service, characteristic)
+    }
+
+    private func firstValue(
+        from stream: AsyncThrowingStream<Data, Error>
+    ) async throws -> Data? {
+        for try await value in stream {
+            return value
+        }
+        return nil
+    }
+}
+
+@MainActor
+final class BluetoothConnectionLeaseRegistryTests: XCTestCase {
+    func testCancelledLeaseFencesPeripheralUntilTerminalCallback() throws {
+        let registry = BluetoothConnectionLeaseRegistry()
+        let peripheralID = UUID()
+        let leaseA = try registry.begin(
+            peripheralID: peripheralID,
+            sessionGeneration: 1
+        )
+
+        XCTAssertTrue(registry.requestCancellation(leaseA))
+        XCTAssertThrowsError(
+            try registry.begin(peripheralID: peripheralID, sessionGeneration: 2)
+        ) { error in
+            XCTAssertEqual(
+                error as? BluetoothConnectionLeaseError,
+                .leaseAlreadyActive(leaseA)
+            )
+        }
+
+        let lateConnect = registry.markConnected(peripheralID: peripheralID)
+        XCTAssertEqual(lateConnect?.lease, leaseA)
+        XCTAssertEqual(lateConnect?.shouldCancel, true)
+        XCTAssertEqual(registry.activeLease(for: peripheralID), leaseA)
+
+        XCTAssertEqual(registry.finish(peripheralID: peripheralID), leaseA)
+        let leaseB = try registry.begin(
+            peripheralID: peripheralID,
+            sessionGeneration: 2
+        )
+        XCTAssertNotEqual(leaseB.token, leaseA.token)
+    }
+
+    func testCentralResetReleasesEveryFencedLease() throws {
+        let registry = BluetoothConnectionLeaseRegistry()
+        let firstID = UUID()
+        let secondID = UUID()
+        let first = try registry.begin(peripheralID: firstID, sessionGeneration: 1)
+        let second = try registry.begin(peripheralID: secondID, sessionGeneration: 2)
+        XCTAssertTrue(registry.requestCancellation(first))
+
+        XCTAssertEqual(Set(registry.reset()), Set([first, second]))
+        XCTAssertNil(registry.activeLease(for: firstID))
+        XCTAssertNoThrow(
+            try registry.begin(peripheralID: firstID, sessionGeneration: 3)
+        )
+    }
+}

--- a/desktop/macos/Desktop/Tests/BluetoothReliabilityTestSupport.swift
+++ b/desktop/macos/Desktop/Tests/BluetoothReliabilityTestSupport.swift
@@ -1,0 +1,465 @@
+import Combine
+import CoreBluetooth
+import XCTest
+
+@testable import Omi_Computer
+
+// MARK: - Test doubles
+
+enum BluetoothReliabilityTestError: Error {
+    case expected
+}
+
+@MainActor
+final class AudioControllerHarness {
+    var suspendStart = false
+    private(set) var startCallCount = 0
+    private(set) var startCompletionCount = 0
+    private(set) var stopCallCount = 0
+    private var startContinuation: CheckedContinuation<Void, Never>?
+    private var stopContinuation: CheckedContinuation<Void, Error>?
+
+    func start() async throws {
+        startCallCount += 1
+        if suspendStart {
+            await withCheckedContinuation { continuation in
+                startContinuation = continuation
+            }
+        }
+        startCompletionCount += 1
+    }
+
+    func resumeStart() {
+        startContinuation?.resume()
+        startContinuation = nil
+        suspendStart = false
+    }
+
+    func stop() async throws {
+        stopCallCount += 1
+        try await withCheckedThrowingContinuation { continuation in
+            stopContinuation = continuation
+        }
+    }
+
+    func failStop(_ error: Error) {
+        stopContinuation?.resume(throwing: error)
+        stopContinuation = nil
+    }
+
+    func succeedStop() {
+        stopContinuation?.resume()
+        stopContinuation = nil
+    }
+}
+
+var bluetoothReliabilityTestDevice: BtDevice {
+    BtDevice(
+        id: "11111111-2222-3333-4444-555555555555",
+        name: "Test Omi",
+        type: .omi,
+        rssi: -42
+    )
+}
+
+actor ManualDeviceOperationClock: DeviceOperationClock {
+    private var sleepers: [CheckedContinuation<Void, Error>] = []
+
+    var sleeperCount: Int { sleepers.count }
+
+    func sleep(for duration: Duration) async throws {
+        try await withCheckedThrowingContinuation { continuation in
+            sleepers.append(continuation)
+        }
+    }
+
+    func advanceAll() {
+        let current = sleepers
+        sleepers.removeAll()
+        current.forEach { $0.resume() }
+    }
+}
+
+@MainActor
+func waitForBluetoothReliabilityCondition(
+    _ predicate: @escaping @MainActor () async -> Bool,
+    file: StaticString = #filePath,
+    line: UInt = #line
+) async {
+    for _ in 0..<500 {
+        if await predicate() { return }
+        await Task.yield()
+    }
+    XCTFail("Timed out waiting for condition", file: file, line: line)
+}
+
+@MainActor
+final class FakeBLEPhysicalDriver: BLEPhysicalDriving {
+    let identifier = UUID(uuidString: bluetoothReliabilityTestDevice.id)!
+    var state: CBPeripheralState = .disconnected
+    weak var delegate: CBPeripheralDelegate?
+    var connectCallCount = 0
+    var disconnectCallCount = 0
+    var discoverServicesCallCount = 0
+    var discoverCharacteristicsCallCount = 0
+    var readValueCallCount = 0
+    var writeValueCallCount = 0
+    private(set) var writtenData: [Data] = []
+    private(set) var issuedLeases: [BluetoothConnectionLease] = []
+    private let firstLeaseToken: UInt64
+
+    init(firstLeaseToken: UInt64 = 1) {
+        self.firstLeaseToken = firstLeaseToken
+    }
+
+    func connect(sessionGeneration: UInt64) throws -> BluetoothConnectionLease {
+        connectCallCount += 1
+        state = .connecting
+        let lease = BluetoothConnectionLease(
+            peripheralID: identifier,
+            token: firstLeaseToken + UInt64(connectCallCount - 1),
+            sessionGeneration: sessionGeneration
+        )
+        issuedLeases.append(lease)
+        return lease
+    }
+
+    func disconnect() {
+        disconnectCallCount += 1
+        state = .disconnected
+    }
+
+    func discoverServices(_ serviceUUIDs: [CBUUID]?) {
+        discoverServicesCallCount += 1
+    }
+    func discoverCharacteristics(_ characteristicUUIDs: [CBUUID]?, for service: CBService) {
+        discoverCharacteristicsCallCount += 1
+    }
+    func readValue(for characteristic: CBCharacteristic) {
+        readValueCallCount += 1
+    }
+    func writeValue(
+        _ data: Data,
+        for characteristic: CBCharacteristic,
+        type: CBCharacteristicWriteType
+    ) {
+        writeValueCallCount += 1
+        writtenData.append(data)
+    }
+    func setNotifyValue(_ enabled: Bool, for characteristic: CBCharacteristic) {}
+    func readRSSI() {}
+}
+
+@MainActor
+final class ReliabilityTestTransport: DeviceTransport {
+    let deviceId = bluetoothReliabilityTestDevice.id
+    let sessionGeneration: UInt64
+    var state: DeviceTransportState = .disconnected
+    private let stateSubject = PassthroughSubject<DeviceTransportState, Never>()
+    var connectionStatePublisher: AnyPublisher<DeviceTransportState, Never> {
+        stateSubject.eraseToAnyPublisher()
+    }
+
+    var connectCallCount = 0
+    var disconnectCallCount = 0
+    var disposeCallCount = 0
+    var writeCallCount = 0
+    private(set) var writtenData: [Data] = []
+
+    init(sessionGeneration: UInt64) {
+        self.sessionGeneration = sessionGeneration
+    }
+
+    func connect() async throws {
+        connectCallCount += 1
+        state = .connected
+        stateSubject.send(.connected)
+    }
+
+    func disconnect() async {
+        disconnectCallCount += 1
+        state = .disconnected
+        stateSubject.send(.disconnected)
+    }
+
+    func isConnected() async -> Bool { state == .connected }
+    func ping() async -> Bool { true }
+    func getCharacteristicStream(
+        serviceUUID: CBUUID,
+        characteristicUUID: CBUUID
+    ) -> AsyncThrowingStream<Data, Error> {
+        AsyncThrowingStream { $0.finish() }
+    }
+    func readCharacteristic(
+        serviceUUID: CBUUID,
+        characteristicUUID: CBUUID
+    ) async throws -> Data { Data() }
+    func writeCharacteristic(
+        data: Data,
+        serviceUUID: CBUUID,
+        characteristicUUID: CBUUID,
+        withResponse: Bool
+    ) async throws {
+        writeCallCount += 1
+        writtenData.append(data)
+    }
+    func dispose() async {
+        disposeCallCount += 1
+        state = .disconnected
+        stateSubject.send(.disconnected)
+    }
+
+    func emitDisconnected() {
+        state = .disconnected
+        stateSubject.send(.disconnected)
+    }
+}
+
+@MainActor
+final class LifecycleHookConnection: BaseDeviceConnection {
+    var prepareCallCount = 0
+    var teardownCallCount = 0
+    var prepareError: Error?
+
+    override func prepareDeviceAfterConnect() async throws {
+        prepareCallCount += 1
+        if let prepareError { throw prepareError }
+    }
+
+    override func teardownDevice() async {
+        teardownCallCount += 1
+    }
+}
+
+@MainActor
+final class ConnectionDelegateDouble: DeviceConnectionDelegate {
+    var unexpectedDisconnectCount = 0
+
+    func deviceConnection(
+        _ connection: DeviceConnection,
+        didDisconnectUnexpectedly device: BtDevice
+    ) {
+        unexpectedDisconnectCount += 1
+    }
+
+    func deviceConnection(
+        _ connection: DeviceConnection,
+        didDetectFall data: AccelerometerData
+    ) {}
+}
+
+@MainActor
+final class SessionConnectionDouble: DeviceConnection {
+    var device: BtDevice
+    let transport: DeviceTransport
+    let sessionGeneration: UInt64
+    var lastPongAt: Date?
+    var cachedFeatures: OmiFeatures?
+    weak var delegate: DeviceConnectionDelegate?
+
+    var suspendConnect = false
+    var suspendDisconnect = false
+    var suspendUnpair = false
+    var connectCallCount = 0
+    var disconnectCallCount = 0
+    var unpairCallCount = 0
+    var batteryLevel = -1
+    var suspendBattery = false
+    var batteryCallCount = 0
+    var batteryStreamCallCount = 0
+    private var connectContinuation: CheckedContinuation<Void, Error>?
+    private var disconnectContinuation: CheckedContinuation<Void, Never>?
+    private var unpairContinuation: CheckedContinuation<Void, Never>?
+    private var batteryContinuation: CheckedContinuation<Int, Never>?
+    private var batteryStreamContinuation: AsyncThrowingStream<Int, Error>.Continuation?
+
+    init(device: BtDevice, sessionGeneration: UInt64) {
+        self.device = device
+        self.sessionGeneration = sessionGeneration
+        self.transport = ReliabilityTestTransport(sessionGeneration: sessionGeneration)
+    }
+
+    func connect() async throws {
+        connectCallCount += 1
+        guard suspendConnect else { return }
+        try await withCheckedThrowingContinuation { continuation in
+            connectContinuation = continuation
+        }
+    }
+
+    func completeConnectSuccessfully() {
+        connectContinuation?.resume()
+        connectContinuation = nil
+    }
+
+    func failConnect(_ error: Error) {
+        connectContinuation?.resume(throwing: error)
+        connectContinuation = nil
+    }
+
+    func disconnect() async {
+        disconnectCallCount += 1
+        guard suspendDisconnect else { return }
+        await withCheckedContinuation { continuation in
+            disconnectContinuation = continuation
+        }
+    }
+    func completeDisconnect() {
+        disconnectContinuation?.resume()
+        disconnectContinuation = nil
+    }
+    func unpair() async {
+        unpairCallCount += 1
+        guard suspendUnpair else { return }
+        await withCheckedContinuation { continuation in
+            unpairContinuation = continuation
+        }
+    }
+    func completeUnpair() {
+        unpairContinuation?.resume()
+        unpairContinuation = nil
+    }
+    func isConnected() async -> Bool { true }
+    func ping() async -> Bool { true }
+    func getBatteryLevel() async -> Int {
+        batteryCallCount += 1
+        guard suspendBattery else { return batteryLevel }
+        return await withCheckedContinuation { continuation in
+            batteryContinuation = continuation
+        }
+    }
+    func completeBattery(level: Int) {
+        batteryContinuation?.resume(returning: level)
+        batteryContinuation = nil
+    }
+    func getBatteryLevelStream() -> AsyncThrowingStream<Int, Error> {
+        batteryStreamCallCount += 1
+        return AsyncThrowingStream { continuation in
+            batteryStreamContinuation = continuation
+        }
+    }
+    func emitBattery(level: Int) {
+        batteryStreamContinuation?.yield(level)
+    }
+    func finishBatteryStream() {
+        batteryStreamContinuation?.finish()
+        batteryStreamContinuation = nil
+    }
+    func getAudioCodec() async -> BleAudioCodec { .pcm8 }
+    func getAudioStream() -> AsyncThrowingStream<Data, Error> {
+        AsyncThrowingStream { $0.finish() }
+    }
+    func getButtonState() async -> [UInt8] { [] }
+    func getButtonStream() -> AsyncThrowingStream<[UInt8], Error> {
+        AsyncThrowingStream { $0.finish() }
+    }
+    func getStorageList() async -> [Int32] { [] }
+    func writeToStorage(fileNum: Int, command: Int, offset: Int) async -> Bool { false }
+    func getStorageStream() -> AsyncThrowingStream<Data, Error> {
+        AsyncThrowingStream { $0.finish() }
+    }
+    func hasPhotoStreaming() async -> Bool { false }
+    func startPhotoCapture() async {}
+    func stopPhotoCapture() async {}
+    func getImageStream() -> AsyncThrowingStream<OrientedImage, Error> {
+        AsyncThrowingStream { $0.finish() }
+    }
+    func getAccelerometerStream() -> AsyncThrowingStream<AccelerometerData, Error> {
+        AsyncThrowingStream { $0.finish() }
+    }
+    func playHaptic(level: Int) async -> Bool { false }
+    func getFeatures() async -> OmiFeatures { [] }
+    func setLedDimRatio(_ ratio: Int) async {}
+    func getLedDimRatio() async -> Int? { nil }
+    func setMicGain(_ gain: Int) async {}
+    func getMicGain() async -> Int? { nil }
+    func isWifiSyncSupported() async -> Bool { false }
+    func setupWifiSync(ssid: String, password: String) async -> WifiSyncSetupResult {
+        .connectionFailed()
+    }
+    func startWifiSync() async -> Bool { false }
+    func stopWifiSync() async -> Bool { false }
+    func getWifiSyncStatusStream() -> AsyncThrowingStream<Int, Error> {
+        AsyncThrowingStream { $0.finish() }
+    }
+}
+
+@MainActor
+final class NoopDeviceSessionScheduler: DeviceSessionScheduling {
+    func schedule(
+        after delay: Duration,
+        action: @escaping @MainActor () -> Void
+    ) -> any DeviceSessionScheduledAction {
+        NoopScheduledAction()
+    }
+}
+
+@MainActor
+final class NoopScheduledAction: DeviceSessionScheduledAction {
+    func cancel() {}
+}
+
+@MainActor
+final class ManualDeviceSessionScheduler: DeviceSessionScheduling {
+    private final class ScheduledAction: DeviceSessionScheduledAction {
+        var action: (@MainActor () -> Void)?
+
+        init(action: @escaping @MainActor () -> Void) {
+            self.action = action
+        }
+
+        func cancel() {
+            action = nil
+        }
+
+        func run() {
+            let current = action
+            action = nil
+            current?()
+        }
+    }
+
+    private var actions: [ScheduledAction] = []
+    var activeActionCount: Int { actions.filter { $0.action != nil }.count }
+
+    func schedule(
+        after delay: Duration,
+        action: @escaping @MainActor () -> Void
+    ) -> any DeviceSessionScheduledAction {
+        let scheduled = ScheduledAction(action: action)
+        actions.append(scheduled)
+        return scheduled
+    }
+
+    func runNext() {
+        actions.first(where: { $0.action != nil })?.run()
+    }
+}
+
+@MainActor
+final class ReliabilityBluetoothManager: DeviceBluetoothManaging {
+    private let stateSubject = CurrentValueSubject<CBManagerState, Never>(.poweredOn)
+    private let scanningSubject = CurrentValueSubject<Bool, Never>(false)
+    private let devicesSubject = CurrentValueSubject<[BtDevice], Never>([])
+    private let centralSubject = PassthroughSubject<BluetoothCentralEvent, Never>()
+
+    var currentBluetoothState: CBManagerState { stateSubject.value }
+    var currentIsScanning: Bool { scanningSubject.value }
+    var currentDiscoveredDevices: [BtDevice] { devicesSubject.value }
+    var bluetoothStatePublisher: AnyPublisher<CBManagerState, Never> {
+        stateSubject.eraseToAnyPublisher()
+    }
+    var isScanningPublisher: AnyPublisher<Bool, Never> {
+        scanningSubject.eraseToAnyPublisher()
+    }
+    var discoveredDevicesPublisher: AnyPublisher<[BtDevice], Never> {
+        devicesSubject.eraseToAnyPublisher()
+    }
+    var centralEventPublisher: AnyPublisher<BluetoothCentralEvent, Never> {
+        centralSubject.eraseToAnyPublisher()
+    }
+
+    func prepareForStateUpdates() {}
+    func startScanning(timeout: TimeInterval) { scanningSubject.send(true) }
+    func stopScanning() { scanningSubject.send(false) }
+}

--- a/desktop/macos/Desktop/Tests/DeviceAudioSessionReliabilityTests.swift
+++ b/desktop/macos/Desktop/Tests/DeviceAudioSessionReliabilityTests.swift
@@ -1,0 +1,347 @@
+import Combine
+import CoreBluetooth
+import XCTest
+
+@testable import Omi_Computer
+
+@MainActor
+final class DeviceAudioStreamLifecycleTests: XCTestCase {
+    func testFriendAudioStreamFinishesWhenSessionTearsDown() async throws {
+        let clock = ManualDeviceOperationClock()
+        let transport = ReliabilityTestTransport(sessionGeneration: 14)
+        let connection = FriendPendantConnection(
+            device: bluetoothReliabilityTestDevice,
+            transport: transport,
+            operationClock: clock
+        )
+        let connectTask = Task { try await connection.connect() }
+        await waitForBluetoothReliabilityCondition { await clock.sleeperCount == 1 }
+        await clock.advanceAll()
+        try await connectTask.value
+
+        let stream = connection.getAudioStream()
+        let consumer = Task {
+            for try await _ in stream {}
+        }
+        await connection.disconnect()
+        try await consumer.value
+    }
+
+    func testLimitlessButtonStreamFinishesWhenSessionTearsDown() async throws {
+        let transport = ReliabilityTestTransport(sessionGeneration: 19)
+        let connection = LimitlessDeviceConnection(
+            device: bluetoothReliabilityTestDevice,
+            transport: transport
+        )
+        let stream = connection.getButtonStream()
+        let consumer = Task {
+            for try await _ in stream {}
+        }
+
+        await connection.teardownDevice()
+        try await consumer.value
+    }
+}
+
+@MainActor
+final class DeviceAudioSetupCancellationTests: XCTestCase {
+    func testBeeCancellationDuringUnmuteWritesCompensatingMute() async {
+        let clock = ManualDeviceOperationClock()
+        let transport = ReliabilityTestTransport(sessionGeneration: 15)
+        transport.state = .connected
+        let connection = BeeDeviceConnection(
+            device: bluetoothReliabilityTestDevice,
+            transport: transport,
+            operationClock: clock
+        )
+
+        let stream = connection.getAudioStream()
+        let consumer = Task {
+            for try await _ in stream {}
+        }
+        await waitForBluetoothReliabilityCondition { transport.writeCallCount == 1 }
+        consumer.cancel()
+        _ = try? await consumer.value
+        await waitForBluetoothReliabilityCondition { transport.writeCallCount == 2 }
+        await waitForBluetoothReliabilityCondition { transport.disconnectCallCount == 1 }
+
+        XCTAssertEqual(transport.writtenData[0], Data([0x06, 0xC0, 0x01]))
+        XCTAssertEqual(transport.writtenData[1], Data([0x06, 0xC0, 0x00]))
+        XCTAssertEqual(transport.disconnectCallCount, 1)
+
+        let replacement = connection.getAudioStream()
+        do {
+            _ = try await firstValue(from: replacement)
+            XCTFail("A poisoned Bee command channel must require reconnect")
+        } catch {}
+        XCTAssertEqual(transport.writeCallCount, 2)
+        await clock.advanceAll()
+    }
+
+    func testPlaudCancellationDuringSetupStopsPartialSession() async {
+        let clock = ManualDeviceOperationClock()
+        let transport = ReliabilityTestTransport(sessionGeneration: 16)
+        transport.state = .connected
+        let connection = PlaudDeviceConnection(
+            device: bluetoothReliabilityTestDevice,
+            transport: transport,
+            operationClock: clock
+        )
+
+        let stream = connection.getAudioStream()
+        let consumer = Task {
+            for try await _ in stream {}
+        }
+        await waitForBluetoothReliabilityCondition { transport.writeCallCount == 1 }
+        consumer.cancel()
+        _ = try? await consumer.value
+        await waitForBluetoothReliabilityCondition { transport.writeCallCount == 2 }
+
+        XCTAssertEqual(transport.writtenData[1], Data([1, 30, 0, 1]))
+        connection.handleNotification([0, 23, 0])
+        for _ in 0..<10 { await Task.yield() }
+        await waitForBluetoothReliabilityCondition { transport.disconnectCallCount == 1 }
+        XCTAssertEqual(transport.writeCallCount, 2)
+        XCTAssertEqual(transport.disconnectCallCount, 1)
+        await clock.advanceAll()
+    }
+
+    func testBeeNormalStopDrainsMuteBeforeWaitingSubscriberRestarts() async {
+        let transport = ReliabilityTestTransport(sessionGeneration: 18)
+        transport.state = .connected
+        let connection = BeeDeviceConnection(
+            device: bluetoothReliabilityTestDevice,
+            transport: transport
+        )
+
+        let firstStream = connection.getAudioStream()
+        let firstConsumer = Task {
+            for try await _ in firstStream {}
+        }
+        await waitForBluetoothReliabilityCondition { transport.writeCallCount == 1 }
+        connection.handleControlResponse([0x06, 0xC0, 0x01])
+        for _ in 0..<10 { await Task.yield() }
+
+        firstConsumer.cancel()
+        _ = try? await firstConsumer.value
+        await waitForBluetoothReliabilityCondition { transport.writeCallCount == 2 }
+
+        let replacementStream = connection.getAudioStream()
+        let replacementConsumer = Task {
+            for try await _ in replacementStream {}
+        }
+        for _ in 0..<10 { await Task.yield() }
+        XCTAssertEqual(transport.writeCallCount, 2)
+
+        connection.handleControlResponse([0x06, 0xC0, 0x00])
+        await waitForBluetoothReliabilityCondition { transport.writeCallCount == 3 }
+        connection.handleControlResponse([0x06, 0xC0, 0x01])
+
+        replacementConsumer.cancel()
+        _ = try? await replacementConsumer.value
+        await waitForBluetoothReliabilityCondition { transport.writeCallCount == 4 }
+        connection.handleControlResponse([0x06, 0xC0, 0x00])
+        await connection.teardownDevice()
+        XCTAssertEqual(transport.disconnectCallCount, 0)
+    }
+
+    func testPlaudStopRecordTimeoutDisconnectsAndFencesRestart() async {
+        let clock = ManualDeviceOperationClock()
+        let transport = ReliabilityTestTransport(sessionGeneration: 20)
+        transport.state = .connected
+        let connection = PlaudDeviceConnection(
+            device: bluetoothReliabilityTestDevice,
+            transport: transport,
+            operationClock: clock
+        )
+        let stream = connection.getAudioStream()
+        let consumer = Task {
+            for try await _ in stream {}
+        }
+
+        await waitForBluetoothReliabilityCondition { transport.writeCallCount == 1 }
+        connection.handleNotification([0, 23, 0, 1])
+        await waitForBluetoothReliabilityCondition { await clock.sleeperCount >= 2 }
+        await clock.advanceAll()
+
+        await waitForBluetoothReliabilityCondition { transport.writeCallCount == 2 }
+        connection.handleNotification([
+            0, 20, 0,
+            1, 0, 0, 0,
+            2, 0, 0, 0,
+            0, 0,
+        ])
+        await waitForBluetoothReliabilityCondition { await clock.sleeperCount >= 2 }
+        await clock.advanceAll()
+
+        await waitForBluetoothReliabilityCondition { transport.writeCallCount == 3 }
+        connection.handleNotification([0, 28, 0, 1])
+        for _ in 0..<10 { await Task.yield() }
+        await clock.advanceAll()
+
+        consumer.cancel()
+        _ = try? await consumer.value
+        await waitForBluetoothReliabilityCondition { transport.writeCallCount == 5 }
+        await waitForBluetoothReliabilityCondition { await clock.sleeperCount >= 1 }
+        await clock.advanceAll()
+        await waitForBluetoothReliabilityCondition { transport.disconnectCallCount == 1 }
+
+        let replacement = connection.getAudioStream()
+        do {
+            _ = try await firstValue(from: replacement)
+            XCTFail("Unacknowledged STOP_RECORD must fence PLAUD audio")
+        } catch {}
+        XCTAssertEqual(transport.writeCallCount, 5)
+    }
+
+    func testBeeRestartClearsPartialAudioFrameFromPreviousSession() async {
+        let transport = ReliabilityTestTransport(sessionGeneration: 21)
+        transport.state = .connected
+        let connection = BeeDeviceConnection(
+            device: bluetoothReliabilityTestDevice,
+            transport: transport
+        )
+        let initialStream = connection.getAudioStream()
+        let initialConsumer = Task {
+            for try await _ in initialStream {}
+        }
+        await waitForBluetoothReliabilityCondition { transport.writeCallCount == 1 }
+        connection.handleControlResponse([0x06, 0xC0, 0x01])
+
+        XCTAssertNil(connection.processAudioPacket([0, 0, 0xFF, 0xF1, 0x50]))
+        initialConsumer.cancel()
+        _ = try? await initialConsumer.value
+        await waitForBluetoothReliabilityCondition { transport.writeCallCount == 2 }
+        connection.handleControlResponse([0x06, 0xC0, 0x00])
+
+        let replacementStream = connection.getAudioStream()
+        let replacementConsumer = Task {
+            for try await _ in replacementStream {}
+        }
+        await waitForBluetoothReliabilityCondition { transport.writeCallCount == 3 }
+        let cleanFrame: [UInt8] = [0xFF, 0xF1, 0x50, 0x80, 0, 0xE0, 0xFC]
+        XCTAssertEqual(
+            connection.processAudioPacket([0, 0] + cleanFrame),
+            cleanFrame
+        )
+        connection.handleControlResponse([0x06, 0xC0, 0x01])
+
+        replacementConsumer.cancel()
+        _ = try? await replacementConsumer.value
+        await waitForBluetoothReliabilityCondition { transport.writeCallCount == 4 }
+        connection.handleControlResponse([0x06, 0xC0, 0x00])
+        await connection.teardownDevice()
+    }
+
+    private func firstValue(
+        from stream: AsyncThrowingStream<Data, Error>
+    ) async throws -> Data? {
+        for try await value in stream {
+            return value
+        }
+        return nil
+    }
+}
+
+@MainActor
+final class DeviceAudioStreamControllerTests: XCTestCase {
+    func testFailedStopFencesWaitingSubscriberInsteadOfRestarting() async {
+        let harness = AudioControllerHarness()
+        let controller = DeviceAudioStreamController(
+            start: { try await harness.start() },
+            stop: { try await harness.stop() }
+        )
+        let initialStream = controller.makeStream()
+        let initialConsumer = Task {
+            for try await _ in initialStream {}
+        }
+        await waitForBluetoothReliabilityCondition { harness.startCallCount == 1 }
+
+        initialConsumer.cancel()
+        _ = try? await initialConsumer.value
+        await waitForBluetoothReliabilityCondition { harness.stopCallCount == 1 }
+
+        let waitingStream = controller.makeStream()
+        let waitingConsumer = Task {
+            for try await _ in waitingStream {}
+        }
+        harness.failStop(BluetoothReliabilityTestError.expected)
+
+        do {
+            try await waitingConsumer.value
+            XCTFail("A failed stop must fence the controller")
+        } catch {}
+        XCTAssertEqual(harness.startCallCount, 1)
+    }
+
+    func testFramesBeforeSetupCompletesAreDropped() async throws {
+        let harness = AudioControllerHarness()
+        harness.suspendStart = true
+        let controller = DeviceAudioStreamController(
+            start: { try await harness.start() },
+            stop: { try await harness.stop() }
+        )
+        let stream = controller.makeStream()
+        var received: [Data] = []
+        let consumer = Task {
+            for try await value in stream {
+                received.append(value)
+            }
+        }
+        await waitForBluetoothReliabilityCondition { harness.startCallCount == 1 }
+
+        controller.yield(Data([1]))
+        harness.resumeStart()
+        await waitForBluetoothReliabilityCondition { harness.startCompletionCount == 1 }
+        controller.yield(Data([2]))
+
+        await waitForBluetoothReliabilityCondition { received == [Data([2])] }
+        consumer.cancel()
+        _ = try? await consumer.value
+        await waitForBluetoothReliabilityCondition { harness.stopCallCount == 1 }
+        harness.succeedStop()
+    }
+
+    func testWaitingReplacementDropsOldFramesUntilStopAndRestartComplete() async throws {
+        let harness = AudioControllerHarness()
+        let controller = DeviceAudioStreamController(
+            start: { try await harness.start() },
+            stop: { try await harness.stop() }
+        )
+        let initialStream = controller.makeStream()
+        let initialConsumer = Task {
+            for try await _ in initialStream {}
+        }
+        await waitForBluetoothReliabilityCondition { harness.startCompletionCount == 1 }
+        initialConsumer.cancel()
+        _ = try? await initialConsumer.value
+        await waitForBluetoothReliabilityCondition { harness.stopCallCount == 1 }
+
+        let replacementStream = controller.makeStream()
+        var replacementValues: [Data] = []
+        let replacementConsumer = Task {
+            for try await value in replacementStream {
+                replacementValues.append(value)
+            }
+        }
+        controller.yield(Data([3]))
+        harness.succeedStop()
+        await waitForBluetoothReliabilityCondition { harness.startCompletionCount == 2 }
+        controller.yield(Data([4]))
+
+        await waitForBluetoothReliabilityCondition { replacementValues == [Data([4])] }
+        replacementConsumer.cancel()
+        _ = try? await replacementConsumer.value
+        await waitForBluetoothReliabilityCondition { harness.stopCallCount == 2 }
+        harness.succeedStop()
+    }
+
+    private func firstValue(
+        from stream: AsyncThrowingStream<Data, Error>
+    ) async throws -> Data? {
+        for try await value in stream {
+            return value
+        }
+        return nil
+    }
+}

--- a/desktop/macos/Desktop/Tests/DeviceCommandCorrelationReliabilityTests.swift
+++ b/desktop/macos/Desktop/Tests/DeviceCommandCorrelationReliabilityTests.swift
@@ -1,0 +1,108 @@
+import Combine
+import CoreBluetooth
+import XCTest
+
+@testable import Omi_Computer
+
+@MainActor
+final class UncorrelatedDeviceCommandTests: XCTestCase {
+    func testPlaudTimeoutPoisonsCommandKeyAndLateResponseCannotAliasRetry() async throws {
+        let clock = ManualDeviceOperationClock()
+        let transport = ReliabilityTestTransport(sessionGeneration: 7)
+        transport.state = .connected
+        let connection = PlaudDeviceConnection(
+            device: bluetoothReliabilityTestDevice,
+            transport: transport,
+            operationClock: clock
+        )
+
+        let first = Task {
+            try await connection.sendCommand(cmdId: 9, payload: [])
+        }
+        await waitForBluetoothReliabilityCondition {
+            let sleeperCount = await clock.sleeperCount
+            return transport.writeCallCount == 1 && sleeperCount == 1
+        }
+        await clock.advanceAll()
+        let firstResult = try await first.value
+        XCTAssertNil(firstResult)
+
+        do {
+            _ = try await connection.sendCommand(cmdId: 9, payload: [])
+            XCTFail("An uncorrelated timed-out command must not be retried in-session")
+        } catch let error as DeviceConnectionError {
+            guard case .operationFailed = error else {
+                return XCTFail("Unexpected connection error: \(error)")
+            }
+        }
+
+        // This is the response to the timed-out command. There is deliberately
+        // no replacement handle for it to complete.
+        connection.handleNotification([0, 9, 0, 0x52])
+        await Task.yield()
+        XCTAssertEqual(transport.writeCallCount, 1)
+    }
+
+    func testPlaudSerializesDifferentCommandIDsOnSharedWriteCharacteristic() async throws {
+        let transport = ReliabilityTestTransport(sessionGeneration: 8)
+        transport.state = .connected
+        let connection = PlaudDeviceConnection(
+            device: bluetoothReliabilityTestDevice,
+            transport: transport
+        )
+
+        let first = Task {
+            try await connection.sendCommand(cmdId: 9, payload: [])
+        }
+        await waitForBluetoothReliabilityCondition { transport.writeCallCount == 1 }
+
+        let second = Task {
+            try await connection.sendCommand(cmdId: 20, payload: [])
+        }
+        for _ in 0..<10 { await Task.yield() }
+        XCTAssertEqual(transport.writeCallCount, 1)
+
+        connection.handleNotification([0, 9, 0, 0x31])
+        let firstResponse = try await first.value
+        XCTAssertEqual(firstResponse, [0x31])
+        await waitForBluetoothReliabilityCondition { transport.writeCallCount == 2 }
+
+        connection.handleNotification([0, 20, 0, 0x32])
+        let secondResponse = try await second.value
+        XCTAssertEqual(secondResponse, [0x32])
+        XCTAssertEqual(transport.writeCallCount, 2)
+    }
+
+    func testPlaudTeardownClosesActiveAndQueuedCommandsBeforeReset() async {
+        let transport = ReliabilityTestTransport(sessionGeneration: 17)
+        transport.state = .connected
+        let connection = PlaudDeviceConnection(
+            device: bluetoothReliabilityTestDevice,
+            transport: transport
+        )
+
+        let active = Task {
+            try await connection.sendCommand(cmdId: 9, payload: [])
+        }
+        await waitForBluetoothReliabilityCondition { transport.writeCallCount == 1 }
+        let queued = Task {
+            try await connection.sendCommand(cmdId: 20, payload: [])
+        }
+        for _ in 0..<10 { await Task.yield() }
+
+        await connection.teardownDevice()
+        _ = try? await active.value
+        _ = try? await queued.value
+        XCTAssertEqual(transport.writeCallCount, 1)
+
+        do {
+            _ = try await connection.sendCommand(cmdId: 28, payload: [])
+            XCTFail("A torn-down adapter must reject new commands")
+        } catch let error as DeviceCommandQueueError {
+            XCTAssertEqual(error, .closed)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+        XCTAssertEqual(transport.writeCallCount, 1)
+    }
+}

--- a/desktop/macos/Desktop/Tests/DeviceOperationBrokerReliabilityTests.swift
+++ b/desktop/macos/Desktop/Tests/DeviceOperationBrokerReliabilityTests.swift
@@ -1,0 +1,244 @@
+import Combine
+import CoreBluetooth
+import XCTest
+
+@testable import Omi_Computer
+
+@MainActor
+final class DeviceOperationBrokerTests: XCTestCase {
+    func testLateHandleCannotCompleteReplacementOperation() async throws {
+        let clock = ManualDeviceOperationClock()
+        let broker = DeviceOperationBroker<String, String>(clock: clock)
+        var handles: [DeviceOperationHandle<String>] = []
+
+        let first = Task {
+            try await broker.perform(key: "battery", timeout: .seconds(1)) { handle in
+                handles.append(handle)
+            }
+        }
+        await waitForBluetoothReliabilityCondition {
+            let sleeperCount = await clock.sleeperCount
+            return handles.count == 1 && sleeperCount == 1
+        }
+        let staleHandle = try XCTUnwrap(handles.first)
+
+        await clock.advanceAll()
+        await assertBrokerError(.timedOut, from: first)
+
+        let second = Task {
+            try await broker.perform(key: "battery") { handle in
+                handles.append(handle)
+            }
+        }
+        await waitForBluetoothReliabilityCondition { handles.count == 2 }
+        let replacementHandle = handles[1]
+
+        let staleAccepted = await broker.succeed(handle: staleHandle, value: "stale")
+        XCTAssertFalse(staleAccepted)
+        let pendingAfterStaleCallback = await broker.pendingCount
+        XCTAssertEqual(pendingAfterStaleCallback, 1)
+
+        let replacementAccepted = await broker.succeed(
+            handle: replacementHandle,
+            value: "replacement"
+        )
+        XCTAssertTrue(replacementAccepted)
+        let replacementValue = try await second.value
+        XCTAssertEqual(replacementValue, "replacement")
+    }
+
+    func testDuplicateKeyIsRejectedWhileFirstOperationIsPending() async throws {
+        let broker = DeviceOperationBroker<String, Void>()
+        var firstHandle: DeviceOperationHandle<String>?
+        let first = Task {
+            try await broker.perform(key: "status") { handle in
+                firstHandle = handle
+            }
+        }
+        await waitForBluetoothReliabilityCondition { firstHandle != nil }
+
+        do {
+            _ = try await broker.perform(key: "status") { _ in }
+            XCTFail("Expected duplicate operation to be rejected")
+        } catch let error as DeviceOperationBrokerError {
+            XCTAssertEqual(error, .operationAlreadyPending)
+        }
+
+        _ = await broker.succeed(handle: try XCTUnwrap(firstHandle), value: ())
+        _ = try await first.value
+    }
+
+    func testAlreadyCancelledTaskNeverStartsPhysicalSideEffect() async {
+        let broker = DeviceOperationBroker<String, Void>()
+        var startCount = 0
+
+        let task = Task {
+            try await broker.perform(key: "cancelled") { _ in
+                startCount += 1
+            }
+        }
+        task.cancel()
+
+        await assertBrokerError(.cancelled, from: task)
+        XCTAssertEqual(startCount, 0)
+        let pendingCount = await broker.pendingCount
+        XCTAssertEqual(pendingCount, 0)
+    }
+
+    func testClaimedCallbackSuccessWinsLateTimeoutAndCallerCancellation() async throws {
+        let clock = ManualDeviceOperationClock()
+        let broker = DeviceOperationBroker<String, String>(clock: clock)
+        var handle: DeviceOperationHandle<String>?
+        var startContinuation: CheckedContinuation<Void, Never>?
+        var terminations: [DeviceOperationTermination] = []
+        let operation = Task {
+            try await broker.perform(
+                key: "command",
+                timeout: .seconds(1),
+                onTerminal: { _, termination in
+                    terminations.append(termination)
+                }
+            ) { operationHandle in
+                    handle = operationHandle
+                    await withCheckedContinuation { continuation in
+                        startContinuation = continuation
+                    }
+                }
+        }
+        await waitForBluetoothReliabilityCondition {
+            let sleeperCount = await clock.sleeperCount
+            return handle != nil && startContinuation != nil && sleeperCount == 1
+        }
+
+        var callbackReturned = false
+        let operationHandle = try XCTUnwrap(handle)
+        let callback = Task {
+            let accepted = await broker.succeed(
+                handle: operationHandle,
+                value: "response"
+            )
+            callbackReturned = true
+            return accepted
+        }
+        for _ in 0..<10 { await Task.yield() }
+        XCTAssertFalse(callbackReturned)
+        let pendingWhileDraining = await broker.pendingCount
+        XCTAssertEqual(pendingWhileDraining, 1)
+        do {
+            _ = try await broker.perform(key: "command") { _ in }
+            XCTFail("A completing key must remain unavailable until start drains")
+        } catch let error as DeviceOperationBrokerError {
+            XCTAssertEqual(error, .operationAlreadyPending)
+        }
+
+        // succeed() has already claimed terminal ownership, but is waiting for
+        // the physical start to drain. The manual clock intentionally ignores
+        // task cancellation, so both terminal sources really reach finish().
+        operation.cancel()
+        await clock.advanceAll()
+        for _ in 0..<10 { await Task.yield() }
+        XCTAssertFalse(callbackReturned)
+        XCTAssertTrue(terminations.isEmpty)
+        let pendingAfterLateTerminals = await broker.pendingCount
+        XCTAssertEqual(pendingAfterLateTerminals, 1)
+
+        startContinuation?.resume()
+        startContinuation = nil
+        let callbackAccepted = await callback.value
+        let operationValue = try await operation.value
+        XCTAssertTrue(callbackAccepted)
+        XCTAssertEqual(operationValue, "response")
+        XCTAssertEqual(terminations, [.succeeded])
+        let pendingAfterCompletion = await broker.pendingCount
+        XCTAssertEqual(pendingAfterCompletion, 0)
+    }
+
+    func testCallbackFailureWaitsForPhysicalStartToDrain() async throws {
+        let broker = DeviceOperationBroker<String, Void>()
+        var handle: DeviceOperationHandle<String>?
+        var startContinuation: CheckedContinuation<Void, Never>?
+        let operation = Task {
+            try await broker.perform(key: "command") { operationHandle in
+                handle = operationHandle
+                await withCheckedContinuation { continuation in
+                    startContinuation = continuation
+                }
+            }
+        }
+        await waitForBluetoothReliabilityCondition { handle != nil && startContinuation != nil }
+
+        var callbackReturned = false
+        let operationHandle = try XCTUnwrap(handle)
+        let callback = Task {
+            let accepted = await broker.fail(
+                handle: operationHandle,
+                reason: "response failed"
+            )
+            callbackReturned = true
+            return accepted
+        }
+        for _ in 0..<10 { await Task.yield() }
+        XCTAssertFalse(callbackReturned)
+
+        startContinuation?.resume()
+        startContinuation = nil
+        let callbackAccepted = await callback.value
+        XCTAssertTrue(callbackAccepted)
+        await assertBrokerError(.failed("response failed"), from: operation)
+    }
+
+    func testCancelAllClaimsAndCompletesEveryPendingKey() async {
+        let broker = DeviceOperationBroker<String, Void>()
+        var startedKeys: Set<String> = []
+        var terminations: [String: DeviceOperationTermination] = [:]
+
+        let first = Task {
+            try await broker.perform(
+                key: "first",
+                onTerminal: { _, termination in
+                    terminations["first"] = termination
+                }
+            ) { _ in
+                startedKeys.insert("first")
+            }
+        }
+        let second = Task {
+            try await broker.perform(
+                key: "second",
+                onTerminal: { _, termination in
+                    terminations["second"] = termination
+                }
+            ) { _ in
+                startedKeys.insert("second")
+            }
+        }
+        await waitForBluetoothReliabilityCondition { startedKeys == ["first", "second"] }
+
+        await broker.cancelAll(reason: .disconnected)
+
+        await assertBrokerError(.disconnected, from: first)
+        await assertBrokerError(.disconnected, from: second)
+        XCTAssertEqual(terminations, [
+            "first": .disconnected,
+            "second": .disconnected,
+        ])
+        let pendingCount = await broker.pendingCount
+        XCTAssertEqual(pendingCount, 0)
+    }
+
+    private func assertBrokerError<Value>(
+        _ expected: DeviceOperationBrokerError,
+        from task: Task<Value, Error>,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async {
+        do {
+            _ = try await task.value
+            XCTFail("Expected broker error", file: file, line: line)
+        } catch let error as DeviceOperationBrokerError {
+            XCTAssertEqual(error, expected, file: file, line: line)
+        } catch {
+            XCTFail("Unexpected error: \(error)", file: file, line: line)
+        }
+    }
+}

--- a/desktop/macos/Desktop/Tests/DeviceProviderTests.swift
+++ b/desktop/macos/Desktop/Tests/DeviceProviderTests.swift
@@ -50,7 +50,13 @@ final class DeviceProviderTests: XCTestCase {
       bluetoothManager: FakeDeviceBluetoothManager(state: .poweredOn),
       userDefaults: defaults,
       notificationCenter: NotificationCenter(),
-      connectionFactory: { FakeDeviceConnection(device: $0, connectError: DeviceTransportError.connectionFailed("boom")) },
+      connectionFactory: { device, generation in
+        FakeDeviceConnection(
+          device: device,
+          sessionGeneration: generation,
+          connectError: DeviceTransportError.connectionFailed("boom")
+        )
+      },
       storageDataChecker: { nil },
       autoReconnectEnabled: false
     )
@@ -89,19 +95,29 @@ final class DeviceProviderTests: XCTestCase {
     XCTAssertNil(provider.errorMessage)
   }
 
-  func testDisconnectNotificationClearsConnectedStateButKeepsPairing() async {
-    let notificationCenter = NotificationCenter()
-    let provider = makeProvider(notificationCenter: notificationCenter, autoReconnectEnabled: false)
+  func testUnexpectedDisconnectFromActiveSessionClearsPresentationButKeepsPairing() async {
+    var connection: FakeDeviceConnection?
+    let provider = DeviceProvider(
+      bluetoothManager: FakeDeviceBluetoothManager(state: .poweredOn),
+      userDefaults: makeDefaults(),
+      notificationCenter: NotificationCenter(),
+      connectionFactory: { device, generation in
+        let created = FakeDeviceConnection(device: device, sessionGeneration: generation)
+        connection = created
+        return created
+      },
+      storageDataChecker: { nil },
+      autoReconnectEnabled: false
+    )
 
     await provider.connect(to: testDevice)
     XCTAssertTrue(provider.isConnected)
 
-    notificationCenter.post(
-      name: .bleDeviceDisconnected,
-      object: nil,
-      userInfo: ["peripheralId": UUID(uuidString: testDevice.id)!]
+    let activeConnection = try! XCTUnwrap(connection)
+    activeConnection.delegate?.deviceConnection(
+      activeConnection,
+      didDisconnectUnexpectedly: testDevice
     )
-    await drainMainQueue()
 
     XCTAssertFalse(provider.isConnected)
     XCTAssertNil(provider.connectedDevice)
@@ -111,19 +127,33 @@ final class DeviceProviderTests: XCTestCase {
     XCTAssertEqual(provider.pairedDevice, testDevice)
   }
 
-  func testDisconnectNotificationForDifferentPeripheralDoesNotClearCurrentDevice() async {
-    let notificationCenter = NotificationCenter()
-    let provider = makeProvider(notificationCenter: notificationCenter, autoReconnectEnabled: false)
+  func testLateDisconnectFromSupersededSessionDoesNotClearReplacement() async {
+    var connections: [FakeDeviceConnection] = []
+    let provider = DeviceProvider(
+      bluetoothManager: FakeDeviceBluetoothManager(state: .poweredOn),
+      userDefaults: makeDefaults(),
+      notificationCenter: NotificationCenter(),
+      connectionFactory: { device, generation in
+        let created = FakeDeviceConnection(device: device, sessionGeneration: generation)
+        connections.append(created)
+        return created
+      },
+      storageDataChecker: { nil },
+      autoReconnectEnabled: false
+    )
 
     await provider.connect(to: testDevice)
     XCTAssertTrue(provider.isConnected)
+    let firstConnection = connections[0]
 
-    notificationCenter.post(
-      name: .bleDeviceDisconnected,
-      object: nil,
-      userInfo: ["peripheralId": UUID(uuidString: "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE")!]
+    await provider.disconnect()
+    await provider.connect(to: testDevice)
+    XCTAssertTrue(provider.isConnected)
+
+    firstConnection.delegate?.deviceConnection(
+      firstConnection,
+      didDisconnectUnexpectedly: testDevice
     )
-    await drainMainQueue()
 
     XCTAssertTrue(provider.isConnected)
     XCTAssertEqual(provider.connectedDevice, testDevice)
@@ -139,7 +169,14 @@ final class DeviceProviderTests: XCTestCase {
       bluetoothManager: FakeDeviceBluetoothManager(state: .poweredOn),
       userDefaults: defaults,
       notificationCenter: NotificationCenter(),
-      connectionFactory: { FakeDeviceConnection(device: $0, batteryLevel: 25, storageList: [8_000]) },
+      connectionFactory: { device, generation in
+        FakeDeviceConnection(
+          device: device,
+          sessionGeneration: generation,
+          batteryLevel: 25,
+          storageList: [8_000]
+        )
+      },
       storageDataChecker: { nil },
       autoReconnectEnabled: false
     )
@@ -169,7 +206,14 @@ final class DeviceProviderTests: XCTestCase {
       bluetoothManager: FakeDeviceBluetoothManager(state: .poweredOn),
       userDefaults: defaults,
       notificationCenter: notificationCenter,
-      connectionFactory: { FakeDeviceConnection(device: $0, batteryLevel: 25, storageList: [8_000]) },
+      connectionFactory: { device, generation in
+        FakeDeviceConnection(
+          device: device,
+          sessionGeneration: generation,
+          batteryLevel: 25,
+          storageList: [8_000]
+        )
+      },
       storageDataChecker: { (2_000_000, 1_000_000) },
       autoReconnectEnabled: false
     )
@@ -189,7 +233,7 @@ final class DeviceProviderTests: XCTestCase {
     XCTAssertFalse(provider.isFirmwareUpdateInProgress)
   }
 
-  func testStartReconnectionTimerAttemptsPersistedPairingImmediately() async {
+  func testStartReconnectingAttemptsPersistedPairingImmediately() async {
     let defaults = makeDefaults()
     defaults.set(testDevice.id, forKey: "pairedDeviceId")
     defaults.set(testDevice.name, forKey: "pairedDeviceName")
@@ -200,24 +244,24 @@ final class DeviceProviderTests: XCTestCase {
       bluetoothManager: FakeDeviceBluetoothManager(state: .poweredOn),
       userDefaults: defaults,
       notificationCenter: NotificationCenter(),
-      connectionFactory: { device in
+      connectionFactory: { device, generation in
         attemptedDevices.append(device)
-        return FakeDeviceConnection(device: device)
+        return FakeDeviceConnection(device: device, sessionGeneration: generation)
       },
       storageDataChecker: { nil },
       autoReconnectEnabled: true
     )
 
-    provider.startReconnectionTimer()
+    provider.startReconnecting()
     await waitUntil { provider.isConnected }
-    provider.stopReconnectionTimer()
+    provider.stopReconnecting()
 
     XCTAssertEqual(attemptedDevices, [testDevice])
     XCTAssertTrue(provider.isConnected)
     XCTAssertEqual(provider.connectedDevice, testDevice)
   }
 
-  func testStartReconnectionTimerWithoutPairingDoesNotAttemptConnection() async {
+  func testStartReconnectingWithoutPairingDoesNotAttemptConnection() async {
     let defaults = makeDefaults()
     defer { removeDefaults(defaults) }
     var connectionFactoryCallCount = 0
@@ -225,15 +269,15 @@ final class DeviceProviderTests: XCTestCase {
       bluetoothManager: FakeDeviceBluetoothManager(state: .poweredOn),
       userDefaults: defaults,
       notificationCenter: NotificationCenter(),
-      connectionFactory: { device in
+      connectionFactory: { device, generation in
         connectionFactoryCallCount += 1
-        return FakeDeviceConnection(device: device)
+        return FakeDeviceConnection(device: device, sessionGeneration: generation)
       },
       storageDataChecker: { nil },
       autoReconnectEnabled: true
     )
 
-    provider.startReconnectionTimer()
+    provider.startReconnecting()
     await drainMainQueue()
 
     XCTAssertEqual(connectionFactoryCallCount, 0)
@@ -248,8 +292,11 @@ final class DeviceProviderTests: XCTestCase {
       bluetoothManager: FakeDeviceBluetoothManager(state: .poweredOn),
       userDefaults: defaults,
       notificationCenter: NotificationCenter(),
-      connectionFactory: { device in
-        let newConnection = FakeDeviceConnection(device: device)
+      connectionFactory: { device, generation in
+        let newConnection = FakeDeviceConnection(
+          device: device,
+          sessionGeneration: generation
+        )
         connection = newConnection
         return newConnection
       },
@@ -288,7 +335,9 @@ final class DeviceProviderTests: XCTestCase {
       bluetoothManager: bluetooth ?? FakeDeviceBluetoothManager(state: .poweredOn),
       userDefaults: defaults ?? makeDefaults(),
       notificationCenter: notificationCenter,
-      connectionFactory: { FakeDeviceConnection(device: $0) },
+      connectionFactory: { device, generation in
+        FakeDeviceConnection(device: device, sessionGeneration: generation)
+      },
       storageDataChecker: { nil },
       autoReconnectEnabled: autoReconnectEnabled
     )
@@ -334,6 +383,7 @@ private final class FakeDeviceBluetoothManager: DeviceBluetoothManaging {
   private let bluetoothStateSubject: CurrentValueSubject<CBManagerState, Never>
   private let isScanningSubject: CurrentValueSubject<Bool, Never>
   private let discoveredDevicesSubject: CurrentValueSubject<[BtDevice], Never>
+  private let centralEventSubject = PassthroughSubject<BluetoothCentralEvent, Never>()
 
   var prepareForStateUpdatesCallCount = 0
   var startScanningTimeouts: [TimeInterval] = []
@@ -361,6 +411,9 @@ private final class FakeDeviceBluetoothManager: DeviceBluetoothManaging {
   var discoveredDevicesPublisher: AnyPublisher<[BtDevice], Never> {
     discoveredDevicesSubject.eraseToAnyPublisher()
   }
+  var centralEventPublisher: AnyPublisher<BluetoothCentralEvent, Never> {
+    centralEventSubject.eraseToAnyPublisher()
+  }
 
   func prepareForStateUpdates() {
     prepareForStateUpdatesCallCount += 1
@@ -378,33 +431,31 @@ private final class FakeDeviceBluetoothManager: DeviceBluetoothManaging {
 }
 
 private final class FakeDeviceConnection: BaseDeviceConnection {
-  private let connectError: Error?
   private let batteryLevel: Int
   private let storageList: [Int32]
   var unpairCallCount = 0
 
   init(
     device: BtDevice,
+    sessionGeneration: UInt64,
     connectError: Error? = nil,
     batteryLevel: Int = 82,
     storageList: [Int32] = []
   ) {
-    self.connectError = connectError
     self.batteryLevel = batteryLevel
     self.storageList = storageList
-    super.init(device: device, transport: FakeDeviceTransport(deviceId: device.id))
+    super.init(
+      device: device,
+      transport: FakeDeviceTransport(
+        deviceId: device.id,
+        sessionGeneration: sessionGeneration,
+        connectError: connectError
+      )
+    )
   }
 
-  override func connect() async throws {
-    if let connectError {
-      throw connectError
-    }
-    try await super.connect()
-  }
-
-  override func unpair() async {
+  override func performDeviceUnpair() async {
     unpairCallCount += 1
-    await super.unpair()
   }
 
   override func getBatteryLevel() async -> Int {
@@ -424,11 +475,15 @@ private final class FakeDeviceConnection: BaseDeviceConnection {
 
 private final class FakeDeviceTransport: DeviceTransport {
   let deviceId: String
+  let sessionGeneration: UInt64
   private(set) var state: DeviceTransportState = .disconnected
   private let connectionStateSubject = PassthroughSubject<DeviceTransportState, Never>()
+  private let connectError: Error?
 
-  init(deviceId: String) {
+  init(deviceId: String, sessionGeneration: UInt64, connectError: Error?) {
     self.deviceId = deviceId
+    self.sessionGeneration = sessionGeneration
+    self.connectError = connectError
   }
 
   var connectionStatePublisher: AnyPublisher<DeviceTransportState, Never> {
@@ -436,6 +491,7 @@ private final class FakeDeviceTransport: DeviceTransport {
   }
 
   func connect() async throws {
+    if let connectError { throw connectError }
     state = .connected
     connectionStateSubject.send(.connected)
   }

--- a/desktop/macos/Desktop/Tests/DeviceSessionCoordinatorProviderReliabilityTests.swift
+++ b/desktop/macos/Desktop/Tests/DeviceSessionCoordinatorProviderReliabilityTests.swift
@@ -1,0 +1,356 @@
+import Combine
+import CoreBluetooth
+import XCTest
+
+@testable import Omi_Computer
+
+@MainActor
+final class DeviceSessionCoordinatorTests: XCTestCase {
+    func testLateSuccessAfterDisconnectIsSuperseded() async throws {
+        let connection = SessionConnectionDouble(
+            device: bluetoothReliabilityTestDevice,
+            sessionGeneration: 1
+        )
+        connection.suspendConnect = true
+        let coordinator = makeCoordinator(connection: connection)
+
+        let connectTask = Task { try await coordinator.connect(to: bluetoothReliabilityTestDevice) }
+        await waitForBluetoothReliabilityCondition { connection.connectCallCount == 1 }
+
+        await coordinator.disconnect(reconnectAfter: nil)
+        connection.completeConnectSuccessfully()
+
+        await assertSuperseded(connectTask)
+        XCTAssertNil(coordinator.activeConnection)
+        XCTAssertEqual(coordinator.snapshot.phase, .idle)
+        XCTAssertNil(coordinator.snapshot.connectedDevice)
+    }
+
+    func testLateFailureAfterUnpairIsSuperseded() async throws {
+        let connection = SessionConnectionDouble(
+            device: bluetoothReliabilityTestDevice,
+            sessionGeneration: 1
+        )
+        connection.suspendConnect = true
+        let coordinator = makeCoordinator(connection: connection)
+
+        let connectTask = Task { try await coordinator.connect(to: bluetoothReliabilityTestDevice) }
+        await waitForBluetoothReliabilityCondition { connection.connectCallCount == 1 }
+
+        await coordinator.unpair()
+        connection.failConnect(BluetoothReliabilityTestError.expected)
+
+        await assertSuperseded(connectTask)
+        XCTAssertNil(coordinator.activeConnection)
+        XCTAssertNil(coordinator.snapshot.pairedDevice)
+        XCTAssertEqual(coordinator.snapshot.phase, .idle)
+    }
+
+    func testUnexpectedDisconnectTriesCachedPeripheralBeforeDiscovery() async throws {
+        let connection = SessionConnectionDouble(
+            device: bluetoothReliabilityTestDevice,
+            sessionGeneration: 1
+        )
+        let scheduler = ManualDeviceSessionScheduler()
+        let coordinator = DeviceSessionCoordinator(
+            pairedDevice: bluetoothReliabilityTestDevice,
+            connectionFactory: { _, _ in connection },
+            scheduler: scheduler,
+            reconnectDelay: .seconds(15),
+            autoReconnectEnabled: true
+        )
+        var discoveryCount = 0
+        var reconnectRequests: [DeviceReconnectRequest] = []
+        coordinator.onDiscoveryRequested = { discoveryCount += 1 }
+        coordinator.onReconnectRequested = { reconnectRequests.append($0) }
+
+        _ = try await coordinator.connect(to: bluetoothReliabilityTestDevice)
+        coordinator.deviceConnection(
+            connection,
+            didDisconnectUnexpectedly: bluetoothReliabilityTestDevice
+        )
+
+        XCTAssertEqual(coordinator.snapshot.phase, .waitingToReconnect(attempt: 1))
+        XCTAssertEqual(discoveryCount, 0)
+        XCTAssertEqual(scheduler.activeActionCount, 1)
+        scheduler.runNext()
+        XCTAssertEqual(reconnectRequests.map(\.device), [bluetoothReliabilityTestDevice])
+        XCTAssertEqual(discoveryCount, 0)
+    }
+
+    func testUnpairInvalidatesReconnectRequestAfterSchedulerCallback() async throws {
+        let connection = SessionConnectionDouble(
+            device: bluetoothReliabilityTestDevice,
+            sessionGeneration: 1
+        )
+        let scheduler = ManualDeviceSessionScheduler()
+        let coordinator = DeviceSessionCoordinator(
+            pairedDevice: bluetoothReliabilityTestDevice,
+            connectionFactory: { _, _ in connection },
+            scheduler: scheduler,
+            autoReconnectEnabled: true
+        )
+        var capturedRequest: DeviceReconnectRequest?
+        coordinator.onReconnectRequested = { capturedRequest = $0 }
+
+        _ = try await coordinator.connect(to: bluetoothReliabilityTestDevice)
+        coordinator.deviceConnection(
+            connection,
+            didDisconnectUnexpectedly: bluetoothReliabilityTestDevice
+        )
+        scheduler.runNext()
+        let request = try XCTUnwrap(capturedRequest)
+
+        await coordinator.unpair()
+        let reconnect = Task { try await coordinator.reconnect(request) }
+        await assertSuperseded(reconnect)
+        XCTAssertNil(coordinator.snapshot.pairedDevice)
+        XCTAssertEqual(connection.connectCallCount, 1)
+    }
+
+    func testStopReconnectingInvalidatesAlreadyDeliveredRequest() async throws {
+        let connection = SessionConnectionDouble(
+            device: bluetoothReliabilityTestDevice,
+            sessionGeneration: 1
+        )
+        let scheduler = ManualDeviceSessionScheduler()
+        let coordinator = DeviceSessionCoordinator(
+            pairedDevice: bluetoothReliabilityTestDevice,
+            connectionFactory: { _, _ in connection },
+            scheduler: scheduler,
+            autoReconnectEnabled: true
+        )
+        var capturedRequest: DeviceReconnectRequest?
+        coordinator.onReconnectRequested = { capturedRequest = $0 }
+
+        _ = try await coordinator.connect(to: bluetoothReliabilityTestDevice)
+        coordinator.deviceConnection(
+            connection,
+            didDisconnectUnexpectedly: bluetoothReliabilityTestDevice
+        )
+        scheduler.runNext()
+        let request = try XCTUnwrap(capturedRequest)
+
+        coordinator.stopReconnecting()
+        let reconnect = Task { try await coordinator.reconnect(request) }
+        await assertSuperseded(reconnect)
+        XCTAssertEqual(coordinator.snapshot.phase, .idle)
+        XCTAssertEqual(connection.connectCallCount, 1)
+    }
+
+    func testUnavailableReconnectStartsDiscoveryForDelayedRetry() async throws {
+        let scheduler = ManualDeviceSessionScheduler()
+        let coordinator = DeviceSessionCoordinator(
+            pairedDevice: bluetoothReliabilityTestDevice,
+            connectionFactory: { _, _ in nil },
+            scheduler: scheduler,
+            reconnectDelay: .seconds(15),
+            autoReconnectEnabled: true
+        )
+        var discoveryCount = 0
+        var reconnectRequest: DeviceReconnectRequest?
+        coordinator.onDiscoveryRequested = { discoveryCount += 1 }
+        coordinator.onReconnectRequested = { reconnectRequest = $0 }
+
+        coordinator.startReconnecting()
+        scheduler.runNext()
+        let request = try XCTUnwrap(reconnectRequest)
+
+        do {
+            _ = try await coordinator.reconnect(request)
+            XCTFail("Expected an unavailable connection")
+        } catch let error as DeviceSessionCoordinatorError {
+            XCTAssertEqual(error, .connectionUnavailable)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+
+        XCTAssertEqual(discoveryCount, 1)
+        XCTAssertEqual(coordinator.snapshot.phase, .waitingToReconnect(attempt: 2))
+        XCTAssertEqual(scheduler.activeActionCount, 1)
+    }
+
+    func testExplicitDifferentDeviceFailureDoesNotRetryPersistedPairing() async {
+        let selectedDevice = BtDevice(
+            id: "99999999-8888-7777-6666-555555555555",
+            name: "Selected Bee",
+            type: .bee,
+            rssi: -35
+        )
+        let scheduler = ManualDeviceSessionScheduler()
+        var factoryDevices: [BtDevice] = []
+        let coordinator = DeviceSessionCoordinator(
+            pairedDevice: bluetoothReliabilityTestDevice,
+            connectionFactory: { device, _ in
+                factoryDevices.append(device)
+                return nil
+            },
+            scheduler: scheduler,
+            reconnectDelay: .seconds(15),
+            autoReconnectEnabled: true
+        )
+        var discoveryCount = 0
+        coordinator.onDiscoveryRequested = { discoveryCount += 1 }
+
+        do {
+            _ = try await coordinator.connect(to: selectedDevice)
+            XCTFail("Expected selected device to be unavailable")
+        } catch let error as DeviceSessionCoordinatorError {
+            XCTAssertEqual(error, .connectionUnavailable)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+
+        XCTAssertEqual(factoryDevices, [selectedDevice])
+        XCTAssertEqual(coordinator.snapshot.pairedDevice, bluetoothReliabilityTestDevice)
+        XCTAssertEqual(coordinator.snapshot.phase, .idle)
+        XCTAssertEqual(discoveryCount, 0)
+        XCTAssertEqual(scheduler.activeActionCount, 0)
+    }
+
+    func testConnectIsRejectedWhileDisconnectTeardownIsSuspended() async throws {
+        let connection = SessionConnectionDouble(
+            device: bluetoothReliabilityTestDevice,
+            sessionGeneration: 1
+        )
+        let coordinator = makeCoordinator(connection: connection)
+        _ = try await coordinator.connect(to: bluetoothReliabilityTestDevice)
+        connection.suspendDisconnect = true
+
+        let teardown = Task {
+            await coordinator.disconnect(reconnectAfter: nil)
+        }
+        await waitForBluetoothReliabilityCondition { connection.disconnectCallCount == 1 }
+        XCTAssertEqual(coordinator.snapshot.phase, .disconnecting)
+
+        await assertConnectionAlreadyActive {
+            try await coordinator.connect(to: bluetoothReliabilityTestDevice)
+        }
+
+        connection.completeDisconnect()
+        await teardown.value
+        XCTAssertEqual(coordinator.snapshot.phase, .idle)
+        XCTAssertNil(coordinator.activeConnection)
+    }
+
+    func testConnectIsRejectedWhileUnpairTeardownIsSuspended() async throws {
+        let connection = SessionConnectionDouble(
+            device: bluetoothReliabilityTestDevice,
+            sessionGeneration: 1
+        )
+        let coordinator = makeCoordinator(connection: connection)
+        _ = try await coordinator.connect(to: bluetoothReliabilityTestDevice)
+        connection.suspendUnpair = true
+
+        let teardown = Task {
+            await coordinator.unpair()
+        }
+        await waitForBluetoothReliabilityCondition { connection.unpairCallCount == 1 }
+        XCTAssertEqual(coordinator.snapshot.phase, .disconnecting)
+
+        await assertConnectionAlreadyActive {
+            try await coordinator.connect(to: bluetoothReliabilityTestDevice)
+        }
+
+        connection.completeUnpair()
+        await teardown.value
+        XCTAssertEqual(coordinator.snapshot.phase, .idle)
+        XCTAssertNil(coordinator.activeConnection)
+        XCTAssertNil(coordinator.snapshot.pairedDevice)
+    }
+
+    private func makeCoordinator(
+        connection: SessionConnectionDouble
+    ) -> DeviceSessionCoordinator {
+        DeviceSessionCoordinator(
+            pairedDevice: bluetoothReliabilityTestDevice,
+            connectionFactory: { _, generation in
+                XCTAssertEqual(generation, connection.sessionGeneration)
+                return connection
+            },
+            scheduler: NoopDeviceSessionScheduler(),
+            autoReconnectEnabled: false
+        )
+    }
+
+    private func assertSuperseded(
+        _ task: Task<DeviceConnection, Error>,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async {
+        do {
+            _ = try await task.value
+            XCTFail("Expected superseded session", file: file, line: line)
+        } catch let error as DeviceSessionCoordinatorError {
+            XCTAssertEqual(error, .superseded, file: file, line: line)
+        } catch {
+            XCTFail("Unexpected error: \(error)", file: file, line: line)
+        }
+    }
+
+    private func assertConnectionAlreadyActive(
+        _ operation: @escaping @MainActor () async throws -> DeviceConnection,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async {
+        do {
+            _ = try await operation()
+            XCTFail("Expected active-session rejection", file: file, line: line)
+        } catch let error as DeviceSessionCoordinatorError {
+            XCTAssertEqual(error, .connectionAlreadyActive, file: file, line: line)
+        } catch {
+            XCTFail("Unexpected error: \(error)", file: file, line: line)
+        }
+    }
+}
+
+@MainActor
+final class DeviceProviderGenerationTests: XCTestCase {
+    func testLateBatteryResultFromOldGenerationCannotOverwriteReplacement() async {
+        let suiteName = "DeviceProviderGenerationTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        var connections: [SessionConnectionDouble] = []
+        let provider = DeviceProvider(
+            bluetoothManager: ReliabilityBluetoothManager(),
+            userDefaults: defaults,
+            notificationCenter: NotificationCenter(),
+            connectionFactory: { device, generation in
+                let connection = SessionConnectionDouble(
+                    device: device,
+                    sessionGeneration: generation
+                )
+                if connections.isEmpty {
+                    connection.suspendBattery = true
+                } else {
+                    connection.batteryLevel = 77
+                }
+                connections.append(connection)
+                return connection
+            },
+            storageDataChecker: { nil },
+            autoReconnectEnabled: false
+        )
+
+        let firstConnect = Task { await provider.connect(to: bluetoothReliabilityTestDevice) }
+        await waitForBluetoothReliabilityCondition {
+            provider.isConnected
+                && connections.first?.batteryCallCount == 1
+        }
+
+        await provider.disconnect()
+        await provider.connect(to: bluetoothReliabilityTestDevice)
+        XCTAssertEqual(provider.batteryLevel, 77)
+
+        connections[0].completeBattery(level: 4)
+        await firstConnect.value
+        XCTAssertEqual(provider.batteryLevel, 77)
+        XCTAssertEqual(provider.activeConnection?.sessionGeneration, 3)
+        XCTAssertEqual(connections[0].batteryStreamCallCount, 0)
+
+        connections[1].emitBattery(level: 88)
+        await waitForBluetoothReliabilityCondition { provider.batteryLevel == 88 }
+        connections[1].finishBatteryStream()
+    }
+}

--- a/desktop/macos/changelog/unreleased/20260712-bluetooth-session-reliability.json
+++ b/desktop/macos/changelog/unreleased/20260712-bluetooth-session-reliability.json
@@ -1,0 +1,3 @@
+{
+  "change": "Improved Bluetooth connection and reconnection reliability across supported devices"
+}

--- a/desktop/macos/e2e/flows/audio-recording.yaml
+++ b/desktop/macos/e2e/flows/audio-recording.yaml
@@ -1,7 +1,7 @@
 version: 2
 name: audio-recording
 tier: manual
-description: Audio recording flow — verify microphone permission, Start Recording button, transcription state, and stop recording
+description: Audio recording flow — verify Bluetooth or microphone source state, Start Recording, transcription state, and stop recording
 app: com.omi.computer-macos
 covers:
   - desktop/Desktop/Sources/MainWindow/Pages/ConversationsPage.swift
@@ -10,10 +10,25 @@ covers:
   - desktop/Desktop/Sources/AppState.swift
   - desktop/macos/Desktop/Sources/FloatingControlBar/FloatingBarUsageLimiter.swift
   - desktop/macos/Desktop/Sources/Bluetooth/Transports/BleTransport.swift
+  - desktop/macos/Desktop/Sources/Bluetooth/Transports/BLEPhysicalDriver.swift
+  - desktop/macos/Desktop/Sources/Bluetooth/Transports/DeviceTransport.swift
+  - desktop/macos/Desktop/Sources/Bluetooth/BluetoothManager.swift
+  - desktop/macos/Desktop/Sources/Bluetooth/Session/BluetoothConnectionLease.swift
+  - desktop/macos/Desktop/Sources/Bluetooth/Session/DeviceAudioStreamController.swift
+  - desktop/macos/Desktop/Sources/Bluetooth/Session/DeviceCommandQueue.swift
+  - desktop/macos/Desktop/Sources/Bluetooth/Session/DeviceOperationBroker.swift
+  - desktop/macos/Desktop/Sources/Bluetooth/Session/DeviceSessionCoordinator.swift
+  - desktop/macos/Desktop/Sources/Bluetooth/Connections/DeviceConnection.swift
+  - desktop/macos/Desktop/Sources/Bluetooth/Connections/DeviceConnectionFactory.swift
   - desktop/macos/Desktop/Sources/Audio/AudioCodecDecoder.swift
   - desktop/macos/Desktop/Sources/Bluetooth/Connections/BeeDeviceConnection.swift
+  - desktop/macos/Desktop/Sources/Bluetooth/Connections/FieldyDeviceConnection.swift
+  - desktop/macos/Desktop/Sources/Bluetooth/Connections/FrameDeviceConnection.swift
+  - desktop/macos/Desktop/Sources/Bluetooth/Connections/FriendPendantConnection.swift
+  - desktop/macos/Desktop/Sources/Bluetooth/Connections/OmiDeviceConnection.swift
   - desktop/macos/Desktop/Sources/Bluetooth/Connections/PlaudDeviceConnection.swift
   - desktop/macos/Desktop/Sources/Bluetooth/Connections/LimitlessDeviceConnection.swift
+  - desktop/macos/Desktop/Sources/Providers/DeviceProvider.swift
   - desktop/macos/Desktop/Sources/SystemAudioCaptureService.swift
 preconditions:
   - auth_ready
@@ -30,6 +45,12 @@ steps:
   - id: S2
     name: Verify Start Recording button
     do: "Check that the 'Start Recording' button with microphone icon is visible on the Dashboard. Note its position and state. If the app is already recording, a 'Stop Recording' button should be visible instead."
+    expect:
+      interactive_count: { min: 1 }
+
+  - id: S2B
+    name: Verify Bluetooth audio source state
+    do: "If an Omi-compatible Bluetooth device is paired, verify its connected state is reflected before recording and that it remains the selected device audio source. If no device is available, verify the app stays usable with the microphone source and does not show a stale connected-device state."
     expect:
       interactive_count: { min: 1 }
 

--- a/desktop/macos/scripts/check-userdefaults-key-ratchet.py
+++ b/desktop/macos/scripts/check-userdefaults-key-ratchet.py
@@ -41,7 +41,7 @@ from pathlib import Path
 # in the scanned sources. MAY ONLY DECREASE. Raising it is a regression and must
 # not be done to make the gate pass; migrate the call site to `DefaultsKey`
 # instead.
-BASELINE = 180
+BASELINE = 178
 
 # Sources root, relative to the repo root.
 SOURCES_ROOT = "desktop/macos/Desktop/Sources"


### PR DESCRIPTION
## Summary

- replace duplicated Bluetooth booleans, reconnect timers, notification broadcasts, and device-specific teardown with one generation-fenced session coordinator and one shared connection lifecycle
- put CoreBluetooth connection identity, callback/timeout/cancellation races, command serialization, and multicast audio behind explicit lease, broker, queue, and stream owners
- make Bee and PLAUD recording sessions fail closed across setup, stop, restart, and partial-frame boundaries
- add injectable physical-driver, clock, scheduler, transport, and connection seams plus behavioral concurrency regressions

## Root cause and durable guard

Bluetooth lifecycle state was spread across `BluetoothManager`, `BleTransport`, `DeviceProvider`, and every device adapter. Raw continuations were keyed only by characteristics or command IDs, reconnect policy inferred intent from persisted UI state, and audio streams coupled one consumer to one physical session without a canonical owner. Recent fixes in the same subsystem repeatedly addressed individual lock, continuation, and teardown symptoms, but no shared boundary prevented the class from recurring.

This change assigns one owner to each contract: manager connection leases preserve CoreBluetooth callback identity; tokenized operation brokers arbitrate callbacks, timeouts, cancellation, and teardown while physical starts drain; command queues serialize request/response lifetimes; one session coordinator owns phase, pairing, reconnect intent, and generation fencing; and multicast audio controllers own setup through fail-closed stop. `ARCHITECTURE.md` records those boundaries, and production-path tests force late callbacks, held writes, cancellation-unaware timeouts, concurrent teardown, stale reconnect requests, setup/stop races, and session restart contamination.

## Behavior and risk

- supported device adapters retain their existing wire commands and codec behavior while sharing lifecycle ownership
- a user-selected device failure no longer silently reconnects a different persisted device
- ambiguous uncorrelated command or stop state retires the physical session instead of layering a retry over unknown device state
- notification audio is delivered only while its recording generation is active; setup, stopping, and prior-session frames are dropped
- no backend API, persisted schema, provisioning, or release pipeline contract changes are involved
- no physical Bluetooth device was available locally; real CoreBluetooth ordering is exercised through the production transport and injected physical driver

## Verification

- focused Bluetooth/session/provider reliability suite — 55 passed after the final rebase
- `desktop/macos/scripts/swift-test-suites.sh` — 249 isolated Swift suites passed
- `desktop/macos/test.sh` — launcher contracts, strict e2e coverage, 328 Rust tests, and 249 Swift suites passed
- clean debug build from an empty `.build` — passed in 100.64s
- clean arm64 release build from a second empty `.build` — passed in 286.39s
- desktop test-quality, strict e2e coverage, and `git diff --check` — passed
- named `omi-bluetooth-quality` bundle built and installed through `run.sh --yolo`, launched on isolated automation port 47915, reported bundle ID `com.omi.omi-bluetooth-quality`, and navigated from Home to Settings through the in-process bridge (the scoped local ad-hoc Library Validation entitlement from #9546 was applied because that separate tooling PR is not on this branch)
- `make preflight` — all 13 selected checks passed after rebase
- independent agent review approved after the final broker, reconnect-intent, and audio-session race fixes

## Product invariants

None affected (`scripts/pr-preflight --suggest`).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9550?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

