### PR TITLE
fix(sync): stop refusing offline uploads — Cloud Tasks queue is the pacer

### DIFF
--- a/backend/tests/unit/test_sync_two_lane.py
+++ b/backend/tests/unit/test_sync_two_lane.py
@@ -253,6 +253,9 @@ def test_server_manifest_allows_only_one_content_set_per_conversation(monkeypatc
 
 
 def test_backfill_reservation_maps_user_and_global_caps(monkeypatch):
+    # Admission caps are opt-in now (Cloud Tasks queue is the pacer); enable them
+    # to exercise the user/global cap → reason mapping.
+    monkeypatch.setenv('SYNC_BACKFILL_ADMISSION_LIMITS', 'true')
     redis = MagicMock()
     monkeypatch.setattr(backfill, 'redis_client', redis)
     monkeypatch.setattr(backfill, 'retry_after_next_utc_day', lambda: 123)

--- a/backend/utils/sync/backfill.py
+++ b/backend/utils/sync/backfill.py
@@ -15,6 +15,15 @@ logger = logging.getLogger(__name__)
 BACKFILL_SLOT_TTL_SECONDS = 2 * 24 * 60 * 60
 
 
+def _admission_limits_enabled() -> bool:
+    # Disabled by default. Cloud Tasks queue concurrency is the sole pacer for
+    # historical recovery, so the app-level per-user in-flight slot and daily
+    # speech caps below are redundant — and they refused legitimate uploads
+    # (202-then-queue is defeated when the endpoint 429s the upload itself).
+    # Set SYNC_BACKFILL_ADMISSION_LIMITS=true to restore the old gating.
+    return os.getenv('SYNC_BACKFILL_ADMISSION_LIMITS', 'false').lower() == 'true'
+
+
 def per_user_daily_limit_ms() -> int:
     return max(0, int(float(os.getenv('SYNC_BACKFILL_USER_DAILY_HOURS', '4')) * 60 * 60 * 1000))
 
@@ -34,6 +43,10 @@ def _day_suffix() -> str:
 
 
 def try_acquire_backfill_slot(uid: str, job_id: str) -> bool:
+    # Admission gating disabled by default: always admit so the upload is
+    # accepted (202) and Cloud Tasks paces processing. See _admission_limits_enabled.
+    if not _admission_limits_enabled():
+        return True
     key = f'sync_backfill:inflight:{uid}'
     acquired = redis_client.set(key, job_id, nx=True, ex=BACKFILL_SLOT_TTL_SECONDS)
     if acquired:
@@ -90,7 +103,10 @@ return {1, global_used + amount}
 
 
 def reserve_backfill_speech(uid: str, job_id: str, speech_ms: int) -> BackfillReservation:
-    if speech_ms <= 0:
+    # Daily/global speech caps disabled by default — the Cloud Tasks queue
+    # bounds concurrent STT load; a per-day upload refusal is the wrong tool
+    # (cost/volume belongs in billing). See _admission_limits_enabled.
+    if not _admission_limits_enabled() or speech_ms <= 0:
         return BackfillReservation(allowed=True)
     retry_after = retry_after_next_utc_day()
     suffix = _day_suffix()


### PR DESCRIPTION
## Problem

Offline-file sync (the `BACKFILL` lane, added in #9412) gates the **upload endpoint itself** on two app-level admission checks:

- `try_acquire_backfill_slot` — a per-user **single in-flight job** Redis lock (`sync_backfill:inflight:{uid}`, 2-day TTL).
- `reserve_backfill_speech` — per-user **4h/day** + global **555h/day** speech caps.

When either trips, the endpoint returns **429** (`backfill_paced` / `backfill_capacity`) and refuses the upload. That defeats the design of the sync path: `POST /v2/sync-local-files` is supposed to save the file, return **202 immediately**, and enqueue a **Cloud Task** so the queue paces processing one job at a time via its own `maxConcurrentDispatches`. The queue is already the rate limiter — the app-level gates are a redundant second limiter bolted on top, and they reject legitimate work.

### Impact (real user)
A paying Neo user draining an offline backlog hit **~1,200 × 429 in 3 hours**, surfaced in-app as "fair use limit reached." Their fair-use state was empty (stage `none`, classifier scored them legitimate every time), and they'd used only **0.86h of the 4h/day cap** — so the daily cap wasn't even the blocker. The blocker was the **concurrency=1 in-flight slot**, which has no env knob. The caps caught zero actual abuse; their only observed effect has been blocking good users.

## Fix

Disable both admission gates by default and let the **Cloud Tasks queue concurrency be the sole pacer** — restoring the original "upload → 202 → queue drains" behavior. Capacity isolation still lives at the right layer: backfill has its own queue, so it can't starve live capture regardless.

- New `_admission_limits_enabled()` gate, env `SYNC_BACKFILL_ADMISSION_LIMITS` (**default `false`**).
- `try_acquire_backfill_slot` → always admits when disabled (upload accepted, queue paces).
- `reserve_backfill_speech` → always allows when disabled.
- Fully reversible with **no redeploy**: set `SYNC_BACKFILL_ADMISSION_LIMITS=true` to restore the old gating.

Deliberately minimal: **only `backend/utils/sync/backfill.py`** changes. The 15+ `release_backfill_slot` call sites, the lane classifier, Cloud Tasks enqueue, the worker, and all deploy infra are untouched (the release calls become harmless no-ops since the slot is never taken). This avoids the risk of surgery across the hot-path endpoint and its cleanup/finally branches.

## Test plan

- [x] `pytest tests/unit/test_sync_two_lane.py` — 19 passed (updated the cap→reason mapping test to opt into `SYNC_BACKFILL_ADMISSION_LIMITS=true`, since the caps are permissive by default now).
- [x] `pytest tests/unit/test_sync_v2.py tests/unit/test_sync_cloud_tasks.py` — 194 passed (these mock the gates, so behavior is unchanged; confirms no regression in the endpoint's 429-rendering paths).
- [ ] After deploy: confirm `POST /v2/sync-local-files` returns 202 for a backlog with a job already in flight (no more `backfill_paced` 429), and the queue drains normally.

## Notes / follow-ups

- Separately, the fair-use system itself is slated for removal (moving to fixed-hour paid plans). That's a bigger change; this PR only removes the offline-sync *upload refusal*. The fair-use enforcement can be turned off independently via `FAIR_USE_ENABLED=false`.
- Longer term, if we want per-user fairness in backfill drain, that belongs in the queue (weighted dispatch), not an app-level upload gate.

cc @Git-on-my-level (author of #9412) — flagging since this changes the admission behavior your PR introduced; happy to adjust the approach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9570?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

