### PR TITLE
fix(dev-keys): skip a malformed dev API key instead of 500ing GET /v1/dev/keys

### DIFF
--- a/backend/database/dev_api_key.py
+++ b/backend/database/dev_api_key.py
@@ -1,8 +1,10 @@
+import logging
 import uuid
 from datetime import datetime
 from typing import List, Optional, Tuple
 
 from google.cloud import firestore
+from pydantic import ValidationError
 
 import database.redis_db as redis_db
 from database._client import db
@@ -13,6 +15,8 @@ from database.memory_app_key_grants import (
 from models.dev_api_key import DevApiKey
 from utils.dev_api_keys import generate_dev_api_key, hash_dev_api_key
 from utils.scopes import READ_ONLY_SCOPES, Scopes
+
+logger = logging.getLogger(__name__)
 
 
 def create_dev_key(user_id: str, name: str, scopes: Optional[List[str]] = None) -> Tuple[str, DevApiKey]:
@@ -82,7 +86,13 @@ def get_dev_keys_for_user(user_id: str) -> List[DevApiKey]:
         # Ensure scopes field is present (None for backward compat)
         if "scopes" not in key_dict:
             key_dict["scopes"] = None
-        keys.append(DevApiKey.model_validate(key_dict))
+        # Older key docs may omit the id field; fall back to the document id, mirroring
+        # get_mcp_keys_for_user. Skip a malformed/legacy key rather than 500 the whole list.
+        key_dict["id"] = key_dict.get("id") or doc.id
+        try:
+            keys.append(DevApiKey.model_validate(key_dict))
+        except ValidationError as e:
+            logger.warning("Skipping malformed dev API key %s: %s", doc.id, e)
     return keys
 
 

--- a/backend/tests/unit/test_dev_keys_legacy_doc.py
+++ b/backend/tests/unit/test_dev_keys_legacy_doc.py
@@ -1,0 +1,81 @@
+"""get_dev_keys_for_user must fall back to doc.id and skip a malformed legacy key, not 500 the list.
+
+GET /v1/dev/keys built DevApiKey.model_validate(doc.to_dict()) per key with no id fallback and no
+try/except. DevApiKey requires id/name/key_prefix/created_at, and Firestore doc.to_dict() omits the
+doc id, so one legacy or malformed key doc raised ValidationError and 500'd the whole list. It now
+falls back to doc.id (mirroring get_mcp_keys_for_user in the sibling module) and skips a genuinely
+malformed key. database.dev_api_key is light (module-level db proxy), so the test drives it directly.
+"""
+
+import os
+
+os.environ.setdefault(
+    'ENCRYPTION_SECRET',
+    'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv',
+)
+
+from unittest.mock import MagicMock
+
+import pytest
+from pydantic import BaseModel, ValidationError
+
+import database.dev_api_key as dev_key
+
+
+class _Probe(BaseModel):
+    x: int
+
+
+def _validation_error() -> ValidationError:
+    try:
+        _Probe.model_validate({})  # missing required field -> a real ValidationError
+    except ValidationError as exc:
+        return exc
+    raise AssertionError('expected a ValidationError')
+
+
+def _doc(doc_id, data):
+    doc = MagicMock()
+    doc.id = doc_id
+    doc.to_dict.return_value = data
+    return doc
+
+
+def _patch_client(monkeypatch, docs):
+    fake = MagicMock()
+    for attr in ('collection', 'where', 'order_by'):
+        getattr(fake, attr).return_value = fake
+    fake.stream.return_value = docs
+    monkeypatch.setattr(dev_key, 'db', fake)
+
+
+def test_id_fallback_and_skip_malformed(monkeypatch):
+    err = _validation_error()
+
+    def fake_validate(data):
+        if data.get('_bad'):
+            raise err
+        return data  # return the dict so the resolved id is inspectable
+
+    monkeypatch.setattr(dev_key.DevApiKey, 'model_validate', staticmethod(fake_validate))
+    _patch_client(
+        monkeypatch,
+        [
+            _doc('k1', {'id': 'k1', 'name': 'n'}),  # explicit id preserved
+            _doc('legacy-id', {'name': 'n2'}),  # missing id field -> falls back to doc.id
+            _doc('bad-id', {'_bad': True}),  # malformed -> skipped, not a 500
+        ],
+    )
+    result = dev_key.get_dev_keys_for_user('u1')
+    assert [k['id'] for k in result] == ['k1', 'legacy-id']  # malformed key skipped, list survives
+
+
+def test_unexpected_error_propagates(monkeypatch):
+    # Only ValidationError is skipped; an unexpected error must surface, not be hidden as a skip.
+    def boom(data):
+        raise RuntimeError('unexpected')
+
+    monkeypatch.setattr(dev_key.DevApiKey, 'model_validate', staticmethod(boom))
+    _patch_client(monkeypatch, [_doc('k1', {'id': 'k1'})])
+    with pytest.raises(RuntimeError):
+        dev_key.get_dev_keys_for_user('u1')


### PR DESCRIPTION
## What

`get_dev_keys_for_user` built a `DevApiKey` per stored key doc with no id fallback and no per-item guard:

```python
for doc in docs:
    key_dict = doc.to_dict()
    if "scopes" not in key_dict:
        key_dict["scopes"] = None
    keys.append(DevApiKey.model_validate(key_dict))
```

`DevApiKey` requires `id`, `name`, `key_prefix`, and `created_at` (no defaults). Firestore `doc.to_dict()` does not include the document id, and older key docs may lack an explicit `id` field, so one legacy or malformed key doc raises `ValidationError`. `GET /v1/dev/keys` (`routers/developer.py`, `listApiKeys`) returns that list directly, so a single bad row 500s the whole endpoint and the user cannot list or manage any of their keys.

## Fix

Fall back to the document id and skip a genuinely malformed key rather than failing the whole read:

```python
key_dict["id"] = key_dict.get("id") or doc.id
try:
    keys.append(DevApiKey.model_validate(key_dict))
except ValidationError as e:
    logger.warning("Skipping malformed dev API key %s: %s", doc.id, e)
```

This is the exact pattern already merged for the sibling module: `database/mcp_api_key.py` `get_mcp_keys_for_user` does the same id fallback plus a narrow `ValidationError` skip for `GET /v1/mcp/keys`. The catch is narrow so an unexpected error still propagates.

## Tests

New `tests/unit/test_dev_keys_legacy_doc.py` drives the function with an injected fake db proxy (database.dev_api_key is light):
- an explicit id is preserved, a doc missing the id field falls back to doc.id, and a malformed doc is skipped so the list survives
- an unexpected non-ValidationError still propagates, not hidden as a skip

## Verification

```
cd backend && ENCRYPTION_SECRET=... python -m pytest tests/unit/test_dev_keys_legacy_doc.py -q
  -> 2 passed
black --line-length 120 --skip-string-normalization --check database/dev_api_key.py tests/unit/test_dev_keys_legacy_doc.py
  -> unchanged
python scripts/check_module_stub_pollution.py -> Checked 605 file(s); 0 violation(s)
```

## Product invariants affected

none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9576?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

