### PR TITLE
fix(chat): use a tz-aware sentinel when sorting chat files with a missing created_at

### DIFF
--- a/backend/database/chat.py
+++ b/backend/database/chat.py
@@ -452,8 +452,10 @@ def get_chat_files_desc(uid: str, files_id: Optional[List[str]] = None, limit: i
         chunk_ref = chunk_ref.order_by('created_at', direction=firestore.Query.DESCENDING)
         results.extend([_typed_doc(doc) for doc in chunk_ref.stream()])
 
-    # Sort all results by created_at and limit
-    results.sort(key=lambda x: x.get('created_at', datetime.min), reverse=True)
+    # Sort all results by created_at and limit. Use a tz-aware sentinel (mirroring the sort keys in
+    # action_items/task_recommendations/memory_ledger): stored created_at is tz-aware, so a naive
+    # datetime.min default would raise "can't compare offset-naive and offset-aware datetimes".
+    results.sort(key=lambda x: x.get('created_at') or datetime.min.replace(tzinfo=timezone.utc), reverse=True)
     return results[:limit]
 
 

--- a/backend/tests/unit/test_chat_files_sort_tz.py
+++ b/backend/tests/unit/test_chat_files_sort_tz.py
@@ -1,0 +1,59 @@
+"""database.chat.get_chat_files_desc must not TypeError sorting files with mixed tz-aware/missing created_at.
+
+In the >30-file chunked merge path, the per-file sort key used a bare naive datetime.min default. Stored
+created_at is tz-aware (datetime.now(timezone.utc)), so a file doc missing created_at made the sort compare
+a naive sentinel with an aware value -> "can't compare offset-naive and offset-aware datetimes" TypeError
+-> 500. The sentinel is now tz-aware, mirroring the sort keys in action_items / task_recommendations /
+memory_ledger. database.chat is light (module-level db proxy), so the test drives it directly.
+"""
+
+import os
+
+os.environ.setdefault(
+    'ENCRYPTION_SECRET',
+    'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv',
+)
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+
+import database.chat as chat
+
+
+def _doc(data):
+    doc = MagicMock()
+    doc.to_dict.return_value = data
+    return doc
+
+
+def _fake_db(stream_batches):
+    fake = MagicMock()
+    for attr in ('collection', 'document', 'where', 'order_by', 'limit'):
+        getattr(fake, attr).return_value = fake
+    fake.stream.side_effect = stream_batches  # one batch per 30-id chunk
+    return fake
+
+
+def _many_ids(n=31):
+    return [f'f{i}' for i in range(n)]  # >30 -> triggers the chunked merge + manual sort
+
+
+def test_sort_tolerates_missing_created_at_across_chunks(monkeypatch):
+    aware_old = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    aware_new = datetime(2026, 2, 1, tzinfo=timezone.utc)
+    chunk1 = [_doc({'id': 'new', 'created_at': aware_new}), _doc({'id': 'missing'})]
+    chunk2 = [_doc({'id': 'old', 'created_at': aware_old})]
+    monkeypatch.setattr(chat, 'db', _fake_db([chunk1, chunk2]))
+    # Before the fix this raised TypeError (naive datetime.min default vs tz-aware created_at).
+    result = chat.get_chat_files_desc('u1', files_id=_many_ids(), limit=100)
+    assert [r['id'] for r in result] == ['new', 'old', 'missing']  # missing sorts last, no 500
+
+
+def test_sort_orders_newest_first_across_chunks(monkeypatch):
+    aware_old = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    aware_new = datetime(2026, 2, 1, tzinfo=timezone.utc)
+    chunk1 = [_doc({'id': 'old', 'created_at': aware_old})]
+    chunk2 = [_doc({'id': 'new', 'created_at': aware_new})]
+    monkeypatch.setattr(chat, 'db', _fake_db([chunk1, chunk2]))
+    result = chat.get_chat_files_desc('u1', files_id=_many_ids(), limit=100)
+    assert [r['id'] for r in result] == ['new', 'old']  # merged descending across chunks


### PR DESCRIPTION
## What

`get_chat_files_desc` merges results across 30-id chunks when more than 30 file ids are requested, then sorts them in Python:

```python
results.sort(key=lambda x: x.get('created_at', datetime.min), reverse=True)
```

The default is a bare naive `datetime.min`. Stored `created_at` is tz-aware (`datetime.now(timezone.utc)`), so if any file doc is missing `created_at`, the sort compares the naive sentinel against a tz-aware value and raises `TypeError: can't compare offset-naive and offset-aware datetimes`, which 500s the request. This is a latent inconsistency rather than a hot path (the manual sort only runs on the >30-file branch), but it is a real crash, and `chat.py:456` was the lone sort site still using the naive sentinel.

## Fix

Use a tz-aware sentinel with the `or` fallback (so an absent or None `created_at` both sort last), matching the existing convention in the sibling sort sites:

```python
results.sort(key=lambda x: x.get('created_at') or datetime.min.replace(tzinfo=timezone.utc), reverse=True)
```

- `database/action_items.py` (`synced_items.sort(... or datetime.min.replace(tzinfo=timezone.utc))`)
- `database/task_recommendations.py`
- `database/memory_ledger.py`

## Tests

New `tests/unit/test_chat_files_sort_tz.py` drives the real >30-file chunked path with an injected fake db proxy:
- one file doc missing `created_at` no longer raises; it sorts last
- files with `created_at` present still order newest-first across chunks

## Verification

```
cd backend && ENCRYPTION_SECRET=... python -m pytest tests/unit/test_chat_files_sort_tz.py -q
  -> 2 passed
black --line-length 120 --skip-string-normalization --check database/chat.py tests/unit/test_chat_files_sort_tz.py
  -> unchanged
python scripts/check_module_stub_pollution.py -> Checked 605 file(s); 0 violation(s)
```

## Product invariants affected

none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9577?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

