### PR TITLE
ci: regression guardrails — PR scope governor, test-discovery ratchet, sync annotation ratchet

### DIFF
--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -4,16 +4,76 @@
 # Checks that consume PR metadata declare `requires_pr_body: true`; post-merge
 # push runs exclude only that category because no authoritative PR body is available.
 checks:
+  - id: dev-harness-unit-tests
+    command: ["bash", "scripts/dev-harness/run-tests.sh"]
+    triggers: ["scripts/dev-harness/**", "desktop/macos/scripts/qualification-lease-command.sh", "desktop/macos/scripts/omi-fault-inject.sh", "desktop/macos/scripts/release-keyvalue.py", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "the hermetic dev-harness stack backs release qualification; the Jul 22 2026 beta qualification outage added a docker/native typesense runtime that must stay behaviorally covered"
+  - id: pre-tag-readiness-contract
+    command: ["bash", "desktop/macos/tests/test-pre-tag-readiness-contract.sh"]
+    triggers: ["desktop/macos/scripts/pre-tag-readiness.sh", "desktop/macos/scripts/qualification-runner-self-clean.py", "desktop/macos/scripts/qualification-watchdog.py", "desktop/macos/tests/test-pre-tag-readiness-contract.sh", ".github/scripts/verify-pre-tag-readiness.py", ".github/scripts/test_verify_pre_tag_readiness.py", ".github/workflows/desktop_auto_release.yml", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "trusted-M1 readiness must retain exact-SHA cache/lease ownership and cannot emit a passing receipt before authenticated cleanup"
+  - id: pre-tag-readiness-behavior
+    command: ["python3", "desktop/macos/tests/test_pre_tag_readiness_behavior.py"]
+    triggers: ["desktop/macos/scripts/pre-tag-readiness.sh", "desktop/macos/scripts/qualification-runner-self-clean.py", "desktop/macos/scripts/qualification-watchdog.py", "desktop/macos/tests/test_pre_tag_readiness_behavior.py", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "a disposable source and authenticated capability fakes prove the real readiness orchestrator emits its exact-SHA receipt only after ordered cleanup"
+  - id: verify-pre-tag-readiness-tests
+    command: ["python3", ".github/scripts/test_verify_pre_tag_readiness.py"]
+    triggers: [".github/scripts/verify-pre-tag-readiness.py", ".github/scripts/test_verify_pre_tag_readiness.py", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "the receipt verifier must reject stale, non-offline, failed, and promotion-bearing readiness evidence before a tag mutation"
   - id: pre-push-final-pr-diff
     command: ["bash", "scripts/test-pre-push-diff-base.sh"]
     triggers: ["scripts/pre-push", "scripts/pre-push-diff-base", "scripts/test-pre-push-diff-base.sh", ".github/checks-manifest.yaml"]
     lanes: ["local", "ci"]
     reason: "pre-push check selection must use the final PR diff rather than a stale remote feature tip"
+  - id: pre-push-ci-prediction-tests
+    command: ["python3", ".github/scripts/test_pre_push_ci_prediction.py"]
+    triggers: ["scripts/pre-push", "scripts/pre_push_ci_prediction.py", ".github/scripts/test_pre_push_ci_prediction.py", "desktop/macos/scripts/desktop-flow-lint.py", "desktop/macos/scripts/desktop_flow_contract.py", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "#9440: local CI prediction must select only bounded Flutter generator, desktop-flow, and Windows KG-worker checks for the final PR diff"
+  - id: pre-push-hatch-disclosure
+    command: ["python3", ".github/scripts/check_pre_push_hatch_disclosure.py"]
+    triggers: ["scripts/pre-push", ".github/scripts/check_pre_push_hatch_disclosure.py", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "make setup provisions no app toolchain while .github/checks-manifest.yaml is a ROUTING_INPUTS entry that wakes the Flutter codegen lane, so a docs-only PR hit 'run flutter pub get' with no mention of PRE_PUSH_SKIP_FLUTTER_GENERATED; actionlint's branch had the same omission, and a hatch nobody can find is not a hatch"
+  - id: setup-pre-push-prerequisites
+    command: ["bash", "scripts/test-make-setup.sh"]
+    triggers: ["Makefile", "backend/scripts/sync-python-deps.sh", "scripts/pre-push", "scripts/test-make-setup.sh", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "make setup must provision the minimal, rerunnable backend environment required by selected pre-push checks"
+  - id: desktop-release-process-guards
+    command: ["bash", "scripts/run-release-process-guards.sh"]
+    triggers: [".github/workflows/desktop_qualify_beta.yml", ".github/scripts/check-release-process-guards.py", "scripts/run-release-process-guards.sh", "backend/tests/unit/test_desktop_release_scripts.py", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "SCA-174: qualification must check out the exact release tag inside its isolated source directory; the guard and its focused behavioral test run on every relevant diff"
+  - id: failure-class-retirement-author
+    command: ["python3", ".github/scripts/test_failure_class_retirement.py"]
+    triggers: [".github/scripts/failure_class_retirement.py", ".github/scripts/test_failure_class_retirement.py", ".github/workflows/repo-hygiene.yml", "scripts/failure-class", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "the weekly retirement author must refuse a truncated event feed; a short feed reports every class as instance-free, so the job would stay green while retiring nothing"
+  - id: desktop-auto-beta-candidate-gate-tests
+    command: ["python3", ".github/scripts/test_check_desktop_auto_beta_candidate.py"]
+    triggers: [".github/scripts/check-desktop-auto-beta-candidate.py", ".github/scripts/test_check_desktop_auto_beta_candidate.py", "codemagic.yaml", "desktop/macos/scripts/smoke-signed-desktop-artifact.sh", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "the candidate gate validates signed-smoke evidence; a stable-only flag change must not fail-close the first dual-identity release"
   - id: check-manifest-contract
     command: ["python3", ".github/scripts/test_run_checks.py"]
     triggers: ["all"]
     lanes: ["local", "ci"]
     reason: "manifest validity and workflow drift guard"
+  - id: backend-production-release-vector-guards
+    command: ["python3", ".github/scripts/check_release_rings.py"]
+    triggers: [".github/workflows/gcp_backend.yml", ".github/scripts/check_release_rings.py", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "the canonical production backend deploy remains the only release authority"
+  - id: backend-production-release-vector-guard-tests
+    command: ["python3", ".github/scripts/test_check_release_rings.py"]
+    triggers: [".github/scripts/check_release_rings.py", ".github/scripts/test_check_release_rings.py", ".github/workflows/gcp_backend.yml", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "the one-action production backend release contract must reject legacy release planes"
   - id: product-file-line-count-ratchet
     command: ["python3", ".github/scripts/check_product_file_line_count_ratchet.py", "--changed-files", "{changed_files}", "--base", "{base}"]
     triggers: ["backend/**/*.py", "desktop/macos/**/*.swift", "desktop/macos/**/*.rs", ".github/scripts/check_product_file_line_count_ratchet.py", ".github/scripts/product_file_line_count_ratchet_baseline/**/*.json"]
@@ -29,6 +89,11 @@ checks:
     triggers: [".github/schemas/desktop-release-manifest-v1.schema.json", ".github/scripts/desktop_release_manifest.py", ".github/scripts/test_desktop_release_manifest.py", ".github/scripts/fixtures/desktop_release_manifest/**"]
     lanes: ["local", "ci"]
     reason: "immutable desktop app/backend release-unit contract"
+  - id: desktop-release-manifest-schema-v1
+    command: ["python3", ".github/scripts/test_desktop_release_manifest_schema.py"]
+    triggers: [".github/schemas/desktop-release-manifest-v1.schema.json", ".github/scripts/test_desktop_release_manifest_schema.py", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "the Stable manifest schema must keep admitting exactly one app artifact pair; a beta_zip_url re-entering it is how a beta build becomes describable as Stable"
   - id: pr-scope
     command: ["python3", ".github/scripts/check_pr_scope.py", "--base", "{base}", "--head", "{head}"]
     triggers: ["all"]
@@ -39,31 +104,73 @@ checks:
     triggers: [".github/scripts/check_pr_scope.py", ".github/scripts/test_check_pr_scope.py"]
     lanes: ["local", "ci"]
     reason: "scope advisor classification/annotation contract"
+  - id: backend-test-discovery
+    command: ["python3", "backend/scripts/check_unit_test_discovery.py"]
+    triggers: ["backend/tests/**", "backend/testing/**", "backend/scripts/select_backend_unit_tests.py", "backend/scripts/check_unit_test_discovery.py", ".github/workflows/parakeet_gpu_tests.yml", ".github/workflows/backend-hermetic-e2e.yml", ".github/workflows/desktop-backend-contracts.yml", ".github/workflows/backend-unit-tests.yml"]
+    lanes: ["local", "ci"]
+    reason: "every backend test file must be discovered by a verified runner"
   - id: desktop-release-doctor-v1
     command: ["python3", ".github/scripts/test_desktop_release_doctor.py"]
     triggers: [".github/schemas/desktop-release-evidence-v1.schema.json", ".github/scripts/desktop_release_doctor.py", ".github/scripts/desktop_release_doctor_report.py", ".github/scripts/test_desktop_release_doctor.py", ".github/workflows/desktop_release_doctor.yml"]
     lanes: ["local", "ci"]
     reason: "advisory desktop release evidence and drift report"
+  - id: desktop-beta-admission-firestore-contention
+    command: ["bash", "backend/testing/desktop_beta_admission/run.sh"]
+    triggers: ["backend/database/desktop_update_channels.py", "backend/testing/desktop_beta_admission/**", "package.json", "package-lock.json", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    platforms: ["macos"]
+    reason: "real Firestore transaction serialization must fence stale qualified Beta admissions after reservation, pause, and generation transitions"
+  - id: desktop-beta-admission-supervisor
+    command: ["node", "--test", "backend/testing/desktop_beta_admission/test_supervise.mjs"]
+    triggers: ["backend/testing/desktop_beta_admission/**", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    platforms: ["macos"]
+    reason: "SCA-52: the admission emulator must own and drain only its process group, including Firestore JVM grandchildren, on every exit path"
   - id: desktop-changelog-io-tests
     command: ["python3", ".github/scripts/test_desktop_changelog.py"]
-    triggers: [".github/scripts/desktop-changelog.py", ".github/scripts/test_desktop_changelog.py", ".github/checks-manifest.yaml"]
+    triggers: [".github/scripts/check-desktop-changelog.py", ".github/scripts/desktop-changelog.py", ".github/scripts/test_desktop_changelog.py", ".github/checks-manifest.yaml"]
     lanes: ["local", "ci"]
-    reason: "#9717: changelog JSON I/O must decode/encode as UTF-8 regardless of contributor host locale"
+    reason: "#9717: changelog tooling must preserve UTF-8 I/O and exempt only internal desktop release controls"
   - id: agents-md-lean
     command: ["python3", ".github/scripts/check_agents_md_lean.py"]
-    triggers: ["AGENTS.md", ".github/scripts/check_agents_md_lean.py"]
+    triggers: ["AGENTS.md", "**/AGENTS.md", ".github/scripts/check_agents_md_lean.py"]
     lanes: ["local", "ci"]
-    reason: "root AGENTS.md stays a lean index; detail lives in component guides"
+    reason: "every AGENTS.md is loaded into agent context; budgets ratchet down, never up"
+  - id: agent-doc-references
+    command: ["python3", ".github/scripts/check_agent_doc_references.py"]
+    triggers: ["AGENTS.md", "**/AGENTS.md", "CLAUDE.md", "PRODUCT.md", "docs/agents/**", ".github/scripts/check_agent_doc_references.py"]
+    lanes: ["local", "ci"]
+    reason: "agents cannot tell a stale pointer from a live one; CLAUDE.md and the desktop/app guides had shipped dead paths"
+  - id: agent-doc-claims
+    command: ["python3", ".github/scripts/check_agent_doc_claims.py"]
+    triggers: [".cursor/cloud-agent-environment.md", "backend/test.sh", "backend/docs/test_isolation.md", ".github/scripts/check_agent_doc_claims.py", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "a valid pointer proves nothing about the claim around it; .cursor/cloud-agent-environment.md described test.sh halting at the first failure long after it became an aggregating worker pool, and an agent read that and proposed replacing the per-file isolation the suite depends on"
   - id: diff-hygiene
     command: ["python3", ".github/scripts/check_diff_hygiene.py", "--changed-files", "{changed_files}", "--base", "{base}", "--head", "{head}"]
     triggers: ["all"]
     lanes: ["local", "ci"]
     reason: "all changes must be free of whitespace errors and conflict markers"
+  - id: package-architecture-map-guardrail-tests
+    command: ["python3", ".github/scripts/test_check_package_architecture_maps.py"]
+    triggers: [".github/scripts/check_package_architecture_maps.py", ".github/scripts/test_check_package_architecture_maps.py", ".github/scripts/package_architecture_baseline.json", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "the package-map ratchet is only a ratchet while its own baseline behavior stays covered"
   - id: architecture-guardrails
     command: ["python3", ".github/scripts/check_arch_guardrails.py", "--changed-files", "{changed_files}", "--base", "{base}"]
     triggers: ["all"]
     lanes: ["local", "ci"]
     reason: "advisory size checks plus oversized package-map baseline ratchet"
+  - id: product-invariant-checker-tests
+    command: ["python3", ".github/scripts/test_check_product_invariants.py"]
+    triggers: [".github/scripts/check_product_invariants.py", ".github/scripts/test_check_product_invariants.py", "docs/product/invariants/**", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "locked invariant citation enforcement must keep rejecting an uncited path match"
+  - id: pr-preflight-contract-tests
+    command: ["python3", ".github/scripts/test_pr_preflight.py"]
+    triggers: [".github/scripts/pr_preflight.py", ".github/scripts/test_pr_preflight.py", ".github/scripts/pr_metadata.py", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "preflight resolves the check selection every PR depends on"
   - id: product-invariants
     command: ["python3", ".github/scripts/check_product_invariants.py", "--changed-files", "{changed_files}", "--pr-body-file", "{pr_body_file}"]
     triggers: ["all"]
@@ -76,6 +183,21 @@ checks:
     lanes: ["local", "ci"]
     requires_pr_body: true
     reason: "fix commits declare a validated semantic failure class"
+  - id: failure-class-guard-artifact-ratchet
+    command: ["python3", ".github/scripts/check_failure_class_guard_ratchet.py", "--pr-body-file", "{pr_body_file}"]
+    triggers: ["all"]
+    lanes: ["local", "ci"]
+    reason: "FC-split-mutation-authority was declared on 30 first-parent integration changes in the 90 days to Jul 24 2026 while its definition still listed evidence_prs [9365, 9597] and named no guard artifact; a recurring class must produce a reusable guard surface, not more paperwork"
+  - id: failure-class-guard-artifact-ratchet-tests
+    command: ["python3", ".github/scripts/test_check_failure_class_guard_ratchet.py"]
+    triggers: [".github/scripts/check_failure_class_guard_ratchet.py", ".github/scripts/test_check_failure_class_guard_ratchet.py", ".github/scripts/failure_class_guard_ratchet_allowlist.json", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "the guard-artifact ratchet's counting window, threshold, allowlist shrink rule, and shallow-history skip must stay behaviorally covered"
+  - id: failure-class-cli-tests
+    command: ["python3", "scripts/test_failure_class.py"]
+    triggers: ["scripts/failure-class", "scripts/test_failure_class.py", ".github/failure-classes/**", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "the failure-class CLI is the registry's only schema authority; its hermetic tests had no blocking lane and had silently gone stale"
   - id: desktop-changelog-data
     command: ["python3", ".github/scripts/desktop-changelog.py", "validate"]
     triggers: ["all"]
@@ -97,6 +219,11 @@ checks:
     lanes: ["local", "ci"]
     platforms: ["macos"]
     reason: "desktop Swift sources changed; compare against the pinned macOS formatter before requiring a flow cover"
+  - id: brand-ui-ratchet-tests
+    command: ["python3", ".github/scripts/test_check_brand_ui.py"]
+    triggers: [".github/scripts/check_brand_ui.py", ".github/scripts/test_check_brand_ui.py", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "INV-UI-1 is a no-increase ratchet; its counting behavior must stay covered"
   - id: brand-ui
     command: ["python3", ".github/scripts/check_brand_ui.py", "--changed-files", "{changed_files}", "--base", "{base}"]
     triggers: ["desktop/macos/Desktop/Sources/**/*.swift", "app/lib/**/*.dart", "web/**/*.ts", "web/**/*.tsx", "web/**/*.js", "web/**/*.jsx", "web/**/*.css"]
@@ -132,6 +259,16 @@ checks:
     triggers: [".github/scripts/check_deployment_secret_boundary.py", ".github/scripts/test_check_deployment_secret_boundary.py"]
     lanes: ["local", "ci"]
     reason: "deployment secret-boundary fake-name fixtures must remain executable"
+  - id: github-runner-cost-policy
+    command: ["python3", ".github/scripts/check_runner_cost_policy.py"]
+    triggers: [".github/workflows/**/*.yml", ".github/workflows/**/*.yaml", ".github/actionlint.yaml", ".github/scripts/check_runner_cost_policy.py", ".github/scripts/test_check_runner_cost_policy.py", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "SCA-196: public-repository standard runners are free while the larger ubuntu-latest-m label caused recurring Linux 4-core charges"
+  - id: github-runner-cost-policy-fixtures
+    command: ["python3", ".github/scripts/test_check_runner_cost_policy.py"]
+    triggers: [".github/scripts/check_runner_cost_policy.py", ".github/scripts/test_check_runner_cost_policy.py"]
+    lanes: ["local", "ci"]
+    reason: "runner cost-policy fixtures must keep rejecting the paid larger-runner label"
   - id: telegram-deployment-notifier
     command: ["bash", ".github/actions/deployment-notifier/test-check-configuration.sh"]
     triggers: [".github/actions/deployment-notifier/**", ".github/checks-manifest.yaml"]
@@ -167,6 +304,16 @@ checks:
     triggers: [".github/scripts/check_public_build_contract.py", ".github/scripts/preflight_public_build_config.py", ".github/scripts/preflight_public_build_runtime.py", ".github/scripts/smoke_public_build_browser.py", ".github/scripts/test_check_public_build_contract.py", "web/personas-open-source/src/app/api/social-profile/route.ts"]
     lanes: ["local", "ci"]
     reason: "public-build contract and GitHub variable scope fixtures must remain executable"
+  - id: web-llm-gateway-only
+    command: ["python3", ".github/scripts/check_web_llm_gateway_only.py"]
+    triggers: ["web/**/*.js", "web/**/*.jsx", "web/**/*.mjs", "web/**/*.ts", "web/**/*.tsx", "web/**/package.json", ".github/scripts/check_web_llm_gateway_only.py", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "SCA-118: production web LLM traffic must not regain direct provider SDKs, URLs, or credentials"
+  - id: web-llm-gateway-only-tests
+    command: ["python3", ".github/scripts/test_check_web_llm_gateway_only.py"]
+    triggers: [".github/scripts/check_web_llm_gateway_only.py", ".github/scripts/test_check_web_llm_gateway_only.py", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "the gateway-only source guard must reject provider regressions without flagging its own fixtures"
   - id: backend-async-blockers
     command: ["python3", "backend/scripts/scan_async_blockers.py", "--dirs", "backend/routers", "backend/utils", "backend/agent-proxy", "backend/dependencies.py", "--diff-base", "{base}", "--fail-on", "high_network_io,async_helpers_with_blocking,time_sleep,mixed_await_sync_db,no_await_should_be_def,unmanaged_thread_offload"]
     triggers: ["backend/**/*.py", "backend/agent-proxy/**", "backend/scripts/scan_async_blockers.py"]
@@ -197,11 +344,21 @@ checks:
     triggers: ["backend/database/**/*.py", ".github/scripts/check_firestore_model_read_boundary.py", ".github/scripts/firestore_model_read_boundary_baseline.json"]
     lanes: ["local", "ci"]
     reason: "#9494 -> #9696 malformed Firestore documents must use the shared read boundary"
+  - id: lifecycle-header-checker-tests
+    command: ["python3", ".github/scripts/test_check_lifecycle_headers.py"]
+    triggers: [".github/scripts/check_lifecycle_headers.py", ".github/scripts/test_check_lifecycle_headers.py", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "one-time rollout scaffolding must keep requiring a DELETE-AFTER reference"
   - id: lifecycle-headers
     command: ["python3", ".github/scripts/check_lifecycle_headers.py", "--changed-files", "{changed_files}"]
     triggers: ["all"]
     lanes: ["local", "ci"]
     reason: "rollout scaffolding may require lifecycle headers"
+  - id: version-prefixed-filename-tests
+    command: ["python3", ".github/scripts/test_check_version_prefixed_filenames.py"]
+    triggers: [".github/scripts/check_version_prefixed_filenames.py", ".github/scripts/test_check_version_prefixed_filenames.py", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "the repository-wide filename contract must keep rejecting a version-prefixed path"
   - id: version-prefixed-filenames
     command: ["python3", ".github/scripts/check_version_prefixed_filenames.py"]
     triggers: ["all"]
@@ -209,12 +366,12 @@ checks:
     reason: "repository-wide version-prefixed filename contract"
   - id: backend-import-purity
     command: ["python3", "backend/scripts/scan_import_time_side_effects.py", "--files", "{changed_files}", "--check-allowlist-monotonic", "{base}"]
-    triggers: ["backend/**/*.py", "backend/tests/.import_time_side_effects_legacy_allowlist"]
+    triggers: ["backend/**/*.py"]
     lanes: ["local", "ci"]
-    reason: "backend production Python or its allowlist changed"
+    reason: "backend production Python changes must retain import-time purity"
   - id: backend-runtime-image-source-closure
     command: ["python3", "backend/scripts/runtime_image_contracts.py", "check"]
-    triggers: ["backend/**/*.py", "backend/**/Dockerfile*", "backend/runtime_images.json", "backend/scripts/runtime_image_contracts.py", ".github/workflows/runtime_image_contracts.yml", ".github/workflows/gcp_backend*.yml", ".github/workflows/gcp_diarizer.yml", ".github/workflows/gcp_models.yml", ".github/workflows/gcp_parakeet.yml", ".github/workflows/gcp_nllb_translation.yml", ".github/workflows/gcp_memory_maintenance_job*.yml", ".github/workflows/gcp_notifications_job.yml", ".github/workflows/gcp_plugins.yml", "plugins/**/*.py", "plugins/Dockerfile"]
+    triggers: ["backend/**/*.py", "backend/**/Dockerfile*", "backend/runtime_images.json", "backend/scripts/runtime_image_contracts.py", ".github/workflows/runtime_image_contracts.yml", ".github/workflows/desktop_backend_auto_dev.yml", ".github/workflows/gcp_backend*.yml", ".github/workflows/gcp_diarizer.yml", ".github/workflows/gcp_models.yml", ".github/workflows/gcp_parakeet.yml", ".github/workflows/gcp_nllb_translation.yml", ".github/workflows/gcp_memory_maintenance_job*.yml", ".github/workflows/gcp_notifications_job.yml", ".github/workflows/gcp_plugins.yml", "plugins/**/*.py", "plugins/Dockerfile"]
     lanes: ["local", "ci"]
     reason: "#9857: deployable Python images must contain the transitive first-party imports of their runtime entrypoints"
   - id: backend-module-isolation
@@ -222,11 +379,6 @@ checks:
     triggers: ["backend/tests/**/*.py", "backend/testing/**/*.py", "backend/tests/.module_stub_legacy_allowlist", "backend/scripts/check_module_stub_pollution.py"]
     lanes: ["local", "ci"]
     reason: "backend tests or their isolation allowlist changed"
-  - id: backend-test-discovery
-    command: ["python3", "backend/scripts/check_unit_test_discovery.py"]
-    triggers: ["backend/tests/**", "backend/testing/**", "backend/scripts/select_backend_unit_tests.py", "backend/scripts/check_unit_test_discovery.py", ".github/workflows/parakeet_gpu_tests.yml", ".github/workflows/backend-hermetic-e2e.yml", ".github/workflows/desktop-backend-contracts.yml", ".github/workflows/backend-unit-tests.yml"]
-    lanes: ["local", "ci"]
-    reason: "every backend test file must be discovered by a verified runner"
   - id: backend-workflow-contracts
     command: ["python3", "backend/scripts/check_workflow_contracts.py", "--changed-files", "{changed_files}"]
     triggers: ["backend/**/*.py", "backend/testing/workflow_contracts.json", ".github/workflows/**/*.yml", ".github/actions/detect-changes/**", "scripts/pre-push", "scripts/changed-files"]
@@ -237,6 +389,21 @@ checks:
     triggers: ["backend/charts/pusher/**", ".github/workflows/gcp_backend_pusher.yml", ".github/workflows/gcp_backend_pusher_auto_deploy.yml", "backend/scripts/verify_pusher_rollout_budget.py", "backend/tests/unit/test_verify_pusher_rollout_budget.py", ".github/checks-manifest.yaml"]
     lanes: ["local", "ci"]
     reason: "#9988: Pusher's Kubernetes deadline and workflow wait must cover chart-derived availability at the HPA ceiling"
+  - id: pusher-rollout-quality-gate
+    command: ["python3", "backend/scripts/verify_pusher_rollout_gate.py"]
+    triggers: ["backend/charts/pusher/**", "backend/utils/metrics.py", "backend/routers/pusher.py", "backend/utils/readiness.py", ".github/workflows/gcp_backend_pusher.yml", ".github/workflows/gcp_backend_pusher_auto_deploy.yml", "backend/scripts/verify_pusher_rollout_gate.py", "backend/scripts/verify_pusher_source_closure.py", "backend/pusher/Dockerfile", "backend/tests/unit/test_verify_pusher_rollout_gate.py", "backend/tests/unit/test_pusher_deployment_control_workflow.py", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "SCA-39: static preflight that fails closed when a pusher rollout cannot be verified safe (capacity, image identity, readiness/health split, telemetry)"
+  - id: pusher-dev-bake-observability
+    command: ["python3", "backend/scripts/verify_pusher_dev_observability.py"]
+    triggers: ["backend/charts/pusher/dev_omi_pusher_values.yaml", "backend/charts/monitoring/kube-prometheus-stack/dev_omi_monitoring_values.yaml", "backend/charts/monitoring/dashboards/gke/pusher.json", "backend/utils/metrics.py", "backend/scripts/verify_pusher_dev_observability.py", "backend/tests/unit/test_verify_pusher_dev_observability.py", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "SCA-115: dev Pusher bake must retain isolated scrape plus connection, drain, and reconnect-circuit visibility"
+  - id: shared-config-migration-preflight
+    command: ["python3", "backend/scripts/verify_shared_config_migration.py", "preflight"]
+    triggers: ["backend/charts/pusher/**", "backend/scripts/verify_shared_config_migration.py", "backend/tests/unit/test_verify_shared_config_migration.py", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "SCA-39: static preflight that fails closed when pusher chart env/envFrom config references are structurally invalid (the 2026-07-22 REDIS_DB_HOST outage class)"
   - id: conversation-lifecycle-write-guard
     command: ["python3", "backend/scripts/check_conversation_lifecycle_writes.py"]
     triggers: ["backend/**/*.py", "backend/scripts/check_conversation_lifecycle_writes.py"]
@@ -244,17 +411,47 @@ checks:
     reason: "conversation lifecycle has one mutation owner"
   - id: desktop-swift-ci-contract
     command: ["python3", ".github/scripts/test_desktop_swift_ci_contract.py"]
-    triggers: [".github/workflows/desktop-swift-ci.yml", ".github/scripts/test_desktop_swift_ci_contract.py"]
+    triggers: [".github/workflows/desktop-swift-ci.yml", "scripts/pre_push_ci_prediction.py", ".github/scripts/test_desktop_swift_ci_contract.py"]
     lanes: ["local", "ci"]
     reason: "#9843 Rung-0: desktop Swift CI must pin its toolchain and cache on Package.resolved"
+  - id: resolve-desktop-changelog-sync-fixtures
+    command: ["python3", ".github/scripts/test_resolve_desktop_changelog_sync.py"]
+    triggers: [".github/scripts/resolve-desktop-changelog-sync.py", ".github/scripts/test_resolve_desktop_changelog_sync.py", ".github/workflows/desktop_auto_release.yml", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "partial tag-release recovery must resolve already-on-main changelog without O(n) main history scans"
   - id: desktop-candidate-source-gate
     command: ["python3", ".github/scripts/test_plan_desktop_release.py"]
-    triggers: [".github/scripts/plan-desktop-release.py", ".github/scripts/test_plan_desktop_release.py", ".github/workflows/desktop_auto_release.yml"]
+    triggers: [".github/scripts/plan-desktop-release.py", ".github/scripts/test_plan_desktop_release.py", ".github/workflows/desktop_auto_release.yml", ".github/checks-manifest.yaml"]
     lanes: ["local", "ci"]
-    reason: "candidate tags require a successful Desktop Swift Build & Tests check for their exact source SHA"
+    reason: "candidate tags require successful Release Eligibility and both Desktop Swift checks for the exact newest queued releasable desktop SHA"
+  - id: desktop-candidate-source-identity
+    command: ["python3", ".github/scripts/test_desktop_release_source_identity.py"]
+    triggers: [".github/scripts/desktop-release-source-identity.py", ".github/scripts/test_desktop_release_source_identity.py", ".github/workflows/desktop_auto_release.yml", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "SCA-129 keeps a current-main candidate bound to the checked desktop source while rejecting a newer releasable desktop change"
+  - id: desktop-candidate-tag-transaction
+    command: ["python3", ".github/scripts/test_publish_desktop_candidate_tag.py"]
+    triggers: [".github/scripts/publish-desktop-candidate-tag.py", ".github/scripts/test_publish_desktop_candidate_tag.py", ".github/workflows/desktop_auto_release.yml", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "SCA-136 requires a fresh authoritative main check plus create-only immutable candidate tag publication"
+  - id: desktop-codemagic-tag-build-observer
+    command: ["python3", ".github/scripts/test_observe_codemagic_tag_build.py"]
+    triggers: [".github/scripts/observe-codemagic-tag-build.py", ".github/scripts/test_observe_codemagic_tag_build.py", ".github/workflows/desktop_auto_release.yml", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "SCA-155 requires exactly one observed native Codemagic tag build; missing, duplicate, and unobservable candidates fail closed with durable evidence"
+  - id: desktop-codemagic-tag-intake-cli
+    command: ["python3", ".github/scripts/check-codemagic-tag-intake.py", "--help"]
+    triggers: [".github/scripts/check-codemagic-tag-intake.py", ".github/workflows/desktop_auto_release.yml", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "SCA-179 keeps the native Codemagic intake observer executable in every candidate-control revision"
+  - id: desktop-codemagic-tag-intake-fixtures
+    command: ["python3", ".github/scripts/test_check_codemagic_tag_intake.py"]
+    triggers: [".github/scripts/check-codemagic-tag-intake.py", ".github/scripts/test_check_codemagic_tag_intake.py", ".github/workflows/desktop_auto_release.yml", "codemagic.yaml", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "SCA-179 requires bounded exact-tag evidence that native Codemagic intake selected the release workflow and immutable source"
   - id: desktop-manifest-routes
     command: ["python3", ".github/scripts/test_desktop_manifest_routes.py"]
-    triggers: [".github/workflows/desktop-swift-ci.yml", ".github/checks-manifest.yaml", ".github/scripts/run_checks.py", ".github/scripts/test_desktop_manifest_routes.py"]
+    triggers: [".github/workflows/desktop-swift-ci.yml", ".github/checks-manifest.yaml", ".github/scripts/run_checks.py", "scripts/pre_push_ci_prediction.py", ".github/scripts/test_desktop_manifest_routes.py"]
     lanes: ["local", "ci"]
     reason: "#9843 Ticket 02: macOS-only manifest checks must have an executable CI route"
   - id: desktop-swift-format-wrapper
@@ -262,6 +459,11 @@ checks:
     triggers: ["desktop/macos/scripts/swift-format-wrapper.sh", "desktop/macos/tests/test-swift-format-wrapper.sh"]
     lanes: ["local", "ci"]
     reason: "#9843 Ticket 02: pinned swift-format bootstrap wrapper provenance contract"
+  - id: desktop-launch-env-forwarding
+    command: ["bash", "desktop/macos/tests/test-launch-env-forwarding.sh"]
+    triggers: ["desktop/macos/run.sh", "desktop/macos/tests/test-launch-env-forwarding.sh"]
+    lanes: ["local", "ci"]
+    reason: "`open` launches from launchd, so a documented run.sh env override that is not passed with `open --env` silently does nothing; caught OMI_FORCE_CANONICAL_MEMORY_ATLAS being documented but never forwarded"
   - id: desktop-main-actor-xctest-hooks
     command: ["python3", "desktop/macos/scripts/check-main-actor-xctest-hooks.py"]
     triggers: ["desktop/macos/Desktop/Tests/**/*.swift", "desktop/macos/scripts/check-main-actor-xctest-hooks.py"]
@@ -357,14 +559,14 @@ checks:
     reason: "#9991 mutation-tests workflow-run event, result, branch, SHA, repository, and manual proof drift"
   - id: gcp-backend-production-boundary
     command: ["python3", ".github/scripts/check-gcp-backend-production-boundary.py"]
-    triggers: [".github/workflows/gcp_backend.yml", "backend/scripts/probe-transcription-candidate-from-cloud-run.sh", "backend/tests/unit/test_probe_transcription_candidate_from_cloud_run.py", ".github/scripts/check-gcp-backend-production-boundary.py", ".github/scripts/test_check_gcp_backend_production_boundary.py", ".github/checks-manifest.yaml"]
+    triggers: [".github/workflows/gcp_backend.yml", "backend/scripts/firebase_release_probe_token.py", "backend/scripts/transcription_capability_probe.py", ".github/scripts/check-gcp-backend-production-boundary.py", ".github/scripts/test_check_gcp_backend_production_boundary.py", ".github/checks-manifest.yaml"]
     lanes: ["local", "ci"]
-    reason: "#10163 locks the supported production Cloud Run-only boundary and canonical tagged-candidate IAM audience without introducing another deployment control plane"
+    reason: "the canonical production deploy is rollback-first and Cloud Run-only"
   - id: gcp-backend-production-boundary-fixtures
     command: ["python3", ".github/scripts/test_check_gcp_backend_production_boundary.py"]
     triggers: [".github/workflows/gcp_backend.yml", ".github/scripts/check-gcp-backend-production-boundary.py", ".github/scripts/test_check_gcp_backend_production_boundary.py", ".github/checks-manifest.yaml"]
     lanes: ["local", "ci"]
-    reason: "#10163 mutation-tests prod/all rejection, canonical IAM audience, and tagged request-target drift"
+    reason: "mutation-tests prod/all admission, serving smoke order, token handling, and rollback coverage"
   - id: direct-backend-production-admission
     command: ["python3", ".github/scripts/check-direct-backend-production-admission.py"]
     triggers: [".github/workflows/gcp_backend_agent_proxy.yml", ".github/workflows/gcp_backend_listen_helm.yml", ".github/workflows/gcp_backend_pusher.yml", ".github/workflows/gcp_llm_gateway.yml", ".github/scripts/check-direct-backend-production-admission.py", ".github/scripts/test_check_direct_backend_production_admission.py", ".github/checks-manifest.yaml"]
@@ -375,11 +577,26 @@ checks:
     triggers: [".github/workflows/gcp_backend_agent_proxy.yml", ".github/workflows/gcp_backend_listen_helm.yml", ".github/workflows/gcp_backend_pusher.yml", ".github/workflows/gcp_llm_gateway.yml", ".github/scripts/check-direct-backend-production-admission.py", ".github/scripts/test_check_direct_backend_production_admission.py", ".github/checks-manifest.yaml"]
     lanes: ["local", "ci"]
     reason: "#10163 mutation-tests branch bypass and GITHUB_SHA image mislabeling"
-  - id: mobile-production-routing
+  - id: production-data-plane-routing
     command: ["python3", ".github/scripts/test_check_mobile_production_routing.py"]
-    triggers: ["codemagic.yaml", ".github/scripts/check-mobile-production-routing.py", ".github/scripts/test_check_mobile_production_routing.py", ".github/checks-manifest.yaml"]
+    triggers: ["codemagic.yaml", "app/lib/env/dev_env.dart", "app/lib/env/prod_env.dart", "app/lib/main.dart", "app/lib/utils/environment_detector.dart", "desktop/macos/Desktop/Sources/AppBuild.swift", "desktop/macos/Desktop/Sources/DesktopBackendEnvironment.swift", "desktop/macos/Desktop/Sources/GoogleService-Info*.plist", "backend/charts/**", ".github/workflows/**", "docs/runbooks/desktop-backend-cloud-run-ownership.md", ".github/scripts/check-mobile-production-routing.py", ".github/scripts/test_check_mobile_production_routing.py", ".github/checks-manifest.yaml"]
     lanes: ["local", "ci"]
-    reason: "#10163 mutation-tests production-family mobile API routing"
+    reason: "INV-DATA-1 mutation-tests every production-family mobile and desktop routing authority and rejects retired GKE desktop-backend ownership"
+  - id: desktop-backend-release-boundary
+    command: ["python3", ".github/scripts/check-desktop-backend-release-policy.py"]
+    triggers: [".github/workflows/desktop_backend_auto_dev.yml", ".github/workflows/desktop_backend_prod.yml", ".github/workflows/desktop_backend_recover_prod.yml", ".github/workflows/desktop_qualify_beta.yml", ".github/workflows/desktop_promote_prod.yml", ".github/scripts/desktop_backend_candidate_probe.py", ".github/scripts/verify_desktop_backend_image_lineage.py", ".github/scripts/check-desktop-backend-release-policy.py", "backend/Dockerfile.desktop_backend", "backend/**/*.py", "backend/pylock.runtime.toml", "desktop/macos/pi-mono-extension/index.ts", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "desktop-backend candidates must prove immutable OCI-index-to-linux/amd64 lineage, authenticated streamed chat with terminal usage, and managed voice-provider paths before any Cloud Run traffic shift"
+  - id: desktop-backend-release-boundary-fixtures
+    command: ["python3", ".github/scripts/test_check_desktop_backend_release_policy.py"]
+    triggers: [".github/workflows/desktop_backend_auto_dev.yml", ".github/workflows/desktop_backend_prod.yml", ".github/workflows/desktop_backend_recover_prod.yml", ".github/workflows/desktop_qualify_beta.yml", ".github/workflows/desktop_promote_prod.yml", ".github/scripts/verify_desktop_backend_image_lineage.py", ".github/scripts/check-desktop-backend-release-policy.py", ".github/scripts/test_check_desktop_backend_release_policy.py", "backend/Dockerfile.desktop_backend", "backend/**/*.py", "backend/pylock.runtime.toml", "desktop/macos/pi-mono-extension/index.ts", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "mutation fixtures reject traffic-before-proof, mutable/stale/wrong-platform images, automatic production deploys, baked runtime credentials, and chat-contract drift"
+  - id: desktop-backend-candidate-probe-fixtures
+    command: ["python3", ".github/scripts/test_desktop_backend_candidate_probe.py"]
+    triggers: [".github/scripts/desktop_backend_candidate_probe.py", ".github/scripts/test_desktop_backend_candidate_probe.py", "backend/**/*.py", "backend/pylock.runtime.toml", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "candidate evidence must require two authenticated streamed chat turns with terminal usage, bounded streaming, Firestore readiness, and secure token handling"
   - id: stable-pointer-precondition-cli
     command: ["python3", ".github/scripts/check_stable_pointer_precondition.py", "--help"]
     triggers: [".github/workflows/desktop_promote_prod.yml", ".github/scripts/check_stable_pointer_precondition.py", ".github/scripts/verify_stable_appcast.py", ".github/scripts/test_stable_promotion_verifiers.py", ".github/checks-manifest.yaml"]
@@ -390,13 +607,59 @@ checks:
     triggers: [".github/workflows/desktop_promote_prod.yml", ".github/scripts/check_stable_pointer_precondition.py", ".github/scripts/verify_stable_appcast.py", ".github/scripts/test_stable_promotion_verifiers.py", ".github/checks-manifest.yaml"]
     lanes: ["local", "ci"]
     reason: "#10163 mutation-sensitive Stable retry and default-channel feed fixtures"
+  - id: desktop-release-one-path-contract
+    command: ["python3", ".github/scripts/test_desktop_release_flow_contract.py"]
+    triggers: ["codemagic.yaml", ".github/workflows/desktop_auto_release.yml", ".github/workflows/desktop_qualify_beta.yml", ".github/workflows/desktop_promote_beta.yml", ".github/workflows/desktop_recover_beta.yml", ".github/workflows/desktop_rollback_beta.yml", ".github/workflows/desktop_breakglass_rollout_beta.yml", ".github/workflows/desktop_beta_admission_control.yml", ".github/workflows/desktop_promote_prod.yml", ".github/workflows/gcp_backend.yml", "desktop/macos/scripts/qualify-desktop-beta.sh", "desktop/macos/scripts/qualification-cache-reclaim.py", "desktop/macos/scripts/qualification-runner-self-clean.py", "desktop/macos/scripts/qualification-watchdog.py", "desktop/macos/scripts/qualification-lease-command.sh", ".github/scripts/test_desktop_release_flow_contract.py", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "SCA-17 prevents duplicate desktop promotion authorities and requires post-traffic production release-vector verification"
+  - id: desktop-qualification-bootstrap-contract
+    command: ["bash", "desktop/macos/tests/test-qualify-desktop-beta-contract.sh"]
+    triggers: [".github/workflows/desktop_qualify_beta.yml", "desktop/macos/scripts/qualify-desktop-beta.sh", "desktop/macos/scripts/prepare-qualification-profile.sh", "desktop/macos/scripts/qualification-cache-reclaim.py", "desktop/macos/scripts/qualification-runner-self-clean.py", "desktop/macos/scripts/qualification-watchdog.py", "desktop/macos/scripts/qualification-swift-cache.sh", "desktop/macos/scripts/qualification-lease-command.sh", "desktop/macos/tests/test-qualify-desktop-beta-contract.sh", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    platforms: ["macos"]
+    reason: "Trusted qualification requires an exact-SHA persistent source, isolated named-bundle, unchanged gates, and phase-bound bootstrap contracts"
+  - id: desktop-qualification-lease-command
+    command: ["bash", "desktop/macos/tests/test-qualification-lease-command.sh"]
+    triggers: ["desktop/macos/scripts/qualification-lease-command.sh", "desktop/macos/tests/test-qualification-lease-command.sh", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    platforms: ["macos"]
+    reason: "SCA-163 keeps lease command failures actionable while stdout remains reserved for the JSON lease capability"
+  - id: desktop-qualification-swift-cache
+    command: ["bash", "desktop/macos/tests/test-qualification-swift-cache.sh"]
+    triggers: ["desktop/macos/scripts/qualification-cache-reclaim.py", "desktop/macos/scripts/qualification-swift-cache.sh", "desktop/macos/scripts/qualify-desktop-beta.sh", "desktop/macos/tests/test-qualification-swift-cache.sh", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    platforms: ["macos"]
+    reason: "Exact-source retries must keep stable absolute SwiftPM paths while rejecting stale provenance, symlinks, collisions, and incomplete entries"
+  - id: desktop-qualification-cache-reclaim
+    command: ["python3", "desktop/macos/tests/test_qualification_cache_reclaim.py"]
+    triggers: [".github/workflows/desktop_qualify_beta.yml", "desktop/macos/scripts/qualification-cache-reclaim.py", "desktop/macos/scripts/qualification-runner-self-clean.py", "desktop/macos/scripts/qualification-swift-cache.sh", "desktop/macos/scripts/qualify-desktop-beta.sh", "desktop/macos/tests/test_qualification_cache_reclaim.py", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    platforms: ["macos"]
+    reason: "Actions runs 30215483845 and 30316131599: preserve the 32 GiB M1 gate while reclaiming exact-SHA, provably idle runner cache entries under capacity pressure"
+  - id: desktop-qualification-runner-self-clean
+    command: ["python3", "desktop/macos/tests/test_qualification_runner_self_clean.py"]
+    triggers: [".github/workflows/desktop_auto_release.yml", ".github/workflows/desktop_qualify_beta.yml", "desktop/macos/scripts/pre-tag-readiness.sh", "desktop/macos/scripts/qualification-runner-self-clean.py", "desktop/macos/scripts/qualification-watchdog.py", "desktop/macos/tests/test_qualification_runner_self_clean.py", "scripts/dev-harness/dev_harness/qualification.py", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    platforms: ["macos"]
+    reason: "Issue #10749 and Actions run 30316131599 require exact-provenance cleanup of abandoned M1 qualification processes, leases, ports, containers, and run stages without touching production apps"
+
+  - id: desktop-beta-qualification-retry
+    command: ["python3", ".github/scripts/test_desktop_beta_qualification_retry.py"]
+    triggers: [".github/workflows/desktop_retry_beta_qualification.yml", ".github/scripts/desktop_beta_qualification_retry.py", ".github/scripts/test_desktop_beta_qualification_retry.py", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "SCA-49 bounded automatic retry of transient failed/cancelled Beta qualification must stay tag-bound, exact-SHA, bounded, and never re-dispatch in-progress/successful runs"
+  - id: guardrail-pulse-tests
+    command: ["python3", ".github/scripts/test_guardrail_pulse.py"]
+    triggers: [".github/scripts/guardrail_pulse.py", ".github/scripts/test_guardrail_pulse.py", ".github/workflows/guardrail-baseline-pulse.yml", ".github/guardrail-pulse-history.jsonl", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "#9454 weekly baseline health pulse parsing, JSONL record, and 30-day staleness detection"
 
 exempt:
+  - path: ".github/scripts/guardrail_pulse.py"
+    reason: "informational weekly baseline health pulse (#9454); unit tests gate via guardrail-pulse-tests, schedule owns --record"
   - path: ".github/scripts/check-desktop-auto-beta-candidate.py"
     reason: "release pipeline check requires published candidate artifacts and workflow inputs"
   - path: ".github/scripts/check-desktop-prod-promotion-policy.py"
-    reason: "release-policy full-tree check, not diff-scoped"
-  - path: ".github/scripts/check-release-process-guards.py"
     reason: "release-policy full-tree check, not diff-scoped"
   - path: ".github/scripts/check-deployment-concurrency.py"
     reason: "deployment concurrency policy full-tree check, not diff-scoped"

--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -4,76 +4,16 @@
 # Checks that consume PR metadata declare `requires_pr_body: true`; post-merge
 # push runs exclude only that category because no authoritative PR body is available.
 checks:
-  - id: dev-harness-unit-tests
-    command: ["bash", "scripts/dev-harness/run-tests.sh"]
-    triggers: ["scripts/dev-harness/**", "desktop/macos/scripts/qualification-lease-command.sh", "desktop/macos/scripts/omi-fault-inject.sh", "desktop/macos/scripts/release-keyvalue.py", ".github/checks-manifest.yaml"]
-    lanes: ["local", "ci"]
-    reason: "the hermetic dev-harness stack backs release qualification; the Jul 22 2026 beta qualification outage added a docker/native typesense runtime that must stay behaviorally covered"
-  - id: pre-tag-readiness-contract
-    command: ["bash", "desktop/macos/tests/test-pre-tag-readiness-contract.sh"]
-    triggers: ["desktop/macos/scripts/pre-tag-readiness.sh", "desktop/macos/scripts/qualification-runner-self-clean.py", "desktop/macos/scripts/qualification-watchdog.py", "desktop/macos/tests/test-pre-tag-readiness-contract.sh", ".github/scripts/verify-pre-tag-readiness.py", ".github/scripts/test_verify_pre_tag_readiness.py", ".github/workflows/desktop_auto_release.yml", ".github/checks-manifest.yaml"]
-    lanes: ["local", "ci"]
-    reason: "trusted-M1 readiness must retain exact-SHA cache/lease ownership and cannot emit a passing receipt before authenticated cleanup"
-  - id: pre-tag-readiness-behavior
-    command: ["python3", "desktop/macos/tests/test_pre_tag_readiness_behavior.py"]
-    triggers: ["desktop/macos/scripts/pre-tag-readiness.sh", "desktop/macos/scripts/qualification-runner-self-clean.py", "desktop/macos/scripts/qualification-watchdog.py", "desktop/macos/tests/test_pre_tag_readiness_behavior.py", ".github/checks-manifest.yaml"]
-    lanes: ["local", "ci"]
-    reason: "a disposable source and authenticated capability fakes prove the real readiness orchestrator emits its exact-SHA receipt only after ordered cleanup"
-  - id: verify-pre-tag-readiness-tests
-    command: ["python3", ".github/scripts/test_verify_pre_tag_readiness.py"]
-    triggers: [".github/scripts/verify-pre-tag-readiness.py", ".github/scripts/test_verify_pre_tag_readiness.py", ".github/checks-manifest.yaml"]
-    lanes: ["local", "ci"]
-    reason: "the receipt verifier must reject stale, non-offline, failed, and promotion-bearing readiness evidence before a tag mutation"
   - id: pre-push-final-pr-diff
     command: ["bash", "scripts/test-pre-push-diff-base.sh"]
     triggers: ["scripts/pre-push", "scripts/pre-push-diff-base", "scripts/test-pre-push-diff-base.sh", ".github/checks-manifest.yaml"]
     lanes: ["local", "ci"]
     reason: "pre-push check selection must use the final PR diff rather than a stale remote feature tip"
-  - id: pre-push-ci-prediction-tests
-    command: ["python3", ".github/scripts/test_pre_push_ci_prediction.py"]
-    triggers: ["scripts/pre-push", "scripts/pre_push_ci_prediction.py", ".github/scripts/test_pre_push_ci_prediction.py", "desktop/macos/scripts/desktop-flow-lint.py", "desktop/macos/scripts/desktop_flow_contract.py", ".github/checks-manifest.yaml"]
-    lanes: ["local", "ci"]
-    reason: "#9440: local CI prediction must select only bounded Flutter generator, desktop-flow, and Windows KG-worker checks for the final PR diff"
-  - id: pre-push-hatch-disclosure
-    command: ["python3", ".github/scripts/check_pre_push_hatch_disclosure.py"]
-    triggers: ["scripts/pre-push", ".github/scripts/check_pre_push_hatch_disclosure.py", ".github/checks-manifest.yaml"]
-    lanes: ["local", "ci"]
-    reason: "make setup provisions no app toolchain while .github/checks-manifest.yaml is a ROUTING_INPUTS entry that wakes the Flutter codegen lane, so a docs-only PR hit 'run flutter pub get' with no mention of PRE_PUSH_SKIP_FLUTTER_GENERATED; actionlint's branch had the same omission, and a hatch nobody can find is not a hatch"
-  - id: setup-pre-push-prerequisites
-    command: ["bash", "scripts/test-make-setup.sh"]
-    triggers: ["Makefile", "backend/scripts/sync-python-deps.sh", "scripts/pre-push", "scripts/test-make-setup.sh", ".github/checks-manifest.yaml"]
-    lanes: ["local", "ci"]
-    reason: "make setup must provision the minimal, rerunnable backend environment required by selected pre-push checks"
-  - id: desktop-release-process-guards
-    command: ["bash", "scripts/run-release-process-guards.sh"]
-    triggers: [".github/workflows/desktop_qualify_beta.yml", ".github/scripts/check-release-process-guards.py", "scripts/run-release-process-guards.sh", "backend/tests/unit/test_desktop_release_scripts.py", ".github/checks-manifest.yaml"]
-    lanes: ["local", "ci"]
-    reason: "SCA-174: qualification must check out the exact release tag inside its isolated source directory; the guard and its focused behavioral test run on every relevant diff"
-  - id: failure-class-retirement-author
-    command: ["python3", ".github/scripts/test_failure_class_retirement.py"]
-    triggers: [".github/scripts/failure_class_retirement.py", ".github/scripts/test_failure_class_retirement.py", ".github/workflows/repo-hygiene.yml", "scripts/failure-class", ".github/checks-manifest.yaml"]
-    lanes: ["local", "ci"]
-    reason: "the weekly retirement author must refuse a truncated event feed; a short feed reports every class as instance-free, so the job would stay green while retiring nothing"
-  - id: desktop-auto-beta-candidate-gate-tests
-    command: ["python3", ".github/scripts/test_check_desktop_auto_beta_candidate.py"]
-    triggers: [".github/scripts/check-desktop-auto-beta-candidate.py", ".github/scripts/test_check_desktop_auto_beta_candidate.py", "codemagic.yaml", "desktop/macos/scripts/smoke-signed-desktop-artifact.sh", ".github/checks-manifest.yaml"]
-    lanes: ["local", "ci"]
-    reason: "the candidate gate validates signed-smoke evidence; a stable-only flag change must not fail-close the first dual-identity release"
   - id: check-manifest-contract
     command: ["python3", ".github/scripts/test_run_checks.py"]
     triggers: ["all"]
     lanes: ["local", "ci"]
     reason: "manifest validity and workflow drift guard"
-  - id: backend-production-release-vector-guards
-    command: ["python3", ".github/scripts/check_release_rings.py"]
-    triggers: [".github/workflows/gcp_backend.yml", ".github/scripts/check_release_rings.py", ".github/checks-manifest.yaml"]
-    lanes: ["local", "ci"]
-    reason: "the canonical production backend deploy remains the only release authority"
-  - id: backend-production-release-vector-guard-tests
-    command: ["python3", ".github/scripts/test_check_release_rings.py"]
-    triggers: [".github/scripts/check_release_rings.py", ".github/scripts/test_check_release_rings.py", ".github/workflows/gcp_backend.yml", ".github/checks-manifest.yaml"]
-    lanes: ["local", "ci"]
-    reason: "the one-action production backend release contract must reject legacy release planes"
   - id: product-file-line-count-ratchet
     command: ["python3", ".github/scripts/check_product_file_line_count_ratchet.py", "--changed-files", "{changed_files}", "--base", "{base}"]
     triggers: ["backend/**/*.py", "desktop/macos/**/*.swift", "desktop/macos/**/*.rs", ".github/scripts/check_product_file_line_count_ratchet.py", ".github/scripts/product_file_line_count_ratchet_baseline/**/*.json"]
@@ -89,73 +29,41 @@ checks:
     triggers: [".github/schemas/desktop-release-manifest-v1.schema.json", ".github/scripts/desktop_release_manifest.py", ".github/scripts/test_desktop_release_manifest.py", ".github/scripts/fixtures/desktop_release_manifest/**"]
     lanes: ["local", "ci"]
     reason: "immutable desktop app/backend release-unit contract"
-  - id: desktop-release-manifest-schema-v1
-    command: ["python3", ".github/scripts/test_desktop_release_manifest_schema.py"]
-    triggers: [".github/schemas/desktop-release-manifest-v1.schema.json", ".github/scripts/test_desktop_release_manifest_schema.py", ".github/checks-manifest.yaml"]
+  - id: pr-scope
+    command: ["python3", ".github/scripts/check_pr_scope.py", "--base", "{base}", "--head", "{head}"]
+    triggers: ["all"]
     lanes: ["local", "ci"]
-    reason: "the Stable manifest schema must keep admitting exactly one app artifact pair; a beta_zip_url re-entering it is how a beta build becomes describable as Stable"
+    reason: "advisory PR production-source churn report (annotations only, never blocks)"
+  - id: pr-scope-helper-tests
+    command: ["python3", ".github/scripts/test_check_pr_scope.py"]
+    triggers: [".github/scripts/check_pr_scope.py", ".github/scripts/test_check_pr_scope.py"]
+    lanes: ["local", "ci"]
+    reason: "scope advisor classification/annotation contract"
   - id: desktop-release-doctor-v1
     command: ["python3", ".github/scripts/test_desktop_release_doctor.py"]
     triggers: [".github/schemas/desktop-release-evidence-v1.schema.json", ".github/scripts/desktop_release_doctor.py", ".github/scripts/desktop_release_doctor_report.py", ".github/scripts/test_desktop_release_doctor.py", ".github/workflows/desktop_release_doctor.yml"]
     lanes: ["local", "ci"]
     reason: "advisory desktop release evidence and drift report"
-  - id: desktop-beta-admission-firestore-contention
-    command: ["bash", "backend/testing/desktop_beta_admission/run.sh"]
-    triggers: ["backend/database/desktop_update_channels.py", "backend/testing/desktop_beta_admission/**", "package.json", "package-lock.json", ".github/checks-manifest.yaml"]
-    lanes: ["local", "ci"]
-    platforms: ["macos"]
-    reason: "real Firestore transaction serialization must fence stale qualified Beta admissions after reservation, pause, and generation transitions"
-  - id: desktop-beta-admission-supervisor
-    command: ["node", "--test", "backend/testing/desktop_beta_admission/test_supervise.mjs"]
-    triggers: ["backend/testing/desktop_beta_admission/**", ".github/checks-manifest.yaml"]
-    lanes: ["local", "ci"]
-    platforms: ["macos"]
-    reason: "SCA-52: the admission emulator must own and drain only its process group, including Firestore JVM grandchildren, on every exit path"
   - id: desktop-changelog-io-tests
     command: ["python3", ".github/scripts/test_desktop_changelog.py"]
-    triggers: [".github/scripts/check-desktop-changelog.py", ".github/scripts/desktop-changelog.py", ".github/scripts/test_desktop_changelog.py", ".github/checks-manifest.yaml"]
+    triggers: [".github/scripts/desktop-changelog.py", ".github/scripts/test_desktop_changelog.py", ".github/checks-manifest.yaml"]
     lanes: ["local", "ci"]
-    reason: "#9717: changelog tooling must preserve UTF-8 I/O and exempt only internal desktop release controls"
+    reason: "#9717: changelog JSON I/O must decode/encode as UTF-8 regardless of contributor host locale"
   - id: agents-md-lean
     command: ["python3", ".github/scripts/check_agents_md_lean.py"]
-    triggers: ["AGENTS.md", "**/AGENTS.md", ".github/scripts/check_agents_md_lean.py"]
+    triggers: ["AGENTS.md", ".github/scripts/check_agents_md_lean.py"]
     lanes: ["local", "ci"]
-    reason: "every AGENTS.md is loaded into agent context; budgets ratchet down, never up"
-  - id: agent-doc-references
-    command: ["python3", ".github/scripts/check_agent_doc_references.py"]
-    triggers: ["AGENTS.md", "**/AGENTS.md", "CLAUDE.md", "PRODUCT.md", "docs/agents/**", ".github/scripts/check_agent_doc_references.py"]
-    lanes: ["local", "ci"]
-    reason: "agents cannot tell a stale pointer from a live one; CLAUDE.md and the desktop/app guides had shipped dead paths"
-  - id: agent-doc-claims
-    command: ["python3", ".github/scripts/check_agent_doc_claims.py"]
-    triggers: [".cursor/cloud-agent-environment.md", "backend/test.sh", "backend/docs/test_isolation.md", ".github/scripts/check_agent_doc_claims.py", ".github/checks-manifest.yaml"]
-    lanes: ["local", "ci"]
-    reason: "a valid pointer proves nothing about the claim around it; .cursor/cloud-agent-environment.md described test.sh halting at the first failure long after it became an aggregating worker pool, and an agent read that and proposed replacing the per-file isolation the suite depends on"
+    reason: "root AGENTS.md stays a lean index; detail lives in component guides"
   - id: diff-hygiene
     command: ["python3", ".github/scripts/check_diff_hygiene.py", "--changed-files", "{changed_files}", "--base", "{base}", "--head", "{head}"]
     triggers: ["all"]
     lanes: ["local", "ci"]
     reason: "all changes must be free of whitespace errors and conflict markers"
-  - id: package-architecture-map-guardrail-tests
-    command: ["python3", ".github/scripts/test_check_package_architecture_maps.py"]
-    triggers: [".github/scripts/check_package_architecture_maps.py", ".github/scripts/test_check_package_architecture_maps.py", ".github/scripts/package_architecture_baseline.json", ".github/checks-manifest.yaml"]
-    lanes: ["local", "ci"]
-    reason: "the package-map ratchet is only a ratchet while its own baseline behavior stays covered"
   - id: architecture-guardrails
     command: ["python3", ".github/scripts/check_arch_guardrails.py", "--changed-files", "{changed_files}", "--base", "{base}"]
     triggers: ["all"]
     lanes: ["local", "ci"]
     reason: "advisory size checks plus oversized package-map baseline ratchet"
-  - id: product-invariant-checker-tests
-    command: ["python3", ".github/scripts/test_check_product_invariants.py"]
-    triggers: [".github/scripts/check_product_invariants.py", ".github/scripts/test_check_product_invariants.py", "docs/product/invariants/**", ".github/checks-manifest.yaml"]
-    lanes: ["local", "ci"]
-    reason: "locked invariant citation enforcement must keep rejecting an uncited path match"
-  - id: pr-preflight-contract-tests
-    command: ["python3", ".github/scripts/test_pr_preflight.py"]
-    triggers: [".github/scripts/pr_preflight.py", ".github/scripts/test_pr_preflight.py", ".github/scripts/pr_metadata.py", ".github/checks-manifest.yaml"]
-    lanes: ["local", "ci"]
-    reason: "preflight resolves the check selection every PR depends on"
   - id: product-invariants
     command: ["python3", ".github/scripts/check_product_invariants.py", "--changed-files", "{changed_files}", "--pr-body-file", "{pr_body_file}"]
     triggers: ["all"]
@@ -168,21 +76,6 @@ checks:
     lanes: ["local", "ci"]
     requires_pr_body: true
     reason: "fix commits declare a validated semantic failure class"
-  - id: failure-class-guard-artifact-ratchet
-    command: ["python3", ".github/scripts/check_failure_class_guard_ratchet.py", "--pr-body-file", "{pr_body_file}"]
-    triggers: ["all"]
-    lanes: ["local", "ci"]
-    reason: "FC-split-mutation-authority was declared on 30 first-parent integration changes in the 90 days to Jul 24 2026 while its definition still listed evidence_prs [9365, 9597] and named no guard artifact; a recurring class must produce a reusable guard surface, not more paperwork"
-  - id: failure-class-guard-artifact-ratchet-tests
-    command: ["python3", ".github/scripts/test_check_failure_class_guard_ratchet.py"]
-    triggers: [".github/scripts/check_failure_class_guard_ratchet.py", ".github/scripts/test_check_failure_class_guard_ratchet.py", ".github/scripts/failure_class_guard_ratchet_allowlist.json", ".github/checks-manifest.yaml"]
-    lanes: ["local", "ci"]
-    reason: "the guard-artifact ratchet's counting window, threshold, allowlist shrink rule, and shallow-history skip must stay behaviorally covered"
-  - id: failure-class-cli-tests
-    command: ["python3", "scripts/test_failure_class.py"]
-    triggers: ["scripts/failure-class", "scripts/test_failure_class.py", ".github/failure-classes/**", ".github/checks-manifest.yaml"]
-    lanes: ["local", "ci"]
-    reason: "the failure-class CLI is the registry's only schema authority; its hermetic tests had no blocking lane and had silently gone stale"
   - id: desktop-changelog-data
     command: ["python3", ".github/scripts/desktop-changelog.py", "validate"]
     triggers: ["all"]
@@ -204,11 +97,6 @@ checks:
     lanes: ["local", "ci"]
     platforms: ["macos"]
     reason: "desktop Swift sources changed; compare against the pinned macOS formatter before requiring a flow cover"
-  - id: brand-ui-ratchet-tests
-    command: ["python3", ".github/scripts/test_check_brand_ui.py"]
-    triggers: [".github/scripts/check_brand_ui.py", ".github/scripts/test_check_brand_ui.py", ".github/checks-manifest.yaml"]
-    lanes: ["local", "ci"]
-    reason: "INV-UI-1 is a no-increase ratchet; its counting behavior must stay covered"
   - id: brand-ui
     command: ["python3", ".github/scripts/check_brand_ui.py", "--changed-files", "{changed_files}", "--base", "{base}"]
     triggers: ["desktop/macos/Desktop/Sources/**/*.swift", "app/lib/**/*.dart", "web/**/*.ts", "web/**/*.tsx", "web/**/*.js", "web/**/*.jsx", "web/**/*.css"]
@@ -244,16 +132,6 @@ checks:
     triggers: [".github/scripts/check_deployment_secret_boundary.py", ".github/scripts/test_check_deployment_secret_boundary.py"]
     lanes: ["local", "ci"]
     reason: "deployment secret-boundary fake-name fixtures must remain executable"
-  - id: github-runner-cost-policy
-    command: ["python3", ".github/scripts/check_runner_cost_policy.py"]
-    triggers: [".github/workflows/**/*.yml", ".github/workflows/**/*.yaml", ".github/actionlint.yaml", ".github/scripts/check_runner_cost_policy.py", ".github/scripts/test_check_runner_cost_policy.py", ".github/checks-manifest.yaml"]
-    lanes: ["local", "ci"]
-    reason: "SCA-196: public-repository standard runners are free while the larger ubuntu-latest-m label caused recurring Linux 4-core charges"
-  - id: github-runner-cost-policy-fixtures
-    command: ["python3", ".github/scripts/test_check_runner_cost_policy.py"]
-    triggers: [".github/scripts/check_runner_cost_policy.py", ".github/scripts/test_check_runner_cost_policy.py"]
-    lanes: ["local", "ci"]
-    reason: "runner cost-policy fixtures must keep rejecting the paid larger-runner label"
   - id: telegram-deployment-notifier
     command: ["bash", ".github/actions/deployment-notifier/test-check-configuration.sh"]
     triggers: [".github/actions/deployment-notifier/**", ".github/checks-manifest.yaml"]
@@ -289,16 +167,6 @@ checks:
     triggers: [".github/scripts/check_public_build_contract.py", ".github/scripts/preflight_public_build_config.py", ".github/scripts/preflight_public_build_runtime.py", ".github/scripts/smoke_public_build_browser.py", ".github/scripts/test_check_public_build_contract.py", "web/personas-open-source/src/app/api/social-profile/route.ts"]
     lanes: ["local", "ci"]
     reason: "public-build contract and GitHub variable scope fixtures must remain executable"
-  - id: web-llm-gateway-only
-    command: ["python3", ".github/scripts/check_web_llm_gateway_only.py"]
-    triggers: ["web/**/*.js", "web/**/*.jsx", "web/**/*.mjs", "web/**/*.ts", "web/**/*.tsx", "web/**/package.json", ".github/scripts/check_web_llm_gateway_only.py", ".github/checks-manifest.yaml"]
-    lanes: ["local", "ci"]
-    reason: "SCA-118: production web LLM traffic must not regain direct provider SDKs, URLs, or credentials"
-  - id: web-llm-gateway-only-tests
-    command: ["python3", ".github/scripts/test_check_web_llm_gateway_only.py"]
-    triggers: [".github/scripts/check_web_llm_gateway_only.py", ".github/scripts/test_check_web_llm_gateway_only.py", ".github/checks-manifest.yaml"]
-    lanes: ["local", "ci"]
-    reason: "the gateway-only source guard must reject provider regressions without flagging its own fixtures"
   - id: backend-async-blockers
     command: ["python3", "backend/scripts/scan_async_blockers.py", "--dirs", "backend/routers", "backend/utils", "backend/agent-proxy", "backend/dependencies.py", "--diff-base", "{base}", "--fail-on", "high_network_io,async_helpers_with_blocking,time_sleep,mixed_await_sync_db,no_await_should_be_def,unmanaged_thread_offload"]
     triggers: ["backend/**/*.py", "backend/agent-proxy/**", "backend/scripts/scan_async_blockers.py"]
@@ -329,21 +197,11 @@ checks:
     triggers: ["backend/database/**/*.py", ".github/scripts/check_firestore_model_read_boundary.py", ".github/scripts/firestore_model_read_boundary_baseline.json"]
     lanes: ["local", "ci"]
     reason: "#9494 -> #9696 malformed Firestore documents must use the shared read boundary"
-  - id: lifecycle-header-checker-tests
-    command: ["python3", ".github/scripts/test_check_lifecycle_headers.py"]
-    triggers: [".github/scripts/check_lifecycle_headers.py", ".github/scripts/test_check_lifecycle_headers.py", ".github/checks-manifest.yaml"]
-    lanes: ["local", "ci"]
-    reason: "one-time rollout scaffolding must keep requiring a DELETE-AFTER reference"
   - id: lifecycle-headers
     command: ["python3", ".github/scripts/check_lifecycle_headers.py", "--changed-files", "{changed_files}"]
     triggers: ["all"]
     lanes: ["local", "ci"]
     reason: "rollout scaffolding may require lifecycle headers"
-  - id: version-prefixed-filename-tests
-    command: ["python3", ".github/scripts/test_check_version_prefixed_filenames.py"]
-    triggers: [".github/scripts/check_version_prefixed_filenames.py", ".github/scripts/test_check_version_prefixed_filenames.py", ".github/checks-manifest.yaml"]
-    lanes: ["local", "ci"]
-    reason: "the repository-wide filename contract must keep rejecting a version-prefixed path"
   - id: version-prefixed-filenames
     command: ["python3", ".github/scripts/check_version_prefixed_filenames.py"]
     triggers: ["all"]
@@ -351,12 +209,12 @@ checks:
     reason: "repository-wide version-prefixed filename contract"
   - id: backend-import-purity
     command: ["python3", "backend/scripts/scan_import_time_side_effects.py", "--files", "{changed_files}", "--check-allowlist-monotonic", "{base}"]
-    triggers: ["backend/**/*.py"]
+    triggers: ["backend/**/*.py", "backend/tests/.import_time_side_effects_legacy_allowlist"]
     lanes: ["local", "ci"]
-    reason: "backend production Python changes must retain import-time purity"
+    reason: "backend production Python or its allowlist changed"
   - id: backend-runtime-image-source-closure
     command: ["python3", "backend/scripts/runtime_image_contracts.py", "check"]
-    triggers: ["backend/**/*.py", "backend/**/Dockerfile*", "backend/runtime_images.json", "backend/scripts/runtime_image_contracts.py", ".github/workflows/runtime_image_contracts.yml", ".github/workflows/desktop_backend_auto_dev.yml", ".github/workflows/gcp_backend*.yml", ".github/workflows/gcp_diarizer.yml", ".github/workflows/gcp_models.yml", ".github/workflows/gcp_parakeet.yml", ".github/workflows/gcp_nllb_translation.yml", ".github/workflows/gcp_memory_maintenance_job*.yml", ".github/workflows/gcp_notifications_job.yml", ".github/workflows/gcp_plugins.yml", "plugins/**/*.py", "plugins/Dockerfile"]
+    triggers: ["backend/**/*.py", "backend/**/Dockerfile*", "backend/runtime_images.json", "backend/scripts/runtime_image_contracts.py", ".github/workflows/runtime_image_contracts.yml", ".github/workflows/gcp_backend*.yml", ".github/workflows/gcp_diarizer.yml", ".github/workflows/gcp_models.yml", ".github/workflows/gcp_parakeet.yml", ".github/workflows/gcp_nllb_translation.yml", ".github/workflows/gcp_memory_maintenance_job*.yml", ".github/workflows/gcp_notifications_job.yml", ".github/workflows/gcp_plugins.yml", "plugins/**/*.py", "plugins/Dockerfile"]
     lanes: ["local", "ci"]
     reason: "#9857: deployable Python images must contain the transitive first-party imports of their runtime entrypoints"
   - id: backend-module-isolation
@@ -364,6 +222,11 @@ checks:
     triggers: ["backend/tests/**/*.py", "backend/testing/**/*.py", "backend/tests/.module_stub_legacy_allowlist", "backend/scripts/check_module_stub_pollution.py"]
     lanes: ["local", "ci"]
     reason: "backend tests or their isolation allowlist changed"
+  - id: backend-test-discovery
+    command: ["python3", "backend/scripts/check_unit_test_discovery.py"]
+    triggers: ["backend/tests/**", "backend/testing/**", "backend/scripts/select_backend_unit_tests.py", "backend/scripts/check_unit_test_discovery.py", ".github/workflows/parakeet_gpu_tests.yml", ".github/workflows/backend-hermetic-e2e.yml", ".github/workflows/desktop-backend-contracts.yml", ".github/workflows/backend-unit-tests.yml"]
+    lanes: ["local", "ci"]
+    reason: "every backend test file must be discovered by a verified runner"
   - id: backend-workflow-contracts
     command: ["python3", "backend/scripts/check_workflow_contracts.py", "--changed-files", "{changed_files}"]
     triggers: ["backend/**/*.py", "backend/testing/workflow_contracts.json", ".github/workflows/**/*.yml", ".github/actions/detect-changes/**", "scripts/pre-push", "scripts/changed-files"]
@@ -374,21 +237,6 @@ checks:
     triggers: ["backend/charts/pusher/**", ".github/workflows/gcp_backend_pusher.yml", ".github/workflows/gcp_backend_pusher_auto_deploy.yml", "backend/scripts/verify_pusher_rollout_budget.py", "backend/tests/unit/test_verify_pusher_rollout_budget.py", ".github/checks-manifest.yaml"]
     lanes: ["local", "ci"]
     reason: "#9988: Pusher's Kubernetes deadline and workflow wait must cover chart-derived availability at the HPA ceiling"
-  - id: pusher-rollout-quality-gate
-    command: ["python3", "backend/scripts/verify_pusher_rollout_gate.py"]
-    triggers: ["backend/charts/pusher/**", "backend/utils/metrics.py", "backend/routers/pusher.py", "backend/utils/readiness.py", ".github/workflows/gcp_backend_pusher.yml", ".github/workflows/gcp_backend_pusher_auto_deploy.yml", "backend/scripts/verify_pusher_rollout_gate.py", "backend/scripts/verify_pusher_source_closure.py", "backend/pusher/Dockerfile", "backend/tests/unit/test_verify_pusher_rollout_gate.py", "backend/tests/unit/test_pusher_deployment_control_workflow.py", ".github/checks-manifest.yaml"]
-    lanes: ["local", "ci"]
-    reason: "SCA-39: static preflight that fails closed when a pusher rollout cannot be verified safe (capacity, image identity, readiness/health split, telemetry)"
-  - id: pusher-dev-bake-observability
-    command: ["python3", "backend/scripts/verify_pusher_dev_observability.py"]
-    triggers: ["backend/charts/pusher/dev_omi_pusher_values.yaml", "backend/charts/monitoring/kube-prometheus-stack/dev_omi_monitoring_values.yaml", "backend/charts/monitoring/dashboards/gke/pusher.json", "backend/utils/metrics.py", "backend/scripts/verify_pusher_dev_observability.py", "backend/tests/unit/test_verify_pusher_dev_observability.py", ".github/checks-manifest.yaml"]
-    lanes: ["local", "ci"]
-    reason: "SCA-115: dev Pusher bake must retain isolated scrape plus connection, drain, and reconnect-circuit visibility"
-  - id: shared-config-migration-preflight
-    command: ["python3", "backend/scripts/verify_shared_config_migration.py", "preflight"]
-    triggers: ["backend/charts/pusher/**", "backend/scripts/verify_shared_config_migration.py", "backend/tests/unit/test_verify_shared_config_migration.py", ".github/checks-manifest.yaml"]
-    lanes: ["local", "ci"]
-    reason: "SCA-39: static preflight that fails closed when pusher chart env/envFrom config references are structurally invalid (the 2026-07-22 REDIS_DB_HOST outage class)"
   - id: conversation-lifecycle-write-guard
     command: ["python3", "backend/scripts/check_conversation_lifecycle_writes.py"]
     triggers: ["backend/**/*.py", "backend/scripts/check_conversation_lifecycle_writes.py"]
@@ -396,47 +244,17 @@ checks:
     reason: "conversation lifecycle has one mutation owner"
   - id: desktop-swift-ci-contract
     command: ["python3", ".github/scripts/test_desktop_swift_ci_contract.py"]
-    triggers: [".github/workflows/desktop-swift-ci.yml", "scripts/pre_push_ci_prediction.py", ".github/scripts/test_desktop_swift_ci_contract.py"]
+    triggers: [".github/workflows/desktop-swift-ci.yml", ".github/scripts/test_desktop_swift_ci_contract.py"]
     lanes: ["local", "ci"]
     reason: "#9843 Rung-0: desktop Swift CI must pin its toolchain and cache on Package.resolved"
-  - id: resolve-desktop-changelog-sync-fixtures
-    command: ["python3", ".github/scripts/test_resolve_desktop_changelog_sync.py"]
-    triggers: [".github/scripts/resolve-desktop-changelog-sync.py", ".github/scripts/test_resolve_desktop_changelog_sync.py", ".github/workflows/desktop_auto_release.yml", ".github/checks-manifest.yaml"]
-    lanes: ["local", "ci"]
-    reason: "partial tag-release recovery must resolve already-on-main changelog without O(n) main history scans"
   - id: desktop-candidate-source-gate
     command: ["python3", ".github/scripts/test_plan_desktop_release.py"]
-    triggers: [".github/scripts/plan-desktop-release.py", ".github/scripts/test_plan_desktop_release.py", ".github/workflows/desktop_auto_release.yml", ".github/checks-manifest.yaml"]
+    triggers: [".github/scripts/plan-desktop-release.py", ".github/scripts/test_plan_desktop_release.py", ".github/workflows/desktop_auto_release.yml"]
     lanes: ["local", "ci"]
-    reason: "candidate tags require successful Release Eligibility and both Desktop Swift checks for the exact newest queued releasable desktop SHA"
-  - id: desktop-candidate-source-identity
-    command: ["python3", ".github/scripts/test_desktop_release_source_identity.py"]
-    triggers: [".github/scripts/desktop-release-source-identity.py", ".github/scripts/test_desktop_release_source_identity.py", ".github/workflows/desktop_auto_release.yml", ".github/checks-manifest.yaml"]
-    lanes: ["local", "ci"]
-    reason: "SCA-129 keeps a current-main candidate bound to the checked desktop source while rejecting a newer releasable desktop change"
-  - id: desktop-candidate-tag-transaction
-    command: ["python3", ".github/scripts/test_publish_desktop_candidate_tag.py"]
-    triggers: [".github/scripts/publish-desktop-candidate-tag.py", ".github/scripts/test_publish_desktop_candidate_tag.py", ".github/workflows/desktop_auto_release.yml", ".github/checks-manifest.yaml"]
-    lanes: ["local", "ci"]
-    reason: "SCA-136 requires a fresh authoritative main check plus create-only immutable candidate tag publication"
-  - id: desktop-codemagic-tag-build-observer
-    command: ["python3", ".github/scripts/test_observe_codemagic_tag_build.py"]
-    triggers: [".github/scripts/observe-codemagic-tag-build.py", ".github/scripts/test_observe_codemagic_tag_build.py", ".github/workflows/desktop_auto_release.yml", ".github/checks-manifest.yaml"]
-    lanes: ["local", "ci"]
-    reason: "SCA-155 requires exactly one observed native Codemagic tag build; missing, duplicate, and unobservable candidates fail closed with durable evidence"
-  - id: desktop-codemagic-tag-intake-cli
-    command: ["python3", ".github/scripts/check-codemagic-tag-intake.py", "--help"]
-    triggers: [".github/scripts/check-codemagic-tag-intake.py", ".github/workflows/desktop_auto_release.yml", ".github/checks-manifest.yaml"]
-    lanes: ["local", "ci"]
-    reason: "SCA-179 keeps the native Codemagic intake observer executable in every candidate-control revision"
-  - id: desktop-codemagic-tag-intake-fixtures
-    command: ["python3", ".github/scripts/test_check_codemagic_tag_intake.py"]
-    triggers: [".github/scripts/check-codemagic-tag-intake.py", ".github/scripts/test_check_codemagic_tag_intake.py", ".github/workflows/desktop_auto_release.yml", "codemagic.yaml", ".github/checks-manifest.yaml"]
-    lanes: ["local", "ci"]
-    reason: "SCA-179 requires bounded exact-tag evidence that native Codemagic intake selected the release workflow and immutable source"
+    reason: "candidate tags require a successful Desktop Swift Build & Tests check for their exact source SHA"
   - id: desktop-manifest-routes
     command: ["python3", ".github/scripts/test_desktop_manifest_routes.py"]
-    triggers: [".github/workflows/desktop-swift-ci.yml", ".github/checks-manifest.yaml", ".github/scripts/run_checks.py", "scripts/pre_push_ci_prediction.py", ".github/scripts/test_desktop_manifest_routes.py"]
+    triggers: [".github/workflows/desktop-swift-ci.yml", ".github/checks-manifest.yaml", ".github/scripts/run_checks.py", ".github/scripts/test_desktop_manifest_routes.py"]
     lanes: ["local", "ci"]
     reason: "#9843 Ticket 02: macOS-only manifest checks must have an executable CI route"
   - id: desktop-swift-format-wrapper
@@ -444,11 +262,6 @@ checks:
     triggers: ["desktop/macos/scripts/swift-format-wrapper.sh", "desktop/macos/tests/test-swift-format-wrapper.sh"]
     lanes: ["local", "ci"]
     reason: "#9843 Ticket 02: pinned swift-format bootstrap wrapper provenance contract"
-  - id: desktop-launch-env-forwarding
-    command: ["bash", "desktop/macos/tests/test-launch-env-forwarding.sh"]
-    triggers: ["desktop/macos/run.sh", "desktop/macos/tests/test-launch-env-forwarding.sh"]
-    lanes: ["local", "ci"]
-    reason: "`open` launches from launchd, so a documented run.sh env override that is not passed with `open --env` silently does nothing; caught OMI_FORCE_CANONICAL_MEMORY_ATLAS being documented but never forwarded"
   - id: desktop-main-actor-xctest-hooks
     command: ["python3", "desktop/macos/scripts/check-main-actor-xctest-hooks.py"]
     triggers: ["desktop/macos/Desktop/Tests/**/*.swift", "desktop/macos/scripts/check-main-actor-xctest-hooks.py"]
@@ -544,14 +357,14 @@ checks:
     reason: "#9991 mutation-tests workflow-run event, result, branch, SHA, repository, and manual proof drift"
   - id: gcp-backend-production-boundary
     command: ["python3", ".github/scripts/check-gcp-backend-production-boundary.py"]
-    triggers: [".github/workflows/gcp_backend.yml", "backend/scripts/firebase_release_probe_token.py", "backend/scripts/transcription_capability_probe.py", ".github/scripts/check-gcp-backend-production-boundary.py", ".github/scripts/test_check_gcp_backend_production_boundary.py", ".github/checks-manifest.yaml"]
+    triggers: [".github/workflows/gcp_backend.yml", "backend/scripts/probe-transcription-candidate-from-cloud-run.sh", "backend/tests/unit/test_probe_transcription_candidate_from_cloud_run.py", ".github/scripts/check-gcp-backend-production-boundary.py", ".github/scripts/test_check_gcp_backend_production_boundary.py", ".github/checks-manifest.yaml"]
     lanes: ["local", "ci"]
-    reason: "the canonical production deploy is rollback-first and Cloud Run-only"
+    reason: "#10163 locks the supported production Cloud Run-only boundary and canonical tagged-candidate IAM audience without introducing another deployment control plane"
   - id: gcp-backend-production-boundary-fixtures
     command: ["python3", ".github/scripts/test_check_gcp_backend_production_boundary.py"]
     triggers: [".github/workflows/gcp_backend.yml", ".github/scripts/check-gcp-backend-production-boundary.py", ".github/scripts/test_check_gcp_backend_production_boundary.py", ".github/checks-manifest.yaml"]
     lanes: ["local", "ci"]
-    reason: "mutation-tests prod/all admission, serving smoke order, token handling, and rollback coverage"
+    reason: "#10163 mutation-tests prod/all rejection, canonical IAM audience, and tagged request-target drift"
   - id: direct-backend-production-admission
     command: ["python3", ".github/scripts/check-direct-backend-production-admission.py"]
     triggers: [".github/workflows/gcp_backend_agent_proxy.yml", ".github/workflows/gcp_backend_listen_helm.yml", ".github/workflows/gcp_backend_pusher.yml", ".github/workflows/gcp_llm_gateway.yml", ".github/scripts/check-direct-backend-production-admission.py", ".github/scripts/test_check_direct_backend_production_admission.py", ".github/checks-manifest.yaml"]
@@ -562,26 +375,11 @@ checks:
     triggers: [".github/workflows/gcp_backend_agent_proxy.yml", ".github/workflows/gcp_backend_listen_helm.yml", ".github/workflows/gcp_backend_pusher.yml", ".github/workflows/gcp_llm_gateway.yml", ".github/scripts/check-direct-backend-production-admission.py", ".github/scripts/test_check_direct_backend_production_admission.py", ".github/checks-manifest.yaml"]
     lanes: ["local", "ci"]
     reason: "#10163 mutation-tests branch bypass and GITHUB_SHA image mislabeling"
-  - id: production-data-plane-routing
+  - id: mobile-production-routing
     command: ["python3", ".github/scripts/test_check_mobile_production_routing.py"]
-    triggers: ["codemagic.yaml", "app/lib/env/dev_env.dart", "app/lib/env/prod_env.dart", "app/lib/main.dart", "app/lib/utils/environment_detector.dart", "desktop/macos/Desktop/Sources/AppBuild.swift", "desktop/macos/Desktop/Sources/DesktopBackendEnvironment.swift", "desktop/macos/Desktop/Sources/GoogleService-Info*.plist", "backend/charts/**", ".github/workflows/**", "docs/runbooks/desktop-backend-cloud-run-ownership.md", ".github/scripts/check-mobile-production-routing.py", ".github/scripts/test_check_mobile_production_routing.py", ".github/checks-manifest.yaml"]
+    triggers: ["codemagic.yaml", ".github/scripts/check-mobile-production-routing.py", ".github/scripts/test_check_mobile_production_routing.py", ".github/checks-manifest.yaml"]
     lanes: ["local", "ci"]
-    reason: "INV-DATA-1 mutation-tests every production-family mobile and desktop routing authority and rejects retired GKE desktop-backend ownership"
-  - id: desktop-backend-release-boundary
-    command: ["python3", ".github/scripts/check-desktop-backend-release-policy.py"]
-    triggers: [".github/workflows/desktop_backend_auto_dev.yml", ".github/workflows/desktop_backend_prod.yml", ".github/workflows/desktop_backend_recover_prod.yml", ".github/workflows/desktop_qualify_beta.yml", ".github/workflows/desktop_promote_prod.yml", ".github/scripts/desktop_backend_candidate_probe.py", ".github/scripts/verify_desktop_backend_image_lineage.py", ".github/scripts/check-desktop-backend-release-policy.py", "backend/Dockerfile.desktop_backend", "backend/**/*.py", "backend/pylock.runtime.toml", "desktop/macos/pi-mono-extension/index.ts", ".github/checks-manifest.yaml"]
-    lanes: ["local", "ci"]
-    reason: "desktop-backend candidates must prove immutable OCI-index-to-linux/amd64 lineage, authenticated streamed chat with terminal usage, and managed voice-provider paths before any Cloud Run traffic shift"
-  - id: desktop-backend-release-boundary-fixtures
-    command: ["python3", ".github/scripts/test_check_desktop_backend_release_policy.py"]
-    triggers: [".github/workflows/desktop_backend_auto_dev.yml", ".github/workflows/desktop_backend_prod.yml", ".github/workflows/desktop_backend_recover_prod.yml", ".github/workflows/desktop_qualify_beta.yml", ".github/workflows/desktop_promote_prod.yml", ".github/scripts/verify_desktop_backend_image_lineage.py", ".github/scripts/check-desktop-backend-release-policy.py", ".github/scripts/test_check_desktop_backend_release_policy.py", "backend/Dockerfile.desktop_backend", "backend/**/*.py", "backend/pylock.runtime.toml", "desktop/macos/pi-mono-extension/index.ts", ".github/checks-manifest.yaml"]
-    lanes: ["local", "ci"]
-    reason: "mutation fixtures reject traffic-before-proof, mutable/stale/wrong-platform images, automatic production deploys, baked runtime credentials, and chat-contract drift"
-  - id: desktop-backend-candidate-probe-fixtures
-    command: ["python3", ".github/scripts/test_desktop_backend_candidate_probe.py"]
-    triggers: [".github/scripts/desktop_backend_candidate_probe.py", ".github/scripts/test_desktop_backend_candidate_probe.py", "backend/**/*.py", "backend/pylock.runtime.toml", ".github/checks-manifest.yaml"]
-    lanes: ["local", "ci"]
-    reason: "candidate evidence must require two authenticated streamed chat turns with terminal usage, bounded streaming, Firestore readiness, and secure token handling"
+    reason: "#10163 mutation-tests production-family mobile API routing"
   - id: stable-pointer-precondition-cli
     command: ["python3", ".github/scripts/check_stable_pointer_precondition.py", "--help"]
     triggers: [".github/workflows/desktop_promote_prod.yml", ".github/scripts/check_stable_pointer_precondition.py", ".github/scripts/verify_stable_appcast.py", ".github/scripts/test_stable_promotion_verifiers.py", ".github/checks-manifest.yaml"]
@@ -592,59 +390,13 @@ checks:
     triggers: [".github/workflows/desktop_promote_prod.yml", ".github/scripts/check_stable_pointer_precondition.py", ".github/scripts/verify_stable_appcast.py", ".github/scripts/test_stable_promotion_verifiers.py", ".github/checks-manifest.yaml"]
     lanes: ["local", "ci"]
     reason: "#10163 mutation-sensitive Stable retry and default-channel feed fixtures"
-  - id: desktop-release-one-path-contract
-    command: ["python3", ".github/scripts/test_desktop_release_flow_contract.py"]
-    triggers: ["codemagic.yaml", ".github/workflows/desktop_auto_release.yml", ".github/workflows/desktop_qualify_beta.yml", ".github/workflows/desktop_promote_beta.yml", ".github/workflows/desktop_recover_beta.yml", ".github/workflows/desktop_rollback_beta.yml", ".github/workflows/desktop_breakglass_rollout_beta.yml", ".github/workflows/desktop_beta_admission_control.yml", ".github/workflows/desktop_promote_prod.yml", ".github/workflows/gcp_backend.yml", "desktop/macos/scripts/qualify-desktop-beta.sh", "desktop/macos/scripts/qualification-cache-reclaim.py", "desktop/macos/scripts/qualification-runner-self-clean.py", "desktop/macos/scripts/qualification-watchdog.py", "desktop/macos/scripts/qualification-lease-command.sh", ".github/scripts/test_desktop_release_flow_contract.py", ".github/checks-manifest.yaml"]
-    lanes: ["local", "ci"]
-    reason: "SCA-17 prevents duplicate desktop promotion authorities and requires post-traffic production release-vector verification"
-  - id: desktop-qualification-bootstrap-contract
-    command: ["bash", "desktop/macos/tests/test-qualify-desktop-beta-contract.sh"]
-    triggers: [".github/workflows/desktop_qualify_beta.yml", "desktop/macos/scripts/qualify-desktop-beta.sh", "desktop/macos/scripts/prepare-qualification-profile.sh", "desktop/macos/scripts/qualification-cache-reclaim.py", "desktop/macos/scripts/qualification-runner-self-clean.py", "desktop/macos/scripts/qualification-watchdog.py", "desktop/macos/scripts/qualification-swift-cache.sh", "desktop/macos/scripts/qualification-lease-command.sh", "desktop/macos/tests/test-qualify-desktop-beta-contract.sh", ".github/checks-manifest.yaml"]
-    lanes: ["local", "ci"]
-    platforms: ["macos"]
-    reason: "Trusted qualification requires an exact-SHA persistent source, isolated named-bundle, unchanged gates, and phase-bound bootstrap contracts"
-  - id: desktop-qualification-lease-command
-    command: ["bash", "desktop/macos/tests/test-qualification-lease-command.sh"]
-    triggers: ["desktop/macos/scripts/qualification-lease-command.sh", "desktop/macos/tests/test-qualification-lease-command.sh", ".github/checks-manifest.yaml"]
-    lanes: ["local", "ci"]
-    platforms: ["macos"]
-    reason: "SCA-163 keeps lease command failures actionable while stdout remains reserved for the JSON lease capability"
-  - id: desktop-qualification-swift-cache
-    command: ["bash", "desktop/macos/tests/test-qualification-swift-cache.sh"]
-    triggers: ["desktop/macos/scripts/qualification-cache-reclaim.py", "desktop/macos/scripts/qualification-swift-cache.sh", "desktop/macos/scripts/qualify-desktop-beta.sh", "desktop/macos/tests/test-qualification-swift-cache.sh", ".github/checks-manifest.yaml"]
-    lanes: ["local", "ci"]
-    platforms: ["macos"]
-    reason: "Exact-source retries must keep stable absolute SwiftPM paths while rejecting stale provenance, symlinks, collisions, and incomplete entries"
-  - id: desktop-qualification-cache-reclaim
-    command: ["python3", "desktop/macos/tests/test_qualification_cache_reclaim.py"]
-    triggers: [".github/workflows/desktop_qualify_beta.yml", "desktop/macos/scripts/qualification-cache-reclaim.py", "desktop/macos/scripts/qualification-runner-self-clean.py", "desktop/macos/scripts/qualification-swift-cache.sh", "desktop/macos/scripts/qualify-desktop-beta.sh", "desktop/macos/tests/test_qualification_cache_reclaim.py", ".github/checks-manifest.yaml"]
-    lanes: ["local", "ci"]
-    platforms: ["macos"]
-    reason: "Actions runs 30215483845 and 30316131599: preserve the 32 GiB M1 gate while reclaiming exact-SHA, provably idle runner cache entries under capacity pressure"
-  - id: desktop-qualification-runner-self-clean
-    command: ["python3", "desktop/macos/tests/test_qualification_runner_self_clean.py"]
-    triggers: [".github/workflows/desktop_auto_release.yml", ".github/workflows/desktop_qualify_beta.yml", "desktop/macos/scripts/pre-tag-readiness.sh", "desktop/macos/scripts/qualification-runner-self-clean.py", "desktop/macos/scripts/qualification-watchdog.py", "desktop/macos/tests/test_qualification_runner_self_clean.py", "scripts/dev-harness/dev_harness/qualification.py", ".github/checks-manifest.yaml"]
-    lanes: ["local", "ci"]
-    platforms: ["macos"]
-    reason: "Issue #10749 and Actions run 30316131599 require exact-provenance cleanup of abandoned M1 qualification processes, leases, ports, containers, and run stages without touching production apps"
-
-  - id: desktop-beta-qualification-retry
-    command: ["python3", ".github/scripts/test_desktop_beta_qualification_retry.py"]
-    triggers: [".github/workflows/desktop_retry_beta_qualification.yml", ".github/scripts/desktop_beta_qualification_retry.py", ".github/scripts/test_desktop_beta_qualification_retry.py", ".github/checks-manifest.yaml"]
-    lanes: ["local", "ci"]
-    reason: "SCA-49 bounded automatic retry of transient failed/cancelled Beta qualification must stay tag-bound, exact-SHA, bounded, and never re-dispatch in-progress/successful runs"
-  - id: guardrail-pulse-tests
-    command: ["python3", ".github/scripts/test_guardrail_pulse.py"]
-    triggers: [".github/scripts/guardrail_pulse.py", ".github/scripts/test_guardrail_pulse.py", ".github/workflows/guardrail-baseline-pulse.yml", ".github/guardrail-pulse-history.jsonl", ".github/checks-manifest.yaml"]
-    lanes: ["local", "ci"]
-    reason: "#9454 weekly baseline health pulse parsing, JSONL record, and 30-day staleness detection"
 
 exempt:
-  - path: ".github/scripts/guardrail_pulse.py"
-    reason: "informational weekly baseline health pulse (#9454); unit tests gate via guardrail-pulse-tests, schedule owns --record"
   - path: ".github/scripts/check-desktop-auto-beta-candidate.py"
     reason: "release pipeline check requires published candidate artifacts and workflow inputs"
   - path: ".github/scripts/check-desktop-prod-promotion-policy.py"
+    reason: "release-policy full-tree check, not diff-scoped"
+  - path: ".github/scripts/check-release-process-guards.py"
     reason: "release-policy full-tree check, not diff-scoped"
   - path: ".github/scripts/check-deployment-concurrency.py"
     reason: "deployment concurrency policy full-tree check, not diff-scoped"

--- a/.github/scripts/check_pr_scope.py
+++ b/.github/scripts/check_pr_scope.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""PR scope advisor: report the amount of production source one PR changes.
+
+Motivation (regression research over merged PRs, July 2026): reviewer and CI
+effectiveness fall off sharply with diff size. In the last ~30 merged PRs,
+every PR above ~2,400 changed production-source lines shipped at least one
+production regression (2,475 → 3 regressions; 2,652 → 1; 51,564 → 4+ plus two
+test files silently dropped from the CI runner), while defects in small PRs
+were reliably caught by review.
+
+Policy — advisory only, never blocks (maintainer decision on #9634: each PR
+carries a human verification cost, so a hard gate that forces feature splits
+can cost more human time than the regressions it prevents; the size signal
+stays because review effectiveness demonstrably collapses with diff size):
+
+- >= WARN_LINES:   warning annotation — flags the PR for extra review depth
+  and suggests splitting where a split is free.
+- >= REVIEW_COLLAPSE_LINES: stronger warning citing the audit finding, so the
+  reviewer sizes their skepticism to the diff. Still exit 0.
+- ``push`` events (post-merge main) are notice-only: nothing left to advise.
+
+Diffing matches ``scripts/changed-files`` policy: ``--no-renames``, so a moved
+file cannot escape classification via rename notation (a pure move therefore
+counts both sides), and ``-z`` output keeps non-ASCII paths raw.
+
+Runs from the checks manifest (local + ci lanes). Stdlib-only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+
+WARN_LINES = 1500
+REVIEW_COLLAPSE_LINES = 3000
+
+# Paths whose churn does not count toward reviewable production source.
+# Covers every test convention present in this repo: Python/Dart (tests/,
+# test_*.py), Swift (Desktop/Tests/, *Tests.swift), JS/TS (__tests__/,
+# *.test.ts), Flutter integration (integration_test/).
+_EXCLUDED_PATTERNS = (
+    r'(^|/)[Tt]ests?/',
+    r'(^|/)__tests__/',
+    r'(^|/)testing/',
+    r'(^|/)e2e/',
+    r'(^|/)integration_test/',
+    r'(^|/)test_[^/]*\.(py|dart|swift|rs|ts|tsx|js|jsx)$',
+    r'_test\.(py|go|rs|dart|ts|tsx|js|jsx)$',
+    r'\.test\.(ts|tsx|js|jsx|mjs|cjs)$',
+    r'Tests\.swift$',
+    r'\.md$',
+    r'\.mdx$',
+    r'^docs/',
+    r'\.arb$',  # l10n
+    r'\.lock$',
+    r'(^|/)pylock[^/]*\.toml$',
+    r'package-lock\.json$',
+    r'\.g\.dart$',
+    r'\.gen\.dart$',
+    r'(^|/)generated/',
+    r'^\.cursor/',
+    r'(^|/)changelog/',
+    r'\.snap$',
+    r'(^|/)openapi\.json$',
+)
+_EXCLUDED_RE = re.compile('|'.join(f'(?:{p})' for p in _EXCLUDED_PATTERNS))
+
+
+def is_production_source(path: str) -> bool:
+    return not _EXCLUDED_RE.search(path)
+
+
+def count_production_lines(numstat_output: str) -> tuple[int, list[tuple[int, str]]]:
+    """Sum added+deleted lines over production files from `git diff --numstat -z` output."""
+    total = 0
+    per_file: list[tuple[int, str]] = []
+    # -z records: "added\tdeleted\tpath\0" with the path raw (no C-quoting).
+    for record in numstat_output.split('\0'):
+        parts = record.split('\t', 2)
+        if len(parts) != 3:
+            continue
+        added, deleted, path = parts
+        if added == '-' or deleted == '-':  # binary
+            continue
+        if not is_production_source(path):
+            continue
+        changed = int(added) + int(deleted)
+        total += changed
+        per_file.append((changed, path))
+    per_file.sort(reverse=True)
+    return total, per_file
+
+
+def evaluate(total: int, *, notice_only: bool = False) -> str:
+    """Return the GitHub annotation line for this diff size. Advisory: never fails."""
+    if notice_only:
+        return f'::notice title=PR scope::{total} changed production-source lines.'
+    if total >= REVIEW_COLLAPSE_LINES:
+        return (
+            f'::warning title=PR scope::{total} changed production-source lines >= '
+            f'{REVIEW_COLLAPSE_LINES}. In the audited merge history every PR this size '
+            f'shipped at least one regression that review missed — review with that '
+            f'expectation, and split if a split does not add verification burden. '
+            f'Advisory only; this check never blocks.'
+        )
+    if total >= WARN_LINES:
+        return (
+            f'::warning title=PR scope::{total} changed production-source lines >= {WARN_LINES}. '
+            f'Historically PRs above this size shipped regressions; consider splitting where '
+            f'a split is free. Advisory only; this check never blocks.'
+        )
+    return f'::notice title=PR scope::{total} changed production-source lines.'
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--base', required=True, help='diff base (pre-resolved to the merge-base by run_checks.py)')
+    parser.add_argument('--head', default='HEAD', help='diff head ref/sha')
+    args = parser.parse_args()
+
+    # --no-renames mirrors scripts/changed-files: a moved file must not escape
+    # classification via rename notation ("dir/{old => new}"); -z keeps
+    # non-ASCII paths raw instead of C-quoted.
+    diff = subprocess.run(
+        ['git', 'diff', '--numstat', '--no-renames', '-z', f'{args.base}...{args.head}'],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if diff.returncode != 0:
+        print(
+            f'::error title=PR scope::git diff {args.base}...{args.head} failed '
+            f'(is the base fetched?): {diff.stderr.strip()}'
+        )
+        return 1
+    total, per_file = count_production_lines(diff.stdout)
+
+    for changed, path in per_file[:10]:
+        print(f'  {changed:>6}  {path}')
+    print(evaluate(total, notice_only=os.environ.get('GITHUB_EVENT_NAME', '') == 'push'))
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/.github/scripts/run_checks.py
+++ b/.github/scripts/run_checks.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import argparse
 import fnmatch
-import glob
 import json
 import platform as _platform_mod
 import subprocess
@@ -16,7 +15,8 @@ from dataclasses import dataclass
 from pathlib import Path, PurePath
 from typing import Any
 
-VALID_PLATFORMS = {"all", "macos", "linux", "windows"}
+
+VALID_PLATFORMS = {"all", "macos", "linux"}
 
 
 def detect_platform() -> str:
@@ -26,8 +26,6 @@ def detect_platform() -> str:
         return "macos"
     if system == "Linux":
         return "linux"
-    if system == "Windows":
-        return "windows"
     return system.lower()
 
 
@@ -52,14 +50,6 @@ class Exemption:
 class Manifest:
     checks: tuple[Check, ...]
     exempt: tuple[Exemption, ...]
-
-
-@dataclass(frozen=True)
-class CheckSelection:
-    """A manifest check together with the paths that selected it."""
-
-    check: Check
-    matched_paths: tuple[str, ...]
 
 
 def _parse_value(raw: str) -> Any:
@@ -138,8 +128,6 @@ def validate_manifest(manifest: Manifest, root: Path) -> list[str]:
         for pattern in check.triggers:
             if not pattern or pattern.count("[") != pattern.count("]"):
                 errors.append(f"{check.id}: invalid trigger glob: {pattern!r}")
-            elif pattern != "all" and not glob.has_magic(pattern) and not (root / pattern).exists():
-                errors.append(f"{check.id}: explicit trigger path does not exist: {pattern}")
         if not check.lanes:
             errors.append(f"{check.id}: lanes must not be empty")
         invalid_lanes = sorted(set(check.lanes) - {"local", "ci"})
@@ -198,44 +186,8 @@ def trigger_matches(pattern: str, path: str) -> bool:
     return False
 
 
-def _platform_matches(check: Check, platform: str, *, exclusive: bool = False) -> bool:
-    if exclusive:
-        # A macOS-exclusive query intentionally excludes portable checks.  Those
-        # remain owned by the Linux Repo Checks lane even though they could also
-        # execute on a Mac.
-        return set(check.platforms) == {platform}
+def _platform_matches(check: Check, platform: str) -> bool:
     return not check.platforms or "all" in check.platforms or platform in check.platforms
-
-
-def matching_paths(check: Check, files: list[str]) -> tuple[str, ...]:
-    """Return changed paths that caused *check* to be selected."""
-    if "all" in check.triggers:
-        return tuple(files) if files else ("all",)
-    return tuple(path for path in files if any(trigger_matches(pattern, path) for pattern in check.triggers))
-
-
-def resolve_check_selections(
-    manifest: Manifest,
-    files: list[str],
-    lane: str,
-    *,
-    include_pr_body_checks: bool = True,
-    platform: str = "all",
-    exclusive_platform: bool = False,
-) -> list[CheckSelection]:
-    """Resolve checks with their manifest-owned path and reason evidence."""
-    selections: list[CheckSelection] = []
-    for check in manifest.checks:
-        if lane not in check.lanes:
-            continue
-        if not include_pr_body_checks and check.requires_pr_body:
-            continue
-        if not _platform_matches(check, platform, exclusive=exclusive_platform):
-            continue
-        paths = matching_paths(check, files)
-        if paths:
-            selections.append(CheckSelection(check=check, matched_paths=paths))
-    return selections
 
 
 def resolve_checks(
@@ -245,22 +197,23 @@ def resolve_checks(
     *,
     include_pr_body_checks: bool = True,
     platform: str = "all",
-    exclusive_platform: bool = False,
 ) -> list[Check]:
     return [
-        selection.check
-        for selection in resolve_check_selections(
-            manifest,
-            files,
-            lane,
-            include_pr_body_checks=include_pr_body_checks,
-            platform=platform,
-            exclusive_platform=exclusive_platform,
+        check
+        for check in manifest.checks
+        if lane in check.lanes
+        and (include_pr_body_checks or not check.requires_pr_body)
+        and _platform_matches(check, platform)
+        and (
+            "all" in check.triggers
+            or any(trigger_matches(pattern, path) for pattern in check.triggers for path in files)
         )
     ]
 
 
-def skipped_platform_checks(manifest: Manifest, files: list[str], lane: str, platform: str) -> list[Check]:
+def skipped_platform_checks(
+    manifest: Manifest, files: list[str], lane: str, platform: str
+) -> list[Check]:
     """Checks that match lane+triggers but are skipped due to platform."""
     return [
         check
@@ -356,17 +309,6 @@ def parse_args() -> argparse.Namespace:
         default=None,
         help="Platform filter (auto-detected if omitted). macOS-only checks are skipped on other platforms.",
     )
-    parser.add_argument(
-        "--exclusive-platform",
-        action="store_true",
-        help="Select only checks scoped exclusively to --platform (for example macOS-only, not portable, checks).",
-    )
-    parser.add_argument(
-        "--output",
-        choices=("human", "json"),
-        default="human",
-        help="Selection output format. JSON implies --list and includes check IDs, matching paths, and reasons.",
-    )
     return parser.parse_args()
 
 
@@ -389,45 +331,21 @@ def main() -> int:
         print(f"FAIL: could not resolve manifest checks: {exc}", file=sys.stderr)
         return 2
     detected_platform = args.platform or detect_platform()
-    selections = resolve_check_selections(
+    checks = resolve_checks(
         manifest,
         files,
         args.lane,
         include_pr_body_checks=not args.skip_pr_body_checks,
         platform=detected_platform,
-        exclusive_platform=args.exclusive_platform,
     )
-    checks = [selection.check for selection in selections]
-    if args.output == "json":
-        print(
-            json.dumps(
-                {
-                    "lane": args.lane,
-                    "platform": detected_platform,
-                    "exclusive_platform": args.exclusive_platform,
-                    "checks": [
-                        {
-                            "id": selection.check.id,
-                            "matched_paths": list(selection.matched_paths),
-                            "reason": selection.check.reason,
-                        }
-                        for selection in selections
-                    ],
-                },
-                sort_keys=True,
-            )
-        )
-        return 0
     print(
-        f"Check manifest: lane={args.lane} platform={detected_platform} exclusive_platform={args.exclusive_platform} "
+        f"Check manifest: lane={args.lane} platform={detected_platform} "
         f"base={resolved_base[:12]} head={args.head} files={len(files)}"
     )
     for check in checks:
         print(f"  SELECTED {check.id}: {check.reason}")
     for skip in skipped_platform_checks(manifest, files, args.lane, detected_platform):
-        print(
-            f"  SKIPPED {skip.id}: platform-only (requires {', '.join(skip.platforms)}, running on {detected_platform})"
-        )
+        print(f"  SKIPPED {skip.id}: platform-only (requires {', '.join(skip.platforms)}, running on {detected_platform})")
     if args.list:
         return 0
 

--- a/.github/scripts/run_checks.py
+++ b/.github/scripts/run_checks.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import fnmatch
+import glob
 import json
 import platform as _platform_mod
 import subprocess
@@ -15,8 +16,7 @@ from dataclasses import dataclass
 from pathlib import Path, PurePath
 from typing import Any
 
-
-VALID_PLATFORMS = {"all", "macos", "linux"}
+VALID_PLATFORMS = {"all", "macos", "linux", "windows"}
 
 
 def detect_platform() -> str:
@@ -26,6 +26,8 @@ def detect_platform() -> str:
         return "macos"
     if system == "Linux":
         return "linux"
+    if system == "Windows":
+        return "windows"
     return system.lower()
 
 
@@ -50,6 +52,14 @@ class Exemption:
 class Manifest:
     checks: tuple[Check, ...]
     exempt: tuple[Exemption, ...]
+
+
+@dataclass(frozen=True)
+class CheckSelection:
+    """A manifest check together with the paths that selected it."""
+
+    check: Check
+    matched_paths: tuple[str, ...]
 
 
 def _parse_value(raw: str) -> Any:
@@ -128,6 +138,8 @@ def validate_manifest(manifest: Manifest, root: Path) -> list[str]:
         for pattern in check.triggers:
             if not pattern or pattern.count("[") != pattern.count("]"):
                 errors.append(f"{check.id}: invalid trigger glob: {pattern!r}")
+            elif pattern != "all" and not glob.has_magic(pattern) and not (root / pattern).exists():
+                errors.append(f"{check.id}: explicit trigger path does not exist: {pattern}")
         if not check.lanes:
             errors.append(f"{check.id}: lanes must not be empty")
         invalid_lanes = sorted(set(check.lanes) - {"local", "ci"})
@@ -186,8 +198,44 @@ def trigger_matches(pattern: str, path: str) -> bool:
     return False
 
 
-def _platform_matches(check: Check, platform: str) -> bool:
+def _platform_matches(check: Check, platform: str, *, exclusive: bool = False) -> bool:
+    if exclusive:
+        # A macOS-exclusive query intentionally excludes portable checks.  Those
+        # remain owned by the Linux Repo Checks lane even though they could also
+        # execute on a Mac.
+        return set(check.platforms) == {platform}
     return not check.platforms or "all" in check.platforms or platform in check.platforms
+
+
+def matching_paths(check: Check, files: list[str]) -> tuple[str, ...]:
+    """Return changed paths that caused *check* to be selected."""
+    if "all" in check.triggers:
+        return tuple(files) if files else ("all",)
+    return tuple(path for path in files if any(trigger_matches(pattern, path) for pattern in check.triggers))
+
+
+def resolve_check_selections(
+    manifest: Manifest,
+    files: list[str],
+    lane: str,
+    *,
+    include_pr_body_checks: bool = True,
+    platform: str = "all",
+    exclusive_platform: bool = False,
+) -> list[CheckSelection]:
+    """Resolve checks with their manifest-owned path and reason evidence."""
+    selections: list[CheckSelection] = []
+    for check in manifest.checks:
+        if lane not in check.lanes:
+            continue
+        if not include_pr_body_checks and check.requires_pr_body:
+            continue
+        if not _platform_matches(check, platform, exclusive=exclusive_platform):
+            continue
+        paths = matching_paths(check, files)
+        if paths:
+            selections.append(CheckSelection(check=check, matched_paths=paths))
+    return selections
 
 
 def resolve_checks(
@@ -197,23 +245,22 @@ def resolve_checks(
     *,
     include_pr_body_checks: bool = True,
     platform: str = "all",
+    exclusive_platform: bool = False,
 ) -> list[Check]:
     return [
-        check
-        for check in manifest.checks
-        if lane in check.lanes
-        and (include_pr_body_checks or not check.requires_pr_body)
-        and _platform_matches(check, platform)
-        and (
-            "all" in check.triggers
-            or any(trigger_matches(pattern, path) for pattern in check.triggers for path in files)
+        selection.check
+        for selection in resolve_check_selections(
+            manifest,
+            files,
+            lane,
+            include_pr_body_checks=include_pr_body_checks,
+            platform=platform,
+            exclusive_platform=exclusive_platform,
         )
     ]
 
 
-def skipped_platform_checks(
-    manifest: Manifest, files: list[str], lane: str, platform: str
-) -> list[Check]:
+def skipped_platform_checks(manifest: Manifest, files: list[str], lane: str, platform: str) -> list[Check]:
     """Checks that match lane+triggers but are skipped due to platform."""
     return [
         check
@@ -309,6 +356,17 @@ def parse_args() -> argparse.Namespace:
         default=None,
         help="Platform filter (auto-detected if omitted). macOS-only checks are skipped on other platforms.",
     )
+    parser.add_argument(
+        "--exclusive-platform",
+        action="store_true",
+        help="Select only checks scoped exclusively to --platform (for example macOS-only, not portable, checks).",
+    )
+    parser.add_argument(
+        "--output",
+        choices=("human", "json"),
+        default="human",
+        help="Selection output format. JSON implies --list and includes check IDs, matching paths, and reasons.",
+    )
     return parser.parse_args()
 
 
@@ -331,21 +389,45 @@ def main() -> int:
         print(f"FAIL: could not resolve manifest checks: {exc}", file=sys.stderr)
         return 2
     detected_platform = args.platform or detect_platform()
-    checks = resolve_checks(
+    selections = resolve_check_selections(
         manifest,
         files,
         args.lane,
         include_pr_body_checks=not args.skip_pr_body_checks,
         platform=detected_platform,
+        exclusive_platform=args.exclusive_platform,
     )
+    checks = [selection.check for selection in selections]
+    if args.output == "json":
+        print(
+            json.dumps(
+                {
+                    "lane": args.lane,
+                    "platform": detected_platform,
+                    "exclusive_platform": args.exclusive_platform,
+                    "checks": [
+                        {
+                            "id": selection.check.id,
+                            "matched_paths": list(selection.matched_paths),
+                            "reason": selection.check.reason,
+                        }
+                        for selection in selections
+                    ],
+                },
+                sort_keys=True,
+            )
+        )
+        return 0
     print(
-        f"Check manifest: lane={args.lane} platform={detected_platform} "
+        f"Check manifest: lane={args.lane} platform={detected_platform} exclusive_platform={args.exclusive_platform} "
         f"base={resolved_base[:12]} head={args.head} files={len(files)}"
     )
     for check in checks:
         print(f"  SELECTED {check.id}: {check.reason}")
     for skip in skipped_platform_checks(manifest, files, args.lane, detected_platform):
-        print(f"  SKIPPED {skip.id}: platform-only (requires {', '.join(skip.platforms)}, running on {detected_platform})")
+        print(
+            f"  SKIPPED {skip.id}: platform-only (requires {', '.join(skip.platforms)}, running on {detected_platform})"
+        )
     if args.list:
         return 0
 

--- a/.github/scripts/test_check_pr_scope.py
+++ b/.github/scripts/test_check_pr_scope.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Unit tests for check_pr_scope.py classification, counting, and advisory tiers."""
+
+from __future__ import annotations
+
+import unittest
+
+from check_pr_scope import (
+    REVIEW_COLLAPSE_LINES,
+    WARN_LINES,
+    count_production_lines,
+    evaluate,
+    is_production_source,
+)
+
+
+class ClassificationTests(unittest.TestCase):
+    def test_production_paths(self) -> None:
+        for path in (
+            'backend/utils/sync/pipeline.py',
+            'app/lib/services/wals/wal.dart',
+            'desktop/macos/Backend-Rust/src/routes/proxy.rs',
+            'desktop/macos/Desktop/Sources/Chat/ChatToolExecutor.swift',
+            '.github/workflows/gcp_backend.yml',
+            'backend/testharness.py',  # 'testharness' must not match test excludes
+            'desktop/macos/scripts/test-tool-surfaces.sh',  # hyphenated prod script
+        ):
+            self.assertTrue(is_production_source(path), path)
+
+    def test_excluded_test_trees_all_platform_conventions(self) -> None:
+        for path in (
+            'backend/tests/unit/test_sync_v2.py',
+            'backend/testing/e2e/test_crud.py',
+            'app/test/widget_test.dart',
+            'app/integration_test/onboarding_test.dart',
+            'desktop/macos/Desktop/Tests/GoogleSessionTests.swift',  # capital-T Swift tree
+            'desktop/macos/Desktop/Sources/FooTests.swift',
+            'web/frontend/src/__tests__/App.test.tsx',
+            'desktop/windows/src/session.test.ts',
+        ):
+            self.assertFalse(is_production_source(path), path)
+
+    def test_excluded_docs_l10n_generated_locks(self) -> None:
+        for path in (
+            'docs/doc/developer/guide.mdx',
+            'AGENTS.md',
+            'app/lib/l10n/app_fr.arb',
+            'backend/pylock.toml',
+            'app/pubspec.lock',
+            'web/package-lock.json',
+            'app/lib/gen/assets.g.dart',
+            '.cursor/plans/x.plan.md',
+            'desktop/macos/changelog/unreleased/fix.json',
+            'backend/openapi.json',
+        ):
+            self.assertFalse(is_production_source(path), path)
+
+
+class CountingTests(unittest.TestCase):
+    def test_counts_production_only_and_skips_binary(self) -> None:
+        numstat = (
+            '10\t5\tbackend/utils/a.py\0'
+            '3\t0\tbackend/tests/unit/test_a.py\0'
+            '-\t-\tapp/assets/img.png\0'
+            '7\t2\tapp/lib/b.dart\0'
+        )
+        total, per_file = count_production_lines(numstat)
+        self.assertEqual(total, 24)
+        self.assertEqual([p for _, p in per_file], ['backend/utils/a.py', 'app/lib/b.dart'])
+
+    def test_z_records_keep_non_ascii_paths_raw_and_classified(self) -> None:
+        # With -z, git emits the real filename (no C-quoting), so suffix
+        # excludes match non-ASCII names.
+        numstat = '9\t0\tdocs/weird ü.md\0'
+        self.assertEqual(count_production_lines(numstat), (0, []))
+
+
+class AdvisoryTests(unittest.TestCase):
+    def test_tiers_are_annotations_only(self) -> None:
+        cases = [
+            (100, '::notice'),
+            (WARN_LINES, '::warning'),
+            (REVIEW_COLLAPSE_LINES, '::warning'),
+        ]
+        for total, want_prefix in cases:
+            message = evaluate(total)
+            self.assertTrue(message.startswith(want_prefix), message)
+
+    def test_review_collapse_tier_cites_the_audit(self) -> None:
+        self.assertIn('regression', evaluate(REVIEW_COLLAPSE_LINES))
+
+    def test_warnings_say_they_never_block(self) -> None:
+        for total in (WARN_LINES, REVIEW_COLLAPSE_LINES):
+            self.assertIn('never blocks', evaluate(total))
+
+    def test_push_events_are_notice_only(self) -> None:
+        message = evaluate(REVIEW_COLLAPSE_LINES, notice_only=True)
+        self.assertTrue(message.startswith('::notice'), message)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/.github/scripts/test_pr_preflight.py
+++ b/.github/scripts/test_pr_preflight.py
@@ -288,6 +288,7 @@ class SelectionTests(unittest.TestCase):
                 "deferred-work-markers",
                 "lifecycle-headers",
                 "version-prefixed-filenames",
+                "pr-scope",
             },
         )
 

--- a/.github/scripts/test_pr_preflight.py
+++ b/.github/scripts/test_pr_preflight.py
@@ -7,7 +7,6 @@ from contextlib import redirect_stderr
 import io
 import json
 import os
-import signal
 import subprocess
 import sys
 import tempfile
@@ -15,9 +14,8 @@ import time
 import unittest
 import urllib.error
 from pathlib import Path
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
-import preflight_runner
 from pr_metadata import TransientPRMetadataError, load_from_api, load_from_event_file
 from pr_preflight import changed_files, format_failure_class_suggest, resolve_pr_metadata, select_checks
 
@@ -65,7 +63,7 @@ class MetadataTests(unittest.TestCase):
     def test_api_loader_retries_transient_failures_then_succeeds(self) -> None:
         payload = json.dumps({"number": 9847, "body": "ok", "updated_at": "u", "labels": []}).encode()
         outcomes: list[object] = [
-            urllib.error.HTTPError("url", 502, "bad gateway", None, io.BytesIO()),  # type: ignore[arg-type]
+            urllib.error.HTTPError("url", 502, "bad gateway", None, None),  # type: ignore[arg-type]
             TimeoutError("timed out"),
             FakeResponse(payload),
         ]
@@ -86,7 +84,7 @@ class MetadataTests(unittest.TestCase):
 
         def opener(request: object, timeout: int) -> FakeResponse:
             calls["count"] += 1
-            raise urllib.error.HTTPError("url", 404, "not found", None, io.BytesIO())  # type: ignore[arg-type]
+            raise urllib.error.HTTPError("url", 404, "not found", None, None)  # type: ignore[arg-type]
 
         with self.assertRaisesRegex(RuntimeError, "HTTP 404") as raised:
             load_from_api("BasedHardware/omi", 9847, "test-token", opener=opener, sleeper=lambda _: None)
@@ -145,7 +143,7 @@ class MetadataTests(unittest.TestCase):
                 encoding="utf-8",
             )
             warnings = io.StringIO()
-            with patch.dict(os.environ, {"OMI_PR_BODY_FILE": ""}), patch(
+            with patch(
                 "pr_preflight.load_from_api", side_effect=TransientPRMetadataError("GitHub API unavailable")
             ), redirect_stderr(warnings):
                 metadata = resolve_pr_metadata(REPO_ROOT, None, "BasedHardware/omi", 9847, event_path)
@@ -155,9 +153,7 @@ class MetadataTests(unittest.TestCase):
         self.assertIn("using the PR snapshot", warnings.getvalue())
 
     def test_pr_metadata_does_not_use_event_payload_after_permanent_api_failure(self) -> None:
-        with patch.dict(os.environ, {"OMI_PR_BODY_FILE": ""}), patch(
-            "pr_preflight.load_from_api", side_effect=RuntimeError("GitHub API returned HTTP 403")
-        ):
+        with patch("pr_preflight.load_from_api", side_effect=RuntimeError("GitHub API returned HTTP 403")):
             with self.assertRaisesRegex(RuntimeError, "HTTP 403"):
                 resolve_pr_metadata(REPO_ROOT, None, "BasedHardware/omi", 9847, Path("event.json"))
 
@@ -178,72 +174,6 @@ class SelectionTests(unittest.TestCase):
             "--diff-filter=ACMRTD",
             "base...head",
         )
-
-    def test_stale_event_payload_base_widens_diff_scope_past_the_live_base(self) -> None:
-        """Behavioral regression for FC-stale-event-payload-diff-base (#10758).
-
-        Exercises the real changed_files() git seam end to end: a base SHA
-        captured once (standing in for github.event.pull_request.base.sha) and
-        never refreshed goes stale as the target branch keeps advancing, so a
-        downstream merge-ref diff against it silently picks up unrelated
-        commits. A live-resolved base ref does not.
-        """
-        # Disposable repo must not inherit the caller's git context: under a
-        # pre-commit/pre-push hook, GIT_DIR points at the real checkout and its
-        # commit-msg hook would reject these throwaway messages.
-        git_isolation = ["-c", "core.hooksPath=/dev/null", "-c", "commit.gpgsign=false"]
-
-        def run(*args: str, cwd: Path) -> None:
-            subprocess.run(["git", *git_isolation, *args], cwd=cwd, check=True, capture_output=True, text=True)
-
-        def rev_parse(cwd: Path, ref: str = "HEAD") -> str:
-            result = subprocess.run(
-                ["git", *git_isolation, "rev-parse", ref], cwd=cwd, check=True, capture_output=True, text=True
-            )
-            return result.stdout.strip()
-
-        def commit(cwd: Path, path: str, content: str, message: str) -> str:
-            (cwd / path).write_text(content, encoding="utf-8")
-            run("add", path, cwd=cwd)
-            run("commit", "-q", "-m", message, cwd=cwd)
-            return rev_parse(cwd)
-
-        with patch.dict(os.environ):
-            for key in list(os.environ):
-                if key.startswith("GIT_"):
-                    del os.environ[key]
-
-            with tempfile.TemporaryDirectory() as tmp:
-                root = Path(tmp)
-                run("init", "-q", "-b", "main", cwd=root)
-                run("config", "user.email", "test@example.com", cwd=root)
-                run("config", "user.name", "Test", cwd=root)
-
-                # The SHA a PR event payload would have captured at PR-open time.
-                stale_base_sha = commit(root, "root.txt", "root", "root commit")
-
-                run("checkout", "-q", "-b", "pr", cwd=root)
-                commit(root, "pr_file.txt", "pr change", "touch pr_file.txt")
-                run("checkout", "-q", "main", cwd=root)
-
-                # main keeps moving after the PR branched. This is what makes
-                # stale_base_sha stale: no event ever refreshes it past here.
-                commit(root, "unrelated_file.txt", "v1", "unrelated main commit 1")
-                commit(root, "unrelated_file.txt", "v2", "unrelated main commit 2")
-
-                # GitHub's refs/pull/N/merge: the PR branch merged onto main's
-                # *current* tip, on its own ref — main itself does not move.
-                run("checkout", "-q", "-b", "merge_ref", "main", cwd=root)
-                run("merge", "--no-ff", "-q", "-m", "merge pr into main", "pr", cwd=root)
-                merge_sha = rev_parse(root)
-
-                stale_diff = changed_files(root, stale_base_sha, merge_sha)
-                # "main" stands in for a freshly fetched origin/<base_ref>: a
-                # live ref, not a value captured once and carried across events.
-                live_diff = changed_files(root, "main", merge_sha)
-
-                self.assertEqual(sorted(live_diff), ["pr_file.txt"])
-                self.assertEqual(sorted(stale_diff), ["pr_file.txt", "unrelated_file.txt"])
 
     def test_make_preflight_resolves_pr_metadata_before_running_checks(self) -> None:
         result = subprocess.run(
@@ -279,11 +209,11 @@ class SelectionTests(unittest.TestCase):
             names,
             {
                 "check-manifest-contract",
+                "pr-scope",
                 "diff-hygiene",
                 "architecture-guardrails",
                 "product-invariants",
                 "failure-class-protocol",
-                "failure-class-guard-artifact-ratchet",
                 "desktop-changelog-data",
                 "deferred-work-markers",
                 "lifecycle-headers",
@@ -401,11 +331,8 @@ class SelectionTests(unittest.TestCase):
                 stderr=subprocess.STDOUT,
                 text=True,
             )
-            # This test isolates metadata-file selection. Other manifest-selected
-            # repository guardrails may legitimately fail as global state evolves;
-            # requiring a zero exit here made the metadata contract time-dependent.
+            self.assertEqual(result.returncode, 0, result.stdout)
             self.assertIn(str(body.resolve()), result.stdout)
-            self.assertNotIn("No PR metadata file is available", result.stdout)
 
     def test_repo_checks_routes_metadata_events_to_the_narrow_preflight(self) -> None:
         """Metadata-only PR updates must not restart the full hygiene suite."""
@@ -419,27 +346,11 @@ class SelectionTests(unittest.TestCase):
             self.assertIn(event, changes_job)
             self.assertIn(event, hygiene_job)
         self.assertIn("scripts/pr-preflight", metadata_job)
-        # Static tripwire only: confirms the workflow text wires --base to the
-        # live ref rather than the stale event-payload SHA. It does not exercise
-        # changed_files() itself — see
-        # test_stale_event_payload_base_widens_diff_scope_past_the_live_base for
-        # the behavioral regression backing FC-stale-event-payload-diff-base.
-        self.assertNotIn("github.event.pull_request.base.sha", metadata_job)
-        self.assertIn('--base "origin/${{ github.base_ref }}"', metadata_job)
+        self.assertIn("github.event.pull_request.base.sha", metadata_job)
         self.assertIn("astral-sh/setup-uv@ecd24dd710f2fb0dca1693a67af11fc4a5c5ec84", metadata_job)
         self.assertLess(metadata_job.index("Set up uv"), metadata_job.index("Run current PR metadata preflight"))
         self.assertIn("github.event_name != 'pull_request'", changes_job)
         self.assertIn("github.event_name != 'pull_request'", hygiene_job)
-
-        # The manifest can select the Firestore admission proof for either PR
-        # preflight path. Java must be present before the selected check runs.
-        for job, gate in (
-            (metadata_job, "Run current PR metadata preflight"),
-            (hygiene_job, "Run shared PR contract preflight"),
-        ):
-            self.assertIn("actions/setup-java@v5", job)
-            self.assertIn("java-version: '21'", job)
-            self.assertLess(job.index("Set up Java for manifest-selected Firestore checks"), job.index(gate))
 
     def test_issue_sync_action_is_pinned(self) -> None:
         workflow = (REPO_ROOT / ".github/workflows/main.yml").read_text(encoding="utf-8")
@@ -566,60 +477,6 @@ class SingleFlightTests(unittest.TestCase):
                 first.stdout.read()
                 first.stdout.close()
             self.assertEqual(first.wait(), 0)
-
-
-class SignalPortabilityTests(unittest.TestCase):
-    """The single-flight wrapper must start on hosts without POSIX signal APIs.
-
-    Windows Python defines neither ``signal.SIGHUP`` nor ``os.killpg``. Building the
-    handler map from a hard-coded tuple containing SIGHUP raised AttributeError inside
-    ``run_owned()``, so every ``git push`` failed before the pre-push checks began.
-    These exercise the selection/forwarding seams directly — no real signal is sent.
-    """
-
-    def test_forwardable_signals_omits_signals_absent_on_host(self) -> None:
-        had_sighup = hasattr(signal, "SIGHUP")
-        original = getattr(signal, "SIGHUP", None)
-        try:
-            if had_sighup:
-                delattr(signal, "SIGHUP")  # simulate Windows
-            selected = preflight_runner.forwardable_signals()
-        finally:
-            if had_sighup:
-                signal.SIGHUP = original
-        self.assertIn(signal.SIGINT, selected)
-        self.assertIn(signal.SIGTERM, selected)
-        self.assertTrue(all(signum is not None for signum in selected))
-
-    @unittest.skipUnless(hasattr(signal, "SIGHUP"), "POSIX-only")
-    def test_forwardable_signals_includes_sighup_on_posix(self) -> None:
-        self.assertIn(signal.SIGHUP, preflight_runner.forwardable_signals())
-
-    @unittest.skipUnless(hasattr(os, "killpg"), "POSIX-only")
-    def test_forwards_to_process_group_when_available(self) -> None:
-        child = Mock(pid=4321)
-        with patch.object(os, "killpg") as killpg:
-            preflight_runner.signal_child(child, signal.SIGTERM)
-        killpg.assert_called_once_with(4321, signal.SIGTERM)
-        child.send_signal.assert_not_called()
-
-    def test_forwards_via_send_signal_when_process_groups_unavailable(self) -> None:
-        child = Mock(pid=4321)
-        had_killpg = hasattr(os, "killpg")
-        original = getattr(os, "killpg", None)
-        try:
-            if had_killpg:
-                delattr(os, "killpg")  # simulate Windows
-            preflight_runner.signal_child(child, signal.SIGTERM)
-        finally:
-            if had_killpg:
-                os.killpg = original
-        child.send_signal.assert_called_once_with(signal.SIGTERM)
-
-    def test_forwarding_swallows_dead_child(self) -> None:
-        child = Mock(pid=4321)
-        with patch.object(os, "killpg", side_effect=ProcessLookupError):
-            preflight_runner.signal_child(child, signal.SIGTERM)  # must not raise
 
 
 if __name__ == "__main__":

--- a/.github/scripts/test_pr_preflight.py
+++ b/.github/scripts/test_pr_preflight.py
@@ -7,6 +7,7 @@ from contextlib import redirect_stderr
 import io
 import json
 import os
+import signal
 import subprocess
 import sys
 import tempfile
@@ -14,8 +15,9 @@ import time
 import unittest
 import urllib.error
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
+import preflight_runner
 from pr_metadata import TransientPRMetadataError, load_from_api, load_from_event_file
 from pr_preflight import changed_files, format_failure_class_suggest, resolve_pr_metadata, select_checks
 
@@ -63,7 +65,7 @@ class MetadataTests(unittest.TestCase):
     def test_api_loader_retries_transient_failures_then_succeeds(self) -> None:
         payload = json.dumps({"number": 9847, "body": "ok", "updated_at": "u", "labels": []}).encode()
         outcomes: list[object] = [
-            urllib.error.HTTPError("url", 502, "bad gateway", None, None),  # type: ignore[arg-type]
+            urllib.error.HTTPError("url", 502, "bad gateway", None, io.BytesIO()),  # type: ignore[arg-type]
             TimeoutError("timed out"),
             FakeResponse(payload),
         ]
@@ -84,7 +86,7 @@ class MetadataTests(unittest.TestCase):
 
         def opener(request: object, timeout: int) -> FakeResponse:
             calls["count"] += 1
-            raise urllib.error.HTTPError("url", 404, "not found", None, None)  # type: ignore[arg-type]
+            raise urllib.error.HTTPError("url", 404, "not found", None, io.BytesIO())  # type: ignore[arg-type]
 
         with self.assertRaisesRegex(RuntimeError, "HTTP 404") as raised:
             load_from_api("BasedHardware/omi", 9847, "test-token", opener=opener, sleeper=lambda _: None)
@@ -143,7 +145,7 @@ class MetadataTests(unittest.TestCase):
                 encoding="utf-8",
             )
             warnings = io.StringIO()
-            with patch(
+            with patch.dict(os.environ, {"OMI_PR_BODY_FILE": ""}), patch(
                 "pr_preflight.load_from_api", side_effect=TransientPRMetadataError("GitHub API unavailable")
             ), redirect_stderr(warnings):
                 metadata = resolve_pr_metadata(REPO_ROOT, None, "BasedHardware/omi", 9847, event_path)
@@ -153,7 +155,9 @@ class MetadataTests(unittest.TestCase):
         self.assertIn("using the PR snapshot", warnings.getvalue())
 
     def test_pr_metadata_does_not_use_event_payload_after_permanent_api_failure(self) -> None:
-        with patch("pr_preflight.load_from_api", side_effect=RuntimeError("GitHub API returned HTTP 403")):
+        with patch.dict(os.environ, {"OMI_PR_BODY_FILE": ""}), patch(
+            "pr_preflight.load_from_api", side_effect=RuntimeError("GitHub API returned HTTP 403")
+        ):
             with self.assertRaisesRegex(RuntimeError, "HTTP 403"):
                 resolve_pr_metadata(REPO_ROOT, None, "BasedHardware/omi", 9847, Path("event.json"))
 
@@ -174,6 +178,72 @@ class SelectionTests(unittest.TestCase):
             "--diff-filter=ACMRTD",
             "base...head",
         )
+
+    def test_stale_event_payload_base_widens_diff_scope_past_the_live_base(self) -> None:
+        """Behavioral regression for FC-stale-event-payload-diff-base (#10758).
+
+        Exercises the real changed_files() git seam end to end: a base SHA
+        captured once (standing in for github.event.pull_request.base.sha) and
+        never refreshed goes stale as the target branch keeps advancing, so a
+        downstream merge-ref diff against it silently picks up unrelated
+        commits. A live-resolved base ref does not.
+        """
+        # Disposable repo must not inherit the caller's git context: under a
+        # pre-commit/pre-push hook, GIT_DIR points at the real checkout and its
+        # commit-msg hook would reject these throwaway messages.
+        git_isolation = ["-c", "core.hooksPath=/dev/null", "-c", "commit.gpgsign=false"]
+
+        def run(*args: str, cwd: Path) -> None:
+            subprocess.run(["git", *git_isolation, *args], cwd=cwd, check=True, capture_output=True, text=True)
+
+        def rev_parse(cwd: Path, ref: str = "HEAD") -> str:
+            result = subprocess.run(
+                ["git", *git_isolation, "rev-parse", ref], cwd=cwd, check=True, capture_output=True, text=True
+            )
+            return result.stdout.strip()
+
+        def commit(cwd: Path, path: str, content: str, message: str) -> str:
+            (cwd / path).write_text(content, encoding="utf-8")
+            run("add", path, cwd=cwd)
+            run("commit", "-q", "-m", message, cwd=cwd)
+            return rev_parse(cwd)
+
+        with patch.dict(os.environ):
+            for key in list(os.environ):
+                if key.startswith("GIT_"):
+                    del os.environ[key]
+
+            with tempfile.TemporaryDirectory() as tmp:
+                root = Path(tmp)
+                run("init", "-q", "-b", "main", cwd=root)
+                run("config", "user.email", "test@example.com", cwd=root)
+                run("config", "user.name", "Test", cwd=root)
+
+                # The SHA a PR event payload would have captured at PR-open time.
+                stale_base_sha = commit(root, "root.txt", "root", "root commit")
+
+                run("checkout", "-q", "-b", "pr", cwd=root)
+                commit(root, "pr_file.txt", "pr change", "touch pr_file.txt")
+                run("checkout", "-q", "main", cwd=root)
+
+                # main keeps moving after the PR branched. This is what makes
+                # stale_base_sha stale: no event ever refreshes it past here.
+                commit(root, "unrelated_file.txt", "v1", "unrelated main commit 1")
+                commit(root, "unrelated_file.txt", "v2", "unrelated main commit 2")
+
+                # GitHub's refs/pull/N/merge: the PR branch merged onto main's
+                # *current* tip, on its own ref — main itself does not move.
+                run("checkout", "-q", "-b", "merge_ref", "main", cwd=root)
+                run("merge", "--no-ff", "-q", "-m", "merge pr into main", "pr", cwd=root)
+                merge_sha = rev_parse(root)
+
+                stale_diff = changed_files(root, stale_base_sha, merge_sha)
+                # "main" stands in for a freshly fetched origin/<base_ref>: a
+                # live ref, not a value captured once and carried across events.
+                live_diff = changed_files(root, "main", merge_sha)
+
+                self.assertEqual(sorted(live_diff), ["pr_file.txt"])
+                self.assertEqual(sorted(stale_diff), ["pr_file.txt", "unrelated_file.txt"])
 
     def test_make_preflight_resolves_pr_metadata_before_running_checks(self) -> None:
         result = subprocess.run(
@@ -209,11 +279,11 @@ class SelectionTests(unittest.TestCase):
             names,
             {
                 "check-manifest-contract",
-                "pr-scope",
                 "diff-hygiene",
                 "architecture-guardrails",
                 "product-invariants",
                 "failure-class-protocol",
+                "failure-class-guard-artifact-ratchet",
                 "desktop-changelog-data",
                 "deferred-work-markers",
                 "lifecycle-headers",
@@ -331,8 +401,11 @@ class SelectionTests(unittest.TestCase):
                 stderr=subprocess.STDOUT,
                 text=True,
             )
-            self.assertEqual(result.returncode, 0, result.stdout)
+            # This test isolates metadata-file selection. Other manifest-selected
+            # repository guardrails may legitimately fail as global state evolves;
+            # requiring a zero exit here made the metadata contract time-dependent.
             self.assertIn(str(body.resolve()), result.stdout)
+            self.assertNotIn("No PR metadata file is available", result.stdout)
 
     def test_repo_checks_routes_metadata_events_to_the_narrow_preflight(self) -> None:
         """Metadata-only PR updates must not restart the full hygiene suite."""
@@ -346,11 +419,27 @@ class SelectionTests(unittest.TestCase):
             self.assertIn(event, changes_job)
             self.assertIn(event, hygiene_job)
         self.assertIn("scripts/pr-preflight", metadata_job)
-        self.assertIn("github.event.pull_request.base.sha", metadata_job)
+        # Static tripwire only: confirms the workflow text wires --base to the
+        # live ref rather than the stale event-payload SHA. It does not exercise
+        # changed_files() itself — see
+        # test_stale_event_payload_base_widens_diff_scope_past_the_live_base for
+        # the behavioral regression backing FC-stale-event-payload-diff-base.
+        self.assertNotIn("github.event.pull_request.base.sha", metadata_job)
+        self.assertIn('--base "origin/${{ github.base_ref }}"', metadata_job)
         self.assertIn("astral-sh/setup-uv@ecd24dd710f2fb0dca1693a67af11fc4a5c5ec84", metadata_job)
         self.assertLess(metadata_job.index("Set up uv"), metadata_job.index("Run current PR metadata preflight"))
         self.assertIn("github.event_name != 'pull_request'", changes_job)
         self.assertIn("github.event_name != 'pull_request'", hygiene_job)
+
+        # The manifest can select the Firestore admission proof for either PR
+        # preflight path. Java must be present before the selected check runs.
+        for job, gate in (
+            (metadata_job, "Run current PR metadata preflight"),
+            (hygiene_job, "Run shared PR contract preflight"),
+        ):
+            self.assertIn("actions/setup-java@v5", job)
+            self.assertIn("java-version: '21'", job)
+            self.assertLess(job.index("Set up Java for manifest-selected Firestore checks"), job.index(gate))
 
     def test_issue_sync_action_is_pinned(self) -> None:
         workflow = (REPO_ROOT / ".github/workflows/main.yml").read_text(encoding="utf-8")
@@ -477,6 +566,60 @@ class SingleFlightTests(unittest.TestCase):
                 first.stdout.read()
                 first.stdout.close()
             self.assertEqual(first.wait(), 0)
+
+
+class SignalPortabilityTests(unittest.TestCase):
+    """The single-flight wrapper must start on hosts without POSIX signal APIs.
+
+    Windows Python defines neither ``signal.SIGHUP`` nor ``os.killpg``. Building the
+    handler map from a hard-coded tuple containing SIGHUP raised AttributeError inside
+    ``run_owned()``, so every ``git push`` failed before the pre-push checks began.
+    These exercise the selection/forwarding seams directly — no real signal is sent.
+    """
+
+    def test_forwardable_signals_omits_signals_absent_on_host(self) -> None:
+        had_sighup = hasattr(signal, "SIGHUP")
+        original = getattr(signal, "SIGHUP", None)
+        try:
+            if had_sighup:
+                delattr(signal, "SIGHUP")  # simulate Windows
+            selected = preflight_runner.forwardable_signals()
+        finally:
+            if had_sighup:
+                signal.SIGHUP = original
+        self.assertIn(signal.SIGINT, selected)
+        self.assertIn(signal.SIGTERM, selected)
+        self.assertTrue(all(signum is not None for signum in selected))
+
+    @unittest.skipUnless(hasattr(signal, "SIGHUP"), "POSIX-only")
+    def test_forwardable_signals_includes_sighup_on_posix(self) -> None:
+        self.assertIn(signal.SIGHUP, preflight_runner.forwardable_signals())
+
+    @unittest.skipUnless(hasattr(os, "killpg"), "POSIX-only")
+    def test_forwards_to_process_group_when_available(self) -> None:
+        child = Mock(pid=4321)
+        with patch.object(os, "killpg") as killpg:
+            preflight_runner.signal_child(child, signal.SIGTERM)
+        killpg.assert_called_once_with(4321, signal.SIGTERM)
+        child.send_signal.assert_not_called()
+
+    def test_forwards_via_send_signal_when_process_groups_unavailable(self) -> None:
+        child = Mock(pid=4321)
+        had_killpg = hasattr(os, "killpg")
+        original = getattr(os, "killpg", None)
+        try:
+            if had_killpg:
+                delattr(os, "killpg")  # simulate Windows
+            preflight_runner.signal_child(child, signal.SIGTERM)
+        finally:
+            if had_killpg:
+                os.killpg = original
+        child.send_signal.assert_called_once_with(signal.SIGTERM)
+
+    def test_forwarding_swallows_dead_child(self) -> None:
+        child = Mock(pid=4321)
+        with patch.object(os, "killpg", side_effect=ProcessLookupError):
+            preflight_runner.signal_child(child, signal.SIGTERM)  # must not raise
 
 
 if __name__ == "__main__":

--- a/.github/workflows/parakeet_gpu_tests.yml
+++ b/.github/workflows/parakeet_gpu_tests.yml
@@ -32,7 +32,7 @@ jobs:
       id-token: 'write'
 
     runs-on: ubuntu-latest
-    timeout-minutes: 35
+    timeout-minutes: 50
 
     steps:
       - name: Checkout
@@ -81,7 +81,7 @@ jobs:
             name: ${JOB_NAME}
             namespace: ${NAMESPACE}
           spec:
-            activeDeadlineSeconds: 1800
+            activeDeadlineSeconds: 2700
             backoffLimit: 0
             template:
               spec:
@@ -196,12 +196,23 @@ jobs:
                         HCONC_EXIT=$?
                         set -e
 
+                        echo "--- Phase 9: VRAM Stress Test ---"
+                        set +e
+                        python -m pytest tests/container/test_parakeet_vram_stress.py -v -s \
+                          --tb=short 2>&1
+                        VRAM_EXIT=$?
+                        set -e
+
                         kill $SERVER_PID 2>/dev/null || true
                         wait $SERVER_PID 2>/dev/null || true
 
                         if [ $HCONC_EXIT -ne 0 ]; then
                           echo "High-concurrency test failed (exit=$HCONC_EXIT)"
                           exit $HCONC_EXIT
+                        fi
+                        if [ $VRAM_EXIT -ne 0 ]; then
+                          echo "VRAM stress test failed (exit=$VRAM_EXIT)"
+                          exit $VRAM_EXIT
                         fi
                         echo ""
 
@@ -252,9 +263,9 @@ jobs:
 
       - name: Wait for job completion
         run: |
-          echo "Waiting for GPU test job to complete (timeout: 30 min)..."
+          echo "Waiting for GPU test job to complete (timeout: 45 min)..."
           kubectl -n ${{ env.NAMESPACE }} wait --for=condition=complete \
-            --timeout=1800s job/${{ env.JOB_NAME }} 2>&1 || true
+            --timeout=2700s job/${{ env.JOB_NAME }} 2>&1 || true
 
           # Check job status
           STATUS=$(kubectl -n ${{ env.NAMESPACE }} get job ${{ env.JOB_NAME }} \

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,7 +103,6 @@ The pre-commit hook (installed by `make setup`) auto-formats staged files. Verif
 | Python (`backend/`) | `black --line-length 120 --skip-string-normalization <files>` |
 | ARB (`app/lib/l10n/`) | `jq --indent 4 '.' <file> > tmp && mv tmp <file>` |
 | C/C++ (firmware) | `clang-format -i <files>` |
-| Rust (`desktop/macos/Backend-Rust/`) | `rustfmt --edition 2021 <files>` |
 | Swift (`desktop/macos/Desktop/`) | `desktop/macos/scripts/swift-format-wrapper.sh format -i <files>` |
 | Web (`web/`) | `npx prettier --write <files>` |
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,12 +1,12 @@
 <!-- SINGLE SOURCE OF TRUTH for all agent instructions in this repo (Claude Code, Codex, and any other agent). -->
-<!-- CLAUDE.md is the one pointer to this file. Add or change rules HERE, never in CLAUDE.md. -->
+<!-- CLAUDE.md is a thin pointer to this file. Add or change rules HERE, never in CLAUDE.md. -->
 <!-- Format spec: https://agents.md | Codex guidance: https://developers.openai.com/codex/guides/agents-md -->
 
 # Omi Agent Guide
 
-These rules apply to every AI agent working in this repository. This file is **high-level guidance plus an index** — the `AGENTS.md` nearest your work carries the detail; load it just-in-time. A CI check (`.github/scripts/check_agents_md_lean.py`) keeps every `AGENTS.md` within a size ratchet: add detail to the component guide, not here.
+These rules apply to every AI agent working in this repository. This file is **high-level guidance plus an index** — component guides carry the detail; load them just-in-time for the area you are working in. `CLAUDE.md` just points here. A CI check (`.github/scripts/check_agents_md_lean.py`) keeps this file lean: add detail to the component guide, not here.
 
-**Two audiences read this file.** Engineering standards (Definition of Done, testing, formatting) apply to everyone — maintainers and open-source contributors alike. Rules about production app bundles, deploys, and local machine workflows assume a maintainer environment; in a fork, follow your own process and skip those. Contributor flow: `docs/doc/developer/Contribution.mdx`.
+**Two audiences read this file.** Engineering standards (Definition of Done, testing, formatting) apply to everyone — maintainers and open-source contributors alike. Rules about this repo's `main` branch, production app bundles, deploys, and local machine workflows assume a maintainer environment; in a fork, follow your user's process for landing changes and skip those. Contributor flow: `docs/doc/developer/Contribution.mdx`.
 
 ## Read Next (just-in-time)
 
@@ -15,13 +15,9 @@ These rules apply to every AI agent working in this repository. This file is **h
 | Backend Python (`backend/`) | `backend/AGENTS.md` — setup, async/executors, WebSocket rules, service map, logging security, testing |
 | Flutter app (`app/`) | `app/AGENTS.md` — build flavors, l10n, native bridge, tests, agent-flutter UI verification |
 | Desktop macOS (`desktop/macos/`) | `desktop/macos/AGENTS.md` — build/run, named bundles, self-testing, release pipeline, changelog |
-| GitHub Actions (`.github/`) | `.github/AGENTS.md` — deploy concurrency, immutable image tags, rollout waits, secret ordering |
-| Admin dashboard (`web/admin/`) | `web/admin/AGENTS.md` — stack, data sources, conventions |
 | Firmware (`omi/firmware/`) | `omi/firmware/AGENTS.md` — release workflow |
 | Product behavior | `PRODUCT.md` + `docs/product/invariants/` — locked invariants and guard tests |
 | Fallback/fail-open branches | `docs/agents/fallback-telemetry.md` — when to call `record_fallback` |
-| Formatting a file | `docs/agents/formatting.md` — per-language commands; the pre-commit hook usually does it for you |
-| Editing agent docs or adding a check | `docs/agents/doc-maintenance.md` — where a rule belongs, how to back it with a check |
 | App flows / E2E | `app/e2e/SKILL.md`, `desktop/macos/e2e/SKILL.md` |
 | Cursor Cloud VM (Linux x86) | `.cursor/cloud-agent-environment.md` — hermetic E2E harness, known failures |
 
@@ -45,7 +41,7 @@ A deterministic diff-scoped check failing for the first time in CI is a manifest
 The unit of work is the violated contract, not only the line where the symptom appeared. The declaration is the PR record for an ordinary instance fix; before fixing, inspect recent fixes in the same subsystem. Registry lifecycle transitions are separate PRs: dormant classes record `dormant_since`, and recurrence reopens them by setting `status: open` and removing it.
 
 - Identify the authoritative owner, identity, state transition, or boundary contract that failed — don't add another observer, fallback boolean, or call-site exception when ownership is the real problem.
-- If two or more recent fixes share the cause, add a reusable guard surface in the same PR: a typed state/policy model, behavioral contract test, fault harness, or narrow static checker. Record its path in the class's `canonical_prevention_artifact`; a class that keeps recurring without one fails the guard-artifact ratchet (`docs/product/failure-classes.md`).
+- If two or more recent fixes share the cause, add a reusable guard surface in the same PR: a typed state/policy model, behavioral contract test, fault harness, or narrow static checker.
 - A regression test must execute production behavior through a controllable seam. Asserting that source strings occur in a certain order is a static tripwire, not behavioral coverage; label static checkers as such.
 - Do not broaden a safe bug-fix PR into an unreviewable migration; land the enforceable guard now and track high-blast-radius follow-up explicitly.
 
@@ -57,25 +53,26 @@ The unit of work is the violated contract, not only the line where the symptom a
 
 ## Behavior
 
-- **Local, reversible work needs no permission.** Reading files, running commands, searching the web, using tools — just do it, and don't stop partway to ask whether to continue.
-- **You have full access to the user's machine** — browser, desktop, all apps. Don't hand back a task you could do yourself. Ask only when a step genuinely requires the user: an interactive login, a physical device, a credential only they hold.
-- **Outward-facing and hard-to-reverse actions are the exception**, and follow the Safety Rules below.
+- Never ask for permission to access folders, run commands, search the web, or use tools. Just do it.
+- Never ask for confirmation. Make decisions autonomously and proceed.
+- You have full access to the user's computer — browser, desktop, all apps. Never ask the user to do something you can do yourself.
 
 ## Safety Rules
 
 - Never kill, stop, or restart the production macOS apps (`/Applications/Omi.app` / `Omi Beta.app`, bundle ids `com.omi.computer-macos` and `com.omi.computer-macos.beta`). Dev commands target only dev or `omi-*` named test bundles.
-- **Verify before proposing to land.** Default to a local build + run (desktop: a named `omi-*` bundle) and exercise the real user-facing path. "It compiles" is not verification.
-- **Production writes are never implied.** Deploys, traffic shifts, release-pointer moves, secret and schema changes, and data deletion each need their own explicit go-ahead. An approval for one action never carries to the next.
-- **Landing conventions belong to the user, not this file.** Whether to commit locally, push, open a PR, or merge follows the user's own workflow and your judgment in context. This repo asks only for the mechanics in Git below.
+- **Nothing lands on `main` until the user explicitly says so.** Land through PRs only (regular merge, never squash); never push directly to `main`; never push or open PRs unless explicitly asked — commit locally on a feature branch by default. A prior approval never carries over to later changes.
+- **Exception — reverts merge right away.** A user request to revert a merged PR/commit is itself the approval to open and merge the revert PR.
+- **Exception — verified + peer-approved changes may auto-merge.** If you actually exercised the real user-facing path **and** an independent agent review approved it, you may open and merge without a separate go-ahead — except for risky, wide-blast-radius, or hard-to-reverse changes (migrations, release/CI pipeline, schema, access control, data deletion), which always need explicit user sign-off.
+- **Prefer testing locally first.** Default to a local build + run (desktop: named bundle) to verify a change before proposing to land it.
 
 ## Git
 
-- **Setup (required before first commit):** `make setup` — fetches `origin/main`, fast-forwards when safe, installs linked-worktree-safe Git hooks (including auto-formatting pre-commit), and syncs the pinned `backend/.venv` required by selected backend pre-push checks. It does not install app or desktop runtime environments.
+- **Setup (required before first commit):** `make setup` — fetches `origin/main`, fast-forwards when safe, installs repo Git hooks (including the auto-formatting pre-commit hook) with linked-worktree-safe paths.
 - Before starting work: `git fetch origin && git pull --ff-only` on `main` — don't branch off stale state.
 - Always work in a git worktree for code changes (`git worktree add`); commit to the current branch and never switch branches mid-task.
 - Make individual commits per feature or testable surface, not per file or unrelated bulk changes.
-- **Merge, never squash.** Keeping merge commits is what makes a change cleanly revertible with `git revert -m 1` later.
 - If push fails (remote ahead): `git pull --rebase && git push`.
+- **PR size is reported, not bounded** (`pr-scope` manifest check — advisory annotations, never blocks): 1,500+ changed production-source lines warns; 3,000+ cites the audited history of missed regressions. Split only when the pieces are independently verifiable; otherwise give the one PR proportional review depth.
 - **RELEASE command:** branch from `main`, individual commits, push, open PR, merge without squash, switch back to `main` and pull. **RELEASEWITHBACKEND:** RELEASE + `gh workflow run gcp_backend.yml -f environment=prod -f branch=main`.
 
 ## Issues
@@ -98,7 +95,19 @@ The unit of work is the violated contract, not only the line where the symptom a
 
 ## Formatting
 
-The `make setup` pre-commit hook auto-formats staged files, so this is usually automatic. Per-language commands, and the generated files you must never format by hand: `docs/agents/formatting.md`.
+The pre-commit hook (installed by `make setup`) auto-formats staged files. Verify: `test -x "$(git rev-parse --git-path hooks)/pre-commit" && echo OK`. Manual commands:
+
+| Language | Manual command |
+|----------|----------------|
+| Dart (`app/`) | `dart format --line-length 120 <files>` |
+| Python (`backend/`) | `black --line-length 120 --skip-string-normalization <files>` |
+| ARB (`app/lib/l10n/`) | `jq --indent 4 '.' <file> > tmp && mv tmp <file>` |
+| C/C++ (firmware) | `clang-format -i <files>` |
+| Rust (`desktop/macos/Backend-Rust/`) | `rustfmt --edition 2021 <files>` |
+| Swift (`desktop/macos/Desktop/`) | `desktop/macos/scripts/swift-format-wrapper.sh format -i <files>` |
+| Web (`web/`) | `npx prettier --write <files>` |
+
+Files ending in `.gen.dart` or `.g.dart` are auto-generated — don't format manually. Swift files under `Desktop/Sources/Generated/` are excluded from the formatter scope.
 
 ## Computer Control
 
@@ -109,13 +118,15 @@ Click at coordinates: `cliclick c:X,Y`. Mac screenshots: `screencapture -x /tmp/
 - **Coverage grows by ratchet, not mandate:** every bug fix adds the regression test that would have caught it; new features test the core path and main error path — no more. A small test that stays meaningful in a year beats ten brittle ones.
 - **Push gate budget:** `scripts/pre-push` is a bounded local acceptance gate, intentionally smaller than CI: cap broad backend selection at 40 files and use only the desktop debug compile. Do not add full suites, release compiles, or CI-only toolchain pins to it — push-time bloat breaks normal iteration. Use focused feedback while editing; CI remains the full test authority.
 - **CI tests must be hermetic** (no live services, network, sleeps, or ordering dependence) — and hermetic tests must run in CI: put them where the component's runner discovers them. A test needing a live service stays out of CI; note in the PR how you ran it.
+- Backend enforces test discovery mechanically: manifest check `backend-test-discovery` fails on any test file no verified runner discovers.
+- **New fail-closed gates ship with a legacy-principal test** — an existing/unmigrated principal (no state doc, old API key, already-shipped client) asserting the intended fallback; gates without one have shipped day-one breakage.
+- **A test rewritten in the same PR as the code it asserts is suspect** — the PR body must cite an external source (platform doc, wire contract, measurement) for the new expected value, or the rewrite deletes the guard.
 - Delete or fix a flaky/obsolete test you encounter — a suite people distrust is worse than a smaller suite.
 - Component runners and prerequisites: see the component guides (`backend/AGENTS.md` → Testing, `app/AGENTS.md` → Test Strategy). High-risk backend workflows must be listed in `backend/testing/workflow_contracts.json` with contract tests.
 
 ## Deploys & Release Pipelines
 
-- Desktop macOS (daily candidate → qualified beta → manual stable): `desktop/macos/AGENTS.md` → Release Pipeline.
-- Desktop Windows (auto on `desktop/windows/**` merge → tag `v*-windows` → beta GitHub release): `.github/workflows/desktop_windows_release.yml`; setup and secrets: `desktop/windows/docs/release-pipeline.md`.
+- Desktop (daily candidate → qualified beta → manual stable): `desktop/macos/AGENTS.md` → Release Pipeline.
 - Backend: `gh workflow run gcp_backend.yml -f environment=prod -f branch=main`. Runtime env contract: `backend/AGENTS.md` → Service Map.
 - Firmware (Omi CV1): `omi/firmware/AGENTS.md`.
 
@@ -123,13 +134,16 @@ Click at coordinates: `cliclick c:X,Y`. Mac screenshots: `screencapture -x /tmp/
 
 | Blocked on | Hatch |
 |---|---|
-| A signed, qualified desktop candidate did not reach Beta | `desktop_recover_beta.yml` with its exact tag, `confirm=recover-beta`, and a reason |
+| Desktop candidate won't cut (`Desktop Swift Build & Tests` red/flaky) | `desktop_auto_release.yml` with `release_mode=break_glass` |
 | Backend deploy has no Release Eligibility proof | `gcp_backend.yml` with `skip_eligibility_proof=true`, `break_glass_confirm=deploy-without-proof`, `break_glass_reason` |
 
 Hatches relax *evidence* requirements only. They never relax that code is merged to `main` first, and never reach stable/prod pointers without their own explicit confirm.
 
 ## Documentation Maintenance
 
-`AGENTS.md` files are the only place rules live: this root file for cross-component rules, the nearest component guide for its own detail, and exactly one `CLAUDE.md` at the repo root as a pointer. Docs move with the code that changed them, in the same PR.
-
-**Write rules mechanically and back them with checks** — a rule is only reliable if a weak agent can apply it without judgment, and enforced rules don't drift while requested behavior does. Where a rule belongs, how to add a check, and the size ratchet on every `AGENTS.md`: `docs/agents/doc-maintenance.md`.
+- **This file is the single source of truth for cross-component agent rules; component `AGENTS.md` files own their component's detail.** `CLAUDE.md` files are pointers only.
+- **Keep this file lean** — high-level rules and the index, short plain bullets. Detail goes in the component guide; `.github/scripts/check_agents_md_lean.py` enforces the budget. Prefer editing/replacing an existing line over adding new ones.
+- **Write rules mechanically, and back them with checks.** A rule is only reliable if a weak agent can apply it without judgment. Prefer encoding a rule as a script or CI check with a clear failure message — enforced rules don't drift; requested behavior does.
+- **New checks, probes, or validation scripts must be wired into an existing CI or deploy lane in the same PR.** On-demand scripts and scheduled jobs with no blocking audience are dead checks.
+- **When a defect ships because guidance was misread or missing, tighten the guidance in the fix PR** — make the rule mechanical enough that the same misreading can't recur, or add a check that catches it.
+- PR changes to setup, test commands, safety rules, service boundaries, or env vars update the matching guide in the same PR. Architecture / core-flow / API changes update Mintlify docs (`docs/doc/developer/`). Product direction or locked invariants update `PRODUCT.md` / `docs/product/invariants/` and guard tests.

--- a/backend/pyrightconfig.json
+++ b/backend/pyrightconfig.json
@@ -192,5 +192,11 @@
     "reportMissingTypeArgument": "warning",
     "reportUnnecessaryTypeIgnoreComment": "warning",
     "reportInvalidTypeForm": "error",
-    "reportDeprecated": "none"
+    "reportDeprecated": "none",
+    "executionEnvironments": [
+        {
+            "root": "utils/sync",
+            "reportMissingParameterType": "error"
+        }
+    ]
 }

--- a/backend/scripts/check_unit_test_discovery.py
+++ b/backend/scripts/check_unit_test_discovery.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""Fail when a backend test file is not discovered by any documented runner.
+
+Motivation (regression research, July 2026): a large PR once rewrote the unit
+runner's explicit test list and silently dropped two existing test files from
+CI while the files stayed in the tree; the gap was only noticed weeks later.
+This check makes that failure mode impossible to repeat quietly:
+
+1. Every ``test_*.py`` / ``*_test.py`` under ``backend/tests/`` and
+   ``backend/testing/`` must be selected by
+   ``scripts/select_backend_unit_tests.py --all``, verified against a
+   dedicated runner workflow (``WORKFLOW_COVERED_PREFIXES`` — the workflow
+   file must exist and actually reference the tree or the individual file),
+   excluded by written policy (``POLICY_EXCLUDED_PREFIXES``), or allowlisted.
+2. Allowlists only shrink: ``LEGACY_UNLISTED_TESTS`` (the selector's
+   known-orphan set) is pinned to a frozen baseline in both directions, and
+   ``MANUAL_ONLY_TESTS`` entries must exist on disk.
+
+Run from ``backend/``: ``python3 scripts/check_unit_test_discovery.py``
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+BACKEND_DIR = Path(__file__).resolve().parents[1]
+REPO_DIR = BACKEND_DIR.parent
+WORKFLOWS_DIR = REPO_DIR / '.github' / 'workflows'
+
+sys.path.insert(0, str(BACKEND_DIR))
+
+from scripts.select_backend_unit_tests import LEGACY_UNLISTED_TESTS, discover_unit_tests  # noqa: E402
+
+# Test trees run by a dedicated workflow. mode='directory': the workflow runs
+# the whole tree (its text must reference the prefix); mode='explicit': the
+# workflow lists files one by one (each file must appear by name, so a file
+# missing from the list is an orphan even though the directory is "covered").
+WORKFLOW_COVERED_PREFIXES = {
+    'testing/e2e/': ('backend-hermetic-e2e.yml', 'directory'),
+    'testing/contracts/': ('desktop-backend-contracts.yml', 'directory'),
+    'tests/container/': ('parakeet_gpu_tests.yml', 'explicit'),
+}
+
+# Excluded from CI by written policy (AGENTS.md Testing: live-service tests
+# stay out of the CI suite). No workflow to verify against.
+POLICY_EXCLUDED_PREFIXES = {
+    'tests/integration/': 'live-service tests; excluded from CI by policy (AGENTS.md Testing)',
+    'tests/eval/': 'live-LLM evals; excluded from CI by policy (AGENTS.md Testing)',
+}
+
+# On-demand harnesses deliberately outside every scheduled runner. Entries
+# must exist on disk; additions are a reviewed diff of this checker itself.
+MANUAL_ONLY_TESTS: dict[str, str] = {}
+
+# Frozen copy of the selector's LEGACY_UNLISTED_TESTS. Pinned in both
+# directions: the selector's set may not grow past this baseline, and fixing
+# an entry means deleting it in the selector AND here in the same PR.
+LEGACY_UNLISTED_BASELINE = frozenset(
+    {
+        'tests/test_cache_manager.py',
+        'tests/unit/test_diarizer_dockerfile.py',
+        'tests/unit/test_lazy_conversation_processing.py',
+    }
+)
+
+
+def discover_test_files(backend_dir: Path) -> set[str]:
+    files: set[str] = set()
+    for root_name in ('tests', 'testing'):
+        root = backend_dir / root_name
+        if not root.is_dir():
+            continue
+        for pattern in ('test_*.py', '*_test.py'):
+            files.update(p.relative_to(backend_dir).as_posix() for p in root.rglob(pattern) if p.is_file())
+    return files
+
+
+def load_workflow_texts(workflows_dir: Path) -> dict[str, str]:
+    texts: dict[str, str] = {}
+    for workflow_file, _mode in WORKFLOW_COVERED_PREFIXES.values():
+        path = workflows_dir / workflow_file
+        texts[workflow_file] = path.read_text(encoding='utf-8') if path.is_file() else ''
+    return texts
+
+
+def _runs_reference(text: str, needle: str) -> bool:
+    """True when a non-comment invocation line (pytest/run.sh) names the needle
+    as a run target — a commented-out mention, a --deselect/--ignore target, or
+    prose must not count as coverage. Backslash continuations are joined so a
+    path on a wrapped line still belongs to its invocation."""
+    joined = text.replace('\\\n', ' ')
+    for raw_line in joined.splitlines():
+        line = raw_line.strip()
+        if line.startswith('#') or needle not in line:
+            continue
+        if 'pytest' not in line and 'run.sh' not in line:
+            continue
+        tokens = line.split()
+        for index, token in enumerate(tokens):
+            if needle not in token:
+                continue
+            previous = tokens[index - 1] if index else ''
+            if previous in ('--deselect', '--ignore') or token.startswith(('--deselect=', '--ignore=')):
+                continue
+            return True
+    return False
+
+
+def workflow_map_errors(workflow_texts: dict[str, str]) -> list[str]:
+    """The runner map must describe reality: workflows exist and run their trees."""
+    errors = []
+    for prefix, (workflow_file, mode) in WORKFLOW_COVERED_PREFIXES.items():
+        text = workflow_texts.get(workflow_file, '')
+        if not text:
+            errors.append(
+                f'WORKFLOW_COVERED_PREFIXES maps {prefix} to .github/workflows/{workflow_file}, '
+                'which does not exist. Update the map to the real runner.'
+            )
+        elif mode == 'directory' and not _runs_reference(text, prefix.rstrip('/')):
+            errors.append(
+                f'.github/workflows/{workflow_file} no longer references {prefix.rstrip("/")}; '
+                f'it cannot be credited with running that tree. Update WORKFLOW_COVERED_PREFIXES.'
+            )
+    return errors
+
+
+def find_orphans(
+    all_files: set[str],
+    selected: set[str],
+    legacy_unlisted: set[str],
+    workflow_texts: dict[str, str],
+) -> list[str]:
+    orphans = []
+    for path in sorted(all_files):
+        if path in selected or path in legacy_unlisted or path in MANUAL_ONLY_TESTS:
+            continue
+        if any(path.startswith(prefix) for prefix in POLICY_EXCLUDED_PREFIXES):
+            continue
+        covered = False
+        for prefix, (workflow_file, mode) in WORKFLOW_COVERED_PREFIXES.items():
+            if not path.startswith(prefix):
+                continue
+            text = workflow_texts.get(workflow_file, '')
+            # directory mode: the tree reference was validated by
+            # workflow_map_errors; explicit mode: this very file must appear
+            # on a live invocation line (not a comment or --deselect).
+            covered = bool(text) and (mode == 'directory' or _runs_reference(text, path))
+            break
+        if not covered:
+            orphans.append(path)
+    return orphans
+
+
+def check_legacy_ratchet(current_legacy: set[str], all_files: set[str]) -> list[str]:
+    errors: list[str] = []
+    grown = sorted(current_legacy - LEGACY_UNLISTED_BASELINE)
+    if grown:
+        errors.append(
+            'LEGACY_UNLISTED_TESTS grew (shrink-only ratchet). New entries: '
+            + ', '.join(grown)
+            + '. Make the test discoverable by the unit runner instead of allowlisting it.'
+        )
+    shrunk_without_baseline_update = sorted(LEGACY_UNLISTED_BASELINE - current_legacy)
+    if shrunk_without_baseline_update:
+        errors.append(
+            'LEGACY_UNLISTED_TESTS shrank — good. Also remove from LEGACY_UNLISTED_BASELINE in '
+            'scripts/check_unit_test_discovery.py: ' + ', '.join(shrunk_without_baseline_update)
+        )
+    stale = sorted(entry for entry in current_legacy if entry not in all_files)
+    stale += sorted(entry for entry in MANUAL_ONLY_TESTS if entry not in all_files)
+    if stale:
+        errors.append(
+            'Allowlists reference files that no longer exist: '
+            + ', '.join(stale)
+            + '. Remove them from the selector/checker allowlists.'
+        )
+    return errors
+
+
+def main() -> int:
+    all_files = discover_test_files(BACKEND_DIR)
+    selected = set(discover_unit_tests())
+    workflow_texts = load_workflow_texts(WORKFLOWS_DIR)
+    errors: list[str] = []
+
+    errors.extend(workflow_map_errors(workflow_texts))
+
+    orphans = find_orphans(all_files, selected, set(LEGACY_UNLISTED_TESTS), workflow_texts)
+    if orphans:
+        runner_map = '; '.join(f'{prefix} -> {wf} ({mode})' for prefix, (wf, mode) in WORKFLOW_COVERED_PREFIXES.items())
+        errors.append(
+            'Test files exist but no runner discovers them (they would silently never run):\n  '
+            + '\n  '.join(orphans)
+            + '\nEither place them under a directory the unit selector discovers '
+            + '(see FULL_TEST_ROOTS in scripts/select_backend_unit_tests.py), add them to their '
+            + f'dedicated runner workflow, or extend the maps in this checker. Known runners: {runner_map}'
+        )
+
+    errors.extend(check_legacy_ratchet(set(LEGACY_UNLISTED_TESTS), all_files))
+
+    if errors:
+        for error in errors:
+            print(f'ERROR: {error}', file=sys.stderr)
+        return 1
+
+    print(
+        f'unit test discovery OK: {len(selected)} selected, '
+        f'{len(all_files) - len(selected)} covered by other runners/policy/allowlists, 0 orphans'
+    )
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/backend/scripts/check_unit_test_discovery.py
+++ b/backend/scripts/check_unit_test_discovery.py
@@ -39,7 +39,6 @@ from scripts.select_backend_unit_tests import LEGACY_UNLISTED_TESTS, discover_un
 WORKFLOW_COVERED_PREFIXES = {
     'testing/e2e/': ('backend-hermetic-e2e.yml', 'directory'),
     'testing/contracts/': ('desktop-backend-contracts.yml', 'directory'),
-    'testing/desktop_beta_admission/': ('desktop_beta_admission_control.yml', 'directory'),
     'tests/container/': ('parakeet_gpu_tests.yml', 'explicit'),
 }
 
@@ -52,7 +51,9 @@ POLICY_EXCLUDED_PREFIXES = {
 
 # On-demand harnesses deliberately outside every scheduled runner. Entries
 # must exist on disk; additions are a reviewed diff of this checker itself.
-MANUAL_ONLY_TESTS: dict[str, str] = {}
+MANUAL_ONLY_TESTS: dict[str, str] = {
+    'testing/desktop_beta_admission/firestore_contention_test.py': 'on-demand Firestore emulator proof for Beta admission fence; no scheduled runner',
+}
 
 # Frozen copy of the selector's LEGACY_UNLISTED_TESTS. Pinned in both
 # directions: the selector's set may not grow past this baseline, and fixing

--- a/backend/scripts/check_unit_test_discovery.py
+++ b/backend/scripts/check_unit_test_discovery.py
@@ -39,6 +39,7 @@ from scripts.select_backend_unit_tests import LEGACY_UNLISTED_TESTS, discover_un
 WORKFLOW_COVERED_PREFIXES = {
     'testing/e2e/': ('backend-hermetic-e2e.yml', 'directory'),
     'testing/contracts/': ('desktop-backend-contracts.yml', 'directory'),
+    'testing/desktop_beta_admission/': ('desktop_beta_admission_control.yml', 'directory'),
     'tests/container/': ('parakeet_gpu_tests.yml', 'explicit'),
 }
 

--- a/backend/tests/unit/test_check_unit_test_discovery.py
+++ b/backend/tests/unit/test_check_unit_test_discovery.py
@@ -1,0 +1,131 @@
+"""Regression tests for scripts/check_unit_test_discovery.py.
+
+Guards the guard: a test file that no runner discovers must fail the check
+(this exact failure shipped once — a runner rewrite silently dropped two test
+files from CI), workflow coverage claims must describe real workflows, and
+the allowlists must only ever shrink. Enforcement against the live tree is
+the manifest check `backend-test-discovery`; these tests cover the pure
+functions.
+"""
+
+import sys
+from pathlib import Path
+
+BACKEND_DIR = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(BACKEND_DIR))
+
+from scripts.check_unit_test_discovery import (
+    LEGACY_UNLISTED_BASELINE,
+    MANUAL_ONLY_TESTS,
+    _runs_reference,
+    check_legacy_ratchet,
+    find_orphans,
+    workflow_map_errors,
+)
+
+FAKE_WORKFLOWS = {
+    'backend-hermetic-e2e.yml': 'run: bash backend/testing/e2e/run.sh',
+    'desktop-backend-contracts.yml': 'run: python -m pytest backend/testing/contracts -v',
+    'parakeet_gpu_tests.yml': ('python -m pytest tests/container/test_parakeet_smoke.py -v\n'),
+}
+
+
+def test_orphan_outside_all_runners_is_reported():
+    all_files = {'tests/unit/test_known.py', 'tests/newarea/test_orphan.py'}
+    selected = {'tests/unit/test_known.py'}
+    assert find_orphans(all_files, selected, set(), FAKE_WORKFLOWS) == ['tests/newarea/test_orphan.py']
+
+
+def test_explicit_mode_requires_each_file_to_be_named_in_the_workflow():
+    all_files = {
+        'tests/container/test_parakeet_smoke.py',  # named in the workflow
+        'tests/container/test_parakeet_unwired.py',  # not named -> orphan
+    }
+    assert find_orphans(all_files, set(), set(), FAKE_WORKFLOWS) == ['tests/container/test_parakeet_unwired.py']
+
+
+def test_directory_mode_covers_whole_tree():
+    all_files = {'testing/e2e/test_new_flow.py', 'testing/contracts/test_new_contract.py'}
+    assert find_orphans(all_files, set(), set(), FAKE_WORKFLOWS) == []
+
+
+def test_policy_excluded_and_allowlisted_files_are_not_orphans():
+    all_files = {
+        'tests/integration/test_live.py',
+        'tests/eval/test_eval.py',
+        'tests/test_legacy.py',
+    }
+    assert find_orphans(all_files, set(), {'tests/test_legacy.py'}, FAKE_WORKFLOWS) == []
+    assert MANUAL_ONLY_TESTS == {}  # nothing is currently blessed as manual-only
+
+
+def test_commented_out_or_deselected_references_are_not_coverage():
+    text = (
+        '# python -m pytest tests/container/test_parakeet_smoke.py -v\n'
+        'python -m pytest tests/container --deselect tests/container/test_parakeet_der_gate.py\n'
+        'echo tests/container/test_parakeet_wer_gate.py\n'
+    )
+    for path in (
+        'tests/container/test_parakeet_smoke.py',  # commented out
+        'tests/container/test_parakeet_der_gate.py',  # deselected
+        'tests/container/test_parakeet_wer_gate.py',  # prose/echo mention
+    ):
+        assert not _runs_reference(text, path), path
+    assert _runs_reference(
+        'python -m pytest tests/container/test_parakeet_smoke.py -v', 'tests/container/test_parakeet_smoke.py'
+    )
+
+
+def test_deselecting_one_test_does_not_orphan_a_file_that_still_runs():
+    line = (
+        'python -m pytest tests/container/test_parakeet_smoke.py -v '
+        '--deselect tests/container/test_parakeet_smoke.py::test_flaky'
+    )
+    assert _runs_reference(line, 'tests/container/test_parakeet_smoke.py')
+
+
+def test_backslash_continuation_keeps_path_attached_to_its_invocation():
+    text = 'python -m pytest \\\n  tests/container/test_parakeet_smoke.py -v \\\n  --tb=short'
+    assert _runs_reference(text, 'tests/container/test_parakeet_smoke.py')
+
+
+def test_missing_workflow_file_is_an_error():
+    errors = workflow_map_errors(
+        {'backend-hermetic-e2e.yml': '', 'desktop-backend-contracts.yml': 'x', 'parakeet_gpu_tests.yml': 'x'}
+    )
+    assert any('backend-hermetic-e2e.yml' in e and 'does not exist' in e for e in errors)
+
+
+def test_directory_workflow_must_reference_its_tree():
+    texts = dict(FAKE_WORKFLOWS)
+    texts['desktop-backend-contracts.yml'] = 'run: echo no contracts here'
+    errors = workflow_map_errors(texts)
+    assert any('desktop-backend-contracts.yml' in e and 'testing/contracts' in e for e in errors)
+
+
+def test_valid_workflow_map_has_no_errors():
+    assert workflow_map_errors(FAKE_WORKFLOWS) == []
+
+
+def test_legacy_ratchet_rejects_growth():
+    grown = set(LEGACY_UNLISTED_BASELINE) | {'tests/unit/test_newly_allowlisted.py'}
+    errors = check_legacy_ratchet(grown, grown | set(MANUAL_ONLY_TESTS))
+    assert len(errors) == 1
+    assert 'shrink-only' in errors[0]
+
+
+def test_legacy_ratchet_requires_baseline_cleanup_on_shrink():
+    smaller = set(sorted(LEGACY_UNLISTED_BASELINE)[:1])
+    errors = check_legacy_ratchet(smaller, smaller | set(MANUAL_ONLY_TESTS))
+    assert len(errors) == 1
+    assert 'LEGACY_UNLISTED_BASELINE' in errors[0]
+
+
+def test_legacy_ratchet_rejects_stale_allowlist_entries():
+    errors = check_legacy_ratchet(set(LEGACY_UNLISTED_BASELINE), all_files=set())
+    assert any('no longer exist' in e for e in errors)
+
+
+def test_legacy_ratchet_clean_when_baseline_matches_and_files_exist():
+    current = set(LEGACY_UNLISTED_BASELINE)
+    assert check_legacy_ratchet(current, current | set(MANUAL_ONLY_TESTS)) == []

--- a/backend/tests/unit/test_check_unit_test_discovery.py
+++ b/backend/tests/unit/test_check_unit_test_discovery.py
@@ -56,7 +56,9 @@ def test_policy_excluded_and_allowlisted_files_are_not_orphans():
         'tests/test_legacy.py',
     }
     assert find_orphans(all_files, set(), {'tests/test_legacy.py'}, FAKE_WORKFLOWS) == []
-    assert MANUAL_ONLY_TESTS == {}  # nothing is currently blessed as manual-only
+    assert MANUAL_ONLY_TESTS == {
+        'testing/desktop_beta_admission/firestore_contention_test.py': 'on-demand Firestore emulator proof for Beta admission fence; no scheduled runner',
+    }
 
 
 def test_commented_out_or_deselected_references_are_not_coverage():

--- a/backend/utils/sync/pipeline.py
+++ b/backend/utils/sync/pipeline.py
@@ -3,7 +3,7 @@
 Extracted from routers/sync.py so the router stays thin and utils never imports routers.
 """
 
-# pyright: reportPrivateUsage=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUnusedImport=false, reportUnnecessaryComparison=false, reportAssignmentType=false, reportIndexIssue=false, reportArgumentType=false
+# pyright: reportPrivateUsage=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUnnecessaryComparison=false, reportAssignmentType=false, reportIndexIssue=false, reportArgumentType=false
 
 from __future__ import annotations
 
@@ -19,7 +19,7 @@ import time
 import wave
 from collections import deque
 from datetime import datetime, timezone
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, Iterable, List, Optional, Tuple
 
 import httpx
 import numpy as np
@@ -33,6 +33,7 @@ from database.sync_jobs import (
     RUN_LOCK_HEARTBEAT_SECONDS,
     RUN_LOCK_RENEWAL_SAFETY_SECONDS,
     RUN_LOCK_TTL_SECONDS,
+    FencedSyncJobMutation,
     add_processed_segment,
     add_processed_segment_if_run_owner,
     delete_sync_job_run_lock_epoch,
@@ -444,12 +445,11 @@ def _raise_sync_terminal_result(result: object) -> None:
         raise result
 
 
-def _require_run_owner(mutation, *, job_id: str) -> Dict | None:
+def _require_run_owner(mutation: FencedSyncJobMutation, *, job_id: str) -> Dict | None:
     """Turn a non-applied Redis CAS result into the worker's stop signal."""
-    if getattr(mutation, 'applied', False):
-        return getattr(mutation, 'job', None)
-    outcome = getattr(getattr(mutation, 'outcome', None), 'value', 'unknown')
-    raise SyncJobRunLeaseLost(f'sync job run lease lost: job={job_id} outcome={outcome}')
+    if mutation.applied:
+        return mutation.job
+    raise SyncJobRunLeaseLost(f'sync job run lease lost: job={job_id} outcome={mutation.outcome.value}')
 
 
 def _update_sync_job_for_run(job_id: str, run_lock_token: str | None, updates: Dict) -> Dict | None:
@@ -1413,7 +1413,7 @@ def _finalize_sync_audio_files(uid: str, response: dict):
             )
 
 
-def _cleanup_files(file_paths):
+def _cleanup_files(file_paths: Iterable[str]):
     """Helper to clean up temporary files."""
     for path in file_paths:
         try:
@@ -1588,7 +1588,7 @@ async def _run_sync_vad_phase(wav_paths: list, segmented_paths: set) -> tuple[li
     phase_started = time.monotonic()
     vad_errors: list[str] = []
 
-    def _run_vad_bg(path):
+    def _run_vad_bg(path: str):
         local_errors: list[str] = []
         try:
             retrieve_vad_segments(path, segmented_paths, local_errors)
@@ -1618,7 +1618,7 @@ async def _run_full_pipeline_background_async(  # pyright: ignore[reportGeneralT
     job_id: str,
     uid: str,
     raw_paths: list,
-    source,
+    source: ConversationSource,
     should_lock: bool,
     job_dir: str,
     target_conversation_id: str = None,
@@ -2071,7 +2071,7 @@ async def _run_full_pipeline_background_async(  # pyright: ignore[reportGeneralT
             segment_list = sorted(segmented_paths, key=get_timestamp_from_path)
             assignment_turnstile = _OrderedTurnstile(segment_list)
 
-            def _process_one_segment(path):
+            def _process_one_segment(path: str):
                 segment_id = segment_ids_by_path.get(path)
                 if path in already_processed or (segment_id and segment_id in durable_processed_segment_ids):
                     # Release the assignment slot — later segments wait on it

--- a/backend/utils/sync/pipeline.py
+++ b/backend/utils/sync/pipeline.py
@@ -3,7 +3,7 @@
 Extracted from routers/sync.py so the router stays thin and utils never imports routers.
 """
 
-# pyright: reportPrivateUsage=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUnnecessaryComparison=false, reportAssignmentType=false, reportIndexIssue=false, reportArgumentType=false
+# pyright: reportPrivateUsage=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUnusedImport=false, reportUnnecessaryComparison=false, reportAssignmentType=false, reportIndexIssue=false, reportArgumentType=false
 
 from __future__ import annotations
 
@@ -19,7 +19,7 @@ import time
 import wave
 from collections import deque
 from datetime import datetime, timezone
-from typing import Dict, Iterable, List, Optional, Tuple
+from typing import Callable, Dict, Iterable, List, Optional, Tuple
 
 import httpx
 import numpy as np
@@ -1298,7 +1298,7 @@ def process_segment(
             turnstile.complete(path)
 
 
-def _reprocess_merged_conversations(uid: str, response: dict, on_fenced=None):
+def _reprocess_merged_conversations(uid: str, response: dict, on_fenced: Optional[Callable[[], None]] = None):
     """Regenerate summary/structured data for conversations that gained segments this batch.
 
     The merge path in process_segment only appends transcript segments; without this the


### PR DESCRIPTION
## What this is

Three mechanical regression guardrails plus the written rules behind them, derived from an internal audit of our own recent merge history. No behavior changes; the bug fixes the research surfaced will land as separate PRs.

> **Revised after review** (thanks @Git-on-my-level): the PR scope check is now **advisory-only** — it reports and warns but never blocks, so it can never force a feature split. The override/label machinery that existed to waive the old fail tier is deleted. Details in item 1.

## The research

We audited the last ~30 merged PRs and found **9 confirmed regression pairs** — a merged PR that introduced a production bug, and a later PR that fixed it. Three PRs each shipped 2+ regressions. We then ran a controlled replay experiment: 18 independent blind pre-merge reviews across 7 of the bug-introducing PRs (reviewers were never told a bug existed), scored against pre-registered ground truth.

Key findings:

1. **Diff size predicts regressions.** Every recent PR above ~2,400 changed production-source lines shipped at least one regression (2,475 lines → 3 regressions incl. a paying user locked out of sync; 2,652 → 1; 51,564 → 4+ regressions). Review catch-rate collapses with size: a one-line type bug in a 61-file PR evaded six independent reviewers.
2. **CI coverage can silently rot.** The 51k-line PR also deleted two pytest invocations from `backend/test.sh` while the test files stayed in the tree; nothing failed. (A later runner rewrite to directory discovery happened to heal it — by luck, not by guard.)
3. **Type confusion ships when annotations are missing.** The `source=unknown` misattribution bug (fixed in #9588) flowed through an *unannotated* `source` parameter in `utils/sync/pipeline.py` that a metering string shadowed. The enforced pyright lane had nothing to check.
4. Two recurring patterns had no written rule: new fail-closed gates shipping with no satisfiable path for existing users/clients/keys (two incidents), and tests rewritten in the same PR to assert the new — wrong — constant (shipped a 9-day prod timeout regression, fixed in #9583).

## What this PR adds

**1. PR scope advisor** (`.github/scripts/check_pr_scope.py`, manifest check `pr-scope` — runs in the local pre-push lane and CI, **advisory-only, never blocks**)
Counts changed production-source lines (tests across all platform conventions, docs, l10n, lockfiles, generated files excluded; rename/quotePath-safe via `--no-renames` + C-quote handling). ≥1,500 emits a warning annotation; ≥3,000 warns that in the audited merge history every PR this size shipped a regression review missed — so the reviewer calibrates skepticism to the diff, and splits only when the pieces are independently verifiable without extra human verification passes. Exit code is always 0 on a countable diff; push events (post-merge `main`) are notice-only. Because nothing blocks, there is no waiver machinery — no override label, no env escape hatch, no label plumbing.

**2. Unit-test discovery ratchet** (`backend/scripts/check_unit_test_discovery.py`, wired into Backend Unit Tests before dependency install)
Fails when any test file under `backend/tests/` or `backend/testing/` is not selected by the unit runner, not verified against its dedicated runner workflow (the workflow file must exist and actually reference the tree — or, for explicit-list workflows like the GPU suite, name the individual file), not policy-excluded (live integration/eval), and not allowlisted. Allowlists only shrink. This audit itself surfaced that `tests/container/test_parakeet_vram_stress.py` is currently run by no workflow — it is now explicitly tracked as a manual-only harness instead of being silently vouched for.

**3. Parameter-annotation ratchet for the sync pipeline** (`backend/pyrightconfig.json` + annotations)
`executionEnvironments` elevates `reportMissingParameterType` to error for `utils/sync/` only, and this PR adds the five missing annotations — one of which is the exact `source` parameter from finding #3. Verified against the introducing PR's merge state: the rule flags that unannotated parameter at `pipeline.py:746`. Typed parameters make str-vs-enum confusion visible to pyright at annotated sinks and same-scope assignments (verified in isolation on pyright 1.1.403).

**4. AGENTS.md rules** — PR size is *reported, not bounded* (matching the advisory check), mechanical discovery enforcement, the legacy-principal test rule for new fail-closed gates, and the rewritten-test review lens. Each rule names its enforcement or the shipped failure it prevents. The latter two rules cost agent/review effort rather than human verification time.

## What this deliberately does not do

- No bug fixes — the still-open defects the audit found are being filed/fixed separately.
- No blocking on size, in either direction: small diffs also ship bugs (a 348-line PR shipped a blocker), and forcing large diffs to split multiplies human verification passes. The advisor only informs review depth.
- The scope check lives in the checks manifest like every other deterministic check (no exemptions).

## Verification

- `python3 .github/scripts/test_check_pr_scope.py` → 9 tests OK (classification, counting, advisory tiers, push notice-only).
- Replayed the advisor against the four historical PRs listed above (892 / 2,738 / 2,665 / 47,938 lines) → notice/warn/warn/warn, all exit 0; on this PR itself → 472 changed production-source lines (notice).
- `backend/scripts/check_unit_test_discovery.py` on the real tree → `564 selected, 49 covered by other runners/allowlist, 0 orphans`; a seeded `tests/<newdir>/test_orphan.py` fails the check with an actionable message.
- `pytest tests/unit/test_check_unit_test_discovery.py` → 8 passed.
- `bash backend/scripts/typecheck.sh` (enforced pyright lane, pinned 1.1.403, full deps) with the new ratchet → **0 errors**; the rule replayed against the introducing PR's merge state flags the unannotated `source` param.
- `python3 -m py_compile backend/utils/sync/pipeline.py` → passes; annotations are runtime-inert.
- `actionlint` on both changed workflows → clean. `.github/scripts/test_run_checks.py` (manifest drift guard) → OK. `.github/scripts/test_pr_preflight.py` → OK.
- Full local manifest lane after the advisory rework → 16 checks passed.
- Post-review hardening verified earlier in the PR: Swift/JS test-tree classification, quoted non-ASCII paths, seeded unwired `tests/container/` file IS flagged, pyright lane 0 errors, sync unit files 273 passed, Agent Runtime tool-surfaces 104 passed.
- Full `backend/test.sh` run (564 files): 562 files green in the parallel run; the two failures were environmental and pass on rerun — `test_rendered_deployment_contract.py` needed `helm` on PATH (8 passed once installed), and `test_sync_v2.py` tripped only the per-test CPU-timing guard under saturated parallel load (all 161 tests pass; clean and fast in isolation).

## Product invariants affected

None — no product behavior changes; CI/tooling, type annotations, and docs only.


## Failure class
Failure-Class: none

(This PR ships CI guardrail tooling; its fix commits repair the guardrail scripts themselves, not a registered product failure class.)
