### PR TITLE
fix(location): return None on a geocode lookup failure instead of 500ing the caller

### DIFF
--- a/backend/tests/unit/test_geocode_lookup_error.py
+++ b/backend/tests/unit/test_geocode_lookup_error.py
@@ -1,0 +1,37 @@
+"""get_google_maps_location returns None on a lookup failure instead of raising (-> HTTP 500).
+
+The sync helper called httpx.get(url).json() unguarded, so a Maps network error or a non-JSON 5xx
+response raised and surfaced as HTTP 500 on conversation create/finalize. Its async twin already
+guards this and returns None; this mirrors it. location.py is light, so the test drives it directly
+with the Redis cache patched to a miss and httpx.get patched to fail.
+"""
+
+import os
+
+os.environ.setdefault(
+    'ENCRYPTION_SECRET',
+    'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv',
+)
+
+from unittest.mock import MagicMock, patch
+
+import httpx
+
+import utils.conversations.location as location
+
+
+def _cache_miss():
+    # r.get returns None so the helper proceeds past the cache to the HTTP lookup.
+    return patch.object(location, 'r', MagicMock(get=MagicMock(return_value=None), set=MagicMock()))
+
+
+def test_returns_none_on_http_error():
+    with _cache_miss(), patch.object(location.httpx, 'get', side_effect=httpx.ConnectError('boom')):
+        assert location.get_google_maps_location(1.0, 2.0) is None
+
+
+def test_returns_none_on_non_json_response():
+    resp = MagicMock()
+    resp.json.side_effect = ValueError('not json')  # e.g. an HTML 5xx error page
+    with _cache_miss(), patch.object(location.httpx, 'get', return_value=resp):
+        assert location.get_google_maps_location(1.0, 2.0) is None

--- a/backend/utils/conversations/location.py
+++ b/backend/utils/conversations/location.py
@@ -30,8 +30,15 @@ def get_google_maps_location(latitude: float, longitude: float) -> Optional[Geol
 
     key = os.getenv('GOOGLE_MAPS_API_KEY')
     url = f"https://maps.googleapis.com/maps/api/geocode/json?latlng={latitude},{longitude}&key={key}"
-    response = httpx.get(url)
-    data = response.json()
+    try:
+        response = httpx.get(url)
+        data = response.json()
+    except Exception as e:
+        # A Maps network error or a non-JSON 5xx response must not 500 the caller (conversation
+        # create/finalize); return None so the caller keeps the raw geolocation. Mirrors the guard
+        # in async_get_google_maps_location.
+        logger.error(f'get_google_maps_location error: {e}')
+        return None
     if data.get('status') != 'OK' or not data.get('results'):
         return None
     place = data['results'][0]


### PR DESCRIPTION
## Problem
The sync `get_google_maps_location` did `httpx.get(url).json()` with no try/except. A Google Maps network error, timeout, or a non-JSON 5xx error page makes `httpx.get`/`.json()` raise, which surfaces as HTTP 500 on the two unguarded callers (`POST /v1/conversations` create and `/v1/conversations/{id}/finalize`).

## Fix
Wrap the request and JSON parse in `try/except Exception -> logger.error -> return None`, exactly as the async twin `async_get_google_maps_location` already does. The enrichment is optional: callers treat `None` as "keep the raw geolocation", so a Maps failure now degrades gracefully instead of failing the whole request.

## Test
`tests/unit/test_geocode_lookup_error.py` patches the Redis cache to a miss and `httpx.get` to (a) raise `ConnectError` and (b) return a response whose `.json()` raises; both now return `None` rather than propagating.

## Verification
- `pytest tests/unit/test_geocode_lookup_error.py` -> 2 passed
- `black --check` clean; `check_module_stub_pollution` -> 0; `scan_async_blockers` -> 0


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9564?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

