### PR TITLE
app: on-device storage usage indicator on Auto Sync page (firmware 3.0.20+)

### DIFF
--- a/app/analysis_baseline.json
+++ b/app/analysis_baseline.json
@@ -6,7 +6,7 @@
   "constant_identifier_names": 8,
   "curly_braces_in_flow_control_structures": 6,
   "dangling_library_doc_comments": 1,
-  "depend_on_referenced_packages": 4,
+  "depend_on_referenced_packages": 6,
   "deprecated_member_use": 34,
   "experimental_member_use": 13,
   "library_private_types_in_public_api": 4,
@@ -25,7 +25,7 @@
   "sort_child_properties_last": 2,
   "unnecessary_brace_in_string_interps": 13,
   "unnecessary_getters_setters": 1,
-  "unnecessary_import": 12,
+  "unnecessary_import": 13,
   "unnecessary_string_interpolations": 2,
   "unnecessary_to_list_in_spreads": 4,
   "use_super_parameters": 6

--- a/app/lib/l10n/app_ar.arb
+++ b/app/lib/l10n/app_ar.arb
@@ -3110,5 +3110,10 @@
                 "type": "String"
             }
         }
-    }
+    },
+    "deviceStorageTitle": "مساحة تخزين الجهاز",
+    "deviceStoragePercentFull": "ممتلئ {percent}%",
+    "deviceStorageUsedOfTotal": "{used} من {total} مستخدمة",
+    "deviceStorageFree": "{free} متاحة",
+    "deviceStorageNearlyFull": "الجهاز ممتلئ تقريبًا — قم بالمزامنة لتحرير مساحة."
 }

--- a/app/lib/l10n/app_be.arb
+++ b/app/lib/l10n/app_be.arb
@@ -10721,5 +10721,10 @@
                 "type": "String"
             }
         }
-    }
+    },
+    "deviceStorageTitle": "Сховішча прылады",
+    "deviceStoragePercentFull": "запоўнена {percent}%",
+    "deviceStorageUsedOfTotal": "{used} з {total} выкарыстана",
+    "deviceStorageFree": "{free} вольна",
+    "deviceStorageNearlyFull": "Прылада амаль запоўнена — сінхранізуйце, каб вызваліць месца."
 }

--- a/app/lib/l10n/app_bg.arb
+++ b/app/lib/l10n/app_bg.arb
@@ -3112,5 +3112,10 @@
                 "type": "String"
             }
         }
-    }
+    },
+    "deviceStorageTitle": "Памет на устройството",
+    "deviceStoragePercentFull": "{percent}% запълнена",
+    "deviceStorageUsedOfTotal": "{used} от {total} използвани",
+    "deviceStorageFree": "{free} свободни",
+    "deviceStorageNearlyFull": "Устройството е почти пълно — синхронизирайте, за да освободите място."
 }

--- a/app/lib/l10n/app_bn.arb
+++ b/app/lib/l10n/app_bn.arb
@@ -10721,5 +10721,10 @@
                 "type": "String"
             }
         }
-    }
+    },
+    "deviceStorageTitle": "ডিভাইস স্টোরেজ",
+    "deviceStoragePercentFull": "{percent}% পূর্ণ",
+    "deviceStorageUsedOfTotal": "{total}-এর মধ্যে {used} ব্যবহৃত",
+    "deviceStorageFree": "{free} খালি",
+    "deviceStorageNearlyFull": "ডিভাইস প্রায় পূর্ণ — জায়গা খালি করতে সিঙ্ক করুন।"
 }

--- a/app/lib/l10n/app_bs.arb
+++ b/app/lib/l10n/app_bs.arb
@@ -10721,5 +10721,10 @@
                 "type": "String"
             }
         }
-    }
+    },
+    "deviceStorageTitle": "Pohrana uređaja",
+    "deviceStoragePercentFull": "{percent}% popunjeno",
+    "deviceStorageUsedOfTotal": "{used} od {total} iskorišteno",
+    "deviceStorageFree": "{free} slobodno",
+    "deviceStorageNearlyFull": "Uređaj je gotovo pun — sinkronizirajte da oslobodite prostor."
 }

--- a/app/lib/l10n/app_ca.arb
+++ b/app/lib/l10n/app_ca.arb
@@ -3112,5 +3112,10 @@
                 "type": "String"
             }
         }
-    }
+    },
+    "deviceStorageTitle": "Emmagatzematge del dispositiu",
+    "deviceStoragePercentFull": "{percent}% ple",
+    "deviceStorageUsedOfTotal": "{used} de {total} utilitzat",
+    "deviceStorageFree": "{free} lliure",
+    "deviceStorageNearlyFull": "El dispositiu és gairebé ple — sincronitza per alliberar espai."
 }

--- a/app/lib/l10n/app_cs.arb
+++ b/app/lib/l10n/app_cs.arb
@@ -3112,5 +3112,10 @@
                 "type": "String"
             }
         }
-    }
+    },
+    "deviceStorageTitle": "Úložiště zařízení",
+    "deviceStoragePercentFull": "{percent}% zaplněno",
+    "deviceStorageUsedOfTotal": "{used} z {total} využito",
+    "deviceStorageFree": "{free} volných",
+    "deviceStorageNearlyFull": "Zařízení je téměř plné — synchronizujte pro uvolnění místa."
 }

--- a/app/lib/l10n/app_da.arb
+++ b/app/lib/l10n/app_da.arb
@@ -3152,5 +3152,10 @@
                 "type": "String"
             }
         }
-    }
+    },
+    "deviceStorageTitle": "Enhedens lager",
+    "deviceStoragePercentFull": "{percent}% fyldt",
+    "deviceStorageUsedOfTotal": "{used} af {total} brugt",
+    "deviceStorageFree": "{free} ledig",
+    "deviceStorageNearlyFull": "Enheden er næsten fuld — synkronisér for at frigøre plads."
 }

--- a/app/lib/l10n/app_de.arb
+++ b/app/lib/l10n/app_de.arb
@@ -3111,5 +3111,10 @@
                 "type": "String"
             }
         }
-    }
+    },
+    "deviceStorageTitle": "Gerätespeicher",
+    "deviceStoragePercentFull": "{percent}% belegt",
+    "deviceStorageUsedOfTotal": "{used} von {total} belegt",
+    "deviceStorageFree": "{free} frei",
+    "deviceStorageNearlyFull": "Gerät fast voll — synchronisieren, um Speicher freizugeben."
 }

--- a/app/lib/l10n/app_el.arb
+++ b/app/lib/l10n/app_el.arb
@@ -3143,5 +3143,10 @@
                 "type": "String"
             }
         }
-    }
+    },
+    "deviceStorageTitle": "Αποθηκευτικός χώρος συσκευής",
+    "deviceStoragePercentFull": "{percent}% γεμάτο",
+    "deviceStorageUsedOfTotal": "{used} από {total} σε χρήση",
+    "deviceStorageFree": "{free} ελεύθερα",
+    "deviceStorageNearlyFull": "Η συσκευή είναι σχεδόν γεμάτη — συγχρονίστε για να ελευθερώσετε χώρο."
 }

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -11280,5 +11280,43 @@
                 "type": "String"
             }
         }
+    },
+    "deviceStorageTitle": "Device Storage",
+    "@deviceStorageTitle": {
+        "description": "Title of the on-device storage usage card on the Auto Sync page"
+    },
+    "deviceStoragePercentFull": "{percent}% full",
+    "@deviceStoragePercentFull": {
+        "description": "Percentage of on-device storage used",
+        "placeholders": {
+            "percent": {
+                "type": "int"
+            }
+        }
+    },
+    "deviceStorageUsedOfTotal": "{used} of {total} used",
+    "@deviceStorageUsedOfTotal": {
+        "description": "Used vs total on-device storage, e.g. 338 MB of 469 MB used",
+        "placeholders": {
+            "used": {
+                "type": "String"
+            },
+            "total": {
+                "type": "String"
+            }
+        }
+    },
+    "deviceStorageFree": "{free} free",
+    "@deviceStorageFree": {
+        "description": "Amount of free on-device storage, e.g. 131 MB free",
+        "placeholders": {
+            "free": {
+                "type": "String"
+            }
+        }
+    },
+    "deviceStorageNearlyFull": "Device nearly full — sync to free space.",
+    "@deviceStorageNearlyFull": {
+        "description": "Warning shown when on-device storage is 95% or more full"
     }
 }

--- a/app/lib/l10n/app_es.arb
+++ b/app/lib/l10n/app_es.arb
@@ -3144,5 +3144,10 @@
                 "type": "String"
             }
         }
-    }
+    },
+    "deviceStorageTitle": "Almacenamiento del dispositivo",
+    "deviceStoragePercentFull": "{percent}% lleno",
+    "deviceStorageUsedOfTotal": "{used} de {total} usado",
+    "deviceStorageFree": "{free} libre",
+    "deviceStorageNearlyFull": "El dispositivo está casi lleno: sincroniza para liberar espacio."
 }

--- a/app/lib/l10n/app_et.arb
+++ b/app/lib/l10n/app_et.arb
@@ -3143,5 +3143,10 @@
                 "type": "String"
             }
         }
-    }
+    },
+    "deviceStorageTitle": "Seadme salvestusruum",
+    "deviceStoragePercentFull": "{percent}% täis",
+    "deviceStorageUsedOfTotal": "{used} / {total} kasutatud",
+    "deviceStorageFree": "{free} vaba",
+    "deviceStorageNearlyFull": "Seade on peaaegu täis — sünkroonige ruumi vabastamiseks."
 }

--- a/app/lib/l10n/app_fa.arb
+++ b/app/lib/l10n/app_fa.arb
@@ -10721,5 +10721,10 @@
                 "type": "String"
             }
         }
-    }
+    },
+    "deviceStorageTitle": "فضای ذخیره‌سازی دستگاه",
+    "deviceStoragePercentFull": "{percent}٪ پر",
+    "deviceStorageUsedOfTotal": "{used} از {total} استفاده‌شده",
+    "deviceStorageFree": "{free} آزاد",
+    "deviceStorageNearlyFull": "دستگاه تقریباً پر است — برای آزادسازی فضا همگام‌سازی کنید."
 }

--- a/app/lib/l10n/app_fi.arb
+++ b/app/lib/l10n/app_fi.arb
@@ -3143,5 +3143,10 @@
                 "type": "String"
             }
         }
-    }
+    },
+    "deviceStorageTitle": "Laitteen tallennustila",
+    "deviceStoragePercentFull": "{percent} % täynnä",
+    "deviceStorageUsedOfTotal": "{used} / {total} käytössä",
+    "deviceStorageFree": "{free} vapaana",
+    "deviceStorageNearlyFull": "Laite on lähes täynnä — synkronoi vapauttaaksesi tilaa."
 }

--- a/app/lib/l10n/app_fr.arb
+++ b/app/lib/l10n/app_fr.arb
@@ -3178,5 +3178,10 @@
                 "type": "String"
             }
         }
-    }
+    },
+    "deviceStorageTitle": "Stockage de l'appareil",
+    "deviceStoragePercentFull": "{percent} % plein",
+    "deviceStorageUsedOfTotal": "{used} sur {total} utilisés",
+    "deviceStorageFree": "{free} libre",
+    "deviceStorageNearlyFull": "Appareil presque plein — synchronisez pour libérer de l'espace."
 }

--- a/app/lib/l10n/app_he.arb
+++ b/app/lib/l10n/app_he.arb
@@ -10721,5 +10721,10 @@
                 "type": "String"
             }
         }
-    }
+    },
+    "deviceStorageTitle": "אחסון המכשיר",
+    "deviceStoragePercentFull": "{percent}% מלא",
+    "deviceStorageUsedOfTotal": "{used} מתוך {total} בשימוש",
+    "deviceStorageFree": "{free} פנוי",
+    "deviceStorageNearlyFull": "המכשיר כמעט מלא — סנכרן כדי לפנות מקום."
 }

--- a/app/lib/l10n/app_hi.arb
+++ b/app/lib/l10n/app_hi.arb
@@ -3144,5 +3144,10 @@
                 "type": "String"
             }
         }
-    }
+    },
+    "deviceStorageTitle": "डिवाइस स्टोरेज",
+    "deviceStoragePercentFull": "{percent}% भरा",
+    "deviceStorageUsedOfTotal": "{total} में से {used} उपयोग किया गया",
+    "deviceStorageFree": "{free} खाली",
+    "deviceStorageNearlyFull": "डिवाइस लगभग भर गया है — स्थान खाली करने के लिए सिंक करें।"
 }

--- a/app/lib/l10n/app_hr.arb
+++ b/app/lib/l10n/app_hr.arb
@@ -10721,5 +10721,10 @@
                 "type": "String"
             }
         }
-    }
+    },
+    "deviceStorageTitle": "Pohrana uređaja",
+    "deviceStoragePercentFull": "{percent}% popunjeno",
+    "deviceStorageUsedOfTotal": "{used} od {total} iskorišteno",
+    "deviceStorageFree": "{free} slobodno",
+    "deviceStorageNearlyFull": "Uređaj je gotovo pun — sinkronizirajte kako biste oslobodili prostor."
 }

--- a/app/lib/l10n/app_hu.arb
+++ b/app/lib/l10n/app_hu.arb
@@ -3239,5 +3239,10 @@
                 "type": "String"
             }
         }
-    }
+    },
+    "deviceStorageTitle": "Eszköz tárhelye",
+    "deviceStoragePercentFull": "{percent}% megtelt",
+    "deviceStorageUsedOfTotal": "{used} / {total} felhasználva",
+    "deviceStorageFree": "{free} szabad",
+    "deviceStorageNearlyFull": "Az eszköz majdnem tele van — szinkronizáljon a hely felszabadításához."
 }

--- a/app/lib/l10n/app_id.arb
+++ b/app/lib/l10n/app_id.arb
@@ -3185,5 +3185,10 @@
                 "type": "String"
             }
         }
-    }
+    },
+    "deviceStorageTitle": "Penyimpanan perangkat",
+    "deviceStoragePercentFull": "{percent}% penuh",
+    "deviceStorageUsedOfTotal": "{used} dari {total} terpakai",
+    "deviceStorageFree": "{free} tersisa",
+    "deviceStorageNearlyFull": "Perangkat hampir penuh — sinkronkan untuk mengosongkan ruang."
 }

--- a/app/lib/l10n/app_it.arb
+++ b/app/lib/l10n/app_it.arb
@@ -3143,5 +3143,10 @@
                 "type": "String"
             }
         }
-    }
+    },
+    "deviceStorageTitle": "Archiviazione del dispositivo",
+    "deviceStoragePercentFull": "{percent}% pieno",
+    "deviceStorageUsedOfTotal": "{used} di {total} utilizzati",
+    "deviceStorageFree": "{free} liberi",
+    "deviceStorageNearlyFull": "Dispositivo quasi pieno — sincronizza per liberare spazio."
 }

--- a/app/lib/l10n/app_ja.arb
+++ b/app/lib/l10n/app_ja.arb
@@ -3144,5 +3144,10 @@
                 "type": "String"
             }
         }
-    }
+    },
+    "deviceStorageTitle": "デバイスのストレージ",
+    "deviceStoragePercentFull": "{percent}% 使用済み",
+    "deviceStorageUsedOfTotal": "{total} 中 {used} を使用",
+    "deviceStorageFree": "空き {free}",
+    "deviceStorageNearlyFull": "デバイスの空き容量がわずかです — 同期して空き容量を確保してください。"
 }

--- a/app/lib/l10n/app_kn.arb
+++ b/app/lib/l10n/app_kn.arb
@@ -10721,5 +10721,10 @@
                 "type": "String"
             }
         }
-    }
+    },
+    "deviceStorageTitle": "ಸಾಧನ ಸಂಗ್ರಹಣೆ",
+    "deviceStoragePercentFull": "{percent}% ತುಂಬಿದೆ",
+    "deviceStorageUsedOfTotal": "{total} ರಲ್ಲಿ {used} ಬಳಸಲಾಗಿದೆ",
+    "deviceStorageFree": "{free} ಖಾಲಿ",
+    "deviceStorageNearlyFull": "ಸಾಧನ ಬಹುತೇಕ ತುಂಬಿದೆ — ಸ್ಥಳವನ್ನು ಮುಕ್ತಗೊಳಿಸಲು ಸಿಂಕ್ ಮಾಡಿ."
 }

--- a/app/lib/l10n/app_ko.arb
+++ b/app/lib/l10n/app_ko.arb
@@ -3143,5 +3143,10 @@
                 "type": "String"
             }
         }
-    }
+    },
+    "deviceStorageTitle": "기기 저장 공간",
+    "deviceStoragePercentFull": "{percent}% 사용 중",
+    "deviceStorageUsedOfTotal": "{total} 중 {used} 사용",
+    "deviceStorageFree": "{free} 남음",
+    "deviceStorageNearlyFull": "기기가 거의 가득 찼습니다 — 동기화하여 공간을 확보하세요."
 }

--- a/app/lib/l10n/app_localizations.dart
+++ b/app/lib/l10n/app_localizations.dart
@@ -186,7 +186,7 @@ abstract class AppLocalizations {
     Locale('uk'),
     Locale('ur'),
     Locale('vi'),
-    Locale('zh'),
+    Locale('zh')
   ];
 
   /// Message shown after an expired authenticated session returns the user to sign-in
