### PR TITLE
fix(backend): make route-policy preflight portable on Windows

### DIFF
--- a/backend/scripts/check_route_policy_baseline.py
+++ b/backend/scripts/check_route_policy_baseline.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import os
 import subprocess
 import tempfile
 from pathlib import Path
@@ -11,6 +12,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[2]
 BACKEND = ROOT / 'backend'
 BASELINE_PATH = 'backend/route_policy_legacy_missing_routes.txt'
+GIT_LAYOUT_PARENT_LIMIT = 3
 
 
 def parse_args() -> argparse.Namespace:
@@ -20,6 +22,38 @@ def parse_args() -> argparse.Namespace:
         help='Git ref whose legacy missing-route baseline is the comparison boundary.',
     )
     return parser.parse_args()
+
+
+def find_git_bash(git_exec_path: Path) -> Path:
+    for parent in tuple(git_exec_path.parents)[:GIT_LAYOUT_PARENT_LIMIT]:
+        for relative_path in ('bin/bash.exe', 'usr/bin/bash.exe'):
+            candidate = parent / relative_path
+            if candidate.is_file():
+                return candidate
+    raise FileNotFoundError(f'Git Bash was not found above {git_exec_path}')
+
+
+def bash_command(
+    *args: str | Path,
+    platform_name: str | None = None,
+    git_exec_path: Path | None = None,
+) -> list[str]:
+    if (platform_name or os.name) == 'nt':
+        if git_exec_path is None:
+            git_environment = os.environ.copy()
+            git_environment.pop('GIT_EXEC_PATH', None)
+            git_exec_path = Path(
+                subprocess.check_output(
+                    ['git', '--exec-path'],
+                    cwd=ROOT,
+                    env=git_environment,
+                    text=True,
+                ).strip()
+            )
+        executable = str(find_git_bash(git_exec_path))
+    else:
+        executable = 'bash'
+    return [executable, *(str(arg) for arg in args)]
 
 
 def base_baseline(ref: str, destination: Path) -> Path:
@@ -38,7 +72,7 @@ def base_baseline(ref: str, destination: Path) -> Path:
 
 
 def run_inventory(baseline: Path) -> int:
-    command = [
+    command = bash_command(
         'scripts/openapi_runner.sh',
         'scripts/route_policy_inventory.py',
         '--manifest',
@@ -46,7 +80,7 @@ def run_inventory(baseline: Path) -> int:
         '--enforce-missing-baseline',
         '--base-missing-baseline',
         str(baseline),
-    ]
+    )
     return subprocess.run(command, cwd=BACKEND, check=False).returncode
 
 

--- a/backend/scripts/openapi_runner.sh
+++ b/backend/scripts/openapi_runner.sh
@@ -3,10 +3,22 @@ set -euo pipefail
 
 BACKEND_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 REQUIREMENTS="$BACKEND_DIR/openapi-requirements.txt"
-VENV_DIR="${OPENAPI_RUNNER_VENV:-$BACKEND_DIR/.openapi-venv}"
+DEFAULT_VENV_DIR="$BACKEND_DIR/.openapi-venv"
+VENV_DIR="${OPENAPI_RUNNER_VENV:-$DEFAULT_VENV_DIR}"
 PYTHON_VERSION="$(cat "$BACKEND_DIR/.python-version")"
 PYTHON_MINOR="${PYTHON_VERSION%.*}"
 PYTHON_BIN="${OPENAPI_RUNNER_PYTHON:-python$PYTHON_MINOR}"
+
+find_venv_python() {
+  local candidate
+  for candidate in "$VENV_DIR/bin/python" "$VENV_DIR/Scripts/python.exe"; do
+    if [ -x "$candidate" ]; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
+  return 1
+}
 
 if [ ! -f "$REQUIREMENTS" ]; then
   echo "FAIL: missing OpenAPI runner requirements at $REQUIREMENTS" >&2
