### PR TITLE
fix(dev): gate Cloud Run candidates before traffic promotion

### DIFF
--- a/.github/actions/sync-backfill-lifecycle/action.yml
+++ b/.github/actions/sync-backfill-lifecycle/action.yml
@@ -36,6 +36,10 @@ inputs:
     description: Manifest-rendered backend-sync-backfill secrets overlay (mode=worker)
     required: false
     default: ''
+  candidate_tag:
+    description: Stable no-traffic candidate tag (mode=worker)
+    required: false
+    default: ''
   provision_sync_ledger_ttl:
     description: Provision and verify Firestore sync_content_ledger TTL (mode=platform)
     required: false
@@ -98,6 +102,15 @@ runs:
         python3 backend/scripts/render_cloud_run_clone_env.py \
           --source-json /tmp/backend-sync-live.json >> "$GITHUB_OUTPUT"
 
+    - name: Render optional candidate tag
+      if: ${{ inputs.mode == 'worker' }}
+      id: candidate-tag
+      shell: bash
+      run: |
+        if [[ -n "${{ inputs.candidate_tag }}" ]]; then
+          echo "flag=--tag=${{ inputs.candidate_tag }}" >> "$GITHUB_OUTPUT"
+        fi
+
     - name: Deploy ${{ inputs.service }}-sync-backfill to Cloud Run
       if: ${{ inputs.mode == 'worker' }}
       id: deploy-backend-sync-backfill
@@ -110,6 +123,7 @@ runs:
         no_traffic: true
         flags: >-
           --revision-suffix=${{ inputs.revision_suffix }}
+          ${{ steps.candidate-tag.outputs.flag }}
           --min-instances=0
           --max-instances=4
           --concurrency=1

--- a/.github/scripts/check-deployment-concurrency.py
+++ b/.github/scripts/check-deployment-concurrency.py
@@ -183,35 +183,33 @@ def validate_lock(name: str, text: str, contract: LockContract) -> list[str]:
     return errors
 
 
-def auto_deploy_acceptance_is_eligible(deploy_result: str) -> bool:
-    """Model the integrated acceptance job's `needs: deploy` success guard."""
-
-    return deploy_result == "success"
-
-
 def validate_auto_deploy_acceptance(text: str) -> list[str]:
-    """Keep acceptance inside the source deploy workflow's mutation lock."""
+    """Keep exact candidate acceptance in the locked deploy job before promotion."""
 
-    block = job_block(text, "verify")
+    block = job_block(text, "deploy")
     if block is None:
-        return ["gcp_backend_auto_dev.yml: missing integrated verify job"]
+        return ["gcp_backend_auto_dev.yml: missing deploy job"]
     required_markers = (
-        "needs: deploy",
-        "if: needs.deploy.result == 'success'",
+        "Capture exact no-traffic candidate URLs",
         "backend/scripts/verify_dev_backend_deployment.py",
+        "backend/scripts/run_dev_candidate_acceptance.py",
+        "--candidate",
         '--commit-sha "${{ github.sha }}"',
         '--deploy-run-id "${{ github.run_id }}"',
         '--deploy-run-attempt "${{ github.run_attempt }}"',
+        "Shift Cloud Run traffic to validated revisions",
     )
     errors = [
-        f"gcp_backend_auto_dev.yml: integrated verify job missing {marker!r}"
+        f"gcp_backend_auto_dev.yml: candidate acceptance missing {marker!r}"
         for marker in required_markers
         if not any(marker in line for line in block)
     ]
-    if any("concurrency:" in line for line in block):
-        errors.append(
-            "gcp_backend_auto_dev.yml: integrated verify must inherit the workflow mutation lock"
-        )
+    smoke_index = next((index for index, line in enumerate(block) if "run_dev_candidate_acceptance.py" in line), -1)
+    promotion_index = next((index for index, line in enumerate(block) if "Shift Cloud Run traffic" in line), -1)
+    if smoke_index >= promotion_index:
+        errors.append("gcp_backend_auto_dev.yml: candidate acceptance must run before traffic promotion")
+    if job_block(text, "verify") is not None:
+        errors.append("gcp_backend_auto_dev.yml: candidate acceptance must not run in a post-promotion verify job")
     return errors
 
 
@@ -464,29 +462,23 @@ jobs:
     ):
         raise PolicyError("cancel-in-progress: true satisfied the deploy contract")
 
-    integrated_acceptance = """name: fixture
+    in_deploy_acceptance = """name: fixture
 jobs:
   deploy:
-    runs-on: ubuntu-latest
-  verify:
-    needs: deploy
-    if: needs.deploy.result == 'success'
     runs-on: ubuntu-latest
     steps:
       - run: >-
           python3 backend/scripts/verify_dev_backend_deployment.py
+          --candidate
           --commit-sha "${{ github.sha }}"
           --deploy-run-id "${{ github.run_id }}"
           --deploy-run-attempt "${{ github.run_attempt }}"
+      - name: Capture exact no-traffic candidate URLs
+      - run: python3 backend/scripts/run_dev_candidate_acceptance.py
+      - name: Shift Cloud Run traffic to validated revisions
 """
-    if validate_auto_deploy_acceptance(integrated_acceptance):
-        raise PolicyError("valid integrated acceptance job was rejected")
-    if auto_deploy_acceptance_is_eligible("cancelled"):
-        raise PolicyError("cancelled deployment made integrated acceptance eligible")
-    if not auto_deploy_acceptance_is_eligible("success"):
-        raise PolicyError(
-            "successful deployment did not make integrated acceptance eligible"
-        )
+    if validate_auto_deploy_acceptance(in_deploy_acceptance):
+        raise PolicyError("valid in-deploy candidate acceptance was rejected")
 
     pusher_deploy = """name: fixture
 jobs:

--- a/.github/scripts/check_deployment_secret_boundary.py
+++ b/.github/scripts/check_deployment_secret_boundary.py
@@ -15,7 +15,7 @@ import re
 import subprocess
 import sys
 from dataclasses import dataclass
-from pathlib import Path
+from pathlib import Path, PurePath
 from typing import Iterable
 
 
@@ -46,9 +46,14 @@ def _value_from_match(match: re.Match[str], group: int = 1) -> str:
     return match.group(group)
 
 
+def repository_relative_path(path: PurePath, root: PurePath) -> str:
+    """Use Git's POSIX repository-path shape on every host platform."""
+    return path.relative_to(root).as_posix()
+
+
 def _deployment_paths(root: Path) -> set[str]:
     paths = {
-        str(path.relative_to(root))
+        repository_relative_path(path, root)
         for path in (root / ".github" / "workflows").glob("*.y*ml")
         if path.is_file()
     }
@@ -58,7 +63,7 @@ def _deployment_paths(root: Path) -> set[str]:
     charts = root / "backend" / "charts"
     if charts.is_dir():
         paths.update(
-            str(path.relative_to(root))
+            repository_relative_path(path, root)
             for path in charts.glob("*/*_values.yaml")
             if path.is_file()
         )

--- a/.github/scripts/test_check_deployment_secret_boundary.py
+++ b/.github/scripts/test_check_deployment_secret_boundary.py
@@ -10,7 +10,7 @@ import subprocess
 import sys
 import tempfile
 import unittest
-from pathlib import Path
+from pathlib import Path, PurePosixPath, PureWindowsPath
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -138,6 +138,18 @@ jobs:
         self.assertIn("exception FAKE_RUNTIME_CONFIG is missing reason", errors)
         self.assertIn("exception FAKE_RUNTIME_CONFIG is missing expires", errors)
         self.assertIn("exception FAKE_RUNTIME_CONFIG is missing allowed_sources", errors)
+
+    def test_current_tree_paths_use_git_posix_separators(self) -> None:
+        windows_path = PureWindowsPath(r"C:\repo\.github\workflows\deploy.yml")
+        windows_root = PureWindowsPath(r"C:\repo")
+        posix_path = PurePosixPath("/repo/.github/workflows/deploy.yml")
+        posix_root = PurePosixPath("/repo")
+
+        self.assertEqual(CHECKER.repository_relative_path(windows_path, windows_root), ".github/workflows/deploy.yml")
+        self.assertEqual(
+            CHECKER.repository_relative_path(windows_path, windows_root),
+            CHECKER.repository_relative_path(posix_path, posix_root),
+        )
 
 
 if __name__ == "__main__":

--- a/.github/workflows/gcp_backend_auto_dev.yml
+++ b/.github/workflows/gcp_backend_auto_dev.yml
@@ -15,6 +15,9 @@ concurrency:
 env:
   SERVICE: backend
   REGION: us-central1
+  # Cloud Run tags are service-scoped. Reusing this tag atomically moves each
+  # service's candidate URL without accumulating stale no-traffic routes.
+  CANDIDATE_TAG: candidate
 
 jobs:
   deploy:
@@ -142,6 +145,7 @@ jobs:
           no_traffic: true
           flags: >-
             --revision-suffix=${{ steps.image-tag.outputs.revision_suffix }}
+            --tag=${{ env.CANDIDATE_TAG }}
             ${{ steps.runtime-env.outputs.cloud_run_flags }}
           env_vars: ${{ steps.runtime-env.outputs.backend_env_vars }}
           secrets: ${{ steps.runtime-env.outputs.backend_secrets }}
@@ -164,6 +168,7 @@ jobs:
           cloud_run_flags: ${{ steps.runtime-env.outputs.cloud_run_flags }}
           backfill_env_vars: ${{ steps.runtime-env.outputs.backend_sync_backfill_env_vars }}
           backfill_secrets: ${{ steps.runtime-env.outputs.backend_sync_backfill_secrets }}
+          candidate_tag: ${{ env.CANDIDATE_TAG }}
 
       - name: Deploy ${{ env.SERVICE }}-sync to Cloud Run
         id: deploy-backend-sync
@@ -176,6 +181,7 @@ jobs:
           no_traffic: true
           flags: >-
             --revision-suffix=${{ steps.image-tag.outputs.revision_suffix }}
+            --tag=${{ env.CANDIDATE_TAG }}
             ${{ steps.runtime-env.outputs.cloud_run_flags }}
           env_vars: |-
             ${{ steps.runtime-env.outputs.backend_sync_env_vars }}
@@ -266,6 +272,7 @@ jobs:
           no_traffic: true
           flags: >-
             --revision-suffix=${{ steps.image-tag.outputs.revision_suffix }}
+            --tag=${{ env.CANDIDATE_TAG }}
             ${{ steps.runtime-env.outputs.cloud_run_flags }}
           env_vars: ${{ steps.runtime-env.outputs.backend_integration_env_vars }}
           secrets: ${{ steps.runtime-env.outputs.backend_integration_secrets }}
@@ -286,11 +293,92 @@ jobs:
             --wait-revision-ready backend-sync-backfill=${{ steps.sync-backfill.outputs.revision }} \
             --wait-revision-ready backend-integration=${{ steps.capture-backend-integration-revision.outputs.revision }}
 
