### PR TITLE
fix(deploy): scope Cloud Run runtime env rendering to selected job

### DIFF
--- a/.github/workflows/gcp_memory_maintenance_job.yml
+++ b/.github/workflows/gcp_memory_maintenance_job.yml
@@ -83,7 +83,7 @@ jobs:
           CLOUD_RUN_VPC_NETWORK: ${{ vars.CLOUD_RUN_VPC_NETWORK }}
           CLOUD_RUN_VPC_SUBNET: ${{ vars.CLOUD_RUN_VPC_SUBNET }}
         run: |
-          python3 backend/scripts/render_backend_runtime_env.py --env ${{ vars.ENV }} >> "$GITHUB_OUTPUT"
+          python3 backend/scripts/render_backend_runtime_env.py --env ${{ vars.ENV }} --job memory-maintenance-job >> "$GITHUB_OUTPUT"
 
       - name: Validate backend runtime env before deploy
         run: |

--- a/.github/workflows/gcp_memory_maintenance_job_auto_dev.yml
+++ b/.github/workflows/gcp_memory_maintenance_job_auto_dev.yml
@@ -58,7 +58,7 @@ jobs:
           CLOUD_RUN_VPC_NETWORK: ${{ vars.CLOUD_RUN_VPC_NETWORK }}
           CLOUD_RUN_VPC_SUBNET: ${{ vars.CLOUD_RUN_VPC_SUBNET }}
         run: |
-          python3 backend/scripts/render_backend_runtime_env.py --env dev >> "$GITHUB_OUTPUT"
+          python3 backend/scripts/render_backend_runtime_env.py --env dev --job memory-maintenance-job >> "$GITHUB_OUTPUT"
 
       - name: Validate backend runtime env before deploy
         run: |

--- a/.github/workflows/gcp_notifications_job.yml
+++ b/.github/workflows/gcp_notifications_job.yml
@@ -88,7 +88,7 @@ jobs:
           CLOUD_RUN_VPC_NETWORK: ${{ vars.CLOUD_RUN_VPC_NETWORK }}
           CLOUD_RUN_VPC_SUBNET: ${{ vars.CLOUD_RUN_VPC_SUBNET }}
         run: |
-          python3 backend/scripts/render_backend_runtime_env.py --env ${{ vars.ENV }} >> "$GITHUB_OUTPUT"
+          python3 backend/scripts/render_backend_runtime_env.py --env ${{ vars.ENV }} --job notifications-job >> "$GITHUB_OUTPUT"
 
       - name: Validate backend runtime env before deploy
         run: |

--- a/backend/scripts/render_backend_runtime_env.py
+++ b/backend/scripts/render_backend_runtime_env.py
@@ -20,6 +20,7 @@ def _as_config_dict(value: object) -> ConfigDict | None:
 def main() -> int:
     parser = argparse.ArgumentParser(description='Render backend Cloud Run runtime env from the manifest.')
     parser.add_argument('--env', choices=('dev', 'prod'), required=True)
+    parser.add_argument('--job', help='Render only the named Cloud Run job and shared network flags.')
     parser.add_argument('--manifest', type=Path, default=DEFAULT_MANIFEST)
     args = parser.parse_args()
 
@@ -28,19 +29,25 @@ def main() -> int:
     env_config = _as_config_dict(environments[args.env]) or {}
     cloud_run = _as_config_dict(env_config['cloud_run']) or {}
 
+    services = _as_config_dict(cloud_run.get('services')) or {}
+    jobs = _as_config_dict(cloud_run.get('jobs')) or {}
+    if args.job is not None and args.job not in jobs:
+        raise ValueError(f'Cloud Run job {args.job} is not defined for {args.env}')
+
     network = _as_config_dict(cloud_run.get('network')) or {}
     _emit_output('cloud_run_flags', _render_flags(_as_config_dict(network.get('flags')) or {}))
