### PR TITLE
fix(deploy): migrate dev public config bindings

### DIFF
--- a/.github/workflows/gcp_backend_auto_dev.yml
+++ b/.github/workflows/gcp_backend_auto_dev.yml
@@ -119,6 +119,14 @@ jobs:
           cache-from: type=registry,ref=gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}:buildcache
           cache-to: type=registry,ref=gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}:buildcache,mode=max
 
+      - name: Migrate legacy public Cloud Run bindings
+        run: >-
+          python3 backend/scripts/preflight-cloud-run-deploy.py
+          --env dev
+          --project="${{ vars.GCP_PROJECT_ID }}"
+          --region="${{ env.REGION }}"
+          --migrate-legacy-public-binding backend --migrate-legacy-public-binding backend-sync
+
       - name: Deploy ${{ env.SERVICE }} to Cloud Run
         id: deploy-backend
         uses: google-github-actions/deploy-cloudrun@v2

--- a/backend/scripts/preflight-cloud-run-deploy.py
+++ b/backend/scripts/preflight-cloud-run-deploy.py
@@ -35,6 +35,7 @@ def main() -> int:
     parser.add_argument('--region', default=DEFAULT_REGION)
     parser.add_argument('--manifest', type=Path, default=DEFAULT_MANIFEST)
     parser.add_argument('--service', action='append', dest='services')
+    parser.add_argument('--migrate-legacy-public-binding', action='append', dest='legacy_public_binding_services')
     parser.add_argument('--check-secrets', action='store_true')
     parser.add_argument('--check-traffic', action='store_true')
     parser.add_argument('--repair-traffic', action='store_true')
@@ -45,6 +46,19 @@ def main() -> int:
 
     services = tuple(args.services or DEFAULT_SERVICES)
     exit_code = 0
+
+    if args.legacy_public_binding_services:
+        try:
+            migrated = migrate_legacy_public_bindings(
+                services=args.legacy_public_binding_services,
+                env=args.env,
+                project=args.project,
+                region=args.region,
+            )
+        except ValueError as exc:
+            parser.error(str(exc))
+        for service in migrated:
+            print(f'migrated legacy GOOGLE_CLIENT_ID binding for {service}')
 
     if args.check_secrets:
         missing = check_rendered_secrets(
@@ -92,6 +106,65 @@ def main() -> int:
                 exit_code = 1
 
     return exit_code
+
+
+PUBLIC_BINDING = 'GOOGLE_CLIENT_ID'
+DEVELOPMENT_PROJECT = 'based-hardware-dev'
+
+
+def migrate_legacy_public_bindings(
+    *, services: tuple[str, ...] | list[str], env: str, project: str, region: str, runner: Any = subprocess.run
+) -> list[str]:
+    if env != 'dev' or project != DEVELOPMENT_PROJECT:
+        raise ValueError('Legacy public-binding migration is development-only')
+
+    migrated: list[str] = []
+    for service in services:
+        document = json.loads(
+            runner(
+                [
+                    'gcloud',
+                    'run',
+                    'services',
+                    'describe',
+                    service,
+                    f'--project={project}',
+                    f'--region={region}',
+                    '--format=json',
+                ],
+                check=True,
+                text=True,
+                capture_output=True,
+            ).stdout
+        )
+        containers = document['spec']['template']['spec'].get('containers')
+        if not isinstance(containers, list) or len(containers) != 1 or not isinstance(containers[0], dict):
+            raise ValueError('Legacy public-binding migration requires exactly one container per Cloud Run service')
+        environments = containers[0].get('env', [])
+        has_legacy_secret = any(
+            entry.get('name') == PUBLIC_BINDING
+            and entry.get('valueFrom', {}).get('secretKeyRef', {}).get('name') == PUBLIC_BINDING
+            for entry in environments
+        )
+        if not has_legacy_secret:
+            continue
+        runner(
+            [
+                'gcloud',
+                'run',
+                'services',
+                'update',
+                service,
+                f'--project={project}',
+                f'--region={region}',
+                f'--remove-secrets={PUBLIC_BINDING}',
+                '--no-traffic',
+                '--quiet',
+            ],
+            check=True,
+        )
+        migrated.append(service)
+    return migrated
 
 
 def check_rendered_secrets(*, env: str, manifest_path: Path, project: str) -> list[SecretBinding]:

--- a/backend/tests/unit/test_verify_dev_backend_deployment.py
+++ b/backend/tests/unit/test_verify_dev_backend_deployment.py
@@ -1,6 +1,27 @@
 from __future__ import annotations
 
+import importlib.util
+import json
+from pathlib import Path
+import sys
+from types import SimpleNamespace
+
+import pytest
+
 from scripts import verify_dev_backend_deployment as verifier
+
+BACKEND_DIR = Path(__file__).resolve().parents[2]
+PREFLIGHT_SCRIPT = BACKEND_DIR / 'scripts' / 'preflight-cloud-run-deploy.py'
+
+
+def _load_preflight():
+    spec = importlib.util.spec_from_file_location('preflight_cloud_run_deploy', PREFLIGHT_SCRIPT)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
 
 
 def _expectation() -> verifier.DeploymentExpectation:
@@ -68,6 +89,209 @@ def _documents(expectation: verifier.DeploymentExpectation) -> dict:
         }
     )
     return documents
