### PR TITLE
fix(memory): preserve canonical lifecycle boundaries

### DIFF
--- a/backend/database/x_posts.py
+++ b/backend/database/x_posts.py
@@ -21,6 +21,8 @@ logger = logging.getLogger(__name__)
 
 users_collection = 'users'
 x_posts_collection = 'x_posts'
+MEMORY_EXTRACTION_PENDING = 'pending'
+MEMORY_EXTRACTION_COMPLETED = 'completed'
 
 # Post "kinds" stored under the same collection, distinguished by the `kind` field.
 KIND_TWEET = 'tweet'
@@ -64,11 +66,54 @@ def save_x_posts(uid: str, posts: List[Dict[str, Any]]) -> int:
         doc['updated_at'] = now
         if pid not in existing:
             doc['ingested_at'] = now
+            # The raw post is the durable extraction source. It stays pending
+            # until every memory write for its extraction batch succeeds.
+            doc['memory_extraction_status'] = MEMORY_EXTRACTION_PENDING
             new_count += 1
         batch.set(coll.document(pid), doc, merge=True)
     batch.commit()
     logger.info(f'save_x_posts uid={uid} received={len(posts)} new={new_count}')
     return new_count
+
+
+def get_pending_memory_extraction_posts(uid: str, limit: int = 200) -> List[Dict[str, Any]]:
+    """Return one bounded, stable batch of raw posts not yet mined for memories.
+
+    Rows created before this ledger field are intentionally pending: replaying
+    source rows incrementally is safer than silently treating a historical raw
+    import as successfully extracted.
+    """
+    bounded_limit = max(1, min(limit, 500))
+    pending: List[Dict[str, Any]] = []
+    for snapshot in _posts_ref(uid).stream():
+        raw = snapshot.to_dict()
+        if not isinstance(raw, dict) or raw.get('memory_extraction_status') == MEMORY_EXTRACTION_COMPLETED:
+            continue
+        row = cast(Dict[str, Any], raw)
+        row.setdefault('id', str(snapshot.id))
+        pending.append(row)
+
+    pending.sort(key=lambda row: (str(row.get('ingested_at') or row.get('created_at') or ''), str(row.get('id') or '')))
+    return pending[:bounded_limit]
+
+
+def mark_memory_extraction_completed(uid: str, post_ids: List[str]) -> None:
+    """Acknowledge extraction only after its canonical/legacy memory writes succeed."""
+    if not post_ids:
+        return
+    now = datetime.now(timezone.utc)
+    batch = db.batch()
+    for post_id in post_ids:
+        batch.set(
+            _posts_ref(uid).document(str(post_id)),
+            {
+                'memory_extraction_status': MEMORY_EXTRACTION_COMPLETED,
+                'memory_extracted_at': now,
+                'updated_at': now,
+            },
+            merge=True,
+        )
+    batch.commit()
 
 
 def get_x_posts(uid: str, limit: int = 100, kind: Optional[str] = None) -> List[Dict[str, Any]]:

--- a/backend/routers/conversations.py
+++ b/backend/routers/conversations.py
@@ -47,7 +47,6 @@ from utils.conversations import lifecycle as lifecycle_service
 from utils.executors import db_executor, postprocess_executor, run_blocking, submit_with_context
 from utils.memory.memory_service import MemoryService
 from utils.memory.memory_system import MemorySystem
-from utils.memory.canonical_activation import canonical_write_enabled
 from utils.memory.surface_routing import pin_memory_system
 from utils.conversations.search import ConversationSearchUnavailableError, search_conversations
 from utils.llm.conversation_processing import generate_summary_with_prompt
