### PR TITLE
fix(backend): render chat tool timestamps in the user's timezone (#6214)

### DIFF
--- a/backend/tests/unit/test_action_item_date_validation.py
+++ b/backend/tests/unit/test_action_item_date_validation.py
@@ -245,7 +245,7 @@ _stub_package("utils.retrieval.tools")
 _stub_package("utils.llm")
 _stub_package("utils.conversations")
 
-# Stub utils.conversations.render (action_item_tools imports resolve_display_tz)
+# Stub utils.conversations.render (action_item_tools imports resolve_display_tz, format_local_time)
 _render_stub = _stub_module("utils.conversations.render")
 
 
@@ -258,7 +258,14 @@ def _real_resolve_display_tz(tz):
     return timezone.utc, "UTC"
 
 
+def _real_format_local_time(dt, display_tz, tz_label):
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return f"{dt.astimezone(display_tz).strftime('%Y-%m-%d %H:%M:%S')} {tz_label}"
+
+
 _render_stub.resolve_display_tz = _real_resolve_display_tz
+_render_stub.format_local_time = _real_format_local_time
 
 # Stub utils.retrieval.agentic
 import contextvars

--- a/backend/tests/unit/test_action_item_tool_result_bound.py
+++ b/backend/tests/unit/test_action_item_tool_result_bound.py
@@ -89,7 +89,7 @@ for _name, _attrs in {
         "send_action_item_data_message",
         "sync_action_item_reminder",
     ],
-    "utils.conversations.render": ["resolve_display_tz"],
+    "utils.conversations.render": ["resolve_display_tz", "format_local_time"],
     "utils.retrieval.agentic": ["agent_config_context"],
 }.items():
     _m = _mod(_name)

--- a/backend/tests/unit/test_action_items_timezone.py
+++ b/backend/tests/unit/test_action_items_timezone.py
@@ -154,7 +154,14 @@ def _real_resolve_display_tz(tz):
     return timezone.utc, "UTC"
 
 
+def _real_format_local_time(dt, display_tz, tz_label):
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return f"{dt.astimezone(display_tz).strftime('%Y-%m-%d %H:%M:%S')} {tz_label}"
+
+
 _render_stub.resolve_display_tz = _real_resolve_display_tz
+_render_stub.format_local_time = _real_format_local_time
 
 # Stub utils.retrieval.agentic (agent_config_context)
 import contextvars
@@ -213,20 +220,20 @@ def _run(items, tz):
 
 
 # ===========================================================================
-# _format_local helper
+# format_local_time helper (shared, from utils.conversations.render)
 # ===========================================================================
 class TestFormatLocalHelper:
     def test_aware_utc_converted_to_user_tz_with_label(self):
-        out = action_item_tools._format_local(_UTC_INSTANT, ZoneInfo("America/Los_Angeles"), "America/Los_Angeles")
+        out = action_item_tools.format_local_time(_UTC_INSTANT, ZoneInfo("America/Los_Angeles"), "America/Los_Angeles")
         assert out == "2026-06-26 15:00:00 America/Los_Angeles"
 
     def test_naive_value_treated_as_utc(self):
         naive = datetime(2026, 6, 26, 22, 0, 0)  # no tzinfo
-        out = action_item_tools._format_local(naive, ZoneInfo("America/Los_Angeles"), "America/Los_Angeles")
+        out = action_item_tools.format_local_time(naive, ZoneInfo("America/Los_Angeles"), "America/Los_Angeles")
         assert out == "2026-06-26 15:00:00 America/Los_Angeles"
 
     def test_utc_label_unchanged(self):
-        out = action_item_tools._format_local(_UTC_INSTANT, timezone.utc, "UTC")
+        out = action_item_tools.format_local_time(_UTC_INSTANT, timezone.utc, "UTC")
         assert out == "2026-06-26 22:00:00 UTC"
 
 

