### PR TITLE
fix(backend): offload blocking chat-setup reads off the event loop

### DIFF
--- a/backend/tests/unit/test_chat_async_offload.py
+++ b/backend/tests/unit/test_chat_async_offload.py
@@ -1,0 +1,111 @@
+"""
+Regression tests: chat setup helpers that do blocking Firestore / LLM I/O must run
+OFF the event-loop thread.
+
+``execute_chat_stream`` / ``execute_agentic_chat_stream`` are async generators driven on
+the event loop by ``StreamingResponse``. Before this fix several synchronous setup helpers
+were called directly on the loop, blocking every concurrent request during chat setup:
+
+- ``execute_agentic_chat_stream`` (the default chat path) ran ``get_user_timezone``,
+  ``_get_agentic_qa_prompt`` (Firestore reads + a LangSmith prompt fetch), and
+  ``load_app_tools`` inline before its first ``await``.
+- ``_has_file_context`` ran ``retrieve_is_file_question`` — a ~1-2s synchronous LLM
+  inference — inline on the file-chat path.
+
+They now run via ``run_blocking(...)``. These tests drive the production async functions
+through the executor seam and assert each helper executes on a non-loop thread, so a
+regression that reintroduces an inline call fails. (Not a source grep: the offload is
+observed via the thread each helper actually runs on.)
+"""
+
+import os
+import threading
+from types import SimpleNamespace
+from unittest.mock import patch
+
+# Hermetic config so importing the chat modules (which construct Typesense / OpenAI clients
+# and require the encryption key) succeeds without network. Matches conftest defaults.
+os.environ.setdefault('ENCRYPTION_SECRET', '0123456789abcdef0123456789abcdef')
+os.environ.setdefault('OPENAI_API_KEY', 'sk-test')
+os.environ.setdefault('TYPESENSE_API_KEY', 'test-typesense-key')
+os.environ.setdefault('TYPESENSE_HOST', 'localhost')
+os.environ.setdefault('TYPESENSE_HOST_PORT', '8108')
+os.environ.setdefault('TYPESENSE_PROTOCOL', 'http')
+
+# Imported at module scope so the heavy import cost lands in collection, keeping each
+# per-test call within the fast-unit duration guard.
+import utils.retrieval.graph as graph  # noqa: E402
+import utils.retrieval.agentic as agentic  # noqa: E402
+
+
+async def test_has_file_context_offloads_llm_call_off_loop():
+    """_has_file_context must run the synchronous retrieve_is_file_question in an executor,
+    not inline on the event loop."""
+    loop_thread = threading.current_thread()
+    ran_on = {}
+
+    def fake_is_file_question(question):
+        ran_on['thread'] = threading.current_thread()
+        return True
+
+    # File attached earlier in the session + a text-only follow-up → the retrieve path.
+    session = SimpleNamespace(id="s1", file_ids=["f1"])
+    last = SimpleNamespace(files_id=None, text="what's in the document I shared?")
+
+    with patch.object(graph, 'retrieve_is_file_question', fake_is_file_question):
+        result = await graph._has_file_context(last, session)
+
+    assert result is True
+    assert 'thread' in ran_on, "retrieve_is_file_question was not called"
+    assert ran_on['thread'] is not loop_thread, "retrieve_is_file_question must run off the event-loop thread"
+
+
+async def test_agentic_setup_reads_run_off_loop():
+    """execute_agentic_chat_stream must offload its blocking Firestore setup reads
+    (get_user_timezone, _get_agentic_qa_prompt, load_app_tools) so they don't block the
+    event loop before the first await."""
+    loop_thread = threading.current_thread()
+    threads = {}
+
+    def rec(name, retval):
+        def _fn(*args, **kwargs):
+            threads[name] = threading.current_thread()
+            return retval
+
+        return _fn
+
+    async def fake_agent_stream(
+        system_prompt,
+        anthropic_messages,
+        tool_schemas,
+        tool_registry,
+        callback,
+        full_response,
+        safety_guard,
+        configurable,
+    ):
+        # End the stream immediately so the generator's queue loop breaks.
+        await callback.queue.put(None)
+
+    with patch.object(agentic, 'get_user_timezone', rec('tz', 'UTC')), patch.object(
+        agentic, '_get_agentic_qa_prompt', rec('prompt', 'SYSTEM')
+    ), patch.object(agentic, 'load_app_tools', rec('app_tools', [])), patch.object(
+        agentic, 'get_current_datetime_block', lambda uid, tz=None: ''
+    ), patch.object(
+        agentic, '_convert_tools', lambda core, app: ([], {})
+    ), patch.object(
+        agentic, '_messages_to_anthropic', lambda messages: []
+    ), patch.object(
+        agentic, '_inject_current_datetime', lambda anthropic_messages, block: []
+    ), patch.object(
+        agentic, '_run_anthropic_agent_stream', fake_agent_stream
+    ):
+        chunks = []
+        async for chunk in agentic.execute_agentic_chat_stream(
+            'uid1', [], app=None, callback_data={}, chat_session=None
+        ):
+            chunks.append(chunk)
+
+    for name in ('tz', 'prompt', 'app_tools'):
+        assert name in threads, f"{name} setup helper was not called"
+        assert threads[name] is not loop_thread, f"{name} setup read must run off the event-loop thread"

