### PR TITLE
fix(desktop-backend): byte-safe upstream error-body log preview

### DIFF
--- a/desktop/macos/Backend-Rust/src/routes/chat_completions.rs
+++ b/desktop/macos/Backend-Rust/src/routes/chat_completions.rs
@@ -663,6 +663,19 @@ fn drain_sse_events(buffer: &mut Vec<u8>) -> Vec<String> {
     events
 }
 
+/// Byte-safe preview of an upstream error body for logging.
+///
+/// `&body[..N]` slices by byte index and panics when byte `N` lands inside a
+/// multi-byte UTF-8 sequence (the same byte-vs-char hazard `drain_sse_events`
+/// avoids). Truncate to the nearest char boundary at or below 500 instead.
+fn error_body_preview(body: &str) -> &str {
+    let mut end = body.len().min(500);
+    while !body.is_char_boundary(end) {
+        end -= 1;
+    }
+    &body[..end]
+}
+
 fn make_chunk(
     id: &str,
     created: i64,
@@ -910,7 +923,7 @@ async fn handle_non_streaming(
             "chat_completions: Anthropic returned {} for user {}: {}",
             status,
             user.uid,
-            &body[..body.len().min(500)]
+            error_body_preview(&body)
         );
         return Ok(response_or_500(
             Response::builder()
@@ -958,7 +971,7 @@ async fn handle_streaming(
             "chat_completions: Anthropic stream returned {} for user {}: {}",
             status,
             user.uid,
-            &body[..body.len().min(500)]
+            error_body_preview(&body)
         );
         return Ok(response_or_500(
             Response::builder()
@@ -2388,6 +2401,23 @@ mod tests {
         assert_eq!(events.len(), 1);
         assert!(events[0].contains("a—b"), "got {}", events[0]);
         assert!(!events[0].contains('\u{fffd}'));
+    }
+
+    #[test]
+    fn test_error_body_preview_never_splits_multibyte_char() {
+        // A >500-byte upstream error body whose 500th byte lands inside a
+        // multi-byte char must not panic the byte slice. "€" (U+20AC) is 3 bytes.
+        let body = format!("{}€tail", "x".repeat(498)); // byte 500 is mid-euro
+        let preview = error_body_preview(&body);
+        assert!(preview.len() <= 500);
+        assert!(body.starts_with(preview));
+        assert!(!preview.contains('\u{fffd}'));
+    }
+
+    #[test]
+    fn test_error_body_preview_passes_short_body_through() {
+        let body = "short error";
+        assert_eq!(error_body_preview(body), "short error");
     }
 
     #[test]


### PR DESCRIPTION
## Bug

`desktop/macos/Backend-Rust/src/routes/chat_completions.rs` logs a preview of a non-2xx Anthropic upstream error body in two places (`handle_non_streaming` and `handle_streaming`):

```rust
&body[..body.len().min(500)]
```

This slices the `String` by **byte** index. `body` is the raw `.text()` of the upstream error response. When the body is longer than 500 bytes and byte 500 lands inside a multi-byte UTF-8 sequence, `Index<Range<usize>>` for `str` **traps**: `byte index 500 is not a char boundary`.

## Root cause & blast radius

Same byte-vs-char boundary class the team just closed in #9638 (`7f78738724`) — that PR fixed the streaming *buffer* decode path in this same file but left these two error-branch siblings untouched.

Both sites are on the live chat path (every non-2xx from `api.anthropic.com`). Triggering needs an error body >500 bytes whose 500th byte splits a multi-byte char — intermittent, but a real coin-flip for non-ASCII error content or long `invalid_request_error` bodies. `CatchPanicLayer` (`main.rs`) contains the panic, so instead of crashing the process it converts a clean upstream-status passthrough into an opaque **500** and drops the `warn!` telemetry. Degraded error handling + lost observability, not a crash.

## Fix

Close the class at the shared boundary rather than patching each call site:

- Extract `error_body_preview(&str) -> &str`; both branches call it.
- Truncate to the nearest char boundary at or below 500 via the stable `str::is_char_boundary` walk-back (`floor_char_boundary` is still unstable on the pinned 1.88 toolchain).

## Tests

Added two regression tests:
- a >500-byte body with a multi-byte char (`€`) at byte 500 does not panic and yields no `U+FFFD`;
- a short body passes through unchanged.

Verified locally: `cargo test error_body_preview` (2 passed), `rustfmt --edition 2021`, `cargo clippy` clean. Found by a desktop crasher scan (no dedicated GitHub issue).

🤖 automated by hourly watchdog; opened for review, not merged.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9642?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