@@ -22,24 +34,36 @@ if ! command -v "$PYTHON_BIN" >/dev/null 2>&1; then
   PYTHON_BIN=python3
 fi
 
-if [ -x "$VENV_DIR/bin/python" ]; then
-  VENV_PYTHON_VERSION="$("$VENV_DIR/bin/python" -c 'import sys; print(".".join(map(str, sys.version_info[:2])))')"
+VENV_PYTHON="$(find_venv_python || true)"
+if [ -n "$VENV_PYTHON" ]; then
+  VENV_PYTHON_VERSION="$("$VENV_PYTHON" -c 'import sys; print(".".join(map(str, sys.version_info[:2])))')"
   if [ "$VENV_PYTHON_VERSION" != "$PYTHON_MINOR" ]; then
+    if [ "$VENV_DIR" != "$DEFAULT_VENV_DIR" ]; then
+      echo "FAIL: custom OpenAPI runner venv at $VENV_DIR uses Python $VENV_PYTHON_VERSION; expected $PYTHON_MINOR. Remove or replace it explicitly." >&2
+      exit 1
+    fi
     rm -rf "$VENV_DIR"
+    VENV_PYTHON=""
   fi
 fi
 
-if [ ! -x "$VENV_DIR/bin/python" ]; then
+if [ -z "$VENV_PYTHON" ]; then
   "$PYTHON_BIN" -m venv "$VENV_DIR"
+  VENV_PYTHON="$(find_venv_python || true)"
 fi
 
-uv pip sync --python "$VENV_DIR/bin/python" "$REQUIREMENTS"
+if [ -z "$VENV_PYTHON" ]; then
+  echo "FAIL: OpenAPI runner venv has no supported Python executable under $VENV_DIR" >&2
+  exit 1
+fi
 
-"$VENV_DIR/bin/python" - <<'PY'
+uv pip sync --python "$VENV_PYTHON" "$REQUIREMENTS"
+
+"$VENV_PYTHON" - <<'PY'
 import tiktoken
 
 tiktoken.encoding_for_model('gpt-4')
 PY
 
 cd "$BACKEND_DIR"
-exec "$VENV_DIR/bin/python" "$@"
+exec "$VENV_PYTHON" "$@"

