### PR TITLE
fix(candidates): return None on a malformed candidate doc in get_candidate instead of 500ing

### DIFF
--- a/backend/database/candidates.py
+++ b/backend/database/candidates.py
@@ -547,7 +547,22 @@ def get_candidate(uid: str, candidate_id: str) -> Optional[CandidateRecord]:
     snapshot = _candidate_ref(uid, candidate_id).get()
     if not snapshot.exists:
         return None
-    return CandidateRecord.from_storage(_snapshot_dict(snapshot))
+    try:
+        return CandidateRecord.from_storage(_snapshot_dict(snapshot))
+    except ValidationError as e:
+        # A malformed/legacy candidate doc must not 500 the read; return None (the router maps that to
+        # 404), mirroring the skip in list_candidates. Catch only ValidationError so unexpected runtime
+        # errors still surface, and log bounded structural error types only since the rendered pydantic
+        # error can contain private task text.
+        errors = e.errors(include_input=False, include_url=False)
+        bounded_error_types = [str(error.get('type', 'unknown')) for error in errors[:5]]
+        logger.warning(
+            'Ignoring malformed candidate record %s: error_count=%s validation_types=%s',
+            getattr(snapshot, 'id', None),
+            e.error_count(),
+            bounded_error_types,
+        )
+        return None
 
 
 def list_candidates(

--- a/backend/tests/unit/test_get_candidate_skip_malformed.py
+++ b/backend/tests/unit/test_get_candidate_skip_malformed.py
@@ -1,0 +1,77 @@
+"""database.candidates.get_candidate returns None on a malformed candidate doc instead of 500ing.
+
+get_candidate built CandidateRecord.from_storage(_snapshot_dict(snapshot)) with no try/except, so one
+legacy or schema-drifted candidate doc raised ValidationError and 500'd GET /v1/candidates/{id} (and
+the staged-task read paths that fetch a candidate). The sibling list_candidates already skips such a
+doc; get_candidate now does the same and returns None (the router maps None -> 404). database.candidates
+is light (module-level db proxy), so the test drives it directly.
+"""
+
+import os
+
+os.environ.setdefault(
+    'ENCRYPTION_SECRET',
+    'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv',
+)
+
+from unittest.mock import MagicMock
+
+import pytest
+from pydantic import BaseModel, ValidationError
+
+import database.candidates as candidates
+
+
+class _Probe(BaseModel):
+    x: int
+
+
+def _a_validation_error() -> ValidationError:
+    try:
+        _Probe.model_validate({})  # missing required field -> a real ValidationError
+    except ValidationError as exc:
+        return exc
+    raise AssertionError('expected a ValidationError')
+
+
+def _snap(exists, data=None, doc_id='c1'):
+    s = MagicMock()
+    s.exists = exists
+    s.id = doc_id
+    s.to_dict.return_value = data
+    return s
+
+
+def _patch_db(monkeypatch, snapshot):
+    fake = MagicMock()
+    for attr in ('collection', 'document'):
+        getattr(fake, attr).return_value = fake
+    fake.get.return_value = snapshot
+    monkeypatch.setattr(candidates, 'db', fake)
+
+
+def test_get_candidate_skips_malformed(monkeypatch):
+    err = _a_validation_error()
+
+    def raise_err(data):
+        raise err
+
+    monkeypatch.setattr(candidates.CandidateRecord, 'from_storage', staticmethod(raise_err))
+    _patch_db(monkeypatch, _snap(True, {'bad': 'doc'}))
+    assert candidates.get_candidate('u1', 'c1') is None  # malformed -> None (router 404s), not a 500
+
+
+def test_get_candidate_missing_returns_none(monkeypatch):
+    _patch_db(monkeypatch, _snap(False))
+    assert candidates.get_candidate('u1', 'c1') is None
+
+
+def test_get_candidate_unexpected_error_propagates(monkeypatch):
+    # Only ValidationError is swallowed; an unexpected error must surface, not be hidden as a skip.
+    def boom(data):
+        raise RuntimeError('unexpected')
+
+    monkeypatch.setattr(candidates.CandidateRecord, 'from_storage', staticmethod(boom))
+    _patch_db(monkeypatch, _snap(True, {'x': 1}))
+    with pytest.raises(RuntimeError):
+        candidates.get_candidate('u1', 'c1')


### PR DESCRIPTION
## What

`get_candidate` built a `CandidateRecord` from a stored doc with no guard:

```python
snapshot = _candidate_ref(uid, candidate_id).get()
if not snapshot.exists:
    return None
return CandidateRecord.from_storage(_snapshot_dict(snapshot))
```

`CandidateRecord.from_storage` is `model_validate`, so one legacy or schema-drifted candidate doc (a missing subject discriminator, a drifted `status` enum, a missing required field) raises `ValidationError`. `GET /v1/candidates/{candidate_id}` returns this directly, and the staged-task read paths (`DELETE /v1/staged-tasks/{id}`, `POST /v1/staged-tasks/{id}/promote`) also fetch a candidate through it, so a single bad doc 500s all of them.

## Fix

Mirror the sibling `list_candidates`, which already wraps the identical construction in `try/except ValidationError` and skips the malformed doc. `get_candidate` now returns `None` on `ValidationError` (the router maps `None` to 404, exactly as if the list had skipped it):

```python
try:
    return CandidateRecord.from_storage(_snapshot_dict(snapshot))
except ValidationError as e:
    errors = e.errors(include_input=False, include_url=False)
    bounded_error_types = [str(error.get('type', 'unknown')) for error in errors[:5]]
    logger.warning('Ignoring malformed candidate record %s: error_count=%s validation_types=%s', getattr(snapshot, 'id', None), e.error_count(), bounded_error_types)
    return None
```

The catch is narrow (`ValidationError`) so unexpected errors still surface, and the log keeps only bounded structural error types (no `input_value`) since the rendered pydantic error can contain private task text -- matching `list_candidates`.

## Tests

New `tests/unit/test_get_candidate_skip_malformed.py` drives it with an injected fake db proxy:
- a malformed doc returns None (no 500)
- a missing doc returns None (unchanged)
- an unexpected non-ValidationError still propagates

## Verification

```
cd backend && ENCRYPTION_SECRET=... python -m pytest tests/unit/test_get_candidate_skip_malformed.py -q
  -> 3 passed
black --line-length 120 --skip-string-normalization --check database/candidates.py tests/unit/test_get_candidate_skip_malformed.py
  -> unchanged
python -m pyright -p pyrightconfig.json database/candidates.py -> 0 errors
python scripts/check_module_stub_pollution.py -> Checked 638 file(s); 0 violations
```

## Product invariants affected

none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9701?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

