### PR TITLE
fix(desktop): converge Tasks to empty when all tasks were completed or removed on other devices

### DIFF
--- a/desktop/macos/Desktop/Sources/Rewind/Core/ActionItemStorage.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/ActionItemStorage.swift
@@ -562,7 +562,8 @@ actor ActionItemStorage {
     @discardableResult
     func reconcileDashboardVisibilityFields(
         _ items: [TaskActionItem],
-        authorization: LocalMutationAuthorization
+        authorization: LocalMutationAuthorization,
+        deriveDeletedFromCancelledStatus: Bool = false
     ) async throws -> Int {
         try authorization.require()
         guard !items.isEmpty else { return 0 }
@@ -577,7 +578,13 @@ actor ActionItemStorage {
                         .filter(Column("backendId") == item.id)
                         .fetchOne(database) else { continue }
 
-                    let incomingDeleted = item.deleted ?? false
+                    // The list/detail wire model carries no `deleted` field; the
+                    // backend projects soft-deletion as status cancelled/superseded.
+                    // Callers doing authoritative per-document reconciliation opt in
+                    // to that derivation.
+                    let statusImpliesDeleted = deriveDeletedFromCancelledStatus
+                        && (item.taskStatus == "cancelled" || item.taskStatus == "superseded")
+                    let incomingDeleted = item.deleted ?? statusImpliesDeleted
                     var changed = false
 
                     if record.completed != item.completed {
@@ -668,11 +675,15 @@ actor ActionItemStorage {
     /// Returns the number of records deleted.
     func hardDeleteAbsentTasks(
         apiIds: Set<String>,
-        authorization: LocalMutationAuthorization
+        authorization: LocalMutationAuthorization,
+        confirmedEmpty: Bool = false
     ) async throws -> Int {
         try authorization.require()
-        // Safety guard: never wipe all tasks if the API set is empty (backend error)
-        guard !apiIds.isEmpty else {
+        // An empty API set is trusted only when the caller independently confirmed
+        // the account has zero incomplete tasks (TasksStore verifies through the
+        // IDs endpoint first); an unconfirmed empty set is treated as a backend
+        // error so a bogus empty page can never wipe local rows.
+        guard !apiIds.isEmpty || confirmedEmpty else {
             log("ActionItemStorage: hardDeleteAbsentTasks skipped — empty API set")
             return 0
         }

--- a/desktop/macos/Desktop/Sources/Stores/APIClient+Tasks.swift
+++ b/desktop/macos/Desktop/Sources/Stores/APIClient+Tasks.swift
@@ -1,5 +1,10 @@
 import Foundation
 
+/// Response wrapper for GET v1/action-items/ids (lightweight reconcile source).
+struct ActionItemIdsResponse: Decodable {
+  let ids: [String]
+}
+
 extension APIClient {
   /// Fetch action items through an immutable owner-bound request. Callers that
   /// span pagination must pass the same owner to every page.
@@ -31,6 +36,21 @@ extension APIClient {
       expectedOwnerId: expectedOwnerId,
       authorizationSnapshot: authorizationSnapshot
     )
+  }
+
+  /// Fetch every action-item ID for the signed-in user (IDs only, no fields).
+  /// Used as an independent confirmation before an empty incomplete-task page
+  /// is allowed to reconcile (wipe) synced local rows.
+  func getActionItemIds(
+    expectedOwnerId: String? = nil,
+    authorizationSnapshot: RuntimeOwnerAuthorizationSnapshot? = nil
+  ) async throws -> [String] {
+    let response: ActionItemIdsResponse = try await get(
+      "v1/action-items/ids",
+      expectedOwnerId: expectedOwnerId,
+      authorizationSnapshot: authorizationSnapshot
+    )
+    return response.ids
   }
 
   func migrateStagedTasks(

--- a/desktop/macos/Desktop/Sources/Stores/TasksStore.swift
+++ b/desktop/macos/Desktop/Sources/Stores/TasksStore.swift
@@ -37,6 +37,9 @@ class TasksStore: ObservableObject {
         }
 
         var fetchPage: ((_ completed: Bool, _ offset: Int, _ limit: Int, _ ownerID: String) async throws -> ActionItemsPage)?
+        var fetchAllTaskIds: ((_ ownerID: String) async throws -> [String])?
+        var fetchTaskDetail: ((_ id: String, _ ownerID: String) async throws -> TaskActionItem?)?
+        var reconcileVisibility: ((_ items: [TaskActionItem], _ ownerID: String) async throws -> Int)?
         var fetchDeletedPage: ((_ offset: Int, _ limit: Int, _ ownerID: String) async throws -> ActionItemsPage)?
         var syncPage: ((_ items: [TaskActionItem], _ overrideStagedDeletions: Bool, _ ownerID: String) async throws -> Void)?
         var hardDeleteAbsent: ((_ ids: Set<String>, _ ownerID: String) async throws -> Int)?
@@ -52,6 +55,9 @@ class TasksStore: ObservableObject {
 
         init(
             fetchPage: ((_ completed: Bool, _ offset: Int, _ limit: Int, _ ownerID: String) async throws -> ActionItemsPage)? = nil,
+            fetchAllTaskIds: ((_ ownerID: String) async throws -> [String])? = nil,
+            fetchTaskDetail: ((_ id: String, _ ownerID: String) async throws -> TaskActionItem?)? = nil,
+            reconcileVisibility: ((_ items: [TaskActionItem], _ ownerID: String) async throws -> Int)? = nil,
             fetchDeletedPage: ((_ offset: Int, _ limit: Int, _ ownerID: String) async throws -> ActionItemsPage)? = nil,
             syncPage: ((_ items: [TaskActionItem], _ overrideStagedDeletions: Bool, _ ownerID: String) async throws -> Void)? = nil,
             hardDeleteAbsent: ((_ ids: Set<String>, _ ownerID: String) async throws -> Int)? = nil,
@@ -66,6 +72,9 @@ class TasksStore: ObservableObject {
             backfillRelevance: ((_ ownerID: String) async throws -> Int)? = nil
         ) {
             self.fetchPage = fetchPage
+            self.fetchAllTaskIds = fetchAllTaskIds
+            self.fetchTaskDetail = fetchTaskDetail
+            self.reconcileVisibility = reconcileVisibility
             self.fetchDeletedPage = fetchDeletedPage
             self.syncPage = syncPage
             self.hardDeleteAbsent = hardDeleteAbsent
@@ -420,17 +429,25 @@ class TasksStore: ObservableObject {
 
             // Reconcile: if we got the full set, hard-delete local tasks absent from API
             // (completed/deleted on mobile). Safe: only deletes synced records.
-            // Safety guard: skip if API returned zero tasks (possible backend error / empty 200).
-            if response.items.count < reloadLimit, !response.items.isEmpty {
-                let apiIds = Set(response.items.map { $0.id })
-                let reconciled = try await hardDeleteAbsent(
-                    apiIds,
-                    lease: lease,
-                    operations: operations
-                )
-                guard isCurrent(lease) else { return }
-                if reconciled > 0 {
-                    log("TasksStore: Reconciled: hard-deleted \(reconciled) absent tasks during auto-refresh")
+            // An empty page is reconciled only after the IDs endpoint confirms the
+            // account truly has zero incomplete tasks (degraded-backend guard).
+            if response.items.count < reloadLimit {
+                if response.items.isEmpty {
+                    if !incompleteTasks.isEmpty {
+                        _ = await reconcileConfirmedEmptyCloud(lease: lease, operations: operations)
+                        guard isCurrent(lease) else { return }
+                    }
+                } else {
+                    let apiIds = Set(response.items.map { $0.id })
+                    let reconciled = try await hardDeleteAbsent(
+                        apiIds,
+                        lease: lease,
+                        operations: operations
+                    )
+                    guard isCurrent(lease) else { return }
+                    if reconciled > 0 {
+                        log("TasksStore: Reconciled: hard-deleted \(reconciled) absent tasks during auto-refresh")
+                    }
                 }
             }
 
@@ -609,19 +626,30 @@ class TasksStore: ObservableObject {
                 if response.items.count < batchSize { break }
             }
 
-            // Safety guard: skip if API returned zero tasks (possible backend error / empty 200).
+            let deleted: Int
             if allApiIds.isEmpty {
-                log("TasksStore: Periodic reconciliation skipped — API returned zero task IDs (possible backend error)")
-                return
+                // Zero incomplete tasks in the cloud — confirm through the IDs
+                // endpoint before wiping so stale local tasks converge to empty
+                // without trusting a single unverified empty response.
+                if incompleteTasks.isEmpty {
+                    // Local cache already matches the empty cloud state.
+                    lastReconciliationDate = Date()
+                    return
+                }
+                guard let confirmed = await reconcileConfirmedEmptyCloud(
+                    lease: lease,
+                    operations: operations
+                ) else { return }
+                deleted = confirmed
+            } else {
+                deleted = try await hardDeleteAbsent(
+                    allApiIds,
+                    lease: lease,
+                    operations: operations
+                )
+                guard isCurrent(lease) else { return }
+                lastReconciliationDate = Date()
             }
-
-            let deleted = try await hardDeleteAbsent(
-                allApiIds,
-                lease: lease,
-                operations: operations
-            )
-            guard isCurrent(lease) else { return }
-            lastReconciliationDate = Date()
 
             if deleted > 0 {
                 log("TasksStore: Full reconciliation: hard-deleted \(deleted) absent tasks")
@@ -925,7 +953,8 @@ class TasksStore: ObservableObject {
     private func hardDeleteAbsent(
         _ ids: Set<String>,
         lease: OwnerOperationLease,
-        operations: OwnerBoundOperations
+        operations: OwnerBoundOperations,
+        confirmedEmpty: Bool = false
     ) async throws -> Int {
         guard isCurrent(lease) else { throw LocalMutationAuthorizationError.revoked }
         if let hardDeleteAbsent = operations.hardDeleteAbsent {
@@ -933,8 +962,151 @@ class TasksStore: ObservableObject {
         }
         return try await ActionItemStorage.shared.hardDeleteAbsentTasks(
             apiIds: ids,
-            authorization: Self.localMutationAuthorization(snapshot: lease.authorizationSnapshot)
+            authorization: Self.localMutationAuthorization(snapshot: lease.authorizationSnapshot),
+            confirmedEmpty: confirmedEmpty
         )
+    }
+
+    /// The cloud returned zero incomplete tasks. A legitimately-empty account must
+    /// still converge (tasks completed/deleted on other devices have to disappear
+    /// here too), but a bogus empty page from a degraded backend must never wipe
+    /// the local cache on its own say-so. Instead of trusting the empty page,
+    /// reconcile against the independent ID census (GET /v1/action-items/ids):
+    ///   - rows whose documents are absent from the census are proven gone and
+    ///     hard-deleted;
+    ///   - rows whose documents still exist are resolved with authoritative
+    ///     per-document reads (completed/deleted flips), never blind deletion;
+    ///   - an empty census itself proves the account has no task documents at
+    ///     all, which authorizes the storage layer's confirmed-empty wipe.
+    /// Returns the number of local rows changed (deleted + visibility flips), or
+    /// nil when the census fetch failed (reconciliation skipped, fail closed).
+    private func reconcileConfirmedEmptyCloud(
+        lease: OwnerOperationLease,
+        operations: OwnerBoundOperations
+    ) async -> Int? {
+        guard isCurrent(lease) else { return nil }
+        do {
+            let censusIds: [String]
+            if let fetchAllTaskIds = operations.fetchAllTaskIds {
+                censusIds = try await fetchAllTaskIds(lease.ownerID)
+            } else {
+                censusIds = try await APIClient.shared.getActionItemIds(
+                    expectedOwnerId: lease.ownerID,
+                    authorizationSnapshot: lease.authorizationSnapshot
+                )
+            }
+            guard isCurrent(lease) else { return nil }
+
+            let census = Set(censusIds)
+            var changed: Int
+            if census.isEmpty {
+                changed = try await hardDeleteAbsent(
+                    [],
+                    lease: lease,
+                    operations: operations,
+                    confirmedEmpty: true
+                )
+            } else {
+                changed = try await hardDeleteAbsent(census, lease: lease, operations: operations)
+                guard isCurrent(lease) else { return nil }
+                changed += await resolveCensusPresentStaleRows(
+                    census: census,
+                    lease: lease,
+                    operations: operations
+                )
+            }
+            guard isCurrent(lease) else { return nil }
+            lastReconciliationDate = Date()
+            if changed > 0 {
+                log("TasksStore: Reconciled empty cloud to-do state: \(changed) stale local tasks resolved")
+            }
+            return changed
+        } catch {
+            if isCurrent(lease) {
+                log("TasksStore: Empty-cloud reconciliation skipped — census fetch failed: \(error.localizedDescription)")
+            }
+            return nil
+        }
+    }
+
+    /// Local incomplete rows whose documents still exist in the census cannot be
+    /// deleted on the empty page's word — read each document and apply its
+    /// authoritative completed/deleted state instead. Loops until a full cache
+    /// read shows no unattempted census-present rows, so the whole stale set is
+    /// resolved in one reconcile pass. Terminates because every iteration either
+    /// attempts new rows or widens the read window: rows that resolve leave the
+    /// incomplete cache, and rows that do not (still incomplete in the cloud, or
+    /// unreadable) are remembered in `attempted` and stay visible by design.
+    private func resolveCensusPresentStaleRows(
+        census: Set<String>,
+        lease: OwnerOperationLease,
+        operations: OwnerBoundOperations
+    ) async -> Int {
+        var flippedTotal = 0
+        var attempted = Set<String>()
+        var readLimit = pageSize
+        do {
+            while true {
+                guard isCurrent(lease) else { return flippedTotal }
+                let rows = try await loadCachedTasks(
+                    scope: .incomplete,
+                    limit: readLimit,
+                    offset: 0,
+                    lease: lease,
+                    operations: operations
+                )
+                let candidates = rows.filter { census.contains($0.id) && !attempted.contains($0.id) }
+                if candidates.isEmpty {
+                    // A short read means the whole remaining cache was visible and
+                    // holds nothing left to resolve. A full read may hide deeper
+                    // rows behind stable ones — widen and look again.
+                    if rows.count < readLimit { break }
+                    readLimit += pageSize
+                    continue
+                }
+
+                var fetched: [TaskActionItem] = []
+                for row in candidates {
+                    guard isCurrent(lease) else { return flippedTotal }
+                    attempted.insert(row.id)
+                    do {
+                        let item: TaskActionItem?
+                        if let fetchTaskDetail = operations.fetchTaskDetail {
+                            item = try await fetchTaskDetail(row.id, lease.ownerID)
+                        } else {
+                            item = try await APIClient.shared.getActionItem(
+                                id: row.id,
+                                expectedOwnerId: lease.ownerID,
+                                authorizationSnapshot: lease.authorizationSnapshot
+                            )
+                        }
+                        if let item { fetched.append(item) }
+                    } catch {
+                        // One unreadable document must not abort the rest; it stays
+                        // visible and is retried on the next reconcile pass.
+                        log("TasksStore: Skipping stale-row resolution for one task: \(error.localizedDescription)")
+                    }
+                }
+                guard isCurrent(lease) else { return flippedTotal }
+                guard !fetched.isEmpty else { continue }
+
+                if let reconcileVisibility = operations.reconcileVisibility {
+                    flippedTotal += try await reconcileVisibility(fetched, lease.ownerID)
+                } else {
+                    flippedTotal += try await ActionItemStorage.shared.reconcileDashboardVisibilityFields(
+                        fetched,
+                        authorization: Self.localMutationAuthorization(snapshot: lease.authorizationSnapshot),
+                        deriveDeletedFromCancelledStatus: true
+                    )
+                }
+            }
+            return flippedTotal
+        } catch {
+            if isCurrent(lease) {
+                log("TasksStore: Stale-row resolution skipped: \(error.localizedDescription)")
+            }
+            return flippedTotal
+        }
     }
 
     private func loadCachedTasks(
@@ -1157,20 +1329,32 @@ class TasksStore: ObservableObject {
                 if response.items.count < batchSize { break }
             }
 
-            // Safety guard: if the API returned zero tasks, skip reconciliation.
-            // This prevents a backend error (200 with empty list) from wiping all local tasks.
+            let deleted: Int
             if allApiIds.isEmpty {
-                log("TasksStore: Reconciliation skipped — API returned zero task IDs (possible backend error)")
-                return
+                // Zero incomplete tasks in the cloud: either the account is truly
+                // empty (everything completed/deleted on another device) or the
+                // backend served a bogus empty page. Confirm before wiping so the
+                // local list converges to empty instead of showing stale tasks
+                // forever, without trusting a single unverified empty response.
+                if incompleteTasks.isEmpty {
+                    // Local cache already matches the empty cloud state.
+                    lastReconciliationDate = Date()
+                    return
+                }
+                guard let confirmed = await reconcileConfirmedEmptyCloud(
+                    lease: lease,
+                    operations: operations
+                ) else { return }
+                deleted = confirmed
+            } else {
+                deleted = try await hardDeleteAbsent(
+                    allApiIds,
+                    lease: lease,
+                    operations: operations
+                )
+                guard isCurrent(lease) else { return }
+                lastReconciliationDate = Date()
             }
-
-            let deleted = try await hardDeleteAbsent(
-                allApiIds,
-                lease: lease,
-                operations: operations
-            )
-            guard isCurrent(lease) else { return }
-            lastReconciliationDate = Date()
 
             if deleted > 0 {
                 log("TasksStore: Reconciled on load: hard-deleted \(deleted) absent tasks")
@@ -1187,10 +1371,7 @@ class TasksStore: ObservableObject {
                     incompleteTasks = refreshed
                     incompleteOffset = refreshed.count
                 }
-                await loadDashboardTasks(
-                    expectedOwnerID: lease.ownerID,
-                    authorizationSnapshot: lease.authorizationSnapshot
-                )
+                await refreshDashboardCache(lease: lease, operations: operations)
             } else {
                 log("TasksStore: Reconciled on load: all local tasks match API")
             }

--- a/desktop/macos/Desktop/Tests/TasksStoreEmptyCloudReconcileTests.swift
+++ b/desktop/macos/Desktop/Tests/TasksStoreEmptyCloudReconcileTests.swift
@@ -1,0 +1,450 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// Regression coverage for the empty-cloud reconcile contract: an account whose
+/// incomplete tasks were all completed/deleted on another device must converge
+/// to an empty desktop list, but a bogus empty `completed=false` page must never
+/// wipe local rows on its own say-so. The empty page only triggers a
+/// reconciliation against the independent ID census: census-absent rows are
+/// proven gone and hard-deleted; census-present rows are resolved through
+/// authoritative per-document reads; a failed census fetch skips everything.
+@MainActor
+private final class EmptyCloudReconcileProbe {
+  var hardDeleteCalls: [Set<String>] = []
+  var censusFetches = 0
+  var detailFetches: [String] = []
+  var visibilityReconciles: [[String]] = []
+  var dashboardRefreshes = 0
+  /// 0 = pristine cache, bumped after each mutation so loadIncomplete can serve
+  /// the cache state the production SQLite would hold at that point.
+  var cacheStage = 0
+}
+
+final class TasksStoreEmptyCloudReconcileTests: XCTestCase {
+
+  // MARK: - Initial-load reconcile (forceReconcileOnLoad)
+
+  @MainActor
+  func testInitialLoadWipesAllStaleSyncedRowsWhenCensusConfirmsAccountHasNoTasks() async {
+    let store = TasksStore.shared
+    await prepareStore(store)
+
+    let staleTask = task(id: "stale-hard-deleted-on-mobile")
+    let probe = EmptyCloudReconcileProbe()
+    let operations = TasksStore.OwnerBoundOperations(
+      fetchPage: { completed, _, _, _ in
+        XCTAssertFalse(completed)
+        return .init(items: [], hasMore: false)
+      },
+      fetchAllTaskIds: { _ in
+        probe.censusFetches += 1
+        return []
+      },
+      syncPage: { _, _, _ in },
+      hardDeleteAbsent: { ids, _ in
+        probe.hardDeleteCalls.append(ids)
+        probe.cacheStage += 1
+        return 1
+      },
+      loadIncomplete: { _ in probe.cacheStage == 0 ? [staleTask] : [] },
+      refreshDashboard: { _ in probe.dashboardRefreshes += 1 })
+
+    await store.loadIncompleteTasks(operations: operations)
+
+    XCTAssertEqual(probe.censusFetches, 1, "empty cloud page must be checked against the ID census")
+    XCTAssertEqual(probe.hardDeleteCalls, [[]], "empty census authorizes the confirmed-empty wipe")
+    XCTAssertEqual(probe.detailFetches, [], "no documents exist, so nothing to resolve per-document")
+    XCTAssertEqual(store.incompleteTasks, [], "stale local tasks must converge to the empty cloud state")
+    XCTAssertEqual(probe.dashboardRefreshes, 1, "dashboard slices must refresh after the wipe")
+    XCTAssertNil(store.error)
+  }
+
+  @MainActor
+  func testInitialLoadResolvesStaleRowsAgainstNonEmptyCensusWithoutBlindDeletion() async {
+    let store = TasksStore.shared
+    await prepareStore(store)
+
+    // Document gone from the cloud entirely (hard-deleted on mobile).
+    let absentTask = task(id: "absent-from-census")
+    // Document still exists but was completed on mobile; the stale local row
+    // must be flipped by an authoritative read, never deleted on the empty
+    // page's word.
+    let presentTask = task(id: "present-in-census")
+    let probe = EmptyCloudReconcileProbe()
+    let operations = TasksStore.OwnerBoundOperations(
+      fetchPage: { _, _, _, _ in .init(items: [], hasMore: false) },
+      fetchAllTaskIds: { _ in
+        probe.censusFetches += 1
+        return [presentTask.id, "unrelated-completed-doc"]
+      },
+      fetchTaskDetail: { id, _ in
+        probe.detailFetches.append(id)
+        return self.task(id: id, completed: true)
+      },
+      reconcileVisibility: { items, _ in
+        probe.visibilityReconciles.append(items.map(\.id))
+        XCTAssertTrue(
+          items.allSatisfy(\.completed),
+          "per-document resolution must carry the authoritative completed state")
+        probe.cacheStage = 2
+        return items.count
+      },
+      syncPage: { _, _, _ in },
+      hardDeleteAbsent: { ids, _ in
+        probe.hardDeleteCalls.append(ids)
+        probe.cacheStage = 1
+        return 1
+      },
+      loadIncomplete: { _ in
+        switch probe.cacheStage {
+        case 0: return [absentTask, presentTask]
+        case 1: return [presentTask]
+        default: return []
+        }
+      },
+      refreshDashboard: { _ in probe.dashboardRefreshes += 1 })
+
+    await store.loadIncompleteTasks(operations: operations)
+
+    XCTAssertEqual(probe.censusFetches, 1)
+    XCTAssertEqual(
+      probe.hardDeleteCalls, [Set([presentTask.id, "unrelated-completed-doc"])],
+      "deletion must run against the census so only proven-absent rows are removed")
+    XCTAssertEqual(
+      probe.detailFetches, [presentTask.id],
+      "census-present stale rows are resolved per-document, not deleted")
+    XCTAssertEqual(probe.visibilityReconciles, [[presentTask.id]])
+    XCTAssertEqual(store.incompleteTasks, [], "both stale rows converge: one wiped, one flipped")
+    XCTAssertNil(store.error)
+  }
+
+  @MainActor
+  func testInitialLoadResolvesMoreThanOnePageOfCensusPresentStaleRowsInOnePass() async {
+    let store = TasksStore.shared
+    await prepareStore(store)
+
+    // More rows than TasksStore.pageSize (100) so a single-page resolution
+    // would strand the tail; the reconcile must drain the whole set in one pass.
+    let staleTasks = (0..<105).map { task(id: "census-present-\($0)") }
+    let staleIds = Set(staleTasks.map(\.id))
+    let probe = EmptyCloudReconcileProbe()
+    let operations = TasksStore.OwnerBoundOperations(
+      fetchPage: { _, _, _, _ in .init(items: [], hasMore: false) },
+      fetchAllTaskIds: { _ in
+        probe.censusFetches += 1
+        return staleTasks.map(\.id)
+      },
+      fetchTaskDetail: { id, _ in
+        probe.detailFetches.append(id)
+        return self.task(id: id, completed: true)
+      },
+      reconcileVisibility: { items, _ in
+        probe.visibilityReconciles.append(items.map(\.id))
+        probe.cacheStage = 2
+        return items.count
+      },
+      syncPage: { _, _, _ in },
+      hardDeleteAbsent: { ids, _ in
+        probe.hardDeleteCalls.append(ids)
+        if probe.cacheStage == 0 { probe.cacheStage = 1 }
+        return 0
+      },
+      loadIncomplete: { _ in probe.cacheStage == 2 ? [] : staleTasks },
+      refreshDashboard: { _ in })
+
+    await store.loadIncompleteTasks(operations: operations)
+
+    XCTAssertEqual(probe.hardDeleteCalls, [staleIds])
+    XCTAssertEqual(
+      Set(probe.detailFetches), staleIds,
+      "every census-present stale row must be resolved in the same pass, not just the first page")
+    XCTAssertEqual(probe.detailFetches.count, staleTasks.count, "each document is read exactly once")
+    XCTAssertEqual(probe.visibilityReconciles.flatMap { $0 }.count, staleTasks.count)
+    XCTAssertEqual(store.incompleteTasks, [], "the full stale set converges in one reconcile pass")
+    XCTAssertNil(store.error)
+  }
+
+  @MainActor
+  func testInitialLoadKeepsLocalTasksWhenCensusFetchFails() async {
+    let store = TasksStore.shared
+    await prepareStore(store)
+
+    let staleTask = task(id: "stale-but-unconfirmed")
+    let probe = EmptyCloudReconcileProbe()
+    let operations = TasksStore.OwnerBoundOperations(
+      fetchPage: { _, _, _, _ in .init(items: [], hasMore: false) },
+      fetchAllTaskIds: { _ in
+        probe.censusFetches += 1
+        throw URLError(.badServerResponse)
+      },
+      syncPage: { _, _, _ in },
+      hardDeleteAbsent: { ids, _ in
+        probe.hardDeleteCalls.append(ids)
+        return 1
+      },
+      loadIncomplete: { _ in [staleTask] },
+      refreshDashboard: { _ in })
+
+    await store.loadIncompleteTasks(operations: operations)
+
+    XCTAssertEqual(probe.censusFetches, 1)
+    XCTAssertEqual(probe.hardDeleteCalls, [], "a failed census fetch must never wipe local rows")
+    XCTAssertEqual(store.incompleteTasks.map(\.id), [staleTask.id], "stale rows stay until the census confirms")
+    XCTAssertNil(store.error)
+  }
+
+  @MainActor
+  func testInitialLoadSkipsCensusWhenLocalCacheAlreadyEmpty() async {
+    let store = TasksStore.shared
+    await prepareStore(store)
+
+    let probe = EmptyCloudReconcileProbe()
+    let operations = TasksStore.OwnerBoundOperations(
+      fetchPage: { _, _, _, _ in .init(items: [], hasMore: false) },
+      fetchAllTaskIds: { _ in
+        probe.censusFetches += 1
+        return []
+      },
+      syncPage: { _, _, _ in },
+      hardDeleteAbsent: { ids, _ in
+        probe.hardDeleteCalls.append(ids)
+        return 0
+      },
+      loadIncomplete: { _ in [] },
+      refreshDashboard: { _ in })
+
+    await store.loadIncompleteTasks(operations: operations)
+
+    XCTAssertEqual(probe.censusFetches, 0, "nothing to reconcile — no census round-trip")
+    XCTAssertEqual(probe.hardDeleteCalls, [])
+    XCTAssertEqual(store.incompleteTasks, [])
+  }
+
+  // MARK: - Auto-refresh reconcile (refreshTasksIfNeeded)
+
+  @MainActor
+  func testAutoRefreshConvergesStaleListWhenCloudEmptiedElsewhere() async {
+    let previousSignedIn = AuthService.shared.isSignedIn
+    let store = TasksStore.shared
+    defer {
+      store.isActive = false
+      AuthService.shared.isSignedIn = previousSignedIn
+    }
+    await prepareStore(store)
+    AuthService.shared.isSignedIn = true
+    // Activate before the first load: the didSet refresh-spawn is gated on
+    // hasLoadedIncomplete, so this cannot fire a default-operations refresh.
+    store.isActive = false
+    store.isActive = true
+
+    // Seed the store with one live task so the follow-up refresh models
+    // "everything was completed on mobile after the desktop loaded".
+    let liveTask = task(id: "live-task")
+    let initialOperations = TasksStore.OwnerBoundOperations(
+      fetchPage: { _, _, _, _ in .init(items: [liveTask], hasMore: false) },
+      fetchAllTaskIds: { _ in [liveTask.id] },
+      syncPage: { _, _, _ in },
+      hardDeleteAbsent: { _, _ in 0 },
+      loadIncomplete: { _ in [liveTask] },
+      refreshDashboard: { _ in })
+    await store.loadIncompleteTasks(operations: initialOperations)
+    XCTAssertEqual(store.incompleteTasks.map(\.id), [liveTask.id])
+
+    let probe = EmptyCloudReconcileProbe()
+    let refreshOperations = TasksStore.OwnerBoundOperations(
+      fetchPage: { _, _, _, _ in .init(items: [], hasMore: false) },
+      fetchAllTaskIds: { _ in
+        probe.censusFetches += 1
+        return []
+      },
+      syncPage: { _, _, _ in },
+      hardDeleteAbsent: { ids, _ in
+        probe.hardDeleteCalls.append(ids)
+        probe.cacheStage += 1
+        return 1
+      },
+      loadIncomplete: { _ in probe.cacheStage == 0 ? [liveTask] : [] },
+      loadDeleted: { _ in [] },
+      refreshDashboard: { _ in })
+
+    await store.refreshTasksIfNeeded(operations: refreshOperations)
+
+    XCTAssertEqual(probe.censusFetches, 1)
+    XCTAssertEqual(probe.hardDeleteCalls, [[]])
+    XCTAssertEqual(store.incompleteTasks, [], "auto-refresh must converge a stale list to the empty cloud state")
+    XCTAssertNil(store.error)
+  }
+
+  // MARK: - Storage layer
+
+  func testHardDeleteAbsentTasksWithConfirmedEmptyWipesOnlySyncedRows() async throws {
+    let fixture = try await RewindStorageTestIsolation.setUp(
+      userIdPrefix: "empty-cloud-reconcile-test")
+    addTeardownBlock {
+      await RewindStorageTestIsolation.tearDown(userDir: fixture.userDir)
+    }
+
+    // One synced stale row (exists locally, gone from the cloud) and one
+    // locally-created row that has not been pushed yet.
+    try await ActionItemStorage.shared.syncTaskActionItems(
+      [
+        TaskActionItem(
+          id: "synced-stale",
+          description: "completed on mobile long ago",
+          completed: false,
+          createdAt: Date(timeIntervalSince1970: 0))
+      ],
+      authorization: .unrestricted)
+    _ = try await ActionItemStorage.shared.insertLocalActionItem(
+      ActionItemRecord(description: "created offline, not pushed"),
+      authorization: .unrestricted)
+
+    // Default (unconfirmed) empty set stays fail-closed.
+    let unconfirmed = try await ActionItemStorage.shared.hardDeleteAbsentTasks(
+      apiIds: [],
+      authorization: .unrestricted)
+    XCTAssertEqual(unconfirmed, 0, "unconfirmed empty API set must not delete anything")
+
+    let deleted = try await ActionItemStorage.shared.hardDeleteAbsentTasks(
+      apiIds: [],
+      authorization: .unrestricted,
+      confirmedEmpty: true)
+    XCTAssertEqual(deleted, 1, "confirmed-empty wipe removes exactly the synced stale row")
+
+    let remaining = try await ActionItemStorage.shared.getLocalActionItems(
+      limit: 10,
+      offset: 0,
+      completed: false)
+    XCTAssertEqual(
+      remaining.map(\.description), ["created offline, not pushed"],
+      "locally-created unsynced rows must survive a confirmed-empty wipe")
+  }
+
+  func testVisibilityReconcileDerivesDeletionFromCancelledStatusOnlyWhenOptedIn() async throws {
+    let fixture = try await RewindStorageTestIsolation.setUp(
+      userIdPrefix: "cancelled-status-reconcile-test")
+    addTeardownBlock {
+      await RewindStorageTestIsolation.tearDown(userDir: fixture.userDir)
+    }
+
+    try await ActionItemStorage.shared.syncTaskActionItems(
+      [
+        TaskActionItem(
+          id: "soft-deleted-in-cloud",
+          description: "retired by the backend",
+          completed: false,
+          createdAt: Date(timeIntervalSince1970: 0))
+      ],
+      authorization: .unrestricted)
+
+    // The wire model has no `deleted` field for list/detail reads; soft
+    // deletion arrives as status=cancelled.
+    let cancelledWireItem = TaskActionItem(
+      id: "soft-deleted-in-cloud",
+      description: "retired by the backend",
+      completed: false,
+      createdAt: Date(timeIntervalSince1970: 0),
+      taskStatus: "cancelled")
+
+    let withoutOptIn = try await ActionItemStorage.shared.reconcileDashboardVisibilityFields(
+      [cancelledWireItem],
+      authorization: .unrestricted)
+    XCTAssertEqual(withoutOptIn, 0, "default callers keep the existing no-derivation semantics")
+
+    let withOptIn = try await ActionItemStorage.shared.reconcileDashboardVisibilityFields(
+      [cancelledWireItem],
+      authorization: .unrestricted,
+      deriveDeletedFromCancelledStatus: true)
+    XCTAssertEqual(withOptIn, 1)
+
+    let visible = try await ActionItemStorage.shared.getLocalActionItems(
+      limit: 10,
+      offset: 0,
+      completed: false)
+    XCTAssertEqual(visible, [], "a cancelled-status document must leave the To Do list")
+  }
+
+  // MARK: - Helpers
+
+  @MainActor
+  private func task(id: String, completed: Bool = false) -> TaskActionItem {
+    TaskActionItem(
+      id: id,
+      description: id,
+      completed: completed,
+      createdAt: Date(timeIntervalSince1970: 0))
+  }
+
+  @MainActor
+  private func prepareStore(_ store: TasksStore) async {
+    let defaults = UserDefaults.standard
+    let previousAuthOwner = defaults.string(forKey: .authUserId)
+    let previousOverride = defaults.string(forKey: .automationOwnerOverride)
+    addTeardownBlock { @MainActor [weak self] in
+      guard let self else { return }
+      await self.establishEffectiveOwner(
+        authOwnerID: previousAuthOwner,
+        automationOverrideID: previousOverride)
+      store.resetSessionState()
+    }
+    await establishEffectiveOwner(authOwnerID: "owner-a", automationOverrideID: nil)
+    store.resetSessionState()
+  }
+
+  @MainActor
+  private func establishEffectiveOwner(
+    authOwnerID: String?,
+    automationOverrideID: String?
+  ) async {
+    let finalOwner = normalizedOwner(automationOverrideID) ?? normalizedOwner(authOwnerID)
+    let bootstrap = finalOwner == "empty-cloud-bootstrap-a"
+      ? "empty-cloud-bootstrap-b"
+      : "empty-cloud-bootstrap-a"
+    if RuntimeOwnerIdentity.currentOwnerId(allowAutomationOverride: true) == bootstrap {
+      await transitionEffectiveOwner(authOwnerID: nil, automationOverrideID: nil)
+    } else {
+      await transitionEffectiveOwner(authOwnerID: bootstrap, automationOverrideID: nil)
+    }
+    await transitionEffectiveOwner(
+      authOwnerID: authOwnerID,
+      automationOverrideID: automationOverrideID)
+  }
+
+  private func transitionEffectiveOwner(
+    authOwnerID: String?,
+    automationOverrideID: String?
+  ) async {
+    let plannedOwner = normalizedOwner(automationOverrideID) ?? normalizedOwner(authOwnerID)
+    _ = await RuntimeOwnerIdentity.performEffectiveOwnerTransition(
+      allowAutomationOverride: true,
+      plannedNextOwner: { _, _ in plannedOwner },
+      quiesceVoice: { _, _ in },
+      revokeKernelOwner: { _, _ in },
+      retargetLocalStorage: { _, _ in },
+      ownerDidChange: {
+        await MainActor.run {
+          NotificationCenter.default.post(name: .runtimeOwnerDidChange, object: nil)
+        }
+      }
+    ) { defaults in
+      if let authOwnerID {
+        defaults.set(authOwnerID, forKey: .authUserId)
+      } else {
+        defaults.removeObject(forKey: .authUserId)
+      }
+      if let automationOverrideID {
+        defaults.set(automationOverrideID, forKey: .automationOwnerOverride)
+      } else {
+        defaults.removeObject(forKey: .automationOwnerOverride)
+      }
+    }
+  }
+
+  private func normalizedOwner(_ value: String?) -> String? {
+    guard let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines),
+      !trimmed.isEmpty
+    else { return nil }
+    return trimmed
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260713-tasks-converge-to-mobile-empty-state.json
+++ b/desktop/macos/changelog/unreleased/20260713-tasks-converge-to-mobile-empty-state.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed Tasks showing hundreds of stale tasks that were already completed or removed on other devices — the desktop list now converges to match mobile, including when all tasks are done"
+}


### PR DESCRIPTION
## Problem

Mobile showed **"No Tasks Yet"** while the macOS desktop showed **365+ tasks** for the same account. Every one of those desktop tasks was already completed or removed elsewhere — they were stale rows in the desktop's local SQLite cache.

## Root cause

All three `TasksStore` reconcile paths (`forceReconcileOnLoad`, `reconcileWithAPIIfNeeded`, the auto-refresh reconcile) treated a zero-item `completed=false` page as a possible backend error and **skipped reconciliation entirely**. A user who completed/deleted every task on another device could therefore never converge: the local-first display re-served the stale cache forever. The failure class is "legitimately-empty cloud state indistinguishable from a degraded-backend empty page, guard fails open to stale data."

## Durable fix

An empty incomplete page never authorizes deletion by itself. It triggers reconciliation against the independent ID census (`GET /v1/action-items/ids`, live on prod and dev):

- rows whose documents are **absent from the census** are proven gone and hard-deleted;
- rows whose documents **still exist** are resolved with authoritative per-document reads (`GET /v1/action-items/{id}`) applied through `reconcileDashboardVisibilityFields`, with an opt-in `deriveDeletedFromCancelledStatus` mapping matching the backend's `deleted → status=cancelled/superseded` projection — never blind deletion;
- an **empty census** itself proves the account has no task documents, which is the only thing that authorizes the storage layer's explicit `confirmedEmpty` wipe;
- a **failed census fetch** preserves the old fail-closed skip.

The resolution loop drains the entire stale set in one pass (terminates: every iteration grows the attempted set or widens the read window). `hardDeleteAbsentTasks` remains scoped to `backendSynced == true` rows — locally-created unsynced tasks are never touched. All mutations are local-cache-only; nothing deletes cloud data.

## Verification

- **Hermetic tests** (8 new, `TasksStoreEmptyCloudReconcileTests`): confirmed-empty wipe; census-present rows resolved per-document instead of deleted; >pageSize (105-row) single-pass convergence; census-failure skip; no-op short-circuit; auto-refresh convergence; storage synced/unsynced selectivity; cancelled-status opt-in derivation. Adjacent suites (`TasksStoreOwnerBoundaryTests` ×14, `ActionItemStorageVisibilityReconciliationTests`, `ActionItemsFTSRepairTests`) all pass; suite also green with `--disable-sandbox`.
- **Real-path E2E** on a named bundle (`omi-tasks-sync`) signed in as the affected account against the live backend: local SQLite held **365 stale incomplete synced rows**, cloud `completed=false` returned **0**, census returned **29** docs. Opening the Tasks page produced `ActionItemStorage: hard-deleted 351 absent tasks` / `TasksStore: Reconciled empty cloud to-do state: 351 stale local tasks resolved`; the 14 census-present rows flipped to completed. Final local DB: exactly 29 completed rows — identical to cloud. The Tasks page renders the "All Caught Up" empty state matching mobile.
- `make preflight`: 13 checks passed. Independent agent review: approved.

## Product invariants affected

none

## Deferred follow-ups (non-blocking reviewer notes)

- The `readLimit` widening branch of the resolution loop is verified by inspection but not exercised by the seam-based tests (the `loadIncomplete` seam ignores `limit`); a limit-honoring seam would close that.
- No hermetic test pins the production glue passing `confirmedEmpty: true` into storage (seams bypass it; a regression there fails safe — empty accounts stop converging — but silently).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9653?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