+
+
+def test_dev_deploy_migrates_only_exact_legacy_google_client_id_secrets_without_traffic() -> None:
+    preflight = _load_preflight()
+    legacy_service = {
+        'spec': {
+            'template': {
+                'spec': {
+                    'containers': [
+                        {
+                            'env': [
+                                {
+                                    'name': 'GOOGLE_CLIENT_ID',
+                                    'valueFrom': {'secretKeyRef': {'name': 'GOOGLE_CLIENT_ID', 'key': 'latest'}},
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        }
+    }
+    literal_service = {
+        'spec': {'template': {'spec': {'containers': [{'env': [{'name': 'GOOGLE_CLIENT_ID', 'value': 'public'}]}]}}}
+    }
+    commands: list[list[str]] = []
+
+    def runner(command: list[str], **_kwargs):
+        commands.append(command)
+        if command[:4] == ['gcloud', 'run', 'services', 'describe']:
+            service = command[4]
+            document = legacy_service if service == 'backend' else literal_service
+            return SimpleNamespace(stdout=json.dumps(document))
+        return SimpleNamespace(stdout='')
+
+    migrated = preflight.migrate_legacy_public_bindings(
+        services=('backend', 'backend-sync'),
+        env='dev',
+        project='based-hardware-dev',
+        region='us-central1',
+        runner=runner,
+    )
+
+    assert migrated == ['backend']
+    assert commands == [
+        [
+            'gcloud',
+            'run',
+            'services',
+            'describe',
+            'backend',
+            '--project=based-hardware-dev',
+            '--region=us-central1',
+            '--format=json',
+        ],
+        [
+            'gcloud',
+            'run',
+            'services',
+            'update',
+            'backend',
+            '--project=based-hardware-dev',
+            '--region=us-central1',
+            '--remove-secrets=GOOGLE_CLIENT_ID',
+            '--no-traffic',
+            '--quiet',
+        ],
+        [
+            'gcloud',
+            'run',
+            'services',
+            'describe',
+            'backend-sync',
+            '--project=based-hardware-dev',
+            '--region=us-central1',
+            '--format=json',
+        ],
+    ]
+
+
+def test_legacy_binding_migration_is_idempotent_after_removal() -> None:
+    preflight = _load_preflight()
+    state = {'legacy': True}
+    updates: list[list[str]] = []
+
+    def runner(command: list[str], **_kwargs):
+        if command[:4] == ['gcloud', 'run', 'services', 'describe']:
+            entry = (
+                {'name': 'GOOGLE_CLIENT_ID', 'valueFrom': {'secretKeyRef': {'name': 'GOOGLE_CLIENT_ID'}}}
+                if state['legacy']
+                else {'name': 'GOOGLE_CLIENT_ID', 'value': 'public'}
+            )
+            document = {
+                'spec': {
+                    'template': {
+                        'spec': {
+                            'containers': [
+                                {'env': [entry]},
+                            ]
+                        }
+                    }
+                }
+            }
+            return SimpleNamespace(stdout=json.dumps(document))
+        updates.append(command)
+        state['legacy'] = False
+        return SimpleNamespace(stdout='')
+
+    first = preflight.migrate_legacy_public_bindings(
+        services=('backend',), env='dev', project='based-hardware-dev', region='us-central1', runner=runner
+    )
+    second = preflight.migrate_legacy_public_bindings(
+        services=('backend',), env='dev', project='based-hardware-dev', region='us-central1', runner=runner
+    )
+
+    assert first == ['backend']
+    assert second == []
+    assert updates == [
+        [
+            'gcloud',
+            'run',
+            'services',
+            'update',
+            'backend',
+            '--project=based-hardware-dev',
+            '--region=us-central1',
+            '--remove-secrets=GOOGLE_CLIENT_ID',
+            '--no-traffic',
+            '--quiet',
+        ]
+    ]
+
+
+def test_legacy_binding_migration_rejects_multi_container_services_without_mutation() -> None:
+    preflight = _load_preflight()
+    commands: list[list[str]] = []
+    multi_container_service = {
+        'spec': {
+            'template': {
+                'spec': {
+                    'containers': [
+                        {'env': []},
+                        {
+                            'env': [
+                                {
+                                    'name': 'GOOGLE_CLIENT_ID',
+                                    'valueFrom': {'secretKeyRef': {'name': 'GOOGLE_CLIENT_ID'}},
+                                }
+                            ]
+                        },
+                    ]
+                }
+            }
+        }
+    }
+
+    def runner(command: list[str], **_kwargs):
+        commands.append(command)
+        return SimpleNamespace(stdout=json.dumps(multi_container_service))
+
+    with pytest.raises(ValueError, match='exactly one container'):
+        preflight.migrate_legacy_public_bindings(
+            services=('backend',), env='dev', project='based-hardware-dev', region='us-central1', runner=runner
+        )
+
+    assert commands == [
+        [
+            'gcloud',
+            'run',
+            'services',
+            'describe',
+            'backend',
+            '--project=based-hardware-dev',
+            '--region=us-central1',
+            '--format=json',
+        ]
+    ]
+
+
+def test_legacy_binding_migration_rejects_non_dev_projects_without_gcloud_calls() -> None:
+    preflight = _load_preflight()
+    calls: list[list[str]] = []
+
+    with pytest.raises(ValueError, match='development-only'):
+        preflight.migrate_legacy_public_bindings(
+            services=('backend',),
+            env='prod',
+            project='based-hardware',
+            region='us-central1',
+            runner=lambda command, **_kwargs: calls.append(command),
+        )
+
+    assert calls == []
+
+
+def test_dev_deploy_invokes_legacy_binding_migration_only_for_dev_services() -> None:
+    workflow = BACKEND_DIR.parent / '.github/workflows/gcp_backend_auto_dev.yml'
+    text = workflow.read_text(encoding='utf-8')
+
+    assert 'environment: development' in text
+    assert 'backend/scripts/preflight-cloud-run-deploy.py' in text
+    assert '--migrate-legacy-public-binding backend --migrate-legacy-public-binding backend-sync' in text
+    assert text.index('migrate-legacy-public-binding') < text.index('Deploy ${{ env.SERVICE }} to Cloud Run')
 
 
 def test_expectation_binds_commit_to_deploy_run_revision_and_image() -> None:


### PR DESCRIPTION
## Summary
- migrate the legacy development Cloud Run `GOOGLE_CLIENT_ID` Secret Manager binding before the normal candidate deploy applies the public literal
- preserve serving traffic during the type transition with `--no-traffic`
- add a tested development-only preflight migration contract, including idempotency and multi-container fail-closed behavior

## Root cause
`GOOGLE_CLIENT_ID` was intentionally reclassified as public configuration in #9670, but the existing dev `backend` and `backend-sync` services still hold Secret Manager bindings. Cloud Run rejects changing that binding type in the same `gcloud run deploy` command as `--update-env-vars`.

The dev auto-deploy now invokes the existing Cloud Run preflight helper before the usual candidate deployment. It refuses non-dev projects, detects only the exact legacy binding, and creates a no-traffic transition revision before the normal no-traffic candidate deployment and validation/traffic-shift gates. No production workflow or service is changed.

## Verification
- RED: the migration contract test failed before the implementation existed
- selected Cloud Run deployment-contract suite: **121 passed**
- YAML parse of `.github/workflows/gcp_backend_auto_dev.yml` — passed
- `git diff --check` — passed
- `gcloud run services update --help` verified `--no-traffic`; read-only dev inspection confirmed both affected services currently bind `GOOGLE_CLIENT_ID` from Secret Manager

## Scope
Development-only migration. No production deployment, configuration write, traffic shift, or secret deletion is included.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9693?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

