### PR TITLE
Guard recurrence handoff against a malformed task workflow control doc

### DIFF
--- a/backend/database/recurrence_inbox.py
+++ b/backend/database/recurrence_inbox.py
@@ -1,11 +1,13 @@
 """Durable workflow-owned handoff for canonical recurrence signals."""
 
 import hashlib
+import logging
 from datetime import datetime, timezone
 from typing import Any
 
 from google.cloud import firestore
 from google.cloud.firestore_v1.base_query import FieldFilter
+from pydantic import ValidationError
 
 from database._client import db as default_db
 from models.memory_recurrence import CanonicalRecurrenceSignal
@@ -15,6 +17,8 @@ from models.workstream_association import (
     RecurrenceOutcomeKind,
 )
 from models.task_intelligence import TaskWorkflowControl, TaskWorkflowMode
+
+logger = logging.getLogger(__name__)
 
 RECURRENCE_INBOX_COLLECTION = 'task_recurrence_inbox'
 TASK_INTELLIGENCE_CONTROL_COLLECTION = 'task_intelligence_control'
@@ -55,7 +59,20 @@ def _control_ref(uid: str, *, firestore_client: Any = None):
 
 
 def _validate_generation(snapshot: Any, account_generation: int) -> None:
-    control = TaskWorkflowControl.model_validate(snapshot.to_dict() or {}) if snapshot.exists else TaskWorkflowControl()
+    try:
+        control = (
+            TaskWorkflowControl.model_validate(snapshot.to_dict() or {}) if snapshot.exists else TaskWorkflowControl()
+        )
+    except ValidationError as e:
+        # A drifted control doc (extra='forbid' plus a renamed/removed field, a bad enum) must not crash the
+        # recurrence handoff. Fall back to the legacy-safe default (workflow_mode=off, account_generation=0),
+        # which fails the checks below, so a malformed control is treated as a generation mismatch (fail-closed)
+        # rather than raising ValidationError. Log bounded error types only, never input_value (task text).
+        logger.warning(
+            'Ignoring malformed task workflow control in recurrence inbox: %s',
+            [str(err.get('type', 'unknown')) for err in e.errors(include_input=False, include_url=False)[:5]],
+        )
+        control = TaskWorkflowControl()
     if control.account_generation != account_generation:
         raise RecurrenceGenerationMismatchError('account generation mismatch')
     if control.workflow_mode not in {TaskWorkflowMode.write, TaskWorkflowMode.read}:

--- a/backend/tests/unit/test_recurrence_inbox_control_skip_malformed.py
+++ b/backend/tests/unit/test_recurrence_inbox_control_skip_malformed.py
@@ -1,0 +1,53 @@
+"""Regression: a malformed task_intelligence_control doc must not crash the recurrence handoff.
+
+recurrence_inbox._validate_generation loads the per-user control doc with
+TaskWorkflowControl.model_validate. The model is extra='forbid', so a drifted document raised
+ValidationError straight out of the recurrence enqueue/transaction paths. The guard falls back to
+the legacy-safe default, which fails the generation/mode checks, so a malformed control is treated
+as a RecurrenceGenerationMismatchError (an outcome callers already handle) rather than crashing.
+"""
+
+import pytest
+
+import database.recurrence_inbox as recurrence_inbox_db
+from database.recurrence_inbox import _validate_generation, RecurrenceGenerationMismatchError
+
+
+class _FakeSnapshot:
+    def __init__(self, *, exists, data):
+        self.exists = exists
+        self._data = data
+
+    def to_dict(self):
+        return self._data
+
+
+def test_malformed_control_is_treated_as_generation_mismatch():
+    # extra='forbid': an unknown persisted field fails to load with ValidationError.
+    snapshot = _FakeSnapshot(
+        exists=True,
+        data={'workflow_mode': 'write', 'account_generation': 1, 'legacy_extra': True},
+    )
+
+    # Falls back to the default (account_generation=0), so it fails the generation check -- a handled
+    # mismatch, not a ValidationError bubbling out of the recurrence handoff.
+    with pytest.raises(RecurrenceGenerationMismatchError):
+        _validate_generation(snapshot, account_generation=1)
+
+
+def test_valid_matching_control_passes():
+    snapshot = _FakeSnapshot(exists=True, data={'workflow_mode': 'write', 'account_generation': 1})
+    assert _validate_generation(snapshot, account_generation=1) is None
+
+
+def test_unexpected_error_propagates(monkeypatch):
+    snapshot = _FakeSnapshot(exists=True, data={'workflow_mode': 'write', 'account_generation': 1})
+
+    def _boom(*_args, **_kwargs):
+        raise RuntimeError('unexpected non-validation failure')
+
+    # The guard catches only ValidationError; anything else must still surface.
+    monkeypatch.setattr(recurrence_inbox_db.TaskWorkflowControl, 'model_validate', _boom)
+
+    with pytest.raises(RuntimeError, match='unexpected non-validation failure'):
+        _validate_generation(snapshot, account_generation=1)