+      - name: Capture exact no-traffic candidate URLs
+        id: candidate-urls
+        run: |
+          set -euo pipefail
+          backend_url="$(python3 backend/scripts/resolve_cloud_run_tagged_url.py \
+            --project=${{ vars.GCP_PROJECT_ID }} \
+            --region=${{ env.REGION }} \
+            --service=backend \
+            --revision=${{ steps.capture-backend-revision.outputs.revision }} \
+            --tag=${{ env.CANDIDATE_TAG }})"
+          backend_sync_url="$(python3 backend/scripts/resolve_cloud_run_tagged_url.py \
+            --project=${{ vars.GCP_PROJECT_ID }} \
+            --region=${{ env.REGION }} \
+            --service=backend-sync \
+            --revision=${{ steps.capture-backend-sync-revision.outputs.revision }} \
+            --tag=${{ env.CANDIDATE_TAG }})"
+          backend_sync_backfill_url="$(python3 backend/scripts/resolve_cloud_run_tagged_url.py \
+            --project=${{ vars.GCP_PROJECT_ID }} \
+            --region=${{ env.REGION }} \
+            --service=backend-sync-backfill \
+            --revision=${{ steps.sync-backfill.outputs.revision }} \
+            --tag=${{ env.CANDIDATE_TAG }})"
+          backend_integration_url="$(python3 backend/scripts/resolve_cloud_run_tagged_url.py \
+            --project=${{ vars.GCP_PROJECT_ID }} \
+            --region=${{ env.REGION }} \
+            --service=backend-integration \
+            --revision=${{ steps.capture-backend-integration-revision.outputs.revision }} \
+            --tag=${{ env.CANDIDATE_TAG }})"
+          # Cloud Run verifies the service URL as the OIDC audience even when
+          # the HTTP request itself uses a tagged candidate URL.
+          backend_audience="$(gcloud run services describe backend --project=${{ vars.GCP_PROJECT_ID }} --region=${{ env.REGION }} --format='value(status.url)')"
+          backend_sync_audience="$(gcloud run services describe backend-sync --project=${{ vars.GCP_PROJECT_ID }} --region=${{ env.REGION }} --format='value(status.url)')"
+          backend_sync_backfill_audience="$(gcloud run services describe backend-sync-backfill --project=${{ vars.GCP_PROJECT_ID }} --region=${{ env.REGION }} --format='value(status.url)')"
+          backend_integration_audience="$(gcloud run services describe backend-integration --project=${{ vars.GCP_PROJECT_ID }} --region=${{ env.REGION }} --format='value(status.url)')"
+          test -n "$backend_audience"
+          test -n "$backend_sync_audience"
+          test -n "$backend_sync_backfill_audience"
+          test -n "$backend_integration_audience"
+          {
+            echo "backend_url=${backend_url}"
+            echo "backend_sync_url=${backend_sync_url}"
+            echo "backend_sync_backfill_url=${backend_sync_backfill_url}"
+            echo "backend_integration_url=${backend_integration_url}"
+            echo "backend_audience=${backend_audience}"
+            echo "backend_sync_audience=${backend_sync_audience}"
+            echo "backend_sync_backfill_audience=${backend_sync_backfill_audience}"
+            echo "backend_integration_audience=${backend_integration_audience}"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Validate backend runtime env after deploy
         env:
           SYNC_LEDGER_FENCE_MODE: ${{ vars.SYNC_LEDGER_FENCE_MODE || 'legacy' }}
         run: |
           python3 backend/scripts/validate-backend-runtime-env.py --env dev --check-workflows --check-live-cloud-run
+
+      # This stays in the deploy job: the workflow-level concurrency lock
+      # remains held until composition and exact candidate smoke both pass.
+      - name: Verify exact candidate composition
+        run: |
+          python3 backend/scripts/verify_dev_backend_deployment.py \
+            --candidate \
+            --commit-sha "${{ github.sha }}" \
+            --deploy-run-id "${{ github.run_id }}" \
+            --deploy-run-attempt "${{ github.run_attempt }}" \
+            --project "${{ vars.GCP_PROJECT_ID }}" \
+            --region "${{ env.REGION }}" \
+            --evidence-path artifacts/dev-backend-deployment-composition.json
+
+      - name: Gate candidate revisions with the acceptance manifest
+        env:
+          PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
+        run: |
+          set -euo pipefail
+          ADMIN_KEY="$(gcloud secrets versions access latest --secret=ADMIN_KEY --project="$PROJECT_ID")"
+          export ADMIN_KEY
+          trap 'unset ADMIN_KEY' EXIT
+          python3 backend/scripts/run_dev_candidate_acceptance.py \
+            --candidate backend=${{ steps.candidate-urls.outputs.backend_url }} \
+            --candidate backend-sync=${{ steps.candidate-urls.outputs.backend_sync_url }} \
+            --candidate backend-sync-backfill=${{ steps.candidate-urls.outputs.backend_sync_backfill_url }} \
+            --candidate backend-integration=${{ steps.candidate-urls.outputs.backend_integration_url }} \
+            --audience backend=${{ steps.candidate-urls.outputs.backend_audience }} \
+            --audience backend-sync=${{ steps.candidate-urls.outputs.backend_sync_audience }} \
+            --audience backend-sync-backfill=${{ steps.candidate-urls.outputs.backend_sync_backfill_audience }} \
+            --audience backend-integration=${{ steps.candidate-urls.outputs.backend_integration_audience }} \
+            --evidence-path artifacts/dev-backend-candidate-acceptance.json
 
       - name: Verify validated revisions are still current
         run: |
@@ -321,72 +409,21 @@ jobs:
             --expect-cloud-run-traffic backend=${{ steps.capture-backend-revision.outputs.revision }} \
             --expect-cloud-run-traffic backend-sync=${{ steps.capture-backend-sync-revision.outputs.revision }} \
             --expect-cloud-run-traffic backend-sync-backfill=${{ steps.sync-backfill.outputs.revision }} \
-            --expect-cloud-run-traffic backend-integration=${{ steps.capture-backend-integration-revision.outputs.revision }}
-
-      - name: Show Output
-        run: echo "Backend deployed to development environment"
-
-  # Keep acceptance in the source workflow's mutation lock. A cancelled deploy
-  # never creates a second workflow run that could replace a pending deploy,
-  # and a newer deploy cannot mutate the composition while this check runs.
-  verify:
-    needs: deploy
-    if: needs.deploy.result == 'success'
-    environment: development
-    permissions:
-      contents: read
-      id-token: write
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout deployed commit
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.sha }}
-
-      - name: Google Auth
-        uses: google-github-actions/auth@v2
-        with:
-          credentials_json: ${{ secrets.GCP_CREDENTIALS }}
-
-      - name: Set up gcloud
-        uses: google-github-actions/setup-gcloud@v2
-
-      - name: Get GKE credentials
-        uses: google-github-actions/get-gke-credentials@v2
-        with:
-          cluster_name: ${{ vars.GKE_CLUSTER }}
-          location: ${{ env.REGION }}
-          project_id: ${{ vars.GCP_PROJECT_ID }}
-
-      - name: Verify exact deployed composition
-        run: |
-          python3 backend/scripts/verify_dev_backend_deployment.py \
-            --commit-sha "${{ github.sha }}" \
-            --deploy-run-id "${{ github.run_id }}" \
-            --deploy-run-attempt "${{ github.run_attempt }}" \
-            --project "${{ vars.GCP_PROJECT_ID }}" \
-            --region "${{ env.REGION }}" \
-            --evidence-path artifacts/dev-backend-deployment-acceptance.json
-
-      - name: Smoke What Matters Now datastore query
-        env:
-          PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
-        run: |
-          set -euo pipefail
-          ADMIN_KEY="$(gcloud secrets versions access latest --secret=ADMIN_KEY --project="$PROJECT_ID")"
-          export ADMIN_KEY
-          trap 'unset ADMIN_KEY' EXIT
-          BACKEND_URL="$(gcloud run services describe backend \
-            --project="$PROJECT_ID" \
-            --region="${{ env.REGION }}" \
-            --format='value(status.url)')"
-          test -n "$BACKEND_URL"
-          python3 backend/scripts/smoke_what_matters_now.py --base-url "$BACKEND_URL"
+            --expect-cloud-run-traffic backend-integration=${{ steps.capture-backend-integration-revision.outputs.revision }} \
+            --candidate-acceptance-manifest backend/deploy/dev_candidate_acceptance.json \
+            --candidate-acceptance-evidence artifacts/dev-backend-candidate-acceptance.json \
+            --candidate-status-output artifacts/dev-backend-candidate-status.json
 
       - name: Upload deployment acceptance evidence
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: dev-backend-deployment-acceptance-${{ github.run_id }}
-          path: artifacts/dev-backend-deployment-acceptance.json
+          path: |
+            artifacts/dev-backend-deployment-composition.json
+            artifacts/dev-backend-candidate-acceptance.json
+            artifacts/dev-backend-candidate-status.json
           if-no-files-found: warn
+
+      - name: Show Output
+        run: echo "Backend deployed to development environment"

--- a/.github/workflows/gcp_memory_maintenance_job.yml
+++ b/.github/workflows/gcp_memory_maintenance_job.yml
@@ -83,7 +83,7 @@ jobs:
           CLOUD_RUN_VPC_NETWORK: ${{ vars.CLOUD_RUN_VPC_NETWORK }}
           CLOUD_RUN_VPC_SUBNET: ${{ vars.CLOUD_RUN_VPC_SUBNET }}
         run: |
-          python3 backend/scripts/render_backend_runtime_env.py --env ${{ vars.ENV }} >> "$GITHUB_OUTPUT"
+          python3 backend/scripts/render_backend_runtime_env.py --env ${{ vars.ENV }} --job memory-maintenance-job >> "$GITHUB_OUTPUT"
 
       - name: Validate backend runtime env before deploy
         run: |

--- a/.github/workflows/gcp_memory_maintenance_job_auto_dev.yml
+++ b/.github/workflows/gcp_memory_maintenance_job_auto_dev.yml
@@ -58,7 +58,7 @@ jobs:
           CLOUD_RUN_VPC_NETWORK: ${{ vars.CLOUD_RUN_VPC_NETWORK }}
           CLOUD_RUN_VPC_SUBNET: ${{ vars.CLOUD_RUN_VPC_SUBNET }}
         run: |
-          python3 backend/scripts/render_backend_runtime_env.py --env dev >> "$GITHUB_OUTPUT"
+          python3 backend/scripts/render_backend_runtime_env.py --env dev --job memory-maintenance-job >> "$GITHUB_OUTPUT"
 
       - name: Validate backend runtime env before deploy
         run: |

--- a/.github/workflows/gcp_notifications_job.yml
+++ b/.github/workflows/gcp_notifications_job.yml
@@ -88,7 +88,7 @@ jobs:
           CLOUD_RUN_VPC_NETWORK: ${{ vars.CLOUD_RUN_VPC_NETWORK }}
           CLOUD_RUN_VPC_SUBNET: ${{ vars.CLOUD_RUN_VPC_SUBNET }}
         run: |
-          python3 backend/scripts/render_backend_runtime_env.py --env ${{ vars.ENV }} >> "$GITHUB_OUTPUT"
+          python3 backend/scripts/render_backend_runtime_env.py --env ${{ vars.ENV }} --job notifications-job >> "$GITHUB_OUTPUT"
 
       - name: Validate backend runtime env before deploy
         run: |

