### PR TITLE
fix(dev): code-own What Matters Now smoke fixture

### DIFF
--- a/.github/workflows/gcp_backend.yml
+++ b/.github/workflows/gcp_backend.yml
@@ -447,7 +447,6 @@ jobs:
       - name: Smoke What Matters Now datastore query
         if: ${{ github.event.inputs.environment == 'development' }}
         env:
-          OMI_TASK_INTELLIGENCE_SMOKE_UID: ${{ secrets.OMI_TASK_INTELLIGENCE_SMOKE_UID }}
           PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
         run: |
           set -euo pipefail

--- a/.github/workflows/gcp_backend_auto_dev.yml
+++ b/.github/workflows/gcp_backend_auto_dev.yml
@@ -369,7 +369,6 @@ jobs:
 
       - name: Smoke What Matters Now datastore query
         env:
-          OMI_TASK_INTELLIGENCE_SMOKE_UID: ${{ secrets.OMI_TASK_INTELLIGENCE_SMOKE_UID }}
           PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
         run: |
           set -euo pipefail

--- a/backend/config/what_matters_now_smoke_fixture.py
+++ b/backend/config/what_matters_now_smoke_fixture.py
@@ -1,0 +1,15 @@
+"""Code-owned identity and runtime gate for the development What Matters Now smoke."""
+
+import os
+
+WHAT_MATTERS_NOW_SMOKE_UID = 'omi-dev-what-matters-now-smoke-v1'
+
+
+def is_development_smoke_fixture(uid: str, *, stage: str | None = None) -> bool:
+    """Return whether ``uid`` is the one fixture allowed by an explicit dev runtime."""
+
+    runtime_stage = os.getenv('OMI_ENV_STAGE') if stage is None else stage
+    return runtime_stage == 'dev' and uid == WHAT_MATTERS_NOW_SMOKE_UID
+
+
+__all__ = ['WHAT_MATTERS_NOW_SMOKE_UID', 'is_development_smoke_fixture']

--- a/backend/database/task_intelligence_control.py
+++ b/backend/database/task_intelligence_control.py
@@ -2,15 +2,27 @@
 
 from typing import Any, cast
 
+from google.api_core.exceptions import AlreadyExists, Conflict
+
+from config.what_matters_now_smoke_fixture import WHAT_MATTERS_NOW_SMOKE_UID, is_development_smoke_fixture
 from database._client import db
-from models.task_intelligence import TaskWorkflowControl
+from models.task_intelligence import TaskWorkflowControl, TaskWorkflowMode
 
 CONTROL_COLLECTION = 'task_intelligence_control'
 CONTROL_DOCUMENT = 'state'
+_SMOKE_FIXTURE_CONTROL = TaskWorkflowControl(workflow_mode=TaskWorkflowMode.read, account_generation=0)
+
+
+class DevelopmentSmokeFixtureConflictError(RuntimeError):
+    """The code-owned smoke fixture will not replace an existing control document."""
+
+
+def _control_ref(uid: str):
+    return db.collection('users').document(uid).collection(CONTROL_COLLECTION).document(CONTROL_DOCUMENT)
 
 
 def get_task_workflow_control(uid: str) -> TaskWorkflowControl:
-    ref = db.collection('users').document(uid).collection(CONTROL_COLLECTION).document(CONTROL_DOCUMENT)
+    ref = _control_ref(uid)
     snapshot = ref.get()
     if snapshot.exists is not True:
         return TaskWorkflowControl()
@@ -21,8 +33,35 @@ def get_task_workflow_control(uid: str) -> TaskWorkflowControl:
 
 
 def set_task_workflow_control(uid: str, control: TaskWorkflowControl) -> None:
-    ref = db.collection('users').document(uid).collection(CONTROL_COLLECTION).document(CONTROL_DOCUMENT)
+    ref = _control_ref(uid)
     ref.set(control.model_dump(mode='json'))
 
 
