### PR TITLE
fix(chat-file): delete OpenAI files even when Firestore docs are malformed

### DIFF
--- a/backend/tests/unit/test_chat_file_skip_malformed.py
+++ b/backend/tests/unit/test_chat_file_skip_malformed.py
@@ -44,3 +44,48 @@ def test_safe_file_chats_skips_malformed_record():
 
 def test_safe_file_chats_empty():
     assert cf._safe_file_chats([]) == []
+
+
+def test_openai_file_ids_includes_malformed_docs():
+    # A doc that fails FileChat validation can still carry openai_file_id; cleanup must see it.
+    records = [
+        _valid_file_dict(),
+        {'id': 'broken', 'openai_file_id': 'oai-orphan'},
+        {'id': 'no-provider'},
+        {**_valid_file_dict(), 'id': 'f3', 'openai_file_id': 'oai-3'},
+    ]
+    assert cf._openai_file_ids(records) == ['oai-1', 'oai-orphan', 'oai-3']
+
+
+def test_cleanup_deletes_openai_file_even_when_doc_is_malformed(monkeypatch):
+    deleted: list[str] = []
+    firestore_deleted: list = []
+
+    monkeypatch.setattr(
+        cf.chat_db,
+        'get_chat_files',
+        lambda _uid: [
+            _valid_file_dict(),
+            {'id': 'broken', 'openai_file_id': 'oai-orphan'},
+        ],
+    )
+    monkeypatch.setattr(
+        cf.chat_db,
+        'delete_multi_files',
+        lambda _uid, files: firestore_deleted.extend(files),
+    )
+    monkeypatch.setattr(
+        cf.openai.files,
+        'delete',
+        lambda file_id, timeout=30.0: deleted.append(file_id),
+    )
+
+    # Bypass __init__ (Firestore session load); cleanup only needs uid + optional ids.
+    tool = cf.FileChatTool.__new__(cf.FileChatTool)
+    tool.uid = 'u1'
+    tool.thread_id = None
+    tool.assistant_id = None
+    tool.cleanup()
+
+    assert deleted == ['oai-1', 'oai-orphan']
+    assert [f.get('id') for f in firestore_deleted] == ['f1', 'broken']

--- a/backend/tests/unit/test_chat_file_skip_malformed.py
+++ b/backend/tests/unit/test_chat_file_skip_malformed.py
@@ -55,37 +55,3 @@ def test_openai_file_ids_includes_malformed_docs():
         {**_valid_file_dict(), 'id': 'f3', 'openai_file_id': 'oai-3'},
     ]
     assert cf._openai_file_ids(records) == ['oai-1', 'oai-orphan', 'oai-3']
-
-
-def test_cleanup_deletes_openai_file_even_when_doc_is_malformed(monkeypatch):
-    deleted: list[str] = []
-    firestore_deleted: list = []
-
-    monkeypatch.setattr(
-        cf.chat_db,
-        'get_chat_files',
-        lambda _uid: [
-            _valid_file_dict(),
-            {'id': 'broken', 'openai_file_id': 'oai-orphan'},
-        ],
-    )
-    monkeypatch.setattr(
-        cf.chat_db,
-        'delete_multi_files',
-        lambda _uid, files: firestore_deleted.extend(files),
-    )
-    monkeypatch.setattr(
-        cf.openai.files,
-        'delete',
-        lambda file_id, timeout=30.0: deleted.append(file_id),
-    )
-
-    # Bypass __init__ (Firestore session load); cleanup only needs uid + optional ids.
-    tool = cf.FileChatTool.__new__(cf.FileChatTool)
-    tool.uid = 'u1'
-    tool.thread_id = None
-    tool.assistant_id = None
-    tool.cleanup()
-
-    assert deleted == ['oai-1', 'oai-orphan']
-    assert [f.get('id') for f in firestore_deleted] == ['f1', 'broken']

--- a/backend/utils/other/chat_file.py
+++ b/backend/utils/other/chat_file.py
@@ -43,6 +43,20 @@ def _safe_file_chats(files_data: List[Dict[str, Any]]) -> List[FileChat]:
     return files
 
 
+def _openai_file_ids(files_data: List[Dict[str, Any]]) -> List[str]:
+    """Collect openai_file_id values from raw file docs without Pydantic validation.
+
+    Cleanup must delete provider objects even when a legacy doc fails FileChat validation
+    (e.g. missing mime_type/created_at) — otherwise Firestore wipe orphans the OpenAI file.
+    """
+    ids: List[str] = []
+    for f in files_data:
+        openai_file_id = f.get('openai_file_id')
+        if isinstance(openai_file_id, str) and openai_file_id:
+            ids.append(openai_file_id)
+    return ids
+
+
 _async_openai: AsyncOpenAI | None = None
 
 
@@ -401,17 +415,15 @@ class FileChatTool:
         """Cleanup chat session files, thread, and assistant"""
         logger.info("start cleanup thread chat with file")
         files = chat_db.get_chat_files(self.uid)
-        # delete file in db
         if files:
-            chat_db.delete_multi_files(self.uid, files)
-
-            file_objs = _safe_file_chats(files)
-            # clear file in openai
-            for file in file_objs:
+            # Delete OpenAI objects from raw docs first — do not gate on FileChat validation,
+            # or a malformed doc with openai_file_id leaks after Firestore delete (#9608 follow-up).
+            for openai_file_id in _openai_file_ids(files):
                 try:
-                    openai.files.delete(file.openai_file_id, timeout=30.0)
+                    openai.files.delete(openai_file_id, timeout=30.0)
                 except Exception as e:
-                    logger.error(f"Failed to delete file {file.openai_file_id}: {e}")
+                    logger.error(f"Failed to delete file {openai_file_id}: {e}")
+            chat_db.delete_multi_files(self.uid, files)
 
         if self.thread_id:
             try:


### PR DESCRIPTION
## Summary
- Follow-up to #9608: `FileChatTool.cleanup()` no longer gates OpenAI deletion on `_safe_file_chats` / `FileChat` validation.
- Collect `openai_file_id` from raw Firestore docs and delete those provider objects before wiping Firestore, so a legacy/partial doc cannot orphan OpenAI storage.
- Regression coverage via `_openai_file_ids` (keeps the shared boundary under the fast-unit CPU budget).

## Root cause / durable guard
- **Root cause:** #9608 correctly skipped malformed docs for chat/answer paths, but cleanup reused that helper for OpenAI deletion. Docs with `openai_file_id` that failed other required fields were deleted from Firestore and left at OpenAI.
- **Durable guard:** `_openai_file_ids` reads provider ids without Pydantic; cleanup uses it exclusively for OpenAI deletes.

## Product invariants affected
none

## Test plan
- [x] `backend/tests/unit/test_chat_file_skip_malformed.py` (incl. `_openai_file_ids` malformed-doc case)
- [x] Local pre-push / PR preflight passed
- [ ] Confirm CI backend unit selection runs the same test file


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9639?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

