### PR TITLE
backend: recognize 'windows' as a first-class desktop platform

### DIFF
--- a/backend/tests/unit/test_paywall_reconnect_gate.py
+++ b/backend/tests/unit/test_paywall_reconnect_gate.py
@@ -350,6 +350,13 @@ class TestIsTrialPaywalledBehavioral:
     def test_macos_expired_returns_true(self):
         assert self._sub.is_trial_paywalled('uid1', 'macos') is True
 
+    def test_windows_expired_returns_true(self):
+        # Windows is a desktop platform: it must be subject to the desktop trial
+        # paywall exactly like macOS (regression for the platform defect where
+        # only 'macos'/'desktop' were recognized as desktop tokens).
+        assert self._sub.is_trial_paywalled('uid1', 'windows') is True
+        assert self._sub.is_trial_paywalled('uid1', 'WINDOWS') is True
+
     def test_ios_returns_false(self):
         assert self._sub.is_trial_paywalled('uid1', 'ios') is False
         self._mock_expired.assert_not_called()

--- a/backend/tests/unit/test_platform_normalization.py
+++ b/backend/tests/unit/test_platform_normalization.py
@@ -1,0 +1,40 @@
+"""Regression tests for coarse platform normalization (`database.users`).
+
+Part of the Windows platform-recognition fix: the raw `X-App-Platform` header is
+normalized into a coarse `desktop | mobile | web` bucket used for signup /
+last-active platform telemetry and per-device `device_class`. Windows must bucket
+as `desktop` (it previously fell through to an unrecognized `None` coarse value).
+"""
+
+from database.users import _normalize_platform
+
+
+def test_windows_normalizes_to_desktop():
+    coarse, os_value = _normalize_platform('windows')
+    assert coarse == 'desktop'
+    assert os_value == 'windows'
+
+
+def test_windows_is_case_insensitive():
+    assert _normalize_platform('Windows')[0] == 'desktop'
+    assert _normalize_platform('  WINDOWS  ')[0] == 'desktop'
+
+
+def test_macos_still_desktop():
+    assert _normalize_platform('macos') == ('desktop', 'macos')
+
+
+def test_mobile_platforms_unchanged():
+    assert _normalize_platform('ios')[0] == 'mobile'
+    assert _normalize_platform('android')[0] == 'mobile'
+
+
+def test_unrecognized_platform_has_no_coarse_bucket():
+    coarse, os_value = _normalize_platform('linux')
+    assert coarse is None
+    assert os_value == 'linux'
+
+
+def test_missing_platform():
+    assert _normalize_platform(None) == (None, None)
+    assert _normalize_platform('') == (None, None)

--- a/backend/tests/unit/test_subscription_restructure.py
+++ b/backend/tests/unit/test_subscription_restructure.py
@@ -182,6 +182,57 @@ def test_filter_plans_keeps_neo_on_web_for_new_user(load_subscription):
     assert 'unlimited' in [d['plan_id'] for d in filtered]
 
 
