### PR TITLE
docs(agents): collapse root AGENTS.md into a lean JIT index + budget ratchet

### DIFF
--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -17,6 +17,11 @@ checks:
     triggers: [".github/schemas/desktop-release-evidence-v1.schema.json", ".github/scripts/desktop_release_doctor.py", ".github/scripts/desktop_release_doctor_report.py", ".github/scripts/test_desktop_release_doctor.py", ".github/workflows/desktop_release_doctor.yml"]
     lanes: ["local", "ci"]
     reason: "advisory desktop release evidence and drift report"
+  - id: agents-md-lean
+    command: ["python3", ".github/scripts/check_agents_md_lean.py"]
+    triggers: ["AGENTS.md", ".github/scripts/check_agents_md_lean.py"]
+    lanes: ["local", "ci"]
+    reason: "root AGENTS.md stays a lean index; detail lives in component guides"
   - id: diff-hygiene
     command: ["python3", ".github/scripts/check_diff_hygiene.py", "--changed-files", "{changed_files}", "--base", "{base}", "--head", "{head}"]
     triggers: ["all"]

--- a/.github/scripts/check_agents_md_lean.py
+++ b/.github/scripts/check_agents_md_lean.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Enforce that the root AGENTS.md stays lean (high-level guidance + index).
+
+Root AGENTS.md is loaded into every agent session for every task, so every line
+costs context in every session. Detail belongs in the component guides
+(backend/AGENTS.md, app/AGENTS.md, desktop/macos/AGENTS.md, omi/firmware/AGENTS.md)
+or docs/, which agents load just-in-time.
+
+Budgets are a ratchet: shrink them when the file shrinks; never raise them to
+admit new detail that has a component-guide home.
+"""
+
+import sys
+import tempfile
+from pathlib import Path
+
+MAX_LINES = 180
+MAX_BYTES = 18_000
+
+FAILURE_HINT = (
+    "Root AGENTS.md must stay lean: it is loaded into every agent session.\n"
+    "Move detail into the matching component guide (backend/AGENTS.md,\n"
+    "app/AGENTS.md, desktop/macos/AGENTS.md, omi/firmware/AGENTS.md) or docs/,\n"
+    "and keep only the high-level rule plus a pointer here.\n"
+    "Do not raise the budget to admit detail that has a component-guide home."
+)
+
+
+def check(path: Path) -> list[str]:
+    data = path.read_bytes()
+    lines = data.decode("utf-8").count("\n") + (0 if data.endswith(b"\n") else 1)
+    errors = []
+    if lines > MAX_LINES:
+        errors.append(f"{path}: {lines} lines exceeds budget of {MAX_LINES}")
+    if len(data) > MAX_BYTES:
+        errors.append(f"{path}: {len(data)} bytes exceeds budget of {MAX_BYTES}")
+    return errors
+
+
+def self_test() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        small = Path(tmp) / "small.md"
+        small.write_text("# ok\n")
+        assert check(small) == [], "lean file must pass"
+
+        long_file = Path(tmp) / "long.md"
+        long_file.write_text("x\n" * (MAX_LINES + 1))
+        assert any("lines" in e for e in check(long_file)), "over-lines must fail"
+
+        fat = Path(tmp) / "fat.md"
+        fat.write_text("y" * (MAX_BYTES + 1))
+        assert any("bytes" in e for e in check(fat)), "over-bytes must fail"
+
+
+def main() -> int:
+    self_test()
+    root = Path(__file__).resolve().parents[2]
+    target = root / "AGENTS.md"
+    if not target.exists():
+        print(f"ERROR: {target} not found", file=sys.stderr)
+        return 1
+    errors = check(target)
+    if errors:
+        for error in errors:
+            print(f"ERROR: {error}", file=sys.stderr)
+        print(FAILURE_HINT, file=sys.stderr)
+        return 1
+    print(f"ok: AGENTS.md within budget ({MAX_LINES} lines / {MAX_BYTES} bytes)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,334 +4,94 @@
 
 # Omi Agent Guide
 
-These rules apply to every AI agent working in this repository. This file is the single source of truth; `CLAUDE.md` just points here.
+These rules apply to every AI agent working in this repository. This file is **high-level guidance plus an index** — component guides carry the detail; load them just-in-time for the area you are working in. `CLAUDE.md` just points here. A CI check (`.github/scripts/check_agents_md_lean.py`) keeps this file lean: add detail to the component guide, not here.
 
-**Two audiences read this file.** Engineering standards (Definition of Done, coding guidelines, testing, formatting) apply to everyone — maintainers and open-source contributors alike. Rules about this repo's `main` branch, production app bundles, deploys, and local machine workflows assume a maintainer environment; if you are working in a fork, follow your user's process for landing changes and skip those. Contributor flow: `docs/doc/developer/Contribution.mdx`. Product direction and locked invariants: `PRODUCT.md` and `docs/product/invariants/`.
+**Two audiences read this file.** Engineering standards (Definition of Done, testing, formatting) apply to everyone — maintainers and open-source contributors alike. Rules about this repo's `main` branch, production app bundles, deploys, and local machine workflows assume a maintainer environment; in a fork, follow your user's process for landing changes and skip those. Contributor flow: `docs/doc/developer/Contribution.mdx`.
+
+## Read Next (just-in-time)
+
+| Working on | Read first |
+|---|---|
+| Backend Python (`backend/`) | `backend/AGENTS.md` — setup, async/executors, WebSocket rules, service map, logging security, testing |
+| Flutter app (`app/`) | `app/AGENTS.md` — build flavors, l10n, native bridge, tests, agent-flutter UI verification |
+| Desktop macOS (`desktop/macos/`) | `desktop/macos/AGENTS.md` — build/run, named bundles, self-testing, release pipeline, changelog |
+| Firmware (`omi/firmware/`) | `omi/firmware/AGENTS.md` — release workflow |
+| Product behavior | `PRODUCT.md` + `docs/product/invariants/` — locked invariants and guard tests |
+| Fallback/fail-open branches | `docs/agents/fallback-telemetry.md` — when to call `record_fallback` |
+| App flows / E2E | `app/e2e/SKILL.md`, `desktop/macos/e2e/SKILL.md` |
+| Cursor Cloud VM (Linux x86) | `.cursor/cloud-agent-environment.md` — hermetic E2E harness, known failures |
 
 ## Definition of Done
 
-Every change must satisfy this checklist before it is committed or put in a PR. When in doubt about any other rule in this file, satisfying this list is the priority.
+Every change must satisfy this checklist before it is committed or put in a PR. When in doubt about any other rule, satisfying this list is the priority.
 
 1. **Behavior changed → a test changed.** Bug fixes include the regression test that would have caught the bug. New features test the core path and the main error path — no more.
 2. **The component's test suite passes** (`backend/test.sh`, `app/test.sh`, or the component's documented equivalent), run locally before committing.
 3. **You exercised the change yourself** — ran the real user-facing path, not just compiled or lint-passed. If you truly could not, say so explicitly instead of implying it works.
 4. **Verification evidence is written down** — the commands you ran and what they showed, in the commit message or PR description.
 5. **No orphaned deferrals** — new `TODO`/`FIXME`/`HACK` comments reference a tracking issue or are resolved before merge.
-6. **Docs moved with the code** — if you changed setup, test commands, service boundaries, env vars, or agent-relevant behavior, the matching doc (this file, a component `AGENTS.md`, or `docs/doc/developer/`) is updated in the same PR. Product-direction or invariant changes update `PRODUCT.md` / `docs/product/invariants/` in the same PR.
+6. **Docs moved with the code** — setup, test commands, service boundaries, env vars, or agent-relevant behavior changes update the matching guide (this file, a component `AGENTS.md`, or `docs/doc/developer/`) in the same PR. Product-direction or invariant changes update `PRODUCT.md` / `docs/product/invariants/` in the same PR.
 7. **Bug classes are closed, not patched around** — write down the root cause and the durable guard in the PR. When recent history contains the same failure class, fix the shared boundary, state model, harness, or static contract that allowed all of them.
-8. **PR contracts pass before opening the PR** — run `make preflight`; it executes the same deterministic check manifest CI runs (`.github/checks-manifest.yaml`). Draft the PR body and run `scripts/pr-preflight --pr-body-file /tmp/pr-body.md` when product-invariant citations apply (or use `scripts/pr-preflight --suggest` to get the paste-ready IDs).
+8. **PR contracts pass before opening the PR** — run `make preflight`; it executes the same deterministic check manifest CI runs (`.github/checks-manifest.yaml`). When product-invariant citations apply, draft the PR body and run `scripts/pr-preflight --pr-body-file /tmp/pr-body.md` (or `scripts/pr-preflight --suggest` for paste-ready IDs).
 
 A deterministic diff-scoped check failing for the first time in CI is a manifest bug: fix the manifest instead of adding a one-off workflow step. Register new checks in `.github/checks-manifest.yaml` with both `local` and `ci` lanes.
 
 ## Bug Fixes: Close the Failure Class
 
-Before implementing a bug fix, inspect recent fixes in the same subsystem. The
-unit of work is the violated contract, not only the line where the symptom
-appeared.
+The unit of work is the violated contract, not only the line where the symptom appeared. Before fixing, inspect recent fixes in the same subsystem.
 
-- Identify the authoritative owner, identity, state transition, or boundary
-  contract that failed. Avoid adding another observer, fallback boolean, status
-  string heuristic, or call-site exception when ownership is the real problem.
-- If two or more recent fixes share the cause, add a reusable guard surface in
-  the same PR: a typed state/policy model, behavioral contract test, fault
-  harness, compatibility check, or narrow static checker.
-- A regression test must execute production behavior through a controllable
-  seam. Reading production source and asserting that strings occur in a certain
-  order is a static tripwire, not behavioral coverage; label and test static
-  checkers as such.
-- Record the root cause, recurrence evidence, durable guard, real-path exercise,
-  and any deliberately deferred high-blast-radius follow-up in the PR body.
-- Do not broaden a safe bug-fix PR into an unreviewable migration. Land the
-  enforceable guard now and track schema, data-migration, or deploy-rollout work
-  explicitly when it requires its own rollback plan.
+- Identify the authoritative owner, identity, state transition, or boundary contract that failed — don't add another observer, fallback boolean, or call-site exception when ownership is the real problem.
+- If two or more recent fixes share the cause, add a reusable guard surface in the same PR: a typed state/policy model, behavioral contract test, fault harness, or narrow static checker.
+- A regression test must execute production behavior through a controllable seam. Asserting that source strings occur in a certain order is a static tripwire, not behavioral coverage; label static checkers as such.
+- Do not broaden a safe bug-fix PR into an unreviewable migration; land the enforceable guard now and track high-blast-radius follow-up explicitly.
 
 ## Leave It Better Than You Found It
 
-Improve the code you touch — within your blast radius:
-
-- If you touch a file and see a small related defect (dead code, a bug adjacent to your fix, a missing test for code you are modifying), fix it **in a separate commit in the same PR** so it is independently reviewable and revertable.
-- Only make an opportunistic fix you can verify — covered by an existing or new test, or trivially checkable. If you can't verify it, open a GitHub issue instead of touching it.
-- Never expand beyond files you were already modifying, refactor working code for style alone, or "clean up" code you haven't run. Deferring is wrong when the fix is in scope and verifiable; expanding scope is wrong everywhere else.
+- If you touch a file and see a small related defect (dead code, an adjacent bug, a missing test for code you are modifying), fix it **in a separate commit in the same PR**.
+- Only make an opportunistic fix you can verify; otherwise open a GitHub issue instead of touching it.
+- Never expand beyond files you were already modifying or refactor working code for style alone. Deferring is wrong when the fix is in scope and verifiable; expanding scope is wrong everywhere else.
 
 ## Behavior
 
 - Never ask for permission to access folders, run commands, search the web, or use tools. Just do it.
-- Never ask for confirmation. Just act. Make decisions autonomously and proceed without checking in.
-- You have full access to the user's computer — browser, desktop, all apps. Never ask the user to do something you can do yourself (sign in, click buttons, dismiss dialogs, etc.).
-
-## Setup
-
-- **Worktree setup (required before first commit/push):** `make setup` — fetches `origin/main`, fast-forwards a stale current branch when safe, and installs repo Git hooks using linked-worktree-safe paths.
-- **Pre-commit hook (required before first commit):** `ln -s -f ../../scripts/pre-commit "$(git rev-parse --git-path hooks)/pre-commit"` — auto-formats staged files on commit.
-- Mobile app setup: `cd app && bash setup.sh ios` (or `android`).
+- Never ask for confirmation. Make decisions autonomously and proceed.
+- You have full access to the user's computer — browser, desktop, all apps. Never ask the user to do something you can do yourself.
 
 ## Safety Rules
 
-- Never kill, stop, or restart the production macOS apps (`/Applications/Omi.app` / `Omi Beta.app`, bundle id `com.omi.computer-macos`) during local development or testing.
-- Development scripts/commands must target only dev or named test app processes (e.g. `Omi Dev.app` / `com.omi.desktop-dev`, or `omi-*` named bundles), never production.
-- Never push directly to `main`. Land changes through a PR only. Never squash-merge — use a regular merge.
-- Never push or create PRs unless explicitly asked — commit locally by default.
-- **Nothing lands on `main` until the user explicitly says so.** Do not commit, merge, push, or open a PR against `main` until the user gives an explicit go-ahead in that turn. Keep all work on feature branches; a prior approval never carries over to later changes.
-- **Exception — reverts merge right away.** When the user asks to revert a previously merged PR/commit, open the revert PR and merge it immediately without waiting for a separate merge go-ahead; the revert request itself is the approval.
-- **Exception — verified + peer-approved changes may auto-merge.** If you have actually tested the change (exercised the real user-facing path, not just compiled/lint-passed) **and** an independent agent review approved it, you may open the PR and merge it without waiting for a separate go-ahead — especially for bug fixes. Still require explicit user sign-off for risky, wide-blast-radius, or hard-to-reverse changes (migrations, release/CI pipeline, schema, access control, data deletion).
-- **Prefer testing locally first.** The user prefers to build and run the app locally to verify a change works before it goes to a PR or merge. Default to a local named-bundle build + run for desktop changes (and the equivalent local run for other components) before proposing to land anything.
+- Never kill, stop, or restart the production macOS apps (`/Applications/Omi.app` / `Omi Beta.app`, bundle id `com.omi.computer-macos`). Dev commands target only dev or `omi-*` named test bundles.
+- **Nothing lands on `main` until the user explicitly says so.** Land through PRs only (regular merge, never squash); never push directly to `main`; never push or open PRs unless explicitly asked — commit locally on a feature branch by default. A prior approval never carries over to later changes.
+- **Exception — reverts merge right away.** A user request to revert a merged PR/commit is itself the approval to open and merge the revert PR.
+- **Exception — verified + peer-approved changes may auto-merge.** If you actually exercised the real user-facing path **and** an independent agent review approved it, you may open and merge without a separate go-ahead — except for risky, wide-blast-radius, or hard-to-reverse changes (migrations, release/CI pipeline, schema, access control, data deletion), which always need explicit user sign-off.
+- **Prefer testing locally first.** Default to a local build + run (desktop: named bundle) to verify a change before proposing to land it.
 
-## Coding Guidelines
+## Git
 
-### Product invariants
+- **Setup (required before first commit):** `make setup` — fetches `origin/main`, fast-forwards when safe, installs repo Git hooks (including the auto-formatting pre-commit hook) with linked-worktree-safe paths.
+- Before starting work: `git fetch origin && git pull --ff-only` on `main` — don't branch off stale state.
+- Always work in a git worktree for code changes (`git worktree add`); commit to the current branch and never switch branches mid-task.
+- Make individual commits per feature or testable surface, not per file or unrelated bulk changes.
+- If push fails (remote ahead): `git pull --rebase && git push`.
+- **RELEASE command:** branch from `main`, individual commits, push, open PR, merge without squash, switch back to `main` and pull. **RELEASEWITHBACKEND:** RELEASE + `gh workflow run gcp_backend.yml -f environment=prod -f branch=main`.
 
-- Read [`PRODUCT.md`](PRODUCT.md) before changing product behavior. Locked rules live in [`docs/product/invariants/`](docs/product/invariants/) (shared chat continuity, memory tiers, agent control plane, integrations harness, brand UI).
-- If you touch a locked invariant’s path globs, name **every** matched invariant ID in the PR body (path-based, not intent-based — e.g. touching `ChatProvider.swift` requires `INV-AUTH-1` even when the diff is not about auth). Discover IDs with `scripts/pr-preflight --suggest`; do not invent a partial list.
-- Update the invariant’s guard test when behavior changes.
-- Do not paste product essays into this file — keep the registry as the SSOT and link here.
+## Issues
 
-### UI / Design (all platforms)
+- Open issues freely — one paragraph of symptom plus evidence (logs, IDs, links) is a complete issue. Tracking beats polish; iterate in comments.
+- Issues state problems; PRs state solutions. Don't write implementation epics, acceptance-criteria matrices, SLOs, or rollout programs into an issue — that content hardens in the PR, where the Definition of Done already demands root cause, durable guard, and evidence.
+- If an issue does prescribe implementation: scope it to one self-contained PR, verify every code claim against current code first (the fix may already exist), and any proposed check must run in an existing CI or deploy lane.
+- Close incident issues on live evidence, not code merge; if live verification is deferred, name its owner in the closing comment.
 
-- **Never use purple.** Purple is off-brand — do not use it anywhere in the UI (icons, accents, glows, hover states, gradients). Use white/neutral for accent icons and primary actions. Enforced as a no-increase ratchet (`INV-UI-1`); see `docs/product/invariants/brand-ui.md`.
+## Cross-Component Guidelines
 
-### Deferred Work Markers
-
-- New `TODO`, `FIXME`, and `HACK` comments must reference a tracking issue or be resolved before merge.
-- Existing markers are legacy debt; only delete or annotate them when the owner and next action are clear.
-- Packages over 12 source files need a package-root `ARCHITECTURE.md` or `README.md`; `.github/scripts/check_arch_guardrails.py` enforces the baseline ratchet.
-- Designated rollout scaffolding (`backend/scripts/*readiness*`, `*gauntlet*`, `*proof*`, and `backend/utils/**/*rollout*`, `*compat*`) needs a near-top `LIFECYCLE: permanent|one-time` header; one-time files also need `DELETE-AFTER: <GitHub issue URL or invariant ID>`. `.github/scripts/check_lifecycle_headers.py` enforces this with `.github/lifecycle-header-baseline.txt` as the frozen legacy census.
-
-### Fallback / resilience telemetry
-
-Silent UX healing is allowed; **silent ops is not**. When a branch changes provider, mode, correctness, or takes a fail-open path, call the shared helper — do **not** invent a new `*_fallback_total` counter or one-off PostHog event.
-
-```
-IF branch changes provider OR mode OR correctness OR fail-open taken:
-  MUST call record_fallback / recordFallback with outcome
-ELSE IF hard failure (no continue):
-  error metric / Sentry / HTTP — NOT the fallback helper
-ELSE (pure cache miss, expected soft path with no mode change):
-  existing domain metric OR nothing — NOT fallback helper
-```
-
-| Field | Values |
-|-------|--------|
-| `component` / `area` | closed enum (`sync_dispatch`, `pusher`, `realtime_hub`, `ptt_cascade`, …) → else `other` |
-| `from` / `to` | closed enums or `none` |
-| `reason` | shared bounded set (`enqueue_failed`, `circuit_open`, `byok`, …) → else `other` |
-| `outcome` | `recovered` (full UX restored) \| `degraded` (continues with hit) \| `exhausted` (no path left) |
-
-Emitters: Python `utils.observability.fallback.record_fallback` → `omi_fallback_total`; Swift `DesktopDiagnosticsManager.recordFallback` → `desktop_health_event`/`fallback_triggered`; Rust `fallback::record_fallback` → fixed-field `tracing` (`event=fallback`). Legacy metrics (`llm_gateway_*`, `pusher_sessions_degraded`) stay — do not copy their fat label sets onto new sites. Alert on rates with denominators or dwell gauges; never page on raw absolute counts or successful `recovered` heals.
-
-Optional ratchet (not CI): `python backend/scripts/check_fallback_instrumentation.py <touched files>` warns when a diff hunk adds fallback/fail-open/degraded branches without `record_fallback`/`recordFallback`.
-
-### Backend (Python)
-
-- **Composition errors** — step helpers raise a typed error caught once at the composition boundary. Do not add assigned-call `isinstance(...): return` flow control; `.github/scripts/check_isinstance_return_ratchet.py` ratchets existing occurrences.
-- **No in-function imports** — all imports at module top level.
-- **Import purity** — a module's top level must be referentially transparent: importing it must not construct clients/connections (`OpenAI(...)`, `Redis(...)`, `Pinecone(...)`, `DeepgramClient(...)`, `firebase_admin.initialize_app(...)`, `tiktoken.encoding_for_model(...)`, etc.), perform network/IO (`requests.*`, `httpx.*`, `open(...)`), read `os.environ["X"]` (subscript — use `os.getenv`/`.get`), or mutate global state. Defer construction into lazy getters (`_x=None; def get_x(): ...`); tests inject fakes via `monkeypatch.setattr` on the singleton. Scope: correctness side effects, not import duration (`import langchain` is slow-but-pure and fine). The shared preflight manifest runs the import-purity guard. Full prescription: `backend/docs/test_isolation.md`.
-- **Test isolation** — never mutate `sys.modules` at module scope in test files. Use `monkeypatch.setattr` on a lazy-held singleton, FastAPI `app.dependency_overrides` for router deps, or (reserve only) `backend/testing/import_isolation.py`. The shared preflight manifest runs the module-pollution guard. Do not extend `tests/unit/memory_import_isolation.py` (deprecated). See `backend/docs/test_isolation.md`.
-- **Import hierarchy** (low → high): `database/` → `utils/` → `routers/` → `main.py`. Never import upward.
-- **Memory management** — `del` byte arrays after processing, `.clear()` dicts/lists holding data.
-- **Async I/O** — never `requests.*` in async (use `httpx.AsyncClient` pools from `utils/http_client.py`), never `Thread().start().join()` (use `critical_executor`/`storage_executor`), never `time.sleep()` in async (use `asyncio.sleep()`). The shared preflight manifest runs the async-blocker guard.
-- **`async def` vs `def` endpoints** — use `def` for endpoints that only call sync code (Firestore, Redis, file I/O); FastAPI runs `def` in a threadpool automatically. Only use `async def` when the endpoint genuinely `await`s something (httpx, file.read(), WebSocket, asyncio.sleep) or uses asyncio APIs directly. Never call sync DB/storage/file functions directly inside `async def` — wrap with `await run_blocking(executor, func, args)`.
-- **Blocking calls in async** — these block the event loop: `database.*` functions (Firestore sync SDK), `open()`/`shutil.*` (file I/O), `upload_*`/`delete_*` from storage (GCS SDK), `creds.refresh()` (Google auth HTTP). In `async def`, always offload via `await run_blocking(executor, func, args)` from `utils.executors`. Pool assignment: `critical_executor` for auth/rate-limits, `db_executor` for Firestore/Redis CRUD, `llm_executor` for LLM calls, `storage_executor` for GCS/file I/O, `postprocess_executor` for coordinators, `sync_executor` for STT/VAD. See `backend/CLAUDE.md` for full rules. Never use bare `asyncio.to_thread()`.
-
-#### Logging Security
-
-Never log raw sensitive data. Use `sanitize()` and `sanitize_pii()` from `utils.log_sanitizer`.
-- `sanitize()` for `response.text`, API responses, error bodies.
-- `sanitize_pii()` for names, emails, user text.
-- Keep UIDs, IPs, status codes visible for debugging.
-- Never put raw `response.text` in exception messages.
-
-#### WebSocket Concurrency
-
-WebSocket handlers (`transcribe.py`, `pusher.py`) use `asyncio.wait(FIRST_COMPLETED)` supervisor loops — never `asyncio.gather()` on the receive task with background tasks. Key rules:
-- Receive timeouts: every `websocket.receive()` wrapped in `asyncio.wait_for(..., timeout=WS_RECEIVE_TIMEOUT)`.
-- Gauge placement: `inc()` in `try` body, `dec()` in `finally` — always paired.
-- Task naming: WebSocket lifetime tasks must include `name=f"ws:{uid}:{task_name}"`.
-- Finite vs lifetime: tasks that complete normally during active sessions (e.g. `process_pending_conversations`) go in `finite_tasks`; all others are lifetime tasks whose completion triggers teardown.
-
-#### Backend Service Map
-
-```
-Shared: Firestore, Redis
-
-backend (main.py)
-  ├── ws ──► pusher (pusher/)
-  ├── ──────► diarizer (diarizer/)
-  ├── ──────► vad (modal/)
-  ├── ──────► deepgram (self-hosted or cloud)
-  ├── ──────► parakeet (parakeet/)
-  ├── ──────► nllb-translation (nllb_translation/)
-  └── ──────► llm-gateway (llm_gateway/main.py)
-
-pusher
-  ├── ──────► diarizer (diarizer/)
-  └── ──────► deepgram (cloud)
-
-agent-proxy (agent-proxy/main.py)
-  └── ws ──► user agent VM (private IP, port 8080)
-
-backend-sync (main.py, Cloud Run)
-  ├── ──────► Cloud Tasks queue `sync-jobs` ──► POST /v2/sync-jobs/run (OIDC, same service; fresh lane)
-  ├── ──────► Cloud Tasks queue `sync-backfill` ──► backend-sync-backfill POST /v2/sync-jobs/run (OIDC; historical lane)
-  ├── ──────► Cloud Tasks queue `audio-merge` ──► POST /v2/audio-merge-jobs/run (OIDC, same service)
-  └── ──────► Cloud Tasks queue `account-deletion` ──► POST /v1/users/account-deletion-wipes/run (OIDC, same service)
-
-notifications-job (modal/job.py)  [cron]
-memory-maintenance-job (modal/memory_maintenance_job.py)  [cron]
-agent-vm-reaper (backend/charts/agent-vm-reaper)  [cron]
-```
-
-Helm charts: `backend/charts/{agent-proxy,agent-vm-reaper,backend-listen,backend-secrets,deepgram-self-hosted,diarizer,llm-gateway,monitoring,nllb-translation,parakeet,pusher,vad}/`
-
-- **backend** (`main.py`) — REST API. Streams audio to pusher via WebSocket (`utils/pusher.py`). Calls diarizer for speaker embeddings (`utils/stt/speaker_embedding.py`). Calls vad for voice activity detection and speaker identification (`utils/stt/vad.py`, `utils/stt/speech_profile.py`). Calls deepgram or parakeet for STT (`HOSTED_PARAKEET_API_URL`, `utils/stt/streaming.py`). Calls NLLB translation when `HOSTED_TRANSLATION_API_URL` is set and NLLB is selected (`utils/translation.py`).
-- **hosted MCP OAuth** (`routers/mcp_sse.py`) — Provider-neutral OAuth for `/v1/mcp/sse`. Configure public or confidential clients with `MCP_OAUTH_CLIENTS_JSON`; allowlist the exact connector callback URI from the provider. The temporary `MCP_OAUTH_CHATGPT_*` envs still define the legacy confidential ChatGPT test client, and `MCP_OAUTH_PUBLIC_*` can expose a no-secret PKCE public client. Also set `MCP_AUTHORIZATION_SERVER_URL`, optional `MCP_RESOURCE_URL`, and token TTL env vars.
-- **llm-gateway** (`llm_gateway/main.py`) — Internal FastAPI service for Omi-managed LLM auto lanes. Called by backend with service auth for `omi:auto:*` chat-completions routes; not exposed to clients.
-- **pusher** (`pusher/main.py`) — Receives audio via binary WebSocket protocol. Calls diarizer and deepgram for speaker sample extraction (`utils/speaker_identification.py` → `utils/speaker_sample.py`).
-- **agent-proxy** (`agent-proxy/main.py`) — GKE. WebSocket proxy at `wss://agent.omi.me/v1/agent/ws`. Validates Firebase ID token, looks up `agentVm` in Firestore, proxies bidirectionally to VM's `ws://<ip>:8080/ws`.
-- **diarizer** (`diarizer/main.py`) — GPU. Speaker embeddings at `/v2/embedding`. Called by backend and pusher (`HOSTED_SPEAKER_EMBEDDING_API_URL`).
-- **vad** (`modal/main.py`) — GPU. `/v1/vad` and `/v1/speaker-identification`. Called by backend only.
-- **deepgram** — STT. Streaming uses self-hosted (`DEEPGRAM_SELF_HOSTED_URL`) or cloud based on `DEEPGRAM_SELF_HOSTED_ENABLED`. Pre-recorded always uses Deepgram cloud. Called by backend and pusher.
-- **parakeet** (`parakeet/`) — GPU STT service for streaming and pre-recorded transcription. Called by backend when `HOSTED_PARAKEET_API_URL` is set and parakeet is selected.
-- **nllb-translation** (`nllb_translation/`) — GPU translation service. Called by backend when `HOSTED_TRANSLATION_API_URL` is set and NLLB is selected.
-- **backend-sync** (`main.py`, same image as backend) — Cloud Run admission service for `/v2/sync-local-files`. The server classifies whole batches: recordings no more than six hours old enter `sync-jobs` (fresh), while older or untrusted batches enter `sync-backfill` and the scale-to-zero **backend-sync-backfill** worker. Fresh keeps its bounded inline fallback; backfill never falls into fresh/inline capacity. Backfill defaults to one in-flight job per UID, four processed speech hours per UID/day, 555 processed speech hours globally/day, a 30-day lookback, and four queue workers. Live fair-use reads only `realtime + sync_fresh`; `sync_backfill` is separately metered. A 45-day Firestore content ledger protects transcription and usage side effects across job expiry and re-upload. Audio playback merges (`/v1/sync/audio/*`) follow the same pattern via queue `audio-merge` building 30-day MP3 artifacts under `playback/` (`AUDIO_MERGE_DISPATCH_MODE`) — per-part files plus one dense per-conversation `conversation.mp3` whose spans manifest + audio_files fingerprint are stamped on the conversation doc (`conversation_audio`); a fingerprint mismatch after late chunks re-enqueues the build. Account deletion uses `ACCOUNT_DELETION_DISPATCH_MODE=cloud_tasks` to enqueue durable wipes to queue `account-deletion`, which posts `/v1/users/account-deletion-wipes/run`; API success is returned only after the deletion marker is persisted and the wipe task is durably enqueued.
-- **notifications-job** (`modal/job.py`) — Cron job, reads Firestore/Redis, sends push notifications and runs X connector sync. It has no canonical maintenance flags or Typesense secrets; its deploy workflow removes only those retired bindings and preserves unrelated notification/X-sync env.
-- **memory-maintenance-job** (`modal/memory_maintenance_job.py`) — Cloud Run Job and sole host for canonical ST→LT maintenance (TTL → consolidation → promotion). Manual deploy via `.github/workflows/gcp_memory_maintenance_job.yml`; auto-dev on push to `main` via `gcp_memory_maintenance_job_auto_dev.yml`. Enablement is a multi-var contract (`MEMORY_MODE`, `MEMORY_ENABLED_USERS`, cron/fast-track/consolidation flags) enforced by `backend/scripts/validate-backend-runtime-env.py`; prod stays `MEMORY_MODE=off` until Gate 3.
-- **monitoring** (`backend/charts/monitoring/`) — Prometheus, Grafana, Loki, Alloy, alerts, and HPA metric adapters for backend services.
-- **agent-vm-reaper** (`backend/charts/agent-vm-reaper/`) — CronJob that deletes stale `omi-agent-*` GCE VMs left by desktop agent sandboxes.
-- **backend-secrets** (`backend/charts/backend-secrets/`) — ExternalSecret and SecretStore resources that sync backend runtime secrets into GKE namespaces.
-
-Backend runtime env contract: keep `backend/deploy/runtime_env.yaml` aligned with GKE Helm values and Cloud Run runtime env; run `backend/scripts/pre-deploy-check.sh` after backend runtime env or deploy workflow changes.
-
-Keep this map up to date. When adding, removing, or changing inter-service calls, update this section. If a PR changes audio streaming, transcription, conversation lifecycle, speaker identification, or the listen/pusher WebSocket protocol — update `docs/doc/developer/backend/listen_pusher_pipeline.mdx` in the same PR.
-
-### App (Flutter)
-
-- All user-facing strings must use l10n (`context.l10n.keyName`) — never hardcoded strings. Add keys to ARB files using `jq` (never read full ARB files). See skill `add-a-new-localization-key-l10n-arb`.
-- When adding new l10n keys, translate all non-English locales — never leave English text in a non-English ARB file. Don't hardcode the count; the authoritative list is whatever `ls app/lib/l10n/app_*.arb` returns minus `app_en.arb`. Use the `omi-add-missing-language-keys-l10n` skill, then verify with `cd app && flutter gen-l10n` — zero "untranslated message(s)" warnings means done.
-- **Firebase Prod Config** — never run `flutterfire configure`; it overwrites prod credentials. Prod config files live in `app/ios/Config/Prod/`, `app/lib/firebase_options_prod.dart`, `app/android/app/src/prod/`.
-- PR CI runs `flutter test` and an analyzer ratchet (`app/scripts/analyze_ratchet.sh`) — analyzer errors always fail; new info/warning lint occurrences above `app/analysis_baseline.json` fail. Run the script locally before committing app Dart changes.
-- Deliberate lint acceptances/improvements update the baseline via `--update-baseline` in the same PR.
-
-#### Verifying UI Changes (agent-flutter)
-
-After any Flutter UI edit, verify programmatically with [agent-flutter](https://github.com/beastoin/agent-flutter). Marionette is integrated in debug builds. Install once: `npm install -g agent-flutter-cli`.
-
-Edit → Verify → Evidence loop:
-1. Edit code, hot restart: `kill -SIGUSR2 $(pgrep -f "flutter run" | head -1)`
-2. Connect: `AGENT_FLUTTER_LOG=/tmp/flutter-run.log agent-flutter connect`
-3. Verify: `agent-flutter snapshot -i`
-4. Interact: `agent-flutter press @e3` / `press 540 1200` / `find type button press` / `fill @e5 "text"` / `dismiss`
-5. Evidence: `agent-flutter screenshot /tmp/evidence.png`
-
-Key rules:
-- Must reconnect after every hot restart (kills VM Service session).
-- Refs go stale frequently — always re-snapshot before every interaction. Use `press x y` as fallback.
-- `AGENT_FLUTTER_LOG` must point to flutter run stdout (not logcat).
-- Prefer `find type X` / `find key "name"` over hardcoded `@ref`. Add `Key('descriptive_name')` to new interactive widgets.
-- App flows & screen map: `app/e2e/SKILL.md`. Full command reference: `agent-flutter schema`.
-
-### Desktop (macOS — Swift app + Rust backend)
-
-The desktop app is a **Swift Package Manager** project (no Xcode project, no `.xcodeproj`). The Rust backend lives in `desktop/macos/Backend-Rust/`.
-- For user-visible desktop changes, follow `desktop/macos/AGENTS.md` → Changelog Entries and add one `desktop/macos/changelog/unreleased/*.json` fragment.
-
-#### Building & Running
-
-- `cd desktop/macos && ./run.sh` — full local dev (build Swift app + Rust backend + Cloudflare tunnel + launch).
-- `cd desktop/macos && ./run.sh --yolo` — quick start against the dev backend, no local services.
-- `OMI_SKIP_BACKEND=1` — app only, use remote backend via `OMI_DESKTOP_API_URL`. `OMI_SKIP_TUNNEL=1` — no Cloudflare tunnel.
-- **Parallel worktrees auto-isolate.** `scripts/dev-instance.sh` derives a unique instance from each linked git worktree, so `run.sh` (and `backend/scripts/dev-serve.sh`) pick per-worktree ports (Rust 10201+, Python 8080+, automation 47777+) and bundle name (`omi-<worktree>`). Kills are pidfile-scoped (never the global `omi-desktop-backend` name), and a taken port fails loud instead of clobbering. The primary checkout is unchanged (`Omi Dev`, 10201/8080/47777). Override any of `OMI_INSTANCE` / `PORT` / `PYTHON_PORT` / `OMI_AUTOMATION_PORT` / `OMI_APP_NAME` to opt out.
-- **`run.sh` build lock is per-worktree, launch-phase only.** It serializes same-checkout builds that share `Desktop/.build/` + `build/$APP_NAME.app`, holds through install/seed/`open`, then releases before the long-running backend wait — never a per-user global mutex. Cross-worktree `./run.sh` must not block each other. Do not point two worktrees at the same explicit `OMI_APP_NAME` (shared `/Applications` path is not cross-locked).
-- `Omi Dev` is the canonical shared development profile: `/Applications/Omi Dev.app`, bundle id `com.omi.desktop-dev`, reusable permissions, and auth seed source. Do not pass `OMI_APP_NAME="Omi Dev"` from a linked worktree; that creates a named bundle displayed as Omi Dev with a different bundle id and breaks permission reuse.
-- Local Python backend (per-worktree port): `cd backend && ./scripts/dev-serve.sh`.
-- Compile-only check: `cd desktop/macos && xcrun swift build -c debug --package-path Desktop` (the `xcrun` prefix is required to match the SDK).
-- **DO NOT** use bare `swift build`, `xcodebuild`, or launch from `build/` directly. Always launch via `cd desktop/macos && ./run.sh` (installs to `/Applications/` and registers with LaunchServices, required for permission "Quit & Reopen").
-- **PR CI** (`desktop-swift-ci.yml`): debug build + parallel suite tests (`OMI_SWIFT_TEST_SUITE_WORKERS=4`). No release compile on ordinary PRs.
-- **Clean release compile** runs in CI on `main` pushes that touch desktop Swift, and on PRs that change `desktop/macos/Desktop/Package.swift`. Locally, for signature / cross-file type changes: `cd desktop/macos && rm -rf Desktop/.build && xcrun swift build -c release --package-path Desktop --triple arm64-apple-macosx` — incremental debug builds can miss stale-cache type errors.
-- **Ship builds** (universal, signed, notarized) are handled entirely by Codemagic CI (no local release script).
-
-#### Named Test Bundles
-
-When testing a feature or fix, **always create a separate named bundle** so it runs side-by-side with dev/prod:
-```bash
-cd desktop/macos && OMI_APP_NAME="omi-fix-rewind" ./run.sh
-```
-This installs `/Applications/omi-fix-rewind.app` with bundle id `com.omi.omi-fix-rewind`, with its own permissions, database, and auth state.
-
-Rules:
-- **ALWAYS prefix the name with `omi-`** (e.g. `omi-fix-rewind`, `omi-vision-test`) so bundles group together in `/Applications/`.
-- NEVER use `Omi Dev` as a named bundle. If you need the shared permission/profile grant, launch from the primary checkout with no `OMI_APP_NAME`; otherwise use an `omi-*` named bundle and expect separate macOS permissions.
-- NEVER use bare `./run.sh` when testing a specific change — it overwrites "Omi Dev".
-- NEVER kill or interfere with "Omi", "Omi Beta" — those are production installs.
-- Keep app name and bundle suffix identical (e.g. `omi-search.app` → `com.omi.omi-search`).
-
-#### Self-Testing the App (end-to-end)
-
-**Hard rule: you may not ask the user to verify a feature you have not actually exercised yourself.** Compiling, "looks correct from the code", or "scroll down to see it" are not verification. If the obvious path is blocked (permission, focus, missing tool), try a long sequence of alternatives before involving the user — extend the bridge with a new action, add a temporary in-process hook, search the web for a workaround, grant the missing permission yourself if you can, write a tiny standalone harness. Roughly: spend ten serious attempts across different approaches before you escalate. Asking the user is the last move, not the first.
-
-Agents can and should self-test the running app — don't stop at a successful compile. The fast path skips the slow parts (web login, sidebar click-through):
-
-1. **Build + launch a named bundle:** `cd desktop/macos && OMI_APP_NAME="omi-<feature>" ./run.sh` (add `OMI_SKIP_TUNNEL=1` for a local backend without a tunnel; `OMI_SKIP_BACKEND=1 OMI_DESKTOP_API_URL=…` to point at a remote backend).
-2. **Boot signed-in (no browser):** sign into "Omi Dev" once; `./run.sh` auto-clones auth/onboarding plus common shortcuts/settings into named bundles **before launch** (UserDefaults is read at startup). To do it manually:
-   ```bash
-   cd desktop/macos && ./scripts/omi-auth-dump.sh                  # capture the Omi Dev session
-   ./scripts/omi-auth-seed.sh com.omi.omi-<feature> \
-     tmp/desktop-auth.json "/Applications/omi-<feature>.app"  # clears stale Keychain; UD→KC migrate
-   ./scripts/omi-settings-seed.sh com.omi.omi-<feature>       # replay shortcuts/settings
-   ```
-   On next launch `restoreAuthState()` picks it up and boots already-signed-in.
-3. **Inspect / drive the app:**
-   - **Prefer the local bridge — it never touches the cursor.** It calls the app's real code in-process (no synthetic mouse events), so it won't take over the user's machine. Use it before reaching for `agent-swift click`/`cliclick`/computer-use. Auto-enables on non-prod bundles; run several at once by giving each its own `OMI_AUTOMATION_PORT` (default 47777).
-   - `./scripts/omi-ctl state` — app-state snapshot (selected tab, auth, onboarding).
-   - `./scripts/omi-ctl navigate <screen> [settings-section]` — jump straight to a screen in ~150ms (`omi-ctl screens` lists targets).
-   - `./scripts/omi-ctl actions` then `./scripts/omi-ctl action <name> [k=v …]` — discover and run semantic actions (e.g. `refresh_all_data`, `toggle_transcription enabled=false`). Add new ones in `DesktopAutomationActionRegistry`. See `desktop/macos/e2e/SKILL.md` §2b.
-   - `agent-swift connect --bundle-id com.omi.omi-<feature>` then `snapshot -i`, `find role textfield fill "…"`, `click @eN`, `screenshot /tmp/evidence.png` — only for UI the bridge can't reach yet (`click` moves the cursor).
-4. **Read logs to confirm behavior:**
-   - App + chat bridge: `/private/tmp/omi-dev.log` (dev builds) or `/private/tmp/omi.log`.
-   - Local Rust backend: stdout of the `./run.sh` process.
-   - Per-user issues: check Sentry dashboard for crashes, PostHog for events.
-5. **Verify the actual behavior**, not just that the app launched — exercise the feature and check the logs/UI reflect the change.
-
-#### Verifying UI Changes (agent-swift)
-
-After any Swift UI edit, verify programmatically with [agent-swift](https://github.com/beastoin/agent-swift) (macOS Accessibility API, no app-side instrumentation). Install once: `brew install beastoin/tap/agent-swift`; grant Accessibility permission to Terminal.app.
-
-Edit → Verify → Evidence loop:
-1. Edit code, rebuild + launch: `cd desktop/macos && OMI_APP_NAME="omi-<feature>" ./run.sh`
-2. Connect: `agent-swift connect --bundle-id com.omi.omi-<feature>`
-3. Verify: `agent-swift snapshot -i` (interactive elements only)
-4. Interact: `agent-swift click @e3` / `fill @e5 "text"` / `find role button click`
-5. Assert: `agent-swift is exists @e3` / `wait text "Settings"`
-6. Evidence: `agent-swift screenshot /tmp/evidence.png`
-
-Key rules:
-- `agent-swift doctor` verifies Accessibility permission and target app.
-- Prefer `click` over `press` for SwiftUI — `click` sends CGEvent clicks (triggers NavigationLink), `press` sends AXPress (AppKit only).
-- Refs go stale after `click`/`press`/`fill`/`scroll` — re-snapshot before the next interaction.
-- Always use `snapshot -i` — full snapshots of complex apps are very verbose.
-- Argument order: `get <property> <ref>`, `is <condition> <ref>`, `wait <condition> [<target>]`, `find <locator> <value>`.
-- Dev bundle id: `com.omi.desktop-dev`. Prod: `com.omi.computer-macos` (never automate prod).
-- App flows & screen map: `desktop/macos/e2e/SKILL.md`. Full command reference: `agent-swift schema`.
-
-## Computer Control (clicking, typing, screenshots)
-
-For controlling the Mac GUI, use the right tool for each job:
-
-| Task | Tool | Example |
-|------|------|---------|
-| Click at coordinates | `cliclick` | `cliclick c:X,Y` |
-| Mac desktop screenshots | `screencapture` | `screencapture -x /tmp/screen.png` |
-| Native macOS app testing | `agent-swift` | See Desktop section above |
-| Browser automation | `playwright` MCP | Headless, most reliable |
-
-Rules:
-- NEVER try 3+ different click tools for the same action — pick one and commit.
-- Prefer `cliclick` over `automac`/`mac-use-mcp` (coordinate bugs on multi-monitor).
+- **Product invariants:** read `PRODUCT.md` before changing product behavior. If your diff touches a locked invariant's path globs, name **every** matched invariant ID in the PR body (path-based, not intent-based; discover with `scripts/pr-preflight --suggest`) and update the invariant's guard test when behavior changes.
+- **Never use purple** anywhere in UI (icons, accents, glows, gradients) — off-brand; use white/neutral. Enforced as a no-increase ratchet (`INV-UI-1`); see `docs/product/invariants/brand-ui.md`.
+- **Fallback telemetry:** when a branch changes provider, mode, or correctness, or takes a fail-open path, call the shared `record_fallback`/`recordFallback` helper — never a new one-off counter. Full contract: `docs/agents/fallback-telemetry.md`.
+- **Logging:** never log raw sensitive data; sanitize API responses and PII (backend: `utils.log_sanitizer`).
+- **Deferred-work markers:** new `TODO`/`FIXME`/`HACK` must reference a tracking issue or be resolved before merge. Packages over 12 source files need a package-root `ARCHITECTURE.md`/`README.md` (`check_arch_guardrails.py` ratchet). Designated rollout scaffolding needs a `LIFECYCLE: permanent|one-time` header; one-time files also need `DELETE-AFTER: <issue URL or invariant ID>` (`check_lifecycle_headers.py`).
 
 ## Formatting
 
-**Install the pre-commit hook before your first commit** (see Setup). Verify: `test -x "$(git rev-parse --git-path hooks)/pre-commit" && echo OK`.
-
-The **pre-commit hook** auto-formats staged files on commit (Dart, Python, ARB/JSON, web/Prettier, C/C++, Rust). You can also format manually:
+The pre-commit hook (installed by `make setup`) auto-formats staged files. Verify: `test -x "$(git rev-parse --git-path hooks)/pre-commit" && echo OK`. Manual commands:
 
 | Language | Manual command |
 |----------|----------------|
@@ -344,57 +104,28 @@ The **pre-commit hook** auto-formats staged files on commit (Dart, Python, ARB/J
 
 Files ending in `.gen.dart` or `.g.dart` are auto-generated — don't format manually.
 
-## Git
+## Computer Control
 
-- **Before your first commit**, install the pre-commit hook (see Setup). Commits without the hook bypass formatting and let violations land on `main`.
-- Before starting work, run `git fetch origin && git pull --ff-only` on `main` — don't branch off stale local state.
-- Always commit to the current branch — never switch branches mid-task. Always work in a git worktree for code changes (`git worktree add`).
-- Never push directly to `main`. Land changes through PRs only. Never squash-merge — use a regular merge.
-- Make individual commits per feature or testable surface, not per file or unrelated bulk changes.
-- If push fails (remote ahead): `git pull --rebase && git push`.
-- Never push or create PRs unless explicitly asked — commit locally by default.
-
-### RELEASE Command
-Create a branch from `main`, make individual commits per feature or testable surface, push and open a PR, merge without squash, then switch back to `main` and pull.
-
-### RELEASEWITHBACKEND Command
-Full RELEASE flow + `gh workflow run gcp_backend.yml -f environment=prod -f branch=main`.
+Click at coordinates: `cliclick c:X,Y`. Mac screenshots: `screencapture -x /tmp/screen.png`. Native macOS app testing: `agent-swift` (see desktop guide). Browser automation: `playwright` MCP. Never try 3+ different click tools for the same action — pick one and commit. Prefer `cliclick` over `automac`/`mac-use-mcp` (multi-monitor coordinate bugs).
 
 ## Testing
 
-### Philosophy — coverage grows by ratchet, not by mandate
+- **Coverage grows by ratchet, not mandate:** every bug fix adds the regression test that would have caught it; new features test the core path and main error path — no more. A small test that stays meaningful in a year beats ten brittle ones.
+- **CI tests must be hermetic** (no live services, network, sleeps, or ordering dependence) — and hermetic tests must run in CI: put them where the component's runner discovers them. A test needing a live service stays out of CI; note in the PR how you ran it.
+- Delete or fix a flaky/obsolete test you encounter — a suite people distrust is worse than a smaller suite.
+- Component runners and prerequisites: see the component guides (`backend/AGENTS.md` → Testing, `app/AGENTS.md` → Test Strategy). High-risk backend workflows must be listed in `backend/testing/workflow_contracts.json` with contract tests.
 
-- **Every bug fix adds the regression test that would have caught it.** This is the one non-negotiable way coverage grows; it compounds exactly where the codebase has proven fragile.
-- **New features test the core path and the main error path.** Don't chase exhaustive coverage — a small test that will still be meaningful in a year beats ten brittle ones.
-- **CI tests must be hermetic**: no live services, no network, no sleeps, no ordering dependence. A test that needs a live service stays out of the CI suite; note in the PR how you ran it instead.
-- **Hermetic tests must run in CI.** Put new hermetic tests where the component's runner discovers them and confirm they execute in a full local run; if a test requires a live service, keep it out of CI and document how you ran it in the PR.
-- Delete or fix a flaky/obsolete test you encounter (see Leave It Better) — a suite people distrust is worse than a smaller suite.
+## Deploys & Release Pipelines
 
-### Running Tests
-
-- Run `backend/test-preflight.sh` first to verify tools, packages, and env vars.
-- High-risk backend workflows (checkpoint/resume, retry/idempotency, side-effect fanout, rollout/repair jobs) must be listed in `backend/testing/workflow_contracts.json` with local contract tests; source-only changes must run those tests before PR.
-- OpenAPI contract checks use `backend/scripts/openapi_runner.sh`, which syncs the pinned `backend/openapi-requirements.txt` runner env and prewarms `tiktoken`; CI and `scripts/pre-push` must use this same path.
-- Backend changes: run `backend/test.sh`. App changes: run `app/test.sh`. Run before committing.
-- Backend unit tests need `python3`, `pytest`, packages from `requirements.txt`, `ENCRYPTION_SECRET` (set by test.sh). Integration tests optionally need `OPENAI_API_KEY`, `DEEPGRAM_API_KEY`, `ADMIN_KEY`, Redis, `GOOGLE_APPLICATION_CREDENTIALS`.
-
-## CI/CD & Logs
-
-- Desktop release pipeline: `.github/workflows/desktop_auto_release.yml` batches `main` into at most one daily `v*-macos` build candidate. Codemagic builds/signs/notarizes it non-live, verifies published digests against signed-smoke evidence, then runs static checks, hermetic T2, and the fault suite before automatically dispatching beta promotion for the newest tag. `DESKTOP_AUTO_BETA_ENABLED=false` pauses automatic beta. Before stable, `.github/workflows/desktop_nominate_stable_candidate.yml` records soak, telemetry, release-note, and qualification evidence without changing either channel pointer. Stable/prod remains manual-only through `.github/workflows/desktop_promote_prod.yml` with `release_tag` and `confirm=promote-stable`; it accepts a nominated stable candidate by default, is roll-forward only, and advances stable only after backend verification. Desktop Rust backend deploys require environment-scoped `DESKTOP_BACKEND_BASE_API_URL` so OAuth callbacks set runtime `BASE_API_URL`.
-- Backend deploy: `gh workflow run gcp_backend.yml -f environment=prod -f branch=main`.
-- Firmware release (Omi CV1): manual `.github/workflows/firmware_release.yml`. Bump `CONFIG_BT_DIS_FW_REV_STR` in `omi/firmware/omi/omi.conf` first, then `gh workflow run firmware_release.yml -f publish=publish -f changelog="..." -f minimum_app_version_code=...` (omit `publish` for a build-only QA run). It builds via Docker (NCS 2.9.0 sysbuild + MCUboot), names the OTA asset `Omi_CV1_OTA_v<ver>.zip` (the "ota" substring is required), and publishes a `Omi_CV1_v<ver>` GitHub Release with the `KEY_VALUE` body that `backend/routers/firmware.py` serves. Build logic lives in `omi/firmware/scripts/ci/`.
+- Desktop (daily candidate → qualified beta → manual stable): `desktop/macos/AGENTS.md` → Release Pipeline.
+- Backend: `gh workflow run gcp_backend.yml -f environment=prod -f branch=main`. Runtime env contract: `backend/AGENTS.md` → Service Map.
+- Firmware (Omi CV1): `omi/firmware/AGENTS.md`.
 
 ## Documentation Maintenance
 
-- **This file (`AGENTS.md`) is the single source of truth for agent instructions.** Add or change rules here. `CLAUDE.md` is only a pointer — do not put instructions in it.
-- **Any AI editing this file must keep it concise and simple** — short, plain bullets a human or agent can scan fast. Prefer editing/replacing an existing line over adding new ones; no verbose prose.
-- **Write rules mechanically, and back them with checks.** Agents of very different capability read this file; a rule is only reliable if a weak agent can apply it without judgment ("put live-service tests under X, excluded from CI" beats "avoid heavy tests"). Prefer encoding a rule as a script or CI check with a clear failure message — enforced rules don't drift; requested behavior does.
+- **This file is the single source of truth for cross-component agent rules; component `AGENTS.md` files own their component's detail.** `CLAUDE.md` files are pointers only.
+- **Keep this file lean** — high-level rules and the index, short plain bullets. Detail goes in the component guide; `.github/scripts/check_agents_md_lean.py` enforces the budget. Prefer editing/replacing an existing line over adding new ones.
+- **Write rules mechanically, and back them with checks.** A rule is only reliable if a weak agent can apply it without judgment. Prefer encoding a rule as a script or CI check with a clear failure message — enforced rules don't drift; requested behavior does.
+- **New checks, probes, or validation scripts must be wired into an existing CI or deploy lane in the same PR.** On-demand scripts and scheduled jobs with no blocking audience are dead checks.
 - **When a defect ships because guidance was misread or missing, tighten the guidance in the fix PR** — make the rule mechanical enough that the same misreading can't recur, or add a check that catches it.
-- If a PR changes setup, test commands, safety rules, service boundaries, or env vars — update this file in the same PR.
-- For architecture / core flow / API changes — update Mintlify docs (`docs/doc/developer/`) in the same PR.
-- For product direction or locked invariants — update `PRODUCT.md` and `docs/product/invariants/` (and guard tests) in the same PR.
-- If a PR changes audio streaming, transcription, conversation lifecycle, or listen/pusher WebSocket — update `docs/doc/developer/backend/listen_pusher_pipeline.mdx`.
-
-## Cursor Cloud specific instructions
-
-Running in a Cursor Cloud VM (Linux x86)? See **[.cursor/cloud-agent-environment.md](.cursor/cloud-agent-environment.md)** — what runs here, the credential-free **hermetic E2E harness** (preferred), running the backend live, and known pre-existing test failures.
+- PR changes to setup, test commands, safety rules, service boundaries, or env vars update the matching guide in the same PR. Architecture / core-flow / API changes update Mintlify docs (`docs/doc/developer/`). Product direction or locked invariants update `PRODUCT.md` / `docs/product/invariants/` and guard tests.

--- a/app/AGENTS.md
+++ b/app/AGENTS.md
@@ -81,6 +81,8 @@ flutter test test/unit/  # specific directory
 
 `bash test.sh` bootstraps missing local generated files with an empty `API_BASE_URL` so `test/` stays hermetic.
 
+PR CI runs `flutter test` and an analyzer ratchet (`app/scripts/analyze_ratchet.sh`) — analyzer errors always fail; new info/warning lint occurrences above `app/analysis_baseline.json` fail. Run the script locally before committing app Dart changes. Deliberate lint acceptances/improvements update the baseline via `--update-baseline` in the same PR.
+
 ### Test Patterns
 - Mock singletons (SharedPreferencesUtil, AuthService, FirebaseAuth) since they aren't injectable
 - Test state machine logic via minimal abstractions mirroring production flow
@@ -129,4 +131,21 @@ All API requests include: X-Request-Start-Time, X-App-Platform, X-Device-Id-Hash
 
 - See `e2e/SKILL.md` for navigation architecture, screen map, widget patterns, and 34 reference flows
 - See `e2e/flows/*.yaml` for individual flow definitions
-- agent-flutter (Marionette) for programmatic UI interaction — see root AGENTS.md for setup
+
+## Verifying UI Changes (agent-flutter)
+
+After any Flutter UI edit, verify programmatically with [agent-flutter](https://github.com/beastoin/agent-flutter) (Marionette is integrated in debug builds). Install once: `npm install -g agent-flutter-cli`.
+
+Edit → Verify → Evidence loop:
+1. Edit code, hot restart: `kill -SIGUSR2 $(pgrep -f "flutter run" | head -1)`
+2. Connect: `AGENT_FLUTTER_LOG=/tmp/flutter-run.log agent-flutter connect`
+3. Verify: `agent-flutter snapshot -i`
+4. Interact: `agent-flutter press @e3` / `press 540 1200` / `find type button press` / `fill @e5 "text"` / `dismiss`
+5. Evidence: `agent-flutter screenshot /tmp/evidence.png`
+
+Key rules:
+- Must reconnect after every hot restart (kills VM Service session).
+- Refs go stale frequently — always re-snapshot before every interaction. Use `press x y` as fallback.
+- `AGENT_FLUTTER_LOG` must point to flutter run stdout (not logcat).
+- Prefer `find type X` / `find key "name"` over hardcoded `@ref`. Add `Key('descriptive_name')` to new interactive widgets.
+- Full command reference: `agent-flutter schema`.

--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -109,6 +109,61 @@ backend/
   test-preflight.sh      # Env validator (Python, pytest, packages, Redis)
 ```
 
+## Service Map
+
+```
+Shared: Firestore, Redis
+
+backend (main.py)
+  ├── ws ──► pusher (pusher/)
+  ├── ──────► diarizer (diarizer/)
+  ├── ──────► vad (modal/)
+  ├── ──────► deepgram (self-hosted or cloud)
+  ├── ──────► parakeet (parakeet/)
+  ├── ──────► nllb-translation (nllb_translation/)
+  └── ──────► llm-gateway (llm_gateway/main.py)
+
+pusher
+  ├── ──────► diarizer (diarizer/)
+  └── ──────► deepgram (cloud)
+
+agent-proxy (agent-proxy/main.py)
+  └── ws ──► user agent VM (private IP, port 8080)
+
+backend-sync (main.py, Cloud Run)
+  ├── ──────► Cloud Tasks queue `sync-jobs` ──► POST /v2/sync-jobs/run (OIDC, same service; fresh lane)
+  ├── ──────► Cloud Tasks queue `sync-backfill` ──► backend-sync-backfill POST /v2/sync-jobs/run (OIDC; historical lane)
+  ├── ──────► Cloud Tasks queue `audio-merge` ──► POST /v2/audio-merge-jobs/run (OIDC, same service)
+  └── ──────► Cloud Tasks queue `account-deletion` ──► POST /v1/users/account-deletion-wipes/run (OIDC, same service)
+
+notifications-job (modal/job.py)  [cron]
+memory-maintenance-job (modal/memory_maintenance_job.py)  [cron]
+agent-vm-reaper (backend/charts/agent-vm-reaper)  [cron]
+```
+
+Helm charts: `backend/charts/{agent-proxy,agent-vm-reaper,backend-listen,backend-secrets,deepgram-self-hosted,diarizer,llm-gateway,monitoring,nllb-translation,parakeet,pusher,vad}/`
+
+- **backend** (`main.py`) — REST API. Streams audio to pusher via WebSocket (`utils/pusher.py`). Calls diarizer for speaker embeddings (`utils/stt/speaker_embedding.py`). Calls vad for voice activity detection and speaker identification (`utils/stt/vad.py`, `utils/stt/speech_profile.py`). Calls deepgram or parakeet for STT (`HOSTED_PARAKEET_API_URL`, `utils/stt/streaming.py`). Calls NLLB translation when `HOSTED_TRANSLATION_API_URL` is set and NLLB is selected (`utils/translation.py`).
+- **hosted MCP OAuth** (`routers/mcp_sse.py`) — Provider-neutral OAuth for `/v1/mcp/sse`. Configure public or confidential clients with `MCP_OAUTH_CLIENTS_JSON`; allowlist the exact connector callback URI from the provider. The temporary `MCP_OAUTH_CHATGPT_*` envs still define the legacy confidential ChatGPT test client, and `MCP_OAUTH_PUBLIC_*` can expose a no-secret PKCE public client. Also set `MCP_AUTHORIZATION_SERVER_URL`, optional `MCP_RESOURCE_URL`, and token TTL env vars.
+- **llm-gateway** (`llm_gateway/main.py`) — Internal FastAPI service for Omi-managed LLM auto lanes. Called by backend with service auth for `omi:auto:*` chat-completions routes; not exposed to clients.
+- **pusher** (`pusher/main.py`) — Receives audio via binary WebSocket protocol. Calls diarizer and deepgram for speaker sample extraction (`utils/speaker_identification.py` → `utils/speaker_sample.py`).
+- **agent-proxy** (`agent-proxy/main.py`) — GKE. WebSocket proxy at `wss://agent.omi.me/v1/agent/ws`. Validates Firebase ID token, looks up `agentVm` in Firestore, proxies bidirectionally to VM's `ws://<ip>:8080/ws`.
+- **diarizer** (`diarizer/main.py`) — GPU. Speaker embeddings at `/v2/embedding`. Called by backend and pusher (`HOSTED_SPEAKER_EMBEDDING_API_URL`).
+- **vad** (`modal/main.py`) — GPU. `/v1/vad` and `/v1/speaker-identification`. Called by backend only.
+- **deepgram** — STT. Streaming uses self-hosted (`DEEPGRAM_SELF_HOSTED_URL`) or cloud based on `DEEPGRAM_SELF_HOSTED_ENABLED`. Pre-recorded always uses Deepgram cloud. Called by backend and pusher.
+- **parakeet** (`parakeet/`) — GPU STT service for streaming and pre-recorded transcription. Called by backend when `HOSTED_PARAKEET_API_URL` is set and parakeet is selected.
+- **nllb-translation** (`nllb_translation/`) — GPU translation service. Called by backend when `HOSTED_TRANSLATION_API_URL` is set and NLLB is selected.
+- **backend-sync** (`main.py`, same image as backend) — Cloud Run admission service for `/v2/sync-local-files`. The server classifies whole batches: recordings no more than six hours old enter `sync-jobs` (fresh), while older or untrusted batches enter `sync-backfill` and the scale-to-zero **backend-sync-backfill** worker. Fresh keeps its bounded inline fallback; backfill never falls into fresh/inline capacity. Backfill defaults to one in-flight job per UID, four processed speech hours per UID/day, 555 processed speech hours globally/day, a 30-day lookback, and four queue workers. Live fair-use reads only `realtime + sync_fresh`; `sync_backfill` is separately metered. A 45-day Firestore content ledger protects transcription and usage side effects across job expiry and re-upload. Audio playback merges (`/v1/sync/audio/*`) follow the same pattern via queue `audio-merge` building 30-day MP3 artifacts under `playback/` (`AUDIO_MERGE_DISPATCH_MODE`) — per-part files plus one dense per-conversation `conversation.mp3` whose spans manifest + audio_files fingerprint are stamped on the conversation doc (`conversation_audio`); a fingerprint mismatch after late chunks re-enqueues the build. Account deletion uses `ACCOUNT_DELETION_DISPATCH_MODE=cloud_tasks` to enqueue durable wipes to queue `account-deletion`, which posts `/v1/users/account-deletion-wipes/run`; API success is returned only after the deletion marker is persisted and the wipe task is durably enqueued.
+- **notifications-job** (`modal/job.py`) — Cron job, reads Firestore/Redis, sends push notifications and runs X connector sync. It has no canonical maintenance flags or Typesense secrets; its deploy workflow removes only those retired bindings and preserves unrelated notification/X-sync env.
+- **memory-maintenance-job** (`modal/memory_maintenance_job.py`) — Cloud Run Job and sole host for canonical ST→LT maintenance (TTL → consolidation → promotion). Manual deploy via `.github/workflows/gcp_memory_maintenance_job.yml`; auto-dev on push to `main` via `gcp_memory_maintenance_job_auto_dev.yml`. Enablement is a multi-var contract (`MEMORY_MODE`, `MEMORY_ENABLED_USERS`, cron/fast-track/consolidation flags) enforced by `backend/scripts/validate-backend-runtime-env.py`; prod stays `MEMORY_MODE=off` until Gate 3.
+- **monitoring** (`backend/charts/monitoring/`) — Prometheus, Grafana, Loki, Alloy, alerts, and HPA metric adapters for backend services.
+- **agent-vm-reaper** (`backend/charts/agent-vm-reaper/`) — CronJob that deletes stale `omi-agent-*` GCE VMs left by desktop agent sandboxes.
+- **backend-secrets** (`backend/charts/backend-secrets/`) — ExternalSecret and SecretStore resources that sync backend runtime secrets into GKE namespaces.
+
+Backend runtime env contract: keep `backend/deploy/runtime_env.yaml` aligned with GKE Helm values and Cloud Run runtime env; run `backend/scripts/pre-deploy-check.sh` after backend runtime env or deploy workflow changes.
+
+Keep this map up to date. When adding, removing, or changing inter-service calls, update this section. If a PR changes audio streaming, transcription, conversation lifecycle, speaker identification, or the listen/pusher WebSocket protocol — update `docs/doc/developer/backend/listen_pusher_pipeline.mdx` in the same PR.
+
 ## Import Rules
 
 All imports at module top level — never inside functions. Strict hierarchy:
@@ -134,6 +189,20 @@ HTTP endpoints: `uid: str = Depends(get_current_user_uid)` from `utils.other.end
 WebSocket endpoints: use `WebSocketException(code=1008)`, **not** `HTTPException` — HTTPException exits ASGI without handshake, causing LB 5xx.
 
 Rate limiting: `Depends(auth.with_rate_limit(get_current_user_uid, "policy_name"))` — policies in `utils/rate_limit_config.py`.
+
+## Logging Security
+
+Never log raw sensitive data. Use `sanitize()` and `sanitize_pii()` from `utils.log_sanitizer`.
+
+- `sanitize()` for `response.text`, API responses, error bodies.
+- `sanitize_pii()` for names, emails, user text.
+- Keep UIDs, IPs, status codes visible for debugging.
+- Never put raw `response.text` in exception messages.
+
+## Error Composition & Memory
+
+- **Composition errors** — step helpers raise a typed error caught once at the composition boundary. Do not add assigned-call `isinstance(...): return` flow control; `.github/scripts/check_isinstance_return_ratchet.py` ratchets existing occurrences.
+- **Memory management** — `del` byte arrays after processing, `.clear()` dicts/lists holding data.
 
 ## Testing
 
@@ -244,7 +313,7 @@ WS handlers in `transcribe.py` and `pusher.py` manage 5-11 concurrent tasks per 
 7. **Firestore collection group queries** need explicit indexes — 500 with no useful error
 8. **Mutable WebSocket state races** — snapshot `nonlocal` variables before spawning async work
 9. **Silent fire-and-forget drops** — functions gating on connection state must log when dropping work
-10. **New fallbacks** — call `utils.observability.fallback.record_fallback` (see root `AGENTS.md`); do not invent a new `*_fallback_total` Counter
+10. **New fallbacks** — call `utils.observability.fallback.record_fallback` (see `docs/agents/fallback-telemetry.md`); do not invent a new `*_fallback_total` Counter
 11. **Queue caps for user data** — `private_cloud_queue` uses `deque(maxlen=20)` to prevent OOM kills (sized for 30 conns/pod); dropping oldest chunk is better than killing the pod and losing ALL data for ALL users
 12. **`langdetect` unreliable on short text** — don't use on <20 chars or gate paid API calls on interim streaming text
 13. **DG keepalive vs response timeout** — `keep_alive()` prevents DG's 10s idle timeout but NOT 1011 response timeout after all audio is processed. Post-session 1011 is benign.

--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -214,6 +214,8 @@ npm run test:listen-lifecycle:emulator  # Real Firestore transaction contention 
 
 **Tests are selector-driven.** Local `test.sh` runs the full discovered set from `tests/unit/`, `tests/services/`, and `tests/routers/` via `scripts/select_backend_unit_tests.py`; CI uses the same selector but may run only a changed-file subset on PRs. Tests that need live services (Redis, Firebase, real API keys) go in `tests/integration/`, which is not part of selector auto-discovery; note in the PR how you ran them.
 
+**OpenAPI contract runner** — OpenAPI contract checks use `backend/scripts/openapi_runner.sh`, which syncs the pinned `backend/openapi-requirements.txt` runner env and prewarms `tiktoken`; CI and `scripts/pre-push` must use this same path.
+
 **Released app-client compatibility** — `docs/api-reference/app-client-openapi.json` is a compatibility boundary, not only a generated snapshot. PR CI compares it directionally with the merge-base via `scripts/check_app_client_openapi_compatibility.py`: requests accepted by the released contract must remain accepted, and new responses must remain decodable by released clients. Additive optional request fields and response fields are allowed. Do not allowlist breaking changes; retain a deprecated boundary field/parameter or version the endpoint.
 
 **Test isolation / import purity** — never mutate `sys.modules` at module scope in tests; production modules must not construct clients or do IO at import time. Sanctioned seams: `monkeypatch.setattr` on a lazy-held singleton, FastAPI `app.dependency_overrides`. Enforced by `python scripts/check_module_stub_pollution.py` and `python scripts/scan_import_time_side_effects.py`. Full prescription: `backend/docs/test_isolation.md`.

--- a/desktop/macos/AGENTS.md
+++ b/desktop/macos/AGENTS.md
@@ -262,6 +262,33 @@ This creates `/Applications/omi-fix-rewind.app` with bundle ID `com.omi.omi-fix-
   QA bundle. This is the compact Swift/Node/Rust contract gate; reserve full
   component suites and the live continuity gauntlet for PR readiness.
 
+### Run Variants & Parallel Worktrees
+- `./run.sh --yolo` — quick start against the dev backend, no local services. `OMI_SKIP_BACKEND=1` — app only, remote backend via `OMI_DESKTOP_API_URL`. `OMI_SKIP_TUNNEL=1` — no Cloudflare tunnel.
+- **Parallel worktrees auto-isolate.** `scripts/dev-instance.sh` derives a unique instance from each linked git worktree, so `run.sh` (and `backend/scripts/dev-serve.sh`) pick per-worktree ports (Rust 10201+, Python 8080+, automation 47777+) and bundle name (`omi-<worktree>`). Kills are pidfile-scoped (never the global `omi-desktop-backend` name), and a taken port fails loud instead of clobbering. The primary checkout is unchanged (`Omi Dev`, 10201/8080/47777). Override any of `OMI_INSTANCE` / `PORT` / `PYTHON_PORT` / `OMI_AUTOMATION_PORT` / `OMI_APP_NAME` to opt out.
+- `Omi Dev` is the canonical shared development profile (reusable permissions, auth seed source). Do not pass `OMI_APP_NAME="Omi Dev"` from a linked worktree; that creates a named bundle displayed as Omi Dev with a different bundle id and breaks permission reuse.
+- Local Python backend (per-worktree port): `cd backend && ./scripts/dev-serve.sh`.
+
+### Self-Testing the App (agents)
+
+**Hard rule: you may not ask the user to verify a feature you have not actually exercised yourself.** Compiling, "looks correct from the code", or "scroll down to see it" are not verification. If the obvious path is blocked (permission, focus, missing tool), try a long sequence of alternatives before involving the user — extend the bridge with a new action, add a temporary in-process hook, search the web for a workaround, grant the missing permission yourself if you can, write a tiny standalone harness. Roughly: spend ten serious attempts across different approaches before you escalate. Asking the user is the last move, not the first.
+
+Fast path (skips web login and sidebar click-through):
+
+1. **Build + launch a named bundle** (see Testing with Named Bundles above). `./run.sh` auto-clones Omi Dev auth/onboarding plus common shortcuts/settings **before launch**. Manual seeding:
+   ```bash
+   ./scripts/omi-auth-dump.sh                                  # capture the Omi Dev session
+   ./scripts/omi-auth-seed.sh com.omi.omi-<feature> \
+     tmp/desktop-auth.json "/Applications/omi-<feature>.app"   # clears stale Keychain; UD→KC migrate
+   ./scripts/omi-settings-seed.sh com.omi.omi-<feature>        # replay shortcuts/settings
+   ```
+2. **Prefer the local bridge — it never touches the cursor.** It calls the app's real code in-process (no synthetic mouse events). Use it before reaching for `agent-swift click`/`cliclick`/computer-use. Auto-enables on non-prod bundles; run several at once via distinct `OMI_AUTOMATION_PORT` (default 47777).
+   - `./scripts/omi-ctl state` — app-state snapshot (selected tab, auth, onboarding).
+   - `./scripts/omi-ctl navigate <screen> [settings-section]` — jump straight to a screen in ~150ms (`omi-ctl screens` lists targets).
+   - `./scripts/omi-ctl actions` then `./scripts/omi-ctl action <name> [k=v …]` — semantic actions (e.g. `refresh_all_data`). Add new ones in `DesktopAutomationActionRegistry`. See `e2e/SKILL.md` §2b.
+   - `agent-swift` only for UI the bridge can't reach yet (`click` moves the cursor).
+3. **Read logs to confirm behavior:** app + chat bridge in `/private/tmp/omi-dev.log` (dev) or `/private/tmp/omi.log`; local Rust backend on the `./run.sh` stdout; per-user issues in Sentry/PostHog.
+4. **Verify the actual behavior**, not just that the app launched — exercise the feature and check the logs/UI reflect the change.
+
 ### After Implementing Changes
 - `xcrun swift build` is for **compile checks only** — it does NOT start the backend
 - To actually test, ALWAYS use `./run.sh` with `OMI_APP_NAME` — it starts Rust backend + Cloudflare tunnel + Swift app together

--- a/docs/agents/fallback-telemetry.md
+++ b/docs/agents/fallback-telemetry.md
@@ -1,0 +1,31 @@
+# Fallback / Resilience Telemetry
+
+Cross-component contract for instrumenting fallback and fail-open branches (Python, Swift, Rust). The one-line rule lives in the root `AGENTS.md`; this file is the full prescription.
+
+Silent UX healing is allowed; **silent ops is not**. When a branch changes provider, mode, correctness, or takes a fail-open path, call the shared helper — do **not** invent a new `*_fallback_total` counter or one-off PostHog event.
+
+```
+IF branch changes provider OR mode OR correctness OR fail-open taken:
+  MUST call record_fallback / recordFallback with outcome
+ELSE IF hard failure (no continue):
+  error metric / Sentry / HTTP — NOT the fallback helper
+ELSE (pure cache miss, expected soft path with no mode change):
+  existing domain metric OR nothing — NOT fallback helper
+```
+
+| Field | Values |
+|-------|--------|
+| `component` / `area` | closed enum (`sync_dispatch`, `pusher`, `realtime_hub`, `ptt_cascade`, …) → else `other` |
+| `from` / `to` | closed enums or `none` |
+| `reason` | shared bounded set (`enqueue_failed`, `circuit_open`, `byok`, …) → else `other` |
+| `outcome` | `recovered` (full UX restored) \| `degraded` (continues with hit) \| `exhausted` (no path left) |
+
+Emitters:
+
+- Python: `utils.observability.fallback.record_fallback` → `omi_fallback_total`
+- Swift: `DesktopDiagnosticsManager.recordFallback` → `desktop_health_event`/`fallback_triggered`
+- Rust: `fallback::record_fallback` → fixed-field `tracing` (`event=fallback`)
+
+Legacy metrics (`llm_gateway_*`, `pusher_sessions_degraded`) stay — do not copy their fat label sets onto new sites. Alert on rates with denominators or dwell gauges; never page on raw absolute counts or successful `recovered` heals.
+
+Optional ratchet (not CI): `python backend/scripts/check_fallback_instrumentation.py <touched files>` warns when a diff hunk adds fallback/fail-open/degraded branches without `record_fallback`/`recordFallback`.

--- a/omi/firmware/AGENTS.md
+++ b/omi/firmware/AGENTS.md
@@ -1,0 +1,17 @@
+# Firmware (Omi CV1) — Agent Guide
+
+Component guide for `omi/firmware/`. General engineering rules: root `AGENTS.md`.
+
+## Release Workflow
+
+Firmware releases are manual via `.github/workflows/firmware_release.yml`:
+
+1. Bump `CONFIG_BT_DIS_FW_REV_STR` in `omi/firmware/omi/omi.conf` first.
+2. `gh workflow run firmware_release.yml -f publish=publish -f changelog="..." -f minimum_app_version_code=...` (omit `publish` for a build-only QA run).
+3. The workflow builds via Docker (NCS 2.9.0 sysbuild + MCUboot), names the OTA asset `Omi_CV1_OTA_v<ver>.zip` (the "ota" substring is required), and publishes a `Omi_CV1_v<ver>` GitHub Release with the `KEY_VALUE` body that `backend/routers/firmware.py` serves.
+
+Build logic lives in `omi/firmware/scripts/ci/`.
+
+## Formatting
+
+C/C++ files: `clang-format -i <files>` (the repo pre-commit hook covers this).


### PR DESCRIPTION
## What

Collapses root `AGENTS.md` from **400 lines / 42KB to 133 lines / 14KB** (–67%). The root file is loaded into every agent session for every task, so every line costs context in every session; it had accumulated component reference detail (service map essays, executor pool tables, release pipeline walkthroughs) alongside the cross-component rules that actually belong there.

The new shape: high-level guidance + a **Read Next (just-in-time)** index that routes agents to component guides based on working context.

- **Moved, not deleted:** backend service map, logging security, and composition/memory rules → `backend/AGENTS.md`; agent-flutter verification + analyzer ratchet → `app/AGENTS.md`; run variants, parallel-worktree isolation, and the self-testing hard rule → `desktop/macos/AGENTS.md`; firmware release workflow → new `omi/firmware/AGENTS.md`; fallback-telemetry contract → new `docs/agents/fallback-telemetry.md`.
- **Deduplicated:** main-branch policy, squash-merge ban, and pre-commit hook install each appeared 2–3 times; now once each.
- **Two new cross-component rules** (from recent issue-review experience on #9752/#9757/#9760): an **Issues** section (issues state problems, PRs state solutions; incident issues close on live evidence) and the **automatic-or-dead** rule (new checks must be wired into an existing CI or deploy lane in the same PR).
- **New CI ratchet:** `.github/scripts/check_agents_md_lean.py` fails when root `AGENTS.md` exceeds 180 lines / 18KB, registered in `.github/checks-manifest.yaml` (local + ci lanes) so `make preflight` and CI both enforce it. The failure message directs detail to the component guides.

## Root cause / durable guard

Root cause: `AGENTS.md`'s own "keep it concise" rule was requested behavior with no check, so detail accumulated PR by PR. Durable guard: the `agents-md-lean` budget ratchet — per the repo's own doctrine, enforced rules don't drift; requested behavior does.

## Verification

- `python3 .github/scripts/check_agents_md_lean.py` → `ok: AGENTS.md within budget (180 lines / 18000 bytes)`; the script self-tests pass/fail behavior on synthetic files on every run.
- `python3 .github/scripts/test_run_checks.py` → 9 tests OK (manifest contract, including the new entry).
- `make preflight` → all 8 selected checks PASS, including `agents-md-lean` selected by the diff triggers.
- Content-loss audit: grepped every moved rule's key terms (`openapi_runner`, `flutterfire`, `test-preflight`, `WS_RECEIVE_TIMEOUT`, `setup.sh ios`, `workflow_contracts`, `listen_pusher_pipeline`, `run_blocking`, `Omi_CV1_OTA`) across all guides — each survives in exactly one home. One rule (`openapi_runner.sh`) was found lost in the audit and restored in its own commit.
- Pre-push hooks (including backend OpenAPI contract lane) passed on push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9766?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

