### PR TITLE
fix(cli): restore Click and Windows locale compatibility

### DIFF
--- a/sdks/python-cli/pyproject.toml
+++ b/sdks/python-cli/pyproject.toml
@@ -39,7 +39,8 @@ classifiers = [
 ]
 dependencies = [
     "click>=8.1,<9.0",
-    "typer>=0.12,<1.0",
+    # Typer 0.26 vendors Click, while omi-cli extends the external Click API.
+    "typer>=0.12,<0.26",
     "rich>=13.7,<15.0",
     "httpx>=0.27,<1.0",
     "tenacity>=8.2,<10.0",

--- a/sdks/python-cli/tests/test_local.py
+++ b/sdks/python-cli/tests/test_local.py
@@ -349,7 +349,11 @@ def test_screenshot_preserves_structured_local_api_error_in_json(config_path: Pa
 
     with respx.mock(base_url=FAKE_LOCAL_URL, assert_all_called=True) as router:
         router.post("/v1/local/tool").mock(return_value=httpx.Response(422, json=error_payload))
-        result = cli_runner.invoke(app, ["--json", "local", "screenshot", "123", "--output", str(output)])
+        result = cli_runner.invoke(
+            app,
+            ["--json", "local", "screenshot", "123", "--output", str(output)],
+            standalone_mode=False,
+        )
 
     assert result.exit_code != 0
     assert not output.exists()
@@ -435,7 +439,11 @@ def test_screenshot_non_json_local_api_error_has_status_code(config_path: Path, 
 
     with respx.mock(base_url=FAKE_LOCAL_URL, assert_all_called=True) as router:
         router.post("/v1/local/tool").mock(return_value=httpx.Response(500, text="plain failure"))
-        result = cli_runner.invoke(app, ["--json", "local", "screenshot", "123", "--output", str(output)])
+        result = cli_runner.invoke(
+            app,
+            ["--json", "local", "screenshot", "123", "--output", str(output)],
+            standalone_mode=False,
+        )
 
     assert result.exit_code != 0
     assert not output.exists()

--- a/sdks/python-cli/tests/test_openapi_contract.py
+++ b/sdks/python-cli/tests/test_openapi_contract.py
@@ -40,7 +40,7 @@ CLI_ROUTES = {
 
 
 def load_public_openapi() -> dict:
-    return json.loads(PUBLIC_OPENAPI_PATH.read_text())
+    return json.loads(PUBLIC_OPENAPI_PATH.read_text(encoding="utf-8"))
 
 
 def normalize_route_template(path: str) -> str:
@@ -76,10 +76,9 @@ def test_cli_memory_category_enum_matches_public_openapi():
 def test_cli_goal_type_enum_matches_public_openapi():
     spec = load_public_openapi()
     goal_type_schema = spec['components']['schemas'].get('GoalType')
-    assert goal_type_schema and 'enum' in goal_type_schema, (
-        'GoalType enum missing from public OpenAPI; the CLI mirrors it for '
-        'goal create/update validation.'
-    )
+    assert (
+        goal_type_schema and 'enum' in goal_type_schema
+    ), 'GoalType enum missing from public OpenAPI; the CLI mirrors it for goal create/update validation.'
     expected = set(goal_type_schema['enum'])
     actual = {item.value for item in GoalType}
 
@@ -104,4 +103,3 @@ def test_cli_local_only_enums_are_documented():
         'ConversationTextSource now exists in public OpenAPI — replace the '
         'CLI-local enum with a contract check against the published schema.'
     )
-


### PR DESCRIPTION
## Summary

- cap Typer below 0.26 while `omi-cli` subclasses the external `click.ClickException` API
- run the two structured-exception unit tests in non-standalone mode so they continue to inspect the original `CliError` payload
- read the public OpenAPI contract explicitly as UTF-8 on locale-encoded Windows hosts

## Why

Typer 0.26 introduced a breaking boundary by vendoring Click and no longer supporting direct external Click integration: https://typer.tiangolo.com/tutorial/click/. The current `typer>=0.12,<1.0` range therefore resolves to a version whose exception base is different from `omi-cli`'s `CliError` base. Six stable exit-code/error-rendering tests fail under Typer 0.26.8.

Separately, `Path.read_text()` inherits the Windows system code page. On a GBK host, all four CLI/OpenAPI contract tests fail while decoding the repository's UTF-8 JSON.

This keeps the last compatible Typer series available (`0.25.x`) rather than pinning one patch release, and makes the contract reader independent of host locale.

## Testing

- fresh dependency resolution: Typer 0.25.1 + Click 8.4.2
- targeted error and OpenAPI tests under `PYTHONUTF8=0`: `12 passed`
- Windows CLI suite excluding the two owner-only ACL tests addressed by #9764: `123 passed, 2 deselected`
- Black and isort: passed
- `git diff --check`: passed

Before the fix, the six external-Click error paths failed under Typer 0.26.8 and the four OpenAPI cases failed with `UnicodeDecodeError` under the Windows locale.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9767?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

