### PR TITLE
fix(credentials): require enforceable private file modes

### DIFF
--- a/backend/database/google_credentials.py
+++ b/backend/database/google_credentials.py
@@ -31,6 +31,10 @@ def _write_credentials_file(raw_credentials: str) -> None:
     except json.JSONDecodeError as exc:
         raise RuntimeError('Google service account credentials are not valid JSON') from exc
 
+    fchmod = getattr(os, 'fchmod', None)
+    if not callable(fchmod):
+        raise RuntimeError('Google service account credentials require owner-only file permissions')
+
     RUNTIME_GOOGLE_CREDENTIALS_PATH.parent.mkdir(parents=True, exist_ok=True)
     fd, temp_path = tempfile.mkstemp(
         dir=RUNTIME_GOOGLE_CREDENTIALS_PATH.parent,
@@ -38,7 +42,7 @@ def _write_credentials_file(raw_credentials: str) -> None:
         text=True,
     )
     try:
-        os.fchmod(fd, 0o600)
+        fchmod(fd, 0o600)
         with os.fdopen(fd, 'w', encoding='utf-8') as handle:
             fd = -1
             json.dump(service_account_info, handle)

--- a/backend/scripts/firebase_release_probe_token.py
+++ b/backend/scripts/firebase_release_probe_token.py
@@ -11,7 +11,8 @@ ID token must match that audience and issuer.
 
 The script never prints a credential, request body, response body, or upstream
 error body. The ID token is written only to a mode-0600 file owned by the
