### PR TITLE
fix(ci): make pre-push preflight portable on Windows

### DIFF
--- a/.github/scripts/preflight_runner.py
+++ b/.github/scripts/preflight_runner.py
@@ -16,6 +16,24 @@ from pathlib import Path
 
 POLL_SECONDS = 0.2
 STATUS_INTERVAL_SECONDS = 5.0
+FORWARD_SIGNAL_NAMES = ("SIGINT", "SIGTERM", "SIGHUP")
+
+
+def supported_forward_signals() -> tuple[int, ...]:
+    return tuple(signum for name in FORWARD_SIGNAL_NAMES if isinstance((signum := getattr(signal, name, None)), int))
+
+
+def forward_signal_to_child(child: subprocess.Popen[str], signum: int) -> None:
+    if child.poll() is not None:
+        return
+    try:
+        kill_process_group = getattr(os, "killpg", None)
+        if callable(kill_process_group):
+            kill_process_group(child.pid, signum)
+        else:
+            child.send_signal(signum)
+    except ProcessLookupError:
+        pass
 
 
 def atomic_json(path: Path, value: dict) -> None:
@@ -32,9 +50,41 @@ def read_json(path: Path) -> dict:
         return {}
 
 
+def windows_process_exists(pid: int) -> bool:
+    import ctypes
+    from ctypes import wintypes
+
+    process_query_limited_information = 0x1000
+    error_access_denied = 5
+    still_active = 259
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    kernel32.OpenProcess.argtypes = (wintypes.DWORD, wintypes.BOOL, wintypes.DWORD)
+    kernel32.OpenProcess.restype = wintypes.HANDLE
+    kernel32.GetExitCodeProcess.argtypes = (
+        wintypes.HANDLE,
+        ctypes.POINTER(wintypes.DWORD),
+    )
+    kernel32.GetExitCodeProcess.restype = wintypes.BOOL
+    kernel32.CloseHandle.argtypes = (wintypes.HANDLE,)
+    kernel32.CloseHandle.restype = wintypes.BOOL
+
+    handle = kernel32.OpenProcess(process_query_limited_information, False, pid)
+    if not handle:
+        return ctypes.get_last_error() == error_access_denied
+    try:
+        exit_code = wintypes.DWORD()
+        if not kernel32.GetExitCodeProcess(handle, ctypes.byref(exit_code)):
+            return True
+        return exit_code.value == still_active
+    finally:
+        kernel32.CloseHandle(handle)
+
+
 def process_exists(pid: int) -> bool:
     if pid <= 0:
         return False
+    if os.name == "nt":
+        return windows_process_exists(pid)
     try:
         os.kill(pid, 0)
         return True
@@ -173,15 +223,10 @@ def run_owned(
         )
 
     def forward_signal(signum: int, _frame: object) -> None:
-        if child is not None and child.poll() is None:
-            try:
-                os.killpg(child.pid, signum)
-            except ProcessLookupError:
-                pass
+        if child is not None:
+            forward_signal_to_child(child, signum)
 
-    previous_handlers = {
-        signum: signal.signal(signum, forward_signal) for signum in (signal.SIGINT, signal.SIGTERM, signal.SIGHUP)
-    }
+    previous_handlers = {signum: signal.signal(signum, forward_signal) for signum in supported_forward_signals()}
     exit_code = 1
     try:
         print(f"Pre-push single-flight log: {log_path}")
@@ -195,6 +240,8 @@ def run_owned(
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             text=True,
+            encoding="utf-8",
+            errors="backslashreplace",
             bufsize=1,
             start_new_session=True,
         )

--- a/.github/scripts/test_pr_preflight.py
+++ b/.github/scripts/test_pr_preflight.py
@@ -65,7 +65,7 @@ class MetadataTests(unittest.TestCase):
 class SelectionTests(unittest.TestCase):
     def test_pre_push_wrapper_reuses_current_bash_interpreter(self) -> None:
         wrapper = PRE_PUSH_SINGLEFLIGHT.read_text(encoding="utf-8")
-        self.assertIn("exec python3 -X utf8 ", wrapper)
+        self.assertIn("export PYTHONUTF8=1\nexec python3 ", wrapper)
         self.assertIn(' -- "$BASH" scripts/pre-push "$@"', wrapper)
 
     def test_make_preflight_resolves_pr_metadata_before_running_checks(self) -> None:
