### PR TITLE
fix(backend): tell API-key callers which endpoints their key actually authenticates

### DIFF
--- a/backend/dependencies.py
+++ b/backend/dependencies.py
@@ -7,6 +7,7 @@ from firebase_admin import auth
 
 import database.mcp_api_key as mcp_api_key_db
 import database.dev_api_key as dev_api_key_db
+from utils.api_key_families import DEV_FAMILY, MCP_FAMILY, wrong_key_family_detail
 from utils.executors import critical_executor, run_blocking
 from utils.log_sanitizer import sanitize
 from utils.observability.api_keys import record_api_key_repairs
@@ -49,6 +50,9 @@ async def get_uid_from_mcp_api_key(api_key: str = Security(api_key_header)) -> s
         )
 
     token = api_key.replace("Bearer ", "")
+    mismatch = wrong_key_family_detail(token, MCP_FAMILY)
+    if mismatch:
+        raise HTTPException(status_code=401, detail=mismatch)
     auth_result = await run_blocking(critical_executor, mcp_api_key_db.get_api_key_auth_result, token)
     record_api_key_repairs(key_kind="mcp", operation="auth", repairs=auth_result.repairs, log=logger)
     user_data = auth_result.context
@@ -79,6 +83,9 @@ async def get_mcp_api_key_auth(api_key: str = Security(api_key_header)) -> "ApiK
         )
 
     token = api_key.replace("Bearer ", "")
+    mismatch = wrong_key_family_detail(token, MCP_FAMILY)
+    if mismatch:
+        raise HTTPException(status_code=401, detail=mismatch)
     auth_result = await run_blocking(critical_executor, mcp_api_key_db.get_api_key_auth_result, token)
     record_api_key_repairs(key_kind="mcp", operation="auth", repairs=auth_result.repairs, log=logger)
     user_data = auth_result.context
@@ -171,6 +178,9 @@ async def get_api_key_auth(api_key: str = Security(api_key_header)) -> ApiKeyAut
         )
 
     token = api_key.replace("Bearer ", "")
+    mismatch = wrong_key_family_detail(token, DEV_FAMILY)
+    if mismatch:
+        raise HTTPException(status_code=401, detail=mismatch)
     auth_result = await run_blocking(critical_executor, dev_api_key_db.get_api_key_auth_result, token)
     record_api_key_repairs(key_kind="dev", operation="auth", repairs=auth_result.repairs, log=logger)
     user_data = auth_result.context

