### PR TITLE
fix(setup): fast-forward stale worktree branches during make setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,7 +61,7 @@ Improve the code you touch — within your blast radius:
 
 ## Setup
 
-- **Worktree setup (required before first commit/push):** `make setup` — installs the repo Git hooks using linked-worktree-safe paths.
+- **Worktree setup (required before first commit/push):** `make setup` — fetches `origin/main`, fast-forwards a stale current branch when safe, and installs repo Git hooks using linked-worktree-safe paths.
 - **Pre-commit hook (required before first commit):** `ln -s -f ../../scripts/pre-commit "$(git rev-parse --git-path hooks)/pre-commit"` — auto-formats staged files on commit.
 - Mobile app setup: `cd app && bash setup.sh ios` (or `android`).
 

--- a/scripts/setup-refresh-main.sh
+++ b/scripts/setup-refresh-main.sh
@@ -17,22 +17,48 @@ if ! git rev-parse --verify "$REMOTE_REF" >/dev/null 2>&1; then
 fi
 
 current_branch="$(git symbolic-ref --short -q HEAD || true)"
+remote_oid="$(git rev-parse "$REMOTE_REF")"
+
+sync_current_worktree_branch() {
+  if [ -z "$current_branch" ] || [ "$current_branch" = "$BRANCH" ]; then
+    return 0
+  fi
+
+  local head_oid
+  head_oid="$(git rev-parse HEAD)"
+
+  if [ "$head_oid" = "$remote_oid" ]; then
+    echo "Current branch ${current_branch} already matches ${REMOTE_BRANCH}."
+    return 0
+  fi
+
+  if git merge-base --is-ancestor "$head_oid" "$remote_oid"; then
+    echo "Fast-forwarding current branch ${current_branch} to ${REMOTE_BRANCH}..."
+    git merge --ff-only "$REMOTE_REF"
+    return 0
+  fi
+
+  echo "Current branch ${current_branch} is not a fast-forward behind ${REMOTE_BRANCH}; left unchanged." >&2
+}
+
 if ! git show-ref --verify --quiet "$LOCAL_REF"; then
   git branch "$BRANCH" "$REMOTE_REF"
   echo "Created local ${BRANCH} from ${REMOTE_BRANCH}."
+  sync_current_worktree_branch
   exit 0
 fi
 
 local_oid="$(git rev-parse "$LOCAL_REF")"
-remote_oid="$(git rev-parse "$REMOTE_REF")"
 
 if [ "$local_oid" = "$remote_oid" ]; then
   echo "Local ${BRANCH} already matches ${REMOTE_BRANCH}."
+  sync_current_worktree_branch
   exit 0
 fi
 
 if ! git merge-base --is-ancestor "$local_oid" "$remote_oid"; then
   echo "Fetched ${REMOTE_BRANCH}; local ${BRANCH} is not a fast-forward, so it was left unchanged." >&2
+  sync_current_worktree_branch
   exit 0
 fi
 
@@ -56,3 +82,5 @@ else
     exit 1
   fi
 fi
+
+sync_current_worktree_branch

--- a/scripts/test-setup-refresh-main.sh
+++ b/scripts/test-setup-refresh-main.sh
@@ -45,6 +45,7 @@ output="$(
 )"
 after="$(git -C "$TMPDIR/primary" rev-parse main)"
 remote_after="$(git -C "$TMPDIR/feature" rev-parse origin/main)"
+feature_after="$(git -C "$TMPDIR/feature" rev-parse HEAD)"
 
 if [ "$before" != "$after" ]; then
   echo "FAIL: local main changed while checked out in another worktree." >&2
@@ -56,10 +57,24 @@ if ! git -C "$TMPDIR/feature" merge-base --is-ancestor "$before" "$remote_after"
   exit 1
 fi
 