@@ -79,7 +79,7 @@ class SelectionTests(unittest.TestCase):
         )
         self.assertEqual(result.returncode, 0, result.stdout)
         self.assertIn(
-            "python3 .github/scripts/pr_preflight.py --lane local --base origin/main",
+            "PYTHONUTF8=1 python3 .github/scripts/pr_preflight.py --lane local --base origin/main",
             result.stdout,
         )
 

--- a/.github/scripts/test_pr_preflight.py
+++ b/.github/scripts/test_pr_preflight.py
@@ -23,6 +23,7 @@ SCRIPT_DIR = Path(__file__).resolve().parent
 RUNNER = SCRIPT_DIR / "preflight_runner.py"
 REPO_ROOT = SCRIPT_DIR.parents[1]
 PRE_PUSH_SINGLEFLIGHT = REPO_ROOT / "scripts" / "pre-push-singleflight"
+PRE_PUSH = REPO_ROOT / "scripts" / "pre-push"
 
 
 class FakeResponse(io.BytesIO):
@@ -67,6 +68,15 @@ class SelectionTests(unittest.TestCase):
         wrapper = PRE_PUSH_SINGLEFLIGHT.read_text(encoding="utf-8")
         self.assertIn("export PYTHONUTF8=1\nexec python3 ", wrapper)
         self.assertIn(' -- "$BASH" scripts/pre-push "$@"', wrapper)
