### PR TITLE
fix(memory): use a tz-aware sentinel in the review-queue sort key to avoid a 500

### DIFF
--- a/backend/database/review_queue.py
+++ b/backend/database/review_queue.py
@@ -138,7 +138,9 @@ def purge_stale_review_conflicts_for_memories(
 
 def _review_conflict_sort_key(item: Dict[str, Any]) -> tuple[float, datetime]:
     impact_value: float = cast(float, item.get('impact') or 0.0)
-    created_value: datetime = cast(datetime, item.get('created_at') or datetime.min)
+    # Use a tz-aware sentinel: stored created_at is tz-aware, and on an impact tie the sort compares
+    # the datetimes, so a naive datetime.min would raise "can't compare naive and aware" -> 500.
+    created_value: datetime = cast(datetime, item.get('created_at') or datetime.min.replace(tzinfo=timezone.utc))
     return (impact_value, created_value)
 
 

--- a/backend/tests/unit/test_review_queue_sort_tz.py
+++ b/backend/tests/unit/test_review_queue_sort_tz.py
@@ -1,0 +1,42 @@
+"""list_review_conflicts must not TypeError sorting items with mixed tz-aware / missing created_at.
+
+_review_conflict_sort_key used a naive datetime.min sentinel for a missing created_at. Stored
+created_at is tz-aware (datetime.now(timezone.utc)); on an impact tie the sort compares the two
+datetimes -> "can't compare offset-naive and offset-aware datetimes" TypeError -> HTTP 500 on
+GET /v3/memories/review-queue. The sentinel is now tz-aware. Pure sort-key function, tested directly.
+"""
+
+import os
+
+os.environ.setdefault(
+    'ENCRYPTION_SECRET',
+    'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv',
+)
+
+from datetime import datetime, timezone
+
+import database.review_queue as review_queue
+
+
+def test_sort_key_tolerates_missing_created_at_on_impact_tie():
+    aware = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    items = [
+        {'impact': 0.5, 'created_at': aware},
+        {'impact': 0.5},  # missing created_at -> sentinel; equal impact forces a datetime comparison
+    ]
+    # Before the fix, comparing the naive datetime.min sentinel with the aware value raised TypeError.
+    items.sort(key=review_queue._review_conflict_sort_key, reverse=True)
+    assert [i.get('created_at') for i in items] == [aware, None]  # real timestamp sorts ahead of the sentinel
+
+
+def test_sort_key_orders_by_impact_then_created_at():
+    older = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    newer = datetime(2026, 2, 1, tzinfo=timezone.utc)
+    items = [
+        {'impact': 0.2, 'created_at': newer},
+        {'impact': 0.9, 'created_at': older},
+        {'impact': 0.2, 'created_at': older},
+    ]
+    items.sort(key=review_queue._review_conflict_sort_key, reverse=True)
+    assert [i['impact'] for i in items] == [0.9, 0.2, 0.2]  # highest impact first
+    assert items[1]['created_at'] == newer and items[2]['created_at'] == older  # tie -> newer first


### PR DESCRIPTION
## Problem
`_review_conflict_sort_key` returned `(impact, cast(datetime, item.get('created_at') or datetime.min))`. `datetime.min` is naive, but stored `created_at` is tz-aware (`datetime.now(timezone.utc)`). On an impact tie, `list_review_conflicts`' `items.sort(key=_review_conflict_sort_key, reverse=True)` compares the two datetimes and raises `TypeError: can't compare offset-naive and offset-aware datetimes` -> HTTP 500 on `GET /v3/memories/review-queue`. Impact ties are common (defaults/fallbacks), so an item missing `created_at` triggers it.

## Fix
Use the tz-aware sentinel `datetime.min.replace(tzinfo=timezone.utc)`, exactly as `database/memory_ledger.py` already does for the same kind of sort.

## Test
`tests/unit/test_review_queue_sort_tz.py` sorts items with one tz-aware `created_at` and one missing (an impact tie) without raising, and confirms the ordering (impact desc, then created_at desc on a tie).

## Verification
- `pytest tests/unit/test_review_queue_sort_tz.py` -> 2 passed
- `black --check` clean; `check_module_stub_pollution` -> 0


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9571?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

