### PR TITLE
test(desktop): harness seams + tests for TASK-05, CHAT-07, AUTH-03/04, TASK-03, MIC-04

### DIFF
--- a/desktop/macos/Desktop/Sources/AuthService.swift
+++ b/desktop/macos/Desktop/Sources/AuthService.swift
@@ -1965,6 +1965,61 @@ class AuthService {
         UserDefaults.standard.removeObject(forKey: .authTokenUserId)
     }
 
+    /// AUTH-03 test seam (**non-prod only**): force the stored idToken's expiry into the
+    /// past by re-saving the CURRENT tokens through `saveTokens` — the same storage path
+    /// the app really uses — so a harness can then relaunch and prove the app refreshes an
+    /// expired idToken *without signing the user out*.
+    ///
+    /// Why this exists: the tokens moved to the Keychain, so the old harness trick of
+    /// `defaults write <bundle> auth_tokenExpiry -float 1000` now tampers a key the app
+    /// no longer reads — the probe silently measured nothing and reported a false
+    /// regression. Going through `saveTokens` keeps the seam correct for BOTH backends
+    /// (keychain and the UserDefaults fallback) and is inert if the storage changes again.
+    ///
+    /// `expiresIn: 0` lands at `now - 300` (saveTokens subtracts the 5-min buffer), i.e.
+    /// already expired. Token material never leaves the process — only a redacted status.
+    func expireStoredTokenForAutomation() -> [String: String] {
+        guard AppBuild.isNonProduction else {
+            return ["error": "expire_auth_token is disabled on production bundles"]
+        }
+        guard let idToken = storedIdToken, let refreshToken = storedRefreshToken else {
+            return ["error": "no stored tokens to expire"]
+        }
+        do {
+            try saveTokens(
+                idToken: idToken,
+                refreshToken: refreshToken,
+                expiresIn: 0,
+                userId: storedTokenUserId ?? ""
+            )
+            return [
+                "expired": "true",
+                "storage": usesKeychainTokenStorage ? "keychain" : "user_defaults",
+                "is_token_expired": isTokenExpired ? "true" : "false",
+            ]
+        } catch {
+            return ["error": "failed to re-save tokens with a past expiry"]
+        }
+    }
+
+    /// AUTH-03 test seam (**non-prod only**): read-only token status. Reports which
+    /// backend actually holds the tokens and whether the stored idToken is currently
+    /// expired, so a harness can assert "expired -> relaunch -> refreshed, still signed
+    /// in" against the REAL storage instead of a UserDefaults key that may not be in use.
+    /// Presence/expiry booleans only — never token material.
+    func tokenStatusForAutomation() -> [String: String] {
+        guard AppBuild.isNonProduction else {
+            return ["error": "auth_token_status is disabled on production bundles"]
+        }
+        return [
+            "signed_in": isSignedIn ? "true" : "false",
+            "storage": usesKeychainTokenStorage ? "keychain" : "user_defaults",
+            "has_id_token": storedIdToken != nil ? "true" : "false",
+            "has_refresh_token": storedRefreshToken != nil ? "true" : "false",
+            "is_token_expired": isTokenExpired ? "true" : "false",
+        ]
+    }
+
     private var usesKeychainTokenStorage: Bool {
         tokenStorageHooks.usesKeychainTokenStorage()
     }

--- a/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
+++ b/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
@@ -3124,6 +3124,41 @@ final class DesktopAutomationActionRegistry {
       return ["blocking_main_thread_ms": "\(durationMs)"]
     }
 
+    // AUTH-03: force the stored idToken's expiry into the past through AuthService's own
+    // storage abstraction, so a harness can relaunch and prove the app REFRESHES an
+    // expired token without signing the user out. The old harness trick
+    // (`defaults write <bundle> auth_tokenExpiry -float 1000`) tampers a key the app no
+    // longer reads now that tokens are keychain-backed — it measured nothing and reported
+    // a false regression. This seam is storage-agnostic and never exposes token material.
+    // Non-prod only (double-gated: here and inside AuthService).
+    register(
+      name: "expire_auth_token",
+      summary:
+        "Expire the stored idToken via AuthService's real storage path (keychain or UserDefaults) so a relaunch must refresh it without signing out — AUTH-03. Status only, no token material. Non-prod only.",
+      params: []
+    ) { _ in
+      guard AppBuild.isNonProduction else {
+        return ["error": "expire_auth_token is disabled on production bundles"]
+      }
+      return await MainActor.run { AuthService.shared.expireStoredTokenForAutomation() }
+    }
+
+    // AUTH-03 read-back: which backend actually holds the tokens, and is the stored
+    // idToken currently expired? Lets a harness assert "expired -> relaunch -> refreshed,
+    // still signed in" against the REAL storage rather than a UserDefaults key the app may
+    // no longer use. Presence/expiry booleans only — never token material. Non-prod only.
+    register(
+      name: "auth_token_status",
+      summary:
+        "Read-only auth token status (signed_in, storage backend, has_id_token, has_refresh_token, is_token_expired) — AUTH-03. No token material. Non-prod only.",
+      params: []
+    ) { _ in
+      guard AppBuild.isNonProduction else {
+        return ["error": "auth_token_status is disabled on production bundles"]
+      }
+      return await MainActor.run { AuthService.shared.tokenStatusForAutomation() }
+    }
+
     // CHAT-07: post `NSWorkspace.didWakeNotification` on the WORKSPACE notification
     // center — the top of the real wake chain. Every production consumer then fires
     // exactly as on a physical wake: RealtimeHubController re-warms/defers its

--- a/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
+++ b/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
@@ -3124,6 +3124,31 @@ final class DesktopAutomationActionRegistry {
       return ["blocking_main_thread_ms": "\(durationMs)"]
     }
 
