### PR TITLE
fix(deploy): normalize Firestore index readiness

### DIFF
--- a/backend/scripts/reconcile_firestore_indexes.py
+++ b/backend/scripts/reconcile_firestore_indexes.py
@@ -25,11 +25,24 @@ IndexSignature = tuple[str, str, tuple[tuple[str, str], ...]]
 CommandRunner = Callable[..., Any]
 
 
-def _index_signature(index: Mapping[str, Any]) -> IndexSignature:
+def _collection_group_from_resource_name(index: Mapping[str, Any]) -> str:
     collection_group = index.get('collectionGroup')
+    if isinstance(collection_group, str):
+        return collection_group
+    name = index.get('name')
+    marker = '/collectionGroups/'
+    if isinstance(name, str) and marker in name:
+        collection_group = name.split(marker, 1)[1].split('/', 1)[0]
+        if collection_group:
+            return collection_group
+    raise ValueError('Firestore index entry must contain collectionGroup or a collectionGroups resource name')
+
+
+def _index_signature(index: Mapping[str, Any]) -> IndexSignature:
+    collection_group = _collection_group_from_resource_name(index)
     query_scope = index.get('queryScope')
     fields = index.get('fields')
-    if not isinstance(collection_group, str) or not isinstance(query_scope, str) or not isinstance(fields, list):
+    if not isinstance(query_scope, str) or not isinstance(fields, list):
         raise ValueError('Firestore index entry must contain collectionGroup, queryScope, and fields')
     normalized_fields: list[tuple[str, str]] = []
     for field in fields:
@@ -116,6 +129,13 @@ def list_live_indexes(
             continue
         state = index.get('state')
         states[signature] = state if isinstance(state, str) else 'UNKNOWN'
+        if (
+            len(signature[2]) > 1
+            and signature[2][-1][0] == '__name__'
+            and signature[2][-1][1] == signature[2][-2][1]
+            and signature[2][-1][1] in {'ASCENDING', 'DESCENDING'}
+        ):
+            states[(signature[0], signature[1], signature[2][:-1])] = states[signature]
     return states
 
 

--- a/backend/tests/unit/test_reconcile_firestore_indexes.py
+++ b/backend/tests/unit/test_reconcile_firestore_indexes.py
@@ -43,6 +43,61 @@ def test_reconcile_deploys_generated_manifest_and_waits_for_every_index():
     assert sleeps == [1]
 
 
+def test_live_gcloud_indexes_derive_collection_group_and_alias_implicit_document_id():
+    live_index = {
+        'name': (
+            'projects/dev-project/databases/(default)/collectionGroups/' 'task_attention_overrides/indexes/index-id'
+        ),
+        'queryScope': 'COLLECTION',
+        'fields': [
+            {'fieldPath': 'account_generation', 'order': 'ASCENDING'},
+            {'fieldPath': 'expires_at', 'order': 'ASCENDING'},
+            {'fieldPath': '__name__', 'order': 'ASCENDING'},
+        ],
+        'state': 'READY',
+    }
+
+    def runner(_command, **_kwargs):
+        return SimpleNamespace(returncode=0, stdout=json.dumps([live_index]))
+
+    states = reconcile_firestore_indexes.list_live_indexes(project='dev-project', database='(default)', runner=runner)
+
+    assert (
+        states[
+            (
+                'task_attention_overrides',
+                'COLLECTION',
+                (('account_generation', 'ASCENDING'), ('expires_at', 'ASCENDING')),
+            )
+        ]
+        == 'READY'
+    )
+
+
+def test_live_gcloud_index_does_not_alias_explicitly_descending_document_id():
+    live_index = {
+        'name': 'projects/dev-project/databases/(default)/collectionGroups/task_attention_overrides/indexes/index-id',
+        'queryScope': 'COLLECTION',
+        'fields': [
+            {'fieldPath': 'account_generation', 'order': 'ASCENDING'},
+            {'fieldPath': 'expires_at', 'order': 'ASCENDING'},
+            {'fieldPath': '__name__', 'order': 'DESCENDING'},
+        ],
+        'state': 'READY',
+    }
+
+    def runner(_command, **_kwargs):
+        return SimpleNamespace(returncode=0, stdout=json.dumps([live_index]))
+
+    states = reconcile_firestore_indexes.list_live_indexes(project='dev-project', database='(default)', runner=runner)
+
+    assert (
+        'task_attention_overrides',
+        'COLLECTION',
+        (('account_generation', 'ASCENDING'), ('expires_at', 'ASCENDING')),
+    ) not in states
+
+
 def test_reconcile_fails_when_a_required_index_never_becomes_ready():
     def runner(command, **_kwargs):
         if command[:3] == ['npx', '--no-install', 'firebase']:


### PR DESCRIPTION
## Summary
- derive Firestore collection groups from real `gcloud firestore indexes composite list` resource names when the CLI omits `collectionGroup`
- treat Firestore's implicit trailing `__name__` field as equivalent to the generated query index signature
- add a regression test using the live CLI response shape that blocked the dev backend rollout

## Root cause and durable guard
The reconciler compared manifest-shaped records to `gcloud` records, but the live CLI response encodes the collection group in `name` and may append an implicit document-id field. It skipped every live record and reported all required indexes as missing even when they were READY. The new test exercises that actual response contract.

## Verification
- RED: `backend/.venv/bin/python -m pytest backend/tests/unit/test_reconcile_firestore_indexes.py::test_live_gcloud_indexes_derive_collection_group_and_alias_implicit_document_id -q` — failed with the expected `KeyError`
- `BACKEND_UNIT_TEST_FILE_LIST=/tmp/omi-index-reconciler-tests.txt bash backend/test.sh` — 5 passed
- `backend/.venv/bin/python -m pytest backend/tests/unit/test_reconcile_firestore_indexes.py backend/tests/unit/test_firestore_index_config.py -q` — 9 passed
- development live read-only reconciliation — 13/13 expected indexes READY
- `bash backend/scripts/typecheck.sh` — 0 errors (existing warnings only)
- `cd backend && bash test.sh` was attempted; it has unrelated pre-existing failures in 11 unit files, including a fast-unit duration guard failure. The focused index suite passes.

## Scope
No production configuration, Firestore mutation, or traffic change. This only corrects the read-only comparison of already-deployed Firestore index metadata.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9689?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

