### PR TITLE
fix(deploy): remove redundant Firestore index

### DIFF
--- a/backend/database/firestore_index_registry.py
+++ b/backend/database/firestore_index_registry.py
@@ -120,12 +120,6 @@ INDEX_ONLY_REQUIREMENTS = (
         (_asc('uid'), _asc('generation'), _desc('updated_at'), _asc('__name__')),
     ),
     FirestoreIndexRequirement(
-        'v3_compatibility_projection_created',
-        'v3_compatibility_projection_items',
-        'COLLECTION',
-        (_desc('created_at'), _desc('__name__')),
-    ),
-    FirestoreIndexRequirement(
         'conversations_category_created',
         'conversations',
         'COLLECTION',

--- a/backend/database/memory_compatibility_projection.py
+++ b/backend/database/memory_compatibility_projection.py
@@ -227,6 +227,9 @@ def _apply_query_order(query: Any) -> Any:
         document_id_field = firestore.FieldPath.document_id()  # type: ignore[reportAttributeAccessIssue,reportUnknownMemberType,reportUnknownVariableType]  # firestore.FieldPath absent from stubs; runtime-guarded by except fallback to "__name__"
     except AttributeError:
         document_id_field = _DOCUMENT_ID_ORDER
+    # Firestore serves this deterministic document-id tie-breaker from the
+    # built-in single-field created_at index. Do not declare it as a composite
+    # index: Firebase rejects that redundant declaration during deployment.
     return query.order_by("created_at", direction=firestore.Query.DESCENDING).order_by(
         document_id_field, direction=firestore.Query.DESCENDING
     )

--- a/backend/tests/unit/test_firestore_index_config.py
+++ b/backend/tests/unit/test_firestore_index_config.py
@@ -27,18 +27,13 @@ def test_firestore_config_declares_memory_items_canary_read_index():
     )
 
 
-def test_firestore_config_declares_v3_compatibility_projection_index():
-    required_fields = [
-        ('created_at', 'DESCENDING'),
-        ('__name__', 'DESCENDING'),
-    ]
-
-    assert any(
-        index.get('collectionGroup') == 'v3_compatibility_projection_items'
-        and index.get('queryScope') == 'COLLECTION'
-        and _fields(index) == required_fields
-        for index in _index_specs()
-    )
+def test_firestore_config_does_not_declare_single_field_composite_indexes():
+    # Firestore manages single-field indexes itself. A declared index with only
+    # one real field plus the document-id tie breaker is rejected at deploy
+    # time as redundant (HTTP 400: configure using single field index controls).
+    for index in _index_specs():
+        indexed_fields = [field for field, _ in _fields(index) if field != '__name__']
+        assert len(indexed_fields) > 1, index
 
 
 def test_firestore_config_declares_mcp_conversation_category_filter_index():

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -23,20 +23,6 @@
       ]
     },
     {
-      "collectionGroup": "v3_compatibility_projection_items",
-      "queryScope": "COLLECTION",
-      "fields": [
-        {
-          "fieldPath": "created_at",
-          "order": "DESCENDING"
-        },
-        {
-          "fieldPath": "__name__",
-          "order": "DESCENDING"
-        }
-      ]
-    },
-    {
       "collectionGroup": "conversations",
       "queryScope": "COLLECTION",
       "fields": [


### PR DESCRIPTION
## Summary
- remove the redundant `v3_compatibility_projection_items` composite index that Firebase rejects as a single-field index
- add a configuration regression guard rejecting any declared composite index with fewer than two non-`__name__` fields

## Root cause
The development backend deploy for `08c8589` failed during Firebase index reconciliation with HTTP 400: `this index is not necessary, configure using single field index controls`. The removed declaration indexed only `created_at` plus Firestore's document-id tie breaker; Firestore supplies that single-field capability without a composite index.

## Verification
- `BACKEND_UNIT_TEST_FILE_LIST=/tmp/omi-firestore-index-tests.txt bash backend/test.sh` — 5 passed
- parsed `firestore.indexes.json`; all 13 remaining declared composite indexes have at least two non-`__name__` fields
- listed 29 currently deployed dev composite indexes; none has fewer than two non-`__name__` fields
- `git diff --check`

## Product invariants affected

- INV-MEM-1

## Scope
This changes deployment configuration only. It does not alter the projection query's deterministic `created_at` / document-id ordering.
