### PR TITLE
fix(recommendations): treat a malformed stored projection as absent instead of 500ing the read

### DIFF
--- a/backend/database/task_recommendations.py
+++ b/backend/database/task_recommendations.py
@@ -366,6 +366,27 @@ def get_decisions(
     return _decision_records(raw_records, evaluation_id)
 
 
+def _valid_evaluation_projection(
+    raw_projection: Any, evaluation_id: str, now: datetime
+) -> Optional[WhatMattersNowProjection]:
+    """Build a WhatMattersNowProjection from a stored projection dict, or None if unusable.
+
+    The stored projection was validated with no guard, so a legacy or schema-drifted doc would raise
+    ValidationError and 500 the recommendation read. Treat a malformed (or non-dict, stale, or
+    id-mismatched) projection as absent, consistent with this reader's other None returns.
+    """
+    if not isinstance(raw_projection, dict):
+        return None
+    try:
+        projection = WhatMattersNowProjection.model_validate(raw_projection)
+    except ValidationError as e:
+        logger.warning('Ignoring malformed stored projection for evaluation %s: %s', evaluation_id, e)
+        return None
+    if projection.evaluation_id != evaluation_id or projection.expires_at <= now:
+        return None
+    return projection
+
+
 def get_evaluation_projection(
     uid: str,
     evaluation_id: str,
@@ -396,13 +417,7 @@ def get_evaluation_projection(
     payload = _snapshot_dict(snapshot)
     if payload.get('account_generation') != account_generation:
         return None
-    raw_projection = payload.get('projection')
-    if not isinstance(raw_projection, dict):
-        return None
-    projection = WhatMattersNowProjection.model_validate(raw_projection)
-    if projection.evaluation_id != evaluation_id or projection.expires_at <= now:
-        return None
-    return projection
+    return _valid_evaluation_projection(payload.get('projection'), evaluation_id, now)
 
 
 def create_feedback(

--- a/backend/tests/unit/test_evaluation_projection_skip_malformed.py
+++ b/backend/tests/unit/test_evaluation_projection_skip_malformed.py
@@ -1,0 +1,75 @@
+"""database.task_recommendations._valid_evaluation_projection treats a malformed projection as absent.
+
+get_evaluation_projection validated the stored projection with an unguarded
+WhatMattersNowProjection.model_validate(raw_projection). A legacy or schema-drifted projection doc
+raised ValidationError and 500'd the recommendation read (utils/task_intelligence/recommendations.py).
+The validate plus freshness checks now live in the pure _valid_evaluation_projection helper, which
+returns None on a malformed, non-dict, stale, or id-mismatched projection, consistent with the
+reader's other None returns.
+"""
+
+import os
+
+os.environ.setdefault(
+    'ENCRYPTION_SECRET',
+    'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv',
+)
+
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+
+from pydantic import BaseModel, ValidationError
+
+import database.task_recommendations as tr
+
+
+class _Probe(BaseModel):
+    x: int
+
+
+def _a_validation_error() -> ValidationError:
+    try:
+        _Probe.model_validate({})  # missing required field -> a real ValidationError
+    except ValidationError as exc:
+        return exc
+    raise AssertionError('expected a ValidationError')
+
+
+NOW = datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+
+def _stub_validate(monkeypatch):
+    err = _a_validation_error()
+
+    def fake_validate(raw):
+        if raw.get('_bad'):
+            raise err
+        return SimpleNamespace(
+            evaluation_id=raw.get('evaluation_id', 'eval1'),
+            expires_at=raw.get('expires_at', NOW + timedelta(hours=1)),
+        )
+
+    monkeypatch.setattr(tr.WhatMattersNowProjection, 'model_validate', staticmethod(fake_validate))
+
+
+def test_valid_projection_returned(monkeypatch):
+    _stub_validate(monkeypatch)
+    out = tr._valid_evaluation_projection({'evaluation_id': 'eval1'}, 'eval1', NOW)
+    assert out is not None and out.evaluation_id == 'eval1'
+
+
+def test_malformed_projection_is_none(monkeypatch):
+    _stub_validate(monkeypatch)
+    # ValidationError from a legacy/schema-drifted doc -> None, not a 500.
+    assert tr._valid_evaluation_projection({'_bad': True}, 'eval1', NOW) is None
+
+
+def test_non_dict_projection_is_none():
+    assert tr._valid_evaluation_projection(None, 'eval1', NOW) is None
+
+
+def test_mismatched_or_expired_is_none(monkeypatch):
+    _stub_validate(monkeypatch)
+    assert tr._valid_evaluation_projection({'evaluation_id': 'other'}, 'eval1', NOW) is None  # id mismatch
+    expired = {'evaluation_id': 'eval1', 'expires_at': NOW - timedelta(hours=1)}
+    assert tr._valid_evaluation_projection(expired, 'eval1', NOW) is None  # stale


### PR DESCRIPTION
## What

`get_evaluation_projection` validated the stored projection with an unguarded call:

```python
raw_projection = payload.get('projection')
if not isinstance(raw_projection, dict):
    return None
projection = WhatMattersNowProjection.model_validate(raw_projection)
...
```

Every other unusable-projection case in this reader already returns `None` (doc missing, wrong account_generation, non-dict projection). But a projection dict that fails `WhatMattersNowProjection` validation (a legacy or schema-drifted doc) raises `ValidationError`, which propagates and 500s the recommendation read (`utils/task_intelligence/recommendations.py:966`).

## Fix

Move the validate plus freshness checks into a pure `_valid_evaluation_projection` helper that returns `None` on a malformed projection instead of raising, consistent with the reader's other `None` returns:

```python
def _valid_evaluation_projection(raw_projection, evaluation_id, now):
    if not isinstance(raw_projection, dict):
        return None
    try:
        projection = WhatMattersNowProjection.model_validate(raw_projection)
    except ValidationError as e:
        logger.warning('Ignoring malformed stored projection for evaluation %s: %s', evaluation_id, e)
        return None
    if projection.evaluation_id != evaluation_id or projection.expires_at <= now:
        return None
    return projection
```

The catch is narrow (`ValidationError`) so an unexpected error still propagates. Extracting the helper also makes the behavior unit-testable without the surrounding `@firestore.transactional` read, matching the `_decision_records` helper added in #9606 for the sibling `get_decisions`.

## Tests

New `tests/unit/test_evaluation_projection_skip_malformed.py` drives the helper directly:
- a valid projection is returned; a malformed one returns None (no 500)
- a non-dict, an id mismatch, and an expired projection each return None

## Verification

```
cd backend && ENCRYPTION_SECRET=... python -m pytest tests/unit/test_evaluation_projection_skip_malformed.py -q
  -> 4 passed
black --line-length 120 --skip-string-normalization --check database/task_recommendations.py tests/unit/test_evaluation_projection_skip_malformed.py
  -> unchanged
python -m pyright -p pyrightconfig.json database/task_recommendations.py -> 0 errors
python scripts/check_module_stub_pollution.py -> 0 violations
```

## Product invariants affected

none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9697?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

