### PR TITLE
fix(desktop): unify PTT listening chrome, drop agent voice follow-up

### DIFF
--- a/desktop/macos/Desktop/Sources/FloatingControlBar/AIResponseView.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/AIResponseView.swift
@@ -15,8 +15,6 @@ struct AIResponseView: View {
 
     let userInput: String
     let chatHistory: [FloatingChatExchange]
-    let isVoiceFollowUp: Bool
-    let voiceFollowUpTranscript: String
     var canClearVisibleConversation: Bool = false
     var showsHeader: Bool = true
 
@@ -54,12 +52,6 @@ struct AIResponseView: View {
 
                 // Current response
                 currentContentView
-
-                // Voice follow-up indicator (shown inline when PTT is active during conversation)
-                if isVoiceFollowUp {
-                    voiceFollowUpView
-                        .id("voiceFollowUp")
-                }
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
 
@@ -69,12 +61,12 @@ struct AIResponseView: View {
                     .accessibilityLabel(shareFeedbackMessage)
             }
 
-            if !isLoading && !isVoiceFollowUp {
+            if !isLoading {
                 followUpInputView
             }
         }
         .padding(.horizontal, OmiSpacing.lg)
-        .padding(.top, state.usesNotchIsland ? 0 : OmiSpacing.lg)
+        .padding(.top, 0)
         .padding(.bottom, OmiSpacing.lg)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .omiAnimation(.spring(response: 0.28, dampingFraction: 0.85), value: showShareFeedback)
@@ -107,8 +99,6 @@ struct AIResponseView: View {
                 currentMessage?.id ?? "",
                 currentMessage?.text ?? "",
                 contentBlocksToken(currentMessage?.contentBlocks ?? []),
-                String(isVoiceFollowUp),
-                voiceFollowUpTranscript,
             ].joined(separator: "\u{1F}")
         )
     }
@@ -439,37 +429,6 @@ struct AIResponseView: View {
                     .padding(.horizontal, OmiSpacing.xxs)
             }
         }
