### PR TITLE
fix(dev): ignore tagged no-traffic candidate routes

### DIFF
--- a/backend/scripts/verify_sync_ledger_fence_transition.py
+++ b/backend/scripts/verify_sync_ledger_fence_transition.py
@@ -22,6 +22,7 @@ import subprocess
 import sys
 from dataclasses import asdict, dataclass
 from typing import Any, Mapping, Protocol, Sequence, cast
+from urllib.parse import urlsplit
 
 SERVICES = ('backend', 'backend-sync', 'backend-sync-backfill')
 FENCE_MODE_ENV = 'SYNC_LEDGER_FENCE_MODE'
@@ -140,8 +141,37 @@ def _traffic_percent(value: Any, *, service: str) -> int:
     return percent
 
 
+def _is_https_url(value: Any) -> bool:
+    if not isinstance(value, str) or not value or value != value.strip():
+        return False
+    parsed = urlsplit(value)
+    return parsed.scheme == 'https' and bool(parsed.netloc)
+
+
+def _is_complete_tag_only_target(target: Mapping[str, Any]) -> bool:
+    """Return whether a no-percent target is a concrete Cloud Run tag route."""
+
+    tag = target.get('tag')
+    revision = target.get('revisionName')
+    return (
+        isinstance(tag, str)
+        and bool(tag)
+        and tag == tag.strip()
+        and isinstance(revision, str)
+        and bool(revision)
+        and _is_https_url(target.get('url'))
+    )
+
+
 def serving_revision_from_status(service_document: Mapping[str, Any], *, service: str) -> str:
-    """Return the one positive-traffic revision from service status only."""
+    """Return the one positive-traffic revision from service status only.
+
+    Cloud Run exposes a tagged no-traffic candidate as a status target with a
+    concrete revision, tag, and URL but without ``percent``.  That target is
+    reachable only through its tagged URL, so it is not serving traffic for
+    this gate.  All other missing percentages remain invalid rather than
+    silently becoming zero.
+    """
 
     status = service_document.get('status')
     if not isinstance(status, Mapping):
@@ -154,12 +184,22 @@ def serving_revision_from_status(service_document: Mapping[str, Any], *, service
     for index, raw_target in enumerate(traffic):
         if not isinstance(raw_target, Mapping):
             raise FenceTransitionVerificationError(f'{service} status traffic target {index} is invalid')
+        if 'percent' not in raw_target and 'tag' in raw_target:
+            if not _is_complete_tag_only_target(raw_target):
+                raise FenceTransitionVerificationError(
+                    f'{service} has a malformed tag-only Cloud Run traffic target {index}'
+                )
+            continue
         percent = _traffic_percent(raw_target.get('percent'), service=service)
         if percent == 0:
             continue
         revision = raw_target.get('revisionName')
         if not isinstance(revision, str) or not revision:
             raise FenceTransitionVerificationError(f'{service} has positive traffic without a concrete revision name')
+        if revision in positive_traffic:
+            raise FenceTransitionVerificationError(
+                f'{service} has ambiguous positive traffic entries for revision: {revision}'
+            )
         positive_traffic[revision] = positive_traffic.get(revision, 0) + percent
 
     if not positive_traffic:

--- a/backend/tests/unit/fixtures/cloud_run/backend_status_tagged_candidate_no_percent.json
+++ b/backend/tests/unit/fixtures/cloud_run/backend_status_tagged_candidate_no_percent.json
@@ -1,0 +1,17 @@
+{
+  "status": {
+    "latestCreatedRevisionName": "backend-candidate",
+    "traffic": [
+      {
+        "revisionName": "backend-candidate",
+        "tag": "candidate",
+        "url": "https://candidate---backend.example.test"
+      },
+      {
+        "percent": 100,
+        "revisionName": "backend-serving",
+        "url": "https://backend.example.test"
+      }
+    ]
+  }
+}

--- a/backend/tests/unit/test_verify_sync_ledger_fence_transition.py
+++ b/backend/tests/unit/test_verify_sync_ledger_fence_transition.py
@@ -1,11 +1,16 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 from typing import Sequence
 
 import pytest
 
 from scripts import verify_sync_ledger_fence_transition as verifier
+
+TAGGED_CANDIDATE_STATUS_FIXTURE = (
+    Path(__file__).parent / 'fixtures' / 'cloud_run' / 'backend_status_tagged_candidate_no_percent.json'
+)
 
 
 class FakeCloudRunner:
@@ -70,6 +75,10 @@ def _config(desired_mode: str) -> verifier.TransitionVerificationConfig:
     )
 
 
