### PR TITLE
fix(memory): persist maintenance job runtime contract

### DIFF
--- a/.github/workflows/gcp_memory_maintenance_job.yml
+++ b/.github/workflows/gcp_memory_maintenance_job.yml
@@ -112,7 +112,7 @@ jobs:
           region: ${{ env.REGION }}
           project_id: ${{ vars.GCP_PROJECT_ID }}
           image: gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}:${{ steps.image-tag.outputs.short_sha }}
-          flags: ${{ steps.runtime-env.outputs.cloud_run_flags }}
+          flags: ${{ steps.runtime-env.outputs.cloud_run_flags }} ${{ steps.runtime-env.outputs.memory_maintenance_job_flags }}
           env_vars: ${{ steps.runtime-env.outputs.memory_maintenance_job_env_vars }}
           secrets: ${{ steps.runtime-env.outputs.memory_maintenance_job_secrets }}
 

--- a/.github/workflows/gcp_memory_maintenance_job_auto_dev.yml
+++ b/.github/workflows/gcp_memory_maintenance_job_auto_dev.yml
@@ -87,7 +87,7 @@ jobs:
           region: ${{ env.REGION }}
           project_id: ${{ vars.GCP_PROJECT_ID }}
           image: gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}:${{ steps.image-tag.outputs.short_sha }}
-          flags: ${{ steps.runtime-env.outputs.cloud_run_flags }}
+          flags: ${{ steps.runtime-env.outputs.cloud_run_flags }} ${{ steps.runtime-env.outputs.memory_maintenance_job_flags }}
           env_vars: ${{ steps.runtime-env.outputs.memory_maintenance_job_env_vars }}
           secrets: ${{ steps.runtime-env.outputs.memory_maintenance_job_secrets }}
 

--- a/backend/deploy/runtime_env.yaml
+++ b/backend/deploy/runtime_env.yaml
@@ -428,6 +428,12 @@ environments:
               secret: PINECONE_API_KEY
               version: latest
         memory-maintenance-job:
+          # Keep the known-good dev maintenance capacity in the checked-in deploy contract.
+          # These must not rely on a prior Cloud Run revision retaining live-only patches.
+          flags:
+            --task-timeout: 3600s
+            --cpu: '2'
+            --memory: 2Gi
           env:
             GOOGLE_CLOUD_PROJECT:
               value: based-hardware
@@ -455,6 +461,9 @@ environments:
               category: memory_rollout
             MEMORY_TYPESENSE_COLLECTION:
               value: canonical_memory_atoms
+              category: memory_rollout
+            TYPESENSE_HOST_PORT:
+              value: '443'
               category: memory_rollout
             PINECONE_INDEX_NAME:
               value: memories-backend-dev

--- a/backend/scripts/render_backend_runtime_env.py
+++ b/backend/scripts/render_backend_runtime_env.py
@@ -45,6 +45,7 @@ def main() -> int:
         if job_config is None:
             raise ValueError(f'Cloud Run job {job} must be a mapping')
         output_prefix = _output_prefix(job)
+        _emit_output(f'{output_prefix}_flags', _render_flags(_as_config_dict(job_config.get('flags')) or {}))
         _emit_output(f'{output_prefix}_env_vars', _render_env_vars(job_config.get('env', {})))
         _emit_output(f'{output_prefix}_secrets', _render_secrets(job_config.get('secrets', {})))
         _emit_output(f'{output_prefix}_secret_names', _render_secret_names(job_config.get('secrets', {})))

