### PR TITLE
test(desktop-backend): bypass proxies for loopback tests

### DIFF
--- a/desktop/macos/Backend-Rust/src/routes/proxy.rs
+++ b/desktop/macos/Backend-Rust/src/routes/proxy.rs
@@ -1317,6 +1317,10 @@ mod tests {
     use tokio::net::{TcpListener, TcpStream};
     use tokio::sync::oneshot;
 
+    fn local_test_client() -> reqwest::Client {
+        reqwest::Client::builder().no_proxy().build().unwrap()
+    }
+
     async fn spawn_hanging_upstream() -> (
         String,
         oneshot::Receiver<()>,
@@ -1457,7 +1461,7 @@ mod tests {
     #[tokio::test]
     async fn hanging_upstream_is_cancelled_at_injected_deadline() {
         let (url, request_seen, disconnected, server) = spawn_hanging_upstream().await;
-        let client = reqwest::Client::new();
+        let client = local_test_client();
         let (deadline_tx, deadline_rx) = oneshot::channel();
         let work = tokio::spawn(async move {
             race_gemini_deadline(
@@ -1489,7 +1493,7 @@ mod tests {
     #[tokio::test]
     async fn dropping_proxy_work_cancels_the_upstream_socket() {
         let (url, request_seen, disconnected, server) = spawn_hanging_upstream().await;
-        let client = reqwest::Client::new();
+        let client = local_test_client();
         let proxy_work = tokio::spawn(async move {
             within_gemini_deadline(
                 Duration::from_secs(30),
@@ -1515,7 +1519,7 @@ mod tests {
     async fn downstream_http_disconnect_cancels_upstream_work() {
         let (upstream_url, request_seen, disconnected, upstream_server) =
             spawn_hanging_upstream().await;
-        let client = reqwest::Client::new();
+        let client = local_test_client();
         let app = Router::new().route(
             "/",
             post(move || {
@@ -1560,7 +1564,7 @@ mod tests {
     #[tokio::test]
     async fn one_budget_includes_pre_dispatch_work_and_upstream_wait() {
         let (url, request_seen, disconnected, server) = spawn_hanging_upstream().await;
-        let client = reqwest::Client::new();
+        let client = local_test_client();
         let (dispatch_tx, dispatch_rx) = oneshot::channel();
         let (deadline_tx, deadline_rx) = oneshot::channel();
         let work = tokio::spawn(async move {


### PR DESCRIPTION
## What changed and why

Closes #9722.

Use a shared test-only reqwest client with system proxies disabled for the four proxy cancellation tests backed by an in-process loopback listener. This keeps production proxy behavior unchanged while making the tests deterministic on Windows hosts with a user proxy enabled.

## Product invariants affected

none

## How it was verified

Verified on Windows 11 with the user proxy still enabled at `127.0.0.1:7897`:

- Before the fix, the four cancellation/disconnect tests consistently failed because reqwest received a proxy-generated `502` and the loopback listener never saw the request.
- `cargo test routes::proxy::tests::` -> 87 passed
- `cargo test` -> 360 passed
- `cargo fmt --check` -> passed
- `cargo clippy -- -D warnings` -> passed
- `scripts/pre-push fork` -> passed all selected checks with `PYTHONUTF8=1` and the internal-only changelog skip

The actual push used `--no-verify` only after the equivalent pre-push command passed because the single-flight hook wrapper currently crashes on Windows; #9724 tracks that separate issue.

## Tests

The four existing loopback cancellation tests are the regression coverage. They fail on the old code when a Windows system proxy is enabled and pass with the test client isolated from host proxy settings.

## Root cause and durable guard (bug fixes)

The violated contract was that an in-process loopback test server must receive the test request directly. `reqwest::Client::new()` honors the Windows user proxy, and that proxy can intercept `127.0.0.1` requests before they reach the test listener.

All four affected tests now obtain their client from one `local_test_client()` helper that calls `.no_proxy()`. The production Gemini clients are untouched, and future loopback cancellation coverage in this module has a single portable client factory to reuse.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9725?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

