### PR TITLE
Guard goal storage normalization against malformed legacy metric rows

### DIFF
--- a/backend/database/goals.py
+++ b/backend/database/goals.py
@@ -184,20 +184,47 @@ def _goal_created_at_sort_key(goal: Dict[str, Any]) -> datetime:
     return _coerce_created_at(goal.get('created_at'))
 
 
+def _safe_float(value: Any, default: float) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _safe_int(value: Any, default: int) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
 def _metric_from_storage(data: dict[str, Any]) -> Optional[GoalMetric]:
     metric = data.get('metric')
     if isinstance(metric, dict):
-        return GoalMetric.model_validate(metric)
+        try:
+            return GoalMetric.model_validate(metric)
+        except ValidationError:
+            return None
     if data.get('target_value') is None and data.get('goal_type') is None:
         return None
-    return GoalMetric(
-        type=GoalType(data.get('goal_type', GoalType.scale.value)),
-        current=float(data.get('current_value', 0)),
-        target=float(data.get('target_value', 0)),
-        min=float(data.get('min_value', 0)) if data.get('min_value') is not None else None,
-        max=float(data.get('max_value', 10)) if data.get('max_value') is not None else None,
-        unit=data.get('unit'),
-    )
+    # A drifted legacy row can carry a null/non-numeric current/target/min/max, a bad goal_type, or an
+    # inconsistent min/max pair. Coerce each field defensively (the sibling min/max already None-guard) and
+    # guard goal_type by set membership like status/source below; the ValidationError backstop degrades a
+    # still-inconsistent metric to absent instead of 500ing every goal read.
+    goal_type = data.get('goal_type', GoalType.scale.value)
+    if goal_type not in {member.value for member in GoalType}:
+        goal_type = GoalType.scale.value
+    try:
+        return GoalMetric(
+            type=GoalType(goal_type),
+            current=_safe_float(data.get('current_value'), 0.0),
+            target=_safe_float(data.get('target_value'), 0.0),
+            min=_safe_float(data.get('min_value'), 0.0) if data.get('min_value') is not None else None,
+            max=_safe_float(data.get('max_value'), 10.0) if data.get('max_value') is not None else None,
+            unit=data.get('unit'),
+        )
+    except ValidationError:
+        return None
 
 
 def _metric_aliases(metric: Optional[GoalMetric]) -> dict[str, Any]:
@@ -264,7 +291,7 @@ def normalize_goal_storage(data: dict[str, Any], *, goal_id: Optional[str] = Non
                 if normalized.get('source') in {source.value for source in GoalSource}
                 else GoalSource.imported.value
             ),
-            'latest_progress_sequence': int(normalized.get('latest_progress_sequence', 0)),
+            'latest_progress_sequence': _safe_int(normalized.get('latest_progress_sequence', 0), 0),
             'is_active': status_value not in {GoalStatus.achieved.value, GoalStatus.abandoned.value},
         }
     )

--- a/backend/tests/unit/test_goal_storage_coerce_guard.py
+++ b/backend/tests/unit/test_goal_storage_coerce_guard.py
@@ -1,0 +1,58 @@
+"""Regression: a drifted legacy goal row must not 500 every goal read.
+
+database.goals._metric_from_storage and normalize_goal_storage project stored rows into the
+canonical shape. current/target/latest_progress_sequence were coerced with raw float()/int(),
+and goal_type with a raw GoalType(...), so a null or non-numeric stored value, or a bad enum,
+raised out of every goal read (get_user_goal, get_all_goals, get_goal_by_id, progress writes).
+The guards coerce each field defensively and degrade a still-inconsistent metric to absent.
+"""
+
+from database.goals import _metric_from_storage, _safe_float, _safe_int, normalize_goal_storage
+from models.goal import GoalType
+
+
+def test_safe_float_and_int_fall_back_on_bad_values():
+    assert _safe_float(None, 0.0) == 0.0
+    assert _safe_float('abc', 0.0) == 0.0
+    assert _safe_float('3.5', 0.0) == 3.5
+    assert _safe_int(None, 0) == 0
+    assert _safe_int('3.5', 0) == 0
+    assert _safe_int(4, 0) == 4
+
+
+def test_metric_from_storage_tolerates_malformed_legacy_row():
+    metric = _metric_from_storage(
+        {'goal_type': 'bogus', 'current_value': None, 'target_value': 'abc', 'min_value': 'xyz'}
+    )
+    assert metric is not None
+    assert metric.type is GoalType.scale  # bad enum falls back to the existing default
+    assert metric.current == 0.0
+    assert metric.target == 0.0
+    assert metric.min == 0.0
+
+
+def test_metric_from_storage_preserves_valid_row():
+    metric = _metric_from_storage(
+        {'goal_type': 'numeric', 'current_value': 3, 'target_value': 10, 'min_value': 0, 'max_value': 20, 'unit': 'kg'}
+    )
+    assert metric is not None
+    assert metric.type is GoalType.numeric
+    assert metric.current == 3.0
+    assert metric.target == 10.0
+    assert metric.max == 20.0
+    assert metric.unit == 'kg'
+
+
+def test_metric_from_storage_degrades_inconsistent_bounds_to_none():
+    # min > max trips the model bounds validator; degrade to no metric instead of 500ing.
+    metric = _metric_from_storage({'goal_type': 'scale', 'target_value': 5, 'min_value': 100, 'max_value': 1})
+    assert metric is None
+
+
+def test_normalize_goal_storage_survives_malformed_sequence_and_metric():
+    normalized = normalize_goal_storage(
+        {'goal_type': 'bogus', 'current_value': None, 'target_value': 'abc', 'latest_progress_sequence': '3.5'}
+    )
+    assert normalized['latest_progress_sequence'] == 0
+    assert normalized['metric'] is not None
+    assert normalized['metric']['current'] == 0.0


