### PR TITLE
fix(openapi): make client generators portable on Windows

### DIFF
--- a/backend/scripts/generate_dart_models.py
+++ b/backend/scripts/generate_dart_models.py
@@ -1236,18 +1236,18 @@ def main() -> int:
     if args.all and args.output:
         raise SystemExit('--output cannot be used with --all')
 
-    spec = json.loads(Path(args.spec).read_text())
+    spec = json.loads(Path(args.spec).read_text(encoding='utf-8'))
     groups = tuple(SCHEMA_GROUPS) if args.all else (args.group,)
     for group in groups:
         output_path = Path(args.output) if args.output else SCHEMA_GROUPS[group]['output']
         generated = build_output(spec, group)
         if args.check:
-            if not output_path.exists() or output_path.read_text() != generated:
+            if not output_path.exists() or output_path.read_text(encoding='utf-8') != generated:
                 raise SystemExit(f'{output_path} is stale; run backend/scripts/generate_dart_models.py --group {group}')
             print(f'{output_path} is up to date')
             continue
         output_path.parent.mkdir(parents=True, exist_ok=True)
-        output_path.write_text(generated)
+        output_path.write_text(generated, encoding='utf-8', newline='\n')
         print(f'wrote {output_path}')
     return 0
 

--- a/backend/scripts/generate_swift_openapi_types.py
+++ b/backend/scripts/generate_swift_openapi_types.py
@@ -16,12 +16,20 @@ import argparse
 import json
 import re
 import sys
-from pathlib import Path
+from pathlib import Path, PurePath
 from typing import Any
 
 ROOT_DIR = Path(__file__).resolve().parents[2]
 DEFAULT_SPEC_PATH = ROOT_DIR / 'docs' / 'api-reference' / 'app-client-openapi.json'
 DEFAULT_OUTPUT = ROOT_DIR / 'desktop' / 'macos' / 'Desktop' / 'Sources' / 'Generated' / 'OmiApi.generated.swift'
+
+
+def source_label_for_path(path: PurePath, root_dir: PurePath = ROOT_DIR) -> str:
+    try:
+        return path.relative_to(root_dir).as_posix()
+    except ValueError:
+        return path.as_posix()
+
 
 # Schemas to generate. Keep this the high-traffic desktop read surface; expand
 # as the desktop Codable migration progresses. Each entry pulls in transitive
@@ -905,20 +913,20 @@ def parse_args() -> argparse.Namespace:
 
 def main() -> int:
     args = parse_args()
-    spec = json.loads(args.spec.read_text())
-    generated = generate(spec, str(args.spec.relative_to(ROOT_DIR)) if args.spec.is_absolute() else str(args.spec))
+    spec = json.loads(args.spec.read_text(encoding='utf-8'))
+    generated = generate(spec, source_label_for_path(args.spec))
 
     if args.check:
-        existing = args.output.read_text() if args.output.exists() else ''
+        existing = args.output.read_text(encoding='utf-8') if args.output.exists() else ''
         if existing != generated:
-            rel = args.output.relative_to(ROOT_DIR) if args.output.is_absolute() else args.output
+            rel = source_label_for_path(args.output)
             print(f'{rel} is out of date. Run: python {Path(__file__).name}', file=sys.stderr)
             return 1
         return 0
 
     args.output.parent.mkdir(parents=True, exist_ok=True)
-    args.output.write_text(generated)
-    print(f'wrote {args.output}')
+    args.output.write_text(generated, encoding='utf-8', newline='\n')
+    print(f'wrote {source_label_for_path(args.output)}')
     return 0
 
 

--- a/backend/scripts/generate_swift_openapi_types.py
+++ b/backend/scripts/generate_swift_openapi_types.py
@@ -206,7 +206,7 @@ def _render_enum(name: str, schema: dict[str, Any]) -> str:
     lines.append('  case _unknown = "__unknown__"')
     lines.append('  public init(from decoder: Decoder) throws {')
     lines.append('    let c = try decoder.singleValueContainer()')
