### PR TITLE
Coerce the goal response sequence field defensively like its sibling numbers

### DIFF
--- a/backend/tests/unit/test_goals_response_int_guard.py
+++ b/backend/tests/unit/test_goals_response_int_guard.py
@@ -1,0 +1,28 @@
+"""Defense-in-depth: the goal response projection helper must coerce the sequence field like its floats.
+
+utils.goals_response.normalize_goal_response defensively re-coerces every field it projects
+(response_float for the numbers, response_bool for is_active, parse_response_datetime for the dates),
+but latest_progress_sequence used a raw int(). A response_int helper makes the standalone projection
+helper uniformly defensive so a null or non-numeric sequence coerces to the fallback instead of raising.
+"""
+
+from utils.goals_response import normalize_goal_response, response_int
+
+
+def test_response_int_falls_back_on_bad_values():
+    assert response_int(None, 0) == 0
+    assert response_int('3.5', 0) == 0
+    assert response_int(True, 0) == 0
+    assert response_int(4, 0) == 4
+    assert response_int('7', 0) == 7
+    assert response_int(2.9, 0) == 2
+
+
+def test_normalize_goal_response_tolerates_bad_sequence():
+    result = normalize_goal_response({'id': 'g1', 'latest_progress_sequence': None})
+    assert result['latest_progress_sequence'] == 0
+
+
+def test_normalize_goal_response_preserves_valid_sequence():
+    result = normalize_goal_response({'id': 'g1', 'latest_progress_sequence': 5})
+    assert result['latest_progress_sequence'] == 5

--- a/backend/utils/goals_response.py
+++ b/backend/utils/goals_response.py
@@ -39,6 +39,17 @@ def response_bool(value, fallback: bool) -> bool:
     return fallback
 
 
+def response_int(value, fallback: int) -> int:
+    if isinstance(value, bool):
+        return fallback
+    if isinstance(value, int):
+        return value
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return fallback
+
+
 def normalize_goal_response(goal: dict) -> dict:
     normalized = dict(goal)
     now = datetime.now(timezone.utc)
@@ -74,7 +85,7 @@ def normalize_goal_response(goal: dict) -> dict:
     normalized['min_value'] = response_float(normalized.get('min_value'), 0)
     normalized['max_value'] = response_float(normalized.get('max_value'), 10)
     normalized['is_active'] = status not in {'achieved', 'abandoned'}
-    normalized['latest_progress_sequence'] = int(normalized.get('latest_progress_sequence', 0))
+    normalized['latest_progress_sequence'] = response_int(normalized.get('latest_progress_sequence'), 0)
     normalized['created_at'] = created_at
     normalized['updated_at'] = updated_at
     return normalized


### PR DESCRIPTION
## What

`utils.goals_response.normalize_goal_response` is a standalone projection helper that defensively re-coerces every field it returns so a drifted value never breaks a response:

```python
normalized['target_value'] = response_float(normalized.get('target_value'), 0)
normalized['current_value'] = response_float(normalized.get('current_value'), 0)
...
normalized['is_active'] = status not in {'achieved', 'abandoned'}
normalized['latest_progress_sequence'] = int(normalized.get('latest_progress_sequence', 0))
```

Every numeric field uses `response_float`, the boolean uses `response_bool`, and the timestamps use `parse_response_datetime`. `latest_progress_sequence` was the one field still using a raw `int()`, which raises `TypeError`/`ValueError` on a `None` or non-numeric input while every neighbor tolerates it.

## Fix

Add a `response_int` helper mirroring the existing `response_float`/`response_bool`, and use it for the sequence:

```python
def response_int(value, fallback: int) -> int:
    if isinstance(value, bool):
        return fallback
    if isinstance(value, int):
        return value
    try:
        return int(value)
    except (TypeError, ValueError):
        return fallback
```

```python
normalized['latest_progress_sequence'] = response_int(normalized.get('latest_progress_sequence'), 0)
```

This is defense-in-depth, stated plainly: the current router callers all pre-normalize through `database.goals.normalize_goal_storage` (guarded in #9707), so this is not a live 500 today. It hardens the standalone projection helper against any future or direct caller and makes it uniformly defensive, matching the pattern it already uses for every other field.

## Tests

New `tests/unit/test_goals_response_int_guard.py` (pure helper, no Firestore):

- `response_int` falls back on `None`/non-numeric/`bool` and passes valid ints and int-like strings through (`int(2.9)` truncates to 2 as `int()` does)
- `normalize_goal_response` tolerates a `null` `latest_progress_sequence` and preserves a valid one

## Verification

```
cd backend && ENCRYPTION_SECRET=... python -m pytest tests/unit/test_goals_response_int_guard.py -q
  -> 3 passed
black --line-length 120 --skip-string-normalization --check utils/goals_response.py tests/unit/test_goals_response_int_guard.py
  -> unchanged
python -m pyright -p pyrightconfig.json utils/goals_response.py
  -> 0 errors
python scripts/check_module_stub_pollution.py
  -> Checked 638 test file(s); 0 violations
```

## Related

Complements #9707, which guarded the same numeric-coercion class in the storage-normalization layer (`database/goals.py`). This finishes it in the response-projection layer.

## Product invariants affected

none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9708?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