--- a/backend/tests/unit/test_api_key_family_errors.py
+++ b/backend/tests/unit/test_api_key_family_errors.py
@@ -1,0 +1,120 @@
+"""An Omi API key used on the wrong endpoint family must say so in the 401.
+
+Regression for #7506: an MCP key on /v1/conversations only answered "Invalid authorization
+token", which reads as a broken key rather than a key/endpoint mismatch.
+"""
+
+import asyncio
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+from typing import Any, Iterator, Optional
+
+import pytest
+from fastapi import HTTPException
+
+from testing.import_isolation import load_module_fresh, stub_modules
+from utils.other.endpoints import get_current_user_uid
+
+BACKEND_DIR = Path(__file__).resolve().parents[2]
+
+
+def _module(name: str, **attributes: Any) -> ModuleType:
+    module = ModuleType(name)
+    for key, value in attributes.items():
+        setattr(module, key, value)
+    return module
+
+
+class _ProductAuthorizationContext:
+    def __init__(self, **values: Any):
+        self.__dict__.update(values)
+
+
+@dataclass(frozen=True)
+class _McpVerifiedAuth:
+    uid: str
+    app_id: Optional[str] = None
+    key_id: Optional[str] = None
+    scopes: tuple[str, ...] = ()
+
+
+class _KeyLookupSpy:
+    """Stands in for the Firestore key lookup so we can assert it is never reached."""
+
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+
+    def __call__(self, token: str) -> SimpleNamespace:
+        self.calls.append(token)
+        return SimpleNamespace(context=None, repairs=frozenset())
+
+
+@contextmanager
+def _loaded_dependencies() -> Iterator[tuple[ModuleType, _KeyLookupSpy, _KeyLookupSpy]]:
+    mcp_lookup = _KeyLookupSpy()
+    dev_lookup = _KeyLookupSpy()
+
+    with stub_modules(
+        {
+            'firebase_admin.auth': _module('firebase_admin.auth', verify_id_token=lambda _token: {'uid': 'user-1'}),
+            'database.mcp_api_key': _module('database.mcp_api_key', get_api_key_auth_result=mcp_lookup),
+            'database.dev_api_key': _module('database.dev_api_key', get_api_key_auth_result=dev_lookup),
+            'utils.other.endpoints': _module('utils.other.endpoints', check_api_key_rate_limit=lambda **_kwargs: None),
+            'utils.mcp_memories': _module(
+                'utils.mcp_memories',
+                McpVerifiedAuth=_McpVerifiedAuth,
+                build_mcp_default_memory_read_context=lambda auth: _ProductAuthorizationContext(uid=auth.uid),
+                build_mcp_default_memory_write_context=lambda auth: _ProductAuthorizationContext(uid=auth.uid),
+            ),
+            'utils.memory.product_authorization': _module(
+                'utils.memory.product_authorization',
+                ProductAuthorizationContext=_ProductAuthorizationContext,
+            ),
+        }
+    ):
+        dependencies = load_module_fresh('dependencies', str(BACKEND_DIR / 'dependencies.py'))
+        yield dependencies, mcp_lookup, dev_lookup
+
+
+def test_developer_key_on_an_mcp_endpoint_names_both_endpoint_families() -> None:
+    with _loaded_dependencies() as (dependencies, mcp_lookup, _dev_lookup):
+        with pytest.raises(HTTPException) as raised:
+            asyncio.run(dependencies.get_uid_from_mcp_api_key('Bearer omi_dev_secret'))
+
+        assert raised.value.status_code == 401
+        assert '/v1/dev/' in raised.value.detail
+        assert 'MCP API key' in raised.value.detail
+        assert mcp_lookup.calls == []
+
+
+def test_mcp_key_on_a_developer_endpoint_names_both_endpoint_families() -> None:
+    with _loaded_dependencies() as (dependencies, _mcp_lookup, dev_lookup):
+        with pytest.raises(HTTPException) as raised:
+            asyncio.run(dependencies.get_api_key_auth('Bearer omi_mcp_secret'))
+
+        assert raised.value.status_code == 401
+        assert '/v1/mcp/' in raised.value.detail
+        assert 'Developer API key' in raised.value.detail
+        assert dev_lookup.calls == []
+
+
+def test_matching_key_family_still_reaches_its_own_key_lookup() -> None:
+    with _loaded_dependencies() as (dependencies, _mcp_lookup, dev_lookup):
+        with pytest.raises(HTTPException) as raised:
+            asyncio.run(dependencies.get_api_key_auth('Bearer omi_dev_secret'))
+
+        # The stubbed lookup rejects every key; what matters is that the prefix guard
+        # let a developer key through to the developer-key lookup.
+        assert raised.value.detail == 'Invalid API Key'
+        assert dev_lookup.calls == ['omi_dev_secret']
+
+
+def test_mcp_key_on_a_firebase_endpoint_points_at_the_mcp_endpoints() -> None:
+    with pytest.raises(HTTPException) as raised:
+        get_current_user_uid(authorization='Bearer omi_mcp_secret')
+
+    assert raised.value.status_code == 401
+    assert '/v1/mcp/' in raised.value.detail
+    assert 'Firebase ID token' in raised.value.detail

