### PR TITLE
Cap the app-tool status-message cache so it cannot grow unbounded

### DIFF
--- a/backend/tests/unit/test_app_tools_status_cap.py
+++ b/backend/tests/unit/test_app_tools_status_cap.py
@@ -1,0 +1,41 @@
+"""Regression: the app-tool status-message cache must stay bounded.
+
+utils.retrieval.tools.app_tools keeps a process-global _tool_status_messages map keyed by
+{app_id}_{tool}. Every agentic chat turn that loads app tools writes new keys, and nothing evicted
+them, so the map grew for the whole process lifetime (the repo's own rule requires module-level dicts
+to cap or TTL). _remember_tool_status caps the map and evicts the oldest entry.
+"""
+
+import pytest
+
+import utils.retrieval.tools.app_tools as app_tools
+
+
+@pytest.fixture(autouse=True)
+def _clear_status_cache():
+    app_tools._tool_status_messages.clear()
+    yield
+    app_tools._tool_status_messages.clear()
+
+
+def test_status_cache_is_bounded_and_evicts_oldest():
+    cap = app_tools._MAX_TOOL_STATUS_MESSAGES
+    for i in range(cap + 50):
+        app_tools._remember_tool_status(f"app_{i}_tool", f"status {i}")
+
+    assert len(app_tools._tool_status_messages) == cap
+    # The oldest keys were evicted; the most recent are retained and still readable.
+    assert "app_0_tool" not in app_tools._tool_status_messages
+    assert f"app_{cap + 49}_tool" in app_tools._tool_status_messages
+    assert app_tools.get_tool_status_message(f"app_{cap + 49}_tool") == f"status {cap + 49}"
+
+
+def test_rewriting_a_key_refreshes_recency_without_growth():
+    for i in range(5):
+        app_tools._remember_tool_status(f"k{i}", f"v{i}")
+    before = len(app_tools._tool_status_messages)
+
+    app_tools._remember_tool_status("k0", "v0-updated")
+
+    assert len(app_tools._tool_status_messages) == before  # updating an existing key does not grow the map
+    assert app_tools.get_tool_status_message("k0") == "v0-updated"

--- a/backend/utils/retrieval/tools/app_tools.py
+++ b/backend/utils/retrieval/tools/app_tools.py
@@ -96,8 +96,18 @@ def _sync_noop(**kwargs: Any) -> None:
     return None
 
 
-# Global mapping of tool names to status messages
+# Global mapping of tool names to status messages. Bounded so a long-lived worker that loads app
+# tools for many distinct apps over its process lifetime cannot grow this map without limit.
+_MAX_TOOL_STATUS_MESSAGES = 2048
 _tool_status_messages: Dict[str, str] = {}
+
+
+def _remember_tool_status(tool_name: str, status_message: str) -> None:
+    # Re-inserting refreshes recency; evict the oldest entry once the cap is reached.
+    _tool_status_messages.pop(tool_name, None)
+    while len(_tool_status_messages) >= _MAX_TOOL_STATUS_MESSAGES:
+        _tool_status_messages.pop(next(iter(_tool_status_messages)), None)
+    _tool_status_messages[tool_name] = status_message
 
 
 def _create_pydantic_model_from_schema(tool_name: str, parameters: Dict[str, Any]) -> type[BaseModel]:
@@ -176,7 +186,7 @@ def create_app_tool(
 
     # Store status message in global mapping for UI display (if provided)
     if app_tool.status_message:
-        _tool_status_messages[tool_name] = app_tool.status_message
+        _remember_tool_status(tool_name, app_tool.status_message)
 
     # Create a Pydantic model from the schema (or empty model if no parameters)
     if app_tool.parameters and app_tool.parameters.get('properties'):


### PR DESCRIPTION
## What

`utils.retrieval.tools.app_tools` keeps a process-global cache of tool status messages:

```python
# Global mapping of tool names to status messages
_tool_status_messages: Dict[str, str] = {}
```

`create_app_tool` writes into it on every load, keyed by `{app_id}_{tool}`:

```python
tool_name = f"{app_id}_{app_tool.name}"
if app_tool.status_message:
    _tool_status_messages[tool_name] = app_tool.status_message
```

`load_app_tools` runs on every agentic chat turn, so distinct `{app_id}_{tool}` keys accumulate for the entire process lifetime. Nothing deletes, caps, or expires them, so the map grows without bound. This is exactly the case the repo's own guidance calls out: "Module-level dicts: add TTL-based eviction or cap size - they grow forever otherwise" (`backend/CLAUDE.md`).

## Fix

Route the write through a small bounded helper that evicts the oldest entry once a cap is reached:

```python
_MAX_TOOL_STATUS_MESSAGES = 2048

def _remember_tool_status(tool_name: str, status_message: str) -> None:
    # Re-inserting refreshes recency; evict the oldest entry once the cap is reached.
    _tool_status_messages.pop(tool_name, None)
    while len(_tool_status_messages) >= _MAX_TOOL_STATUS_MESSAGES:
        _tool_status_messages.pop(next(iter(_tool_status_messages)), None)
    _tool_status_messages[tool_name] = status_message
```

Dict insertion order (Python 3.7+) makes `next(iter(...))` the oldest key. Re-inserting a key refreshes its recency, so an actively-used tool stays cached. The cap of 2048 comfortably covers any realistic set of active app-tools while bounding worst-case memory. The getter (`get_tool_status_message`) is unchanged.

## Tests

New `tests/unit/test_app_tools_status_cap.py`:

- writing past the cap keeps the map at exactly the cap, evicts the oldest key, and retains the most recent (still readable via `get_tool_status_message`)
- updating an existing key does not grow the map

## Verification

```
cd backend && ENCRYPTION_SECRET=... python -m pytest tests/unit/test_app_tools_status_cap.py -q
  -> 2 passed
black --line-length 120 --skip-string-normalization --check utils/retrieval/tools/app_tools.py tests/unit/test_app_tools_status_cap.py
  -> unchanged
python -m pyright -p pyrightconfig.json utils/retrieval/tools/app_tools.py
  -> 0 errors
python scripts/check_module_stub_pollution.py
  -> Checked 638 test file(s); 0 violations
```

## Product invariants affected

none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9713?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

