### PR TITLE
fix(listen): decide empty-recording cleanup from decoded segments

### DIFF
--- a/backend/database/conversation_finalization_jobs.py
+++ b/backend/database/conversation_finalization_jobs.py
@@ -13,6 +13,7 @@ from typing import Any, Callable, Literal, Mapping, TypedDict
 
 from google.cloud import firestore
 
+from database import conversations as conversations_db
 from database._client import document_id_from_seed, get_firestore_client
 
 CONVERSATIONS_COLLECTION = 'conversations'
@@ -119,10 +120,10 @@ def _no_finalization_intent(status: str) -> FinalizationIntent:
 
 
 def _conversation_has_finalization_content(
-    conversation: Mapping[str, Any], conversation_ref: Any, transaction: Any
+    uid: str, conversation: Mapping[str, Any], conversation_ref: Any, transaction: Any
 ) -> bool:
     """Read current and pre-marker photo content within the admission transaction."""
-    if conversation.get('has_content') or conversation.get('transcript_segments') or conversation.get('photos'):
+    if conversations_db.raw_conversation_has_content(uid, dict(conversation)):
         return True
     # `has_content` was added after photo-only listen recordings already
     # existed. Keep their durable child documents admissible until all legacy
@@ -149,7 +150,7 @@ def _create_or_get_finalization_intent_txn(
     conversation = conversation_snapshot.to_dict() or {}
     if conversation.get('deferred'):
         return _no_finalization_intent('deferred')
-    if not _conversation_has_finalization_content(conversation, conversation_ref, transaction):
+    if not _conversation_has_finalization_content(uid, conversation, conversation_ref, transaction):
         return _no_finalization_intent('no_content')
 
     # The lifecycle service owns this pure decision, but it is evaluated while

--- a/backend/database/conversations.py
+++ b/backend/database/conversations.py
@@ -132,6 +132,47 @@ def _prepare_conversation_for_write(data: Dict[str, Any], uid: str, level: str) 
     return data
 
 
+def _decode_transcript_segments_strict(uid: str, raw_segments: Any, compressed: bool) -> List[Any]:
+    """Decode a stored ``transcript_segments`` blob, raising when it cannot be read.
+
+    The read path swallows decode failures into an empty list, which is safe for
+    rendering but unsafe for a caller deciding whether a conversation is empty.
+    """
+    if isinstance(raw_segments, list):
+        return raw_segments
+    if isinstance(raw_segments, str):
+        payload = encryption.decrypt(raw_segments, uid)
+        if compressed:
+            return json.loads(zlib.decompress(bytes.fromhex(payload)).decode('utf-8'))
+        return json.loads(payload)
+    if isinstance(raw_segments, bytes) and compressed:
+        return json.loads(zlib.decompress(raw_segments).decode('utf-8'))
+    raise ValueError(f'undecodable transcript_segments: {type(raw_segments).__name__} compressed={compressed}')
+
+
+def raw_conversation_has_content(uid: str, conversation: Dict[str, Any]) -> bool:
+    """Decide whether an un-decoded Firestore snapshot holds user content.
+
+    ``transcript_segments`` is written compressed (and encrypted for enhanced
+    users), so an empty segment list is a non-empty blob on the raw document.
+    Only the decoded value distinguishes an empty recording from a real one.
+    Undecodable segments count as content: never delete data we cannot read.
+    """
+    if conversation.get('has_content') or conversation.get('photos'):
+        return True
+    raw_segments = conversation.get('transcript_segments')
+    if not raw_segments:
+        return False
+    try:
+        segments = _decode_transcript_segments_strict(
+            uid, raw_segments, bool(conversation.get('transcript_segments_compressed'))
+        )
+    except (json.JSONDecodeError, TypeError, zlib.error, ValueError) as e:
+        logger.error(f'raw_conversation_has_content: undecodable segments, assuming content. {uid} {e}')
+        return True
+    return bool(segments)
+
+
 def _prepare_conversation_for_read(conversation_data: Optional[Dict[str, Any]], uid: str) -> Optional[Dict[str, Any]]:
     if not conversation_data:
         return None

--- a/backend/database/conversations.py
+++ b/backend/database/conversations.py
@@ -132,6 +132,18 @@ def _prepare_conversation_for_write(data: Dict[str, Any], uid: str, level: str) 
     return data
 
 
+def encode_conversation_for_write(
+    uid: str, conversation_data: Dict[str, Any], level: str = 'standard'
+) -> Dict[str, Any]:
+    """Encode a conversation exactly as the write path stores it.
+
+    The seam exists for harnesses that seed Firestore directly: a hand-written
+    document with a plain ``transcript_segments`` list is a state production
+    never writes, and seeding one hides encoding-aware guard bugs.
+    """
+    return _prepare_conversation_for_write(conversation_data, uid, level)
+
+
 def _decode_transcript_segments_strict(uid: str, raw_segments: Any, compressed: bool) -> List[Any]:
     """Decode a stored ``transcript_segments`` blob, raising when it cannot be read.
 

--- a/backend/database/recording_sessions.py
+++ b/backend/database/recording_sessions.py
@@ -14,6 +14,7 @@ from typing import Any, Literal, TypedDict
 
 from google.cloud import firestore
 
+from database import conversations as conversations_db
 from database._client import get_firestore_client
 
 RECORDING_SESSIONS_COLLECTION = 'recording_sessions'
@@ -184,9 +185,7 @@ def tombstone_and_delete_empty_conversation(
         if (
             conversation.get('status') != 'in_progress'
             or conversation.get('discarded')
-            or conversation.get('has_content')
-            or conversation.get('transcript_segments')
-            or conversation.get('photos')
+            or conversations_db.raw_conversation_has_content(uid, conversation)
         ):
             return False
 

--- a/backend/scripts/listen_lifecycle_emulator_test.py
+++ b/backend/scripts/listen_lifecycle_emulator_test.py
@@ -75,18 +75,32 @@ def _commit_cleanup_parent_delete(uid: str, conversation_id: str, transaction: s
     )
 
 
-def _seed_live_generation(client: Any, uid: str, conversation_id: str, recording_session_id: str) -> Any:
+def _seed_empty_live_conversation(client: Any, uid: str, conversation_id: str) -> Any:
+    """Write an empty in-progress conversation the way production writes it.
+
+    Segments are stored compressed, so a raw empty list is a document state
+    production never produces — seeding one hides encoding-aware guard bugs.
+    """
     conversation_ref = _conversation_ref(client, uid, conversation_id)
     conversation_ref.set(
-        {
-            'id': conversation_id,
-            'status': 'in_progress',
-            'discarded': False,
-            'transcript_segments': [],
-            'has_content': False,
-            'data_protection_level': 'standard',
-        }
+        conversations_db._prepare_conversation_for_write(
+            {
+                'id': conversation_id,
+                'status': 'in_progress',
+                'discarded': False,
+                'transcript_segments': [],
+                'has_content': False,
+                'data_protection_level': 'standard',
+            },
+            uid,
+            'standard',
+        )
     )
+    return conversation_ref
+
+
+def _seed_live_generation(client: Any, uid: str, conversation_id: str, recording_session_id: str) -> Any:
+    conversation_ref = _seed_empty_live_conversation(client, uid, conversation_id)
     recording_sessions_db.create_or_get_recording_session(
         uid,
         recording_session_id,
@@ -316,17 +330,7 @@ def _assert_photo_content_contract(client: Any, uid: str) -> None:
 
 def _assert_photo_only_finalization_is_admitted(client: Any, uid: str) -> None:
     conversation_id = f'photo-finalization-{uuid.uuid4().hex}'
-    conversation_ref = _conversation_ref(client, uid, conversation_id)
-    conversation_ref.set(
-        {
-            'id': conversation_id,
-            'status': 'in_progress',
-            'discarded': False,
-            'transcript_segments': [],
-            'has_content': False,
-            'data_protection_level': 'standard',
-        }
-    )
+    _seed_empty_live_conversation(client, uid, conversation_id)
     if not conversations_db.store_conversation_photos(
         uid,
         conversation_id,
@@ -348,17 +352,7 @@ def _assert_photo_only_finalization_is_admitted(client: Any, uid: str) -> None:
 def _assert_legacy_photo_only_finalization_is_admitted(client: Any, uid: str) -> None:
     """Pre-marker photo children must still admit a durable finalization job."""
     conversation_id = f'legacy-photo-finalization-{uuid.uuid4().hex}'
-    conversation_ref = _conversation_ref(client, uid, conversation_id)
-    conversation_ref.set(
-        {
-            'id': conversation_id,
-            'status': 'in_progress',
-            'discarded': False,
-            'transcript_segments': [],
-            'has_content': False,
-            'data_protection_level': 'standard',
-        }
-    )
+    conversation_ref = _seed_empty_live_conversation(client, uid, conversation_id)
     conversation_ref.collection('photos').document('legacy-only-photo').set(
         {'id': 'legacy-only-photo', 'description': 'pre-marker photo-only listen conversation'}
     )

--- a/backend/scripts/listen_lifecycle_emulator_test.py
+++ b/backend/scripts/listen_lifecycle_emulator_test.py
@@ -83,7 +83,8 @@ def _seed_empty_live_conversation(client: Any, uid: str, conversation_id: str) -
     """
     conversation_ref = _conversation_ref(client, uid, conversation_id)
     conversation_ref.set(
-        conversations_db._prepare_conversation_for_write(
+        conversations_db.encode_conversation_for_write(
+            uid,
             {
                 'id': conversation_id,
                 'status': 'in_progress',
@@ -92,8 +93,6 @@ def _seed_empty_live_conversation(client: Any, uid: str, conversation_id: str) -
                 'has_content': False,
                 'data_protection_level': 'standard',
             },
-            uid,
-            'standard',
         )
     )
     return conversation_ref

--- a/backend/tests/unit/test_recording_sessions.py
+++ b/backend/tests/unit/test_recording_sessions.py
@@ -20,9 +20,9 @@ def _stored_conversation(segments: list[dict[str, Any]], *, level: str = 'standa
     Seeding a raw ``transcript_segments`` list is what let the empty-cleanup
     guard ship reading a compressed blob as if it were a plain list.
     """
-    return conversations_db._prepare_conversation_for_write(
-        {'id': 'conversation', 'status': 'in_progress', 'transcript_segments': segments},
+    return conversations_db.encode_conversation_for_write(
         'uid',
+        {'id': 'conversation', 'status': 'in_progress', 'transcript_segments': segments},
         level,
     )
 

--- a/backend/tests/unit/test_recording_sessions.py
+++ b/backend/tests/unit/test_recording_sessions.py
@@ -9,8 +9,22 @@ from typing import Any
 
 import pytest
 
+from database import conversations as conversations_db
 from database import recording_sessions
 from utils.conversations import lifecycle as lifecycle_service
+
+
+def _stored_conversation(segments: list[dict[str, Any]], *, level: str = 'standard') -> dict[str, Any]:
+    """Encode a conversation exactly as the production write path stores it.
+
+    Seeding a raw ``transcript_segments`` list is what let the empty-cleanup
+    guard ship reading a compressed blob as if it were a plain list.
+    """
+    return conversations_db._prepare_conversation_for_write(
+        {'id': 'conversation', 'status': 'in_progress', 'transcript_segments': segments},
+        'uid',
+        level,
+    )
 
 
 @dataclass
@@ -178,14 +192,10 @@ def test_missing_active_binding_is_tombstoned_before_rollover(recording_store, m
     assert original['lifecycle_phase'] == 'discarded'
 
 
-def test_empty_cleanup_atomically_tombstones_its_session(recording_store):
+@pytest.mark.parametrize('level', ['standard', 'enhanced'])
+def test_empty_cleanup_atomically_tombstones_its_session(recording_store, level):
     conversation_path = ('users', 'uid', 'conversations', 'conversation')
-    recording_store.documents[conversation_path] = {
-        'id': 'conversation',
-        'status': 'in_progress',
-        'transcript_segments': [],
-        'has_content': False,
-    }
+    recording_store.documents[conversation_path] = _stored_conversation([], level=level)
     recording_sessions.create_or_get_recording_session(
         'uid', 'recording', 'conversation', firestore_client=recording_store
     )
@@ -201,14 +211,12 @@ def test_empty_cleanup_atomically_tombstones_its_session(recording_store):
     assert binding['lifecycle_phase'] == 'discarded'
 
 
-def test_empty_cleanup_refuses_late_content_without_tombstoning(recording_store):
+@pytest.mark.parametrize('level', ['standard', 'enhanced'])
+def test_empty_cleanup_refuses_late_content_without_tombstoning(recording_store, level):
     conversation_path = ('users', 'uid', 'conversations', 'conversation')
-    recording_store.documents[conversation_path] = {
-        'id': 'conversation',
-        'status': 'in_progress',
-        'transcript_segments': [{'id': 'late-segment', 'text': 'persisted'}],
-        'has_content': True,
-    }
+    recording_store.documents[conversation_path] = _stored_conversation(
+        [{'id': 'late-segment', 'text': 'persisted'}], level=level
+    )
     recording_sessions.create_or_get_recording_session(
         'uid', 'recording', 'conversation', firestore_client=recording_store
     )
@@ -222,6 +230,26 @@ def test_empty_cleanup_refuses_late_content_without_tombstoning(recording_store)
     assert conversation_path in recording_store.documents
     assert binding is not None
     assert binding['lifecycle_phase'] == 'in_progress'
+
+
+def test_empty_cleanup_keeps_a_conversation_whose_segments_cannot_be_decoded(recording_store):
+    conversation_path = ('users', 'uid', 'conversations', 'conversation')
+    recording_store.documents[conversation_path] = {
+        'id': 'conversation',
+        'status': 'in_progress',
+        'transcript_segments': b'not-a-zlib-stream',
+        'transcript_segments_compressed': True,
+    }
+    recording_sessions.create_or_get_recording_session(
+        'uid', 'recording', 'conversation', firestore_client=recording_store
+    )
+
+    deleted = recording_sessions.tombstone_and_delete_empty_conversation(
+        'uid', 'conversation', 'recording', firestore_client=recording_store
+    )
+
+    assert deleted is False
+    assert conversation_path in recording_store.documents
 
 
 def test_conflicting_retry_returns_the_original_conversation(recording_store):


### PR DESCRIPTION
## Bug

The empty-session cleanup added in `7a0fa284af` (empty-cleanup fencing) reads the **raw, un-decoded** Firestore snapshot inside its transaction and treats `transcript_segments` as a plain list (`database/recording_sessions.py`):

```python
conversation = snapshot.to_dict() or {}
if (... or conversation.get('transcript_segments') or ...):
    return False
```

But every conversation write goes through `_prepare_conversation_for_write`, which **zlib-compresses** `transcript_segments` (and encrypts it to a hex string for `enhanced` users). An **empty** list is stored as `zlib.compress(b"[]")` = 10 non-empty bytes — always truthy. `backend/AGENTS.md` says it outright: *"Segments are encrypted at rest — direct Firestore reads return opaque blobs."*

So the guard short-circuits on **100% of real documents**:

- `tombstone_and_delete_empty_conversation` **never deletes anything**. Every silent listen session (VAD suppressed everything, mic muted, brief connect, STT init failed) permanently leaves an orphan `in_progress` conversation **plus** an `in_progress` `recording_sessions` row, per user, per session, unbounded. Pre-refactor this branch did `delete_conversation(...); return True`.
- `_process_conversation` returns `False` on that path, so `redis_db.remove_in_progress_conversation_id(uid)` is **skipped** on disconnect.
- The tombstone/rollover fencing added in `ef3034a9dd` only fires when the bound conversation is gone — and it never is. It is dead code as shipped.
- Same class of bug in `conversation_finalization_jobs.py` (`fc4270129d`): the `no_content` admission fence reads the raw blob, so it always reports content and the legacy-photo subcollection query beneath it is unreachable.

Not deployed to prod yet — the last successful backend/listen prod deploys (07-12, 07-13) predate these commits, so this is caught before it ships.

## Root cause

An **encoded field used as a content predicate**. The write path owns the encoding; the guard read the encoded bytes and asked a plain-Python truthiness question.

## Fix

Decide emptiness from the **decoded** value, via `raw_conversation_has_content(uid, raw)` placed next to the encoder that owns the representation, and use it at both raw-snapshot fences. Segments that **cannot** be decoded count as content — never delete data we cannot read (the read path swallows decode errors into `[]`, which is safe for rendering but unsafe for a delete decision).

`has_content` alone is not sufficient: conversations already `in_progress` with segments when the marker shipped have no `has_content` key, and deleting those *would* be real data loss.

## Why the tests missed it — and the durable guard

Both suites seeded `transcript_segments: []` as a **raw list**, a document state production never writes. This PR seeds through the **production encoder** in both `tests/unit/test_recording_sessions.py` (parametrized `standard` + `enhanced`) and the emulator harness `scripts/listen_lifecycle_emulator_test.py`, so an encoding-aware guard bug can't hide behind a hand-written fixture again. Added a test that an undecodable blob is never deleted.

## Verification

- `bash test.sh` (backend/) — every file passes except `tests/unit/test_vad_gate.py`, which fails identically on **unmodified main** (pre-existing ONNX concurrency flake; passes in isolation).
- **Reverted only the guard, kept the new tests → `2 failed, 25 passed`** (`test_empty_cleanup_atomically_tombstones_its_session[standard]` and `[enhanced]`). The regression tests would have caught this.
- `python backend/scripts/check_conversation_lifecycle_writes.py` → passed.
- Not exercised against a live listen WebSocket — **UNVERIFIED on a real recording session**; the proof is the encoder-seeded transaction tests above.

🤖 automated by hourly watchdog; opened for review, not merged (not yet live on prod, so it does not meet the auto-merge-and-deploy bar).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9754?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

