### PR TITLE
fix(desktop): native-resolution detail tiles for capture_screen so chat reads on-screen text instead of guessing

### DIFF
--- a/desktop/macos/Desktop/Sources/FloatingControlBar/ScreenCaptureManager.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/ScreenCaptureManager.swift
@@ -36,7 +36,13 @@ class ScreenCaptureManager {
     /// resolution, compressed in memory via libwebp. No disk I/O.
     static func captureScreenData() -> Data? {
         guard let image = captureScreenImage() else { return nil }
+        guard let data = encodeWebP(image) else { return nil }
+        log("ScreenCaptureManager: Screenshot captured \(image.width)x\(image.height), WebP \(data.count / 1024) KB")
+        return data
+    }
 
+    /// Encode a CGImage to WebP (quality 70) via libwebp, in memory.
+    private static func encodeWebP(_ image: CGImage) -> Data? {
         let width = image.width
         let height = image.height
 
@@ -72,9 +78,127 @@ class ScreenCaptureManager {
 
         let data = Data(bytes: webpPtr, count: size)
         WebPFree(webpPtr)
-
-        log("ScreenCaptureManager: Screenshot captured \(width)x\(height), WebP \(data.count / 1024) KB")
         return data
+    }
+
+    // MARK: - Detail tiles (vision legibility)
+
+    /// A native-resolution sub-region of a screenshot, sized so a vision model
+    /// receives it without provider-side downscaling.
+    struct DetailTile: Equatable {
+        let label: String
+        let rect: CGRect
+    }
+
+    /// Vision APIs downscale images whose long edge exceeds ~1568 px. A full-Retina
+    /// screenshot (5+ MP) squeezed to ~1.15 MP makes dense UI text — product titles,
+    /// prices, labels — illegible, so the model guesses instead of reading (e.g.
+    /// conflating two similar listings). Tiles at or under this edge arrive at
+    /// native sharpness.
+    static let maxVisionTileLongEdge = 1568
+
+    /// Grid-partition a width×height image into native-resolution tiles whose long
+    /// edge stays ≤ `maxLongEdge`. The tiles exactly cover the image with no gaps or
+    /// overlaps. Returns [] when the full image already fits (no tiling needed).
+    /// Pure math — no capture, no I/O — so it is unit-testable.
+    static func detailTileRects(
+        width: Int, height: Int, maxLongEdge: Int = ScreenCaptureManager.maxVisionTileLongEdge
+    ) -> [DetailTile] {
+        guard width > 0, height > 0, maxLongEdge > 0 else { return [] }
+        guard max(width, height) > maxLongEdge else { return [] }
+
+        let cols = (width + maxLongEdge - 1) / maxLongEdge
+        let rows = (height + maxLongEdge - 1) / maxLongEdge
+
+        var tiles: [DetailTile] = []
+        for row in 0..<rows {
+            let y0 = row * height / rows
+            let y1 = (row + 1) * height / rows
+            for col in 0..<cols {
+                let x0 = col * width / cols
+                let x1 = (col + 1) * width / cols
+                tiles.append(
+                    DetailTile(
+                        label: tileLabel(row: row, col: col, rows: rows, cols: cols),
+                        rect: CGRect(x: x0, y: y0, width: x1 - x0, height: y1 - y0)
+                    ))
+            }
+        }
+        return tiles
+    }
+
+    /// Human-readable position label ("top-left", "right", "r2c3") the model can
+    /// map to what the user described on screen.
+    static func tileLabel(row: Int, col: Int, rows: Int, cols: Int) -> String {
+        if rows <= 2 && cols <= 2 {
+            let vertical = rows == 2 ? (row == 0 ? "top" : "bottom") : nil
+            let horizontal = cols == 2 ? (col == 0 ? "left" : "right") : nil
+            switch (vertical, horizontal) {
+            case let (v?, h?): return "\(v)-\(h)"
+            case let (v?, nil): return v
+            case let (nil, h?): return h
+            default: return "full"
+            }
+        }
+        return "r\(row + 1)c\(col + 1)"
+    }
+
+    /// Result of a chat-tool screen capture: the full-screen file plus
+    /// native-resolution detail tiles for large (Retina) displays.
+    struct ChatScreenshotCapture {
+        let fullImageURL: URL
+        let tiles: [(label: String, rect: CGRect, url: URL)]
+    }
+
+    /// Capture the screen for the chat `capture_screen` tool: writes the full frame
+    /// plus native-resolution detail tiles so the model can re-read small text
+    /// (titles, prices, labels) at legible sharpness. Tiles are best-effort — the
+    /// full-screen file is the contract.
+    static func captureScreenWithDetailTiles() -> ChatScreenshotCapture? {
+        guard let image = captureScreenImage() else { return nil }
+        guard let directory = screenshotsDirectory() else { return nil }
+
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd_HH-mm-ss"
+        let timestamp = formatter.string(from: Date())
+
+        guard let fullData = encodeWebP(image) else { return nil }
+        let fullURL = directory.appendingPathComponent("screenshot-\(timestamp).webp")
+        do {
+            try fullData.write(to: fullURL)
+        } catch {
+            log("ScreenCaptureManager: Could not save screenshot: \(error)")
+            return nil
+        }
+        log("ScreenCaptureManager: Screenshot captured \(image.width)x\(image.height), WebP \(fullData.count / 1024) KB")
+
+        var tiles: [(label: String, rect: CGRect, url: URL)] = []
+        for tile in detailTileRects(width: image.width, height: image.height) {
+            guard let cropped = image.cropping(to: tile.rect), let tileData = encodeWebP(cropped) else {
+                log("ScreenCaptureManager: Skipping detail tile \(tile.label) (crop/encode failed)")
+                continue
+            }
+            let tileURL = directory.appendingPathComponent("screenshot-\(timestamp)-\(tile.label).webp")
+            do {
+                try tileData.write(to: tileURL)
+                tiles.append((label: tile.label, rect: tile.rect, url: tileURL))
+            } catch {
+                log("ScreenCaptureManager: Could not save detail tile \(tile.label): \(error)")
+            }
+        }
+        return ChatScreenshotCapture(fullImageURL: fullURL, tiles: tiles)
+    }
+
+    private static func screenshotsDirectory() -> URL? {
+        let fileManager = FileManager.default
+        guard let documentsDirectory = fileManager.urls(for: .documentDirectory, in: .userDomainMask).first else {
+            return nil
+        }
+        let directory = documentsDirectory
+            .appendingPathComponent("Omi")
+            .appendingPathComponent("Screenshots")
+        try? fileManager.createDirectory(at: directory, withIntermediateDirectories: true, attributes: nil)
+        return directory
     }
 
     private static func displayIDUnderMouse() -> CGDirectDisplayID {
@@ -91,20 +215,12 @@ class ScreenCaptureManager {
     /// Legacy file-based capture (kept for callers that need a URL).
     static func captureScreen() -> URL? {
         guard let data = captureScreenData() else { return nil }
-
-        let fileManager = FileManager.default
-        guard let documentsDirectory = fileManager.urls(for: .documentDirectory, in: .userDomainMask).first else {
-            return nil
-        }
-        let screenshotsDirectory = documentsDirectory
-            .appendingPathComponent("Omi")
-            .appendingPathComponent("Screenshots")
-        try? fileManager.createDirectory(at: screenshotsDirectory, withIntermediateDirectories: true, attributes: nil)
+        guard let directory = screenshotsDirectory() else { return nil }
 
         let formatter = DateFormatter()
         formatter.dateFormat = "yyyy-MM-dd_HH-mm-ss"
         let timestamp = formatter.string(from: Date())
-        let fileURL = screenshotsDirectory.appendingPathComponent("screenshot-\(timestamp).webp")
+        let fileURL = directory.appendingPathComponent("screenshot-\(timestamp).webp")
 
         do {
             try data.write(to: fileURL)

--- a/desktop/macos/Desktop/Sources/Generated/GeneratedToolCapabilities.swift
+++ b/desktop/macos/Desktop/Sources/Generated/GeneratedToolCapabilities.swift
@@ -428,8 +428,11 @@ enum GeneratedToolCapabilities {
       bullets: [
       "For screen-awareness questions, call get_work_context first.",
       "Use capture_screen only when raw pixels are necessary; it requires explicit approval before image bytes are shared.",
-      "After capture_screen returns a file path, use Read to view the image.",
+      "The result lists the full-screen image path plus native-resolution detail tiles on large screens; use Read to view them.",
       "Call get_work_context first when the user asks about what's on their screen or what they're looking at.",
+      "After capture_screen returns, use Read to view the full-screen image.",
+      "The full screenshot is downscaled before you see it — before quoting small on-screen text (titles, prices, sizes, labels) or choosing between similar-looking items, Read the detail tile covering that item and take the exact text from the tile.",
+      "Keep every detail you cite (title, price, badge, position) bound to one on-screen item; if text is not legible even in a tile, say so instead of inferring.",
       "Do NOT use bash screencapture - always use this tool instead."
     ]
     ),

--- a/desktop/macos/Desktop/Sources/Generated/GeneratedToolExecutors.swift
+++ b/desktop/macos/Desktop/Sources/Generated/GeneratedToolExecutors.swift
@@ -40,7 +40,7 @@ enum GeneratedSwiftToolExecutor: String {
 
 enum GeneratedToolExecutors {
   static let manifestVersion = 1
-  static let manifestDigest = "sha256:f4fde1cce57e9e19d861354b22de28f92e6146514551f7b9cb38668ffb0906e0"
+  static let manifestDigest = "sha256:30c266133689612ba129f4bff932f5d936ab12fc38b412083bf25d9e868c127f"
 
   static let aliasToCanonical: [String: GeneratedSwiftTool] = [
     "search_screen_history": .semanticSearch,

--- a/desktop/macos/Desktop/Sources/Providers/ChatToolExecutor.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatToolExecutor.swift
@@ -594,9 +594,9 @@ class ChatToolExecutor {
       )
     }
     guard
-      let fileURL = performOwnerBoundPhysicalEffect(
+      let capture = performOwnerBoundPhysicalEffect(
         expectedOwnerID: expectedOwnerID,
-        effect: { ScreenCaptureManager.captureScreen() }) ?? nil
+        effect: { ScreenCaptureManager.captureScreenWithDetailTiles() }) ?? nil
     else {
       guard isExpectedOwnerCurrent(expectedOwnerID) else { return authorizedOwnerChangedResult() }
       ScreenContextToolTelemetry.trackToolResult(
@@ -614,7 +614,36 @@ class ChatToolExecutor {
       ok: true,
       permissionTCCGranted: true
     )
-    return fileURL.path
+    return captureScreenToolResult(
+      fullPath: capture.fullImageURL.path,
+      tiles: capture.tiles.map { (label: $0.label, rect: $0.rect, path: $0.url.path) }
+    )
+  }
+
+  /// Format the capture_screen tool result: the full-screen path first (the
+  /// original single-line contract), then native-resolution detail tiles. Vision
+  /// APIs downscale a full-Retina frame until dense UI text (product titles,
+  /// prices, labels) is illegible — the model then guesses instead of reading.
+  /// The tile listing tells it where to re-read at native sharpness. Pure and
+  /// nonisolated so it is hermetically testable.
+  nonisolated static func captureScreenToolResult(
+    fullPath: String,
+    tiles: [(label: String, rect: CGRect, path: String)]
+  ) -> String {
+    guard !tiles.isEmpty else { return fullPath }
+    var lines = [fullPath]
+    lines.append("")
+    lines.append(
+      "Detail tiles (native resolution). The full screenshot above gets downscaled before you see it, "
+        + "which can make small text unreadable. Before quoting or relying on small on-screen text "
+        + "(titles, prices, sizes, labels) or choosing between similar-looking items, Read the tile "
+        + "covering that part of the screen and take the exact text from it:")
+    for tile in tiles {
+      let r = tile.rect
+      lines.append(
+        "- \(tile.label) (x \(Int(r.minX))-\(Int(r.maxX)), y \(Int(r.minY))-\(Int(r.maxY))): \(tile.path)")
+    }
+    return lines.joined(separator: "\n")
   }
 
   private static func executeGetWorkContext(

--- a/desktop/macos/Desktop/Tests/ScreenCaptureDetailTileTests.swift
+++ b/desktop/macos/Desktop/Tests/ScreenCaptureDetailTileTests.swift
@@ -1,0 +1,103 @@
+import CoreGraphics
+import XCTest
+
+@testable import Omi_Computer
+
+/// Regression coverage for capture_screen detail tiles.
+///
+/// Vision APIs downscale images whose long edge exceeds ~1568 px, so a full-Retina
+/// screenshot arrives at the model too blurry to read dense UI text — it then guesses
+/// (e.g. conflating two similar product listings and citing the wrong size). The tool
+/// now emits native-resolution tiles the model can Read for exact text. These tests pin
+/// the partition math and the tool-result contract.
+final class ScreenCaptureDetailTileTests: XCTestCase {
+
+  // MARK: - Partition math
+
+  func testNoTilesWhenImageAlreadyFits() {
+    XCTAssertEqual(ScreenCaptureManager.detailTileRects(width: 1440, height: 900), [])
+    XCTAssertEqual(ScreenCaptureManager.detailTileRects(width: 1568, height: 1568), [])
+  }
+
+  func testDegenerateInputsProduceNoTiles() {
+    XCTAssertEqual(ScreenCaptureManager.detailTileRects(width: 0, height: 900), [])
+    XCTAssertEqual(ScreenCaptureManager.detailTileRects(width: 3000, height: -1), [])
+    XCTAssertEqual(ScreenCaptureManager.detailTileRects(width: 3000, height: 2000, maxLongEdge: 0), [])
+  }
+
+  func testRetinaLaptopDisplayTilesIntoLabeledQuadrants() {
+    // 14" MBP Retina: 3024x1964 -> 2x2 grid of 1512x982 native-resolution quadrants.
+    let tiles = ScreenCaptureManager.detailTileRects(width: 3024, height: 1964)
+    XCTAssertEqual(tiles.count, 4)
+    XCTAssertEqual(tiles.map(\.label), ["top-left", "top-right", "bottom-left", "bottom-right"])
+    for tile in tiles {
+      XCTAssertEqual(tile.rect.width, 1512)
+      XCTAssertEqual(tile.rect.height, 982)
+    }
+  }
+
+  func testWideDisplayTilesIntoLeftRightHalves() {
+    // 2560x1440: only the width exceeds the cap -> left/right halves, full height.
+    let tiles = ScreenCaptureManager.detailTileRects(width: 2560, height: 1440)
+    XCTAssertEqual(tiles.map(\.label), ["left", "right"])
+    XCTAssertEqual(tiles.map { Int($0.rect.width) }, [1280, 1280])
+    XCTAssertEqual(tiles.map { Int($0.rect.height) }, [1440, 1440])
+  }
+
+  func testTilesExactlyCoverTheImageAndRespectTheLongEdgeCap() {
+    // Property check across realistic display sizes, including odd dimensions and 5K.
+    let sizes = [(3024, 1964), (2560, 1440), (5120, 2880), (3456, 2234), (3137, 2001), (1569, 900)]
+    for (width, height) in sizes {
+      let tiles = ScreenCaptureManager.detailTileRects(width: width, height: height)
+      XCTAssertFalse(tiles.isEmpty, "\(width)x\(height) exceeds the cap and must tile")
+
+      var coveredArea = 0
+      for tile in tiles {
+        XCTAssertLessThanOrEqual(
+          Int(max(tile.rect.width, tile.rect.height)), ScreenCaptureManager.maxVisionTileLongEdge,
+          "tile \(tile.label) of \(width)x\(height) exceeds the vision long-edge cap")
+        XCTAssertGreaterThanOrEqual(tile.rect.minX, 0)
+        XCTAssertGreaterThanOrEqual(tile.rect.minY, 0)
+        XCTAssertLessThanOrEqual(Int(tile.rect.maxX), width)
+        XCTAssertLessThanOrEqual(Int(tile.rect.maxY), height)
+        coveredArea += Int(tile.rect.width) * Int(tile.rect.height)
+      }
+      // No gaps: within-bounds tiles whose areas sum to the full image, plus the
+      // pairwise-disjointness below, is an exact cover.
+      XCTAssertEqual(coveredArea, width * height, "\(width)x\(height) tiles must cover the image exactly")
+      for i in tiles.indices {
+        for j in tiles.indices where j > i {
+          let overlap = tiles[i].rect.intersection(tiles[j].rect)
+          XCTAssertTrue(
+            overlap.isNull || overlap.width == 0 || overlap.height == 0,
+            "tiles \(tiles[i].label) and \(tiles[j].label) overlap for \(width)x\(height)")
+        }
+      }
+    }
+  }
+
+  // MARK: - Tool-result contract
+
+  func testToolResultIsBarePathWhenThereAreNoTiles() {
+    // Small displays keep the original single-line contract exactly.
+    let result = ChatToolExecutor.captureScreenToolResult(fullPath: "/tmp/shot.webp", tiles: [])
+    XCTAssertEqual(result, "/tmp/shot.webp")
+  }
+
+  func testToolResultListsTilesWithPositionsAndLegibilityGuidance() {
+    let result = ChatToolExecutor.captureScreenToolResult(
+      fullPath: "/tmp/shot.webp",
+      tiles: [
+        (label: "top-left", rect: CGRect(x: 0, y: 0, width: 1512, height: 982), path: "/tmp/shot-top-left.webp"),
+        (label: "top-right", rect: CGRect(x: 1512, y: 0, width: 1512, height: 982), path: "/tmp/shot-top-right.webp"),
+      ]
+    )
+    let lines = result.components(separatedBy: "\n")
+    XCTAssertEqual(lines.first, "/tmp/shot.webp", "full-screen path must stay the first line")
+    XCTAssertTrue(result.contains("- top-left (x 0-1512, y 0-982): /tmp/shot-top-left.webp"))
+    XCTAssertTrue(result.contains("- top-right (x 1512-3024, y 0-982): /tmp/shot-top-right.webp"))
+    // The guidance that makes the model re-read small text from a tile instead of guessing.
+    XCTAssertTrue(result.contains("Read the tile"))
+    XCTAssertTrue(result.contains("titles, prices, sizes, labels"))
+  }
+}

--- a/desktop/macos/agent/src/runtime/omi-tool-manifest.ts
+++ b/desktop/macos/agent/src/runtime/omi-tool-manifest.ts
@@ -489,7 +489,7 @@ const swiftToolSurfacePatches: Record<string, OmiToolSurfacePatch> = {
       [
         "For screen-awareness questions, call get_work_context first.",
         "Use capture_screen only when raw pixels are necessary; it requires explicit approval before image bytes are shared.",
-        "After capture_screen returns a file path, use Read to view the image.",
+        "The result lists the full-screen image path plus native-resolution detail tiles on large screens; use Read to view them.",
       ],
     ),
   },
@@ -1016,12 +1016,14 @@ const swiftToolManifestDrafts: OmiToolManifestEntryDraft[] = [
     name: "capture_screen",
     label: "Capture Screen",
     description:
-      "Capture raw screenshot pixels only when get_work_context is insufficient. Returns the file path to the saved JPEG image after approval. Use the Read tool to view the image after capturing.",
+      "Capture raw screenshot pixels only when get_work_context is insufficient. Returns the saved full-screen image path plus native-resolution detail tiles on large screens, after approval. Use the Read tool to view the images after capturing.",
     promptSnippet: "capture_screen - Take a screenshot of the user's current screen",
     promptGuidelines: [
       "Call get_work_context first when the user asks about what's on their screen or what they're looking at.",
       "Use capture_screen only when raw pixels are necessary; it requires explicit approval before image bytes are shared.",
-      "After capture_screen returns a file path, use Read to view the image.",
+      "After capture_screen returns, use Read to view the full-screen image.",
+      "The full screenshot is downscaled before you see it — before quoting small on-screen text (titles, prices, sizes, labels) or choosing between similar-looking items, Read the detail tile covering that item and take the exact text from the tile.",
+      "Keep every detail you cite (title, price, badge, position) bound to one on-screen item; if text is not legible even in a tile, say so instead of inferring.",
       "Do NOT use bash screencapture - always use this tool instead.",
     ],
     latency: "fast local",

--- a/desktop/macos/agent/tests/fixtures/tool-manifest.json
+++ b/desktop/macos/agent/tests/fixtures/tool-manifest.json
@@ -3768,12 +3768,14 @@
   {
     "name": "capture_screen",
     "label": "Capture Screen",
-    "description": "Capture raw screenshot pixels only when get_work_context is insufficient. Returns the file path to the saved JPEG image after approval. Use the Read tool to view the image after capturing.",
+    "description": "Capture raw screenshot pixels only when get_work_context is insufficient. Returns the saved full-screen image path plus native-resolution detail tiles on large screens, after approval. Use the Read tool to view the images after capturing.",
     "promptSnippet": "capture_screen - Take a screenshot of the user's current screen",
     "promptGuidelines": [
       "Call get_work_context first when the user asks about what's on their screen or what they're looking at.",
       "Use capture_screen only when raw pixels are necessary; it requires explicit approval before image bytes are shared.",
-      "After capture_screen returns a file path, use Read to view the image.",
+      "After capture_screen returns, use Read to view the full-screen image.",
+      "The full screenshot is downscaled before you see it — before quoting small on-screen text (titles, prices, sizes, labels) or choosing between similar-looking items, Read the detail tile covering that item and take the exact text from the tile.",
+      "Keep every detail you cite (title, price, badge, position) bound to one on-screen item; if text is not legible even in a tile, say so instead of inferring.",
       "Do NOT use bash screencapture - always use this tool instead."
     ],
     "latency": "fast local",
@@ -3815,7 +3817,7 @@
       "bullets": [
         "For screen-awareness questions, call get_work_context first.",
         "Use capture_screen only when raw pixels are necessary; it requires explicit approval before image bytes are shared.",
-        "After capture_screen returns a file path, use Read to view the image."
+        "The result lists the full-screen image path plus native-resolution detail tiles on large screens; use Read to view them."
       ]
     }
   },

--- a/desktop/macos/changelog/unreleased/20260713-screen-capture-detail-tiles.json
+++ b/desktop/macos/changelog/unreleased/20260713-screen-capture-detail-tiles.json
@@ -1,0 +1,3 @@
+{
+  "change": "Improved chat accuracy when reading your screen: large screenshots now include close-up tiles so Omi reads small text like product titles and prices exactly instead of guessing"
+}

--- a/desktop/macos/e2e/flows/ptt-lifecycle.yaml
+++ b/desktop/macos/e2e/flows/ptt-lifecycle.yaml
@@ -14,6 +14,7 @@ covers:
   - desktop/macos/Desktop/Sources/RealtimeOmni/RealtimeOmniService.swift
   - desktop/macos/Desktop/Sources/RealtimeOmni/RealtimeOmniTestHarness.swift
   - desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
+  - desktop/macos/Desktop/Sources/FloatingControlBar/ScreenCaptureManager.swift
   - desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubSettings.swift
   - desktop/macos/Desktop/Sources/FloatingControlBar/VoiceTurnCoordinator.swift
   - desktop/macos/Desktop/Sources/FloatingControlBar/VoiceTurnStateMachine.swift


### PR DESCRIPTION
## Summary

Fixes a reported chat-quality failure: asked to compare bunk-bed listings on an Amazon results page, Omi chat recommended the "Overall Pick" item but cited it as "Twin over **Full**" when the actual listing is "Twin over **Twin**" — it fused the badge/price of one listing with the size from a *different* similar listing, and built its recommendation on the wrong size.

## Root cause

`capture_screen` saves the display at **full Retina resolution** (5+ MP) and the agent Reads that single image. Vision APIs downscale any image whose long edge exceeds ~1568 px to ~1.15 MP, so an entire Retina screenshot arrives ~2× blurred — dense UI text (product titles, prices, sizes) becomes illegible, and the model *infers* from partial glyphs instead of reading, conflating adjacent similar-looking items. Nothing in the pipeline gave it a way to re-read a region at legible sharpness, and nothing in the prompt told it to verify small text before quoting it.

## Fix

1. **Native-resolution detail tiles** (`ScreenCaptureManager`): `captureScreenWithDetailTiles()` writes the full frame plus a grid partition of native-resolution tiles whose long edge stays ≤ 1568 px (`detailTileRects` — pure, unit-tested math; exact cover, no gaps/overlaps; no tiling when the display already fits). A 3024×1964 Retina display yields 4 labeled quadrants (`top-left` …) that reach the model at native sharpness.
2. **Tool result lists the tiles** (`ChatToolExecutor`): `capture_screen` now returns the full-screen path first (original contract preserved — small displays return exactly the bare path as before) followed by each tile's position and path, with an inline instruction to Read the tile covering an item before quoting small text (`captureScreenToolResult` — pure, unit-tested formatter).
3. **Grounding guidance** (`omi-tool-manifest.ts`): the tool's prompt guidelines now tell the model that the full screenshot is downscaled; to Read the covering detail tile before quoting titles/prices/sizes/labels or choosing between similar items; and to keep every cited detail (title, price, badge, position) bound to one on-screen item — saying so rather than inferring when text is illegible. Regenerated the tool-surfaces codegen (`GeneratedToolCapabilities/Executors.swift`, `tool-manifest.json` fixture).

## Testing

- `ScreenCaptureDetailTileTests` (new, hermetic): partition math (Retina laptop → labeled quadrants; wide display → left/right halves; property check over 6 display sizes for exact cover, in-bounds, pairwise-disjoint, long-edge cap; degenerate inputs) and the tool-result contract (bare path with no tiles; positions + paths + legibility guidance with tiles).
- Agent Node suite: **502/502 pass** (run on this machine), including the tool-surfaces drift check against the regenerated snapshot (`generate-tool-surfaces.mjs --check` → all outputs match).
- Desktop static checkers green at head: `check_desktop_test_quality.py`, `check-sources-root-layout.py`, `check-e2e-flow-coverage.py --strict` (ScreenCaptureManager honestly covered via `ptt-lifecycle` — `RealtimeHubController` invokes it on the hub vision path; ChatToolExecutor via `chat-hermetic`), `desktop-flow-lint.py` (54 flows), `pr-preflight` (14 checks).
- Swift compile + XCTest run in `desktop-swift-ci` (no macOS toolchain in this sandbox). **The end-to-end quality claim (model reads titles correctly) needs a live A/B on a Mac** — quick recipe: build a named bundle, open a dense product grid, ask the floating chat to compare items, and check the reply quotes exact titles; the capture directory (`~/Documents/Omi/Screenshots`) should show `screenshot-<ts>-top-left.webp` etc. alongside the full frame.

## Product invariants affected

- **INV-AGENT-*** — path-based match (`agent/src/runtime/omi-tool-manifest.ts` under `agent/src/runtime/**`). The change edits only the `capture_screen` tool's description/prompt-guideline strings and the regenerated tool-surfaces snapshot; session/run/attempt identity, authority, and lifecycle are untouched, so no specific control-plane invariant is affected and no guard test changes.
- **INV-CHAT-1** — path-based match (`Providers/ChatToolExecutor.swift`, `FloatingControlBar/ScreenCaptureManager.swift`). The change alters only the `capture_screen` tool's *result payload* (file paths + tile listing) and the screenshot files written to disk; the kernel-owned transcript, single-provider write path, and viewport model are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RAxLsaxtwVNDTWAZFfJp9q)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9643?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

