### PR TITLE
fix(deploy): preflight pusher config references

### DIFF
--- a/.github/workflows/gcp_backend_pusher.yml
+++ b/.github/workflows/gcp_backend_pusher.yml
@@ -130,10 +130,12 @@ jobs:
           location: ${{ env.REGION }}
           project_id: ${{ vars.GCP_PROJECT_ID }}
 
-      - name: Require non-secret backend runtime config
+      - name: Preflight pusher ConfigMap and Secret references
         if: env.SERVICE == 'pusher'
         run: |
-          kubectl -n ${{ vars.ENV }}-omi-backend get configmap ${{ vars.ENV }}-omi-backend-config >/dev/null
+          python3 -m pip install -q pyyaml
+          python3 backend/scripts/verify_pusher_config_references.py \
+            --environment ${{ vars.ENV }} --namespace ${{ vars.ENV }}-omi-backend
 
       - name: Deploy Pusher to GKE cluster using Helm
         env:

--- a/.github/workflows/gcp_backend_pusher_auto_deploy.yml
+++ b/.github/workflows/gcp_backend_pusher_auto_deploy.yml
@@ -62,6 +62,12 @@ jobs:
           location: ${{ env.REGION }}
           project_id: ${{ vars.GCP_PROJECT_ID }}
 
+      - name: Preflight pusher ConfigMap and Secret references
+        run: |
+          python3 -m pip install -q pyyaml
+          python3 backend/scripts/verify_pusher_config_references.py \
+            --environment ${{ vars.ENV }} --namespace ${{ vars.ENV }}-omi-backend
+
       - name: Deploy Pusher to GKE cluster using Helm
         run: |
           helm -n ${{ vars.ENV }}-omi-backend upgrade --install ${{ vars.ENV }}-omi-pusher ./backend/charts/pusher -f ./backend/charts/pusher/${{ vars.ENV }}_omi_pusher_values.yaml --set-string "image.tag=${GITHUB_SHA::7}"

