### PR TITLE
fix(app): centralize recording sync recovery

### DIFF
--- a/.github/workflows/mobile-app-checks.yml
+++ b/.github/workflows/mobile-app-checks.yml
@@ -138,8 +138,78 @@ jobs:
           cache: true
 
       - name: Run Flutter tests
+        id: flutter_tests
         working-directory: app
-        run: bash test.sh
+        run: |
+          set -o pipefail
+          bash test.sh \
+            --reporter expanded \
+            --file-reporter "json:$GITHUB_WORKSPACE/flutter-test-results.json" \
+            2>&1 | tee "$GITHUB_WORKSPACE/flutter-test-output.log"
+
+      - name: Summarize failed Flutter tests
+        if: ${{ failure() && steps.flutter_tests.outcome == 'failure' }}
+        env:
+          FLUTTER_TEST_RESULTS: ${{ github.workspace }}/flutter-test-results.json
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+          from collections import defaultdict
+          from pathlib import Path
+
+          report = Path(os.environ['FLUTTER_TEST_RESULTS'])
+          summary = Path(os.environ['GITHUB_STEP_SUMMARY'])
+          tests = {}
+          errors = defaultdict(list)
+          failures = []
+
+          if report.exists():
+              for raw_line in report.read_text().splitlines():
+                  try:
+                      event = json.loads(raw_line)
+                  except json.JSONDecodeError:
+                      continue
+                  event_type = event.get('type')
+                  if event_type == 'testStart':
+                      test = event.get('test', {})
+                      tests[str(test.get('id'))] = test
+                  elif event_type == 'error':
+                      details = str(event.get('error', 'Unknown error'))
+                      if event.get('stackTrace'):
+                          details = f"{details}\n{event['stackTrace']}"
+                      errors[str(event.get('testID'))].append(details)
+                  elif event_type == 'testDone' and event.get('result') in {'failure', 'error'}:
+                      failures.append(event)
+
+          with summary.open('a') as output:
+              output.write('## Flutter test diagnostics\n\n')
+              if not failures:
+                  output.write(
+                      'Flutter exited unsuccessfully but emitted no failed-test event. '
+                      'Download the `flutter-test-diagnostics` artifact for the complete JSON stream and console log.\n'
+                  )
+              for failure in failures:
+                  test_id = str(failure.get('testID'))
+                  test = tests.get(test_id, {})
+                  name = test.get('name', f'Unknown test (id {test_id})')
+                  output.write(f'### {name}\n\n')
+                  details = '\n'.join(errors[test_id]).strip()
+                  if details:
+                      output.write('```text\n')
+                      output.write(details[-6000:].replace('```', '``\\`'))
+                      output.write('\n```\n\n')
+          PY
+
+      - name: Upload Flutter test diagnostics
+        if: ${{ failure() && steps.flutter_tests.outcome == 'failure' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: flutter-test-diagnostics
+          path: |
+            flutter-test-results.json
+            flutter-test-output.log
+          if-no-files-found: warn
 
   android-compile-smoke:
     name: Android Compile Smoke

--- a/app/lib/backend/schema/conversation.dart
+++ b/app/lib/backend/schema/conversation.dart
@@ -564,12 +564,18 @@ class SyncLocalFilesResponse {
   int totalSegments;
   List<String> errors;
 
+  /// Client-side batches that could not be uploaded. Unlike [failedSegments],
+  /// these failures leave WALs retryable locally and must re-arm foreground
+  /// recovery rather than presenting a completed sync.
+  int localUploadFailures;
+
   SyncLocalFilesResponse({
     required this.newConversationIds,
     required this.updatedConversationIds,
     this.failedSegments = 0,
     this.totalSegments = 0,
     this.errors = const [],
+    this.localUploadFailures = 0,
   });
 
   bool get hasPartialFailure => failedSegments > 0;

--- a/app/lib/pages/conversations/auto_sync_page.dart
+++ b/app/lib/pages/conversations/auto_sync_page.dart
@@ -46,7 +46,7 @@ class _AutoSyncPageState extends State<AutoSyncPage> {
       // hit the same device and would otherwise contend on the GATT link.
       await syncProvider.discoverDeviceWals(firmwareVersion: deviceProvider.currentFirmwareVersion);
       await deviceProvider.refreshRingStorageStatus();
-      SyncReconciler.instance.poke();
+      await RecordingTransferCoordinator.instance.wake(WakeTrigger.foregrounded);
     });
   }
 

--- a/app/lib/pages/home/page.dart
+++ b/app/lib/pages/home/page.dart
@@ -61,6 +61,7 @@ import 'package:omi/utils/device.dart';
 import 'package:omi/utils/platform/platform_service.dart';
 import 'package:omi/services/announcement_service.dart';
 import 'package:omi/services/notifications.dart';
+import 'package:omi/services/wals/recording_transfer_coordinator.dart';
 import 'package:omi/utils/other/temp.dart';
 import 'package:omi/utils/audio/foreground.dart';
 import 'package:omi/utils/l10n_extensions.dart';
@@ -522,7 +523,7 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver, Ticker
         }
         if (!syncProvider.isSyncing) {
           Logger.debug('HomePage: Auto-sync triggered ($fileCount files, $totalBytes bytes)');
-          syncProvider.syncWals();
+          syncProvider.syncWals(trigger: WakeTrigger.deviceConnected);
         }
       };
     });

--- a/app/lib/providers/device_provider.dart
+++ b/app/lib/providers/device_provider.dart
@@ -21,6 +21,7 @@ import 'package:omi/services/notifications.dart';
 import 'package:omi/services/services.dart';
 import 'package:omi/services/battery_widget_service.dart';
 import 'package:omi/services/wals/wal_syncs.dart';
+import 'package:omi/services/wals/recording_transfer_coordinator.dart';
 import 'package:omi/utils/device.dart';
 import 'package:omi/utils/logger.dart';
 import 'package:omi/utils/other/debouncer.dart';
@@ -480,6 +481,11 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
     syncs.flashPage.setDevice(device);
     syncs.storage.setDevice(device);
     syncs.ring.setDevice(device);
+
+    // Device connection and inventory are a recovery wake, even when the
+    // home page is not mounted. The coordinator serializes it with every
+    // other foreground trigger and applies the auto-sync preference itself.
+    unawaited(RecordingTransferCoordinator.instance.wake(WakeTrigger.deviceConnected));
 
     // Auto-sync: check if device has offline files
     _checkAndStartAutoSync(device);

--- a/app/lib/providers/sync_provider.dart
+++ b/app/lib/providers/sync_provider.dart
@@ -25,6 +25,8 @@ class SyncProvider extends ChangeNotifier implements IWalServiceListener, IWalSy
   final IWalService? _walServiceOverride;
   final SyncUploadGate _uploadGate;
   final bool _startBackgroundSync;
+  final Future<void> Function(LocalWalSyncImpl phone) _waitForWalReady;
+  final Future<void> Function() _startRecovery;
 
   /// Completes after WAL loading and startup fair-use reconciliation finish.
   @visibleForTesting
@@ -293,9 +295,13 @@ class SyncProvider extends ChangeNotifier implements IWalServiceListener, IWalSy
     IWalService? walService,
     SyncUploadGate? uploadGate,
     @visibleForTesting bool startBackgroundSync = true,
+    @visibleForTesting Future<void> Function(LocalWalSyncImpl phone)? waitForWalReady,
+    @visibleForTesting Future<void> Function()? startRecovery,
   })  : _walServiceOverride = walService,
         _uploadGate = uploadGate ?? SyncUploadGate.instance,
-        _startBackgroundSync = startBackgroundSync {
+        _startBackgroundSync = startBackgroundSync,
+        _waitForWalReady = waitForWalReady ?? ((phone) => phone.walReady),
+        _startRecovery = startRecovery ?? (() => RecordingTransferCoordinator.instance.wake(WakeTrigger.startup)) {
     _walService.subscribe(this, this);
     _audioPlayerUtils.addListener(_onAudioPlayerStateChanged);
     _freshRateLimitWasActive = SyncRateLimiter.instance.isLimitedForLane('fresh');
@@ -311,7 +317,7 @@ class SyncProvider extends ChangeNotifier implements IWalServiceListener, IWalSy
       await _uploadGate.reconcileFairUseStatus();
       if (_isDisposed) return;
       if (_startBackgroundSync) {
-        _attachTransferCoordinator();
+        await _attachTransferCoordinator();
       }
     } catch (error, stackTrace) {
       Logger.error('SyncProvider: initialization failed: $error\n$stackTrace');
@@ -332,12 +338,13 @@ class SyncProvider extends ChangeNotifier implements IWalServiceListener, IWalSy
     }
   }
 