--- a/backend/deploy/dev_candidate_acceptance.json
+++ b/backend/deploy/dev_candidate_acceptance.json
@@ -1,0 +1,49 @@
+{
+  "schema_version": 1,
+  "services": {
+    "backend": {
+      "contract": "what_matters_now",
+      "command": [
+        "python3",
+        "backend/scripts/smoke_what_matters_now.py",
+        "--base-url",
+        "{base_url}",
+        "--cloud-run-identity-token-env",
+        "CLOUD_RUN_IDENTITY_TOKEN"
+      ]
+    },
+    "backend-integration": {
+      "contract": "health",
+      "command": [
+        "python3",
+        "backend/scripts/smoke_cloud_run_health.py",
+        "--base-url",
+        "{base_url}",
+        "--cloud-run-identity-token-env",
+        "CLOUD_RUN_IDENTITY_TOKEN"
+      ]
+    },
+    "backend-sync": {
+      "contract": "health",
+      "command": [
+        "python3",
+        "backend/scripts/smoke_cloud_run_health.py",
+        "--base-url",
+        "{base_url}",
+        "--cloud-run-identity-token-env",
+        "CLOUD_RUN_IDENTITY_TOKEN"
+      ]
+    },
+    "backend-sync-backfill": {
+      "contract": "health",
+      "command": [
+        "python3",
+        "backend/scripts/smoke_cloud_run_health.py",
+        "--base-url",
+        "{base_url}",
+        "--cloud-run-identity-token-env",
+        "CLOUD_RUN_IDENTITY_TOKEN"
+      ]
+    }
+  }
+}

--- a/backend/scripts/deploy_status_report.py
+++ b/backend/scripts/deploy_status_report.py
@@ -9,7 +9,7 @@ import json
 import subprocess
 import sys
 from pathlib import Path