@@ -8935,10 +8935,7 @@ abstract class AppLocalizations {
   ///
   /// In en, this message translates to:
   /// **'{accessDescription} and is {triggerDescription}.'**
-  String accessesAndTriggeredBy(
-    String accessDescription,
-    String triggerDescription,
-  );
+  String accessesAndTriggeredBy(String accessDescription, String triggerDescription);
 
   /// Sentence starting with 'Is' for trigger description
   ///
@@ -17945,7 +17942,7 @@ class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> 
         'uk',
         'ur',
         'vi',
-        'zh',
+        'zh'
       ].contains(locale.languageCode);
 
   @override
@@ -18055,10 +18052,8 @@ AppLocalizations lookupAppLocalizations(Locale locale) {
       return AppLocalizationsZh();
   }
 
-  throw FlutterError(
-    'AppLocalizations.delegate failed to load unsupported locale "$locale". This is likely '
-    'an issue with the localizations generation tool. Please file an issue '
-    'on GitHub with a reproducible sample app and the gen-l10n configuration '
-    'that was used.',
-  );
+  throw FlutterError('AppLocalizations.delegate failed to load unsupported locale "$locale". This is likely '
+      'an issue with the localizations generation tool. Please file an issue '
+      'on GitHub with a reproducible sample app and the gen-l10n configuration '
+      'that was used.');
 }

--- a/app/lib/l10n/app_localizations.dart
+++ b/app/lib/l10n/app_localizations.dart
@@ -186,7 +186,7 @@ abstract class AppLocalizations {
     Locale('uk'),
     Locale('ur'),
     Locale('vi'),
-    Locale('zh')
+    Locale('zh'),
   ];
 
   /// Message shown after an expired authenticated session returns the user to sign-in
@@ -8935,7 +8935,10 @@ abstract class AppLocalizations {
   ///
   /// In en, this message translates to:
   /// **'{accessDescription} and is {triggerDescription}.'**
-  String accessesAndTriggeredBy(String accessDescription, String triggerDescription);
+  String accessesAndTriggeredBy(
+    String accessDescription,
+    String triggerDescription,
+  );
 
   /// Sentence starting with 'Is' for trigger description
   ///
@@ -17852,6 +17855,36 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Error connecting to Ray-Ban Meta: {error}'**
   String errorConnectingRayBanMeta(String error);
+
+  /// Title of the on-device storage usage card on the Auto Sync page
+  ///
+  /// In en, this message translates to:
+  /// **'Device Storage'**
+  String get deviceStorageTitle;
+
+  /// Percentage of on-device storage used
+  ///
+  /// In en, this message translates to:
+  /// **'{percent}% full'**
+  String deviceStoragePercentFull(int percent);
+
+  /// Used vs total on-device storage, e.g. 338 MB of 469 MB used
+  ///
+  /// In en, this message translates to:
+  /// **'{used} of {total} used'**
+  String deviceStorageUsedOfTotal(String used, String total);
+
+  /// Amount of free on-device storage, e.g. 131 MB free
+  ///
+  /// In en, this message translates to:
+  /// **'{free} free'**
+  String deviceStorageFree(String free);
+
+  /// Warning shown when on-device storage is 95% or more full
+  ///
+  /// In en, this message translates to:
+  /// **'Device nearly full — sync to free space.'**
+  String get deviceStorageNearlyFull;
 }
 
 class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {
@@ -17912,7 +17945,7 @@ class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> 
         'uk',
         'ur',
         'vi',
-        'zh'
+        'zh',
       ].contains(locale.languageCode);
 
   @override
@@ -18022,8 +18055,10 @@ AppLocalizations lookupAppLocalizations(Locale locale) {
       return AppLocalizationsZh();
   }
 
-  throw FlutterError('AppLocalizations.delegate failed to load unsupported locale "$locale". This is likely '
-      'an issue with the localizations generation tool. Please file an issue '
-      'on GitHub with a reproducible sample app and the gen-l10n configuration '
-      'that was used.');
+  throw FlutterError(
+    'AppLocalizations.delegate failed to load unsupported locale "$locale". This is likely '
+    'an issue with the localizations generation tool. Please file an issue '
+    'on GitHub with a reproducible sample app and the gen-l10n configuration '
+    'that was used.',
+  );
 }

--- a/app/lib/l10n/app_localizations_ar.dart
+++ b/app/lib/l10n/app_localizations_ar.dart
@@ -4659,10 +4659,7 @@ class AppLocalizationsAr extends AppLocalizations {
   }
 
   @override
