### PR TITLE
Fail open in three vector_db functions when no Pinecone index is configured

### DIFF
--- a/backend/database/vector_db.py
+++ b/backend/database/vector_db.py
@@ -120,6 +120,8 @@ def upsert_vector(uid: str, conversation_id: str, vector: List[float]) -> None:
 
 
 def upsert_vector2(uid: str, conversation_id: str, vector: List[float], metadata: Dict[str, Any]) -> None:
+    if index is None:
+        return
     data: VectorRecordDoc = _get_data(uid, conversation_id, vector)
     typed_metadata: Dict[str, Any] = data['metadata']
     typed_metadata.update(metadata)
@@ -128,6 +130,8 @@ def upsert_vector2(uid: str, conversation_id: str, vector: List[float], metadata
 
 
 def update_vector_metadata(uid: str, conversation_id: str, metadata: Dict[str, Any]) -> Dict[str, Any]:
+    if index is None:
+        return {}
     metadata['uid'] = uid
     metadata['memory_id'] = conversation_id
     result: Dict[str, Any] = index.update(f'{uid}-{conversation_id}', set_metadata=metadata, namespace="ns1")
@@ -188,6 +192,8 @@ def query_vectors_by_metadata(
     dates: List[str],
     limit: int = 5,
 ) -> List[str]:
+    if index is None:
+        return []
     and_clauses: List[Dict[str, Any]] = [{'uid': {'$eq': uid}}]
     filter_data: Dict[str, Any] = {'$and': and_clauses}
     if people or topics or entities or dates:

--- a/backend/tests/unit/test_vector_db_index_none_guard.py
+++ b/backend/tests/unit/test_vector_db_index_none_guard.py
@@ -1,0 +1,28 @@
+"""Regression: vector_db functions must fail open when no Pinecone index is configured.
+
+database.vector_db.index is None on deploys without Pinecone (self-hosted, offline, local dev).
+20+ functions guard `if index is None`, but query_vectors_by_metadata, upsert_vector2, and
+update_vector_metadata dereferenced index directly, raising AttributeError instead of the intended
+empty/skip. That either silently dropped the proactive-notification memory lookup or died as an
+unlogged AttributeError on the structured-vector save. The guards restore the fail-open contract.
+"""
+
+import database.vector_db as vector_db
+
+
+def test_query_vectors_by_metadata_returns_empty_without_index(monkeypatch):
+    monkeypatch.setattr(vector_db, 'index', None)
+    result = vector_db.query_vectors_by_metadata('uid1', [0.1, 0.2], [], [], [], [], [], limit=5)
+    assert result == []
+
+
+def test_upsert_vector2_is_a_noop_without_index(monkeypatch):
+    monkeypatch.setattr(vector_db, 'index', None)
+    # Must not raise (previously AttributeError on index.upsert).
+    assert vector_db.upsert_vector2('uid1', 'conv1', [0.1, 0.2], {'k': 'v'}) is None
+
+
+def test_update_vector_metadata_returns_empty_without_index(monkeypatch):
+    monkeypatch.setattr(vector_db, 'index', None)
+    result = vector_db.update_vector_metadata('uid1', 'conv1', {'k': 'v'})
+    assert result == {}


### PR DESCRIPTION
## What

`database.vector_db.index` is the Pinecone index, and it is `None` on any deploy without Pinecone configured (self-hosted vector search, the `PROVIDER_MODE=offline` harness, local dev). The module treats this as a first-class state: more than twenty functions guard it, for example

```python
def query_vectors(...):
    if index is None:
        return []
    ...

def delete_vector(...):
    if index is None:
        return
    ...
```

Three functions missed that guard and dereferenced `index` directly:

- `query_vectors_by_metadata` -> `index.query(...)`
- `upsert_vector2` -> `index.upsert(...)`
- `update_vector_metadata` -> `index.update(...)`

With no index these raise `AttributeError: 'NoneType' object has no attribute ...` instead of the intended empty/skip. `query_vectors_by_metadata` is called from the app-integration memory lookup (`utils/app_integrations.py`), where the failure silently drops the lookup; `upsert_vector2`/`update_vector_metadata` run during conversation processing (`utils/conversations/process_conversation.py`), where the structured-vector save dies as an unlogged `AttributeError` rather than the intended skip.

## Fix

Add the same `if index is None` guard the sibling functions already use, returning the type-appropriate empty result:

```python
def query_vectors_by_metadata(...) -> List[str]:
    if index is None:
        return []

def upsert_vector2(...) -> None:
    if index is None:
        return

def update_vector_metadata(...) -> Dict[str, Any]:
    if index is None:
        return {}
```

This restores the module's fail-open contract uniformly: without a vector index, reads return empty and writes are skipped, instead of raising.

## Tests

New `tests/unit/test_vector_db_index_none_guard.py` (forces `index` to None via monkeypatch):

- `query_vectors_by_metadata` returns `[]`
- `upsert_vector2` is a no-op (previously `AttributeError` on `index.upsert`)
- `update_vector_metadata` returns `{}`

## Verification

```
cd backend && ENCRYPTION_SECRET=... python -m pytest tests/unit/test_vector_db_index_none_guard.py -q
  -> 3 passed
black --line-length 120 --skip-string-normalization --check database/vector_db.py tests/unit/test_vector_db_index_none_guard.py
  -> unchanged
python -m pyright -p pyrightconfig.json database/vector_db.py
  -> 0 errors
python scripts/check_module_stub_pollution.py
  -> Checked 638 test file(s); 0 violations
```

## Product invariants affected

none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9715?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