--- a/backend/tests/unit/test_tool_services_timezone.py
+++ b/backend/tests/unit/test_tool_services_timezone.py
@@ -1,0 +1,200 @@
+"""Chat/agent tool timestamps render in the user's timezone (issue #6214).
+
+``/v1/tools/*`` (``routers/tools.py``) is the tool surface desktop, web, and MCP agent clients
+call. Its conversations service already localized timestamps, but two siblings did not:
+
+- ``get_action_items_text`` emitted a bare UTC wall clock (``Due: 2026-06-26 22:00:00``) with no
+  timezone label, so the model read it as local time and stated the wrong time of day.
+- ``search_memories_text`` / ``search_memories_tool`` emitted a bare UTC calendar date, which is a
+  day late for a user west of Greenwich in the evening.
+
+The modules under test are imported normally and their collaborators are swapped with
+``monkeypatch.setattr``, so the assertions run the real formatting code.
+"""
+
+import os
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from zoneinfo import ZoneInfo
+
+import pytest
+
+os.environ.setdefault(
+    "ENCRYPTION_SECRET",
+    "omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv",
+)
+os.environ.setdefault("OPENAI_API_KEY", "test-openai-key-not-real")
+
+import utils.conversations.render as render  # noqa: E402
+import utils.retrieval.tool_services.action_items as action_items_svc  # noqa: E402
+import utils.retrieval.tool_services.memories as memories_svc  # noqa: E402
+import utils.retrieval.tools.memory_tools as memory_tools  # noqa: E402
+from utils.memory.memory_system import MemorySystem  # noqa: E402
+
+# 22:00 UTC on 2026-06-26 is 19:00 the same day in Sao Paulo (UTC-3) — the reporter's 3-hour skew.
+UTC_INSTANT = datetime(2026, 6, 26, 22, 0, 0, tzinfo=timezone.utc)
+# 01:30 UTC on the 27th is still the 26th in Sao Paulo: the UTC date rolls over at a different
+# instant than the user's, which is what made memory dates a day late.
+UTC_AFTER_MIDNIGHT = datetime(2026, 6, 27, 1, 30, 0, tzinfo=timezone.utc)
+SAO_PAULO = "America/Sao_Paulo"
+
+
+@pytest.fixture
+def user_tz(monkeypatch):
+    """Set the timezone every module under test reads when rendering timestamps."""
+
+    def _set(tz, *, fail=False):
+        def _get_user_time_zone(uid):
+            if fail:
+                raise RuntimeError("firestore down")
+            return tz
+
+        for mod in (action_items_svc, memories_svc, memory_tools):
+            monkeypatch.setattr(mod.notification_db, "get_user_time_zone", _get_user_time_zone)
+
+    return _set
+
+
+def _memory(created_at):
+    return SimpleNamespace(
+        content="Likes espresso",
+        created_at=created_at,
+        category=SimpleNamespace(value="preferences"),
+    )
+
+
+def _run_action_items(monkeypatch, items):
+    monkeypatch.setattr(action_items_svc.action_items_db, "get_action_items", lambda *a, **k: items)
+    return action_items_svc.get_action_items_text(uid="test-uid")
+
+
+def _stub_canonical_memory_search(monkeypatch, module, memories):
+    """Point ``module`` at the canonical memory system and return ``memories`` from its search."""
+    matches = [SimpleNamespace(memory=m, score=0.9) for m in memories]
+    monkeypatch.setattr(module, "pin_memory_system", lambda *a, **k: MemorySystem.CANONICAL)
+    monkeypatch.setattr(
+        module,
+        "MemoryService",
+        lambda *a, **k: SimpleNamespace(search=lambda *sa, **sk: matches),
+    )
+
+
+# ---------------------------------------------------------------------------
+# The shared formatters
+# ---------------------------------------------------------------------------
+class TestRenderFormatters:
+    def test_time_converted_and_labelled(self):
+        assert render.format_local_time(UTC_INSTANT, ZoneInfo(SAO_PAULO), SAO_PAULO) == (
+            f"2026-06-26 19:00:00 {SAO_PAULO}"
+        )
+
+    def test_time_naive_value_treated_as_utc(self):
+        naive = datetime(2026, 6, 26, 22, 0, 0)
+        assert render.format_local_time(naive, ZoneInfo(SAO_PAULO), SAO_PAULO) == (f"2026-06-26 19:00:00 {SAO_PAULO}")
+
+    def test_date_rolls_back_across_utc_midnight(self):
+        assert render.format_local_date(UTC_AFTER_MIDNIGHT, ZoneInfo(SAO_PAULO)) == "2026-06-26"
+
+    def test_date_naive_value_treated_as_utc(self):
+        naive = datetime(2026, 6, 27, 1, 30, 0)
+        assert render.format_local_date(naive, ZoneInfo(SAO_PAULO)) == "2026-06-26"
+
+    def test_utc_fallback_unchanged(self):
+        assert render.format_local_time(UTC_INSTANT, timezone.utc, "UTC") == "2026-06-26 22:00:00 UTC"
+        assert render.format_local_date(UTC_AFTER_MIDNIGHT, timezone.utc) == "2026-06-27"
+
+
+# ---------------------------------------------------------------------------
+# get_action_items_text — the REST tool service the agent clients call
+# ---------------------------------------------------------------------------
+class TestActionItemsTextTimezone:
+    def test_due_and_created_rendered_in_user_timezone(self, monkeypatch, user_tz):
+        user_tz(SAO_PAULO)
+        out = _run_action_items(
+            monkeypatch,
+            [{'id': 'ai-1', 'description': 'Call the dentist', 'created_at': UTC_INSTANT, 'due_at': UTC_INSTANT}],
+        )
+        assert f"Due: 2026-06-26 19:00:00 {SAO_PAULO}" in out
+        assert f"Created: 2026-06-26 19:00:00 {SAO_PAULO}" in out
+        # The bare UTC wall clock the model used to misread as local time is gone.
+        assert "22:00:00" not in out
+
+    def test_completed_at_rendered_in_user_timezone(self, monkeypatch, user_tz):
+        user_tz(SAO_PAULO)
+        out = _run_action_items(
+            monkeypatch,
+            [{'id': 'ai-1', 'description': 'Ship it', 'completed': True, 'completed_at': UTC_INSTANT}],
+        )
+        assert f"Completed: 2026-06-26 19:00:00 {SAO_PAULO}" in out
+
+    def test_every_timestamp_carries_a_timezone_label(self, monkeypatch, user_tz):
+        user_tz(SAO_PAULO)
+        out = _run_action_items(
+            monkeypatch,
+            [
+                {
+                    'id': 'ai-1',
+                    'description': 'Call the dentist',
+                    'created_at': UTC_INSTANT,
+                    'due_at': UTC_INSTANT,
+                    'completed_at': UTC_INSTANT,
+                }
+            ],
+        )
+        stamped = [ln for ln in out.splitlines() if ln.strip().startswith(("Created:", "Due:", "Completed:"))]
+        assert len(stamped) == 3
+        for line in stamped:
+            assert line.rstrip().endswith(SAO_PAULO), f"unlabelled timestamp: {line!r}"
+
+    def test_naive_timestamp_treated_as_utc(self, monkeypatch, user_tz):
+        user_tz(SAO_PAULO)
+        out = _run_action_items(
+            monkeypatch,
+            [{'id': 'ai-1', 'description': 'Task', 'due_at': datetime(2026, 6, 26, 22, 0, 0)}],
+        )
+        assert f"Due: 2026-06-26 19:00:00 {SAO_PAULO}" in out
+
+    def test_unset_timezone_falls_back_to_labelled_utc(self, monkeypatch, user_tz):
+        user_tz(None)
+        out = _run_action_items(monkeypatch, [{'id': 'ai-1', 'description': 'Task', 'due_at': UTC_INSTANT}])
+        assert "Due: 2026-06-26 22:00:00 UTC" in out
+
+    def test_timezone_lookup_failure_does_not_abort_retrieval(self, monkeypatch, user_tz):
+        user_tz(None, fail=True)
+        out = _run_action_items(monkeypatch, [{'id': 'ai-1', 'description': 'Task', 'due_at': UTC_INSTANT}])
+        assert "Task" in out
+        assert "Due: 2026-06-26 22:00:00 UTC" in out
+
+
+# ---------------------------------------------------------------------------
+# Memory dates — REST tool service and the agentic tool
+# ---------------------------------------------------------------------------
+class TestMemoryDateTimezone:
+    def test_service_search_date_uses_user_timezone(self, monkeypatch, user_tz):
+        user_tz(SAO_PAULO)
+        _stub_canonical_memory_search(monkeypatch, memories_svc, [_memory(UTC_AFTER_MIDNIGHT)])
+        out = memories_svc.search_memories_text(uid="test-uid", query="coffee")
+        assert "date: 2026-06-26" in out
+        assert "date: 2026-06-27" not in out
+
+    def test_tool_search_date_uses_user_timezone(self, monkeypatch, user_tz):
+        user_tz(SAO_PAULO)
+        _stub_canonical_memory_search(monkeypatch, memory_tools, [_memory(UTC_AFTER_MIDNIGHT)])
+        out = memory_tools.search_memories_tool.func(
+            query="coffee",
+            config={"configurable": {"user_id": "test-uid"}},
+        )
+        assert "date: 2026-06-26" in out
+        assert "date: 2026-06-27" not in out
+
+    def test_unset_timezone_falls_back_to_utc_date(self, monkeypatch, user_tz):
+        user_tz(None)
+        _stub_canonical_memory_search(monkeypatch, memories_svc, [_memory(UTC_AFTER_MIDNIGHT)])
+        out = memories_svc.search_memories_text(uid="test-uid", query="coffee")
+        assert "date: 2026-06-27" in out
+
+    def test_missing_created_at_still_renders(self, monkeypatch, user_tz):
+        user_tz(SAO_PAULO)
+        _stub_canonical_memory_search(monkeypatch, memories_svc, [_memory(None)])
+        out = memories_svc.search_memories_text(uid="test-uid", query="coffee")
+        assert "date: Unknown" in out

