### PR TITLE
fix(backend): never send the 'multi' STT sentinel as an NLLB translation target (#9623)

### DIFF
--- a/backend/tests/unit/test_transcribe_decisions.py
+++ b/backend/tests/unit/test_transcribe_decisions.py
@@ -108,6 +108,32 @@ def test_translation_language_gating():
     )
 
 
+def test_translation_language_rejects_sentinel_preferences():
+    # Legacy Firestore users/{uid}.language rows hold the STT sentinel itself; sending it
+    # to NLLB as a target is always an unsupported_target 400 + a Google fallback (#9623).
+    for sentinel in ('multi', 'auto'):
+        assert (
+            select_translation_language(
+                single_language_mode=False,
+                stt_language='multi',
+                language='multi',
+                user_language_preference=sentinel,
+            )
+            is None
+        )
+
+    # An un-normalized 'auto' request language is a sentinel too, never a target.
+    assert (
+        select_translation_language(
+            single_language_mode=False,
+            stt_language='multi',
+            language='auto',
+            user_language_preference='fr',
+        )
+        is None
+    )
+
+
 def test_effective_conversation_timeout_pins_current_quirks():
     assert effective_conversation_timeout(30, is_multi_channel=False) == 120
     assert effective_conversation_timeout(120, is_multi_channel=False) == 120

--- a/backend/utils/transcribe_decisions.py
+++ b/backend/utils/transcribe_decisions.py
@@ -82,6 +82,15 @@ def normalize_language(language: str) -> str:
     return 'multi' if language == 'auto' else language
 
 
+# STT sentinels meaning "detect the language" — not BCP47 codes, so they can never
+# be a translation target (NLLB rejects them as unsupported_target).
+LANGUAGE_SENTINELS = frozenset({'multi', 'auto'})
+
+
+def is_translation_target(language: str) -> bool:
+    return bool(language) and language not in LANGUAGE_SENTINELS
+
+
 def should_force_single_language(onboarding_mode: bool, single_language_mode: bool) -> bool:
     if onboarding_mode:
         return True
@@ -99,9 +108,9 @@ def select_translation_language(
         return None
     if stt_language == 'multi':
         if language == 'multi':
-            if user_language_preference:
+            if is_translation_target(user_language_preference):
                 return user_language_preference
-        else:
+        elif is_translation_target(language):
             return language
     return None
 


### PR DESCRIPTION
Fixes #9623.

## Bug
~3,952 NLLB translation requests/day arrive with `target_lang="multi"`. NLLB correctly rejects them (`unsupported_target`, HTTP 400) because `multi` is not a BCP47 code, and every one of them falls back to **paid Google Translate** — ~5.5% of the daily Google fallback budget, burning money for zero user benefit.

## Root cause
`multi` is the STT sentinel for "detect the language", not a language. `select_translation_language()` (`backend/utils/transcribe_decisions.py`) treated *any* non-empty `users/{uid}.language` as a valid translation target:

```python
if language == 'multi':
    if user_language_preference:      # <-- 'multi' is truthy
        return user_language_preference
```

Affected users have the sentinel literally stored in Firestore (legacy app versions / never completed language selection), so the connect-time projection built a `TranslationCoordinator` with `target_language='multi'` → NLLB 400 → Google fallback, on every session.

## Fix
Gate the target on a single predicate at the decision boundary — a sentinel (`multi`/`auto`) means no language was ever chosen, so there is nothing to translate into:

```python
LANGUAGE_SENTINELS = frozenset({'multi', 'auto'})

def is_translation_target(language: str) -> bool:
    return bool(language) and language not in LANGUAGE_SENTINELS
```

This repairs **existing** bad Firestore rows at the point of use — no data migration needed. Users who never picked a language simply get no translation (correct: there is no target), and users with a real preference (`es`, `fr`, …) are untouched.

Closing the class, not the line: the sentinel-as-BCP47-target confusion is now impossible to reintroduce at this boundary, since both the stored preference and the request language go through the same predicate.

## Verification
Exercised `project_listen_connect_decisions()` — the exact function `/v4/listen` calls at connect to pick the NLLB target — against the prod state from the issue (app sends `language='multi'`, Firestore holds the sentinel):

| `users/{uid}.language` | before (main) | after |
|---|---|---|
| `'multi'` | `nllb_target='multi'` → **NLLB 400 → Google fallback** | `None` → no translation |
| `'auto'` | `nllb_target='auto'` → **NLLB 400 → Google fallback** | `None` → no translation |
| `'es'` | `'es'` → translate | `'es'` → translate (unchanged) |
| `''` | `None` | `None` (unchanged) |

Regression test `test_translation_language_rejects_sentinel_preferences` **fails on pre-fix code** with exactly the prod symptom (`AssertionError: assert 'multi' is None`) and passes after.

```
pytest tests/unit/test_transcribe_decisions.py tests/unit/test_listen_session_bootstrap.py
24 passed in 1.37s
```

## Deliberately not in this PR
`PATCH /v1/users/language` (`routers/users.py:766`) still accepts any string with no BCP47 validation. Adding validation there is a separate, riskier change (it can start 400-ing live clients, and it would not fix the already-corrupted rows this PR handles). Tracked in #9623; the read-path guard here is what stops the daily fallbacks.

🤖 automated by hourly watchdog; opened for review, not merged.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9628?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

