### PR TITLE
Fix PTT dead-mic recovery and prove realtime providers

### DIFF
--- a/.github/actions/transcription-release-candidate-probe/action.yml
+++ b/.github/actions/transcription-release-candidate-probe/action.yml
@@ -6,7 +6,10 @@ inputs:
     description: Tagged no-traffic Cloud Run candidate URL.
     required: true
   project_id:
-    description: Firebase and Cloud Run project for the existing deploy identity.
+    description: GCP project used for Secret Manager and the existing deploy identity.
+    required: true
+  firebase_auth_project_id:
+    description: Firebase project whose ID-token audience the candidate verifies.
     required: true
   evidence_path:
     description: Optional absolute path for the redacted probe report.
@@ -21,13 +24,15 @@ runs:
       env:
         CANDIDATE_API_URL: ${{ inputs.candidate_api_url }}
         EVIDENCE_PATH: ${{ inputs.evidence_path }}
-        PROBE_PROJECT_ID: ${{ inputs.project_id }}
+        PROBE_SECRET_PROJECT: ${{ inputs.project_id }}
+        FIREBASE_AUTH_PROJECT_ID: ${{ inputs.firebase_auth_project_id }}
       run: |
         set -euo pipefail
         token_file="$(mktemp "$RUNNER_TEMP/omi-transcription-probe.XXXXXX")"
         trap 'rm -f "$token_file"' EXIT
         python3 backend/scripts/firebase_release_probe_token.py \
-          --project "$PROBE_PROJECT_ID" \
+          --secret-project "$PROBE_SECRET_PROJECT" \
+          --firebase-project "$FIREBASE_AUTH_PROJECT_ID" \
           --token-output "$token_file"
         probe_args=(
           --candidate-api-url "$CANDIDATE_API_URL"

--- a/.github/workflows/backend-unit-tests.yml
+++ b/.github/workflows/backend-unit-tests.yml
@@ -13,6 +13,7 @@ on:
       - '.github/workflows/backend-unit-tests.yml'
       - '.github/workflows/desktop-checks.yml'
       - '.github/workflows/desktop-swift-ci.yml'
+      - '.github/workflows/desktop_backend_auto_dev.yml'
       - '.github/workflows/repo-checks.yml'
       - '.github/workflows/desktop_promote_beta.yml'
       - '.github/workflows/desktop_promote_prod.yml'
@@ -26,6 +27,7 @@ on:
       - 'scripts/install-git-hooks.sh'
       - 'scripts/pre-push'
       - 'scripts/pre-push-singleflight'
+      - 'scripts/voice-provider-probe.sh'
   pull_request:
     paths:
       - '.gitignore'
@@ -36,6 +38,7 @@ on:
       - '.github/workflows/backend-unit-tests.yml'
       - '.github/workflows/desktop-checks.yml'
       - '.github/workflows/desktop-swift-ci.yml'
+      - '.github/workflows/desktop_backend_auto_dev.yml'
       - '.github/workflows/repo-checks.yml'
       - '.github/workflows/desktop_promote_beta.yml'
       - '.github/workflows/desktop_promote_prod.yml'
@@ -49,6 +52,7 @@ on:
       - 'scripts/install-git-hooks.sh'
       - 'scripts/pre-push'
       - 'scripts/pre-push-singleflight'
+      - 'scripts/voice-provider-probe.sh'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/desktop_backend_auto_dev.yml
+++ b/.github/workflows/desktop_backend_auto_dev.yml
@@ -18,6 +18,7 @@ on:
 env:
   SERVICE: desktop-backend
   REGION: us-central1
+  FIREBASE_AUTH_PROJECT_ID: based-hardware
   DEFAULT_DESKTOP_BACKEND_BASE_API_URL: https://desktop-backend-dt5lrfkkoa-uc.a.run.app
 
 concurrency:
@@ -107,7 +108,7 @@ jobs:
           image: gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}
           flags: '--allow-unauthenticated'
           env_vars: |
-            FIREBASE_PROJECT_ID=based-hardware
+            FIREBASE_PROJECT_ID=${{ env.FIREBASE_AUTH_PROJECT_ID }}
             GOOGLE_APPLICATION_CREDENTIALS=/app/google-credentials.json
             BASE_API_URL=${{ steps.desktop-base-api-url.outputs.base_api_url }}
             OMI_DESKTOP_RELEASE_SHA=${{ github.sha }}
@@ -236,7 +237,8 @@ jobs:
           token_file="$(mktemp "$RUNNER_TEMP/omi-voice-provider-probe.XXXXXX")"
           trap 'rm -f "$token_file"' EXIT
           python3 backend/scripts/firebase_release_probe_token.py \
-            --project "$PROJECT_ID" \
+            --secret-project "$PROJECT_ID" \
+            --firebase-project "$FIREBASE_AUTH_PROJECT_ID" \
             --token-output "$token_file"
 
           for provider in openai gemini; do

--- a/.github/workflows/desktop_backend_auto_dev.yml
+++ b/.github/workflows/desktop_backend_auto_dev.yml
@@ -5,7 +5,15 @@ on:
     branches: [ "main" ]
     paths:
       - 'desktop/macos/Backend-Rust/**'
+      - 'backend/scripts/firebase_release_probe_token.py'
+      - 'scripts/voice-provider-probe.sh'
   workflow_dispatch:
+    inputs:
+      skip_provider_probe:
+        description: 'Skip the managed realtime-provider probe during an active upstream outage'
+        required: false
+        default: false
+        type: boolean
 
 env:
   SERVICE: desktop-backend
@@ -202,6 +210,51 @@ jobs:
 
           echo "Development desktop-backend did not report the deployed release identity." >&2
           exit 1
+
+      - name: Prove managed realtime provider paths
+        env:
+          PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
+          SKIP_PROVIDER_PROBE: ${{ github.event.inputs.skip_provider_probe || 'false' }}
+        run: |
+          set -euo pipefail
+          if [[ "$SKIP_PROVIDER_PROBE" == "true" ]]; then
+            echo "::warning title=Managed realtime provider probe skipped::skip_provider_probe=true was requested during a provider outage."
+            echo "### Managed realtime provider probe skipped" >> "$GITHUB_STEP_SUMMARY"
+            echo "Reason: workflow_dispatch input skip_provider_probe=true" >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          SERVICE_URL=$(gcloud run services describe "$SERVICE" \
+            --region "$REGION" \
+            --project "$PROJECT_ID" \
+            --format='value(status.url)')
+          if [[ -z "$SERVICE_URL" ]]; then
+            echo "Could not resolve the deployed desktop-backend URL for the provider probe." >&2
+            exit 1
+          fi
+
+          token_file="$(mktemp "$RUNNER_TEMP/omi-voice-provider-probe.XXXXXX")"
+          trap 'rm -f "$token_file"' EXIT
+          python3 backend/scripts/firebase_release_probe_token.py \
+            --project "$PROJECT_ID" \
+            --token-output "$token_file"
+
+          for provider in openai gemini; do
+            for attempt in 1 2 3; do
+              probe_exit=0
+              scripts/voice-provider-probe.sh "$provider" "$SERVICE_URL" \
+                --bearer-token-file "$token_file" || probe_exit=$?
+              if [[ "$probe_exit" -eq 0 ]]; then
+                break
+              fi
+              if [[ "$probe_exit" -ne 75 || "$attempt" -eq 3 ]]; then
+                echo "Managed realtime provider proof failed for $provider." >&2
+                exit "$probe_exit"
+              fi
+              echo "Retrying $provider provider proof after a retryable upstream failure ($attempt/3)."
+              sleep 5
+            done
+          done
 
       - name: Show Output
         run: echo "Desktop backend deployed to development environment"

--- a/.github/workflows/gcp_backend.yml
+++ b/.github/workflows/gcp_backend.yml
@@ -409,6 +409,7 @@ jobs:
         with:
           candidate_api_url: ${{ steps.transcription-candidate.outputs.url }}
           project_id: ${{ vars.GCP_PROJECT_ID }}
+          firebase_auth_project_id: based-hardware
 
       - name: Remove passed transcription candidate tag
         if: ${{ success() }}

--- a/.github/workflows/sync_ledger_fence_cutover.yml
+++ b/.github/workflows/sync_ledger_fence_cutover.yml
@@ -270,6 +270,7 @@ jobs:
         with:
           candidate_api_url: ${{ steps.prepare.outputs.candidate_probe_url }}
           project_id: ${{ vars.GCP_PROJECT_ID }}
+          firebase_auth_project_id: based-hardware
           evidence_path: ${{ runner.temp }}/transcription-capability-probe.json
 
       - name: Record protected full-route probe proof

--- a/backend/scripts/firebase_release_probe_token.py
+++ b/backend/scripts/firebase_release_probe_token.py
@@ -4,16 +4,20 @@
 The script uses the already authenticated deploy identity. It reads the existing
 Firebase web API key from Secret Manager, remotely signs a five-minute Firebase
 custom token for the fixed non-human release-probe UID, then exchanges it for a