-  String accessesAndTriggeredBy(
-    String accessDescription,
-    String triggerDescription,
-  ) {
+  String accessesAndTriggeredBy(String accessDescription, String triggerDescription) {
     return '$accessDescription و$triggerDescription.';
   }
 

--- a/app/lib/l10n/app_localizations_ar.dart
+++ b/app/lib/l10n/app_localizations_ar.dart
@@ -4659,7 +4659,10 @@ class AppLocalizationsAr extends AppLocalizations {
   }
 
   @override
-  String accessesAndTriggeredBy(String accessDescription, String triggerDescription) {
+  String accessesAndTriggeredBy(
+    String accessDescription,
+    String triggerDescription,
+  ) {
     return '$accessDescription و$triggerDescription.';
   }
 
@@ -9516,4 +9519,25 @@ class AppLocalizationsAr extends AppLocalizations {
   String errorConnectingRayBanMeta(String error) {
     return 'خطأ في الاتصال بـ Ray-Ban Meta: $error';
   }
+
+  @override
+  String get deviceStorageTitle => 'مساحة تخزين الجهاز';
+
+  @override
+  String deviceStoragePercentFull(int percent) {
+    return 'ممتلئ $percent%';
+  }
+
+  @override
+  String deviceStorageUsedOfTotal(String used, String total) {
+    return '$used من $total مستخدمة';
+  }
+
+  @override
+  String deviceStorageFree(String free) {
+    return '$free متاحة';
+  }
+
+  @override
+  String get deviceStorageNearlyFull => 'الجهاز ممتلئ تقريبًا — قم بالمزامنة لتحرير مساحة.';
 }

--- a/app/lib/l10n/app_localizations_be.dart
+++ b/app/lib/l10n/app_localizations_be.dart
@@ -4708,10 +4708,7 @@ class AppLocalizationsBe extends AppLocalizations {
   }
 
   @override
-  String accessesAndTriggeredBy(
-    String accessDescription,
-    String triggerDescription,
-  ) {
+  String accessesAndTriggeredBy(String accessDescription, String triggerDescription) {
     return '$accessDescription і запушчаны $triggerDescription.';
   }
 

--- a/app/lib/l10n/app_localizations_be.dart
+++ b/app/lib/l10n/app_localizations_be.dart
@@ -4708,7 +4708,10 @@ class AppLocalizationsBe extends AppLocalizations {
   }
 
   @override
-  String accessesAndTriggeredBy(String accessDescription, String triggerDescription) {
+  String accessesAndTriggeredBy(
+    String accessDescription,
+    String triggerDescription,
+  ) {
     return '$accessDescription і запушчаны $triggerDescription.';
   }
 
@@ -9604,4 +9607,25 @@ class AppLocalizationsBe extends AppLocalizations {
   String errorConnectingRayBanMeta(String error) {
     return 'Памылка падключэння да Ray-Ban Meta: $error';
   }
+
+  @override
+  String get deviceStorageTitle => 'Сховішча прылады';
+
+  @override
+  String deviceStoragePercentFull(int percent) {
+    return 'запоўнена $percent%';
+  }
+
+  @override
+  String deviceStorageUsedOfTotal(String used, String total) {
+    return '$used з $total выкарыстана';
+  }
+
+  @override
+  String deviceStorageFree(String free) {
+    return '$free вольна';
+  }
+
+  @override
+  String get deviceStorageNearlyFull => 'Прылада амаль запоўнена — сінхранізуйце, каб вызваліць месца.';
 }

--- a/app/lib/l10n/app_localizations_bg.dart
+++ b/app/lib/l10n/app_localizations_bg.dart
@@ -4709,10 +4709,7 @@ class AppLocalizationsBg extends AppLocalizations {
   }
 
   @override
-  String accessesAndTriggeredBy(
-    String accessDescription,
-    String triggerDescription,
-  ) {
+  String accessesAndTriggeredBy(String accessDescription, String triggerDescription) {
     return '$accessDescription и е $triggerDescription.';
   }
 

--- a/app/lib/l10n/app_localizations_bg.dart
+++ b/app/lib/l10n/app_localizations_bg.dart
@@ -4709,7 +4709,10 @@ class AppLocalizationsBg extends AppLocalizations {
   }
 
   @override
-  String accessesAndTriggeredBy(String accessDescription, String triggerDescription) {
+  String accessesAndTriggeredBy(
+    String accessDescription,
+    String triggerDescription,
+  ) {
     return '$accessDescription и е $triggerDescription.';
   }
 
@@ -9610,4 +9613,25 @@ class AppLocalizationsBg extends AppLocalizations {
   String errorConnectingRayBanMeta(String error) {
     return 'Грешка при свързване с Ray-Ban Meta: $error';
   }
+
+  @override
+  String get deviceStorageTitle => 'Памет на устройството';
+
+  @override
+  String deviceStoragePercentFull(int percent) {
+    return '$percent% запълнена';
+  }
+
+  @override
+  String deviceStorageUsedOfTotal(String used, String total) {
+    return '$used от $total използвани';
+  }
+
+  @override
+  String deviceStorageFree(String free) {
+    return '$free свободни';
+  }
+
+  @override
+  String get deviceStorageNearlyFull => 'Устройството е почти пълно — синхронизирайте, за да освободите място.';
 }

--- a/app/lib/l10n/app_localizations_bn.dart
+++ b/app/lib/l10n/app_localizations_bn.dart
@@ -4701,10 +4701,7 @@ class AppLocalizationsBn extends AppLocalizations {
   }
 
   @override
-  String accessesAndTriggeredBy(
-    String accessDescription,
-    String triggerDescription,
-  ) {
+  String accessesAndTriggeredBy(String accessDescription, String triggerDescription) {
     return '$accessDescription এবং $triggerDescription দ্বারা ট্রিগার।';
   }
 

--- a/app/lib/l10n/app_localizations_bn.dart
+++ b/app/lib/l10n/app_localizations_bn.dart
@@ -4701,7 +4701,10 @@ class AppLocalizationsBn extends AppLocalizations {
   }
 
   @override
-  String accessesAndTriggeredBy(String accessDescription, String triggerDescription) {
+  String accessesAndTriggeredBy(
+    String accessDescription,
+    String triggerDescription,
+  ) {
     return '$accessDescription এবং $triggerDescription দ্বারা ট্রিগার।';
   }
 
@@ -9579,4 +9582,25 @@ class AppLocalizationsBn extends AppLocalizations {
   String errorConnectingRayBanMeta(String error) {
     return 'Ray-Ban Meta-তে সংযোগ করতে ত্রুটি: $error';
   }
+
+  @override
+  String get deviceStorageTitle => 'ডিভাইস স্টোরেজ';
+
+  @override
+  String deviceStoragePercentFull(int percent) {
+    return '$percent% পূর্ণ';
+  }
+
+  @override
+  String deviceStorageUsedOfTotal(String used, String total) {
+    return '$total-এর মধ্যে $used ব্যবহৃত';
+  }
+
+  @override
+  String deviceStorageFree(String free) {
+    return '$free খালি';
+  }
+
+  @override
+  String get deviceStorageNearlyFull => 'ডিভাইস প্রায় পূর্ণ — জায়গা খালি করতে সিঙ্ক করুন।';
 }

--- a/app/lib/l10n/app_localizations_bs.dart
+++ b/app/lib/l10n/app_localizations_bs.dart
@@ -4706,10 +4706,7 @@ class AppLocalizationsBs extends AppLocalizations {
   }
 
   @override
-  String accessesAndTriggeredBy(
-    String accessDescription,
-    String triggerDescription,
-  ) {
+  String accessesAndTriggeredBy(String accessDescription, String triggerDescription) {
     return '$accessDescription i pokrenuto sa $triggerDescription.';
   }
 

--- a/app/lib/l10n/app_localizations_bs.dart
+++ b/app/lib/l10n/app_localizations_bs.dart
@@ -4706,7 +4706,10 @@ class AppLocalizationsBs extends AppLocalizations {
   }
 
   @override
-  String accessesAndTriggeredBy(String accessDescription, String triggerDescription) {
+  String accessesAndTriggeredBy(
+    String accessDescription,
+    String triggerDescription,
+  ) {
     return '$accessDescription i pokrenuto sa $triggerDescription.';
   }
 
@@ -9600,4 +9603,25 @@ class AppLocalizationsBs extends AppLocalizations {
   String errorConnectingRayBanMeta(String error) {
     return 'Greška pri povezivanju s Ray-Ban Meta: $error';
   }
+
+  @override
+  String get deviceStorageTitle => 'Pohrana uređaja';
+
+  @override
+  String deviceStoragePercentFull(int percent) {
+    return '$percent% popunjeno';
+  }
+
+  @override
+  String deviceStorageUsedOfTotal(String used, String total) {
+    return '$used od $total iskorišteno';
+  }
+
+  @override
+  String deviceStorageFree(String free) {
+    return '$free slobodno';
+  }
+
+  @override
+  String get deviceStorageNearlyFull => 'Uređaj je gotovo pun — sinkronizirajte da oslobodite prostor.';
 }

--- a/app/lib/l10n/app_localizations_ca.dart
+++ b/app/lib/l10n/app_localizations_ca.dart
@@ -4724,7 +4724,10 @@ class AppLocalizationsCa extends AppLocalizations {
   }
 
   @override
-  String accessesAndTriggeredBy(String accessDescription, String triggerDescription) {
+  String accessesAndTriggeredBy(
+    String accessDescription,
+    String triggerDescription,
+  ) {
     return '$accessDescription i és $triggerDescription.';
   }
 
@@ -9629,4 +9632,25 @@ class AppLocalizationsCa extends AppLocalizations {
   String errorConnectingRayBanMeta(String error) {
     return 'Error en connectar amb Ray-Ban Meta: $error';
   }
+
+  @override
+  String get deviceStorageTitle => 'Emmagatzematge del dispositiu';
+
+  @override
+  String deviceStoragePercentFull(int percent) {
+    return '$percent% ple';
+  }
+
+  @override
+  String deviceStorageUsedOfTotal(String used, String total) {
+    return '$used de $total utilitzat';
+  }
+
+  @override
+  String deviceStorageFree(String free) {
+    return '$free lliure';
+  }
+
+  @override
+  String get deviceStorageNearlyFull => 'El dispositiu és gairebé ple — sincronitza per alliberar espai.';
 }

--- a/app/lib/l10n/app_localizations_ca.dart
+++ b/app/lib/l10n/app_localizations_ca.dart
@@ -4724,10 +4724,7 @@ class AppLocalizationsCa extends AppLocalizations {
   }
 
   @override
-  String accessesAndTriggeredBy(
-    String accessDescription,
-    String triggerDescription,
-  ) {
+  String accessesAndTriggeredBy(String accessDescription, String triggerDescription) {
     return '$accessDescription i és $triggerDescription.';
   }
 

--- a/app/lib/l10n/app_localizations_cs.dart
+++ b/app/lib/l10n/app_localizations_cs.dart
@@ -4689,10 +4689,7 @@ class AppLocalizationsCs extends AppLocalizations {
   }
 
   @override
-  String accessesAndTriggeredBy(
-    String accessDescription,
-    String triggerDescription,
-  ) {
+  String accessesAndTriggeredBy(String accessDescription, String triggerDescription) {
     return '$accessDescription a je $triggerDescription.';
   }
 

--- a/app/lib/l10n/app_localizations_cs.dart
+++ b/app/lib/l10n/app_localizations_cs.dart
@@ -4689,7 +4689,10 @@ class AppLocalizationsCs extends AppLocalizations {
   }
 
   @override
-  String accessesAndTriggeredBy(String accessDescription, String triggerDescription) {
+  String accessesAndTriggeredBy(
+    String accessDescription,
+    String triggerDescription,
+  ) {
     return '$accessDescription a je $triggerDescription.';
   }
 
@@ -9574,4 +9577,25 @@ class AppLocalizationsCs extends AppLocalizations {
   String errorConnectingRayBanMeta(String error) {
     return 'Chyba při připojování k Ray-Ban Meta: $error';
   }
+
+  @override
+  String get deviceStorageTitle => 'Úložiště zařízení';
+
+  @override
+  String deviceStoragePercentFull(int percent) {
+    return '$percent% zaplněno';
+  }
+
+  @override
+  String deviceStorageUsedOfTotal(String used, String total) {
+    return '$used z $total využito';
+  }
+
+  @override
+  String deviceStorageFree(String free) {
+    return '$free volných';
+  }
+
+  @override
+  String get deviceStorageNearlyFull => 'Zařízení je téměř plné — synchronizujte pro uvolnění místa.';
 }

--- a/app/lib/l10n/app_localizations_da.dart
+++ b/app/lib/l10n/app_localizations_da.dart
@@ -4681,10 +4681,7 @@ class AppLocalizationsDa extends AppLocalizations {
   }
 
   @override
-  String accessesAndTriggeredBy(
-    String accessDescription,
-    String triggerDescription,
-  ) {
+  String accessesAndTriggeredBy(String accessDescription, String triggerDescription) {
     return '$accessDescription og er $triggerDescription.';
   }
 

--- a/app/lib/l10n/app_localizations_da.dart
+++ b/app/lib/l10n/app_localizations_da.dart
@@ -4681,7 +4681,10 @@ class AppLocalizationsDa extends AppLocalizations {
   }
 
   @override
-  String accessesAndTriggeredBy(String accessDescription, String triggerDescription) {
+  String accessesAndTriggeredBy(
+    String accessDescription,
+    String triggerDescription,
+  ) {
     return '$accessDescription og er $triggerDescription.';
   }
 
@@ -9558,4 +9561,25 @@ class AppLocalizationsDa extends AppLocalizations {
   String errorConnectingRayBanMeta(String error) {
     return 'Fejl ved forbindelse til Ray-Ban Meta: $error';
   }
+
+  @override
+  String get deviceStorageTitle => 'Enhedens lager';
+
+  @override
+  String deviceStoragePercentFull(int percent) {
+    return '$percent% fyldt';
+  }
+
+  @override
+  String deviceStorageUsedOfTotal(String used, String total) {
+    return '$used af $total brugt';
+  }
+
+  @override
+  String deviceStorageFree(String free) {
+    return '$free ledig';
+  }
+
+  @override
+  String get deviceStorageNearlyFull => 'Enheden er næsten fuld — synkronisér for at frigøre plads.';
 }

--- a/app/lib/l10n/app_localizations_de.dart
+++ b/app/lib/l10n/app_localizations_de.dart
@@ -4733,7 +4733,10 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
-  String accessesAndTriggeredBy(String accessDescription, String triggerDescription) {
+  String accessesAndTriggeredBy(
+    String accessDescription,
+    String triggerDescription,
+  ) {
     return '$accessDescription und wird $triggerDescription.';
   }
 
@@ -9654,4 +9657,25 @@ class AppLocalizationsDe extends AppLocalizations {
   String errorConnectingRayBanMeta(String error) {
     return 'Fehler beim Verbinden mit Ray-Ban Meta: $error';
   }
+
+  @override
+  String get deviceStorageTitle => 'Gerätespeicher';
+
+  @override
+  String deviceStoragePercentFull(int percent) {
+    return '$percent% belegt';
+  }
+
+  @override
+  String deviceStorageUsedOfTotal(String used, String total) {
+    return '$used von $total belegt';
+  }
+
+  @override
+  String deviceStorageFree(String free) {
+    return '$free frei';
+  }
+
+  @override
+  String get deviceStorageNearlyFull => 'Gerät fast voll — synchronisieren, um Speicher freizugeben.';
 }

--- a/app/lib/l10n/app_localizations_de.dart
+++ b/app/lib/l10n/app_localizations_de.dart
@@ -4733,10 +4733,7 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
-  String accessesAndTriggeredBy(
-    String accessDescription,
-    String triggerDescription,
-  ) {
+  String accessesAndTriggeredBy(String accessDescription, String triggerDescription) {
     return '$accessDescription und wird $triggerDescription.';
   }
 

--- a/app/lib/l10n/app_localizations_el.dart
+++ b/app/lib/l10n/app_localizations_el.dart
@@ -4733,10 +4733,7 @@ class AppLocalizationsEl extends AppLocalizations {
   }
 
   @override
-  String accessesAndTriggeredBy(
-    String accessDescription,
-    String triggerDescription,
-  ) {
+  String accessesAndTriggeredBy(String accessDescription, String triggerDescription) {
     return '$accessDescription και είναι $triggerDescription.';
   }
 

--- a/app/lib/l10n/app_localizations_el.dart
+++ b/app/lib/l10n/app_localizations_el.dart
@@ -4733,7 +4733,10 @@ class AppLocalizationsEl extends AppLocalizations {
   }
 
   @override
-  String accessesAndTriggeredBy(String accessDescription, String triggerDescription) {
+  String accessesAndTriggeredBy(
+    String accessDescription,
+    String triggerDescription,
+  ) {
     return '$accessDescription και είναι $triggerDescription.';
   }
 
@@ -9642,4 +9645,25 @@ class AppLocalizationsEl extends AppLocalizations {
   String errorConnectingRayBanMeta(String error) {
     return 'Σφάλμα σύνδεσης με Ray-Ban Meta: $error';
   }
+
+  @override
+  String get deviceStorageTitle => 'Αποθηκευτικός χώρος συσκευής';
+
+  @override
+  String deviceStoragePercentFull(int percent) {
+    return '$percent% γεμάτο';
+  }
+
+  @override
+  String deviceStorageUsedOfTotal(String used, String total) {
+    return '$used από $total σε χρήση';
+  }
+
+  @override
+  String deviceStorageFree(String free) {
+    return '$free ελεύθερα';
+  }
+
+  @override
+  String get deviceStorageNearlyFull => 'Η συσκευή είναι σχεδόν γεμάτη — συγχρονίστε για να ελευθερώσετε χώρο.';
 }

--- a/app/lib/l10n/app_localizations_en.dart
+++ b/app/lib/l10n/app_localizations_en.dart
@@ -4698,10 +4698,7 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
-  String accessesAndTriggeredBy(
-    String accessDescription,
-    String triggerDescription,
-  ) {
+  String accessesAndTriggeredBy(String accessDescription, String triggerDescription) {
     return '$accessDescription and is $triggerDescription.';
   }
 

--- a/app/lib/l10n/app_localizations_en.dart
+++ b/app/lib/l10n/app_localizations_en.dart
@@ -4698,7 +4698,10 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
-  String accessesAndTriggeredBy(String accessDescription, String triggerDescription) {
+  String accessesAndTriggeredBy(
+    String accessDescription,
+    String triggerDescription,
+  ) {
     return '$accessDescription and is $triggerDescription.';
   }
 
@@ -9568,4 +9571,25 @@ class AppLocalizationsEn extends AppLocalizations {
   String errorConnectingRayBanMeta(String error) {
     return 'Error connecting to Ray-Ban Meta: $error';
   }
+
+  @override
+  String get deviceStorageTitle => 'Device Storage';
+
+  @override
+  String deviceStoragePercentFull(int percent) {
+    return '$percent% full';
+  }
+
+  @override
+  String deviceStorageUsedOfTotal(String used, String total) {
+    return '$used of $total used';
+  }
+
+  @override
+  String deviceStorageFree(String free) {
+    return '$free free';
+  }
+
+  @override
+  String get deviceStorageNearlyFull => 'Device nearly full — sync to free space.';
 }

--- a/app/lib/l10n/app_localizations_es.dart
+++ b/app/lib/l10n/app_localizations_es.dart
@@ -4690,10 +4690,7 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
-  String accessesAndTriggeredBy(
-    String accessDescription,
-    String triggerDescription,
-  ) {
+  String accessesAndTriggeredBy(String accessDescription, String triggerDescription) {
     return '$accessDescription y es $triggerDescription.';
   }
 

--- a/app/lib/l10n/app_localizations_es.dart
+++ b/app/lib/l10n/app_localizations_es.dart
@@ -4690,7 +4690,10 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
-  String accessesAndTriggeredBy(String accessDescription, String triggerDescription) {
+  String accessesAndTriggeredBy(
+    String accessDescription,
+    String triggerDescription,
+  ) {
     return '$accessDescription y es $triggerDescription.';
   }
 
@@ -9595,4 +9598,25 @@ class AppLocalizationsEs extends AppLocalizations {
   String errorConnectingRayBanMeta(String error) {
     return 'Error al conectar con Ray-Ban Meta: $error';
   }
+
+  @override
+  String get deviceStorageTitle => 'Almacenamiento del dispositivo';
+
+  @override
+  String deviceStoragePercentFull(int percent) {
+    return '$percent% lleno';
+  }
+
+  @override
+  String deviceStorageUsedOfTotal(String used, String total) {
+    return '$used de $total usado';
+  }
+
+  @override
+  String deviceStorageFree(String free) {
+    return '$free libre';
+  }
+
+  @override
+  String get deviceStorageNearlyFull => 'El dispositivo está casi lleno: sincroniza para liberar espacio.';
 }

--- a/app/lib/l10n/app_localizations_et.dart
+++ b/app/lib/l10n/app_localizations_et.dart
@@ -4694,10 +4694,7 @@ class AppLocalizationsEt extends AppLocalizations {
   }
 
   @override
-  String accessesAndTriggeredBy(
-    String accessDescription,
-    String triggerDescription,
-  ) {
+  String accessesAndTriggeredBy(String accessDescription, String triggerDescription) {
     return '$accessDescription ja on $triggerDescription.';
   }
 

--- a/app/lib/l10n/app_localizations_et.dart
+++ b/app/lib/l10n/app_localizations_et.dart
@@ -4694,7 +4694,10 @@ class AppLocalizationsEt extends AppLocalizations {
   }
 
   @override
-  String accessesAndTriggeredBy(String accessDescription, String triggerDescription) {
+  String accessesAndTriggeredBy(
+    String accessDescription,
+    String triggerDescription,
+  ) {
     return '$accessDescription ja on $triggerDescription.';
   }
 
@@ -9570,4 +9573,25 @@ class AppLocalizationsEt extends AppLocalizations {
   String errorConnectingRayBanMeta(String error) {
     return 'Viga Ray-Ban Metaga ühendamisel: $error';
   }
+
+  @override
+  String get deviceStorageTitle => 'Seadme salvestusruum';
+
+  @override
+  String deviceStoragePercentFull(int percent) {
+    return '$percent% täis';
+  }
+
+  @override
+  String deviceStorageUsedOfTotal(String used, String total) {
+    return '$used / $total kasutatud';
+  }
+
+  @override
+  String deviceStorageFree(String free) {
+    return '$free vaba';
+  }
+
+  @override
+  String get deviceStorageNearlyFull => 'Seade on peaaegu täis — sünkroonige ruumi vabastamiseks.';
 }

--- a/app/lib/l10n/app_localizations_fa.dart
+++ b/app/lib/l10n/app_localizations_fa.dart
@@ -4699,7 +4699,10 @@ class AppLocalizationsFa extends AppLocalizations {
   }
 
   @override
-  String accessesAndTriggeredBy(String accessDescription, String triggerDescription) {
+  String accessesAndTriggeredBy(
+    String accessDescription,
+    String triggerDescription,
+  ) {
     return '$accessDescription و $triggerDescription.';
   }
 
@@ -9575,4 +9578,25 @@ class AppLocalizationsFa extends AppLocalizations {
   String errorConnectingRayBanMeta(String error) {
     return 'خطا در اتصال به Ray-Ban Meta: $error';
   }
+
+  @override
+  String get deviceStorageTitle => 'فضای ذخیره‌سازی دستگاه';
+
+  @override
+  String deviceStoragePercentFull(int percent) {
+    return '$percent٪ پر';
+  }
+
+  @override
+  String deviceStorageUsedOfTotal(String used, String total) {
+    return '$used از $total استفاده‌شده';
+  }
+
+  @override
+  String deviceStorageFree(String free) {
+    return '$free آزاد';
+  }
+
+  @override
+  String get deviceStorageNearlyFull => 'دستگاه تقریباً پر است — برای آزادسازی فضا همگام‌سازی کنید.';
 }

--- a/app/lib/l10n/app_localizations_fa.dart
+++ b/app/lib/l10n/app_localizations_fa.dart
@@ -4699,10 +4699,7 @@ class AppLocalizationsFa extends AppLocalizations {
   }
 
   @override
-  String accessesAndTriggeredBy(
-    String accessDescription,
-    String triggerDescription,
-  ) {
+  String accessesAndTriggeredBy(String accessDescription, String triggerDescription) {
     return '$accessDescription و $triggerDescription.';
   }
 

--- a/app/lib/l10n/app_localizations_fi.dart
+++ b/app/lib/l10n/app_localizations_fi.dart
@@ -4695,7 +4695,10 @@ class AppLocalizationsFi extends AppLocalizations {
   }
 
   @override
-  String accessesAndTriggeredBy(String accessDescription, String triggerDescription) {
+  String accessesAndTriggeredBy(
+    String accessDescription,
+    String triggerDescription,
+  ) {
     return '$accessDescription ja on $triggerDescription.';
   }
 
@@ -9574,4 +9577,25 @@ class AppLocalizationsFi extends AppLocalizations {
   String errorConnectingRayBanMeta(String error) {
     return 'Virhe yhdistettäessä Ray-Ban Metaan: $error';
   }
+
+  @override
+  String get deviceStorageTitle => 'Laitteen tallennustila';
+
+  @override
+  String deviceStoragePercentFull(int percent) {
+    return '$percent % täynnä';
+  }
+
+  @override
+  String deviceStorageUsedOfTotal(String used, String total) {
+    return '$used / $total käytössä';
+  }
+
+  @override
+  String deviceStorageFree(String free) {
+    return '$free vapaana';
+  }
+
+  @override
+  String get deviceStorageNearlyFull => 'Laite on lähes täynnä — synkronoi vapauttaaksesi tilaa.';
 }

--- a/app/lib/l10n/app_localizations_fi.dart
+++ b/app/lib/l10n/app_localizations_fi.dart
@@ -4695,10 +4695,7 @@ class AppLocalizationsFi extends AppLocalizations {
   }
 
   @override
-  String accessesAndTriggeredBy(
-    String accessDescription,
-    String triggerDescription,
-  ) {
+  String accessesAndTriggeredBy(String accessDescription, String triggerDescription) {
     return '$accessDescription ja on $triggerDescription.';
   }
 

--- a/app/lib/l10n/app_localizations_fr.dart
+++ b/app/lib/l10n/app_localizations_fr.dart
@@ -4741,7 +4741,10 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
-  String accessesAndTriggeredBy(String accessDescription, String triggerDescription) {
+  String accessesAndTriggeredBy(
+    String accessDescription,
+    String triggerDescription,
+  ) {
     return '$accessDescription et est $triggerDescription.';
   }
 
@@ -9660,4 +9663,25 @@ class AppLocalizationsFr extends AppLocalizations {
   String errorConnectingRayBanMeta(String error) {
     return 'Erreur de connexion aux Ray-Ban Meta : $error';
   }
+
+  @override
+  String get deviceStorageTitle => 'Stockage de l\'appareil';
+
+  @override
+  String deviceStoragePercentFull(int percent) {
+    return '$percent % plein';
+  }
+
+  @override
+  String deviceStorageUsedOfTotal(String used, String total) {
+    return '$used sur $total utilisés';
+  }
+
+  @override
+  String deviceStorageFree(String free) {
+    return '$free libre';
+  }
+
+  @override
+  String get deviceStorageNearlyFull => 'Appareil presque plein — synchronisez pour libérer de l\'espace.';
 }

--- a/app/lib/l10n/app_localizations_fr.dart
+++ b/app/lib/l10n/app_localizations_fr.dart
@@ -4741,10 +4741,7 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
-  String accessesAndTriggeredBy(
-    String accessDescription,
-    String triggerDescription,
-  ) {
+  String accessesAndTriggeredBy(String accessDescription, String triggerDescription) {
     return '$accessDescription et est $triggerDescription.';
   }
 

--- a/app/lib/l10n/app_localizations_he.dart
+++ b/app/lib/l10n/app_localizations_he.dart
@@ -4659,10 +4659,7 @@ class AppLocalizationsHe extends AppLocalizations {
   }
 
   @override
-  String accessesAndTriggeredBy(
-    String accessDescription,
-    String triggerDescription,
-  ) {
+  String accessesAndTriggeredBy(String accessDescription, String triggerDescription) {
     return '$accessDescription ו-is $triggerDescription.';
   }
 

--- a/app/lib/l10n/app_localizations_he.dart
+++ b/app/lib/l10n/app_localizations_he.dart
@@ -4659,7 +4659,10 @@ class AppLocalizationsHe extends AppLocalizations {
   }
 
   @override
-  String accessesAndTriggeredBy(String accessDescription, String triggerDescription) {
+  String accessesAndTriggeredBy(
+    String accessDescription,
+    String triggerDescription,
+  ) {
     return '$accessDescription ו-is $triggerDescription.';
   }
 
@@ -9501,4 +9504,25 @@ class AppLocalizationsHe extends AppLocalizations {
   String errorConnectingRayBanMeta(String error) {
     return 'שגיאה בהתחברות ל-Ray-Ban Meta: $error';
   }
+
+  @override
+  String get deviceStorageTitle => 'אחסון המכשיר';
+
+  @override
+  String deviceStoragePercentFull(int percent) {
+    return '$percent% מלא';
+  }
+
+  @override
+  String deviceStorageUsedOfTotal(String used, String total) {
+    return '$used מתוך $total בשימוש';
+  }
+
+  @override
+  String deviceStorageFree(String free) {
+    return '$free פנוי';
+  }
+
+  @override
+  String get deviceStorageNearlyFull => 'המכשיר כמעט מלא — סנכרן כדי לפנות מקום.';
 }

--- a/app/lib/l10n/app_localizations_hi.dart
+++ b/app/lib/l10n/app_localizations_hi.dart
@@ -4670,10 +4670,7 @@ class AppLocalizationsHi extends AppLocalizations {
   }
 
   @override
-  String accessesAndTriggeredBy(
-    String accessDescription,
-    String triggerDescription,
-  ) {
+  String accessesAndTriggeredBy(String accessDescription, String triggerDescription) {
     return '$accessDescription और $triggerDescription।';
   }
 

--- a/app/lib/l10n/app_localizations_hi.dart
+++ b/app/lib/l10n/app_localizations_hi.dart
@@ -4670,7 +4670,10 @@ class AppLocalizationsHi extends AppLocalizations {
   }
 
   @override
-  String accessesAndTriggeredBy(String accessDescription, String triggerDescription) {
+  String accessesAndTriggeredBy(
+    String accessDescription,
+    String triggerDescription,
+  ) {
     return '$accessDescription और $triggerDescription।';
   }
 
@@ -9550,4 +9553,25 @@ class AppLocalizationsHi extends AppLocalizations {
   String errorConnectingRayBanMeta(String error) {
     return 'Ray-Ban Meta से कनेक्ट करने में त्रुटि: $error';
   }
+
+  @override
+  String get deviceStorageTitle => 'डिवाइस स्टोरेज';
+
+  @override
+  String deviceStoragePercentFull(int percent) {
+    return '$percent% भरा';
+  }
+
+  @override
+  String deviceStorageUsedOfTotal(String used, String total) {
+    return '$total में से $used उपयोग किया गया';
+  }
+
+  @override
+  String deviceStorageFree(String free) {
+    return '$free खाली';
+  }
+
+  @override
+  String get deviceStorageNearlyFull => 'डिवाइस लगभग भर गया है — स्थान खाली करने के लिए सिंक करें।';
 }

--- a/app/lib/l10n/app_localizations_hr.dart
+++ b/app/lib/l10n/app_localizations_hr.dart
@@ -4713,10 +4713,7 @@ class AppLocalizationsHr extends AppLocalizations {
   }
 
   @override
-  String accessesAndTriggeredBy(
-    String accessDescription,
-    String triggerDescription,
-  ) {
+  String accessesAndTriggeredBy(String accessDescription, String triggerDescription) {
     return '$accessDescription i okidano je $triggerDescription.';
   }
 

--- a/app/lib/l10n/app_localizations_hr.dart
+++ b/app/lib/l10n/app_localizations_hr.dart
@@ -4713,7 +4713,10 @@ class AppLocalizationsHr extends AppLocalizations {
   }
 
   @override
-  String accessesAndTriggeredBy(String accessDescription, String triggerDescription) {
+  String accessesAndTriggeredBy(
+    String accessDescription,
+    String triggerDescription,
+  ) {
     return '$accessDescription i okidano je $triggerDescription.';
   }
 
@@ -9607,4 +9610,25 @@ class AppLocalizationsHr extends AppLocalizations {
   String errorConnectingRayBanMeta(String error) {
     return 'Pogreška pri povezivanju s Ray-Ban Meta: $error';
   }
+
+  @override
+  String get deviceStorageTitle => 'Pohrana uređaja';
+
+  @override
+  String deviceStoragePercentFull(int percent) {
+    return '$percent% popunjeno';
+  }
+
+  @override
+  String deviceStorageUsedOfTotal(String used, String total) {
+    return '$used od $total iskorišteno';
+  }
+
+  @override
+  String deviceStorageFree(String free) {
+    return '$free slobodno';
+  }
+
+  @override
+  String get deviceStorageNearlyFull => 'Uređaj je gotovo pun — sinkronizirajte kako biste oslobodili prostor.';
 }

--- a/app/lib/l10n/app_localizations_hu.dart
+++ b/app/lib/l10n/app_localizations_hu.dart
@@ -4718,10 +4718,7 @@ class AppLocalizationsHu extends AppLocalizations {
   }
 
   @override
-  String accessesAndTriggeredBy(
-    String accessDescription,
-    String triggerDescription,
-  ) {
+  String accessesAndTriggeredBy(String accessDescription, String triggerDescription) {
     return '$accessDescription és $triggerDescription.';
   }
 

--- a/app/lib/l10n/app_localizations_hu.dart
+++ b/app/lib/l10n/app_localizations_hu.dart
@@ -4718,7 +4718,10 @@ class AppLocalizationsHu extends AppLocalizations {
   }
 
   @override
-  String accessesAndTriggeredBy(String accessDescription, String triggerDescription) {
+  String accessesAndTriggeredBy(
+    String accessDescription,
+    String triggerDescription,
+  ) {
     return '$accessDescription és $triggerDescription.';
   }
 
@@ -9614,4 +9617,25 @@ class AppLocalizationsHu extends AppLocalizations {
   String errorConnectingRayBanMeta(String error) {
     return 'Hiba a Ray-Ban Meta csatlakoztatásakor: $error';
   }
+
+  @override
+  String get deviceStorageTitle => 'Eszköz tárhelye';
+
+  @override
+  String deviceStoragePercentFull(int percent) {
+    return '$percent% megtelt';
+  }
+
+  @override
+  String deviceStorageUsedOfTotal(String used, String total) {
+    return '$used / $total felhasználva';
+  }
+
+  @override
+  String deviceStorageFree(String free) {
+    return '$free szabad';
+  }
+
+  @override
+  String get deviceStorageNearlyFull => 'Az eszköz majdnem tele van — szinkronizáljon a hely felszabadításához.';
 }

--- a/app/lib/l10n/app_localizations_id.dart
+++ b/app/lib/l10n/app_localizations_id.dart
@@ -4708,7 +4708,10 @@ class AppLocalizationsId extends AppLocalizations {
   }
 
   @override
-  String accessesAndTriggeredBy(String accessDescription, String triggerDescription) {
+  String accessesAndTriggeredBy(
+    String accessDescription,
+    String triggerDescription,
+  ) {
     return '$accessDescription dan $triggerDescription.';
   }
 
@@ -9583,4 +9586,25 @@ class AppLocalizationsId extends AppLocalizations {
   String errorConnectingRayBanMeta(String error) {
     return 'Kesalahan saat menghubungkan ke Ray-Ban Meta: $error';
   }
+
+  @override
+  String get deviceStorageTitle => 'Penyimpanan perangkat';
+
+  @override
+  String deviceStoragePercentFull(int percent) {
+    return '$percent% penuh';
+  }
+
+  @override
+  String deviceStorageUsedOfTotal(String used, String total) {
+    return '$used dari $total terpakai';
+  }
+
+  @override
+  String deviceStorageFree(String free) {
+    return '$free tersisa';
+  }
+
+  @override
+  String get deviceStorageNearlyFull => 'Perangkat hampir penuh — sinkronkan untuk mengosongkan ruang.';
 }

--- a/app/lib/l10n/app_localizations_id.dart
+++ b/app/lib/l10n/app_localizations_id.dart
@@ -4708,10 +4708,7 @@ class AppLocalizationsId extends AppLocalizations {
   }
 
   @override
-  String accessesAndTriggeredBy(
-    String accessDescription,
-    String triggerDescription,
-  ) {
+  String accessesAndTriggeredBy(String accessDescription, String triggerDescription) {
     return '$accessDescription dan $triggerDescription.';
   }
 

--- a/app/lib/l10n/app_localizations_it.dart
+++ b/app/lib/l10n/app_localizations_it.dart
@@ -4725,7 +4725,10 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
-  String accessesAndTriggeredBy(String accessDescription, String triggerDescription) {
+  String accessesAndTriggeredBy(
+    String accessDescription,
+    String triggerDescription,
+  ) {
     return '$accessDescription ed è $triggerDescription.';
   }
 
@@ -9630,4 +9633,25 @@ class AppLocalizationsIt extends AppLocalizations {
   String errorConnectingRayBanMeta(String error) {
     return 'Errore di connessione a Ray-Ban Meta: $error';
   }
+
+  @override
+  String get deviceStorageTitle => 'Archiviazione del dispositivo';
+
+  @override
+  String deviceStoragePercentFull(int percent) {
+    return '$percent% pieno';
+  }
+
+  @override
+  String deviceStorageUsedOfTotal(String used, String total) {
+    return '$used di $total utilizzati';
+  }
+
+  @override
+  String deviceStorageFree(String free) {
+    return '$free liberi';
+  }
+
+  @override
+  String get deviceStorageNearlyFull => 'Dispositivo quasi pieno — sincronizza per liberare spazio.';
 }

--- a/app/lib/l10n/app_localizations_it.dart
+++ b/app/lib/l10n/app_localizations_it.dart
@@ -4725,10 +4725,7 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
-  String accessesAndTriggeredBy(
-    String accessDescription,
-    String triggerDescription,
-  ) {
+  String accessesAndTriggeredBy(String accessDescription, String triggerDescription) {
     return '$accessDescription ed è $triggerDescription.';
   }
 

--- a/app/lib/l10n/app_localizations_ja.dart
+++ b/app/lib/l10n/app_localizations_ja.dart
@@ -4610,7 +4610,10 @@ class AppLocalizationsJa extends AppLocalizations {
   }
 
   @override
-  String accessesAndTriggeredBy(String accessDescription, String triggerDescription) {
+  String accessesAndTriggeredBy(
+    String accessDescription,
+    String triggerDescription,
+  ) {
     return '$accessDescription、$triggerDescription。';
   }
 
@@ -9416,4 +9419,25 @@ class AppLocalizationsJa extends AppLocalizations {
   String errorConnectingRayBanMeta(String error) {
     return 'Ray-Ban Meta への接続エラー: $error';
   }
+
+  @override
+  String get deviceStorageTitle => 'デバイスのストレージ';
+
+  @override
+  String deviceStoragePercentFull(int percent) {
+    return '$percent% 使用済み';
+  }
+
+  @override
+  String deviceStorageUsedOfTotal(String used, String total) {
+    return '$total 中 $used を使用';
+  }
+
+  @override
+  String deviceStorageFree(String free) {
+    return '空き $free';
+  }
+
+  @override
+  String get deviceStorageNearlyFull => 'デバイスの空き容量がわずかです — 同期して空き容量を確保してください。';
 }

--- a/app/lib/l10n/app_localizations_ja.dart
+++ b/app/lib/l10n/app_localizations_ja.dart
@@ -4610,10 +4610,7 @@ class AppLocalizationsJa extends AppLocalizations {
   }
 
   @override
-  String accessesAndTriggeredBy(
-    String accessDescription,
-    String triggerDescription,
-  ) {
+  String accessesAndTriggeredBy(String accessDescription, String triggerDescription) {
     return '$accessDescription、$triggerDescription。';
   }
 

--- a/app/lib/l10n/app_localizations_kn.dart
+++ b/app/lib/l10n/app_localizations_kn.dart
@@ -4714,10 +4714,7 @@ class AppLocalizationsKn extends AppLocalizations {
   }
 
   @override
-  String accessesAndTriggeredBy(
-    String accessDescription,
-    String triggerDescription,
-  ) {
+  String accessesAndTriggeredBy(String accessDescription, String triggerDescription) {
     return '$accessDescription ಮತ್ತು $triggerDescription ಆಗಿದೆ.';
   }
 

--- a/app/lib/l10n/app_localizations_kn.dart
+++ b/app/lib/l10n/app_localizations_kn.dart
@@ -4714,7 +4714,10 @@ class AppLocalizationsKn extends AppLocalizations {
   }
 
   @override
-  String accessesAndTriggeredBy(String accessDescription, String triggerDescription) {
+  String accessesAndTriggeredBy(
+    String accessDescription,
+    String triggerDescription,
+  ) {
     return '$accessDescription ಮತ್ತು $triggerDescription ಆಗಿದೆ.';
   }
 
@@ -9604,4 +9607,25 @@ class AppLocalizationsKn extends AppLocalizations {
   String errorConnectingRayBanMeta(String error) {
     return 'Ray-Ban Meta ಗೆ ಸಂಪರ್ಕಿಸುವಲ್ಲಿ ದೋಷ: $error';
   }
+
+  @override
+  String get deviceStorageTitle => 'ಸಾಧನ ಸಂಗ್ರಹಣೆ';
+
+  @override
+  String deviceStoragePercentFull(int percent) {
+    return '$percent% ತುಂಬಿದೆ';
+  }
+
+  @override
+  String deviceStorageUsedOfTotal(String used, String total) {
+    return '$total ರಲ್ಲಿ $used ಬಳಸಲಾಗಿದೆ';
+  }
+
+  @override
+  String deviceStorageFree(String free) {
+    return '$free ಖಾಲಿ';
+  }
+
+  @override
+  String get deviceStorageNearlyFull => 'ಸಾಧನ ಬಹುತೇಕ ತುಂಬಿದೆ — ಸ್ಥಳವನ್ನು ಮುಕ್ತಗೊಳಿಸಲು ಸಿಂಕ್ ಮಾಡಿ.';
 }

--- a/app/lib/l10n/app_localizations_ko.dart
+++ b/app/lib/l10n/app_localizations_ko.dart
@@ -4612,7 +4612,10 @@ class AppLocalizationsKo extends AppLocalizations {
   }
 
   @override
-  String accessesAndTriggeredBy(String accessDescription, String triggerDescription) {
+  String accessesAndTriggeredBy(
+    String accessDescription,
+    String triggerDescription,
+  ) {
     return '$accessDescription 및 $triggerDescription.';
   }
 
@@ -9417,4 +9420,25 @@ class AppLocalizationsKo extends AppLocalizations {
   String errorConnectingRayBanMeta(String error) {
     return 'Ray-Ban Meta 연결 오류: $error';
   }
+
+  @override
+  String get deviceStorageTitle => '기기 저장 공간';
+
+  @override
+  String deviceStoragePercentFull(int percent) {
+    return '$percent% 사용 중';
+  }
+
+  @override
+  String deviceStorageUsedOfTotal(String used, String total) {
+    return '$total 중 $used 사용';
+  }
+
+  @override
+  String deviceStorageFree(String free) {
+    return '$free 남음';
+  }
+
+  @override
+  String get deviceStorageNearlyFull => '기기가 거의 가득 찼습니다 — 동기화하여 공간을 확보하세요.';
 }

--- a/app/lib/l10n/app_localizations_ko.dart
+++ b/app/lib/l10n/app_localizations_ko.dart
@@ -4612,10 +4612,7 @@ class AppLocalizationsKo extends AppLocalizations {
   }
 
   @override
-  String accessesAndTriggeredBy(
-    String accessDescription,
-    String triggerDescription,
-  ) {
+  String accessesAndTriggeredBy(String accessDescription, String triggerDescription) {
     return '$accessDescription 및 $triggerDescription.';
   }
 

--- a/app/lib/l10n/app_localizations_lt.dart
+++ b/app/lib/l10n/app_localizations_lt.dart
@@ -4696,7 +4696,10 @@ class AppLocalizationsLt extends AppLocalizations {
   }
 
   @override
-  String accessesAndTriggeredBy(String accessDescription, String triggerDescription) {
+  String accessesAndTriggeredBy(
+    String accessDescription,
+    String triggerDescription,
+  ) {
     return '$accessDescription ir yra $triggerDescription.';
   }
 
@@ -9590,4 +9593,25 @@ class AppLocalizationsLt extends AppLocalizations {
   String errorConnectingRayBanMeta(String error) {
     return 'Klaida jungiantis prie Ray-Ban Meta: $error';
   }
+
+  @override
+  String get deviceStorageTitle => 'Įrenginio saugykla';
+
+  @override
+  String deviceStoragePercentFull(int percent) {
+    return 'užpildyta $percent%';
+  }
+
+  @override
+  String deviceStorageUsedOfTotal(String used, String total) {
+    return 'panaudota $used iš $total';
+  }
+
+  @override
+  String deviceStorageFree(String free) {
+    return '$free laisva';
+  }
+
+  @override
+  String get deviceStorageNearlyFull => 'Įrenginys beveik pilnas — sinchronizuokite, kad atlaisvintumėte vietos.';
 }

--- a/app/lib/l10n/app_localizations_lt.dart
+++ b/app/lib/l10n/app_localizations_lt.dart
@@ -4696,10 +4696,7 @@ class AppLocalizationsLt extends AppLocalizations {
   }
 
   @override
-  String accessesAndTriggeredBy(
-    String accessDescription,
-    String triggerDescription,
-  ) {
+  String accessesAndTriggeredBy(String accessDescription, String triggerDescription) {
     return '$accessDescription ir yra $triggerDescription.';
   }
 

--- a/app/lib/l10n/app_localizations_lv.dart
+++ b/app/lib/l10n/app_localizations_lv.dart
@@ -4703,10 +4703,7 @@ class AppLocalizationsLv extends AppLocalizations {
   }
 
   @override
-  String accessesAndTriggeredBy(
-    String accessDescription,
-    String triggerDescription,
-  ) {
+  String accessesAndTriggeredBy(String accessDescription, String triggerDescription) {
     return '$accessDescription un ir $triggerDescription.';
   }
 

--- a/app/lib/l10n/app_localizations_lv.dart
+++ b/app/lib/l10n/app_localizations_lv.dart
@@ -4703,7 +4703,10 @@ class AppLocalizationsLv extends AppLocalizations {
   }
 
   @override
-  String accessesAndTriggeredBy(String accessDescription, String triggerDescription) {
+  String accessesAndTriggeredBy(
+    String accessDescription,
+    String triggerDescription,
+  ) {
     return '$accessDescription un ir $triggerDescription.';
   }
 
@@ -9595,4 +9598,25 @@ class AppLocalizationsLv extends AppLocalizations {
   String errorConnectingRayBanMeta(String error) {
     return 'Kļūda, veidojot savienojumu ar Ray-Ban Meta: $error';
   }
+
+  @override
+  String get deviceStorageTitle => 'Ierīces krātuve';
+
+  @override
+  String deviceStoragePercentFull(int percent) {
+    return '$percent% aizpildīts';
+  }
+
+  @override
+  String deviceStorageUsedOfTotal(String used, String total) {
+    return 'izmantoti $used no $total';
+  }
+
+  @override
+  String deviceStorageFree(String free) {
+    return '$free brīvi';
+  }
+
+  @override
+  String get deviceStorageNearlyFull => 'Ierīce ir gandrīz pilna — sinhronizējiet, lai atbrīvotu vietu.';
 }

--- a/app/lib/l10n/app_localizations_mk.dart
+++ b/app/lib/l10n/app_localizations_mk.dart
@@ -4719,7 +4719,10 @@ class AppLocalizationsMk extends AppLocalizations {
   }
 
   @override
-  String accessesAndTriggeredBy(String accessDescription, String triggerDescription) {
+  String accessesAndTriggeredBy(
+    String accessDescription,
+    String triggerDescription,
+  ) {
     return '$accessDescription и е $triggerDescription.';
   }
 
@@ -9625,4 +9628,25 @@ class AppLocalizationsMk extends AppLocalizations {
   String errorConnectingRayBanMeta(String error) {
     return 'Грешка при поврзување со Ray-Ban Meta: $error';
   }
+
+  @override
+  String get deviceStorageTitle => 'Меморија на уредот';
+
+  @override
+  String deviceStoragePercentFull(int percent) {
+    return '$percent% полна';
+  }
+
+  @override
+  String deviceStorageUsedOfTotal(String used, String total) {
+    return '$used од $total искористени';
+  }
+
+  @override
+  String deviceStorageFree(String free) {
+    return '$free слободни';
+  }
+
+  @override
+  String get deviceStorageNearlyFull => 'Уредот е речиси полн — синхронизирајте за да ослободите простор.';
 }

--- a/app/lib/l10n/app_localizations_mk.dart
+++ b/app/lib/l10n/app_localizations_mk.dart
@@ -4719,10 +4719,7 @@ class AppLocalizationsMk extends AppLocalizations {
   }
 
   @override
-  String accessesAndTriggeredBy(
-    String accessDescription,
-    String triggerDescription,
-  ) {
+  String accessesAndTriggeredBy(String accessDescription, String triggerDescription) {
     return '$accessDescription и е $triggerDescription.';
   }
 

--- a/app/lib/l10n/app_localizations_mr.dart
+++ b/app/lib/l10n/app_localizations_mr.dart
@@ -4705,10 +4705,7 @@ class AppLocalizationsMr extends AppLocalizations {
   }
 
   @override
-  String accessesAndTriggeredBy(
-    String accessDescription,
-    String triggerDescription,
-  ) {
+  String accessesAndTriggeredBy(String accessDescription, String triggerDescription) {
     return '$accessDescription आणि $triggerDescription आहे.';
   }
 

--- a/app/lib/l10n/app_localizations_mr.dart
+++ b/app/lib/l10n/app_localizations_mr.dart
@@ -4705,7 +4705,10 @@ class AppLocalizationsMr extends AppLocalizations {
   }
 
   @override
-  String accessesAndTriggeredBy(String accessDescription, String triggerDescription) {
+  String accessesAndTriggeredBy(
+    String accessDescription,
+    String triggerDescription,
+  ) {
     return '$accessDescription आणि $triggerDescription आहे.';
   }
 
@@ -9582,4 +9585,25 @@ class AppLocalizationsMr extends AppLocalizations {
   String errorConnectingRayBanMeta(String error) {
     return 'Ray-Ban Meta शी कनेक्ट करताना त्रुटी: $error';
   }
+
+  @override
+  String get deviceStorageTitle => 'डिव्हाइस स्टोरेज';
+
+  @override
+  String deviceStoragePercentFull(int percent) {
+    return '$percent% भरले';
+  }
+
+  @override
+  String deviceStorageUsedOfTotal(String used, String total) {
+    return '$total पैकी $used वापरले';
+  }
+
+  @override
+  String deviceStorageFree(String free) {
+    return '$free रिकामे';
+  }
+
+  @override
+  String get deviceStorageNearlyFull => 'डिव्हाइस जवळजवळ भरले आहे — जागा मोकळी करण्यासाठी सिंक करा.';
 }

--- a/app/lib/l10n/app_localizations_ms.dart
+++ b/app/lib/l10n/app_localizations_ms.dart
@@ -4712,10 +4712,7 @@ class AppLocalizationsMs extends AppLocalizations {
   }
 
   @override
-  String accessesAndTriggeredBy(
-    String accessDescription,
-    String triggerDescription,
-  ) {
+  String accessesAndTriggeredBy(String accessDescription, String triggerDescription) {
     return '$accessDescription dan $triggerDescription.';
   }
 

--- a/app/lib/l10n/app_localizations_ms.dart
+++ b/app/lib/l10n/app_localizations_ms.dart
@@ -4712,7 +4712,10 @@ class AppLocalizationsMs extends AppLocalizations {
   }
 
   @override
-  String accessesAndTriggeredBy(String accessDescription, String triggerDescription) {
+  String accessesAndTriggeredBy(
+    String accessDescription,
+    String triggerDescription,
+  ) {
     return '$accessDescription dan $triggerDescription.';
   }
 
@@ -9598,4 +9601,25 @@ class AppLocalizationsMs extends AppLocalizations {
   String errorConnectingRayBanMeta(String error) {
     return 'Ralat semasa menyambung ke Ray-Ban Meta: $error';
   }
+
+  @override
+  String get deviceStorageTitle => 'Storan peranti';
+
+  @override
+  String deviceStoragePercentFull(int percent) {
+    return '$percent% penuh';
+  }
+
+  @override
+  String deviceStorageUsedOfTotal(String used, String total) {
+    return '$used daripada $total digunakan';
+  }
+
+  @override
+  String deviceStorageFree(String free) {
+    return '$free bebas';
+  }
+
+  @override
+  String get deviceStorageNearlyFull => 'Peranti hampir penuh — segerakkan untuk mengosongkan ruang.';
 }

--- a/app/lib/l10n/app_localizations_nl.dart
+++ b/app/lib/l10n/app_localizations_nl.dart
@@ -4709,10 +4709,7 @@ class AppLocalizationsNl extends AppLocalizations {
   }
 
   @override
-  String accessesAndTriggeredBy(
-    String accessDescription,
-    String triggerDescription,
-  ) {
+  String accessesAndTriggeredBy(String accessDescription, String triggerDescription) {
     return '$accessDescription en is $triggerDescription.';
   }
 

--- a/app/lib/l10n/app_localizations_nl.dart
+++ b/app/lib/l10n/app_localizations_nl.dart
@@ -4709,7 +4709,10 @@ class AppLocalizationsNl extends AppLocalizations {
   }
 
   @override
-  String accessesAndTriggeredBy(String accessDescription, String triggerDescription) {
+  String accessesAndTriggeredBy(
+    String accessDescription,
+    String triggerDescription,
+  ) {
     return '$accessDescription en is $triggerDescription.';
   }
 
@@ -9601,4 +9604,25 @@ class AppLocalizationsNl extends AppLocalizations {
   String errorConnectingRayBanMeta(String error) {
     return 'Fout bij verbinden met Ray-Ban Meta: $error';
   }
+
+  @override
+  String get deviceStorageTitle => 'Apparaatopslag';
+
+  @override
+  String deviceStoragePercentFull(int percent) {
+    return '$percent% vol';
+  }
+
+  @override
+  String deviceStorageUsedOfTotal(String used, String total) {
+    return '$used van $total gebruikt';
+  }
+
+  @override
+  String deviceStorageFree(String free) {
+    return '$free vrij';
+  }
+
+  @override
+  String get deviceStorageNearlyFull => 'Apparaat bijna vol — synchroniseer om ruimte vrij te maken.';
 }

--- a/app/lib/l10n/app_localizations_no.dart
+++ b/app/lib/l10n/app_localizations_no.dart
@@ -4697,10 +4697,7 @@ class AppLocalizationsNo extends AppLocalizations {
   }
 
   @override
-  String accessesAndTriggeredBy(
-    String accessDescription,
-    String triggerDescription,
-  ) {
+  String accessesAndTriggeredBy(String accessDescription, String triggerDescription) {
     return '$accessDescription og er $triggerDescription.';
   }
 

--- a/app/lib/l10n/app_localizations_no.dart
+++ b/app/lib/l10n/app_localizations_no.dart
@@ -4697,7 +4697,10 @@ class AppLocalizationsNo extends AppLocalizations {
   }
 
   @override
-  String accessesAndTriggeredBy(String accessDescription, String triggerDescription) {
+  String accessesAndTriggeredBy(
+    String accessDescription,
+    String triggerDescription,
+  ) {
     return '$accessDescription og er $triggerDescription.';
   }
 
@@ -9572,4 +9575,25 @@ class AppLocalizationsNo extends AppLocalizations {
   String errorConnectingRayBanMeta(String error) {
     return 'Feil ved tilkobling til Ray-Ban Meta: $error';
   }
+
+  @override
+  String get deviceStorageTitle => 'Enhetslagring';
+
+  @override
+  String deviceStoragePercentFull(int percent) {
+    return '$percent% fullt';
+  }
+
+  @override
+  String deviceStorageUsedOfTotal(String used, String total) {
+    return '$used av $total brukt';
+  }
+
+  @override
+  String deviceStorageFree(String free) {
+    return '$free ledig';
+  }
+
+  @override
+  String get deviceStorageNearlyFull => 'Enheten er nesten full — synkroniser for å frigjøre plass.';
 }

--- a/app/lib/l10n/app_localizations_pl.dart
+++ b/app/lib/l10n/app_localizations_pl.dart
@@ -4704,10 +4704,7 @@ class AppLocalizationsPl extends AppLocalizations {
   }
 
   @override
-  String accessesAndTriggeredBy(
-    String accessDescription,
-    String triggerDescription,
-  ) {
+  String accessesAndTriggeredBy(String accessDescription, String triggerDescription) {
     return '$accessDescription i jest $triggerDescription.';
   }
 

--- a/app/lib/l10n/app_localizations_pl.dart
+++ b/app/lib/l10n/app_localizations_pl.dart
@@ -4704,7 +4704,10 @@ class AppLocalizationsPl extends AppLocalizations {
   }
 
   @override
-  String accessesAndTriggeredBy(String accessDescription, String triggerDescription) {
+  String accessesAndTriggeredBy(
+    String accessDescription,
+    String triggerDescription,
+  ) {
     return '$accessDescription i jest $triggerDescription.';
   }
 
@@ -9600,4 +9603,25 @@ class AppLocalizationsPl extends AppLocalizations {
   String errorConnectingRayBanMeta(String error) {
     return 'Błąd podczas łączenia z Ray-Ban Meta: $error';
   }
+
+  @override
+  String get deviceStorageTitle => 'Pamięć urządzenia';
+
+  @override
+  String deviceStoragePercentFull(int percent) {
+    return 'zapełniono $percent%';
+  }
+
+  @override
+  String deviceStorageUsedOfTotal(String used, String total) {
+    return 'wykorzystano $used z $total';
+  }
+
+  @override
+  String deviceStorageFree(String free) {
+    return '$free wolne';
+  }
+
+  @override
+  String get deviceStorageNearlyFull => 'Urządzenie jest prawie pełne — zsynchronizuj, aby zwolnić miejsce.';
 }

--- a/app/lib/l10n/app_localizations_pt.dart
+++ b/app/lib/l10n/app_localizations_pt.dart
@@ -4681,7 +4681,10 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
-  String accessesAndTriggeredBy(String accessDescription, String triggerDescription) {
+  String accessesAndTriggeredBy(
+    String accessDescription,
+    String triggerDescription,
+  ) {
     return '$accessDescription e é $triggerDescription.';
   }
 
@@ -9580,4 +9583,25 @@ class AppLocalizationsPt extends AppLocalizations {
   String errorConnectingRayBanMeta(String error) {
     return 'Erro ao conectar ao Ray-Ban Meta: $error';
   }
+
+  @override
+  String get deviceStorageTitle => 'Armazenamento do dispositivo';
+
+  @override
+  String deviceStoragePercentFull(int percent) {
+    return '$percent% cheio';
+  }
+
+  @override
+  String deviceStorageUsedOfTotal(String used, String total) {
+    return '$used de $total usado';
+  }
+
+  @override
+  String deviceStorageFree(String free) {
+    return '$free livre';
+  }
+
+  @override
+  String get deviceStorageNearlyFull => 'Dispositivo quase cheio — sincronize para liberar espaço.';
 }

--- a/app/lib/l10n/app_localizations_pt.dart
+++ b/app/lib/l10n/app_localizations_pt.dart
@@ -4681,10 +4681,7 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
-  String accessesAndTriggeredBy(
-    String accessDescription,
-    String triggerDescription,
-  ) {
+  String accessesAndTriggeredBy(String accessDescription, String triggerDescription) {
     return '$accessDescription e é $triggerDescription.';
   }
 

--- a/app/lib/l10n/app_localizations_ro.dart
+++ b/app/lib/l10n/app_localizations_ro.dart
@@ -4719,10 +4719,7 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
-  String accessesAndTriggeredBy(
-    String accessDescription,
-    String triggerDescription,
-  ) {
+  String accessesAndTriggeredBy(String accessDescription, String triggerDescription) {
     return '$accessDescription și este $triggerDescription.';
   }
 

--- a/app/lib/l10n/app_localizations_ro.dart
+++ b/app/lib/l10n/app_localizations_ro.dart
@@ -4719,7 +4719,10 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
-  String accessesAndTriggeredBy(String accessDescription, String triggerDescription) {
+  String accessesAndTriggeredBy(
+    String accessDescription,
+    String triggerDescription,
+  ) {
     return '$accessDescription și este $triggerDescription.';
   }
 
@@ -9620,4 +9623,25 @@ class AppLocalizationsRo extends AppLocalizations {
   String errorConnectingRayBanMeta(String error) {
     return 'Eroare la conectarea la Ray-Ban Meta: $error';
   }
+
+  @override
+  String get deviceStorageTitle => 'Stocarea dispozitivului';
+
+  @override
+  String deviceStoragePercentFull(int percent) {
+    return '$percent% plin';
+  }
+
+  @override
+  String deviceStorageUsedOfTotal(String used, String total) {
+    return '$used din $total utilizat';
+  }
+
+  @override
+  String deviceStorageFree(String free) {
+    return '$free liber';
+  }
+
+  @override
+  String get deviceStorageNearlyFull => 'Dispozitivul este aproape plin — sincronizează pentru a elibera spațiu.';
 }

--- a/app/lib/l10n/app_localizations_ru.dart
+++ b/app/lib/l10n/app_localizations_ru.dart
@@ -4707,7 +4707,10 @@ class AppLocalizationsRu extends AppLocalizations {
   }
 
   @override
-  String accessesAndTriggeredBy(String accessDescription, String triggerDescription) {
+  String accessesAndTriggeredBy(
+    String accessDescription,
+    String triggerDescription,
+  ) {
     return '$accessDescription и $triggerDescription.';
   }
 
@@ -9609,4 +9612,25 @@ class AppLocalizationsRu extends AppLocalizations {
   String errorConnectingRayBanMeta(String error) {
     return 'Ошибка подключения к Ray-Ban Meta: $error';
   }
+
+  @override
+  String get deviceStorageTitle => 'Хранилище устройства';
+
+  @override
+  String deviceStoragePercentFull(int percent) {
+    return 'заполнено $percent%';
+  }
+
+  @override
+  String deviceStorageUsedOfTotal(String used, String total) {
+    return 'использовано $used из $total';
+  }
+
+  @override
+  String deviceStorageFree(String free) {
+    return '$free свободно';
+  }
+
+  @override
+  String get deviceStorageNearlyFull => 'Устройство почти заполнено — синхронизируйте, чтобы освободить место.';
 }

--- a/app/lib/l10n/app_localizations_ru.dart
+++ b/app/lib/l10n/app_localizations_ru.dart
@@ -4707,10 +4707,7 @@ class AppLocalizationsRu extends AppLocalizations {
   }
 
   @override
-  String accessesAndTriggeredBy(
-    String accessDescription,
-    String triggerDescription,
-  ) {
+  String accessesAndTriggeredBy(String accessDescription, String triggerDescription) {
     return '$accessDescription и $triggerDescription.';
   }
 

--- a/app/lib/l10n/app_localizations_sk.dart
+++ b/app/lib/l10n/app_localizations_sk.dart
@@ -4692,10 +4692,7 @@ class AppLocalizationsSk extends AppLocalizations {
   }
 
   @override
-  String accessesAndTriggeredBy(
-    String accessDescription,
-    String triggerDescription,
-  ) {
+  String accessesAndTriggeredBy(String accessDescription, String triggerDescription) {
     return '$accessDescription a je $triggerDescription.';
   }
 

--- a/app/lib/l10n/app_localizations_sk.dart
+++ b/app/lib/l10n/app_localizations_sk.dart
@@ -4692,7 +4692,10 @@ class AppLocalizationsSk extends AppLocalizations {
   }
 
   @override
-  String accessesAndTriggeredBy(String accessDescription, String triggerDescription) {
+  String accessesAndTriggeredBy(
+    String accessDescription,
+    String triggerDescription,
+  ) {
     return '$accessDescription a je $triggerDescription.';
   }
 
@@ -9565,4 +9568,25 @@ class AppLocalizationsSk extends AppLocalizations {
   String errorConnectingRayBanMeta(String error) {
     return 'Chyba pri pripájaní k Ray-Ban Meta: $error';
   }
+
+  @override
+  String get deviceStorageTitle => 'Úložisko zariadenia';
+
+  @override
+  String deviceStoragePercentFull(int percent) {
+    return '$percent% zaplnené';
+  }
+
+  @override
+  String deviceStorageUsedOfTotal(String used, String total) {
+    return '$used z $total využité';
+  }
+
+  @override
+  String deviceStorageFree(String free) {
+    return '$free voľných';
+  }
+
+  @override
+  String get deviceStorageNearlyFull => 'Zariadenie je takmer plné — synchronizujte, aby ste uvoľnili miesto.';
 }

--- a/app/lib/l10n/app_localizations_sl.dart
+++ b/app/lib/l10n/app_localizations_sl.dart
@@ -4703,10 +4703,7 @@ class AppLocalizationsSl extends AppLocalizations {
   }
 
   @override
-  String accessesAndTriggeredBy(
-    String accessDescription,
-    String triggerDescription,
-  ) {
+  String accessesAndTriggeredBy(String accessDescription, String triggerDescription) {
     return '$accessDescription in je $triggerDescription.';
   }
 

--- a/app/lib/l10n/app_localizations_sl.dart
+++ b/app/lib/l10n/app_localizations_sl.dart
@@ -4703,7 +4703,10 @@ class AppLocalizationsSl extends AppLocalizations {
   }
 
   @override
-  String accessesAndTriggeredBy(String accessDescription, String triggerDescription) {
+  String accessesAndTriggeredBy(
+    String accessDescription,
+    String triggerDescription,
+  ) {
     return '$accessDescription in je $triggerDescription.';
   }
 
@@ -9601,4 +9604,25 @@ class AppLocalizationsSl extends AppLocalizations {
   String errorConnectingRayBanMeta(String error) {
     return 'Napaka pri povezovanju z Ray-Ban Meta: $error';
   }
+
+  @override
+  String get deviceStorageTitle => 'Shramba naprave';
+
+  @override
+  String deviceStoragePercentFull(int percent) {
+    return '$percent% zasedeno';
+  }
+
+  @override
+  String deviceStorageUsedOfTotal(String used, String total) {
+    return '$used od $total porabljeno';
+  }
+
+  @override
+  String deviceStorageFree(String free) {
+    return '$free prosto';
+  }
+
+  @override
+  String get deviceStorageNearlyFull => 'Naprava je skoraj polna — sinhronizirajte za sprostitev prostora.';
 }

--- a/app/lib/l10n/app_localizations_sr.dart
+++ b/app/lib/l10n/app_localizations_sr.dart
@@ -4703,7 +4703,10 @@ class AppLocalizationsSr extends AppLocalizations {
   }
 
   @override
-  String accessesAndTriggeredBy(String accessDescription, String triggerDescription) {
+  String accessesAndTriggeredBy(
+    String accessDescription,
+    String triggerDescription,
+  ) {
     return '$accessDescription и је $triggerDescription.';
   }
 
@@ -9587,4 +9590,25 @@ class AppLocalizationsSr extends AppLocalizations {
   String errorConnectingRayBanMeta(String error) {
     return 'Грешка при повезивању са Ray-Ban Meta: $error';
   }
+
+  @override
+  String get deviceStorageTitle => 'Меморија уређаја';
+
+  @override
+  String deviceStoragePercentFull(int percent) {
+    return '$percent% попуњено';
+  }
+
+  @override
+  String deviceStorageUsedOfTotal(String used, String total) {
+    return '$used од $total искоришћено';
+  }
+
+  @override
+  String deviceStorageFree(String free) {
+    return '$free слободно';
+  }
+
+  @override
+  String get deviceStorageNearlyFull => 'Уређај је скоро пун — синхронизујте да ослободите простор.';
 }

--- a/app/lib/l10n/app_localizations_sr.dart
+++ b/app/lib/l10n/app_localizations_sr.dart
@@ -4703,10 +4703,7 @@ class AppLocalizationsSr extends AppLocalizations {
   }
 
   @override
-  String accessesAndTriggeredBy(
-    String accessDescription,
-    String triggerDescription,
-  ) {
+  String accessesAndTriggeredBy(String accessDescription, String triggerDescription) {
     return '$accessDescription и је $triggerDescription.';
   }
 

--- a/app/lib/l10n/app_localizations_sv.dart
+++ b/app/lib/l10n/app_localizations_sv.dart
@@ -4697,10 +4697,7 @@ class AppLocalizationsSv extends AppLocalizations {
   }
 
   @override
-  String accessesAndTriggeredBy(
-    String accessDescription,
-    String triggerDescription,
-  ) {
+  String accessesAndTriggeredBy(String accessDescription, String triggerDescription) {
     return '$accessDescription och är $triggerDescription.';
   }
 

--- a/app/lib/l10n/app_localizations_sv.dart
+++ b/app/lib/l10n/app_localizations_sv.dart
@@ -4697,7 +4697,10 @@ class AppLocalizationsSv extends AppLocalizations {
   }
 
   @override
-  String accessesAndTriggeredBy(String accessDescription, String triggerDescription) {
+  String accessesAndTriggeredBy(
+    String accessDescription,
+    String triggerDescription,
+  ) {
     return '$accessDescription och är $triggerDescription.';
   }
 
@@ -9579,4 +9582,25 @@ class AppLocalizationsSv extends AppLocalizations {
   String errorConnectingRayBanMeta(String error) {
     return 'Fel vid anslutning till Ray-Ban Meta: $error';
   }
+
+  @override
+  String get deviceStorageTitle => 'Enhetens lagring';
+
+  @override
+  String deviceStoragePercentFull(int percent) {
+    return '$percent% fullt';
+  }
+
+  @override
+  String deviceStorageUsedOfTotal(String used, String total) {
+    return '$used av $total använt';
+  }
+
+  @override
+  String deviceStorageFree(String free) {
+    return '$free ledigt';
+  }
+
+  @override
+  String get deviceStorageNearlyFull => 'Enheten är nästan full — synkronisera för att frigöra utrymme.';
 }

--- a/app/lib/l10n/app_localizations_ta.dart
+++ b/app/lib/l10n/app_localizations_ta.dart
@@ -4728,10 +4728,7 @@ class AppLocalizationsTa extends AppLocalizations {
   }
 
   @override
-  String accessesAndTriggeredBy(
-    String accessDescription,
-    String triggerDescription,
-  ) {
+  String accessesAndTriggeredBy(String accessDescription, String triggerDescription) {
     return '$accessDescription மற்றும் $triggerDescription।';
   }
 

--- a/app/lib/l10n/app_localizations_ta.dart
+++ b/app/lib/l10n/app_localizations_ta.dart
@@ -4728,7 +4728,10 @@ class AppLocalizationsTa extends AppLocalizations {
   }
 
   @override
-  String accessesAndTriggeredBy(String accessDescription, String triggerDescription) {
+  String accessesAndTriggeredBy(
+    String accessDescription,
+    String triggerDescription,
+  ) {
     return '$accessDescription மற்றும் $triggerDescription।';
   }
 
@@ -9643,4 +9646,25 @@ class AppLocalizationsTa extends AppLocalizations {
   String errorConnectingRayBanMeta(String error) {
     return 'Ray-Ban Meta உடன் இணைப்பதில் பிழை: $error';
   }
+
+  @override
+  String get deviceStorageTitle => 'சாதன சேமிப்பு';
+
+  @override
+  String deviceStoragePercentFull(int percent) {
+    return '$percent% நிரம்பியது';
+  }
+
+  @override
+  String deviceStorageUsedOfTotal(String used, String total) {
+    return '$total இல் $used பயன்படுத்தப்பட்டது';
+  }
+
+  @override
+  String deviceStorageFree(String free) {
+    return '$free காலி';
+  }
+
+  @override
+  String get deviceStorageNearlyFull => 'சாதனம் கிட்டத்தட்ட நிரம்பிவிட்டது — இடத்தைக் காலி செய்ய ஒத்திசைக்கவும்.';
 }

--- a/app/lib/l10n/app_localizations_te.dart
+++ b/app/lib/l10n/app_localizations_te.dart
@@ -4722,10 +4722,7 @@ class AppLocalizationsTe extends AppLocalizations {
   }
 
   @override
-  String accessesAndTriggeredBy(
-    String accessDescription,
-    String triggerDescription,
-  ) {
+  String accessesAndTriggeredBy(String accessDescription, String triggerDescription) {
     return '$accessDescription మరియు $triggerDescription.';
   }
 

--- a/app/lib/l10n/app_localizations_te.dart
+++ b/app/lib/l10n/app_localizations_te.dart
@@ -4722,7 +4722,10 @@ class AppLocalizationsTe extends AppLocalizations {
   }
 
   @override
-  String accessesAndTriggeredBy(String accessDescription, String triggerDescription) {
+  String accessesAndTriggeredBy(
+    String accessDescription,
+    String triggerDescription,
+  ) {
     return '$accessDescription మరియు $triggerDescription.';
   }
 
@@ -9621,4 +9624,25 @@ class AppLocalizationsTe extends AppLocalizations {
   String errorConnectingRayBanMeta(String error) {
     return 'Ray-Ban Meta కు కనెక్ట్ చేయడంలో లోపం: $error';
   }
+
+  @override
+  String get deviceStorageTitle => 'పరికర నిల్వ';
+
+  @override
+  String deviceStoragePercentFull(int percent) {
+    return '$percent% నిండింది';
+  }
+
+  @override
+  String deviceStorageUsedOfTotal(String used, String total) {
+    return '$total లో $used ఉపయోగించబడింది';
+  }
+
+  @override
+  String deviceStorageFree(String free) {
+    return '$free ఖాళీ';
+  }
+
+  @override
+  String get deviceStorageNearlyFull => 'పరికరం దాదాపు నిండిపోయింది — స్థలాన్ని ఖాళీ చేయడానికి సింక్ చేయండి.';
 }

--- a/app/lib/l10n/app_localizations_th.dart
+++ b/app/lib/l10n/app_localizations_th.dart
@@ -4672,10 +4672,7 @@ class AppLocalizationsTh extends AppLocalizations {
   }
 
   @override
-  String accessesAndTriggeredBy(
-    String accessDescription,
-    String triggerDescription,
-  ) {
+  String accessesAndTriggeredBy(String accessDescription, String triggerDescription) {
     return '$accessDescription และ $triggerDescription';
   }
 

--- a/app/lib/l10n/app_localizations_th.dart
+++ b/app/lib/l10n/app_localizations_th.dart
@@ -4672,7 +4672,10 @@ class AppLocalizationsTh extends AppLocalizations {
   }
 
   @override
-  String accessesAndTriggeredBy(String accessDescription, String triggerDescription) {
+  String accessesAndTriggeredBy(
+    String accessDescription,
+    String triggerDescription,
+  ) {
     return '$accessDescription และ $triggerDescription';
   }
 
@@ -9522,4 +9525,25 @@ class AppLocalizationsTh extends AppLocalizations {
   String errorConnectingRayBanMeta(String error) {
     return 'เกิดข้อผิดพลาดในการเชื่อมต่อกับ Ray-Ban Meta: $error';
   }
+
+  @override
+  String get deviceStorageTitle => 'ที่จัดเก็บของอุปกรณ์';
+
+  @override
+  String deviceStoragePercentFull(int percent) {
+    return 'เต็ม $percent%';
+  }
+
+  @override
+  String deviceStorageUsedOfTotal(String used, String total) {
+    return 'ใช้ไป $used จาก $total';
+  }
+
+  @override
+  String deviceStorageFree(String free) {
+    return 'ว่าง $free';
+  }
+
+  @override
+  String get deviceStorageNearlyFull => 'อุปกรณ์เกือบเต็มแล้ว — ซิงค์เพื่อเพิ่มพื้นที่ว่าง';
 }

--- a/app/lib/l10n/app_localizations_tl.dart
+++ b/app/lib/l10n/app_localizations_tl.dart
@@ -4736,7 +4736,10 @@ class AppLocalizationsTl extends AppLocalizations {
   }
 
   @override
-  String accessesAndTriggeredBy(String accessDescription, String triggerDescription) {
+  String accessesAndTriggeredBy(
+    String accessDescription,
+    String triggerDescription,
+  ) {
     return '$accessDescription at ay $triggerDescription.';
   }
 
@@ -9663,4 +9666,25 @@ class AppLocalizationsTl extends AppLocalizations {
   String errorConnectingRayBanMeta(String error) {
     return 'Error sa pagkonekta sa Ray-Ban Meta: $error';
   }
+
+  @override
+  String get deviceStorageTitle => 'Storage ng device';
+
+  @override
+  String deviceStoragePercentFull(int percent) {
+    return '$percent% puno';
+  }
+
+  @override
+  String deviceStorageUsedOfTotal(String used, String total) {
+    return '$used sa $total ang nagamit';
+  }
+
+  @override
+  String deviceStorageFree(String free) {
+    return '$free ang libre';
+  }
+
+  @override
+  String get deviceStorageNearlyFull => 'Halos puno na ang device — mag-sync para magbakante ng espasyo.';
 }

--- a/app/lib/l10n/app_localizations_tl.dart
+++ b/app/lib/l10n/app_localizations_tl.dart
@@ -4736,10 +4736,7 @@ class AppLocalizationsTl extends AppLocalizations {
   }
 
   @override
-  String accessesAndTriggeredBy(
-    String accessDescription,
-    String triggerDescription,
-  ) {
+  String accessesAndTriggeredBy(String accessDescription, String triggerDescription) {
     return '$accessDescription at ay $triggerDescription.';
   }
 

--- a/app/lib/l10n/app_localizations_tr.dart
+++ b/app/lib/l10n/app_localizations_tr.dart
@@ -4705,7 +4705,10 @@ class AppLocalizationsTr extends AppLocalizations {
   }
 
   @override
-  String accessesAndTriggeredBy(String accessDescription, String triggerDescription) {
+  String accessesAndTriggeredBy(
+    String accessDescription,
+    String triggerDescription,
+  ) {
     return '$accessDescription ve $triggerDescription.';
   }
 
@@ -9585,4 +9588,25 @@ class AppLocalizationsTr extends AppLocalizations {
   String errorConnectingRayBanMeta(String error) {
     return 'Ray-Ban Meta\'ya bağlanırken hata: $error';
   }
+
+  @override
+  String get deviceStorageTitle => 'Cihaz depolama';
+
+  @override
+  String deviceStoragePercentFull(int percent) {
+    return '%$percent dolu';
+  }
+
+  @override
+  String deviceStorageUsedOfTotal(String used, String total) {
+    return '$total alanın $used kısmı kullanıldı';
+  }
+
+  @override
+  String deviceStorageFree(String free) {
+    return '$free boş';
+  }
+
+  @override
+  String get deviceStorageNearlyFull => 'Cihaz neredeyse dolu — yer açmak için eşitleyin.';
 }

--- a/app/lib/l10n/app_localizations_tr.dart
+++ b/app/lib/l10n/app_localizations_tr.dart
@@ -4705,10 +4705,7 @@ class AppLocalizationsTr extends AppLocalizations {
   }
 
   @override
-  String accessesAndTriggeredBy(
-    String accessDescription,
-    String triggerDescription,
-  ) {
+  String accessesAndTriggeredBy(String accessDescription, String triggerDescription) {
     return '$accessDescription ve $triggerDescription.';
   }
 

--- a/app/lib/l10n/app_localizations_uk.dart
+++ b/app/lib/l10n/app_localizations_uk.dart
@@ -4701,7 +4701,10 @@ class AppLocalizationsUk extends AppLocalizations {
   }
 
   @override
-  String accessesAndTriggeredBy(String accessDescription, String triggerDescription) {
+  String accessesAndTriggeredBy(
+    String accessDescription,
+    String triggerDescription,
+  ) {
     return '$accessDescription і $triggerDescription.';
   }
 
@@ -9594,4 +9597,25 @@ class AppLocalizationsUk extends AppLocalizations {
   String errorConnectingRayBanMeta(String error) {
     return 'Помилка підключення до Ray-Ban Meta: $error';
   }
+
+  @override
+  String get deviceStorageTitle => 'Сховище пристрою';
+
+  @override
+  String deviceStoragePercentFull(int percent) {
+    return 'заповнено $percent%';
+  }
+
+  @override
+  String deviceStorageUsedOfTotal(String used, String total) {
+    return 'використано $used з $total';
+  }
+
+  @override
+  String deviceStorageFree(String free) {
+    return '$free вільно';
+  }
+
+  @override
+  String get deviceStorageNearlyFull => 'Пристрій майже заповнений — синхронізуйте, щоб звільнити місце.';
 }

--- a/app/lib/l10n/app_localizations_uk.dart
+++ b/app/lib/l10n/app_localizations_uk.dart
@@ -4701,10 +4701,7 @@ class AppLocalizationsUk extends AppLocalizations {
   }
 
   @override
-  String accessesAndTriggeredBy(
-    String accessDescription,
-    String triggerDescription,
-  ) {
+  String accessesAndTriggeredBy(String accessDescription, String triggerDescription) {
     return '$accessDescription і $triggerDescription.';
   }
 

--- a/app/lib/l10n/app_localizations_ur.dart
+++ b/app/lib/l10n/app_localizations_ur.dart
@@ -4703,7 +4703,10 @@ class AppLocalizationsUr extends AppLocalizations {
   }
 
   @override
-  String accessesAndTriggeredBy(String accessDescription, String triggerDescription) {
+  String accessesAndTriggeredBy(
+    String accessDescription,
+    String triggerDescription,
+  ) {
     return '$accessDescription اور $triggerDescription سے متحرک ہے۔';
   }
 
@@ -9587,4 +9590,25 @@ class AppLocalizationsUr extends AppLocalizations {
   String errorConnectingRayBanMeta(String error) {
     return 'Ray-Ban Meta سے جڑنے میں خرابی: $error';
   }
+
+  @override
+  String get deviceStorageTitle => 'آلے کا اسٹوریج';
+
+  @override
+  String deviceStoragePercentFull(int percent) {
+    return '$percent% بھرا';
+  }
+
+  @override
+  String deviceStorageUsedOfTotal(String used, String total) {
+    return '$total میں سے $used استعمال شدہ';
+  }
+
+  @override
+  String deviceStorageFree(String free) {
+    return '$free خالی';
+  }
+
+  @override
+  String get deviceStorageNearlyFull => 'آلہ تقریباً بھر چکا ہے — جگہ خالی کرنے کے لیے سنک کریں۔';
 }

--- a/app/lib/l10n/app_localizations_ur.dart
+++ b/app/lib/l10n/app_localizations_ur.dart
@@ -4703,10 +4703,7 @@ class AppLocalizationsUr extends AppLocalizations {
   }
 
   @override
-  String accessesAndTriggeredBy(
-    String accessDescription,
-    String triggerDescription,
-  ) {
+  String accessesAndTriggeredBy(String accessDescription, String triggerDescription) {
     return '$accessDescription اور $triggerDescription سے متحرک ہے۔';
   }
 

--- a/app/lib/l10n/app_localizations_vi.dart
+++ b/app/lib/l10n/app_localizations_vi.dart
@@ -4703,7 +4703,10 @@ class AppLocalizationsVi extends AppLocalizations {
   }
 
   @override
-  String accessesAndTriggeredBy(String accessDescription, String triggerDescription) {
+  String accessesAndTriggeredBy(
+    String accessDescription,
+    String triggerDescription,
+  ) {
     return '$accessDescription và $triggerDescription.';
   }
 
@@ -9571,4 +9574,25 @@ class AppLocalizationsVi extends AppLocalizations {
   String errorConnectingRayBanMeta(String error) {
     return 'Lỗi khi kết nối với Ray-Ban Meta: $error';
   }
+
+  @override
+  String get deviceStorageTitle => 'Bộ nhớ thiết bị';
+
+  @override
+  String deviceStoragePercentFull(int percent) {
+    return 'Đã đầy $percent%';
+  }
+
+  @override
+  String deviceStorageUsedOfTotal(String used, String total) {
+    return 'Đã dùng $used trong $total';
+  }
+
+  @override
+  String deviceStorageFree(String free) {
+    return 'Còn trống $free';
+  }
+
+  @override
+  String get deviceStorageNearlyFull => 'Thiết bị gần đầy — đồng bộ để giải phóng dung lượng.';
 }

--- a/app/lib/l10n/app_localizations_vi.dart
+++ b/app/lib/l10n/app_localizations_vi.dart
@@ -4703,10 +4703,7 @@ class AppLocalizationsVi extends AppLocalizations {
   }
 
   @override
-  String accessesAndTriggeredBy(
-    String accessDescription,
-    String triggerDescription,
-  ) {
+  String accessesAndTriggeredBy(String accessDescription, String triggerDescription) {
     return '$accessDescription và $triggerDescription.';
   }
 

--- a/app/lib/l10n/app_localizations_zh.dart
+++ b/app/lib/l10n/app_localizations_zh.dart
@@ -4603,10 +4603,7 @@ class AppLocalizationsZh extends AppLocalizations {
   }
 
   @override
-  String accessesAndTriggeredBy(
-    String accessDescription,
-    String triggerDescription,
-  ) {
+  String accessesAndTriggeredBy(String accessDescription, String triggerDescription) {
     return '$accessDescription，$triggerDescription。';
   }
 

--- a/app/lib/l10n/app_localizations_zh.dart
+++ b/app/lib/l10n/app_localizations_zh.dart
@@ -4603,7 +4603,10 @@ class AppLocalizationsZh extends AppLocalizations {
   }
 
   @override
-  String accessesAndTriggeredBy(String accessDescription, String triggerDescription) {
+  String accessesAndTriggeredBy(
+    String accessDescription,
+    String triggerDescription,
+  ) {
     return '$accessDescription，$triggerDescription。';
   }
 
@@ -9398,4 +9401,25 @@ class AppLocalizationsZh extends AppLocalizations {
   String errorConnectingRayBanMeta(String error) {
     return '连接 Ray-Ban Meta 时出错：$error';
   }
+
+  @override
+  String get deviceStorageTitle => '设备存储';
+
+  @override
+  String deviceStoragePercentFull(int percent) {
+    return '已用 $percent%';
+  }
+
+  @override
+  String deviceStorageUsedOfTotal(String used, String total) {
+    return '$total 中已使用 $used';
+  }
+
+  @override
+  String deviceStorageFree(String free) {
+    return '剩余 $free';
+  }
+
+  @override
+  String get deviceStorageNearlyFull => '设备快满了 — 请同步以释放空间。';
 }

--- a/app/lib/l10n/app_lt.arb
+++ b/app/lib/l10n/app_lt.arb
@@ -3143,5 +3143,10 @@
                 "type": "String"
             }
         }
-    }
+    },
+    "deviceStorageTitle": "Įrenginio saugykla",
+    "deviceStoragePercentFull": "užpildyta {percent}%",
+    "deviceStorageUsedOfTotal": "panaudota {used} iš {total}",
+    "deviceStorageFree": "{free} laisva",
+    "deviceStorageNearlyFull": "Įrenginys beveik pilnas — sinchronizuokite, kad atlaisvintumėte vietos."
 }

--- a/app/lib/l10n/app_lv.arb
+++ b/app/lib/l10n/app_lv.arb
@@ -3143,5 +3143,10 @@
                 "type": "String"
             }
         }
-    }
+    },
+    "deviceStorageTitle": "Ierīces krātuve",
+    "deviceStoragePercentFull": "{percent}% aizpildīts",
+    "deviceStorageUsedOfTotal": "izmantoti {used} no {total}",
+    "deviceStorageFree": "{free} brīvi",
+    "deviceStorageNearlyFull": "Ierīce ir gandrīz pilna — sinhronizējiet, lai atbrīvotu vietu."
 }

--- a/app/lib/l10n/app_mk.arb
+++ b/app/lib/l10n/app_mk.arb
@@ -10721,5 +10721,10 @@
                 "type": "String"
             }
         }
-    }
+    },
+    "deviceStorageTitle": "Меморија на уредот",
+    "deviceStoragePercentFull": "{percent}% полна",
+    "deviceStorageUsedOfTotal": "{used} од {total} искористени",
+    "deviceStorageFree": "{free} слободни",
+    "deviceStorageNearlyFull": "Уредот е речиси полн — синхронизирајте за да ослободите простор."
 }

--- a/app/lib/l10n/app_mr.arb
+++ b/app/lib/l10n/app_mr.arb
@@ -10721,5 +10721,10 @@
                 "type": "String"
             }
         }
-    }
+    },
+    "deviceStorageTitle": "डिव्हाइस स्टोरेज",
+    "deviceStoragePercentFull": "{percent}% भरले",
+    "deviceStorageUsedOfTotal": "{total} पैकी {used} वापरले",
+    "deviceStorageFree": "{free} रिकामे",
+    "deviceStorageNearlyFull": "डिव्हाइस जवळजवळ भरले आहे — जागा मोकळी करण्यासाठी सिंक करा."
 }

--- a/app/lib/l10n/app_ms.arb
+++ b/app/lib/l10n/app_ms.arb
@@ -3143,5 +3143,10 @@
                 "type": "String"
             }
         }
-    }
+    },
+    "deviceStorageTitle": "Storan peranti",
+    "deviceStoragePercentFull": "{percent}% penuh",
+    "deviceStorageUsedOfTotal": "{used} daripada {total} digunakan",
+    "deviceStorageFree": "{free} bebas",
+    "deviceStorageNearlyFull": "Peranti hampir penuh — segerakkan untuk mengosongkan ruang."
 }

--- a/app/lib/l10n/app_nl.arb
+++ b/app/lib/l10n/app_nl.arb
@@ -3143,5 +3143,10 @@
                 "type": "String"
             }
         }
-    }
+    },
+    "deviceStorageTitle": "Apparaatopslag",
+    "deviceStoragePercentFull": "{percent}% vol",
+    "deviceStorageUsedOfTotal": "{used} van {total} gebruikt",
+    "deviceStorageFree": "{free} vrij",
+    "deviceStorageNearlyFull": "Apparaat bijna vol — synchroniseer om ruimte vrij te maken."
 }

--- a/app/lib/l10n/app_no.arb
+++ b/app/lib/l10n/app_no.arb
@@ -3143,5 +3143,10 @@
                 "type": "String"
             }
         }
-    }
+    },
+    "deviceStorageTitle": "Enhetslagring",
+    "deviceStoragePercentFull": "{percent}% fullt",
+    "deviceStorageUsedOfTotal": "{used} av {total} brukt",
+    "deviceStorageFree": "{free} ledig",
+    "deviceStorageNearlyFull": "Enheten er nesten full — synkroniser for å frigjøre plass."
 }

--- a/app/lib/l10n/app_pl.arb
+++ b/app/lib/l10n/app_pl.arb
@@ -3178,5 +3178,10 @@
                 "type": "String"
             }
         }
-    }
+    },
+    "deviceStorageTitle": "Pamięć urządzenia",
+    "deviceStoragePercentFull": "zapełniono {percent}%",
+    "deviceStorageUsedOfTotal": "wykorzystano {used} z {total}",
+    "deviceStorageFree": "{free} wolne",
+    "deviceStorageNearlyFull": "Urządzenie jest prawie pełne — zsynchronizuj, aby zwolnić miejsce."
 }

--- a/app/lib/l10n/app_pt.arb
+++ b/app/lib/l10n/app_pt.arb
@@ -3179,5 +3179,10 @@
                 "type": "String"
             }
         }
-    }
+    },
+    "deviceStorageTitle": "Armazenamento do dispositivo",
+    "deviceStoragePercentFull": "{percent}% cheio",
+    "deviceStorageUsedOfTotal": "{used} de {total} usado",
+    "deviceStorageFree": "{free} livre",
+    "deviceStorageNearlyFull": "Dispositivo quase cheio — sincronize para liberar espaço."
 }

--- a/app/lib/l10n/app_ro.arb
+++ b/app/lib/l10n/app_ro.arb
@@ -3143,5 +3143,10 @@
                 "type": "String"
             }
         }
-    }
+    },
+    "deviceStorageTitle": "Stocarea dispozitivului",
+    "deviceStoragePercentFull": "{percent}% plin",
+    "deviceStorageUsedOfTotal": "{used} din {total} utilizat",
+    "deviceStorageFree": "{free} liber",
+    "deviceStorageNearlyFull": "Dispozitivul este aproape plin — sincronizează pentru a elibera spațiu."
 }

--- a/app/lib/l10n/app_ru.arb
+++ b/app/lib/l10n/app_ru.arb
@@ -3178,5 +3178,10 @@
                 "type": "String"
             }
         }
-    }
+    },
+    "deviceStorageTitle": "Хранилище устройства",
+    "deviceStoragePercentFull": "заполнено {percent}%",
+    "deviceStorageUsedOfTotal": "использовано {used} из {total}",
+    "deviceStorageFree": "{free} свободно",
+    "deviceStorageNearlyFull": "Устройство почти заполнено — синхронизируйте, чтобы освободить место."
 }

--- a/app/lib/l10n/app_sk.arb
+++ b/app/lib/l10n/app_sk.arb
@@ -3148,5 +3148,10 @@
                 "type": "String"
             }
         }
-    }
+    },
+    "deviceStorageTitle": "Úložisko zariadenia",
+    "deviceStoragePercentFull": "{percent}% zaplnené",
+    "deviceStorageUsedOfTotal": "{used} z {total} využité",
+    "deviceStorageFree": "{free} voľných",
+    "deviceStorageNearlyFull": "Zariadenie je takmer plné — synchronizujte, aby ste uvoľnili miesto."
 }

--- a/app/lib/l10n/app_sl.arb
+++ b/app/lib/l10n/app_sl.arb
@@ -10721,5 +10721,10 @@
                 "type": "String"
             }
         }
-    }
+    },
+    "deviceStorageTitle": "Shramba naprave",
+    "deviceStoragePercentFull": "{percent}% zasedeno",
+    "deviceStorageUsedOfTotal": "{used} od {total} porabljeno",
+    "deviceStorageFree": "{free} prosto",
+    "deviceStorageNearlyFull": "Naprava je skoraj polna — sinhronizirajte za sprostitev prostora."
 }

--- a/app/lib/l10n/app_sr.arb
+++ b/app/lib/l10n/app_sr.arb
@@ -10721,5 +10721,10 @@
                 "type": "String"
             }
         }
-    }
+    },
+    "deviceStorageTitle": "Меморија уређаја",
+    "deviceStoragePercentFull": "{percent}% попуњено",
+    "deviceStorageUsedOfTotal": "{used} од {total} искоришћено",
+    "deviceStorageFree": "{free} слободно",
+    "deviceStorageNearlyFull": "Уређај је скоро пун — синхронизујте да ослободите простор."
 }

--- a/app/lib/l10n/app_sv.arb
+++ b/app/lib/l10n/app_sv.arb
@@ -3143,5 +3143,10 @@
                 "type": "String"
             }
         }
-    }
+    },
+    "deviceStorageTitle": "Enhetens lagring",
+    "deviceStoragePercentFull": "{percent}% fullt",
+    "deviceStorageUsedOfTotal": "{used} av {total} använt",
+    "deviceStorageFree": "{free} ledigt",
+    "deviceStorageNearlyFull": "Enheten är nästan full — synkronisera för att frigöra utrymme."
 }

--- a/app/lib/l10n/app_ta.arb
+++ b/app/lib/l10n/app_ta.arb
@@ -10721,5 +10721,10 @@
                 "type": "String"
             }
         }
-    }
+    },
+    "deviceStorageTitle": "சாதன சேமிப்பு",
+    "deviceStoragePercentFull": "{percent}% நிரம்பியது",
+    "deviceStorageUsedOfTotal": "{total} இல் {used} பயன்படுத்தப்பட்டது",
+    "deviceStorageFree": "{free} காலி",
+    "deviceStorageNearlyFull": "சாதனம் கிட்டத்தட்ட நிரம்பிவிட்டது — இடத்தைக் காலி செய்ய ஒத்திசைக்கவும்."
 }

--- a/app/lib/l10n/app_te.arb
+++ b/app/lib/l10n/app_te.arb
@@ -10721,5 +10721,10 @@
                 "type": "String"
             }
         }
-    }
+    },
+    "deviceStorageTitle": "పరికర నిల్వ",
+    "deviceStoragePercentFull": "{percent}% నిండింది",
+    "deviceStorageUsedOfTotal": "{total} లో {used} ఉపయోగించబడింది",
+    "deviceStorageFree": "{free} ఖాళీ",
+    "deviceStorageNearlyFull": "పరికరం దాదాపు నిండిపోయింది — స్థలాన్ని ఖాళీ చేయడానికి సింక్ చేయండి."
 }

--- a/app/lib/l10n/app_th.arb
+++ b/app/lib/l10n/app_th.arb
@@ -3143,5 +3143,10 @@
                 "type": "String"
             }
         }
-    }
+    },
+    "deviceStorageTitle": "ที่จัดเก็บของอุปกรณ์",
+    "deviceStoragePercentFull": "เต็ม {percent}%",
+    "deviceStorageUsedOfTotal": "ใช้ไป {used} จาก {total}",
+    "deviceStorageFree": "ว่าง {free}",
+    "deviceStorageNearlyFull": "อุปกรณ์เกือบเต็มแล้ว — ซิงค์เพื่อเพิ่มพื้นที่ว่าง"
 }

--- a/app/lib/l10n/app_tl.arb
+++ b/app/lib/l10n/app_tl.arb
@@ -10721,5 +10721,10 @@
                 "type": "String"
             }
         }
-    }
+    },
+    "deviceStorageTitle": "Storage ng device",
+    "deviceStoragePercentFull": "{percent}% puno",
+    "deviceStorageUsedOfTotal": "{used} sa {total} ang nagamit",
+    "deviceStorageFree": "{free} ang libre",
+    "deviceStorageNearlyFull": "Halos puno na ang device — mag-sync para magbakante ng espasyo."
 }

--- a/app/lib/l10n/app_tr.arb
+++ b/app/lib/l10n/app_tr.arb
@@ -3178,5 +3178,10 @@
                 "type": "String"
             }
         }
-    }
+    },
+    "deviceStorageTitle": "Cihaz depolama",
+    "deviceStoragePercentFull": "%{percent} dolu",
+    "deviceStorageUsedOfTotal": "{total} alanın {used} kısmı kullanıldı",
+    "deviceStorageFree": "{free} boş",
+    "deviceStorageNearlyFull": "Cihaz neredeyse dolu — yer açmak için eşitleyin."
 }

