### PR TITLE
fix(monitoring): keep empty error counters healthy

### DIFF
--- a/backend/charts/monitoring/alert-rules.json
+++ b/backend/charts/monitoring/alert-rules.json
@@ -1727,7 +1727,7 @@
         }
       }
     ],
-    "noDataState": "Alerting",
+    "noDataState": "OK",
     "execErrState": "Error",
     "for": "5m",
     "keep_firing_for": "0s",
@@ -1885,7 +1885,7 @@
         }
       }
     ],
-    "noDataState": "Alerting",
+    "noDataState": "OK",
     "execErrState": "Error",
     "for": "3m",
     "keep_firing_for": "0s",
@@ -2939,7 +2939,7 @@
         }
       }
     ],
-    "noDataState": "Alerting",
+    "noDataState": "OK",
     "execErrState": "Error",
     "for": "5m",
     "keep_firing_for": "0s",
@@ -3094,7 +3094,7 @@
         }
       }
     ],
-    "noDataState": "Alerting",
+    "noDataState": "OK",
     "execErrState": "Error",
     "for": "3m",
     "keep_firing_for": "0s",
@@ -5898,7 +5898,7 @@
         }
       }
     ],
-    "noDataState": "Alerting",
+    "noDataState": "OK",
     "execErrState": "Error",
     "for": "5m",
     "keep_firing_for": "0s",
@@ -6053,7 +6053,7 @@
         }
       }
     ],
-    "noDataState": "Alerting",
+    "noDataState": "OK",
     "execErrState": "Error",
     "for": "3m",
     "keep_firing_for": "0s",

--- a/backend/tests/unit/test_monitoring_alert_rule_contract.py
+++ b/backend/tests/unit/test_monitoring_alert_rule_contract.py
@@ -1,0 +1,44 @@
+"""Static contract for Grafana rules where an empty error-count series is healthy."""
+
+import json
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[3]
+MONITORING = REPO / "backend/charts/monitoring"
+ERROR_COUNT_RULES = {
+    "cew4j7ruiik1sd",  # Backend 4XX
+    "cew4jcnpa68sga",  # Backend 5XX
+    "cew97rzyegdtsa",  # Backend-sync 4XX
+    "cew97uqu791q8a",  # Backend-sync 5XX
+    "eew96lge97gg0e",  # Backend-integration 4XX
+    "eew96o25qztvkf",  # Backend-integration 5XX
+}
+
+
+def _rules(path: Path) -> dict[str, dict]:
+    return {rule["uid"]: rule for rule in json.loads(path.read_text(encoding="utf-8"))}
+
+
+def test_stackdriver_error_count_rules_treat_no_data_as_zero_errors():
+    """Grafana's Stackdriver empty result is healthy for these error counters."""
+    rules = _rules(MONITORING / "alert-rules.json")
+
+    assert ERROR_COUNT_RULES <= rules.keys()
+    for uid in ERROR_COUNT_RULES:
+        rule = rules[uid]
+        assert rule["noDataState"] == "OK", rule["title"]
+        query = rule["data"][0]["model"]
+        assert query["datasource"]["type"] == "stackdriver"
+        assert any("backend_request_count" in value for value in query["timeSeriesList"]["filters"])
+
+
+def test_split_alert_exports_preserve_error_count_no_data_contract():
+    """The deployable combined export and group exports must not drift."""
+    combined = _rules(MONITORING / "alert-rules.json")
+    split = {}
+    for name in ("backend.json", "backend-sync.json", "backend-integration.json"):
+        split.update(_rules(MONITORING / "alerts" / name))
+
+    assert ERROR_COUNT_RULES <= split.keys()
+    for uid in ERROR_COUNT_RULES:
+        assert combined[uid]["noDataState"] == split[uid]["noDataState"] == "OK"


### PR DESCRIPTION
## Summary
- restore `noDataState: OK` for the six Stackdriver backend/backend-sync/backend-integration 4XX/5XX count alerts in the deployable combined Grafana export
- add a regression contract covering zero-error semantics and combined/split alert-export drift

## Root cause and durable guard
Stackdriver returns no series when these error counters are zero. The grouped alert exports correctly treated that as `OK`, but a Grafana export sync reset the combined deploy artifact to `Alerting`. Grafana then raised false critical `NoData` alerts. The contract test checks every affected rule's Stackdriver counter shape and requires the combined and split exports to agree on `OK`.

## Verification
- `uv run --with pytest pytest -q backend/tests/unit/test_monitoring_alert_rule_contract.py` — 2 passed
- `python3 -m json.tool backend/charts/monitoring/alert-rules.json`
- `make preflight`

## Deferred / rollout
This is a version-controlled provisioning correction only. It does not mutate remote Grafana, alert routing, workloads, traffic, credentials, or public status. Production application of the reviewed provisioning artifact remains subject to the normal monitoring deployment/change-control path.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9710?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