--- a/backend/scripts/verify_pusher_config_references.py
+++ b/backend/scripts/verify_pusher_config_references.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Fail a pusher deploy before rollout when rendered references are unavailable.
+
+This renders committed pusher chart inputs, extracts ConfigMap/Secret names only,
+and uses `kubectl get ... -o name`; it never reads Secret data or key values.
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[2]
+ENVIRONMENTS = {"dev", "prod"}
+
+
+def references(value: Any) -> set[tuple[str, str]]:
+    found: set[tuple[str, str]] = set()
+
+    def walk(item: Any) -> None:
+        if isinstance(item, dict):
+            for key, child in item.items():
+                if key in ("configMapRef", "configMapKeyRef") and isinstance(child, dict) and child.get("name"):
+                    found.add(("configmap", str(child["name"])))
+                elif key in ("secretRef", "secretKeyRef") and isinstance(child, dict) and child.get("name"):
+                    found.add(("secret", str(child["name"])))
+                else:
+                    walk(child)
+        elif isinstance(item, list):
+            for child in item:
+                walk(child)
+
+    walk(value)
+    return found
+
+
+def render(environment: str, image_tag: str = "contract-test") -> list[dict[str, Any]]:
+    chart = ROOT / "backend/charts/pusher"
+    values = chart / f"{environment}_omi_pusher_values.yaml"
+    result = subprocess.run(
+        [
+            "helm",
+            "template",
+            f"{environment}-omi-pusher",
+            str(chart),
+            "-f",
+            str(values),
+            "--set-string",
+            f"image.tag={image_tag}",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode:
+        raise RuntimeError(result.stderr.strip() or "helm template failed")
+    return [doc for doc in yaml.safe_load_all(result.stdout) if isinstance(doc, dict)]
+
+
+def pusher_references(environment: str) -> set[tuple[str, str]]:
+    expected_configmap = f"{environment}-omi-backend-config"
+    expected_secret = f"{environment}-omi-backend-secrets"
+    deployments = [doc for doc in render(environment) if doc.get("kind") == "Deployment"]
+    if len(deployments) != 1:
+        raise RuntimeError("pusher render did not contain exactly one Deployment")
+    refs = references(deployments[0].get("spec", {}).get("template", {}).get("spec", {}))
+    missing = {("configmap", expected_configmap), ("secret", expected_secret)} - refs
+    if missing:
+        names = ", ".join(f"{kind}/{name}" for kind, name in sorted(missing))
+        raise RuntimeError(f"rendered pusher is missing required references: {names}")
+    return refs
+
+
+def verify(namespace: str, refs: set[tuple[str, str]]) -> list[str]:
+    failures: list[str] = []
+    for kind, name in sorted(refs):
+        result = subprocess.run(
+            ["kubectl", "-n", namespace, "get", kind, name, "-o", "name"], check=False, capture_output=True, text=True
+        )
+        if result.returncode:
+            detail = (result.stderr or result.stdout).strip().splitlines()
+            failures.append(f"required {kind}/{name} unavailable: {detail[-1] if detail else 'kubectl failed'}")
+    return failures
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--environment", required=True, choices=sorted(ENVIRONMENTS))
+    parser.add_argument("--namespace", required=True)
+    parser.add_argument("--render-only", action="store_true")
+    args = parser.parse_args()
+    refs = pusher_references(args.environment)
+    failures = [] if args.render_only else verify(args.namespace, refs)
+    if failures:
+        for failure in failures:
+            print(f"FAIL: {failure}")
+        return 1
+    print(
+        "Pusher ConfigMap/Secret reference preflight passed: "
+        + ", ".join(f"{kind}/{name}" for kind, name in sorted(refs))
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/tests/unit/test_verify_pusher_config_references.py
+++ b/backend/tests/unit/test_verify_pusher_config_references.py
@@ -1,0 +1,52 @@
+"""Tests for metadata-only pusher ConfigMap/Secret deployment preflight."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import runpy
+from types import SimpleNamespace
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "verify_pusher_config_references.py"
+
+
+@pytest.fixture
+def preflight() -> SimpleNamespace:
+    return SimpleNamespace(**runpy.run_path(str(SCRIPT)))
+
+
+def deployment(refs: list[dict]) -> list[dict]:
+    return [{"kind": "Deployment", "spec": {"template": {"spec": {"containers": [{"envFrom": refs}]}}}}]
+
+
+def test_extracts_object_names_without_values(preflight: SimpleNamespace):
+    refs = preflight.references({"env": [{"valueFrom": {"secretKeyRef": {"name": "safe-name", "key": "KEY"}}}]})
+    assert refs == {("secret", "safe-name")}
+
+
+def test_rejects_missing_required_configmap_fixture(monkeypatch, preflight: SimpleNamespace):
+    monkeypatch.setitem(
+        preflight.pusher_references.__globals__,
+        "render",
+        lambda _env: deployment([{"secretRef": {"name": "dev-omi-backend-secrets"}}]),
+    )
+    with pytest.raises(RuntimeError, match="configmap/dev-omi-backend-config"):
+        preflight.pusher_references("dev")
+
+
+def test_accepts_expected_dev_reference_fixture(monkeypatch, preflight: SimpleNamespace):
+    monkeypatch.setitem(
+        preflight.pusher_references.__globals__,
+        "render",
+        lambda _env: deployment(
+            [
+                {"configMapRef": {"name": "dev-omi-backend-config"}},
+                {"secretRef": {"name": "dev-omi-backend-secrets"}},
+            ]
+        ),
+    )
+    assert preflight.pusher_references("dev") == {
+        ("configmap", "dev-omi-backend-config"),
+        ("secret", "dev-omi-backend-secrets"),
+    }


### PR DESCRIPTION
## Summary
- Render pusher dev/prod inputs before rollout and verify ConfigMap/Secret names with metadata-only kubectl reads.
- Enforce the guard in manual and automatic pusher deploys.
- Add valid and intentionally missing-reference fixture tests.

## Verification
- 11 targeted tests passed.
- Render-only preflight passed for dev and prod.
- `make preflight` passed (15 checks).
- Independent Codex review found no actionable regressions.

No Secret data or values are read or emitted.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9690?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

