### PR TITLE
fix(imports): clamp get_import_jobs limit so ?limit=-1 cannot 500

### DIFF
--- a/backend/routers/imports.py
+++ b/backend/routers/imports.py
@@ -104,6 +104,9 @@ def get_import_jobs(
     Returns:
         List of import jobs ordered by creation date (newest first)
     """
+    # Clamp pagination so a negative value cannot reach Firestore (which raises -> HTTP 500) and an
+    # oversized limit cannot stream the whole collection.
+    limit = max(1, min(limit, 1000))
     jobs = import_jobs_db.get_import_jobs(uid, limit=limit)
 
     # Build each response individually so one malformed/legacy job (missing id, or a status value not in

--- a/backend/tests/unit/test_import_jobs_malformed.py
+++ b/backend/tests/unit/test_import_jobs_malformed.py
@@ -132,3 +132,16 @@ def test_all_valid_jobs_returned():
     page = [{'id': 'a', 'status': _PENDING}, {'id': 'b', 'status': _PENDING}]
     result = _get(page)
     assert [r.job_id for r in result] == ['a', 'b']
+
+
+def test_limit_is_clamped_before_firestore():
+    # get_import_jobs passed the request limit straight to get_import_jobs -> Firestore .limit(), so
+    # ?limit=-1 raised (HTTP 500) and an oversized limit could stream the whole collection. Mirrors the
+    # clamp the sibling dev-API list endpoints already apply.
+    with patch.object(imports_mod.import_jobs_db, 'get_import_jobs', return_value=[]) as m:
+        imports_mod.get_import_jobs(uid='uid1', limit=-1)
+        imports_mod.get_import_jobs(uid='uid1', limit=99999)
+        imports_mod.get_import_jobs(uid='uid1', limit=0)
+    assert m.call_args_list[0].kwargs['limit'] == 1  # -1 -> 1
+    assert m.call_args_list[1].kwargs['limit'] == 1000  # 99999 -> 1000
+    assert m.call_args_list[2].kwargs['limit'] == 1  # 0 -> 1


### PR DESCRIPTION
## Problem
`GET /v1/import/jobs` took `limit: int = 50` with no bound and passed it straight to `import_jobs_db.get_import_jobs`, which runs Firestore `.limit(limit)`. A request with `?limit=-1` makes Firestore raise, surfacing as HTTP 500 for any authenticated caller; an oversized limit could stream the whole collection. (The endpoint already skips malformed jobs per-item; only the limit was unclamped.)

## Fix
Clamp the limit at the top of the handler, matching the sibling dev-API list endpoints (`get_memories`, `get_action_items`, `get_conversations`) under their comment "Clamp pagination so a negative value cannot reach Firestore (which raises -> HTTP 500)".

```
limit = max(1, min(limit, 1000))
```

## Test
Added `test_limit_is_clamped_before_firestore` to the existing `test_import_jobs_malformed.py` (which already drives `get_import_jobs`): negative, oversized, and zero limits are all clamped before reaching the DB call.

## Verification
- `pytest tests/unit/test_import_jobs_malformed.py` -> 3 passed
- `black --check` clean; `check_module_stub_pollution` -> 0; `scan_async_blockers` -> 0

This completes the pagination-clamp class across the two list endpoints the earlier sweep missed; the companion is #9555 (goals).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9557?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