+
+    def test_pre_push_accepts_and_propagates_windows_backend_python(self) -> None:
+        pre_push = PRE_PUSH.read_text(encoding="utf-8")
+        setup_prefix = pre_push[: pre_push.index("require_backend_python()")]
+
+        self.assertIn('BACKEND_PYTHON="${BACKEND_PYTHON:-}"', setup_prefix)
+        self.assertIn('"$PWD/backend/.venv/bin/python"', setup_prefix)
+        self.assertIn('"$PWD/backend/.venv/Scripts/python.exe"', setup_prefix)
+        self.assertIn('PYRIGHT_PYTHON="$BACKEND_PYTHON" bash scripts/typecheck.sh', pre_push)
 
     def test_make_preflight_resolves_pr_metadata_before_running_checks(self) -> None:
         result = subprocess.run(

--- a/.github/scripts/test_pr_preflight.py
+++ b/.github/scripts/test_pr_preflight.py
@@ -6,19 +6,23 @@ from __future__ import annotations
 import io
 import json
 import os
+import signal
 import subprocess
 import sys
 import tempfile
 import time
 import unittest
+from unittest import mock
 from pathlib import Path
 
+import preflight_runner
 from pr_metadata import load_from_api
 from pr_preflight import select_checks
 
 SCRIPT_DIR = Path(__file__).resolve().parent
 RUNNER = SCRIPT_DIR / "preflight_runner.py"
 REPO_ROOT = SCRIPT_DIR.parents[1]
+PRE_PUSH_SINGLEFLIGHT = REPO_ROOT / "scripts" / "pre-push-singleflight"
 
 
 class FakeResponse(io.BytesIO):
@@ -59,6 +63,11 @@ class MetadataTests(unittest.TestCase):
 
 
 class SelectionTests(unittest.TestCase):
+    def test_pre_push_wrapper_reuses_current_bash_interpreter(self) -> None:
+        wrapper = PRE_PUSH_SINGLEFLIGHT.read_text(encoding="utf-8")
+        self.assertIn("exec python3 -X utf8 ", wrapper)
+        self.assertIn(' -- "$BASH" scripts/pre-push "$@"', wrapper)
+
     def test_make_preflight_resolves_pr_metadata_before_running_checks(self) -> None:
         result = subprocess.run(
             ["make", "-n", "preflight"],
@@ -196,13 +205,57 @@ class SelectionTests(unittest.TestCase):
             self.assertIn(str(body.resolve()), result.stdout)
 
 
+class SignalCompatibilityTests(unittest.TestCase):
+    def test_process_exists_uses_windows_probe_without_os_kill(self) -> None:
+        with (
+            mock.patch.object(preflight_runner.os, "name", "nt"),
+            mock.patch.object(preflight_runner, "windows_process_exists", return_value=True) as windows_probe,
+            mock.patch.object(preflight_runner.os, "kill") as kill,
+        ):
+            self.assertTrue(preflight_runner.process_exists(4321))
+
+        windows_probe.assert_called_once_with(4321)
+        kill.assert_not_called()
+
+    def test_supported_forward_signals_skip_unavailable_members(self) -> None:
+        with mock.patch.object(preflight_runner.signal, "SIGHUP", None, create=True):
+            self.assertEqual(
+                preflight_runner.supported_forward_signals(),
+                (signal.SIGINT, signal.SIGTERM),
+            )
+
+    def test_forward_signal_uses_child_api_without_killpg(self) -> None:
+        child = mock.Mock(pid=4321)
+        child.poll.return_value = None
+
+        with mock.patch.object(preflight_runner.os, "killpg", None, create=True):
+            preflight_runner.forward_signal_to_child(child, signal.SIGTERM)
+
+        child.send_signal.assert_called_once_with(signal.SIGTERM)
+
+    def test_forward_signal_keeps_posix_process_group_behavior(self) -> None:
+        child = mock.Mock(pid=4321)
+        child.poll.return_value = None
+        killpg = mock.Mock()
+
+        with mock.patch.object(preflight_runner.os, "killpg", killpg, create=True):
+            preflight_runner.forward_signal_to_child(child, signal.SIGTERM)
+
+        killpg.assert_called_once_with(4321, signal.SIGTERM)
+        child.send_signal.assert_not_called()
+
+
 class SingleFlightTests(unittest.TestCase):
     def run_runner(
         self,
         state_root: Path,
         command: list[str],
     ) -> subprocess.Popen[str]:
-        env = {**os.environ, "OMI_PREFLIGHT_STATE_DIR": str(state_root)}
+        env = {
+            **os.environ,
+            "OMI_PREFLIGHT_STATE_DIR": str(state_root),
+            "PYTHONUTF8": "1",
+        }
         return subprocess.Popen(
             [sys.executable, str(RUNNER), "--name", "test", "--", *command],
             cwd=REPO_ROOT,
@@ -212,6 +265,26 @@ class SingleFlightTests(unittest.TestCase):
             stderr=subprocess.STDOUT,
             text=True,
         )
+
+    def test_invalid_utf8_child_output_is_escaped_without_aborting(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            temp = Path(tmp)
+            command = [
+                sys.executable,
+                "-c",
+                "import sys; sys.stdout.buffer.write(b'bad:\\xa1\\n'); sys.stdout.buffer.flush()",
+            ]
+            runner = self.run_runner(temp, command)
+            assert runner.stdin is not None
+            runner.stdin.close()
+            output = runner.stdout.read() if runner.stdout else ""
+
+            self.assertEqual(runner.wait(), 0, output)
+            if runner.stdout:
+                runner.stdout.close()
+            self.assertIn(r"bad:\xa1", output)
+            log = (temp / "test" / "preflight.log").read_text(encoding="utf-8")
+            self.assertIn(r"bad:\xa1", log)
 
     def wait_for_lock(self, state_root: Path) -> None:
         lock = state_root / "test" / "lock" / "owner.json"

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ setup-hooks:
 	@bash scripts/install-git-hooks.sh
 
 preflight:
-	python3 .github/scripts/pr_preflight.py --lane local --base origin/main
+	PYTHONUTF8=1 python3 .github/scripts/pr_preflight.py --lane local --base origin/main
 
 dev-check:
 	bash scripts/dev-harness/dev-check.sh

--- a/scripts/pre-push
+++ b/scripts/pre-push
@@ -86,14 +86,22 @@ SELECTED_BACKEND_TESTS_REASON=$(mktemp "${TMPDIR:-/tmp}/omi-pre-push-backend-tes
 FAST_BACKEND_TESTS=$(mktemp "${TMPDIR:-/tmp}/omi-pre-push-fast-backend-tests.XXXXXX")
 trap 'rm -f "$CHANGED_FILES_LIST" "$SELECTED_BACKEND_TESTS" "$SELECTED_BACKEND_TESTS_REASON" "$FAST_BACKEND_TESTS"' EXIT
 printf '%s\n' "${CHANGED_FILES[@]}" > "$CHANGED_FILES_LIST"
-BACKEND_PYTHON="$PWD/backend/.venv/bin/python"
+BACKEND_PYTHON="${BACKEND_PYTHON:-}"
+if [[ -z "$BACKEND_PYTHON" ]]; then
+  for backend_python_candidate in "$PWD/backend/.venv/bin/python" "$PWD/backend/.venv/Scripts/python.exe"; do
+    if [[ -x "$backend_python_candidate" ]]; then
+      BACKEND_PYTHON="$backend_python_candidate"
+      break
+    fi
+  done
+fi
 
 require_backend_python() {
-  if [[ -x "$BACKEND_PYTHON" ]]; then
+  if [[ -n "$BACKEND_PYTHON" && -x "$BACKEND_PYTHON" ]]; then
     return 0
   fi
-  echo "FAIL: a selected backend check requires backend/.venv/bin/python, but it was not found." >&2
-  echo "      Create it with: cd backend && bash scripts/sync-python-deps.sh" >&2
+  echo "FAIL: a selected backend check requires a usable backend Python." >&2
+  echo "      Set BACKEND_PYTHON or run: cd backend && bash scripts/sync-python-deps.sh" >&2
   return 1
 }
 
@@ -275,7 +283,7 @@ check_backend_typecheck_if_needed() {
   require_backend_python
   (
     cd backend
-    bash scripts/typecheck.sh
+    PYRIGHT_PYTHON="$BACKEND_PYTHON" bash scripts/typecheck.sh
   )
 }
 

--- a/scripts/pre-push-singleflight
+++ b/scripts/pre-push-singleflight
@@ -4,4 +4,5 @@ set -euo pipefail
 
 ROOT="$(git rev-parse --show-toplevel)"
 cd "$ROOT"
-exec python3 -X utf8 .github/scripts/preflight_runner.py --name pre-push -- "$BASH" scripts/pre-push "$@"
+export PYTHONUTF8=1
+exec python3 .github/scripts/preflight_runner.py --name pre-push -- "$BASH" scripts/pre-push "$@"

--- a/scripts/pre-push-singleflight
+++ b/scripts/pre-push-singleflight
@@ -4,4 +4,4 @@ set -euo pipefail
 
 ROOT="$(git rev-parse --show-toplevel)"
 cd "$ROOT"
-exec python3 .github/scripts/preflight_runner.py --name pre-push -- scripts/pre-push "$@"
+exec python3 -X utf8 .github/scripts/preflight_runner.py --name pre-push -- "$BASH" scripts/pre-push "$@"


### PR DESCRIPTION
## Summary

- registers only signal constants available on the current platform
- keeps POSIX process-group forwarding and falls back to `Popen.send_signal()` when `os.killpg` is unavailable
- replaces Windows `os.kill(pid, 0)` probing with a read-only `OpenProcess` / `GetExitCodeProcess` check
- passes the wrapper's current `$BASH` interpreter path to the runner so Windows can launch the script without re-resolving `bash`
- propagates Python UTF-8 mode through the pre-push runner's child checks and the direct `make preflight` entrypoint
- resolves backend Python from an explicit override or either POSIX/Windows venv layout, propagates it to Pyright, and does not make unselected backend checks require a venv
- keeps mixed-codepage child output observable with UTF-8 `\xNN` escapes instead of aborting the hook
- adds platform-simulation coverage while making the existing single-flight tests pass on Windows

Fixes #9610.

## Root cause

The pre-push single-flight path assumed POSIX signal, process, interpreter, and output behavior:

1. `signal.SIGHUP` was evaluated unconditionally, but Windows Python does not define it.
2. Signal forwarding called `os.killpg`, which Windows Python does not expose.
3. `process_exists()` used `os.kill(pid, 0)`. On Windows, signal value `0` is `CTRL_C_EVENT`, so a joiner could interrupt the shared console instead of performing a side-effect-free existence probe.
4. The wrapper passed the extensionless `scripts/pre-push` Bash file directly to Windows `CreateProcess`, which cannot resolve a shebang script without an interpreter.
5. Passing a bare `bash` executable name still allowed native Windows process lookup to select `C:\Windows\System32\bash.exe` (WSL) instead of the Git Bash interpreter that was already running the hook.
6. The log streamer decoded every child byte as strict UTF-8, so one local-codepage byte could abort all checks even though the wrapped command was still running.
7. Starting only the runner with `-X utf8` did not propagate UTF-8 mode to Python checks it launched, and the direct `make preflight` entrypoint did not set it at all. Those children fell back to the Windows ANSI code page and could fail on valid UTF-8 repository files.
8. `scripts/pre-push` hard-coded `backend/.venv/bin/python`, so a standard native Windows venv with `Scripts/python.exe` failed before selected backend checks could run.
9. Even after selecting a Windows interpreter, the backend type-check wrapper did not receive it and fell back to a PATH lookup that could inspect the wrong environment.

The first assumption crashed a real Windows push before any checks started. After fixing it, the third assumption reproduced by interrupting the existing single-flight test host, which confirmed the whole signal boundary needed to be made portable rather than patching only the first traceback.

## Durable guard

- Signal registration is derived from the constants the runtime actually exposes.
- POSIX keeps `killpg`; other platforms use the child process API.
- Windows PID liveness uses a query-only process handle, checks `STILL_ACTIVE`, and always closes the handle. Access-denied is treated conservatively as alive, matching the existing POSIX `PermissionError` behavior.
- The wrapper provides its existing `$BASH` path as a separate argv element; it does not use `shell=True`, command strings, or a second PATH lookup.
- The wrapper exports `PYTHONUTF8=1` before starting the runner, so every descendant Python check inherits the same mode; the make target sets the same environment at its process boundary.
- Backend Python selection remains lazy, honors `BACKEND_PYTHON`, otherwise detects both `.venv/bin/python` and `.venv/Scripts/python.exe`, and passes the selected interpreter to the Pyright lane.
- The runner uses `backslashreplace` while decoding child output, preserving invalid bytes as visible `\xNN` text without changing the child exit code.
- Tests simulate missing `SIGHUP`, missing `killpg`, and the Windows liveness branch, enforce the current-interpreter and UTF-8 entrypoint contracts, then exercise the full two-process single-flight join behavior.

## Real-path exercise

- Ran the existing concurrent single-flight tests under Windows Python 3.11: identical work joined and executed once; different input was rejected without interrupting the host.
- Ran a real Windows process probe: an active child returned `True`, then returned `False` after termination.
- Passed the current Git Bash `$BASH` path through the native Windows Python runner and launched GNU Bash successfully; the old bare `bash` argv selected WSL and failed.
- Cleared `PYTHONUTF8` in the parent PowerShell session, then ran `make preflight`; the make target propagated UTF-8 mode and all 9 selected checks passed, including backend workflow contracts and repository-wide desktop changelog validation.
- A normal `git push` completed without `--no-verify`, passed all 9 shared preflight checks, and ran the complete backend Pyright lane with 0 errors using the selected Windows interpreter. The backend unit step selected two real tests but exposed a separate CRLF list-consumer bug, so that step used its documented skip after the failure was filed as #9627. OpenAPI and macOS Swift used their documented platform/dependency skips.

## Product invariants affected

None. This changes contributor tooling only and does not affect application runtime or product behavior.

## Validation

- old-code regression: existing `SingleFlightTests.test_identical_processes_join_and_execute_once` failed on Windows with `AttributeError: module 'signal' has no attribute 'SIGHUP'`
- `python .github/scripts/test_pr_preflight.py SignalCompatibilityTests` -> 4 passed
- `python .github/scripts/test_pr_preflight.py SingleFlightTests` -> 2 passed
- `python .github/scripts/test_pr_preflight.py` -> 16 passed
- `python .github/scripts/test_run_checks.py` -> 9 passed
- official backend workflow-contract test file through native Windows Python -> 17 passed
- `make preflight` with parent `PYTHONUTF8` unset -> all 9 selected checks passed
- locked Windows backend environment on CPython 3.11.15: `test-preflight.sh` -> 0 failures
- full backend Pyright lane with the selected Windows interpreter -> 0 errors
- `python -m black --line-length 120 --skip-string-normalization --check .github/scripts/preflight_runner.py .github/scripts/test_pr_preflight.py`
- `python -m py_compile .github/scripts/preflight_runner.py .github/scripts/test_pr_preflight.py`
- `bash -n scripts/pre-push-singleflight scripts/pre-push`
- `git diff --check`
- official backend workflow-contract test file on CPython 3.11.15 -> 17 passed
- real Windows `git push` hook -> all 9 PR preflight checks and the complete backend type-check lane passed; the selected-unit CRLF failure is isolated in #9627
