### PR TITLE
fix(desktop): keep PTT dead-mic recovery armed across zero-frame turns (#9081)

### DIFF
--- a/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
@@ -12,11 +12,15 @@ struct PTTSilentMicRecoveryPolicy {
   private(set) var consecutiveDeadMicTurns = 0
 
   mutating func recordDiscardedTurn(totalSec: TimeInterval, peak: Int) -> Bool {
-    if totalSec >= Self.minDeadTurnSeconds && peak <= Self.deadMicPeakThreshold {
-      consecutiveDeadMicTurns += 1
-    } else {
+    if peak > Self.deadMicPeakThreshold {
+      // Audible input proves the mic is alive, whatever else went wrong with the turn.
       consecutiveDeadMicTurns = 0
+    } else if totalSec >= Self.minDeadTurnSeconds {
+      consecutiveDeadMicTurns += 1
     }
+    // A turn too short to judge carries no evidence either way — an accidental tap, or a
+    // release that beat CoreAudio's capture start and delivered no frames at all. It must
+    // not erase a dead-mic streak, or a dead mic interleaved with taps never recovers.
     return consecutiveDeadMicTurns >= Self.consecutiveDeadTurnThreshold
   }
 

--- a/desktop/macos/Desktop/Tests/PTTSilentMicRecoveryPolicyTests.swift
+++ b/desktop/macos/Desktop/Tests/PTTSilentMicRecoveryPolicyTests.swift
@@ -46,4 +46,27 @@ final class PTTSilentMicRecoveryPolicyTests: XCTestCase {
     XCTAssertFalse(policy.recordDiscardedTurn(totalSec: 1.0, peak: 0))
     XCTAssertEqual(policy.consecutiveDeadMicTurns, 1)
   }
+
+  /// A turn that captured no frames (release beat CoreAudio's capture start) is silent for
+  /// reasons unrelated to mic health. Treating it as proof of a live mic reset the streak, so a
+  /// dead mic interleaved with taps never reached the recovery threshold (#9081).
+  func testZeroFrameTurnDoesNotEraseDeadMicStreak() {
+    var policy = PTTSilentMicRecoveryPolicy()
+
+    XCTAssertFalse(policy.recordDiscardedTurn(totalSec: 1.0, peak: 0))
+    XCTAssertFalse(policy.recordDiscardedTurn(totalSec: 0, peak: 0))
+    XCTAssertEqual(policy.consecutiveDeadMicTurns, 1)
+
+    XCTAssertTrue(policy.recordDiscardedTurn(totalSec: 1.0, peak: 0))
+  }
+
+  func testAudibleShortTapResetsDeadMicStreak() {
+    var policy = PTTSilentMicRecoveryPolicy()
+
+    XCTAssertFalse(policy.recordDiscardedTurn(totalSec: 1.0, peak: 0))
+    XCTAssertFalse(
+      policy.recordDiscardedTurn(
+        totalSec: 0.05, peak: PTTSilentMicRecoveryPolicy.deadMicPeakThreshold + 1))
+    XCTAssertEqual(policy.consecutiveDeadMicTurns, 0)
+  }
 }

--- a/desktop/macos/changelog/unreleased/20260713-ptt-dead-mic-recovery.json
+++ b/desktop/macos/changelog/unreleased/20260713-ptt-dead-mic-recovery.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed push-to-talk never attempting mic recovery when a dead microphone was interleaved with short taps, leaving repeated silent turns"
+}


### PR DESCRIPTION
## Bug

Fixes #9081. Desktop health telemetry shows `ptt_audio_capture_silent_turn` on macOS 0.12.0 hold mode affecting **169 users / 1,104 events**, every one of them reporting `recovery_action=none`, `recovery_result=not_attempted`. PTT has a dead-mic self-heal — it simply never fired for the users who needed it, so a dead microphone stayed dead turn after turn with no recovery attempted.

## Root cause

`PTTSilentMicRecoveryPolicy.recordDiscardedTurn` (`PushToTalkManager.swift`) decides whether consecutive silent turns should trigger a CoreAudio capture rebuild:

```swift
if totalSec >= Self.minDeadTurnSeconds && peak <= Self.deadMicPeakThreshold {
  consecutiveDeadMicTurns += 1
} else {
  consecutiveDeadMicTurns = 0   // <-- any turn under 0.25s lands here
}
```

Every turn shorter than `minDeadTurnSeconds` (0.25s) fell into the `else` branch and **reset the dead-mic streak**. Crucially that includes turns which captured *no frames at all*: `startMicCapture` starts CoreAudio asynchronously (`AudioDeviceStart` is blocking HAL IPC to `coreaudiod`), so a key release that beats capture start finalizes a turn with `totalSec = 0, peak = 0`. Such a turn says nothing about mic health, but it erased the evidence — so with a dead mic interleaved with ordinary taps, `consecutiveDeadMicTurns` never reached the threshold of 2 and recovery was never requested. All four `recordPTTSilentTurn` call sites (hub, omni, batch, warm-wait fallback) derive `recovery_action`/`recovery_result` from this one return value, which is why the field data is uniformly `none`/`not_attempted`.

The failure class: **absence of evidence was treated as evidence of health.**

## Fix

Make each outcome carry only the evidence it actually has:

- audible input (`peak > deadMicPeakThreshold`) proves the mic is alive → reset the streak
- a judgeable silent turn (`totalSec >= minDeadTurnSeconds`, near-zero peak) → increment
- a too-short / zero-frame turn → **neutral**, leave the streak intact

Three-line behavior change in the policy struct; no call sites, thresholds, or telemetry fields changed.

## Verification

- **Regression test** `PTTSilentMicRecoveryPolicyTests.testZeroFrameTurnDoesNotEraseDeadMicStreak` reproduces the field scenario (dead turn → zero-frame turn → dead turn). It **fails on the old code** (`consecutiveDeadMicTurns` 0 instead of 1; recovery never returns `true`) and passes on the fix. Added `testAudibleShortTapResetsDeadMicStreak` to pin the other direction.
- `xcrun swift test --package-path Desktop --filter "PTT|PushToTalk|VoiceTurn|DesktopDiagnostics"` → **65 tests, 0 failures** (incl. `PTTAudioCaptureRaceTests`, `PTTSilentTurnRecoveryWiringTests`, `PushToTalkStateMachineTests`, `DesktopDiagnosticsManagerTests`).
- `xcrun swift build -c debug --package-path Desktop` → green.
- `make preflight` → green.

Hermetic unit coverage of a pure policy struct; not exercised against a physically dead microphone on prod hardware.

## Product invariants

Path-matched by `desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift`:

- **INV-CHAT-1** — unchanged. No chat write-path, provider, projection, or viewport code is touched; no message store or turn-recording behavior changes.
- **INV-VOICE-1** — preserved and strengthened. The voice-turn state machine, capture lifecycle, and silence gating are untouched; the only change is when the existing dead-mic recovery is allowed to arm, so a silent capture is more likely to self-heal rather than less.

## Follow-up (not in this PR)

The zero-frame turns themselves come from the release beating asynchronous CoreAudio capture start. Closing that race means changing the turn state machine's capture-start/finalize ordering — a wider blast radius than this fix warrants, and it remains tracked by #9081's investigation items.

🤖 automated by the hourly desktop bug watchdog.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9677?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

