### PR TITLE
Guard task workflow control reads against a malformed control doc

### DIFF
--- a/backend/database/task_intelligence_control.py
+++ b/backend/database/task_intelligence_control.py
@@ -1,12 +1,16 @@
 """Firestore persistence for per-user task workflow migration controls."""
 
+import logging
 from typing import Any, cast
 
 from google.api_core.exceptions import AlreadyExists, Conflict
+from pydantic import ValidationError
 
 from config.what_matters_now_smoke_fixture import WHAT_MATTERS_NOW_SMOKE_UID, is_development_smoke_fixture
 from database._client import db
 from models.task_intelligence import TaskWorkflowControl, TaskWorkflowMode
+
+logger = logging.getLogger(__name__)
 
 CONTROL_COLLECTION = 'task_intelligence_control'
 CONTROL_DOCUMENT = 'state'
@@ -29,7 +33,19 @@ def get_task_workflow_control(uid: str) -> TaskWorkflowControl:
     payload = snapshot.to_dict()
     if not isinstance(payload, dict):
         return TaskWorkflowControl()
-    return TaskWorkflowControl.model_validate(cast(dict[str, Any], payload))
+    try:
+        return TaskWorkflowControl.model_validate(cast(dict[str, Any], payload))
+    except ValidationError as e:
+        # A single drifted control doc (extra='forbid' plus a removed/renamed field, a bad enum) must not
+        # 500 every candidate/staged-task read that gates on it. Fall back to the default, which the model
+        # defines as legacy-safe (workflow_mode=off, account_generation=0) so writes stay disabled, never
+        # silently enabled. Log only bounded error types -- never input_value, which can carry task text.
+        logger.warning(
+            'Ignoring malformed task workflow control for %s: %s',
+            uid,
+            [str(err.get('type', 'unknown')) for err in e.errors(include_input=False, include_url=False)[:5]],
+        )
+        return TaskWorkflowControl()
 
 
 def set_task_workflow_control(uid: str, control: TaskWorkflowControl) -> None:

--- a/backend/tests/unit/test_task_workflow_control_skip_malformed.py
+++ b/backend/tests/unit/test_task_workflow_control_skip_malformed.py
@@ -1,0 +1,94 @@
+"""Regression: a malformed task workflow control doc must not 500 the reads that gate on it.
+
+`get_task_workflow_control` is called by every candidate and staged-task router path
+(routers/candidates.py, routers/staged_tasks.py). A single drifted control document
+(the model is extra='forbid', so a removed/renamed field or a bad enum value fails to
+load) used to raise ValidationError straight out to the client. The guard falls back to
+the model's legacy-safe default instead, and only an unexpected non-ValidationError still
+propagates.
+"""
+
+import pytest
+
+import database.task_intelligence_control as task_control_db
+from models.task_intelligence import TaskWorkflowControl, TaskWorkflowMode
+
+
+class _FakeSnapshot:
+    def __init__(self, *, exists, data):
+        self.exists = exists
+        self._data = data
+
+    def to_dict(self):
+        return self._data
+
+
+class _FakeDoc:
+    def __init__(self, snapshot):
+        self._snapshot = snapshot
+
+    def collection(self, _name):
+        return _FakeCollection(self._snapshot)
+
+    def get(self):
+        return self._snapshot
+
+
+class _FakeCollection:
+    def __init__(self, snapshot):
+        self._snapshot = snapshot
+
+    def document(self, _id):
+        return _FakeDoc(self._snapshot)
+
+
+class _FakeDb:
+    def __init__(self, snapshot):
+        self._snapshot = snapshot
+
+    def collection(self, _name):
+        return _FakeCollection(self._snapshot)
+
+
+def _install_db(monkeypatch, snapshot):
+    monkeypatch.setattr(task_control_db, 'db', _FakeDb(snapshot))
+
+
+def test_malformed_control_falls_back_to_legacy_default(monkeypatch):
+    # extra='forbid': an unknown/renamed persisted field fails to load with ValidationError.
+    snapshot = _FakeSnapshot(
+        exists=True,
+        data={'workflow_mode': 'write', 'account_generation': 2, 'unexpected_legacy_field': True},
+    )
+    _install_db(monkeypatch, snapshot)
+
+    control = task_control_db.get_task_workflow_control('uid-1')
+
+    # Falls back to the default, which is legacy-safe: writes stay disabled, never silently enabled.
+    assert control == TaskWorkflowControl()
+    assert control.workflow_mode is TaskWorkflowMode.off
+    assert control.account_generation == 0
+
+
+def test_valid_control_is_parsed(monkeypatch):
+    snapshot = _FakeSnapshot(exists=True, data={'workflow_mode': 'write', 'account_generation': 2})
+    _install_db(monkeypatch, snapshot)
+
+    control = task_control_db.get_task_workflow_control('uid-1')
+
+    assert control.workflow_mode is TaskWorkflowMode.write
+    assert control.account_generation == 2
+
+
+def test_unexpected_error_propagates(monkeypatch):
+    snapshot = _FakeSnapshot(exists=True, data={'workflow_mode': 'write', 'account_generation': 2})
+    _install_db(monkeypatch, snapshot)
+
+    def _boom(*_args, **_kwargs):
+        raise RuntimeError('unexpected non-validation failure')
+
+    # The guard catches only ValidationError; anything else must still surface.
+    monkeypatch.setattr(task_control_db.TaskWorkflowControl, 'model_validate', _boom)
+
+    with pytest.raises(RuntimeError, match='unexpected non-validation failure'):
+        task_control_db.get_task_workflow_control('uid-1')


