### PR TITLE
fix(backend): give inline listen finalization a terminal failure state

### DIFF
--- a/backend/database/conversation_finalization_jobs.py
+++ b/backend/database/conversation_finalization_jobs.py
@@ -37,6 +37,7 @@ class FinalizationClaim(TypedDict):
 
     status: str
     lease_epoch: int | None
+    attempt_count: int
 
 
 def _now() -> datetime:
@@ -52,8 +53,8 @@ def get_finalization_reconcile_stale_after() -> timedelta:
     return timedelta(seconds=max(30, seconds))
 
 
-def _claim_result(status: str, lease_epoch: int | None = None) -> FinalizationClaim:
-    return {'status': status, 'lease_epoch': lease_epoch}
+def _claim_result(status: str, lease_epoch: int | None = None, attempt_count: int = 0) -> FinalizationClaim:
+    return {'status': status, 'lease_epoch': lease_epoch, 'attempt_count': attempt_count}
 
 
 def _is_current_lease(job: dict[str, Any], dispatch_generation: int, lease_epoch: int) -> bool:
@@ -251,6 +252,7 @@ def _claim_finalization_job_txn(
 
     lease_epoch = int(job.get('lease_epoch') or 0) + 1
     lease_expires_at = now + timedelta(seconds=lease_seconds)
+    attempt_count = int(job.get('attempt_count') or 0) + 1
 
     transaction.update(
         job_ref,
@@ -263,10 +265,12 @@ def _claim_finalization_job_txn(
             'lease_epoch': lease_epoch,
             'reconcile_after_at': (firestore.DELETE_FIELD if bool(job.get('requires_byok')) else lease_expires_at),
             'updated_at': now,
-            'attempt_count': int(job.get('attempt_count') or 0) + 1,
+            # The claimer owns the attempt budget: an inline (pusher) worker has
+            # no Cloud Tasks retry count to fence its terminal attempt with.
+            'attempt_count': attempt_count,
         },
     )
-    return _claim_result('claimed', lease_epoch)
+    return _claim_result('claimed', lease_epoch, attempt_count)
 
 
 def claim_finalization_job(

--- a/backend/routers/pusher.py
+++ b/backend/routers/pusher.py
@@ -12,6 +12,8 @@ from starlette.websockets import WebSocketState
 import database.conversations as conversations_db
 from database import conversation_finalization_jobs as finalization_jobs_db
 from database import users as users_db
+from models.conversation_enums import ConversationStatus
+from services.conversation_finalization import final_attempt_failed
 from utils.apps import is_audio_bytes_app_enabled
 from utils.app_integrations import (
     trigger_realtime_integrations,
@@ -31,7 +33,7 @@ from utils.webhooks import (
     realtime_transcript_webhook,
     get_audio_bytes_webhook_seconds,
 )
-from utils.cloud_tasks import is_audio_merge_dispatch_enabled
+from utils.cloud_tasks import get_listen_finalization_tasks_max_attempts, is_audio_merge_dispatch_enabled
 from utils.other.storage import maybe_invalidate_conversation_playback, upload_audio_chunks_batch
 from utils.metrics import PUSHER_ACTIVE_WS_CONNECTIONS
 from utils.speaker_identification import extract_speaker_samples
@@ -127,11 +129,38 @@ async def _process_conversation_task(
     job_id: Optional[str] = None
     generation: Optional[int] = None
     lease_epoch: Optional[int] = None
+    attempt_count: int = 0
 
-    async def mark_retryable(failure_code: str) -> None:
+    async def record_failure(failure_code: str) -> bool:
+        """Release the lease. Returns whether this was the terminal attempt.
+
+        Inline dispatch has no Cloud Tasks worker to exhaust the attempt budget,
+        so the claimed attempt count is the only bound on a deterministically
+        failing job. Without a terminal state the conversation would stay
+        `processing` forever and be re-finalized by every later session.
+        """
         if job_id is None or generation is None or lease_epoch is None:
-            return
+            return False
+        terminal = attempt_count >= get_listen_finalization_tasks_max_attempts()
         try:
+            if terminal:
+                await run_blocking(
+                    db_executor,
+                    final_attempt_failed,
+                    job_id,
+                    generation,
+                    lease_epoch,
+                    attempt_count,
+                )
+                await run_blocking(
+                    db_executor,
+                    conversations_db.update_conversation_status,
+                    uid,
+                    conversation_id,
+                    ConversationStatus.failed,
+                )
+                await run_blocking(db_executor, conversations_db.set_conversation_as_discarded, uid, conversation_id)
+                return True
             await run_blocking(
                 db_executor,
                 finalization_jobs_db.mark_finalization_retryable,
@@ -142,11 +171,14 @@ async def _process_conversation_task(
             )
         except Exception:
             logger.error(
-                'pusher finalization recovery update failed uid=%s conversation=%s failure=%s',
+                'pusher finalization recovery update failed uid=%s conversation=%s failure=%s terminal=%s',
                 uid,
                 conversation_id,
                 failure_code,
+                terminal,
             )
+            return False
+        return False
 
     try:
         if not finalization_job_id or dispatch_generation is None:
@@ -173,8 +205,17 @@ async def _process_conversation_task(
             await send_result({'conversation_id': conversation_id, 'success': True})
             return
         if claim_status != 'claimed':
-            await send_result({'conversation_id': conversation_id, 'error': f'job_{claim_status}'})
+            await send_result(
+                {
+                    'conversation_id': conversation_id,
+                    'error': f'job_{claim_status}',
+                    # A dead-lettered job is never actionable again; telling the
+                    # live session it is terminal stops it from re-requesting.
+                    'terminal': claim_status in finalization_jobs_db.TERMINAL_JOB_STATUSES,
+                }
+            )
             return
+        attempt_count = claim['attempt_count']
         lease_epoch = claim['lease_epoch']
         if lease_epoch is None:
             logger.error(
@@ -197,21 +238,27 @@ async def _process_conversation_task(
             return
         await send_result({'conversation_id': conversation_id, 'success': True})
     except ConversationFinalizationError:
-        await mark_retryable('processing_failed')
+        terminal = await record_failure('processing_failed')
         logger.error(
-            'pusher finalization failed uid=%s conversation=%s failure=processing_failed', uid, conversation_id
+            'pusher finalization failed uid=%s conversation=%s failure=processing_failed terminal=%s',
+            uid,
+            conversation_id,
+            terminal,
         )
         try:
-            await send_result({'conversation_id': conversation_id, 'error': 'processing_failed'})
+            await send_result({'conversation_id': conversation_id, 'error': 'processing_failed', 'terminal': terminal})
         except Exception:
             pass
     except Exception:
-        await mark_retryable('worker_failed')
+        terminal = await record_failure('worker_failed')
         logger.error(
-            'pusher finalization task failed uid=%s conversation=%s failure=worker_failed', uid, conversation_id
+            'pusher finalization task failed uid=%s conversation=%s failure=worker_failed terminal=%s',
+            uid,
+            conversation_id,
+            terminal,
         )
         try:
-            await send_result({'conversation_id': conversation_id, 'error': 'processing_failed'})
+            await send_result({'conversation_id': conversation_id, 'error': 'processing_failed', 'terminal': terminal})
         except Exception:
             pass
 

--- a/backend/tests/unit/test_conversation_finalization_jobs.py
+++ b/backend/tests/unit/test_conversation_finalization_jobs.py
@@ -141,7 +141,7 @@ def test_duplicate_task_delivery_claims_only_once_until_lease_expires():
     first = _Transaction()
 
     claim = jobs._claim_finalization_job_txn(first, ref, 2, False, 1500, now)
-    assert claim == {'status': 'claimed', 'lease_epoch': 1}
+    assert claim == {'status': 'claimed', 'lease_epoch': 1, 'attempt_count': 1}
     claim_update = first.updates[0][1]
     assert claim_update['status'] == 'leased'
     assert claim_update['attempt_count'] == 1
@@ -151,6 +151,7 @@ def test_duplicate_task_delivery_claims_only_once_until_lease_expires():
     assert jobs._claim_finalization_job_txn(duplicate, ref, 2, False, 1500, now + timedelta(seconds=1)) == {
         'status': 'leased',
         'lease_epoch': None,
+        'attempt_count': 0,
     }
     assert duplicate.updates == []
 
@@ -169,7 +170,7 @@ def test_expired_worker_lease_can_be_safely_reclaimed():
     transaction = _Transaction()
 
     claim = jobs._claim_finalization_job_txn(transaction, ref, 2, False, 1500, now)
-    assert claim == {'status': 'claimed', 'lease_epoch': 1}
+    assert claim == {'status': 'claimed', 'lease_epoch': 1, 'attempt_count': 2}
     assert transaction.updates[0][1]['attempt_count'] == 2
     assert transaction.updates[0][1]['lease_epoch'] == 1
 
@@ -197,7 +198,7 @@ def test_live_pusher_claim_cannot_use_another_conversations_job():
         expected_conversation_id='other-conversation',
     )
 
-    assert status == {'status': 'identity_mismatch', 'lease_epoch': None}
+    assert status == {'status': 'identity_mismatch', 'lease_epoch': None, 'attempt_count': 0}
     assert transaction.updates == []
 
 
@@ -208,6 +209,7 @@ def test_completed_and_dead_letter_jobs_never_execute_again():
         assert jobs._claim_finalization_job_txn(transaction, ref, 1, False, 1500, _now()) == {
             'status': status,
             'lease_epoch': None,
+            'attempt_count': 0,
         }
         assert transaction.updates == []
 
@@ -246,7 +248,7 @@ def test_expired_lease_reclaim_fences_a_stale_worker_terminal_write():
 
     reclaim = _Transaction()
     new_claim = jobs._claim_finalization_job_txn(reclaim, ref, 3, False, 1500, now)
-    assert new_claim == {'status': 'claimed', 'lease_epoch': 5}
+    assert new_claim == {'status': 'claimed', 'lease_epoch': 5, 'attempt_count': 1}
     ref.data = ref.data | reclaim.updates[0][1]
 
     stale_completion = _Transaction()

--- a/backend/tests/unit/test_listen_finalization_cloud_tasks.py
+++ b/backend/tests/unit/test_listen_finalization_cloud_tasks.py
@@ -250,7 +250,7 @@ async def test_pusher_rejects_legacy_finalization_without_a_durable_job():
 @pytest.mark.anyio
 async def test_pusher_claims_the_durable_job_before_finalizing(monkeypatch):
     websocket = _PusherWebSocket()
-    claim = MagicMock(return_value={'status': 'claimed', 'lease_epoch': 7})
+    claim = MagicMock(return_value={'status': 'claimed', 'lease_epoch': 7, 'attempt_count': 1})
     completed = MagicMock(return_value=True)
     finalizer = AsyncMock()
     monkeypatch.setattr(pusher_router, 'run_blocking', _inline_run_blocking)
@@ -280,9 +280,12 @@ async def test_pusher_requeues_an_unexpected_failure_after_claim(monkeypatch):
     retryable = MagicMock(return_value=True)
     monkeypatch.setattr(pusher_router, 'run_blocking', _inline_run_blocking)
     monkeypatch.setattr(
-        jobs_db, 'claim_finalization_job', lambda *args, **kwargs: {'status': 'claimed', 'lease_epoch': 4}
+        jobs_db,
+        'claim_finalization_job',
+        lambda *args, **kwargs: {'status': 'claimed', 'lease_epoch': 4, 'attempt_count': 1},
     )
     monkeypatch.setattr(jobs_db, 'mark_finalization_retryable', retryable)
+    monkeypatch.setattr(pusher_router, 'get_listen_finalization_tasks_max_attempts', lambda: 5)
     monkeypatch.setattr(
         pusher_router, 'finalize_persisted_conversation', AsyncMock(side_effect=RuntimeError('raw transcript'))
     )
@@ -292,7 +295,76 @@ async def test_pusher_requeues_an_unexpected_failure_after_claim(monkeypatch):
     )
 
     retryable.assert_called_once_with('job-1', 3, 4, 'worker_failed')
-    assert json.loads(websocket.sent[0][4:]) == {'conversation_id': 'conversation-1', 'error': 'processing_failed'}
+    assert json.loads(websocket.sent[0][4:]) == {
+        'conversation_id': 'conversation-1',
+        'error': 'processing_failed',
+        'terminal': False,
+    }
+
+
+@pytest.mark.anyio
+async def test_pusher_dead_letters_a_job_that_exhausted_its_attempt_budget(monkeypatch):
+    """Inline dispatch owns the attempt budget: no Cloud Tasks worker will ever exhaust it.
+
+    Without this the conversation stays `processing` forever and every later
+    listen session re-runs the same failing LLM finalization.
+    """
+    websocket = _PusherWebSocket()
+    retryable = MagicMock(return_value=True)
+    dead_letter = MagicMock(return_value=True)
+    status_update = MagicMock()
+    discard = MagicMock()
+    monkeypatch.setattr(pusher_router, 'run_blocking', _inline_run_blocking)
+    monkeypatch.setattr(
+        jobs_db,
+        'claim_finalization_job',
+        lambda *args, **kwargs: {'status': 'claimed', 'lease_epoch': 4, 'attempt_count': 5},
+    )
+    monkeypatch.setattr(jobs_db, 'mark_finalization_retryable', retryable)
+    monkeypatch.setattr(jobs_db, 'mark_finalization_dead_letter', dead_letter)
+    monkeypatch.setattr(pusher_router, 'get_listen_finalization_tasks_max_attempts', lambda: 5)
+    monkeypatch.setattr(pusher_router.conversations_db, 'update_conversation_status', status_update)
+    monkeypatch.setattr(pusher_router.conversations_db, 'set_conversation_as_discarded', discard)
+    monkeypatch.setattr(
+        pusher_router,
+        'finalize_persisted_conversation',
+        AsyncMock(side_effect=ConversationFinalizationError('processing_failed')),
+    )
+
+    await pusher_router._process_conversation_task(
+        'uid-1', 'conversation-1', 'en', websocket, finalization_job_id='job-1', dispatch_generation=3
+    )
+
+    dead_letter.assert_called_once_with('job-1', 3, 4, 5, firestore_client=None)
+    retryable.assert_not_called()
+    status_update.assert_called_once_with('uid-1', 'conversation-1', ConversationStatus.failed)
+    discard.assert_called_once_with('uid-1', 'conversation-1')
+    assert json.loads(websocket.sent[0][4:]) == {
+        'conversation_id': 'conversation-1',
+        'error': 'processing_failed',
+        'terminal': True,
+    }
+
+
+@pytest.mark.anyio
+async def test_pusher_tells_the_live_session_a_dead_lettered_job_is_terminal(monkeypatch):
+    websocket = _PusherWebSocket()
+    monkeypatch.setattr(pusher_router, 'run_blocking', _inline_run_blocking)
+    monkeypatch.setattr(
+        jobs_db,
+        'claim_finalization_job',
+        lambda *args, **kwargs: {'status': 'dead_letter', 'lease_epoch': None, 'attempt_count': 0},
+    )
+
+    await pusher_router._process_conversation_task(
+        'uid-1', 'conversation-1', 'en', websocket, finalization_job_id='job-1', dispatch_generation=3
+    )
+
+    assert json.loads(websocket.sent[0][4:]) == {
+        'conversation_id': 'conversation-1',
+        'error': 'job_dead_letter',
+        'terminal': True,
+    }
 
 
 @pytest.mark.anyio

--- a/backend/tests/unit/utils/test_listen_pusher_session.py
+++ b/backend/tests/unit/utils/test_listen_pusher_session.py
@@ -46,8 +46,10 @@ def response_201(conversation_id: str, success=True):
     return struct.pack("<I", 201) + payload
 
 
-def error_response_201(conversation_id: str):
-    payload = json.dumps({"conversation_id": conversation_id, "error": "processing_failed"}).encode("utf-8")
+def error_response_201(conversation_id: str, terminal: bool = False):
+    payload = json.dumps(
+        {"conversation_id": conversation_id, "error": "processing_failed", "terminal": terminal}
+    ).encode("utf-8")
     return struct.pack("<I", 201) + payload
 
 
@@ -266,6 +268,24 @@ async def test_incoming_finalization_error_keeps_request_for_bounded_retry():
     finalization_frames = [frame for frame in ws.sent if frame_type(frame) == 104]
     assert len(finalization_frames) == 2
     assert session.pending_conversation_requests['conv-1']['retries'] == 1
+
+
+@pytest.mark.anyio
+async def test_incoming_terminal_finalization_error_stops_retrying():
+    active_ref = {"active": True}
+    ws = FakePusherWebSocket(incoming=[error_response_201("conv-1", terminal=True)])
+    ws.on_recv = lambda: active_ref.update(active=False)
+    session = make_session(ws=ws, active_ref=active_ref)
+    await session.connect()
+    await session.request_conversation_processing("conv-1", "job-1", 2)
+
+    await session.pusher_receive()
+
+    # A dead-lettered job can never succeed: re-requesting it would retry the
+    # same failing finalization for the whole life of the session.
+    assert session.pending_conversation_requests == {}
+    finalization_frames = [frame for frame in ws.sent if frame_type(frame) == 104]
+    assert len(finalization_frames) == 1
 
 
 @pytest.mark.anyio

--- a/backend/utils/listen_pusher_session.py
+++ b/backend/utils/listen_pusher_session.py
@@ -286,13 +286,21 @@ class ListenPusherSession:
                     conversation_id = result.get("conversation_id")
 
                     if "error" in result:
-                        pending = self.pending_conversation_requests.get(conversation_id)
-                        if pending is not None:
-                            # The pusher has released its durable lease back to
-                            # queued. Keep the request so this live session can
-                            # reclaim it instead of stranding `processing`.
-                            pending['sent_at'] = self.deps.now() - PENDING_REQUEST_TIMEOUT - 1
-                        logger.error(f"Conversation processing failed: {self.uid} {self.session_id}")
+                        if result.get("terminal"):
+                            # The job reached its attempt budget and is now
+                            # dead-lettered. Retrying it would never converge.
+                            self.pending_conversation_requests.pop(conversation_id, None)
+                            logger.error(
+                                f"Conversation processing failed terminally: {conversation_id} {self.uid} {self.session_id}"
+                            )
+                        else:
+                            pending = self.pending_conversation_requests.get(conversation_id)
+                            if pending is not None:
+                                # The pusher has released its durable lease back to
+                                # queued. Keep the request so this live session can
+                                # reclaim it instead of stranding `processing`.
+                                pending['sent_at'] = self.deps.now() - PENDING_REQUEST_TIMEOUT - 1
+                            logger.error(f"Conversation processing failed: {self.uid} {self.session_id}")
                     elif result.get("success"):
                         self.pending_conversation_requests.pop(conversation_id, None)
                         logger.info(f"Conversation processed by pusher: {conversation_id} {self.uid} {self.session_id}")


### PR DESCRIPTION
## Bug (live on prod)

A conversation whose finalization fails deterministically (LLM refusal, malformed/oversized transcript, a bad segment) **never resolves**. It stays `status=processing` forever — a permanently spinning conversation in the UI — and its full LLM post-processing is re-run indefinitely.

## Root cause

Prod runs `LISTEN_FINALIZATION_DISPATCH_MODE=inline` — the default in `utils/cloud_tasks.py:83`, and the var is set nowhere in `backend/deploy/`, `backend/charts/`, or `.github/workflows/`. So every finalization goes through the **pusher WebSocket path**, never the Cloud Tasks worker.

Two recent commits compose into an unbounded retry loop on that path:

- `2d67863cad` ("make listen finalization durable") deleted pusher's terminal fallback (`set_conversation_as_discarded` on `process_conversation` failure) and replaced it with `mark_finalization_retryable` → job back to `queued`. But the only other terminal writer, `mark_finalization_dead_letter`, is reachable **only** from the Cloud Tasks router, and `reconcile_listen_finalization_jobs()` early-returns in inline mode (`services/conversation_finalization.py:101`).
- `fafee4505e` ("fence listen finalization retries") then removed the last bound in the live session's retry loop (`utils/listen_pusher_session.py:329-338` resets `retries = 0` after each burst) and kept the pending request on error instead of popping it.

Net effect, with no state transition out of `queued` other than success:
1. the conversation stays `processing` forever (`_create_or_get_finalization_intent_txn` set it; nothing moves it off);
2. the live session re-requests it in 3-attempt bursts every 300s for the life of the session;
3. `cleanup_processing_conversations()` re-schedules it at the start of every later session (`routers/transcribe.py:912-925`).

Each retry is a full LLM post-processing run — so this is a stuck-UI bug *and* a cost/retry storm.

## Fix (the claimer owns the attempt budget)

- `claim_finalization_job` now returns `attempt_count` alongside `lease_epoch` (it was already incremented on claim — inline dispatch just had no way to read it).
- `routers/pusher.py` dead-letters the job once `attempt_count` reaches `get_listen_finalization_tasks_max_attempts()` — the same bound the Cloud Tasks worker enforces — via the existing `final_attempt_failed`, then resolves the conversation to `failed` + discarded so it leaves the `processing` sweep. Retryable failures below the budget behave exactly as before.
- The failure frame carries `terminal: true`, and `listen_pusher_session` pops the pending request on it, so the live session stops re-requesting a job that can never succeed. A claim that returns an already-`dead_letter` job is reported terminal too.

`processing → failed` is an existing legal lifecycle transition (`test_conversation_lifecycle_contract`).

## Regression tests

- `test_pusher_dead_letters_a_job_that_exhausted_its_attempt_budget` — terminal attempt dead-letters the job, marks the conversation `failed` + discarded, never calls `mark_finalization_retryable`.
- `test_pusher_tells_the_live_session_a_dead_lettered_job_is_terminal`.
- `test_incoming_terminal_finalization_error_stops_retrying` — the live session drops the pending request instead of re-requesting.

## Verification

- `pytest` on the finalization/pusher/listen suites: **279 passed** (`test_listen_finalization_cloud_tasks`, `test_conversation_finalization_jobs`, `test_conversation_lifecycle_contract`, `test_listen_pusher_session`, `test_listen_pipeline`, `test_listen_fallback_removal`, `test_transcribe_teardown_flush`, `test_pusher_*`).
- `scan_import_time_side_effects.py`, `check_module_stub_pollution.py`, `check_isinstance_return_ratchet.py`, `scan_async_blockers.py` — all clean.
- **UNVERIFIED** end-to-end: I did not reproduce a real deterministic finalization failure against a live conversation; the terminal path is covered by hermetic tests only.

🤖 automated by hourly watchdog.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9704?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

