### PR TITLE
Clamp app review scores to 0-5 so an out-of-range score cannot skew the ranking

### DIFF
--- a/backend/tests/unit/test_app_review_score_clamp.py
+++ b/backend/tests/unit/test_app_review_score_clamp.py
@@ -1,0 +1,52 @@
+"""Regression: an out-of-range app review score must not skew the marketplace ranking.
+
+ReviewAppRequest.score is an unbounded float on the write path, so a review posted with a huge or
+negative score used to flow into rating_avg (utils.apps averaging sites) and from there into
+weighted_rating / compute_app_score, pinning one app to the top or bottom of every listing. The read
+path already bounds score with Field(ge=0, le=5); _clamp_review_score closes the same bound on the
+write boundary (set_app_review) and the aggregation sites without changing the request contract.
+"""
+
+import pytest
+
+import utils.apps as apps_mod
+from utils.apps import _clamp_review_score, set_app_review
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        (1e6, 5.0),
+        (10, 5.0),
+        (5, 5.0),
+        (3.5, 3.5),
+        (0, 0.0),
+        (-1, 0.0),
+        (-1e9, 0.0),
+        ("bad", 0.0),
+        (None, 0.0),
+    ],
+)
+def test_clamp_review_score(raw, expected):
+    assert _clamp_review_score(raw) == expected
+
+
+def test_set_app_review_clamps_out_of_range_score(monkeypatch):
+    captured = {}
+    monkeypatch.setattr(apps_mod, "set_app_review_in_db", lambda app_id, uid, review: captured.update(review=review))
+    monkeypatch.setattr(apps_mod, "set_app_review_cache", lambda app_id, uid, review: None)
+
+    result = set_app_review("app1", "uid1", {"score": 1e6, "review": "great"})
+
+    assert result == {"status": "ok"}
+    assert captured["review"]["score"] == 5.0
+
+
+def test_set_app_review_clamps_negative_score(monkeypatch):
+    captured = {}
+    monkeypatch.setattr(apps_mod, "set_app_review_in_db", lambda app_id, uid, review: captured.update(review=review))
+    monkeypatch.setattr(apps_mod, "set_app_review_cache", lambda app_id, uid, review: None)
+
+    set_app_review("app1", "uid1", {"score": -3})
+
+    assert captured["review"]["score"] == 0.0

--- a/backend/utils/apps.py
+++ b/backend/utils/apps.py
@@ -213,6 +213,17 @@ def remove_app_access_for_tester(app_id: str, uid: str) -> None:
 # ********************************
 
 
+def _clamp_review_score(score: Any) -> float:
+    # App reviews are a 0-5 scale. Clamp so a drifted or abusive out-of-range score cannot skew
+    # rating_avg and the marketplace ranking (weighted_rating / compute_app_score) that reads it.
+    # The read path already bounds score with Field(ge=0, le=5); this closes the same bound on the
+    # write and aggregation paths, where the request model leaves score unbounded.
+    try:
+        return max(0.0, min(5.0, float(score)))
+    except (TypeError, ValueError):
+        return 0.0
+
+
 def weighted_rating(app: App) -> float:
     C = 3.0  # Assume 3.0 is the mean rating across all apps
     m = 5  # Minimum number of ratings required to be considered
@@ -291,7 +302,11 @@ def get_popular_apps() -> List[App]:
             app_dict['installs'] = apps_install.get(app['id'], 0)
             reviews = apps_reviews.get(app['id'], {})
             sorted_reviews = reviews.values()
-            rating_avg = sum([x['score'] for x in sorted_reviews]) / len(sorted_reviews) if reviews else None
+            rating_avg = (
+                sum([_clamp_review_score(x['score']) for x in sorted_reviews]) / len(sorted_reviews)
+                if reviews
+                else None
+            )
             app_dict['rating_avg'] = rating_avg
             app_dict['rating_count'] = len(sorted_reviews)
             built_app = _safe_build_app(app_dict)
@@ -363,7 +378,11 @@ def get_available_apps(uid: str, include_reviews: bool = False) -> List[App]:
         if include_reviews:
             reviews = apps_review.get(app['id'], {})
             sorted_reviews = reviews.values()
-            rating_avg = sum([x['score'] for x in sorted_reviews]) / len(sorted_reviews) if reviews else None
+            rating_avg = (
+                sum([_clamp_review_score(x['score']) for x in sorted_reviews]) / len(sorted_reviews)
+                if reviews
+                else None
+            )
             app_dict['reviews'] = [details for details in reviews.values() if details['review']]
             app_dict['user_review'] = reviews.get(uid)
             app_dict['rating_avg'] = rating_avg