-from typing import Any, cast
+from typing import Any, Mapping, cast
 
 DEFAULT_REGION = 'us-central1'
 DEFAULT_GKE_SERVICES = (
@@ -58,6 +58,9 @@ def main() -> int:
     parser.add_argument('--expect-cloud-run-traffic', action='append', default=[], metavar='SERVICE=REVISION')
     parser.add_argument('--k8s-state', type=Path, help='Offline Kubernetes state JSON fixture.')
     parser.add_argument('--cloud-run-state', type=Path, help='Offline Cloud Run state JSON fixture.')
+    parser.add_argument('--candidate-acceptance-manifest', type=Path)
+    parser.add_argument('--candidate-acceptance-evidence', type=Path)
+    parser.add_argument('--candidate-status-output', type=Path)
     parser.add_argument('--now', help='ISO timestamp used by tests for age calculations.')
     args = parser.parse_args()
 
@@ -71,6 +74,7 @@ def main() -> int:
     namespace = args.namespace or f'{args.env}-omi-backend'
     findings: list[Finding] = []
     sections: list[str] = []
+    candidate_tracker: dict[str, Any] | None = None
 
     if include_gke:
         k8s_state = load_json(args.k8s_state) if args.k8s_state else fetch_k8s_state(namespace)
@@ -111,6 +115,24 @@ def main() -> int:
         sections.append(section)
         findings.extend(cloud_findings)
 
+    if args.candidate_acceptance_manifest or args.candidate_acceptance_evidence:
+        if not args.candidate_acceptance_manifest or not args.candidate_acceptance_evidence:
+            print('candidate acceptance manifest and evidence must be supplied together', file=sys.stderr)
+            return 2
+        candidate_tracker = candidate_acceptance_tracker(
+            manifest_path=args.candidate_acceptance_manifest,
+            evidence_path=args.candidate_acceptance_evidence,
+        )
+        section, candidate_findings = render_candidate_acceptance_report(candidate_tracker)
+        sections.append(section)
+        findings.extend(candidate_findings)
+
+    if args.candidate_status_output:
+        if candidate_tracker is None:
+            print('--candidate-status-output requires candidate acceptance manifest and evidence', file=sys.stderr)
+            return 2
+        write_candidate_tracker(args.candidate_status_output, candidate_tracker)
+
     print('\n\n'.join(sections))
     if findings:
         print('\nFindings')
@@ -118,6 +140,127 @@ def main() -> int:
             print(f'- {finding.severity} [{finding.scope}] {finding.message}')
 
     return 1 if any(f.severity == 'FAIL' for f in findings) else 0
+
+
+def candidate_acceptance_tracker(*, manifest_path: Path, evidence_path: Path) -> dict[str, Any]:
+    """Normalize only bounded candidate outcomes for deployment tracking artifacts."""
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding='utf-8'))
+        services = manifest.get('services') if isinstance(manifest, Mapping) else None
+        if manifest.get('schema_version') != 1 or not isinstance(services, Mapping):
+            raise ValueError
+        expected = {
+            service: value.get('contract')
+            for service, value in services.items()
+            if isinstance(service, str) and isinstance(value, Mapping) and isinstance(value.get('contract'), str)
+        }
+        if not expected or len(expected) != len(services):
+            raise ValueError
+    except (OSError, ValueError, json.JSONDecodeError, AttributeError):
+        return {
+            'schema_version': 1,
+            'status': 'FAIL',
+            'failed_contract_category': 'configuration',
+            'checks': [],
+        }
+
+    try:
+        evidence = json.loads(evidence_path.read_text(encoding='utf-8'))
+    except FileNotFoundError:
+        return {
+            'schema_version': 1,
+            'status': 'NOT_RUN',
+            'failed_contract_category': None,
+            'checks': [
+                {'service': service, 'contract': contract, 'status': 'NOT_RUN'}
+                for service, contract in sorted(expected.items())
+            ],
+        }
+    except (OSError, json.JSONDecodeError):
+        return {
+            'schema_version': 1,
+            'status': 'FAIL',
+            'failed_contract_category': 'configuration',
+            'checks': [],
+        }
+
+    checks = evidence.get('checks') if isinstance(evidence, Mapping) else None
+    evidence_status = evidence.get('status') if isinstance(evidence, Mapping) else None
+    normalized: list[dict[str, str]] = []
+    if not isinstance(checks, list):
+        checks = []
+    for raw_check in checks:
+        if not isinstance(raw_check, Mapping):
+            continue
+        service = raw_check.get('service')
+        contract = raw_check.get('contract')
+        status = raw_check.get('status')
+        if (
+            isinstance(service, str)
+            and isinstance(contract, str)
+            and isinstance(status, str)
+            and status in {'PASS', 'FAIL', 'NOT_RUN'}
+        ):
+            normalized.append({'service': service, 'contract': contract, 'status': status})
+    expected_pairs = {(service, contract) for service, contract in expected.items()}
+    actual_pairs = {(check['service'], check['contract']) for check in normalized}
+    duplicate_pairs = len(actual_pairs) != len(normalized)
+    if actual_pairs != expected_pairs or duplicate_pairs:
+        return {
+            'schema_version': 1,
+            'status': 'FAIL',
+            'failed_contract_category': 'configuration',
+            'checks': normalized,
+        }
+    failed = next((check['contract'] for check in normalized if check['status'] == 'FAIL'), None)
+    expected_status = 'PASS' if all(check['status'] == 'PASS' for check in normalized) else 'FAIL'
+    if evidence_status != expected_status:
+        return {
+            'schema_version': 1,
+            'status': 'FAIL',
+            'failed_contract_category': 'configuration',
+            'checks': normalized,
+        }
+    return {
+        'schema_version': 1,
+        'status': expected_status,
+        'failed_contract_category': failed,
+        'checks': sorted(normalized, key=lambda check: check['service']),
+    }
+
+
+def render_candidate_acceptance_report(tracker: Mapping[str, Any]) -> tuple[str, list[Finding]]:
+    lines = [
+        'Cloud Run candidate acceptance',
+        '| Service | Contract | Status |',
+        '|---|---|---|',
+    ]
+    findings: list[Finding] = []
+    checks = tracker.get('checks')
+    if not isinstance(checks, list):
+        checks = []
+    for check in checks:
+        if not isinstance(check, Mapping):
+            continue
+        service = str(check.get('service') or '-')
+        contract = str(check.get('contract') or '-')
+        status = str(check.get('status') or 'FAIL')
+        lines.append(f'| `{service}` | `{contract}` | {status} |')
+        if status == 'FAIL':
+            findings.append(Finding('FAIL', service, f'candidate contract {contract} failed before traffic promotion'))
+    status = str(tracker.get('status') or 'FAIL')
+    failed_category = tracker.get('failed_contract_category')
+    lines.extend(['', f'Overall candidate status: **{status}**'])
+    if isinstance(failed_category, str):
+        lines.append(f'Failed contract category: `{failed_category}`')
+    if status == 'FAIL' and not findings:
+        findings.append(Finding('FAIL', 'candidate-acceptance', 'candidate acceptance evidence is invalid'))
+    return '\n'.join(lines), findings
+
+
+def write_candidate_tracker(path: Path, tracker: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(tracker, indent=2, sort_keys=True) + '\n', encoding='utf-8')
 
 
 def render_gke_report(

--- a/backend/scripts/firestore_query_coverage.py
+++ b/backend/scripts/firestore_query_coverage.py
@@ -19,7 +19,7 @@ import json
 import sys
 from dataclasses import dataclass, field
 from datetime import date
-from pathlib import Path
+from pathlib import Path, PurePath
 from typing import Any, Iterable, Mapping
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -32,6 +32,11 @@ BASELINE_PATH = BACKEND_ROOT / 'scripts' / 'firestore_query_coverage_baseline.js
 WAIVERS_PATH = BACKEND_ROOT / 'scripts' / 'firestore_query_coverage_waivers.json'
 QUERY_SPEC_SOURCE = Path('backend/database/firestore_index_registry.py')
 NON_SERVING_SEGMENTS = {'tests', 'scripts', 'migrations', 'migration'}
+
+
+def canonical_source_path(path: PurePath) -> str:
+    """Return a repository-relative source path stable across host platforms."""
+    return path.as_posix()
 
 
 @dataclass(frozen=True)
@@ -357,7 +362,7 @@ def inventory(*, waiver_ids: set[str]) -> list[QueryShape]:
         constants = _module_constants(tree)
         non_serving_scope = _non_serving_scope(relative)
         module_analyzer = FunctionQueryAnalyzer(
-            source=str(relative),
+            source=canonical_source_path(relative),
             symbol='<module>',
             constants=constants,
             non_serving_scope=non_serving_scope,
@@ -370,7 +375,7 @@ def inventory(*, waiver_ids: set[str]) -> list[QueryShape]:
             if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
                 continue
             analyzer = FunctionQueryAnalyzer(
-                source=str(relative),
+                source=canonical_source_path(relative),
                 symbol=node.name,
                 constants=constants,
                 non_serving_scope=non_serving_scope,
@@ -386,7 +391,7 @@ def inventory(*, waiver_ids: set[str]) -> list[QueryShape]:
             0,
         )
         shape = QueryShape(
-            source=str(QUERY_SPEC_SOURCE),
+            source=canonical_source_path(QUERY_SPEC_SOURCE),
             symbol=spec.identifier,
             line=line,
             collection_group=spec.collection_group,

--- a/backend/scripts/reconcile_firestore_indexes.py
+++ b/backend/scripts/reconcile_firestore_indexes.py
@@ -8,6 +8,7 @@ import json
 import subprocess
 import sys
 import time
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable, Iterable, Mapping
 
@@ -33,6 +34,15 @@ _GCLOUD_FIELD_CONFIGS = {
     'DESCENDING': 'order=descending',
     'CONTAINS': 'array-config=contains',
 }
+
+
+@dataclass(frozen=True)
+class LiveIndex:
+    """One Firestore Admin API resource, retained without response-shape aliases."""
+
+    resource_name: str
+    signature: IndexSignature
+    state: str
 
 
 def _collection_group_from_resource_name(index: Mapping[str, Any]) -> str:
@@ -134,13 +144,8 @@ def gcloud_create_index_command(*, project: str, database: str, signature: Index
     return [*command, '--quiet']
 
 
-def list_live_indexes(
-    *,
-    project: str,
-    database: str,
-    include_implicit_document_id_alias: bool = True,
-    runner: CommandRunner = subprocess.run,
-) -> dict[IndexSignature, str]:
+def list_live_indexes(*, project: str, database: str, runner: CommandRunner = subprocess.run) -> list[LiveIndex]:
+    """Read live Admin API resources without normalizing distinct index shapes."""
     command = [
         'gcloud',
         'firestore',
@@ -160,7 +165,7 @@ def list_live_indexes(
         raise RuntimeError('Firestore composite-index listing did not return JSON') from exc
     if not isinstance(payload, list):
         raise RuntimeError('Firestore composite-index listing did not return a list')
-    states: dict[IndexSignature, str] = {}
+    live_indexes: list[LiveIndex] = []
     for index in payload:
         if not isinstance(index, Mapping):
             continue
@@ -168,20 +173,70 @@ def list_live_indexes(
             signature = _index_signature(index)
         except ValueError:
             continue
+        resource_name = index.get('name')
+        if not isinstance(resource_name, str) or not resource_name:
+            continue
         state = index.get('state')
-        states[signature] = state if isinstance(state, str) else 'UNKNOWN'
-        # Firestore Admin API output includes the implicit terminal document-ID
-        # order for ordinary indexes. Preserve the historic compatibility alias
-        # outside dev provisioning, but never let it prove an exact manifest
-        # signature before a create-and-wait reconciliation.
-        if (
-            include_implicit_document_id_alias
-            and len(signature[2]) > 1
-            and signature[2][-1][0] == '__name__'
-            and signature[2][-1][1] == signature[2][-2][1]
-            and signature[2][-1][1] in {'ASCENDING', 'DESCENDING'}
-        ):
-            states[(signature[0], signature[1], signature[2][:-1])] = states[signature]
+        live_indexes.append(LiveIndex(resource_name=resource_name, signature=signature, state=state or 'UNKNOWN'))
+    return live_indexes
+
+
+def expected_index_resource_prefix(*, project: str, database: str, signature: IndexSignature) -> str:
+    collection_group = signature[0]
+    return f'projects/{project}/databases/{database}/collectionGroups/{collection_group}/indexes/'
+
+
+def _matches_expected_resource_identity(
+    live_index: LiveIndex, *, project: str, database: str, signature: IndexSignature
+) -> bool:
+    prefix = expected_index_resource_prefix(project=project, database=database, signature=signature)
+    identifier = live_index.resource_name.removeprefix(prefix)
+    return live_index.resource_name.startswith(prefix) and bool(identifier) and '/' not in identifier
+
+
+def _implicit_terminal_document_id_alias(signature: IndexSignature) -> IndexSignature | None:
+    """Return the historic Firebase-manifest shape for an Admin API implicit terminal order."""
+    fields = signature[2]
+    if (
+        len(fields) > 1
+        and fields[-1][0] == '__name__'
+        and fields[-1][1] == fields[-2][1]
+        and fields[-1][1] in {'ASCENDING', 'DESCENDING'}
+    ):
+        return (signature[0], signature[1], fields[:-1])
+    return None
+
+
+def expected_index_states(
+    *,
+    expected: Iterable[IndexSignature],
+    live_indexes: Iterable[LiveIndex],
+    project: str,
+    database: str,
+    allow_implicit_terminal_document_id_alias: bool = False,
+) -> dict[IndexSignature, str]:
+    """Return exact Admin API readiness states, failing closed on any ambiguity."""
+    states: dict[IndexSignature, str] = {}
+    inventory = list(live_indexes)
+    for signature in set(expected):
+        matches = [
+            index
+            for index in inventory
+            if (
+                index.signature == signature
+                or (
+                    allow_implicit_terminal_document_id_alias
+                    and _implicit_terminal_document_id_alias(index.signature) == signature
+                )
+            )
+            and _matches_expected_resource_identity(index, project=project, database=database, signature=signature)
+        ]
+        if not matches:
+            states[signature] = 'MISSING'
+        elif len(matches) != 1:
+            states[signature] = 'AMBIGUOUS'
+        else:
+            states[signature] = matches[0].state
     return states
 
 
@@ -194,11 +249,20 @@ def format_signature(signature: IndexSignature) -> str:
 def missing_index_signatures(
     *,
     expected: Iterable[IndexSignature],
-    states: Mapping[IndexSignature, str],
+    live_indexes: Iterable[LiveIndex],
+    project: str,
+    database: str,
+    allow_implicit_terminal_document_id_alias: bool = False,
 ) -> set[IndexSignature]:
     """Return manifest requirements absent from the Firestore Admin API inventory."""
-
-    return set(expected).difference(states)
+    states = expected_index_states(
+        expected=expected,
+        live_indexes=live_indexes,
+        project=project,
+        database=database,
+        allow_implicit_terminal_document_id_alias=allow_implicit_terminal_document_id_alias,
+    )
+    return {signature for signature, state in states.items() if state == 'MISSING'}
 
 
 def provision_missing_indexes(
@@ -212,12 +276,13 @@ def provision_missing_indexes(
 
     missing = missing_index_signatures(
         expected=expected,
-        states=list_live_indexes(
+        live_indexes=list_live_indexes(
             project=project,
             database=database,
-            include_implicit_document_id_alias=False,
             runner=runner,
         ),
+        project=project,
+        database=database,
     )
     for signature in sorted(missing):
         result = runner(
@@ -239,7 +304,7 @@ def wait_for_indexes(
     database: str,
     timeout_seconds: float,
     poll_interval_seconds: float,
-    include_implicit_document_id_alias: bool = True,
+    allow_implicit_terminal_document_id_alias: bool = False,
     runner: CommandRunner = subprocess.run,
     sleep: Callable[[float], None] = time.sleep,
     monotonic: Callable[[], float] = time.monotonic,
@@ -251,11 +316,16 @@ def wait_for_indexes(
     expected_set = set(expected)
     deadline = monotonic() + timeout_seconds
     while True:
-        states = list_live_indexes(
+        states = expected_index_states(
+            expected=expected_set,
+            live_indexes=list_live_indexes(
+                project=project,
+                database=database,
+                runner=runner,
+            ),
             project=project,
             database=database,
-            include_implicit_document_id_alias=include_implicit_document_id_alias,
-            runner=runner,
+            allow_implicit_terminal_document_id_alias=allow_implicit_terminal_document_id_alias,
         )
         pending = {
             signature: states.get(signature, 'MISSING')
@@ -289,13 +359,18 @@ def reconcile(
     manifest = verify_manifest_source(manifest_path)
     expected = expected_index_signatures(manifest)
     if dry_run:
-        states = list_live_indexes(
+        live_indexes = list_live_indexes(
             project=project,
             database=database,
-            include_implicit_document_id_alias=not provision_missing,
             runner=runner,
         )
-        missing = missing_index_signatures(expected=expected, states=states)
+        missing = missing_index_signatures(
+            expected=expected,
+            live_indexes=live_indexes,
+            project=project,
+            database=database,
+            allow_implicit_terminal_document_id_alias=not provision_missing,
+        )
         if provision_missing:
             for signature in sorted(missing):
                 print(f'Firestore index provisioning dry run: would create {format_signature(signature)}')
@@ -312,7 +387,7 @@ def reconcile(
         database=database,
         timeout_seconds=timeout_seconds,
         poll_interval_seconds=poll_interval_seconds,
-        include_implicit_document_id_alias=not provision_missing,
+        allow_implicit_terminal_document_id_alias=not provision_missing,
         runner=runner,
         sleep=sleep,
         monotonic=monotonic,

--- a/backend/scripts/render_backend_runtime_env.py
+++ b/backend/scripts/render_backend_runtime_env.py
@@ -20,6 +20,10 @@ def _as_config_dict(value: object) -> ConfigDict | None:
 def main() -> int:
     parser = argparse.ArgumentParser(description='Render backend Cloud Run runtime env from the manifest.')
     parser.add_argument('--env', choices=('dev', 'prod'), required=True)
+    parser.add_argument(
+        '--job',
+        help='render only this Cloud Run job and the shared network flags; services remain full-environment only',
+    )
     parser.add_argument('--manifest', type=Path, default=DEFAULT_MANIFEST)
     args = parser.parse_args()
 
@@ -28,27 +32,48 @@ def main() -> int:
     env_config = _as_config_dict(environments[args.env]) or {}
     cloud_run = _as_config_dict(env_config['cloud_run']) or {}
 
-    network = _as_config_dict(cloud_run.get('network')) or {}
-    _emit_output('cloud_run_flags', _render_flags(_as_config_dict(network.get('flags')) or {}))
-    services = _as_config_dict(cloud_run.get('services')) or {}
-    for service, raw_service_config in services.items():
-        service_config = _as_config_dict(raw_service_config)
-        if service_config is None:
-            raise ValueError(f'Cloud Run service {service} must be a mapping')
-        output_prefix = _output_prefix(service)
-        _emit_output(f'{output_prefix}_env_vars', _render_env_vars(service_config.get('env', {})))
-        _emit_output(f'{output_prefix}_secrets', _render_secrets(service_config.get('secrets', {})))
-        _emit_output(f'{output_prefix}_secret_names', _render_secret_names(service_config.get('secrets', {})))
     jobs = _as_config_dict(cloud_run.get('jobs')) or {}
-    for job, raw_job_config in jobs.items():
+    selected_jobs = jobs
+    if args.job:
+        raw_job_config = jobs.get(args.job)
+        if raw_job_config is None:
+            raise ValueError(f'unknown Cloud Run job {args.job!r} for environment {args.env}')
+        selected_jobs = {args.job: raw_job_config}
+
+    # Render everything before emitting output. A selected job with an invalid
+    # contract must fail without leaving a partial GITHUB_OUTPUT file behind.
+    rendered_outputs: list[tuple[str, str]] = []
+    network = _as_config_dict(cloud_run.get('network')) or {}
+    rendered_outputs.append(('cloud_run_flags', _render_flags(_as_config_dict(network.get('flags')) or {})))
+    services = _as_config_dict(cloud_run.get('services')) or {}
+    if not args.job:
+        for service, raw_service_config in services.items():
+            service_config = _as_config_dict(raw_service_config)
+            if service_config is None:
+                raise ValueError(f'Cloud Run service {service} must be a mapping')
+            output_prefix = _output_prefix(service)
+            rendered_outputs.extend(
+                (
+                    (f'{output_prefix}_env_vars', _render_env_vars(service_config.get('env', {}))),
+                    (f'{output_prefix}_secrets', _render_secrets(service_config.get('secrets', {}))),
+                    (f'{output_prefix}_secret_names', _render_secret_names(service_config.get('secrets', {}))),
+                )
+            )
+    for job, raw_job_config in selected_jobs.items():
         job_config = _as_config_dict(raw_job_config)
         if job_config is None:
             raise ValueError(f'Cloud Run job {job} must be a mapping')
         output_prefix = _output_prefix(job)
-        _emit_output(f'{output_prefix}_flags', _render_flags(_as_config_dict(job_config.get('flags')) or {}))
-        _emit_output(f'{output_prefix}_env_vars', _render_env_vars(job_config.get('env', {})))
-        _emit_output(f'{output_prefix}_secrets', _render_secrets(job_config.get('secrets', {})))
-        _emit_output(f'{output_prefix}_secret_names', _render_secret_names(job_config.get('secrets', {})))
+        rendered_outputs.extend(
+            (
+                (f'{output_prefix}_flags', _render_flags(_as_config_dict(job_config.get('flags')) or {})),
+                (f'{output_prefix}_env_vars', _render_env_vars(job_config.get('env', {}))),
+                (f'{output_prefix}_secrets', _render_secrets(job_config.get('secrets', {}))),
+                (f'{output_prefix}_secret_names', _render_secret_names(job_config.get('secrets', {}))),
+            )
+        )
+    for name, value in rendered_outputs:
+        _emit_output(name, value)
     return 0
 
 

--- a/backend/scripts/run_dev_candidate_acceptance.py
+++ b/backend/scripts/run_dev_candidate_acceptance.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""Run source-owned smoke commands against exact no-traffic Cloud Run candidate URLs.
+
+The evidence report deliberately contains only service names, bounded contract
+categories, and outcomes. Candidate URLs, identity tokens, request data, and
+subprocess output never enter the report or workflow logs from this runner.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+from urllib.parse import urlparse
+
+ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_MANIFEST = ROOT / 'backend/deploy/dev_candidate_acceptance.json'
+IDENTITY_TOKEN_ENV = 'CLOUD_RUN_IDENTITY_TOKEN'
+
+
+@dataclass(frozen=True)
+class CandidateCheck:
+    service: str
+    contract: str
+    command: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class CheckOutcome:
+    service: str
+    contract: str
+    status: str
+
+
+def _absolute_https_url(value: str) -> str:
+    parsed = urlparse(value)
+    if parsed.scheme != 'https' or not parsed.netloc or value != value.strip():
+        raise ValueError('candidate URL must be an absolute HTTPS URL')
+    return value.rstrip('/')
+
+
+def load_manifest(path: Path) -> list[CandidateCheck]:
+    try:
+        document = json.loads(path.read_text(encoding='utf-8'))
+    except (OSError, json.JSONDecodeError) as error:
+        raise ValueError('candidate acceptance manifest is unreadable') from error
+    if not isinstance(document, Mapping) or document.get('schema_version') != 1:
+        raise ValueError('candidate acceptance manifest has an unsupported schema')
+    services = document.get('services')
+    if not isinstance(services, Mapping) or not services:
+        raise ValueError('candidate acceptance manifest must contain services')
+    checks: list[CandidateCheck] = []
+    for service, raw_check in sorted(services.items()):
+        if not isinstance(service, str) or not service or not isinstance(raw_check, Mapping):
+            raise ValueError('candidate acceptance manifest contains an invalid service entry')
+        contract = raw_check.get('contract')
+        command = raw_check.get('command')
+        if (
+            not isinstance(contract, str)
+            or not contract
+            or not isinstance(command, list)
+            or not command
+            or not all(isinstance(part, str) and part for part in command)
+            or '{base_url}' not in command
+        ):
+            raise ValueError(f'candidate acceptance manifest has an invalid command for {service}')
+        checks.append(CandidateCheck(service=service, contract=contract, command=tuple(command)))
+    return checks
+
+
+def parse_candidate_urls(values: Sequence[str], *, expected_services: set[str]) -> dict[str, str]:
+    urls: dict[str, str] = {}
+    for value in values:
+        service, separator, raw_url = value.partition('=')
+        if not separator or service not in expected_services or service in urls:
+            raise ValueError('candidate URL inputs must map every declared service exactly once')
+        urls[service] = _absolute_https_url(raw_url)
+    if set(urls) != expected_services:
+        raise ValueError('candidate URL inputs must map every declared service exactly once')
+    return urls
+
+
+def mint_cloud_run_identity_token(*, audience: str) -> str:
+    result = subprocess.run(
+        ['gcloud', 'auth', 'print-identity-token', f'--audiences={audience}'],
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    token = result.stdout.strip()
+    if result.returncode != 0 or not token or len(token) > 8192:
+        raise RuntimeError('candidate identity-token acquisition failed')
+    return token
+
+
+def run_check(check: CandidateCheck, *, base_url: str, audience: str) -> CheckOutcome:
+    identity_token = ''
+    try:
+        identity_token = mint_cloud_run_identity_token(audience=audience)
+        environment = dict(os.environ)
+        environment[IDENTITY_TOKEN_ENV] = identity_token
+        command = [part.replace('{base_url}', base_url) for part in check.command]
+        result = subprocess.run(
+            command,
+            cwd=ROOT,
+            check=False,
+            capture_output=True,
+            text=True,
+            env=environment,
+        )
+        return CheckOutcome(
+            service=check.service, contract=check.contract, status='PASS' if result.returncode == 0 else 'FAIL'
+        )
+    except (OSError, RuntimeError):
+        return CheckOutcome(service=check.service, contract=check.contract, status='FAIL')
+    finally:
+        identity_token = ''
+
+
+def evidence_document(outcomes: Sequence[CheckOutcome]) -> dict[str, Any]:
+    status = 'PASS' if outcomes and all(outcome.status == 'PASS' for outcome in outcomes) else 'FAIL'
+    return {
+        'schema_version': 1,
+        'status': status,
+        'checks': [
+            {'service': outcome.service, 'contract': outcome.contract, 'status': outcome.status} for outcome in outcomes
+        ],
+    }
+
+
+def write_evidence(path: Path, outcomes: Sequence[CheckOutcome]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(evidence_document(outcomes), indent=2, sort_keys=True) + '\n', encoding='utf-8')
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--manifest', type=Path, default=DEFAULT_MANIFEST)
+    parser.add_argument('--candidate', action='append', default=[], metavar='SERVICE=URL')
+    parser.add_argument('--audience', action='append', default=[], metavar='SERVICE=URL')
+    parser.add_argument('--evidence-path', type=Path, required=True)
+    args = parser.parse_args(argv)
+    outcomes: list[CheckOutcome] = []
+    try:
+        checks = load_manifest(args.manifest)
+        expected_services = {check.service for check in checks}
+        candidate_urls = parse_candidate_urls(args.candidate, expected_services=expected_services)
+        audiences = parse_candidate_urls(args.audience, expected_services=expected_services)
+        for index, check in enumerate(checks):
+            outcome = run_check(check, base_url=candidate_urls[check.service], audience=audiences[check.service])
+            outcomes.append(outcome)
+            if outcome.status != 'PASS':
+                outcomes.extend(
+                    CheckOutcome(service=skipped.service, contract=skipped.contract, status='NOT_RUN')
+                    for skipped in checks[index + 1 :]
+                )
+                break
+    except ValueError:
+        outcomes.append(CheckOutcome(service='candidate-acceptance', contract='configuration', status='FAIL'))
+    finally:
+        write_evidence(args.evidence_path, outcomes)
+    document = evidence_document(outcomes)
+    print(
+        f"Candidate acceptance {document['status']}: "
+        + ', '.join(f'{outcome.service}/{outcome.contract}={outcome.status}' for outcome in outcomes)
+    )
+    return 0 if document['status'] == 'PASS' else 1
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/backend/scripts/smoke_cloud_run_health.py
+++ b/backend/scripts/smoke_cloud_run_health.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Probe one tagged Cloud Run candidate's health contract without logging credentials or response bodies."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import time
+from dataclasses import dataclass
+from typing import Callable
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlparse
+from urllib.request import Request, urlopen
+
+
+@dataclass(frozen=True)
+class HealthSmokeConfig:
+    base_url: str
+    cloud_run_identity_token: str
+    timeout_seconds: float
+    attempts: int
+    retry_delay_seconds: float
+
+
+def _validate_base_url(value: str) -> str:
+    base_url = value.rstrip('/')
+    parsed = urlparse(base_url)
+    if parsed.scheme not in {'http', 'https'} or not parsed.netloc:
+        raise ValueError('base_url must be an absolute HTTP(S) URL')
+    return base_url
+
+
+def run_smoke(
+    config: HealthSmokeConfig,
+    *,
+    http_open: Callable = urlopen,
+    sleep: Callable[[float], None] = time.sleep,
+) -> int:
+    if config.attempts <= 0:
+        raise ValueError('attempts must be positive')
+    if config.timeout_seconds <= 0:
+        raise ValueError('timeout_seconds must be positive')
+    if config.retry_delay_seconds < 0:
+        raise ValueError('retry_delay_seconds must not be negative')
+    url = f'{_validate_base_url(config.base_url)}/v1/health'
+    headers = {'Accept': 'application/json'}
+    if config.cloud_run_identity_token:
+        headers['X-Serverless-Authorization'] = f'Bearer {config.cloud_run_identity_token}'
+    status: int | None = None
+    for attempt in range(config.attempts):
+        request = Request(url, method='GET', headers=headers)
+        try:
+            with http_open(request, timeout=config.timeout_seconds) as response:
+                status = int(response.status)
+        except HTTPError as error:
+            status = error.code
+        except (URLError, OSError, TimeoutError) as error:
+            if attempt + 1 == config.attempts:
+                raise RuntimeError('Cloud Run health smoke could not reach the candidate') from error
+        if status is not None and 200 <= status < 300:
+            print(f'Cloud Run health smoke passed (HTTP {status})')
+            return status
+        if attempt + 1 < config.attempts:
+            sleep(config.retry_delay_seconds)
+    raise RuntimeError(f'Cloud Run health smoke received HTTP {status or "unreachable"}')
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--base-url', required=True)
+    parser.add_argument('--cloud-run-identity-token-env', default='')
+    parser.add_argument('--timeout-seconds', type=float, default=30.0)
+    parser.add_argument('--attempts', type=int, default=3)
+    parser.add_argument('--retry-delay-seconds', type=float, default=2.0)
+    args = parser.parse_args()
+    identity_token = os.environ.get(args.cloud_run_identity_token_env, '').strip()
+    if args.cloud_run_identity_token_env and not identity_token:
+        print(
+            f'ERROR: required Cloud Run identity token environment variable {args.cloud_run_identity_token_env} is empty',
+            file=sys.stderr,
+        )
+        return 1
+    try:
+        run_smoke(
+            HealthSmokeConfig(
+                base_url=args.base_url,
+                cloud_run_identity_token=identity_token,
+                timeout_seconds=args.timeout_seconds,
+                attempts=args.attempts,
+                retry_delay_seconds=args.retry_delay_seconds,
+            )
+        )
+    except (RuntimeError, ValueError) as error:
+        print(f'ERROR: {error}', file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/backend/scripts/smoke_what_matters_now.py
+++ b/backend/scripts/smoke_what_matters_now.py
@@ -24,6 +24,7 @@ class SmokeConfig:
     base_url: str
     admin_key: str
     timeout_seconds: float
+    cloud_run_identity_token: str = ''
 
 
 def _validate_base_url(value: str) -> str:
@@ -36,13 +37,16 @@ def _validate_base_url(value: str) -> str:
 
 def run_smoke(config: SmokeConfig, *, http_open: Callable = urlopen) -> int:
     url = f'{_validate_base_url(config.base_url)}/v1/what-matters-now'
+    headers = {
+        'Accept': 'application/json',
+        'Authorization': f'Bearer {config.admin_key}{WHAT_MATTERS_NOW_SMOKE_UID}',
+    }
+    if config.cloud_run_identity_token:
+        headers['X-Serverless-Authorization'] = f'Bearer {config.cloud_run_identity_token}'
     request = Request(
         url,
         method='GET',
-        headers={
-            'Accept': 'application/json',
-            'Authorization': f'Bearer {config.admin_key}{WHAT_MATTERS_NOW_SMOKE_UID}',
-        },
+        headers=headers,
     )
     try:
         with http_open(request, timeout=config.timeout_seconds) as response:
@@ -62,11 +66,23 @@ def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument('--base-url', required=True)
     parser.add_argument('--admin-key-env', default='ADMIN_KEY')
+    parser.add_argument(
+        '--cloud-run-identity-token-env',
+        default='',
+        help='optional environment variable holding an OIDC token for a tagged Cloud Run candidate',
+    )
     parser.add_argument('--timeout-seconds', type=float, default=30.0)
     args = parser.parse_args()
     admin_key = os.environ.get(args.admin_key_env, '').strip()
     if not admin_key:
         print(f'ERROR: required admin-key environment variable {args.admin_key_env} is empty', file=sys.stderr)
+        return 1
+    identity_token = os.environ.get(args.cloud_run_identity_token_env, '').strip()
+    if args.cloud_run_identity_token_env and not identity_token:
+        print(
+            f'ERROR: required Cloud Run identity token environment variable {args.cloud_run_identity_token_env} is empty',
+            file=sys.stderr,
+        )
         return 1
     try:
         run_smoke(
@@ -74,6 +90,7 @@ def main() -> int:
                 base_url=args.base_url,
                 admin_key=admin_key,
                 timeout_seconds=args.timeout_seconds,
+                cloud_run_identity_token=identity_token,
             )
         )
     except (RuntimeError, ValueError) as exc:

--- a/backend/scripts/verify_dev_backend_deployment.py
+++ b/backend/scripts/verify_dev_backend_deployment.py
@@ -142,14 +142,27 @@ def collect_documents(commands: Mapping[str, Sequence[str]]) -> dict[str, Mappin
     return documents
 
 
-def evaluate(expectation: DeploymentExpectation, documents: Mapping[str, Mapping[str, Any]]) -> list[str]:
+def evaluate(
+    expectation: DeploymentExpectation,
+    documents: Mapping[str, Mapping[str, Any]],
+    *,
+    require_serving_traffic: bool = True,
+) -> list[str]:
     errors: list[str] = []
     for service, expected_revision in expectation.revisions.items():
         document = documents.get(f'cloud_run/{service}')
         if document is None:
             errors.append(f'cloud_run/{service}: result missing')
         else:
-            errors.extend(evaluate_cloud_run_service(service, expected_revision, expectation.image, document))
+            errors.extend(
+                evaluate_cloud_run_service(
+                    service,
+                    expected_revision,
+                    expectation.image,
+                    document,
+                    require_serving_traffic=require_serving_traffic,
+                )
+            )
     for key, evaluator in (
         ('gke/deployment', evaluate_listener_deployment),
         ('gke/service', evaluate_listener_service),
@@ -164,7 +177,12 @@ def evaluate(expectation: DeploymentExpectation, documents: Mapping[str, Mapping
 
 
 def evaluate_cloud_run_service(
-    service: str, expected_revision: str, expected_image: str, document: Mapping[str, Any]
+    service: str,
+    expected_revision: str,
+    expected_image: str,
+    document: Mapping[str, Any],
+    *,
+    require_serving_traffic: bool = True,
 ) -> list[str]:
     status = _mapping(document.get('status'))
     template_spec = _mapping(_mapping(_mapping(document.get('spec')).get('template')).get('spec'))
@@ -179,7 +197,7 @@ def evaluate_cloud_run_service(
         errors.append(f'cloud_run/{service}: latest ready revision is not {expected_revision}')
     if image != expected_image:
         errors.append(f'cloud_run/{service}: template image is not {expected_image}')
-    if not expected_traffic or _mapping(expected_traffic[0]).get('percent') != 100:
+    if require_serving_traffic and (not expected_traffic or _mapping(expected_traffic[0]).get('percent') != 100):
         errors.append(f'cloud_run/{service}: expected revision does not receive 100% traffic')
     timeout = template_spec.get('timeoutSeconds')
     if not isinstance(timeout, int) or timeout < MIN_CLOUD_RUN_TIMEOUT_SECONDS:
@@ -245,7 +263,11 @@ def evaluate_listener_endpoints(expectation: DeploymentExpectation, document: Ma
 
 
 def evidence(
-    expectation: DeploymentExpectation, documents: Mapping[str, Mapping[str, Any]], errors: Sequence[str]
+    expectation: DeploymentExpectation,
+    documents: Mapping[str, Mapping[str, Any]],
+    errors: Sequence[str],
+    *,
+    require_serving_traffic: bool = True,
 ) -> dict[str, Any]:
     cloud_run: dict[str, dict[str, Any]] = {}
     for service in CLOUD_RUN_SERVICES:
@@ -277,6 +299,7 @@ def evidence(
             'deploy_run_attempt': expectation.deploy_run_attempt,
             'image': expectation.image,
             'revisions': dict(expectation.revisions),
+            'require_serving_traffic': require_serving_traffic,
         },
         'cloud_run': cloud_run,
         'gke_listener': {
@@ -318,6 +341,11 @@ def main() -> int:
     parser.add_argument('--project', required=True)
     parser.add_argument('--region', default='us-central1')
     parser.add_argument('--environment', default='dev')
+    parser.add_argument(
+        '--candidate',
+        action='store_true',
+        help='verify a ready no-traffic candidate revision before promotion',
+    )
     parser.add_argument('--evidence-path', type=Path)
     args = parser.parse_args()
     try:
@@ -332,11 +360,15 @@ def main() -> int:
         commands = build_read_only_commands(expectation)
         assert_commands_are_read_only(commands)
         documents = collect_documents(commands)
-        errors = evaluate(expectation, documents)
+        errors = evaluate(expectation, documents, require_serving_traffic=not args.candidate)
     except (RuntimeError, ValueError) as exc:
         print(f'ERROR: {exc}', file=sys.stderr)
         return 1
-    rendered = json.dumps(evidence(expectation, documents, errors), indent=2, sort_keys=True)
+    rendered = json.dumps(
+        evidence(expectation, documents, errors, require_serving_traffic=not args.candidate),
+        indent=2,
+        sort_keys=True,
+    )
     print(rendered)
     if args.evidence_path:
         args.evidence_path.parent.mkdir(parents=True, exist_ok=True)

--- a/backend/tests/unit/test_deploy_status_report.py
+++ b/backend/tests/unit/test_deploy_status_report.py
@@ -9,8 +9,10 @@ sys.path.insert(0, str(BACKEND_ROOT))
 
 from scripts.deploy_status_report import (
     Finding,
+    candidate_acceptance_tracker,
     load_json,
     parse_expected_traffic,
+    render_candidate_acceptance_report,
     render_cloud_run_report,
     render_gke_report,
 )
@@ -178,3 +180,35 @@ def test_cloud_run_report_uses_state_project_region_when_cli_project_missing() -
 
 def test_secret_key_verifier_reads_expected_keys_without_secret_values() -> None:
     assert expected_keys(FIXTURES / 'backend_secrets_values.yaml') == {'OPENAI_API_KEY', 'SENTINEL_FAKE_ONLY'}
+
+
+def test_candidate_tracker_records_the_failed_contract_without_candidate_url(tmp_path) -> None:
+    manifest = tmp_path / 'manifest.json'
+    evidence = tmp_path / 'evidence.json'
+    manifest.write_text('{"schema_version":1,"services":{"backend":{"contract":"what_matters_now"}}}', encoding='utf-8')
+    evidence.write_text(
+        '{"schema_version":1,"status":"FAIL","checks":[{"service":"backend","contract":"what_matters_now","status":"FAIL"}]}',
+        encoding='utf-8',
+    )
+
+    tracker = candidate_acceptance_tracker(manifest_path=manifest, evidence_path=evidence)
+    report, findings = render_candidate_acceptance_report(tracker)
+
+    assert tracker['status'] == 'FAIL'
+    assert tracker['failed_contract_category'] == 'what_matters_now'
+    assert 'candidate contract what_matters_now failed before traffic promotion' in findings[0].message
+    assert 'candidate.example' not in report
+
+
+def test_candidate_tracker_marks_missing_evidence_not_run(tmp_path) -> None:
+    manifest = tmp_path / 'manifest.json'
+    manifest.write_text('{"schema_version":1,"services":{"backend-sync":{"contract":"health"}}}', encoding='utf-8')
+
+    tracker = candidate_acceptance_tracker(manifest_path=manifest, evidence_path=tmp_path / 'missing.json')
+
+    assert tracker == {
+        'schema_version': 1,
+        'status': 'NOT_RUN',
+        'failed_contract_category': None,
+        'checks': [{'service': 'backend-sync', 'contract': 'health', 'status': 'NOT_RUN'}],
+    }

--- a/backend/tests/unit/test_firestore_query_contract.py
+++ b/backend/tests/unit/test_firestore_query_contract.py
@@ -1,7 +1,7 @@
 import ast
 import json
 from datetime import datetime, timedelta, timezone
-from pathlib import Path
+from pathlib import Path, PurePosixPath, PureWindowsPath
 from types import SimpleNamespace
 
 import pytest
@@ -218,3 +218,13 @@ def test_query_coverage_baseline_tracks_current_raw_and_unsupported_debt():
     report = firestore_query_coverage.report_for(firestore_query_coverage.inventory(waiver_ids=set()))
 
     assert firestore_query_coverage.check_ratchet(report, committed) == []
+
+
+def test_query_source_paths_are_posix_canonical_on_every_host_platform():
+    windows_path = PureWindowsPath('backend\\database\\conversations.py')
+    posix_path = PurePosixPath('backend/database/conversations.py')
+
+    assert firestore_query_coverage.canonical_source_path(windows_path) == 'backend/database/conversations.py'
+    assert firestore_query_coverage.canonical_source_path(
+        windows_path
+    ) == firestore_query_coverage.canonical_source_path(posix_path)

--- a/backend/tests/unit/test_reconcile_firestore_indexes.py
+++ b/backend/tests/unit/test_reconcile_firestore_indexes.py
@@ -9,7 +9,7 @@ from scripts import reconcile_firestore_indexes
 
 
 def _ready_indexes():
-    return [{**index, 'state': 'READY'} for index in firebase_index_manifest()['indexes']]
+    return [_gcloud_live_index(index) for index in firebase_index_manifest()['indexes']]
 
 
 def _gcloud_live_index(index, *, state='READY'):
@@ -120,7 +120,9 @@ def test_live_gcloud_indexes_derive_collection_group_with_explicit_document_id()
     def runner(_command, **_kwargs):
         return SimpleNamespace(returncode=0, stdout=json.dumps([live_index]))
 
-    states = reconcile_firestore_indexes.list_live_indexes(project='dev-project', database='(default)', runner=runner)
+    live_indexes = reconcile_firestore_indexes.list_live_indexes(
+        project='dev-project', database='(default)', runner=runner
+    )
 
     attention_override_signature = (
         'task_attention_overrides',
@@ -134,10 +136,15 @@ def test_live_gcloud_indexes_derive_collection_group_with_explicit_document_id()
     assert attention_override_signature in reconcile_firestore_indexes.expected_index_signatures(
         firebase_index_manifest()
     )
-    assert states[attention_override_signature] == 'READY'
+    assert reconcile_firestore_indexes.expected_index_states(
+        expected={attention_override_signature},
+        live_indexes=live_indexes,
+        project='dev-project',
+        database='(default)',
+    ) == {attention_override_signature: 'READY'}
 
 
-def test_live_gcloud_indexes_alias_implicit_terminal_document_id_by_default():
+def test_live_gcloud_indexes_do_not_alias_implicit_terminal_document_id():
     live_index = {
         'name': 'projects/dev-project/databases/(default)/collectionGroups/task_attention_overrides/indexes/index-id',
         'queryScope': 'COLLECTION',
@@ -152,18 +159,28 @@ def test_live_gcloud_indexes_alias_implicit_terminal_document_id_by_default():
     def runner(_command, **_kwargs):
         return SimpleNamespace(returncode=0, stdout=json.dumps([live_index]))
 
-    states = reconcile_firestore_indexes.list_live_indexes(project='dev-project', database='(default)', runner=runner)
-
-    assert (
-        states[
-            (
-                'task_attention_overrides',
-                'COLLECTION',
-                (('account_generation', 'ASCENDING'), ('expires_at', 'ASCENDING')),
-            )
-        ]
-        == 'READY'
+    live_indexes = reconcile_firestore_indexes.list_live_indexes(
+        project='dev-project', database='(default)', runner=runner
     )
+
+    implicit_signature = (
+        'task_attention_overrides',
+        'COLLECTION',
+        (('account_generation', 'ASCENDING'), ('expires_at', 'ASCENDING')),
+    )
+    assert reconcile_firestore_indexes.expected_index_states(
+        expected={implicit_signature},
+        live_indexes=live_indexes,
+        project='dev-project',
+        database='(default)',
+    ) == {implicit_signature: 'MISSING'}
+    assert reconcile_firestore_indexes.expected_index_states(
+        expected={implicit_signature},
+        live_indexes=live_indexes,
+        project='dev-project',
+        database='(default)',
+        allow_implicit_terminal_document_id_alias=True,
+    ) == {implicit_signature: 'READY'}
 
 
 def test_dev_provisioning_does_not_accept_an_implicit_document_id_alias():
@@ -201,6 +218,37 @@ def test_dev_provisioning_does_not_accept_an_implicit_document_id_alias():
 
     assert missing == expected
     assert commands[1][:5] == ['gcloud', 'firestore', 'indexes', 'composite', 'create']
+
+
+def test_live_index_from_another_resource_identity_does_not_satisfy_the_manifest():
+    signature = (
+        'task_attention_overrides',
+        'COLLECTION',
+        (('account_generation', 'ASCENDING'), ('expires_at', 'ASCENDING')),
+    )
+    live_index = {
+        'name': 'projects/other-project/databases/(default)/collectionGroups/task_attention_overrides/indexes/index-id',
+        'queryScope': 'COLLECTION',
+        'fields': [
+            {'fieldPath': 'account_generation', 'order': 'ASCENDING'},
+            {'fieldPath': 'expires_at', 'order': 'ASCENDING'},
+        ],
+        'state': 'READY',
+    }
+
+    def runner(_command, **_kwargs):
+        return SimpleNamespace(returncode=0, stdout=json.dumps([live_index]))
+
+    live_indexes = reconcile_firestore_indexes.list_live_indexes(
+        project='dev-project', database='(default)', runner=runner
+    )
+
+    assert reconcile_firestore_indexes.expected_index_states(
+        expected={signature},
+        live_indexes=live_indexes,
+        project='dev-project',
+        database='(default)',
+    ) == {signature: 'MISSING'}
 
 
 def test_provisioning_dry_run_only_lists_indexes_and_does_not_write(capsys):

--- a/backend/tests/unit/test_render_backend_runtime_env.py
+++ b/backend/tests/unit/test_render_backend_runtime_env.py
@@ -54,6 +54,33 @@ def test_network_flags_still_required(monkeypatch):
         _MODULE['_render_flags']({'--network': {'env_var': 'CLOUD_RUN_VPC_NETWORK'}})
 
 
+def test_selected_job_renders_only_shared_network_and_named_job_outputs(capsys, monkeypatch):
+    monkeypatch.setenv('CLOUD_RUN_VPC_NETWORK', 'omi-dev-vpc-1')
+    monkeypatch.setenv('CLOUD_RUN_VPC_SUBNET', 'omi-dev-subnet-1')
+    monkeypatch.setattr(
+        'sys.argv',
+        ['render_backend_runtime_env.py', '--env', 'dev', '--job', 'memory-maintenance-job'],
+    )
+
+    assert _MODULE['main']() == 0
+
+    output = capsys.readouterr().out
+    assert 'cloud_run_flags<<' in output
+    assert 'memory_maintenance_job_flags<<' in output
+    assert 'memory_maintenance_job_env_vars<<' in output
+    assert 'backend_env_vars<<' not in output
+    assert 'notifications_job_env_vars<<' not in output
+
+
+def test_selected_job_rejects_unknown_name_without_emitting_partial_output(capsys, monkeypatch):
+    monkeypatch.setattr('sys.argv', ['render_backend_runtime_env.py', '--env', 'dev', '--job', 'unknown-job'])
+
+    with pytest.raises(ValueError, match='unknown Cloud Run job'):
+        _MODULE['main']()
+
+    assert capsys.readouterr().out == ''
+
+
 def test_render_dev_emits_memory_maintenance_job_outputs(capsys, monkeypatch):
     monkeypatch.setenv('CLOUD_RUN_VPC_NETWORK', 'omi-dev-vpc-1')
     monkeypatch.setenv('CLOUD_RUN_VPC_SUBNET', 'omi-us-central1-dev-vpc-1-subnet-1')
@@ -164,6 +191,7 @@ def test_notifications_job_workflow_passes_vpc_vars_and_checkout_sha():
     assert 'CLOUD_RUN_VPC_SUBNET: ${{ vars.CLOUD_RUN_VPC_SUBNET }}' in text
     assert 'git rev-parse --short=7 HEAD' in text
     assert 'short_sha=${GITHUB_SHA::7}' not in text
+    assert 'render_backend_runtime_env.py --env ${{ vars.ENV }} --job notifications-job' in text
     assert 'env_vars_update_strategy: overwrite' not in text
     assert 'secrets_update_strategy: overwrite' not in text
     assert (
@@ -190,3 +218,12 @@ def test_memory_maintenance_job_workflow_passes_vpc_vars_and_checkout_sha():
     assert "id-token: 'write'" not in text
     assert 'git rev-parse --short=7 HEAD' in text
     assert 'short_sha=${GITHUB_SHA::7}' not in text
+    assert 'render_backend_runtime_env.py --env ${{ vars.ENV }} --job memory-maintenance-job' in text
+
+
+def test_auto_dev_memory_maintenance_workflow_selects_only_its_job():
+    workflow = Path(__file__).resolve().parents[3] / '.github/workflows/gcp_memory_maintenance_job_auto_dev.yml'
+
+    assert 'render_backend_runtime_env.py --env dev --job memory-maintenance-job' in workflow.read_text(
+        encoding='utf-8'
+    )

--- a/backend/tests/unit/test_run_dev_candidate_acceptance.py
+++ b/backend/tests/unit/test_run_dev_candidate_acceptance.py
@@ -1,0 +1,164 @@
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+from scripts import run_dev_candidate_acceptance as acceptance
+
+
+def test_checked_in_manifest_declares_exactly_the_dev_cloud_run_candidates():
+    checks = acceptance.load_manifest(acceptance.DEFAULT_MANIFEST)
+
+    assert [(check.service, check.contract) for check in checks] == [
+        ('backend', 'what_matters_now'),
+        ('backend-integration', 'health'),
+        ('backend-sync', 'health'),
+        ('backend-sync-backfill', 'health'),
+    ]
+    assert all('{base_url}' in check.command for check in checks)
+
+
+def test_candidate_urls_require_a_complete_unique_https_mapping():
+    expected = {'backend', 'backend-sync'}
+
+    assert acceptance.parse_candidate_urls(
+        ['backend=https://backend-candidate.example', 'backend-sync=https://sync-candidate.example'],
+        expected_services=expected,
+    ) == {
+        'backend': 'https://backend-candidate.example',
+        'backend-sync': 'https://sync-candidate.example',
+    }
+
+    for values in (
+        ['backend=https://backend-candidate.example'],
+        ['backend=https://backend-candidate.example', 'backend=https://other.example'],
+        ['backend=http://backend-candidate.example', 'backend-sync=https://sync-candidate.example'],
+    ):
+        try:
+            acceptance.parse_candidate_urls(values, expected_services=expected)
+        except ValueError:
+            pass
+        else:
+            raise AssertionError(f'expected invalid candidate map: {values}')
+
+
+def test_candidate_check_passes_oidc_only_to_the_child_environment(monkeypatch):
+    check = acceptance.CandidateCheck(
+        service='backend-sync',
+        contract='health',
+        command=('python3', 'backend/scripts/smoke_cloud_run_health.py', '--base-url', '{base_url}'),
+    )
+    captured = {}
+    monkeypatch.setattr(acceptance, 'mint_cloud_run_identity_token', lambda *, audience: f'token-for:{audience}')
+
+    def fake_run(command, **kwargs):
+        captured['command'] = command
+        captured['environment'] = kwargs['env']
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(acceptance.subprocess, 'run', fake_run)
+
+    outcome = acceptance.run_check(
+        check,
+        base_url='https://candidate.example',
+        audience='https://backend-service.example',
+    )
+
+    assert outcome == acceptance.CheckOutcome(service='backend-sync', contract='health', status='PASS')
+    assert captured['command'][-1] == 'https://candidate.example'
+    assert captured['environment'][acceptance.IDENTITY_TOKEN_ENV] == 'token-for:https://backend-service.example'
+    assert 'token-for:' not in json.dumps(acceptance.evidence_document([outcome]))
+
+
+def test_main_writes_redacted_failed_contract_evidence(monkeypatch, tmp_path, capsys):
+    evidence_path = tmp_path / 'candidate.json'
+    manifest = tmp_path / 'manifest.json'
+    manifest.write_text(
+        json.dumps(
+            {
+                'schema_version': 1,
+                'services': {
+                    'backend': {
+                        'contract': 'what_matters_now',
+                        'command': ['python3', 'backend/scripts/smoke_what_matters_now.py', '--base-url', '{base_url}'],
+                    }
+                },
+            }
+        ),
+        encoding='utf-8',
+    )
+    monkeypatch.setattr(
+        acceptance,
+        'run_check',
+        lambda check, *, base_url, audience: acceptance.CheckOutcome(check.service, check.contract, 'FAIL'),
+    )
+
+    assert (
+        acceptance.main(
+            [
+                '--manifest',
+                str(manifest),
+                '--candidate',
+                'backend=https://candidate.example',
+                '--audience',
+                'backend=https://backend-service.example',
+                '--evidence-path',
+                str(evidence_path),
+            ]
+        )
+        == 1
+    )
+
+    evidence = json.loads(evidence_path.read_text(encoding='utf-8'))
+    assert evidence == {
+        'checks': [{'contract': 'what_matters_now', 'service': 'backend', 'status': 'FAIL'}],
+        'schema_version': 1,
+        'status': 'FAIL',
+    }
+    assert 'candidate.example' not in capsys.readouterr().out
+
+
+def test_failure_marks_later_manifest_contracts_not_run(monkeypatch, tmp_path):
+    evidence_path = tmp_path / 'candidate.json'
+    manifest = tmp_path / 'manifest.json'
+    manifest.write_text(
+        json.dumps(
+            {
+                'schema_version': 1,
+                'services': {
+                    'backend': {'contract': 'what_matters_now', 'command': ['echo', '{base_url}']},
+                    'backend-sync': {'contract': 'health', 'command': ['echo', '{base_url}']},
+                },
+            }
+        ),
+        encoding='utf-8',
+    )
+    monkeypatch.setattr(
+        acceptance,
+        'run_check',
+        lambda check, *, base_url, audience: acceptance.CheckOutcome(check.service, check.contract, 'FAIL'),
+    )
+
+    assert (
+        acceptance.main(
+            [
+                '--manifest',
+                str(manifest),
+                '--candidate',
+                'backend=https://candidate.example',
+                '--candidate',
+                'backend-sync=https://sync.example',
+                '--audience',
+                'backend=https://backend-service.example',
+                '--audience',
+                'backend-sync=https://sync-service.example',
+                '--evidence-path',
+                str(evidence_path),
+            ]
+        )
+        == 1
+    )
+
+    assert json.loads(evidence_path.read_text(encoding='utf-8'))['checks'] == [
+        {'contract': 'what_matters_now', 'service': 'backend', 'status': 'FAIL'},
+        {'contract': 'health', 'service': 'backend-sync', 'status': 'NOT_RUN'},
+    ]

--- a/backend/tests/unit/test_smoke_cloud_run_health.py
+++ b/backend/tests/unit/test_smoke_cloud_run_health.py
@@ -1,0 +1,92 @@
+from types import SimpleNamespace
+from urllib.error import HTTPError
+
+import pytest
+
+from scripts import smoke_cloud_run_health
+
+
+class _Response:
+    status = 204
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+
+def test_health_smoke_uses_serverless_identity_header_and_never_reads_body(capsys):
+    captured = {}
+
+    def http_open(request, timeout):
+        captured['url'] = request.full_url
+        captured['identity'] = request.get_header('X-serverless-authorization')
+        captured['timeout'] = timeout
+        return _Response()
+
+    status = smoke_cloud_run_health.run_smoke(
+        smoke_cloud_run_health.HealthSmokeConfig(
+            base_url='https://candidate.example/',
+            cloud_run_identity_token='identity-token-that-must-not-leak',
+            timeout_seconds=7,
+            attempts=1,
+            retry_delay_seconds=0,
+        ),
+        http_open=http_open,
+    )
+
+    assert status == 204
+    assert captured == {
+        'url': 'https://candidate.example/v1/health',
+        'identity': 'Bearer identity-token-that-must-not-leak',
+        'timeout': 7,
+    }
+    assert 'identity-token' not in capsys.readouterr().out
+
+
+def test_health_smoke_retries_bounded_http_failures_then_succeeds():
+    attempts = []
+    delays = []
+
+    def http_open(_request, timeout):
+        assert timeout == 7
+        attempts.append(1)
+        if len(attempts) == 1:
+            raise HTTPError('https://candidate.example/v1/health', 503, 'unavailable', {}, None)
+        return _Response()
+
+    assert (
+        smoke_cloud_run_health.run_smoke(
+            smoke_cloud_run_health.HealthSmokeConfig(
+                base_url='https://candidate.example',
+                cloud_run_identity_token='',
+                timeout_seconds=7,
+                attempts=2,
+                retry_delay_seconds=1,
+            ),
+            http_open=http_open,
+            sleep=delays.append,
+        )
+        == 204
+    )
+    assert len(attempts) == 2
+    assert delays == [1]
+
+
+def test_health_smoke_fails_when_candidate_never_returns_success():
+    def http_open(_request, timeout):
+        assert timeout == 7
+        raise HTTPError('https://candidate.example/v1/health', 503, 'unavailable', {}, None)
+
+    with pytest.raises(RuntimeError, match='HTTP 503'):
+        smoke_cloud_run_health.run_smoke(
+            smoke_cloud_run_health.HealthSmokeConfig(
+                base_url='https://candidate.example',
+                cloud_run_identity_token='',
+                timeout_seconds=7,
+                attempts=1,
+                retry_delay_seconds=0,
+            ),
+            http_open=http_open,
+        )

--- a/backend/tests/unit/test_smoke_what_matters_now.py
+++ b/backend/tests/unit/test_smoke_what_matters_now.py
@@ -44,6 +44,29 @@ def test_smoke_uses_admin_auth_without_reading_or_reporting_the_response_body(ca
     assert 'private' not in output
 
 
+def test_smoke_keeps_app_auth_and_uses_serverless_identity_when_supplied():
+    captured = {}
+
+    def http_open(request, timeout):
+        assert timeout == 7
+        captured['authorization'] = request.get_header('Authorization')
+        captured['identity'] = request.get_header('X-serverless-authorization')
+        return _Response(200)
+
+    smoke_what_matters_now.run_smoke(
+        smoke_what_matters_now.SmokeConfig(
+            base_url='https://api.omi.dev',
+            admin_key='private-key',
+            timeout_seconds=7,
+            cloud_run_identity_token='identity-token',
+        ),
+        http_open=http_open,
+    )
+
+    assert captured['authorization'] == f'Bearer private-key{WHAT_MATTERS_NOW_SMOKE_UID}'
+    assert captured['identity'] == 'Bearer identity-token'
+
+
 def test_smoke_fails_on_a_backend_5xx_without_exposing_the_response_body():
     def http_open(_request, timeout):
         raise HTTPError('https://api.omi.dev/v1/what-matters-now', 500, 'boom', {}, None)
@@ -80,18 +103,21 @@ def test_main_uses_the_code_owned_fixture_without_a_uid_environment_variable(mon
     )
 
 
-def test_auto_dev_smoke_resolves_the_backend_cloud_run_url_with_existing_auth():
+def test_auto_dev_smoke_uses_the_tagged_candidate_output_with_existing_auth():
     root = Path(__file__).resolve().parents[3]
     workflow = (root / '.github' / 'workflows' / 'gcp_backend_auto_dev.yml').read_text(encoding='utf-8')
 
     assert 'OMI_TASK_INTELLIGENCE_SMOKE_UID' not in workflow
     assert '--secret=ADMIN_KEY' in workflow
-    assert 'BACKEND_URL="$(gcloud run services describe backend' in workflow
-    assert '--project="$PROJECT_ID"' in workflow
-    assert "--region=\"${{ env.REGION }}\"" in workflow
-    assert "--format='value(status.url)')\"" in workflow
-    assert 'test -n "$BACKEND_URL"' in workflow
-    assert 'smoke_what_matters_now.py --base-url "$BACKEND_URL"' in workflow
+    assert 'Capture exact no-traffic candidate URLs' in workflow
+    assert 'resolve_cloud_run_tagged_url.py' in workflow
+    assert '--tag=${{ env.CANDIDATE_TAG }}' in workflow
+    assert 'run_dev_candidate_acceptance.py' in workflow
+    assert '--candidate backend=${{ steps.candidate-urls.outputs.backend_url }}' in workflow
+    assert workflow.index('run_dev_candidate_acceptance.py') < workflow.index(
+        'Shift Cloud Run traffic to validated revisions'
+    )
+    assert '--audience backend=${{ steps.candidate-urls.outputs.backend_audience }}' in workflow
     assert 'smoke_what_matters_now.py --base-url https://api.omi.dev' not in workflow
 
 

--- a/backend/tests/unit/test_verify_dev_backend_deployment.py
+++ b/backend/tests/unit/test_verify_dev_backend_deployment.py
@@ -356,6 +356,16 @@ def test_evaluate_fails_closed_when_a_stale_revision_is_serving() -> None:
     assert 'gke/deployment: desired replicas are not all updated' in errors
 
 
+def test_candidate_evaluation_accepts_ready_revision_before_traffic_promotion() -> None:
+    expectation = _expectation()
+    documents = _documents(expectation)
+    documents['cloud_run/backend']['status']['traffic'] = [{'revisionName': 'backend-old', 'percent': 100}]
+
+    errors = verifier.evaluate(expectation, documents, require_serving_traffic=False)
+
+    assert errors == []
+
+
 def test_evaluate_fails_closed_when_available_replicas_are_not_the_updated_template() -> None:
     expectation = _expectation()
     documents = _documents(expectation)

--- a/docs/doc/developer/backend/transcription.mdx
+++ b/docs/doc/developer/backend/transcription.mdx
@@ -247,6 +247,28 @@ The Cloud Run candidate itself makes the private VPC hop to Parakeet. After a
 passing or failed candidate gate, the workflow removes its temporary tag; a
 failed gate never shifts traffic.
 
+## Automatic development candidate acceptance
+
+`gcp_backend_auto_dev.yml` keeps the development backend mutation lock while
+it deploys the four Cloud Run services (`backend`, `backend-sync`,
+`backend-sync-backfill`, and `backend-integration`) with the service-scoped
+`candidate` tag. It resolves each exact tag URL from Cloud Run status, runs the
+source-owned `backend/deploy/dev_candidate_acceptance.json` manifest, and only
+then permits the one traffic-promotion step. The backend uses the authenticated
+What Matters Now contract; the worker services use bounded `/v1/health` checks.
+The evidence artifact records only service, bounded contract category, and
+outcome — never URLs, tokens, user data, or response bodies.
+
+Candidate requests carry an OIDC token in `X-Serverless-Authorization` while
+the application keeps its own `Authorization` header. The token audience is
+the canonical Cloud Run service URL as required by Cloud Run; the HTTP target
+remains the exact no-traffic tagged candidate URL.
+
+Development pusher is deliberately **GKE-only** (`pusher.omiapi.com`). A
+legacy Cloud Run `pusher` service is not a deploy, candidate, or health-report
+surface; do not publish an image merely to make that retired surface appear
+ready.
+
 ## Deepgram Configuration
 
 When using Deepgram, the following options are configured:


### PR DESCRIPTION
## What changed and why

Closes #9755
Closes #9101
Closes #9747
Closes #9682
Closes #9738

Dev deployments now deploy the four Cloud Run services under no-traffic candidate tags, validate exact revisions and source-owned smoke contracts with Cloud Run OIDC, then promote traffic only after successful acceptance. This also makes Firestore provisioning exact, scopes runtime render output to each job, normalizes repository paths, and records bounded acceptance evidence.

## Product invariants affected

none

## How it was verified

- `cd backend && bash test.sh` — passed all 603 backend test files.
- `make preflight` and the full pre-push contract suite — passed.
- Exercised the health smoke against a local header-authenticated candidate fixture; it returned HTTP 204.
- Sol review: approved after the no-traffic verifier regression was added.

## Tests

Regression coverage exercises no-traffic candidate composition, exact Firestore resource identity, selective Cloud Run job rendering, candidate evidence tracking, health/OIDC smoke behavior, and Windows/POSIX source paths.

## Root cause and durable guard (bug fixes)

The deploy workflow promoted revisions before acceptance and its verifier was coupled to 100 percent traffic. The acceptance manifest, candidate URL resolver, OIDC-aware runners, pre-promotion verifier mode, post-promotion status report, and lock-policy test now make acceptance a required, ordered deployment contract. Exact Admin API resource matching prevents a same-shaped Firestore index from another project from satisfying dev provisioning.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9762?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

