### PR TITLE
fix(cli): enforce owner-only config ACLs on Windows

### DIFF
--- a/.github/failure-classes/FC-private-credential-file-permissions.json
+++ b/.github/failure-classes/FC-private-credential-file-permissions.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": 1,
+  "id": "FC-private-credential-file-permissions",
+  "violated_contract": "Credential material must not be persisted unless the destination is created with enforceable owner-only access before the first byte is written.",
+  "canonical_prevention": "Route credential persistence through a platform-specific secure-create primitive that applies owner-only permissions atomically, verifies the effective policy before writing, and runs its behavioral contract on every supported operating system.",
+  "canonical_prevention_artifact": [
+    "sdks/python-cli/tests/test_config.py",
+    ".github/workflows/python-cli-ci.yml"
+  ],
+  "evidence_prs": [9764],
+  "scope_hints": [
+    "sdks/python-cli/**",
+    "backend/scripts/*credential*.py",
+    "backend/utils/*credential*.py"
+  ],
+  "status": "open"
+}

--- a/.github/workflows/python-cli-ci.yml
+++ b/.github/workflows/python-cli-ci.yml
@@ -1,0 +1,54 @@
+name: Python CLI
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'sdks/python-cli/**'
+      - '.github/workflows/python-cli-ci.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'sdks/python-cli/**'
+      - '.github/workflows/python-cli-ci.yml'
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    working-directory: sdks/python-cli
+
+jobs:
+  tests:
+    name: ${{ matrix.label }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - label: Linux / Python 3.10
+            os: ubuntu-latest
+            python-version: '3.10'
+          - label: Linux / Python 3.12
+            os: ubuntu-latest
+            python-version: '3.12'
+          - label: Windows ACL / Python 3.12
+            os: windows-latest
+            python-version: '3.12'
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: sdks/python-cli/pyproject.toml
+
+      - name: Install package and test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[dev]"
+
+      - name: Run tests
+        run: python -m pytest -q

--- a/sdks/python-cli/omi_cli/_secure_file.py
+++ b/sdks/python-cli/omi_cli/_secure_file.py
@@ -1,0 +1,204 @@
+"""Create credential files with owner-only access on POSIX and Windows.
+
+The Windows DACL deliberately omits SYSTEM and Administrators so only the
+Windows object owner receives file access.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import errno
+import os
+import sys
+from ctypes import wintypes
+from pathlib import Path
+from typing import Any
+
+# Protected DACL: FILE_ALL_ACCESS for the file owner, with no inherited ACEs.
+_WINDOWS_OWNER_ONLY_DACL = "D:P(A;;FA;;;OW)"
+_SDDL_REVISION_1 = 1
+_SE_FILE_OBJECT = 1
+_DACL_SECURITY_INFORMATION = 0x00000004
+_READ_CONTROL = 0x00020000
+_GENERIC_WRITE = 0x40000000
+_CREATE_NEW = 1
+_FILE_ATTRIBUTE_NORMAL = 0x80
+_ERROR_FILE_EXISTS = 80
+_ERROR_ALREADY_EXISTS = 183
+
+
+class _SecurityAttributes(ctypes.Structure):
+    _fields_ = [
+        ("nLength", wintypes.DWORD),
+        ("lpSecurityDescriptor", wintypes.LPVOID),
+        ("bInheritHandle", wintypes.BOOL),
+    ]
+
+
+def open_owner_only(path: Path) -> int:
+    """Create *path* exclusively and return a writable, owner-only descriptor."""
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+    if sys.platform != "win32":
+        return os.open(path, flags, 0o600)
+    return _open_owner_only_windows(path)
+
+
+if sys.platform == "win32":
+    import msvcrt
+
+    def _open_owner_only_windows(path: Path) -> int:
+        advapi32 = ctypes.WinDLL("advapi32", use_last_error=True)
+        kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+
+        convert_sddl = advapi32.ConvertStringSecurityDescriptorToSecurityDescriptorW
+        convert_sddl.argtypes = [
+            wintypes.LPCWSTR,
+            wintypes.DWORD,
+            ctypes.POINTER(wintypes.LPVOID),
+            ctypes.POINTER(wintypes.ULONG),
+        ]
+        convert_sddl.restype = wintypes.BOOL
+
+        create_file = kernel32.CreateFileW
+        create_file.argtypes = [
+            wintypes.LPCWSTR,
+            wintypes.DWORD,
+            wintypes.DWORD,
+            ctypes.POINTER(_SecurityAttributes),
+            wintypes.DWORD,
+            wintypes.DWORD,
+            wintypes.HANDLE,
+        ]
+        create_file.restype = wintypes.HANDLE
+
+        local_free = kernel32.LocalFree
+        local_free.argtypes = [wintypes.HLOCAL]
+        local_free.restype = wintypes.HLOCAL
+
+        security_descriptor = wintypes.LPVOID()
+        descriptor_size = wintypes.ULONG()
+        if not convert_sddl(
+            _WINDOWS_OWNER_ONLY_DACL,
+            _SDDL_REVISION_1,
+            ctypes.byref(security_descriptor),
+            ctypes.byref(descriptor_size),
+        ):
+            error = ctypes.get_last_error()
+            raise OSError(error, "Windows could not build an owner-only security descriptor", str(path))
+
+        try:
+            attributes = _SecurityAttributes(
+                ctypes.sizeof(_SecurityAttributes),
+                security_descriptor,
+                False,
+            )
+            # READ_CONTROL lets us verify the DACL before writing any credential.
+            handle = create_file(
+                str(path),
+                _GENERIC_WRITE | _READ_CONTROL,
+                0,
+                ctypes.byref(attributes),
+                _CREATE_NEW,
+                _FILE_ATTRIBUTE_NORMAL,
+                None,
+            )
+            create_error = ctypes.get_last_error() if handle == wintypes.HANDLE(-1).value else 0
+        finally:
+            local_free(security_descriptor)
+
+        if handle == wintypes.HANDLE(-1).value:
+            error = create_error
+            if error in {_ERROR_FILE_EXISTS, _ERROR_ALREADY_EXISTS}:
+                raise FileExistsError(errno.EEXIST, os.strerror(errno.EEXIST), str(path))
+            raise OSError(error, "Windows could not create the owner-only file", str(path))
+
+        close_handle = kernel32.CloseHandle
+        close_handle.argtypes = [wintypes.HANDLE]
+        close_handle.restype = wintypes.BOOL
+
+        try:
+            if _windows_dacl_sddl(handle) != _WINDOWS_OWNER_ONLY_DACL:
+                raise PermissionError(errno.EACCES, "Windows did not enforce owner-only file permissions", str(path))
+            descriptor_flags = os.O_WRONLY | getattr(os, "O_BINARY", 0)
+            return msvcrt.open_osfhandle(handle, descriptor_flags)
+        except BaseException:
+            close_handle(handle)
+            try:
+                path.unlink(missing_ok=True)
+            except OSError:
+                pass
+            raise
+
+    def _windows_dacl_sddl(handle: int, *, _advapi32: Any = None, _kernel32: Any = None) -> str:
+        """Return the protected DACL for a Windows file handle as stable SDDL."""
+        advapi32 = _advapi32 or ctypes.WinDLL("advapi32", use_last_error=True)
+        kernel32 = _kernel32 or ctypes.WinDLL("kernel32", use_last_error=True)
+
+        get_security_info = advapi32.GetSecurityInfo
+        get_security_info.argtypes = [
+            wintypes.HANDLE,
+            wintypes.DWORD,
+            wintypes.DWORD,
+            ctypes.POINTER(wintypes.LPVOID),
+            ctypes.POINTER(wintypes.LPVOID),
+            ctypes.POINTER(wintypes.LPVOID),
+            ctypes.POINTER(wintypes.LPVOID),
+            ctypes.POINTER(wintypes.LPVOID),
+        ]
+        get_security_info.restype = wintypes.DWORD
+
+        convert_sddl = advapi32.ConvertSecurityDescriptorToStringSecurityDescriptorW
+        convert_sddl.argtypes = [
+            wintypes.LPVOID,
+            wintypes.DWORD,
+            wintypes.DWORD,
+            ctypes.POINTER(wintypes.LPWSTR),
+            ctypes.POINTER(wintypes.ULONG),
+        ]
+        convert_sddl.restype = wintypes.BOOL
+
+        local_free = kernel32.LocalFree
+        local_free.argtypes = [wintypes.HLOCAL]
+        local_free.restype = wintypes.HLOCAL
+
+        security_descriptor = wintypes.LPVOID()
+        dacl = wintypes.LPVOID()
+        result = get_security_info(
+            handle,
+            _SE_FILE_OBJECT,
+            _DACL_SECURITY_INFORMATION,
+            None,
+            None,
+            ctypes.byref(dacl),
+            None,
+            ctypes.byref(security_descriptor),
+        )
+        if result != 0:
+            raise OSError(result, "Windows could not read the file security descriptor")
+
+        try:
+            sddl = wintypes.LPWSTR()
+            sddl_length = wintypes.ULONG()
+            if not convert_sddl(
+                security_descriptor,
+                _SDDL_REVISION_1,
+                _DACL_SECURITY_INFORMATION,
+                ctypes.byref(sddl),
+                ctypes.byref(sddl_length),
+            ):
+                error = ctypes.get_last_error()
+                raise OSError(error, "Windows could not verify the owner-only DACL")
+            try:
+                return sddl.value or ""
+            finally:
+                local_free(sddl)
+        finally:
+            local_free(security_descriptor)
+
+else:
+
+    def _open_owner_only_windows(path: Path) -> int:
+        raise OSError(errno.ENOSYS, "Windows owner-only file creation is unavailable", str(path))
+
+    def _windows_dacl_sddl(handle: int, *, _advapi32: Any = None, _kernel32: Any = None) -> str:
+        raise OSError(errno.ENOSYS, "Windows DACL inspection is unavailable")

--- a/sdks/python-cli/omi_cli/config.py
+++ b/sdks/python-cli/omi_cli/config.py
@@ -22,6 +22,8 @@ from typing import Any, Optional
 
 import tomli_w
 
+from omi_cli._secure_file import open_owner_only
+
 if sys.version_info >= (3, 11):
     import tomllib
 else:  # pragma: no cover — exercised only on 3.10
@@ -176,12 +178,9 @@ def load(path: Optional[Path] = None) -> Config:
 def save(config: Config) -> None:
     """Persist the config to disk with secure (owner-only) permissions.
 
-    The temp file is **created** with mode ``0o600`` via :func:`os.open`, not
-    chmodded after the fact — this closes a TOCTOU window where another local
-    user could read bearer credentials between file creation (default umask,
-    typically ``0o644``) and the chmod call. We also temporarily clamp the
-    process umask to ``0o077`` so any platform that ANDs the requested mode
-    against the umask still ends up with owner-only perms.
+    The temp file is created with owner-only access before any credential is
+    written. POSIX uses mode ``0o600``; Windows uses a protected owner-rights
+    DACL supplied directly to ``CreateFileW``.
     """
     config.path.parent.mkdir(parents=True, exist_ok=True)
     # Tighten parent dir perms too — credentials live underneath. Best-effort:
@@ -197,16 +196,16 @@ def save(config: Config) -> None:
     }
 
     tmp_path = config.path.with_suffix(config.path.suffix + ".tmp")
-    # Belt-and-suspenders: clamp umask AND pass an explicit 0o600 mode to os.open.
+    # Clamp the umask for POSIX. The Windows helper applies an equivalent DACL.
     old_umask = os.umask(0o077)
     try:
         # O_EXCL guards against following an attacker-planted symlink at this path.
         try:
-            fd = os.open(tmp_path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+            fd = open_owner_only(tmp_path)
         except FileExistsError:
             # Stale temp from a previous interrupted save — remove and retry once.
             os.unlink(tmp_path)
-            fd = os.open(tmp_path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+            fd = open_owner_only(tmp_path)
         try:
             with os.fdopen(fd, "wb") as fh:
                 tomli_w.dump(payload, fh)

--- a/sdks/python-cli/tests/test_config.py
+++ b/sdks/python-cli/tests/test_config.py
@@ -5,9 +5,30 @@ from __future__ import annotations
 import os
 import stat
 from pathlib import Path
+from typing import BinaryIO
 
+import pytest
+
+from omi_cli import _secure_file
 from omi_cli import config as cfg
 from omi_cli.main import app
+
+
+def _assert_owner_only_descriptor(handle: BinaryIO) -> None:
+    if os.name == "nt":
+        import msvcrt  # type: ignore[import-not-found]
+
+        windows_handle = msvcrt.get_osfhandle(handle.fileno())
+        assert _secure_file._windows_dacl_sddl(windows_handle) == "D:P(A;;FA;;;OW)"
+        return
+
+    mode = stat.S_IMODE(os.fstat(handle.fileno()).st_mode)
+    assert mode == 0o600
+
+
+def _assert_owner_only(path: Path) -> None:
+    with path.open("rb") as handle:
+        _assert_owner_only_descriptor(handle)
 
 
 def test_default_config_path_honors_env(monkeypatch, tmp_path: Path) -> None:
@@ -55,22 +76,29 @@ def test_save_creates_file_with_secure_perms(config_path: Path) -> None:
     config.set_profile(profile)
     cfg.save(config)
 
-    mode = stat.S_IMODE(os.stat(config_path).st_mode)
-    # Owner read/write only — credentials are inside.
-    assert mode == 0o600
+    _assert_owner_only(config_path)
 
 
 def test_save_does_not_leave_world_readable_window(monkeypatch, config_path: Path) -> None:
     """TOCTOU regression test (Greptile P1).
 
-    Force a permissive umask, save the config, and assert that *neither* the
-    final file nor any leftover temp file is world-readable. Earlier versions
-    of ``save()`` created the temp with default umask perms (~0o644) before
-    chmodding to 0o600 — that left a window where another local user could
-    read bearer credentials.
+    Force a permissive umask, inspect the temp file when serialization starts,
+    and assert that neither it nor the final file is accessible to other users.
+    Earlier versions created the temp with inherited/default permissions before
+    tightening them, which exposed bearer credentials during serialization.
     """
-    # Force a permissive umask. If save() relied on umask alone, the file would
-    # be created at 0o666 by default and the test would fail.
+    tmp = config_path.with_suffix(config_path.suffix + ".tmp")
+    original_dump = cfg.tomli_w.dump
+    checked_during_write = False
+
+    def dump_after_permission_check(payload, handle) -> None:
+        nonlocal checked_during_write
+        _assert_owner_only_descriptor(handle)
+        checked_during_write = True
+        original_dump(payload, handle)
+
+    monkeypatch.setattr(cfg.tomli_w, "dump", dump_after_permission_check)
+
     old_umask = os.umask(0o000)
     try:
         config = cfg.load()
@@ -82,13 +110,25 @@ def test_save_does_not_leave_world_readable_window(monkeypatch, config_path: Pat
     finally:
         os.umask(old_umask)
 
-    # Final file is owner-only.
-    mode = stat.S_IMODE(os.stat(config_path).st_mode)
-    assert mode == 0o600
-
-    # No leftover temp file with relaxed perms.
-    tmp = config_path.with_suffix(config_path.suffix + ".tmp")
+    assert checked_during_write
+    _assert_owner_only(config_path)
     assert not tmp.exists()
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows DACL enforcement only")
+def test_save_fails_closed_when_windows_dacl_verification_fails(monkeypatch, config_path: Path) -> None:
+    monkeypatch.setattr(_secure_file, "_windows_dacl_sddl", lambda _handle: "D:")
+    config = cfg.load()
+    profile = config.get_profile()
+    profile.auth_method = "api_key"
+    profile.api_key = "omi_dev_secret"
+    config.set_profile(profile)
+
+    with pytest.raises(PermissionError, match="did not enforce owner-only"):
+        cfg.save(config)
+
+    assert not config_path.exists()
+    assert not config_path.with_suffix(config_path.suffix + ".tmp").exists()
 
 
 def test_save_overwrites_stale_temp_file(config_path: Path) -> None:


### PR DESCRIPTION
## What changed and why

`omi-cli` stores API keys, OAuth tokens, and local bearer tokens in `config.toml`, whose contract is owner-only. On Windows, Python accepts POSIX `0o600` flags but creates a file without an equivalent owner-only DACL, so this change routes config writes through a secure-create primitive that applies and verifies the platform policy before serialization starts.

The POSIX path still creates files as `0600`. The Windows path supplies a protected owner-only DACL to `CreateFileW`, denies handle sharing during serialization, reads the effective DACL back through the open handle, and fails closed without leaving a credential file if enforcement cannot be verified. The DACL deliberately omits SYSTEM and Administrators so only the Windows object owner receives file access.

This update also adds path-scoped Python CLI CI on Linux 3.10/3.12 and Windows 3.12. The Windows leg executes the real Win32 ACL contract that Linux-only release CI could not cover.

## Product invariants affected

none

## How it was verified

- CPython 3.10 on Windows: full `python -m pytest -q` suite passed (126 tests).
- CPython 3.12 on Windows: full `python -m pytest -q` suite passed (126 tests).
- CPython 3.12 focused Win32 path: secure final file, no world-readable serialization window, and fail-closed DACL verification all passed (3 tests).
- `actionlint .github/workflows/python-cli-ci.yml` passed.
- `black --check --line-length 120 --skip-string-normalization .` passed (36 files unchanged).
- `git diff --check` and 12 selected manifest checks passed locally.
- The remaining `check-manifest-contract` check is not runnable on current
  Windows `main`: its own platform self-test accepts only `all`, `linux`, and
  `macos`. The Linux repository-check lane remains authoritative for that check.

The tests exercise `cfg.save()` against real temporary files. On Windows they inspect the live native handle while `tomli_w.dump` is running, so the evidence covers the pre-write ACL rather than only the final file.

## Tests

`sdks/python-cli/tests/test_config.py` covers the secure final file, the in-progress descriptor before credential bytes are written, stale temporary-file recovery, and fail-closed cleanup when Windows DACL verification is altered.

## Failure class (fixes)

Failure-Class: new

## Failure-class transition narrative (only when needed)

Violated contract: credential material must not be persisted unless the destination is created with enforceable owner-only access before the first byte is written.

Canonical prevention: all CLI config persistence now uses `omi_cli._secure_file.open_owner_only`, which applies the native policy atomically and verifies it before serialization. The behavioral contract lives in `sdks/python-cli/tests/test_config.py`, and `.github/workflows/python-cli-ci.yml` runs it on a real Windows host. PR #9764 is the evidence instance.

## New guards (only when adding a check or ratchet)

This Windows CI leg would have caught the permission defect evidenced by PR #9764. The production fix is already a shared primitive for every `omi-cli` config write; the CI leg is still required because a POSIX runner cannot execute or validate Win32 ACL calls.