@@ -402,7 +421,9 @@ def get_available_app_by_id_with_reviews(app_id: str, uid: str | None) -> Dict[s
     app['usage_count'] = get_app_usage_count(app['id']) if not app['private'] else None
     reviews = get_app_reviews(app['id'])
     sorted_reviews = reviews.values()
-    rating_avg = sum([x['score'] for x in sorted_reviews]) / len(sorted_reviews) if reviews else None
+    rating_avg = (
+        sum([_clamp_review_score(x['score']) for x in sorted_reviews]) / len(sorted_reviews) if reviews else None
+    )
     app['reviews'] = [details for details in reviews.values() if details['review']]
     app['rating_avg'] = rating_avg
     app['rating_count'] = len(sorted_reviews)
@@ -491,7 +512,11 @@ def get_approved_available_apps(include_reviews: bool = False) -> list[App]:
             if include_reviews:
                 reviews = apps_reviews.get(app['id'], {})
                 sorted_reviews = reviews.values()
-                rating_avg = sum([x['score'] for x in sorted_reviews]) / len(sorted_reviews) if reviews else None
+                rating_avg = (
+                    sum([_clamp_review_score(x['score']) for x in sorted_reviews]) / len(sorted_reviews)
+                    if reviews
+                    else None
+                )
                 app_dict['reviews'] = []
                 app_dict['rating_avg'] = rating_avg
                 app_dict['rating_count'] = len(sorted_reviews)
@@ -507,6 +532,8 @@ def get_approved_available_apps(include_reviews: bool = False) -> list[App]:
 
 
 def set_app_review(app_id: str, uid: str, review: Dict[str, Any]) -> Dict[str, str]:
+    if 'score' in review:
+        review['score'] = _clamp_review_score(review['score'])
     set_app_review_in_db(app_id, uid, review)
     set_app_review_cache(app_id, uid, review)
     return {'status': 'ok'}


### PR DESCRIPTION
## What

`ReviewAppRequest.score` is an unbounded `float` on the write path:

```python
class ReviewAppRequest(PydanticBaseModel):
    score: float
```

A non-owner can `POST /v1/apps/review` with any value. The stored score flows into `rating_avg`:

```python
rating_avg = sum([x['score'] for x in sorted_reviews]) / len(sorted_reviews) if reviews else None
```

and `rating_avg` feeds the marketplace ranking (`weighted_rating`, and `compute_app_score` via `(rating_avg / 5) ** 2`). So a single review with a huge score (`1e300`) or a negative one, whether abusive or an honest 0-100-scale client bug, can push one app to the top or bottom of every listing and corrupt the displayed rating. The read path already bounds the score with `Field(ge=0, le=5)` (`routers/apps.py`), but the write and aggregation paths do not.

## Fix

Add a small clamp helper and apply it at both the write boundary and the aggregation sites:

```python
def _clamp_review_score(score: Any) -> float:
    try:
        return max(0.0, min(5.0, float(score)))
    except (TypeError, ValueError):
        return 0.0
```

- `set_app_review` clamps `review['score']` before it is persisted, so stored scores stay in range.
- The `rating_avg` aggregation sites clamp each score (`sum([_clamp_review_score(x['score']) ...])`), so an already-stored out-of-range score cannot skew the ranking either.

The request contract is deliberately unchanged (no `Field(ge, le)` added to `ReviewAppRequest`): tightening an accepted request field would break the released app-client OpenAPI compatibility boundary. Released clients that send any float are still accepted; the value is bounded server-side. This mirrors the bound the read path already applies.

## Tests

New `tests/unit/test_app_review_score_clamp.py`:

- `_clamp_review_score` clamps out-of-range values (`1e6` -> 5.0, `-1e9` -> 0.0), passes valid scores through, and defaults non-numeric/None to 0.0
- `set_app_review` clamps a huge score (1e6 -> 5.0) and a negative score (-3 -> 0.0) before persisting

## Verification

```
cd backend && ENCRYPTION_SECRET=... python -m pytest tests/unit/test_app_review_score_clamp.py -q
  -> 11 passed
black --line-length 120 --skip-string-normalization --check utils/apps.py tests/unit/test_app_review_score_clamp.py
  -> unchanged
python -m pyright -p pyrightconfig.json utils/apps.py
  -> 0 errors
python scripts/check_module_stub_pollution.py
  -> Checked 638 test file(s); 0 violations
```

## Product invariants affected

none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9716?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

