### PR TITLE
test(backend): make vision stream progress clock-free

### DIFF
--- a/backend/tests/unit/test_vision_stream_async.py
+++ b/backend/tests/unit/test_vision_stream_async.py
@@ -52,9 +52,7 @@ class TestAsyncVisionStreamPattern:
         callback = AsyncStreamingCallback()
         chunks = ["Hello", " world", "!"]
 
-        # Track when chunks arrive
         received = []
-        received_times = []
 
         async def _produce():
             return await _fake_vision_stream(chunks, callback)
@@ -62,12 +60,13 @@ class TestAsyncVisionStreamPattern:
         task = asyncio.create_task(_produce())
 
         # Drain queue concurrently (mirrors graph.py pattern)
-        loop = asyncio.get_event_loop()
         while True:
             chunk = await callback.queue.get()
             if chunk:
                 received.append(chunk)
-                received_times.append(loop.time())
+                # Intermediate chunks must be observable before the producer completes.
+                if len(received) < len(chunks):
+                    assert not task.done()
             else:
                 break
 
@@ -75,9 +74,6 @@ class TestAsyncVisionStreamPattern:
 
         assert answer == "Hello world!"
         assert received == ["data: Hello", "data:  world", "data: !"]
-        assert len(received_times) == 3
-        # Chunks should arrive at different times (progressive, not burst)
-        assert received_times[-1] - received_times[0] >= 0.02
 
     @pytest.mark.asyncio
     async def test_empty_stream_terminates(self):


### PR DESCRIPTION
## Summary

- replaces a 20 ms event-loop clock threshold with a task-state progress contract
- keeps the vision stream test sensitive to producers that finish in one burst while remaining portable across Windows event loops

Fixes #9630.

## Root cause

`test_chunks_arrive_progressively` sampled `loop.time()` after each queued chunk and required at least 20 ms between the first and last samples. On native Windows, the event-loop clock can return the same observable value for these short intervals, so the test failed even though the consumer received each chunk while the producer was still active.

The old assertion measured clock resolution rather than the producer/consumer behavior that the test is intended to protect.

## Durable guard

For every intermediate chunk, the test now asserts that the producer task has not completed. An implementation that queues the entire response and terminator in one burst completes before the consumer observes the first chunk, so this assertion still fails for the regression while avoiding wall-clock precision assumptions.

The existing assertions continue to verify the final answer and exact chunk order.

## Real-path exercise

- Before the change, the affected test failed in 20 of 20 isolated native Windows CPython 3.11.15 runs.
- After the change, it passed in 20 of 20 isolated runs.
- The complete test module passed through the repository's `backend/test.sh` file-isolated runner on Windows.

## Product invariants affected

None. This changes a backend unit test only.

## Validation

- `PYTHON=... BACKEND_UNIT_TEST_FILE_LIST=... BACKEND_PYTEST_WORKERS=1 bash backend/test.sh` -> 11 passed
- `python -m pytest backend/tests/unit/test_vision_stream_async.py -q` -> 11 passed
- `python -m black --check backend/tests/unit/test_vision_stream_async.py`
- `python -m py_compile backend/tests/unit/test_vision_stream_async.py`
- `git diff --check`
- full backend Pyright with the locked Windows interpreter -> 0 errors, 1756 existing warnings
- `make preflight` -> first 7 selected checks passed, then the known Windows shell-launch failure tracked and fixed by #9624; the route-policy check itself and all 5 later selected manifest checks passed when run directly


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9631?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

