### PR TITLE
fix(desktop): bind the hub route when the realtime transport goes ready

### DIFF
--- a/desktop/macos/Desktop/Sources/FloatingControlBar/VoiceTurnStateMachine.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/VoiceTurnStateMachine.swift
@@ -771,12 +771,17 @@ struct VoiceTurnReducer {
         return VoiceTurnReduction(model: model, effects: effects)
       }
       cancel(.hubWarm, in: &model, effects: &effects)
-      // Transport readiness is not context admission. Keep the logical route in
-      // warm-wait until providerReconnected proves an admitted physical binding.
+      // The route is the driver's audio/commit routing signal, not an admission
+      // grant: the PTT driver owns a hub turn only while the route reads `.hub`.
+      // Input admission stays fenced by `providerConnection` and
+      // `RealtimeInputAdmissionPolicy`, so binding here cannot leak audio to the
+      // provider before the canonical context is bound.
+      model.turn?.route = .hub(sessionID: sessionID)
+      model.turn?.sessionID = sessionID
       effects.append(.prepareHubInput(turnID: turn.id, sessionID: sessionID))
 
     case .hubAdmissionRejected:
-      guard turn.route == .hubWarmWait else {
+      guard routeMatchesHub(turn.route) else {
         stale(&model, event: event, effects: &effects)
         return VoiceTurnReduction(model: model, effects: effects)
       }

--- a/desktop/macos/Desktop/Tests/VoiceTurnCoordinatorTests.swift
+++ b/desktop/macos/Desktop/Tests/VoiceTurnCoordinatorTests.swift
@@ -255,7 +255,7 @@ final class VoiceTurnCoordinatorTests: XCTestCase {
     coordinator.send(.hubReady(turnID: turnID, sessionID: sessionID))
 
     XCTAssertEqual(resolutions, 1)
-    XCTAssertEqual(coordinator.model.turn?.route, .hubWarmWait)
+    XCTAssertEqual(coordinator.model.turn?.route, .hub(sessionID: sessionID))
     XCTAssertEqual(
       coordinator.timelineSnapshot().filter { $0.event == "hub_ready" }.count,
       1)

--- a/desktop/macos/Desktop/Tests/VoiceTurnReducerTests.swift
+++ b/desktop/macos/Desktop/Tests/VoiceTurnReducerTests.swift
@@ -238,7 +238,7 @@ final class VoiceTurnReducerTests: XCTestCase {
       timedOut.effects.contains(.fallbackToTranscription(turnID: turnID, reason: .hubWarmTimeout)))
   }
 
-  func testTransportReadyPreparesContextWithoutAdmittingHubRoute() {
+  func testTransportReadyBindsHubRouteAndPreparesContext() {
     let turnID = VoiceTurnID()
     let sessionID = VoiceSessionID()
     var model = reduce(.idle, .start(turnID: turnID, ownerID: nil, intent: .hold)).model
@@ -246,11 +246,47 @@ final class VoiceTurnReducerTests: XCTestCase {
 
     let ready = reduce(model, .hubReady(turnID: turnID, sessionID: sessionID))
 
-    XCTAssertEqual(ready.model.turn?.route, .hubWarmWait)
-    XCTAssertNil(ready.model.turn?.sessionID)
+    XCTAssertEqual(ready.model.turn?.route, .hub(sessionID: sessionID))
+    XCTAssertEqual(ready.model.turn?.sessionID, sessionID)
     XCTAssertEqual(ready.model.turn?.phase, .recording)
     XCTAssertTrue(ready.effects.contains(.cancelDeadline(turnID: turnID, deadline: .hubWarm)))
     XCTAssertTrue(ready.effects.contains(.prepareHubInput(turnID: turnID, sessionID: sessionID)))
+
+    // Binding the route is not an admission grant. `prepareHubInput` opens the
+    // context-fresh preparation the driver fences audio behind, so the provider
+    // connection is still closed until `providerReconnected` admits the input.
+    let reservation = reserveIdentity(ready.model, turnID: turnID)
+    let preparing = reduce(
+      reservation.model,
+      .providerReconnectStarted(
+        turnID: turnID,
+        identity: reservation.identity,
+        previousSessionID: sessionID))
+    XCTAssertEqual(
+      preparing.model.turn?.providerConnection,
+      .reconnecting(identity: reservation.identity, previousSessionID: sessionID))
+  }
+
+  /// A turn released while the socket was still warming commits through
+  /// `commitBufferedRealtimeHubTurn`, which the PTT driver gates on a `.hub`
+  /// route. Leaving the route in warm-wait after `hubReady` stranded the turn in
+  /// `finalizing` forever — no commit, no reply, no transcription fallback.
+  func testBufferedWarmWaitTurnStaysCommittableAfterTransportReady() {
+    let turnID = VoiceTurnID()
+    let sessionID = VoiceSessionID()
+    var model = reduce(.idle, .start(turnID: turnID, ownerID: nil, intent: .hold)).model
+    model = reduce(model, .selectRoute(turnID: turnID, route: .hubWarmWait)).model
+    model = reduce(model, .finalize(turnID: turnID)).model
+    model = reduce(model, .hubReady(turnID: turnID, sessionID: sessionID)).model
+
+    XCTAssertEqual(model.turn?.phase, .finalizing)
+    XCTAssertEqual(model.turn?.route, .hub(sessionID: sessionID))
+    XCTAssertFalse(model.turn?.hubCommitPending == true)
+
+    // The driver now owns the hub turn, so its deferred commit is accepted and
+    // the replayed audio is committed once admission lands.
+    let deferred = reduce(model, .hubCommitDeferred(turnID: turnID))
+    XCTAssertTrue(deferred.model.turn?.hubCommitPending == true)
   }
 
   func testHubAdmissionRejectionAfterTransportReadyFallsBackAfterRelease() {

--- a/desktop/macos/changelog/unreleased/20260714-ptt-warm-wait-hub-commit.json
+++ b/desktop/macos/changelog/unreleased/20260714-ptt-warm-wait-hub-commit.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed push-to-talk turns spoken while the voice connection was still warming up getting stuck thinking with no reply"
+}


### PR DESCRIPTION
## Product invariants affected

- INV-CHAT-1
- INV-VOICE-1

## The bug

Every push-to-talk turn taken while the realtime socket was still warming up died silently: the thinking spinner stayed up forever, the user's speech was dropped, and no reply, transcription fallback, or journal row was ever produced. Only pressing PTT again escaped it.

## Root cause

`dbd69e71c5` ("make realtime context admission fail closed") removed the `route = .hub(sessionID:)` binding from the `hubReady` reducer case, to keep transport readiness distinct from context admission. But the route is precisely what the **PTT driver** reads to decide it owns a hub turn — admission is fenced separately, by `providerConnection` and `RealtimeInputAdmissionPolicy` inside `RealtimeHubController`.

With the route stranded in `.hubWarmWait`:

1. `commitBufferedRealtimeHubTurn()` opens with `guard isHubMode` (route `.hub`) — so the one function that exists to serve the buffered warm-wait path returned immediately.
2. `hubCommitPending` therefore stayed `false`, so when admission landed, `finishContextFreshInputOnCurrentSession()` replayed the buffered audio and called `beginInputTurn` but never `commitInputTurn` — the provider was never asked to respond.
3. `hubReady` had already cancelled the `.hubWarm` deadline, and the successful reconnect cancelled `.providerReconnect`, so **no deadline was armed**. The turn sat in `finalizing` indefinitely.

Mid-hold mic audio in that window never reached the hub at all: the tap only calls `feedAudio` when `isHubMode`.

Ironically it broke precisely when admission *succeeded* — a rejected admission at least terminated the turn via `providerReconnectFailed`.

## The fix

Restore the route binding in `hubReady`, and widen the `hubAdmissionRejected` guard to `routeMatchesHub`. That event is sent from *inside* the `prepareHubInput` effect handler — i.e. after the route has been applied — so the #9684 transcription fallback would otherwise go stale.

**The fail-closed property is preserved.** The route is a driver-routing signal, not an admission grant. Audio still cannot reach the provider before the canonical context is bound: `feedAudio` parks chunks in `reconnectAudioBuffer`, and `commitTurn` defers through `hubCommitDeferred` (which also arms the `deferredCommit` deadline, closing the no-deadline hang) until `RealtimeInputAdmissionPolicy` admits the input.

## Verification

- Added `testBufferedWarmWaitTurnStaysCommittableAfterTransportReady` and reworked `testTransportReadyBindsHubRouteAndPreparesContext` (it previously asserted the broken state). Both **fail on the pre-fix reducer and pass after it** — verified by stashing the source fix and re-running.
- `desktop/macos/scripts/agent-logic-harness.sh --swift-only` → **379 tests, 0 failures**.
- `make preflight` → green.

Not runtime-exercised in a live named bundle (**UNVERIFIED** on-device); the finding and fix are established by static trace plus the reducer/coordinator regression tests above.

## Scope / risk

The regressing commit is on `main` and rode into the `v0.12.73` **candidate**, but that release is still `channel: candidate` — it has not been promoted to beta or stable, so no production user is affected yet. This lands the fix before it can ship.

🤖 automated by hourly watchdog; opened for review, not merged (not live on prod → outside the auto-merge gate).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9699?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