-  /// Wire presentation seams into the single recording-recovery owner. The
-  /// coordinator retains a startup wake if CaptureController emitted it before
-  /// provider initialization completed.
-  void _attachTransferCoordinator() {
+  /// Wait for persisted WALs before attaching the single recovery owner, so
+  /// its sole startup wake cannot race an empty in-memory inventory.
+  Future<void> _attachTransferCoordinator() async {
     try {
       final phone = _walService.getSyncs().phone;
+      await _waitForWalReady(phone);
+      if (_isDisposed) return;
       SyncReconciler.instance.attach(phone, _onReconciledConversations);
       RecordingTransferCoordinator.instance.configure(
         reconcile: SyncReconciler.instance.poke,
@@ -349,7 +356,7 @@ class SyncProvider extends ChangeNotifier implements IWalServiceListener, IWalSy
         connectivityChanges: ConnectivityService().onConnectionChange,
         initiallyConnected: ConnectivityService().isConnected,
       );
-      unawaited(RecordingTransferCoordinator.instance.wake(WakeTrigger.startup));
+      unawaited(_startRecovery());
     } catch (e) {
       Logger.debug('SyncProvider: attach recording transfer coordinator failed: $e');
     }

--- a/app/lib/providers/sync_provider.dart
+++ b/app/lib/providers/sync_provider.dart
@@ -4,6 +4,7 @@ import 'package:flutter/foundation.dart';
 
 import 'package:omi/backend/preferences.dart';
 import 'package:omi/backend/schema/conversation.dart';
+import 'package:omi/services/connectivity_service.dart';
 import 'package:omi/services/services.dart';
 import 'package:omi/services/wals.dart';
 import 'package:omi/utils/debug_log_manager.dart';
@@ -236,7 +237,6 @@ class SyncProvider extends ChangeNotifier implements IWalServiceListener, IWalSy
   // Track WAL processing progress
   int _totalWalsToProcess = 0;
   int _walsProcessedCount = 0;
-  Timer? _autoUploadTimer;
   bool _isDisposed = false;
   late bool _freshRateLimitWasActive;
   late bool _backfillRateLimitWasActive;
@@ -311,8 +311,7 @@ class SyncProvider extends ChangeNotifier implements IWalServiceListener, IWalSy
       await _uploadGate.reconcileFairUseStatus();
       if (_isDisposed) return;
       if (_startBackgroundSync) {
-        _attachReconciler();
-        _scheduleAutoUploadPendingPhoneFiles();
+        _attachTransferCoordinator();
       }
     } catch (error, stackTrace) {
       Logger.error('SyncProvider: initialization failed: $error\n$stackTrace');
@@ -328,19 +327,31 @@ class SyncProvider extends ChangeNotifier implements IWalServiceListener, IWalSy
     _freshRateLimitWasActive = freshActive;
     _backfillRateLimitWasActive = backfillActive;
     notifyListeners();
-    if (cooldownEnded && _startBackgroundSync) _scheduleAutoUploadPendingPhoneFiles();
+    if (cooldownEnded && _startBackgroundSync) {
+      unawaited(RecordingTransferCoordinator.instance.wake(WakeTrigger.cooldownElapsed));
+    }
   }
 
-  /// Wire the background reconciler to the phone sync + our conversation
-  /// surfacing, then poke once to resume any recordings left `uploaded` by a
-  /// previous session (app-kill recovery).
-  void _attachReconciler() {
+  /// Wire presentation seams into the single recording-recovery owner. The
+  /// coordinator retains a startup wake if CaptureController emitted it before
+  /// provider initialization completed.
+  void _attachTransferCoordinator() {
     try {
       final phone = _walService.getSyncs().phone;
       SyncReconciler.instance.attach(phone, _onReconciledConversations);
-      SyncReconciler.instance.poke();
+      RecordingTransferCoordinator.instance.configure(
+        reconcile: SyncReconciler.instance.poke,
+        discover: _discoverPendingWals,
+        refreshPending: refreshWals,
+        drain: _drainEligibleWals,
+        autoUploadEnabled: () =>
+            !SharedPreferencesUtil().useCustomStt && SharedPreferencesUtil().autoSyncOfflineRecordings,
+        connectivityChanges: ConnectivityService().onConnectionChange,
+        initiallyConnected: ConnectivityService().isConnected,
+      );
+      unawaited(RecordingTransferCoordinator.instance.wake(WakeTrigger.startup));
     } catch (e) {
-      Logger.debug('SyncProvider: attach reconciler failed: $e');
+      Logger.debug('SyncProvider: attach recording transfer coordinator failed: $e');
     }
   }
 
@@ -361,47 +372,34 @@ class SyncProvider extends ChangeNotifier implements IWalServiceListener, IWalSy
     await refreshWals();
   }
 
-  bool _isAutoUploading = false;
-
-  /// Auto-upload phone WALs to cloud on app open when device is not connected
-  /// and no sync is already in progress.
-  void _scheduleAutoUploadPendingPhoneFiles() {
-    _autoUploadTimer?.cancel();
-    _autoUploadTimer = Timer(const Duration(seconds: 3), () {
-      _autoUploadTimer = null;
-      _autoUploadPendingPhoneFiles();
-    });
+  Future<void> _discoverPendingWals() async {
+    if (_isDisposed) return;
+    await _walService.getSyncs().refreshWalsFromDevice();
   }
 
-  void _autoUploadPendingPhoneFiles() async {
-    if (_isDisposed) return;
-    // Custom STT users sync manually (with confirmation) — never auto-upload.
-    if (SharedPreferencesUtil().useCustomStt) return;
-    // Respect the user's auto-sync opt-out (device settings). Defaults to on.
-    if (!SharedPreferencesUtil().autoSyncOfflineRecordings) return;
-    if (_syncState.isProcessing) return;
-    if (_walService.getSyncs().isStorageSyncing || _walService.getSyncs().isSdCardSyncing) return;
-    final phoneWals = _allWals
-        .where((w) => w.status == WalStatus.miss && (w.storage == WalStorage.disk || w.storage == WalStorage.mem))
-        .toList();
-    if (phoneWals.isEmpty) return;
-    if (_isDisposed) return;
-    Logger.debug('SyncProvider: Auto-uploading ${phoneWals.length} pending phone files to cloud');
-    _isAutoUploading = true;
-    await _performSync(
-      operation: () => _walService.getSyncs().phone.syncAll(progress: this),
-      context: 'auto-upload phone files',
-    );
-    _isAutoUploading = false;
-  }
-
-  /// Cancel auto-upload if running. Called before device-triggered sync.
-  void _cancelAutoUploadIfNeeded() {
-    if (_isAutoUploading) {
-      Logger.debug('SyncProvider: Cancelling auto-upload for device sync');
-      _walService.getSyncs().phone.cancelSync();
-      _isAutoUploading = false;
+  Future<RecordingTransferDrainResult> _drainEligibleWals() async {
+    if (_isDisposed || _syncState.isProcessing) return const RecordingTransferDrainResult.skipped();
+    if (_walService.getSyncs().isStorageSyncing || _walService.getSyncs().isSdCardSyncing) {
+      return const RecordingTransferDrainResult.skipped();
     }
+
+    final hadEligibleWals = missingWals.isNotEmpty;
+    if (!hadEligibleWals) return const RecordingTransferDrainResult.skipped();
+
+    _updateSyncState(_syncState.toIdle());
+    _totalWalsToProcess = missingWals.length;
+    _walsProcessedCount = 0;
+    final result = await _performSync(
+      operation: () => _walService.getSyncs().syncAll(progress: this),
+      context: 'coordinated recording transfer',
+      rethrowOnError: true,
+    );
+    await refreshWals();
+    return RecordingTransferDrainResult(
+      attempted: true,
+      failed: (result?.localUploadFailures ?? 0) > 0,
+      needsReconciliation: uploadedWals.isNotEmpty,
+    );
   }
 
   void _onAudioPlayerStateChanged() {
@@ -456,8 +454,15 @@ class SyncProvider extends ChangeNotifier implements IWalServiceListener, IWalSy
     await refreshWals();
   }
 
-  Future<void> syncWals() async {
-    _cancelAutoUploadIfNeeded();
+  Future<void> syncWals({WakeTrigger trigger = WakeTrigger.userRetry}) async {
+    if (_startBackgroundSync) {
+      await RecordingTransferCoordinator.instance.wake(trigger);
+      return;
+    }
+    await _syncWalsDirect();
+  }
+
+  Future<void> _syncWalsDirect() async {
     _updateSyncState(_syncState.toIdle());
     _totalWalsToProcess = missingWals.length;
     _walsProcessedCount = 0;
@@ -468,7 +473,6 @@ class SyncProvider extends ChangeNotifier implements IWalServiceListener, IWalSy
   }
 
   Future<void> syncWal(Wal wal) async {
-    _cancelAutoUploadIfNeeded();
     _updateSyncState(_syncState.toIdle());
     await _performSync(
       operation: () => _walService.getSyncs().syncWal(wal: wal, progress: this),
@@ -477,10 +481,11 @@ class SyncProvider extends ChangeNotifier implements IWalServiceListener, IWalSy
     );
   }
 
-  Future<void> _performSync({
+  Future<SyncLocalFilesResponse?> _performSync({
     required Future<SyncLocalFilesResponse?> Function() operation,
     required String context,
     Wal? failedWal,
+    bool rethrowOnError = false,
   }) async {
     try {
       _updateSyncState(_syncState.toSyncing());
@@ -502,10 +507,12 @@ class SyncProvider extends ChangeNotifier implements IWalServiceListener, IWalSy
       // If sync was cancelled while awaiting, don't override the cancel state.
       // cancelSync() already processed any partial conversation results.
       if (!_syncState.isSyncing && _syncState.status != SyncStatus.fetchingConversations) {
-        return;
+        return result;
       }
 
-      if (result != null && _hasConversationResults(result)) {
+      if ((result?.localUploadFailures ?? 0) > 0) {
+        _updateSyncState(_syncState.toError(message: 'Upload failed. Check your connection and try again'));
+      } else if (result != null && _hasConversationResults(result)) {
         Logger.debug(
           'SyncProvider: $context returned ${result.newConversationIds.length} new, ${result.updatedConversationIds.length} updated conversations',
         );
@@ -518,9 +525,7 @@ class SyncProvider extends ChangeNotifier implements IWalServiceListener, IWalSy
         DebugLogManager.logInfo('SyncProvider: $context completed with no new conversations');
         _updateSyncState(_syncState.toCompleted(conversations: []));
       }
-      // Uploads just finished — recordings are now `uploaded`. Kick the
-      // reconciler so their conversations stream in without the user waiting.
-      SyncReconciler.instance.poke();
+      return result;
     } catch (e) {
       final errorMessage = _formatSyncError(e, failedWal);
       Logger.debug('SyncProvider: Error in $context: $errorMessage');
@@ -529,6 +534,8 @@ class SyncProvider extends ChangeNotifier implements IWalServiceListener, IWalSy
         if (failedWal != null) 'walStorage': failedWal.storage.toString(),
       });
       _updateSyncState(_syncState.toError(message: errorMessage, failedWal: failedWal));
+      if (rethrowOnError) rethrow;
+      return null;
     }
   }
 
@@ -561,11 +568,15 @@ class SyncProvider extends ChangeNotifier implements IWalServiceListener, IWalSy
   }
 
   Future<void> retrySync() async {
+    if (_startBackgroundSync) {
+      await RecordingTransferCoordinator.instance.wake(WakeTrigger.userRetry);
+      return;
+    }
     final failedWal = _syncState.failedWal;
     if (failedWal != null) {
       await syncWal(failedWal);
     } else {
-      await syncWals();
+      await _syncWalsDirect();
     }
   }
 
@@ -709,8 +720,8 @@ class SyncProvider extends ChangeNotifier implements IWalServiceListener, IWalSy
       _updateSyncState(_syncState.toIdle());
     }
     // Cancel only stops further uploads. Recordings already `uploaded` are
-    // safe on the server — keep reconciling them.
-    SyncReconciler.instance.poke();
+    // safe on the server — keep reconciling them through the single owner.
+    unawaited(RecordingTransferCoordinator.instance.wake(WakeTrigger.cooldownElapsed));
   }
 
   /// Transfer a single WAL from device storage (SD card or flash page) to phone storage
@@ -750,8 +761,6 @@ class SyncProvider extends ChangeNotifier implements IWalServiceListener, IWalSy
   @override
   void dispose() {
     _isDisposed = true;
-    _autoUploadTimer?.cancel();
-    _autoUploadTimer = null;
     _audioPlayerUtils.removeListener(_onAudioPlayerStateChanged);
     SyncRateLimiter.instance.removeListener(_onRateLimiterChanged);
     WaveformUtils.clearCache();

--- a/app/lib/providers/sync_provider.dart
+++ b/app/lib/providers/sync_provider.dart
@@ -483,18 +483,29 @@ class SyncProvider extends ChangeNotifier implements IWalServiceListener, IWalSy
   }
 
   Future<void> syncWal(Wal wal) async {
+    // UI Sync/Auto Sync still call syncWal for a single row, but must not
+    // race a coordinator drain (or device download) on the same WAL stack.
+    if (_startBackgroundSync && _isTransferSeamBusy()) {
+      await _wakeTransfer(WakeTrigger.userRetry);
+      return;
+    }
     _updateSyncState(_syncState.toIdle());
     final result = await _performSync(
       operation: () => _walService.getSyncs().syncWal(wal: wal, progress: this),
       context: 'sync WAL ${wal.id}',
       failedWal: wal,
     );
-    // UI Sync/Auto Sync paths call syncWal directly and bypass the
-    // coordinator drain. A 202 leaves the WAL `uploaded` — wake the single
-    // owner so reconcile is scheduled (do not poke SyncReconciler here).
+    // A 202 leaves the WAL `uploaded` — wake the single owner so reconcile
+    // is scheduled (do not poke SyncReconciler here).
     if (result != null && _startBackgroundSync) {
       unawaited(_wakeTransfer(WakeTrigger.cooldownElapsed));
     }
+  }
+
+  bool _isTransferSeamBusy() {
+    if (_syncState.isProcessing) return true;
+    final syncs = _walService.getSyncs();
+    return syncs.isStorageSyncing == true || syncs.isSdCardSyncing == true;
   }
 
   Future<SyncLocalFilesResponse?> _performSync({

--- a/app/lib/providers/sync_provider.dart
+++ b/app/lib/providers/sync_provider.dart
@@ -27,6 +27,7 @@ class SyncProvider extends ChangeNotifier implements IWalServiceListener, IWalSy
   final bool _startBackgroundSync;
   final Future<void> Function(LocalWalSyncImpl phone) _waitForWalReady;
   final Future<void> Function() _startRecovery;
+  final Future<void> Function(WakeTrigger trigger) _wakeTransfer;
 
   /// Completes after WAL loading and startup fair-use reconciliation finish.
   @visibleForTesting
@@ -297,11 +298,13 @@ class SyncProvider extends ChangeNotifier implements IWalServiceListener, IWalSy
     @visibleForTesting bool startBackgroundSync = true,
     @visibleForTesting Future<void> Function(LocalWalSyncImpl phone)? waitForWalReady,
     @visibleForTesting Future<void> Function()? startRecovery,
+    @visibleForTesting Future<void> Function(WakeTrigger trigger)? wakeTransfer,
   })  : _walServiceOverride = walService,
         _uploadGate = uploadGate ?? SyncUploadGate.instance,
         _startBackgroundSync = startBackgroundSync,
         _waitForWalReady = waitForWalReady ?? ((phone) => phone.walReady),
-        _startRecovery = startRecovery ?? (() => RecordingTransferCoordinator.instance.wake(WakeTrigger.startup)) {
+        _startRecovery = startRecovery ?? (() => RecordingTransferCoordinator.instance.wake(WakeTrigger.startup)),
+        _wakeTransfer = wakeTransfer ?? ((trigger) => RecordingTransferCoordinator.instance.wake(trigger)) {
     _walService.subscribe(this, this);
     _audioPlayerUtils.addListener(_onAudioPlayerStateChanged);
     _freshRateLimitWasActive = SyncRateLimiter.instance.isLimitedForLane('fresh');
@@ -334,7 +337,7 @@ class SyncProvider extends ChangeNotifier implements IWalServiceListener, IWalSy
     _backfillRateLimitWasActive = backfillActive;
     notifyListeners();
     if (cooldownEnded && _startBackgroundSync) {
-      unawaited(RecordingTransferCoordinator.instance.wake(WakeTrigger.cooldownElapsed));
+      unawaited(_wakeTransfer(WakeTrigger.cooldownElapsed));
     }
   }
 
@@ -385,9 +388,9 @@ class SyncProvider extends ChangeNotifier implements IWalServiceListener, IWalSy
   }
 
   Future<RecordingTransferDrainResult> _drainEligibleWals() async {
-    if (_isDisposed || _syncState.isProcessing) return const RecordingTransferDrainResult.skipped();
+    if (_isDisposed || _syncState.isProcessing) return const RecordingTransferDrainResult.contended();
     if (_walService.getSyncs().isStorageSyncing || _walService.getSyncs().isSdCardSyncing) {
-      return const RecordingTransferDrainResult.skipped();
+      return const RecordingTransferDrainResult.contended();
     }
 
     final hadEligibleWals = missingWals.isNotEmpty;
@@ -463,7 +466,7 @@ class SyncProvider extends ChangeNotifier implements IWalServiceListener, IWalSy
 
   Future<void> syncWals({WakeTrigger trigger = WakeTrigger.userRetry}) async {
     if (_startBackgroundSync) {
-      await RecordingTransferCoordinator.instance.wake(trigger);
+      await _wakeTransfer(trigger);
       return;
     }
     await _syncWalsDirect();
@@ -481,11 +484,17 @@ class SyncProvider extends ChangeNotifier implements IWalServiceListener, IWalSy
 
   Future<void> syncWal(Wal wal) async {
     _updateSyncState(_syncState.toIdle());
-    await _performSync(
+    final result = await _performSync(
       operation: () => _walService.getSyncs().syncWal(wal: wal, progress: this),
       context: 'sync WAL ${wal.id}',
       failedWal: wal,
     );
+    // UI Sync/Auto Sync paths call syncWal directly and bypass the
+    // coordinator drain. A 202 leaves the WAL `uploaded` — wake the single
+    // owner so reconcile is scheduled (do not poke SyncReconciler here).
+    if (result != null && _startBackgroundSync) {
+      unawaited(_wakeTransfer(WakeTrigger.cooldownElapsed));
+    }
   }
 
   Future<SyncLocalFilesResponse?> _performSync({
@@ -517,9 +526,9 @@ class SyncProvider extends ChangeNotifier implements IWalServiceListener, IWalSy
         return result;
       }
 
-      if ((result?.localUploadFailures ?? 0) > 0) {
-        _updateSyncState(_syncState.toError(message: 'Upload failed. Check your connection and try again'));
-      } else if (result != null && _hasConversationResults(result)) {
+      // Process successful conversation IDs even when other batches failed —
+      // localUploadFailures must not discard completed results.
+      if (result != null && _hasConversationResults(result)) {
         Logger.debug(
           'SyncProvider: $context returned ${result.newConversationIds.length} new, ${result.updatedConversationIds.length} updated conversations',
         );
@@ -528,9 +537,13 @@ class SyncProvider extends ChangeNotifier implements IWalServiceListener, IWalSy
           'updatedConversations': result.updatedConversationIds.length,
         });
         await _processConversationResults(result);
-      } else {
+      } else if ((result?.localUploadFailures ?? 0) == 0) {
         DebugLogManager.logInfo('SyncProvider: $context completed with no new conversations');
         _updateSyncState(_syncState.toCompleted(conversations: []));
+      }
+
+      if ((result?.localUploadFailures ?? 0) > 0) {
+        _updateSyncState(_syncState.toError(message: 'Upload failed. Check your connection and try again'));
       }
       return result;
     } catch (e) {
@@ -576,7 +589,7 @@ class SyncProvider extends ChangeNotifier implements IWalServiceListener, IWalSy
 
   Future<void> retrySync() async {
     if (_startBackgroundSync) {
-      await RecordingTransferCoordinator.instance.wake(WakeTrigger.userRetry);
+      await _wakeTransfer(WakeTrigger.userRetry);
       return;
     }
     final failedWal = _syncState.failedWal;
@@ -728,7 +741,7 @@ class SyncProvider extends ChangeNotifier implements IWalServiceListener, IWalSy
     }
     // Cancel only stops further uploads. Recordings already `uploaded` are
     // safe on the server — keep reconciling them through the single owner.
-    unawaited(RecordingTransferCoordinator.instance.wake(WakeTrigger.cooldownElapsed));
+    unawaited(_wakeTransfer(WakeTrigger.cooldownElapsed));
   }
 
   /// Transfer a single WAL from device storage (SD card or flash page) to phone storage

--- a/app/lib/services/capture/capture_controller.dart
+++ b/app/lib/services/capture/capture_controller.dart
@@ -245,14 +245,6 @@ class CaptureController extends ChangeNotifier
 
   void updateExternalActions(CaptureExternalActions? actions) {
     externalActions = actions ?? const NoopCaptureExternalActions();
-
-    // Queue the startup pass after provider wiring. The coordinator retains
-    // this wake until SyncProvider has attached the production drain seams.
-    Future.delayed(
-      const Duration(seconds: 5),
-      () => RecordingTransferCoordinator.instance.wake(WakeTrigger.startup),
-    );
-
     notifyListeners();
   }
 

--- a/app/lib/services/capture/capture_controller.dart
+++ b/app/lib/services/capture/capture_controller.dart
@@ -246,12 +246,12 @@ class CaptureController extends ChangeNotifier
   void updateExternalActions(CaptureExternalActions? actions) {
     externalActions = actions ?? const NoopCaptureExternalActions();
 
-    // Run orphan recovery once after providers are wired up and WAL service is initialized.
-    // Uses Future.delayed to let the WAL service finish loading wals.json from disk.
-    if (!_orphanRecoveryDone) {
-      _orphanRecoveryDone = true;
-      Future.delayed(const Duration(seconds: 5), () => recoverOrphanedWals());
-    }
+    // Queue the startup pass after provider wiring. The coordinator retains
+    // this wake until SyncProvider has attached the production drain seams.
+    Future.delayed(
+      const Duration(seconds: 5),
+      () => RecordingTransferCoordinator.instance.wake(WakeTrigger.startup),
+    );
 
     notifyListeners();
   }
@@ -352,8 +352,6 @@ class CaptureController extends ChangeNotifier
     notifyListeners();
   }
 
-  bool _orphanRecoveryDone = false;
-
   /// Preserved session start for auto-sync after socket-driven conversation completion.
   /// Set before _resetStateVariables() clears _sessionStartSeconds, consumed on ConversationEvent.
   int _pendingAutoSyncSessionStart = 0;
@@ -364,8 +362,8 @@ class CaptureController extends ChangeNotifier
   /// The conversation ID from ConversationProcessingStartedEvent, kept for fallback sync.
   String? _pendingAutoSyncConversationId;
 
-  /// Future tracking the in-progress _finalizeAndStampSession(), so _autoSyncSessionWals()
-  /// can await it before querying disk WALs. Prevents race when backend responds fast.
+  /// Future tracking the in-progress _finalizeAndStampSession(), so the next
+  /// coordinated transfer wake cannot run before the durable stamp is ready.
   Future<void>? _pendingFinalizeAndStamp;
 
   /// Set in onClosed() when the socket drops during active device recording.
@@ -1686,7 +1684,7 @@ class CaptureController extends ChangeNotifier
       _pendingAutoSyncConversationId = event.memory.id;
 
       // Force-drain tail buffer, stamp WALs with conversation ID, then clear state.
-      // Store the future so _autoSyncSessionWals() can await it before querying disk WALs.
+      // Store the future so the coordinated transfer wake waits for the stamp.
       _pendingFinalizeAndStamp = _finalizeAndStampSession(_sessionStartSeconds, event.memory.id);
 
       _resetStateVariables();
@@ -1695,12 +1693,11 @@ class CaptureController extends ChangeNotifier
       _autoSyncFallbackTimer?.cancel();
       _autoSyncFallbackTimer = Timer(const Duration(seconds: 30), () {
         if (_pendingAutoSyncSessionStart > 0 && _pendingAutoSyncConversationId != null) {
-          final sessionStart = _pendingAutoSyncSessionStart;
           final convId = _pendingAutoSyncConversationId!;
           _pendingAutoSyncSessionStart = 0;
           _pendingAutoSyncConversationId = null;
           Logger.debug('Auto-sync fallback timer fired — syncing WALs to conversation $convId');
-          _autoSyncSessionWals(sessionStart, convId);
+          _autoSyncSessionWals();
         }
       });
       return;
@@ -1712,10 +1709,9 @@ class CaptureController extends ChangeNotifier
       _processConversationCreated(event.memory, event.messages.cast<ServerMessage>());
       _autoSyncFallbackTimer?.cancel();
       if (_pendingAutoSyncSessionStart > 0) {
-        final sessionStart = _pendingAutoSyncSessionStart;
         _pendingAutoSyncSessionStart = 0;
         _pendingAutoSyncConversationId = null;
-        _autoSyncSessionWals(sessionStart, event.memory.id);
+        _autoSyncSessionWals();
       }
       return;
     }
@@ -1824,7 +1820,7 @@ class CaptureController extends ChangeNotifier
       // Stamp WALs with conversation ID and auto-sync
       if (sessionStart > 0 && result.conversation != null) {
         await phoneSync.stampConversationId(sessionStart, result.conversation!.id);
-        _autoSyncSessionWals(sessionStart, result.conversation!.id);
+        _autoSyncSessionWals();
       }
     });
 
@@ -1845,137 +1841,15 @@ class CaptureController extends ChangeNotifier
     }
   }
 
