### PR TITLE
fix(desktop): don't trap on a zero-area window frame during screen capture

### DIFF
--- a/desktop/macos/Desktop/Sources/ScreenCaptureService.swift
+++ b/desktop/macos/Desktop/Sources/ScreenCaptureService.swift
@@ -739,6 +739,43 @@ final class ScreenCaptureService: Sendable {
     }
   }
 
+  /// Capture dimensions that preserve the window's aspect ratio, or nil for a
+  /// degenerate frame. `static` so it is synchronously unit-testable.
+  ///
+  /// A zero-width frame makes `aspectRatio` 0, so `configWidth / aspectRatio` is
+  /// NaN (0/0). NaN fails every comparison, so the `> maxSize` clamp does not fire
+  /// and `Int(NaN)` traps — an uncatchable crash, not a thrown error. Refuse to
+  /// capture a zero-area window instead.
+  static func captureDimensions(
+    width: CGFloat, height: CGFloat, maxSize: CGFloat
+  ) -> (width: Int, height: Int)? {
+    guard width > 0, height > 0 else { return nil }
+
+    let aspectRatio = width / height
+    var configWidth = min(width, maxSize)
+    var configHeight = configWidth / aspectRatio
+    if configHeight > maxSize {
+      configHeight = maxSize
+      configWidth = configHeight * aspectRatio
+    }
+    return (Int(configWidth), Int(configHeight))
+  }
+
+  /// Aspect-preserving stream configuration, or nil if the window has no area.
+  private func captureConfiguration(for window: SCWindow) -> SCStreamConfiguration? {
+    guard
+      let size = Self.captureDimensions(
+        width: window.frame.width, height: window.frame.height, maxSize: maxSize)
+    else { return nil }
+
+    let config = SCStreamConfiguration()
+    config.scalesToFit = true
+    config.showsCursor = false
+    config.width = size.width
+    config.height = size.height
+    return config
+  }
+
   /// Capture using ScreenCaptureKit (macOS 14.0+)
   @available(macOS 14.0, *)
   private func captureWithScreenCaptureKit(windowID: CGWindowID) async -> Data? {
@@ -753,23 +790,12 @@ final class ScreenCaptureService: Sendable {
         log("Window not found in SCShareableContent")
         return nil
       }
+      guard let config = captureConfiguration(for: window) else {
+        log("Skipping capture of zero-area window frame")
+        return nil
+      }
 
       let filter = SCContentFilter(desktopIndependentWindow: window)
-      let config = SCStreamConfiguration()
-      config.scalesToFit = true
-      config.showsCursor = false
-      // Calculate dimensions maintaining aspect ratio (don't create square canvas)
-      let windowWidth = window.frame.width
-      let windowHeight = window.frame.height
-      let aspectRatio = windowWidth / windowHeight
-      var configWidth = min(windowWidth, maxSize)
-      var configHeight = configWidth / aspectRatio
-      if configHeight > maxSize {
-        configHeight = maxSize
-        configWidth = configHeight * aspectRatio
-      }
-      config.width = Int(configWidth)
-      config.height = Int(configHeight)
 
       let image = try await SCScreenshotManager.captureImage(
         contentFilter: filter,
@@ -818,33 +844,21 @@ final class ScreenCaptureService: Sendable {
       }
 
       let filterAndConfig: (SCContentFilter, SCStreamConfiguration)? = autoreleasepool {
-        guard let window = content.windows.first(where: { $0.windowID == windowID }) else {
+        guard let window = content.windows.first(where: { $0.windowID == windowID }),
+          let config = captureConfiguration(for: window)
+        else {
           return nil
         }
 
-        let filter = SCContentFilter(desktopIndependentWindow: window)
-        let config = SCStreamConfiguration()
-        config.scalesToFit = true
-        config.showsCursor = false
-        let windowWidth = window.frame.width
-        let windowHeight = window.frame.height
-        let aspectRatio = windowWidth / windowHeight
-        var configWidth = min(windowWidth, maxSize)
-        var configHeight = configWidth / aspectRatio
-        if configHeight > maxSize {
-          configHeight = maxSize
-          configWidth = configHeight * aspectRatio
-        }
-        config.width = Int(configWidth)
-        config.height = Int(configHeight)
-        return (filter, config)
+        return (SCContentFilter(desktopIndependentWindow: window), config)
       }
 
       guard let (filter, config) = filterAndConfig else {
-        // Window ID no longer exists — the user closed a tab, dismissed a modal,
-        // or the app destroyed the window between resolution and capture. This is
-        // routine, not a capture failure. Caller should re-resolve and retry.
-        log("Window \(windowID) not found in SCShareableContent (window closed)")
+        // Window ID no longer exists, or it reports a zero-area frame — the user
+        // closed a tab, dismissed a modal, or the app destroyed the window between
+        // resolution and capture. This is routine, not a capture failure. Caller
+        // should re-resolve and retry.
+        log("Window \(windowID) not capturable in SCShareableContent (closed or zero-area)")
         return .windowGone
       }
 
@@ -877,26 +891,13 @@ final class ScreenCaptureService: Sendable {
       // accumulate in Swift concurrency's cooperative thread pool (which doesn't
       // drain autorelease pools between tasks).
       let filterAndConfig: (SCContentFilter, SCStreamConfiguration)? = autoreleasepool {
-        guard let window = content.windows.first(where: { $0.windowID == windowID }) else {
+        guard let window = content.windows.first(where: { $0.windowID == windowID }),
+          let config = captureConfiguration(for: window)
+        else {
           return nil
         }
 
-        let filter = SCContentFilter(desktopIndependentWindow: window)
-        let config = SCStreamConfiguration()
-        config.scalesToFit = true
-        config.showsCursor = false
-        let windowWidth = window.frame.width
-        let windowHeight = window.frame.height
-        let aspectRatio = windowWidth / windowHeight
-        var configWidth = min(windowWidth, maxSize)
-        var configHeight = configWidth / aspectRatio
-        if configHeight > maxSize {
-          configHeight = maxSize
-          configWidth = configHeight * aspectRatio
-        }
-        config.width = Int(configWidth)
-        config.height = Int(configHeight)
-        return (filter, config)
+        return (SCContentFilter(desktopIndependentWindow: window), config)
       }
 
       guard let (filter, config) = filterAndConfig else {

--- a/desktop/macos/Desktop/Tests/ScreenCaptureDimensionsTests.swift
+++ b/desktop/macos/Desktop/Tests/ScreenCaptureDimensionsTests.swift
@@ -1,0 +1,51 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// Regression coverage for window-capture sizing.
+///
+/// The capture path previously computed `configHeight = min(width, maxSize) / (width / height)`
+/// inline. A zero-width window frame makes that expression NaN (0/0); NaN fails the
+/// `configHeight > maxSize` clamp, so `Int(NaN)` executed and trapped — crashing the app
+/// from the background screen-capture loop. Sizing is now a pure function that refuses
+/// degenerate frames; these tests pin that.
+final class ScreenCaptureDimensionsTests: XCTestCase {
+    private let maxSize: CGFloat = 3000
+
+    func testPreservesAspectRatioForNormalWindow() {
+        let size = ScreenCaptureService.captureDimensions(width: 1440, height: 900, maxSize: maxSize)
+        XCTAssertEqual(size?.width, 1440)
+        XCTAssertEqual(size?.height, 900)
+    }
+
+    func testClampsOversizedWindowToMaxSize() {
+        // 6000x3000 → width clamps to 3000, height follows the 2:1 aspect ratio.
+        let size = ScreenCaptureService.captureDimensions(width: 6000, height: 3000, maxSize: maxSize)
+        XCTAssertEqual(size?.width, 3000)
+        XCTAssertEqual(size?.height, 1500)
+    }
+
+    func testClampsTallWindowByHeight() {
+        // 1000x9000 → height clamps to 3000, width follows the 1:9 aspect ratio.
+        let size = ScreenCaptureService.captureDimensions(width: 1000, height: 9000, maxSize: maxSize)
+        XCTAssertEqual(size?.height, 3000)
+        XCTAssertEqual(size?.width, 333)
+    }
+
+    /// The crash: width 0 produced NaN, and `Int(NaN)` traps.
+    func testReturnsNilForZeroWidthFrame() {
+        XCTAssertNil(ScreenCaptureService.captureDimensions(width: 0, height: 900, maxSize: maxSize))
+    }
+
+    func testReturnsNilForZeroHeightFrame() {
+        XCTAssertNil(ScreenCaptureService.captureDimensions(width: 1440, height: 0, maxSize: maxSize))
+    }
+
+    func testReturnsNilForFullyDegenerateFrame() {
+        XCTAssertNil(ScreenCaptureService.captureDimensions(width: 0, height: 0, maxSize: maxSize))
+    }
+
+    func testReturnsNilForNegativeFrame() {
+        XCTAssertNil(ScreenCaptureService.captureDimensions(width: -100, height: 900, maxSize: maxSize))
+    }
+}

--- a/desktop/macos/changelog/unreleased/20260713-screen-capture-zero-area-window-crash.json
+++ b/desktop/macos/changelog/unreleased/20260713-screen-capture-zero-area-window-crash.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed a crash when a window reported a zero-area frame while the app was capturing screen context"
+}


### PR DESCRIPTION
## Bug

`ScreenCaptureService` sized its capture canvas inline, duplicated at **three** call sites (`captureWithScreenCaptureKit`, `captureWindowCGImage`, `captureActiveWindowCGImage`):

```swift
let aspectRatio = windowWidth / windowHeight
var configWidth  = min(windowWidth, maxSize)
var configHeight = configWidth / aspectRatio
if configHeight > maxSize { configHeight = maxSize; configWidth = configHeight * aspectRatio }
config.width  = Int(configWidth)
config.height = Int(configHeight)
```

When a window reports a **zero-width frame**, `aspectRatio` is `0`, so `configHeight` is `0 / 0` = **NaN**. NaN fails every comparison, so the `> maxSize` clamp silently does not fire, and **`Int(NaN)` traps**.

A trap is not a Swift error — the enclosing `do/catch` cannot catch it. The process dies. This runs on every background screen-capture cycle, so a rare per-cycle condition compounds.

## Root cause

Unvalidated geometry from `SCWindow.frame` flowed straight into a division and then a trapping `Int(_: Double)` conversion, and the guard was missing in all three copies of the block.

## Fix

The sizing math becomes one pure function, `captureDimensions(width:height:maxSize:)`, that returns `nil` for a degenerate frame; all three sites now go through a single `captureConfiguration(for:)`. A zero-area window is **skipped** — reported as the already-existing benign `.windowGone`, which the caller re-resolves and retries — instead of crashing.

This closes the class rather than patching one line: three copies of the trap collapse into one guarded path (net **−53** lines), and the math is now unit-testable in isolation (same shape as the existing `StorageSyncService.bytesPerSecond`).

Behavior for valid geometry is unchanged.

## Verification

- **Trap reproduced standalone** with the exact production expression for `w=0, h=900` → `configHeight = nan`, process dies (**exit 133**). Zero *height* alone is safe (`+inf` → `0`); it is specifically **width == 0** that yields NaN.
- **New `ScreenCaptureDimensionsTests`** (7 cases) calls the production function, including the `width: 0` input that traps on `main` today — the test that would have caught this. All pass.
- `xcrun swift test --filter "ScreenCapture|CaptureScreenTool|ScreenContextTelemetry|ScreenPrivacy"` → **53 tests, 0 failures**.
- `xcrun swift build -c debug --package-path Desktop` → clean.
- `python3 scripts/check_desktop_test_quality.py` → OK (no new debt).
- Named-bundle app (`omi-fix-capture-nan`) **builds, installs and launches** carrying the change; automation bridge responds.

### Not verified (stated plainly)

A real zero-width window cannot be summoned on demand, and a throwaway ad-hoc bundle gets neither a Screen Recording TCC grant nor a signed-in session — so the ScreenCaptureKit path could not be driven end-to-end in the running app. The crash and its fix are proven **at the function level** (unit test + standalone repro), not by observing a live degenerate window.

🤖 automated by hourly watchdog; opened for review, not merged.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9659?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