-    lines.append(f'    let raw = try c.decode(String.self)')
+    lines.append('    let raw = try c.decode(String.self)')
     lines.append(f'    self = {name}(rawValue: raw) ?? ._unknown')
     lines.append('  }')
     lines.append('}')
@@ -494,7 +494,7 @@ def _render_patch_struct(name: str, schema: dict[str, Any]) -> str:
     lines.append('    var c = encoder.container(keyedBy: CodingKeys.self)')
     for swift_name, _, _ in fields:
         lines.append(f'    switch {swift_name} {{')
-        lines.append(f'    case .omitted: break')
+        lines.append('    case .omitted: break')
         lines.append(f'    case .value(let value): try c.encode(value, forKey: .{swift_name})')
         lines.append(f'    case .null: try c.encodeNil(forKey: .{swift_name})')
         lines.append('    }')

--- a/backend/scripts/generate_ts_openapi_types.py
+++ b/backend/scripts/generate_ts_openapi_types.py
@@ -11,7 +11,7 @@ import argparse
 import json
 import re
 import sys
-from pathlib import Path
+from pathlib import Path, PurePath
 from typing import Any
 
 ROOT_DIR = Path(__file__).resolve().parents[2]
@@ -29,6 +29,14 @@ IDENTIFIER_RE = re.compile(r'[^A-Za-z0-9_$]')
 
 def stable_json(value: Any) -> str:
     return json.dumps(value, ensure_ascii=False, indent=2, sort_keys=True) + '\n'
+
+
+def source_label_for_path(spec_path: PurePath, root_dir: PurePath = ROOT_DIR) -> str:
+    """Return a stable slash-separated label for generated-file headers."""
+    try:
+        return spec_path.relative_to(root_dir).as_posix()
+    except ValueError:
+        return spec_path.as_posix()
 
 
 def ts_identifier(name: str) -> str:
@@ -431,31 +439,24 @@ def parse_args() -> argparse.Namespace:
 def main() -> int:
     args = parse_args()
     spec_path = args.spec if args.spec.is_absolute() else (Path.cwd() / args.spec)
-    spec = json.loads(spec_path.read_text())
-    try:
-        source_label = str(spec_path.relative_to(ROOT_DIR))
-    except ValueError:
-        source_label = str(spec_path)
-    rendered = generate(spec, source_label)
+    spec = json.loads(spec_path.read_text(encoding='utf-8'))
+    rendered = generate(spec, source_label_for_path(spec_path))
 
     outputs = args.output or DEFAULT_OUTPUTS
     stale: list[Path] = []
     for output in outputs:
         path = output if output.is_absolute() else (Path.cwd() / output)
         if args.check:
-            if not path.exists() or path.read_text() != rendered:
+            if not path.exists() or path.read_text(encoding='utf-8') != rendered:
                 stale.append(path)
         else:
             path.parent.mkdir(parents=True, exist_ok=True)
-            path.write_text(rendered)
-            print(f'wrote {path.relative_to(ROOT_DIR)}')
+            path.write_text(rendered, encoding='utf-8', newline='\n')
+            print(f'wrote {source_label_for_path(path)}')
 
     if stale:
         for path in stale:
-            try:
-                label = path.relative_to(ROOT_DIR)
-            except ValueError:
-                label = path
+            label = source_label_for_path(path)
             print(f'{label} is stale; run backend/scripts/generate_ts_openapi_types.py', file=sys.stderr)
         return 1
     return 0

--- a/backend/tests/unit/test_app_client_dart_generator.py
+++ b/backend/tests/unit/test_app_client_dart_generator.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
 import json
+import os
+import subprocess
+import sys
 from pathlib import Path
 
 from models.conversation import Conversation
@@ -38,6 +41,22 @@ MEMORIES_DART_PATH = ROOT_DIR / 'app' / 'lib' / 'backend' / 'schema' / 'gen' / '
 GOALS_DART_PATH = ROOT_DIR / 'app' / 'lib' / 'backend' / 'schema' / 'gen' / 'goals_wire.g.dart'
 TASK_INTELLIGENCE_DART_PATH = ROOT_DIR / 'app' / 'lib' / 'backend' / 'schema' / 'gen' / 'task_intelligence_wire.g.dart'
 CONVERSATION_FIXTURE_PATH = ROOT_DIR / 'backend' / 'testing' / 'e2e' / 'fixtures' / 'conversations.json'