+    // CHAT-07: post `NSWorkspace.didWakeNotification` on the WORKSPACE notification
+    // center — the top of the real wake chain. Every production consumer then fires
+    // exactly as on a physical wake: RealtimeHubController re-warms/defers its
+    // session ("system_wake"), and AppState's observer re-broadcasts the
+    // default-center `.systemDidWake` for downstream consumers. (Posting only the
+    // default-center `.systemDidWake` would MISS RealtimeHub, which observes the
+    // workspace center directly.) Transcription restart stays guarded by
+    // wasTranscribingBeforeSleep, so a synthetic wake is a safe no-op there.
+    // Read-only with respect to user data; non-prod only.
+    register(
+      name: "simulate_system_wake",
+      summary: "Post NSWorkspace.didWakeNotification on the workspace center (the top of the real wake chain: RealtimeHub re-warm + AppState .systemDidWake re-broadcast) so post-wake restart paths run without a real sleep — CHAT-07 harness. Non-prod only.",
+      params: []
+    ) { _ in
+      guard AppBuild.isNonProduction else {
+        return ["error": "simulate_system_wake is disabled on production bundles"]
+      }
+      await MainActor.run {
+        NSWorkspace.shared.notificationCenter.post(
+          name: NSWorkspace.didWakeNotification, object: nil)
+      }
+      log("DesktopAutomationBridge: simulate_system_wake posted NSWorkspace.didWakeNotification")
+      return ["posted": "NSWorkspace.didWakeNotification"]
+    }
+
     // PERM-06: trigger the permission-flow "Quit & Reopen" restart — the exact
     // AppState.restartApp() path used after granting Accessibility / Screen
     // Recording — so a harness can prove the SAME bundle relaunches with the

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
@@ -1116,16 +1116,36 @@ class PushToTalkManager: ObservableObject {
     // Append while under the cap (the chunk that reaches it is kept, so the warning
     // fires exactly at the crossing). Set the once-flag atomically under the lock so
     // the warning is enqueued exactly once, not on every subsequent chunk.
-    var justHitCap = false
-    if batchAudioBuffer.count < Self.maxBatchAudioBytes {
-      batchAudioBuffer.append(audioData)
-      if batchAudioBuffer.count >= Self.maxBatchAudioBytes && !batchAudioOverflowSignaled {
-        batchAudioOverflowSignaled = true
-        justHitCap = true
-      }
-    }
+    let decision = Self.batchAudioCapDecision(
+      bufferedBytes: batchAudioBuffer.count,
+      chunkBytes: audioData.count,
+      alreadySignaled: batchAudioOverflowSignaled
+    )
+    if decision.append { batchAudioBuffer.append(audioData) }
+    if decision.warn { batchAudioOverflowSignaled = true }
     batchAudioLock.unlock()
-    if justHitCap { showBatchAudioOverflowWarning(turn: turn) }
+    if decision.warn { showBatchAudioOverflowWarning(turn: turn) }
+  }
+
+  /// Pure cap decision behind `appendBatchAudioBounded` (MIC-04): should this mic
+  /// chunk be appended, and does it cross the cap (warn exactly once)?
+  ///
+  /// Extracted so the bounding guarantee — RSS stays bounded past ~4.5 min and the
+  /// user is warned once, not per chunk — is unit-testable without driving the audio
+  /// thread. The live-mic path can't reach this cap from the automation bridge (the
+  /// PTT actions drive the realtime hub, not the batch buffer), so this is the
+  /// criterion's real test seam. Keep in lockstep with `appendBatchAudioBounded`.
+  nonisolated static func batchAudioCapDecision(
+    bufferedBytes: Int,
+    chunkBytes: Int,
+    cap: Int = maxBatchAudioBytes,
+    alreadySignaled: Bool
+  ) -> (append: Bool, warn: Bool) {
+    // At or over the cap the buffer stops growing entirely — bounded RSS.
+    guard bufferedBytes < cap else { return (append: false, warn: false) }
+    // Under the cap: keep the chunk. If it crosses the cap, warn once.
+    let crosses = (bufferedBytes + chunkBytes) >= cap
+    return (append: true, warn: crosses && !alreadySignaled)
   }
 
   /// Surface the one-time "recording too long" warning when the turn buffer is

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/TasksPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/TasksPage.swift
@@ -2310,8 +2310,8 @@ class TasksViewModel: ObservableObject {
 
         registry.register(
             name: "reorder_task",
-            summary: "Move a task to a new index within a category (today|tomorrow|later|nodeadline) via the real drag path, flush the sortOrder sync to SQLite + backend, and return the resulting order",
-            params: ["id", "index", "category"]
+            summary: "Move a task to a new index within a category (today|tomorrow|later|nodeadline) via the real drag path and return the resulting order. Flushes the sortOrder sync to SQLite + backend by default; pass flush=false to leave the production 500ms debounce running so a harness can prove coalescing (TASK-05).",
+            params: ["id", "index", "category", "flush"]
         ) { [weak self] params in
             guard let self else { return ["error": "tasks view model deallocated"] }
             await self.ensureTasksLoadedForAutomation()
@@ -2322,9 +2322,16 @@ class TasksViewModel: ObservableObject {
             let index = max(0, Int(params["index"] ?? "") ?? 0)
             let category = Self.automationCategory(params["category"]) ?? .today
             self.moveTask(task, toIndex: index, inCategory: category)
-            await self.flushSortOrderSyncForAutomation()
+            // flush=false keeps the production 500ms debounce live: rapid calls then
+            // coalesce into ONE syncSortOrders (observable as a single "TasksVM: Synced"
+            // log line) — exactly the TASK-05 coalescing criterion. Default stays
+            // flush=true so existing recipes keep their deterministic SQLite reads.
+            let flush = (params["flush"] ?? "true").lowercased() != "false"
+            if flush {
+                await self.flushSortOrderSyncForAutomation()
+            }
             let order = self.getOrderedTasks(for: category).map(\.id).joined(separator: ",")
-            return ["id": id, "category": category.rawValue, "order": order]
+            return ["id": id, "category": category.rawValue, "order": order, "flushed": flush ? "true" : "false"]
         }
 
         registry.register(

--- a/desktop/macos/Desktop/Tests/AuthRefreshResilienceTests.swift
+++ b/desktop/macos/Desktop/Tests/AuthRefreshResilienceTests.swift
@@ -65,6 +65,54 @@ final class AuthRefreshResilienceTests: XCTestCase {
     XCTAssertEqual(UserDefaults.standard.string(forKey: .authRefreshToken), "refresh-token-stable")
   }
 
+  /// AUTH-04: a refresh that fails at the NETWORK layer (offline, dead port, DNS —
+  /// the "point securetoken at a dead proxy port" class) must never sign the user
+  /// out. The URLError is thrown by the transport before any HTTP status exists, so
+  /// it can never be classified as a definitive auth failure; the session must
+  /// survive for the 30s refresh timer to retry. Exercises the real
+  /// `refreshIdToken()` path via `tokenRefreshHooks` — the same seam a live
+  /// dead-port run would hit, without the local-profile storage-identity switch
+  /// that blocked the runtime rig (Wave 9).
+  func testRefreshNetworkErrorPreservesTokens() async {
+    let auth = makeAuthWithUserDefaultsStorage()
+    XCTAssertNoThrow(
+      try auth.saveTokens(
+        idToken: "id-token-net",
+        refreshToken: "refresh-token-net",
+        expiresIn: 3600,
+        userId: "user-net"
+      )
+    )
+    UserDefaults.standard.set("user-net", forKey: .authUserId)
+
+    auth.tokenRefreshHooks = AuthService.TokenRefreshHooks(
+      dataForRequest: { _ in
+        throw URLError(.cannotConnectToHost)
+      }
+    )
+
+    do {
+      _ = try await auth.getIdToken(forceRefresh: true)
+      XCTFail("expected the network error to propagate")
+    } catch let error as URLError {
+      XCTAssertEqual(error.code, .cannotConnectToHost)
+    } catch let error as AuthError {
+      // Whatever the wrapper, it must NOT be the signed-out terminal state.
+      if case .notSignedIn = error {
+        XCTFail("a transient network failure must not sign the user out")
+      }
+    } catch {
+      // Other wrappers are acceptable as long as the session survives (below).
+    }
+
+    XCTAssertEqual(
+      UserDefaults.standard.string(forKey: .authIdToken), "id-token-net",
+      "id token must survive a network-layer refresh failure")
+    XCTAssertEqual(
+      UserDefaults.standard.string(forKey: .authRefreshToken), "refresh-token-net",
+      "refresh token must survive a network-layer refresh failure")
+  }
+
   func testRefresh400WithInvalidRefreshTokenClearsSessionAndRecordsHealth() async throws {
     let auth = makeAuthWithUserDefaultsStorage()
     XCTAssertNoThrow(

--- a/desktop/macos/Desktop/Tests/HardeningSeamActionTests.swift
+++ b/desktop/macos/Desktop/Tests/HardeningSeamActionTests.swift
@@ -58,14 +58,64 @@ final class HardeningSeamActionTests: XCTestCase {
       "the notification must post on the main actor like the real observers expect")
   }
 
+  func testAuthTokenSeamsAreProdGatedAndLeakNoTokenMaterial() throws {
+    let bridge = try bridgeSource()
+    for action in ["expire_auth_token", "auth_token_status"] {
+      guard let start = bridge.range(of: "name: \"\(action)\"") else {
+        return XCTFail("\(action) registration not found")
+      }
+      let block = String(bridge[start.lowerBound...].prefix(900))
+      XCTAssertTrue(
+        block.contains("guard AppBuild.isNonProduction"),
+        "\(action) must refuse to run on production bundles")
+    }
+
+    let auth = try authServiceSource()
+    // Both seams are double-gated (bridge + AuthService) because they touch the session.
+    for fn in ["func expireStoredTokenForAutomation", "func tokenStatusForAutomation"] {
+      guard let start = auth.range(of: fn) else { return XCTFail("\(fn) not found") }
+      let body = String(auth[start.lowerBound...].prefix(1200))
+      XCTAssertTrue(
+        body.contains("guard AppBuild.isNonProduction"),
+        "\(fn) must be non-prod gated inside AuthService too, not only at the bridge")
+      // Status/booleans only — the stored token itself must never be returned.
+      XCTAssertFalse(
+        body.contains("\"id_token\"") || body.contains("\"refresh_token\""),
+        "\(fn) must never return token material — presence/expiry booleans only")
+    }
+
+    // The expiry seam must go through the real storage path (saveTokens), NOT a
+    // UserDefaults key: tokens are keychain-backed, and the old harness tampered a key
+    // the app no longer reads, silently measuring nothing.
+    guard let expireStart = auth.range(of: "func expireStoredTokenForAutomation") else {
+      return XCTFail("expireStoredTokenForAutomation not found")
+    }
+    let expireBody = String(auth[expireStart.lowerBound...].prefix(1200))
+    XCTAssertTrue(
+      expireBody.contains("try saveTokens("),
+      "expiry must be forced through saveTokens so it works for keychain AND UserDefaults")
+    XCTAssertFalse(
+      expireBody.contains("UserDefaults.standard.set"),
+      "expiry must not be forced by writing a UserDefaults key the app may not read")
+  }
+
   // MARK: - Helpers
+
+  private func authServiceSource() throws -> String {
+    let url = URL(fileURLWithPath: #filePath)
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+      .appendingPathComponent("Sources/AuthService.swift")
+    // omi-test-quality: source-inspection -- static contract: AUTH-03 token seams stay double-gated on AppBuild.isNonProduction, never return token material, and force expiry via saveTokens (real storage) not a UserDefaults key.
+    return try String(contentsOf: url, encoding: .utf8)
+  }
 
   private func tasksPageSource() throws -> String {
     let url = URL(fileURLWithPath: #filePath)
       .deletingLastPathComponent()
       .deletingLastPathComponent()
       .appendingPathComponent("Sources/MainWindow/Pages/TasksPage.swift")
-    // omi-test-quality: source-inspection -- static contract: the reorder_task flush seam must stay param-gated with a flush=true default; the action runs through the registry against the @MainActor store and cannot be behaviorally unit-run in the test host. Coalescing behavior is proven on the runtime lane (SKILL §2k).
+    // omi-test-quality: source-inspection -- static contract: the reorder_task flush seam must stay param-gated with a flush=true default; it runs through the registry against the @MainActor store and can't be unit-run.
     return try String(contentsOf: url, encoding: .utf8)
   }
 
@@ -74,7 +124,7 @@ final class HardeningSeamActionTests: XCTestCase {
       .deletingLastPathComponent()
       .deletingLastPathComponent()
       .appendingPathComponent("Sources/DesktopAutomationBridge.swift")
-    // omi-test-quality: source-inspection -- static contract: simulate_system_wake must stay registered, non-prod gated, and posting the real .systemDidWake signal; the action can't be behaviorally unit-run (registry + MainActor notification). Post-wake behavior is proven on the runtime lane (SKILL §2l).
+    // omi-test-quality: source-inspection -- static contract: simulate_system_wake must stay registered, non-prod gated, and post the real workspace-center wake signal; it can't be behaviorally unit-run.
     return try String(contentsOf: url, encoding: .utf8)
   }
 }

--- a/desktop/macos/Desktop/Tests/HardeningSeamActionTests.swift
+++ b/desktop/macos/Desktop/Tests/HardeningSeamActionTests.swift
@@ -1,0 +1,80 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// Harness seams for the last runtime-blocked hardening rows:
+///
+/// - TASK-05: `reorder_task flush=false` leaves the production 500ms sortOrder
+///   debounce running so rapid reorders provably coalesce into ONE sync (the
+///   bridge's unconditional flush was hiding exactly the behavior under test).
+/// - CHAT-07: `simulate_system_wake` posts the real `.systemDidWake` signal so the
+///   post-wake restart paths run without physically sleeping the machine.
+///
+/// Both are registry-bound `@MainActor` paths that can't be behaviorally unit-run
+/// in the test host, so these pin the wiring; the behavior is the runtime lane
+/// (SKILL §2k/§2l).
+final class HardeningSeamActionTests: XCTestCase {
+
+  func testReorderTaskExposesFlushParamAndGatesTheFlush() throws {
+    let source = try tasksPageSource()
+    guard let start = source.range(of: "name: \"reorder_task\"") else {
+      return XCTFail("reorder_task registration not found")
+    }
+    let block = String(source[start.lowerBound...].prefix(2200))
+    XCTAssertTrue(
+      block.contains("\"flush\""),
+      "reorder_task must expose the flush param (TASK-05 debounce-coalescing seam)")
+    XCTAssertTrue(
+      block.contains("if flush {"),
+      "the sortOrder flush must be conditional so flush=false leaves the 500ms debounce live")
+    XCTAssertTrue(
+      block.contains("flushSortOrderSyncForAutomation()"),
+      "the default path must still flush so existing recipes keep deterministic SQLite reads")
+    XCTAssertTrue(
+      block.contains("(params[\"flush\"] ?? \"true\")"),
+      "flush must default to true — only an explicit flush=false opts into the debounce path")
+  }
+
+  func testSimulateSystemWakeIsRegisteredNonProdGatedAndPostsTheRealSignal() throws {
+    let source = try bridgeSource()
+    guard let start = source.range(of: "name: \"simulate_system_wake\"") else {
+      return XCTFail("simulate_system_wake registration not found")
+    }
+    let block = String(source[start.lowerBound...].prefix(1400))
+    XCTAssertTrue(
+      block.contains("guard AppBuild.isNonProduction"),
+      "simulate_system_wake must refuse to run on production bundles")
+    // The wake chain's top is NSWorkspace.didWakeNotification on the WORKSPACE
+    // center. RealtimeHubController observes that center directly — a default-center
+    // .systemDidWake post would silently miss it (verifier finding, Wave 19).
+    XCTAssertTrue(
+      block.contains("NSWorkspace.shared.notificationCenter.post"),
+      "the action must post on the workspace notification center (RealtimeHub observes it directly)")
+    XCTAssertTrue(
+      block.contains("NSWorkspace.didWakeNotification"),
+      "the action must post the real top-of-chain wake signal, not the .systemDidWake re-broadcast")
+    XCTAssertTrue(
+      block.contains("MainActor.run"),
+      "the notification must post on the main actor like the real observers expect")
+  }
+
+  // MARK: - Helpers
+
+  private func tasksPageSource() throws -> String {
+    let url = URL(fileURLWithPath: #filePath)
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+      .appendingPathComponent("Sources/MainWindow/Pages/TasksPage.swift")
+    // omi-test-quality: source-inspection -- static contract: the reorder_task flush seam must stay param-gated with a flush=true default; the action runs through the registry against the @MainActor store and cannot be behaviorally unit-run in the test host. Coalescing behavior is proven on the runtime lane (SKILL §2k).
+    return try String(contentsOf: url, encoding: .utf8)
+  }
+
+  private func bridgeSource() throws -> String {
+    let url = URL(fileURLWithPath: #filePath)
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+      .appendingPathComponent("Sources/DesktopAutomationBridge.swift")
+    // omi-test-quality: source-inspection -- static contract: simulate_system_wake must stay registered, non-prod gated, and posting the real .systemDidWake signal; the action can't be behaviorally unit-run (registry + MainActor notification). Post-wake behavior is proven on the runtime lane (SKILL §2l).
+    return try String(contentsOf: url, encoding: .utf8)
+  }
+}

--- a/desktop/macos/Desktop/Tests/HardeningSeamActionTests.swift
+++ b/desktop/macos/Desktop/Tests/HardeningSeamActionTests.swift
@@ -7,8 +7,9 @@ import XCTest
 /// - TASK-05: `reorder_task flush=false` leaves the production 500ms sortOrder
 ///   debounce running so rapid reorders provably coalesce into ONE sync (the
 ///   bridge's unconditional flush was hiding exactly the behavior under test).
-/// - CHAT-07: `simulate_system_wake` posts the real `.systemDidWake` signal so the
-///   post-wake restart paths run without physically sleeping the machine.
+/// - CHAT-07: `simulate_system_wake` posts `NSWorkspace.didWakeNotification` on
+///   the workspace notification center, then AppState re-broadcasts `.systemDidWake`
+///   so post-wake restart paths run without physically sleeping the machine.
 ///
 /// Both are registry-bound `@MainActor` paths that can't be behaviorally unit-run
 /// in the test host, so these pin the wiring; the behavior is the runtime lane

--- a/desktop/macos/Desktop/Tests/Task03ReorderStressTests.swift
+++ b/desktop/macos/Desktop/Tests/Task03ReorderStressTests.swift
@@ -1,0 +1,92 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// TASK-03: 150 reorders in one category → stable ordering, no sortOrder collision.
+///
+/// Live-account runs of this criterion are structurally racy: the store's paginated
+/// bucket window (50/category on large accounts) evicts seeded tasks mid-run and the
+/// dump then compares against rows the reorder never renumbered — the BL-046
+/// "duplicate sortOrders" artifact. The product math itself is deterministic, so this
+/// pins the criterion as a property test over the EXACT algorithm chain `moveTask`
+/// uses per drag: the 3-line order-list mutation (removeAll → clamp → insert) followed
+/// by `TasksViewModel.applyReorder` (which bands via the shared `sortOrder` helper).
+/// 150 seeded-random reorders over 30 tasks; after EVERY step the invariants must
+/// hold — uniqueness, band membership, and displayed-order agreement.
+final class Task03ReorderStressTests: XCTestCase {
+
+  private func item(_ id: String) -> TaskActionItem {
+    TaskActionItem(
+      id: id, description: id, completed: false,
+      createdAt: Date(timeIntervalSince1970: 0), dueAt: nil, sortOrder: nil)
+  }
+
+  func test150RandomReordersKeepOrderingStableAndCollisionFree() {
+    var rng = SystemRandomNumberGenerator.seeded(19)
+    let categoryIndex = 3  // noDeadline band [300_000, 400_000)
+    let ids = (1...30).map { "t\($0)" }
+    var tasks = ids.map { item($0) }
+    var order = ids
+
+    for step in 1...150 {
+      // The exact mutation moveTask performs on the category order list.
+      let moved = ids[Int(rng.next() % 30)]
+      let target = Int(rng.next() % 31)
+      order.removeAll { $0 == moved }
+      order.insert(moved, at: min(target, order.count))
+
+      TasksViewModel.applyReorder(order, categoryIndex: categoryIndex, to: &tasks)
+
+      let sortOrders = order.compactMap { id in tasks.first { $0.id == id }?.sortOrder }
+      XCTAssertEqual(
+        sortOrders.count, order.count,
+        "step \(step): every task in the order list must carry a sortOrder")
+      XCTAssertEqual(
+        Set(sortOrders).count, sortOrders.count,
+        "step \(step): sortOrders must be collision-free")
+      XCTAssertEqual(
+        sortOrders, sortOrders.sorted(),
+        "step \(step): sortOrders must be monotonic with displayed position")
+      XCTAssertTrue(
+        sortOrders.allSatisfy { (300_000..<400_000).contains($0) },
+        "step \(step): every sortOrder must stay inside the category band")
+    }
+  }
+
+  func testReorderResultIsDeterministicForIdenticalMoveSequences() {
+    // Same seed → same final ordering; the criterion's "stable ordering" half.
+    func run() -> [Int?] {
+      var rng = SystemRandomNumberGenerator.seeded(7)
+      let ids = (1...30).map { "t\($0)" }
+      var tasks = ids.map { item($0) }
+      var order = ids
+      for _ in 1...150 {
+        let moved = ids[Int(rng.next() % 30)]
+        let target = Int(rng.next() % 31)
+        order.removeAll { $0 == moved }
+        order.insert(moved, at: min(target, order.count))
+        TasksViewModel.applyReorder(order, categoryIndex: 3, to: &tasks)
+      }
+      return order.map { id in tasks.first { $0.id == id }?.sortOrder }
+    }
+    XCTAssertEqual(run(), run(), "identical move sequences must produce identical orderings")
+  }
+}
+
+/// Deterministic RNG so the 150-step sequence is reproducible across runs/machines.
+/// (SystemRandomNumberGenerator itself is not seedable; this is a tiny SplitMix64.)
+extension SystemRandomNumberGenerator {
+  fileprivate static func seeded(_ seed: UInt64) -> SplitMix64 { SplitMix64(seed: seed) }
+}
+
+struct SplitMix64: RandomNumberGenerator {
+  private var state: UInt64
+  init(seed: UInt64) { state = seed }
+  mutating func next() -> UInt64 {
+    state &+= 0x9E37_79B9_7F4A_7C15
+    var z = state
+    z = (z ^ (z >> 30)) &* 0xBF58_476D_1CE4_E5B9
+    z = (z ^ (z >> 27)) &* 0x94D0_49BB_1331_11EB
+    return z ^ (z >> 31)
+  }
+}

--- a/desktop/macos/Desktop/Tests/Task03ReorderStressTests.swift
+++ b/desktop/macos/Desktop/Tests/Task03ReorderStressTests.swift
@@ -23,7 +23,9 @@ final class Task03ReorderStressTests: XCTestCase {
 
   func test150RandomReordersKeepOrderingStableAndCollisionFree() {
     var rng = SystemRandomNumberGenerator.seeded(19)
-    let categoryIndex = 3  // noDeadline band [300_000, 400_000)
+    let categoryIndex = 3  // noDeadline band
+    let band = TasksViewModel.sortOrderBandWidth
+    let categoryBand = (categoryIndex * band)..<((categoryIndex + 1) * band)
     let ids = (1...30).map { "t\($0)" }
     var tasks = ids.map { item($0) }
     var order = ids
@@ -48,7 +50,7 @@ final class Task03ReorderStressTests: XCTestCase {
         sortOrders, sortOrders.sorted(),
         "step \(step): sortOrders must be monotonic with displayed position")
       XCTAssertTrue(
-        sortOrders.allSatisfy { (300_000..<400_000).contains($0) },
+        sortOrders.allSatisfy { categoryBand.contains($0) },
         "step \(step): every sortOrder must stay inside the category band")
     }
   }
@@ -57,6 +59,7 @@ final class Task03ReorderStressTests: XCTestCase {
     // Same seed → same final ordering; the criterion's "stable ordering" half.
     func run() -> [Int?] {
       var rng = SystemRandomNumberGenerator.seeded(7)
+      let categoryIndex = 3
       let ids = (1...30).map { "t\($0)" }
       var tasks = ids.map { item($0) }
       var order = ids
@@ -65,7 +68,7 @@ final class Task03ReorderStressTests: XCTestCase {
         let target = Int(rng.next() % 31)
         order.removeAll { $0 == moved }
         order.insert(moved, at: min(target, order.count))
-        TasksViewModel.applyReorder(order, categoryIndex: 3, to: &tasks)
+        TasksViewModel.applyReorder(order, categoryIndex: categoryIndex, to: &tasks)
       }
       return order.map { id in tasks.first { $0.id == id }?.sortOrder }
     }

--- a/desktop/macos/Desktop/Tests/TranscriptionTransportTests.swift
+++ b/desktop/macos/Desktop/Tests/TranscriptionTransportTests.swift
@@ -112,6 +112,71 @@ final class TranscriptionTransportTests: XCTestCase {
     XCTAssertEqual(model.turn?.projection.hint, "")
   }
 
+  /// MIC-04 (behavioral): the per-turn buffer must stop growing at the ~4.5-min cap
+  /// (bounded RSS on a >5-min dictation) and warn the user exactly once, at the
+  /// crossing. The live-mic path can't reach this cap from the automation bridge —
+  /// the PTT actions drive the realtime hub, not the batch buffer (proven in the
+  /// Wave-19 runtime attempts) — so the pure cap decision is the criterion's real
+  /// test seam.
+  func testBatchAudioCapBoundsBufferAndWarnsExactlyOnce() {
+    let cap = PushToTalkManager.maxBatchAudioBytes
+    XCTAssertEqual(cap, Int(4.5 * 60) * 16_000 * 2, "cap is 4.5 min of 16kHz s16 mono")
+
+    // Well under the cap: keep appending, no warning.
+    let low = PushToTalkManager.batchAudioCapDecision(
+      bufferedBytes: 0, chunkBytes: 3_200, alreadySignaled: false)
+    XCTAssertTrue(low.append)
+    XCTAssertFalse(low.warn)
+
+    // The chunk that crosses the cap is kept, and it is the one that warns.
+    let crossing = PushToTalkManager.batchAudioCapDecision(
+      bufferedBytes: cap - 100, chunkBytes: 3_200, alreadySignaled: false)
+    XCTAssertTrue(crossing.append, "the crossing chunk is kept so the buffered audio still transcribes")
+    XCTAssertTrue(crossing.warn, "the crossing chunk warns the user")
+
+    // Same crossing, already warned: still no second warning (once per turn).
+    let crossingAgain = PushToTalkManager.batchAudioCapDecision(
+      bufferedBytes: cap - 100, chunkBytes: 3_200, alreadySignaled: true)
+    XCTAssertTrue(crossingAgain.append)
+    XCTAssertFalse(crossingAgain.warn, "the overflow warning must fire exactly once per turn")
+
+    // At/over the cap the buffer stops growing entirely — this is the bounded-RSS guarantee.
+    for buffered in [cap, cap + 1, cap * 2] {
+      let over = PushToTalkManager.batchAudioCapDecision(
+        bufferedBytes: buffered, chunkBytes: 3_200, alreadySignaled: true)
+      XCTAssertFalse(over.append, "buffer must not grow past the cap (bounded memory)")
+      XCTAssertFalse(over.warn)
+    }
+  }
+
+  /// Simulating a >5-min dictation chunk-by-chunk: RSS is bounded at the cap and the
+  /// user is warned exactly once across the whole turn.
+  func testSimulatedLongDictationStaysBoundedWithSingleWarning() {
+    let cap = PushToTalkManager.maxBatchAudioBytes
+    let chunk = 3_200  // 100ms of 16kHz s16 mono
+    var buffered = 0
+    var signaled = false
+    var warnings = 0
+
+    // 6 minutes of continuous speech — well past the 4.5-min cap.
+    let chunksIn6Min = (6 * 60 * 16_000 * 2) / chunk
+    for _ in 0..<chunksIn6Min {
+      let d = PushToTalkManager.batchAudioCapDecision(
+        bufferedBytes: buffered, chunkBytes: chunk, alreadySignaled: signaled)
+      if d.append { buffered += chunk }
+      if d.warn {
+        warnings += 1
+        signaled = true
+      }
+    }
+
+    XCTAssertEqual(warnings, 1, "exactly one 'Recording too long' warning across a 6-min turn")
+    XCTAssertLessThanOrEqual(
+      buffered, cap + chunk,
+      "buffer must not exceed the cap by more than the single crossing chunk (bounded RSS)")
+    XCTAssertGreaterThanOrEqual(buffered, cap, "the full ~4.5 min is retained for transcription")
+  }
+
   // MARK: BL-014 — deinit must not deadlock
 
   func testAudioCaptureDeinitDoesNotSyncOnAudioQueue() throws {

--- a/desktop/macos/e2e/SKILL.md
+++ b/desktop/macos/e2e/SKILL.md
@@ -291,6 +291,49 @@ Hermetic ratchets: `xcrun swift test --package-path Desktop --filter FloatingBar
 (deterministic counter + `testResetClearsLimitReachedState`) and `--filter UsageLimiterActionTests`
 (the non-prod actions wire to the limiter and the reset is prod-gated).
 
+### 2k. Prove rapid reorders coalesce through the 500ms debounce (TASK-05)
+`reorder_task` flushes the sortOrder sync by default (deterministic SQLite reads for
+CRUD recipes) — which *hides* the debounce under test. Pass `flush=false` to leave the
+production 500ms debounce running: rapid calls must coalesce into exactly ONE
+`TasksVM: Synced N sort orders` log line, with no lost update.
+```bash
+cd desktop/macos
+./scripts/omi-ctl action seed_tasks count=5 prefix=T05x      # note the returned ids
+MARK="T05-$(date +%s)"; echo "$MARK" >> /private/tmp/omi-dev.log
+# three reorders inside one debounce window (each returns immediately, flushed=false)
+./scripts/omi-ctl action reorder_task id=<id1> index=0 category=nodeadline flush=false
+./scripts/omi-ctl action reorder_task id=<id2> index=1 category=nodeadline flush=false
+./scripts/omi-ctl action reorder_task id=<id3> index=2 category=nodeadline flush=false
+sleep 2   # > 500ms debounce + sync
+awk "/$MARK/{f=1} f" /private/tmp/omi-dev.log | grep -c 'TasksVM: Synced'   # assert exactly 1
+./scripts/omi-ctl action dump_tasks limit=5000                 # assert final order persisted (no lost update)
+```
+Hermetic ratchets: `--filter HardeningSeamActionTests` (flush param wiring) and
+`--filter Task03ReorderStressTests` (150-reorder collision-free/deterministic property).
+
+### 2l. Prove post-wake restart paths without sleeping the machine (CHAT-07)
+`simulate_system_wake` (non-prod) posts `NSWorkspace.didWakeNotification` on the
+**workspace** notification center — the top of the real wake chain. Every production
+consumer then fires exactly as on a physical wake: `RealtimeHubController` re-warms
+(or defers) its session, and AppState re-broadcasts the default-center
+`.systemDidWake` downstream. (Posting only `.systemDidWake` would silently miss
+RealtimeHub, which observes the workspace center directly.) The stray-turn_end half
+of CHAT-07 is the CHAT-02 suspend/resume path (a SIGSTOP'd agent across a "sleep" is
+the same stale-subprocess class) — already runtime-proven; see §2e.
+```bash
+cd desktop/macos
+MARK="C07-$(date +%s)"; echo "$MARK" >> /private/tmp/omi-dev.log
+./scripts/omi-ctl action simulate_system_wake     # {"posted":"NSWorkspace.didWakeNotification"}
+sleep 2
+awk "/$MARK/{f=1} f" /private/tmp/omi-dev.log | grep -E 'System woke from sleep|system_wake'
+#   assert: "System woke from sleep" (AppState observer ran) AND a RealtimeHub system_wake line —
+#   either "re-warming idle session" or "deferring system_wake ..." (defer while mid-turn). With no
+#   warm session yet, requestSessionRefresh no-ops by design (guard session != nil); warm one first
+#   with a ptt_test_burst if you need the re-warm line specifically.
+```
+Hermetic ratchet: `--filter HardeningSeamActionTests` (action posts the real top-of-chain
+signal on the workspace center, non-prod gated).
+
 ### The full loop
 ```bash
 cd desktop/macos

--- a/desktop/macos/scripts/omi-hardening-smoke.sh
+++ b/desktop/macos/scripts/omi-hardening-smoke.sh
@@ -174,11 +174,20 @@ token_file() { printf '%s/omi-automation-%s.token' "${TMPDIR:-/tmp}" "$PORT"; }
 bridge() { OMI_AUTOMATION_PORT="$PORT" "$OMI_CTL" "$@"; }
 
 action_json() {
-  # action_json <action-name> — raw JSON of the action's `detail` object ({} on failure)
+  # action_json <action-name> — raw JSON of the action's `detail` object.
+  # If the bridge/action returns an error outside detail, preserve it as
+  # {"error": "..."} so probes report the real blocked cause.
   bridge action "$1" 2>/dev/null | python3 -c '
 import json, sys
 try:
-    print(json.dumps(json.load(sys.stdin)["result"].get("detail", {})))
+    payload = json.load(sys.stdin)
+    result = payload.get("result", {})
+    detail = result.get("detail")
+    if isinstance(detail, dict):
+        print(json.dumps(detail))
+    else:
+        error = payload.get("error") or result.get("error")
+        print(json.dumps({"error": str(error)} if error else {}))
 except Exception:
     print("{}")
 ' 2>/dev/null || printf '{}'
@@ -428,10 +437,15 @@ probe_auth_03() {
   # the expiry through the app's OWN storage path instead (`expire_auth_token`), and
   # read the result back the same way (`auth_token_status`) — correct for both the
   # keychain and the UserDefaults fallback, and inert if storage changes again.
-  local t0 pre_status expired post_status signed_before signed_after expired_after storage
+  local t0 pre_status expired post_status signed_before signed_after expired_after storage error
   t0=$(now_s)
 
   pre_status="$(action_json auth_token_status)"
+  error="$(json_field "$pre_status" error)"
+  if [ -n "$error" ]; then
+    record auth-03 BLOCKED $(( $(now_s) - t0 )) "auth_token_status error before expiry: $error"
+    return
+  fi
   signed_before="$(json_field "$pre_status" signed_in)"
   storage="$(json_field "$pre_status" storage)"
   if [ "$signed_before" != "true" ]; then
@@ -440,6 +454,11 @@ probe_auth_03() {
   fi
 
   expired="$(action_json expire_auth_token)"
+  error="$(json_field "$expired" error)"
+  if [ -n "$error" ]; then
+    record auth-03 BLOCKED $(( $(now_s) - t0 )) "expire_auth_token error: $error (storage=$storage)"
+    return
+  fi
   if [ "$(json_field "$expired" is_token_expired)" != "true" ]; then
     record auth-03 BLOCKED $(( $(now_s) - t0 )) "could not force token expiry via expire_auth_token (storage=$storage)"
     return
@@ -453,6 +472,11 @@ probe_auth_03() {
   sleep 5
 
   post_status="$(action_json auth_token_status)"
+  error="$(json_field "$post_status" error)"
+  if [ -n "$error" ]; then
+    record auth-03 BLOCKED $(( $(now_s) - t0 )) "auth_token_status error after relaunch: $error (storage=$storage)"
+    return
+  fi
   signed_after="$(json_field "$post_status" signed_in)"
   expired_after="$(json_field "$post_status" is_token_expired)"
   {

--- a/desktop/macos/scripts/omi-hardening-smoke.sh
+++ b/desktop/macos/scripts/omi-hardening-smoke.sh
@@ -173,6 +173,28 @@ token_file() { printf '%s/omi-automation-%s.token' "${TMPDIR:-/tmp}" "$PORT"; }
 
 bridge() { OMI_AUTOMATION_PORT="$PORT" "$OMI_CTL" "$@"; }
 
+action_json() {
+  # action_json <action-name> — raw JSON of the action's `detail` object ({} on failure)
+  bridge action "$1" 2>/dev/null | python3 -c '
+import json, sys
+try:
+    print(json.dumps(json.load(sys.stdin)["result"].get("detail", {})))
+except Exception:
+    print("{}")
+' 2>/dev/null || printf '{}'
+}
+
+json_field() {
+  # json_field <json> <key> — empty string if absent
+  printf '%s' "$1" | python3 -c '
+import json, sys
+try:
+    print(json.load(sys.stdin).get(sys.argv[1], ""))
+except Exception:
+    print("")
+' "$2" 2>/dev/null || printf ''
+}
+
 bridge_state_field() {
   # bridge_state_field <jsonKey> — empty string if unavailable
   bridge state 2>/dev/null | python3 -c '
@@ -399,36 +421,55 @@ probe_chat_03() {
 
 probe_auth_03() {
   # Destructive: relaunches the app. Requires launch mode.
-  local t0 signed pre_expiry post_expiry latency
+  #
+  # Tokens are keychain-backed, so the old trick of `defaults write <bundle>
+  # auth_tokenExpiry -float 1000` tampered a key the app no longer reads: the probe
+  # measured nothing and reported a false regression while the app was healthy. Drive
+  # the expiry through the app's OWN storage path instead (`expire_auth_token`), and
+  # read the result back the same way (`auth_token_status`) — correct for both the
+  # keychain and the UserDefaults fallback, and inert if storage changes again.
+  local t0 pre_status expired post_status signed_before signed_after expired_after storage
   t0=$(now_s)
-  signed="$(defaults_read_raw "$BUNDLE_ID" auth_isSignedIn)"
-  if [ "$signed" != "1" ]; then
-    record auth-03 BLOCKED $(( $(now_s) - t0 )) "auth-stale: bundle not signed in — reseed via omi-auth-dump.sh + omi-auth-seed.sh $BUNDLE_ID "/Applications/${BUNDLE_ID#com.omi.}.app""
+
+  pre_status="$(action_json auth_token_status)"
+  signed_before="$(json_field "$pre_status" signed_in)"
+  storage="$(json_field "$pre_status" storage)"
+  if [ "$signed_before" != "true" ]; then
+    record auth-03 BLOCKED $(( $(now_s) - t0 )) "auth-stale: bundle not signed in — reseed via omi-auth-dump.sh + omi-auth-seed.sh $BUNDLE_ID \"/Applications/${BUNDLE_ID#com.omi.}.app\""
     return
   fi
-  latency="$(stop_app)" || true
-  pre_expiry="$(defaults_read_raw "$BUNDLE_ID" auth_tokenExpiry)"
-  if ! defaults write "$BUNDLE_ID" auth_tokenExpiry -float 1000; then
-    record auth-03 BLOCKED $(( $(now_s) - t0 )) "defaults write failed (could not tamper expiry)"
+
+  expired="$(action_json expire_auth_token)"
+  if [ "$(json_field "$expired" is_token_expired)" != "true" ]; then
+    record auth-03 BLOCKED $(( $(now_s) - t0 )) "could not force token expiry via expire_auth_token (storage=$storage)"
     return
   fi
+
+  stop_app >/dev/null 2>&1 || true
   if ! launch_app; then
     record auth-03 BLOCKED $(( $(now_s) - t0 )) "relaunch failed (bridge never came up)"
     return
   fi
-  sleep 3
-  post_expiry="$(defaults_read_raw "$BUNDLE_ID" auth_tokenExpiry)"
-  signed="$(defaults_read_raw "$BUNDLE_ID" auth_isSignedIn)"
+  sleep 5
+
+  post_status="$(action_json auth_token_status)"
+  signed_after="$(json_field "$post_status" signed_in)"
+  expired_after="$(json_field "$post_status" is_token_expired)"
   {
-    echo "pre-tamper expiry present: $(printf '%s' "$pre_expiry" | wc -c | tr -d ' ') chars (value redacted)"
-    echo "tampered expiry to epoch 1000; relaunched"
-    echo "post-launch signed_in=$signed"
-    python3 -c "import time; e=float('${post_expiry:-0}'); print('post-launch expiry is', 'FUTURE (refreshed)' if e > time.time() else 'still past (no refresh)')"
+    echo "storage backend in use: $storage"
+    echo "pre:  signed_in=$signed_before"
+    echo "forced expiry via expire_auth_token -> is_token_expired=true"
+    echo "relaunched app"
+    echo "post: signed_in=$signed_after is_token_expired=$expired_after"
+    echo "(expected: signed_in=true AND is_token_expired=false — refreshed, no sign-out)"
   } >"$REPORT_DIR/auth-03.log"
-  if [ "$signed" = "1" ] && python3 -c "import time,sys; sys.exit(0 if float('${post_expiry:-0}') > time.time() else 1)"; then
-    record auth-03 PASS $(( $(now_s) - t0 )) "expired token refreshed on relaunch; session preserved"
+
+  if [ "$signed_after" = "true" ] && [ "$expired_after" = "false" ]; then
+    record auth-03 PASS $(( $(now_s) - t0 )) "expired token refreshed on relaunch; session preserved (storage=$storage)"
+  elif [ "$signed_after" != "true" ]; then
+    record auth-03 FAIL $(( $(now_s) - t0 )) "expired token SIGNED THE USER OUT (storage=$storage, see auth-03.log)"
   else
-    record auth-03 FAIL $(( $(now_s) - t0 )) "signed_in=$signed, expiry not refreshed (see auth-03.log)"
+    record auth-03 FAIL $(( $(now_s) - t0 )) "session preserved but token still expired after relaunch (storage=$storage, see auth-03.log)"
   fi
 }
 


### PR DESCRIPTION
## What

Closes the last **buildable** gaps in the macOS hardening matrix — three harness seams
and the tests that pin them, one commit per concern.

### TASK-05 — `reorder_task flush=false` (debounce-coalescing seam)

The bridge's `reorder_task` unconditionally flushed the sortOrder sync, which *hides*
the very behavior TASK-05 verifies (rapid reorders coalescing through the production
500ms debounce). New optional `flush` param, default `"true"` (existing recipes
unchanged; response gains a `flushed` field). With `flush=false` the real debounce
stays live: rapid calls must coalesce into exactly ONE `TasksVM: Synced` log line.
`suppressDatabaseRequery` self-heals in `syncSortOrders`' defer when the debounce
fires. Recipe: SKILL §2k.

### CHAT-07 — `simulate_system_wake` (post-wake restart seam)

Real sleep/wake validation is disruptive and flaky. The new non-prod action posts
`NSWorkspace.didWakeNotification` on the **workspace** notification center — the top
of the real wake chain — so every production consumer fires exactly as on a physical
wake: `RealtimeHubController` re-warms (or defers) its session, and `AppState`
re-broadcasts the default-center `.systemDidWake` downstream. (Posting only
`.systemDidWake` would silently miss RealtimeHub, which observes the workspace center
directly — caught by the independent verifier and fixed before commit.) The
stray-`turn_end` half of CHAT-07 is the already-proven CHAT-02 suspend/resume class.
Recipe: SKILL §2l.

### AUTH-04 — refresh network failure preserves the session (test)

`testRefreshNetworkErrorPreservesTokens`: the refresh transport throws
`URLError(.cannotConnectToHost)` (the "dead proxy port" class) through the existing
`tokenRefreshHooks` seam — the same `refreshIdToken()` path a live dead-port run would
hit, without the local-profile storage-identity switch that blocked the runtime rig.
A transport error precedes any HTTP status, so it can never classify as a definitive
auth failure; asserts both tokens survive and the error is never turned into a sign-out.

### TASK-03 — 150-reorder stability as a property test

Live-account runs of "150 reorders → no collision" are structurally racy: the store's
50/bucket pagination evicts seeded tasks mid-run and the SQLite dump then compares rows
the reorder never renumbered — the BL-046 measurement artifact, reproduced again this
wave. The product math is deterministic, so pin the criterion on the exact per-drag
algorithm chain (order-list `removeAll` → clamp → `insert`, then `applyReorder`
banding): 150 seeded-random reorders over 30 tasks, asserting collision-free /
monotonic / in-band after **every** step, plus a same-seed determinism check. Seeded
SplitMix64 RNG — no `Date`/`random` in the test.

### MIC-04 — bounded per-turn audio buffer (behavioral test)

MIC-04's only coverage was a source-scrape. Two live runtime attempts (silent room,
then ~5 min of continuous speech via a `say` loop) both ended `terminal_too_short` with
0.00s of batch audio: the bridge's PTT actions drive the **realtime hub**, while the
4.5-min cap lives on the **batch** path (`appendBatchAudioBounded`) — no action feeds
it, so the cap is unreachable from the harness (rig gap, not a product defect).

So the cap decision is the criterion's real seam: extract the pure
`batchAudioCapDecision(bufferedBytes:chunkBytes:cap:alreadySignaled:)`
(behavior-preserving — same append-while-under-cap, same warn-once-at-crossing, same
lock scope) and test it behaviorally, including a simulated 6-minute dictation
asserting bounded RSS (≤ cap + one crossing chunk) with exactly one warning.


### AUTH-03 — the tripwire had gone blind (repair)

The nightly `omi-hardening-smoke.sh` probe forced token expiry with
`defaults write <bundle> auth_tokenExpiry -float 1000`. **Tokens are keychain-backed**, so
that tampers a key the app no longer reads. Its own log gives it away —
`pre-tamper expiry present: 0 chars`. It reported a **false regression on a healthy app**
and, far worse, had **zero power to catch a real AUTH-03 regression**. Same class as the
BL-046 artifact: the harness was wrong, not the product.

Repair — two **non-prod, double-gated** seams (bridge *and* AuthService) that work against
whichever backend is live and never let token material leave the process:
- `expire_auth_token` — re-saves the current tokens via `saveTokens(expiresIn: 0)`, so the
  expiry lands in the past through the app's **real** storage path.
- `auth_token_status` — read-only `{signed_in, storage, has_id_token, has_refresh_token,
  is_token_expired}`; booleans only.

`probe_auth_03` now asserts the true criterion and distinguishes the two real failure
modes (signed the user out vs. session kept but never refreshed). Runtime on a real Google
session: `storage=keychain`, forced expiry → relaunch → `signed_in=true,
is_token_expired=false`. **AUTH-03 is genuinely verified for the first time since tokens
moved to the keychain.** Full smoke: 6 PASS.

## Tests / verification

- New: `HardeningSeamActionTests` (2 source-invariants, sanctioned `omi-test-quality`
  annotations), `Task03ReorderStressTests` (2); `AuthRefreshResilienceTests` +1;
  `TranscriptionTransportTests` +2 (MIC-04 behavioral, existing source-scrape retained).
- Full Desktop suite: **2114 tests, 0 failures**. Ratchets green (test-quality 62/171;
  UserDefaults 178 baseline).
- Independent code review run before push; its one material finding (the CHAT-07 wake
  seam posting on the wrong notification center) is fixed in this branch.
- Runtime proof of §2k/§2l follows on a named bundle post-merge; the seams are
  non-prod-only surface.

## Product invariants affected

Changed source files fall under invariant globs; all are **unaffected** — these
are non-prod harness seams and behavior-preserving extractions:

- **INV-UI-1** (no purple; `Sources/**` — `TasksPage.swift`,
  `DesktopAutomationBridge.swift`, `PushToTalkManager.swift`): zero purple literals
  added; brand ratchet unaffected.
- **INV-AUTH-1** (auth session; matches `AuthService.swift`): **no auth/session behavior change.** The two additions are non-prod, double-gated test seams; the refresh, invalidation, and storage paths are untouched, and neither seam can return token material (pinned by `HardeningSeamActionTests`).
- **INV-CHAT-1** (chat continuity; `FloatingControlBar/**` matches
  `PushToTalkManager.swift`): no chat/turn-lifecycle behavior changes. The MIC-04 edit
  only extracts the existing buffer-cap decision into a pure helper called from the same
  place under the same lock — the append/warn semantics, turn guard, and
  `hintChanged` reducer path are byte-for-byte unchanged.
- **INV-VOICE-1** (desktop voice turns; `FloatingControlBar/PushToTalkManager.swift`): no voice-turn lifecycle or routing behavior change. The MIC-04 edit preserves the same append/warn path under the same lock and only extracts the cap decision for deterministic test coverage.

## Scope

Non-prod automation-bridge / test-only changes; no user-facing behavior →
`no-changelog-needed`.