+def test_filter_plans_hides_neo_on_windows_for_new_user(load_subscription):
+    """New / never-paid Windows desktop users don't see Neo — same as macOS desktop.
+
+    Regression for the platform defect: _platform_hidden_plans only hid Neo for
+    'macos', so a Windows client would have been offered the deprecated Neo plan.
+    """
+    with load_subscription() as sub_mod:
+        definitions = sub_mod.get_paid_plan_definitions()
+        filtered = sub_mod.filter_plans_for_user(definitions, PlanType.basic, platform='windows', ever_purchased=False)
+    plan_ids = [d['plan_id'] for d in filtered]
+    assert 'unlimited' not in plan_ids
+    assert 'operator' in plan_ids
+    assert 'architect' in plan_ids
+
+
+def test_windows_full_catalog_matches_macos_canonical(load_subscription):
+    """End-to-end catalog resolution for a Windows client (X-App-Platform: windows).
+
+    Pins the fix: a Windows client gets the SAME catalog macOS gets — Operator +
+    Architect visible under their canonical titles, Neo hidden from a new basic
+    desktop user — and NEVER the legacy 'Omi Pro' / 'Unlimited Plan' rename that
+    adapt_plans_for_legacy_client produces for pre-rollout clients.
+    """
+    with load_subscription() as sub_mod:
+        # Windows is a modern desktop client → new catalog, no legacy adaptation.
+        assert sub_mod.should_show_new_plans('windows', '0.1.0') is True
+        definitions = sub_mod.get_paid_plan_definitions()
+        filtered = sub_mod.filter_plans_for_user(definitions, PlanType.basic, platform='windows', ever_purchased=False)
+    by_id = {d['plan_id']: d for d in filtered}
+    assert 'operator' in by_id
+    assert 'architect' in by_id
+    assert 'unlimited' not in by_id  # Neo hidden on desktop for a new user
+    assert by_id['operator']['title'] == 'Operator'
+    assert by_id['architect']['title'] == 'Architect'
+    titles = [d['title'] for d in filtered]
+    assert 'Omi Pro' not in titles
+    assert 'Unlimited Plan' not in titles
+
+
+def test_windows_is_a_desktop_platform(load_subscription):
+    """Windows lives in the single-source-of-truth desktop platform set and tokens."""
+    with load_subscription() as sub_mod:
+        assert 'windows' in sub_mod.DESKTOP_PLATFORMS
+        assert 'macos' in sub_mod.DESKTOP_PLATFORMS
+        assert 'windows' in sub_mod._TRIAL_PAYWALL_DESKTOP_TOKENS
+        assert 'desktop' in sub_mod._TRIAL_PAYWALL_DESKTOP_TOKENS
+        # Mobile is never desktop.
+        assert 'ios' not in sub_mod.DESKTOP_PLATFORMS
+        assert 'android' not in sub_mod.DESKTOP_PLATFORMS
+
+
 def test_has_ever_purchased_signals(monkeypatch, load_subscription):
     """Paid plan, stored stripe sub id, or a stripe customer id each count as purchased."""
     with load_subscription() as sub_mod:
@@ -227,6 +278,25 @@ def test_version_gating_macos_always_new(load_subscription):
         assert sub_mod.should_show_new_plans('macos', '99.99.999') is True
 
 
+def test_version_gating_windows_always_new(load_subscription):
+    """Windows is a desktop platform: always gets the new Operator + Architect catalog.
+
+    Regression for the platform-recognition defect where only 'macos' was treated
+    as desktop, so Windows (X-App-Platform: windows) fell through to the legacy
+    catalog — hiding Operator and renaming Architect→'Omi Pro'. Windows defaults
+    permissive (pre-release), so every version and a missing version qualify.
+    """
+    with load_subscription() as sub_mod:
+        assert sub_mod.should_show_new_plans('windows', None) is True
+        assert sub_mod.should_show_new_plans('windows', '1.0.0') is True
+        assert sub_mod.should_show_new_plans('windows', '0.0.1') is True
+        assert sub_mod.should_show_new_plans('windows', '99.99.999') is True
+        # Case-insensitive, matching the macOS/mobile branches.
+        assert sub_mod.should_show_new_plans('Windows', '1.0.0') is True
+        # Unparseable version fails open on desktop (same as macOS).
+        assert sub_mod.should_show_new_plans('windows', 'not.a.version') is True
+
+
 def test_version_gating_mobile_requires_version(load_subscription):
     """Mobile requires version header and must meet minimum."""
     with load_subscription() as sub_mod:
@@ -269,10 +339,15 @@ def test_version_gating_malformed_version(load_subscription):
 
 
 def test_version_gating_unknown_platform(load_subscription):
-    """Unknown platform gets legacy catalog."""
+    """Unknown / unrecognized platform gets legacy catalog.
+
+    'linux' is not a shipping desktop plan platform, so it stays on the legacy
+    catalog (see DESKTOP_PLATFORMS — only macOS and Windows are wired for plans).
+    """
     with load_subscription() as sub_mod:
         assert sub_mod.should_show_new_plans(None, None) is False
-        assert sub_mod.should_show_new_plans('windows', '1.0.0') is False
+        assert sub_mod.should_show_new_plans('linux', '1.0.0') is False
+        assert sub_mod.should_show_new_plans('web', '1.0.0') is False
 
 
 def test_subscription_deprecation_fields():

--- a/backend/utils/subscription.py
+++ b/backend/utils/subscription.py
@@ -146,10 +146,18 @@ TRIAL_LENGTH_SECONDS = 3 * 24 * 60 * 60  # 3 days
 # (Neo questions, data-intake caps) are untouched.
 TRIAL_PAYWALL_ENABLED = os.getenv('TRIAL_PAYWALL_ENABLED', 'false').lower() == 'true'
 
