### PR TITLE
fix(desktop): Apple Notes "exec" over-filter + Opus decoder slice-safety

### DIFF
--- a/desktop/macos/Desktop/Sources/AppleNotesReaderService.swift
+++ b/desktop/macos/Desktop/Sources/AppleNotesReaderService.swift
@@ -527,11 +527,16 @@ actor AppleNotesReaderService {
     return normalized.trimmingCharacters(in: .whitespacesAndNewlines)
   }
 
-  private static func isLikelyAttachment(title: String, summary: String) -> Bool {
+  nonisolated static func isLikelyAttachment(title: String, summary: String) -> Bool {
     let combined = "\(title) \(summary)".trimmingCharacters(in: .whitespacesAndNewlines)
     guard !combined.isEmpty else { return true }
 
-    if combined.contains("SOLITE") || combined.contains("exec") || combined.contains("kMDItem") {
+    // "SOLITE" / "kMDItem" are distinctive metadata/artifact tokens safe to match as
+    // substrings. "exec" must match only as a whole word — as a raw substring it wrongly
+    // dropped ordinary notes whose title/summary merely *contained* it ("Q3 execution
+    // plan", "Executive summary", "executed tasks").
+    let hasExecToken = combined.range(of: #"\bexec\b"#, options: [.regularExpression, .caseInsensitive]) != nil
+    if combined.contains("SOLITE") || combined.contains("kMDItem") || hasExecToken {
       return true
     }
 

--- a/desktop/macos/Desktop/Sources/Audio/AudioCodecDecoder.swift
+++ b/desktop/macos/Desktop/Sources/Audio/AudioCodecDecoder.swift
@@ -178,8 +178,10 @@ final class OpusAudioDecoder: AudioCodecDecoder {
 
         guard !data.isEmpty else { return nil }
 
-        // Validate Opus TOC byte
-        let tocByte = data[0]
+        // Validate Opus TOC byte. Index off startIndex, not a literal 0: `Data` subscripting
+        // is startIndex-relative, so `data[0]` traps on a non-zero-based slice (the sibling
+        // AAC decoder was already hardened for this class via `adtsRawAACRange`).
+        let tocByte = data[data.startIndex]
         if !isValidOpusToc(tocByte) {
             logger.debug("Invalid Opus TOC byte: 0x\(String(format: "%02x", tocByte))")
             // Still try to decode - might be valid

--- a/desktop/macos/Desktop/Tests/AppleNotesReaderServiceTests.swift
+++ b/desktop/macos/Desktop/Tests/AppleNotesReaderServiceTests.swift
@@ -17,6 +17,25 @@ final class AppleNotesReaderServiceTests: XCTestCase {
     XCTAssertEqual(path, "/notes/NoteStore.sqlite")
   }
 
+  func testIsLikelyAttachmentDoesNotDropOrdinaryNotesContainingExecSubstring() {
+    // Regression: a raw `contains("exec")` substring match wrongly classified ordinary
+    // notes as attachment/metadata artifacts and silently dropped them from the import.
+    for title in ["Q3 execution plan", "Executive summary", "executed the migration", "executive decisions"] {
+      XCTAssertFalse(
+        AppleNotesReaderService.isLikelyAttachment(title: title, summary: "notes and details"),
+        "note titled \"\(title)\" must not be filtered as an attachment"
+      )
+    }
+  }
+
+  func testIsLikelyAttachmentStillFiltersArtifactTokens() {
+    // The metadata/artifact tokens the filter targets must still be caught.
+    XCTAssertTrue(AppleNotesReaderService.isLikelyAttachment(title: "kMDItemFSName", summary: ""))
+    XCTAssertTrue(AppleNotesReaderService.isLikelyAttachment(title: "SOLITE", summary: ""))
+    XCTAssertTrue(AppleNotesReaderService.isLikelyAttachment(title: "exec", summary: ""))
+    XCTAssertTrue(AppleNotesReaderService.isLikelyAttachment(title: "", summary: ""))
+  }
+
   func testResolveSelectedFolderAcceptsAndInfersNotesContainer() throws {
     let root = try makeTemporaryDirectory()
     defer { try? FileManager.default.removeItem(at: root) }

--- a/desktop/macos/changelog/unreleased/20260713-applenotes-exec-filter.json
+++ b/desktop/macos/changelog/unreleased/20260713-applenotes-exec-filter.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed Apple Notes import silently skipping notes whose title or summary contained words like \"execution\" or \"executive\""
+}

--- a/desktop/macos/e2e/flows/apple-notes-read.yaml
+++ b/desktop/macos/e2e/flows/apple-notes-read.yaml
@@ -1,0 +1,24 @@
+version: 2
+name: apple-notes-read
+tier: 2
+description: Apple Notes read-access probe rejects an invalid folder deterministically (no import/save)
+app: non-prod
+covers:
+  - desktop/macos/Desktop/Sources/AppleNotesReaderService.swift
+preconditions:
+  - automation_bridge_ready
+
+steps:
+  - id: S1
+    name: Probe rejects a non-Notes folder without crashing
+    # A bogus folderPath fails every branch of resolveSelectedFolder, so validateSelectedFolder
+    # throws .invalidSelectedFolder regardless of whether this machine has an Apple Notes store —
+    # a deterministic, hermetic outcome that still exercises AppleNotesReaderService end to end.
+    bridge.action:
+      name: apple_notes_read_probe
+      params:
+        folderPath: "/nonexistent/omi-e2e-apple-notes-fixture"
+        maxResults: 5
+        remember: false
+    expect:
+      result.detail.ok: "false"


### PR DESCRIPTION
## Summary

macOS bug sweep (batch 10) — a fan-out review of previously-unswept desktop subsystems (audio pipeline, auth/credential/keychain, conversation lifecycle + readers, ProactiveAssistants). Two fixes here; the higher-risk findings are documented below for local handling.

## Fixes

### 1. MEDIUM — Apple Notes import silently dropped notes containing "exec"
`AppleNotesReaderService.isLikelyAttachment` classified a note as a binary/metadata artifact (and dropped it from the onboarding import) when its title/summary merely **contained** the case-sensitive substring `"exec"`. That matches ordinary words — "Q3 **exec**ution plan", "**Exec**utive summary", "**exec**uted tasks" — so legitimate notes were silently excluded (reached via `readRecentNotes` → `fetchRecentNotes`, and the `connectionStatus` note count). Fixed to match `"exec"` only as a whole word (`\bexec\b`, case-insensitive); the distinctive `"SOLITE"` / `"kMDItem"` artifact tokens stay substring matches (`AppleNotesReaderService.swift`).
- Regression test: `AppleNotesReaderServiceTests.testIsLikelyAttachmentDoesNotDropOrdinaryNotesContainingExecSubstring` (real notes survive) + `...StillFiltersArtifactTokens` (artifact tokens still filtered). `isLikelyAttachment` made `nonisolated static` (internal) to match the existing tested helpers (`classifyReadError`, `resolveSelectedFolder`).
- e2e coverage: new `e2e/flows/apple-notes-read.yaml` drives the existing `apple_notes_read_probe` bridge action against an invalid folder — a deterministic, hermetic outcome that exercises `AppleNotesReaderService` end to end (validated `desktop-flow-lint.py` OK).

### 2. LOW (defensive) — Opus decoder `data[0]` was startIndex-unsafe
`OpusAudioDecoder.decode` read the TOC byte via `data[0]`. `Data` subscripting is `startIndex`-relative, so `data[0]` traps on a non-zero-based slice. Not reachable today (all current callers pass zero-based `Data`), but it's exactly the class the sibling AAC decoder was already hardened against (`adtsRawAACRange`). Changed to `data[data.startIndex]` to close the class (`Audio/AudioCodecDecoder.swift`). No behavior change for current callers.

## Testing

- Desktop static checkers pass at head: `check_desktop_test_quality.py` (baseline; behavioral test, not source-inspection), `check-sources-root-layout.py` (baseline), `check-e2e-flow-coverage.py --strict` (both changed files covered), `desktop-flow-lint.py` (53 flows OK).
- `scripts/pr-preflight` green — 13 checks (INV-INT-1 citation present; brand-ui/INV-UI-1 clean; changelog present).
- Swift compile + XCTest run in `desktop-swift-ci` (no local macOS toolchain in this sandbox).

## Findings documented for local handling (NOT in this PR)

- **MEDIUM — audio stop-time teardown data race** (`AudioCaptureService.stopCapture` + `SystemAudioCaptureService`): `stopCapture` clears `onAudioChunk`/`audioConverter`/formats on the main thread while the CoreAudio HAL IOProc is still running (it's only stopped later via a deferred `audioQueue.async { AudioDeviceStop(...) }`), so the IOProc can hit `onAudioChunk?(byteData)` concurrently with the main-thread nil-write — a real ARC data race → probabilistic crash-on-stop. The correct fix (stop/destroy the IOProc before clearing callbacks/converter, keeping the stop off the main thread) is subtle real-time-audio threading across two services and needs a local build + run to validate. Left untouched deliberately.
- LOW: ProactiveAssistants `AssistantCoordinator.unregister`/`stopAll` have zero callers (bounded retention after stop); initial `notifyAppSwitch` dropped by async registration (recovered by first-frame capture). Auth `refreshIdToken` builds the refresh body without URL-encoding (Firebase refresh tokens are URL-safe → not reachable). Not fixed — low value / not reachable.

## Product invariants affected

- **INV-INT-1** (Integrations harness over heuristics) — path-based match: `AppleNotesReaderService.swift` matches the `**/*ReaderService*` glob. This change only makes an existing artifact-filter heuristic (`isLikelyAttachment`) less over-broad — it does not change the connector harness, trace/redaction contract, or the "harness over heuristics" direction; the invariant's guard remains satisfied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RAxLsaxtwVNDTWAZFfJp9q)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9635?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

