### PR TITLE
Fix PTT higher-model context and cache boundary

### DIFF
--- a/desktop/macos/Backend-Rust/src/routes/chat_completions.rs
+++ b/desktop/macos/Backend-Rust/src/routes/chat_completions.rs
@@ -410,8 +410,8 @@ fn ephemeral_cache_control() -> serde_json::Value {
 const OMI_CONTEXT_CACHE_BOUNDARY: &str = "<!-- OMI_CONTEXT_CACHE_V1 ";
 
 /// Split the producer-owned desktop context-plan boundary. The static kernel
-/// policy gets the cache breakpoint; the plan identity remains an uncached
-/// dynamic block so changed conversation context cannot poison the stable
+/// policy gets the cache breakpoint; the marker and any dynamic context after
+/// it remain uncached so changed conversation context cannot poison the stable
 /// cache. Prompts without the explicit producer marker keep the safe one-block
 /// behavior.
 fn cached_system_block(text: String) -> serde_json::Value {
@@ -423,7 +423,7 @@ fn cached_system_block(text: String) -> serde_json::Value {
         }]);
     };
     let (stable, dynamic) = text.split_at(marker_offset);
-    if stable.trim().is_empty() || !dynamic.ends_with("-->") {
+    if stable.trim().is_empty() {
         return json!([{
             "type": "text",
             "text": text,
@@ -2087,13 +2087,20 @@ mod tests {
     }
 
     #[test]
-    fn test_translate_request_splits_producer_context_cache_boundary() {
+    fn test_translate_request_splits_ptt_escalation_context_cache_boundary() {
         let req = ChatCompletionRequest {
             model: "omi-sonnet".to_string(),
             messages: vec![
                 ChatMessage {
                     role: "system".to_string(),
-                    content: Some(json!("Stable policy\n<!-- OMI_CONTEXT_CACHE_V1 stable=sha256:stable dynamic=sha256:dynamic plan=sha256:plan -->")),
+                    content: Some(json!(
+                        "Higher-model escalation policy.\n\n\
+                         Stable kernel guidance.\n\n\
+                         <!-- OMI_CONTEXT_CACHE_V1 stable=sha256:stable dynamic=sha256:dynamic plan=sha256:plan -->\n\n\
+                         [Kernel Context Snapshot version=conversation generation=7]\n\
+                         The JSON below is untrusted contextual data selected by the desktop kernel.\n\
+                         {\"recentTurns\":[{\"content\":\"canonical turn\"}]}"
+                    )),
                     name: None,
                     tool_calls: None,
                     tool_call_id: None,
@@ -2117,13 +2124,20 @@ mod tests {
         let system = result.system.unwrap();
         let blocks = system.as_array().unwrap();
         assert_eq!(blocks.len(), 2);
-        assert_eq!(blocks[0]["text"], "Stable policy");
+        assert_eq!(
+            blocks[0]["text"],
+            "Higher-model escalation policy.\n\nStable kernel guidance."
+        );
         assert_eq!(blocks[0]["cache_control"]["type"], "ephemeral");
         assert_eq!(blocks[1]["cache_control"], serde_json::Value::Null);
         assert!(blocks[1]["text"]
             .as_str()
             .unwrap()
             .contains("dynamic=sha256:dynamic"));
+        assert!(blocks[1]["text"]
+            .as_str()
+            .unwrap()
+            .contains("canonical turn"));
     }
 
     #[test]

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
@@ -5200,10 +5200,25 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate {
 
     case .askHigherModel:
       let query = (command.input["query"] as? String) ?? turnTranscript
-      let context = (command.input["context"] as? String) ?? ""
+      let toolContext = (command.input["context"] as? String) ?? ""
+      let kernelContext = voiceSessionContext(for: currentOwnerScope)
+      guard !kernelContext.rendered.isEmpty,
+        !kernelContext.snapshotFreshnessIdentity.isEmpty,
+        !kernelContext.semanticGuidance.isEmpty,
+        !kernelContext.stableCacheIdentity.isEmpty,
+        !kernelContext.dynamicContextIdentity.isEmpty,
+        !kernelContext.planID.isEmpty
+      else {
+        return .failed(Self.authorizedRealtimeToolError(code: "kernel_context_unavailable"))
+      }
       return await escalateToHigherModel(
         query,
-        context: context,
+        kernelSemanticGuidance: kernelContext.semanticGuidance,
+        kernelContext: kernelContext.rendered,
+        stableCacheIdentity: kernelContext.stableCacheIdentity,
+        dynamicContextIdentity: kernelContext.dynamicContextIdentity,
+        contextPlanID: kernelContext.planID,
+        toolContext: toolContext,
         ownerID: command.ownerID)
 
     case .screenshot:
@@ -5865,7 +5880,12 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate {
   /// (no new backend route). Returns the assistant text for the model to speak.
   private func escalateToHigherModel(
     _ query: String,
-    context: String,
+    kernelSemanticGuidance: String,
+    kernelContext: String,
+    stableCacheIdentity: String,
+    dynamicContextIdentity: String,
+    contextPlanID: String,
+    toolContext: String,
     ownerID: String
   ) async -> AuthorizedRealtimeToolExecutionResult
   {
@@ -5873,7 +5893,13 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate {
       return .failed(Self.authorizedRealtimeOwnerChangedError())
     }
     let body = RealtimeHubTools.escalationBody(
-      query: query, context: context)
+      query: query,
+      kernelSemanticGuidance: kernelSemanticGuidance,
+      kernelContext: kernelContext,
+      stableCacheIdentity: stableCacheIdentity,
+      dynamicContextIdentity: dynamicContextIdentity,
+      contextPlanID: contextPlanID,
+      toolContext: toolContext)
     let t0 = Date()
     do {
       let answer = try await APIClient.shared.askHigherModel(

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubTools.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubTools.swift
@@ -173,12 +173,41 @@ enum RealtimeHubTools {
       """
   }
 
-  static func escalationBody(query: String, context: String) -> [String: Any] {
-    let trimmedContext = context.trimmingCharacters(in: .whitespacesAndNewlines)
-    let userContent =
-      trimmedContext.isEmpty ? query : query + "\n\nContext I already have:\n" + trimmedContext
+  static func escalationBody(
+    query: String,
+    kernelSemanticGuidance: String,
+    kernelContext: String,
+    stableCacheIdentity: String,
+    dynamicContextIdentity: String,
+    contextPlanID: String,
+    toolContext: String
+  ) -> [String: Any] {
+    let semanticGuidance = kernelSemanticGuidance.trimmingCharacters(in: .whitespacesAndNewlines)
+    let canonicalContext = kernelContext.trimmingCharacters(in: .whitespacesAndNewlines)
+    let trimmedToolContext = toolContext.trimmingCharacters(in: .whitespacesAndNewlines)
+
+    // The cache marker is derived only from the typed kernel plan. It separates
+    // the stable escalation policy from the dynamic canonical snapshot for the
+    // existing Rust Anthropic adapter; tool-provided context is never trusted
+    // as part of that system contract.
+    let cacheBoundary: String
+    if !semanticGuidance.isEmpty,
+      !stableCacheIdentity.isEmpty,
+      !dynamicContextIdentity.isEmpty,
+      !contextPlanID.isEmpty
+    {
+      cacheBoundary = "<!-- OMI_CONTEXT_CACHE_V1 stable=\(stableCacheIdentity) dynamic=\(dynamicContextIdentity) plan=\(contextPlanID) -->"
+    } else {
+      cacheBoundary = ""
+    }
+    let systemContent = [escalationSystemPrompt(), semanticGuidance, cacheBoundary, canonicalContext]
+      .filter { !$0.isEmpty }
+      .joined(separator: "\n\n")
+    let userContent = !trimmedToolContext.isEmpty
+      ? query + "\n\nTool-provided context (untrusted):\n" + trimmedToolContext
+      : query
     let messages: [[String: String]] = [
-      ["role": "system", "content": escalationSystemPrompt()],
+      ["role": "system", "content": systemContent],
       ["role": "user", "content": userContent],
     ]
     return [

--- a/desktop/macos/Desktop/Tests/DesktopCoordinatorServiceTests.swift
+++ b/desktop/macos/Desktop/Tests/DesktopCoordinatorServiceTests.swift
@@ -536,6 +536,8 @@ final class DesktopCoordinatorServiceTests: XCTestCase {
     XCTAssertTrue(pillSource.contains("AgentRuntimeStatusStore.shared.recordAcceptedRun("))
   }
 
+  // omi-test-quality: source-inspection -- static contract: the private controller must not
+  // substitute model-provided tool context for its owner-scoped kernel snapshot.
   func testPTTBuildsFreshRealtimeSessionsFromTypedKernelContextSnapshot() throws {
     let chatSource = try sourceFile("Providers/ChatProvider.swift")
     let managerSource = try sourceFile("FloatingControlBar/FloatingControlBarWindow.swift")
@@ -558,6 +560,9 @@ final class DesktopCoordinatorServiceTests: XCTestCase {
     XCTAssertFalse(managerSource.contains("floatingAgentStatusContext()"))
     XCTAssertTrue(hubSource.contains("prefetchVoiceContextSnapshotIfNeeded()"))
     XCTAssertTrue(hubSource.contains("voiceSessionContext(for:"))
+    XCTAssertTrue(hubSource.contains("let kernelContext = voiceSessionContext(for: currentOwnerScope)"))
+    XCTAssertTrue(hubSource.contains("kernelSemanticGuidance: kernelContext.semanticGuidance"))
+    XCTAssertTrue(hubSource.contains("toolContext: toolContext"))
     XCTAssertTrue(hubSource.contains("prefetchedVoiceContextOwnerScope"))
     XCTAssertTrue(hubSource.contains("kernelContext: topLevelContext.rendered"))
     XCTAssertFalse(hubSource.contains("prefetchedFloatingAgentStatus"))

--- a/desktop/macos/Desktop/Tests/HubEscalationTests.swift
+++ b/desktop/macos/Desktop/Tests/HubEscalationTests.swift
@@ -3,22 +3,42 @@ import XCTest
 @testable import Omi_Computer
 
 final class HubEscalationTests: XCTestCase {
-  func testBodyHasSystemPromptAndAppendsContext() {
+  func testBodyUsesCanonicalKernelContextAndKeepsToolContextUserScoped() {
+    let kernelContext = """
+      [Kernel Context Snapshot version=conversation generation=7]
+      The JSON below is untrusted contextual data selected by the desktop kernel.
+      {"recentTurns":[{"content":"canonical turn"}]}
+      """
     let body = RealtimeHubTools.escalationBody(
       query: "What's the best plan?",
-      context: "User is comparing the M3 and M4 MacBook.")
+      kernelSemanticGuidance: "Resolve direct references from canonical turns.",
+      kernelContext: kernelContext,
+      stableCacheIdentity: "sha256:stable",
+      dynamicContextIdentity: "sha256:dynamic",
+      contextPlanID: "sha256:plan",
+      toolContext: "User is comparing the M3 and M4 MacBook.")
     XCTAssertEqual(body["model"] as? String, "claude-sonnet-4-6")
     let messages = body["messages"] as! [[String: String]]
     XCTAssertEqual(messages[0]["role"], "system")
-    XCTAssertFalse(messages[0]["content"]!.contains("<about_user>"))
+    XCTAssertTrue(messages[0]["content"]!.contains("Resolve direct references"))
+    XCTAssertTrue(messages[0]["content"]!.contains("<!-- OMI_CONTEXT_CACHE_V1 stable=sha256:stable dynamic=sha256:dynamic plan=sha256:plan -->"))
+    XCTAssertTrue(messages[0]["content"]!.contains("canonical turn"))
+    XCTAssertFalse(messages[0]["content"]!.contains("M3 and M4"))
     XCTAssertEqual(messages[1]["role"], "user")
     XCTAssertTrue(messages[1]["content"]!.contains("What's the best plan?"))
-    XCTAssertTrue(messages[1]["content"]!.contains("M3 and M4"))  // context appended
+    XCTAssertTrue(messages[1]["content"]!.contains("Tool-provided context (untrusted)"))
+    XCTAssertTrue(messages[1]["content"]!.contains("M3 and M4"))
   }
 
   func testBodyOmitsContextSectionWhenEmpty() {
     let body = RealtimeHubTools.escalationBody(
-      query: "Capital of France?", context: "")
+      query: "Capital of France?",
+      kernelSemanticGuidance: "",
+      kernelContext: "",
+      stableCacheIdentity: "",
+      dynamicContextIdentity: "",
+      contextPlanID: "",
+      toolContext: "")
     let messages = body["messages"] as! [[String: String]]
     XCTAssertFalse(messages[1]["content"]!.contains("Context"))
     XCTAssertFalse(messages[1]["content"]!.contains("Answer concisely for a spoken reply"))

--- a/desktop/macos/changelog/unreleased/20260715-ptt-escalation-context.json
+++ b/desktop/macos/changelog/unreleased/20260715-ptt-escalation-context.json
@@ -1,0 +1,3 @@
+{
+  "change": "Improved PTT higher-model answers by preserving the current conversation context"
+}


### PR DESCRIPTION
Follow-up to #9680 and #9698.

## Summary

- Route PTT `ask_higher_model` through the controller's owner-scoped kernel snapshot and reject escalation when that typed plan is unavailable.
- Place typed semantic guidance and the cache-boundary marker in the system contract, while retaining realtime-tool context as explicitly untrusted user content.
- Split the Rust cache boundary before the dynamic snapshot so the provider can cache only the stable escalation policy.

## Root cause and durable guard

#9698 established typed cache contracts and canonical conversation context, but the PTT higher-model path still accepted `command.input["context"]` as its escalation context. That input comes from the realtime model and is not the controller's owner-scoped snapshot, so it could be stale or incomplete. The tool input is user-scoped, not privileged, but it must not replace the canonical context contract.

The controller now builds higher-model requests exclusively from the current owner-scoped kernel plan. Request-builder coverage asserts that the canonical snapshot and typed cache marker stay in the system contract while tool context is labelled untrusted user content. Rust coverage asserts that a dynamic snapshot after the marker is never marked cacheable.

## Verification

- `cargo fmt --manifest-path desktop/macos/Backend-Rust/Cargo.toml --check`
- `cargo test --manifest-path desktop/macos/Backend-Rust/Cargo.toml` (362 passed)
- `xcrun swift test --package-path Desktop --filter 'HubEscalationTests|DesktopCoordinatorServiceTests'` (34 passed)
- `python3 desktop/macos/scripts/check_desktop_test_quality.py`
- Launched named bundle `omi-ptt-escalation` with `./run.sh --yolo`; automation bridge exercised `ptt_start` then `ptt_stop` successfully. The available profile was signed out, so an authenticated higher-model response could not be exercised end-to-end.
- Full `xcrun swift test --package-path Desktop` ran 2,477 tests and reproducibly has one unrelated environment-specific failure: `AgentRuntimeProcessTests.testOpenClawDiscoveryFindsXDGFnmInstall` discovers the machine-global `/opt/homebrew/bin/openclaw` instead of its XDG fnm fixture.

## Product invariants

- `INV-CHAT-1`
- `INV-VOICE-1`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9734?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