-__all__ = ['get_task_workflow_control', 'set_task_workflow_control']
+def ensure_development_smoke_fixture(uid: str, *, stage: str | None = None) -> bool:
+    """Create the dev fixture control once, without replacing any existing state."""
+
+    if not is_development_smoke_fixture(uid, stage=stage):
+        return False
+    expected_payload = _SMOKE_FIXTURE_CONTROL.model_dump(mode='json')
+    ref = _control_ref(uid)
+    try:
+        # Firestore's create operation is an atomic exists=false compare-and-create.
+        ref.create(expected_payload)
+    except (AlreadyExists, Conflict):
+        snapshot = ref.get()
+        if snapshot.exists and snapshot.to_dict() == expected_payload:
+            return False
+        raise DevelopmentSmokeFixtureConflictError(
+            'development smoke fixture control already exists with differing state'
+        ) from None
+
+    return True
+
+
+__all__ = [
+    'WHAT_MATTERS_NOW_SMOKE_UID',
+    'DevelopmentSmokeFixtureConflictError',
+    'ensure_development_smoke_fixture',
+    'get_task_workflow_control',
+    'set_task_workflow_control',
+]

--- a/backend/routers/task_recommendations.py
+++ b/backend/routers/task_recommendations.py
@@ -126,6 +126,7 @@ def get_what_matters_now(
     device_id: Optional[str] = Query(default=None, min_length=1, max_length=128),
     uid: str = Depends(auth.get_current_user_uid),
 ):
+    task_control_db.ensure_development_smoke_fixture(uid)
     rollout = _require_product(uid)
     bound_device_id = _bound_device_id(request_context, device_id, required=False)
     try:

--- a/backend/scripts/smoke_what_matters_now.py
+++ b/backend/scripts/smoke_what_matters_now.py
@@ -7,16 +7,21 @@ import argparse
 import os
 import sys
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Callable
 from urllib.error import HTTPError, URLError
 from urllib.parse import urlparse
 from urllib.request import Request, urlopen
 
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(BACKEND_ROOT))
+
+from config.what_matters_now_smoke_fixture import WHAT_MATTERS_NOW_SMOKE_UID  # noqa: E402
+
 
 @dataclass(frozen=True)
 class SmokeConfig:
     base_url: str
-    uid: str
     admin_key: str
     timeout_seconds: float
 
@@ -34,7 +39,10 @@ def run_smoke(config: SmokeConfig, *, http_open: Callable = urlopen) -> int:
     request = Request(
         url,
         method='GET',
-        headers={'Accept': 'application/json', 'Authorization': f'Bearer {config.admin_key}{config.uid}'},
+        headers={
+            'Accept': 'application/json',
+            'Authorization': f'Bearer {config.admin_key}{WHAT_MATTERS_NOW_SMOKE_UID}',
+        },
     )
     try:
         with http_open(request, timeout=config.timeout_seconds) as response:
@@ -53,15 +61,10 @@ def run_smoke(config: SmokeConfig, *, http_open: Callable = urlopen) -> int:
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument('--base-url', required=True)
-    parser.add_argument('--uid-env', default='OMI_TASK_INTELLIGENCE_SMOKE_UID')
     parser.add_argument('--admin-key-env', default='ADMIN_KEY')
     parser.add_argument('--timeout-seconds', type=float, default=30.0)
     args = parser.parse_args()
-    uid = os.environ.get(args.uid_env, '').strip()
     admin_key = os.environ.get(args.admin_key_env, '').strip()
-    if not uid:
-        print(f'ERROR: required smoke UID environment variable {args.uid_env} is empty', file=sys.stderr)
-        return 1
     if not admin_key:
         print(f'ERROR: required admin-key environment variable {args.admin_key_env} is empty', file=sys.stderr)
         return 1
