### PR TITLE
Reject an unsupported listen codec/sample_rate before building the decoder

### DIFF
--- a/backend/routers/transcribe.py
+++ b/backend/routers/transcribe.py
@@ -150,6 +150,7 @@ from utils.transcribe_decisions import (  # async-blockers: no-import-scope; asy
     normalize_codec_frame,
     normalize_language,
     person_id_for_client,
+    validate_audio_format,
     resolve_photo_conversation_source,
     select_translation_language,
     should_enable_speaker_identification,
@@ -379,6 +380,12 @@ async def _stream_handler(
     logger.info(
         f'_stream_handler {uid} {session_id} {language} {sample_rate} {codec} {include_speech_profile} {stt_service} {conversation_timeout} custom_stt={custom_stt_mode} onboarding={onboarding_mode} client_conversation_id={bool(client_conversation_id)}'
     )
+
+    audio_format_error = validate_audio_format(codec, sample_rate)
+    if audio_format_error is not None:
+        logger.warning(f"Rejecting unsupported audio format: {audio_format_error} {uid} {session_id}")
+        await websocket.close(code=1003, reason=audio_format_error)
+        return
 
     use_custom_stt = custom_stt_mode == CustomSttMode.enabled
     is_multi_channel = channels >= 2

--- a/backend/tests/unit/test_validate_audio_format.py
+++ b/backend/tests/unit/test_validate_audio_format.py
@@ -1,0 +1,38 @@
+"""Regression: an unsupported codec/sample_rate must be rejected before the decoder is built.
+
+routers.transcribe._stream_handler constructs the native opus/lc3 decoders
+(opuslib.Decoder(sample_rate, 1), lc3py.Decoder(frame_duration, sample_rate)) before its main
+try block. An opus sample_rate outside opuslib's supported set, or a bare 'lc3' codec (which
+normalizes to a None frame duration), raised OpusError/TypeError that escaped the ASGI handler
+as an unclean 1006 close. validate_audio_format is checked at connect so those requests close
+cleanly (1003) instead.
+"""
+
+from utils.transcribe_decisions import OPUS_SUPPORTED_SAMPLE_RATES, validate_audio_format
+
+
+def test_supported_formats_pass():
+    assert validate_audio_format('opus', 16000) is None
+    assert validate_audio_format('opus_fs320', 48000) is None
+    assert validate_audio_format('lc3_fs1030', 16000) is None
+    assert validate_audio_format('pcm8', 8000) is None
+    assert validate_audio_format('pcm16', 16000) is None
+    assert validate_audio_format('aac', 16000) is None
+
+
+def test_opus_rejects_a_rate_opuslib_cannot_decode():
+    # 44100 is not one of opus's supported rates; opuslib.Decoder(44100, 1) would raise OpusError.
+    reason = validate_audio_format('opus', 44100)
+    assert reason is not None
+    assert '44100' in reason
+    assert validate_audio_format('opus_fs320', 44100) is not None
+    # Every advertised opus rate is accepted.
+    for rate in OPUS_SUPPORTED_SAMPLE_RATES:
+        assert validate_audio_format('opus', rate) is None
+
+
+def test_bare_lc3_is_rejected_but_the_known_variant_is_not():
+    # bare 'lc3' normalizes to a None frame duration -> lc3py.Decoder(None, ...) TypeError.
+    assert validate_audio_format('lc3', 16000) is not None
+    # the recognized variant carries a frame duration and must still pass.
+    assert validate_audio_format('lc3_fs1030', 16000) is None

--- a/backend/utils/transcribe_decisions.py
+++ b/backend/utils/transcribe_decisions.py
@@ -78,6 +78,24 @@ def normalize_codec_frame(codec: str) -> CodecFrameDecision:
     return CodecFrameDecision(codec, frame_size, lc3_chunk_size, lc3_frame_duration_us)
 
 
+OPUS_SUPPORTED_SAMPLE_RATES = frozenset({8000, 12000, 16000, 24000, 48000})
+
+
+def validate_audio_format(codec: str, sample_rate: int) -> Optional[str]:
+    """Reason the client codec/sample_rate cannot initialize a decoder, or None if it can.
+
+    opuslib.Decoder only accepts the standard opus sample rates, and lc3py.Decoder needs a frame
+    duration that only the lc3_fs1030 variant carries (bare 'lc3' normalizes to a None duration).
+    Checked before any decoder is constructed so an unsupported request closes the socket cleanly
+    instead of raising OpusError/TypeError out of the ASGI handler as an unclean 1006 drop.
+    """
+    if codec in ('opus', 'opus_fs320') and sample_rate not in OPUS_SUPPORTED_SAMPLE_RATES:
+        return f'opus requires a sample rate in {sorted(OPUS_SUPPORTED_SAMPLE_RATES)}, got {sample_rate}'
+    if codec == 'lc3':
+        return 'lc3 streaming requires the lc3_fs1030 codec (bare lc3 has no frame duration)'
+    return None
+
+
 def normalize_language(language: str) -> str:
     return 'multi' if language == 'auto' else language
 


### PR DESCRIPTION
## What

`routers.transcribe._stream_handler` builds the native audio decoders before its main `try` block:

```python
# multi-channel
multi_opus_decoders = [_get_opuslib().Decoder(sample_rate, 1) for _ in channel_configs]
# single-channel
opus_decoder = _get_opuslib().Decoder(sample_rate, 1)
lc3_decoder = _get_lc3().Decoder(lc3_frame_duration_us, sample_rate)
```

`sample_rate` and `codec` come straight from the connect query string. `opuslib.Decoder` only accepts the standard opus rates, so a device opening `/v4/listen?codec=opus&sample_rate=44100` raises `OpusError`. A bare `codec=lc3` normalizes to a `None` frame duration (only `lc3_fs1030` carries one), so `lc3py.Decoder(None, sample_rate)` raises `TypeError`. Both raise before the handler's `try`, so the exception escapes to Starlette as an unhandled ASGI error and the socket drops as an unclean 1006 instead of closing cleanly with a reason. The decode path already knows only specific formats are valid (it gates `codec == 'opus' and sample_rate == 16000`), but the constructor was ungated.

## Fix

Add a pure `validate_audio_format(codec, sample_rate)` in `utils.transcribe_decisions` and call it at connect, before any decoder is constructed:

```python
audio_format_error = validate_audio_format(codec, sample_rate)
if audio_format_error is not None:
    logger.warning(f"Rejecting unsupported audio format: {audio_format_error} {uid} {session_id}")
    await websocket.close(code=1003, reason=audio_format_error)
    return
```

`opus`/`opus_fs320` are checked against opuslib's supported set `{8000, 12000, 16000, 24000, 48000}`; a bare `lc3` is rejected in favor of the `lc3_fs1030` variant that carries a frame duration. The guard sits ahead of all three construction sites, so an unsupported request now closes with 1003 (unsupported data) and a human-readable reason instead of crashing the handler.

The rate set is opuslib's constructor set, not narrowed to 16 kHz, so this only rejects formats that cannot build a decoder at all; it does not change which rates the decode path accepts.

## Tests

New `tests/unit/test_validate_audio_format.py` (pure helper, no heavy import):

- supported pairs pass (`opus`/`opus_fs320` at valid rates, `lc3_fs1030`, `pcm8`/`pcm16`/`aac`)
- an opus rate opuslib cannot decode (44100) is rejected, and every advertised opus rate is accepted
- bare `lc3` is rejected while `lc3_fs1030` passes

## Verification

```
cd backend && ENCRYPTION_SECRET=... python -m pytest tests/unit/test_validate_audio_format.py -q
  -> 3 passed
black --line-length 120 --skip-string-normalization --check utils/transcribe_decisions.py routers/transcribe.py tests/unit/test_validate_audio_format.py
  -> unchanged
python -m pyright -p pyrightconfig.json utils/transcribe_decisions.py
  -> 0 errors    (routers/transcribe.py is pyright-excluded; py_compile clean)
python scripts/check_module_stub_pollution.py
  -> Checked 638 test file(s); 0 violations
```

## Product invariants affected

none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9712?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

