### PR TITLE
fix(mcp): return -32602 instead of 500 when get_goals/get_screen_activity get a non-bool flag

### DIFF
--- a/backend/routers/mcp_sse.py
+++ b/backend/routers/mcp_sse.py
@@ -1295,7 +1295,10 @@ def execute_tool(
         return {"success": True}
 
     elif tool_name == "get_goals":
-        include_inactive = parse_mcp_bool(arguments.get("include_inactive"), "include_inactive", default=False)
+        try:
+            include_inactive = parse_mcp_bool(arguments.get("include_inactive"), "include_inactive", default=False)
+        except ValueError as e:
+            raise ToolExecutionError(str(e), code=-32602)
         return {"goals": goals_db.get_all_goals(user_id, include_inactive=include_inactive)}
 
     elif tool_name == "get_chat_messages":
@@ -1314,7 +1317,10 @@ def execute_tool(
         start = _parse_mcp_date(arguments.get("start_date"), "start_date")
         end = _parse_mcp_date(arguments.get("end_date"), "end_date")
         app = arguments.get("app")
-        summary = parse_mcp_bool(arguments.get("summary"), "summary", default=False)
+        try:
+            summary = parse_mcp_bool(arguments.get("summary"), "summary", default=False)
+        except ValueError as e:
+            raise ToolExecutionError(str(e), code=-32602)
         if summary:
             try:
                 return screen_activity_db.get_screen_activity_summary(user_id, start_date=start, end_date=end)

--- a/backend/tests/unit/test_mcp_sse_pagination_bounds.py
+++ b/backend/tests/unit/test_mcp_sse_pagination_bounds.py
@@ -93,3 +93,22 @@ def test_get_x_posts_negative_limit_is_clamped(mcp):
 
     assert result == {"posts": []}
     assert fake.call_args.kwargs["limit"] == 1  # clamped up to the minimum
+
+
+def test_get_goals_non_bool_include_inactive_returns_invalid_params(mcp):
+    """A non-boolean include_inactive must return a clean -32602, not crash in parse_mcp_bool.
+
+    Sibling boolean flags (create_action_item.completed, get_memories.include_activity) already
+    wrap parse_mcp_bool in ToolExecutionError; get_goals did not, so parse_mcp_bool's ValueError
+    escaped execute_tool as HTTP 500.
+    """
+    with pytest.raises(mcp.ToolExecutionError) as exc:
+        mcp.execute_tool("test-uid", "get_goals", {"include_inactive": "maybe"})
+    assert exc.value.code == -32602
+
+
+def test_get_screen_activity_non_bool_summary_returns_invalid_params(mcp):
+    """A non-boolean summary must return a clean -32602, not crash in parse_mcp_bool (same gap)."""
+    with pytest.raises(mcp.ToolExecutionError) as exc:
+        mcp.execute_tool("test-uid", "get_screen_activity", {"summary": "maybe"})
+    assert exc.value.code == -32602


### PR DESCRIPTION
## Problem
The MCP `tools/call` handlers for `get_goals` (`include_inactive`) and `get_screen_activity` (`summary`) called `parse_mcp_bool` outside any try/except. `parse_mcp_bool` raises `ValueError` on a non-boolean argument, and `execute_tool`'s dispatch only catches `ToolExecutionError`, so a request like `{"method":"tools/call","params":{"name":"get_goals","arguments":{"include_inactive":"maybe"}}}` escaped as HTTP 500 instead of a clean JSON-RPC `-32602` invalid-params error.

## Fix
Wrap both `parse_mcp_bool` calls in `try/except ValueError -> ToolExecutionError(str(e), code=-32602)`, matching every sibling boolean/int flag in the same dispatch (`create_action_item.completed`, `complete_action_item.completed`, `get_memories.include_activity/include_sensitive`, `get_chat_messages` limit/offset). These were the only two unwrapped `parse_mcp_bool` sites.

## Test
Added two cases to `test_mcp_sse_pagination_bounds.py` (which already exercises `execute_tool` arg validation): a non-boolean `include_inactive` and `summary` each raise `ToolExecutionError` with code `-32602`, not a bare `ValueError`.

## Verification
- `pytest tests/unit/test_mcp_sse_pagination_bounds.py` -> 7 passed
- `black --check` clean; `check_module_stub_pollution` -> 0; `scan_async_blockers` -> 0


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9559?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

