### PR TITLE
fix(memory): add guarded legacy remediation apply

### DIFF
--- a/backend/scripts/apply_legacy_backfill_remediation.py
+++ b/backend/scripts/apply_legacy_backfill_remediation.py
@@ -1,0 +1,74 @@
+"""Archive deterministic legacy-backfill noise for one canonical-memory account.
+
+Default mode is metadata-only dry-run. ``--apply`` requires a fresh exact count
+and an explicit acknowledgement; it archives records through the canonical
+apply ledger and never deletes their evidence or source memory rows.
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import asdict
+import getpass
+import json
+import sys
+from pathlib import Path
+
+BACKEND_DIR = Path(__file__).resolve().parents[1]
+if str(BACKEND_DIR) not in sys.path:
+    sys.path.insert(0, str(BACKEND_DIR))
+
+from utils.memory.legacy_backfill import apply_legacy_backfill_remediation_archives
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Archive deterministic legacy-backfill noise for one account")
+    parser.add_argument("--uid", required=True, help="Firebase uid to remediate")
+    parser.add_argument("--apply", action="store_true", help="Apply the archive transition (default is dry-run)")
+    parser.add_argument(
+        "--expected-archive-count",
+        type=int,
+        default=None,
+        help="Fresh exact archive candidate count; required with --apply",
+    )
+    parser.add_argument(
+        "--i-understand-archives-exclude-default-read",
+        action="store_true",
+        help="Required with --apply; archive stays available only through explicit archive access",
+    )
+    parser.add_argument(
+        "--allow-admin-override",
+        action="store_true",
+        help="Bypass CANONICAL_MEMORY_USERS gate (requires --i-understand-uid-not-whitelisted)",
+    )
+    parser.add_argument(
+        "--i-understand-uid-not-whitelisted",
+        action="store_true",
+        help="Confirm uid may be outside CANONICAL_MEMORY_USERS (required with --allow-admin-override)",
+    )
+    parser.add_argument("--operator-context", default=None, help="Operator identity for audit logs")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    if args.apply and args.expected_archive_count is None:
+        print("--apply requires --expected-archive-count", file=sys.stderr)
+        return 2
+    if args.apply and not args.i_understand_archives_exclude_default_read:
+        print("--apply requires --i-understand-archives-exclude-default-read", file=sys.stderr)
+        return 2
+    report = apply_legacy_backfill_remediation_archives(
+        args.uid,
+        expected_archive_count=args.expected_archive_count,
+        dry_run=not args.apply,
+        allow_admin_override=args.allow_admin_override,
+        acknowledge_non_canonical_uid=args.i_understand_uid_not_whitelisted,
+        operator_context=args.operator_context or getpass.getuser(),
+    )
+    print(json.dumps(asdict(report), default=str, indent=2, sort_keys=True))
+    return 1 if report.cohort_gated or report.errors else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/scripts/apply_legacy_backfill_remediation.py
+++ b/backend/scripts/apply_legacy_backfill_remediation.py
@@ -67,7 +67,14 @@ def main(argv: list[str] | None = None) -> int:
         operator_context=args.operator_context or getpass.getuser(),
     )
     print(json.dumps(asdict(report), default=str, indent=2, sort_keys=True))
-    return 1 if report.cohort_gated or report.errors else 0
+    derived_sync_failed = any(
+        (
+            report.vector_sync_failures,
+            report.keyword_sync_failures,
+            report.kg_invalidation_failures,
+        )
+    )
+    return 1 if report.cohort_gated or report.errors or derived_sync_failed else 0
 
 
 if __name__ == "__main__":

--- a/backend/tests/unit/test_inv_mem_1_guard.py
+++ b/backend/tests/unit/test_inv_mem_1_guard.py
@@ -356,6 +356,17 @@ class TestInvMem1DefaultAccessAndCanonicalCollection:
         assert result_ids == {"mem_st", "mem_lt"}
         assert "mem_ar" not in result_ids
 
+    def test_archive_transition_is_removed_from_default_access(self):
+        now = datetime.now(timezone.utc)
+        policy = MemoryAccessPolicy.for_omi_chat()
+        long_term = _item("mem_transition", tier=MemoryTier.long_term, expires_at=None)
+        archived = long_term.model_copy(update={"tier": MemoryTier.archive, "item_revision": 2})
+
+        decision = is_default_access_eligible(archived, policy, now=now)
+
+        assert decision.allowed is False
+        assert decision.reason == "archive_requires_explicit_query"
+
     def test_memory_collections_canonical_product_memory_path_is_memory_items(self):
         paths = MemoryCollections(uid="u_guard")
 

--- a/backend/tests/unit/test_ws_c_backfill.py
+++ b/backend/tests/unit/test_ws_c_backfill.py
@@ -35,6 +35,7 @@ def _ws_c_import_isolation():
         _fetch_active_legacy_memories,
         backfill_user_bucketed,
         backfill_user,
+        apply_legacy_backfill_remediation_archives,
         build_legacy_backfill_remediation_plan,
         classify_legacy_backfill_bucket,
         is_active_legacy_row,
@@ -46,6 +47,7 @@ def _ws_c_import_isolation():
     module_globals["_fetch_active_legacy_memories"] = _fetch_active_legacy_memories
     module_globals["backfill_user"] = backfill_user
     module_globals["backfill_user_bucketed"] = backfill_user_bucketed
+    module_globals["apply_legacy_backfill_remediation_archives"] = apply_legacy_backfill_remediation_archives
     module_globals["build_legacy_backfill_remediation_plan"] = build_legacy_backfill_remediation_plan
     module_globals["classify_legacy_backfill_bucket"] = classify_legacy_backfill_bucket
     module_globals["is_active_legacy_row"] = is_active_legacy_row
@@ -617,6 +619,123 @@ def test_remediation_plan_preserves_asserted_rows_and_archives_known_noise(_trus
     assert entries["mem_sensitive"].action == LegacyBackfillRemediationAction.review
     assert entries["mem_sensitive"].reason == "sensitive_requires_review"
     assert db.docs[f"users/{LEGACY_UID}/memory_items/mem_noise"]["status"] == MemoryItemStatus.active.value
+
+
+def test_remediation_archives_only_planned_noise_through_apply_and_repairs_projections(_trusted_account, monkeypatch):
+    db = _canonical_db_with_control(LEGACY_UID)
+    evidence = MemoryEvidence(
+        evidence_id="ev_remediation_noise",
+        source_type="legacy_memory",
+        source_id="legacy-noise",
+        source_version="v1",
+        artifact_preservation=ArtifactPreservationState.preserved,
+    )
+    item = MemoryItem(
+        memory_id="mem_remediation_noise",
+        uid=LEGACY_UID,
+        version=1,
+        tier=MemoryTier.long_term,
+        status=MemoryItemStatus.active,
+        processing_state=ProcessingState.processed,
+        content="Email from Alex: imported email body",
+        evidence=[evidence],
+        source_state=SourceState.active,
+        sensitivity_labels=[],
+        visibility="private",
+        user_asserted=False,
+        captured_at=NOW_TS,
+        updated_at=NOW_TS,
+        ledger_commit_id="commit_before_remediation",
+        ledger_sequence=1,
+        source_commit_id="commit_before_remediation",
+        source_commit_sequence=1,
+        content_hash="hash_before_remediation",
+        account_generation=1,
+        promotion={"source_surface": "legacy_backfill", "bucket": "profile_required_promotion"},
+    )
+    db.docs[f"users/{LEGACY_UID}/memory_items/{item.memory_id}"] = _stored_item(item)
+    db.docs[f"users/{LEGACY_UID}/memory_evidence/{evidence.evidence_id}"] = evidence.model_dump(mode="json")
+    projection_calls: list[tuple[str, str]] = []
+    monkeypatch.setattr(
+        "utils.memory.legacy_backfill.sync_atom_keyword_index_for_item",
+        lambda archived, **_: projection_calls.append(("keyword", archived.tier.value)) or True,
+    )
+    monkeypatch.setattr(
+        "utils.memory.legacy_backfill.sync_canonical_memory_vector",
+        lambda archived, **_: projection_calls.append(("vector", archived.tier.value)) or True,
+    )
+    monkeypatch.setattr(
+        "utils.memory.legacy_backfill.invalidate_kg_for_memory_retraction",
+        lambda uid, memory_ids, **_: projection_calls.append(("kg", memory_ids[0])),
+    )
+
+    report = apply_legacy_backfill_remediation_archives(
+        LEGACY_UID,
+        expected_archive_count=1,
+        dry_run=False,
+        db_client=db,
+    )
+
+    archived = MemoryItem.model_validate(db.docs[f"users/{LEGACY_UID}/memory_items/{item.memory_id}"])
+    assert report.errors == []
+    assert report.archived_count == 1
+    assert archived.tier == MemoryTier.archive
+    assert archived.status == MemoryItemStatus.active
+    assert archived.item_revision == item.item_revision + 1
+    assert archived.promotion["remediation"]["action"] == "archive"
+    assert projection_calls == [("keyword", "archive"), ("vector", "archive"), ("kg", item.memory_id)]
+    assert any(
+        path.startswith(f"users/{LEGACY_UID}/memory_commits/") for path in db.docs
+    ), "remediation must use the canonical apply ledger"
+
+
+def test_remediation_count_lock_refuses_to_mutate_when_the_fresh_plan_changes(_trusted_account):
+    db = _canonical_db_with_control(LEGACY_UID)
+    evidence = MemoryEvidence(
+        evidence_id="ev_remediation_count_lock",
+        source_type="legacy_memory",
+        source_id="legacy-count-lock",
+        source_version="v1",
+        artifact_preservation=ArtifactPreservationState.preserved,
+    )
+    item = MemoryItem(
+        memory_id="mem_remediation_count_lock",
+        uid=LEGACY_UID,
+        version=1,
+        tier=MemoryTier.long_term,
+        status=MemoryItemStatus.active,
+        processing_state=ProcessingState.processed,
+        content="Local downloads include installer.dmg",
+        evidence=[evidence],
+        source_state=SourceState.active,
+        sensitivity_labels=[],
+        visibility="private",
+        user_asserted=False,
+        captured_at=NOW_TS,
+        updated_at=NOW_TS,
+        ledger_commit_id="commit_count_lock",
+        ledger_sequence=1,
+        source_commit_id="commit_count_lock",
+        source_commit_sequence=1,
+        content_hash="hash_count_lock",
+        account_generation=1,
+        promotion={"source_surface": "legacy_backfill", "bucket": "profile_required_promotion"},
+    )
+    db.docs[f"users/{LEGACY_UID}/memory_items/{item.memory_id}"] = _stored_item(item)
+    db.docs[f"users/{LEGACY_UID}/memory_evidence/{evidence.evidence_id}"] = evidence.model_dump(mode="json")
+
+    report = apply_legacy_backfill_remediation_archives(
+        LEGACY_UID,
+        expected_archive_count=2,
+        dry_run=False,
+        db_client=db,
+    )
+
+    persisted = MemoryItem.model_validate(db.docs[f"users/{LEGACY_UID}/memory_items/{item.memory_id}"])
+    assert report.archived_count == 0
+    assert report.errors == ["expected_archive_count=2 does not match candidate_count=1"]
+    assert persisted.tier == MemoryTier.long_term
+    assert not any(path.startswith(f"users/{LEGACY_UID}/memory_commits/") for path in db.docs)
 
 
 def test_bucketed_inventory_dry_run_reports_counts_and_writes_nothing(_trusted_account):

--- a/backend/tests/unit/test_ws_c_backfill.py
+++ b/backend/tests/unit/test_ws_c_backfill.py
@@ -661,6 +661,10 @@ def test_remediation_archives_only_planned_noise_through_apply_and_repairs_proje
         lambda archived, **_: projection_calls.append(("keyword", archived.tier.value)) or True,
     )
     monkeypatch.setattr(
+        "utils.memory.legacy_backfill.delete_canonical_memory_vector",
+        lambda uid, memory_id: projection_calls.append(("vector_delete", memory_id)) or True,
+    )
+    monkeypatch.setattr(
         "utils.memory.legacy_backfill.sync_canonical_memory_vector",
         lambda archived, **_: projection_calls.append(("vector", archived.tier.value)) or True,
     )
@@ -683,7 +687,12 @@ def test_remediation_archives_only_planned_noise_through_apply_and_repairs_proje
     assert archived.status == MemoryItemStatus.active
     assert archived.item_revision == item.item_revision + 1
     assert archived.promotion["remediation"]["action"] == "archive"
-    assert projection_calls == [("keyword", "archive"), ("vector", "archive"), ("kg", item.memory_id)]
+    assert projection_calls == [
+        ("keyword", "archive"),
+        ("vector_delete", item.memory_id),
+        ("vector", "archive"),
+        ("kg", item.memory_id),
+    ]
     assert any(
         path.startswith(f"users/{LEGACY_UID}/memory_commits/") for path in db.docs
     ), "remediation must use the canonical apply ledger"

--- a/backend/utils/memory/ARCHITECTURE.md
+++ b/backend/utils/memory/ARCHITECTURE.md
@@ -76,7 +76,7 @@ backend/modal/memory_maintenance_job.py
       canonical_kg_promotion.py            extract the knowledge-graph projection
 ```
 
-Consolidation and promotion mutate authoritative state only through `memory_apply_store.py`. Separately, stale vector hits and tombstone/delete paths create deterministic `vector_repair_purge` records with `backend/database/memory_vector_repair_outbox.py`. `memory_vector_repair_outbox_worker.py` leases, retries, dead-letters, and acknowledges those repairs. Repair/purge records share `memory_outbox` storage with normal apply events but are a different event contract.
+Consolidation and promotion mutate authoritative state only through `memory_apply_store.py`. The reviewed legacy-backfill remediation executor follows the same ledger path: it can only archive deterministic legacy artifacts, retains evidence, removes the keyword projection, refreshes the explicit archive vector, and invalidates KG citations. Separately, stale vector hits and tombstone/delete paths create deterministic `vector_repair_purge` records with `backend/database/memory_vector_repair_outbox.py`. `memory_vector_repair_outbox_worker.py` leases, retries, dead-letters, and acknowledges those repairs. Repair/purge records share `memory_outbox` storage with normal apply events but are a different event contract.
 
 ## Rollout and legacy sunset
 

--- a/backend/utils/memory/canonical_vector_sync.py
+++ b/backend/utils/memory/canonical_vector_sync.py
@@ -11,18 +11,20 @@ from models.product_memory import MemoryItemStatus, ProcessingState, MemoryItem
 logger = logging.getLogger(__name__)
 
 
-def delete_canonical_memory_vector(uid: str, memory_id: str) -> None:
+def delete_canonical_memory_vector(uid: str, memory_id: str) -> bool:
     """Delete a canonical neutral-id vector (identity = memory_id)."""
     try:
         from database.vector_db import delete_pinecone_memory_vectors_by_id
 
-        delete_pinecone_memory_vectors_by_id([memory_id])
+        deleted_count = delete_pinecone_memory_vectors_by_id([memory_id])
+        return deleted_count == 1
     except Exception:
         logger.exception(
             "canonical vector delete failed memory_id=%s uid=%s",
             memory_id,
             uid,
         )
+        return False
 
 
 def sync_canonical_memory_vector(

--- a/backend/utils/memory/legacy_backfill.py
+++ b/backend/utils/memory/legacy_backfill.py
@@ -41,7 +41,7 @@ from models.product_memory import MemoryItemStatus, MemoryLayer, ProcessingState
 from utils.memory.atom_keyword_index import sync_atom_keyword_index_for_item
 from utils.memory.canonical_memory_adapter import extraction_memory_id, invalidate_kg_for_memory_retraction
 from utils.memory.canonical_kg_promotion import extract_kg_for_promoted_memory
-from utils.memory.canonical_vector_sync import sync_canonical_memory_vector
+from utils.memory.canonical_vector_sync import delete_canonical_memory_vector, sync_canonical_memory_vector
 from utils.memory.memory_system import MemorySystem, resolve_memory_system
 from utils.memory.product_memory_read_service import fetch_authoritative_product_memory_items
 from utils.memory.required_promotion import (
@@ -642,7 +642,13 @@ def _archive_legacy_backfill_item_via_apply(
         vector_sync_failed = True
 
     keyword_sync_succeeded = sync_atom_keyword_index_for_item(archived, db_client=db_client)
-    sync_canonical_memory_vector(archived, on_hard_failure=_record_vector_sync_failure)
+    # The existing long-term vector is eligible for default retrieval. Remove it
+    # before publishing the archive vector so an upsert failure fails closed for
+    # default access rather than leaving stale long-term metadata queryable.
+    deleted_prior_vector = delete_canonical_memory_vector(uid, archived.memory_id)
+    synced_archive_vector = sync_canonical_memory_vector(archived, on_hard_failure=_record_vector_sync_failure)
+    if not deleted_prior_vector and not synced_archive_vector:
+        _record_vector_sync_failure()
     kg_invalidation_failed = False
     try:
         invalidate_kg_for_memory_retraction(uid, [archived.memory_id], db_client=db_client)

--- a/backend/utils/memory/legacy_backfill.py
+++ b/backend/utils/memory/legacy_backfill.py
@@ -39,7 +39,7 @@ from models.memory_contracts import DurablePatchDecision, LifecycleState, determ
 from models.memory_operations import MemoryOperation, MemoryOperationType
 from models.product_memory import MemoryItemStatus, MemoryLayer, ProcessingState, MemoryItem
 from utils.memory.atom_keyword_index import sync_atom_keyword_index_for_item
-from utils.memory.canonical_memory_adapter import extraction_memory_id
+from utils.memory.canonical_memory_adapter import extraction_memory_id, invalidate_kg_for_memory_retraction
 from utils.memory.canonical_kg_promotion import extract_kg_for_promoted_memory
 from utils.memory.canonical_vector_sync import sync_canonical_memory_vector
 from utils.memory.memory_system import MemorySystem, resolve_memory_system
@@ -215,6 +215,35 @@ class LegacyBackfillRemediationPlan:
     candidate_count: int
     action_counts: Dict[str, int]
     samples: Dict[str, List[LegacyBackfillRemediationEntry]]
+
+
+@dataclass(frozen=True)
+class LegacyBackfillRemediationApplyReport:
+    """Result of the deliberately narrow legacy-backfill archive transition."""
+
+    uid: str
+    dry_run: bool
+    expected_archive_count: Optional[int]
+    candidate_count: int
+    archived_count: int
+    idempotent_count: int
+    vector_sync_failures: int
+    keyword_sync_failures: int
+    kg_invalidation_failures: int
+    cohort_gated: bool = False
+    errors: List[str] = field(default_factory=_empty_str_list)
+
+
+@dataclass(frozen=True)
+class LegacyBackfillRemediationArchiveResult:
+    """Named result for one durable archive transition and its derived repairs."""
+
+    control: MemoryControlState
+    archived: bool
+    idempotent: bool
+    vector_sync_failed: bool
+    keyword_sync_failed: bool
+    kg_invalidation_failed: bool
 
 
 def legacy_backfill_memory_id(*, uid: str, legacy_memory_id: str) -> str:
@@ -503,6 +532,246 @@ def build_legacy_backfill_remediation_plan(
         candidate_count=len(candidates),
         action_counts=action_counts,
         samples={action: entries for action, entries in samples.items() if entries},
+    )
+
+
+def _archive_remediation_candidates(uid: str, *, db_client: Any) -> List[MemoryItem]:
+    """Return only active, explicitly attributed rows the deterministic planner archives."""
+
+    return [
+        item
+        for item in fetch_authoritative_product_memory_items(uid=uid, db_client=db_client)
+        if item.tier == MemoryLayer.long_term
+        and item.status == MemoryItemStatus.active
+        and _is_legacy_backfill_item(item)
+        and classify_legacy_backfill_remediation(item).action == LegacyBackfillRemediationAction.archive
+    ]
+
+
+def _archive_legacy_backfill_item_via_apply(
+    *,
+    uid: str,
+    item: MemoryItem,
+    control: MemoryControlState,
+    run_id: str,
+    db_client: Any,
+) -> LegacyBackfillRemediationArchiveResult:
+    """Archive one planner-approved item through the canonical apply ledger.
+
+    The expected revision and content hash turn concurrent edits into a safe failure
+    rather than archiving an item whose classification may no longer be valid.
+    """
+
+    entry = classify_legacy_backfill_remediation(item)
+    if entry.action != LegacyBackfillRemediationAction.archive:
+        raise ValueError(f"remediation item is no longer archive-eligible: {item.memory_id}")
+    evidence_ids = [evidence.evidence_id for evidence in item.evidence]
+    logical_payload: Payload = {
+        "decision": DurablePatchDecision.update.value,
+        "target_memory_id": item.memory_id,
+        "result_status": LifecycleState.active.value,
+    }
+    operation = MemoryOperation.new(
+        uid=uid,
+        operation_type=MemoryOperationType.archive_transition,
+        source_packet_id=(
+            f"legacy_backfill_remediation_archive:{item.memory_id}:"
+            f"r{item.item_revision}:head:{control.head_commit_id}"
+        ),
+        target_memory_id=item.memory_id,
+        evidence_ids=evidence_ids,
+        logical_payload=logical_payload,
+        account_generation=control.account_generation,
+        source_generation=control.source_generation,
+        observed_head_commit_id=control.head_commit_id,
+    )
+    operation_ref = db_client.document(f"{MemoryCollections(uid=uid).memory_operations}/{operation.operation_id}")
+    if not operation_ref.get().exists:
+        operation_ref.set(operation.model_dump(mode="json"))
+    idempotency_key = deterministic_contract_id(
+        "legacy-backfill-remediation-archive",
+        {
+            "uid": uid,
+            "memory_id": item.memory_id,
+            "item_revision": item.item_revision,
+            "content_hash": item.content_hash,
+        },
+    )
+    promotion = dict(item.promotion or {})
+    promotion["remediation"] = {
+        "action": LegacyBackfillRemediationAction.archive.value,
+        "reason": entry.reason,
+        "run_id": run_id,
+        "previous_tier": item.tier.value,
+    }
+    result = apply_long_term_patch_firestore(
+        uid=uid,
+        operation_id=operation.operation_id,
+        patch_payload={
+            "patch_id": f"patch_lb_remediate_{idempotency_key[:20]}",
+            "packet_id": f"legacy_backfill_remediation_archive:{item.memory_id}",
+            "run_id": run_id,
+            "observed_head_commit_id": control.head_commit_id,
+            "idempotency_key": idempotency_key,
+            **logical_payload,
+            # archive_explicit: this operator path intentionally changes default visibility.
+            "target_tier": MemoryLayer.archive.value,
+            "evidence_ids": evidence_ids,
+            "expected_item_revision": item.item_revision,
+            "expected_content_hash": item.content_hash,
+            "promotion_audit": promotion,
+        },
+        db_client=db_client,
+    )
+    if result.status not in {ApplyStatus.committed, ApplyStatus.idempotent_skip}:
+        raise RuntimeError(f"archive remediation failed: {result.status} ({result.reason})")
+
+    archived = (
+        result.memory_items[0]
+        if result.memory_items
+        else _load_canonical_item(uid, item.memory_id, db_client=db_client)
+    )
+    # archive_explicit postcondition: default readers must no longer see this item.
+    if archived is None or archived.tier != MemoryLayer.archive:
+        raise RuntimeError("archive remediation did not persist an archive-tier memory")
+
+    vector_sync_failed = False
+
+    def _record_vector_sync_failure() -> None:
+        nonlocal vector_sync_failed
+        vector_sync_failed = True
+
+    keyword_sync_succeeded = sync_atom_keyword_index_for_item(archived, db_client=db_client)
+    sync_canonical_memory_vector(archived, on_hard_failure=_record_vector_sync_failure)
+    kg_invalidation_failed = False
+    try:
+        invalidate_kg_for_memory_retraction(uid, [archived.memory_id], db_client=db_client)
+    except Exception:
+        kg_invalidation_failed = True
+        logger.exception(
+            "legacy backfill remediation KG invalidation failed uid=%s memory_id=%s", uid, archived.memory_id
+        )
+    return LegacyBackfillRemediationArchiveResult(
+        control=result.control_state,
+        archived=result.status == ApplyStatus.committed,
+        idempotent=result.status == ApplyStatus.idempotent_skip,
+        vector_sync_failed=vector_sync_failed,
+        keyword_sync_failed=not keyword_sync_succeeded,
+        kg_invalidation_failed=kg_invalidation_failed,
+    )
+
+
+def apply_legacy_backfill_remediation_archives(
+    uid: str,
+    *,
+    expected_archive_count: Optional[int] = None,
+    dry_run: bool = True,
+    run_id: Optional[str] = None,
+    allow_admin_override: bool = False,
+    acknowledge_non_canonical_uid: bool = False,
+    operator_context: Optional[str] = None,
+    db_client: Any = None,
+) -> LegacyBackfillRemediationApplyReport:
+    """Archive only the deterministic planner's legacy-backfill noise recommendations.
+
+    This is intentionally a count-locked, per-account operator action. It never
+    deletes memory content or touches ambiguous, sensitive, manually asserted, or
+    unattributed rows. Actual transitions use ``apply_long_term_patch_firestore``.
+    """
+
+    client: Any = db_client if db_client is not None else default_db_client
+    try:
+        assert_canonical_cohort_for_backfill(
+            uid,
+            allow_admin_override=allow_admin_override,
+            acknowledge_non_canonical_uid=acknowledge_non_canonical_uid,
+            operator_context=operator_context,
+            db_client=client,
+        )
+    except BackfillCohortGateError as exc:
+        return LegacyBackfillRemediationApplyReport(
+            uid=uid,
+            dry_run=dry_run,
+            expected_archive_count=expected_archive_count,
+            candidate_count=0,
+            archived_count=0,
+            idempotent_count=0,
+            vector_sync_failures=0,
+            keyword_sync_failures=0,
+            kg_invalidation_failures=0,
+            cohort_gated=True,
+            errors=[str(exc)],
+        )
+
+    candidates = _archive_remediation_candidates(uid, db_client=client)
+    candidate_count = len(candidates)
+    if not dry_run and expected_archive_count is None:
+        raise ValueError("expected_archive_count is required for an archive remediation apply")
+    if expected_archive_count is not None and candidate_count != expected_archive_count:
+        return LegacyBackfillRemediationApplyReport(
+            uid=uid,
+            dry_run=dry_run,
+            expected_archive_count=expected_archive_count,
+            candidate_count=candidate_count,
+            archived_count=0,
+            idempotent_count=0,
+            vector_sync_failures=0,
+            keyword_sync_failures=0,
+            kg_invalidation_failures=0,
+            errors=[
+                f"expected_archive_count={expected_archive_count} does not match candidate_count={candidate_count}"
+            ],
+        )
+    if dry_run:
+        return LegacyBackfillRemediationApplyReport(
+            uid=uid,
+            dry_run=True,
+            expected_archive_count=expected_archive_count,
+            candidate_count=candidate_count,
+            archived_count=0,
+            idempotent_count=0,
+            vector_sync_failures=0,
+            keyword_sync_failures=0,
+            kg_invalidation_failures=0,
+        )
+
+    control = _read_control_state(uid, db_client=client, create_if_missing=False)
+    effective_run_id = run_id or f"legacy_backfill_remediation_{datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%SZ')}"
+    archived_count = 0
+    idempotent_count = 0
+    vector_sync_failures = 0
+    keyword_sync_failures = 0
+    kg_invalidation_failures = 0
+    errors: List[str] = []
+    for item in candidates:
+        try:
+            result = _archive_legacy_backfill_item_via_apply(
+                uid=uid,
+                item=item,
+                control=control,
+                run_id=effective_run_id,
+                db_client=client,
+            )
+            control = result.control
+            archived_count += int(result.archived)
+            idempotent_count += int(result.idempotent)
+            vector_sync_failures += int(result.vector_sync_failed)
+            keyword_sync_failures += int(result.keyword_sync_failed)
+            kg_invalidation_failures += int(result.kg_invalidation_failed)
+        except Exception as exc:
+            errors.append(f"{item.memory_id}: {sanitize(str(exc))}")
+            logger.exception("legacy backfill remediation archive failed uid=%s memory_id=%s", uid, item.memory_id)
+    return LegacyBackfillRemediationApplyReport(
+        uid=uid,
+        dry_run=False,
+        expected_archive_count=expected_archive_count,
+        candidate_count=candidate_count,
+        archived_count=archived_count,
+        idempotent_count=idempotent_count,
+        vector_sync_failures=vector_sync_failures,
+        keyword_sync_failures=keyword_sync_failures,
+        kg_invalidation_failures=kg_invalidation_failures,
+        errors=errors,
     )
 
 


### PR DESCRIPTION
## Summary
- Add a per-account, dry-run-by-default executor for deterministic legacy-backfill noise.
- Require an exact fresh archive count and explicit acknowledgement before applying a transition.
- Archive through the canonical apply ledger, retain evidence, remove keyword retrieval, refresh explicit-archive retrieval, and invalidate graph citations.

## Root cause and durable guard
The historical-import planner could identify deterministic artifacts, but had no safe apply path. Operators would otherwise need a direct Firestore mutation that bypasses the canonical commit chain and derived projections. The new executor accepts only explicit `legacy_backfill` long-term rows that the deterministic classifier marks `archive`; its count lock plus revision/hash preconditions reject stale or broadened plans.

## Product invariants affected
- INV-MEM-1: archive remains excluded from default reads; the invariant guard now characterizes an archive transition explicitly.

## Verification
- `cd backend && ./test.sh`
- `cd backend && pytest tests/unit/test_ws_c_backfill.py tests/unit/test_memory_apply_store.py tests/unit/test_inv_mem_1_guard.py tests/unit/test_ws_m_atom_keyword_index.py tests/unit/test_canonical_memory_vectors.py -q`
- `make preflight`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9652?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

