### PR TITLE
Guard paid-app price coercion so a bad price does not 500 the app update

### DIFF
--- a/backend/tests/unit/test_app_paid_price_guard.py
+++ b/backend/tests/unit/test_app_paid_price_guard.py
@@ -1,0 +1,61 @@
+"""Regression: a paid-app update with a missing or non-numeric price must not 500.
+
+routers.apps.update_app passes the raw request price straight into
+utils.apps.upsert_app_payment_link, which does int(price * 100) to build a Stripe recurring
+price. A null price (is_paid toggled on without a price) or a non-numeric value used to raise
+TypeError/ValueError. The guard treats any non-positive or non-numeric price like the existing
+price==0 case: it skips link creation and returns without crashing.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+import utils.apps as apps_mod
+from utils.apps import upsert_app_payment_link
+
+
+def _app_data(**over):
+    data = {
+        'id': 'app1',
+        'name': 'Test App',
+        'category': 'productivity',
+        'author': 'Zach',
+        'description': 'desc',
+        'image': 'https://storage.googleapis.com/x/y.png',
+        'capabilities': [],
+        'uid': 'u1',
+        'is_paid': True,
+        'payment_plan': 'monthly_recurring',
+        'price': 5.0,
+    }
+    data.update(over)
+    return data
+
+
+@pytest.fixture
+def stripe_mock(monkeypatch):
+    monkeypatch.setattr(apps_mod, 'get_app_by_id_db', lambda app_id: _app_data())
+    monkeypatch.setattr(apps_mod, 'get_stripe_connect_account_id', lambda uid: 'acct_1')
+    monkeypatch.setattr(apps_mod, 'update_app_in_db', lambda *a, **k: None)
+    stripe = MagicMock()
+    stripe.create_product.return_value = SimpleNamespace(id='prod_1')
+    stripe.create_app_monthly_recurring_price.return_value = SimpleNamespace(id='price_1')
+    stripe.create_app_payment_link.return_value = SimpleNamespace(id='link_1', url='https://pay/x')
+    monkeypatch.setattr(apps_mod, 'stripe', stripe)
+    return stripe
+
+
+@pytest.mark.parametrize('bad_price', [None, '5.0', 'abc', -1, 0, True])
+def test_invalid_price_skips_link_without_crashing(stripe_mock, bad_price):
+    # Must not raise, and must not attempt to build a Stripe price from a bad value.
+    upsert_app_payment_link('app1', True, bad_price, 'monthly_recurring', 'u1')
+    stripe_mock.create_app_monthly_recurring_price.assert_not_called()
+
+
+def test_valid_price_creates_the_recurring_price(stripe_mock):
+    upsert_app_payment_link('app1', True, 5.0, 'monthly_recurring', 'u1')
+    stripe_mock.create_app_monthly_recurring_price.assert_called_once()
+    # int(5.0 * 100) == 500 cents, the exact value that used to crash on a bad price.
+    assert stripe_mock.create_app_monthly_recurring_price.call_args[0][1] == 500

--- a/backend/utils/apps.py
+++ b/backend/utils/apps.py
@@ -607,7 +607,7 @@ def get_app_money_made(app_id: str) -> dict[str, int | float]:
 
 
 def upsert_app_payment_link(
-    app_id: str, is_paid_app: bool, price: float, payment_plan: str, uid: str, previous_price: float | None = None
+    app_id: str, is_paid_app: bool, price: Any, payment_plan: str, uid: str, previous_price: float | None = None
 ):
     if not is_paid_app:
         logger.info(f"App is not a paid app, app_id: {app_id}")
@@ -628,8 +628,12 @@ def upsert_app_payment_link(
         logger.info(f"App price is existing, app_id: {app_id}")
         return app
 
-    if price == 0:
-        logger.error(f"App price is not invalid, app_id: {app_id}")
+    # A paid app needs a positive numeric price before we can build a Stripe link. update_app passes the
+    # raw request price straight through, so a null price (is_paid toggled on without a price) or a
+    # non-numeric value would reach int(price * 100) below and raise, 500ing the update. Treat any
+    # non-positive or non-numeric price like the existing price==0 case: skip link creation, no crash.
+    if not isinstance(price, (int, float)) or isinstance(price, bool) or price <= 0:
+        logger.error(f"App price is missing or not a positive number, app_id: {app_id}")
         return app
 
     # create recurring payment link


### PR DESCRIPTION
## What

`utils.apps.upsert_app_payment_link` builds a Stripe recurring price:

```python
payment_price = stripe.create_app_monthly_recurring_price(app.payment_product_id, int(price * 100))
```

`routers.apps.update_app` (PATCH `/v1/apps/{app_id}`) passes the raw request price into it:

```python
upsert_app_payment_link(data.get('id'), data.get('is_paid', False), data.get('price'), data.get('payment_plan'), data.get('uid'), previous_price=app.get("price", 0))
```

`create_app` validates the paid-app price up front (422 if missing/negative), but `update_app` does not. So PATCHing an app to `is_paid=true` without a `price` (`data.get('price')` is `None`), or with a raw numeric string, reaches `int(None * 100)` / `int("5.0" * 100)` and raises `TypeError`/`ValueError`, returning HTTP 500. The existing `if price == 0` guard only covered the zero case.

## Fix

Extend that guard to skip link creation for any non-positive or non-numeric price, matching the graceful `price == 0` path already there:

```python
if not isinstance(price, (int, float)) or isinstance(price, bool) or price <= 0:
    logger.error(f"App price is missing or not a positive number, app_id: {app_id}")
    return app
```

The `price` parameter was annotated `float`, but the caller passes untyped request data, so the annotation is corrected to `Any` (that annotation is also what made the guard necessary). Neither caller uses the return value (`update_app` returns `{'status': 'ok'}`, `create_app` ignores it), so returning early without a link is safe.

Scope: this stops the 500. The related ordering issue -- `update_app` persists `is_paid` before the payment link is confirmed, so a paid app can still end up without a link on any upsert miss -- predates this crash (the 500 fired after the persist too) and is a separate follow-up; it is not widened into this PR.

## Tests

New `tests/unit/test_app_paid_price_guard.py` (drives `upsert_app_payment_link` with the Stripe client and db mocked):

- a `None` / non-numeric / negative / zero / bool price skips Stripe entirely without raising
- a valid `5.0` price still creates the recurring price with `int(5.0 * 100) == 500` cents

## Verification

```
cd backend && ENCRYPTION_SECRET=... python -m pytest tests/unit/test_app_paid_price_guard.py -q
  -> 7 passed
black --line-length 120 --skip-string-normalization --check utils/apps.py tests/unit/test_app_paid_price_guard.py
  -> unchanged
python -m pyright -p pyrightconfig.json utils/apps.py
  -> 0 errors
python scripts/check_module_stub_pollution.py
  -> Checked 638 test file(s); 0 violations
```

## Product invariants affected

none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9711?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

