### PR TITLE
fix(desktop): stop cutting off long-context Gemini calls at 90s (#9135)

### DIFF
--- a/desktop/macos/Backend-Rust/src/routes/proxy.rs
+++ b/desktop/macos/Backend-Rust/src/routes/proxy.rs
@@ -50,9 +50,21 @@ const MAX_OUTPUT_TOKENS_CAP: u64 = 8192;
 /// explicitly on all production paths.
 const DEFAULT_THINKING_BUDGET: u64 = 1024;
 
-/// Keep non-streaming upstream calls below observed Cloud Run request boundaries
-/// so the proxy owns timeout mapping and desktop clients get a retryable error.
-const GEMINI_UPSTREAM_TIMEOUT: Duration = Duration::from_secs(90);
+/// Cloud Run's configured request timeout for `desktop-backend`.
+const CLOUD_RUN_REQUEST_TIMEOUT: Duration = Duration::from_secs(300);
+
+/// Headroom reserved under the platform deadline so the proxy — not Cloud Run —
+/// is the one that gives up, and clients get our typed, retryable `upstream_timeout`
+/// body instead of an opaque platform 504.
+const GEMINI_UPSTREAM_HEADROOM_SECS: u64 = 60;
+
+/// Deadline for non-streaming upstream calls, derived from the platform bound so it
+/// can never drift above it. Long-context `generateContent` on 2.5-flash regularly
+/// spends 60-100s thinking before the first response byte, so a deadline near that
+/// tail converts successful generations into 504s (#9135). The Swift client waits
+/// 300s (`GeminiClient.swift`) and does not auto-retry timeouts.
+const GEMINI_UPSTREAM_TIMEOUT: Duration =
+    Duration::from_secs(CLOUD_RUN_REQUEST_TIMEOUT.as_secs() - GEMINI_UPSTREAM_HEADROOM_SECS);
 
 /// Bound TCP/TLS setup for all Gemini proxy calls. Streaming requests must not
 /// use a total response timeout because long SSE replies are expected.
@@ -1097,8 +1109,17 @@ mod tests {
     #[test]
     fn gemini_upstream_timeout_stays_below_cloud_run_deadline() {
         assert!(GEMINI_CONNECT_TIMEOUT < GEMINI_UPSTREAM_TIMEOUT);
-        assert!(GEMINI_UPSTREAM_TIMEOUT <= Duration::from_secs(90));
-        assert!(GEMINI_UPSTREAM_TIMEOUT < Duration::from_secs(120));
+
+        // The proxy must give up before Cloud Run does, so clients get our typed
+        // `upstream_timeout` body rather than an opaque platform 504. Keep real
+        // headroom for the response to flush.
+        assert!(GEMINI_UPSTREAM_TIMEOUT < CLOUD_RUN_REQUEST_TIMEOUT);
+        assert!(CLOUD_RUN_REQUEST_TIMEOUT - GEMINI_UPSTREAM_TIMEOUT >= Duration::from_secs(30));
+
+        // Regression guard (#9135): a 90s deadline cut off long-context 2.5-flash
+        // generations that complete upstream in 90-100s, turning them into 504s.
+        // Verified against prod Vertex: a 150k-token request returned 200 at 95.5s.
+        assert!(GEMINI_UPSTREAM_TIMEOUT >= Duration::from_secs(180));
     }
 
     #[test]

--- a/desktop/macos/changelog/unreleased/20260712-gemini-proxy-long-context-timeout.json
+++ b/desktop/macos/changelog/unreleased/20260712-gemini-proxy-long-context-timeout.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed long-context AI requests failing with \"AI request took too long\" even when the model had already produced an answer"
+}


### PR DESCRIPTION
Fixes #9135.

## Bug (live on prod)

The desktop Gemini proxy returns persistent `504`s on
`/v1/proxy/gemini/models/gemini-2.5-flash:generateContent` while `/health` stays green.

## Root cause

**The proxy — not the upstream — was the binding deadline.**

`GEMINI_UPSTREAM_TIMEOUT` was hardcoded to 90s, with the comment "keep non-streaming upstream calls
below observed Cloud Run request boundaries". But `desktop-backend`'s Cloud Run request timeout is
actually **300s** (`gcloud run services describe desktop-backend --format='value(spec.template.spec.timeoutSeconds)'` → `300`),
and the Swift client waits **300s** (`GeminiClient.swift`) and deliberately does not auto-retry timeouts.

So the 90s guess was ~3.3x tighter than the real bound, and it aborted generations the model had
already spent the money to produce.

## Prod evidence (last 6h, `desktop-backend` Cloud Logging)

- **11 of 1000** `/v1/proxy/gemini` unary calls returned `504` (~1.1%).
- **Every** `504` had latency **90.03–90.13s** — our own timeout firing, not an upstream failure.
- All were `phase=request status=timeout provider=vertex_ai model=gemini-2.5-flash`,
  `payload_bucket` 16–512kb.
- Successful calls reach **84.5s**, and 6 completed in the `60-120s` bucket — the latency tail
  straddles the cap, so the cap was slicing through live traffic.

## Upstream premise verified against real prod Vertex AI

Long-context 2.5-flash spends most of its wall-clock *thinking*, before the first response byte:

| request | result |
|---|---|
| 181 KB / 40k prompt tokens | `200` in **64.3s** (7,863 thinking tokens) |
| 741 KB / 150k prompt tokens | `200` in **95.5s**, full valid answer |

The second one **would have been 504'd at 90s** — a successful generation thrown away, and the user
shown "AI request took too long".

## Fix

Derive the deadline from the platform bound instead of hardcoding a guess:

```rust
const CLOUD_RUN_REQUEST_TIMEOUT: Duration = Duration::from_secs(300);
const GEMINI_UPSTREAM_HEADROOM_SECS: u64 = 60;
const GEMINI_UPSTREAM_TIMEOUT: Duration =
    Duration::from_secs(CLOUD_RUN_REQUEST_TIMEOUT.as_secs() - GEMINI_UPSTREAM_HEADROOM_SECS); // 240s
```

This closes the failure class rather than re-tuning a number: the deadline can no longer drift above
the platform timeout, so the proxy always remains the component that gives up first and clients keep
getting our typed, retryable `upstream_timeout` JSON instead of an opaque platform 504.

Streaming is untouched (it correctly has no total-response timeout). Error classification, structured
`upstream_result` logging, and the typed 504 body already landed in #8911 — this fixes the remaining
defect: the deadline itself.

## Regression test

The existing test hardcoded the very bound that was wrong (`GEMINI_UPSTREAM_TIMEOUT <= 90s`), so it
would have *locked the bug in*. It now asserts the real contract: strictly below the platform
timeout, ≥30s flush headroom, and generous enough to cover the observed completion tail.

## Verification

- `cargo test proxy::` → **78 passed**, 0 failed
- `cargo clippy` → clean (no warnings)
- `cargo check` → clean
- Prod log analysis + real prod Vertex timing runs above

**Not exercised:** an authenticated >90s request through the running proxy — that needs a signed-in
desktop session and Omi Dev is not signed in on this machine. The upstream premise and the constant
contract are proven; the passthrough itself is not path-exercised.

🤖 automated by hourly watchdog


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9583?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

