### PR TITLE
fix(preflight): normalize Firestore query paths

### DIFF
--- a/backend/scripts/firestore_query_coverage.py
+++ b/backend/scripts/firestore_query_coverage.py
@@ -19,7 +19,7 @@ import json
 import sys
 from dataclasses import dataclass, field
 from datetime import date
-from pathlib import Path
+from pathlib import Path, PurePath
 from typing import Any, Iterable, Mapping
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -32,6 +32,10 @@ BASELINE_PATH = BACKEND_ROOT / 'scripts' / 'firestore_query_coverage_baseline.js
 WAIVERS_PATH = BACKEND_ROOT / 'scripts' / 'firestore_query_coverage_waivers.json'
 QUERY_SPEC_SOURCE = Path('backend/database/firestore_index_registry.py')
 NON_SERVING_SEGMENTS = {'tests', 'scripts', 'migrations', 'migration'}
+
+
+def _canonical_source(path: PurePath) -> str:
+    return path.as_posix()
 
 
 @dataclass(frozen=True)
@@ -353,11 +357,12 @@ def inventory(*, waiver_ids: set[str]) -> list[QueryShape]:
             part.startswith('.') or part in {'venv', '__pycache__'} for part in backend_relative.parts
         ):
             continue
-        tree = ast.parse(path.read_text(encoding='utf-8'), filename=str(relative))
+        source = _canonical_source(relative)
+        tree = ast.parse(path.read_text(encoding='utf-8'), filename=source)
         constants = _module_constants(tree)
         non_serving_scope = _non_serving_scope(relative)
         module_analyzer = FunctionQueryAnalyzer(
-            source=str(relative),
+            source=source,
             symbol='<module>',
             constants=constants,
             non_serving_scope=non_serving_scope,
@@ -370,7 +375,7 @@ def inventory(*, waiver_ids: set[str]) -> list[QueryShape]:
             if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
                 continue
             analyzer = FunctionQueryAnalyzer(
-                source=str(relative),
+                source=source,
                 symbol=node.name,
                 constants=constants,
                 non_serving_scope=non_serving_scope,
@@ -386,7 +391,7 @@ def inventory(*, waiver_ids: set[str]) -> list[QueryShape]:
             0,
         )
         shape = QueryShape(
-            source=str(QUERY_SPEC_SOURCE),
+            source=_canonical_source(QUERY_SPEC_SOURCE),
             symbol=spec.identifier,
             line=line,
             collection_group=spec.collection_group,

--- a/backend/tests/unit/test_firestore_query_contract.py
+++ b/backend/tests/unit/test_firestore_query_contract.py
@@ -1,7 +1,7 @@
 import ast
 import json
 from datetime import datetime, timedelta, timezone
-from pathlib import Path
+from pathlib import Path, PurePath, PurePosixPath, PureWindowsPath
 from types import SimpleNamespace
 
 import pytest
@@ -178,6 +178,34 @@ def test_inventory_finds_a_direct_compound_chain_wrapped_by_list():
         ('status', '=='),
         ('expires_at', '>'),
     ]
+
+
+def test_query_fingerprints_are_platform_independent():
+    tree = ast.parse(
+        "def read(client):\n"
+        "    return client.collection('items').where('status', '==', 'open').where('expires_at', '>', 0).stream()\n"
+    )
+    function = tree.body[0]
+
+    def fingerprint(source_path: PurePath) -> tuple[str, str]:
+        source = firestore_query_coverage._canonical_source(source_path)
+        analyzer = firestore_query_coverage.FunctionQueryAnalyzer(
+            source=source,
+            symbol='read',
+            constants={},
+            non_serving_scope=None,
+            registered_signatures={},
+            waiver_ids=set(),
+        )
+        shapes = analyzer.analyze(function.body)
+        assert len(shapes) == 1
+        return source, shapes[0].fingerprint
+
+    windows_source, windows_fingerprint = fingerprint(PureWindowsPath('backend/database/example.py'))
+    posix_source, posix_fingerprint = fingerprint(PurePosixPath('backend/database/example.py'))
+
+    assert windows_source == posix_source == 'backend/database/example.py'
+    assert windows_fingerprint == posix_fingerprint
 
 
 def test_query_coverage_ratchet_rejects_a_new_raw_serving_shape():


### PR DESCRIPTION
## Summary

- canonicalize Firestore query inventory source paths before they enter fingerprints
- use the same canonical path for AST diagnostics, runtime query shapes, and registry shapes
- add a platform-independent Windows/Posix fingerprint regression test

## Root cause

`inventory()` passed `str(relative)` into `QueryShape.source`, and `source` is part of the fingerprint. Linux generated `backend/database/...` while Windows generated `backend\database\...`, so all 45 existing raw or unsupported fingerprints looked new on Windows. Waiver IDs were platform-dependent for the same reason.

The old code reproduced both failures on Windows:

- `firestore_query_coverage.py --check-ratchet` reported 42 new raw shapes and 3 new unsupported shapes
- `test_query_coverage_baseline_tracks_current_raw_and_unsupported_debt` failed against the committed baseline

## Durable guard

All inventory paths now pass through `PurePath.as_posix()` before constructing a `QueryShape`. The regression test feeds equivalent `PureWindowsPath` and `PurePosixPath` values through the analyzer and requires identical source strings and fingerprints. The full baseline test also passes on Windows.

## Validation

- `python backend/scripts/firestore_query_coverage.py --check-ratchet` - passed
- `python -m pytest backend/tests/unit/test_firestore_query_contract.py::test_query_coverage_baseline_tracks_current_raw_and_unsupported_debt -q -m slow` - 1 passed
- official `backend/test.sh` selected-file runner - 6 passed, 2 deselected
- `black --check --line-length 120 --skip-string-normalization ...` - passed
- `backend/scripts/typecheck.sh` - 0 errors
- `$env:PYTHONUTF8='1'; make preflight` - 14 checks passed

Fixes #9682.
Contributes to #9440.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9683?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