-  Future<void> _autoSyncSessionWals(int sessionStartSeconds, String conversationId) async {
-    // Third-party STT users opt out of auto-sync: offline files can only be
-    // transcribed on Omi's servers (counting toward their limit), not on their
-    // own provider. They sync manually with an explicit confirmation instead.
-    if (SharedPreferencesUtil().useCustomStt) {
-      Logger.debug('Auto-sync skipped: custom STT provider enabled');
-      return;
-    }
-    // Omi users can opt out of auto-sync from device settings; they back up
-    // manually instead. Defaults to on.
-    if (!SharedPreferencesUtil().autoSyncOfflineRecordings) {
-      Logger.debug('Auto-sync skipped: disabled by user');
-      return;
-    }
+  Future<void> _autoSyncSessionWals() async {
     // Wait for finalize+stamp to complete so tail buffer WALs are on disk before querying.
     if (_pendingFinalizeAndStamp != null) {
       await _pendingFinalizeAndStamp;
       _pendingFinalizeAndStamp = null;
     }
-    final phoneSync = _wal.getSyncs().phone;
-    final unsyncedWals = phoneSync.getSessionUnsyncedWals(sessionStartSeconds);
-    if (unsyncedWals.isEmpty) return;
-
-    Logger.debug('Auto-syncing ${unsyncedWals.length} session WALs to conversation $conversationId');
-    for (final wal in unsyncedWals) {
-      await _syncSingleWal(wal, conversationId, phoneSync);
-    }
-  }
-
-  /// Sync a single WAL to a conversation with retry and backoff.
-  /// Retries up to 3 times with exponential delays (5s, 10s, 20s).
-  /// Network/transient errors (SocketException, no connectivity) do NOT increment retryCount.
-  Future<void> _syncSingleWal(Wal wal, String conversationId, LocalWalSyncImpl phoneSync) async {
-    if (wal.filePath == null) {
-      Logger.debug('Auto-sync WAL ${wal.id}: no filePath, marking corrupted');
-      wal.status = WalStatus.corrupted;
-      await phoneSync.persistRetryMetadata(wal);
-      return;
-    }
-    final fullPath = await Wal.getFilePath(wal.filePath);
-    if (fullPath == null) {
-      Logger.debug('Auto-sync WAL ${wal.id}: path resolution failed, marking corrupted');
-      wal.status = WalStatus.corrupted;
-      await phoneSync.persistRetryMetadata(wal);
-      return;
-    }
-    final file = File(fullPath);
-    if (!file.existsSync()) {
-      Logger.debug('Auto-sync WAL ${wal.id}: file missing, marking corrupted');
-      wal.status = WalStatus.corrupted;
-      await phoneSync.persistRetryMetadata(wal);
-      return;
-    }
-
-    if (!_isConnected) {
-      Logger.debug('Auto-sync WAL ${wal.id}: offline, will retry later');
-      return;
-    }
-
-    // Honor an active fair-use cooldown: don't fire uploads that will just be
-    // 429'd, which amplifies the throttle and mislabels recordings as failed.
-    if (SyncRateLimiter.instance.isLimited) {
-      Logger.debug('Auto-sync WAL ${wal.id}: rate-limited until ${SyncRateLimiter.instance.until}, skipping');
-      return;
-    }
-
-    // Upload only — no poll-to-terminal, no in-method retry loop. On 202 the
-    // WAL becomes `uploaded` and the SyncReconciler resolves the job out of
-    // band; on real failure we bump retryCount so orphan recovery / the next
-    // sync retries (the local file is retained until confirmed synced).
-    try {
-      final result = await SyncUploadGate.instance.upload([file], conversationId: conversationId);
-      if (result.completed != null) {
-        // 200 fast-path: server already produced the result.
-        await phoneSync.markWalSyncedAndPersist(wal);
-      } else {
-        wal.status = WalStatus.uploaded;
-        wal.jobId = result.jobId;
-        wal.uploadedAt = DateTime.now().millisecondsSinceEpoch ~/ 1000;
-        await phoneSync.persistRetryMetadata(wal); // persists the WAL list
-        SyncReconciler.instance.poke();
-      }
-    } on SyncRateLimitedException {
-      // Account-level rate limit — do not bump retryCount. The WAL stays
-      // pending and the global upload gate owns the cooldown.
-      Logger.debug('Auto-sync WAL ${wal.id}: rate-limited, paused until ${SyncRateLimiter.instance.until}');
-    } on SocketException {
-      Logger.debug('Auto-sync WAL ${wal.id}: network error, aborting without incrementing retryCount');
-    } catch (e) {
-      wal.retryCount = wal.retryCount + 1;
-      wal.lastRetryAt = DateTime.now().millisecondsSinceEpoch ~/ 1000;
-      await phoneSync.persistRetryMetadata(wal);
-      Logger.debug('Auto-sync WAL ${wal.id} upload failed (retryCount=${wal.retryCount}): $e');
-    }
-  }
-
-  /// Recover orphaned WALs on startup. Called once after providers are initialized.
-  /// Finds WALs with conversationId set but status still miss, and syncs them.
-  /// Skips recovery if offline — retryCount is not incremented for transient failures.
-  Future<void> recoverOrphanedWals() async {
-    // Custom STT users never auto-sync (offline files would use Omi STT + count
-    // toward their limit). They back up manually with explicit confirmation.
-    if (SharedPreferencesUtil().useCustomStt) {
-      Logger.debug('Orphan WAL recovery skipped: custom STT provider enabled');
-      return;
-    }
-    // Honor the user's auto-sync opt-out (device settings). Defaults to on.
-    if (!SharedPreferencesUtil().autoSyncOfflineRecordings) {
-      Logger.debug('Orphan WAL recovery skipped: auto-sync disabled by user');
-      return;
-    }
-    if (!_isConnected) {
-      Logger.debug('Startup recovery: offline, skipping orphan WAL sync');
-      _orphanRecoveryDone = false; // Allow retry on next external action update.
-      return;
-    }
-    final phoneSync = _wal.getSyncs().phone;
-    await phoneSync.walReady; // Wait for WALs to be loaded from disk
-    final orphaned = phoneSync.getOrphanedWals();
-    if (orphaned.isEmpty) return;
-
-    Logger.debug('Startup recovery: found ${orphaned.length} orphaned WALs to sync');
-    for (final wal in orphaned) {
-      await _syncSingleWal(wal, wal.conversationId!, phoneSync);
-    }
-    // Check if any orphaned WALs remain (e.g., transient SocketException while "online").
-    // If so, allow onConnectionStateChanged to re-trigger recovery on next transition.
-    final remaining = phoneSync.getOrphanedWals();
-    if (remaining.isNotEmpty) {
-      _orphanRecoveryDone = false;
-    }
+    // The stamped conversation id stays on the WAL; the single transfer owner
+    // will reconcile first and then offer retryable bytes through `syncAll`.
+    await RecordingTransferCoordinator.instance.wake(WakeTrigger.cooldownElapsed);
   }
 
   Future<void> _processConversationCreated(ServerConversation? conversation, List<ServerMessage> messages) async {
@@ -2183,11 +2057,6 @@ class CaptureController extends ChangeNotifier
 
   void onConnectionStateChanged(bool isConnected) {
     _isConnected = isConnected;
-    // When coming back online, retry orphan recovery if it was skipped due to being offline
-    if (isConnected && !_orphanRecoveryDone) {
-      _orphanRecoveryDone = true;
-      recoverOrphanedWals();
-    }
     notifyListeners();
   }
 

--- a/app/lib/services/wals.dart
+++ b/app/lib/services/wals.dart
@@ -23,5 +23,6 @@ export 'wals/flash_page_wal_sync.dart';
 export 'wals/wal_syncs.dart';
 export 'wals/wal_service.dart';
 export 'wals/sync_reconciler.dart';
+export 'wals/recording_transfer_coordinator.dart';
 export 'wals/sync_rate_limiter.dart';
 export 'wals/sync_upload_gate.dart';

--- a/app/lib/services/wals/local_wal_sync.dart
+++ b/app/lib/services/wals/local_wal_sync.dart
@@ -836,6 +836,7 @@ class LocalWalSyncImpl implements LocalWalSync {
       'updatedConversations': resp.updatedConversationIds.length,
     });
 
+    resp.localUploadFailures = batchesFailed;
     progress?.onWalSyncedProgress(1.0);
     return resp;
   }

