### PR TITLE
fix(apps): skip a malformed usage-history doc instead of 500ing app usage/earnings

### DIFF
--- a/backend/tests/unit/test_app_usage_history_skip.py
+++ b/backend/tests/unit/test_app_usage_history_skip.py
@@ -1,0 +1,48 @@
+"""get_app_usage_history / get_app_money_made must skip a malformed usage doc, not 500 the enrichment.
+
+Both functions built UsageHistoryItem(**x) per raw usage doc with no guard. UsageHistoryItem requires
+uid/timestamp/type (enum), and the results are Redis/process-cached and shared, so one legacy or
+malformed usage document (a bad type enum, a missing timestamp) raised ValidationError and 500'd the
+whole app usage/earnings enrichment. _safe_usage_history_items skips such a record and logs the app id
+plus offending field names, mirroring _safe_build_app in the same module. The helper is a pure
+function, so the test imports and calls it directly (no monkeypatch, no sys.modules).
+"""
+
+import os
+
+os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
+os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv')
+
+from datetime import datetime, timezone
+
+import utils.apps as apps_utils  # noqa: E402
+from models.app import UsageHistoryItem, UsageHistoryType  # noqa: E402
+
+
+def _valid_usage_dict():
+    return {
+        'uid': 'u1',
+        'timestamp': datetime(2026, 1, 1, tzinfo=timezone.utc),
+        'type': UsageHistoryType.chat_message_sent.value,
+    }
+
+
+def test_safe_usage_history_items_returns_items_for_valid_records():
+    items = apps_utils._safe_usage_history_items([_valid_usage_dict(), _valid_usage_dict()], 'app1')
+    assert len(items) == 2
+    assert all(isinstance(i, UsageHistoryItem) for i in items)
+
+
+def test_safe_usage_history_items_skips_malformed_records():
+    # A doc missing timestamp/type and a doc with an out-of-enum type are skipped, not raised.
+    records = [
+        _valid_usage_dict(),
+        {'uid': 'u1'},  # missing required timestamp + type
+        {**_valid_usage_dict(), 'type': 'not_a_real_type'},  # bad enum value
+    ]
+    items = apps_utils._safe_usage_history_items(records, 'app1')
+    assert [i.uid for i in items] == ['u1']  # only the valid record survives, no 500
+
+
+def test_safe_usage_history_items_empty():
+    assert apps_utils._safe_usage_history_items([], 'app1') == []

--- a/backend/utils/apps.py
+++ b/backend/utils/apps.py
@@ -539,12 +539,31 @@ def get_app_money_made_amount(app_id: str) -> float:
     return amount
 
 
+def _safe_usage_history_items(usage: List[Dict[str, Any]], app_id: str) -> List[UsageHistoryItem]:
+    """Build UsageHistoryItem records from raw usage docs, skipping (not raising on) a malformed one.
+
+    get_app_usage_history / get_app_money_made are Redis/process-cached and shared, so one legacy or
+    malformed usage document (a bad type enum, a missing timestamp) must not 500 the whole enrichment.
+    """
+    items: List[UsageHistoryItem] = []
+    for x in usage:
+        try:
+            items.append(UsageHistoryItem(**x))
+        except ValidationError as e:
+            logger.warning(
+                "Skipping malformed usage history item for app %s: %s",
+                app_id,
+                [err['loc'][0] for err in e.errors()],
+            )
+    return items
+
+
 def get_app_usage_history(app_id: str) -> List[Dict[str, Any]]:
     cached_usage = get_app_usage_history_cache(app_id)
     if cached_usage:
         return cached_usage
     usage = get_app_usage_history_db(app_id)
-    usage = [UsageHistoryItem(**x) for x in usage]
+    usage = _safe_usage_history_items(usage, app_id)
     # return usage by date grouped count
     by_date: 'defaultdict[Any, int]' = defaultdict(int)
     for item in usage:
@@ -563,7 +582,7 @@ def get_app_money_made(app_id: str) -> dict[str, int | float]:
     if cached_money:
         return cached_money
     usage = get_app_usage_history_db(app_id)
-    usage = [UsageHistoryItem(**x) for x in usage]
+    usage = _safe_usage_history_items(usage, app_id)
     type1 = len(list(filter(lambda x: x.type == UsageHistoryType.memory_created_external_integration, usage)))
     type2 = len(list(filter(lambda x: x.type == UsageHistoryType.memory_created_prompt, usage)))
     type3 = len(list(filter(lambda x: x.type == UsageHistoryType.chat_message_sent, usage)))


### PR DESCRIPTION
## What

`get_app_usage_history` and `get_app_money_made` built a `UsageHistoryItem` per raw usage doc with a bare comprehension and no per-item guard:

```python
usage = [UsageHistoryItem(**x) for x in usage]
```

`UsageHistoryItem` requires `uid`, `timestamp`, and `type` (a `UsageHistoryType` enum). These results are Redis/process-cached and shared across callers, so one legacy or malformed usage document (an out-of-enum `type`, a missing `timestamp`) raises `ValidationError` and 500s the whole app usage-history and earnings enrichment for that app.

## Fix

Route both sites through a shared `_safe_usage_history_items` helper that skips a malformed record rather than failing the whole build, mirroring the `_safe_build_app` guard already in this module for the marketplace list builders:

```python
def _safe_usage_history_items(usage, app_id):
    items = []
    for x in usage:
        try:
            items.append(UsageHistoryItem(**x))
        except ValidationError as e:
            logger.warning("Skipping malformed usage history item for app %s: %s", app_id, [err['loc'][0] for err in e.errors()])
    return items
```

The catch is narrow (`ValidationError`) and logs only the app id plus offending field names, matching `_safe_build_app`.

## Tests

New `tests/unit/test_app_usage_history_skip.py` calls the pure helper directly (same seam as `test_apps_marketplace_poison_guard.py`, which imports `utils.apps` with no stubs):
- valid records build items
- a record missing timestamp/type and a record with an out-of-enum type are skipped, and the valid one survives
- empty input returns empty

## Verification

```
cd backend && ENCRYPTION_SECRET=... OPENAI_API_KEY=... python -m pytest \
  tests/unit/test_app_usage_history_skip.py tests/unit/test_apps_marketplace_poison_guard.py -q
  -> 7 passed
black --line-length 120 --skip-string-normalization --check utils/apps.py tests/unit/test_app_usage_history_skip.py
  -> unchanged
python scripts/check_module_stub_pollution.py -> Checked 605 file(s); 0 violation(s)
```

## Product invariants affected

none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9578?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