@@ -69,7 +72,6 @@ def main() -> int:
         run_smoke(
             SmokeConfig(
                 base_url=args.base_url,
-                uid=uid,
                 admin_key=admin_key,
                 timeout_seconds=args.timeout_seconds,
             )

--- a/backend/tests/unit/test_smoke_what_matters_now.py
+++ b/backend/tests/unit/test_smoke_what_matters_now.py
@@ -1,9 +1,11 @@
+from pathlib import Path
 from types import SimpleNamespace
 from urllib.error import HTTPError
 
 import pytest
 
 from scripts import smoke_what_matters_now
+from config.what_matters_now_smoke_fixture import WHAT_MATTERS_NOW_SMOKE_UID
 
 
 class _Response:
@@ -27,16 +29,14 @@ def test_smoke_uses_admin_auth_without_reading_or_reporting_the_response_body(ca
         return _Response(200)
 
     status = smoke_what_matters_now.run_smoke(
-        smoke_what_matters_now.SmokeConfig(
-            base_url='https://api.omi.dev/', uid='private-test-uid', admin_key='private-key', timeout_seconds=7
-        ),
+        smoke_what_matters_now.SmokeConfig(base_url='https://api.omi.dev/', admin_key='private-key', timeout_seconds=7),
         http_open=http_open,
     )
 
     assert status == 200
     assert captured == {
         'url': 'https://api.omi.dev/v1/what-matters-now',
-        'authorization': 'Bearer private-keyprivate-test-uid',
+        'authorization': f'Bearer private-key{WHAT_MATTERS_NOW_SMOKE_UID}',
         'timeout': 7,
     }
     output = capsys.readouterr().out
@@ -51,7 +51,7 @@ def test_smoke_fails_on_a_backend_5xx_without_exposing_the_response_body():
     with pytest.raises(RuntimeError, match='HTTP 500'):
         smoke_what_matters_now.run_smoke(
             smoke_what_matters_now.SmokeConfig(
-                base_url='https://api.omi.dev', uid='private-test-uid', admin_key='private-key', timeout_seconds=7
+                base_url='https://api.omi.dev', admin_key='private-key', timeout_seconds=7
             ),
             http_open=http_open,
         )
@@ -60,8 +60,30 @@ def test_smoke_fails_on_a_backend_5xx_without_exposing_the_response_body():
 def test_smoke_rejects_non_http_base_urls():
     with pytest.raises(ValueError, match='absolute HTTP'):
         smoke_what_matters_now.run_smoke(
-            smoke_what_matters_now.SmokeConfig(
-                base_url='not-a-url', uid='private-test-uid', admin_key='private-key', timeout_seconds=7
-            ),
+            smoke_what_matters_now.SmokeConfig(base_url='not-a-url', admin_key='private-key', timeout_seconds=7),
             http_open=SimpleNamespace(),
         )
+
+
+def test_main_uses_the_code_owned_fixture_without_a_uid_environment_variable(monkeypatch):
+    captured = {}
+    monkeypatch.setenv('ADMIN_KEY', 'private-key')
+    monkeypatch.delenv('OMI_TASK_INTELLIGENCE_SMOKE_UID', raising=False)
+    monkeypatch.setattr(smoke_what_matters_now.sys, 'argv', ['smoke', '--base-url', 'https://api.omi.dev'])
+    monkeypatch.setattr(
+        smoke_what_matters_now, 'run_smoke', lambda config: captured.setdefault('config', config) or 200
+    )
+
+    assert smoke_what_matters_now.main() == 0
+    assert captured['config'] == smoke_what_matters_now.SmokeConfig(
+        base_url='https://api.omi.dev', admin_key='private-key', timeout_seconds=30.0
+    )
+
+
+def test_development_deploy_workflows_use_only_the_existing_admin_key_for_the_smoke():
+    root = Path(__file__).resolve().parents[3]
+    for workflow_name in ('gcp_backend.yml', 'gcp_backend_auto_dev.yml'):
+        workflow = (root / '.github' / 'workflows' / workflow_name).read_text(encoding='utf-8')
+        assert 'OMI_TASK_INTELLIGENCE_SMOKE_UID' not in workflow
+        assert '--secret=ADMIN_KEY' in workflow
+        assert 'smoke_what_matters_now.py --base-url https://api.omi.dev' in workflow

--- a/backend/tests/unit/test_task_intelligence_rollout.py
+++ b/backend/tests/unit/test_task_intelligence_rollout.py
@@ -1,6 +1,7 @@
 import pytest
 
 from models.task_intelligence import TaskWorkflowMode
+from config.what_matters_now_smoke_fixture import WHAT_MATTERS_NOW_SMOKE_UID
 from utils.task_intelligence import rollout as rollout_module
 from utils.task_intelligence.rollout import resolve_task_intelligence_for_user, resolve_task_intelligence_rollout
 from utils.memory.memory_system import MemorySystem
@@ -52,6 +53,32 @@ def test_production_resolver_fails_closed_for_legacy_memory_user(monkeypatch):
     assert decision.canonical_reads_authoritative is True
     assert decision.memory_cohort_eligible is False
     assert decision.intelligence_evaluation_enabled is False
+    assert decision.intelligence_product_enabled is False
+
+
+def test_explicit_dev_runtime_allows_only_the_code_owned_smoke_fixture(monkeypatch):
+    monkeypatch.setenv('OMI_ENV_STAGE', 'dev')
+    monkeypatch.setattr(rollout_module, 'resolve_memory_system', lambda uid, db_client=None: MemorySystem.LEGACY)
+
+    decision = resolve_task_intelligence_for_user(uid=WHAT_MATTERS_NOW_SMOKE_UID, workflow_mode='read')
+
+    assert decision.memory_cohort_eligible is True
+    assert decision.intelligence_product_enabled is True
+    other = resolve_task_intelligence_for_user(uid='another-user', workflow_mode='read')
+    assert other.intelligence_product_enabled is False
+
+
+@pytest.mark.parametrize('stage', ['', 'local', 'prod'])
+def test_smoke_fixture_rollout_fails_closed_outside_explicit_dev_runtime(monkeypatch, stage):
+    if stage:
+        monkeypatch.setenv('OMI_ENV_STAGE', stage)
+    else:
+        monkeypatch.delenv('OMI_ENV_STAGE', raising=False)
+    monkeypatch.setattr(rollout_module, 'resolve_memory_system', lambda uid, db_client=None: MemorySystem.LEGACY)
+
+    decision = resolve_task_intelligence_for_user(uid=WHAT_MATTERS_NOW_SMOKE_UID, workflow_mode='read')
+
+    assert decision.memory_cohort_eligible is False
     assert decision.intelligence_product_enabled is False
 
 

--- a/backend/tests/unit/test_what_matters_now_smoke_fixture.py
+++ b/backend/tests/unit/test_what_matters_now_smoke_fixture.py
@@ -1,0 +1,90 @@
+from copy import deepcopy
+
+import pytest
+
+import database.task_intelligence_control as task_control_db
+from models.task_intelligence import TaskWorkflowControl, TaskWorkflowMode
+
+
+class _ControlSnapshot:
+    def __init__(self, payload):
+        self._payload = deepcopy(payload)
+        self.exists = payload is not None
+
+    def to_dict(self):
+        return deepcopy(self._payload)
+
+
+class _CreateOnlyControlReference:
+    def __init__(self, payload=None):
+        self.payload = deepcopy(payload)
+        self.create_payloads = []
+
+    def create(self, payload):
+        self.create_payloads.append(deepcopy(payload))
+        if self.payload is not None:
+            raise task_control_db.AlreadyExists('control already exists')
+        self.payload = deepcopy(payload)
+
+    def get(self):
+        return _ControlSnapshot(self.payload)
+
+
+def test_fixture_identity_is_code_owned_and_requires_explicit_dev_runtime(monkeypatch):
+    assert task_control_db.is_development_smoke_fixture(task_control_db.WHAT_MATTERS_NOW_SMOKE_UID, stage='dev')
+    assert not task_control_db.is_development_smoke_fixture('another-user', stage='dev')
+    assert not task_control_db.is_development_smoke_fixture(task_control_db.WHAT_MATTERS_NOW_SMOKE_UID, stage='prod')
+    assert not task_control_db.is_development_smoke_fixture(task_control_db.WHAT_MATTERS_NOW_SMOKE_UID, stage='local')
+
+    monkeypatch.setenv('OMI_ENV_STAGE', 'dev')
+    assert task_control_db.is_development_smoke_fixture(task_control_db.WHAT_MATTERS_NOW_SMOKE_UID)
+
+
+def test_fixture_setup_create_only_writes_the_minimal_control_document(monkeypatch):
+    expected = TaskWorkflowControl(workflow_mode=TaskWorkflowMode.read, account_generation=0)
+    control_ref = _CreateOnlyControlReference()
+
+    monkeypatch.setattr(task_control_db, '_control_ref', lambda _uid: control_ref)
+
+    assert task_control_db.ensure_development_smoke_fixture(task_control_db.WHAT_MATTERS_NOW_SMOKE_UID, stage='dev')
+    assert control_ref.payload == expected.model_dump(mode='json')
+    assert control_ref.create_payloads == [expected.model_dump(mode='json')]
+
+
+def test_fixture_setup_is_idempotent_when_expected_control_already_exists(monkeypatch):
+    expected = TaskWorkflowControl(workflow_mode=TaskWorkflowMode.read, account_generation=0).model_dump(mode='json')
+    control_ref = _CreateOnlyControlReference(expected)
+
+    monkeypatch.setattr(task_control_db, '_control_ref', lambda _uid: control_ref)
+
+    assert not task_control_db.ensure_development_smoke_fixture(task_control_db.WHAT_MATTERS_NOW_SMOKE_UID, stage='dev')
+    assert control_ref.payload == expected
+    assert control_ref.create_payloads == [expected]
+
+
+def test_fixture_setup_preserves_differing_existing_control_and_fails_smoke(monkeypatch):
+    differing_control = {'workflow_mode': 'write', 'account_generation': 3}
+    control_ref = _CreateOnlyControlReference(differing_control)
+
+    monkeypatch.setattr(task_control_db, '_control_ref', lambda _uid: control_ref)
+
+    with pytest.raises(task_control_db.DevelopmentSmokeFixtureConflictError, match='differing state'):
+        task_control_db.ensure_development_smoke_fixture(task_control_db.WHAT_MATTERS_NOW_SMOKE_UID, stage='dev')
+
+    assert control_ref.payload == differing_control
+    assert control_ref.create_payloads == [
+        TaskWorkflowControl(workflow_mode=TaskWorkflowMode.read, account_generation=0).model_dump(mode='json')
+    ]
+
+
+def test_fixture_setup_fails_closed_without_a_development_runtime(monkeypatch):
+    monkeypatch.setattr(
+        task_control_db,
+        'get_task_workflow_control',
+        lambda _uid: (_ for _ in ()).throw(AssertionError('Firestore must not be read outside dev')),
+    )
+
+    assert not task_control_db.ensure_development_smoke_fixture(
+        task_control_db.WHAT_MATTERS_NOW_SMOKE_UID, stage='prod'
+    )
+    assert not task_control_db.ensure_development_smoke_fixture('another-user', stage='dev')

--- a/backend/tests/unit/test_workstream_router_contract.py
+++ b/backend/tests/unit/test_workstream_router_contract.py
@@ -16,6 +16,7 @@ import routers.workstreams as workstreams_router
 from models.goal import GoalCreate, GoalFocusRequest, GoalUpdate
 from models.task_recommendation import NormalizedContextSnapshot, OpenLoopSnapshot, SnapshotReceipt
 from models.workstream import TaskOriginWorkIntent, WorkIntentReceipt, WorkstreamUpdate
+from config.what_matters_now_smoke_fixture import WHAT_MATTERS_NOW_SMOKE_UID
 
 
 def test_openapi_exposes_intent_and_thread_resources_without_manual_workstream_create():
@@ -208,6 +209,37 @@ def test_task_intelligence_reads_fail_closed_when_generation_changes_during_proj
 
     assert error.value.status_code == 404
     assert projection_reads == ['debug' if surface == 'debug' else 'evaluate']
+
+
+def test_what_matters_now_initializes_the_dev_smoke_fixture_before_rollout(monkeypatch):
+    calls = []
+    sentinel_projection = object()
+    monkeypatch.setattr(
+        task_recommendations_router,
+        'task_control_db',
+        SimpleNamespace(ensure_development_smoke_fixture=lambda uid: calls.append(('ensure', uid)) or True),
+    )
+    monkeypatch.setattr(
+        task_recommendations_router,
+        '_rollout',
+        lambda uid: calls.append(('rollout', uid))
+        or SimpleNamespace(intelligence_product_enabled=True, account_generation=0),
+    )
+    monkeypatch.setattr(task_recommendations_router, '_bound_device_id', lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        task_recommendations_router.recommendations, 'evaluate', lambda *_args, **_kwargs: sentinel_projection
+    )
+
+    result = task_recommendations_router.get_what_matters_now(
+        request_context=object(), device_id=None, uid=WHAT_MATTERS_NOW_SMOKE_UID
+    )
+
+    assert result is sentinel_projection
+    assert calls == [
+        ('ensure', WHAT_MATTERS_NOW_SMOKE_UID),
+        ('rollout', WHAT_MATTERS_NOW_SMOKE_UID),
+        ('rollout', WHAT_MATTERS_NOW_SMOKE_UID),
+    ]
 
 
 def test_qualitative_goal_create_forwards_canonical_shape_without_numeric_defaults(monkeypatch):

--- a/backend/utils/task_intelligence/rollout.py
+++ b/backend/utils/task_intelligence/rollout.py
@@ -7,6 +7,7 @@ resolver obtains cohort membership from the canonical memory owner.
 
 # LIFECYCLE: permanent
 
+from config.what_matters_now_smoke_fixture import is_development_smoke_fixture
 from models.task_intelligence import TaskIntelligenceRolloutDecision, TaskWorkflowMode
 from utils.memory.memory_system import MemorySystem, resolve_memory_system
 
@@ -65,7 +66,9 @@ def resolve_task_intelligence_for_user(
 ) -> TaskIntelligenceRolloutDecision:
     """Compose workflow mode with the authoritative canonical-memory selector."""
 
-    memory_cohort_eligible = resolve_memory_system(uid, db_client=db_client) == MemorySystem.CANONICAL
+    memory_cohort_eligible = is_development_smoke_fixture(uid) or (
+        resolve_memory_system(uid, db_client=db_client) == MemorySystem.CANONICAL
+    )
     return resolve_task_intelligence_rollout(
         uid=uid,
         workflow_mode=workflow_mode,


### PR DESCRIPTION
## Summary
- replace the development What Matters Now smoke UID secret with one deterministic, non-personal, code-owned fixture
- initialize only the minimum fixture control document with an atomic create-if-absent operation
- preserve a conflicting pre-existing document and fail closed rather than overwriting it
- permit the fixture only for `OMI_ENV_STAGE=dev`; production remains on the normal cohort selector

## Scope and safety
- development smoke paths only; no production workflow/runtime behavior is broadened
- removes `OMI_TASK_INTELLIGENCE_SMOKE_UID` from the two development smoke workflow bindings
- adds no environment variables or secrets; uses existing `ADMIN_KEY` authentication only
- smoke continues to exercise the deployed `/v1/what-matters-now` route

## Verification
- independent review: approved after create-only conflict handling was added
- focused fixture/smoke/rollout/router tests: 42 passed
- backend typecheck: 0 errors (existing warnings only)
- actionlint, runtime-env validation, workflow contracts, OpenAPI contract, formatting, diff hygiene, and repository pre-push checks passed


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9726?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

