### PR TITLE
Guard long-term memory patch against a malformed stored timestamp

### DIFF
--- a/backend/models/memory_apply.py
+++ b/backend/models/memory_apply.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from datetime import datetime, timezone
 from enum import Enum
 from typing import Any, Dict, List, Optional
@@ -28,6 +29,8 @@ from models.product_memory import (
     MemoryItem,
 )
 from utils.memory.short_term_lifecycle import default_short_term_expiry
+
+logger = logging.getLogger(__name__)
 
 
 class ApplyStatus(str, Enum):
@@ -397,6 +400,20 @@ def _barrier_outbox_events(
     ]
 
 
+def _coerce_iso_timestamp(value: str, *, field: str) -> Optional[datetime]:
+    """Parse a stored ISO timestamp string, tolerating a trailing 'Z'.
+
+    Returns None on a malformed value so the caller can drop just that one field instead of
+    letting a single drifted string abort the whole patch. Logs the field name only, never the
+    raw value, which can carry memory text.
+    """
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        logger.warning("Dropping malformed timestamp field %s in long-term memory patch", field)
+        return None
+
+
 def apply_long_term_patch_transaction(
     *, control_state: MemoryControlState, operation: MemoryOperation, patch_payload: Dict[str, Any]
 ) -> ApplyResult:
@@ -427,9 +444,13 @@ def apply_long_term_patch_transaction(
             extra_item_updates[optional_key] = raw.pop(optional_key)
     for timestamp_key in ("last_corroborated_at", "captured_at", "updated_at", "expires_at"):
         if timestamp_key in extra_item_updates and isinstance(extra_item_updates[timestamp_key], str):
-            extra_item_updates[timestamp_key] = datetime.fromisoformat(
-                extra_item_updates[timestamp_key].replace("Z", "+00:00")
-            )
+            coerced = _coerce_iso_timestamp(extra_item_updates[timestamp_key], field=timestamp_key)
+            if coerced is None:
+                # Drop just the malformed field; the item keeps its existing (update path) or
+                # materialized (create path) value instead of the whole patch raising ValueError.
+                extra_item_updates.pop(timestamp_key)
+            else:
+                extra_item_updates[timestamp_key] = coerced
     if (
         "confidence" in extra_item_updates
         and extra_item_updates["confidence"] is not None

--- a/backend/tests/unit/test_memory_apply_timestamp_coerce.py
+++ b/backend/tests/unit/test_memory_apply_timestamp_coerce.py
@@ -1,0 +1,98 @@
+"""Regression: a malformed stored timestamp string must not abort a long-term memory patch.
+
+apply_long_term_patch_transaction coerces four optional timestamp fields
+(last_corroborated_at, captured_at, updated_at, expires_at) from ISO strings via
+datetime.fromisoformat. A single drifted value (a non-ISO string left by an older writer)
+used to raise ValueError and abort the whole patch apply for that item. The guard drops just
+the malformed field, so the item keeps its existing (update path) or materialized (create
+path) value and the patch still commits.
+"""
+
+from datetime import datetime, timezone
+
+from models.memory_apply import (
+    ApplyStatus,
+    MemoryControlState,
+    apply_long_term_patch_transaction,
+    _coerce_iso_timestamp,
+)
+from models.memory_operations import MemoryOperation, MemoryOperationType
+from models.memory_contracts import DurablePatchDecision, LifecycleState
+
+
+def _operation(**overrides):
+    base = dict(
+        uid="u1",
+        operation_type=MemoryOperationType.long_term_apply,
+        source_packet_id="pkt1",
+        target_memory_id=None,
+        evidence_ids=["ev1"],
+        logical_payload={"decision": "add", "memory_text": "User prefers concise updates.", "result_status": "active"},
+        account_generation=1,
+        source_generation=2,
+        observed_head_commit_id="head0",
+    )
+    base.update(overrides)
+    return MemoryOperation.new(**base)
+
+
+def _patch(**overrides):
+    payload = dict(
+        patch_id="patch1",
+        packet_id="pkt1",
+        run_id="run1",
+        observed_head_commit_id="head0",
+        idempotency_key="idem1",
+        decision=DurablePatchDecision.add,
+        result_status=LifecycleState.active,
+        evidence_ids=["ev1"],
+        memory_text="User prefers concise updates.",
+        confidence="medium",
+        relationship_to_user="self",
+        subject_entity_id="user",
+        subject_label="the user",
+        aboutness="primary_user",
+    )
+    payload.update(overrides)
+    return payload
+
+
+def _control():
+    return MemoryControlState(uid="u1", head_commit_id="head0", account_generation=1, source_generation=2)
+
+
+def test_coerce_iso_timestamp_parses_valid_z_suffix():
+    parsed = _coerce_iso_timestamp("2026-07-14T12:00:00Z", field="updated_at")
+    assert parsed == datetime(2026, 7, 14, 12, 0, tzinfo=timezone.utc)
+
+
+def test_coerce_iso_timestamp_returns_none_on_malformed():
+    assert _coerce_iso_timestamp("not-a-timestamp", field="captured_at") is None
+
+
+def test_malformed_timestamp_field_is_dropped_and_patch_still_commits():
+    # Before the guard, a non-ISO captured_at raised ValueError out of the whole apply.
+    result = apply_long_term_patch_transaction(
+        control_state=_control(),
+        operation=_operation(),
+        patch_payload=_patch(captured_at="not-a-timestamp"),
+    )
+
+    assert result.status == ApplyStatus.committed
+    committed = result.memory_items[0]
+    # The malformed value was dropped; the item kept its materialized captured_at (a real datetime).
+    assert isinstance(committed.captured_at, datetime)
+    assert committed.captured_at != "not-a-timestamp"
+
+
+def test_valid_timestamp_overrides_are_applied():
+    result = apply_long_term_patch_transaction(
+        control_state=_control(),
+        operation=_operation(),
+        patch_payload=_patch(captured_at="2026-07-14T00:00:00Z", updated_at="2026-07-14T01:00:00Z"),
+    )
+
+    assert result.status == ApplyStatus.committed
+    committed = result.memory_items[0]
+    assert committed.captured_at == datetime(2026, 7, 14, 0, 0, tzinfo=timezone.utc)
+    assert committed.updated_at == datetime(2026, 7, 14, 1, 0, tzinfo=timezone.utc)


### PR DESCRIPTION
## What

`apply_long_term_patch_transaction` (models/memory_apply.py) pulls four optional timestamp fields off the patch and coerces them from stored ISO strings:

```python
for timestamp_key in ("last_corroborated_at", "captured_at", "updated_at", "expires_at"):
    if timestamp_key in extra_item_updates and isinstance(extra_item_updates[timestamp_key], str):
        extra_item_updates[timestamp_key] = datetime.fromisoformat(
            extra_item_updates[timestamp_key].replace("Z", "+00:00")
        )
```

`datetime.fromisoformat` raises `ValueError` on any non-ISO string. A single drifted value (a legacy or hand-edited stored timestamp, a format left behind by an older writer) aborts the entire patch apply for that memory item. This runs in the background memory-maintenance path, so the failure is a stuck item rather than an HTTP 500, but the whole patch is lost either way.

## Fix

Extract a small helper that returns `None` on `ValueError`, and drop the one malformed field instead of coercing it:

```python
def _coerce_iso_timestamp(value: str, *, field: str) -> Optional[datetime]:
    try:
        return datetime.fromisoformat(value.replace("Z", "+00:00"))
    except ValueError:
        logger.warning("Dropping malformed timestamp field %s in long-term memory patch", field)
        return None
```

```python
coerced = _coerce_iso_timestamp(extra_item_updates[timestamp_key], field=timestamp_key)
if coerced is None:
    extra_item_updates.pop(timestamp_key)
else:
    extra_item_updates[timestamp_key] = coerced
```

Dropping (rather than writing `None`) means the item keeps its prior value in both consumers:

- update path: `_apply_update_memory_item` does `updates.update(extra_updates)` then `existing.model_copy(update=updates)`, so a dropped key leaves the existing item's value untouched
- create path: `MemoryItem(**{**memory_item.dict(), **extra_item_updates})`, so a dropped key keeps the materialized value

The except is narrow (`ValueError` only). The log names the field only, never the raw value, since a stored memory timestamp field can carry private text if the data is malformed in an unexpected way.

## Close the failure class

This is the last unguarded `datetime.fromisoformat` on stored input in `models/memory_apply.py` (one site). The same class in the task-integration due-date path was already guarded; two other model deserializers (`models/app.py`, `models/calendar_mutation.py`) parse stored timestamps and are separately scoped, not touched here to keep this fix confined to one file.

## Tests

New `tests/unit/test_memory_apply_timestamp_coerce.py` (imports the light models module directly, no stubbing):

- the helper parses a valid `Z` suffix to an aware datetime, and returns `None` on a malformed string
- a malformed `captured_at` is dropped and the patch still commits (before the guard this raised `ValueError` out of the whole apply); the committed item keeps its materialized datetime
- valid `captured_at` and `updated_at` overrides are still applied as aware datetimes

## Verification

```
cd backend && ENCRYPTION_SECRET=... python -m pytest tests/unit/test_memory_apply_timestamp_coerce.py -q
  -> 4 passed
black --line-length 120 --skip-string-normalization --check models/memory_apply.py tests/unit/test_memory_apply_timestamp_coerce.py
  -> unchanged
python -m pyright -p pyrightconfig.json models/memory_apply.py
  -> 0 errors
python scripts/check_module_stub_pollution.py
  -> Checked 638 test file(s); 0 violations
```

## Product invariants affected

none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9703?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

