### PR TITLE
fix(memory): no-op mark_consolidated on an absent short-term doc instead of 500ing resolve

### DIFF
--- a/backend/database/short_term_memories.py
+++ b/backend/database/short_term_memories.py
@@ -21,6 +21,11 @@ def _is_payload(value: object) -> TypeGuard[Payload]:
 
 def mark_consolidated(uid: str, short_term_id: str, commit_id: Optional[str]) -> None:
     doc_ref = db.collection(users_collection).document(uid).collection(short_term_collection).document(short_term_id)
+    # A conflict's source_short_term_id can point at an absent short-term doc (canonical cohorts write
+    # memory_items, not short_term). Firestore .update() raises NotFound on a missing doc (unlike set),
+    # which would surface as a 500 on resolve; no-op instead, mirroring memory_app_key_grants.
+    if not doc_ref.get().exists:
+        return
     now = datetime.now(timezone.utc)
     doc_ref.update(
         {

--- a/backend/tests/unit/test_mark_consolidated_missing_doc.py
+++ b/backend/tests/unit/test_mark_consolidated_missing_doc.py
@@ -1,0 +1,42 @@
+"""mark_consolidated must no-op on an absent short-term doc instead of 500ing resolve.
+
+Resolving a review conflict (POST /v3/memories/review-queue/{id}/resolve) calls mark_consolidated on
+the conflict's source_short_term_id. Canonical cohorts write memory_items, not short_term, so that id
+can point at an absent short_term doc. Firestore .update() raises NotFound on a missing doc (unlike
+set), which surfaced as HTTP 500. It now checks existence first. database.short_term_memories is light.
+"""
+
+import os
+
+os.environ.setdefault(
+    'ENCRYPTION_SECRET',
+    'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv',
+)
+
+from unittest.mock import MagicMock
+
+import database.short_term_memories as stm
+
+
+def _fake_db(doc_ref):
+    fake = MagicMock()
+    fake.collection.return_value.document.return_value.collection.return_value.document.return_value = doc_ref
+    return fake
+
+
+def test_noop_when_doc_absent(monkeypatch):
+    doc_ref = MagicMock()
+    doc_ref.get.return_value.exists = False
+    monkeypatch.setattr(stm, 'db', _fake_db(doc_ref))
+    stm.mark_consolidated('u1', 'st1', 'commit-1')  # must not raise
+    doc_ref.update.assert_not_called()
+
+
+def test_updates_when_doc_exists(monkeypatch):
+    doc_ref = MagicMock()
+    doc_ref.get.return_value.exists = True
+    monkeypatch.setattr(stm, 'db', _fake_db(doc_ref))
+    stm.mark_consolidated('u1', 'st1', 'commit-1')
+    doc_ref.update.assert_called_once()
+    written = doc_ref.update.call_args.args[0]
+    assert written['status'] == 'consolidated' and written['consolidated_commit_id'] == 'commit-1'


### PR DESCRIPTION
## Problem
`mark_consolidated` did `doc_ref.update(...)` with no existence check. Firestore `.update()` raises `NotFound` on a missing document (unlike `set`). Resolving a review conflict (`POST /v3/memories/review-queue/{id}/resolve`) calls `mark_consolidated` on the conflict's `source_short_term_id`, and canonical cohorts write `memory_items` rather than `short_term`, so that id can point at an absent `short_term` doc -> `NotFound` -> HTTP 500.

## Fix
Add an existence guard and no-op if the doc is gone, exactly as `database/memory_app_key_grants` already does for the same `update()`-on-a-missing-doc hazard.

## Test
`tests/unit/test_mark_consolidated_missing_doc.py`: with the doc absent, `mark_consolidated` returns without calling `.update()` (no raise); with it present, the update is applied.

## Verification
- `pytest tests/unit/test_mark_consolidated_missing_doc.py` -> 2 passed
- `black --check` clean; `check_module_stub_pollution` -> 0

## Product invariants affected

- INV-MEM-1 (memory tiers) — this touches `database/short_term_memories.py`. The change is a defensive existence guard on `mark_consolidated`'s Firestore `.update()`; it does not alter the three-tier model or consolidation semantics.
