### PR TITLE
fix(windows): select the Rewind capture source by primary display id (#9607)

### DIFF
--- a/desktop/windows/src/main/rewind/sourceId.test.ts
+++ b/desktop/windows/src/main/rewind/sourceId.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+const getSources = vi.fn()
+const getPrimaryDisplay = vi.fn()
+const on = vi.fn()
+
+vi.mock('electron', () => ({
+  desktopCapturer: { getSources: (...args: unknown[]) => getSources(...args) },
+  screen: {
+    getPrimaryDisplay: () => getPrimaryDisplay(),
+    on: (...args: unknown[]) => on(...args)
+  }
+}))
+
+// The module caches at module scope, so each test gets a fresh copy.
+async function loadModule(): Promise<typeof import('./sourceId')> {
+  vi.resetModules()
+  return import('./sourceId')
+}
+
+const source = (id: string, displayId: string): { id: string; display_id: string } => ({
+  id,
+  display_id: displayId
+})
+
+describe('getPrimarySourceId', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    getPrimaryDisplay.mockReturnValue({ id: 2 })
+  })
+
+  it('picks the source whose display_id is the primary display, not the first one', async () => {
+    getSources.mockResolvedValue([source('screen:1:0', '1'), source('screen:0:0', '2')])
+    const { getPrimarySourceId } = await loadModule()
+    expect(await getPrimarySourceId()).toBe('screen:0:0')
+  })
+
+  it('falls back to the first source when no display_id matches', async () => {
+    getSources.mockResolvedValue([source('screen:1:0', '7'), source('screen:0:0', '8')])
+    const { getPrimarySourceId } = await loadModule()
+    expect(await getPrimarySourceId()).toBe('screen:1:0')
+  })
+
+  it('falls back to the first source when Electron reports no display ids', async () => {
+    getSources.mockResolvedValue([source('screen:1:0', ''), source('screen:0:0', '')])
+    const { getPrimarySourceId } = await loadModule()
+    expect(await getPrimarySourceId()).toBe('screen:1:0')
+  })
+
+  it('returns null when there are no screen sources', async () => {
+    getSources.mockResolvedValue([])
+    const { getPrimarySourceId } = await loadModule()
+    expect(await getPrimarySourceId()).toBeNull()
+  })
+
+  it('caches the id and dedupes concurrent callers into one getSources() call', async () => {
+    getSources.mockResolvedValue([source('screen:0:0', '2')])
+    const { getPrimarySourceId } = await loadModule()
+
+    const [a, b] = await Promise.all([getPrimarySourceId(), getPrimarySourceId()])
+    const c = await getPrimarySourceId()
+
+    expect([a, b, c]).toEqual(['screen:0:0', 'screen:0:0', 'screen:0:0'])
+    expect(getSources).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('prewarmPrimarySourceId', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    getPrimaryDisplay.mockReturnValue({ id: 2 })
+  })
+
+  it('re-resolves the primary source after the display layout changes', async () => {
+    getSources.mockResolvedValue([source('screen:0:0', '2')])
+    const { prewarmPrimarySourceId, getPrimarySourceId } = await loadModule()
+
+    prewarmPrimarySourceId()
+    expect(await getPrimarySourceId()).toBe('screen:0:0')
+
+    // The user makes the other monitor primary: same sources, new primary display.
+    getSources.mockResolvedValue([source('screen:0:0', '2'), source('screen:1:0', '3')])
+    getPrimaryDisplay.mockReturnValue({ id: 3 })
+
+    const invalidate = on.mock.calls.find(([event]) => event === 'display-metrics-changed')?.[1] as
+      (() => void) | undefined
+    expect(invalidate).toBeTypeOf('function')
+    invalidate?.()
+
+    expect(await getPrimarySourceId()).toBe('screen:1:0')
+  })
+})

--- a/desktop/windows/src/main/rewind/sourceId.ts
+++ b/desktop/windows/src/main/rewind/sourceId.ts
@@ -15,7 +15,13 @@ async function fetchPrimarySourceId(): Promise<string | null> {
     types: ['screen'],
     thumbnailSize: { width: 0, height: 0 } // ids only — no screen bitmap
   })
-  return sources[0]?.id ?? null
+  // A source's `id` is a sequential screen number, and getSources() makes no
+  // ordering guarantee — so sources[0] is not necessarily the primary display.
+  // `display_id` is the documented link to the Screen API; match on it and only
+  // fall back to the first source when Electron doesn't report one.
+  const primaryDisplayId = String(screen.getPrimaryDisplay().id)
+  const primary = sources.find((s) => s.display_id === primaryDisplayId)
+  return primary?.id ?? sources[0]?.id ?? null
 }
 
 /** Cached primary-screen source id; computes it (slowly) once, then reuses it. */


### PR DESCRIPTION
Fixes #9607.

## Bug
`desktop/windows/src/main/rewind/sourceId.ts` treated `desktopCapturer.getSources({ types: ['screen'] })[0]` as the primary display. `getSources()` makes no ordering guarantee and a source's `id` is just a sequential screen number, so on a multi-display Windows setup a reordered source list makes **Rewind capture and the `screen:readNow` fallback read a secondary monitor** while the code and UI describe the source as primary — the user's Rewind timeline and "what's on screen" answers come from the wrong monitor.

## Root cause
Display identity was inferred from list position instead of being read from the Screen API. Electron exposes the supported mapping: `DesktopCapturerSource.display_id` corresponds to `screen.getPrimaryDisplay().id` ([docs](https://www.electronjs.org/docs/latest/api/structures/desktop-capturer-source)).

## Fix
- Match `source.display_id` against `String(screen.getPrimaryDisplay().id)`.
- Fall back to the first source only when Electron reports no matching display id (older/edge platforms where `display_id` is empty).
- Single-flight cache and `display-added`/`display-removed`/`display-metrics-changed` invalidation are unchanged, so a primary-display switch now re-resolves to the new primary.

7 lines of source; no change to capture cadence, image retention, OCR, privacy filters, or upload behavior.

## Verification
- New `src/main/rewind/sourceId.test.ts` — 6 tests over the real module with mocked Electron sources: primary-not-first, no matching display id, empty `display_id`, no sources, cache/single-flight (one `getSources()` call), and re-resolution after display-change invalidation.
- **Regression proof:** the two bug-specific tests (`picks the source whose display_id is the primary display`, `re-resolves the primary source after the display layout changes`) **fail on the pre-fix code** and pass on the fix. Verified by reverting `sourceId.ts` and re-running: `2 failed | 4 passed` → with the fix `6 passed`.
- `npx vitest run` (full windows suite): **556 passed**, 3 skipped.
- `npm run typecheck` clean; `npx eslint` on the touched files clean; `make preflight` 8/8 checks passed.
- **UNVERIFIED on real hardware:** this run has no Windows machine and no multi-monitor rig, so the physical multi-display path was not exercised end-to-end. Coverage is the deterministic mocked-source path the issue itself prescribes.

🤖 automated by hourly watchdog; opened for review, not merged.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9621?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