--- a/backend/scripts/validate-backend-runtime-env.py
+++ b/backend/scripts/validate-backend-runtime-env.py
@@ -42,6 +42,11 @@ _NOTIFICATIONS_JOB_FORBIDDEN_MEMORY_ENV = frozenset(
 _NOTIFICATIONS_JOB_FORBIDDEN_MEMORY_SECRETS = frozenset({'TYPESENSE_HOST', 'TYPESENSE_API_KEY'})
 _SYNC_LEDGER_FENCE_SERVICES = ('backend', 'backend-sync', 'backend-sync-backfill')
 _SYNC_LEDGER_FENCE_MODES = frozenset({'legacy', 'standby', 'active'})
+_MEMORY_MAINTENANCE_DEV_REQUIRED_FLAGS = {
+    '--task-timeout': '3600s',
+    '--cpu': '2',
+    '--memory': '2Gi',
+}
 
 
 def _as_config_dict(value: object) -> ConfigDict | None:
@@ -460,6 +465,20 @@ def _validate_memory_maintenance_job_contract(env: str, env_config: ConfigDict) 
 
     job_env = _as_config_dict(job.get('env')) or {}
     job_secrets = _as_config_dict(job.get('secrets')) or {}
+    if env == 'dev':
+        job_flags = _as_config_dict(job.get('flags')) or {}
+        for flag_name, expected_value in _MEMORY_MAINTENANCE_DEV_REQUIRED_FLAGS.items():
+            actual_entry = job_flags.get(flag_name)
+            if actual_entry is None:
+                errors.append(ValidationError(scope, f'missing required dev Cloud Run flag {flag_name}'))
+                continue
+            if _expected_flag_value(actual_entry) != expected_value:
+                errors.append(
+                    ValidationError(
+                        scope,
+                        f'dev Cloud Run flag {flag_name} must be {expected_value!r}',
+                    )
+                )
     for required_env in (
         'MEMORY_MODE',
         'MEMORY_ENABLED_USERS',

--- a/backend/scripts/validate-backend-runtime-env.py
+++ b/backend/scripts/validate-backend-runtime-env.py
@@ -745,6 +745,14 @@ def _validate_cloud_run_workflows(
                 actual=actual_secrets,
             )
         )
+        errors.extend(
+            _validate_workflow_flags(
+                scope=f'cloud_run_workflow/{job}',
+                expected=_as_config_dict(job_config.get('flags')) or {},
+                actual=_substitute_values(job_state.get('flags', {}), variables=workflow_vars),
+                strict_provisional=strict_provisional,
+            )
+        )
     return errors
 
 
@@ -1098,6 +1106,7 @@ def _rendered_runtime_env_outputs(workflow: ConfigDict, *, env: str, manifest: C
             if job_config is None:
                 continue
             output_prefix = job.replace('-', '_')
+            outputs[f'{output_prefix}_flags'] = _render_cloud_run_flags(job_config.get('flags', {}))
             outputs[f'{output_prefix}_env_vars'] = _render_cloud_run_env_vars(job_config.get('env', {}))
             outputs[f'{output_prefix}_secrets'] = _render_cloud_run_secrets(job_config.get('secrets', {}))
     return outputs

--- a/backend/tests/unit/test_backend_runtime_env_validator.py
+++ b/backend/tests/unit/test_backend_runtime_env_validator.py
@@ -988,6 +988,44 @@ def test_memory_maintenance_job_contract_passes_for_repo_manifest():
     assert validator.validate_runtime_env(env='prod') == []
 
 
+def test_memory_maintenance_job_contract_rejects_missing_dev_capacity_flag(tmp_path):
+    validator = load_validator()
+    manifest = validator._load_yaml(ROOT / 'deploy/runtime_env.yaml')
+    job = manifest['environments']['dev']['cloud_run']['jobs']['memory-maintenance-job']
+    del job['flags']['--memory']
+    path = tmp_path / 'runtime_env.yaml'
+    write_yaml(path, manifest)
+
+    errors = validator.validate_runtime_env(env='dev', manifest_path=path)
+
+    assert (
+        validator.ValidationError(
+            'dev/cloud_run/jobs/memory-maintenance-job',
+            'missing required dev Cloud Run flag --memory',
+        )
+        in errors
+    )
+
+
+def test_memory_maintenance_job_contract_rejects_wrong_dev_capacity_value(tmp_path):
+    validator = load_validator()
+    manifest = validator._load_yaml(ROOT / 'deploy/runtime_env.yaml')
+    job = manifest['environments']['dev']['cloud_run']['jobs']['memory-maintenance-job']
+    job['flags']['--cpu'] = '1'
+    path = tmp_path / 'runtime_env.yaml'
+    write_yaml(path, manifest)
+
+    errors = validator.validate_runtime_env(env='dev', manifest_path=path)
+
+    assert (
+        validator.ValidationError(
+            'dev/cloud_run/jobs/memory-maintenance-job',
+            "dev Cloud Run flag --cpu must be '2'",
+        )
+        in errors
+    )
+
+
 def test_memory_maintenance_job_contract_rejects_notifications_job_maintenance_config(tmp_path):
     validator = load_validator()
     manifest = validator._load_yaml(ROOT / 'deploy/runtime_env.yaml')

--- a/backend/tests/unit/test_backend_runtime_env_validator.py
+++ b/backend/tests/unit/test_backend_runtime_env_validator.py
@@ -988,15 +988,20 @@ def test_memory_maintenance_job_contract_passes_for_repo_manifest():
     assert validator.validate_runtime_env(env='prod') == []
 
 
-def test_memory_maintenance_job_contract_rejects_missing_dev_capacity_flag(tmp_path):
+def test_memory_maintenance_job_contract_rejects_missing_dev_capacity_flag():
     validator = load_validator()
-    manifest = validator._load_yaml(ROOT / 'deploy/runtime_env.yaml')
-    job = manifest['environments']['dev']['cloud_run']['jobs']['memory-maintenance-job']
+    job = memory_maintenance_job_block()
+    job['flags'] = {
+        '--task-timeout': '3600s',
+        '--cpu': '2',
+        '--memory': '2Gi',
+    }
     del job['flags']['--memory']
-    path = tmp_path / 'runtime_env.yaml'
-    write_yaml(path, manifest)
 
-    errors = validator.validate_runtime_env(env='dev', manifest_path=path)
+    errors = validator._validate_memory_maintenance_job_contract(
+        'dev',
+        {'cloud_run': {'jobs': {'memory-maintenance-job': job}}},
+    )
 
     assert (
         validator.ValidationError(

--- a/backend/tests/unit/test_backend_runtime_env_validator.py
+++ b/backend/tests/unit/test_backend_runtime_env_validator.py
@@ -1103,7 +1103,10 @@ def test_memory_maintenance_auto_dev_workflow_is_listed_and_targets_job():
     assert "backend/**" in text
     assert 'Dockerfile.memory_maintenance_job' in text
     assert "id-token: 'write'" not in text
-    assert 'flags: ${{ steps.runtime-env.outputs.cloud_run_flags }}' in text
+    assert (
+        'flags: ${{ steps.runtime-env.outputs.cloud_run_flags }} '
+        '${{ steps.runtime-env.outputs.memory_maintenance_job_flags }}'
+    ) in text
     manifest = yaml.safe_load((ROOT / 'deploy/runtime_env.yaml').read_text(encoding='utf-8'))
     assert (
         '.github/workflows/gcp_memory_maintenance_job_auto_dev.yml'

--- a/backend/tests/unit/test_render_backend_runtime_env.py
+++ b/backend/tests/unit/test_render_backend_runtime_env.py
@@ -69,6 +69,13 @@ def test_render_dev_emits_memory_maintenance_job_outputs(capsys, monkeypatch):
     assert 'MEMORY_CANONICAL_CONSOLIDATION_ENABLED=true' in memory_env
     assert 'MEMORY_ENABLED_USERS=vi7SA9ckQCe4ccobWNxlbdcNdC23' in memory_env
     assert 'MEMORY_MODE=read' in memory_env
+    assert 'TYPESENSE_HOST_PORT=443' in memory_env
+
+    flags_marker = '__BACKEND_RUNTIME_ENV_memory_maintenance_job_flags__'
+    flags_start = out.index(f'memory_maintenance_job_flags<<{flags_marker}')
+    flags_body_start = out.index('\n', flags_start) + 1
+    flags_body_end = out.index(flags_marker, flags_body_start)
+    assert out[flags_body_start:flags_body_end].strip() == '--task-timeout=3600s --cpu=2 --memory=2Gi'
 
     assert 'memory_maintenance_job_secrets<<' in out
     assert 'OPENAI_API_KEY=OPENAI_API_KEY:latest' in out
@@ -164,7 +171,10 @@ def test_memory_maintenance_job_workflow_passes_vpc_vars_and_checkout_sha():
     assert 'memory_maintenance_job_secrets' in text
     assert 'CLOUD_RUN_VPC_NETWORK: ${{ vars.CLOUD_RUN_VPC_NETWORK }}' in text
     assert 'CLOUD_RUN_VPC_SUBNET: ${{ vars.CLOUD_RUN_VPC_SUBNET }}' in text
-    assert 'flags: ${{ steps.runtime-env.outputs.cloud_run_flags }}' in text
+    assert (
+        'flags: ${{ steps.runtime-env.outputs.cloud_run_flags }} '
+        '${{ steps.runtime-env.outputs.memory_maintenance_job_flags }}'
+    ) in text
     assert "id-token: 'write'" not in text
     assert 'git rev-parse --short=7 HEAD' in text
     assert 'short_sha=${GITHUB_SHA::7}' not in text


### PR DESCRIPTION
## Summary

- Declare the dev memory-maintenance job's known-good Typesense port, timeout, CPU, and memory in the runtime manifest.
- Render job-specific Cloud Run flags and pass them through both manual and auto-dev deployment workflows.
- Validate that a workflow cannot silently omit the declared job flags.

## Root cause and durable guard

The dedicated job was patched live, but its source-of-truth manifest and deploy inputs did not declare those settings. A redeploy could therefore drift from the known-good runtime contract. The renderer plus workflow validator now make every job-specific setting explicit and testable before deploy.

## Product invariants affected

None. This change affects only deployment configuration and does not change product memory tiers or access policy.

## Verification

- `cd backend && ./test.sh`
- `cd backend && pytest tests/unit/test_render_backend_runtime_env.py tests/unit/test_backend_runtime_env_validator.py -q`
- `cd backend && python scripts/validate-backend-runtime-env.py --env dev --check-workflows`
- `cd backend && python scripts/validate-backend-runtime-env.py --env prod --check-workflows`
- `make preflight`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9650?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

