### PR TITLE
fix(dev): scope tagged candidate route handling

### DIFF
--- a/.github/workflows/gcp_backend_auto_dev.yml
+++ b/.github/workflows/gcp_backend_auto_dev.yml
@@ -51,7 +51,8 @@ jobs:
           python3 backend/scripts/verify_sync_ledger_fence_transition.py \
             --project=${{ vars.GCP_PROJECT_ID }} \
             --region=${{ env.REGION }} \
-            --desired-mode="$SYNC_LEDGER_FENCE_MODE"
+            --desired-mode="$SYNC_LEDGER_FENCE_MODE" \
+            --allow-tagged-no-percent-targets
 
       - name: Reconcile generated Firestore indexes before backend deploy
         run: |

--- a/backend/scripts/verify_sync_ledger_fence_transition.py
+++ b/backend/scripts/verify_sync_ledger_fence_transition.py
@@ -71,6 +71,7 @@ class TransitionVerificationConfig:
     project: str
     region: str
     desired_mode: str
+    allow_tagged_no_percent_targets: bool = False
 
 
 @dataclass(frozen=True)
@@ -163,7 +164,9 @@ def _is_complete_tag_only_target(target: Mapping[str, Any]) -> bool:
     )
 
 
-def serving_revision_from_status(service_document: Mapping[str, Any], *, service: str) -> str:
+def serving_revision_from_status(
+    service_document: Mapping[str, Any], *, service: str, allow_tagged_no_percent_targets: bool = False
+) -> str:
     """Return the one positive-traffic revision from service status only.
 
     Cloud Run exposes a tagged no-traffic candidate as a status target with a
@@ -185,6 +188,8 @@ def serving_revision_from_status(service_document: Mapping[str, Any], *, service
         if not isinstance(raw_target, Mapping):
             raise FenceTransitionVerificationError(f'{service} status traffic target {index} is invalid')
         if 'percent' not in raw_target and 'tag' in raw_target:
+            if not allow_tagged_no_percent_targets:
+                raise FenceTransitionVerificationError(f'{service} has a non-integer Cloud Run traffic percentage')
             if not _is_complete_tag_only_target(raw_target):
                 raise FenceTransitionVerificationError(
                     f'{service} has a malformed tag-only Cloud Run traffic target {index}'
@@ -263,7 +268,11 @@ def _read_serving_revision(
         build_describe_service_command(project=config.project, region=config.region, service=service)
     )
     service_document = _json_object(service_result, resource=f'Cloud Run service {service}')
-    revision = serving_revision_from_status(service_document, service=service)
+    revision = serving_revision_from_status(
+        service_document,
+        service=service,
+        allow_tagged_no_percent_targets=config.allow_tagged_no_percent_targets,
+    )
     revision_result = runner.run(
         build_describe_revision_command(project=config.project, region=config.region, revision=revision)
     )
@@ -319,6 +328,7 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser.add_argument('--project', required=True)
     parser.add_argument('--region', required=True)
     parser.add_argument('--desired-mode', required=True, choices=sorted(FENCE_MODES))
+    parser.add_argument('--allow-tagged-no-percent-targets', action='store_true')
     return parser.parse_args(argv)
 
 
@@ -328,6 +338,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         project=args.project,
         region=args.region,
         desired_mode=args.desired_mode,
+        allow_tagged_no_percent_targets=args.allow_tagged_no_percent_targets,
     )
     try:
         result = verify_transition(config, runner=SubprocessCommandRunner())

--- a/backend/tests/unit/test_verify_sync_ledger_fence_transition.py
+++ b/backend/tests/unit/test_verify_sync_ledger_fence_transition.py
@@ -67,11 +67,14 @@ def _runner(*, modes: dict[str, str | None]) -> FakeCloudRunner:
     return FakeCloudRunner(service_documents=service_documents, revision_documents=revision_documents)
 
 
-def _config(desired_mode: str) -> verifier.TransitionVerificationConfig:
+def _config(
+    desired_mode: str, *, allow_tagged_no_percent_targets: bool = False
+) -> verifier.TransitionVerificationConfig:
     return verifier.TransitionVerificationConfig(
         project='omi-prod',
         region='us-central1',
         desired_mode=desired_mode,
+        allow_tagged_no_percent_targets=allow_tagged_no_percent_targets,
     )
 
 
@@ -112,7 +115,7 @@ def test_ignores_complete_tag_only_candidate_before_serving_traffic() -> None:
     runner = _runner(modes={service: 'active' for service in verifier.SERVICES})
     runner.service_documents['backend'] = _tagged_candidate_status_fixture()
 
-    result = verifier.verify_transition(_config('active'), runner=runner)
+    result = verifier.verify_transition(_config('active', allow_tagged_no_percent_targets=True), runner=runner)
 
     assert result.serving_revisions[0].revision == 'backend-serving'
     described_revisions = [
@@ -120,6 +123,16 @@ def test_ignores_complete_tag_only_candidate_before_serving_traffic() -> None:
     ]
     assert 'backend-candidate' not in described_revisions
     assert described_revisions == [f'{service}-serving' for service in verifier.SERVICES]
+
+
+def test_rejects_tag_only_candidate_without_dev_opt_in_before_describing_a_revision() -> None:
+    runner = _runner(modes={service: 'active' for service in verifier.SERVICES})
+    runner.service_documents['backend'] = _tagged_candidate_status_fixture()
+
+    with pytest.raises(verifier.FenceTransitionVerificationError, match='non-integer Cloud Run traffic percentage'):
+        verifier.verify_transition(_config('active'), runner=runner)
+
+    assert not any(command[:4] == ['gcloud', 'run', 'revisions', 'describe'] for command in runner.commands)
 
 
 def test_rejects_malformed_tag_only_target_before_describing_a_revision() -> None:
@@ -130,7 +143,7 @@ def test_rejects_malformed_tag_only_target_before_describing_a_revision() -> Non
     ]
 
     with pytest.raises(verifier.FenceTransitionVerificationError, match='malformed tag-only'):
-        verifier.verify_transition(_config('active'), runner=runner)
+        verifier.verify_transition(_config('active', allow_tagged_no_percent_targets=True), runner=runner)
 
     assert not any(command[:4] == ['gcloud', 'run', 'revisions', 'describe'] for command in runner.commands)
 
@@ -168,7 +181,7 @@ def test_tag_only_candidate_does_not_relax_serving_traffic_validation(traffic: l
     runner.service_documents['backend']['status']['traffic'] = traffic
 
     with pytest.raises(verifier.FenceTransitionVerificationError, match=error):
-        verifier.verify_transition(_config('active'), runner=runner)
+        verifier.verify_transition(_config('active', allow_tagged_no_percent_targets=True), runner=runner)
 
     assert not any(command[:4] == ['gcloud', 'run', 'revisions', 'describe'] for command in runner.commands)
 


### PR DESCRIPTION
## Summary
- Restores the production/manual fail-closed traffic contract.
- Enables no-percent tagged Cloud Run candidate routes only in the automatic development workflow.
- Adds explicit regression coverage for the default rejection and dev opt-in.

## Why
PR #9773 correctly fixed the development candidate tag shape but changed a shared verifier used by manual production deployment. This follow-up limits the new behavior to dev only.

## Validation
- `backend/.venv/bin/python -m pytest -q backend/tests/unit/test_verify_sync_ledger_fence_transition.py backend/tests/unit/test_backend_runtime_env_validator.py` → 48 passed
- runtime env validation for dev and prod
- actionlint for both workflows
- `git diff --check`

No deploy or cloud mutation is included.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9776?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