+def _tagged_candidate_status_fixture() -> dict:
+    return json.loads(TAGGED_CANDIDATE_STATUS_FIXTURE.read_text(encoding='utf-8'))
+
+
 def test_uses_positive_status_traffic_not_latest_created_or_service_template() -> None:
     runner = _runner(modes={service: 'active' for service in verifier.SERVICES})
 
@@ -94,6 +103,71 @@ def test_rejects_split_positive_traffic_before_describing_a_revision() -> None:
     ]
 
     with pytest.raises(verifier.FenceTransitionVerificationError, match='splits positive traffic'):
+        verifier.verify_transition(_config('active'), runner=runner)
+
+    assert not any(command[:4] == ['gcloud', 'run', 'revisions', 'describe'] for command in runner.commands)
+
+
+def test_ignores_complete_tag_only_candidate_before_serving_traffic() -> None:
+    runner = _runner(modes={service: 'active' for service in verifier.SERVICES})
+    runner.service_documents['backend'] = _tagged_candidate_status_fixture()
+
+    result = verifier.verify_transition(_config('active'), runner=runner)
+
+    assert result.serving_revisions[0].revision == 'backend-serving'
+    described_revisions = [
+        command[4] for command in runner.commands if command[:4] == ['gcloud', 'run', 'revisions', 'describe']
+    ]
+    assert 'backend-candidate' not in described_revisions
+    assert described_revisions == [f'{service}-serving' for service in verifier.SERVICES]
+
+
+def test_rejects_malformed_tag_only_target_before_describing_a_revision() -> None:
+    runner = _runner(modes={service: 'active' for service in verifier.SERVICES})
+    runner.service_documents['backend']['status']['traffic'] = [
+        {'revisionName': 'backend-candidate', 'tag': 'candidate'},
+        {'revisionName': 'backend-serving', 'percent': 100},
+    ]
+
+    with pytest.raises(verifier.FenceTransitionVerificationError, match='malformed tag-only'):
+        verifier.verify_transition(_config('active'), runner=runner)
+
+    assert not any(command[:4] == ['gcloud', 'run', 'revisions', 'describe'] for command in runner.commands)
+
+
+@pytest.mark.parametrize(
+    ('traffic', 'error'),
+    [
+        (
+            [
+                {'revisionName': 'backend-candidate', 'tag': 'candidate', 'url': 'https://candidate.example.test'},
+                {'revisionName': 'backend-serving', 'percent': '100.0'},
+            ],
+            'non-integer Cloud Run traffic percentage',
+        ),
+        (
+            [
+                {'revisionName': 'backend-candidate', 'tag': 'candidate', 'url': 'https://candidate.example.test'},
+                {'revisionName': 'backend-serving', 'percent': 50},
+                {'revisionName': 'backend-serving', 'percent': 50},
+            ],
+            'ambiguous positive traffic entries',
+        ),
+        (
+            [
+                {'revisionName': 'backend-candidate', 'tag': 'candidate', 'url': 'https://candidate.example.test'},
+                {'revisionName': 'backend-serving', 'percent': 99},
+                {'revisionName': 'backend-stale', 'percent': 1},
+            ],
+            'splits positive traffic',
+        ),
+    ],
+)
+def test_tag_only_candidate_does_not_relax_serving_traffic_validation(traffic: list[dict], error: str) -> None:
+    runner = _runner(modes={service: 'active' for service in verifier.SERVICES})
+    runner.service_documents['backend']['status']['traffic'] = traffic
+
+    with pytest.raises(verifier.FenceTransitionVerificationError, match=error):
         verifier.verify_transition(_config('active'), runner=runner)
 
     assert not any(command[:4] == ['gcloud', 'run', 'revisions', 'describe'] for command in runner.commands)


### PR DESCRIPTION
## Summary

- Accept complete tagged Cloud Run targets without a `percent` as no-traffic candidate routes.
- Keep all serving-traffic validation fail-closed for malformed, non-integer, split, or ambiguous traffic.
- Add a fixture matching the dev candidate tag response that blocked run 29373588876.

## Validation

- `backend/.venv/bin/python -m pytest -q backend/tests/unit/test_verify_sync_ledger_fence_transition.py` → passed
- `git diff --check`

No deployment, Cloud Run mutation, traffic change, or production behavior change is included.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9773?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