--- a/backend/tests/unit/test_tools_router.py
+++ b/backend/tests/unit/test_tools_router.py
@@ -19,6 +19,7 @@ import types
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from unittest.mock import MagicMock, patch
+from zoneinfo import ZoneInfo
 
 import pytest
 from fastapi import FastAPI
@@ -249,6 +250,32 @@ calendar_tools_mod.create_calendar_event_tool = FakeCalendarEventTool()
 
 # Stub render and factory modules
 render_mod = _stub_module("utils.conversations.render")
+
+
+def _stub_resolve_display_tz(tz):
+    if tz:
+        try:
+            return ZoneInfo(tz), tz
+        except Exception:
+            pass
+    return timezone.utc, "UTC"
+
+
+def _stub_format_local_time(dt, display_tz, tz_label):
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return f"{dt.astimezone(display_tz).strftime('%Y-%m-%d %H:%M:%S')} {tz_label}"
+
+
+def _stub_format_local_date(dt, display_tz):
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(display_tz).strftime('%Y-%m-%d')
+
+
+render_mod.resolve_display_tz = _stub_resolve_display_tz
+render_mod.format_local_time = _stub_format_local_time
+render_mod.format_local_date = _stub_format_local_date
 render_mod.conversations_to_string = MagicMock(
     side_effect=lambda convs, **kw: f"[{len(convs)} conversations formatted]"
 )