@@ -645,7 +644,7 @@ def delete_conversation(
         # so a partial failure cannot orphan derived data.
         db_client = getattr(db_client_module, 'db', None)
         memory_system = pin_memory_system(uid, db_client=db_client)
-        if memory_system == MemorySystem.CANONICAL and canonical_write_enabled(uid, db_client=db_client):
+        if memory_system == MemorySystem.CANONICAL:
             MemoryService(db_client=db_client).retract_conversation_memories(uid, conversation_id)
         else:
             deletion_result = memories_db.delete_memories_for_conversation(uid, conversation_id)

--- a/backend/routers/memories.py
+++ b/backend/routers/memories.py
@@ -23,7 +23,7 @@ from models.memory_imports import MemoryImportBatchRequest, MemoryImportBatchRes
 from utils.apps import update_personas_async
 from utils.memory.v3.composed_get_service import V3ComposedRequestParams, V3ComposedResponse
 from utils.memory.v3.production_runtime import build_v3_production_runtime
-from utils.memory.canonical_activation import canonical_read_enabled, canonical_write_decision, canonical_write_enabled
+from utils.memory.canonical_activation import canonical_read_enabled, canonical_write_decision
 from utils.memory.canonical_memory_adapter import (
     memory_item_to_memorydb,
     read_canonical_memory_item,
@@ -331,7 +331,7 @@ def _validate_memory(uid: str, memory_id: str) -> MemoryPayload:
 
 
 def _validate_mutable_memory(uid: str, memory_id: str, *, db_client: Any) -> MemoryPayload:
-    if canonical_write_enabled(uid, db_client=db_client):
+    if _canonical_write_enabled_or_fail_closed(uid, db_client=db_client):
         item = read_canonical_memory_item(uid, memory_id, db_client=db_client)
         if item is None:
             raise HTTPException(status_code=404, detail='Memory not found')

--- a/backend/tests/unit/test_canonical_extraction_subject_wiring.py
+++ b/backend/tests/unit/test_canonical_extraction_subject_wiring.py
@@ -21,6 +21,7 @@ from models.memory_apply import MemoryControlState
 from models.product_memory import MemoryItemStatus, MemoryTier
 from utils.memory.canonical_memory_adapter import read_canonical_memories, write_canonical_extraction_memory
 from utils.memory.canonical_kg_promotion import extract_kg_for_promoted_memory
+from utils.memory.canonical_activation import CanonicalWriteDecision
 from utils.memory.memory_service import MemoryService
 from utils.memory.memory_system import MemorySystem
 from utils.memory.required_promotion import required_promotion_payload
@@ -106,9 +107,9 @@ def test_memory_service_write_persists_subject_and_predicate(monkeypatch_trusted
 
     db = _FakeDb(_control_seed(uid))
     service = MemoryService(db_client=db)
-    with (
-        patch("utils.memory.memory_service.resolve_pinned_memory_system", return_value=MemorySystem.CANONICAL),
-        patch("utils.memory.memory_service.canonical_write_enabled", return_value=True),
+    with patch(
+        "utils.memory.memory_service.canonical_write_decision",
+        return_value=CanonicalWriteDecision(enabled=True, memory_system=MemorySystem.CANONICAL),
     ):
         service.write(uid, payload)
 
@@ -134,9 +135,9 @@ def test_canonical_manual_memory_matches_its_request_device(monkeypatch_trusted_
     db = _FakeDb(_control_seed(uid))
     service = MemoryService(db_client=db)
 
-    with (
-        patch("utils.memory.memory_service.resolve_pinned_memory_system", return_value=MemorySystem.CANONICAL),
-        patch("utils.memory.memory_service.canonical_write_enabled", return_value=True),
+    with patch(
+        "utils.memory.memory_service.canonical_write_decision",
+        return_value=CanonicalWriteDecision(enabled=True, memory_system=MemorySystem.CANONICAL),
     ):
         service.write(
             uid,
@@ -174,9 +175,9 @@ def test_write_mode_rollout_doc_does_not_collide_with_apply_control_state(monkey
     db = _FakeDb({f"users/{uid}/memory_control/state": _rollout_control_doc(uid)})
     service = MemoryService(db_client=db)
 
-    with (
-        patch("utils.memory.memory_service.resolve_pinned_memory_system", return_value=MemorySystem.CANONICAL),
-        patch("utils.memory.memory_service.canonical_write_enabled", return_value=True),
+    with patch(
+        "utils.memory.memory_service.canonical_write_decision",
+        return_value=CanonicalWriteDecision(enabled=True, memory_system=MemorySystem.CANONICAL),
     ):
         service.write(uid, payload)
 

--- a/backend/tests/unit/test_listen_finalization_cloud_tasks.py
+++ b/backend/tests/unit/test_listen_finalization_cloud_tasks.py
@@ -754,6 +754,8 @@ async def test_completed_conversation_replays_only_the_durable_fanout_boundary(m
     )
     monkeypatch.setattr(persisted_finalizer, 'deserialize_conversation', lambda value: conversation)
     monkeypatch.setattr(persisted_finalizer, 'get_cached_user_geolocation', lambda uid: None)
+    extracted = MagicMock()
+    monkeypatch.setattr(persisted_finalizer, 'extract_memories', extracted)
     monkeypatch.setattr(
         persisted_finalizer.lifecycle_service,
         'claim_finalization_fanout',
@@ -777,6 +779,7 @@ async def test_completed_conversation_replays_only_the_durable_fanout_boundary(m
         idempotency_key='conversation:conversation-1:finalization',
         require_delivery=True,
     )
+    extracted.assert_called_once_with('uid-1', conversation)
     assert disposition == ConversationFinalizationDisposition.completed
     completed.assert_called_once_with('job-1', 2, 3)
 
@@ -855,7 +858,8 @@ async def test_finalizer_skips_fanout_when_atomic_claim_is_fenced(monkeypatch):
     )
     monkeypatch.setattr(persisted_finalizer, 'deserialize_conversation', lambda value: conversation)
     monkeypatch.setattr(persisted_finalizer, 'get_cached_user_geolocation', lambda uid: None)
-    monkeypatch.setattr(persisted_finalizer, 'process_conversation', lambda *args: conversation)
+    monkeypatch.setattr(persisted_finalizer, 'process_conversation', lambda *args, **kwargs: conversation)
+    monkeypatch.setattr(persisted_finalizer, 'extract_memories', MagicMock())
     claim_fanout = MagicMock(
         return_value={'status': 'fenced', 'fanout_key': 'conversation:conversation-1:finalization'}
     )
@@ -873,3 +877,40 @@ async def test_finalizer_skips_fanout_when_atomic_claim_is_fenced(monkeypatch):
     assert disposition == ConversationFinalizationDisposition.fenced
     claim_fanout.assert_called_once_with('job-1', 2, 3)
     integrations.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_finalizer_retries_canonical_memory_extraction_before_fanout(monkeypatch):
+    async def inline_run_blocking(_executor, func, *args, **kwargs):
+        return func(*args, **kwargs)
+
+    conversation = SimpleNamespace(
+        id='conversation-1', status=ConversationStatus.processing, language='en', discarded=False
+    )
+    process = MagicMock(return_value=conversation)
+    extract = MagicMock(side_effect=RuntimeError('canonical write gate unavailable'))
+    claim_fanout = MagicMock()
+    monkeypatch.setattr(persisted_finalizer, 'run_blocking', inline_run_blocking)
+    monkeypatch.setattr(
+        persisted_finalizer.conversations_db,
+        'get_conversation',
+        lambda *args: {'id': 'conversation-1', 'status': ConversationStatus.processing.value, 'discarded': False},
+    )
+    monkeypatch.setattr(persisted_finalizer, 'deserialize_conversation', lambda value: conversation)
+    monkeypatch.setattr(persisted_finalizer, 'get_cached_user_geolocation', lambda uid: None)
+    monkeypatch.setattr(persisted_finalizer, 'process_conversation', process)
+    monkeypatch.setattr(persisted_finalizer, 'extract_memories', extract)
+    monkeypatch.setattr(persisted_finalizer.lifecycle_service, 'claim_finalization_fanout', claim_fanout)
+
+    with pytest.raises(ConversationFinalizationError):
+        await persisted_finalizer.finalize_persisted_conversation(
+            'uid-1',
+            'conversation-1',
+            finalization_job_id='job-1',
+            dispatch_generation=2,
+            lease_epoch=3,
+        )
+
+    assert process.call_args.kwargs['defer_memory_extraction'] is True
+    extract.assert_called_once_with('uid-1', conversation)
+    claim_fanout.assert_not_called()

--- a/backend/tests/unit/test_memory_replace_policy.py
+++ b/backend/tests/unit/test_memory_replace_policy.py
@@ -120,7 +120,6 @@ def test_legacy_reextract_failure_preserves_existing_memories(extractor_side_eff
         "memory_system_request_scope",
         lambda uid: MagicMock(__enter__=lambda s: pc.MemorySystem.LEGACY, __exit__=lambda *a: None),
     )
-    monkeypatch.setattr(pc, "canonical_write_enabled", lambda *a, **k: False)
 
     conversation = Conversation(
         id="conv-preserve",
@@ -166,7 +165,6 @@ def test_canonical_reextract_failure_preserves_existing_memories(extractor_side_
         "memory_system_request_scope",
         lambda uid: MagicMock(__enter__=lambda s: pc.MemorySystem.CANONICAL, __exit__=lambda *a: None),
     )
-    monkeypatch.setattr(pc, "canonical_write_enabled", lambda *a, **k: True)
     monkeypatch.setattr(pc.users_db, "get_user_language_preference", lambda uid: "en")
 
     conversation = Conversation(

--- a/backend/tests/unit/test_memory_service_parity.py
+++ b/backend/tests/unit/test_memory_service_parity.py
@@ -204,6 +204,19 @@ class TestMemoryServiceParity:
         assert decision.fail_closed is True
         assert decision.reason == "invalid_rollout_config"
 
+    def test_canonical_write_decision_missing_db_fails_closed_for_code_cohort(self, monkeypatch):
+        from tests.unit.canonical_cohort_test_helpers import set_canonical_cohort
+        from utils.memory.canonical_activation import canonical_write_decision
+
+        set_canonical_cohort(monkeypatch, "uid-canonical")
+
+        decision = canonical_write_decision("uid-canonical", db_client=None)
+
+        assert decision.enabled is False
+        assert decision.memory_system == MemorySystem.CANONICAL
+        assert decision.fail_closed is True
+        assert decision.reason == "missing_db_client"
+
     def test_read_matches_direct_legacy_helper(self, monkeypatch):
         service_mod = _load_memory_service(monkeypatch)
         memories = [_sample_memory_dict("mem-1"), _sample_memory_dict("mem-2")]
@@ -274,6 +287,62 @@ class TestMemoryServiceParity:
 
         assert exc.value.status_code == 503
         create_memory.assert_not_called()
+
+    def test_all_canonical_service_mutations_fail_closed_without_legacy_fallback(self, monkeypatch):
+        service_mod = _load_memory_service(monkeypatch)
+        monkeypatch.setattr(
+            service_mod,
+            "canonical_write_decision",
+            lambda *args, **kwargs: SimpleNamespace(
+                enabled=False,
+                memory_system=MemorySystem.CANONICAL,
+                fail_closed=True,
+                reason="rollout_write_not_ready",
+            ),
+        )
+        service = service_mod.MemoryService(db_client=_FirestoreFake())
+        legacy = service._legacy
+        for method in (
+            "write",
+            "write_batch",
+            "update_content",
+            "update_visibility",
+            "review",
+            "update_product_fields",
+            "delete",
+            "delete_all",
+        ):
+            setattr(legacy, method, MagicMock())
+
+        operations = [
+            lambda: service.ensure_canonical_mutation_ready("uid-canonical"),
+            lambda: service.write("uid-canonical", _sample_memory_dict()),
+            lambda: service.write_batch("uid-canonical", [_sample_memory_dict()]),
+            lambda: service.update_content("uid-canonical", "memory-id", "updated"),
+            lambda: service.update_visibility("uid-canonical", "memory-id", "private"),
+            lambda: service.review("uid-canonical", "memory-id", True),
+            lambda: service.update_product_fields("uid-canonical", "memory-id", tags=["tag"]),
+            lambda: service.delete("uid-canonical", "memory-id"),
+            lambda: service.delete_all("uid-canonical"),
+            lambda: service.retract_conversation_memories("uid-canonical", "conversation-id"),
+        ]
+
+        for operation in operations:
+            with pytest.raises(HTTPException) as exc:
+                operation()
+            assert exc.value.status_code == 503
+
+        for method in (
+            "write",
+            "write_batch",
+            "update_content",
+            "update_visibility",
+            "review",
+            "update_product_fields",
+            "delete",
+            "delete_all",
+        ):
+            getattr(legacy, method).assert_not_called()
 
     def test_external_canonical_create_uses_canonical_backend_without_rechecking_public_write(self, monkeypatch):
         service_mod = _load_memory_service(monkeypatch)

--- a/backend/tests/unit/test_merge_conversations_canonical_delete.py
+++ b/backend/tests/unit/test_merge_conversations_canonical_delete.py
@@ -71,9 +71,8 @@ def test_delete_conversation_related_data_routes_canonical_to_retract():
         "utils.conversations.merge_conversations.pin_memory_system",
         return_value=MemorySystem.CANONICAL,
     ):
-        with patch("utils.conversations.merge_conversations.canonical_write_enabled", return_value=True):
-            with patch("utils.conversations.merge_conversations.MemoryService", return_value=service):
-                _delete_conversation_and_related_data("uid-canonical", "conv-1")
+        with patch("utils.conversations.merge_conversations.MemoryService", return_value=service):
+            _delete_conversation_and_related_data("uid-canonical", "conv-1")
 
     service.retract_conversation_memories.assert_called_once_with("uid-canonical", "conv-1")
     legacy_delete.assert_not_called()
@@ -93,3 +92,23 @@ def test_delete_conversation_related_data_routes_legacy_to_memories_db():
 
     legacy_delete.assert_called_once_with("uid-legacy", "conv-1")
     service.retract_conversation_memories.assert_not_called()
+
+
+def test_canonical_retraction_failure_stops_source_cleanup():
+    service = MagicMock()
+    service.retract_conversation_memories.side_effect = RuntimeError("canonical unavailable")
+    delete_conversation = sys.modules["database.conversations"].delete_conversation
+    delete_conversation.reset_mock()
+    legacy_delete = sys.modules["database.memories"].delete_memories_for_conversation
+    legacy_delete.reset_mock()
+
+    with patch(
+        "utils.conversations.merge_conversations.pin_memory_system",
+        return_value=MemorySystem.CANONICAL,
+    ):
+        with patch("utils.conversations.merge_conversations.MemoryService", return_value=service):
+            with pytest.raises(RuntimeError, match="canonical unavailable"):
+                _delete_conversation_and_related_data("uid-canonical", "conv-1")
+
+    legacy_delete.assert_not_called()
+    delete_conversation.assert_not_called()

--- a/backend/tests/unit/test_sync_v2.py
+++ b/backend/tests/unit/test_sync_v2.py
@@ -3113,7 +3113,7 @@ class TestConversationFinalizerExecutor:
     def test_process_conversation_uses_postprocess_bulkhead(self):
         source = self._read_finalizer_source()
         assert 'postprocess_executor' in source
-        assert re.search(r'run_blocking\(\s+postprocess_executor, process_conversation', source)
+        assert re.search(r'run_blocking\(\s+postprocess_executor,\s+process_conversation', source)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/unit/test_ws_i_write_convergence.py
+++ b/backend/tests/unit/test_ws_i_write_convergence.py
@@ -488,12 +488,13 @@ def test_extract_memories_inner_canonical_uses_memory_service(monkeypatch):
     ]
     write_mock = MagicMock()
     retract_mock = MagicMock()
+    readiness_mock = MagicMock()
     service = MagicMock()
     service.write = write_mock
     service.retract_conversation_memories = retract_mock
+    service.ensure_canonical_mutation_ready = readiness_mock
 
     _patch_cohort_resolver(monkeypatch, MemorySystem.CANONICAL)
-    monkeypatch.setattr(pc, "canonical_write_enabled", lambda *args, **kwargs: True)
     monkeypatch.setattr(pc, "new_memories_extractor", lambda *args, **kwargs: memories)
     monkeypatch.setattr(pc, "record_usage", lambda *args, **kwargs: None)
     monkeypatch.setattr(pc.users_db, "get_user_language_preference", lambda uid: "en")
@@ -511,6 +512,7 @@ def test_extract_memories_inner_canonical_uses_memory_service(monkeypatch):
     pc._extract_memories_inner("uid-canonical", conversation)
 
     retract_mock.assert_called_once_with("uid-canonical", "conv-canonical")
+    readiness_mock.assert_called_once_with("uid-canonical")
     legacy_delete.assert_not_called()
     legacy_save.assert_not_called()
     assert write_mock.call_count == 2
@@ -523,6 +525,7 @@ def test_extract_memories_inner_canonical_uses_memory_service(monkeypatch):
     conversation.is_locked = True
     pc._extract_memories_inner("uid-canonical", conversation)
     assert write_mock.call_count == 4
+    assert readiness_mock.call_count == 2
     association_mock.assert_not_called()
 
 
@@ -864,7 +867,6 @@ def test_review_memory_routes_canonical_cohort_through_memory_service():
 def test_preference_tools_routes_canonical_cohort_through_memory_service():
     source = (BACKEND_DIR / "utils" / "retrieval" / "tools" / "preference_tools.py").read_text(encoding="utf-8")
     assert "resolve_memory_system(uid, db_client=db) == MemorySystem.CANONICAL" in source
-    assert "canonical_write_enabled(" in source
     assert "MemoryService(db_client=db).create_external_memory(" in source
     assert "require_canonical_promotion=True" in source
     canonical_pos = source.find("MemorySystem.CANONICAL")

--- a/backend/tests/unit/test_ws_m_atom_keyword_index.py
+++ b/backend/tests/unit/test_ws_m_atom_keyword_index.py
@@ -373,10 +373,6 @@ class TestKeywordSearchAndHybrid:
         upsert_atom_keyword_doc(item)
 
         monkeypatch.setattr(
-            "utils.memory.memory_service.resolve_pinned_memory_system",
-            lambda uid, **_: MemorySystem.CANONICAL,
-        )
-        monkeypatch.setattr(
             "utils.memory.memory_service.canonical_read_enabled",
             lambda uid, db_client=None: True,
         )

--- a/backend/tests/unit/test_x_memory_extraction_retry.py
+++ b/backend/tests/unit/test_x_memory_extraction_retry.py
@@ -1,0 +1,100 @@
+"""Durability contracts for X raw-source memory extraction."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+from fastapi import HTTPException
+
+os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv')
+
+from models.memories import Memory, MemoryCategory
+from utils import x_connector
+from utils.memory.memory_system import MemorySystem
+
+
+async def _inline_run_blocking(_executor, func, *args, **kwargs):
+    return func(*args, **kwargs)
+
+
+@pytest.mark.anyio
+async def test_sync_retries_pending_raw_posts_when_a_prior_canonical_write_failed(monkeypatch):
+    """Raw dedupe cannot hide a source whose prior memory write failed."""
+    post = {'id': 'post-1', 'text': 'I prefer tea', 'created_at': '2026-07-14T00:00:00Z', 'kind': 'tweet'}
+    saved_counts = iter([1, 0])
+    extraction_calls = []
+    integration_updates = []
+
+    monkeypatch.setattr(x_connector, 'run_blocking', _inline_run_blocking)
+    monkeypatch.setattr(x_connector.users_db, 'get_integration', lambda *args: {'x_user_id': 'x-user'})
+    monkeypatch.setattr(
+        x_connector.users_db,
+        'set_integration',
+        lambda _uid, _key, payload: integration_updates.append(payload),
+    )
+    monkeypatch.setattr(x_connector.x_posts_db, 'get_newest_tweet_id', lambda _uid: None)
+    monkeypatch.setattr(x_connector.x_posts_db, 'save_x_posts', lambda _uid, _posts: next(saved_counts))
+    monkeypatch.setattr(
+        x_connector.x_posts_db,
+        'get_pending_memory_extraction_posts',
+        lambda _uid, _limit: [post],
+    )
+    monkeypatch.setattr(x_connector.x_posts_db, 'count_x_posts', lambda _uid: 1)
+    monkeypatch.setattr(x_connector, 'upsert_x_post_vectors_batch', lambda *args: None)
+    monkeypatch.setattr(x_connector, 'get_valid_access_token', lambda _uid: _async_value('token'))
+    monkeypatch.setattr(x_connector, 'fetch_tweets', lambda *args: _async_value([post]))
+    monkeypatch.setattr(x_connector, 'fetch_bookmarks', lambda *args: _async_value([]))
+
+    def extract(_uid, posts):
+        extraction_calls.append(posts)
+        if len(extraction_calls) == 1:
+            raise HTTPException(status_code=503, detail='canonical write unavailable')
+        return 1
+
+    monkeypatch.setattr(x_connector, '_extract_and_index', extract)
+
+    with pytest.raises(HTTPException, match='canonical write unavailable'):
+        await x_connector.sync_x_for_user('uid-1')
+    result = await x_connector.sync_x_for_user('uid-1')
+
+    assert extraction_calls == [[post], [post]]
+    assert result['new_posts'] == 0
+    assert result['memories_created'] == 1
+    assert integration_updates[-1]['memory_count'] == 1
+
+
+def test_pending_x_source_is_acknowledged_only_after_memory_writes_succeed(monkeypatch):
+    post = {'id': 'post-1', 'text': 'I prefer tea', 'created_at': '2026-07-14T00:00:00Z', 'kind': 'tweet'}
+    acknowledgements = []
+    memory = Memory(content='User prefers tea', category=MemoryCategory.interesting)
+
+    monkeypatch.setattr(x_connector, 'extract_memories_from_text', lambda *args: [memory])
+    monkeypatch.setattr(x_connector, 'resolve_memory_system', lambda *args, **kwargs: MemorySystem.CANONICAL)
+    monkeypatch.setattr(
+        x_connector.x_posts_db,
+        'mark_memory_extraction_completed',
+        lambda uid, post_ids: acknowledgements.append((uid, post_ids)),
+    )
+
+    class FailingMemoryService:
+        def __init__(self, **_kwargs):
+            pass
+
+        def write(self, *_args, **_kwargs):
+            raise HTTPException(status_code=503, detail='canonical write unavailable')
+
+    monkeypatch.setattr(x_connector, 'MemoryService', FailingMemoryService)
+
+    with pytest.raises(HTTPException, match='canonical write unavailable'):
+        x_connector._extract_and_index('uid-1', [post])
+
+    assert acknowledgements == []
+
+    monkeypatch.setattr(x_connector, 'extract_memories_from_text', lambda *args: [])
+    assert x_connector._extract_and_index('uid-1', [post]) == 0
+    assert acknowledgements == [('uid-1', ['post-1'])]
+
+
+async def _async_value(value):
+    return value

--- a/backend/utils/conversations/finalizer.py
+++ b/backend/utils/conversations/finalizer.py
@@ -16,7 +16,7 @@ from models.geolocation import Geolocation
 from utils.app_integrations import trigger_external_integrations
 from utils.conversations.factory import deserialize_conversation
 from utils.conversations.location import async_resolve_geolocation
-from utils.conversations.process_conversation import process_conversation
+from utils.conversations.process_conversation import extract_memories, process_conversation
 from utils.conversations import lifecycle as lifecycle_service
 from utils.executors import db_executor, postprocess_executor, run_blocking
 
@@ -92,8 +92,18 @@ async def finalize_persisted_conversation(
         resolved_language = language or getattr(conversation, 'language', None) or 'en'
         if conversation.status != ConversationStatus.completed:
             conversation = await run_blocking(
-                postprocess_executor, process_conversation, uid, resolved_language, conversation
+                postprocess_executor,
+                process_conversation,
+                uid,
+                resolved_language,
+                conversation,
+                defer_memory_extraction=True,
             )
+        if not getattr(conversation, 'discarded', False):
+            # A finalization job owns a durable lease. Keep canonical memory
+            # extraction inside that lease so a temporary fail-closed gate
+            # leaves the job retryable instead of dropping the source.
+            await run_blocking(postprocess_executor, extract_memories, uid, conversation)
         # This is deliberately the only fanout admission read. The lifecycle
         # transaction re-reads the durable conversation together with the job
         # lease, so a discard or superseding generation cannot slip between a

--- a/backend/utils/conversations/memories.py
+++ b/backend/utils/conversations/memories.py
@@ -7,7 +7,6 @@ import database.users as users_db
 from models.memories import MemoryDB, Memory, MemoryCategory
 from models.integrations import ExternalIntegrationCreateMemory
 from utils.llm.memories import extract_memories_from_text
-from utils.memory.canonical_activation import canonical_write_enabled
 from utils.memory.memory_api_contract import MemoryApiExposure, memory_write_payload
 from utils.memory.memory_service import MemoryService
 from utils.memory.memory_system import MemorySystem, resolve_memory_system
@@ -124,9 +123,7 @@ def process_external_integration_memory(
     if saved_memories:
         # Background writers use resolve_memory_system (no request pin); routers use pin_memory_system.
         db_client = getattr(db_client_module, 'db', None)
-        if resolve_memory_system(uid, db_client=db_client) == MemorySystem.CANONICAL and canonical_write_enabled(
-            uid, db_client=db_client
-        ):
+        if resolve_memory_system(uid, db_client=db_client) == MemorySystem.CANONICAL:
             memory_service = MemoryService(db_client=db_client)
             for memory_db in saved_memories:
                 if memory_db.id in explicit_memory_ids:
@@ -182,9 +179,7 @@ def process_twitter_memories(uid: str, tweets_text: str, persona_id: str) -> Lis
     if saved_memories:
         # Background writers use resolve_memory_system (no request pin); routers use pin_memory_system.
         db_client = getattr(db_client_module, 'db', None)
-        if resolve_memory_system(uid, db_client=db_client) == MemorySystem.CANONICAL and canonical_write_enabled(
-            uid, db_client=db_client
-        ):
+        if resolve_memory_system(uid, db_client=db_client) == MemorySystem.CANONICAL:
             memory_service = MemoryService(db_client=db_client)
             for memory_db in saved_memories:
                 memory_service.write(uid, memory_db.model_dump())

--- a/backend/utils/conversations/merge_conversations.py
+++ b/backend/utils/conversations/merge_conversations.py
@@ -22,7 +22,6 @@ from models.conversation_enums import ConversationStatus
 from models.structured import Structured
 from utils.memory.memory_service import MemoryService
 from utils.memory.memory_system import MemorySystem
-from utils.memory.canonical_activation import canonical_write_enabled
 from utils.memory.surface_routing import pin_memory_system
 from utils.conversations.datetime_utils import coerce_utc_datetime
 from utils.conversations import lifecycle as lifecycle_service
@@ -527,14 +526,21 @@ def _delete_conversation_and_related_data(uid: str, conversation_id: str) -> Non
     import database.memories as memories_db
     import database.action_items as action_items_db
 
+    memory_system: MemorySystem | None = None
     try:
         memory_system = pin_memory_system(uid, db_client=firestore_db)
-        if memory_system == MemorySystem.CANONICAL and canonical_write_enabled(uid, db_client=firestore_db):
+        if memory_system == MemorySystem.CANONICAL:
             MemoryService(db_client=firestore_db).retract_conversation_memories(uid, conversation_id)
         else:
             memories_db.delete_memories_for_conversation(uid, conversation_id)
     except Exception as e:
         logger.error(f"Error deleting memories for {conversation_id}: {e}")
+        # A canonical-selected account must retry the merge rather than delete
+        # its source conversation while its canonical evidence retraction is
+        # unavailable. Continuing here would silently leave active canonical
+        # memories pointing at a deleted source.
+        if memory_system == MemorySystem.CANONICAL:
+            raise
 
     try:
         # Delete action items from standalone collection

--- a/backend/utils/conversations/process_conversation.py
+++ b/backend/utils/conversations/process_conversation.py
@@ -48,7 +48,6 @@ from models.conversation_enums import ConversationSource, ConversationStatus, Ex
 from utils.conversations.factory import deserialize_conversation
 from utils.conversations import lifecycle as lifecycle_service
 from utils.conversations.subjects import infer_subject_from_segments
-from utils.memory.canonical_activation import canonical_write_enabled
 from utils.memory.memory_api_contract import MemoryApiExposure, memory_write_payload
 from utils.memory.memory_service import MemoryService
 from utils.memory.memory_system import MemorySystem
@@ -484,9 +483,18 @@ def _update_goal_progress(uid: str, conversation: Conversation) -> None:
         logger.error(f"[GOAL] Error updating progress: {e}")
 
 
-def _extract_memories(uid: str, conversation: Conversation) -> None:
+def extract_memories(uid: str, conversation: Conversation) -> None:
+    """Extract one conversation's memories through the selected memory system.
+
+    Finalization workers use this public boundary while holding their durable
+    lease. Keep the private helper below for existing in-module async callers.
+    """
     with track_usage(uid, Features.MEMORIES):
         _extract_memories_inner(uid, conversation)
+
+
+def _extract_memories(uid: str, conversation: Conversation) -> None:
+    extract_memories(uid, conversation)
 
 
 def _extract_memories_canonical(uid: str, conversation: Conversation, *, db_client: Any) -> None:
@@ -589,7 +597,8 @@ def _extract_memories_canonical(uid: str, conversation: Conversation, *, db_clie
 def _extract_memories_inner(uid: str, conversation: Conversation) -> None:
     with memory_system_request_scope(uid) as memory_system:
         db_client = getattr(db_client_module, 'db', None)
-        if memory_system == MemorySystem.CANONICAL and canonical_write_enabled(uid, db_client=db_client):
+        if memory_system == MemorySystem.CANONICAL:
+            MemoryService(db_client=db_client).ensure_canonical_mutation_ready(uid)
             _extract_memories_canonical(uid, conversation, db_client=db_client)
             return
 
@@ -992,6 +1001,7 @@ def process_conversation(
     is_reprocess: bool = False,
     app_id: Optional[str] = None,
     persistence_observer: Callable[[bool], None] | None = None,
+    defer_memory_extraction: bool = False,
 ) -> Conversation:
     def report_persistence(current: bool) -> None:
         if persistence_observer is not None:
@@ -1180,7 +1190,15 @@ def process_conversation(
             submit_with_context(postprocess_executor, save_structured_vector, uid, conversation)
             if TRANSCRIPT_CHUNK_INDEXING_ENABLED:
                 submit_with_context(postprocess_executor, save_transcript_chunk_vectors, uid, conversation)
-        submit_with_context(postprocess_executor, _extract_memories, uid, conversation)
+        if not defer_memory_extraction:
+            with memory_system_request_scope(uid) as memory_system:
+                if memory_system == MemorySystem.CANONICAL:
+                    # Canonical writes intentionally fail closed. Do not hide a
+                    # retryable gate/store failure in an unobserved future and
+                    # report this conversation as successfully processed.
+                    _extract_memories(uid, conversation)
+                else:
+                    submit_with_context(postprocess_executor, _extract_memories, uid, conversation)
         submit_with_context(postprocess_executor, _save_action_items, uid, conversation)
         submit_with_context(postprocess_executor, _update_goal_progress, uid, conversation)
 

--- a/backend/utils/memory/canonical_activation.py
+++ b/backend/utils/memory/canonical_activation.py
@@ -33,6 +33,13 @@ def canonical_write_decision(uid: str, *, db_client: Any) -> CanonicalWriteDecis
     """Resolve canonical write readiness without collapsing enrolled failures into legacy fallback."""
 
     if db_client is None:
+        if uid in set(list_canonical_cohort_uids()):
+            return CanonicalWriteDecision(
+                enabled=False,
+                memory_system=MemorySystem.CANONICAL,
+                fail_closed=True,
+                reason="missing_db_client",
+            )
         return CanonicalWriteDecision(
             enabled=False,
             memory_system=MemorySystem.LEGACY,

--- a/backend/utils/memory/memory_service.py
+++ b/backend/utils/memory/memory_service.py
@@ -28,9 +28,8 @@ from utils.memory.canonical_memory_adapter import (
 )
 from utils.memory.required_promotion import required_processing_payload
 from utils.client_device import DeviceScopeRequest
-from utils.memory.canonical_activation import canonical_read_enabled, canonical_write_decision, canonical_write_enabled
+from utils.memory.canonical_activation import canonical_read_enabled, canonical_write_decision
 from utils.memory.memory_system import MemorySystem
-from utils.memory.memory_system_pin import resolve_pinned_memory_system
 from utils.memory.default_read_rollout import guard_legacy_memory_write
 from utils.memory.memory_api_contract import MemoryApiExposure, memory_api_payload, memory_write_payload
 from utils.retrieval.hybrid import rrf_rerank
@@ -434,11 +433,30 @@ class MemoryService:
         self._legacy = LegacyMemoryBackend()
         self._canonical = CanonicalMemoryBackend(db_client=db_client)
 
-    def _resolve_backend(self, uid: str):
-        system = resolve_pinned_memory_system(uid, db_client=self._db_client)
-        if system == MemorySystem.CANONICAL:
+    def _resolve_mutation_backend(self, uid: str):
+        """Return the only store a mutation may affect for this account.
+
+        Canonical selection is sticky for mutations: a temporarily unavailable
+        canonical control/write gate is retryable, not permission to create or
+        modify a legacy row. Legacy accounts retain their existing behavior.
+        """
+
+        decision = canonical_write_decision(uid, db_client=self._db_client)
+        if decision.memory_system != MemorySystem.CANONICAL:
+            return self._legacy
+        if decision.enabled:
             return self._canonical
-        return self._legacy
+        raise HTTPException(status_code=503, detail={"reason": decision.reason, "memory_system": "canonical"})
+
+    def ensure_canonical_mutation_ready(self, uid: str) -> None:
+        """Fail closed when a canonical-selected background writer cannot mutate."""
+
+        backend = self._resolve_mutation_backend(uid)
+        if backend is not self._canonical:
+            raise HTTPException(
+                status_code=503,
+                detail={"reason": "canonical_selection_changed", "memory_system": "canonical"},
+            )
 
     def read(
         self,
@@ -481,36 +499,19 @@ class MemoryService:
         return _legacy_search_memories_mcp(uid, query, limit=limit)
 
     def write(self, uid: str, data: Dict[str, Any]) -> str:
-        if resolve_pinned_memory_system(uid, db_client=self._db_client) == MemorySystem.CANONICAL:
-            if not canonical_write_enabled(uid, db_client=self._db_client):
-                return self._legacy.write(uid, data)
-        return self._resolve_backend(uid).write(uid, data)
+        return self._resolve_mutation_backend(uid).write(uid, data)
 
     def write_batch(self, uid: str, items: List[Dict[str, Any]]) -> List[str]:
-        if resolve_pinned_memory_system(uid, db_client=self._db_client) == MemorySystem.CANONICAL:
-            if not canonical_write_enabled(uid, db_client=self._db_client):
-                return self._legacy.write_batch(uid, items)
-        return self._resolve_backend(uid).write_batch(uid, items)
+        return self._resolve_mutation_backend(uid).write_batch(uid, items)
 
     def update_content(self, uid: str, memory_id: str, content: str) -> MemoryDB:
-        if resolve_pinned_memory_system(uid, db_client=self._db_client) == MemorySystem.CANONICAL:
-            if not canonical_write_enabled(uid, db_client=self._db_client):
-                return self._legacy.update_content(uid, memory_id, content)
-        return self._resolve_backend(uid).update_content(uid, memory_id, content)
+        return self._resolve_mutation_backend(uid).update_content(uid, memory_id, content)
 
     def update_visibility(self, uid: str, memory_id: str, visibility: str) -> None:
-        if resolve_pinned_memory_system(uid, db_client=self._db_client) == MemorySystem.CANONICAL:
-            if not canonical_write_enabled(uid, db_client=self._db_client):
-                self._legacy.update_visibility(uid, memory_id, visibility)
-                return
-        self._resolve_backend(uid).update_visibility(uid, memory_id, visibility)
+        self._resolve_mutation_backend(uid).update_visibility(uid, memory_id, visibility)
 
     def review(self, uid: str, memory_id: str, value: bool) -> None:
-        if resolve_pinned_memory_system(uid, db_client=self._db_client) == MemorySystem.CANONICAL:
-            if not canonical_write_enabled(uid, db_client=self._db_client):
-                self._legacy.review(uid, memory_id, value)
-                return
-        self._resolve_backend(uid).review(uid, memory_id, value)
+        self._resolve_mutation_backend(uid).review(uid, memory_id, value)
 
     def update_product_fields(
         self,
@@ -520,29 +521,22 @@ class MemoryService:
         tags: Optional[List[str]] = None,
         category: Optional[str] = None,
     ) -> MemoryDB:
-        if resolve_pinned_memory_system(uid, db_client=self._db_client) == MemorySystem.CANONICAL:
-            if not canonical_write_enabled(uid, db_client=self._db_client):
-                return self._legacy.update_product_fields(uid, memory_id, tags=tags, category=category)
-        return self._resolve_backend(uid).update_product_fields(uid, memory_id, tags=tags, category=category)
+        return self._resolve_mutation_backend(uid).update_product_fields(
+            uid,
+            memory_id,
+            tags=tags,
+            category=category,
+        )
 
     def delete(self, uid: str, memory_id: str) -> None:
-        if resolve_pinned_memory_system(uid, db_client=self._db_client) == MemorySystem.CANONICAL:
-            if not canonical_write_enabled(uid, db_client=self._db_client):
-                self._legacy.delete(uid, memory_id)
-                return
-        self._resolve_backend(uid).delete(uid, memory_id)
+        self._resolve_mutation_backend(uid).delete(uid, memory_id)
 
     def delete_all(self, uid: str) -> None:
-        if resolve_pinned_memory_system(uid, db_client=self._db_client) == MemorySystem.CANONICAL:
-            if not canonical_write_enabled(uid, db_client=self._db_client):
-                self._legacy.delete_all(uid)
-                return
-        self._resolve_backend(uid).delete_all(uid)
+        self._resolve_mutation_backend(uid).delete_all(uid)
 
     def retract_conversation_memories(self, uid: str, conversation_id: str) -> Optional[Dict[str, Any]]:
-        if resolve_pinned_memory_system(uid, db_client=self._db_client) != MemorySystem.CANONICAL:
-            return None
-        if not canonical_write_enabled(uid, db_client=self._db_client):
+        backend = self._resolve_mutation_backend(uid)
+        if backend is self._legacy:
             return None
         return retract_conversation_sourced_memories(uid, conversation_id, db_client=self._db_client)
 

--- a/backend/utils/retrieval/tools/preference_tools.py
+++ b/backend/utils/retrieval/tools/preference_tools.py
@@ -15,7 +15,6 @@ import database.vector_db as vector_db
 from database._client import db
 import logging
 from models.memories import MemoryDB
-from utils.memory.canonical_activation import canonical_write_enabled
 from utils.memory.memory_service import MemoryService
 from utils.memory.memory_system import MemorySystem, resolve_memory_system
 
@@ -105,9 +104,7 @@ def save_user_preference_tool(preference: str, config: RunnableConfig = None) ->
     memory_data['scoring'] = MemoryDB.calculate_score(MemoryDB.model_validate(memory_data))
 
     try:
-        if resolve_memory_system(uid, db_client=db) == MemorySystem.CANONICAL and canonical_write_enabled(
-            uid, db_client=db
-        ):
+        if resolve_memory_system(uid, db_client=db) == MemorySystem.CANONICAL:
             MemoryService(db_client=db).create_external_memory(
                 uid,
                 MemoryDB.model_validate(memory_data),

--- a/backend/utils/x_connector.py
+++ b/backend/utils/x_connector.py
@@ -35,7 +35,6 @@ from database._client import db
 from database.vector_db import upsert_memory_vectors_batch, upsert_x_post_vectors_batch
 from models.memories import MemoryDB
 from utils.llm.memories import extract_memories_from_text
-from utils.memory.canonical_activation import canonical_write_enabled
 from utils.memory.memory_api_contract import MemoryApiExposure, memory_write_payload
 from utils.memory.memory_service import MemoryService
 from utils.memory.memory_system import MemorySystem, resolve_memory_system
@@ -83,6 +82,7 @@ _SYNC_JOB_USER_SPACING_SEC = 1.5  # gap between users to stay gentle on X limits
 MAX_TWEET_PAGES = 4  # ~4 * 100 = up to 400 recent tweets per sync
 MAX_BOOKMARK_PAGES = 2
 MEMORY_BATCH_CHARS = 8000  # group post text into ~8k-char chunks for extraction
+MAX_PENDING_MEMORY_EXTRACTION_POSTS = 200  # bounded incremental replay of durable raw sources
 
 
 def is_oauth_configured() -> bool:
@@ -351,49 +351,51 @@ def _extract_and_index(uid: str, posts: List[Dict]) -> int:
     total = 0
     for chunk, post_ids in chunks:
         extracted = extract_memories_from_text(uid, chunk, 'twitter_tweets')
-        if not extracted:
-            continue
-        source_id = f"{INTEGRATION_KEY}:{hashlib.sha256('|'.join(post_ids).encode('utf-8')).hexdigest()[:24]}"
-        memory_dbs: List[MemoryDB] = []
-        for m in extracted:
-            mdb = MemoryDB.from_memory(
-                m,
-                uid,
-                None,
-                False,
-                source_id=source_id,
-                source_type="integration:x",
-                source_signal="integration",
-                artifact_ref={"kind": "integration_text", "text_source": "twitter_tweets", "post_ids": post_ids},
-                extractor_id="extract_memories_from_text",
-            )
-            mdb.manually_added = False
-            # Tag with the connector key so X-derived memories are identifiable
-            # (and cleanly removable on disconnect / re-import).
-            mdb.app_id = INTEGRATION_KEY
-            memory_dbs.append(mdb)
-        # Background writers use resolve_memory_system (no request pin); routers use pin_memory_system.
-        if resolve_memory_system(uid, db_client=db) == MemorySystem.CANONICAL and canonical_write_enabled(
-            uid, db_client=db
-        ):
-            memory_service = MemoryService(db_client=db)
-            for mdb in memory_dbs:
-                memory_service.write(uid, mdb.model_dump())
-        else:
-            memories_db.save_memories(uid, [memory_write_payload(m, MemoryApiExposure.LEGACY) for m in memory_dbs])
-            upsert_memory_vectors_batch(
-                uid,
-                [
-                    {
-                        'memory_id': m.id,
-                        'content': m.content,
-                        'category': m.category.value,
-                        'subject_entity_id': m.subject_entity_id,
-                    }
-                    for m in memory_dbs
-                ],
-            )
-        total += len(memory_dbs)
+        if extracted:
+            source_id = f"{INTEGRATION_KEY}:{hashlib.sha256('|'.join(post_ids).encode('utf-8')).hexdigest()[:24]}"
+            memory_dbs: List[MemoryDB] = []
+            for m in extracted:
+                mdb = MemoryDB.from_memory(
+                    m,
+                    uid,
+                    None,
+                    False,
+                    source_id=source_id,
+                    source_type="integration:x",
+                    source_signal="integration",
+                    artifact_ref={"kind": "integration_text", "text_source": "twitter_tweets", "post_ids": post_ids},
+                    extractor_id="extract_memories_from_text",
+                )
+                mdb.manually_added = False
+                # Tag with the connector key so X-derived memories are identifiable
+                # (and cleanly removable on disconnect / re-import).
+                mdb.app_id = INTEGRATION_KEY
+                memory_dbs.append(mdb)
+            # Background writers use resolve_memory_system (no request pin); routers use pin_memory_system.
+            if resolve_memory_system(uid, db_client=db) == MemorySystem.CANONICAL:
+                memory_service = MemoryService(db_client=db)
+                for mdb in memory_dbs:
+                    memory_service.write(uid, mdb.model_dump())
+            else:
+                memories_db.save_memories(uid, [memory_write_payload(m, MemoryApiExposure.LEGACY) for m in memory_dbs])
+                upsert_memory_vectors_batch(
+                    uid,
+                    [
+                        {
+                            'memory_id': m.id,
+                            'content': m.content,
+                            'category': m.category.value,
+                            'subject_entity_id': m.subject_entity_id,
+                        }
+                        for m in memory_dbs
+                    ],
+                )
+            total += len(memory_dbs)
+
+        # Do not acknowledge this raw source until every write above succeeds.
+        # A failed canonical gate therefore remains visible to the next hourly
+        # sync instead of being swallowed by raw-post deduplication.
+        x_posts_db.mark_memory_extraction_completed(uid, post_ids)
     return total
 
 
@@ -485,21 +487,27 @@ async def sync_x_for_user(uid: str) -> Dict:
 
     try:
         written = await run_blocking(db_executor, x_posts_db.save_x_posts, uid, new_posts)
-        # Only mine memories from posts we hadn't seen before (the raw store dedupes,
-        # but extraction is the expensive part — restrict it to genuinely new text).
-        fresh = new_posts if written == len(new_posts) else new_posts[:written]
+        # Raw rows own extraction progress. This includes interrupted prior
+        # writes (and legacy rows without a state), so canonical gate failures
+        # replay incrementally rather than becoming invisible after raw dedupe.
+        pending_posts = await run_blocking(
+            db_executor,
+            x_posts_db.get_pending_memory_extraction_posts,
+            uid,
+            MAX_PENDING_MEMORY_EXTRACTION_POSTS,
+        )
         # Vector-index the raw posts so agents can semantically search the actual
         # tweets (not just the extracted memories) via the MCP search_x_posts tool.
         # Chunk to stay within Pinecone's per-upsert vector limit (~100).
         items_to_index = [
-            {'post_id': p['id'], 'content': p.get('text', ''), 'kind': p.get('kind', 'tweet')} for p in fresh
+            {'post_id': p['id'], 'content': p.get('text', ''), 'kind': p.get('kind', 'tweet')} for p in pending_posts
         ]
         for i in range(0, len(items_to_index), 100):
             try:
                 await run_blocking(db_executor, upsert_x_post_vectors_batch, uid, items_to_index[i : i + 100])
             except Exception as e:
                 logger.warning(f'x_connector: failed to index x_posts chunk[{i}:{i+100}] for uid={uid}: {e}')
-        memories_created = await run_blocking(db_executor, _extract_and_index, uid, fresh)
+        memories_created = await run_blocking(db_executor, _extract_and_index, uid, pending_posts)
         post_count = await run_blocking(db_executor, x_posts_db.count_x_posts, uid)
 
         await run_blocking(

--- a/desktop/macos/Desktop/Sources/APIClient.swift
+++ b/desktop/macos/Desktop/Sources/APIClient.swift
@@ -2434,10 +2434,10 @@ extension APIClient {
   }
 }
 
-struct CreateMemoryResponse: Codable {
-  let id: String
-  let message: String?
-}
+/// The create endpoint returns the stored memory, including its authoritative
+/// canonical lifecycle. Keep the historical name so callers do not mistake a
+/// successful response for an ID-only receipt.
+typealias CreateMemoryResponse = ServerMemory
 
 /// One item in a POST /v3/memories/batch payload. Mirrors the `Memory` model
 /// in `backend/models/memories.py`. The server honors `category`, so batch

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoriesPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoriesPage.swift
@@ -288,8 +288,8 @@ class MemoriesViewModel: ObservableObject {
     canonicalLifecycleExposed ? token.layerFilter.allowedLayers : nil
   }
 
-  private func includeExplicitLifecycleRows(for token: MemoryScopeToken) -> Bool {
-    canonicalLifecycleExposed
+  private func recordReadScope(for token: MemoryScopeToken) -> MemoryRecordReadScope {
+    canonicalLifecycleExposed ? .canonicalProduct : .legacyCompatibility
   }
 
   private func displayMemories(_ values: [ServerMemory], for token: MemoryScopeToken) -> [ServerMemory] {
@@ -301,12 +301,36 @@ class MemoriesViewModel: ObservableObject {
   }
 
   private func displayMemories(_ values: [ServerMemory], lifecycleExposed: Bool) -> [ServerMemory] {
-    lifecycleExposed ? values : values.filter { !$0.tierIsExplicit }
+    values.filter { $0.tierIsExplicit == lifecycleExposed }
   }
 
   private struct MemoryPageFetchResult {
     let page: APIClient.MemoryListPage
     let deviceScopeSupportedOverride: Bool?
+  }
+
+  private var lifecycleExposureCapabilityKey: String {
+    let userId = UserDefaults.standard.string(forKey: "auth_userId") ?? "unknown"
+    return "memoriesCanonicalLifecycleExposure_v1_\(userId)"
+  }
+
+  /// Restores the last authoritative lifecycle capability for this account.
+  ///
+  /// The cache itself cannot prove whether an untiered row is a legacy
+  /// compatibility record or a local-pending write. Until the first response
+  /// establishes that capability, defer cache rendering instead of briefly
+  /// presenting those rows as product memories.
+  @discardableResult
+  private func restoreCanonicalLifecycleExposure() -> Bool {
+    guard let exposed = UserDefaults.standard.object(forKey: lifecycleExposureCapabilityKey) as? Bool else {
+      return false
+    }
+    canonicalLifecycleExposed = exposed
+    return true
+  }
+
+  private func persistCanonicalLifecycleExposure(_ exposed: Bool) {
+    UserDefaults.standard.set(exposed, forKey: lifecycleExposureCapabilityKey)
   }
 
   @discardableResult
@@ -319,6 +343,7 @@ class MemoriesViewModel: ObservableObject {
     guard isCurrentScope(token) else { return false }
     if let expectedOffset, currentOffset != expectedOffset { return false }
     canonicalLifecycleExposed = page.canonicalLifecycleExposed
+    persistCanonicalLifecycleExposure(page.canonicalLifecycleExposed)
     if let deviceScopeCapability = deviceScopeSupportedOverride ?? page.deviceScopeSupported {
       deviceScopeSupported = deviceScopeCapability
     }
@@ -326,6 +351,7 @@ class MemoriesViewModel: ObservableObject {
   }
 
   private func layerAllowed(_ memory: ServerMemory, for token: MemoryScopeToken) -> Bool {
+    guard memory.tierIsExplicit == canonicalLifecycleExposed else { return false }
     guard let allowedLayers = layers(for: token) else { return true }
     return Set(allowedLayers).contains(memory.tier)
   }
@@ -345,7 +371,7 @@ class MemoriesViewModel: ObservableObject {
           limit: pageSize,
           offset: 0,
           tiers: layers(for: token),
-          includeExplicitLifecycleRows: includeExplicitLifecycleRows(for: token)
+          scope: recordReadScope(for: token)
         )
         guard isCurrentScope(token) else { return }
         memories = displayCacheMemories(loaded, for: token)
@@ -450,7 +476,7 @@ class MemoriesViewModel: ObservableObject {
         limit: reloadLimit,
         offset: 0,
         tiers: layers(for: token),
-        includeExplicitLifecycleRows: includeExplicitLifecycleRows(for: token)
+        scope: recordReadScope(for: token)
       )
       guard isCurrentScope(token) else { return }
       if let fetchedLifecycleExposure {
@@ -537,7 +563,7 @@ class MemoriesViewModel: ObservableObject {
         limit: reloadLimit,
         offset: 0,
         tiers: layers(for: token),
-        includeExplicitLifecycleRows: includeExplicitLifecycleRows(for: token)
+        scope: recordReadScope(for: token)
       )
       guard isCurrentScope(token) else { return }
       log(
@@ -570,10 +596,9 @@ class MemoriesViewModel: ObservableObject {
       var counts: [MemoryTag: Int] = [:]
 
       // Get total count (no filters) and store for "All" badge
-      let includeExplicitLifecycleRows = canonicalLifecycleExposed
       let totalCount = try await MemoryStorage.shared.getLocalMemoriesCount(
         tiers: activeLayerFilter,
-        includeExplicitLifecycleRows: includeExplicitLifecycleRows
+        scope: canonicalLifecycleExposed ? .canonicalProduct : .legacyCompatibility
       )
       totalMemoriesCount = totalCount
 
@@ -582,7 +607,7 @@ class MemoriesViewModel: ObservableObject {
         counts[tag] = try await MemoryStorage.shared.getLocalMemoriesCount(
           category: tag.rawValue,
           tiers: activeLayerFilter,
-          includeExplicitLifecycleRows: includeExplicitLifecycleRows
+          scope: canonicalLifecycleExposed ? .canonicalProduct : .legacyCompatibility
         )
       }
 
@@ -620,7 +645,7 @@ class MemoriesViewModel: ObservableObject {
         matchAnyTag: nil,
         matchAnyCategory: matchAnyCategory.isEmpty ? nil : matchAnyCategory,
         tiers: layers(for: token),
-        includeExplicitLifecycleRows: includeExplicitLifecycleRows(for: token)
+        scope: recordReadScope(for: token)
       )
 
       guard isCurrentScope(token) else { return }
@@ -729,7 +754,7 @@ class MemoriesViewModel: ObservableObject {
         query: query,
         limit: 10000,
         tiers: layers(for: token),
-        includeExplicitLifecycleRows: includeExplicitLifecycleRows(for: token)
+        scope: recordReadScope(for: token)
       )
       guard isCurrentScope(token) else { return }
       searchResults = displayCacheMemories(results, for: token)
@@ -791,38 +816,46 @@ class MemoriesViewModel: ObservableObject {
     rawBackendOffset = 0
     let token = currentScopeToken
     let tokenTiers = layers(for: token)
+    let hasRememberedLifecycleExposure = restoreCanonicalLifecycleExposure()
 
     // Step 1: Load from local cache first for instant display
-    // Use timeout to avoid blocking UI if database is initializing (e.g. recovery)
-    do {
-      let cachedMemories = try await withThrowingTaskGroup(of: [ServerMemory].self) { group in
-        group.addTask {
-          try await MemoryStorage.shared.getLocalMemories(
-            limit: self.pageSize,
-            offset: 0,
-            tiers: tokenTiers,
-            includeExplicitLifecycleRows: self.includeExplicitLifecycleRows(for: token)
-          )
+    // A cache alone cannot establish an account's lifecycle capability. On a
+    // first launch, wait for the authoritative response rather than flash
+    // untiered legacy/local-pending records in a canonical user experience.
+    // Use timeout to avoid blocking UI if database is initializing (e.g. recovery).
+    if hasRememberedLifecycleExposure {
+      do {
+        let cachedMemories = try await withThrowingTaskGroup(of: [ServerMemory].self) { group in
+          group.addTask {
+            try await MemoryStorage.shared.getLocalMemories(
+              limit: self.pageSize,
+              offset: 0,
+              tiers: tokenTiers,
+              scope: self.recordReadScope(for: token)
+            )
+          }
+          group.addTask {
+            try await Task.sleep(nanoseconds: 3_000_000_000)  // 3 second timeout
+            throw CancellationError()
+          }
+          let result = try await group.next()!
+          group.cancelAll()
+          return result
         }
-        group.addTask {
-          try await Task.sleep(nanoseconds: 3_000_000_000)  // 3 second timeout
-          throw CancellationError()
-        }
-        let result = try await group.next()!
-        group.cancelAll()
-        return result
-      }
 
-      if !cachedMemories.isEmpty, isCurrentScope(token) {
-        memories = displayCacheMemories(cachedMemories, for: token)
-        currentOffset = cachedMemories.count
-        hasMoreMemories = cachedMemories.count >= pageSize
-        isLoading = false  // Show cached data immediately
-        log("MemoriesViewModel: Loaded \(cachedMemories.count) memories from local cache")
+        if !cachedMemories.isEmpty, isCurrentScope(token) {
+          memories = displayCacheMemories(cachedMemories, for: token)
+          currentOffset = cachedMemories.count
+          hasMoreMemories = cachedMemories.count >= pageSize
+          isLoading = false  // Show cached data immediately
+          log("MemoriesViewModel: Loaded \(cachedMemories.count) memories from local cache")
+        }
+      } catch {
+        log("MemoriesViewModel: Local cache unavailable, falling back to API")
+        // Continue to API fetch even if cache fails
       }
-    } catch {
-      log("MemoriesViewModel: Local cache unavailable, falling back to API")
-      // Continue to API fetch even if cache fails
+    } else {
+      log("MemoriesViewModel: Deferring unclassified cache until lifecycle capability is confirmed")
     }
 
     // Step 2: Fetch from API in background and sync to local cache
@@ -874,7 +907,7 @@ class MemoriesViewModel: ObservableObject {
             limit: pageSize,
             offset: 0,
             tiers: layers(for: token),
-            includeExplicitLifecycleRows: includeExplicitLifecycleRows(for: token)
+            scope: recordReadScope(for: token)
           )
         }
         guard isCurrentScope(token) else {
@@ -1076,7 +1109,7 @@ class MemoriesViewModel: ObservableObject {
         limit: pageSize,
         offset: requestedOffset,
         tiers: layers(for: token),
-        includeExplicitLifecycleRows: includeExplicitLifecycleRows(for: token)
+        scope: recordReadScope(for: token)
       )
 
       guard isCurrentScope(token), currentOffset == requestedOffset else { return }

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/Focus/FocusAssistant.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/Focus/FocusAssistant.swift
@@ -792,7 +792,7 @@ actor FocusAssistant: ProactiveAssistant {
         guard RuntimeOwnerIdentity.currentOwnerId() == ownerID else { return }
 
         // Sync to backend once and update both tables with backendId
-        if let backendId = await syncFocusSessionToBackend(
+        if let backendMemory = await syncFocusSessionToBackend(
             analysis: analysis,
             windowTitle: windowTitle,
             ownerID: ownerID)
@@ -803,7 +803,7 @@ actor FocusAssistant: ProactiveAssistant {
                 do {
                     try await ProactiveStorage.shared.updateFocusSessionSyncStatus(
                         id: recordId,
-                        backendId: backendId,
+                        backendId: backendMemory.id,
                         synced: true
                     )
                     guard RuntimeOwnerIdentity.currentOwnerId() == ownerID else { return }
@@ -815,7 +815,7 @@ actor FocusAssistant: ProactiveAssistant {
             // Update memories table
             if let memId = memoryId {
                 do {
-                    try await MemoryStorage.shared.markSynced(id: memId, backendId: backendId)
+                    try await MemoryStorage.shared.markSynced(id: memId, serverMemory: backendMemory)
                     guard RuntimeOwnerIdentity.currentOwnerId() == ownerID else { return }
                 } catch {
                     logError("Focus: Failed to update memories sync status", error: error)
@@ -884,7 +884,7 @@ actor FocusAssistant: ProactiveAssistant {
         analysis: ScreenAnalysis,
         windowTitle: String? = nil,
         ownerID: String
-    ) async -> String? {
+    ) async -> ServerMemory? {
         guard RuntimeOwnerIdentity.currentOwnerId() == ownerID else { return nil }
         do {
             // Build content for the memory
@@ -913,7 +913,7 @@ actor FocusAssistant: ProactiveAssistant {
             guard RuntimeOwnerIdentity.currentOwnerId() == ownerID else { return nil }
 
             log("Focus: Synced as memory to backend (id: \(response.id))")
-            return response.id
+            return response
         } catch {
             logError("Focus: Failed to sync to backend", error: error)
             return nil

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/Insight/InsightAssistant.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/Insight/InsightAssistant.swift
@@ -252,7 +252,7 @@ actor InsightAssistant: ProactiveAssistant {
         guard RuntimeOwnerIdentity.currentOwnerId() == ownerID else { return }
 
         // Sync to backend and update local record with backendId
-        if let backendId = await syncInsightToBackend(
+        if let backendMemory = await syncInsightToBackend(
             insight: extractedInsight,
             insightResult: adviceResult,
             windowTitle: windowTitle,
@@ -261,7 +261,7 @@ actor InsightAssistant: ProactiveAssistant {
             guard RuntimeOwnerIdentity.currentOwnerId() == ownerID else { return }
             if let recordId = extractionRecord?.id {
                 do {
-                    try await MemoryStorage.shared.markSynced(id: recordId, backendId: backendId)
+                    try await MemoryStorage.shared.markSynced(id: recordId, serverMemory: backendMemory)
                     guard RuntimeOwnerIdentity.currentOwnerId() == ownerID else { return }
                 } catch {
                     logError("Insight: Failed to update sync status", error: error)
@@ -363,7 +363,7 @@ actor InsightAssistant: ProactiveAssistant {
         insightResult: InsightExtractionResult,
         windowTitle: String? = nil,
         ownerID: String
-    ) async -> String? {
+    ) async -> ServerMemory? {
         guard RuntimeOwnerIdentity.currentOwnerId() == ownerID else { return nil }
         do {
             // Build tags: ["tips", "<category>"]
@@ -388,7 +388,7 @@ actor InsightAssistant: ProactiveAssistant {
             guard RuntimeOwnerIdentity.currentOwnerId() == ownerID else { return nil }
 
             log("Insight: Synced to backend (id: \(response.id))")
-            return response.id
+            return response
         } catch {
             logError("Insight: Failed to sync to backend", error: error)
             return nil

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/MemoryExtraction/MemoryAssistant.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/MemoryExtraction/MemoryAssistant.swift
@@ -198,7 +198,7 @@ actor MemoryAssistant: ProactiveAssistant {
         guard RuntimeOwnerIdentity.currentOwnerId() == ownerID else { return }
 
         // Sync to backend with full extraction data
-        if let backendId = await syncMemoryToBackend(
+        if let backendMemory = await syncMemoryToBackend(
             memory: memory,
             contextSummary: memoryResult.contextSummary,
             windowTitle: windowTitle,
@@ -208,7 +208,7 @@ actor MemoryAssistant: ProactiveAssistant {
             // Update SQLite record with backend ID
             if let recordId = extractionRecord?.id {
                 do {
-                    try await MemoryStorage.shared.markSynced(id: recordId, backendId: backendId)
+                    try await MemoryStorage.shared.markSynced(id: recordId, serverMemory: backendMemory)
                     guard RuntimeOwnerIdentity.currentOwnerId() == ownerID else { return }
                 } catch {
                     logError("Memory: Failed to update sync status", error: error)
@@ -287,7 +287,7 @@ actor MemoryAssistant: ProactiveAssistant {
         contextSummary: String? = nil,
         windowTitle: String? = nil,
         ownerID: String
-    ) async -> String? {
+    ) async -> ServerMemory? {
         guard RuntimeOwnerIdentity.currentOwnerId() == ownerID else { return nil }
         do {
             // Convert ExtractedMemory category to MemoryCategory
@@ -306,7 +306,7 @@ actor MemoryAssistant: ProactiveAssistant {
             guard RuntimeOwnerIdentity.currentOwnerId() == ownerID else { return nil }
 
             log("Memory: Synced to backend (id: \(response.id))")
-            return response.id
+            return response
         } catch {
             logError("Memory: Failed to sync to backend", error: error)
             return nil

--- a/desktop/macos/Desktop/Sources/Rewind/Core/MemoryStorage.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/MemoryStorage.swift
@@ -1,6 +1,19 @@
 import Foundation
 import GRDB
 
+/// Selects which provenance class may participate in a local-memory read.
+///
+/// This is intentionally separate from ``MemoryLayer``: legacy compatibility
+/// rows and unsynced local captures are not product-memory tiers.
+enum MemoryRecordReadScope: Sendable {
+    /// Preserve the caller's historical mixed-cache behavior.
+    case all
+    /// Only rows whose lifecycle came from the authoritative canonical API.
+    case canonicalProduct
+    /// Rows that do not expose a canonical lifecycle, for legacy compatibility.
+    case legacyCompatibility
+}
+
 /// Actor-based storage manager for memories with bidirectional sync
 /// Provides local-first caching for fast startup and background sync with backend
 actor MemoryStorage {
@@ -48,11 +61,32 @@ actor MemoryStorage {
         return query.filter(tiers.map { $0.rawValue }.contains(Column("tier")))
     }
 
-    private static func applyLifecycleExposureFilter(
+    private static func applyRecordReadScope(
         _ query: QueryInterfaceRequest<MemoryRecord>,
-        includeExplicitLifecycleRows: Bool
+        scope: MemoryRecordReadScope
     ) -> QueryInterfaceRequest<MemoryRecord> {
-        includeExplicitLifecycleRows ? query : query.filter(Column("tierIsExplicit") == false)
+        switch scope {
+        case .all:
+            return query
+        case .canonicalProduct:
+            return query.filter(Column("tierIsExplicit") == true)
+        case .legacyCompatibility:
+            return query.filter(Column("tierIsExplicit") == false)
+        }
+    }
+
+    private static func appendRecordReadScopeCondition(
+        _ conditions: inout [String],
+        scope: MemoryRecordReadScope
+    ) {
+        switch scope {
+        case .all:
+            return
+        case .canonicalProduct:
+            conditions.append("tierIsExplicit = 1")
+        case .legacyCompatibility:
+            conditions.append("tierIsExplicit = 0")
+        }
     }
 
     private static func appendTierCondition(_ conditions: inout [String], _ arguments: inout [DatabaseValue], tiers: [MemoryLayer]?) {
@@ -76,7 +110,7 @@ actor MemoryStorage {
         category: String? = nil,
         tags: [String]? = nil,
         tiers: [MemoryLayer]? = [.shortTerm, .longTerm],
-        includeExplicitLifecycleRows: Bool = true,
+        scope: MemoryRecordReadScope = .all,
         includeDismissed: Bool = false
     ) async throws -> [ServerMemory] {
         let db = try await ensureInitialized()
@@ -95,9 +129,9 @@ actor MemoryStorage {
             }
 
             query = Self.applyTierFilter(query, tiers: tiers)
-            query = Self.applyLifecycleExposureFilter(
+            query = Self.applyRecordReadScope(
                 query,
-                includeExplicitLifecycleRows: includeExplicitLifecycleRows
+                scope: scope
             )
 
             // Tag filtering using JSON
@@ -122,7 +156,7 @@ actor MemoryStorage {
         category: String? = nil,
         tags: [String]? = nil,
         tiers: [MemoryLayer]? = [.shortTerm, .longTerm],
-        includeExplicitLifecycleRows: Bool = true,
+        scope: MemoryRecordReadScope = .all,
         includeDismissed: Bool = false
     ) async throws -> Int {
         let db = try await ensureInitialized()
@@ -141,9 +175,9 @@ actor MemoryStorage {
             }
 
             query = Self.applyTierFilter(query, tiers: tiers)
-            query = Self.applyLifecycleExposureFilter(
+            query = Self.applyRecordReadScope(
                 query,
-                includeExplicitLifecycleRows: includeExplicitLifecycleRows
+                scope: scope
             )
 
             if let tags = tags, !tags.isEmpty {
@@ -165,7 +199,7 @@ actor MemoryStorage {
         matchAnyCategory: [String]? = nil, // OR logic: matches any of these categories
         excludeTags: [String]? = nil,      // Exclude memories containing these tags
         tiers: [MemoryLayer]? = [.shortTerm, .longTerm],
-        includeExplicitLifecycleRows: Bool = true,
+        scope: MemoryRecordReadScope = .all,
         includeDismissed: Bool = false
     ) async throws -> [ServerMemory] {
         let db = try await ensureInitialized()
@@ -180,9 +214,7 @@ actor MemoryStorage {
             }
 
             Self.appendTierCondition(&conditions, &arguments, tiers: tiers)
-            if !includeExplicitLifecycleRows {
-                conditions.append("tierIsExplicit = 0")
-            }
+            Self.appendRecordReadScopeCondition(&conditions, scope: scope)
 
             // Tag OR conditions
             if let tags = matchAnyTag, !tags.isEmpty {
@@ -243,7 +275,7 @@ actor MemoryStorage {
         category: String? = nil,
         tags: [String]? = nil,
         tiers: [MemoryLayer]? = [.shortTerm, .longTerm],
-        includeExplicitLifecycleRows: Bool = true,
+        scope: MemoryRecordReadScope = .all,
         includeDismissed: Bool = false
     ) async throws -> [ServerMemory] {
         let db = try await ensureInitialized()
@@ -266,9 +298,9 @@ actor MemoryStorage {
             }
 
             query = Self.applyTierFilter(query, tiers: tiers)
-            query = Self.applyLifecycleExposureFilter(
+            query = Self.applyRecordReadScope(
                 query,
-                includeExplicitLifecycleRows: includeExplicitLifecycleRows
+                scope: scope
             )
 
             if let tags = tags, !tags.isEmpty {
@@ -527,6 +559,36 @@ actor MemoryStorage {
         }
 
         log("MemoryStorage: Marked memory \(id) as synced (backendId: \(backendId))")
+    }
+
+    /// Reconcile a known local capture with the authoritative create receipt.
+    ///
+    /// A local record has no product-tier authority before the server responds.
+    /// Updating it from the receipt prevents a canonical Short-term item from
+    /// being rendered as the local model's legacy Long-term default.
+    func markSynced(id: Int64, serverMemory: ServerMemory) async throws {
+        let db = try await ensureInitialized()
+
+        try await db.write { database in
+            guard var record = try MemoryRecord.fetchOne(database, key: id) else {
+                throw MemoryStorageError.recordNotFound
+            }
+
+            if let existing = try MemoryRecord
+                .filter(Column("backendId") == serverMemory.id)
+                .fetchOne(database),
+                existing.id != record.id {
+                try record.delete(database)
+                return
+            }
+
+            record.backendId = serverMemory.id
+            record.backendSynced = true
+            record.updateFrom(serverMemory)
+            try record.update(database)
+        }
+
+        log("MemoryStorage: Reconciled memory \(id) from authoritative create receipt (backendId: \(serverMemory.id))")
     }
 
     /// Get memories that haven't been synced to backend yet

--- a/desktop/macos/Desktop/Tests/MemoryAuthoritativeTierSyncTests.swift
+++ b/desktop/macos/Desktop/Tests/MemoryAuthoritativeTierSyncTests.swift
@@ -99,7 +99,32 @@ final class MemoryAuthoritativeTierSyncTests: XCTestCase {
         XCTAssertEqual(record?.tierIsExplicit, false)
     }
 
-    func testLocalReadsCanExcludeCanonicalLifecycleRowsWhenServerDoesNotExposeLifecycle() async throws {
+    func testAuthoritativeCreateReceiptReplacesLocalUntieredDefault() async throws {
+        let local = MemoryRecord(
+            backendSynced: false,
+            content: "Local-first memory"
+        )
+        let inserted = try await MemoryStorage.shared.insertLocalMemory(local)
+        guard let recordId = inserted.id else {
+            XCTFail("Expected inserted local memory id")
+            return
+        }
+
+        let receipt = makeMemory(
+            id: "canonical-create-\(UUID().uuidString)",
+            tier: .shortTerm,
+            tierIsExplicit: true,
+            updatedAt: Date(timeIntervalSince1970: 2_000)
+        )
+        try await MemoryStorage.shared.markSynced(id: recordId, serverMemory: receipt)
+
+        let record = try await MemoryStorage.shared.getMemoryByBackendId(receipt.id)
+        XCTAssertEqual(record?.tier, MemoryLayer.shortTerm.rawValue)
+        XCTAssertEqual(record?.tierIsExplicit, true)
+        XCTAssertEqual(record?.backendSynced, true)
+    }
+
+    func testLocalReadsKeepCanonicalAndLegacyScopesDisjoint() async throws {
         let legacy = makeMemory(
             id: "legacy-visible",
             tier: .longTerm,
@@ -120,34 +145,63 @@ final class MemoryAuthoritativeTierSyncTests: XCTestCase {
         )
         try await MemoryStorage.shared.syncServerMemories([legacy, shortTerm, longTerm])
 
-        let local = try await MemoryStorage.shared.getLocalMemories(
+        let legacyLocal = try await MemoryStorage.shared.getLocalMemories(
             limit: 10,
             tiers: nil,
-            includeExplicitLifecycleRows: false
+            scope: .legacyCompatibility
         )
-        XCTAssertEqual(local.map(\.id), ["legacy-visible"])
+        XCTAssertEqual(legacyLocal.map(\.id), ["legacy-visible"])
 
-        let count = try await MemoryStorage.shared.getLocalMemoriesCount(
+        let legacyCount = try await MemoryStorage.shared.getLocalMemoriesCount(
             tiers: nil,
-            includeExplicitLifecycleRows: false
+            scope: .legacyCompatibility
         )
-        XCTAssertEqual(count, 1)
+        XCTAssertEqual(legacyCount, 1)
 
-        let filtered = try await MemoryStorage.shared.getFilteredMemories(
+        let legacyFiltered = try await MemoryStorage.shared.getFilteredMemories(
             limit: 10,
             matchAnyCategory: ["system"],
             tiers: nil,
-            includeExplicitLifecycleRows: false
+            scope: .legacyCompatibility
         )
-        XCTAssertEqual(filtered.map(\.id), ["legacy-visible"])
+        XCTAssertEqual(legacyFiltered.map(\.id), ["legacy-visible"])
 
-        let search = try await MemoryStorage.shared.searchLocalMemories(
+        let legacySearch = try await MemoryStorage.shared.searchLocalMemories(
             query: "Memory",
             limit: 10,
             tiers: nil,
-            includeExplicitLifecycleRows: false
+            scope: .legacyCompatibility
         )
-        XCTAssertEqual(search.map(\.id), ["legacy-visible"])
+        XCTAssertEqual(legacySearch.map(\.id), ["legacy-visible"])
+
+        let canonical = try await MemoryStorage.shared.getLocalMemories(
+            limit: 10,
+            tiers: nil,
+            scope: .canonicalProduct
+        )
+        XCTAssertEqual(Set(canonical.map(\.id)), ["canonical-short-hidden", "canonical-long-hidden"])
+
+        let canonicalCount = try await MemoryStorage.shared.getLocalMemoriesCount(
+            tiers: nil,
+            scope: .canonicalProduct
+        )
+        XCTAssertEqual(canonicalCount, 2)
+
+        let canonicalFiltered = try await MemoryStorage.shared.getFilteredMemories(
+            limit: 10,
+            matchAnyCategory: ["system"],
+            tiers: nil,
+            scope: .canonicalProduct
+        )
+        XCTAssertEqual(Set(canonicalFiltered.map(\.id)), ["canonical-short-hidden", "canonical-long-hidden"])
+
+        let canonicalSearch = try await MemoryStorage.shared.searchLocalMemories(
+            query: "Memory",
+            limit: 10,
+            tiers: nil,
+            scope: .canonicalProduct
+        )
+        XCTAssertEqual(Set(canonicalSearch.map(\.id)), ["canonical-short-hidden", "canonical-long-hidden"])
     }
 
     private func corruptLocalTier(

--- a/desktop/macos/Desktop/Tests/MemoryLayerFilterTests.swift
+++ b/desktop/macos/Desktop/Tests/MemoryLayerFilterTests.swift
@@ -103,11 +103,11 @@ final class MemoryLayerFilterTests: XCTestCase {
         XCTAssertFalse(hidden.tierIsExplicit)
     }
 
-    func testNonCanonicalDisplayExcludesLifecycleExplicitRows() throws {
+    func testLifecycleDisplayScopesAreMutuallyExclusive() throws {
         let source = try memoriesPageSource()
 
-        XCTAssertTrue(source.contains("includeExplicitLifecycleRows(for: token)"))
-        XCTAssertTrue(source.contains("lifecycleExposed ? values : values.filter { !$0.tierIsExplicit }"))
+        XCTAssertTrue(source.contains("recordReadScope(for: token)"))
+        XCTAssertTrue(source.contains("values.filter { $0.tierIsExplicit == lifecycleExposed }"))
         XCTAssertFalse(source.contains("lifecycleExposed ? values : values.map { $0.hidingLifecycleExposure() }"))
     }
 
@@ -152,6 +152,15 @@ final class MemoryLayerFilterTests: XCTestCase {
         XCTAssertTrue(source.contains("memories.append(contentsOf: visibleMemories)"))
         XCTAssertTrue(source.contains("memories = displayCacheMemories(cachedMemories, for: token)"))
         XCTAssertTrue(source.contains("memories = displayCacheMemories(mergedMemories, for: token)"))
+    }
+
+    func testMemoriesPageDoesNotRenderUnclassifiedCacheBeforeLifecycleCapability() throws {
+        let source = try memoriesPageSource()
+
+        XCTAssertTrue(source.contains("memoriesCanonicalLifecycleExposure_v1_"))
+        XCTAssertTrue(source.contains("let hasRememberedLifecycleExposure = restoreCanonicalLifecycleExposure()"))
+        XCTAssertTrue(source.contains("if hasRememberedLifecycleExposure {"))
+        XCTAssertTrue(source.contains("Deferring unclassified cache until lifecycle capability is confirmed"))
     }
 
     func testLayerFilterControlsRenderOnlyAfterCanonicalLifecycleExposure() throws {

--- a/desktop/macos/changelog/unreleased/20260714-canonical-memory-lifecycle-cache.json
+++ b/desktop/macos/changelog/unreleased/20260714-canonical-memory-lifecycle-cache.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed canonical memory views so only server-confirmed Short-term and Long-term memories receive lifecycle badges and filters"
+}

--- a/docs/memory/domain_model.md
+++ b/docs/memory/domain_model.md
@@ -72,6 +72,10 @@ flowchart TD
 
 - **Memories** is one store; **layer** (`short_term` / `long_term` / `archive`) is a field on each
   record. Layer drives lifecycle, TTL, promotion, and UI badges — not which collection you query.
+- A client cache record without an authoritative canonical lifecycle is **not** an implicit
+  Long-term memory. Canonical product surfaces may read only explicitly layered records;
+  untiered legacy and local-pending records remain a compatibility/provenance concern until
+  an authoritative read or create receipt supplies their lifecycle.
 - **Conversations** are never Memories. No merge of Conversations tab into Memories.
 - **Promotion** is an explicit Short-term → Long-term transition (corroboration, consolidation,
   or user assertion) within Memories — audited, not a silent flag flip.


### PR DESCRIPTION
## Summary

- Make canonical lifecycle authority explicit in the desktop cache and UI, and reconcile local captures from the server's authoritative receipt.
- Fail canonical-selected mutations closed rather than silently writing legacy records when canonical routing is unavailable.
- Preserve retryable canonical extraction: persisted finalizers own deferred extraction before fan-out, direct canonical callers surface retryable errors, and X raw sources replay unacknowledged extraction after transient failures.

## Root cause and durable guard

The desktop cache treated a missing lifecycle as an implied long-term tier, while temporarily unavailable canonical writers could fall back to legacy. Background extraction could also discard a failed canonical write after its source had been marked seen. Explicit read scopes and authoritative receipts, closed mutation routing, synchronous canonical extraction for direct callers, finalizer-owned retries, and post-success source acknowledgement close that failure class.

## Scope and migration

This does not migrate or delete user data. Legacy source rows remain intact. The revision-ledger migration stays separate and must be dry-run capable, incremental, and safe to operate in bulk.

## Product invariants affected

- INV-AUTH-1
- INV-MEM-1

## Verification

- `cd desktop/macos && OMI_SWIFT_TEST_SUITE_WORKERS=4 xcrun swift test --package-path Desktop` (2,526 passed)
- `cd backend && BACKEND_UNIT_TEST_FILE_LIST=/tmp/omi-backend-unit-failures.txt bash test.sh` (the affected backend files and the timing-gated runtime-contract file passed)
- Launched the named `omi-canonical-memory-contract` bundle against dev; the Memory view displayed explicit lifecycle-tagged rows.
- Independent final Grok review passed after the direct-caller and retry-boundary fixes.
- `scripts/pr-preflight --pr-body-file /tmp/canonical-memory-pr.md`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9785?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