--- a/app/lib/services/wals/recording_transfer_coordinator.dart
+++ b/app/lib/services/wals/recording_transfer_coordinator.dart
@@ -169,6 +169,11 @@ class RecordingTransferCoordinator {
   /// Coalesces concurrent events into a single extra serial pass. Five wakes
   /// during one pass therefore run at most two passes and never parallel drains.
   Future<void> wake(WakeTrigger trigger) {
+    // Recovery is foreground-only. Persisted WAL state is recovered by the
+    // foreground wake, so background connectivity/device callbacks must not
+    // start discovery or a whole-WAL drain.
+    if (!_foreground) return Future.value();
+
     if (!_configured) {
       _wakeBeforeConfigured = _preferWake(_wakeBeforeConfigured, trigger);
       return Future.value();

--- a/app/lib/services/wals/recording_transfer_coordinator.dart
+++ b/app/lib/services/wals/recording_transfer_coordinator.dart
@@ -25,16 +25,27 @@ class RecordingTransferDrainResult {
     required this.attempted,
     required this.failed,
     required this.needsReconciliation,
+    this.contended = false,
   });
 
+  /// Nothing eligible to drain (empty backlog). Not a retry signal.
   const RecordingTransferDrainResult.skipped()
       : attempted = false,
         failed = false,
-        needsReconciliation = false;
+        needsReconciliation = false,
+        contended = false;
+
+  /// Drain could not run because another sync owned the seam. Retry later.
+  const RecordingTransferDrainResult.contended()
+      : attempted = false,
+        failed = false,
+        needsReconciliation = false,
+        contended = true;
 
   final bool attempted;
   final bool failed;
   final bool needsReconciliation;
+  final bool contended;
 }
 
 typedef RecordingTransferPass = Future<void> Function();
@@ -228,18 +239,23 @@ class RecordingTransferCoordinator {
 
       final result = await _drain();
       await _refreshPending();
-      if (result.failed) {
-        _scheduleRetry('eligible WAL upload returned a retryable failure');
-        return;
-      }
-      _failureStreak = 0;
 
-      // A successful 202 upload created `uploaded` WALs. Re-enter the
-      // reconciler through this owner so it can schedule its foreground poll.
+      // Partial upload success still leaves `uploaded` WALs that need the
+      // reconciler before any failure/contention retry path runs.
       if (result.needsReconciliation) {
         await _reconcile();
         await _refreshPending();
       }
+
+      if (result.failed) {
+        _scheduleRetry('eligible WAL upload returned a retryable failure');
+        return;
+      }
+      if (result.contended) {
+        _scheduleRetry('eligible WAL drain was contended');
+        return;
+      }
+      _failureStreak = 0;
     } catch (error, stackTrace) {
       Logger.debug(
         'RecordingTransferCoordinator: $trigger pass failed: $error\n$stackTrace',

--- a/app/lib/services/wals/recording_transfer_coordinator.dart
+++ b/app/lib/services/wals/recording_transfer_coordinator.dart
@@ -1,0 +1,278 @@
+import 'dart:async';
+
+import 'package:omi/utils/logger.dart';
+
+/// The event that made another foreground recording-transfer pass worthwhile.
+///
+/// All recording recovery paths use this closed set so a wake can be audited
+/// without introducing a second recovery owner.
+enum WakeTrigger {
+  startup,
+  foregrounded,
+  connectivityRestored,
+  deviceConnected,
+  cooldownElapsed,
+  userRetry,
+}
+
+/// Result reported by the production drain seam.
+///
+/// A local WAL upload can fail per batch and still return normally from
+/// `syncAll`. [failed] makes that durable retry signal explicit without
+/// changing WAL state transitions: failed WALs remain retryable (`miss`).
+class RecordingTransferDrainResult {
+  const RecordingTransferDrainResult({
+    required this.attempted,
+    required this.failed,
+    required this.needsReconciliation,
+  });
+
+  const RecordingTransferDrainResult.skipped()
+      : attempted = false,
+        failed = false,
+        needsReconciliation = false;
+
+  final bool attempted;
+  final bool failed;
+  final bool needsReconciliation;
+}
+
+typedef RecordingTransferPass = Future<void> Function();
+typedef RecordingTransferDrain = Future<RecordingTransferDrainResult> Function();
+typedef RecordingTransferCooldownScheduler = void Function(Duration delay, void Function() callback);
+
+/// The single foreground owner for recording recovery.
+///
+/// It deliberately knows no provider or transport details. Production wires
+/// the seams once, while tests use the same coordinator with fake connectivity,
+/// time, reconciliation, and drain functions.
+class RecordingTransferCoordinator {
+  RecordingTransferCoordinator({
+    required RecordingTransferPass reconcile,
+    required RecordingTransferPass discover,
+    required RecordingTransferPass refreshPending,
+    required RecordingTransferDrain drain,
+    required bool Function() autoUploadEnabled,
+    Stream<bool>? connectivityChanges,
+    bool initiallyConnected = true,
+    DateTime Function()? clock,
+    RecordingTransferCooldownScheduler? scheduleCooldown,
+  })  : _reconcile = reconcile,
+        _discover = discover,
+        _refreshPending = refreshPending,
+        _drain = drain,
+        _autoUploadEnabled = autoUploadEnabled,
+        _clock = clock ?? DateTime.now,
+        _scheduleCooldown = scheduleCooldown {
+    _configured = true;
+    _listenToConnectivity(connectivityChanges, initiallyConnected);
+  }
+
+  RecordingTransferCoordinator._singleton()
+      : _reconcile = _noop,
+        _discover = _noop,
+        _refreshPending = _noop,
+        _drain = _skippedDrain,
+        _autoUploadEnabled = _disabled,
+        _clock = DateTime.now;
+
+  static final RecordingTransferCoordinator instance = RecordingTransferCoordinator._singleton();
+
+  static Future<void> _noop() async {}
+  static Future<RecordingTransferDrainResult> _skippedDrain() async => const RecordingTransferDrainResult.skipped();
+  static bool _disabled() => false;
+
+  static const List<Duration> _failureBackoff = [
+    Duration(seconds: 5),
+    Duration(seconds: 10),
+    Duration(seconds: 20),
+    Duration(seconds: 60),
+  ];
+
+  RecordingTransferPass _reconcile;
+  RecordingTransferPass _discover;
+  RecordingTransferPass _refreshPending;
+  RecordingTransferDrain _drain;
+  bool Function() _autoUploadEnabled;
+  final DateTime Function() _clock;
+  RecordingTransferCooldownScheduler? _scheduleCooldown;
+
+  StreamSubscription<bool>? _connectivitySubscription;
+  Timer? _cooldownTimer;
+  Future<void>? _inFlight;
+  WakeTrigger? _pendingWake;
+  WakeTrigger? _wakeBeforeConfigured;
+  bool _configured = false;
+  bool _foreground = true;
+  bool _wasConnected = true;
+  int _failureStreak = 0;
+  int _cooldownGeneration = 0;
+
+  /// Visible to tests and diagnostics; this is not persisted because timers are
+  /// foreground-only and startup is always another wake.
+  DateTime? nextCooldownAt;
+
+  /// Configures the application singleton after the provider can surface
+  /// reconciliation and presentation results. Wakes received before that point
+  /// are retained rather than dropped.
+  void configure({
+    required RecordingTransferPass reconcile,
+    required RecordingTransferPass discover,
+    required RecordingTransferPass refreshPending,
+    required RecordingTransferDrain drain,
+    required bool Function() autoUploadEnabled,
+    required Stream<bool> connectivityChanges,
+    required bool initiallyConnected,
+  }) {
+    _reconcile = reconcile;
+    _discover = discover;
+    _refreshPending = refreshPending;
+    _drain = drain;
+    _autoUploadEnabled = autoUploadEnabled;
+    _configured = true;
+    _listenToConnectivity(connectivityChanges, initiallyConnected);
+
+    final queued = _wakeBeforeConfigured;
+    _wakeBeforeConfigured = null;
+    if (queued != null) {
+      scheduleMicrotask(() => wake(queued));
+    }
+  }
+
+  void _listenToConnectivity(
+    Stream<bool>? connectivityChanges,
+    bool initiallyConnected,
+  ) {
+    _connectivitySubscription?.cancel();
+    _wasConnected = initiallyConnected;
+    _connectivitySubscription = connectivityChanges?.listen((isConnected) {
+      final restored = isConnected && !_wasConnected;
+      _wasConnected = isConnected;
+      if (restored) {
+        unawaited(wake(WakeTrigger.connectivityRestored));
+      }
+    });
+  }
+
+  /// Stops foreground-only retry timers while the app is backgrounded. The
+  /// persisted WAL state is picked up by the next foreground or startup wake.
+  void setForeground(bool isForeground) {
+    _foreground = isForeground;
+    if (!isForeground) {
+      _cooldownGeneration++;
+      _cooldownTimer?.cancel();
+      _cooldownTimer = null;
+      nextCooldownAt = null;
+    }
+  }
+
+  /// Coalesces concurrent events into a single extra serial pass. Five wakes
+  /// during one pass therefore run at most two passes and never parallel drains.
+  Future<void> wake(WakeTrigger trigger) {
+    if (!_configured) {
+      _wakeBeforeConfigured = _preferWake(_wakeBeforeConfigured, trigger);
+      return Future.value();
+    }
+
+    final active = _inFlight;
+    if (active != null) {
+      _pendingWake = _preferWake(_pendingWake, trigger);
+      return active;
+    }
+
+    final pass = _run(trigger);
+    _inFlight = pass;
+    pass.whenComplete(() {
+      if (!identical(_inFlight, pass)) return;
+      _inFlight = null;
+      final lateWake = _pendingWake;
+      _pendingWake = null;
+      if (lateWake != null) {
+        unawaited(wake(lateWake));
+      }
+    });
+    return pass;
+  }
+
+  WakeTrigger _preferWake(WakeTrigger? existing, WakeTrigger incoming) {
+    if (existing == WakeTrigger.userRetry || incoming != WakeTrigger.userRetry) {
+      return existing ?? incoming;
+    }
+    return incoming;
+  }
+
+  Future<void> _run(WakeTrigger firstWake) async {
+    WakeTrigger wake = firstWake;
+    do {
+      _pendingWake = null;
+      await _runPass(wake);
+      wake = _pendingWake ?? wake;
+    } while (_pendingWake != null);
+  }
+
+  Future<void> _runPass(WakeTrigger trigger) async {
+    try {
+      // Uploaded jobs are resolved before a whole-WAL drain can offer any
+      // retryable bytes. `syncAll` only uploads `miss`, preserving job ids.
+      await _reconcile();
+      await _discover();
+      await _refreshPending();
+
+      final mayUpload = trigger == WakeTrigger.userRetry || _autoUploadEnabled();
+      if (!mayUpload) return;
+
+      final result = await _drain();
+      await _refreshPending();
+      if (result.failed) {
+        _scheduleRetry('eligible WAL upload returned a retryable failure');
+        return;
+      }
+      _failureStreak = 0;
+
+      // A successful 202 upload created `uploaded` WALs. Re-enter the
+      // reconciler through this owner so it can schedule its foreground poll.
+      if (result.needsReconciliation) {
+        await _reconcile();
+        await _refreshPending();
+      }
+    } catch (error, stackTrace) {
+      Logger.debug(
+        'RecordingTransferCoordinator: $trigger pass failed: $error\n$stackTrace',
+      );
+      _scheduleRetry('pass threw while recovering recording transfers');
+    }
+  }
+
+  void _scheduleRetry(String reason) {
+    if (!_foreground) return;
+    final index = _failureStreak.clamp(0, _failureBackoff.length - 1);
+    final delay = _failureBackoff[index];
+    _failureStreak++;
+    nextCooldownAt = _clock().add(delay);
+    Logger.debug(
+      'RecordingTransferCoordinator: scheduling $reason in ${delay.inSeconds}s',
+    );
+
+    _cooldownTimer?.cancel();
+    final generation = ++_cooldownGeneration;
+    void fire() {
+      if (!_foreground || generation != _cooldownGeneration) return;
+      _cooldownTimer = null;
+      nextCooldownAt = null;
+      unawaited(wake(WakeTrigger.cooldownElapsed));
+    }
+
+    final scheduler = _scheduleCooldown;
+    if (scheduler != null) {
+      scheduler(delay, fire);
+    } else {
+      _cooldownTimer = Timer(delay, fire);
+    }
+  }
+
+  void dispose() {
+    _connectivitySubscription?.cancel();
+    _cooldownTimer?.cancel();
+    _cooldownTimer = null;
+  }
+}

--- a/app/lib/services/wals/sync_reconciler.dart
+++ b/app/lib/services/wals/sync_reconciler.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:omi/backend/schema/conversation.dart';
 import 'package:omi/services/wals/local_wal_sync.dart';
+import 'package:omi/services/wals/recording_transfer_coordinator.dart';
 import 'package:omi/services/wals/wal.dart';
 import 'package:omi/utils/logger.dart';
 
@@ -11,8 +12,8 @@ import 'package:omi/utils/logger.dart';
 typedef ConversationSurfaceCallback = Future<void> Function(SyncLocalFilesResponse result);
 
 /// Drives [LocalWalSyncImpl.reconcileUploadedWals] off the upload critical
-/// path: on demand (`poke`), on a backed-off foreground timer while any
-/// recording is still `uploaded`, and (via the owner) on app start.
+/// path. [RecordingTransferCoordinator] owns when a pass runs; this service
+/// remains the callee that resolves already-uploaded server jobs.
 ///
 /// All state lives in the persisted WAL list, so this survives navigation and
 /// app-kill — a fresh process just `poke`s on startup and resumes. Scheduling
@@ -38,12 +39,15 @@ class SyncReconciler {
     _onConversations = onConversations;
   }
 
-  /// Run one reconcile pass now. Debounced — a no-op if a pass is already in
-  /// flight, so it is safe to call from many triggers (startup, screen open,
-  /// just-finished upload, timer).
+  /// Run one reconcile pass now. Wake coalescing belongs to
+  /// [RecordingTransferCoordinator], so a caller never loses a recovery event
+  /// because a previous pass is in flight.
   Future<void> poke() async {
     final phone = _phone;
-    if (phone == null || _running) return;
+    if (phone == null) return;
+    if (_running) {
+      throw StateError('SyncReconciler invoked outside RecordingTransferCoordinator');
+    }
     _running = true;
     try {
       final resp = await phone.reconcileUploadedWals();
@@ -58,6 +62,7 @@ class SyncReconciler {
       }
     } catch (e) {
       Logger.debug('SyncReconciler: reconcile pass failed: $e');
+      rethrow;
     } finally {
       _running = false;
     }
@@ -81,14 +86,17 @@ class SyncReconciler {
     }
     final secs = _backoffSecs[_idleStreak.clamp(0, _backoffSecs.length - 1)];
     _idleStreak++;
-    _timer = Timer(Duration(seconds: secs), poke);
+    _timer = Timer(Duration(seconds: secs), () {
+      unawaited(RecordingTransferCoordinator.instance.wake(WakeTrigger.cooldownElapsed));
+    });
   }
 
   /// App came to the foreground — resume fast cadence and check immediately.
   void onForeground() {
     _foreground = true;
     _idleStreak = 0;
-    poke();
+    RecordingTransferCoordinator.instance.setForeground(true);
+    unawaited(RecordingTransferCoordinator.instance.wake(WakeTrigger.foregrounded));
   }
 
   /// App backgrounded — stop the timer. State is persisted; a later
@@ -97,6 +105,7 @@ class SyncReconciler {
     _foreground = false;
     _timer?.cancel();
     _timer = null;
+    RecordingTransferCoordinator.instance.setForeground(false);
   }
 
   void dispose() {

--- a/app/lib/services/wals/wal_syncs.dart
+++ b/app/lib/services/wals/wal_syncs.dart
@@ -252,6 +252,7 @@ class WalSyncs implements IWalSync {
           (id) => !resp.updatedConversationIds.contains(id) && !resp.newConversationIds.contains(id),
         ),
       );
+      resp.localUploadFailures += preDrainResult.localUploadFailures;
     }
 
     // Phase 0: New offline storage sync, gated by firmware version.
@@ -335,6 +336,7 @@ class WalSyncs implements IWalSync {
           (id) => !resp.updatedConversationIds.contains(id) && !resp.newConversationIds.contains(id),
         ),
       );
+      resp.localUploadFailures += partialRes.localUploadFailures;
     }
 
     DebugLogManager.logEvent('sync_completed', {

--- a/app/test.sh
+++ b/app/test.sh
@@ -51,4 +51,4 @@ if [[ ${#missing_files[@]} -gt 0 ]]; then
   flutter pub run build_runner build --delete-conflicting-outputs
 fi
 
-flutter test
+flutter test "$@"

--- a/app/test/providers/capture_provider_test.dart
+++ b/app/test/providers/capture_provider_test.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:connectivity_plus_platform_interface/connectivity_plus_platform_interface.dart';
+import 'package:fake_async/fake_async.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
@@ -491,6 +492,18 @@ void main() {
   });
 
   group('external actions port', () {
+    test('repeated external-action updates do not schedule duplicate startup recovery', () {
+      fakeAsync((async) {
+        final provider = CaptureProvider();
+        final pendingTimersBeforeUpdates = async.pendingTimers.length;
+
+        provider.updateExternalActions(MockCaptureExternalActions());
+        provider.updateExternalActions(MockCaptureExternalActions());
+
+        expect(async.pendingTimers, hasLength(pendingTimersBeforeUpdates));
+      });
+    });
+
     test('topConversationId delegates through external actions', () {
       final provider = CaptureProvider();
       final mockExternalActions = MockCaptureExternalActions()..topConversationIdOverride = 'conversation-1';

--- a/app/test/providers/sync_provider_startup_reconciliation_test.dart
+++ b/app/test/providers/sync_provider_startup_reconciliation_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:omi/backend/http/api/conversations.dart';
 import 'package:omi/backend/preferences.dart';
@@ -33,6 +35,41 @@ void main() {
     expect(statusCalls, 1);
     expect(limiter.hasPersistedFairUseState, isFalse);
     expect(limiter.isLimited, isFalse);
+    provider.dispose();
+  });
+
+  test('provider waits for persisted WAL readiness before attaching startup recovery', () async {
+    SharedPreferences.setMockInitialValues({});
+    await SharedPreferencesUtil.init();
+    final readiness = Completer<void>();
+    final limiter = SyncRateLimiter.instance..clear();
+    final gate = SyncUploadGate(
+      limiter: limiter,
+      fairUseStatusLoader: () async => {'stage': 'none'},
+      uploader: (files, {onUploadProgress, conversationId, syncLane = SyncUploadLane.fresh}) async =>
+          UploadFilesResult.queued('unused'),
+    );
+    var startupWakes = 0;
+    final provider = SyncProvider(
+      walService: WalService(),
+      uploadGate: gate,
+      waitForWalReady: (_) => readiness.future,
+      startRecovery: () async {
+        startupWakes++;
+      },
+    );
+    var initialized = false;
+    unawaited(provider.initialized.then((_) => initialized = true));
+
+    await Future<void>.delayed(Duration.zero);
+    expect(initialized, isFalse);
+    expect(startupWakes, 0);
+
+    readiness.complete();
+    await provider.initialized;
+
+    expect(initialized, isTrue);
+    expect(startupWakes, 1);
     provider.dispose();
   });
 }

--- a/app/test/providers/sync_provider_sync_wal_wake_test.dart
+++ b/app/test/providers/sync_provider_sync_wal_wake_test.dart
@@ -1,0 +1,131 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:omi/backend/preferences.dart';
+import 'package:omi/backend/schema/bt_device/bt_device.dart';
+import 'package:omi/backend/schema/conversation.dart';
+import 'package:omi/providers/sync_provider.dart';
+import 'package:omi/services/wals/recording_transfer_coordinator.dart';
+import 'package:omi/services/wals/sync_rate_limiter.dart';
+import 'package:omi/services/wals/wal.dart';
+import 'package:omi/services/wals/wal_interfaces.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Fake syncs object returned by [_FakeWalService.getSyncs]. SyncProvider treats
+/// getSyncs() as dynamic, so only the members it actually calls are needed here.
+class _FakeSyncs {
+  final List<Wal> wals;
+  int syncWalCalls = 0;
+  SyncLocalFilesResponse? nextSyncResult;
+
+  _FakeSyncs(this.wals);
+
+  Future<List<Wal>> getAllWals() async => List<Wal>.of(wals);
+
+  Future<void> refreshWalsFromDevice({String? firmwareVersion}) async {}
+
+  bool get isStorageSyncing => false;
+  bool get isSdCardSyncing => false;
+
+  SyncLocalFilesResponse? get accumulatedResponse => null;
+
+  void cancelSync() {}
+
+  Future<SyncLocalFilesResponse?> syncWal({required Wal wal, IWalSyncProgressListener? progress}) async {
+    syncWalCalls++;
+    final result = nextSyncResult ?? SyncLocalFilesResponse(newConversationIds: [], updatedConversationIds: []);
+    if (result.localUploadFailures == 0 && result.newConversationIds.isEmpty) {
+      // Mirror a 202 accepted upload: WAL becomes `uploaded`, no conversations yet.
+      wal.status = WalStatus.uploaded;
+      wal.jobId = 'job-202';
+    }
+    return result;
+  }
+}
+
+class _FakeWalService implements IWalService {
+  final _FakeSyncs syncs;
+  _FakeWalService(this.syncs);
+
+  @override
+  void start() {}
+
+  @override
+  Future stop() async {}
+
+  @override
+  void subscribe(IWalServiceListener subscription, Object context) {}
+
+  @override
+  void unsubscribe(Object context) {}
+
+  @override
+  dynamic getSyncs() => syncs;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('syncWal 202 wakes the transfer coordinator for reconciliation', () async {
+    SharedPreferences.setMockInitialValues({});
+    await SharedPreferencesUtil.init();
+    SyncRateLimiter.instance.clear();
+
+    final wal = Wal(timerStart: 1000, codec: BleAudioCodec.pcm16, seconds: 30, status: WalStatus.miss);
+    final syncs = _FakeSyncs([wal]);
+    final wakes = <WakeTrigger>[];
+
+    final provider = SyncProvider(
+      walService: _FakeWalService(syncs),
+      startBackgroundSync: true,
+      waitForWalReady: (_) async {},
+      startRecovery: () async {},
+      wakeTransfer: (trigger) async {
+        wakes.add(trigger);
+      },
+    );
+    await provider.initialized;
+
+    await provider.syncWal(wal);
+
+    expect(syncs.syncWalCalls, 1);
+    expect(
+      wakes,
+      [WakeTrigger.cooldownElapsed],
+      reason: 'successful syncWal must wake coordinator so uploaded WALs reconcile',
+    );
+    provider.dispose();
+  });
+
+  test('partial localUploadFailures still complete then surface error', () async {
+    SharedPreferences.setMockInitialValues({});
+    await SharedPreferencesUtil.init();
+    SyncRateLimiter.instance.clear();
+
+    final wal = Wal(timerStart: 1000, codec: BleAudioCodec.pcm16, seconds: 30, status: WalStatus.miss);
+    final syncs = _FakeSyncs([wal])
+      ..nextSyncResult = SyncLocalFilesResponse(
+        newConversationIds: [],
+        updatedConversationIds: [],
+        localUploadFailures: 1,
+      );
+    final wakes = <WakeTrigger>[];
+
+    final provider = SyncProvider(
+      walService: _FakeWalService(syncs),
+      startBackgroundSync: true,
+      waitForWalReady: (_) async {},
+      startRecovery: () async {},
+      wakeTransfer: (trigger) async {
+        wakes.add(trigger);
+      },
+    );
+    await provider.initialized;
+
+    await provider.syncWal(wal);
+
+    expect(provider.syncState.hasError, isTrue);
+    expect(provider.syncError, contains('Upload failed'));
+    // Still wakes — successful HTTP return with partial failures may include uploads.
+    expect(wakes, [WakeTrigger.cooldownElapsed]);
+    provider.dispose();
+  });
+}

--- a/app/test/providers/sync_provider_sync_wal_wake_test.dart
+++ b/app/test/providers/sync_provider_sync_wal_wake_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:omi/backend/preferences.dart';
 import 'package:omi/backend/schema/bt_device/bt_device.dart';
@@ -15,6 +16,7 @@ class _FakeSyncs {
   final List<Wal> wals;
   int syncWalCalls = 0;
   SyncLocalFilesResponse? nextSyncResult;
+  Completer<SyncLocalFilesResponse?>? hangSyncWal;
 
   _FakeSyncs(this.wals);
 
@@ -31,6 +33,8 @@ class _FakeSyncs {
 
   Future<SyncLocalFilesResponse?> syncWal({required Wal wal, IWalSyncProgressListener? progress}) async {
     syncWalCalls++;
+    final hang = hangSyncWal;
+    if (hang != null) return hang.future;
     final result = nextSyncResult ?? SyncLocalFilesResponse(newConversationIds: [], updatedConversationIds: []);
     if (result.localUploadFailures == 0 && result.newConversationIds.isEmpty) {
       // Mirror a 202 accepted upload: WAL becomes `uploaded`, no conversations yet.
@@ -126,6 +130,43 @@ void main() {
     expect(provider.syncError, contains('Upload failed'));
     // Still wakes — successful HTTP return with partial failures may include uploads.
     expect(wakes, [WakeTrigger.cooldownElapsed]);
+    provider.dispose();
+  });
+
+  test('syncWal during an in-flight sync wakes the coordinator instead of racing', () async {
+    SharedPreferences.setMockInitialValues({});
+    await SharedPreferencesUtil.init();
+    SyncRateLimiter.instance.clear();
+
+    final wal = Wal(timerStart: 1000, codec: BleAudioCodec.pcm16, seconds: 30, status: WalStatus.miss);
+    final other = Wal(timerStart: 2000, codec: BleAudioCodec.pcm16, seconds: 30, status: WalStatus.miss);
+    final hang = Completer<SyncLocalFilesResponse?>();
+    final syncs = _FakeSyncs([wal, other])..hangSyncWal = hang;
+    final wakes = <WakeTrigger>[];
+
+    final provider = SyncProvider(
+      walService: _FakeWalService(syncs),
+      startBackgroundSync: true,
+      waitForWalReady: (_) async {},
+      startRecovery: () async {},
+      wakeTransfer: (trigger) async {
+        wakes.add(trigger);
+      },
+    );
+    await provider.initialized;
+
+    final first = provider.syncWal(wal);
+    await Future<void>.delayed(Duration.zero);
+    expect(provider.isSyncing, isTrue);
+    expect(syncs.syncWalCalls, 1);
+
+    await provider.syncWal(other);
+
+    expect(syncs.syncWalCalls, 1, reason: 'contended syncWal must not start a parallel upload');
+    expect(wakes, [WakeTrigger.userRetry]);
+
+    hang.complete(SyncLocalFilesResponse(newConversationIds: [], updatedConversationIds: []));
+    await first;
     provider.dispose();
   });
 }

--- a/app/test/services/wals/recording_transfer_coordinator_test.dart
+++ b/app/test/services/wals/recording_transfer_coordinator_test.dart
@@ -138,6 +138,30 @@ void main() {
       expect(harness.reconciledUploadedWal, isTrue);
       expect(harness.reofferedUploadedWal, isFalse);
     });
+
+    test('partial drain failure still reconciles uploaded WALs before retry', () async {
+      final harness = _TransferHarness()
+        ..drainFails = true
+        ..drainNeedsReconciliation = true;
+      addTearDown(harness.dispose);
+
+      await harness.coordinator.wake(WakeTrigger.startup);
+
+      // Initial reconcile + post-drain reconcile for uploaded WALs.
+      expect(harness.reconcilePasses, 2);
+      expect(harness.scheduledCooldowns, hasLength(1));
+    });
+
+    test('contended drain schedules retry instead of clearing as success', () async {
+      final harness = _TransferHarness()..drainContended = true;
+      addTearDown(harness.dispose);
+
+      await harness.coordinator.wake(WakeTrigger.startup);
+
+      expect(harness.drainPasses, 1);
+      expect(harness.scheduledCooldowns, hasLength(1));
+      expect(harness.coordinator.nextCooldownAt, DateTime.utc(2026, 1, 1, 0, 0, 5));
+    });
   });
 }
 
@@ -180,6 +204,8 @@ class _TransferHarness {
 
   Completer<void>? reconcileGate;
   bool drainFails = false;
+  bool drainNeedsReconciliation = false;
+  bool drainContended = false;
   bool uploadedWalAwaitingReconcile = false;
   bool reconciledUploadedWal = false;
   bool reofferedUploadedWal = false;
@@ -215,12 +241,19 @@ class _TransferHarness {
     _concurrentDrains++;
     maximumConcurrentDrains = maximumConcurrentDrains < _concurrentDrains ? _concurrentDrains : maximumConcurrentDrains;
     try {
+      if (drainContended) {
+        return const RecordingTransferDrainResult.contended();
+      }
       if (uploadedWalAwaitingReconcile) reofferedUploadedWal = true;
       if (drainFails) {
         // This mirrors LocalWalSyncImpl's normal-return failure: the WAL stays
         // retryable and is not surfaced as synced.
         walState = 'miss';
-        return const RecordingTransferDrainResult(attempted: true, failed: true, needsReconciliation: false);
+        return RecordingTransferDrainResult(
+          attempted: true,
+          failed: true,
+          needsReconciliation: drainNeedsReconciliation,
+        );
       }
       drainedWalIds.addAll(backlog);
       backlog.clear();

--- a/app/test/services/wals/recording_transfer_coordinator_test.dart
+++ b/app/test/services/wals/recording_transfer_coordinator_test.dart
@@ -78,6 +78,25 @@ void main() {
       expect(harness.coordinator.nextCooldownAt, isNull);
     });
 
+    test('background recovery wakes wait for the foreground before draining', () async {
+      final harness = _TransferHarness();
+      addTearDown(harness.dispose);
+
+      harness.coordinator.setForeground(false);
+      harness.connectivity.add(false);
+      harness.connectivity.add(true);
+      await _settle();
+
+      expect(harness.reconcilePasses, 0);
+      expect(harness.drainPasses, 0);
+
+      harness.coordinator.setForeground(true);
+      await harness.coordinator.wake(WakeTrigger.foregrounded);
+
+      expect(harness.reconcilePasses, 1);
+      expect(harness.drainPasses, 1);
+    });
+
     test('startup resumes a pending backlog once without loss or duplication', () async {
       final sharedBacklog = <String>['pending-wal'];
       final drainedWalIds = <String>[];

--- a/app/test/services/wals/recording_transfer_coordinator_test.dart
+++ b/app/test/services/wals/recording_transfer_coordinator_test.dart
@@ -1,0 +1,219 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:omi/services/wals/recording_transfer_coordinator.dart';
+
+void main() {
+  group('RecordingTransferCoordinator', () {
+    test('connectivity restoration drains without a Bluetooth event (#7373)', () async {
+      final harness = _TransferHarness();
+      addTearDown(harness.dispose);
+
+      harness.connectivity.add(false);
+      harness.connectivity.add(true);
+      await _settle();
+
+      expect(harness.drainPasses, 1);
+    });
+
+    test('connectivity restoration drains after a successful startup pass', () async {
+      final harness = _TransferHarness();
+      addTearDown(harness.dispose);
+
+      await harness.coordinator.wake(WakeTrigger.startup);
+      harness.backlog.add('wal-after-startup');
+      harness.connectivity.add(false);
+      harness.connectivity.add(true);
+      await _settle();
+
+      expect(harness.drainPasses, 2);
+    });
+
+    test('five concurrent wakes schedule exactly one additional serial pass', () async {
+      final harness = _TransferHarness();
+      addTearDown(harness.dispose);
+      final reconcileGate = Completer<void>();
+      harness.reconcileGate = reconcileGate;
+
+      final firstWake = harness.coordinator.wake(WakeTrigger.startup);
+      await _settle();
+      expect(harness.reconcilePasses, 1);
+
+      final concurrentWakes = List.generate(
+        5,
+        (_) => harness.coordinator.wake(WakeTrigger.connectivityRestored),
+      );
+      reconcileGate.complete();
+      await Future.wait([firstWake, ...concurrentWakes]);
+
+      expect(harness.reconcilePasses, 2);
+      expect(harness.drainPasses, 1);
+      expect(harness.maximumConcurrentDrains, 1);
+    });
+
+    test('a retryable drain failure never presents synced and schedules cooldown', () async {
+      final harness = _TransferHarness()..drainFails = true;
+      addTearDown(harness.dispose);
+
+      await harness.coordinator.wake(WakeTrigger.startup);
+
+      expect(harness.walState, 'miss');
+      expect(harness.walState, isNot('synced'));
+      expect(harness.scheduledCooldowns, hasLength(1));
+      expect(harness.scheduledCooldowns.single.delay, const Duration(seconds: 5));
+      expect(harness.coordinator.nextCooldownAt, DateTime.utc(2026, 1, 1, 0, 0, 5));
+    });
+
+    test('backgrounding cancels a scheduled foreground cooldown wake', () async {
+      final harness = _TransferHarness()..drainFails = true;
+      addTearDown(harness.dispose);
+
+      await harness.coordinator.wake(WakeTrigger.startup);
+      final scheduled = harness.scheduledCooldowns.single;
+      harness.coordinator.setForeground(false);
+      scheduled.callback();
+      await _settle();
+
+      expect(harness.drainPasses, 1);
+      expect(harness.coordinator.nextCooldownAt, isNull);
+    });
+
+    test('startup resumes a pending backlog once without loss or duplication', () async {
+      final sharedBacklog = <String>['pending-wal'];
+      final drainedWalIds = <String>[];
+      final firstProcess = _TransferHarness(backlog: sharedBacklog, drainedWalIds: drainedWalIds);
+      addTearDown(firstProcess.dispose);
+
+      await firstProcess.coordinator.wake(WakeTrigger.startup);
+      expect(drainedWalIds, ['pending-wal']);
+      expect(sharedBacklog, isEmpty);
+
+      final restartedProcess = _TransferHarness(backlog: sharedBacklog, drainedWalIds: drainedWalIds);
+      addTearDown(restartedProcess.dispose);
+      await restartedProcess.coordinator.wake(WakeTrigger.startup);
+
+      expect(drainedWalIds, ['pending-wal']);
+      expect(restartedProcess.drainPasses, 0);
+    });
+
+    test('auto-sync opt-out still reconciles and reports pending, while retry uploads', () async {
+      final harness = _TransferHarness(autoUploadEnabled: false);
+      addTearDown(harness.dispose);
+
+      await harness.coordinator.wake(WakeTrigger.startup);
+      expect(harness.reconcilePasses, 1);
+      expect(harness.discoveryPasses, 1);
+      expect(harness.pendingRefreshes, 1);
+      expect(harness.drainPasses, 0);
+
+      await harness.coordinator.wake(WakeTrigger.userRetry);
+      expect(harness.drainPasses, 1);
+    });
+
+    test('uploaded WALs resolve before the drain can offer bytes again', () async {
+      final harness = _TransferHarness()..uploadedWalAwaitingReconcile = true;
+      addTearDown(harness.dispose);
+
+      await harness.coordinator.wake(WakeTrigger.connectivityRestored);
+
+      expect(harness.reconciledUploadedWal, isTrue);
+      expect(harness.reofferedUploadedWal, isFalse);
+    });
+  });
+}
+
+Future<void> _settle() => Future<void>.delayed(Duration.zero);
+
+class _ScheduledCooldown {
+  const _ScheduledCooldown(this.delay, this.callback);
+
+  final Duration delay;
+  final void Function() callback;
+}
+
+class _TransferHarness {
+  _TransferHarness({
+    bool autoUploadEnabled = true,
+    List<String>? backlog,
+    List<String>? drainedWalIds,
+  })  : _autoUploadEnabled = autoUploadEnabled,
+        backlog = backlog ?? <String>['wal-1'],
+        drainedWalIds = drainedWalIds ?? <String>[] {
+    coordinator = RecordingTransferCoordinator(
+      reconcile: _reconcile,
+      discover: _discover,
+      refreshPending: _refreshPending,
+      drain: _drain,
+      autoUploadEnabled: () => _autoUploadEnabled,
+      connectivityChanges: connectivity.stream,
+      initiallyConnected: true,
+      clock: () => DateTime.utc(2026, 1, 1),
+      scheduleCooldown: (delay, callback) => scheduledCooldowns.add(_ScheduledCooldown(delay, callback)),
+    );
+  }
+
+  final bool _autoUploadEnabled;
+  final StreamController<bool> connectivity = StreamController<bool>.broadcast(sync: true);
+  final List<String> backlog;
+  final List<String> drainedWalIds;
+  final List<_ScheduledCooldown> scheduledCooldowns = [];
+  late final RecordingTransferCoordinator coordinator;
+
+  Completer<void>? reconcileGate;
+  bool drainFails = false;
+  bool uploadedWalAwaitingReconcile = false;
+  bool reconciledUploadedWal = false;
+  bool reofferedUploadedWal = false;
+  String walState = 'miss';
+  int reconcilePasses = 0;
+  int discoveryPasses = 0;
+  int pendingRefreshes = 0;
+  int drainPasses = 0;
+  int _concurrentDrains = 0;
+  int maximumConcurrentDrains = 0;
+
+  Future<void> _reconcile() async {
+    reconcilePasses++;
+    if (uploadedWalAwaitingReconcile) {
+      uploadedWalAwaitingReconcile = false;
+      reconciledUploadedWal = true;
+    }
+    final gate = reconcileGate;
+    if (gate != null) await gate.future;
+  }
+
+  Future<void> _discover() async {
+    discoveryPasses++;
+  }
+
+  Future<void> _refreshPending() async {
+    pendingRefreshes++;
+  }
+
+  Future<RecordingTransferDrainResult> _drain() async {
+    if (backlog.isEmpty) return const RecordingTransferDrainResult.skipped();
+    drainPasses++;
+    _concurrentDrains++;
+    maximumConcurrentDrains = maximumConcurrentDrains < _concurrentDrains ? _concurrentDrains : maximumConcurrentDrains;
+    try {
+      if (uploadedWalAwaitingReconcile) reofferedUploadedWal = true;
+      if (drainFails) {
+        // This mirrors LocalWalSyncImpl's normal-return failure: the WAL stays
+        // retryable and is not surfaced as synced.
+        walState = 'miss';
+        return const RecordingTransferDrainResult(attempted: true, failed: true, needsReconciliation: false);
+      }
+      drainedWalIds.addAll(backlog);
+      backlog.clear();
+      walState = 'uploaded';
+      return const RecordingTransferDrainResult(attempted: true, failed: false, needsReconciliation: false);
+    } finally {
+      _concurrentDrains--;
+    }
+  }
+
+  Future<void> dispose() async {
+    coordinator.dispose();
+    await connectivity.close();
+  }
+}

--- a/app/test/unit/wal_recovery_test.dart
+++ b/app/test/unit/wal_recovery_test.dart
@@ -462,19 +462,23 @@ void main() {
 
       final listener = _FakeListener();
       final sync = LocalWalSyncImpl(listener);
-      sync.start();
+      try {
+        sync.start();
 
-      // walReady should complete once _initializeWals finishes
-      await sync.walReady;
-      // If we get here, the Completer completed successfully
-      expect(true, isTrue);
-
-      sync.stop();
-      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(
-        const MethodChannel('plugins.flutter.io/path_provider'),
-        null,
-      );
-      if (tempDir.existsSync()) tempDir.deleteSync(recursive: true);
+        // walReady should complete once _initializeWals finishes
+        await sync.walReady;
+        // If we get here, the Completer completed successfully
+        expect(true, isTrue);
+      } finally {
+        // Must await stop before deleting tempDir — unawaited flush/save races
+        // the teardown and flakes under suite concurrency (CI).
+        await sync.stop();
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(
+          const MethodChannel('plugins.flutter.io/path_provider'),
+          null,
+        );
+        if (tempDir.existsSync()) tempDir.deleteSync(recursive: true);
+      }
     });
   });
 }

--- a/app/test/widgets/transcript_test.dart
+++ b/app/test/widgets/transcript_test.dart
@@ -28,7 +28,7 @@ void main() {
     await SharedPreferencesUtil.init();
   }
 
-  TranscriptSegment _segment(String id, int speakerId) {
+  TranscriptSegment segmentFor(String id, int speakerId) {
     // Note: speakerId is extracted from speaker string by TranscriptSegment constructor
     return TranscriptSegment(
       id: id,
@@ -87,7 +87,7 @@ void main() {
     });
 
     testWidgets('shows Speaker X when no person is assigned', (tester) async {
-      final segment = _segment('seg2', 0);
+      final segment = segmentFor('seg2', 0);
 
       await tester.pumpWidget(
         MaterialApp(
@@ -108,7 +108,7 @@ void main() {
     });
 
     testWidgets('Tag button is removed from UI', (tester) async {
-      final segment = _segment('seg3', 1);
+      final segment = segmentFor('seg3', 1);
       final suggestion = SpeakerLabelSuggestionEvent(
         speakerId: 1,
         personId: 'person-456',


### PR DESCRIPTION
## Summary

- Adds `RecordingTransferCoordinator` as the single foreground owner for recording recovery wakes.
- Routes startup, connectivity restoration, foreground, device connection, cooldown, and user retry through the coordinator.
- Reconciles uploaded WALs before discovery/drain, preserves the auto-sync preference for automatic wakes, and retries normal-return local upload failures with bounded foreground cooldowns.

## Root cause and durable guard

Recovery ownership was split: `CaptureController` retried only orphan WALs when startup had been skipped, `SyncReconciler` only polled uploaded jobs, and `SyncProvider` separately auto-drained phone files. Consequently, restoring connectivity after a successful startup pass did not drain retryable WALs until an incidental device reconnect.

This PR makes the coordinator the authoritative wake owner and adds a hermetic production-coordinator harness covering connectivity recovery, post-startup recovery, singleflight coalescing, retryable failures, restart backlog recovery, preference gating/user retry, uploaded-job ordering, and background cooldown cancellation.

The coordinator's post-configuration wake is the sole startup emitter. `CaptureController` no longer schedules recovery from proxy-provider external-action updates; a fake-async regression test proves repeated updates add no delayed startup timers. Startup waits for the persisted phone-WAL readiness barrier before the coordinator attaches, and background lifecycle state prevents connectivity/device recovery wakes from starting discovery or a drain until foregrounded.

Recurrence evidence: #7373, #9471, and the stranded-backlog aspect of #7240.

## Verification

- `cd app && flutter test test/services/wals/recording_transfer_coordinator_test.dart`
- `cd app && flutter test test/providers/sync_provider_startup_reconciliation_test.dart test/services/wals/recording_transfer_coordinator_test.dart test/providers/capture_provider_test.dart`
- `cd app && bash test.sh` (813 tests passed)
- `cd app && flutter test test/widgets/transcript_test.dart`
- `cd app && ./scripts/analyze_ratchet.sh`
- `make preflight`

I could not perform the required physical-device airplane-mode flow: this Mac has no connected Omi device and no iOS/Android emulator. The PR does not claim that hardware verification occurred.

## Scope

Closes #9752.

Does not close #9471, #7240, or #7221. No backend, protocol, persistence-schema, or OS background-execution changes.
