### PR TITLE
feat(desktop): fallback telemetry for empty-cloud task reconciliation

### DIFF
--- a/desktop/macos/Desktop/Sources/DesktopDiagnosticsManager.swift
+++ b/desktop/macos/Desktop/Sources/DesktopDiagnosticsManager.swift
@@ -750,6 +750,7 @@ final class DesktopDiagnosticsManager {
     "ble_audio",
     "automation_bridge",
     "transcription_retry",
+    "task_reconcile",
     "other",
   ]
 

--- a/desktop/macos/Desktop/Sources/Stores/TasksStore.swift
+++ b/desktop/macos/Desktop/Sources/Stores/TasksStore.swift
@@ -1019,11 +1019,26 @@ class TasksStore: ObservableObject {
             lastReconciliationDate = Date()
             if changed > 0 {
                 log("TasksStore: Reconciled empty cloud to-do state: \(changed) stale local tasks resolved")
+                DesktopDiagnosticsManager.shared.recordFallback(
+                    area: "task_reconcile",
+                    from: "incomplete_page",
+                    to: "id_census",
+                    reason: "local_heal",
+                    outcome: .recovered,
+                    extra: ["resolved_rows": changed]
+                )
             }
             return changed
         } catch {
             if isCurrent(lease) {
                 log("TasksStore: Empty-cloud reconciliation skipped — census fetch failed: \(error.localizedDescription)")
+                DesktopDiagnosticsManager.shared.recordFallback(
+                    area: "task_reconcile",
+                    from: "incomplete_page",
+                    to: "none",
+                    reason: "other",
+                    outcome: .degraded
+                )
             }
             return nil
         }
@@ -1043,8 +1058,21 @@ class TasksStore: ObservableObject {
         operations: OwnerBoundOperations
     ) async -> Int {
         var flippedTotal = 0
+        var unresolvedRows = 0
         var attempted = Set<String>()
         var readLimit = pageSize
+        defer {
+            if unresolvedRows > 0 {
+                DesktopDiagnosticsManager.shared.recordFallback(
+                    area: "task_reconcile",
+                    from: "id_census",
+                    to: "none",
+                    reason: "other",
+                    outcome: .degraded,
+                    extra: ["unresolved_rows": unresolvedRows]
+                )
+            }
+        }
         do {
             while true {
                 guard isCurrent(lease) else { return flippedTotal }
@@ -1084,6 +1112,7 @@ class TasksStore: ObservableObject {
                     } catch {
                         // One unreadable document must not abort the rest; it stays
                         // visible and is retried on the next reconcile pass.
+                        unresolvedRows += 1
                         log("TasksStore: Skipping stale-row resolution for one task: \(error.localizedDescription)")
                     }
                 }
@@ -1103,6 +1132,7 @@ class TasksStore: ObservableObject {
             return flippedTotal
         } catch {
             if isCurrent(lease) {
+                unresolvedRows += 1
                 log("TasksStore: Stale-row resolution skipped: \(error.localizedDescription)")
             }
             return flippedTotal

--- a/desktop/macos/Desktop/Tests/TasksStoreEmptyCloudReconcileTests.swift
+++ b/desktop/macos/Desktop/Tests/TasksStoreEmptyCloudReconcileTests.swift
@@ -58,6 +58,11 @@ final class TasksStoreEmptyCloudReconcileTests: XCTestCase {
     XCTAssertEqual(store.incompleteTasks, [], "stale local tasks must converge to the empty cloud state")
     XCTAssertEqual(probe.dashboardRefreshes, 1, "dashboard slices must refresh after the wipe")
     XCTAssertNil(store.error)
+
+    let fallback = try? latestFallbackSnapshot()
+    XCTAssertEqual(fallback?["area"] as? String, "task_reconcile", "census heal must emit fallback telemetry")
+    XCTAssertEqual(fallback?["outcome"] as? String, "recovered")
+    XCTAssertEqual(fallback?["to"] as? String, "id_census")
   }
 
   @MainActor
@@ -192,6 +197,11 @@ final class TasksStoreEmptyCloudReconcileTests: XCTestCase {
     XCTAssertEqual(probe.hardDeleteCalls, [], "a failed census fetch must never wipe local rows")
     XCTAssertEqual(store.incompleteTasks.map(\.id), [staleTask.id], "stale rows stay until the census confirms")
     XCTAssertNil(store.error)
+
+    let fallback = try? latestFallbackSnapshot()
+    XCTAssertEqual(fallback?["area"] as? String, "task_reconcile", "fail-open skip must emit degraded telemetry")
+    XCTAssertEqual(fallback?["outcome"] as? String, "degraded")
+    XCTAssertEqual(fallback?["to"] as? String, "none")
   }
 
   @MainActor
@@ -366,6 +376,17 @@ final class TasksStoreEmptyCloudReconcileTests: XCTestCase {
   }
 
   // MARK: - Helpers
+
+  /// Latest fallback_triggered snapshot from the shared diagnostics manager
+  /// (same attachment-read pattern as DesktopDiagnosticsManagerTests).
+  private func latestFallbackSnapshot() throws -> [String: Any] {
+    let url = try XCTUnwrap(DesktopDiagnosticsManager.shared.writeDiagnosticsAttachment())
+    defer { try? FileManager.default.removeItem(at: url) }
+    let data = try Data(contentsOf: url)
+    let root = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+    let snapshots = try XCTUnwrap(root["snapshots"] as? [[String: Any]])
+    return try XCTUnwrap(snapshots.last(where: { ($0["event"] as? String) == "fallback_triggered" }))
+  }
 
   @MainActor
   private func task(id: String, completed: Bool = false) -> TaskActionItem {


### PR DESCRIPTION
## What

The empty-cloud task reconciliation (merged in #9653/#9665) healed or degraded silently — logs only — violating the repo's fallback/resilience telemetry contract (silent UX healing is allowed; silent ops is not).

Emit `DesktopDiagnosticsManager.recordFallback` with area `task_reconcile` (added to the closed area set — the sanctioned extension mechanism), at most twice per reconcile pass, counts-only payloads:

- **recovered** `incomplete_page → id_census` (reason `local_heal`) when the census path resolves stale local rows
- **degraded** `incomplete_page → none` when the census fetch fails and reconciliation skips fail-open (stale rows stay visible)
- **degraded** `id_census → none` (+`unresolved_rows` count) when per-document resolution leaves rows unresolved

## Verification

Two hermetic assertions in `TasksStoreEmptyCloudReconcileTests` via the same `writeDiagnosticsAttachment` seam `DesktopDiagnosticsManagerTests` uses (drive `loadIncompleteTasks(operations:)`, assert the snapshot fields). 22/22 tests across reconcile/diagnostics/toggle/requery suites; desktop test-quality checker at baseline. Independent agent review approved (contract conformance, once-per-pass emission incl. lease-revocation early returns, payload hygiene).

## Product invariants affected

none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9671?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

