### PR TITLE
fix(windows): skip generated file index directories

### DIFF
--- a/desktop/windows/src/main/fileIndex/scanRules.test.ts
+++ b/desktop/windows/src/main/fileIndex/scanRules.test.ts
@@ -1,23 +1,54 @@
 import { describe, it, expect } from 'vitest'
 import { shouldVisitDir, shouldIndexFile, SKIP_DIRS, MAX_DEPTH, MAX_FILE_SIZE } from './scanRules'
 
+const GENERATED_AND_DEPENDENCY_DIRS = [
+  '.Trash',
+  'node_modules',
+  '.git',
+  '__pycache__',
+  '.venv',
+  'venv',
+  '.cache',
+  '.npm',
+  '.yarn',
+  'Pods',
+  'DerivedData',
+  '.build',
+  'build',
+  'dist',
+  '.next',
+  '.nuxt',
+  'target',
+  'vendor',
+  'Library',
+  '.local',
+  '.cargo',
+  '.rustup'
+] as const
+
 describe('shouldVisitDir', () => {
-  it('skips noise directories', () => {
-    expect(shouldVisitDir('node_modules', 1)).toBe(false)
-    expect(shouldVisitDir('.git', 1)).toBe(false)
-    expect(shouldVisitDir('__pycache__', 1)).toBe(false)
-    expect(shouldVisitDir('.Trash', 1)).toBe(false)
-    expect(SKIP_DIRS.has('.Trash')).toBe(true)
+  it.each(GENERATED_AND_DEPENDENCY_DIRS)('skips ignored directory %s', (name) => {
+    expect(SKIP_DIRS.has(name)).toBe(true)
+    expect(shouldVisitDir(name, 1)).toBe(false)
   })
-  it('skips noise directories case-insensitively on Windows paths', () => {
-    expect(shouldVisitDir('Node_Modules', 1)).toBe(false)
-    expect(shouldVisitDir('.GIT', 1)).toBe(false)
-    expect(shouldVisitDir('__PYCACHE__', 1)).toBe(false)
+
+  it.each(['Node_Modules', '.GIT', '__PYCACHE__', 'DERIVEDDATA', '.NEXT', 'LIBRARY'])(
+    'skips %s case-insensitively on Windows paths',
+    (name) => {
+      expect(shouldVisitDir(name, 1)).toBe(false)
+    }
+  )
+
+  it('does not skip similarly named project directories', () => {
+    expect(shouldVisitDir('build-tools', 1)).toBe(true)
+    expect(shouldVisitDir('vendor-notes', 1)).toBe(true)
   })
+
   it('visits normal dirs within depth', () => {
     expect(shouldVisitDir('src', 1)).toBe(true)
     expect(shouldVisitDir('src', MAX_DEPTH)).toBe(true)
   })
+
   it('stops past max depth', () => {
     expect(shouldVisitDir('src', MAX_DEPTH + 1)).toBe(false)
   })

--- a/desktop/windows/src/main/fileIndex/scanRules.ts
+++ b/desktop/windows/src/main/fileIndex/scanRules.ts
@@ -1,6 +1,30 @@
 export const MAX_DEPTH = 3
 export const MAX_FILE_SIZE = 500 * 1024 * 1024 // 500 MB, matching macOS
-export const SKIP_DIRS = new Set(['.Trash', 'node_modules', '.git', '__pycache__'])
+// Keep this aligned with FileIndexScanPolicy.standard on macOS.
+export const SKIP_DIRS = new Set([
+  '.Trash',
+  'node_modules',
+  '.git',
+  '__pycache__',
+  '.venv',
+  'venv',
+  '.cache',
+  '.npm',
+  '.yarn',
+  'Pods',
+  'DerivedData',
+  '.build',
+  'build',
+  'dist',
+  '.next',
+  '.nuxt',
+  'target',
+  'vendor',
+  'Library',
+  '.local',
+  '.cargo',
+  '.rustup'
+])
 const NORMALIZED_SKIP_DIRS = new Set([...SKIP_DIRS].map((name) => name.toLowerCase()))
 
 // True when a subdirectory at `depth` should be descended into.


### PR DESCRIPTION
## Summary
- aligns the Windows local file index skip list with macOS `FileIndexScanPolicy.standard`
- skips generated, dependency, build, and cache directories such as `.venv`, `.cache`, `build`, `dist`, `.next`, `target`, `vendor`, and `Library`
- preserves case-insensitive Windows matching and adds regression coverage for exact ignored names and similarly named allowed folders

## Why
Part of #8991. Windows already has the local file indexing pipeline, but its scan policy only skipped four directories. Developer roots can contain large generated folders, so the first onboarding/indexing scan could waste time and fill `indexed_files` with dependency and build metadata that macOS intentionally ignores.

## Product invariants affected
None. This only narrows local Windows metadata indexing exclusions; it does not change memory tiers, auth/session behavior, chat continuity, agent control, integrations, or UI styling.

## Validation
- `pnpm exec vitest run src/main/fileIndex/fileTypes.test.ts src/main/fileIndex/scanRoots.test.ts src/main/fileIndex/scanRules.test.ts` -> 37 passed
- `pnpm exec prettier --check src/main/fileIndex/scanRules.ts src/main/fileIndex/scanRules.test.ts`
- `pnpm run typecheck:node`
- `pnpm run typecheck:web`
- `pnpm test` -> 82 files passed, 1 skipped; 577 tests passed, 3 skipped
- `pnpm run build`
- `git diff --check`

I did not run a default live file-index scan against the real Windows profile because that would enumerate personal Documents/Desktop metadata. The covered path is the same scan policy used by the real indexer.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9595?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

