### PR TITLE
fix(desktop): keep PTT escalation available on a new voice session

### DIFF
--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
@@ -3244,23 +3244,35 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate {
         + "contextChars=\(topLevelContext.rendered.count) plan=\(topLevelContext.planID.prefix(24)))")
   }
 
-  private struct VoiceSessionContext {
+  struct VoiceSessionContext {
+    let sessionID: String
     let rendered: String
     let snapshotFreshnessIdentity: String
     let planID: String
     let stableCacheIdentity: String
     let dynamicContextIdentity: String
     let semanticGuidance: String
+
+    /// Availability contract, mirroring `KernelVoiceContextSnapshot.isResolved`:
+    /// a kernel session bound to this owner scope plus a deterministic freshness
+    /// identity. Rendered context, plan identities, and semantic guidance are
+    /// context *material* — a valid new conversation renders none of it, and
+    /// `RealtimeHubTools.escalationBody` omits each empty section on its own.
+    /// Requiring them here would fail-closed on the first turn of every session.
+    var isResolved: Bool {
+      !sessionID.isEmpty && !snapshotFreshnessIdentity.isEmpty
+    }
   }
 
   /// Exact context material selected and rendered by the kernel for realtime.
   private func voiceSessionContext(for ownerScope: RealtimeHubOwnerScope) -> VoiceSessionContext {
     guard prefetchedVoiceContextOwnerScope == ownerScope else {
       return VoiceSessionContext(
-        rendered: "", snapshotFreshnessIdentity: "", planID: "", stableCacheIdentity: "",
-        dynamicContextIdentity: "", semanticGuidance: "")
+        sessionID: "", rendered: "", snapshotFreshnessIdentity: "", planID: "",
+        stableCacheIdentity: "", dynamicContextIdentity: "", semanticGuidance: "")
     }
     return VoiceSessionContext(
+      sessionID: prefetchedVoiceContextSessionID,
       rendered: prefetchedVoiceContext,
       snapshotFreshnessIdentity: prefetchedVoiceContextFreshnessIdentity,
       planID: prefetchedVoiceContextPlanID,
@@ -5202,13 +5214,7 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate {
       let query = (command.input["query"] as? String) ?? turnTranscript
       let toolContext = (command.input["context"] as? String) ?? ""
       let kernelContext = voiceSessionContext(for: currentOwnerScope)
-      guard !kernelContext.rendered.isEmpty,
-        !kernelContext.snapshotFreshnessIdentity.isEmpty,
-        !kernelContext.semanticGuidance.isEmpty,
-        !kernelContext.stableCacheIdentity.isEmpty,
-        !kernelContext.dynamicContextIdentity.isEmpty,
-        !kernelContext.planID.isEmpty
-      else {
+      guard kernelContext.isResolved else {
         return .failed(Self.authorizedRealtimeToolError(code: "kernel_context_unavailable"))
       }
       return await escalateToHigherModel(

--- a/desktop/macos/Desktop/Tests/HubEscalationTests.swift
+++ b/desktop/macos/Desktop/Tests/HubEscalationTests.swift
@@ -30,6 +30,47 @@ final class HubEscalationTests: XCTestCase {
     XCTAssertTrue(messages[1]["content"]!.contains("M3 and M4"))
   }
 
+  /// A valid new conversation renders no context material but still carries a
+  /// kernel session and a freshness identity. Escalation must stay available:
+  /// gating it on rendered text broke the first PTT turn of every session.
+  @MainActor
+  func testResolvedSnapshotWithoutContextMaterialStillAllowsEscalation() {
+    let context = RealtimeHubController.VoiceSessionContext(
+      sessionID: "session_1",
+      rendered: "",
+      snapshotFreshnessIdentity: "conversation:renderer:v1",
+      planID: "",
+      stableCacheIdentity: "",
+      dynamicContextIdentity: "",
+      semanticGuidance: "")
+    XCTAssertTrue(context.isResolved)
+  }
+
+  /// The `.empty` sentinel (transport/bridge failure, or a snapshot bound to a
+  /// different owner scope) must still fail closed.
+  @MainActor
+  func testUnresolvedSnapshotBlocksEscalation() {
+    let unbound = RealtimeHubController.VoiceSessionContext(
+      sessionID: "",
+      rendered: "",
+      snapshotFreshnessIdentity: "",
+      planID: "",
+      stableCacheIdentity: "",
+      dynamicContextIdentity: "",
+      semanticGuidance: "")
+    XCTAssertFalse(unbound.isResolved)
+
+    let sessionlessButRendered = RealtimeHubController.VoiceSessionContext(
+      sessionID: "",
+      rendered: "[Kernel Context Snapshot]",
+      snapshotFreshnessIdentity: "conversation:renderer:v1",
+      planID: "sha256:plan",
+      stableCacheIdentity: "sha256:stable",
+      dynamicContextIdentity: "sha256:dynamic",
+      semanticGuidance: "Resolve direct references.")
+    XCTAssertFalse(sessionlessButRendered.isResolved)
+  }
+
   func testBodyOmitsContextSectionWhenEmpty() {
     let body = RealtimeHubTools.escalationBody(
       query: "Capital of France?",

--- a/desktop/macos/changelog/unreleased/20260714-ptt-escalation-new-session.json
+++ b/desktop/macos/changelog/unreleased/20260714-ptt-escalation-new-session.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed the floating bar failing to escalate a hard voice question to the higher model at the start of a new conversation"
+}


### PR DESCRIPTION
## Bug

After #9734, asking the floating bar a hard question over PTT on a **new voice session** fails instead of escalating. The user hears a refusal/error rather than an answer from the higher model.

## Root cause

#9734 correctly started feeding the canonical kernel context into `ask_higher_model`, but its availability guard requires *every* field of the prefetched snapshot to be non-empty:

```swift
guard !kernelContext.rendered.isEmpty,
  !kernelContext.snapshotFreshnessIdentity.isEmpty,
  !kernelContext.semanticGuidance.isEmpty,
  !kernelContext.stableCacheIdentity.isEmpty,
  !kernelContext.dynamicContextIdentity.isEmpty,
  !kernelContext.planID.isEmpty
else { return .failed(...kernel_context_unavailable) }
```

Rendered context is context **material**, not an availability signal. `KernelVoiceContextSnapshot.isResolved` states the contract directly:

> `.empty` is a transport/bridge failure sentinel, not a valid blank conversation. **A valid new conversation may render no text**, but it still has a kernel session and a deterministic freshness identity.

On the first PTT turn of a session there is nothing in the journal yet, so `snapshot.renderedContext` is empty — a perfectly resolved snapshot. The guard reads that as "kernel context unavailable" and hard-fails the tool.

`RealtimeHubTools.escalationBody` was already written to tolerate this: it filters empty sections out of the system message and has an explicit `else { cacheBoundary = "" }` branch, covered by `testBodyOmitsContextSectionWhenEmpty`. The new guard made that branch unreachable — the empty case was handled, not unsafe.

## Fix

Gate on the snapshot's own resolution contract — a kernel session bound to the current owner scope, plus a freshness identity — mirroring `KernelVoiceContextSnapshot.isResolved`:

```swift
guard kernelContext.isResolved else {
  return .failed(Self.authorizedRealtimeToolError(code: "kernel_context_unavailable"))
}
```

`voiceSessionContext(for:)` already returns an all-empty context on owner-scope mismatch, and the prefetch only stores fields from a snapshot that passed `isResolved`. So the two cases the guard exists for — the `.empty` transport-failure sentinel and a snapshot bound to a different owner — both still fail closed. Only "resolved, but this conversation has no context material yet" now proceeds, which is what `escalationBody` handles.

## Tests

Two regression tests on the production decision function (`RealtimeHubController.VoiceSessionContext.isResolved`):
- `testResolvedSnapshotWithoutContextMaterialStillAllowsEscalation` — bound session + freshness identity, empty rendered/guidance/plan → escalation allowed (this is the case that broke).
- `testUnresolvedSnapshotBlocksEscalation` — `.empty` sentinel and a rendered-but-sessionless context → still fail closed.

## Verification

- `xcrun swift build -c debug --package-path Desktop` — clean
- `swift test --filter HubEscalationTests` — 4/4 (2 new)
- `swift test --filter "RealtimeHub|RuntimeOwnerIdentity|KernelTurnRecordedProjection|FloatingControlBarState"` — 164 tests, 0 failures
- `make preflight` — 8/8 checks pass

Not exercised in a running app against a live model (no PTT hardware loop in this environment) — the escalation-availability decision is covered hermetically instead.

🤖 automated by hourly watchdog; opened for review, not merged.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9748?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