### PR DESCRIPTION
## What

`database.goals.normalize_goal_storage` projects a stored goal row into the canonical shape. It runs on every goal read (`get_user_goal`, `get_all_goals`, `get_goal_by_id`) and before progress-event writes, and it delegates the metric to `_metric_from_storage`:

```python
return GoalMetric(
    type=GoalType(data.get('goal_type', GoalType.scale.value)),
    current=float(data.get('current_value', 0)),
    target=float(data.get('target_value', 0)),
    min=float(data.get('min_value', 0)) if data.get('min_value') is not None else None,
    max=float(data.get('max_value', 10)) if data.get('max_value') is not None else None,
    unit=data.get('unit'),
)
```

`current`/`target` use a raw `float()`, `goal_type` a raw `GoalType()`, and `latest_progress_sequence` (line 267) a raw `int()`. A drifted legacy row with a null or non-numeric `current_value`/`target_value`/`latest_progress_sequence`, or a `goal_type` that is not a valid enum value, raises `TypeError`/`ValueError` out of the read, so one bad row 500s every goal endpoint for that user.

The tell: `min`/`max` on the very next lines already None-guard (the author knew these stored numbers can be null), but `current`/`target` do not.

## Fix

Add small `_safe_float`/`_safe_int` helpers (try/except returning a default) and apply them to all four metric numbers plus `latest_progress_sequence`. Guard `goal_type` by set membership, exactly like the `status` and `source` fields already do in the same function. Wrap the metric construction in a `ValidationError` backstop so a still-inconsistent metric (a `min > max` pair that trips the model bounds validator, or a malformed nested `metric` dict) degrades to no metric rather than 500ing:

```python
goal_type = data.get('goal_type', GoalType.scale.value)
if goal_type not in {member.value for member in GoalType}:
    goal_type = GoalType.scale.value
try:
    return GoalMetric(
        type=GoalType(goal_type),
        current=_safe_float(data.get('current_value'), 0.0),
        target=_safe_float(data.get('target_value'), 0.0),
        min=_safe_float(data.get('min_value'), 0.0) if data.get('min_value') is not None else None,
        max=_safe_float(data.get('max_value'), 10.0) if data.get('max_value') is not None else None,
        unit=data.get('unit'),
    )
except ValidationError:
    return None
```

Good fields are preserved; only a genuinely bad field is defaulted, and the goal itself always loads.

## Close the failure class

This closes the numeric/enum coercion of stored goal fields in the storage-normalization layer. The response-projection layer (`utils/goals_response.py`) already guards its float fields with a `response_float` helper but still has one raw `int(latest_progress_sequence)`; that sibling gap is addressed in a separate follow-up so each layer is independently reviewable.

## Tests

New `tests/unit/test_goal_storage_coerce_guard.py` (pure functions, no Firestore):

- `_safe_float`/`_safe_int` fall back on `None`/non-numeric and pass valid values through
- a malformed legacy row yields a defaulted metric (bad enum falls back to `scale`, bad numbers to 0.0)
- a valid row is preserved unchanged
- an inconsistent `min > max` pair degrades to no metric instead of raising
- `normalize_goal_storage` survives a malformed `latest_progress_sequence` + metric

## Verification

```
cd backend && ENCRYPTION_SECRET=... python -m pytest tests/unit/test_goal_storage_coerce_guard.py -q
  -> 5 passed
black --line-length 120 --skip-string-normalization --check database/goals.py tests/unit/test_goal_storage_coerce_guard.py
  -> unchanged
python -m pyright -p pyrightconfig.json database/goals.py
  -> 0 errors
python scripts/check_module_stub_pollution.py
  -> Checked 638 test file(s); 0 violations
```

## Product invariants affected

none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9707?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

