### PR TITLE
fix(preflight): normalize deployment paths on Windows

### DIFF
--- a/.github/scripts/check_deployment_secret_boundary.py
+++ b/.github/scripts/check_deployment_secret_boundary.py
@@ -15,7 +15,7 @@ import re
 import subprocess
 import sys
 from dataclasses import dataclass
-from pathlib import Path
+from pathlib import Path, PurePath
 from typing import Iterable
 
 
@@ -42,13 +42,17 @@ class Binding:
     name: str
 
 
+def _repository_relative_path(path: PurePath, root: PurePath) -> str:
+    return path.relative_to(root).as_posix()
+
+
 def _value_from_match(match: re.Match[str], group: int = 1) -> str:
     return match.group(group)
 
 
 def _deployment_paths(root: Path) -> set[str]:
     paths = {
-        str(path.relative_to(root))
+        _repository_relative_path(path, root)
         for path in (root / ".github" / "workflows").glob("*.y*ml")
         if path.is_file()
     }
@@ -57,11 +61,7 @@ def _deployment_paths(root: Path) -> set[str]:
             paths.add(relative)
     charts = root / "backend" / "charts"
     if charts.is_dir():
-        paths.update(
-            str(path.relative_to(root))
-            for path in charts.glob("*/*_values.yaml")
-            if path.is_file()
-        )
+        paths.update(_repository_relative_path(path, root) for path in charts.glob("*/*_values.yaml") if path.is_file())
     return paths
 
 
@@ -83,7 +83,8 @@ def _base_paths(root: Path, base: str) -> set[str]:
     return {
         path
         for path in paths
-        if path.startswith(".github/workflows/") and path.endswith((".yml", ".yaml"))
+        if path.startswith(".github/workflows/")
+        and path.endswith((".yml", ".yaml"))
         or path == "backend/deploy/runtime_env.yaml"
         or re.fullmatch(r"backend/charts/[^/]+/[^/]+_values\.yaml", path) is not None
     }
