### PR TITLE
fix(backend): forward attribute access through the lazy Typesense shim

### DIFF
--- a/backend/tests/unit/test_typesense_lazy_client_shim.py
+++ b/backend/tests/unit/test_typesense_lazy_client_shim.py
@@ -1,0 +1,81 @@
+"""The lazy Typesense shim must expose the real client's surface, not just subscripts.
+
+The shim defers client construction (offline tests import these modules with
+Typesense unconfigured). A shim that only implements ``__getitem__`` silently
+narrows the API: ``client.collections.create(...)`` — the only non-subscript
+production caller (``utils.memory.atom_keyword_index.ensure_memories_collection``)
+— then raises AttributeError, which its caller swallows, so the collection is
+never auto-created and every atom upsert no-ops forever.
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import MagicMock
+
+import pytest
+
+os.environ.setdefault(
+    "ENCRYPTION_SECRET",
+    "omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv",
+)
+
+from utils.conversations import search
+
+
+@pytest.fixture
+def fake_typesense(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
+    """Replace the constructed client, keeping the real shim under test."""
+    fake = MagicMock()
+    monkeypatch.setattr(search, "_typesense_client", None)
+    monkeypatch.setattr(search, "_get_typesense_client", lambda: fake)
+    return fake
+
+
+def test_collections_attribute_calls_reach_the_real_client(fake_typesense: MagicMock) -> None:
+    schema = {"name": "canonical_memory_atoms", "fields": []}
+
+    search.client.collections.create(schema)
+
+    fake_typesense.collections.create.assert_called_once_with(schema)
+
+
+def test_collections_subscript_still_reaches_the_real_client(fake_typesense: MagicMock) -> None:
+    search.client.collections["conversations"].documents.search({"q": "*"})
+
+    fake_typesense.collections.__getitem__.assert_called_once_with("conversations")
+
+
+def test_client_attribute_calls_reach_the_real_client(fake_typesense: MagicMock) -> None:
+    search.client.multi_search.perform({}, {})
+
+    fake_typesense.multi_search.perform.assert_called_once_with({}, {})
+
+
+def test_dunder_lookups_do_not_construct_a_client(monkeypatch: pytest.MonkeyPatch) -> None:
+    def explode() -> object:
+        raise AssertionError("shim constructed a Typesense client during introspection")
+
+    monkeypatch.setattr(search, "_get_typesense_client", explode)
+
+    with pytest.raises(AttributeError):
+        search.client.__deepcopy__
+    with pytest.raises(AttributeError):
+        search.client.collections.__deepcopy__
+
+
+def test_ensure_memories_collection_creates_through_the_shim(
+    fake_typesense: MagicMock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """End-to-end: the real production caller creates a missing collection."""
+    from utils.memory import atom_keyword_index
+
+    monkeypatch.setenv(atom_keyword_index.ATOM_KEYWORD_COLLECTION_ENV, "canonical_memory_atoms")
+    fake_typesense.collections.__getitem__.return_value.retrieve.side_effect = Exception("collection missing")
+
+    atom_keyword_index.ensure_memories_collection()
+
+    fake_typesense.collections.create.assert_called_once()
+    created_schema = fake_typesense.collections.create.call_args.args[0]
+    assert created_schema["name"] == "canonical_memory_atoms"
+    assert atom_keyword_index._REQUIRED_SCHEMA_FIELDS <= {field["name"] for field in created_schema["fields"]}

--- a/backend/utils/conversations/search.py
+++ b/backend/utils/conversations/search.py
@@ -61,14 +61,28 @@ def _get_typesense_client() -> Any:
     return _typesense_client
 
 
+def _lazy_getattr(target: Any, name: str) -> Any:
+    # Dunders stay unresolved so introspection (copy, pickle, mock) cannot
+    # construct a real client and defeat the laziness this shim exists for.
+    if name.startswith('__') and name.endswith('__'):
+        raise AttributeError(name)
+    return getattr(target(), name)
+
+
 class _LazyCollections:
     def __getitem__(self, name: str) -> Any:
         return _get_typesense_client().collections[name]
+
+    def __getattr__(self, name: str) -> Any:
+        return _lazy_getattr(lambda: _get_typesense_client().collections, name)
 
 
 class _LazyTypesenseClient:
     def __init__(self) -> None:
         self.collections: Any = _LazyCollections()
+
+    def __getattr__(self, name: str) -> Any:
+        return _lazy_getattr(_get_typesense_client, name)
 
 
 client: Any = _LazyTypesenseClient()


### PR DESCRIPTION
## Bug

`cf1e0d5cc1` ("defer Typesense client construction") replaced the module-level `typesense.Client` in `utils/conversations/search.py` with a lazy shim — but `_LazyCollections` implements **only `__getitem__`**.

That silently narrows the client's API to subscript access. The one non-subscript production caller is `ensure_memories_collection()` (`utils/memory/atom_keyword_index.py:174`), which does an **attribute** call:

```python
_typesense_client().collections.create(schema)
```

It now raises:

```
AttributeError: '_LazyCollections' object has no attribute 'create'
```

## Impact

`ensure_memories_collection()` only reaches `.create(...)` when the collection is missing (the `retrieve()` except branch) — i.e. exactly on a fresh Typesense instance, a recreated cluster, or a renamed `MEMORY_TYPESENSE_COLLECTION`. That is the state the memory-maintenance job's Typesense wiring (`29daca1ba4`, same day) just stood up.

The `AttributeError` is then **swallowed** by `upsert_atom_keyword_doc`'s bare `except Exception` (`atom_keyword_index.py:197`), which logs a WARNING and returns `False`. Net effect: the canonical atom collection can never be auto-created, every atom upsert silently no-ops, and canonical memory hybrid retrieval degrades to **vector-only, permanently and silently**. It also counts as `keyword_sync_failures`, which `fea058bb13` made `apply_legacy_backfill_remediation.py` exit 1 on — so the new operator remediation script reports failure in exactly this environment.

## Root cause and durable guard

A lazy proxy that hand-picks one dunder instead of forwarding the wrapped object's surface. Patching only `create` would leave the next caller of any other client method to hit a fresh `AttributeError`.

The guard forwards **every** real attribute, on both shim levels (`_LazyCollections` and `_LazyTypesenseClient`). Dunder names deliberately stay unresolved, so `copy`/`pickle`/mock introspection cannot construct a real client and defeat the laziness the shim exists for.

## Why no existing test caught it

`tests/unit/test_ws_m_atom_keyword_index.py:242` patches `atom_keyword_index._typesense_client` with a `MagicMock`, so the real shim is never exercised — and its fixture makes `retrieve()` raise, so every test *does* take the create branch, but against a mock where `.create` exists. The suite is structurally blind to this. The new test patches `search._get_typesense_client` instead, keeping the **real shim** under test.

## Verification

Run from `backend/` (python3.11 venv):

- `tests/unit/test_typesense_lazy_client_shim.py` — **5 passed** with the fix. Reverting `search.py` to the old shim **fails 3 of them** with the exact `AttributeError` at `atom_keyword_index.py:174`, including the end-to-end `ensure_memories_collection()` create path.
- **69 passed** across the atom-keyword-index, conversation-hybrid-search, typesense-timeout-failsoft, search pagination/date/UTC, and memory-search-gateway suites.
- `scripts/scan_import_time_side_effects.py` → 668 files, 0 violations; `scripts/check_module_stub_pollution.py` → 634 files, 0 violations.
- `black --line-length 120 --skip-string-normalization` clean.

🤖 automated by hourly watchdog; opened for review, not merged.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9669?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

