### PR TITLE
docs(app): rebuild e2e screen map from source and add iOS device testing playbook

### DIFF
--- a/app/e2e/IOS_DEVICE_TESTING.md
+++ b/app/e2e/IOS_DEVICE_TESTING.md
@@ -1,0 +1,104 @@
+# Testing the Omi App on a Physical iPhone (Agent Playbook)
+
+How an AI agent builds, drives, and verifies the Flutter app end-to-end on a real iPhone — no screenshots required, no human at the keyboard except for auth. Written from a real session (2026-07-11, iPhone XR, iOS 18.7.9, app 1.0.543) that smoke-tested PR #9484 on production backend with a signed-in account.
+
+Quick-reference version: [`SKILL.md`](./SKILL.md) → "Setup (iOS physical device)". This file is the full setup + playbook + troubleshooting.
+
+---
+
+## 1. One-time host setup
+
+```bash
+# agent-flutter CLI (widget-tree driving over Flutter's Marionette debug protocol)
+npm install -g agent-flutter-cli          # provides `agent-flutter`
+
+# marionette MCP server (needed ONLY for enter_text-by-key and rich widget dumps;
+# already registered in the repo's .mcp.json → just install the binary)
+dart pub global activate marionette_mcp   # installs ~/.pub-cache/bin/marionette_mcp
+```
+
+The repo's `.mcp.json` already maps `marionette` to `~/.pub-cache/bin/marionette_mcp`, so Claude Code agents in this repo get the MCP tools (`mcp__marionette__*`) automatically once the binary exists.
+
+Device prerequisites (human, once): iPhone in Developer Mode, cable to the Mac, host trusted, and **screen unlocked for the whole session** (see §7 — iOS kills the debug link when the app backgrounds too long).
+
+## 2. Per-worktree app setup
+
+The app builds fine from any git worktree, but `app/test.sh`'s bootstrap seeds **dev-placeholder** Firebase/env files that point at the wrong project for prod flavor. Before a `--flavor prod` build in a fresh worktree, copy the real config from the primary checkout:
+
+```bash
+M=<primary-checkout>/app; W=<worktree>/app
+cp $M/.env $W/.env
+cp $M/lib/firebase_options_prod.dart $W/lib/firebase_options_prod.dart
+cp $M/ios/Config/Prod/GoogleService-Info.plist $W/ios/Config/Prod/GoogleService-Info.plist
+cp $M/lib/env/prod_env.g.dart $W/lib/env/prod_env.g.dart   # or rerun build_runner after copying .env
+```
+
+**Which flavor:** prefer `prod` on a physical device. The dev flavor's bundle id may have no usable provisioning profile in a fresh worktree — it fails with `Provisioning profile "iOS Team Provisioning Profile: *" doesn't support the App Groups capability`. Prod uses the routinely-provisioned profile. Note: a prod build **replaces the App Store app** on the phone (same bundle id; data/keychain survive, but reinstall from the App Store afterwards if the user wants the signed release back).
+
+## 3. Launch
+
+```bash
+flutter devices                                # get the device id (cable connected, phone unlocked)
+cd app && flutter run -d <device-id> --flavor prod \
+  > /tmp/omi-flutter.log 2>&1 &                # ALWAYS capture stdout — it is the auth token for agent-flutter AND your verification log
+# wait for: "A Dart VM Service on <device> is available at: http://127.0.0.1:<port>/<token>/"
+```
+
+First build in a worktree ≈ 10 min (pods + Xcode). Incremental relaunches are fast.
+
+**Auth:** if the app boots to onboarding, an agent can drive consent/permission screens, but Sign in with Apple/Google needs the human once (Face ID / device biometrics). Ask, then take over — everything after sign-in is agent-drivable.
+
+## 4. Connect and drive
+
+```bash
+export AGENT_FLUTTER_LOG=/tmp/omi-flutter.log
+agent-flutter connect                          # auto-detects ws URI from the log
+```
+
+Primary command palette (all verified on iOS):
+
+| Goal | Command |
+|---|---|
+| What's on screen (orientation + assertions) | `agent-flutter text` — semantic text dump; **your main tool** |
+| Element inventory with bounds | `agent-flutter snapshot -i` (labels are EMPTY on marionette_flutter 0.3.0 — identify by `flutterType` + bounds geometry) |
+| Tap by visible text | `agent-flutter find text "Save Memory" press` |
+| Tap by ref | `agent-flutter press @e5` (re-snapshot in the SAME shell step — refs go stale between calls) |
+| Rich widget properties (controller text, enabled state, keys) | MCP `mcp__marionette__get_interactive_elements` |
+| Text entry that actually works | MCP `mcp__marionette__enter_text` with a `ValueKey` (see §6) |
+| Screenshot (last resort / human evidence) | `agent-flutter screenshot /tmp/x.png` — path **must** be under `/tmp` |
+
+Navigation facts and the current screen map live in [`SKILL.md`](./SKILL.md) — notably: chat opens from the **"Ask Omi anything…" input bar on home**, not a nav tab; back is the **in-app top-left IconButton** (`agent-flutter back` is adb/Android-only).
+
+## 5. Verify like an agent (no screenshots)
+
+Three assertion channels, use all of them:
+
+1. **Text presence** — after an action, `agent-flutter text` and check the expected string appeared. e.g. pressing an AI message's copy button must surface `"✨ Message copied to clipboard"`; saving a memory must make its text appear in the list dump. This is stronger than a screenshot: nothing has to eyeball it.
+2. **The run log** — `grep -iE 'exception|error' /tmp/omi-flutter.log` after every flow, and read the tail to confirm the action actually fired (an API call you expected, or its absence proving a tap missed). Known-benign: `PlatformException(4001 …)` from Intercom when notifications aren't granted.
+3. **Widget properties** — MCP `get_interactive_elements` shows `TextEditingController` contents, button `enabled` state, and `Key:` values. This is how you prove a fill really landed (the CLI can claim success while the field stays empty — §6).
+
+## 6. The escalation ladder (when a target won't respond)
+
+Verified order of attack; stop at the first rung that works:
+
+1. `find text "…" press` — works for real text-bearing widgets; silently hits inert labels sometimes (verify via log/text-dump that something happened).
+2. `snapshot -i` → identify by `flutterType` + bounds → `press @ref` in the same step. Geometry knowledge helps: bottom-nav slots at y≈816 / x=20·114·207·300; "Ask Omi" bar y≈756 full-width; per-message action InkWells w≈12–14 at x≈22/54/88/122.
+3. **Do NOT bother on iOS**: `press x y` (adb), `back` (adb), `dismiss` (adb), `text --press/--fill` (UIAutomator). They fail with device/adb errors.
+4. **ValueKey + hot reload** — the durable fix when a field/button can't be targeted (e.g. keyless `TextField`s where `fill @ref` reports success but the controller stays empty):
+   - Add `key: const ValueKey('descriptive_name')` to the widget in source.
+   - `mcp__marionette__hot_reload` (ignore a spurious "may need full restart" message if the key then shows up; **open-sheet state survives hot reload**).
+   - `mcp__marionette__enter_text {key: descriptive_name, input: …}` / `tap {key: …}`.
+   - **Keep the keys** — commit them (`chore(app): add automation keys to …`). AGENTS.md endorses keys on interactive widgets; they're how the next agent avoids this ladder entirely. Existing precedent: `memory_content_field` / `memory_save_button` (PR #9484), 10 more in PR #9543.
+
+## 7. Session hygiene & gotchas
+
+- **Keep the phone unlocked.** iOS terminates the debug link after prolonged backgrounding: `"The OS has terminated the Flutter debug connection for being inactive"` — the app keeps running but you must relaunch `flutter run` to reattach. This is a session-ender if you're mid-flow; check the phone before long code-reading pauses.
+- **Test data**: create-then-delete your own artifacts (e.g. a memory literally named "smoke-test — safe to delete"); never exercise destructive flows on the user's real data. If a leftover survives (session died first), tell the user exactly what to remove.
+- **Build side effects**: `flutter run` dirties `app/ios/Flutter/AppFrameworkInfo.plist` and sometimes `app/pubspec.lock` — `git checkout --` them before committing anything.
+- **After the session**: the phone carries your branch build. Tell the user; App Store reinstall restores the release binary (data survives).
+
+## 8. Known limitations
+
+- No biometric/OS-dialog control: Sign in with Apple, system permission prompts mid-flow, and Safari OAuth sheets need the human (agent-flutter sees only the Flutter tree).
+- Semantic `text` dump is partial — some visual text (image-heavy cards, custom painters) never appears; corroborate with widget-tree types/bounds.
+- One session at a time per device; `flutter run` owns the VM Service.

--- a/app/e2e/SKILL.md
+++ b/app/e2e/SKILL.md
@@ -41,6 +41,8 @@ agent-flutter snapshot -i --json    # see what's on screen
 
 ### Setup (iOS physical device)
 
+Full iOS physical-device playbook (setup, driving, verification, troubleshooting): [`IOS_DEVICE_TESTING.md`](./IOS_DEVICE_TESTING.md).
+
 Verified 2026-07-11 on an iPhone XR (iOS 18.7.9), app 1.0.543, prod-flavor debug build, agent-flutter CLI + marionette MCP. iOS Simulator has no BLE — use a physical device for anything beyond onboarding/UI checks (see also iOS Simulator Known Limitations below).
 
 ```bash