--- a/backend/utils/api_key_families.py
+++ b/backend/utils/api_key_families.py
@@ -1,0 +1,55 @@
+"""Recognize Omi API key families so a key used on the wrong endpoint gets an actionable 401.
+
+Each key family authenticates exactly one endpoint family: `omi_mcp_` keys only the MCP
+endpoints, `omi_dev_` keys only the Developer API, and every other route requires a Firebase
+ID token issued by the app. Presenting the wrong one otherwise fails as a generic
+"Invalid authorization token" / "Invalid API Key", which reads as a broken key or a dead
+endpoint rather than a key/endpoint mismatch.
+"""
+
+from typing import Optional
+
+MCP_KEY_PREFIX = "omi_mcp_"
+DEV_KEY_PREFIX = "omi_dev_"
+
+FIREBASE_FAMILY = "firebase"
+MCP_FAMILY = "mcp"
+DEV_FAMILY = "dev"
+
+_FAMILY_BY_PREFIX = {
+    MCP_KEY_PREFIX: MCP_FAMILY,
+    DEV_KEY_PREFIX: DEV_FAMILY,
+}
+
+_KEY_USAGE = {
+    MCP_FAMILY: (
+        "MCP API keys (omi_mcp_...) only authenticate the MCP endpoints under /v1/mcp/ "
+        "(for example GET /v1/mcp/memories, GET /v1/mcp/conversations) and the MCP server at /v1/mcp/sse"
+    ),
+    DEV_FAMILY: (
+        "Developer API keys (omi_dev_...) only authenticate the Developer API under /v1/dev/ "
+        "(for example GET /v1/dev/user/memories)"
+    ),
+}
+
+_ENDPOINT_EXPECTATION = {
+    FIREBASE_FAMILY: "This endpoint requires a Firebase ID token from a signed-in Omi app",
+    MCP_FAMILY: "This endpoint requires an MCP API key (Settings -> Developer -> MCP -> Create Key)",
+    DEV_FAMILY: "This endpoint requires a Developer API key (Settings -> Developer -> Create Key)",
+}
+
+
+def api_key_family(token: Optional[str]) -> str:
+    """Family of the presented credential, inferred from its prefix."""
+    for prefix, family in _FAMILY_BY_PREFIX.items():
+        if token and token.startswith(prefix):
+            return family
+    return FIREBASE_FAMILY
+
+
+def wrong_key_family_detail(token: Optional[str], expected_family: str) -> Optional[str]:
+    """401 detail explaining the mismatch, or None when the key belongs to `expected_family`."""
+    presented = api_key_family(token)
+    if presented == expected_family or presented == FIREBASE_FAMILY:
+        return None
+    return f"{_KEY_USAGE[presented]}. {_ENDPOINT_EXPECTATION[expected_family]}."

--- a/backend/utils/other/endpoints.py
+++ b/backend/utils/other/endpoints.py
@@ -13,6 +13,7 @@ import redis as redis_pkg
 
 from database.redis_db import check_rate_limit, try_acquire_listen_lock
 from database.users import record_client_device, record_user_platform
+from utils.api_key_families import FIREBASE_FAMILY, wrong_key_family_detail
 from utils.client_device import resolve_client_device
 from utils.byok import extract_byok_from_websocket, set_byok_keys, validate_byok_request, validate_byok_websocket
 from utils.executors import critical_executor, run_blocking