+if [ "$feature_after" != "$remote_after" ]; then
+  echo "FAIL: stale feature branch was not fast-forwarded to origin/main." >&2
+  exit 1
+fi
+
 case "$output" in
   *"checked out in another worktree"*) ;;
   *)
     echo "FAIL: expected checked-out worktree message." >&2
+    echo "$output" >&2
+    exit 1
+    ;;
+esac
+
+case "$output" in
+  *"Fast-forwarding current branch feature"*) ;;
+  *)
+    echo "FAIL: expected feature branch fast-forward message." >&2
     echo "$output" >&2
     exit 1
     ;;
@@ -118,3 +133,60 @@ case "$diverged_output" in
 esac
 
 echo "setup-refresh-main diverged-current-main test passed."
+
+git init --bare --initial-branch=main "$TMPDIR/diverged-feature-remote.git" >/dev/null
+
+git clone "$TMPDIR/diverged-feature-remote.git" "$TMPDIR/diverged-feature-primary" >/dev/null 2>&1
+(
+  cd "$TMPDIR/diverged-feature-primary"
+  git config user.email test@example.com
+  git config user.name "Test User"
+  echo one >file.txt
+  git add file.txt
+  git commit -m initial >/dev/null
+  git push origin HEAD:main >/dev/null 2>&1
+  git branch -M main
+  git fetch origin main >/dev/null 2>&1
+  git branch --set-upstream-to origin/main main >/dev/null
+)
+
+git clone "$TMPDIR/diverged-feature-remote.git" "$TMPDIR/diverged-feature-updater" >/dev/null 2>&1
+(
+  cd "$TMPDIR/diverged-feature-updater"
+  git config user.email test@example.com
+  git config user.name "Test User"
+  echo remote >>file.txt
+  git commit -am remote-update >/dev/null
+  git push origin main >/dev/null 2>&1
+)
+
+(
+  cd "$TMPDIR/diverged-feature-primary"
+  git worktree add "$TMPDIR/diverged-feature" -b feature >/dev/null 2>&1
+  cd "$TMPDIR/diverged-feature"
+  echo local >>file.txt
+  git commit -am local-feature >/dev/null
+)
+
+diverged_feature_before="$(git -C "$TMPDIR/diverged-feature" rev-parse HEAD)"
+diverged_feature_output="$(
+  cd "$TMPDIR/diverged-feature"
+  bash "$ROOT/scripts/setup-refresh-main.sh" 2>&1
+)"
+diverged_feature_after="$(git -C "$TMPDIR/diverged-feature" rev-parse HEAD)"
+
+if [ "$diverged_feature_before" != "$diverged_feature_after" ]; then
+  echo "FAIL: diverged feature branch changed." >&2
+  exit 1
+fi
+
+case "$diverged_feature_output" in
+  *"not a fast-forward behind"*) ;;
+  *)
+    echo "FAIL: expected non-fast-forward current-branch message." >&2
+    echo "$diverged_feature_output" >&2
+    exit 1
+    ;;
+esac
+
+echo "setup-refresh-main diverged-current-branch test passed."


### PR DESCRIPTION
## Summary

- Extend `make setup` (`scripts/setup-refresh-main.sh`) to fast-forward the **current worktree branch** when it is safely behind `origin/main`
- Keeps existing behavior for the shared local `main` ref (still skips force-update when `main` is checked out elsewhere)
- Adds hermetic coverage for stale feature branches and diverged branches that should be left unchanged
- Documents the behavior in `AGENTS.md`

## Problem

New linked worktrees (especially Cursor `cursor/*` branches) often start pinned to an older `main`. `make setup` already fetched `origin/main` and refreshed the shared `main` ref, but left the checked-out branch behind — so agents had to manually merge/rebase before starting work.

## Test plan

- [x] `bash scripts/test-setup-refresh-main.sh`
- [x] Ran `scripts/setup-refresh-main.sh` in a stale Cursor worktree; `cursor/cb0448bc` fast-forwarded to `origin/main`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9604?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

