### PR TITLE
fix(users): validate people at the boundary so a malformed person doc cannot 500 the read

### DIFF
--- a/backend/database/users.py
+++ b/backend/database/users.py
@@ -3,11 +3,13 @@ from typing import Optional
 
 from google.cloud import firestore
 from google.cloud.firestore_v1 import FieldFilter, transactional
+from pydantic import ValidationError
 
 from ._client import db, document_id_from_seed
 from database.firestore_cache import CachePolicy, get_or_fetch, invalidate
 from database.redis_db import try_acquire_client_device_write_lock, try_acquire_user_platform_write_lock
 from models.users import Subscription, PlanLimits, PlanType, SubscriptionStatus
+from models.other import Person
 from utils.subscription import get_default_basic_subscription
 import logging
 
@@ -672,6 +674,13 @@ def get_people_by_ids(uid: str, person_ids: list[str]):
         if doc.exists:
             data = doc.to_dict()
             data.setdefault('id', doc.id)
+            try:
+                # Validate at the boundary: every caller builds Person(**p) from these dicts, so a
+                # legacy or partial doc (e.g. missing name) would 500 the read. Skip it instead.
+                Person(**data)
+            except ValidationError as e:
+                logger.warning('Skipping malformed person doc %s: %s', doc.id, e)
+                continue
             all_people.append(data)
     return all_people
 

--- a/backend/tests/unit/test_get_people_by_ids_skip_malformed.py
+++ b/backend/tests/unit/test_get_people_by_ids_skip_malformed.py
@@ -1,0 +1,52 @@
+"""database.users.get_people_by_ids validates at the boundary so a malformed person doc is skipped.
+
+Every caller builds [Person(**p) for p in get_people_by_ids(...)]. get_people_by_ids only setdefaults
+the id field, while Person requires name, so one legacy or partially-written person doc missing name
+raised ValidationError and 500'd the read (conversation list, trends, external integrations, chat
+retrieval, ...). PR #9494 fixed one call site; this closes the class at the boundary: get_people_by_ids
+now skips a Person-invalid doc (logging it) and returns only valid person dicts.
+"""
+
+import os
+
+os.environ.setdefault(
+    'ENCRYPTION_SECRET',
+    'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv',
+)
+
+from unittest.mock import MagicMock
+
+import database.users as users
+
+
+def _doc(doc_id, data):
+    d = MagicMock()
+    d.exists = True
+    d.id = doc_id
+    d.to_dict.return_value = data
+    return d
+
+
+def _patch_db(monkeypatch, docs):
+    fake = MagicMock()
+    for attr in ('collection', 'document'):
+        getattr(fake, attr).return_value = fake
+    fake.get_all.return_value = docs
+    monkeypatch.setattr(users, 'db', fake)
+
+
+def test_get_people_by_ids_skips_malformed_and_keeps_valid(monkeypatch):
+    _patch_db(
+        monkeypatch,
+        [
+            _doc('p1', {'id': 'p1', 'name': 'Alice'}),  # valid
+            _doc('p2', {'id': 'p2'}),  # missing required name -> Person invalid -> skipped
+            _doc('legacy', {'name': 'Bob'}),  # missing id -> id falls back to doc.id, then valid
+        ],
+    )
+    result = users.get_people_by_ids('u1', ['p1', 'p2', 'legacy'])
+    assert sorted(p['id'] for p in result) == ['legacy', 'p1']  # malformed p2 skipped; legacy id filled
+
+
+def test_get_people_by_ids_empty_returns_empty(monkeypatch):
+    assert users.get_people_by_ids('u1', []) == []

--- a/backend/tests/unit/test_users_missing_doc_guards.py
+++ b/backend/tests/unit/test_users_missing_doc_guards.py
@@ -64,6 +64,7 @@ _mod(
     SubscriptionStatus=MagicMock(),
 )
 _mod("utils.subscription", get_default_basic_subscription=MagicMock())
+_mod("models.other", Person=MagicMock())
 
 
 def _load():


### PR DESCRIPTION
## What

`get_people_by_ids` returns raw person dicts and only setdefaults the `id` field:

```python
data = doc.to_dict()
data.setdefault('id', doc.id)
all_people.append(data)
```

Every caller then builds `[Person(**p) for p in get_people_by_ids(...)]` (routers/conversations.py, utils/conversations/process_conversation.py + render.py, utils/llm/chat.py, external_integrations.py, trends.py, memories.py, retrieval tools). `Person` (models/other.py) requires `name`, which `get_people_by_ids` does not guarantee, so one legacy or partially-written person doc missing `name` raises `ValidationError` and 500s the read.

My earlier PR #9494 fixed this for a single call site (`get_conversations_text`). This closes the same failure class at the boundary so every caller is covered by one guard.

## Fix

Validate each doc against `Person` at the boundary and skip (log) a malformed one:

```python
data = doc.to_dict()
data.setdefault('id', doc.id)
try:
    Person(**data)
except ValidationError as e:
    logger.warning('Skipping malformed person doc %s: %s', doc.id, e)
    continue
all_people.append(data)
```

`get_people_by_ids` still returns dicts (callers unchanged), now guaranteed Person-valid. The catch is narrow (`ValidationError`) so an unexpected error still propagates. Skipping a malformed person matches #9494's behavior: that person just goes unresolved rather than 500ing the whole response.

## Tests

New `tests/unit/test_get_people_by_ids_skip_malformed.py` drives it with an injected fake db proxy:
- a valid doc is kept, a doc missing `name` is skipped, and a doc missing `id` falls back to `doc.id` and is kept
- empty input returns empty

## Verification

```
cd backend && ENCRYPTION_SECRET=... python -m pytest tests/unit/test_get_people_by_ids_skip_malformed.py -q
  -> 2 passed
black --line-length 120 --skip-string-normalization --check database/users.py tests/unit/test_get_people_by_ids_skip_malformed.py
  -> unchanged
python -m pyright -p pyrightconfig.json database/users.py -> 0 errors
python scripts/check_module_stub_pollution.py -> 0 violations
```

## Product invariants affected

none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9696?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