--- a/backend/utils/retrieval/agentic.py
+++ b/backend/utils/retrieval/agentic.py
@@ -53,6 +53,7 @@ from utils.retrieval.safety import AgentSafetyGuard, SafetyGuardError
 from utils.llm.byok_errors import handle_llm_error_async
 from utils.llm.clients import anthropic_client, ANTHROPIC_AGENT_MODEL
 from utils.llm.chat import _get_agentic_qa_prompt, get_current_datetime_block, get_user_timezone
+from utils.executors import run_blocking, db_executor
 from utils.other.endpoints import timeit
 from utils.observability.langsmith import is_langsmith_enabled
 import logging
@@ -559,10 +560,14 @@ async def execute_agentic_chat_stream(
     """
     # Resolve the user's timezone once and reuse it for both the system prompt and the
     # injected datetime block, avoiding a duplicate notification_db lookup per request.
-    tz = get_user_timezone(uid)
+    # These setup helpers do blocking Firestore reads (and a LangSmith prompt fetch inside
+    # _get_agentic_qa_prompt); offload them so they don't block the event loop while this
+    # async generator is driven on the loop by StreamingResponse. (get_current_datetime_block
+    # below stays inline — with tz passed it's pure formatting, no I/O.)
+    tz = await run_blocking(db_executor, get_user_timezone, uid)
 
     # Build system prompt
-    system_prompt = _get_agentic_qa_prompt(uid, app, messages, context=context, tz=tz)
+    system_prompt = await run_blocking(db_executor, _get_agentic_qa_prompt, uid, app, messages, context=context, tz=tz)
 
     # Get prompt metadata for tracing/versioning
     prompt_name, prompt_commit, prompt_source = None, None, None
@@ -579,7 +584,7 @@ async def execute_agentic_chat_stream(
     # Dynamic app tools — deferred, discovered on-demand via tool search
     app_tools = []
     try:
-        app_tools = load_app_tools(uid)
+        app_tools = await run_blocking(db_executor, load_app_tools, uid)
         if app_tools:
             logger.info(f"Loaded {len(app_tools)} app tools (deferred via tool search)")
     except Exception as e:

--- a/backend/utils/retrieval/graph.py
+++ b/backend/utils/retrieval/graph.py
@@ -21,6 +21,7 @@ from models.app import App
 from models.chat import ChatSession, Message, PageContext
 from utils.llm.chat import retrieve_is_file_question
 from utils.llm.clients import get_llm
+from utils.executors import run_blocking, llm_executor
 from utils.other.chat_file import FileChatTool
 from utils.retrieval.agentic import AsyncStreamingCallback, execute_agentic_chat_stream
 from utils.observability.langsmith import get_chat_tracer_callbacks
@@ -34,14 +35,17 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 
-def _has_file_context(last_message: Optional[Message], chat_session: Optional[ChatSession]) -> bool:
+async def _has_file_context(last_message: Optional[Message], chat_session: Optional[ChatSession]) -> bool:
     """Check if the request involves file attachments."""
     if last_message and last_message.files_id and len(last_message.files_id) > 0:
         return chat_session is not None
 
     if chat_session and chat_session.file_ids and len(chat_session.file_ids) > 0:
         question = last_message.text if last_message else ""
-        if question and retrieve_is_file_question(question):
+        # retrieve_is_file_question runs a synchronous ~1-2s LLM inference; offload it so it
+        # doesn't block the event loop while execute_chat_stream's async generator is driven
+        # on the loop by StreamingResponse.
+        if question and await run_blocking(llm_executor, retrieve_is_file_question, question):
             return True
 
     return False
@@ -230,7 +234,7 @@ async def execute_chat_stream(
 
     # 2. File attachments
     last_msg = messages[-1] if messages else None
-    if chat_session is not None and _has_file_context(last_msg, chat_session):
+    if chat_session is not None and await _has_file_context(last_msg, chat_session):
         async for chunk in _execute_file_chat_stream(uid, messages, chat_session, callback_data):
             yield chunk
         return


### PR DESCRIPTION
## Summary

Backend bug sweep (batch 9) — two confirmed event-loop-blocking bugs on the **default** chat path, found by a fan-out review of the chat + agentic-retrieval (RAG) pipeline. Both ship with behavioral regression tests that fail pre-fix and pass post-fix.

The chat send path is a sync `def` endpoint (`send_message`) returning a `StreamingResponse` whose async generator (`generate_stream` → `execute_chat_stream`) is iterated on the event loop by Starlette. Several synchronous setup helpers ran inline on that loop, blocking every concurrent request (transcription, health checks, other chats) during chat setup.

## Fixes

### 1. MEDIUM — Agentic chat setup did sequential blocking Firestore reads on the event loop (every request)
`execute_agentic_chat_stream` (the default path for all normal chat) ran `get_user_timezone`, `_get_agentic_qa_prompt` (Firestore reads for user name/goals + a LangSmith prompt fetch), and `load_app_tools` **before its first `await`** — ~3–4 sequential Firestore round-trips blocking the loop on every agentic chat request. Fixed by offloading each via `await run_blocking(db_executor, fn, ...)` (`utils/retrieval/agentic.py`). `get_current_datetime_block` stays inline — with the resolved `tz` passed in it is pure formatting, no I/O.

### 2. MEDIUM — File-chat detection ran a synchronous ~1–2s LLM inference on the event loop
`_has_file_context` called `retrieve_is_file_question` (a synchronous `.with_structured_output().invoke()`) inline whenever a session had files attached and the user sent a text-only follow-up — freezing the loop for the full inference. Fixed by making `_has_file_context` async and offloading the invoke via `await run_blocking(llm_executor, retrieve_is_file_question, question)`; its single caller now awaits it (`utils/retrieval/graph.py`).

## Root cause & durable guard

- Both are the same class: synchronous I/O executed inline inside an async generator that Starlette drives on the event loop via `StreamingResponse`.
- These were invisible to `scan_async_blockers.py`: it scans only `@router`-decorated endpoints, and `send_message` is a sync `def` (correctly threadpooled by FastAPI) whose nested async generator into `utils/` the scanner does not follow. The behavioral tests are the enforceable guard for the two fixed sites.
- **Deferred follow-up (not bundled here):** extending `scan_async_blockers.py` to trace `StreamingResponse(async_gen())` reachability into `utils/` async code is a larger change — it would begin scanning all `utils/` async functions and needs its own baseline/ratchet, so per the repo rule against broadening a safe bug-fix PR into an unreviewable migration, it is tracked separately rather than landed here.

## Testing

- `tests/unit/test_chat_async_offload.py` (new) — drives the production async functions through the executor seam and asserts each blocking helper runs on a **non-event-loop thread**. Confirmed to FAIL pre-fix (BUG1: `await` on a sync bool raises `TypeError`; BUG2: `"tz setup read must run off the event-loop thread"`) and PASS post-fix (verified by `git stash` of the two production files). Not a source grep — the offload is observed via the thread each helper actually runs on.
- `.venv` synced from `pylock.toml`; `pytest tests/unit/test_chat_async_offload.py` → 2 passed.
- `python scripts/scan_async_blockers.py --dirs routers utils` → 0 blocking findings (confirms no new blockers introduced).
- `check_module_stub_pollution.py` / `scan_import_time_side_effects.py` → 0 violations; both changed modules import cleanly; black-formatted.
- The full selector-picked suite includes live-service e2e tests that can't run in this credential-less sandbox; those run in CI. Note: `test.sh` runs each test file in its own process (`--dist=loadfile`), so cross-file state is isolated.

## Product invariants affected

- None (`scripts/pr-preflight --suggest` → none; the changed paths are not under a locked-invariant glob).

## Noted, not fixed (out of scope)

- `tests/unit/test_prompt_cache_integration.py` mutates `sys.modules` at module scope (the anti-pattern AGENTS.md forbids). It leaks into later test files **only when run in the same pytest process**; the CI runner (`test.sh`) isolates per file, so it does not affect CI. Pre-existing and outside this PR's blast radius — flagged for a separate cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RAxLsaxtwVNDTWAZFfJp9q)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9633?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

