### PR TITLE
Bound the gateway BYOK LLM-client cache so it cannot grow unbounded

### DIFF
--- a/backend/tests/unit/test_byok_gateway_cache_cap.py
+++ b/backend/tests/unit/test_byok_gateway_cache_cap.py
@@ -1,0 +1,40 @@
+"""Regression: the gateway BYOK LLM-client cache must stay bounded.
+
+utils.llm.gateway_byok caches a ChatOpenAI client per cache key, and the cache key includes a
+per-BYOK-key fingerprint, so a long-lived process serving many distinct BYOK credentials accumulated
+a client per key for the whole process lifetime (the repo's rule requires module-level dicts to cap
+or TTL). _remember_byok_client caps the map and evicts the oldest entry.
+"""
+
+import pytest
+
+import utils.llm.gateway_byok as gw
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    gw._byok_gateway_llm_cache.clear()
+    yield
+    gw._byok_gateway_llm_cache.clear()
+
+
+def test_cache_is_bounded_and_evicts_oldest():
+    cap = gw._MAX_BYOK_GATEWAY_CLIENTS
+    for i in range(cap + 25):
+        gw._remember_byok_client((f"key-{i}",), f"client-{i}")
+
+    assert len(gw._byok_gateway_llm_cache) == cap
+    # oldest evicted, most recent retained
+    assert ("key-0",) not in gw._byok_gateway_llm_cache
+    assert gw._byok_gateway_llm_cache[(f"key-{cap + 24}",)] == f"client-{cap + 24}"
+
+
+def test_rewriting_a_key_refreshes_without_growth():
+    for i in range(5):
+        gw._remember_byok_client((f"k{i}",), f"c{i}")
+    before = len(gw._byok_gateway_llm_cache)
+
+    gw._remember_byok_client(("k0",), "c0-new")
+
+    assert len(gw._byok_gateway_llm_cache) == before  # updating an existing key does not grow the map
+    assert gw._byok_gateway_llm_cache[("k0",)] == "c0-new"

--- a/backend/utils/llm/gateway_byok.py
+++ b/backend/utils/llm/gateway_byok.py
@@ -15,7 +15,19 @@ _BYOK_GATEWAY_HEADER_PREFIX = 'X-Omi-Byok-'
 _BYOK_GATEWAY_HEADER_SUFFIX = '-Key'
 
 _usage_callback = get_usage_callback()
+
+# Cache gateway BYOK LLM clients, bounded so a long-lived process serving many distinct BYOK keys
+# (the cache key includes a per-key fingerprint) cannot grow this map of clients without limit.
+_MAX_BYOK_GATEWAY_CLIENTS = 256
 _byok_gateway_llm_cache: Dict[tuple[Any, ...], Any] = {}
+
+
+def _remember_byok_client(cache_key: tuple[Any, ...], client: Any) -> None:
+    # Re-inserting refreshes recency; evict the oldest entry once the cap is reached.
+    _byok_gateway_llm_cache.pop(cache_key, None)
+    while len(_byok_gateway_llm_cache) >= _MAX_BYOK_GATEWAY_CLIENTS:
+        _byok_gateway_llm_cache.pop(next(iter(_byok_gateway_llm_cache)), None)
+    _byok_gateway_llm_cache[cache_key] = client
 
 
 def byok_gateway_header_name(provider: str) -> str:
@@ -74,5 +86,5 @@ def get_or_create_omi_gateway_llm_for_byok(
         kwargs['streaming'] = True
         kwargs['stream_options'] = {'include_usage': True}
     client = ChatOpenAI(model=lane_id, **kwargs)
-    _byok_gateway_llm_cache[cache_key] = client
+    _remember_byok_client(cache_key, client)
     return client


### PR DESCRIPTION
## What

`utils.llm.gateway_byok` caches the gateway BYOK LLM client per cache key:

```python
_byok_gateway_llm_cache: Dict[tuple[Any, ...], Any] = {}
...
cached = _byok_gateway_llm_cache.get(cache_key)
if cached is not None:
    return cached
...
client = ChatOpenAI(model=lane_id, **kwargs)
_byok_gateway_llm_cache[cache_key] = client
```

The `cache_key` is built from `(base_url, service_token_cache_key, provider, key_fingerprint, request_timeout, max_retries)`, and `key_fingerprint` is derived per BYOK key. So a long-lived process serving many distinct BYOK credentials accumulates one `ChatOpenAI` client per key, and nothing ever evicts them. The map grows for the entire process lifetime. This is exactly the case the repo's own guidance calls out: "Module-level dicts: add TTL-based eviction or cap size - they grow forever otherwise."

## Fix

Route the write through a small bounded helper that evicts the oldest entry once a cap is reached:

```python
_MAX_BYOK_GATEWAY_CLIENTS = 256

def _remember_byok_client(cache_key: tuple[Any, ...], client: Any) -> None:
    # Re-inserting refreshes recency; evict the oldest entry once the cap is reached.
    _byok_gateway_llm_cache.pop(cache_key, None)
    while len(_byok_gateway_llm_cache) >= _MAX_BYOK_GATEWAY_CLIENTS:
        _byok_gateway_llm_cache.pop(next(iter(_byok_gateway_llm_cache)), None)
    _byok_gateway_llm_cache[cache_key] = client
```

Dict insertion order (Python 3.7+) makes `next(iter(...))` the oldest key. Re-inserting a key refreshes its recency, so an actively-used client stays cached. The read path (cache hit / miss) is unchanged; only the write is bounded. The cap of 256 comfortably covers realistic concurrent BYOK usage while bounding worst-case client retention.

## Tests

New `tests/unit/test_byok_gateway_cache_cap.py`:

- writing past the cap keeps the map at exactly the cap, evicts the oldest key, and retains the most recent
- updating an existing key does not grow the map

## Verification

```
cd backend && ENCRYPTION_SECRET=... python -m pytest tests/unit/test_byok_gateway_cache_cap.py -q
  -> 2 passed
black --line-length 120 --skip-string-normalization --check utils/llm/gateway_byok.py tests/unit/test_byok_gateway_cache_cap.py
  -> unchanged
python -m pyright -p pyrightconfig.json utils/llm/gateway_byok.py
  -> 0 errors
python scripts/check_module_stub_pollution.py
  -> Checked 660 test file(s); 0 violations
```

## Product invariants affected

none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9778?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