@@ -275,7 +276,9 @@ def validate_bindings(
     # Public build configuration is an explicit migration target, not legacy
     # debt. Reject it even when a pre-ratchet line still exists in the base.
     to_validate = new_or_changed | {
-        binding for binding in current if binding.source == "github_secrets" and _classification(policy, binding.name) == "public_build"
+        binding
+        for binding in current
+        if binding.source == "github_secrets" and _classification(policy, binding.name) == "public_build"
     }
     for binding in sorted(to_validate):
         kind = _classification(policy, binding.name)
@@ -286,7 +289,9 @@ def validate_bindings(
         if kind in expected or _exception_allows(policy, binding):
             continue
         if binding.source == "github_secrets" and kind == "public_build":
-            errors.append(f"{binding.path}: public_build setting {binding.name} must use vars.{binding.name}, not secrets.{binding.name}")
+            errors.append(
+                f"{binding.path}: public_build setting {binding.name} must use vars.{binding.name}, not secrets.{binding.name}"
+            )
         else:
             expected_text = " or ".join(sorted(expected))
             errors.append(

--- a/.github/scripts/test_check_deployment_secret_boundary.py
+++ b/.github/scripts/test_check_deployment_secret_boundary.py
@@ -10,7 +10,7 @@ import subprocess
 import sys
 import tempfile
 import unittest
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -30,6 +30,14 @@ POLICY = {
     },
     "exceptions": {},
 }
+
+
+class RepositoryPathFixture(unittest.TestCase):
+    def test_windows_repository_paths_use_git_separators(self) -> None:
+        root = PureWindowsPath("C:/omi")
+        path = root / ".github" / "workflows" / "deploy.yml"
+
+        self.assertEqual(CHECKER._repository_relative_path(path, root), ".github/workflows/deploy.yml")
 
 
 def git_environment() -> dict[str, str]:
@@ -90,7 +98,9 @@ jobs:
     def test_rejects_public_build_setting_from_github_secret(self) -> None:
         self.write(".github/workflows/deploy.yml", "BUILD: ${{ secrets.FAKE_PUBLIC_BUILD }}\n")
 
-        self.assertIn("public_build setting FAKE_PUBLIC_BUILD must use vars.FAKE_PUBLIC_BUILD", "\n".join(self.errors()))
+        self.assertIn(
+            "public_build setting FAKE_PUBLIC_BUILD must use vars.FAKE_PUBLIC_BUILD", "\n".join(self.errors())
+        )
 
     def test_rejects_config_external_secret_mapping(self) -> None:
         self.write(
@@ -102,12 +112,17 @@ jobs:
 """,
         )
 
-        self.assertIn("external_secret binding FAKE_RUNTIME_CONFIG is config; expected secret", "\n".join(self.errors()))
+        self.assertIn(
+            "external_secret binding FAKE_RUNTIME_CONFIG is config; expected secret", "\n".join(self.errors())
+        )
 
     def test_rejects_secret_from_github_variable(self) -> None:
         self.write(".github/workflows/deploy.yml", "TOKEN: ${{ vars.FAKE_SERVER_SECRET }}\n")
 
-        self.assertIn("github_vars binding FAKE_SERVER_SECRET is secret; expected config or public_build", "\n".join(self.errors()))
+        self.assertIn(
+            "github_vars binding FAKE_SERVER_SECRET is secret; expected config or public_build",
+            "\n".join(self.errors()),
+        )
 
     def test_rejects_config_loaded_from_secret_manager(self) -> None:
         self.write(
@@ -133,7 +148,9 @@ jobs:
         policy["exceptions"] = {"FAKE_RUNTIME_CONFIG": {"owner": "platform"}}
         self.write("config/deployment-setting-classification.json", json.dumps(policy))
 
-        errors = CHECKER.validate_policy(CHECKER.load_policy(self.root / "config/deployment-setting-classification.json"))
+        errors = CHECKER.validate_policy(
+            CHECKER.load_policy(self.root / "config/deployment-setting-classification.json")
+        )
 
         self.assertIn("exception FAKE_RUNTIME_CONFIG is missing reason", errors)
         self.assertIn("exception FAKE_RUNTIME_CONFIG is missing expires", errors)


### PR DESCRIPTION
## What changed and why

Normalize current-tree deployment paths to POSIX repository-relative form before comparing them with Git's base-tree paths. This prevents the deployment secret-boundary ratchet from treating every existing binding as new on native Windows. Add a host-independent `PureWindowsPath` regression test so Linux CI also enforces the separator contract. Closes #9738.

## Product invariants affected

none

## How it was verified

- Reproduced the bug on Windows 10.0.26200 with Python 3.11.15: the existing 7-test fixture suite failed `test_rejects_new_unclassified_binding_but_allows_legacy_baseline`, and the production checker failed even with `--base HEAD` while reporting hundreds of unchanged bindings.
- `python3 .github/scripts/test_check_deployment_secret_boundary.py` (8 tests passed after the fix)
- `python3 .github/scripts/check_deployment_secret_boundary.py --base HEAD`
- `black --check --line-length 120 --skip-string-normalization .github/scripts/check_deployment_secret_boundary.py .github/scripts/test_check_deployment_secret_boundary.py`
- `ruff check --target-version py39 .github/scripts/check_deployment_secret_boundary.py .github/scripts/test_check_deployment_secret_boundary.py`
- `python3 .github/scripts/pr_preflight.py --lane local --base origin/main --head HEAD` (10 selected checks passed)
- `bash scripts/pre-push fork` (all fast pre-push checks passed on native Windows)

## Tests

The new `PureWindowsPath` fixture verifies that production path normalization emits `.github/workflows/deploy.yml`, matching Git tree output. The existing temporary-repository fixture then exercises the complete current-vs-base binding comparison and now passes on Windows.

## Root cause and durable guard (bug fixes)

`_deployment_paths()` converted `Path.relative_to()` with `str()`, producing backslashes on Windows, while `_base_paths()` consumes Git output with forward slashes. Since each `Binding` includes its path, identical bindings never compared equal and the diff ratchet collapsed into a full-repository scan. The shared path conversion now uses `PurePath.as_posix()` for every discovered current-tree file, and the Windows-path unit fixture keeps that cross-platform contract enforced in all CI environments.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9743?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

