### PR TITLE
fix(dev): preflight runtime binding drift

### DIFF
--- a/.github/workflows/gcp_backend_auto_dev.yml
+++ b/.github/workflows/gcp_backend_auto_dev.yml
@@ -130,6 +130,14 @@ jobs:
           --migrate-legacy-public-binding backend-sync-backfill
           --migrate-legacy-public-binding backend-integration
 
+      - name: Check development Cloud Run runtime bindings
+        run: >-
+          python3 backend/scripts/preflight-cloud-run-deploy.py
+          --env dev
+          --project="${{ vars.GCP_PROJECT_ID }}"
+          --region="${{ env.REGION }}"
+          --check-runtime-bindings
+
       - name: Deploy ${{ env.SERVICE }} to Cloud Run
         id: deploy-backend
         uses: google-github-actions/deploy-cloudrun@v2

--- a/backend/scripts/preflight-cloud-run-deploy.py
+++ b/backend/scripts/preflight-cloud-run-deploy.py
@@ -11,8 +11,6 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, cast
 
-import yaml
-
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 import render_backend_runtime_env  # noqa: E402
 import repair_cloud_run_traffic  # noqa: E402
@@ -30,6 +28,14 @@ class SecretBinding:
     version: str
 
 
+@dataclass(frozen=True)
+class RuntimeBindingContract:
+    """Expected pre-candidate Cloud Run binding state for one service."""
+
+    public_names: frozenset[str]
+    secret_references: dict[str, str]
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description='Preflight checks for backend Cloud Run deploys.')
     parser.add_argument('--env', choices=('dev', 'prod'), required=True)
@@ -38,6 +44,7 @@ def main() -> int:
     parser.add_argument('--manifest', type=Path, default=DEFAULT_MANIFEST)
     parser.add_argument('--service', action='append', dest='services')
     parser.add_argument('--migrate-legacy-public-binding', action='append', dest='legacy_public_binding_services')
+    parser.add_argument('--check-runtime-bindings', action='store_true')
     parser.add_argument('--check-secrets', action='store_true')
     parser.add_argument('--check-traffic', action='store_true')
     parser.add_argument('--repair-traffic', action='store_true')
@@ -56,11 +63,30 @@ def main() -> int:
                 env=args.env,
                 project=args.project,
                 region=args.region,
+                manifest_path=args.manifest,
             )
         except ValueError as exc:
             parser.error(str(exc))
         for service in migrated:
             print(f'migrated legacy GOOGLE_CLIENT_ID binding for {service}')
