### PR TITLE
test(backend): run changed-files through Git Bash on Windows

### DIFF
--- a/backend/tests/unit/test_changed_files_script.py
+++ b/backend/tests/unit/test_changed_files_script.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 import subprocess
 
@@ -7,6 +8,21 @@ CHANGED_FILES = ROOT / 'scripts/changed-files'
 
 def _git(repo: Path, *args: str) -> str:
     return subprocess.check_output(['git', *args], cwd=repo, text=True).strip()
+
+
+def _find_git_bash(git_exec_path: Path) -> Path:
+    for parent in git_exec_path.parents:
+        for relative_path in ('bin/bash.exe', 'usr/bin/bash.exe'):
+            candidate = parent / relative_path
+            if candidate.is_file():
+                return candidate
+    raise FileNotFoundError(f'Git Bash was not found above {git_exec_path}')
+
+
+def _bash() -> str:
+    if os.name != 'nt':
+        return 'bash'
+    return str(_find_git_bash(Path(_git(ROOT, '--exec-path'))))
 
 
 def _commit(repo: Path, message: str) -> str:
@@ -40,7 +56,7 @@ def test_changed_files_reports_delete_rename_and_file_type_change(tmp_path):
     changed_type.symlink_to('target.py')
     head = _commit(repo, 'move delete and change type')
 
-    changed = set(subprocess.check_output([str(CHANGED_FILES), base, head], cwd=repo, text=True).splitlines())
+    changed = set(subprocess.check_output([_bash(), str(CHANGED_FILES), base, head], cwd=repo, text=True).splitlines())
 
     assert changed == {
         'backend/routers/deleted.py',
@@ -58,3 +74,14 @@ def test_changed_files_helper_is_not_hidden_by_repository_ignore_rules():
     )
 
     assert result.returncode == 1
+
+
+def test_git_bash_resolution_uses_the_git_installation(tmp_path):
+    git_root = tmp_path / 'Git'
+    git_exec_path = git_root / 'mingw64/libexec/git-core'
+    git_exec_path.mkdir(parents=True)
+    git_bash = git_root / 'bin/bash.exe'
+    git_bash.parent.mkdir()
+    git_bash.touch()
+
+    assert _find_git_bash(git_exec_path) == git_bash


### PR DESCRIPTION
## Summary

- launch the `scripts/changed-files` contract test through Bash instead of asking Windows `CreateProcess` to execute an extensionless script
- on Windows, resolve `bash.exe` from the active Git for Windows installation rather than accepting a PATH-shadowing WSL executable
- add a platform-independent resolver guard so Linux CI also protects the Windows launcher contract

Fixes #9617.

## Root cause

The behavioral test passed `scripts/changed-files` directly to `subprocess.check_output()`. POSIX follows the script shebang, but native Windows `CreateProcess` rejects the extensionless Bash file with `WinError 193` before any assertion runs.

Using a bare `bash` argv is not sufficient on Windows: this machine exposes `C:\Windows\System32\bash.exe` ahead of Git Bash, which starts WSL and fails when WSL virtualization is unavailable.

## Durable guard

- POSIX keeps the normal `bash` lookup.
- Windows asks `git --exec-path` for the active Git installation, searches that installation's parent layout for `bin/bash.exe` or `usr/bin/bash.exe`, and passes the resolved executable as a structured argv element.
- The test does not use `shell=True`, a command string, or a hard-coded installation path.
- A hermetic path-layout test verifies that resolver behavior on every CI platform.

## Real-path exercise

- On the old code, native Windows Python 3.11 reproduced `OSError: [WinError 193]` at the direct script launch.
- On the fixed code, native Windows Python selected `C:\Program Files\Git\bin\bash.exe` and exercised the real `scripts/changed-files` behavior successfully.
- Launching the same pytest file from Git Bash into native Windows Python also passed.

## Product invariants affected

None. This changes a repository test harness only.

## Validation

- `python -m pytest backend/tests/unit/test_changed_files_script.py -q` -> 3 passed
- `python -m pytest backend/tests/unit/test_changed_files_script.py backend/tests/unit/test_workflow_contracts.py -q` -> 20 passed
- `python -m black --check --line-length 120 --skip-string-normalization backend/tests/unit/test_changed_files_script.py`
- `python -m py_compile backend/tests/unit/test_changed_files_script.py`
- `git diff --check`
- remaining selected manifest checks (`lifecycle`, filename policy, import purity, module isolation, workflow contracts) -> passed when run directly
- Windows `make preflight` reached the independently broken direct Bash launch in `backend-route-policy-baseline`; that local preflight blocker is tracked separately in #9619


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9620?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

