### PR TITLE
fix(desktop): restore Gemini platform deadline

### DIFF
--- a/desktop/macos/Backend-Rust/src/routes/proxy.rs
+++ b/desktop/macos/Backend-Rust/src/routes/proxy.rs
@@ -51,15 +51,27 @@ const MAX_OUTPUT_TOKENS_CAP: u64 = 8192;
 /// explicitly on all production paths.
 const DEFAULT_THINKING_BUDGET: u64 = 1024;
 
-/// One end-to-end budget for non-streaming Gemini work. This deliberately leaves
-/// headroom below the observed ~90 second infrastructure boundary and includes
-/// token acquisition, provider selection/fallback, request send, and body drain.
-const GEMINI_TOTAL_TIMEOUT: Duration = Duration::from_secs(75);
+/// Cloud Run's configured request timeout for `desktop-backend`.
+const CLOUD_RUN_REQUEST_TIMEOUT: Duration = Duration::from_secs(300);
+
+/// Headroom reserved under the platform deadline so the proxy, rather than
+/// Cloud Run, owns timeout mapping and can return the typed, retryable
+/// `upstream_timeout` response.
+const GEMINI_PLATFORM_HEADROOM: Duration = Duration::from_secs(60);
+
+/// One end-to-end budget for non-streaming Gemini work. It derives from the
+/// Cloud Run request contract and includes token acquisition, provider
+/// selection/fallback, request send, and body drain. Long-context calls can
+/// legitimately spend more than 90 seconds thinking before their first byte.
+const GEMINI_TOTAL_TIMEOUT: Duration =
+    Duration::from_secs(CLOUD_RUN_REQUEST_TIMEOUT.as_secs() - GEMINI_PLATFORM_HEADROOM.as_secs());
 
 /// Per-attempt defense inside the logical budget. There are no post-dispatch
 /// retries: generateContent may have completed (and incurred cost) even when its
 /// response is lost, so replaying it is not known-safe.
-const GEMINI_ATTEMPT_TIMEOUT: Duration = Duration::from_secs(70);
+const GEMINI_ATTEMPT_HEADROOM: Duration = Duration::from_secs(5);
+const GEMINI_ATTEMPT_TIMEOUT: Duration =
+    Duration::from_secs(GEMINI_TOTAL_TIMEOUT.as_secs() - GEMINI_ATTEMPT_HEADROOM.as_secs());
 
 /// Bound TCP/TLS setup for all Gemini proxy calls. Streaming requests must not
 /// use a total response timeout because long SSE replies are expected.
@@ -1355,7 +1367,15 @@ mod tests {
     fn gemini_upstream_timeout_stays_below_cloud_run_deadline() {
         assert!(GEMINI_CONNECT_TIMEOUT < GEMINI_ATTEMPT_TIMEOUT);
         assert!(GEMINI_ATTEMPT_TIMEOUT < GEMINI_TOTAL_TIMEOUT);
-        assert!(GEMINI_TOTAL_TIMEOUT < Duration::from_secs(90));
+        assert!(GEMINI_TOTAL_TIMEOUT < CLOUD_RUN_REQUEST_TIMEOUT);
+        assert!(
+            CLOUD_RUN_REQUEST_TIMEOUT - GEMINI_TOTAL_TIMEOUT >= GEMINI_PLATFORM_HEADROOM,
+            "reserve enough time to flush the proxy-owned timeout response"
+        );
+        assert!(
+            GEMINI_TOTAL_TIMEOUT >= Duration::from_secs(180),
+            "long-context Gemini calls must not be cut off at the old 70-second deadline"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- restore the non-streaming Gemini proxy deadline from the Cloud Run request contract: 300 seconds minus 60 seconds of response headroom
- keep the newer single logical deadline, cancellation propagation, timeout classification, metering, and telemetry behavior intact
- guard against again reducing the end-to-end budget below 180 seconds or consuming the platform-response margin

Fixes #9524.

## Root cause and durable guard

A merge that preserved the newer proxy telemetry model also reintroduced a 75-second logical deadline and 70-second HTTP-client timeout. Cloud Run and the desktop client both allow 300 seconds, so the proxy was rejecting valid long-context Gemini calls around 70 seconds.

The timeout is now derived from the 300-second Cloud Run contract. The regression test asserts that it remains below the platform deadline with 60 seconds of response headroom and stays at least 180 seconds, while preserving the smaller per-attempt margin inside the total budget.

## Verification

- `cd desktop/macos/Backend-Rust && cargo test --locked` — 350 passed
- `cd desktop/macos/Backend-Rust && cargo check --locked` — passed
- `cd desktop/macos/Backend-Rust && cargo clippy --locked -- -D warnings` — passed
- `cd desktop/macos && bash test.sh` — launcher, Rust, and isolated Swift suites passed
- `make preflight` — passed; no locked product invariants apply
- `cd desktop/macos && OMI_APP_NAME="omi-issue-9524" OMI_SIGN_IDENTITY="-" OMI_ALLOW_ADHOC_SIGN=1 OMI_AUTOMATION_PORT=47996 ./run.sh --yolo` — named bundle built, signed, installed, launched, and was inspected through its automation bridge

The machine had no Omi Dev auth session to seed, so an authenticated real Gemini request could not be exercised locally. The proxy’s real cancellation path and deadline contract are covered by the Rust suite; no production traffic was changed.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9644?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

