### PR TITLE
fix(conversations): tolerate a segment doc missing 'start' in the transcripts endpoint

### DIFF
--- a/backend/database/conversations.py
+++ b/backend/database/conversations.py
@@ -1180,11 +1180,15 @@ def get_conversation_transcripts_by_model(uid: str, conversation_id: str):
     speechmatics_ref = conversation_ref.collection('speechmatics_streaming')
     whisperx_ref = conversation_ref.collection('fal_whisperx')
 
+    # Sort each provider's segments by start time, tolerating a legacy/partial doc missing 'start'
+    # (a bare x['start'] would KeyError and 500 the whole transcripts response).
     return {
-        'deepgram': list(sorted([doc.to_dict() for doc in deepgram_ref.stream()], key=lambda x: x['start'])),
-        'soniox': list(sorted([doc.to_dict() for doc in soniox_ref.stream()], key=lambda x: x['start'])),
-        'speechmatics': list(sorted([doc.to_dict() for doc in speechmatics_ref.stream()], key=lambda x: x['start'])),
-        'whisperx': list(sorted([doc.to_dict() for doc in whisperx_ref.stream()], key=lambda x: x['start'])),
+        'deepgram': list(sorted([doc.to_dict() for doc in deepgram_ref.stream()], key=lambda x: x.get('start', 0))),
+        'soniox': list(sorted([doc.to_dict() for doc in soniox_ref.stream()], key=lambda x: x.get('start', 0))),
+        'speechmatics': list(
+            sorted([doc.to_dict() for doc in speechmatics_ref.stream()], key=lambda x: x.get('start', 0))
+        ),
+        'whisperx': list(sorted([doc.to_dict() for doc in whisperx_ref.stream()], key=lambda x: x.get('start', 0))),
     }
 
 

--- a/backend/tests/unit/test_conversation_transcripts_missing_start.py
+++ b/backend/tests/unit/test_conversation_transcripts_missing_start.py
@@ -1,0 +1,44 @@
+"""get_conversation_transcripts_by_model must tolerate a segment doc missing 'start'.
+
+GET /v1/conversations/{id}/transcripts sorted each provider's segments by ``x['start']``. A legacy
+or partial segment doc missing 'start' raised KeyError and 500'd the whole transcripts response.
+The sort now uses ``x.get('start', 0)``. database.conversations is light, so the test drives the
+function directly with its db proxy patched to a fake chaining client.
+"""
+
+import os
+
+os.environ.setdefault(
+    'ENCRYPTION_SECRET',
+    'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv',
+)
+os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
+
+from unittest.mock import MagicMock
+
+import database.conversations as conversations_db
+
+
+def _snap(doc):
+    snap = MagicMock()
+    snap.to_dict.return_value = doc
+    return snap
+
+
+def test_transcripts_tolerate_segment_missing_start(monkeypatch):
+    # deepgram has a good doc plus a legacy doc missing 'start'; the sort must not KeyError.
+    docs = [_snap({'start': 2.0, 'text': 'b'}), _snap({'text': 'no-start'}), _snap({'start': 1.0, 'text': 'a'})]
+    fake_db = MagicMock()
+    fake_db.collection.return_value = fake_db
+    fake_db.document.return_value = fake_db
+    fake_db.stream.return_value = docs
+    monkeypatch.setattr(conversations_db, 'db', fake_db)
+
+    result = conversations_db.get_conversation_transcripts_by_model('u1', 'c1')
+
+    # Missing 'start' sorts as 0 (first); before the fix x['start'] raised KeyError here.
+    assert result['deepgram'] == [{'text': 'no-start'}, {'start': 1.0, 'text': 'a'}, {'start': 2.0, 'text': 'b'}]
+    # All four provider collections use the same fake stream, so each is sorted the same way.
+    assert result['soniox'] == result['deepgram']
+    assert result['speechmatics'] == result['deepgram']
+    assert result['whisperx'] == result['deepgram']


### PR DESCRIPTION
## Problem
`get_conversation_transcripts_by_model` (`GET /v1/conversations/{conversation_id}/transcripts`) sorted each of the four provider streams (deepgram, soniox, speechmatics, whisperx) with a bare `key=lambda x: x['start']`. Normal segments carry `start`, but a legacy or partial doc missing it raises `KeyError`, which surfaces as HTTP 500 for the whole transcripts response.

## Fix
Sort with `x.get('start', 0)` (a missing `start` sorts first), the same defensive dict access `database/chat.py` already uses on Firestore doc dicts.

## Test
`tests/unit/test_conversation_transcripts_missing_start.py` patches the module `db` proxy with a fake stream containing one good doc and one missing `start`, and asserts the result sorts without raising.

## Verification
- `pytest tests/unit/test_conversation_transcripts_missing_start.py` -> 1 passed
- `black --check` clean; `check_module_stub_pollution` -> 0; `scan_async_blockers` -> 0


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9563?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

