### PR TITLE
fix(backend-listen): restore Helm env identity defaults (#9552)

### DIFF
--- a/backend/charts/backend-listen/dev_omi_backend_listen_values.yaml
+++ b/backend/charts/backend-listen/dev_omi_backend_listen_values.yaml
@@ -7,14 +7,14 @@ replicaCount: 1
 
 # This sets the container image more information can be found here: https://kubernetes.io/docs/concepts/containers/images/
 image:
-  repository: ""
+  repository: gcr.io/based-hardware-dev/backend
   # This sets the pull policy for images.
   pullPolicy: Always
-  # Overrides the image tag whose default is the chart appVersion.
-  tag: "latest"
+  # Build-specific; CI/manual deploy must pass --set image.tag=<short-sha>.
+  tag: ""
 
-gcpProjectId: ""
-runtimeGcpProjectId: ""
+gcpProjectId: based-hardware-dev
+runtimeGcpProjectId: based-hardware-dev
 
 # This is for the secrets for pulling an image from a private repository more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
 imagePullSecrets: []
@@ -328,7 +328,7 @@ env:
         name: dev-omi-backend-secrets
         key: SERVICE_ACCOUNT_JSON
   - name: GOOGLE_CLOUD_PROJECT
-    value: ""
+    value: "based-hardware-dev"
   - name: TWILIO_ACCOUNT_SID
     valueFrom:
       secretKeyRef:

--- a/backend/charts/backend-listen/prod_omi_backend_listen_values.yaml
+++ b/backend/charts/backend-listen/prod_omi_backend_listen_values.yaml
@@ -7,14 +7,14 @@ replicaCount: 1
 
 # This sets the container image more information can be found here: https://kubernetes.io/docs/concepts/containers/images/
 image:
-  repository: ""
+  repository: gcr.io/based-hardware/backend
   # This sets the pull policy for images.
   pullPolicy: Always
-  # Overrides the image tag whose default is the chart appVersion.
-  tag: "latest"
+  # Build-specific; CI/manual deploy must pass --set image.tag=<short-sha>.
+  tag: ""
 
-gcpProjectId: ""
-runtimeGcpProjectId: ""
+gcpProjectId: based-hardware
+runtimeGcpProjectId: based-hardware
 
 # This is for the secrets for pulling an image from a private repository more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
 imagePullSecrets: []
@@ -281,7 +281,7 @@ env:
         name: prod-omi-backend-secrets
         key: OPENROUTER_API_KEY
   - name: GOOGLE_CLOUD_PROJECT
-    value: ""
+    value: "based-hardware"
   - name: CONVERSATION_SUMMARIZED_APP_IDS
     valueFrom:
       secretKeyRef:

--- a/backend/charts/backend-listen/templates/deployment.yaml
+++ b/backend/charts/backend-listen/templates/deployment.yaml
@@ -49,12 +49,12 @@ spec:
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          image: "{{ required "image.repository is required" .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ required "image.repository is required" .Values.image.repository }}:{{ required "image.tag is required" .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
             {{- range .Values.env }}
             - name: {{ .name }}
-              {{- if and (eq .name "GOOGLE_CLOUD_PROJECT") $.Values.runtimeGcpProjectId }}
+              {{- if eq .name "GOOGLE_CLOUD_PROJECT" }}
               value: {{ required "runtimeGcpProjectId is required" $.Values.runtimeGcpProjectId | quote }}
               {{- else if hasKey . "value" }}
               value: {{ .value | quote }}

--- a/backend/tests/unit/test_backend_listen_helm_defaults.py
+++ b/backend/tests/unit/test_backend_listen_helm_defaults.py
@@ -1,0 +1,100 @@
+"""Regression tests for backend-listen Helm env identity defaults (#9552)."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parents[3]
+CHART_DIR = ROOT / "backend" / "charts" / "backend-listen"
+
+ENV_IDENTITY_DEFAULTS = {
+    "prod": {
+        "values_file": CHART_DIR / "prod_omi_backend_listen_values.yaml",
+        "image_repository": "gcr.io/based-hardware/backend",
+        "gcp_project_id": "based-hardware",
+        "runtime_gcp_project_id": "based-hardware",
+    },
+    "dev": {
+        "values_file": CHART_DIR / "dev_omi_backend_listen_values.yaml",
+        "image_repository": "gcr.io/based-hardware-dev/backend",
+        "gcp_project_id": "based-hardware-dev",
+        "runtime_gcp_project_id": "based-hardware-dev",
+    },
+}
+
+
+def _load_values(path: Path) -> dict:
+    loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
+    return loaded if isinstance(loaded, dict) else {}
+
+
+def _env_value(values: dict, name: str) -> str | None:
+    for entry in values.get("env", []) or []:
+        if isinstance(entry, dict) and entry.get("name") == name and "value" in entry:
+            return str(entry["value"])
+    return None
+
+
+@pytest.mark.parametrize("env_name", ["prod", "dev"])
+def test_backend_listen_values_have_env_identity_defaults(env_name: str):
+    expected = ENV_IDENTITY_DEFAULTS[env_name]
+    values = _load_values(expected["values_file"])
+
+    assert values["image"]["repository"] == expected["image_repository"]
+    assert values["gcpProjectId"] == expected["gcp_project_id"]
+    assert values["runtimeGcpProjectId"] == expected["runtime_gcp_project_id"]
+    assert _env_value(values, "GOOGLE_CLOUD_PROJECT") == expected["runtime_gcp_project_id"]
+
+
+@pytest.mark.parametrize("env_name", ["prod", "dev"])
+def test_backend_listen_helm_template_uses_runtime_project_for_google_cloud_project(env_name: str):
+    helm = shutil.which("helm")
+    if helm is None:
+        pytest.skip("helm is not installed")
+
+    expected = ENV_IDENTITY_DEFAULTS[env_name]
+    rendered = subprocess.run(
+        [
+            helm,
+            "template",
+            "backend-listen",
+            str(CHART_DIR),
+            "-f",
+            str(expected["values_file"]),
+            "--set",
+            "image.tag=abc1234",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+
+    assert f'name: GOOGLE_CLOUD_PROJECT\n              value: "{expected["runtime_gcp_project_id"]}"' in rendered
+    assert f'image: "{expected["image_repository"]}:abc1234"' in rendered
+
+
+def test_backend_listen_helm_template_requires_image_tag():
+    helm = shutil.which("helm")
+    if helm is None:
+        pytest.skip("helm is not installed")
+
+    result = subprocess.run(
+        [
+            helm,
+            "template",
+            "backend-listen",
+            str(CHART_DIR),
+            "-f",
+            str(ENV_IDENTITY_DEFAULTS["prod"]["values_file"]),
+        ],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode != 0
+    assert "image.tag is required" in result.stderr


### PR DESCRIPTION
## Summary

Fixes #9552.

- Restores hardcoded prod/dev defaults for environment identity fields in `backend-listen` Helm values: `image.repository`, `gcpProjectId`, `runtimeGcpProjectId`, and `GOOGLE_CLOUD_PROJECT`.
- Makes the deployment template fail closed: `GOOGLE_CLOUD_PROJECT` is always injected from `runtimeGcpProjectId` (no longer bypassed when the value is an empty string), and `image.tag` is required instead of falling back to stale `Chart.AppVersion`.
- Leaves build-specific `image.tag` empty in values files; CI and manual deploys must pass `--set image.tag=<short-sha>` as before.

## Root cause

PR #8429 emptied environment-stable Helm defaults so CI `--set` overrides would work, but manual `helm upgrade` without those flags deployed empty repository/project values and broke backend-listen.

## Test plan

- [x] `python3 -m pytest backend/tests/unit/test_backend_listen_helm_defaults.py -v`
- [x] Pre-push checks passed (runtime env validator, selected unit tests, manifest checks)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9579?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

