### PR TITLE
fix(llm-gateway): surface terminal failure classes

### DIFF
--- a/backend/llm_gateway/gateway/metrics.py
+++ b/backend/llm_gateway/gateway/metrics.py
@@ -187,9 +187,10 @@ def observe_route_result(
             provider=labels['provider'],
             credential_source=labels['credential_source'],
         ).observe(ttfb_seconds)
-    logger.info(
+    terminal_log = logger.warning if outcome == 'error' else logger.info
+    terminal_log(
         'llm_gateway_terminal request_id=%s surface=%s streaming=%s phase=%s lane=%s route=%s provider=%s '
-        'model=%s credential_source=%s outcome=%s error_class=%s fallback_used=%s ttfb_seconds=%s',
+        'model=%s credential_source=%s outcome=%s error_class=%s failure_class=%s fallback_used=%s ttfb_seconds=%s',
         request_id,
         _bounded(api_surface),
         _bool_label(streaming),
@@ -201,6 +202,7 @@ def observe_route_result(
         labels['credential_source'],
         labels['outcome'],
         labels['error_class'],
+        labels['fallback_reason'],
         labels['fallback_used'],
         f'{ttfb_seconds:.6f}' if ttfb_seconds is not None else 'none',
     )
@@ -214,7 +216,7 @@ def observe_request_rejection(*, api_surface: str, error_class: str, request_id:
     surface_label = _bounded(api_surface)
     error_label = _bounded(error_class)
     REQUEST_REJECTIONS_TOTAL.labels(api_surface=surface_label, error_class=error_label).inc()
-    logger.info(
+    logger.warning(
         'llm_gateway_request_rejected request_id=%s surface=%s error_class=%s',
         request_id,
         surface_label,

--- a/backend/tests/unit/test_llm_gateway_metrics.py
+++ b/backend/tests/unit/test_llm_gateway_metrics.py
@@ -83,19 +83,59 @@ def test_observation_failure_warning_is_rate_limited_and_payload_free(monkeypatc
     assert matching == ['llm_gateway_observation_failed request_id=request-1 surface=anthropic_messages']
 
 
-def test_pre_route_rejection_metric_has_only_bounded_contract_labels(monkeypatch):
+def test_terminal_errors_are_warning_logs_with_only_bounded_failure_fields(monkeypatch, caplog):
+    requests = _Metric()
+    latency = _Metric()
+    monkeypatch.setattr(metrics, 'REQUESTS_TOTAL', requests)
+    monkeypatch.setattr(metrics, 'REQUEST_LATENCY_SECONDS', latency)
+
+    with caplog.at_level(logging.WARNING, logger=metrics.logger.name):
+        metrics.observe_route_result(
+            metrics.time_request(),
+            lane_id='omi:auto:conv-structure',
+            route_artifact_id='route.conv_structure.model_config.001',
+            provider='none',
+            model='none',
+            credential_source='service_forwarded_byok',
+            used_lkg=False,
+            fallback_used=False,
+            fallback_reason='byok_auth',
+            outcome='error',
+            error_class='credential_failure',
+            request_id='936c2c10-c509-41f1-95cf-2162710d5ac8',
+            api_surface='openai_chat_completions',
+            streaming=False,
+            phase='before_output',
+        )
+
+    matching = [record.message for record in caplog.records if 'llm_gateway_terminal' in record.message]
+    assert matching == [
+        'llm_gateway_terminal request_id=936c2c10-c509-41f1-95cf-2162710d5ac8 '
+        'surface=openai_chat_completions streaming=false phase=before_output '
+        'lane=omi:auto:conv-structure route=route.conv_structure.model_config.001 '
+        'provider=none model=none credential_source=service_forwarded_byok outcome=error '
+        'error_class=credential_failure failure_class=byok_auth fallback_used=false ttfb_seconds=none'
+    ]
+
+
+def test_pre_route_rejection_metric_has_only_bounded_contract_labels(monkeypatch, caplog):
     rejections = _Metric()
     monkeypatch.setattr(metrics, 'REQUEST_REJECTIONS_TOTAL', rejections)
 
-    metrics.observe_request_rejection(
-        api_surface='openai_chat_completions',
-        error_class='invalid_request',
-        request_id='5d1baae6-c824-4988-adc3-ae82df35cfa5',
-    )
+    with caplog.at_level(logging.WARNING, logger=metrics.logger.name):
+        metrics.observe_request_rejection(
+            api_surface='openai_chat_completions',
+            error_class='invalid_request',
+            request_id='5d1baae6-c824-4988-adc3-ae82df35cfa5',
+        )
 
     assert rejections.increments == [
         {
             'api_surface': 'openai_chat_completions',
             'error_class': 'invalid_request',
         }
+    ]
+    assert [record.message for record in caplog.records if 'llm_gateway_request_rejected' in record.message] == [
+        'llm_gateway_request_rejected request_id=5d1baae6-c824-4988-adc3-ae82df35cfa5 '
+        'surface=openai_chat_completions error_class=invalid_request'
     ]

--- a/docs/doc/developer/backend/llm_gateway.mdx
+++ b/docs/doc/developer/backend/llm_gateway.mdx
@@ -618,6 +618,13 @@ plus `kind`, `field`, `route`, and `service`. This gives rollout owners a stable
 query surface even when backend caller metrics are hard to inspect per runtime
 surface.
 
+Gateway terminal errors and request rejections emit warning-level, privacy-safe
+Cloud Logging lines. `llm_gateway_terminal` includes only the opaque request ID,
+route metadata, credential source, and bounded `error_class` / `failure_class`;
+it never includes provider bodies, prompts, or credentials. Successful terminal
+events remain metrics and info-level logs to avoid turning normal traffic into
+an operational alert stream.
+
 Shadow-only features can also emit privacy-safe comparison buckets through
 `llm_gateway_chat_extraction_comparisons_total{feature,field,outcome}`. These
 metrics compare derived properties such as category match, empty/non-empty


### PR DESCRIPTION
## Summary

- Promote LLM gateway terminal errors and pre-route rejections to warning-level structured logs.
- Include the existing bounded failure class in terminal error logs so Cloud Logging distinguishes provider, credential, capability, and transport failures.
- Document the privacy-safe terminal error log contract.

## Why

The gateway already recorded terminal metrics and opaque request IDs, but normal application logger output was not visible in the running Uvicorn container. Recent 400 and 401 failures therefore could not be classified from live logs without inspecting request bodies or credentials.

## Impact

Successful traffic remains metrics and info-level only. Warning logs contain only opaque request IDs, route metadata, credential source, and bounded error classes; they never contain prompts, provider bodies, or keys.

## Validation

- cd backend && bash test.sh
- Focused gateway metrics, OpenAI-compatible, and Anthropic passthrough tests: 35 passed
- Pre-push checks passed, including import-purity, module isolation, async-blocker, typecheck, and generated-contract checks


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9596?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

