### PR TITLE
fix(deploy): protect prod pusher Typesense binding

### DIFF
--- a/backend/charts/pusher/prod_omi_pusher_values.yaml
+++ b/backend/charts/pusher/prod_omi_pusher_values.yaml
@@ -217,6 +217,14 @@ env:
       secretKeyRef:
         name: prod-omi-backend-secrets
         key: MARKETPLACE_APP_REVIEWERS
+  - name: TYPESENSE_HOST
+    valueFrom:
+      configMapKeyRef:
+        name: prod-omi-backend-config
+        key: TYPESENSE_HOST
+      # TYPESENSE_HOST is public runtime configuration. Clear a historical
+      # Secret-backed binding when Helm strategically merges this named env.
+      secretKeyRef: null
   - name: TYPESENSE_HOST_PORT
     value: "443"
   - name: TYPESENSE_API_KEY

--- a/backend/tests/unit/test_verify_pusher_config_references.py
+++ b/backend/tests/unit/test_verify_pusher_config_references.py
@@ -104,8 +104,8 @@ def test_rendered_dev_pusher_google_client_id_clears_legacy_secret_source(prefli
     }
 
 
-def test_rendered_dev_pusher_typesense_host_clears_legacy_secret_source(preflight: SimpleNamespace):
-    environment = "dev"
+@pytest.mark.parametrize("environment", ["dev", "prod"])
+def test_rendered_pusher_typesense_host_clears_legacy_secret_source(preflight: SimpleNamespace, environment: str):
     deployment = next(document for document in preflight.render(environment) if document.get("kind") == "Deployment")
     env = deployment["spec"]["template"]["spec"]["containers"][0]["env"]
     typesense_host = next(item for item in env if item["name"] == "TYPESENSE_HOST")


### PR DESCRIPTION
## Summary

Closes the remaining production half of the pusher `TYPESENSE_HOST` strategic-merge contract.

- Binds `TYPESENSE_HOST` in the prod pusher chart to `prod-omi-backend-config/TYPESENSE_HOST`.
- Sets `secretKeyRef: null` so a historical Secret-backed named environment entry cannot survive a Helm/Kubernetes strategic merge.
- Extends the rendered contract test to require the value-safe ConfigMap binding in both dev and prod; the Typesense API key remains a Secret binding.

This is deliberately limited to the production chart safety binding. The standalone-pusher workflow ordering repair remains intact on local commit `d7eb3ca`, pending a credential with GitHub `workflow` scope; this PR does not bypass or replace that repair.

## Verification

- `backend/.venv/bin/python -m pytest backend/tests/unit/test_verify_pusher_config_references.py -q` → `18 passed`
- Render-only metadata/key-name preflight passed for dev and prod.
- `make preflight` → 16 selected checks passed.
- `git diff --check` passed.

No deployment, workload, Secret/ConfigMap value, traffic, IAM/RBAC, Grafana, alert route, or public-status setting was changed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9784?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