-    }
-
-    // MARK: - Voice Follow-Up
-
-    private var voiceFollowUpView: some View {
-        HStack(spacing: OmiSpacing.sm) {
-            // Playful realtime mic waveform (replaces the old pulsing red dot)
-            VoiceWaveformBars(isActive: isVoiceFollowUp)
-
-            Image(systemName: "mic.fill")
-                .scaledFont(size: OmiType.body, weight: .semibold)
-                .foregroundColor(.white)
-
-            if !voiceFollowUpTranscript.isEmpty {
-                Text(voiceFollowUpTranscript)
-                    .scaledFont(size: OmiType.body)
-                    .foregroundColor(.white.opacity(0.8))
-                    .lineLimit(2)
-                    .truncationMode(.head)
-            } else {
-                Text("Listening...")
-                    .scaledFont(size: OmiType.body)
-                    .foregroundColor(.white.opacity(0.5))
-            }
-
-            Spacer()
-        }
-        .padding(.horizontal, OmiSpacing.sm)
-        .padding(.vertical, OmiSpacing.sm)
-        .background(OmiColors.accent.opacity(0.12))
-        .cornerRadius(OmiChrome.elementRadius)
     }
 
     // MARK: - Follow-Up Input

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/AgentPill.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/AgentPill.swift
@@ -151,10 +151,6 @@ final class AgentPillsManager: ObservableObject {
     private var pendingFollowUpsByPill: [UUID: [PendingAgentFollowUp]] = [:]
     private var producingJournalSurfaceByPill: [UUID: AgentSurfaceReference] = [:]
 
-    /// Which pill (if any) is currently capturing a voice follow-up — drives the
-    /// pill popover's mic button state.
-    @Published var recordingPillID: UUID?
-
     private let viewedFinishedTTL: TimeInterval = 10 * 60
 
     private var projectionSyncCancellable: AnyCancellable?
@@ -197,10 +193,6 @@ final class AgentPillsManager: ObservableObject {
         projectionRefreshTask = nil
         for task in runTasksByPill.values { task.cancel() }
         for item in viewedExpirationWorkItemsByPill.values { item.cancel() }
-        if let recordingPillID {
-            PushToTalkManager.shared.cancelPillFollowUp(for: recordingPillID)
-        }
-        recordingPillID = nil
         runTasksByPill.removeAll()
         runAttemptGenerationByPill.removeAll()
         viewedExpirationWorkItemsByPill.removeAll()
@@ -579,24 +571,6 @@ final class AgentPillsManager: ObservableObject {
         return pill
     }
 
-    // MARK: - Voice follow-up (continue THIS agent's session)
-
-    /// Tap the pill's mic button: start recording if idle, or stop + transcribe +
-    /// send if this pill is already recording.
-    func toggleFollowUpVoice(for pill: AgentPill) {
-        if recordingPillID == pill.id {
-            log("AgentPills: voice follow-up STOP tapped for \(pill.title)")
-            recordingPillID = nil
-            PushToTalkManager.shared.endPillFollowUp()
-        } else if recordingPillID == nil {
-            log("AgentPills: voice follow-up START tapped for \(pill.title)")
-            recordingPillID = pill.id
-            // Routes through the realtime omni STT (hub pipeline); the transcript comes
-            // back into continueAgent(from:text:) for THIS pill's session.
-            PushToTalkManager.shared.startPillFollowUp(for: pill)
-        }
-    }
-
     /// Send a follow-up to the same canonical background-agent session.
     func continueAgent(
         from pill: AgentPill,
@@ -807,10 +781,6 @@ final class AgentPillsManager: ObservableObject {
     func stop(pillID: UUID) {
         guard let pill = pills.first(where: { $0.id == pillID }), !pill.status.isFinished else { return }
         log("AgentPills: stopping pill \(pill.title)")
-        if recordingPillID == pillID {
-            recordingPillID = nil
-            PushToTalkManager.shared.cancelPillFollowUp(for: pillID)
-        }
         let runId = pill.canonicalRunId
         runTasksByPill[pillID]?.cancel()
         runTasksByPill[pillID] = nil
@@ -967,10 +937,6 @@ final class AgentPillsManager: ObservableObject {
     }
 
     private func cleanup(pillID: UUID) {
-        if recordingPillID == pillID {
-            recordingPillID = nil
-            PushToTalkManager.shared.cancelPillFollowUp(for: pillID)
-        }
         let pill = pills.first(where: { $0.id == pillID })
         let shouldCancelRun = pill?.status.isFinished == false
         let runId = pill?.canonicalRunId
@@ -990,10 +956,6 @@ final class AgentPillsManager: ObservableObject {
     }
 
     private func removeRenderedProjection(pillID: UUID) {
-        if recordingPillID == pillID {
-            recordingPillID = nil
-            PushToTalkManager.shared.cancelPillFollowUp(for: pillID)
-        }
         runTasksByPill[pillID]?.cancel()
         runTasksByPill[pillID] = nil
         runAttemptGenerationByPill[pillID] = nil
@@ -1444,7 +1406,7 @@ final class AgentPillsManager: ObservableObject {
     }
 
     private func hasLocalTransientState(pillID: UUID) -> Bool {
-        recordingPillID == pillID || pendingFollowUpsByPill[pillID]?.isEmpty == false
+        pendingFollowUpsByPill[pillID]?.isEmpty == false
     }
 
     func snapshotJSON(limit: Int = 20) -> String {

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarState.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarState.swift
@@ -224,7 +224,6 @@ class FloatingControlBarState: NSObject, ObservableObject {
             let shouldExpandForVoice = barState.isVoiceListening
 
             if shouldExpandForVoice != wasExpandedForVoice,
-               !barState.isVoiceFollowUp,
                !barState.showingAIConversation,
                UserDefaults.standard.bool(forKey: .hasCompletedOnboarding)
             {
@@ -321,12 +320,6 @@ class FloatingControlBarState: NSObject, ObservableObject {
     /// exposes a real camera housing safe area. External displays keep old pill UI.
     @Published var usesNotchIsland: Bool = false
     @Published var notchRevealProgress: CGFloat = 1
-
-    // Voice follow-up state (PTT while AI conversation is active)
-    var isVoiceFollowUp: Bool { voiceProjection.isFollowUp && isVoiceListening }
-    var voiceFollowUpTranscript: String {
-        isVoiceFollowUp ? voiceProjection.transcript : ""
-    }
 
     private func applyVoiceProjection(_ projection: VoiceTurnUIProjection) {
         voiceProjection = projection
@@ -637,10 +630,7 @@ class FloatingControlBarState: NSObject, ObservableObject {
         // are cleared, and late-arriving chunks update a surface nobody sees.
         // (Cubic P2 — presentation/process desync.)
         FloatingControlBarManager.shared.cancelChat()
-        // Call cancelListening() directly instead of gating on isVoiceFollowUp:
-        // the derived UI flag is not the authoritative source of microphone
-        // state, and cancelListening() is already guarded by state != .idle.
-        // (Cubic P2 — stale PTT capture after surface hide.)
+        // cancelListening() is already guarded by state != .idle.
         PushToTalkManager.shared.cancelListening()
         activeAgentChatPillID = nil
         conversationSurface = .closed

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift
@@ -153,15 +153,20 @@ struct FloatingControlBarView: View {
     }
 
     private var showingNotchWaveform: Bool {
-        state.isVoiceListening && !state.isVoiceFollowUp && !state.showingAIConversation
+        state.isVoiceListening && state.pttHintText.isEmpty
     }
 
     /// The notch "thinking" state: a PTT query is committed and being processed,
     /// with no live listening or open conversation surface. Shows the spinning
-    /// Omi mark in the left notch lobe.
+    /// Omi mark in the left notch lobe (chat already has its own loading UI).
     private var showingNotchThinking: Bool {
         (state.isThinking || state.isVoiceResponseWaiting)
-            && !state.showingAIConversation && !state.isVoiceListening
+            && !state.showingAIConversation
+            && !state.isVoiceListening
+    }
+
+    private var showingPTTStatusBanner: Bool {
+        !state.pttHintText.isEmpty
     }
 
     private var shouldUseOmiChatOverlayHitTarget: Bool {
@@ -170,13 +175,21 @@ struct FloatingControlBarView: View {
 
     private var unifiedFloatingSurface: some View {
         VStack(spacing: 0) {
-            if state.usesNotchIsland {
+            if state.usesNotchIsland || state.showingAIConversation {
                 notchChrome
             } else {
                 // No camera housing to blend into — the pill surface starts
                 // with a slim top inset instead of the notch chrome band.
                 Color.clear
                     .frame(height: FloatingControlBarWindow.pillSurfaceTopPadding)
+            }
+
+            if showingPTTStatusBanner {
+                pttStatusBanner
+                    .frame(height: FloatingControlBarWindow.pttHintRowHeight)
+                    .padding(.horizontal, OmiSpacing.md)
+                    .padding(.bottom, OmiSpacing.xs)
+                    .transition(.opacity)
             }
 
             if shouldShowNotchHoverMenu {
@@ -199,14 +212,6 @@ struct FloatingControlBarView: View {
                 } else {
                     pillAgentListMenu
                 }
-            }
-
-            if state.usesNotchIsland && !state.pttHintText.isEmpty && !state.showingAIConversation {
-                notchPttHintRow
-                    .frame(height: FloatingControlBarWindow.pttHintRowHeight)
-                    .padding(.horizontal, OmiSpacing.md)
-                    .padding(.bottom, OmiSpacing.xs)
-                    .transition(.opacity)
             }
 
             if state.showingAIConversation {
@@ -363,7 +368,7 @@ struct FloatingControlBarView: View {
         let hasExpandedSurface = state.showingAIConversation
             || state.currentNotification != nil
             || shouldShowNotchHoverMenu
-            || !state.pttHintText.isEmpty
+            || showingPTTStatusBanner
         guard hasExpandedSurface else {
             return CGSize(width: notchChromeWidth, height: notchChromeHeight)
         }
@@ -493,22 +498,6 @@ struct FloatingControlBarView: View {
         .accessibilityHint("Open settings")
     }
 
-    /// Transient too-short PTT hint shown below the notch chrome (notch layout has
-    /// no inline text spot, unlike the pill's `voiceListeningView`). White/neutral,
-    /// no toast; cleared on the same ~2s lifecycle as `pttHintText`.
-    private var notchPttHintRow: some View {
-        HStack(spacing: OmiSpacing.xs) {
-            Image(systemName: "mic.fill")
-                .scaledFont(size: OmiType.caption, weight: .semibold)
-                .foregroundColor(.white.opacity(0.9))
-            Text(state.pttHintText)
-                .scaledFont(size: 12, weight: .medium)
-                .foregroundColor(.white)
-                .lineLimit(1)
-        }
-        .frame(maxWidth: .infinity)
-    }
-
     private var notchOmiChatRow: some View {
         Button {
             openOmiChatFromNotchRow()
@@ -597,14 +586,38 @@ struct FloatingControlBarView: View {
         FloatingControlBarWindow.notchChromeHeight(for: window?.screen ?? NSScreen.main)
     }
 
+    /// Full-width readable status strip under chrome / pill for too-short PTT
+    /// taps and mic errors. Keeps long copy out of the narrow logo/mic slot.
+    private var pttStatusBanner: some View {
+        HStack(spacing: OmiSpacing.xs) {
+            Image(systemName: "mic.fill")
+                .scaledFont(size: OmiType.caption, weight: .semibold)
+                .foregroundColor(.white.opacity(0.9))
+            Text(state.pttHintText)
+                .scaledFont(size: 12, weight: .medium)
+                .foregroundColor(.white)
+                .lineLimit(1)
+            Spacer(minLength: 0)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
     /// Collapsed pill / hover bar chrome. Conversations, notifications-with-
     /// chat, and the agent list all render on `unifiedFloatingSurface` — this
     /// chrome only ever shows the idle pill, hover hints, and voice states.
     private var barChrome: some View {
         VStack(spacing: 0) {
             controlBarView
+
+            if showingPTTStatusBanner {
+                pttStatusBanner
+                    .frame(height: FloatingControlBarWindow.pttHintRowHeight)
+                    .padding(.horizontal, 10)
+                    .padding(.bottom, OmiSpacing.xs)
+                    .transition(.opacity)
+            }
         }
-        .frame(maxWidth: barNeedsFullWidth ? .infinity : nil, alignment: .top)
+        .frame(maxWidth: barNeedsFullWidth || showingPTTStatusBanner ? .infinity : nil, alignment: .top)
         .overlay(alignment: .topTrailing) {
             if isHovering && !state.isVoiceListening {
                 Button {
@@ -1117,14 +1130,19 @@ struct FloatingControlBarView: View {
         let allowsHoverExpansion = isHovering && !state.isVoiceResponseGlowActive
         return Group {
             if !state.pttHintText.isEmpty {
-                // Too-short PTT hint takes precedence over every other bar state
-                // (incl. follow-up turns) for its brief window.
-                voiceListeningView
-                    .padding(.horizontal, 10)
-                    .padding(.vertical, 5)
-                    .frame(height: 42)
-                    .transition(.opacity)
-            } else if state.isVoiceListening && !state.isVoiceFollowUp {
+                // Too-short / error copy lives in `pttStatusBanner` below — keep
+                // the pill chrome as the idle strip so we don't stack two mics.
+                PillStatusObservingView(manager: agentPills) { pills in
+                    let agentGroup = state.isVoiceResponseGlowActive
+                        ? nil
+                        : NotchAgentStatusGroup.aggregate(for: pills)
+                    compactCircleView(agentGroup: agentGroup)
+                        .modifier(AgentStatusGlow(group: agentGroup))
+                }
+                .frame(height: 14)
+                .padding(.vertical, 5)
+                .transition(.opacity)
+            } else if state.isVoiceListening {
                 voiceListeningView
                     .padding(.horizontal, 10)
                     .padding(.vertical, 5)
@@ -1336,30 +1354,22 @@ struct FloatingControlBarView: View {
 
     private var voiceListeningView: some View {
         HStack(spacing: 7) {
-            if !state.pttHintText.isEmpty {
-                // Too-short PTT tap: inline hint instead of the live waveform.
-                Image(systemName: "mic.fill")
-                    .scaledFont(size: 12, weight: .semibold)
-                    .foregroundColor(.white)
-                Text(state.pttHintText)
-                    .scaledFont(size: OmiType.caption, weight: .medium)
-                    .foregroundColor(.white)
-            } else {
+            if state.pttHintText.isEmpty {
                 // Playful realtime mic waveform (replaces the old pulsing red dot)
                 VoiceWaveformBars(isActive: state.isVoiceListening)
+            }
 
-                Image(systemName: "mic.fill")
-                    .scaledFont(size: 12, weight: .semibold)
-                    .foregroundColor(.white)
+            Image(systemName: "mic.fill")
+                .scaledFont(size: 12, weight: .semibold)
+                .foregroundColor(.white)
 
-                if state.isVoiceLocked {
-                    Image(systemName: "lock.fill")
-                        .scaledFont(size: OmiType.micro, weight: .bold)
-                        .foregroundColor(.orange)
-                        .frame(width: 18, height: 18)
-                        .background(Color.orange.opacity(0.2))
-                        .cornerRadius(4)
-                }
+            if state.isVoiceLocked && state.pttHintText.isEmpty {
+                Image(systemName: "lock.fill")
+                    .scaledFont(size: OmiType.micro, weight: .bold)
+                    .foregroundColor(.orange)
+                    .frame(width: 18, height: 18)
+                    .background(Color.orange.opacity(0.2))
+                    .cornerRadius(4)
             }
         }
     }
@@ -1409,10 +1419,13 @@ struct FloatingControlBarView: View {
         let height = lastInputEditorHeight > 0
             ? lastInputEditorHeight
             : FloatingControlBarWindow.notchInputPanelMinimumContentHeight
-        let topBand = state.usesNotchIsland
+        let topBand = (state.usesNotchIsland || state.showingAIConversation)
             ? notchChromeHeight
             : FloatingControlBarWindow.pillSurfaceTopPadding
-        let baseHeight = topBand + height + FloatingControlBarWindow.notchInputPanelVerticalPadding
+        let statusBanner = showingPTTStatusBanner
+            ? FloatingControlBarWindow.pttStatusBannerBudget
+            : 0
+        let baseHeight = topBand + statusBanner + height + FloatingControlBarWindow.notchInputPanelVerticalPadding
         let headerBudget = !agentPills.pills.isEmpty
             ? FloatingControlBarWindow.notchChatHeaderVerticalBudget
             : 0
@@ -1440,8 +1453,6 @@ struct FloatingControlBarView: View {
             ),
             userInput: state.displayedQuery,
             chatHistory: state.derivedChatHistory(from: provider),
-            isVoiceFollowUp: state.isVoiceFollowUp,
-            voiceFollowUpTranscript: state.voiceFollowUpTranscript,
             canClearVisibleConversation: false,
             showsHeader: false,
             onClearVisibleConversation: onClearVisibleConversation,
@@ -1700,10 +1711,6 @@ private struct AgentMainChatView: View {
         _followUpText = State(initialValue: ChatDraftStore.shared.text(for: .floatingAgent(pill.id)))
     }
 
-    private var isRecording: Bool {
-        manager.recordingPillID == pill.id
-    }
-
     private var isRunning: Bool {
         guard !hasFinalAssistantOutput else { return false }
         switch pill.status {
@@ -1758,7 +1765,6 @@ private struct AgentMainChatView: View {
                         String(message.isStreaming),
                     ].joined(separator: "\u{1F}")
                 }.joined(separator: "\u{1E}"),
-                String(isRecording),
             ].joined(separator: "\u{1D}")
         )
     }
@@ -1777,11 +1783,6 @@ private struct AgentMainChatView: View {
             ) {
                 conversationContent
                     .id(pill.contentRevision)
-
-                if isRecording {
-                    voiceFollowUpView
-                        .id("agentVoiceFollowUp")
-                }
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
 
@@ -2094,23 +2095,6 @@ private struct AgentMainChatView: View {
         }
     }
 
-    private var voiceFollowUpView: some View {
-        HStack(spacing: OmiSpacing.sm) {
-            VoiceWaveformBars(isActive: true)
-            Image(systemName: "mic.fill")
-                .scaledFont(size: 14, weight: .semibold)
-                .foregroundColor(.white)
-            Text("Listening...")
-                .scaledFont(size: OmiType.body)
-                .foregroundColor(.white.opacity(0.62))
-            Spacer(minLength: 0)
-        }
-        .padding(.horizontal, 10)
-        .padding(.vertical, OmiSpacing.sm)
-        .background(Color.white.opacity(0.08))
-        .clipShape(RoundedRectangle(cornerRadius: OmiChrome.elementRadius, style: .continuous))
-    }
-
     private var followUpInput: some View {
         VStack(alignment: .leading, spacing: OmiSpacing.sm) {
             if !attachments.isEmpty {
@@ -2122,17 +2106,6 @@ private struct AgentMainChatView: View {
             }
 
             HStack(spacing: OmiSpacing.xs) {
-                Button {
-                    manager.toggleFollowUpVoice(for: pill)
-                } label: {
-                    Image(systemName: isRecording ? "stop.circle.fill" : "mic.fill")
-                        .scaledFont(size: 17, weight: .semibold)
-                        .foregroundColor(isRecording ? Color.white : .secondary)
-                        .frame(width: 24, height: 24)
-                }
-                .buttonStyle(.plain)
-                .help(isRecording ? "Stop voice follow-up" : "Voice follow-up")
-
                 TextField("Ask this agent...", text: $followUpText)
                     .textFieldStyle(.plain)
                     .scaledFont(size: OmiType.body)

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
@@ -120,14 +120,15 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
         pillSurfaceTopPadding + notchInputPanelMinimumContentHeight + notchInputPanelVerticalPadding
     }
     private static let voiceBarSize = NSSize(width: 224, height: 42)
+    /// Readable status strip under chrome/pill for too-short PTT / mic errors.
+    static let pttHintRowHeight: CGFloat = 30
     private static let maxBarSize = NSSize(width: 1200, height: 1000)
     static let notchExpandedWidth: CGFloat = 382
     private static let notificationWidth: CGFloat = 430
     private static let notificationHeight: CGFloat = 108
     private static let notificationSpacing: CGFloat = 8
-    /// Height of the transient PTT hint row shown below the notch chrome
-    /// (e.g. "Hold longer to record") after a too-short tap.
-    static let pttHintRowHeight: CGFloat = 30
+    /// Vertical room for the readable PTT status banner under chrome/pill.
+    static var pttStatusBannerBudget: CGFloat { notificationSpacing + pttHintRowHeight }
     private static let askOmiAnimationDuration: TimeInterval = 0.14
     private static let askOmiSettleDelay: TimeInterval = 0.16
     /// Hover-menu (agent switcher) motion.
@@ -168,10 +169,10 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
     private var suppressHoverResize = false
     private var inputHeightCancellable: AnyCancellable?
     private var responseHeightCancellable: AnyCancellable?
-    private var pttHintCancellable: AnyCancellable?
     private var agentPillsCancellable: AnyCancellable?
     private var voiceResponseGlowCancellable: AnyCancellable?
     private var draggableBarCancellable: AnyCancellable?
+    private var pttHintCancellable: AnyCancellable?
     private var previousVoiceResponseGlowActive = false
     private var resizeWorkItem: DispatchWorkItem?
     /// Saved center point from before chat opened, used to restore position on close.
@@ -357,14 +358,18 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
     private var collapsedBarSize: NSSize { notchModeEnabled ? notchCollapsedSize : Self.minBarSize }
     private var expandedContentWidth: CGFloat { Self.notchExpandedWidth }
     private var inputPanelHeight: CGFloat {
-        let base = notchModeEnabled ? notchInputPanelHeightForCurrentScreen : Self.pillInputPanelHeight
+        // Chat always mounts shared top chrome, so budget chrome height even off-notch.
+        let base = (notchModeEnabled || state.showingAIConversation)
+            ? notchInputPanelHeightForCurrentScreen
+            : Self.pillInputPanelHeight
+        let statusBanner = state.pttHintText.isEmpty ? 0 : Self.pttStatusBannerBudget
         // When notch mode renders the "Back / Omi Chat" header (agent pills
         // present), the input panel needs additional vertical room so the
         // header + editor + padding all fit. (Codex P2 — input/send clipping.)
         if !AgentPillsManager.shared.pills.isEmpty {
-            return base + Self.notchChatHeaderVerticalBudget
+            return base + statusBanner + Self.notchChatHeaderVerticalBudget
         }
-        return base
+        return base + statusBanner
     }
 
     var onPlayPause: (() -> Void)?
@@ -717,14 +722,12 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
     private func defaultFrameForCurrentState() -> NSRect {
         let size: NSSize
         if state.showingAIConversation {
-            size = NSSize(width: expandedContentWidth, height: max(inputPanelHeight, frame.height))
-        } else if notchModeEnabled && !state.pttHintText.isEmpty {
-            size = NSSize(
-                width: Self.notchExpandedWidth,
-                height: notchChromeHeightForCurrentScreen + Self.notificationSpacing + Self.pttHintRowHeight
-            )
+            let height = max(inputPanelHeight, frame.height)
+            size = NSSize(width: expandedContentWidth, height: height)
+        } else if !state.pttHintText.isEmpty {
+            size = pttHintSurfaceSize(usesNotchIsland: notchModeEnabled)
         } else if state.isVoiceListening {
-            size = notchSize(active: true)
+            size = notchModeEnabled ? notchSize(active: true) : Self.voiceBarSize
         } else if state.currentNotification != nil {
             size = NSSize(
                 width: Self.notificationWidth,
@@ -745,18 +748,18 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
         if state.showingAIConversation {
             let defaultWidth = Self.notchExpandedWidth
             let width = max(defaultWidth, currentResponseSurfaceWidth(usesNotchIsland: usesNotchIsland))
-            let panelHeight = usesNotchIsland ? notchInputPanelHeightForCurrentScreen : Self.pillInputPanelHeight
+            // Chat always mounts shared top chrome, so budget chrome height even
+            // on non-notch displays (pillSurfaceTopPadding alone would clip).
+            let panelHeight = notchInputPanelHeightForCurrentScreen
+            let statusBanner = state.pttHintText.isEmpty ? 0 : Self.pttStatusBannerBudget
             let reservedGlowOutset = usesNotchIsland ? Self.notchGlowOutsetBottom : 0
-            let contentHeight = max(panelHeight, frame.height - reservedGlowOutset)
+            let contentHeight = max(panelHeight + statusBanner, frame.height - reservedGlowOutset)
             return NSSize(width: width, height: contentHeight)
         }
-        // Notch: grow just enough to fit the transient too-short PTT hint row.
+        // Grow just enough to fit the readable PTT status banner under chrome/pill.
         // (isVoiceListening is true during the hint, so this must precede it.)
-        if usesNotchIsland && !state.pttHintText.isEmpty {
-            return NSSize(
-                width: Self.notchExpandedWidth,
-                height: notchChromeHeightForCurrentScreen + Self.notificationSpacing + Self.pttHintRowHeight
-            )
+        if !state.pttHintText.isEmpty {
+            return pttHintSurfaceSize(usesNotchIsland: usesNotchIsland)
         }
         if state.isVoiceListening {
             return usesNotchIsland ? notchSize(active: true) : Self.voiceBarSize
@@ -784,14 +787,15 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
         if state.showingAIConversation {
             let width = Self.notchExpandedWidth
             let chromeHeight = Self.notchChromeHeight(for: screen)
-            let panelHeight = usesNotchIsland ? Self.notchInputPanelHeight(for: screen) : Self.pillInputPanelHeight
-            size = NSSize(width: width, height: max(panelHeight, frame.height, chromeHeight))
-        } else if usesNotchIsland && !state.pttHintText.isEmpty {
-            let chromeHeight = Self.notchChromeHeight(for: screen)
+            // Chat always mounts shared top chrome.
+            let panelHeight = Self.notchInputPanelHeight(for: screen)
+            let statusBanner = state.pttHintText.isEmpty ? 0 : Self.pttStatusBannerBudget
             size = NSSize(
-                width: Self.notchExpandedWidth,
-                height: chromeHeight + Self.notificationSpacing + Self.pttHintRowHeight
+                width: width,
+                height: max(panelHeight + statusBanner, frame.height, chromeHeight + statusBanner)
             )
+        } else if !state.pttHintText.isEmpty {
+            size = pttHintSurfaceSize(usesNotchIsland: usesNotchIsland, screen: screen)
         } else if state.isVoiceListening {
             size = usesNotchIsland ? notchSize(sideWidth: Self.notchActiveSideWidth, for: screen) : Self.voiceBarSize
         } else if state.currentNotification != nil {
@@ -982,8 +986,7 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
                     )
                     return
                 }
-                // Voice listening/thinking/glow and the PTT hint own their own
-                // frames (syncActiveIsland / observePttHint).
+                // Voice listening/thinking/glow own their own frames (syncActiveIsland).
                 guard !self.state.isVoiceListening,
                       !self.state.isThinking,
                       !self.state.isVoiceResponseGlowActive,
@@ -1022,25 +1025,40 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
             }
     }
 
-    /// Resize the notch surface when the transient too-short PTT hint appears or
-    /// clears. `isVoiceListening` is already true when the hint fires (no size
-    /// transition fires on its own), so the hint needs its own resize. Notch only —
-    /// the pill layout renders the hint inside its existing voice size.
+    /// Resize when the transient PTT status banner appears or clears.
+    /// `isVoiceListening` is already true when the hint fires, so the banner
+    /// needs its own resize for chrome/pill and for open chat (which also mounts
+    /// the banner under the shared top chrome).
     private func observePttHint() {
         pttHintCancellable = state.$voiceProjection
             .map { $0.hint.isEmpty }
             .removeDuplicates()
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
-                guard let self, self.notchModeEnabled else { return }
-                guard !self.state.showingAIConversation else { return }
+                guard let self else { return }
                 self.resizeAnchored(
                     to: self.currentSurfaceSizeForCurrentScreen(),
-                    makeResizable: false,
+                    makeResizable: self.state.showingAIConversation && self.state.showingAIResponse,
                     animated: true,
                     anchorTop: true
                 )
             }
+    }
+
+    private func pttHintSurfaceSize(usesNotchIsland: Bool, screen: NSScreen? = nil) -> NSSize {
+        let chromeHeight: CGFloat
+        let width: CGFloat
+        if usesNotchIsland {
+            chromeHeight = screen.map { Self.notchChromeHeight(for: $0) } ?? notchChromeHeightForCurrentScreen
+            width = Self.notchExpandedWidth
+        } else {
+            chromeHeight = Self.voiceBarSize.height
+            width = max(Self.voiceBarSize.width, Self.notchExpandedWidth * 0.72)
+        }
+        return NSSize(
+            width: width,
+            height: chromeHeight + Self.pttStatusBannerBudget
+        )
     }
 
     private var cursorTrackingTimer: DispatchSourceTimer?
@@ -1174,10 +1192,8 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
         responseHeightCancellable = nil
         state.responseContentHeight = 0
 
-        // Cancel PTT if in follow-up mode
-        if state.isVoiceFollowUp {
-            PushToTalkManager.shared.cancelListening()
-        }
+        // Cancel PTT if listening while chat closes
+        PushToTalkManager.shared.cancelListening()
 
         OmiMotion.withGated(.easeOut(duration: 0.08)) {
             state.showingAIConversation = false

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
@@ -120,10 +120,6 @@ class PushToTalkManager: ObservableObject {
   // Realtime-as-hub (Phase 1): when active, the realtime model is THE hub — it does
   // in-session STT + reasoning + routing (tool choice) + speaks the reply. Mic PCM is
   // streamed to RealtimeHubController; there is no transcript→router→ChatProvider hop.
-  /// When set, the next finalized PTT turn is a voice follow-up to this agent pill:
-  /// it uses the realtime omni STT and routes the transcript into the pill's agent
-  /// session (RealtimeHub pipeline), NOT the floating bar or the hub model.
-  private var followUpPill: AgentPill?
   // Mic chunks captured before the relay finishes connecting (raw 16k PCM),
   // flushed once the service exists so the user's first words aren't clipped.
   private var omniPreconnectBuffer: [Data] = []
@@ -312,7 +308,7 @@ class PushToTalkManager: ObservableObject {
     switch route {
     case .hub, .hubWarmWait:
       return true
-    case .undecided, .omniSTT, .deepgramBatch, .deepgramLive, .agentFollowUp:
+    case .undecided, .omniSTT, .deepgramBatch, .deepgramLive:
       return false
     }
   }
@@ -439,7 +435,7 @@ class PushToTalkManager: ObservableObject {
       return
     }
     if isBlockedByUsageLimit() { return }
-    _ = voiceTurnCoordinator.begin(intent: followUpPill == nil ? .hold : .agentFollowUp)
+    _ = voiceTurnCoordinator.begin(intent: .hold)
     RealtimeHubController.shared.prefetchVoiceContextSnapshotIfNeeded()
     // Reset the overflow flag under the buffer lock so it's atomic w.r.t. the
     // audio thread's appendBatchAudioBounded (fresh turn → allow the warning again).
@@ -547,10 +543,6 @@ class PushToTalkManager: ObservableObject {
     contextCaptureTask?.cancel()
     contextCaptureTask = nil
     micCaptureStartInFlight = false
-    if followUpPill != nil {
-      followUpPill = nil
-      AgentPillsManager.shared.recordingPillID = nil
-    }
     stopAudioTranscription(discardBufferedAudio: discardBufferedAudio)
     transcriptSegments = []
     seenFinalSegmentIDs.removeAll()
@@ -611,36 +603,6 @@ class PushToTalkManager: ObservableObject {
   func cancelListening() {
     guard !isIdle else { return }
     log("PushToTalkManager: cancelling listening")
-    stopListening()
-  }
-
-  // MARK: - Agent voice follow-up
-
-  /// Begin a voice follow-up to a specific agent pill (the pill's mic button). Reuses
-  /// the realtime omni STT capture; the transcript routes to the agent's session via
-  /// AgentPillsManager.continueAgent (not the floating bar / hub model).
-  func startPillFollowUp(for pill: AgentPill) {
-    guard isIdle else {
-      log("PushToTalkManager: follow-up ignored — PTT busy (phase=\(String(describing: phase)))")
-      AgentPillsManager.shared.recordingPillID = nil
-      return
-    }
-    log("PushToTalkManager: voice follow-up START for agent \(pill.title)")
-    followUpPill = pill
-    startListening()
-  }
-
-  /// End the in-progress voice follow-up (second mic tap) and send it to the agent.
-  func endPillFollowUp() {
-    guard followUpPill != nil, !isIdle else { return }
-    log("PushToTalkManager: voice follow-up END — finalizing")
-    finalize()
-  }
-
-  /// Cancel an in-progress voice follow-up for a pill that was dismissed.
-  func cancelPillFollowUp(for pillID: UUID) {
-    guard followUpPill?.id == pillID else { return }
-    log("PushToTalkManager: voice follow-up CANCEL for dismissed agent")
     stopListening()
   }
 
@@ -1258,34 +1220,6 @@ class PushToTalkManager: ObservableObject {
       log("PushToTalkManager: refusing provider dispatch after authenticated owner changed")
       return
     }
-    // Voice follow-up to an agent pill: route the transcript into THAT agent's session
-    // (RealtimeHub pipeline) instead of the floating bar.
-    if let pill = followUpPill {
-      followUpPill = nil
-      AgentPillsManager.shared.recordingPillID = nil
-      activeTracer = nil
-      let q = query.trimmingCharacters(in: .whitespacesAndNewlines)
-      if q.isEmpty {
-        log("PushToTalkManager: voice follow-up empty — not sending")
-      } else {
-        guard voiceTurnCoordinator.requireCurrentOwner(for: turnID) != nil else { return }
-        log("PushToTalkManager: routing voice follow-up → agent (\(q.count) chars)")
-        let completionToken = currentVoiceTurnID.flatMap {
-          voiceTurnCoordinator.nonHubCompletionToken(for: $0)
-        }
-        AgentPillsManager.shared.continueAgent(from: pill, text: q) { outcome in
-          guard let completionToken else { return }
-          VoiceTurnCoordinator.shared.completeNonHubProvider(
-            completionToken,
-            outcome: outcome)
-        }
-        if completionToken == nil, let turnID = currentVoiceTurnID {
-          log("PushToTalkManager: agent follow-up missing provider completion identity")
-          voiceTurnCoordinator.send(.finish(turnID: turnID, reason: .providerFailed))
-        }
-      }
-      return
-    }
     // QueryTracer: hand the PTT tracer to the floating-bar query via TaskLocal so
     // routing, the LLM call, and TTS all record into this same trace. Ownership
     // moves out of activeTracer here; the unstructured Task spawned inside
@@ -1385,16 +1319,6 @@ class PushToTalkManager: ObservableObject {
     // + spoken reply). Stream mic PCM to the hub and skip both the omni/Deepgram
     // STT path AND the transcript→router→ChatProvider hop. The Haiku classify()
     // router is bypassed — routing is the model's tool choice.
-    // Voice follow-up to an agent: always use the omni STT (we need a transcript to
-    // route to the agent), never the hub model — the hub would answer it itself.
-    if followUpPill != nil {
-      if let turnID = currentVoiceTurnID {
-        voiceTurnCoordinator.send(.selectRoute(turnID: turnID, route: .agentFollowUp))
-      }
-      _ = startOmniTranscription()
-      return
-    }
-
     if RealtimeHubController.shared.isActive {
       if let turnID = currentVoiceTurnID {
         voiceTurnCoordinator.send(.selectRoute(turnID: turnID, route: .hub(sessionID: nil)))
@@ -1881,9 +1805,7 @@ extension PushToTalkManager {
     let delegateProxy = VoiceTurnOmniDelegateProxy(owner: self, identity: identity)
     omniDelegateProxy = delegateProxy
     let provider = RealtimeOmniSettings.shared.effectiveProvider
-    if let turnID = currentVoiceTurnID,
-      voiceTurnCoordinator.activeTurn?.route != .agentFollowUp
-    {
+    if let turnID = currentVoiceTurnID {
       voiceTurnCoordinator.send(.selectRoute(turnID: turnID, route: .omniSTT))
     }
     if captureAlreadyRunning {

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/VoiceTurnCoordinator.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/VoiceTurnCoordinator.swift
@@ -546,7 +546,6 @@ final class VoiceTurnCoordinator {
     case .omniSTT: return "omni_stt"
     case .deepgramBatch: return "deepgram_batch"
     case .deepgramLive: return "deepgram_live"
-    case .agentFollowUp: return "agent_follow_up"
     }
   }
 

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/VoiceTurnStateMachine.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/VoiceTurnStateMachine.swift
@@ -91,7 +91,6 @@ struct VoiceEffectIdentity: Hashable, Equatable, Sendable {
 enum VoiceTurnIntent: String, Equatable, Sendable {
   case hold
   case locked
-  case agentFollowUp
   case automation
 }
 
@@ -102,7 +101,6 @@ enum VoiceTurnRoute: Equatable, Sendable {
   case omniSTT
   case deepgramBatch
   case deepgramLive
-  case agentFollowUp
 }
 
 enum VoiceContextOutcome: Equatable, Sendable {
@@ -239,7 +237,6 @@ enum VoiceTurnDeadline: String, Equatable, Hashable, Sendable, CaseIterable {
 struct VoiceTurnUIProjection: Equatable, Sendable {
   var isListening = false
   var isLocked = false
-  var isFollowUp = false
   var transcript = ""
   var hint = ""
   var isThinking = false
@@ -314,7 +311,7 @@ struct VoiceTurn: Equatable, Sendable {
     self.supersededTurnID = supersededTurnID
     self.intent = intent
     phase = intent == .locked ? .lockedRecording : .recording
-    route = intent == .agentFollowUp ? .agentFollowUp : .undecided
+    route = .undecided
     pendingToolCallIDs = []
     toolEffectIdentities = [:]
     providerFinished = false
@@ -334,7 +331,6 @@ struct VoiceTurn: Equatable, Sendable {
     projection = VoiceTurnUIProjection(
       isListening: true,
       isLocked: intent == .locked,
-      isFollowUp: intent == .agentFollowUp,
       transcript: "",
       hint: "",
       isThinking: false,
@@ -1216,7 +1212,6 @@ struct VoiceTurnReducer {
     case .clearPresentation:
       model.turn?.projection.isListening = false
       model.turn?.projection.isLocked = false
-      model.turn?.projection.isFollowUp = false
       model.turn?.projection.transcript = ""
       model.turn?.projection.hint = ""
       model.turn?.projection.isThinking = false

--- a/desktop/macos/Desktop/Tests/AgentPillLifecycleTests.swift
+++ b/desktop/macos/Desktop/Tests/AgentPillLifecycleTests.swift
@@ -117,7 +117,11 @@ final class AgentPillLifecycleTests: XCTestCase {
     XCTAssertTrue(source.contains("preservingAttemptForSameRun: true"))
     XCTAssertTrue(source.contains("return !hasLocalTransientState(pillID: pill.id)"))
     XCTAssertTrue(source.contains("private func hasLocalTransientState(pillID: UUID) -> Bool"))
-    XCTAssertTrue(source.contains("recordingPillID == pillID || pendingFollowUpsByPill[pillID]?.isEmpty == false"))
+    XCTAssertTrue(source.contains("pendingFollowUpsByPill[pillID]?.isEmpty == false"))
+    XCTAssertFalse(source.contains("recordingPillID"))
+    XCTAssertFalse(source.contains("toggleFollowUpVoice"))
+    XCTAssertFalse(source.contains("startPillFollowUp"))
+    XCTAssertFalse(source.contains("cancelPillFollowUp"))
   }
 
   func testFinishedAgentArtifactsAreDeliveredToParentChatSurfaces() throws {
@@ -283,7 +287,7 @@ final class AgentPillLifecycleTests: XCTestCase {
     XCTAssertFalse(windowSource.contains("let targetSize = self.currentSurfaceSizeForCurrentScreen(frameIncludesVoiceGlow: wasActive)"))
   }
 
-  func testNotchPTTUsesCompactWaveformOnly() throws {
+    func testNotchPTTUsesCompactWaveformOnly() throws {
     let source = try floatingControlBarViewSource()
 
     guard let lobeRange = source.range(of: "private var notchAgentLobe: some View"),
@@ -294,7 +298,25 @@ final class AgentPillLifecycleTests: XCTestCase {
     let lobeSource = String(source[lobeRange.lowerBound..<controlRange.lowerBound])
 
     XCTAssertTrue(lobeSource.contains("VoiceWaveformBars(isActive: true)"))
-    XCTAssertFalse(lobeSource.contains("Image(systemName: \"mic.fill\")"))
+    XCTAssertFalse(lobeSource.contains("showingNotchPttHint"))
+    XCTAssertTrue(source.contains("pttStatusBanner"))
+    XCTAssertTrue(source.contains("state.isVoiceListening && state.pttHintText.isEmpty"))
+    XCTAssertFalse(source.contains("!state.isVoiceFollowUp && !state.showingAIConversation"))
+  }
+
+  func testVoiceWaveformBarsOwnedByChromeMorph() throws {
+    let view = try floatingControlBarViewSource()
+    let response = try aiResponseViewSource()
+    let waveformSites = view.components(separatedBy: "VoiceWaveformBars(").count - 1
+    // Chrome morph lobe + optional idle pill voiceListeningView.
+    XCTAssertEqual(waveformSites, 2)
+    XCTAssertTrue(view.contains("private var notchAgentLobe: some View"))
+    XCTAssertTrue(view.contains("private var voiceListeningView: some View"))
+    XCTAssertTrue(view.contains("if state.usesNotchIsland || state.showingAIConversation {\n                notchChrome"))
+    XCTAssertFalse(response.contains("VoiceWaveformBars("))
+    XCTAssertFalse(view.contains("voiceFollowUpView"))
+    XCTAssertFalse(view.contains("toggleFollowUpVoice"))
+    XCTAssertFalse(view.contains("agentFollowUp"))
   }
 
   func testNotchHoverMenuKeepsAskOmiReachable() throws {
@@ -472,7 +494,8 @@ final class AgentPillLifecycleTests: XCTestCase {
     XCTAssertTrue(source.contains("showsHeader: false"))
     XCTAssertTrue(responseSource.contains("var showsHeader: Bool = true"))
     XCTAssertTrue(responseSource.contains("if showsHeader {"))
-    XCTAssertTrue(responseSource.contains(".padding(.top, state.usesNotchIsland ? 0 : OmiSpacing.lg)"))
+    XCTAssertTrue(responseSource.contains(".padding(.top, 0)"))
+    XCTAssertFalse(responseSource.contains(".padding(.top, state.usesNotchIsland ? 0 : OmiSpacing.lg)"))
     XCTAssertFalse(source.contains("NotchAgentSwitcherMenu("))
     XCTAssertFalse(source.contains("Text(\"Subagents\")"))
     XCTAssertFalse(source.contains(".fill(Color.white.opacity(0.025))"))

--- a/desktop/macos/Desktop/Tests/FloatingControlBarStateTests.swift
+++ b/desktop/macos/Desktop/Tests/FloatingControlBarStateTests.swift
@@ -123,11 +123,12 @@ final class FloatingControlBarStateTests: XCTestCase {
             "@Published var isVoiceLocked",
             "@Published var pttHintText",
             "@Published var isThinking",
-            "@Published var isVoiceFollowUp",
             "presentVoiceResponseActive",
             "beginVoiceResponseWaiting",
             "clearVoiceResponseState",
             "debugSetVoiceResponseActive",
+            "var isVoiceFollowUp",
+            "var voiceFollowUpTranscript",
         ] {
             XCTAssertFalse(source.contains(forbidden), "legacy voice mutation surface: \(forbidden)")
         }
@@ -469,14 +470,14 @@ final class FloatingControlBarStateTests: XCTestCase {
         XCTAssertTrue(state.isAgentSwitcherExpanded)
     }
 
-    func testHideConversationSurfaceCannotClearReducerOwnedFollowUpProjection() {
+    func testHideConversationSurfaceDoesNotMutateReducerProjectionDirectly() {
         let state = FloatingControlBarState()
         let coordinator = VoiceTurnCoordinator()
         coordinator.configure(barState: state)
         let agentID = UUID()
         state.present(.agent(agentID))
         state.isAILoading = true
-        let turnID = coordinator.begin(intent: .agentFollowUp)
+        let turnID = coordinator.begin(intent: .hold)
         coordinator.send(.transcriptChanged(turnID: turnID, text: "partial transcript"))
 
         state.hideConversationSurface()
@@ -486,14 +487,16 @@ final class FloatingControlBarStateTests: XCTestCase {
         XCTAssertFalse(state.showingAIConversation)
         XCTAssertFalse(state.showingAIResponse)
         XCTAssertFalse(state.isAILoading)
-        XCTAssertTrue(state.isVoiceFollowUp)
-        XCTAssertEqual(state.voiceFollowUpTranscript, "partial transcript")
+        // cancelListening is a no-op when PushToTalkManager is idle; projection stays
+        // reducer-owned until the coordinator cancels the turn.
         XCTAssertEqual(state.voiceProjection, coordinator.projection)
+        XCTAssertTrue(state.isVoiceListening)
+        XCTAssertEqual(state.voiceProjection.transcript, "partial transcript")
         XCTAssertFalse(state.hasVisibleConversation)
 
         coordinator.send(.cancel(turnID: turnID, reason: .cancelled))
-        XCTAssertFalse(state.isVoiceFollowUp)
-        XCTAssertEqual(state.voiceFollowUpTranscript, "")
+        XCTAssertFalse(state.isVoiceListening)
+        XCTAssertEqual(state.voiceProjection.transcript, "")
     }
 
     private func makeResponseActive(

--- a/desktop/macos/Desktop/Tests/FloatingOwnerProjectionTests.swift
+++ b/desktop/macos/Desktop/Tests/FloatingOwnerProjectionTests.swift
@@ -190,7 +190,6 @@ final class FloatingOwnerProjectionTests: XCTestCase {
     NotificationCenter.default.post(name: .runtimeOwnerDidChange, object: nil)
 
     XCTAssertTrue(manager.pills.isEmpty)
-    XCTAssertNil(manager.recordingPillID)
   }
 
   @MainActor

--- a/desktop/macos/Desktop/Tests/PTTAudioCaptureRaceTests.swift
+++ b/desktop/macos/Desktop/Tests/PTTAudioCaptureRaceTests.swift
@@ -84,28 +84,26 @@ final class PTTAudioCaptureRaceTests: XCTestCase {
     XCTAssertTrue(state.contains("var pttHintText: String"))
   }
 
-  /// MIC-02b: the notch-island layout bypasses the pill's `voiceListeningView`, so the
-  /// hint must render as its own row below the notch chrome (`notchPttHintRow`), the
-  /// surface must count as expanded so it draws, and the window must grow to fit it —
-  /// otherwise the hint is clipped to zero height and never seen on a notched Mac.
+  /// MIC-02b: too-short PTT / mic-error copy renders in a full-width status
+  /// banner under chrome (notch + non-notch), not cramped into the logo lobe.
   func testNotchIslandRendersAndSizesPTTHint() throws {
     let view = try source(relativePath: "Sources/FloatingControlBar/FloatingControlBarView.swift")
-    // Dedicated notch hint row, gated on the notch layout + a non-empty hint.
-    XCTAssertTrue(view.contains("notchPttHintRow"))
-    XCTAssertTrue(view.contains("state.usesNotchIsland && !state.pttHintText.isEmpty"))
-    // The hint keeps the unified surface in its expanded (drawn) state.
-    XCTAssertTrue(view.contains("|| !state.pttHintText.isEmpty"))
+    XCTAssertTrue(view.contains("pttStatusBanner"))
+    XCTAssertTrue(view.contains("showingPTTStatusBanner"))
+    XCTAssertTrue(view.contains("state.isVoiceListening && state.pttHintText.isEmpty"))
+    XCTAssertFalse(view.contains("showingNotchPttHint"))
+    XCTAssertFalse(view.contains("notchPttHintRow"))
+    // Waveform no longer excludes open chat; thinking still does (chat has its own loader).
+    XCTAssertFalse(view.contains("!state.isVoiceFollowUp && !state.showingAIConversation"))
+    XCTAssertTrue(view.contains("&& !state.showingAIConversation\n            && !state.isVoiceListening"))
 
     let window = try source(relativePath: "Sources/FloatingControlBar/FloatingControlBarWindow.swift")
-    // All three sizing paths grow for the hint...
-    let sizedBranches = window.components(separatedBy: "!state.pttHintText.isEmpty").count - 1
-    XCTAssertGreaterThanOrEqual(sizedBranches, 3)
-    // ...using a dedicated hint-row height...
     XCTAssertTrue(window.contains("pttHintRowHeight"))
-    // ...and a dedicated observer resizes when the hint appears/clears (no
-    // isVoiceListening transition fires on its own to trigger a resize).
-    XCTAssertTrue(window.contains("state.$voiceProjection"))
-    XCTAssertTrue(window.contains("$0.hint.isEmpty"))
+    XCTAssertTrue(window.contains("observePttHint"))
+    XCTAssertTrue(window.contains("pttHintSurfaceSize"))
+    XCTAssertTrue(window.contains("pttStatusBannerBudget"))
+    // Chat-open hints must grow the panel (do not bail out of observePttHint).
+    XCTAssertFalse(window.contains("guard !self.state.showingAIConversation else { return }\n                self.resizeAnchored(\n                    to: self.currentSurfaceSizeForCurrentScreen()"))
   }
 
   private func managerSource() throws -> String {

--- a/desktop/macos/Desktop/Tests/VoiceTurnCoordinatorTests.swift
+++ b/desktop/macos/Desktop/Tests/VoiceTurnCoordinatorTests.swift
@@ -376,7 +376,6 @@ final class VoiceTurnCoordinatorTests: XCTestCase {
       (.omniSTT, "omni_stt"),
       (.deepgramBatch, "deepgram_batch"),
       (.deepgramLive, "deepgram_live"),
-      (.agentFollowUp, "agent_follow_up"),
     ]
     for (route, expected) in routes {
       XCTAssertEqual(VoiceTurnCoordinator.routeLabel(route), expected, "turn=\(turnID)")

--- a/desktop/macos/changelog/unreleased/20260713-ptt-shared-listening-chrome.json
+++ b/desktop/macos/changelog/unreleased/20260713-ptt-shared-listening-chrome.json
@@ -1,0 +1,3 @@
+{
+  "change": "Push-to-talk listening morphs shared floating-bar chrome during chat on every display; too-short/error copy uses a readable status banner under chrome/pill; agent voice follow-up was removed so global PTT always talks to the main agent"
+}


### PR DESCRIPTION
## Summary
- Unify PTT listening into one shared chrome morph (logo/pill → waveform) for notch and non-notch, including when Ask Omi chat is open.
- Put too-short / mic-error copy in a readable full-width status banner under chrome (not cramped into the lobe); grow the panel so chat+hint does not clip.
- Remove background-agent voice follow-up end-to-end so global PTT always talks to the main agent; typed agent follow-up stays.
- Keep thinking mark out of the lobe while chat is open (chat already shows its own loading UI).

## Product invariants affected
- INV-CHAT-1
- INV-VOICE-1

## Test plan
- [x] Targeted Swift: `PTTAudioCaptureRaceTests`, `AgentPillLifecycleTests` waveform/ownership cases
- [x] Named bundle `omi-ptt-chrome` with `shortcut_draggableBarEnabled=true` (notch off)
- [x] Pill PTT shows waveform; short tap shows readable “Hold longer to record” banner under pill
- [x] Chat open + non-notch mounts top chrome morph for listening
- [ ] Manual: notch display — short tap banner under island; chat open — no duplicate thinking mark in lobe



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9641?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