--- a/app/lib/l10n/app_uk.arb
+++ b/app/lib/l10n/app_uk.arb
@@ -3143,5 +3143,10 @@
                 "type": "String"
             }
         }
-    }
+    },
+    "deviceStorageTitle": "Сховище пристрою",
+    "deviceStoragePercentFull": "заповнено {percent}%",
+    "deviceStorageUsedOfTotal": "використано {used} з {total}",
+    "deviceStorageFree": "{free} вільно",
+    "deviceStorageNearlyFull": "Пристрій майже заповнений — синхронізуйте, щоб звільнити місце."
 }

--- a/app/lib/l10n/app_ur.arb
+++ b/app/lib/l10n/app_ur.arb
@@ -10721,5 +10721,10 @@
                 "type": "String"
             }
         }
-    }
+    },
+    "deviceStorageTitle": "آلے کا اسٹوریج",
+    "deviceStoragePercentFull": "{percent}% بھرا",
+    "deviceStorageUsedOfTotal": "{total} میں سے {used} استعمال شدہ",
+    "deviceStorageFree": "{free} خالی",
+    "deviceStorageNearlyFull": "آلہ تقریباً بھر چکا ہے — جگہ خالی کرنے کے لیے سنک کریں۔"
 }

--- a/app/lib/l10n/app_vi.arb
+++ b/app/lib/l10n/app_vi.arb
@@ -3148,5 +3148,10 @@
                 "type": "String"
             }
         }
