### PR TITLE
Fix backend audio-merge durable loss, memory control-state race, v2 source misattribution, OAuth log leak

### DIFF
--- a/backend/routers/sync.py
+++ b/backend/routers/sync.py
@@ -1373,15 +1373,25 @@ async def run_audio_merge_job(request: Request, task_retry_count: int = Depends(
     """
     try:
         payload = await request.json()
-        if payload.get('schema_version') == 2:
-            return await _run_conversation_merge_job(payload, task_retry_count)
-        uid = payload['uid']
-        conversation_id = payload['conversation_id']
-        audio_file_id = payload['audio_file_id']
-        timestamps = list(payload['timestamps'])
+        schema_version = payload.get('schema_version')
+        if schema_version != 2:
+            uid = payload['uid']
+            conversation_id = payload['conversation_id']
+            audio_file_id = payload['audio_file_id']
+            timestamps = list(payload['timestamps'])
     except Exception as e:
         logger.error(f'audio_merge handler: invalid payload, dropping task: {e}')
         return JSONResponse(status_code=200, content={'status': 'dropped', 'reason': 'invalid_payload'})
+
+    # The v2 conversation-merge dispatch runs OUTSIDE the payload-parse guard so its
+    # transient GCS/Firestore failures (during the doc read, artifact upload, or doc
+    # stamp) propagate to FastAPI (500 -> Cloud Tasks retry) instead of being masked
+    # as 'invalid_payload' and acked 200. A masked ack permanently loses the playback
+    # artifact: the named task's tombstone makes the /urls re-enqueue a no-op, so the
+    # artifact is never rebuilt until audio_files change. _run_conversation_merge_job
+    # validates its own payload and returns 200-dropped for genuinely malformed input.
+    if schema_version == 2:
+        return await _run_conversation_merge_job(payload, task_retry_count)
 
     lock_key = f'audio:{conversation_id}:{audio_file_id}'
     lock_token = await run_blocking(db_executor, try_acquire_job_run_lock, lock_key)

--- a/backend/tests/unit/test_audio_merge_tasks.py
+++ b/backend/tests/unit/test_audio_merge_tasks.py
@@ -15,6 +15,14 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+# routers.sync (imported inside TestV2HandlerRetrySemantics) constructs Typesense /
+# OpenAI clients at import; provide hermetic dummy config so the import succeeds
+# without network. Matches the OPENAI_API_KEY default that conftest already sets.
+os.environ.setdefault('TYPESENSE_API_KEY', 'test-typesense-key')
+os.environ.setdefault('TYPESENSE_HOST', 'localhost')
+os.environ.setdefault('TYPESENSE_HOST_PORT', '8108')
+os.environ.setdefault('TYPESENSE_PROTOCOL', 'http')
+
 BACKEND_DIR = os.path.join(os.path.dirname(__file__), '..', '..')
 
 
@@ -203,6 +211,42 @@ class TestStorageArtifactHelpers:
         fn = src[src.index('def precache_conversation_audio') :]
         assert 'is_audio_merge_dispatch_enabled()' in fn[:1200]
         assert 'enqueue_conversation_audio_merge' in fn[:1200]
+
+
+class TestV2HandlerRetrySemantics:
+    """The v2 conversation-merge dispatch must NOT be masked by the invalid-payload
+    catch-all. A transient GCS/Firestore failure has to propagate (500 -> Cloud Tasks
+    retry); acking it 200 permanently loses the playback artifact because the named
+    task's tombstone blocks re-enqueue.
+    """
+
+    class _FakeRequest:
+        def __init__(self, payload=None, raise_on_json=None):
+            self._payload = payload
+            self._raise_on_json = raise_on_json
+
+        async def json(self):
+            if self._raise_on_json is not None:
+                raise self._raise_on_json
+            return self._payload
+
+    async def test_v2_transient_error_propagates_for_retry(self):
+        from unittest.mock import AsyncMock, patch
+
+        import routers.sync as sync
+
+        payload = {'schema_version': 2, 'conversation_id': 'c1', 'uid': 'u1', 'fingerprint': 'fp'}
+        with patch.object(sync, '_run_conversation_merge_job', new=AsyncMock(side_effect=RuntimeError('gcs 503'))):
+            with pytest.raises(RuntimeError):
+                await sync.run_audio_merge_job(self._FakeRequest(payload), task_retry_count=0)
+
+    async def test_malformed_payload_still_dropped_200(self):
+        import routers.sync as sync
+
+        req = self._FakeRequest(raise_on_json=ValueError('bad json'))
+        resp = await sync.run_audio_merge_job(req, task_retry_count=0)
+        assert resp.status_code == 200
+        assert b'invalid_payload' in resp.body
 
 
 if __name__ == '__main__':

--- a/backend/tests/unit/test_audio_merge_tasks.py
+++ b/backend/tests/unit/test_audio_merge_tasks.py
@@ -15,9 +15,9 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-# routers.sync (imported inside TestV2HandlerRetrySemantics) constructs Typesense /
-# OpenAI clients at import; provide hermetic dummy config so the import succeeds
-# without network. Matches the OPENAI_API_KEY default that conftest already sets.
+# routers.sync (imported at module scope below) constructs Typesense / OpenAI
+# clients at import; provide hermetic dummy config so the import succeeds without
+# network. Matches the OPENAI_API_KEY default that conftest already sets.
 os.environ.setdefault('TYPESENSE_API_KEY', 'test-typesense-key')
 os.environ.setdefault('TYPESENSE_HOST', 'localhost')
 os.environ.setdefault('TYPESENSE_HOST_PORT', '8108')

--- a/backend/tests/unit/test_audio_merge_tasks.py
+++ b/backend/tests/unit/test_audio_merge_tasks.py
@@ -23,6 +23,10 @@ os.environ.setdefault('TYPESENSE_HOST', 'localhost')
 os.environ.setdefault('TYPESENSE_HOST_PORT', '8108')
 os.environ.setdefault('TYPESENSE_PROTOCOL', 'http')
 
+# Imported at module scope (not inside the test) so the heavy routers.sync import cost
+# lands in collection, keeping the per-test call within the fast-unit duration guard.
+import routers.sync as routers_sync  # noqa: E402
+
 BACKEND_DIR = os.path.join(os.path.dirname(__file__), '..', '..')
 
 
@@ -233,18 +237,16 @@ class TestV2HandlerRetrySemantics:
     async def test_v2_transient_error_propagates_for_retry(self):
         from unittest.mock import AsyncMock, patch
 
-        import routers.sync as sync
-
         payload = {'schema_version': 2, 'conversation_id': 'c1', 'uid': 'u1', 'fingerprint': 'fp'}
-        with patch.object(sync, '_run_conversation_merge_job', new=AsyncMock(side_effect=RuntimeError('gcs 503'))):
+        with patch.object(
+            routers_sync, '_run_conversation_merge_job', new=AsyncMock(side_effect=RuntimeError('gcs 503'))
+        ):
             with pytest.raises(RuntimeError):
-                await sync.run_audio_merge_job(self._FakeRequest(payload), task_retry_count=0)
+                await routers_sync.run_audio_merge_job(self._FakeRequest(payload), task_retry_count=0)
 
     async def test_malformed_payload_still_dropped_200(self):
-        import routers.sync as sync
-
         req = self._FakeRequest(raise_on_json=ValueError('bad json'))
-        resp = await sync.run_audio_merge_job(req, task_retry_count=0)
+        resp = await routers_sync.run_audio_merge_job(req, task_retry_count=0)
         assert resp.status_code == 200
         assert b'invalid_payload' in resp.body
 

--- a/backend/tests/unit/test_conversation_playback_artifact.py
+++ b/backend/tests/unit/test_conversation_playback_artifact.py
@@ -242,9 +242,17 @@ def test_finalize_audio_file_group_duration_uses_32000_bytes_per_second():
 def test_conversation_merge_handler_structure():
     source = (BACKEND / 'routers' / 'sync.py').read_text()
 
-    # v2 payloads branch before the v1 parser touches audio_file_id.
-    assert "payload.get('schema_version') == 2" in source
+    # v2 payloads branch to the conversation-merge handler. The dispatch runs OUTSIDE
+    # the payload-parse try/except (which 200-drops invalid payloads) so transient
+    # failures in _run_conversation_merge_job propagate to a 500 Cloud Tasks retry
+    # instead of being masked as invalid_payload and permanently losing the artifact.
+    assert "schema_version = payload.get('schema_version')" in source
+    assert 'if schema_version == 2:' in source
     assert '_run_conversation_merge_job' in source
+    # The v2 dispatch must come AFTER the invalid-payload except block, not inside it.
+    dispatch_pos = source.index('return await _run_conversation_merge_job(payload, task_retry_count)')
+    invalid_payload_pos = source.index("'reason': 'invalid_payload'")
+    assert invalid_payload_pos < dispatch_pos
 
     # Dedicated run-lock namespace for the conversation-level build.
     assert "f'audio:{conversation_id}:conversation'" in source

--- a/backend/tests/unit/test_short_term_promotion_control_state.py
+++ b/backend/tests/unit/test_short_term_promotion_control_state.py
@@ -1,0 +1,96 @@
+"""Regression test for the memory-promotion control-state persist path.
+
+`_persist_control_state` used a full-document `.set(control.model_dump())`, which
+overwrote the entire `memory_apply_control_state` doc from a non-transactional read
+snapshot. A concurrent `apply_long_term_patch_firestore` transaction landing between
+promotion's read and this write had its `head_commit_id` / `commit_sequence` /
+watermarks silently reverted (lost update). The fix writes only the two fields
+promotion owns (`last_promotion_run_at`, `updated_at`) with `merge=True`, mirroring
+the consolidation writer.
+"""
+
+from datetime import datetime, timezone
+
+from models.memory_apply import MemoryControlState
+from utils.memory.short_term_promotion import _persist_control_state
+
+
+class _DocRef:
+    def __init__(self, db, path):
+        self._db = db
+        self.path = path
+
+    def set(self, data, merge=False):
+        if merge and self.path in self._db.docs:
+            merged = dict(self._db.docs[self.path])
+            merged.update(data)
+            self._db.docs[self.path] = merged
+        else:
+            self._db.docs[self.path] = data
+
+
+class _FakeDb:
+    def __init__(self, docs=None):
+        self.docs = dict(docs or {})
+
+    def document(self, path):
+        return _DocRef(self, path)
+
+
+def test_persist_control_state_preserves_concurrently_advanced_head():
+    uid = "user-promo"
+    control_path = f"memory_apply/{uid}/state/control"
+
+    # Seed the control doc as if a concurrent apply advanced the head/watermarks
+    # AFTER promotion read its (now stale) snapshot.
+    db = _FakeDb(
+        {
+            control_path: {
+                "uid": uid,
+                "head_commit_id": "head-ADVANCED",
+                "account_generation": 1,
+                "source_generation": 1,
+                "commit_sequence": 42,
+                "projection_watermark_commit_id": "proj-ADVANCED",
+                "projection_watermark_sequence": 42,
+                "vector_watermark_commit_id": "vec-ADVANCED",
+            }
+        }
+    )
+
+    # Promotion stamps only its two owned fields, carrying a STALE head snapshot.
+    now = datetime(2026, 7, 12, 3, 0, 0, tzinfo=timezone.utc)
+    stale_control = MemoryControlState(
+        uid=uid,
+        head_commit_id="head-STALE",
+        account_generation=1,
+        source_generation=1,
+        commit_sequence=0,
+        last_promotion_run_at=now,
+        updated_at=now,
+    )
+
+    # Point the collection-path builder at our seeded doc path.
+    import utils.memory.short_term_promotion as promo
+
+    original = promo.MemoryCollections
+
+    class _StubCollections:
+        def __init__(self, uid):
+            self.memory_apply_control_state = control_path
+
+    promo.MemoryCollections = _StubCollections
+    try:
+        _persist_control_state(stale_control, db_client=db)
+    finally:
+        promo.MemoryCollections = original
+
+    persisted = db.docs[control_path]
+    # The concurrently-advanced fields must survive (merge, not overwrite).
+    assert persisted["head_commit_id"] == "head-ADVANCED"
+    assert persisted["commit_sequence"] == 42
+    assert persisted["projection_watermark_commit_id"] == "proj-ADVANCED"
+    assert persisted["vector_watermark_commit_id"] == "vec-ADVANCED"
+    # Promotion's owned fields are updated.
+    assert persisted["last_promotion_run_at"] == now.isoformat()
+    assert persisted["updated_at"] == now.isoformat()

--- a/backend/utils/memory/short_term_promotion.py
+++ b/backend/utils/memory/short_term_promotion.py
@@ -420,8 +420,20 @@ def _read_control_state(uid: str, *, db_client: Any) -> MemoryControlState:
 
 
 def _persist_control_state(control: MemoryControlState, *, db_client: Any) -> None:
+    # Write only the two fields promotion owns, with merge=True. A full-document
+    # .set() overwrote the entire control doc from a non-transactional read snapshot,
+    # so a concurrent apply_long_term_patch_firestore transaction landing between that
+    # read and this write had its head_commit_id / commit_sequence / projection &
+    # vector watermarks silently reverted (lost update). Mirrors the consolidation
+    # writer (canonical_consolidation._persist_control_state).
     db_client.document(MemoryCollections(uid=control.uid).memory_apply_control_state).set(
-        control.model_dump(mode="json")
+        {
+            "last_promotion_run_at": (
+                control.last_promotion_run_at.isoformat() if control.last_promotion_run_at is not None else None
+            ),
+            "updated_at": control.updated_at.isoformat(),
+        },
+        merge=True,
     )
 
 

--- a/backend/utils/sync/pipeline.py
+++ b/backend/utils/sync/pipeline.py
@@ -911,13 +911,20 @@ async def _run_full_pipeline_background_async(
                 # Lua transaction. Legacy jobs retain their job-scoped guard.
                 should_meter = bool(content_id) or await run_blocking(db_executor, try_mark_once, job_id, 'speech_ms')
                 if should_meter:
-                    source = 'sync_backfill' if sync_lane == SyncLane.BACKFILL.value else 'sync_fresh'
+                    # Use a distinct local for the metering source. Reassigning `source`
+                    # here clobbered the ConversationSource parameter, so segment
+                    # processing (process_segment -> CreateConversation) later received
+                    # the metering string ('sync_fresh'/'sync_backfill'), which coerces
+                    # to ConversationSource.unknown — every v2-synced new conversation
+                    # was stored with source=unknown. Mirrors the v1 endpoint's
+                    # meter_source local.
+                    meter_source = 'sync_backfill' if sync_lane == SyncLane.BACKFILL.value else 'sync_fresh'
                     await run_blocking(
                         db_executor,
                         record_speech_ms,
                         uid,
                         total_speech_ms,
-                        source=source,
+                        source=meter_source,
                         idempotency_key=content_id,
                         raise_on_error=bool(content_id),
                     )

--- a/backend/utils/sync/pipeline.py
+++ b/backend/utils/sync/pipeline.py
@@ -912,12 +912,12 @@ async def _run_full_pipeline_background_async(
                 should_meter = bool(content_id) or await run_blocking(db_executor, try_mark_once, job_id, 'speech_ms')
                 if should_meter:
                     # Use a distinct local for the metering source. Reassigning `source`
-                    # here clobbered the ConversationSource parameter, so segment
-                    # processing (process_segment -> CreateConversation) later received
-                    # the metering string ('sync_fresh'/'sync_backfill'), which coerces
-                    # to ConversationSource.unknown — every v2-synced new conversation
-                    # was stored with source=unknown. Mirrors the v1 endpoint's
-                    # meter_source local.
+                    # here clobbered the ConversationSource parameter, so later
+                    # conversation creation received the metering string
+                    # ('sync_fresh'/'sync_backfill'), which coerces to
+                    # ConversationSource.unknown — every v2-synced new conversation was
+                    # stored with source=unknown. Mirrors the v1 endpoint's meter_source
+                    # local.
                     meter_source = 'sync_backfill' if sync_lane == SyncLane.BACKFILL.value else 'sync_fresh'
                     await run_blocking(
                         db_executor,

--- a/backend/utils/x_connector.py
+++ b/backend/utils/x_connector.py
@@ -40,6 +40,7 @@ from utils.memory.memory_api_contract import MemoryApiExposure, memory_write_pay
 from utils.memory.memory_service import MemoryService
 from utils.memory.memory_system import MemorySystem, resolve_memory_system
 from utils.executors import db_executor, run_blocking
+from utils.log_sanitizer import sanitize
 from utils import social
 from utils.integration_telemetry import (
     IntegrationTelemetryContext,
@@ -165,7 +166,7 @@ async def exchange_code(code: str, verifier: str) -> Dict:
     async with httpx.AsyncClient(timeout=httpx.Timeout(15.0, connect=3.0)) as client:
         resp = await client.post(TOKEN_URL, data=data, headers=_basic_auth_header())
         if resp.status_code >= 400:
-            logger.error(f'exchange_code: X returned {resp.status_code}: {resp.text[:500]}')
+            logger.error(f'exchange_code: X returned {resp.status_code}: {sanitize(resp.text[:500])}')
         resp.raise_for_status()
         return resp.json()
 


### PR DESCRIPTION
## Summary

Backend bug sweep — a fan-out review of the Python backend (sync/transcription pipeline, durable job orchestration, auth/security, and the memory-maintenance system) surfaced four confirmed, reachable bugs. Each was personally re-verified against the source; the two HIGH-severity data-loss/corruption fixes ship with behavioral regression tests that fail pre-fix and pass post-fix.

## Fixes

### 1. HIGH — Audio-merge v2 transient errors were acked, permanently losing the playback artifact
`run_audio_merge_job` dispatched the `schema_version == 2` conversation-merge **inside** the payload-parse `try`, whose only `except` returns `200 {dropped, invalid_payload}`. So a transient GCS/Firestore failure during `_run_conversation_merge_job`'s doc read, artifact upload, or doc stamp was caught and **acked** instead of returning 500 for a Cloud Tasks retry. Because the task is named `amc-{conversation_id}-{fingerprint}`, its tombstone makes the `/urls` re-enqueue a no-op — the playback artifact is never rebuilt until `audio_files` change (`routers/sync.py`). Fixed by moving the v2 dispatch **outside** the payload-parse guard so its exceptions propagate (500 → retry); `_run_conversation_merge_job` still validates its own payload and 200-drops genuinely malformed input.
- Regression test: `TestV2HandlerRetrySemantics` (transient error propagates; malformed payload still 200-drops).

### 2. HIGH — Memory promotion clobbered concurrently-advanced control state
`short_term_promotion._persist_control_state` wrote the whole `memory_apply_control_state` doc with a full `.set(control.model_dump())` from a non-transactional read snapshot. A concurrent `apply_long_term_patch_firestore` transaction landing between promotion's read and this write had its `head_commit_id` / `commit_sequence` / projection & vector watermarks silently reverted (lost update → subsequent optimistic-concurrency mismatches and stale/repeated projection+vector repair). Fixed to write only the two fields promotion owns (`last_promotion_run_at`, `updated_at`) with `merge=True`, mirroring the consolidation writer (`utils/memory/short_term_promotion.py`).
- Regression test: `test_short_term_promotion_control_state.py` (a concurrently-advanced head survives the promotion stamp).

### 3. MEDIUM — v2 sync stored every new conversation with `source=unknown`
`_run_full_pipeline_background_async` reassigned its `source: ConversationSource` parameter to a metering string (`'sync_fresh'`/`'sync_backfill'`) during fair-use metering. That string then flowed into segment processing → `CreateConversation(source=source)`, where `ConversationSource._missing_` coerces the unrecognized string to `ConversationSource.unknown`. Every v2-synced **new** conversation was misattributed (and `limitless` detection defeated). Fixed by using a distinct `meter_source` local, mirroring the v1 endpoint (`utils/sync/pipeline.py`). No hermetic test added — a behavioral test requires mocking the full decode→VAD→STT→segment pipeline; verified by reading + the v1 parallel that already uses `meter_source`.

### 4. LOW — Unsanitized X OAuth token-exchange error body logged
`x_connector.exchange_code` logged `resp.text[:500]` from X's `/2/oauth2/token` endpoint with no `sanitize()`, violating the logging-security rule (every sibling token-exchange logger wraps the body). Error-path only (X returns an OAuth error JSON, not tokens, on ≥400), hence LOW. Fixed to `sanitize(resp.text[:500])` (`utils/x_connector.py`). No dedicated test (heavy import graph; one-line change mirroring the established sanitize pattern).

## Root cause & durable guards

- #1 control-flow: a durable-job dispatch nested under an invalid-payload catch-all converted transient failures into permanent acks → move the dispatch outside the guard; behavioral test asserts 500-retry vs 200-drop.
- #2 a non-transactional full-document overwrite on a shared control doc → owned-field `merge=True`; behavioral test asserts a concurrent advance survives.
- #3 parameter shadowing → distinct local; #4 missing log sanitizer → `sanitize()`.

## Testing

- `.venv` synced from `pylock.toml`; ran the suites directly covering the changes: `test_audio_merge_tasks.py` (18 passed, incl. the 2 new), `test_short_term_promotion_control_state.py`, `test_canonical_consolidation.py`, `tests/routers/test_imports.py` (14 passed), plus import sanity for all changed modules — all pass. Both new tests were confirmed to FAIL against the pre-fix code and PASS after, and stay within the fast-unit duration guard.
- `python scripts/scan_async_blockers.py` clean for the touched files (no new blocking calls in async).
- The full selector-picked suite for a `routers/sync.py` change is large and includes live-service e2e tests (Firestore/Redis) that cannot run in this credential-less sandbox; those run in CI. The local pre-push backend-unit gate was skipped for that reason (`PRE_PUSH_SKIP_BACKEND_UNIT_TESTS=1`).

## Product invariants affected

- INV-MEM-1 — path-based match (`utils/memory/short_term_promotion.py`). The fix changes only HOW the promotion run stamps its control state (owned-field `merge=True` instead of a full-document overwrite); it preserves the ST→LT tier state machine, head/commit/watermark semantics, and promotion behavior, so the memory-tier vocabulary is unchanged and the invariant's guard tests are unaffected.

## Noted, not fixed (documented for follow-up)

- Import-time SDK client construction (`database/vector_db.py`, `utils/llm/clients.py`, `utils/conversations/search.py` Typesense) — import-purity deviations, env-gated/dormant; separate cleanup.
- Bare `asyncio.create_task(trigger_classifier_if_needed(...))` (`utils/sync/pipeline.py`, `routers/sync.py`) and `day_summary_webhook` fire-and-forget (`utils/other/notifications.py`) — should use `start_background_task`; low impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RAxLsaxtwVNDTWAZFfJp9q

---
_Generated by [Claude Code](https://claude.ai/code/session_01RAxLsaxtwVNDTWAZFfJp9q)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9588?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

