### PR TITLE
fix(monitoring): align alert queries to dashboard panels

### DIFF
--- a/backend/charts/monitoring/alerts/backend-integration.json
+++ b/backend/charts/monitoring/alerts/backend-integration.json
@@ -212,7 +212,7 @@
             "groupBys": [
               "metric.label.response_code_class"
             ],
-            "perSeriesAligner": "ALIGN_SUM",
+            "perSeriesAligner": "ALIGN_NONE",
             "preprocessor": "rate",
             "projectName": "based-hardware",
             "view": "FULL"

--- a/backend/charts/monitoring/alerts/backend-sync.json
+++ b/backend/charts/monitoring/alerts/backend-sync.json
@@ -901,7 +901,9 @@
     "annotations": {
       "runbook": "backend/docs/runbooks/sync-dispatch-fallback.md",
       "summary": "Paused: backend-sync metrics not scraped by GKE Prometheus \u2014 use Cloud Logging",
-      "threshold": "0.2 (20% enqueue_failed)"
+      "threshold": "0.2 (20% enqueue_failed)",
+      "__dashboardUid__": "omi-resilience-fallbacks",
+      "__panelId__": "3"
     },
     "isPaused": false,
     "notification_settings": {

--- a/backend/charts/monitoring/alerts/backend-sync.json
+++ b/backend/charts/monitoring/alerts/backend-sync.json
@@ -208,7 +208,7 @@
             "groupBys": [
               "metric.label.response_code_class"
             ],
-            "perSeriesAligner": "ALIGN_SUM",
+            "perSeriesAligner": "ALIGN_NONE",
             "preprocessor": "rate",
             "projectName": "based-hardware",
             "view": "FULL"

--- a/backend/charts/monitoring/alerts/parakeet.json
+++ b/backend/charts/monitoring/alerts/parakeet.json
@@ -21,7 +21,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum(rate(stackdriver_internal_http_lb_rule_loadbalancing_googleapis_com_https_internal_backend_latencies_count{forwarding_rule_name=\"k8s2-fr-heiog7uv-prod-omi-backend-prod-omi-parakeet-g38rzz69\",response_code_class=\"500\"}[5m])) or vector(0)",
+          "expr": "sum(rate(stackdriver_internal_http_lb_rule_loadbalancing_googleapis_com_https_internal_backend_latencies_count{forwarding_rule_name=~\".*prod-omi-parakeet.*\",response_code_class=\"500\"}[5m])) or vector(0)",
           "instant": true,
           "intervalMs": 1000,
           "maxDataPoints": 43200,
@@ -156,7 +156,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "(sum(rate(stackdriver_internal_http_lb_rule_loadbalancing_googleapis_com_https_internal_backend_latencies_count{forwarding_rule_name=\"k8s2-fr-heiog7uv-prod-omi-backend-prod-omi-parakeet-g38rzz69\",response_code_class=\"500\"}[5m])) or vector(0)) / (sum(rate(stackdriver_internal_http_lb_rule_loadbalancing_googleapis_com_https_internal_backend_latencies_count{forwarding_rule_name=\"k8s2-fr-heiog7uv-prod-omi-backend-prod-omi-parakeet-g38rzz69\"}[5m])) > 0)",
+          "expr": "(sum(rate(stackdriver_internal_http_lb_rule_loadbalancing_googleapis_com_https_internal_backend_latencies_count{forwarding_rule_name=~\".*prod-omi-parakeet.*\",response_code_class=\"500\"}[5m])) or vector(0)) / (sum(rate(stackdriver_internal_http_lb_rule_loadbalancing_googleapis_com_https_internal_backend_latencies_count{forwarding_rule_name=~\".*prod-omi-parakeet.*\"}[5m])) > 0)",
           "instant": true,
           "intervalMs": 1000,
           "maxDataPoints": 43200,
@@ -176,7 +176,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum(rate(stackdriver_internal_http_lb_rule_loadbalancing_googleapis_com_https_internal_backend_latencies_count{forwarding_rule_name=\"k8s2-fr-heiog7uv-prod-omi-backend-prod-omi-parakeet-g38rzz69\"}[5m]))",
+          "expr": "sum(rate(stackdriver_internal_http_lb_rule_loadbalancing_googleapis_com_https_internal_backend_latencies_count{forwarding_rule_name=~\".*prod-omi-parakeet.*\"}[5m]))",
           "instant": true,
           "intervalMs": 1000,
           "maxDataPoints": 43200,
@@ -423,7 +423,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "histogram_quantile(0.99, sum by (le)(rate(stackdriver_internal_http_lb_rule_loadbalancing_googleapis_com_https_internal_backend_latencies_bucket{forwarding_rule_name=\"k8s2-fr-heiog7uv-prod-omi-backend-prod-omi-parakeet-g38rzz69\"}[5m])))",
+          "expr": "histogram_quantile(0.99, sum by (le)(rate(stackdriver_internal_http_lb_rule_loadbalancing_googleapis_com_https_internal_backend_latencies_bucket{forwarding_rule_name=~\".*prod-omi-parakeet.*\"}[5m])))",
           "instant": true,
           "intervalMs": 1000,
           "maxDataPoints": 43200,
@@ -558,7 +558,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum(rate(stackdriver_internal_http_lb_rule_loadbalancing_googleapis_com_https_internal_backend_latencies_count{forwarding_rule_name=\"k8s2-fr-heiog7uv-prod-omi-backend-prod-omi-parakeet-g38rzz69\"}[5m]))",
+          "expr": "sum(rate(stackdriver_internal_http_lb_rule_loadbalancing_googleapis_com_https_internal_backend_latencies_count{forwarding_rule_name=~\".*prod-omi-parakeet.*\"}[5m]))",
           "instant": true,
           "intervalMs": 1000,
           "maxDataPoints": 43200,

--- a/backend/charts/monitoring/alerts/parakeet.json
+++ b/backend/charts/monitoring/alerts/parakeet.json
@@ -121,7 +121,7 @@
     "keep_firing_for": "0s",
     "annotations": {
       "__dashboardUid__": "07e4c65f-ae79-414d-bf05-99468267d199",
-      "__panelId__": "7",
+      "__panelId__": "122",
       "threshold": "0.1"
     },
     "labels": {
@@ -389,7 +389,7 @@
     "keep_firing_for": "0s",
     "annotations": {
       "__dashboardUid__": "07e4c65f-ae79-414d-bf05-99468267d199",
-      "__panelId__": "113"
+      "__panelId__": "21"
     },
     "labels": {
       "instatus_component": "speech-processing",
@@ -523,7 +523,7 @@
     "keep_firing_for": "0s",
     "annotations": {
       "__dashboardUid__": "07e4c65f-ae79-414d-bf05-99468267d199",
-      "__panelId__": "6",
+      "__panelId__": "123",
       "threshold": "30000ms"
     },
     "labels": {
@@ -658,7 +658,7 @@
     "keep_firing_for": "0s",
     "annotations": {
       "__dashboardUid__": "07e4c65f-ae79-414d-bf05-99468267d199",
-      "__panelId__": "5",
+      "__panelId__": "122",
       "threshold": "5 req/s"
     },
     "labels": {

--- a/backend/charts/monitoring/alerts/pusher.json
+++ b/backend/charts/monitoring/alerts/pusher.json
@@ -640,7 +640,7 @@
     "keep_firing_for": "0s",
     "annotations": {
       "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
-      "__panelId__": "86",
+      "__panelId__": "88",
       "threshold": "30"
     },
     "isPaused": false,

--- a/backend/charts/monitoring/alerts/pusher.json
+++ b/backend/charts/monitoring/alerts/pusher.json
@@ -121,7 +121,7 @@
     "keep_firing_for": "0s",
     "annotations": {
       "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
-      "__panelId__": "45",
+      "__panelId__": "77",
       "threshold": "1"
     },
     "isPaused": false,
@@ -256,7 +256,7 @@
     "keep_firing_for": "0s",
     "annotations": {
       "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
-      "__panelId__": "45",
+      "__panelId__": "77",
       "threshold": "1"
     },
     "labels": {
@@ -391,7 +391,7 @@
     "keep_firing_for": "0s",
     "annotations": {
       "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
-      "__panelId__": "42",
+      "__panelId__": "75",
       "threshold": "10"
     },
     "isPaused": false,
@@ -505,7 +505,7 @@
     "keep_firing_for": "0s",
     "annotations": {
       "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
-      "__panelId__": "69",
+      "__panelId__": "79",
       "threshold": "40"
     },
     "isPaused": false,
@@ -540,7 +540,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "max(pusher_active_ws_connections{pod=~\"prod-omi-pusher.*\"})",
+          "expr": "max(pusher_active_ws_connections{job=\"pusher-metrics\"})",
           "instant": true,
           "intervalMs": 1000,
           "maxDataPoints": 43200,
@@ -640,7 +640,7 @@
     "keep_firing_for": "0s",
     "annotations": {
       "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
-      "__panelId__": "43",
+      "__panelId__": "86",
       "threshold": "30"
     },
     "isPaused": false,
@@ -674,7 +674,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum(pusher_sessions_degraded) / clamp_min(sum(pusher_active_ws_connections), 1)",
+          "expr": "sum(pusher_sessions_degraded{job=\"pusher-metrics\"}) / clamp_min(sum(pusher_active_ws_connections{job=\"pusher-metrics\"}), 1)",
           "instant": true,
           "intervalMs": 1000,
           "maxDataPoints": 43200,

--- a/backend/charts/monitoring/alerts/resilience.json
+++ b/backend/charts/monitoring/alerts/resilience.json
@@ -101,7 +101,9 @@
       "runbook": "backend/docs/runbooks/llm-gateway-fallback.md",
       "severity": "ticket",
       "summary": "Dependency health \u2014 elevated LLM gateway fallback rate, not a product outage by itself",
-      "threshold": "0.05 (5% fallback share over 30m)"
+      "threshold": "0.05 (5% fallback share over 30m)",
+      "__dashboardUid__": "omi-resilience-fallbacks",
+      "__panelId__": "5"
     },
     "labels": {
       "severity": "warning",

--- a/backend/charts/monitoring/alerts/traffic-zero.json
+++ b/backend/charts/monitoring/alerts/traffic-zero.json
@@ -323,8 +323,8 @@
     "for": "5m",
     "keep_firing_for": "0s",
     "annotations": {
-      "__dashboardUid__": "855b2e16-c098-407a-85dc-dc9ce87698a9",
-      "__panelId__": "9",
+      "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
+      "__panelId__": "21",
       "summary": "Backend-listen has zero ready pods \u2014 all replicas are down or failing health checks",
       "threshold": "< 1 ready pod"
     },

--- a/backend/charts/monitoring/alerts/traffic-zero.json
+++ b/backend/charts/monitoring/alerts/traffic-zero.json
@@ -211,7 +211,7 @@
     "keep_firing_for": "0s",
     "annotations": {
       "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
-      "__panelId__": "19",
+      "__panelId__": "17",
       "summary": "Backend-listen receiving zero LB traffic for 10+ minutes \u2014 transcription pipeline may be down",
       "threshold": "< 0.001 rps (effectively zero)"
     },
@@ -359,7 +359,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum(pusher_active_ws_connections{namespace=\"prod-omi-backend\", pod=~\"prod-omi-pusher.*\"}) or vector(0)",
+          "expr": "sum(pusher_active_ws_connections{job=\"pusher-metrics\"}) or vector(0)",
           "instant": true,
           "intervalMs": 1000,
           "maxDataPoints": 43200,
@@ -437,7 +437,7 @@
     "keep_firing_for": "0s",
     "annotations": {
       "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
-      "__panelId__": "43",
+      "__panelId__": "86",
       "summary": "Pusher has zero active WebSocket connections for 10+ minutes \u2014 live transcription pipeline broken",
       "threshold": "< 1 active connection"
     },


### PR DESCRIPTION
## Summary

Aligns all 53 alerting rules from PR #9554 against the two source-of-truth dashboards:
- **Omi Services Overview** (uid `6d3d0897`, 67 panels)
- **Parakeet ASR Monitoring** (uid `07e4c65f`, 46 panels)

### Changes by file (6 files, 10 commits)

**backend-integration.json** — 5XX error rate alert `perSeriesAligner` changed from `ALIGN_SUM` to `ALIGN_NONE` (matching Panel 27 with `preprocessor=rate`)

**backend-sync.json** — Same `perSeriesAligner` fix (matching Panel 34). Added dashboard annotation to enqueue_failed alert.

**parakeet.json** — All 5 `forwarding_rule_name` selectors changed from exact match to regex `=~".*prod-omi-parakeet.*"` (matching Parakeet dashboard Panels 122/123). Panel IDs realigned.

**pusher.json** — Panel IDs realigned to match dashboard (77, 75, 79, 88). Label filters aligned to `job="pusher-metrics"` (max concurrent + degraded session). Panel 88 (per-pod) used for max() alert instead of panel 86 (aggregate sum).

**resilience.json** — Added dashboard annotation to LLM gateway fallback alert.

**traffic-zero.json** — Backend-listen pods annotation corrected: UID → Omi Services Overview, panel → 21 (Replica count). Pusher WS label aligned to `job="pusher-metrics"`. Backend-listen LB panel realigned.

### Alignment audit

All 53 rules reviewed. 13 changed paths across 6 files. All `__dashboardUid__` + `__panelId__` annotations verified (53 pairs, 0 missing across 19 dashboards).

### Design decisions documented

- Pusher LB alerts use Prometheus-exported `backend_latencies_count`; dashboard uses native Stackdriver `backend_request_count` — closest contextual panel, not same metric
- Pusher max-concurrent uses `max()` (per-pod overload); panel 88 shows per-pod series (closest match)
- Backend-listen `replicas_ready` alert links to panel 21 (`replicas`) — no `replicas_ready` panel exists

## Test plan

- [x] JSON syntax validation: all 11 files pass `json.load()`
- [x] Structural check: all rules have required fields
- [x] Dashboard annotation verification: 53 pairs, 0 missing
- [x] Changed expression assertions: P1-P13 all PASS
- [x] CODEx review: 3 rounds, PR_APPROVED_LGTM
- [x] CODEx tester: TESTS_APPROVED
- [ ] Deploy via `grizzly apply` and verify 0 firing false positives (mon)

### Workflow checkpoints

CP0-CP9B all passed. CP9C not required (config-only, no cluster infra).

🤖 Generated with [Claude Code](https://claude.com/claude-code)