--- a/backend/tests/unit/test_route_policy_preflight.py
+++ b/backend/tests/unit/test_route_policy_preflight.py
@@ -1,0 +1,150 @@
+import os
+from pathlib import Path
+import subprocess
+
+import pytest
+
+from scripts import check_route_policy_baseline as route_policy
+
+ROOT = Path(__file__).resolve().parents[3]
+OPENAPI_RUNNER = ROOT / 'backend/scripts/openapi_runner.sh'
+
+
+def _bash_path(path: Path) -> str:
+    if os.name != 'nt':
+        return path.as_posix()
+    return subprocess.check_output(
+        route_policy.bash_command('-lc', 'cygpath -u "$1"', 'bash', path),
+        text=True,
+    ).strip()
+
+
+def test_windows_bash_command_uses_active_git_installation(tmp_path):
+    git_root = tmp_path / 'Git'
+    git_exec_path = git_root / 'mingw64/libexec/git-core'
+    git_exec_path.mkdir(parents=True)
+    git_bash = git_root / 'bin/bash.exe'
+    git_bash.parent.mkdir()
+    git_bash.touch()
+
+    command = route_policy.bash_command(
+        'scripts/probe.sh',
+        'argument',
+        platform_name='nt',
+        git_exec_path=git_exec_path,
+    )
+
+    assert command == [str(git_bash), 'scripts/probe.sh', 'argument']
+
+
+def test_windows_bash_command_ignores_git_exec_path_override(tmp_path, monkeypatch):
+    git_root = tmp_path / 'Git'
+    git_exec_path = git_root / 'mingw64/libexec/git-core'
+    git_exec_path.mkdir(parents=True)
+    git_bash = git_root / 'bin/bash.exe'
+    git_bash.parent.mkdir()
+    git_bash.touch()
+    monkeypatch.setenv('GIT_EXEC_PATH', str(tmp_path / 'untrusted'))
+
+    def fake_check_output(command, **kwargs):
+        assert command == ['git', '--exec-path']
+        assert 'GIT_EXEC_PATH' not in kwargs['env']
+        return str(git_exec_path)
+
+    monkeypatch.setattr(route_policy.subprocess, 'check_output', fake_check_output)
+
+    assert route_policy.bash_command('probe.sh', platform_name='nt') == [str(git_bash), 'probe.sh']
+
+
+def test_git_bash_search_does_not_escape_git_installation(tmp_path):
+    git_exec_path = tmp_path / 'nested/Git/mingw64/libexec/git-core'
+    git_exec_path.mkdir(parents=True)
+    unrelated_bash = tmp_path / 'bin/bash.exe'
+    unrelated_bash.parent.mkdir()
+    unrelated_bash.touch()
+
+    with pytest.raises(FileNotFoundError):
+        route_policy.find_git_bash(git_exec_path)
+
+
+def test_openapi_runner_accepts_windows_venv_layout(tmp_path):
+    venv_dir = tmp_path / 'venv'
+    venv_python = venv_dir / 'Scripts/python.exe'
+    venv_python.parent.mkdir(parents=True)
+    venv_python.write_text(
+        '#!/usr/bin/env bash\n'
+        'case "${1:-}" in\n'
+        "  -c) printf '3.11\\n' ;;\n"
+        '  -) cat >/dev/null ;;\n'
+        "  *) printf 'ok' > \"$2\" ;;\n"
+        'esac\n',
+        encoding='utf-8',
+    )
+    venv_python.chmod(0o755)
+
+    fake_bin = tmp_path / 'bin'
+    fake_bin.mkdir()
+    fake_uv = fake_bin / 'uv'
+    fake_uv.write_text('#!/usr/bin/env bash\nexit 0\n', encoding='utf-8')
+    fake_uv.chmod(0o755)
+
+    marker = tmp_path / 'probe-ran.txt'
+    env = {
+        **os.environ,
+        'OPENAPI_RUNNER_VENV': _bash_path(venv_dir),
+        'PATH': (
+            f'{_bash_path(fake_bin)}:/usr/bin:/bin'
+            if os.name == 'nt'
+            else f'{fake_bin}{os.pathsep}{os.environ["PATH"]}'
+        ),
+    }
+
+    result = subprocess.run(
+        route_policy.bash_command(OPENAPI_RUNNER, 'probe.py', _bash_path(marker)),
+        cwd=ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert marker.read_text(encoding='utf-8') == 'ok'
+
+
+def test_openapi_runner_does_not_delete_mismatched_custom_venv(tmp_path):
+    venv_dir = tmp_path / 'venv'
+    venv_python = venv_dir / 'Scripts/python.exe'
+    venv_python.parent.mkdir(parents=True)
+    venv_python.write_text("#!/usr/bin/env bash\nprintf '3.10\\n'\n", encoding='utf-8')
+    venv_python.chmod(0o755)
+    sentinel = venv_dir / 'keep.txt'
+    sentinel.write_text('keep', encoding='utf-8')
+
+    fake_bin = tmp_path / 'bin'
+    fake_bin.mkdir()
+    fake_uv = fake_bin / 'uv'
+    fake_uv.write_text('#!/usr/bin/env bash\nexit 0\n', encoding='utf-8')
+    fake_uv.chmod(0o755)
+    env = {
+        **os.environ,
+        'OPENAPI_RUNNER_VENV': _bash_path(venv_dir),
+        'PATH': (
+            f'{_bash_path(fake_bin)}:/usr/bin:/bin'
+            if os.name == 'nt'
+            else f'{fake_bin}{os.pathsep}{os.environ["PATH"]}'
+        ),
+    }
+
+    result = subprocess.run(
+        route_policy.bash_command(OPENAPI_RUNNER, 'probe.py'),
+        cwd=ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 1
+    assert 'custom OpenAPI runner venv' in result.stderr
+    assert sentinel.read_text(encoding='utf-8') == 'keep'


### PR DESCRIPTION
## Summary

- launches the route-policy OpenAPI runner through Bash instead of passing an extensionless shell script to Windows `CreateProcess`
- resolves Git Bash from the active Git for Windows installation, avoiding the WSL `bash.exe` alias on native Windows
- accepts both POSIX `bin/python` and Windows `Scripts/python.exe` virtual-environment layouts in the OpenAPI runner
- refuses to delete a custom runner venv when its Python version is incompatible
- adds regression coverage for interpreter discovery and the native Windows venv layout

Fixes #9619.

## Root cause

`check_route_policy_baseline.py` passed `scripts/openapi_runner.sh` directly to `subprocess.run()`. POSIX resolves the script through its shebang, but native Windows returns `FileNotFoundError: [WinError 2]` before the route inventory starts.

Passing a bare `bash` name is not sufficient on Windows because native process lookup can select `C:\Windows\System32\bash.exe` (the WSL launcher) instead of the Git Bash interpreter used by the repository tooling. Once the script is launched with Git Bash, its hard-coded `<venv>/bin/python` path exposes the second assumption: native Windows venvs create `<venv>/Scripts/python.exe`.

## Durable guard

- The Python checker builds a structured argv and discovers `bin/bash.exe` or `usr/bin/bash.exe` within the active Git installation layout. It ignores inherited `GIT_EXEC_PATH`, bounds the parent search, and does not use `shell=True` or command-string interpolation.
- POSIX behavior remains a normal `bash` invocation.
- The shell runner resolves one venv Python path and uses it consistently for version validation, dependency sync, cache prewarming, and the final command.
- A mismatched repository-default venv remains an automatically replaceable cache; a mismatched custom override fails with an actionable message and is left intact.
- The regression test creates an isolated `Scripts/python.exe` layout and verifies the requested OpenAPI command actually runs.

## Real-path exercise

On Windows Python 3.11, the updated checker created and used a native `Scripts/python.exe` OpenAPI venv, synchronized the pinned runner dependencies, generated the real route inventory, and completed with:

```text
base_baseline_missing_entries: 477
baseline_additions: 0
current_missing_manifest_entries: 477
new_missing_manifest_entries: 0
stale_missing_baseline_entries: 0
route policy missing-route baseline is current
```

## Product invariants affected

None. This changes contributor preflight tooling only and does not affect application runtime or route policy contents.

## Validation

- old-code real path -> `FileNotFoundError: [WinError 2]` while launching `scripts/openapi_runner.sh`
- old-code regression tests -> 5 failed because the Bash command builder, bounded interpreter discovery, and Windows venv support were absent
- `python -m pytest backend/tests/unit/test_route_policy_preflight.py -q` -> 5 passed
- `PYTHONUTF8=1 BACKEND_UNIT_TEST_FILE_LIST=<focused-list> BACKEND_PYTEST_WORKERS=1 bash backend/test.sh` -> 22 passed
- `python -m pytest backend/tests/unit/test_route_policy_preflight.py backend/tests/unit/test_workflow_contracts.py -q` -> 22 passed
- `python .github/scripts/test_run_checks.py` -> 9 passed
- `make preflight` on current `origin/main` -> all 13 selected checks passed, including the real route-policy baseline path
- `python -m black --line-length 120 --skip-string-normalization --check backend/scripts/check_route_policy_baseline.py backend/tests/unit/test_route_policy_preflight.py`
- `python -m py_compile backend/scripts/check_route_policy_baseline.py backend/tests/unit/test_route_policy_preflight.py`
- `bash -n backend/scripts/openapi_runner.sh`
- `git diff --check`
- real Windows `check_route_policy_baseline.py --base-ref origin/main` -> baseline current, no additions or stale entries


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9624?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

