### PR TITLE
fix(dev): provision Firestore indexes explicitly

### DIFF
--- a/.github/workflows/gcp_backend_auto_dev.yml
+++ b/.github/workflows/gcp_backend_auto_dev.yml
@@ -41,14 +41,6 @@ jobs:
       - name: Set up gcloud
         uses: google-github-actions/setup-gcloud@v2
 
-      - name: Set up Node for Firebase index deployment
-        uses: actions/setup-node@v4
-        with:
-          node-version: '22'
-
-      - name: Install locked Firebase tooling
-        run: npm ci --ignore-scripts
-
       - name: Verify serving sync ledger fence mode before deploy
         env:
           SYNC_LEDGER_FENCE_MODE: ${{ vars.SYNC_LEDGER_FENCE_MODE || 'legacy' }}
@@ -61,7 +53,8 @@ jobs:
       - name: Reconcile generated Firestore indexes before backend deploy
         run: |
           python3 backend/scripts/reconcile_firestore_indexes.py \
-            --project "${{ vars.GCP_PROJECT_ID }}"
+            --project "${{ vars.GCP_PROJECT_ID }}" \
+            --provision-missing
 
       - name: Login to GCR
         run: gcloud auth configure-docker

--- a/backend/scripts/reconcile_firestore_indexes.py
+++ b/backend/scripts/reconcile_firestore_indexes.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Deploy the generated Firestore index manifest and wait until every index is READY."""
+"""Reconcile the generated Firestore index manifest and wait for READY indexes."""
 
 from __future__ import annotations
 
@@ -23,6 +23,16 @@ DEFAULT_POLL_INTERVAL_SECONDS = 10.0
 
 IndexSignature = tuple[str, str, tuple[tuple[str, str], ...]]
 CommandRunner = Callable[..., Any]
+
+_GCLOUD_QUERY_SCOPES = {
+    'COLLECTION': 'collection',
+    'COLLECTION_GROUP': 'collection-group',
+}
+_GCLOUD_FIELD_CONFIGS = {
+    'ASCENDING': 'order=ascending',
+    'DESCENDING': 'order=descending',
+    'CONTAINS': 'array-config=contains',
+}
 
 
 def _collection_group_from_resource_name(index: Mapping[str, Any]) -> str:
@@ -94,10 +104,41 @@ def deploy_indexes(*, project: str, manifest_path: Path, runner: CommandRunner =
         raise RuntimeError('Firebase index deployment failed')
 
 
+def gcloud_create_index_command(*, project: str, database: str, signature: IndexSignature) -> list[str]:
+    """Build the Firestore Admin API create command for one manifest signature."""
+
+    collection_group, query_scope, fields = signature
+    try:
+        gcloud_query_scope = _GCLOUD_QUERY_SCOPES[query_scope]
+    except KeyError as exc:
+        raise ValueError(f'unsupported Firestore query scope for gcloud provisioning: {query_scope!r}') from exc
+    command = [
+        'gcloud',
+        'firestore',
+        'indexes',
+        'composite',
+        'create',
+        f'--project={project}',
+        f'--database={database}',
+        f'--collection-group={collection_group}',
+        f'--query-scope={gcloud_query_scope}',
+    ]
+    for field_path, direction in fields:
+        try:
+            field_config = _GCLOUD_FIELD_CONFIGS[direction]
+        except KeyError as exc:
+            raise ValueError(
+                f'unsupported Firestore field configuration for gcloud provisioning: {direction!r}'
+            ) from exc
+        command.append(f'--field-config=field-path={field_path},{field_config}')
+    return [*command, '--quiet']
+
+
 def list_live_indexes(
     *,
     project: str,
     database: str,
+    include_implicit_document_id_alias: bool = True,
     runner: CommandRunner = subprocess.run,
 ) -> dict[IndexSignature, str]:
     command = [
@@ -129,8 +170,13 @@ def list_live_indexes(
             continue
         state = index.get('state')
         states[signature] = state if isinstance(state, str) else 'UNKNOWN'
+        # Firestore Admin API output includes the implicit terminal document-ID
+        # order for ordinary indexes. Preserve the historic compatibility alias
+        # outside dev provisioning, but never let it prove an exact manifest
+        # signature before a create-and-wait reconciliation.
         if (
-            len(signature[2]) > 1
+            include_implicit_document_id_alias
+            and len(signature[2]) > 1
             and signature[2][-1][0] == '__name__'
             and signature[2][-1][1] == signature[2][-2][1]
             and signature[2][-1][1] in {'ASCENDING', 'DESCENDING'}
@@ -145,6 +191,47 @@ def format_signature(signature: IndexSignature) -> str:
     return f'{query_scope}/{collection_group} ({field_text})'
 
 
+def missing_index_signatures(
+    *,
+    expected: Iterable[IndexSignature],
+    states: Mapping[IndexSignature, str],
+) -> set[IndexSignature]:
+    """Return manifest requirements absent from the Firestore Admin API inventory."""
+
+    return set(expected).difference(states)
+
+
+def provision_missing_indexes(
+    *,
+    expected: Iterable[IndexSignature],
+    project: str,
+    database: str,
+    runner: CommandRunner = subprocess.run,
+) -> set[IndexSignature]:
+    """Create only manifest entries absent from the live Firestore inventory."""
+
+    missing = missing_index_signatures(
+        expected=expected,
+        states=list_live_indexes(
+            project=project,
+            database=database,
+            include_implicit_document_id_alias=False,
+            runner=runner,
+        ),
+    )
+    for signature in sorted(missing):
+        result = runner(
+            gcloud_create_index_command(project=project, database=database, signature=signature),
+            cwd=ROOT,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            raise RuntimeError(f'Firestore composite-index provisioning failed: {format_signature(signature)}')
+    return missing
+
+
 def wait_for_indexes(
     *,
     expected: Iterable[IndexSignature],
@@ -152,6 +239,7 @@ def wait_for_indexes(
     database: str,
     timeout_seconds: float,
     poll_interval_seconds: float,
+    include_implicit_document_id_alias: bool = True,
     runner: CommandRunner = subprocess.run,
     sleep: Callable[[float], None] = time.sleep,
     monotonic: Callable[[], float] = time.monotonic,
@@ -163,7 +251,12 @@ def wait_for_indexes(
     expected_set = set(expected)
     deadline = monotonic() + timeout_seconds
     while True:
-        states = list_live_indexes(project=project, database=database, runner=runner)
+        states = list_live_indexes(
+            project=project,
+            database=database,
+            include_implicit_document_id_alias=include_implicit_document_id_alias,
+            runner=runner,
+        )
         pending = {
             signature: states.get(signature, 'MISSING')
             for signature in expected_set
@@ -187,18 +280,39 @@ def reconcile(
     manifest_path: Path,
     timeout_seconds: float,
     poll_interval_seconds: float,
+    provision_missing: bool = False,
+    dry_run: bool = False,
     runner: CommandRunner = subprocess.run,
     sleep: Callable[[float], None] = time.sleep,
     monotonic: Callable[[], float] = time.monotonic,
 ) -> None:
     manifest = verify_manifest_source(manifest_path)
-    deploy_indexes(project=project, manifest_path=manifest_path, runner=runner)
+    expected = expected_index_signatures(manifest)
+    if dry_run:
+        states = list_live_indexes(
+            project=project,
+            database=database,
+            include_implicit_document_id_alias=not provision_missing,
+            runner=runner,
+        )
+        missing = missing_index_signatures(expected=expected, states=states)
+        if provision_missing:
+            for signature in sorted(missing):
+                print(f'Firestore index provisioning dry run: would create {format_signature(signature)}')
+        else:
+            print('Firestore index deployment dry run: would deploy the generated Firebase manifest')
+        return
+    if provision_missing:
+        provision_missing_indexes(expected=expected, project=project, database=database, runner=runner)
+    else:
+        deploy_indexes(project=project, manifest_path=manifest_path, runner=runner)
     wait_for_indexes(
-        expected=expected_index_signatures(manifest),
+        expected=expected,
         project=project,
         database=database,
         timeout_seconds=timeout_seconds,
         poll_interval_seconds=poll_interval_seconds,
+        include_implicit_document_id_alias=not provision_missing,
         runner=runner,
         sleep=sleep,
         monotonic=monotonic,
@@ -212,6 +326,14 @@ def main() -> int:
     parser.add_argument('--manifest', type=Path, default=ROOT / 'firestore.indexes.json')
     parser.add_argument('--timeout-seconds', type=float, default=DEFAULT_TIMEOUT_SECONDS)
     parser.add_argument('--poll-interval-seconds', type=float, default=DEFAULT_POLL_INTERVAL_SECONDS)
+    parser.add_argument(
+        '--provision-missing',
+        action='store_true',
+        help='create manifest entries missing from the Firestore Admin API inventory with gcloud',
+    )
+    parser.add_argument(
+        '--dry-run', action='store_true', help='validate the manifest and print the no-write reconciliation plan'
+    )
     args = parser.parse_args()
     try:
         reconcile(
@@ -220,6 +342,8 @@ def main() -> int:
             manifest_path=args.manifest.resolve(),
             timeout_seconds=args.timeout_seconds,
             poll_interval_seconds=args.poll_interval_seconds,
+            provision_missing=args.provision_missing,
+            dry_run=args.dry_run,
         )
     except (OSError, RuntimeError, ValueError) as exc:
         print(f'ERROR: {exc}', file=sys.stderr)

--- a/backend/tests/unit/test_reconcile_firestore_indexes.py
+++ b/backend/tests/unit/test_reconcile_firestore_indexes.py
@@ -12,6 +12,17 @@ def _ready_indexes():
     return [{**index, 'state': 'READY'} for index in firebase_index_manifest()['indexes']]
 
 
+def _gcloud_live_index(index, *, state='READY'):
+    return {
+        'name': (
+            'projects/dev-project/databases/(default)/collectionGroups/' f"{index['collectionGroup']}/indexes/index-id"
+        ),
+        'queryScope': index['queryScope'],
+        'fields': index['fields'],
+        'state': state,
+    }
+
+
 def test_reconcile_deploys_generated_manifest_and_waits_for_every_index():
     commands = []
     list_calls = 0
@@ -41,6 +52,55 @@ def test_reconcile_deploys_generated_manifest_and_waits_for_every_index():
     assert commands[0][:6] == ['npx', '--no-install', 'firebase', 'deploy', '--only', 'firestore:indexes']
     assert all(command[:4] == ['gcloud', 'firestore', 'indexes', 'composite'] for command in commands[1:])
     assert sleeps == [1]
+
+
+def test_provision_missing_uses_gcloud_with_every_manifest_field_and_waits_for_ready():
+    commands = []
+    list_calls = 0
+    target = firebase_index_manifest()['indexes'][-1]
+
+    def runner(command, **_kwargs):
+        nonlocal list_calls
+        commands.append(command)
+        if command[:5] == ['gcloud', 'firestore', 'indexes', 'composite', 'create']:
+            return SimpleNamespace(returncode=0, stdout='')
+        list_calls += 1
+        indexes = [_gcloud_live_index(index) for index in firebase_index_manifest()['indexes']]
+        if list_calls == 1:
+            indexes.pop()
+        else:
+            indexes[-1] = _gcloud_live_index(target, state='CREATING' if list_calls == 2 else 'READY')
+        return SimpleNamespace(returncode=0, stdout=json.dumps(indexes))
+
+    reconcile_firestore_indexes.reconcile(
+        project='dev-project',
+        database='(default)',
+        manifest_path=Path(__file__).resolve().parents[3] / 'firestore.indexes.json',
+        timeout_seconds=30,
+        poll_interval_seconds=1,
+        provision_missing=True,
+        runner=runner,
+        sleep=lambda _seconds: None,
+        monotonic=iter((0, 0, 1, 1)).__next__,
+    )
+
+    assert commands[0][:4] == ['gcloud', 'firestore', 'indexes', 'composite']
+    assert commands[1] == [
+        'gcloud',
+        'firestore',
+        'indexes',
+        'composite',
+        'create',
+        '--project=dev-project',
+        '--database=(default)',
+        '--collection-group=task_attention_overrides',
+        '--query-scope=collection',
+        '--field-config=field-path=account_generation,order=ascending',
+        '--field-config=field-path=expires_at,order=ascending',
+        '--field-config=field-path=__name__,order=ascending',
+        '--quiet',
+    ]
+    assert all(command[:3] != ['npx', '--no-install', 'firebase'] for command in commands)
 
 
 def test_live_gcloud_indexes_derive_collection_group_with_explicit_document_id():
@@ -77,14 +137,14 @@ def test_live_gcloud_indexes_derive_collection_group_with_explicit_document_id()
     assert states[attention_override_signature] == 'READY'
 
 
-def test_live_gcloud_index_does_not_alias_explicitly_descending_document_id():
+def test_live_gcloud_indexes_alias_implicit_terminal_document_id_by_default():
     live_index = {
         'name': 'projects/dev-project/databases/(default)/collectionGroups/task_attention_overrides/indexes/index-id',
         'queryScope': 'COLLECTION',
         'fields': [
             {'fieldPath': 'account_generation', 'order': 'ASCENDING'},
             {'fieldPath': 'expires_at', 'order': 'ASCENDING'},
-            {'fieldPath': '__name__', 'order': 'DESCENDING'},
+            {'fieldPath': '__name__', 'order': 'ASCENDING'},
         ],
         'state': 'READY',
     }
@@ -95,10 +155,103 @@ def test_live_gcloud_index_does_not_alias_explicitly_descending_document_id():
     states = reconcile_firestore_indexes.list_live_indexes(project='dev-project', database='(default)', runner=runner)
 
     assert (
-        'task_attention_overrides',
-        'COLLECTION',
-        (('account_generation', 'ASCENDING'), ('expires_at', 'ASCENDING')),
-    ) not in states
+        states[
+            (
+                'task_attention_overrides',
+                'COLLECTION',
+                (('account_generation', 'ASCENDING'), ('expires_at', 'ASCENDING')),
+            )
+        ]
+        == 'READY'
+    )
+
+
+def test_dev_provisioning_does_not_accept_an_implicit_document_id_alias():
+    commands = []
+    expected = {
+        (
+            'task_attention_overrides',
+            'COLLECTION',
+            (('account_generation', 'ASCENDING'), ('expires_at', 'ASCENDING')),
+        )
+    }
+    live_index = {
+        'name': 'projects/dev-project/databases/(default)/collectionGroups/task_attention_overrides/indexes/index-id',
+        'queryScope': 'COLLECTION',
+        'fields': [
+            {'fieldPath': 'account_generation', 'order': 'ASCENDING'},
+            {'fieldPath': 'expires_at', 'order': 'ASCENDING'},
+            {'fieldPath': '__name__', 'order': 'ASCENDING'},
+        ],
+        'state': 'READY',
+    }
+
+    def runner(command, **_kwargs):
+        commands.append(command)
+        if command[:5] == ['gcloud', 'firestore', 'indexes', 'composite', 'create']:
+            return SimpleNamespace(returncode=0, stdout='')
+        return SimpleNamespace(returncode=0, stdout=json.dumps([live_index]))
+
+    missing = reconcile_firestore_indexes.provision_missing_indexes(
+        expected=expected,
+        project='dev-project',
+        database='(default)',
+        runner=runner,
+    )
+
+    assert missing == expected
+    assert commands[1][:5] == ['gcloud', 'firestore', 'indexes', 'composite', 'create']
+
+
+def test_provisioning_dry_run_only_lists_indexes_and_does_not_write(capsys):
+    commands = []
+
+    def runner(command, **_kwargs):
+        commands.append(command)
+        return SimpleNamespace(returncode=0, stdout='[]')
+
+    reconcile_firestore_indexes.reconcile(
+        project='dev-project',
+        database='(default)',
+        manifest_path=Path(__file__).resolve().parents[3] / 'firestore.indexes.json',
+        timeout_seconds=30,
+        poll_interval_seconds=1,
+        provision_missing=True,
+        dry_run=True,
+        runner=runner,
+    )
+
+    assert commands == [
+        [
+            'gcloud',
+            'firestore',
+            'indexes',
+            'composite',
+            'list',
+            '--project=dev-project',
+            '--database=(default)',
+            '--format=json',
+        ]
+    ]
+    assert 'would create COLLECTION/task_attention_overrides' in capsys.readouterr().out
+
+
+def test_provisioning_fails_closed_when_gcloud_cannot_create_a_missing_index():
+    def runner(command, **_kwargs):
+        if command[:5] == ['gcloud', 'firestore', 'indexes', 'composite', 'create']:
+            return SimpleNamespace(returncode=1, stdout='')
+        return SimpleNamespace(returncode=0, stdout='[]')
+
+    with pytest.raises(RuntimeError, match='provisioning failed'):
+        reconcile_firestore_indexes.reconcile(
+            project='dev-project',
+            database='(default)',
+            manifest_path=Path(__file__).resolve().parents[3] / 'firestore.indexes.json',
+            timeout_seconds=30,
+            poll_interval_seconds=1,
+            provision_missing=True,
+            runner=runner,
+        )
 
 
 def test_reconcile_fails_when_a_required_index_never_becomes_ready():

--- a/backend/tests/unit/test_verify_dev_backend_deployment.py
+++ b/backend/tests/unit/test_verify_dev_backend_deployment.py
@@ -305,6 +305,19 @@ def test_dev_deploy_invokes_legacy_binding_migration_only_for_dev_services() -> 
     assert '--check-runtime-bindings' not in production_workflow.read_text(encoding='utf-8')
 
 
+def test_dev_deploy_uses_manifest_derived_gcloud_index_provisioning_only() -> None:
+    workflow = BACKEND_DIR.parent / '.github/workflows/gcp_backend_auto_dev.yml'
+    production_workflow = BACKEND_DIR.parent / '.github/workflows/gcp_backend.yml'
+    text = workflow.read_text(encoding='utf-8')
+
+    assert 'environment: development' in text
+    assert 'backend/scripts/reconcile_firestore_indexes.py' in text
+    assert '--provision-missing' in text
+    assert 'firebase' not in text
+    assert 'setup-node' not in text
+    assert '--provision-missing' not in production_workflow.read_text(encoding='utf-8')
+
+
 def test_expectation_binds_commit_to_deploy_run_revision_and_image() -> None:
     expectation = _expectation()
 


### PR DESCRIPTION
## Summary

- make the development-only Firestore reconciliation path provision missing manifest-derived composite indexes through `gcloud firestore indexes composite create`
- preserve production's existing Firebase deployment/implicit-document-ID reconciliation behavior
- prevent development provisioning and readiness from accepting the legacy implicit terminal-`__name__` alias
- add exact gcloud command, no-write dry-run, failure, and former false-ready regression coverage

## Validation

- `backend/.venv/bin/python -m pytest -q backend/tests/unit/test_reconcile_firestore_indexes.py backend/tests/unit/test_verify_dev_backend_deployment.py backend/tests/unit/test_smoke_what_matters_now.py` — 26 passed
- independent review approved
- `actionlint -shellcheck '' .github/workflows/gcp_backend_auto_dev.yml`
- `backend/.venv/bin/python backend/scripts/check_workflow_contracts.py`
- `backend/.venv/bin/python backend/scripts/validate-backend-runtime-env.py --env dev --check-workflows`
- full repository pre-push contract suite passed

## Scope

Development auto-deploy only. No production workflow, cloud resource, traffic, secret, or manual console/API mutation was performed.

Related to #9755.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9756?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

