### PR TITLE
fix(desktop): keep the push-to-talk query alive when the Ask Omi panel collapses

### DIFF
--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
@@ -1192,8 +1192,14 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
         responseHeightCancellable = nil
         state.responseContentHeight = 0
 
-        // Cancel PTT if listening while chat closes
-        PushToTalkManager.shared.cancelListening()
+        // Cancel PTT only while the mic is still capturing. A turn that has already committed
+        // its transcript is awaiting its answer, and `openAIInputWithQuery` collapses this
+        // surface *before* dispatching the voice query — an unconditional cancel there
+        // terminates the turn, so `routeQuery` is fenced out and the user's spoken question is
+        // silently dropped.
+        if PushToTalkManager.shared.isCapturingAudio {
+            PushToTalkManager.shared.cancelListening()
+        }
 
         OmiMotion.withGated(.easeOut(duration: 0.08)) {
             state.showingAIConversation = false

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
@@ -95,6 +95,10 @@ class PushToTalkManager: ObservableObject {
   /// A projection of the authoritative reducer. This manager owns microphone and
   /// provider I/O only; it never stores a second logical lifecycle state.
   var phase: VoiceTurnPhase? { voiceTurnCoordinator.activeTurn?.phase }
+  /// True only while the mic is still capturing. Callers that cancel PTT as a side effect of a
+  /// UI transition (rather than an explicit user abort) must gate on this: `cancelListening()`
+  /// terminates any non-idle turn, including one that has already committed its transcript.
+  var isCapturingAudio: Bool { voiceTurnCoordinator.isCapturingAudio }
   private var currentVoiceTurnID: VoiceTurnID? { voiceTurnCoordinator.activeTurnID }
   private var isIdle: Bool { currentVoiceTurnID == nil }
 

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/VoiceTurnCoordinator.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/VoiceTurnCoordinator.swift
@@ -124,6 +124,10 @@ final class VoiceTurnCoordinator {
 
   var activeTurnID: VoiceTurnID? { model.turn?.phase.isTerminal == false ? model.turn?.id : nil }
   var activeTurn: VoiceTurn? { model.turn?.phase.isTerminal == false ? model.turn : nil }
+  /// True only while the mic is still capturing for the active turn. Once the transcript
+  /// is committed the turn is awaiting its answer, so it is active but no longer capturing —
+  /// cancelling it there discards what the user already said.
+  var isCapturingAudio: Bool { activeTurn?.phase.isRecording == true }
   var projection: VoiceTurnUIProjection { model.turn?.projection ?? .idle }
   var outputSnapshot: VoiceOutputSnapshot {
     VoiceOutputSnapshot(

--- a/desktop/macos/Desktop/Tests/VoiceTurnCoordinatorTests.swift
+++ b/desktop/macos/Desktop/Tests/VoiceTurnCoordinatorTests.swift
@@ -4,6 +4,29 @@ import XCTest
 
 @MainActor
 final class VoiceTurnCoordinatorTests: XCTestCase {
+  /// A committed turn is still active (so `cancelListening()` would terminate it) but is no
+  /// longer capturing. Surface teardown must gate on `isCapturingAudio`, or collapsing the Ask
+  /// Omi panel to present the answer cancels the turn and drops the user's spoken question.
+  func testIsCapturingAudioIsFalseOnceTheTranscriptIsCommitted() {
+    let coordinator = VoiceTurnCoordinator(scheduler: ManualVoiceTurnScheduler())
+    let turnID = coordinator.begin(intent: .hold)
+    coordinator.send(.captureStarted(turnID: turnID, captureID: VoiceCaptureID(1)))
+
+    XCTAssertTrue(coordinator.isCapturingAudio)
+
+    coordinator.send(.finalize(turnID: turnID))
+    coordinator.send(.transcriptionFinal(turnID: turnID, text: "what is on my screen"))
+
+    XCTAssertEqual(coordinator.activeTurn?.phase, .awaitingResponse)
+    XCTAssertFalse(coordinator.isCapturingAudio)
+    XCTAssertNotNil(coordinator.activeTurnID)
+
+    // The turn a surface collapse would have cancelled is the one that still owns the query.
+    coordinator.send(.cancel(turnID: turnID, reason: .cancelled))
+    XCTAssertNil(coordinator.activeTurnID)
+    XCTAssertFalse(coordinator.isCapturingAudio)
+  }
+
   func testLocalAutomationFinalizeRemainsCommitableWithoutPhysicalCaptureBuffer() {
     let coordinator = VoiceTurnCoordinator(scheduler: ManualVoiceTurnScheduler())
     var physicalFinalizeCount = 0

--- a/desktop/macos/changelog/unreleased/20260714-ptt-query-dropped-when-panel-open.json
+++ b/desktop/macos/changelog/unreleased/20260714-ptt-query-dropped-when-panel-open.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed push-to-talk silently dropping your question when the Ask Omi panel was already open"
+}


### PR DESCRIPTION
## Bug

Speak to Omi via push-to-talk **while the Ask Omi input panel is already open** and your question is silently dropped — the panel collapses, and no answer and no error ever appear.

Regression from `fa0046a322` ("unify PTT listening chrome and drop agent voice follow-up"), which is on `main` but **not yet in a released build** (no `v*-macos` tag contains it), so this lands before it reaches users.

## Root cause

That commit replaced the guarded PTT cancel in `closeAIConversation()`:

```swift
-        if state.isVoiceFollowUp {
-            PushToTalkManager.shared.cancelListening()
-        }
+        PushToTalkManager.shared.cancelListening()
```

on the reasoning (stated in a sibling comment) that `cancelListening()` is "already guarded by `state != .idle`". That guard is **not a microphone guard** — `isIdle` is `activeTurnID == nil`, which stays false for the *entire* voice turn, including `.awaitingResponse` after the transcript has been committed.

`openAIInputWithQuery(fromVoice:)` collapses the input panel **before** it dispatches the voice query, so the close path now kills the very turn it is about to route:

1. Panel open (`showingAIConversation == true`, no response yet) → user holds PTT and speaks. `isCurrentSessionFollowUp` is `false`, so release takes the `openAIInputWithQuery` path.
2. `sendTranscript` → `.transcriptionFinal` → phase `.awaitingResponse` → `sendQuery` → `openAIInputWithQuery(fromVoice: true, voiceTurnID:)`.
3. Inside it: `if window.state.showingAIConversation { window.closeAIConversation() }` → unconditional `cancelListening()` → turn is not idle → `stopListening()` → `.cancel` → `terminal` (the coordinator drains its FIFO synchronously).
4. The next statement's fence — `guard VoiceTurnCoordinator.shared.requireCurrentOwner(for: voiceTurnID) != nil` — now fails, so `routeQuery` never runs. The query is gone.

Same cause also killed an in-flight voice turn on Esc / click-away while the answer was still generating.

## Fix

Cancel PTT only while the mic is **still capturing**. The decision lives on the authoritative reducer rather than at the call site:

- `VoiceTurnCoordinator.isCapturingAudio` = `activeTurn?.phase.isRecording == true`
- `PushToTalkManager.isCapturingAudio` projects it
- `closeAIConversation()` gates its cancel on it

A committed turn awaiting its answer now survives surface teardown; an in-progress capture is still cancelled when the chat closes, which is what `fa0046a322` was after.

## Verification

- `xcrun swift build -c debug --package-path Desktop` → **Build complete**
- `xcrun swift test --filter VoiceTurn --filter PushToTalk --filter PTT --filter FloatingControlBarStateTests` → **all green**, including the new `testIsCapturingAudioIsFalseOnceTheTranscriptIsCommitted` (asserts a committed turn is active-but-not-capturing — the exact state the old code cancelled).
- **UNVERIFIED in-app:** reproducing the user path needs real mic speech, which this automated run could not drive (`ptt_start`/`ptt_stop` with no audio ends the turn with a hint before it ever commits). The dropped-query path was traced end to end in source instead. Worth one manual pass: open Ask Omi, speak, confirm the answer appears.

🤖 automated by hourly watchdog; opened for review, not merged (the regression is not yet in a released build, so it fails the prod-bug auto-merge gate).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9674?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

