### PR TITLE
fix(desktop): recover PTT turns rejected by realtime context admission

### DIFF
--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
@@ -3139,7 +3139,7 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate {
       reconnectAudioBuffer = nil
       live.abandonInputTurn()
       VoiceTurnCoordinator.shared.send(
-        .providerReconnectFailed(
+        .providerContextAdmissionRejected(
           turnID: pending.turnID,
           identity: pending.identity,
           message: "realtime context admission rejected: \(admission)"))
@@ -3213,7 +3213,7 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate {
     guard VoiceTurnCoordinator.shared.activeTurnID == turnID else { return }
     session?.abandonInputTurn()
     VoiceTurnCoordinator.shared.send(
-      .providerReconnectFailed(
+      .providerContextAdmissionRejected(
         turnID: turnID,
         identity: pending.identity,
         message: message))
@@ -3779,7 +3779,7 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate {
       reconnectAudioBuffer = nil
       live.abandonInputTurn()
       VoiceTurnCoordinator.shared.send(
-        .providerReconnectFailed(
+        .providerContextAdmissionRejected(
           turnID: pending.turnID,
           identity: pending.identity,
           message: "realtime reconnect admission rejected: \(admission)"))

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/VoiceTurnStateMachine.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/VoiceTurnStateMachine.swift
@@ -409,6 +409,12 @@ enum VoiceTurnEvent: Equatable, Sendable {
     turnID: VoiceTurnID, identity: VoiceEffectIdentity, sessionID: VoiceSessionID)
   case providerReconnectFailed(
     turnID: VoiceTurnID, identity: VoiceEffectIdentity, message: String)
+  /// Buffered PTT input was discarded before it ever reached the provider, because the
+  /// context-bound admission rejected it (or the kernel snapshot it needed failed). Unlike
+  /// `providerReconnectFailed` — a transport failure that kills the turn — the captured audio
+  /// is still intact, so the turn takes the bounded transcription fallback instead of dying.
+  case providerContextAdmissionRejected(
+    turnID: VoiceTurnID, identity: VoiceEffectIdentity, message: String)
   case providerReplacementStarted(
     turnID: VoiceTurnID, identity: VoiceEffectIdentity,
     previousResponseID: VoiceResponseID?, nextResponseID: VoiceResponseID)
@@ -470,6 +476,7 @@ enum VoiceTurnEvent: Equatable, Sendable {
       .hubCommitDeferredForReplacement(let turnID),
       .providerReconnectStarted(let turnID, _, _), .providerReconnected(let turnID, _, _),
       .providerReconnectFailed(let turnID, _, _),
+      .providerContextAdmissionRejected(let turnID, _, _),
       .providerReplacementStarted(let turnID, _, _, _),
       .providerReplacementReady(let turnID, _, _, _), .contextResolved(let turnID, _),
       .providerReplacementFailed(let turnID, _, _),
@@ -518,6 +525,7 @@ enum VoiceTurnEvent: Equatable, Sendable {
     case .providerReconnectStarted: return "provider_reconnect_started"
     case .providerReconnected: return "provider_reconnected"
     case .providerReconnectFailed: return "provider_reconnect_failed"
+    case .providerContextAdmissionRejected: return "provider_context_admission_rejected"
     case .providerReplacementStarted: return "provider_replacement_started"
     case .providerReplacementReady: return "provider_replacement_ready"
     case .providerReplacementFailed: return "provider_replacement_failed"
@@ -895,6 +903,41 @@ struct VoiceTurnReducer {
         return VoiceTurnReduction(model: model, effects: effects)
       }
       terminate(&model, reason: .providerFailed, effects: &effects)
+
+    case .providerContextAdmissionRejected(_, let identity, _):
+      guard case .reconnecting(let expectedIdentity, _) = turn.providerConnection,
+        expectedIdentity == identity, !turn.phase.isTerminal
+      else {
+        stale(&model, event: event, effects: &effects)
+        return VoiceTurnReduction(model: model, effects: effects)
+      }
+      cancel(.providerReconnect, in: &model, effects: &effects)
+      // The rejected audio never reached the provider, so the turn is still recoverable —
+      // but only from an input phase, because the transcription fallback transcribes the
+      // capture buffer. `providerReconnectStarted` projects a released turn into
+      // awaitingResponse while it waits for the socket, so restore the input phase first;
+      // any other phase has no buffered input to rescue and keeps the terminal behavior.
+      let inputPhase: VoiceTurnPhase? = {
+        if turn.phase.isRecording { return turn.phase }
+        if turn.phase == .finalizing { return .finalizing }
+        if turn.phase == .awaitingResponse, turn.hubCommitPending { return .finalizing }
+        return nil
+      }()
+      guard let inputPhase else {
+        terminate(&model, reason: .providerFailed, effects: &effects)
+        return VoiceTurnReduction(model: model, effects: effects)
+      }
+      cancel(.hubWarm, in: &model, effects: &effects)
+      model.turn?.providerConnection = .ready
+      model.turn?.phase = inputPhase
+      model.turn?.projection.isListening = inputPhase.isRecording
+      model.turn?.projection.isThinking = !inputPhase.isRecording
+      model.turn?.projection.isResponseWaiting = false
+      model.turn?.route = .deepgramBatch
+      effects.append(.fallbackToTranscription(turnID: turn.id, reason: .hubWarmTimeout))
+      if inputPhase == .finalizing {
+        schedule(.transcription, after: deadlines.transcription, in: &model, effects: &effects)
+      }
 
     case .providerReplacementStarted(
       _, let identity, let previousResponseID, let nextResponseID):

--- a/desktop/macos/Desktop/Tests/VoiceTurnReducerTests.swift
+++ b/desktop/macos/Desktop/Tests/VoiceTurnReducerTests.swift
@@ -1243,6 +1243,71 @@ final class VoiceTurnReducerTests: XCTestCase {
     XCTAssertEqual(failed.model.turn?.phase, .terminal(.providerFailed))
   }
 
+  func testContextAdmissionRejectionAfterReleaseTranscribesInsteadOfDroppingTheTurn() {
+    let turnID = VoiceTurnID()
+    var model = reduce(.idle, .start(turnID: turnID, ownerID: nil, intent: .hold)).model
+    model = reduce(model, .selectRoute(turnID: turnID, route: .hubWarmWait)).model
+    model = reduce(model, .finalize(turnID: turnID)).model
+    model = reduce(model, .hubCommitDeferred(turnID: turnID)).model
+    let reservation = reserveIdentity(model, turnID: turnID)
+    model = reservation.model
+    model = reduce(
+      model,
+      .providerReconnectStarted(
+        turnID: turnID,
+        identity: reservation.identity,
+        previousSessionID: nil)).model
+    // The pending commit projects the released turn into awaitingResponse while it waits
+    // for the socket; the rejection must still be able to rescue the captured audio.
+    XCTAssertEqual(model.turn?.phase, .awaitingResponse)
+
+    let rejected = reduce(
+      model,
+      .providerContextAdmissionRejected(
+        turnID: turnID,
+        identity: reservation.identity,
+        message: "realtime context admission rejected: rejectMissingContextIdentity"))
+
+    XCTAssertEqual(rejected.model.turn?.phase, .finalizing)
+    XCTAssertEqual(rejected.model.turn?.route, .deepgramBatch)
+    XCTAssertEqual(rejected.model.turn?.providerConnection, .ready)
+    XCTAssertTrue(rejected.model.turn?.deadlines.contains(.transcription) == true)
+    XCTAssertFalse(rejected.model.turn?.deadlines.contains(.providerReconnect) == true)
+    XCTAssertTrue(
+      rejected.effects.contains(
+        .fallbackToTranscription(turnID: turnID, reason: .hubWarmTimeout)))
+    XCTAssertNil(rejected.model.lastTerminal)
+  }
+
+  func testContextAdmissionRejectionWhileHoldingKeepsRecordingOnTheTranscriptionRoute() {
+    let turnID = VoiceTurnID()
+    var model = reduce(.idle, .start(turnID: turnID, ownerID: nil, intent: .hold)).model
+    model = reduce(model, .selectRoute(turnID: turnID, route: .hubWarmWait)).model
+    let reservation = reserveIdentity(model, turnID: turnID)
+    model = reservation.model
+    model = reduce(
+      model,
+      .providerReconnectStarted(
+        turnID: turnID,
+        identity: reservation.identity,
+        previousSessionID: nil)).model
+
+    let rejected = reduce(
+      model,
+      .providerContextAdmissionRejected(
+        turnID: turnID,
+        identity: reservation.identity,
+        message: "realtime context admission rejected: rejectStaleProviderContext"))
+
+    XCTAssertEqual(rejected.model.turn?.phase, .recording)
+    XCTAssertEqual(rejected.model.turn?.route, .deepgramBatch)
+    XCTAssertFalse(rejected.model.turn?.deadlines.contains(.transcription) == true)
+    XCTAssertTrue(
+      rejected.effects.contains(
+        .fallbackToTranscription(turnID: turnID, reason: .hubWarmTimeout)))
+    XCTAssertNil(rejected.model.lastTerminal)
+  }
+
   func testExplicitInterruptRevokesToolAndRejectsItsLateCallback() throws {
     let (startingModel, turnID, _, _) = awaitingHubResponse()
     let reservation = reserveIdentity(startingModel, turnID: turnID)

--- a/desktop/macos/changelog/unreleased/20260714-ptt-context-admission-fallback.json
+++ b/desktop/macos/changelog/unreleased/20260714-ptt-context-admission-fallback.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed push-to-talk dropping a spoken question with no answer when the realtime session rejected the turn's context — it now falls back to transcription instead of silently ending the turn"
+}


### PR DESCRIPTION
## Bug

A spoken push-to-talk question can be **silently dropped** — the user holds PTT, speaks a full question, releases, and gets **no answer, no transcript, and no error**. The captured audio is discarded.

## Root cause

`dbd69e71c5` ("make realtime context admission fail closed") made context admission fail-closed and routed all three *asynchronous* rejection sites through `.providerReconnectFailed`:

- `RealtimeHubController.finishContextFreshInputOnCurrentSession()`
- `RealtimeHubController.finishSessionReconnectAfterReady()`
- `RealtimeHubController.failContextFreshInputPreparation()`

`.providerReconnectFailed` means **transport failure**, and the reducer maps it to `terminate(reason: .providerFailed)` — the turn dies with no transcription fallback.

But an admission rejection is a **context/policy decision, not a transport failure**. The buffered audio never reached the provider and is still intact in `batchAudioBuffer`, so the turn is recoverable. The follow-up `711b3a13af` restored exactly that bounded Deepgram fallback — but only for the **synchronous** rejection (`.hubAdmissionRejected`), which fires *before* `.providerReconnectStarted` projects the turn. The async half stayed fatal.

Reachable without a race: `.rejectStaleProviderContext` fires on any owner-scope skew between the context bind and the socket build (`sessionVoiceContextFreshnessIdentity` is reset to `""` by `teardownSession()` and re-derived empty when `prefetchedVoiceContextOwnerScope != ownerScope`).

## Fix

Add `.providerContextAdmissionRejected` for the three sites that discard buffered input *before it ever reached the provider*. The reducer:

1. undoes the `awaitingResponse` projection that `providerReconnectStarted` applies to a released turn (the transcription fallback only runs from an input phase — otherwise the turn would hang instead of dying, which is worse);
2. takes the same bounded transcription fallback as the synchronous case.

A phase with no buffered input to rescue keeps the terminal behavior, and a genuine transport failure (`hubDidError`) still terminates via `.providerReconnectFailed`.

**Closing the class:** the failed contract was conflating *admission rejection* with *transport failure* on one event. Both halves of the rejection surface now map to the same recovery, and `.providerReconnectFailed` is left to mean only what it says.

## Verification

- `xcrun swift build -c debug --package-path Desktop` — green.
- `VoiceTurnReducerTests` — **57/57 pass**, including 2 new regression tests: a released turn transcribes instead of dying; a still-held turn keeps recording on the transcription route.
- **Teeth check:** with the reducer forced back to `terminate()`, both new tests fail (10 assertions); with the fix they pass.
- **Not exercised in a live app** — the rejection needs a provider-side race / stale-context condition I cannot reproduce on demand. Coverage is behavioral through the production reducer API (a controllable seam), not a source grep.

## Scope

4 files, +114/−3. Unreleased code (`dbd69e71c5` is not in `v0.12.72`, the current prod build), so this is **not live on prod** — opened for review, **not merged**.

🤖 automated by hourly watchdog; opened for review, not merged.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9684?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



## Product invariants affected

- INV-CHAT-1
- INV-VOICE-1
