### PR TITLE
fix: harden desktop update policy recovery

### DIFF
--- a/backend/database/desktop_update_policy.py
+++ b/backend/database/desktop_update_policy.py
@@ -1,7 +1,12 @@
 from typing import Any, Optional, cast
+from urllib.parse import urlparse
 
 from database._client import get_firestore_client
 
+# Keep the default live until the stable-promotion workflow has published the
+# static repair page. Operators can point an active recovery policy at that
+# immutable page once it exists; an absent or malformed policy must not send
+# clients to a not-yet-published route.
 DEFAULT_DESKTOP_DOWNLOAD_URL = "https://api.omi.me/v2/desktop/download/latest?channel=stable"
 VALID_DESKTOP_UPDATE_SEVERITIES = {"none", "banner", "required"}
 
@@ -39,7 +44,17 @@ def _as_string_list(value: Any) -> list[str]:
     return [item.strip() for item in narrowed if isinstance(item, str) and item.strip()]
 
 
-def _default_policy() -> dict[str, Any]:
+def _as_download_url(value: Any) -> Optional[str]:
+    candidate = _as_string(value)
+    if candidate is None:
+        return None
+    parsed = urlparse(candidate)
+    if parsed.scheme.lower() not in {"http", "https"} or not parsed.netloc:
+        return None
+    return candidate
+
+
+def default_desktop_update_policy() -> dict[str, Any]:
     return {
         "id": "current",
         "active": False,
@@ -55,7 +70,7 @@ def _default_policy() -> dict[str, Any]:
 
 
 def _normalize_policy(data: dict[str, Any]) -> dict[str, Any]:
-    policy = _default_policy()
+    policy = default_desktop_update_policy()
 
     severity = _as_string(data.get("severity")) or "none"
     if severity not in VALID_DESKTOP_UPDATE_SEVERITIES:
@@ -74,7 +89,7 @@ def _normalize_policy(data: dict[str, Any]) -> dict[str, Any]:
             "title": _as_string(data.get("title")),
             "message": _as_string(data.get("message")),
             "cta_text": _as_string(data.get("cta_text")) or policy["cta_text"],
-            "download_url": _as_string(data.get("download_url")) or policy["download_url"],
+            "download_url": _as_download_url(data.get("download_url")) or policy["download_url"],
             "can_dismiss": _as_bool(data.get("can_dismiss"), default=True),
             "platforms": _as_string_list(data.get("platforms")),
         }