--- a/backend/utils/conversations/render.py
+++ b/backend/utils/conversations/render.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from datetime import datetime, timezone
+from datetime import datetime, timezone, tzinfo
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Set, cast
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
@@ -28,6 +28,31 @@ def resolve_display_tz(tz: Optional[str]) -> Any:
         except (ZoneInfoNotFoundError, ValueError):
             logger.warning(f"resolve_display_tz: invalid timezone '{tz}', falling back to UTC")
     return timezone.utc, "UTC"
+
+
+def _as_utc(dt: datetime) -> datetime:
+    """Treat a naive timestamp as UTC so ``astimezone`` cannot reinterpret it as server-local."""
+    return dt.replace(tzinfo=timezone.utc) if dt.tzinfo is None else dt
+
+
+def format_local_time(dt: datetime, display_tz: tzinfo, tz_label: str) -> str:
+    """Render a stored timestamp as a labelled wall clock in the user's timezone.
+
+    Every timestamp a chat tool hands the model must carry a timezone label. An unlabelled
+    UTC wall clock reads as local time to the model, which then states the wrong time of day
+    ("tonight" for a mid-afternoon due date) — issues #4643 and #6214.
+    """
+    return f"{_as_utc(dt).astimezone(display_tz).strftime('%Y-%m-%d %H:%M:%S')} {tz_label}"
+
+
+def format_local_date(dt: datetime, display_tz: tzinfo) -> str:
+    """Render a stored timestamp as a calendar date in the user's timezone.
+
+    Needed because the UTC date rolls over at a different instant than the user's: a memory
+    captured at 21:00 in Sao Paulo is stored as the next UTC day, so a raw UTC date is a day
+    late for anyone west of Greenwich in the evening (issue #6214).
+    """
+    return _as_utc(dt).astimezone(display_tz).strftime('%Y-%m-%d')
 
 
 # ---------------------------------------------------------------------------

