### PR TITLE
fix(mcp): fall back to doc.id and skip a malformed key in get_mcp_keys_for_user

### DIFF
--- a/backend/database/mcp_api_key.py
+++ b/backend/database/mcp_api_key.py
@@ -4,6 +4,7 @@ import logging
 from typing import Any, Dict, Optional, Tuple, cast
 
 from google.cloud import firestore
+from pydantic import ValidationError
 
 import database.redis_db as redis_db
 from database._client import get_firestore_client
@@ -168,7 +169,13 @@ def get_mcp_keys_for_user(user_id: str) -> list[McpApiKey]:
     for doc in docs:
         raw: object = doc.to_dict()
         data: Dict[str, Any] = cast(Dict[str, Any], raw) if isinstance(raw, dict) else {}
-        keys.append(McpApiKey.model_validate(data))
+        # Older key docs may omit the id field; fall back to the document id, mirroring the other
+        # readers in this module. Skip a genuinely malformed/legacy key rather than 500 the whole list.
+        data["id"] = data.get("id") or doc.id
+        try:
+            keys.append(McpApiKey.model_validate(data))
+        except ValidationError as e:
+            logger.warning("Skipping malformed MCP key %s: %s", doc.id, e)
     return keys
 
 

--- a/backend/tests/unit/test_mcp_keys_legacy_doc.py
+++ b/backend/tests/unit/test_mcp_keys_legacy_doc.py
@@ -1,0 +1,79 @@
+"""get_mcp_keys_for_user must fall back to doc.id and skip a malformed legacy key, not 500 the list.
+
+GET /v1/mcp/keys built McpApiKey.model_validate(doc.to_dict()) per key with no id fallback and no
+try/except. Firestore doc.to_dict() omits the doc id, and older key docs may lack an explicit id
+field, so one legacy/malformed key raised ValidationError and 500'd the whole list. It now falls
+back to doc.id (mirroring the other readers in the module) and skips a genuinely malformed key.
+"""
+
+import os
+
+os.environ.setdefault(
+    'ENCRYPTION_SECRET',
+    'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv',
+)
+
+from unittest.mock import MagicMock
+
+import pytest
+from pydantic import BaseModel, ValidationError
+
+import database.mcp_api_key as mcp_key
+
+
+class _Probe(BaseModel):
+    x: int
+
+
+def _validation_error() -> ValidationError:
+    try:
+        _Probe.model_validate({})
+    except ValidationError as exc:
+        return exc
+    raise AssertionError('expected a ValidationError')
+
+
+def _doc(doc_id, data):
+    doc = MagicMock()
+    doc.id = doc_id
+    doc.to_dict.return_value = data
+    return doc
+
+
+def _patch_client(monkeypatch, docs):
+    fake = MagicMock()
+    for attr in ('collection', 'where', 'order_by'):
+        getattr(fake, attr).return_value = fake
+    fake.stream.return_value = docs
+    monkeypatch.setattr(mcp_key, '_db', lambda: fake)
+
+
+def test_id_fallback_and_skip_malformed(monkeypatch):
+    err = _validation_error()
+
+    def fake_validate(data):
+        if data.get('_bad'):
+            raise err
+        return data  # return the dict so the resolved id is inspectable
+
+    monkeypatch.setattr(mcp_key.McpApiKey, 'model_validate', staticmethod(fake_validate))
+    _patch_client(
+        monkeypatch,
+        [
+            _doc('k1', {'id': 'k1', 'name': 'n'}),  # explicit id preserved
+            _doc('legacy-id', {'name': 'n2'}),  # missing id field -> falls back to doc.id
+            _doc('bad-id', {'_bad': True}),  # malformed -> skipped, not a 500
+        ],
+    )
+    result = mcp_key.get_mcp_keys_for_user('u1')
+    assert [k['id'] for k in result] == ['k1', 'legacy-id']
+
+
+def test_unexpected_error_propagates(monkeypatch):
+    def boom(data):
+        raise RuntimeError('unexpected')
+
+    monkeypatch.setattr(mcp_key.McpApiKey, 'model_validate', staticmethod(boom))
+    _patch_client(monkeypatch, [_doc('k1', {'id': 'k1'})])
+    with pytest.raises(RuntimeError):
+        mcp_key.get_mcp_keys_for_user('u1')


### PR DESCRIPTION
## Problem
`get_mcp_keys_for_user` (`GET /v1/mcp/keys`) built `McpApiKey.model_validate(doc.to_dict())` per key with no id fallback and no try/except. Firestore `doc.to_dict()` omits the document id, and (per this module's own docstring: "Older key documents may be missing the app identity, scopes, and memory grant state") older key docs may lack the `id` field. `McpApiKey` requires `id`/`name`/`key_prefix`/`created_at`, so one legacy or malformed key raises `ValidationError` and 500s the whole list.

## Fix
Fall back to the document id (`data["id"] = data.get("id") or doc.id`), exactly as the sibling readers `delete_mcp_key` and `get_user_and_scopes_by_api_key` already do, and wrap the per-item validate in `try/except ValidationError` to skip a genuinely malformed key with a log. The except is narrow, so an unexpected error still propagates.

## Test
`tests/unit/test_mcp_keys_legacy_doc.py` patches `_db` with a fake stream (an explicit-id key, a legacy key missing the id field, and a malformed key): the legacy key resolves to `doc.id`, the malformed one is skipped, and a non-`ValidationError` propagates.

## Verification
- `pytest tests/unit/test_mcp_keys_legacy_doc.py` -> 2 passed
- `black --check` clean; `check_module_stub_pollution` -> 0; `scan_async_blockers` -> 0


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9569?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

