### PR TITLE
fix(monitoring): align alert panel IDs and queries to dashboard panels

### DIFF
--- a/backend/charts/monitoring/alerts/backend-sync.json
+++ b/backend/charts/monitoring/alerts/backend-sync.json
@@ -901,7 +901,9 @@
     "annotations": {
       "runbook": "backend/docs/runbooks/sync-dispatch-fallback.md",
       "summary": "Paused: backend-sync metrics not scraped by GKE Prometheus \u2014 use Cloud Logging",
-      "threshold": "0.2 (20% enqueue_failed)"
+      "threshold": "0.2 (20% enqueue_failed)",
+      "__dashboardUid__": "omi-resilience-fallbacks",
+      "__panelId__": "3"
     },
     "isPaused": false,
     "notification_settings": {

--- a/backend/charts/monitoring/alerts/parakeet.json
+++ b/backend/charts/monitoring/alerts/parakeet.json
@@ -121,7 +121,7 @@
     "keep_firing_for": "0s",
     "annotations": {
       "__dashboardUid__": "07e4c65f-ae79-414d-bf05-99468267d199",
-      "__panelId__": "7",
+      "__panelId__": "122",
       "threshold": "0.1"
     },
     "labels": {
@@ -389,7 +389,7 @@
     "keep_firing_for": "0s",
     "annotations": {
       "__dashboardUid__": "07e4c65f-ae79-414d-bf05-99468267d199",
-      "__panelId__": "113"
+      "__panelId__": "21"
     },
     "labels": {
       "instatus_component": "speech-processing",
@@ -523,7 +523,7 @@
     "keep_firing_for": "0s",
     "annotations": {
       "__dashboardUid__": "07e4c65f-ae79-414d-bf05-99468267d199",
-      "__panelId__": "6",
+      "__panelId__": "123",
       "threshold": "30000ms"
     },
     "labels": {
@@ -658,7 +658,7 @@
     "keep_firing_for": "0s",
     "annotations": {
       "__dashboardUid__": "07e4c65f-ae79-414d-bf05-99468267d199",
-      "__panelId__": "5",
+      "__panelId__": "122",
       "threshold": "5 req/s"
     },
     "labels": {

--- a/backend/charts/monitoring/alerts/pusher.json
+++ b/backend/charts/monitoring/alerts/pusher.json
@@ -121,7 +121,7 @@
     "keep_firing_for": "0s",
     "annotations": {
       "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
-      "__panelId__": "45",
+      "__panelId__": "77",
       "threshold": "1"
     },
     "isPaused": false,
@@ -256,7 +256,7 @@
     "keep_firing_for": "0s",
     "annotations": {
       "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
-      "__panelId__": "45",
+      "__panelId__": "77",
       "threshold": "1"
     },
     "labels": {
@@ -391,7 +391,7 @@
     "keep_firing_for": "0s",
     "annotations": {
       "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
-      "__panelId__": "42",
+      "__panelId__": "75",
       "threshold": "10"
     },
     "isPaused": false,
@@ -505,7 +505,7 @@
     "keep_firing_for": "0s",
     "annotations": {
       "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
-      "__panelId__": "69",
+      "__panelId__": "79",
       "threshold": "40"
     },
     "isPaused": false,
@@ -540,7 +540,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "max(pusher_active_ws_connections{pod=~\"prod-omi-pusher.*\"})",
+          "expr": "max(pusher_active_ws_connections{job=\"pusher-metrics\"})",
           "instant": true,
           "intervalMs": 1000,
           "maxDataPoints": 43200,
@@ -640,7 +640,7 @@
     "keep_firing_for": "0s",
     "annotations": {
       "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
-      "__panelId__": "43",
+      "__panelId__": "86",
       "threshold": "30"
     },
     "isPaused": false,
@@ -674,7 +674,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum(pusher_sessions_degraded) / clamp_min(sum(pusher_active_ws_connections), 1)",
+          "expr": "sum(pusher_sessions_degraded{job=\"pusher-metrics\"}) / clamp_min(sum(pusher_active_ws_connections{job=\"pusher-metrics\"}), 1)",
           "instant": true,
           "intervalMs": 1000,
           "maxDataPoints": 43200,

--- a/backend/charts/monitoring/alerts/resilience.json
+++ b/backend/charts/monitoring/alerts/resilience.json
@@ -101,7 +101,9 @@
       "runbook": "backend/docs/runbooks/llm-gateway-fallback.md",
       "severity": "ticket",
       "summary": "Dependency health \u2014 elevated LLM gateway fallback rate, not a product outage by itself",
-      "threshold": "0.05 (5% fallback share over 30m)"
+      "threshold": "0.05 (5% fallback share over 30m)",
+      "__dashboardUid__": "omi-resilience-fallbacks",
+      "__panelId__": "5"
     },
     "labels": {
       "severity": "warning",

--- a/backend/charts/monitoring/alerts/traffic-zero.json
+++ b/backend/charts/monitoring/alerts/traffic-zero.json
@@ -211,7 +211,7 @@
     "keep_firing_for": "0s",
     "annotations": {
       "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
-      "__panelId__": "19",
+      "__panelId__": "17",
       "summary": "Backend-listen receiving zero LB traffic for 10+ minutes \u2014 transcription pipeline may be down",
       "threshold": "< 0.001 rps (effectively zero)"
     },
@@ -359,7 +359,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum(pusher_active_ws_connections{namespace=\"prod-omi-backend\", pod=~\"prod-omi-pusher.*\"}) or vector(0)",
+          "expr": "sum(pusher_active_ws_connections{job=\"pusher-metrics\"}) or vector(0)",
           "instant": true,
           "intervalMs": 1000,
           "maxDataPoints": 43200,
@@ -437,7 +437,7 @@
     "keep_firing_for": "0s",
     "annotations": {
       "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
-      "__panelId__": "43",
+      "__panelId__": "86",
       "summary": "Pusher has zero active WebSocket connections for 10+ minutes \u2014 live transcription pipeline broken",
       "threshold": "< 1 active connection"
     },


### PR DESCRIPTION
## Summary
- **Pusher alerts**: Remapped 6 panel IDs (42/43/45/69 → 75/77/79/86) and aligned label filters from `pod=~"prod-omi-pusher.*"` to `job="pusher-metrics"` matching Omi Services Overview dashboard
- **Traffic-zero alerts**: Fixed backend-listen panel (19→17, RPS not error rate) and pusher WS panel (43→86) with query filter alignment
- **Parakeet alerts**: Remapped 4 panel IDs from app-level panels to LB-level panels (5→122, 6→123, 7→122, 113→21) since alerts use LB stackdriver metrics
- **Backend-sync & resilience alerts**: Added missing `__dashboardUid__` and `__panelId__` annotations linking to resilience-fallbacks dashboard

## Context
PR #9554 built alert PromQL expressions without referencing existing dashboards. This rework aligns all 53 rules against the two source-of-truth dashboards:
1. Omi Services Overview (uid `6d3d0897`) — 67 panels
2. Parakeet ASR Monitoring (uid `07e4c65f`) — 43 panels

16 fixes across 5 alert files. Remaining 39 rules were already correctly aligned.

## Test plan
- [ ] Deploy to Grafana and verify alert panel links navigate to correct dashboard panels
- [ ] Confirm pusher WS alerts still fire correctly with `job="pusher-metrics"` filter
- [ ] Verify no alerts enter error/nodata state after deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9561?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