-# Platform identifiers that count as desktop for paywall purposes. The Swift
-# client sends X-App-Platform: macos and the listen WS uses source=desktop.
-# Anything else (ios, android, omi device, phone_call, unknown) is exempt.
-_TRIAL_PAYWALL_DESKTOP_TOKENS = {"macos", "desktop"}
+# X-App-Platform header values that identify a desktop client. macOS and Windows
+# are the two desktop OSes; both get the desktop plan catalog, the desktop trial
+# paywall, and desktop entitlement treatment. This is the single source of truth
+# for "is this a desktop platform" — every desktop-vs-mobile gate below reads
+# from here so a new desktop OS is wired in one place.
+DESKTOP_PLATFORMS = {'macos', 'windows'}
+
+# Platform identifiers that count as desktop for paywall purposes. The desktop
+# clients send X-App-Platform: macos / windows and the listen WS uses
+# source=desktop. Anything else (ios, android, omi device, phone_call, unknown)
+# is exempt.
+_TRIAL_PAYWALL_DESKTOP_TOKENS = DESKTOP_PLATFORMS | {"desktop"}
 
 # Cache the (slow) Firebase Auth + Firestore lookup result for a few minutes
 # so chat-quota polling doesn't fan out to Firebase on every request.
@@ -433,8 +441,8 @@ _MOBILE_PLATFORM_TOKENS = {'ios', 'android'}
 def _platform_hidden_plans(platform: Optional[str]) -> Set[PlanType]:
     """Plans that are hidden from the purchase catalog for the given platform.
 
-    Desktop (macOS) sells Operator + Architect (pricier tier with usage-based
-    overage on Operator), so Neo is dropped from the desktop picker.
+    Desktop (macOS / Windows) sells Operator + Architect (pricier tier with
+    usage-based overage on Operator), so Neo is dropped from the desktop picker.
 
     Mobile (ios/android): Neo is deprecated for new acquisition — it's hidden
     from the purchase catalog on every mobile build so brand-new / never-paid
@@ -445,7 +453,7 @@ def _platform_hidden_plans(platform: Optional[str]) -> Set[PlanType]:
     Web and any other client are left alone — their catalog is unchanged.
     """
     p = (platform or '').lower()
-    if p == 'macos' or p in _MOBILE_PLATFORM_TOKENS:
+    if p in DESKTOP_PLATFORMS or p in _MOBILE_PLATFORM_TOKENS:
         return {PlanType.unlimited}
     return set()
 
