### PR TITLE
fix(preflight): read desktop changelog as UTF-8

### DIFF
--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -37,6 +37,11 @@ checks:
     triggers: ["all"]
     lanes: ["local", "ci"]
     reason: "repository-wide desktop changelog schema contract"
+  - id: desktop-changelog-encoding-contract
+    command: ["python3", ".github/scripts/test_desktop_changelog.py"]
+    triggers: [".github/scripts/desktop-changelog.py", ".github/scripts/test_desktop_changelog.py"]
+    lanes: ["local", "ci"]
+    reason: "desktop changelog JSON uses UTF-8 across host locales"
   - id: desktop-changelog-entry
     command: ["python3", ".github/scripts/check-desktop-changelog.py", "--base", "{base}", "--head", "{head}", "{skip_changelog}"]
     triggers: ["desktop/macos/**"]

--- a/.github/scripts/desktop-changelog.py
+++ b/.github/scripts/desktop-changelog.py
@@ -24,14 +24,16 @@ class ChangelogError(Exception):
 
 def read_json(path: Path) -> object:
     try:
-        return json.loads(path.read_text())
+        return json.loads(path.read_text(encoding="utf-8"))
     except json.JSONDecodeError as exc:
         raise ChangelogError(f"{path} is not valid JSON: {exc}") from exc
 
 
 def write_json(path: Path, data: object) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(data, indent=2, ensure_ascii=False) + "\n")
+    path.write_text(
+        json.dumps(data, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
+    )
 
 
 def normalize_changes(raw: object, path: Path) -> list[str]:

--- a/.github/scripts/test_desktop_changelog.py
+++ b/.github/scripts/test_desktop_changelog.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Behavioral contract tests for desktop changelog JSON encoding."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import unittest
+from pathlib import Path
+from typing import cast
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+MODULE_PATH = SCRIPT_DIR / "desktop-changelog.py"
+SPEC = importlib.util.spec_from_file_location("desktop_changelog", MODULE_PATH)
+assert SPEC and SPEC.loader
+desktop_changelog = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(desktop_changelog)
+
+
+class _Utf8OnlyReadPath:
+    def __init__(self, text: str) -> None:
+        self.text = text
+        self.encoding: str | None = None
+
+    def read_text(self, encoding: str | None = None) -> str:
+        self.encoding = encoding
+        if encoding != "utf-8":
+            raise UnicodeError("host locale cannot decode this UTF-8 file")
+        return self.text
+
+
+class _RecordingParent:
+    def __init__(self) -> None:
+        self.created = False
+
+    def mkdir(self, *, parents: bool, exist_ok: bool) -> None:
+        self.created = parents and exist_ok
+
+
+class _Utf8OnlyWritePath:
+    def __init__(self) -> None:
+        self.parent = _RecordingParent()
+        self.text = ""
+        self.encoding: str | None = None
+
+    def write_text(self, text: str, encoding: str | None = None) -> int:
+        self.encoding = encoding
+        if encoding != "utf-8":
+            raise UnicodeError("host locale cannot encode this changelog")
+        self.text = text
+        return len(text)
+
+
+class JsonEncodingTests(unittest.TestCase):
+    def test_read_json_uses_utf8_instead_of_the_host_locale(self) -> None:
+        expected = {"change": "Fixes \u2014 \U0001f6e0\ufe0f"}
+        path = _Utf8OnlyReadPath(json.dumps(expected, ensure_ascii=False))
+
+        actual = desktop_changelog.read_json(cast(Path, path))
+
+        self.assertEqual(actual, expected)
+        self.assertEqual(path.encoding, "utf-8")
+
+    def test_write_json_uses_utf8_and_preserves_unicode(self) -> None:
+        expected = {"change": "Fixes \u2014 \U0001f6e0\ufe0f"}
+        path = _Utf8OnlyWritePath()
+
+        desktop_changelog.write_json(cast(Path, path), expected)
+
+        self.assertTrue(path.parent.created)
+        self.assertEqual(path.encoding, "utf-8")
+        self.assertEqual(json.loads(path.text), expected)
+        self.assertIn(expected["change"], path.text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- reads and writes desktop changelog JSON with an explicit UTF-8 encoding
- adds a behavioral encoding contract for hosts whose default locale is not UTF-8
- registers the contract in the shared local/CI check manifest

Fixes #9717.

## Root cause

`desktop-changelog.py` relied on the implicit encoding of `Path.read_text()` and `Path.write_text()`. Native Windows Python uses the process ANSI code page when no encoding is supplied, so valid UTF-8 changelog content could raise `UnicodeDecodeError` under a GBK locale before validation started. The write path had the same host-dependent contract and could reject changelog text not representable in the active code page.

## Durable guard

The changelog boundary now always uses UTF-8 for both reads and writes. The regression tests provide path doubles that reject any omitted or non-UTF-8 encoding, and the shared check manifest runs those tests whenever the implementation or contract changes.

## Real-path exercise

On native Windows Python, I cleared `PYTHONUTF8` and ran `python .github/scripts/desktop-changelog.py validate`. The old code failed with a GBK `UnicodeDecodeError`; the fixed command completed successfully against the repository's real changelog data.

## Product invariants affected

None. This changes repository tooling only and does not affect product behavior.

## Validation

- old-code regression: `test_desktop_changelog.py` failed both encoding tests before the production change
- `python .github/scripts/test_desktop_changelog.py` -> 2 passed
- `python .github/scripts/desktop-changelog.py validate` with parent `PYTHONUTF8` unset -> passed
- `python .github/scripts/test_run_checks.py` -> 9 passed
- `python -m py_compile .github/scripts/desktop-changelog.py .github/scripts/test_desktop_changelog.py` -> passed
- `make preflight` with parent `PYTHONUTF8` unset -> all 9 selected checks passed
- `git diff --check origin/main...HEAD` -> passed


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9718?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