### PR DESCRIPTION
## What

`recurrence_inbox._validate_generation` reads the per-user `task_intelligence_control/state` doc and validates it before every recurrence handoff:

```python
def _validate_generation(snapshot: Any, account_generation: int) -> None:
    control = TaskWorkflowControl.model_validate(snapshot.to_dict() or {}) if snapshot.exists else TaskWorkflowControl()
    if control.account_generation != account_generation:
        raise RecurrenceGenerationMismatchError('account generation mismatch')
    if control.workflow_mode not in {TaskWorkflowMode.write, TaskWorkflowMode.read}:
        raise RecurrenceGenerationMismatchError('task workflow mode changed')
```

`TaskWorkflowControl` is `model_config = ConfigDict(extra='forbid', ...)`, so any drift in the stored control doc (a removed or renamed field, a bad enum value) fails to load with `ValidationError`. This function is called from `enqueue_recurrence_signal` and the two recurrence transactions, so a single corrupt control document raises `ValidationError` out of the recurrence handoff instead of the modeled mismatch outcome.

## Fix

Fall back to the model default on `ValidationError`:

```python
try:
    control = (
        TaskWorkflowControl.model_validate(snapshot.to_dict() or {}) if snapshot.exists else TaskWorkflowControl()
    )
except ValidationError as e:
    logger.warning(
        'Ignoring malformed task workflow control in recurrence inbox: %s',
        [str(err.get('type', 'unknown')) for err in e.errors(include_input=False, include_url=False)[:5]],
    )
    control = TaskWorkflowControl()
```

The default is legacy-safe by construction (`workflow_mode=off`, `account_generation=0`). It fails both checks below, so a malformed control raises `RecurrenceGenerationMismatchError` (`account_generation=0` will not match a real generation; `off` is not in `{write, read}`). That error is already a handled outcome for callers (`utils/task_intelligence/workstream_association.py` catches it), so a corrupt control is treated as a stale generation and the operation is safely skipped rather than crashing.

The catch is narrow (`ValidationError`), so an unexpected failure still surfaces. The log keeps only bounded pydantic error type strings, not `input_value`, since a rendered pydantic error can contain private task text.

## Tests

New `tests/unit/test_recurrence_inbox_control_skip_malformed.py`, driving `_validate_generation` with a fake snapshot (no db needed):

- a malformed doc (extra forbidden field) raises the handled `RecurrenceGenerationMismatchError`, not `ValidationError`
- a valid matching control passes
- an unexpected non-`ValidationError` still propagates

## Verification

```
cd backend && ENCRYPTION_SECRET=... python -m pytest tests/unit/test_recurrence_inbox_control_skip_malformed.py -q
  -> 3 passed
black --line-length 120 --skip-string-normalization --check database/recurrence_inbox.py tests/unit/test_recurrence_inbox_control_skip_malformed.py
  -> unchanged
python -m pyright -p pyrightconfig.json database/recurrence_inbox.py
  -> 0 errors
python scripts/check_module_stub_pollution.py
  -> Checked 638 test file(s); 0 violations
```

## Related

Same `TaskWorkflowControl.model_validate` guard as #9702, applied at a different call site (`get_task_workflow_control` there vs `recurrence_inbox._validate_generation` here). A shared parse helper is the eventual close-the-class consolidation across the several call sites that validate this control doc (`get_task_workflow_control`, `recurrence_inbox._validate_generation`, `candidates.py` `_validate_write_control`/`_validate_generation`, `task_recommendations.py` `_validate_generation`); it is deferred here to keep each guard independently reviewable and avoid textual conflicts across the in-flight PRs #9701/#9702.

## Product invariants affected

none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9705?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