-Firebase ID token. It never prints a credential, request body, response body,
-or upstream error body. The ID token is written only to a mode-0600 file owned
-by the current runner process.
+Firebase ID token. The caller separately names the expected Firebase auth
+project; the script rejects a mismatched token audience or issuer. It never
+prints a credential, request body, response body, or upstream error body. The
+ID token is written only to a mode-0600 file owned by the current runner
+process.
 """
 
 from __future__ import annotations
 
 import argparse
+import base64
 import json
 import os
+import re
 import stat
 import subprocess
 import sys
@@ -32,6 +36,7 @@ IDENTITY_TOOLKIT_URL = 'https://identitytoolkit.googleapis.com/v1/accounts:signI
 CUSTOM_TOKEN_TTL_SECONDS = 300
 HTTP_TIMEOUT_SECONDS = 30
 MAX_TOKEN_CHARS = 8192
+FIREBASE_PROJECT_ID_PATTERN = re.compile(r'^[a-z][a-z0-9-]{4,62}$')
 
 
 class ProbeTokenError(RuntimeError):
@@ -169,22 +174,57 @@ def _exchange_custom_token(custom_token: str, firebase_api_key: str) -> str:
     return id_token
 
 
-def mint_probe_token(project: str) -> str:
+def _validate_firebase_id_token_claims(id_token: str, firebase_project: str) -> None:
+    """Assert the exchanged token is for the backend's Firebase auth project.
+
+    This is intentionally an unverified claim check: the target backend still
+    verifies the token signature before authorizing the probe. Its purpose here
+    is to fail before a deployment probe when the Secret Manager project or
+    deploy identity is accidentally paired with a Firebase API key for a
+    different auth project.
+    """
+    token_parts = id_token.split('.')
+    if len(token_parts) != 3 or not token_parts[1] or len(token_parts[1]) > MAX_TOKEN_CHARS:
+        raise ProbeTokenError('firebase_token_claims')
+    try:
+        padded_claims = token_parts[1] + '=' * (-len(token_parts[1]) % 4)
+        claims = json.loads(base64.urlsafe_b64decode(padded_claims.encode('ascii')).decode('utf-8'))
+    except (UnicodeDecodeError, ValueError, json.JSONDecodeError):
+        raise ProbeTokenError('firebase_token_claims') from None
+    if not isinstance(claims, dict):
+        raise ProbeTokenError('firebase_token_claims')
+    try:
+        valid = (
+            claims.get('aud') == firebase_project
+            and claims.get('iss') == f'https://securetoken.google.com/{firebase_project}'
+            and claims.get('sub') == PROBE_UID
+        )
+    finally:
+        claims.clear()
+    if not valid:
+        raise ProbeTokenError('firebase_token_claims')
+
+
+def mint_probe_token(secret_project: str, firebase_project: str) -> str:
     firebase_api_key = ''
     service_account = ''
     access_token = ''
     custom_token = ''
+    id_token = ''
     try:
-        firebase_api_key = _access_secret(project)
+        firebase_api_key = _access_secret(secret_project)
         service_account = _active_service_account()
         access_token = _access_token()
         custom_token = _signed_custom_token(service_account, access_token)
-        return _exchange_custom_token(custom_token, firebase_api_key)
+        id_token = _exchange_custom_token(custom_token, firebase_api_key)
+        _validate_firebase_id_token_claims(id_token, firebase_project)
+        return id_token
     finally:
         firebase_api_key = ''
         service_account = ''
         access_token = ''
         custom_token = ''
+        id_token = ''
 
 
 def write_token(path: Path, token: str) -> None:
@@ -211,7 +251,8 @@ def write_token(path: Path, token: str) -> None:
 
 def parse_args(argv: Sequence[str]) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument('--project', required=True)
+    parser.add_argument('--secret-project', required=True)
+    parser.add_argument('--firebase-project', required=True)
     parser.add_argument('--token-output', required=True, type=Path)
     return parser.parse_args(argv)
 
@@ -220,7 +261,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     args = parse_args(argv or sys.argv[1:])
     token = ''
     try:
-        token = mint_probe_token(args.project)
+        if not FIREBASE_PROJECT_ID_PATTERN.fullmatch(args.firebase_project):
+            raise ProbeTokenError('firebase_project')
+        token = mint_probe_token(args.secret_project, args.firebase_project)
         write_token(args.token_output, token)
     except ProbeTokenError as error:
         print(json.dumps({'suite': 'omi_firebase_release_probe_token', 'stage': error.stage, 'status': 'FAIL'}))

--- a/backend/testing/workflow_contracts.json
+++ b/backend/testing/workflow_contracts.json
@@ -422,6 +422,25 @@
       ]
     },
     {
+      "id": "desktop_backend_realtime_provider_proof",
+      "risk": "high",
+      "sources": [
+        ".github/workflows/desktop_backend_auto_dev.yml",
+        "backend/scripts/firebase_release_probe_token.py",
+        "scripts/voice-provider-probe.sh"
+      ],
+      "tests": [
+        "tests/unit/test_firebase_release_probe_token.py",
+        "tests/unit/test_voice_provider_probe.py"
+      ],
+      "checks": [],
+      "invariants": [
+        "every deployed development desktop backend proves the managed OpenAI and Gemini mint-to-response paths",
+        "the bypass is explicit in the workflow log and is limited to an operator-declared upstream outage",
+        "probe credentials and provider responses never appear in workflow output"
+      ]
+    },
+    {
       "id": "backend_cloud_run_deploy",
       "risk": "high",
       "sources": [

--- a/backend/testing/workflow_contracts.json
+++ b/backend/testing/workflow_contracts.json
@@ -436,6 +436,7 @@
       "checks": [],
       "invariants": [
         "every deployed development desktop backend proves the managed OpenAI and Gemini mint-to-response paths",
+        "the Firebase ID token audience and issuer match the deployed backend's explicit Firebase auth project",
         "the bypass is explicit in the workflow log and is limited to an operator-declared upstream outage",
         "probe credentials and provider responses never appear in workflow output"
       ]

--- a/backend/tests/unit/test_firebase_release_probe_token.py
+++ b/backend/tests/unit/test_firebase_release_probe_token.py
@@ -1,4 +1,5 @@
 import importlib.util
+import base64
 import json
 import stat
 import sys
@@ -14,6 +15,16 @@ def _load_module():
     sys.modules[spec.name] = module
     spec.loader.exec_module(module)
     return module
+
+
+def _id_token(*, aud='based-hardware', sub='omi-release-probe'):
+    claims = {
+        'aud': aud,
+        'iss': f'https://securetoken.google.com/{aud}',
+        'sub': sub,
+    }
+    encoded = base64.urlsafe_b64encode(json.dumps(claims).encode()).decode().rstrip('=')
+    return f'header.{encoded}.signature'
 
 
 def test_mint_probe_token_uses_fixed_uid_short_lived_custom_claims_and_discards_refresh(monkeypatch):
@@ -34,7 +45,7 @@ def test_mint_probe_token_uses_fixed_uid_short_lived_custom_claims_and_discards_
         if stage == 'custom_token_signing':
             return {'signedJwt': 'custom-token-that-must-not-leak'}
         return {
-            'idToken': 'firebase-id-token-that-must-not-leak',
+            'idToken': _id_token(),
             'refreshToken': 'refresh-token-that-must-not-leak',
         }
 
@@ -42,7 +53,7 @@ def test_mint_probe_token_uses_fixed_uid_short_lived_custom_claims_and_discards_
     monkeypatch.setattr(module, '_request_json', fake_request)
     monkeypatch.setattr(module.time, 'time', lambda: 1_700_000_000)
 
-    assert module.mint_probe_token('omi-prod') == 'firebase-id-token-that-must-not-leak'
+    assert module.mint_probe_token('based-hardware-dev', 'based-hardware') == _id_token()
     assert commands[0][0][0:5] == ['gcloud', 'secrets', 'versions', 'access', 'latest']
     signing_url, signing_body, signing_access_token, signing_stage = requests[0]
     claims = json.loads(signing_body['payload'])
@@ -64,10 +75,14 @@ def test_token_acquisition_failure_is_redacted_and_does_not_create_output(monkey
     module = _load_module()
     output = tmp_path / 'probe-token'
     monkeypatch.setattr(
-        module, 'mint_probe_token', lambda _project: (_ for _ in ()).throw(module.ProbeTokenError('secret_access'))
+        module,
+        'mint_probe_token',
+        lambda _secret_project, _firebase_project: (_ for _ in ()).throw(module.ProbeTokenError('secret_access')),
     )
 
-    exit_code = module.main(['--project', 'omi-prod', '--token-output', str(output)])
+    exit_code = module.main(
+        ['--secret-project', 'omi-prod', '--firebase-project', 'based-hardware', '--token-output', str(output)]
+    )
 
     report = json.loads(capsys.readouterr().out)
     assert exit_code == 1
@@ -99,3 +114,19 @@ def test_write_token_uses_owner_only_permissions(tmp_path):
 
     assert output.read_text(encoding='utf-8') == 'firebase-id-token-that-must-not-leak'
     assert stat.S_IMODE(output.stat().st_mode) == 0o600
+
+
+def test_mint_probe_token_rejects_a_token_for_a_different_firebase_auth_project(monkeypatch):
+    module = _load_module()
+    monkeypatch.setattr(module, '_access_secret', lambda _project: 'api-key-that-must-not-leak')
+    monkeypatch.setattr(module, '_active_service_account', lambda: 'deployer@omi-prod.iam.gserviceaccount.com')
+    monkeypatch.setattr(module, '_access_token', lambda: 'access-token-that-must-not-leak')
+    monkeypatch.setattr(module, '_signed_custom_token', lambda _account, _token: 'custom-token-that-must-not-leak')
+    monkeypatch.setattr(module, '_exchange_custom_token', lambda _custom, _key: _id_token(aud='wrong-project'))
+
+    try:
+        module.mint_probe_token('based-hardware-dev', 'based-hardware')
+    except module.ProbeTokenError as error:
+        assert error.stage == 'firebase_token_claims'
+    else:
+        raise AssertionError('expected Firebase auth-project mismatch')

--- a/backend/tests/unit/test_voice_provider_probe.py
+++ b/backend/tests/unit/test_voice_provider_probe.py
@@ -1,0 +1,139 @@
+import importlib.machinery
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+
+def _load_module():
+    repo = Path(__file__).resolve().parents[3]
+    script_path = repo / "scripts" / "voice-provider-probe.sh"
+    loader = importlib.machinery.SourceFileLoader("voice_provider_probe", str(script_path))
+    spec = importlib.util.spec_from_loader(loader.name, loader)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    loader.exec_module(module)
+    return module
+
+
+class _Response:
+    status = 200
+
+    def __init__(self, body):
+        self.body = body
+
+    def read(self, _size=-1):
+        return self.body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+
+def test_openai_probe_mints_then_connects_commits_and_waits_for_a_terminal_response(monkeypatch, capsys):
+    module = _load_module()
+    sent = []
+
+    class FakeWebSocket:
+        def __init__(self):
+            self.events = iter(
+                [
+                    {"type": "session.updated"},
+                    {"type": "response.done", "response": {"status": "completed"}},
+                ]
+            )
+            self._socket = None
+            self.closed = False
+
+        def send_json(self, payload):
+            sent.append(payload)
+
+        def receive_json(self):
+            return next(self.events)
+
+        def close(self):
+            self.closed = True
+
+    websocket = FakeWebSocket()
+    monkeypatch.setattr(module, "_mint_provider_token", lambda _config: "ek_probe-token-must-not-leak")
+    monkeypatch.setattr(module, "_openai_websocket", lambda _token, _timeout: websocket)
+
+    result = module.run_probe(
+        module.ProbeConfig(
+            provider="openai",
+            base_url="https://candidate.invalid",
+            bearer_token="firebase-token-must-not-leak",
+            timeout_seconds=5,
+        )
+    )
+
+    output = capsys.readouterr().out
+    assert result == 0
+    assert websocket.closed is True
+    assert [event["type"] for event in sent] == [
+        "conversation.item.create",
+        "response.create",
+    ]
+    assert sent[0]["item"]["content"][0]["text"] == module.PROBE_INPUT
+    assert "step=mint status=PASS class=none" in output
+    assert "step=connect status=PASS class=none" in output
+    assert "step=commit status=PASS class=none" in output
+    assert "step=response status=PASS class=none" in output
+    assert "step=close status=PASS class=expected_idle_teardown" in output
+    assert "firebase-token-must-not-leak" not in output
+    assert "ek_probe-token-must-not-leak" not in output
+    assert module.PROBE_INPUT not in output
+
+
+def test_mint_rejects_a_2xx_response_with_the_wrong_typed_provider_token(monkeypatch):
+    module = _load_module()
+    calls = []
+
+    def fake_urlopen(request, *, timeout):
+        calls.append((request, timeout))
+        return _Response(json.dumps({"provider": "gemini", "token": "auth_tokens/not-openai"}).encode())
+
+    monkeypatch.setattr(module.urllib.request, "urlopen", fake_urlopen)
+    config = module.ProbeConfig(
+        provider="openai",
+        base_url="https://candidate.invalid",
+        bearer_token="firebase-token-must-not-leak",
+        timeout_seconds=5,
+    )
+
+    try:
+        module._mint_provider_token(config)
+    except module.ProbeFailure as error:
+        assert error.failure_class == "mint_schema"
+    else:
+        raise AssertionError("expected typed mint schema rejection")
+
+    request, _ = calls[0]
+    assert request.full_url == "https://candidate.invalid/v2/realtime/session"
+    assert json.loads(request.data) == {"provider": "openai"}
+
+
+def test_timeout_returns_retryable_exit_code_without_exposing_the_token(monkeypatch, capsys):
+    module = _load_module()
+    monkeypatch.setattr(
+        module,
+        "_mint_provider_token",
+        lambda _config: (_ for _ in ()).throw(module.ProbeFailure("timeout", retryable=True)),
+    )
+
+    result = module.run_probe(
+        module.ProbeConfig(
+            provider="gemini",
+            base_url="https://candidate.invalid",
+            bearer_token="firebase-token-must-not-leak",
+            timeout_seconds=5,
+        )
+    )
+
+    output = capsys.readouterr().out
+    assert result == 75
+    assert "provider=gemini step=mint status=FAIL class=timeout" in output
+    assert "firebase-token-must-not-leak" not in output

--- a/backend/tests/unit/test_voice_provider_probe.py
+++ b/backend/tests/unit/test_voice_provider_probe.py
@@ -225,3 +225,32 @@ def test_provider_send_timeout_is_reported_once_as_a_retryable_bounded_failure(m
     assert output.count("status=FAIL") == 1
     assert "provider=openai step=commit status=FAIL class=timeout" in output
     assert "provider token must not leak" not in output
+
+
+def test_http_429_is_classified_as_retryable():
+    module = _load_module()
+    error = module._classify_http_error(429)
+    assert error.failure_class == "mint_http_4xx"
+    assert error.retryable is True
+
+
+def test_mint_http_429_returns_retryable_exit_code(monkeypatch, capsys):
+    module = _load_module()
+    monkeypatch.setattr(
+        module,
+        "_mint_provider_token",
+        lambda _config: (_ for _ in ()).throw(module._classify_http_error(429)),
+    )
+
+    result = module.run_probe(
+        module.ProbeConfig(
+            provider="openai",
+            base_url="https://candidate.invalid",
+            bearer_token="firebase-token-must-not-leak",
+            timeout_seconds=5,
+        )
+    )
+
+    output = capsys.readouterr().out
+    assert result == 75
+    assert "provider=openai step=mint status=FAIL class=mint_http_4xx" in output

--- a/backend/tests/unit/test_voice_provider_probe.py
+++ b/backend/tests/unit/test_voice_provider_probe.py
@@ -88,6 +88,63 @@ def test_openai_probe_mints_then_connects_commits_and_waits_for_a_terminal_respo
     assert module.PROBE_INPUT not in output
 
 
+def test_gemini_probe_completes_a_direct_setup_input_and_turn_complete_path(monkeypatch, capsys):
+    module = _load_module()
+    created = []
+
+    class FakeWebSocket:
+        def __init__(self, url, headers, timeout):
+            self.url = url
+            self.headers = headers
+            self.timeout = timeout
+            self.events = iter([{"setupComplete": {}}, {"serverContent": {"turnComplete": True}}])
+            self.sent = []
+            self._socket = None
+            self.closed = False
+            created.append(self)
+
+        def connect(self):
+            return None
+
+        def send_json(self, payload):
+            self.sent.append(payload)
+
+        def receive_json(self):
+            return next(self.events)
+
+        def close(self):
+            self.closed = True
+
+    monkeypatch.setattr(module, "ProviderWebSocket", FakeWebSocket)
+    monkeypatch.setattr(module, "_mint_provider_token", lambda _config: "auth_tokens/gemini-token-must-not-leak")
+
+    result = module.run_probe(
+        module.ProbeConfig(
+            provider="gemini",
+            base_url="https://candidate.invalid",
+            bearer_token="firebase-token-must-not-leak",
+            timeout_seconds=5,
+        )
+    )
+
+    output = capsys.readouterr().out
+    websocket = created[0]
+    assert result == 0
+    assert websocket.closed is True
+    assert websocket.headers == {}
+    assert websocket.url.startswith(module.GEMINI_URL_PREFIX)
+    assert websocket.sent[0]["setup"]["model"] == "models/gemini-3.1-flash-live-preview"
+    assert websocket.sent[1:] == [
+        {"realtimeInput": {"activityStart": {}}},
+        {"realtimeInput": {"text": module.PROBE_INPUT}},
+        {"realtimeInput": {"activityEnd": {}}},
+    ]
+    assert "provider=gemini step=response status=PASS class=none" in output
+    assert "firebase-token-must-not-leak" not in output
+    assert "gemini-token-must-not-leak" not in output
+    assert module.PROBE_INPUT not in output
+
+
 def test_mint_rejects_a_2xx_response_with_the_wrong_typed_provider_token(monkeypatch):
     module = _load_module()
     calls = []
@@ -137,3 +194,34 @@ def test_timeout_returns_retryable_exit_code_without_exposing_the_token(monkeypa
     assert result == 75
     assert "provider=gemini step=mint status=FAIL class=timeout" in output
     assert "firebase-token-must-not-leak" not in output
+
+
+def test_provider_send_timeout_is_reported_once_as_a_retryable_bounded_failure(monkeypatch, capsys):
+    module = _load_module()
+
+    class FakeWebSocket:
+        _socket = None
+
+        def send_json(self, _payload):
+            raise TimeoutError("provider token must not leak")
+
+        def close(self):
+            return None
+
+    monkeypatch.setattr(module, "_mint_provider_token", lambda _config: "ek_probe-token-must-not-leak")
+    monkeypatch.setattr(module, "_openai_websocket", lambda _token, _timeout: FakeWebSocket())
+
+    result = module.run_probe(
+        module.ProbeConfig(
+            provider="openai",
+            base_url="https://candidate.invalid",
+            bearer_token="firebase-token-must-not-leak",
+            timeout_seconds=5,
+        )
+    )
+
+    output = capsys.readouterr().out
+    assert result == 75
+    assert output.count("status=FAIL") == 1
+    assert "provider=openai step=commit status=FAIL class=timeout" in output
+    assert "provider token must not leak" not in output

--- a/backend/tests/unit/test_workflow_contracts.py
+++ b/backend/tests/unit/test_workflow_contracts.py
@@ -49,6 +49,8 @@ def test_workflow_contract_sources_select_adjacent_tests():
         "backend/config/prerecorded_stt.py": "tests/unit/test_parakeet_prerecorded.py",
         "backend/scripts/validate-backend-runtime-env.py": "tests/unit/test_backend_runtime_env_validator.py",
         "backend/scripts/firebase_release_probe_token.py": "tests/unit/test_firebase_release_probe_token.py",
+        "scripts/voice-provider-probe.sh": "tests/unit/test_voice_provider_probe.py",
+        ".github/workflows/desktop_backend_auto_dev.yml": "tests/unit/test_voice_provider_probe.py",
         "backend/charts/pusher/templates/deployment.yaml": "tests/unit/test_rendered_deployment_contract.py",
         "backend/scripts/validate_rendered_deployment_contract.py": "tests/unit/test_rendered_deployment_contract.py",
         ".github/workflows/gcp_backend_auto_dev.yml": "tests/unit/test_verify_dev_backend_deployment.py",

--- a/desktop/macos/AGENTS.md
+++ b/desktop/macos/AGENTS.md
@@ -292,6 +292,7 @@ Fast path (skips web login and sidebar click-through):
 ### After Implementing Changes
 - `xcrun swift build` is for **compile checks only** — it does NOT start the backend
 - To actually test, ALWAYS use `./run.sh` with `OMI_APP_NAME` — it starts Rust backend + Cloudflare tunnel + Swift app together
+- Voice-path verification means a natural authenticated PTT turn on a named bundle — signed-out, forced-transcript, or reducer-only runs do not count; provider mint or payload changes must also show the deploy-inline provider probe.
 - **When the user says "test it"**, use the `test-local` skill to build, run, and verify via macOS automation
 
 ### macOS Version Compatibility

--- a/desktop/macos/Backend-Rust/ARCHITECTURE.md
+++ b/desktop/macos/Backend-Rust/ARCHITECTURE.md
@@ -11,6 +11,14 @@ The active Rust routes cover authentication, provider proxies, realtime session
 minting, desktop chat, TTS, screen activity ingestion, release manifests, agent
 VM control, support webhooks, and health/configuration endpoints.
 
+Every development deployment of this backend proves its managed realtime path
+after traffic is assigned: the deploy workflow uses the non-human release-probe
+identity to mint each provider credential, opens OpenAI and Gemini directly,
+commits a fixed non-sensitive input, and waits for the provider terminal event.
+`scripts/voice-provider-probe.sh` emits only bounded step/failure classes and
+the workflow fails closed. An upstream-outage override is manual and visibly
+recorded as `skip_provider_probe=true` in the run log.
+
 Firestore access is deliberately limited to data required by those routes:
 
 | Repository | Live responsibility |

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
@@ -59,8 +59,17 @@ struct PTTSilentMicRecoveryPolicy {
     return resolveRecoveryOutcome(.succeeded)
   }
 
+  /// Bluetooth silent-mic fallback only needs the dead-mic streak cleared. It must
+  /// not arm `capture_rebuild` outcomes — that recovery uses `switch_to_built_in_mic`.
   mutating func recordCaptureRebuild() {
     consecutiveDeadMicTurns = 0
+  }
+
+  /// Arm truthful success/failure reporting for a CoreAudio capture rebuild. Used by
+  /// both the dead-mic threshold path and the mid-turn silent-mic watchdog rebuild.
+  mutating func armCaptureRebuildOutcome() {
+    consecutiveDeadMicTurns = 0
+    awaitingRecoveryOutcome = true
   }
 
   private mutating func resolveRecoveryOutcome(_ outcome: RecoveryOutcome) -> RecoveryOutcome? {
@@ -1938,7 +1947,10 @@ class PushToTalkManager: ObservableObject {
 
   private func requestCoreAudioCaptureRecovery(reason: String, restartPTT: Bool, batchMode: Bool) {
     log("PushToTalkManager: requesting CoreAudio capture rebuild — \(reason)")
-    silentMicRecoveryPolicy.recordCaptureRebuild()
+    // Arm here (not in recordCaptureRebuild) so Bluetooth built-in fallback cannot
+    // mislabel switch_to_built_in_mic results as capture_rebuild outcomes, while the
+    // silent-mic watchdog CoreAudio path still gets a next-turn success/failure.
+    silentMicRecoveryPolicy.armCaptureRebuildOutcome()
     stopMicCapture()
     clearBufferedTurnAudio()
     NotificationCenter.default.post(

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
@@ -5,27 +5,69 @@ import CoreAudio
 import OmiSupport
 
 struct PTTSilentMicRecoveryPolicy {
+  enum RecoveryOutcome: String, Equatable {
+    case succeeded
+    case failed
+  }
+
+  struct DiscardedTurnDecision: Equatable {
+    let shouldRebuildCapture: Bool
+    let recoveryOutcome: RecoveryOutcome?
+  }
+
   static let deadMicPeakThreshold = 5
   static let minDeadTurnSeconds: TimeInterval = 0.25
   static let consecutiveDeadTurnThreshold = 2
 
   private(set) var consecutiveDeadMicTurns = 0
+  private var awaitingRecoveryOutcome = false
 
-  mutating func recordDiscardedTurn(totalSec: TimeInterval, peak: Int) -> Bool {
-    if totalSec >= Self.minDeadTurnSeconds && peak <= Self.deadMicPeakThreshold {
-      consecutiveDeadMicTurns += 1
-    } else {
+  mutating func recordDiscardedTurn(totalSec: TimeInterval, peak: Int) -> DiscardedTurnDecision {
+    let recoveryOutcome: RecoveryOutcome?
+    let shouldRebuildCapture: Bool
+
+    if peak > Self.deadMicPeakThreshold {
+      // Audible input proves the mic is alive, whatever else went wrong with the turn.
+      recoveryOutcome = resolveRecoveryOutcome(.succeeded)
       consecutiveDeadMicTurns = 0
+      shouldRebuildCapture = false
+    } else if totalSec >= Self.minDeadTurnSeconds {
+      recoveryOutcome = resolveRecoveryOutcome(.failed)
+      consecutiveDeadMicTurns += 1
+      shouldRebuildCapture = consecutiveDeadMicTurns >= Self.consecutiveDeadTurnThreshold
+      if shouldRebuildCapture {
+        // Arm the outcome before issuing the side effect. This prevents a third
+        // consecutive turn from asking for a second rebuild while the first awaits
+        // its next judgeable turn.
+        consecutiveDeadMicTurns = 0
+        awaitingRecoveryOutcome = true
+      }
+    } else {
+      // A turn too short to judge carries no evidence either way — an accidental
+      // tap, or a release that beat CoreAudio's capture start and delivered no
+      // frames. It must not erase a dead-mic streak or resolve a pending rebuild.
+      recoveryOutcome = nil
+      shouldRebuildCapture = false
     }
-    return consecutiveDeadMicTurns >= Self.consecutiveDeadTurnThreshold
+    return DiscardedTurnDecision(
+      shouldRebuildCapture: shouldRebuildCapture,
+      recoveryOutcome: recoveryOutcome)
   }
 
-  mutating func recordSuccessfulTurn() {
+  mutating func recordSuccessfulTurn() -> RecoveryOutcome? {
     consecutiveDeadMicTurns = 0
+    return resolveRecoveryOutcome(.succeeded)
   }
 
   mutating func recordCaptureRebuild() {
     consecutiveDeadMicTurns = 0
+    awaitingRecoveryOutcome = true
+  }
+
+  private mutating func resolveRecoveryOutcome(_ outcome: RecoveryOutcome) -> RecoveryOutcome? {
+    guard awaitingRecoveryOutcome else { return nil }
+    awaitingRecoveryOutcome = false
+    return outcome
   }
 }
 
@@ -1000,7 +1042,8 @@ class PushToTalkManager: ObservableObject {
       if !Self.hubTurnHasSpeech(pcm16k: turnAudio) {
         let (peak, rms) = Self.audioEnergy(pcm16k: turnAudio)
         let dev = audioCaptureService?.currentDeviceDescription ?? "?"
-        let attemptRecovery = silentMicRecoveryPolicy.recordDiscardedTurn(totalSec: totalSec, peak: peak)
+        let recoveryDecision = silentMicRecoveryPolicy.recordDiscardedTurn(totalSec: totalSec, peak: peak)
+        recordSilentMicRecoveryOutcome(recoveryDecision.recoveryOutcome)
         DesktopDiagnosticsManager.shared.recordPTTSilentTurn(
           source: "hub",
           mode: finalizedMode,
@@ -1011,14 +1054,14 @@ class PushToTalkManager: ObservableObject {
           deviceDescription: dev,
           micPermissionGranted: hasMicPermission,
           hubActive: true,
-          recoveryAction: attemptRecovery ? "capture_rebuild" : "none",
-          recoveryResult: attemptRecovery ? "attempted" : "not_attempted")
+          recoveryAction: recoveryDecision.shouldRebuildCapture ? "capture_rebuild" : "none",
+          recoveryResult: recoveryDecision.shouldRebuildCapture ? "attempted" : "not_attempted")
         log(
           "PushToTalkManager: discarding hub turn — audio \(String(format: "%.2f", totalSec))s "
             + "peak=\(peak)/32767 rms=\(rms) device=[\(dev)] "
             + "(peak≈0 ⇒ dead mic; high peak ⇒ classifier misfire; low ⇒ quiet/far mic) — not committing"
         )
-        if attemptRecovery {
+        if recoveryDecision.shouldRebuildCapture {
           requestCoreAudioCaptureRecovery(reason: "repeated dead-mic PTT turns", restartPTT: false, batchMode: false)
         }
         _ = RealtimeHubController.shared.cancelTurn(turnID: turnID)
@@ -1050,7 +1093,7 @@ class PushToTalkManager: ObservableObject {
         log("PushToTalkManager: realtime hub already owns this pending commit — skipping duplicate fallback")
         return
       }
-      silentMicRecoveryPolicy.recordSuccessfulTurn()
+      recordSilentMicRecoveryOutcome(silentMicRecoveryPolicy.recordSuccessfulTurn())
       DesktopDiagnosticsManager.shared.recordPTTCommitted(mode: finalizedMode, hubActive: true)
       AnalyticsManager.shared.floatingBarPTTEnded(
         mode: finalizedMode, hadTranscript: true, transcriptLength: 0)
@@ -1076,7 +1119,8 @@ class PushToTalkManager: ObservableObject {
         // A dead mic (peak≈0 for a real hold) leaves omni/batch users stuck on
         // repeated silent turns with no recovery. Mirror the hub path: rebuild the
         // CoreAudio capture after consecutive dead-mic turns.
-        let attemptRecovery = silentMicRecoveryPolicy.recordDiscardedTurn(totalSec: totalSec, peak: peak)
+        let recoveryDecision = silentMicRecoveryPolicy.recordDiscardedTurn(totalSec: totalSec, peak: peak)
+        recordSilentMicRecoveryOutcome(recoveryDecision.recoveryOutcome)
         DesktopDiagnosticsManager.shared.recordPTTSilentTurn(
           source: isOmniSTT ? "omni_stt" : "batch_stt",
           mode: finalizedMode,
@@ -1087,14 +1131,14 @@ class PushToTalkManager: ObservableObject {
           deviceDescription: audioCaptureService?.currentDeviceDescription,
           micPermissionGranted: hasMicPermission,
           hubActive: false,
-          recoveryAction: attemptRecovery ? "capture_rebuild" : "none",
-          recoveryResult: attemptRecovery ? "attempted" : "not_attempted")
+          recoveryAction: recoveryDecision.shouldRebuildCapture ? "capture_rebuild" : "none",
+          recoveryResult: recoveryDecision.shouldRebuildCapture ? "attempted" : "not_attempted")
         log(
           "PushToTalkManager: discarding silent turn (audio \(String(format: "%.2f", totalSec))s, voiced \(String(format: "%.2f", voicedSec))s) — not transcribing"
         )
         AnalyticsManager.shared.floatingBarPTTEnded(
           mode: finalizedMode, hadTranscript: false, transcriptLength: 0)
-        if attemptRecovery {
+        if recoveryDecision.shouldRebuildCapture {
           requestCoreAudioCaptureRecovery(reason: "repeated dead-mic PTT turns", restartPTT: false, batchMode: isBatch)
         }
         // A too-short turn means the release beat capture (or the user tapped
@@ -1112,7 +1156,7 @@ class PushToTalkManager: ObservableObject {
     // Past the silence gate — a real turn will be transcribed and answered. Show
     // the "thinking" indicator through the transcription/first-token gap; it hands
     // off to the conversation surface (or voice glow) the moment output arrives.
-    silentMicRecoveryPolicy.recordSuccessfulTurn()
+    recordSilentMicRecoveryOutcome(silentMicRecoveryPolicy.recordSuccessfulTurn())
     voiceTurnCoordinator.send(.transcriptionStarted(turnID: turnID))
 
     // Realtime omni: commit the turn and wait for the final transcript.
@@ -1578,7 +1622,8 @@ class PushToTalkManager: ObservableObject {
       // Mirror the primary hub path: repeated dead-mic turns must trip capture
       // recovery here too, otherwise users whose turns land on the buffered
       // warm-wait path get recovery_action=none forever (issue #9081).
-      let attemptRecovery = silentMicRecoveryPolicy.recordDiscardedTurn(totalSec: totalSec, peak: peak)
+      let recoveryDecision = silentMicRecoveryPolicy.recordDiscardedTurn(totalSec: totalSec, peak: peak)
+      recordSilentMicRecoveryOutcome(recoveryDecision.recoveryOutcome)
       DesktopDiagnosticsManager.shared.recordPTTSilentTurn(
         source: "buffered_hub",
         mode: finalizedMode,
@@ -1589,15 +1634,15 @@ class PushToTalkManager: ObservableObject {
         deviceDescription: dev,
         micPermissionGranted: hasMicPermission,
         hubActive: true,
-        recoveryAction: attemptRecovery ? "capture_rebuild" : "none",
-        recoveryResult: attemptRecovery ? "attempted" : "not_attempted")
+        recoveryAction: recoveryDecision.shouldRebuildCapture ? "capture_rebuild" : "none",
+        recoveryResult: recoveryDecision.shouldRebuildCapture ? "attempted" : "not_attempted")
       log(
         "PushToTalkManager: discarding buffered hub turn — audio \(String(format: "%.2f", totalSec))s "
           + "peak=\(peak)/32767 rms=\(rms) device=[\(dev)] — not committing")
       if let turnID = currentVoiceTurnID {
         _ = RealtimeHubController.shared.cancelTurn(turnID: turnID)
       }
-      if attemptRecovery {
+      if recoveryDecision.shouldRebuildCapture {
         requestCoreAudioCaptureRecovery(reason: "repeated dead-mic PTT turns", restartPTT: false, batchMode: false)
       }
       AnalyticsManager.shared.floatingBarPTTEnded(
@@ -1624,7 +1669,7 @@ class PushToTalkManager: ObservableObject {
       log("PushToTalkManager: buffered hub commit is already owned — skipping duplicate fallback")
       return
     }
-    silentMicRecoveryPolicy.recordSuccessfulTurn()
+    recordSilentMicRecoveryOutcome(silentMicRecoveryPolicy.recordSuccessfulTurn())
     DesktopDiagnosticsManager.shared.recordPTTCommitted(mode: finalizedMode, hubActive: true)
     AnalyticsManager.shared.floatingBarPTTEnded(
       mode: finalizedMode, hadTranscript: true, transcriptLength: 0)
@@ -1642,7 +1687,8 @@ class PushToTalkManager: ObservableObject {
       let (peak, rms) = Self.audioEnergy(pcm16k: audio)
       // Same dead-mic recovery as the primary omni/batch path — the warm-wait
       // fallback was previously the one silent-turn exit with no recovery (#9081).
-      let attemptRecovery = silentMicRecoveryPolicy.recordDiscardedTurn(totalSec: totalSec, peak: peak)
+      let recoveryDecision = silentMicRecoveryPolicy.recordDiscardedTurn(totalSec: totalSec, peak: peak)
+      recordSilentMicRecoveryOutcome(recoveryDecision.recoveryOutcome)
       DesktopDiagnosticsManager.shared.recordPTTSilentTurn(
         source: "warm_wait_fallback",
         mode: finalizedMode,
@@ -1653,13 +1699,13 @@ class PushToTalkManager: ObservableObject {
         deviceDescription: audioCaptureService?.currentDeviceDescription,
         micPermissionGranted: hasMicPermission,
         hubActive: false,
-        recoveryAction: attemptRecovery ? "capture_rebuild" : "none",
-        recoveryResult: attemptRecovery ? "attempted" : "not_attempted")
+        recoveryAction: recoveryDecision.shouldRebuildCapture ? "capture_rebuild" : "none",
+        recoveryResult: recoveryDecision.shouldRebuildCapture ? "attempted" : "not_attempted")
       log(
         "PushToTalkManager: discarding warm-wait fallback turn (audio \(String(format: "%.2f", totalSec))s, voiced \(String(format: "%.2f", voicedSec))s)")
       AnalyticsManager.shared.floatingBarPTTEnded(
         mode: finalizedMode, hadTranscript: false, transcriptLength: 0)
-      if attemptRecovery {
+      if recoveryDecision.shouldRebuildCapture {
         requestCoreAudioCaptureRecovery(reason: "repeated dead-mic PTT turns", restartPTT: false, batchMode: true)
       }
       if let turnID = currentVoiceTurnID {
@@ -1670,7 +1716,7 @@ class PushToTalkManager: ObservableObject {
       }
       return
     }
-    silentMicRecoveryPolicy.recordSuccessfulTurn()
+    recordSilentMicRecoveryOutcome(silentMicRecoveryPolicy.recordSuccessfulTurn())
     guard let turnID = currentVoiceTurnID else { return }
     voiceTurnCoordinator.send(.selectRoute(turnID: turnID, route: .deepgramBatch))
     voiceTurnCoordinator.send(.transcriptionStarted(turnID: turnID))
@@ -1904,6 +1950,13 @@ class PushToTalkManager: ObservableObject {
     if restartPTT {
       startMicCapture(batchMode: batchMode, overrideDeviceID: preferredPTTInputOverrideDeviceID())
     }
+  }
+
+  private func recordSilentMicRecoveryOutcome(_ outcome: PTTSilentMicRecoveryPolicy.RecoveryOutcome?) {
+    guard let outcome else { return }
+    DesktopDiagnosticsManager.shared.recordPTTDeviceRouteChanged(
+      recoveryAction: "capture_rebuild",
+      recoveryResult: outcome.rawValue)
   }
 
   private func preferredPTTInputOverrideDeviceID() -> AudioDeviceID? {

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
@@ -61,7 +61,6 @@ struct PTTSilentMicRecoveryPolicy {
 
   mutating func recordCaptureRebuild() {
     consecutiveDeadMicTurns = 0
-    awaitingRecoveryOutcome = true
   }
 
   private mutating func resolveRecoveryOutcome(_ outcome: RecoveryOutcome) -> RecoveryOutcome? {

--- a/desktop/macos/Desktop/Tests/PTTSilentMicRecoveryPolicyTests.swift
+++ b/desktop/macos/Desktop/Tests/PTTSilentMicRecoveryPolicyTests.swift
@@ -93,6 +93,18 @@ final class PTTSilentMicRecoveryPolicyTests: XCTestCase {
     XCTAssertEqual(policy.consecutiveDeadMicTurns, 1)
   }
 
+  func testCaptureRebuildResetsCounterWithoutArmingOutcome() {
+    var policy = PTTSilentMicRecoveryPolicy()
+
+    XCTAssertFalse(policy.recordDiscardedTurn(totalSec: 1.0, peak: 0).shouldRebuildCapture)
+    policy.recordCaptureRebuild()
+
+    XCTAssertEqual(policy.consecutiveDeadMicTurns, 0)
+    // Bluetooth silent-mic fallback calls recordCaptureRebuild for counter reset
+    // only; it must not arm capture_rebuild outcome tracking.
+    XCTAssertNil(policy.recordSuccessfulTurn())
+  }
+
   private func armedRecoveryPolicy() -> PTTSilentMicRecoveryPolicy {
     var policy = PTTSilentMicRecoveryPolicy()
     XCTAssertFalse(policy.recordDiscardedTurn(totalSec: 1.0, peak: 0).shouldRebuildCapture)

--- a/desktop/macos/Desktop/Tests/PTTSilentMicRecoveryPolicyTests.swift
+++ b/desktop/macos/Desktop/Tests/PTTSilentMicRecoveryPolicyTests.swift
@@ -105,6 +105,27 @@ final class PTTSilentMicRecoveryPolicyTests: XCTestCase {
     XCTAssertNil(policy.recordSuccessfulTurn())
   }
 
+  func testCoreAudioCaptureRebuildArmsOutcomeForNextJudgeableTurn() {
+    var policy = PTTSilentMicRecoveryPolicy()
+
+    policy.armCaptureRebuildOutcome()
+
+    XCTAssertEqual(policy.consecutiveDeadMicTurns, 0)
+    XCTAssertEqual(policy.recordSuccessfulTurn(), .succeeded)
+    XCTAssertNil(policy.recordSuccessfulTurn())
+  }
+
+  func testCoreAudioCaptureRebuildFailureIsRecordedWithoutImmediateRearm() {
+    var policy = PTTSilentMicRecoveryPolicy()
+
+    policy.armCaptureRebuildOutcome()
+    let nextTurn = policy.recordDiscardedTurn(totalSec: 1.0, peak: 0)
+
+    XCTAssertEqual(nextTurn.recoveryOutcome, .failed)
+    XCTAssertFalse(nextTurn.shouldRebuildCapture)
+    XCTAssertEqual(policy.consecutiveDeadMicTurns, 1)
+  }
+
   private func armedRecoveryPolicy() -> PTTSilentMicRecoveryPolicy {
     var policy = PTTSilentMicRecoveryPolicy()
     XCTAssertFalse(policy.recordDiscardedTurn(totalSec: 1.0, peak: 0).shouldRebuildCapture)

--- a/desktop/macos/Desktop/Tests/PTTSilentMicRecoveryPolicyTests.swift
+++ b/desktop/macos/Desktop/Tests/PTTSilentMicRecoveryPolicyTests.swift
@@ -6,33 +6,37 @@ final class PTTSilentMicRecoveryPolicyTests: XCTestCase {
   func testRepeatedDeadMicTurnsRequestRecovery() {
     var policy = PTTSilentMicRecoveryPolicy()
 
-    XCTAssertFalse(policy.recordDiscardedTurn(totalSec: 1.0, peak: 0))
+    XCTAssertFalse(policy.recordDiscardedTurn(totalSec: 1.0, peak: 0).shouldRebuildCapture)
     XCTAssertEqual(policy.consecutiveDeadMicTurns, 1)
 
-    XCTAssertTrue(policy.recordDiscardedTurn(totalSec: 1.0, peak: 0))
-    XCTAssertEqual(policy.consecutiveDeadMicTurns, 2)
+    XCTAssertTrue(policy.recordDiscardedTurn(totalSec: 1.0, peak: 0).shouldRebuildCapture)
+    XCTAssertEqual(policy.consecutiveDeadMicTurns, 0)
   }
 
   func testShortSilentTapDoesNotCountAsDeadMic() {
     var policy = PTTSilentMicRecoveryPolicy()
 
-    XCTAssertFalse(policy.recordDiscardedTurn(totalSec: 0.05, peak: 0))
+    XCTAssertFalse(policy.recordDiscardedTurn(totalSec: 0.05, peak: 0).shouldRebuildCapture)
     XCTAssertEqual(policy.consecutiveDeadMicTurns, 0)
   }
 
   func testQuietButNonZeroTurnResetsDeadMicCounter() {
     var policy = PTTSilentMicRecoveryPolicy()
 
-    XCTAssertFalse(policy.recordDiscardedTurn(totalSec: 1.0, peak: 0))
-    XCTAssertFalse(policy.recordDiscardedTurn(totalSec: 1.0, peak: PTTSilentMicRecoveryPolicy.deadMicPeakThreshold + 1))
+    XCTAssertFalse(policy.recordDiscardedTurn(totalSec: 1.0, peak: 0).shouldRebuildCapture)
+    XCTAssertFalse(
+      policy.recordDiscardedTurn(
+        totalSec: 1.0,
+        peak: PTTSilentMicRecoveryPolicy.deadMicPeakThreshold + 1
+      ).shouldRebuildCapture)
     XCTAssertEqual(policy.consecutiveDeadMicTurns, 0)
   }
 
   func testSuccessfulTurnResetsDeadMicCounter() {
     var policy = PTTSilentMicRecoveryPolicy()
 
-    XCTAssertFalse(policy.recordDiscardedTurn(totalSec: 1.0, peak: 0))
-    policy.recordSuccessfulTurn()
+    XCTAssertFalse(policy.recordDiscardedTurn(totalSec: 1.0, peak: 0).shouldRebuildCapture)
+    XCTAssertNil(policy.recordSuccessfulTurn())
 
     XCTAssertEqual(policy.consecutiveDeadMicTurns, 0)
   }
@@ -40,10 +44,59 @@ final class PTTSilentMicRecoveryPolicyTests: XCTestCase {
   func testSuccessfulTurnPreventsNonConsecutiveDeadMicRecovery() {
     var policy = PTTSilentMicRecoveryPolicy()
 
-    XCTAssertFalse(policy.recordDiscardedTurn(totalSec: 1.0, peak: 0))
-    policy.recordSuccessfulTurn()
+    XCTAssertFalse(policy.recordDiscardedTurn(totalSec: 1.0, peak: 0).shouldRebuildCapture)
+    XCTAssertNil(policy.recordSuccessfulTurn())
 
-    XCTAssertFalse(policy.recordDiscardedTurn(totalSec: 1.0, peak: 0))
+    XCTAssertFalse(policy.recordDiscardedTurn(totalSec: 1.0, peak: 0).shouldRebuildCapture)
     XCTAssertEqual(policy.consecutiveDeadMicTurns, 1)
+  }
+
+  /// A zero-frame turn is neutral: it must leave the prior judgeable dead-mic
+  /// evidence intact so the existing capture rebuild can arm on the next turn.
+  func testZeroFrameTurnBetweenNearZeroTurnsPreservesDeadMicEvidence() {
+    var policy = PTTSilentMicRecoveryPolicy()
+
+    XCTAssertFalse(policy.recordDiscardedTurn(totalSec: 1.0, peak: 0).shouldRebuildCapture)
+    XCTAssertFalse(policy.recordDiscardedTurn(totalSec: 0, peak: 0).shouldRebuildCapture)
+    XCTAssertEqual(policy.consecutiveDeadMicTurns, 1)
+
+    XCTAssertTrue(policy.recordDiscardedTurn(totalSec: 1.0, peak: 0).shouldRebuildCapture)
+  }
+
+  func testThresholdRequestsExactlyOneCaptureRebuildUntilNextJudgeableTurn() {
+    var policy = PTTSilentMicRecoveryPolicy()
+
+    XCTAssertFalse(policy.recordDiscardedTurn(totalSec: 1.0, peak: 0).shouldRebuildCapture)
+    XCTAssertTrue(policy.recordDiscardedTurn(totalSec: 1.0, peak: 0).shouldRebuildCapture)
+
+    let nextTurn = policy.recordDiscardedTurn(totalSec: 1.0, peak: 0)
+    XCTAssertEqual(nextTurn.recoveryOutcome, .failed)
+    XCTAssertFalse(nextTurn.shouldRebuildCapture)
+    XCTAssertEqual(policy.consecutiveDeadMicTurns, 1)
+  }
+
+  func testAudibleTurnAfterCaptureRebuildRecordsSuccessAndRearmsPolicy() {
+    var policy = armedRecoveryPolicy()
+
+    XCTAssertEqual(policy.recordSuccessfulTurn(), .succeeded)
+    XCTAssertFalse(policy.recordDiscardedTurn(totalSec: 1.0, peak: 0).shouldRebuildCapture)
+    XCTAssertTrue(policy.recordDiscardedTurn(totalSec: 1.0, peak: 0).shouldRebuildCapture)
+  }
+
+  func testNearZeroTurnAfterCaptureRebuildRecordsFailureWithoutSpinning() {
+    var policy = armedRecoveryPolicy()
+
+    let nextTurn = policy.recordDiscardedTurn(totalSec: 1.0, peak: 0)
+
+    XCTAssertEqual(nextTurn.recoveryOutcome, .failed)
+    XCTAssertFalse(nextTurn.shouldRebuildCapture)
+    XCTAssertEqual(policy.consecutiveDeadMicTurns, 1)
+  }
+
+  private func armedRecoveryPolicy() -> PTTSilentMicRecoveryPolicy {
+    var policy = PTTSilentMicRecoveryPolicy()
+    XCTAssertFalse(policy.recordDiscardedTurn(totalSec: 1.0, peak: 0).shouldRebuildCapture)
+    XCTAssertTrue(policy.recordDiscardedTurn(totalSec: 1.0, peak: 0).shouldRebuildCapture)
+    return policy
   }
 }

--- a/desktop/macos/Desktop/Tests/PTTSilentTurnRecoveryWiringTests.swift
+++ b/desktop/macos/Desktop/Tests/PTTSilentTurnRecoveryWiringTests.swift
@@ -23,10 +23,10 @@ final class PTTSilentTurnRecoveryWiringTests: XCTestCase {
     // Every silent-turn record must carry an explicit recovery decision — no site
     // may fall back to the `recoveryAction: "none"` default silently.
     let silentTurnCalls = source.components(separatedBy: "recordPTTSilentTurn(").count - 1
-    let recoveryDecisions = source.components(separatedBy: "recoveryResult: attemptRecovery").count - 1
+    let recoveryDecisions = source.components(separatedBy: "recoveryResult: recoveryDecision.shouldRebuildCapture").count - 1
     XCTAssertEqual(
       silentTurnCalls, recoveryDecisions,
-      "Every recordPTTSilentTurn site must pass recoveryResult: attemptRecovery")
+      "Every recordPTTSilentTurn site must pass the production recovery decision")
 
     // Every discard must be counted toward the dead-mic threshold so recovery can
     // eventually trip, and each site attempts a capture rebuild once tripped.
@@ -39,6 +39,20 @@ final class PTTSilentTurnRecoveryWiringTests: XCTestCase {
       silentTurnCalls,
       "Every silent-turn discard must guard a capture rebuild")
 
+    // A rebuild is not proven by being invoked: each silent discard and each
+    // accepted audible turn must resolve the pending recovery through the shared
+    // diagnostics surface on its next judgeable result.
+    let recoveryOutcomeRecords = source.components(
+      separatedBy: "recordSilentMicRecoveryOutcome(").count - 2
+    let successfulTurns = source.components(
+      separatedBy: "silentMicRecoveryPolicy.recordSuccessfulTurn()").count - 1
+    XCTAssertEqual(
+      recoveryOutcomeRecords,
+      silentTurnCalls + successfulTurns,
+      "Every judgeable PTT turn must record a pending capture-rebuild outcome")
+    XCTAssertTrue(source.contains("recoveryAction: \"capture_rebuild\""))
+    XCTAssertTrue(source.contains("DesktopDiagnosticsManager.shared.recordPTTDeviceRouteChanged"))
+
     // The two previously-unwired buffered paths must now participate.
     XCTAssertTrue(source.contains("source: \"buffered_hub\""))
     XCTAssertTrue(source.contains("source: \"warm_wait_fallback\""))
@@ -49,7 +63,7 @@ final class PTTSilentTurnRecoveryWiringTests: XCTestCase {
       .deletingLastPathComponent()
       .deletingLastPathComponent()
       .appendingPathComponent("Sources/FloatingControlBar/PushToTalkManager.swift")
-    // omi-test-quality: source-inspection -- static contract: every recordPTTSilentTurn discard site must wire recovery; PushToTalkManager is a @MainActor singleton with no behavioral seam
+    // omi-test-quality: source-inspection -- static contract: every recordPTTSilentTurn discard site must wire recovery and settle its outcome; PushToTalkManager is a @MainActor singleton with no behavioral seam
     return try String(contentsOf: url, encoding: .utf8)
   }
 }

--- a/desktop/macos/Desktop/Tests/PTTSilentTurnRecoveryWiringTests.swift
+++ b/desktop/macos/Desktop/Tests/PTTSilentTurnRecoveryWiringTests.swift
@@ -52,6 +52,16 @@ final class PTTSilentTurnRecoveryWiringTests: XCTestCase {
       "Every judgeable PTT turn must record a pending capture-rebuild outcome")
     XCTAssertTrue(source.contains("recoveryAction: \"capture_rebuild\""))
     XCTAssertTrue(source.contains("DesktopDiagnosticsManager.shared.recordPTTDeviceRouteChanged"))
+    // CoreAudio rebuild owns outcome arming; Bluetooth keeps recordCaptureRebuild unarmed.
+    XCTAssertTrue(source.contains("silentMicRecoveryPolicy.armCaptureRebuildOutcome()"))
+    let recoveryHelper = source.components(separatedBy: "private func requestCoreAudioCaptureRecovery").last ?? ""
+    let recoveryBody = recoveryHelper.components(separatedBy: "private func recordSilentMicRecoveryOutcome").first ?? ""
+    XCTAssertTrue(
+      recoveryBody.contains("armCaptureRebuildOutcome()"),
+      "requestCoreAudioCaptureRecovery must arm capture_rebuild outcomes")
+    XCTAssertFalse(
+      recoveryBody.contains("recordCaptureRebuild()"),
+      "requestCoreAudioCaptureRecovery must not call Bluetooth-only recordCaptureRebuild")
 
     // The two previously-unwired buffered paths must now participate.
     XCTAssertTrue(source.contains("source: \"buffered_hub\""))

--- a/desktop/macos/changelog/unreleased/20260714-ptt-dead-mic-recovery.json
+++ b/desktop/macos/changelog/unreleased/20260714-ptt-dead-mic-recovery.json
@@ -1,0 +1,3 @@
+{
+  "change": "Improved push-to-talk recovery after silent microphone capture"
+}

--- a/scripts/voice-provider-probe.sh
+++ b/scripts/voice-provider-probe.sh
@@ -246,7 +246,12 @@ class ProviderWebSocket:
         encoded = json.dumps(payload, separators=(",", ":")).encode("utf-8")
         if len(encoded) > MAX_WEBSOCKET_MESSAGE_BYTES:
             raise ProbeFailure("commit_failed")
-        self._send_frame(0x1, encoded)
+        try:
+            self._send_frame(0x1, encoded)
+        except (socket.timeout, TimeoutError) as error:
+            raise ProbeFailure("timeout", retryable=True) from error
+        except (OSError, ssl.SSLError) as error:
+            raise ProbeFailure("provider_transport") from error
 
     def _send_frame(self, opcode: int, payload: bytes) -> None:
         length = len(payload)
@@ -345,6 +350,8 @@ def _receive_until(websocket: ProviderWebSocket, timeout_seconds: float, matcher
             event = websocket.receive_json()
         except (socket.timeout, TimeoutError) as error:
             raise ProbeFailure("timeout", retryable=True) from error
+        except (OSError, ssl.SSLError) as error:
+            raise ProbeFailure("provider_transport") from error
         if event.get("type") == "error" or "error" in event:
             raise ProbeFailure("provider_event_error")
         if matcher(event):
@@ -357,36 +364,44 @@ def _openai_websocket(token: str, timeout_seconds: float) -> ProviderWebSocket:
         {"Authorization": f"Bearer {token}"},
         timeout_seconds,
     )
-    websocket.connect()
-    websocket.send_json(
-        {
-            "type": "session.update",
-            "session": {
-                "type": "realtime",
-                "instructions": "Return the requested deterministic response.",
-                "output_modalities": ["text"],
-            },
-        }
-    )
-    _receive_until(websocket, timeout_seconds, lambda event: event.get("type") == "session.updated")
-    return websocket
+    try:
+        websocket.connect()
+        websocket.send_json(
+            {
+                "type": "session.update",
+                "session": {
+                    "type": "realtime",
+                    "instructions": "Return the requested deterministic response.",
+                    "output_modalities": ["text"],
+                },
+            }
+        )
+        _receive_until(websocket, timeout_seconds, lambda event: event.get("type") == "session.updated")
+        return websocket
+    except Exception:
+        websocket.close()
+        raise
 
 
 def _gemini_websocket(token: str, timeout_seconds: float) -> ProviderWebSocket:
     query = urllib.parse.urlencode({"access_token": token})
     websocket = ProviderWebSocket(f"{GEMINI_URL_PREFIX}?{query}", {}, timeout_seconds)
-    websocket.connect()
-    websocket.send_json(
-        {
-            "setup": {
-                "model": "models/gemini-3.1-flash-live-preview",
-                "generationConfig": {"responseModalities": ["AUDIO"], "temperature": 0.0},
-                "systemInstruction": {"parts": [{"text": "Return the requested deterministic response."}]},
+    try:
+        websocket.connect()
+        websocket.send_json(
+            {
+                "setup": {
+                    "model": "models/gemini-3.1-flash-live-preview",
+                    "generationConfig": {"responseModalities": ["AUDIO"], "temperature": 0.0},
+                    "systemInstruction": {"parts": [{"text": "Return the requested deterministic response."}]},
+                }
             }
-        }
-    )
-    _receive_until(websocket, timeout_seconds, lambda event: "setupComplete" in event)
-    return websocket
+        )
+        _receive_until(websocket, timeout_seconds, lambda event: "setupComplete" in event)
+        return websocket
+    except Exception:
+        websocket.close()
+        raise
 
 
 def run_probe(config: ProbeConfig) -> int:
@@ -454,6 +469,12 @@ def run_probe(config: ProbeConfig) -> int:
     except ProbeFailure as error:
         _emit(config.provider, current_step, "FAIL", error.failure_class)
         return 75 if error.retryable else 1
+    except (socket.timeout, TimeoutError):
+        _emit(config.provider, current_step, "FAIL", "timeout")
+        return 75
+    except (OSError, ssl.SSLError):
+        _emit(config.provider, current_step, "FAIL", "provider_transport")
+        return 1
     finally:
         provider_token = ""
     _emit(config.provider, "close", "PASS", "expected_idle_teardown")

--- a/scripts/voice-provider-probe.sh
+++ b/scripts/voice-provider-probe.sh
@@ -1,0 +1,480 @@
+#!/usr/bin/env python3
+"""Prove one deployed managed realtime-provider turn without exposing credentials.
+
+The probe mints a short-lived provider credential from the deployed desktop
+backend, opens the provider's direct WebSocket path, commits a fixed harmless
+text fixture, and waits for the provider's terminal response event. It accepts
+only a mode-0600 Firebase ID-token file so callers never put a bearer token in a
+command line, environment dump, or log.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import os
+import socket
+import ssl
+import stat
+import struct
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Sequence
+
+MINT_PATH = "/v2/realtime/session"
+OPENAI_URL = "wss://api.openai.com/v1/realtime?model=gpt-realtime-2"
+GEMINI_URL_PREFIX = "wss://generativelanguage.googleapis.com/ws/google.ai.generativelanguage.v1alpha.GenerativeService.BidiGenerateContentConstrained"
+OPENAI_TOKEN_PREFIX = "ek_"
+GEMINI_TOKEN_PREFIX = "auth_tokens/"
+PROBE_INPUT = "Reply with exactly OMI_PROVIDER_PROBE_OK."
+MAX_TOKEN_CHARS = 8192
+MAX_HTTP_RESPONSE_BYTES = 128 * 1024
+MAX_HANDSHAKE_BYTES = 32 * 1024
+MAX_WEBSOCKET_MESSAGE_BYTES = 1024 * 1024
+DEFAULT_TIMEOUT_SECONDS = 25.0
+
+
+@dataclass(frozen=True)
+class ProbeConfig:
+    provider: str
+    base_url: str
+    bearer_token: str | None
+    timeout_seconds: float
+
+
+class ProbeFailure(RuntimeError):
+    def __init__(self, failure_class: str, *, retryable: bool = False):
+        super().__init__(failure_class)
+        self.failure_class = failure_class
+        self.retryable = retryable
+
+
+def _read_bearer_token(path: Path | None) -> str | None:
+    if path is None:
+        return None
+    descriptor = -1
+    try:
+        descriptor = os.open(path, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
+        file_stat = os.fstat(descriptor)
+        if not stat.S_ISREG(file_stat.st_mode) or file_stat.st_mode & 0o077:
+            return None
+        with os.fdopen(descriptor, encoding="utf-8") as handle:
+            descriptor = -1
+            token = handle.read().strip()
+    except (OSError, UnicodeDecodeError):
+        return None
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+    return token if 0 < len(token) <= MAX_TOKEN_CHARS else None
+
+
+def _normalize_base_url(value: str) -> str | None:
+    try:
+        parsed = urllib.parse.urlsplit(value.strip())
+    except ValueError:
+        return None
+    if parsed.scheme != "https" or not parsed.netloc or parsed.query or parsed.fragment:
+        return None
+    return urllib.parse.urlunsplit((parsed.scheme, parsed.netloc, parsed.path.rstrip("/"), "", ""))
+
+
+def config_from_args(args: argparse.Namespace) -> ProbeConfig:
+    return ProbeConfig(
+        provider=args.provider,
+        base_url=_normalize_base_url(args.backend_base_url) or "",
+        bearer_token=_read_bearer_token(args.bearer_token_file),
+        timeout_seconds=args.timeout_seconds,
+    )
+
+
+def _emit(provider: str, step: str, status: str, failure_class: str) -> None:
+    print(f"provider={provider} step={step} status={status} class={failure_class}", flush=True)
+
+
+def _classify_http_error(status_code: int) -> ProbeFailure:
+    if 400 <= status_code < 500:
+        return ProbeFailure("mint_http_4xx")
+    if 500 <= status_code < 600:
+        return ProbeFailure("upstream_5xx", retryable=True)
+    return ProbeFailure("mint_http_unexpected")
+
+
+def _mint_provider_token(config: ProbeConfig) -> str:
+    if not config.base_url or not config.bearer_token:
+        raise ProbeFailure("configuration")
+    body = json.dumps({"provider": config.provider}, separators=(",", ":")).encode("utf-8")
+    request = urllib.request.Request(
+        f"{config.base_url}{MINT_PATH}",
+        data=body,
+        method="POST",
+        headers={
+            "Accept": "application/json",
+            "Authorization": f"Bearer {config.bearer_token}",
+            "Content-Type": "application/json",
+        },
+    )
+    payload_bytes = b""
+    try:
+        with urllib.request.urlopen(request, timeout=config.timeout_seconds) as response:
+            if int(response.status) < 200 or int(response.status) >= 300:
+                raise _classify_http_error(int(response.status))
+            payload_bytes = response.read(MAX_HTTP_RESPONSE_BYTES + 1)
+    except urllib.error.HTTPError as error:
+        raise _classify_http_error(error.code) from error
+    except (socket.timeout, TimeoutError):
+        raise ProbeFailure("timeout", retryable=True)
+    except (urllib.error.URLError, OSError, ValueError):
+        raise ProbeFailure("mint_transport")
+
+    if len(payload_bytes) > MAX_HTTP_RESPONSE_BYTES:
+        raise ProbeFailure("mint_schema")
+    try:
+        payload = json.loads(payload_bytes.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        raise ProbeFailure("mint_schema")
+    finally:
+        payload_bytes = b""
+    if not isinstance(payload, dict):
+        raise ProbeFailure("mint_schema")
+    token = payload.get("token")
+    expected_prefix = OPENAI_TOKEN_PREFIX if config.provider == "openai" else GEMINI_TOKEN_PREFIX
+    valid = payload.get("provider") == config.provider and isinstance(token, str) and token.startswith(expected_prefix)
+    if not valid or len(token) > MAX_TOKEN_CHARS:
+        raise ProbeFailure("mint_schema")
+    return token
+
+
+class ProviderWebSocket:
+    def __init__(self, url: str, headers: dict[str, str], timeout_seconds: float):
+        self.url = url
+        self.headers = headers
+        self.timeout_seconds = timeout_seconds
+        self._socket: socket.socket | ssl.SSLSocket | None = None
+        self._closed = False
+        self._fragment_opcode: int | None = None
+        self._fragments: list[bytes] = []
+
+    def connect(self) -> None:
+        parsed = urllib.parse.urlsplit(self.url)
+        if parsed.scheme != "wss" or not parsed.hostname:
+            raise ProbeFailure("connect_failed")
+        try:
+            tcp_socket = socket.create_connection((parsed.hostname, parsed.port or 443), self.timeout_seconds)
+            tls_socket = ssl.create_default_context().wrap_socket(tcp_socket, server_hostname=parsed.hostname)
+            tls_socket.settimeout(self.timeout_seconds)
+            self._socket = tls_socket
+            self._perform_handshake(parsed)
+        except ProbeFailure:
+            self.close()
+            raise
+        except (socket.timeout, TimeoutError) as error:
+            self.close()
+            raise ProbeFailure("timeout", retryable=True) from error
+        except (OSError, ssl.SSLError, ValueError) as error:
+            self.close()
+            raise ProbeFailure("connect_failed") from error
+
+    def _perform_handshake(self, parsed: urllib.parse.SplitResult) -> None:
+        path = parsed.path or "/"
+        if parsed.query:
+            path = f"{path}?{parsed.query}"
+        host = parsed.hostname or ""
+        if parsed.port and parsed.port != 443:
+            host = f"{host}:{parsed.port}"
+        websocket_key = base64.b64encode(os.urandom(16)).decode("ascii")
+        lines = [
+            f"GET {path} HTTP/1.1",
+            f"Host: {host}",
+            "Upgrade: websocket",
+            "Connection: Upgrade",
+            f"Sec-WebSocket-Key: {websocket_key}",
+            "Sec-WebSocket-Version: 13",
+        ]
+        for name, value in self.headers.items():
+            if "\r" in name or "\n" in name or "\r" in value or "\n" in value:
+                raise ProbeFailure("connect_failed")
+            lines.append(f"{name}: {value}")
+        self._send_raw(("\r\n".join(lines) + "\r\n\r\n").encode("ascii"))
+        raw_response = self._read_until_headers_complete()
+        try:
+            header_text = raw_response.decode("iso-8859-1")
+            status_line = header_text.split("\r\n", 1)[0]
+            status_code = int(status_line.split()[1])
+        except (UnicodeDecodeError, IndexError, ValueError):
+            raise ProbeFailure("connect_failed")
+        if status_code != 101:
+            if 500 <= status_code < 600:
+                raise ProbeFailure("upstream_5xx", retryable=True)
+            if 400 <= status_code < 500:
+                raise ProbeFailure("connect_http_4xx")
+            raise ProbeFailure("connect_failed")
+
+    def _read_until_headers_complete(self) -> bytes:
+        response = bytearray()
+        while b"\r\n\r\n" not in response:
+            if len(response) >= MAX_HANDSHAKE_BYTES:
+                raise ProbeFailure("connect_failed")
+            response.extend(self._recv_exact(1))
+        return bytes(response)
+
+    def _send_raw(self, payload: bytes) -> None:
+        if self._socket is None:
+            raise ProbeFailure("connect_failed")
+        self._socket.sendall(payload)
+
+    def _recv_exact(self, size: int) -> bytes:
+        if self._socket is None:
+            raise ProbeFailure("connect_failed")
+        chunks: list[bytes] = []
+        remaining = size
+        while remaining:
+            chunk = self._socket.recv(remaining)
+            if not chunk:
+                raise ProbeFailure("connect_failed")
+            chunks.append(chunk)
+            remaining -= len(chunk)
+        return b"".join(chunks)
+
+    def send_json(self, payload: dict[str, Any]) -> None:
+        encoded = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+        if len(encoded) > MAX_WEBSOCKET_MESSAGE_BYTES:
+            raise ProbeFailure("commit_failed")
+        self._send_frame(0x1, encoded)
+
+    def _send_frame(self, opcode: int, payload: bytes) -> None:
+        length = len(payload)
+        frame = bytearray([0x80 | opcode])
+        if length < 126:
+            frame.append(0x80 | length)
+        elif length < 65536:
+            frame.append(0x80 | 126)
+            frame.extend(struct.pack("!H", length))
+        else:
+            frame.append(0x80 | 127)
+            frame.extend(struct.pack("!Q", length))
+        mask = os.urandom(4)
+        frame.extend(mask)
+        frame.extend(value ^ mask[index % 4] for index, value in enumerate(payload))
+        self._send_raw(bytes(frame))
+
+    def receive_json(self) -> dict[str, Any]:
+        while True:
+            opcode, finished, payload = self._receive_frame()
+            if opcode == 0x8:
+                raise ProbeFailure("connect_failed")
+            if opcode == 0x9:
+                self._send_frame(0xA, payload)
+                continue
+            if opcode == 0xA:
+                continue
+            if opcode == 0x0:
+                if self._fragment_opcode is None:
+                    raise ProbeFailure("provider_event_error")
+                self._fragments.append(payload)
+                if not finished:
+                    continue
+                opcode = self._fragment_opcode
+                payload = b"".join(self._fragments)
+                self._fragment_opcode = None
+                self._fragments.clear()
+            elif not finished:
+                if opcode not in (0x1, 0x2):
+                    raise ProbeFailure("provider_event_error")
+                self._fragment_opcode = opcode
+                self._fragments = [payload]
+                continue
+            if opcode not in (0x1, 0x2):
+                continue
+            try:
+                decoded = json.loads(payload.decode("utf-8"))
+            except (UnicodeDecodeError, json.JSONDecodeError):
+                raise ProbeFailure("provider_event_error")
+            if not isinstance(decoded, dict):
+                raise ProbeFailure("provider_event_error")
+            return decoded
+
+    def _receive_frame(self) -> tuple[int, bool, bytes]:
+        first, second = self._recv_exact(2)
+        finished = bool(first & 0x80)
+        opcode = first & 0x0F
+        masked = bool(second & 0x80)
+        length = second & 0x7F
+        if length == 126:
+            length = struct.unpack("!H", self._recv_exact(2))[0]
+        elif length == 127:
+            length = struct.unpack("!Q", self._recv_exact(8))[0]
+        if length > MAX_WEBSOCKET_MESSAGE_BYTES:
+            raise ProbeFailure("provider_event_error")
+        mask = self._recv_exact(4) if masked else b""
+        payload = self._recv_exact(length)
+        if masked:
+            payload = bytes(value ^ mask[index % 4] for index, value in enumerate(payload))
+        return opcode, finished, payload
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        try:
+            if self._socket is not None:
+                self._send_frame(0x8, b"")
+        except (OSError, ProbeFailure):
+            pass
+        finally:
+            if self._socket is not None:
+                self._socket.close()
+                self._socket = None
+
+
+def _receive_until(websocket: ProviderWebSocket, timeout_seconds: float, matcher: Any) -> None:
+    deadline = time.monotonic() + timeout_seconds
+    while True:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise ProbeFailure("timeout", retryable=True)
+        if websocket._socket is not None:
+            websocket._socket.settimeout(remaining)
+        try:
+            event = websocket.receive_json()
+        except (socket.timeout, TimeoutError) as error:
+            raise ProbeFailure("timeout", retryable=True) from error
+        if event.get("type") == "error" or "error" in event:
+            raise ProbeFailure("provider_event_error")
+        if matcher(event):
+            return
+
+
+def _openai_websocket(token: str, timeout_seconds: float) -> ProviderWebSocket:
+    websocket = ProviderWebSocket(
+        OPENAI_URL,
+        {"Authorization": f"Bearer {token}"},
+        timeout_seconds,
+    )
+    websocket.connect()
+    websocket.send_json(
+        {
+            "type": "session.update",
+            "session": {
+                "type": "realtime",
+                "instructions": "Return the requested deterministic response.",
+                "output_modalities": ["text"],
+            },
+        }
+    )
+    _receive_until(websocket, timeout_seconds, lambda event: event.get("type") == "session.updated")
+    return websocket
+
+
+def _gemini_websocket(token: str, timeout_seconds: float) -> ProviderWebSocket:
+    query = urllib.parse.urlencode({"access_token": token})
+    websocket = ProviderWebSocket(f"{GEMINI_URL_PREFIX}?{query}", {}, timeout_seconds)
+    websocket.connect()
+    websocket.send_json(
+        {
+            "setup": {
+                "model": "models/gemini-3.1-flash-live-preview",
+                "generationConfig": {"responseModalities": ["AUDIO"], "temperature": 0.0},
+                "systemInstruction": {"parts": [{"text": "Return the requested deterministic response."}]},
+            }
+        }
+    )
+    _receive_until(websocket, timeout_seconds, lambda event: "setupComplete" in event)
+    return websocket
+
+
+def run_probe(config: ProbeConfig) -> int:
+    if config.provider not in {"openai", "gemini"} or not config.base_url or not config.bearer_token:
+        _emit(config.provider, "authenticate", "FAIL", "configuration")
+        return 1
+    _emit(config.provider, "authenticate", "PASS", "none")
+    provider_token = ""
+    current_step = "mint"
+    try:
+        provider_token = _mint_provider_token(config)
+        _emit(config.provider, "mint", "PASS", "none")
+        if config.provider == "openai":
+            current_step = "connect"
+            websocket = _openai_websocket(provider_token, config.timeout_seconds)
+            _emit(config.provider, "connect", "PASS", "none")
+            try:
+                current_step = "commit"
+                websocket.send_json(
+                    {
+                        "type": "conversation.item.create",
+                        "item": {
+                            "type": "message",
+                            "role": "user",
+                            "content": [{"type": "input_text", "text": PROBE_INPUT}],
+                        },
+                    }
+                )
+                websocket.send_json(
+                    {"type": "response.create", "response": {"output_modalities": ["text"]}}
+                )
+                _emit(config.provider, "commit", "PASS", "none")
+                current_step = "response"
+
+                def response_completed(event: dict[str, Any]) -> bool:
+                    if event.get("type") != "response.done":
+                        return False
+                    response = event.get("response")
+                    return isinstance(response, dict) and response.get("status") == "completed"
+
+                _receive_until(websocket, config.timeout_seconds, response_completed)
+                _emit(config.provider, "response", "PASS", "none")
+            finally:
+                websocket.close()
+        else:
+            current_step = "connect"
+            websocket = _gemini_websocket(provider_token, config.timeout_seconds)
+            _emit(config.provider, "connect", "PASS", "none")
+            try:
+                current_step = "commit"
+                websocket.send_json({"realtimeInput": {"activityStart": {}}})
+                websocket.send_json({"realtimeInput": {"text": PROBE_INPUT}})
+                websocket.send_json({"realtimeInput": {"activityEnd": {}}})
+                _emit(config.provider, "commit", "PASS", "none")
+                current_step = "response"
+                _receive_until(
+                    websocket,
+                    config.timeout_seconds,
+                    lambda event: isinstance(event.get("serverContent"), dict)
+                    and event["serverContent"].get("turnComplete") is True,
+                )
+                _emit(config.provider, "response", "PASS", "none")
+            finally:
+                websocket.close()
+    except ProbeFailure as error:
+        _emit(config.provider, current_step, "FAIL", error.failure_class)
+        return 75 if error.retryable else 1
+    finally:
+        provider_token = ""
+    _emit(config.provider, "close", "PASS", "expected_idle_teardown")
+    return 0
+
+
+def parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("provider", choices=("openai", "gemini"))
+    parser.add_argument("backend_base_url")
+    parser.add_argument("--bearer-token-file", required=True, type=Path)
+    parser.add_argument("--timeout-seconds", type=float, default=DEFAULT_TIMEOUT_SECONDS)
+    args = parser.parse_args(argv)
+    if not 1 <= args.timeout_seconds <= 60:
+        parser.error("--timeout-seconds must be between 1 and 60")
+    return args
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    return run_probe(config_from_args(parse_args(argv or sys.argv[1:])))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/voice-provider-probe.sh
+++ b/scripts/voice-provider-probe.sh
@@ -99,6 +99,9 @@ def _emit(provider: str, step: str, status: str, failure_class: str) -> None:
 
 
 def _classify_http_error(status_code: int) -> ProbeFailure:
+    # Match desktop mint (CredentialHealthManager.classifyHTTPFailure): upstream 429 is transient.
+    if status_code == 429:
+        return ProbeFailure("mint_http_4xx", retryable=True)
     if 400 <= status_code < 500:
         return ProbeFailure("mint_http_4xx")
     if 500 <= status_code < 600:


### PR DESCRIPTION
## Summary

- Make push-to-talk silent-mic recovery preserve zero-frame evidence, record the post-rebuild outcome, and re-arm only after a truthful success/failure result.
- Add a bounded deployed OpenAI and Gemini realtime mint-to-terminal-response probe to the desktop development release workflow, with an explicit outage-only bypass.
- Make the Firebase Secret Manager/IAM project distinct from the expected Firebase auth project and reject mismatched probe-token claims before they reach a deployed service.

Closes #9757
Closes #9677
Closes #9081
Closes #9190

## Root cause and durable guard

A zero-frame PTT turn previously reset the silent-capture evidence, while recovery was logged as successful when it was merely attempted. The policy now treats zero frames as neutral, keeps its threshold bounded, and waits for the next judgeable turn to record the rebuild outcome. Behavioral policy tests and wiring checks cover the affected discard and completion paths.

The development desktop-backend workflow verified revision identity but did not prove the direct managed provider websocket paths. It now mints a fixed non-human identity token, validates its auth-project audience/issuer/subject without exposing it, calls each provider directly, requires its terminal event, sanitizes all bounded results, and retries only timeouts or upstream 5xx responses. Hermetic tests cover OpenAI, Gemini, token contract mismatch, and transport timeout behavior.

## Verification

- `cd desktop/macos && ./scripts/swift-test-suites.sh`
- `BACKEND_PYTEST_WORKERS=4 PYTHON=/Users/david/workspace/omi/backend/.venv/bin/python ./backend/test.sh`
- `actionlint .github/workflows/desktop_backend_auto_dev.yml .github/workflows/gcp_backend.yml .github/workflows/sync_ledger_fence_cutover.yml`
- `python3 -m py_compile backend/scripts/firebase_release_probe_token.py scripts/voice-provider-probe.sh`
- `make preflight`
- Named `omi-9757-ptt` bundle launched with the automation bridge; exercised `ptt_start` then `ptt_stop` with no invalid lifecycle transition. The local bundle had no seeded auth session, so it correctly reached signed-out cancellation rather than an authenticated provider turn; the deployed workflow probe is the authenticated provider-path guard.

## Product invariants affected

- INV-CHAT-1
- INV-VOICE-1


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9770?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