@@ -96,19 +111,19 @@ def get_desktop_update_policy(
     client: Any = firestore_client if firestore_client is not None else get_firestore_client()
     doc = client.collection("desktop_update_policy").document("current").get()
     if not getattr(doc, "exists", False):
-        return _default_policy()
+        return default_desktop_update_policy()
 
     raw_doc: object = doc.to_dict()
     raw: dict[str, Any] = cast(dict[str, Any], raw_doc) if isinstance(raw_doc, dict) else {}
     policy = _normalize_policy(raw)
     if not _applies_to_platform(policy, platform):
-        return _default_policy()
+        return default_desktop_update_policy()
 
     maximum_build = policy.get("maximum_build_number")
     if current_build is not None and maximum_build is not None and current_build > maximum_build:
-        return _default_policy()
+        return default_desktop_update_policy()
 
     if not policy["active"]:
-        return _default_policy()
+        return default_desktop_update_policy()
 
     return policy

--- a/backend/routers/updates.py
+++ b/backend/routers/updates.py
@@ -10,7 +10,7 @@ from fastapi.responses import RedirectResponse, Response, HTMLResponse
 from pydantic import BaseModel, Field
 
 from database.desktop_update_channels import promote_channel, register_release_manifest
-from database.desktop_update_policy import get_desktop_update_policy
+from database.desktop_update_policy import default_desktop_update_policy, get_desktop_update_policy
 from database.redis_db import delete_generic_cache
 from utils.desktop_update_resolver import live_cache_key, resolve_pointer_release
 from utils.executors import db_executor, run_blocking
@@ -663,7 +663,21 @@ def get_desktop_update_policy_endpoint(
     ``desktop_update_policy/current`` to show a dismissible banner or a required
     manual-update prompt to future desktop clients.
     """
-    return get_desktop_update_policy(current_build=current_build, platform=platform)
+    try:
+        return get_desktop_update_policy(current_build=current_build, platform=platform)
+    except Exception as exc:
+        # The policy only accelerates manual recovery; clients still have the
+        # Sparkle appcast and stable manual download path when Firestore is unavailable.
+        logger.warning("desktop_update_policy_unavailable error_type=%s", type(exc).__name__)
+        record_fallback(
+            component="other",
+            from_mode="desktop_update_policy",
+            to_mode="desktop_update_appcast",
+            reason="other",
+            outcome="recovered",
+            log=logger,
+        )
+        return default_desktop_update_policy()
 
 
 @router.post("/v2/desktop/clear-cache", response_model=ClearCacheResponse)

--- a/backend/tests/unit/test_desktop_updates.py
+++ b/backend/tests/unit/test_desktop_updates.py
@@ -878,6 +878,27 @@ class TestDesktopUpdatePolicyEndpoint:
             resp = await client.get("/v2/desktop/update-policy?platform=ios")
         assert resp.status_code == 422
 
+    @pytest.mark.asyncio
+    async def test_firestore_failure_returns_inactive_policy_and_records_fallback(self):
+        with (
+            patch("routers.updates.get_desktop_update_policy", side_effect=RuntimeError("unavailable")),
+            patch("routers.updates.record_fallback") as fallback,
+        ):
+            async with AsyncClient(transport=ASGITransport(app=_test_app), base_url="http://test") as client:
+                resp = await client.get("/v2/desktop/update-policy?platform=macos&current_build=11400")
+
+        assert resp.status_code == 200
+        assert resp.json()["active"] is False
+        assert resp.json()["download_url"].endswith("/v2/desktop/download/latest?channel=stable")
+        fallback.assert_called_once_with(
+            component="other",
+            from_mode="desktop_update_policy",
+            to_mode="desktop_update_appcast",
+            reason="other",
+            outcome="recovered",
+            log=ANY,
+        )
+
 
 class TestDesktopUpdatePolicyDatabase:
     def _mock_doc(self, exists=True, data=None):
@@ -894,6 +915,22 @@ class TestDesktopUpdatePolicyDatabase:
 
         assert policy["active"] is False
         assert policy["severity"] == "none"
+        assert policy["download_url"].endswith("/v2/desktop/download/latest?channel=stable")
+
+    def test_invalid_policy_download_url_uses_stable_manual_download_path(self):
+        doc = self._mock_doc(
+            data={
+                "active": True,
+                "severity": "required",
+                "download_url": "file:///Applications/Omi.app",
+            }
+        )
+        mock_db = MagicMock()
+        mock_db.collection.return_value.document.return_value.get.return_value = doc
+
+        policy = get_desktop_update_policy(current_build=11400, firestore_client=mock_db)
+
+        assert policy["active"] is True
         assert policy["download_url"].endswith("/v2/desktop/download/latest?channel=stable")
 
     def test_required_policy_applies_through_maximum_build(self):

--- a/desktop/macos/Desktop/Sources/APIClient.swift
+++ b/desktop/macos/Desktop/Sources/APIClient.swift
@@ -4887,8 +4887,11 @@ struct UserProfileResponse: Codable {
 
 // MARK: - Desktop Update Policy Models
 
-struct DesktopUpdatePolicyResponse: Codable, Equatable {
-  enum Severity: String, Codable {
+struct DesktopUpdatePolicyResponse: Decodable, Equatable, Sendable {
+  static let stableManualDownloadURL = URL(
+    string: "https://api.omi.me/v2/desktop/download/latest?channel=stable")!
+
+  enum Severity: String, Codable, Sendable {
     case none
     case banner
     case required
@@ -4912,6 +4915,77 @@ struct DesktopUpdatePolicyResponse: Codable, Equatable {
     case ctaText = "cta_text"
     case downloadURL = "download_url"
     case canDismiss = "can_dismiss"
+  }
+
+  init(
+    id: String,
+    active: Bool,
+    severity: Severity,
+    maximumBuildNumber: Int?,
+    latestBuildNumber: Int?,
+    title: String?,
+    message: String?,
+    ctaText: String,
+    downloadURL: String,
+    canDismiss: Bool
+  ) {
+    self.id = id
+    self.active = active
+    self.severity = severity
+    self.maximumBuildNumber = maximumBuildNumber
+    self.latestBuildNumber = latestBuildNumber
+    self.title = title
+    self.message = message
+    self.ctaText = ctaText
+    self.downloadURL = Self.resolvedDownloadURL(from: downloadURL).absoluteString
+    self.canDismiss = canDismiss
+  }
+
+  init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    let id = Self.nonEmptyString(try? container.decode(String.self, forKey: .id)) ?? "current"
+    let active = (try? container.decode(Bool.self, forKey: .active)) ?? false
+    let severity = (try? container.decode(String.self, forKey: .severity))
+      .flatMap(Severity.init(rawValue:)) ?? .none
+    let maximumBuildNumber = try? container.decode(Int.self, forKey: .maximumBuildNumber)
+    let latestBuildNumber = try? container.decode(Int.self, forKey: .latestBuildNumber)
+    let title = Self.nonEmptyString(try? container.decode(String.self, forKey: .title))
+    let message = Self.nonEmptyString(try? container.decode(String.self, forKey: .message))
+    let ctaText = Self.nonEmptyString(try? container.decode(String.self, forKey: .ctaText))
+      ?? "Download latest"
+    let downloadURL = (try? container.decode(String.self, forKey: .downloadURL)) ?? ""
+    let canDismiss = (try? container.decode(Bool.self, forKey: .canDismiss)) ?? true
+
+    self.init(
+      id: id,
+      active: active,
+      severity: severity,
+      maximumBuildNumber: maximumBuildNumber,
+      latestBuildNumber: latestBuildNumber,
+      title: title,
+      message: message,
+      ctaText: ctaText,
+      downloadURL: downloadURL,
+      canDismiss: canDismiss
+    )
+  }
+
+  static func resolvedDownloadURL(from candidate: String?) -> URL {
+    guard let candidate = nonEmptyString(candidate),
+      let url = URL(string: candidate),
+      let scheme = url.scheme?.lowercased(),
+      ["http", "https"].contains(scheme),
+      url.host != nil
+    else {
+      return stableManualDownloadURL
+    }
+    return url
+  }
+
+  private static func nonEmptyString(_ value: String?) -> String? {
+    guard let value else { return nil }
+    let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+    return trimmed.isEmpty ? nil : trimmed
   }
 
   var isRequired: Bool {

--- a/desktop/macos/Desktop/Sources/DesktopUpdatePolicyManager.swift
+++ b/desktop/macos/Desktop/Sources/DesktopUpdatePolicyManager.swift
@@ -12,8 +12,34 @@ final class DesktopUpdatePolicyManager: ObservableObject {
   private var lastCheckAt = Date.distantPast
   private let minimumCheckInterval: TimeInterval = 5 * 60
   private let dismissedPrefix = "desktopUpdatePolicyDismissed."
+  private let fetchPolicy: (Int?) async throws -> DesktopUpdatePolicyResponse
+  private let currentBuildProvider: () -> Int?
+  private let now: () -> Date
+  private let defaults: UserDefaults
 
-  private init() {}
+  private init() {
+    fetchPolicy = { currentBuild in
+      try await APIClient.shared.getDesktopUpdatePolicy(currentBuild: currentBuild)
+    }
+    currentBuildProvider = {
+      guard let raw = Bundle.main.infoDictionary?["CFBundleVersion"] as? String else { return nil }
+      return Int(raw)
+    }
+    now = Date.init
+    defaults = .standard
+  }
+
+  init(
+    fetchPolicy: @escaping (Int?) async throws -> DesktopUpdatePolicyResponse,
+    currentBuildProvider: @escaping () -> Int? = { nil },
+    now: @escaping () -> Date = Date.init,
+    defaults: UserDefaults = .standard
+  ) {
+    self.fetchPolicy = fetchPolicy
+    self.currentBuildProvider = currentBuildProvider
+    self.now = now
+    self.defaults = defaults
+  }
 
   var visiblePolicy: DesktopUpdatePolicyResponse? {
     guard let policy, policy.active, policy.severity != .none else { return nil }
@@ -22,48 +48,47 @@ final class DesktopUpdatePolicyManager: ObservableObject {
   }
 
   func refresh(force: Bool = false) {
-    let now = Date()
-    guard force || now.timeIntervalSince(lastCheckAt) >= minimumCheckInterval else { return }
-    lastCheckAt = now
+    Task { await refreshNow(force: force) }
+  }
 
-    Task {
-      do {
-        let fetched = try await APIClient.shared.getDesktopUpdatePolicy(currentBuild: currentBuildNumber)
-        await MainActor.run {
-          self.policy = fetched.active ? fetched : nil
-        }
-      } catch {
-        log("DesktopUpdatePolicy: failed to fetch policy: \(error.localizedDescription)")
-      }
+  func refreshNow(force: Bool = false) async {
+    let currentTime = now()
+    guard force || currentTime.timeIntervalSince(lastCheckAt) >= minimumCheckInterval else { return }
+    lastCheckAt = currentTime
+
+    do {
+      let fetched = try await fetchPolicy(currentBuildProvider())
+      policy = fetched.active ? fetched : nil
+    } catch {
+      // Never preserve a stale required prompt when its control plane is down.
+      // Sparkle and the stable manual download path remain available independently.
+      policy = nil
+      log("DesktopUpdatePolicy: unavailable error_type=\(String(reflecting: type(of: error)))")
+      DesktopDiagnosticsManager.shared.recordFallback(
+        area: "other",
+        from: "desktop_update_policy",
+        to: "desktop_update_appcast",
+        reason: "other",
+        outcome: .recovered,
+        extra: ["user_visible": false]
+      )
     }
   }
 
   func dismiss(_ policy: DesktopUpdatePolicyResponse) {
     guard policy.canDismiss, !policy.isRequired else { return }
-    UserDefaults.standard.set(true, forKey: dismissedKey(for: policy))
+    defaults.set(true, forKey: dismissedKey(for: policy))
     if self.policy?.id == policy.id {
       self.policy = nil
     }
   }
 
   func openDownload(_ policy: DesktopUpdatePolicyResponse) {
-    guard let url = URL(string: policy.downloadURL),
-      let scheme = url.scheme?.lowercased(),
-      ["http", "https"].contains(scheme)
-    else {
-      log("DesktopUpdatePolicy: ignored invalid download URL")
-      return
-    }
-    NSWorkspace.shared.open(url)
-  }
-
-  private var currentBuildNumber: Int? {
-    guard let raw = Bundle.main.infoDictionary?["CFBundleVersion"] as? String else { return nil }
-    return Int(raw)
+    NSWorkspace.shared.open(DesktopUpdatePolicyResponse.resolvedDownloadURL(from: policy.downloadURL))
   }
 
   private func isDismissed(_ policy: DesktopUpdatePolicyResponse) -> Bool {
-    UserDefaults.standard.bool(forKey: dismissedKey(for: policy))
+    defaults.bool(forKey: dismissedKey(for: policy))
   }
 
   private func dismissedKey(for policy: DesktopUpdatePolicyResponse) -> String {

--- a/desktop/macos/Desktop/Tests/DesktopUpdatePolicyManagerTests.swift
+++ b/desktop/macos/Desktop/Tests/DesktopUpdatePolicyManagerTests.swift
@@ -1,0 +1,95 @@
+import Foundation
+import XCTest
+
+@testable import Omi_Computer
+
+@MainActor
+final class DesktopUpdatePolicyManagerTests: XCTestCase {
+  private enum FetchError: Error {
+    case unavailable
+  }
+
+  private actor PolicySequence {
+    private var results: [Result<DesktopUpdatePolicyResponse, FetchError>]
+
+    init(_ results: [Result<DesktopUpdatePolicyResponse, FetchError>]) {
+      self.results = results
+    }
+
+    func next() throws -> DesktopUpdatePolicyResponse {
+      try results.removeFirst().get()
+    }
+  }
+
+  func testMalformedRequiredPolicyUsesStableManualRecoveryPage() throws {
+    let data = Data(
+      """
+      {
+        "id": "legacy-repair",
+        "active": true,
+        "severity": "required",
+        "download_url": "file:///Applications/Omi.app",
+        "can_dismiss": false
+      }
+      """.utf8
+    )
+
+    let policy = try JSONDecoder().decode(DesktopUpdatePolicyResponse.self, from: data)
+
+    XCTAssertTrue(policy.isRequired)
+    XCTAssertEqual(policy.downloadURL, DesktopUpdatePolicyResponse.stableManualDownloadURL.absoluteString)
+    XCTAssertFalse(policy.canDismiss)
+  }
+
+  func testMalformedPolicyCannotBecomeBlocking() throws {
+    let data = Data(
+      """
+      {
+        "id": 42,
+        "active": "yes",
+        "severity": "critical",
+        "cta_text": 7,
+        "download_url": "javascript:alert(1)"
+      }
+      """.utf8
+    )
+
+    let policy = try JSONDecoder().decode(DesktopUpdatePolicyResponse.self, from: data)
+
+    XCTAssertFalse(policy.active)
+    XCTAssertEqual(policy.severity, .none)
+    XCTAssertEqual(policy.ctaText, "Download latest")
+    XCTAssertEqual(policy.downloadURL, DesktopUpdatePolicyResponse.stableManualDownloadURL.absoluteString)
+  }
+
+  func testUnavailableRefreshClearsStaleRequiredPolicy() async {
+    let required = DesktopUpdatePolicyResponse(
+      id: "legacy-repair",
+      active: true,
+      severity: .required,
+      maximumBuildNumber: 11507,
+      latestBuildNumber: 12070,
+      title: "Update required",
+      message: "Install the latest Omi desktop app.",
+      ctaText: "Download latest",
+      downloadURL: DesktopUpdatePolicyResponse.stableManualDownloadURL.absoluteString,
+      canDismiss: false
+    )
+    let sequence = PolicySequence([.success(required), .failure(.unavailable)])
+    let suiteName = "DesktopUpdatePolicyManagerTests-\(UUID().uuidString)"
+    let defaults = UserDefaults(suiteName: suiteName)!
+    defer { defaults.removePersistentDomain(forName: suiteName) }
+    let manager = DesktopUpdatePolicyManager(
+      fetchPolicy: { _ in try await sequence.next() },
+      currentBuildProvider: { 11400 },
+      now: { Date(timeIntervalSince1970: 1_700_000_000) },
+      defaults: defaults
+    )
+
+    await manager.refreshNow(force: true)
+    XCTAssertEqual(manager.visiblePolicy?.id, "legacy-repair")
+
+    await manager.refreshNow(force: true)
+    XCTAssertNil(manager.visiblePolicy)
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260714-update-policy-recovery.json
+++ b/desktop/macos/changelog/unreleased/20260714-update-policy-recovery.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed macOS update recovery so a broken update notice or failed policy check still gives you a working stable download path."
+}


### PR DESCRIPTION
## Summary

- Fail open when the desktop update-policy control plane is unavailable, preserving Sparkle and the stable manual download path.
- Reject malformed policy URLs in both the backend and macOS client, and make malformed policy payloads non-blocking.
- Clear a previously displayed required prompt if a subsequent policy refresh fails, with recovery telemetry and regression coverage.

## Root cause and durable guard

The update-policy control plane was able to leave desktop clients with a stale blocking prompt or an unusable download target when Firestore or policy data failed. The backend now returns an inactive safe default on control-plane failure; the client decodes policy data defensively, verifies HTTP(S) download targets, and clears stale policy state on refresh failure. Tests cover the backend fault boundary, malformed payloads, and stale-required-prompt recovery.

## Product invariants affected

- INV-AUTH-1

`APIClient.swift` is a path-glob match only. This change does not alter session invalidation, 401 handling, credentials, or authenticated-surface gating.

## Verification

- `cd backend && /private/tmp/omi-9528-venv/bin/pytest -q tests/unit/test_desktop_updates.py tests/unit/test_desktop_update_channels.py tests/unit/test_desktop_update_resolver.py` — 101 passed
- `cd desktop/macos && xcrun swift test --package-path Desktop --filter 'DesktopUpdatePolicyManagerTests|UpdateFailureDiagnosticsTests|UpdateRelaunchWindowPolicyTests'` — 17 passed
- `cd desktop/macos && python3 scripts/check_desktop_test_quality.py` — passed
- `make preflight` with this PR body — passed
- Built and launched the isolated named bundle `omi-update-policy-recovery`; the local automation bridge was reachable. The environment has no reusable signed-in session, so the authenticated banner could not be exercised end to end.

## Release gate

Live discovery on 2026-07-14 found the configured static repair page returning 404 while the stable dynamic download endpoint and appcast were healthy. This PR deliberately retains the verified stable endpoint as the safe fallback. Publish and verify the static repair page through the normal stable-promotion workflow, then validate a relaunch into the target build before closing the umbrella issue.

Refs #9528


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9647?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

