### PR TITLE
fix(desktop): bound RealtimeOmni pre-connect audio buffer

### DIFF
--- a/desktop/macos/Desktop/Sources/RealtimeOmni/RealtimeOmniService.swift
+++ b/desktop/macos/Desktop/Sources/RealtimeOmni/RealtimeOmniService.swift
@@ -52,10 +52,12 @@ final class RealtimeOmniService: NSObject {
     private var terminated = false  // fire omniDidError at most once per turn
     private var pendingAudio: [Data] = []
     private var pendingAudioBytes = 0
-    /// Cap on audio buffered while the relay session is still connecting, matching the
-    /// hub's `maxBufferedAudioBytes` (120 s @ 16 kHz s16le). Without a bound, a relay
-    /// that stalls open (connecting but never `session.created`) during a multi-minute
-    /// locked-mode hold would grow `pendingAudio` unboundedly.
+    /// Byte cap on audio buffered while the relay session is still connecting, matching the
+    /// hub's byte-based `maxBufferedAudioBytes`. `sendAudio` queues PCM already resampled to
+    /// the provider's `requiredInputSampleRate`, so the covered duration depends on that rate
+    /// (~120 s at 16 kHz, ~80 s at 24 kHz s16le). Without a bound, a relay that stalls open
+    /// (connecting but never `session.created`) during a multi-minute locked-mode hold would
+    /// grow `pendingAudio` unboundedly.
     private static let maxPendingAudioBytes = 3_840_000
     private var pendingCommit = false  // turn ended before the session opened; commit after activityStart
 

--- a/desktop/macos/Desktop/Sources/RealtimeOmni/RealtimeOmniService.swift
+++ b/desktop/macos/Desktop/Sources/RealtimeOmni/RealtimeOmniService.swift
@@ -51,6 +51,12 @@ final class RealtimeOmniService: NSObject {
     private var isOpen = false
     private var terminated = false  // fire omniDidError at most once per turn
     private var pendingAudio: [Data] = []
+    private var pendingAudioBytes = 0
+    /// Cap on audio buffered while the relay session is still connecting, matching the
+    /// hub's `maxBufferedAudioBytes` (120 s @ 16 kHz s16le). Without a bound, a relay
+    /// that stalls open (connecting but never `session.created`) during a multi-minute
+    /// locked-mode hold would grow `pendingAudio` unboundedly.
+    private static let maxPendingAudioBytes = 3_840_000
     private var pendingCommit = false  // turn ended before the session opened; commit after activityStart
 
     // Gemini's Live endpoint resets BOTH of Apple's WebSocket stacks
@@ -117,6 +123,7 @@ final class RealtimeOmniService: NSObject {
         nw = nil
         isOpen = false
         pendingAudio.removeAll()
+        pendingAudioBytes = 0
         pendingCommit = false
     }
 
@@ -176,6 +183,21 @@ final class RealtimeOmniService: NSObject {
 
     /// Feed mic PCM16 mono at `requiredInputSampleRate`. Caller is responsible for
     /// resampling to that rate (16k mic → 24k for OpenAI).
+    /// Appends `chunk` to `buffer` (tracking total bytes in `bytes`), dropping the
+    /// oldest chunks so the buffered total never exceeds `maxBytes` (unless a single
+    /// chunk alone exceeds it, in which case that one chunk is kept). Bounds memory
+    /// while the relay is still connecting. `nonisolated static` so it is unit-testable.
+    nonisolated static func appendBoundedAudio(
+        _ chunk: Data, to buffer: inout [Data], bytes: inout Int, maxBytes: Int
+    ) {
+        buffer.append(chunk)
+        bytes += chunk.count
+        while bytes > maxBytes, buffer.count > 1 {
+            let dropped = buffer.removeFirst()
+            bytes -= dropped.count
+        }
+    }
+
     func sendAudio(_ pcm: Data) {
         // Buffer until the session is open. PTT starts the mic immediately and
         // streams chunks during the connect handshake (plus a pre-connect buffer
@@ -184,7 +206,10 @@ final class RealtimeOmniService: NSObject {
         // ("invalid argument") — markReady() sends activityStart and *then* flushes
         // pendingAudio, so queuing here preserves that ordering. (The test harness
         // only sends after omniDidConnect, so it never exercised this race.)
-        guard isOpen else { pendingAudio.append(pcm); return }
+        guard isOpen else {
+            Self.appendBoundedAudio(pcm, to: &pendingAudio, bytes: &pendingAudioBytes, maxBytes: Self.maxPendingAudioBytes)
+            return
+        }
         let b64 = pcm.base64EncodedString()
         switch provider {
         case .gptRealtime2:
@@ -383,6 +408,7 @@ final class RealtimeOmniService: NSObject {
         }
         for chunk in pendingAudio { sendAudio(chunk) }
         pendingAudio.removeAll()
+        pendingAudioBytes = 0
         if pendingCommit {
             pendingCommit = false
             commitInputTurn()

--- a/desktop/macos/Desktop/Tests/RealtimeOmniPendingAudioBoundTests.swift
+++ b/desktop/macos/Desktop/Tests/RealtimeOmniPendingAudioBoundTests.swift
@@ -12,18 +12,31 @@ import XCTest
 final class RealtimeOmniPendingAudioBoundTests: XCTestCase {
     private func chunk(_ n: Int) -> Data { Data(repeating: 0, count: n) }
 
+    /// A 30-byte chunk whose first byte marks its append order, so we can assert
+    /// *which* chunks survive (not just how many) — distinguishing drop-oldest from
+    /// an accidental drop-newest that would keep the count identical.
+    private func markedChunk(_ index: Int) -> Data {
+        var c = Data(repeating: 0, count: 30)
+        c[c.startIndex] = UInt8(index)
+        return c
+    }
+
     func testDropsOldestWhenExceedingCap() {
         var buffer: [Data] = []
         var bytes = 0
         let maxBytes = 100
-        // Append 10 chunks of 30 bytes each = 300 bytes; cap is 100.
-        for _ in 0..<10 {
-            RealtimeOmniService.appendBoundedAudio(chunk(30), to: &buffer, bytes: &bytes, maxBytes: maxBytes)
+        // Append 10 distinctly-marked 30-byte chunks = 300 bytes; cap is 100.
+        for i in 0..<10 {
+            RealtimeOmniService.appendBoundedAudio(markedChunk(i), to: &buffer, bytes: &bytes, maxBytes: maxBytes)
         }
         XCTAssertLessThanOrEqual(bytes, maxBytes)
         XCTAssertEqual(bytes, buffer.reduce(0) { $0 + $1.count }, "tracked bytes must match buffer contents")
-        // 100 / 30 → keeps the newest 3 chunks (90 bytes).
+        // 100 / 30 → keeps the newest 3 chunks (90 bytes): the ones marked 7, 8, 9.
         XCTAssertEqual(buffer.count, 3)
+        XCTAssertEqual(
+            buffer.compactMap { $0.first }, [7, 8, 9],
+            "must retain the NEWEST chunks (drop-oldest), not merely the right count"
+        )
     }
 
     func testKeepsAtLeastNewestChunkEvenIfItAloneExceedsCap() {

--- a/desktop/macos/Desktop/Tests/RealtimeOmniPendingAudioBoundTests.swift
+++ b/desktop/macos/Desktop/Tests/RealtimeOmniPendingAudioBoundTests.swift
@@ -1,0 +1,45 @@
+import Foundation
+import XCTest
+
+@testable import Omi_Computer
+
+/// Regression coverage for the bounded pre-connect audio buffer in RealtimeOmniService.
+///
+/// While the relay session is still connecting, mic chunks are queued in `pendingAudio`.
+/// Without a cap, a relay that stalls open during a multi-minute locked-mode hold would
+/// grow the buffer unboundedly. `appendBoundedAudio` drops the oldest chunks to keep the
+/// buffered total under the cap. These tests pin that policy.
+final class RealtimeOmniPendingAudioBoundTests: XCTestCase {
+    private func chunk(_ n: Int) -> Data { Data(repeating: 0, count: n) }
+
+    func testDropsOldestWhenExceedingCap() {
+        var buffer: [Data] = []
+        var bytes = 0
+        let maxBytes = 100
+        // Append 10 chunks of 30 bytes each = 300 bytes; cap is 100.
+        for _ in 0..<10 {
+            RealtimeOmniService.appendBoundedAudio(chunk(30), to: &buffer, bytes: &bytes, maxBytes: maxBytes)
+        }
+        XCTAssertLessThanOrEqual(bytes, maxBytes)
+        XCTAssertEqual(bytes, buffer.reduce(0) { $0 + $1.count }, "tracked bytes must match buffer contents")
+        // 100 / 30 → keeps the newest 3 chunks (90 bytes).
+        XCTAssertEqual(buffer.count, 3)
+    }
+
+    func testKeepsAtLeastNewestChunkEvenIfItAloneExceedsCap() {
+        var buffer: [Data] = []
+        var bytes = 0
+        RealtimeOmniService.appendBoundedAudio(chunk(500), to: &buffer, bytes: &bytes, maxBytes: 100)
+        XCTAssertEqual(buffer.count, 1)
+        XCTAssertEqual(bytes, 500)
+    }
+
+    func testNoDropUnderCap() {
+        var buffer: [Data] = []
+        var bytes = 0
+        RealtimeOmniService.appendBoundedAudio(chunk(10), to: &buffer, bytes: &bytes, maxBytes: 100)
+        RealtimeOmniService.appendBoundedAudio(chunk(20), to: &buffer, bytes: &bytes, maxBytes: 100)
+        XCTAssertEqual(buffer.count, 2)
+        XCTAssertEqual(bytes, 30)
+    }
+}

--- a/desktop/macos/changelog/unreleased/20260713-realtime-pending-audio-bound.json
+++ b/desktop/macos/changelog/unreleased/20260713-realtime-pending-audio-bound.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed unbounded audio buffering that could grow memory if a voice session stalled while connecting"
+}


### PR DESCRIPTION
## Summary

Desktop bug sweep (batch 8) — one confirmed unbounded-memory-growth bug in the realtime voice path.

`RealtimeOmniService.sendAudio` queues mic PCM chunks in `pendingAudio` while the relay session is still connecting (PTT starts the mic immediately and streams chunks during the connect handshake, so they queue until `markReady()` flushes them). The queue had **no bound**: a relay that stalls open — connecting but never emitting `session.created` — during a multi-minute locked-mode hold grows `pendingAudio` unboundedly, one chunk per mic frame, until the session finally opens or the app hits memory pressure.

## Fix

- Add a byte-tracked cap `maxPendingAudioBytes = 3_840_000` (120 s @ 16 kHz s16le = `16000 × 2 × 120`, matching the hub's `maxBufferedAudioBytes`) enforced by a new `nonisolated static appendBoundedAudio(_:to:bytes:maxBytes:)` drop-oldest helper.
- Wire it into the connecting-buffer guard in `sendAudio`; keep at least the newest chunk even if it alone exceeds the cap.
- Reset the byte counter alongside `pendingAudio.removeAll()` in both `reset()` and the `markReady()` flush.

The helper is `nonisolated static` so it is unit-testable without standing up the actor / a live relay.

## Testing

- `RealtimeOmniPendingAudioBoundTests` (new) — behavioral coverage calling the production `appendBoundedAudio` API: drops oldest when over cap (10×30 B, cap 100 → newest 3 kept), keeps the newest chunk even if it alone exceeds the cap, no drop under cap, and tracked-bytes always equals the buffer contents.
- Desktop static checkers pass at head: `check_desktop_test_quality.py` (baseline; behavioral test, not source-inspection), `check-sources-root-layout.py` (baseline), `check-e2e-flow-coverage.py --strict` (RealtimeOmniService covered by `ptt-lifecycle`).
- `scripts/pr-preflight` green — 13 checks (product-invariants: none; brand-ui/INV-UI-1 clean; changelog present).
- Swift compile + XCTest run in `desktop-swift-ci` — no local macOS toolchain in this sandbox.

## Notes

- Originally this batch also carried a RewindIndexer frame-count fix, but `main` (`2efd54dc2` / `1f7a90868`) already landed a more complete version (`readVideoSamplePresentationTimes` counts real samples via `AVAssetReader` instead of `duration × nominalFrameRate`), so that part was dropped as superseded — this PR is RealtimeOmni-only.

## Product invariants affected

- None (`scripts/pr-preflight --suggest` → none; RealtimeOmniService is not under a locked invariant path glob).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RAxLsaxtwVNDTWAZFfJp9q)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9602?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