### PR DESCRIPTION
## What

`get_task_workflow_control` loads the per-user `task_intelligence_control/state` doc and validates it:

```python
payload = snapshot.to_dict()
if not isinstance(payload, dict):
    return TaskWorkflowControl()
return TaskWorkflowControl.model_validate(cast(dict[str, Any], payload))
```

`TaskWorkflowControl` is `model_config = ConfigDict(extra='forbid', ...)`, so any drift in the stored doc (a removed or renamed field left behind by an older writer, a bad enum value) fails to load with `ValidationError`. Every candidate and staged-task read gates on this function:

- `routers/candidates.py` (list, get, resolve, promote paths) calls it 6 times
- `routers/staged_tasks.py` calls it 4 times

So a single corrupt control document 500s all of those endpoints for that user, not just one.

## Fix

Fall back to the model default on `ValidationError`:

```python
try:
    return TaskWorkflowControl.model_validate(cast(dict[str, Any], payload))
except ValidationError as e:
    logger.warning(
        'Ignoring malformed task workflow control for %s: %s',
        uid,
        [str(err.get('type', 'unknown')) for err in e.errors(include_input=False, include_url=False)[:5]],
    )
    return TaskWorkflowControl()
```

The default is legacy-safe by construction: `workflow_mode=off` (not in the `{write, read}` set that `_validate_write_control` requires) and `account_generation=0`. So a corrupt control document disables candidate writes rather than silently enabling them. The model docstring already states "defaults preserve legacy behavior."

The catch is narrow (`ValidationError`), so an unexpected failure still surfaces. The log keeps only bounded pydantic error type strings, not `input_value`, since a rendered pydantic error can contain private task text.

## Tests

New `tests/unit/test_task_workflow_control_skip_malformed.py`, driven through the module `db` seam (`monkeypatch.setattr` on the module reference, no `sys.modules` mutation):

- a malformed doc (extra forbidden field) falls back to the default, with `workflow_mode` off and `account_generation` 0
- a valid doc still parses (`workflow_mode` write, `account_generation` 2)
- an unexpected non-`ValidationError` still propagates

## Verification

```
cd backend && ENCRYPTION_SECRET=... python -m pytest tests/unit/test_task_workflow_control_skip_malformed.py -q
  -> 3 passed
black --line-length 120 --skip-string-normalization --check database/task_intelligence_control.py tests/unit/test_task_workflow_control_skip_malformed.py
  -> unchanged
python -m pyright -p pyrightconfig.json database/task_intelligence_control.py
  -> 0 errors
python scripts/check_module_stub_pollution.py
  -> Checked 638 test file(s); 0 violations
```

## Product invariants affected

none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9702?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

