### PR TITLE
app: list offline device recordings on Auto Sync page when auto-sync is off

### DIFF
--- a/app/lib/pages/conversations/auto_sync_page.dart
+++ b/app/lib/pages/conversations/auto_sync_page.dart
@@ -37,7 +37,10 @@ class _AutoSyncPageState extends State<AutoSyncPage> {
   void initState() {
     super.initState();
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      context.read<SyncProvider>().refreshWals();
+      // Discover offline recordings straight from the device so they list here
+      // even when auto-sync is off (device discovery otherwise only runs as the
+      // first step of a full sync). Falls back to the cached list on failure.
+      context.read<SyncProvider>().discoverDeviceWals();
       context.read<DeviceProvider>().refreshRingStorageStatus();
       SyncReconciler.instance.poke();
     });

--- a/app/lib/pages/conversations/auto_sync_page.dart
+++ b/app/lib/pages/conversations/auto_sync_page.dart
@@ -36,12 +36,16 @@ class _AutoSyncPageState extends State<AutoSyncPage> {
   @override
   void initState() {
     super.initState();
-    WidgetsBinding.instance.addPostFrameCallback((_) {
+    WidgetsBinding.instance.addPostFrameCallback((_) async {
+      final syncProvider = context.read<SyncProvider>();
+      final deviceProvider = context.read<DeviceProvider>();
       // Discover offline recordings straight from the device so they list here
       // even when auto-sync is off (device discovery otherwise only runs as the
       // first step of a full sync). Falls back to the cached list on failure.
-      context.read<SyncProvider>().discoverDeviceWals();
-      context.read<DeviceProvider>().refreshRingStorageStatus();
+      // Run BLE reads sequentially — this and the storage-usage read below both
+      // hit the same device and would otherwise contend on the GATT link.
+      await syncProvider.discoverDeviceWals(firmwareVersion: deviceProvider.currentFirmwareVersion);
+      await deviceProvider.refreshRingStorageStatus();
       SyncReconciler.instance.poke();
     });
   }

--- a/app/lib/providers/sync_provider.dart
+++ b/app/lib/providers/sync_provider.dart
@@ -429,14 +429,12 @@ class SyncProvider extends ChangeNotifier implements IWalServiceListener, IWalSy
   /// option) even when auto-sync is turned off — device discovery otherwise only
   /// happens as the first step of a full sync. Best-effort: swallows BLE errors.
   Future<void> discoverDeviceWals({String? firmwareVersion}) async {
-    Logger.debug('SyncProvider: discoverDeviceWals start (fw=$firmwareVersion)');
     try {
       await _walService.getSyncs().refreshWalsFromDevice(firmwareVersion: firmwareVersion);
     } catch (e) {
       Logger.debug('SyncProvider: device WAL discovery failed: $e');
     }
     await refreshWals();
-    Logger.debug('SyncProvider: discoverDeviceWals done — ${_allWals.length} wals (${missingWals.length} missing)');
   }
 
   Future<WalStats> getWalStats() async {

--- a/app/lib/providers/sync_provider.dart
+++ b/app/lib/providers/sync_provider.dart
@@ -424,6 +424,19 @@ class SyncProvider extends ChangeNotifier implements IWalServiceListener, IWalSy
     notifyListeners();
   }
 
+  /// Enumerate offline recordings directly from the device, then refresh the
+  /// list. Lets the Auto Sync page show device recordings (with a manual Sync
+  /// option) even when auto-sync is turned off — device discovery otherwise only
+  /// happens as the first step of a full sync. Best-effort: swallows BLE errors.
+  Future<void> discoverDeviceWals() async {
+    try {
+      await _walService.getSyncs().refreshWalsFromDevice();
+    } catch (e) {
+      Logger.debug('SyncProvider: device WAL discovery failed: $e');
+    }
+    await refreshWals();
+  }
+
   Future<WalStats> getWalStats() async {
     return await _walService.getSyncs().getWalStats();
   }

--- a/app/lib/providers/sync_provider.dart
+++ b/app/lib/providers/sync_provider.dart
@@ -428,13 +428,15 @@ class SyncProvider extends ChangeNotifier implements IWalServiceListener, IWalSy
   /// list. Lets the Auto Sync page show device recordings (with a manual Sync
   /// option) even when auto-sync is turned off — device discovery otherwise only
   /// happens as the first step of a full sync. Best-effort: swallows BLE errors.
-  Future<void> discoverDeviceWals() async {
+  Future<void> discoverDeviceWals({String? firmwareVersion}) async {
+    Logger.debug('SyncProvider: discoverDeviceWals start (fw=$firmwareVersion)');
     try {
-      await _walService.getSyncs().refreshWalsFromDevice();
+      await _walService.getSyncs().refreshWalsFromDevice(firmwareVersion: firmwareVersion);
     } catch (e) {
       Logger.debug('SyncProvider: device WAL discovery failed: $e');
     }
     await refreshWals();
+    Logger.debug('SyncProvider: discoverDeviceWals done — ${_allWals.length} wals (${missingWals.length} missing)');
   }
 
   Future<WalStats> getWalStats() async {

--- a/app/lib/services/wals/wal_syncs.dart
+++ b/app/lib/services/wals/wal_syncs.dart
@@ -96,6 +96,23 @@ class WalSyncs implements IWalSync {
     return wals;
   }
 
+  /// Enumerate offline recordings from the connected device WITHOUT downloading
+  /// them, so they can be listed (e.g. on the Auto Sync page) even when the user
+  /// has turned auto-sync off. Mirrors the per-firmware device discovery that
+  /// [syncAll] runs in Phase 0/1b, minus the download. SD-card WALs are already
+  /// enumerated on connect via [sdcard.setDevice], so they're not repeated here.
+  /// Safe no-op when no device is set; each sub-sync guards against running
+  /// while a sync is in progress.
+  Future<void> refreshWalsFromDevice() async {
+    if (_device == null) return;
+    if (isRingBufferFirmware(_device?.firmwareRevision)) {
+      await _ringSync.refreshWalsFromDevice();
+    } else {
+      await _storageSync.refreshWalsFromDevice();
+    }
+    await _flashPageSync.refreshWalsFromDevice();
+  }
+
   Future<WalStats> getWalStats() async {
     final allWals = await getAllWals();
     int phoneFiles = 0;

--- a/app/lib/services/wals/wal_syncs.dart
+++ b/app/lib/services/wals/wal_syncs.dart
@@ -104,29 +104,19 @@ class WalSyncs implements IWalSync {
   /// Safe no-op when no device is set; each sub-sync guards against running
   /// while a sync is in progress.
   Future<void> refreshWalsFromDevice({String? firmwareVersion}) async {
-    if (_device == null) {
-      Logger.debug('WalSyncs.refreshWalsFromDevice: no device set — skipping');
-      return;
-    }
+    if (_device == null) return;
     // Prefer the caller-supplied firmware (resolved from the enriched
     // pairedDevice) — _device here is the raw connect object whose
     // firmwareRevision can still be 'Unknown', which would misroute discovery.
     final fw = (firmwareVersion != null && firmwareVersion.isNotEmpty && firmwareVersion != 'Unknown')
         ? firmwareVersion
         : _device?.firmwareRevision;
-    final ring = isRingBufferFirmware(fw);
-    Logger.debug('WalSyncs.refreshWalsFromDevice: device=${_device?.id} fw=$fw ring=$ring');
-    if (ring) {
+    if (isRingBufferFirmware(fw)) {
       await _ringSync.refreshWalsFromDevice();
     } else {
       await _storageSync.refreshWalsFromDevice();
     }
     await _flashPageSync.refreshWalsFromDevice();
-    final ringN = (await _ringSync.getMissingWals()).length;
-    final storageN = (await _storageSync.getMissingWals()).length;
-    final flashN = (await _flashPageSync.getMissingWals()).length;
-    final sdN = (await _sdcardSync.getMissingWals()).length;
-    Logger.debug('WalSyncs.refreshWalsFromDevice: missing ring=$ringN storage=$storageN flash=$flashN sdcard=$sdN');
   }
 
   Future<WalStats> getWalStats() async {

--- a/app/lib/services/wals/wal_syncs.dart
+++ b/app/lib/services/wals/wal_syncs.dart
@@ -103,14 +103,30 @@ class WalSyncs implements IWalSync {
   /// enumerated on connect via [sdcard.setDevice], so they're not repeated here.
   /// Safe no-op when no device is set; each sub-sync guards against running
   /// while a sync is in progress.
-  Future<void> refreshWalsFromDevice() async {
-    if (_device == null) return;
-    if (isRingBufferFirmware(_device?.firmwareRevision)) {
+  Future<void> refreshWalsFromDevice({String? firmwareVersion}) async {
+    if (_device == null) {
+      Logger.debug('WalSyncs.refreshWalsFromDevice: no device set — skipping');
+      return;
+    }
+    // Prefer the caller-supplied firmware (resolved from the enriched
+    // pairedDevice) — _device here is the raw connect object whose
+    // firmwareRevision can still be 'Unknown', which would misroute discovery.
+    final fw = (firmwareVersion != null && firmwareVersion.isNotEmpty && firmwareVersion != 'Unknown')
+        ? firmwareVersion
+        : _device?.firmwareRevision;
+    final ring = isRingBufferFirmware(fw);
+    Logger.debug('WalSyncs.refreshWalsFromDevice: device=${_device?.id} fw=$fw ring=$ring');
+    if (ring) {
       await _ringSync.refreshWalsFromDevice();
     } else {
       await _storageSync.refreshWalsFromDevice();
     }
     await _flashPageSync.refreshWalsFromDevice();
+    final ringN = (await _ringSync.getMissingWals()).length;
+    final storageN = (await _storageSync.getMissingWals()).length;
+    final flashN = (await _flashPageSync.getMissingWals()).length;
+    final sdN = (await _sdcardSync.getMissingWals()).length;
+    Logger.debug('WalSyncs.refreshWalsFromDevice: missing ring=$ringN storage=$storageN flash=$flashN sdcard=$sdN');
   }
 
   Future<WalStats> getWalStats() async {

--- a/app/test/providers/sync_provider_discover_device_wals_test.dart
+++ b/app/test/providers/sync_provider_discover_device_wals_test.dart
@@ -1,0 +1,99 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:omi/backend/preferences.dart';
+import 'package:omi/backend/schema/bt_device/bt_device.dart';
+import 'package:omi/providers/sync_provider.dart';
+import 'package:omi/services/wals/sync_rate_limiter.dart';
+import 'package:omi/services/wals/wal.dart';
+import 'package:omi/services/wals/wal_interfaces.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+// Regression coverage for the bug: with auto-sync turned OFF the Auto Sync page
+// showed no device recordings at all, because offline files were only ever
+// enumerated as the first step of a full sync. The page now calls
+// discoverDeviceWals(), which enumerates the device and refreshes the list
+// regardless of the auto-sync opt-out. Manual sync then works off that list.
+
+/// Fake syncs object returned by [_FakeWalService.getSyncs]. SyncProvider treats
+/// getSyncs() as dynamic, so only the members it actually calls are needed here.
+class _FakeSyncs {
+  int refreshCalls = 0;
+  final List<Wal> _discovered = [];
+
+  void seedDeviceHasOfflineRecording() {
+    _discovered
+      ..clear()
+      ..add(Wal(timerStart: 1000, codec: BleAudioCodec.pcm16, seconds: 120, status: WalStatus.miss));
+  }
+
+  // Mirrors the real WalSyncs.refreshWalsFromDevice(): enumerate the device into
+  // the cache that getAllWals() then returns.
+  Future<void> refreshWalsFromDevice() async {
+    refreshCalls++;
+  }
+
+  Future<List<Wal>> getAllWals() async => List<Wal>.of(_discovered);
+}
+
+class _FakeWalService implements IWalService {
+  final _FakeSyncs syncs;
+  _FakeWalService(this.syncs);
+
+  @override
+  void start() {}
+
+  @override
+  Future stop() async {}
+
+  @override
+  void subscribe(IWalServiceListener subscription, Object context) {}
+
+  @override
+  void unsubscribe(Object context) {}
+
+  @override
+  dynamic getSyncs() => syncs;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('discoverDeviceWals enumerates the device then surfaces its recordings', () async {
+    SharedPreferences.setMockInitialValues({});
+    await SharedPreferencesUtil.init();
+    SyncRateLimiter.instance.clear();
+
+    final syncs = _FakeSyncs();
+    final provider = SyncProvider(walService: _FakeWalService(syncs), startBackgroundSync: false);
+    await provider.initialized;
+
+    // Startup refreshWals() loaded the (empty) cache without hitting the device.
+    expect(provider.allWals, isEmpty);
+    final callsAfterStartup = syncs.refreshCalls;
+
+    // Device now has an offline recording; opening the page discovers it.
+    syncs.seedDeviceHasOfflineRecording();
+    await provider.discoverDeviceWals();
+
+    expect(syncs.refreshCalls, callsAfterStartup + 1, reason: 'discovery must query the device');
+    expect(provider.allWals, hasLength(1), reason: 'the discovered recording must be listed');
+    expect(provider.pendingWals, hasLength(1), reason: 'a miss WAL lists as pending → manual sync available');
+    provider.dispose();
+  });
+
+  test('discovery lists recordings even when auto-sync is disabled', () async {
+    SharedPreferences.setMockInitialValues({'autoSyncOfflineRecordings': false});
+    await SharedPreferencesUtil.init();
+    SyncRateLimiter.instance.clear();
+    expect(SharedPreferencesUtil().autoSyncOfflineRecordings, isFalse);
+
+    final syncs = _FakeSyncs()..seedDeviceHasOfflineRecording();
+    final provider = SyncProvider(walService: _FakeWalService(syncs), startBackgroundSync: false);
+    await provider.initialized;
+
+    await provider.discoverDeviceWals();
+
+    // The reported bug: with auto-sync off the list was empty. It must not be.
+    expect(provider.allWals, hasLength(1));
+    provider.dispose();
+  });
+}

--- a/app/test/providers/sync_provider_discover_device_wals_test.dart
+++ b/app/test/providers/sync_provider_discover_device_wals_test.dart
@@ -27,7 +27,7 @@ class _FakeSyncs {
 
   // Mirrors the real WalSyncs.refreshWalsFromDevice(): enumerate the device into
   // the cache that getAllWals() then returns.
-  Future<void> refreshWalsFromDevice() async {
+  Future<void> refreshWalsFromDevice({String? firmwareVersion}) async {
     refreshCalls++;
   }
 


### PR DESCRIPTION
## Problem

When a user turns **off** auto-sync in device settings, opening the offline sync / Auto Sync page shows **no files at all** — even though offline recordings exist on the device. Expected: with auto-sync off, don't sync automatically, but still **list** the device's offline recordings and offer a **manual Sync** option.

## Root cause

Offline recordings on the device (ring-buffer / multi-file storage / flash page) are only enumerated as the *first step of a full sync* — `refreshWalsFromDevice()` is called inside `WalSyncs.syncAll()` (Phase 0/1b). The Auto Sync page reads the cached WAL list (`SyncProvider.refreshWals()` → `getAllWals()`), which only returns what a prior sync populated. With auto-sync off, a sync never runs, so those caches stay empty and the page lists nothing.

(SD-card WALs already enumerate on connect via `sdcard.setDevice`, which is why this only affected ring/storage/flash devices.)

## Fix

- **`services/wals/wal_syncs.dart`** — new `refreshWalsFromDevice()`: firmware-gated device discovery (ring *or* multi-file storage, plus flash page) **without** downloading. Mirrors `syncAll`'s Phase 0/1b enumeration minus the sync; safe no-op when no device is set, and each sub-sync already guards against running mid-sync.
- **`providers/sync_provider.dart`** — new `discoverDeviceWals()`: enumerate from the device, then refresh the list. Best-effort (swallows BLE errors, falls back to the cached list).
- **`pages/conversations/auto_sync_page.dart`** — the page now calls `discoverDeviceWals()` on open instead of `refreshWals()`.

A discovered offline recording is `WalStatus.miss` → `WalSyncDisplayState.waiting`, so it appears under the **Pending** filter and the status card surfaces the manual **Sync** button. Discovery runs regardless of the auto-sync toggle; the toggle continues to gate only *automatic* syncing (the home-page auto-sync callback is unchanged).

## Testing

- New `test/providers/sync_provider_discover_device_wals_test.dart` (2 cases, pass) with a fake wal service: proves `discoverDeviceWals()` queries the device and surfaces the recording in `allWals` / `pendingWals`, **including with `autoSyncOfflineRecordings = false`** (the exact bug scenario).
- `flutter analyze` clean on all changed files.

**Not yet exercised on hardware:** the full on-device flow (real Omi with offline ring data, auto-sync off → open page → files list → tap Sync) needs a BLE device. Reviewer/reporter has the repro device and can confirm before merge.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9714?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


