### PR TITLE
fix(deploy): sync prod LLM gateway token

### DIFF
--- a/backend/charts/backend-secrets/prod_omi_backend_secrets_values.yaml
+++ b/backend/charts/backend-secrets/prod_omi_backend_secrets_values.yaml
@@ -22,6 +22,8 @@ externalSecret:
       remoteKey: OPENAI_API_KEY
     - secretKey: ANTHROPIC_API_KEY
       remoteKey: ANTHROPIC_API_KEY
+    - secretKey: OMI_LLM_GATEWAY_SERVICE_TOKEN
+      remoteKey: OMI_LLM_GATEWAY_SERVICE_TOKEN
     - secretKey: FAL_KEY
       remoteKey: FAL_KEY
     - secretKey: GROQ_API_KEY

--- a/backend/tests/unit/test_llm_gateway_deploy_contract.py
+++ b/backend/tests/unit/test_llm_gateway_deploy_contract.py
@@ -43,6 +43,18 @@ def test_llm_gateway_anthropic_secret_and_authenticated_readiness_probe_contract
         assert 'X-Omi-Service-Caller: backend' in probe_command
 
 
+def test_gateway_service_token_is_provided_by_external_secrets_contract():
+    for environment in ('dev', 'prod'):
+        gateway = _load_yaml(f'charts/llm-gateway/{environment}_omi_llm_gateway_values.yaml')
+        secrets = _load_yaml(f'charts/backend-secrets/{environment}_omi_backend_secrets_values.yaml')
+
+        assert _env_map(gateway)['OMI_LLM_GATEWAY_SERVICE_TOKEN']['valueFrom']['secretKeyRef'] == {
+            'name': f'{environment}-omi-backend-secrets',
+            'key': 'OMI_LLM_GATEWAY_SERVICE_TOKEN',
+        }
+        assert 'OMI_LLM_GATEWAY_SERVICE_TOKEN' in _secret_keys(secrets)
+
+
 def test_monitoring_scrapes_llm_gateway_with_shared_metrics_secret_contract():
     for environment in ('dev', 'prod'):
         monitoring = _load_yaml(f'charts/monitoring/kube-prometheus-stack/{environment}_omi_monitoring_values.yaml')


### PR DESCRIPTION
## Summary
- Map the production `OMI_LLM_GATEWAY_SERVICE_TOKEN` Secret Manager secret into `prod-omi-backend-secrets` through ExternalSecrets.
- Add a deploy-contract regression test requiring every gateway service-token reference to be backed by the corresponding environment’s ExternalSecret mapping.

## Root cause and durable guard
The production gateway chart referenced `prod-omi-backend-secrets.OMI_LLM_GATEWAY_SERVICE_TOKEN`, but the production ExternalSecret values omitted the corresponding `remoteKey`. A Secret Manager secret therefore could not reach the gateway or backend pod. The added deploy-contract test checks the gateway reference and ExternalSecret key together for both dev and prod.

## Verification
- New regression test failed before the mapping was added because the prod ExternalSecret key was absent.
- `python -m pytest backend/tests/unit/test_llm_gateway_deploy_contract.py -q` — 4 passed.
- `python -m pytest backend/tests/unit/test_llm_gateway_deploy_contract.py backend/tests/unit/test_deploy_status_report.py -q` — 11 passed.
- `ENVIRONMENT=prod ... DRY_RUN=true backend/scripts/deploy-backend-secrets.sh` — rendered the production ExternalSecret successfully.
- `backend/test.sh` ran the complete unit matrix. Five unrelated files tripped the fast-unit duration guard under the full run; rerunning exactly those files through the prescribed `BACKEND_UNIT_TEST_FILE_LIST=... bash test.sh` runner passed (including 61 desktop-transcribe tests).

## Rollout note
This PR only repairs the configuration contract. Deploying it still requires the standard explicit production gateway release and its in-cluster smoke checks.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9655?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

