### PR TITLE
fix(dev): clamp get_goals limit so ?limit=-1 cannot 500

### DIFF
--- a/backend/routers/developer.py
+++ b/backend/routers/developer.py
@@ -2080,6 +2080,9 @@ def get_goals(
     - **limit**: Maximum number of goals to return
     - **include_inactive**: If True, includes inactive/completed goals
     """
+    # Clamp pagination so a negative value cannot reach Firestore (which raises -> HTTP 500) and an
+    # oversized limit cannot stream the whole collection. Mirrors the GET /v3/memories hardening.
+    limit = max(1, min(limit, 1000))
     if include_inactive:
         goals = goals_db.get_all_goals(uid, include_inactive=True)
     else:

--- a/backend/tests/unit/test_dev_api_conversations_poison.py
+++ b/backend/tests/unit/test_dev_api_conversations_poison.py
@@ -210,3 +210,17 @@ def test_pagination_is_clamped_before_firestore():
     assert high[1] == 100 and high[2] == 0  # limit 99999 -> 100, offset -1 -> 0
     assert m.call_args_list[1].args[1] == 25  # transcript reads cap tighter
     assert m.call_args_list[2].args[1] == 1  # limit 0 -> 1
+
+
+def test_goals_limit_is_clamped_before_firestore():
+    # Sibling of the conversations clamp above: GET /v1/dev/user/goals passed the request `limit`
+    # straight to get_user_goals -> Firestore .limit(), so ?limit=-1 raised (HTTP 500) and an
+    # oversized limit could stream the whole collection. Reuses this file's developer-router
+    # harness (database.goals is already stubbed); call the handler directly.
+    with patch.object(developer_module.goals_db, 'get_user_goals', return_value=[]) as m:
+        developer_module.get_goals(uid='uid1', limit=-1)
+        developer_module.get_goals(uid='uid1', limit=99999)
+        developer_module.get_goals(uid='uid1', limit=0)
+    assert m.call_args_list[0].kwargs['limit'] == 1  # -1 -> 1
+    assert m.call_args_list[1].kwargs['limit'] == 1000  # 99999 -> 1000
+    assert m.call_args_list[2].kwargs['limit'] == 1  # 0 -> 1


### PR DESCRIPTION
## Problem
`GET /v1/dev/user/goals` took `limit: int = 10` with no bound and passed it straight to `get_user_goals`, which runs Firestore `.limit(limit)`. A request with `?limit=-1` makes Firestore raise, surfacing as HTTP 500 for any authenticated caller; an oversized limit could stream the whole collection.

## Fix
Clamp the limit at the top of the handler, exactly as the three sibling list endpoints in this same router already do (`get_memories`, `get_action_items`, `get_conversations`), under their comment "Clamp pagination so a negative value cannot reach Firestore (which raises -> HTTP 500)". `get_goals` is the endpoint that sweep missed.

```
limit = max(1, min(limit, 1000))
```

## Test
Added a regression test next to the existing `get_conversations` clamp test in `test_dev_api_conversations_poison.py`, reusing that file's developer-router import-isolation harness rather than duplicating its ~140-line setup: negative, oversized, and zero limits are all clamped before reaching `get_user_goals`.

## Verification
- `pytest tests/unit/test_dev_api_conversations_poison.py` -> 3 passed
- `black --check` clean; `check_module_stub_pollution` -> 0 violations

The sibling unclamped list endpoint `GET /v1/import/jobs` has the same gap; I am fixing it in a companion PR so each is independently reviewable.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9555?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

