### PR TITLE
fix(dev): migrate pusher Google client ID binding

### DIFF
--- a/backend/charts/pusher/dev_omi_pusher_values.yaml
+++ b/backend/charts/pusher/dev_omi_pusher_values.yaml
@@ -145,6 +145,14 @@ env:
       secretKeyRef:
         name: dev-omi-backend-secrets
         key: GOOGLE_MAPS_API_KEY
+  - name: GOOGLE_CLIENT_ID
+    valueFrom:
+      configMapKeyRef:
+        name: dev-omi-backend-config
+        key: GOOGLE_CLIENT_ID
+      # Clear the historical named Secret source when Helm strategically merges
+      # this item into an existing Deployment during an upgrade.
+      secretKeyRef: null
   - name: GOOGLE_CLIENT_SECRET
     valueFrom:
       secretKeyRef:

--- a/backend/tests/unit/test_verify_pusher_config_references.py
+++ b/backend/tests/unit/test_verify_pusher_config_references.py
@@ -85,24 +85,41 @@ def test_rendered_dev_pusher_redis_host_clears_legacy_secret_source(preflight: S
     }
 
 
+def test_rendered_dev_pusher_google_client_id_clears_legacy_secret_source(preflight: SimpleNamespace):
+    environment = "dev"
+    deployment = next(document for document in preflight.render(environment) if document.get("kind") == "Deployment")
+    env = deployment["spec"]["template"]["spec"]["containers"][0]["env"]
+    google_client_id = next(item for item in env if item["name"] == "GOOGLE_CLIENT_ID")
+    google_client_secret = next(item for item in env if item["name"] == "GOOGLE_CLIENT_SECRET")
+
+    assert google_client_id["valueFrom"] == {
+        "configMapKeyRef": {"name": f"{environment}-omi-backend-config", "key": "GOOGLE_CLIENT_ID"},
+        "secretKeyRef": None,
+    }
+    assert google_client_secret["valueFrom"] == {
+        "secretKeyRef": {"name": f"{environment}-omi-backend-secrets", "key": "GOOGLE_CLIENT_SECRET"}
+    }
+
+
 @pytest.mark.skipif(shutil.which("kubectl") is None, reason="kubectl is required for the local strategic-merge fixture")