-    services = _as_config_dict(cloud_run.get('services')) or {}
-    for service, raw_service_config in services.items():
-        service_config = _as_config_dict(raw_service_config)
-        if service_config is None:
-            raise ValueError(f'Cloud Run service {service} must be a mapping')
-        output_prefix = _output_prefix(service)
-        _emit_output(f'{output_prefix}_env_vars', _render_env_vars(service_config.get('env', {})))
-        _emit_output(f'{output_prefix}_secrets', _render_secrets(service_config.get('secrets', {})))
-        _emit_output(f'{output_prefix}_secret_names', _render_secret_names(service_config.get('secrets', {})))
-    jobs = _as_config_dict(cloud_run.get('jobs')) or {}
-    for job, raw_job_config in jobs.items():
+    if args.job is None:
+        for service, raw_service_config in services.items():
+            service_config = _as_config_dict(raw_service_config)
+            if service_config is None:
+                raise ValueError(f'Cloud Run service {service} must be a mapping')
+            output_prefix = _output_prefix(service)
+            _emit_output(f'{output_prefix}_env_vars', _render_env_vars(service_config.get('env', {})))
+            _emit_output(f'{output_prefix}_secrets', _render_secrets(service_config.get('secrets', {})))
+            _emit_output(f'{output_prefix}_secret_names', _render_secret_names(service_config.get('secrets', {})))
+
+    jobs_to_render = {args.job: jobs[args.job]} if args.job is not None else jobs
+    for job, raw_job_config in jobs_to_render.items():
         job_config = _as_config_dict(raw_job_config)
         if job_config is None:
             raise ValueError(f'Cloud Run job {job} must be a mapping')

