### PR TITLE
feat(monitoring): add backend-listen WS connection drop alert

### DIFF
--- a/backend/charts/monitoring/alerts/traffic-zero.json
+++ b/backend/charts/monitoring/alerts/traffic-zero.json
@@ -452,6 +452,119 @@
     "record": null
   },
   {
+    "uid": "tz_backend_listen_ws_drop",
+    "orgID": 1,
+    "folderUID": "betdycdziadc0e",
+    "ruleGroup": "Traffic Zero Detection",
+    "title": "Backend-listen - active WS connections critically low",
+    "condition": "C",
+    "data": [
+      {
+        "refId": "A",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 600,
+          "to": 0
+        },
+        "datasourceUid": "prometheus",
+        "model": {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(backend_listen_active_ws_connections{job=\"backend-listen-metrics\"}) or vector(0)",
+          "instant": true,
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "A"
+        }
+      },
+      {
+        "refId": "B",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
+        "datasourceUid": "__expr__",
+        "model": {
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "A",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "reducer": "last",
+          "refId": "B",
+          "type": "reduce"
+        }
+      },
+      {
+        "refId": "C",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
+        "datasourceUid": "__expr__",
+        "model": {
+          "conditions": [
+            {
+              "evaluator": {
+                "params": [
+                  10
+                ],
+                "type": "lt"
+              },
+              "operator": {
+                "type": "and"
+              },
+              "query": {
+                "params": [
+                  "C"
+                ]
+              },
+              "reducer": {
+                "params": [],
+                "type": "last"
+              },
+              "type": "query"
+            }
+          ],
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "B",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "C",
+          "type": "threshold"
+        }
+      }
+    ],
+    "noDataState": "Alerting",
+    "execErrState": "Error",
+    "for": "5m",
+    "keep_firing_for": "0s",
+    "annotations": {
+      "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
+      "__panelId__": "82",
+      "summary": "Backend-listen active WS connections dropped below 10 for 5+ minutes — clients disconnecting, likely backend-listen failure (3-day baseline: min=52, avg=218, max=365)",
+      "threshold": "< 10 active connections"
+    },
+    "labels": {
+      "severity": "critical",
+      "instatus_component": "live-transcription"
+    },
+    "isPaused": false,
+    "notification_settings": {
+      "receiver": "Omi - Services Alerting (Telegram)"
+    },
+    "record": null
+  },
+  {
     "uid": "tz_backend_cloudrun_zero",
     "orgID": 1,
     "folderUID": "betdycdziadc0e",


### PR DESCRIPTION
## Summary

Adds a critical alert for backend-listen active WebSocket connections dropping below 10. This catches any backend-listen failure that causes client disconnections, regardless of root cause (e.g., helm empty defaults incident).

### Alert specification

| Field | Value |
|---|---|
| UID | `tz_backend_listen_ws_drop` |
| Expression | `sum(backend_listen_active_ws_connections{job="backend-listen-metrics"}) or vector(0)` |
| Threshold | `< 10` |
| Duration | `5m` |
| Severity | `critical` |
| Dashboard link | Omi Services Overview → Panel 82 ("Backend-listen active WS") |
| instatus_component | `live-transcription` |

### Baseline (3-day)

- Min non-zero: 52
- Average: 218
- Max: 365
- Threshold (10) is ~5% of minimum, giving wide margin before false positives

### Expression alignment

Query matches dashboard panel 82 exactly: `sum(backend_listen_active_ws_connections{job="backend-listen-metrics"})`

## Test plan

- [x] JSON syntax validation: `traffic-zero.json` passes `json.load()`
- [x] Dashboard annotation: panel 82 resolves in Omi Services Overview
- [x] Expression matches dashboard panel 82
- [ ] Deploy via `grizzly apply` and verify alert evaluates to OK (mon)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9565?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

