### PR TITLE
fix(recommendations): skip a malformed decision record instead of 500ing get_decisions

### DIFF
--- a/backend/database/task_recommendations.py
+++ b/backend/database/task_recommendations.py
@@ -2,11 +2,13 @@
 
 import hashlib
 import json
+import logging
 from datetime import datetime, timezone
 from typing import Any, Optional, cast
 
 from google.cloud import firestore
 from google.cloud.firestore_v1 import FieldFilter
+from pydantic import ValidationError
 
 from database._client import get_firestore_client
 from models.task_recommendation import (
@@ -23,6 +25,8 @@ from models.task_recommendation import (
     WhatMattersNowProjection,
 )
 from models.task_intelligence import TaskWorkflowControl, TaskWorkflowMode
+
+logger = logging.getLogger(__name__)
 
 FEEDBACK_COLLECTION = 'task_feedback'
 OUTCOMES_COLLECTION = 'task_outcomes'
@@ -309,6 +313,23 @@ def get_projection(
     return projection if include_expired or projection.expires_at > now else None
 
 
+def _decision_records(raw_records: list[Any], evaluation_id: str) -> list[DecisionRecord]:
+    """Build DecisionRecord objects from stored decision dicts, skipping a malformed one.
+
+    DecisionRecord is extra='forbid', so a legacy or schema-drifted audit record would raise
+    ValidationError and 500 the whole recommendation read. Skip such a record rather than fail the
+    batch; unexpected errors still propagate. Sorted by subject_id to match the caller.
+    """
+    records: list[DecisionRecord] = []
+    for record in raw_records:
+        try:
+            records.append(DecisionRecord.model_validate(record))
+        except ValidationError as e:
+            logger.warning('Skipping malformed decision record in evaluation %s: %s', evaluation_id, e)
+    records.sort(key=lambda record: record.subject_id)
+    return records
+
+
 def get_decisions(
     uid: str,
     evaluation_id: str,
@@ -341,9 +362,7 @@ def get_decisions(
     raw_records = payload.get('decisions')
     if not isinstance(raw_records, list):
         return []
-    records = [DecisionRecord.model_validate(record) for record in raw_records]
-    records.sort(key=lambda record: record.subject_id)
-    return records
+    return _decision_records(raw_records, evaluation_id)
 
 
 def get_evaluation_projection(

--- a/backend/tests/unit/test_decision_records_skip_malformed.py
+++ b/backend/tests/unit/test_decision_records_skip_malformed.py
@@ -1,0 +1,62 @@
+"""database.task_recommendations._decision_records skips a malformed decision record, not 500s.
+
+get_decisions built [DecisionRecord.model_validate(r) for r in raw_records] with no guard, inside a
+Firestore transaction. DecisionRecord is extra='forbid', so a legacy or schema-drifted stored audit
+record raised ValidationError and 500'd the recommendation read (utils/task_intelligence/
+recommendations.py get_decisions callers). The decode is now the pure _decision_records helper, which
+skips a malformed record and sorts by subject_id; the test drives that helper directly.
+"""
+
+import os
+
+os.environ.setdefault(
+    'ENCRYPTION_SECRET',
+    'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv',
+)
+
+from types import SimpleNamespace
+
+import pytest
+from pydantic import BaseModel, ValidationError
+
+import database.task_recommendations as tr
+
+
+class _Probe(BaseModel):
+    x: int
+
+
+def _a_validation_error() -> ValidationError:
+    try:
+        _Probe.model_validate({})  # missing required field -> a real ValidationError
+    except ValidationError as exc:
+        return exc
+    raise AssertionError('expected a ValidationError')
+
+
+def _stub_validate(monkeypatch):
+    err = _a_validation_error()
+
+    def fake_validate(record):
+        if record.get('_bad'):
+            raise err
+        return SimpleNamespace(subject_id=record['subject_id'])
+
+    monkeypatch.setattr(tr.DecisionRecord, 'model_validate', staticmethod(fake_validate))
+
+
+def test_decision_records_skips_malformed_and_sorts(monkeypatch):
+    _stub_validate(monkeypatch)
+    raw = [{'subject_id': 'b'}, {'_bad': True, 'subject_id': 'x'}, {'subject_id': 'a'}]
+    out = tr._decision_records(raw, 'eval1')
+    assert [r.subject_id for r in out] == ['a', 'b']  # malformed skipped, remainder sorted by subject_id
+
+
+def test_decision_records_unexpected_error_propagates(monkeypatch):
+    # Only ValidationError is skipped; an unexpected error must surface, not be hidden as a skip.
+    def boom(record):
+        raise RuntimeError('unexpected')
+
+    monkeypatch.setattr(tr.DecisionRecord, 'model_validate', staticmethod(boom))
+    with pytest.raises(RuntimeError):
+        tr._decision_records([{'subject_id': 'a'}], 'eval1')


### PR DESCRIPTION
## What

`get_decisions` decoded stored decision records with an unguarded comprehension inside a Firestore transaction:

```python
records = [DecisionRecord.model_validate(record) for record in raw_records]
```

`DecisionRecord` is `ConfigDict(extra='forbid')` with several required fields, so one legacy or schema-drifted audit record in the stored `decisions` list (a stray field from a newer or older writer, or a missing required field) raises `ValidationError`. That propagates out of `get_decisions` and 500s the recommendation read that calls it (`utils/task_intelligence/recommendations.py`).

## Fix

Move the decode into a pure `_decision_records` helper that skips a malformed record rather than failing the whole batch, and rewire `get_decisions` to call it:

```python
def _decision_records(raw_records, evaluation_id):
    records = []
    for record in raw_records:
        try:
            records.append(DecisionRecord.model_validate(record))
        except ValidationError as e:
            logger.warning('Skipping malformed decision record in evaluation %s: %s', evaluation_id, e)
    records.sort(key=lambda record: record.subject_id)
    return records
```

The catch is narrow (`ValidationError` only) so an unexpected error still propagates. Extracting the helper also makes the skip behavior unit-testable without the surrounding `@firestore.transactional` read machinery. This matches the skip-malformed guards already used across the backend list readers.

## Tests

New `tests/unit/test_decision_records_skip_malformed.py` drives the helper directly:
- a malformed record in the middle of the list is skipped, the rest are returned sorted by subject_id
- an unexpected non-ValidationError still propagates, not hidden as a skip

## Verification

```
cd backend && ENCRYPTION_SECRET=... python -m pytest tests/unit/test_decision_records_skip_malformed.py -q
  -> 2 passed
black --line-length 120 --skip-string-normalization --check database/task_recommendations.py tests/unit/test_decision_records_skip_malformed.py
  -> unchanged
python scripts/check_module_stub_pollution.py -> Checked 614 file(s); 0 violation(s)
```

## Product invariants affected

none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9606?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