-    }
+    },
+    "deviceStorageTitle": "Bộ nhớ thiết bị",
+    "deviceStoragePercentFull": "Đã đầy {percent}%",
+    "deviceStorageUsedOfTotal": "Đã dùng {used} trong {total}",
+    "deviceStorageFree": "Còn trống {free}",
+    "deviceStorageNearlyFull": "Thiết bị gần đầy — đồng bộ để giải phóng dung lượng."
 }

--- a/app/lib/l10n/app_zh.arb
+++ b/app/lib/l10n/app_zh.arb
@@ -3165,5 +3165,10 @@
                 "type": "String"
             }
         }
-    }
+    },
+    "deviceStorageTitle": "设备存储",
+    "deviceStoragePercentFull": "已用 {percent}%",
+    "deviceStorageUsedOfTotal": "{total} 中已使用 {used}",
+    "deviceStorageFree": "剩余 {free}",
+    "deviceStorageNearlyFull": "设备快满了 — 请同步以释放空间。"
 }

--- a/app/lib/pages/conversations/auto_sync_page.dart
+++ b/app/lib/pages/conversations/auto_sync_page.dart
@@ -6,6 +6,8 @@ import 'package:omi/backend/preferences.dart';
 import 'package:omi/models/sync_state.dart';
 import 'package:omi/pages/conversations/local_storage_page.dart';
 import 'package:omi/pages/conversations/private_cloud_sync_page.dart';
