### PR TITLE
test(backend): reuse workflow selector discovery

### DIFF
--- a/backend/tests/unit/test_workflow_contracts.py
+++ b/backend/tests/unit/test_workflow_contracts.py
@@ -3,6 +3,8 @@ import json
 import re
 from pathlib import Path
 
+import pytest
+
 BACKEND_DIR = Path(__file__).resolve().parents[2]
 
 
@@ -15,10 +17,15 @@ def _load_script(name: str):
     return module
 
 
-def test_memory_policy_core_change_selects_inv_mem_guard():
-    """Narrow memory policy PRs always pull INV-MEM guard tests."""
+@pytest.fixture(scope="module")
+def selector_and_all_tests():
     selector = _load_script("select_backend_unit_tests")
-    all_tests = selector.discover_all_tests()
+    return selector, selector.discover_all_tests()
+
+
+def test_memory_policy_core_change_selects_inv_mem_guard(selector_and_all_tests):
+    """Narrow memory policy PRs always pull INV-MEM guard tests."""
+    selector, all_tests = selector_and_all_tests
 
     selected, reason = selector.tests_for_changed_paths(
         ["backend/utils/memory/chat_memory_adapter.py"],
@@ -28,9 +35,8 @@ def test_memory_policy_core_change_selects_inv_mem_guard():
     assert reason == "selected backend unit tests from changed paths and workflow contracts"
 
 
-def test_workflow_contract_sources_select_adjacent_tests():
-    selector = _load_script("select_backend_unit_tests")
-    all_tests = selector.discover_all_tests()
+def test_workflow_contract_sources_select_adjacent_tests(selector_and_all_tests):
+    selector, all_tests = selector_and_all_tests
 
     full_run_cases = {
         "backend/database/memory_vector_repair_outbox_worker.py": "tests/unit/test_vector_repair_outbox_worker.py",
@@ -68,9 +74,8 @@ def test_workflow_contract_sources_select_adjacent_tests():
         assert selected == all_tests
 
 
-def test_workflow_contract_directory_glob_selects_nested_chart_test():
-    selector = _load_script("select_backend_unit_tests")
-    all_tests = selector.discover_all_tests()
+def test_workflow_contract_directory_glob_selects_nested_chart_test(selector_and_all_tests):
+    selector, all_tests = selector_and_all_tests
 
     selected, reason = selector.tests_for_changed_paths(
         ["backend/charts/pusher/templates/deployment.yaml"],
@@ -81,10 +86,9 @@ def test_workflow_contract_directory_glob_selects_nested_chart_test():
     assert reason == "selected backend unit tests from changed paths and workflow contracts"
 
 
-def test_selector_docs_and_flat_utils_do_not_force_full_suite_via_globs():
+def test_selector_docs_and_flat_utils_do_not_force_full_suite_via_globs(selector_and_all_tests):
     """Docs/AGENTS skip selection; metrics is not a FULL_RUN_GLOBS hit."""
-    selector = _load_script("select_backend_unit_tests")
-    all_tests = selector.discover_all_tests()
+    selector, all_tests = selector_and_all_tests
 
     for path in (
         "backend/AGENTS.md",
@@ -111,9 +115,8 @@ def test_selector_docs_and_flat_utils_do_not_force_full_suite_via_globs():
         assert reason == f"{path} requires the full backend unit suite"
 
 
-def test_unmapped_source_forces_full_suite_even_when_direct_test_changed():
-    selector = _load_script("select_backend_unit_tests")
-    all_tests = selector.discover_all_tests()
+def test_unmapped_source_forces_full_suite_even_when_direct_test_changed(selector_and_all_tests):
+    selector, all_tests = selector_and_all_tests
 
     selected, reason = selector.tests_for_changed_paths(
         [
@@ -127,9 +130,8 @@ def test_unmapped_source_forces_full_suite_even_when_direct_test_changed():
     assert reason == "backend/new_unmapped_runtime.py did not match a backend test-selection contract"
 
 
-def test_mapped_source_with_direct_test_remains_narrow():
-    selector = _load_script("select_backend_unit_tests")
-    all_tests = selector.discover_all_tests()
+def test_mapped_source_with_direct_test_remains_narrow(selector_and_all_tests):
+    selector, all_tests = selector_and_all_tests
 
     selected, reason = selector.tests_for_changed_paths(
         [
@@ -144,9 +146,8 @@ def test_mapped_source_with_direct_test_remains_narrow():
     assert reason == "selected backend unit tests from changed paths and workflow contracts"
 
 
-def test_removed_test_forces_full_discovered_suite():
-    selector = _load_script("select_backend_unit_tests")
-    all_tests = selector.discover_all_tests()
+def test_removed_test_forces_full_discovered_suite(selector_and_all_tests):
+    selector, all_tests = selector_and_all_tests
 
     selected, reason = selector.tests_for_changed_paths(
         ["backend/tests/unit/test_removed_contract.py"],


### PR DESCRIPTION
## What changed and why

Reuse one module-scoped workflow-selector discovery across the contract tests instead of reloading the selector and rescanning every backend unit test in each test. This keeps the Windows fast-unit lane below its per-file timing budget without changing the contract assertions. Closes #9729.

## Product invariants affected

none

## How it was verified

- Reproduced the baseline twice on Windows: all 19 tests passed, but the fast-unit duration guard rejected the file at about 0.14s and 0.12s against the 0.12s budget.
- Repeated the strict `backend/test.sh` run five times after the change. All 19 tests passed each time, with total runs of 0.57s, 0.47s, 0.54s, 0.52s, and 0.60s and no duration warning.
- `black --check --line-length 120 --skip-string-normalization backend/tests/unit/test_workflow_contracts.py`
- Passed lifecycle-header, version-filename, import-purity, module-isolation, workflow-contract, diff-hygiene, release-policy, and deployment-concurrency checks.
- The repository-wide Firestore query ratchet still fails on Windows with 40 unregistered and 3 unsupported fingerprints. The same command reports the identical fingerprints from an unchanged detached `origin/main` worktree, so that baseline is unrelated to this test-only diff.

## Tests

The changed file is the regression coverage. Its existing 19 contract tests still exercise the same assertion set, now under the same strict fast-unit timing guard that exposed the Windows failure.

## Root cause and durable guard (bug fixes)

Each of seven tests independently imported `select_backend_unit_tests.py` and walked the complete unit-test tree. Windows filesystem startup variance pushed that repeated discovery over the fast-unit per-file budget even though every assertion passed. A module-scoped fixture performs the immutable discovery once, and the existing duration guard continues to enforce the budget.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9731?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

