### PR TITLE
fix(conversations): transactional segment-text edits to stop lost updates (#9392)

### DIFF
--- a/backend/database/conversations.py
+++ b/backend/database/conversations.py
@@ -599,38 +599,50 @@ def update_conversation_segment_text(uid: str, conversation_id: str, segment_id:
     """
     Update a single segment's text in a conversation.
 
+    The read-modify-write runs in a Firestore transaction so concurrent edits
+    (e.g. the same conversation open in two tabs) can't lose-update each other.
+    Without it, two edits that both read the pre-edit transcript_segments array
+    and each rewrite the whole array clobber one another — the later write wins
+    and silently drops the earlier edit.
+
     Returns:
         'ok' on success, 'not_found' if conversation missing, 'locked' if conversation is locked,
         'segment_not_found' if segment_id not found.
     """
     doc_ref = db.collection('users').document(uid).collection(conversations_collection).document(conversation_id)
-    doc_snapshot = doc_ref.get()
-    if not doc_snapshot.exists:
-        return 'not_found'
+    transaction = db.transaction()
 
-    raw_data = doc_snapshot.to_dict()
-    if raw_data.get('is_locked', False):
-        return 'locked'
+    @firestore.transactional
+    def _update_segment_text(transaction) -> str:
+        doc_snapshot = doc_ref.get(transaction=transaction)
+        if not doc_snapshot.exists:
+            return 'not_found'
 
-    conversation_data = _prepare_conversation_for_read(raw_data, uid)
-    if not conversation_data:
-        return 'not_found'
+        raw_data = doc_snapshot.to_dict()
+        if raw_data.get('is_locked', False):
+            return 'locked'
 
-    segments = conversation_data.get('transcript_segments', [])
-    found = False
-    for segment in segments:
-        if isinstance(segment, dict) and segment.get('id') == segment_id:
-            segment['text'] = text
-            found = True
-            break
+        conversation_data = _prepare_conversation_for_read(raw_data, uid)
+        if not conversation_data:
+            return 'not_found'
 
-    if not found:
-        return 'segment_not_found'
+        segments = conversation_data.get('transcript_segments', [])
+        found = False
+        for segment in segments:
+            if isinstance(segment, dict) and segment.get('id') == segment_id:
+                segment['text'] = text
+                found = True
+                break
 
-    doc_level = conversation_data.get('data_protection_level', 'standard')
-    prepared_payload = _prepare_conversation_for_write({'transcript_segments': segments}, uid, doc_level)
-    doc_ref.update(prepared_payload)
-    return 'ok'
+        if not found:
+            return 'segment_not_found'
+
+        doc_level = conversation_data.get('data_protection_level', 'standard')
+        prepared_payload = _prepare_conversation_for_write({'transcript_segments': segments}, uid, doc_level)
+        transaction.update(doc_ref, prepared_payload)
+        return 'ok'
+
+    return _update_segment_text(transaction)
 
 
 def delete_conversation_photos(uid: str, conversation_id: str) -> int:

--- a/backend/tests/unit/test_conversation_revision_contract.py
+++ b/backend/tests/unit/test_conversation_revision_contract.py
@@ -67,6 +67,9 @@ class _Transaction:
     def set(self, ref, data, **kwargs):
         ref.set(data, **kwargs)
 
+    def update(self, ref, data):
+        ref.update(data)
+
 
 def test_document_update_time_is_exposed_as_server_revision():
     revision = datetime(2026, 7, 9, 12, 0, tzinfo=timezone.utc)
@@ -261,3 +264,67 @@ def test_mutation_response_contract_carries_canonical_revision_and_state():
     assert result.conversation.structured.title == 'Renamed'
     assert result.conversation.structured.overview == 'Processing finished'
     assert result.conversation.starred is True
+
+
+def _segment_snapshot(segments, *, is_locked=False, exists=True):
+    return _Snapshot(
+        {
+            'data_protection_level': 'standard',
+            'is_locked': is_locked,
+            'transcript_segments': segments,
+        },
+        exists=exists,
+    )
+
+
+def test_segment_text_edit_reads_and_writes_inside_a_transaction(monkeypatch):
+    # Regression for #9392: the read-modify-write must be atomic so concurrent
+    # edits to different segments can't lose-update each other.
+    ref = _ConversationRef(_segment_snapshot([{'id': 's1', 'text': 'old'}, {'id': 's2', 'text': 'keep'}]))
+    monkeypatch.setattr(conversations_db, 'db', _Firestore(ref))
+    monkeypatch.setattr(conversations_db.firestore, 'transactional', lambda function: function)
+
+    result = conversations_db.update_conversation_segment_text('user-1', 'conv-1', 's1', 'new text')
+
+    assert result == 'ok'
+    # The write went through the transaction (recorded on the ref), and the edit
+    # landed while the untouched segment is preserved.
+    assert len(ref.update_calls) == 1
+    import json as _json
+    import zlib as _zlib
+
+    written = _json.loads(_zlib.decompress(ref.update_calls[0]['transcript_segments']).decode('utf-8'))
+    assert {s['id']: s['text'] for s in written} == {'s1': 'new text', 's2': 'keep'}
+
+
+def test_segment_text_edit_missing_segment_does_not_write(monkeypatch):
+    ref = _ConversationRef(_segment_snapshot([{'id': 's1', 'text': 'old'}]))
+    monkeypatch.setattr(conversations_db, 'db', _Firestore(ref))
+    monkeypatch.setattr(conversations_db.firestore, 'transactional', lambda function: function)
+
+    result = conversations_db.update_conversation_segment_text('user-1', 'conv-1', 'missing', 'x')
+
+    assert result == 'segment_not_found'
+    assert ref.update_calls == []
+
+
+def test_segment_text_edit_rejects_locked_conversation(monkeypatch):
+    ref = _ConversationRef(_segment_snapshot([{'id': 's1', 'text': 'old'}], is_locked=True))
+    monkeypatch.setattr(conversations_db, 'db', _Firestore(ref))
+    monkeypatch.setattr(conversations_db.firestore, 'transactional', lambda function: function)
+
+    result = conversations_db.update_conversation_segment_text('user-1', 'conv-1', 's1', 'x')
+
+    assert result == 'locked'
+    assert ref.update_calls == []
+
+
+def test_segment_text_edit_missing_conversation_returns_not_found(monkeypatch):
+    ref = _ConversationRef(_segment_snapshot([], exists=False))
+    monkeypatch.setattr(conversations_db, 'db', _Firestore(ref))
+    monkeypatch.setattr(conversations_db.firestore, 'transactional', lambda function: function)
+
+    result = conversations_db.update_conversation_segment_text('user-1', 'conv-1', 's1', 'x')
+
+    assert result == 'not_found'
+    assert ref.update_calls == []


### PR DESCRIPTION
## What

Wrap `update_conversation_segment_text` (`backend/database/conversations.py`) in a Firestore transaction so concurrent transcript-segment text edits can't silently lose-update each other.

## Why

From #9392:

> `update_conversation_segment_text` does `doc_ref.get()` → mutate one segment in the decoded `transcript_segments` array → `doc_ref.update()` (rewrites the **whole** array). Two concurrent edits (even to different segments) both read the pre-edit array; the later write overwrites the earlier one → lost update.
>
> **Repro:** open the same conversation in two tabs and edit different segments within the same ~200ms window → one edit is lost (both return 200).
>
> **Proposed fix:** wrap the read-modify-write in a Firestore transaction.

The web PR (#9353) only serializes saves within a single client; the cross-tab / cross-client race requires this backend fix.

## Change

- The read (`doc_ref.get`) and the whole-array write now run inside a `@firestore.transactional` inner function — the **same pattern already used by `upsert_conversation`** in this file — so the read is retried on write contention and the array rewrite is atomic.
- Return-code contract (`ok` / `not_found` / `locked` / `segment_not_found`) is unchanged, so `patch_conversation_segment_text` in `routers/conversations.py` behaves identically.

## Root cause & durable guard

- **Root cause:** a shared read-modify-write over the entire `transcript_segments` array with no transaction.
- **Durable guard:** atomic Firestore transaction + regression tests that drive the real db function through a controllable transaction seam and assert the edit is written via `transaction.update` while the untouched segment is preserved.

## Verified

Added 4 tests to `backend/tests/unit/test_conversation_revision_contract.py` (edit lands + other segment preserved / missing-segment no-write / locked / not_found), run with the backend venv:

```
ENCRYPTION_SECRET=... .venv/bin/python -m pytest tests/unit/test_conversation_revision_contract.py -q
14 passed in 4.37s
```

(10 pre-existing + 4 new; the new ones deselected-run green under `-k segment`.)

## Scope note (deliberately deferred)

#9392 also covers two larger, separate surfaces left as follow-ups so this PR stays reviewable and revertable:
1. the speaker-assign race — read happens in the router, write via `update_conversation_segments` (used by 6 call sites incl. the sync pipeline); fixing it correctly means moving the mutation inside a transaction per endpoint.
2. `reprocess_conversation` overwriting the transcript from a stale snapshot (touches `process_conversation` persistence).

Auto-generated from issue feedback by the mini issues-improver. Review before merge.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9574?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