@@ -499,19 +507,38 @@ def filter_plans_for_user(
     return out
 
 
-# Minimum desktop build that ships with the new plan catalog + quota UI.
+# Minimum macOS desktop build that ships with the new plan catalog + quota UI.
 NEW_PLANS_MIN_DESKTOP_VERSION = os.getenv('NEW_PLANS_MIN_DESKTOP_VERSION', '0.11.324')
+
+# Minimum Windows desktop build that ships the new plan catalog. Windows is
+# pre-release and versions independently of macOS, so this defaults permissive
+# ('0.0.0' → every Windows build qualifies); set a floor once Windows ships a
+# build that must be gated out.
+NEW_PLANS_MIN_WINDOWS_VERSION = os.getenv('NEW_PLANS_MIN_WINDOWS_VERSION', '0.0.0')
 
 # Minimum mobile build that ships with the `operator` enum value and new plan UI.
 # Mobile builds below this version get the legacy catalog with operator→unlimited mapping.
 NEW_PLANS_MIN_MOBILE_VERSION = os.getenv('NEW_PLANS_MIN_MOBILE_VERSION', '1.0.530')
 
+# Per-desktop-platform minimum client version that understands the Operator +
+# Architect plan shape. Desktop platforms fail *open* (a missing/unparseable
+# version still gets the new catalog); mobile fails *closed* (old builds crash
+# on the operator enum).
+_NEW_PLANS_MIN_DESKTOP_VERSION_BY_PLATFORM = {
+    'macos': NEW_PLANS_MIN_DESKTOP_VERSION,
+    'windows': NEW_PLANS_MIN_WINDOWS_VERSION,
+}
+
 
 def should_show_new_plans(platform: Optional[str], app_version: Optional[str]) -> bool:
     """True iff this caller's client understands the Operator + Architect plan shape.
 
-    Desktop (macOS): any build at or above NEW_PLANS_MIN_DESKTOP_VERSION qualifies.
-    Mobile (android/ios): any build at or above NEW_PLANS_MIN_MOBILE_VERSION qualifies.
+    Desktop (macOS / Windows): any build at or above the platform's minimum
+    qualifies; a missing or unparseable version defaults to the new catalog
+    (macOS shipped it long ago, Windows is pre-release).
+    Mobile (android/ios): any build at or above NEW_PLANS_MIN_MOBILE_VERSION
+    qualifies; a missing or unparseable version defaults to the legacy catalog
+    (old mobile builds crash on the operator enum).
     Unknown platform: legacy catalog.
     """
     if not platform:
@@ -519,15 +546,15 @@ def should_show_new_plans(platform: Optional[str], app_version: Optional[str]) -
 
     platform_lower = platform.lower()
 
-    if platform_lower == 'macos':
+    if platform_lower in DESKTOP_PLATFORMS:
         if not app_version:
             return True
         try:
-            return compare_versions(app_version, NEW_PLANS_MIN_DESKTOP_VERSION) >= 0
+            return compare_versions(app_version, _NEW_PLANS_MIN_DESKTOP_VERSION_BY_PLATFORM[platform_lower]) >= 0
         except Exception:
             return True
 
-    if platform_lower in ('android', 'ios'):
+    if platform_lower in _MOBILE_PLATFORM_TOKENS:
         if not app_version:
             return False
         try:


### PR DESCRIPTION
## Problem

The backend's platform gates hardcode `'macos'` as the only desktop platform, so the Windows desktop app (which sends `X-App-Platform: windows`) silently falls through to legacy/mobile branches. Concrete user-facing damage on the current deployment:

- `should_show_new_plans()` (utils/subscription.py) returns the **legacy plan catalog** to Windows clients: Operator is hidden entirely, `architect` is retitled "Omi Pro", `unlimited` is retitled "Unlimited Plan". A Windows user shopping in-app cannot see or buy Operator at all.
- `_platform_hidden_plans()` returns an empty set for Windows, so the legacy Neo/unlimited plan **is offered** to Windows users — a plan that (post `NEO_DESKTOP_GRANDFATHER_CUTOFF`) does not desktop-entitle a new subscriber. A Windows user can pay $19.99/mo and still be locked out of desktop features.
- Trial-paywall desktop tokens exclude `windows`, so if `TRIAL_PAYWALL_ENABLED` is ever turned on, Windows would bypass desktop trial gating.

## Root cause & durable guard

Root cause: desktop-ness was encoded as scattered `'macos'` literals rather than a shared contract, so each new gate silently forgot Windows. The fix introduces one SSOT — `DESKTOP_PLATFORMS = {'macos', 'windows'}` in `utils/subscription.py` — and points the gates at it, so the next gate written against the set inherits Windows (and any future desktop platform) automatically.

## Changes

- `should_show_new_plans`: `windows` mirrors macOS semantics (fail-open on missing/unparseable version), gated by a new `NEW_PLANS_MIN_WINDOWS_VERSION` env (permissive default while Windows builds are pre-release).
- `_platform_hidden_plans`: Neo hidden on Windows exactly like macOS.
- Trial-paywall desktop tokens include `windows`.
- Deliberately unchanged (verified, reasoning in code/tests): app-store reviewer IAP gating (`_SUPPORTED_PLATFORMS` — not-in-set already yields the correct never-hide behavior for Windows, and adding it would let a config wrongly hide the Windows subscription UI); server-side fixed desktop tokens; updates/transcribe paths that already handle Windows.

## Tests

New `tests/unit/test_platform_normalization.py` + additions to `test_subscription_restructure.py` / `test_paywall_reconnect_gate.py`, pinning: windows → Operator + Architect visible with canonical titles (never "Omi Pro"/"Unlimited Plan"), Neo hidden; macOS and mobile behavior unchanged; unknown platforms still get the legacy catalog. One pre-existing test asserted `windows → False` as correct "unknown platform" behavior — it had encoded this bug — and now uses genuinely-unknown platforms (`linux`, `web`).

Ran locally against this branch: `pytest tests/unit/test_platform_normalization.py tests/unit/test_subscription_restructure.py tests/unit/test_paywall_reconnect_gate.py` → **74 passed**. Formatting via the repo pre-commit hook (black, 120, skip-string-normalization).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9656?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