+import 'package:omi/pages/conversations/widgets/device_storage_card.dart';
+import 'package:omi/providers/device_provider.dart';
 import 'package:omi/providers/sync_provider.dart';
 import 'package:omi/providers/user_provider.dart';
 import 'package:omi/services/wals.dart';
@@ -36,14 +38,15 @@ class _AutoSyncPageState extends State<AutoSyncPage> {
     super.initState();
     WidgetsBinding.instance.addPostFrameCallback((_) {
       context.read<SyncProvider>().refreshWals();
+      context.read<DeviceProvider>().refreshRingStorageStatus();
       SyncReconciler.instance.poke();
     });
   }
 
   @override
   Widget build(BuildContext context) {
-    return Consumer2<SyncProvider, UserProvider>(
-      builder: (context, syncProvider, userProvider, _) {
+    return Consumer3<SyncProvider, UserProvider, DeviceProvider>(
+      builder: (context, syncProvider, userProvider, deviceProvider, _) {
         final syncState = syncProvider.syncState;
         final pendingWals = syncProvider.pendingWals;
         final syncedWals = syncProvider.syncedWals;
@@ -92,6 +95,11 @@ class _AutoSyncPageState extends State<AutoSyncPage> {
                       _buildConversationsCard(syncProvider),
                     ],
                     if (syncState.hasError) ...[const SizedBox(height: 16), _buildErrorCard(syncState, syncProvider)],
+                    if (WalSyncs.isRingBufferFirmware(deviceProvider.currentFirmwareVersion) &&
+                        deviceProvider.ringStatus != null) ...[
+                      const SizedBox(height: 32),
+                      DeviceStorageCard(status: deviceProvider.ringStatus!),
+                    ],
                     const SizedBox(height: 32),
                     _buildStorageSettings(userProvider),
                     if (hasAnyRecording) ...[

--- a/app/lib/pages/conversations/widgets/device_storage_card.dart
+++ b/app/lib/pages/conversations/widgets/device_storage_card.dart
@@ -23,9 +23,11 @@ class DeviceStorageCard extends StatelessWidget {
     final percent = (fraction * 100).round();
     final nearlyFull = fraction >= 0.95;
 
+    // Neutral white for normal usage (brand INV-UI-1: white/neutral accents);
+    // amber/red are reserved for the near-full warning/critical bands.
     final Color barColor = fraction >= 0.95
         ? ResponsiveHelper.errorColor
-        : (fraction >= 0.80 ? ResponsiveHelper.warningColor : ResponsiveHelper.purplePrimary);
+        : (fraction >= 0.80 ? ResponsiveHelper.warningColor : Colors.white);
 
     return Container(
       padding: const EdgeInsets.all(16),

--- a/app/lib/pages/conversations/widgets/device_storage_card.dart
+++ b/app/lib/pages/conversations/widgets/device_storage_card.dart
@@ -1,0 +1,76 @@
+import 'package:flutter/material.dart';
+
+import 'package:omi/services/devices/connectors/device_connection.dart';
+import 'package:omi/utils/audio/wav_bytes.dart';
+import 'package:omi/utils/l10n_extensions.dart';
+import 'package:omi/utils/responsive/responsive_helper.dart';
+
+/// On-device ring-buffer storage usage indicator, shown on the Auto Sync page
+/// for firmware 3.0.20+ devices. Compact card: title + % full, a slim usage
+/// bar (amber ≥80%, red ≥95%), and a "used of total · free" summary line.
+class DeviceStorageCard extends StatelessWidget {
+  final RingStatus status;
+
+  const DeviceStorageCard({super.key, required this.status});
+
+  @override
+  Widget build(BuildContext context) {
+    final l = context.l10n;
+    final used = status.usedBytes < 0 ? 0 : status.usedBytes;
+    final free = status.freeBytes < 0 ? 0 : status.freeBytes;
+    final total = used + free;
+    final fraction = total == 0 ? 0.0 : (used / total).clamp(0.0, 1.0);
+    final percent = (fraction * 100).round();
+    final nearlyFull = fraction >= 0.95;
+
+    final Color barColor = fraction >= 0.95
+        ? ResponsiveHelper.errorColor
+        : (fraction >= 0.80 ? ResponsiveHelper.warningColor : ResponsiveHelper.purplePrimary);
+
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(color: const Color(0xFF1C1C1E), borderRadius: BorderRadius.circular(20)),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Expanded(
+                child: Text(
+                  l.deviceStorageTitle,
+                  style: const TextStyle(color: Colors.white, fontSize: 15, fontWeight: FontWeight.w500),
+                ),
+              ),
+              Text(
+                l.deviceStoragePercentFull(percent),
+                style: TextStyle(color: barColor, fontSize: 14, fontWeight: FontWeight.w600),
+              ),
+            ],
+          ),
+          const SizedBox(height: 12),
+          ClipRRect(
+            borderRadius: BorderRadius.circular(3),
+            child: LinearProgressIndicator(
+              value: fraction,
+              minHeight: 6,
+              backgroundColor: Colors.grey.shade800,
+              valueColor: AlwaysStoppedAnimation<Color>(barColor),
+            ),
+          ),
+          const SizedBox(height: 10),
+          Text(
+            '${l.deviceStorageUsedOfTotal(WavBytesUtil.formatBytes(used, decimals: 0), WavBytesUtil.formatBytes(total, decimals: 0))}  ·  ${l.deviceStorageFree(WavBytesUtil.formatBytes(free, decimals: 0))}',
+            style: TextStyle(color: Colors.grey.shade500, fontSize: 13, fontWeight: FontWeight.w400),
+          ),
+          if (nearlyFull) ...[
+            const SizedBox(height: 8),
+            Text(
+              l.deviceStorageNearlyFull,
+              style: const TextStyle(color: ResponsiveHelper.errorColor, fontSize: 13, fontWeight: FontWeight.w400),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}

--- a/app/lib/providers/device_provider.dart
+++ b/app/lib/providers/device_provider.dart
@@ -15,6 +15,7 @@ import 'package:omi/pages/home/omiglass_ota_update.dart';
 import 'package:omi/providers/capture_provider.dart';
 import 'package:omi/providers/local_recordings_provider.dart';
 import 'package:omi/services/devices.dart';
+import 'package:omi/services/devices/connectors/device_connection.dart';
 import 'package:omi/services/devices/connectors/omi_connection.dart';
 import 'package:omi/services/notifications.dart';
 import 'package:omi/services/services.dart';
@@ -34,6 +35,13 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
   bool isConnected = false;
   bool isDeviceStorageSupport = false;
   bool supportsMultiFileSync = SharedPreferencesUtil().deviceSupportsMultiFileSync;
+
+  // Latest on-device ring-buffer storage snapshot (firmware 3.0.20+ only).
+  // Surfaced on the Auto Sync page as a storage-usage indicator. Null when the
+  // device predates the ring protocol or hasn't been read yet.
+  RingStatus? _ringStatus;
+  RingStatus? get ringStatus => _ringStatus;
+
   BtDevice? connectedDevice;
   BtDevice? pairedDevice;
   StreamSubscription<List<int>>? _bleBatteryLevelListener;
@@ -524,6 +532,10 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
       // ring firmware no longer serves).
       if (WalSyncs.isRingBufferFirmware(fwVersion)) {
         final ringStatus = await connection.getRingStatus();
+        if (ringStatus != null) {
+          _ringStatus = ringStatus;
+          notifyListeners();
+        }
         if (ringStatus == null || ringStatus.unreadPackets <= 0) return;
         Logger.debug(
           'DeviceProvider: Ring auto-sync detected ${ringStatus.unreadPackets} unread packets (${ringStatus.usedBytes} bytes)',
@@ -539,6 +551,27 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
       onOfflineDataDetected?.call(device, status.fileCount, status.totalUsedBytes);
     } catch (e) {
       Logger.debug('DeviceProvider: Auto-sync check failed: $e');
+    }
+  }
+
+  /// Refresh the on-device ring-buffer storage snapshot for the storage-usage
+  /// indicator. No-op on firmware < 3.0.20 (the ring protocol isn't served) or
+  /// when there's no active connection. Safe to call from UI (e.g. on page open).
+  Future<void> refreshRingStorageStatus() async {
+    try {
+      final fwVersion = pairedDevice?.firmwareRevision ?? connectedDevice?.firmwareRevision;
+      if (!WalSyncs.isRingBufferFirmware(fwVersion)) return;
+      final deviceId = pairedDevice?.id ?? connectedDevice?.id;
+      if (deviceId == null) return;
+      final connection = await ServiceManager.instance().device.ensureConnection(deviceId);
+      if (connection == null) return;
+      final status = await connection.getRingStatus();
+      if (status != null) {
+        _ringStatus = status;
+        notifyListeners();
+      }
+    } catch (e) {
+      Logger.debug('DeviceProvider: refreshRingStorageStatus failed: $e');
     }
   }
 

--- a/app/test/widgets/device_storage_card_test.dart
+++ b/app/test/widgets/device_storage_card_test.dart
@@ -1,0 +1,75 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:omi/l10n/app_localizations.dart';
+import 'package:omi/pages/conversations/widgets/device_storage_card.dart';
+import 'package:omi/services/devices/connectors/device_connection.dart';
+import 'package:omi/utils/responsive/responsive_helper.dart';
+
+const int _mb = 1024 * 1024;
+
+Widget _app(Widget child) {
+  return MaterialApp(
+    localizationsDelegates: const [
+      AppLocalizations.delegate,
+      GlobalMaterialLocalizations.delegate,
+      GlobalWidgetsLocalizations.delegate,
+      GlobalCupertinoLocalizations.delegate,
+    ],
+    supportedLocales: AppLocalizations.supportedLocales,
+    home: Scaffold(body: child),
+  );
+}
+
+RingStatus _status({required int usedMb, required int freeMb}) =>
+    RingStatus(usedBytes: usedMb * _mb, unreadPackets: 0, freeBytes: freeMb * _mb, rtcValid: 1);
+
+Color? _barColor(WidgetTester tester) {
+  final indicator = tester.widget<LinearProgressIndicator>(find.byType(LinearProgressIndicator));
+  return indicator.valueColor?.value;
+}
+
+void main() {
+  testWidgets('normal fill: percent, bar value and purple color, no warning', (tester) async {
+    await tester.pumpWidget(_app(DeviceStorageCard(status: _status(usedMb: 338, freeMb: 131))));
+    await tester.pump();
+
+    // 338 / (338+131) = 0.7207 -> 72%
+    expect(find.text('72% full'), findsOneWidget);
+    expect(find.textContaining('338 MB of 469 MB used'), findsOneWidget);
+    expect(find.textContaining('131 MB free'), findsOneWidget);
+
+    final indicator = tester.widget<LinearProgressIndicator>(find.byType(LinearProgressIndicator));
+    expect(indicator.value, closeTo(0.7207, 0.001));
+    expect(_barColor(tester), ResponsiveHelper.purplePrimary);
+
+    // No nearly-full warning below 95%.
+    expect(find.text('Device nearly full — sync to free space.'), findsNothing);
+  });
+
+  testWidgets('warning band (>=80%, <95%) turns the bar amber', (tester) async {
+    // 400 / 469 = 0.853
+    await tester.pumpWidget(_app(DeviceStorageCard(status: _status(usedMb: 400, freeMb: 69))));
+    await tester.pump();
+    expect(_barColor(tester), ResponsiveHelper.warningColor);
+    expect(find.text('Device nearly full — sync to free space.'), findsNothing);
+  });
+
+  testWidgets('nearly full (>=95%) turns bar red and shows the sync hint', (tester) async {
+    // 460 / 469 = 0.981
+    await tester.pumpWidget(_app(DeviceStorageCard(status: _status(usedMb: 460, freeMb: 9))));
+    await tester.pump();
+    expect(find.text('98% full'), findsOneWidget);
+    expect(_barColor(tester), ResponsiveHelper.errorColor);
+    expect(find.text('Device nearly full — sync to free space.'), findsOneWidget);
+  });
+
+  testWidgets('empty device: zero total does not divide by zero', (tester) async {
+    await tester.pumpWidget(_app(DeviceStorageCard(status: _status(usedMb: 0, freeMb: 0))));
+    await tester.pump();
+    expect(find.text('0% full'), findsOneWidget);
+    final indicator = tester.widget<LinearProgressIndicator>(find.byType(LinearProgressIndicator));
+    expect(indicator.value, 0.0);
+  });
+}

--- a/app/test/widgets/device_storage_card_test.dart
+++ b/app/test/widgets/device_storage_card_test.dart
@@ -31,7 +31,7 @@ Color? _barColor(WidgetTester tester) {
 }
 
 void main() {
-  testWidgets('normal fill: percent, bar value and purple color, no warning', (tester) async {
+  testWidgets('normal fill: percent, bar value and neutral color, no warning', (tester) async {
     await tester.pumpWidget(_app(DeviceStorageCard(status: _status(usedMb: 338, freeMb: 131))));
     await tester.pump();
 
@@ -42,7 +42,7 @@ void main() {
 
     final indicator = tester.widget<LinearProgressIndicator>(find.byType(LinearProgressIndicator));
     expect(indicator.value, closeTo(0.7207, 0.001));
-    expect(_barColor(tester), ResponsiveHelper.purplePrimary);
+    expect(_barColor(tester), Colors.white);
 
     // No nearly-full warning below 95%.
     expect(find.text('Device nearly full — sync to free space.'), findsNothing);


### PR DESCRIPTION
## What

Adds a **Device Storage** usage indicator to the Auto Sync page, shown only for devices on **firmware 3.0.20+** (the ring-buffer protocol). It surfaces how full the on-device audio ring is — used / total, % full, and free space — so users know when to sync before the ring overwrites unsynced audio.

The reading already existed on the wire: `getRingStatus()` reads the 16-byte storage status characteristic (`used / unread / free / rtcValid`). Today that value is read once during auto-sync detection and discarded; this PR caches it on `DeviceProvider` and renders it.

## UI

Compact card above the STORAGE settings section: title + `% full`, a slim usage bar, and a `used of total · free` summary line. The bar shifts **purple → amber (≥80%) → red (≥95%)**, and a "Device nearly full — sync to free space." hint appears at ≥95%. Design follows the WhatsApp/Spotify storage patterns adapted to omi's dark card style.

On firmware < 3.0.20, no paired device, or no reading available, the card is simply absent — no regression for existing users.

## Changes

- `providers/device_provider.dart` — `ringStatus` getter + `refreshRingStorageStatus()`; also caches the reading on the existing auto-sync ring path (no extra BLE read).
- `pages/conversations/widgets/device_storage_card.dart` (new) — the presentational card (reuses `WavBytesUtil.formatBytes`, `ResponsiveHelper` colors).
- `pages/conversations/auto_sync_page.dart` — `Consumer3` incl. `DeviceProvider`; refresh on page open; gated render via `WalSyncs.isRingBufferFirmware`.
- l10n — 5 `deviceStorage*` keys added to the English template and translated across all 48 other locales (+ regenerated Dart).

## Testing

- `test/widgets/device_storage_card_test.dart` — 4 tests: normal fill (72%, purple, no hint), warning band (amber), nearly-full (red + hint), and zero-total (no divide-by-zero). All pass.
- `flutter analyze` clean on the new code.
- `flutter gen-l10n` — zero untranslated messages across 49 locales.

**Not yet exercised:** the device-connected end-to-end (real `getRingStatus()` → card on a physical 3.0.20+ device over BLE) — needs hardware. The widget tests cover the card's rendering/logic; the BLE→provider→UI path is unverified on-device.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9568?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

