### PR TITLE
fix(desktop): stop the launch-time update-channel probe from hanging the main thread (#9192)

### DIFF
--- a/desktop/macos/Desktop/Sources/AppBuild.swift
+++ b/desktop/macos/Desktop/Sources/AppBuild.swift
@@ -8,6 +8,11 @@ enum AppBuild {
   private static let desktopAppcastURL = URL(
     string: "https://api.omi.me/v2/desktop/appcast.xml?platform=macos")!
 
+  /// How long the launch-time channel probe may hold the main thread. It runs before the
+  /// first frame, so it has to stay clear of the 3s watchdog that reports "App Hanging".
+  private static let channelProbeMainThreadBudget: TimeInterval = 1.5
+  private static let channelProbeRequestTimeout: TimeInterval = 3
+
   static var bundleIdentifier: String {
     Bundle.main.bundleIdentifier ?? productionBundleIdentifier
   }
@@ -101,7 +106,7 @@ enum AppBuild {
   @discardableResult
   static func syncUpdateChannelOnFirstLaunch() -> String? {
     guard UserDefaults.standard.string(forKey: updateChannelDefaultsKey) == nil else { return nil }
-    let resolved = resolveFreshInstallUpdateChannelSynchronously()
+    let resolved = probeFreshInstallUpdateChannel()
     UserDefaults.standard.set(resolved, forKey: updateChannelDefaultsKey)
     return resolved
   }
@@ -110,13 +115,21 @@ enum AppBuild {
   /// by the syncUpdateChannelWithInstalledApp() bug (commit 8c60fafe8, March 27 2026).
   /// Re-checks the appcast: if the current build is ahead of latest stable, restore beta.
   static func migrateBetaChannelOverwrite() {
+    migrateBetaChannelOverwrite(probeAppcast: probeFreshInstallUpdateChannel)
+  }
+
+  static func migrateBetaChannelOverwrite(probeAppcast: () -> String) {
     guard !UserDefaults.standard.bool(forKey: betaOverwriteMigrationKey) else { return }
     UserDefaults.standard.set(true, forKey: betaOverwriteMigrationKey)
 
+    // A fresh install has no stored channel, so there is nothing to restore — and
+    // syncUpdateChannelOnFirstLaunch() probes the same appcast moments later. Probing
+    // here as well made every new install pay for two serial launch-blocking round
+    // trips to answer one question.
+    guard UserDefaults.standard.string(forKey: updateChannelDefaultsKey) != nil else { return }
     guard currentUpdateChannel == "stable" else { return }
 
-    let resolved = resolveFreshInstallUpdateChannelSynchronously()
-    if resolved == "beta" {
+    if probeAppcast() == "beta" {
       UserDefaults.standard.set("beta", forKey: updateChannelDefaultsKey)
     }
   }
@@ -202,43 +215,115 @@ enum AppBuild {
     return Int(raw)
   }
 
-  private static func resolveFreshInstallUpdateChannelSynchronously(timeout: TimeInterval = 3) -> String {
-    let fallback = inferredUpdateChannel
+  private static func probeFreshInstallUpdateChannel() -> String {
+    probeFreshInstallUpdateChannel(
+      fallback: inferredUpdateChannel,
+      currentBuild: currentBuildNumber,
+      mainThreadBudget: channelProbeMainThreadBudget,
+      fetchAppcast: fetchDesktopAppcast,
+      persistLateCorrection: storeLateChannelCorrection
+    )
+  }
 
+  /// Resolve the channel for an install with no stored preference.
+  ///
+  /// This runs on the main thread during launch (`AppState.init` needs the channel before
+  /// it loads backend URLs), so it waits at most `mainThreadBudget` for the appcast. Past
+  /// that it returns the bundle-inferred channel and lets the request finish in the
+  /// background: a late answer that disagrees is written through `persistLateCorrection`,
+  /// so the next launch starts on the right channel.
+  ///
+  /// It used to block for up to 3.5s inline, and pinned the timed-out guess permanently.
+  static func probeFreshInstallUpdateChannel(
+    fallback: String,
+    currentBuild: Int?,
+    mainThreadBudget: TimeInterval,
+    fetchAppcast: @escaping (@escaping (String?) -> Void) -> Void,
+    persistLateCorrection: @escaping (String) -> Void
+  ) -> String {
     if fallback == "beta" {
       return "beta"
     }
 
-    guard let currentBuild = currentBuildNumber else {
+    guard let currentBuild else {
       return fallback
     }
 
+    let appcast = AppcastProbeResult()
+    let semaphore = DispatchSemaphore(value: 0)
+
+    fetchAppcast { xml in
+      appcast.set(xml)
+      semaphore.signal()
+    }
+
+    if semaphore.wait(timeout: .now() + mainThreadBudget) == .success {
+      guard let appcastXML = appcast.value else { return fallback }
+      return resolveFreshInstallUpdateChannel(
+        currentBuild: currentBuild,
+        fallback: fallback,
+        appcastXML: appcastXML
+      )
+    }
+
+    DispatchQueue.global(qos: .utility).async {
+      guard
+        semaphore.wait(timeout: .now() + channelProbeRequestTimeout + 0.5) == .success,
+        let appcastXML = appcast.value
+      else { return }
+
+      let resolved = resolveFreshInstallUpdateChannel(
+        currentBuild: currentBuild,
+        fallback: fallback,
+        appcastXML: appcastXML
+      )
+      guard resolved != fallback else { return }
+      persistLateCorrection(resolved)
+    }
+
+    return fallback
+  }
+
+  private static func fetchDesktopAppcast(completion: @escaping (String?) -> Void) {
     let configuration = URLSessionConfiguration.ephemeral
-    configuration.timeoutIntervalForRequest = timeout
-    configuration.timeoutIntervalForResource = timeout
+    configuration.timeoutIntervalForRequest = channelProbeRequestTimeout
+    configuration.timeoutIntervalForResource = channelProbeRequestTimeout
 
     let session = URLSession(configuration: configuration)
-    let semaphore = DispatchSemaphore(value: 0)
-    var appcastXML: String?
+    session.dataTask(with: desktopAppcastURL) { data, _, _ in
+      defer { session.finishTasksAndInvalidate() }
+      guard let data, let xml = String(data: data, encoding: .utf8) else {
+        completion(nil)
+        return
+      }
+      completion(xml)
+    }.resume()
+  }
 
-    let task = session.dataTask(with: desktopAppcastURL) { data, _, _ in
-      defer { semaphore.signal() }
-      guard let data, let xml = String(data: data, encoding: .utf8) else { return }
-      appcastXML = xml
+  private static func storeLateChannelCorrection(_ resolved: String) {
+    DispatchQueue.main.async {
+      // Only upgrade the guess this probe stored — never clobber a channel the user
+      // picked in Settings while the appcast was still in flight.
+      guard currentUpdateChannel == "stable" else { return }
+      UserDefaults.standard.set(resolved, forKey: updateChannelDefaultsKey)
+      log("AppBuild: appcast answered after the launch budget; update channel set to \(resolved)")
     }
-    task.resume()
+  }
+}
 
-    let finishedInTime = semaphore.wait(timeout: .now() + timeout + 0.5) == .success
-    session.finishTasksAndInvalidate()
+private final class AppcastProbeResult: @unchecked Sendable {
+  private let lock = NSLock()
+  private var xml: String?
 
-    guard finishedInTime, let appcastXML else {
-      return fallback
-    }
+  func set(_ value: String?) {
+    lock.lock()
+    defer { lock.unlock() }
+    xml = value
+  }
 
-    return resolveFreshInstallUpdateChannel(
-      currentBuild: currentBuild,
-      fallback: fallback,
-      appcastXML: appcastXML
-    )
+  var value: String? {
+    lock.lock()
+    defer { lock.unlock() }
+    return xml
   }
 }

--- a/desktop/macos/Desktop/Tests/AppBuildUpdateChannelProbeTests.swift
+++ b/desktop/macos/Desktop/Tests/AppBuildUpdateChannelProbeTests.swift
@@ -1,0 +1,189 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// Launch-time update-channel probe (#9192).
+///
+/// The probe runs on the main thread inside `AppState.init()`, before the first frame,
+/// because backend routing needs the channel. It must therefore never hold the main
+/// thread past the 3s "App Hanging" watchdog, and it must not permanently pin an
+/// install to the channel it guessed when the network was too slow to answer.
+final class AppBuildUpdateChannelProbeTests: XCTestCase {
+
+  private static let betaAppcast = """
+    <rss><channel>
+      <item><sparkle:version>11000</sparkle:version></item>
+      <item><sparkle:channel>beta</sparkle:channel><sparkle:version>11200</sparkle:version></item>
+    </channel></rss>
+    """
+
+  // MARK: - Fast path: the appcast answers within the budget
+
+  func testAppcastAnsweringWithinBudgetResolvesBetaForABuildAheadOfStable() {
+    let resolved = AppBuild.probeFreshInstallUpdateChannel(
+      fallback: "stable",
+      currentBuild: 11200,
+      mainThreadBudget: 1.5,
+      fetchAppcast: { completion in completion(Self.betaAppcast) },
+      persistLateCorrection: { _ in XCTFail("answered in time; nothing to correct") }
+    )
+
+    XCTAssertEqual(resolved, "beta")
+  }
+
+  func testAppcastAnsweringWithinBudgetKeepsStableForABuildAtLatestStable() {
+    let resolved = AppBuild.probeFreshInstallUpdateChannel(
+      fallback: "stable",
+      currentBuild: 11000,
+      mainThreadBudget: 1.5,
+      fetchAppcast: { completion in completion(Self.betaAppcast) },
+      persistLateCorrection: { _ in XCTFail("answered in time; nothing to correct") }
+    )
+
+    XCTAssertEqual(resolved, "stable")
+  }
+
+  // MARK: - Regression: a silent network must not hold the main thread
+
+  /// The bug: the probe waited on the appcast for 3.5s inline, and `prepareUpdateChannelForBackendRouting`
+  /// ran it twice on a fresh install — up to 7s of main-thread stall before the first frame.
+  /// A fetch that never answers must return the inferred channel immediately instead.
+  func testSilentNetworkReturnsTheInferredChannelWithoutBlocking() {
+    var pendingCompletion: ((String?) -> Void)?
+
+    let started = Date()
+    let resolved = AppBuild.probeFreshInstallUpdateChannel(
+      fallback: "stable",
+      currentBuild: 11200,
+      mainThreadBudget: 0,
+      fetchAppcast: { completion in pendingCompletion = completion },
+      persistLateCorrection: { _ in }
+    )
+
+    XCTAssertEqual(resolved, "stable", "launch must proceed on the inferred channel")
+    XCTAssertLessThan(
+      Date().timeIntervalSince(started), 1.0,
+      "an unanswered appcast must not stall the launch path")
+    XCTAssertNotNil(pendingCompletion, "the request is left in flight, not cancelled")
+  }
+
+  /// A beta install whose first launch had a slow network used to be pinned to stable
+  /// forever (the timed-out guess was written to UserDefaults and never re-resolved).
+  /// The late answer now corrects the stored channel for the next launch.
+  func testAppcastAnsweringAfterTheBudgetCorrectsTheStoredChannel() {
+    var pendingCompletion: ((String?) -> Void)?
+    let corrected = expectation(description: "late appcast corrects the stored channel")
+    var correctedTo: String?
+
+    let resolved = AppBuild.probeFreshInstallUpdateChannel(
+      fallback: "stable",
+      currentBuild: 11200,
+      mainThreadBudget: 0,
+      fetchAppcast: { completion in pendingCompletion = completion },
+      persistLateCorrection: { channel in
+        correctedTo = channel
+        corrected.fulfill()
+      }
+    )
+
+    XCTAssertEqual(resolved, "stable", "this launch keeps the channel it already routed on")
+
+    pendingCompletion?(Self.betaAppcast)
+
+    wait(for: [corrected], timeout: 5)
+    XCTAssertEqual(correctedTo, "beta")
+  }
+
+  func testLateAppcastAgreeingWithTheInferredChannelWritesNothing() {
+    var pendingCompletion: ((String?) -> Void)?
+    let settled = expectation(description: "late appcast processed")
+    settled.isInverted = true
+
+    let resolved = AppBuild.probeFreshInstallUpdateChannel(
+      fallback: "stable",
+      currentBuild: 11000,
+      mainThreadBudget: 0,
+      fetchAppcast: { completion in pendingCompletion = completion },
+      persistLateCorrection: { _ in settled.fulfill() }
+    )
+
+    XCTAssertEqual(resolved, "stable")
+
+    pendingCompletion?(Self.betaAppcast)
+
+    wait(for: [settled], timeout: 1)
+  }
+
+  // MARK: - The probe is skipped entirely when the bundle already answers
+
+  func testBetaBundleResolvesWithoutTouchingTheNetwork() {
+    let resolved = AppBuild.probeFreshInstallUpdateChannel(
+      fallback: "beta",
+      currentBuild: 11200,
+      mainThreadBudget: 1.5,
+      fetchAppcast: { _ in XCTFail("a beta bundle needs no appcast round trip") },
+      persistLateCorrection: { _ in XCTFail("nothing to correct") }
+    )
+
+    XCTAssertEqual(resolved, "beta")
+  }
+
+  func testMissingBuildNumberResolvesWithoutTouchingTheNetwork() {
+    let resolved = AppBuild.probeFreshInstallUpdateChannel(
+      fallback: "stable",
+      currentBuild: nil,
+      mainThreadBudget: 1.5,
+      fetchAppcast: { _ in XCTFail("no build number to compare against") },
+      persistLateCorrection: { _ in XCTFail("nothing to correct") }
+    )
+
+    XCTAssertEqual(resolved, "stable")
+  }
+
+  // MARK: - The beta-overwrite migration must not probe on a fresh install
+
+  /// `prepareUpdateChannelForBackendRouting()` runs the migration and then the first-launch
+  /// sync. On a fresh install there is no overwritten preference to restore, so the migration
+  /// probing the appcast only doubled the launch-blocking round trips.
+  func testBetaOverwriteMigrationDoesNotProbeOnAFreshInstall() {
+    withCleanChannelDefaults {
+      AppBuild.migrateBetaChannelOverwrite(probeAppcast: {
+        XCTFail("a fresh install has no overwritten channel to restore")
+        return "stable"
+      })
+
+      XCTAssertNil(
+        UserDefaults.standard.string(forKey: "update_channel"),
+        "the first-launch sync owns the initial channel")
+      XCTAssertTrue(UserDefaults.standard.bool(forKey: "didMigrateBetaOverwrite_v1"))
+    }
+  }
+
+  func testBetaOverwriteMigrationStillRestoresBetaForAnExistingStableUser() {
+    withCleanChannelDefaults {
+      UserDefaults.standard.set("stable", forKey: "update_channel")
+
+      AppBuild.migrateBetaChannelOverwrite(probeAppcast: { "beta" })
+
+      XCTAssertEqual(UserDefaults.standard.string(forKey: "update_channel"), "beta")
+    }
+  }
+
+  private func withCleanChannelDefaults(_ body: () -> Void) {
+    let defaults = UserDefaults.standard
+    let previousChannel = defaults.string(forKey: "update_channel")
+    let previousMigration = defaults.bool(forKey: "didMigrateBetaOverwrite_v1")
+    defer {
+      defaults.set(previousMigration, forKey: "didMigrateBetaOverwrite_v1")
+      if let previousChannel {
+        defaults.set(previousChannel, forKey: "update_channel")
+      } else {
+        defaults.removeObject(forKey: "update_channel")
+      }
+    }
+
+    defaults.removeObject(forKey: "update_channel")
+    defaults.removeObject(forKey: "didMigrateBetaOverwrite_v1")
+    body()
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260714-launch-update-channel-probe.json
+++ b/desktop/macos/changelog/unreleased/20260714-launch-update-channel-probe.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed the app freezing for several seconds on its first launch when the network was slow, and stopped a slow first launch from pinning beta installs to the stable update channel"
+}

--- a/desktop/macos/e2e/flows/harness-smoke.yaml
+++ b/desktop/macos/e2e/flows/harness-smoke.yaml
@@ -6,6 +6,7 @@ app: non-prod
 covers:
   - desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
   - desktop/macos/Desktop/Sources/AppState/AppState+Environment.swift
+  - desktop/macos/Desktop/Sources/AppBuild.swift
   - desktop/macos/Desktop/Sources/BundleEnvironment.swift
   - desktop/macos/Desktop/Sources/DesktopBackendEnvironment.swift
   - desktop/macos/Desktop/Sources/AuthService.swift


### PR DESCRIPTION
Fixes part of #9192 (Desktop `App Hanging` Sentry clusters — ~145k events / 1.3k users).

## The bug

`AppState.init()` resolves the update channel *before* it loads backend URLs, so the appcast probe runs **on the main thread, before the first frame**. On a fresh install it ran **twice**:

1. `migrateBetaChannelOverwrite()` probes the appcast, then
2. `syncUpdateChannelOnFirstLaunch()` probes it again for the same answer.

Each probe blocked for up to **3.5s** (3s request timeout + 0.5s slack). A slow, captive-portal, or offline first launch therefore stalled the main thread for **up to 7s** — well past the 3000 ms watchdog that reports `App Hanging: App hanging for at least 3000 ms`. `UpdaterViewModel.init()` runs the same pair from `applicationDidFinishLaunching`.

Second defect in the same path: the timed-out **guess was persisted permanently**. `syncUpdateChannelOnFirstLaunch()` writes the fallback to `update_channel`, and the key being set is exactly what stops it from ever re-resolving — so a beta install whose first launch had a slow network was pinned to the **stable** channel (and stable backend routing) for good.

## Why it stays synchronous

Beta and stable both ship as `omi.app` (`codemagic.yaml` → `APP_NAME: "omi"`), so `inferredUpdateChannel` — which only looks at bundle name/path/id — cannot tell them apart. The appcast round trip is the *only* signal that identifies a beta install, and `DesktopBackendEnvironment.shouldUseDevelopmentBackends` reads the resulting channel to pick the backend. Making it fire-and-forget would route a beta user's first session at the prod backend, so the probe stays synchronous — just bounded.

## The fix

- **`migrateBetaChannelOverwrite()` skips the probe on a fresh install.** With no stored channel there is no overwritten preference to restore, and the first-launch sync resolves the same answer moments later. One round trip instead of two.
- **The probe holds the main thread for at most 1.5s.** Past that, launch proceeds on the bundle-inferred channel and the request finishes in the background; a late answer that disagrees corrects the stored channel, so the **next** launch starts on the right one instead of being pinned to the guess. The current session keeps the channel it already routed on — no mid-session backend switch.

Worst-case main-thread block on first launch: **~7s → 1.5s**.

## Verification

- `xcrun swift build -c debug --package-path Desktop` — green.
- New `AppBuildUpdateChannelProbeTests` (9 tests) drive the **production** probe with the network injected: a fast answer resolves beta/stable; a silent network returns immediately without blocking; a late answer corrects the stored channel; an agreeing late answer writes nothing; the migration no longer probes on a fresh install; a beta bundle and a missing build number skip the network entirely.
- Adjacent update/backend-routing suites green (23 tests).
- `make preflight` — 13 checks pass. No product invariants affected.

## ⚠️ Not exercised on the real launch path

Neither this machine nor the Mac mini has a code-signing identity, and `run.sh` refuses ad-hoc signing because it resets Screen Recording permissions for **all** Omi apps including prod — so I did not launch a signed named bundle. The timing and late-correction behavior is proven at the function level (the tests call the same function the app calls, with only the network injected), **not** by watching a real first launch. Worth a signed named-bundle launch before merge.

## Related main-thread blockers found while triaging #9192 (not touched here)

- `OmiApp.swift:351` — `LSRegisterURL(bundleURL, true)` runs on the main thread in `applicationDidFinishLaunching`, every launch (its neighbours `stripProvenanceXattrs` / `resetIconCacheIfNeeded` are correctly dispatched off-main).
- `NotificationRegistrationRepair.swift:140` — the repair does its heavy work off-main but hops `LSRegisterURL` back onto the main queue; it re-runs every launch for the population whose repair keeps failing (#9082).
- `ProactiveAssistantsPlugin.swift:488` — `RewindShutdownFlush.flush(timeout: 5)` is a `DispatchSemaphore.wait` on `@MainActor`, reached from the screen-capture toggle and from automatic permission/recovery paths.

🤖 automated by the hourly watchdog; opened for review, not merged.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9695?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