@@ -107,99 +109,115 @@ sleep 3 && agent-flutter disconnect && agent-flutter connect
 
 ### Screen Map
 ```
-Onboarding (wrapper.dart) — 11-step wizard
+Onboarding (wrapper.dart) — step wizard
 ├── 0: Auth (auth.dart) — Google/Apple sign-in
-├── 1: Name (name_widget.dart)
-├── 2: Primary Language (primary_language_widget.dart)
-├── 3: Found Omi (found_omi_widget.dart)
-├── 4: Permissions (permissions_widget.dart)
-├── 5: User Review (user_review_page.dart)
-├── 6-7: Welcome / Find Devices (placeholders)
-├── 8: Speech Profile (speech_profile_widget.dart)
-├── 9: Knowledge Graph (knowledge_graph_step.dart)
-└── 10: Complete (complete_screen.dart)
+├── 1: AI Consent
+├── 2: Name (name_widget.dart)
+├── 3: Primary Language (primary_language_widget.dart)
+├── 4: Found Omi (found_omi_widget.dart)
+├── 5: Permissions (permissions_widget.dart)
+├── 6: User Review (user_review_page.dart)
+├── 9: Speech Profile (speech_profile_widget.dart)
+├── 10: Knowledge Graph (knowledge_graph_step.dart)
+└── 11: Complete (complete_screen.dart) → Home
 
-Home (page.dart) — main app after auth
-├── [top bar] Connect Device | Search | History | Settings icon
-├── [center] Daily Score card → Add Goal
-├── ["Ask Omi anything…" input bar] → Chat (chat/page.dart) — full-width bar above bottom nav, not a button/tab
-│   └── Message history, "Ask anything" field, AI responses, message actions
-├── [record button] → Conversation Capturing (conversation_capturing/page.dart)
-│   └── Live transcript, waveform, stop button
+Home (home/page.dart) — main app after auth, 4-slot bottom nav
+├── ["Ask Omi anything…" input bar] → Chat (chat/page.dart) — full-width bar above bottom nav, not a tab
+│   ├── Message history, "Ask anything" field, AI responses
+│   └── AI-message action row: Copy ("✨ Message copied to clipboard" snackbar), thumbs up, thumbs down, Share
+├── [mic in the bar] → Chat with voice auto-start
+├── [battery/record widget, top left] (battery_info_widget.dart)
+│   ├── Device connected → battery pill → Connected Device (home/device.dart); phone icon → Phone Calls
+│   └── No device → Connect → Connect Device page; Record pill → Conversation Capturing (conversation_capturing/page.dart)
+│       └── Chevron → record options sheet (Phone Mic record / Phone Call)
+├── [settings gear, top right] → Settings sheet (settings_drawer.dart) — present on every slot
 │
-├── [tab 0] Conversations (conversations_page.dart) — bottom-nav slot 1
+├── [slot 0] Home (home/home_content.dart)
+│   ├── Conversation capture widget, today's tasks widget
+│   ├── Daily Recaps → Daily Summary Detail; "View All" → Conversations
+│   ├── Mind Map → Memory Graph (memory_graph_page.dart) (only with ≥3 conversations)
+│   └── Get-started tiles (only with <3 conversations)
+│
+├── [slot 1] Conversations (conversations_page.dart)
 │   ├── Folder tabs (All, Starred, custom folders)
-│   ├── Daily summaries toggle
-│   ├── Today's tasks widget
+│   ├── Top-bar extras on this slot: sync icon (when paired/pending), search, calendar date filter
 │   └── Conversation item (GestureDetector row) → Detail (conversation_detail/page.dart)
-│       ├── Transcript, Summary, Action Items tabs, share, audio
+│       ├── Transcript, Summary, Action Items tabs, share, audio (search hidden on Action Items tab)
+│       ├── Pull-down menu: Copy Transcript / Copy Summary / Copy ID / Share Audio (if audio) / Link Event / Test Prompt
 │       └── Back via in-app top-left IconButton — not the OS/adb back gesture
 │
-├── [tab 1] Action Items (action_items_page.dart) — bottom-nav slot 2
+├── [slot 2] Tasks (action_items_page.dart)
 │   ├── Categories: Today, Tomorrow, Later, No Deadline, Overdue
 │   ├── FAB → Create task sheet (action_item_form_sheet.dart)
-│   ├── Task checkboxes, drag-drop reorder
-│   └── Task → Goal linking
+│   ├── Task checkboxes, drag-drop reorder, task → goal linking
+│   └── Top-bar extras on this slot: export → Task Integrations, completed toggle
 │
-├── [tab 2] Memories (memories/page.dart) — bottom-nav slot 3, also reachable via Settings → Memories
-│   ├── Search bar, graph button, management button
+└── [slot 3] Apps (apps/page.dart) — "Search 1500+ Apps" / "Featured" (explore_install_page.dart)
+    ├── Popular apps (horizontal scroll)
+    ├── Category sections → Category apps page
+    ├── App item → App Detail (app_detail/app_detail.dart)
+    │   └── Reviews, capabilities, install/enable, Chat button → Chat
+    └── Top-bar "+" on this slot → Add App / Add MCP Server
+
+Settings sheet (settings_drawer.dart) — rows in order
+├── Profile (profile.dart)
+│   ├── Name → Change name dialog
+│   ├── Email (read-only)
+│   ├── Language → Language Settings (language_settings_page.dart)
+│   ├── Custom Vocabulary (custom_vocabulary_page.dart)
+│   ├── Speech Profile (speech_profile/page.dart)
+│   ├── Identifying Others (people.dart)
+│   ├── Payment Methods (payments/payments_page.dart)
+│   ├── Conversation Display (conversation_display_settings.dart)
+│   ├── Data Privacy (data_privacy_page.dart)
+│   └── Delete Account (delete_account.dart)
+├── Notifications (notifications_settings_page.dart)
+│   ├── Frequency slider (0-5)
+│   ├── Daily Summary toggle + time picker
+│   └── Daily Reflection toggle
+├── Plan & Usage (usage_page.dart) (only in some subscription states)
+├── Offline Sync (sync_page.dart)
+│   ├── Local storage, recordings list
+│   ├── Fast transfer settings
+│   └── Private cloud sync
+├── Device Settings (device_settings.dart) (only when a device is connected)
+│   ├── Device info (name, ID, firmware, SD card)
+│   ├── LED brightness slider, mic gain slider
+│   └── Double tap action picker
+├── Integrations (integrations_page.dart) — BETA; also opens from conversation detail
+│   └── Google Calendar, Gmail, Apple Health
+├── Permissions (permissions_page.dart) — Microphone, Bluetooth, Location, Background Activity
+├── Memories (memories/page.dart) — not a bottom-nav tab; reached here or via /memories, /facts deep links
+│   ├── Search bar, "This device" filter chip
 │   ├── FAB (bottom-right) → New Memory sheet (memory_dialog.dart) — the "Create new memory" text row
 │   │   is NOT tappable, only the FAB is; field/button ValueKeys `memory_content_field` / `memory_save_button` (PR #9484)
-│   ├── Category chips filter
 │   ├── Memory item → Quick edit sheet (memory_edit_sheet.dart)
 │   ├── Graph → Memory Graph (memory_graph_page.dart)
 │   └── Management → Category management sheet
-│
-├── [tab 3] Apps (apps/page.dart) — bottom-nav slot 4 ("Search 1500+ Apps" / "Featured")
-│   ├── Search, filter, create buttons
-│   ├── Popular apps (horizontal scroll)
-│   ├── Category sections → Category apps page
-│   ├── App item → App Detail (app_detail/app_detail.dart)
-│   │   └── Reviews, capabilities, install/enable
-│   └── Create → Custom app or MCP server
-│
-└── [settings icon] → Settings sheet (settings_drawer.dart)
-    ├── Profile (profile.dart)
-    │   ├── Name → Change name dialog
-    │   ├── Email (read-only)
-    │   ├── Language → Language Settings (language_settings_page.dart)
-    │   ├── Custom Vocabulary (custom_vocabulary_page.dart)
-    │   ├── Speech Profile (speech_profile/page.dart)
-    │   ├── Identifying Others (people.dart)
-    │   ├── Payment Methods (payments/payments_page.dart)
-    │   ├── Conversation Display (conversation_display_settings.dart)
-    │   ├── Data Privacy (data_privacy_page.dart)
-    │   └── Delete Account (delete_account.dart)
-    ├── Notifications (notifications_settings_page.dart)
-    │   ├── Frequency slider (0-5)
-    │   ├── Daily Summary toggle + time picker
-    │   └── Daily Reflection toggle
-    ├── Plan & Usage (usage_page.dart)
-    ├── Offline Sync (sync_page.dart)
-    │   ├── Local storage, recordings list
-    │   ├── Fast transfer settings
-    │   └── Private cloud sync
-    ├── Device Settings (device_settings.dart) — requires BLE device
-    │   ├── Device info (name, ID, firmware, SD card)
-    │   ├── LED brightness slider, mic gain slider
-    │   └── Double tap action picker
-    ├── Integrations (integrations_page.dart) — BETA
-    │   └── Google Calendar, Gmail, Apple Health
-    ├── Permissions (permissions_page.dart) — Microphone, Bluetooth, Location, Background Activity
-    ├── Memories → jumps to Memories tab (bottom-nav slot 3)
-    ├── Phone Calls (phone_call_settings_page.dart)
-    │   └── Verified numbers list, delete button
-    ├── Transcription Settings (transcription_settings_page.dart)
-    │   ├── Source toggle: Omi Cloud vs Custom STT
-    │   ├── Provider selector, API key, model config
-    │   └── Advanced JSON editors, logs viewer
-    ├── Developer Settings (developer.dart)
-    │   ├── Custom STT provider config
-    │   ├── API key management
-    │   └── MCP API keys
-    ├── What's New → Changelog sheet
-    ├── Referral Program (referral_page.dart) — NEW
-    └── Sign Out → Confirmation dialog
+├── Feedback/Bug → feedback.omi.me (Intercom platforms only)
+├── Help Center → help.omi.me (Intercom platforms only)
+├── Developer Settings (developer.dart)
+│   ├── Custom STT provider config
+│   ├── API key management
+│   └── MCP API keys
+├── What's New → Changelog sheet
+├── Get Omi for Mac → App Store link
+├── Referral Program (referral_page.dart) — NEW
+└── Sign Out → Confirmation dialog
+(Settings search reaches a few extra destinations not in the visible list, e.g. Background Mode on Android.)
+
+Transcription Settings (transcription_settings_page.dart) — not in settings drawer; reached from
+Plan & Usage, Developer Settings, or the Plans sheet
+├── Source toggle: Omi Cloud vs Custom STT
+├── Provider selector, API key, model config
+└── Advanced JSON editors, logs viewer
+
+Phone Calls (phone_calls_page.dart) — from battery-widget phone icon, record options, or get-started tile
+├── Phone Setup Intro when no verified numbers
+├── Contacts / Keypad tabs; call → Active Call page
+└── Gear → Phone Call Settings (phone_call_settings_page.dart) — verified numbers list, delete button
+
+Plans sheet (plans_sheet.dart) — from Plan & Usage, chat quota-exceeded, phone-calls upsell
 
 Persona Profile (persona_profile.dart) — AI clone management
 ├── Avatar (100x100), name with verified badge
@@ -227,7 +245,8 @@ Speech Profile (speech_profile/page.dart)
 - Detect with: `snapshot -i --json` → filter `flutterType == 'InkWell'` and `bounds.y > 780`
 - Navigate home: press the leftmost one
 - iOS (verified 2026-07-11, iPhone XR, 414pt-wide screen): 4 slots at y≈816, x=20/114/207/300, each w=94.
-  Slot 1 = Conversations/home (folder tabs All/Starred/…), slot 4 = Apps marketplace ("Search 1500+ Apps" / "Featured")
+  Left to right: slot 0 = Home, slot 1 = Conversations (folder tabs All/Starred/…), slot 2 = Tasks,
+  slot 3 = Apps marketplace ("Search 1500+ Apps" / "Featured")
 
 **Chat entry point (not a bottom-nav tab):**
 - Open chat by tapping the "Ask Omi anything…" input bar on the home screen — a full-width gesture
@@ -355,6 +374,8 @@ Supported `expect` kinds:
 ## Navigation Graph (flow-walker verified)
 
 Real navigation edges verified by flow-walker run11 on Pixel 7a (26 screens, 44 edges, depth 3). Screen names mapped from fingerprint IDs to semantic names.
+
+Note: run11 predates the current bottom nav — its tab labels below reflect the old layout (Conversations/Action Items/Memories/Apps as tabs). Today slot 0 is Home, Tasks is slot 2, Apps is slot 3, and Memories lives under Settings — see Screen Map above. The per-screen element counts and edges remain useful.
 
 ```
 Home (24 elements: 17 gesture, 3 icon, 4 inkwell)


