### PR TITLE
fix(desktop): three crash-class traps (audio teardown, BLE parse, agent-VM upload) + chat code-mangling

### DIFF
--- a/desktop/macos/Desktop/Sources/AgentVMService.swift
+++ b/desktop/macos/Desktop/Sources/AgentVMService.swift
@@ -158,6 +158,15 @@ actor AgentVMService {
         await uploadDatabase(vmIP: vmIP, authToken: authToken)
     }
 
+    /// Compression ratio as a whole-number percent. Guards against a zero
+    /// original size: a 0-byte or unreadable `omi.db` (which still passes the
+    /// `fileExists` check and gzips to a non-empty stub) would otherwise trap on
+    /// unsigned integer division by zero and crash the app during upload.
+    static func compressionPercent(compressed: UInt64, original: UInt64) -> UInt64 {
+        guard original > 0 else { return 0 }
+        return compressed * 100 / original
+    }
+
     /// Upload the local omi.db (gzip-compressed) to the VM's /upload endpoint.
     /// Pauses AgentSync during upload to prevent competing for memory and network.
     private func uploadDatabase(vmIP: String, authToken: String) async {
@@ -219,7 +228,7 @@ actor AgentVMService {
 
             let compressedAttrs = try FileManager.default.attributesOfItem(atPath: tempGzPath.path)
             let compressedSize = compressedAttrs[.size] as? UInt64 ?? 0
-            log("AgentVMService: Compressed \(originalSize / 1024 / 1024) MB → \(compressedSize / 1024 / 1024) MB (\(compressedSize * 100 / originalSize)%)")
+            log("AgentVMService: Compressed \(originalSize / 1024 / 1024) MB → \(compressedSize / 1024 / 1024) MB (\(Self.compressionPercent(compressed: compressedSize, original: originalSize))%)")
         } catch {
             log("AgentVMService: Compression failed — \(error.localizedDescription)")
             try? FileManager.default.removeItem(at: tempGzPath)

--- a/desktop/macos/Desktop/Sources/AudioCaptureService.swift
+++ b/desktop/macos/Desktop/Sources/AudioCaptureService.swift
@@ -241,20 +241,23 @@ class AudioCaptureService: @unchecked Sendable {
             return
         }
 
-        self.onAudioChunk = onAudioChunk
-        self.onAudioLevel = onAudioLevel
         resetSilentMicWatchdog()
 
         // All CoreAudio HAL calls (AudioObjectGetPropertyData, AudioDeviceStart, etc.) are
         // synchronous IPC to coreaudiod via mach_msg. After wake from sleep the daemon can
         // take seconds to respond, blocking the caller. Dispatch the entire setup to audioQueue,
         // mirroring the pattern already used in stopCapture() and handleConfigurationChange().
+        // The callback assignments live on audioQueue too: the serial queue is the single
+        // owner of all state the HAL IO thread reads (callbacks, converter, formats), so a
+        // stop's deferred clear and a restart's fresh assignment can never interleave.
         try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
             audioQueue.async { [weak self] in
                 guard let self else {
                     continuation.resume()
                     return
                 }
+                self.onAudioChunk = onAudioChunk
+                self.onAudioLevel = onAudioLevel
                 do {
                     try self.startCaptureOnQueue()
                     continuation.resume()
@@ -356,23 +359,30 @@ class AudioCaptureService: @unchecked Sendable {
         deviceID = kAudioObjectUnknown
         isCapturing = false
         isReconfiguring = false
-        onAudioChunk = nil
-        onAudioLevel = nil
-
-        // Clean up converter
-        audioConverter = nil
-        inputFormat = nil
-        targetFormat = nil
-        detectedSampleRate = 0.0
-        smoothedLevel = 0.0
         isTrackingOverrideDevice = false
 
-        // AudioDeviceStop can block waiting for the IO thread — run off main thread
-        if let procID = procID, devID != kAudioObjectUnknown {
-            audioQueue.async {
+        // Do NOT release the state handleAudioInput reads (callbacks, converter,
+        // formats, detectedSampleRate) here: the CoreAudio HAL IO thread can still be
+        // inside handleAudioInput until AudioDeviceStop below returns, and nil-ing
+        // ARC references from the main thread races its reads (torn retain/release →
+        // intermittent crash on stop; detectedSampleRate=0 would divide-by-zero the
+        // resample math). The serial audioQueue quiesces the IOProc first and then
+        // clears; startCapture assigns this state on the same queue, so a stop's
+        // clear and a restart's fresh assignment can never interleave.
+        // AudioDeviceStop can block waiting for the IO thread — run off main thread.
+        audioQueue.async { [weak self] in
+            if let procID = procID, devID != kAudioObjectUnknown {
                 AudioDeviceStop(devID, procID)
                 AudioDeviceDestroyIOProcID(devID, procID)
             }
+            guard let self else { return }
+            self.onAudioChunk = nil
+            self.onAudioLevel = nil
+            self.audioConverter = nil
+            self.inputFormat = nil
+            self.targetFormat = nil
+            self.detectedSampleRate = 0.0
+            self.smoothedLevel = 0.0
         }
 
         log("AudioCapture: Stopped capturing")

--- a/desktop/macos/Desktop/Sources/Bluetooth/Connections/LimitlessDeviceConnection.swift
+++ b/desktop/macos/Desktop/Sources/Bluetooth/Connections/LimitlessDeviceConnection.swift
@@ -213,8 +213,9 @@ final class LimitlessDeviceConnection: BaseDeviceConnection {
                 let (length, newPos) = decodeVarint(payload, pos)
                 pos = newPos
 
-                let fieldData = Array(payload[pos..<min(pos + length, payload.count)])
-                pos += length
+                let fieldLength = Self.boundedFieldLength(length, at: pos, count: payload.count)
+                let fieldData = Array(payload[pos..<pos + fieldLength])
+                pos += fieldLength
 
                 if fieldNum == 2 {
                     handleStorageBuffer(fieldData)
@@ -255,10 +256,11 @@ final class LimitlessDeviceConnection: BaseDeviceConnection {
                 let (length, newPos) = decodeVarint(storageData, pos)
                 pos = newPos
 
+                let fieldLength = Self.boundedFieldLength(length, at: pos, count: storageData.count)
                 if fieldNum == 6 {
-                    flashPageData = Array(storageData[pos..<min(pos + length, storageData.count)])
+                    flashPageData = Array(storageData[pos..<pos + fieldLength])
                 }
-                pos += length
+                pos += fieldLength
             } else {
                 pos += 1
             }
@@ -723,16 +725,27 @@ final class LimitlessDeviceConnection: BaseDeviceConnection {
         return (result, pos)
     }
 
+    /// Clamps a protobuf length-delimited field length so both the payload slice
+    /// and the cursor advance are always in-bounds. A malformed varint can decode
+    /// to a negative value (a 10-byte varint sets bit 63 → `Int.min`) or a length
+    /// larger than the buffer; either would trap `Array(data[pos..<pos+length])`
+    /// or corrupt the cursor via `pos += length`. Returns the number of field
+    /// bytes to consume, always in `0...(count - pos)`.
+    static func boundedFieldLength(_ length: Int, at pos: Int, count: Int) -> Int {
+        guard length > 0, pos >= 0, pos < count else { return 0 }
+        return min(length, count - pos)
+    }
+
     // MARK: - BLE Packet Parsing
 
-    private struct BlePacket {
+    struct BlePacket {
         let index: Int
         let seq: Int
         let numFrags: Int
         let payload: [UInt8]
     }
 
-    private func parseBlePacket(_ data: [UInt8]) -> BlePacket? {
+    func parseBlePacket(_ data: [UInt8]) -> BlePacket? {
         var pos = 0
         var index: Int?
         var seq = 0
@@ -759,10 +772,11 @@ final class LimitlessDeviceConnection: BaseDeviceConnection {
                 let (length, newPos) = decodeVarint(data, pos)
                 pos = newPos
 
+                let fieldLength = Self.boundedFieldLength(length, at: pos, count: data.count)
                 if fieldNum == 4 {
-                    payload = Array(data[pos..<min(pos + length, data.count)])
+                    payload = Array(data[pos..<pos + fieldLength])
                 }
-                pos += length
+                pos += fieldLength
             } else {
                 break
             }

--- a/desktop/macos/Desktop/Sources/Bluetooth/Connections/LimitlessDeviceConnection.swift
+++ b/desktop/macos/Desktop/Sources/Bluetooth/Connections/LimitlessDeviceConnection.swift
@@ -712,12 +712,21 @@ final class LimitlessDeviceConnection: BaseDeviceConnection {
     }
 
     private func decodeVarint(_ data: [UInt8], _ startPos: Int) -> (Int, Int) {
+        // A base-128 varint for a 64-bit value is at most 10 bytes. Cap the read
+        // so a malformed packet that is all continuation bytes (high bit set)
+        // can't scan the entire buffer as one varint; the decoded value is still
+        // range-clamped by `boundedFieldLength` before it indexes anything.
+        // (Swift's `<<` is a non-trapping smart shift, so the shift itself is
+        // safe regardless — this cap is bounded-read hygiene, not a crash guard.)
+        let maxVarintBytes = 10
         var result = 0
         var shift = 0
         var pos = startPos
-        while pos < data.count {
+        var bytesRead = 0
+        while pos < data.count && bytesRead < maxVarintBytes {
             let byte = data[pos]
             pos += 1
+            bytesRead += 1
             result |= Int(byte & 0x7f) << shift
             if (byte & 0x80) == 0 { break }
             shift += 7

--- a/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
@@ -4852,7 +4852,7 @@ private var activeBridgeSendGeneration: Int?
     private func updateMessage(id: String, text: String) {
         if let index = messages.firstIndex(where: { $0.id == id }) {
             if messages[index].sender == .ai {
-                messages[index].text = normalizeAssistantSentenceSpacing(text)
+                messages[index].text = Self.normalizeAssistantSentenceSpacing(text)
             } else {
                 messages[index].text = text
             }
@@ -4861,7 +4861,49 @@ private var activeBridgeSendGeneration: Int?
 
     /// Normalize missing spaces after sentence punctuation in assistant messages.
     /// Example: "Hello.World" -> "Hello. World", "Great!Lets go" -> "Great! Lets go"
-    private func normalizeAssistantSentenceSpacing(_ text: String) -> String {
+    ///
+    /// Code spans are preserved verbatim so identifiers, file paths, and method
+    /// chains like `pd.DataFrame`, `System.IO`, or `foo.Bar()` are never mangled
+    /// into `pd. DataFrame`. Both fenced code blocks (``` / ~~~) and inline
+    /// backtick spans are skipped. Applied on every streaming flush, so it must
+    /// treat an unterminated span (fence or backtick still open mid-stream) as
+    /// code to avoid corrupting code that is still arriving.
+    static func normalizeAssistantSentenceSpacing(_ text: String) -> String {
+        let lines = text.components(separatedBy: "\n")
+        var output: [String] = []
+        output.reserveCapacity(lines.count)
+        var inFencedBlock = false
+
+        for line in lines {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            if trimmed.hasPrefix("```") || trimmed.hasPrefix("~~~") {
+                inFencedBlock.toggle()
+                output.append(line)  // fence marker line, verbatim
+            } else if inFencedBlock {
+                output.append(line)  // code content, verbatim
+            } else {
+                output.append(normalizeInlinePreservingCode(line))
+            }
+        }
+
+        return output.joined(separator: "\n")
+    }
+
+    /// Apply sentence-spacing normalization to a single line, leaving inline
+    /// backtick code spans untouched. An odd number of backticks (an unterminated
+    /// span) leaves its trailing content treated as code.
+    private static func normalizeInlinePreservingCode(_ line: String) -> String {
+        guard line.contains("`") else { return applySentenceSpacing(line) }
+
+        let parts = line.split(separator: "`", omittingEmptySubsequences: false)
+        let normalizedParts = parts.enumerated().map { index, part -> String in
+            // Even segments are outside inline code; odd segments are inside.
+            index.isMultiple(of: 2) ? applySentenceSpacing(String(part)) : String(part)
+        }
+        return normalizedParts.joined(separator: "`")
+    }
+
+    private static func applySentenceSpacing(_ text: String) -> String {
         var normalized = text
 
         if let punctuationUpper = try? NSRegularExpression(pattern: #"([.!?])(?=[A-Z])"#) {
@@ -4889,7 +4931,7 @@ private var activeBridgeSendGeneration: Int?
     private func flushStreamingBuffer() {
         streamingBuffer.flush(messages: &messages) { message, text in
             if message.sender == .ai {
-                return self.normalizeAssistantSentenceSpacing(text)
+                return Self.normalizeAssistantSentenceSpacing(text)
             }
             return text
         }
@@ -4918,7 +4960,7 @@ private var activeBridgeSendGeneration: Int?
             messages: &messages,
             normalizeText: { message, text in
             if message.sender == .ai {
-                return self.normalizeAssistantSentenceSpacing(text)
+                return Self.normalizeAssistantSentenceSpacing(text)
             }
             return text
             }
@@ -4944,7 +4986,7 @@ private var activeBridgeSendGeneration: Int?
             messages: &messages,
             normalizeText: { message, text in
             if message.sender == .ai {
-                return self.normalizeAssistantSentenceSpacing(text)
+                return Self.normalizeAssistantSentenceSpacing(text)
             }
             return text
             }
@@ -5182,7 +5224,7 @@ private var activeBridgeSendGeneration: Int?
             messages: &messages,
             normalizeText: { message, text in
             if message.sender == .ai {
-                return self.normalizeAssistantSentenceSpacing(text)
+                return Self.normalizeAssistantSentenceSpacing(text)
             }
             return text
             }

--- a/desktop/macos/Desktop/Sources/SystemAudioCaptureService.swift
+++ b/desktop/macos/Desktop/Sources/SystemAudioCaptureService.swift
@@ -100,19 +100,21 @@ class SystemAudioCaptureService: @unchecked Sendable {
             return
         }
 
-        self.onAudioChunk = onAudioChunk
-        self.onAudioLevel = onAudioLevel
-
         // All CoreAudio HAL calls (CreateTap, CreateAggregateDevice, AudioDeviceStart) are
         // synchronous IPC to coreaudiod via mach_msg. After wake from sleep the daemon can
         // take seconds to respond, blocking the caller. Dispatch the entire setup to audioQueue,
         // mirroring the pattern already used in stopCapture().
+        // The callback assignments live on audioQueue too: the serial queue is the single
+        // owner of all state the HAL IO thread reads (callbacks, converter, formats), so a
+        // stop's deferred clear and a restart's fresh assignment can never interleave.
         try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
             audioQueue.async { [weak self] in
                 guard let self else {
                     continuation.resume()
                     return
                 }
+                self.onAudioChunk = onAudioChunk
+                self.onAudioLevel = onAudioLevel
                 do {
                     try self.startCaptureOnQueue()
                     continuation.resume()
@@ -229,8 +231,6 @@ class SystemAudioCaptureService: @unchecked Sendable {
     func stopCapture() {
         guard isCapturing else { return }
         isCapturing = false
-        onAudioChunk = nil
-        onAudioLevel = nil
 
         // Capture values for background cleanup to avoid blocking main thread
         let procID = self.ioProcID
@@ -240,13 +240,17 @@ class SystemAudioCaptureService: @unchecked Sendable {
         self.ioProcID = nil
         self.aggregateDeviceID = kAudioObjectUnknown
         self.tapID = kAudioObjectUnknown
-        self.audioConverter = nil
-        self.inputFormat = nil
-        self.targetFormat = nil
-        self.sourceSampleRate = 0.0
 
-        // AudioDeviceStop can block — run off main thread
-        audioQueue.async {
+        // Do NOT release the state handleAudioInput reads (callbacks, converter,
+        // formats, sourceSampleRate) here: the CoreAudio HAL IO thread can still be
+        // inside handleAudioInput until AudioDeviceStop below returns, and nil-ing
+        // ARC references from the main thread races its reads (torn retain/release →
+        // intermittent crash on stop; sourceSampleRate=0 would divide-by-zero the
+        // resample math). The serial audioQueue quiesces the IOProc first and then
+        // clears; startCapture assigns this state on the same queue, so a stop's
+        // clear and a restart's fresh assignment can never interleave.
+        // AudioDeviceStop can block — run off main thread.
+        audioQueue.async { [weak self] in
             if let procID = procID, aggDevID != kAudioObjectUnknown {
                 AudioDeviceStop(aggDevID, procID)
                 AudioDeviceDestroyIOProcID(aggDevID, procID)
@@ -257,6 +261,13 @@ class SystemAudioCaptureService: @unchecked Sendable {
             if tID != kAudioObjectUnknown {
                 AudioHardwareDestroyProcessTap(tID)
             }
+            guard let self else { return }
+            self.onAudioChunk = nil
+            self.onAudioLevel = nil
+            self.audioConverter = nil
+            self.inputFormat = nil
+            self.targetFormat = nil
+            self.sourceSampleRate = 0.0
         }
 
         log("SystemAudioCapture: Stopped capturing")

--- a/desktop/macos/Desktop/Tests/AgentVMCompressionRatioTests.swift
+++ b/desktop/macos/Desktop/Tests/AgentVMCompressionRatioTests.swift
@@ -1,0 +1,30 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// Regression coverage for the agent-VM database upload log. The compression
+/// ratio was computed inline as `compressedSize * 100 / originalSize` (UInt64);
+/// a 0-byte or unreadable `omi.db` yields `originalSize == 0` yet still passes
+/// the `fileExists` guard and gzips to a non-empty stub, so execution reached the
+/// division and trapped on unsigned integer divide-by-zero, crashing the app on
+/// launch for signed-in users. `compressionPercent` now guards the divisor.
+final class AgentVMCompressionRatioTests: XCTestCase {
+
+    func testZeroOriginalSizeReturnsZeroInsteadOfTrapping() {
+        // Before the fix this line traps (UInt64 division by zero) and crashes.
+        XCTAssertEqual(AgentVMService.compressionPercent(compressed: 20, original: 0), 0)
+        XCTAssertEqual(AgentVMService.compressionPercent(compressed: 0, original: 0), 0)
+    }
+
+    func testTypicalCompressionRatios() {
+        XCTAssertEqual(AgentVMService.compressionPercent(compressed: 25, original: 100), 25)
+        XCTAssertEqual(AgentVMService.compressionPercent(compressed: 50, original: 200), 25)
+        // Whole-number (integer) percent, matching the original log semantics.
+        XCTAssertEqual(AgentVMService.compressionPercent(compressed: 1, original: 3), 33)
+    }
+
+    func testCompressedLargerThanOriginalIsNotClamped() {
+        // gzip on tiny inputs can exceed the original; the log just reports > 100%.
+        XCTAssertEqual(AgentVMService.compressionPercent(compressed: 40, original: 20), 200)
+    }
+}

--- a/desktop/macos/Desktop/Tests/ChatSentenceSpacingTests.swift
+++ b/desktop/macos/Desktop/Tests/ChatSentenceSpacingTests.swift
@@ -1,0 +1,100 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// Regression coverage for `ChatProvider.normalizeAssistantSentenceSpacing`.
+/// The normalizer inserts a space after sentence punctuation followed by an
+/// uppercase letter. Previously it ran over the whole message with no code
+/// awareness, so identifiers like `pd.DataFrame` or `System.IO` inside code were
+/// rewritten to `pd. DataFrame` / `System. IO` and — because the streamed text
+/// becomes the durable transcript — that corruption was persisted. The normalizer
+/// now preserves fenced blocks and inline backtick spans verbatim.
+@MainActor
+final class ChatSentenceSpacingTests: XCTestCase {
+
+    // MARK: - Prose (behavior preserved)
+
+    func testInsertsSpaceAfterSentencePunctuationInProse() {
+        XCTAssertEqual(ChatProvider.normalizeAssistantSentenceSpacing("Hello.World"), "Hello. World")
+        XCTAssertEqual(ChatProvider.normalizeAssistantSentenceSpacing("Great!Lets go"), "Great! Lets go")
+        XCTAssertEqual(ChatProvider.normalizeAssistantSentenceSpacing("Done?Then stop"), "Done? Then stop")
+    }
+
+    func testInsertsSpaceBeforeQuotedUppercase() {
+        XCTAssertEqual(
+            ChatProvider.normalizeAssistantSentenceSpacing("He said.\"Yes\""),
+            "He said. \"Yes\""
+        )
+    }
+
+    func testLeavesProperlySpacedProseUnchanged() {
+        let text = "This is fine. And so is this."
+        XCTAssertEqual(ChatProvider.normalizeAssistantSentenceSpacing(text), text)
+    }
+
+    // MARK: - Inline code (must not be mangled)
+
+    func testDoesNotMangleInlineCodeIdentifiers() {
+        XCTAssertEqual(
+            ChatProvider.normalizeAssistantSentenceSpacing("Use `pd.DataFrame` to load it"),
+            "Use `pd.DataFrame` to load it"
+        )
+        XCTAssertEqual(
+            ChatProvider.normalizeAssistantSentenceSpacing("Import `System.IO` first"),
+            "Import `System.IO` first"
+        )
+    }
+
+    func testNormalizesProseButPreservesInlineCodeOnSameLine() {
+        XCTAssertEqual(
+            ChatProvider.normalizeAssistantSentenceSpacing("Done.Call `a.Bar()` here.Next"),
+            "Done. Call `a.Bar()` here. Next"
+        )
+    }
+
+    func testUnterminatedInlineBacktickTreatsRemainderAsCode() {
+        // A backtick still open mid-stream: everything after it stays verbatim.
+        XCTAssertEqual(
+            ChatProvider.normalizeAssistantSentenceSpacing("See `x.Y"),
+            "See `x.Y"
+        )
+    }
+
+    // MARK: - Fenced code blocks (must not be mangled)
+
+    func testDoesNotMangleFencedCodeBlock() {
+        let input = """
+        Here is code.Read it:
+        ```python
+        df = pd.DataFrame()
+        obj.Method()
+        ```
+        Runs fine.Enjoy
+        """
+        let expected = """
+        Here is code. Read it:
+        ```python
+        df = pd.DataFrame()
+        obj.Method()
+        ```
+        Runs fine. Enjoy
+        """
+        XCTAssertEqual(ChatProvider.normalizeAssistantSentenceSpacing(input), expected)
+    }
+
+    func testUnterminatedFenceTreatsRemainderAsCode() {
+        let input = """
+        Intro.Text
+        ```swift
+        let x = Foo.Bar()
+        y.Baz()
+        """
+        let expected = """
+        Intro. Text
+        ```swift
+        let x = Foo.Bar()
+        y.Baz()
+        """
+        XCTAssertEqual(ChatProvider.normalizeAssistantSentenceSpacing(input), expected)
+    }
+}

--- a/desktop/macos/Desktop/Tests/LimitlessDeviceParsingTests.swift
+++ b/desktop/macos/Desktop/Tests/LimitlessDeviceParsingTests.swift
@@ -78,6 +78,26 @@ final class LimitlessDeviceParsingTests: XCTestCase {
         XCTAssertEqual(result?.payload ?? [], [0xAA, 0xBB, 0xCC])
     }
 
+    /// A length varint that is all continuation bytes (high bit set) with no
+    /// terminator. The 10-byte varint cap bounds the read so the parser can't
+    /// scan the whole buffer as one varint, and the clamped length keeps the
+    /// slice empty — no trap, no hang.
+    func testParseBlePacketSurvivesOverlongContinuationVarint() {
+        let connection = makeConnection()
+
+        var packet: [UInt8] = []
+        packet += [0x08, 0x01]                        // field 1 (index) = 1
+        packet += [0x18, 0x01]                        // field 3 (numFrags) = 1
+        packet += [0x22]                              // field 4 (payload), wireType 2
+        packet += Array(repeating: 0xFF, count: 20)   // 20 continuation bytes, no terminator
+
+        let result = connection.parseBlePacket(packet)
+
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.index, 1)
+        XCTAssertEqual(result?.payload.count, 0)
+    }
+
     // MARK: - Helpers
 
     private func makeConnection() -> LimitlessDeviceConnection {

--- a/desktop/macos/Desktop/Tests/LimitlessDeviceParsingTests.swift
+++ b/desktop/macos/Desktop/Tests/LimitlessDeviceParsingTests.swift
@@ -1,0 +1,89 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// Regression coverage for the protobuf length-delimited parsing in
+/// `LimitlessDeviceConnection`. A malformed varint length (a 10-byte varint sets
+/// bit 63 → `Int.min`, or a length larger than the buffer) previously trapped
+/// `Array(data[pos..<pos + length])` and corrupted the cursor via `pos += length`,
+/// crashing the app on a single corrupt BLE notification. The parser now clamps
+/// every field length through `boundedFieldLength`.
+@MainActor
+final class LimitlessDeviceParsingTests: XCTestCase {
+
+    // MARK: - boundedFieldLength (shared guard surface)
+
+    func testBoundedFieldLengthClampsNegativeToZero() {
+        // A 10-byte varint decodes to Int.min; the guard must reject it.
+        XCTAssertEqual(LimitlessDeviceConnection.boundedFieldLength(Int.min, at: 3, count: 16), 0)
+        XCTAssertEqual(LimitlessDeviceConnection.boundedFieldLength(-1, at: 0, count: 16), 0)
+    }
+
+    func testBoundedFieldLengthClampsOverlongToRemaining() {
+        // Claimed length exceeds the buffer → consume only the remaining bytes.
+        XCTAssertEqual(LimitlessDeviceConnection.boundedFieldLength(1_000_000, at: 4, count: 16), 12)
+        XCTAssertEqual(LimitlessDeviceConnection.boundedFieldLength(Int.max, at: 0, count: 8), 8)
+    }
+
+    func testBoundedFieldLengthPassesValidLengthThrough() {
+        XCTAssertEqual(LimitlessDeviceConnection.boundedFieldLength(5, at: 2, count: 16), 5)
+        XCTAssertEqual(LimitlessDeviceConnection.boundedFieldLength(4, at: 12, count: 16), 4)
+    }
+
+    func testBoundedFieldLengthGuardsCursorAtOrBeyondEnd() {
+        XCTAssertEqual(LimitlessDeviceConnection.boundedFieldLength(3, at: 16, count: 16), 0)
+        XCTAssertEqual(LimitlessDeviceConnection.boundedFieldLength(3, at: -1, count: 16), 0)
+    }
+
+    // MARK: - parseBlePacket end-to-end (real production parse path)
+
+    /// A field-4 (payload) length-delimited field whose length varint is a
+    /// 10-byte sequence decoding to a negative value. Before the fix this trapped
+    /// on the payload slice; now it must return without crashing.
+    func testParseBlePacketSurvivesNegativeLengthVarint() {
+        let connection = makeConnection()
+
+        var packet: [UInt8] = []
+        packet += [0x08, 0x05]  // field 1 (index) = 5
+        packet += [0x18, 0x01]  // field 3 (numFrags) = 1
+        packet += [0x22]        // field 4 (payload), wireType 2
+        // 10-byte varint: nine continuation bytes then a terminator that sets bit 63.
+        packet += Array(repeating: 0xFF, count: 9)
+        packet += [0x7F]
+
+        let result = connection.parseBlePacket(packet)
+
+        // The malformed length is clamped to zero → empty payload, no trap.
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.index, 5)
+        XCTAssertEqual(result?.numFrags, 1)
+        XCTAssertEqual(result?.payload.count, 0)
+    }
+
+    /// A payload length that overshoots the buffer must clamp to the remaining
+    /// bytes rather than trap.
+    func testParseBlePacketClampsOverlongPayloadLength() {
+        let connection = makeConnection()
+
+        var packet: [UInt8] = []
+        packet += [0x08, 0x02]        // field 1 (index) = 2
+        packet += [0x18, 0x01]        // field 3 (numFrags) = 1
+        packet += [0x22, 0x40]        // field 4 (payload), claimed length = 64
+        packet += [0xAA, 0xBB, 0xCC]  // only 3 bytes actually present
+
+        let result = connection.parseBlePacket(packet)
+
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.index, 2)
+        XCTAssertEqual(result?.payload ?? [], [0xAA, 0xBB, 0xCC])
+    }
+
+    // MARK: - Helpers
+
+    private func makeConnection() -> LimitlessDeviceConnection {
+        LimitlessDeviceConnection(
+            device: bluetoothReliabilityTestDevice,
+            transport: ReliabilityTestTransport(sessionGeneration: 1)
+        )
+    }
+}

--- a/desktop/macos/changelog/unreleased/20260713-agentvm-upload-crash.json
+++ b/desktop/macos/changelog/unreleased/20260713-agentvm-upload-crash.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed a crash on launch that could occur when preparing an empty local database for agent sync"
+}

--- a/desktop/macos/changelog/unreleased/20260713-audio-stop-teardown-race.json
+++ b/desktop/macos/changelog/unreleased/20260713-audio-stop-teardown-race.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed an intermittent crash when stopping recording caused by audio teardown racing the live capture thread"
+}

--- a/desktop/macos/changelog/unreleased/20260713-chat-code-spacing.json
+++ b/desktop/macos/changelog/unreleased/20260713-chat-code-spacing.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed chat answers inserting a stray space into code like <code>pd.DataFrame</code> when normalizing sentence spacing"
+}

--- a/desktop/macos/changelog/unreleased/20260713-limitless-ble-parse-crash.json
+++ b/desktop/macos/changelog/unreleased/20260713-limitless-ble-parse-crash.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed a crash that could occur when a paired BLE device sent a corrupt or malformed data packet"
+}

--- a/desktop/macos/e2e/flows/harness-smoke.yaml
+++ b/desktop/macos/e2e/flows/harness-smoke.yaml
@@ -14,6 +14,7 @@ covers:
   - desktop/macos/Desktop/Sources/ClientDeviceService.swift
   - desktop/macos/Desktop/Sources/LocalAgentAPIServer.swift
   - desktop/macos/Desktop/Sources/AgentSyncService.swift
+  - desktop/macos/Desktop/Sources/AgentVMService.swift
   - desktop/macos/Desktop/Sources/APIKeyService.swift
   - desktop/macos/Desktop/Sources/FileIndexing/FileIndexerService.swift
   - desktop/macos/Desktop/Sources/StartupWarmupCoordinator.swift


### PR DESCRIPTION
## What changed and why

Four independent desktop bug fixes found by a targeted crash/trap + chat-quality sweep. Three close process-terminating traps on malformed or edge-case input; the fourth stops chat from silently corrupting code in its answers.

1. **Audio teardown race** (`AudioCaptureService`, `SystemAudioCaptureService`) — stopping/reconfiguring capture cleared callback/converter/format state on the caller thread while the live CoreAudio IOProc (a real-time thread) was still reading it, a torn concurrent read/write. Teardown now runs single-owner on the capture serial queue after `AudioDeviceStop` drains the IOProc; the synchronous control-plane flags flip first so no new work is admitted.
2. **BLE protobuf length trap** (`LimitlessDeviceConnection`) — a malformed varint length in a device notification could decode to a negative value (a 10-byte varint sets bit 63 → `Int.min`) or exceed the buffer; the length-delimited field sites then trapped on `Array(data[pos..<pos+length])` and corrupted the cursor via `pos += length`, crashing on a single corrupt/hostile packet.
3. **Agent-VM upload divide-by-zero** (`AgentVMService`) — the compression-ratio log computed `compressedSize * 100 / originalSize` (UInt64); a 0-byte or unreadable `omi.db` passes the `fileExists` guard and gzips to a non-empty stub, so `originalSize == 0` reached the division and trapped, crashing on launch for signed-in users.
4. **Chat sentence-spacing mangles code** (`ChatProvider`) — `normalizeAssistantSentenceSpacing` inserts a space after sentence punctuation followed by an uppercase letter, but ran over the whole message with no code awareness, so `pd.DataFrame`/`System.IO`/`foo.Bar()` inside code became `pd. DataFrame` etc. The streamed text is the durable transcript, so the corruption was persisted and copied.

## Product invariants affected

- **INV-AUTH-1** — path-based match (`Providers/ChatProvider.swift`). The change is confined to the `normalizeAssistantSentenceSpacing` text helper; session death/ownership (`AuthSessionCoordinator`) and the auth surface are untouched, so no guard test changes.
- **INV-CHAT-1** — path-based match (`Providers/ChatProvider.swift`). The change alters only how assistant *text* is normalized before display/persistence; the kernel-owned transcript, single-writer journal path, projection, and viewport model are untouched. No new message store, identity format, or dual-write path is introduced.

## How it was verified

- Personally traced each defect through the production code path to a constructible triggering input (documented per fix in the commit bodies).
- Static checkers run locally at head, all green: `check_desktop_test_quality.py` (debt at/below baseline), `check-sources-root-layout.py` (baseline 77), `check-e2e-flow-coverage.py --strict` (all 5 changed Sources files covered), `desktop-flow-lint.py` (54 flows / 125 actions), `scripts/pr-preflight` (13 checks pass; invariants: INV-AUTH-1, INV-CHAT-1 — cited above).
- **Not run in this sandbox** (no macOS/Swift toolchain): `xcrun swift build` + the XCTest suite. Swift compile + the new tests run in `desktop-swift-ci`.
- **Needs a local run on a Mac before merge:** (a) an audio stop/start cycling test for the teardown-race fix (no hermetic seam for the real-time IOProc thread), and (b) the INV-6 continuity gauntlet for the `ChatProvider` touch (`agent-continuity-gauntlet.sh --suite continuity` on a named `omi-*` bundle) — the change is off the write-path semantics but the file is in-scope for the gauntlet gate.

## Tests

New hermetic regression tests, each executing the production API:

- `LimitlessDeviceParsingTests` — the shared `boundedFieldLength` guard (Int.min length, overlong length, in-range passthrough, cursor-at-end) plus the real `parseBlePacket` path on a negative-length and an overlong-length varint (would trap before the fix).
- `AgentVMCompressionRatioTests` — `compressionPercent` with a zero original size (the div-by-zero case), typical ratios, and compressed > original.
- `ChatSentenceSpacingTests` — prose normalization preserved; inline code (`pd.DataFrame`, `System.IO`) and fenced blocks not mangled; unterminated inline backtick and unterminated fence treated as code.
- The audio-race fix has no hermetic seam (real-time IOProc thread); see the local cycling test above.

## Root cause and durable guard (bug fixes)

- **Traps 2 & 3 share a class:** trusting a computed size/length before using it as an array bound or divisor. Each is closed with a pure, unit-tested guard helper at the boundary (`boundedFieldLength`, `compressionPercent`) rather than a call-site `if` — the helper is the single reusable surface all sites route through.
- **Trap 1 (audio):** the violated contract was single-ownership of capture state vs. the real-time IOProc. Fix makes the serial capture queue the sole owner of teardown, mirroring the earlier `SystemAudioCaptureService` deinit-deadlock fix (kept `deinit` on direct HAL teardown to avoid a `queue.sync` deadlock).
- **Chat mangling:** the normalizer violated "don't rewrite code spans." Durable guard is code-span awareness (fenced + inline), with the unterminated-span-is-code rule so streaming can't corrupt in-flight code; pinned by `ChatSentenceSpacingTests`.

## Scoped cleanups (optional)

None beyond the fixes above; each fix is its own commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RAxLsaxtwVNDTWAZFfJp9q)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9645?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

