### PR TITLE
fix(deploy): complete dev public binding migration

### DIFF
--- a/.github/workflows/gcp_backend_auto_dev.yml
+++ b/.github/workflows/gcp_backend_auto_dev.yml
@@ -125,7 +125,10 @@ jobs:
           --env dev
           --project="${{ vars.GCP_PROJECT_ID }}"
           --region="${{ env.REGION }}"
-          --migrate-legacy-public-binding backend --migrate-legacy-public-binding backend-sync
+          --migrate-legacy-public-binding backend
+          --migrate-legacy-public-binding backend-sync
+          --migrate-legacy-public-binding backend-sync-backfill
+          --migrate-legacy-public-binding backend-integration
 
       - name: Deploy ${{ env.SERVICE }} to Cloud Run
         id: deploy-backend

--- a/backend/scripts/preflight-cloud-run-deploy.py
+++ b/backend/scripts/preflight-cloud-run-deploy.py
@@ -11,6 +11,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, cast
 
+import yaml
+
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 import render_backend_runtime_env  # noqa: E402
 import repair_cloud_run_traffic  # noqa: E402
@@ -108,18 +110,46 @@ def main() -> int:
     return exit_code
 
 
-PUBLIC_BINDING = 'GOOGLE_CLIENT_ID'
 DEVELOPMENT_PROJECT = 'based-hardware-dev'
 
 
 def migrate_legacy_public_bindings(
-    *, services: tuple[str, ...] | list[str], env: str, project: str, region: str, runner: Any = subprocess.run
+    *,
+    services: tuple[str, ...] | list[str],
+    env: str,
+    project: str,
+    region: str,
+    manifest_path: Path = DEFAULT_MANIFEST,
+    runner: Any = subprocess.run,
 ) -> list[str]:
     if env != 'dev' or project != DEVELOPMENT_PROJECT:
         raise ValueError('Legacy public-binding migration is development-only')
 
+    manifest = yaml.safe_load(manifest_path.read_text(encoding='utf-8'))
+    if not isinstance(manifest, dict):
+        raise ValueError(f'Expected a mapping in {manifest_path}')
+    environments = manifest.get('environments')
+    if not isinstance(environments, dict):
+        raise ValueError(f'Missing environments in {manifest_path}')
+    environment_config = environments.get(env)
+    if not isinstance(environment_config, dict):
+        raise ValueError(f'Missing {env} environment in {manifest_path}')
+    cloud_run = environment_config.get('cloud_run')
+    if not isinstance(cloud_run, dict):
+        raise ValueError(f'Missing Cloud Run config for {env} in {manifest_path}')
+    service_configs = cloud_run.get('services')
+    if not isinstance(service_configs, dict):
+        raise ValueError(f'Missing Cloud Run services for {env} in {manifest_path}')
+
     migrated: list[str] = []
     for service in services:
