### PR TITLE
fix(backend): make workflow contract reads UTF-8 on Windows

### DIFF
--- a/backend/scripts/check_workflow_contracts.py
+++ b/backend/scripts/check_workflow_contracts.py
@@ -16,7 +16,7 @@ CONTRACTS_REL_PATH = "backend/testing/workflow_contracts.json"
 
 
 def load_contracts() -> dict[str, Any]:
-    return json.loads(CONTRACTS_PATH.read_text())
+    return json.loads(CONTRACTS_PATH.read_text(encoding="utf-8"))
 
 
 def normalize_path(path: str) -> str:
@@ -82,7 +82,7 @@ def check_no_large_tuple_results(contracts: dict[str, Any], changed_paths: list[
     for rel_path in sorted(workflow_sources(contracts, changed_paths, check_name="no_large_tuple_results")):
         source_path = REPO_DIR / rel_path
         try:
-            tree = ast.parse(source_path.read_text())
+            tree = ast.parse(source_path.read_text(encoding="utf-8"))
         except SyntaxError as exc:
             errors.append(f"{rel_path}:{exc.lineno}: cannot parse source: {exc.msg}")
             continue
@@ -106,7 +106,7 @@ def main() -> int:
 
     changed_paths = None
     if args.changed_files:
-        changed_paths = Path(args.changed_files).read_text().splitlines()
+        changed_paths = Path(args.changed_files).read_text(encoding="utf-8").splitlines()
 
     contracts = load_contracts()
     errors = check_no_large_tuple_results(contracts, changed_paths)

--- a/backend/scripts/select_backend_unit_tests.py
+++ b/backend/scripts/select_backend_unit_tests.py
@@ -289,7 +289,7 @@ def is_memory_policy_core_path(path: str) -> bool:
 def load_workflow_contracts() -> List[Dict[str, Any]]:
     if not WORKFLOW_CONTRACTS_PATH.exists():
         return []
-    data: object = json.loads(WORKFLOW_CONTRACTS_PATH.read_text())
+    data: object = json.loads(WORKFLOW_CONTRACTS_PATH.read_text(encoding='utf-8'))
     if not isinstance(data, dict):
         return []
     typed_data: Dict[str, Any] = cast(Dict[str, Any], data)
@@ -378,7 +378,7 @@ def match_tests(all_tests: list[str], test_globs: tuple[str, ...]) -> set[str]:
 
 
 def read_lines(path: Path) -> list[str]:
-    return [line.strip() for line in path.read_text().splitlines() if line.strip()]
+    return [line.strip() for line in path.read_text(encoding='utf-8').splitlines() if line.strip()]
 
 
 def existing_tests(paths: list[str], all_tests: list[str]) -> list[str]:

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -4,6 +4,10 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "$ROOT_DIR"
 
+# Repository sources are UTF-8. Native Windows Python otherwise inherits the
+# system code page, which makes source-reading tests locale-dependent.
+export PYTHONUTF8="${PYTHONUTF8:-1}"
+
 # Git exports repository-local variables while invoking hooks. They must not
 # leak into pytest: tests that create temporary repositories would otherwise
 # keep operating on the outer worktree. The runner is already anchored at the

--- a/backend/tests/unit/test_workflow_contracts.py
+++ b/backend/tests/unit/test_workflow_contracts.py
@@ -157,8 +157,8 @@ def test_removed_test_forces_full_discovered_suite():
 
 
 def test_every_external_workflow_contract_source_triggers_backend_unit_workflow():
-    contracts = json.loads((BACKEND_DIR / "testing/workflow_contracts.json").read_text())
-    workflow_text = (BACKEND_DIR.parent / ".github/workflows/backend-unit-tests.yml").read_text()
+    contracts = json.loads((BACKEND_DIR / "testing/workflow_contracts.json").read_text(encoding="utf-8"))
+    workflow_text = (BACKEND_DIR.parent / ".github/workflows/backend-unit-tests.yml").read_text(encoding="utf-8")
 
     external_sources = {
         source
@@ -175,8 +175,16 @@ def test_every_external_workflow_contract_source_triggers_backend_unit_workflow(
     assert missing == set()
 
 
+def test_backend_test_runner_defaults_python_to_utf8():
+    runner = (BACKEND_DIR / "test.sh").read_text(encoding="utf-8")
+    utf8_export = 'export PYTHONUTF8="${PYTHONUTF8:-1}"'
+
+    assert utf8_export in runner
+    assert runner.index(utf8_export) < runner.index('PYTHON_BIN="${PYTHON:-}"')
+
+
 def test_pre_push_requires_backend_python_lazily():
-    pre_push = (BACKEND_DIR.parent / "scripts/pre-push").read_text()
+    pre_push = (BACKEND_DIR.parent / "scripts/pre-push").read_text(encoding="utf-8")
     setup_prefix = pre_push[: pre_push.index("run_step()")]
 
     assert "require_backend_python()" in setup_prefix
@@ -193,7 +201,7 @@ def test_pre_push_requires_backend_python_lazily():
 
 
 def test_pre_push_runs_each_named_check_phase_once():
-    pre_push = (BACKEND_DIR.parent / "scripts/pre-push").read_text()
+    pre_push = (BACKEND_DIR.parent / "scripts/pre-push").read_text(encoding="utf-8")
     check_calls = re.findall(r"^run_step (check_[A-Za-z0-9_]+)$", pre_push, flags=re.MULTILINE)
     duplicates = sorted({name for name in check_calls if check_calls.count(name) > 1})
 
@@ -202,14 +210,16 @@ def test_pre_push_runs_each_named_check_phase_once():
 
 def test_shared_change_detection_and_backend_isolation_are_ci_wired():
     repo = BACKEND_DIR.parent
-    detect_changes = (repo / ".github/actions/detect-changes/action.yml").read_text()
-    manifest = (repo / ".github/checks-manifest.yaml").read_text()
-    backend_checks = (repo / ".github/workflows/backend-checks.yml").read_text()
-    repo_checks = (repo / ".github/workflows/repo-checks.yml").read_text()
-    desktop_checks = (repo / ".github/workflows/desktop-checks.yml").read_text()
-    agent_proxy_auto_deploy = (repo / ".github/workflows/gcp_backend_agent_proxy_auto_deploy.yml").read_text()
-    swift_test_suites = (repo / "desktop/macos/scripts/swift-test-suites.sh").read_text()
-    pre_push = (repo / "scripts/pre-push").read_text()
+    detect_changes = (repo / ".github/actions/detect-changes/action.yml").read_text(encoding="utf-8")
+    manifest = (repo / ".github/checks-manifest.yaml").read_text(encoding="utf-8")
+    backend_checks = (repo / ".github/workflows/backend-checks.yml").read_text(encoding="utf-8")
+    repo_checks = (repo / ".github/workflows/repo-checks.yml").read_text(encoding="utf-8")
+    desktop_checks = (repo / ".github/workflows/desktop-checks.yml").read_text(encoding="utf-8")
+    agent_proxy_auto_deploy = (repo / ".github/workflows/gcp_backend_agent_proxy_auto_deploy.yml").read_text(
+        encoding="utf-8"
+    )
+    swift_test_suites = (repo / "desktop/macos/scripts/swift-test-suites.sh").read_text(encoding="utf-8")
+    pre_push = (repo / "scripts/pre-push").read_text(encoding="utf-8")
 
     assert 'FILES=$(scripts/changed-files "$DIFF_BASE"...HEAD)' in detect_changes
     assert "has_backend_isolation_gate" in detect_changes
@@ -237,7 +247,7 @@ def test_shared_change_detection_and_backend_isolation_are_ci_wired():
 
 
 def test_installed_pre_push_hook_falls_back_for_older_worktrees():
-    installer = (BACKEND_DIR.parent / "scripts/install-git-hooks.sh").read_text()
+    installer = (BACKEND_DIR.parent / "scripts/install-git-hooks.sh").read_text(encoding="utf-8")
 
     assert 'if [ -x "$ROOT/scripts/pre-push-singleflight" ]' in installer
     assert 'exec "$ROOT/scripts/pre-push" "$@"' in installer


### PR DESCRIPTION
## Summary

- gives every Python process started by `backend/test.sh` a deterministic UTF-8 default while preserving an explicit `PYTHONUTF8` override
- reads workflow contracts, changed-file lists, Python sources, and repository contract fixtures with an explicit UTF-8 encoding
- adds a contract test that keeps the runner's UTF-8 export ahead of its first Python selection/invocation

Fixes #9625.

## Root cause

Repository source and configuration files are UTF-8, but native Windows Python uses the system ANSI code page unless UTF-8 mode is selected. On a GBK system, the official backend runner reached existing `Path.read_text()` calls with `encoding='locale'` and failed before assertions when valid UTF-8 punctuation appeared in repository files.

The same workflow-contract helpers also relied on the process locale when called directly, so changing only the test runner would leave those CLI paths platform-dependent.

## Durable guard

- `backend/test.sh` exports `PYTHONUTF8=${PYTHONUTF8:-1}` before selecting or starting Python. Callers can still set `PYTHONUTF8=0` explicitly.
- Workflow-contract tooling specifies UTF-8 at each repository-text boundary instead of relying on ambient locale.
- The unit contract verifies both the export value and its placement before `PYTHON_BIN` setup.

## Real-path exercise

The official `backend/test.sh` path was run from Git Bash with native Windows Python 3.11 and `PYTHONUTF8` explicitly unset. Before the fix it produced four GBK `UnicodeDecodeError` failures; after the fix the same file completed 18/18 under the normal fast-unit timing guard.

## Product invariants affected

None. This changes backend contributor/test tooling only and does not affect application runtime behavior.

## Validation

- old-code official runner with `PYTHONUTF8` unset -> 4 failed, 13 passed; all failures were GBK decode errors
- updated official runner with `PYTHONUTF8` unset -> 18 passed
- native Windows `python -m pytest backend/tests/unit/test_workflow_contracts.py -q` with `PYTHONUTF8` unset -> 18 passed
- native Windows `python backend/scripts/check_workflow_contracts.py` with `PYTHONUTF8` unset -> pass
- native Windows `python backend/scripts/select_backend_unit_tests.py --all` with `PYTHONUTF8` unset -> 557 test files discovered
- `make preflight` with UTF-8 enabled -> first 8 selected checks passed, then current `main` hit the separate Windows shell-launch failure fixed by #9624
- remaining lifecycle, filename, import-purity, module-isolation, and workflow-contract checks -> passed when run directly with the same generated changed-file list
- route-policy inventory through the synced Windows OpenAPI venv -> baseline current (477 existing, 0 additions, 0 stale)
- `python -m black --line-length 120 --skip-string-normalization --check backend/scripts/check_workflow_contracts.py backend/scripts/select_backend_unit_tests.py backend/tests/unit/test_workflow_contracts.py`
- `python -m py_compile backend/scripts/check_workflow_contracts.py backend/scripts/select_backend_unit_tests.py backend/tests/unit/test_workflow_contracts.py`
- `bash -n backend/test.sh`
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9626?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

