### PR TITLE
fix(desktop): rotate expired OpenAI realtime sessions

### DIFF
--- a/desktop/macos/Desktop/Sources/DesktopDiagnosticsManager.swift
+++ b/desktop/macos/Desktop/Sources/DesktopDiagnosticsManager.swift
@@ -14,6 +14,7 @@ enum DesktopHealthEventName: String {
   case pttCommitted = "ptt_committed"
   case realtimeTokenMintFailed = "realtime_token_mint_failed"
   case realtimeProviderExpectedIdleTeardown = "realtime_provider_expected_idle_teardown"
+  case realtimeProviderExpectedSessionRotation = "realtime_provider_expected_session_rotation"
   case realtimeProviderPolicyClose = "realtime_provider_policy_close"
   case realtimeProviderSessionError = "realtime_provider_session_error"
   case fallbackTriggered = "fallback_triggered"
@@ -447,6 +448,8 @@ final class DesktopDiagnosticsManager {
     switch normalizedCategory {
     case RealtimeHubCloseCategory.expectedIdleTeardown.rawValue:
       event = .realtimeProviderExpectedIdleTeardown
+    case RealtimeHubCloseCategory.expectedSessionRotation.rawValue:
+      event = .realtimeProviderExpectedSessionRotation
     case RealtimeHubCloseCategory.providerPolicyCloseFast.rawValue,
       CredentialFailureClass.providerPolicyClose(provider: .openai).logValue:
       event = .realtimeProviderPolicyClose
@@ -459,6 +462,10 @@ final class DesktopDiagnosticsManager {
       "alive_for_seconds": Int(aliveFor),
       "active_turn": activeTurn,
     ]
+    if normalizedCategory == RealtimeHubCloseCategory.expectedSessionRotation.rawValue {
+      properties["recovery_action"] = "rotate_realtime_session"
+      properties["recovery_result"] = activeTurn ? "turn_terminated_and_rewarm_started" : "rewarm_started"
+    }
     if let authMode {
       properties["auth_mode"] = authMode.rawValue
     }

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
@@ -21,16 +21,26 @@ import OmiSupport
 /// Safe, non-sensitive classification for realtime WebSocket teardown messages.
 ///
 /// Gemini can idle-close warm sessions with WebSocket 1008 after the socket has
-/// lived for a while. That path is expected and should re-warm quietly rather
-/// than page Sentry as a production error. Fast 1008 closes are different: they
-/// usually mean provider policy/auth/config rejection and should still be
-/// reported, but with a stable category instead of raw provider text.
+/// lived for a while, and OpenAI has a known maximum-session-duration close.
+/// Both expected lifecycle paths should re-warm quietly rather than page Sentry
+/// as production errors. Fast 1008 closes are different: they usually mean
+/// provider policy/auth/config rejection and should still be reported, but with
+/// a stable category instead of raw provider text.
 enum RealtimeHubCloseCategory: String {
   case expectedIdleTeardown = "expected_idle_teardown"
+  case expectedSessionRotation = "expected_session_rotation"
   case providerAuthFailed = "provider_auth_failed"
   case providerQuotaExceeded = "provider_quota_exceeded"
   case providerPolicyCloseFast = "provider_policy_close_fast"
   case providerTransient = "provider_transient"
+}
+
+/// The controller owns transport replacement, while the voice-turn reducer owns
+/// any active logical turn. Keeping this plan typed prevents provider-close text
+/// from leaking into lifecycle decisions outside the classifier boundary.
+enum RealtimeHubSessionRotationPlan: Equatable {
+  case rewarmIdleTransport
+  case terminateActiveTurnAndRewarm
 }
 
 enum RealtimeHubCloseClassifier {
@@ -43,6 +53,12 @@ enum RealtimeHubCloseClassifier {
     provider: RealtimeHubProvider = .openai
   ) -> RealtimeHubCloseCategory? {
     let lower = message.lowercased()
+    if provider == .openai,
+      lower.contains("your session hit the maximum duration")
+      && lower.contains("60 minutes")
+    {
+      return .expectedSessionRotation
+    }
     guard lower.contains("websocket closed (1008)") else { return nil }
     if CredentialHealthManager.classifyProviderClose(
       message: message,
@@ -60,8 +76,20 @@ enum RealtimeHubCloseClassifier {
     return .providerPolicyCloseFast
   }
 
+  static func sessionRotationPlan(
+    for category: RealtimeHubCloseCategory?,
+    hasActiveTurn: Bool
+  ) -> RealtimeHubSessionRotationPlan? {
+    guard category == .expectedSessionRotation else { return nil }
+    return hasActiveTurn ? .terminateActiveTurnAndRewarm : .rewarmIdleTransport
+  }
+
+  static func isExpectedLifecycleClose(_ category: RealtimeHubCloseCategory?) -> Bool {
+    category == .expectedIdleTeardown || category == .expectedSessionRotation
+  }
+
   static func shouldReportToSentry(_ category: RealtimeHubCloseCategory?) -> Bool {
-    category != .expectedIdleTeardown
+    !isExpectedLifecycleClose(category)
   }
 }
 
@@ -4595,7 +4623,7 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate {
     let fingerprint = provider.flatMap { APIKeyService.byokKey($0.byokProvider) }.map(
       APIKeyService.byokFingerprint)
     var credentialFailureClass: CredentialFailureClass?
-    if let provider, closeCategory != .expectedIdleTeardown {
+    if let provider, !RealtimeHubCloseClassifier.isExpectedLifecycleClose(closeCategory) {
       var failureClass = CredentialHealthManager.classifyProviderClose(
         message: message, provider: provider)
       if authMode == .managed, case .providerAuthFailed = failureClass {
@@ -4612,6 +4640,7 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate {
     let categoryText = closeCategory.map { " category=\($0.rawValue)" } ?? ""
     let shouldRedactProviderMessage: Bool = {
       if closeCategory == .providerPolicyCloseFast { return true }
+      if closeCategory == .expectedSessionRotation { return true }
       if case .providerAuthFailed = credentialFailureClass { return true }
       if case .providerQuotaExceeded = credentialFailureClass { return true }
       return false
@@ -4628,8 +4657,15 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate {
       logError("RealtimeHub: session error —\(categoryText) provider=\(providerTag)\(safeMessage)")
     } else {
       log(
-        "RealtimeHub: session closed —\(categoryText) provider=\(providerTag) aliveFor=\(Int(aliveFor))s \(message)"
+        "RealtimeHub: session closed —\(categoryText) provider=\(providerTag) aliveFor=\(Int(aliveFor))s\(safeMessage)"
       )
+    }
+    if let sessionRotationPlan = RealtimeHubCloseClassifier.sessionRotationPlan(
+      for: closeCategory,
+      hasActiveTurn: hasActiveTurn)
+    {
+      recoverFromExpectedSessionRotation(sessionRotationPlan, activeTurn: activeTurn)
+      return
     }
     if replacementAudioBuffer != nil, let failedProvider = provider {
       let replacementFailoverReason = failoverReason(for: credentialFailureClass)
@@ -4646,15 +4682,7 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate {
       return
     }
     if ownsActiveHubTurn {
-      // The reply is dead — stop only output owned by this hub turn. A warm
-      // background socket must never terminate a Deepgram/Omni fallback turn.
-      pcmPlayer?.stop()
-      realtimePlaybackEpoch += 1
-      FloatingBarVoicePlaybackService.shared.interruptCurrentResponse()
-      if let turnID = activeTurn?.id {
-        VoiceTurnCoordinator.shared.send(.finish(turnID: turnID, reason: .providerFailed))
-      }
-      exitVoiceUI(clearResponseGlow: true)
+      terminateActiveHubTurn(activeTurn)
     }
     teardownSession()
     // Provider switching changes the user's voice identity and can fragment model-local
@@ -4689,6 +4717,35 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate {
       self.reconnectPending = false
       if self.session == nil { self.ensureWarm() }
     }
+  }
+
+  /// OpenAI limits realtime sessions to sixty minutes. Rotation is a normal
+  /// transport lifecycle event: keep the provider choice, replace the retired
+  /// socket immediately, and let the reducer terminalize an interrupted turn.
+  private func recoverFromExpectedSessionRotation(
+    _ plan: RealtimeHubSessionRotationPlan,
+    activeTurn: VoiceTurn?
+  ) {
+    if plan == .terminateActiveTurnAndRewarm {
+      terminateActiveHubTurn(activeTurn)
+    }
+    teardownSession()
+    hubReconnectStrikes = 0
+    reconnectPending = false
+    ensureWarm()
+  }
+
+  /// A warm background socket must never terminate a Deepgram/Omni fallback
+  /// turn. The reducer deduplicates repeated terminal events, keeping the UI in
+  /// a single actionable terminal projection when transport callbacks race.
+  private func terminateActiveHubTurn(_ activeTurn: VoiceTurn?) {
+    pcmPlayer?.stop()
+    realtimePlaybackEpoch += 1
+    FloatingBarVoicePlaybackService.shared.interruptCurrentResponse()
+    if let turnID = activeTurn?.id {
+      VoiceTurnCoordinator.shared.send(.finish(turnID: turnID, reason: .providerFailed))
+    }
+    exitVoiceUI(clearResponseGlow: true)
   }
 
   /// Return the floating bar from its PTT voice state to compact after a hub turn.

--- a/desktop/macos/Desktop/Tests/DesktopDiagnosticsManagerTests.swift
+++ b/desktop/macos/Desktop/Tests/DesktopDiagnosticsManagerTests.swift
@@ -139,6 +139,24 @@ final class DesktopDiagnosticsManagerTests: XCTestCase {
     XCTAssertEqual(snapshot["active_turn"] as? Bool, false)
   }
 
+  func testExpectedSessionRotationUsesNonErrorHealthEvent() throws {
+    DesktopDiagnosticsManager.shared.recordRealtimeProviderClose(
+      provider: "openai",
+      category: RealtimeHubCloseCategory.expectedSessionRotation.rawValue,
+      aliveFor: 3_600,
+      activeTurn: true,
+      authMode: .managed,
+      failureClass: nil)
+
+    let snapshot = try latestSnapshot()
+
+    XCTAssertEqual(snapshot["event"] as? String, "realtime_provider_expected_session_rotation")
+    XCTAssertEqual(snapshot["provider"] as? String, "openai")
+    XCTAssertEqual(snapshot["category"] as? String, "expected_session_rotation")
+    XCTAssertEqual(snapshot["recovery_action"] as? String, "rotate_realtime_session")
+    XCTAssertEqual(snapshot["recovery_result"] as? String, "turn_terminated_and_rewarm_started")
+  }
+
   func testProviderCloseFallsBackToFailureClassInsteadOfUnclassified() throws {
     DesktopDiagnosticsManager.shared.recordRealtimeProviderClose(
       provider: "openai",

--- a/desktop/macos/Desktop/Tests/RealtimeHubCloseClassifierTests.swift
+++ b/desktop/macos/Desktop/Tests/RealtimeHubCloseClassifierTests.swift
@@ -22,6 +22,44 @@ final class RealtimeHubCloseClassifierTests: XCTestCase {
     XCTAssertTrue(RealtimeHubCloseClassifier.shouldReportToSentry(category))
   }
 
+  func testClassifiesOpenAIMaximumDurationAsExpectedSessionRotation() {
+    let category = RealtimeHubCloseClassifier.category(
+      message: "Your session hit the maximum duration of 60 minutes.",
+      aliveFor: 60 * 60,
+      provider: .openai)
+
+    XCTAssertEqual(category, .expectedSessionRotation)
+    XCTAssertEqual(
+      RealtimeHubCloseClassifier.sessionRotationPlan(
+        for: category,
+        hasActiveTurn: false),
+      .rewarmIdleTransport)
+    XCTAssertFalse(RealtimeHubCloseClassifier.shouldReportToSentry(category))
+  }
+
+  func testOpenAISessionRotationDuringTurnRequiresReducerOwnedTerminalization() {
+    let category = RealtimeHubCloseClassifier.category(
+      message: "Your session hit the maximum duration of 60 minutes.",
+      aliveFor: 60 * 60,
+      hasActiveTurn: true,
+      provider: .openai)
+
+    XCTAssertEqual(
+      RealtimeHubCloseClassifier.sessionRotationPlan(
+        for: category,
+        hasActiveTurn: true),
+      .terminateActiveTurnAndRewarm)
+  }
+
+  func testDoesNotClassifyMaximumDurationForAnotherProvider() {
+    let category = RealtimeHubCloseClassifier.category(
+      message: "Your session hit the maximum duration of 60 minutes.",
+      aliveFor: 60 * 60,
+      provider: .gemini)
+
+    XCTAssertNil(category)
+  }
+
   func testClassifiesFastWebSocket1008AsProviderPolicyClose() {
     let category = RealtimeHubCloseClassifier.category(
       message: "WebSocket closed (1008) policy violation",

--- a/desktop/macos/Desktop/Tests/VoiceTurnReducerTests.swift
+++ b/desktop/macos/Desktop/Tests/VoiceTurnReducerTests.swift
@@ -85,6 +85,32 @@ final class VoiceTurnReducerTests: XCTestCase {
     XCTAssertFalse(duplicate.effects.contains(where: \.isTerminal))
   }
 
+  func testOpenAISessionRotationTerminatesActiveHubTurnOnce() {
+    let turnID = VoiceTurnID()
+    let sessionID = VoiceSessionID()
+    let category = RealtimeHubCloseClassifier.category(
+      message: "Your session hit the maximum duration of 60 minutes.",
+      aliveFor: 60 * 60,
+      hasActiveTurn: true,
+      provider: .openai)
+    XCTAssertEqual(
+      RealtimeHubCloseClassifier.sessionRotationPlan(
+        for: category,
+        hasActiveTurn: true),
+      .terminateActiveTurnAndRewarm)
+
+    var model = reduce(.idle, .start(turnID: turnID, ownerID: nil, intent: .hold)).model
+    model = reduce(model, .selectRoute(turnID: turnID, route: .hub(sessionID: sessionID))).model
+
+    let terminal = reduce(model, .finish(turnID: turnID, reason: .providerFailed))
+    XCTAssertEqual(terminal.model.turn?.phase, .terminal(.providerFailed))
+    XCTAssertEqual(terminal.effects.filter(\.isTerminal).count, 1)
+
+    let duplicate = reduce(terminal.model, .finish(turnID: turnID, reason: .providerFailed))
+    XCTAssertEqual(duplicate.model.duplicateTerminalCount, 1)
+    XCTAssertFalse(duplicate.effects.contains(where: \.isTerminal))
+  }
+
   func testQuickTapLockWindowCanBecomeLockedRecording() {
     let turnID = VoiceTurnID()
     var model = reduce(.idle, .start(turnID: turnID, ownerID: nil, intent: .hold)).model

--- a/desktop/macos/changelog/unreleased/20260714-openai-realtime-session-rotation.json
+++ b/desktop/macos/changelog/unreleased/20260714-openai-realtime-session-rotation.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed voice sessions reconnecting after OpenAI's 60-minute realtime limit"
+}


### PR DESCRIPTION
## Summary

- Classify OpenAI's 60-minute Realtime expiry as an expected session-rotation condition and immediately create a replacement transport.
- Route an interrupted active PTT turn through the existing `VoiceTurnCoordinator` terminal lifecycle; the next PTT uses the fresh, healthy session.
- Emit a safe, non-error desktop health event and add classifier, reducer, and diagnostics regression coverage.

## Root cause

`RealtimeHubCloseClassifier` recognized only WebSocket 1008 lifecycle closes. OpenAI reports its maximum-duration expiry with a distinct message, so it bypassed expected-close handling and could surface as an error instead of a routine transport rotation.

## Durable guard

The typed session-rotation plan distinguishes idle re-warm from active-turn terminalization. Focused tests cover OpenAI-only classification, Sentry suppression, reducer exactly-once terminal behavior, and bounded diagnostic recovery metadata.

## Verification

- `cd desktop/macos && xcrun swift test --package-path Desktop --filter 'RealtimeHubCloseClassifierTests|VoiceTurnReducerTests|DesktopDiagnosticsManagerTests'` — 68 passed.
- `cd desktop/macos && ./scripts/agent-logic-harness.sh` — passed (502 agent-runtime tests and 104 pi-mono package tests).
- Named local bundle `omi-realtime-rotation`: `omi-ctl action ptt_test_turn ...` completed a real controller PTT turn using the fresh OpenAI transport and persisted the forced transcript.
- `OMI_PR_BODY_FILE=/tmp/omi-pr-body.md make preflight` — passed (14 checks).
- Pre-push hook — passed, including full desktop Swift build.

## Product invariants affected

- `INV-CHAT-1`
- `INV-VOICE-1`

Closes #9666
Closes #9667

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9672?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