-current runner process.
+current runner process; platforms that cannot enforce that mode fail before
+creating the output file.
 """
 
 from __future__ import annotations
@@ -244,13 +245,16 @@ def _signed_custom_token_locally(credentials_path: Path, firebase_project: str) 
             f'{_base64url(json.dumps(header, separators=(",", ":"), sort_keys=True).encode("utf-8"))}.'
             f'{_base64url(json.dumps(claims, separators=(",", ":"), sort_keys=True).encode("utf-8"))}'
         )
+        fchmod = getattr(os, 'fchmod', None)
+        if not callable(fchmod):
+            raise ProbeTokenError('custom_token_signing', 'credential_unavailable')
         try:
             descriptor, key_path = tempfile.mkstemp(
                 prefix='omi-firebase-probe-signer-',
                 dir=os.environ.get('RUNNER_TEMP'),
             )
             try:
-                os.fchmod(descriptor, 0o600)
+                fchmod(descriptor, 0o600)
                 with os.fdopen(descriptor, 'w', encoding='utf-8') as handle:
                     descriptor = -1
                     handle.write(private_key)
@@ -369,13 +373,16 @@ def mint_probe_token(
 def write_token(path: Path, token: str) -> None:
     if not path.parent.is_dir() or not token or len(token) > MAX_TOKEN_CHARS:
         raise ProbeTokenError('token_output')
+    fchmod = getattr(os, 'fchmod', None)
+    if not callable(fchmod):
+        raise ProbeTokenError('token_output')
     flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC | getattr(os, 'O_NOFOLLOW', 0)
     try:
         descriptor = os.open(path, flags, 0o600)
         try:
             if not stat.S_ISREG(os.fstat(descriptor).st_mode):
                 raise ProbeTokenError('token_output')
-            os.fchmod(descriptor, 0o600)
+            fchmod(descriptor, 0o600)
             with os.fdopen(descriptor, 'w', encoding='utf-8') as handle:
                 descriptor = -1
                 handle.write(token)

--- a/backend/tests/unit/test_firebase_release_probe_token.py
+++ b/backend/tests/unit/test_firebase_release_probe_token.py
@@ -2,11 +2,14 @@ import importlib.util
 import base64
 import io
 import json
+import os
 import stat
 import subprocess
 import sys
 import urllib.error
 from pathlib import Path
+
+import pytest
 
 
 def _load_module():
@@ -116,6 +119,41 @@ def test_firebase_auth_exchange_failure_is_redacted(monkeypatch):
         raise AssertionError('expected a redacted Firebase exchange failure')
 
 
+def test_write_token_fails_closed_when_owner_only_permissions_are_unavailable(monkeypatch, tmp_path, capsys):
+    module = _load_module()
+    output = tmp_path / 'probe-token'
+    monkeypatch.setattr(
+        module,
+        'mint_probe_token',
+        lambda _secret_project, _firebase_project, **_kwargs: 'firebase-id-token-that-must-not-leak',
+    )
+    monkeypatch.delattr(module.os, 'fchmod', raising=False)
+
+    exit_code = module.main(
+        [
+            '--secret-project',
+            'omi-deploy',
+            '--firebase-project',
+            'omi-prod',
+            '--token-output',
+            str(output),
+        ]
+    )
+
+    report = json.loads(capsys.readouterr().out)
+    assert exit_code == 1
+    assert report == {
+        'suite': 'omi_firebase_release_probe_token',
+        'stage': 'token_output',
+        'error_class': 'operation_failed',
+        'status': 'FAIL',
+    }
+    assert not output.exists()
+
+
+@pytest.mark.skipif(
+    not callable(getattr(os, 'fchmod', None)), reason='owner-only descriptor modes require POSIX fchmod'
+)
 def test_write_token_uses_owner_only_permissions(tmp_path):
     module = _load_module()
     output = tmp_path / 'probe-token'
@@ -142,6 +180,9 @@ def test_mint_probe_token_rejects_a_token_for_a_different_firebase_auth_project(
         raise AssertionError('expected Firebase auth-project mismatch')
 
 
+@pytest.mark.skipif(
+    not callable(getattr(os, 'fchmod', None)), reason='owner-only descriptor modes require POSIX fchmod'
+)
 def test_local_signer_uses_matching_service_account_without_remote_iam(monkeypatch, tmp_path):
     module = _load_module()
     credentials = tmp_path / 'firebase-signer.json'
@@ -179,6 +220,34 @@ def test_local_signer_uses_matching_service_account_without_remote_iam(monkeypat
     assert base64.urlsafe_b64decode(signature_part + '=' * (-len(signature_part) % 4)) == b'signature'
 
 
+def test_local_signer_fails_before_creating_a_key_file_when_private_modes_are_unavailable(monkeypatch, tmp_path):
+    module = _load_module()
+    monkeypatch.setattr(
+        module,
+        '_read_signer_credentials',
+        lambda _path, _project: (
+            'firebase-probe@based-hardware.iam.gserviceaccount.com',
+            'fixed-key-id',
+            '-----BEGIN PRIVATE KEY-----\nnot-a-real-key\n-----END PRIVATE KEY-----\n',
+        ),
+    )
+    monkeypatch.delattr(module.os, 'fchmod', raising=False)
+    monkeypatch.setattr(
+        module.tempfile,
+        'mkstemp',
+        lambda **_kwargs: (_ for _ in ()).throw(AssertionError('temporary key file must not be created')),
+    )
+
+    with pytest.raises(module.ProbeTokenError) as error:
+        module._signed_custom_token_locally(tmp_path / 'firebase-signer.json', 'based-hardware')
+
+    assert error.value.stage == 'custom_token_signing'
+    assert error.value.error_class == 'credential_unavailable'
+
+
+@pytest.mark.skipif(
+    not callable(getattr(os, 'fchmod', None)), reason='owner-only descriptor modes require POSIX fchmod'
+)
 def test_local_signer_rejects_cross_project_credentials_before_signing(monkeypatch, tmp_path):
     module = _load_module()
     credentials = tmp_path / 'firebase-signer.json'

--- a/backend/tests/unit/test_google_credentials.py
+++ b/backend/tests/unit/test_google_credentials.py
@@ -4,7 +4,12 @@ import pytest
 
 from database import google_credentials
 
+requires_owner_only_permissions = pytest.mark.skipif(
+    not callable(getattr(os, 'fchmod', None)), reason='owner-only descriptor modes require POSIX fchmod'
+)
 
+
+@requires_owner_only_permissions
 def test_service_account_json_materializes_credentials_file(monkeypatch, tmp_path):
     credentials_path = tmp_path / 'google-credentials.json'
     monkeypatch.setattr(google_credentials, 'RUNTIME_GOOGLE_CREDENTIALS_PATH', credentials_path)
@@ -18,6 +23,7 @@ def test_service_account_json_materializes_credentials_file(monkeypatch, tmp_pat
     assert credentials_path.stat().st_mode & 0o777 == 0o600
 
 
+@requires_owner_only_permissions
 def test_google_application_credentials_json_materializes_credentials_file(monkeypatch, tmp_path):
     credentials_path = tmp_path / 'google-credentials.json'
     monkeypatch.setattr(google_credentials, 'RUNTIME_GOOGLE_CREDENTIALS_PATH', credentials_path)
@@ -30,6 +36,20 @@ def test_google_application_credentials_json_materializes_credentials_file(monke
     assert credentials_path.exists()
 
 
+def test_inline_credentials_fail_closed_when_owner_only_permissions_are_unavailable(monkeypatch, tmp_path):
+    credentials_path = tmp_path / 'google-credentials.json'
+    monkeypatch.setattr(google_credentials, 'RUNTIME_GOOGLE_CREDENTIALS_PATH', credentials_path)
+    monkeypatch.setenv('SERVICE_ACCOUNT_JSON', '{"client_email": "unused@example.com"}')
+    monkeypatch.delenv('GOOGLE_APPLICATION_CREDENTIALS', raising=False)
+    monkeypatch.delattr(google_credentials.os, 'fchmod', raising=False)
+
+    with pytest.raises(RuntimeError, match='require owner-only file permissions'):
+        google_credentials.prepare_google_credentials()
+
+    assert not credentials_path.exists()
+    assert list(tmp_path.iterdir()) == []
+
+
 def test_missing_google_application_credentials_path_fails_fast(monkeypatch, tmp_path):
     missing_path = tmp_path / 'missing-google-credentials.json'
     monkeypatch.delenv('SERVICE_ACCOUNT_JSON', raising=False)
@@ -39,6 +59,7 @@ def test_missing_google_application_credentials_path_fails_fast(monkeypatch, tmp
         google_credentials.prepare_google_credentials()
 
 
+@requires_owner_only_permissions
 def test_existing_credentials_file_is_replaced_with_private_permissions(monkeypatch, tmp_path):
     credentials_path = tmp_path / 'google-credentials.json'
     credentials_path.write_text('old credentials', encoding='utf-8')


### PR DESCRIPTION
## Summary

- require owner-only descriptor permissions before writing either release-probe tokens or inline Google service-account credentials
- fail before creating or truncating any credential output when the platform cannot enforce that contract
- keep redacted release-probe failures and add cross-platform regression coverage for both writers
- preserve real mode-`0600` assertions on POSIX

## Why

Both credential writers unconditionally called `os.fchmod`, which is unavailable on Windows. The release-probe helper opened its token output first and then escaped the redacted error path with `AttributeError`; the runtime Google credential writer likewise failed with an implementation-level exception after creating a temporary file.

Checking the capability before filesystem mutation gives unsupported platforms an intentional fail-closed result without weakening the existing owner-only security contract. POSIX behavior is unchanged.

## Failure class

Failure-Class: none

This is an isolated platform-capability gap in private-file creation, not an instance of a registered recurring semantic failure class. The focused regression tests guard both credential writers.

## Testing

- before the Google credential fix on Windows: `3 failed, 1 passed`
- backend file-isolated runner with the CI timing ceiling: `25 passed, 4 skipped`
  - release-probe token tests: `4 passed, 1 skipped`
  - Google credential tests: `2 passed, 3 skipped`
  - workflow contract tests: `19 passed`
- Black 24.4.2: passed
- Ruff 0.4.4: passed
- workflow contract static check: passed
- `git diff --check`: passed

The skipped Windows cases assert actual POSIX mode bits; Linux CI continues to execute those mode-`0600` checks.