--- a/backend/scripts/validate-backend-runtime-env.py
+++ b/backend/scripts/validate-backend-runtime-env.py
@@ -1124,22 +1124,25 @@ def _rendered_runtime_env_outputs(workflow: ConfigDict, *, env: str, manifest: C
         rendered_env = _extract_renderer_env(run, env=env)
         if rendered_env is None:
             continue
+        rendered_job = _extract_renderer_job(run)
         env_config = _get_env_config(manifest, rendered_env)
         cloud_run = _as_config_dict(env_config.get('cloud_run')) or {}
         network = _as_config_dict(cloud_run.get('network')) or {}
         outputs['cloud_run_flags'] = _render_cloud_run_flags((_as_config_dict(network.get('flags')) or {}))
-        services = _as_config_dict(cloud_run.get('services'))
-        if services is None:
-            continue
-        for service, raw_service_config in services.items():
-            service_config = _as_config_dict(raw_service_config)
-            if service_config is None:
-                continue
-            output_prefix = service.replace('-', '_')
-            outputs[f'{output_prefix}_env_vars'] = _render_cloud_run_env_vars(service_config.get('env', {}))
-            outputs[f'{output_prefix}_secrets'] = _render_cloud_run_secrets(service_config.get('secrets', {}))
+        if rendered_job is None:
+            services = _as_config_dict(cloud_run.get('services')) or {}
+            for service, raw_service_config in services.items():
+                service_config = _as_config_dict(raw_service_config)
+                if service_config is None:
+                    continue
+                output_prefix = service.replace('-', '_')
+                outputs[f'{output_prefix}_env_vars'] = _render_cloud_run_env_vars(service_config.get('env', {}))
+                outputs[f'{output_prefix}_secrets'] = _render_cloud_run_secrets(service_config.get('secrets', {}))
         jobs = _as_config_dict(cloud_run.get('jobs')) or {}
-        for job, raw_job_config in jobs.items():
+        jobs_to_render = jobs if rendered_job is None else {}
+        if rendered_job is not None and rendered_job in jobs:
+            jobs_to_render = {rendered_job: jobs[rendered_job]}
+        for job, raw_job_config in jobs_to_render.items():
             job_config = _as_config_dict(raw_job_config)
             if job_config is None:
                 continue
@@ -1172,6 +1175,16 @@ def _extract_renderer_env(run: str, *, env: str) -> str | None:
         return 'prod'
     if '--env ${{ vars.ENV }}' in run:
         return env
+    return None
+
+
+def _extract_renderer_job(run: str) -> str | None:
+    words = run.split()
+    for index, word in enumerate(words):
+        if word.startswith('--job='):
+            return word.partition('=')[2] or None
+        if word == '--job' and index + 1 < len(words):
+            return words[index + 1]
     return None
 
 

--- a/backend/tests/unit/test_backend_runtime_env_validator.py
+++ b/backend/tests/unit/test_backend_runtime_env_validator.py
@@ -736,6 +736,48 @@ def test_cloud_run_workflow_validation_uses_custom_manifest_for_runtime_env_outp
     assert errors == []
 
 
+def test_runtime_env_output_simulation_honors_selected_job():
+    validator = load_validator()
+    workflow = {
+        'jobs': {
+            'deploy': {
+                'steps': [
+                    {
+                        'id': 'runtime-env',
+                        'run': (
+                            'python3 backend/scripts/render_backend_runtime_env.py '
+                            '--env dev --job memory-maintenance-job'
+                        ),
+                    }
+                ]
+            }
+        }
+    }
+    manifest = {
+        'environments': {
+            'dev': {
+                'cloud_run': {
+                    'network': {'flags': {'--network': 'omi-dev-vpc-1'}},
+                    'services': {'backend': {'env': {}, 'secrets': {}}},
+                    'jobs': {
+                        'memory-maintenance-job': {'flags': {}, 'env': {}, 'secrets': {}},
+                        'notifications-job': {'flags': {}, 'env': {}, 'secrets': {}},
+                    },
+                }
+            }
+        }
+    }
+
+    outputs = validator._rendered_runtime_env_outputs(workflow, env='dev', manifest=manifest)
+
+    assert set(outputs) == {
+        'cloud_run_flags',
+        'memory_maintenance_job_flags',
+        'memory_maintenance_job_env_vars',
+        'memory_maintenance_job_secrets',
+    }
+
+
 def test_cloud_run_state_rejects_old_secret_versions(tmp_path):
     validator = load_validator()
     state_path = tmp_path / 'cloud_run_state.json'

--- a/backend/tests/unit/test_render_backend_runtime_env.py
+++ b/backend/tests/unit/test_render_backend_runtime_env.py
@@ -23,6 +23,38 @@ def _job_secret_lines(out: str, job_prefix: str) -> set[str]:
     return set(out[start:end].splitlines())
 
 
+def _write_job_scope_manifest(tmp_path: Path) -> Path:
+    manifest = tmp_path / 'runtime_env.yaml'
+    manifest.write_text(
+        '''\
+environments:
+  dev:
+    cloud_run:
+      network:
+        flags:
+          --network:
+            value: test-network
+      services:
+        backend:
+          env:
+            GOOGLE_CLIENT_ID:
+              env_var: GOOGLE_CLIENT_ID
+          secrets: {}
+      jobs:
+        memory-maintenance-job:
+          env:
+            JOB_MODE:
+              value: maintenance
+          secrets: {}
+        notifications-job:
+          env: {}
+          secrets: {}
+''',
+        encoding='utf-8',
+    )
+    return manifest
+
+
 def test_required_env_var_missing_raises(monkeypatch):
     monkeypatch.delenv('SOME_REQUIRED_URL', raising=False)
     with pytest.raises(ValueError, match='requires'):
@@ -52,6 +84,42 @@ def test_network_flags_still_required(monkeypatch):
     monkeypatch.delenv('CLOUD_RUN_VPC_NETWORK', raising=False)
     with pytest.raises(ValueError, match='requires'):
         _MODULE['_render_flags']({'--network': {'env_var': 'CLOUD_RUN_VPC_NETWORK'}})
+
+
+def test_selected_job_ignores_unrelated_service_env(capsys, monkeypatch, tmp_path):
+    manifest = _write_job_scope_manifest(tmp_path)
+    monkeypatch.delenv('GOOGLE_CLIENT_ID', raising=False)
+    monkeypatch.setattr(
+        'sys.argv',
+        [
+            'render_backend_runtime_env.py',
+            '--env',
+            'dev',
+            '--job',
+            'memory-maintenance-job',
+            '--manifest',
+            str(manifest),
+        ],
+    )
+
+    assert _MODULE['main']() == 0
+    out = capsys.readouterr().out
+    assert 'cloud_run_flags<<' in out
+    assert 'memory_maintenance_job_env_vars<<' in out
+    assert 'backend_env_vars<<' not in out
+    assert 'notifications_job_env_vars<<' not in out
+
+
+def test_unknown_selected_job_fails_before_outputs(capsys, monkeypatch, tmp_path):
+    manifest = _write_job_scope_manifest(tmp_path)
+    monkeypatch.setattr(
+        'sys.argv',
+        ['render_backend_runtime_env.py', '--env', 'dev', '--job', 'missing-job', '--manifest', str(manifest)],
+    )
+
+    with pytest.raises(ValueError, match='Cloud Run job missing-job is not defined for dev'):
+        _MODULE['main']()
+    assert capsys.readouterr().out == ''
 
 
 def test_render_dev_emits_memory_maintenance_job_outputs(capsys, monkeypatch):
@@ -162,6 +230,7 @@ def test_notifications_job_workflow_passes_vpc_vars_and_checkout_sha():
     text = workflow.read_text(encoding='utf-8')
     assert 'CLOUD_RUN_VPC_NETWORK: ${{ vars.CLOUD_RUN_VPC_NETWORK }}' in text
     assert 'CLOUD_RUN_VPC_SUBNET: ${{ vars.CLOUD_RUN_VPC_SUBNET }}' in text
+    assert 'render_backend_runtime_env.py --env ${{ vars.ENV }} --job notifications-job' in text
     assert 'git rev-parse --short=7 HEAD' in text
     assert 'short_sha=${GITHUB_SHA::7}' not in text
     assert 'env_vars_update_strategy: overwrite' not in text
@@ -183,6 +252,7 @@ def test_memory_maintenance_job_workflow_passes_vpc_vars_and_checkout_sha():
     assert 'memory_maintenance_job_secrets' in text
     assert 'CLOUD_RUN_VPC_NETWORK: ${{ vars.CLOUD_RUN_VPC_NETWORK }}' in text
     assert 'CLOUD_RUN_VPC_SUBNET: ${{ vars.CLOUD_RUN_VPC_SUBNET }}' in text
+    assert 'render_backend_runtime_env.py --env ${{ vars.ENV }} --job memory-maintenance-job' in text
     assert (
         'flags: ${{ steps.runtime-env.outputs.cloud_run_flags }} '
         '${{ steps.runtime-env.outputs.memory_maintenance_job_flags }}'
@@ -190,3 +260,9 @@ def test_memory_maintenance_job_workflow_passes_vpc_vars_and_checkout_sha():
     assert "id-token: 'write'" not in text
     assert 'git rev-parse --short=7 HEAD' in text
     assert 'short_sha=${GITHUB_SHA::7}' not in text
+
+    auto_dev_workflow = (
+        Path(__file__).resolve().parents[3] / '.github/workflows/gcp_memory_maintenance_job_auto_dev.yml'
+    )
+    auto_dev_text = auto_dev_workflow.read_text(encoding='utf-8')
+    assert 'render_backend_runtime_env.py --env dev --job memory-maintenance-job' in auto_dev_text


### PR DESCRIPTION
## Summary

- add a `--job` mode that renders shared Cloud Run network flags and only the selected job
- use the scoped renderer in the manual/auto memory-maintenance and notifications workflows
- keep static workflow validation aligned with the renderer's output scope

## Root cause

Job-only workflows invoked the renderer without a scope, so it eagerly resolved every Cloud Run service and job in the manifest. A missing service-only value such as `GOOGLE_CLIENT_ID` could therefore stop an unrelated maintenance-job deployment before its own outputs were emitted.

Unknown job names now fail before any output, while existing unscoped service deployment workflows retain the full-render behavior.

Closes #9747.

## Validation

- `python -m pytest -q backend/tests/unit/test_render_backend_runtime_env.py backend/tests/unit/test_backend_runtime_env_validator.py backend/tests/unit/test_preflight_cloud_run_deploy.py backend/tests/unit/test_workflow_contracts.py` (82 passed)
- `backend/scripts/typecheck.sh` (0 errors)
- `validate-backend-runtime-env.py --env dev --check-workflows`
- `validate-backend-runtime-env.py --env prod --check-workflows`
- `actionlint` on all three changed workflows
- Black 24.4.2 and Ruff 0.4.4 on changed Python files


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9750?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

