### PR TITLE
chore(admin): document and verify local development

### DIFF
--- a/.github/workflows/web-checks.yml
+++ b/.github/workflows/web-checks.yml
@@ -116,4 +116,7 @@ jobs:
           NEXT_PUBLIC_OMI_API_URL: https://api.omiapi.com
         run: |
           npm ci
+          npm run lint
+          npm run typecheck
+          npm test
           npm run build

--- a/web/admin/.env.example
+++ b/web/admin/.env.example
@@ -1,6 +1,10 @@
 # Omi Admin Dashboard — Environment Variables
 # Copy this file to .env.local and fill in your values.
 
+# Local development only. Set to 1 to enter the dashboard as a non-production
+# dev admin without Firebase login. This bypass is hard-disabled when NODE_ENV=production.
+NEXT_PUBLIC_DEV_BYPASS_AUTH=0
+
 # Firebase Client SDK (public, safe to expose)
 NEXT_PUBLIC_FIREBASE_API_KEY=
 NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN=
@@ -46,6 +50,7 @@ SHOPIFY_ACCESS_TOKEN=
 
 # Mixpanel
 MIXPANEL_SECRET=
+MIXPANEL_API_BASE=
 
 # OpenAI
 OPENAI_API_KEY=
@@ -54,3 +59,15 @@ OPENAI_API_KEY=
 POSTHOG_PERSONAL_API_KEY=
 POSTHOG_PROJECT_ID=
 POSTHOG_HOST=
+
+# Admin features used only on their respective dashboard pages
+ANTHROPIC_API_KEY=
+ENCRYPTION_SECRET=
+GITHUB_TOKEN=
+GOAFFPRO_ACCESS_TOKEN=
+TYPESENSE_CONVERSATION_COLLECTION=
+
+# Scheduled cache precomputation and optional analytics cost overrides
+CRON_SECRET=
+ADMIN_INFRA_OVERHEAD_MONTHLY=
+ADMIN_SERVICE_COSTS_JSON=

--- a/web/admin/.eslintrc.json
+++ b/web/admin/.eslintrc.json
@@ -1,0 +1,4 @@
+{
+  "extends": ["next/core-web-vitals"],
+  "ignorePatterns": ["lib/services/omi-api/omiApi.generated.ts"]
+}

