### PR TITLE
fix(desktop-backend): don't fail a chat turn on a guessed web-search requirement

### DIFF
--- a/desktop/macos/Backend-Rust/src/fallback.rs
+++ b/desktop/macos/Backend-Rust/src/fallback.rs
@@ -34,6 +34,7 @@ const ALLOWED_COMPONENTS: &[&str] = &[
     "webhook",
     "realtime_hub",
     "ptt_cascade",
+    "chat_retrieval",
     "gemini_model",
     "gemini_proxy",
     "gemini_stream_proxy",

--- a/desktop/macos/Backend-Rust/src/routes/chat_completions.rs
+++ b/desktop/macos/Backend-Rust/src/routes/chat_completions.rs
@@ -19,6 +19,7 @@ use std::time::Duration;
 
 use crate::auth::{AuthUser, PaywalledAuthUser};
 use crate::byok;
+use crate::fallback::{record_fallback, FallbackOutcome};
 use crate::models::chat_completions::*;
 use crate::AppState;
 
@@ -265,11 +266,25 @@ fn translate_request_inner(
     // Haiku is excluded: web_search_20260209 is not supported there, and a
     // tools-bearing haiku request would 400 with it attached.
     let web_search_supported = enable_web_search && !upstream_model.starts_with("claude-haiku");
-    let force_web_search =
+    let wants_web_search =
         policy.requires(RetrievalSource::PublicWeb) && !caller_disabled_tools(req);
-    if force_web_search && !web_search_supported {
+    if wants_web_search && !web_search_supported && policy.web_requirement_is_explicit() {
         return Err(
             "required public web search is unavailable for this model or deployment".to_string(),
+        );
+    }
+    // A heuristic freshness/anaphoric guess is not a user demand. On a route
+    // without web search (haiku, or the kill switch) answer the turn from model
+    // knowledge instead of failing it — the forced-search instruction below also
+    // bans private context, which would be wrong for a turn we merely guessed at.
+    let force_web_search = wants_web_search && web_search_supported;
+    if wants_web_search && !web_search_supported {
+        record_fallback(
+            "chat_retrieval",
+            "forced_web_search",
+            "model_knowledge",
+            "capability_mismatch",
+            FallbackOutcome::Degraded,
         );
     }
     let client_tools = req.tools.as_deref().unwrap_or(&[]);
@@ -715,7 +730,10 @@ async fn chat_completions(
 
     let web_search_enabled = web_search_enabled();
     let policy = retrieval_policy(&req.messages);
+    // Only an explicit "search the web" is worth failing the turn over. A
+    // heuristic guess degrades to a normal answer in `translate_request_inner`.
     if policy.requires(RetrievalSource::PublicWeb)
+        && policy.web_requirement_is_explicit()
         && !caller_disabled_tools(&req)
         && (!web_search_enabled || route.upstream_model.starts_with("claude-haiku"))
     {
@@ -2484,6 +2502,30 @@ mod tests {
         let req = test_request(vec![user_message("Search the web for HumanPost")]);
         let error = translate_request_inner(&req, "claude-sonnet-4-6", false).unwrap_err();
         assert!(error.contains("required public web search is unavailable"));
+    }
+
+    #[test]
+    fn test_translate_request_guessed_freshness_answers_without_web_search() {
+        // A guessed public-web turn on a route that cannot search (haiku, or the
+        // kill switch) must still be answered: no error, no web_search tool, and
+        // no forced-search instruction — that instruction bans private context.
+        let req = test_request(vec![user_message("Who's playing in the World Cup today?")]);
+
+        for (model, enable_web_search) in [
+            ("claude-haiku-4-5-20251001", true),
+            ("claude-sonnet-4-6", false),
+        ] {
+            let result = translate_request_inner(&req, model, enable_web_search).unwrap();
+            assert!(result.tools.is_none());
+            assert!(result.tool_choice.is_none());
+            let prompt = serde_json::to_value(&result.messages[0])
+                .unwrap()
+                .to_string();
+            assert!(
+                !prompt.contains("omi_retrieval_policy"),
+                "{model}: {prompt}"
+            );
+        }
     }
 
     #[test]

--- a/desktop/macos/Backend-Rust/src/routes/retrieval_policy.rs
+++ b/desktop/macos/Backend-Rust/src/routes/retrieval_policy.rs
@@ -59,6 +59,18 @@ impl RetrievalPolicy {
         self.prohibited_sources.contains(&source)
     }
 
+    /// True only when the user asked for the public web in so many words.
+    ///
+    /// Everything else (`Freshness`, `AnaphoricLookup`) is a heuristic guess, so
+    /// it may steer a turn but must never fail one: a route that cannot search
+    /// the web still owes the user an answer.
+    pub(crate) fn web_requirement_is_explicit(&self) -> bool {
+        matches!(
+            self.reason,
+            RetrievalReason::ExplicitWeb | RetrievalReason::Mixed
+        )
+    }
+
     pub(crate) fn reason(&self) -> &'static str {
         self.reason.as_str()
     }
@@ -178,8 +190,33 @@ const ANAPHORIC_LOOKUP_PHRASES: &[&str] = &[
     "find out",
 ];
 
+/// The generic qualifier+subject pairing describes a short conversational ask
+/// ("who is playing today?"). Service synthesis prompts, pasted documents and
+/// agent instructions are long and hit these common words by accident, so they
+/// stay out of the broad heuristic. The fixed phrases above still apply at any
+/// length.
+const MAX_GENERIC_LOOKUP_CHARS: usize = 240;
+
 fn contains_any(text: &str, phrases: &[&str]) -> bool {
     phrases.iter().any(|phrase| text.contains(phrase))
+}
+
+/// Substring matching on single words reads "market" out of "marketing" and
+/// "game" out of "gameplan", so the generic terms match on word boundaries.
+fn contains_any_word(text: &str, words: &[&str]) -> bool {
+    words.iter().any(|word| {
+        text.match_indices(word).any(|(start, _)| {
+            let before_is_word = text[..start]
+                .chars()
+                .next_back()
+                .is_some_and(|ch| ch.is_alphanumeric());
+            let after_is_word = text[start + word.len()..]
+                .chars()
+                .next()
+                .is_some_and(|ch| ch.is_alphanumeric());
+            !before_is_word && !after_is_word
+        })
+    })
 }
 
 fn is_current_weather_lookup(text: &str) -> bool {
@@ -189,8 +226,9 @@ fn is_current_weather_lookup(text: &str) -> bool {
 fn is_fresh_public_lookup(text: &str) -> bool {
     contains_any(text, FRESH_PUBLIC_PHRASES)
         || is_current_weather_lookup(text)
-        || (contains_any(text, FRESH_PUBLIC_TEMPORAL_QUALIFIERS)
-            && contains_any(text, FRESH_PUBLIC_LOOKUP_TERMS))
+        || (text.len() <= MAX_GENERIC_LOOKUP_CHARS
+            && contains_any_word(text, FRESH_PUBLIC_TEMPORAL_QUALIFIERS)
+            && contains_any_word(text, FRESH_PUBLIC_LOOKUP_TERMS))
 }
 
 pub(crate) fn caller_disabled_tools(req: &ChatCompletionRequest) -> bool {
@@ -406,6 +444,41 @@ mod tests {
         assert!(policy.requires(RetrievalSource::PublicWeb));
         assert!(policy.requires(RetrievalSource::OmiPrivate));
         assert_eq!(policy.reason, RetrievalReason::Mixed);
+    }
+
+    #[test]
+    fn leaves_a_service_synthesis_prompt_on_auto() {
+        // The calendar/gmail/notes readers synthesize with a long machine-written
+        // prompt that happens to contain "today" and "schedule". Classifying it as
+        // a public-web lookup routed the import into the web-search-unavailable
+        // failure and dropped every extracted memory.
+        let policy = retrieval_policy(&[message(
+            "user",
+            "Analyze these calendar events and extract a profile.\n\
+             Today's date: 2026-07-14\n\
+             - Extract 10-15 memories (facts about their role, recurring meetings, \
+             relationships, routines, interests, work schedule, hobbies, social life)\n\
+             - Profile should summarize professional identity and schedule patterns",
+        )]);
+        assert_eq!(policy, RetrievalPolicy::auto());
+    }
+
+    #[test]
+    fn does_not_match_generic_lookup_terms_inside_longer_words() {
+        let policy =
+            retrieval_policy(&[message("user", "Review the marketing copy I wrote today")]);
+        assert_eq!(policy, RetrievalPolicy::auto());
+    }
+
+    #[test]
+    fn only_an_explicit_request_is_a_strict_web_requirement() {
+        let guessed = retrieval_policy(&[message("user", "Who's playing in the World Cup today?")]);
+        assert!(guessed.requires(RetrievalSource::PublicWeb));
+        assert!(!guessed.web_requirement_is_explicit());
+
+        let asked = retrieval_policy(&[message("user", "Search the web for the World Cup final")]);
+        assert!(asked.requires(RetrievalSource::PublicWeb));
+        assert!(asked.web_requirement_is_explicit());
     }
 
     #[test]

--- a/desktop/macos/changelog/unreleased/20260714-retrieval-policy-false-web-search.json
+++ b/desktop/macos/changelog/unreleased/20260714-retrieval-policy-false-web-search.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed Calendar, Gmail and Apple Notes imports failing to extract anything, and chat turns erroring out, when a message merely mentioned something like \"today\" plus \"schedule\""
+}


### PR DESCRIPTION
## The bug

`is_fresh_public_lookup()` (`retrieval_policy.rs`) marks a turn as **requires public web** whenever the last user message contains any of `"right now" / "currently" / "today" / "this week"` **and** any of a generic subject list (`"schedule"`, `"match"`, `"game"`, `"news"`, `"release"`, `"market"`, …) — raw `str::contains` substring matching over the entire message, at any length.

That *guess* is then treated as a hard requirement: in `chat_completions.rs`, a route that cannot run Anthropic's server-side `web_search` (every `claude-haiku` route, or any route when the `OMI_DESKTOP_WEB_SEARCH_DISABLED` kill switch is set) returns **503 `web_search_unavailable`** instead of answering, and `translate_request_inner` hard-errors on the same condition.

The two combine into a deterministic break:

- **Calendar import extracts nothing.** `CalendarReaderService`'s synthesis prompt is machine-written, runs on the haiku synthesis model (`ModelQoS.Claude.synthesis`), and contains both `Today's date: <iso>` and `work schedule`. Every import 503s on both attempts and silently drops all memories/tasks/profile. `GmailReaderService`, `AppleNotesReaderService` and the haiku agent-pill calls have the same shape.
- **Ordinary sonnet chat turns get hijacked.** "review the marketing copy I wrote today" matches (`market` inside `market`ing) → the forced-search instruction is prepended, and that instruction explicitly tells the model **not** to use the user's private context.

Introduced by ef8104a54e (07-13), which added the generic qualifier+subject heuristic on top of the pre-existing haiku 503 guard.

**Root cause:** a heuristic was given the authority of an explicit user instruction.

## The fix

- **A guessed requirement never fails a turn.** `Freshness` / `AnaphoricLookup` on a route without web search now degrades: answer from model knowledge, no injected tool, no forced-search instruction, and record a `chat_retrieval` / `capability_mismatch` / `degraded` fallback (per the AGENTS.md fallback contract). Only an explicit "search the web" (`ExplicitWeb` / `Mixed`) still fails closed — `RetrievalPolicy::web_requirement_is_explicit()`.
- **The generic heuristic stops matching by accident.** Word-boundary matching (so `market` no longer fires inside `marketing`) and a 240-char cap, so machine-generated service prompts stay out of it. The fixed phrases (`"latest news"`, `"current weather"`, …) still apply at any length.

## Verification

- `cargo test` — **360 passed**, including 4 new regression tests: the real calendar synthesis prompt and "review the marketing copy I wrote today" stay on `auto`; a guessed-freshness turn on haiku *and* with web search disabled translates with no tools and no policy instruction instead of erroring; explicit vs guessed web requirement.
- **The tests catch the bug:** reverting only the source fix (keeping the tests) fails 3 of them — `leaves_a_service_synthesis_prompt_on_auto`, `does_not_match_generic_lookup_terms_inside_longer_words`, `test_translate_request_guessed_freshness_answers_without_web_search`. (The 4th covers the new accessor, which doesn't exist pre-fix.)
- `cargo clippy -- -D warnings` (the exact CI command) clean; `rustfmt` applied.
- **Not exercised against a live backend.** Coverage is at the Rust behavior level — the tests call the production `retrieval_policy()` / `translate_request_inner()` with the literal prompt text from `CalendarReaderService.swift`, but I did not run a real Calendar import through a deployed desktop-backend. **UNVERIFIED at that layer.**

## Not merged

Prod desktop-backend was last promoted **2026-07-12 01:16**; the offending commit landed **07-13 16:54**, so this is live on `main`/dev (and the beta lane), **not on prod** — the watchdog's auto-merge gate requires live prod impact. Landing this before the next `desktop_promote_prod` run keeps it from ever reaching prod users.

🤖 automated by hourly watchdog; opened for review, not merged.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9692?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

