### PR TITLE
fix(desktop-backend): stop corrupting multi-byte characters in streamed chat replies

### DIFF
--- a/desktop/macos/Backend-Rust/src/routes/chat_completions.rs
+++ b/desktop/macos/Backend-Rust/src/routes/chat_completions.rs
@@ -647,6 +647,22 @@ fn sse_line(data: &serde_json::Value) -> Bytes {
     Bytes::from(format!("data: {}\n\n", json_str))
 }
 
+/// Pull every complete SSE event block out of the raw byte buffer, leaving any
+/// trailing partial event behind.
+///
+/// The buffer must stay bytes: network chunks split at arbitrary offsets, so
+/// decoding a chunk before it is framed destroys any multi-byte character that
+/// straddles the boundary. Event blocks always end on the ASCII "\n\n", so a
+/// complete block is safe to decode.
+fn drain_sse_events(buffer: &mut Vec<u8>) -> Vec<String> {
+    let mut events = Vec::new();
+    while let Some(event_end) = buffer.windows(2).position(|w| w == b"\n\n") {
+        events.push(String::from_utf8_lossy(&buffer[..event_end]).into_owned());
+        buffer.drain(..event_end + 2);
+    }
+    events
+}
+
 fn make_chunk(
     id: &str,
     created: i64,
@@ -970,7 +986,7 @@ async fn handle_streaming(
         let mut final_usage: Option<AnthropicUsage> = None;
         let mut initial_usage: Option<AnthropicUsage> = None;
         let mut sent_role = false;
-        let mut buffer = String::new();
+        let mut buffer: Vec<u8> = Vec::new();
 
         // Collect raw bytes and split into SSE events
         let mut byte_stream = std::pin::pin!(byte_stream);
@@ -983,13 +999,10 @@ async fn handle_streaming(
                 }
             };
 
-            buffer.push_str(&String::from_utf8_lossy(&chunk));
+            buffer.extend_from_slice(&chunk);
 
             // Parse SSE events from buffer
-            while let Some(event_end) = buffer.find("\n\n") {
-                let event_block = buffer[..event_end].to_string();
-                buffer = buffer[event_end + 2..].to_string();
-
+            for event_block in drain_sse_events(&mut buffer) {
                 // Extract data line
                 let data_line = event_block
                     .lines()
@@ -2346,6 +2359,35 @@ mod tests {
         let openai = translate_response(&resp, "omi-sonnet");
         assert!(openai.choices[0].message.content.is_none());
         assert!(openai.choices[0].message.tool_calls.is_some());
+    }
+
+    #[test]
+    fn test_drain_sse_events_splits_on_blank_line() {
+        let mut buffer = b"event: a\ndata: {\"x\":1}\n\ndata: {\"y\":2}\n\ndata: par".to_vec();
+        let events = drain_sse_events(&mut buffer);
+
+        assert_eq!(events.len(), 2);
+        assert!(events[0].contains("\"x\":1"));
+        assert!(events[1].contains("\"y\":2"));
+        assert_eq!(buffer, b"data: par");
+    }
+
+    #[test]
+    fn test_drain_sse_events_preserves_char_split_across_chunks() {
+        // "—" (U+2014) is 3 bytes; a network chunk can land in the middle of it.
+        let event = "data: {\"text\":\"a—b\"}\n\n".as_bytes().to_vec();
+        let split = 17; // inside the em dash's 3 bytes (16..19)
+        let mut buffer = Vec::new();
+
+        buffer.extend_from_slice(&event[..split]);
+        assert!(drain_sse_events(&mut buffer).is_empty());
+
+        buffer.extend_from_slice(&event[split..]);
+        let events = drain_sse_events(&mut buffer);
+
+        assert_eq!(events.len(), 1);
+        assert!(events[0].contains("a—b"), "got {}", events[0]);
+        assert!(!events[0].contains('\u{fffd}'));
     }
 
     #[test]


### PR DESCRIPTION
## Bug

Every streamed chat reply from the desktop backend can silently corrupt multi-byte characters — em dashes, curly quotes, ellipses, emoji, and **all** CJK/Cyrillic/accented text — replacing them with `` (U+FFFD).

## Root cause

`chat_completions.rs` buffered the upstream Anthropic SSE stream as a `String`:

```rust
buffer.push_str(&String::from_utf8_lossy(&chunk));
```

`chunk` is a `Bytes` off `bytes_stream()` — an arbitrary network read boundary, **not** a char boundary. When a multi-byte character straddles two chunks, lossy-decoding *each chunk* before appending destroys it irrecoverably: the truncated prefix (`E2 80`) becomes U+FFFD, and the orphaned continuation byte (`94`) becomes another. The character can never be reassembled.

The corruption is silent because SSE/JSON syntax is all-ASCII: the event still parses, and the mangled text flows straight through `TextDelta` (reply text) and `InputJsonDelta` (tool-call arguments) to the client.

Reproduced against the old code path — `data: {"text":"a—b"}` split at byte 17 (inside the em dash) decodes to `data: {"text":"a���b"}`.

This is the only path that decodes rather than passes bytes through; the Gemini streams in `proxy.rs` use `Body::from_stream` and are unaffected.

## Fix

Buffer **raw bytes** and only decode complete SSE event blocks. Event blocks always end on the ASCII `\n\n`, so a complete block is always valid UTF-8. Framing is extracted into `drain_sse_events()`, which is now unit-tested.

## Verification

- New test `test_drain_sse_events_preserves_char_split_across_chunks` feeds an em dash split mid-character across two chunks and asserts no U+FFFD — **fails on the old code, passes on the new**.
- New test `test_drain_sse_events_splits_on_blank_line` covers framing and partial-event retention.
- `cargo test` — 350 passed, 0 failed. `cargo clippy -- -D warnings` (CI's exact invocation) clean. `cargo fmt --check` clean.

## Scope / risk

One file, +48/-6, no behavior change beyond the framing layer. Note that merging this deploys to **dev** only (`desktop_backend_auto_dev.yml`); prod promotion remains the deliberate manual `desktop_promote_prod.yml` step.

Follow-up spotted but deliberately left out of scope: `chat_completions.rs:897` and `:945` truncate an upstream error body with `&body[..body.len().min(500)]`, which panics on a non-char-boundary (contained by `CatchPanicLayer`, so it degrades to a 500). `tts.rs:85` and `realtime.rs:209` already use the correct `.chars().take(500)` idiom.

🤖 automated by hourly watchdog

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9638?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

