### PR TITLE
fix(ci): preserve invariant citations on main pushes

### DIFF
--- a/.github/scripts/test_run_checks.py
+++ b/.github/scripts/test_run_checks.py
@@ -38,7 +38,10 @@ def deterministic_workflow_references(workflows_dir: Path) -> set[str]:
             path = match.group("path")
             name = Path(path).name
             if (
-                (path.startswith(".github/scripts/") and (name.startswith(("check_", "check-")) or name.endswith("-count.py")))
+                (
+                    path.startswith(".github/scripts/")
+                    and (name.startswith(("check_", "check-")) or name.endswith("-count.py"))
+                )
                 or (path.startswith("backend/scripts/") and name.startswith(("scan_", "check_")))
                 or (path.startswith("desktop/macos/scripts/") and name.startswith(("check_", "check-")))
             ):
@@ -72,9 +75,19 @@ class ManifestContractTests(unittest.TestCase):
 
     def test_ci_lane_is_reachable_from_repo_checks(self) -> None:
         workflow = (WORKFLOWS_DIR / "repo-checks.yml").read_text(encoding="utf-8")
-        self.assertRegex(workflow, r"run_checks\.py\s+--lane\s+ci")
+        self.assertRegex(workflow, r"run_checks\.py(?:\s+\\)?\s+--lane\s+ci")
         manifest = load_manifest(MANIFEST_PATH)
         self.assertTrue(any("ci" in check.lanes for check in manifest.checks))
+
+    def test_main_push_forwards_commit_body_to_invariant_check(self) -> None:
+        workflow = (WORKFLOWS_DIR / "repo-checks.yml").read_text(encoding="utf-8")
+        step_name = "      - name: Run deterministic check manifest on main pushes"
+        step_start = workflow.index(step_name)
+        step_end = workflow.index("\n      - name:", step_start + len(step_name))
+        main_push_step = workflow[step_start:step_end]
+
+        self.assertIn("git show -s --format=%B HEAD > /tmp/main-push-body.md", main_push_step)
+        self.assertIn("--pr-body-file /tmp/main-push-body.md", main_push_step)
 
     def test_unregistered_fake_workflow_check_is_named(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/.github/workflows/repo-checks.yml
+++ b/.github/workflows/repo-checks.yml
@@ -84,7 +84,12 @@ jobs:
 
       - name: Run deterministic check manifest on main pushes
         if: github.event_name != 'pull_request'
-        run: python3 .github/scripts/run_checks.py --lane ci --base "${{ needs.changes.outputs.diff_base }}"
+        run: |
+          git show -s --format=%B HEAD > /tmp/main-push-body.md
+          python3 .github/scripts/run_checks.py \
+            --lane ci \
+            --base "${{ needs.changes.outputs.diff_base }}" \
+            --pr-body-file /tmp/main-push-body.md
 
       - name: Test brand UI ratchet helper
         run: python3 .github/scripts/test_check_brand_ui.py

--- a/backend/tests/unit/test_workflow_contracts.py
+++ b/backend/tests/unit/test_workflow_contracts.py
@@ -245,7 +245,10 @@ def test_shared_change_detection_and_backend_isolation_are_ci_wired():
     assert "unmanaged_thread_offload" in manifest
     assert "scan_import_time_side_effects.py" not in backend_checks
     assert "check_module_stub_pollution.py" not in backend_checks
-    assert "run_checks.py --lane ci" in repo_checks
+    assert "run_checks.py" in repo_checks
+    assert "--lane ci" in repo_checks
+    assert "git show -s --format=%B HEAD > /tmp/main-push-body.md" in repo_checks
+    assert "--pr-body-file /tmp/main-push-body.md" in repo_checks
     assert 'BASE_REMOTE="${PRE_PUSH_BASE_REMOTE:-origin}"' in pre_push
     assert 'scripts/changed-files "$DIFF_BASE" "$local_oid"' in pre_push
     assert "scripts/pr-preflight --lane local" in pre_push


### PR DESCRIPTION
## What changed and why

Pass the main merge commit's full message/body into the shared deterministic manifest through its existing `--pr-body-file` contract. This preserves product-invariant citations after merge instead of replacing the correctly documented PR body with an empty temporary file. Add a workflow wiring regression assertion that keeps the main-push step connected to that description. Closes #9744.

## Product invariants affected

none

## How it was verified

- Confirmed failed main run `29360878812` rejected `INV-CHAT-1` and `INV-VOICE-1` after #9734 merged even though both the PR body and merge commit `a3e1b7401560d6ae2b671c62fcfa3873ddd05e43` contain those IDs.
- Reproduced locally with `python3 .github/scripts/run_checks.py --lane ci --base HEAD~1`: the unmodified main-push path exited 1 for the same two missing IDs.
- Replayed the exact #9734 merge diff after writing `git show -s --format=%B HEAD` to the body file. All 14 selected CI manifest checks passed, including `product-invariants` naming both required IDs.
- `python3 .github/scripts/test_run_checks.py` (10 tests passed)
- `actionlint -shellcheck= .github/workflows/repo-checks.yml`
- `black --check --line-length 120 --skip-string-normalization .github/scripts/test_run_checks.py`
- `ruff check --target-version py39 .github/scripts/test_run_checks.py`
- Passed lifecycle-header, version-prefixed filename, backend workflow-contract, and path-normalized deployment secret-boundary checks.
- Native Windows full preflight currently false-fails at the deployment secret-boundary ratchet because main still compares backslash current paths with forward-slash Git paths. That unrelated defect is #9738 with fix #9743; all checks before it and all remaining selected checks pass for this branch.

## Tests

The new manifest contract test isolates the main-push workflow step and requires both creation and forwarding of `/tmp/main-push-body.md`. The exact previously failing merge was also exercised through the production CI-lane runner. The no-body baseline still fails, confirming undocumented direct pushes remain fail-closed.

## Root cause and durable guard (bug fixes)

Pull-request runs use `scripts/pr-preflight` to load PR metadata, while main pushes called `run_checks.py` directly without a body file. The runner intentionally substitutes an empty body when none is supplied, so the post-merge product-invariant check could never recognize valid citations. GitHub's regular merge commit already retains the PR description; forwarding that deterministic local data restores parity without API calls or weaker validation, and the workflow contract test prevents the input from being dropped again.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9746?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

