### PR TITLE
fix(announcements): tolerate a legacy doc missing id or created_at in Announcement.from_dict

### DIFF
--- a/backend/models/announcement.py
+++ b/backend/models/announcement.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from enum import Enum
 from typing import Any, List, Mapping, Optional, cast
 
@@ -173,10 +173,15 @@ class Announcement(BaseModel):
         except ValueError:
             announcement_type = AnnouncementType.ANNOUNCEMENT
 
+        # Tolerate a legacy doc missing id or created_at the same way a missing type is tolerated above,
+        # so a single malformed announcement cannot 500 the whole list. A missing created_at sorts as
+        # the epoch.
+        announcement_id = cast(str, data.get("id")) or ""
+        created_at = cast(datetime, data.get("created_at")) or datetime.fromtimestamp(0, tz=timezone.utc)
         return Announcement(
-            id=cast(str, data.get("id")),
+            id=announcement_id,
             type=announcement_type,
-            created_at=cast(datetime, data.get("created_at")),
+            created_at=created_at,
             active=data.get("active", True),
             app_version=data.get("app_version"),
             firmware_version=data.get("firmware_version"),

--- a/backend/tests/unit/test_announcement_malformed_type.py
+++ b/backend/tests/unit/test_announcement_malformed_type.py
@@ -34,3 +34,28 @@ def test_valid_types_preserved():
     ]:
         a = Announcement.from_dict({**_BASE, 'type': raw})
         assert a.type == expected
+
+
+# id and created_at are also required with no default; a legacy doc missing them used to raise
+# ValidationError and 500 the whole list, defeating the same tolerance goal stated for type.
+
+
+def test_missing_created_at_falls_back_not_raises():
+    a = Announcement.from_dict({'id': 'a1', 'type': 'announcement'})  # no created_at
+    assert a.created_at == datetime.fromtimestamp(0, tz=timezone.utc)
+
+
+def test_none_created_at_falls_back():
+    a = Announcement.from_dict({'id': 'a1', 'type': 'announcement', 'created_at': None})
+    assert a.created_at == datetime.fromtimestamp(0, tz=timezone.utc)
+
+
+def test_missing_id_falls_back_not_raises():
+    a = Announcement.from_dict({'created_at': datetime(2026, 1, 1, tzinfo=timezone.utc), 'type': 'announcement'})
+    assert a.id == ''
+
+
+def test_valid_id_and_created_at_preserved():
+    ts = datetime(2026, 6, 1, tzinfo=timezone.utc)
+    a = Announcement.from_dict({'id': 'keep', 'created_at': ts, 'type': 'announcement'})
+    assert a.id == 'keep' and a.created_at == ts


### PR DESCRIPTION
## Problem
`Announcement.from_dict` already falls back to a generic `type` for a missing/out-of-enum type, with the stated goal that "one malformed/legacy announcement document cannot 500 the whole (public) announcements list". But `id` and `created_at` (both required, no default) were passed straight from `data.get()` through a no-op `cast`, so a legacy doc missing either yields `None` -> `ValidationError` -> HTTP 500 for the whole list. This is reached from the authenticated `GET /v1/announcements/pending` and the changelogs/features/general endpoints, which build `from_dict` per record.

## Fix
Apply the same tolerance the `type` fallback already uses: default a missing `id` to `''` and a missing/`None` `created_at` to the epoch (`datetime.fromtimestamp(0, tz=timezone.utc)`, tz-aware so it sorts safely alongside real timestamps). One fix in `from_dict` covers every list caller.

## Test
Extended `tests/unit/test_announcement_malformed_type.py` (which already covers the `type` fallback): a doc missing `created_at`, a `None` `created_at`, and a missing `id` each build without raising, and valid `id`/`created_at` are preserved.

## Verification
- `pytest tests/unit/test_announcement_malformed_type.py` -> 7 passed
- `black --check` clean; `check_module_stub_pollution` -> 0


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9566?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

