### PR TITLE
fix(ci): make pre-push single-flight runner start on hosts without POSIX signals (#9724)

### DIFF
--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -17,6 +17,11 @@ checks:
     triggers: [".github/schemas/desktop-release-evidence-v1.schema.json", ".github/scripts/desktop_release_doctor.py", ".github/scripts/desktop_release_doctor_report.py", ".github/scripts/test_desktop_release_doctor.py", ".github/workflows/desktop_release_doctor.yml"]
     lanes: ["local", "ci"]
     reason: "advisory desktop release evidence and drift report"
+  - id: preflight-runner-portability
+    command: ["python3", ".github/scripts/test_preflight_runner.py"]
+    triggers: [".github/scripts/preflight_runner.py", ".github/scripts/test_preflight_runner.py"]
+    lanes: ["local", "ci"]
+    reason: "single-flight pre-push runner must start on hosts without POSIX signal APIs"
   - id: diff-hygiene
     command: ["python3", ".github/scripts/check_diff_hygiene.py", "--changed-files", "{changed_files}", "--base", "{base}", "--head", "{head}"]
     triggers: ["all"]

--- a/.github/scripts/preflight_runner.py
+++ b/.github/scripts/preflight_runner.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import ctypes
 import hashlib
 import json
 import os
@@ -16,6 +17,34 @@ from pathlib import Path
 
 POLL_SECONDS = 0.2
 STATUS_INTERVAL_SECONDS = 5.0
+OWNED_SIGNAL_NAMES = ("SIGINT", "SIGTERM", "SIGHUP", "SIGBREAK")
+IS_WINDOWS = os.name == "nt"
+HAS_PROCESS_GROUPS = hasattr(os, "killpg")
+WINDOWS_STILL_ACTIVE = 259
+WINDOWS_PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
+WINDOWS_ERROR_ACCESS_DENIED = 5
+
+
+def owned_signals(module: object = signal) -> tuple[int, ...]:
+    """Signals the host actually defines; Windows has no SIGHUP but adds SIGBREAK."""
+    return tuple(getattr(module, name) for name in OWNED_SIGNAL_NAMES if hasattr(module, name))
+
+
+def signal_child(child: subprocess.Popen, signum: int) -> None:
+    """Forward a signal to the owned child on any host.
+
+    POSIX children get their own session (``start_new_session``), so the whole group is
+    signalled; Windows has no such group here and ``os.kill`` would terminate outright.
+    """
+    if child.poll() is not None:
+        return
+    try:
+        if HAS_PROCESS_GROUPS:
+            os.killpg(child.pid, signum)
+        else:
+            child.terminate()
+    except OSError:
+        pass
 
 
 def atomic_json(path: Path, value: dict) -> None:
@@ -32,9 +61,26 @@ def read_json(path: Path) -> dict:
         return {}
 
 
+def windows_process_exists(pid: int) -> bool:
+    """Liveness probe for Windows, where ``os.kill(pid, 0)`` terminates the target."""
+    kernel32 = ctypes.windll.kernel32
+    handle = kernel32.OpenProcess(WINDOWS_PROCESS_QUERY_LIMITED_INFORMATION, False, pid)
+    if not handle:
+        return kernel32.GetLastError() == WINDOWS_ERROR_ACCESS_DENIED
+    try:
+        exit_code = ctypes.c_ulong()
+        if kernel32.GetExitCodeProcess(handle, ctypes.byref(exit_code)) == 0:
+            return True
+        return exit_code.value == WINDOWS_STILL_ACTIVE
+    finally:
+        kernel32.CloseHandle(handle)
+
+
 def process_exists(pid: int) -> bool:
     if pid <= 0:
         return False
+    if IS_WINDOWS:
+        return windows_process_exists(pid)
     try:
         os.kill(pid, 0)
         return True
@@ -173,15 +219,10 @@ def run_owned(
         )
 
     def forward_signal(signum: int, _frame: object) -> None:
-        if child is not None and child.poll() is None:
-            try:
-                os.killpg(child.pid, signum)
-            except ProcessLookupError:
-                pass
+        if child is not None:
+            signal_child(child, signum)
 
-    previous_handlers = {
-        signum: signal.signal(signum, forward_signal) for signum in (signal.SIGINT, signal.SIGTERM, signal.SIGHUP)
-    }
+    previous_handlers = {signum: signal.signal(signum, forward_signal) for signum in owned_signals()}
     exit_code = 1
     try:
         print(f"Pre-push single-flight log: {log_path}")

--- a/.github/scripts/test_preflight_runner.py
+++ b/.github/scripts/test_preflight_runner.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Portability contract tests for the pre-push single-flight runner."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+from pathlib import Path
+import signal
+import types
+import unittest
+from unittest import mock
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+MODULE_PATH = SCRIPT_DIR / "preflight_runner.py"
+SPEC = importlib.util.spec_from_file_location("preflight_runner", MODULE_PATH)
+assert SPEC and SPEC.loader
+runner = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(runner)
+
+
+class FakeChild:
+    def __init__(self, returncode: int | None = None) -> None:
+        self.pid = 4321
+        self.returncode = returncode
+        self.terminated = False
+
+    def poll(self) -> int | None:
+        return self.returncode
+
+    def terminate(self) -> None:
+        self.terminated = True
+
+
+class OwnedSignalTests(unittest.TestCase):
+    def test_skips_signals_the_host_does_not_define(self) -> None:
+        windows_signal = types.SimpleNamespace(SIGINT=2, SIGTERM=15, SIGBREAK=21)
+
+        self.assertEqual(runner.owned_signals(windows_signal), (2, 15, 21))
+
+    def test_registers_sighup_when_the_host_defines_it(self) -> None:
+        posix_signal = types.SimpleNamespace(SIGINT=2, SIGTERM=15, SIGHUP=1)
+
+        self.assertEqual(runner.owned_signals(posix_signal), (2, 15, 1))
+
+    def test_every_selected_signal_is_registrable_on_this_host(self) -> None:
+        for signum in runner.owned_signals():
+            previous = signal.getsignal(signum)
+            signal.signal(signum, previous)
+
+
+class SignalChildTests(unittest.TestCase):
+    def test_posix_signals_the_whole_child_process_group(self) -> None:
+        child = FakeChild()
+
+        with mock.patch.object(runner, "HAS_PROCESS_GROUPS", True):
+            with mock.patch.object(runner.os, "killpg") as killpg:
+                runner.signal_child(child, signal.SIGINT)
+
+        killpg.assert_called_once_with(child.pid, signal.SIGINT)
+        self.assertFalse(child.terminated)
+
+    def test_hosts_without_process_groups_terminate_the_child(self) -> None:
+        child = FakeChild()
+
+        with mock.patch.object(runner, "HAS_PROCESS_GROUPS", False):
+            runner.signal_child(child, signal.SIGINT)
+
+        self.assertTrue(child.terminated)
+
+    def test_exited_child_is_left_alone(self) -> None:
+        child = FakeChild(returncode=0)
+
+        with mock.patch.object(runner, "HAS_PROCESS_GROUPS", False):
+            runner.signal_child(child, signal.SIGINT)
+
+        self.assertFalse(child.terminated)
+
+    def test_dead_child_does_not_raise(self) -> None:
+        child = FakeChild()
+
+        with mock.patch.object(runner, "HAS_PROCESS_GROUPS", True):
+            with mock.patch.object(runner.os, "killpg", side_effect=ProcessLookupError):
+                runner.signal_child(child, signal.SIGTERM)
+
+
+class ProcessExistsTests(unittest.TestCase):
+    def test_windows_never_calls_os_kill(self) -> None:
+        with mock.patch.object(runner, "IS_WINDOWS", True):
+            with mock.patch.object(runner, "windows_process_exists", return_value=True) as probe:
+                with mock.patch.object(runner.os, "kill", side_effect=AssertionError("os.kill terminates on Windows")):
+                    self.assertTrue(runner.process_exists(99))
+
+        probe.assert_called_once_with(99)
+
+    def test_live_and_dead_pids(self) -> None:
+        self.assertTrue(runner.process_exists(os.getpid()))
+        self.assertFalse(runner.process_exists(0))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #9724.

## Bug
On Windows, **every `git push` fails before any pre-push check runs**:

```
AttributeError: module 'signal' has no attribute 'SIGHUP'
```

`scripts/pre-push-singleflight` routes through `.github/scripts/preflight_runner.py`, whose `run_owned()` built its handler map from `(signal.SIGINT, signal.SIGTERM, signal.SIGHUP)` unconditionally. Windows Python does not define `SIGHUP`, so the wrapper exits 1 and Git rejects the push.

## Root cause / failure class
The runner assumes POSIX process APIs are always present. Fixing only the signal tuple would leave two more landmines on the same code path, so this PR closes the class:

1. **Signal registration** — `owned_signals()` registers only signals the host actually defines, and picks up `SIGBREAK` where it exists (Windows' console-interrupt signal).
2. **Signal forwarding** — `signal_child()` uses `os.killpg` where process groups exist (POSIX children get their own session via `start_new_session`), and falls back to `child.terminate()` elsewhere.
3. **Liveness probe** — `process_exists()` used `os.kill(pid, 0)`. On Windows `os.kill` does not send a signal; it calls `TerminateProcess`. The moment the runner became reachable on Windows, the stale-lock probe would have **killed the live lock holder**. Windows now probes with `OpenProcess`/`GetExitCodeProcess` (access-denied ⇒ alive, mirroring the POSIX `PermissionError` branch).

## Regression test
`.github/scripts/test_preflight_runner.py` (9 tests) exercises signal selection against Windows- and POSIX-shaped signal modules, forwarding on hosts with and without process groups, and asserts `process_exists` never reaches `os.kill` on Windows — no real signal needed to interrupt the test process, per the issue. Registered in `.github/checks-manifest.yaml` (`preflight-runner-portability`, local + ci lanes), so it is diff-scoped-selected whenever the runner changes.

## Verification
- `python3 .github/scripts/test_preflight_runner.py` → 9 tests OK
- `python3 .github/scripts/test_run_checks.py` → 9 tests OK (manifest contract guard)
- `make preflight` on this branch → 9 checks passed, with `preflight-runner-portability` SELECTED by the diff
- Real run: `preflight_runner.py --name wd -- sh -c 'echo "==> phase-one"; echo hello; exit 3'` streamed the phase line, wrote `result.json`, exited 3
- **A/B against `HEAD`:** SIGINT to the runner kills the child process group in both the old and the new code — POSIX forwarding behavior is unchanged
- Old expression against a Windows-shaped signal module raises `AttributeError: 'SIGHUP'`; `owned_signals()` returns `(SIGINT, SIGTERM, SIGBREAK)`

**Not verified on a real Windows host** (no Windows machine available) — the Windows paths are covered by the hermetic tests above and by CPython's documented `os.kill`/`OpenProcess` semantics.

🤖 automated by hourly watchdog; opened for review, not merged.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9730?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

