### PR TITLE
fix(dev): smoke deployed Cloud Run URL

### DIFF
--- a/.github/workflows/gcp_backend_auto_dev.yml
+++ b/.github/workflows/gcp_backend_auto_dev.yml
@@ -383,7 +383,12 @@ jobs:
           ADMIN_KEY="$(gcloud secrets versions access latest --secret=ADMIN_KEY --project="$PROJECT_ID")"
           export ADMIN_KEY
           trap 'unset ADMIN_KEY' EXIT
-          python3 backend/scripts/smoke_what_matters_now.py --base-url https://api.omi.dev
+          BACKEND_URL="$(gcloud run services describe backend \
+            --project="$PROJECT_ID" \
+            --region="${{ env.REGION }}" \
+            --format='value(status.url)')"
+          test -n "$BACKEND_URL"
+          python3 backend/scripts/smoke_what_matters_now.py --base-url "$BACKEND_URL"
 
       - name: Upload deployment acceptance evidence
         if: always()

--- a/backend/tests/unit/test_smoke_what_matters_now.py
+++ b/backend/tests/unit/test_smoke_what_matters_now.py
@@ -80,10 +80,25 @@ def test_main_uses_the_code_owned_fixture_without_a_uid_environment_variable(mon
     )
 
 
-def test_development_deploy_workflows_use_only_the_existing_admin_key_for_the_smoke():
+def test_auto_dev_smoke_resolves_the_backend_cloud_run_url_with_existing_auth():
     root = Path(__file__).resolve().parents[3]
-    for workflow_name in ('gcp_backend.yml', 'gcp_backend_auto_dev.yml'):
-        workflow = (root / '.github' / 'workflows' / workflow_name).read_text(encoding='utf-8')
-        assert 'OMI_TASK_INTELLIGENCE_SMOKE_UID' not in workflow
-        assert '--secret=ADMIN_KEY' in workflow
-        assert 'smoke_what_matters_now.py --base-url https://api.omi.dev' in workflow
+    workflow = (root / '.github' / 'workflows' / 'gcp_backend_auto_dev.yml').read_text(encoding='utf-8')
+
+    assert 'OMI_TASK_INTELLIGENCE_SMOKE_UID' not in workflow
+    assert '--secret=ADMIN_KEY' in workflow
+    assert 'BACKEND_URL="$(gcloud run services describe backend' in workflow
+    assert '--project="$PROJECT_ID"' in workflow
+    assert "--region=\"${{ env.REGION }}\"" in workflow
+    assert "--format='value(status.url)')\"" in workflow
+    assert 'test -n "$BACKEND_URL"' in workflow
+    assert 'smoke_what_matters_now.py --base-url "$BACKEND_URL"' in workflow
+    assert 'smoke_what_matters_now.py --base-url https://api.omi.dev' not in workflow
+
+
+def test_manual_development_smoke_keeps_its_existing_external_hostname_path():
+    root = Path(__file__).resolve().parents[3]
+    workflow = (root / '.github' / 'workflows' / 'gcp_backend.yml').read_text(encoding='utf-8')
+
+    assert 'OMI_TASK_INTELLIGENCE_SMOKE_UID' not in workflow
+    assert '--secret=ADMIN_KEY' in workflow
+    assert 'smoke_what_matters_now.py --base-url https://api.omi.dev' in workflow


### PR DESCRIPTION
## Summary
- resolve the development `backend` Cloud Run `status.url` with authenticated `gcloud` immediately before the What Matters Now acceptance smoke
- pass that direct deployed service URL to the existing admin-authenticated smoke script
- retain the manual/external-hostname workflow behavior unchanged

## Why
The prior development rollout completed successfully, but acceptance used `https://api.omi.dev`, which currently has no DNS record. The live development backend Cloud Run URL was healthy. Direct Cloud Run resolution makes the development deploy smoke test the revision that was just deployed.

## Scope and safety
- development auto-deploy workflow only
- no production workflow behavior, secrets, variables, authentication, traffic, or application code changes
- empty Cloud Run URLs fail closed

## Verification
- independent review approved
- focused workflow/smoke tests: 16 passed
- actionlint, shell syntax/mock snippet execution, diff hygiene, runtime-env validation, typecheck (0 errors), selected backend tests, OpenAPI contract, formatting, and full repository pre-push checks passed


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9745?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

