### PR TITLE
fix(monitoring): resolve 5XX alert false positives from Stackdriver no-data

### DIFF
--- a/backend/charts/monitoring/alerts/backend-integration.json
+++ b/backend/charts/monitoring/alerts/backend-integration.json
@@ -306,7 +306,7 @@
       }
     ],
     "updated": "2026-06-23T01:27:11Z",
-    "noDataState": "Alerting",
+    "noDataState": "OK",
     "execErrState": "Error",
     "for": "3m",
     "keep_firing_for": "0s",

--- a/backend/charts/monitoring/alerts/backend-sync.json
+++ b/backend/charts/monitoring/alerts/backend-sync.json
@@ -302,7 +302,7 @@
       }
     ],
     "updated": "2026-06-23T01:27:10Z",
-    "noDataState": "Alerting",
+    "noDataState": "OK",
     "execErrState": "Error",
     "for": "3m",
     "keep_firing_for": "0s",

--- a/backend/charts/monitoring/alerts/backend.json
+++ b/backend/charts/monitoring/alerts/backend.json
@@ -305,7 +305,7 @@
       }
     ],
     "updated": "2026-06-23T01:27:10Z",
-    "noDataState": "Alerting",
+    "noDataState": "OK",
     "execErrState": "Error",
     "for": "3m",
     "keep_firing_for": "0s",


### PR DESCRIPTION
## Summary
- Fix 3 Stackdriver-based 5XX alert rules that fire false positives when there are zero 5XX errors
- Change `noDataState` from `"Alerting"` to `"OK"` for backend, backend-integration, and backend-sync 5XX rules

## Root Cause
Stackdriver queries filtered by `response_code_class = "500"` return **no data** when there are zero 5XX errors. With `noDataState: "Alerting"`, Grafana treats no-data as an alert condition and fires with sentinel value `-1`. This is the firing alert mon reported: "Backend - 5XX error rate is high" with value -1.

Prometheus-based 5XX rules are not affected because they use `or vector(0)` to return 0 instead of no-data. Stackdriver queries cannot use `or vector(0)`.

## Changes
| File | UID | Rule Title |
|------|-----|------------|
| `backend.json` | `cew4jcnpa68sga` | Backend - 5XX error rate is high |
| `backend-integration.json` | `eew96o25qztvkf` | Backend-integration - 5XX error rate is high |
| `backend-sync.json` | `cew97uqu791q8a` | Backend-sync - 5XX error rate is high |

Each: `noDataState: "Alerting"` → `noDataState: "OK"`

## Test plan
- [ ] JSON validation passes (`python3 -m json.tool` on all 3 files)
- [ ] No remaining `noDataState: "Alerting"` in the 3 changed files
- [ ] Deploy to Grafana and verify the firing alert resolves
- [ ] Verify 5XX alerts still fire correctly when actual 5XX errors occur (non-empty Stackdriver response)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9567?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

