### PR TITLE
fix(chat-file): skip a malformed file doc instead of 500ing the chat-file flow

### DIFF
--- a/backend/tests/unit/test_chat_file_skip_malformed.py
+++ b/backend/tests/unit/test_chat_file_skip_malformed.py
@@ -1,0 +1,46 @@
+"""utils.other.chat_file._safe_file_chats skips a malformed file doc instead of 500ing the chat-file flow.
+
+get_chat_files / get_chat_files_desc results were turned into FileChat objects with unguarded
+[FileChat(**f) for f in ...] comprehensions at three sites. FileChat requires id/name/mime_type/
+openai_file_id/created_at, so one legacy or partial file document raised ValidationError and 500'd
+the whole attach / answer / cleanup flow. All three sites now route through _safe_file_chats, which
+skips a malformed record (mirroring utils.apps._safe_build_app). The helper is pure, so the test
+imports and calls it directly.
+"""
+
+import os
+
+os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
+os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv')
+
+from datetime import datetime, timezone
+
+import utils.other.chat_file as cf  # noqa: E402
+from models.chat import FileChat  # noqa: E402
+
+
+def _valid_file_dict():
+    return {
+        'id': 'f1',
+        'name': 'a.png',
+        'mime_type': 'image/png',
+        'openai_file_id': 'oai-1',
+        'created_at': datetime(2026, 1, 1, tzinfo=timezone.utc),
+    }
+
+
+def test_safe_file_chats_returns_files_for_valid_records():
+    out = cf._safe_file_chats([_valid_file_dict(), {**_valid_file_dict(), 'id': 'f2'}])
+    assert [f.id for f in out] == ['f1', 'f2']
+    assert all(isinstance(f, FileChat) for f in out)
+
+
+def test_safe_file_chats_skips_malformed_record():
+    # A doc missing required fields (openai_file_id/mime_type/created_at) is skipped, not raised.
+    records = [_valid_file_dict(), {'id': 'broken'}, {**_valid_file_dict(), 'id': 'f3'}]
+    out = cf._safe_file_chats(records)
+    assert [f.id for f in out] == ['f1', 'f3']  # malformed 'broken' skipped, list survives
+
+
+def test_safe_file_chats_empty():
+    assert cf._safe_file_chats([]) == []

--- a/backend/utils/other/chat_file.py
+++ b/backend/utils/other/chat_file.py
@@ -12,6 +12,7 @@ from openai.types.chat import (
     ChatCompletionMessageParam,
 )
 from PIL import Image
+from pydantic import ValidationError
 
 import database.chat as chat_db
 from models.chat import ChatSession, FileChat
@@ -20,6 +21,27 @@ from utils.llm.gateway_client import raise_if_gateway_feature_mode_blocks_direct
 import logging
 
 logger = logging.getLogger(__name__)
+
+
+def _safe_file_chats(files_data: List[Dict[str, Any]]) -> List[FileChat]:
+    """Build FileChat objects from raw file docs, skipping (not raising on) a malformed one.
+
+    A legacy or partial file document (missing openai_file_id, mime_type, created_at, ...) must not
+    500 the whole chat-file flow. Skip such a record, logging the file id and offending field names,
+    mirroring utils.apps._safe_build_app.
+    """
+    files: List[FileChat] = []
+    for f in files_data:
+        try:
+            files.append(FileChat(**f))
+        except ValidationError as e:
+            logger.warning(
+                "Skipping malformed chat file %s: %s",
+                f.get('id') if isinstance(f, dict) else None,
+                [err['loc'][0] for err in e.errors()],
+            )
+    return files
+
 
 _async_openai: AsyncOpenAI | None = None
 
@@ -151,7 +173,7 @@ class FileChatTool:
             files_data = await run_blocking(
                 db_executor, chat_db.get_chat_files_desc, self.uid, files_id=file_ids, limit=9
             )
-            files = [FileChat(**f) for f in files_data]
+            files = _safe_file_chats(files_data)
             all_images = all(f.is_image() for f in files) if files else False
         except Exception:
             callback.end_nowait()
@@ -280,7 +302,7 @@ class FileChatTool:
         # OpenAI has a limit of 10 items in content array (1 text + max 9 images)
         files = chat_db.get_chat_files_desc(uid, files_id=file_ids, limit=9)
 
-        files_typed = [FileChat(**file) for file in files]
+        files_typed = _safe_file_chats(files)
 
         contents: List[Dict[str, Any]] = []
         attachments: List[Dict[str, Any]] = []
@@ -383,7 +405,7 @@ class FileChatTool:
         if files:
             chat_db.delete_multi_files(self.uid, files)
 
-            file_objs = [FileChat(**file) for file in files]
+            file_objs = _safe_file_chats(files)
             # clear file in openai
             for file in file_objs:
                 try:

--- a/backend/utils/other/chat_file.py
+++ b/backend/utils/other/chat_file.py
@@ -37,7 +37,7 @@ def _safe_file_chats(files_data: List[Dict[str, Any]]) -> List[FileChat]:
         except ValidationError as e:
             logger.warning(
                 "Skipping malformed chat file %s: %s",
-                f.get('id') if isinstance(f, dict) else None,
+                f.get('id'),
                 [err['loc'][0] for err in e.errors()],
             )
     return files


### PR DESCRIPTION
## What

Three sites in `utils/other/chat_file.py` turned raw file docs into `FileChat` objects with an unguarded comprehension:

```python
files = [FileChat(**f) for f in files_data]   # + two more (line ~283, ~386)
```

`FileChat` requires `id`, `name`, `mime_type`, `openai_file_id`, and `created_at`. The file docs come from `chat_db.get_chat_files` / `get_chat_files_desc`, so one legacy or partial file document (missing `openai_file_id`, `mime_type`, or `created_at`) raises `ValidationError` and 500s the flows that build these objects: the async file-read path, `_fill_question` (answering with file context), and `cleanup` (session teardown).

## Fix

Route all three sites through a shared `_safe_file_chats` helper that skips a malformed record rather than failing the whole batch, mirroring `utils/apps.py` `_safe_build_app`:

```python
def _safe_file_chats(files_data):
    files = []
    for f in files_data:
        try:
            files.append(FileChat(**f))
        except ValidationError as e:
            logger.warning("Skipping malformed chat file %s: %s", f.get('id') if isinstance(f, dict) else None, [err['loc'][0] for err in e.errors()])
    return files
```

The catch is narrow (`ValidationError` only) so an unexpected error still propagates, and it logs the file id plus offending field names only.

## Tests

New `tests/unit/test_chat_file_skip_malformed.py` calls the pure helper directly (imports `utils.other.chat_file`, no stubs):
- valid records build FileChat objects
- a record missing required fields is skipped and the valid ones survive
- empty input returns empty

## Verification

```
cd backend && ENCRYPTION_SECRET=... OPENAI_API_KEY=... python -m pytest tests/unit/test_chat_file_skip_malformed.py -q
  -> 3 passed
black --line-length 120 --skip-string-normalization --check utils/other/chat_file.py tests/unit/test_chat_file_skip_malformed.py
  -> unchanged
python scripts/check_module_stub_pollution.py -> Checked 614 file(s); 0 violation(s)
```

## Product invariants affected

none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9608?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