@@ -76,8 +77,12 @@ def get_current_user_uid(
     elif len(str(authorization).split(' ')) != 2:
         raise HTTPException(status_code=401, detail="Invalid authorization token")
 
+    token = authorization.split(' ')[1]
+    key_family_mismatch = wrong_key_family_detail(token, FIREBASE_FAMILY)
+    if key_family_mismatch:
+        raise HTTPException(status_code=401, detail=key_family_mismatch)
+
     try:
-        token = authorization.split(' ')[1]
         uid = verify_token(token)
     except InvalidIdTokenError as e:
         logger.error(e)
@@ -129,8 +134,12 @@ def get_current_user_uid_no_byok_validation(
     elif len(str(authorization).split(' ')) != 2:
         raise HTTPException(status_code=401, detail="Invalid authorization token")
 
+    token = authorization.split(' ')[1]
+    key_family_mismatch = wrong_key_family_detail(token, FIREBASE_FAMILY)
+    if key_family_mismatch:
+        raise HTTPException(status_code=401, detail=key_family_mismatch)
+
     try:
-        token = authorization.split(' ')[1]
         uid = verify_token(token)
     except InvalidIdTokenError as e:
         logger.error(e)

--- a/docs/doc/developer/mcp/troubleshooting.mdx
+++ b/docs/doc/developer/mcp/troubleshooting.mdx
@@ -13,6 +13,21 @@ description: "Debug and fix common MCP connection issues"
     - Generate a new key in the Omi app: **Settings → Developer → MCP**
     - Ensure the key hasn't been revoked
   </Accordion>
+  <Accordion title="Calling the REST API with an MCP key (404 or 401)" icon="code">
+    An `omi_mcp_...` key authenticates the MCP endpoints only. Two things follow:
+
+    - **Use the `/v1/mcp/` REST endpoints** — e.g. `GET /v1/mcp/memories`, `GET /v1/mcp/memories/search?query=...`, `GET /v1/mcp/conversations`, `GET /v1/mcp/action-items`. They accept the same key as the MCP server and return plain JSON.
+    - **`/v1/memories` and `/v2/memories` do not exist.** Requests to them return `404 Not Found` regardless of the key.
+
+    ```bash
+    curl -H "Authorization: Bearer omi_mcp_YOUR_KEY" \
+      "https://api.omi.me/v1/mcp/memories?limit=5"
+    ```
+
+    To call the [Developer API](/doc/developer/api/overview) (`/v1/dev/...`) instead, create a separate
+    key in **Settings → Developer → Create Key**; it starts with `omi_dev_`. Using either key on the
+    other's endpoints returns a `401` that names the endpoints that key does authenticate.
+  </Accordion>
   <Accordion title="No tools showing up" icon="toolbox">
     - Send an `initialize` request first — tools are only available after initialization
     - Check that your client supports the Streamable HTTP transport (2025-03-26 spec)


### PR DESCRIPTION
## What

An Omi API key presented to the wrong endpoint family now gets a 401 that names **the endpoints that key does authenticate** and **the credential the endpoint wants**, instead of a generic rejection. Adds the missing MCP-vs-REST section to the MCP troubleshooting docs.

## Why

From #7506, a user building an Obsidian integration:

> | `GET https://api.omi.me/v1/memories` | **404 Not Found** |
> | `GET https://api.omi.me/v1/conversations` | **401 Unauthorized** `{"detail":"Invalid authorization token"}` |
> All requests use `Authorization: Bearer omi_mcp_...` with a valid MCP key […]
> 2. Are MCP keys (`omi_mcp_...`) valid for direct REST API calls, or is a separate key type required?

The key was valid — just scoped to the wrong endpoints. `omi_mcp_` keys authenticate `/v1/mcp/*`, `omi_dev_` keys authenticate `/v1/dev/*`, everything else needs a Firebase ID token. All three boundaries collapsed a *mismatch* into the same message as a *revoked key*, so there was nothing in the response to act on. The reporter also notes the community plugin `atomicpapa/obsidian-omi-sync` fails the same way, so this misdirects everyone building on the REST API with an MCP key.

## How

`backend/utils/api_key_families.py` classifies the presented credential by prefix; the three HTTP auth boundaries (`get_uid_from_mcp_api_key`, `get_mcp_api_key_auth`, `get_api_key_auth`, and `get_current_user_uid` / `…_no_byok_validation`) consult it before verifying. A wrong-family key is rejected before its Firestore lookup; unknown/garbage tokens keep the existing generic message, so the change adds information without weakening auth. Docs get a troubleshooting entry covering the exact 404/401 pair reported.

## Verified

Backend served locally (`uvicorn main:app`, offline providers), replaying the issue's requests:

```
$ curl -H "Authorization: Bearer omi_mcp_fakekey123" localhost:8099/v1/conversations
401 {"detail":"MCP API keys (omi_mcp_...) only authenticate the MCP endpoints under /v1/mcp/
     (for example GET /v1/mcp/memories, GET /v1/mcp/conversations) and the MCP server at
     /v1/mcp/sse. This endpoint requires a Firebase ID token from a signed-in Omi app."}

$ curl -H "Authorization: Bearer omi_mcp_fakekey123" localhost:8099/v1/dev/user/memories
401 {"detail":"MCP API keys (omi_mcp_...) … This endpoint requires a Developer API key
     (Settings -> Developer -> Create Key)."}

$ curl -H "Authorization: Bearer omi_dev_fakekey123" localhost:8099/v1/mcp/memories
401 {"detail":"Developer API keys (omi_dev_...) only authenticate the Developer API under
     /v1/dev/ … This endpoint requires an MCP API key (Settings -> Developer -> MCP -> Create Key)."}

$ curl -H "Authorization: Bearer not-a-real-token" localhost:8099/v1/conversations
401 {"detail":"Invalid authorization token"}          # unchanged

$ curl -H "Authorization: Bearer ${ADMIN_KEY}user123" localhost:8099/v1/conversations
200 []                                                # valid auth unaffected
```

- `tests/unit/test_api_key_family_errors.py` — 4 new regression tests (each mismatch direction, matching family still reaches its own key lookup, MCP key on a Firebase route). 4 passed.
- Full backend suite: `bash test.sh` → exit 0, 581 test files, 0 failures.
- `make preflight` → 13/13 checks pass (import purity, module isolation, async blockers, route-policy baseline).

## Not in scope

`/v1/memories` and `/v2/memories` genuinely do not exist (memories are `/v3/memories`, `/v1/dev/user/memories`, `/v1/mcp/memories`) — the 404s are correct, and the docs entry now says so rather than resurrecting dead routes.

Auto-generated from issue feedback by the mini issues-improver. Review before merge.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9636?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