+
+
+def test_dart_generator_cli_uses_utf8_when_the_process_locale_does_not():
+    env = os.environ.copy()
+    env.update({'LANG': 'C', 'LC_ALL': 'C', 'PYTHONCOERCECLOCALE': '0', 'PYTHONUTF8': '0'})
+
+    completed = subprocess.run(
+        [sys.executable, str(generate_dart_models.__file__), '--all', '--check'],
+        check=False,
+        capture_output=True,
+        text=True,
+        cwd=ROOT_DIR,
+        env=env,
+    )
+
+    assert completed.returncode == 0, completed.stderr
 
 
 def test_conversation_wire_dart_is_generated_from_app_client_openapi():

--- a/backend/tests/unit/test_app_client_swift_generator.py
+++ b/backend/tests/unit/test_app_client_swift_generator.py
@@ -8,7 +8,10 @@ that the namespaced OmiAPI types cover the desktop's highest-traffic read DTOs.
 from __future__ import annotations
 
 import json
-from pathlib import Path
+import os
+import subprocess
+import sys
+from pathlib import Path, PureWindowsPath
 
 from scripts import generate_swift_openapi_types
 
@@ -149,3 +152,29 @@ def test_swift_generator_emits_required_headers_and_client_default_headers():
     assert 'idempotencyKey: String' in generated
     assert 'for (name, value) in client.headers' in generated
     assert 'req.setValue(String(idempotencyKey), forHTTPHeaderField: "Idempotency-Key")' in generated
+
+
+def test_swift_source_label_is_stable_for_windows_paths():
+    root = PureWindowsPath('C:/src/omi')
+    spec_path = root / 'docs' / 'api-reference' / 'app-client-openapi.json'
+
+    assert (
+        generate_swift_openapi_types.source_label_for_path(spec_path, root)
+        == 'docs/api-reference/app-client-openapi.json'
+    )
+
+
+def test_swift_generator_cli_uses_utf8_when_the_process_locale_does_not():
+    env = os.environ.copy()
+    env.update({'LANG': 'C', 'LC_ALL': 'C', 'PYTHONCOERCECLOCALE': '0', 'PYTHONUTF8': '0'})
+
+    completed = subprocess.run(
+        [sys.executable, str(generate_swift_openapi_types.__file__), '--check'],
+        check=False,
+        capture_output=True,
+        text=True,
+        cwd=ROOT_DIR,
+        env=env,
+    )
+
+    assert completed.returncode == 0, completed.stderr

--- a/backend/tests/unit/test_app_client_ts_generator.py
+++ b/backend/tests/unit/test_app_client_ts_generator.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
 import json
+import os
 import re
-from pathlib import Path
+import subprocess
+import sys
+from pathlib import Path, PureWindowsPath
 
 from scripts import generate_ts_openapi_types
 
@@ -11,11 +14,11 @@ SPEC_PATH = ROOT_DIR / 'docs' / 'api-reference' / 'app-client-openapi.json'
 
 
 def test_typescript_schema_types_are_generated_from_app_client_openapi():
-    spec = json.loads(SPEC_PATH.read_text())
+    spec = json.loads(SPEC_PATH.read_text(encoding='utf-8'))
     generated = generate_ts_openapi_types.generate(spec, 'docs/api-reference/app-client-openapi.json')
 
     for output in generate_ts_openapi_types.DEFAULT_OUTPUTS:
-        assert output.read_text() == generated
+        assert output.read_text(encoding='utf-8') == generated
     assert '// GENERATED CODE - DO NOT EDIT.' in generated
     assert 'export interface Conversation {' in generated
     assert 'export interface GoalResponse {' in generated
@@ -27,7 +30,7 @@ def test_typescript_schema_types_are_generated_from_app_client_openapi():
 
 
 def test_typescript_operation_response_map_is_generated():