### PR DESCRIPTION
## What

Two docs-only commits for the app e2e agent guide:

1. **`app/e2e/IOS_DEVICE_TESTING.md` (new)** — full playbook for driving the app end-to-end on a physical iPhone: one-time host setup (agent-flutter CLI + marionette MCP binary; the repo `.mcp.json` already registers the server), per-worktree prod-config seeding, launch/connect sequence, the screenshot-free verification channels (semantic text dump, run-log grep, widget-property reads), the target-escalation ladder ending in ValueKey + hot reload, and session hygiene (iOS background debug-connection kill, test-data cleanup, build-artifact reverts). Distilled from the live device session that verified #9484.
2. **`app/e2e/SKILL.md` Screen Map rebuild** — the map had drifted badly from the shipped app. Rebuilt from a full source walk of the current navigation, in the file's existing format:
   - Bottom nav corrected: slot 0 **Home**, slot 1 Conversations, slot 2 Tasks, slot 3 Apps (was: Conversations/Action Items/Memories/Apps).
   - **Memories is not a nav tab** — documented under the Settings sheet with its `/memories`, `/facts` deep links.
   - Chat entry documented as the "Ask Omi anything…" bar (plus mic voice auto-start), with the AI-message action-row order.
   - Settings sheet rows rewritten in actual build order, gates in plain words (Plan & Usage subscription-gated, Device Settings only when a device is connected, Feedback/Help Intercom platforms only).
   - Pages with non-obvious entry points folded in: Transcription Settings (reached from Plan & Usage / Developer Settings / Plans sheet — not the settings drawer), Phone Call Settings (only from Phone Calls gear), Plans sheet (usage page, chat quota, upsells).
   - Current onboarding sequence (Auth → AI Consent → Name → Language → Found Omi → Permissions → User Review → Speech Profile → Knowledge Graph → Complete).
   - Per-slot conditional top-bar controls noted on their slots; stale claims elsewhere in the file fixed (widget-pattern nav slots); the historical flow-walker run11 section kept as data with a one-line note that it predates the current nav.

## Why

Agents navigating the app from SKILL.md were being steered wrong — in a live device session the documented chat entry point didn't exist and the tab layout didn't match, costing real time (the user had to intervene). Per AGENTS.md, guidance that caused a misread gets tightened in the fix.

## Verification

Docs-only. Map derived from a cited source walk of current `origin/main` (root shell → bottom_nav_bar.dart → per-slot pages → settings_drawer.dart rows in build order), cross-checked against the live iPhone XR session of 2026-07-11 (chat bar, action-row order, settings rows, Apps tab). Playbook file diff-verified byte-identical to the session-derived original. Full file re-read: fences balanced, no surviving old-map claims (grepped tab/slot/Memories-nav references). `git diff --stat`: exactly the two files.

## Product invariants affected

none (`scripts/pr-preflight --suggest`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9551?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

