### PR TITLE
Add one-click ChatGPT directory connection

### DIFF
--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/AgentConnectPickerSheet.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/AgentConnectPickerSheet.swift
@@ -3,19 +3,20 @@ import SwiftUI
 import OmiTheme
 
 /// Connect sheet for a grouped agent (Claude → Claude Code + Cloud, ChatGPT →
-/// Codex + Cloud). Both options are shown on screen at once as cards — no
-/// picker — each with a prominent "Do it for me" primary and a quiet "Copy
-/// command" secondary. Claude Code / Codex (the CLI) is listed first.
+/// Codex + directory app). Both options are shown on screen at once as cards — no
+/// picker — each with a prominent primary action and a quiet manual fallback.
+/// The ChatGPT directory option is listed first so the one-click path leads.
 struct ConnectDestinationSheet: View {
   let destination: MemoryExportDestination
   @Binding var statuses: [MemoryExportDestination: MemoryExportStatus]
   let onDismiss: () -> Void
 
-  /// CLI+cloud pair for an anchor destination (CLI first).
+  /// Cloud/CLI pair for an anchor destination. ChatGPT leads with its approved
+  /// directory listing; Claude keeps its established CLI-first order.
   static func group(for d: MemoryExportDestination) -> [MemoryExportDestination] {
     switch d {
     case .claude, .claudeCode: return [.claudeCode, .claude]
-    case .chatgpt, .codex: return [.codex, .chatgpt]
+    case .chatgpt, .codex: return [.chatgpt, .codex]
     default: return [d]
     }
   }
@@ -25,7 +26,7 @@ struct ConnectDestinationSheet: View {
   private var groupName: String {
     switch destination {
     case .claude, .claudeCode: return "Claude"
-    case .chatgpt, .codex: return "ChatGPT"
+    case .chatgpt, .codex: return "ChatGPT / Codex"
     default: return destination.title
     }
   }
@@ -158,16 +159,29 @@ private struct ConnectOptionCard: View {
 
         // Secondary — full manual instructions in a quiet dropdown.
         if let setup = destination.mcpSetup(key: mcpKey ?? "YOUR_OMI_KEY") {
-          ManualInstallationDisclosure(isExpanded: $showManual, fontSize: 12) {
+          ManualInstallationDisclosure(
+            isExpanded: $showManual,
+            title: destination == .chatgpt ? "Developer-mode fallback" : "Manual installation",
+            fontSize: 12
+          ) {
             VStack(alignment: .leading, spacing: OmiSpacing.sm) {
-              ForEach(Array(setup.steps.enumerated()), id: \.offset) { idx, step in
-                Text("\(idx + 1). \(step)")
+              if destination == .chatgpt {
+                Text("Use this only when your workspace requires a developer-mode custom app.")
                   .scaledFont(size: OmiType.caption)
                   .foregroundColor(OmiColors.textTertiary)
                   .fixedSize(horizontal: false, vertical: true)
                   .frame(maxWidth: .infinity, alignment: .leading)
+                manualBlock(chatGPTDeveloperModeText)
+              } else {
+                ForEach(Array(setup.steps.enumerated()), id: \.offset) { idx, step in
+                  Text("\(idx + 1). \(step)")
+                    .scaledFont(size: OmiType.caption)
+                    .foregroundColor(OmiColors.textTertiary)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                }
+                manualBlock(manualText(for: setup))
               }
-              manualBlock(manualText(for: setup))
             }
             .padding(.top, OmiSpacing.sm)
           }
@@ -187,7 +201,9 @@ private struct ConnectOptionCard: View {
         .fill(OmiColors.backgroundSecondary)
     )
     .task {
-      statuses[destination] = await MemoryExportService.shared.status(for: destination)
+      statuses[destination] = destination == .chatgpt
+        ? await MemoryExportService.shared.refreshChatGPTDirectoryConnectionStatus()
+        : await MemoryExportService.shared.status(for: destination)
       await prepareMCPKeyIfNeeded()
     }
     .onReceive(permissionRefreshTimer) { _ in
@@ -196,12 +212,20 @@ private struct ConnectOptionCard: View {
     .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification))
     { _ in
       refreshPermissionStateIfNeeded()
+      refreshChatGPTDirectoryConnectionIfNeeded()
     }
   }
 
   private func refreshPermissionStateIfNeeded() {
     guard MemoryExportExecutor.requiresAccessibilityPreflight(destination) else { return }
     permissionRefreshID += 1
+  }
+
+  private func refreshChatGPTDirectoryConnectionIfNeeded() {
+    guard destination == .chatgpt else { return }
+    Task {
+      statuses[.chatgpt] = await MemoryExportService.shared.refreshChatGPTDirectoryConnectionStatus()
+    }
   }
 
   private var isConnected: Bool {
@@ -239,7 +263,9 @@ private struct ConnectOptionCard: View {
         case .completed:
           resultMessage = .success(outcome.taskTitle)
         }
-        statuses[destination] = await MemoryExportService.shared.status(for: destination)
+        statuses[destination] = destination == .chatgpt
+          ? await MemoryExportService.shared.refreshChatGPTDirectoryConnectionStatus()
+          : await MemoryExportService.shared.status(for: destination)
       } catch {
         resultMessage = .failure(setupFailureMessage(for: error))
       }
@@ -304,6 +330,21 @@ private struct ConnectOptionCard: View {
       return "Server URL: \(setup.serverURL)\nKey: \(mcpKey ?? "YOUR_OMI_KEY")"
     }
     return "Server URL: \(setup.serverURL)"
+  }
+
+  private var chatGPTDeveloperModeText: String {
+    let clientID = destination.cloudOAuthClientID ?? ""
+    let tokenAuthMethod = destination.cloudTokenAuthMethod ?? "none"
+    return [
+      "Name: Omi Memory",
+      "Connection / server URL: \(MemoryExportDestination.mcpServerURL)",
+      "Authentication: OAuth",
+      "OAuth Client ID: \(clientID)",
+      "OAuth Client Secret: leave blank",
+      "Token auth method: \(tokenAuthMethod)",
+      "Auth URL: \(MemoryExportDestination.mcpAuthorizeURL)",
+      "Token URL: \(MemoryExportDestination.mcpTokenURL)",
+    ].joined(separator: "\n")
   }
 
   private func manualBlock(_ text: String) -> some View {

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
@@ -1426,7 +1426,7 @@ struct DashboardPage: View {
                 openExportDestination(.claudeCode)
             }
             HomeAIChoiceButton(title: "ChatGPT / Codex", brand: .chatgpt, isConnected: isMCPDestinationConnected(.chatgpt)) {
-                openExportDestination(.codex)
+                openExportDestination(.chatgpt)
             }
             HomeAIChoiceButton(title: "OpenClaw", brand: .openclaw, isConnected: isMCPDestinationConnected(.openclaw)) {
                 openExportDestination(.openclaw)

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/ManualInstallationDisclosure.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/ManualInstallationDisclosure.swift
@@ -3,15 +3,18 @@ import OmiTheme
 
 struct ManualInstallationDisclosure<Content: View>: View {
   @Binding private var isExpanded: Bool
+  private let title: String
   private let fontSize: CGFloat
   private let content: () -> Content
 
   init(
     isExpanded: Binding<Bool>,
+    title: String = "Manual installation",
     fontSize: CGFloat,
     @ViewBuilder content: @escaping () -> Content
   ) {
     _isExpanded = isExpanded
+    self.title = title
     self.fontSize = fontSize
     self.content = content
   }
@@ -24,7 +27,7 @@ struct ManualInstallationDisclosure<Content: View>: View {
             .scaledFont(size: OmiType.micro, weight: .semibold)
             .frame(width: 10)
 
-          Text("Manual installation")
+          Text(title)
             .scaledFont(size: fontSize, weight: .medium)
         }
         .foregroundColor(OmiColors.textTertiary)
@@ -34,8 +37,8 @@ struct ManualInstallationDisclosure<Content: View>: View {
         .contentShape(Rectangle())
       }
       .buttonStyle(.plain)
-      .help(isExpanded ? "Hide manual installation" : "Show manual installation")
-      .accessibilityLabel("Manual installation")
+      .help(isExpanded ? "Hide \(title.lowercased())" : "Show \(title.lowercased())")
+      .accessibilityLabel(title)
       .accessibilityValue(isExpanded ? "Expanded" : "Collapsed")
 
       if isExpanded {

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryExportDestinationSheet.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryExportDestinationSheet.swift
@@ -6,8 +6,8 @@ struct ExportsSection: View {
   let statuses: [MemoryExportDestination: MemoryExportStatus]
   let onSelectDestination: (MemoryExportDestination) -> Void
 
-  // Claude/Claude Code and ChatGPT/Codex are merged into one row each; tapping
-  // opens the grouped sheet that shows both options. The CLI-only cases drop out.
+  // Claude/Claude Code and ChatGPT/Codex each share one choice. Their setup
+  // sheets keep the cloud and CLI paths distinct without making this list uneven.
   private var entries: [(destination: MemoryExportDestination, title: String?, subtitle: String?)] {
     MemoryExportDestination.allCases.compactMap { d in
       switch d {
@@ -18,7 +18,9 @@ struct ExportsSection: View {
           .claude, "Claude / Claude Code", "Claude Code (CLI) or Claude cloud — choose in setup."
         )
       case .chatgpt:
-        return (.chatgpt, "ChatGPT / Codex", "Codex (CLI) or ChatGPT cloud — choose in setup.")
+        return (
+          .chatgpt, "ChatGPT / Codex", "Add Omi in ChatGPT or connect Codex locally — choose in setup."
+        )
       default:
         return (d, nil, nil)
       }
@@ -461,7 +463,9 @@ struct MemoryExportDestinationSheet: View {
     .background(OmiColors.backgroundPrimary)
     .task {
       await model.loadConfiguration()
-      statuses[destination] = await MemoryExportService.shared.status(for: destination)
+      statuses[destination] = destination == .chatgpt
+        ? await MemoryExportService.shared.refreshChatGPTDirectoryConnectionStatus()
+        : await MemoryExportService.shared.status(for: destination)
       if destination.supportsMCP && destination.requiresHostedMCPKeyForSetup && model.mcpKey == nil {
         await model.generateMCPKey()
       }
@@ -472,12 +476,20 @@ struct MemoryExportDestinationSheet: View {
     .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification))
     { _ in
       refreshPermissionStateIfNeeded()
+      refreshChatGPTDirectoryConnectionIfNeeded()
     }
   }
 
   private func refreshPermissionStateIfNeeded() {
     guard MemoryExportExecutor.requiresAccessibilityPreflight(destination) else { return }
     permissionRefreshID += 1
+  }
+
+  private func refreshChatGPTDirectoryConnectionIfNeeded() {
+    guard destination == .chatgpt else { return }
+    Task {
+      statuses[.chatgpt] = await MemoryExportService.shared.refreshChatGPTDirectoryConnectionStatus()
+    }
   }
 
   @ViewBuilder
@@ -507,14 +519,20 @@ struct MemoryExportDestinationSheet: View {
 
   @ViewBuilder
   private var manualSetupDisclosure: some View {
-    ManualInstallationDisclosure(isExpanded: $showManualSetup, fontSize: 13) {
+    ManualInstallationDisclosure(
+      isExpanded: $showManualSetup,
+      title: destination == .chatgpt ? "Developer-mode fallback" : "Manual installation",
+      fontSize: 13
+    ) {
       VStack(alignment: .leading, spacing: OmiSpacing.lg) {
         methodHeader(
           icon: "bolt.fill",
-          title: "Live connection",
-          tag: "AUTOMATIC",
-          tagColor: OmiColors.success,
-          subtitle: "Set it once — \(destination.title) reads your memories live and stays in sync."
+          title: destination == .chatgpt ? "Custom ChatGPT app" : "Live connection",
+          tag: destination == .chatgpt ? "ADVANCED" : "AUTOMATIC",
+          tagColor: destination == .chatgpt ? OmiColors.textTertiary : OmiColors.success,
+          subtitle: destination == .chatgpt
+            ? "Use only when your workspace requires a developer-mode custom app."
+            : "Set it once — \(destination.title) reads your memories live and stays in sync."
         )
         mcpSection
 
@@ -641,6 +659,8 @@ struct MemoryExportDestinationSheet: View {
 
   private var executeBlockSubtitle: String {
     switch destination.mcpExecuteKind {
+    case .directoryApp:
+      return "Open Omi’s approved ChatGPT listing, then add Omi and authorize it in ChatGPT. Omi checks the connection when you return."
     case .localAutonomous:
       return
         "Omi sets up \(destination.title) for you — it runs as an Omi task you can watch in the floating bar. If it gets stuck, use the manual steps below."
@@ -672,10 +692,10 @@ struct MemoryExportDestinationSheet: View {
           Image(systemName: "sparkles")
             .scaledFont(size: OmiType.body, weight: .semibold)
             .foregroundColor(OmiColors.textSecondary)
-          Text("Let Omi do it")
+          Text(destination.mcpExecuteKind == .directoryApp ? "Connect in ChatGPT" : "Let Omi do it")
             .scaledFont(size: OmiType.subheading, weight: .semibold)
             .foregroundColor(OmiColors.textPrimary)
-          Text("FASTEST")
+          Text(destination.mcpExecuteKind == .directoryApp ? "ONE CLICK" : "FASTEST")
             .scaledFont(size: OmiType.micro, weight: .bold)
             .foregroundColor(OmiColors.success)
             .padding(.horizontal, OmiSpacing.xs)
@@ -690,7 +710,9 @@ struct MemoryExportDestinationSheet: View {
         Button {
           Task {
             await model.executeWithOmi(destination: destination)
-            statuses[destination] = await MemoryExportService.shared.status(for: destination)
+            statuses[destination] = destination == .chatgpt
+              ? await MemoryExportService.shared.refreshChatGPTDirectoryConnectionStatus()
+              : await MemoryExportService.shared.status(for: destination)
             // Assisted flow: the user pastes values by hand, so surface the
             // field-by-field steps instead of leaving them collapsed.
             if destination.mcpExecuteKind == .assisted, destination.assistedOverlayHint != nil {
@@ -777,6 +799,8 @@ struct MemoryExportDestinationSheet: View {
     VStack(alignment: .leading, spacing: OmiSpacing.md) {
       if destination == .claude {
         claudeConnectorFields
+      } else if destination == .chatgpt {
+        chatGPTDeveloperModeFields
       } else {
         mcpCodeRow(
           label: "Server URL", value: MemoryExportDestination.mcpServerURL, copyLabel: "Server URL")
@@ -846,6 +870,48 @@ struct MemoryExportDestinationSheet: View {
         .scaledFont(size: OmiType.caption)
         .foregroundColor(OmiColors.textTertiary)
         .fixedSize(horizontal: false, vertical: true)
+    }
+  }
+
+  @ViewBuilder
+  private var chatGPTDeveloperModeFields: some View {
+    VStack(alignment: .leading, spacing: OmiSpacing.md) {
+      Text("Copy these fields only when creating a ChatGPT developer-mode custom app.")
+        .scaledFont(size: OmiType.caption)
+        .foregroundColor(OmiColors.textTertiary)
+        .fixedSize(horizontal: false, vertical: true)
+
+      mcpCodeRow(label: "Name", value: "Omi Memory", copyLabel: "Name")
+      mcpCodeRow(
+        label: "Connection / server URL",
+        value: MemoryExportDestination.mcpServerURL,
+        copyLabel: "Connection / server URL")
+      mcpCodeRow(label: "Authentication", value: "OAuth", copyLabel: "Authentication")
+
+      Text("Advanced OAuth settings")
+        .scaledFont(size: OmiType.caption, weight: .medium)
+        .foregroundColor(OmiColors.textSecondary)
+        .padding(.top, OmiSpacing.hairline)
+
+      mcpCodeRow(
+        label: "OAuth Client ID",
+        value: destination.cloudOAuthClientID ?? "",
+        copyLabel: "OAuth Client ID")
+      Text("Leave OAuth Client Secret blank.")
+        .scaledFont(size: OmiType.caption)
+        .foregroundColor(OmiColors.textTertiary)
+      mcpCodeRow(
+        label: "Token auth method",
+        value: destination.cloudTokenAuthMethod ?? "none",
+        copyLabel: "Token auth method")
+      mcpCodeRow(
+        label: "Auth URL",
+        value: MemoryExportDestination.mcpAuthorizeURL,
+        copyLabel: "Auth URL")
+      mcpCodeRow(
+        label: "Token URL",
+        value: MemoryExportDestination.mcpTokenURL,
+        copyLabel: "Token URL")
     }
   }
 

--- a/desktop/macos/Desktop/Sources/MemoryExportExecutor.swift
+++ b/desktop/macos/Desktop/Sources/MemoryExportExecutor.swift
@@ -28,6 +28,16 @@ enum MemoryExportExecutor {
   }
 
   static func run(_ destination: MemoryExportDestination) async throws -> Outcome {
+    if case .directoryApp = destination.mcpExecuteKind {
+      guard let directoryURL = destination.directoryInstallURL else {
+        throw ExecutorError.unsupported(destination.title)
+      }
+      NSWorkspace.shared.open(directoryURL)
+      return Outcome(
+        taskTitle: "Opened Omi in ChatGPT. Add Omi and authorize it there, then return to Omi.",
+        mode: .assisted)
+    }
+
     if requiresAccessibilityPreflight(destination), !isAccessibilityReadyForBrowserSetup() {
       requestAccessibilityApprovalForCloudSetup()
       throw ExecutorError.browserSetupRequired(cloudSetupAccessibilityPermissionMessage)
@@ -47,6 +57,8 @@ enum MemoryExportExecutor {
     }
 
     switch destination.mcpExecuteKind {
+    case .directoryApp:
+      throw ExecutorError.unsupported(destination.title)
     case .localAutonomous:
       guard let task = destination.omiExecutionTask(key: key) else {
         throw ExecutorError.unsupported(destination.title)

--- a/desktop/macos/Desktop/Sources/MemoryExportService.swift
+++ b/desktop/macos/Desktop/Sources/MemoryExportService.swift
@@ -37,6 +37,11 @@ enum MemoryExportDestination: String, CaseIterable, Identifiable, Sendable {
     mcpBaseURL.contains("api.omi.me") ? "omi-chatgpt-prod" : "omi-chatgpt-dev"
   }
 
+  /// The approved ChatGPT directory listing. This is the primary ChatGPT
+  /// connection path; the custom-connector flow remains an advanced fallback.
+  static let chatGPTDirectoryInstallURL = URL(
+    string: "https://chatgpt.com/plugins/plugin_asdk_app_6a1490df4c588191b9339ae21978c873?q=omi")!
+
   var cloudOAuthClientID: String? {
     switch self {
     case .chatgpt: return Self.chatgptOAuthClientID
@@ -92,7 +97,7 @@ enum MemoryExportDestination: String, CaseIterable, Identifiable, Sendable {
     switch self {
     case .notion: return "Copy-ready page export"
     case .obsidian: return "Choose once, refresh anytime"
-    case .chatgpt: return "Live MCP or memory pack"
+    case .chatgpt: return "Add Omi from the ChatGPT directory"
     case .claude: return "Live MCP or memory pack"
     case .gemini: return "Prompt + memory pack"
     case .agents: return "One prompt for your agent"
@@ -108,7 +113,7 @@ enum MemoryExportDestination: String, CaseIterable, Identifiable, Sendable {
     case .notion: return "Copy a ready-to-paste memory page and jump into Notion."
     case .obsidian: return "Write Omi memories into your Obsidian vault."
     case .chatgpt:
-      return "Connect over MCP so ChatGPT reads your memories live, or copy a memory pack."
+      return "Add Omi in ChatGPT, authorize once, and use your memories in every ChatGPT chat."
     case .claude:
       return "Connect over MCP so Claude reads your memories live, or copy a memory pack."
     case .gemini: return "Copy the prompt and memory pack, then open Gemini."
@@ -154,7 +159,9 @@ enum MemoryExportDestination: String, CaseIterable, Identifiable, Sendable {
     }
   }
 
-  /// How the "Do it for me" button performs setup.
+  /// How the primary connection button performs setup.
+  /// - `.directoryApp`: opens an approved provider directory listing. Provider
+  ///   consent completes the connection, then Omi refreshes the OAuth grant.
   /// - `.localAutonomous`: deterministic local CLI/config/file work.
   /// - `.browserAutonomous`: open the cloud connector in the user's default
   ///   signed-in browser and use native macOS automation, with assisted fallback
@@ -163,11 +170,12 @@ enum MemoryExportDestination: String, CaseIterable, Identifiable, Sendable {
   ///   docs/cloud-connectors-roadmap.md before mapping anything back here.
   /// - `.assisted`: deterministic open + copy, with an on-screen guidance card
   ///   for cloud connectors. The user performs the final paste/click.
-  enum MCPExecuteKind { case localAutonomous, browserAutonomous, assisted }
+  enum MCPExecuteKind: Equatable { case directoryApp, localAutonomous, browserAutonomous, assisted }
   var mcpExecuteKind: MCPExecuteKind {
     switch self {
+    case .chatgpt: return .directoryApp
     case .claudeCode, .codex, .openclaw, .hermes: return .localAutonomous
-    case .chatgpt, .claude, .notion, .obsidian, .gemini, .agents: return .assisted
+    case .claude, .notion, .obsidian, .gemini, .agents: return .assisted
     }
   }
 
@@ -209,6 +217,10 @@ enum MemoryExportDestination: String, CaseIterable, Identifiable, Sendable {
     case .agents, .claudeCode, .codex, .openclaw, .hermes:
       return nil
     }
+  }
+
+  var directoryInstallURL: URL? {
+    self == .chatgpt ? Self.chatGPTDirectoryInstallURL : nil
   }
 
   var manualPrompt: String {
@@ -371,7 +383,12 @@ enum MemoryExportDestination: String, CaseIterable, Identifiable, Sendable {
         title: "Connected",
         subtitle: "OpenClaw is ready to read Omi Memory."
       )
-    case .chatgpt, .claude:
+    case .chatgpt:
+      return MCPSetupCompletionSummary(
+        title: "Authorized in ChatGPT",
+        subtitle: "ChatGPT can now use your Omi memories."
+      )
+    case .claude:
       return MCPSetupCompletionSummary(
         title: "Connected",
         subtitle: "\(title) can read Omi Memory."
@@ -620,10 +637,7 @@ enum MemoryExportDestination: String, CaseIterable, Identifiable, Sendable {
         "Copy each value into the Add custom connector form, then click Add and Connect."
       )
     case .chatgpt:
-      return (
-        "Finish in ChatGPT",
-        "In Settings → Apps → Advanced, enable Developer mode. Then click Create app and fill the fields below."
-      )
+      return nil
     default:
       return nil
     }
@@ -681,6 +695,8 @@ struct MemoryExportConnectionPresentation: Equatable {
       title = "Connecting…"
     } else {
       switch destination.mcpExecuteKind {
+      case .directoryApp:
+        title = "Add Omi to ChatGPT"
       case .localAutonomous:
         title = "Do it for me"
       case .browserAutonomous:
@@ -757,6 +773,26 @@ actor MemoryExportService {
   private let notionBaseURL = URL(string: "https://api.notion.com/v1")!
   private var mcpKeyWarmTask: (ownerUserId: String, id: UUID, task: Task<String, Error>)?
 
+  private struct OAuthGrant: Decodable {
+    let clientID: String
+    let status: String?
+    let revokedAt: String?
+
+    enum CodingKeys: String, CodingKey {
+      case clientID = "client_id"
+      case status
+      case revokedAt = "revoked_at"
+    }
+
+    var isActive: Bool {
+      revokedAt == nil && status != "revoked"
+    }
+  }
+
+  private struct OAuthGrantsResponse: Decodable {
+    let grants: [OAuthGrant]
+  }
+
   func status(for destination: MemoryExportDestination) -> MemoryExportStatus {
     let currentMCPKey = storedMCPKey()
     let localConnections: Set<MemoryExportDestination> = destination.supportsMCP
@@ -788,7 +824,11 @@ actor MemoryExportService {
       hasConnection = hasLocalMCPConnection
     case .claude:
       hasConnection = exportedCount > 0 || hasConnectedTimestamp || hasLocalMCPConnection
-    case .chatgpt, .notion, .obsidian, .gemini, .agents:
+    case .chatgpt:
+      // A copied memory pack is not an OAuth authorization. ChatGPT's status
+      // is only changed by the provider-backed grant refresh below.
+      hasConnection = hasConnectedTimestamp || hasLocalMCPConnection
+    case .notion, .obsidian, .gemini, .agents:
       hasConnection = exportedCount > 0 || hasConnectedTimestamp || hasLocalMCPConnection
     }
     let isConfigured: Bool
@@ -822,6 +862,31 @@ actor MemoryExportService {
       lastWriteWins: MemoryExportDestination.allCases.map { destination in
         (destination, status(for: destination, localMCPConnections: localConnections))
       })
+  }
+
+  /// Refreshes the authoritative connection state after returning from the
+  /// ChatGPT directory. Network failures intentionally retain the last known
+  /// state rather than presenting an authorization as revoked.
+  func refreshChatGPTDirectoryConnectionStatus() async -> MemoryExportStatus {
+    do {
+      let response: OAuthGrantsResponse = try await APIClient.shared.get(
+        "v1/mcp/oauth/grants", includeBYOK: false)
+      let isAuthorized = response.grants.contains {
+        $0.clientID == MemoryExportDestination.chatgptOAuthClientID && $0.isActive
+      }
+
+      if isAuthorized {
+        defaults.set(Date().timeIntervalSince1970, forKey: MemoryExportDestination.chatgpt.connectedAtKey)
+        defaults.set("Authorized through ChatGPT", forKey: MemoryExportDestination.chatgpt.detailKey)
+      } else {
+        defaults.removeObject(forKey: MemoryExportDestination.chatgpt.connectedAtKey)
+        defaults.removeObject(forKey: MemoryExportDestination.chatgpt.detailKey)
+      }
+    } catch {
+      log("MemoryExportService: ChatGPT OAuth grant refresh failed: \(error.localizedDescription)")
+    }
+
+    return status(for: .chatgpt)
   }
 
   func notionConfiguration() -> (token: String, parentPageID: String) {

--- a/desktop/macos/Desktop/Tests/BrowserAutomationTargetTests.swift
+++ b/desktop/macos/Desktop/Tests/BrowserAutomationTargetTests.swift
@@ -32,14 +32,17 @@ final class BrowserAutomationTargetTests: XCTestCase {
   }
 
   func testDestinationModesSeparateCloudBrowserAndLocalSetup() {
-    // ChatGPT/Claude cloud are assisted-first: deterministic open+copy plus an
-    // on-screen guidance card. See docs/cloud-connectors-roadmap.md.
-    XCTAssertEqual(MemoryExportDestination.chatgpt.mcpExecuteKind, .assisted)
+    // ChatGPT uses the approved directory listing. Claude remains assisted-first.
+    XCTAssertEqual(MemoryExportDestination.chatgpt.mcpExecuteKind, .directoryApp)
+    XCTAssertEqual(
+      MemoryExportDestination.chatgpt.directoryInstallURL?.absoluteString,
+      "https://chatgpt.com/plugins/plugin_asdk_app_6a1490df4c588191b9339ae21978c873?q=omi")
     XCTAssertEqual(MemoryExportDestination.claude.mcpExecuteKind, .assisted)
-    XCTAssertNotNil(MemoryExportDestination.chatgpt.assistedOverlayHint)
+    XCTAssertNil(MemoryExportDestination.chatgpt.assistedOverlayHint)
     XCTAssertNotNil(MemoryExportDestination.claude.assistedOverlayHint)
     XCTAssertNil(MemoryExportDestination.gemini.assistedOverlayHint)
     XCTAssertEqual(MemoryExportDestination.claude.assistedSetupFields(key: "k")?.count, 4)
+    // Preserve the developer-mode custom app fields as the advanced fallback.
     XCTAssertEqual(MemoryExportDestination.chatgpt.assistedSetupFields(key: "k")?.count, 8)
     // Prod ChatGPT client is public PKCE — the secret row must stay blank.
     XCTAssertEqual(
@@ -65,6 +68,11 @@ final class BrowserAutomationTargetTests: XCTestCase {
     XCTAssertEqual(MemoryExportDestination.codex.mcpExecuteKind, .localAutonomous)
     XCTAssertEqual(MemoryExportDestination.claudeCode.mcpExecuteKind, .localAutonomous)
     XCTAssertEqual(MemoryExportDestination.gemini.mcpExecuteKind, .assisted)
+  }
+
+  func testChatGPTAndCodexShareOnePickerChoice() {
+    XCTAssertEqual(ConnectDestinationSheet.group(for: .chatgpt), [.chatgpt, .codex])
+    XCTAssertEqual(ConnectDestinationSheet.group(for: .codex), [.chatgpt, .codex])
   }
 
   func testAgentSkillHandlesNullableHostedProfileAndRemoteTransport() {

--- a/desktop/macos/Desktop/Tests/MemoryExportStatusTests.swift
+++ b/desktop/macos/Desktop/Tests/MemoryExportStatusTests.swift
@@ -62,6 +62,20 @@ final class MemoryExportStatusTests: XCTestCase {
     XCTAssertTrue(status.hasConnection)
   }
 
+  func testChatGPTMemoryPackDoesNotClaimDirectoryAuthorization() async {
+    UserDefaults.standard.set(7, forKey: "memoryExportExportedCount.chatgpt")
+
+    let status = await MemoryExportService.shared.status(for: .chatgpt)
+    let presentation = MemoryExportConnectionPresentation.make(
+      destination: .chatgpt,
+      status: status,
+      isRunning: false)
+
+    XCTAssertFalse(status.isConfigured)
+    XCTAssertFalse(status.hasConnection)
+    XCTAssertEqual(presentation.primaryActionTitle, "Add Omi to ChatGPT")
+  }
+
   func testOnlyLocalAgentSetupDestinationsHaveLocallyVerifiableLiveSetup() {
     XCTAssertFalse(MemoryExportDestination.chatgpt.hasLocallyVerifiableLiveSetup)
     XCTAssertFalse(MemoryExportDestination.claude.hasLocallyVerifiableLiveSetup)

--- a/desktop/macos/changelog/unreleased/20260713-chatgpt-directory-one-click.json
+++ b/desktop/macos/changelog/unreleased/20260713-chatgpt-directory-one-click.json
@@ -1,0 +1,3 @@
+{
+  "change": "Added a one-click Omi connection through the approved ChatGPT app directory inside the combined ChatGPT / Codex choice, with verified authorization status and a developer-mode fallback"
+}

--- a/desktop/macos/docs/cloud-connectors-roadmap.md
+++ b/desktop/macos/docs/cloud-connectors-roadmap.md
@@ -6,9 +6,12 @@ and no API** — ChatGPT (custom connector / developer mode) and Claude
 [integrations-philosophy.md](./integrations-philosophy.md) §1 and is not covered
 here.
 
-**Status (July 2026):** assisted-first. Autonomous setup for these two is
-**parked**, not abandoned — this doc is the plan for bringing it back on a
-sounder foundation, and for making it unnecessary altogether.
+**Status (July 2026):** ChatGPT is directory-first: Desktop opens Omi’s
+approved ChatGPT listing and reads the user’s existing OAuth grant on return.
+The developer-mode custom-app fields remain an advanced fallback. Claude is
+still assisted-first. Autonomous setup remains **parked**, not abandoned — this
+doc is the plan for bringing it back on a sounder foundation where a directory
+is not available.
 
 ---
 
@@ -31,9 +34,9 @@ and they failed differently:
 Conclusion per the philosophy doc: stop tuning heuristics on surfaces we don't
 own. Make the deterministic 90% ours, hand the user the last click.
 
-## Phase 1 — Assisted-first (SHIPPED with this doc)
+## Phase 1 — Assisted-first (Claude, and ChatGPT fallback)
 
-"Do it for me" for ChatGPT/Claude now:
+"Do it for me" for Claude — and the optional ChatGPT developer-mode fallback — now:
 
 1. opens the provider deep link in the default browser,
 2. shows an on-screen card with **one copy button per field**
@@ -72,21 +75,20 @@ data (§6), every run captures a sanitized trace for the eval corpus (§7), and
 completion is gated on the functional probe. When this lands, delete
 `CloudConnectorFormAutomation` rather than extending it.
 
-## Phase 3 — Get out of category 3 entirely (STRATEGIC)
+## Phase 3 — Get out of category 3 entirely
 
 The real fix is distribution, not automation:
 
 - **Anthropic connector directory**: get Omi Memory listed so Claude users
   click "Connect" in the directory and do a standard OAuth consent. No form,
   no automation.
-- **OpenAI Apps SDK**: ship Omi Memory as a ChatGPT app for the same one-click
-  flow — also removes the developer-mode/plan gate for end users.
+- **OpenAI Apps SDK (SHIPPED):** Omi is listed as a ChatGPT app. Desktop opens
+  the directory listing directly and verifies the resulting OAuth grant after
+  the user returns.
 
 The backend is already shaped for this (`backend/routers/mcp_sse.py` supports
-public PKCE clients and per-provider callback allowlisting); the remaining work
-is mostly the submission/review process. Start the applications early — the
-timeline is the providers', not ours. Once listed, Phases 1–2 become the
-fallback for users outside the directories.
+public PKCE clients and per-provider callback allowlisting). Once listed,
+Phases 1–2 become the fallback for users outside the directories.
 
 ## How to pick up this work
 


### PR DESCRIPTION
## Summary

- Add Omi's approved ChatGPT directory listing as the primary one-click connection path.
- Keep ChatGPT and Codex visually grouped on macOS, with ChatGPT first in the chooser and Codex local setup second.
- Refresh the authoritative ChatGPT OAuth grant when the app returns from ChatGPT; retain the developer-mode configuration as an advanced fallback.

## Root cause and durable guard

Splitting ChatGPT and Codex into separate destination rows made the macOS home and export lists visually uneven. The group model now owns their shared row and chooser, and a regression test asserts that both destinations resolve to the same ChatGPT-first group.

## Product invariants affected

- INV-INT-1
- INV-MEM-1

## Verification

- `xcrun swift test -c debug --package-path Desktop --filter 'BrowserAutomationTargetTests|MemoryExportStatusTests'` (46 passed)
- `./scripts/agent-logic-harness.sh --cross-surface-smoke` (passed)
- Built and exercised `/Applications/omi-chatgpt-directory.app`: combined row, ChatGPT-first chooser, developer-mode fallback, and exact approved directory URL.
- `make preflight` (passed with this PR body)

## Notes

- The broader desktop suite currently has one unrelated failure in `HubSystemInstructionTests.testRealtimeListAgentSessionsToolIsExposed`; the targeted connection-flow suite passes.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9679?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

