### PR TITLE
fix(goals): skip a malformed progress event instead of 500ing the goal detail page

### DIFF
--- a/backend/database/goals.py
+++ b/backend/database/goals.py
@@ -2,12 +2,14 @@
 
 import hashlib
 import json
+import logging
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, cast
 from uuid import uuid4
 
 from google.cloud import firestore
 from google.cloud.firestore_v1 import FieldFilter
+from pydantic import ValidationError
 
 from database import _client
 from models.goal import (
@@ -21,6 +23,8 @@ from models.goal import (
     GoalType,
 )
 from models.task_intelligence import TaskWorkflowControl, TaskWorkflowMode
+
+logger = logging.getLogger(__name__)
 
 goals_collection = 'goals'
 goal_history_collection = 'goal_history'
@@ -785,7 +789,14 @@ def list_goal_progress_events(
         .order_by('sequence', direction=firestore.Query.DESCENDING)
         .limit(limit)
     )
-    return [GoalProgressEvent.model_validate(_snapshot_dict(snapshot)) for snapshot in query.stream()]
+    events: list[GoalProgressEvent] = []
+    for snapshot in query.stream():
+        try:
+            events.append(GoalProgressEvent.model_validate(_snapshot_dict(snapshot)))
+        except ValidationError as e:
+            # Skip a malformed/legacy progress event rather than 500 the whole detail page.
+            logger.warning('Skipping malformed goal progress event %s: %s', getattr(snapshot, 'id', None), e)
+    return events
 
 
 def update_goal_progress(

--- a/backend/tests/unit/test_goal_progress_events_skip_malformed.py
+++ b/backend/tests/unit/test_goal_progress_events_skip_malformed.py
@@ -1,0 +1,85 @@
+"""database.goals.list_goal_progress_events skips a malformed event instead of 500ing the detail page.
+
+The function validated each Firestore doc with a bare comprehension
+`[GoalProgressEvent.model_validate(_snapshot_dict(s)) for s in query.stream()]`, so one malformed or
+legacy event doc (GoalProgressEvent is extra='forbid' with required event_id/goal_id/sequence>=1/
+kind/summary/created_at) raised ValidationError and 500'd GET /v1/goals/{id}/detail (get_goal_detail
+passes this list as progress_events=). Mirrors the skip-malformed guard the sibling workstreams list
+loops carry. database.goals is light (firestore_client injectable), so the test drives it directly.
+"""
+
+import os
+
+os.environ.setdefault(
+    'ENCRYPTION_SECRET',
+    'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv',
+)
+
+from unittest.mock import MagicMock
+
+import pytest
+from pydantic import BaseModel, ValidationError
+
+import database.goals as goals
+
+
+class _Probe(BaseModel):
+    x: int
+
+
+def _a_validation_error() -> ValidationError:
+    try:
+        _Probe.model_validate({})  # missing required field -> a real ValidationError
+    except ValidationError as exc:
+        return exc
+    raise AssertionError('expected a ValidationError')
+
+
+def _snapshot(doc):
+    snap = MagicMock()
+    snap.id = doc.get('id')
+    snap.to_dict.return_value = doc
+    return snap
+
+
+def _fake_client(snapshots):
+    fake = MagicMock()
+    for attr in ('collection', 'document', 'order_by', 'limit', 'where'):
+        getattr(fake, attr).return_value = fake
+    fake.stream.return_value = snapshots
+    return fake
+
+
+@pytest.fixture(autouse=True)
+def _direct_snapshot_dict(monkeypatch):
+    # Bypass the real _snapshot_dict decode; the test controls the dicts directly.
+    monkeypatch.setattr(goals, '_snapshot_dict', lambda snap: snap.to_dict())
+
+
+def _stub_validate(monkeypatch):
+    err = _a_validation_error()
+
+    def fake_validate(doc):
+        if doc.get('_bad'):
+            raise err
+        return doc
+
+    monkeypatch.setattr(goals.GoalProgressEvent, 'model_validate', staticmethod(fake_validate))
+
+
+def test_list_goal_progress_events_skips_malformed(monkeypatch):
+    _stub_validate(monkeypatch)
+    client = _fake_client([_snapshot({'id': 'e1'}), _snapshot({'id': 'bad', '_bad': True}), _snapshot({'id': 'e2'})])
+    result = goals.list_goal_progress_events('u1', 'g1', firestore_client=client)
+    assert result == [{'id': 'e1'}, {'id': 'e2'}]  # one malformed event must not 500 the detail page
+
+
+def test_unexpected_error_is_not_swallowed(monkeypatch):
+    # Only ValidationError is skipped; an unexpected error must surface, not be hidden as a skip.
+    def boom(doc):
+        raise RuntimeError('unexpected')
+
+    monkeypatch.setattr(goals.GoalProgressEvent, 'model_validate', staticmethod(boom))
+    client = _fake_client([_snapshot({'id': 'e1'})])
+    with pytest.raises(RuntimeError):
+        goals.list_goal_progress_events('u1', 'g1', firestore_client=client)


### PR DESCRIPTION
## What

`list_goal_progress_events` built a `GoalProgressEvent` per Firestore event doc with a bare list comprehension and no per-item guard:

```python
return [GoalProgressEvent.model_validate(_snapshot_dict(snapshot)) for snapshot in query.stream()]
```

`GoalProgressEvent` is `extra='forbid'` with required `event_id`, `goal_id`, `sequence` (>= 1), `kind`, `summary` (min_length=1), and `created_at`. One malformed or legacy event doc (a stray field, an empty summary, `sequence` < 1) raises `ValidationError`, which propagates out and 500s the whole goal detail page. `get_goal_detail` passes this list straight into the detail projection as `progress_events=`, and `GET /v1/goals/{goal_id}/detail` does not catch `ValidationError`, so it becomes an HTTP 500 for the entire page.

## Fix

Iterate and skip a malformed doc rather than fail the whole read:

```python
events: list[GoalProgressEvent] = []
for snapshot in query.stream():
    try:
        events.append(GoalProgressEvent.model_validate(_snapshot_dict(snapshot)))
    except ValidationError as e:
        logger.warning('Skipping malformed goal progress event %s: %s', getattr(snapshot, 'id', None), e)
return events
```

The catch is narrow (`ValidationError` only) so an unexpected error still propagates. This is the same failure class already guarded elsewhere: the workstreams list loops (`list_artifact_descriptors`, `list_continuation_checkpoints`) and the action-item readers in `routers/action_items.py` / `routers/developer.py` (`_safe_action_item_responses`).

## Tests

New `tests/unit/test_goal_progress_events_skip_malformed.py` drives the function directly with an injected fake client (database.goals is light):
- a malformed event in the middle of the stream is skipped, the valid ones are returned
- an unexpected non-ValidationError still propagates, not hidden as a skip

## Verification

```
cd backend && ENCRYPTION_SECRET=... python -m pytest tests/unit/test_goal_progress_events_skip_malformed.py -q
  -> 2 passed
black --line-length 120 --skip-string-normalization --check database/goals.py tests/unit/test_goal_progress_events_skip_malformed.py
  -> unchanged
python scripts/check_module_stub_pollution.py -> Checked 605 file(s); 0 violation(s)
```

## Product invariants affected

none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9575?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