+        service_config = service_configs.get(service)
+        if not isinstance(service_config, dict):
+            raise ValueError(f'Missing Cloud Run service config for {service}')
+        public_env = service_config.get('env')
+        if not isinstance(public_env, dict):
+            raise ValueError(f'Missing public environment config for {service}')
+        public_binding_names = set(public_env)
         document = json.loads(
             runner(
                 [
@@ -140,13 +170,13 @@ def migrate_legacy_public_bindings(
         containers = document['spec']['template']['spec'].get('containers')
         if not isinstance(containers, list) or len(containers) != 1 or not isinstance(containers[0], dict):
             raise ValueError('Legacy public-binding migration requires exactly one container per Cloud Run service')
-        environments = containers[0].get('env', [])
-        has_legacy_secret = any(
-            entry.get('name') == PUBLIC_BINDING
-            and entry.get('valueFrom', {}).get('secretKeyRef', {}).get('name') == PUBLIC_BINDING
-            for entry in environments
+        legacy_binding_names = sorted(
+            entry['name']
+            for entry in containers[0].get('env', [])
+            if entry.get('name') in public_binding_names
+            and entry.get('valueFrom', {}).get('secretKeyRef', {}).get('name') == entry.get('name')
         )
-        if not has_legacy_secret:
+        if not legacy_binding_names:
             continue
         runner(
             [
@@ -157,7 +187,7 @@ def migrate_legacy_public_bindings(
                 service,
                 f'--project={project}',
                 f'--region={region}',
-                f'--remove-secrets={PUBLIC_BINDING}',
+                f'--remove-secrets={",".join(legacy_binding_names)}',
                 '--no-traffic',
                 '--quiet',
             ],

--- a/backend/tests/unit/test_verify_dev_backend_deployment.py
+++ b/backend/tests/unit/test_verify_dev_backend_deployment.py
@@ -103,7 +103,11 @@ def test_dev_deploy_migrates_only_exact_legacy_google_client_id_secrets_without_
                                 {
                                     'name': 'GOOGLE_CLIENT_ID',
                                     'valueFrom': {'secretKeyRef': {'name': 'GOOGLE_CLIENT_ID', 'key': 'latest'}},
-                                }
+                                },
+                                {
+                                    'name': 'STT_PRERECORDED_MODEL',
+                                    'valueFrom': {'secretKeyRef': {'name': 'STT_PRERECORDED_MODEL', 'key': 'latest'}},
+                                },
                             ]
                         }
                     ]
@@ -152,7 +156,7 @@ def test_dev_deploy_migrates_only_exact_legacy_google_client_id_secrets_without_
             'backend',
             '--project=based-hardware-dev',
             '--region=us-central1',
-            '--remove-secrets=GOOGLE_CLIENT_ID',
+            '--remove-secrets=GOOGLE_CLIENT_ID,STT_PRERECORDED_MODEL',
             '--no-traffic',
             '--quiet',
         ],
@@ -290,7 +294,9 @@ def test_dev_deploy_invokes_legacy_binding_migration_only_for_dev_services() -> 
 
     assert 'environment: development' in text
     assert 'backend/scripts/preflight-cloud-run-deploy.py' in text
-    assert '--migrate-legacy-public-binding backend --migrate-legacy-public-binding backend-sync' in text
+    assert text.count('--migrate-legacy-public-binding') == 4
+    for service in ('backend', 'backend-sync', 'backend-sync-backfill', 'backend-integration'):
+        assert f'--migrate-legacy-public-binding {service}' in text
     assert text.index('migrate-legacy-public-binding') < text.index('Deploy ${{ env.SERVICE }} to Cloud Run')
 
 


### PR DESCRIPTION
## Summary
- complete the development-only Cloud Run migration of public configuration that remains legacy Secret Manager-bound
- derive eligible public names from the checked-in dev runtime manifest rather than a hand-maintained one-variable list
- cover `backend`, `backend-sync`, `backend-sync-backfill`, and `backend-integration` before their canonical no-traffic redeploys

## Root cause
PR #9693 safely migrated `GOOGLE_CLIENT_ID` for two services, but dev rollout `29313849625` then exposed the next legacy type mismatch: `STT_PRERECORDED_MODEL` remained Secret Manager-bound while the runtime manifest declares it public. Read-only inventory showed remaining type transitions across four dev services.

This change removes only bindings where the environment variable is declared public for that exact dev service **and** the legacy secret reference is self-referential. The helper rejects non-dev/project targets and multi-container service shapes, then uses `gcloud run services update --no-traffic` before the normal candidate deploy.

## Verification
- RED: regression test required both public bindings to be removed together before implementation
- selected Cloud Run deployment-contract suite: **121 passed**
- focused preflight + deployment-contract tests: **14 passed**
- `actionlint .github/workflows/gcp_backend_auto_dev.yml` — passed
- YAML parse using backend virtualenv — passed
- `git diff --check` — passed
- independent review — approved

## Scope
Development-only workflow and helper. No production workflow, Cloud Run service, secret deletion, or traffic change is included.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9694?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

