### PR TITLE
fix(desktop): align beta qualification controls

### DIFF
--- a/desktop/macos/e2e/flows/chat-hermetic.yaml
+++ b/desktop/macos/e2e/flows/chat-hermetic.yaml
@@ -97,13 +97,13 @@ steps:
       result.detail.idle: "true"
 
   - id: S4
-    name: Assert stub marker echoed in assistant reply
+    name: Assert deterministic exact stub reply
     bridge.action:
       name: main_chat_snapshot
       params:
         limit: "12"
     expect:
-      result.detail.last_assistant_text: "Stub saw marker: chat-hermetic"
+      result.detail.last_assistant_text: "MARKER:chat-hermetic"
 
   - id: S5
     name: Logs clean

--- a/desktop/macos/scripts/qualify-desktop-beta.sh
+++ b/desktop/macos/scripts/qualify-desktop-beta.sh
@@ -281,6 +281,8 @@ prepare_qualification_defaults "$QUALIFICATION_BUNDLE_ID" "$BUNDLE"
   OMI_SKIP_SETTINGS_SEED=1 make desktop-run-local DESKTOP_APP_NAME="$BUNDLE" DESKTOP_USER=alice
 ) >"$LAUNCH_LOG" 2>&1 &
 DESKTOP_LAUNCH_PID=$!
+# Build time must not consume the desktop-launch readiness allowance.
+SECONDS=0
 
 if ! wait_for_bridge "$AUTOMATION_PORT"; then
   echo "--- last 80 lines of $LAUNCH_LOG ---" >&2


### PR DESCRIPTION
## Summary
- Aligns `chat-hermetic` with the deterministic exact-reply behavior already implemented by the offline Rust stub.
- Resets the bridge-readiness timer after launch so a slow local build cannot consume the app-start allowance.

## Qualification evidence
The signed candidate `v0.12.73+12073-macos` passed 36/37 Tier-2 flows. Its only failure expected `Stub saw marker: chat-hermetic`, while the candidate's deterministic stub correctly returned `MARKER:chat-hermetic` because the flow prompt requests that exact token.

## Validation
- `bash -n desktop/macos/scripts/qualify-desktop-beta.sh`
- PyYAML assertion verifies the corrected flow expectation
- `git diff --check`

## Scope
Desktop qualification controls only. No release artifact, app code, backend, production infrastructure, or beta/stable pointer is changed.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9781?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