+
+    if args.check_runtime_bindings:
+        try:
+            drift = check_runtime_bindings(
+                services=services,
+                env=args.env,
+                project=args.project,
+                region=args.region,
+                manifest_path=args.manifest,
+            )
+        except ValueError as exc:
+            parser.error(str(exc))
+        if drift:
+            for error in drift:
+                print(f'ERROR [{error}]', file=sys.stderr)
+            exit_code = 1
+        else:
+            print('development Cloud Run runtime-binding contract passed')
 
     if args.check_secrets:
         missing = check_rendered_secrets(
@@ -122,24 +148,8 @@ def migrate_legacy_public_bindings(
     manifest_path: Path = DEFAULT_MANIFEST,
     runner: Any = subprocess.run,
 ) -> list[str]:
-    if env != 'dev' or project != DEVELOPMENT_PROJECT:
-        raise ValueError('Legacy public-binding migration is development-only')
-
-    manifest = yaml.safe_load(manifest_path.read_text(encoding='utf-8'))
-    if not isinstance(manifest, dict):
-        raise ValueError(f'Expected a mapping in {manifest_path}')
-    environments = manifest.get('environments')
-    if not isinstance(environments, dict):
-        raise ValueError(f'Missing environments in {manifest_path}')
-    environment_config = environments.get(env)
-    if not isinstance(environment_config, dict):
-        raise ValueError(f'Missing {env} environment in {manifest_path}')
-    cloud_run = environment_config.get('cloud_run')
-    if not isinstance(cloud_run, dict):
-        raise ValueError(f'Missing Cloud Run config for {env} in {manifest_path}')
-    service_configs = cloud_run.get('services')
-    if not isinstance(service_configs, dict):
-        raise ValueError(f'Missing Cloud Run services for {env} in {manifest_path}')
+    _require_development_scope(env=env, project=project, check_name='Legacy public-binding migration')
+    service_configs = _cloud_run_service_configs(env=env, manifest_path=manifest_path)
 
     migrated: list[str] = []
     for service in services:
@@ -150,30 +160,13 @@ def migrate_legacy_public_bindings(
         if not isinstance(public_env, dict):
             raise ValueError(f'Missing public environment config for {service}')
         public_binding_names = set(public_env)
-        document = json.loads(
-            runner(
-                [
-                    'gcloud',
-                    'run',
-                    'services',
-                    'describe',
-                    service,
-                    f'--project={project}',
-                    f'--region={region}',
-                    '--format=json',
-                ],
-                check=True,
-                text=True,
-                capture_output=True,
-            ).stdout
-        )
-        containers = document['spec']['template']['spec'].get('containers')
-        if not isinstance(containers, list) or len(containers) != 1 or not isinstance(containers[0], dict):
-            raise ValueError('Legacy public-binding migration requires exactly one container per Cloud Run service')
+        document = _describe_cloud_run_service(service=service, project=project, region=region, runner=runner)
+        containers = _single_container(document, operation='Legacy public-binding migration')
         legacy_binding_names = sorted(
             entry['name']
-            for entry in containers[0].get('env', [])
-            if entry.get('name') in public_binding_names
+            for entry in _container_env_entries(containers, operation='Legacy public-binding migration')
+            if isinstance(entry, dict)
+            and entry.get('name') in public_binding_names
             and entry.get('valueFrom', {}).get('secretKeyRef', {}).get('name') == entry.get('name')
         )
         if not legacy_binding_names:
@@ -195,6 +188,176 @@ def migrate_legacy_public_bindings(
         )
         migrated.append(service)
     return migrated
+
+
+def check_runtime_bindings(
+    *,
+    services: tuple[str, ...] | list[str],
+    env: str,
+    project: str,
+    region: str,
+    manifest_path: Path = DEFAULT_MANIFEST,
+    runner: Any = subprocess.run,
+) -> list[str]:
+    """Check only manifest-declared development bindings before candidate deploy.
+
+    The workflow removes legacy Secret Manager bindings for public values before
+    it deploys the candidate revision.  At this point a declared public value
+    is therefore valid when it is literal or absent; a Secret Manager or other
+    value source is still drift.  Declared secrets must already match exactly.
+    This is deliberately not a full live-service inventory: normal retained
+    Cloud Run bindings absent from runtime_env.yaml are outside this check.
+    """
+    _require_development_scope(env=env, project=project, check_name='Runtime binding check')
+    service_configs = _cloud_run_service_configs(env=env, manifest_path=manifest_path)
+    drift: list[str] = []
+
+    for service in services:
+        raw_service_config = service_configs.get(service)
+        service_config = render_backend_runtime_env._as_config_dict(raw_service_config)
+        if service_config is None:
+            raise ValueError(f'Missing Cloud Run service config for {service}')
+        expected = _expected_runtime_bindings(service=service, service_config=service_config)
+        declared_names = expected.public_names | set(expected.secret_references)
+        document = _describe_cloud_run_service(service=service, project=project, region=region, runner=runner)
+        container = _single_container(document, operation='Runtime binding check')
+        actual = _actual_runtime_bindings(
+            service=service,
+            env_entries=_container_env_entries(container, operation='Runtime binding check'),
+            declared_names=declared_names,
+            drift=drift,
+        )
+
+        for env_name in sorted(expected.public_names):
+            observed_binding = actual.get(env_name)
+            if observed_binding not in (None, 'public literal'):
+                drift.append(
+                    f'runtime-binding/{service}/{env_name}: expected public literal or absent before candidate deploy, '
+                    f'observed {observed_binding}'
+                )
+
+        for env_name in sorted(expected.secret_references):
+            expected_binding = expected.secret_references[env_name]
+            observed_binding = actual.get(env_name)
+            if observed_binding is None:
+                drift.append(f'runtime-binding/{service}/{env_name}: expected {expected_binding}, binding is missing')
+            elif observed_binding != expected_binding:
+                drift.append(
+                    f'runtime-binding/{service}/{env_name}: expected {expected_binding}, observed {observed_binding}'
+                )
+
+    return drift
+
+
+def _require_development_scope(*, env: str, project: str, check_name: str) -> None:
+    if env != 'dev' or project != DEVELOPMENT_PROJECT:
+        raise ValueError(f'{check_name} is development-only')
+
+
+def _cloud_run_service_configs(*, env: str, manifest_path: Path) -> dict[str, Any]:
+    manifest = render_backend_runtime_env._load_yaml(manifest_path)
+    environments = render_backend_runtime_env._as_config_dict(manifest.get('environments'))
+    if environments is None:
+        raise ValueError(f'Missing environments in {manifest_path}')
+    environment_config = render_backend_runtime_env._as_config_dict(environments.get(env))
+    if environment_config is None:
+        raise ValueError(f'Missing {env} environment in {manifest_path}')
+    cloud_run = render_backend_runtime_env._as_config_dict(environment_config.get('cloud_run'))
+    if cloud_run is None:
+        raise ValueError(f'Missing Cloud Run config for {env} in {manifest_path}')
+    service_configs = render_backend_runtime_env._as_config_dict(cloud_run.get('services'))
+    if service_configs is None:
+        raise ValueError(f'Missing Cloud Run services for {env} in {manifest_path}')
+    return service_configs
+
+
+def _expected_runtime_bindings(*, service: str, service_config: dict[str, Any]) -> RuntimeBindingContract:
+    public_env = render_backend_runtime_env._as_config_dict(service_config.get('env')) or {}
+    secrets = render_backend_runtime_env._as_config_dict(service_config.get('secrets')) or {}
+    public_names = frozenset(str(env_name) for env_name in public_env)
+    secret_names = {str(env_name) for env_name in secrets}
+    overlap = sorted(public_names & secret_names)
+    if overlap:
+        raise ValueError(f'Cloud Run service {service} has public/secret binding overlap: {", ".join(overlap)}')
+
+    secret_references: dict[str, str] = {}
+    for env_name, raw_secret in secrets.items():
+        secret = render_backend_runtime_env._as_config_dict(raw_secret)
+        if secret is None or not isinstance(secret.get('secret'), str) or not secret['secret']:
+            raise ValueError(f'Cloud Run secret binding {env_name} must have a secret entry')
+        secret_references[str(env_name)] = (
+            f'Secret Manager reference {secret["secret"]}:{secret.get("version", "latest")}'
+        )
+    return RuntimeBindingContract(public_names=public_names, secret_references=secret_references)
+
+
+def _describe_cloud_run_service(*, service: str, project: str, region: str, runner: Any) -> dict[str, Any]:
+    document = json.loads(
+        runner(
+            [
+                'gcloud',
+                'run',
+                'services',
+                'describe',
+                service,
+                f'--project={project}',
+                f'--region={region}',
+                '--format=json',
+            ],
+            check=True,
+            text=True,
+            capture_output=True,
+        ).stdout
+    )
+    if not isinstance(document, dict):
+        raise ValueError(f'Cloud Run service {service} describe did not return a mapping')
+    return cast(dict[str, Any], document)
+
+
+def _single_container(document: dict[str, Any], *, operation: str) -> dict[str, Any]:
+    spec = document.get('spec')
+    template = spec.get('template') if isinstance(spec, dict) else None
+    template_spec = template.get('spec') if isinstance(template, dict) else None
+    containers = template_spec.get('containers') if isinstance(template_spec, dict) else None
+    if not isinstance(containers, list) or len(containers) != 1 or not isinstance(containers[0], dict):
+        raise ValueError(f'{operation} requires exactly one container per Cloud Run service')
+    return cast(dict[str, Any], containers[0])
+
+
+def _container_env_entries(container: dict[str, Any], *, operation: str) -> list[Any]:
+    env_entries = container.get('env', [])
+    if not isinstance(env_entries, list):
+        raise ValueError(f'{operation} requires a list of Cloud Run environment bindings')
+    return env_entries
+
+
+def _actual_runtime_bindings(
+    *, service: str, env_entries: list[Any], declared_names: set[str] | frozenset[str], drift: list[str]
+) -> dict[str, str]:
+    actual: dict[str, str] = {}
+    for entry in env_entries:
+        if not isinstance(entry, dict) or not isinstance(entry.get('name'), str) or not entry['name']:
+            continue
+        env_name = entry['name']
+        if env_name not in declared_names:
+            continue
+        if env_name in actual:
+            drift.append(f'runtime-binding/{service}/{env_name}: duplicate Cloud Run environment binding')
+            continue
+        actual[env_name] = _observed_binding(entry)
+    return actual
+
+
+def _observed_binding(entry: dict[str, Any]) -> str:
+    if 'value' in entry:
+        return 'public literal'
+    value_from = entry.get('valueFrom')
+    secret_ref = value_from.get('secretKeyRef') if isinstance(value_from, dict) else None
+    secret_name = secret_ref.get('name') if isinstance(secret_ref, dict) else None
+    if isinstance(secret_name, str) and secret_name:
+        version = secret_ref.get('key', 'latest')
+        return f'Secret Manager reference {secret_name}:{version}'
+    return 'unsupported value source'
 
 
 def check_rendered_secrets(*, env: str, manifest_path: Path, project: str) -> list[SecretBinding]:

--- a/backend/tests/unit/test_preflight_cloud_run_deploy.py
+++ b/backend/tests/unit/test_preflight_cloud_run_deploy.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
 import importlib.util
+import json
 from pathlib import Path
+import subprocess
 import sys
+from types import SimpleNamespace
 
 import pytest
 
@@ -59,3 +62,409 @@ def test_parse_revision_targets_rejects_missing_equals() -> None:
 
     with pytest.raises(ValueError, match='SERVICE=REVISION'):
         preflight._parse_revision_targets(['backend'])
+
+
+def test_runtime_binding_check_accepts_manifest_literal_and_secret_bindings_read_only(tmp_path: Path) -> None:
+    preflight = load_preflight()
+    manifest = tmp_path / 'runtime_env.yaml'
+    manifest.write_text(
+        '''\
+environments:
+  dev:
+    cloud_run:
+      services:
+        backend:
+          env:
+            PUBLIC_SETTING:
+              value: public
+          secrets:
+            PRIVATE_SETTING:
+              secret: expected-secret
+              version: '7'
+''',
+        encoding='utf-8',
+    )
+    commands: list[list[str]] = []
+    document = {
+        'spec': {
+            'template': {
+                'spec': {
+                    'containers': [
+                        {
+                            'env': [
+                                {'name': 'PUBLIC_SETTING', 'value': 'public'},
+                                {
+                                    'name': 'PRIVATE_SETTING',
+                                    'valueFrom': {'secretKeyRef': {'name': 'expected-secret', 'key': '7'}},
+                                },
+                            ]
+                        }
+                    ]
+                }
+            }
+        }
+    }
+
+    def runner(command: list[str], **_kwargs):
+        commands.append(command)
+        return SimpleNamespace(stdout=json.dumps(document))
+
+    drift = preflight.check_runtime_bindings(
+        services=('backend',),
+        env='dev',
+        project='based-hardware-dev',
+        region='us-central1',
+        manifest_path=manifest,
+        runner=runner,
+    )
+
+    assert drift == []
+    assert commands == [
+        [
+            'gcloud',
+            'run',
+            'services',
+            'describe',
+            'backend',
+            '--project=based-hardware-dev',
+            '--region=us-central1',
+            '--format=json',
+        ]
+    ]
+    assert not any('update' in command or 'remove' in command for command in commands)
+
+
+def test_runtime_binding_check_reports_manifest_declared_secret_missing_from_live_service(tmp_path: Path) -> None:
+    preflight = load_preflight()
+    manifest = tmp_path / 'runtime_env.yaml'
+    manifest.write_text(
+        '''\
+environments:
+  dev:
+    cloud_run:
+      services:
+        backend:
+          secrets:
+            PRIVATE_SETTING:
+              secret: expected-secret
+              version: '7'
+''',
+        encoding='utf-8',
+    )
+    document = {'spec': {'template': {'spec': {'containers': [{'env': []}]}}}}
+
+    drift = preflight.check_runtime_bindings(
+        services=('backend',),
+        env='dev',
+        project='based-hardware-dev',
+        region='us-central1',
+        manifest_path=manifest,
+        runner=lambda _command, **_kwargs: SimpleNamespace(stdout=json.dumps(document)),
+    )
+
+    assert drift == [
+        'runtime-binding/backend/PRIVATE_SETTING: expected Secret Manager reference expected-secret:7, binding is missing'
+    ]
+
+
+def test_runtime_binding_check_rejects_multi_container_live_service_shape(tmp_path: Path) -> None:
+    preflight = load_preflight()
+    manifest = tmp_path / 'runtime_env.yaml'
+    manifest.write_text(
+        '''\
+environments:
+  dev:
+    cloud_run:
+      services:
+        backend:
+          env:
+            PUBLIC_SETTING:
+              value: public
+''',
+        encoding='utf-8',
+    )
+    document = {
+        'spec': {
+            'template': {
+                'spec': {
+                    'containers': [
+                        {'env': [{'name': 'PUBLIC_SETTING', 'value': 'public'}]},
+                        {'env': []},
+                    ]
+                }
+            }
+        }
+    }
+
+    with pytest.raises(ValueError, match='exactly one container'):
+        preflight.check_runtime_bindings(
+            services=('backend',),
+            env='dev',
+            project='based-hardware-dev',
+            region='us-central1',
+            manifest_path=manifest,
+            runner=lambda _command, **_kwargs: SimpleNamespace(stdout=json.dumps(document)),
+        )
+
+
+def test_runtime_binding_check_propagates_gcloud_describe_failure(tmp_path: Path) -> None:
+    preflight = load_preflight()
+    manifest = tmp_path / 'runtime_env.yaml'
+    manifest.write_text(
+        '''\
+environments:
+  dev:
+    cloud_run:
+      services:
+        backend:
+          env:
+            PUBLIC_SETTING:
+              value: public
+''',
+        encoding='utf-8',
+    )
+    command = ['gcloud', 'run', 'services', 'describe', 'backend']
+
+    def failing_runner(_command: list[str], **_kwargs):
+        raise subprocess.CalledProcessError(returncode=1, cmd=command, stderr='describe failed')
+
+    with pytest.raises(subprocess.CalledProcessError, match='returned non-zero exit status 1'):
+        preflight.check_runtime_bindings(
+            services=('backend',),
+            env='dev',
+            project='based-hardware-dev',
+            region='us-central1',
+            manifest_path=manifest,
+            runner=failing_runner,
+        )
+
+
+def test_remove_secret_then_pre_candidate_check_accepts_absent_public_binding(tmp_path: Path) -> None:
+    preflight = load_preflight()
+    manifest = tmp_path / 'runtime_env.yaml'
+    manifest.write_text(
+        '''\
+environments:
+  dev:
+    cloud_run:
+      services:
+        backend:
+          env:
+            PUBLIC_SETTING:
+              value: public
+          secrets:
+            PRIVATE_SETTING:
+              secret: expected-secret
+              version: '7'
+''',
+        encoding='utf-8',
+    )
+    commands: list[list[str]] = []
+    state = {
+        'env': [
+            {
+                'name': 'PUBLIC_SETTING',
+                'valueFrom': {'secretKeyRef': {'name': 'PUBLIC_SETTING', 'key': 'latest'}},
+            },
+            {
+                'name': 'PRIVATE_SETTING',
+                'valueFrom': {'secretKeyRef': {'name': 'expected-secret', 'key': '7'}},
+            },
+        ]
+    }
+
+    def runner(command: list[str], **_kwargs):
+        commands.append(command)
+        if command[:4] == ['gcloud', 'run', 'services', 'describe']:
+            return SimpleNamespace(
+                stdout=json.dumps({'spec': {'template': {'spec': {'containers': [{'env': state['env']}]}}}})
+            )
+        assert command[3] == 'update'
+        assert '--remove-secrets=PUBLIC_SETTING' in command
+        state['env'] = [state['env'][1]]
+        return SimpleNamespace(stdout='')
+
+    migrated = preflight.migrate_legacy_public_bindings(
+        services=('backend',),
+        env='dev',
+        project='based-hardware-dev',
+        region='us-central1',
+        manifest_path=manifest,
+        runner=runner,
+    )
+    command_count_after_migration = len(commands)
+    drift = preflight.check_runtime_bindings(
+        services=('backend',),
+        env='dev',
+        project='based-hardware-dev',
+        region='us-central1',
+        manifest_path=manifest,
+        runner=runner,
+    )
+
+    assert migrated == ['backend']
+    assert drift == []
+    assert commands[1][3] == 'update'
+    assert commands[command_count_after_migration:] == [
+        [
+            'gcloud',
+            'run',
+            'services',
+            'describe',
+            'backend',
+            '--project=based-hardware-dev',
+            '--region=us-central1',
+            '--format=json',
+        ]
+    ]
+
+
+def test_runtime_binding_check_ignores_undeclared_live_bindings(tmp_path: Path) -> None:
+    preflight = load_preflight()
+    manifest = tmp_path / 'runtime_env.yaml'
+    manifest.write_text(
+        '''\
+environments:
+  dev:
+    cloud_run:
+      services:
+        backend:
+          env:
+            GLOBAL_PUBLIC:
+              value: global
+          secrets:
+            GLOBAL_SECRET:
+              secret: inherited-secret
+              version: '3'
+        backend-integration:
+          env:
+            INTEGRATION_PUBLIC:
+              value: integration
+          secrets:
+            INTEGRATION_SECRET:
+              secret: integration-secret
+              version: latest
+''',
+        encoding='utf-8',
+    )
+    document = {
+        'spec': {
+            'template': {
+                'spec': {
+                    'containers': [
+                        {
+                            'env': [
+                                {
+                                    'name': 'GLOBAL_PUBLIC',
+                                    'valueFrom': {'configMapKeyRef': {'key': 'retained-live-binding'}},
+                                },
+                                {
+                                    'name': 'GLOBAL_SECRET',
+                                    'valueFrom': {'secretKeyRef': {'name': 'retained-live-secret', 'key': '9'}},
+                                },
+                                {'name': 'INTEGRATION_PUBLIC', 'value': 'integration'},
+                                {
+                                    'name': 'INTEGRATION_SECRET',
+                                    'valueFrom': {'secretKeyRef': {'name': 'integration-secret', 'key': 'latest'}},
+                                },
+                            ]
+                        }
+                    ]
+                }
+            }
+        }
+    }
+
+    drift = preflight.check_runtime_bindings(
+        services=('backend-integration',),
+        env='dev',
+        project='based-hardware-dev',
+        region='us-central1',
+        manifest_path=manifest,
+        runner=lambda _command, **_kwargs: SimpleNamespace(stdout=json.dumps(document)),
+    )
+
+    assert drift == []
+
+
+def test_runtime_binding_check_reports_declared_type_mismatches_only(tmp_path: Path) -> None:
+    preflight = load_preflight()
+    manifest = tmp_path / 'runtime_env.yaml'
+    manifest.write_text(
+        '''\
+environments:
+  dev:
+    cloud_run:
+      services:
+        backend:
+          env:
+            PUBLIC_SETTING:
+              value: public
+            SECOND_PUBLIC_SETTING:
+              value: another-public-setting
+          secrets:
+            PRIVATE_SETTING:
+              secret: expected-secret
+              version: latest
+''',
+        encoding='utf-8',
+    )
+    document = {
+        'spec': {
+            'template': {
+                'spec': {
+                    'containers': [
+                        {
+                            'env': [
+                                {
+                                    'name': 'PUBLIC_SETTING',
+                                    'valueFrom': {'secretKeyRef': {'name': 'legacy-public', 'key': 'latest'}},
+                                },
+                                {'name': 'SECOND_PUBLIC_SETTING', 'valueFrom': {'configMapKeyRef': {'key': 'value'}}},
+                                {'name': 'PRIVATE_SETTING', 'value': 'not-secret'},
+                                {'name': 'UNEXPECTED_SETTING', 'value': 'unexpected'},
+                            ]
+                        }
+                    ]
+                }
+            }
+        }
+    }
+
+    drift = preflight.check_runtime_bindings(
+        services=('backend',),
+        env='dev',
+        project='based-hardware-dev',
+        region='us-central1',
+        manifest_path=manifest,
+        runner=lambda _command, **_kwargs: SimpleNamespace(stdout=json.dumps(document)),
+    )
+
+    assert drift == [
+        'runtime-binding/backend/PUBLIC_SETTING: expected public literal or absent before candidate deploy, observed Secret Manager reference legacy-public:latest',
+        'runtime-binding/backend/SECOND_PUBLIC_SETTING: expected public literal or absent before candidate deploy, observed unsupported value source',
+        'runtime-binding/backend/PRIVATE_SETTING: expected Secret Manager reference expected-secret:latest, observed public literal',
+    ]
+
+
+@pytest.mark.parametrize(
+    ('env', 'project'),
+    [
+        ('prod', 'based-hardware'),
+        ('dev', 'based-hardware'),
+    ],
+)
+def test_runtime_binding_check_rejects_non_development_scope_without_gcloud_calls(env: str, project: str) -> None:
+    preflight = load_preflight()
+    calls: list[list[str]] = []
+
+    with pytest.raises(ValueError, match='development-only'):
+        preflight.check_runtime_bindings(
+            services=('backend',),
+            env=env,
+            project=project,
+            region='us-central1',
+            runner=lambda command, **_kwargs: calls.append(command),
+        )
+
+    assert calls == []

--- a/backend/tests/unit/test_verify_dev_backend_deployment.py
+++ b/backend/tests/unit/test_verify_dev_backend_deployment.py
@@ -290,6 +290,7 @@ def test_legacy_binding_migration_rejects_non_dev_projects_without_gcloud_calls(
 
 def test_dev_deploy_invokes_legacy_binding_migration_only_for_dev_services() -> None:
     workflow = BACKEND_DIR.parent / '.github/workflows/gcp_backend_auto_dev.yml'
+    production_workflow = BACKEND_DIR.parent / '.github/workflows/gcp_backend.yml'
     text = workflow.read_text(encoding='utf-8')
 
     assert 'environment: development' in text
@@ -298,6 +299,10 @@ def test_dev_deploy_invokes_legacy_binding_migration_only_for_dev_services() -> 
     for service in ('backend', 'backend-sync', 'backend-sync-backfill', 'backend-integration'):
         assert f'--migrate-legacy-public-binding {service}' in text
     assert text.index('migrate-legacy-public-binding') < text.index('Deploy ${{ env.SERVICE }} to Cloud Run')
+    assert '--check-runtime-bindings' in text
+    assert text.index('migrate-legacy-public-binding') < text.index('--check-runtime-bindings')
+    assert text.index('--check-runtime-bindings') < text.index('Deploy ${{ env.SERVICE }} to Cloud Run')
+    assert '--check-runtime-bindings' not in production_workflow.read_text(encoding='utf-8')
 
 
 def test_expectation_binds_commit_to_deploy_run_revision_and_image() -> None:


### PR DESCRIPTION
## Summary
- add a development-only, read-only Cloud Run runtime-binding preflight after the existing legacy public-binding migration and before candidate deployment
- compare only bindings declared by the checked-in development runtime manifest, avoiding false drift from retained unmanaged live bindings
- fail closed for declared secret mismatches/missing values, lingering Secret Manager or unsupported public bindings, malformed/multi-container service shapes, and failed Cloud Run describes

## Scope and safety
- requires exactly `env=dev` and `project=based-hardware-dev`
- invokes only `gcloud run services describe` in check mode
- no traffic, secret, Cloud Run update, production workflow, environment-variable, or secret changes
- expected public literals may be absent after the legacy-secret removal and before the candidate deploy; they may not remain secret-backed

## Verification
- independent review approved after coverage additions
- focused unit/workflow tests: 23 passed
- live read-only development runtime-binding contract: passed
- actionlint, diff hygiene, runtime-env validation, typecheck (0 errors), selected backend unit checks, OpenAPI contract, formatting, and repository pre-push checks passed


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9732?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

