### PR TITLE
fix(backend): emit LF selector artifacts on Windows

### DIFF
--- a/backend/scripts/select_backend_unit_tests.py
+++ b/backend/scripts/select_backend_unit_tests.py
@@ -414,11 +414,11 @@ def main() -> None:
     if output:
         output += '\n'
     if args.output:
-        args.output.write_text(output)
+        args.output.write_text(output, encoding='utf-8', newline='\n')
     else:
         print(output, end='')
     if args.reason_output:
-        args.reason_output.write_text(reason + '\n')
+        args.reason_output.write_text(reason + '\n', encoding='utf-8', newline='\n')
 
 
 if __name__ == '__main__':

--- a/backend/tests/unit/test_backend_unit_selector_output.py
+++ b/backend/tests/unit/test_backend_unit_selector_output.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+import subprocess
+import sys
+
+BACKEND_DIR = Path(__file__).resolve().parents[2]
+SELECTOR = BACKEND_DIR / 'scripts' / 'select_backend_unit_tests.py'
+SELECTED_TEST = 'tests/unit/test_workflow_contracts.py'
+
+
+def test_selector_artifacts_use_lf_on_every_platform(tmp_path: Path) -> None:
+    input_list = tmp_path / 'input.txt'
+    selected_list = tmp_path / 'selected.txt'
+    reason_file = tmp_path / 'reason.txt'
+    input_list.write_bytes(f'{SELECTED_TEST}\r\n'.encode('utf-8'))
+
+    subprocess.run(
+        [
+            sys.executable,
+            str(SELECTOR),
+            '--from-test-list',
+            str(input_list),
+            '--output',
+            str(selected_list),
+            '--reason-output',
+            str(reason_file),
+        ],
+        cwd=BACKEND_DIR,
+        check=True,
+    )
+
+    assert selected_list.read_bytes() == f'{SELECTED_TEST}\n'.encode('utf-8')
+    assert reason_file.read_bytes() == b'using provided backend unit test list\n'


### PR DESCRIPTION
## Summary

- writes backend selector and reason artifacts as UTF-8 with deterministic LF line endings on every platform
- adds a subprocess regression that feeds the selector a CRLF input list and verifies both output artifacts byte-for-byte

Fixes #9627.

## Root cause

`backend/scripts/select_backend_unit_tests.py` built LF-delimited strings but passed them to `Path.write_text()` without an explicit newline policy. Native Windows Python translated those `\n` characters to CRLF. The generated test list is consumed by `backend/test.sh` under Git Bash with `read -r`, which preserved the trailing carriage return and passed nonexistent paths such as `tests/unit/test_workflow_contracts.py\r` to pytest.

This was reproduced through the real Windows pre-push path in #9618: selector discovery succeeded, but both selected test files failed with pytest status 4 because their generated names retained `\r`.

## Durable guard

- Both selector artifacts now specify `encoding='utf-8'` and `newline='\n'` at the write boundary.
- The regression launches the production selector with native Python, accepts a CRLF input artifact, and compares the selected and reason output bytes exactly. It fails against the old implementation on Windows.

## Real-path exercise

- Re-ran the selector and backend runner under native Windows CPython 3.11.15; the runner discovered and launched 564 test files without any carriage-return path failures.
- The new regression passed inside that full runner. The full suite still returned nonzero for 27 unrelated Windows/high-concurrency failures, primarily the existing 0.12-second fast-unit CPU guard plus a progressive-stream timing assertion; none involved the selector output test.
- Ran the real diff-scoped inner pre-push hook: it selected the changed regression as the capped representative for the broad selector change, consumed the generated LF list, and passed the test and all other applicable stages.

## Product invariants affected

None. This changes contributor test tooling only.

## Validation

- `python -m pytest backend/tests/unit/test_backend_unit_selector_output.py backend/tests/unit/test_workflow_contracts.py -q` -> 18 passed
- `python -m black --check --line-length 120 --skip-string-normalization backend/scripts/select_backend_unit_tests.py backend/tests/unit/test_backend_unit_selector_output.py`
- `python -m py_compile backend/scripts/select_backend_unit_tests.py backend/tests/unit/test_backend_unit_selector_output.py`
- `git diff --check`
- full backend Pyright with the locked Windows interpreter -> 0 errors
- `make preflight` -> first 7 selected checks passed, then the known Windows shell-launch failure tracked and fixed by #9624; all 5 remaining selected manifest checks passed when run directly
- diff-scoped `scripts/pre-push` -> selected regression 1 passed and all applicable stages passed; PR preflight/OpenAPI were skipped for #9624 and the already-verified type-check step was skipped inside the old wrapper because #9618 is not merged
- full `backend/test.sh` on Windows -> generated LF list consumed successfully and new regression passed; suite remained nonzero on unrelated existing Windows/high-concurrency failures described above


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9629?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

