### PR TITLE
Fix delayed Home screenshot counter

### DIFF
--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/HomeStatusStore.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/HomeStatusStore.swift
@@ -21,8 +21,12 @@ struct HomeStatusLoader {
                 await connectorStatusStore.refresh()
             },
             loadScreenshotCount: {
-                let stats = await RewindIndexer.shared.getStats()
-                return stats?.total
+                do {
+                    return try await RewindDatabase.shared.getScreenshotCount()
+                } catch {
+                    logError("HomeStatusLoader: Failed to load screenshot count", error: error)
+                    return nil
+                }
             },
             loadKnowledgeCounts: { includeOmiDeviceHistory in
                 async let conversations = try? APIClient.shared.getConversationsCount(includeDiscarded: false)
@@ -66,6 +70,7 @@ final class HomeStatusStore: ObservableObject {
     private let loader: HomeStatusLoader
     private let currentUserIDProvider: () -> String?
     private var sessionUserID: String?
+    private var localDatabaseReady: Bool
     private var lastRefreshAt = Date.distantPast
     private var refreshTask: Task<Void, Never>?
     private var refreshID: UUID?
@@ -77,7 +82,8 @@ final class HomeStatusStore: ObservableObject {
         connectorStatusStore: ImportConnectorStatusStore? = nil,
         defaults: UserDefaults = .standard,
         loader: HomeStatusLoader? = nil,
-        currentUserIDProvider: (() -> String?)? = nil
+        currentUserIDProvider: (() -> String?)? = nil,
+        localDatabaseReady: Bool = false
     ) {
         let currentUserIDProvider = currentUserIDProvider ?? {
             defaults.string(forKey: .authUserId)
@@ -90,6 +96,7 @@ final class HomeStatusStore: ObservableObject {
         self.loader = loader ?? .live(connectorStatusStore: connectorStatusStore)
         self.currentUserIDProvider = currentUserIDProvider
         self.sessionUserID = sessionUserID
+        self.localDatabaseReady = localDatabaseReady
         accountHasOmiDeviceConversations = Self.loadPersistedDeviceHistory(
             defaults: defaults,
             userID: sessionUserID
@@ -144,6 +151,22 @@ final class HomeStatusStore: ObservableObject {
         accountHasOmiDeviceConversations = false
     }
 
+    /// The Rewind database has opened for the current owner. Load the local
+    /// screenshot metric immediately instead of waiting for the Home refresh
+    /// cooldown after a pre-startup refresh skipped it.
+    func databaseDidBecomeReady() async {
+        ensureCurrentSessionScope()
+        localDatabaseReady = true
+
+        let generation = refreshGeneration
+        let loadedScreenshotCount = await loader.loadScreenshotCount()
+        guard !Task.isCancelled,
+              generation == refreshGeneration,
+              localDatabaseReady
+        else { return }
+        apply(screenshotCount: loadedScreenshotCount)
+    }
+
     private func resetTransientState() {
         refreshGeneration += 1
         refreshTask?.cancel()
@@ -151,6 +174,7 @@ final class HomeStatusStore: ObservableObject {
         refreshID = nil
         latestKnowledgeRefreshID = nil
         lastRefreshAt = .distantPast
+        localDatabaseReady = false
         screenshotCount = nil
         conversationCount = nil
         memoryCount = nil
@@ -173,9 +197,10 @@ final class HomeStatusStore: ObservableObject {
 
     private func performRefresh(generation: Int) async {
         let includeDeviceHistory = !accountHasOmiDeviceConversations
+        let shouldLoadScreenshotCount = localDatabaseReady
         let knowledgeRefreshID = beginKnowledgeRefresh()
         async let connectorStatuses: Void = loader.refreshConnectorStatuses()
-        async let screenshots = loader.loadScreenshotCount()
+        async let screenshots: Int? = shouldLoadScreenshotCount ? loader.loadScreenshotCount() : nil
         async let knowledgeCounts = loader.loadKnowledgeCounts(includeDeviceHistory)
         async let exportStatuses = loader.loadMemoryExportStatuses()
         let (_, loadedScreenshots, loadedKnowledgeCounts, loadedExportStatuses) = await (

--- a/desktop/macos/Desktop/Sources/ViewModelContainer.swift
+++ b/desktop/macos/Desktop/Sources/ViewModelContainer.swift
@@ -103,6 +103,9 @@ class ViewModelContainer: ObservableObject {
         // DB-dependent loads are guarded — skip them if database init failed
         // to prevent a stampede of retries from each storage actor
         let dbAvailable = !databaseInitFailed
+        if dbAvailable {
+            await homeStatusStore.databaseDidBecomeReady()
+        }
 
         schedulePostInteractiveWarmup(dbAvailable: dbAvailable)
         isLoading = false
@@ -154,6 +157,7 @@ class ViewModelContainer: ObservableObject {
         do {
             try await RewindDatabase.shared.initialize()
             databaseInitFailed = false
+            await homeStatusStore.databaseDidBecomeReady()
             warmupCoordinator.markDatabaseRetryComplete()
             TranscriptionRetryService.shared.resumeAfterDatabaseRecovery()
             log("ViewModelContainer: Database retry succeeded, scheduling staged startup warmup")

--- a/desktop/macos/Desktop/Tests/HomeStatusStoreTests.swift
+++ b/desktop/macos/Desktop/Tests/HomeStatusStoreTests.swift
@@ -36,7 +36,8 @@ final class HomeStatusStoreTests: XCTestCase {
                     exportLoads += 1
                     return [:]
                 }
-            )
+            ),
+            localDatabaseReady: true
         )
         let start = Date(timeIntervalSince1970: 10_000)
 
@@ -106,6 +107,101 @@ final class HomeStatusStoreTests: XCTestCase {
         XCTAssertEqual(connectorLoads, 1)
     }
 
+    func testDatabaseReadinessLoadsSkippedScreenshotCountWithoutWaitingForCooldown() async {
+        let testDefaults = makeDefaults()
+        let defaults = testDefaults.defaults
+        defer { defaults.removePersistentDomain(forName: testDefaults.suiteName) }
+
+        var connectorLoads = 0
+        var screenshotLoads = 0
+        var knowledgeLoads = 0
+        var exportLoads = 0
+        let connectorStore = ImportConnectorStatusStore(defaults: defaults)
+        let store = HomeStatusStore(
+            connectorStatusStore: connectorStore,
+            defaults: defaults,
+            loader: HomeStatusLoader(
+                refreshConnectorStatuses: { connectorLoads += 1 },
+                loadScreenshotCount: {
+                    screenshotLoads += 1
+                    return 73
+                },
+                loadKnowledgeCounts: { _ in
+                    knowledgeLoads += 1
+                    return HomeKnowledgeCounts(
+                        conversations: nil,
+                        memories: nil,
+                        tasks: nil,
+                        hasOmiDeviceConversations: nil
+                    )
+                },
+                loadMemoryExportStatuses: {
+                    exportLoads += 1
+                    return [:]
+                }
+            )
+        )
+        let start = Date(timeIntervalSince1970: 25_000)
+
+        await store.refreshIfNeeded(now: start)
+
+        XCTAssertEqual(screenshotLoads, 0)
+        XCTAssertNil(store.screenshotCount)
+        XCTAssertEqual(connectorLoads, 1)
+        XCTAssertEqual(knowledgeLoads, 1)
+        XCTAssertEqual(exportLoads, 1)
+
+        await store.databaseDidBecomeReady()
+
+        XCTAssertEqual(screenshotLoads, 1)
+        XCTAssertEqual(store.screenshotCount, 73)
+
+        await store.refreshIfNeeded(now: start.addingTimeInterval(1))
+
+        XCTAssertEqual(
+            screenshotLoads,
+            1,
+            "The readiness-triggered screenshot load must not wait for or bypass the normal Home refresh cooldown"
+        )
+        XCTAssertEqual(connectorLoads, 1)
+        XCTAssertEqual(knowledgeLoads, 1)
+        XCTAssertEqual(exportLoads, 1)
+    }
+
+    func testFailedScreenshotRefreshKeepsLastKnownCount() async {
+        let testDefaults = makeDefaults()
+        let defaults = testDefaults.defaults
+        defer { defaults.removePersistentDomain(forName: testDefaults.suiteName) }
+
+        var results: [Int?] = [9, nil]
+        let connectorStore = ImportConnectorStatusStore(defaults: defaults)
+        let store = HomeStatusStore(
+            connectorStatusStore: connectorStore,
+            defaults: defaults,
+            loader: HomeStatusLoader(
+                refreshConnectorStatuses: {},
+                loadScreenshotCount: { results.removeFirst() },
+                loadKnowledgeCounts: { _ in
+                    HomeKnowledgeCounts(
+                        conversations: nil,
+                        memories: nil,
+                        tasks: nil,
+                        hasOmiDeviceConversations: nil
+                    )
+                },
+                loadMemoryExportStatuses: { [:] }
+            ),
+            localDatabaseReady: true
+        )
+
+        await store.refreshIfNeeded(now: Date(timeIntervalSince1970: 27_000))
+        XCTAssertEqual(store.screenshotCount, 9)
+
+        await store.refreshIfNeeded(force: true, now: Date(timeIntervalSince1970: 27_001))
+
+        XCTAssertEqual(store.screenshotCount, 9)
+    }
+
     func testCompletedImportRefreshesOnlyKnowledgeCounts() async {
         let testDefaults = makeDefaults()
         let defaults = testDefaults.defaults
@@ -138,7 +234,8 @@ final class HomeStatusStoreTests: XCTestCase {
                     exportLoads += 1
                     return [:]
                 }
-            )
+            ),
+            localDatabaseReady: true
         )
 
         await store.refreshIfNeeded(now: Date(timeIntervalSince1970: 30_000))

--- a/desktop/macos/changelog/unreleased/20260714-home-screenshot-counter.json
+++ b/desktop/macos/changelog/unreleased/20260714-home-screenshot-counter.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed the Home screenshot counter appearing unavailable during app startup"
+}


### PR DESCRIPTION
## Summary

- Load the Home screenshot metric from the authoritative local database rather than the broader Rewind indexer statistics scan.
- Make database readiness an explicit `HomeStatusStore` transition, so a pre-startup Home refresh cannot suppress the local metric for the normal refresh cooldown.
- Add behavioral regression coverage for the startup ordering and for retaining the last known count if a later local read fails.

## Root cause and durable guard

The Home status refresh could begin before the Rewind database was available. Its screenshot load then returned `nil`, but the refresh still recorded its timestamp. The 60-second Home activation cooldown consequently prevented another load until a later activation. The old loader also coupled the count to the indexer's aggregate-statistics/storage scan, so an unrelated failure could hide an otherwise available screenshot count.

`ViewModelContainer` now tells `HomeStatusStore` when the local database is ready. The store fetches just the screenshot count immediately through an injected loader seam and preserves the last known value on a later failed read. The regression tests drive the exact pre-ready refresh, ready transition, and within-cooldown activation sequence.

## Verification

- `cd desktop/macos && xcrun swift test --package-path Desktop --scratch-path /tmp/omi-screenshot-counter-build` — 2,460 tests passed.
- `cd desktop/macos && python3 scripts/check_desktop_test_quality.py` — passed.
- `make preflight` — 13 selected checks passed.
- `OMI_APP_NAME="omi-home-screenshot-counter" OMI_SIGN_IDENTITY="-" OMI_ALLOW_ADHOC_SIGN=1 OMI_AUTOMATION_PORT=48011 ./run.sh --yolo` — named development bundle built, signed, installed, launched, and exposed its automation bridge.

The named bundle had no locally seeded signed-in session, so I could not visually exercise the authenticated Home dashboard. The behavioral regression test covers the real startup ordering through the production store and its controllable loader seam.

## Product invariants

None required by `scripts/pr-preflight --suggest`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9728?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

