### PR TITLE
fix(windows): select primary display capture source

### DIFF
--- a/desktop/windows/src/main/rewind/sourceId.test.ts
+++ b/desktop/windows/src/main/rewind/sourceId.test.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const electron = vi.hoisted(() => ({
+  getSources: vi.fn(),
+  getPrimaryDisplay: vi.fn(),
+  on: vi.fn()
+}))
+
+vi.mock('electron', () => ({
+  desktopCapturer: { getSources: electron.getSources },
+  screen: {
+    getPrimaryDisplay: electron.getPrimaryDisplay,
+    on: electron.on
+  }
+}))
+
+async function loadSourceId(): Promise<typeof import('./sourceId')> {
+  vi.resetModules()
+  return import('./sourceId')
+}
+
+describe('getPrimarySourceId', () => {
+  beforeEach(() => {
+    electron.getSources.mockReset()
+    electron.getPrimaryDisplay.mockReset()
+    electron.on.mockReset()
+    electron.getPrimaryDisplay.mockReturnValue({ id: 202 })
+  })
+
+  it('selects the source whose display ID matches the primary display', async () => {
+    electron.getSources.mockResolvedValue([
+      { id: 'screen:0:0', display_id: '101' },
+      { id: 'screen:1:0', display_id: '202' }
+    ])
+
+    const { getPrimarySourceId } = await loadSourceId()
+
+    await expect(getPrimarySourceId()).resolves.toBe('screen:1:0')
+    expect(electron.getPrimaryDisplay).toHaveBeenCalledOnce()
+  })
+
+  it('falls back to the first source when Electron exposes no matching display ID', async () => {
+    electron.getSources.mockResolvedValue([
+      { id: 'screen:0:0', display_id: '' },
+      { id: 'screen:1:0', display_id: '' }
+    ])
+
+    const { getPrimarySourceId } = await loadSourceId()
+
+    await expect(getPrimarySourceId()).resolves.toBe('screen:0:0')
+  })
+
+  it('returns null when no screen source is available', async () => {
+    electron.getSources.mockResolvedValue([])
+
+    const { getPrimarySourceId } = await loadSourceId()
+
+    await expect(getPrimarySourceId()).resolves.toBeNull()
+  })
+
+  it('caches the selected source for the session', async () => {
+    electron.getSources.mockResolvedValue([{ id: 'screen:1:0', display_id: '202' }])
+
+    const { getPrimarySourceId } = await loadSourceId()
+
+    await expect(getPrimarySourceId()).resolves.toBe('screen:1:0')
+    await expect(getPrimarySourceId()).resolves.toBe('screen:1:0')
+    expect(electron.getSources).toHaveBeenCalledOnce()
+  })
+
+  it('selects again after display metrics invalidate the cache', async () => {
+    const listeners = new Map<string, () => void>()
+    electron.on.mockImplementation((event: string, listener: () => void) => {
+      listeners.set(event, listener)
+    })
+    electron.getSources
+      .mockResolvedValueOnce([{ id: 'screen:0:0', display_id: '202' }])
+      .mockResolvedValueOnce([{ id: 'screen:1:0', display_id: '303' }])
+
+    const { getPrimarySourceId, prewarmPrimarySourceId } = await loadSourceId()
+    prewarmPrimarySourceId()
+    await expect(getPrimarySourceId()).resolves.toBe('screen:0:0')
+
+    electron.getPrimaryDisplay.mockReturnValue({ id: 303 })
+    listeners.get('display-metrics-changed')?.()
+
+    await expect(getPrimarySourceId()).resolves.toBe('screen:1:0')
+    expect(electron.getSources).toHaveBeenCalledTimes(2)
+  })
+})

--- a/desktop/windows/src/main/rewind/sourceId.ts
+++ b/desktop/windows/src/main/rewind/sourceId.ts
@@ -15,7 +15,11 @@ async function fetchPrimarySourceId(): Promise<string | null> {
     types: ['screen'],
     thumbnailSize: { width: 0, height: 0 } // ids only — no screen bitmap
   })
-  return sources[0]?.id ?? null
+  const firstSource = sources[0]
+  if (!firstSource) return null
+
+  const primaryDisplayId = String(screen.getPrimaryDisplay().id)
+  return sources.find((source) => source.display_id === primaryDisplayId)?.id ?? firstSource.id
 }
 
 /** Cached primary-screen source id; computes it (slowly) once, then reuses it. */


### PR DESCRIPTION
## Summary

- selects the Windows Rewind capture source by matching Electron's `DesktopCapturerSource.display_id` to `screen.getPrimaryDisplay().id`
- keeps the existing first-source fallback when Electron does not expose a usable display ID
- preserves session caching and display-change invalidation, with regression coverage for reordered multi-display sources

Fixes #9607.

## Root cause

`fetchPrimarySourceId()` returned `sources[0]` and treated the list position as primary-display identity. Electron exposes a separate `display_id` field for matching a desktop source to the Screen API, so a multi-display source list that is not primary-first could make both Rewind capture and the `screen:readNow` fallback read a secondary monitor.

## Durable guard

The selection boundary now uses Electron's documented display identity and falls back only when no match is available. The new test puts the primary source second and fails against the old implementation; additional cases cover unavailable IDs, no sources, caching, and display-metrics invalidation.

## Real-path exercise

Ran an Electron 39 metadata-only probe on Windows. The current single-display machine reported one source whose `display_id` matched `screen.getPrimaryDisplay().id`, and the matching source ID was valid for `chromeMediaSourceId`. The probe did not capture or persist screen pixels. Multi-display ordering is exercised deterministically in the regression test.

## Product invariants affected

None. This only corrects Windows desktop source selection. It does not change capture cadence, retention, OCR, privacy filtering, memory tiers, auth/session behavior, chat continuity, agent control, integrations, or UI styling.

## Validation

- old-code regression proof: `pnpm exec vitest run src/main/rewind/sourceId.test.ts` -> 1 failed, 4 passed; old code selected `screen:0:0` instead of primary `screen:1:0`
- `pnpm exec vitest run src/main/rewind/sourceId.test.ts` -> 5 passed
- `pnpm exec prettier --check src/main/rewind/sourceId.ts src/main/rewind/sourceId.test.ts`
- `pnpm exec eslint src/main/rewind/sourceId.ts src/main/rewind/sourceId.test.ts --quiet`
- `pnpm run typecheck:node`
- `pnpm test` -> 83 files passed, 1 skipped; 555 tests passed, 3 skipped
- `pnpm run build`
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9609?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

