### PR TITLE
fix(backend): unconfigured recordings bucket deadlocks account deletion (6 users stuck on prod)

### DIFF
--- a/backend/tests/unit/test_conversation_recordings_purge.py
+++ b/backend/tests/unit/test_conversation_recordings_purge.py
@@ -1,0 +1,52 @@
+"""Regression test: an unconfigured recordings bucket must not deadlock the account-deletion wipe.
+
+BUCKET_MEMORIES_RECORDINGS was never wired into the backend charts, so `memories_recordings_bucket`
+resolved to None in prod and `.bucket(None)` raised ValueError("Cannot determine path without bucket
+name"). delete_all_conversation_recordings is a *required* purge step, so that raise aborted
+background_wipe_user_data before users_db.delete_user_data(): every account-deletion request failed,
+was marked wipe_failed, and was re-enqueued forever with the user's data still in Firestore.
+
+An unconfigured bucket now means "nothing to purge" — uploads resolve the same name, so a deployment
+without it cannot have stored recordings. A *real* GCS failure must still block the irreversible
+Firestore wipe (test_delete_account_purge_storage.py::test_gcs_failure_blocks_firestore_wipe).
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from utils.other import storage as storage_mod
+
+
+class TestDeleteAllConversationRecordings:
+    def test_unconfigured_bucket_is_a_no_op(self):
+        """Before the fix this raised ValueError and blocked the whole account wipe."""
+        with patch.object(storage_mod, "memories_recordings_bucket", None), patch.object(
+            storage_mod, "_get_storage_client"
+        ) as get_client:
+            storage_mod.delete_all_conversation_recordings("uid1")
+        get_client.assert_not_called()
+
+    def test_configured_bucket_purges_the_uid_prefix(self):
+        blob = MagicMock()
+        bucket = MagicMock()
+        bucket.list_blobs.return_value = [blob]
+        client = MagicMock()
+        client.bucket.return_value = bucket
+        with patch.object(storage_mod, "memories_recordings_bucket", "memories-recordings"), patch.object(
+            storage_mod, "_get_storage_client", return_value=client
+        ):
+            storage_mod.delete_all_conversation_recordings("uid1")
+        client.bucket.assert_called_once_with("memories-recordings")
+        bucket.list_blobs.assert_called_once_with(prefix="uid1/")
+        blob.delete.assert_called_once()
+
+    def test_real_gcs_failure_still_raises(self):
+        """The purge is required: a genuine GCS error must keep blocking the irreversible wipe."""
+        client = MagicMock()
+        client.bucket.side_effect = RuntimeError("gcs down")
+        with patch.object(storage_mod, "memories_recordings_bucket", "memories-recordings"), patch.object(
+            storage_mod, "_get_storage_client", return_value=client
+        ):
+            with pytest.raises(RuntimeError):
+                storage_mod.delete_all_conversation_recordings("uid1")

--- a/backend/utils/other/storage.py
+++ b/backend/utils/other/storage.py
@@ -80,7 +80,7 @@ def _get_storage_client() -> Any:
 
 speech_profiles_bucket = (os.getenv('BUCKET_SPEECH_PROFILES') or '').strip() or None
 postprocessing_audio_bucket = os.getenv('BUCKET_POSTPROCESSING')
-memories_recordings_bucket = os.getenv('BUCKET_MEMORIES_RECORDINGS')
+memories_recordings_bucket = (os.getenv('BUCKET_MEMORIES_RECORDINGS') or '').strip() or None
 private_cloud_sync_bucket = os.getenv('BUCKET_PRIVATE_CLOUD_SYNC', 'omi-private-cloud-sync')
 syncing_local_bucket = os.getenv('BUCKET_TEMPORAL_SYNC_LOCAL')
 omi_apps_bucket = os.getenv('BUCKET_PLUGINS_LOGOS')
@@ -346,6 +346,12 @@ def get_conversation_recording_if_exists(uid: str, memory_id: str) -> Optional[s
 
 def delete_all_conversation_recordings(uid: str) -> None:
     if not uid:
+        return
+    if not memories_recordings_bucket:
+        # A required purge failure blocks the irreversible Firestore wipe (see
+        # services/users/account_deletion.py), so an unconfigured bucket must not raise here:
+        # uploads resolve the same name, so a deployment without it cannot have stored recordings.
+        logger.warning('BUCKET_MEMORIES_RECORDINGS is not configured; skipping conversation recordings purge')
         return
     bucket = _get_storage_client().bucket(memories_recordings_bucket)
     # Trailing slash so a uid is not a prefix of another uid's folder (e.g. "abc" matching "abcd/").


### PR DESCRIPTION
## The bug (live on prod, right now)

Account deletion is **failing for every user who requests it**, and their data is being retained.

`BUCKET_MEMORIES_RECORDINGS` was never wired into the backend Helm charts (it's absent from `prod_omi_backend_listen_values.yaml`, the dev values, and `.env.template`), so `memories_recordings_bucket` resolves to `None` in prod. `delete_all_conversation_recordings` calls `.bucket(None)`, and listing raises:

```
ValueError: Cannot determine path without bucket name.
```

That purge is a **required** step, so the raise aborts `background_wipe_user_data` *before* `users_db.delete_user_data()`. The wipe is marked `wipe_failed`, the reconciler re-enqueues it, and it fails again — forever. Prod logs (last 24h):

```
ERROR:services.users.account_deletion:delete_account purge recordings failed for <uid>: Cannot determine path without bucket name.
ERROR:services.users.account_deletion:delete_account background wipe failed for <uid>: required derived purge failed: conversation_recordings
INFO:services.users.account_deletion:delete_account reconciliation: re-enqueued 6, skipped 0
```

Six uids are stuck in that loop. Their Firestore data (conversations, memories, chats) is still there after they asked to be deleted.

## Root cause

An **unconfigured** bucket was being treated as a **purge failure**. A permanent config gap therefore became a permanent block on an irreversible-but-requested deletion.

## The fix

An unconfigured bucket now means "nothing to purge" and returns cleanly — uploads resolve the same bucket name, so a deployment without it cannot have stored recordings.

A **real** GCS failure still raises and still blocks the irreversible Firestore wipe. That contract is deliberate (retry rather than partially wipe) and is unchanged — `test_gcs_failure_blocks_firestore_wipe` still passes untouched.

## Verification (real path, live prod GCS, prod service account)

- Replaying the **pre-fix** function body with the bucket unset and one of the actual stuck uids reproduces the prod log line byte-for-byte: `ValueError: Cannot determine path without bucket name.`
- **With the fix**, the same call returns cleanly → `required_failures` is empty → the wipe proceeds to the Firestore delete.
- **With the bucket configured**, the purge still lists live `gs://memories-recordings` and deletes the `{uid}/` prefix (exercised against a uid with no objects, so nothing was deleted).
- New regression test **fails without the guard, passes with it**.
- `backend/test.sh`: 564 test files, **0 failures**.

## ⚠️ Not merged — needs your sign-off

`AGENTS.md` requires explicit user sign-off for **data deletion** changes, and this one *enables* an irreversible Firestore wipe that is currently blocked. I've verified it end-to-end, but I'm not merging that class of change autonomously. **The blast radius is only users who already requested deletion** — this does not change *who* gets wiped, only whether the recordings step can veto the wipe.

## ⚠️ Config gap left open (deploy config — not mine to land)

`BUCKET_MEMORIES_RECORDINGS` is still missing from the Helm values. Consequences:
- Conversation recordings are **not** purged on account deletion. One legacy uid still has objects in `gs://memories-recordings` — if they delete their account, this fix skips their `.wav` files. (None of the 6 currently-stuck uids have objects there, so nothing is left behind for them.)
- The recordings feature is inert deployment-wide: `upload_conversation_recording` (consent-gated on `store_recording_permission`) and the `has_recording` endpoint both hit the same unset name.

Wiring the env var into the charts restores the purge and the feature. I left it alone because it's deploy config.

🤖 automated by hourly watchdog; opened for review, **not merged**.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9632?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

