### PR TITLE
fix(firestore): index active attention overrides

### DIFF
--- a/backend/database/firestore_index_registry.py
+++ b/backend/database/firestore_index_registry.py
@@ -196,7 +196,7 @@ ACTIVE_ATTENTION_OVERRIDE_QUERY = FirestoreQuerySpec(
         FirestoreQueryFilter('account_generation', '==', 'account_generation'),
         FirestoreQueryFilter('expires_at', '>', 'now'),
     ),
-    index_fields=(_asc('account_generation'), _asc('expires_at')),
+    index_fields=(_asc('account_generation'), _asc('expires_at'), _asc('__name__')),
 )
 
 QUERY_SPECS = (ACTIVE_ATTENTION_OVERRIDE_QUERY,)

--- a/backend/tests/unit/test_firestore_query_contract.py
+++ b/backend/tests/unit/test_firestore_query_contract.py
@@ -138,6 +138,7 @@ def test_generated_firestore_manifest_matches_the_checked_in_contract():
         'fields': [
             {'fieldPath': 'account_generation', 'order': 'ASCENDING'},
             {'fieldPath': 'expires_at', 'order': 'ASCENDING'},
+            {'fieldPath': '__name__', 'order': 'ASCENDING'},
         ],
     }
 

--- a/backend/tests/unit/test_reconcile_firestore_indexes.py
+++ b/backend/tests/unit/test_reconcile_firestore_indexes.py
@@ -43,7 +43,7 @@ def test_reconcile_deploys_generated_manifest_and_waits_for_every_index():
     assert sleeps == [1]
 
 
-def test_live_gcloud_indexes_derive_collection_group_and_alias_implicit_document_id():
+def test_live_gcloud_indexes_derive_collection_group_with_explicit_document_id():
     live_index = {
         'name': (
             'projects/dev-project/databases/(default)/collectionGroups/' 'task_attention_overrides/indexes/index-id'
@@ -62,16 +62,19 @@ def test_live_gcloud_indexes_derive_collection_group_and_alias_implicit_document
 
     states = reconcile_firestore_indexes.list_live_indexes(project='dev-project', database='(default)', runner=runner)
 
-    assert (
-        states[
-            (
-                'task_attention_overrides',
-                'COLLECTION',
-                (('account_generation', 'ASCENDING'), ('expires_at', 'ASCENDING')),
-            )
-        ]
-        == 'READY'
+    attention_override_signature = (
+        'task_attention_overrides',
+        'COLLECTION',
+        (
+            ('account_generation', 'ASCENDING'),
+            ('expires_at', 'ASCENDING'),
+            ('__name__', 'ASCENDING'),
+        ),
     )
+    assert attention_override_signature in reconcile_firestore_indexes.expected_index_signatures(
+        firebase_index_manifest()
+    )
+    assert states[attention_override_signature] == 'READY'
 
 
 def test_live_gcloud_index_does_not_alias_explicitly_descending_document_id():

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -255,6 +255,10 @@
         {
           "fieldPath": "expires_at",
           "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "__name__",
+          "order": "ASCENDING"
         }
       ]
     }


### PR DESCRIPTION
## Summary
- add the explicit `__name__ ASC` trailing field required by the active `task_attention_overrides` Firestore query
- keep the query registry and generated `firestore.indexes.json` manifest in lockstep
- add regression coverage for the exact three-field signature and reconciliation of the live index shape

## Why
The latest development acceptance smoke reached the freshly deployed backend but surfaced a Firestore `FailedPrecondition`: the active attention-override query requires `account_generation ASC`, `expires_at ASC`, and `__name__ ASC`. The prior checked-in two-field index was insufficient.

## Scope and safety
- source-of-truth Firestore index manifest/registry and tests only
- no production deployment, Cloud resource mutation, workflow, traffic, secret, or environment change
- the existing development Firestore reconciliation gate will provision and wait for this manifest entry before the next backend candidate deploy

## Verification
- independent review approved
- focused index/query/reconciliation tests: 12 passed
- generated-manifest check, diff hygiene, typecheck (0 errors), selected backend tests, OpenAPI contract, formatting, and full repository pre-push checks passed


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9751?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