--- a/backend/utils/retrieval/tool_services/action_items.py
+++ b/backend/utils/retrieval/tool_services/action_items.py
@@ -7,12 +7,14 @@ from datetime import datetime, timedelta, timezone
 from typing import Optional, Any, Dict, List
 
 import database.action_items as action_items_db
+import database.notifications as notification_db
 from utils.notifications import (
     send_action_item_completed_notification,
     send_action_item_created_notification,
     send_action_item_data_message,
     sync_action_item_reminder,
 )
+from utils.conversations.render import format_local_time, resolve_display_tz
 from utils.retrieval.tool_services.conversations import parse_iso_date
 import logging
 
@@ -106,18 +108,26 @@ def get_action_items_text(
             status_info = " pending"
         return f"No{status_info} action items found{date_info}."
 
-    # Format
+    # Render timestamps in the user's local timezone with an explicit label, matching
+    # get_action_items_tool: an unlabelled UTC wall clock makes the agent state the wrong
+    # time of day (issue #6214). A timezone lookup failure must never abort retrieval.
+    try:
+        display_tz, tz_label = resolve_display_tz(notification_db.get_user_time_zone(uid))
+    except Exception as tz_error:
+        logger.warning(f"get_action_items_text - timezone lookup failed, formatting in UTC: {tz_error}")
+        display_tz, tz_label = timezone.utc, "UTC"
+
     result = f"User Action Items ({len(action_items)} total):\n\n"
     for i, item in enumerate(action_items, 1):
         status = "✅ Completed" if item.get('completed', False) else "⬜ Pending"
         result += f"{i}. [{status}] {item.get('description', 'No description')}\n"
         result += f"   ID: {item.get('id')}\n"
         if item.get('created_at'):
-            result += f"   Created: {item['created_at'].strftime('%Y-%m-%d %H:%M:%S')}\n"
+            result += f"   Created: {format_local_time(item['created_at'], display_tz, tz_label)}\n"
         if item.get('due_at'):
-            result += f"   Due: {item['due_at'].strftime('%Y-%m-%d %H:%M:%S')}\n"
+            result += f"   Due: {format_local_time(item['due_at'], display_tz, tz_label)}\n"
         if item.get('completed_at'):
-            result += f"   Completed: {item['completed_at'].strftime('%Y-%m-%d %H:%M:%S')}\n"
+            result += f"   Completed: {format_local_time(item['completed_at'], display_tz, tz_label)}\n"
         if item.get('conversation_id'):
             result += f"   From conversation: {item['conversation_id']}\n"
         result += "\n"

--- a/backend/utils/retrieval/tool_services/memories.py
+++ b/backend/utils/retrieval/tool_services/memories.py
@@ -3,12 +3,15 @@ Shared service functions for memory retrieval.
 Used by both LangChain tools (mobile chat) and REST router (desktop/web).
 """
 
+from datetime import timezone
 from typing import Optional, Any, Dict, List, cast
 
 import database.memories as memory_db
+import database.notifications as notification_db
 import database.vector_db as vector_db
 from database._client import db as firestore_db
 from models.memories import MemoryDB
+from utils.conversations.render import format_local_date, resolve_display_tz
 from utils.memory.memory_service import MemoryService
 from utils.memory.memory_system import MemorySystem
 from utils.memory.surface_routing import pin_memory_system
@@ -133,6 +136,14 @@ def search_memories_text(
 
     limit = max(1, min(limit, 20))
 
+    # Memory dates go to the chat model; the UTC date rolls over at a different instant than
+    # the user's, so a raw UTC date is a day late for them in the evening (issue #6214).
+    try:
+        display_tz, _ = resolve_display_tz(notification_db.get_user_time_zone(uid))
+    except Exception as tz_error:
+        logger.warning(f"search_memories_text - timezone lookup failed, formatting dates in UTC: {tz_error}")
+        display_tz = timezone.utc
+
     memory_system = pin_memory_system(uid, db_client=firestore_db)
     if memory_system == MemorySystem.CANONICAL:
         matches = MemoryService(db_client=firestore_db).search(uid, query, limit=limit)
@@ -141,7 +152,7 @@ def search_memories_text(
         result = f"Found {len(matches)} memories matching '{query}':\n\n"
         for match in matches:
             memory = match.memory
-            date_str = memory.created_at.strftime('%Y-%m-%d') if memory.created_at else 'Unknown'
+            date_str = format_local_date(memory.created_at, display_tz) if memory.created_at else 'Unknown'
             result += (
                 f"- {memory.content} (relevance: {match.score:.2f}, "
                 f"category: {memory.category.value}, date: {date_str})\n"
@@ -202,7 +213,7 @@ def search_memories_text(
         for item in memory_objects:
             memory = item['memory']
             score = item['score']
-            date_str = memory.created_at.strftime('%Y-%m-%d') if memory.created_at else 'Unknown'
+            date_str = format_local_date(memory.created_at, display_tz) if memory.created_at else 'Unknown'
             result += (
                 f"- {memory.content} (relevance: {score:.2f}, category: {memory.category.value}, date: {date_str})\n"
             )

--- a/backend/utils/retrieval/tools/action_item_tools.py
+++ b/backend/utils/retrieval/tools/action_item_tools.py
@@ -2,7 +2,7 @@
 Tools for accessing and managing user action items.
 """
 
-from datetime import datetime, timedelta, timezone, tzinfo
+from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional, Tuple, cast
 import contextvars
 
@@ -17,7 +17,7 @@ from utils.notifications import (
     send_action_item_data_message,
     sync_action_item_reminder,
 )
-from utils.conversations.render import resolve_display_tz
+from utils.conversations.render import format_local_time, resolve_display_tz
 import logging
 
 logger = logging.getLogger(__name__)
@@ -28,18 +28,6 @@ try:
 except ImportError:
     # Fallback if import fails
     agent_config_context = contextvars.ContextVar('agent_config', default=None)
-
-
-def _format_local(dt: datetime, display_tz: tzinfo, tz_label: str) -> str:
-    """Render a stored timestamp in the user's local timezone with a tz label.
-
-    Action-item timestamps are stored tz-aware (UTC); a naive value is treated as
-    UTC defensively so the chat model never sees an unlabeled wall-clock time and
-    mislabels the time of day (issue #4643).
-    """
-    if dt.tzinfo is None:
-        dt = dt.replace(tzinfo=timezone.utc)
-    return f"{dt.astimezone(display_tz).strftime('%Y-%m-%d %H:%M:%S')} {tz_label}"
 
 
 # Bound the chat tool result so a broad request ("show me all my tasks") cannot flood the chat
@@ -341,13 +329,13 @@ def get_action_items_tool(
 
         # Add dates if available (rendered in the user's local timezone)
         if item.get('created_at'):
-            result += f"   Created: {_format_local(item['created_at'], display_tz, tz_label)}\n"
+            result += f"   Created: {format_local_time(item['created_at'], display_tz, tz_label)}\n"
 
         if item.get('due_at'):
-            result += f"   Due: {_format_local(item['due_at'], display_tz, tz_label)}\n"
+            result += f"   Due: {format_local_time(item['due_at'], display_tz, tz_label)}\n"
 
         if item.get('completed_at'):
-            result += f"   Completed: {_format_local(item['completed_at'], display_tz, tz_label)}\n"
+            result += f"   Completed: {format_local_time(item['completed_at'], display_tz, tz_label)}\n"
 
         if item.get('conversation_id'):
             result += f"   From conversation: {item['conversation_id']}\n"

--- a/backend/utils/retrieval/tools/memory_tools.py
+++ b/backend/utils/retrieval/tools/memory_tools.py
@@ -2,7 +2,7 @@
 Tools for accessing user memories and facts.
 """
 
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, cast
 import contextvars
 
@@ -10,6 +10,7 @@ from langchain_core.tools import tool  # type: ignore[reportUnknownVariableType]
 from langchain_core.runnables import RunnableConfig
 
 import database.memories as memory_db
+import database.notifications as notification_db
 import database.vector_db as vector_db
 from database._client import db as firestore_db
 from models.memories import MemoryDB
@@ -21,6 +22,7 @@ from utils.memory.chat_memory_adapter import (
     search_memory_default_chat_memories_vector_decision_text,
 )
 from utils.memory.default_read_rollout import MemoryReadDecision
+from utils.conversations.render import format_local_date, resolve_display_tz
 from utils.retrieval.hybrid import rrf_rerank
 from utils.retrieval.tools.result_bounds import cap_items_for_llm, bounded_result
 import logging
@@ -340,6 +342,14 @@ def search_memories_tool(
     # Cap limit at 20
     limit = min(limit, 20)
 
+    # Memory dates go to the chat model; the UTC date rolls over at a different instant than
+    # the user's, so a raw UTC date is a day late for them in the evening (issue #6214).
+    try:
+        display_tz, _ = resolve_display_tz(notification_db.get_user_time_zone(uid))
+    except Exception as tz_error:
+        logger.warning(f"search_memories_tool - timezone lookup failed, formatting dates in UTC: {tz_error}")
+        display_tz = timezone.utc
+
     memory_system = pin_memory_system(uid, db_client=firestore_db)
     if memory_system == MemorySystem.CANONICAL:
         matches = MemoryService(db_client=firestore_db).search(uid, query, limit=limit)
@@ -352,7 +362,7 @@ def search_memories_tool(
         result = f"Found {len(matches)} memories matching '{query}':\n\n"
         for match in matches:
             memory = match.memory
-            date_str = memory.created_at.strftime('%Y-%m-%d') if memory.created_at else 'Unknown'
+            date_str = format_local_date(memory.created_at, display_tz) if memory.created_at else 'Unknown'
             result += (
                 f"- {memory.content} (relevance: {match.score:.2f}, "
                 f"category: {memory.category.value}, date: {date_str})\n"
@@ -443,7 +453,7 @@ def search_memories_tool(
         for item in memory_objects:
             memory = item['memory']
             score = item['score']
-            date_str = memory.created_at.strftime('%Y-%m-%d') if memory.created_at else 'Unknown'
+            date_str = format_local_date(memory.created_at, display_tz) if memory.created_at else 'Unknown'
             result += (
                 f"- {memory.content} (relevance: {score:.2f}, category: {memory.category.value}, date: {date_str})\n"
             )


### PR DESCRIPTION
## What

Chat/agent tool results that still emitted **bare UTC timestamps** now render in the user's configured timezone, with an explicit timezone label.

Three surfaces were leaking UTC:

| Surface | Before | After |
|---|---|---|
| `get_action_items_text` (`/v1/tools/action-items` — desktop, web, MCP agent clients) | `Due: 2026-06-26 22:00:00` | `Due: 2026-06-26 19:00:00 America/Sao_Paulo` |
| `search_memories_text` (same REST surface) | `date: 2026-06-27` | `date: 2026-06-26` |
| `search_memories_tool` (agentic chat) | `date: 2026-06-27` | `date: 2026-06-26` |

## Why

From #6214:

> When chatting with Omi AI, it confuses hours and gives wrong times because it's not properly handling the user's timezone.
> User asks "what time did X happen?" → AI answers with UTC time (**off by 3 hours** for a UTC-3 user) instead of converting to the user's local timezone (America/Sao_Paulo).
>
> **Expected:** AI should *always* use the user's configured timezone when discussing times in chat.

The conversations half of this was fixed in #7736 (`conversations_to_string` localizes), but the **action-item and memory tool results were never converted** — so the issue's "always" is still not true today, and the reporter's exact symptom survives on the surfaces above.

The failure mode is specifically the **missing timezone label**: an unlabelled UTC wall clock reads as local time to the model, so it says "tonight" for a due date that is actually mid-afternoon for the user. Memory dates are worse in a quieter way — the UTC calendar date rolls over at a different instant than the user's, so a memory captured at 21:00 in São Paulo is reported a day late.

## Root cause / bug class

The agentic action-item tool already fixed exactly this in #4643, but the fix was applied at one call site rather than the shared boundary. Its REST sibling (`tool_services/action_items.py`) and both memory paths kept formatting raw `strftime` output.

To close the class rather than patch one more site, the formatting now has **one owner**: `_format_local` is promoted out of `action_item_tools.py` into `utils/conversations/render.py` as `format_local_time` (next to the existing `resolve_display_tz`), plus a new `format_local_date` for the date-only case. Both treat a naive timestamp as UTC defensively, so no path can hand the model an unlabelled wall clock.

A timezone lookup failure falls back to **labelled** UTC and never aborts retrieval.

## Verified

Backend env synced with `./scripts/sync-python-deps.sh`; `ENCRYPTION_SECRET` / `OPENAI_API_KEY` per `test.sh`.

**1. Regression tests fail without the fix.** New `backend/tests/unit/test_tool_services_timezone.py` (15 tests) imports the real modules and swaps collaborators with `monkeypatch`, so it exercises the production formatters. Reverting only the three production files and re-running:

```
8 failed, 10 passed      <- pre-fix (behavioural assertions on the rendered string)
15 passed                <- with the fix
```

**2. Real rendered tool output** (the string the model actually receives), user tz `America/Sao_Paulo`, stored `due_at = 2026-06-26T22:00:00Z`:

```
BEFORE:   Due: 2026-06-26 22:00:00                        <- no tz; model reads it as 22:00 local
AFTER:    Created: 2026-06-26 19:00:00 America/Sao_Paulo
          Due:     2026-06-26 19:00:00 America/Sao_Paulo

memory stored 2026-06-27T01:30Z
BEFORE:   date: 2026-06-27                                 <- a day late for the user
AFTER:    date: 2026-06-26
```

That is the reporter's 3-hour skew, gone.

**3. Full backend suite** — `bash test.sh`: no collection errors, no regressions. The single failure, `test_vad_gate.py::test_concurrent_sessions_no_deadlock`, is a **pre-existing flake unrelated to this change** (it touches none of the changed modules); A/B'd against pristine `origin/main`, where it fails 3/3 runs in isolation while this branch passes 2/3.

**4. `make preflight`** — `PR preflight passed: 8 checks`.

Covered: conversion correctness, naive-timestamp handling, the label on every emitted timestamp, unset-timezone fallback, and timezone-lookup failure.

## Not covered

`MemoryDB.get_memories_as_str` still renders `... UTC` — it is explicitly labelled, so the model can convert it correctly and it is not the mislabelling bug; threading a timezone into that shared model method is a wider change and is left out deliberately.

fixes #6214

---
Auto-generated from issue feedback by the mini issues-improver. Review before merge.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9719?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

