### PR TITLE
fix(deploy): guard dev pusher config rollout

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -27,4 +27,5 @@ These rules apply to GitHub Actions workflows and custom actions under `.github/
 - Keep rollout checks close to the deploy step they verify, especially for `backend-listen`, `pusher`, `agent-proxy`, `llm-gateway`, `parakeet`, `diarizer`, and `vad`.
 - Use `backend/scripts/deploy_status_report.py` as a strict gate on success paths; use it with `|| true` only after a primary rollout/traffic command already failed.
 - Before restarting GKE workloads that depend on `backend-secrets`, wait for ExternalSecret Ready and run `backend/scripts/verify_k8s_secret_keys.py`; never print secret values.
+- Before any pusher Helm mutation, verify `${ENV}-omi-backend-config` exists so a missing shared runtime ConfigMap cannot replace the healthy replica.
 - When editing workflows, keep `actionlint` coverage in CI so YAML and GitHub expression mistakes fail before merge.

--- a/.github/scripts/check-deployment-concurrency.py
+++ b/.github/scripts/check-deployment-concurrency.py
@@ -114,6 +114,12 @@ WRITER_MARKERS = (
     "gcloud run jobs update ",
 )
 
+PUSHER_CHART_MARKER = "backend/charts/pusher"
+PUSHER_CONFIGMAP_PREFLIGHT = (
+    "kubectl -n ${{ vars.ENV }}-omi-backend get configmap "
+    "${{ vars.ENV }}-omi-backend-config >/dev/null"
+)
+
 
 class PolicyError(ValueError):
     pass
@@ -206,6 +212,56 @@ def validate_auto_deploy_acceptance(text: str) -> list[str]:
             "gcp_backend_auto_dev.yml: integrated verify must inherit the workflow mutation lock"
         )
     return errors
+
+
+def validate_pusher_config_preflight(name: str, text: str) -> list[str]:
+    """Require an active ConfigMap check in the pusher deploy job before Helm."""
+
+    if PUSHER_CHART_MARKER not in text:
+        return []
+    block = job_block(text, "deploy")
+    if block is None:
+        return [f"{name}: pusher deploy must verify the backend runtime ConfigMap before Helm"]
+
+    chart_indexes = [
+        index
+        for index, line in enumerate(block)
+        if PUSHER_CHART_MARKER in line and not line.lstrip().startswith("#")
+    ]
+    if not chart_indexes:
+        return []
+    chart_index = min(chart_indexes)
+
+    for preflight_index, line in enumerate(block[:chart_index]):
+        stripped = line.strip()
+        command = stripped.removeprefix("- run: ").removeprefix("run: ")
+        if command != PUSHER_CONFIGMAP_PREFLIGHT or line.lstrip().startswith("#"):
+            continue
+        step_start = preflight_index
+        while step_start > 0 and not block[step_start].startswith("      - "):
+            step_start -= 1
+        step_end = preflight_index + 1
+        while step_end < len(block) and not block[step_end].startswith("      - "):
+            step_end += 1
+        conditions = [
+            candidate.strip()
+            for candidate in block[step_start:step_end]
+            if candidate.strip().startswith("if:")
+        ]
+        nonfatal = any(
+            candidate.strip().startswith("continue-on-error:")
+            or candidate.strip() == "set +e"
+            for candidate in block[step_start:step_end]
+        )
+        allowed_conditions = (
+            ["if: env.SERVICE == 'pusher'"]
+            if name == "gcp_backend_pusher.yml"
+            else []
+        )
+        if not nonfatal and conditions == allowed_conditions:
+            return []
+
+    return [f"{name}: pusher deploy must verify the backend runtime ConfigMap before Helm"]
 
 
 def is_persistent_writer(text: str) -> bool:
@@ -323,6 +379,8 @@ def check_repository() -> list[str]:
 
     auto_deploy = workflow_text.get("gcp_backend_auto_dev.yml", "")
     errors.extend(validate_auto_deploy_acceptance(auto_deploy))
+    for name, text in workflow_text.items():
+        errors.extend(validate_pusher_config_preflight(name, text))
     separate_acceptance_workflows = sorted(
         name
         for name, text in workflow_text.items()
@@ -398,6 +456,93 @@ jobs:
         raise PolicyError(
             "successful deployment did not make integrated acceptance eligible"
         )
+
+    pusher_deploy = """name: fixture
+jobs:
+  deploy:
+    steps:
+      - run: kubectl -n ${{ vars.ENV }}-omi-backend get configmap ${{ vars.ENV }}-omi-backend-config >/dev/null
+      - run: helm upgrade ./backend/charts/pusher
+"""
+    if validate_pusher_config_preflight("fixture.yml", pusher_deploy):
+        raise PolicyError("valid pusher ConfigMap preflight was rejected")
+    missing_preflight = pusher_deploy.replace(
+        "kubectl -n ${{ vars.ENV }}-omi-backend get configmap ${{ vars.ENV }}-omi-backend-config >/dev/null\n",
+        "",
+    )
+    if not any(
+        "before Helm" in error
+        for error in validate_pusher_config_preflight("fixture.yml", missing_preflight)
+    ):
+        raise PolicyError("missing pusher ConfigMap preflight satisfied the deploy contract")
+
+    equivalent_chart_path = """name: fixture
+jobs:
+  deploy:
+    steps:
+      - run: helm upgrade backend/charts/pusher
+"""
+    if not validate_pusher_config_preflight("fixture.yml", equivalent_chart_path):
+        raise PolicyError("equivalent pusher chart path bypassed the deploy contract")
+
+    late_preflight = """name: fixture
+jobs:
+  deploy:
+    steps:
+      - run: helm upgrade ./backend/charts/pusher
+      - run: kubectl -n ${{ vars.ENV }}-omi-backend get configmap ${{ vars.ENV }}-omi-backend-config >/dev/null
+"""
+    if not any(
+        "before Helm" in error
+        for error in validate_pusher_config_preflight("fixture.yml", late_preflight)
+    ):
+        raise PolicyError("late pusher ConfigMap preflight satisfied the deploy contract")
+
+    cross_job_preflight = """name: fixture
+jobs:
+  prepare:
+    steps:
+      - run: kubectl -n ${{ vars.ENV }}-omi-backend get configmap ${{ vars.ENV }}-omi-backend-config >/dev/null
+  deploy:
+    steps:
+      - run: helm upgrade ./backend/charts/pusher
+"""
+    if not validate_pusher_config_preflight("fixture.yml", cross_job_preflight):
+        raise PolicyError("cross-job pusher ConfigMap preflight satisfied the deploy contract")
+
+    disabled_preflight = """name: fixture
+jobs:
+  deploy:
+    steps:
+      - name: Disabled preflight
+        if: false
+        run: kubectl -n ${{ vars.ENV }}-omi-backend get configmap ${{ vars.ENV }}-omi-backend-config >/dev/null
+      - run: helm upgrade ./backend/charts/pusher
+"""
+    if not validate_pusher_config_preflight("fixture.yml", disabled_preflight):
+        raise PolicyError("disabled pusher ConfigMap preflight satisfied the deploy contract")
+
+    nonfatal_preflight = """name: fixture
+jobs:
+  deploy:
+    steps:
+      - name: Nonfatal preflight
+        continue-on-error: true
+        run: kubectl -n ${{ vars.ENV }}-omi-backend get configmap ${{ vars.ENV }}-omi-backend-config >/dev/null
+      - run: helm upgrade ./backend/charts/pusher
+"""
+    if not validate_pusher_config_preflight("fixture.yml", nonfatal_preflight):
+        raise PolicyError("nonfatal pusher ConfigMap preflight satisfied the deploy contract")
+
+    masked_preflight = """name: fixture
+jobs:
+  deploy:
+    steps:
+      - run: kubectl -n ${{ vars.ENV }}-omi-backend get configmap ${{ vars.ENV }}-omi-backend-config >/dev/null || true
+      - run: helm upgrade ./backend/charts/pusher
+"""
+    if not validate_pusher_config_preflight("fixture.yml", masked_preflight):
+        raise PolicyError("masked pusher ConfigMap preflight satisfied the deploy contract")
 
 
 def main() -> int:

--- a/.github/workflows/gcp_backend_pusher_auto_deploy.yml
+++ b/.github/workflows/gcp_backend_pusher_auto_deploy.yml
@@ -62,6 +62,10 @@ jobs:
           location: ${{ env.REGION }}
           project_id: ${{ vars.GCP_PROJECT_ID }}
 
+      - name: Require non-secret backend runtime config
+        run: |
+          kubectl -n ${{ vars.ENV }}-omi-backend get configmap ${{ vars.ENV }}-omi-backend-config >/dev/null
+
       - name: Deploy Pusher to GKE cluster using Helm
         run: |
           helm -n ${{ vars.ENV }}-omi-backend upgrade --install ${{ vars.ENV }}-omi-pusher ./backend/charts/pusher -f ./backend/charts/pusher/${{ vars.ENV }}_omi_pusher_values.yaml --set-string "image.tag=${GITHUB_SHA::7}"

--- a/backend/charts/pusher/dev_omi_pusher_values.yaml
+++ b/backend/charts/pusher/dev_omi_pusher_values.yaml
@@ -324,8 +324,8 @@ podDisruptionBudget:
 strategy:
   type: RollingUpdate
   rollingUpdate:
-    maxUnavailable: 1
-    maxSurge: 2
+    maxUnavailable: 0
+    maxSurge: 1
 
 terminationGracePeriodSeconds: 120
 lifecycle:

--- a/backend/tests/unit/test_rendered_deployment_contract.py
+++ b/backend/tests/unit/test_rendered_deployment_contract.py
@@ -129,6 +129,19 @@ def test_repository_charts_render_the_full_contract_when_helm_is_available(contr
     assert contracts.validate_all_contracts(contracts.render_chart, helm) == []
 
 
+def test_dev_pusher_rollout_preserves_the_existing_replica(contracts: SimpleNamespace):
+    helm = shutil.which("helm")
+    assert helm is not None, "helm must be installed for the rendered deployment contract"
+    contract = next(contract for contract in contracts.CONTRACTS if contract.service == "pusher")
+    documents = contracts.render_chart(contract, "dev", helm)
+    deployment = contracts.deployment_for(documents, contracts.release_name(contract, "dev"))
+
+    assert deployment is not None
+    rolling_update = deployment["spec"]["strategy"]["rollingUpdate"]
+    assert rolling_update["maxUnavailable"] == 0
+    assert rolling_update["maxSurge"] == 1
+
+
 def test_first_party_charts_reject_missing_image_tag_when_helm_is_available(contracts: SimpleNamespace):
     helm = shutil.which("helm")
     assert helm is not None, "helm must be installed for the rendered deployment contract"


### PR DESCRIPTION
## Summary
- fail pusher auto-deploys before Helm when the shared backend runtime ConfigMap is missing
- enforce the ConfigMap preflight across every pusher Helm workflow
- preserve the existing dev pusher replica during failed rollouts

## Root cause
PR #9670 made pusher depend on `dev-omi-backend-config`, but the push-triggered pusher workflow omitted the preflight added to the manual workflow. A concurrent backend deploy failed before creating the ConfigMap, while pusher Helm replaced the only healthy replica.

## Durable guard
- repository deployment policy rejects any pusher Helm workflow lacking a pre-Helm ConfigMap check
- self-test covers valid, missing, and incorrectly ordered preflights
- rendered Helm test requires dev pusher `maxUnavailable: 0` and `maxSurge: 1`

## Validation
- `python3 .github/scripts/check-deployment-concurrency.py --self-test`
- `python3 .github/scripts/check-deployment-concurrency.py`
- `python3 .github/scripts/check_deployment_secret_boundary.py --base origin/main`
- `/Users/dazheng/workspace/omi/backend/.venv/bin/python -m pytest backend/tests/unit/test_rendered_deployment_contract.py -q` (`9 passed`)
- `OMI_PR_BODY_FILE=/tmp/omi-dev-pusher-config-pr.md scripts/pre-push` (`Fast pre-push checks passed`)

## Operational verification
- context-pinned rollback restored dev pusher revision 110's template as deployment revision 112
- deployment is `1/1` ready and available with one ready EndpointSlice endpoint
- in-cluster `/health` via port-forward returned `200 {"status":"healthy"}`
- migrated all 18 required non-secret values from the existing dev Kubernetes Secret to GitHub development environment variables and `dev-omi-backend-config`; values were never printed
- retained the old secret keys until the ConfigMap-backed current pusher revision is deployed and verified

## Deployment note
Landing this PR changes the dev pusher chart and triggers its auto-deploy. The new workflow preflights the now-provisioned ConfigMap before Helm, and the rollout preserves the healthy replica if the candidate cannot start.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9691?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

