### PR TITLE
fix(ci): restore GitHub issue project sync

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,7 @@ jobs:
           project_field: Status
           # Optional unless that project_field was set up. Then this field is required.
           # The value to modify in the project field
-          project_value: Backlog
+          project_value: Someday
           # Optional, labels to work with. Read below to see how to configure it.
           # If this value is set, the action will be applied only to issues with such label(s).
           labels: |


### PR DESCRIPTION
## What changed and why

Replace the removed `Backlog` value in the GitHub Issue Sync workflow with the project's current backlog-equivalent `Someday` status. The action rejects values that are not present in the Project V2 single-select field, so every qualifying issue sync currently fails before adding the item. Closes #9736.

## Product invariants affected

none

## How it was verified

- Inspected failed GitHub Issue Sync run `29356714415`, which reports that `Backlog` does not exist and lists `Someday`, `Next Week`, `TODO (This week)`, `In progress`, `In review`, and `Done` as the available values.
- Confirmed from workflow history that `Backlog` replaced the original to-do status specifically to route synced issues into the backlog, making `Someday` the current semantic equivalent.
- `actionlint -shellcheck= .github/workflows/main.yml`
- Passed diff hygiene, architecture guardrails, product invariants, desktop changelog, deferred-work marker, lifecycle header, version-prefixed filename, and backend workflow contract checks.
- The deployment secret-boundary check passes when repository-relative paths are normalized. Its native Windows invocation currently false-fails even with `--base HEAD` because current paths use backslashes while Git base paths use forward slashes; tracked separately in #9738.

## Tests

This is a one-value workflow configuration repair. Static workflow validation and all applicable deterministic checks pass apart from the isolated native Windows path-comparison defect described above. A live Project V2 mutation cannot be exercised from a fork because the upstream project token is intentionally unavailable there.

## Root cause and durable guard (bug fixes)

The configured Project V2 status was renamed or removed while the workflow retained the exact string `Backlog`. The action validates single-select values by name, so the stale value causes a hard failure. Routing to the existing `Someday` option restores the intended backlog placement without changing triggers, permissions, labels, project selection, or active-work statuses.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9740?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