-def test_historical_secret_redis_host_upgrade_uses_kubernetes_strategic_merge(
-    tmp_path: Path, preflight: SimpleNamespace
+@pytest.mark.parametrize("env_name", ["REDIS_DB_HOST", "GOOGLE_CLIENT_ID"])
+def test_historical_secret_named_env_upgrade_uses_kubernetes_strategic_merge(
+    tmp_path: Path, preflight: SimpleNamespace, env_name: str
 ):
     """Exercise Kubernetes' named-env strategic merge behavior without a cluster.
 
-    Helm emits the new REDIS_DB_HOST item for the release update. The fixture
-    starts with the historical live Secret source and applies that item through
+    Helm emits the new named env item for the release update. The fixture starts
+    with the historical live Secret source and applies that item through
     Kustomize's Kubernetes strategic-merge implementation. Without an explicit
-    null, the nested valueFrom map retains the Secret source and matches the
-    failed live validation. The explicit null removes it while retaining the
-    ConfigMap source.
+    null, the nested valueFrom map retains the Secret source and produces the
+    invalid dual-source representation. The explicit null removes it while
+    retaining the ConfigMap source.
     """
 
     base = tmp_path / "base"
     base.mkdir()
     (base / "kustomization.yaml").write_text("resources:\n  - deployment.yaml\n")
-    (base / "deployment.yaml").write_text(textwrap.dedent("""\
+    (base / "deployment.yaml").write_text(textwrap.dedent(f"""\
             apiVersion: apps/v1
             kind: Deployment
             metadata:
@@ -120,17 +137,17 @@ def test_historical_secret_redis_host_upgrade_uses_kubernetes_strategic_merge(
                     - name: pusher
                       image: example/pusher
                       env:
-                        - name: REDIS_DB_HOST
+                        - name: {env_name}
                           valueFrom:
                             secretKeyRef:
                               name: dev-omi-backend-secrets
-                              key: REDIS_DB_HOST
+                              key: {env_name}
             """))
 
     def render(value_from: str) -> dict:
         overlay = tmp_path / f"overlay-{len(list(tmp_path.glob('overlay-*')))}"
         overlay.mkdir()
-        strategic_patch = textwrap.dedent("""\
+        strategic_patch = textwrap.dedent(f"""\
             apiVersion: apps/v1
             kind: Deployment
             metadata:
@@ -141,7 +158,7 @@ def test_historical_secret_redis_host_upgrade_uses_kubernetes_strategic_merge(
                   containers:
                     - name: pusher
                       env:
-                        - name: REDIS_DB_HOST
+                        - name: {env_name}
                           valueFrom:
             """)
         strategic_patch += textwrap.indent(value_from, " " * 16)
@@ -158,20 +175,23 @@ def test_historical_secret_redis_host_upgrade_uses_kubernetes_strategic_merge(
         result = subprocess.run(["kubectl", "kustomize", str(overlay)], check=True, capture_output=True, text=True)
         return yaml.safe_load(result.stdout)
 
-    broken = render("""\
+    broken = render(f"""\
 configMapKeyRef:
   name: dev-omi-backend-config
-  key: REDIS_DB_HOST
+  key: {env_name}
 """)
     broken_value_from = broken["spec"]["template"]["spec"]["containers"][0]["env"][0]["valueFrom"]
-    assert set(broken_value_from) == {"configMapKeyRef", "secretKeyRef"}
+    assert broken_value_from == {
+        "configMapKeyRef": {"name": "dev-omi-backend-config", "key": env_name},
+        "secretKeyRef": {"name": "dev-omi-backend-secrets", "key": env_name},
+    }
 
     rendered_deployment = next(document for document in preflight.render("dev") if document.get("kind") == "Deployment")
     rendered_env = rendered_deployment["spec"]["template"]["spec"]["containers"][0]["env"]
-    rendered_redis_host = next(item for item in rendered_env if item["name"] == "REDIS_DB_HOST")
-    fixed = render(yaml.safe_dump(rendered_redis_host["valueFrom"], sort_keys=False))
+    rendered_item = next(item for item in rendered_env if item["name"] == env_name)
+    fixed = render(yaml.safe_dump(rendered_item["valueFrom"], sort_keys=False))
     fixed_value_from = fixed["spec"]["template"]["spec"]["containers"][0]["env"][0]["valueFrom"]
-    assert fixed_value_from == {"configMapKeyRef": {"name": "dev-omi-backend-config", "key": "REDIS_DB_HOST"}}
+    assert fixed_value_from == {"configMapKeyRef": {"name": "dev-omi-backend-config", "key": env_name}}
 
 
 @pytest.mark.parametrize("kind", ["configmap", "secret"])


### PR DESCRIPTION
## Summary
- Adds the development pusher `GOOGLE_CLIENT_ID` ConfigMap binding and declaratively clears the historical Secret binding during Helm strategic merge.
- Keeps `GOOGLE_CLIENT_SECRET` Secret-backed.
- Adds historical-upgrade regression coverage alongside the existing Redis-host transition coverage.

## Evidence
After #9772, Helm revision 118 succeeded but its new pusher pod was blocked in `CreateContainerConfigError`: the stale explicit `GOOGLE_CLIENT_ID` Secret key binding referenced an intentionally absent dev Secret key.

## Validation
- `backend/.venv/bin/python -m pytest -q backend/tests/unit/test_verify_pusher_config_references.py` → passed
- Helm lint for dev/prod inputs (only existing missing-image-tag warnings)
- `git diff --check`

## Scope
Development values and tests only. No production chart, workload, deploy, Secret, or ConfigMap mutation.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9777?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