--- a/web/admin/README.md
+++ b/web/admin/README.md
@@ -1,0 +1,106 @@
+# Omi Admin Dashboard
+
+The dashboard at `admin.omi.me` is a Next.js app. It presents the internal
+admin UI, authenticates the browser with Firebase, and exposes same-origin
+Next route handlers under `app/api/`. Those handlers authorize the caller and
+then read from Firebase or call the Omi API and vendor APIs. Browser code
+never receives the server credentials.
+
+## Run locally
+
+```bash
+cd web/admin
+cp .env.example .env.local
+npm ci
+```
+
+For UI work, set the following in `.env.local` and start the app:
+
+```dotenv
+NEXT_PUBLIC_DEV_BYPASS_AUTH=1
+```
+
+```bash
+npm run dev
+```
+
+Open <http://localhost:3000/dashboard>. The bypass supplies the fixed local
+identity `dev-admin` to the client and protected route handlers; it is
+hard-disabled for production builds. It is useful for layout and interaction
+work, but API cards whose backing service is not configured will show errors.
+Do not put production credentials in `.env.local`.
+
+## Test against a local backend
+
+For a working Omi API integration, run the backend locally using its
+[developer guide](../../backend/AGENTS.md) and use a separate development or
+offline data environment. Set these values in `web/admin/.env.local`:
+
+```dotenv
+NEXT_PUBLIC_DEV_BYPASS_AUTH=1
+NEXT_PUBLIC_OMI_API_URL=http://localhost:8080
+OMI_API_SECRET_KEY=<the same value as backend ADMIN_KEY>
+```
+
+The dashboard sends both the base key and a token formed from that key plus
+the authenticated UID. With the bypass, the UID is `dev-admin`, which the
+local backend accepts when its `ADMIN_KEY` matches `OMI_API_SECRET_KEY`.
+Admin actions can mutate the backend and its data stores, so this mode must
+never point at production.
+
+Routes that read or write Firestore also need `FIREBASE_PROJECT_ID`,
+`FIREBASE_CLIENT_EMAIL`, and `FIREBASE_PRIVATE_KEY` for a non-production
+Firebase project. Pages that use an external system need only that system's
+credential from `.env.example` (for example Stripe, PostHog, Typesense,
+GoAffPro, or Anthropic). Firebase client variables are needed when testing the
+real login flow instead of the bypass.
+
+## Checks
+
+Run these before opening a PR:
+
+```bash
+npm run check
+npm run build
+```
+
+`check` runs ESLint, TypeScript, and the Vitest unit suite. Use `npm run
+test:watch` while adding or editing tests. The GitHub web check runs the same
+three checks for changes under `web/admin/`, then builds the app.
+
+## Authentication and permissions
+
+In normal operation, the browser signs in with Firebase Google or email
+authentication. The client and every protected route require the user UID to
+exist at `adminData/{uid}` in Firestore. Server route handlers verify the
+Firebase ID token with the Firebase Admin SDK; they do not trust the
+client-side check alone.
+
+For local work, permissions break down as follows:
+
+- UI-only work needs no cloud, Firebase, or vendor access when the development
+  bypass is enabled.
+- Real login testing needs a Firebase Authentication user and a matching
+  `adminData/{uid}` document in a non-production project.
+- Data-backed pages need a Firebase service account that can read the
+  appropriate non-production Firestore project, plus only the service
+  credentials for the page under test.
+- Local Omi API work needs a local backend `ADMIN_KEY`; do not request or use
+  the production key.
+- Deployment through GitHub Actions needs permission to merge or push to the
+  deployment branch and approval for the target GitHub Environment. The
+  workflow's deployment identity, not a developer workstation, needs access
+  to Artifact Registry, Cloud Run, and the Cloud Run runtime secrets. A direct
+  GCP deployment would additionally require equivalent Cloud Run, Artifact
+  Registry, service-account impersonation, and Secret Manager access.
+
+## Delivery path and current gaps
+
+`.github/workflows/gcp_admin.yml` deploys changes under `web/admin/` on pushes
+to `main` or `development`. It builds the Docker image from this directory,
+bakes public `NEXT_PUBLIC_*` values into the image, injects server secrets at
+Cloud Run runtime, and shifts 100% of traffic to the new revision. The
+repository does not define a pull-request preview deployment, local Firebase
+emulators, seeded admin data, or browser end-to-end tests. Those are the next
+meaningful investments once the local UI and backend loop above is in regular
+use.

--- a/web/admin/package.json
+++ b/web/admin/package.json
@@ -6,7 +6,11 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "eslint .",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "check": "npm run lint && npm run typecheck && npm test"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",

--- a/web/admin/tsconfig.json
+++ b/web/admin/tsconfig.json
@@ -11,7 +11,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "incremental": true,
     "plugins": [
       {
@@ -22,6 +22,6 @@
       "@/*": ["./*"]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts", ".next/dev/types/**/*.ts"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## Summary

- document the supported local UI, authentication, backend-integration, and permissions workflows for the Omi admin dashboard
- expose repeatable lint, typecheck, and Vitest scripts, and repair the obsolete `next lint` command for Next 16
- run those existing checks in the admin CI job before the existing production build

## Impact

- No admin UI source or runtime route changed: `web/admin/app`, `components`, `hooks`, and `lib` are untouched.
- No Cloud Run deployment configuration changed: `.github/workflows/gcp_admin.yml` is untouched.
- The intended delivery-process change is that `web-checks` now blocks an admin change on lint, typecheck, or unit-test failures before the existing build.

## Verification

- `npm run check` (0 lint errors; 23 pre-existing warnings; 23 Vitest tests passed)
- `npm run build` with the same dummy public environment variables used by CI
- `make preflight`
- local Next dev server with `NEXT_PUBLIC_DEV_BYPASS_AUTH=1`: `/dashboard` returned 200 and a protected route accepted the development auth token before correctly reporting its missing backend credential


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9774?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

