### PR TITLE
fix(desktop): guard audio-capture resample math against divide-by-zero traps

### DIFF
--- a/desktop/macos/Desktop/Sources/AudioCaptureService.swift
+++ b/desktop/macos/Desktop/Sources/AudioCaptureService.swift
@@ -506,6 +506,18 @@ class AudioCaptureService: @unchecked Sendable {
         return status == noErr ? format : nil
     }
 
+    /// Frames a `sourceSampleRate`→`targetSampleRate` conversion of `frameCount` input
+    /// frames produces. Returns 0 when the source rate is unknown (0): dividing by a
+    /// zero rate yields `.infinity`, and `AVAudioFrameCount(.infinity)` traps the
+    /// real-time IOProc thread — reachable when a device reports no rate at start or
+    /// `stopCapture` zeroes `detectedSampleRate` mid-callback. Pure math, unit-testable.
+    static func resampledFrameCapacity(
+        frameCount: AVAudioFrameCount, sourceSampleRate: Double, targetSampleRate: Double
+    ) -> AVAudioFrameCount {
+        guard frameCount > 0, sourceSampleRate > 0, targetSampleRate > 0 else { return 0 }
+        return AVAudioFrameCount(ceil(Double(frameCount) * targetSampleRate / sourceSampleRate))
+    }
+
     /// Handle incoming audio data from the IOProc callback
     private func handleAudioInput(_ inputData: UnsafePointer<AudioBufferList>?, timestamp: UnsafePointer<AudioTimeStamp>?) {
         guard isCapturing,
@@ -518,6 +530,7 @@ class AudioCaptureService: @unchecked Sendable {
         guard let data = buffer.mData, buffer.mDataByteSize > 0 else { return }
 
         let bytesPerFrame = UInt32(MemoryLayout<Float32>.size) * buffer.mNumberChannels
+        guard bytesPerFrame > 0 else { return }
         let frameCount = buffer.mDataByteSize / bytesPerFrame
         guard frameCount > 0 else { return }
 
@@ -543,8 +556,10 @@ class AudioCaptureService: @unchecked Sendable {
         }
 
         // Convert to target format (16kHz mono)
-        let outputFrameCapacity = AVAudioFrameCount(ceil(Double(frameCount) * targetSampleRate / detectedSampleRate))
-        guard let outputBuffer = AVAudioPCMBuffer(pcmFormat: targetFmt, frameCapacity: outputFrameCapacity) else { return }
+        let outputFrameCapacity = Self.resampledFrameCapacity(
+            frameCount: frameCount, sourceSampleRate: detectedSampleRate, targetSampleRate: targetSampleRate)
+        guard outputFrameCapacity > 0,
+              let outputBuffer = AVAudioPCMBuffer(pcmFormat: targetFmt, frameCapacity: outputFrameCapacity) else { return }
 
         var error: NSError?
         var hasConsumedInput = false

--- a/desktop/macos/Desktop/Sources/SystemAudioCaptureService.swift
+++ b/desktop/macos/Desktop/Sources/SystemAudioCaptureService.swift
@@ -309,6 +309,18 @@ class SystemAudioCaptureService: @unchecked Sendable {
         )
     }
 
+    /// Frames a `sourceSampleRate`→`targetSampleRate` conversion of `frameCount` input
+    /// frames produces. Returns 0 when the source rate is unknown (0): dividing by a
+    /// zero rate yields `.infinity`, and `AVAudioFrameCount(.infinity)` traps the
+    /// real-time tap thread — reachable when the tap reports no rate at start or
+    /// `stopCapture` zeroes `sourceSampleRate` mid-callback. Pure math, unit-testable.
+    static func resampledFrameCapacity(
+        frameCount: AVAudioFrameCount, sourceSampleRate: Double, targetSampleRate: Double
+    ) -> AVAudioFrameCount {
+        guard frameCount > 0, sourceSampleRate > 0, targetSampleRate > 0 else { return 0 }
+        return AVAudioFrameCount(ceil(Double(frameCount) * targetSampleRate / sourceSampleRate))
+    }
+
     /// Handle incoming audio data from the tap
     private func handleAudioInput(_ inputData: UnsafePointer<AudioBufferList>?, timestamp: UnsafePointer<AudioTimeStamp>?) {
         guard isCapturing,
@@ -323,6 +335,7 @@ class SystemAudioCaptureService: @unchecked Sendable {
 
         // Calculate frame count
         let bytesPerFrame = UInt32(MemoryLayout<Float32>.size) * buffer.mNumberChannels
+        guard bytesPerFrame > 0 else { return }
         let frameCount = buffer.mDataByteSize / bytesPerFrame
 
         guard frameCount > 0 else { return }
@@ -355,8 +368,10 @@ class SystemAudioCaptureService: @unchecked Sendable {
         }
 
         // Calculate output frame count based on sample rate conversion
-        let outputFrameCapacity = AVAudioFrameCount(ceil(Double(frameCount) * targetSampleRate / sourceSampleRate))
-        guard let outputBuffer = AVAudioPCMBuffer(pcmFormat: targetFmt, frameCapacity: outputFrameCapacity) else { return }
+        let outputFrameCapacity = Self.resampledFrameCapacity(
+            frameCount: frameCount, sourceSampleRate: sourceSampleRate, targetSampleRate: targetSampleRate)
+        guard outputFrameCapacity > 0,
+              let outputBuffer = AVAudioPCMBuffer(pcmFormat: targetFmt, frameCapacity: outputFrameCapacity) else { return }
 
         // Convert using input block pattern
         var error: NSError?

--- a/desktop/macos/Desktop/Tests/AudioCaptureResampleCapacityTests.swift
+++ b/desktop/macos/Desktop/Tests/AudioCaptureResampleCapacityTests.swift
@@ -1,0 +1,60 @@
+import AVFoundation
+import XCTest
+
+@testable import Omi_Computer
+
+/// Regression coverage for the sample-rate conversion capacity math in the real-time
+/// audio IOProc/tap callbacks.
+///
+/// Both capture services computed `AVAudioFrameCount(ceil(frameCount * target / source))`
+/// inline. When the source rate was 0 — a device reporting no rate at start, or
+/// `stopCapture` zeroing the shared rate mid-callback on the lock-free `@unchecked
+/// Sendable` service — the division yields `.infinity`, and `AVAudioFrameCount(.infinity)`
+/// traps the process ("Double value cannot be converted to UInt32 because it is either
+/// infinite or NaN"). The extracted helper returns 0 for that case so the callback bails
+/// out instead of crashing.
+final class AudioCaptureResampleCapacityTests: XCTestCase {
+    func testMicZeroSourceRateReturnsZeroInsteadOfTrapping() {
+        XCTAssertEqual(
+            AudioCaptureService.resampledFrameCapacity(
+                frameCount: 480, sourceSampleRate: 0, targetSampleRate: 16000),
+            0)
+    }
+
+    @available(macOS 14.4, *)
+    func testSystemAudioZeroSourceRateReturnsZeroInsteadOfTrapping() {
+        XCTAssertEqual(
+            SystemAudioCaptureService.resampledFrameCapacity(
+                frameCount: 512, sourceSampleRate: 0, targetSampleRate: 16000),
+            0)
+        // 44.1kHz -> 16kHz rounds up (ceil) to avoid a short output buffer.
+        XCTAssertEqual(
+            SystemAudioCaptureService.resampledFrameCapacity(
+                frameCount: 441, sourceSampleRate: 44100, targetSampleRate: 16000),
+            160)
+    }
+
+    func testZeroFrameCountOrTargetReturnsZero() {
+        XCTAssertEqual(
+            AudioCaptureService.resampledFrameCapacity(
+                frameCount: 0, sourceSampleRate: 48000, targetSampleRate: 16000),
+            0)
+        XCTAssertEqual(
+            AudioCaptureService.resampledFrameCapacity(
+                frameCount: 480, sourceSampleRate: 48000, targetSampleRate: 0),
+            0)
+    }
+
+    func testDownsampleAndUpsampleRoundUp() {
+        // 48kHz -> 16kHz: 480 frames -> 160.
+        XCTAssertEqual(
+            AudioCaptureService.resampledFrameCapacity(
+                frameCount: 480, sourceSampleRate: 48000, targetSampleRate: 16000),
+            160)
+        // Upsample 8kHz -> 16kHz doubles the frames.
+        XCTAssertEqual(
+            AudioCaptureService.resampledFrameCapacity(
+                frameCount: 100, sourceSampleRate: 8000, targetSampleRate: 16000),
+            200)
+    }
+}

--- a/desktop/macos/changelog/unreleased/20260713-audio-capture-rate-crash.json
+++ b/desktop/macos/changelog/unreleased/20260713-audio-capture-rate-crash.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed a rare crash when stopping a recording or changing audio devices mid-capture"
+}


### PR DESCRIPTION
## Bug
Both `AudioCaptureService` (mic) and `SystemAudioCaptureService` (system audio) can **crash the whole app** during normal use — stopping a recording, a meeting ending, or unplugging/switching an audio device mid-capture.

## Root cause
Each real-time IOProc/tap callback computed the converter output capacity inline:
```swift
let outputFrameCapacity = AVAudioFrameCount(ceil(Double(frameCount) * targetSampleRate / detectedSampleRate))
```
When the source sample rate is `0`, `x / 0.0 == .infinity`, and `AVAudioFrameCount(.infinity)` (a `UInt32` conversion) **traps**: *"Double value cannot be converted to UInt32 because it is either infinite or NaN."*

The rate is legitimately `0` in two normal-use windows on these lock-free `@unchecked Sendable` services:
- **Initial start** assigns `detectedSampleRate`/`sourceSampleRate = streamFormat.mSampleRate` with **no `> 0` guard** — unlike the already-hardened *reconfigure* path (`guard streamFormat.mSampleRate > 0 …`).
- **`stopCapture` zeroes the rate** while a callback that already passed its `isCapturing` entry guard is still running on the real-time thread → the divisor is read as `0` mid-flight.

The same callbacks also divided `mDataByteSize / bytesPerFrame` **before** guarding, which traps on a 0-channel buffer (aggregate/virtual devices).

## Fix (closes the divide-by-zero class in both callbacks)
- Extract `resampledFrameCapacity(frameCount:sourceSampleRate:targetSampleRate:)` on each service — pure, unit-testable, returns `0` when any input is `0`. Callers now bail via `guard outputFrameCapacity > 0`.
- Guard `bytesPerFrame > 0` before the frame-count division.
- Add `AudioCaptureResampleCapacityTests` pinning the zero-rate / zero-frame cases and up/down-sample rounding.

## Verification
- `xcrun swift build -c debug --package-path Desktop` → **Build complete**.
- `xcrun swift test --filter AudioCaptureResampleCapacityTests` → **4/4 pass**.
- No Sentry access from the watchdog runner, so I did not confirm this as a currently-firing top crasher — hence PR-only, not auto-merged.

🤖 automated by hourly watchdog; opened for review, not merged.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9649?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