-    spec = json.loads(SPEC_PATH.read_text())
+    spec = json.loads(SPEC_PATH.read_text(encoding='utf-8'))
     generated = generate_ts_openapi_types.generate(spec, 'docs/api-reference/app-client-openapi.json')
 
     assert 'export interface OmiApiPaths {' in generated
@@ -138,3 +141,49 @@ def test_typescript_generator_emits_type_for_object_unions():
     assert 'export type NullableObject =' in generated
     assert 'export interface NullableObject' not in generated
     assert re.search(r'export type CandidateRecord = \{[\s\S]*?\} \| \{', generated)
+
+
+def test_typescript_source_label_is_stable_for_windows_paths():
+    root = PureWindowsPath('C:/src/omi')
+    spec_path = root / 'docs' / 'api-reference' / 'app-client-openapi.json'
+
+    assert (
+        generate_ts_openapi_types.source_label_for_path(spec_path, root) == 'docs/api-reference/app-client-openapi.json'
+    )
+
+
+def test_typescript_generator_cli_uses_utf8_when_the_process_locale_does_not(tmp_path: Path):
+    spec_path = tmp_path / 'openapi.json'
+    output_path = tmp_path / 'generated.ts'
+    spec = {
+        'components': {
+            'schemas': {
+                'Price\u20ac': {
+                    'type': 'object',
+                    'properties': {'currency': {'type': 'string'}},
+                }
+            }
+        },
+        'paths': {},
+    }
+    spec_path.write_text(json.dumps(spec, ensure_ascii=False), encoding='utf-8')
+    env = os.environ.copy()
+    env.update({'LANG': 'C', 'LC_ALL': 'C', 'PYTHONCOERCECLOCALE': '0', 'PYTHONUTF8': '0'})
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(generate_ts_openapi_types.__file__),
+            '--spec',
+            str(spec_path),
+            '--output',
+            str(output_path),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert 'export interface Price_ {' in output_path.read_text(encoding='utf-8')


### PR DESCRIPTION
## Summary
- read and write all Dart, TypeScript, and Swift OpenAPI generator files explicitly as UTF-8
- emit slash-stable source labels in generated TypeScript and Swift headers on every OS
- handle TypeScript and Swift output paths outside the repository without `relative_to()` failures
- add subprocess regression coverage with Python UTF-8 mode disabled, plus Windows path-label tests

## Root cause
The client generators used `Path.read_text()` and `Path.write_text()` without an encoding. On Windows, Python therefore inherited the active ANSI code page. The UTF-8 app-client contract failed to decode under GBK before generation started.

After forcing UTF-8 manually, TypeScript `--check` still reported all four committed outputs as stale because the generated header embedded a Windows backslash path while the committed Linux-generated header used forward slashes. The Swift generator had the same path-label contract, and both generators assumed every explicit output lived under the repository root.

This was visible in the contributor path because `scripts/pre-push` invokes all three generator checks directly; it does not inherit the UTF-8 export used by `backend/test.sh`.

## Scope and safety
- generator file I/O, generated-file labels, diagnostics, and regression tests only
- no OpenAPI schema, generated client API, backend route, application runtime, or deployment behavior changes
- generated outputs remain byte-stable on Linux and use explicit LF newlines when written on Windows

## Product invariants affected
None.

## Verification
- real Windows checks with `PYTHONUTF8` unset:
  - `python backend/scripts/generate_dart_models.py --all --check`
  - `python backend/scripts/generate_ts_openapi_types.py --check`
  - `python backend/scripts/generate_swift_openapi_types.py --check`
- official backend runner for the three generator test files: 43 passed
- forced non-UTF-8 locale and Windows path regression subset: 5 passed
- Black 24.4.2 and Ruff 0.4.4: passed
- diff hygiene, lifecycle headers, versioned filenames, import purity, test isolation, workflow contracts, async blocker, route policy, and conversation lifecycle guards: passed

The full 601-file backend run had one unrelated Windows CPU-time guard at the exact `0.12s` threshold; all four assertions in that file passed, and the same file passed its isolated official-runner retry in `0.10s`. The aggregate preflight also encounters the existing Windows Firestore path-normalization false positive fixed by #9683; checks after that gate were run directly and passed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9759?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

